### PR TITLE
Store, retrieve and display the current template "version" in the code panel

### DIFF
--- a/charm/src/iframe/static.ts
+++ b/charm/src/iframe/static.ts
@@ -527,6 +527,14 @@ export function extractUserCode(html: string): string | null {
   return html.substring(startIndex + startMarker.length, endIndex);
 }
 
+export function extractVersionTag(template?: string) {
+  // Extract the template version from the HTML comment
+  const versionMatch = template?.match(
+    /<meta name="template-version" content="([^"]+)">/,
+  );
+  return versionMatch ? versionMatch[1] : null;
+}
+
 const security = () =>
   `## Security Restrictions
 - Do not use browser dialog functions (\`prompt()\`, \`alert()\`, \`confirm()\`)

--- a/charm/src/iframe/static.ts
+++ b/charm/src/iframe/static.ts
@@ -16,6 +16,7 @@ const libraries = {
     "tone": "https://esm.sh/tone@15.0.4",
   },
 };
+
 const jsonRegex = new RegExp(
   "```(?:json)?\s*(\{[\s\S]*?\})\s*```|(\{[\s\S]*\})",
 );
@@ -23,6 +24,7 @@ const jsonRegex = new RegExp(
 // The HTML template that wraps the developer's code
 export const prefillHtml = `<html>
 <head>
+<meta name="template-version" content="1.0.0">
 <script src="https://cdn.tailwindcss.com"></script>
 <script type="importmap">
 ${JSON.stringify(libraries)}

--- a/charm/src/index.ts
+++ b/charm/src/index.ts
@@ -12,5 +12,9 @@ export {
   generateNewRecipeVersion,
   iterate,
 } from "./iterate.ts";
-export { extractUserCode, injectUserCode } from "./iframe/static.ts";
+export {
+  extractUserCode,
+  extractVersionTag,
+  injectUserCode,
+} from "./iframe/static.ts";
 export { getIframeRecipe, type IFrameRecipe } from "./iframe/recipe.ts";

--- a/jumble/src/views/CharmDetailView.tsx
+++ b/jumble/src/views/CharmDetailView.tsx
@@ -1,6 +1,7 @@
 import {
   Charm,
   extractUserCode,
+  extractVersionTag,
   generateNewRecipeVersion,
   getIframeRecipe,
   IFrameRecipe,
@@ -825,14 +826,6 @@ const OperationTab = () => {
     </div>
   );
 };
-
-function extractVersionTag(template?: string) {
-  // Extract the template version from the HTML comment
-  const versionMatch = template?.match(
-    /<meta name="template-version" content="([^"]+)">/,
-  );
-  return versionMatch ? versionMatch[1] : null;
-}
 
 // Code Tab Component
 const CodeTab = () => {

--- a/jumble/src/views/CharmDetailView.tsx
+++ b/jumble/src/views/CharmDetailView.tsx
@@ -296,6 +296,7 @@ function useCodeEditor(
   }, [workingSrc, iframeRecipe, charm, navigate, replicaName]);
 
   return {
+    fullSrc: iframeRecipe?.src ?? "",
     workingSrc,
     setWorkingSrc,
     hasUnsavedChanges,
@@ -825,18 +826,27 @@ const OperationTab = () => {
   );
 };
 
+function extractVersionTag(template?: string) {
+  // Extract the template version from the HTML comment
+  const versionMatch = template?.match(
+    /<meta name="template-version" content="([^"]+)">/,
+  );
+  return versionMatch ? versionMatch[1] : null;
+}
+
 // Code Tab Component
 const CodeTab = () => {
   const { charmId: paramCharmId } = useParams<CharmRouteParams>();
   const { currentFocus: charm, iframeRecipe } = useCharm(paramCharmId);
   const [showFullCode, setShowFullCode] = useState(false);
 
-  const { workingSrc, setWorkingSrc, hasUnsavedChanges, saveChanges } =
+  const { fullSrc, workingSrc, setWorkingSrc, hasUnsavedChanges, saveChanges } =
     useCodeEditor(
       charm,
       iframeRecipe,
       showFullCode,
     );
+  const templateVersion = extractVersionTag(fullSrc);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -854,8 +864,11 @@ const CodeTab = () => {
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
-      <div className="p-4 flex-grow flex flex-col overflow-hidden">
-        <div className="mt-4 flex justify-start">
+      <div className="flex items-center gap-4 p-4">
+        <span className="px-2 py-1 inline rounded-full text-xs bg-gray-100 border border-gray-300">
+          <span>Template Version: {templateVersion ?? "Missing"}</span>
+        </span>
+        <div className="flex items-center px-3 py-1 rounded-full bg-gray-100 border border-gray-300">
           <input
             type="checkbox"
             id="fullCode"
@@ -863,10 +876,15 @@ const CodeTab = () => {
             onChange={(e) => setShowFullCode(e.target.checked)}
             className="border-2 border-black mr-2"
           />
-          <label htmlFor="fullCode" className="text-sm font-medium">
-            Full Code
+          <label
+            htmlFor="fullCode"
+            className="text-xs font-medium cursor-pointer"
+          >
+            Show Full Template
           </label>
         </div>
+      </div>
+      <div className="px-4 flex-grow flex flex-col overflow-hidden">
         {hasUnsavedChanges && (
           <div className="mt-4 flex justify-end">
             <button


### PR DESCRIPTION
- **Store, retrieve and display the current template "version" in the code panel**

Introduces `<meta name="template-version" content="1.0.0">` tag in template, which can be grabbed from the parent context using the new `extractVersionTag` function.

This is displayed in the UI: 
<img width="975" alt="image" src="https://github.com/user-attachments/assets/bd784d6f-9f6f-4bd7-a942-d60d50603b52" />

