### PR TITLE
feat: Use nested sandbox frames to provide CSP

### DIFF
--- a/typescript/packages/common-iframe-sandbox/README.md
+++ b/typescript/packages/common-iframe-sandbox/README.md
@@ -27,8 +27,7 @@ See [context.ts](/typescript/packages/common-iframe-sandbox/src/context.ts).
 
 * Support updating the `src` property.
 * Flushing subscriptions inbetween frame loads.
-* Uniquely identify context handler calls so that they can be mapped to the correct iframe instance when there are multiple active sandboxed iframes.
-* Support browsers that do not support `HTMLIFrameElement.prototype.csp` (non-chromium).
+* Audit the IPC communication (`postMessage()`) with origin-bounds and ensure other frames can't spoof messages.
 * Abort on unsupported browsers.
 * Further testing.
 

--- a/typescript/packages/common-iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/typescript/packages/common-iframe-sandbox/src/common-iframe-sandbox.ts
@@ -1,9 +1,12 @@
-import { LitElement, html } from "lit";
+import { LitElement, PropertyValues, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { Ref, createRef, ref } from "lit/directives/ref.js";
 import * as IPC from "./ipc.js";
 import { getIframeContextHandler } from "./context.js";
-import { CSP } from "./csp.js";
+import OuterFrame from "./outer-frame.js";
+
+// TODO this should probably be randomly generated
+let FRAME_IDS = 0;
 
 // @summary A sandboxed iframe to execute arbitrary scripts.
 // @tag common-iframe-sandbox
@@ -17,10 +20,11 @@ export class CommonIframeSandboxElement extends LitElement {
   @property({ type: Object }) context?: object;
 
   private iframeRef: Ref<HTMLIFrameElement> = createRef();
-
+  private frameId: number = ++FRAME_IDS;
+  private initialized: boolean = false;
   private subscriptions: Map<string, any> = new Map();
 
-  private handleMessage = (event: MessageEvent) => {
+  private onMessage = (event: MessageEvent) => {
     if (event.data?.source == "react-devtools-content-script") {
       return;
     }
@@ -40,100 +44,158 @@ export class CommonIframeSandboxElement extends LitElement {
       return;
     }
 
-    if (!IPC.isGuestMessage(event.data)) {
-      console.error("common-iframe-sandbox: Malformed message from guest.");
+    if (!IPC.isIPCGuestMessage(event.data)) {
+      console.error("common-iframe-sandbox: Malformed message from guest.", event.data);
       return;
     }
 
-    const message: IPC.GuestMessage = event.data;
+    const outerMessage: IPC.IPCGuestMessage = event.data;
 
-    switch (message.type) {
-      case IPC.GuestMessageType.Error: {
-        const { description, source, lineno, colno, stacktrace } = message.data;
-        const error = { description, source, lineno, colno, stacktrace };
-        this.dispatchEvent(new CustomEvent("error", {
-          detail: error,
-        }));
+    switch (outerMessage.type) {
+      case IPC.IPCGuestMessageType.Load: {
+        this.dispatchEvent(new CustomEvent("load"));
         return;
       }
-
-      case IPC.GuestMessageType.Read: {
-        const key = message.data;
-        const value = IframeHandler.read(this.context, key);
-        const response: IPC.HostMessage = {
-          type: IPC.HostMessageType.Update,
-          data: [key, value],
-        }
-        this.iframeRef.value?.contentWindow?.postMessage(response, "*");
+      case IPC.IPCGuestMessageType.Error: {
+        console.error(`common-iframe-sandbox: Error from outer frame: ${outerMessage.data}`);
         return;
       }
-
-      case IPC.GuestMessageType.Write: {
-        const [key, value] = message.data;
-        IframeHandler.write(this.context, key, value);
-        return;
-      }
-
-      case IPC.GuestMessageType.Subscribe: {
-        const key = message.data;
-
-        if (this.subscriptions.has(key)) {
-          console.warn("common-iframe-sandbox: Already subscribed to `${key}`");
+      case IPC.IPCGuestMessageType.Ready: {
+        if (this.initialized) {
+          console.error(`common-iframe-sandbox: Already initialized. This should not occur.`);
           return;
         }
-        let receipt = IframeHandler.subscribe(this.context, key, (key, value) => this.notifySubscribers(key, value));
-        this.subscriptions.set(key, receipt);
+        this.initialized = true;
+        this.toGuest({
+          id: this.frameId,
+          type: IPC.IPCHostMessageType.Init,
+        });
+        if (this.src) {
+          this.updateInnerDoc();
+        }
         return;
       }
+      case IPC.IPCGuestMessageType.Passthrough: {
+        const message: IPC.GuestMessage = outerMessage.data;
+        switch (message.type) {
+          case IPC.GuestMessageType.Error: {
+            const { description, source, lineno, colno, stacktrace } = message.data;
+            const error = { description, source, lineno, colno, stacktrace };
+            this.dispatchEvent(new CustomEvent("error", {
+              detail: error,
+            }));
+            return;
+          }
 
-      case IPC.GuestMessageType.Unsubscribe: {
-        const key = message.data;
-        let receipt = this.subscriptions.get(key);
-        if (!receipt) {
-          return;
-        }
+          case IPC.GuestMessageType.Read: {
+            const key = message.data;
+            const value = IframeHandler.read(this.context, key);
+            const response: IPC.IPCHostMessage = {
+              id: this.frameId,
+              type: IPC.IPCHostMessageType.Passthrough,
+              data: {
+                type: IPC.HostMessageType.Update,
+                data: [key, value],
+              },
+            };
+            this.toGuest(response);
+            return;
+          }
+
+          case IPC.GuestMessageType.Write: {
+            const [key, value] = message.data;
+            IframeHandler.write(this.context, key, value);
+            return;
+          }
+
+          case IPC.GuestMessageType.Subscribe: {
+            const key = message.data;
+
+            if (this.subscriptions.has(key)) {
+              console.warn("common-iframe-sandbox: Already subscribed to `${key}`");
+              return;
+            }
+            let receipt = IframeHandler.subscribe(this.context, key, (key, value) => this.notifySubscribers(key, value));
+            this.subscriptions.set(key, receipt);
+            return;
+          }
+
+          case IPC.GuestMessageType.Unsubscribe: {
+            const key = message.data;
+            let receipt = this.subscriptions.get(key);
+            if (!receipt) {
+              return;
+            }
+            IframeHandler.unsubscribe(this.context, receipt);
+            this.subscriptions.delete(key);
+            return;
+          }
+        };
+      }
+    }
+  }
+
+  private updateInnerDoc() {
+    // Remove all active subscriptions when navigating
+    // to a new document.
+    const IframeHandler = getIframeContextHandler();
+    if (IframeHandler != null) {
+      for (const [_, receipt] of this.subscriptions) {
         IframeHandler.unsubscribe(this.context, receipt);
-        this.subscriptions.delete(key);
-        return;
       }
-    };
+      this.subscriptions.clear();
+    }
+
+    this.toGuest({
+      id: this.frameId,
+      type: IPC.IPCHostMessageType.LoadDocument,
+      data: this.src,
+    });
   }
 
   private notifySubscribers(key: string, value: any) {
-    const response: IPC.HostMessage = {
-      type: IPC.HostMessageType.Update,
-      data: [key, value],
-    }
-    this.iframeRef.value?.contentWindow?.postMessage(response, "*");
+    const response: IPC.IPCHostMessage = {
+      id: this.frameId,
+      type: IPC.IPCHostMessageType.Passthrough,
+      data: {
+        type: IPC.HostMessageType.Update,
+        data: [key, value],
+      }
+    };
+    this.toGuest(response);
+  }
+        
+  private toGuest(event: IPC.IPCHostMessage) {
+    this.iframeRef.value?.contentWindow?.postMessage(event, "*");
   }
 
-  private boundHandleMessage = this.handleMessage.bind(this);
+  private boundOnMessage = this.onMessage.bind(this);
 
   override connectedCallback() {
     super.connectedCallback();
-    window.addEventListener("message", this.boundHandleMessage);
+    window.addEventListener("message", this.boundOnMessage);
   }
 
   override disconnectedCallback() {
     super.disconnectedCallback();
-    window.removeEventListener("message", this.boundHandleMessage);
+    window.removeEventListener("message", this.boundOnMessage);
   }
 
-  private handleLoad() {
-    this.dispatchEvent(new CustomEvent("load"));
+  override willUpdate(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has('src') && this.initialized) {
+      this.updateInnerDoc();
+    }
   }
 
   override render() {
     return html`
       <iframe
         ${ref(this.iframeRef)}
-        sandbox="allow-scripts allow-forms allow-pointer-lock"
-        csp="${CSP}"
-        .srcdoc=${this.src}
+        sandbox="allow-scripts allow-pointer-lock"
+        .srcdoc=${OuterFrame}
         height="100%"
         width="100%"
         style="border: none;"
-        @load=${this.handleLoad}
       ></iframe>
     `;
   }

--- a/typescript/packages/common-iframe-sandbox/src/outer-frame.ts
+++ b/typescript/packages/common-iframe-sandbox/src/outer-frame.ts
@@ -1,0 +1,112 @@
+import { CSP } from './csp.js';
+
+const HOST_ORIGIN = new URL(window.location.href).origin;
+
+export default `
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="Content-Security-Policy" content="${CSP}" \/>
+  <style>
+html, body {
+  height: 100%;
+}
+iframe {
+  height: 100%;
+  width: 100%;
+  border: none;
+}
+  <\/style>
+<\/head>
+<body>
+	<iframe 
+    sandbox="allow-scripts"><\/iframe>
+	<script>
+const iframe = document.querySelector("iframe");
+const HOST_ORIGIN = "${HOST_ORIGIN}";
+const HOST_WINDOW = window.parent;
+const INNER_WINDOW = iframe.contentWindow;
+let FRAME_ID = null;
+
+iframe.addEventListener("load", onInnerLoad);
+window.addEventListener("message", onMessage);
+window.addEventListener("error", onOuterError);
+
+toHost({ type: "ready" });
+
+function onMessage(e) {
+  if (!e.data || typeof e.data.type !== "string") {
+    return; 
+  }
+
+  if (e.source === INNER_WINDOW) {
+    assertInitialized();
+    toHost({
+      id: FRAME_ID,
+      type: "passthrough",
+      data: e.data,
+    });
+    return;
+  }
+
+  if (e.source === HOST_WINDOW && e.origin === HOST_ORIGIN) {
+    // Handle initialization, receiving the frame ID.
+    if (FRAME_ID == null && e.data.type === "init") {
+      FRAME_ID = e.data.id;
+      return;
+    }
+
+    if (FRAME_ID == null || FRAME_ID !== e.data.id) {
+      return; 
+    }
+
+    switch (e.data.type) {
+      case "init": {
+        // There shouldn't be a second "init" command.
+        return;
+      }
+      case "load-document": {
+        iframe.srcdoc = e.data.data;
+        return; 
+      } 
+      case "passthrough": {
+        toInner(e.data.data);
+        return;
+      }
+    }
+  }
+}
+
+function onInnerLoad(e) {
+  // The iframe can fire its load event before
+  // loading the srcdoc contents in some browsers.
+  // Ignore, and wait for initialization to occur.
+  if (FRAME_ID == null) {
+    return; 
+  }
+  toHost({ type: "load", id: FRAME_ID });
+}
+
+function onOuterError({ message, filename, lineno, colno, error }) {
+  // Not all browsers can directly send the \`ErrorEvent\` object.
+  toHost({ type: "error", id: FRAME_ID, data: { message, filename, lineno, colno, error }})
+}
+
+function assertInitialized() {
+  if (FRAME_ID == null) {
+    throw new Error("Expected frame to be assigned an id.");
+  }
+}
+
+function toHost(data) {
+  HOST_WINDOW.postMessage(data, HOST_ORIGIN);
+}
+
+function toInner(data) {
+  INNER_WINDOW.postMessage(data, "*");
+}
+	<\/script>
+<\/body>
+<\/html>
+<\/html>
+`;


### PR DESCRIPTION
Use nested sandbox frames to provide CSP via meta tags rather than the less-supported iframe csp property.

PROS: appealing that there's a trusted intermediary that does not share a root origin. works consistent across browsers.
CONS: a bit messy nesting frames, performance could be an issue though i'm not concerned here.
The intermediary could be served with CSP HTTP headers in the future as a static asset (on a separate domain even) as an extra layer. Probably comparable to the inline version. could more easily share e.g ipc implementation between host and intermediary
will be a convenient time to uniquely identify frame messages such that we can support more than one common-iframe at a time

```js
// ┌──────────────┐              ┌───────────────┐
// │     Host     │              │     Guest     │
// └───────┬──────┘              └───────┬───────┘
//         │                             │        
//         │◄───────────READY────────────┤        
//         │                             │        
//         ├────────────INIT────────────►│        
//    ┌───►│                             │
//    │    ├────────LOAD-DOCUMENT───────►│        
//    │    │                             │        
//    │    │◄───────────LOAD─────────────┤        
//    │    │                             │◄───┐   
//    │    │◄────────PASSTHROUGH────────►│    │   
//    │    ▼                             ▼    │   
//    └────┘                             └────┘   
```