### PR TITLE
coarse schema check on write from iframe

### DIFF
--- a/jumble/src/iframe-ctx.ts
+++ b/jumble/src/iframe-ctx.ts
@@ -171,10 +171,27 @@ export const setupIframe = () =>
         console.log("write", key, value, JSON.stringify(value));
         if (isCell(context)) {
           addCommonIDfromObjectID(value);
-          if (isObj(value) && !Array.isArray(value)) {
+          const currentValue = context.key(key).get();
+          const currentValueType = currentValue !== undefined
+            ? Array.isArray(currentValue) ? "array" : typeof currentValue
+            : undefined;
+          const type = context.key(key).schema?.type ??
+            currentValueType ?? typeof value;
+          if (type === "object" && isObj(value) && !Array.isArray(value)) {
             context.key(key).update(value);
-          } else {
+          } else if (
+            (type === "array" && Array.isArray(value)) ||
+            (type === "integer" && typeof value === "number") ||
+            (type === typeof value as string)
+          ) {
             context.key(key).set(value);
+          } else {
+            console.warn(
+              "write skipped due to type",
+              type,
+              value,
+              context.key(key).schema,
+            );
           }
         } else {
           context[key] = value;


### PR DESCRIPTION
The iframe might send `null` or `undefined` before getting data, which might explain #845.

We'll now catch this by doing a coarse schema check on writes, basically just making sure that `null` can't overwrite an object, etc.

If there is a schema, the schema is used to derive the desired type. Otherwise the current value in the charm sets the type, unless it's undefined, then anything is allowed.
