### PR TITLE
set input event cells to be ephemeral

### DIFF
--- a/typescript/packages/common-runner/src/runner.ts
+++ b/typescript/packages/common-runner/src/runner.ts
@@ -346,6 +346,7 @@ function instantiateJavaScriptNode(
       }
 
       const inputsCell = getDoc(eventInputs, cause);
+      inputsCell.ephemeral = true;
       inputsCell.freeze(); // Freezes the bindings, not aliased cells.
 
       const frame = pushFrameFromCause(cause, {
@@ -374,6 +375,7 @@ function instantiateJavaScriptNode(
     // Schedule the action to run when the inputs change
 
     const inputsCell = getDoc(inputs);
+    inputsCell.ephemeral = true;
     inputsCell.freeze(); // Freezes the bindings, not aliased cells.
 
     let resultCell: DocImpl<any> | undefined;


### PR DESCRIPTION
otherwise as they are frozen/readOnly, it breaks sync