### PR TITLE
chore: Update the did() method in common-identity to be synchronous

### DIFF
--- a/typescript/packages/common-identity/src/ed25519/index.ts
+++ b/typescript/packages/common-identity/src/ed25519/index.ts
@@ -51,11 +51,11 @@ export class Ed25519Signer implements Signer {
     return await Ed25519Signer.fromRaw(bytes);
   }
 
-  static deserialize(input: KeyPairRaw): Ed25519Signer {
+  static async deserialize(input: KeyPairRaw): Promise<Ed25519Signer> {
     if (isCryptoKeyPair(input)) {
-      return new Ed25519Signer(NativeEd25519Signer.deserialize(input));
+      return new Ed25519Signer(await NativeEd25519Signer.deserialize(input));
     } else if (isInsecureCryptoKeyPair(input)) {
-      return new Ed25519Signer(NobleEd25519Signer.deserialize(input));
+      return new Ed25519Signer(await NobleEd25519Signer.deserialize(input));
     } else {
       throw new Error("common-identity: Could not deserialize key.");
     }
@@ -64,22 +64,16 @@ export class Ed25519Signer implements Signer {
 
 export class Ed25519Verifier implements Verifier {
   private impl: NativeEd25519Verifier | NobleEd25519Verifier;
-  private _did: string | null;
   constructor(impl: NativeEd25519Verifier | NobleEd25519Verifier) {
     this.impl = impl;
-    this._did = null;
   }
 
   verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
     return this.impl.verify(signature, data);
   }
 
-  async did(): Promise<string> {
-    if (this._did) {
-      return this._did;
-    }
-    this._did = await this.impl.did();
-    return this._did;
+  did(): DID {
+    return this.impl.did();
   }
 
   static async fromDid(did: DID): Promise<Ed25519Verifier> {

--- a/typescript/packages/common-identity/src/ed25519/noble.ts
+++ b/typescript/packages/common-identity/src/ed25519/noble.ts
@@ -12,10 +12,6 @@ export class NobleEd25519Signer implements Signer {
     return new NobleEd25519Verifier(this.keypair.publicKey);
   }
 
-  async did(): Promise<string> {
-    return bytesToDid(this.keypair.publicKey);
-  }
-
   serialize(): InsecureCryptoKeyPair {
     return this.keypair;
   }
@@ -34,23 +30,25 @@ export class NobleEd25519Signer implements Signer {
     return await NobleEd25519Signer.fromRaw(privateKey);
   }
 
-  static deserialize(keypair: InsecureCryptoKeyPair) {
+  static async deserialize(keypair: InsecureCryptoKeyPair) {
     return new NobleEd25519Signer(keypair);
   }
 }
 
 export class NobleEd25519Verifier implements Verifier {
   private publicKey: Uint8Array;
+  private _did: DID;
   constructor(publicKey: Uint8Array) {
     this.publicKey = publicKey;
+    this._did = bytesToDid(publicKey);
   }
 
   async verify(signature: Uint8Array, data: Uint8Array): Promise<boolean> {
     return await ed25519.verifyAsync(signature, data, this.publicKey);
   }
 
-  async did(): Promise<string> {
-    return bytesToDid(this.publicKey);
+  did(): DID{
+    return this._did;
   }
   
   static async fromDid(did: DID): Promise<NobleEd25519Verifier> {

--- a/typescript/packages/common-identity/src/identity.ts
+++ b/typescript/packages/common-identity/src/identity.ts
@@ -56,8 +56,8 @@ export class Identity implements Signer {
   }
 
   // Deserialize `input` from storage into an `Identity`.
-  static deserialize(input: any): Identity {
-    return new Identity(Ed25519Signer.deserialize(input)); 
+  static async deserialize(input: any): Promise<Identity> {
+    return new Identity(await Ed25519Signer.deserialize(input)); 
   }
 }
 
@@ -72,8 +72,8 @@ export class VerifierIdentity implements Verifier {
     return await this.inner.verify(signature, data);
   }
 
-  async did(): Promise<string> {
-    return await this.inner.did();
+  did(): DID {
+    return this.inner.did();
   }
 
   static async fromDid(did: DID): Promise<VerifierIdentity> {

--- a/typescript/packages/common-identity/src/interface.ts
+++ b/typescript/packages/common-identity/src/interface.ts
@@ -13,7 +13,7 @@ export interface Signer {
 
 export interface Verifier {
   verify(signature: Uint8Array, data: Uint8Array): Promise<boolean>;
-  did(): Promise<string>;
+  did(): DID;
 }
 
 export type InsecureCryptoKeyPair = {

--- a/typescript/packages/common-identity/src/key-store.ts
+++ b/typescript/packages/common-identity/src/key-store.ts
@@ -20,7 +20,7 @@ export class KeyStore {
   async get(name: string): Promise<Identity | undefined> {
     let result = await this.db.get(this.storeName, name);
     if (result) {
-      return Identity.deserialize(result);
+      return await Identity.deserialize(result);
     }
     return result;
   }

--- a/typescript/packages/common-identity/test/ed25519.test.js
+++ b/typescript/packages/common-identity/test/ed25519.test.js
@@ -43,7 +43,7 @@ describe("ed25519 impl", () => {
   it("derives DID key", async (Signer) => {
     let signer = await Signer.fromRaw(TEST_PRIVATE_KEY);
     let verifier = signer.verifier();
-    let did = await verifier.did();
+    let did = verifier.did();
     assert(did === TEST_DID);
   });
 
@@ -57,7 +57,7 @@ describe("ed25519 impl", () => {
 
     for (let fixture of fixtures) {
       let verifier = await Verifier.fromDid(fixture);
-      assert(await verifier.did() === fixture);
+      assert(verifier.did() === fixture);
     }
   });
 

--- a/typescript/packages/common-identity/test/identity.test.js
+++ b/typescript/packages/common-identity/test/identity.test.js
@@ -4,7 +4,7 @@ import { assert } from "./utils.js";
 describe("Identity", async () => {
   it("generates mnemonics", async () => {
     let [identity, mnemonic] = await Identity.generateMnemonic();
-    let did = await identity.verifier().did();
+    let did = identity.verifier().did();
     let identity2 = await Identity.fromMnemonic(mnemonic);
     assert(did, identity2.verifier().did());
   });

--- a/typescript/packages/jumble/src/components/User.tsx
+++ b/typescript/packages/jumble/src/components/User.tsx
@@ -7,11 +7,11 @@ export function User() {
   
   useEffect(() => {
     let ignore = false;
-    async function setDidInner() {
+    function setDidInner() {
       if (!user) {
         return;
       }
-      let did = await user.verifier().did();
+      let did = user.verifier().did();
       if (!ignore) {
         setDid(did);
       }


### PR DESCRIPTION
Move the asynchronous requirements (native ed25519 requires exporting a public key) inside generation, caching the DID, so that the external interfaces are synchronous; for transaction work