### PR TITLE
Clean up common frp

### DIFF
--- a/typescript/packages/common-frp/src/operators.ts
+++ b/typescript/packages/common-frp/src/operators.ts
@@ -2,7 +2,8 @@ import {
   map as mapStream,
   select as selectStream,
   filter as filterStream,
-  zip as zipStreams,
+  join as joinStreams,
+  chooseLeft,
   scan as scanStream,
   hold as holdStream,
   Stream
@@ -115,15 +116,15 @@ export const filter = <T>(
  * Zip two streams together.
  * Will buffer left and right values until both are available.
  */
-export const zip = <T, U, V>(
-  right: Stream<U>
+export const join = <T>(
+  right: Stream<T>,
+  choose: (left: T, right: T) => T,
 ) => (
   left: Stream<T>,
-  combine: (left: T, right: U) => V,
-) => zipStreams(
+) => joinStreams(
   left,
   right,
-  combine
+  choose
 )
 
 /** Scan a stream, accumulating step state in a signal */

--- a/typescript/packages/common-frp/src/publisher.ts
+++ b/typescript/packages/common-frp/src/publisher.ts
@@ -8,6 +8,11 @@ export type Cancellable = {
 
 export type Send<T> = (value: T) => void
 
+/** A sendable is a type that can receive values via a send method */
+export type Sendable<T> = {
+  send: Send<T>
+}
+
 /** Low-level pub-sub channel used under the hood. */
 export const publisher = <T>() => {
   const subscribers = new Set<Send<T>>()
@@ -32,7 +37,12 @@ export const publisher = <T>() => {
     }
   }
 
-  return { pub, sub }
+  return {
+    // Allow iterating over subscribers
+    [Symbol.iterator]: () => subscribers.values(),
+    pub,
+    sub
+  }
 }
 
 /** Combine multiple unsubscribe functions into a single unsubscribe function */

--- a/typescript/packages/common-frp/src/signal.ts
+++ b/typescript/packages/common-frp/src/signal.ts
@@ -2,6 +2,7 @@ import { debug } from './shared.js'
 import {
   publisher,
   Send,
+  Sendable,
   Cancel,
   Cancellable,
   combineCancels
@@ -67,10 +68,6 @@ export type Updates<T> = {
   [__updates__]: (subscriber: Send<T>) => Cancel
 }
 
-export type Subject<T> = {
-  send: (value: T) => void
-}
-
 const isEqual = Object.is
 
 export type Gettable<T> = {
@@ -80,7 +77,7 @@ export type Gettable<T> = {
 const sample = <T>(container: Gettable<T>) => container.get()
 
 export type Signal<T> = Gettable<T> & Updates<void> & Cancellable
-export type SignalSubject<T> = Gettable<T> & Updates<void> & Subject<T>
+export type WriteableSignal<T> = Gettable<T> & Updates<void> & Sendable<T>
 
 export type Effect = {
   <A>(

--- a/typescript/packages/common-frp/src/stream.ts
+++ b/typescript/packages/common-frp/src/stream.ts
@@ -84,37 +84,67 @@ export const filter = <T>(
   })
 })
 
-/**
- * Zip two streams together.
- * Will buffer left and right values until both are available.
- */
-export const zip = <T, U, V>(
-  left: Stream<T>,
-  right: Stream<U>,
-  combine: (left: T, right: U) => V
-) => generate<V>(send => {
-  const leftQueue: Array<T> = []
-  const rightQueue: Array<U> = []
+const throttled = (job: () => void) => {
+  let isScheduled = false
 
-  const forward = () => {
-    if (leftQueue.length > 0 && rightQueue.length > 0) {
-      const leftValue = leftQueue.shift()!
-      const rightValue = rightQueue.shift()!
-      const value = combine(leftValue, rightValue)
-      debug('zip', 'dispatching value', value)
-      send(value)
-    }
+  const perform = () => {
+    isScheduled = false
+    job()
   }
 
+  return () => {
+    if (!isScheduled) {
+      isScheduled = true
+      queueMicrotask(perform)
+    }
+  }
+}
+
+export const chooseLeft = <T>(left: T, _: T) => left
+
+/**
+ * Join two streams together.
+ * Uses throttling/batching on microtask to ensure upstreams that emitted
+ * during same tick are processed together during the same moment. E.g.
+ * prevents the diamond problem.
+ */
+export const join = <T>(
+  left: Stream<T>,
+  right: Stream<T>,
+  choose: (left: T, right: T) => T = chooseLeft
+) => generate<T>(send => {
+  let leftState: T | undefined = undefined
+  let rightState: T | undefined = undefined
+
+  // NOTE: we are currently using the microtask queue to batch and solve the
+  // diamond problem. This works as long as events in the stream are values.
+  // 
+  // If we want to support promises as values but maintain this kind of
+  // moment-by-moment batching, we will need to create a transaction system
+  // with a logical clock that waits for all promises to resolve before moving
+  // on to the next transaction.
+  const forward = throttled(() => {
+    if (leftState !== undefined && rightState !== undefined) {
+      const value = choose(leftState, rightState)
+      send(value)
+    } else if (leftState !== undefined) {
+      send(leftState)
+    } else if (rightState !== undefined) {
+      send(rightState)
+    }
+    leftState = undefined
+    rightState = undefined
+  })
+
   const cancelLeft = sink(left, value => {
-    debug('zip', 'queue value', value)
-    leftQueue.push(value)
+    debug('zip', 'queue left value', value)
+    leftState = value
     forward()
   })
 
   const cancelRight = sink(right, value => {
-    debug('zip', 'queue value', value)
-    rightQueue.push(value)
+    debug('zip', 'queue right value', value)
+    rightState = value
     forward()
   })
 

--- a/typescript/packages/common-frp/src/stream.ts
+++ b/typescript/packages/common-frp/src/stream.ts
@@ -1,13 +1,23 @@
 import { debug } from "./shared.js"
-import { publisher, Send, Cancel, combineCancels } from "./publisher.js"
+import {
+  publisher,
+  Send,
+  Sendable,
+  Cancel,
+  Cancellable,
+  combineCancels
+} from "./publisher.js"
 import { state, Signal, __updates__ } from "./signal.js"
 
 const __sink__ = Symbol('sink')
 
-export type Stream<T> = {
+/** A sink is an observable that delivers new values */
+export type Sink<T> = {
   [__sink__]: (subscriber: Send<T>) => Cancel
-  cancel?: Cancel
 }
+
+/** A stream is a sink that can be cancelled */
+export type Stream<T> = Sink<T> & Cancellable
 
 /**
  * Subscribe to a stream, receiving all updates after the point of subscription.
@@ -18,11 +28,13 @@ export const sink = <T>(
   subscriber: Send<T>
 ) => upstream[__sink__](subscriber)
 
+export type WriteableStream<T> = Sendable<T> & Sink<T>
+
 /**
  * Create a stream subject - a source for a stream that has a send method
  * for publishing new items to stream.
  */
-export const subject = <T>() => {
+export const subject = <T>(): WriteableStream<T> => {
   const { pub, sub } = publisher<T>()
   return { [__sink__]: sub, send: pub }
 }


### PR DESCRIPTION
- [x] Allow iteration of publisher subscribers
- [x] Introduce Sendable type
- [x] Clean up types and make consistent (WriteableSignal, WriteableStream)
- [x] Improve stream join logic