### PR TITLE
remove direct use of sourceCell from jumble

### DIFF
--- a/typescript/packages/common-charm/src/charm.ts
+++ b/typescript/packages/common-charm/src/charm.ts
@@ -158,12 +158,14 @@ export class CharmManager {
   }
 
   // Return Cell with argument content according to the schema of the charm.
-  getArgument<T = any>(charm: Cell<Charm | T>): T {
+  getArgument<T = any>(charm: Cell<Charm | T>): Cell<T> | undefined {
     const source = charm.getSourceCell(processSchema);
     const recipeId = source?.get()?.[TYPE];
     const recipe = getRecipe(recipeId);
     const argumentSchema = recipe?.argumentSchema;
-    return source?.key("argument").asSchema(argumentSchema!) as T;
+    return source?.key("argument").asSchema(argumentSchema!) as
+      | Cell<T>
+      | undefined;
   }
 
   // note: removing a charm doesn't clean up the charm's cells


### PR DESCRIPTION
Ben: PTAL if this feels right. I added a new `getArgument` helper to CharmManager to abstract the sourceCell stuff away (cc: Jake for that). The other call path comes via spellcaster, see the TODO (not urgent, just wanting to verify that my interpretation is correct).