### PR TITLE
feat: Terminate frames from the main thread after failing health check

### DIFF
--- a/iframe-sandbox/src/ipc.ts
+++ b/iframe-sandbox/src/ipc.ts
@@ -28,8 +28,6 @@ export enum IPCHostMessageType {
   LoadDocument = "load-document",
   // Host instructing guest to pass through a `HostMessage`.
   Passthrough = "passthrough",
-  // Host instructing guest to remove inner content (due to failed HealthCheck)
-  Freeze = "freeze",
 }
 
 /**
@@ -39,8 +37,7 @@ export enum IPCHostMessageType {
 export type IPCHostMessage =
   | { id: any; type: IPCHostMessageType.Init }
   | { id: any; type: IPCHostMessageType.LoadDocument; data: string }
-  | { id: any; type: IPCHostMessageType.Passthrough; data: HostMessage }
-  | { id: any; type: IPCHostMessageType.Freeze };
+  | { id: any; type: IPCHostMessageType.Passthrough; data: HostMessage };
 
 export enum IPCGuestMessageType {
   // Guest alerting the host that it is ready.

--- a/iframe-sandbox/src/outer-frame.ts
+++ b/iframe-sandbox/src/outer-frame.ts
@@ -25,27 +25,12 @@ iframe {
   width: 100vw;
   border: none;
 }
-
-body[frozen] iframe {
-  display: none; 
-}
-#frozen-message {
-  display: none;
-  font-family: monospace;
-  margin: 40% auto;
-  text-align: center;
-  font-size: 20px;
-}
-body[frozen] #frozen-message {
-  display: block; 
-}
   <\/style>
 <\/head>
 <body>
 <iframe
   allow="clipboard-write"
   sandbox="allow-scripts"><\/iframe>
-<div id="frozen-message">🤨 Charm crashed! 🤨</div>
 <script>
 const iframe = document.querySelector("iframe");
 const HOST_ORIGIN = "${HOST_ORIGIN}";
@@ -91,16 +76,11 @@ function onMessage(e) {
         return;
       }
       case "load-document": {
-        document.body.removeAttribute("frozen");
         iframe.srcdoc = e.data.data;
         return;
       }
       case "passthrough": {
         toInner(e.data.data);
-        return;
-      }
-      case "freeze": {
-        document.body.setAttribute("frozen", "");
         return;
       }
     }


### PR DESCRIPTION
Further investigation into iframe process separation:

* Chrome/Safari put null origin frames into their own process (heuristically; this may not always be true e.g. on a resource-constrained/mobile device)
* Firefox does not
* Using a separate origin for the outer frame *does* force process separation on browsers (including Firefox)
* Testing by clicking the color-changing title bar while churning in a frame

Current plan:
* Move terminating frames back to the main thread (from the outer frame) so that if a frame is hanging on e.g. 10s of processing, the main thread can terminate it explicitly while still being blocked e.g. after 2-3s.
* If frames are not separate (Firefox), the main thread must wait a moment for frame churn to stop before terminating (e.g. after 10s of processing, well past the deadline)
* The extra complexity of routing or another domain host for the frame, needing to maintain CSP rules for top domain, and work across all the ways charms can be run does not currently seem worth the cost to force Firefox to use separate processes for now
