### PR TITLE
Simplify interface for getCellFromLink

### DIFF
--- a/cli/write-to-authcell.ts
+++ b/cli/write-to-authcell.ts
@@ -1,9 +1,5 @@
 // Load .env file
-import {
-  type CellLink,
-  getCellFromCellLink,
-  storage,
-} from "@commontools/runner";
+import { type CellLink, getCellFromLink, storage } from "@commontools/runner";
 import { parseArgs } from "@std/cli/parse-args";
 
 const TOOLSHED_API_URL = Deno.env.get("TOOLSHED_API_URL") ||
@@ -23,11 +19,12 @@ async function main(
 
   const doc = await storage.syncCellById(replica, cellId, true);
   const authCellEntity = {
+    space: replica,
     cell: doc,
     path: ["argument", "auth"],
   } satisfies CellLink;
 
-  const authCell = getCellFromCellLink(replica, authCellEntity);
+  const authCell = getCellFromLink(authCellEntity);
   // authCell.set({ token: "wat" });
   await storage.synced();
 

--- a/runner/src/cell.ts
+++ b/runner/src/cell.ts
@@ -214,27 +214,27 @@ export function getCellFromEntityId(
   return createCell(doc, path, log, schema);
 }
 
-export function getCellFromCellLink<T>(
-  space: string,
+export function getCellFromLink<T>(
   docLink: CellLink,
   schema?: JSONSchema,
   log?: ReactivityLog,
 ): Cell<T>;
-export function getCellFromCellLink<S extends JSONSchema = JSONSchema>(
-  space: string,
+export function getCellFromLink<S extends JSONSchema = JSONSchema>(
   docLink: CellLink,
   schema: S,
   log?: ReactivityLog,
 ): Cell<Schema<S>>;
-export function getCellFromCellLink(
-  space: string, // TODO(seefeld): Read from DocLink once it's defined there
+export function getCellFromLink(
   docLink: CellLink,
   schema?: JSONSchema,
   log?: ReactivityLog,
 ): Cell<any> {
+  if (!docLink.space) {
+    throw new Error("Cell link has no space");
+  }
   const doc = isDoc(docLink.cell)
     ? docLink.cell
-    : getDocByEntityId(space, getEntityId(docLink.cell)!, true)!;
+    : getDocByEntityId(docLink.space, getEntityId(docLink.cell)!, true)!;
   return createCell(doc, docLink.path, log, schema);
 }
 

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -13,8 +13,8 @@ export type { ReactivityLog } from "./scheduler.ts";
 export { getDoc, isDoc } from "./doc.ts";
 export {
   getCell,
-  getCellFromCellLink,
   getCellFromEntityId,
+  getCellFromLink,
   getImmutableCell,
   isCell,
   isCellLink,

--- a/toolshed/routes/integrations/google-oauth/google-oauth.utils.ts
+++ b/toolshed/routes/integrations/google-oauth/google-oauth.utils.ts
@@ -1,10 +1,6 @@
 import { OAuth2Client } from "@cmd-johnson/oauth2-client";
 import env from "@/env.ts";
-import {
-  type CellLink,
-  getCellFromCellLink,
-  storage,
-} from "@commontools/runner";
+import { type CellLink, getCellFromLink, storage } from "@commontools/runner";
 import { Context } from "@hono/hono";
 import { Identity, Signer } from "@commontools/identity";
 // Types
@@ -169,10 +165,8 @@ export async function getAuthCellAndStorage(docLink: CellLink | string) {
 
     storage.setRemoteStorage(new URL("http://localhost:8000"));
 
-    // FIXME(ja): the space should be inferred from the doclink - but it isn't there yet
     // FIXME(ja): add the authcell schema!
-    const authCell = getCellFromCellLink(
-      parsedDocLink.space, // FIXME(ja): the space should be inferred from the doclink - but it isn't there yet
+    const authCell = getCellFromLink(
       parsedDocLink,
       undefined,
     );


### PR DESCRIPTION
Now that cell links have spaces, let's simplify the interface for getCellFromLink

@anotherjesse please double check the auth code, specifically that .space should be there because it's generated by Cell.getAsCellLink(). i'm not 100% that's for sure the case (vs hand creating it as `{ cell: ..., path: ... }`).