### PR TITLE
CharmManager adds Spell's schemas to .get() with optional running + add .getArgument(charm)

### DIFF
--- a/typescript/packages/common-charm/src/charm.ts
+++ b/typescript/packages/common-charm/src/charm.ts
@@ -10,6 +10,7 @@ import {
   type Cell,
   getEntityId,
   isCell,
+  getRecipe,
 } from "@commontools/runner";
 import { type Storage } from "./storage.js";
 import { syncRecipeBlobby } from "./syncRecipe.js";
@@ -17,7 +18,6 @@ import { syncRecipeBlobby } from "./syncRecipe.js";
 export type Charm = {
   [NAME]?: string;
   [UI]?: any;
-  [TYPE]?: string;
   [key: string]: any;
 };
 
@@ -75,21 +75,54 @@ export class CharmManager {
     await idle();
   }
 
-  async get(id: string): Promise<Cell<Charm> | undefined> {
+  async get(id: string, runIt: boolean = true): Promise<Cell<Charm> | undefined> {
     await this.storage.syncCell(this.charmsDoc);
 
+    // Load the charm from storage.
     const idAsDocId = JSON.stringify({ "/": id });
-    const charm = this.charms
-      .get()
-      .find((charm) => JSON.stringify(getEntityId(charm)) === idAsDocId);
-    if (!charm) return undefined;
+    const resultDoc = await this.storage.syncCell(idAsDocId);
 
     // Make sure we have the recipe so we can run it!
-    await this.syncRecipe(charm);
+    const recipeId = await this.syncRecipe(resultDoc.asCell());
+    const recipe = getRecipe(recipeId);
 
-    // Make sure the charm is running. This is re-entrant and has no effect if
-    // the charm is already running.
-    return run(undefined, undefined, charm.getAsDocLink().cell).asCell([], undefined, charmSchema);
+    let resultSchema = recipe?.resultSchema;
+
+    // Unless there is a non-object schema, add UI and NAME properties if present
+    if (!resultSchema || resultSchema.type === "object") {
+      const { [UI]: hasUI, [NAME]: hasName } = resultDoc.get();
+      if (hasUI || hasName) {
+        // Copy the original schema, so we can modify properties without
+        // affecting other uses of the same spell.
+        resultSchema = {
+          ...resultSchema,
+          properties: {
+            ...resultSchema?.properties,
+          },
+        };
+        if (hasUI && !resultSchema.properties![UI])
+          resultSchema.properties![UI] = { type: "object" }; // TODO: vdom schema
+        if (hasName && !resultSchema.properties![NAME])
+          resultSchema.properties![NAME] = { type: "string" };
+      }
+    }
+
+    if (runIt) {
+      // Make sure the charm is running. This is re-entrant and has no effect if
+      // the charm is already running.
+      return run(undefined, undefined, resultDoc).asCell([], undefined, resultSchema);
+    } else {
+      return resultDoc.asCell([], undefined, resultSchema);
+    }
+  }
+
+  // Return Cell with argument content according to the schema of the charm.
+  getArgument<T = any>(charm: Cell<Charm | T>): T {
+    const source = charm.getSourceCell();
+    const recipeId = source?.get()?.[TYPE];
+    const recipe = getRecipe(recipeId);
+    const argumentSchema = recipe?.argumentSchema;
+    return source?.key("argument").asSchema(argumentSchema!) as T;
   }
 
   // note: removing a charm doesn't clean up the charm's cells

--- a/typescript/packages/common-runner/src/cell.ts
+++ b/typescript/packages/common-runner/src/cell.ts
@@ -69,7 +69,7 @@ export interface Cell<T> {
   sink(callback: (value: T) => Cancel | undefined | void): Cancel;
   updates(callback: (value: T) => Cancel | undefined | void): Cancel;
   key<K extends keyof T>(valueKey: K): Cell<T[K]>;
-  asSchema(schema: JSONSchema): Cell<T>;
+  asSchema(schema?: JSONSchema): Cell<T>;
   withLog(log: ReactivityLog): Cell<T>;
   getAsQueryResult<Path extends PropertyKey[]>(
     path?: Path,
@@ -244,7 +244,7 @@ function createRegularCell<T>(
             : undefined;
       return createCell(doc, [...path, key], log, currentSchema, rootSchema) as Cell<T[K]>;
     },
-    asSchema: (newSchema: JSONSchema) => createCell(doc, path, log, newSchema, newSchema),
+    asSchema: (newSchema?: JSONSchema) => createCell(doc, path, log, newSchema, newSchema),
     withLog: (newLog: ReactivityLog) => createCell(doc, path, newLog, schema, rootSchema),
     getAsQueryResult: (subPath: PropertyKey[] = [], newLog?: ReactivityLog) =>
       createQueryResultProxy(doc, [...path, ...subPath], newLog ?? log),


### PR DESCRIPTION
`CharmManager.get(charmId | charm, runIt = true)` now uses the spell's schema in the cell, but always adds `[NAME]` and `[UI]` if present in the charm. You can now pass a charm to it, and it'll return it with the right schema. A new second argument allows turning off automatically launching it.

New: `CharmManager.getArgument(charm)` returns the argument as a cell with the original argument schema.

Note that `CharmManager.getCharms` returns an array of charms, but those only have `[NAME]` and `[UI]` set, since they work off a bare bones schema for charms on that array. So if you then want the the result data or run it call `CharmManager.get(charm)` with it. We should probably just move that into the cell interface itself, i.e. the ability to run it and to represent itself as the schema promises.

Also, FYI, if you want to write into the result of `.getArgument()`, ideally navigate into the cell with `.key()` and then call `.set()` there. This will cause the minimal change possible.