### PR TITLE
chore: Fix react-dom error message from improper inclusion.

### DIFF
--- a/jumble/deno.json
+++ b/jumble/deno.json
@@ -30,7 +30,6 @@
     "emoji-picker-react": "npm:emoji-picker-react@^4.12.0",
     "json5": "npm:json5@^2.2.3",
     "react-dom": "npm:react-dom@^18.3.1",
-    "react-dom/client": "npm:react-dom@^18.3.1",
     "react-dropzone": "npm:react-dropzone@^14.3.5",
     "react-icons": "npm:react-icons@^5.4.0",
     "react-markdown": "npm:react-markdown@^9.0.3",

--- a/jumble/src/main.tsx
+++ b/jumble/src/main.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from "react";
-import { createRoot } from "react-dom";
+import { createRoot } from "react-dom/client";
 import {
   BrowserRouter as Router,
   Navigate,


### PR DESCRIPTION
Fixes an error `Warning: You are importing createRoot from "react-dom" which is not supported. You should instead import it from "react-dom/client".`