### PR TITLE
fix: Use fallback/deserializable key implementation when using passphrase in BG service

### DIFF
--- a/background-charm-service/src/env.ts
+++ b/background-charm-service/src/env.ts
@@ -18,8 +18,7 @@ const envSchema = z.object({
   OPERATOR_PASS: z.string().default("implicit trust"),
   // Path to the identity keyfile that the service
   // runs as.
-  IDENTITY: z.string(),
-
+  IDENTITY: z.string().optional(),
   // Toolshed configuration
   TOOLSHED_API_URL: z.string().default("http://localhost:8000"),
   // Background Charm Service: default is public space "toolshed-system"

--- a/identity/src/index.ts
+++ b/identity/src/index.ts
@@ -1,5 +1,9 @@
 export { PassKey } from "./pass-key.ts";
-export { Identity, VerifierIdentity } from "./identity.ts";
+export {
+  Identity,
+  type IdentityCreateConfig,
+  VerifierIdentity,
+} from "./identity.ts";
 export { KeyStore } from "./key-store.ts";
 export * from "./interface.ts";
 export { createAdminSession, createSession, type Session } from "./session.ts";


### PR DESCRIPTION
* Reconfigured Identity to better handle using the fallback (serializable) implementation, allowing `OPERATOR_PASS` to work in the BG service.
* Made `IDENTITY` an optional env var until `OPERATOR_PASS` can be phased out.