### PR TITLE
fix: handle streams in charm input by using optional chaining for get()

### DIFF
--- a/jumble/src/iframe-ctx.ts
+++ b/jumble/src/iframe-ctx.ts
@@ -112,7 +112,8 @@ export const setupIframe = () =>
 
       const action: Action = (log: ReactivityLog) => {
         const data = isCell(context)
-          ? context.withLog(log).key(key).get()
+          // get?.() because streams don't have a get, set undefined for those
+          ? context.withLog(log).key(key).get?.()
           : context?.[key];
         const serialized = serializeProxyObjects(data);
         if (serialized !== previousValue) {


### PR DESCRIPTION
Streams don't have a get() method, so we need to use optional chaining to avoid errors when a stream is used in a charm input.