### PR TITLE
feat: Handle unhandled errors in worker thread by not crashing parent thread

### DIFF
--- a/background-charm-service/src/service.ts
+++ b/background-charm-service/src/service.ts
@@ -6,8 +6,8 @@ import { SpaceManager } from "./space-manager.ts";
 import { useCancelGroup } from "@commontools/runner";
 
 export interface BackgroundCharmServiceOptions {
-  identity: Identity,
-  toolshedUrl: string,
+  identity: Identity;
+  toolshedUrl: string;
 }
 
 export class BackgroundCharmService {

--- a/background-charm-service/src/worker-controller.ts
+++ b/background-charm-service/src/worker-controller.ts
@@ -75,9 +75,9 @@ export class WorkerController {
     // FIXME(ja): what should we do if the worker is erroring?
     // perhaps restart the worker?
     this.worker.onerror = (err) => {
-      log(`${this.did}: Worker error:`, err, {
-        error: true,
-      });
+      log(`${this.did}: Worker error:`, { error: true }, err);
+      // If not prevented, error is rethrown in this context.
+      err.preventDefault();
     };
   }
 
@@ -87,9 +87,11 @@ export class WorkerController {
       toolshedUrl,
       rawIdentity: identity.serialize(),
     }).catch((err) => {
-      log(`Worker controller ${this.did} worker setup failed:`, err, {
-        error: true,
-      });
+      log(
+        `Worker controller ${this.did} worker setup failed:`,
+        { error: true },
+        err,
+      );
     }).then(() => {
       this.ready = true;
       log(`Worker controller ${this.did} ready for work`);


### PR DESCRIPTION
Also log the error; previous usage has arg 2 and 3 flipped, due to `ErrorEvent.prototype.error` satisfying `log`'s `option` type.

In service of #934