### PR TITLE
Deprecated `apply` and (old) `handler`. Renamed `asHandler` to `handler`.

### DIFF
--- a/typescript/packages/lookslike-high-level/src/builder/README.md
+++ b/typescript/packages/lookslike-high-level/src/builder/README.md
@@ -134,4 +134,4 @@ cycle when a new event is queued.
 
 We currently only support simple event handler for one event.
 
-Right now, only `handler` and `asHandler` return these "streams".
+Right now, only `handler` returns these "streams".

--- a/typescript/packages/lookslike-high-level/src/builder/built-in.ts
+++ b/typescript/packages/lookslike-high-level/src/builder/built-in.ts
@@ -1,5 +1,5 @@
-import { createNodeFactory } from "./module.js";
-import { Value, NodeFactory } from "./types.js";
+import { lift, createNodeFactory } from "./module.js";
+import { Value, NodeFactory, CellProxy } from "./types.js";
 
 export function generateData<T>(
   params: Value<{
@@ -36,3 +36,26 @@ let generateDataFactory:
       { pending: boolean; result: any; partial: any; error: any }
     >
   | undefined = undefined;
+
+// Example:
+// str`Hello, ${name}!`
+//
+// TODO: This should be a built-in module
+export function str(
+  strings: TemplateStringsArray,
+  ...values: any[]
+): CellProxy<string> {
+  const interpolatedString = ({
+    strings,
+    values,
+  }: {
+    strings: TemplateStringsArray;
+    values: any[];
+  }) =>
+    strings.reduce(
+      (result, str, i) => result + str + (i < values.length ? values[i] : ""),
+      ""
+    );
+
+  return lift(interpolatedString)({ strings, values });
+}

--- a/typescript/packages/lookslike-high-level/src/builder/index.ts
+++ b/typescript/packages/lookslike-high-level/src/builder/index.ts
@@ -1,14 +1,7 @@
 export { cell } from "./cell-proxy.js";
-export {
-  lift,
-  createNodeFactory as builtin,
-  asHandler,
-  apply,
-  handler,
-  str,
-} from "./module.js";
+export { lift, createNodeFactory as builtin, handler } from "./module.js";
 export { recipe } from "./recipe.js";
-export { generateData, ifElse } from "./built-in.js";
+export { generateData, ifElse, str } from "./built-in.js";
 export {
   ID,
   TYPE,

--- a/typescript/packages/lookslike-high-level/src/builder/module.ts
+++ b/typescript/packages/lookslike-high-level/src/builder/module.ts
@@ -49,7 +49,7 @@ export function lift<T, R>(implementation: (input: T) => R): NodeFactory<T, R> {
   });
 }
 
-export function asHandler<E, T>(
+export function handler<E, T>(
   handler: (event: E, props: T) => any
 ): NodeFactory<T, E> {
   const module: Module & toJSON = {
@@ -73,57 +73,4 @@ export function asHandler<E, T>(
 
     return stream as unknown as CellProxy<E>;
   }, module);
-}
-
-export function apply<T extends (...args: any[]) => any>(
-  inputs: Value<Parameters<T>[0]>,
-  implementation: T
-): NodeFactory<Parameters<T>[0], ReturnType<T>>;
-export function apply<T, R>(
-  inputs: Value<T>,
-  implementation: (input: T) => R
-): Value<R>;
-export function apply<T, R>(
-  inputs: Value<T>,
-  implementation: (input: T) => R
-): Value<R> {
-  return lift(implementation)(inputs);
-}
-
-export function handler<T extends (...args: any[]) => any>(
-  props: Value<Parameters<T>[1]>,
-  implementation: T
-): NodeFactory<Parameters<T>[1], Parameters<T>[0]>;
-export function handler<E, T>(
-  props: Value<T>,
-  handler: (event: E, props: T) => any
-): Value<E>;
-export function handler<E, T>(
-  props: Value<T>,
-  handler: (event: E, props: T) => any
-): Value<E> {
-  return asHandler(handler)(props);
-}
-
-// Example:
-// str`Hello, ${name}!`
-//
-// TODO: This should be a built-in module
-export function str(
-  strings: TemplateStringsArray,
-  ...values: any[]
-): CellProxy<string> {
-  const interpolatedString = ({
-    strings,
-    values,
-  }: {
-    strings: TemplateStringsArray;
-    values: any[];
-  }) =>
-    strings.reduce(
-      (result, str, i) => result + str + (i < values.length ? values[i] : ""),
-      ""
-    );
-
-  return lift(interpolatedString)({ strings, values });
 }

--- a/typescript/packages/lookslike-high-level/src/recipes/annotation.ts
+++ b/typescript/packages/lookslike-high-level/src/recipes/annotation.ts
@@ -2,7 +2,7 @@ import { html, type View } from "@commontools/common-html";
 import {
   recipe,
   lift,
-  asHandler,
+  handler,
   cell,
   UI,
   ID,
@@ -114,8 +114,7 @@ const buildSuggestionsList = lift(({ suggestion }) => {
   return [];
 });
 
-// Extracted handler using asHandler
-const acceptSuggestion = asHandler<
+const acceptSuggestion = handler<
   {},
   {
     acceptedSuggestion: View | undefined;

--- a/typescript/packages/lookslike-high-level/src/recipes/local-search.ts
+++ b/typescript/packages/lookslike-high-level/src/recipes/local-search.ts
@@ -1,7 +1,7 @@
 import { html } from "@commontools/common-html";
 import {
   recipe,
-  asHandler,
+  handler,
   lift,
   str,
   cell,
@@ -23,14 +23,14 @@ export interface Place {
   rating: number;
 }
 
-const searchPlaces = asHandler<
+const searchPlaces = handler<
   {},
   { what: string; where: string; query: { prompt: string } }
 >((_, { what, where, query }) => {
   query.prompt = `generate 10 places that match they query: ${what} in ${where}`;
 });
 
-const updateValue = asHandler<{ detail: { value: string } }, { value: string }>(
+const updateValue = handler<{ detail: { value: string } }, { value: string }>(
   ({ detail }, state) => detail?.value && (state.value = detail.value)
 );
 

--- a/typescript/packages/lookslike-high-level/src/recipes/luft-bnb-search.ts
+++ b/typescript/packages/lookslike-high-level/src/recipes/luft-bnb-search.ts
@@ -2,7 +2,7 @@ import { html } from "@commontools/common-html";
 import {
   recipe,
   lift,
-  asHandler,
+  handler,
   str,
   generateData,
   UI,
@@ -34,11 +34,11 @@ const justMonthAndDay = lift((isoDate: string) =>
   isoDate.split("T")[0].slice(5)
 );
 
-const updateValue = asHandler<{ detail: { value: string } }, { value: string }>(
+const updateValue = handler<{ detail: { value: string } }, { value: string }>(
   ({ detail }, state) => detail?.value && (state.value = detail.value)
 );
 
-const handleSearchClick = asHandler<
+const handleSearchClick = handler<
   {},
   {
     startDate: string;
@@ -54,7 +54,7 @@ const handleSearchClick = asHandler<
   state.location = state.locationUI;
 });
 
-const makeBooking = asHandler<
+const makeBooking = handler<
   {},
   {
     place: LuftBnBPlace;

--- a/typescript/packages/lookslike-high-level/src/recipes/playlist.ts
+++ b/typescript/packages/lookslike-high-level/src/recipes/playlist.ts
@@ -1,8 +1,8 @@
 import { html } from "@commontools/common-html";
 import {
   recipe,
-  apply,
   str,
+  lift,
   generateData,
   ifElse,
   UI,
@@ -68,9 +68,9 @@ export const playlistForTrip = recipe<{
       </common-vstack>
     `,
     playlist,
-    [NAME]: apply({ playlist, ticket }, ({ playlist, ticket }) =>
+    [NAME]: lift(({ playlist, ticket }) =>
       playlist?.title ? playlist.title : `Creating playlist for ${ticket.show}`
-    ),
+    )({ playlist, ticket }),
   };
 });
 

--- a/typescript/packages/lookslike-high-level/src/recipes/todo-list.ts
+++ b/typescript/packages/lookslike-high-level/src/recipes/todo-list.ts
@@ -1,24 +1,23 @@
 import { html } from "@commontools/common-html";
-import { recipe, asHandler, UI, NAME } from "../builder/index.js";
+import { recipe, handler, UI, NAME } from "../builder/index.js";
 
 export interface TodoItem {
   title: string;
   done: boolean;
 }
 
-const addTask = asHandler<
-  { detail: { message: string } },
-  { items: TodoItem[] }
->((event, { items }) => {
-  const task = event.detail?.message?.trim();
-  if (task) items.push({ title: task, done: false });
-});
+const addTask = handler<{ detail: { message: string } }, { items: TodoItem[] }>(
+  (event, { items }) => {
+    const task = event.detail?.message?.trim();
+    if (task) items.push({ title: task, done: false });
+  }
+);
 
-const updateTitle = asHandler<{ detail: { value: string } }, { title: string }>(
+const updateTitle = handler<{ detail: { value: string } }, { title: string }>(
   ({ detail }, state) => (state.title = detail.value)
 );
 
-const updateItem = asHandler<
+const updateItem = handler<
   { detail: { done: boolean; value: string } },
   { item: TodoItem }
 >(({ detail }, { item }) => {

--- a/typescript/packages/lookslike-high-level/test/builder/module.test.ts
+++ b/typescript/packages/lookslike-high-level/test/builder/module.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { isCell, isModule, CellProxy } from "../../src/builder/types.js";
-import { lift, asHandler, apply, handler } from "../../src/builder/module.js";
+import { lift, handler } from "../../src/builder/module.js";
 import { cell } from "../../src/builder/cell-proxy.js";
 
 describe("lift function", () => {
@@ -17,9 +17,9 @@ describe("lift function", () => {
   });
 });
 
-describe("asHandler function", () => {
+describe("handler function", () => {
   it("creates a node factory for event handlers", () => {
-    const clickHandler = asHandler<MouseEvent, { x: number; y: number }>(
+    const clickHandler = handler<MouseEvent, { x: number; y: number }>(
       (event, props) => {
         props.x = event.clientX;
         props.y = event.clientY;
@@ -30,45 +30,13 @@ describe("asHandler function", () => {
   });
 
   it("creates a cell proxy with stream when called", () => {
-    const clickHandler = asHandler<MouseEvent, { x: number; y: number }>(
+    const clickHandler = handler<MouseEvent, { x: number; y: number }>(
       (event, props) => {
         props.x = event.clientX;
         props.y = event.clientY;
       }
     );
     const stream = clickHandler({ x: cell(10), y: cell(20) });
-    expect(isCell(stream)).toBe(true);
-    const { value, nodes } = (
-      stream as unknown as CellProxy<{ $stream: true }>
-    ).export();
-    expect(value).toEqual({ $stream: true });
-    expect(nodes.size).toBe(1);
-    expect([...nodes][0].module).toMatchObject({ wrapper: "handler" });
-    expect([...nodes][0].inputs).toMatchObject({ $event: stream });
-  });
-});
-
-describe("apply function", () => {
-  it("applies an implementation to inputs and returns a value", () => {
-    const result = apply({ a: cell(3), b: cell(4) }, ({ a, b }) => a + b);
-    expect(isCell(result)).toBe(true);
-    const { nodes } = (
-      result as unknown as CellProxy<{ $stream: true }>
-    ).export();
-    expect(nodes.size).toBe(1);
-    expect([...nodes][0].module).toMatchObject({ type: "javascript" });
-  });
-});
-
-describe("handler function", () => {
-  it("creates an event handler and returns a value", () => {
-    const stream = handler(
-      { x: cell(5), y: cell(10) },
-      (event: MouseEvent, props) => {
-        props.x = event.clientX;
-        props.y = event.clientY;
-      }
-    );
     expect(isCell(stream)).toBe(true);
     const { value, nodes } = (
       stream as unknown as CellProxy<{ $stream: true }>


### PR DESCRIPTION
They just called `lift` and `asHandler` under the hood and using lift(<implementation>)(<parameters>) instead is fine.