### PR TITLE
add support for `index` to `map`

### DIFF
--- a/typescript/packages/common-builder/src/opaque-ref.ts
+++ b/typescript/packages/common-builder/src/opaque-ref.ts
@@ -71,6 +71,7 @@ export function opaqueRef<T>(value?: Opaque<T> | T): OpaqueRef<T> {
       map: <S>(
         fn: (
           value: Opaque<Required<T extends Array<infer U> ? U : T>>,
+          index: Opaque<number>,
         ) => Opaque<S>,
       ) => {
         // Create the factory if it doesn't exist. Doing it here to avoid
@@ -81,7 +82,9 @@ export function opaqueRef<T>(value?: Opaque<T> | T): OpaqueRef<T> {
         });
         return mapFactory({
           list: proxy,
-          op: recipe("mapping function", fn),
+          op: recipe("mapping function", ({ item, index }: Opaque<any>) =>
+            fn(item, index),
+          ),
         });
       },
       /**

--- a/typescript/packages/common-builder/test/recipe.test.ts
+++ b/typescript/packages/common-builder/test/recipe.test.ts
@@ -232,21 +232,21 @@ describe("recipe with map node that references a parent cell", () => {
 
 describe("recipe with map node that references a parent cell in another recipe", () => {
   it("correctly creates references to the parent cells", () => {
-    const multiplyArray = recipe<{ values: { x: number }[]; factor: number }>(
+    const multiplyArray = recipe<{ values: { x: number }[] }>(
       "Double numbers",
-      ({ values, factor }) => {
+      ({ values }) => {
         const wrapper = recipe("Wrapper", () => {
-          const doubled = values.map(({ x }) => {
-            const double = lift<{ x: number; factor: number }>(
+          const multiplied = values.map(({ x }, index) => {
+            const multiply = lift<{ x: number; factor: number }>(
               ({ x, factor }) => ({
                 x: x * factor,
               }),
             );
-            return { doubled: double({ x, factor }) };
+            return { multiplied: multiply({ x, factor: index }) };
           });
-          return { doubled };
+          return { multiplied };
         });
-        return wrapper({ values, factor });
+        return wrapper({ values });
       },
     );
 
@@ -257,7 +257,7 @@ describe("recipe with map node that references a parent cell in another recipe",
     expect(isRecipe(subSubRecipe)).toBeTruthy();
     expect(subSubRecipe.nodes[0].inputs).toEqual({
       x: { $alias: { cell: 2, path: ["argument", "item", "x"] } },
-      factor: { $alias: { path: ["argument", "factor"] } },
+      factor: { $alias: { cell: 2, path: ["argument", "index"] } },
     });
   });
 });

--- a/typescript/packages/common-builder/test/recipe.test.ts
+++ b/typescript/packages/common-builder/test/recipe.test.ts
@@ -16,7 +16,7 @@ describe("recipe function", () => {
 
   it("creates a recipe, with simple function", () => {
     const doubleRecipe = recipe<{ x: number }>("Double a number", ({ x }) => {
-      const double = lift<number>((x) => x * 2);
+      const double = lift<number>(x => x * 2);
       return { double: double(x) };
     });
     expect(isRecipe(doubleRecipe)).toBe(true);
@@ -39,7 +39,7 @@ describe("recipe function", () => {
 describe("complex recipe function", () => {
   const doubleRecipe = recipe<{ x: number }>("Double a number", ({ x }) => {
     x.setDefault(1);
-    const double = lift<number>((x) => x * 2);
+    const double = lift<number>(x => x * 2);
     return { double: double(double(x)) };
   });
   const { argumentSchema, result, nodes } = doubleRecipe;
@@ -95,7 +95,7 @@ describe("schemas", () => {
     const double = lift(
       z.number().describe("A number"),
       z.number().describe("Doubled"),
-      (x) => x * 2,
+      x => x * 2,
     );
     // @ts-ignore-error ZodNumber and number clash to be investigated
     const testRecipe = recipe(
@@ -172,7 +172,7 @@ describe("recipe with map node", () => {
     "Double numbers",
     ({ values }) => {
       const doubled = values.map(({ x }) => {
-        const double = lift<number>((x) => x * 2);
+        const double = lift<number>(x => x * 2);
         return { doubled: double(x) };
       });
       return { doubled };
@@ -224,7 +224,7 @@ describe("recipe with map node that references a parent cell", () => {
     expect(
       (multiplyArray.nodes[0].inputs as { op: Recipe }).op.nodes[0].inputs,
     ).toEqual({
-      x: { $alias: { cell: 1, path: ["argument", "x"] } },
+      x: { $alias: { cell: 1, path: ["argument", "item", "x"] } },
       factor: { $alias: { path: ["argument", "factor"] } },
     });
   });
@@ -256,7 +256,7 @@ describe("recipe with map node that references a parent cell in another recipe",
     const subSubRecipe = (subRecipe.nodes[0].inputs as { op: Recipe }).op;
     expect(isRecipe(subSubRecipe)).toBeTruthy();
     expect(subSubRecipe.nodes[0].inputs).toEqual({
-      x: { $alias: { cell: 2, path: ["argument", "x"] } },
+      x: { $alias: { cell: 2, path: ["argument", "item", "x"] } },
       factor: { $alias: { path: ["argument", "factor"] } },
     });
   });

--- a/typescript/packages/common-runner/src/builtins/map.ts
+++ b/typescript/packages/common-runner/src/builtins/map.ts
@@ -105,7 +105,7 @@ export function map(
 
       // If the value is new, instantiate the recipe and store the result cell
       let itemResult =
-        sourceRefToResult.length > index &&
+        index < sourceRefToResult.length &&
         isEqualCellReferences(sourceRefToResult[index].ref, value)
           ? sourceRefToResult[index]
           : undefined;

--- a/typescript/packages/common-runner/src/builtins/map.ts
+++ b/typescript/packages/common-runner/src/builtins/map.ts
@@ -51,6 +51,7 @@ export function map(
     cause,
   });
   result.sourceCell = parentCell;
+
   let sourceRefToResult: { ref: CellReference; resultCell: CellImpl<any> }[] =
     [];
 
@@ -103,9 +104,11 @@ export function map(
       value = followCellReferences(value, log);
 
       // If the value is new, instantiate the recipe and store the result cell
-      let itemResult = sourceRefToResult.find(({ ref }) =>
-        isEqualCellReferences(ref, value),
-      );
+      let itemResult =
+        sourceRefToResult.length > index &&
+        isEqualCellReferences(sourceRefToResult[index].ref, value)
+          ? sourceRefToResult[index]
+          : undefined;
 
       if (!itemResult) {
         if (value.cell.getAtPath(value.path) === undefined) {
@@ -117,14 +120,14 @@ export function map(
         if (!value.cell.entityId) value.cell.generateEntityId();
         const resultCell = cell();
         resultCell.generateEntityId({ map: value.cell.entityId });
-        run(op, value, resultCell);
+        run(op, { item: value, index }, resultCell);
         resultCell.sourceCell!.sourceCell = parentCell;
         if (Array.isArray(parentCell.get())) debugger;
 
         // TODO: Have `run` return cancel, once we make resultCell required
         addCancel(cancels.get(resultCell));
         itemResult = { ref: value, resultCell };
-        sourceRefToResult.push(itemResult);
+        sourceRefToResult[index] = itemResult;
       }
 
       // Send the result value to the result cell

--- a/typescript/packages/common-runner/test/recipes.test.ts
+++ b/typescript/packages/common-runner/test/recipes.test.ts
@@ -90,10 +90,6 @@ describe("Recipe Runner", () => {
 
     await idle();
 
-    // This is necessary to ensure the recipe has time to run
-    // TODO: Get await idle() to work for this case as well
-    await new Promise(resolve => setTimeout(resolve, 100));
-
     expect(result.getAsQueryResult()).toMatchObject({
       multiplied: [{ multiplied: 1 }, { multiplied: 4 }, { multiplied: 9 }],
     });
@@ -118,10 +114,6 @@ describe("Recipe Runner", () => {
     });
 
     await idle();
-
-    // This is necessary to ensure the recipe has time to run
-    // TODO: Get await idle() to work for this case as well
-    await new Promise(resolve => setTimeout(resolve, 100));
 
     expect(result.getAsQueryResult()).toMatchObject({
       doubled: [3, 6, 9],

--- a/typescript/packages/common-runner/test/recipes.test.ts
+++ b/typescript/packages/common-runner/test/recipes.test.ts
@@ -73,18 +73,20 @@ describe("Recipe Runner", () => {
   });
 
   it("should handle recipes with map nodes", async () => {
-    const doubleArray = recipe<{ values: { x: number }[] }>(
-      "Double numbers",
+    const multipliedArray = recipe<{ values: { x: number }[] }>(
+      "Multiply numbers",
       ({ values }) => {
-        const doubled = values.map(({ x }) => {
-          const double = lift<number>(x => x * 2);
-          return { double: double(x) };
+        const multiplied = values.map(({ x }, index) => {
+          const multiply = lift<number>(x => x * (index + 1));
+          return { multiplied: multiply(x) };
         });
-        return { doubled };
+        return { multiplied };
       },
     );
 
-    const result = run(doubleArray, { values: [{ x: 1 }, { x: 2 }, { x: 3 }] });
+    const result = run(multipliedArray, {
+      values: [{ x: 1 }, { x: 2 }, { x: 3 }],
+    });
 
     await idle();
 
@@ -93,7 +95,7 @@ describe("Recipe Runner", () => {
     await new Promise(resolve => setTimeout(resolve, 100));
 
     expect(result.getAsQueryResult()).toMatchObject({
-      doubled: [{ double: 2 }, { double: 4 }, { double: 6 }],
+      multiplied: [{ multiplied: 1 }, { multiplied: 4 }, { multiplied: 9 }],
     });
   });
 


### PR DESCRIPTION
support `list.map((item, index) => ...)`

implementation:
- turn underlying recipe into one that gets `item` and `index` and call passed function with both of those
- remember prior charmlets by index, not by reference, since now they are index dependent