### PR TITLE
adding a little cli to quickly convert space names to dids

### DIFF
--- a/cli/deno.json
+++ b/cli/deno.json
@@ -4,7 +4,8 @@
     "google-importer": "deno run --allow-read --allow-env --allow-net google-importer.ts",
     "memorydemo": "deno run --allow-read --allow-env --allow-net memory_demo.ts",
     "test": "deno test",
-    "charmdemo": "deno run --allow-read --allow-env --allow-net charm_demo.ts"
+    "charmdemo": "deno run --allow-read --allow-env --allow-net charm_demo.ts",
+    "name2did": "deno run -A name2did.ts"
   },
   "imports": {
     "open": "https://deno.land/x/open@v0.0.6/index.ts"

--- a/cli/name2did.ts
+++ b/cli/name2did.ts
@@ -1,0 +1,21 @@
+import { Identity } from "@commontools/identity";
+
+const OPERATOR_PASS = Deno.env.get("OPERATOR_PASS") ?? "implicit trust";
+
+export const name2did = async (name: string) => {
+  const account = await Identity.fromPassphrase(OPERATOR_PASS);
+  const space = await account.derive(name);
+  console.log(" NAME:", name);
+  console.log("SPACE:", space.did());
+};
+
+const args = Deno.args;
+
+if (args.length < 1) {
+  console.error("Error: Please provide a name argument.");
+  console.log("Usage: deno task name2did <name>");
+  Deno.exit(1);
+}
+
+await name2did(args[0]);
+Deno.exit(0);


### PR DESCRIPTION
To run this, if you are in `./labs/cli`, you can run `deno task name2did foo`

```
deno task name2did foo
 NAME: foo
SPACE: did:key:z6MkrvSneCFqY1Fv6yBXtrZSRX7XcasyoTttPffFzRzaRnRv
```

If you need to modify the passphrase used to derive the space did, you can override it like so:

```
OPERATOR_PASS='yoyoyo' deno task name2did foo

 NAME: foo
SPACE: did:key:z6Mkg7fKkueYuduXcV5DNUiUyg812syaDYE2zkv4eo7qpJn
```