### PR TITLE
fix: Require deterministic signing in the ed25519 WebCrypto implementation

### DIFF
--- a/identity/src/ed25519/index.ts
+++ b/identity/src/ed25519/index.ts
@@ -7,17 +7,14 @@ import {
   Signer,
   Verifier,
 } from "../interface.ts";
-import {
-  isNativeEd25519Supported,
-  NativeEd25519Signer,
-  NativeEd25519Verifier,
-} from "./native.ts";
+import { NativeEd25519Signer, NativeEd25519Verifier } from "./native.ts";
 import { NobleEd25519Signer, NobleEd25519Verifier } from "./noble.ts";
 import * as bip39 from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english";
 import {
   fromPEM,
   generateEd25519Pkcs8,
+  isNativeEd25519Supported,
   pkcs8ToEd25519Raw,
   toPEM,
 } from "./utils.ts";

--- a/identity/src/ed25519/native.ts
+++ b/identity/src/ed25519/native.ts
@@ -5,6 +5,7 @@ import {
   didToBytes,
   ED25519_ALG,
   ed25519RawToPkcs8,
+  isNativeEd25519Supported,
 } from "./utils.ts";
 import {
   AsBytes,
@@ -14,7 +15,6 @@ import {
   Signer,
   Verifier,
 } from "../interface.ts";
-import { clone } from "../utils.ts";
 
 // WebCrypto Key formats for Ed25519
 // Non-explicitly described in https://wicg.github.io/webcrypto-secure-curves/#ed25519
@@ -25,38 +25,6 @@ import { clone } from "../utils.ts";
 // | jwk    |   X    |    X    |
 // | pkcs8  |        |    X    |
 // | spki   |   X    |         |
-
-// Returns whether ed25519 is supported in Web Crypto API.
-// Tests both 1) key creation and 2) serialization.
-//
-// * Chrome currently requires Experimental Web Features flag enabled for ed25519 keys
-// * Firefox supports ed25519 keys, though cannot be serialized (stored in IndexedDB)
-//   until v136 https://bugzilla.mozilla.org/show_bug.cgi?id=1939993
-export const isNativeEd25519Supported = (() => {
-  let isSupported: boolean | null = null;
-  return async function isNativeEd25519Supported() {
-    if (isSupported !== null) {
-      return isSupported;
-    }
-    const dummyKey = new Uint8Array(32);
-    try {
-      const key = await globalThis.crypto.subtle.importKey(
-        "raw",
-        dummyKey,
-        ED25519_ALG,
-        false,
-        [
-          "verify",
-        ],
-      );
-      await clone(key);
-      isSupported = true;
-    } catch (e) {
-      isSupported = false;
-    }
-    return isSupported;
-  };
-})();
 
 export class NativeEd25519Signer<ID extends DIDKey> implements Signer<ID> {
   #keypair: CryptoKeyPair;

--- a/identity/src/ed25519/utils.ts
+++ b/identity/src/ed25519/utils.ts
@@ -126,3 +126,78 @@ export function didToBytes(did: DIDKey): Uint8Array {
 export class AuthorizationError extends Error {
   override name = "AuthorizationError" as const;
 }
+
+// Returns whether ed25519 is supported in Web Crypto API.
+// Supported implies:
+//
+// * WebCrypto ED25519 key implementation supported[1].
+// * Can be serialized for IndexedDb[2][3].
+// * Uses deterministic signatures as per RFC 8032[4].
+//
+// * [1] Webkit and Firefox implement WebCrypto (caveats below), and Chrome currently requires
+//   "Experimental Web Features" flag enabled for ed25519 keys.
+//   https://caniuse.com/mdn-api_subtlecrypto_generatekey_ed25519
+// * [2] Firefox supports ed25519 keys, though cannot be serialized (stored in IndexedDB)
+//   until v136 https://bugzilla.mozilla.org/show_bug.cgi?id=1939993.
+// * [3] While Deno serializes `CryptoKey`s without throwing, they cannot be rehydrated
+//   after cloning. We do not test that here, as we prefer the WebCrypto implementation
+//   in Deno, but in scenarios where a clone is necessary, a fallback implementation
+//   can be requested.
+//   https://github.com/denoland/deno/issues/12067#issuecomment-1975001079
+// * [4] Safari/Webkit generates randomized signatures as per `draft-irtf-cfrg-det-sigs-with-noise`
+//   https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/
+export const isNativeEd25519Supported = (() => {
+  async function isDeterministic(key: CryptoKey): Promise<boolean> {
+    const payload = new Uint8Array(32);
+    const [first, second] = [
+      new Uint8Array(await crypto.subtle.sign("ed25519", key, payload)),
+      new Uint8Array(await crypto.subtle.sign("ed25519", key, payload)),
+    ];
+    if (first.length !== second.length) return false;
+    for (let i = 0; i < first.length; i++) {
+      if (first[i] !== second[i]) return false;
+    }
+    return true;
+  }
+
+  // Note we do not test if the key can be rehydrated (fails in Deno if needed),
+  // we're mostly checking that Firefox keys can be saved to storage.
+  function isCloneable(key: CryptoKey): boolean {
+    try {
+      globalThis.structuredClone(key);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  async function testEd25519Features(): Promise<boolean> {
+    let key;
+    try {
+      key = await crypto.subtle.generateKey("ed25519", false, [
+        "sign",
+      ]) as CryptoKeyPair;
+    } catch (e) {
+      return false;
+    }
+
+    if (!(await isDeterministic(key.privateKey))) {
+      return false;
+    }
+    if (!isCloneable(key.privateKey)) {
+      return false;
+    }
+    return true;
+  }
+
+  let isSupported: boolean | null = null;
+
+  return async function isNativeEd25519Supported() {
+    if (isSupported !== null) {
+      return isSupported;
+    }
+
+    isSupported = await testEd25519Features();
+    return isSupported;
+  };
+})();

--- a/identity/src/utils.ts
+++ b/identity/src/utils.ts
@@ -28,14 +28,3 @@ const HASH_ALG = "SHA-256";
 export async function hash(input: Uint8Array): Promise<Uint8Array> {
   return new Uint8Array(await globalThis.crypto.subtle.digest(HASH_ALG, input));
 }
-
-// Clones object using Structured Clone Algorithm.
-// Used to test if ed25519 keys can be stored in IndexedDB.
-export function clone<T>(obj: T): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const { port1, port2 } = new MessageChannel();
-    port1.onmessage = (msg) => resolve(msg.data);
-    port1.onmessageerror = (e) => reject(e);
-    port2.postMessage(obj);
-  });
-}

--- a/identity/test/ed25519.test.ts
+++ b/identity/test/ed25519.test.ts
@@ -1,5 +1,4 @@
 import {
-  isNativeEd25519Supported,
   NativeEd25519Signer,
   NativeEd25519Verifier,
 } from "../src/ed25519/native.ts";
@@ -7,9 +6,10 @@ import {
   NobleEd25519Signer,
   NobleEd25519Verifier,
 } from "../src/ed25519/noble.ts";
+import { isNativeEd25519Supported } from "../src/ed25519/utils.ts";
 import { assert } from "@std/assert";
 import { bytesEqual } from "./utils.ts";
-import { DID, DIDKey } from "../src/interface.ts";
+import { DIDKey } from "../src/interface.ts";
 import * as ed25519 from "@noble/ed25519";
 
 type SignerImpl<ID extends DIDKey> =


### PR DESCRIPTION
Otherwise, use noble implementation. Fixes identity usage in Safari.

In service of #874

Strategy on determining whether to use WebCrypto or noble implementation:

```
// Returns whether ed25519 is supported in Web Crypto API.
// Supported implies:
//
// * WebCrypto ED25519 key implementation supported[1].
// * Can be serialized for IndexedDb[2][3].
// * Uses deterministic signatures as per RFC 8032[4].
//
// * [1] Webkit and Firefox implement WebCrypto (caveats below), and Chrome currently requires
//   "Experimental Web Features" flag enabled for ed25519 keys.
//   https://caniuse.com/mdn-api_subtlecrypto_generatekey_ed25519
// * [2] Firefox supports ed25519 keys, though cannot be serialized (stored in IndexedDB)
//   until v136 https://bugzilla.mozilla.org/show_bug.cgi?id=1939993.
// * [3] While Deno serializes `CryptoKey`s without throwing, they cannot be rehydrated
//   after cloning. We do not test that here, as we prefer the WebCrypto implementation
//   in Deno, but in scenarios where a clone is necessary, a fallback implementation
//   can be requested.
//   https://github.com/denoland/deno/issues/12067#issuecomment-1975001079
// * [4] Safari/Webkit generates randomized signatures as per `draft-irtf-cfrg-det-sigs-with-noise`
//   https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/
```