### PR TITLE
Fix: skip loader if no libraries

### DIFF
--- a/charm/src/iframe/static.ts
+++ b/charm/src/iframe/static.ts
@@ -293,6 +293,7 @@ ${JSON.stringify(libraries)}
 
       if (!requestedLibs || requestedLibs.length === 0) {
         loader.updateStatus('No additional libraries to load');
+        loader.remove(); // Remove the loading overlay immediately if no libraries to load
         return modules;
       }
 


### PR DESCRIPTION
- **Do not show loading overlay if there are no libraries to load**
