### PR TITLE
Implement dummy data utility

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -9351,7 +9351,8 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.24.0"
+        "@anthropic-ai/sdk": "^0.24.0",
+        "@cfworker/json-schema": "^1.12.8"
       },
       "devDependencies": {
         "tslib": "^2.6.2",

--- a/typescript/packages/llm-client/package.json
+++ b/typescript/packages/llm-client/package.json
@@ -28,7 +28,8 @@
     "./lib/index.js"
   ],
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.24.0"
+    "@anthropic-ai/sdk": "^0.24.0",
+    "@cfworker/json-schema": "^1.12.8"
   },
   "devDependencies": {
     "tslib": "^2.6.2",

--- a/typescript/packages/llm-client/src/dummy-data.ts
+++ b/typescript/packages/llm-client/src/dummy-data.ts
@@ -1,0 +1,28 @@
+import { Schema } from "@cfworker/json-schema";
+import { LLMClient } from "./index.js";
+
+export function grabJson(txt: string) {
+  return JSON.parse(txt.match(/```json\n([\s\S]+?)```/)?.[1] ?? "{}");
+}
+
+export async function generateData<T>(
+  client: LLMClient,
+  description: string,
+  inputData: any,
+  jsonSchema: Schema,
+) {
+  const request = `
+  You specialize in generating believable and useful data for testing applications during development. Take the provided input parameters and use them to hallucinate a plausible result that conforms to the following JSON schema:
+
+  <schema>${JSON.stringify(jsonSchema)}</schema>
+
+  <description>${description}</description>
+  <input>${JSON.stringify(inputData)}</input>
+
+  Respond with only the generated data in a JSON block.`;
+
+  const thread = await client.createThread(request);
+  const response = thread.conversation[thread.conversation.length - 1];
+
+  return grabJson(response) as T;
+}

--- a/typescript/packages/llm-client/src/index.ts
+++ b/typescript/packages/llm-client/src/index.ts
@@ -1,4 +1,5 @@
 import { Anthropic } from "@anthropic-ai/sdk";
+export * from './dummy-data.js'
 
 type Tool = Anthropic.Messages.Tool & {
   implementation: (input: any) => Promise<string> | string;


### PR DESCRIPTION
Introduces a small utility function to trivially generate data based off of a description, some input data and a schema it should adhere to. Should be useful for implementing a prototype of search (cc @seefeldb).

```ts
import { generateData, LLMClient } from "@commontools/llm-client";

const client = new LLMClient({
  serverUrl: LLM_SERVER_URL,
  tools: [],
  system: `Generate dummy data as JSON as per the provided spec. Use the input to imagine what an API response would look like for a request.`,
});

const test = await generateData(
  client,
  "generate 3 user profiles",
  { name: "John Doe" },
  {
    type: "array",
    items: {
      type: "object",
      properties: {
        name: { type: "string" },
        email: { type: "string" },
        age: { type: "number" },
        role: { type: "string" },
        birthday: { type: "string" },
        favoriteColor: { type: "string" },
      },
    },
  },
);

console.log(test);
```

This produces:

```json
[
    {
        "name": "John Doe",
        "email": "john.doe@example.com",
        "age": 35,
        "role": "Software Engineer",
        "birthday": "1988-03-15",
        "favoriteColor": "blue"
    },
    {
        "name": "Jane Smith",
        "email": "jane.smith@example.com",
        "age": 28,
        "role": "Product Manager",
        "birthday": "1995-07-22",
        "favoriteColor": "purple"
    },
    {
        "name": "Alex Johnson",
        "email": "alex.johnson@example.com",
        "age": 42,
        "role": "Marketing Director",
        "birthday": "1981-11-03",
        "favoriteColor": "green"
    }
]
```