### PR TITLE
fix: commit subscription

### DIFF
--- a/memory/interface.ts
+++ b/memory/interface.ts
@@ -149,7 +149,7 @@ export type Protocol<Space extends MemorySpace = MemorySpace> = {
           source: Subscribe<Space>["args"],
         ): Task<
           Result<Unit, SystemError | AuthorizationError>,
-          Transaction<Space>
+          Commit<Space>
         >;
         unsubscribe(
           source: Unsubscribe<Space>["args"],
@@ -230,9 +230,6 @@ export type Method<
     perform(effect: Effect): void;
   };
 };
-
-type PC = ProviderCommand<Protocol>;
-type CCI = ConsumerCommandInvocation<Protocol>;
 
 export type InferOf<T> = keyof T extends DID ? keyof T : never;
 
@@ -460,7 +457,7 @@ export interface MemorySession<Space extends MemorySpace = MemorySpace>
 }
 
 export interface Subscriber<Space extends MemorySpace = MemorySpace> {
-  transact(transaction: Transaction<Space>): AwaitResult<Unit, SystemError>;
+  commit(commit: Commit<Space>): AwaitResult<Unit, SystemError>;
   close(): AwaitResult<Unit, SystemError>;
 }
 

--- a/memory/memory.ts
+++ b/memory/memory.ts
@@ -157,7 +157,7 @@ export const transact = async (session: Session, transaction: Transaction) => {
 
           const promises = [];
           for (const subscriber of session.subscribers) {
-            promises.push(subscriber.transact(transaction));
+            promises.push(subscriber.commit(result.ok));
           }
           await Promise.all(promises);
 

--- a/memory/provider.ts
+++ b/memory/provider.ts
@@ -3,6 +3,7 @@ import type {
   AsyncResult,
   Await,
   CloseResult,
+  Commit,
   ConnectionError,
   ConsumerCommandInvocation,
   ConsumerInvocationFor,
@@ -88,6 +89,7 @@ class MemoryProvider<
   fetch(request: Request) {
     return fetch(this, request);
   }
+
   session(): ProviderSession<MemoryProtocol> {
     const session = new MemoryProviderSession(
       this.memory,
@@ -251,9 +253,9 @@ class MemoryProviderSession<
     }
   }
 
-  transact(transaction: Transaction<Space>) {
+  commit(commit: Commit<Space>) {
     for (const [id, channels] of this.channels) {
-      if (Subscription.match(transaction, channels)) {
+      if (Subscription.match(commit, channels)) {
         // Note that we intentionally exit on the first match because we do not
         // want to send same transaction multiple times to the same consumer.
         // Consumer does it's own bookkeeping of all the subscriptions and will
@@ -261,7 +263,7 @@ class MemoryProviderSession<
         return this.perform({
           the: "task/effect",
           of: id,
-          is: transaction,
+          is: commit,
         });
       }
     }

--- a/memory/subscription.ts
+++ b/memory/subscription.ts
@@ -1,64 +1,88 @@
 import {
   Cause,
+  Commit,
   Entity,
   MemorySpace,
   Selector,
   The,
-  Transaction,
 } from "./interface.ts";
+import { the as commitType } from "./commit.ts";
 
-export const match = (transaction: Transaction, watched: Set<string>) => {
-  for (const [of, attributes] of Object.entries(transaction.args.changes)) {
-    for (const [the, changes] of Object.entries(attributes)) {
-      for (const change of Object.values(changes)) {
-        // If `change == true` we simply confirm that state has not changed
-        // so we don't need to notify those subscribers.
-        if (change !== true) {
-          const watches =
-            watched.has(formatAddress(transaction.sub, { the, of })) ||
-            watched.has(formatAddress(transaction.sub, { the })) ||
-            watched.has(formatAddress(transaction.sub, { of })) ||
-            watched.has(formatAddress(transaction.sub, {}));
+export const match = (commit: Commit, watched: Set<string>) => {
+  for (const at of Object.keys(commit) as MemorySpace[]) {
+    const changes = commit[at][commitType] ?? {};
+    for (
+      const [cause, { is: { transaction, since } }] of Object.entries(changes)
+    ) {
+      // If commit on this space are watched we have a match
+      if (matchAddress(watched, { the: commitType, of: at, at })) {
+        return true;
+      }
 
-          if (watches) {
-            return true;
+      // Otherwise we consider individual in the commit transaction to figure
+      // out if we have a match.
+      for (const [of, attributes] of Object.entries(transaction.args.changes)) {
+        for (const [the, changes] of Object.entries(attributes)) {
+          for (const change of Object.values(changes)) {
+            // If `change == true` we simply confirm that state has not changed
+            // so we don't need to notify those subscribers.
+            if (
+              change !== true &&
+              matchAddress(watched, { at: transaction.sub, the, of })
+            ) {
+              return true;
+            }
           }
         }
       }
     }
   }
+
   return false;
 };
 
+const matchAddress = (
+  watched: Set<string>,
+  { at, the, of }: { the: string; of: string; at: MemorySpace },
+) =>
+  watched.has(formatAddress({ at, the, of })) ||
+  watched.has(formatAddress({ at, the })) ||
+  watched.has(formatAddress({ at, of })) ||
+  watched.has(formatAddress({ at }));
+
+export const ANY = "_";
+
 export const channels = function* (space: MemorySpace, selector: Selector) {
-  const all = [["_", {}]] as const;
+  const all = [[ANY, {}]] as const;
   const entities = Object.entries(selector);
   for (const [of, attributes] of entities.length > 0 ? entities : all) {
     const selector = Object.entries(attributes);
     for (const [the] of selector.length > 0 ? selector : all) {
-      yield formatAddress(space, { the, of });
+      yield formatAddress({ at: space, the, of });
     }
   }
 };
 
 export const fromSelector = function* (selector: Selector) {
-  const all = [[undefined, {}]] as const;
+  const all = [[ANY, {}]] as const;
   const entities = Object.entries(selector);
   for (const [of, attributes] of entities.length > 0 ? entities : all) {
     const selector = Object.entries(attributes);
     for (const [the, members] of selector.length > 0 ? selector : all) {
-      const selector = Object.entries(members);
+      const selector = Object.keys(members);
       for (
-        const cause of selector.length > 0 ? Object.keys(selector) : [undefined]
+        const cause of selector.length > 0 ? selector : [ANY]
       ) {
         const selector: { of?: Entity; the?: The; cause?: Cause } = {};
-        if (of) {
+        if (of !== ANY) {
           selector.of = of as Entity;
         }
-        if (the) {
+
+        if (the !== ANY) {
           selector.the = the as The;
         }
-        if (cause) {
+
+        if (cause !== ANY) {
           selector.cause = cause as Cause;
         }
         yield selector;
@@ -68,6 +92,9 @@ export const fromSelector = function* (selector: Selector) {
 };
 
 export const formatAddress = (
-  space: MemorySpace,
-  { of = "_", the = "_" }: { the?: string; of?: string },
-) => `watch:///${space}/${of}/${the}`;
+  { at = "_", of = "_", the = "_" }: {
+    at?: string;
+    the?: string;
+    of?: string;
+  },
+) => `watch:///${at}/${of}/${the}`;

--- a/runner/src/storage/remote.ts
+++ b/runner/src/storage/remote.ts
@@ -618,7 +618,7 @@ class Subscription<Space extends MemorySpace> {
 
   subscribe(subscriber: Subscriber): Cancel {
     this.subscribers.add(subscriber);
-    return () => this.unsubscribe.bind(this, subscriber);
+    return () => this.unsubscribe(subscriber);
   }
   unsubscribe(subscriber: Subscriber) {
     this.subscribers.delete(subscriber);


### PR DESCRIPTION
Changes subscription logic so that provider sends commits to consumers as opposed to transactions. This fixes subscriptions on space commits (as illustrated by test case) which without this change does not work.