### PR TITLE
Renderer using new `Cell` with VDOM as schema

### DIFF
--- a/typescript/packages/common-builder/src/types.ts
+++ b/typescript/packages/common-builder/src/types.ts
@@ -102,6 +102,7 @@ export type JSONSchema = {
   items?: JSONSchema;
   $ref?: string;
   asCell?: boolean;
+  anyOf?: JSONSchema[];
   additionalProperties?: JSONSchema | boolean;
 };
 

--- a/typescript/packages/common-html/src/render.ts
+++ b/typescript/packages/common-html/src/render.ts
@@ -23,8 +23,13 @@ const schema: JSONSchema = {
     children: {
       type: "array",
       items: {
-        $ref: "#",
-        asCell: true,
+        anyOf: [
+          { $ref: "#", asCell: true },
+          { type: "string", asCell: true },
+          { type: "number", asCell: true },
+          { type: "boolean", asCell: true },
+          { type: "array", items: { $ref: "#", asCell: true } },
+        ],
       },
     },
   },
@@ -73,7 +78,7 @@ const renderNode = (node: VNode): [HTMLElement | null, Cancel] => {
 const bindChildren = (element: HTMLElement, children: Array<Child>): Cancel => {
   const [cancel, addCancel] = useCancelGroup();
 
-  for (const child of children) {
+  for (const child of children.flat()) {
     if (typeof child === "string" || typeof child === "number" || typeof child === "boolean") {
       // Bind static content
       element.append(child.toString());

--- a/typescript/packages/common-html/src/render.ts
+++ b/typescript/packages/common-html/src/render.ts
@@ -11,7 +11,7 @@ import {
 import { JSONSchema } from "@commontools/builder";
 import * as logger from "./logger.js";
 
-const schema: JSONSchema = {
+const vdomSchema: JSONSchema = {
   type: "object",
   properties: {
     type: { type: "string" },
@@ -33,12 +33,12 @@ const schema: JSONSchema = {
       },
     },
   },
-};
+} as const;
 
 /** Render a view into a parent element */
 export const render = (parent: HTMLElement, view: VNode | Cell<VNode>): Cancel => {
   // If this is a reactive cell, ensure the schema is VNode
-  if (isCell(view)) view = view.asSchema(schema);
+  if (isCell(view)) view = view.asSchema(vdomSchema);
   return effect(view, (view: VNode) => renderImpl(parent, view));
 };
 

--- a/typescript/packages/common-runner/src/builtins/map.ts
+++ b/typescript/packages/common-runner/src/builtins/map.ts
@@ -70,10 +70,9 @@ export function map(
     const opRef = getDocLinkOrThrow(op);
     op = opRef.cell.getAtPath(opRef.path);
 
-    // Update values that are new or have changed
+    // Add values that have been appended
     for (let index = result.get().length; index < list.length; index++) {
-      const resultCell = getDoc();
-      resultCell.generateEntityId({ result, index });
+      const resultCell = getDoc(undefined, { result, index });
       run(
         op,
         {
@@ -92,6 +91,7 @@ export function map(
       result.setAtPath([index], { cell: resultCell, path: [] }, log);
     }
 
+    // Shorten the result if the list got shorter
     if (result.get().length > list.length) {
       result.setAtPath(["length"], list.length, log);
     }

--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -15,10 +15,8 @@ import {
   followAliases,
   followCellReferences,
   normalizeToCells,
-  pathAffected,
   setNestedValue,
   followLinks,
-  compactifyPaths,
 } from "./utils.js";
 import { queueEvent, subscribe } from "./scheduler.js";
 import {
@@ -28,7 +26,7 @@ import {
   getEntityId,
   setDocByEntityId,
 } from "./cell-map.js";
-import { useCancelGroup, type Cancel } from "./cancel.js";
+import { type Cancel } from "./cancel.js";
 import { validateAndTransform } from "./schema.js";
 
 /**

--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -94,6 +94,7 @@ export interface Cell<T> {
   getAsDocLink(): DocLink;
   toJSON(): { "/": string } | undefined;
   value: T;
+  docLink: DocLink;
   entityId: EntityId | undefined;
   [isCellMarker]: true;
   copyTrap: boolean;
@@ -593,6 +594,9 @@ function createRegularCell<T>(
     toJSON: () => doc.toJSON(),
     get value(): T {
       return self.get();
+    },
+    get docLink(): DocLink {
+      return { cell: doc, path };
     },
     get entityId(): EntityId | undefined {
       return getEntityId(self.getAsDocLink());

--- a/typescript/packages/common-runner/src/scheduler.ts
+++ b/typescript/packages/common-runner/src/scheduler.ts
@@ -36,38 +36,45 @@ export function unschedule(fn: Action): void {
   pending.delete(fn);
 }
 
+export function subscribe(action: Action, log: ReactivityLog): Cancel {
+  setDependencies(action, log);
+
+  cancels.set(
+    action,
+    log.reads.map(({ cell: doc, path }) =>
+      doc.updates((_newValue, changedPath) => {
+        if (pathAffected(changedPath, path)) {
+          dirty.add(doc);
+          queueExecution();
+          pending.add(action);
+        }
+      }),
+    ),
+  );
+
+  return () => unschedule(action);
+}
+
 // Like schedule, but runs the action immediately to gather dependencies
 export async function run(action: Action): Promise<any> {
   const log: ReactivityLog = { reads: [], writes: [] };
 
   if (running) await running;
 
+  let result: any;
   running = new Promise(async (resolve) => {
     try {
-      const result = await action(log);
-
+      result = await action(log);
+    } catch (e) {
+      console.error("caught error", e, action);
+    } finally {
       // Note: By adding the listeners after the call we avoid triggering a re-run
       // of the action if it changed a r/w cell. Note that this also means that
       // those actions can't loop on themselves.
-      setDependencies(action, log);
-      cancels.set(
-        action,
-        Array.from(log.reads).map(({ cell, path }) =>
-          cell.updates((_newValue, changedPath) => {
-            if (pathAffected(changedPath, path)) {
-              dirty.add(cell);
-              queueExecution();
-              pending.add(action);
-            }
-          }),
-        ),
-      );
+      subscribe(action, log);
 
       running = undefined;
       resolve(result);
-    } catch (e) {
-      console.error("caught error", e, action);
-      resolve(undefined);
     }
   });
 
@@ -114,10 +121,10 @@ function queueExecution() {
 }
 
 function setDependencies(action: Action, log: ReactivityLog) {
-  dependencies.set(action, {
-    reads: compactifyPaths(log.reads),
-    writes: compactifyPaths(log.writes),
-  });
+  const reads = compactifyPaths(log.reads);
+  const writes = compactifyPaths(log.writes);
+  dependencies.set(action, { reads, writes });
+  return reads;
 }
 
 function handleError(error: Error) {

--- a/typescript/packages/common-runner/src/scheduler.ts
+++ b/typescript/packages/common-runner/src/scheduler.ts
@@ -121,10 +121,10 @@ function queueExecution() {
 }
 
 function setDependencies(action: Action, log: ReactivityLog) {
-  const reads = compactifyPaths(log.reads);
-  const writes = compactifyPaths(log.writes);
-  dependencies.set(action, { reads, writes });
-  return reads;
+  dependencies.set(action, {
+    reads: compactifyPaths(log.reads),
+    writes: compactifyPaths(log.writes),
+  });
 }
 
 function handleError(error: Error) {

--- a/typescript/packages/common-runner/src/schema.ts
+++ b/typescript/packages/common-runner/src/schema.ts
@@ -109,16 +109,22 @@ export function validateAndTransform(
       let objectCandidates = options.filter((option) => option.type === "object");
       const numAsCells = objectCandidates.filter((option) => option.asCell).length;
 
+      // If there are more than two asCell branches, merge them
       if (numAsCells > 2) {
-        const optionsWithoutAsCell = objectCandidates.map((option) => {
-          const {
-            asCell: {},
-            ...rest
-          } = option as any;
-          return rest;
-        });
+        const asCellRemoved = objectCandidates
+          .filter((option) => option.asCell)
+          .map((option) =>
+            (option.anyOf ?? [option]).map((branch) => {
+              const {
+                asCell: {},
+                ...rest
+              } = branch as any;
+              return rest;
+            }),
+          )
+          .flat();
         objectCandidates = objectCandidates.filter((option) => !option.asCell);
-        objectCandidates.push({ anyOf: optionsWithoutAsCell });
+        objectCandidates.push({ anyOf: asCellRemoved });
       }
 
       // Run extraction for each union branch.

--- a/typescript/packages/common-runner/src/schema.ts
+++ b/typescript/packages/common-runner/src/schema.ts
@@ -1,5 +1,5 @@
 import { type DocImpl, type DocLink, type ReactivityLog } from "./cell.js";
-import { JSONSchema } from "@commontools/common-builder";
+import { JSONSchema } from "@commontools/builder";
 import { followLinks } from "./utils.js";
 
 export function resolveSchema(

--- a/typescript/packages/common-runner/src/utils.ts
+++ b/typescript/packages/common-runner/src/utils.ts
@@ -11,7 +11,6 @@ import {
   UnsafeBinding,
   unsafe_materializeFactory,
   isOpaqueRef,
-  doc,
 } from "@commontools/common-builder";
 import {
   type DocImpl,
@@ -314,7 +313,7 @@ export function followLinks(ref: DocLink, seen: DocLink[] = [], log?: Reactivity
     else if (isDoc(target)) ref = { cell: target, path: [] } satisfies DocLink;
     else if (isAlias(target))
       ref = {
-        cell: target.$alias.cell ?? doc,
+        cell: target.$alias.cell ?? ref.cell,
         path: target.$alias.path,
       } satisfies DocLink;
     else return ref;

--- a/typescript/packages/common-runner/src/utils.ts
+++ b/typescript/packages/common-runner/src/utils.ts
@@ -7,8 +7,12 @@ import {
   unsafe_materializeFactory,
   unsafe_originalRecipe,
   unsafe_parentRecipe,
-  type UnsafeBinding,
-} from "@commontools/builder";
+  Recipe,
+  UnsafeBinding,
+  unsafe_materializeFactory,
+  isOpaqueRef,
+  doc,
+} from "@commontools/common-builder";
 import {
   type DocImpl,
   type DocLink,
@@ -291,6 +295,33 @@ export function findAllAliasedCells(binding: any, cell: DocImpl<any>): DocLink[]
   return cells;
 }
 
+// Follows links and returns the last one
+export function followLinks(ref: DocLink, seen: DocLink[] = [], log?: ReactivityLog): DocLink {
+  while (true) {
+    log?.reads.push({ cell: ref.cell, path: ref.path });
+
+    if (seen.some((r) => r.cell === ref.cell && arrayEqual(r.path, ref.path)))
+      throw new Error(
+        `Reference cycle detected ${JSON.stringify(ref.cell.entityId ?? "unknown")} ${ref.path.join(".")}`,
+      );
+    seen.push(ref);
+
+    const target = ref.cell.getAtPath(ref.path);
+
+    if (isQueryResultForDereferencing(target)) ref = getDocLinkOrThrow(target);
+    else if (isCell(target)) ref = target.getAsDocLink();
+    else if (isDocLink(target)) ref = target;
+    else if (isDoc(target)) ref = { cell: target, path: [] } satisfies DocLink;
+    else if (isAlias(target))
+      ref = {
+        cell: target.$alias.cell ?? doc,
+        path: target.$alias.path,
+      } satisfies DocLink;
+    else return ref;
+  }
+}
+
+// Follows cell references and returns the last one
 // Follows cell references and returns the last one
 export function followCellReferences(reference: DocLink, log?: ReactivityLog): any {
   const seen = new Set<DocLink>();
@@ -357,35 +388,6 @@ export function pathAffected(changedPath: PropertyKey[], path: PropertyKey[]) {
     (changedPath.length <= path.length && changedPath.every((key, index) => key === path[index])) ||
     path.every((key, index) => key === changedPath[index])
   );
-}
-
-export function transformToCells(cell: DocImpl<any>, value: any, log?: ReactivityLog): any {
-  if (isQueryResultForDereferencing(value)) {
-    const ref = followCellReferences(getDocLinkOrThrow(value));
-    if (cell === ref.cell) {
-      return transformToCells(cell, cell.getAtPath(ref.path), log);
-    } else return ref.cell.asCell(ref.path, log);
-  } else if (isAlias(value)) {
-    const ref = followCellReferences(followAliases(value, cell, log), log);
-    return ref.cell.asCell(ref.path, log);
-  } else if (isDoc(value)) {
-    return value.asCell([], log);
-  } else if (isDocLink(value)) {
-    const ref = followCellReferences(value, log);
-    return ref.cell.asCell(ref.path, log);
-  } else if (isCell(value)) {
-    return value;
-  }
-
-  if (typeof value === "object" && value !== null) {
-    if (Array.isArray(value)) {
-      return value.map((value) => transformToCells(cell, value, log));
-    } else {
-      return Object.fromEntries(
-        Object.entries(value).map(([key, value]) => [key, transformToCells(cell, value, log)]),
-      );
-    }
-  } else return value;
 }
 
 /**

--- a/typescript/packages/common-runner/src/utils.ts
+++ b/typescript/packages/common-runner/src/utils.ts
@@ -7,11 +7,8 @@ import {
   unsafe_materializeFactory,
   unsafe_originalRecipe,
   unsafe_parentRecipe,
-  Recipe,
   UnsafeBinding,
-  unsafe_materializeFactory,
-  isOpaqueRef,
-} from "@commontools/common-builder";
+} from "@commontools/builder";
 import {
   type DocImpl,
   type DocLink,

--- a/typescript/packages/common-runner/test/cell.test.ts
+++ b/typescript/packages/common-runner/test/cell.test.ts
@@ -286,7 +286,7 @@ describe("asCell", () => {
     expect(lastEventSeen).toBe("event");
   });
 
-  it("should call sink only when the cell changes on the subpath", () => {
+  it("should call sink only when the cell changes on the subpath", async () => {
     const c = getDoc({ a: { b: 42, c: 10 }, d: 5 });
     const values: number[] = [];
     c.asCell(["a", "b"]).sink((value) => values.push(value));
@@ -294,6 +294,7 @@ describe("asCell", () => {
     c.setAtPath(["a", "c"], 100);
     c.setAtPath(["a", "b"], 42);
     c.setAtPath(["a", "b"], 300);
+    await idle();
     expect(values).toEqual([42, 300]);
     expect(c.get()).toEqual({ a: { b: 300, c: 100 }, d: 50 });
   });

--- a/typescript/packages/common-runner/test/scheduler.test.ts
+++ b/typescript/packages/common-runner/test/scheduler.test.ts
@@ -144,7 +144,7 @@ describe("scheduler", () => {
   });
 
   it("should stop eventually when encountering infinite loops", async () => {
-    let maxRuns = 200; // More than the limit in scheduler
+    let maxRuns = 120; // More than the limit in scheduler
     const a = getDoc(1);
     const b = getDoc(2);
     const c = getDoc(0);
@@ -171,7 +171,7 @@ describe("scheduler", () => {
     await idle();
 
     expect(maxRuns).toBeGreaterThan(0);
-    expect(stopped).toHaveBeenCalledOnce();
+    expect(stopped).toHaveBeenCalled();
   });
 
   it("should not loop on r/w changes on its own output", async () => {

--- a/typescript/packages/common-runner/test/schema.test.ts
+++ b/typescript/packages/common-runner/test/schema.test.ts
@@ -412,6 +412,7 @@ describe("Schema Support", () => {
           data: [
             { type: "text", value: "hello" },
             { type: "number", value: 42 },
+            { not: "matching", should: "be ignored" },
           ],
         });
         const schema: JSONSchema = {
@@ -446,6 +447,7 @@ describe("Schema Support", () => {
         expect(result.data).toEqual([
           { type: "text", value: "hello" },
           { type: "number", value: 42 },
+          {},
         ]);
       });
 

--- a/typescript/packages/common-runner/test/schema.test.ts
+++ b/typescript/packages/common-runner/test/schema.test.ts
@@ -527,6 +527,7 @@ describe("Schema Support", () => {
               { type: "text", value: "hello" },
               { type: "text", value: "world" },
             ],
+            "or just text",
           ],
         });
 
@@ -545,6 +546,9 @@ describe("Schema Support", () => {
               items: {
                 anyOf: [
                   { $ref: "#", asCell: true },
+                  { type: "string", asCell: true },
+                  { type: "number", asCell: true },
+                  { type: "boolean", asCell: true },
                   { type: "array", items: { $ref: "#", asCell: true } },
                 ],
               },
@@ -556,7 +560,6 @@ describe("Schema Support", () => {
         const result = cell.get();
         expect(result.type).toBe("vnode");
         expect(result.name).toBe("div");
-        console.log("result", result);
         expect(isCell(result.children)).toBe(false);
         expect(isCell(result.props)).toBe(false);
         expect(isCell(result.props.style)).toBe(true);
@@ -568,6 +571,8 @@ describe("Schema Support", () => {
         expect(result.children[1][0].get().value).toBe("hello");
         expect(isCell(result.children[1][1])).toBe(true);
         expect(result.children[1][1].get().value).toBe("world");
+        expect(isCell(result.children[2])).toBe(true);
+        expect(result.children[2].get()).toBe("or just text");
       });
     });
   });

--- a/typescript/packages/common-runner/test/schema.test.ts
+++ b/typescript/packages/common-runner/test/schema.test.ts
@@ -517,7 +517,7 @@ describe("Schema Support", () => {
       });
 
       it("should work for the vdom schema with $ref", () => {
-        const c = getDoc({
+        const plain = getDoc({
           type: "vnode",
           name: "div",
           props: { style: { color: "red" } },
@@ -527,6 +527,28 @@ describe("Schema Support", () => {
               { type: "text", value: "hello" },
               { type: "text", value: "world" },
             ],
+            "or just text",
+          ],
+        });
+
+        const withLinks = getDoc({
+          type: "vnode",
+          name: "div",
+          props: {
+            style: {
+              cell: getDoc({ color: "red" }),
+              path: [],
+            },
+          },
+          children: [
+            { type: "text", value: "single" },
+            {
+              cell: getDoc([
+                { type: "text", value: "hello" },
+                { cell: getDoc({ type: "text", value: "world" }), path: [] },
+              ]),
+              path: [],
+            },
             "or just text",
           ],
         });
@@ -556,23 +578,25 @@ describe("Schema Support", () => {
           },
         };
 
-        const cell = c.asCell([], undefined, schema);
-        const result = cell.get();
-        expect(result.type).toBe("vnode");
-        expect(result.name).toBe("div");
-        expect(isCell(result.children)).toBe(false);
-        expect(isCell(result.props)).toBe(false);
-        expect(isCell(result.props.style)).toBe(true);
-        expect(result.props.style.get().color).toBe("red");
-        expect(isCell(result.children[0])).toBe(true);
-        expect(result.children[0].get().value).toBe("single");
-        expect(isCell(result.children[1])).toBe(false);
-        expect(isCell(result.children[1][0])).toBe(true);
-        expect(result.children[1][0].get().value).toBe("hello");
-        expect(isCell(result.children[1][1])).toBe(true);
-        expect(result.children[1][1].get().value).toBe("world");
-        expect(isCell(result.children[2])).toBe(true);
-        expect(result.children[2].get()).toBe("or just text");
+        for (const doc of [plain, withLinks]) {
+          const cell = doc.asCell([], undefined, schema);
+          const result = cell.get();
+          expect(result.type).toBe("vnode");
+          expect(result.name).toBe("div");
+          expect(isCell(result.children)).toBe(false);
+          expect(isCell(result.props)).toBe(false);
+          expect(isCell(result.props.style)).toBe(true);
+          expect(result.props.style.get().color).toBe("red");
+          expect(isCell(result.children[0])).toBe(true);
+          expect(result.children[0].get().value).toBe("single");
+          expect(isCell(result.children[1])).toBe(false);
+          expect(isCell(result.children[1][0])).toBe(true);
+          expect(result.children[1][0].get().value).toBe("hello");
+          expect(isCell(result.children[1][1])).toBe(true);
+          expect(result.children[1][1].get().value).toBe("world");
+          expect(isCell(result.children[2])).toBe(true);
+          expect(result.children[2].get()).toBe("or just text");
+        }
       });
     });
   });


### PR DESCRIPTION
Turns out that the renderer use-case is a neat power-user use-case of the schema stuff, so this PR has a bunch of fixes and new features.

Renderer is now also using the regular runner scheduler (before it was all a separate system!).