### PR TITLE
external references in recipes don't need internal aliases anymore

### DIFF
--- a/builder/src/types.ts
+++ b/builder/src/types.ts
@@ -237,8 +237,8 @@ type CanBeOpaqueRef = { [toOpaqueRef]: () => OpaqueRef<any> };
 
 export function canBeOpaqueRef(value: any): value is CanBeOpaqueRef {
   return (
-    !!value &&
     (typeof value === "object" || typeof value === "function") &&
+    value !== null &&
     typeof value[toOpaqueRef] === "function"
   );
 }

--- a/builder/src/utils.ts
+++ b/builder/src/utils.ts
@@ -141,7 +141,7 @@ export function toJSONWithAliases(
     value = createShadowRef(value);
   }
 
-  // If the this is an external reference, just copy it the reference in as is.
+  // If this is an external reference, just copy the reference as is.
   if (isOpaqueRef(value)) {
     const { external } = value.export();
     if (external) return external;

--- a/builder/src/utils.ts
+++ b/builder/src/utils.ts
@@ -141,6 +141,12 @@ export function toJSONWithAliases(
     value = createShadowRef(value);
   }
 
+  // If the this is an external reference, just copy it the reference in as is.
+  if (isOpaqueRef(value)) {
+    const { external } = value.export();
+    if (external) return external;
+  }
+
   if (isOpaqueRef(value) || isShadowRef(value)) {
     const pathToCell = paths.get(value);
     if (pathToCell) {
@@ -157,7 +163,9 @@ export function toJSONWithAliases(
         },
       } satisfies Alias;
     } else throw new Error(`Cell not found in paths`);
-  } else if (isAlias(value)) {
+  }
+
+  if (isAlias(value)) {
     const alias = (value as Alias).$alias;
     if (isShadowRef(alias.cell)) {
       const cell = alias.cell.shadowOf;


### PR DESCRIPTION
Fixes CT-294

Jordan: Just in case you are curious, this is pretty deep in the recipe stack