### PR TITLE
Simplifying interface to build builtin / trusted / raw modules

### DIFF
--- a/typescript/packages/common-builder/src/built-in.ts
+++ b/typescript/packages/common-builder/src/built-in.ts
@@ -16,7 +16,7 @@ export function llm(
   error: any;
 }> {
   llmFactory ||= createNodeFactory({
-    type: "builtin",
+    type: "ref",
     implementation: "llm",
   });
   return llmFactory(params);
@@ -31,7 +31,7 @@ export function fetchData<T>(
   }>
 ): Value<{ pending: boolean; result: T; error: any }> {
   fetchDataFactory ||= createNodeFactory({
-    type: "builtin",
+    type: "ref",
     implementation: "fetchData",
   });
   return fetchDataFactory(params);
@@ -45,7 +45,7 @@ export function streamData<T>(
   }>
 ): Value<{ pending: boolean; result: T; error: any }> {
   streamDataFactory ||= createNodeFactory({
-    type: "builtin",
+    type: "ref",
     implementation: "streamData",
   });
   return streamDataFactory(params);
@@ -64,7 +64,7 @@ export function ifElse<T, U, V>(
   ifFalse: Value<V>
 ): CellProxy<T extends true ? U : V> {
   ifElseFactory ||= createNodeFactory({
-    type: "builtin",
+    type: "ref",
     implementation: "ifElse",
   });
   return ifElseFactory([condition, ifTrue, ifFalse]);

--- a/typescript/packages/common-builder/src/cell-proxy.ts
+++ b/typescript/packages/common-builder/src/cell-proxy.ts
@@ -61,7 +61,7 @@ export function cell<T>(value?: Value<T> | T): CellProxy<T> {
         // Create the factory if it doesn't exist. Doing it here to avoid
         // circular dependency.
         mapFactory ||= createNodeFactory({
-          type: "builtin",
+          type: "ref",
           implementation: "map",
         });
         return mapFactory({

--- a/typescript/packages/common-builder/src/index.ts
+++ b/typescript/packages/common-builder/src/index.ts
@@ -1,11 +1,5 @@
 export { cell } from "./cell-proxy.js";
-export {
-  lift,
-  createNodeFactory as builtin,
-  byRef,
-  handler,
-  isolated,
-} from "./module.js";
+export { createNodeFactory, lift, byRef, handler, isolated } from "./module.js";
 export {
   recipe,
   recipeFromFrame,

--- a/typescript/packages/common-builder/src/types.ts
+++ b/typescript/packages/common-builder/src/types.ts
@@ -102,13 +102,7 @@ export function isStreamAlias(value: any): value is StreamAlias {
 }
 
 export type Module = {
-  type:
-    | "ref"
-    | "javascript"
-    | "recipe"
-    | "builtin"
-    | "isolated"
-    | "passthrough";
+  type: "ref" | "javascript" | "recipe" | "raw" | "isolated" | "passthrough";
   implementation?: Function | Recipe | JavaScriptModuleDefinition | string;
   wrapper?: "handler";
 };

--- a/typescript/packages/common-builder/test/recipe.test.ts
+++ b/typescript/packages/common-builder/test/recipe.test.ts
@@ -115,7 +115,7 @@ describe("recipe with map node", () => {
   it("correctly serializes to a single map node", () => {
     expect(doubleArray.nodes.length).toBe(1);
     const module = doubleArray.nodes[0].module as Module;
-    expect(module.type).toBe("builtin");
+    expect(module.type).toBe("ref");
     expect(module.implementation).toBe("map");
   });
 

--- a/typescript/packages/common-runner/src/builtins/fetch-data.ts
+++ b/typescript/packages/common-runner/src/builtins/fetch-data.ts
@@ -1,9 +1,6 @@
-import { type Node } from "@commontools/common-builder";
 import { cell, CellImpl, ReactivityLog } from "../cell.js";
-import { sendValueToBinding, findAllAliasedCells } from "../utils.js";
-import { schedule, Action } from "../scheduler.js";
-import { mapBindingsToCell, normalizeToCells } from "../utils.js";
-
+import { normalizeToCells } from "../utils.js";
+import { type Action } from "../scheduler.js";
 /**
  * Fetch data from a URL.
  *
@@ -15,17 +12,14 @@ import { mapBindingsToCell, normalizeToCells } from "../utils.js";
  * @returns { pending: boolean, result: any, error: any } - As individual cells, representing `pending` state, final `result`, and any `error`.
  */
 export function fetchData(
-  recipeCell: CellImpl<any>,
-  { inputs, outputs }: Node,
-) {
-  const inputBindings = mapBindingsToCell(inputs, recipeCell) as {
+  inputsCell: CellImpl<{
     url: string;
     mode?: "text" | "json";
     options?: { body?: any; method?: string; headers?: Record<string, string> };
     result?: any;
-  };
-  const inputsCell = cell(inputBindings);
-
+  }>,
+  sendResult: (result: any) => void
+): Action {
   const pending = cell(false);
   const result = cell<any | undefined>(undefined);
   const error = cell<any | undefined>(undefined);
@@ -36,12 +30,11 @@ export function fetchData(
     error,
   });
 
-  const outputBindings = mapBindingsToCell(outputs, recipeCell) as any[];
-  sendValueToBinding(recipeCell, outputBindings, resultCell);
+  sendResult(resultCell);
 
   let currentRun = 0;
 
-  const startFetch: Action = (log: ReactivityLog) => {
+  return (log: ReactivityLog) => {
     const { url, mode, options } = inputsCell.getAsProxy([], log);
     const processResponse =
       (mode || "json") === "json"
@@ -79,9 +72,4 @@ export function fetchData(
         error.setAtPath([], err, log);
       });
   };
-
-  schedule(startFetch, {
-    reads: findAllAliasedCells(inputBindings, recipeCell),
-    writes: findAllAliasedCells(outputBindings, recipeCell),
-  });
 }

--- a/typescript/packages/common-runner/src/builtins/if-else.ts
+++ b/typescript/packages/common-runner/src/builtins/if-else.ts
@@ -1,27 +1,19 @@
-import { type Node } from "@commontools/common-builder";
 import {
   cell,
   getCellReferenceOrThrow,
   type CellImpl,
   type ReactivityLog,
 } from "../cell.js";
-import { sendValueToBinding, findAllAliasedCells } from "../utils.js";
-import { schedule, type Action } from "../scheduler.js";
-import { mapBindingsToCell } from "../utils.js";
+import { type Action } from "../scheduler.js";
 
-export function ifElse(recipeCell: CellImpl<any>, { inputs, outputs }: Node) {
-  const inputBindings = mapBindingsToCell(inputs, recipeCell) as [
-    any,
-    any,
-    any
-  ];
-  const inputsCell = cell(inputBindings);
-
-  const outputBindings = mapBindingsToCell(outputs, recipeCell) as any;
-
+export function ifElse(
+  inputsCell: CellImpl<[any, any, any]>,
+  sendResult: (result: any) => void
+): Action {
   const result = cell<any>(undefined);
+  sendResult(result);
 
-  const checkCondition: Action = (log: ReactivityLog) => {
+  return (log: ReactivityLog) => {
     const condition = inputsCell.getAsProxy([0], log);
 
     const ref = getCellReferenceOrThrow(
@@ -29,11 +21,4 @@ export function ifElse(recipeCell: CellImpl<any>, { inputs, outputs }: Node) {
     );
     result.send(ref.cell.getAsProxy(ref.path), log);
   };
-
-  sendValueToBinding(recipeCell, outputBindings, result);
-
-  schedule(checkCondition, {
-    reads: findAllAliasedCells(inputBindings[0], recipeCell),
-    writes: findAllAliasedCells(outputBindings, recipeCell),
-  });
 }

--- a/typescript/packages/common-runner/src/builtins/index.ts
+++ b/typescript/packages/common-runner/src/builtins/index.ts
@@ -1,19 +1,12 @@
-import { type CellImpl } from "../cell.js";
-import { type Action } from "../scheduler.js";
+import { addModuleByRef, raw } from "../module.js";
 import { map } from "./map.js";
 import { fetchData } from "./fetch-data.js";
 import { streamData } from "./stream-data.js";
 import { llm } from "./llm.js";
 import { ifElse } from "./if-else.js";
-export const builtins: {
-  [key: string]: (
-    inputsCell: CellImpl<any>,
-    sendResult: (result: any) => void
-  ) => Action;
-} = {
-  map,
-  fetchData,
-  streamData,
-  llm,
-  ifElse,
-};
+
+addModuleByRef("map", raw(map));
+addModuleByRef("fetchData", raw(fetchData));
+addModuleByRef("streamData", raw(streamData));
+addModuleByRef("llm", raw(llm));
+addModuleByRef("ifElse", raw(ifElse));

--- a/typescript/packages/common-runner/src/builtins/index.ts
+++ b/typescript/packages/common-runner/src/builtins/index.ts
@@ -1,12 +1,15 @@
-import { type Node } from "@commontools/common-builder";
 import { type CellImpl } from "../cell.js";
+import { type Action } from "../scheduler.js";
 import { map } from "./map.js";
 import { fetchData } from "./fetch-data.js";
 import { streamData } from "./stream-data.js";
 import { llm } from "./llm.js";
 import { ifElse } from "./if-else.js";
 export const builtins: {
-  [key: string]: (recipeCell: CellImpl<any>, node: Node) => void;
+  [key: string]: (
+    inputsCell: CellImpl<any>,
+    sendResult: (result: any) => void
+  ) => Action;
 } = {
   map,
   fetchData,

--- a/typescript/packages/common-runner/src/index.ts
+++ b/typescript/packages/common-runner/src/index.ts
@@ -1,4 +1,5 @@
-export { run, addModuleByRef, charmById } from "./runner.js";
+export { run, charmById } from "./runner.js";
+export { addModuleByRef, raw } from "./module.js";
 export {
   run as addAction,
   unschedule as removeAction,

--- a/typescript/packages/common-runner/src/module.ts
+++ b/typescript/packages/common-runner/src/module.ts
@@ -1,0 +1,35 @@
+import {
+  type Module,
+  type ModuleFactory,
+  createNodeFactory,
+} from "@commontools/common-builder";
+import { type Action } from "./scheduler.js";
+import { type CellImpl } from "./cell.js";
+
+const moduleMap = new Map<string, Module>();
+
+export function addModuleByRef(ref: string, module: Module) {
+  moduleMap.set(ref, module);
+}
+
+export function getModuleByRef(ref: string): Module {
+  if (typeof ref !== "string") throw new Error(`Unknown module ref: ${ref}`);
+  const module = moduleMap.get(ref);
+  if (!module) throw new Error(`Unknown module ref: ${ref}`);
+  return module;
+}
+
+// This corresponds to the node factory factories in common-builder:module.ts.
+// But it's here, because the signature depends on implementation details of the
+// runner, and won't work with any other runners.
+export function raw<T, R>(
+  implementation: (
+    inputsCell: CellImpl<T>,
+    sendResult: (result: R) => void
+  ) => Action
+): ModuleFactory<T, R> {
+  return createNodeFactory({
+    type: "raw",
+    implementation,
+  });
+}

--- a/typescript/packages/common-runner/src/runner.ts
+++ b/typescript/packages/common-runner/src/runner.ts
@@ -316,10 +316,18 @@ function instantiateBuiltinNode(
 
   // Built-ins can define their own scheduling logic, so they'll
   // implement parts of the above themselves.
-  builtins[module.implementation](recipeCell, {
-    module,
-    inputs: inputBindings,
-    outputs: outputBindings,
+
+  const mappedInputBindings = mapBindingsToCell(inputBindings, recipeCell);
+  const mappedOutputBindings = mapBindingsToCell(outputBindings, recipeCell);
+
+  const action = builtins[module.implementation](
+    cell(mappedInputBindings),
+    (result) => sendValueToBinding(recipeCell, mappedOutputBindings, result)
+  );
+
+  schedule(action, {
+    reads: findAllAliasedCells(mappedInputBindings, recipeCell),
+    writes: findAllAliasedCells(mappedOutputBindings, recipeCell),
   });
 }
 

--- a/typescript/packages/common-runner/src/runner.ts
+++ b/typescript/packages/common-runner/src/runner.ts
@@ -33,7 +33,8 @@ import {
   sendValueToBinding,
   staticDataToNestedCells,
 } from "./utils.js";
-import { builtins } from "./builtins/index.js";
+import { getModuleByRef } from "./module.js";
+import "./builtins/index.js";
 import init, {
   CommonRuntime,
   JavaScriptModuleDefinition,
@@ -119,12 +120,6 @@ export function run<T, R = any>(recipe: Recipe, bindings: T): CellImpl<R> {
   return recipeCell;
 }
 
-const moduleMap = new Map<string, Module>();
-
-export function addModuleByRef(ref: string, module: Module) {
-  moduleMap.set(ref, module);
-}
-
 function instantiateNode(
   module: Module | Alias,
   inputBindings: JSON,
@@ -134,12 +129,8 @@ function instantiateNode(
   if (isModule(module)) {
     switch (module.type) {
       case "ref":
-        if (typeof module.implementation !== "string")
-          throw new Error(`Unknown module ref: ${module.implementation}`);
-        if (!moduleMap.has(module.implementation))
-          throw new Error(`Unknown module ref: ${module.implementation}`);
         instantiateNode(
-          moduleMap.get(module.implementation)!,
+          getModuleByRef(module.implementation as string),
           inputBindings,
           outputBindings,
           recipeCell
@@ -153,13 +144,8 @@ function instantiateNode(
           recipeCell
         );
         break;
-      case "builtin":
-        instantiateBuiltinNode(
-          module,
-          inputBindings,
-          outputBindings,
-          recipeCell
-        );
+      case "raw":
+        instantiateRawNode(module, inputBindings, outputBindings, recipeCell);
         break;
       case "passthrough":
         instantiatePassthroughNode(
@@ -303,16 +289,16 @@ function instantiateJavaScriptNode(
   }
 }
 
-function instantiateBuiltinNode(
+function instantiateRawNode(
   module: Module,
   inputBindings: JSON,
   outputBindings: JSON,
   recipeCell: CellImpl<any>
 ) {
-  if (typeof module.implementation !== "string")
-    throw new Error(`Builtin is not a string`);
-  if (!(module.implementation in builtins))
-    throw new Error(`Unknown builtin: ${module.implementation}`);
+  if (typeof module.implementation !== "function")
+    throw new Error(
+      `Raw module is not a function, got: ${module.implementation}`
+    );
 
   // Built-ins can define their own scheduling logic, so they'll
   // implement parts of the above themselves.
@@ -320,9 +306,10 @@ function instantiateBuiltinNode(
   const mappedInputBindings = mapBindingsToCell(inputBindings, recipeCell);
   const mappedOutputBindings = mapBindingsToCell(outputBindings, recipeCell);
 
-  const action = builtins[module.implementation](
+  const action = module.implementation(
     cell(mappedInputBindings),
-    (result) => sendValueToBinding(recipeCell, mappedOutputBindings, result)
+    (result: any) =>
+      sendValueToBinding(recipeCell, mappedOutputBindings, result)
   );
 
   schedule(action, {

--- a/typescript/packages/common-runner/test/recipes.test.ts
+++ b/typescript/packages/common-runner/test/recipes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { recipe, lift, handler, byRef } from "@commontools/common-builder";
-import { addModuleByRef, run } from "../src/runner.js";
+import { run } from "../src/runner.js";
+import { addModuleByRef } from "../src/module.js";
 import { cell } from "../src/cell.js";
 import { idle } from "../src/scheduler.js";
 


### PR DESCRIPTION
Used primarily for modules that don't follow the regular flow, e.g. because they are async, need raw access to cells, etc.