### PR TITLE
chore: Explicitly define the top-level origin for CSP

### DIFF
--- a/typescript/packages/common-iframe-sandbox/src/csp.ts
+++ b/typescript/packages/common-iframe-sandbox/src/csp.ts
@@ -3,6 +3,11 @@ const SCRIPT_CDNS = [
   'https://cdn.tailwindcss.com'
 ];
 
+// In Chromium browsers, "'self'" selects the top frame origin from
+// null origins. In Firefox this does not apply. Instead, use
+// the top frame origin explicitly.
+export const HOST_ORIGIN = new URL(window.location.href).origin;
+
 // This CSP directive uses 'unsafe-inline' to allow
 // origin-less styles and scripts to be used, defeating
 // many traditional uses of CSP.
@@ -11,11 +16,11 @@ export const CSP = `` +
   // each specific fetch directive as needed.
   `default-src 'none';` +
   // Scripts: Allow 1P, inline, and CDNs.
-  `script-src 'self' 'unsafe-inline' ${SCRIPT_CDNS.join(' ')};` +
+  `script-src ${HOST_ORIGIN} 'unsafe-inline' ${SCRIPT_CDNS.join(' ')};` +
   // Styles: Allow 1P, inline.
-  `style-src 'self' 'unsafe-inline';` +
+  `style-src ${HOST_ORIGIN} 'unsafe-inline';` +
   // Images: Allow 1P, inline.
-  `img-src 'self' 'unsafe-inline';` +
+  `img-src ${HOST_ORIGIN} 'unsafe-inline';` +
   // Disabling until we have a concrete case.
   `form-action 'none';` +
   // Disable <base> element

--- a/typescript/packages/common-iframe-sandbox/src/outer-frame.ts
+++ b/typescript/packages/common-iframe-sandbox/src/outer-frame.ts
@@ -1,6 +1,4 @@
-import { CSP } from './csp.js';
-
-const HOST_ORIGIN = new URL(window.location.href).origin;
+import { CSP, HOST_ORIGIN } from './csp.js';
 
 export default `
 <!DOCTYPE html>

--- a/typescript/packages/common-iframe-sandbox/test/iframe-csp.test.js
+++ b/typescript/packages/common-iframe-sandbox/test/iframe-csp.test.js
@@ -71,6 +71,14 @@ describe("common-iframe CSP", () => {
     `<script>fetch("${ORIGIN_URL}/foo.js")</script>`,
     null,
   ], [
+    "allows 1P img",
+    `<img src="${ORIGIN_URL}/foo.jpg" />`,
+    null,
+  ], [
+    "allows 1P CSS",
+    `<link rel="stylesheet" href="${ORIGIN_URL}/styles.css">`,
+    null,
+  ], [
     "disallows opening windows (_blank)",
     openWindow("_blank"),
     null,


### PR DESCRIPTION
Explicitly define the top-level origin for CSP, as 'self' is interpreted differently in browsers in nested, sandboxed iframes. In Firefox, "self" doesn't appear to select any origins in a sandboxed iframe (null origin).