### PR TITLE
Feature: Allow parameters to recipe to also be arrays or literals

### DIFF
--- a/typescript/packages/common-builder/src/cell-proxy.ts
+++ b/typescript/packages/common-builder/src/cell-proxy.ts
@@ -69,6 +69,27 @@ export function cell<T>(value?: Value<T> | T): CellProxy<T> {
           op: recipe("mapping function", fn),
         });
       },
+      /**
+       * We assume the cell is an array and will provide an infinite iterator.
+       * The primary use-case is destructuring a tuple (`[a, b] = ...`). We
+       * hence limit to at most 50 items, which should be enough for that, but
+       * prevents infinite loops if used elsewhere.
+       */
+      [Symbol.iterator]: () => {
+        let index = 0;
+        return {
+          next: () => {
+            if (index >= 50)
+              throw new Error(
+                "Can't use iterator over an opaque value in an unlimited loop."
+              );
+            return {
+              done: false,
+              value: createNestedProxy([...path, index++]),
+            };
+          },
+        };
+      },
       [isCellProxyMarker]: true,
     };
 

--- a/typescript/packages/common-builder/src/types.ts
+++ b/typescript/packages/common-builder/src/types.ts
@@ -43,6 +43,7 @@ export type CellProxyMethods<T> = {
   map<S>(
     fn: (value: T extends Array<infer U> ? Value<U> : Value<T>) => Value<S>
   ): Value<S[]>;
+  [Symbol.iterator](): Iterator<T>;
   [isCellProxyMarker]: true;
 };
 

--- a/typescript/packages/common-runner/src/builtins/map.ts
+++ b/typescript/packages/common-runner/src/builtins/map.ts
@@ -87,9 +87,6 @@ export function map(
       // TODO: Replace with something that follows aliases as well.
       value = followCellReferences(value, log);
 
-      if (typeof value !== "object")
-        throw new Error("map currently only supports objects");
-
       // If the value is new, instantiate the recipe and store the result cell
       let itemResult = sourceRefToResult.find(({ ref }) =>
         isEqualCellReferences(ref, value)

--- a/typescript/packages/common-runner/test/html-recipes.test.ts
+++ b/typescript/packages/common-runner/test/html-recipes.test.ts
@@ -59,7 +59,7 @@ describe("recipes with HTML", () => {
     await idle();
 
     const parent = document.createElement("div");
-    const cell = result.asSimpleCell<View>([UI]);
+    const cell = result.asSimpleCell([UI]);
     render(parent, cell.get());
 
     expect(parent.innerHTML).toBe(
@@ -92,7 +92,7 @@ describe("recipes with HTML", () => {
     await idle();
 
     const parent = document.createElement("div");
-    const cell = result.asSimpleCell<View>([UI]);
+    const cell = result.asSimpleCell([UI]);
     render(parent, cell.get());
 
     expect(parent.innerHTML).toBe("<div><div>test</div></div>");
@@ -108,9 +108,41 @@ describe("recipes with HTML", () => {
     await idle();
 
     const parent = document.createElement("div");
-    const cell = result.asSimpleCell<View>([UI]);
+    const cell = result.asSimpleCell([UI]);
     render(parent, cell.get());
 
     expect(parent.innerHTML).toBe("<div>Hello, world!</div>");
+  });
+
+  it("works with nested maps of non-objects", async () => {
+    const entries = lift((row: object) => Object.entries(row));
+
+    const data = [
+      { test: 123, ok: false },
+      { test: 345, another: "xxx" },
+      { test: 456, ok: true },
+    ];
+
+    const nestedMapRecipe = recipe<any[]>("nested map recipe", (data) => ({
+      [UI]: html`<div>
+        ${data.map(
+          (row) => html`<ul>
+            ${entries(row).map(([k, v]) => html`<li>${k}: ${v}</li>`)}
+          </ul>`
+        )}
+      </div>`,
+    }));
+
+    const result = run(nestedMapRecipe, data);
+
+    await idle();
+
+    const parent = document.createElement("div");
+    const cell = result.asSimpleCell([UI]);
+    render(parent, cell.get());
+
+    expect(parent.innerHTML).toBe(
+      "<div><ul><li>test: 123</li><li>ok: false</li></ul><ul><li>test: 345</li><li>another: xxx</li></ul><ul><li>test: 456</li><li>ok: true</li></ul></div>"
+    );
   });
 });


### PR DESCRIPTION
It's now the same as `lift`, which is good, because they can be used interchangeably (i.e. a caller doesn't know which it is).

This now also allows mapping over arrays of arrays and arrays of literals. Before only mapping over arrays of objects was possible.