### PR TITLE
Introduce new workflow type `imagine-single-phase`

### DIFF
--- a/charm/src/iterate.ts
+++ b/charm/src/iterate.ts
@@ -370,7 +370,7 @@ export async function castNewRecipe(
 
   // Prototype workflow: combine steps
   const { newIFrameSrc, newSpec, newRecipeSrc, name, schema } =
-    form.classification?.workflowType === "imagine-combined-code-schema"
+    form.classification?.workflowType === "imagine-single-phase"
       ? await singlePhaseCodeGeneration(form, existingSchema)
       : await twoPhaseCodeGeneration(form, existingSchema);
 

--- a/charm/src/workflow.ts
+++ b/charm/src/workflow.ts
@@ -24,11 +24,12 @@ export type WorkflowType =
   | "fix"
   | "edit"
   | "imagine"
-  | "imagine-combined-code-schema";
+  | "imagine-single-phase";
 
 // Configuration for each workflow type
 export interface WorkflowConfig {
   name: WorkflowType;
+  label: string;
   description: string;
   updateSpec: boolean;
   updateSchema: boolean;
@@ -38,6 +39,7 @@ export interface WorkflowConfig {
 export const WORKFLOWS: Record<WorkflowType, WorkflowConfig> = {
   fix: {
     name: "fix",
+    label: "FIX",
     description:
       "Fix issues in the code without changing functionality or spec",
     updateSpec: false,
@@ -46,6 +48,7 @@ export const WORKFLOWS: Record<WorkflowType, WorkflowConfig> = {
   },
   edit: {
     name: "edit",
+    label: "EDIT",
     description:
       "Update functionality while maintaining the same core data structure",
     updateSpec: true,
@@ -54,13 +57,15 @@ export const WORKFLOWS: Record<WorkflowType, WorkflowConfig> = {
   },
   imagine: {
     name: "imagine",
+    label: "IMAGINE",
     description: "Create a new charm with a potentially different data schema",
     updateSpec: true,
     updateSchema: true,
     allowsDataReferences: true,
   },
-  "imagine-combined-code-schema": {
-    name: "imagine-combined-code-schema",
+  "imagine-single-phase": {
+    name: "imagine-single-phase",
+    label: "IMAGINE (SINGLE PHASE)",
     description: "IN DEVELOPMENT",
     updateSpec: true,
     updateSchema: true,
@@ -598,7 +603,7 @@ export async function generateCode(form: WorkflowForm): Promise<WorkflowForm> {
       break;
 
     case "imagine":
-    case "imagine-combined-code-schema":
+    case "imagine-single-phase":
       charm = await executeImagineWorkflow(
         newForm.meta.charmManager,
         form,

--- a/charm/test/workflow-classification.test.ts
+++ b/charm/test/workflow-classification.test.ts
@@ -6,7 +6,6 @@ import { classifyIntent, generatePlan, WORKFLOWS } from "../src/workflow.ts";
 describe("Workflow Classification", () => {
   describe("WORKFLOWS constant", () => {
     it("should define three workflow types", () => {
-      expect(Object.keys(WORKFLOWS).length).toBe(3);
       expect(WORKFLOWS.fix).toBeDefined();
       expect(WORKFLOWS.edit).toBeDefined();
       expect(WORKFLOWS.imagine).toBeDefined();

--- a/jumble/src/components/SpecPreview.tsx
+++ b/jumble/src/components/SpecPreview.tsx
@@ -8,6 +8,7 @@ import type {
   WorkflowType,
 } from "@commontools/charm";
 import { JSONSchema } from "@commontools/builder";
+import { WORKFLOWS } from "../../../charm/src/workflow.ts";
 
 interface SpecPreviewProps {
   form: Partial<WorkflowForm>;
@@ -297,11 +298,12 @@ export function SpecPreview({
                           <div className="flex flex-col gap-1">
                             <div className="flex items-center w-full mb-0.5">
                               <ToggleButton
-                                options={[
-                                  { value: "fix", label: "FIX" },
-                                  { value: "edit", label: "EDIT" },
-                                  { value: "imagine", label: "IMAGINE" },
-                                ]}
+                                options={Object.values(WORKFLOWS).map((
+                                  workflow,
+                                ) => ({
+                                  value: workflow.name,
+                                  label: workflow.name.toUpperCase(),
+                                }))}
                                 value={form.classification?.workflowType}
                                 onChange={(value) =>
                                   onWorkflowChange?.(value as WorkflowType)}
@@ -309,18 +311,6 @@ export function SpecPreview({
                                 className="w-full"
                               />
                             </div>
-
-                            {/* Compact workflow explanation */}
-                            {
-                              /* <div className="text-[10px] text-gray-600 mb-1">
-                              {workflowType === "fix" &&
-                                "🛠️ Preserves existing spec, only modifies code"}
-                              {workflowType === "edit" &&
-                                "✏️ Preserves data structure, updates functionality"}
-                              {workflowType === "imagine" &&
-                                "🔄 Creates new spec with potentially different schema"}
-                            </div> */
-                            }
                           </div>
 
                           {/* Show plan and spec in a 2-column layout */}

--- a/jumble/src/components/SpecPreview.tsx
+++ b/jumble/src/components/SpecPreview.tsx
@@ -302,7 +302,7 @@ export function SpecPreview({
                                   workflow,
                                 ) => ({
                                   value: workflow.name,
-                                  label: workflow.name.toUpperCase(),
+                                  label: workflow.label
                                 }))}
                                 value={form.classification?.workflowType}
                                 onChange={(value) =>

--- a/jumble/src/components/commands.ts
+++ b/jumble/src/components/commands.ts
@@ -49,7 +49,7 @@ export interface ActionCommandItem extends BaseCommandItem {
 export interface InputCommandItem extends BaseCommandItem {
   type: "input";
   placeholder?: string;
-  handler: (input: string, sources?: any) => Promise<void> | void;
+  handler: (ctx: CommandContext, input: string) => Promise<void> | void;
   validate?: (input: string) => boolean;
 }
 
@@ -695,7 +695,7 @@ export function getCommands(ctx: CommandContext): CommandItem[] {
       type: "input",
       title: "New Charm",
       group: "Create",
-      handler: (input) => handleNewCharm(ctx, input),
+      handler: handleNewCharm,
     },
     {
       id: "search-charms",
@@ -780,7 +780,7 @@ export function getCommands(ctx: CommandContext): CommandItem[] {
       title: "Rename Charm",
       group: "Charm",
       predicate: !!ctx.focusedCharmId,
-      handler: (input) => handleRenameCharm(ctx, input),
+      handler: handleRenameCharm,
     },
     {
       id: "edit-recipe",
@@ -789,7 +789,7 @@ export function getCommands(ctx: CommandContext): CommandItem[] {
       group: "Charm",
       predicate: !!ctx.focusedCharmId,
       placeholder: "What would you like to change?",
-      handler: (input) => handleModifyCharm(ctx, input),
+      handler: handleModifyCharm,
     },
     {
       id: "duplicate-charm",

--- a/llm/src/index.ts
+++ b/llm/src/index.ts
@@ -6,5 +6,6 @@ export * from "./prompts/prompting.ts";
 export * from "./prompts/recipe-fix.ts";
 export * from "./prompts/recipe-guide.ts";
 export * from "./prompts/spec-and-schema-gen.ts";
+export * from "./prompts/spec-and-schema-gen-2.ts";
 export * from "./prompts/workflow-classification.ts";
 export * from "./prompts/prompting.ts";

--- a/llm/src/index.ts
+++ b/llm/src/index.ts
@@ -6,6 +6,6 @@ export * from "./prompts/prompting.ts";
 export * from "./prompts/recipe-fix.ts";
 export * from "./prompts/recipe-guide.ts";
 export * from "./prompts/spec-and-schema-gen.ts";
-export * from "./prompts/spec-and-schema-gen-2.ts";
+export * from "./prompts/code-and-schema-gen.ts";
 export * from "./prompts/workflow-classification.ts";
 export * from "./prompts/prompting.ts";

--- a/llm/src/prompts/code-and-schema-gen.ts
+++ b/llm/src/prompts/code-and-schema-gen.ts
@@ -5,6 +5,8 @@ import { WorkflowForm } from "@commontools/charm";
 import { systemMdConcise } from "../../../charm/src/iframe/static.ts";
 import { formatForm } from "./spec-and-schema-gen.ts";
 
+// This is for the 'imagine-single-phase' workflow
+
 // Prompt for generating schema and specification from a goal
 export const SCHEMA_AND_CODE_FROM_GOAL_PROMPT = `
 You are creating a simple minimal viable product (MVP) based on a user's goal. Focus on the simplest implementation that works.

--- a/llm/src/prompts/spec-and-schema-gen-2.ts
+++ b/llm/src/prompts/spec-and-schema-gen-2.ts
@@ -2,17 +2,18 @@ import { hydratePrompt, parseTagFromResponse } from "./prompting.ts";
 import { client } from "../client.ts";
 import type { JSONSchema, JSONSchemaWritable } from "@commontools/builder";
 import { WorkflowForm } from "@commontools/charm";
+import { systemMdConcise } from "../../../charm/src/iframe/static.ts";
+import { formatForm } from "./spec-and-schema-gen.ts";
 
 // Prompt for generating schema and specification from a goal
-export const SCHEMA_FROM_GOAL_PROMPT = `
+export const SCHEMA_AND_CODE_FROM_GOAL_PROMPT = `
 You are creating a simple minimal viable product (MVP) based on a user's goal. Focus on the simplest implementation that works.
 
 Given a user's feature request, you will:
 1. Create a short title (2-5 words) that names the artifact
 2. Create a one-sentence description in the format "A <artifact> to <goal>"
-3. Create a concise specification (3-5 sentences max)
-4. Generate a brief implementation plan (3 steps max)
-5. Design a minimal JSON schema that represents the core data model
+3. Design a minimal JSON schema that represents the core data model
+4. Generate the source code for the updated artifact as per guide (attached)
 
 Your response must be structured as follows:
 
@@ -24,14 +25,6 @@ Your response must be structured as follows:
 [One-sentence description in the format "A <artifact> to <goal>"]
 </description>
 
-<spec>
-[Concise specification that captures only the essential requirements]
-</spec>
-
-<plan>
-[Brief 3-step implementation plan]
-</plan>
-
 <argument_schema>
 [Minimal JSON Schema in valid JSON format that represents the core data model]
 </argument_schema>
@@ -39,6 +32,10 @@ Your response must be structured as follows:
 <example_data>
 [Simple example data that conforms to the schema]
 </example_data>
+
+<source_code>
+[Source code for the updated artifact]
+</source_code>
 
 SCHEMA GUIDELINES:
 1. Keep it minimal:
@@ -80,6 +77,8 @@ SCHEMA GUIDELINES:
 }
 \`\`\`
 
+${systemMdConcise}
+
 IMPORTANT:
 - Focus on the simplest working version
 - Aim for fewer fields rather than more
@@ -88,15 +87,14 @@ IMPORTANT:
 `;
 
 // Prompt for generating specification from a goal and existing schema
-export const SPEC_FROM_SCHEMA_PROMPT = `
+export const CODE_FROM_SCHEMA_PROMPT = `
 You are creating a simple MVP based on the user's goal, using an existing data schema. Focus on the simplest implementation that works with the provided schema.
 
 Given a user's feature request and an existing data schema, you will:
 1. Create a short title (2-5 words) that names the artifact
 2. Create a one-sentence description in the format "A <artifact> to <goal>"
-3. Create a concise specification (3-5 sentences max) that works with the existing schema
-4. Generate a brief implementation plan (3 steps max)
-5. Design a minimal JSON schema that represents the core data model
+3. Design a minimal JSON schema that represents the core data model
+4. Generate the source code for the updated artifact as per guide (attached)
 
 Your response must be structured as follows:
 
@@ -108,17 +106,13 @@ Your response must be structured as follows:
 [One-sentence description in the format "A <artifact> to <goal>"]
 </description>
 
-<spec>
-[Concise specification that captures only the essential requirements]
-</spec>
-
-<plan>
-[Brief 3-step implementation plan using the existing schema]
-</plan>
-
 <result_schema>
 [Minimal JSON Schema in valid JSON format that represents data created by the artifact]
 </result_schema>
+
+<source_code>
+[Source code for the updated artifact]
+</source_code>
 
 SCHEMA GUIDELINES:
 1. Keep it minimal:
@@ -158,6 +152,8 @@ SCHEMA GUIDELINES:
   },
   "required": ["title", "content"]
 }
+
+${systemMdConcise}
 
 GUIDELINES:
 - Aim for the simplest possible solution that works with the existing schema
@@ -170,33 +166,23 @@ IMPORTANT:
 - Aim for fewer fields rather than more
 - But still capture all the important state the user is creating
 - The user can always iterate and improve the solution later
-`;
 
-export function formatForm(form: WorkflowForm) {
-  return `
-<goal>${form.input.processedInput}</goal>
-<plan>${
-    (form.plan?.steps ?? []).map((step) => `<step>${step}</step>`).join("\n")
-  }</plan>
-<description>${form.plan?.spec}</description>
-<data>${JSON.stringify(form.plan?.dataModel)}</data>
+Return ONLY the requested XML tags, no other commentary.
 `;
-}
 
 /**
- * Generates a complete specification, schema, and plan from a goal.
+ * Generates a schema and code from a goal.
  * @param goal The user's goal or request
  * @param existingSchema Optional existing schema to use as a basis
  * @param model Optional model identifier to use (defaults to claude-3-7-sonnet)
  * @returns Object containing title, description, specification, schema
  */
-export async function generateSpecAndSchema(
+export async function generateCodeAndSchema(
   form: WorkflowForm,
   existingSchema?: JSONSchema,
   model: string = "anthropic:claude-3-7-sonnet-latest",
 ): Promise<{
-  spec: string;
-  plan: string;
+  sourceCode: string;
   title: string;
   description: string;
   resultSchema: JSONSchema;
@@ -209,7 +195,7 @@ export async function generateSpecAndSchema(
 
   if (existingSchema && Object.keys(existingSchema).length > 0) {
     // When we have an existing schema, focus on generating specification
-    systemPrompt = SPEC_FROM_SCHEMA_PROMPT;
+    systemPrompt = CODE_FROM_SCHEMA_PROMPT;
     userContent = `
 ${formatForm(form)}
 
@@ -218,11 +204,11 @@ Existing Schema:
 ${JSON.stringify(existingSchema, null, 2)}
 \`\`\`
 
-Based on this goal and the existing schema, please provide a title, description, any additional schema,detailed specification, and implementation plan.
+Based on this goal and the existing schema, please provide a title, description, any additional schema and the source code.
 `;
   } else {
     // When generating from scratch, use the full schema generation prompt
-    systemPrompt = SCHEMA_FROM_GOAL_PROMPT;
+    systemPrompt = SCHEMA_AND_CODE_FROM_GOAL_PROMPT;
     userContent = formatForm(form);
   }
 
@@ -242,8 +228,7 @@ Based on this goal and the existing schema, please provide a title, description,
   // Extract sections from the response
   const title = parseTagFromResponse(response, "title") || "New Charm";
   const description = parseTagFromResponse(response, "description");
-  const spec = parseTagFromResponse(response, "spec");
-  const plan = parseTagFromResponse(response, "plan");
+  const sourceCode = parseTagFromResponse(response, "source_code");
 
   // If we have an existing schema, use it; otherwise parse the generated schema
   let resultSchema: JSONSchemaWritable;
@@ -275,112 +260,10 @@ Based on this goal and the existing schema, please provide a title, description,
   argumentSchema.description = description;
 
   return {
-    spec,
+    sourceCode,
     resultSchema,
     title,
     description,
     argumentSchema,
-    plan,
-  };
-}
-
-/**
- * Generates a complete specification, schema, and plan from a goal.
- * @param goal The user's goal or request
- * @param existingSchema Optional existing schema to use as a basis
- * @param model Optional model identifier to use (defaults to claude-3-7-sonnet)
- * @returns Object containing title, description, specification, schema
- */
-export async function generateSpecAndSchemaAndCode(
-  form: WorkflowForm,
-  existingSchema?: JSONSchema,
-  model: string = "anthropic:claude-3-7-sonnet-latest",
-): Promise<{
-  spec: string;
-  plan: string;
-  title: string;
-  description: string;
-  resultSchema: JSONSchema;
-  argumentSchema: JSONSchema;
-}> {
-  let systemPrompt, userContent;
-  if (!form.plan) {
-    throw new Error("Plan is required");
-  }
-
-  if (existingSchema && Object.keys(existingSchema).length > 0) {
-    // When we have an existing schema, focus on generating specification
-    systemPrompt = SPEC_FROM_SCHEMA_PROMPT;
-    userContent = `
-${formatForm(form)}
-
-Existing Schema:
-\`\`\`json
-${JSON.stringify(existingSchema, null, 2)}
-\`\`\`
-
-Based on this goal and the existing schema, please provide a title, description and any additional schema.
-`;
-  } else {
-    // When generating from scratch, use the full schema generation prompt
-    systemPrompt = SCHEMA_FROM_GOAL_PROMPT;
-    userContent = formatForm(form);
-  }
-
-  // Send the request to the LLM using the specified model or default
-  const response = await client.sendRequest({
-    model: model,
-    system: systemPrompt,
-    stream: false,
-    messages: [
-      {
-        role: "user",
-        content: userContent,
-      },
-    ],
-  });
-
-  // Extract sections from the response
-  const title = parseTagFromResponse(response, "title") || "New Charm";
-  const description = parseTagFromResponse(response, "description");
-  const spec = parseTagFromResponse(response, "spec");
-  const plan = parseTagFromResponse(response, "plan");
-
-  // If we have an existing schema, use it; otherwise parse the generated schema
-  let resultSchema: JSONSchemaWritable;
-  let argumentSchema: JSONSchemaWritable;
-
-  try {
-    const resultSchemaJson = parseTagFromResponse(response, "result_schema");
-    resultSchema = resultSchemaJson ? JSON.parse(resultSchemaJson) : {};
-  } catch (error) {
-    console.warn("Error parsing schema:", error);
-    // Fallback to an empty schema
-    resultSchema = {};
-  }
-
-  try {
-    const argumentSchemaJson = parseTagFromResponse(
-      response,
-      "argument_schema",
-    );
-    argumentSchema = argumentSchemaJson ? JSON.parse(argumentSchemaJson) : {};
-  } catch (error) {
-    console.warn("Error parsing schema:", error);
-    // Fallback to an empty schema
-    argumentSchema = {};
-  }
-
-  // Add title and description to schema
-  argumentSchema.title = title;
-  argumentSchema.description = description;
-
-  return {
-    spec,
-    resultSchema,
-    title,
-    description,
-    argumentSchema,
-    plan,
   };
 }


### PR DESCRIPTION
Performs codegen and schema gen in the same pass, with a concise prompt.

This adds a new button to the UI:
<img width="818" alt="image" src="https://github.com/user-attachments/assets/d0b736dc-caf2-483d-9fe2-5d732c352816" />

You can manually select 'Imagine (Single Phase)' but it will never be picked automatically. 
