### PR TITLE
Fix #840: InvalidCharacterError: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.

### DIFF
--- a/jumble/src/utils/credentials.ts
+++ b/jumble/src/utils/credentials.ts
@@ -41,10 +41,24 @@ export function getPublicKeyCredentialDescriptor(
   storedCredential: StoredCredential | null,
 ): PublicKeyCredentialDescriptor | undefined {
   if (storedCredential?.method === "passkey") {
-    return {
-      id: Uint8Array.from(atob(storedCredential.id), (c) => c.charCodeAt(0)),
-      type: "public-key" as PublicKeyCredentialType,
-    };
+    try {
+      // Check if the string is valid base64
+      const isValidBase64 = /^[A-Za-z0-9+/=]*$/.test(storedCredential.id);
+      if (!isValidBase64) {
+        console.warn("Invalid base64 format in stored credential ID");
+        return undefined;
+      }
+      
+      return {
+        id: Uint8Array.from(atob(storedCredential.id), (c) => c.charCodeAt(0)),
+        type: "public-key" as PublicKeyCredentialType,
+      };
+    } catch (error) {
+      console.error("Error creating credential descriptor:", error);
+      // Clear the invalid credential to prevent future errors
+      clearStoredCredential();
+      return undefined;
+    }
   }
   return undefined;
 }

--- a/jumble/src/utils/credentials.ts
+++ b/jumble/src/utils/credentials.ts
@@ -10,6 +10,10 @@ export interface StoredCredential {
   method: AuthMethod;
 }
 
+export function isValidBase64(str: string): boolean {
+  return /^[A-Za-z0-9+/=]*$/.test(str);
+}
+
 export function getStoredCredential(): StoredCredential | null {
   const stored = localStorage.getItem("storedCredential");
   return stored ? JSON.parse(stored) : null;
@@ -43,8 +47,7 @@ export function getPublicKeyCredentialDescriptor(
   if (storedCredential?.method === "passkey") {
     try {
       // Check if the string is valid base64
-      const isValidBase64 = /^[A-Za-z0-9+/=]*$/.test(storedCredential.id);
-      if (!isValidBase64) {
+      if (!isValidBase64(storedCredential.id)) {
         console.warn("Invalid base64 format in stored credential ID");
         return undefined;
       }

--- a/jumble/src/views/AuthenticationView.tsx
+++ b/jumble/src/views/AuthenticationView.tsx
@@ -208,9 +208,17 @@ export function AuthenticationView() {
 
           // Store credentials before completing authentication
           if (!storedCredential) {
-            const storedCred = createPasskeyCredential(passkey.id());
-            saveCredential(storedCred);
-            setStoredCredential(storedCred);
+            // Ensure the ID is properly base64 encoded
+            const id = passkey.id();
+            // Verify it's valid base64 before storing
+            const isValidBase64 = /^[A-Za-z0-9+/=]*$/.test(id);
+            if (isValidBase64) {
+              const storedCred = createPasskeyCredential(id);
+              saveCredential(storedCred);
+              setStoredCredential(storedCred);
+            } else {
+              console.warn("Skipping credential storage: ID is not valid base64");
+            }
           }
 
           return passkey;

--- a/jumble/src/views/AuthenticationView.tsx
+++ b/jumble/src/views/AuthenticationView.tsx
@@ -21,6 +21,7 @@ import {
   createPassphraseCredential,
   getPublicKeyCredentialDescriptor,
   getStoredCredential,
+  isValidBase64,
   saveCredential,
   type StoredCredential,
 } from "@/utils/credentials.ts";
@@ -211,8 +212,7 @@ export function AuthenticationView() {
             // Ensure the ID is properly base64 encoded
             const id = passkey.id();
             // Verify it's valid base64 before storing
-            const isValidBase64 = /^[A-Za-z0-9+/=]*$/.test(id);
-            if (isValidBase64) {
+            if (isValidBase64(id)) {
               const storedCred = createPasskeyCredential(id);
               saveCredential(storedCred);
               setStoredCredential(storedCred);


### PR DESCRIPTION

Fixes #840

## Fix for InvalidCharacterError in WebAuthn Credential Handling

### What was fixed
- Fixed issue #840 where invalid base64 encoding in credential IDs caused an uncaught `InvalidCharacterError` during `atob()` execution
- The error occurred during WebAuthn passkey authentication when attempting to process malformed credential data

### How it was fixed
- Added proper validation of base64-encoded credential IDs before attempting to decode them
- Implemented a regex check (`/^[A-Za-z0-9+/=]*$/`) to verify strings are valid base64 format
- Added error handling with try/catch around credential conversion operations
- Implemented fallback behavior to clear invalid credentials from storage
- Added validation before storing new credential IDs to prevent saving malformed data

### Technical details
- Modified `getPublicKeyCredentialDescriptor()` to validate and safely handle malformed base64 inputs
- Added validation in `AuthenticationView.tsx` before storing passkey credentials
- Introduced graceful error handling to ensure the application can recover from invalid credential states
- Used console.warn/error for logging validation failures to aid debugging

### Testing considerations
- Verified fix by testing with known valid and invalid credential formats
- Ensure authentication flow works correctly after clearing invalid credentials
- Confirm proper fallback behavior when encountering malformed base64 data


This PR was created with Claude Code assistance.
