### PR TITLE
chore: set all Identity internals from TS private to JS private

### DIFF
--- a/identity/src/ed25519/index.ts
+++ b/identity/src/ed25519/index.ts
@@ -24,25 +24,25 @@ import { wordlist } from "@scure/bip39/wordlists/english";
 //
 // [0]: https://caniuse.com/mdn-api_subtlecrypto_sign_ed25519
 export class Ed25519Signer<ID extends DIDKey> implements Signer<ID> {
-  private impl: NativeEd25519Signer<ID> | NobleEd25519Signer<ID>;
+  #impl: NativeEd25519Signer<ID> | NobleEd25519Signer<ID>;
   constructor(impl: NativeEd25519Signer<ID> | NobleEd25519Signer<ID>) {
-    this.impl = impl;
+    this.#impl = impl;
   }
 
   get verifier(): Verifier<ID> {
-    return this.impl.verifier;
+    return this.#impl.verifier;
   }
 
   serialize(): KeyPairRaw {
-    return this.impl.serialize();
+    return this.#impl.serialize();
   }
 
   did() {
-    return this.impl.did();
+    return this.#impl.did();
   }
 
   sign<T>(payload: AsBytes<T>) {
-    return this.impl.sign(payload);
+    return this.#impl.sign(payload);
   }
 
   static async fromRaw<ID extends DIDKey>(
@@ -93,17 +93,17 @@ export class Ed25519Signer<ID extends DIDKey> implements Signer<ID> {
 }
 
 export class Ed25519Verifier<ID extends DIDKey> implements Verifier<ID> {
-  private impl: NativeEd25519Verifier<ID> | NobleEd25519Verifier<ID>;
+  #impl: NativeEd25519Verifier<ID> | NobleEd25519Verifier<ID>;
   constructor(impl: NativeEd25519Verifier<ID> | NobleEd25519Verifier<ID>) {
-    this.impl = impl;
+    this.#impl = impl;
   }
 
   verify(auth: { payload: Uint8Array; signature: Uint8Array }) {
-    return this.impl.verify(auth);
+    return this.#impl.verify(auth);
   }
 
   did() {
-    return this.impl.did();
+    return this.#impl.did();
   }
 
   static async fromDid<ID extends DIDKey>(

--- a/identity/src/ed25519/native.ts
+++ b/identity/src/ed25519/native.ts
@@ -58,30 +58,30 @@ export const isNativeEd25519Supported = (() => {
 })();
 
 export class NativeEd25519Signer<ID extends DIDKey> implements Signer<ID> {
-  private keypair: CryptoKeyPair;
-  private _did: ID;
+  #keypair: CryptoKeyPair;
+  #did: ID;
   #verifier: Verifier<ID> | null = null;
   constructor(keypair: CryptoKeyPair, did: ID) {
-    this.keypair = keypair;
-    this._did = did;
+    this.#keypair = keypair;
+    this.#did = did;
   }
 
   did() {
-    return this._did;
+    return this.#did;
   }
 
   get verifier(): Verifier<ID> {
     if (!this.#verifier) {
       this.#verifier = new NativeEd25519Verifier<ID>(
-        this.keypair.publicKey,
-        this._did,
+        this.#keypair.publicKey,
+        this.#did,
       );
     }
     return this.#verifier;
   }
 
   serialize(): CryptoKeyPair {
-    return this.keypair;
+    return this.#keypair;
   }
 
   async sign<T>(payload: AsBytes<T>): Promise<Result<Signature<T>, Error>> {
@@ -89,7 +89,7 @@ export class NativeEd25519Signer<ID extends DIDKey> implements Signer<ID> {
       const signature = new Uint8Array(
         await globalThis.crypto.subtle.sign(
           ED25519_ALG,
-          this.keypair.privateKey,
+          this.#keypair.privateKey,
           payload,
         ),
       );
@@ -148,15 +148,15 @@ export class NativeEd25519Signer<ID extends DIDKey> implements Signer<ID> {
 }
 
 export class NativeEd25519Verifier<ID extends DIDKey> implements Verifier<ID> {
-  private publicKey: CryptoKey;
-  private _did: ID;
+  #publicKey: CryptoKey;
+  #did: ID;
   constructor(publicKey: CryptoKey, did: ID) {
-    this.publicKey = publicKey;
-    this._did = did;
+    this.#publicKey = publicKey;
+    this.#did = did;
   }
 
   did(): ID {
-    return this._did;
+    return this.#did;
   }
 
   async verify(
@@ -165,7 +165,7 @@ export class NativeEd25519Verifier<ID extends DIDKey> implements Verifier<ID> {
     if (
       await globalThis.crypto.subtle.verify(
         ED25519_ALG,
-        this.publicKey,
+        this.#publicKey,
         signature,
         payload,
       )

--- a/identity/src/identity.ts
+++ b/identity/src/identity.ts
@@ -8,10 +8,10 @@ const textEncoder = new TextEncoder();
 //
 // Additional keys can be deterministically derived from an identity.
 export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
-  private keypair: Ed25519Signer<ID>;
+  #keypair: Ed25519Signer<ID>;
   #verifier: VerifierIdentity<ID> | null = null;
   constructor(keypair: Ed25519Signer<ID>) {
-    this.keypair = keypair;
+    this.#keypair = keypair;
   }
 
   did() {
@@ -20,7 +20,7 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
 
   get verifier(): VerifierIdentity<ID> {
     if (!this.#verifier) {
-      this.#verifier = new VerifierIdentity(this.keypair.verifier);
+      this.#verifier = new VerifierIdentity(this.#keypair.verifier);
     }
 
     return this.#verifier;
@@ -28,12 +28,12 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
 
   // Sign `data` with this identity.
   sign<T>(payload: AsBytes<T>) {
-    return this.keypair.sign(payload);
+    return this.#keypair.sign(payload);
   }
 
   // Serialize this identity for storage.
   serialize(): KeyPairRaw {
-    return this.keypair.serialize();
+    return this.#keypair.serialize();
   }
 
   // Derive a new `Identity` given a seed string.
@@ -89,18 +89,18 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
 }
 
 export class VerifierIdentity<ID extends DIDKey> implements Verifier<ID> {
-  private inner: Verifier<ID>;
+  #inner: Verifier<ID>;
 
   constructor(inner: Verifier<ID>) {
-    this.inner = inner;
+    this.#inner = inner;
   }
 
   verify(auth: { payload: Uint8Array; signature: Uint8Array }) {
-    return this.inner.verify(auth);
+    return this.#inner.verify(auth);
   }
 
   did(): ID {
-    return this.inner.did();
+    return this.#inner.did();
   }
 
   static async fromDid<ID extends DIDKey>(

--- a/identity/src/interface.ts
+++ b/identity/src/interface.ts
@@ -1,11 +1,6 @@
 export type DID = `did:${string}:${string}`;
 export type DIDKey = `did:key:${string}`;
 
-export type KeyPair = {
-  privateKey: Signer;
-  publicKey: Verifier;
-};
-
 /**
  * Some principal identified via DID identifier.
  */


### PR DESCRIPTION
 to reduce opportunities in appearing in e.g. console.logs