### PR TITLE
Introduce `GenerationOptions` and streamline LLM metadata

### DIFF
--- a/charm/src/iframe/prompt.ts
+++ b/charm/src/iframe/prompt.ts
@@ -4,10 +4,11 @@ import {
   hydratePrompt,
   type LLMMessage,
   type LLMRequest,
+  applyDefaults,
+  type GenerationOptions
 } from "@commontools/llm";
 
 import { extractUserCode, systemMd } from "./static.ts";
-import { applyDefaults, GenerationOptions } from "../../../llm/src/options.ts";
 
 export const RESPONSE_PREFILL = "```javascript\n";
 

--- a/charm/src/iframe/prompt.ts
+++ b/charm/src/iframe/prompt.ts
@@ -7,6 +7,7 @@ import {
 } from "@commontools/llm";
 
 import { extractUserCode, systemMd } from "./static.ts";
+import { applyDefaults, GenerationOptions } from "../../../llm/src/options.ts";
 
 export const RESPONSE_PREFILL = "```javascript\n";
 
@@ -16,17 +17,15 @@ export const buildPrompt = ({
   newSpec,
   schema,
   steps,
-  model,
-  cache = true,
 }: {
   src?: string;
   spec?: string;
   newSpec: string;
   schema: JSONSchema;
   steps?: string[];
-  model?: string;
-  cache: boolean;
-}): LLMRequest => {
+}, options: GenerationOptions): LLMRequest => {
+  const { model, cache, space, generationId } = applyDefaults(options);
+
   const messages: LLMMessage[] = [];
   if (spec && src) {
     messages.push({
@@ -74,12 +73,14 @@ ${steps.map((step, index) => `${index + 1}. ${step}`).join("\n")}`
   });
 
   return {
-    model: model ?? DEFAULT_MODEL_NAME,
+    model: model,
     system: system.text,
     messages,
     stop: "\n```",
     metadata: {
       systemPrompt: system.version,
+      generationId,
+      space,
     },
     cache,
   };

--- a/charm/src/iterate.ts
+++ b/charm/src/iterate.ts
@@ -23,10 +23,11 @@ import {
   generateCodeAndSchema,
   generateSpecAndSchema,
   LLMClient,
+  applyDefaults,
+  type GenerationOptions
 } from "@commontools/llm";
 import { injectUserCode } from "./iframe/static.ts";
 import { IFrameRecipe, WorkflowForm } from "./index.ts";
-import { applyDefaults, GenerationOptions } from "../../llm/src/options.ts";
 
 const llm = new LLMClient();
 

--- a/charm/src/iterate.ts
+++ b/charm/src/iterate.ts
@@ -280,7 +280,7 @@ async function singlePhaseCodeGeneration(
       detail: {
         type: "job-update",
         jobId: form.meta.generationId,
-        status: `Generating code and schema ${form.meta.modelId}...`,
+        status: `Generating code and schema ${form.meta.model}...`,
       },
     }),
   );
@@ -291,7 +291,7 @@ async function singlePhaseCodeGeneration(
     title,
     description,
     llmRequestId,
-  } = await generateCodeAndSchema(form, existingSchema, form.meta.modelId);
+  } = await generateCodeAndSchema(form, existingSchema, form.meta.model);
 
   console.log("resultSchema", resultSchema);
 
@@ -363,7 +363,7 @@ async function twoPhaseCodeGeneration(
       detail: {
         type: "job-update",
         jobId: form.meta.generationId,
-        status: `Generating spec and schema ${form.meta.modelId}...`,
+        status: `Generating spec and schema ${form.meta.model}...`,
       },
     }),
   );
@@ -374,7 +374,7 @@ async function twoPhaseCodeGeneration(
     title,
     description,
     plan,
-  } = await generateSpecAndSchema(form, existingSchema, form.meta.modelId);
+  } = await generateSpecAndSchema(form, existingSchema, form.meta.model);
 
   console.log("resultSchema", resultSchema);
 
@@ -420,7 +420,7 @@ async function twoPhaseCodeGeneration(
     schema,
     steps: form.plan?.steps,
   }, {
-    model: form.meta.modelId,
+    model: form.meta.model,
     generationId: form.meta.generationId,
     cache: form.meta.cache,
     space: form.meta.charmManager.getSpaceName(),

--- a/charm/src/workflow.ts
+++ b/charm/src/workflow.ts
@@ -317,7 +317,7 @@ export interface WorkflowForm {
     charmManager: CharmManager;
     permittedWorkflows?: WorkflowType[];
     generationId?: string;
-    modelId?: string;
+    model?: string;
     isComplete: boolean;
     cache: boolean;
     llmRequestId?: string;
@@ -347,7 +347,7 @@ export function createWorkflowForm(
 ): WorkflowForm {
   const {
     input,
-    modelId,
+    model,
     charm,
     generationId,
     charmManager,
@@ -369,7 +369,7 @@ export function createWorkflowForm(
     spellToCast: null,
     meta: {
       isComplete: false,
-      modelId,
+      model,
       generationId: generationId ?? crypto.randomUUID(),
       cache,
       charmManager,

--- a/charm/src/workflow.ts
+++ b/charm/src/workflow.ts
@@ -680,7 +680,7 @@ export async function processWorkflow(
             type: "job-update",
             jobId: form.meta.generationId,
             title: form.input.processedInput,
-            status: `Classifying task ${form.meta.modelId}...`,
+            status: `Classifying task ${form.meta.model}...`,
           },
         }),
       );
@@ -834,7 +834,7 @@ export async function processWorkflow(
             type: "job-update",
             jobId: form.meta.generationId,
             title: form.input.processedInput,
-            status: `Planning task ${form.meta.modelId}...`,
+            status: `Planning task ${form.meta.model}...`,
           },
         }),
       );
@@ -856,7 +856,7 @@ export async function processWorkflow(
             type: "job-update",
             jobId: form.meta.generationId,
             title: form.input.processedInput,
-            status: `Generating charm ${form.meta.modelId}...`,
+            status: `Generating charm ${form.meta.model}...`,
           },
         }),
       );
@@ -958,7 +958,7 @@ export function executeFixWorkflow(
     charmManager,
     form.input.existingCharm!,
     form.plan,
-    form.meta.modelId,
+    form.meta.model,
     form.meta.generationId,
     form.meta.cache,
   );
@@ -981,7 +981,7 @@ export function executeEditWorkflow(
     charmManager,
     form.input.existingCharm!,
     form.plan,
-    form.meta.modelId,
+    form.meta.model,
     form.meta.generationId,
     form.meta.cache,
   );

--- a/charm/src/workflow.ts
+++ b/charm/src/workflow.ts
@@ -20,6 +20,7 @@ import { extractUserCode } from "./iframe/static.ts";
 import { formatPromptWithMentions } from "./format.ts";
 import { castNewRecipe } from "./iterate.ts";
 import { VNode } from "@commontools/html";
+import { applyDefaults, GenerationOptions } from "@commontools/llm";
 
 export interface RecipeRecord {
   argumentSchema: JSONSchema; // Schema type from jsonschema
@@ -336,24 +337,24 @@ export interface WorkflowForm {
  * @returns A new workflow form object
  */
 export function createWorkflowForm(
-  {
+  options: {
+    input: string;
+    charm?: Cell<Charm>;
+    generationId?: string;
+    charmManager: CharmManager;
+    permittedWorkflows?: WorkflowType[];
+  } & GenerationOptions,
+): WorkflowForm {
+  const {
     input,
     modelId,
     charm,
     generationId,
     charmManager,
-    cache = true,
+    cache,
     permittedWorkflows,
-  }: {
-    input: string;
-    modelId?: string;
-    charm?: Cell<Charm>;
-    generationId?: string;
-    cache: boolean;
-    charmManager: CharmManager;
-    permittedWorkflows?: WorkflowType[];
-  },
-): WorkflowForm {
+  } = applyDefaults(options);
+
   return {
     input: {
       rawInput: input,

--- a/charm/src/workflow.ts
+++ b/charm/src/workflow.ts
@@ -608,7 +608,7 @@ export async function processWorkflow(
   let form = createWorkflowForm({
     input,
     charm: options.existingCharm,
-    modelId: options.model,
+    model: options.model,
     cache: options.cache,
     charmManager,
     permittedWorkflows: options.permittedWorkflows,
@@ -958,9 +958,12 @@ export function executeFixWorkflow(
     charmManager,
     form.input.existingCharm!,
     form.plan,
-    form.meta.model,
-    form.meta.generationId,
-    form.meta.cache,
+    {
+      model: form.meta.model,
+      space: form.meta.charmManager.getSpaceName(),
+      cache: form.meta.cache,
+      generationId: form.meta.generationId,
+    },
   );
 }
 
@@ -981,9 +984,12 @@ export function executeEditWorkflow(
     charmManager,
     form.input.existingCharm!,
     form.plan,
-    form.meta.model,
-    form.meta.generationId,
-    form.meta.cache,
+    {
+      model: form.meta.model,
+      space: form.meta.charmManager.getSpaceName(),
+      cache: form.meta.cache,
+      generationId: form.meta.generationId,
+    },
   );
 }
 

--- a/llm/src/index.ts
+++ b/llm/src/index.ts
@@ -11,3 +11,4 @@ export * from "./prompts/spec-and-schema-gen.ts";
 export * from "./prompts/code-and-schema-gen.ts";
 export * from "./prompts/workflow-classification.ts";
 export * from "./prompts/prompting.ts";
+export * from "./options.ts";

--- a/llm/src/options.ts
+++ b/llm/src/options.ts
@@ -1,0 +1,18 @@
+import { DEFAULT_MODEL_NAME } from "./index.ts";
+
+export type GenerationOptions = {
+  generationId?: string;
+  model?: string;
+  cache?: boolean;
+  space?: string;
+};
+
+export function applyDefaults<T extends Partial<GenerationOptions> | undefined>(
+  options?: T,
+): T & { model: string; cache: boolean } {
+  return {
+    model: DEFAULT_MODEL_NAME,
+    cache: true,
+    ...(options || {}),
+  } as T & { modelId: string; cache: boolean };
+}

--- a/llm/src/options.ts
+++ b/llm/src/options.ts
@@ -14,5 +14,5 @@ export function applyDefaults<T extends Partial<GenerationOptions> | undefined>(
     model: DEFAULT_MODEL_NAME,
     cache: true,
     ...(options || {}),
-  } as T & { modelId: string; cache: boolean };
+  } as T & { model: string; cache: boolean };
 }

--- a/llm/src/prompts/charm-describe.ts
+++ b/llm/src/prompts/charm-describe.ts
@@ -1,5 +1,5 @@
 import { LLMClient } from "../client.ts";
-import { llmPrompt } from "../index.ts";
+import { applyDefaults, GenerationOptions, llmPrompt } from "../index.ts";
 import { hydratePrompt, parseTagFromResponse } from "./prompting.ts";
 import { DEFAULT_MODEL_NAME } from "../types.ts";
 
@@ -50,9 +50,10 @@ export async function describeCharm(
   spec: string,
   code: string,
   schema: string,
-  model: string = DEFAULT_MODEL_NAME,
-  cache: boolean = true,
+  options?: GenerationOptions,
 ) {
+  const { model, cache, space, generationId } = applyDefaults(options);
+
   const system = hydratePrompt(SYSTEM_PROMPT, {
     SPEC: spec,
     CODE: code,
@@ -76,6 +77,8 @@ export async function describeCharm(
       context: "charm-describe",
       systemPrompt: system.version,
       userPrompt: prompt.version,
+      space,
+      generationId,
     },
     cache,
   });

--- a/llm/src/prompts/code-and-schema-gen.ts
+++ b/llm/src/prompts/code-and-schema-gen.ts
@@ -263,6 +263,7 @@ Based on this goal and the existing schema, please provide a title, description,
       generationId: form.meta.generationId,
       systemPrompt: systemPrompt.version,
       userPrompt: userContent.version,
+      space: form.meta.charmManager.getSpaceName(),
     },
   });
 

--- a/llm/src/prompts/recipe-fix.ts
+++ b/llm/src/prompts/recipe-fix.ts
@@ -1,5 +1,6 @@
 import { LLMClient } from "../client.ts";
-import { llmPrompt } from "../index.ts";
+import { GenerationOptions, llmPrompt } from "../index.ts";
+import { applyDefaults } from "../options.ts";
 import { DEFAULT_MODEL_NAME } from "../types.ts";
 import { hydratePrompt, parseTagFromResponse } from "./prompting.ts";
 import { recipeGuidePrompt } from "./recipe-guide.ts";
@@ -84,7 +85,7 @@ export async function fixRecipePrompt(
   code: string,
   schema: string,
   error: string,
-  options: { model?: string; cache?: boolean },
+  options?: GenerationOptions,
 ) {
   const system = hydratePrompt(SYSTEM_PROMPT, {
     SPEC: spec,
@@ -97,8 +98,7 @@ export async function fixRecipePrompt(
     `Please fix the code. Remember to only return the user code portion, not the full template. Do not include any HTML, head, or body tags - just the JavaScript functions.`,
   );
 
-  const model = options.model || DEFAULT_MODEL_NAME;
-  const cache = options.cache || true;
+  const { model, cache, space, generationId } = applyDefaults(options);
 
   const response = await new LLMClient().sendRequest({
     model,
@@ -115,6 +115,8 @@ export async function fixRecipePrompt(
       workflow: "recipe-fix",
       systemPrompt: system.version,
       userPrompt: prompt.version,
+      space,
+      generationId,
     },
     cache,
   });

--- a/llm/src/prompts/spec-and-schema-gen.ts
+++ b/llm/src/prompts/spec-and-schema-gen.ts
@@ -260,6 +260,7 @@ Based on this goal and the existing schema, please provide a title, description,
       generationId: form.meta.generationId,
       systemPrompt: systemPrompt.version,
       userPrompt: userContent.version,
+      space: form.meta.charmManager.getSpaceName(),
     },
   });
 
@@ -380,6 +381,7 @@ Based on this goal and the existing schema, please provide a title, description,
       generationId: form.meta.generationId,
       systemPrompt: systemPrompt.version,
       userPrompt: userContent.version,
+      space: form.meta.charmManager.getSpaceName(),
     },
     cache: form.meta.cache,
   });

--- a/llm/src/prompts/workflow-classification.ts
+++ b/llm/src/prompts/workflow-classification.ts
@@ -231,6 +231,7 @@ export async function classifyWorkflow(
       generationId: form.meta.generationId,
       systemPrompt: systemPrompt.version,
       userPrompt: prompt.version,
+      space: form.meta.charmManager.getSpaceName(),
     },
   });
 
@@ -352,6 +353,7 @@ export async function generateWorkflowPlan(
       generationId: form.meta.generationId,
       systemPrompt: systemPrompt.version,
       userPrompt: prompt.version,
+      space: form.meta.charmManager.getSpaceName(),
     },
   });
 

--- a/llm/src/prompts/workflow-classification.ts
+++ b/llm/src/prompts/workflow-classification.ts
@@ -223,7 +223,7 @@ export async function classifyWorkflow(
   const response = await new LLMClient().sendRequest({
     system: systemPrompt.text,
     messages: [{ role: "user", content: prompt.text }],
-    model: form.meta.modelId ?? DEFAULT_MODEL_NAME,
+    model: form.meta.model ?? DEFAULT_MODEL_NAME,
     cache: form.meta.cache,
     metadata: {
       context: "workflow",
@@ -345,7 +345,7 @@ export async function generateWorkflowPlan(
   const response = await new LLMClient().sendRequest({
     system: systemPrompt.text,
     messages: [{ role: "user", content: prompt.text }],
-    model: form.meta.modelId ?? DEFAULT_MODEL_NAME,
+    model: form.meta.model ?? DEFAULT_MODEL_NAME,
     cache: form.meta.cache,
     metadata: {
       context: "workflow",

--- a/runner/src/builtins/llm.ts
+++ b/runner/src/builtins/llm.ts
@@ -82,6 +82,7 @@ export function llm(
       model: model ?? DEFAULT_MODEL_NAME,
       metadata: {
         // FIXME(ja): how do we get the context of space/charm id here
+        // bf: I also do not know... this one is tricky
         context: "charm",
       },
       cache: true,


### PR DESCRIPTION
An attempt to make threading metadata through the stack a little cleaner, along with apply defaults and using that to pass the `space` in the metadata.