### PR TITLE
disable follow-on events for now

### DIFF
--- a/typescript/packages/common-runner/src/scheduler.ts
+++ b/typescript/packages/common-runner/src/scheduler.ts
@@ -77,10 +77,15 @@ export function queueEvent(eventRef: CellReference, event: any) {
       ref.path.every((p, i) => p === eventRef.path[i])
     ) {
       queueExecution();
+      eventQueue.push(() => handler(event));
+      /*
+       * TODO: Re-enable ability for handlers to return follow-up events
+       * once it is less likely to accidentally create cycles.
       eventQueue.push(() => {
         const nextEvent = handler(event);
         if (nextEvent) queueEvent(ref, nextEvent);
       });
+      */
     }
   }
 }


### PR DESCRIPTION
Right now `handler((e, state) => state.value = e.value)` accidentally creates an infinite loop as the handler returning a value is treated as issuing another event. Disabling this for now until we find a better way to do this.