### PR TITLE
[deno-web-test] Use a dynamically chosen port

### DIFF
--- a/deno-web-test/browser.ts
+++ b/deno-web-test/browser.ts
@@ -9,16 +9,18 @@ export class BrowserController extends EventTarget {
   private manifest: Manifest;
   private page: Page | null;
   private browser: Browser | null;
+  private serverPort: number;
 
-  constructor(manifest: Manifest) {
+  constructor(manifest: Manifest, serverPort: number) {
     super();
     this.manifest = manifest;
     this.browser = null;
     this.page = null;
+    this.serverPort = serverPort;
   }
 
   async load(filePath: string) {
-    const rootUrl = `http://localhost:${this.manifest.port}`;
+    const rootUrl = `http://localhost:${this.serverPort}`;
     const jsTestPath = tsToJs(filePath);
     const testUrl = `${rootUrl}/?test=/${jsTestPath}`;
     const config = this.manifest.config;

--- a/deno-web-test/cli.ts
+++ b/deno-web-test/cli.ts
@@ -1,4 +1,3 @@
-import { parseArgs } from "@std/cli/parse-args";
 import { TestServer } from "./server.ts";
 import { Manifest } from "./manifest.ts";
 import { buildTestDir } from "./utils.ts";
@@ -9,9 +8,16 @@ const manifest = await Manifest.create(Deno.cwd(), [...Deno.args]);
 await buildTestDir(manifest);
 
 const server = new TestServer(manifest);
-server.start(manifest.port);
+server.start(manifest.requestedPort);
+const port = server.port();
 
-const runner = new Runner(manifest);
+if (!port) {
+  throw new Error(
+    `Server could not listen on requested port ${manifest.requestedPort}.`,
+  );
+}
+
+const runner = new Runner(manifest, port);
 const success = await runner.run();
 
 if (!success) {

--- a/deno-web-test/manifest.ts
+++ b/deno-web-test/manifest.ts
@@ -10,8 +10,9 @@ export class Manifest {
   readonly tests: string[];
   // The root directory path of the static server.
   readonly serverDir: string;
-  // The port the static server is being served on.
-  readonly port: number;
+  // The requested port the static server is being served on.
+  // If `0` (the default), the actual listening port will be different.
+  readonly requestedPort: number;
   // Configuration defined via `deno-web-test.config.ts`
   readonly config: Config;
 
@@ -24,7 +25,7 @@ export class Manifest {
     this.projectDir = projectDir;
     this.tests = tests;
     this.serverDir = serverDir;
-    this.port = 8000;
+    this.requestedPort = 0;
     this.config = config;
   }
 

--- a/deno-web-test/runner.ts
+++ b/deno-web-test/runner.ts
@@ -11,11 +11,11 @@ export class Runner {
   browser: BrowserController;
   results: TestFileResults[];
 
-  constructor(manifest: Manifest) {
+  constructor(manifest: Manifest, serverPort: number) {
     this.manifest = manifest;
     this.reporter = new Reporter();
     this.results = [];
-    this.browser = new BrowserController(manifest);
+    this.browser = new BrowserController(manifest, serverPort);
     this.browser.addEventListener(
       "console",
       (e: Event) => this.onConsole(e as ConsoleEvent),

--- a/deno-web-test/server.ts
+++ b/deno-web-test/server.ts
@@ -26,6 +26,11 @@ export class TestServer {
     this.server.unref();
   }
 
+  // Returns the listening port, if server running.
+  port(): number | undefined {
+    return this.server?.addr?.port;
+  }
+
   async stop() {
     if (this.server) {
       await this.server.shutdown();


### PR DESCRIPTION
The default port 8000 conflicts with a locally running toolshed. Use a dynamically chosen port so that tests can run concurrently without additional configuration.