### PR TITLE
feat: Add generatePkcs8, fromPkcs8 static methods on Identity

### DIFF
--- a/identity/src/ed25519/index.ts
+++ b/identity/src/ed25519/index.ts
@@ -15,6 +15,7 @@ import {
 import { NobleEd25519Signer, NobleEd25519Verifier } from "./noble.ts";
 import * as bip39 from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english";
+import { generateEd25519Pkcs8, pkcs8ToEd25519Raw } from "./utils.ts";
 
 // Platform-specific implementation of an ED25519 Keypair.
 //
@@ -68,6 +69,17 @@ export class Ed25519Signer<ID extends DIDKey> implements Signer<ID> {
   > {
     const mnemonic = bip39.generateMnemonic(wordlist, 256);
     return [await Ed25519Signer.fromMnemonic(mnemonic), mnemonic];
+  }
+
+  static generatePkcs8<ID extends DIDKey>(): Uint8Array {
+    return generateEd25519Pkcs8();
+  }
+
+  static async fromPkcs8<ID extends DIDKey>(
+    pkcs8: Uint8Array,
+  ): Promise<Ed25519Signer<ID>> {
+    const raw = pkcs8ToEd25519Raw(pkcs8);
+    return await Ed25519Signer.fromRaw(raw);
   }
 
   static async fromMnemonic<ID extends DIDKey>(

--- a/identity/src/ed25519/native.ts
+++ b/identity/src/ed25519/native.ts
@@ -4,6 +4,7 @@ import {
   bytesToDid,
   didToBytes,
   ED25519_ALG,
+  ed25519RawToPkcs8,
 } from "./utils.ts";
 import {
   AsBytes,
@@ -201,38 +202,10 @@ export class NativeEd25519Verifier<ID extends DIDKey> implements Verifier<ID> {
   }
 }
 
-// 0x302e020100300506032b657004220420
-// via https://stackoverflow.com/a/79135112
-const PKCS8_PREFIX = new Uint8Array([
-  48,
-  46,
-  2,
-  1,
-  0,
-  48,
-  5,
-  6,
-  3,
-  43,
-  101,
-  112,
-  4,
-  34,
-  4,
-  32,
-]);
-
-// Signer Ed25519 keys cannot be imported into Subtle Crypto in "raw" format.
-// Convert to "pkcs8" before doing so.
-//
-//
-// @AUDIT
-// via https://stackoverflow.com/a/79135112
-function ed25519RawToPkcs8(rawSignerKey: Uint8Array): Uint8Array {
-  return new Uint8Array([...PKCS8_PREFIX, ...rawSignerKey]);
-}
-
 async function didFromPublicKey(publicKey: CryptoKey): Promise<DIDKey> {
-  const rawPublicKey = await globalThis.crypto.subtle.exportKey("raw", publicKey);
+  const rawPublicKey = await globalThis.crypto.subtle.exportKey(
+    "raw",
+    publicKey,
+  );
   return bytesToDid(new Uint8Array(rawPublicKey));
 }

--- a/identity/src/ed25519/utils.ts
+++ b/identity/src/ed25519/utils.ts
@@ -1,6 +1,7 @@
 import { base58btc } from "multiformats/bases/base58";
 import { varint } from "multiformats";
 import { DIDKey } from "../interface.ts";
+import * as ed25519 from "@noble/ed25519";
 
 export const ED25519_ALG = "Ed25519";
 const ED25519_CODE = 0xed;
@@ -32,6 +33,24 @@ const PKCS8_PREFIX = new Uint8Array([
   32,
 ]);
 
+function arrayEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+export function pkcs8ToEd25519Raw(pkcs8: Uint8Array): Uint8Array {
+  if (pkcs8.length !== (PKCS8_PREFIX.length + ED25519_PUB_KEY_RAW_SIZE)) {
+    throw new Error("Invalid key length.");
+  }
+  if (!arrayEqual(pkcs8.subarray(0, 16), PKCS8_PREFIX)) {
+    throw new Error("Invalid key prefix.");
+  }
+  return new Uint8Array(pkcs8.subarray(16, 48));
+}
+
 // Private Ed25519 keys cannot be imported into Subtle Crypto in "raw" format.
 // Convert to "pkcs8" before doing so.
 //
@@ -39,6 +58,11 @@ const PKCS8_PREFIX = new Uint8Array([
 // via https://stackoverflow.com/a/79135112
 export function ed25519RawToPkcs8(rawPrivateKey: Uint8Array): Uint8Array {
   return new Uint8Array([...PKCS8_PREFIX, ...rawPrivateKey]);
+}
+
+// Generates a new random key in pkcs8 format.
+export function generateEd25519Pkcs8(): Uint8Array {
+  return ed25519RawToPkcs8(ed25519.utils.randomPrivateKey());
 }
 
 // Convert public key bytes into a `did:key:z...`.

--- a/identity/src/identity.ts
+++ b/identity/src/identity.ts
@@ -67,6 +67,24 @@ export class Identity<ID extends DIDKey = DIDKey> implements Signer<ID> {
     return [new Identity(signer), mnemonic];
   }
 
+  // Generate a new keypair in PKCS8 form.
+  //
+  // Due to hiding access to private key material
+  // in the JS environment (via WebCrypto), we cannot
+  // simply "export" existing keys. If a key should
+  // be stored as PKCS8, generate it with this method.
+  static async generatePkcs8(): Promise<Uint8Array> {
+    // Not a promise, but force it for consistent interface
+    return await Ed25519Signer.generatePkcs8();
+  }
+
+  static async fromPkcs8<ID extends DIDKey>(
+    pkcs8: Uint8Array,
+  ): Promise<Identity<ID>> {
+    const signer = await Ed25519Signer.fromPkcs8<ID>(pkcs8);
+    return new Identity(signer);
+  }
+
   static async fromMnemonic<ID extends DIDKey>(
     mnemonic: string,
   ): Promise<Identity<ID>> {

--- a/identity/src/key-store.ts
+++ b/identity/src/key-store.ts
@@ -80,11 +80,11 @@ class DB {
   ) {
     const req = globalThis.indexedDB.open(dbName, dbVersion);
     once(req, "upgradeneeded", onUpgrade);
-    once(req, "blocked", e => {
+    once(req, "blocked", (e) => {
       console.log("KeyStore: Blocked");
     });
     const db = await asyncWrap(req);
-    once(db, "versionchange", e => {
+    once(db, "versionchange", (e) => {
       console.log("KeyStore: VersionChange", e.oldVersion, e.newVersion);
     });
     return new DB(db);

--- a/identity/test/identity.test.ts
+++ b/identity/test/identity.test.ts
@@ -7,3 +7,18 @@ Deno.test("Identity generates mnemonics", async () => {
   const identity2 = await Identity.fromMnemonic(mnemonic);
   assert(did, identity2.verifier.did());
 });
+
+Deno.test("Can generate into/read from PKCS8", async () => {
+  const pkcs8 = await Identity.generatePkcs8();
+  const identity = await Identity.fromPkcs8(pkcs8);
+  assert(identity.verifier.did());
+  // Change a byte, should be invalid pkcs8
+  pkcs8[1] = 0;
+  let throws = false;
+  try {
+    const identity = await Identity.fromPkcs8(pkcs8);
+  } catch (e) {
+    throws = true;
+  }
+  assert(throws, "Identity.fromPkcs8() throws with invalid pkcs8");
+});


### PR DESCRIPTION
Introduce new methods for generating PKCS8 format keys as direct access to private key material is disallowed, in service of #783