### PR TITLE
Llm feedback

### DIFF
--- a/builder/src/env.ts
+++ b/builder/src/env.ts
@@ -30,3 +30,15 @@ export function setRecipeEnvironment(env: RecipeEnvironment) {
 export function getRecipeEnvironment(): RecipeEnvironment {
   return globalEnv;
 }
+
+// until we thread the trace IDs through the entire workflow/recipe/...
+
+let lastTraceSpanID: string | undefined;
+
+export function setLastTraceSpanID(spanID: string) {
+  lastTraceSpanID = spanID;
+}
+
+export function getLastTraceSpanID(): string | undefined {
+  return lastTraceSpanID;
+}

--- a/builder/src/index.ts
+++ b/builder/src/index.ts
@@ -10,8 +10,10 @@ export {
   render,
 } from "./module.ts";
 export {
+  getLastTraceSpanID,
   getRecipeEnvironment,
   type RecipeEnvironment,
+  setLastTraceSpanID,
   setRecipeEnvironment,
 } from "./env.ts";
 export {

--- a/charm/src/iterate.ts
+++ b/charm/src/iterate.ts
@@ -29,7 +29,7 @@ export const genSrc = async ({
   schema,
   steps,
   model,
-  generationId
+  generationId,
 }: {
   src?: string;
   spec?: string;
@@ -88,7 +88,7 @@ export async function iterate(
     schema: iframe.argumentSchema,
     steps: plan?.steps,
     model,
-    generationId
+    generationId,
   });
 
   return generateNewRecipeVersion(charmManager, charm, newIFrameSrc, newSpec);
@@ -337,7 +337,7 @@ async function twoPhaseCodeGeneration(
     newSpec,
     schema,
     steps: form.plan?.steps,
-    generationId: form.meta.generationId
+    generationId: form.meta.generationId,
   });
   const name = extractTitle(newIFrameSrc, title); // Use the generated title as fallback
   const newRecipeSrc = buildFullRecipe({

--- a/jumble/src/components/ActionBar.tsx
+++ b/jumble/src/components/ActionBar.tsx
@@ -39,7 +39,7 @@ export function ActionBar() {
             <NavLink
               key={action.id}
               to={action.to}
-              className={actionButtonStyles}
+              className={`${actionButtonStyles} ${action.className || ""}`}
               style={actionButtonInlineStyles}
             >
               <ActionButton label={action.label}>
@@ -52,7 +52,7 @@ export function ActionBar() {
         return (
           <animated.button
             key={action.id}
-            className={actionButtonStyles}
+            className={`${actionButtonStyles} ${action.className || ""}`}
             style={actionButtonInlineStyles}
             onClick={action.onClick}
           >

--- a/jumble/src/components/FeedbackActions.tsx
+++ b/jumble/src/components/FeedbackActions.tsx
@@ -1,16 +1,8 @@
 import { useEffect, useState } from "react";
 import { FeedbackDialog } from "@/components/FeedbackDialog.tsx";
 import { submitFeedback } from "@/services/feedback.ts";
+import { getLastTraceSpanID } from "@commontools/builder";
 import { MdThumbDownOffAlt, MdThumbUpOffAlt } from "react-icons/md";
-
-const getCurrentSpanID = (): string => {
-  // @ts-ignore: we set the lastTraceSpanID in llm client
-  const traceSpanID = globalThis.lastTraceSpanID;
-  if (!traceSpanID) {
-    return "";
-  }
-  return traceSpanID as string;
-};
 
 export function FeedbackActions() {
   // States for the feedback dialog
@@ -56,7 +48,7 @@ export function FeedbackActions() {
         {
           score: data.score,
           explanation: data.explanation,
-          spanId: getCurrentSpanID(),
+          spanId: getLastTraceSpanID() as string,
         },
         data.userInfo,
       );

--- a/jumble/src/components/FeedbackActions.tsx
+++ b/jumble/src/components/FeedbackActions.tsx
@@ -4,7 +4,8 @@ import { FeedbackDialog } from "@/components/FeedbackDialog.tsx";
 import { submitFeedback } from "@/services/feedback.ts";
 import { MdSend, MdThumbDownOffAlt, MdThumbUpOffAlt } from "react-icons/md";
 
-// For demo purposes - in a real app, this would come from the current response or context
+// FIXME(jake): This is for demo purposes... ideally we could just get the llm
+// span from the persisted blobby blob of the charm recipe, but none of that is hooked up yet.
 const CURRENT_SPAN_ID = "48fc49c695cdc4f3";
 
 export function FeedbackActions() {
@@ -26,7 +27,6 @@ export function FeedbackActions() {
     );
     setInitialScore(score);
     setIsFeedbackDialogOpen(true);
-    // Hide the feedback buttons when opening the modal
     setShowFeedbackButtons(false);
   };
 
@@ -104,12 +104,13 @@ export function FeedbackActions() {
       {/* Popup buttons that appear when feedback button is clicked */}
       {showFeedbackButtons && (
         <div className="fixed z-[100] bottom-2 right-2 flex flex-col-reverse gap-2 pointer-events-none">
-          {/* This spacer accounts for the main button height */}
-          <div className="h-16"></div>
+          {/* This spacer places the thumbs buttons just above the feedback button */}
+          <div className="h-12"></div>
 
           {/* Thumbs down button */}
           <div className="pointer-events-auto">
             <button
+              type="button"
               className="w-12 h-12 cursor-pointer flex items-center justify-center border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)] bg-red-50 hover:translate-y-[-2px] relative group"
               onClick={() => handleOpenFeedback(0)}
             >
@@ -123,6 +124,7 @@ export function FeedbackActions() {
           {/* Thumbs up button */}
           <div className="pointer-events-auto">
             <button
+              type="button"
               className="w-12 h-12 cursor-pointer flex items-center justify-center border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)] bg-green-50 hover:translate-y-[-2px] relative group"
               onClick={() => handleOpenFeedback(1)}
             >

--- a/jumble/src/components/FeedbackActions.tsx
+++ b/jumble/src/components/FeedbackActions.tsx
@@ -6,7 +6,15 @@ import { MdSend, MdThumbDownOffAlt, MdThumbUpOffAlt } from "react-icons/md";
 
 // FIXME(jake): This is for demo purposes... ideally we could just get the llm
 // span from the persisted blobby blob of the charm recipe, but none of that is hooked up yet.
-const CURRENT_SPAN_ID = "48fc49c695cdc4f3";
+// const CURRENT_SPAN_ID = "48fc49c695cdc4f3";
+
+const getCurrentSpanID = (): string => {
+  const traceSpanID = localStorage.getItem("traceSpanID");
+  if (!traceSpanID) {
+    return "";
+  }
+  return traceSpanID as string;
+};
 
 export function FeedbackActions() {
   // States for the feedback dialog
@@ -45,7 +53,7 @@ export function FeedbackActions() {
         {
           score: data.score,
           explanation: data.explanation,
-          spanId: CURRENT_SPAN_ID,
+          spanId: getCurrentSpanID(),
         },
         data.userInfo,
       );

--- a/jumble/src/components/FeedbackActions.tsx
+++ b/jumble/src/components/FeedbackActions.tsx
@@ -4,10 +4,6 @@ import { FeedbackDialog } from "@/components/FeedbackDialog.tsx";
 import { submitFeedback } from "@/services/feedback.ts";
 import { MdSend, MdThumbDownOffAlt, MdThumbUpOffAlt } from "react-icons/md";
 
-// FIXME(jake): This is for demo purposes... ideally we could just get the llm
-// span from the persisted blobby blob of the charm recipe, but none of that is hooked up yet.
-// const CURRENT_SPAN_ID = "48fc49c695cdc4f3";
-
 const getCurrentSpanID = (): string => {
   const traceSpanID = localStorage.getItem("traceSpanID");
   if (!traceSpanID) {

--- a/jumble/src/components/FeedbackActions.tsx
+++ b/jumble/src/components/FeedbackActions.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from "react";
+import { Action, useActionManager } from "@/contexts/ActionManagerContext.tsx";
+import { FeedbackDialog } from "@/components/FeedbackDialog.tsx";
+import { submitFeedback } from "@/services/feedback.ts";
+import { MdSend, MdThumbDownOffAlt, MdThumbUpOffAlt } from "react-icons/md";
+
+// For demo purposes - in a real app, this would come from the current response or context
+const CURRENT_SPAN_ID = "48fc49c695cdc4f3";
+
+export function FeedbackActions() {
+  // States for the feedback dialog
+  const [isFeedbackDialogOpen, setIsFeedbackDialogOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [initialScore, setInitialScore] = useState<number>(1);
+  const [showFeedbackButtons, setShowFeedbackButtons] = useState(false);
+  const { registerAction } = useActionManager();
+
+  // Handler functions for feedback actions
+  const toggleFeedbackButtons = () => {
+    setShowFeedbackButtons((prev) => !prev);
+  };
+
+  const handleOpenFeedback = (score: number) => {
+    console.log(
+      `Opening ${score === 1 ? "positive" : "negative"} feedback dialog`,
+    );
+    setInitialScore(score);
+    setIsFeedbackDialogOpen(true);
+    // Hide the feedback buttons when opening the modal
+    setShowFeedbackButtons(false);
+  };
+
+  const handleCloseFeedback = () => {
+    setIsFeedbackDialogOpen(false);
+  };
+
+  const handleSubmitFeedback = async (
+    data: { score: number; explanation: string; userInfo?: any },
+  ) => {
+    console.log("Submitting feedback:", data);
+    setIsSubmitting(true);
+
+    try {
+      await submitFeedback(
+        {
+          score: data.score,
+          explanation: data.explanation,
+          spanId: CURRENT_SPAN_ID,
+        },
+        data.userInfo,
+      );
+
+      setIsFeedbackDialogOpen(false);
+      alert("Feedback submitted successfully! Thank you for your input.");
+    } catch (error) {
+      alert(
+        `Error submitting feedback: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // Register all actions
+  useEffect(() => {
+    // Create actions array for batch registration
+    const actions: Action[] = [];
+
+    // Register the main feedback toggle button
+    const toggleAction: Action = {
+      id: "feedback-toggle",
+      label: "Feedback",
+      icon: <MdSend size={24} />,
+      onClick: toggleFeedbackButtons,
+      priority: 30,
+      className: showFeedbackButtons ? "bg-blue-100" : "",
+    };
+
+    actions.push(toggleAction);
+
+    // Register all actions and collect unregister functions
+    const unregisterFunctions = actions.map((action) => registerAction(action));
+
+    // Return combined cleanup function
+    return () => {
+      unregisterFunctions.forEach((unregister) => unregister());
+    };
+  }, [showFeedbackButtons, registerAction]);
+
+  // Render feedback dialog and the popup buttons
+  return (
+    <>
+      {/* Feedback dialog for submissions */}
+      <FeedbackDialog
+        isOpen={isFeedbackDialogOpen}
+        onClose={handleCloseFeedback}
+        onSubmit={handleSubmitFeedback}
+        initialScore={initialScore}
+        isSubmitting={isSubmitting}
+      />
+
+      {/* Popup buttons that appear when feedback button is clicked */}
+      {showFeedbackButtons && (
+        <div className="fixed z-[100] bottom-2 right-2 flex flex-col-reverse gap-2 pointer-events-none">
+          {/* This spacer accounts for the main button height */}
+          <div className="h-16"></div>
+
+          {/* Thumbs down button */}
+          <div className="pointer-events-auto">
+            <button
+              className="w-12 h-12 cursor-pointer flex items-center justify-center border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)] bg-red-50 hover:translate-y-[-2px] relative group"
+              onClick={() => handleOpenFeedback(0)}
+            >
+              <MdThumbDownOffAlt className="w-6 h-6" />
+              <div className="absolute left-[-100px] top-1/2 -translate-y-1/2 bg-gray-800 text-white px-2 py-1 rounded text-sm opacity-0 group-hover:opacity-100 transition-opacity z-[200] whitespace-nowrap">
+                Not Helpful
+              </div>
+            </button>
+          </div>
+
+          {/* Thumbs up button */}
+          <div className="pointer-events-auto">
+            <button
+              className="w-12 h-12 cursor-pointer flex items-center justify-center border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)] bg-green-50 hover:translate-y-[-2px] relative group"
+              onClick={() => handleOpenFeedback(1)}
+            >
+              <MdThumbUpOffAlt className="w-6 h-6" />
+              <div className="absolute left-[-100px] top-1/2 -translate-y-1/2 bg-gray-800 text-white px-2 py-1 rounded text-sm opacity-0 group-hover:opacity-100 transition-opacity z-[200] whitespace-nowrap">
+                Helpful
+              </div>
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/jumble/src/components/FeedbackActions.tsx
+++ b/jumble/src/components/FeedbackActions.tsx
@@ -4,7 +4,8 @@ import { submitFeedback } from "@/services/feedback.ts";
 import { MdThumbDownOffAlt, MdThumbUpOffAlt } from "react-icons/md";
 
 const getCurrentSpanID = (): string => {
-  const traceSpanID = localStorage.getItem("traceSpanID");
+  // @ts-ignore: we set the lastTraceSpanID in llm client
+  const traceSpanID = globalThis.lastTraceSpanID;
   if (!traceSpanID) {
     return "";
   }

--- a/jumble/src/components/FeedbackDialog.tsx
+++ b/jumble/src/components/FeedbackDialog.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from "react";
+import { fetchUserInfo } from "@/services/feedback.ts";
+
+interface FeedbackDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (
+    data: { score: number; explanation: string; userInfo?: any },
+  ) => Promise<void>;
+  initialScore: number;
+  isSubmitting?: boolean;
+}
+
+export function FeedbackDialog({
+  isOpen,
+  onClose,
+  onSubmit,
+  initialScore,
+  isSubmitting = false,
+}: FeedbackDialogProps) {
+  const [explanation, setExplanation] = useState("");
+
+  // Reset explanation when dialog opens with a new score
+  useEffect(() => {
+    if (isOpen) {
+      setExplanation("");
+    }
+  }, [isOpen, initialScore]);
+
+  // Log when dialog open state changes
+  useEffect(() => {
+    console.log(
+      "FeedbackDialog isOpen:",
+      isOpen,
+      "initialScore:",
+      initialScore,
+    );
+  }, [isOpen, initialScore]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!isOpen) return;
+
+      if (e.key === "Escape") {
+        onClose();
+      } else if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        if (!isSubmitting && explanation.trim()) {
+          submitFeedback();
+        }
+      }
+    };
+
+    globalThis.addEventListener("keydown", handleKeyDown);
+    return () => globalThis.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose, onSubmit, explanation, isSubmitting, initialScore]);
+
+  if (!isOpen) return null;
+
+  const submitFeedback = async () => {
+    if (!explanation.trim()) return;
+
+    console.log("Submitting feedback form with explanation:", explanation);
+
+    // Fetch user info only when submitting
+    try {
+      const userInfo = await fetchUserInfo();
+      console.log("Fetched user info before submission:", userInfo);
+
+      // Submit feedback with the user info
+      await onSubmit({
+        score: initialScore,
+        explanation,
+        userInfo,
+      });
+    } catch (error) {
+      console.error("Error fetching user info during submission:", error);
+      // Continue with submission even if user info fetch fails
+      await onSubmit({ score: initialScore, explanation });
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    submitFeedback();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-[#00000080] flex items-center justify-center z-50">
+      <div className="bg-white border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)] p-6 max-w-lg w-full mx-4">
+        <h2 className="text-2xl font-bold mb-4">
+          {initialScore === 1 ? "Positive Feedback" : "Improvement Feedback"}
+        </h2>
+        <form onSubmit={handleSubmit}>
+          <div className="mb-6">
+            <label className="block text-sm font-medium mb-1">
+              {initialScore === 1
+                ? "What did you like about this response?"
+                : "How could this response be improved?"}
+            </label>
+            <textarea
+              value={explanation}
+              onChange={(e) => setExplanation(e.target.value)}
+              className="w-full px-3 py-2 border-2 border-black"
+              rows={5}
+              disabled={isSubmitting}
+              placeholder={initialScore === 1
+                ? "What aspects were helpful or well done?"
+                : "What would make this response more useful?"}
+              required
+            />
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 border-2 border-black hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isSubmitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 bg-black text-white border-2 border-black hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              disabled={isSubmitting || !explanation.trim()}
+            >
+              {isSubmitting ? "Submitting..." : (
+                <span>
+                  Submit <span className="text-xs">cmd+enter</span>
+                </span>
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/jumble/src/contexts/ActionManagerContext.tsx
+++ b/jumble/src/contexts/ActionManagerContext.tsx
@@ -24,6 +24,7 @@ export type Action = {
   priority?: number;
   to?: string; // For NavLink actions
   keyCombo?: KeyCombo; // Keyboard shortcut
+  className?: string; // Optional CSS class for styling the button
 };
 
 type ActionManagerContextType = {

--- a/jumble/src/global.d.ts
+++ b/jumble/src/global.d.ts
@@ -56,4 +56,7 @@ declare module "react-icons/md" {
   export const MdOutlineStar: React.FC<IconProps>;
   export const MdOutlineStarBorder: React.FC<IconProps>;
   export const MdShare: React.FC<IconProps>;
+  export const MdSend: React.FC<IconProps>;
+  export const MdThumbDownOffAlt: React.FC<IconProps>;
+  export const MdThumbUpOffAlt: React.FC<IconProps>;
 }

--- a/jumble/src/hooks/use-global-actions.tsx
+++ b/jumble/src/hooks/use-global-actions.tsx
@@ -33,22 +33,6 @@ export function useGlobalActions() {
     ),
   );
 
-  // Feedback action (always available)
-  useAction(
-    useMemo(
-      () => ({
-        id: "feedback-toggle",
-        label: "Feedback",
-        icon: <MdSend size={24} />,
-        onClick: () => {
-          globalThis.dispatchEvent(new CustomEvent("toggle-feedback"));
-        },
-        priority: 30,
-      }),
-      [],
-    ),
-  );
-
   const hasCharmId = useCallback(() => Boolean(charmId), [charmId]);
 
   const { charmManager } = useCharmManager();
@@ -106,6 +90,23 @@ export function useGlobalActions() {
         priority: 50,
       }),
       [hasCharmId, togglePath],
+    ),
+  );
+
+  // Feedback action (available only when a charm is open)
+  useAction(
+    useMemo(
+      () => ({
+        id: "feedback-toggle",
+        label: "Feedback",
+        icon: <MdSend size={24} />,
+        onClick: () => {
+          globalThis.dispatchEvent(new CustomEvent("toggle-feedback"));
+        },
+        priority: 30,
+        predicate: hasCharmId,
+      }),
+      [hasCharmId],
     ),
   );
 }

--- a/jumble/src/hooks/use-global-actions.tsx
+++ b/jumble/src/hooks/use-global-actions.tsx
@@ -1,7 +1,7 @@
 import "@commontools/ui";
 import { useLocation, useParams } from "react-router-dom";
 import { type CharmRouteParams } from "@/routes.ts";
-import { MdEdit, MdOutlineStar, MdShare } from "react-icons/md";
+import { MdEdit, MdOutlineStar, MdSend, MdShare } from "react-icons/md";
 
 import { useAction } from "@/contexts/ActionManagerContext.tsx";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -28,6 +28,22 @@ export function useGlobalActions() {
           globalThis.dispatchEvent(new CustomEvent("open-command-center"));
         },
         priority: 100,
+      }),
+      [],
+    ),
+  );
+
+  // Feedback action (always available)
+  useAction(
+    useMemo(
+      () => ({
+        id: "feedback-toggle",
+        label: "Feedback",
+        icon: <MdSend size={24} />,
+        onClick: () => {
+          globalThis.dispatchEvent(new CustomEvent("toggle-feedback"));
+        },
+        priority: 30,
       }),
       [],
     ),

--- a/jumble/src/services/feedback.ts
+++ b/jumble/src/services/feedback.ts
@@ -1,0 +1,75 @@
+interface UserInfo {
+  name: string;
+  email: string;
+  shortName: string;
+  avatar: string;
+}
+
+interface FeedbackData {
+  score: number;
+  explanation: string;
+  spanId: string;
+}
+
+export async function fetchUserInfo(): Promise<UserInfo | null> {
+  try {
+    console.log("Fetching user info from /api/whoami...");
+    const response = await fetch("/api/whoami");
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch user info: ${response.status} ${response.statusText}`,
+      );
+    }
+    const data = await response.json();
+    console.log("User info fetched successfully:", data);
+    return data;
+  } catch (error) {
+    console.error("Error fetching user info:", error);
+    return null;
+  }
+}
+
+export async function submitFeedback(
+  data: FeedbackData,
+  userInfo: UserInfo | null,
+): Promise<boolean> {
+  try {
+    const payload = {
+      span_id: data.spanId,
+      name: userInfo?.email || "anonymous@user.com",
+      annotator_kind: "HUMAN",
+      result: {
+        label: "user_feedback",
+        score: data.score,
+        explanation: data.explanation,
+      },
+    };
+
+    console.log("Sending feedback payload:", JSON.stringify(payload, null, 2));
+
+    const response = await fetch("/api/ai/llm/feedback", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    console.log("Feedback API response status:", response.status);
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      console.error("Feedback API error response:", errorData);
+      throw new Error(
+        errorData.error || `Failed to submit feedback: ${response.status}`,
+      );
+    }
+
+    const responseData = await response.json();
+    console.log("Feedback API success response:", responseData);
+    return true;
+  } catch (error) {
+    console.error("Error submitting feedback:", error);
+    throw error;
+  }
+}

--- a/jumble/src/views/Shell.tsx
+++ b/jumble/src/views/Shell.tsx
@@ -12,6 +12,7 @@ import { useGlobalActions } from "@/hooks/use-global-actions.tsx";
 import { SyncStatusProvider } from "@/contexts/SyncStatusContext.tsx";
 import { ToggleableNetworkInspector } from "@/components/NetworkInspector.tsx";
 import { NetworkInspectorProvider } from "@/contexts/NetworkInspectorContext.tsx";
+import { FeedbackActions } from "@/components/FeedbackActions.tsx";
 
 export default function Shell() {
   const { charmId } = useParams<CharmRouteParams>();
@@ -36,6 +37,7 @@ export default function Shell() {
             <ActionBar />
             <CharmPublisher />
             <CommandCenter />
+            <FeedbackActions />
             <ToggleableNetworkInspector
               visible={localStorage.getItem("networkInspectorVisible") ===
                 "true"}

--- a/jumble/vite.config.ts
+++ b/jumble/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       "localhost",
       "127.0.0.1",
       "bens-macbook-pro.saga-castor.ts.net",
+      "jake.saga-castor.ts.net",
     ],
     proxy: {
       "/api/integrations": {

--- a/llm/src/client.ts
+++ b/llm/src/client.ts
@@ -78,7 +78,8 @@ export class LLMClient {
 
         const traceSpanID = response.headers.get("x-ct-llm-trace-id") as string;
         if (traceSpanID) {
-          localStorage.setItem("traceSpanID", traceSpanID);
+          // @ts-ignore: this is a hack until we send this through workflow
+          globalThis.lastTraceSpanID = traceSpanID;
         }
 
         // the server might return cached data instead of a stream

--- a/llm/src/client.ts
+++ b/llm/src/client.ts
@@ -1,4 +1,5 @@
 import { LlmPrompt } from "./prompts/prompting.ts";
+import { setLastTraceSpanID } from "@commontools/builder";
 
 export type SimpleMessage = {
   role: "user" | "assistant";
@@ -78,8 +79,7 @@ export class LLMClient {
 
         const traceSpanID = response.headers.get("x-ct-llm-trace-id") as string;
         if (traceSpanID) {
-          // @ts-ignore: this is a hack until we send this through workflow
-          globalThis.lastTraceSpanID = traceSpanID;
+          setLastTraceSpanID(traceSpanID);
         }
 
         // the server might return cached data instead of a stream

--- a/llm/src/client.ts
+++ b/llm/src/client.ts
@@ -76,13 +76,17 @@ export class LLMClient {
           throw new Error("No response body");
         }
 
+        const traceSpanID = response.headers.get("x-ct-llm-trace-id") as string;
+        if (traceSpanID) {
+          localStorage.setItem("traceSpanID", traceSpanID);
+        }
+
         // the server might return cached data instead of a stream
         if (response.headers.get("content-type") === "application/json") {
           const data = (await response.json()) as SimpleMessage;
           // FIXME(ja): can the LLM ever return anything other than a string?
           return data.content as string;
         }
-
         // FIXME(ja): this doesn't handle falling back to other models
         // if we fail during streaming
         return await this.stream(response.body, partialCB);

--- a/toolshed/env.ts
+++ b/toolshed/env.ts
@@ -44,6 +44,7 @@ const EnvSchema = z.object({
   // LLM Observability Tool
   CTTS_AI_LLM_PHOENIX_PROJECT: z.string().default(""),
   CTTS_AI_LLM_PHOENIX_URL: z.string().default(""),
+  CTTS_AI_LLM_PHOENIX_API_URL: z.string().default(""),
   CTTS_AI_LLM_PHOENIX_API_KEY: z.string().default(""),
   // ===========================================================================
 

--- a/toolshed/routes/ai/llm/instrumentation.ts
+++ b/toolshed/routes/ai/llm/instrumentation.ts
@@ -27,7 +27,13 @@ export function register() {
           },
         }),
         spanFilter: (span) => {
-          return isOpenInferenceSpan(span);
+          // console.log("SPAN", span);
+          const includeSpanCriteria = [
+            isOpenInferenceSpan(span),
+            span.attributes["http.route"] == "/api/ai/llm", // Include the root span, which is in the hono app
+            span.instrumentationLibrary.name.includes("@vercel/otel"), // Include the actual LLM API fetch span
+          ];
+          return includeSpanCriteria.some((c) => c);
         },
       }),
     ],

--- a/toolshed/routes/ai/llm/llm.handlers.ts
+++ b/toolshed/routes/ai/llm/llm.handlers.ts
@@ -118,10 +118,10 @@ export const generateText: AppRouteHandler<GenerateTextRoute> = async (c) => {
     JSON.stringify(withoutMetadata(payload)),
   );
   const cachedResult = await cache.loadItem(cacheKey);
-  // if (cachedResult) {
-  //   const lastMessage = cachedResult.messages[cachedResult.messages.length - 1];
-  //   return c.json(lastMessage);
-  // }
+  if (cachedResult) {
+    const lastMessage = cachedResult.messages[cachedResult.messages.length - 1];
+    return c.json(lastMessage);
+  }
 
   const persistCache = async (
     messages: { role: string; content: string }[],

--- a/toolshed/routes/ai/llm/llm.handlers.ts
+++ b/toolshed/routes/ai/llm/llm.handlers.ts
@@ -208,17 +208,19 @@ export const submitFeedback: AppRouteHandler<FeedbackRoute> = async (c) => {
       ],
     };
 
+    const phoenixAnnotationPayload = {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Authorization": `Bearer ${env.CTTS_AI_LLM_PHOENIX_API_KEY}`,
+      },
+      body: JSON.stringify(phoenixPayload),
+    };
+
     const response = await fetch(
       `${env.CTTS_AI_LLM_PHOENIX_API_URL}/span_annotations?sync=false`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Accept": "application/json",
-          "api_key": env.CTTS_AI_LLM_PHOENIX_API_KEY,
-        },
-        body: JSON.stringify(phoenixPayload),
-      },
+      phoenixAnnotationPayload,
     );
 
     if (!response.ok) {

--- a/toolshed/routes/ai/llm/llm.handlers.ts
+++ b/toolshed/routes/ai/llm/llm.handlers.ts
@@ -226,7 +226,7 @@ export const submitFeedback: AppRouteHandler<FeedbackRoute> = async (c) => {
       throw new Error(`Phoenix API error: ${response.status} ${errorText}`);
     }
 
-    return c.json({ success: true });
+    return c.json({ success: true }, HttpStatusCodes.OK);
   } catch (error) {
     console.error("Error submitting feedback:", error);
     const message = error instanceof Error ? error.message : "Unknown error";

--- a/toolshed/routes/ai/llm/llm.index.ts
+++ b/toolshed/routes/ai/llm/llm.index.ts
@@ -11,7 +11,8 @@ if (env.CTTS_AI_LLM_PHOENIX_PROJECT) {
 
 const router = createRouter()
   .openapi(routes.getModels, handlers.getModels)
-  .openapi(routes.generateText, handlers.generateText);
+  .openapi(routes.generateText, handlers.generateText)
+  .openapi(routes.feedback, handlers.submitFeedback);
 
 router.use(
   "/api/ai/llm/*",

--- a/toolshed/routes/ai/llm/llm.routes.ts
+++ b/toolshed/routes/ai/llm/llm.routes.ts
@@ -72,6 +72,18 @@ export type GetModelsRouteQueryParams = z.infer<
   typeof GetModelsRouteQueryParams
 >;
 
+export const FeedbackSchema = z.object({
+  span_id: z.string(),
+  name: z.string().default("user feedback"),
+  annotator_kind: z.enum(["HUMAN", "LLM"]).default("HUMAN"),
+  result: z.object({
+    label: z.string().optional(),
+    score: z.number().optional(),
+    explanation: z.string().optional(),
+  }),
+  metadata: z.record(z.unknown()).optional(),
+});
+
 // Route definitions
 export const getModels = createRoute({
   path: "/api/ai/llm/models",
@@ -157,5 +169,54 @@ export const generateText = createRoute({
   },
 });
 
+export const feedback = createRoute({
+  path: "/api/ai/llm/feedback",
+  method: "post",
+  tags,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: FeedbackSchema.openapi({
+            example: {
+              span_id: "67f6740bbe1ddc3f",
+              name: "correctness",
+              annotator_kind: "HUMAN",
+              result: {
+                label: "correct",
+                score: 1,
+                explanation: "The response answered the question I asked",
+              },
+            },
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      z.object({
+        success: z.boolean(),
+      }).openapi({
+        example: {
+          success: true,
+        },
+      }),
+      "Feedback submitted successfully",
+    ),
+    [HttpStatusCodes.BAD_REQUEST]: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.string(),
+          }),
+        },
+      },
+      description: "Invalid request parameters",
+    },
+  },
+});
+
 export type GetModelsRoute = typeof getModels;
 export type GenerateTextRoute = typeof generateText;
+export type FeedbackRoute = typeof feedback;


### PR DESCRIPTION
This PR contains all of the API and UI plumbing to handle user feedback submissions for a specific opentelemetry span id (which points to a llm request)

NOTE: This is currently a work-in-progress. We need to figure out how to get the actual llm telemetry span id from the active charm, and I'm not sure how to do this part.

the ui is that we have a feedback button, when you click it, it pops open a thumbs-up and thumbs-down button

<img width="252" alt="image" src="https://github.com/user-attachments/assets/e19933c9-3115-4b49-b95f-14ba632d139b" />

when you click a thumbs button, it gives you a text field to fill out some feedback, which we then send to phoenix
<img width="574" alt="image" src="https://github.com/user-attachments/assets/4cc702c6-bc94-4012-889d-0c3055cf87a5" />

this shows up in phoenix as an annotation 
<img width="1305" alt="image" src="https://github.com/user-attachments/assets/89cca3b8-8aac-44de-be64-dd3cb47d8d70" />
