### PR TITLE
Add markdown conversion to gmail recipe

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -83,6 +83,7 @@
     "merkle-reference": "npm:merkle-reference@^2.0.1",
     "multiformats": "npm:multiformats@^13.3.2",
     "react": "npm:react@^18.3.1",
+    "turndown": "npm:turndown@^7.1.2",
     "typescript": "npm:typescript",
     "vite": "npm:vite@^6.2.1",
     "zod-to-json-schema": "npm:zod-to-json-schema@^3.24.1",

--- a/deno.lock
+++ b/deno.lock
@@ -131,6 +131,7 @@
     "npm:tailwindcss@^4.0.6": "4.0.13",
     "npm:three@0.173": "0.173.0",
     "npm:ts-node@^10.9.2": "10.9.2_@types+node@22.12.0_typescript@5.8.2",
+    "npm:turndown@^7.1.2": "7.2.0",
     "npm:typescript@*": "5.8.2",
     "npm:typescript@^5.6.2": "5.8.2",
     "npm:vite@*": "6.2.1_@types+node@22.12.0",
@@ -1541,6 +1542,9 @@
     },
     "@mediapipe/tasks-vision@0.10.17": {
       "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg=="
+    },
+    "@mixmark-io/domino@2.2.0": {
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
     },
     "@monogrid/gainmap-js@3.1.0_three@0.173.0": {
       "integrity": "sha512-Obb0/gEd/HReTlg8ttaYk+0m62gQJmCblMOjHSMHRrBP2zdfKMHLCRbh/6ex9fSUJMKdjjIEiohwkbGD3wj2Nw==",
@@ -6554,6 +6558,12 @@
     "turbo-stream@2.4.0": {
       "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g=="
     },
+    "turndown@7.2.0": {
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
+      "dependencies": [
+        "@mixmark-io/domino"
+      ]
+    },
     "type-fest@0.21.3": {
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
     },
@@ -6996,6 +7006,7 @@
       "npm:merkle-reference@^2.0.1",
       "npm:multiformats@^13.3.2",
       "npm:react@^18.3.1",
+      "npm:turndown@^7.1.2",
       "npm:typescript@*",
       "npm:vite@^6.2.1",
       "npm:zod-to-json-schema@^3.24.1",

--- a/recipes/gmail.tsx
+++ b/recipes/gmail.tsx
@@ -24,17 +24,59 @@ const turndown = new TurndownService({
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const EmailProperties = {
-  id: { type: "string" },
-  threadId: { type: "string" },
-  labelIds: { type: "array", items: { type: "string" } },
-  snippet: { type: "string" },
-  subject: { type: "string" },
-  from: { type: "string" },
-  date: { type: "string" },
-  to: { type: "string" },
-  plainText: { type: "string" },
-  htmlContent: { type: "string" },
-  markdownContent: { type: "string" },
+  id: {
+    type: "string",
+    title: "Email ID",
+    description: "Unique identifier for the email",
+  },
+  threadId: {
+    type: "string",
+    title: "Thread ID",
+    description: "Identifier for the email thread",
+  },
+  labelIds: {
+    type: "array",
+    items: { type: "string" },
+    title: "Labels",
+    description: "Gmail labels assigned to the email",
+  },
+  snippet: {
+    type: "string",
+    title: "Snippet",
+    description: "Brief preview of the email content",
+  },
+  subject: {
+    type: "string",
+    title: "Subject",
+    description: "Email subject line",
+  },
+  from: {
+    type: "string",
+    title: "From",
+    description: "Sender's email address",
+  },
+  date: {
+    type: "string",
+    title: "Date",
+    description: "Date and time when the email was sent",
+  },
+  to: { type: "string", title: "To", description: "Recipient's email address" },
+  plainText: {
+    type: "string",
+    title: "Plain Text Content",
+    description: "Email content in plain text format (often empty)",
+  },
+  htmlContent: {
+    type: "string",
+    title: "HTML Content",
+    description: "Email content in HTML format",
+  },
+  markdownContent: {
+    type: "string",
+    title: "Markdown Content",
+    description:
+      "Email content converted to Markdown format. Often best for processing email contents.",
+  },
 } as const;
 
 const EmailSchema = {

--- a/recipes/gmail.tsx
+++ b/recipes/gmail.tsx
@@ -21,6 +21,11 @@ const turndown = new TurndownService({
   emDelimiter: "*",
 });
 
+turndown.addRule("removeStyleTags", {
+  filter: ["style"],
+  replacement: "",
+});
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const EmailProperties = {

--- a/runner/src/local-build.ts
+++ b/runner/src/local-build.ts
@@ -4,6 +4,7 @@ import * as commonBuilder from "@commontools/builder";
 import * as zod from "zod";
 import * as zodToJsonSchema from "zod-to-json-schema";
 import * as merkleReference from "merkle-reference";
+import * as turndown from "turndown";
 
 let DOMParser: any;
 
@@ -124,6 +125,8 @@ export const tsToExports = async (
         return merkleReference;
       case "zod-to-json-schema":
         return zodToJsonSchema;
+      case "turndown":
+        return turndown;
       default:
         throw new Error(`Module not found: ${moduleName}`);
     }

--- a/runner/src/local-build.ts
+++ b/runner/src/local-build.ts
@@ -4,7 +4,7 @@ import * as commonBuilder from "@commontools/builder";
 import * as zod from "zod";
 import * as zodToJsonSchema from "zod-to-json-schema";
 import * as merkleReference from "merkle-reference";
-import * as turndown from "turndown";
+import turndown from "turndown";
 
 let DOMParser: any;
 


### PR DESCRIPTION
Generates markdown from the html context, falling back to plain text

Should help with #866 

Open:
- [x] seems to include styles right now, just pasting them into the body
- [ ] should we escape plain text? let's see what wrapping it in `<pre>` would do?
- [ ] ideally some heuristic to strip invisible pixels and decorative images, not sure how easy that is. not important.
