### PR TITLE
schema fixes / status messages on failures

### DIFF
--- a/background-charm-service/cast-admin.ts
+++ b/background-charm-service/cast-admin.ts
@@ -9,13 +9,13 @@ import {
 import { type DID, Identity } from "@commontools/identity";
 import { createAdminSession } from "@commontools/identity";
 import {
+  BG_CELL_CAUSE,
+  BG_SYSTEM_SPACE_ID,
   bgUpdaterCharmsSchema,
-  CELL_CAUSE,
-  SYSTEM_SPACE_ID,
 } from "@commontools/utils";
 import { getIdentity } from "./src/utils.ts";
 
-const { recipePath, name, quit } = parseArgs(
+const { recipePath, quit } = parseArgs(
   Deno.args,
   {
     string: ["recipePath"],
@@ -46,8 +46,8 @@ storage.setRemoteStorage(new URL(toolshedUrl));
 setBobbyServerUrl(toolshedUrl);
 
 async function castRecipe() {
-  const spaceId = SYSTEM_SPACE_ID;
-  const cause = CELL_CAUSE;
+  const spaceId = BG_SYSTEM_SPACE_ID;
+  const cause = BG_CELL_CAUSE;
   console.log(`Casting recipe from ${recipePath} in space ${spaceId}`);
 
   storage.setSigner(identity);
@@ -79,11 +79,11 @@ async function castRecipe() {
     const targetCell = getCell(
       spaceId as DID,
       cause,
-      bgUpdaterCharmsSchema.properties.charms,
+      bgUpdaterCharmsSchema,
     );
 
     // Ensure the cell is synced
-    storage.syncCell(targetCell, true);
+    await storage.syncCell(targetCell, true);
     await storage.synced();
 
     console.log("Getting cell...");

--- a/background-charm-service/src/service.ts
+++ b/background-charm-service/src/service.ts
@@ -1,6 +1,6 @@
 import { Identity } from "@commontools/identity";
 import { type Cell, storage } from "@commontools/runner";
-import { type BGCharmEntry, newGetFunc } from "@commontools/utils";
+import { type BGCharmEntry, getBGUpdaterCharmsCell } from "@commontools/utils";
 import { log } from "./utils.ts";
 import { SpaceManager } from "./space-manager.ts";
 import { useCancelGroup } from "@commontools/runner";
@@ -25,7 +25,7 @@ export class BackgroundCharmService {
   async initialize() {
     storage.setRemoteStorage(new URL(this.toolshedUrl));
     storage.setSigner(this.identity);
-    this.charmsCell = await newGetFunc();
+    this.charmsCell = await getBGUpdaterCharmsCell();
     await storage.syncCell(this.charmsCell, true);
     await storage.synced();
 

--- a/background-charm-service/src/space-manager.ts
+++ b/background-charm-service/src/space-manager.ts
@@ -230,7 +230,8 @@ export class SpaceManager {
       })),
     ]).then((result) => {
       if (!result.success) {
-        this.disableCharm(charmId, bg);
+        const error = "error" in result ? result.error : "Unknown error";
+        this.disableCharm(charmId, bg, error);
       } else {
         this.recordSuccess(charmId, bg);
       }
@@ -242,16 +243,22 @@ export class SpaceManager {
   private recordSuccess(charmId: string, bg: Cell<BGCharmEntry>) {
     bg.update({
       lastRun: Date.now(),
+      status: "Success",
     });
     if (this.schedulableBgs.has(charmId)) {
       this.addPendingRun(charmId, bg, this.rerunIntervalMs / 1000);
     }
   }
 
-  private disableCharm(charmId: string, bg: Cell<BGCharmEntry>) {
+  private disableCharm(
+    charmId: string,
+    bg: Cell<BGCharmEntry>,
+    error?: string,
+  ) {
     bg.update({
       disabledAt: Date.now(),
       lastRun: Date.now(),
+      status: error ? error : "Disabled",
     });
     this.schedulableBgs.delete(charmId);
     this.pendingRuns = this.pendingRuns.filter((r) => r.charmId !== charmId);

--- a/recipes/bgAdmin.tsx
+++ b/recipes/bgAdmin.tsx
@@ -9,6 +9,7 @@ import {
   UI,
 } from "@commontools/builder";
 
+// NOTE(ja): this must be the same as the schema in utils/src/updaters.ts
 const BGCharmEntrySchema = {
   type: "object",
   properties: {

--- a/recipes/bgAdmin.tsx
+++ b/recipes/bgAdmin.tsx
@@ -17,9 +17,9 @@ const BGCharmEntrySchema = {
     integration: { type: "string" },
     createdAt: { type: "number" },
     updatedAt: { type: "number" },
-    disabledAt: { type: "number" },
-    lastRun: { type: "number" },
-    status: { type: "string" },
+    disabledAt: { type: "number", default: 0 },
+    lastRun: { type: "number", default: 0 },
+    status: { type: "string", default: "" },
   },
   required: [
     "space",

--- a/toolshed/routes/integrations/google-oauth/google-oauth.handlers.ts
+++ b/toolshed/routes/integrations/google-oauth/google-oauth.handlers.ts
@@ -25,7 +25,7 @@ import {
   getBaseUrl,
   persistTokens,
 } from "./google-oauth.utils.ts";
-import { addCharmToBG } from "@commontools/utils";
+import { addOrUpdateBGCharm } from "@commontools/utils";
 
 import { type CellLink } from "@commontools/runner";
 
@@ -195,17 +195,11 @@ export const callback: AppRouteHandler<CallbackRoute> = async (c) => {
           "Adding Google integration charm to Gmail integrations",
         );
 
-        const added = await addCharmToBG({
+        await addOrUpdateBGCharm({
           space,
           charmId: integrationCharmId,
-          integration: "gmail",
+          integration: "google",
         });
-
-        if (added) {
-          logger.info("Added charm to Gmail integrations");
-        } else {
-          logger.info("Charm already exists in Gmail integrations");
-        }
       } else {
         logger.warn(
           { decodedState },
@@ -363,7 +357,7 @@ export const backgroundIntegration: AppRouteHandler<
   try {
     const payload = await c.req.json();
 
-    await addCharmToBG({
+    await addOrUpdateBGCharm({
       space: payload.space,
       charmId: payload.charmId,
       integration: payload.integration,

--- a/utils/src/updaters.ts
+++ b/utils/src/updaters.ts
@@ -1,5 +1,5 @@
 import { Cell, getCell, storage } from "@commontools/runner";
-import { JSONSchema, Schema } from "@commontools/builder";
+import { ID, JSONSchema, Schema } from "@commontools/builder";
 
 // This is the derived space id for toolshed-system
 export const BG_SYSTEM_SPACE_ID =
@@ -63,8 +63,8 @@ export async function addOrUpdateBGCharm({
 
   if (existingCharmIndex === -1) {
     console.log("Adding charm to BGUpdater charms cell");
-    const newBG = getCell(BG_SYSTEM_SPACE_ID, undefined, CharmEntrySchema);
-    newBG.set({
+    charmsCell.push({
+      [ID]: `${space}/${charmId}`,
       space,
       charmId,
       integration,
@@ -73,8 +73,7 @@ export async function addOrUpdateBGCharm({
       disabledAt: undefined,
       lastRun: 0,
       status: "Initializing",
-    });
-    charmsCell.push(newBG);
+    } as unknown as Cell<BGCharmEntry>);
 
     // Ensure changes are synced
     await storage.synced();

--- a/utils/src/updaters.ts
+++ b/utils/src/updaters.ts
@@ -85,10 +85,14 @@ export async function addOrUpdateBGCharm({
   } else {
     console.log("Charm already exists in BGUpdater charms cell, re-enabling");
     existingCharm.update({
-      disabledAt: undefined,
+      disabledAt: 0,
       updatedAt: Date.now(),
       status: "re-added",
     });
+
+    await storage.synced();
+
+    console.log("Charms cell", JSON.stringify(charmsCell.get(), null, 2));
     return false;
   }
 }

--- a/utils/src/updaters.ts
+++ b/utils/src/updaters.ts
@@ -2,9 +2,9 @@ import { Cell, getCell, storage } from "@commontools/runner";
 import { JSONSchema, Schema } from "@commontools/builder";
 
 // This is the derived space id for toolshed-system
-export const SYSTEM_SPACE_ID =
+export const BG_SYSTEM_SPACE_ID =
   "did:key:z6Mkfuw7h6jDwqVb6wimYGys14JFcyTem4Kqvdj9DjpFhY88";
-export const CELL_CAUSE = "bgUpdater-2025-03-18";
+export const BG_CELL_CAUSE = "bgUpdater-2025-03-18";
 
 export const CharmEntrySchema = {
   type: "object",
@@ -13,10 +13,10 @@ export const CharmEntrySchema = {
     charmId: { type: "string" },
     integration: { type: "string" },
     createdAt: { type: "number" },
-    lastRun: { type: "number", default: null },
     updatedAt: { type: "number" },
-    disabledAt: { type: "number", default: null },
-    runs: { type: "number", default: 0 },
+    disabledAt: { type: "number", default: 0 },
+    lastRun: { type: "number", default: 0 },
+    status: { type: "string", default: "" },
   },
   required: [
     "space",
@@ -24,27 +24,21 @@ export const CharmEntrySchema = {
     "integration",
     "createdAt",
     "updatedAt",
-    "enabled",
-    "runs",
+    "lastRun",
+    "status",
   ],
 } as const satisfies JSONSchema;
 export type BGCharmEntry = Schema<typeof CharmEntrySchema>;
 
-// Define schema for the cell with correct type literals
 export const bgUpdaterCharmsSchema = {
-  type: "object",
-  properties: {
-    charms: {
-      type: "array",
-      items: CharmEntrySchema,
-      default: [],
-    },
-  },
-  required: ["charms"],
+  type: "array",
+  items: CharmEntrySchema,
+  default: [],
 } as const satisfies JSONSchema;
+
 export type BGUpdaterCharmsSchema = Schema<typeof bgUpdaterCharmsSchema>;
 
-export async function addCharmToBG({
+export async function addOrUpdateBGCharm({
   space,
   charmId,
   integration,
@@ -65,54 +59,43 @@ export async function addCharmToBG({
   const charms = charmsCell.get() || [];
 
   // Check if this charm is already in the list to avoid duplicates
-  const exists = charms.some(
-    (charm: BGCharmEntry) => charm.space === space && charm.charmId === charmId,
+  const existingCharm = charms.find(
+    (charm: Cell<BGCharmEntry>) =>
+      charm.get().space === space && charm.get().charmId === charmId,
   );
 
-  if (!exists) {
+  if (!existingCharm) {
     console.log("Adding charm to BGUpdater charms cell");
-    charmsCell.push({
+    const newBG = getCell(BG_SYSTEM_SPACE_ID, undefined, CharmEntrySchema);
+    newBG.set({
       space,
       charmId,
       integration,
       createdAt: Date.now(),
       updatedAt: Date.now(),
       disabledAt: undefined,
-      runs: 0,
+      lastRun: 0,
+      status: "created",
     });
+    charmsCell.push(newBG);
 
     // Ensure changes are synced
     await storage.synced();
     return true;
+  } else {
+    console.log("Charm already exists in BGUpdater charms cell, re-enabling");
+    existingCharm.update({
+      disabledAt: undefined,
+      updatedAt: Date.now(),
+      status: "re-added",
+    });
+    return false;
   }
-
-  console.log("Charm already exists in BGUpdater charms cell");
-  return false;
 }
 
-/**
- * Get the BGUpdater charms cell
- */
-export async function getBGUpdaterCharmsCell() {
-  if (!storage.hasSigner()) {
-    throw new Error("Storage has no signer");
-  }
-
-  if (!storage.hasRemoteStorage()) {
-    throw new Error("Storage has no remote storage");
-  }
-  const schema = bgUpdaterCharmsSchema.properties.charms;
-
-  const charmsCell = getCell(SYSTEM_SPACE_ID, CELL_CAUSE, schema);
-
-  // Ensure the cell is synced
-  await storage.syncCell(charmsCell, true);
-  await storage.synced();
-
-  return charmsCell;
-}
-
-export async function newGetFunc(): Promise<Cell<Cell<BGCharmEntry>[]>> {
+export async function getBGUpdaterCharmsCell(): Promise<
+  Cell<Cell<BGCharmEntry>[]>
+> {
   if (!storage.hasSigner()) {
     throw new Error("Storage has no signer");
   }
@@ -129,7 +112,7 @@ export async function newGetFunc(): Promise<Cell<Cell<BGCharmEntry>[]>> {
     default: [],
   } as const satisfies JSONSchema;
 
-  const charmsCell = getCell(SYSTEM_SPACE_ID, CELL_CAUSE, schema);
+  const charmsCell = getCell(BG_SYSTEM_SPACE_ID, BG_CELL_CAUSE, schema);
 
   // Ensure the cell is synced
   // FIXME(ja): does True do the right thing here? Does this mean: I REALLY REALLY


### PR DESCRIPTION
- re-auth should re-enable bg flow
- ensure the schemas match & cleanup (status was missing)
- set status on enable/disable/worker error

![image](https://github.com/user-attachments/assets/10be7434-043e-419b-a440-c705fc2a1719)