### PR TITLE
Initial pass where I only show generated code.

### DIFF
--- a/charm/src/index.ts
+++ b/charm/src/index.ts
@@ -12,4 +12,5 @@ export {
   generateNewRecipeVersion,
   iterate,
 } from "./iterate.ts";
+export { extractUserCode, injectUserCode } from "./iframe/static.ts";
 export { getIframeRecipe, type IFrameRecipe } from "./iframe/recipe.ts";


### PR DESCRIPTION
This is an initial pass for #720 
I'm punting on the situation where the recipe is old, and we edit the user code. If they do that, the new pre/post regions will be based on the latest build.
I still need to let them switch between just user code section view and the whole IFrameRecipe.src. Currently just showing user code section.
