### PR TITLE
Force loading environment variables in `models.ts`

### DIFF
--- a/typescript/packages/planning-server/src/models.ts
+++ b/typescript/packages/planning-server/src/models.ts
@@ -4,6 +4,10 @@ import { openai } from "npm:@ai-sdk/openai";
 import { vertex } from "npm:@ai-sdk/google-vertex";
 import { ollama } from "ollama-ai-provider";
 
+// ensure env is ready to be read
+import { config } from "https://deno.land/x/dotenv/mod.ts";
+await config({ export: true });
+
 export type Capabilities = {
   contextWindow: number;
   maxOutputTokens: number;


### PR DESCRIPTION
I assume that the import in `index` is triggering before we load the env, causing `model.ts` to evaluate before the env is ready and skipping all the models.

Duplicating this call is silly but it does indicate a lifecycle problem wrt handling environment in the app.
