### PR TITLE
chore: Rework BG worker failures

### DIFF
--- a/background-charm-service/src/service.ts
+++ b/background-charm-service/src/service.ts
@@ -76,10 +76,7 @@ export class BackgroundCharmService {
           identity: this.identity,
         });
         this.charmSchedulers.set(did, scheduler);
-        scheduler.start().catch((err) => {
-          log(`${did} Scheduler failed to initialize: ${err}`);
-          this.charmSchedulers.delete(did);
-        });
+        scheduler.start();
       }
 
       // we are only filtering charms because until the FIXME above is fixed

--- a/background-charm-service/src/worker-ipc.ts
+++ b/background-charm-service/src/worker-ipc.ts
@@ -1,0 +1,69 @@
+import { isKeyPairRaw, KeyPairRaw } from "@commontools/identity";
+
+export enum WorkerIPCMessageType {
+  Initialize = "initialize",
+  Run = "run",
+  Cleanup = "cleanup",
+}
+
+export type InitializationData = {
+  did: string;
+  toolshedUrl: string;
+  rawIdentity: KeyPairRaw;
+};
+
+export function isInitializationData(value: any): value is InitializationData {
+  return !!(value && typeof value === "object" &&
+    typeof value.did === "string" &&
+    typeof value.toolshedUrl === "string" &&
+    isKeyPairRaw(value.rawIdentity));
+}
+
+export type RunData = {
+  charmId: string;
+};
+
+export function isRunData(value: any): value is RunData {
+  return !!(value && typeof value === "object" &&
+    typeof value.charmId === "string");
+}
+
+export type WorkerIPCRequest = {
+  type: WorkerIPCMessageType.Initialize;
+  msgId: number;
+  data: InitializationData;
+} | {
+  type: WorkerIPCMessageType.Run;
+  msgId: number;
+  data: RunData;
+} | {
+  type: WorkerIPCMessageType.Cleanup;
+  msgId: number;
+};
+
+export function isWorkerIPCRequest(value: any): value is WorkerIPCRequest {
+  if (!value || typeof value !== "object" || typeof value.msgId !== "number") {
+    return false;
+  }
+  if (value.type === WorkerIPCMessageType.Initialize) {
+    return isInitializationData(value.data);
+  }
+  if (value.type === WorkerIPCMessageType.Run) {
+    return isRunData(value.data);
+  }
+  if (value.type === WorkerIPCMessageType.Cleanup) {
+    return !("data" in value);
+  }
+  return false;
+}
+
+export type WorkerIPCResponse = {
+  msgId: number;
+  error?: string;
+};
+
+export function isWorkerIPCResponse(value: any): value is WorkerIPCResponse {
+  return !!(value && typeof value === "object" &&
+    typeof value.msgId === "number" &&
+    ("error" in value ? typeof value.error === "string" : true));
+}

--- a/identity/src/interface.ts
+++ b/identity/src/interface.ts
@@ -108,3 +108,7 @@ export function isInsecureCryptoKeyPair(input: any): input is CryptoKeyPair {
     input.publicKey instanceof Uint8Array
   );
 }
+
+export function isKeyPairRaw(value: any): value is KeyPairRaw {
+  return isCryptoKeyPair(value) || isInsecureCryptoKeyPair(value);
+}


### PR DESCRIPTION
* On (runtime graph) failure, the charm is rescheduled up to 2 more times with a linear backoff. If still unsuccessful, the charm is disabled.
* Disabled tasks do not affect the execution of successfully running tasks.
* Terminal errors (e.g. errors in handling code, or outside of graph execution, like an unhandled rejection) recreate the worker environment.
  * TBD if we want to disable all running charms. Due to no longer adhering to execution within a single tick, we cannot trace back failures to a specific charm.
* RSS recipe will now throw (reject) upon failure rather than setting empty items, and be returned in the handler promise chain. Previously, this would be an unhandled rejection.
* Add some types.