### PR TITLE
properly catch errors in handlers and lifted functions

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -6961,13 +6961,7 @@
         "dependencies": [
           "jsr:@db/sqlite@0.12",
           "npm:@opentelemetry/api@^1.9.0"
-        ],
-        "packageJson": {
-          "dependencies": [
-            "npm:merkle-reference@^2.0.1",
-            "npm:multiformats@^13.3.2"
-          ]
-        }
+        ]
       },
       "toolshed": {
         "dependencies": [

--- a/deno.lock
+++ b/deno.lock
@@ -6961,7 +6961,13 @@
         "dependencies": [
           "jsr:@db/sqlite@0.12",
           "npm:@opentelemetry/api@^1.9.0"
-        ]
+        ],
+        "packageJson": {
+          "dependencies": [
+            "npm:merkle-reference@^2.0.1",
+            "npm:multiformats@^13.3.2"
+          ]
+        }
       },
       "toolshed": {
         "dependencies": [

--- a/runner/src/scheduler.ts
+++ b/runner/src/scheduler.ts
@@ -191,6 +191,7 @@ async function execute() {
         new Error(
           `Too many iterations: ${loopCounter.get(fn)} ${fn.name ?? ""}`,
         ),
+        fn,
       );
     } else await run(fn);
   }


### PR DESCRIPTION
- changed default behavior to just console.error errors, but not re-throw
- catch errors in handlers
- make sure to resolve promise even if onerror() handlers throw again
- added tests

Fixes #775 