### PR TITLE
Blobby additions

### DIFF
--- a/typescript/packages/toolshed/routes/ai/spell/spell.test.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/spell.test.ts
@@ -14,7 +14,7 @@ const app = createApp()
   .route("/", router)
   .route("/", llmRouter)
   .route("/", blobbyRouter);
-Deno.serve(app.fetch);
+// Deno.serve(app.fetch);
 
 // bf: these are commented out because the LLM is not configured in CI and they will fail
 // they work locally if you have claude set up

--- a/typescript/packages/toolshed/routes/storage/blobby/blobby.handlers.ts
+++ b/typescript/packages/toolshed/routes/storage/blobby/blobby.handlers.ts
@@ -88,12 +88,27 @@ export const listBlobsHandler: AppRouteHandler<typeof listBlobs> = async (
   const logger = c.get("logger");
   const showAll = c.req.query("all") === "true";
   const showAllWithData = c.req.query("allWithData") !== undefined;
-  // TODO(jake): Replace with actual user when auth is added
   const prefix = c.req.query("prefix");
   const search = c.req.query("search");
+  const keys = c.req.query("keys");
   const user = "system";
 
   try {
+    // If keys are provided, fetch those specific blobs
+    if (keys) {
+      const requestedKeys = keys.split(",");
+      const blobData: Record<string, unknown> = {};
+
+      for (const key of requestedKeys) {
+        const content = await storage.getBlob(key);
+        if (content) {
+          blobData[key] = JSON.parse(content);
+        }
+      }
+
+      return c.json(blobData, 200);
+    }
+
     // Get the list of blobs based on user/all flag
     let blobs = showAll || showAllWithData
       ? await getAllBlobs(redis)

--- a/typescript/packages/toolshed/routes/storage/blobby/blobby.handlers.ts
+++ b/typescript/packages/toolshed/routes/storage/blobby/blobby.handlers.ts
@@ -89,12 +89,23 @@ export const listBlobsHandler: AppRouteHandler<typeof listBlobs> = async (
   const showAll = c.req.query("all") === "true";
   const showAllWithData = c.req.query("allWithData") !== undefined;
   // TODO(jake): Replace with actual user when auth is added
+  const prefix = c.req.query("prefix");
   const user = "system";
+
   try {
     // Get the list of blobs based on user/all flag
-    const blobs = showAll || showAllWithData
+    let blobs = showAll || showAllWithData
       ? await getAllBlobs(redis)
       : await getUserBlobs(redis, user);
+
+    // Apply prefix filter if specified
+    if (prefix) {
+      blobs = blobs.filter((key) => key.startsWith(prefix));
+      logger.info(
+        { prefix, matchingBlobs: blobs.length },
+        "Applied prefix filter",
+      );
+    }
 
     // If showAllWithData is true, fetch the full blob data for each hash
     if (showAllWithData) {

--- a/typescript/packages/toolshed/routes/storage/blobby/blobby.routes.ts
+++ b/typescript/packages/toolshed/routes/storage/blobby/blobby.routes.ts
@@ -96,6 +96,7 @@ export const listBlobs = createRoute({
     query: z.object({
       all: z.string().optional(),
       allWithData: z.string().optional(),
+      prefix: z.string().optional(),
     }),
   },
   responses: {

--- a/typescript/packages/toolshed/routes/storage/blobby/blobby.routes.ts
+++ b/typescript/packages/toolshed/routes/storage/blobby/blobby.routes.ts
@@ -98,6 +98,7 @@ export const listBlobs = createRoute({
       allWithData: z.string().optional(),
       prefix: z.string().optional(),
       search: z.string().optional(),
+      keys: z.string().optional(),
     }),
   },
   responses: {

--- a/typescript/packages/toolshed/routes/storage/blobby/blobby.routes.ts
+++ b/typescript/packages/toolshed/routes/storage/blobby/blobby.routes.ts
@@ -97,6 +97,7 @@ export const listBlobs = createRoute({
       all: z.string().optional(),
       allWithData: z.string().optional(),
       prefix: z.string().optional(),
+      search: z.string().optional(),
     }),
   },
   responses: {

--- a/typescript/packages/toolshed/routes/storage/blobby/blobby.test.ts
+++ b/typescript/packages/toolshed/routes/storage/blobby/blobby.test.ts
@@ -257,4 +257,78 @@ Deno.test("blobby storage routes", async (t) => {
       }
     },
   );
+
+  await t.step(
+    "GET /api/storage/blobby?keys=key1,key2 fetches specific blobs",
+    async () => {
+      // Create three test blobs
+      const blob1 = {
+        message: "First test blob",
+        id: 1,
+      };
+      const blob2 = {
+        message: "Second test blob",
+        id: 2,
+      };
+      const blob3 = {
+        message: "Third test blob",
+        id: 3,
+      };
+
+      const key1 = await sha256(JSON.stringify(blob1));
+      const key2 = await sha256(JSON.stringify(blob2));
+      const key3 = await sha256(JSON.stringify(blob3));
+
+      // Upload all three blobs
+      const blobs = [[blob1, key1], [blob2, key2], [blob3, key3]];
+      for (
+        const [content, key] of blobs
+      ) {
+        await app.fetch(
+          new Request(`http://localhost/api/storage/blobby/${key}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(content),
+          }),
+        );
+      }
+
+      // Fetch only two of the blobs
+      const response = await app.fetch(
+        new Request(`http://localhost/api/storage/blobby?keys=${key1},${key2}`),
+      );
+      assertEquals(response.status, 200);
+
+      const json = await response.json();
+      assertEquals(typeof json, "object");
+
+      // Should only contain the two requested blobs
+      assertEquals(Object.keys(json).length, 2);
+      assertEquals(json[key1].message, blob1.message);
+      assertEquals(json[key2].message, blob2.message);
+      assertEquals(json[key3], undefined);
+
+      // Verify blob metadata
+      assertEquals(typeof json[key1].blobCreatedAt, "string");
+      assertEquals(json[key1].blobAuthor, "system");
+      assertEquals(typeof json[key2].blobCreatedAt, "string");
+      assertEquals(json[key2].blobAuthor, "system");
+    },
+  );
+
+  await t.step(
+    "GET /api/storage/blobby?keys=invalid returns empty result",
+    async () => {
+      const response = await app.fetch(
+        new Request(
+          "http://localhost/api/storage/blobby?keys=invalid1,invalid2",
+        ),
+      );
+      assertEquals(response.status, 200);
+
+      const json = await response.json();
+      assertEquals(typeof json, "object");
+      assertEquals(Object.keys(json).length, 0);
+    },
+  );
 });


### PR DESCRIPTION
This PR adds a few features to the blobby API

* key-prefix search: so you can fetch blobs that have keys beginning with a string like `spell-`
* full text search (very basic/rudimentary, this will be slow/bad when we have a large number of keys)
* fetch blobs based on list of specific keys