### PR TITLE
Add mime type for source map files

### DIFF
--- a/toolshed/routes/frontend/frontend.static.ts
+++ b/toolshed/routes/frontend/frontend.static.ts
@@ -19,6 +19,9 @@ function getMimeType(reqPath: string): string {
   if (reqPath.endsWith(".ttf")) {
     return "font/ttf";
   }
+  if (reqPath.endsWith(".map")) {
+    return "application/json";
+  }
   throw new Error("Unknown mimetype");
 }
 


### PR DESCRIPTION
We get a bunch of complaints in Sentry about this unknown mimetype, and it's trivial to avoid for this case.