### PR TITLE
counters now work again with unnested values

### DIFF
--- a/typescript/packages/lookslike-high-level/src/recipes/counter.ts
+++ b/typescript/packages/lookslike-high-level/src/recipes/counter.ts
@@ -1,8 +1,8 @@
 import { html } from "@commontools/common-html";
 import { recipe, NAME, UI, handler } from "@commontools/common-builder";
 
-const inc = handler<{}, { count: { value: number } }>(({}, state) => {
-  state.count.value += 1;
+const inc = handler<{}, { count: number }>(({}, state) => {
+  state.count += 1;
 });
 
 const updateValue = handler<{ detail: { value: string } }, { value: string }>(
@@ -11,10 +11,10 @@ const updateValue = handler<{ detail: { value: string } }, { value: string }>(
   }
 );
 
-export const counter = recipe<{ title: string; count: { value: number } }>(
+export const counter = recipe<{ title: string; count: number }>(
   "counter",
   ({ title, count }) => {
-    count.setDefault({ value: 0 });
+    count.setDefault(0);
     title.setDefault("untitled counter");
 
     return {

--- a/typescript/packages/lookslike-high-level/src/recipes/counters.ts
+++ b/typescript/packages/lookslike-high-level/src/recipes/counters.ts
@@ -1,57 +1,51 @@
 import { html } from "@commontools/common-html";
 import { recipe, NAME, UI, handler, lift } from "@commontools/common-builder";
 
-const inc = handler<{}, { count: { value: number } }>(({}, state) => {
-  state.count.value += 1;
+const inc = handler<{}, { count: number }>(({}, state) => {
+  state.count += 1;
 });
 
 const updateRandomItem = handler<
   {},
-  { items: { title: string; count: { value: number } }[] }
+  { items: { title: string; count: number }[] }
 >(({}, state) => {
-  state.items[Math.floor(Math.random() * state.items.length)].count.value += 1;
+  state.items[Math.floor(Math.random() * state.items.length)].count += 1;
 });
 
-const addItem = handler<
-  {},
-  { items: { title: string; count: { value: number } }[] }
->(({}, state) => {
-  state.items.push({
-    title: `item ${state.items.length + 1}`,
-    count: { value: 0 },
-  });
-});
-
-const sum = lift(({ items }) =>
-  items.reduce(
-    (acc: number, item: { count: { value: number } }) => acc + item.count.value,
-    0
-  )
+const addItem = handler<{}, { items: { title: string; count: number }[] }>(
+  ({}, state) => {
+    state.items.push({ title: `item ${state.items.length + 1}`, count: 0 });
+  }
 );
 
-export const counters = recipe<{
-  items: { title: string; count: { value: number } }[];
-}>("counters", ({ items }) => {
-  items.setDefault([]);
-  //items.setDefault([{ title: "item 1", count: 0 }, { title: "item 2", count: 0 }]);
+const sum = lift(({ items }) =>
+  items.reduce((acc: number, item: { count: number }) => acc + item.count, 0)
+);
 
-  const total = sum({ items });
+export const counters = recipe<{ items: { title: string; count: number }[] }>(
+  "counters",
+  ({ items }) => {
+    items.setDefault([]);
+    //items.setDefault([{ title: "item 1", count: 0 }, { title: "item 2", count: 0 }]);
 
-  return {
-    [NAME]: "counters",
-    [UI]: html`<div>
-      <ul>
-        ${items.map(
-          ({ title, count }) =>
-            html`<li>
-              ${title} - ${count.value}
-              <button onclick=${inc({ count })}>Inc</button>
-            </li>`
-        )}
-      </ul>
-      <p>Total: ${total}</p>
-      <button onclick=${updateRandomItem({ items })}>Inc random item</button>
-      <button onclick=${addItem({ items })}>Add new item</button>
-    </div>`,
-  };
-});
+    const total = sum({ items });
+
+    return {
+      [NAME]: "counters",
+      [UI]: html`<div>
+        <ul>
+          ${items.map(
+            ({ title, count }) =>
+              html`<li>
+                ${title} - ${count}
+                <button onclick=${inc({ count })}>Inc</button>
+              </li>`
+          )}
+        </ul>
+        <p>Total: ${total}</p>
+        <button onclick=${updateRandomItem({ items })}>Inc random item</button>
+        <button onclick=${addItem({ items })}>Add new item</button>
+      </div>`,
+    };
+  }
+);


### PR DESCRIPTION
The fix was moving to aliases instead of cell references when launching a charm with cell, fixed in #191