### PR TITLE
harmonize JSONSchema definition with the one from storage

### DIFF
--- a/builder/src/types.ts
+++ b/builder/src/types.ts
@@ -103,12 +103,23 @@ export type HandlerFactory<T, R> =
   & toJSON;
 
 export type JSONValue =
-  | string
-  | number
-  | boolean
   | null
-  | JSONValue[]
-  | { [key: string]: JSONValue } & { [ID]?: any; [ID_FIELD]?: any };
+  | boolean
+  | number
+  | string
+  | JSONArray
+  | JSONObject & IDFields;
+
+export interface JSONArray extends ArrayLike<JSONValue> {}
+
+export interface JSONObject extends Record<string, JSONValue> {}
+
+// Annotations when writing data that help determine the entity id. They are
+// removed before sending to storage.
+export interface IDFields {
+  [ID]?: any;
+  [ID_FIELD]?: any;
+}
 
 // TODO(@ubik2) When specifying a JSONSchema, you can often use a boolean
 // This is particularly useful for specifying the schema of a property.


### PR DESCRIPTION
Still more to do, but at least now everything from storage is automatically compatible with what builder/runner expects. And in the other direction, we wouldn't want it to go without paying attention, but presumably what happens is that the builder type is still used when `[ID]` can't be possible anymore.

Ideally we rename one of these. The builder one is more user-visible, FWIW (but also technically incorrect, so happy to change it to `DataValue` or something like this)