### PR TITLE
Drop `stopSequences` when calling `o3`

### DIFF
--- a/toolshed/routes/ai/llm/generateText.ts
+++ b/toolshed/routes/ai/llm/generateText.ts
@@ -150,6 +150,11 @@ export async function generateText(
     maxTokens: params.maxTokens,
   };
 
+  if (params.model == "openai:o3") {
+    // o3 does not support stop sequences
+    streamParams.stopSequences = undefined;
+  }
+
   // Apply JSON mode configuration if requested
   if (params.mode) {
     configureJsonMode(


### PR DESCRIPTION
They are unsupported, at least currently. See phoenix report: https://phoenix.commontools.dev/projects/UHJvamVjdDo2/spans/b2fa90798de7dbebd8adebcfc54a3d20?selectedSpanNodeId=U3BhbjoxNTQxNTY%3D

Confirmed working locally: 
<img width="1987" alt="image" src="https://github.com/user-attachments/assets/36040500-38b4-4b38-9348-2812768e3fa0" />

Happy to merge as-is, just want to confirm this makes sense / I didn't miss anything.