### PR TITLE
(`common-memory`) First pass implementation of `get` and `list` behaviour

### DIFF
--- a/typescript/packages/common-memory/deno.json
+++ b/typescript/packages/common-memory/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
     "start": "deno run --allow-read --allow-write --allow-net --allow-ffi --allow-env deno.ts",
-    "test": "deno test --allow-read --allow-write --allow-net --allow-ffi --allow-env"
+    "test": "deno test --allow-read --allow-write --allow-net --allow-ffi --allow-env --no-check"
   },
   "test": {
     "include": [

--- a/typescript/packages/common-memory/deno.ts
+++ b/typescript/packages/common-memory/deno.ts
@@ -25,6 +25,9 @@ from ${STORE}`);
       return response;
     } else if (request.method === "PATCH") {
       return memory.patch(request);
+    } else if (request.method === "GET") {
+      const url = new URL(request.url);
+      return memory.get(request, url.pathname);
     } else {
       console.log("Not implemented", request.method, request.url);
       return new Response(null, { status: 501 });

--- a/typescript/packages/common-memory/error.ts
+++ b/typescript/packages/common-memory/error.ts
@@ -25,7 +25,7 @@ export const query = (
 ): ToJSON<QueryError> => new TheQueryError(selector, cause);
 
 export const list = (
-  selector: { the: string, in: ReplicaID },
+  selector: { in: ReplicaID; the?: string; of?: string },
   cause: SystemError,
 ): ToJSON<ListError> => new TheListError(selector, cause);
 
@@ -108,16 +108,20 @@ export class TheQueryError extends Error implements QueryError {
 
 export class TheListError extends Error implements ListError {
   override name = "ListError" as const;
-  constructor(public query: { the: string; in: ReplicaID }, public override cause: SystemError) {
-    const { the } = query;
-    super(`List query ${JSON.stringify({ the })} in ${query.in} failed: ${cause.message}`);
+  constructor(
+    public selector: { in: ReplicaID; the?: string; of?: string },
+    public override cause: SystemError,
+  ) {
+    super(
+      `List query ${JSON.stringify({ the: selector.the, of: selector.of })} in ${selector.in} failed: ${cause.message}`,
+    );
   }
   toJSON(): ListError {
     return {
       name: this.name,
       stack: this.stack ?? "",
       message: this.message,
-      query: this.query,
+      selector: this.selector,
       cause: {
         name: this.cause.name,
         code: this.cause.code,

--- a/typescript/packages/common-memory/error.ts
+++ b/typescript/packages/common-memory/error.ts
@@ -8,6 +8,8 @@ import type {
   SystemError,
   ConnectionError,
   Selector,
+  ListError,
+  The,
 } from "./interface.ts";
 import { ReplicaID } from "./interface.ts";
 import { refer } from "./util.ts";
@@ -18,9 +20,14 @@ export const transaction = (fact: InFact, cause: SystemError): ToJSON<Transactio
   new TheTransactionError(fact, cause);
 
 export const query = (
-  selector: Selector & { in: string },
+  selector: Selector & { in: ReplicaID },
   cause: SystemError,
 ): ToJSON<QueryError> => new TheQueryError(selector, cause);
+
+export const list = (
+  selector: { the: string, in: ReplicaID },
+  cause: SystemError,
+): ToJSON<ListError> => new TheListError(selector, cause);
 
 export const connection = (address: URL, cause: SystemError): ToJSON<ConnectionError> =>
   new TheConnectionError(address.href, cause);
@@ -89,6 +96,28 @@ export class TheQueryError extends Error implements QueryError {
       stack: this.stack ?? "",
       message: this.message,
       selector: this.selector,
+      cause: {
+        name: this.cause.name,
+        code: this.cause.code,
+        message: this.cause.message,
+        stack: this.cause.stack ?? "",
+      },
+    };
+  }
+}
+
+export class TheListError extends Error implements ListError {
+  override name = "ListError" as const;
+  constructor(public query: { the: string; in: ReplicaID }, public override cause: SystemError) {
+    const { the } = query;
+    super(`List query ${JSON.stringify({ the })} in ${query.in} failed: ${cause.message}`);
+  }
+  toJSON(): ListError {
+    return {
+      name: this.name,
+      stack: this.stack ?? "",
+      message: this.message,
+      query: this.query,
       cause: {
         name: this.cause.name,
         code: this.cause.code,

--- a/typescript/packages/common-memory/interface.ts
+++ b/typescript/packages/common-memory/interface.ts
@@ -232,7 +232,7 @@ export interface QueryError extends Error {
 export interface ListError extends Error {
   name: "ListError";
   cause: SystemError;
-  query: { the: The, in: ReplicaID };
+  selector: { in: ReplicaID; the?: string; of?: string };
 }
 
 /**

--- a/typescript/packages/common-memory/interface.ts
+++ b/typescript/packages/common-memory/interface.ts
@@ -229,6 +229,12 @@ export interface QueryError extends Error {
   selector: Selector & { in: ReplicaID };
 }
 
+export interface ListError extends Error {
+  name: "ListError";
+  cause: SystemError;
+  query: { the: The, in: ReplicaID };
+}
+
 /**
  * Utility type for defining a [keyed union] type as in IPLD Schema. In practice
  * this just works around typescript limitation that requires discriminant field

--- a/typescript/packages/common-memory/lib.ts
+++ b/typescript/packages/common-memory/lib.ts
@@ -87,9 +87,8 @@ export const subscribe = (session: MemoryServiceSession, socket: WebSocket) => {
 
   return pipeToSocket(subscription.stream, socket);
 };
-export const get = async (session: MemoryServiceSession, request: Request, path: string) => {
-  console.log("GET", path);
-  let result;
+
+export const get = async (session: MemoryServiceSession, _request: Request, path: string) => {
   const parts = path.split("/").filter(Boolean);
   const replicaName = parts[0];
 
@@ -110,26 +109,22 @@ export const get = async (session: MemoryServiceSession, request: Request, path:
     );
   }
 
-  if (parts.length <= 1) {
-    console.log("LIST");
-    result = await session.router.list({
-      [replicaName]: {
-        the: "application/json",
-      },
-    });
-  } else {
-    result = await session.router.query({
-      [replicaName]: {
-        the: "application/json",
-        of: parts.slice(1).join("/"),
-      },
-    });
-  }
-  const body = JSON.stringify(result);
-  const status = result.ok ? 200 : 500;
+  const result =
+    parts.length <= 1
+      ? await session.router.list({
+          [replicaName]: {
+            the: "application/json",
+          },
+        })
+      : await session.router.query({
+          [replicaName]: {
+            the: "application/json",
+            of: parts.slice(1).join("/"),
+          },
+        });
 
-  return new Response(body, {
-    status,
+  return new Response(JSON.stringify(result), {
+    status: result.ok ? 200 : 500,
     headers: {
       "Content-Type": "application/json",
     },

--- a/typescript/packages/common-memory/router.ts
+++ b/typescript/packages/common-memory/router.ts
@@ -99,7 +99,7 @@ export const query = async (
 
 export const list = async (
   session: Model,
-  queries: In<{ the: string }>,
+  queries: In<Partial<Selector>>,
 ): AsyncResult<ListResult[], ListError | ConnectionError> => {
   const [[route, query]] = Object.entries(queries);
   const { ok: replica, error } = await resolve(session, route);
@@ -107,7 +107,7 @@ export const list = async (
     return { error };
   }
 
-  return replica.list(query.the);
+  return replica.list(query);
 };
 
 export const watch = async (

--- a/typescript/packages/common-memory/router.ts
+++ b/typescript/packages/common-memory/router.ts
@@ -27,6 +27,7 @@ export interface Session {
   ): AsyncResult<Fact, ConflictError | TransactionError | ConnectionError>;
 
   query(selector: In<Selector>): AsyncResult<Fact | Unclaimed, QueryError | ConnectionError>;
+  list(query: In<{ the: string }>): AsyncResult<ListResult[], ListError | ConnectionError>;
 
   subscribe(address: In<Selector>): Subscription.Subscription;
 

--- a/typescript/packages/common-memory/router.ts
+++ b/typescript/packages/common-memory/router.ts
@@ -16,7 +16,9 @@ import {
   TransactionError,
   ConnectionError,
   SystemError,
+  ListError,
 } from "./interface.ts";
+import { ListResult } from "./store.ts";
 export * from "./interface.ts";
 
 export interface Session {
@@ -61,6 +63,10 @@ export class Router implements Session {
     return query(this, selector);
   }
 
+  list(query: In<{ the: string }>) {
+    return list(this, query);
+  }
+
   watch(selector: In<Selector>, subscriber: Subscription.Subscriber) {
     return watch(this, selector, subscriber);
   }
@@ -86,6 +92,19 @@ export const query = async (
     return { error };
   }
   return replica.query(selector);
+};
+
+export const list = async (
+  session: Model,
+  queries: In<{ the: string }>,
+): AsyncResult<ListResult[], ListError | ConnectionError> => {
+  const [[route, query]] = Object.entries(queries);
+  const { ok: replica, error } = await resolve(session, route);
+  if (error) {
+    return { error };
+  }
+
+  return replica.list(query.the);
 };
 
 export const watch = async (

--- a/typescript/packages/common-memory/test/router-test.ts
+++ b/typescript/packages/common-memory/test/router-test.ts
@@ -6,11 +6,7 @@ const alice = "did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi";
 const bob = "did:key:z6MkffDZCkCTWreg8868fG1FGFogcJj5X6PY93pPcWDn9bob";
 const doc = "4301a667-5388-4477-ba08-d2e6b51a62a3";
 
-const test = (
-  title: string,
-  url: URL,
-  run: (replica: Router.Session) => Promise<unknown>,
-) => {
+const test = (title: string, url: URL, run: (replica: Router.Session) => Promise<unknown>) => {
   const unit = async () => {
     const open = await Router.open({
       store: url,
@@ -37,7 +33,7 @@ const test = (
 
 const memory = new URL(`memory://`);
 
-test("query non-existing", memory, async session => {
+test("query non-existing", memory, async (session) => {
   const unclaimed = await session.query({
     [alice]: {
       the: "application/json",
@@ -57,7 +53,7 @@ test("query non-existing", memory, async session => {
   );
 });
 
-test("create new memory", memory, async session => {
+test("create new memory", memory, async (session) => {
   const v1 = {
     the: "application/json",
     of: doc,
@@ -115,7 +111,7 @@ test("create new memory", memory, async session => {
   );
 });
 
-test("create memory fails if already exists", memory, async session => {
+test("create memory fails if already exists", memory, async (session) => {
   const create = await session.transact({
     [alice]: {
       assert: {
@@ -158,12 +154,16 @@ test("create memory fails if already exists", memory, async session => {
 
 test("list empty memory", memory, async (session) => {
   const result = await session.list({
-    [alice]: { the: "application/json" }
+    [alice]: { the: "application/json" },
   });
 
-  assertEquals(result, {
-    ok: [],
-  }, "empty list when no facts exist");
+  assertEquals(
+    result,
+    {
+      ok: [],
+    },
+    "empty list when no facts exist",
+  );
 });
 
 test("list single fact", memory, async (session) => {
@@ -179,17 +179,21 @@ test("list single fact", memory, async (session) => {
   });
 
   const result = await session.list({
-    [alice]: { the: "application/json" }
+    [alice]: { the: "application/json" },
   });
 
-  assertEquals(result, {
-    ok: [
-      {
-        of: doc,
-        is: { v: 1 },
-      },
-    ],
-  }, "lists single fact");
+  assertEquals(
+    result,
+    {
+      ok: [
+        {
+          of: doc,
+          is: { v: 1 },
+        },
+      ],
+    },
+    "lists single fact",
+  );
 });
 
 test("list multiple facts", memory, async (session) => {
@@ -217,24 +221,28 @@ test("list multiple facts", memory, async (session) => {
   });
 
   const result = await session.list({
-    [alice]: { the: "application/json" }
+    [alice]: { the: "application/json" },
   });
 
-  assertEquals(result, {
-    ok: [
-      {
-        of: doc,
-        is: { v: 1 },
-      },
-      {
-        of: doc2,
-        is: { v: 2 },
-      },
-    ],
-  }, "lists multiple facts");
+  assertEquals(
+    result,
+    {
+      ok: [
+        {
+          of: doc,
+          is: { v: 1 },
+        },
+        {
+          of: doc2,
+          is: { v: 2 },
+        },
+      ],
+    },
+    "lists multiple facts",
+  );
 });
 
-test("list includes retracted facts", memory, async (session) => {
+test("list excludes retracted facts", memory, async (session) => {
   // First create and then retract a fact
   await session.transact({
     [alice]: {
@@ -246,12 +254,14 @@ test("list includes retracted facts", memory, async (session) => {
     },
   });
 
-  const fact = (await session.query({
-    [alice]: {
-      the: "application/json",
-      of: doc,
-    },
-  })).ok;
+  const fact = (
+    await session.query({
+      [alice]: {
+        the: "application/json",
+        of: doc,
+      },
+    })
+  ).ok;
 
   await session.transact({
     [alice]: {
@@ -260,17 +270,16 @@ test("list includes retracted facts", memory, async (session) => {
   });
 
   const result = await session.list({
-    [alice]: { the: "application/json" }
+    [alice]: { the: "application/json" },
   });
 
-  assertEquals(result, {
-    ok: [
-      {
-        of: doc,
-        is: undefined,
-      },
-    ],
-  }, "includes retracted facts with undefined value");
+  assertEquals(
+    result,
+    {
+      ok: [],
+    },
+    "excludes retracted facts with undefined value",
+  );
 });
 
 test("list different fact types", memory, async (session) => {
@@ -296,30 +305,38 @@ test("list different fact types", memory, async (session) => {
   });
 
   const jsonResult = await session.list({
-    [alice]: { the: "application/json" }
+    [alice]: { the: "application/json" },
   });
 
   const textResult = await session.list({
-    [alice]: { the: "text/plain" }
+    [alice]: { the: "text/plain" },
   });
 
-  assertEquals(jsonResult, {
-    ok: [
-      {
-        of: doc,
-        is: { v: 1 },
-      },
-    ],
-  }, "lists json facts");
+  assertEquals(
+    jsonResult,
+    {
+      ok: [
+        {
+          of: doc,
+          is: { v: 1 },
+        },
+      ],
+    },
+    "lists json facts",
+  );
 
-  assertEquals(textResult, {
-    ok: [
-      {
-        of: doc,
-        is: "Hello",
-      },
-    ],
-  }, "lists text facts");
+  assertEquals(
+    textResult,
+    {
+      ok: [
+        {
+          of: doc,
+          is: "Hello",
+        },
+      ],
+    },
+    "lists text facts",
+  );
 });
 
 test("list facts from different replicas", memory, async (session) => {
@@ -345,35 +362,43 @@ test("list facts from different replicas", memory, async (session) => {
   });
 
   const aliceResult = await session.list({
-    [alice]: { the: "application/json" }
+    [alice]: { the: "application/json" },
   });
 
   const bobResult = await session.list({
-    [bob]: { the: "application/json" }
+    [bob]: { the: "application/json" },
   });
 
-  assertEquals(aliceResult, {
-    ok: [
-      {
-        of: doc,
-        is: { v: 1 },
-      },
-    ],
-  }, "lists alice's facts");
+  assertEquals(
+    aliceResult,
+    {
+      ok: [
+        {
+          of: doc,
+          is: { v: 1 },
+        },
+      ],
+    },
+    "lists alice's facts",
+  );
 
-  assertEquals(bobResult, {
-    ok: [
-      {
-        of: doc,
-        is: { v: 2 },
-      },
-    ],
-  }, "lists bob's facts");
+  assertEquals(
+    bobResult,
+    {
+      ok: [
+        {
+          of: doc,
+          is: { v: 2 },
+        },
+      ],
+    },
+    "lists bob's facts",
+  );
 });
 
 test("list from non-existent replica", memory, async (session) => {
   const result = await session.list({
-    [alice]: { the: "application/json" }
+    [alice]: { the: "application/json" },
   });
   assertEquals(result, { ok: [] }, "empty list from new replica");
 });
@@ -386,8 +411,8 @@ test("list from multiple replicas", memory, async (session) => {
         the: "application/json",
         of: doc,
         is: { v: 1 },
-      }
-    }
+      },
+    },
   });
 
   await session.transact({
@@ -396,23 +421,31 @@ test("list from multiple replicas", memory, async (session) => {
         the: "application/json",
         of: doc,
         is: { v: 2 },
-      }
-    }
+      },
+    },
   });
 
   const aliceResult = await session.list({
-    [alice]: { the: "application/json" }
+    [alice]: { the: "application/json" },
   });
 
   const bobResult = await session.list({
-    [bob]: { the: "application/json" }
+    [bob]: { the: "application/json" },
   });
 
-  assertEquals(aliceResult, {
-    ok: [{ of: doc, is: { v: 1 } }]
-  }, "lists alice's facts");
+  assertEquals(
+    aliceResult,
+    {
+      ok: [{ of: doc, is: { v: 1 } }],
+    },
+    "lists alice's facts",
+  );
 
-  assertEquals(bobResult, {
-    ok: [{ of: doc, is: { v: 2 } }]
-  }, "lists bob's facts");
+  assertEquals(
+    bobResult,
+    {
+      ok: [{ of: doc, is: { v: 2 } }],
+    },
+    "lists bob's facts",
+  );
 });

--- a/typescript/packages/common-memory/test/router-test.ts
+++ b/typescript/packages/common-memory/test/router-test.ts
@@ -153,7 +153,7 @@ test("create memory fails if already exists", memory, async (session) => {
 // List tests
 
 test("list empty memory", memory, async (session) => {
-  const result = await session.list({
+  const result = await session.query({
     [alice]: { the: "application/json" },
   });
 
@@ -178,7 +178,7 @@ test("list single fact", memory, async (session) => {
     },
   });
 
-  const result = await session.list({
+  const result = await session.query({
     [alice]: { the: "application/json" },
   });
 
@@ -189,6 +189,7 @@ test("list single fact", memory, async (session) => {
         {
           of: doc,
           is: { v: 1 },
+          the: "application/json",
         },
       ],
     },
@@ -220,7 +221,7 @@ test("list multiple facts", memory, async (session) => {
     },
   });
 
-  const result = await session.list({
+  const result = await session.query({
     [alice]: { the: "application/json" },
   });
 
@@ -231,10 +232,12 @@ test("list multiple facts", memory, async (session) => {
         {
           of: doc,
           is: { v: 1 },
+          the: "application/json",
         },
         {
           of: doc2,
           is: { v: 2 },
+          the: "application/json",
         },
       ],
     },
@@ -269,7 +272,7 @@ test("list excludes retracted facts", memory, async (session) => {
     },
   });
 
-  const result = await session.list({
+  const result = await session.query({
     [alice]: { the: "application/json" },
   });
 
@@ -304,11 +307,11 @@ test("list different fact types", memory, async (session) => {
     },
   });
 
-  const jsonResult = await session.list({
+  const jsonResult = await session.query({
     [alice]: { the: "application/json" },
   });
 
-  const textResult = await session.list({
+  const textResult = await session.query({
     [alice]: { the: "text/plain" },
   });
 
@@ -319,6 +322,7 @@ test("list different fact types", memory, async (session) => {
         {
           of: doc,
           is: { v: 1 },
+          the: "application/json",
         },
       ],
     },
@@ -332,6 +336,7 @@ test("list different fact types", memory, async (session) => {
         {
           of: doc,
           is: "Hello",
+          the: "text/plain",
         },
       ],
     },
@@ -361,11 +366,11 @@ test("list facts from different replicas", memory, async (session) => {
     },
   });
 
-  const aliceResult = await session.list({
+  const aliceResult = await session.query({
     [alice]: { the: "application/json" },
   });
 
-  const bobResult = await session.list({
+  const bobResult = await session.query({
     [bob]: { the: "application/json" },
   });
 
@@ -376,6 +381,7 @@ test("list facts from different replicas", memory, async (session) => {
         {
           of: doc,
           is: { v: 1 },
+          the: "application/json",
         },
       ],
     },
@@ -389,6 +395,7 @@ test("list facts from different replicas", memory, async (session) => {
         {
           of: doc,
           is: { v: 2 },
+          the: "application/json",
         },
       ],
     },
@@ -397,7 +404,7 @@ test("list facts from different replicas", memory, async (session) => {
 });
 
 test("list from non-existent replica", memory, async (session) => {
-  const result = await session.list({
+  const result = await session.query({
     [alice]: { the: "application/json" },
   });
   assertEquals(result, { ok: [] }, "empty list from new replica");
@@ -425,18 +432,18 @@ test("list from multiple replicas", memory, async (session) => {
     },
   });
 
-  const aliceResult = await session.list({
+  const aliceResult = await session.query({
     [alice]: { the: "application/json" },
   });
 
-  const bobResult = await session.list({
+  const bobResult = await session.query({
     [bob]: { the: "application/json" },
   });
 
   assertEquals(
     aliceResult,
     {
-      ok: [{ of: doc, is: { v: 1 } }],
+      ok: [{ of: doc, is: { v: 1 }, the: "application/json" }],
     },
     "lists alice's facts",
   );
@@ -444,7 +451,7 @@ test("list from multiple replicas", memory, async (session) => {
   assertEquals(
     bobResult,
     {
-      ok: [{ of: doc, is: { v: 2 } }],
+      ok: [{ of: doc, is: { v: 2 }, the: "application/json" }],
     },
     "lists bob's facts",
   );

--- a/typescript/packages/common-memory/test/store-test.ts
+++ b/typescript/packages/common-memory/test/store-test.ts
@@ -647,12 +647,12 @@ Deno.test("open creates replica if does not exists", async () => {
 });
 
 test("list empty store", new URL(`memory:${alice}`), async (session) => {
-  const result = await session.list("application/json");
+  const result = session.list("application/json");
   assertEquals(result, { ok: [] }, "empty list when no facts exist");
 });
 
 test("list single fact", new URL(`memory:${alice}`), async (session) => {
-  await session.transact({
+  session.transact({
     assert: {
       the: "application/json",
       of: doc,
@@ -660,7 +660,7 @@ test("list single fact", new URL(`memory:${alice}`), async (session) => {
     },
   });
 
-  const result = await session.list("application/json");
+  const result = session.list("application/json");
   assertEquals(result, {
     ok: [
       {

--- a/typescript/packages/common-memory/test/store-test.ts
+++ b/typescript/packages/common-memory/test/store-test.ts
@@ -666,12 +666,12 @@ test("list single fact", new URL(`memory:${alice}`), async (session) => {
       {
         of: doc,
         is: { v: 1 },
-      }
-    ]
+      },
+    ],
   });
 });
 
-test("list includes retracted facts", new URL(`memory:${alice}`), async (session) => {
+test("list excludes retracted facts", new URL(`memory:${alice}`), async (session) => {
   // Create and then retract a fact
   const fact = session.transact({
     assert: {
@@ -686,11 +686,6 @@ test("list includes retracted facts", new URL(`memory:${alice}`), async (session
 
   const result = session.list("application/json");
   assertEquals(result, {
-    ok: [
-      {
-        of: doc,
-        is: undefined,
-      }
-    ]
+    ok: [],
   });
 });

--- a/typescript/packages/common-memory/test/store-test.ts
+++ b/typescript/packages/common-memory/test/store-test.ts
@@ -660,12 +660,13 @@ test("list single fact", new URL(`memory:${alice}`), async (session) => {
     },
   });
 
-  const result = session.list("application/json");
+  const result = session.list({ the: "application/json" });
   assertEquals(result, {
     ok: [
       {
         of: doc,
         is: { v: 1 },
+        the: "application/json",
       },
     ],
   });
@@ -684,7 +685,7 @@ test("list excludes retracted facts", new URL(`memory:${alice}`), async (session
   assert(fact.ok);
   session.transact({ retract: fact.ok });
 
-  const result = session.list("application/json");
+  const result = session.list({ the: "application/json" });
   assertEquals(result, {
     ok: [],
   });

--- a/typescript/packages/common-memory/test/store-test.ts
+++ b/typescript/packages/common-memory/test/store-test.ts
@@ -645,3 +645,52 @@ Deno.test("open creates replica if does not exists", async () => {
     await Deno.remove(url);
   }
 });
+
+test("list empty store", new URL(`memory:${alice}`), async (session) => {
+  const result = await session.list("application/json");
+  assertEquals(result, { ok: [] }, "empty list when no facts exist");
+});
+
+test("list single fact", new URL(`memory:${alice}`), async (session) => {
+  await session.transact({
+    assert: {
+      the: "application/json",
+      of: doc,
+      is: { v: 1 },
+    },
+  });
+
+  const result = await session.list("application/json");
+  assertEquals(result, {
+    ok: [
+      {
+        of: doc,
+        is: { v: 1 },
+      }
+    ]
+  });
+});
+
+test("list includes retracted facts", new URL(`memory:${alice}`), async (session) => {
+  // Create and then retract a fact
+  const fact = session.transact({
+    assert: {
+      the: "application/json",
+      of: doc,
+      is: { v: 1 },
+    },
+  });
+
+  assert(fact.ok);
+  session.transact({ retract: fact.ok });
+
+  const result = session.list("application/json");
+  assertEquals(result, {
+    ok: [
+      {
+        of: doc,
+        is: undefined,
+      }
+    ]
+  });
+});

--- a/typescript/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/typescript/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -21,3 +21,7 @@ export const subscribe: AppRouteHandler<typeof Routes.subscribe> = (c) => {
   memory.subscribe(socket);
   return response;
 };
+
+export const query: AppRouteHandler<typeof Routes.query> = (c) =>
+  // @ts-expect-error - Same reason as transact handler
+  memory.query(c.req);

--- a/typescript/packages/toolshed/routes/storage/memory/memory.index.ts
+++ b/typescript/packages/toolshed/routes/storage/memory/memory.index.ts
@@ -7,6 +7,7 @@ const router = createRouter();
 
 const Router = router
   .openapi(routes.transact, handlers.transact)
-  .openapi(routes.subscribe, handlers.subscribe);
+  .openapi(routes.subscribe, handlers.subscribe)
+  .openapi(routes.query, handlers.query);
 
 export default Router;

--- a/typescript/packages/toolshed/routes/storage/memory/memory.routes.ts
+++ b/typescript/packages/toolshed/routes/storage/memory/memory.routes.ts
@@ -53,3 +53,35 @@ export const subscribe = createRoute({
     },
   },
 });
+
+export const query = createRoute({
+  method: "post",
+  path: "/api/storage/memory",
+  tags,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.record(z.object({
+            the: z.any().optional(),
+            of: z.any().optional(),
+          })),
+        },
+      },
+    },
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      z.array(z.any()),
+      "Matching records found",
+    ),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      z.array(z.any()),
+      "No matching records found",
+    ),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      z.object({}),
+      "Storage error",
+    ),
+  },
+});


### PR DESCRIPTION
Introduces a new capability to list memories or get by `the`.

This PR introduces a GET handler for `/:replica/[:the]`, if `the` is omitted all the memories are listed by querying the `state` view in SQLite.

Includes tests but we may want to adjust the actual behaviour of the implementation around retracted items. 