### PR TITLE
FIX: Closing one window no longer affects other open windows.

### DIFF
--- a/typescript/packages/lookslike-high-level/src/components/window-manager.ts
+++ b/typescript/packages/lookslike-high-level/src/components/window-manager.ts
@@ -1,7 +1,7 @@
 import { LitElement, html, css } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ref, createRef, Ref } from "lit/directives/ref.js";
-import { repeat } from "lit/directives/repeat.js"; // Import repeat directive
+import { repeat } from "lit/directives/repeat.js";
 import { style } from "@commontools/common-ui";
 import { render } from "@commontools/common-html";
 import { Gem, ID, UI, NAME } from "../data.js";


### PR DESCRIPTION
- Assign Unique `windowId`: Updated `sagas` to include a `windowId` for each window, ensuring each has a distinct identifier.
- Use Lit’s `repeat` Directive: Integrated the `repeat` directive with `windowId` as the key to manage window rendering accurately.
- Update `openSaga` Method: Modified `openSaga` to generate and assign a unique `windowId` when opening a new saga.
- Refine `onClose` Handler: Changed `onClose` to accept `windowId` as a parameter, ensuring the correct window is removed.
- Clean Up References: Deleted corresponding `sagaRefs` entries when a window is closed to prevent memory leaks.

---

Note: o1-mini wrote this patch/commit message - I revised/manually tested the patch