### PR TITLE
feat: Wire up feedback to activity status jobs

### DIFF
--- a/charm/src/iterate.ts
+++ b/charm/src/iterate.ts
@@ -46,7 +46,7 @@ export const genSrc = async ({
   model?: string;
   generationId?: string;
   cache: boolean;
-}): Promise<string> => {
+}): Promise<{ content: string; llmRequestId?: string }> => {
   const request = buildPrompt({
     src,
     spec,
@@ -85,7 +85,7 @@ export const genSrc = async ({
   const source = injectUserCode(
     response.content.split(RESPONSE_PREFILL)[1].split("\n```")[0],
   );
-  return source;
+  return { content: source, llmRequestId: response.id };
 };
 
 /**
@@ -99,7 +99,7 @@ export async function iterate(
   model?: string,
   generationId?: string,
   cache = true,
-): Promise<Cell<Charm>> {
+): Promise<{ cell: Cell<Charm>; llmRequestId?: string }> {
   const { iframe } = getIframeRecipe(charm);
   if (!iframe) {
     throw new Error("Cannot iterate on a non-iframe. Must extend instead.");
@@ -109,7 +109,7 @@ export async function iterate(
   const iframeSpec = iframe.spec;
   const newSpec = plan?.spec ?? iframeSpec;
 
-  const newIFrameSrc = await genSrc({
+  const { content: newIFrameSrc, llmRequestId } = await genSrc({
     src: iframe.src,
     spec: iframeSpec,
     newSpec,
@@ -120,13 +120,16 @@ export async function iterate(
     cache,
   });
 
-  return generateNewRecipeVersion(
-    charmManager,
-    charm,
-    newIFrameSrc,
-    newSpec,
-    generationId,
-  );
+  return {
+    cell: await generateNewRecipeVersion(
+      charmManager,
+      charm,
+      newIFrameSrc,
+      newSpec,
+      generationId,
+    ),
+    llmRequestId,
+  };
 }
 
 export function extractTitle(src: string, defaultTitle: string): string {
@@ -273,6 +276,7 @@ async function singlePhaseCodeGeneration(
     resultSchema,
     title,
     description,
+    llmRequestId,
   } = await generateCodeAndSchema(form, existingSchema, form.meta.modelId);
 
   console.log("resultSchema", resultSchema);
@@ -331,6 +335,7 @@ async function singlePhaseCodeGeneration(
     newRecipeSrc,
     name,
     schema,
+    llmRequestId,
   };
 }
 
@@ -396,7 +401,7 @@ async function twoPhaseCodeGeneration(
   }
 
   // Phase 2: Generate UI code using the schema and enhanced spec
-  const newIFrameSrc = await genSrc({
+  const { content: newIFrameSrc, llmRequestId } = await genSrc({
     newSpec,
     schema,
     steps: form.plan?.steps,
@@ -421,6 +426,7 @@ async function twoPhaseCodeGeneration(
     newRecipeSrc,
     name,
     schema,
+    llmRequestId,
   };
 }
 
@@ -435,7 +441,7 @@ async function twoPhaseCodeGeneration(
 export async function castNewRecipe(
   charmManager: CharmManager,
   form: WorkflowForm,
-): Promise<Cell<Charm>> {
+): Promise<{ cell: Cell<Charm>; llmRequestId?: string }> {
   console.log("Processing form:", form);
 
   // Remove $UI, $NAME, and any streams from the cells
@@ -445,7 +451,7 @@ export async function castNewRecipe(
   const existingSchema = createJsonSchema(scrubbed);
 
   // Prototype workflow: combine steps
-  const { newIFrameSrc, newSpec, newRecipeSrc, name, schema } =
+  const { newIFrameSrc, newSpec, newRecipeSrc, name, schema, llmRequestId } =
     form.classification?.workflowType === "imagine-single-phase"
       ? await singlePhaseCodeGeneration(form, existingSchema)
       : await twoPhaseCodeGeneration(form, existingSchema);
@@ -462,7 +468,10 @@ export async function castNewRecipe(
     }),
   );
 
-  return compileAndRunRecipe(charmManager, newRecipeSrc, newSpec, input);
+  return {
+    cell: await compileAndRunRecipe(charmManager, newRecipeSrc, newSpec, input),
+    llmRequestId,
+  };
 }
 
 export async function compileRecipe(

--- a/jumble/src/components/ActivityStatus.tsx
+++ b/jumble/src/components/ActivityStatus.tsx
@@ -11,6 +11,7 @@ import { createPath } from "@/routes.ts";
 import { charmId } from "@commontools/charm";
 import { useCharmManager } from "@/contexts/CharmManagerContext.tsx";
 import { DitheredCube } from "@/components/DitherCube.tsx";
+import { FeedbackActions } from "@/components/FeedbackActions.tsx";
 
 // Isolated component for elapsed time that handles its own refresh
 const ElapsedTime = ({ startTime }: { startTime: Date }) => {
@@ -169,6 +170,21 @@ const ActivityStatus: React.FC<ActivityStatusProps> = ({ className }) => {
       }
     }
 
+    const FeedbackButtons = ({ activity }: { activity: Activity }) => {
+      if (activity.type !== "job") return null;
+      const job: Job = activity as Job;
+      if (!job.llmRequestId) return null;
+      return (
+        <FeedbackActions
+          className={`flex flex-row`}
+          llmRequestId={job.llmRequestId}
+        >
+          <button type="button" slot="negative">👎</button>
+          <button type="button" slot="positive">👍</button>
+        </FeedbackActions>
+      );
+    };
+
     return (
       <div
         className={`flex items-center px-3 py-2 h-9 border-b border-gray-200 ${bgColor} relative`}
@@ -190,10 +206,18 @@ const ActivityStatus: React.FC<ActivityStatusProps> = ({ className }) => {
 
         {getActivityIcon(activity)}
         <div className="flex-1 min-w-0 mr-2.5">
-          <div className="font-medium whitespace-nowrap overflow-hidden text-ellipsis mb-0.5 text-gray-800">
+          <div
+            className="font-medium whitespace-nowrap overflow-hidden text-ellipsis mb-0.5 text-gray-800"
+            title={activity.title}
+          >
             {activity.title}
           </div>
-          <div className="text-[11px] text-gray-600 whitespace-nowrap overflow-hidden text-ellipsis">
+          <div
+            className="text-[11px] text-gray-600 whitespace-nowrap overflow-hidden text-ellipsis"
+            title={activity.type === "job"
+              ? (activity as Job).status
+              : (activity as Notification).message}
+          >
             {activity.type === "job"
               ? (activity as Job).status
               : (activity as Notification).message}
@@ -209,18 +233,21 @@ const ActivityStatus: React.FC<ActivityStatusProps> = ({ className }) => {
         {activity.type === "job" &&
           (activity as Job).state === "completed" &&
           (activity as Job).result && (
-          <button
-            type="button"
-            onClick={() => {
-              navigate(createPath("charmShow", {
-                charmId: charmId((activity as Job).result!)!,
-                replicaName: charmManager.getSpaceName(),
-              }));
-            }}
-            className="bg-black text-white border-none px-2 py-0.5 text-[10px] cursor-pointer whitespace-nowrap"
-          >
-            View Charm
-          </button>
+          <>
+            <FeedbackButtons activity={activity}></FeedbackButtons>
+            <button
+              type="button"
+              onClick={() => {
+                navigate(createPath("charmShow", {
+                  charmId: charmId((activity as Job).result!)!,
+                  replicaName: charmManager.getSpaceName(),
+                }));
+              }}
+              className="bg-black text-white border-none px-2 py-0.5 text-[10px] cursor-pointer whitespace-nowrap"
+            >
+              View Charm
+            </button>
+          </>
         )}
 
         {/* Show action button for notifications if provided */}
@@ -248,7 +275,7 @@ const ActivityStatus: React.FC<ActivityStatusProps> = ({ className }) => {
 
   return (
     <div
-      className={`fixed bottom-16 right-2 w-80 bg-white text-xs text-gray-700 max-h-[calc(100vh-100px)] overflow-hidden flex flex-col z-50 border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)] hover:translate-y-[-2px] hover:shadow-[2px_4px_0px_0px_rgba(0,0,0,0.7)] transition-[border,box-shadow,transform,opacity] duration-100 ease-in-out ${
+      className={`fixed bottom-16 right-2 w-80 bg-white text-xs text-gray-700 max-h-[calc(100vh-100px)] overflow-hidden flex flex-col z-50 border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)] transition-[border,opacity] duration-100 ease-in-out ${
         className || ""
       }`}
     >

--- a/jumble/src/components/FeedbackActions.tsx
+++ b/jumble/src/components/FeedbackActions.tsx
@@ -1,22 +1,19 @@
-import { useEffect, useState } from "react";
+import { ReactElement, useEffect, useState } from "react";
 import { FeedbackDialog } from "@/components/FeedbackDialog.tsx";
+import { Slot } from "@/components/Slot.tsx";
 import { submitFeedback } from "@/services/feedback.ts";
 import { getLastTraceSpanID } from "@commontools/builder";
 import { MdThumbDownOffAlt, MdThumbUpOffAlt } from "react-icons/md";
 import { notify } from "@/contexts/ActivityContext.tsx";
 import { useLocation } from "react-router-dom";
 
-export function FeedbackActions() {
-  // States for the feedback dialog
-  const [isFeedbackDialogOpen, setIsFeedbackDialogOpen] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [initialScore, setInitialScore] = useState<number>(1);
+export function PrimaryFeedbackActions(
+  { llmRequestId }: { llmRequestId?: string } = {},
+) {
   const [showFeedbackButtons, setShowFeedbackButtons] = useState(false);
-
-  // Close dialog & hide buttons when the user navigates to a different route
+  // Hide buttons when the user navigates to a different route
   const location = useLocation();
   useEffect(() => {
-    setIsFeedbackDialogOpen(false);
     setShowFeedbackButtons(false);
   }, [location.pathname]);
 
@@ -32,6 +29,87 @@ export function FeedbackActions() {
     };
   }, []);
 
+  const onFeedbackActionsClose = () => {
+    setShowFeedbackButtons(false);
+  };
+
+  return (
+    <>
+      {/* Popup buttons that appear when feedback button is clicked */}
+      {showFeedbackButtons && (
+        <div className="fixed z-[100] bottom-2 right-2 flex flex-col-reverse gap-2 pointer-events-none">
+          {/* This spacer places the thumbs buttons just above the feedback button */}
+          <div className="h-12"></div>
+
+          <FeedbackActions
+            className="pointer-events-auto"
+            llmRequestId={llmRequestId}
+            onClose={() => onFeedbackActionsClose()}
+          >
+            {/* Thumbs down button */}
+            <div slot="negative" className="pointer-events-auto">
+              <button
+                type="button"
+                className="w-12 h-12 cursor-pointer flex items-center justify-center border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)] bg-red-50 hover:translate-y-[-2px] relative group"
+              >
+                <MdThumbDownOffAlt className="w-6 h-6" />
+                <div className="absolute left-[-100px] top-1/2 -translate-y-1/2 bg-gray-800 text-white px-2 py-1 rounded text-sm opacity-0 group-hover:opacity-100 transition-opacity z-[200] whitespace-nowrap">
+                  Not Helpful
+                </div>
+              </button>
+            </div>
+
+            {/* Thumbs up button */}
+            <div slot="positive" className="pointer-events-auto">
+              <button
+                type="button"
+                className="w-12 h-12 cursor-pointer flex items-center justify-center border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)] bg-green-50 hover:translate-y-[-2px] relative group"
+              >
+                <MdThumbUpOffAlt className="w-6 h-6" />
+                <div className="absolute left-[-100px] top-1/2 -translate-y-1/2 bg-gray-800 text-white px-2 py-1 rounded text-sm opacity-0 group-hover:opacity-100 transition-opacity z-[200] whitespace-nowrap">
+                  Helpful
+                </div>
+              </button>
+            </div>
+          </FeedbackActions>
+        </div>
+      )}
+    </>
+  );
+}
+
+export function FeedbackActions(
+  { llmRequestId, className, children, onClose, onOpen }: {
+    llmRequestId?: string;
+    onClose?: () => void;
+    onOpen?: () => void;
+    className?: string;
+    children: ReactElement[];
+  },
+) {
+  // States for the feedback dialog
+  const [isFeedbackDialogOpen, setIsFeedbackDialogOpenInternal] = useState(
+    false,
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [initialScore, setInitialScore] = useState<number>(1);
+
+  // Close dialog & hide buttons when the user navigates to a different route
+  const location = useLocation();
+  useEffect(() => {
+    setIsFeedbackDialogOpen(false);
+  }, [location.pathname]);
+
+  const setIsFeedbackDialogOpen = (enabled: boolean) => {
+    const wasOpen = isFeedbackDialogOpen;
+    setIsFeedbackDialogOpenInternal(enabled);
+    if (!wasOpen && enabled && onOpen) {
+      onOpen();
+    } else if (wasOpen && !enabled && onClose) {
+      onClose();
+    }
+  };
+
   // Handler functions for feedback actions
   const handleOpenFeedback = (score: number) => {
     console.log(
@@ -39,7 +117,6 @@ export function FeedbackActions() {
     );
     setInitialScore(score);
     setIsFeedbackDialogOpen(true);
-    setShowFeedbackButtons(false);
   };
 
   const handleCloseFeedback = () => {
@@ -52,12 +129,13 @@ export function FeedbackActions() {
     console.log("Submitting feedback:", data);
     setIsSubmitting(true);
 
+    const spanId = llmRequestId ?? getLastTraceSpanID() as string;
     try {
       await submitFeedback(
         {
           score: data.score,
           explanation: data.explanation,
-          spanId: getLastTraceSpanID() as string,
+          spanId,
         },
         data.userInfo,
       );
@@ -82,7 +160,7 @@ export function FeedbackActions() {
 
   // Render feedback dialog and the popup buttons
   return (
-    <>
+    <div className={className}>
       {/* Feedback dialog for submissions */}
       <FeedbackDialog
         isOpen={isFeedbackDialogOpen}
@@ -91,42 +169,12 @@ export function FeedbackActions() {
         initialScore={initialScore}
         isSubmitting={isSubmitting}
       />
-
-      {/* Popup buttons that appear when feedback button is clicked */}
-      {showFeedbackButtons && (
-        <div className="fixed z-[100] bottom-2 right-2 flex flex-col-reverse gap-2 pointer-events-none">
-          {/* This spacer places the thumbs buttons just above the feedback button */}
-          <div className="h-12"></div>
-
-          {/* Thumbs down button */}
-          <div className="pointer-events-auto">
-            <button
-              type="button"
-              className="w-12 h-12 cursor-pointer flex items-center justify-center border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)] bg-red-50 hover:translate-y-[-2px] relative group"
-              onClick={() => handleOpenFeedback(0)}
-            >
-              <MdThumbDownOffAlt className="w-6 h-6" />
-              <div className="absolute left-[-100px] top-1/2 -translate-y-1/2 bg-gray-800 text-white px-2 py-1 rounded text-sm opacity-0 group-hover:opacity-100 transition-opacity z-[200] whitespace-nowrap">
-                Not Helpful
-              </div>
-            </button>
-          </div>
-
-          {/* Thumbs up button */}
-          <div className="pointer-events-auto">
-            <button
-              type="button"
-              className="w-12 h-12 cursor-pointer flex items-center justify-center border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)] bg-green-50 hover:translate-y-[-2px] relative group"
-              onClick={() => handleOpenFeedback(1)}
-            >
-              <MdThumbUpOffAlt className="w-6 h-6" />
-              <div className="absolute left-[-100px] top-1/2 -translate-y-1/2 bg-gray-800 text-white px-2 py-1 rounded text-sm opacity-0 group-hover:opacity-100 transition-opacity z-[200] whitespace-nowrap">
-                Helpful
-              </div>
-            </button>
-          </div>
-        </div>
-      )}
-    </>
+      <div onClick={() => handleOpenFeedback(0)}>
+        <Slot name="negative" required>{children}</Slot>
+      </div>
+      <div onClick={() => handleOpenFeedback(1)}>
+        <Slot name="positive" required>{children}</Slot>
+      </div>
+    </div>
   );
 }

--- a/jumble/src/components/Slot.tsx
+++ b/jumble/src/components/Slot.tsx
@@ -1,0 +1,105 @@
+// @ts-nocheck vendored
+/**
+Vendored from https://gist.github.com/giuseppelt/14d2bda071f728f5164baa76ecf60b01
+
+Container component:
+```
+import { Slot } from "./components";
+
+export function TestContainer({ children } ) {
+  return (
+    <div>
+      <Slot name="header" required children={children} />
+      <p>content</p>
+      <Slot children={children} />
+      <Slot name="footer" fallback={<p>Default Footer</p>} children={children} />
+    </div>
+  );
+}
+```
+
+Using component:
+```
+import { TestContainer } from "./components";
+
+export function ComplexComponent() {
+   return (
+      <TextContainer>
+        <p slot="header">This will be the header</p>
+
+        <p>Other body content</p>
+        <p>Other body content</p>
+        <p>Other body content</p>
+      </TextContainer>
+   );
+}
+```
+*/
+import { cloneElement, isValidElement, ReactElement, ReactNode } from "react";
+
+declare global {
+  namespace React {
+    interface Attributes {
+      slot?: string;
+    }
+  }
+}
+
+export type SlotProps = {
+  name?: string;
+  required?: boolean;
+  fallback?: ReactElement;
+  children?: ReactNode;
+};
+
+export function Slot(props: SlotProps) {
+  const {
+    name,
+    children,
+    required,
+    fallback,
+  } = props;
+
+  // this is a default slot, that is, non-slotted children
+  if (!name) {
+    return getDefaultSlot(children);
+  }
+
+  // otherwise get it
+  const Content = getSlot(children, name);
+  if (Content) {
+    // remove slot property
+    return cloneElement(Content, { slot: undefined });
+  }
+
+  if (!Content && required) {
+    throw new Error(`Slot(${name}) is required`);
+  }
+
+  return Content ?? fallback ?? null;
+}
+
+function getSlot(children: ReactNode, name: string): ReactElement | undefined {
+  if (children) {
+    if (Array.isArray(children)) {
+      return children.find((x) =>
+        isValidElement(x) && (x.props as any)?.slot === name
+      );
+    } else if (isValidElement(children) && children.props?.slot === name) {
+      return children;
+    }
+  }
+}
+
+function getDefaultSlot(children: ReactNode) {
+  if (children) {
+    if (isValidElement(children)) {
+      return children.props?.slot ? null : children;
+    } else if (Array.isArray(children)) {
+      return children.map((x) =>
+        x && isValidElement(x) && (x.props as any)?.slot ? null : x
+      );
+    }
+  }
+  return children;
+}

--- a/jumble/src/iframe-ctx.ts
+++ b/jumble/src/iframe-ctx.ts
@@ -281,7 +281,7 @@ export const setupIframe = () =>
       if (!jsonPayload.cache) {
         jsonPayload.cache = true;
       }
-      updateJob(jobId, "Using " + jsonPayload.model);
+      updateJob(jobId, `Using ${jsonPayload.model}`);
       jsonPayload.metadata = {
         ...jsonPayload.metadata,
         context: "iframe",
@@ -291,7 +291,12 @@ export const setupIframe = () =>
 
       const res = await llm.sendRequest(jsonPayload);
       console.log("onLLMRequest res", res);
-      completeJob(jobId, res.content ?? "Completed!");
+      completeJob({
+        id: jobId,
+        result: undefined,
+        status: res.content ?? "Completed!",
+        llmRequestId: res.id
+      });
       return res as any;
     },
     async onReadWebpageRequest(
@@ -306,7 +311,10 @@ export const setupIframe = () =>
         `/api/ai/webreader/${encodeURIComponent(payload)}`,
       );
       console.log("onReadWebpageRequest res", res);
-      completeJob(jobId, res.status === 200 ? "Completed!" : "Failed!");
+      completeJob({
+        id: jobId,
+        status: res.status === 200 ? "Completed!" : "Failed!"
+      });
       return await res.json();
     },
     async onPerform(

--- a/jumble/src/views/Shell.tsx
+++ b/jumble/src/views/Shell.tsx
@@ -12,7 +12,7 @@ import { useGlobalActions } from "@/hooks/use-global-actions.tsx";
 import { SyncStatusProvider } from "@/contexts/SyncStatusContext.tsx";
 import { ToggleableNetworkInspector } from "@/components/NetworkInspector.tsx";
 import { NetworkInspectorProvider } from "@/contexts/NetworkInspectorContext.tsx";
-import { FeedbackActions } from "@/components/FeedbackActions.tsx";
+import { PrimaryFeedbackActions } from "@/components/FeedbackActions.tsx";
 import ActivityStatus from "@/components/ActivityStatus.tsx";
 
 export default function Shell() {
@@ -38,7 +38,7 @@ export default function Shell() {
             <ActionBar />
             <CharmPublisher />
             <CommandCenter />
-            <FeedbackActions />
+            <PrimaryFeedbackActions />
             <ToggleableNetworkInspector
               visible={localStorage.getItem("networkInspectorVisible") ===
                 "true"}

--- a/llm/src/prompts/code-and-schema-gen.ts
+++ b/llm/src/prompts/code-and-schema-gen.ts
@@ -207,6 +207,7 @@ export async function generateCodeAndSchema(
   description: string;
   resultSchema: JSONSchema;
   argumentSchema: JSONSchema;
+  llmRequestId?: string;
 }> {
   let systemPrompt, userContent;
   if (!form.plan) {
@@ -308,5 +309,6 @@ Based on this goal and the existing schema, please provide a title, description,
     title,
     description,
     argumentSchema,
+    llmRequestId: response.id,
   };
 }


### PR DESCRIPTION
* Display an option to upvote/downvote a job with a `llmRequestId`.
* Introduce a composable form of <FeedbackActions> for various button types. Same components used between the primary feedback on main page and individual jobs.
* Add tooltips to activity status and details.
* Introduce a vendored, composable utility <Slot>.
* Remove some animated styles that were causing blinking issues with the nested <FeedbackDialog>.

note there's currently an issue with staging serving the ID, TBD