### PR TITLE
Toolshed common-memory cleanup

### DIFF
--- a/typescript/packages/common-memory/deno.json
+++ b/typescript/packages/common-memory/deno.json
@@ -4,9 +4,7 @@
     "test": "deno test --allow-read --allow-write --allow-net --allow-ffi --allow-env --no-check"
   },
   "test": {
-    "include": [
-      "test/*-test.ts"
-    ]
+    "include": ["test/*-test.ts"]
   },
   "exports": {
     ".": "./lib.ts"


### PR DESCRIPTION
This pull request teases apart some of the inter-mingling of concerns in `toolshed` and `common-memory`, to fix a bug found in sentry https://github.com/commontoolsinc/labs/issues/316

When exposed in `toolshed`, the `common-memory` code runs into issues with duplicate request body / json parsing.

To fix this bug, and to not run the entire http processing stack twice, I think we should move all of the http handling concerns for the `/api/storage/memory` endpoint up into the `toolshed` hono app; and update `common-memory` to expose non-http-handling functions for `query`, and `patch`.

Some background on the bug: The `toolshed` hono api has openapi request schema validation. The first thing that happens to a request is that it is parsed and validated. This happens to read the request body stream when running `await request.json()`, and then later inside our `toolshed` handler, we're passing that request object through to `memory.patch(c.req)`-- which in turn is running another `await request.json()`. This is problematic, because you can only read the request body stream once; so the `common-memory` code was crashing/erroring.

---

Some other things to consider:

* it's kind of weird that we're maintaining 2 http interfaces; one in `common-memory`, and one in `toolshed`, does it make sense to [kill `deno.ts` in `common-memory`](https://github.com/commontoolsinc/labs/blob/main/typescript/packages/common-memory/deno.ts)? 
* still need to add tests