### PR TITLE
fix: inspector with new provider

### DIFF
--- a/runner/src/storage/cache.ts
+++ b/runner/src/storage/cache.ts
@@ -967,12 +967,21 @@ export class Provider implements StorageProvider {
     // disconnect.
     if (this.connection === socket) {
       // Report disconnection to inspector
-      this.inspect({
-        disconnect: {
-          reason: event.type,
-          description: `Disconnected because of the ${event.type}`,
-        },
-      });
+      switch (event.type) {
+        case "error":
+        case "timeout":
+        case "close": {
+          this.inspect({
+            disconnect: {
+              reason: event.type,
+              message: `Disconnected because of the ${event.type}`,
+            },
+          });
+          break;
+        }
+        default:
+          throw new Error(`Unknown event type: ${event.type}`);
+      }
 
       this.connect();
     }

--- a/runner/src/storage/cache.ts
+++ b/runner/src/storage/cache.ts
@@ -833,9 +833,9 @@ export class Provider implements StorageProvider {
     );
   }
 
-  inspect<T>(
-    message: T,
-  ): T {
+  inspect(
+    message: RawCommand,
+  ): RawCommand {
     this.inspector?.postMessage({
       ...message,
       time: Date.now(),


### PR DESCRIPTION
Fixes how cached provider broadcasts messages.

> Changes to the remote.ts have landed while I was working on the IDB cache and during merge I did not noticed that inspector wiring was different.