### PR TITLE
Fix #728: Exclude trash items from @mentions and prioritize pinned charms

### DIFF
--- a/jumble/src/components/CommandCenter.tsx
+++ b/jumble/src/components/CommandCenter.tsx
@@ -22,7 +22,7 @@ import { usePreferredLanguageModel } from "@/contexts/LanguageModelContext.tsx";
 import { TranscribeInput } from "./TranscribeCommand.tsx";
 import { useBackgroundTasks } from "@/contexts/BackgroundTaskContext.tsx";
 import { Composer, ComposerSubmitBar } from "@/components/Composer.tsx";
-import { charmId } from "@/utils/charms.ts";
+import { charmId, getMentionableCharms } from "@/utils/charms.ts";
 import { formatPromptWithMentions } from "@/utils/format.ts";
 import { NAME } from "@commontools/builder";
 import {
@@ -199,13 +199,14 @@ export function useCharmMentions() {
   useEffect(() => {
     const fetchCharmMentions = async () => {
       try {
-        const charms = charmManager.getCharms();
-        await charmManager.sync(charms);
+        // Get mentionable charms - filtered to exclude trash and prioritize pinned
+        const mentionableCharms = await getMentionableCharms(charmManager);
 
-        const mentions = charms.get().map((charm: any) => {
+        // Convert to the format needed for mentions
+        const mentions = mentionableCharms.map((charm: any) => {
           const data = charm.get();
           const name = data?.[NAME] ?? "Untitled";
-          const id = charmId(charm.entityId!)!;
+          const id = charmId(charm)!;
           return {
             id,
             name: `${name} (#${id.slice(-4)})`,

--- a/jumble/src/components/CommandCenter.tsx
+++ b/jumble/src/components/CommandCenter.tsx
@@ -203,15 +203,19 @@ export function useCharmMentions() {
         const mentionableCharms = await getMentionableCharms(charmManager);
 
         // Convert to the format needed for mentions
-        const mentions = mentionableCharms.map((charm: any) => {
+        const mentions = mentionableCharms.map((charm) => {
           const data = charm.get();
           const name = data?.[NAME] ?? "Untitled";
-          const id = charmId(charm)!;
+          const id = charmId(charm);
+          if (!id) {
+            console.warn(`Warning: Charm without ID found`, charm);
+            return null;
+          }
           return {
             id,
             name: `${name} (#${id.slice(-4)})`,
           };
-        });
+        }).filter((mention): mention is {id: string, name: string} => mention !== null);
 
         setCharmMentions(mentions);
       } catch (error) {
@@ -359,10 +363,15 @@ export function CommandCenter() {
     const handleEditRecipe = (e: KeyboardEvent) => {
       if (e.key === "i" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
+        const editRecipeCommand = allCommands.find((cmd) => cmd.id === "edit-recipe");
+        if (!editRecipeCommand) {
+          console.warn("Edit recipe command not found");
+          return;
+        }
         setOpen(true);
         setMode({
           type: "input",
-          command: allCommands.find((cmd) => cmd.id === "edit-recipe")!,
+          command: editRecipeCommand,
           placeholder: "What would you like to change?",
         });
       }
@@ -370,10 +379,15 @@ export function CommandCenter() {
 
     const handleEditRecipeEvent = () => {
       if (focusedCharmId) {
+        const editRecipeCommand = allCommands.find((cmd) => cmd.id === "edit-recipe");
+        if (!editRecipeCommand) {
+          console.warn("Edit recipe command not found");
+          return;
+        }
         setOpen(true);
         setMode({
           type: "input",
-          command: allCommands.find((cmd) => cmd.id === "edit-recipe")!,
+          command: editRecipeCommand,
           placeholder: "What would you like to change?",
         });
       }
@@ -503,10 +517,12 @@ export function CommandCenter() {
           });
           break;
         case "select":
+          // The select mode options should be provided by the command handler
+          // since the SelectCommandItem interface doesn't have an options property
           setMode({
             type: "select",
             command: cmd,
-            options: [], // You'll need to provide the actual options here
+            options: [], // Options will be provided when the command is executed
           });
           break;
         case "transcribe":

--- a/jumble/src/utils/charms.ts
+++ b/jumble/src/utils/charms.ts
@@ -1,7 +1,57 @@
-import { type Charm } from "@commontools/charm";
-import { getEntityId } from "@commontools/runner";
+import { type Charm, CharmManager } from "@commontools/charm";
+import { Cell, getEntityId } from "@commontools/runner";
+import { NAME } from "@commontools/builder";
 
 export function charmId(charm: Charm): string | undefined {
   const id = getEntityId(charm);
   return id ? id["/"] : undefined;
+}
+
+/**
+ * Gets mentionable charms by filtering out trash and prioritizing pinned charms
+ * @param charmManager The charm manager instance
+ * @returns Promise that resolves to an array of mentionable charms (filtered out trash and pinned first)
+ */
+export async function getMentionableCharms(charmManager: CharmManager): Promise<Cell<Charm>[]> {
+  // Sync all collections to ensure we have the latest data
+  await Promise.all([
+    charmManager.sync(charmManager.getCharms()),
+    charmManager.sync(charmManager.getPinned()),
+    charmManager.sync(charmManager.getTrash())
+  ]);
+  
+  // Get all collections
+  const allCharms = charmManager.getCharms().get();
+  const pinnedCharms = charmManager.getPinned().get();
+  const trashedCharms = charmManager.getTrash().get();
+  
+  // Create a set of trashed charm IDs for quick lookup
+  const trashedIds = new Set(
+    trashedCharms.map(charm => charmId(charm))
+  );
+  
+  // Create a set of pinned charm IDs for quick lookup
+  const pinnedIds = new Set(
+    pinnedCharms.map(charm => charmId(charm))
+  );
+  
+  // Filter out trashed charms
+  const mentionableCharms = allCharms.filter(charm => 
+    !trashedIds.has(charmId(charm))
+  );
+  
+  // Sort charms with pinned first, then by name
+  return mentionableCharms.sort((a, b) => {
+    const aId = charmId(a);
+    const bId = charmId(b);
+    
+    // Sort pinned first
+    if (pinnedIds.has(aId) && !pinnedIds.has(bId)) return -1;
+    if (!pinnedIds.has(aId) && pinnedIds.has(bId)) return 1;
+    
+    // Then sort by name
+    const aName = a.get()?.[NAME] ?? "Untitled";
+    const bName = b.get()?.[NAME] ?? "Untitled";
+    return aName.localeCompare(bName);
+  });
 }

--- a/jumble/src/utils/charms.ts
+++ b/jumble/src/utils/charms.ts
@@ -26,24 +26,31 @@ export async function getMentionableCharms(charmManager: CharmManager): Promise<
   const trashedCharms = charmManager.getTrash().get();
   
   // Create a set of trashed charm IDs for quick lookup
-  const trashedIds = new Set(
-    trashedCharms.map(charm => charmId(charm))
+  const trashedIds = new Set<string>(
+    trashedCharms.map(charm => charmId(charm)).filter((id): id is string => id !== undefined)
   );
   
   // Create a set of pinned charm IDs for quick lookup
-  const pinnedIds = new Set(
-    pinnedCharms.map(charm => charmId(charm))
+  const pinnedIds = new Set<string>(
+    pinnedCharms.map(charm => charmId(charm)).filter((id): id is string => id !== undefined)
   );
   
-  // Filter out trashed charms
-  const mentionableCharms = allCharms.filter(charm => 
-    !trashedIds.has(charmId(charm))
-  );
+  // Filter out trashed charms and those without IDs
+  const mentionableCharms = allCharms.filter(charm => {
+    const id = charmId(charm);
+    return id !== undefined && !trashedIds.has(id);
+  });
   
   // Sort charms with pinned first, then by name
   return mentionableCharms.sort((a, b) => {
     const aId = charmId(a);
     const bId = charmId(b);
+    
+    // By this point both aId and bId should be defined, but check just in case
+    if (!aId || !bId) {
+      console.warn("Unexpected undefined ID in sort function");
+      return 0;
+    }
     
     // Sort pinned first
     if (pinnedIds.has(aId) && !pinnedIds.has(bId)) return -1;


### PR DESCRIPTION
Fixes #728 

## Summary
- Filters out charms from the trash collection when suggesting @mentions in the Composer
- Prioritizes pinned charms in the mention suggestion list
- Implements a reusable `getMentionableCharms` function that can be used elsewhere in the codebase

## Test plan
1. Create some charms
2. Move one of the charms to trash
3. Pin one of the charms
4. Open the command palette or any other area with the composer
5. Type @ and verify that:
   - The trashed charm doesn't appear in the mentions list
   - The pinned charm appears at the top of the list

🤖 Generated with [Claude Code](https://claude.ai/code)