### PR TITLE
Refactor normalize arrays

### DIFF
--- a/builder/src/index.ts
+++ b/builder/src/index.ts
@@ -28,6 +28,7 @@ export {
 export {
   type Alias,
   type Frame,
+  ID,
   isAlias,
   isModule,
   isOpaqueRef,

--- a/builder/src/recipe.ts
+++ b/builder/src/recipe.ts
@@ -344,7 +344,13 @@ function factoryFromRecipe<T, R>(
 const frames: Frame[] = [];
 
 export function pushFrame(frame?: Frame): Frame {
-  if (!frame) frame = { parent: getTopFrame(), opaqueRefs: new Set() };
+  if (!frame) {
+    frame = {
+      parent: getTopFrame(),
+      opaqueRefs: new Set(),
+      generatedIdCounter: 0,
+    };
+  }
   frames.push(frame);
   return frame;
 }
@@ -356,6 +362,7 @@ export function pushFrameFromCause(
   const frame = {
     parent: getTopFrame(),
     cause,
+    generatedIdCounter: 0,
     opaqueRefs: new Set(),
     ...(unsafe_binding ? { unsafe_binding } : {}),
   };

--- a/builder/src/types.ts
+++ b/builder/src/types.ts
@@ -1,3 +1,5 @@
+export const ID: symbol = Symbol("ID, unique to the context");
+
 // Should be Symbol("UI") or so, but this makes repeat() use these when
 // iterating over recipes.
 export const TYPE = "$TYPE";

--- a/builder/src/types.ts
+++ b/builder/src/types.ts
@@ -239,6 +239,7 @@ export type UnsafeBinding = {
 export type Frame = {
   parent?: Frame;
   cause?: any;
+  generatedIdCounter: number;
   opaqueRefs: Set<OpaqueRef<any>>;
   unsafe_binding?: UnsafeBinding;
 };

--- a/jumble/vite.config.ts
+++ b/jumble/vite.config.ts
@@ -18,7 +18,8 @@ export default defineConfig({
     ],
     proxy: {
       "/api/integrations": {
-        target: Deno.env.get("TOOLSHED_API_URL") ?? "http://localhost:8000/",
+        target: Deno.env.get("INTEGRATIONS_URL") ??
+          Deno.env.get("TOOLSHED_API_URL") ?? "http://localhost:8000/",
         changeOrigin: true,
       },
       "/api/ai/spell/": {

--- a/recipes/gmail.tsx
+++ b/recipes/gmail.tsx
@@ -3,6 +3,7 @@ import {
   cell,
   derive,
   handler,
+  ID,
   JSONSchema,
   NAME,
   recipe,
@@ -69,7 +70,7 @@ const AuthSchema = {
 } as const satisfies JSONSchema;
 type Auth = Schema<typeof AuthSchema>;
 
-const Recipe = {
+const GmailImporterInputs = {
   type: "object",
   properties: {
     settings: {
@@ -129,56 +130,87 @@ const ResultSchema = {
   },
 } as const satisfies JSONSchema;
 
-const updateLimit = handler<{ detail: { value: string } }, { limit: number }>(
+const updateLimit = handler(
+  {
+    type: "object",
+    properties: {
+      detail: {
+        type: "object",
+        properties: { value: { type: "string" } },
+        required: ["value"],
+      },
+    },
+  },
+  {
+    type: "object",
+    properties: { limit: { type: "number", asCell: true } },
+    required: ["limit"],
+  },
   ({ detail }, state) => {
-    state.limit = parseInt(detail?.value ?? "10") || 0;
+    state.limit.set(parseInt(detail?.value ?? "10") || 0);
   },
 );
 
-const googleUpdater = handler<
-  NonNullable<unknown>,
-  { emails: Email[]; auth: Auth; settings: { labels: string; limit: number } }
->((_event, state) => {
-  console.log("googleUpdater!");
+const googleUpdater = handler(
+  {},
+  {
+    type: "object",
+    properties: {
+      emails: { type: "array", items: EmailSchema, default: [], asCell: true },
+      auth: AuthSchema,
+      settings: GmailImporterInputs.properties.settings,
+    },
+    required: ["emails", "auth", "settings"],
+  },
+  (_event, state) => {
+    console.log("googleUpdater!");
 
-  if (!state.auth.token) {
-    console.log("no token");
-    return;
-  }
-  if (state.auth.expiresAt && state.auth.expiresAt < Date.now()) {
-    console.log("token expired at ", state.auth.expiresAt);
-    return;
-  }
+    if (!state.auth.token) {
+      debugger;
+      console.log("no token");
+      return;
+    }
+    if (state.auth.expiresAt && state.auth.expiresAt < Date.now()) {
+      console.log("token expired at ", state.auth.expiresAt);
+      return;
+    }
 
-  // Get the set of existing email IDs for efficient lookup
-  const existingEmailIds = new Set(
-    (state.emails || []).map((email) => email.id),
-  );
+    // Get the set of existing email IDs for efficient lookup
+    const existingEmailIds = new Set(
+      (state.emails.get()).map((email) => email.id),
+    );
 
-  console.log("existing email ids", existingEmailIds);
+    console.log("existing email ids", existingEmailIds);
 
-  const labels = state.settings.labels
-    .split(",")
-    .map((label) => label.trim())
-    .filter(Boolean);
+    const labels = state.settings.labels
+      .split(",")
+      .map((label) => label.trim())
+      .filter(Boolean);
 
-  console.log("labels", labels);
+    console.log("labels", labels);
 
-  fetchEmail(state.auth.token, state.settings.limit, labels, existingEmailIds)
-    .then((emails) => {
-      // Filter out any duplicates by ID
-      const newEmails = emails.messages.filter((email) =>
-        !existingEmailIds.has(email.id)
-      );
+    fetchEmail(state.auth.token, state.settings.limit, labels, existingEmailIds)
+      .then((emails) => {
+        // Filter out any duplicates by ID
+        const newEmails = emails.messages.filter((email) =>
+          !existingEmailIds.has(email.id)
+        );
 
-      if (newEmails.length > 0) {
-        console.log(`Adding ${newEmails.length} new emails`);
-        state.emails.push(...newEmails);
-      } else {
-        console.log("No new emails found");
-      }
-    });
-});
+        if (newEmails.length > 0) {
+          console.log(`Adding ${newEmails.length} new emails`);
+
+          // Use email ID to generate our ID
+          newEmails.forEach((email) => {
+            email[ID] = email.id;
+          });
+
+          state.emails.push(...newEmails);
+        } else {
+          console.log("No new emails found");
+        }
+      });
+  },
+);
 
 // Helper function to decode base64 encoded email parts
 function decodeBase64(data: string) {
@@ -292,7 +324,7 @@ const updateLabels = handler<{ detail: { value: string } }, { labels: string }>(
   },
 );
 
-export default recipe(Recipe, ResultSchema, ({ settings }) => {
+export default recipe(GmailImporterInputs, ResultSchema, ({ settings }) => {
   const auth = cell<Auth>({
     token: "",
     tokenType: "",

--- a/recipes/gmail.tsx
+++ b/recipes/gmail.tsx
@@ -166,18 +166,17 @@ const googleUpdater = handler(
     console.log("googleUpdater!");
 
     if (!state.auth.token) {
-      debugger;
-      console.log("no token");
+      console.warn("no token");
       return;
     }
     if (state.auth.expiresAt && state.auth.expiresAt < Date.now()) {
-      console.log("token expired at ", state.auth.expiresAt);
+      console.warn("token expired at ", state.auth.expiresAt);
       return;
     }
 
     // Get the set of existing email IDs for efficient lookup
     const existingEmailIds = new Set(
-      (state.emails.get()).map((email) => email.id),
+      state.emails.get().map((email) => email.id),
     );
 
     console.log("existing email ids", existingEmailIds);

--- a/runner/src/builtins/fetch-data.ts
+++ b/runner/src/builtins/fetch-data.ts
@@ -1,6 +1,5 @@
 import { type DocImpl, getDoc } from "../doc.ts";
 import { type ReactivityLog } from "../scheduler.ts";
-import { normalizeToDocLinks } from "../utils.ts";
 import { type Action, idle } from "../scheduler.ts";
 import { refer } from "merkle-reference";
 

--- a/runner/src/builtins/fetch-data.ts
+++ b/runner/src/builtins/fetch-data.ts
@@ -103,11 +103,6 @@ export function fetchData(
       .then(async (data) => {
         if (thisRun !== currentRun) return;
 
-        normalizeToDocLinks(parentDoc, data, undefined, log, {
-          fetchData: { url },
-          cause,
-        });
-
         await idle();
 
         pending.setAtPath([], false, log);

--- a/runner/src/builtins/stream-data.ts
+++ b/runner/src/builtins/stream-data.ts
@@ -136,11 +136,6 @@ export function streamData(
               data: JSON.parse(data),
             };
 
-            normalizeToDocLinks(parentDoc, parsedData, undefined, log, {
-              streamData: { url },
-              cause,
-            });
-
             await idle();
 
             result.setAtPath([], parsedData, log);

--- a/runner/src/builtins/stream-data.ts
+++ b/runner/src/builtins/stream-data.ts
@@ -1,5 +1,4 @@
 import { type DocImpl, getDoc } from "../doc.ts";
-import { normalizeToDocLinks } from "../utils.ts";
 import { type Action, idle } from "../scheduler.ts";
 import { type ReactivityLog } from "../scheduler.ts";
 

--- a/runner/src/cell.ts
+++ b/runner/src/cell.ts
@@ -372,7 +372,7 @@ function createRegularCell<T>(
           !isCell(value) && !isDocLink(value) && !isDoc(value) &&
           !Array.isArray(value) && typeof value === "object" &&
           value !== null &&
-          !value[ID] && getTopFrame()
+          value[ID] === undefined && getTopFrame()
         ) {
           return {
             [ID]: getTopFrame()!.generatedIdCounter++,

--- a/runner/src/query-result-proxy.ts
+++ b/runner/src/query-result-proxy.ts
@@ -152,19 +152,19 @@ export function createQueryResultProxy<T>(
                 context: getTopFrame()?.cause ?? "unknown",
               };
 
-              diffAndUpdate(
-                { cell: valueCell, path: valuePath },
-                result,
-                log,
-                cause,
-              );
-
               const resultCell = getDoc<any[]>(
                 undefined as unknown as any[],
                 cause,
                 valueCell.space,
               );
               resultCell.send(result);
+
+              diffAndUpdate(
+                { cell: resultCell, path: [] },
+                result,
+                log,
+                cause,
+              );
 
               result = resultCell.getAsQueryResult([], log);
             }

--- a/runner/src/runner.ts
+++ b/runner/src/runner.ts
@@ -29,9 +29,9 @@ import {
   extractDefaultValues,
   findAllAliasedDocs,
   followAliases,
+  maybeUnwrapProxy,
   mergeObjects,
   sendValueToBinding,
-  staticDataToNestedDocs,
   unsafe_noteParentOnRecipes,
   unwrapOneLevelAndBindtoDoc,
 } from "./utils.ts";
@@ -203,12 +203,7 @@ export function run<T, R = any>(
   };
 
   // Ensure static data is converted to doc link, e.g. for arrays
-  argument = staticDataToNestedDocs(
-    processCell,
-    argument,
-    undefined,
-    resultCell,
-  );
+  argument = deepCopy(maybeUnwrapProxy(argument));
 
   // TODO(seefeld): Move up, only do this if it's not from the sourceCell
   if (defaults) argument = mergeObjects(argument, deepCopy(defaults));

--- a/runner/src/scheduler.ts
+++ b/runner/src/scheduler.ts
@@ -175,7 +175,11 @@ async function execute() {
   for (const fn of order) {
     loopCounter.set(fn, (loopCounter.get(fn) || 0) + 1);
     if (loopCounter.get(fn)! > MAX_ITERATIONS_PER_RUN) {
-      handleError(new Error("Too many iterations"));
+      handleError(
+        new Error(
+          `Too many iterations: ${loopCounter.get(fn)} ${fn.name ?? ""}`,
+        ),
+      );
     } else await run(fn);
   }
 

--- a/runner/src/utils.ts
+++ b/runner/src/utils.ts
@@ -92,8 +92,7 @@ export function sendValueToBinding(
 ) {
   if (isAlias(binding)) {
     const ref = followAliases(binding, doc, log);
-    const changes = normalizeAndDiff(ref, value, log, { doc, binding });
-    applyChangeSet(changes, log);
+    diffAndUpdate(ref, value, log, { doc, binding });
   } else if (Array.isArray(binding)) {
     if (Array.isArray(value)) {
       for (let i = 0; i < Math.min(binding.length, value.length); i++) {
@@ -460,7 +459,7 @@ export function followAliases(
  * @param newValue - The new value to traverse.
  * @param log - The log to write to.
  * @param context - The context of the change.
- * @returns An array of changes that should be written.
+ * @returns Whether any changes were made.
  */
 export function diffAndUpdate(
   current: DocLink,

--- a/runner/test/cell.test.ts
+++ b/runner/test/cell.test.ts
@@ -204,21 +204,13 @@ describe("createProxy", () => {
     const proxy = c.getAsQueryResult([], log);
     proxy[0] = 1;
     proxy.push(2);
-    expect(c.get()).toHaveLength(2);
-    expect(isDocLink(c.get()[0])).toBeTruthy();
-    expect(c.get()[0].cell.get()).toBe(1);
-    expect(isDocLink(c.get()[1])).toBeTruthy();
-    expect(c.get()[1].cell.get()).toBe(2);
+    expect(c.get()).toEqual([1, 2]);
+    // only read array, but not the elements
     expect(log.reads.map((r) => r.path)).toEqual([[]]);
+    // writes to path ["0", "1"]
     expect(log.writes.filter((w) => w.cell === c).map((w) => w.path)).toEqual([[
       "0",
     ], ["1"]]);
-    expect(
-      log.writes.filter((w) => w.cell === c.get()[0].cell).map((w) => w.path),
-    ).toEqual([[]]);
-    expect(
-      log.writes.filter((w) => w.cell === c.get()[1].cell).map((w) => w.path),
-    ).toEqual([[]]);
   });
 
   it("should support pop() and only read the popped element", () => {

--- a/runner/test/cell.test.ts
+++ b/runner/test/cell.test.ts
@@ -1235,9 +1235,10 @@ describe("asCell with schema", () => {
       "should push values that are already cells reusing the reference",
       getSpace("test"),
     );
+    const dCell = d.asCell();
 
     arrayCell.push(d);
-    arrayCell.push(d.asCell());
+    arrayCell.push(dCell);
     arrayCell.push(d.getAsQueryResult());
     arrayCell.push({ cell: d, path: [] });
 

--- a/runner/test/cell.test.ts
+++ b/runner/test/cell.test.ts
@@ -382,10 +382,10 @@ describe("createProxy", () => {
     ]);
   });
 
-  it("should allow changig array lengts by writing length", () => {
+  it("should allow changing array lengths by writing length", () => {
     const c = getDoc(
       [1, 2, 3],
-      "should allow changig array lengts by writing length",
+      "should allow changing array lengths by writing length",
       getSpace("test"),
     );
     const log: ReactivityLog = { reads: [], writes: [] };
@@ -407,10 +407,10 @@ describe("createProxy", () => {
     ]);
   });
 
-  it("should allow changig array by splicing", () => {
+  it("should allow changing array by splicing", () => {
     const c = getDoc(
       [1, 2, 3],
-      "should allow changig array by splicing",
+      "should allow changing array by splicing",
       getSpace("test"),
     );
     const log: ReactivityLog = { reads: [], writes: [] };

--- a/runner/test/scheduler.test.ts
+++ b/runner/test/scheduler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { assertSpyCalls, spy } from "@std/testing/mock";
+import { assertSpyCall, assertSpyCalls, spy } from "@std/testing/mock";
 import { getDoc } from "../src/doc.ts";
 import { type ReactivityLog } from "../src/scheduler.ts";
 import {
@@ -271,8 +271,8 @@ describe("scheduler", () => {
 
     await idle();
 
-    expect(maxRuns).toBeGreaterThan(0);
-    assertSpyCalls(stopped, 1);
+    expect(maxRuns).toBeGreaterThan(10);
+    assertSpyCall(stopped, 0, undefined);
   });
 
   it("should not loop on r/w changes on its own output", async () => {

--- a/runner/test/scheduler.test.ts
+++ b/runner/test/scheduler.test.ts
@@ -16,6 +16,7 @@ import {
   unschedule,
 } from "../src/scheduler.ts";
 import { getSpace } from "../src/space.ts";
+
 describe("scheduler", () => {
   it("should run actions when cells change", async () => {
     let runCount = 0;


### PR DESCRIPTION
Removed `normalizeToDocLinks` which was nasty
- No longer turning arrays into docs by default
- When passing `[ID]` (a symbol) on an object, it will convert those into cells using the passed ID as part of the cause. The rest of the cause comes from the running frame, i.e. the charm if it's a derived function or the event if it's a handler
- Cell.push() will still create individual cells per item
- Diffing changes more granularly

Also
- updated Gmail recipe accordingly to use cells and deliberate IDs
- add a new INTEGRATIONS_URL in vite config
  
Co-authored with @ellyxir and @ubik2 