### PR TITLE
 chore: Add tests and fallback for client-side ed25519 implementation

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -14,6 +14,10 @@ jobs:
       matrix:
         node-version: [22]
     steps:
+    - name: Install test dependencies
+      run: |
+        sudo apt update
+        sudo apt-get install -y xvfb x11-xserver-utils
     - uses: actions/checkout@v4
     - name: Install pnpm
       uses: pnpm/action-setup@v4
@@ -32,4 +36,8 @@ jobs:
       run: |
         cd typescript/packages/common-iframe-sandbox
         pnpm test
+        cd -
+        cd typescript/packages/common-identity
+        pnpm test
+        cd -
 

--- a/typescript/packages/common-html/package.json
+++ b/typescript/packages/common-html/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@eslint/js": "^9.19.0",
     "@web/dev-server-esbuild": "^1.0.3",
-    "@web/test-runner": "^0.19.0",
+    "@web/test-runner": "^0.20.0",
     "eslint": "^9.19.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.3",

--- a/typescript/packages/common-identity/README.md
+++ b/typescript/packages/common-identity/README.md
@@ -20,10 +20,28 @@ The derived 32-bytes is used as raw private key material for a `RootKey`, from w
 The `RootKey` is securely stored in IndexedDb at a well-known location, and on page load, is retrieved,
 acting as a pseudo-cookie for authentication, so that the user does not need to reauthenticate their passkey.
 
-Identities (not yet developed) are derived from root keys. Each *space* and *persona* identity is a keypair,
-used to delegate authority. These keys are derived from the `RootKey` private key, and a "name", such that
-the key can be deterministically derived. Eventually, the server will (probably) record which spaces/personas
-are mapped to a "user" so that authenticating on a new device, the identity keys can be reproduced.
+Personas are deterministically derived from root keys, such that each `RootKey` can derive any number of `PersonaKey`s.
+These personas are visible users to the system, and these identites are used for signing transactions and delegating ownership.
+
+Similarly, a `SpaceKey` is a generated (non-derived) keypair representing an identity of a "space". When `SpaceKey` is generated, it immediately delegates access to a `PersonaKey` before burning its private key.
+
+## Key Derivation
+
+> [!WARNING]
+> This needs a cryptographic review. Using a signed deterministic value as key material could be compromised by an attacker
+> getting specific data signed by a root key.
+
+Deriving a `PersonaKey` from a `RootKey` performs the following algorithm:
+
+* `i` = Encode `name` into bytes
+* `i` = SHA-512 hash `i` 
+* `i` = Sign `i` with root key
+* `i` = SHA-512 hash `i` 
+* Use `i` as raw ed25519 private key material
+
+```
+hash(sign(hash(encode(name))))
+```
 
 ## Browser Support
 

--- a/typescript/packages/common-identity/package.json
+++ b/typescript/packages/common-identity/package.json
@@ -22,7 +22,7 @@
   "author": "",
   "license": "UNLICENSED",
   "dependencies": {
-    "@noble/ed25519": "*",
+    "@noble/ed25519": "^2.2.3",
     "tslib": "^2.8.1"
   },
   "devDependencies": {
@@ -37,6 +37,7 @@
     "typescript": "^5.7.3",
     "vite": "^6.0.11",
     "vite-plugin-dts": "^4.5.0",
-    "@web/test-runner": "^0.19.0"
+    "@web/test-runner": "^0.20.0",
+    "@web/test-runner-chrome": "^0.18.0"
   }
 }

--- a/typescript/packages/common-identity/src/derived-key.ts
+++ b/typescript/packages/common-identity/src/derived-key.ts
@@ -1,0 +1,37 @@
+import { Ed25519KeyPair } from "./ed25519/index.js";
+import { KeyPair, KeyPairRaw } from "./keys.js";
+import { RootKey } from "./root-key.js";
+import { hash } from "./utils.js";
+
+const textEncoder = new TextEncoder();
+
+export class DerivedKey implements KeyPair {
+  private keypair: Ed25519KeyPair;
+  constructor(keypair: Ed25519KeyPair) {
+    this.keypair = keypair;
+  }
+
+  // Sign `data` with this `RootKey`.
+  async sign(data: Uint8Array): Promise<Uint8Array> {
+    return await this.keypair.sign(data);
+  }
+ 
+  // Verify `signature` and `data` with this `RootKey`.
+  async verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
+    return await this.keypair.verify(signature, data);
+  }
+
+  serialize(): KeyPairRaw {
+    return this.keypair.serialize();
+  }
+
+  // Generate a `RootKey` from a `PassKey`.
+  static async fromRootKey(rootKey: RootKey, name: string): Promise<DerivedKey> {
+    const seed = textEncoder.encode(name);
+    const hashed = await hash(seed);
+    const signed = await rootKey.sign(hashed);
+    const signedHash = await hash(signed);
+    const keypair = await Ed25519KeyPair.generateFromRaw(signedHash);
+    return new DerivedKey(keypair);
+  }
+}

--- a/typescript/packages/common-identity/src/ed25519/index.ts
+++ b/typescript/packages/common-identity/src/ed25519/index.ts
@@ -1,0 +1,49 @@
+import { KeyPair, KeyPairStatic, KeyPairRaw, isInsecureCryptoKeyPair, isCryptoKeyPair } from "../keys.js";
+import { NativeEd25519 } from "./native.js";
+import { NobleEd25519 } from "./noble.js";
+
+// Platform-specific implementation of an ED25519 Keypair.
+//
+// On browsers[0] that implement ed25519, the native Web Crypto
+// `NativeEd25519` is used. Otherwise, the `@noble/ed25519` implementation
+// is used.
+//
+// [0]: https://caniuse.com/mdn-api_subtlecrypto_sign_ed25519
+export class Ed25519KeyPair implements KeyPair {
+  private impl: KeyPair;
+  constructor(impl: KeyPair) {
+    this.impl = impl;
+  }
+
+  serialize(): KeyPairRaw {
+    return this.impl.serialize();
+  }
+
+  sign(data: Uint8Array): Promise<Uint8Array> {
+    return this.impl.sign(data);
+  }
+
+  verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
+    return this.impl.verify(signature, data);
+  }
+
+  static async generateFromRaw(rawPrivateKey: Uint8Array): Promise<Ed25519KeyPair> {
+    let Class: KeyPairStatic = (await NativeEd25519.isSupported()) ? NativeEd25519 : NobleEd25519;
+    return new Ed25519KeyPair(await Class.generateFromRaw(rawPrivateKey)); 
+  }
+  
+  static async generate(): Promise<Ed25519KeyPair> {
+    let Class: KeyPairStatic = (await NativeEd25519.isSupported()) ? NativeEd25519 : NobleEd25519;
+    return new Ed25519KeyPair(await Class.generate()); 
+  }
+
+  static deserialize(input: KeyPairRaw): Ed25519KeyPair {
+    if (isCryptoKeyPair(input)) {
+      return new Ed25519KeyPair(NativeEd25519.deserialize(input));
+    } else if (isInsecureCryptoKeyPair(input)) {
+      return new Ed25519KeyPair(NobleEd25519.deserialize(input));
+    } else {
+      throw new Error("common-identity: Could not deserialize key.");
+    }
+  };
+}

--- a/typescript/packages/common-identity/src/ed25519/native.ts
+++ b/typescript/packages/common-identity/src/ed25519/native.ts
@@ -1,0 +1,72 @@
+import * as ed25519 from "@noble/ed25519";
+import { ED25519_ALG } from "./utils.js";
+import { KeyPair, KeyPairRaw } from "../keys.js";
+
+// WebCrypto Key formats for Ed25519
+// Non-explicitly described in https://wicg.github.io/webcrypto-secure-curves/#ed25519
+//
+// | Format | Public | Private |
+// | ------ | ------ |---------|
+// | raw    |   X    |         | 
+// | jwk    |   X    |    X    |
+// | pkcs8  |        |    X    |
+// | spki   |   X    |         |
+
+export class NativeEd25519 implements KeyPair {
+  private keypair: CryptoKeyPair;
+  constructor(keypair: CryptoKeyPair) {
+    this.keypair = keypair;
+  }
+
+  serialize(): KeyPairRaw {
+    return this.keypair;
+  }
+  
+  async sign(data: Uint8Array): Promise<Uint8Array> {
+    return new Uint8Array(await window.crypto.subtle.sign(ED25519_ALG, this.keypair.privateKey, data));
+  }
+ 
+  async verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
+    return await window.crypto.subtle.verify(ED25519_ALG, this.keypair.publicKey, signature, data);
+  }
+
+  static async generateFromRaw(rawPrivateKey: Uint8Array): Promise<NativeEd25519> {
+    const pkcs8Private = ed25519RawToPkcs8(rawPrivateKey);
+    const rawPublic = await ed25519.getPublicKeyAsync(rawPrivateKey);
+    const privateKey = await window.crypto.subtle.importKey("pkcs8", pkcs8Private, ED25519_ALG, false, ["sign"]);
+    const publicKey = await window.crypto.subtle.importKey("raw", rawPublic, ED25519_ALG, false, ["verify"]);
+    return new NativeEd25519({ publicKey, privateKey });
+  }
+
+  static async generate(): Promise<NativeEd25519> {
+    let keypair = await window.crypto.subtle.generateKey(ED25519_ALG, false, ["sign", "verify"]);
+    return new NativeEd25519(keypair);
+  }
+
+  static deserialize(keypair: CryptoKeyPair) {
+    return new NativeEd25519(keypair);
+  }
+
+  // Returns whether ed25519 is supported in Web Crypto API.
+  static async isSupported() {
+    let dummyKey = new Uint8Array(32);
+    try {
+      await window.crypto.subtle.importKey("raw", dummyKey, ED25519_ALG, false, ["verify"]);
+      return true;
+    } catch (e) {}
+    return false;
+  }
+}
+
+// 0x302e020100300506032b657004220420
+// via https://stackoverflow.com/a/79135112
+const PKCS8_PREFIX = new Uint8Array([ 48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32 ]);
+
+// Private Ed25519 keys cannot be imported into Subtle Crypto in "raw" format.
+// Convert to "pkcs8" before doing so.
+// 
+// @AUDIT
+// via https://stackoverflow.com/a/79135112
+function ed25519RawToPkcs8(rawPrivateKey: Uint8Array): Uint8Array {
+  return new Uint8Array([...PKCS8_PREFIX, ...rawPrivateKey]);
+}

--- a/typescript/packages/common-identity/src/ed25519/noble.ts
+++ b/typescript/packages/common-identity/src/ed25519/noble.ts
@@ -1,0 +1,36 @@
+import * as ed25519 from "@noble/ed25519";
+import { KeyPair, InsecureCryptoKeyPair, KeyPairRaw } from "../keys.js";
+
+export class NobleEd25519 implements KeyPair {
+  private keypair: InsecureCryptoKeyPair;
+  constructor(keypair: InsecureCryptoKeyPair) {
+    this.keypair = keypair;
+  }
+
+  serialize(): KeyPairRaw {
+    return this.keypair;
+  }
+  
+  async sign(data: Uint8Array): Promise<Uint8Array> {
+    return await ed25519.signAsync(data, this.keypair.privateKey);
+  }
+ 
+  async verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
+    return await ed25519.verifyAsync(signature, data, this.keypair.publicKey);
+  }
+
+  static async generateFromRaw(privateKey: Uint8Array): Promise<NobleEd25519> {
+    const publicKey = await ed25519.getPublicKeyAsync(privateKey);
+    return new NobleEd25519({ publicKey, privateKey });
+  }
+
+  static async generate(): Promise<NobleEd25519> {
+    let privateKey = ed25519.utils.randomPrivateKey();
+    const publicKey = await ed25519.getPublicKeyAsync(privateKey);
+    return new NobleEd25519({ publicKey, privateKey });
+  }
+
+  static deserialize(keypair: InsecureCryptoKeyPair) {
+    return new NobleEd25519(keypair);
+  }
+}

--- a/typescript/packages/common-identity/src/ed25519/utils.ts
+++ b/typescript/packages/common-identity/src/ed25519/utils.ts
@@ -1,0 +1,14 @@
+export const ED25519_ALG = "Ed25519";
+
+// 0x302e020100300506032b657004220420
+// via https://stackoverflow.com/a/79135112
+const PKCS8_PREFIX = new Uint8Array([ 48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32 ]);
+
+// Private Ed25519 keys cannot be imported into Subtle Crypto in "raw" format.
+// Convert to "pkcs8" before doing so.
+// 
+// @AUDIT
+// via https://stackoverflow.com/a/79135112
+export function ed25519RawToPkcs8(rawPrivateKey: Uint8Array): Uint8Array {
+  return new Uint8Array([...PKCS8_PREFIX, ...rawPrivateKey]);
+}

--- a/typescript/packages/common-identity/src/key-store.ts
+++ b/typescript/packages/common-identity/src/key-store.ts
@@ -1,3 +1,4 @@
+import { Ed25519KeyPair } from "./ed25519/index.js";
 import { once } from "./utils.js";
 
 const DB_NAME = "key-store";
@@ -16,13 +17,17 @@ export class KeyStore {
   }
 
   // Get the `RootKey` keypair at the globally-known key space. 
-  async get(): Promise<CryptoKeyPair | undefined> {
-    return await this.db.get(STORE_NAME, ROOT_KEY);
+  async get(): Promise<Ed25519KeyPair | undefined> {
+    let result = await this.db.get(STORE_NAME, ROOT_KEY);
+    if (result) {
+      return Ed25519KeyPair.deserialize(result);
+    }
+    return result;
   }
   
   // Set the global `RootKey` keypair at the globally-known key space. 
-  async set(value: CryptoKeyPair): Promise<any> {
-    return await this.db.set(STORE_NAME, ROOT_KEY, value);
+  async set(value: Ed25519KeyPair): Promise<undefined> {
+    await this.db.set(STORE_NAME, ROOT_KEY, value.serialize());
   }
 
   // Clear the key store's table.

--- a/typescript/packages/common-identity/src/keys.ts
+++ b/typescript/packages/common-identity/src/keys.ts
@@ -1,0 +1,30 @@
+export interface KeyPairStatic {
+  generateFromRaw(rawPrivateKey: Uint8Array): Promise<KeyPair>;
+  generate(): Promise<KeyPair>;
+  deserialize(input: any): KeyPair;
+}
+
+export interface KeyPair {
+  sign(data: Uint8Array): Promise<Uint8Array>;
+  verify(signature: Uint8Array, data: Uint8Array): Promise<boolean>;
+  serialize(): KeyPairRaw;
+}
+
+export type InsecureCryptoKeyPair = {
+  privateKey: Uint8Array,
+  publicKey: Uint8Array,
+};
+
+export type KeyPairRaw = CryptoKeyPair | InsecureCryptoKeyPair;
+
+export function isCryptoKeyPair(input: any): input is CryptoKeyPair {
+  return !!(window.CryptoKey && typeof input === "object" &&
+    input.privateKey instanceof window.CryptoKey &&
+    input.publicKey instanceof window.CryptoKey);
+}
+
+export function isInsecureCryptoKeyPair(input: any): input is CryptoKeyPair {
+  return !!(typeof input === "object" &&
+    input.privateKey instanceof Uint8Array &&
+    input.publicKey instanceof Uint8Array);
+}

--- a/typescript/packages/common-identity/src/root-key.ts
+++ b/typescript/packages/common-identity/src/root-key.ts
@@ -1,37 +1,25 @@
 import { KeyStore } from "./key-store.js";
 import { PassKey } from "./pass-key.js";
-import { rawToEd25519KeyPair } from "./utils.js";
-
-const ED25519 = "ed25519";
-
-// WebCrypto Key formats for Ed25519
-// Non-explicitly described in https://wicg.github.io/webcrypto-secure-curves/#ed25519
-//
-// | Format | Public | Private |
-// | ------ | ------ |---------|
-// | raw    |   X    |         | 
-// | jwk    |   X    |    X    |
-// | pkcs8  |        |    X    |
-// | spki   |   X    |         |
+import { Ed25519KeyPair } from "./ed25519/index.js";
 
 // A `RootKey` represents the primary key from which all identities
 // are derived. A `RootKey` is deterministically derived from a `PassKey`'s
 // PRF output, a 32-byte hash, which is used as ed25519 key material.
 // Typically, there is only one instance of `RootKey` per document.
 export class RootKey {
-  private keypair: CryptoKeyPair;
-  constructor(keypair: CryptoKeyPair) {
+  private keypair: Ed25519KeyPair;
+  constructor(keypair: Ed25519KeyPair) {
     this.keypair = keypair;
   }
 
   // Sign `data` with this `RootKey`.
-  async sign(data: Uint8Array): Promise<ArrayBuffer> {
-    return await window.crypto.subtle.sign(ED25519, this.keypair.privateKey, data);
+  async sign(data: Uint8Array): Promise<Uint8Array> {
+    return await this.keypair.sign(data);
   }
  
   // Verify `signature` and `data` with this `RootKey`.
-  async verify(signature: ArrayBuffer, data: Uint8Array): Promise<boolean> {
-    return await window.crypto.subtle.verify(ED25519, this.keypair.publicKey, signature, data);
+  async verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
+    return await this.keypair.verify(signature, data);
   }
 
   // Save this key into a per-origin singleton storage.
@@ -60,7 +48,7 @@ export class RootKey {
       throw new Error("common-identity: No prf found from PassKey");
     }
 
-    const keypair = await rawToEd25519KeyPair(seed);
+    const keypair = await Ed25519KeyPair.generateFromRaw(seed);
     return new RootKey(keypair);
   }
 

--- a/typescript/packages/common-identity/src/space-key.ts
+++ b/typescript/packages/common-identity/src/space-key.ts
@@ -1,0 +1,28 @@
+import { Ed25519KeyPair } from "./ed25519/index.js";
+import { KeyPair, KeyPairRaw } from "./keys.js";
+
+export class SpaceKey implements KeyPair {
+  private keypair: Ed25519KeyPair;
+  constructor(keypair: Ed25519KeyPair) {
+    this.keypair = keypair;
+  }
+
+  // Sign `data` with this `RootKey`.
+  async sign(data: Uint8Array): Promise<Uint8Array> {
+    return await this.keypair.sign(data);
+  }
+ 
+  // Verify `signature` and `data` with this `RootKey`.
+  async verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
+    return await this.keypair.verify(signature, data);
+  }
+
+  serialize(): KeyPairRaw {
+    return this.keypair.serialize();
+  }
+
+  // Generate a `RootKey` from a `PassKey`.
+  static async generate(): Promise<SpaceKey> {
+    return new SpaceKey(await Ed25519KeyPair.generate());
+  }
+}

--- a/typescript/packages/common-identity/src/utils.ts
+++ b/typescript/packages/common-identity/src/utils.ts
@@ -1,5 +1,3 @@
-import * as ed25519 from "@noble/ed25519";
-
 export function random(length: number): Uint8Array {
   const buffer = new Uint8Array(length);
   window.crypto.getRandomValues(buffer);
@@ -19,29 +17,7 @@ export function once(target: EventTarget, eventName: string, callback: (e: any) 
   target.addEventListener(eventName, wrap);
 }
 
-// 0x302e020100300506032b657004220420
-// via https://stackoverflow.com/a/79135112
-const PKCS8_PREFIX = new Uint8Array([ 48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32 ]);
-
-// Private Ed25519 keys cannot be imported into Subtle Crypto in "raw" format.
-// Convert to "pkcs8" before doing so.
-// 
-// @AUDIT
-// via https://stackoverflow.com/a/79135112
-export function ed25519RawToPkcs8(rawPrivateKey: Uint8Array): Uint8Array {
-  return new Uint8Array([...PKCS8_PREFIX, ...rawPrivateKey]);
-}
-
-// Derive a ed25519 `CryptoKeyPair` from a 32-byte seed.
-export async function rawToEd25519KeyPair(seed: Uint8Array): Promise<CryptoKeyPair> {
-  const pkcs8Private = ed25519RawToPkcs8(seed);
-  const rawPublic = await ed25519.getPublicKey(seed);
-  const privateKey = await window.crypto.subtle.importKey("pkcs8", pkcs8Private, { name: "Ed25519" }, false, ["sign"]);
-  const publicKey = await window.crypto.subtle.importKey("raw", rawPublic, { name: "Ed25519" }, false, ["verify"]);
-  return { publicKey, privateKey };
-}
-
-// Derive a RSA `CryptoKeyPair` from a 32-byte seed.
-export async function rawToRSAKeyPair(_seed: Uint8Array): Promise<CryptoKeyPair> {
-  throw new Error("TODO");
+const HASH_ALG = "SHA-512";
+export async function hash(input: Uint8Array): Promise<Uint8Array> {
+  return new Uint8Array(await window.crypto.subtle.digest(HASH_ALG, input));
 }

--- a/typescript/packages/common-identity/test/ed25519.test.js
+++ b/typescript/packages/common-identity/test/ed25519.test.js
@@ -1,0 +1,24 @@
+import { NativeEd25519 } from "../lib/src/ed25519/native.js";
+import { NobleEd25519 } from "../lib/src/ed25519/noble.js";
+import { bytesEqual, assert } from "./utils.js";
+
+describe("ed25519 comparison", async () => {
+  it("ed25519 is supported in this environment", async () => {
+    assert(await NativeEd25519.isSupported());
+  });
+
+  it("has same results in both impls when generating from noble", async () => {
+    let noble = await NobleEd25519.generate();
+    let native = await NativeEd25519.generateFromRaw(noble.keypair.privateKey);
+    let buffer = new Uint8Array(32).fill(10);
+    let nobleSig = await noble.sign(buffer);
+    let nativeSig = await native.sign(buffer);
+    assert(bytesEqual(nobleSig, nativeSig));
+    // Impls verify other impl's sig
+    assert(await noble.verify(nativeSig, buffer))
+    assert(await native.verify(nobleSig, buffer))
+    // Base case that should fail
+    assert(!await noble.verify(nobleSig, new Uint8Array(32).fill(1)));
+    assert(!await native.verify(nativeSig, new Uint8Array(32).fill(1)));
+  });
+})

--- a/typescript/packages/common-identity/test/utils.js
+++ b/typescript/packages/common-identity/test/utils.js
@@ -1,0 +1,15 @@
+export const assert = (condition) => {
+  if (!condition) {
+    throw new Error("assertion failed.");
+  }
+}
+
+export const bytesEqual = (a, b) => {
+  let aLen = a.length;
+  let bLen = b.length;
+  if (aLen != bLen) return false;
+  for (let i = 0; i < aLen; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}

--- a/typescript/packages/common-identity/web-test-runner.config.js
+++ b/typescript/packages/common-identity/web-test-runner.config.js
@@ -1,0 +1,14 @@
+import { chromeLauncher } from '@web/test-runner-chrome';
+
+const ED25519_FLAG = "--enable-experimental-web-platform-features";
+export default {
+  browsers: [
+    chromeLauncher({
+      launchOptions: {
+        headless: true,
+        devtools: true,
+        args: [ED25519_FLAG],
+      },
+    }),
+  ],
+};

--- a/typescript/packages/common-iframe-sandbox/package.json
+++ b/typescript/packages/common-iframe-sandbox/package.json
@@ -35,6 +35,6 @@
     "typescript": "^5.7.3",
     "vite": "^6.0.11",
     "vite-plugin-dts": "^4.5.0",
-    "@web/test-runner": "^0.19.0"
+    "@web/test-runner": "^0.20.0"
   }
 }

--- a/typescript/packages/common-ui/package.json
+++ b/typescript/packages/common-ui/package.json
@@ -40,6 +40,6 @@
     "typescript": "^5.7.3",
     "vite": "^6.0.11",
     "vite-plugin-dts": "^4.5.0",
-    "@web/test-runner": "^0.19.0"
+    "@web/test-runner": "^0.20.0"
   }
 }

--- a/typescript/packages/pnpm-lock.yaml
+++ b/typescript/packages/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       '@web/test-runner':
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^0.20.0
+        version: 0.20.0
       eslint:
         specifier: ^9.19.0
         version: 9.19.0(jiti@2.4.2)
@@ -159,8 +159,8 @@ importers:
   common-identity:
     dependencies:
       '@noble/ed25519':
-        specifier: '*'
-        version: 1.7.3
+        specifier: ^2.2.3
+        version: 2.2.3
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -172,8 +172,11 @@ importers:
         specifier: ^22.10.10
         version: 22.12.0
       '@web/test-runner':
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^0.20.0
+        version: 0.20.0
+      '@web/test-runner-chrome':
+        specifier: ^0.18.0
+        version: 0.18.0
       esbuild:
         specifier: '*'
         version: 0.24.2
@@ -218,8 +221,8 @@ importers:
         specifier: ^22.10.10
         version: 22.10.10
       '@web/test-runner':
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^0.20.0
+        version: 0.20.0
       eslint:
         specifier: ^9.19.0
         version: 9.19.0(jiti@2.4.2)
@@ -428,8 +431,8 @@ importers:
         specifier: ^22.10.10
         version: 22.10.10
       '@web/test-runner':
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^0.20.0
+        version: 0.20.0
       eslint:
         specifier: ^9.19.0
         version: 9.19.0(jiti@2.4.2)
@@ -1090,8 +1093,8 @@ packages:
     peerDependencies:
       three: '>= 0.159.0'
 
-  '@noble/ed25519@1.7.3':
-    resolution: {integrity: sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==}
+  '@noble/ed25519@2.2.3':
+    resolution: {integrity: sha512-iHV8eI2mRcUmOx159QNrU8vTpQ/Xm70yJ2cTk3Trc86++02usfqFoNl6x0p3JN81ZDS/1gx6xiK0OwrgqCT43g==}
 
   '@noble/hashes@1.3.3':
     resolution: {integrity: sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==}
@@ -1117,8 +1120,8 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@puppeteer/browsers@2.6.1':
-    resolution: {integrity: sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==}
+  '@puppeteer/browsers@2.7.1':
+    resolution: {integrity: sha512-MK7rtm8JjaxPN7Mf1JdZIZKPD2Z+W7osvrC1vjpvfOX1K0awDIHYbNi89f7eotp7eMUn2shWnt03HwVbriXtKQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1965,8 +1968,8 @@ packages:
     resolution: {integrity: sha512-GzfK5disEJ6wEjoPwx8AVNwUe9gYIiwc+x//QYxYDAFKUp4Xb1OJAGLc2l2gVrSQmtPGLKrTRcW90Hv4pEq1qA==}
     engines: {node: '>=18.0.0'}
 
-  '@web/test-runner-chrome@0.17.0':
-    resolution: {integrity: sha512-Il5N9z41NKWCrQM1TVgRaDWWYoJtG5Ha4fG+cN1MWL2OlzBS4WoOb4lFV3EylZ7+W3twZOFr1zy2Rx61yDYd/A==}
+  '@web/test-runner-chrome@0.18.0':
+    resolution: {integrity: sha512-EkB70HtHwY36pIbgn9HzqtKAv+i53qa0/UBrs+H0m8j24TxIEH9oWIdF9O/RFxjYpla7fIvZMhOFOjejgrRU5g==}
     engines: {node: '>=18.0.0'}
 
   '@web/test-runner-commands@0.9.0':
@@ -1985,8 +1988,8 @@ packages:
     resolution: {integrity: sha512-ZL9F6FXd0DBQvo/h/+mSfzFTSRVxzV9st/AHhpgABtUtV/AIpVE9to6+xdkpu6827kwjezdpuadPfg+PlrBWqQ==}
     engines: {node: '>=18.0.0'}
 
-  '@web/test-runner@0.19.0':
-    resolution: {integrity: sha512-qLUupi88OK1Kl52cWPD/2JewUCRUxYsZ1V1DyLd05P7u09zCdrUYrtkB/cViWyxlBe/TOvqkSNpcTv6zLJ9GoA==}
+  '@web/test-runner@0.20.0':
+    resolution: {integrity: sha512-xN+4wgEm5xh0VSiC08eUYXW0QDt/NuzZyey4s7Nnjyjs9NkuJHd1jG9aNzfgL1edpJJ/RldHc0KiM2to1h2kxQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2169,9 +2172,6 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
@@ -2255,8 +2255,8 @@ packages:
     engines: {node: '>=12.13.0'}
     hasBin: true
 
-  chromium-bidi@0.11.0:
-    resolution: {integrity: sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==}
+  chromium-bidi@1.3.0:
+    resolution: {integrity: sha512-G3x1bkST13kmbL7+dT/oRkNH/7C4UqG+0YQpmySrzXspyOhYgDNc6lhSGpj3cuexvH25WTENhTYq2Tt9JRXtbw==}
     peerDependencies:
       devtools-protocol: '*'
 
@@ -2461,8 +2461,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  devtools-protocol@0.0.1367902:
-    resolution: {integrity: sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==}
+  devtools-protocol@0.0.1402036:
+    resolution: {integrity: sha512-JwAYQgEvm3yD45CHB+RmF5kMbWtXBaOGwuxa87sZogHcLCv8c/IqnThaoQ1y60d7pXWjSKWQphPEc+1rAScVdg==}
 
   diff-match-patch@1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
@@ -3642,8 +3642,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  puppeteer-core@23.11.1:
-    resolution: {integrity: sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==}
+  puppeteer-core@24.2.1:
+    resolution: {integrity: sha512-bCypUh3WXzETafv1TCFAjIUnI8BiQ/d+XvEfEXDLcIMm9CAvROqnBmbt79yBjwasoDZsgfXnUmIJU7Y27AalVQ==}
     engines: {node: '>=18'}
 
   qr-creator@1.0.0:
@@ -3853,6 +3853,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
@@ -4055,9 +4060,6 @@ packages:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
 
-  through@2.3.8:
-    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -4172,9 +4174,6 @@ packages:
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
-
-  unbzip2-stream@1.4.3:
-    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
@@ -4448,9 +4447,6 @@ packages:
     resolution: {integrity: sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==}
     peerDependencies:
       zod: ^3.24.1
-
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
   zod@3.24.1:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
@@ -5038,7 +5034,7 @@ snapshots:
       promise-worker-transferable: 1.0.4
       three: 0.173.0
 
-  '@noble/ed25519@1.7.3': {}
+  '@noble/ed25519@2.2.3': {}
 
   '@noble/hashes@1.3.3': {}
 
@@ -5058,15 +5054,14 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@puppeteer/browsers@2.6.1':
+  '@puppeteer/browsers@2.7.1':
     dependencies:
       debug: 4.4.0
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.6.3
+      semver: 7.7.1
       tar-fs: 3.0.8
-      unbzip2-stream: 1.4.3
       yargs: 17.7.2
     transitivePeerDependencies:
       - bare-buffer
@@ -6068,13 +6063,13 @@ snapshots:
       '@types/parse5': 6.0.3
       parse5: 6.0.1
 
-  '@web/test-runner-chrome@0.17.0':
+  '@web/test-runner-chrome@0.18.0':
     dependencies:
       '@web/test-runner-core': 0.13.4
       '@web/test-runner-coverage-v8': 0.8.0
       async-mutex: 0.4.0
       chrome-launcher: 0.15.2
-      puppeteer-core: 23.11.1
+      puppeteer-core: 24.2.1
     transitivePeerDependencies:
       - bare-buffer
       - bufferutil
@@ -6143,12 +6138,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@web/test-runner@0.19.0':
+  '@web/test-runner@0.20.0':
     dependencies:
       '@web/browser-logs': 0.4.1
       '@web/config-loader': 0.3.2
       '@web/dev-server': 0.4.6
-      '@web/test-runner-chrome': 0.17.0
+      '@web/test-runner-chrome': 0.18.0
       '@web/test-runner-commands': 0.9.0
       '@web/test-runner-core': 0.13.4
       '@web/test-runner-mocha': 0.9.0
@@ -6332,11 +6327,6 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -6415,11 +6405,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  chromium-bidi@0.11.0(devtools-protocol@0.0.1367902):
+  chromium-bidi@1.3.0(devtools-protocol@0.0.1402036):
     dependencies:
-      devtools-protocol: 0.0.1367902
+      devtools-protocol: 0.0.1402036
       mitt: 3.0.1
-      zod: 3.23.8
+      zod: 3.24.1
 
   cli-cursor@3.1.0:
     dependencies:
@@ -6594,7 +6584,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  devtools-protocol@0.0.1367902: {}
+  devtools-protocol@0.0.1402036: {}
 
   diff-match-patch@1.0.5: {}
 
@@ -7407,7 +7397,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.3
 
   marky@1.2.5: {}
 
@@ -7941,12 +7931,12 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  puppeteer-core@23.11.1:
+  puppeteer-core@24.2.1:
     dependencies:
-      '@puppeteer/browsers': 2.6.1
-      chromium-bidi: 0.11.0(devtools-protocol@0.0.1367902)
+      '@puppeteer/browsers': 2.7.1
+      chromium-bidi: 1.3.0(devtools-protocol@0.0.1402036)
       debug: 4.4.0
-      devtools-protocol: 0.0.1367902
+      devtools-protocol: 0.0.1402036
       typed-query-selector: 2.12.0
       ws: 8.18.0
     transitivePeerDependencies:
@@ -8180,6 +8170,8 @@ snapshots:
 
   semver@7.6.3: {}
 
+  semver@7.7.1: {}
+
   set-cookie-parser@2.7.1: {}
 
   setprototypeof@1.1.0: {}
@@ -8383,8 +8375,6 @@ snapshots:
 
   throttleit@2.1.0: {}
 
-  through@2.3.8: {}
-
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -8475,11 +8465,6 @@ snapshots:
   ua-parser-js@1.0.40: {}
 
   ufo@1.5.4: {}
-
-  unbzip2-stream@1.4.3:
-    dependencies:
-      buffer: 5.7.1
-      through: 2.3.8
 
   undici-types@6.20.0: {}
 
@@ -8831,8 +8816,6 @@ snapshots:
   zod-to-json-schema@3.24.1(zod@3.24.1):
     dependencies:
       zod: 3.24.1
-
-  zod@3.23.8: {}
 
   zod@3.24.1: {}
 


### PR DESCRIPTION
 chore: Add tests and fallback for client-side ed25519 implementation.

* Introduce DerivedKey, SpaceKey
* Introduce Ed25519KeyPair, wrapping native and client (@noble/ed25519)
  implementations.
* Add unit tests. Enable ed25519 flags in Chromium while running.
* Update @web/test-runner everywhere to 0.20.0.