### PR TITLE
feat: Replace Usuba UI w/ Lookslike Prototype

### DIFF
--- a/rust/usuba/src/routes/ui.rs
+++ b/rust/usuba/src/routes/ui.rs
@@ -8,7 +8,7 @@ use rust_embed::Embed;
 use crate::{UsubaError, UsubaState};
 
 #[derive(Embed)]
-#[folder = "../../typescript/packages/usuba-ui/dist"]
+#[folder = "../../typescript/packages/lookslike-prototype/dist"]
 struct Asset;
 
 pub struct StaticFile<T>(pub T);
@@ -70,5 +70,5 @@ pub async fn upstream_index(state: State<UsubaState>, request: Request) -> impl 
 }
 
 pub async fn ui_index(state: State<UsubaState>, request: Request) -> impl IntoResponse {
-    ui_file("/$.html".parse::<Uri>().unwrap(), state, request).await
+    ui_file("/index.html".parse::<Uri>().unwrap(), state, request).await
 }

--- a/rust/usuba/src/serve.rs
+++ b/rust/usuba/src/serve.rs
@@ -50,8 +50,7 @@ pub async fn serve(listener: TcpListener, upstream: Option<Uri>) -> Result<(), U
         .route("/api/v0/module", post(build_module))
         .route("/api/v0/module/:id", get(retrieve_module))
         .route("/api/v0/recipe/eval", post(eval_recipe))
-        .route("/", get(upstream_index))
-        .route("/$", get(ui_index))
+        .route("/", get(ui_index))
         .route("/*file", get(ui_file))
         .with_state(UsubaState {
             storage,


### PR DESCRIPTION
This change drops the original, very basic UI that we built for Usuba and also takes out the reverse-proxying behavior. Instead, we serve the lookslike prototype directly. When building for release, the lookslike prototype UI is bundled into the `usuba` binary.