### PR TITLE
Fulfill argument schema with spellcaster when launching recipe

### DIFF
--- a/typescript/packages/lookslike-high-level/src/components/window-manager.ts
+++ b/typescript/packages/lookslike-high-level/src/components/window-manager.ts
@@ -603,7 +603,6 @@ export class CommonWindowManager extends LitElement {
           const searchParams = new URLSearchParams(url.search);
           const encodedData = searchParams.get("data");
           let initialData = {};
-          debugger;
 
           const fulfillUrl =
             typeof window !== "undefined"
@@ -624,7 +623,7 @@ export class CommonWindowManager extends LitElement {
               options: {
                 format: "json",
                 validate: true,
-                maxExamples: 5,
+                maxExamples: 25,
               },
             }),
           });

--- a/typescript/packages/lookslike-high-level/src/components/window-manager.ts
+++ b/typescript/packages/lookslike-high-level/src/components/window-manager.ts
@@ -596,13 +596,44 @@ export class CommonWindowManager extends LitElement {
     const recipeMatch = matchRoute("/recipe/:recipeId", url);
     if (recipeMatch) {
       const recipeId = recipeMatch.params.recipeId;
-      syncRecipe(recipeId).then(() => {
+      syncRecipe(recipeId).then(async () => {
         const recipe = getRecipe(recipeId);
         if (recipe) {
           // Get data from URL query parameter if it exists
           const searchParams = new URLSearchParams(url.search);
           const encodedData = searchParams.get("data");
           let initialData = {};
+          debugger;
+
+          const fulfillUrl =
+            typeof window !== "undefined"
+              ? window.location.protocol + "//" + window.location.host + "/api/ai/spell/fulfill"
+              : "//api/ai/spell/fulfill";
+
+          // Call AI to analyze input schema and provide suggestions
+          const response = await fetch(fulfillUrl, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              accepts: "application/json",
+            },
+            body: JSON.stringify({
+              schema: recipe.argumentSchema?.properties,
+              many: false,
+              prompt: "",
+              options: {
+                format: "json",
+                validate: true,
+                maxExamples: 5,
+              },
+            }),
+          });
+
+          if (response.ok) {
+            const aiResponse = await response.json();
+            initialData = aiResponse.result;
+            console.log("AI response:", aiResponse);
+          }
 
           if (encodedData) {
             try {

--- a/typescript/packages/lookslike-high-level/src/recipes/articlesIframe.html
+++ b/typescript/packages/lookslike-high-level/src/recipes/articlesIframe.html
@@ -1,0 +1,119 @@
+<html>
+  <head>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"
+    ></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script>
+      window.onerror = function (message, source, lineno, colno, error) {
+        window.parent.postMessage(
+          {
+            type: "error",
+            data: {
+              description: message,
+              source: source,
+              lineno: lineno,
+              colno: colno,
+              stacktrace: error && error.stack ? error.stack : new Error().stack,
+            },
+          },
+          "*",
+        );
+        return false;
+      };
+
+      window.subscribeToKey = function (key) {
+        console.log("iframe: Subscribing to", key);
+        window.parent.postMessage(
+          {
+            type: "subscribe",
+            data: key,
+          },
+          "*",
+        );
+      };
+
+      window.unsubscribeFromKey = function (key) {
+        console.log("iframe: unsubscribing to", key);
+        window.parent.postMessage(
+          {
+            type: "unsubscribe",
+            data: key,
+          },
+          "*",
+        );
+      };
+
+      window.writeData = function (key, value) {
+        console.log("iframe: Writing data", key, value);
+        window.parent.postMessage(
+          {
+            type: "write",
+            data: [key, value],
+          },
+          "*",
+        );
+      };
+    </script>
+    <title>Article List</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      function App() {
+        const [data, setData] = React.useState({ articles: [] });
+
+        React.useEffect(() => {
+          function handleMessage(event) {
+            if (event.data.type === "update") {
+              if (event.data.data[0] === "articles") {
+                setData((prev) => ({ ...prev, [event.data.data[0]]: event.data.data[1] }));
+              }
+            }
+          }
+
+          window.addEventListener("message", handleMessage);
+          window.subscribeToKey("articles");
+
+          return () => {
+            window.removeEventListener("message", handleMessage);
+            window.unsubscribeFromKey("articles");
+          };
+        }, []);
+
+        return (
+          <div className="min-h-screen bg-gradient-to-br from-purple-50 to-pink-50 p-8">
+            <div className="max-w-3xl mx-auto">
+              <h1 className="text-3xl font-bold mb-6">Articles</h1>
+              <div className="space-y-4">
+                {data.articles &&
+                  data.articles.map((article, index) => (
+                    <div key={index} className="bg-white p-4 rounded-lg shadow-md">
+                      <a
+                        href={article.url}
+                        className="text-xl text-blue-600 hover:text-blue-800 font-medium"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {article.title}
+                      </a>
+                    </div>
+                  ))}
+              </div>
+              {(!data.articles || data.articles.length === 0) && (
+                <div className="text-gray-500 text-center py-8">No articles available</div>
+              )}
+            </div>
+          </div>
+        );
+      }
+
+      const root = ReactDOM.createRoot(document.getElementById("root"));
+      root.render(<App />);
+    </script>
+  </body>
+</html>

--- a/typescript/packages/lookslike-high-level/src/recipes/articlesIframe.tsx
+++ b/typescript/packages/lookslike-high-level/src/recipes/articlesIframe.tsx
@@ -1,0 +1,82 @@
+import { h } from "@commontools/html";
+import { recipe, UI, NAME } from "@commontools/builder";
+import type { JSONSchema } from "@commontools/builder";
+
+//<TYPE>IFRAME V0</TYPE>
+
+type Recipe = {
+  type: "iframe";
+  src: string;
+  argumentSchema: JSONSchema;
+  resultSchema: JSONSchema;
+  spec: string;
+  name: string;
+};
+
+//<SRC>
+// const src = "<p>hello world</p>";\
+import src from "./articlesIframe.html?raw";
+//</SRC>
+
+//<ARGUMENT SCHEMA>
+const argumentSchema = {
+  type: "object",
+  properties: {
+    articles: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          title: {
+            type: "string",
+          },
+          url: {
+            type: "string",
+          },
+        },
+        required: ["title", "url"],
+      },
+    },
+  },
+  description: "List of articles with titles and URLs",
+} as JSONSchema;
+//</ARGUMENT SCHEMA>
+
+//<RESULT SCHEMA>
+const resultSchema = {
+  type: "object",
+  properties: {
+    text: {
+      type: "string",
+      default: "(empty)",
+    },
+  },
+  description: "SMOL Counter demo",
+} as JSONSchema;
+//</RESULT SCHEMA>
+
+//<SPEC>
+const spec = "grid of articles";
+//</SPEC>
+
+//<NAME>
+const name = "smol iframe";
+//</NAME>
+
+const iframeRecipe: Recipe = {
+  type: "iframe",
+  src,
+  argumentSchema,
+  resultSchema,
+  spec,
+  name,
+};
+
+const runIframeRecipe = ({ argumentSchema, resultSchema, src, name }: Recipe) =>
+  recipe(argumentSchema, resultSchema, (data) => ({
+    [NAME]: name,
+    [UI]: <common-iframe src={src} $context={data}></common-iframe>,
+    // FIXME: add resultSchema to the result
+  }));
+
+export default runIframeRecipe(iframeRecipe);

--- a/typescript/packages/lookslike-high-level/src/recipes/index.ts
+++ b/typescript/packages/lookslike-high-level/src/recipes/index.ts
@@ -106,3 +106,8 @@ import wikiSrc from "./wiki.tsx?raw";
 import wiki from "./wiki.js";
 addRecipe(wiki, wikiSrc);
 export { wiki };
+
+import articlesIframeSrc from "./articlesIframe.tsx?raw";
+import articlesIframe from "./articlesIframe.js";
+addRecipe(articlesIframe, articlesIframeSrc);
+export { articlesIframe };

--- a/typescript/packages/lookslike-high-level/src/recipes/reading-list.tsx
+++ b/typescript/packages/lookslike-high-level/src/recipes/reading-list.tsx
@@ -2,13 +2,12 @@ import { h } from "@commontools/html";
 import { recipe, handler, UI, NAME, derive, lift, cell } from "@commontools/builder";
 import { z } from "zod";
 
-const BookItem = z.object({
+const ArticleItem = z.object({
   title: z.string(),
-  author: z.string(),
-  done: z.boolean().default(false),
+  url: z.string(),
 });
 
-export type BookItem = z.infer<typeof BookItem>;
+export type ArticleItem = z.infer<typeof ArticleItem>;
 
 const updateTitle = handler<{ detail: { value: string } }, { title: string }>(
   ({ detail }, state) => {
@@ -16,13 +15,13 @@ const updateTitle = handler<{ detail: { value: string } }, { title: string }>(
   },
 );
 
-const updateItem = handler<{ detail: { checked: boolean; value: string } }, { item: BookItem }>(
+const updateItem = handler<{ detail: { checked: boolean; value: string } }, { item: ArticleItem }>(
   ({ detail }, { item }) => {
     item.done = detail.checked;
   },
 );
 
-const deleteItem = handler<{}, { list: BookItem[]; item: BookItem }>(({}, { item, list }) => {
+const deleteItem = handler<{}, { list: ArticleItem[]; item: ArticleItem }>(({}, { item, list }) => {
   let idx = list.findIndex((i) => i.title === item.title);
   if (idx !== -1) list.splice(idx, 1);
   console.log("deleted item", item, idx);
@@ -51,11 +50,11 @@ export default recipe(
   z
     .object({
       title: z.string().default("Reading list"),
-      books: z.array(BookItem).default([]).describe("#booklist"),
+      articles: z.array(ArticleItem).default([]).describe("#readinglist"),
     })
-    .describe("Reading list"),
-  ({ title, books }) => {
-    const list = oneWayCopy(books);
+    .describe("Reading list 2"),
+  ({ title, articles }) => {
+    const list = oneWayCopy(articles);
     return {
       [NAME]: title,
       [UI]: (
@@ -65,23 +64,23 @@ export default recipe(
             placeholder="List title"
             oncommon-input={updateTitle({ title })}
           />
-          <common-vstack gap="sm">
-            {list.map((item: BookItem) => (
+          <div
+            class="card-grid"
+            style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 1rem;"
+          >
+            {list.map((item: ArticleItem) => (
               <common-draggable $entity={item}>
-                <common-hstack>
-                  <common-todo
-                    checked={item.done}
-                    value={derive(item, ({ title, author }) => `${title} by ${author}`)}
-                    ontodo-checked={updateItem({ item })}
-                    ontodo-input={updateItem({ item })}
-                  />
-                  <sl-button outline variant="danger" onclick={deleteItem({ item, list })}>
-                    Delete
-                  </sl-button>
-                </common-hstack>
+                <sl-card>
+                  <h3 slot="header">{item.title}</h3>
+                  <div>
+                    <a href={item.url} target="_blank" rel="noopener noreferrer">
+                      {item.url}
+                    </a>
+                  </div>
+                </sl-card>
               </common-draggable>
             ))}
-          </common-vstack>
+          </div>
         </os-container>
       ),
       title,

--- a/typescript/packages/lookslike-high-level/vite.config.ts
+++ b/typescript/packages/lookslike-high-level/vite.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
   plugins: [dts()],
   server: {
     proxy: {
+      "/api/ai/spell/fulfill": {
+        target: process.env.TOOLSHED_API_URL ?? "http://localhost:8000/",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
       "/api/ai/llm": {
         target: process.env.TOOLSHED_API_URL ?? "http://localhost:8000/api/ai/llm",
         changeOrigin: true,

--- a/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
@@ -3,13 +3,17 @@ import { hc } from "hono/client";
 
 const client = hc<AppType>("http://localhost:8000/");
 
-export async function getAllBlobs(): Promise<string[]> {
-  const res = await client.api.storage.blobby.$get({ query: { all: "true" } });
+export async function getAllBlobs(
+  withData: boolean = false,
+): Promise<string[] | { [id: string]: any }> {
+  const res = await client.api.storage.blobby.$get({
+    query: { all: "true", allWithData: withData ? "true" : "" },
+  });
   const data = await res.json();
   if ("error" in data) {
     throw new Error(data.error);
   }
-  return data.blobs;
+  return data.blobs || data;
 }
 
 export async function getBlob(key: string): Promise<unknown> {

--- a/typescript/packages/toolshed/routes/ai/spell/behavior/strategies/scanBySchema.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/behavior/strategies/scanBySchema.ts
@@ -46,7 +46,7 @@ export async function scanBySchema(
     data: Record<string, unknown>;
   }> = [];
 
-  for (const blobKey of allBlobs) {
+  for (const blobKey of (allBlobs as string[])) {
     try {
       const content = await getBlob(blobKey);
       if (!content) {

--- a/typescript/packages/toolshed/routes/ai/spell/behavior/strategies/scanForKey.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/behavior/strategies/scanForKey.ts
@@ -9,7 +9,7 @@ export async function scanForKey(
   const log = new PrefixedLogger(logger, "scanForKey");
 
   log.info(`Starting key scan for phrase: ${phrase}`);
-  const allBlobs = await getAllBlobs();
+  const allBlobs = await getAllBlobs() as string[];
   log.info(`Retrieved ${allBlobs.length} blobs to scan`);
 
   const matchingExamples: Array<{

--- a/typescript/packages/toolshed/routes/ai/spell/behavior/strategies/scanForText.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/behavior/strategies/scanForText.ts
@@ -16,7 +16,7 @@ export async function scanForText(
     data: Record<string, unknown>;
   }> = [];
 
-  for (const blobKey of allBlobs) {
+  for (const blobKey of (allBlobs as string[])) {
     try {
       const content = await getBlob(blobKey);
       if (!content) {

--- a/typescript/packages/toolshed/routes/ai/spell/fulfill.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/fulfill.ts
@@ -1,0 +1,572 @@
+import { getAllBlobs, getBlob } from "@/routes/ai/spell/behavior/effects.ts";
+import { generateText } from "@/lib/llm.ts";
+import { performSearch } from "@/routes/ai/spell/behavior/search.ts";
+import { checkSchemaMatch } from "@/lib/schema-match.ts";
+import { Logger } from "@/lib/prefixed-logger.ts";
+import {
+  ProcessSchemaRequest,
+  ProcessSchemaResponse,
+} from "@/routes/ai/spell/spell.handlers.ts";
+
+interface SchemaFragment {
+  path: string[];
+  schema: Record<string, unknown>;
+  matches: Array<{
+    key: string;
+    data: Record<string, unknown>;
+    similarity: number;
+  }>;
+}
+
+export async function processSchema(
+  body: ProcessSchemaRequest,
+  logger: Logger,
+  startTime: number,
+): Promise<ProcessSchemaResponse> {
+  logger.info(
+    { schema: body.schema, many: body.many, options: body.options },
+    "Starting schema processing request",
+  );
+
+  // Get all blob keys first
+  const allBlobs = await getAllBlobs(true);
+  logger.info(
+    { blobCount: allBlobs.length },
+    "Retrieved blob keys from storage",
+  );
+  // Fetch all blob contents once
+  const blobContents = new Map<string, Record<string, unknown>>();
+  for (const [key, content] of Object.entries(allBlobs)) {
+    blobContents.set(key, content as Record<string, unknown>);
+  }
+  logger.info(
+    { loadedBlobCount: blobContents.size },
+    "Loaded blob contents into memory",
+  );
+
+  let fragmentsWithMatches: SchemaFragment[];
+  let reassembled: Record<string, unknown>;
+
+  if (body.options?.exact) {
+    // When exact matching, treat the entire schema as one fragment
+    logger.debug("Using exact schema matching mode");
+    const exactFragment: SchemaFragment = {
+      path: [],
+      schema: body.schema,
+      matches: [],
+    };
+
+    const matches = await findExactMatches(exactFragment, blobContents, logger);
+    exactFragment.matches = matches;
+    fragmentsWithMatches = [exactFragment];
+    reassembled = {
+      matches: matches.map((m) => m.data),
+    };
+
+    logger.info(
+      { matchCount: matches.length },
+      "Completed exact schema matching",
+    );
+  } else {
+    // Normal decomposition mode
+    logger.debug("Beginning schema decomposition");
+    const fragments = decomposeSchema(body.schema);
+    logger.info(
+      {
+        fragmentCount: fragments.length,
+        fragmentPaths: fragments.map((f) => f.path.join(".")),
+      },
+      "Schema decomposed into fragments",
+    );
+
+    // Print each fragment
+    fragments.forEach((fragment) => {
+      logger.info({
+        path: fragment.path.join("."),
+        schema: fragment.schema,
+      }, "Fragment details");
+    });
+
+    let totalMatches = 0;
+    fragmentsWithMatches = await Promise.all(
+      fragments.map(async (fragment) => {
+        logger.debug(
+          { fragmentPath: fragment.path.join(".") },
+          "Processing fragment",
+        );
+        const matches = await findFragmentMatches(
+          fragment,
+          blobContents,
+          logger,
+        );
+        totalMatches += matches.length;
+        return { ...fragment, matches };
+      }),
+    );
+
+    logger.info(
+      { totalMatches, fragmentCount: fragments.length },
+      "Completed fragment matching",
+    );
+
+    logger.debug("Beginning fragment reassembly");
+    reassembled = reassembleFragments(fragmentsWithMatches, body.schema);
+    logger.info(
+      { reassembled },
+      "Fragments reassembled into complete object",
+    );
+  }
+
+  logger.debug("Constructing prompt with reassembled examples");
+  const prompt = constructSchemaPrompt(
+    body.schema,
+    [{ key: "reassembled", data: reassembled }],
+    body.prompt,
+    body.many,
+  );
+
+  logger.info({ prompt }, "Sending request to LLM");
+  const llmStartTime = performance.now();
+  const llmResponse = await generateText({
+    model: "claude-3-5-sonnet",
+    system: body.many
+      ? "Return valid JSON array synthesized from real data from the database. Each object must match the schema exactly."
+      : "Return a valid JSON object synthesized from real data from the database. Must match the schema exactly.",
+    stream: false,
+    messages: [{ role: "user", content: prompt }],
+  });
+  logger.info(
+    { llmTime: Math.round(performance.now() - llmStartTime) },
+    "Received LLM response",
+  );
+
+  let result: Record<string, unknown> | Array<Record<string, unknown>>;
+  try {
+    logger.debug("Parsing LLM response");
+    result = JSON.parse(llmResponse);
+    if (body.many && !Array.isArray(result)) {
+      logger.debug("Converting single object to array for many=true");
+      result = [result];
+    }
+    logger.info(
+      {
+        resultType: body.many ? "array" : "object",
+        resultSize: body.many ? (result as Array<unknown>).length : 1,
+      },
+      "Successfully parsed LLM response",
+    );
+  } catch (error) {
+    logger.error(
+      { error, response: llmResponse },
+      "Failed to parse LLM response",
+    );
+    throw new Error("Failed to parse LLM response as JSON");
+  }
+
+  const totalTime = Math.round(performance.now() - startTime);
+  logger.info(
+    { totalTime },
+    "Completed schema processing request",
+  );
+
+  return {
+    result,
+    metadata: {
+      processingTime: totalTime,
+      schemaFormat: body.options?.format || "json",
+      fragments: fragmentsWithMatches,
+      reassembledExample: reassembled,
+    },
+  };
+}
+
+function decomposeSchema(
+  schema: Record<string, unknown>,
+  parentPath: string[] = [],
+): SchemaFragment[] {
+  const fragments: SchemaFragment[] = [];
+
+  for (const [key, value] of Object.entries(schema)) {
+    const currentPath = [...parentPath, key];
+
+    if (isObject(value)) {
+      // Handle array definitions
+      if (
+        (value as Record<string, unknown>).type === "array" &&
+        isObject((value as Record<string, unknown>).items)
+      ) {
+        const itemSchema = (value as Record<string, unknown>).items as Record<
+          string,
+          unknown
+        >;
+        // Create a more permissive version of the items schema
+        const permissiveItemSchema = {
+          ...itemSchema,
+          additionalProperties: true, // Allow additional properties
+          required: (itemSchema as Record<string, unknown>).required || [], // Maintain required properties
+        };
+
+        fragments.push({
+          path: [...currentPath, "items"],
+          schema: permissiveItemSchema,
+          matches: [],
+        });
+
+        // If the items schema has properties, recursively decompose those
+        if (isObject((itemSchema as Record<string, unknown>).properties)) {
+          fragments.push(...decomposeSchema(
+            (itemSchema as Record<string, unknown>).properties as Record<
+              string,
+              unknown
+            >,
+            [...currentPath, "items", "properties"],
+          ));
+        }
+      } // Handle regular objects
+      else if (
+        !("type" in value) ||
+        isObject((value as Record<string, unknown>).properties)
+      ) {
+        const objectSchema = {
+          ...value,
+          additionalProperties: true, // Allow additional properties
+          required: (value as Record<string, unknown>).required || [], // Maintain required properties
+        };
+
+        fragments.push({
+          path: currentPath,
+          schema: { [key]: objectSchema },
+          matches: [],
+        });
+
+        // Recursively decompose if it has properties
+        if ((value as Record<string, unknown>).properties) {
+          fragments.push(...decomposeSchema(
+            (value as Record<string, unknown>).properties as Record<
+              string,
+              unknown
+            >,
+            [...currentPath, "properties"],
+          ));
+        }
+      }
+    }
+  }
+
+  return fragments;
+}
+
+async function findExactMatches(
+  fragment: SchemaFragment,
+  blobContents: Map<string, Record<string, unknown>>,
+  logger: Logger,
+): Promise<
+  Array<{ key: string; data: Record<string, unknown>; similarity: number }>
+> {
+  const matches: Array<
+    { key: string; data: Record<string, unknown>; similarity: number }
+  > = [];
+
+  for (const [blobKey, blobData] of blobContents) {
+    try {
+      // For exact matching, check each subtree of the blob
+      const subtreeMatches = findExactSubtreeMatches(blobData, fragment.schema);
+
+      for (const matchData of subtreeMatches) {
+        matches.push({
+          key: blobKey,
+          data: matchData,
+          similarity: 1.0, // Exact matches have perfect similarity
+        });
+      }
+    } catch (error) {
+      logger.error(
+        { error, blobKey },
+        "Error during exact schema matching",
+      );
+    }
+  }
+
+  logger.info(
+    {
+      matchCount: matches.length,
+      topMatch: matches[0]?.key,
+    },
+    "Completed exact matching",
+  );
+
+  return matches;
+}
+
+function findExactSubtreeMatches(
+  data: Record<string, unknown>,
+  schema: Record<string, unknown>,
+): Array<Record<string, unknown>> {
+  const matches: Array<Record<string, unknown>> = [];
+
+  // Check if current object matches
+  if (checkSchemaMatch(data, schema)) {
+    matches.push(data);
+  }
+
+  // Recursively check all object properties
+  for (const value of Object.values(data)) {
+    if (isObject(value)) {
+      matches.push(...findExactSubtreeMatches(
+        value as Record<string, unknown>,
+        schema,
+      ));
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        if (isObject(item)) {
+          matches.push(...findExactSubtreeMatches(
+            item as Record<string, unknown>,
+            schema,
+          ));
+        }
+      }
+    }
+  }
+
+  return matches;
+}
+async function findFragmentMatches(
+  fragment: SchemaFragment,
+  blobContents: Map<string, Record<string, unknown>>,
+  logger: Logger,
+): Promise<
+  Array<{ key: string; data: Record<string, unknown>; similarity: number }>
+> {
+  const matches: Array<
+    { key: string; data: Record<string, unknown>; similarity: number }
+  > = [];
+
+  logger.debug(
+    { fragmentPath: fragment.path.join("."), schema: fragment.schema },
+    "Starting fragment match search",
+  );
+
+  for (const [blobKey, blobData] of blobContents) {
+    try {
+      // For each blob, look for matching objects at any level
+      const subtreeMatches = findMatchingObjectsInSubtree(
+        blobData,
+        fragment.schema,
+      );
+
+      for (const match of subtreeMatches) {
+        matches.push({
+          key: blobKey,
+          data: match,
+          similarity: 1.0,
+        });
+      }
+    } catch (error) {
+      logger.error({ error, blobKey }, "Error processing blob");
+    }
+  }
+  logger.info(
+    {
+      fragmentPath: fragment.path.join("."),
+      matchCount: matches.length,
+      matches,
+    },
+    "Found matching objects",
+  );
+
+  return matches;
+}
+
+function findMatchingObjectsInSubtree(
+  data: unknown,
+  schema: Record<string, unknown>,
+): Array<Record<string, unknown>> {
+  const matches: Array<Record<string, unknown>> = [];
+
+  // Helper to check if an object matches our article schema
+  function isMatchingObject(obj: Record<string, unknown>): boolean {
+    // Check for required properties
+    if (!obj.title || typeof obj.title !== "string") return false;
+
+    // Handle both url and sourceUrl
+    const hasValidUrl = (obj.url && typeof obj.url === "string") ||
+      (obj.sourceUrl && typeof obj.sourceUrl === "string");
+
+    return hasValidUrl;
+  }
+
+  if (isObject(data)) {
+    // Check if current object matches
+    if (isMatchingObject(data as Record<string, unknown>)) {
+      // Transform to match expected schema
+      matches.push({
+        title: data.title,
+        url: data.sourceUrl || data.url,
+      });
+    }
+
+    // Recursively check all properties
+    for (const value of Object.values(data)) {
+      if (isObject(value)) {
+        matches.push(...findMatchingObjectsInSubtree(value, schema));
+      } else if (Array.isArray(value)) {
+        for (const item of value) {
+          matches.push(...findMatchingObjectsInSubtree(item, schema));
+        }
+      }
+    }
+  } else if (Array.isArray(data)) {
+    for (const item of data) {
+      matches.push(...findMatchingObjectsInSubtree(item, schema));
+    }
+  }
+
+  return matches;
+}
+
+function reassembleFragments(
+  fragments: SchemaFragment[],
+  originalSchema: Record<string, unknown>,
+): Record<string, unknown> {
+  const reassembled: Record<string, unknown> = {};
+
+  for (const fragment of fragments) {
+    if (fragment.matches.length > 0) {
+      // Use all matches
+      const matchData = fragment.matches.map((m) => m.data);
+      if (matchData.length === 1) {
+        setNestedValue(reassembled, fragment.path, matchData[0]);
+      } else {
+        setNestedValue(reassembled, fragment.path, matchData);
+      }
+    }
+  }
+
+  return reassembled;
+}
+
+function isObject(value: unknown): boolean {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isArray(value: unknown): boolean {
+  return Array.isArray(value);
+}
+
+function extractPathData(
+  data: Record<string, unknown>,
+  path: string[],
+): Record<string, unknown> | null {
+  let current: any = data;
+
+  // Special handling for "items" in the path
+  for (const key of path) {
+    if (current === undefined || current === null) return null;
+
+    if (key === "items" && Array.isArray(current)) {
+      // Return the array items directly
+      return current;
+    }
+
+    current = current[key];
+  }
+
+  return current;
+}
+
+function calculateSimilarity(
+  data: Record<string, unknown>,
+  schema: Record<string, unknown>,
+): number {
+  // Implement similarity calculation logic
+  // Could use structural similarity, field name matching, value type matching, etc.
+  // Return a score between 0 and 1
+  return 0.8; // Placeholder
+}
+
+function setNestedValue(
+  obj: Record<string, unknown>,
+  path: string[],
+  value: unknown,
+): void {
+  let current = obj;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i];
+    current[key] = current[key] || {};
+    current = current[key] as Record<string, unknown>;
+  }
+  current[path[path.length - 1]] = value;
+}
+
+function constructSchemaPrompt(
+  schema: Record<string, unknown>,
+  examples: Array<{ key: string; data: Record<string, unknown> }>,
+  userPrompt?: string,
+  many?: boolean,
+): string {
+  const schemaStr = JSON.stringify(schema, null, 2);
+  const MAX_VALUE_LENGTH = 500; // Maximum length for individual values
+
+  // Helper function to truncate large values
+  function sanitizeObject(
+    obj: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const sanitized: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(obj)) {
+      if (typeof value === "string" && value.length > MAX_VALUE_LENGTH) {
+        // Only truncate long string values
+        sanitized[key] = value.substring(0, MAX_VALUE_LENGTH) +
+          "... [truncated]";
+      } else {
+        // Keep everything else as-is
+        sanitized[key] = value;
+      }
+    }
+    return sanitized;
+  }
+
+  const examplesStr = examples
+    .map(({ key, data }) => {
+      const sanitizedData = sanitizeObject(data);
+      return `--- Example from "${key}" ---\n${
+        JSON.stringify(
+          sanitizedData,
+          null,
+          2,
+        )
+      }`;
+    })
+    .join("\n\n");
+
+  return `# TASK
+  ${
+    many
+      ? `Generate multiple objects that fit the requested schema based on the references provided.`
+      : `Fit data into the requested schema based on the references provided.`
+  }
+
+# SCHEMA
+${schemaStr}
+
+# REFERENCES FROM DATABASE
+${examples.length > 0 ? examplesStr : "No existing examples found in database."}
+
+# INSTRUCTIONS
+1. ${
+    many
+      ? `Generate an array of objects that strictly follow the schema structure`
+      : `Generate an object that strictly follows the schema structure`
+  }
+2. Combine and synthesize examples to create valid ${
+    many ? "objects" : "an object"
+  }
+3. Return ONLY valid JSON ${many ? "array" : "object"} matching the schema
+
+${userPrompt ? `# ADDITIONAL REQUIREMENTS\n${userPrompt}\n\n` : ""}
+
+# RESPONSE FORMAT
+Respond with ${
+    many ? "an array of valid JSON objects" : "a single valid JSON object"
+  }.`;
+}

--- a/typescript/packages/toolshed/routes/ai/spell/fulfill.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/fulfill.ts
@@ -223,7 +223,7 @@ function decomposeSchema(
         }
       } // Handle regular objects
       else if (
-        !("type" in value) ||
+        !("type" in (value as Record<string, unknown>)) ||
         isObject((value as Record<string, unknown>).properties)
       ) {
         const objectSchema = {
@@ -447,7 +447,7 @@ function extractPathData(
   data: Record<string, unknown>,
   path: string[],
 ): Record<string, unknown> | null {
-  let current: any = data;
+  let current = data;
 
   // Special handling for "items" in the path
   for (const key of path) {
@@ -458,7 +458,7 @@ function extractPathData(
       return current;
     }
 
-    current = current[key];
+    current = current[key] as Record<string, unknown>;
   }
 
   return current;

--- a/typescript/packages/toolshed/routes/ai/spell/fulfill.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/fulfill.ts
@@ -510,8 +510,18 @@ function constructSchemaPrompt(
         // Only truncate long string values
         sanitized[key] = value.substring(0, MAX_VALUE_LENGTH) +
           "... [truncated]";
+      } else if (Array.isArray(value)) {
+        // Recursively sanitize array elements
+        sanitized[key] = value.map((item) =>
+          typeof item === "object" && item !== null
+            ? sanitizeObject(item as Record<string, unknown>)
+            : item
+        );
+      } else if (typeof value === "object" && value !== null) {
+        // Recursively sanitize nested objects
+        sanitized[key] = sanitizeObject(value as Record<string, unknown>);
       } else {
-        // Keep everything else as-is
+        // Keep primitives as-is
         sanitized[key] = value;
       }
     }

--- a/typescript/packages/toolshed/routes/ai/spell/fulfill.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/fulfill.ts
@@ -265,13 +265,11 @@ function decomposeSchema(
   return fragments;
 }
 
-async function findExactMatches(
+function findExactMatches(
   fragment: SchemaFragment,
   blobContents: Map<string, Record<string, unknown>>,
   logger: Logger,
-): Promise<
-  Array<{ key: string; data: Record<string, unknown>; similarity: number }>
-> {
+): Array<{ key: string; data: Record<string, unknown>; similarity: number }> {
   const matches: Array<
     { key: string; data: Record<string, unknown>; similarity: number }
   > = [];
@@ -339,13 +337,12 @@ function findExactSubtreeMatches(
 
   return matches;
 }
-async function findFragmentMatches(
+
+function findFragmentMatches(
   fragment: SchemaFragment,
   blobContents: Map<string, Record<string, unknown>>,
   logger: Logger,
-): Promise<
-  Array<{ key: string; data: Record<string, unknown>; similarity: number }>
-> {
+): Array<{ key: string; data: Record<string, unknown>; similarity: number }> {
   const matches: Array<
     { key: string; data: Record<string, unknown>; similarity: number }
   > = [];
@@ -385,6 +382,7 @@ async function findFragmentMatches(
 
   return matches;
 }
+
 function findMatchingObjectsInSubtree(
   data: unknown,
   schema: Record<string, unknown>,

--- a/typescript/packages/toolshed/routes/ai/spell/spell.handlers.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/spell.handlers.ts
@@ -8,6 +8,7 @@ import type { ProcessSchemaRoute, SearchSchemaRoute } from "./spell.routes.ts";
 import { performSearch } from "./behavior/search.ts";
 import { checkSchemaMatch } from "@/lib/schema-match.ts";
 import { Logger } from "@/lib/prefixed-logger.ts";
+import { processSchema } from "@/routes/ai/spell/fulfill.ts";
 
 // Process Schema schemas
 export const ProcessSchemaRequestSchema = z.object({
@@ -34,12 +35,20 @@ export const ProcessSchemaResponseSchema = z.object({
   metadata: z.object({
     processingTime: z.number(),
     schemaFormat: z.string(),
-    examples: z.array(
+    fragments: z.array(
       z.object({
-        key: z.string(),
-        data: z.record(z.any()),
+        matches: z.array(
+          z.object({
+            key: z.string(),
+            data: z.record(z.any()),
+            similarity: z.number(),
+          }),
+        ),
+        path: z.array(z.string()),
+        schema: z.record(z.any()),
       }),
     ),
+    reassembledExample: z.record(z.any()),
   }),
 });
 
@@ -80,101 +89,11 @@ export type SearchSchemaResponse = z.infer<typeof SearchSchemaResponseSchema>;
 
 export const fulfill: AppRouteHandler<ProcessSchemaRoute> = async (c) => {
   const logger: Logger = c.get("logger");
-
   const body = (await c.req.json()) as ProcessSchemaRequest;
   const startTime = performance.now();
 
   try {
-    logger.info(
-      { schema: body.schema, many: body.many },
-      "Processing schema request",
-    );
-
-    const allBlobs = await getAllBlobs();
-
-    logger.info("Found blobs: " + allBlobs.length);
-
-    const matchingExamples: Array<{
-      key: string;
-      data: Record<string, unknown>;
-    }> = [];
-    const allExamples: Array<{
-      key: string;
-      data: Record<string, unknown>;
-    }> = [];
-
-    for (const blobKey of allBlobs) {
-      try {
-        const content = await getBlob(blobKey);
-        if (!content) continue;
-
-        const blobData = content as Record<string, unknown>;
-
-        allExamples.push({
-          key: blobKey,
-          data: blobData,
-        });
-
-        const matches = checkSchemaMatch(blobData, body.schema);
-        if (matches) {
-          matchingExamples.push({
-            key: blobKey,
-            data: blobData,
-          });
-        }
-      } catch (error) {
-        logger.error(`Error processing key ${blobKey}: ${error}`);
-        continue;
-      }
-    }
-
-    const maxExamples = body.options?.maxExamples || 5;
-
-    const examplesList = matchingExamples.length > 0
-      ? matchingExamples.slice(0, maxExamples)
-      : allExamples.sort(() => Math.random() - 0.5).slice(0, maxExamples);
-
-    const prompt = constructSchemaPrompt(
-      body.schema,
-      examplesList,
-      body.prompt,
-      body.many,
-    );
-
-    const llmResponse = await generateText({
-      model: "claude-3-5-sonnet",
-      system: body.many
-        ? "Generate valid JSON array containing multiple objects, no commentary. Each object in the array must fulfill the schema exactly, if there is no reference data then return nothing."
-        : "Generate valid JSON only, no commentary. The schema provided must be fulfilled exactly, if there is no reference data return nothing.",
-      stream: false,
-      messages: [
-        {
-          role: "user",
-          content: prompt,
-        },
-      ],
-    });
-
-    let result: Record<string, unknown> | Array<Record<string, unknown>>;
-    try {
-      result = JSON.parse(llmResponse);
-      // Validate that we got an array when many=true
-      if (body.many && !Array.isArray(result)) {
-        result = [result]; // Wrap single object in array if needed
-      }
-    } catch (error) {
-      logger.error({ error }, "Failed to parse LLM response");
-      throw new Error("Failed to parse LLM response as JSON");
-    }
-
-    const response: ProcessSchemaResponse = {
-      result,
-      metadata: {
-        processingTime: Math.round(performance.now() - startTime),
-        schemaFormat: body.options?.format || "json",
-        examples: examplesList,
-      },
-    };
+    const response = await processSchema(body, logger, startTime);
 
     logger.info(
       { processingTime: response.metadata.processingTime },
@@ -189,87 +108,6 @@ export const fulfill: AppRouteHandler<ProcessSchemaRoute> = async (c) => {
     );
   }
 };
-
-function constructSchemaPrompt(
-  schema: Record<string, unknown>,
-  examples: Array<{ key: string; data: Record<string, unknown> }>,
-  userPrompt?: string,
-  many?: boolean,
-): string {
-  const schemaStr = JSON.stringify(schema, null, 2);
-  const MAX_VALUE_LENGTH = 500; // Maximum length for individual values
-
-  // Helper function to truncate large values
-  function sanitizeObject(
-    obj: Record<string, unknown>,
-  ): Record<string, unknown> {
-    const sanitized: Record<string, unknown> = {};
-
-    for (const [key, value] of Object.entries(obj)) {
-      if (typeof value === "string") {
-        // Truncate long strings
-        if (value.length > MAX_VALUE_LENGTH) {
-          sanitized[key] = value.substring(0, MAX_VALUE_LENGTH) +
-            "... [truncated]";
-          continue;
-        }
-      } else if (typeof value === "object" && value !== null) {
-        // Handle arrays and objects
-        const stringified = JSON.stringify(value);
-        if (stringified.length > MAX_VALUE_LENGTH) {
-          sanitized[key] = "[large content omitted]";
-          continue;
-        }
-      }
-      sanitized[key] = value;
-    }
-    return sanitized;
-  }
-
-  const examplesStr = examples
-    .map(({ key, data }) => {
-      const sanitizedData = sanitizeObject(data);
-      return `--- Example from "${key}" ---\n${
-        JSON.stringify(
-          sanitizedData,
-          null,
-          2,
-        )
-      }`;
-    })
-    .join("\n\n");
-
-  return `# TASK
-  ${
-    many
-      ? `Generate multiple objects that fit the requested schema based on the references provided.`
-      : `Fit data into the requested schema based on the references provided.`
-  }
-
-# SCHEMA
-${schemaStr}
-
-# REFERENCES FROM DATABASE
-${examples.length > 0 ? examplesStr : "No existing examples found in database."}
-
-# INSTRUCTIONS
-1. ${
-    many
-      ? `Generate an array of objects that strictly follow the schema structure`
-      : `Generate an object that strictly follows the schema structure`
-  }
-2. Combine and synthesize examples to create valid ${
-    many ? "objects" : "an object"
-  }
-3. Return ONLY valid JSON ${many ? "array" : "object"} matching the schema
-
-${userPrompt ? `# ADDITIONAL REQUIREMENTS\n${userPrompt}\n\n` : ""}
-
-# RESPONSE FORMAT
-Respond with ${
-    many ? "an array of valid JSON objects" : "a single valid JSON object"
-  }.`;
-}
 
 export const search: AppRouteHandler<SearchSchemaRoute> = async (c) => {
   const logger: Logger = c.get("logger");

--- a/typescript/packages/toolshed/routes/ai/spell/spell.handlers.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/spell.handlers.ts
@@ -78,7 +78,7 @@ export const SearchSchemaResponseSchema = z.object({
 export type SearchSchemaRequest = z.infer<typeof SearchSchemaRequestSchema>;
 export type SearchSchemaResponse = z.infer<typeof SearchSchemaResponseSchema>;
 
-export const imagine: AppRouteHandler<ProcessSchemaRoute> = async (c) => {
+export const fulfill: AppRouteHandler<ProcessSchemaRoute> = async (c) => {
   const logger: Logger = c.get("logger");
 
   const body = (await c.req.json()) as ProcessSchemaRequest;

--- a/typescript/packages/toolshed/routes/ai/spell/spell.handlers.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/spell.handlers.ts
@@ -26,6 +26,7 @@ export const ProcessSchemaRequestSchema = z.object({
       format: z.enum(["json", "yaml"]).optional(),
       validate: z.boolean().optional(),
       maxExamples: z.number().default(5).optional(),
+      exact: z.boolean().optional(),
     })
     .optional(),
 });

--- a/typescript/packages/toolshed/routes/ai/spell/spell.index.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/spell.index.ts
@@ -13,7 +13,7 @@ import * as routes from "./spell.routes.ts";
 const router = createRouter();
 
 const Router = router
-  .openapi(routes.imagine, handlers.imagine)
+  .openapi(routes.fulfill, handlers.fulfill)
   .openapi(routes.search, handlers.search);
 
 export default Router;

--- a/typescript/packages/toolshed/routes/ai/spell/spell.routes.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/spell.routes.ts
@@ -15,8 +15,8 @@ const ErrorResponseSchema = z.object({
   error: z.string(),
 });
 
-export const imagine = createRoute({
-  path: "/ai/spell/imagine",
+export const fulfill = createRoute({
+  path: "/ai/spell/fulfill",
   method: "post",
   tags,
   request: {
@@ -40,7 +40,7 @@ export const imagine = createRoute({
   },
 });
 
-export type ProcessSchemaRoute = typeof imagine;
+export type ProcessSchemaRoute = typeof fulfill;
 
 export const search = createRoute({
   path: "/ai/spell/search",


### PR DESCRIPTION
When hitting a `/recipe/:recipeId` URL, use the new toolshed `fulfill` endpoint to request data that will fit the schema.

I will walk through how the fulfill process works on a call, since it's a bit hairy, but it seems to work! I'm unsure how to integrate further beyond my stab in `window-manager.ts` but @anotherjesse hopefully you can follow my lead in terms of usage?

Happy to land this PR but going through the process so you can read the diff first.


https://github.com/user-attachments/assets/6e580ab1-0d56-40cd-9aa1-43828771afd9

