### PR TITLE
chore: Update Writable->Mutable and apply it recursively for queries.

### DIFF
--- a/builder/src/index.ts
+++ b/builder/src/index.ts
@@ -44,11 +44,12 @@ export {
   isStatic,
   isStreamAlias,
   type JSONSchema,
-  type JSONSchemaWritable,
+  type JSONSchemaMutable,
   type JSONValue,
   markAsStatic,
   type Module,
   type ModuleFactory,
+  type Mutable,
   NAME,
   type Node,
   type NodeFactory,
@@ -67,7 +68,6 @@ export {
   unsafe_originalRecipe,
   unsafe_parentRecipe,
   type UnsafeBinding,
-  type Writable,
 } from "./types.ts";
 export { type Schema, schema } from "./schema-to-ts.ts";
 

--- a/builder/src/recipe.ts
+++ b/builder/src/recipe.ts
@@ -4,7 +4,7 @@ import {
   isOpaqueRef,
   isShadowRef,
   type JSONSchema,
-  type JSONSchemaWritable,
+  type JSONSchemaMutable,
   makeOpaqueRef,
   type Module,
   type Node,
@@ -262,7 +262,7 @@ function factoryFromRecipe<T, R>(
 
   if (typeof argumentSchemaArg === "string") {
     // Create a writable schema
-    const writableSchema: JSONSchemaWritable = createJsonSchema(defaults, true);
+    const writableSchema: JSONSchemaMutable = createJsonSchema(defaults, true);
     writableSchema.description = argumentSchemaArg;
 
     delete (writableSchema.properties as any)?.[UI]; // TODO(seefeld): This should be a schema for views

--- a/builder/src/types.ts
+++ b/builder/src/types.ts
@@ -1,4 +1,5 @@
 import { isObj } from "@commontools/utils";
+import { Mutable } from "@commontools/utils/types";
 
 export const ID: unique symbol = Symbol("ID, unique to the context");
 export const ID_FIELD: unique symbol = Symbol(
@@ -150,13 +151,8 @@ export type JSONSchema = {
   readonly additionalProperties?: Readonly<JSONSchema> | boolean;
 };
 
-export type Writable<T> = {
-  -readonly [P in keyof T]: T[P] extends ReadonlyArray<infer U> ? Writable<U>[]
-    : T[P] extends Readonly<infer U> ? Writable<U>
-    : T[P];
-};
-
-export type JSONSchemaWritable = Writable<JSONSchema>;
+export { type Mutable };
+export type JSONSchemaMutable = Mutable<JSONSchema>;
 
 export type Alias = {
   $alias: {

--- a/builder/src/utils.ts
+++ b/builder/src/utils.ts
@@ -8,7 +8,7 @@ import {
   isShadowRef,
   isStatic,
   type JSONSchema,
-  type JSONSchemaWritable,
+  type JSONSchemaMutable,
   type JSONValue,
   makeOpaqueRef,
   markAsStatic,
@@ -232,7 +232,7 @@ export function toJSONWithAliases(
 export function createJsonSchema(
   example: any,
   addDefaults = false,
-): JSONSchemaWritable {
+): JSONSchemaMutable {
   function analyzeType(value: any): JSONSchema {
     if (isCell(value)) {
       if (value.schema) {
@@ -259,7 +259,7 @@ export function createJsonSchema(
     }
 
     const type = typeof value;
-    const schema: JSONSchemaWritable = {};
+    const schema: JSONSchemaMutable = {};
 
     switch (type) {
       case "object":
@@ -314,7 +314,7 @@ export function createJsonSchema(
     return schema;
   }
 
-  return analyzeType(example);
+  return analyzeType(example) as JSONSchemaMutable;
 }
 
 export function moduleToJSON(module: Module) {

--- a/charm/src/iterate.ts
+++ b/charm/src/iterate.ts
@@ -9,7 +9,7 @@ import { isObj } from "@commontools/utils";
 import {
   createJsonSchema,
   JSONSchema,
-  type Writable,
+  JSONSchemaMutable,
 } from "@commontools/builder";
 import { Charm, CharmManager, charmSourceCellSchema } from "./manager.ts";
 import {
@@ -19,12 +19,12 @@ import {
 } from "./iframe/recipe.ts";
 import { buildPrompt, RESPONSE_PREFILL } from "./iframe/prompt.ts";
 import {
+  applyDefaults,
   formatForm,
   generateCodeAndSchema,
   generateSpecAndSchema,
+  type GenerationOptions,
   LLMClient,
-  applyDefaults,
-  type GenerationOptions
 } from "@commontools/llm";
 import { injectUserCode } from "./iframe/static.ts";
 import { IFrameRecipe, WorkflowForm } from "./index.ts";
@@ -236,7 +236,7 @@ export function scrub(data: any): any {
               (key) => [key, {}],
             ),
           ),
-        } as JSONSchema;
+        } satisfies JSONSchema;
         console.log("scrubbed generated schema", scrubbed);
         // Only if we found any properties, return the scrubbed schema
         return Object.keys(scrubbed).length > 0
@@ -302,7 +302,7 @@ async function singlePhaseCodeGeneration(
     ...existingSchema,
     title: title || "missing",
     description,
-  } as Writable<JSONSchema>;
+  } as JSONSchemaMutable;
 
   if (!schema.type) {
     schema.type = "object";
@@ -392,7 +392,7 @@ async function twoPhaseCodeGeneration(
     ...existingSchema,
     title: title || "missing",
     description,
-  } as Writable<JSONSchema>;
+  } as JSONSchemaMutable;
 
   if (!schema.type) {
     schema.type = "object";

--- a/jumble/integration/basic-flow.test.ts
+++ b/jumble/integration/basic-flow.test.ts
@@ -12,7 +12,6 @@ import {
   addCharm,
   inspectCharm,
   login,
-  Mutable,
   snapshot,
   waitForSelectorClick,
   waitForSelectorWithText,
@@ -20,6 +19,7 @@ import {
 import * as path from "@std/path";
 import { ensureDirSync } from "@std/fs";
 import { join } from "@std/path";
+import { Mutable } from "@commontools/utils/types";
 
 const TOOLSHED_API_URL = Deno.env.get("TOOLSHED_API_URL") ??
   "http://localhost:8000/";

--- a/jumble/src/recipes/smolIframe.ts
+++ b/jumble/src/recipes/smolIframe.ts
@@ -12,7 +12,7 @@ const argumentSchema = {
     },
   },
   description: "SMOL Counter demo",
-} as JSONSchema;
+} satisfies JSONSchema;
 
 export default recipe(argumentSchema, (data) => ({
   [NAME]: "smol iframe",

--- a/llm/src/prompts/code-and-schema-gen.ts
+++ b/llm/src/prompts/code-and-schema-gen.ts
@@ -1,6 +1,6 @@
 import { hydratePrompt, parseTagFromResponse } from "./prompting.ts";
 import { LLMClient } from "../client.ts";
-import type { JSONSchema, JSONSchemaWritable } from "@commontools/builder";
+import type { JSONSchema, JSONSchemaMutable } from "@commontools/builder";
 import { WorkflowForm } from "@commontools/charm";
 import { systemMdConcise } from "../../../charm/src/iframe/static.ts";
 import { formatForm } from "./spec-and-schema-gen.ts";
@@ -273,8 +273,8 @@ Based on this goal and the existing schema, please provide a title, description,
   const sourceCode = parseTagFromResponse(response.content, "source_code");
 
   // If we have an existing schema, use it; otherwise parse the generated schema
-  let resultSchema: JSONSchemaWritable;
-  let argumentSchema: JSONSchemaWritable;
+  let resultSchema: JSONSchemaMutable;
+  let argumentSchema: JSONSchemaMutable;
 
   try {
     const resultSchemaJson = parseTagFromResponse(

--- a/llm/src/prompts/spec-and-schema-gen.ts
+++ b/llm/src/prompts/spec-and-schema-gen.ts
@@ -1,7 +1,7 @@
 import { hydratePrompt, llmPrompt, parseTagFromResponse } from "./prompting.ts";
 import { LLMClient } from "../client.ts";
 import { DEFAULT_MODEL_NAME } from "../types.ts";
-import type { JSONSchema, JSONSchemaWritable } from "@commontools/builder";
+import type { JSONSchema, JSONSchemaMutable } from "@commontools/builder";
 import { WorkflowForm } from "@commontools/charm";
 
 // Prompt for generating schema and specification from a goal
@@ -271,8 +271,8 @@ Based on this goal and the existing schema, please provide a title, description,
   const plan = parseTagFromResponse(response.content, "plan");
 
   // If we have an existing schema, use it; otherwise parse the generated schema
-  let resultSchema: JSONSchemaWritable;
-  let argumentSchema: JSONSchemaWritable;
+  let resultSchema: JSONSchemaMutable;
+  let argumentSchema: JSONSchemaMutable;
 
   try {
     const resultSchemaJson = parseTagFromResponse(
@@ -393,8 +393,8 @@ Based on this goal and the existing schema, please provide a title, description,
   const plan = parseTagFromResponse(response.content, "plan");
 
   // If we have an existing schema, use it; otherwise parse the generated schema
-  let resultSchema: JSONSchemaWritable;
-  let argumentSchema: JSONSchemaWritable;
+  let resultSchema: JSONSchemaMutable;
+  let argumentSchema: JSONSchemaMutable;
 
   try {
     const resultSchemaJson = parseTagFromResponse(

--- a/recipes/bgAdmin.tsx
+++ b/recipes/bgAdmin.tsx
@@ -4,6 +4,7 @@ import {
   handler,
   JSONSchema,
   lift,
+  Mutable,
   NAME,
   recipe,
   Schema,
@@ -34,8 +35,8 @@ const BGCharmEntrySchema = {
     "lastRun",
     "status",
   ],
-} as const as JSONSchema;
-type BGCharmEntry = Schema<typeof BGCharmEntrySchema>;
+} as const satisfies JSONSchema;
+type BGCharmEntry = Mutable<Schema<typeof BGCharmEntrySchema>>;
 
 const BGCharmEntriesSchema = {
   type: "array",
@@ -49,7 +50,7 @@ const InputSchema = {
   properties: {
     charms: BGCharmEntriesSchema,
   },
-} as const as JSONSchema;
+} as const satisfies JSONSchema;
 
 const ResultSchema = {
   type: "object",

--- a/recipes/discord.tsx
+++ b/recipes/discord.tsx
@@ -48,7 +48,7 @@ const MessageSchema = {
     "referenced_message_id",
     "thread_id",
   ],
-} as const as JSONSchema;
+} as const satisfies JSONSchema;
 type MessageSchema = Schema<typeof MessageSchema>;
 
 const InputSchema = {

--- a/recipes/gmail.tsx
+++ b/recipes/gmail.tsx
@@ -6,6 +6,7 @@ import {
   handler,
   ID,
   JSONSchema,
+  Mutable,
   NAME,
   recipe,
   Schema,
@@ -93,8 +94,8 @@ const EmailSchema = {
   type: "object",
   properties: EmailProperties,
   required: Object.keys(EmailProperties),
-} as const as JSONSchema;
-type Email = Schema<typeof EmailSchema>;
+} as const satisfies JSONSchema;
+type Email = Mutable<Schema<typeof EmailSchema>>;
 
 const AuthSchema = {
   type: "object",

--- a/recipes/simpleValue.tsx
+++ b/recipes/simpleValue.tsx
@@ -23,7 +23,7 @@ const updaterSchema = {
 } as const satisfies JSONSchema;
 
 // Different way to define the same schema, using 'schema' helper function,
-// let's as leave off `as const as JSONSchema`.
+// let's as leave off `as const satisfies JSONSchema`.
 const inputSchema = schema({
   type: "object",
   properties: {

--- a/runner/test/recipes.test.ts
+++ b/runner/test/recipes.test.ts
@@ -457,10 +457,12 @@ describe("Recipe Runner", () => {
           properties: {
             value: { type: "number" },
           },
+          required: ["value"],
         },
         multiplier: { type: "number" },
       },
-    } as JSONSchema;
+      required: ["settings"],
+    } satisfies JSONSchema;
 
     const multiplyRecipe = recipe<{
       settings: { value: number };
@@ -522,9 +524,11 @@ describe("Recipe Runner", () => {
               },
             },
           },
+          required: ["items"],
         },
       },
-    } as JSONSchema;
+      required: ["data"],
+    } satisfies JSONSchema;
 
     const sumRecipe = recipe<{ data: { items: Array<{ value: number }> } }>(
       "Sum Items",
@@ -579,9 +583,9 @@ describe("Recipe Runner", () => {
           },
         },
       },
-    } as JSONSchema;
+    } satisfies JSONSchema;
 
-    const dynamicRecipe = recipe<{ context: Record<string, number> }>(
+    const dynamicRecipe = recipe<{ context: Record<PropertyKey, number> }>(
       "Dynamic Context",
       ({ context }) => {
         const result = lift(

--- a/runner/test/schema-lineage.test.ts
+++ b/runner/test/schema-lineage.test.ts
@@ -258,7 +258,7 @@ describe("Schema propagation end-to-end example", () => {
             additionalProperties: { asCell: true },
           },
         },
-      } as const as JSONSchema,
+      } as const satisfies JSONSchema,
     );
 
     expect(isCell(c.get().props.value)).toBe(true);

--- a/utils/deno.json
+++ b/utils/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@commontools/utils",
   "tasks": {
-    "test": "echo 'No tests to run.'"
+    "test": "deno test"
   },
   "exports": {
     ".": "./src/index.ts",
@@ -9,6 +9,7 @@
     "./encoding": "./src/encoding.ts",
     "./env": "./src/env.ts",
     "./sleep": "./src/sleep.ts",
+    "./types": "./src/types.ts",
     "./integration": "./src/integration.ts",
     "./zod-utils": "./src/zod-utils.ts"
   }

--- a/utils/src/integration.ts
+++ b/utils/src/integration.ts
@@ -6,10 +6,6 @@ import { sleep } from "@commontools/utils/sleep";
 
 const COMMON_CLI_PATH = path.join(import.meta.dirname!, "../../cli");
 
-export type Mutable<T> = {
-  -readonly [k in keyof T]: T[k];
-};
-
 export const decode = (() => {
   const decoder = new TextDecoder();
   return (buffer: Uint8Array): string => decoder.decode(buffer);
@@ -107,7 +103,7 @@ export const waitForSelectorWithText = async (
   page: Page,
   selector: string,
   text: string,
-  config?: { retry?: number, timeoutMs?: number }
+  config?: { retry?: number; timeoutMs?: number },
 ): Promise<ElementHandle> => {
   const retry = config?.retry ?? 60;
   const timeout = config?.timeoutMs ?? 1000;

--- a/utils/src/types.ts
+++ b/utils/src/types.ts
@@ -1,0 +1,3 @@
+export type Mutable<T> = T extends ReadonlyArray<infer U> ? Mutable<U>[]
+  : T extends object ? ({ -readonly [P in keyof T]: Mutable<T[P]> })
+  : T;

--- a/utils/test/types.test.ts
+++ b/utils/test/types.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "@std/testing/bdd";
+import { Mutable } from "@commontools/utils/types";
+
+type ImmutableObj<T> = {
+  readonly prop: T;
+};
+
+function mutate<T>(value: T, callback: (v: Mutable<T>) => void) {
+  callback(value as Mutable<T>);
+}
+
+describe("types", () => {
+  describe("Mutable", () => {
+    it("Enables mutation on nested `{ readonly prop: T }`", () => {
+      const schema: ImmutableObj<ImmutableObj<number>> = { prop: { prop: 5 } };
+      mutate(schema, (schema) => {
+        schema.prop.prop = 10;
+      });
+    });
+    it("Enables mutation on nested `Readonly<T>`", () => {
+      const schema: Readonly<{
+        prop: Readonly<{
+          prop: number;
+        }>;
+      }> = { prop: { prop: 5 } };
+      mutate(schema, (schema) => {
+        schema.prop.prop = 10;
+      });
+    });
+    it("Enables mutation on `ReadonlyArray`", () => {
+      const schema: ReadonlyArray<number> = [1, 2, 3];
+      mutate(schema, (schema) => {
+        schema[1] = 100;
+      });
+    });
+    it("Enables mutation on `readonly T[]`", () => {
+      const schema: readonly number[] = [1, 2, 3];
+      mutate(schema, (schema) => {
+        schema[1] = 100;
+      });
+    });
+    it("Enables mutation on `ReadonlyArray` nested in `Readonly<T>`", () => {
+      const schema: Readonly<{
+        prop: ReadonlyArray<number>;
+      }> = { prop: [1, 2, 3] };
+      mutate(schema, (schema) => {
+        schema.prop[1] = 100;
+      });
+    });
+    it("Passes through for primitive types", () => {
+      const _: Mutable<null> = null;
+      const __: Mutable<number> = 5;
+      const ___: Mutable<string> = "hi";
+    });
+  });
+});


### PR DESCRIPTION
* Gmail recipe was using `as JSONSchema` rather than `satisfies JSONSchema`, which was causing some type issues
* No strong feelings for naming between `Writable`, `Mutable`, mostly noting distinction
* Pulled in extra `satisfies JSONSchema` clauses from @ubik2  #1103 (without which `Schema` resolves to `any`)
* The `Writable` type helper was not applying mutability recursively; an object with a string type would break out its properties, starting with:

```ts
// via `Schema<typeof EmailSchema>`
type Email = {
    readonly id: string;
} & {} & Record<...>
```

but typed as

```ts
// via `Writable<Schema<typeof EmailSchema>>`
type EmailWritable = {
    id: Writable<{
        toString: () => string;
        charAt: (pos: number) => string;
        charCodeAt: (index: number) => number;
        concat: (...strings: string[]) => string;
        indexOf: (searchString: string, position?: number) => number;
        ... 46 more ...;
        [Symbol.iterator]: () => StringIterator<string>;
    }>;
}
```

With using a recursive version of the `Mutable` helper, the types now resolve to a query instance:

```ts
// via `Mutable<Schema<typeof EmailSchema>>`
type Email  = {
    id: string;
}
```

While the email case is *mostly* readonly, and this is used as just an illustrative example (bgAdmin for example does need mutability), we do set `ID` on a `email` query, a property of `JSONSchema`, not `Schema`; this is failing types currently, not sure of the way forward here:

```ts
email[ID] = email.id
```