### PR TITLE
window.alert() on first error in a recipe

### DIFF
--- a/jumble/src/main.tsx
+++ b/jumble/src/main.tsx
@@ -33,7 +33,8 @@ setupIframe();
 // Show an alert on the first error in a handler or lifted function.
 let errorCount = 0;
 onError((error) =>
-  !errorCount++ && globalThis.alert("Error: " + error.message)
+  !errorCount++ &&
+  globalThis.alert("Uncaught error in recipe: " + error.message)
 );
 
 createRoot(document.getElementById("root")!).render(

--- a/jumble/src/main.tsx
+++ b/jumble/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { onError } from "@commontools/runner";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import "./styles/index.css";
 import Shell from "@/views/Shell.tsx";
@@ -28,6 +29,12 @@ const ReplicaRedirect = () => {
 };
 
 setupIframe();
+
+// Show an alert on the first error in a handler or lifted function.
+let errorCount = 0;
+onError((error) =>
+  !errorCount++ && globalThis.alert("Error: " + error.message)
+);
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -3,6 +3,7 @@ export { addModuleByRef, raw } from "./module.ts";
 export {
   type Action,
   idle,
+  onError,
   run as addAction,
   unschedule as removeAction,
 } from "./scheduler.ts";


### PR DESCRIPTION
In Jumble, window.alert() on first caught error coming from a recipe. This is so we don't ignore those. Once they are being generated automatically, we'll want to use a different path.

Note: Default behavior of the scheduler is already to `console.error` any error.

Follow up to #775 