### PR TITLE
add .with support to `handler` output

### DIFF
--- a/typescript/packages/common-builder/src/module.ts
+++ b/typescript/packages/common-builder/src/module.ts
@@ -100,9 +100,9 @@ export function byRef<T, R>(ref: string): ModuleFactory<T, R> {
   });
 }
 
-export function handler<E, T>(
-  handler: (event: E, props: T) => any,
-): HandlerFactory<T, E> {
+export function handler<E, T>(handler: {
+  (this: T, event: E, props: T): any;
+}): HandlerFactory<T, E> {
   const module: Handler &
     toJSON & { bind: (inputs: Opaque<T>) => OpaqueRef<E> } = {
     type: "javascript",

--- a/typescript/packages/common-builder/src/module.ts
+++ b/typescript/packages/common-builder/src/module.ts
@@ -103,11 +103,15 @@ export function byRef<T, R>(ref: string): ModuleFactory<T, R> {
 export function handler<E, T>(
   handler: (event: E, props: T) => any,
 ): HandlerFactory<T, E> {
-  const module: Handler & toJSON = {
+  const module: Handler &
+    toJSON & { bind: (inputs: Opaque<T>) => OpaqueRef<E> } = {
     type: "javascript",
     implementation: handler,
     wrapper: "handler",
     with: (inputs: Opaque<T>) => factory(inputs),
+    // Overriding the default `bind` method on functions. The wrapper will bind
+    // the actual inputs, so they'll be available as `this`
+    bind: (inputs: Opaque<T>) => factory(inputs),
     toJSON: () => moduleToJSON(module),
   };
 

--- a/typescript/packages/common-builder/src/module.ts
+++ b/typescript/packages/common-builder/src/module.ts
@@ -100,7 +100,7 @@ export function byRef<T, R>(ref: string): ModuleFactory<T, R> {
   });
 }
 
-export function handler<E, T>(handler: {
+export function handler<E = any, T = any>(handler: {
   (this: T, event: E, props: T): any;
 }): HandlerFactory<T, E> {
   const module: Handler &

--- a/typescript/packages/common-builder/src/module.ts
+++ b/typescript/packages/common-builder/src/module.ts
@@ -100,8 +100,12 @@ export function byRef<T, R>(ref: string): ModuleFactory<T, R> {
   });
 }
 
-export function handler<E = any, T = any>(handler: {
-  (this: T, event: E, props: T): any;
+export function handler<E, T>(handler: {
+  (
+    this: T extends unknown ? any : T,
+    event: E extends unknown ? any : E,
+    props: T extends unknown ? any : T,
+  ): any;
 }): HandlerFactory<T, E> {
   const module: Handler &
     toJSON & { bind: (inputs: Opaque<T>) => OpaqueRef<E> } = {

--- a/typescript/packages/common-builder/src/types.ts
+++ b/typescript/packages/common-builder/src/types.ts
@@ -75,7 +75,7 @@ export type toJSON = {
 };
 
 export type NodeFactory<T, R> = ((inputs: Opaque<T>) => OpaqueRef<R>) &
-  (Module | Recipe) &
+  (Module | Handler | Recipe) &
   toJSON;
 
 export type RecipeFactory<T, R> = ((inputs: Opaque<T>) => OpaqueRef<R>) &
@@ -84,6 +84,10 @@ export type RecipeFactory<T, R> = ((inputs: Opaque<T>) => OpaqueRef<R>) &
 
 export type ModuleFactory<T, R> = ((inputs: Opaque<T>) => OpaqueRef<R>) &
   Module &
+  toJSON;
+
+export type HandlerFactory<T, R> = ((inputs: Opaque<T>) => OpaqueRef<R>) &
+  Handler<T, R> &
   toJSON;
 
 export type JSONValue =
@@ -118,6 +122,10 @@ export type Module = {
   wrapper?: "handler";
   argumentSchema?: JSON;
   resultSchema?: JSON;
+};
+
+export type Handler<T = any, R = any> = Module & {
+  with: (inputs: Opaque<T>) => OpaqueRef<R>;
 };
 
 export function isModule(value: any): value is Module {

--- a/typescript/packages/common-builder/test/module.test.ts
+++ b/typescript/packages/common-builder/test/module.test.ts
@@ -43,7 +43,7 @@ describe("module", () => {
         (event, props) => {
           props.x = event.clientX;
           props.y = event.clientY;
-        }
+        },
       );
       expect(typeof clickHandler).toBe("function");
       expect(isModule(clickHandler)).toBe(true);
@@ -54,9 +54,27 @@ describe("module", () => {
         (event, props) => {
           props.x = event.clientX;
           props.y = event.clientY;
-        }
+        },
       );
       const stream = clickHandler({ x: opaqueRef(10), y: opaqueRef(20) });
+      expect(isOpaqueRef(stream)).toBe(true);
+      const { value, nodes } = (
+        stream as unknown as OpaqueRef<{ $stream: true }>
+      ).export();
+      expect(value).toEqual({ $stream: true });
+      expect(nodes.size).toBe(1);
+      expect([...nodes][0].module).toMatchObject({ wrapper: "handler" });
+      expect([...nodes][0].inputs.$event).toBe(stream);
+    });
+
+    it("creates a opaque ref with stream when with is called", () => {
+      const clickHandler = handler<MouseEvent, { x: number; y: number }>(
+        (event, props) => {
+          props.x = event.clientX;
+          props.y = event.clientY;
+        },
+      );
+      const stream = clickHandler.with({ x: opaqueRef(10), y: opaqueRef(20) });
       expect(isOpaqueRef(stream)).toBe(true);
       const { value, nodes } = (
         stream as unknown as OpaqueRef<{ $stream: true }>
@@ -73,7 +91,7 @@ describe("module", () => {
       const add = isolated<{ a: number; b: number }, number>(
         { a: { tag: "number", val: 0 }, b: { tag: "number", val: 0 } },
         { result: "number" },
-        ({ a, b }) => a + b
+        ({ a, b }) => a + b,
       );
       expect(typeof add).toBe("function");
       const result = add({ a: 1, b: 2 });
@@ -84,10 +102,10 @@ describe("module", () => {
       const definition = module.implementation as JavaScriptModuleDefinition;
       expect(definition.body).toContain("export const run = () => {");
       expect(definition.body).toContain(
-        'inputs["a"] = read("a")?.deref()?.val;'
+        'inputs["a"] = read("a")?.deref()?.val;',
       );
       expect(definition.body).toContain(
-        'inputs["b"] = read("b")?.deref()?.val;'
+        'inputs["b"] = read("b")?.deref()?.val;',
       );
       expect(definition.body).toContain('write("result", {');
       expect(definition.inputs).toMatchObject({

--- a/typescript/packages/common-runner/src/runner.ts
+++ b/typescript/packages/common-runner/src/runner.ts
@@ -634,5 +634,5 @@ function instantiateRecipeNode(
 
 const moduleWrappers = {
   handler: (fn: (event: any, ...props: any[]) => any) => (props: any) =>
-    fn(props.$event, props),
+    fn.bind(props)(props.$event, props),
 };

--- a/typescript/packages/common-runner/test/recipes.test.ts
+++ b/typescript/packages/common-runner/test/recipes.test.ts
@@ -150,10 +150,10 @@ describe("Recipe Runner", () => {
 
   it("should execute handlers that use bind and this", async () => {
     // Switch to `function` so that we can set the type of `this`.
-    const incHandler = handler(function (
-      this: { counter: { value: number } },
-      { amount }: { amount: number },
-    ) {
+    const incHandler = handler<
+      { amount: number },
+      { counter: { value: number } }
+    >(function ({ amount }) {
       this.counter.value += amount;
     });
 

--- a/typescript/packages/common-runner/test/recipes.test.ts
+++ b/typescript/packages/common-runner/test/recipes.test.ts
@@ -177,6 +177,32 @@ describe("Recipe Runner", () => {
     expect(result.getAsQueryResult()).toMatchObject({ counter: { value: 3 } });
   });
 
+  it("should execute handlers that use bind and this (no types)", async () => {
+    // Switch to `function` so that we can set the type of `this`.
+    const incHandler = handler(function ({ amount }) {
+      this.counter.value += amount;
+    });
+
+    const incRecipe = recipe<{ counter: { value: number } }>(
+      "Increment counter",
+      ({ counter }) => {
+        return { counter, stream: incHandler.bind({ counter }) };
+      },
+    );
+
+    const result = run(incRecipe, { counter: { value: 0 } });
+
+    await idle();
+
+    result.asRendererCell(["stream"]).send({ amount: 1 });
+    await idle();
+    expect(result.getAsQueryResult()).toMatchObject({ counter: { value: 1 } });
+
+    result.asRendererCell(["stream"]).send({ amount: 2 });
+    await idle();
+    expect(result.getAsQueryResult()).toMatchObject({ counter: { value: 3 } });
+  });
+
   it("should execute recipes returned by handlers", async () => {
     const counter = cell({ value: 0 });
     const nested = cell({ a: { b: { c: 0 } } });


### PR DESCRIPTION
```tsx
  const clickHandler = handler(...);
  ...
  <button onclick={clickHandler({ item }))>
```

is a bit confusing as it looks like it's called when an event happens, but really we're creating an event handler ahead of timing and binding data to it.

This PR adds a `.with` method to handlers, so that we can write

```tsx
  <button onclick=`{clickHandler.with({ item })}`>
```

which hopefully is a bit clearer.

This PR also overrides `.bind` to do the same, and then calls the handler with the state parameter bound to `this`. This requires passing an anonymous `function` instead of an arrow function:

```ts
    const incHandler = handler<
      { amount: number },
      { counter: { value: number } }
    >(function ({ amount }) {
      this.counter.value += amount;
    });
```

or just

```ts
    const incHandler = handler(function (event) {
      this.counter.value += event.amount;
    });
```
