### PR TITLE
fix: Add missing WASI shim to lookslike prototype

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -298,8 +298,7 @@
     "node_modules/@bytecodealliance/preview2-shim": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.16.2.tgz",
-      "integrity": "sha512-36MwesmbLSf3Y5/OHcS85iBaF0N92CQ4gpjtDVKSbrjxmrBKCWlWVfoQ03F/cqDg8k5K7pzVaVBH0XBIbTCfTQ==",
-      "dev": true
+      "integrity": "sha512-36MwesmbLSf3Y5/OHcS85iBaF0N92CQ4gpjtDVKSbrjxmrBKCWlWVfoQ03F/cqDg8k5K7pzVaVBH0XBIbTCfTQ=="
     },
     "node_modules/@cfworker/json-schema": {
       "version": "1.12.8",
@@ -9329,6 +9328,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@babel/parser": "^7.24.6",
+        "@bytecodealliance/preview2-shim": "^0.16.2",
         "@codemirror/basic-setup": "^0.20.0",
         "@codemirror/lang-javascript": "^6.2.2",
         "@codemirror/lang-json": "^6.0.1",

--- a/typescript/packages/lookslike-prototype/package.json
+++ b/typescript/packages/lookslike-prototype/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@babel/parser": "^7.24.6",
+    "@bytecodealliance/preview2-shim": "^0.16.2",
     "@codemirror/basic-setup": "^0.20.0",
     "@codemirror/lang-javascript": "^6.2.2",
     "@codemirror/lang-json": "^6.0.1",

--- a/typescript/packages/lookslike-prototype/public/wasi-shim
+++ b/typescript/packages/lookslike-prototype/public/wasi-shim
@@ -1,0 +1,1 @@
+../../../node_modules/@bytecodealliance/preview2-shim/lib/browser

--- a/typescript/packages/lookslike-prototype/public/wasi.js
+++ b/typescript/packages/lookslike-prototype/public/wasi.js
@@ -1,0 +1,17 @@
+import * as cli from '/wasi-shim/cli.js';
+import * as clocks from '/wasi-shim/clocks.js';
+import * as filesystem from '/wasi-shim/filesystem.js';
+import * as http from '/wasi-shim/http.js';
+import * as io from '/wasi-shim/io.js';
+import * as random from '/wasi-shim/random.js';
+import * as sockets from '/wasi-shim/sockets.js';
+
+export const shim = {
+  '/wasi-shim/cli.js': Promise.resolve(cli),
+  '/wasi-shim/clocks.js': Promise.resolve(clocks),
+  '/wasi-shim/filesystem.js': Promise.resolve(filesystem),
+  '/wasi-shim/http.js': Promise.resolve(http),
+  '/wasi-shim/io.js': Promise.resolve(io),
+  '/wasi-shim/random.js': Promise.resolve(random),
+  '/wasi-shim/sockets.js': Promise.resolve(sockets),
+};


### PR DESCRIPTION
These paths were an implementation detail of `usuba-ui`, but are load bearing when it comes to polyfilling Wasm Components in the runtime. We should fix this, but in the mean time this is the short path to get the lookslike prototype going.