### PR TITLE
createJsonSchema is now descend into Cells and reuse schemas

### DIFF
--- a/builder/src/recipe.ts
+++ b/builder/src/recipe.ts
@@ -266,9 +266,8 @@ function factoryFromRecipe<T, R>(
   let argumentSchema: JSONSchemaWritable;
 
   if (typeof argumentSchemaArg === "string") {
-    // TODO(seefeld): initial is likely not needed anymore
-    // TODO(seefeld): But we need a derived schema for the result
-    argumentSchema = createJsonSchema(defaults, {});
+    // TODO(seefeld): We still need a derived schema for the result
+    argumentSchema = createJsonSchema(defaults, true);
     argumentSchema.description = argumentSchemaArg;
 
     delete (argumentSchema.properties as any)?.[UI]; // TODO(seefeld): This should be a schema for views

--- a/charm/src/iterate.ts
+++ b/charm/src/iterate.ts
@@ -100,7 +100,7 @@ export async function castNewRecipe(
   data: any,
   newSpec: string,
 ): Promise<Cell<Charm>> {
-  const schema = isCell(data) ? { ...data.schema } : createJsonSchema({}, data);
+  const schema = isCell(data) ? { ...data.schema } : createJsonSchema(data);
   schema.description = newSpec;
   console.log("schema", schema);
 


### PR DESCRIPTION
`createJsonSchema` is now descend into Cells/Docs/etc. while using Cell schemas if present.
Whether to copy the example into the defaults is now a boolean.