### PR TITLE
typescript/tsx recipe local compile flow

### DIFF
--- a/typescript/packages/lookslike-high-level/src/components/sidebar.ts
+++ b/typescript/packages/lookslike-high-level/src/components/sidebar.ts
@@ -97,7 +97,7 @@ export class CommonSidebar extends LitElement {
   override render() {
     const prompt = this.getFieldOrDefault("prompt", "");
     const data = this.getFieldOrDefault("data", {});
-    const src = this.getFieldOrDefault("partialHTML", "");
+    const src = this.getFieldOrDefault("recipeSrc", "");
     const schema = this.getFieldOrDefault("schema", {});
     const query = this.getFieldOrDefault("query", {});
 
@@ -145,6 +145,10 @@ export class CommonSidebar extends LitElement {
 
     const onDataChanged = (e: CustomEvent) => {
       this.setField("data", JSON.parse(e.detail.state.doc.toString()));
+    };
+
+    const onSrcChanged = (e: CustomEvent) => {
+      this.setField("recipeSrc", e.detail.state.doc.toString());
     };
 
     return html`
@@ -212,8 +216,9 @@ export class CommonSidebar extends LitElement {
                 <div>
                   <os-code-editor
                     slot="content"
-                    language="text/html"
+                    language="text/x.typescript"
                     .source=${watchCell(src)}
+                    @doc-change=${onSrcChanged}
                   ></os-code-editor>
                 </div>
               </os-sidebar-group>

--- a/typescript/packages/lookslike-high-level/src/localBuild.ts
+++ b/typescript/packages/lookslike-high-level/src/localBuild.ts
@@ -1,0 +1,77 @@
+import ts from 'typescript';
+import * as commonHtml from "@commontools/common-html";
+import * as commonBuilder from "@commontools/common-builder";
+import * as commonRunner from "@commontools/common-runner";
+import * as zod from "zod";
+
+
+// NOTE(ja): this isn't currently doing typechecking, but it could...
+export const buildRecipe = ({ src }: { src: string }): { recipe: commonBuilder.Recipe } | { errors: string } => {
+    if (!src) {
+        return { errors: "No source code provided" }
+    }
+
+    // Custom module resolution
+    const customRequire = (moduleName: string) => {
+        switch (moduleName) {
+            case "@commontools/common-html":
+                return commonHtml;
+            case "@commontools/common-builder":
+                return commonBuilder;
+            case "@commontools/common-runner":
+                return commonRunner;
+            case "zod":
+                return zod;
+            default:
+                throw new Error(`Module not found: ${moduleName}`);
+        }
+    };
+
+    // Add error handling for compilation
+    const result = ts.transpileModule(src, {
+        compilerOptions: {
+            module: ts.ModuleKind.CommonJS,
+            target: ts.ScriptTarget.ES2022,
+            strict: true,
+            jsx: ts.JsxEmit.React,
+            jsxFactory: 'h',
+            jsxFragmentFactory: 'Fragment',
+            esModuleInterop: true,
+        },
+        reportDiagnostics: true
+    });
+
+    // Check for compilation errors
+    if (result.diagnostics && result.diagnostics.length > 0) {
+        const errors = result.diagnostics.map(diagnostic => {
+            const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+            let locationInfo = '';
+            
+            if (diagnostic.file && diagnostic.start !== undefined) {
+                const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+                locationInfo = `[${line + 1}:${character + 1}] `; // +1 because TypeScript uses 0-based positions
+            }
+            
+            return `Compilation Error: ${locationInfo}${message}`;
+        }).join('\n');
+        return { errors };
+    }
+
+    const js = result.outputText;
+
+    try {
+        // Wrap the transpiled code in a function that provides the custom require and mock exports
+        const wrappedCode = `
+            (function(require) {
+                const exports = {};
+                ${js}
+                return exports;
+            })(${customRequire.toString()})
+        `;
+
+        const { default: recipe } = eval(wrappedCode);
+        return { recipe }
+    } catch (e) {
+        return { errors: (e as Error).message }
+    }
+};

--- a/typescript/packages/lookslike-high-level/src/recipes/coder.tsx
+++ b/typescript/packages/lookslike-high-level/src/recipes/coder.tsx
@@ -1,0 +1,61 @@
+import { h, } from "@commontools/common-html";
+import { recipe, NAME, UI, handler, lift, cell, ifElse, navigateTo } from "@commontools/common-builder";
+import { buildRecipe } from "../localBuild.js";
+
+const build = lift<{ src: string, recipe: any, errors: string }>((state) => {
+    if (state.src) {
+        const newRecipe = buildRecipe({ src: state.src })
+        if ("errors" in newRecipe) {
+            state.errors = newRecipe.errors
+            state.recipe = {}
+        } else {
+            // NOTE(ja): we should probably send the JSON graph, not the function... but...
+            // 1. I'm not sure how to run it from this recipe then
+            // 2. converting to JSON loses closures (which is good, but we 
+            //    use them to get around holes in the current implementation)
+            // state.recipe = JSON.parse(JSON.stringify(newRecipe.recipe))
+            state.recipe = newRecipe.recipe
+            state.errors = ""
+        }
+    }
+    console.log("build", state.src, state.errors, state.recipe)
+})
+
+const run = handler<{  }, { recipe: any }>(({ }, state) => {
+    const data = {}; // FIXME(ja): this should be sent ...
+    return navigateTo(state.recipe(data))
+})
+
+const jsonify = lift(({ recipe }) => JSON.stringify(recipe, null, 2))
+
+export const coder = recipe<{
+    src: string;
+    errors: string;
+}>("coder", ({ src }) => {
+
+    const recipe = cell({})
+    const errors = cell("")
+
+    build({ src, recipe, errors })
+
+    return {
+        [UI]: <os-container>
+            <h2>Coder</h2>
+            {ifElse(
+                errors,
+                <pre>${errors}</pre>,
+                <span></span>
+            )}
+            {ifElse(
+                errors,
+                <span></span>,
+                <div>
+                    <button onclick={run({ recipe })}>Run</button>
+                    <pre>{jsonify({ recipe })}</pre>
+                </div>
+            )}
+        </os-container>,
+        [NAME]: "coder",
+        recipeSrc: src,
+    }
+})

--- a/typescript/packages/lookslike-high-level/src/recipes/coder.tsx
+++ b/typescript/packages/lookslike-high-level/src/recipes/coder.tsx
@@ -51,7 +51,8 @@ export const coder = recipe<{
                 <span></span>,
                 <div>
                     <button onclick={run({ recipe })}>Run</button>
-                    <pre>{jsonify({ recipe })}</pre>
+                    <os-code-editor source={jsonify({ recipe })}
+                        language="application/json"></os-code-editor>
                 </div>
             )}
         </os-container>,


### PR DESCRIPTION
- expose recipe source in a 'coder' recipe
- on change to recipe, compile - showing errors or graph
- allow user to click 'run' to create charm and navigate to

To use this currently, in your `data.ts` do:
  
    import counterSrc from "./recipes/counter.tsx?raw";
    addCharms([
      await runPersistent(coder, { src: counterSrc }, "coder"),
    ])

the recipe needs to be exposed as the `default` export