### PR TITLE
Background Jobs + Basic Charm Indexer

### DIFF
--- a/typescript/packages/jumble/src/components/TranscribeCommand.tsx
+++ b/typescript/packages/jumble/src/components/TranscribeCommand.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useAudioRecorder } from '@/hooks/use-audio-recorder';
 import { CommandContext, CommandItem } from './commands';
+import { DitheredCube } from './DitherCube';
 
 interface TranscribeInputProps {
   mode: { command: CommandItem; placeholder: string };
@@ -46,11 +47,14 @@ export function TranscribeInput({ mode, context }: TranscribeInputProps) {
 
   return (
     <div className="flex items-center justify-center p-2 gap-2">
-      <span className="text-sm text-red-500 animate-pulse">
+      <span className={`text-sm ${isRecording ? 'text-red-500 animate-pulse' : ''}`}>
         {isRecording ? (
           <>🎤 Recording... {recordingSeconds}s</>
         ) : isTranscribing ? (
-          <>✍️ Transcribing...</>
+          <div className="flex items-center gap-2">
+            <DitheredCube width={24} height={24} animate animationSpeed={2} cameraZoom={12} />
+            <span>Transcribing...</span>
+          </div>
         ) : null}
       </span>
       {isRecording && (

--- a/typescript/packages/jumble/src/components/commands.ts
+++ b/typescript/packages/jumble/src/components/commands.ts
@@ -1,4 +1,3 @@
-import { Command } from "cmdk";
 import "./commands.css";
 import { castNewRecipe, Charm, CharmManager, compileAndRunRecipe } from "@commontools/charm";
 import { NavigateFunction } from "react-router-dom";
@@ -25,16 +24,19 @@ export interface CommandItem {
   predicate?: boolean; // Can be computed value instead of function
 }
 
-export function getTitle(title: string | ((context: CommandContext) => string), context: CommandContext): string {
-  return typeof title === 'function' ? title(context) : title;
+export function getTitle(
+  title: string | ((context: CommandContext) => string),
+  context: CommandContext,
+): string {
+  return typeof title === "function" ? title(context) : title;
 }
 
 export function getChildren(
   children: CommandItem[] | ((context: CommandContext) => CommandItem[]) | undefined,
-  context: CommandContext
+  context: CommandContext,
 ): CommandItem[] {
   if (!children) return [];
-  return typeof children === 'function' ? children(context) : children;
+  return typeof children === "function" ? children(context) : children;
 }
 
 export interface CommandContext {
@@ -121,7 +123,7 @@ async function handleSearchCharms(deps: CommandContext) {
     const results = await Promise.all(
       charms.map(async (charm) => {
         const data = charm.cell.get();
-        const title = data?.[NAME] ?? 'Untitled';
+        const title = data?.[NAME] ?? "Untitled";
         return {
           title: title + ` (#${charmId(charm.cell.entityId!).slice(-4)})`,
           id: charmId(charm.cell.entityId!),
@@ -248,16 +250,16 @@ async function handleStartCounterJob(deps: CommandContext) {
   console.log("Started counter job with ID:", jobId);
 
   const interval = setInterval(() => {
-    const job = deps.listJobs().find(j => j.id === jobId);
+    const job = deps.listJobs().find((j) => j.id === jobId);
     console.log("Current job state:", job);
 
-    if (!job || job.status !== 'running') {
+    if (!job || job.status !== "running") {
       console.log("Job stopped or not found, clearing interval");
       clearInterval(interval);
       return;
     }
 
-    const currentCount = parseInt(job.messages[job.messages.length - 1]?.split(': ')[1] || '0');
+    const currentCount = parseInt(job.messages[job.messages.length - 1]?.split(": ")[1] || "0");
     const newCount = currentCount + 1;
     console.log("Updating count from", currentCount, "to", newCount);
 
@@ -380,254 +382,263 @@ async function handleIndexCharms(deps: CommandContext) {
 }
 
 export function getCommands(deps: CommandContext): CommandItem[] {
-  return [{
-    id: "new-charm",
-    type: "input",
-    title: "New Charm",
-    group: "Create",
-    handler: (input) => handleNewCharm(deps, input),
-  },
-  {
-    id: "search-charms",
-    type: "action",
-    title: "Search Charms",
-    group: "Navigation",
-    handler: () => handleSearchCharms(deps),
-  },
-  {
-    id: "spellcaster",
-    type: "input",
-    title: "Spellcaster",
-    group: "Create",
-    predicate: !!deps.focusedReplicaId,
-    handler: (input) => handleSpellcaster(deps, input),
-  },
-  {
-    id: "edit-recipe",
-    type: "input",
-    title: `Iterate${deps.preferredModel ? ` (${deps.preferredModel})` : ""}`,
-    group: "Edit",
-    predicate: !!deps.focusedCharmId,
-    placeholder: "What would you like to change?",
-    handler: (input) => handleEditRecipe(deps, input),
-  },
-  {
-    id: "delete-charm",
-    type: "confirm",
-    title: "Delete Charm",
-    group: "Edit",
-    predicate: !!deps.focusedCharmId,
-    message: "Are you sure you want to delete this charm?",
-    handler: () => handleDeleteCharm(deps),
-  },
-  {
-    id: "view-detail",
-    type: "action",
-    title: "View Detail",
-    group: "View",
-    predicate: !!deps.focusedCharmId,
-    handler: () => {
-      if (!deps.focusedCharmId) {
-        deps.setOpen(false);
-        return;
-      }
-      deps.navigate(`/${deps.focusedReplicaId}/${deps.focusedCharmId}/detail`);
-      deps.setOpen(false);
+  return [
+    {
+      id: "new-charm",
+      type: "input",
+      title: "New Charm",
+      group: "Create",
+      handler: (input) => handleNewCharm(deps, input),
     },
-  },
-  {
-    id: "edit-code",
-    type: "action",
-    title: "Edit Code",
-    group: "View",
-    predicate: !!deps.focusedCharmId,
-    handler: () => {
-      if (!deps.focusedCharmId) {
-        deps.setOpen(false);
-        return;
-      }
-      deps.navigate(`/${deps.focusedReplicaId}/${deps.focusedCharmId}/detail#code`);
-      deps.setOpen(false);
+    {
+      id: "search-charms",
+      type: "action",
+      title: "Search Charms",
+      group: "Navigation",
+      handler: () => handleSearchCharms(deps),
     },
-  },
-  {
-    id: "view-data",
-    type: "action",
-    title: "View Backing Data",
-    group: "View",
-    predicate: !!deps.focusedCharmId,
-    handler: () => {
-      if (!deps.focusedCharmId) {
-        deps.setOpen(false);
-        return;
-      }
-      deps.navigate(`/${deps.focusedReplicaId}/${deps.focusedCharmId}/detail#data`);
-      deps.setOpen(false);
+    {
+      id: "spellcaster",
+      type: "input",
+      title: "Spellcaster",
+      group: "Create",
+      predicate: !!deps.focusedReplicaId,
+      handler: (input) => handleSpellcaster(deps, input),
     },
-  },
-  {
-    id: "view-charm",
-    type: "action",
-    title: "View Charm",
-    group: "View",
-    predicate: !!deps.focusedCharmId,
-    handler: () => {
-      if (!deps.focusedCharmId) {
-        deps.setOpen(false);
-        return;
-      }
-      deps.navigate(`/${deps.focusedReplicaId}/${deps.focusedCharmId}`);
-      deps.setOpen(false);
+    {
+      id: "edit-recipe",
+      type: "input",
+      title: `Iterate${deps.preferredModel ? ` (${deps.preferredModel})` : ""}`,
+      group: "Edit",
+      predicate: !!deps.focusedCharmId,
+      placeholder: "What would you like to change?",
+      handler: (input) => handleEditRecipe(deps, input),
     },
-  },
-  {
-    id: "back",
-    type: "action",
-    title: "Navigate Back",
-    group: "Navigation",
-    handler: () => {
-      window.history.back();
-      deps.setOpen(false);
+    {
+      id: "delete-charm",
+      type: "confirm",
+      title: "Delete Charm",
+      group: "Edit",
+      predicate: !!deps.focusedCharmId,
+      message: "Are you sure you want to delete this charm?",
+      handler: () => handleDeleteCharm(deps),
     },
-  },
-  {
-    id: "home",
-    type: "action",
-    title: "Navigate Home",
-    group: "Navigation",
-    predicate: !!deps.focusedReplicaId,
-    handler: () => {
-      if (deps.focusedReplicaId) {
-        deps.navigate(`/${deps.focusedReplicaId}`);
-      }
-      deps.setOpen(false);
-    },
-  },
-  {
-    id: "advanced",
-    type: "menu",
-    title: "Advanced",
-    children: [
-      {
-        id: "start-counter-job",
-        type: "action",
-        title: "Start Counter Job",
-        handler: () => handleStartCounterJob(deps),
-      },
-      {
-        id: "index-charms",
-        type: "action",
-        title: "Index Charms",
-        handler: () => handleIndexCharms(deps),
-      },
-      {
-        id: "import-json",
-        type: "action",
-        title: "Import JSON",
-        handler: () => handleImportJSON(deps),
-      },
-      {
-        id: "load-recipe",
-        type: "action",
-        title: "Load Recipe",
-        handler: () => handleLoadRecipe(deps),
-      },
-      {
-        id: "switch-replica",
-        type: "input",
-        title: "Switch Replica",
-        placeholder: "Enter replica name",
-        handler: (input) => {
-          if (input) {
-            window.location.href = `/${input}`;
-          }
+    {
+      id: "view-detail",
+      type: "action",
+      title: "View Detail",
+      group: "View",
+      predicate: !!deps.focusedCharmId,
+      handler: () => {
+        if (!deps.focusedCharmId) {
           deps.setOpen(false);
-        },
+          return;
+        }
+        deps.navigate(`/${deps.focusedReplicaId}/${deps.focusedCharmId}/detail`);
+        deps.setOpen(false);
       },
-    ],
-  },
-  {
-    id: "select-model",
-    type: "action",
-    title: "Select AI Model",
-    group: "Settings",
-    handler: () => handleSelectModel(deps),
-  },
-  {
-    id: "edit-recipe-voice",
-    type: "transcribe",
-    title: `Iterate (Voice)${deps.preferredModel ? ` (${deps.preferredModel})` : ""}`,
-    group: "Edit",
-    predicate: !!deps.focusedCharmId,
-    handler: async (transcription) => {
-      if (!transcription) return;
-
-      const commands = getCommands(deps);
-      const editRecipeCommand = commands.find(cmd => cmd.id === "edit-recipe")!;
-
-      deps.setModeWithInput({
-        type: "input",
-        command: editRecipeCommand,
-        placeholder: "What would you like to change?",
-        preserveInput: true
-      }, transcription);
     },
-  },
-  {
-    id: "background-jobs",
-    type: "menu",
-    title: `Background Jobs (${deps.listJobs().length})`,
-    group: "View",
-    children: [
-      ...deps.listJobs().map((job): CommandItem => ({
-        id: `job-${job.id}`,
-        type: "menu",
-        title: `${job.name} (${job.status})`,
-        children: [
-          {
-            id: `job-${job.id}-toggle`,
-            type: "action",
-            title: job.status === 'running' ? "Pause" : "Resume",
-            handler: async () => {
-              if (job.status === 'running') {
-                deps.stopJob(job.id);
-              } else {
-                // deps.resumeJob(job.id);
-              }
-              deps.setMode({ type: "main" });
-            },
-          },
-          {
-            id: `job-${job.id}-cancel`,
-            type: "action",
-            title: "Stop",
-            handler: async () => {
-              deps.stopJob(job.id);
-              deps.setMode({ type: "main" });
-            },
-          },
-          {
-            id: `job-${job.id}-messages`,
-            type: "menu",
-            title: "View Messages",
-            children: job.messages.map((msg, i): CommandItem => ({
-              id: `msg-${job.id}-${i}`,
-              type: "action",
-              title: msg,
-              handler: () => {}
-            })),
-          },
-        ],
-      })),
-      {
-        id: "clear-completed-jobs",
-        type: "action",
-        title: "Clear Completed Jobs",
-        handler: async () => {
-          // deps.clearCompletedJobs();
-          deps.setMode({ type: "main" });
-        },
+    {
+      id: "edit-code",
+      type: "action",
+      title: "Edit Code",
+      group: "View",
+      predicate: !!deps.focusedCharmId,
+      handler: () => {
+        if (!deps.focusedCharmId) {
+          deps.setOpen(false);
+          return;
+        }
+        deps.navigate(`/${deps.focusedReplicaId}/${deps.focusedCharmId}/detail#code`);
+        deps.setOpen(false);
       },
-    ],
-  }];
+    },
+    {
+      id: "view-data",
+      type: "action",
+      title: "View Backing Data",
+      group: "View",
+      predicate: !!deps.focusedCharmId,
+      handler: () => {
+        if (!deps.focusedCharmId) {
+          deps.setOpen(false);
+          return;
+        }
+        deps.navigate(`/${deps.focusedReplicaId}/${deps.focusedCharmId}/detail#data`);
+        deps.setOpen(false);
+      },
+    },
+    {
+      id: "view-charm",
+      type: "action",
+      title: "View Charm",
+      group: "View",
+      predicate: !!deps.focusedCharmId,
+      handler: () => {
+        if (!deps.focusedCharmId) {
+          deps.setOpen(false);
+          return;
+        }
+        deps.navigate(`/${deps.focusedReplicaId}/${deps.focusedCharmId}`);
+        deps.setOpen(false);
+      },
+    },
+    {
+      id: "back",
+      type: "action",
+      title: "Navigate Back",
+      group: "Navigation",
+      handler: () => {
+        window.history.back();
+        deps.setOpen(false);
+      },
+    },
+    {
+      id: "home",
+      type: "action",
+      title: "Navigate Home",
+      group: "Navigation",
+      predicate: !!deps.focusedReplicaId,
+      handler: () => {
+        if (deps.focusedReplicaId) {
+          deps.navigate(`/${deps.focusedReplicaId}`);
+        }
+        deps.setOpen(false);
+      },
+    },
+    {
+      id: "advanced",
+      type: "menu",
+      title: "Advanced",
+      children: [
+        {
+          id: "start-counter-job",
+          type: "action",
+          title: "Start Counter Job",
+          handler: () => handleStartCounterJob(deps),
+        },
+        {
+          id: "index-charms",
+          type: "action",
+          title: "Index Charms",
+          handler: () => handleIndexCharms(deps),
+        },
+        {
+          id: "import-json",
+          type: "action",
+          title: "Import JSON",
+          handler: () => handleImportJSON(deps),
+        },
+        {
+          id: "load-recipe",
+          type: "action",
+          title: "Load Recipe",
+          handler: () => handleLoadRecipe(deps),
+        },
+        {
+          id: "switch-replica",
+          type: "input",
+          title: "Switch Replica",
+          placeholder: "Enter replica name",
+          handler: (input) => {
+            if (input) {
+              window.location.href = `/${input}`;
+            }
+            deps.setOpen(false);
+          },
+        },
+      ],
+    },
+    {
+      id: "select-model",
+      type: "action",
+      title: "Select AI Model",
+      group: "Settings",
+      handler: () => handleSelectModel(deps),
+    },
+    {
+      id: "edit-recipe-voice",
+      type: "transcribe",
+      title: `Iterate (Voice)${deps.preferredModel ? ` (${deps.preferredModel})` : ""}`,
+      group: "Edit",
+      predicate: !!deps.focusedCharmId,
+      handler: async (transcription) => {
+        if (!transcription) return;
+
+        const commands = getCommands(deps);
+        const editRecipeCommand = commands.find((cmd) => cmd.id === "edit-recipe")!;
+
+        deps.setModeWithInput(
+          {
+            type: "input",
+            command: editRecipeCommand,
+            placeholder: "What would you like to change?",
+            preserveInput: true,
+          },
+          transcription,
+        );
+      },
+    },
+    {
+      id: "background-jobs",
+      type: "menu",
+      title: `Background Jobs (${deps.listJobs().length})`,
+      group: "Other",
+      children: [
+        ...deps.listJobs().map(
+          (job): CommandItem => ({
+            id: `job-${job.id}`,
+            type: "menu",
+            title: `${job.name} (${job.status})`,
+            children: [
+              {
+                id: `job-${job.id}-toggle`,
+                type: "action",
+                title: job.status === "running" ? "Pause" : "Resume",
+                handler: async () => {
+                  if (job.status === "running") {
+                    deps.stopJob(job.id);
+                  } else {
+                    // deps.resumeJob(job.id);
+                  }
+                  deps.setMode({ type: "main" });
+                },
+              },
+              {
+                id: `job-${job.id}-cancel`,
+                type: "action",
+                title: "Stop",
+                handler: async () => {
+                  deps.stopJob(job.id);
+                  deps.setMode({ type: "main" });
+                },
+              },
+              {
+                id: `job-${job.id}-messages`,
+                type: "menu",
+                title: "View Messages",
+                children: job.messages.map(
+                  (msg, i): CommandItem => ({
+                    id: `msg-${job.id}-${i}`,
+                    type: "action",
+                    title: msg,
+                    handler: () => {},
+                  }),
+                ),
+              },
+            ],
+          }),
+        ),
+        {
+          id: "clear-completed-jobs",
+          type: "action",
+          title: "Clear Completed Jobs",
+          handler: async () => {
+            // deps.clearCompletedJobs();
+            deps.setMode({ type: "main" });
+          },
+        },
+      ],
+    },
+  ];
 }

--- a/typescript/packages/jumble/src/contexts/BackgroundTaskContext.tsx
+++ b/typescript/packages/jumble/src/contexts/BackgroundTaskContext.tsx
@@ -1,0 +1,97 @@
+import React, { createContext, useCallback, useContext, useRef, useState } from "react";
+
+export interface BackgroundJob {
+  id: string;
+  name: string;
+  status: 'running' | 'paused' | 'stopped' | 'completed';
+  progress?: number;
+  messages: string[];
+  startTime: number;
+}
+
+interface BackgroundTaskContextType {
+  listJobs: () => BackgroundJob[];
+  startJob: (name: string) => string;
+  pauseJob: (id: string) => void;
+  resumeJob: (id: string) => void;
+  stopJob: (id: string) => void;
+  updateJobProgress: (id: string, progress: number) => void;
+  addJobMessage: (id: string, message: string) => void;
+}
+
+const BackgroundTaskContext = createContext<BackgroundTaskContextType>({
+  listJobs: () => [],
+  startJob: () => "",
+  pauseJob: () => { },
+  resumeJob: () => { },
+  stopJob: () => { },
+  updateJobProgress: () => { },
+  addJobMessage: () => { }
+});
+export const BackgroundTaskProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const jobsRef = useRef<BackgroundJob[]>([]);
+
+  const startJob = useCallback((name: string) => {
+    const id = crypto.randomUUID();
+    debugger
+    jobsRef.current = [...jobsRef.current, {
+      id,
+      name,
+      status: 'running',
+      messages: [],
+      startTime: Date.now()
+    }];
+    debugger
+    return id;
+  }, []);
+
+  const pauseJob = useCallback((id: string) => {
+    jobsRef.current = jobsRef.current.map(job =>
+      job.id === id ? { ...job, status: 'paused' } : job
+    );
+  }, []);
+
+  const resumeJob = useCallback((id: string) => {
+    jobsRef.current = jobsRef.current.map(job =>
+      job.id === id ? { ...job, status: 'running' } : job
+    );
+  }, []);
+
+  const stopJob = useCallback((id: string) => {
+    jobsRef.current = jobsRef.current.map(job =>
+      job.id === id ? { ...job, status: 'stopped' } : job
+    );
+  }, []);
+
+  const updateJobProgress = useCallback((id: string, progress: number) => {
+    jobsRef.current = jobsRef.current.map(job =>
+      job.id === id ? { ...job, progress } : job
+    );
+  }, []);
+
+  const addJobMessage = useCallback((id: string, message: string) => {
+    jobsRef.current = jobsRef.current.map(job =>
+      job.id === id ? { ...job, messages: [...job.messages, message] } : job
+    );
+  }, []);
+
+  const listJobs = useCallback(() => {
+    return jobsRef.current;
+  }, []);
+
+  return (
+    <BackgroundTaskContext.Provider value={{
+      listJobs,
+      startJob,
+      pauseJob,
+      resumeJob,
+      stopJob,
+      updateJobProgress,
+      addJobMessage
+    }}>
+      {children}
+    </BackgroundTaskContext.Provider>
+  );
+};
+
+export const useBackgroundTasks = () => useContext(BackgroundTaskContext);

--- a/typescript/packages/jumble/src/contexts/BackgroundTaskContext.tsx
+++ b/typescript/packages/jumble/src/contexts/BackgroundTaskContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useRef, useState } from "react";
+import React, { createContext, useCallback, useContext, useRef } from "react";
 
 export interface BackgroundJob {
   id: string;
@@ -33,7 +33,6 @@ export const BackgroundTaskProvider: React.FC<{ children: React.ReactNode }> = (
 
   const startJob = useCallback((name: string) => {
     const id = crypto.randomUUID();
-    debugger
     jobsRef.current = [...jobsRef.current, {
       id,
       name,
@@ -41,7 +40,6 @@ export const BackgroundTaskProvider: React.FC<{ children: React.ReactNode }> = (
       messages: [],
       startTime: Date.now()
     }];
-    debugger
     return id;
   }, []);
 

--- a/typescript/packages/jumble/src/main.tsx
+++ b/typescript/packages/jumble/src/main.tsx
@@ -13,36 +13,39 @@ import CharmList from "@/views/CharmList";
 import CharmShowView from "@/views/CharmShowView";
 import CharmDetailView from "@/views/CharmDetailView";
 import { LanguageModelProvider } from "./contexts/LanguageModelContext";
+import { BackgroundTaskProvider } from "./contexts/BackgroundTaskContext";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <CharmsProvider>
-      <LanguageModelProvider>
-        <Router>
-          <Routes>
-            {/* Redirect root to common-knowledge */}
-            <Route path="/" element={<Navigate to="/common-knowledge" replace />} />
+      <BackgroundTaskProvider>
+        <LanguageModelProvider>
+          <Router>
+            <Routes>
+              {/* Redirect root to common-knowledge */}
+              <Route path="/" element={<Navigate to="/common-knowledge" replace />} />
 
-            {/* Photoflow routes preserved */}
-            <Route path="/experiments/photoflow" element={<PhotoFlowIndex />} />
-            <Route path="/experiments/photoflow/:photosetName" element={<PhotoSetView />} />
-            <Route path="/experiments/photoflow/:photosetName/spells/new" element={<NewSpell />} />
+              {/* Photoflow routes preserved */}
+              <Route path="/experiments/photoflow" element={<PhotoFlowIndex />} />
+              <Route path="/experiments/photoflow/:photosetName" element={<PhotoSetView />} />
+              <Route path="/experiments/photoflow/:photosetName/spells/new" element={<NewSpell />} />
 
-            <Route
-              path="/:replicaName"
-              element={
-                <CharmsManagerProvider>
-                  <Shell />
-                </CharmsManagerProvider>
-              }
-            >
-              <Route index element={<CharmList />} />
-              <Route path=":charmId" element={<CharmShowView />} />
-              <Route path=":charmId/detail" element={<CharmDetailView />} />
-            </Route>
-          </Routes>
-        </Router>
-      </LanguageModelProvider>
+              <Route
+                path="/:replicaName"
+                element={
+                  <CharmsManagerProvider>
+                    <Shell />
+                  </CharmsManagerProvider>
+                }
+              >
+                <Route index element={<CharmList />} />
+                <Route path=":charmId" element={<CharmShowView />} />
+                <Route path=":charmId/detail" element={<CharmDetailView />} />
+              </Route>
+            </Routes>
+          </Router>
+        </LanguageModelProvider>
+      </BackgroundTaskProvider>
     </CharmsProvider>
   </StrictMode>,
 );

--- a/typescript/packages/jumble/src/utils/indexing.ts
+++ b/typescript/packages/jumble/src/utils/indexing.ts
@@ -1,0 +1,123 @@
+import { CharmManager } from "@commontools/charm";
+import { BackgroundJob } from "@/contexts/BackgroundTaskContext";
+import { llm } from "./llm";
+
+interface IndexingContext {
+  startJob: (name: string) => string;
+  stopJob: (jobId: string) => void;
+  addJobMessage: (jobId: string, message: string) => void;
+  updateJobProgress: (jobId: string, progress: number) => void;
+  listJobs: () => BackgroundJob[];
+}
+
+const CONCURRENT_LIMIT = 3;
+async function saveToMemory(space: string, entity: string, data: any, contentType: string = "application/json"): Promise<Response> {
+  return fetch("/api/storage/memory", {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      [space]: {
+        assert: {
+          the: contentType,
+          of: entity,
+          is: data
+        }
+      }
+    })
+  });
+}
+
+
+async function indexCharm(
+  charm: any,
+  jobId: string,
+  context: IndexingContext,
+  replica: string
+): Promise<void> {
+  try {
+    // Simulate indexing work for this example
+    const charmId = charm.cell.entityId?.['/'];
+    context.addJobMessage(jobId, `Indexing charm ${charmId}...`);
+    console.log('indexing', charm)
+    const stringified = JSON.stringify(charm.cell.asCell().get());
+
+    const response = await llm.sendRequest({
+      model: 'anthropic:claude-3-5-sonnet-latest',
+      messages: [{
+        role: "user",
+        content: `Analyze this UI component JSON and describe it in a single terse paragraph with up to 2 relevant hashtags: ${stringified}`
+      }]
+    });
+    context.addJobMessage(jobId, response);
+    console.log(stringified, response);
+
+    await saveToMemory(replica, charmId, response, 'text/plain;variant=description');
+
+    await new Promise(resolve => setTimeout(resolve, 200)); // Simulate work
+    context.addJobMessage(jobId, `✓ Indexed charm ${charmId}`);
+  } catch (error) {
+    context.addJobMessage(
+      jobId,
+      `Failed to index charm ${charm.entityId}: ${error}`
+    );
+    console.error(error);
+  }
+}
+
+export async function startCharmIndexing(
+  charmManager: CharmManager,
+  context: IndexingContext
+): Promise<void> {
+  const jobId = context.startJob("Indexing Charms");
+  context.addJobMessage(jobId, "Starting charm indexing...");
+
+  try {
+    const charms = charmManager.getCharms().get();
+    const total = charms.length;
+
+    if (total === 0) {
+      context.addJobMessage(jobId, "No charms found to index");
+      context.stopJob(jobId);
+      return;
+    }
+
+    context.addJobMessage(jobId, `Found ${total} charms to index`);
+    let completed = 0;
+
+    // Process charms in batches of CONCURRENT_LIMIT
+    for (let i = 0; i < total; i += CONCURRENT_LIMIT) {
+      const batch = charms.slice(i, i + CONCURRENT_LIMIT);
+
+      // Check if job was stopped
+      const job = context.listJobs().find(j => j.id === jobId);
+      if (!job || job.status !== 'running') {
+        context.addJobMessage(jobId, "Indexing stopped by user");
+        return;
+      }
+
+      await Promise.all(
+        batch.map(charm => indexCharm(charm, jobId, context, charmManager.getReplica()))
+      );
+
+      completed += batch.length;
+      const progress = completed / total;
+      context.updateJobProgress(jobId, progress);
+      context.addJobMessage(
+        jobId,
+        `Progress: ${completed}/${total} charms (${Math.round(progress * 100)}%)`
+      );
+    }
+
+    context.addJobMessage(jobId, "Indexing completed successfully");
+  } catch (error) {
+    context.addJobMessage(
+      jobId,
+      `Indexing failed with error: ${error}`
+    );
+    console.error(error);
+  } finally {
+    context.stopJob(jobId);
+  }
+}

--- a/typescript/packages/jumble/src/utils/llm.ts
+++ b/typescript/packages/jumble/src/utils/llm.ts
@@ -1,0 +1,8 @@
+import { LLMClient } from "@commontools/llm-client";
+
+export const llmUrl =
+  typeof window !== "undefined"
+    ? window.location.protocol + "//" + window.location.host + "/api/ai/llm"
+    : "//api/ai/llm";
+
+export const llm = new LLMClient(llmUrl);

--- a/typescript/packages/jumble/src/views/CharmDetailView.tsx
+++ b/typescript/packages/jumble/src/views/CharmDetailView.tsx
@@ -104,8 +104,8 @@ const IterationTab: React.FC<IterationTabProps> = ({ charm }) => {
               {loading && (
                 <DitheredCube
                   animationSpeed={2}
-                  width={40}
-                  height={40}
+                  width={24}
+                  height={24}
                   animate={true}
                   cameraZoom={12}
                 />

--- a/typescript/packages/jumble/src/views/Shell.tsx
+++ b/typescript/packages/jumble/src/views/Shell.tsx
@@ -6,11 +6,11 @@ import { animated } from "@react-spring/web";
 import { MdOutlineStar } from "react-icons/md";
 
 import { setIframeContextHandler } from "@commontools/iframe-sandbox";
-import { LLMClient } from "@commontools/llm-client";
 import { Action, ReactivityLog, addAction, removeAction } from "@commontools/runner";
 
 import ShellHeader from "@/components/ShellHeader";
 import { CommandCenter } from "@/components/CommandCenter";
+import { llm } from "@/utils/llm";
 
 // FIXME(ja): perhaps this could be in common-charm?  needed to enable iframe with sandboxing
 // This is to prepare Proxy objects to be serialized
@@ -20,13 +20,6 @@ import { CommandCenter } from "@/components/CommandCenter";
 const serializeProxyObjects = (proxy: any) => {
   return proxy == undefined ? undefined : JSON.parse(JSON.stringify(proxy));
 };
-
-const llmUrl =
-  typeof window !== "undefined"
-    ? window.location.protocol + "//" + window.location.host + "/api/ai/llm"
-    : "//api/ai/llm";
-
-const llm = new LLMClient(llmUrl);
 
 setIframeContextHandler({
   read(context: any, key: string): any {


### PR DESCRIPTION
- https://github.com/commontoolsinc/labs/issues/389

- rework command abstraction to handle dynamic menu items more elegantly
- implement background job abstraction (`useBackgroundJobs` hook)
  - this may come in handy for variants, or anywhere you want to run a task that persists while navigating around the app
- implement counter job example
- implement basic charm indexer
  - for each charm, describe it via LLM and save to `common-memory` under `text/plain;variant=description`


https://github.com/user-attachments/assets/8f096814-2a88-444c-a2d6-f1e4758c4bc4

