### PR TITLE
feat: Split up Identity into Signer and Verifier components.

### DIFF
--- a/typescript/packages/common-identity/examples/index.html
+++ b/typescript/packages/common-identity/examples/index.html
@@ -85,6 +85,7 @@ const ROOT_KEY = "$ROOT_KEY";
 const encoder = new TextEncoder();
 let passKeyDeferred = defer();
 let rootKey = null;
+let store = null;
 
 (async function init() {
   // Show registration success if we were redirected
@@ -92,7 +93,7 @@ let rootKey = null;
   maybeDisplayRegisterSuccess();
 
   // Open the key store at the default location.
-  let store = await KeyStore.open();
+  store = await KeyStore.open();
 
   // First check if we've already stored a root key.
   let rootKey = await store.get(ROOT_KEY);
@@ -139,12 +140,14 @@ $("#sign-message").addEventListener("input", async (e) => {
   const data = encoder.encode(e.target.value);
   const signature = await rootKey.sign(data);
   $("#signature").innerText = btoa(String.fromCharCode(...new Uint8Array(signature))); 
-  setVerificationStatus(await rootKey.verify(signature, data));
+  setVerificationStatus(await rootKey.verifier().verify(signature, data));
 });
 
 $("#clear-db").addEventListener("click", async (e) => {
-  await RootKey.clearStorage();
-  window.location.reload();
+  if (store) {
+    await store.clear();
+    window.location.reload();
+  }
 });
 
 $("#auth").addEventListener("click", e => {

--- a/typescript/packages/common-identity/package.json
+++ b/typescript/packages/common-identity/package.json
@@ -22,7 +22,7 @@
   "author": "",
   "license": "UNLICENSED",
   "dependencies": {
-    "bs58": "^6.0.0",
+    "multiformats": "^13.3.2",
     "@noble/ed25519": "^2.2.3",
     "tslib": "^2.8.1"
   },

--- a/typescript/packages/common-identity/src/ed25519/native.ts
+++ b/typescript/packages/common-identity/src/ed25519/native.ts
@@ -1,6 +1,6 @@
 import * as ed25519 from "@noble/ed25519";
-import { ED25519_ALG, keyToDid } from "./utils.js";
-import { KeyPair, KeyPairRaw } from "../keys.js";
+import { ED25519_ALG, bytesToDid, didToBytes } from "./utils.js";
+import { DID, Signer, Verifier } from "../interface.js";
 
 // WebCrypto Key formats for Ed25519
 // Non-explicitly described in https://wicg.github.io/webcrypto-secure-curves/#ed25519
@@ -12,57 +12,87 @@ import { KeyPair, KeyPairRaw } from "../keys.js";
 // | pkcs8  |        |    X    |
 // | spki   |   X    |         |
 
-export class NativeEd25519 implements KeyPair {
+// Returns whether ed25519 is supported in Web Crypto API.
+export const isNativeEd25519Supported = (() => {
+  let isSupported: boolean | null = null;
+  return async function isNativeEd25519Supported() {
+    if (isSupported !== null) {
+      return isSupported;
+    }
+    let dummyKey = new Uint8Array(32);
+    try {
+      await window.crypto.subtle.importKey("raw", dummyKey, ED25519_ALG, false, ["verify"]);
+      isSupported = true;
+    } catch (e) {
+      isSupported = false;
+    }
+    return isSupported;
+  }
+})();
+
+export class NativeEd25519Signer implements Signer {
   private keypair: CryptoKeyPair;
   constructor(keypair: CryptoKeyPair) {
     this.keypair = keypair;
   }
 
-  async did(): Promise<string> {
-    let rawPublic = await window.crypto.subtle.exportKey("raw", this.keypair.publicKey);
-    return keyToDid(new Uint8Array(rawPublic));
+  verifier(): Verifier {
+    return new NativeEd25519Verifier(this.keypair.publicKey);
   }
 
-  serialize(): KeyPairRaw {
+  serialize(): CryptoKeyPair {
     return this.keypair;
   }
   
   async sign(data: Uint8Array): Promise<Uint8Array> {
     return new Uint8Array(await window.crypto.subtle.sign(ED25519_ALG, this.keypair.privateKey, data));
   }
- 
-  async verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
-    return await window.crypto.subtle.verify(ED25519_ALG, this.keypair.publicKey, signature, data);
-  }
 
-  static async generateFromRaw(rawPrivateKey: Uint8Array): Promise<NativeEd25519> {
+  static async fromRaw(rawPrivateKey: Uint8Array): Promise<NativeEd25519Signer> {
     const pkcs8Private = ed25519RawToPkcs8(rawPrivateKey);
     const rawPublic = await ed25519.getPublicKeyAsync(rawPrivateKey);
     const privateKey = await window.crypto.subtle.importKey("pkcs8", pkcs8Private, ED25519_ALG, false, ["sign"]);
     // Set the public key to be extractable for DID generation.
     const publicKey = await window.crypto.subtle.importKey("raw", rawPublic, ED25519_ALG, true, ["verify"]);
-    return new NativeEd25519({ publicKey, privateKey });
+    return new NativeEd25519Signer({ publicKey, privateKey });
   }
 
-  static async generate(): Promise<NativeEd25519> {
-    // This notably sets only the private key as extractable, ideal as we need
+  static async generate(): Promise<NativeEd25519Signer> {
+    // This notably sets only the public key as extractable, ideal as we need
     // access to the public key for DID generation. 
     let keypair = await window.crypto.subtle.generateKey(ED25519_ALG, false, ["sign", "verify"]);
-    return new NativeEd25519(keypair);
+    return new NativeEd25519Signer(keypair);
   }
 
   static deserialize(keypair: CryptoKeyPair) {
-    return new NativeEd25519(keypair);
+    return new NativeEd25519Signer(keypair);
+  }
+}
+
+export class NativeEd25519Verifier implements Verifier {
+  private publicKey: CryptoKey;
+  constructor(publicKey: CryptoKey) {
+    this.publicKey = publicKey;
   }
 
-  // Returns whether ed25519 is supported in Web Crypto API.
-  static async isSupported() {
-    let dummyKey = new Uint8Array(32);
-    try {
-      await window.crypto.subtle.importKey("raw", dummyKey, ED25519_ALG, false, ["verify"]);
-      return true;
-    } catch (e) {}
-    return false;
+  async did(): Promise<string> {
+    let rawPublic = await window.crypto.subtle.exportKey("raw", this.publicKey);
+    return bytesToDid(new Uint8Array(rawPublic));
+  }
+
+  async verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
+    return await window.crypto.subtle.verify(ED25519_ALG, this.publicKey, signature, data);
+  }
+
+  static async fromDid(did: DID): Promise<NativeEd25519Verifier> {
+    let bytes = didToBytes(did);
+    return await NativeEd25519Verifier.fromRaw(bytes);
+  }
+
+  static async fromRaw(rawPublicKey: Uint8Array): Promise<NativeEd25519Verifier> {
+    // Set the public key to be extractable for DID generation.
+    const publicKey = await window.crypto.subtle.importKey("raw", rawPublicKey, ED25519_ALG, true, ["verify"]);
+    return new NativeEd25519Verifier(publicKey);
   }
 }
 
@@ -70,11 +100,11 @@ export class NativeEd25519 implements KeyPair {
 // via https://stackoverflow.com/a/79135112
 const PKCS8_PREFIX = new Uint8Array([ 48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 112, 4, 34, 4, 32 ]);
 
-// Private Ed25519 keys cannot be imported into Subtle Crypto in "raw" format.
+// Signer Ed25519 keys cannot be imported into Subtle Crypto in "raw" format.
 // Convert to "pkcs8" before doing so.
 // 
 // @AUDIT
 // via https://stackoverflow.com/a/79135112
-function ed25519RawToPkcs8(rawPrivateKey: Uint8Array): Uint8Array {
-  return new Uint8Array([...PKCS8_PREFIX, ...rawPrivateKey]);
+function ed25519RawToPkcs8(rawSignerKey: Uint8Array): Uint8Array {
+  return new Uint8Array([...PKCS8_PREFIX, ...rawSignerKey]);
 }

--- a/typescript/packages/common-identity/src/ed25519/noble.ts
+++ b/typescript/packages/common-identity/src/ed25519/noble.ts
@@ -1,41 +1,64 @@
 import * as ed25519 from "@noble/ed25519";
-import { KeyPair, InsecureCryptoKeyPair, KeyPairRaw } from "../keys.js";
-import { keyToDid } from "./utils.js";
+import { InsecureCryptoKeyPair, Verifier, Signer, DID } from "../interface.js";
+import { bytesToDid, didToBytes } from "./utils.js";
 
-export class NobleEd25519 implements KeyPair {
+export class NobleEd25519Signer implements Signer {
   private keypair: InsecureCryptoKeyPair;
   constructor(keypair: InsecureCryptoKeyPair) {
     this.keypair = keypair;
   }
 
-  async did(): Promise<string> {
-    return keyToDid(this.keypair.publicKey);
+  verifier(): NobleEd25519Verifier {
+    return new NobleEd25519Verifier(this.keypair.publicKey);
   }
 
-  serialize(): KeyPairRaw {
+  async did(): Promise<string> {
+    return bytesToDid(this.keypair.publicKey);
+  }
+
+  serialize(): InsecureCryptoKeyPair {
     return this.keypair;
   }
   
   async sign(data: Uint8Array): Promise<Uint8Array> {
     return await ed25519.signAsync(data, this.keypair.privateKey);
   }
- 
-  async verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
-    return await ed25519.verifyAsync(signature, data, this.keypair.publicKey);
-  }
 
-  static async generateFromRaw(privateKey: Uint8Array): Promise<NobleEd25519> {
+  static async fromRaw(privateKey: Uint8Array): Promise<NobleEd25519Signer> {
     const publicKey = await ed25519.getPublicKeyAsync(privateKey);
-    return new NobleEd25519({ publicKey, privateKey });
+    return new NobleEd25519Signer({ publicKey, privateKey });
   }
 
-  static async generate(): Promise<NobleEd25519> {
+  static async generate(): Promise<NobleEd25519Signer> {
     let privateKey = ed25519.utils.randomPrivateKey();
-    const publicKey = await ed25519.getPublicKeyAsync(privateKey);
-    return new NobleEd25519({ publicKey, privateKey });
+    return await NobleEd25519Signer.fromRaw(privateKey);
   }
 
   static deserialize(keypair: InsecureCryptoKeyPair) {
-    return new NobleEd25519(keypair);
+    return new NobleEd25519Signer(keypair);
+  }
+}
+
+export class NobleEd25519Verifier implements Verifier {
+  private publicKey: Uint8Array;
+  constructor(publicKey: Uint8Array) {
+    this.publicKey = publicKey;
+  }
+
+  async verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
+    return await ed25519.verifyAsync(signature, data, this.publicKey);
+  }
+
+  async did(): Promise<string> {
+    return bytesToDid(this.publicKey);
+  }
+  
+  static async fromDid(did: DID): Promise<NobleEd25519Verifier> {
+    let bytes = didToBytes(did);
+    return await NobleEd25519Verifier.fromRaw(bytes);
+  }
+  
+  static async fromRaw(rawPublicKey: Uint8Array): Promise<NobleEd25519Verifier> {
+    return new NobleEd25519Verifier(rawPublicKey);
   }
 }

--- a/typescript/packages/common-identity/src/identity.ts
+++ b/typescript/packages/common-identity/src/identity.ts
@@ -1,5 +1,5 @@
-import { Ed25519KeyPair } from "./ed25519/index.js";
-import { KeyPair, KeyPairRaw } from "./keys.js";
+import { Ed25519Signer, Ed25519Verifier } from "./ed25519/index.js";
+import { DID, KeyPairRaw, Signer, Verifier } from "./interface.js";
 import { hash } from "./utils.js";
 
 const textEncoder = new TextEncoder();
@@ -7,15 +7,14 @@ const textEncoder = new TextEncoder();
 // An `Identity` represents a public/private key pair.
 //
 // Additional keys can be deterministically derived from an identity. 
-export class Identity implements KeyPair {
-  private keypair: Ed25519KeyPair;
-  constructor(keypair: Ed25519KeyPair) {
+export class Identity implements Signer {
+  private keypair: Ed25519Signer;
+  constructor(keypair: Ed25519Signer) {
     this.keypair = keypair;
   }
 
-  // Return the DID key of this keypair's public key.
-  async did() {
-    return await this.keypair.did();
+  verifier(): VerifierIdentity {
+    return new VerifierIdentity(this.keypair.verifier());
   }
 
   // Sign `data` with this identity.
@@ -23,11 +22,6 @@ export class Identity implements KeyPair {
     return await this.keypair.sign(data);
   }
  
-  // Verify `signature` and `data` with this identity.
-  async verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
-    return await this.keypair.verify(signature, data);
-  }
-
   // Serialize this identity for storage.
   serialize(): KeyPairRaw {
     return this.keypair.serialize();
@@ -36,24 +30,43 @@ export class Identity implements KeyPair {
   // Derive a new `Identity` given a seed string.
   async derive(name: string): Promise<Identity> {
     const seed = textEncoder.encode(name);
-    const hashed = await hash(seed);
-    const signed = await this.sign(hashed);
+    const signed = await this.sign(seed);
     const signedHash = await hash(signed);
-    return await Identity.generateFromRaw(new Uint8Array(signedHash.subarray(0, 32)));
+    return await Identity.fromRaw(new Uint8Array(signedHash));
   }
 
   // Generate a new identity from raw ed25519 key material.
-  static async generateFromRaw(rawPrivateKey: Uint8Array): Promise<Identity> {
-    return new Identity(await Ed25519KeyPair.generateFromRaw(rawPrivateKey));
+  static async fromRaw(rawPrivateKey: Uint8Array): Promise<Identity> {
+    return new Identity(await Ed25519Signer.fromRaw(rawPrivateKey));
   }
   
   // Generate a new identity.
   static async generate(): Promise<Identity> {
-    return new Identity(await Ed25519KeyPair.generate());
+    return new Identity(await Ed25519Signer.generate());
   }
 
   // Deserialize `input` from storage into an `Identity`.
   static deserialize(input: any): Identity {
-    return new Identity(Ed25519KeyPair.deserialize(input)); 
+    return new Identity(Ed25519Signer.deserialize(input)); 
+  }
+}
+
+export class VerifierIdentity implements Verifier {
+  private inner: Verifier;
+
+  constructor(inner: Verifier) {
+    this.inner = inner;
+  }
+
+  async verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
+    return await this.inner.verify(signature, data);
+  }
+
+  async did(): Promise<string> {
+    return await this.inner.did();
+  }
+
+  static async fromDid(did: DID): Promise<VerifierIdentity> {
+    return new VerifierIdentity(await Ed25519Verifier.fromDid(did));
   }
 }

--- a/typescript/packages/common-identity/src/interface.ts
+++ b/typescript/packages/common-identity/src/interface.ts
@@ -1,13 +1,19 @@
-export interface KeyPairStatic {
-  generateFromRaw(rawPrivateKey: Uint8Array): Promise<KeyPair>;
-  generate(): Promise<KeyPair>;
-  deserialize(input: any): KeyPair;
+export type DID = `did:${string}:${string}`;
+
+export type KeyPair = {
+  privateKey: Signer,
+  publicKey: Verifier,
+};
+
+export interface Signer {
+  sign(data: Uint8Array): Promise<Uint8Array>;
+  verifier(): Verifier;
+  serialize(): KeyPairRaw;
 }
 
-export interface KeyPair {
-  sign(data: Uint8Array): Promise<Uint8Array>;
+export interface Verifier {
   verify(signature: Uint8Array, data: Uint8Array): Promise<boolean>;
-  serialize(): KeyPairRaw;
+  did(): Promise<string>;
 }
 
 export type InsecureCryptoKeyPair = {

--- a/typescript/packages/common-identity/src/pass-key.ts
+++ b/typescript/packages/common-identity/src/pass-key.ts
@@ -40,7 +40,7 @@ export class PassKey {
       throw new Error("common-identity: No prf found from PassKey");
     }
 
-    return await Identity.generateFromRaw(seed);
+    return await Identity.fromRaw(seed);
   }
 
   // Return the secret 32-bytes derived from the passkey's PRF data.

--- a/typescript/packages/common-identity/src/utils.ts
+++ b/typescript/packages/common-identity/src/utils.ts
@@ -17,8 +17,8 @@ export function once(target: EventTarget, eventName: string, callback: (e: any) 
   target.addEventListener(eventName, wrap);
 }
 
-const HASH_ALG = "SHA-512";
-// Hash input via SHA-512.
+const HASH_ALG = "SHA-256";
+// Hash input via SHA-256.
 export async function hash(input: Uint8Array): Promise<Uint8Array> {
   return new Uint8Array(await window.crypto.subtle.digest(HASH_ALG, input));
 }

--- a/typescript/packages/common-identity/test/ed25519.test.js
+++ b/typescript/packages/common-identity/test/ed25519.test.js
@@ -1,5 +1,5 @@
-import { NativeEd25519 } from "../lib/src/ed25519/native.js";
-import { NobleEd25519 } from "../lib/src/ed25519/noble.js";
+import { NativeEd25519Signer, NativeEd25519Verifier, isNativeEd25519Supported } from "../lib/src/ed25519/native.js";
+import { NobleEd25519Signer, NobleEd25519Verifier } from "../lib/src/ed25519/noble.js";
 import { bytesEqual, assert } from "./utils.js";
 
 const TEST_PRIVATE_KEY = new Uint8Array([
@@ -12,37 +12,62 @@ const TEST_DID = "did:key:z6MkjosLwWEobyT9T6RqLTdaEhFrXAZUNkRZJuUae2ukgfEa";
 
 describe("ed25519 comparison", async () => {
   it("ed25519 is supported in this environment", async () => {
-    assert(await NativeEd25519.isSupported());
+    assert(await isNativeEd25519Supported());
   });
 
   it("has same results in both impls when generating from noble", async () => {
-    let noble = await NobleEd25519.generate();
-    let native = await NativeEd25519.generateFromRaw(noble.keypair.privateKey);
+    let noble = await NobleEd25519Signer.generate();
+    let native = await NativeEd25519Signer.fromRaw(noble.keypair.privateKey);
     let buffer = new Uint8Array(32).fill(10);
     let nobleSig = await noble.sign(buffer);
     let nativeSig = await native.sign(buffer);
+    let nobleVerifier = noble.verifier();
+    let nativeVerifier = native.verifier();
     assert(bytesEqual(nobleSig, nativeSig));
     // Impls verify other impl's sig
-    assert(await noble.verify(nativeSig, buffer))
-    assert(await native.verify(nobleSig, buffer))
+    assert(await nobleVerifier.verify(nativeSig, buffer))
+    assert(await nativeVerifier.verify(nobleSig, buffer))
     // Base case that should fail
-    assert(!await noble.verify(nobleSig, new Uint8Array(32).fill(1)));
-    assert(!await native.verify(nativeSig, new Uint8Array(32).fill(1)));
+    assert(!await nobleVerifier.verify(nobleSig, new Uint8Array(32).fill(1)));
+    assert(!await nativeVerifier.verify(nativeSig, new Uint8Array(32).fill(1)));
   });
 });
 
-describe("Native ed25519", () => {
-  it("derives DID key", async () => {
-    let key = await NativeEd25519.generateFromRaw(TEST_PRIVATE_KEY);
-    let did = await key.did();
-    assert(did === TEST_DID);
-  });
-});
+// These tests are run with both Native and Noble implementations.
+// Code at the start and end of the `describe` function sets this up.
+describe("ed25519", () => {
+  let innerIt = globalThis.it;
+  const tests = []; 
+  const it = (name, fn) => tests.push({ name, fn });
 
-describe("Noble ed25519", () => {
-  it("derives DID key", async () => {
-    let key = await NobleEd25519.generateFromRaw(TEST_PRIVATE_KEY);
-    let did = await key.did();
+  it("derives DID key", async (Signer) => {
+    let signer = await Signer.fromRaw(TEST_PRIVATE_KEY);
+    let verifier = signer.verifier();
+    let did = await verifier.did();
     assert(did === TEST_DID);
   });
+
+  it("derives bytes from DID key and back", async (Signer, Verifier) => {
+    // @see https://w3c-ccg.github.io/did-method-key/#test-vectors
+    const fixtures = [
+      'did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp',
+      'did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG',
+      'did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf',
+    ];
+
+    for (let fixture of fixtures) {
+      let verifier = await Verifier.fromDid(fixture);
+      assert(await verifier.did() === fixture);
+    }
+  });
+
+  // Run all tests with both implentations
+  for (let { name, fn } of tests) {
+    innerIt(`(native) ${name}`, async () => {
+      return await fn(NativeEd25519Signer, NativeEd25519Verifier); 
+    });
+    innerIt(`(noble) ${name}`, async () => {
+      return await fn(NobleEd25519Signer, NobleEd25519Verifier); 
+    });
+  }
 });

--- a/typescript/packages/pnpm-lock.yaml
+++ b/typescript/packages/pnpm-lock.yaml
@@ -161,9 +161,9 @@ importers:
       '@noble/ed25519':
         specifier: ^2.2.3
         version: 2.2.3
-      bs58:
-        specifier: ^6.0.0
-        version: 6.0.0
+      multiformats:
+        specifier: ^13.3.2
+        version: 13.3.2
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -2147,9 +2147,6 @@ packages:
       bare-events:
         optional: true
 
-  base-x@5.0.0:
-    resolution: {integrity: sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ==}
-
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -2174,9 +2171,6 @@ packages:
     resolution: {integrity: sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  bs58@6.0.0:
-    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
@@ -3427,6 +3421,9 @@ packages:
 
   multiformats@13.3.1:
     resolution: {integrity: sha512-QxowxTNwJ3r5RMctoGA5p13w5RbRT2QDkoM+yFlqfLiioBp78nhDjnRLvmSBI9+KAqN4VdgOVWM9c0CHd86m3g==}
+
+  multiformats@13.3.2:
+    resolution: {integrity: sha512-qbB0CQDt3QKfiAzZ5ZYjLFOs+zW43vA4uyM8g27PeEuXZybUOFyjrVdP93HPBHMoglibwfkdVwbzfUq8qGcH6g==}
 
   nanocolors@0.2.13:
     resolution: {integrity: sha512-0n3mSAQLPpGLV9ORXT5+C/D4mwew7Ebws69Hx4E2sgz2ZA5+32Q80B9tL8PbL7XHnRDiAxH/pnrUJ9a4fkTNTA==}
@@ -6306,8 +6303,6 @@ snapshots:
       bare-events: 2.5.4
     optional: true
 
-  base-x@5.0.0: {}
-
   base64-js@1.5.1: {}
 
   basic-ftp@5.0.5: {}
@@ -6335,10 +6330,6 @@ snapshots:
       electron-to-chromium: 1.5.90
       node-releases: 2.0.19
       update-browserslist-db: 1.1.2(browserslist@4.24.4)
-
-  bs58@6.0.0:
-    dependencies:
-      base-x: 5.0.0
 
   buffer-crc32@0.2.13: {}
 
@@ -7706,6 +7697,8 @@ snapshots:
   muggle-string@0.4.1: {}
 
   multiformats@13.3.1: {}
+
+  multiformats@13.3.2: {}
 
   nanocolors@0.2.13: {}
 


### PR DESCRIPTION
* Add fromDid/Did methods for verifiers.
* Remove redundant hashing in derivation
* Use SHA-256 when deriving keys.