### PR TITLE
API improvements

### DIFF
--- a/typescript/packages/common-frp/README.md
+++ b/typescript/packages/common-frp/README.md
@@ -12,7 +12,6 @@ Common functional reactive programming utilities.
     - [x] All graph dependencies held in array (in contrast to S.js style or Signals style where graph is defined via VM execution trace)
 - [x] Glitch free: updates happen during discrete moments using a transaction system
 - [x] Transformations should happen during same transaction
-- [ ] Transactions
-    - [ ] (see experimental for WIP)
-- [ ] Cycles
-    - [ ] TODO: switch from microtask-based topological sorting to transaction-based push-pull (see experimental for WIP)
+- [x] Transactions
+- [ ] Cycles supported for Signals
+    - [ ] TODO need to improve [push-pull dirty marking logic](https://github.com/tc39/proposal-signals?tab=readme-ov-file#common-algorithms).

--- a/typescript/packages/common-frp/src/dom.ts
+++ b/typescript/packages/common-frp/src/dom.ts
@@ -1,9 +1,9 @@
-import { stream } from './stream.js'
+import { generate } from './stream.js'
 
 export const events = (
   element: HTMLElement,
   name: string
-) => stream((send: (value: Event) => void) => {
+) => generate((send: (value: Event) => void) => {
   element.addEventListener(name, send)
   return () => element.removeEventListener(name, send)
 })

--- a/typescript/packages/common-frp/src/operators.ts
+++ b/typescript/packages/common-frp/src/operators.ts
@@ -11,6 +11,11 @@ import {
 export type UnaryFn<A, B> = (a: A) => B
 
 export type Pipe = {
+  <A, B>(
+    value: A,
+    a2b: UnaryFn<A, B>
+  ): B
+
   <A, B, C>(
     value: A,
     a2b: UnaryFn<A, B>,

--- a/typescript/packages/common-frp/src/signal.ts
+++ b/typescript/packages/common-frp/src/signal.ts
@@ -92,7 +92,7 @@ export const effect = <T>(
   return signal[__updates__](() => withReads(job))
 }
 
-export const signal = <T>(initial: T) => {
+export const state = <T>(initial: T) => {
   const updates = publisher<void>()
 
   let state = initial


### PR DESCRIPTION
- Add 2-argument variant to pipe
- Add stream.subject
- Rename stream.stream to stream.generate
- Rename signal.signal to signal.state (similar to TC39 signals)