### PR TITLE
Run queries returned by lift

### DIFF
--- a/typescript/packages/common-builder/src/index.ts
+++ b/typescript/packages/common-builder/src/index.ts
@@ -1,4 +1,4 @@
-export { opaqueRef as cell } from "./opaque-ref.js";
+export { opaqueRef as cell, stream } from "./opaque-ref.js";
 export {
   createNodeFactory,
   derive,

--- a/typescript/packages/common-builder/src/opaque-ref.ts
+++ b/typescript/packages/common-builder/src/opaque-ref.ts
@@ -137,6 +137,10 @@ export function opaqueRef<T>(value?: Opaque<T> | T): OpaqueRef<T> {
   return top;
 }
 
+export function stream<T>(): OpaqueRef<T> {
+  return opaqueRef<T>({ $stream: true } as T);
+}
+
 export function createShadowRef(ref: OpaqueRef<any>): ShadowRef {
   return { shadowOf: ref };
 }

--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -834,7 +834,6 @@ function makeOpaqueRef(
   let ref = opaqueRefs.find((p) => arrayEqual(valuePath, p.path))?.opaqueRef;
   if (!ref) {
     ref = opaqueRef();
-    for (const key of valuePath) ref = ref.key(key);
     ref.setPreExisting({ $alias: { cell: valueCell, path: valuePath } });
     opaqueRefs.push({ path: valuePath, opaqueRef: ref });
   }

--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -772,7 +772,6 @@ export function createQueryResultProxy<T>(
         };
         ref.cell.send(value);
         ref.cell.sourceCell = valueCell;
-        if (Array.isArray(valueCell.get())) debugger;
 
         log?.writes.push(ref);
 

--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -376,7 +376,7 @@ export function cell<T>(value?: T, cause?: any): CellImpl<T> {
     toJSON: () =>
       typeof entityId?.toJSON === "function"
         ? entityId.toJSON()
-        : (entityId as { "/": string }),
+        : (entityId as { "/": string }) ?? { "/": "" },
     get value(): T {
       return value as T;
     },

--- a/typescript/packages/common-runner/src/runner.ts
+++ b/typescript/packages/common-runner/src/runner.ts
@@ -556,6 +556,7 @@ function instantiateRecipeNode(
   addCancel: AddCancel,
 ) {
   if (!isRecipe(module.implementation)) throw new Error(`Invalid recipe`);
+  const recipe = mapBindingsToCell(module.implementation, processCell);
   const inputs = mapBindingsToCell(inputBindings, processCell);
   const resultCell = cell(undefined, {
     recipe: module.implementation,
@@ -563,7 +564,7 @@ function instantiateRecipeNode(
     inputBindings,
     outputBindings,
   });
-  run(module.implementation, inputs, resultCell);
+  run(recipe, inputs, resultCell);
   sendValueToBinding(processCell, outputBindings, {
     cell: resultCell,
     path: [],

--- a/typescript/packages/common-runner/src/utils.ts
+++ b/typescript/packages/common-runner/src/utils.ts
@@ -495,7 +495,6 @@ export function normalizeToCells(
           value[i] = { cell: cell(value[i]), path: [] } satisfies CellReference;
           value[i].cell.entityId = itemId;
           value[i].cell.sourceCell = parentCell;
-          if (Array.isArray(parentCell.get())) debugger;
 
           preceedingItemId = itemId;
           log?.writes.push(value[i]);

--- a/typescript/packages/common-runner/src/utils.ts
+++ b/typescript/packages/common-runner/src/utils.ts
@@ -7,6 +7,7 @@ import {
   Recipe,
   UnsafeBinding,
   unsafe_materializeFactory,
+  isOpaqueRef,
 } from "@commontools/common-builder";
 import {
   cell,
@@ -558,6 +559,13 @@ export function isEqualCellReferences(
     a.cell === b.cell &&
     arrayEqual(a.path, b.path)
   );
+}
+
+export function containsOpaqueRef(value: any): boolean {
+  if (isOpaqueRef(value)) return true;
+  if (typeof value === "object" && value !== null)
+    return Object.values(value).some(containsOpaqueRef);
+  return false;
 }
 
 export function deepCopy(value: any): any {

--- a/typescript/packages/common-runner/test/recipes.test.ts
+++ b/typescript/packages/common-runner/test/recipes.test.ts
@@ -26,6 +26,7 @@ describe("Recipe Runner", () => {
   it("should handle nested recipes", async () => {
     const innerRecipe = recipe<{ x: number }>("Inner Recipe", ({ x }) => {
       const squared = lift((n: number) => {
+        console.log("inner squared", n);
         return n * n;
       })(x);
       return { squared };
@@ -36,15 +37,22 @@ describe("Recipe Runner", () => {
       ({ value }) => {
         const { squared } = innerRecipe({ x: value });
         const result = lift((n: number) => {
+          console.log("n", n);
           return n + 1;
         })(squared);
         return { result };
       },
     );
 
+    console.log("outerRecipe", JSON.stringify(outerRecipe.toJSON(), null, 2));
     const result = run(outerRecipe, { value: 4 });
+    console.log(
+      "sourceCells",
+      JSON.stringify(result.sourceCell?.getAsQueryResult(), null, 2),
+    );
 
     await idle();
+    console.log("result", JSON.stringify(result.getAsQueryResult(), null, 2));
 
     expect(result.getAsQueryResult()).toEqual({ result: 17 });
   });

--- a/typescript/packages/common-runner/test/recipes.test.ts
+++ b/typescript/packages/common-runner/test/recipes.test.ts
@@ -204,6 +204,27 @@ describe("Recipe Runner", () => {
     ]);
   });
 
+  it("should handle recipes returned by lifted functions", async () => {
+    const multiply = lift<{ x: number; y: number }>(({ x, y }) => x * y);
+
+    const multiplyGenerator = lift<{ x: number; y: number }>((args) => {
+      return multiply(args);
+    });
+
+    const multiplyRecipe = recipe<{ x: number; y: number }>(
+      "multiply",
+      (args) => {
+        return { result: multiplyGenerator(args) };
+      },
+    );
+
+    const result = run(multiplyRecipe, { x: 2, y: 3 });
+
+    await idle();
+
+    expect(result.getAsQueryResult()).toEqual({ result: 6 });
+  });
+
   it("should support referenced modules", async () => {
     addModuleByRef(
       "double",

--- a/typescript/packages/common-runner/test/recipes.test.ts
+++ b/typescript/packages/common-runner/test/recipes.test.ts
@@ -15,7 +15,6 @@ describe("Recipe Runner", () => {
       },
     );
 
-    console.log("simpleRecipe", JSON.stringify(simpleRecipe.toJSON(), null, 2));
     const result = run(simpleRecipe, { value: 5 });
 
     await idle();
@@ -26,7 +25,6 @@ describe("Recipe Runner", () => {
   it("should handle nested recipes", async () => {
     const innerRecipe = recipe<{ x: number }>("Inner Recipe", ({ x }) => {
       const squared = lift((n: number) => {
-        console.log("inner squared", n);
         return n * n;
       })(x);
       return { squared };
@@ -37,22 +35,15 @@ describe("Recipe Runner", () => {
       ({ value }) => {
         const { squared } = innerRecipe({ x: value });
         const result = lift((n: number) => {
-          console.log("n", n);
           return n + 1;
         })(squared);
         return { result };
       },
     );
 
-    console.log("outerRecipe", JSON.stringify(outerRecipe.toJSON(), null, 2));
     const result = run(outerRecipe, { value: 4 });
-    console.log(
-      "sourceCells",
-      JSON.stringify(result.sourceCell?.getAsQueryResult(), null, 2),
-    );
 
     await idle();
-    console.log("result", JSON.stringify(result.getAsQueryResult(), null, 2));
 
     expect(result.getAsQueryResult()).toEqual({ result: 17 });
   });

--- a/typescript/packages/common-runner/test/recipes.test.ts
+++ b/typescript/packages/common-runner/test/recipes.test.ts
@@ -206,7 +206,9 @@ describe("Recipe Runner", () => {
     await idle();
     expect(values).toEqual([
       [1, 1, 0],
-      [3, 1, 0], // That's the first logger called again when counter changes
+      // Next is the first logger called again when counter changes, since this
+      // is now a long running charmlet:
+      [3, 1, 0],
       [3, 2, 0],
     ]);
   });

--- a/typescript/packages/common-runner/test/runner.test.ts
+++ b/typescript/packages/common-runner/test/runner.test.ts
@@ -54,14 +54,18 @@ describe("runRecipe", () => {
         },
       },
       resultSchema: {},
-      result: { $alias: { path: ["internal", "output"] } },
+      result: { $alias: { cell: 1, path: ["internal", "output"] } },
       nodes: [
         {
           module: {
             type: "passthrough",
           },
-          inputs: { value: { $alias: { path: ["argument", "input"] } } },
-          outputs: { value: { $alias: { path: ["internal", "output"] } } },
+          inputs: {
+            value: { $alias: { cell: 1, path: ["argument", "input"] } },
+          },
+          outputs: {
+            value: { $alias: { cell: 1, path: ["internal", "output"] } },
+          },
         },
       ],
     } as Recipe;
@@ -171,15 +175,15 @@ describe("runRecipe", () => {
     const nestedRecipe: Recipe = {
       argumentSchema: {},
       resultSchema: {},
-      result: { $alias: { path: ["internal", "result"] } },
+      result: { $alias: { cell: 1, path: ["internal", "result"] } },
       nodes: [
         {
           module: {
             type: "javascript",
             implementation: (value: number) => value * 2,
           },
-          inputs: { $alias: { path: ["argument", "input"] } },
-          outputs: { $alias: { path: ["internal", "result"] } },
+          inputs: { $alias: { cell: 1, path: ["argument", "input"] } },
+          outputs: { $alias: { cell: 1, path: ["internal", "result"] } },
         },
       ],
     };

--- a/typescript/packages/common-runner/test/utils.test.ts
+++ b/typescript/packages/common-runner/test/utils.test.ts
@@ -4,7 +4,7 @@ import {
   mergeObjects,
   sendValueToBinding,
   setNestedValue,
-  mapBindingsToCell,
+  unwrapOneLevelAndBindtoCell,
   followCellReferences,
   followAliases,
   compactifyPaths,
@@ -233,7 +233,7 @@ describe("mapBindingToCell", () => {
       z: 3,
     };
 
-    const result = mapBindingsToCell(binding, testCell);
+    const result = unwrapOneLevelAndBindtoCell(binding, testCell);
     expect(result).toEqual({
       x: { $alias: { cell: testCell, path: ["a"] } },
       y: { $alias: { cell: testCell, path: ["b", "c"] } },


### PR DESCRIPTION
`lift`, like `handler` can return recipes (i.e. queries). The result of the query is then the result of the `lift`. For `lift`, any rerun will override the previous one, for `handler` each is a new charmlet.