### PR TITLE
Properly await async handlers and lifts

### DIFF
--- a/runner/src/scheduler.ts
+++ b/runner/src/scheduler.ts
@@ -203,11 +203,14 @@ async function execute() {
   const handler = eventQueue.shift();
   if (handler) {
     try {
-      await Promise.resolve(handler()).catch((error) => {
+      running = Promise.resolve(handler()).catch((error) => {
         handleError(error as Error, handler);
       });
+      await running;
     } catch (error) {
       handleError(error as Error, handler);
+    } finally {
+      running = undefined;
     }
   }
 


### PR DESCRIPTION
`await idle()` now waits for pending async handlers and lifted functions to finish

A dependency for #787 