### PR TITLE
Fixing honoclient usage

### DIFF
--- a/toolshed/env.ts
+++ b/toolshed/env.ts
@@ -95,6 +95,9 @@ const EnvSchema = z.object({
 
   // Identity signer passphrase for storage authentication
   IDENTITY_PASSPHRASE: z.string().default("implicit trust"),
+
+  // URL of the toolshed API, for self-referring requests
+  TOOLSHED_API_URL: z.string().default("http://localhost:8000"),
 });
 
 export type env = z.infer<typeof EnvSchema>;

--- a/toolshed/lib/llm.ts
+++ b/toolshed/lib/llm.ts
@@ -1,11 +1,11 @@
 import { AppType } from "@/app.ts";
 import { hc } from "@hono/hono/client";
-
+import env from "@/env.ts";
 // NOTE(jake): Ideally this would be exposed via the hono client, but I wasn't
 // able to get it all wired up. Importing the route definition is fine for now.
 import type { GetModelsRouteQueryParams } from "@/routes/ai/llm/llm.routes.ts";
 
-const client = hc<AppType>("http://localhost:8000/");
+const client = hc<AppType>(env.TOOLSHED_API_URL);
 
 export async function listAvailableModels({
   capability,

--- a/toolshed/routes/ai/spell/behavior/effects.ts
+++ b/toolshed/routes/ai/spell/behavior/effects.ts
@@ -3,7 +3,7 @@ import { AppType } from "@/app.ts";
 import { Consumer } from "@commontools/memory";
 import { Identity } from "@commontools/identity";
 import { Memory, memory } from "@/routes/storage/memory.ts";
-
+import env from "@/env.ts";
 // Create a spellbook consumer.
 const spellbook = Consumer.open({
   // Principal is currently derived from `sha256("spellbook")`
@@ -13,7 +13,7 @@ const spellbook = Consumer.open({
   session: memory.session(),
 });
 
-const client = hc<AppType>("http://localhost:8000/");
+const client = hc<AppType>(env.TOOLSHED_API_URL);
 export interface BlobOptions {
   allWithData?: boolean;
   prefix?: string;

--- a/toolshed/routes/hc_example/index.ts
+++ b/toolshed/routes/hc_example/index.ts
@@ -7,7 +7,7 @@ import { createRouter } from "@/lib/create-app.ts";
 import { HealthResponseSchema } from "@/routes/health/health.handlers.ts";
 import { type AppType } from "@/app.ts";
 import type { AppRouteHandler } from "@/lib/types.ts";
-
+import env from "@/env.ts";
 const tags = ["Health RPC Client"];
 
 export const index = createRoute({
@@ -27,7 +27,7 @@ export const indexHandler: AppRouteHandler<typeof index> = async (c) => {
   // calls to endpoints within the application.
 
   // Create a client that points to the server. The URL would change for production.
-  const client = hc<AppType>("http://localhost:8000/");
+  const client = hc<AppType>(env.TOOLSHED_API_URL);
 
   // Call the health endpoint.
   const res = await client._health.$get();

--- a/toolshed/routes/spellbook/spellbook.handlers.ts
+++ b/toolshed/routes/spellbook/spellbook.handlers.ts
@@ -13,7 +13,7 @@ import { hc } from "@hono/hono/client";
 import { type AppType } from "@/app.ts";
 import env from "@/env.ts";
 
-const client = hc<AppType>("http://localhost:8000");
+const client = hc<AppType>(env.TOOLSHED_API_URL);
 
 interface SpellData {
   spellbookTitle?: string;
@@ -140,7 +140,7 @@ export const createSpellHandler: AppRouteHandler<typeof createSpell> = async (
 
     return c.json({ success: true });
   } catch (error) {
-    logger.error({ error }, "Error creating spell");
+    logger.error(error, "Error creating spell");
     return c.json({ success: false }, 500);
   }
 };
@@ -172,7 +172,7 @@ export const listSpellsHandler: AppRouteHandler<typeof listSpells> = async (
 
     return c.json({ spells });
   } catch (error) {
-    logger.error({ error }, "Error listing spells");
+    logger.error(error, "Error listing spells");
     return c.json({ spells: [] }, 500);
   }
 };
@@ -196,7 +196,7 @@ export const getSpellHandler: AppRouteHandler<typeof getSpell> = async (c) => {
 
     return c.json(spell);
   } catch (error) {
-    logger.error({ error }, "Error getting spell");
+    logger.error(error, "Error getting spell");
     return c.json({ error: "Internal server error" }, 500);
   }
 };
@@ -262,7 +262,7 @@ export const toggleLikeHandler: AppRouteHandler<typeof toggleLike> = async (
       isLiked: !wasLiked,
     });
   } catch (error) {
-    logger.error({ error }, "Error toggling spell like");
+    logger.error(error, "Error toggling spell like");
     return c.json({
       success: false,
       likes: [],
@@ -346,7 +346,7 @@ export const createCommentHandler: AppRouteHandler<typeof createComment> =
         comment: newComment,
       });
     } catch (error) {
-      logger.error({ error }, "Error creating comment");
+      logger.error(error, "Error creating comment");
       return c.json({
         success: false,
         error: "Internal server error",
@@ -399,7 +399,7 @@ export const shareSpellHandler: AppRouteHandler<typeof shareSpell> = async (
       shares: currentShares + 1,
     });
   } catch (error) {
-    logger.error({ error }, "Error sharing spell");
+    logger.error(error, "Error sharing spell");
     return c.json({
       success: false,
       shares: 0,
@@ -450,7 +450,7 @@ export const trackRunHandler: AppRouteHandler<typeof trackRun> = async (c) => {
       runs: currentRuns + 1,
     });
   } catch (error) {
-    logger.error({ error }, "Error tracking spell run");
+    logger.error(error, "Error tracking spell run");
     return c.json({
       success: false,
       runs: 0,
@@ -485,7 +485,7 @@ export const deleteSpellHandler: AppRouteHandler<typeof deleteSpell> = async (
 
     return c.json({ success: true });
   } catch (error) {
-    logger.error({ error }, "Error deleting spell");
+    logger.error(error, "Error deleting spell");
     return c.json({ success: false }, 500);
   }
 };


### PR DESCRIPTION
This recently broke with a deployment change, we no longer have localhost:8000 in production, so we need a new way to define the api url for internal request routing.