### PR TITLE
chore: Fix type check in deno-web-test and common-identity tests.

### DIFF
--- a/typescript/packages/common-identity/deno.json
+++ b/typescript/packages/common-identity/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@commontools/identity",
   "tasks": {
-    "test": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts test/*.test.ts"
+    "test": "deno check . && deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts test/*.test.ts"
   },
   "exports": "./src/index.ts",
   "imports": {

--- a/typescript/packages/common-identity/test/ed25519.test.ts
+++ b/typescript/packages/common-identity/test/ed25519.test.ts
@@ -24,7 +24,7 @@ interface SignerClass {
   ): Promise<SignerImpl<ID>>;
 }
 interface VerifierClass {
-  fromDid<ID extends DIDKey>(did: DID): Promise<VerifierImpl<ID>>;
+  fromDid<ID extends DIDKey>(did: ID): Promise<VerifierImpl<ID>>;
   fromRaw<ID extends DIDKey>(
     rawPrivateKey: Uint8Array,
   ): Promise<VerifierImpl<ID>>;
@@ -126,7 +126,7 @@ testBothImpls(
     Verifier: VerifierClass,
   ) => {
     // @see https://w3c-ccg.github.io/did-method-key/#test-vectors
-    const fixtures: DID[] = [
+    const fixtures: DIDKey[] = [
       "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
       "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG",
       "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",

--- a/typescript/packages/common-os-ui/src/components/code-editor/os-code-editor.ts
+++ b/typescript/packages/common-os-ui/src/components/code-editor/os-code-editor.ts
@@ -1,5 +1,5 @@
 import { css, html, PropertyValues, ReactiveElement, render } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { basicSetup, EditorView } from "codemirror";
 import { Compartment, EditorState, Extension } from "@codemirror/state";
 import { LanguageSupport } from "@codemirror/language";

--- a/typescript/packages/common-os-ui/src/components/editor/os-rich-text-editor.ts
+++ b/typescript/packages/common-os-ui/src/components/editor/os-rich-text-editor.ts
@@ -5,7 +5,7 @@ import { Node, Schema } from "prosemirror-model";
 import { history } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
 import { baseKeymap } from "prosemirror-commands";
-import { customElement } from "lit/decorators.ts";
+import { customElement } from "lit/decorators.js";
 import { base } from "../../shared/styles.ts";
 import { editorClassPlugin } from "./prosemirror/editor-class-plugin.ts";
 import { updateVerState, verPlugin } from "./prosemirror/ver-plugin.ts";

--- a/typescript/packages/common-os-ui/src/components/os-ai-box.ts
+++ b/typescript/packages/common-os-ui/src/components/os-ai-box.ts
@@ -1,6 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement } from "lit/decorators.ts";
-import { property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 @customElement("os-ai-box")

--- a/typescript/packages/common-os-ui/src/components/os-ai-icon.ts
+++ b/typescript/packages/common-os-ui/src/components/os-ai-icon.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement } from "lit/decorators.ts";
+import { customElement } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 @customElement("os-ai-icon")

--- a/typescript/packages/common-os-ui/src/components/os-avatar.ts
+++ b/typescript/packages/common-os-ui/src/components/os-avatar.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 @customElement("os-avatar")

--- a/typescript/packages/common-os-ui/src/components/os-charm-chip.ts
+++ b/typescript/packages/common-os-ui/src/components/os-charm-chip.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 @customElement("os-charm-chip")

--- a/typescript/packages/common-os-ui/src/components/os-charm-icon.ts
+++ b/typescript/packages/common-os-ui/src/components/os-charm-icon.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 /**

--- a/typescript/packages/common-os-ui/src/components/os-charm-row.ts
+++ b/typescript/packages/common-os-ui/src/components/os-charm-row.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 @customElement("os-charm-row")

--- a/typescript/packages/common-os-ui/src/components/os-chrome.ts
+++ b/typescript/packages/common-os-ui/src/components/os-chrome.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 /**

--- a/typescript/packages/common-os-ui/src/components/os-colgrid.ts
+++ b/typescript/packages/common-os-ui/src/components/os-colgrid.ts
@@ -1,5 +1,5 @@
 import { css, html } from "lit";
-import { customElement } from "lit/decorators.ts";
+import { customElement } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 import {
   breakpointLg,

--- a/typescript/packages/common-os-ui/src/components/os-common-import.ts
+++ b/typescript/packages/common-os-ui/src/components/os-common-import.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, state } from "lit/decorators.ts";
+import { customElement, state } from "lit/decorators.js";
 
 @customElement("os-common-import")
 export class OsCommonImport extends LitElement {

--- a/typescript/packages/common-os-ui/src/components/os-container.ts
+++ b/typescript/packages/common-os-ui/src/components/os-container.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement } from "lit/decorators.ts";
+import { customElement } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 @customElement("os-container")

--- a/typescript/packages/common-os-ui/src/components/os-dialog.ts
+++ b/typescript/packages/common-os-ui/src/components/os-dialog.ts
@@ -1,7 +1,7 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
-import { classMap } from "lit/directives/class-map.ts";
+import { classMap } from "lit/directives/class-map.js";
 
 @customElement("os-dialog")
 export class OsDialog extends LitElement {

--- a/typescript/packages/common-os-ui/src/components/os-fab.ts
+++ b/typescript/packages/common-os-ui/src/components/os-fab.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property, state } from "lit/decorators.ts";
+import { customElement, property, state } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 @customElement("os-fab")

--- a/typescript/packages/common-os-ui/src/components/os-floating-completions.ts
+++ b/typescript/packages/common-os-ui/src/components/os-floating-completions.ts
@@ -1,9 +1,9 @@
 import { css, html, LitElement, PropertyValues } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 import { createRect, positionMenu, Rect } from "../shared/position.ts";
 import * as completion from "./editor/completion.ts";
-import { classMap } from "lit/directives/class-map.ts";
+import { classMap } from "lit/directives/class-map.js";
 import { clamp } from "../shared/number.ts";
 
 /** Completion clicked */

--- a/typescript/packages/common-os-ui/src/components/os-icon-button-plain.ts
+++ b/typescript/packages/common-os-ui/src/components/os-icon-button-plain.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 /**

--- a/typescript/packages/common-os-ui/src/components/os-icon-button.ts
+++ b/typescript/packages/common-os-ui/src/components/os-icon-button.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 /**

--- a/typescript/packages/common-os-ui/src/components/os-icon.ts
+++ b/typescript/packages/common-os-ui/src/components/os-icon.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 @customElement("os-icon")

--- a/typescript/packages/common-os-ui/src/components/os-location.ts
+++ b/typescript/packages/common-os-ui/src/components/os-location.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 /**

--- a/typescript/packages/common-os-ui/src/components/os-navpanel.ts
+++ b/typescript/packages/common-os-ui/src/components/os-navpanel.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement } from "lit/decorators.ts";
+import { customElement } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 @customElement("os-navpanel")

--- a/typescript/packages/common-os-ui/src/components/os-navstack.ts
+++ b/typescript/packages/common-os-ui/src/components/os-navstack.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import {
   durationMd,
   easeOutCubicCss,

--- a/typescript/packages/common-os-ui/src/components/os-sidebar-group.ts
+++ b/typescript/packages/common-os-ui/src/components/os-sidebar-group.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement } from "lit/decorators.ts";
+import { customElement } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 @customElement("os-sidebar-group")

--- a/typescript/packages/common-os-ui/src/components/os-tab-bar.ts
+++ b/typescript/packages/common-os-ui/src/components/os-tab-bar.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement, property } from "lit/decorators.ts";
+import { customElement, property } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 interface TabItem {

--- a/typescript/packages/common-os-ui/src/components/os-tile.ts
+++ b/typescript/packages/common-os-ui/src/components/os-tile.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from "lit";
-import { customElement } from "lit/decorators.ts";
+import { customElement } from "lit/decorators.js";
 import { base } from "../shared/styles.ts";
 
 @customElement("os-tile")

--- a/typescript/packages/deno-web-test/config.ts
+++ b/typescript/packages/deno-web-test/config.ts
@@ -7,8 +7,6 @@ import { exists } from "@std/fs/exists";
 export type Config = {
   // Whether the test runner should run headlessly. Default: true.
   headless?: boolean;
-  // Whether devtools should be enabled. Default: false.
-  devtools?: boolean;
   // What browser to run.
   product?: "chrome" | "firefox";
   // Arguments to be passed into the browser.
@@ -25,12 +23,10 @@ export const applyDefaults = (config: object): Config => {
 };
 
 export const extractAstralConfig = (config: Config): LaunchOptions => {
-  const astralConfig = {};
-  for (const prop of ["headless", "devtools", "product", "args"]) {
-    if (prop in config) {
-      astralConfig[prop] = config[prop];
-    }
-  }
+  const astralConfig: LaunchOptions = {};
+  if ("headless" in config) astralConfig.headless = config.headless;
+  if ("product" in config) astralConfig.product = config.product;
+  if ("args" in config) astralConfig.args = config.args;
   return astralConfig;
 };
 

--- a/typescript/packages/deno-web-test/deno.json
+++ b/typescript/packages/deno-web-test/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@commontools/deno-web-test",
   "tasks": {
-    "test": "deno test --allow-env --allow-read --allow-write --allow-run --allow-net test/*.test.ts"
+    "test": "deno check . && deno test --allow-env --allow-read --allow-write --allow-run --allow-net test/*.test.ts"
   },
   "exports": {
     ".": "./mod.ts",

--- a/typescript/packages/deno-web-test/runner.ts
+++ b/typescript/packages/deno-web-test/runner.ts
@@ -1,3 +1,4 @@
+import { ConsoleEvent } from "@astral/astral";
 import { Manifest } from "./manifest.ts";
 import { summarize } from "./utils.ts";
 import { BrowserController } from "./browser.ts";
@@ -15,7 +16,10 @@ export class Runner {
     this.reporter = new Reporter();
     this.results = [];
     this.browser = new BrowserController(manifest);
-    this.browser.addEventListener("console", (e) => this.onConsole(e));
+    this.browser.addEventListener(
+      "console",
+      (e: Event) => this.onConsole(e as ConsoleEvent),
+    );
   }
 
   // Runs all tests in the browser. Return value
@@ -62,14 +66,14 @@ export class Runner {
   onConsole(e: ConsoleEvent) {
     if (this.manifest.config.pipeConsole) {
       switch (e.detail.type) {
+        case "warning":
+          console.warn(`browser: ${e.detail.text}`);
+          break;
         case "log":
-          console.log(`deno-web-test: ${e.detail.text}`);
-          break;
-        case "warn":
-          console.warn(`deno-web-test: ${e.detail.text}`);
-          break;
+        case "info":
+        case "debug":
         case "error":
-          console.error(`deno-web-test: ${e.detail.text}`);
+          console[e.detail.type](`browser: ${e.detail.text}`);
           break;
       }
     }

--- a/typescript/packages/deno-web-test/server.ts
+++ b/typescript/packages/deno-web-test/server.ts
@@ -15,7 +15,7 @@ export class TestServer {
 
   start(port: number) {
     this.server = Deno.serve(
-      { port, hostname: "127.0.0.1", onListen({ path }) {} },
+      { port, hostname: "127.0.0.1", onListen() {} },
       (req: Request) =>
         serveDir(req, {
           fsRoot: this.manifest.serverDir,

--- a/typescript/packages/deno-web-test/test/project-with-config/mod.ts
+++ b/typescript/packages/deno-web-test/test/project-with-config/mod.ts
@@ -1,7 +1,7 @@
-export const createEd25519Key = async (): CryptoKey => {
+export const createEd25519Key = (): Promise<CryptoKey> => {
   const dummyKey = new Uint8Array(32);
 
-  return await globalThis.crypto.subtle.importKey(
+  return globalThis.crypto.subtle.importKey(
     "raw",
     dummyKey,
     "ed25519",

--- a/typescript/packages/deno.lock
+++ b/typescript/packages/deno.lock
@@ -7229,12 +7229,6 @@
       "npm:zod@^3.24.1"
     ],
     "members": {
-      "common-cli": {
-        "dependencies": [
-          "jsr:@cmd-johnson/oauth2-client@2",
-          "jsr:@std/dotenv@~0.225.3"
-        ]
-      },
       "common-identity": {
         "dependencies": [
           "npm:@scure/bip39@^1.5.4"


### PR DESCRIPTION
There were a few files not being typechecked in deno-web-test. Fixed those issues, and added the check to the test for identity and DWT.

For common-os-ui, I replaced `lit`'s export to `lit/decorators.js` (as it exposes a compiled JS export, not typescript) -- still has issues with standard decorators, but it doesn't look like we're using this package currently.