### PR TITLE
Builder & Runner: Associate argument schema all the way through to cell that goes to renderer

### DIFF
--- a/builder/src/opaque-ref.ts
+++ b/builder/src/opaque-ref.ts
@@ -1,5 +1,6 @@
 import {
   isOpaqueRefMarker,
+  type JSONSchema,
   type NodeFactory,
   type NodeRef,
   type Opaque,
@@ -29,7 +30,10 @@ let mapFactory: NodeFactory<any, any>;
 //
 // The proxy yields another proxy for each nested value, but still allows the
 // methods to be called. Setters just call .set() on the nested cell.
-export function opaqueRef<T>(value?: Opaque<T> | T): OpaqueRef<T> {
+export function opaqueRef<T>(
+  value?: Opaque<T> | T,
+  schema?: JSONSchema,
+): OpaqueRef<T> {
   const store = {
     value,
     defaultValue: undefined,
@@ -43,6 +47,8 @@ export function opaqueRef<T>(value?: Opaque<T> | T): OpaqueRef<T> {
   function createNestedProxy(
     path: PropertyKey[],
     target?: any,
+    schema?: JSONSchema,
+    rootSchema: JSONSchema | undefined = schema,
   ): OpaqueRef<any> {
     const methods: OpaqueRefMethods<any> = {
       get: () => unsafe_materialize(unsafe_binding, path),
@@ -51,7 +57,28 @@ export function opaqueRef<T>(value?: Opaque<T> | T): OpaqueRef<T> {
           unsafe_materialize(unsafe_binding, path); // TODO(seefeld): Set value
         } else setValueAtPath(store, ["value", ...path], newValue);
       },
-      key: (key: PropertyKey) => createNestedProxy([...path, key]),
+      key: (key: PropertyKey) => {
+        // Determine child schema when accessing a property
+        let childSchema: JSONSchema | undefined;
+
+        if (schema?.type === "object") {
+          // For root object properties
+          childSchema = schema.properties?.[key as string] ||
+            (typeof schema.additionalProperties === "object"
+              ? schema.additionalProperties
+              : undefined);
+        } else if (schema?.type === "array") {
+          // For root array elements
+          childSchema = schema.items;
+        }
+
+        return createNestedProxy(
+          [...path, key],
+          key in methods ? methods[key as keyof OpaqueRefMethods<any>] : store,
+          childSchema,
+          childSchema ? rootSchema : undefined, // Only pass rootSchema if we have a child schema
+        );
+      },
       setDefault: (newValue: Opaque<any>) => {
         if (!hasValueAtPath(store, ["defaultValue", ...path])) {
           setValueAtPath(store, ["defaultValue", ...path], newValue);
@@ -66,6 +93,8 @@ export function opaqueRef<T>(value?: Opaque<T> | T): OpaqueRef<T> {
       export: () => ({
         cell: top,
         path,
+        schema,
+        rootSchema,
         ...store,
       }),
       unsafe_bindToRecipeAndPath: (
@@ -136,12 +165,9 @@ export function opaqueRef<T>(value?: Opaque<T> | T): OpaqueRef<T> {
       get(_, prop) {
         if (typeof prop === "symbol") {
           return methods[prop as keyof OpaqueRefMethods<any>];
-        } else if (prop in methods) {
-          return createNestedProxy(
-            [...path, prop],
-            methods[prop as keyof OpaqueRefMethods<any>],
-          );
-        } else return createNestedProxy([...path, prop], store);
+        } else {
+          return methods.key(prop);
+        }
       },
       set(_, prop, value) {
         methods.set({ [prop]: value });
@@ -152,7 +178,7 @@ export function opaqueRef<T>(value?: Opaque<T> | T): OpaqueRef<T> {
     return proxy;
   }
 
-  const top = createNestedProxy([], store) as OpaqueRef<T>;
+  const top = createNestedProxy([], store, schema) as OpaqueRef<T>;
 
   store.frame.opaqueRefs.add(top);
 

--- a/builder/src/opaque-ref.ts
+++ b/builder/src/opaque-ref.ts
@@ -14,6 +14,7 @@ import {
 import { hasValueAtPath, setValueAtPath } from "./utils.ts";
 import { getTopFrame, recipe } from "./recipe.ts";
 import { createNodeFactory } from "./module.ts";
+import { SchemaWithoutCell } from "./schema-to-ts.ts";
 
 let mapFactory: NodeFactory<any, any>;
 
@@ -30,6 +31,15 @@ let mapFactory: NodeFactory<any, any>;
 //
 // The proxy yields another proxy for each nested value, but still allows the
 // methods to be called. Setters just call .set() on the nested cell.
+export function opaqueRef<S extends JSONSchema>(
+  value: Opaque<SchemaWithoutCell<S>> | SchemaWithoutCell<S>,
+  schema: S,
+): OpaqueRef<SchemaWithoutCell<S>>;
+export function opaqueRef<T>(
+  value?: Opaque<T> | T,
+  schema?: JSONSchema,
+): OpaqueRef<T>;
+
 export function opaqueRef<T>(
   value?: Opaque<T> | T,
   schema?: JSONSchema,

--- a/builder/src/recipe.ts
+++ b/builder/src/recipe.ts
@@ -107,8 +107,15 @@ export function recipe<T, R>(
   // and `outputs` with Value<> (which containts OpaqueRef<>) and/or default
   // values.
   const frame = pushFrame();
-  const inputs = opaqueRef<Required<T>>();
+
+  const jsonSchema = argumentSchema instanceof z.ZodType
+    ? (zodToJsonSchema(argumentSchema) as JSONSchema)
+    : argumentSchema as JSONSchema | undefined;
+
+  const inputs = opaqueRef<Required<T>>(undefined, jsonSchema);
+
   const outputs = fn!(inputs);
+
   const result = factoryFromRecipe<T, R>(
     argumentSchema,
     resultSchema,
@@ -125,7 +132,11 @@ export function recipeFromFrame<T, R>(
   resultSchema: JSONSchema | z.ZodTypeAny | undefined,
   fn: (input: OpaqueRef<Required<T>>) => Opaque<R>,
 ): RecipeFactory<T, R> {
-  const inputs = opaqueRef<Required<T>>();
+  const jsonSchema = argumentSchema instanceof z.ZodType
+    ? (zodToJsonSchema(argumentSchema) as JSONSchema)
+    : argumentSchema as JSONSchema | undefined;
+
+  const inputs = opaqueRef<Required<T>>(undefined, jsonSchema);
   const outputs = fn(inputs);
   return factoryFromRecipe<T, R>(argumentSchema, resultSchema, inputs, outputs);
 }

--- a/builder/src/types.ts
+++ b/builder/src/types.ts
@@ -1,3 +1,5 @@
+import { isObj } from "@commontools/utils";
+
 export const ID: symbol = Symbol("ID, unique to the context");
 export const ID_FIELD: symbol = Symbol(
   "ID_FIELD, name of sibling that contains id",
@@ -150,7 +152,8 @@ export type Alias = {
 };
 
 export function isAlias(value: any): value is Alias {
-  return !!(value && value.$alias && Array.isArray(value.$alias.path));
+  return isObj(value) && isObj(value.$alias) &&
+    Array.isArray(value.$alias.path);
 }
 
 export type StreamAlias = {

--- a/builder/src/types.ts
+++ b/builder/src/types.ts
@@ -41,9 +41,14 @@ export type OpaqueRefMethods<T> = {
     nodes: Set<NodeRef>;
     external?: any;
     name?: string;
+    schema?: JSONSchema;
+    rootSchema?: JSONSchema;
     frame: Frame;
   };
-  unsafe_bindToRecipeAndPath(recipe: Recipe, path: PropertyKey[]): void;
+  unsafe_bindToRecipeAndPath(
+    recipe: Recipe,
+    path: PropertyKey[],
+  ): void;
   unsafe_getExternal(): OpaqueRef<T>;
   map<S>(
     fn: (
@@ -136,7 +141,12 @@ export type Writable<T> = {
 export type JSONSchemaWritable = Writable<JSONSchema>;
 
 export type Alias = {
-  $alias: { cell?: any; path: PropertyKey[] };
+  $alias: {
+    cell?: any;
+    path: PropertyKey[];
+    schema?: JSONSchema;
+    rootSchema?: JSONSchema;
+  };
 };
 
 export function isAlias(value: any): value is Alias {

--- a/builder/src/utils.ts
+++ b/builder/src/utils.ts
@@ -146,10 +146,14 @@ export function toJSONWithAliases(
     if (pathToCell) {
       if (ignoreSelfAliases && deepEqual(path, pathToCell)) return undefined;
 
+      // Get schema from exported value if available
+      const exported = isOpaqueRef(value) ? value.export() : undefined;
       return {
         $alias: {
           ...(isShadowRef(value) ? { cell: value } : {}),
           path: pathToCell as (string | number)[],
+          ...(exported?.schema ? { schema: exported.schema } : {}),
+          ...(exported?.rootSchema ? { rootSchema: exported.rootSchema } : {}),
         },
       } satisfies Alias;
     } else throw new Error(`Cell not found in paths`);

--- a/builder/test/opaque-ref-schema.test.ts
+++ b/builder/test/opaque-ref-schema.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { recipe } from "../src/index.ts";
+import { popFrame, pushFrame } from "../src/recipe.ts";
+import { opaqueRef } from "../src/opaque-ref.ts";
+import type { Frame, JSONSchema } from "../src/types.ts";
+
+describe("OpaqueRef Schema Support", () => {
+  let frame: Frame;
+
+  beforeEach(() => {
+    // Setup frame for the test
+    frame = pushFrame();
+  });
+
+  afterEach(() => {
+    popFrame(frame);
+  });
+
+  describe("Schema Setting and Retrieval", () => {
+    it("should store and retrieve schema information", () => {
+      // Set a schema
+      const schema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          age: { type: "number" },
+        },
+      } as const satisfies JSONSchema;
+
+      // Create an opaque ref
+      const ref = opaqueRef<{ name: string; age: number }>(undefined, schema);
+
+      // Export the ref and check the schema is included
+      const exported = ref.export();
+      expect(exported.schema).toBeDefined();
+      expect(exported.schema).toEqual(schema);
+      expect(exported.rootSchema).toEqual(schema);
+    });
+
+    it("should handle separate root schema", () => {
+      // Set a schema with root schema
+      const rootSchema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          details: {
+            type: "object",
+            properties: {
+              age: { type: "number" },
+            },
+          },
+        },
+      } as const satisfies JSONSchema;
+
+      // Create an opaque ref
+      const ref = opaqueRef<{ name: string; details: { age: number } }>(
+        undefined,
+        rootSchema,
+      ).key("details");
+
+      // Export the ref and check both schemas are included
+      const exported = ref.export();
+      expect(exported.schema).toBeDefined();
+      expect(exported.schema).toEqual(rootSchema.properties.details);
+      expect(exported.rootSchema).toBeDefined();
+      expect(exported.rootSchema).toEqual(rootSchema);
+    });
+  });
+
+  describe("Schema Propagation in Proxies", () => {
+    it("should propagate schema to child properties via key()", () => {
+      // Set a schema
+      const schema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          age: { type: "number" },
+        },
+      } as const satisfies JSONSchema;
+
+      // Create an opaque ref
+      const ref = opaqueRef<{ name: string; age: number }>(undefined, schema);
+
+      // Get a child property
+      const nameRef = ref.key("name");
+
+      // Export the child ref and check it has the correct schema
+      const exported = nameRef.export();
+      expect(exported.schema).toBeDefined();
+      expect(exported.schema).toEqual({ type: "string" });
+      expect(exported.rootSchema).toEqual(schema);
+    });
+
+    it("should propagate schema to array elements", () => {
+      // Set a schema
+      const schema = {
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "number" },
+                text: { type: "string" },
+              },
+            },
+          },
+        },
+      } as const satisfies JSONSchema;
+
+      // Create an opaque ref with an array
+      const ref = opaqueRef<{ items: Array<{ id: number; text: string }> }>(
+        undefined,
+        schema,
+      );
+
+      // Access array element
+      const itemsRef = ref.key("items");
+      const firstItemRef = itemsRef[0];
+      const idRef = firstItemRef.key("id");
+
+      // Check schema for array element property
+      const exported = idRef.export();
+      expect(exported.schema).toBeDefined();
+      expect(exported.schema).toEqual({ type: "number" });
+    });
+
+    it("should handle nested object schemas correctly", () => {
+      // Set a schema with nested objects
+      const schema = {
+        type: "object",
+        properties: {
+          user: {
+            type: "object",
+            properties: {
+              profile: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  settings: {
+                    type: "object",
+                    properties: {
+                      theme: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as const satisfies JSONSchema;
+
+      // Create an opaque ref with nested objects
+      const ref = opaqueRef<{
+        user: {
+          profile: {
+            name: string;
+            settings: {
+              theme: string;
+            };
+          };
+        };
+      }>(undefined, schema);
+
+      // Access deeply nested property
+      const themeRef = ref.key("user").key("profile").key("settings").key(
+        "theme",
+      );
+
+      // Check schema was correctly propagated
+      const exported = themeRef.export();
+      expect(exported.schema).toBeDefined();
+      expect(exported.schema).toEqual({ type: "string" });
+      expect(exported.rootSchema).toEqual(schema);
+    });
+  });
+
+  describe("Schema in Recipe Context", () => {
+    it("should initialize opaque refs with schema from argument schema", () => {
+      // Create a recipe with schema
+      const testRecipe = recipe(
+        {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            age: { type: "number" },
+          },
+        },
+        (input) => {
+          // Directly return the input
+          return input;
+        },
+      );
+
+      expect((testRecipe.result as any).$alias).toBeDefined();
+      const alias = (testRecipe.result as any).$alias;
+
+      // Check that schema was set
+      expect(alias.schema).toBeDefined();
+      expect(alias.schema.type).toBe("object");
+      expect(alias.schema.properties?.name).toEqual({ type: "string" });
+      expect(alias.schema.properties?.age).toEqual({ type: "number" });
+    });
+
+    it("should track schema through recipe bindings", () => {
+      // Create a recipe that uses child properties
+      const testRecipe = recipe(
+        {
+          type: "object",
+          properties: {
+            user: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                details: {
+                  type: "object",
+                  properties: {
+                    age: { type: "number" },
+                  },
+                },
+              },
+            },
+          },
+        } as const satisfies JSONSchema,
+        (input) => {
+          // Get a nested property
+          // TODO(seefeld): Fix type inference
+          const age = (input as any).user.details.age;
+
+          // Export both the original ref and nested property
+          return {
+            age,
+          };
+        },
+      );
+
+      expect((testRecipe.result as any).age?.$alias).toBeDefined();
+      const alias = (testRecipe.result as any).age.$alias;
+
+      // Check the age property schema
+      expect(alias.schema).toBeDefined();
+      expect(alias.schema).toEqual({ type: "number" });
+      expect(alias.rootSchema).toBeDefined();
+      expect(alias.rootSchema.type).toBe("object");
+    });
+  });
+});

--- a/html/test/html-recipes.test.ts
+++ b/html/test/html-recipes.test.ts
@@ -127,7 +127,7 @@ describe("recipes with HTML", () => {
     const parent = document.createElement("div");
     document.body.appendChild(parent);
     const cell = result.asCell<{ [UI]: VNode }>().key(UI);
-    render(parent, cell.get());
+    render(parent, cell);
 
     assert.equal(parent.innerHTML, "<div><div>test</div></div>");
   });

--- a/jumble/src/iframe-ctx.ts
+++ b/jumble/src/iframe-ctx.ts
@@ -104,7 +104,11 @@ function setPreviousValue(context: any, key: string, value: any) {
 export const setupIframe = () =>
   setIframeContextHandler({
     read(context: any, key: string): any {
-      const data = isCell(context) ? context.key(key).get?.() : context?.[key];
+      const data = key === "*"
+        ? isCell(context) ? context.get() : context
+        : isCell(context)
+        ? context.key(key).get?.()
+        : context?.[key];
       const serialized = removeNonJsonData(data);
       console.log("read", key, serialized, JSON.stringify(serialized));
       setPreviousValue(context, key, JSON.stringify(serialized));

--- a/runner/src/cell.ts
+++ b/runner/src/cell.ts
@@ -176,6 +176,8 @@ export type CellLink = {
   space?: string;
   cell: DocImpl<any>;
   path: PropertyKey[];
+  schema?: JSONSchema;
+  rootSchema?: JSONSchema;
 };
 
 export function getCell<T>(
@@ -283,6 +285,13 @@ export function createCell<T>(
   // The corner case where during it's lifetime this changes from non-stream to stream
   // or vice versa will not be detected.
   const ref = resolveLinkToValue(doc, path);
+
+  // Use schema from alias if provided and no explicit schema was set
+  if (!schema && ref.schema) {
+    schema = ref.schema;
+    rootSchema = ref.rootSchema || ref.schema;
+  }
+
   if (isStreamAlias(ref.cell.getAtPath(ref.path))) {
     return createStreamCell(
       ref.cell,

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -56,4 +56,4 @@ export {
   setBlobbyServerUrl,
 } from "./blobby-storage.ts";
 export { tsToExports } from "./local-build.ts";
-export { addCommonIDfromObjectID } from "./utils.ts";
+export { addCommonIDfromObjectID, maybeGetCellLink } from "./utils.ts";

--- a/runner/src/schema.ts
+++ b/runner/src/schema.ts
@@ -263,7 +263,7 @@ export function validateAndTransform(
   rootSchema: JSONSchema | undefined = schema,
   seen: CellLink[] = [],
 ): any {
-  const resolvedSchema = resolveSchema(schema, rootSchema, true);
+  let resolvedSchema = resolveSchema(schema, rootSchema, true);
 
   // Follow aliases, etc. to last element on path + just aliases on that last one
   // When we generate cells below, we want them to be based of this value, as that
@@ -273,8 +273,8 @@ export function validateAndTransform(
   path = resolvedRef.path;
 
   // Use schema from alias if provided and no explicit schema was set
-  if (!schema && resolvedRef.schema) {
-    schema = resolvedRef.schema;
+  if (!resolvedSchema && resolvedRef.schema) {
+    resolvedSchema = resolvedRef.schema;
     rootSchema = resolvedRef.rootSchema || resolvedRef.schema;
   }
 

--- a/runner/src/schema.ts
+++ b/runner/src/schema.ts
@@ -263,12 +263,20 @@ export function validateAndTransform(
   rootSchema: JSONSchema | undefined = schema,
   seen: CellLink[] = [],
 ): any {
+  const resolvedSchema = resolveSchema(schema, rootSchema, true);
+
   // Follow aliases, etc. to last element on path + just aliases on that last one
   // When we generate cells below, we want them to be based of this value, as that
   // is what a setter would change when they update a value or reference.
-  ({ cell: doc, path } = resolvePath(doc, path, log));
+  const resolvedRef = resolvePath(doc, path, log);
+  doc = resolvedRef.cell;
+  path = resolvedRef.path;
 
-  const resolvedSchema = resolveSchema(schema, rootSchema, true);
+  // Use schema from alias if provided and no explicit schema was set
+  if (!schema && resolvedRef.schema) {
+    schema = resolvedRef.schema;
+    rootSchema = resolvedRef.rootSchema || resolvedRef.schema;
+  }
 
   // If this should be a reference, return as a Cell of resolvedSchema
   // NOTE: Need to check on the passed schema whether it's a reference, not the

--- a/runner/src/utils.ts
+++ b/runner/src/utils.ts
@@ -364,8 +364,8 @@ export function resolvePath(
         cell: aliasResult.cell,
         path: aliasResult.path,
         schema: ref.schema,
+        ...(ref.rootSchema ? { rootSchema: ref.rootSchema } : {}),
       };
-      if (ref.rootSchema) aliasResult.rootSchema = ref.rootSchema;
     } else {
       ref = aliasResult;
     }
@@ -457,7 +457,13 @@ export function followAliases(
     result = { ...alias.$alias } as CellLink;
     if (!result.cell) result.cell = cell;
 
-    if (seen.has(alias)) throw new Error("Alias cycle detected");
+    if (seen.has(alias)) {
+      throw new Error(
+        `Alias cycle detected: ${JSON.stringify(alias)} in ${
+          JSON.stringify([...seen])
+        }`,
+      );
+    }
     seen.add(alias);
     alias = cell.getAtPath(alias.$alias.path);
     if (isAlias(alias)) log?.reads.push({ cell, path: alias.$alias.path });

--- a/runner/test/schema-lineage.test.ts
+++ b/runner/test/schema-lineage.test.ts
@@ -1,0 +1,156 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { getDoc } from "../src/doc.ts";
+import { type Cell, isCell } from "../src/cell.ts";
+import { type JSONSchema } from "@commontools/builder";
+import { recipe, opaqueRef } from "@commontools/builder";
+import { run, stop } from "../src/runner.ts";
+import { idle } from "../src/scheduler.ts";
+
+describe("Schema Lineage", () => {
+  describe("Schema Propagation through Aliases", () => {
+    it("should propagate schema from aliases to cells", () => {
+      // Create a doc with an alias that has schema information
+      const targetDoc = getDoc(
+        { count: 42, label: "test" },
+        "schema-lineage-target",
+        "test"
+      );
+
+      // Create a schema for our alias
+      const schema = {
+        type: "object",
+        properties: {
+          count: { type: "number" },
+          label: { type: "string" }
+        }
+      } as const satisfies JSONSchema;
+
+      // Create a doc with an alias that includes schema information
+      const sourceDoc = getDoc(
+        { 
+          $alias: { 
+            cell: targetDoc, 
+            path: [],
+            schema,
+            rootSchema: schema
+          } 
+        },
+        "schema-lineage-source",
+        "test"
+      );
+
+      // Access the doc without providing a schema
+      const cell = sourceDoc.asCell();
+      
+      // The cell should have picked up the schema from the alias
+      expect(cell.schema).toBeDefined();
+      expect(cell.schema).toEqual(schema);
+      
+      // When we access a nested property, it should have the correct schema
+      const countCell = cell.key("count");
+      expect(countCell.schema).toBeDefined();
+      expect(countCell.schema).toEqual({ type: "number" });
+    });
+
+    it("should respect explicitly provided schema over alias schema", () => {
+      // Create a doc with an alias that has schema information
+      const targetDoc = getDoc(
+        { count: 42, label: "test" },
+        "schema-lineage-target-explicit",
+        "test"
+      );
+
+      // Create schemas with different types
+      const aliasSchema = {
+        type: "object",
+        properties: {
+          count: { type: "number" },
+          label: { type: "string" }
+        }
+      } as const satisfies JSONSchema;
+
+      const explicitSchema = {
+        type: "object",
+        properties: {
+          count: { type: "string" }, // Different type than in aliasSchema
+          label: { type: "string" }
+        }
+      } as const satisfies JSONSchema;
+
+      // Create a doc with an alias that includes schema information
+      const sourceDoc = getDoc(
+        { 
+          $alias: { 
+            cell: targetDoc, 
+            path: [],
+            schema: aliasSchema,
+            rootSchema: aliasSchema
+          } 
+        },
+        "schema-lineage-source-explicit",
+        "test"
+      );
+
+      // Access the doc with explicit schema
+      const cell = sourceDoc.asCell([], undefined, explicitSchema);
+      
+      // The cell should have the explicit schema, not the alias schema
+      expect(cell.schema).toBeDefined();
+      expect(cell.schema).toEqual(explicitSchema);
+      
+      // The nested property should have the schema from explicitSchema
+      const countCell = cell.key("count");
+      expect(countCell.schema).toBeDefined();
+      expect(countCell.schema).toEqual({ type: "string" });
+    });
+  });
+
+  describe("Schema Propagation from Aliases (without Recipes)", () => {
+    it("should track schema through deep aliases", () => {
+      // Create a series of nested aliases with schemas
+      const valueDoc = getDoc(
+        { count: 5, name: "test" },
+        "deep-alias-value",
+        "test"
+      );
+      
+      // Create a schema for our first level alias
+      const numberSchema = { type: "number" };
+      
+      // Create a doc with an alias specifically for the count field
+      const countDoc = getDoc(
+        { 
+          $alias: { 
+            cell: valueDoc, 
+            path: ["count"],
+            schema: numberSchema,
+            rootSchema: numberSchema
+          } 
+        },
+        "count-alias",
+        "test"
+      );
+      
+      // Create a third level of aliasing
+      const finalDoc = getDoc(
+        { 
+          $alias: { 
+            cell: countDoc, 
+            path: [],
+          } 
+        },
+        "final-alias",
+        "test"
+      );
+      
+      // Access the doc without providing a schema
+      const cell = finalDoc.asCell();
+      
+      // The cell should have picked up the schema from the alias chain
+      expect(cell.schema).toBeDefined();
+      expect(cell.schema).toEqual(numberSchema);
+      expect(cell.get()).toBe(5);
+    });
+  });
+});

--- a/runner/test/utils.test.ts
+++ b/runner/test/utils.test.ts
@@ -7,7 +7,6 @@ import {
   diffAndUpdate,
   extractDefaultValues,
   followAliases,
-  followCellReferences,
   isEqualCellLink,
   mergeObjects,
   normalizeAndDiff,
@@ -293,56 +292,6 @@ describe("mapBindingToCell", () => {
       y: { $alias: { cell: testCell, path: ["b", "c"] } },
       z: 3,
     });
-  });
-});
-
-describe("followCellReferences", () => {
-  it("should follow a simple cell reference", () => {
-    const testCell = getDoc(
-      { value: 42 },
-      "should follow a simple cell reference 1",
-      "test",
-    );
-    const reference: CellLink = { cell: testCell, path: ["value"] };
-    const result = followCellReferences(reference);
-    expect(result.cell.getAtPath(result.path)).toBe(42);
-  });
-
-  it("should follow nested cell references", () => {
-    const innerCell = getDoc(
-      { inner: 10 },
-      "should follow nested cell references 1",
-      "test",
-    );
-    const outerCell = getDoc(
-      {
-        outer: { cell: innerCell, path: ["inner"] },
-      },
-      "should follow nested cell references 2",
-      "test",
-    );
-    const reference: CellLink = { cell: outerCell, path: ["outer"] };
-    const result = followCellReferences(reference);
-    expect(result.cell.getAtPath(result.path)).toBe(10);
-  });
-
-  it("should throw an error on circular references", () => {
-    const cellA = getDoc(
-      {},
-      "should throw an error on circular references 1",
-      "test",
-    );
-    const cellB = getDoc(
-      {},
-      "should throw an error on circular references 2",
-      "test",
-    );
-    cellA.send({ ref: { cell: cellB, path: ["ref"] } });
-    cellB.send({ ref: { cell: cellA, path: ["ref"] } });
-    const reference: CellLink = { cell: cellA, path: ["ref"] };
-    expect(() => followCellReferences(reference)).toThrow(
-      "Reference cycle detected",
-    );
   });
 });
 


### PR DESCRIPTION
It turns out the argument schema wasn't actually piped through all the way from recipe creation to running the charm to then what the renderer would pass to e.g. the iframe lit element. This fixes that.

The main steps are:
- builder:
  - opaque refs are now schema aware (which is actually also another step towards eventual unification with Cell)
  - recipe creation passes argument schema as schema to an opaque ref
  - when recipe is being serialized, which currently means opaque refs get turned into aliases, the schemas are written into alias
- runner:
  - when following aliases, pick up the schema of the first alias the sets one
  - when there is no schema, or a parent schema runs out of specificity (e.g. a prop in vdom that can by any type), then such an alias provided schema is used instead
  