### PR TITLE
charm cleanups:

### DIFF
--- a/charm/src/charm.ts
+++ b/charm/src/charm.ts
@@ -155,7 +155,7 @@ export class CharmManager {
 
   // NOTE(ja): making a private method, as runPersistent ensures the charm
   // and recipe are persisted.. cleanup?
-  async _add(newCharms: Cell<Charm>[]) {
+  private async add(newCharms: Cell<Charm>[]) {
     await storage.syncCell(this.charmsDoc);
     await idle();
 
@@ -297,7 +297,7 @@ export class CharmManager {
 
     const newCharm = resultDoc.asCell([], undefined, charmSchema);
 
-    await this._add([newCharm]);
+    await this.add([newCharm]);
     await this.syncRecipe(newCharm);
 
     return newCharm;

--- a/cli/charm_demo.ts
+++ b/cli/charm_demo.ts
@@ -60,7 +60,7 @@ async function main() {
   );
 
   // let's add the cell to the charmManager
-  await charmManager.add([cell]);
+  // await charmManager.add([cell]); // Note(ja): commenting out as I'm hiding the add() method
   log(charmManager, "charmmanager after adding cell");
 }
 

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -69,8 +69,6 @@ async function main() {
       const recipeSrc = await Deno.readTextFile(recipeFile);
       const recipe = await compileRecipe(recipeSrc, "recipe", []);
       const charm = await manager.runPersistent(recipe, undefined, cause);
-      await manager.syncRecipe(charm);
-      manager.add([charm]);
       const charmWithSchema = (await manager.get(charm))!;
       charmWithSchema.sink((value) => {
         console.log("running charm:", getEntityId(charm), value);

--- a/jumble/src/components/CharmRunner.tsx
+++ b/jumble/src/components/CharmRunner.tsx
@@ -51,8 +51,6 @@ function useCharmLoader({
       const charm = await charmManager.runPersistent(factory, argument);
       if (currentMountKey !== mountingKey.current) return;
 
-      charmManager.add([charm]);
-
       if (currentMountKey !== mountingKey.current) return;
 
       onCharmReadyCallback(charm);

--- a/jumble/src/components/commands.ts
+++ b/jumble/src/components/commands.ts
@@ -131,12 +131,7 @@ export const castSpellAsCharm = async (
     if (!recipe) return;
 
     console.log("Casting...");
-    const charm: Cell<Charm> = await charmManager.runPersistent(
-      recipe,
-      argument,
-    );
-    charmManager.add([charm]);
-    return charm.entityId;
+    return charmManager.runPersistent(recipe, argument);
   }
   console.log("Failed to cast");
   return null;
@@ -414,7 +409,6 @@ async function handleImportJSON(deps: CommandContext) {
     if (!title) return;
 
     const newCharm = await castNewRecipe(deps.charmManager, data, title);
-    if (!newCharm) throw new Error("Failed to create new charm");
 
     const id = charmId(newCharm);
     if (!id || !deps.focusedReplicaId) {
@@ -438,6 +432,9 @@ async function handleImportJSON(deps: CommandContext) {
 async function handleLoadRecipe(deps: CommandContext) {
   deps.setLoading(true);
   try {
+    if (!deps.focusedReplicaId) {
+      throw new Error("Missing focused replica name");
+    }
     const input = document.createElement("input");
     input.type = "file";
     input.accept = ".tsx";
@@ -457,21 +454,13 @@ async function handleLoadRecipe(deps: CommandContext) {
       "imported",
       {},
     );
-    if (!newCharm) {
-      throw new Error("Failed to cast charm");
-    }
     const id = charmId(newCharm);
-    if (!id || !deps.focusedReplicaId) {
-      throw new Error("Missing charm ID or replica name");
-    }
-    if (id) {
-      deps.navigate(
-        createPath("charmShow", {
-          charmId: id,
-          replicaName: deps.focusedReplicaId,
-        }),
-      );
-    }
+    deps.navigate(
+      createPath("charmShow", {
+        charmId: id,
+        replicaName: deps.focusedReplicaId,
+      }),
+    );
   } finally {
     deps.setLoading(false);
     deps.setOpen(false);

--- a/jumble/src/hooks/use-charm.ts
+++ b/jumble/src/hooks/use-charm.ts
@@ -18,7 +18,6 @@ const loadCharmData = async (
   let iframeRecipe = null;
 
   if (charm) {
-    await charmManager.syncRecipe(charm);
     const ir = getIframeRecipe(charm);
     iframeRecipe = ir?.iframe ?? null;
   }

--- a/jumble/src/utils/charms.ts
+++ b/jumble/src/utils/charms.ts
@@ -1,7 +1,8 @@
 import { type Charm } from "@commontools/charm";
 import { getEntityId } from "@commontools/runner";
 
-export function charmId(charm: Charm): string | undefined {
+export function charmId(charm: Charm): string {
   const id = getEntityId(charm);
-  return id ? id["/"] : undefined;
+  if (!id) throw new Error("No charm ID found");
+  return id["/"];
 }


### PR DESCRIPTION
- runPersist should handle persisting (sync recipe / adding to charm list)
- by throwing instead of log/return undefined - we simplify types / checking