### PR TITLE
Cell creation helpers

### DIFF
--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -8,7 +8,7 @@ import {
 } from "./query-result-proxy.js";
 import { resolvePath, followLinks, prepareForSaving } from "./utils.js";
 import { queueEvent, subscribe, type ReactivityLog } from "./scheduler.js";
-import { type EntityId, getEntityId } from "./cell-map.js";
+import { type EntityId, getDocByEntityId, getEntityId } from "./cell-map.js";
 import { type Cancel, isCancel, useCancelGroup } from "./cancel.js";
 import { validateAndTransform } from "./schema.js";
 
@@ -91,6 +91,33 @@ export interface Stream<T> {
   sink(callback: (event: T) => Cancel | undefined | void): Cancel;
   updates(callback: (event: T) => Cancel | undefined | void): Cancel;
   [isStreamMarker]: true;
+}
+
+export function getCellFromEntityId<T>(
+  entityId: EntityId,
+  path: PropertyKey[] = [],
+  schema?: JSONSchema,
+  log?: ReactivityLog,
+): Cell<T> {
+  const doc = getDocByEntityId(entityId, true)!;
+  return createCell(doc, path, log, schema);
+}
+
+export function getCellFromDocLink<T>(
+  docLink: DocLink,
+  schema?: JSONSchema,
+  log?: ReactivityLog,
+): Cell<T> {
+  const doc = isDoc(docLink.cell)
+    ? docLink.cell
+    : getDocByEntityId(getEntityId(docLink.cell)!, true)!;
+  return createCell(doc, docLink.path, log, schema);
+}
+
+export function getImmutableCell<T>(data: T, schema?: JSONSchema, log?: ReactivityLog): Cell<T> {
+  const doc = getDoc<T>(data);
+  doc.freeze();
+  return createCell(doc, [], log, schema);
 }
 
 export function createCell<T>(

--- a/typescript/packages/common-runner/test/call-map.test.ts
+++ b/typescript/packages/common-runner/test/call-map.test.ts
@@ -32,21 +32,23 @@ describe("cell-map", () => {
     it("should return the entity ID for a cell", () => {
       const c = getDoc({});
       c.generateEntityId();
+      const id = getEntityId(c);
 
-      expect(getEntityId(c)).toEqual(c.entityId);
-      expect(getEntityId(c.getAsQueryResult())).toEqual(c.entityId);
-      expect(getEntityId(c.asCell())).toEqual(c.entityId);
-      expect(getEntityId({ cell: c, path: [] })).toEqual(c.entityId);
+      expect(getEntityId(c)).toEqual(id);
+      expect(getEntityId(c.getAsQueryResult())).toEqual(id);
+      expect(getEntityId(c.asCell())).toEqual(id);
+      expect(getEntityId({ cell: c, path: [] })).toEqual(id);
     });
 
     it("should return a different entity ID for reference with paths", () => {
       const c = getDoc({ foo: { bar: 42 } });
       c.generateEntityId();
+      const id = getEntityId(c);
 
-      expect(getEntityId(c.getAsQueryResult())).toEqual(c.entityId);
-      expect(getEntityId(c.getAsQueryResult(["foo"]))).not.toEqual(c.entityId);
-      expect(getEntityId(c.asCell(["foo"]))).not.toEqual(c.entityId);
-      expect(getEntityId({ cell: c, path: ["foo"] })).not.toEqual(c.entityId);
+      expect(getEntityId(c.getAsQueryResult())).toEqual(id);
+      expect(getEntityId(c.getAsQueryResult(["foo"]))).not.toEqual(id);
+      expect(getEntityId(c.asCell(["foo"]))).not.toEqual(id);
+      expect(getEntityId({ cell: c, path: ["foo"] })).not.toEqual(id);
 
       expect(getEntityId(c.getAsQueryResult(["foo"]))).toEqual(getEntityId(c.asCell(["foo"])));
       expect(getEntityId(c.getAsQueryResult(["foo"]))).toEqual(


### PR DESCRIPTION
Introduces:
- `getCellFromEntityId(entityid, [path, [schema, log]]])` – create a cell from a known entityid, will create underlying doc if necessary
- `getCellFromDocLink(doclink, [schema, [log]])` - where doclink is `cell.getAsDocLink()`, which can be serialized
- `getImmutableCell(data, [schema, [log]])` - creates immutable in-memory data, `log` will be transferred to mutable `Cell` instances linked off of this.
