### PR TITLE
refactor launch and opensaga

### DIFF
--- a/typescript/packages/lookslike-high-level/src/components/window-manager.ts
+++ b/typescript/packages/lookslike-high-level/src/components/window-manager.ts
@@ -3,7 +3,7 @@ import { customElement, property } from "lit/decorators.js";
 import { ref, createRef, Ref } from "lit/directives/ref.js";
 import { style } from "@commontools/common-ui";
 import { render } from "@commontools/common-html";
-import { Gem, ID, UI, NAME } from "../data.js";
+import { Gem, ID, UI, NAME, addGems } from "../data.js";
 import { CellImpl, isCell, gemById } from "@commontools/common-runner";
 
 @customElement("common-window-manager")
@@ -116,6 +116,8 @@ export class CommonWindowManager extends LitElement {
   openSaga(sagaId: number) {
     const saga = gemById.get(sagaId) as CellImpl<Gem>;
     if (!isCell(saga)) throw new Error(`Saga ${sagaId} doesn't exist`);
+
+    addGems([saga]); // Make sure any shows gem is in the list of gems
 
     const existingWindow = this.renderRoot.querySelector(`#window-${sagaId}`);
     if (existingWindow) {

--- a/typescript/packages/lookslike-high-level/src/data.ts
+++ b/typescript/packages/lookslike-high-level/src/data.ts
@@ -39,8 +39,14 @@ export function isGem(value: any): value is Gem {
 
 export const dataGems = cell<CellImpl<Gem>[]>([]);
 
-export function addGems(gems: CellImpl<any>[]) {
-  dataGems.send([...dataGems.get(), ...gems]);
+export function addGems(newGems: CellImpl<any>[]) {
+  const currentGems = dataGems.get();
+  const currentIds = new Set(currentGems.map((gem) => gem.get()[ID]));
+  const gemsToAdd = newGems.filter((gem) => !currentIds.has(gem.get()[ID]));
+
+  if (gemsToAdd.length > 0) {
+    dataGems.send([...currentGems, ...gemsToAdd]);
+  }
 }
 
 addGems([
@@ -136,7 +142,6 @@ export function launch(recipe: Recipe, bindings: any) {
     );
   }
   const gem = run(recipe, bindings);
-  addGems([gem]);
   openSaga(gem.get()[ID]);
 }
 

--- a/typescript/packages/lookslike-high-level/src/recipes/home.ts
+++ b/typescript/packages/lookslike-high-level/src/recipes/home.ts
@@ -2,19 +2,25 @@ import { html } from "@commontools/common-html";
 import { recipe, lift, ID, UI } from "@commontools/common-builder";
 import { Gem, RecipeManifest } from "../data.js";
 
-const getIDsForSagasWithUI = lift((sagas: Gem[]) =>
-  sagas
-    .filter((saga) => saga[UI]) // Only show sagas with UI
-    .map((saga) => ({ id: saga[ID] }))
+const getIDsForSagasWithUI = lift<
+  { sagas: Gem[]; homeId: number },
+  { id: number }[]
+>(
+  ({ sagas, homeId }) =>
+    sagas
+      .filter((saga) => saga[UI]) // Only show sagas with UI
+      .map((saga) => ({ id: saga[ID] }))
+      .filter((saga) => saga.id != homeId) // Don't include the home screen
 );
 
 export const home = recipe<{
   sagas: Gem[];
   recipes: RecipeManifest[];
-}>("home screen", ({ sagas, recipes }) => {
+  [ID]: number;
+}>("home screen", ({ sagas, recipes, [ID]: homeId }) => {
   return {
     [UI]: html`<common-vstack
-      >${getIDsForSagasWithUI(sagas).map(
+      >${getIDsForSagasWithUI({ sagas, homeId }).map(
         (saga) => html`<div><common-saga-link saga=${saga.id}></sagaLink></div>`
       )}
       ${recipes.map(
@@ -23,7 +29,7 @@ export const home = recipe<{
             <common-recipe-link foo="bar" recipe=${recipe}></common-recipe-link>
           </div>`
       )}<common-annotation
-        query="dream fun things to explore, especially with tickets and reservations"
+        query="dream fun things to explore"
         target="-1"
         data=${{ sagas, recipes }}
       />


### PR DESCRIPTION
now it's easier to use `openSaga` to `launch` an already running recipe. A particular use-case is if the recipe was already run within another recipe, e.g. via `list.map((item) => myRecipe(item))`, which produces an array of `myRecipe` instantiations. You can now `openSaga` with `[ID]` of any of these items of that list.

- window manager now ensures any ever opened gem is in the list of all gems
- addGems doesn't add any dupes
- launch now just uses openSaga, relying on it to add the gem to the list