### PR TITLE
Refactoring demo recipes to pull apart modules and graph declaration

### DIFF
--- a/typescript/packages/lookslike-high-level/src/recipes/home.ts
+++ b/typescript/packages/lookslike-high-level/src/recipes/home.ts
@@ -2,19 +2,19 @@ import { html } from "@commontools/common-html";
 import { recipe, lift, ID, UI } from "../builder/index.js";
 import { Gem, RecipeManifest } from "../data.js";
 
+const getIDsForSagasWithUI = lift((sagas: Gem[]) =>
+  sagas
+    .filter((saga) => saga[UI]) // Only show sagas with UI
+    .map((saga) => ({ id: saga[ID] }))
+);
+
 export const home = recipe<{
   sagas: Gem[];
   recipes: RecipeManifest[];
 }>("home screen", ({ sagas, recipes }) => {
-  const sagaIDs = lift((sagas: Gem[]) =>
-    sagas
-      .filter((saga) => saga[UI]) // Only show sagas with UI
-      .map((saga) => ({ id: saga[ID] }))
-  )(sagas);
-
   return {
     [UI]: html`<common-vstack
-      >${sagaIDs.map(
+      >${getIDsForSagasWithUI(sagas).map(
         (saga) => html`<div><common-saga-link saga=${saga.id}></sagaLink></div>`
       )}
       ${recipes.map(

--- a/typescript/packages/lookslike-high-level/src/recipes/luft-bnb-search.ts
+++ b/typescript/packages/lookslike-high-level/src/recipes/luft-bnb-search.ts
@@ -35,7 +35,7 @@ const justMonthAndDay = lift((isoDate: string) =>
 );
 
 const updateValue = asHandler<{ detail: { value: string } }, { value: string }>(
-  ({ detail }, state) => detail.value && (state.value = detail.value)
+  ({ detail }, state) => detail?.value && (state.value = detail.value)
 );
 
 const handleSearchClick = asHandler<

--- a/typescript/packages/lookslike-high-level/src/recipes/todo-list-as-task.ts
+++ b/typescript/packages/lookslike-high-level/src/recipes/todo-list-as-task.ts
@@ -3,38 +3,33 @@ import { recipe, lift, ID, UI } from "../builder/index.js";
 import { addSuggestion, description } from "../suggestions.js";
 import { type TodoItem } from "./todo-list.js";
 
-// TODO: detailUI as input is so we can overwrite it, but it should be an output
-// that is then replacing another signal in the caller.
+const getListSummary = lift((items: TodoItem[]) => {
+  const notDoneTitles = items.flatMap((item) =>
+    item.done ? [] : [item.title]
+  );
+
+  return (
+    items.length +
+    " items. " +
+    (notDoneTitles.length
+      ? "Open tasks: " + notDoneTitles.join(", ")
+      : "All done.")
+  );
+});
+
+const allDone = lift((items: TodoItem[]) => items.every((item) => item.done));
+
 export const todoListAsTask = recipe<{
   list: { [ID]: number; [UI]: any; items: TodoItem[] };
   task: TodoItem;
 }>("todo list as task", ({ list, task }) => {
-  const listSummary = lift((items: TodoItem[]) => {
-    const notDoneTitles = items.flatMap((item) =>
-      item.done ? [] : [item.title]
-    );
-
-    const summary =
-      items.length +
-      " items. " +
-      (notDoneTitles.length
-        ? "Open tasks: " +
-          notDoneTitles.splice(0, 3).join(", ") +
-          (notDoneTitles.length > 0 ? ", ..." : "")
-        : "All done.");
-
-    return summary;
-  })(list.items);
-
-  task.done = lift((items: TodoItem[]) => items.every((item) => item.done))(
-    list.items
-  );
+  task.done = allDone(list.items);
 
   return {
     [UI]: html` <details>
       <summary>
         <common-vstack gap="sm">
-          <span>${listSummary}</span>
+          <span>${getListSummary(list.items)}</span>
           <common-saga-link saga=${list[ID]} />
         </common-vstack>
       </summary>


### PR DESCRIPTION
I'm attempting a different way to organize the code in this PR, inspired by recent discussions.

The original style closely mimics functions-as-components as seen in many modern frameworks, but because we can't use closures yet (until we write a plugin that translates them), there's a bunch of odd boilerplate.

Here I'm instead declaring all the module-y bits, i.e. `lift` and `asHandler` outside of the recipe function and then use the recipe function just to build the graph, which in most cases boils down to just building the UI.
