### PR TITLE
Potential fix for issue #380

### DIFF
--- a/typescript/packages/jumble/src/contexts/CharmManagerContext.tsx
+++ b/typescript/packages/jumble/src/contexts/CharmManagerContext.tsx
@@ -1,7 +1,6 @@
-import React, { createContext, useContext } from "react";
-import { CharmManager } from "@commontools/charm";
+import React, { createContext, useContext, useMemo } from "react";
+import { CharmManager, createStorage } from "@commontools/charm";
 import { useParams } from "react-router-dom";
-import { createStorage } from "@commontools/charm";
 
 export type CharmManagerContextType = {
   charmManager: CharmManager;
@@ -14,25 +13,18 @@ export const CharmsManagerProvider: React.FC<{ children: React.ReactNode }> = ({
   const { replicaName } = useParams<{ replicaName: string }>();
   const effectiveReplica = replicaName || "common-knowledge";
 
-  // NOTE(ja): disable switching replicas until
-  // https://github.com/commontoolsinc/labs/issues/377 is fixed
-  // const [charmManager, setCharmManager] = useState<CharmManager>(defaultManager);
-  // const previousReplicaRef = useRef<string | undefined>();
-
-  // useEffect(() => {
-  //   if (previousReplicaRef.current === effectiveReplica) {
-  //     return;
-  //   }
-  //   previousReplicaRef.current = effectiveReplica;
-
-  // Create new charm manager instance with updated replica
-  const storageType = (import.meta as any).env.VITE_STORAGE_TYPE ?? "remote";
-  const storage = storageType === "remote" ?
-    createStorage({ type: "remote", replica: effectiveReplica, url: new URL(location.href) }) :
-    createStorage({ type: storageType as "memory" | "local" });
-  const charmManager = new CharmManager(storage);
-  // setCharmManager(manager);
-  // }, [effectiveReplica]);
+  const charmManager = useMemo(() => {
+    const storageType = (import.meta as any).env.VITE_STORAGE_TYPE ?? "remote";
+    const storage =
+      storageType === "remote"
+        ? createStorage({
+            type: "remote",
+            replica: effectiveReplica,
+            url: new URL(location.href),
+          })
+        : createStorage({ type: storageType as "memory" | "local" });
+    return new CharmManager(storage);
+  }, [effectiveReplica]);
 
   return (
     <CharmManagerContext.Provider value={{ charmManager, currentReplica: effectiveReplica }}>


### PR DESCRIPTION
I'm running out of steam, but was hoping to get this fixed before I left for the day. After working through this with o3-mini, I think this might be a reasonable fix.

In the breaking commit, the removal of the `useEffect` (and the associated state/references) in `CharmManagerContext.tsx` meant that a new instance of the `CharmManager` was being created on every render rather than only when the `effectiveReplica` changed.

By wrapping the creation of the `CharmManager` in a `useMemo` that depends on `effectiveReplica`, the code ensures that the same instance is used across renders unless the effective replica actually changes.