### PR TITLE
Blobquery

### DIFF
--- a/typescript/packages/blobby/.env-example
+++ b/typescript/packages/blobby/.env-example
@@ -1,3 +1,4 @@
 PORT=3000
 REDIS_URL=redis://localhost:6379
 BASE_URL=http://localhost:3000
+SNAP_API_URL=https://paas.saga-castor.ts.net/snap

--- a/typescript/packages/blobby/README.md
+++ b/typescript/packages/blobby/README.md
@@ -46,3 +46,70 @@ If you want to run against a remote server, you can set the `BASE_URL` environme
 ```bash
 BASE_URL=https://paas.saga-castor.ts.net/blobby deno task upload-test
 ```
+
+## Using the Blobby HTTP API
+
+The blobby service supports a few different endpoints for interacting with the blob storage. For these examples, we'll use the production server url as the base url, but you could swap-in `http://localhost:3000` if you wanted to test against a local server.
+
+#### List ALL blobs
+
+```bash
+curl https://paas.saga-castor.ts.net/blobby/blobs?all=true
+```
+
+#### List your user's blobs
+
+```bash
+curl https://paas.saga-castor.ts.net/blobby/blobs
+```
+
+#### Store a blob
+
+```bash
+curl -X POST https://paas.saga-castor.ts.net/blobby/blob/[hash] \
+  -H "Content-Type: text/plain" \
+  -d '{"superhappyobjects": {"wibble": "wobble", "foo": "bar"}}'
+```
+
+#### Get a blob
+
+```bash
+curl https://paas.saga-castor.ts.net/blobby/blob/[hash]
+```
+
+#### Get a PNG screenshot of a blob
+
+```bash
+curl https://paas.saga-castor.ts.net/blobby/blob/[hash]/png
+```
+
+#### Query JSON blob contents
+
+The API supports querying nested JSON values using path segments. For example, given a blob with content:
+
+```json
+{
+  "superhappyobjects": {
+    "wibble": "wobble",
+    "foo": "bar"
+  }
+}
+```
+
+Get a nested object:
+
+```bash
+curl https://paas.saga-castor.ts.net/blobby/blob/[hash]/superhappyobjects
+# Returns: {"wibble": "wobble", "foo": "bar"}
+```
+
+Get a specific value:
+
+```bash
+curl https://paas.saga-castor.ts.net/blobby/blob/[hash]/superhappyobjects/foo
+# Returns: bar
+```
+
+### Authentication
+
+All endpoints require Tailscale authentication by default. The service expects a `Tailscale-User-Login` header to be present in the request. This is handled transparently when accessing the service through Tailscale.

--- a/typescript/packages/blobby/deno.json
+++ b/typescript/packages/blobby/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
-    "dev": "deno run --watch --env --allow-env=PORT,REDIS_URL,TAILSCALE_AUTH --allow-net --allow-read=. --allow-write=./data src/index.ts",
-    "start": "deno run --env --allow-env=PORT,REDIS_URL,TAILSCALE_AUTH --allow-net --allow-read=. --allow-write=./data src/index.ts",
+    "dev": "deno run --watch --env --allow-env=PORT,REDIS_URL,TAILSCALE_AUTH,SNAP_API_URL --allow-net --allow-read=. --allow-write=./data src/index.ts",
+    "start": "deno run --env --allow-env=PORT,REDIS_URL,TAILSCALE_AUTH,SNAP_API_URL --allow-net --allow-read=. --allow-write=./data src/index.ts",
     "upload-test": "deno run --env --allow-env=BASE_URL --allow-net test/upload-test.ts"
   },
   "fmt": {

--- a/typescript/packages/blobby/src/index.ts
+++ b/typescript/packages/blobby/src/index.ts
@@ -113,7 +113,7 @@ app.get("/blob/:hash", async (c) => {
 
 app.get("/blob/:hash/png", async (c) => {
   const hash = c.req.param("hash");
-  const snapURL = `https://paas.saga-castor.ts.net/snap/screenshot/${hash}`;
+  const snapURL = `${Deno.env.get("SNAP_API_URL")}/screenshot/${hash}`;
 
   const snap = await fetch(snapURL);
   const snapBlob = await snap.blob();


### PR DESCRIPTION
This PR adds the ability to query nested JSON keys/values using path segments.

For example, given a blob with content:

```json
{
  "superhappyobjects": {
    "wibble": "wobble",
    "foo": "bar"
  }
}
```

Get a nested object:

```bash
curl https://paas.saga-castor.ts.net/blobby/blob/[hash]/superhappyobjects
# Returns: {"wibble": "wobble", "foo": "bar"}
```

Get a specific value:

```bash
curl https://paas.saga-castor.ts.net/blobby/blob/[hash]/superhappyobjects/foo
# Returns: bar
```
