### PR TITLE
chore: Thread identity (passphrase or file) and toolshed URL into individual BG workers

### DIFF
--- a/background-charm-service/cast-admin.ts
+++ b/background-charm-service/cast-admin.ts
@@ -13,6 +13,7 @@ import {
   CELL_CAUSE,
   SYSTEM_SPACE_ID,
 } from "@commontools/utils";
+import { getIdentity } from "./src/utils.ts";
 
 const { recipePath, name, quit } = parseArgs(
   Deno.args,
@@ -36,7 +37,7 @@ if (!recipePath) {
 const toolshedUrl = Deno.env.get("TOOLSHED_API_URL") ??
   "https://toolshed.saga-castor.ts.net/";
 
-const OPERATOR_PASS = Deno.env.get("OPERATOR_PASS") ?? "implicit trust";
+const identity = await getIdentity(Deno.env.get("IDENTITY"), Deno.env.get("OPERATOR_PASS"));
 
 storage.setRemoteStorage(new URL(toolshedUrl));
 setBobbyServerUrl(toolshedUrl);
@@ -46,9 +47,7 @@ async function castRecipe() {
   const cause = CELL_CAUSE;
   console.log(`Casting recipe from ${recipePath} in space ${spaceId}`);
 
-  console.log("OPERATOR_PASS", OPERATOR_PASS);
-  const signer = await Identity.fromPassphrase(OPERATOR_PASS);
-  storage.setSigner(signer);
+  storage.setSigner(identity);
 
   console.log("params:", {
     spaceId,
@@ -91,7 +90,7 @@ async function castRecipe() {
 
     // Create session and charm manager (matching main.ts pattern)
     const session = await openSession({
-      passphrase: OPERATOR_PASS,
+      identity,
       name: "recipe-caster",
       space: spaceId as DID,
     });

--- a/background-charm-service/src/env.ts
+++ b/background-charm-service/src/env.ts
@@ -2,26 +2,31 @@ import { z } from "zod";
 
 const envSchema = z.object({
   // Job queue settings
-  MAX_CONCURRENT_JOBS: z.coerce.number().positive().default(5),
-  MAX_RETRIES: z.coerce.number().nonnegative().default(3),
-  POLLING_INTERVAL_MS: z.coerce.number().positive().default(100),
+  //MAX_CONCURRENT_JOBS: z.coerce.number().positive().default(5),
+  //MAX_RETRIES: z.coerce.number().nonnegative().default(3),
+  //POLLING_INTERVAL_MS: z.coerce.number().positive().default(100),
 
   // Execution settings
-  CYCLE_INTERVAL_MS: z.coerce.number().positive().default(60_000),
-  LOG_INTERVAL_MS: z.coerce.number().positive().default(300_000),
-  MAX_CONSECUTIVE_FAILURES: z.coerce.number().positive().default(5),
+  //CYCLE_INTERVAL_MS: z.coerce.number().positive().default(60_000),
+  //LOG_INTERVAL_MS: z.coerce.number().positive().default(300_000),
+  //MAX_CONSECUTIVE_FAILURES: z.coerce.number().positive().default(5),
 
   // Timeouts (in milliseconds)
-  CHARM_EXECUTION_TIMEOUT_MS: z.coerce.number().positive().default(30_000),
+  //CHARM_EXECUTION_TIMEOUT_MS: z.coerce.number().positive().default(30_000),
 
-  // Toolshed configuration
+  // Identity 
   OPERATOR_PASS: z.string().default("implicit trust"),
+  // Path to the identity keyfile that the service
+  // runs as.
+  IDENTITY: z.string(),
+  
+  // Toolshed configuration
   TOOLSHED_API_URL: z.string().default("http://localhost:8000"),
 
   // Background Charm Service: default is public space "toolshed-system"
-  SERVICE_DID: z.string().default(
-    "did:key:z6Mkfuw7h6jDwqVb6wimYGys14JFcyTem4Kqvdj9DjpFhY88",
-  ),
+  //SERVICE_DID: z.string().default(
+  //  "did:key:z6Mkfuw7h6jDwqVb6wimYGys14JFcyTem4Kqvdj9DjpFhY88",
+  //),
 });
 
 export type EnvVars = z.infer<typeof envSchema>;

--- a/background-charm-service/src/main.ts
+++ b/background-charm-service/src/main.ts
@@ -1,7 +1,12 @@
 import { BackgroundCharmService } from "./service.ts";
-import { log } from "./utils.ts";
+import { log, getIdentity } from "./utils.ts";
+import { env } from "./env.ts";
 
-const service = new BackgroundCharmService();
+const identity = await getIdentity(env.IDENTITY, env.OPERATOR_PASS);
+const service = new BackgroundCharmService({
+  identity,
+  toolshedUrl: env.TOOLSHED_API_URL,
+});
 
 const shutdown = () => {
   // @ts-ignore: Object is possibly 'undefined'

--- a/background-charm-service/src/space-manager.ts
+++ b/background-charm-service/src/space-manager.ts
@@ -3,11 +3,12 @@ import { Cell } from "@commontools/runner";
 import { log } from "./utils.ts";
 import { WorkerController } from "./worker-controller.ts";
 import { type Cancel, useCancelGroup } from "@commontools/runner";
+import { Identity } from "@commontools/identity";
 
 type CharmSchedulerOptions = {
   did: string;
   toolshedUrl: string;
-  operatorPass: string;
+  identity: Identity;
   maxConcurrentJobs?: number;
   maxRetries?: number;
   pollingIntervalMs?: number;
@@ -54,7 +55,7 @@ export class SpaceManager {
 
     this.workerController.setupWorker(
       options.toolshedUrl,
-      options.operatorPass,
+      options.identity,
     ).then(
       () => {
         log(`Worker controller ${this.did} ready for work`);

--- a/background-charm-service/src/utils.ts
+++ b/background-charm-service/src/utils.ts
@@ -1,6 +1,6 @@
 import { Charm, CharmManager } from "@commontools/charm";
 import { Cell, getEntityId } from "@commontools/runner";
-import { DID, openSession, type Session } from "@commontools/identity";
+import { Identity, DID, type Session } from "@commontools/identity";
 import { env } from "./env.ts";
 
 /**
@@ -44,4 +44,28 @@ export function isValidDID(did: string): boolean {
 
 export function isValidCharmId(id: string): boolean {
   return !!id && id.length === 59;
+}
+
+// Derives the identity configured for this service,
+// receiving an `IDENTITY` and `OPERATOR_PASS` from the environment.
+//
+// First, uses the key path to load a key.
+// If not set, falls back to operator pass to
+// use an insecure passphrase.
+// This fallback should be removed once fully migrated
+// over to using keyfiles. 
+export async function getIdentity(identityPath?: string, operatorPass?: string): Promise<Identity> {
+  if (identityPath) {
+    console.log(`Using identity at ${identityPath}`);
+    try {
+      const pkcs8Key = await Deno.readFile(identityPath);
+      return await Identity.fromPkcs8(pkcs8Key);
+    } catch (e) {
+      throw new Error(`Could not read key at ${identityPath}.`);
+    }
+  } else if (operatorPass) {
+    console.warn("Using insecure passphrase identity.");
+    return await Identity.fromPassphrase(operatorPass);
+  }
+  throw new Error("No IDENTITY or OPERATOR_PASS environemnt set.");
 }

--- a/background-charm-service/src/worker-controller.ts
+++ b/background-charm-service/src/worker-controller.ts
@@ -2,6 +2,7 @@ import { BGCharmEntry, sleep } from "@commontools/utils";
 import { Cell } from "@commontools/runner";
 import { defer } from "@commontools/utils";
 import { log } from "./utils.ts";
+import { Identity } from "@commontools/identity";
 
 type PendingResponse = {
   resolve: (result: any) => void;
@@ -80,11 +81,11 @@ export class WorkerController {
     };
   }
 
-  public setupWorker(toolshedUrl: string, operatorPass: string) {
-    return this.call("setup", {
+  public setupWorker(toolshedUrl: string, identity: Identity) {
+    return this.exec("setup", {
       did: this.did,
-      toolshed_url: toolshedUrl,
-      operator_pass: operatorPass,
+      toolshedUrl,
+      rawIdentity: identity.serialize(),
     }).catch((err) => {
       log(`Worker controller ${this.did} worker setup failed:`, err, {
         error: true,
@@ -96,7 +97,7 @@ export class WorkerController {
   }
 
   // send a message and return a promise that resolves with the response
-  private call(type: string, data?: any): Promise<any> {
+  private exec(type: string, data?: any): Promise<any> {
     // Only allow "setup" calls when not ready
     if (type !== "setup" && !this.ready) {
       return Promise.reject(new Error("Worker not initialized"));
@@ -122,11 +123,11 @@ export class WorkerController {
   public runCharm(
     bg: Cell<BGCharmEntry>,
   ): Promise<{ success: boolean; data?: any; charmId: string }> {
-    return this.call("runCharm", { charmId: bg.get().charmId });
+    return this.exec("runCharm", { charmId: bg.get().charmId });
   }
 
   public shutdown() {
-    return this.call("shutdown").catch(() => {
+    return this.exec("shutdown").catch(() => {
       log(
         "Failed to shutdown worker gracefully, terminating with unknown status.",
       );

--- a/cli/cast-recipe.ts
+++ b/cli/cast-recipe.ts
@@ -6,7 +6,7 @@ import {
   setBobbyServerUrl,
   storage,
 } from "@commontools/runner";
-import { type DID, Identity, openSession } from "@commontools/identity";
+import { type DID, Identity, openSessionFromPassphrase } from "@commontools/identity";
 
 const { spaceId, targetCellCause, recipePath, cause, name, quit } = parseArgs(
   Deno.args,
@@ -64,7 +64,7 @@ async function castRecipe() {
     console.log("Recipe compiled successfully");
 
     // Create session and charm manager (matching main.ts pattern)
-    const session = await openSession({
+    const session = await openSessionFromPassphrase({
       passphrase: OPERATOR_PASS,
       name: name!,
       space: spaceId as DID,

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -7,7 +7,7 @@ import {
   setBobbyServerUrl,
   storage,
 } from "@commontools/runner";
-import { createSession } from "@commontools/identity";
+import { createSessionFromPassphrase } from "@commontools/identity";
 
 const { name, charmId, recipeFile, cause, quit } = parseArgs(Deno.args, {
   string: ["name", "charmId", "recipeFile", "cause"],
@@ -24,7 +24,7 @@ storage.setRemoteStorage(new URL(toolshedUrl));
 setBobbyServerUrl(toolshedUrl);
 
 async function main() {
-  const session = await createSession({
+  const session = await createSessionFromPassphrase({
     passphrase: OPERATOR_PASS,
     name: name!,
   });

--- a/identity/src/index.ts
+++ b/identity/src/index.ts
@@ -2,4 +2,4 @@ export { PassKey } from "./pass-key.ts";
 export { Identity, VerifierIdentity } from "./identity.ts";
 export { KeyStore } from "./key-store.ts";
 export * from "./interface.ts";
-export { createSession, openSession, type Session } from "./session.ts";
+export { createSession, openSession, createSessionFromPassphrase, openSessionFromPassphrase, type Session } from "./session.ts";

--- a/identity/src/session.ts
+++ b/identity/src/session.ts
@@ -9,7 +9,7 @@ export type Session = {
   as: Identity;
 };
 
-export const openSession = async (
+export const openSessionFromPassphrase = async (
   { passphrase, space, name }: {
     passphrase: string;
     space: DID;
@@ -22,11 +22,37 @@ export const openSession = async (
   as: await Identity.fromPassphrase(passphrase),
 });
 
-export const createSession = async (
+export const createSessionFromPassphrase = async (
   { passphrase, name }: { passphrase: string; name: string },
 ) => {
   const account = await Identity.fromPassphrase(passphrase);
   const space = await account.derive(name);
+
+  return {
+    private: name.startsWith("~"),
+    name,
+    space: space.did(),
+    as: space,
+  };
+};
+
+export const openSession = async (
+  { identity, space, name }: {
+    identity: Identity;
+    space: DID;
+    name: string;
+  },
+) => await ({
+  private: name.startsWith("~"),
+  name,
+  space,
+  as: identity,
+});
+
+export const createSession = async (
+  { identity, name }: { identity: Identity; name: string },
+) => {
+  const space = await identity.derive(name);
 
   return {
     private: name.startsWith("~"),


### PR DESCRIPTION
* Configure `openSession` and `createSession` to take `Identity`, not a passphrase, and rename current methods to `[open|create]SessionFromPassphrase`. The passphrase methods should eventually be removed.
* Keys are being serialized (in Deno, Identity should be using native WebCrypto keys, which should be serializable, and not directly expose key material to JS), need to test this works. Once delegation functional, we'll probably want different keys for each Worker.
* Commenting out currently unused env vars
* Rename `WorkerController.prototype.call` to `exec`, wanting to avoid confusion with `Function.prototype.call`
* Should be safe to land before integrating a real key file #890 

Using an identity file is additive, this will fallback to continue using passphrase.

In service of #882  and #783