### PR TITLE
fix: bind storage inspector to a tab

### DIFF
--- a/cli/memory_demo.ts
+++ b/cli/memory_demo.ts
@@ -35,6 +35,7 @@ async function main() {
   const authority = await Identity.fromPassphrase("ellyse5");
 
   const storageProvider: StorageProvider = new RemoteStorageProvider({
+    id: import.meta.url,
     address: new URL("/api/storage/memory", BASE_URL),
     space: authority.did(),
     as: authority,

--- a/jumble/src/components/NetworkInspector.tsx
+++ b/jumble/src/components/NetworkInspector.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useResizableDrawer } from "@/hooks/use-resizeable-drawer.ts";
 import JsonViewImport from "@uiw/react-json-view";
 import { githubDarkTheme } from "@uiw/react-json-view/githubDark";
-
+import { storage } from "@commontools/runner";
 // Type assertion to help TypeScript understand this is a valid React component
 const JsonView: React.FC<{
   value: any;
@@ -20,7 +20,7 @@ const model = getDoc(Inspector.create(), "inspector", "").asCell();
 // Custom hooks
 export function useStorageBroadcast(callback: (data: any) => void) {
   useEffect(() => {
-    const messages = new BroadcastChannel("storage/remote");
+    const messages = new BroadcastChannel(storage.id);
     messages.onmessage = ({ data }) => callback(data);
     return () => messages.close();
   }, [callback]);

--- a/runner/src/storage/remote.ts
+++ b/runner/src/storage/remote.ts
@@ -64,6 +64,12 @@ export interface RemoteStorageProviderSettings {
 }
 
 export interface RemoteStorageProviderOptions {
+  /**
+   * Unique identifier of the storage. Used as name of the `BroadcastChannel`
+   * in order to allow inspection of the storage.
+   */
+  id: string;
+
   address: URL;
   as: Memory.Signer;
   space?: MemorySpace;
@@ -104,13 +110,14 @@ export class RemoteStorageProvider implements StorageProvider {
   timeoutID = 0;
 
   constructor({
+    id,
     address,
     as,
     space = HOME,
     the = "application/json",
     settings = defaultSettings,
     inspector = globalThis.BroadcastChannel
-      ? new BroadcastChannel("storage/remote")
+      ? new BroadcastChannel(id)
       : undefined,
   }: RemoteStorageProviderOptions) {
     this.address = address;


### PR DESCRIPTION
Adds unique `id` to a storage that is then used to publish / subscribe updates to inspector / status UI.