### PR TITLE
fix: Show trash section when all charms are in trash

### DIFF
--- a/jumble/src/views/CharmList.tsx
+++ b/jumble/src/views/CharmList.tsx
@@ -118,7 +118,8 @@ export default function CharmList() {
     );
   }
 
-  if (!charms || charms.length === 0) {
+  // Only show empty state when both main list and trash are empty
+  if ((!charms || charms.length === 0) && (!trash || trash.length === 0)) {
     return (
       <div className="flex flex-col items-center justify-center h-[70vh] text-center p-8">
         <div className="mb-6">


### PR DESCRIPTION
## Summary
- Fix issue where the empty state is shown when all charms are in trash, preventing users from accessing the trash
- Only show empty state when both main list AND trash are empty

## Test plan
1. Move all charms to trash
2. Verify that the UI still renders and trash section is accessible
3. Empty the trash
4. Verify that empty state is now shown

Fixes #906
Fixes CT-109