### PR TITLE
feat: Add 'allow-modals' to inner iframe sandbox

### DIFF
--- a/iframe-sandbox/src/outer-frame.ts
+++ b/iframe-sandbox/src/outer-frame.ts
@@ -30,7 +30,7 @@ iframe {
 <body>
 <iframe
   allow="clipboard-write"
-  sandbox="allow-scripts"><\/iframe>
+  sandbox="allow-scripts allow-modals"><\/iframe>
 <script>
 const iframe = document.querySelector("iframe");
 const HOST_ORIGIN = "${HOST_ORIGIN}";


### PR DESCRIPTION
This enables [`confirm()` and friends](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#allow-modals), used in some recipes.

Fixes #893