### PR TITLE
chore: Move typescript to its own bundle chunk to reduce frontend payload

### DIFF
--- a/runner/src/local-build.ts
+++ b/runner/src/local-build.ts
@@ -8,6 +8,18 @@ import turndown from "turndown";
 
 let DOMParser: any;
 
+type TypeScriptAPI = typeof import("typescript");
+const getTSCompiler = (() => {
+  let ts: Promise<TypeScriptAPI> | void;
+  return function getTSCompiler(): Promise<TypeScriptAPI> {
+    if (ts) {
+      return ts;
+    }
+    ts = import("typescript").then((exports) => exports.default);
+    return ts;
+  };
+})();
+
 // NOTE(ja): importing JSDOM in browser throws an error :(
 async function getDOMParser() {
   if (DOMParser) {
@@ -62,6 +74,7 @@ const ensureRequires = async (js: string): Promise<Record<string, any>> => {
 export const tsToExports = async (
   src: string,
 ): Promise<{ exports?: any; errors?: string }> => {
+  const ts = await getTSCompiler();
   // Add error handling for compilation
   const result = ts.transpileModule(src, {
     compilerOptions: {


### PR DESCRIPTION
Currently, our frontend bundle contains 9MB of typescript compiler code to dynamically compile recipes.

previous index.js: 15MB
new index.js: 6MB

---

File-on-disk, bundle transforms from a 7MB bundle into two 3.5MB bundles