### PR TITLE
Spellcaster: Reuse data with another spell

### DIFF
--- a/typescript/packages/common-charm/src/syncRecipe.ts
+++ b/typescript/packages/common-charm/src/syncRecipe.ts
@@ -8,9 +8,7 @@ import {
 } from "@commontools/runner";
 import { buildRecipe } from "./localBuild.js";
 
-// FIXME(jake): This needs to be settable by environment variable...
-// If this is hardcoded, then it is not possible to develop spellbook locally.
-export const BLOBBY_SERVER_URL = "https://toolshed.saga-castor.ts.net/api/storage/blobby";
+export const BLOBBY_SERVER_URL = "/api/storage/blobby";
 
 const recipesKnownToStorage = new Set<string>();
 

--- a/typescript/packages/jumble/src/components/CommandCenter.tsx
+++ b/typescript/packages/jumble/src/components/CommandCenter.tsx
@@ -317,10 +317,15 @@ export function CommandCenter() {
           value={search}
           onValueChange={setSearch}
           onKeyDown={(e) => {
+            // Only handle Enter for input mode, ignore for select mode
             if (mode.type === "input" && e.key === "Enter") {
               e.preventDefault();
               const command = mode.command;
               command.handler?.(search);
+            }
+            // For select mode, prevent the default Enter behavior
+            if (mode.type === "select" && e.key === "Enter") {
+              e.preventDefault();
             }
           }}
           style={{ flexGrow: 1 }}
@@ -373,8 +378,10 @@ export function CommandCenter() {
                             parent: cmd,
                           });
                         } else if (cmd.type === "action") {
-                          cmd.handler?.(context);
-                          if (!cmd.handler || cmd.handler.length === 0) {
+                          // Only close if the handler doesn't return a Promise
+                          // This allows async handlers that change mode to keep the palette open
+                          const result = cmd.handler?.(context);
+                          if (!cmd.handler || (!result && cmd.handler.length === 0)) {
                             setOpen(false);
                           }
                         } else {

--- a/typescript/packages/jumble/src/components/CommandCenter.tsx
+++ b/typescript/packages/jumble/src/components/CommandCenter.tsx
@@ -6,22 +6,13 @@ import { useMatch, useNavigate } from "react-router-dom";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { DialogDescription, DialogTitle } from "@radix-ui/react-dialog";
 import { DitheredCube } from "./DitherCube";
-import {
-  CommandContext,
-  CommandItem,
-  CommandMode,
-  commands,
-  getChildren,
-  getCommands,
-  getTitle,
-} from "./commands";
+import { CommandContext, CommandItem, CommandMode, getCommands } from "./commands";
 import { usePreferredLanguageModel } from "@/contexts/LanguageModelContext";
 import { TranscribeInput } from "./TranscribeCommand";
 import { useBackgroundTasks } from "@/contexts/BackgroundTaskContext";
 
 function CommandProcessor({
   mode,
-  command,
   context,
   onComplete,
 }: {

--- a/typescript/packages/jumble/src/components/CommandCenter.tsx
+++ b/typescript/packages/jumble/src/components/CommandCenter.tsx
@@ -67,10 +67,7 @@ function CommandProcessor({
       return (
         <>
           {mode.options.map((option) => (
-            <Command.Item
-              key={option.id}
-              onSelect={() => mode.command.handler?.(context, option.value)}
-            >
+            <Command.Item key={option.id} onSelect={() => mode.command.handler?.(option.value)}>
               {option.title}
             </Command.Item>
           ))}

--- a/typescript/packages/jumble/src/components/commands.ts
+++ b/typescript/packages/jumble/src/components/commands.ts
@@ -386,6 +386,73 @@ async function handleIndexCharms(deps: CommandContext) {
   });
   deps.setOpen(false);
 }
+
+async function handleUseDataInSpell(deps: CommandContext) {
+  deps.setLoading(true);
+  try {
+    // Mock data - this would be replaced with actual fetch request
+    const mockSpells = [
+      { id: "spell1", name: "Transform to Table", description: "Converts data into table format" },
+      { id: "spell2", name: "Generate Summary", description: "Creates a summary of the data" },
+      { id: "spell3", name: "Convert to Chart", description: "Visualizes data as a chart" },
+    ];
+
+    deps.setMode({
+      type: "select",
+      command: {
+        id: "spell-select",
+        type: "select",
+        title: "Select Spell to Use",
+        handler: async (selectedSpell) => {
+          console.log("Selected spell:", selectedSpell);
+          // TODO: Implement actual spell casting logic
+          deps.setOpen(false);
+        },
+      },
+      options: mockSpells.map((spell) => ({
+        id: spell.id,
+        title: `${spell.name} - ${spell.description}`,
+        value: spell,
+      })),
+    });
+  } finally {
+    deps.setLoading(false);
+  }
+}
+
+async function handleUseSpellOnOtherData(deps: CommandContext) {
+  deps.setLoading(true);
+  try {
+    // Mock data - this would be replaced with actual fetch request
+    const mockCharms = [
+      { id: "charm1", name: "User Data", description: "Contains user information" },
+      { id: "charm2", name: "Product Catalog", description: "List of products" },
+      { id: "charm3", name: "Analytics", description: "Website analytics data" },
+    ];
+
+    deps.setMode({
+      type: "select",
+      command: {
+        id: "charm-data-select",
+        type: "select",
+        title: "Select Charm Data to Use",
+        handler: async (selectedCharm) => {
+          console.log("Selected charm:", selectedCharm);
+          // TODO: Implement actual data processing logic
+          deps.setOpen(false);
+        },
+      },
+      options: mockCharms.map((charm) => ({
+        id: charm.id,
+        title: `${charm.name} - ${charm.description}`,
+        value: charm,
+      })),
+    });
+  } finally {
+    deps.setLoading(false);
+  }
+}
+
 export function getCommands(deps: CommandContext): CommandItem[] {
   return [
     {
@@ -402,13 +469,35 @@ export function getCommands(deps: CommandContext): CommandItem[] {
       group: "Navigation",
       handler: () => handleSearchCharms(deps),
     },
+    // Create a new Spellcaster menu that contains all spell-related commands
     {
-      id: "spellcaster",
-      type: "input",
+      id: "spellcaster-menu",
+      type: "menu",
       title: "Spellcaster",
       group: "Create",
       predicate: !!deps.focusedReplicaId,
-      handler: (input) => handleSpellcaster(deps, input),
+      children: [
+        {
+          id: "spellcaster",
+          type: "input",
+          title: "Search Spells",
+          handler: (input) => handleSpellcaster(deps, input),
+        },
+        {
+          id: "use-data-in-spell",
+          type: "action",
+          title: "Use Current Data in Spell",
+          predicate: !!deps.focusedCharmId,
+          handler: () => handleUseDataInSpell(deps),
+        },
+        {
+          id: "use-spell-on-other-data",
+          type: "action",
+          title: "Use Current Spell on Other Data",
+          predicate: !!deps.focusedCharmId,
+          handler: () => handleUseSpellOnOtherData(deps),
+        },
+      ],
     },
     {
       id: "rename-charm",

--- a/typescript/packages/jumble/src/search.ts
+++ b/typescript/packages/jumble/src/search.ts
@@ -17,8 +17,8 @@ export interface SpellSearchResult {
 export async function castSpell(replica: string, value: string) {
   const searchUrl =
     typeof window !== "undefined"
-      ? window.location.protocol + "//" + window.location.host + "/ai/spell/search"
-      : "//ai/spell/search";
+      ? window.location.protocol + "//" + window.location.host + "/api/ai/spell/search"
+      : "//api/ai/spell/search";
 
   // Search for suggested spells based on input
   const response = await fetch(searchUrl, {

--- a/typescript/packages/jumble/src/search.ts
+++ b/typescript/packages/jumble/src/search.ts
@@ -17,8 +17,8 @@ export interface SpellSearchResult {
 export async function castSpell(replica: string, value: string) {
   const searchUrl =
     typeof window !== "undefined"
-      ? window.location.protocol + "//" + window.location.host + "/api/ai/spell/search"
-      : "//api/ai/spell/search";
+      ? window.location.protocol + "//" + window.location.host + "/ai/spell/search"
+      : "//ai/spell/search";
 
   // Search for suggested spells based on input
   const response = await fetch(searchUrl, {

--- a/typescript/packages/jumble/vite.config.ts
+++ b/typescript/packages/jumble/vite.config.ts
@@ -8,12 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     proxy: {
-      "/api/ai/spell/fulfill": {
-        target: process.env.TOOLSHED_API_URL ?? "http://localhost:8000/",
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ""),
-      },
-      "/api/ai/spell/search": {
+      "/api/ai/spell/": {
         target: process.env.TOOLSHED_API_URL ?? "http://localhost:8000/",
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),

--- a/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
@@ -1,4 +1,5 @@
 import { hc } from "hono/client";
+import { AppType } from "@/app.ts";
 import { Memory } from "@commontools/memory";
 
 const client = hc<AppType>("http://localhost:8000/");
@@ -30,10 +31,6 @@ function handleErrorResponse(data: any) {
 export async function getAllMemories(
   replica: string,
 ): Promise<Record<string, any>> {
-  if (!replica.startsWith("did:")) {
-    replica = `did:key:${replica}`;
-  }
-
   const res = await client.api.storage.memory.$post({
     json: {
       cmd: "/memory/query",
@@ -41,7 +38,7 @@ export async function getAllMemories(
       sub: replica,
       args: {
         select: {
-          _: {
+          _: { // <- any id
             "application/json": {
               "_": { // <- any cause
                 "is": {},

--- a/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
@@ -44,7 +44,9 @@ export async function getAllMemories(
         select: {
           _: {
             "application/json": {
-              is: {},
+              "_": { // <- any cause
+                "is": {},
+              },
             },
           },
         },
@@ -91,7 +93,9 @@ export async function getMemory(
         select: {
           ["of:" + key]: {
             "application/json": {
-              is: {},
+              "_": { // <- any cause
+                "is": {},
+              },
             },
           },
         },

--- a/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
@@ -1,4 +1,3 @@
-import { AppType } from "@/app.ts";
 import { hc } from "hono/client";
 import { Memory } from "@commontools/memory";
 
@@ -108,14 +107,29 @@ export async function getMemory(
     return null;
   }
 
-  console.log(data);
-
+  console.log(key, data);
   const memory = Array.isArray(data.ok) ? data.ok[0] : data.ok;
-  if (!memory?.is?.value?.argument) {
-    return null;
-  }
 
-  return memory.is.value.argument;
+  // format
+  // {
+  //   ok: {
+  //     "did:key:replica": {
+  //       "of:charmId": {
+  //         "application/json": {
+  //           "causeId": {
+  //             "is": {
+  //               "value": {...}
+  //             }
+  //           }
+  //         }
+  //       }
+  //     }
+  //   }
+  // }
+
+  const memoryData = memory[replica]["of:" + key]["application/json"];
+  const [, firstValue] = Object.entries(memoryData)[0];
+  return (firstValue as any)?.is?.value;
 }
 
 export async function getAllBlobs(

--- a/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
@@ -82,7 +82,7 @@ export async function getAllMemories(
 export async function getMemory(
   key: string,
   replica: string,
-): Promise<unknown> {
+): Promise<any> {
   const res = await client.api.storage.memory.$post({
     json: {
       cmd: "/memory/query",
@@ -126,10 +126,11 @@ export async function getMemory(
   //     }
   //   }
   // }
-
+  //
+  //
   const memoryData = memory[replica]["of:" + key]["application/json"];
   const [, firstValue] = Object.entries(memoryData)[0];
-  return (firstValue as any)?.is?.value;
+  return (firstValue as any)?.is;
 }
 
 export async function getAllBlobs(

--- a/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
@@ -100,12 +100,8 @@ export async function getMemory(
   });
   const data = await res.json();
   if ("error" in data) {
-    handleErrorResponse(data);
-    return null;
+    throw handleErrorResponse(data);
   }
-
-  console.log(key, data);
-  const memory = Array.isArray(data.ok) ? data.ok[0] : data.ok;
 
   // format
   // {
@@ -125,14 +121,15 @@ export async function getMemory(
   // }
   //
   //
+  const memory = Array.isArray(data.ok) ? data.ok[0] : data.ok;
   const memoryData = memory[replica]["of:" + key]["application/json"];
   const [, firstValue] = Object.entries(memoryData)[0];
   return (firstValue as any)?.is;
 }
 
-export async function getAllBlobs(
+export async function getAllBlobs<T extends unknown>(
   options: BlobOptions = {},
-): Promise<string[] | { [id: string]: any }> {
+): Promise<string[] | { [id: string]: T }> {
   const query: Record<string, string> = {
     all: "true",
   };
@@ -145,19 +142,17 @@ export async function getAllBlobs(
   const res = await client.api.storage.blobby.$get({ query });
   const data = await res.json();
   if ("error" in data) {
-    handleErrorResponse(data);
-    return [];
+    throw handleErrorResponse(data);
   }
   return data.blobs || data;
 }
 
-export async function getBlob(key: string): Promise<unknown> {
+export async function getBlob<T extends unknown>(key: string): Promise<T> {
   const res = await client.api.storage.blobby[":key"].$get({ param: { key } });
   const data = (await res.json()) as any;
 
   if ("error" in data) {
-    handleErrorResponse(data);
-    return [];
+    throw handleErrorResponse(data);
   }
 
   return data;

--- a/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
@@ -78,6 +78,42 @@ export async function getAllMemories(
   return memoryMap;
 }
 
+export async function getMemory(
+  key: string,
+  replica: string,
+): Promise<unknown> {
+  const res = await client.api.storage.memory.$post({
+    json: {
+      cmd: "/memory/query",
+      iss: "did:web:common.tools",
+      sub: replica,
+      args: {
+        select: {
+          ["of:" + key]: {
+            "application/json": {
+              is: {},
+            },
+          },
+        },
+      },
+    },
+  });
+  const data = await res.json();
+  if ("error" in data) {
+    handleErrorResponse(data);
+    return null;
+  }
+
+  console.log(data);
+
+  const memory = Array.isArray(data.ok) ? data.ok[0] : data.ok;
+  if (!memory?.is?.value?.argument) {
+    return null;
+  }
+
+  return memory.is.value.argument;
+}
+
 export async function getAllBlobs(
   options: BlobOptions = {},
 ): Promise<string[] | { [id: string]: any }> {

--- a/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/behavior/effects.ts
@@ -31,6 +31,10 @@ function handleErrorResponse(data: any) {
 export async function getAllMemories(
   replica: string,
 ): Promise<Record<string, any>> {
+  if (!replica.startsWith("did:")) {
+    replica = `did:key:${replica}`;
+  }
+
   const res = await client.api.storage.memory.$post({
     json: {
       cmd: "/memory/query",

--- a/typescript/packages/toolshed/routes/ai/spell/behavior/spell-search.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/behavior/spell-search.ts
@@ -217,7 +217,7 @@ function searchBlobs(
     .map(({ rank, ...rest }) => rest);
 }
 
-function findCompatibleSpells(
+export function findCompatibleSpells(
   blob: Record<string, unknown>,
   spells: Record<string, Spell>,
 ): Array<{ key: string; name: string; description: string }> {

--- a/typescript/packages/toolshed/routes/ai/spell/spell.handlers.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/spell.handlers.ts
@@ -380,7 +380,7 @@ export const reuse: AppRouteHandler<ReuseRoute> = async (c) => {
     console.log("charm", charm);
 
     const response: ReuseResponse = {
-      result: {},
+      result: charm,
     };
 
     return c.json(response, HttpStatusCodes.OK);

--- a/typescript/packages/toolshed/routes/ai/spell/spell.index.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/spell.index.ts
@@ -22,8 +22,8 @@ router.use(
 );
 
 const Router = router
-  .openapi(routes.fulfill, handlers.fulfill)
-  .openapi(routes.caster, handlers.caster)
+  .openapi(routes.recast, handlers.recast)
+  .openapi(routes.reuse, handlers.reuse)
   .openapi(routes.spellSearch, handlers.spellSearch);
 
 export default Router;

--- a/typescript/packages/toolshed/routes/ai/spell/spell.routes.ts
+++ b/typescript/packages/toolshed/routes/ai/spell/spell.routes.ts
@@ -6,6 +6,10 @@ import {
   CasterResponseSchema,
   ProcessSchemaRequestSchema,
   ProcessSchemaResponseSchema,
+  RecastRequestSchema,
+  RecastResponseSchema,
+  ReuseRequestSchema,
+  ReuseResponseSchema,
   SearchSchemaRequestSchema,
   SearchSchemaResponseSchema,
   SpellSearchRequestSchema,
@@ -126,3 +130,56 @@ export const spellSearch = createRoute({
 });
 
 export type SpellSearchRoute = typeof spellSearch;
+
+export const recast = createRoute({
+  path: "/ai/spell/recast",
+  method: "post",
+  tags,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: RecastRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      RecastResponseSchema,
+      "The recast result",
+    ),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      ErrorResponseSchema,
+      "An error occurred",
+    ),
+  },
+});
+
+export const reuse = createRoute({
+  path: "/ai/spell/reuse",
+  method: "post",
+  tags,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: ReuseRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      ReuseResponseSchema,
+      "The reuse result",
+    ),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      ErrorResponseSchema,
+      "An error occurred",
+    ),
+  },
+});
+
+export type RecastRoute = typeof recast;
+export type ReuseRoute = typeof reuse;

--- a/typescript/packages/toolshed/routes/storage/memory/memory.routes.ts
+++ b/typescript/packages/toolshed/routes/storage/memory/memory.routes.ts
@@ -204,20 +204,23 @@ export const query = createRoute({
   responses: {
     [HttpStatusCodes.OK]: jsonContent(
       z.object({
-        ok: z.union([
-          z.array(
+        ok: z.record(
+          z.string(),
+          z.union([
+            z.array(
+              z.object({
+                the: z.any(),
+                of: z.any(),
+                is: z.any(),
+              }),
+            ),
             z.object({
               the: z.any(),
               of: z.any(),
               is: z.any(),
             }),
-          ),
-          z.object({
-            the: z.any(),
-            of: z.any(),
-            is: z.any(),
-          }),
-        ]),
+          ]),
+        ),
       }),
       "Matching records found",
     ),


### PR DESCRIPTION
- **Replica must start with `did` when contacting common-memory**
- **Fix spell search path in production**
- **Mock up new commands and fix open/close bugs**
- **WIP new toolshed routes**
- **Fix malformed query**
- **Fix memory retrieval**
- **Remove hardcoded BLOBBY_URL**
- **Implement 'reuse' endpoint**
- **Hacking my way working data reuse between spells**
- **It's alive!**
