### PR TITLE
fix: ignore schema incopmpatible writes

### DIFF
--- a/jumble/public/module/charm/sandbox/bootstrap.js
+++ b/jumble/public/module/charm/sandbox/bootstrap.js
@@ -46,12 +46,18 @@ window.useDoc = function (key) {
 
   // Update function
   const updateDoc = newValue => {
-    if (typeof newValue === "function") {
-      newValue = newValue(doc)
+    // only perform write if sourceData contains this key otherwise we ignore
+    // write which somewhat aligns with returning `undefined`.
+    // TODO(@seefeld) - should we throw here instead or use different method
+    // to decide whether to send a write request
+    if (key in window.sourceData) {
+      if (typeof newValue === "function") {
+        newValue = newValue(doc)
+      }
+      console.log("useDoc", key, "written", newValue)
+      setDocState(newValue)
+      window.parent.postMessage({ type: "write", data: [key, newValue] }, "*")
     }
-    console.log("useDoc", key, "written", newValue)
-    setDocState(newValue)
-    window.parent.postMessage({ type: "write", data: [key, newValue] }, "*")
   }
 
   // If we have not yet received response from the host we use field from the


### PR DESCRIPTION
Per https://linear.app/common-tools/issue/CT-318/disallow-writing-data-that-isnt-in-the-schema

I'm not sure if we should simply ignore writes that are for keys not in the document or through 