### PR TITLE
Add retry on conflict for Cell.push

### DIFF
--- a/runner/src/cell.ts
+++ b/runner/src/cell.ts
@@ -410,6 +410,13 @@ function createRegularCell<T>(
 
       // Append the new values to the array.
       diffAndUpdate(ref, [...array, ...valuesToWrite], log, cause);
+
+      // Hacky retry logic for push only. See storage.ts for details on this
+      // retry approach and what we should really be doing instead.
+      if (!ref.cell.retry) ref.cell.retry = [];
+      ref.cell.retry.push((newBaseValue: any[]) =>
+        diffAndUpdate(ref, [...newBaseValue, ...valuesToWrite], log, cause)
+      );
     },
     equals: (other: Cell<any>) =>
       JSON.stringify(self) === JSON.stringify(other),

--- a/runner/src/cell.ts
+++ b/runner/src/cell.ts
@@ -400,6 +400,13 @@ function createRegularCell<T>(
         }
       });
 
+      // Hacky retry logic for push only. See storage.ts for details on this
+      // retry approach and what we should really be doing instead.
+      if (!ref.cell.retry) ref.cell.retry = [];
+      ref.cell.retry.push((newBaseValue: any[]) =>
+        diffAndUpdate(ref, [...newBaseValue, ...valuesToWrite], log, cause)
+      );
+
       // If there is no array yet, create it first. We have to do this as a
       // separate operation, so that in the next steps [ID] is properly anchored
       // in the array.
@@ -410,13 +417,6 @@ function createRegularCell<T>(
 
       // Append the new values to the array.
       diffAndUpdate(ref, [...array, ...valuesToWrite], log, cause);
-
-      // Hacky retry logic for push only. See storage.ts for details on this
-      // retry approach and what we should really be doing instead.
-      if (!ref.cell.retry) ref.cell.retry = [];
-      ref.cell.retry.push((newBaseValue: any[]) =>
-        diffAndUpdate(ref, [...newBaseValue, ...valuesToWrite], log, cause)
-      );
     },
     equals: (other: Cell<any>) =>
       JSON.stringify(self) === JSON.stringify(other),

--- a/runner/src/doc.ts
+++ b/runner/src/doc.ts
@@ -194,6 +194,16 @@ export type DocImpl<T> = {
   ephemeral: boolean;
 
   /**
+   * Retry callbacks for the current value on cell. Will be cleared after a
+   * transaction goes through, whether it ultimately succeeds or not.
+   *
+   * See retry logic in storage.ts - this is a temporary approach, and notes
+   * there explain what should really happen. Hence the minimal possible
+   * code changes to get the current functionality.
+   */
+  retry?: ((previousValue: T) => T)[];
+
+  /**
    * Internal only: Used by builder to turn cells into proxies tied to them.
    * Useful when building a recipe that directly refers to existing cells, such
    * as a recipe created and returned by a handler.

--- a/runner/src/storage/base.ts
+++ b/runner/src/storage/base.ts
@@ -4,6 +4,8 @@ import { log } from "../storage.ts";
 export interface StorageValue<T = any> {
   value: T;
   source?: EntityId;
+  // This is used on writes to retry on conflicts.
+  retry?: ((previousValue: T) => T)[];
 }
 
 export interface StorageProvider {

--- a/runner/src/storage/volatile.ts
+++ b/runner/src/storage/volatile.ts
@@ -1,6 +1,7 @@
 import type { EntityId } from "@commontools/runner";
 import { log } from "../storage.ts";
 import { BaseStorageProvider, type StorageValue } from "./base.ts";
+import { RemoteStorageProvider } from "./remote.ts";
 
 /**
  * Volatile (in-memory) storage provider. Just for testing.
@@ -54,9 +55,40 @@ export class VolatileStorageProvider extends BaseStorageProvider {
 
   send<T = any>(
     batch: { entityId: EntityId; value: StorageValue<T> }[],
-  ): Promise<{ ok: object }> {
+    doNotNotify: boolean = false, // for testing
+  ): Promise<{ ok: object } | { error: Error }> {
     const spaceStorage = getOrCreateSpaceStorage(this.spaceName);
     const spaceSubscribers = getOrCreateSpaceSubscribers(this.spaceName);
+
+    for (const { entityId } of batch) {
+      const key = JSON.stringify(entityId);
+      const value = spaceStorage.get(key);
+      const valueString = JSON.stringify(value);
+      // Should only happen because of doNotNotify, this is used to simulate a conflict
+      if (value && this.lastValues.get(key) !== valueString) {
+        log(
+          () => [
+            "conflict volatile",
+            this.spaceName,
+            key,
+            this.lastValues.get(key),
+            valueString,
+          ],
+        );
+        this.lastValues.set(key, valueString); // Simulate storage catching up
+        return Promise.resolve({
+          // Bare bones ConflictError from RemoteStorageProvider
+          // Just what the current storage provider needs to resolve conflicts
+          error: {
+            name: "ConflictError",
+            conflict: {
+              of: RemoteStorageProvider.toEntity(entityId),
+              actual: { is: value },
+            },
+          } as unknown as Error,
+        });
+      }
+    }
 
     for (const { entityId, value } of batch) {
       const key = JSON.stringify(entityId);
@@ -65,7 +97,10 @@ export class VolatileStorageProvider extends BaseStorageProvider {
         log(() => ["send volatile", this.spaceName, key, valueString]);
         this.lastValues.set(key, valueString);
         spaceStorage.set(key, value);
-        spaceSubscribers.forEach((listener) => listener(key, value));
+        if (!doNotNotify) {
+          // For testing, this creates a conflict above
+          spaceSubscribers.forEach((listener) => listener(key, value));
+        }
       }
     }
 

--- a/runner/src/storage/volatile.ts
+++ b/runner/src/storage/volatile.ts
@@ -66,16 +66,12 @@ export class VolatileStorageProvider extends BaseStorageProvider {
       const valueString = JSON.stringify(value);
       // Should only happen because of doNotNotify, this is used to simulate a conflict
       if (value && this.lastValues.get(key) !== valueString) {
-        log(
-          () => [
-            "conflict volatile",
-            this.spaceName,
-            key,
-            this.lastValues.get(key),
-            valueString,
-          ],
-        );
-        this.lastValues.set(key, valueString); // Simulate storage catching up
+        log(() => ["conflict", key, this.lastValues.get(key), valueString]);
+
+        // Simulate storage catching up
+        this.lastValues.set(key, valueString);
+        this.notifySubscribers(key, value);
+
         return Promise.resolve({
           // Bare bones ConflictError from RemoteStorageProvider
           // Just what the current storage provider needs to resolve conflicts

--- a/runner/test/push-conflict.test.ts
+++ b/runner/test/push-conflict.test.ts
@@ -43,9 +43,57 @@ describe("Push conflict", () => {
 
     // Retry list should be empty now, since the change was applied.
     expect(!!listDoc.retry?.length).toBe(false);
+  });
 
-    // Wait for database to settle any follow-up batches, which the system will
-    // realize are all redundant. But otherwise the test suite complains.
+  it("should resolve push conflicts among other conflicts", async () => {
+    const nameDoc = getDoc<string | undefined>(
+      undefined,
+      "name",
+      "push and set",
+    );
+    const listDoc = getDoc<any[]>([], "list", "push and set");
+
+    const name = nameDoc.asCell();
+    const list = listDoc.asCell();
+
+    await storage.syncCell(name);
+    await storage.syncCell(list);
+
+    const memory = new VolatileStorageProvider("push and set");
+
+    // Update memory without notifying main storage
+    await memory.sync(nameDoc.entityId, true); // Get current value
+    await memory.sync(listDoc.entityId, true); // Get current value
+    await memory.send<any>([{
+      entityId: nameDoc.entityId,
+      value: { value: "foo" },
+    }, {
+      entityId: listDoc.entityId,
+      value: { value: [1, 2, 3] },
+    }], true); // true = do not notify main storage
+
+    let retryCalled = 0;
+    listDoc.retry = [(value) => {
+      retryCalled++;
+      return value;
+    }];
+
+    name.set("bar");
+    list.push(4);
+
+    // This is locally ahead of the db, and retry wasn't called yet.
+    expect(name.get()).toEqual("bar");
+    expect(list.get()).toEqual([4]);
+    expect(retryCalled).toEqual(0);
+
     await storage.synced();
+
+    // We successfully replayed the change on top of the db:
+    expect(name.get()).toEqual("foo");
+    expect(list.get()).toEqual([1, 2, 3, 4]);
+    expect(retryCalled).toEqual(1);
+
+    // Retry list should be empty now, since the change was applied.
+    expect(!!listDoc.retry?.length).toBe(false);
   });
 });

--- a/runner/test/push-conflict.test.ts
+++ b/runner/test/push-conflict.test.ts
@@ -10,35 +10,42 @@ storage.setSigner(await Identity.fromPassphrase("test operator"));
 
 describe("Push conflict", () => {
   it("should resolve push conflicts", async () => {
-    const charmsDoc = getDoc<any[]>([], "charms", "push conflict");
-    const charms = charmsDoc.asCell();
-    await storage.syncCell(charms);
+    const listDoc = getDoc<any[]>([], "list", "push conflict");
+    const list = listDoc.asCell();
+    await storage.syncCell(list);
 
     const memory = new VolatileStorageProvider("push conflict");
 
-    console.log("sending");
-    await memory.sync(charmsDoc.entityId, true);
+    // Update memory without notifying main storage
+    await memory.sync(listDoc.entityId, true); // Get current value
     await memory.send([{
-      entityId: charmsDoc.entityId,
+      entityId: listDoc.entityId,
       value: { value: [1, 2, 3] },
-    }], true); // Update memory without notifying
+    }], true); // true = do not notify main storage
 
     let retryCalled = false;
-    charmsDoc.retry = [(value) => {
+    listDoc.retry = [(value) => {
       retryCalled = true;
       return value;
     }];
 
-    console.log("pushing");
-    charms.push(4);
-    expect(charms.get()).toEqual([4]);
+    list.push(4);
+
+    // This is locally ahead of the db, and retry wasn't called yet.
+    expect(list.get()).toEqual([4]);
+    expect(retryCalled).toEqual(false);
 
     await storage.synced();
 
+    // We successfully replayed the change on top of the db:
+    expect(list.get()).toEqual([1, 2, 3, 4]);
     expect(retryCalled).toEqual(true);
-    expect(charms.get()).toEqual([1, 2, 3, 4]);
 
-    // Clears timers
+    // Retry list should be empty now, since the change was applied.
+    expect(!!listDoc.retry?.length).toBe(false);
+
+    // Wait for database to settle any follow-up batches, which the system will
+    // realize are all redundant. But otherwise the test suite complains.
     await storage.synced();
   });
 });

--- a/runner/test/push-conflict.test.ts
+++ b/runner/test/push-conflict.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { storage } from "../src/storage.ts";
+import { getDoc } from "@commontools/runner";
+import { VolatileStorageProvider } from "../src/storage/volatile.ts";
+import { Identity } from "@commontools/identity";
+
+storage.setRemoteStorage(new URL(`volatile:`));
+storage.setSigner(await Identity.fromPassphrase("test operator"));
+
+describe("Push conflict", () => {
+  it("should resolve push conflicts", async () => {
+    const charmsDoc = getDoc<any[]>([], "charms", "push conflict");
+    const charms = charmsDoc.asCell();
+    await storage.syncCell(charms);
+
+    const memory = new VolatileStorageProvider("push conflict");
+
+    console.log("sending");
+    await memory.sync(charmsDoc.entityId, true);
+    await memory.send([{
+      entityId: charmsDoc.entityId,
+      value: { value: [1, 2, 3] },
+    }], true); // Update memory without notifying
+
+    let retryCalled = false;
+    charmsDoc.retry = [(value) => {
+      retryCalled = true;
+      return value;
+    }];
+
+    console.log("pushing");
+    charms.push(4);
+    expect(charms.get()).toEqual([4]);
+
+    await storage.synced();
+
+    expect(retryCalled).toEqual(true);
+    expect(charms.get()).toEqual([1, 2, 3, 4]);
+
+    // Clears timers
+    await storage.synced();
+  });
+});


### PR DESCRIPTION
This is a minimal-changes-to-the-code version of adding retry for Cell.push, which is what we use to add charms to the charms list. It's breaking layers of abstractions, so this is rather temporary until we've refactored storage to a point where transactions are a unified concept from scheduler to remote storage provider.

Tests implemented by faking a conflict in volatile storage provider.

Also simplified the logic for waiting for a batch to finish.