### PR TITLE
Fix for incorrect subscription to included items.

### DIFF
--- a/runner/src/storage/remote.ts
+++ b/runner/src/storage/remote.ts
@@ -423,7 +423,8 @@ export class RemoteStorageProvider implements StorageProvider {
     // If we did have connection
     if (this.connectionCount > 1) {
       for (const local of this.state.values()) {
-        for (const query of local.remote.values()) {
+        const uniqueRemotes = new Set(local.remote.values());
+        for (const query of uniqueRemotes) {
           query.reconnect();
         }
       }


### PR DESCRIPTION
In some cases, we were using the initial selector of the first query, instead of the version derived from the selection.
When we reconnect, since our remote map can contain the same value more than once, only reconnect each one once.

