### PR TITLE
don't send data back to the iframe that came from the iframe + change useDoc to not expect that

### DIFF
--- a/charm/src/iframe/static.ts
+++ b/charm/src/iframe/static.ts
@@ -53,7 +53,7 @@ ${JSON.stringify(libraries)}
           setReceived(true);
 
           // Update the state with the received value or null if undefined
-          const value = event.data.data[1] === undefined ? null : event.data.data[1];
+          const value = event.data.data[1];
           console.log("useDoc", key, "updated", value);
           setDocState(value);
         }
@@ -62,18 +62,18 @@ ${JSON.stringify(libraries)}
       window.addEventListener("message", handleMessage);
 
       // Subscribe to the specific key
-      window.parent.postMessage({ type: "subscribe", data: key }, "*");
+      window.parent.postMessage({ type: "subscribe", data: [key] }, "*");
       window.parent.postMessage({ type: "read", data: key }, "*");
 
       return () => {
         window.removeEventListener("message", handleMessage);
-        window.parent.postMessage({ type: "unsubscribe", data: key }, "*");
+        window.parent.postMessage({ type: "unsubscribe", data: [key] }, "*");
       };
     }, [key]);
 
     // After we've received a response, apply default value if needed
     React.useEffect(() => {
-      if (received && doc === null && defaultValue !== undefined) {
+      if (received && doc === undefined && defaultValue !== undefined) {
         // Only write the default value if we've confirmed no data exists
         console.log("useDoc", key, "default", defaultValue);
         window.parent.postMessage({ type: "write", data: [key, defaultValue] }, "*");
@@ -91,7 +91,7 @@ ${JSON.stringify(libraries)}
     };
 
     // Return the current document value or the default if we haven't received data yet
-    return [received ? (doc === null ? defaultValue : doc) : defaultValue, updateDoc];
+    return [received ? (doc === undefined ? defaultValue : doc) : defaultValue, updateDoc];
   };
 
   // Define llm utility with React available

--- a/charm/src/iframe/static.ts
+++ b/charm/src/iframe/static.ts
@@ -6,13 +6,14 @@ const libraries = {
     "d3": "https://esm.sh/d3@7.8.5",
     "moment": "https://esm.sh/moment@2.29.4",
     "marked": "https://esm.sh/marked@15.0.7",
-    "@react-spring/web": "https://esm.sh/@react-spring/web@9.7.3?external=react",
-    "@use-gesture/react": "https://esm.sh/@use-gesture/react@10.3.0?external=react",
+    "@react-spring/web":
+      "https://esm.sh/@react-spring/web@9.7.3?external=react",
+    "@use-gesture/react":
+      "https://esm.sh/@use-gesture/react@10.3.0?external=react",
     "uuid": "https://esm.sh/uuid@11.0.1",
-    "tone": "https://esm.sh/tone@15.0.4"
-  }
+    "tone": "https://esm.sh/tone@15.0.4",
+  },
 };
-
 
 // The HTML template that wraps the developer's code
 export const prefillHtml = `<html>
@@ -85,6 +86,7 @@ ${JSON.stringify(libraries)}
         newValue = newValue(doc);
       }
       console.log("useDoc", key, "written", newValue);
+      setDocState(newValue);
       window.parent.postMessage({ type: "write", data: [key, newValue] }, "*");
     };
 
@@ -445,13 +447,13 @@ window.__app = { onLoad, onReady, title };
 export function injectUserCode(userCode: string) {
   // Add comment fences around the user code for later extraction
   const fencedUserCode = `// BEGIN_USER_CODE\n${userCode}\n// END_USER_CODE`;
-  return prefillHtml.replace('// USER_CODE_PLACEHOLDER', fencedUserCode);
+  return prefillHtml.replace("// USER_CODE_PLACEHOLDER", fencedUserCode);
 }
 
 // Function to extract the user code from HTML with fences
 export function extractUserCode(html: string): string | null {
-  const startMarker = '// BEGIN_USER_CODE\n';
-  const endMarker = '\n// END_USER_CODE';
+  const startMarker = "// BEGIN_USER_CODE\n";
+  const endMarker = "\n// END_USER_CODE";
 
   const startIndex = html.indexOf(startMarker);
   if (startIndex === -1) return null;
@@ -493,7 +495,7 @@ Create an interactive React component that fulfills the user's request. Focus on
 ## Library Usage
 - Request additional libraries in \`onLoad\` by returning an array of module names
 - Available libraries:
-  ${Object.entries(libraries).map(([k, v]) => `- ${k} : ${v}`).join('\n')}
+  ${Object.entries(libraries).map(([k, v]) => `- ${k} : ${v}`).join("\n")}
 - Only use the explicitly provided libraries
 
 ## Security Restrictions
@@ -599,7 +601,7 @@ function ImageComponent() {
 
 \`\`\`javascript
 // Import from modern ESM libraries:
-${Object.keys(libraries.imports).map(lib => `//   - ${lib}`).join('\n')}
+${Object.keys(libraries.imports).map((lib) => `//   - ${lib}`).join("\n")}
 function onLoad() {
   return ['@react-spring/web']; // Request the modules you need
 }

--- a/iframe-sandbox/src/context.ts
+++ b/iframe-sandbox/src/context.ts
@@ -7,6 +7,7 @@ export interface IframeContextHandler {
     context: any,
     key: string,
     callback: (key: string, value: any) => void,
+    doNotSendMyDataBack: boolean,
   ): any;
   unsubscribe(context: any, receipt: any): void;
   onLLMRequest(context: any, payload: string): Promise<object>;

--- a/iframe-sandbox/src/ipc.ts
+++ b/iframe-sandbox/src/ipc.ts
@@ -100,7 +100,7 @@ export function isGuestError(e: object): e is GuestError {
 export enum HostMessageType {
   Update = "update",
   LLMResponse = "llm-response",
-  ReadWebpageResponse = "readwebpage-response"
+  ReadWebpageResponse = "readwebpage-response",
 }
 
 export type HostMessage =
@@ -125,13 +125,13 @@ export enum GuestMessageType {
   Write = "write",
   Read = "read",
   LLMRequest = "llm-request",
-  WebpageRequest = 'readwebpage-request'
+  WebpageRequest = "readwebpage-request",
 }
 
 export type GuestMessage =
   | { type: GuestMessageType.Error; data: GuestError }
-  | { type: GuestMessageType.Subscribe; data: string }
-  | { type: GuestMessageType.Unsubscribe; data: string }
+  | { type: GuestMessageType.Subscribe; data: string | string[] }
+  | { type: GuestMessageType.Unsubscribe; data: string | string[] }
   | { type: GuestMessageType.Read; data: string }
   | { type: GuestMessageType.Write; data: [string, any] }
   | { type: GuestMessageType.LLMRequest; data: string }

--- a/jumble/src/iframe-ctx.ts
+++ b/jumble/src/iframe-ctx.ts
@@ -126,6 +126,7 @@ export const setupIframe = () =>
       context: any,
       key: string,
       callback: (key: string, value: any) => void,
+      doNotSendMyDataBack: boolean,
     ): any {
       const action: Action = (log: ReactivityLog) => {
         const data = key === "*"
@@ -137,7 +138,7 @@ export const setupIframe = () =>
         const serialized = removeNonJsonData(data);
         const serializedString = JSON.stringify(serialized);
         const previousValue = getPreviousValue(context, key);
-        if (serializedString !== previousValue) {
+        if (serializedString !== previousValue || !doNotSendMyDataBack) {
           console.log("subscribe", key, serialized, previousValue);
           setPreviousValue(context, key, serializedString);
           callback(key, serialized);


### PR DESCRIPTION
Since it's a breaking change in the behavior, I revved the iframe protocol: subscribe now accepts an array of keys, and this triggers the new behavior. In a few weeks, let's remove support for single strings and remove support for the old behavior.