### PR TITLE
feat: Enable mapping of console messages from charms

### DIFF
--- a/charm/src/iterate.ts
+++ b/charm/src/iterate.ts
@@ -3,7 +3,7 @@ import {
   isCell,
   isStream,
   registerNewRecipe,
-  tsToExports,
+  runtime,
 } from "@commontools/runner";
 import { isObj } from "@commontools/utils";
 import {
@@ -491,12 +491,7 @@ export async function compileRecipe(
   spec: string,
   parents?: string[],
 ) {
-  const { exports, errors } = await tsToExports(recipeSrc);
-  if (errors) {
-    console.error(errors);
-    throw new Error("Compilation errors in recipe");
-  }
-  const recipe = exports.default;
+  const recipe = await runtime.compile(recipeSrc);
   if (!recipe) {
     throw new Error("No default recipe found in the compiled exports.");
   }

--- a/jumble/src/main.tsx
+++ b/jumble/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode, useEffect } from "react";
 import { createRoot } from "react-dom/client";
-import { onError } from "@commontools/runner";
+import { ConsoleMethod, onConsole, onError } from "@commontools/runner";
 import {
   BrowserRouter as Router,
   createBrowserRouter,
@@ -96,6 +96,21 @@ onError((error: Error) => {
   // Also send to Sentry
   Sentry.captureException(error);
 });
+
+// Handle console messages depending on charm context.
+// This is essentially the same as the default handling currently,
+// but adding this here for future use.
+onConsole(
+  (
+    _metadata:
+      | { charmId?: string; space?: string; recipeId?: string }
+      | undefined,
+    _method: ConsoleMethod,
+    args: any[],
+  ) => {
+    return args;
+  },
+);
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -3,6 +3,7 @@ export { addModuleByRef, raw } from "./module.ts";
 export {
   idle,
   isErrorWithContext,
+  onConsole,
   onError,
   run as addAction,
   unschedule as removeAction,
@@ -58,7 +59,7 @@ export {
   saveToBlobby,
   setBlobbyServerUrl,
 } from "./blobby-storage.ts";
-export { tsToExports } from "./local-build.ts";
+export { ConsoleMethod, runtime } from "./runtime/index.ts";
 export {
   addCommonIDfromObjectID,
   followAliases,

--- a/runner/src/recipe-sync.ts
+++ b/runner/src/recipe-sync.ts
@@ -6,7 +6,6 @@ import {
   getRecipeSrc,
   registerRecipe,
 } from "./recipe-map.ts";
-import { buildRecipe } from "./local-build.ts";
 import {
   createItemsKnownToStorageSet,
   getBlobbyServerUrl,
@@ -14,6 +13,7 @@ import {
   saveToBlobby,
   setBlobbyServerUrl,
 } from "./blobby-storage.ts";
+import { runtime } from "./runtime/index.ts";
 
 // For backward compatibility
 export function setBobbyServerUrl(url: string) {
@@ -46,8 +46,7 @@ export async function syncRecipeBlobby(id: string) {
   const spec = response.spec || "";
   const parents = response.parents || [];
 
-  const { recipe, errors } = await buildRecipe(src);
-  if (errors) throw new Error(errors);
+  const recipe = await runtime.compile(src);
 
   registerRecipe(id, recipe!, src, spec, parents);
   recipesKnownToStorage.add(id);

--- a/runner/src/runner.ts
+++ b/runner/src/runner.ts
@@ -4,7 +4,6 @@ import {
   isModule,
   isRecipe,
   isStreamAlias,
-  type JSONSchema,
   type JSONValue,
   type Module,
   type NodeFactory,
@@ -32,7 +31,6 @@ import {
   extractDefaultValues,
   findAllAliasedCells,
   followAliases,
-  maybeUnwrapProxy,
   mergeObjects,
   sendValueToBinding,
   unsafe_noteParentOnRecipes,
@@ -47,6 +45,7 @@ import { isQueryResultForDereferencing } from "./query-result-proxy.ts";
 import { getCellLinkOrThrow } from "./query-result-proxy.ts";
 import { storage } from "./storage.ts";
 import { syncRecipeBlobby } from "./recipe-sync.ts";
+import { runtime } from "./runtime/index.ts";
 
 export const cancels = new WeakMap<DocImpl<any>, Cancel>();
 
@@ -347,7 +346,7 @@ function instantiateJavaScriptNode(
 
   let fn = (
     typeof module.implementation === "string"
-      ? eval(module.implementation)
+      ? runtime.getInvocation(module.implementation)
       : module.implementation
   ) as (inputs: any) => any;
 

--- a/runner/src/runtime/console.ts
+++ b/runner/src/runtime/console.ts
@@ -1,0 +1,104 @@
+const trueConsole = globalThis.console;
+
+export enum ConsoleMethod {
+  Assert = "assert",
+  Clear = "clear",
+  Count = "count",
+  CountReset = "countReset",
+  Debug = "debug",
+  Dir = "dir",
+  DirXml = "dirxml",
+  Error = "error",
+  Group = "group",
+  GroupCollapsed = "groupCollapsed",
+  GroupEnd = "groupEnd",
+  Info = "info",
+  Log = "log",
+  Table = "table",
+  Time = "time",
+  TimeEnd = "timeEnd",
+  TimeLog = "timeLog",
+  TimeStamp = "timeStamp",
+  Trace = "trace",
+  Warn = "warn",
+}
+
+export class ConsoleEvent extends Event {
+  readonly method: ConsoleMethod;
+  readonly args: any[];
+  constructor(method: ConsoleMethod, args: any[]) {
+    super("console");
+    this.method = method;
+    this.args = args;
+  }
+}
+
+export class Console {
+  #emitter: EventTarget;
+  constructor(emitter: EventTarget) {
+    this.#emitter = emitter;
+  }
+  private impl(method: ConsoleMethod, ...args: any[]) {
+    this.#emitter.dispatchEvent(new ConsoleEvent(method, args));
+  }
+  assert(...args: any[]) {
+    return this.impl(ConsoleMethod.Assert, ...args);
+  }
+  clear(...args: any[]) {
+    return this.impl(ConsoleMethod.Clear, ...args);
+  }
+  count(...args: any[]) {
+    return this.impl(ConsoleMethod.Count, ...args);
+  }
+  countReset(...args: any[]) {
+    return this.impl(ConsoleMethod.CountReset, ...args);
+  }
+  debug(...args: any[]) {
+    return this.impl(ConsoleMethod.Debug, ...args);
+  }
+  dir(...args: any[]) {
+    return this.impl(ConsoleMethod.Dir, ...args);
+  }
+  dirxml(...args: any[]) {
+    return this.impl(ConsoleMethod.DirXml, ...args);
+  }
+  error(...args: any[]) {
+    return this.impl(ConsoleMethod.Error, ...args);
+  }
+  group(...args: any[]) {
+    return this.impl(ConsoleMethod.Group, ...args);
+  }
+  groupCollapsed(...args: any[]) {
+    return this.impl(ConsoleMethod.GroupCollapsed, ...args);
+  }
+  groupEnd(...args: any[]) {
+    return this.impl(ConsoleMethod.GroupEnd, ...args);
+  }
+  info(...args: any[]) {
+    return this.impl(ConsoleMethod.Info, ...args);
+  }
+  log(...args: any[]) {
+    return this.impl(ConsoleMethod.Log, ...args);
+  }
+  table(...args: any[]) {
+    return this.impl(ConsoleMethod.Table, ...args);
+  }
+  time(...args: any[]) {
+    return this.impl(ConsoleMethod.Time, ...args);
+  }
+  timeEnd(...args: any[]) {
+    return this.impl(ConsoleMethod.TimeEnd, ...args);
+  }
+  timeLog(...args: any[]) {
+    return this.impl(ConsoleMethod.TimeLog, ...args);
+  }
+  timeStamp(...args: any[]) {
+    return this.impl(ConsoleMethod.TimeStamp, ...args);
+  }
+  trace(...args: any[]) {
+    return this.impl(ConsoleMethod.Trace, ...args);
+  }
+  warn(...args: any[]) {
+    return this.impl(ConsoleMethod.Warn, ...args);
+  }
+}

--- a/runner/src/runtime/eval-runtime.ts
+++ b/runner/src/runtime/eval-runtime.ts
@@ -1,0 +1,33 @@
+import { Recipe } from "@commontools/builder";
+import { mapSourceMapsOnStacktrace, tsToExports } from "./local-build.ts";
+import { Runtime, RuntimeFunction } from "./runtime.ts";
+import { Console } from "./console.ts";
+
+const RUNTIME_CONSOLE_HOOK = "RUNTIME_CONSOLE_HOOK";
+declare global {
+  var [RUNTIME_CONSOLE_HOOK]: any;
+}
+
+export class UnsafeEvalRuntime extends EventTarget implements Runtime {
+  constructor() {
+    super();
+    // We install our console shim globally so that it can be referenced
+    // by the eval script scope.
+    globalThis[RUNTIME_CONSOLE_HOOK] = new Console(this);
+  }
+  async compile(source: string): Promise<Recipe | undefined> {
+    if (!source) {
+      throw new Error("No source provided.");
+    }
+    const exports = await tsToExports(source, {
+      injection: `const console = globalThis.${RUNTIME_CONSOLE_HOOK};`,
+    });
+    return "default" in exports ? exports.default : undefined;
+  }
+  getInvocation(source: string): RuntimeFunction {
+    return eval(source);
+  }
+  mapStackTrace(stack: string): string {
+    return mapSourceMapsOnStacktrace(stack);
+  }
+}

--- a/runner/src/runtime/index.ts
+++ b/runner/src/runtime/index.ts
@@ -1,0 +1,6 @@
+import { UnsafeEvalRuntime } from "./eval-runtime.ts";
+export { UnsafeEvalRuntime };
+export { type Runtime } from "./runtime.ts";
+export { ConsoleMethod } from "./console.ts";
+
+export const runtime = new UnsafeEvalRuntime();

--- a/runner/src/runtime/runtime.ts
+++ b/runner/src/runtime/runtime.ts
@@ -1,0 +1,8 @@
+import { Recipe } from "@commontools/builder";
+
+export type RuntimeFunction = (input: any) => void;
+export interface Runtime extends EventTarget {
+  compile(source: string): Promise<Recipe | undefined>;
+  getInvocation(source: string): RuntimeFunction;
+  mapStackTrace(stack: string): string;
+}


### PR DESCRIPTION
Adds runtime hooks for intercepting console commands from charms, similar to `onError`, except there can only be one handler at a time. See jumble for a "passthru" implementation. In background workers, messages are annotated with charm ID. In contexts where the runtime is used and no `onConsole` defined, a default passthru implementation is used.

```ts
// Passthru
onConsole(
  (
    _metadata:
      | { charmId?: string; space?: string; recipeId?: string }
      | undefined,
    _method: ConsoleMethod,
    args: any[],
  ) => {
    return args;
  },
);
```

Example bg worker log:

```
Worker(did:key:z6Mkh6sEaGxkcq5j9SRofMMCfj1Tg7D1Y5ktVWbgytCpnbYS) Running charm did:key:z6Mkh6sEaGxkcq5j9SRofMMCfj1Tg7D1Y5ktVWbgytCpnbYS/baedreibysswug2cjrqczv3k2vxtzzvbfjfnwjn4lcfb4arulmpb3fleici
Worker(did:key:z6Mkh6sEaGxkcq5j9SRofMMCfj1Tg7D1Y5ktVWbgytCpnbYS) Loading charm baedreibysswug2cjrqczv3k2vxtzzvbfjfnwjn4lcfb4arulmpb3fleici for the first time
Charm(baedreibysswug2cjrqczv3k2vxtzzvbfjfnwjn4lcfb4arulmpb3fleici) counter# 22
Charm(baedreibysswug2cjrqczv3k2vxtzzvbfjfnwjn4lcfb4arulmpb3fleici) testing throwing an error! in updater
Charm(baedreibysswug2cjrqczv3k2vxtzzvbfjfnwjn4lcfb4arulmpb3fleici) counter# 23
Charm(baedreibysswug2cjrqczv3k2vxtzzvbfjfnwjn4lcfb4arulmpb3fleici) counter# 23
Worker(did:key:z6Mkh6sEaGxkcq5j9SRofMMCfj1Tg7D1Y5ktVWbgytCpnbYS) Successfully executed charm did:key:z6Mkh6sEaGxkcq5j9SRofMMCfj1Tg7D1Y5ktVWbgytCpnbYS/baedreibysswug2cjrqczv3k2vxtzzvbfjfnwjn4lcfb4arulmpb3fleici
```