### PR TITLE
inmemory -> volatile storage provider

### DIFF
--- a/runner/src/storage.ts
+++ b/runner/src/storage.ts
@@ -248,8 +248,8 @@ class StorageImpl implements Storage {
     if (!provider) {
       // Default to "remote", but let either custom URL (used in tests) or
       // environment variable override this.
-      const type = this.remoteStorageUrl?.protocol === "memory:"
-        ? "memory"
+      const type = this.remoteStorageUrl?.protocol === "volatile:"
+        ? "volatile"
         : ((import.meta as any).env?.VITE_STORAGE_TYPE ?? "remote");
 
       if (type === "remote") {

--- a/runner/src/storage.ts
+++ b/runner/src/storage.ts
@@ -11,7 +11,7 @@ import { isStatic, markAsStatic } from "@commontools/builder";
 import { StorageProvider, StorageValue } from "./storage/base.ts";
 import { RemoteStorageProvider } from "./storage/remote.ts";
 import { debug } from "@commontools/html"; // FIXME(ja): can we move debug to somewhere else?
-import { InMemoryStorageProvider } from "./storage/memory.ts";
+import { VolatileStorageProvider } from "./storage/volatile.ts";
 import { Signer } from "@commontools/identity";
 import { isBrowser } from "@commontools/utils/env";
 
@@ -262,8 +262,8 @@ class StorageImpl implements Storage {
           space: space as `did:${string}:${string}`,
           as: this.signer,
         });
-      } else if (type === "memory") {
-        provider = new InMemoryStorageProvider(space);
+      } else if (type === "volatile") {
+        provider = new VolatileStorageProvider(space);
       } else {
         throw new Error(`Unknown storage type: ${type}`);
       }

--- a/runner/src/storage/volatile.ts
+++ b/runner/src/storage/volatile.ts
@@ -3,9 +3,9 @@ import { log } from "../storage.ts";
 import { BaseStorageProvider, type StorageValue } from "./base.ts";
 
 /**
- * In-memory storage provider. Just for testing.
+ * Volatile (in-memory) storage provider. Just for testing.
  *
- * It doesn't make much sense,  since it's just a copy of the in memory docs.
+ * It doesn't make much sense, since it's just a copy of the volatile docs.
  * But for testing we can create multiple instances that share the memory.
  */
 const spaceStorageMap = new Map<string, Map<string, StorageValue>>();
@@ -32,7 +32,7 @@ function getOrCreateSpaceSubscribers(
   return spaceSubscribersMap.get(spaceName)!;
 }
 
-export class InMemoryStorageProvider extends BaseStorageProvider {
+export class VolatileStorageProvider extends BaseStorageProvider {
   private handleStorageUpdateFn: (key: string, value: any) => void;
   private lastValues = new Map<string, string | undefined>();
   private spaceName: string;
@@ -62,7 +62,7 @@ export class InMemoryStorageProvider extends BaseStorageProvider {
       const key = JSON.stringify(entityId);
       const valueString = JSON.stringify(value);
       if (this.lastValues.get(key) !== valueString) {
-        log(() => ["send in memory", this.spaceName, key, valueString]);
+        log(() => ["send volatile", this.spaceName, key, valueString]);
         this.lastValues.set(key, valueString);
         spaceStorage.set(key, value);
         spaceSubscribers.forEach((listener) => listener(key, value));
@@ -79,7 +79,7 @@ export class InMemoryStorageProvider extends BaseStorageProvider {
     const spaceStorage = getOrCreateSpaceStorage(this.spaceName);
     const key = JSON.stringify(entityId);
     log(
-      () => ["sync in memory", this.spaceName, key, this.lastValues.get(key)],
+      () => ["sync volatile", this.spaceName, key, this.lastValues.get(key)],
     );
     if (spaceStorage.has(key)) {
       this.lastValues.set(key, JSON.stringify(spaceStorage.get(key)!));
@@ -91,7 +91,7 @@ export class InMemoryStorageProvider extends BaseStorageProvider {
 
   get<T>(entityId: EntityId): StorageValue<T> | undefined {
     const key = JSON.stringify(entityId);
-    log(() => ["get in memory", this.spaceName, key, this.lastValues.get(key)]);
+    log(() => ["get volatile", this.spaceName, key, this.lastValues.get(key)]);
     return this.lastValues.has(key)
       ? (JSON.parse(this.lastValues.get(key)!) as StorageValue)
       : undefined;

--- a/runner/test/storage.test.ts
+++ b/runner/test/storage.test.ts
@@ -6,7 +6,7 @@ import { CellLink, createRef, DocImpl, getDoc } from "@commontools/runner";
 import { VolatileStorageProvider } from "../src/storage/volatile.ts";
 import { Identity } from "@commontools/identity";
 
-storage.setRemoteStorage(new URL("memory://"));
+storage.setRemoteStorage(new URL("volatile://"));
 storage.setSigner(await Identity.fromPassphrase("test operator"));
 
 describe("Storage", () => {

--- a/runner/test/storage.test.ts
+++ b/runner/test/storage.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { storage } from "../src/storage.ts";
 import { StorageProvider } from "../src/storage/base.ts";
-import { InMemoryStorageProvider } from "../src/storage/memory.ts";
 import { CellLink, createRef, DocImpl, getDoc } from "@commontools/runner";
+import { VolatileStorageProvider } from "../src/storage/volatile.ts";
 import { Identity } from "@commontools/identity";
 
 storage.setRemoteStorage(new URL("memory://"));
@@ -15,7 +15,7 @@ describe("Storage", () => {
   let n = 0;
 
   beforeEach(() => {
-    storage2 = new InMemoryStorageProvider("test");
+    storage2 = new VolatileStorageProvider("test");
     testDoc = getDoc<string>(
       undefined as unknown as string,
       `storage test cell ${n++}`,


### PR DESCRIPTION
rename to simplify 'common memory/remote' vs 'in-memory/memory'