### PR TITLE
Spellbook Jr. Improvements

### DIFF
--- a/typescript/packages/lookslike-high-level/src/data.ts
+++ b/typescript/packages/lookslike-high-level/src/data.ts
@@ -170,8 +170,17 @@ export async function syncRecipe(id: string) {
   recipesKnownToStorage.add(recipeId);
 }
 
-export async function saveRecipe(id: string, src: string, spec?: string, parents?: string[]) {
-  if (recipesKnownToStorage.has(id)) return;
+export async function saveRecipe(
+  id: string,
+  src: string,
+  spec?: string,
+  parents?: string[],
+  spellbookTitle?: string,
+  spellbookTags?: string[],
+) {
+  // If the recipe is already known to storage, we don't need to save it again,
+  // unless the user is trying to attach a spellbook title or tags.
+  if (recipesKnownToStorage.has(id) && !spellbookTitle) return;
   recipesKnownToStorage.add(id);
 
   console.log("Saving recipe", id);
@@ -186,6 +195,8 @@ export async function saveRecipe(id: string, src: string, spec?: string, parents
       spec,
       parents,
       recipeName: getRecipeName(id),
+      spellbookTitle,
+      spellbookTags,
     }),
   });
   return response.ok;
@@ -194,10 +205,7 @@ export async function saveRecipe(id: string, src: string, spec?: string, parents
 import smolIframe from "./recipes/smolIframe.js";
 import complexIframe from "./recipes/complexIframe.js";
 
-addCharms([
-  run(smolIframe, { count: 1 }),
-  run(complexIframe, { count: 42 }),
-]);
+addCharms([run(smolIframe, { count: 1 }), run(complexIframe, { count: 42 })]);
 
 export type RecipeManifest = {
   name: string;

--- a/typescript/packages/spellbookjr/app/components/recipe-card.tsx
+++ b/typescript/packages/spellbookjr/app/components/recipe-card.tsx
@@ -3,12 +3,15 @@
 import Image from "next/image";
 import Link from "next/link";
 import { LuHeart } from "react-icons/lu";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 
 interface RecipeCardProps {
   hash: string;
   name: string;
   author: string;
   likes: number;
+  spellbookTitle: string;
+  spellbookTags: string[];
   imageUrl: string;
 }
 
@@ -17,8 +20,21 @@ export default function RecipeCard({
   name,
   author,
   likes,
+  spellbookTitle,
+  spellbookTags,
   imageUrl,
 }: RecipeCardProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const handleTagClick = (e: React.MouseEvent<HTMLSpanElement>, tag: string) => {
+    e.preventDefault();
+    const params = new URLSearchParams(searchParams);
+    params.set("q", tag);
+    router.replace(`${pathname}?${params.toString()}`);
+  };
+
   return (
     <Link
       href={`/recipes/${hash}`}
@@ -28,14 +44,28 @@ export default function RecipeCard({
         <img src={imageUrl} alt={name} className="object-cover" />
       </div>
       <div className="mt-4">
-        <h2 className="text-xl font-semibold text-purple-900 group-hover:text-purple-600">
-          {name}
+        <h2 className="mt-1 text-xl font-bold text-purple-900 group-hover:text-purple-600">
+          {spellbookTitle}
         </h2>
+        <h3 className="text-sm italic text-purple-900 group-hover:text-purple-600">({name})</h3>
+
         <p className="mt-1 text-sm text-gray-600">by {author}</p>
-        <div className="mt-2 flex items-center text-purple-400">
+        <div className="mt-1 flex flex-wrap gap-1">
+          {spellbookTags.map((tag) => (
+            <span
+              key={tag}
+              onClick={(e) => handleTagClick(e, tag)}
+              className="text-sm text-purple-600 hover:text-purple-800 hover:underline cursor-pointer"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+        {/* TODO(jake): Add likes back in once we have some form of identity */}
+        {/* <div className="mt-2 flex items-center text-purple-400">
           <LuHeart className="mr-1 h-4 w-4" />
           <span className="text-sm">{likes}</span>
-        </div>
+        </div> */}
       </div>
     </Link>
   );

--- a/typescript/packages/spellbookjr/app/components/search-box.tsx
+++ b/typescript/packages/spellbookjr/app/components/search-box.tsx
@@ -23,15 +23,16 @@ export function SearchBox({ defaultValue = "" }) {
   };
 
   return (
-    <div>
+    <div className="flex items-center">
       <input
         type="text"
         defaultValue={defaultValue}
         onChange={(e) => handleSearch(e.target.value)}
         placeholder="Search recipes"
-        className={isPending ? "opacity-50" : ""}
+        className={`text-black border-2 border-purple-900 rounded-full px-2 py-1 ${
+          isPending ? "opacity-50" : ""
+        }`}
       />
-      {isPending && <span>Updating...</span>}
     </div>
   );
 }

--- a/typescript/packages/spellbookjr/app/lib/blobby.ts
+++ b/typescript/packages/spellbookjr/app/lib/blobby.ts
@@ -1,12 +1,19 @@
 const BLOBBY_BASE_URL =
-  process.env.BLOBBY_BASE_URL ||
-  "https://toolshed.commontools.dev/api/storage/blobby";
+  process.env.BLOBBY_BASE_URL || "https://toolshed.commontools.dev/api/storage/blobby";
 
-const SNAP_BASE_URL =
-  process.env.SNAP_BASE_URL || "https://paas.saga-castor.ts.net/snap";
+const SNAP_BASE_URL = process.env.SNAP_BASE_URL || "https://paas.saga-castor.ts.net/snap";
 
 export const getAllBlobs = async () => {
   const response = await fetch(`${BLOBBY_BASE_URL}?all=true&prefix=spell-`, {
+    cache: "no-store",
+  });
+  if (!response.ok) throw new Error("Failed to fetch blobs");
+  const data = await response.json();
+  return data.blobs as string[];
+};
+
+export const getAllSellbookBlobs = async () => {
+  const response = await fetch(`${BLOBBY_BASE_URL}?search=spellbookTitle&prefix=spell-`, {
     cache: "no-store",
   });
   if (!response.ok) throw new Error("Failed to fetch blobs");


### PR DESCRIPTION
This PR makes Spellbook Jr. more useful.

If you want to share a spell for other folks to use, you can now do so by clicking the "Publish to spellbook" button. This prompts you for a title and hashtags. 

Also updated Spellbook Jr. to only display spells that have been manually published with user-defined title and tags