### PR TITLE
fix: render now maps to lowercase DOM events

### DIFF
--- a/typescript/packages/common-html/src/render.ts
+++ b/typescript/packages/common-html/src/render.ts
@@ -248,7 +248,7 @@ const cleanEventProp = (key: string) => {
   if (!key.startsWith("on")) {
     return null;
   }
-  return key.slice(2);
+  return key.slice(2).toLowerCase();
 };
 
 /** Attach an event listener, returning a function to cancel the listener */


### PR DESCRIPTION
Since our linter now enforces `onClick` instead of `onclick`, but since that's React standard it might anyway be how code is going to be generated.

Mostly this means that all our custom events have to be lowercase as well, which for now they all are.