### PR TITLE
Refactor: Split inputs and outputs in recipes

### DIFF
--- a/typescript/packages/common-builder/src/index.ts
+++ b/typescript/packages/common-builder/src/index.ts
@@ -36,10 +36,13 @@ export {
   isRecipe,
   isAlias,
   isStreamAlias,
+  isStatic,
+  markAsStatic,
   type toJSON,
   type JSONValue,
   type JSON,
   type Frame,
+  Static,
 } from "./types.js";
 
 // This should be a separate package, but for now it's easier to keep it here.

--- a/typescript/packages/common-builder/src/recipe.ts
+++ b/typescript/packages/common-builder/src/recipe.ts
@@ -123,7 +123,7 @@ function factoryFromRecipe<T, R>(
   )!;
 
   // Set initial values for all cells, add non-inputs defaults
-  const internal: any = {};
+  const initial: any = {};
   cells.forEach((cell) => {
     // Only process roots of extra cells:
     if (cell === inputs) return;
@@ -131,19 +131,19 @@ function factoryFromRecipe<T, R>(
     if (path.length > 0) return;
 
     const cellPath = paths.get(cell)!;
-    if (value) setValueAtPath(internal, cellPath, value);
+    if (value) setValueAtPath(initial, cellPath, value);
     if (defaultValue) setValueAtPath(defaults, cellPath, defaultValue);
   });
 
   // External cells all have to be added to the initial state
   cells.forEach((cell) => {
     const { external } = cell.export();
-    if (external) setValueAtPath(internal, paths.get(cell)!, external);
+    if (external) setValueAtPath(initial, paths.get(cell)!, external);
   });
 
   // TODO: initial is likely not needed anymore
   // TODO: But we need a new one for the result
-  const schema = createJsonSchema(defaults, internal) as {
+  const schema = createJsonSchema(defaults, initial) as {
     properties: { [key: string]: any };
     description: string;
   };
@@ -171,7 +171,7 @@ function factoryFromRecipe<T, R>(
 
   const recipe: Recipe & toJSON = {
     schema,
-    internal,
+    initial,
     result,
     nodes: serializedNodes,
     toJSON: () => recipeToJSON(recipe),

--- a/typescript/packages/common-builder/src/types.ts
+++ b/typescript/packages/common-builder/src/types.ts
@@ -122,7 +122,7 @@ export type Node = {
 
 export type Recipe = {
   schema: JSON;
-  internal?: JSON;
+  initial?: JSON;
   result: JSON;
   nodes: Node[];
 };

--- a/typescript/packages/common-builder/src/types.ts
+++ b/typescript/packages/common-builder/src/types.ts
@@ -122,7 +122,8 @@ export type Node = {
 
 export type Recipe = {
   schema: JSON;
-  initial: JSON;
+  internal?: JSON;
+  result: JSON;
   nodes: Node[];
 };
 

--- a/typescript/packages/common-builder/src/types.ts
+++ b/typescript/packages/common-builder/src/types.ts
@@ -156,3 +156,21 @@ export const toCellProxy = Symbol("toCellProxy");
 export type Frame = {
   parent?: Frame;
 };
+
+const isStaticMarker = Symbol("isStatic");
+
+export type Static = {
+  [isStaticMarker]: true;
+};
+
+export function isStatic(value: any): value is Static {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    value[isStaticMarker] === true
+  );
+}
+
+export function markAsStatic(value: any): void {
+  value[isStaticMarker] = true;
+}

--- a/typescript/packages/common-builder/src/utils.ts
+++ b/typescript/packages/common-builder/src/utils.ts
@@ -11,6 +11,7 @@ import {
   isAlias,
   canBeCellProxy,
   makeCellProxy,
+  isStatic,
 } from "./types.js";
 
 /** traverse a value, _not_ entering cells */
@@ -94,6 +95,7 @@ export function toJSONWithAliases(
   ignoreSelfAliases: boolean = false,
   path: PropertyKey[] = []
 ): JSONValue | undefined {
+  if (isStatic(value)) return value;
   if (canBeCellProxy(value)) value = makeCellProxy(value);
   if (isCellProxy(value)) {
     const pathToCell = paths.get(value);

--- a/typescript/packages/common-builder/src/utils.ts
+++ b/typescript/packages/common-builder/src/utils.ts
@@ -209,7 +209,7 @@ export function moduleToJSON(module: Module) {
 export function recipeToJSON(recipe: Recipe) {
   return {
     schema: recipe.schema,
-    ...(recipe.internal ? { internal: recipe.internal } : {}),
+    ...(recipe.initial ? { initial: recipe.initial } : {}),
     result: recipe.result,
     nodes: recipe.nodes,
   };

--- a/typescript/packages/common-builder/src/utils.ts
+++ b/typescript/packages/common-builder/src/utils.ts
@@ -207,7 +207,8 @@ export function moduleToJSON(module: Module) {
 export function recipeToJSON(recipe: Recipe) {
   return {
     schema: recipe.schema,
-    initial: recipe.initial,
+    ...(recipe.internal ? { internal: recipe.internal } : {}),
+    result: recipe.result,
     nodes: recipe.nodes,
   };
 }

--- a/typescript/packages/common-builder/test/recipe.test.ts
+++ b/typescript/packages/common-builder/test/recipe.test.ts
@@ -27,7 +27,7 @@ describe("complex recipe function", () => {
     const double = lift<number>((x) => x * 2);
     return { double: double(double(x)) };
   });
-  const { schema, initial, nodes } = doubleRecipe;
+  const { schema, internal, result, nodes } = doubleRecipe;
 
   it("has the correct schema and initial data", () => {
     expect(isRecipe(doubleRecipe)).toBe(true);
@@ -35,11 +35,12 @@ describe("complex recipe function", () => {
       description: "Double a number",
       type: "object",
       properties: {
-        double: {},
         x: { type: "integer", default: 1 },
       },
     });
-    expect(initial).toEqual({ double: { $alias: { path: ["__#1"] } } });
+    expect(result).toEqual({
+      double: { $alias: { path: ["internal", "__#1"] } },
+    });
   });
 
   it("has the correct nodes", () => {
@@ -47,10 +48,14 @@ describe("complex recipe function", () => {
     expect(isModule(nodes[0].module) && nodes[0].module.type).toBe(
       "javascript"
     );
-    expect(nodes[0].inputs).toEqual({ $alias: { path: ["x"] } });
-    expect(nodes[0].outputs).toEqual({ $alias: { path: ["__#0"] } });
-    expect(nodes[1].inputs).toEqual({ $alias: { path: ["__#0"] } });
-    expect(nodes[1].outputs).toEqual({ $alias: { path: ["__#1"] } });
+    expect(nodes[0].inputs).toEqual({ $alias: { path: ["parameters", "x"] } });
+    expect(nodes[0].outputs).toEqual({
+      $alias: { path: ["internal", "__#0"] },
+    });
+    expect(nodes[1].inputs).toEqual({ $alias: { path: ["internal", "__#0"] } });
+    expect(nodes[1].outputs).toEqual({
+      $alias: { path: ["internal", "__#1"] },
+    });
   });
 });
 
@@ -62,7 +67,7 @@ describe("complex recipe with path aliases", () => {
     const result2 = double({ x: result.doubled });
     return { double: result2.doubled };
   });
-  const { schema, initial, nodes } = doubleRecipe;
+  const { schema, internal, result, nodes } = doubleRecipe;
 
   it("has the correct schema and initial values", () => {
     expect(isRecipe(doubleRecipe)).toBe(true);
@@ -70,12 +75,11 @@ describe("complex recipe with path aliases", () => {
       description: "Double a number",
       type: "object",
       properties: {
-        double: {},
         x: { type: "integer", default: 1 },
       },
     });
-    expect(initial).toEqual({
-      double: { $alias: { path: ["__#1", "doubled"] } },
+    expect(result).toEqual({
+      double: { $alias: { path: ["internal", "__#1", "doubled"] } },
     });
   });
 
@@ -84,12 +88,18 @@ describe("complex recipe with path aliases", () => {
     expect(isModule(nodes[0].module) && nodes[0].module.type).toBe(
       "javascript"
     );
-    expect(nodes[0].inputs).toEqual({ x: { $alias: { path: ["x"] } } });
-    expect(nodes[0].outputs).toEqual({ $alias: { path: ["__#0"] } });
-    expect(nodes[1].inputs).toEqual({
-      x: { $alias: { path: ["__#0", "doubled"] } },
+    expect(nodes[0].inputs).toEqual({
+      x: { $alias: { path: ["parameters", "x"] } },
     });
-    expect(nodes[1].outputs).toEqual({ $alias: { path: ["__#1"] } });
+    expect(nodes[0].outputs).toEqual({
+      $alias: { path: ["internal", "__#0"] },
+    });
+    expect(nodes[1].inputs).toEqual({
+      x: { $alias: { path: ["internal", "__#0", "doubled"] } },
+    });
+    expect(nodes[1].outputs).toEqual({
+      $alias: { path: ["internal", "__#1"] },
+    });
   });
 
   it("correctly serializes to JSON", () => {
@@ -122,7 +132,7 @@ describe("recipe with map node", () => {
   it("correctly lists the input array as input to the map node", () => {
     const node = doubleArray.nodes[0];
     expect(node.inputs).toMatchObject({
-      list: { $alias: { path: ["values"] } },
+      list: { $alias: { path: ["parameters", "values"] } },
     });
   });
 

--- a/typescript/packages/common-html/package.json
+++ b/typescript/packages/common-html/package.json
@@ -42,7 +42,8 @@
   "wireit": {
     "build": {
       "dependencies": [
-        "../common-propagator:build"
+        "../common-propagator:build",
+        "../common-builder:build"
       ],
       "files": [
         "./src/**/*"

--- a/typescript/packages/common-html/src/view.ts
+++ b/typescript/packages/common-html/src/view.ts
@@ -1,6 +1,7 @@
 import { Parser } from "htmlparser2";
 import * as logger from "./logger.js";
 import { path } from "@commontools/common-propagator/path.js";
+import { markAsStatic } from "@commontools/common-builder";
 
 /** Parse a markup string and context into a view */
 export const view = (markup: string, context: Context): View => {
@@ -16,6 +17,8 @@ export const view = (markup: string, context: Context): View => {
   if (!isVNode(template)) {
     throw new ParseError("Template root must be an element");
   }
+
+  markAsStatic(template);
 
   const view: View = {
     type: "view",
@@ -78,7 +81,7 @@ export type VNode = {
 export const vnode = (
   name: string,
   props: Props = {},
-  children: Array<Child> = [],
+  children: Array<Child> = []
 ): VNode => {
   return { type: "vnode", name, props, children };
 };
@@ -198,7 +201,7 @@ export const tokenize = (markup: string): Array<Token> => {
       lowerCaseTags: true,
       lowerCaseAttributeNames: true,
       xmlMode: false,
-    },
+    }
   );
 
   parser.write(markup);
@@ -283,7 +286,7 @@ export const parse = (markup: string): VNode => {
         const top = stack.pop();
         if (!isVNode(top) || top.name !== token.name) {
           throw new ParseError(
-            `Unexpected closing tag ${token.name} in ${top?.name}`,
+            `Unexpected closing tag ${token.name} in ${top?.name}`
           );
         }
         break;
@@ -298,7 +301,7 @@ export const parse = (markup: string): VNode => {
         const top = stack.pop();
         if (!isSection(top) || top.name !== token.name) {
           throw new ParseError(
-            `Unexpected closing block ${token.name} in ${top?.name}`,
+            `Unexpected closing block ${token.name} in ${top?.name}`
           );
         }
         break;

--- a/typescript/packages/common-runner/src/builtins/map.ts
+++ b/typescript/packages/common-runner/src/builtins/map.ts
@@ -81,7 +81,7 @@ export function map(
       }
 
       if (isCell(value)) value = { cell: value, path: [] };
-      if (!isCellReference(value))
+      else if (!isCellReference(value))
         throw new Error("map requires all values to be cell references");
 
       // TODO: Replace with something that follows aliases as well.

--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -259,7 +259,7 @@ function simpleCell<T>(
         getAsCellReference: () => ({ cell, path } satisfies CellReference),
         toJSON: () => cell.toJSON(),
         get value(): T {
-          return cell.get();
+          return self.get();
         },
         get entityId(): EntityId | undefined {
           return getEntityId(self.getAsCellReference());

--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -84,6 +84,7 @@ export type CellImpl<T> = {
   toJSON(): { "/": string } | undefined;
   value: T;
   entityId?: EntityId | undefined;
+  sourceCell: CellImpl<any> | undefined;
   [toCellProxy]: () => BuilderCellProxy<T>;
   [isCellMarker]: true;
 };
@@ -108,6 +109,7 @@ export function cell<T>(value?: T): CellImpl<T> {
   const callbacks = new Set<(value: T, path: PropertyKey[]) => void>();
   let readOnly = false;
   let entityId: EntityId | undefined;
+  let sourceCell: CellImpl<any> | undefined;
 
   const self: CellImpl<T> = {
     get: () => value as T,
@@ -150,17 +152,6 @@ export function cell<T>(value?: T): CellImpl<T> {
       proxied, e.g. for aliases. TODO: Consider changing proxy here. */
     },
     isFrozen: () => readOnly,
-    get value(): T {
-      return value as T;
-    },
-    get entityId(): EntityId | undefined {
-      return entityId;
-    },
-    set entityId(id: EntityId) {
-      if (entityId) throw new Error("Entity ID already set");
-      entityId = id;
-      setCellByEntityId(id, self);
-    },
     generateEntityId: (cause?: any): void => {
       entityId = createRef(
         typeof value === "object" && value !== null
@@ -176,6 +167,23 @@ export function cell<T>(value?: T): CellImpl<T> {
     // writing a structure to this that might contain a reference to this cell,
     // and we want to serialize that as am IPLD link to this cell.
     toJSON: () => entityId?.toJSON(),
+    get value(): T {
+      return value as T;
+    },
+    get entityId(): EntityId | undefined {
+      return entityId;
+    },
+    set entityId(id: EntityId) {
+      if (entityId) throw new Error("Entity ID already set");
+      entityId = id;
+      setCellByEntityId(id, self);
+    },
+    get sourceCell(): CellImpl<any> | undefined {
+      return sourceCell;
+    },
+    set sourceCell(cell: CellImpl<any> | undefined) {
+      sourceCell = cell;
+    },
     [toCellProxy]: () => toBuilderCellProxy(self, []),
     [isCellMarker]: true,
   };

--- a/typescript/packages/common-runner/src/runner.ts
+++ b/typescript/packages/common-runner/src/runner.ts
@@ -128,11 +128,9 @@ export function run<T, R = any>(
   resultCell.send(mapBindingsToCell<R>(recipe.result as R, processCell));
 
   // TODO: This will overwrite existing values
-  const internal = mergeObjects(
-    defaults,
-    recipe.internal,
-    processCell.get()?.internal
-  );
+  const internal = mergeObjects(recipe.internal, processCell.get()?.internal);
+
+  if (defaults) parameters = mergeObjects(parameters, defaults);
 
   // TODO: Don't overwrite, reuse
   if (!processCell.get())

--- a/typescript/packages/common-runner/src/runner.ts
+++ b/typescript/packages/common-runner/src/runner.ts
@@ -276,17 +276,8 @@ function instantiateJavaScriptNode(
       const ref = followAliases(value, processCell);
       cell = ref.cell;
       path = ref.path;
-      console.log("alias", path, JSON.stringify(cell.get()));
       value = cell.getAtPath(path);
     }
-    console.log(
-      "isStream?",
-      inputs,
-      key,
-      value,
-      JSON.stringify(cell.get()),
-      path
-    );
     if (isStreamAlias(value)) {
       streamRef = { cell, path };
       break;

--- a/typescript/packages/common-runner/src/runner.ts
+++ b/typescript/packages/common-runner/src/runner.ts
@@ -127,9 +127,11 @@ export function run<T, R = any>(
   // Send "query" to results to the result cell
   resultCell.send(mapBindingsToCell<R>(recipe.result as R, processCell));
 
+  // TODO: This will overwrite existing values
   const internal = mergeObjects(
     defaults,
-    processCell.get()?.internal ?? recipe.internal
+    recipe.internal,
+    processCell.get()?.internal
   );
 
   // TODO: Don't overwrite, reuse

--- a/typescript/packages/common-runner/src/utils.ts
+++ b/typescript/packages/common-runner/src/utils.ts
@@ -455,3 +455,14 @@ export function isEqualCellReferences(
     arrayEqual(a.path, b.path)
   );
 }
+
+export function deepCopy(value: any): any {
+  if (isCell(value)) return value;
+  if (typeof value === "object" && value !== null)
+    return Array.isArray(value)
+      ? value.map(deepCopy)
+      : Object.fromEntries(
+          Object.entries(value).map(([key, value]) => [key, deepCopy(value)])
+        );
+  else return value;
+}

--- a/typescript/packages/common-runner/test/recipes.test.ts
+++ b/typescript/packages/common-runner/test/recipes.test.ts
@@ -5,7 +5,7 @@ import { addModuleByRef } from "../src/module.js";
 import { cell } from "../src/cell.js";
 import { idle } from "../src/scheduler.js";
 
-describe.skip("Recipe Runner", () => {
+describe("Recipe Runner", () => {
   it("should run a simple recipe", async () => {
     const simpleRecipe = recipe<{ value: number }>(
       "Simple Recipe",

--- a/typescript/packages/common-runner/test/recipes.test.ts
+++ b/typescript/packages/common-runner/test/recipes.test.ts
@@ -112,8 +112,6 @@ describe("Recipe Runner", () => {
       }
     );
 
-    console.log("recipe", JSON.stringify(incRecipe, null, 2));
-
     const result = run(incRecipe, { counter: { value: 0 } });
 
     await idle();
@@ -147,7 +145,6 @@ describe("Recipe Runner", () => {
       { counter: { value: number }; nested: { a: { b: { c: number } } } }
     >((event, { counter, nested }) => {
       counter.value += event.amount;
-      console.log("counter", counter.value, event.amount);
       return incLogger({ counter, amount: event.amount, nested: nested.a.b });
     });
 

--- a/typescript/packages/common-runner/test/recipes.test.ts
+++ b/typescript/packages/common-runner/test/recipes.test.ts
@@ -5,7 +5,7 @@ import { addModuleByRef } from "../src/module.js";
 import { cell } from "../src/cell.js";
 import { idle } from "../src/scheduler.js";
 
-describe("Recipe Runner", () => {
+describe.skip("Recipe Runner", () => {
   it("should run a simple recipe", async () => {
     const simpleRecipe = recipe<{ value: number }>(
       "Simple Recipe",

--- a/typescript/packages/common-runner/test/runner.test.ts
+++ b/typescript/packages/common-runner/test/runner.test.ts
@@ -112,7 +112,6 @@ describe("runRecipe", () => {
   it("should handle nested recipes", async () => {
     const nestedRecipe: Recipe = {
       schema: {},
-      internal: { parameters: { value: 1 } },
       result: { output: { $alias: { path: ["internal", "result"] } } },
       nodes: [
         {

--- a/typescript/packages/common-runner/test/runner.test.ts
+++ b/typescript/packages/common-runner/test/runner.test.ts
@@ -109,6 +109,58 @@ describe("runRecipe", () => {
     expect(result.getAsProxy()).toEqual({ result: 2 });
   });
 
+  it("should run a simple module with no outputs", async () => {
+    let ran = false;
+
+    const mockRecipe: Recipe = {
+      schema: {},
+      result: { result: { $alias: { path: ["internal", "result"] } } },
+      nodes: [
+        {
+          module: {
+            type: "javascript",
+            implementation: () => {
+              ran = true;
+            },
+          },
+          inputs: { $alias: { path: ["parameters", "value"] } },
+          outputs: {},
+        },
+      ],
+    };
+
+    const result = run(mockRecipe, { value: 1 });
+    await idle();
+    expect(result.getAsProxy()).toEqual({ result: undefined });
+    expect(ran).toBe(true);
+  });
+
+  it("should handle incorrect inputs gracefully", async () => {
+    let ran = false;
+
+    const mockRecipe: Recipe = {
+      schema: {},
+      result: { result: { $alias: { path: ["internal", "result"] } } },
+      nodes: [
+        {
+          module: {
+            type: "javascript",
+            implementation: () => {
+              ran = true;
+            },
+          },
+          inputs: { $alias: { path: ["parameters", "other"] } },
+          outputs: {},
+        },
+      ],
+    };
+
+    const result = run(mockRecipe, { value: 1 });
+    await idle();
+    expect(result.getAsProxy()).toEqual({ result: undefined });
+    expect(ran).toBe(true);
+  });
+
   it("should handle nested recipes", async () => {
     const nestedRecipe: Recipe = {
       schema: {},


### PR DESCRIPTION
Before inputs and outputs lives in the same namespace.

Now `run` returns the cell representing the results (which is actually a "query" via aliases to the actual cells containing the results).

Cells have now have a `sourceCell` that generate their content, so `.sourceCell` on the cell returned by `run` returns the cell that contains the remaining information, including references to parameters and internal cells.

One advantage is that `.map()` on a cell now works a lot more like one would expect: Only the outputs of the recipe passed to it are in the output.