### PR TITLE
Common-html/render: Cleanup, DOM diffing & lots of helpers & fixes discovered while doing so

### DIFF
--- a/typescript/packages/common-html/src/jsx.ts
+++ b/typescript/packages/common-html/src/jsx.ts
@@ -1,3 +1,5 @@
+import type { Cell, Stream } from "@commontools/runner";
+
 declare global {
   namespace JSX {
     interface IntrinsicElements {
@@ -32,18 +34,18 @@ export function h(
  * variable (dynamic).
  */
 export type Props = {
-  [key: string]: string | number | boolean | object | Array<any> | null;
+  [key: string]: string | number | boolean | object | Array<any> | null | Cell<any> | Stream<any>;
 };
 
 /** A child in a view can be one of a few things */
-export type Child = VNode | string;
+export type Child = VNode | string | Cell<Child> | Array<Child>;
 
 /** A "virtual view node", e.g. a virtual DOM element */
 export type VNode = {
   type: "vnode";
   name: string;
   props: Props;
-  children: Array<Child>;
+  children: Array<Child> | Cell<Array<Child>>;
 };
 
 export const isVNode = (value: unknown): value is VNode => {

--- a/typescript/packages/common-html/src/render.ts
+++ b/typescript/packages/common-html/src/render.ts
@@ -64,7 +64,10 @@ export const renderImpl = (parent: HTMLElement, view: VNode): Cancel => {
   }
   parent.append(root);
   logger.debug("Rendered", root);
-  return cancel;
+  return () => {
+    root.remove();
+    cancel();
+  };
 };
 
 export default render;

--- a/typescript/packages/common-html/src/render.ts
+++ b/typescript/packages/common-html/src/render.ts
@@ -1,4 +1,4 @@
-import { isVNode } from "./jsx.js";
+import { isVNode, type Child, type Props, type VNode } from "./jsx.js";
 import {
   effect,
   useCancelGroup,
@@ -6,7 +6,6 @@ import {
   type Cell,
   isCell,
   isStream,
-  Stream,
 } from "@commontools/runner";
 import { JSONSchema } from "@commontools/builder";
 import * as logger from "./logger.js";
@@ -35,19 +34,6 @@ const vdomSchema: JSONSchema = {
     },
   },
 } as const;
-
-type Props = {
-  [key: string]: string | number | boolean | object | Array<any> | null | Cell<any> | Stream<any>;
-};
-
-type VNode = {
-  type: "vnode";
-  name: string;
-  props: Props;
-  children: Array<Child> | Cell<Array<Child>>;
-};
-
-type Child = VNode | string;
 
 /** Render a view into a parent element */
 export const render = (parent: HTMLElement, view: VNode | Cell<VNode>): Cancel => {

--- a/typescript/packages/common-runner/src/cancel.ts
+++ b/typescript/packages/common-runner/src/cancel.ts
@@ -49,3 +49,5 @@ export const useCancelGroup = (): [Cancel, AddCancel] => {
 
   return [cancelAll, addCancel];
 };
+
+export const noOp = () => {};

--- a/typescript/packages/common-runner/src/cell-map.ts
+++ b/typescript/packages/common-runner/src/cell-map.ts
@@ -76,11 +76,10 @@ export const createRef = (source: Object = {}, cause: any = crypto.randomUUID())
  * @param value - The value to extract the entity ID from.
  * @returns The entity ID, or undefined if the value is not a cell.
  */
-export const getEntityId = (value: any): EntityId | undefined => {
-  if (typeof value === "string") return JSON.parse(value) as EntityId;
-  if (typeof value === "object" && value !== null && "/" in value) {
-    return value as EntityId;
-  }
+export const getEntityId = (value: any): { "/": string } | undefined => {
+  if (typeof value === "string") return JSON.parse(value);
+  if (typeof value === "object" && value !== null && "/" in value)
+    return JSON.parse(JSON.stringify(value));
 
   let ref: DocLink | undefined = undefined;
 
@@ -92,8 +91,9 @@ export const getEntityId = (value: any): EntityId | undefined => {
   if (!ref?.cell.entityId) return undefined;
 
   if (ref.path.length > 0) {
-    return createRef({ path: ref.path }, ref.cell.entityId);
-  } else return ref.cell.entityId;
+    console.warn("getEntityId: path support experimental", ref.path);
+    return JSON.parse(JSON.stringify(createRef({ path: ref.path }, ref.cell.entityId)));
+  } else return JSON.parse(JSON.stringify(ref.cell.entityId));
 };
 
 export function getDocByEntityId<T = any>(

--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -141,7 +141,7 @@ function createRegularCell<T>(
   rootSchema?: JSONSchema,
 ): Cell<T> {
   const self: Cell<T> = {
-    get: () => validateAndTransform(doc, path, schema, log),
+    get: () => validateAndTransform(doc, path, schema, log, rootSchema),
     set: (newValue: T) => {
       // TODO: This doesn't respect aliases on write. Should it?
       const ref = resolvePath(doc, path, log);
@@ -249,13 +249,13 @@ function subscribeToReferencedDocs<T>(
   } satisfies ReactivityLog;
 
   // Get the value once to determine all the docs that need to be subscribed to.
-  const value = validateAndTransform(doc, path, schema, initialLog, false, rootSchema) as T;
+  const value = validateAndTransform(doc, path, schema, initialLog, rootSchema) as T;
 
   // Subscribe to the docs that are read (via logs), call callback on next change.
   let cleanup: Cancel | undefined;
   const cancel = subscribe((log) => {
     if (isCancel(cleanup)) cleanup();
-    const newValue = validateAndTransform(doc, path, schema, log, false, rootSchema) as T;
+    const newValue = validateAndTransform(doc, path, schema, log, rootSchema) as T;
     cleanup = callback(newValue);
     console.log("subscribeToReferencedDocs update", {
       id: JSON.stringify(doc),

--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -247,12 +247,15 @@ function subscribeToReferencedDocs<T>(
     reads: [],
     writes: [],
   } satisfies ReactivityLog;
+  let cleanup: Cancel | undefined;
 
   // Get the value once to determine all the docs that need to be subscribed to.
   const value = validateAndTransform(doc, path, schema, initialLog, rootSchema) as T;
 
+  // Call the callback once with initial value if requested.
+  if (callCallbackOnFirstRun) cleanup = callback(value);
+
   // Subscribe to the docs that are read (via logs), call callback on next change.
-  let cleanup: Cancel | undefined;
   const cancel = subscribe((log) => {
     if (isCancel(cleanup)) cleanup();
     const newValue = validateAndTransform(doc, path, schema, log, rootSchema) as T;
@@ -274,9 +277,6 @@ function subscribeToReferencedDocs<T>(
     value,
     initialLog,
   });
-
-  // Call the callback once with initial value if requested.
-  if (callCallbackOnFirstRun) cleanup = callback(value);
 
   return () => {
     cancel();

--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -1,4 +1,4 @@
-import { isAlias, isStreamAlias } from "@commontools/builder";
+import { isStreamAlias } from "@commontools/builder";
 import { getTopFrame, type JSONSchema } from "@commontools/builder";
 import { getDoc, isDoc, isDocLink, type DocImpl, type DocLink, type DeepKeyLookup } from "./doc.js";
 import {

--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -262,35 +262,11 @@ function subscribeToReferencedDocs<T>(
     if (isCancel(cleanup)) cleanup();
     const newValue = validateAndTransform(doc, path, schema, log, rootSchema) as T;
     cleanup = callback(newValue);
-    console.log("subscribeToReferencedDocs update", JSON.stringify(doc), {
-      //doc,
-      path,
-      schema,
-      newValue,
-      log,
-      value,
-      initialLog: JSON.stringify(initialLog),
-    });
   }, initialLog);
-
-  console.log("subscribeToReferencedDocs", JSON.stringify(doc), {
-    //doc,
-    path,
-    schema,
-    value,
-    initialLog: JSON.stringify(initialLog),
-  });
 
   return () => {
     cancel();
     if (isCancel(cleanup)) cleanup();
-    console.log("subscribeToReferencedDocs cleanup", JSON.stringify(doc), {
-      //doc,
-      path,
-      schema,
-      value,
-      initialLog: JSON.stringify(initialLog),
-    });
   };
 }
 

--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -74,7 +74,7 @@ export interface Cell<T> {
     log?: ReactivityLog,
   ): QueryResult<DeepKeyLookup<T, Path>>;
   getAsDocLink(): DocLink;
-  toJSON(): { "/": string } | undefined;
+  toJSON(): { cell: { "/": string } | undefined; path: PropertyKey[] };
   value: T;
   docLink: DocLink;
   entityId: EntityId | undefined;
@@ -238,7 +238,12 @@ function createRegularCell<T>(
     getAsQueryResult: (subPath: PropertyKey[] = [], newLog?: ReactivityLog) =>
       createQueryResultProxy(doc, [...path, ...subPath], newLog ?? log),
     getAsDocLink: () => ({ cell: doc, path }) satisfies DocLink,
-    toJSON: () => doc.toJSON(),
+    toJSON: () =>
+      // TODO: Should this include the schema, as cells are defiined by doclink & schema?
+      ({ cell: doc.toJSON(), path }) satisfies {
+        cell: { "/": string } | undefined;
+        path: PropertyKey[];
+      },
     get value(): T {
       return self.get();
     },

--- a/typescript/packages/common-runner/src/doc.ts
+++ b/typescript/packages/common-runner/src/doc.ts
@@ -73,6 +73,7 @@ export type DocImpl<T> = {
     path?: Path,
     log?: ReactivityLog,
     schema?: JSONSchema,
+    rootSchema?: JSONSchema,
   ): Cell<DeepKeyLookup<Q, Path>>;
 
   /**
@@ -245,7 +246,8 @@ export function getDoc<T>(value?: T, cause?: any): DocImpl<T> {
       path?: Path,
       log?: ReactivityLog,
       schema?: JSONSchema,
-    ) => createCell<Q>(self, path || [], log, schema),
+      rootSchema?: JSONSchema,
+    ) => createCell<Q>(self, path || [], log, schema, rootSchema),
     send: (newValue: T, log?: ReactivityLog) => self.setAtPath([], newValue, log),
     updates: (callback: (value: T, path: PropertyKey[]) => void) => {
       callbacks.add(callback);

--- a/typescript/packages/common-runner/src/index.ts
+++ b/typescript/packages/common-runner/src/index.ts
@@ -2,26 +2,18 @@ export { run, stop } from "./runner.js";
 export { addModuleByRef, raw } from "./module.js";
 export { type Action, idle, run as addAction, unschedule as removeAction } from "./scheduler.js";
 export type { DocImpl, DocLink } from "./doc.js";
-export type { Cell } from "./cell.js";
+export type { Cell, Stream } from "./cell.js";
 export type { QueryResult } from "./query-result-proxy.js";
 export type { ReactivityLog } from "./scheduler.js";
 export { getDoc, isDoc, isDocLink } from "./doc.js";
-export { isCell } from "./cell.js";
+export { isCell, isStream } from "./cell.js";
 export {
   getDocLinkOrThrow,
   getDocLinkOrValue,
   isQueryResult,
   isQueryResultForDereferencing,
 } from "./query-result-proxy.js";
-export {
-  effect,
-  type GettableCell,
-  isGettable,
-  isReactive,
-  isSendable,
-  type ReactiveCell,
-  type SendableCell,
-} from "./reactivity.js";
+export { effect } from "./reactivity.js";
 export { createRef, type EntityId, getDocByEntityId, getEntityId } from "./cell-map.js";
 export {
   addRecipe,
@@ -33,4 +25,4 @@ export {
   getRecipeSpec,
   getRecipeSrc,
 } from "./recipe-map.js";
-export { type AddCancel, type Cancel, useCancelGroup } from "./cancel.js";
+export { type AddCancel, type Cancel, useCancelGroup, noOp } from "./cancel.js";

--- a/typescript/packages/common-runner/src/reactivity.ts
+++ b/typescript/packages/common-runner/src/reactivity.ts
@@ -1,7 +1,6 @@
 import { Cancel, isCancel, noOp } from "./cancel.js";
 import { Cell, isCell } from "./cell.js";
-import { DocImpl, isDoc, isDocLink } from "./doc.js";
-import { getDocLinkOrThrow, isQueryResultForDereferencing } from "./query-result-proxy.js";
+import { DocImpl, isDoc } from "./doc.js";
 
 /**
  * Effect that runs a callback when the value changes. The callback is also
@@ -16,6 +15,8 @@ export const effect = <T>(
   value: Cell<T> | DocImpl<T> | T,
   callback: (value: T) => Cancel | undefined | void,
 ): Cancel => {
+  if (isDoc(value)) value = value.asCell();
+
   if (isCell(value) || isDoc(value)) {
     return value.sink(callback);
   } else {

--- a/typescript/packages/common-runner/src/reactivity.ts
+++ b/typescript/packages/common-runner/src/reactivity.ts
@@ -26,7 +26,7 @@ export const effect = <T>(
   if (isCell(value)) {
     return value.sink(callback);
   } else {
-    const cancel = callback(value);
+    const cancel = callback(value as T);
     return isCancel(cancel) ? cancel : noOp;
   }
 };

--- a/typescript/packages/common-runner/src/reactivity.ts
+++ b/typescript/packages/common-runner/src/reactivity.ts
@@ -1,58 +1,5 @@
-import { Cancel, isCancel } from "./cancel.js";
-
-export interface ReactiveCell<T> {
-  sink(callback: (value: T) => void): () => void;
-}
-
-export interface GettableCell<T> {
-  get(): T;
-}
-
-export interface SendableCell<T> {
-  send(value: T): void;
-}
-
-/**
- * Check if value is a reactive cell.
- *
- * @param {any} value - The value to check.
- * @returns {boolean}
- */
-export const isReactive = <T = unknown>(value: ReactiveCell<T> | T): value is ReactiveCell<T> => {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "sink" in value &&
-    typeof value.sink === "function"
-  );
-};
-
-/**
- * Check if value is a gettable cell.
- *
- * @param {any} value - The value to check.
- * @returns {boolean}
- */
-export const isGettable = <T = unknown>(value: unknown): value is GettableCell<T> => {
-  return (
-    typeof value === "object" && value !== null && "get" in value && typeof value.get === "function"
-  );
-};
-
-/**
- * Check if value is a sendable cell.
- *
- * @param {any} value - The value to check.
- * @returns {boolean}
- */
-export const isSendable = <T = unknown>(value: unknown): value is SendableCell<T> => {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "send" in value &&
-    typeof value.send === "function"
-  );
-};
+import { Cancel, noOp } from "./cancel.js";
+import { Cell, isCell } from "./cell.js";
 
 /**
  * Effect that runs a callback when the value changes. The callback is also
@@ -63,22 +10,11 @@ export const isSendable = <T = unknown>(value: unknown): value is SendableCell<T
  * @param {function} callback - The callback to run when the value changes.
  * @returns {function} - A function to cancel the effect.
  */
-export const effect = <T>(
-  value: ReactiveCell<T> | T,
-  callback: (value: T) => Cancel | void,
-): Cancel => {
-  const listener = () => {
-    let cleanup: Cancel = noOp;
-    return (value: ReactiveCell<T> | T) => {
-      cleanup();
-      const next = isReactive(value) ? value.sink(listener()) : callback(value);
-      cleanup = isCancel(next) ? next : noOp;
-      return next;
-    };
-  };
-
-  const next = listener()(value);
-  return isCancel(next) ? next : noOp;
+export const effect = <T>(value: Cell<T> | T, callback: (value: T) => Cancel | void): Cancel => {
+  if (isCell(value)) {
+    return value.sink(callback);
+  } else {
+    callback(value);
+    return noOp;
+  }
 };
-
-const noOp = () => {};

--- a/typescript/packages/common-runner/src/reactivity.ts
+++ b/typescript/packages/common-runner/src/reactivity.ts
@@ -16,14 +16,7 @@ export const effect = <T>(
   value: Cell<T> | DocImpl<T> | T,
   callback: (value: T) => Cancel | undefined | void,
 ): Cancel => {
-  if (isDoc(value)) {
-    value = value.asCell();
-  } else {
-    if (isQueryResultForDereferencing(value)) value = getDocLinkOrThrow(value) as any;
-    if (isDocLink(value)) value = value.cell.asCell(value.path);
-  }
-
-  if (isCell(value)) {
+  if (isCell(value) || isDoc(value)) {
     return value.sink(callback);
   } else {
     const cancel = callback(value as T);

--- a/typescript/packages/common-runner/src/reactivity.ts
+++ b/typescript/packages/common-runner/src/reactivity.ts
@@ -1,5 +1,7 @@
 import { Cancel, isCancel, noOp } from "./cancel.js";
 import { Cell, isCell } from "./cell.js";
+import { isDoc, isDocLink } from "./doc.js";
+import { getDocLinkOrThrow, isQueryResultForDereferencing } from "./query-result-proxy.js";
 
 /**
  * Effect that runs a callback when the value changes. The callback is also
@@ -14,6 +16,13 @@ export const effect = <T>(
   value: Cell<T> | T,
   callback: (value: T) => Cancel | undefined | void,
 ): Cancel => {
+  if (isDoc(value)) {
+    value = value.asCell();
+  } else {
+    if (isQueryResultForDereferencing(value)) value = getDocLinkOrThrow(value) as any;
+    if (isDocLink(value)) value = value.cell.asCell(value.path);
+  }
+
   if (isCell(value)) {
     return value.sink(callback);
   } else {

--- a/typescript/packages/common-runner/src/reactivity.ts
+++ b/typescript/packages/common-runner/src/reactivity.ts
@@ -1,6 +1,6 @@
 import { Cancel, isCancel, noOp } from "./cancel.js";
 import { Cell, isCell } from "./cell.js";
-import { isDoc, isDocLink } from "./doc.js";
+import { DocImpl, isDoc, isDocLink } from "./doc.js";
 import { getDocLinkOrThrow, isQueryResultForDereferencing } from "./query-result-proxy.js";
 
 /**
@@ -13,7 +13,7 @@ import { getDocLinkOrThrow, isQueryResultForDereferencing } from "./query-result
  * @returns {function} - A function to cancel the effect.
  */
 export const effect = <T>(
-  value: Cell<T> | T,
+  value: Cell<T> | DocImpl<T> | T,
   callback: (value: T) => Cancel | undefined | void,
 ): Cancel => {
   if (isDoc(value)) {

--- a/typescript/packages/common-runner/src/reactivity.ts
+++ b/typescript/packages/common-runner/src/reactivity.ts
@@ -1,4 +1,4 @@
-import { Cancel, noOp } from "./cancel.js";
+import { Cancel, isCancel, noOp } from "./cancel.js";
 import { Cell, isCell } from "./cell.js";
 
 /**
@@ -10,11 +10,14 @@ import { Cell, isCell } from "./cell.js";
  * @param {function} callback - The callback to run when the value changes.
  * @returns {function} - A function to cancel the effect.
  */
-export const effect = <T>(value: Cell<T> | T, callback: (value: T) => Cancel | void): Cancel => {
+export const effect = <T>(
+  value: Cell<T> | T,
+  callback: (value: T) => Cancel | undefined | void,
+): Cancel => {
   if (isCell(value)) {
     return value.sink(callback);
   } else {
-    callback(value);
-    return noOp;
+    const cancel = callback(value);
+    return isCancel(cancel) ? cancel : noOp;
   }
 };

--- a/typescript/packages/common-runner/src/schema.ts
+++ b/typescript/packages/common-runner/src/schema.ts
@@ -61,7 +61,7 @@ export function validateAndTransform(
       (Array.isArray(resolvedSchema?.anyOf) &&
         resolvedSchema.anyOf.every((option) => option.asCell)))
   )
-    return doc.asCell(path, log, resolvedSchema);
+    return doc.asCell(path, log, resolvedSchema, rootSchema);
 
   // If there is no schema, return as raw data via query result proxy
   if (!resolvedSchema) return doc.getAsQueryResult(path, log);

--- a/typescript/packages/common-runner/src/schema.ts
+++ b/typescript/packages/common-runner/src/schema.ts
@@ -4,6 +4,30 @@ import { isCell, createCell } from "./cell.js";
 import { type ReactivityLog } from "./scheduler.js";
 import { resolvePath, followLinks } from "./utils.js";
 
+/**
+ * Schemas are mostly a subset of JSONSchema.
+ *
+ * One addition is `asCell`. When true, the `.get()` returns an instance of
+ * `Cell`, i.e. a reactive reference to the value underneath. Some implications
+ * this has:
+ *  - If `log` is passed, it will be passed on to new cells, and unless that
+ *    cell is read, no further reads are logged down this branch.
+ *  - The cell reflects as closely as possible the current value. So it doesn't
+ *    change when the underlying reference changes. This is useful to e.g. to
+ *    read the current value of "currently selected item" and keep that constant
+ *    even if in the future another item is selected. NOTE:
+ *    - For this to work, the underlying value should be a reference itself.
+ *      Otherwise the closest parent document is used, so that e.g. reading
+ *      current.name tracks changes on current.
+ *    - If the value is an alias, aliases are followed first and the cell is
+ *      based on the first non-alias value. This is because writes will follow
+ *      aliases as well.
+ *
+ *  Calling `effect` on returned cells within a higher-level `effect` works as
+ *  expected. Be sure to track the cancels, though. (Tracking cancels isn't
+ *  necessary when using the schedueler directly)
+ */
+
 export function resolveSchema(
   schema: JSONSchema | undefined,
   rootSchema: JSONSchema | undefined = schema,

--- a/typescript/packages/common-runner/src/schema.ts
+++ b/typescript/packages/common-runner/src/schema.ts
@@ -79,7 +79,7 @@ export function validateAndTransform(
       if (isAlias(value))
         throw new Error("Unexpected alias in path, should have been handled by resolvePath");
       if (isDocLink(value)) {
-        log?.reads.push({ cell: doc, path: path.slice(0, i + 1), schemaAsCellLink: true });
+        log?.reads.push({ cell: doc, path: path.slice(0, i + 1) });
         return createCell(
           value.cell,
           [...value.path, ...path.slice(i + 1)],
@@ -102,7 +102,7 @@ export function validateAndTransform(
   // this set of links.
   const ref = followLinks({ cell: doc, path }, [], log);
   const value = ref.cell.getAtPath(ref.path);
-  log?.reads.push({ cell: ref.cell, path: ref.path, schema: true });
+  log?.reads.push({ cell: ref.cell, path: ref.path });
 
   // TODO: The behavior when one of the options is very permissive (e.g. no type
   // or an object that allows any props) is not well defined.

--- a/typescript/packages/common-runner/src/utils.ts
+++ b/typescript/packages/common-runner/src/utils.ts
@@ -318,7 +318,7 @@ export function resolvePath(
 
   // Follow aliases on the last key, but no other kinds of links.
   if (isAlias(ref.cell.getAtPath(ref.path))) {
-    log?.reads.push({ cell: ref.cell, path: ref.path, resolvePath: true });
+    log?.reads.push({ cell: ref.cell, path: ref.path });
     ref = followAliases(ref.cell.getAtPath(ref.path), ref.cell, log);
   }
 
@@ -346,7 +346,7 @@ export function followLinks(ref: DocLink, seen: DocLink[] = [], log?: Reactivity
 
     if (nextRef) {
       // Log all the refs that were followed, but not the final value they point to.
-      log?.reads.push({ cell: ref.cell, path: ref.path, followLinks: true });
+      log?.reads.push({ cell: ref.cell, path: ref.path });
 
       ref = nextRef;
 
@@ -369,7 +369,7 @@ export function followCellReferences(reference: DocLink, log?: ReactivityLog): a
   let result = reference;
 
   while (isDocLink(reference)) {
-    log?.reads.push({ cell: reference.cell, path: reference.path, followCellReferences: true });
+    log?.reads.push({ cell: reference.cell, path: reference.path });
     result = reference;
     if (seen.has(reference)) throw new Error("Reference cycle detected");
     seen.add(reference);
@@ -392,7 +392,7 @@ export function followAliases(alias: any, cell: DocImpl<any>, log?: ReactivityLo
     if (seen.has(alias)) throw new Error("Alias cycle detected");
     seen.add(alias);
     alias = cell.getAtPath(alias.$alias.path);
-    if (isAlias(alias)) log?.reads.push({ cell, path: alias.$alias.path, followAliases: true });
+    if (isAlias(alias)) log?.reads.push({ cell, path: alias.$alias.path });
   }
 
   return result!;

--- a/typescript/packages/common-runner/src/utils.ts
+++ b/typescript/packages/common-runner/src/utils.ts
@@ -287,8 +287,6 @@ export function findAllAliasedCells(binding: any, cell: DocImpl<any>): DocLink[]
 // Follows links and returns the last one
 export function followLinks(ref: DocLink, seen: DocLink[] = [], log?: ReactivityLog): DocLink {
   while (true) {
-    log?.reads.push({ cell: ref.cell, path: ref.path });
-
     if (seen.some((r) => r.cell === ref.cell && arrayEqual(r.path, ref.path)))
       throw new Error(
         `Reference cycle detected ${JSON.stringify(ref.cell.entityId ?? "unknown")} ${ref.path.join(".")}`,
@@ -307,6 +305,9 @@ export function followLinks(ref: DocLink, seen: DocLink[] = [], log?: Reactivity
         path: target.$alias.path,
       } satisfies DocLink;
     else return ref;
+
+    // Log all the refs that were followed, but not the final value they point to.
+    log?.reads.push({ cell: ref.cell, path: ref.path });
   }
 }
 

--- a/typescript/packages/common-runner/src/utils.ts
+++ b/typescript/packages/common-runner/src/utils.ts
@@ -404,7 +404,7 @@ export function compactifyPaths(entries: DocLink[]): DocLink[] {
   const cellToPaths = new Map<DocImpl<any>, PropertyKey[][]>();
   for (const { cell, path } of entries) {
     const paths = cellToPaths.get(cell) || [];
-    paths.push(path);
+    paths.push(path.map((key) => key.toString())); // Normalize to strings as keys
     cellToPaths.set(cell, paths);
   }
 
@@ -425,6 +425,7 @@ export function compactifyPaths(entries: DocLink[]): DocLink[] {
 }
 
 export function pathAffected(changedPath: PropertyKey[], path: PropertyKey[]) {
+  changedPath = changedPath.map((key) => key.toString()); // Normalize to strings as keys
   return (
     (changedPath.length <= path.length && changedPath.every((key, index) => key === path[index])) ||
     path.every((key, index) => key === changedPath[index])

--- a/typescript/packages/common-runner/src/utils.ts
+++ b/typescript/packages/common-runner/src/utils.ts
@@ -284,15 +284,53 @@ export function findAllAliasedCells(binding: any, cell: DocImpl<any>): DocLink[]
   return cells;
 }
 
+export function resolvePath(
+  doc: DocImpl<any>,
+  path: PropertyKey[],
+  log?: ReactivityLog,
+  seen: DocLink[] = [],
+): DocLink {
+  // Follow aliases, doc links, etc. in path, so that we end up on the right
+  // doc, meaning the one that contains the value we want to access without any
+  // redirects in between.
+  //
+  // If the path points to a redirect itself, we don't want to follow it: Other
+  // functions like followLwill do that. We just want to skip the interim ones.
+  //
+  // Let's look at a few examples:
+  //
+  // Doc: { link }, path: [] --> no change
+  // Doc: { link }, path: ["foo"] --> follow link, path: ["foo"]
+  // Doc: { foo: { link } }, path: ["foo"] --> no change
+  // Doc: { foo: { link } }, path: ["foo", "bar"] --> follow link, path: ["bar"]
+
+  let ref: DocLink = { cell: doc, path: [] };
+
+  let keys = [...path];
+  while (keys.length) {
+    // First follow all the aliases and links, _before_ accessing the key.
+    ref = followLinks(ref, seen, log);
+    doc = ref.cell;
+    path = [...ref.path, ...keys];
+
+    // Now access the key.
+    const key = keys.shift()!;
+    ref = { cell: doc, path: [...ref.path, key] };
+  }
+
+  // Follow aliases on the last key, but no other kinds of links.
+  if (isAlias(ref.cell.getAtPath(ref.path))) {
+    ref = followAliases(ref.cell.getAtPath(ref.path), ref.cell, log);
+    doc = ref.cell;
+    path = ref.path;
+  }
+
+  return ref;
+}
+
 // Follows links and returns the last one
 export function followLinks(ref: DocLink, seen: DocLink[] = [], log?: ReactivityLog): DocLink {
   while (true) {
-    if (seen.some((r) => r.cell === ref.cell && arrayEqual(r.path, ref.path)))
-      throw new Error(
-        `Reference cycle detected ${JSON.stringify(ref.cell.entityId ?? "unknown")} ${ref.path.join(".")}`,
-      );
-    seen.push(ref);
-
     const target = ref.cell.getAtPath(ref.path);
 
     if (isQueryResultForDereferencing(target)) ref = getDocLinkOrThrow(target);
@@ -307,7 +345,14 @@ export function followLinks(ref: DocLink, seen: DocLink[] = [], log?: Reactivity
     else return ref;
 
     // Log all the refs that were followed, but not the final value they point to.
-    log?.reads.push({ cell: ref.cell, path: ref.path });
+    log?.reads.push({ cell: ref.cell, path: ref.path, followLinks: true });
+
+    // Detect cycles (at this point these are all references that point to something)
+    if (seen.some((r) => r.cell === ref.cell && arrayEqual(r.path, ref.path)))
+      throw new Error(
+        `Reference cycle detected ${JSON.stringify(ref.cell.entityId ?? "unknown")} ${ref.path.join(".")}`,
+      );
+    seen.push(ref);
   }
 }
 
@@ -318,7 +363,7 @@ export function followCellReferences(reference: DocLink, log?: ReactivityLog): a
   let result = reference;
 
   while (isDocLink(reference)) {
-    log?.reads.push(reference);
+    log?.reads.push({ cell: reference.cell, path: reference.path, followCellReferences: true });
     result = reference;
     if (seen.has(reference)) throw new Error("Reference cycle detected");
     seen.add(reference);
@@ -341,7 +386,7 @@ export function followAliases(alias: any, cell: DocImpl<any>, log?: ReactivityLo
     if (seen.has(alias)) throw new Error("Alias cycle detected");
     seen.add(alias);
     alias = cell.getAtPath(alias.$alias.path);
-    if (isAlias(alias)) log?.reads.push({ cell, path: alias.$alias.path });
+    if (isAlias(alias)) log?.reads.push({ cell, path: alias.$alias.path, followAliases: true });
   }
 
   return result!;

--- a/typescript/packages/common-runner/test/cell.test.ts
+++ b/typescript/packages/common-runner/test/cell.test.ts
@@ -295,13 +295,18 @@ describe("asCell", () => {
     c.asCell(["a", "b"]).sink((value) => {
       values.push(value);
     });
+    expect(values).toEqual([42]); // Initial call
     c.setAtPath(["d"], 50);
+    await idle();
     c.setAtPath(["a", "c"], 100);
+    await idle();
     c.setAtPath(["a", "b"], 42);
+    await idle();
+    expect(values).toEqual([42]); // Didn't get called again
     c.setAtPath(["a", "b"], 300);
     await idle();
-    expect(values).toEqual([42, 300]);
     expect(c.get()).toEqual({ a: { b: 300, c: 100 }, d: 50 });
+    expect(values).toEqual([42, 300]); // Got called again
   });
 });
 

--- a/typescript/packages/common-runner/test/cell.test.ts
+++ b/typescript/packages/common-runner/test/cell.test.ts
@@ -140,13 +140,10 @@ describe("createProxy", () => {
     expect(c.get()[0].cell.get()).toBe(1);
     expect(isDocLink(c.get()[1])).toBeTruthy();
     expect(c.get()[1].cell.get()).toBe(2);
-    expect(log.reads).toEqual([{ cell: c, path: [] }]);
-    expect(log.writes).toEqual([
-      { cell: c.get()[0].cell, path: [] },
-      { cell: c, path: ["0"] },
-      { cell: c.get()[1].cell, path: [] },
-      { cell: c, path: ["1"] },
-    ]);
+    expect(log.reads.map((r) => r.path)).toEqual([[]]);
+    expect(log.writes.filter((w) => w.cell === c).map((w) => w.path)).toEqual([["0"], ["1"]]);
+    expect(log.writes.filter((w) => w.cell === c.get()[0].cell).map((w) => w.path)).toEqual([[]]);
+    expect(log.writes.filter((w) => w.cell === c.get()[1].cell).map((w) => w.path)).toEqual([[]]);
   });
 
   it("should support pop() and only read the popped element", () => {
@@ -180,12 +177,7 @@ describe("createProxy", () => {
     const result = proxy.find((x: any) => x === 2);
     expect(result).toBe(2);
     expect(c.get()).toEqual([1, 2, 3]);
-    expect(log.reads).toEqual([
-      { cell: c, path: [] },
-      { cell: c, path: [0] },
-      { cell: c, path: [1] },
-      { cell: c, path: [2] },
-    ]);
+    expect(log.reads.map((r) => r.path)).toEqual([[], [0], [1], [2]]);
     expect(log.writes).toEqual([]);
   });
 
@@ -195,13 +187,7 @@ describe("createProxy", () => {
     const proxy = c.getAsQueryResult([], log);
     const result = proxy.a.map((x: any) => x + 1);
     expect(result).toEqual([2, 3, 4]);
-    expect(log.reads).toEqual([
-      { cell: c, path: [] },
-      { cell: c, path: ["a"] },
-      { cell: c, path: ["a", 0] },
-      { cell: c, path: ["a", 1] },
-      { cell: c, path: ["a", 2] },
-    ]);
+    expect(log.reads.map((r) => r.path)).toEqual([[], ["a"], ["a", 0], ["a", 1], ["a", 2]]);
   });
 
   it("should allow changig array lengts by writing length", () => {

--- a/typescript/packages/common-runner/test/cell.test.ts
+++ b/typescript/packages/common-runner/test/cell.test.ts
@@ -292,7 +292,9 @@ describe("asCell", () => {
   it("should call sink only when the cell changes on the subpath", async () => {
     const c = getDoc({ a: { b: 42, c: 10 }, d: 5 });
     const values: number[] = [];
-    c.asCell(["a", "b"]).sink((value) => values.push(value));
+    c.asCell(["a", "b"]).sink((value) => {
+      values.push(value);
+    });
     c.setAtPath(["d"], 50);
     c.setAtPath(["a", "c"], 100);
     c.setAtPath(["a", "b"], 42);

--- a/typescript/packages/common-runner/test/schema.test.ts
+++ b/typescript/packages/common-runner/test/schema.test.ts
@@ -4,8 +4,8 @@ import { isCell } from "../src/cell.js";
 import type { JSONSchema } from "@commontools/builder";
 import { idle } from "../src/scheduler.js";
 
-describe.only("Schema Support", () => {
-  describe.only("Examples", () => {
+describe("Schema Support", () => {
+  describe("Examples", () => {
     it("allows mapping of fields via interim cells", () => {
       const c = getDoc({
         id: 1,
@@ -48,7 +48,7 @@ describe.only("Schema Support", () => {
       });
     });
 
-    it.skip("should support nested sinks via asCell", async () => {
+    it("should support nested sinks via asCell", async () => {
       const schema: JSONSchema = {
         type: "object",
         properties: {

--- a/typescript/packages/jumble/src/utils/charms.ts
+++ b/typescript/packages/jumble/src/utils/charms.ts
@@ -1,14 +1,8 @@
 import { type Charm } from "@commontools/charm";
-import { EntityId } from "@commontools/runner";
+import { getEntityId, type EntityId } from "@commontools/runner";
 
-export function charmId(charm: Charm | EntityId) {
-  if ("cell" in charm) {
-    if (typeof charm.cell.entityId["/"] === "string") {
-      return charm.cell.entityId["/"];
-    } else {
-      return charm.cell.toJSON()["/"];
-    }
-  } else {
-    return charm.toJSON?.()?.["/"] ?? charm["/"];
-  }
+export function charmId(charm: Charm): string | undefined {
+  const id = getEntityId(charm);
+  // FIXME(ja):   Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'string'.ts(2322)
+  return id ? id["/"] : undefined;
 }

--- a/typescript/packages/jumble/src/views/CharmList.tsx
+++ b/typescript/packages/jumble/src/views/CharmList.tsx
@@ -2,9 +2,9 @@ import { useCell } from "@/hooks/use-cell";
 import { NavLink } from "react-router-dom";
 import { NAME, UI } from "@commontools/builder";
 import { useCharmManager } from "@/contexts/CharmManagerContext";
-import { castNewRecipe, Charm } from "@commontools/charm";
+import { Charm } from "@commontools/charm";
 import { charmId } from "@/utils/charms";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Card } from "@/components/Card";
 import { useParams } from "react-router-dom";
 import { render } from "@commontools/html";
@@ -65,35 +65,6 @@ export default function CharmList() {
   console.log("replicaName", replicaName);
   const { charmManager } = useCharmManager();
   const [charms] = useCell(charmManager.getCharms());
-  const commonImportRef = useRef<HTMLElement | null>(null);
-
-  const onImportLocalData = useCallback(
-    (event: CommonDataEvent) => {
-      const [data] = event.detail.data;
-      console.log("Importing local data:", data);
-      // FIXME(ja): this needs better error handling
-      const title = prompt("Enter a title for your recipe:");
-      if (!title) return;
-
-      castNewRecipe(charmManager, data, title);
-      // if (charmId) {
-      //   openCharm(charmId);
-      // }
-    },
-    [charmManager],
-  );
-
-  useEffect(() => {
-    const current = commonImportRef.current;
-    if (current) {
-      current.addEventListener("common-data", onImportLocalData as EventListener);
-    }
-    return () => {
-      if (current) {
-        current.removeEventListener("common-data", onImportLocalData as EventListener);
-      }
-    };
-  }, [replicaName, onImportLocalData]);
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 p-8">

--- a/typescript/packages/jumble/src/views/CharmList.tsx
+++ b/typescript/packages/jumble/src/views/CharmList.tsx
@@ -35,7 +35,7 @@ function CharmPreview({ charm, replicaName }: { charm: Charm; replicaName: strin
   useEffect(() => {
     if (!previewRef.current || !isIntersecting) return;
     const preview = previewRef.current;
-    const charmData = charm.cell.get()?.[UI];
+    const charmData = charm[UI];
     if (!charmData) return;
     preview.innerHTML = ""; // Clear any existing rendered content
     const cancel = render(preview, charmData);
@@ -47,7 +47,7 @@ function CharmPreview({ charm, replicaName }: { charm: Charm; replicaName: strin
       <NavLink to={`/${replicaName}/${charmId(charm)}`}>
         <div>
           <h3 className="text-xl font-semibold text-gray-800 mb-4">
-            {(charm.cell.getAsQueryResult()?.[NAME] || "Unnamed Charm") +
+            {(charm[NAME] || "Unnamed Charm") +
               ` (#${charmId(charm).slice(-4)})`}
           </h3>
           <div
@@ -99,7 +99,6 @@ export default function CharmList() {
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 p-8">
       {replicaName &&
         charms
-          .filter((c) => !!c.cell)
           .map((charm) => (
             <CharmPreview key={charmId(charm)} charm={charm} replicaName={replicaName} />
           ))}

--- a/typescript/packages/jumble/src/views/CharmList.tsx
+++ b/typescript/packages/jumble/src/views/CharmList.tsx
@@ -37,9 +37,15 @@ function CharmPreview({ charm, replicaName }: { charm: Charm; replicaName: strin
     const preview = previewRef.current;
     const charmData = charm[UI];
     if (!charmData) return;
-    preview.innerHTML = ""; // Clear any existing rendered content
-    const cancel = render(preview, charmData);
-    return cancel;
+    preview.innerHTML = "";
+
+    try {
+      const cancel = render(preview, charmData);
+      return cancel;
+    } catch (error) {
+      console.error('Failed to render charm preview:', error);
+      preview.innerHTML = '<p>Preview unavailable</p>';
+    }
   }, [charm, isIntersecting]);
 
   return (


### PR DESCRIPTION
Added proper DOM diffing and removed a lot of now redundant reactivity stuff by moving everything to assume `Cell`.

Other changes:
- Cell.sink callbacks can return cancel functions that are called before the next call and at the end
- Added a `Stream` type
- Changed specifics of how `asCell` behaves when encountering aliases, etc. 
- Fixed scheduling bug when listening to changes on arrays
- Removed a lot of redundant calling
- A lot more tests, especially around asCell, scheduling, etc.

Quick follow-up: Renaming and moving between files. Just wanted to keep the diffs clean.