### PR TITLE
feat: Integrate common-identity in Jumble.

### DIFF
--- a/typescript/packages/jumble/README.md
+++ b/typescript/packages/jumble/README.md
@@ -1,50 +1,15 @@
-# React + TypeScript + Vite
+# Jumble
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+## Running
 
-Currently, two official plugins are available:
+### Local
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default tseslint.config({
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+```bash
+pnpm run dev
 ```
 
-- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
-- Optionally add `...tseslint.configs.stylisticTypeChecked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
+### Using remote LLM services
 
-```js
-// eslint.config.js
-import react from 'eslint-plugin-react'
-
-export default tseslint.config({
-  // Set the react version
-  settings: { react: { version: '18.3' } },
-  plugins: {
-    // Add the react plugin
-    react,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
-  },
-})
+```bash
+TOOLSHED_API_URL=https://toolshed.saga-castor.ts.net pnpm run dev
 ```

--- a/typescript/packages/jumble/package.json
+++ b/typescript/packages/jumble/package.json
@@ -27,6 +27,7 @@
     "@commontools/builder": "workspace:*",
     "@commontools/charm": "workspace:*",
     "@commontools/html": "workspace:*",
+    "@commontools/identity": "workspace:*",
     "@commontools/iframe-sandbox": "workspace:*",
     "@commontools/llm-client": "workspace:*",
     "@commontools/os-ui": "workspace:*",

--- a/typescript/packages/jumble/src/components/ShellHeader.tsx
+++ b/typescript/packages/jumble/src/components/ShellHeader.tsx
@@ -8,6 +8,7 @@ import { useCharmManager } from "@/contexts/CharmManagerContext";
 import { NAME, TYPE } from "@commontools/builder";
 import { useNavigate } from "react-router-dom";
 import { saveSpell } from "@/services/spellbook";
+import { User } from "@/components/User";
 
 type ShellHeaderProps = {
   replicaName?: string;
@@ -89,6 +90,7 @@ export function ShellHeader({
         <NavPath replicaId={replicaName} charmId={charmId} />
       </div>
       <div className="header-end flex items-center gap-2">
+        <User />
         {charmId && (
           <>
             <NavLink

--- a/typescript/packages/jumble/src/components/User.tsx
+++ b/typescript/packages/jumble/src/components/User.tsx
@@ -1,0 +1,52 @@
+import { useAuthentication } from "@/contexts/AuthenticationContext";
+import { useEffect, useState } from "react";
+
+export function User() {
+  const { user, clearAuthentication } = useAuthentication();
+  const [did, setDid] = useState<string | undefined>(undefined);
+  
+  useEffect(() => {
+    let ignore = false;
+    async function setDidInner() {
+      if (!user) {
+        return;
+      }
+      let did = await user.verifier().did();
+      if (!ignore) {
+        setDid(did);
+      }
+    }
+    setDidInner();
+    return () => {
+      setDid(undefined);
+      ignore = true;
+    }
+  }, [user]);
+
+  let h = "0";
+  let s = "50%";
+  let l = "50%";
+
+  if (did) {
+    let index = did.length - 4;
+    // DID string is `did:key:z{REST}`. Taking the last 3 characters,
+    // we use the first two added for hue.
+    h = `${did.charCodeAt(index) + did.charCodeAt(index + 1)}`;
+    // Then the final character for saturation, map ASCII codes 49-122 to saturation 50%-100%
+    s = `${(50 + (((did.charCodeAt(index + 2) - 49) / 73) * 50))}%`;
+  }
+
+  const styles = {
+    width: "30px",
+    height: "30px",
+    backgroundColor: `hsl(${h}, ${s}, ${l})`,
+  };
+  return (
+    <div
+      onClick={clearAuthentication}
+      title={did ?? "undefined"}
+      style={styles}
+      className="relative flex max-w-xs items-center rounded-full bg-gray-800 text-sm focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800 focus:outline-hidden">
+    </div>
+  );
+}

--- a/typescript/packages/jumble/src/contexts/AuthenticationContext.tsx
+++ b/typescript/packages/jumble/src/contexts/AuthenticationContext.tsx
@@ -1,0 +1,147 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { Identity, KeyStore, PassKey } from "@commontools/identity";
+
+// Location in storage of root key.
+const ROOT_KEY = "$ROOT_KEY";
+// "Name" of default persona derived from root key.
+const DEFAULT_PERSONA = "default";
+
+interface AuthenticationContextType {
+  // The authenticated user/persona.
+  user: Identity | void;
+  // Call PassKey registration.
+  passkeyRegister: (name: string, displayName: string) => Promise<void>;
+  // Authenticate the user via passkey.
+  passkeyAuthenticate: () => Promise<void>;
+  // Generate a passphrase for a new user
+  passphraseRegister: () => Promise<string>;
+  // Authenticate via passphrase.
+  passphraseAuthenticate: (mnemonic: string) => Promise<void>;
+  // Clears authentication database.
+  clearAuthentication: () => Promise<void>;
+  // Internal: Root key.
+  root: Identity | void;
+  // Internal: Persistent storage for keys. 
+  keyStore: KeyStore | void;
+}
+
+const AuthenticationContext = createContext<AuthenticationContextType>(null!);
+
+// (async) open a key store
+// (async) check to see key exists
+export const AuthenticationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [keyStore, setKeyStore] = useState<KeyStore | void>(undefined);
+  const [user, setUser] = useState<Identity | void>(undefined);
+  const [root, setRoot] = useState<Identity | void>(undefined);
+
+  // On load, open the KeyStore and find a root key.
+  useEffect(() => {
+    let ignore = false;
+    async function getKeyStoreAndRoot() {
+      let keyStore = await KeyStore.open();
+      let root = await keyStore.get(ROOT_KEY);
+      if (!ignore) {
+        setKeyStore(keyStore);
+        if (root) {
+          setRoot(root);
+        }
+      }
+    }
+    getKeyStoreAndRoot(); 
+    return () => {
+      ignore = true;
+      setKeyStore(undefined);
+      setRoot(undefined);
+    }
+  }, []);
+
+  // When root changes, update `user` to the default persona
+  useEffect(() => {
+    let ignore = false;
+    async function setPersona() {
+      setUser(undefined);
+      if (!root) {
+        return;
+      }
+      let user = await root.derive(DEFAULT_PERSONA);
+      if (!ignore) {
+        setUser(user);
+      }
+    }
+    setPersona();
+    return () => {
+      ignore = true;
+      setUser(undefined);
+    }
+  }, [root]);
+
+  // This calls out to WebAuthn to register a user. The state of whether
+  // a user has previously registered a passkey is not tracked (and could
+  // only be tracked per document), so this doesn't use any hooks.
+  //
+  // Must be called within a user gesture.
+  const passkeyRegister = useCallback(async (name: string, displayName: string) => {
+    return PassKey.create(name, displayName);
+  }, []);
+
+
+  // This should be called when a passkey (possibly) exists for the user already,
+  // and no root key has yet been stored (e.g. first login). Subsequent page loads
+  // should load key from storage and not require this callback.
+  //
+  // Must be called within a user gesture.
+  const passkeyAuthenticate = useCallback(async () => {
+    if (!keyStore) {
+      return;
+    }
+    let passkey = await PassKey.get();
+    let root = await passkey.createRootKey();
+    await keyStore.set(ROOT_KEY, root);
+    setRoot(root);
+  }, [keyStore]);
+ 
+
+  const passphraseRegister = useCallback(async () => {
+    // Don't store the root identity here. Return only the
+    // mnemonic so that the UI can present guidance on handling
+    // the private key. The root will be derived from the mnemonic
+    // on authentication.
+    let [_, mnemonic] = await Identity.generateMnemonic();
+    return mnemonic;
+  }, []);
+
+  const passphraseAuthenticate = useCallback(async (mnemonic: string) => {
+    if (!keyStore) {
+      return;
+    }
+    let root = await Identity.fromMnemonic(mnemonic);
+    await keyStore.set(ROOT_KEY, root);
+    setRoot(root);
+  }, [keyStore]);
+  
+  const clearAuthentication = useCallback(async () => {
+    if (!keyStore) {
+      return;
+    }
+    await keyStore.clear();
+    setRoot(undefined);
+    setUser(undefined);
+  }, [keyStore]);
+
+  return (
+    <AuthenticationContext.Provider value={{
+      user,
+      passkeyAuthenticate,
+      passkeyRegister,
+      passphraseAuthenticate,
+      passphraseRegister,
+      clearAuthentication,
+      root,
+      keyStore,
+    }}>
+      {children}
+    </AuthenticationContext.Provider>
+  );
+};
+
+export const useAuthentication = () => useContext(AuthenticationContext);

--- a/typescript/packages/jumble/src/main.tsx
+++ b/typescript/packages/jumble/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter as Router, Routes, Route, Navigate, useParams } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import "@/styles/index.css";
 import PhotoFlowIndex from "@/views/experiments/photoflow/Index.tsx";
 import PhotoSetView from "@/views/experiments/photoflow/PhotoSetView.tsx";
@@ -14,6 +14,7 @@ import CharmShowView from "@/views/CharmShowView";
 import CharmDetailView from "@/views/CharmDetailView";
 import { LanguageModelProvider } from "./contexts/LanguageModelContext";
 import { BackgroundTaskProvider } from "./contexts/BackgroundTaskContext";
+import { AuthenticationProvider } from "./contexts/AuthenticationContext";
 import { setupIframe } from "./iframe-ctx";
 import GenerateJSONView from "@/views/utility/GenerateJSONView";
 import SpellbookIndexView from "@/views/spellbook/SpellbookIndexView";
@@ -24,53 +25,55 @@ setupIframe();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <CharmsProvider>
-      <BackgroundTaskProvider>
-        <LanguageModelProvider>
-          <Router>
-            <Routes>
-              {/* Redirect root to common-knowledge */}
-              <Route path="/" element={<Navigate to="/common-knowledge" replace />} />
+    <AuthenticationProvider>
+      <CharmsProvider>
+        <BackgroundTaskProvider>
+          <LanguageModelProvider>
+            <Router>
+              <Routes>
+                {/* Redirect root to common-knowledge */}
+                <Route path="/" element={<Navigate to="/common-knowledge" replace />} />
 
-              <Route
-                path="/:replicaName"
-                element={
-                  <CharmsManagerProvider>
-                    <Shell />
-                  </CharmsManagerProvider>
-                }
-              >
-                <Route index element={<CharmList />} />
-                <Route path=":charmId" element={<CharmShowView />} />
-                <Route path=":charmId/detail" element={<CharmDetailView />} />
-              </Route>
+                <Route
+                  path="/:replicaName"
+                  element={
+                    <CharmsManagerProvider>
+                      <Shell />
+                    </CharmsManagerProvider>
+                  }
+                >
+                  <Route index element={<CharmList />} />
+                  <Route path=":charmId" element={<CharmShowView />} />
+                  <Route path=":charmId/detail" element={<CharmDetailView />} />
+                </Route>
 
-              {/* Spellbook routes */}
-              <Route path="/spellbook" element={<SpellbookIndexView />} />
-              <Route path="/spellbook/:spellId" element={<SpellbookDetailView />} />
-              <Route
-                path="/spellbook/launch/:spellId"
-                element={
-                  <CharmsManagerProvider>
-                    <SpellbookLaunchView />
-                  </CharmsManagerProvider>
-                }
-              />
+                {/* Spellbook routes */}
+                <Route path="/spellbook" element={<SpellbookIndexView />} />
+                <Route path="/spellbook/:spellId" element={<SpellbookDetailView />} />
+                <Route
+                  path="/spellbook/launch/:spellId"
+                  element={
+                    <CharmsManagerProvider>
+                      <SpellbookLaunchView />
+                    </CharmsManagerProvider>
+                  }
+                />
 
-              {/* internal tools / experimental routes */}
-              <Route path="/utility/jsongen" element={<GenerateJSONView />} />
+                {/* internal tools / experimental routes */}
+                <Route path="/utility/jsongen" element={<GenerateJSONView />} />
 
-              {/* Photoflow routes preserved */}
-              <Route path="/experiments/photoflow" element={<PhotoFlowIndex />} />
-              <Route path="/experiments/photoflow/:photosetName" element={<PhotoSetView />} />
-              <Route
-                path="/experiments/photoflow/:photosetName/spells/new"
-                element={<NewSpell />}
-              />
-            </Routes>
-          </Router>
-        </LanguageModelProvider>
-      </BackgroundTaskProvider>
-    </CharmsProvider>
+                {/* Photoflow routes preserved */}
+                <Route path="/experiments/photoflow" element={<PhotoFlowIndex />} />
+                <Route path="/experiments/photoflow/:photosetName" element={<PhotoSetView />} />
+                <Route
+                  path="/experiments/photoflow/:photosetName/spells/new"
+                  element={<NewSpell />}
+                />
+              </Routes>
+            </Router>
+          </LanguageModelProvider>
+        </BackgroundTaskProvider>
+      </CharmsProvider>
+    </AuthenticationProvider>
   </StrictMode>,
 );

--- a/typescript/packages/jumble/src/views/AuthenticationView.tsx
+++ b/typescript/packages/jumble/src/views/AuthenticationView.tsx
@@ -1,0 +1,63 @@
+import { useAuthentication } from "@/contexts/AuthenticationContext";
+import { useCallback, useRef, useState } from "react";
+
+const BTN_STYLE=`bg-gray-50 border-2 p-2 w-full flex-1 cursor-pointer`;
+const PW_STYLE=`bg-gray-50 border-2 p-2 w-full flex-1`;
+
+export function AuthenticationView() {
+  const { user, passkeyRegister, passkeyAuthenticate, passphraseRegister, passphraseAuthenticate } = useAuthentication();
+  if (user) {
+    throw new Error("Displaying authentication view when already authenticated.");
+  }
+  const [mnemonic, setMnemonic] = useState<string>("");
+  const passphraseInput = useRef(null);
+
+
+  const createMnemonic = useCallback(async () => {
+    setMnemonic(await passphraseRegister());
+  }, []);
+
+  const authWithMnemonicInput = useCallback(async () => {
+    if (passphraseInput.current == null) { return; }
+    let passphrase = passphraseInput.current.value;
+    await passphraseAuthenticate(passphrase);
+    setMnemonic("");
+  }, [passphraseInput]);
+
+  const authWithMnemonicState = useCallback(async () => {
+    let passphrase = mnemonic;
+    setMnemonic("");
+    await passphraseAuthenticate(passphrase);
+  }, [mnemonic]);
+
+  if (mnemonic) {
+    return (
+      <div className="flex flex-col">
+      <div className="flex flex-col bg-gray-50 items-center justify-between border-2 p-2 m-2 flex-1"> 
+        <h3>Your Secret Recovery Key</h3>
+        <textarea
+          readOnly={true}
+          value={mnemonic}
+          className="block w-full rounded-md bg-white px-3 py-1.5">
+        </textarea>
+        <button className={BTN_STYLE} onClick={authWithMnemonicState}>OK</button>
+      </div>
+      </div>
+    )
+  }
+  return (
+    <div className="flex flex-row">
+      <div className="flex flex-col bg-gray-50 items-center justify-between border-2 p-2 m-2 flex-1"> 
+        <h3>via Passkey</h3>
+        <button className={BTN_STYLE} onClick={() => passkeyRegister("Common Tools User", "commontoolsuser")}>Register</button>
+        <button className={BTN_STYLE} onClick={passkeyAuthenticate}>Login</button>
+      </div>
+      <div className="flex flex-col bg-gray-50 items-center justify-between border-2 p-2 m-2 flex-1">
+        <h3>via Passphrase</h3>
+        <button className={BTN_STYLE} onClick={createMnemonic}>Register</button>
+        <button className={BTN_STYLE} onClick={authWithMnemonicInput}>Login</button>
+        <input className={PW_STYLE} type="password" placeholder="passphrase" ref={passphraseInput}></input>
+      </div>
+    </div>
+  );
+}

--- a/typescript/packages/jumble/src/views/Shell.tsx
+++ b/typescript/packages/jumble/src/views/Shell.tsx
@@ -7,6 +7,8 @@ import { MdOutlineStar } from "react-icons/md";
 
 import ShellHeader from "@/components/ShellHeader";
 import { CommandCenter } from "@/components/CommandCenter";
+import { useAuthentication } from "@/contexts/AuthenticationContext";
+import { AuthenticationView } from "@/views/AuthenticationView";
 
 
 export default function Shell() {
@@ -24,6 +26,14 @@ export default function Shell() {
   const onLaunchCommand = useCallback(() => {
     window.dispatchEvent(new CustomEvent("open-command-center"));
   }, []);
+  
+  const { user } = useAuthentication();
+
+  if (!user) {
+    return (
+      <AuthenticationView /> 
+    )
+  }
 
   return (
     <div className="shell h-full bg-gray-50 border-2 border-black">

--- a/typescript/packages/pnpm-lock.yaml
+++ b/typescript/packages/pnpm-lock.yaml
@@ -484,6 +484,9 @@ importers:
       '@commontools/html':
         specifier: workspace:*
         version: link:../common-html
+      '@commontools/identity':
+        specifier: workspace:*
+        version: link:../common-identity
       '@commontools/iframe-sandbox':
         specifier: workspace:*
         version: link:../common-iframe-sandbox


### PR DESCRIPTION
* Introduce `AuthenticationContext` for interacting with the authenticated user
* Main entry now kicks off to `AuthenticationView` if not authenticated.
  * After registering, we need to also "login". Clicking "login" after registering should go through the WebAuthn flow, and the derived keys are then stored.
* If authenticated, a `User` widget is rendered in the `ShellHeader`, color derived from the authenticated key. Clicking this button clears authentication storage for re-testing.
* Add running instructions to README