### PR TITLE
Revive multi user capability in toolshed

### DIFF
--- a/typescript/packages/common-runner/src/storage/remote.ts
+++ b/typescript/packages/common-runner/src/storage/remote.ts
@@ -203,7 +203,6 @@ export class RemoteStorageProvider implements StorageProvider {
       local.set(of, fact);
       facts.push(fact);
     }
-    
 
     const result = await memory.transact({ changes: Changes.from(facts) });
 
@@ -263,7 +262,9 @@ export class RemoteStorageProvider implements StorageProvider {
       connection.removeEventListener("error", this);
     }
 
-    const socket = new WebSocket(this.address.href);
+    const webSocketUrl = new URL(this.address.href);
+    webSocketUrl.searchParams.set("space", this.workspace);
+    const socket = new WebSocket(webSocketUrl.href);
     this.connection = socket;
     socket.addEventListener("message", this);
     socket.addEventListener("open", this);

--- a/typescript/packages/toolshed/deploy/toolshed.nginx.conf
+++ b/typescript/packages/toolshed/deploy/toolshed.nginx.conf
@@ -14,16 +14,14 @@ map $backend_choice $served_from {
     "127.0.0.1:8005" "8005";
 }
 
-# Use the client's IP as the sticky value.
-map $remote_addr $sticky_value {
-    default $remote_addr;
+# Use the space query parameter as the sticky value
+map $arg_space $sticky_value {
+    ""      $remote_addr;  # Fall back to client IP if space parameter is not present
+    default $arg_space;    # Use the space parameter value
 }
 
-# Deterministically assign a backend server based on the client's IP.
+# Deterministically assign a backend server based on the sticky value.
 split_clients "$sticky_value" $backend_choice {
-    # NOTE: 8000 is running, but reserved for "internal" use, where our codebase
-    # makes requests to localhost:8000.
-    # 20%   127.0.0.1:8000;
     20%   127.0.0.1:8001;
     20%   127.0.0.1:8002;
     20%   127.0.0.1:8003;
@@ -48,9 +46,14 @@ server {
         proxy_set_header Host $host;
         proxy_set_header Tailscale-User-Login $http_tailscale_user_login;
         proxy_pass http://$backend_choice;
+        # 5min timeout
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
     }
 
     location /api/storage/memory {
+        add_header X-Served-From $served_from always;
         proxy_pass http://$backend_choice;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
@@ -69,7 +72,6 @@ server {
     location /_nginx {
         # Enable the stub_status module.
         stub_status;
-
         # Optionally, restrict access to this endpoint.
         # For example, only allow local connections:
         # Allow all devices on the Tailscale network.


### PR DESCRIPTION
Yesterday I made some breaking changes that prevent multi-user capabilities on our production deployment of toolshed.

This PR introduces a new `?space=foo` query parameter to the client connection to the websocket, which nginx then uses as the hash to determine and pin all requests for that space to a given backend toolshed process.

This should unblock multi-user collaboration in a single space, by ensuring that all users will receive broadcast websocket events to a given space.

--

This relies on the fact that right now whenever you navigate to a space, we open a websocket for that given space. If/when we move to a allowing a websocket connection to make requests across different spaces, we'll need to re-evaluate how this works.