### PR TITLE
only export types in node build

### DIFF
--- a/typescript/packages/common-memory/interface.ts
+++ b/typescript/packages/common-memory/interface.ts
@@ -2,6 +2,11 @@ import type { Reference } from "merkle-reference";
 
 export type { Reference };
 
+export type Command = {
+  watch?: In<Selector>;
+  unwatch?: In<Selector>;
+};
+
 /**
  * Unique identifier for the store.
  */

--- a/typescript/packages/common-memory/lib.ts
+++ b/typescript/packages/common-memory/lib.ts
@@ -37,10 +37,6 @@ interface MemoryServiceSession {
   router: Router.Router;
 }
 
-export type Command = {
-  watch?: In<Selector>;
-  unwatch?: In<Selector>;
-};
 
 class Service implements MemoryService {
   constructor(public router: Router.Router) {}

--- a/typescript/packages/common-memory/package.json
+++ b/typescript/packages/common-memory/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@commontools/memory",
+  "type": "module",
   "exports": {
-    ".": "./lib.ts"
+    ".": "./interface.ts"
   },
   "dependencies": {
     "merkle-reference": "^2.0.1"


### PR DESCRIPTION
this fixes `pnpm run build` in common-charm/lookslike-high-level/jumble by
only exporting the interfaces from node's package.json

