### PR TITLE
Fix rendering exception when cell has value 'undefined'

### DIFF
--- a/typescript/packages/common-html/src/render.ts
+++ b/typescript/packages/common-html/src/render.ts
@@ -124,7 +124,9 @@ const bindChildren = (
 
       return { node: currentNode!, cancel };
     } else {
-      if (typeof child === "string" || typeof child === "number" || typeof child === "boolean") {
+      if (typeof child === "undefined" || child === null) {
+        return { node: document.createTextNode(""), cancel: () => {} };
+      } else if (typeof child === "string" || typeof child === "number" || typeof child === "boolean") {
         return { node: document.createTextNode(child.toString()), cancel: () => {} };
       } else if (isVNode(child)) {
         const [childElement, cancel] = renderNode(child);


### PR DESCRIPTION
Uncaught Error: Unsupported static child type
    at renderChild (render.ts:132:20)
    at updateChildren (render.ts:157:29)
    at render.ts:187:63
    at subscribeToReferencedDocs (cell.ts:258:41)
    at Object.sink (cell.ts:195:7)
    at effect (reactivity.ts:21:18)
    at bindChildren (render.ts:187:29)
    at renderNode (render.ts:75:26)
    at render.ts:97:47
    at subscribeToReferencedDocs (cell.ts:258:41)