### PR TITLE
fix: fix html fragment support

### DIFF
--- a/html/deno.json
+++ b/html/deno.json
@@ -4,6 +4,10 @@
   "tasks": {
     "test": "deno test --allow-env"
   },
-  "imports": {
+  "imports": {},
+  "compilerOptions": {
+    "jsx": "react",
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "h.fragment"
   }
 }

--- a/html/src/index.ts
+++ b/html/src/index.ts
@@ -1,3 +1,3 @@
 export { render, setEventSanitizer, setNodeSanitizer } from "./render.ts";
 export { debug, setDebug } from "./logger.ts";
-export { Fragment, h, type VNode } from "./jsx.ts";
+export { h, type VNode } from "./jsx.ts";

--- a/html/src/jsx.ts
+++ b/html/src/jsx.ts
@@ -1,11 +1,13 @@
 import type { Cell, Stream } from "@commontools/runner";
-// declare global {
-//   namespace JSX {
-//     interface IntrinsicElements {
-//       [elemName: string]: any;
-//     }
-//   }
-// }
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      [elemName: string]: any;
+    }
+  }
+}
+
+const FRAGMENT_ELEMENT = "common-fragment";
 
 export const h = Object.assign(function h(
   name: string | ((...args: any[]) => any),
@@ -27,7 +29,7 @@ export const h = Object.assign(function h(
   }
 }, {
   fragment({ children }: { children: Child[] }) {
-    return children;
+    return h(FRAGMENT_ELEMENT, null, children);
   },
 });
 

--- a/html/src/jsx.ts
+++ b/html/src/jsx.ts
@@ -7,9 +7,7 @@ import type { Cell, Stream } from "@commontools/runner";
 //   }
 // }
 
-export const Fragment = "Fragment";
-
-export function h(
+export const h = Object.assign(function h(
   name: string | ((...args: any[]) => any),
   props: { [key: string]: any } | null,
   ...children: Child[]
@@ -27,7 +25,11 @@ export function h(
       children: children.flat(),
     };
   }
-}
+}, {
+  fragment({ children }: { children: Child[] }) {
+    return children;
+  },
+});
 
 /**
  * Dynamic properties. Can either be string type (static) or a Mustache

--- a/html/test/jsx.tsx
+++ b/html/test/jsx.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, it } from "@std/testing/bdd";
 import * as assert from "./assert.ts";
 import { h } from "../src/jsx.ts";
 
-describe("jsx dom fragments supprot", () => {
+describe("jsx dom fragments support", () => {
   it("dom fragments should work", () => {
     const fragment = (
       <>

--- a/html/test/jsx.tsx
+++ b/html/test/jsx.tsx
@@ -1,0 +1,56 @@
+import { beforeEach, describe, it } from "@std/testing/bdd";
+import * as assert from "./assert.ts";
+import { h } from "../src/jsx.ts";
+
+describe("jsx dom fragments supprot", () => {
+  it("dom fragments should work", async () => {
+    const fragment = (
+      <>
+        <p>Hello world</p>
+      </>
+    );
+
+    assert.matchObject(fragment, [
+      <p>Hello world</p>,
+    ]);
+  });
+
+  it("dom fragments with multiple children", async () => {
+    const fragment = (
+      <>
+        <p>Grocery List</p>
+        <ul>
+          <li>Buy Milk</li>
+        </ul>
+      </>
+    );
+
+    assert.matchObject(fragment, [
+      <p>Grocery List</p>,
+      <ul>
+        <li>Buy Milk</li>
+      </ul>,
+    ]);
+  });
+
+  it("fragments inside the element", async () => {
+    const grocery = (
+      <>
+        <p>Grocery List</p>
+        <ul>
+          <li>Buy Milk</li>
+        </ul>
+      </>
+    );
+
+    assert.matchObject(
+      <div>{grocery}</div>,
+      <div>
+        <p>Grocery List</p>
+        <ul>
+          <li>Buy Milk</li>
+        </ul>
+      </div>,
+    );
+  });
+});

--- a/html/test/jsx.tsx
+++ b/html/test/jsx.tsx
@@ -10,9 +10,12 @@ describe("jsx dom fragments supprot", () => {
       </>
     );
 
-    assert.matchObject(fragment, [
-      <p>Hello world</p>,
-    ]);
+    assert.matchObject(
+      fragment,
+      <common-fragment>
+        <p>Hello world</p>
+      </common-fragment>,
+    );
   });
 
   it("dom fragments with multiple children", async () => {
@@ -25,12 +28,15 @@ describe("jsx dom fragments supprot", () => {
       </>
     );
 
-    assert.matchObject(fragment, [
-      <p>Grocery List</p>,
-      <ul>
-        <li>Buy Milk</li>
-      </ul>,
-    ]);
+    assert.matchObject(
+      fragment,
+      <common-fragment>
+        <p>Grocery List</p>
+        <ul>
+          <li>Buy Milk</li>
+        </ul>
+      </common-fragment>,
+    );
   });
 
   it("fragments inside the element", async () => {
@@ -46,10 +52,12 @@ describe("jsx dom fragments supprot", () => {
     assert.matchObject(
       <div>{grocery}</div>,
       <div>
-        <p>Grocery List</p>
-        <ul>
-          <li>Buy Milk</li>
-        </ul>
+        <common-fragment>
+          <p>Grocery List</p>
+          <ul>
+            <li>Buy Milk</li>
+          </ul>
+        </common-fragment>
       </div>,
     );
   });

--- a/html/test/jsx.tsx
+++ b/html/test/jsx.tsx
@@ -3,7 +3,7 @@ import * as assert from "./assert.ts";
 import { h } from "../src/jsx.ts";
 
 describe("jsx dom fragments supprot", () => {
-  it("dom fragments should work", async () => {
+  it("dom fragments should work", () => {
     const fragment = (
       <>
         <p>Hello world</p>
@@ -18,7 +18,7 @@ describe("jsx dom fragments supprot", () => {
     );
   });
 
-  it("dom fragments with multiple children", async () => {
+  it("dom fragments with multiple children", () => {
     const fragment = (
       <>
         <p>Grocery List</p>
@@ -39,7 +39,7 @@ describe("jsx dom fragments supprot", () => {
     );
   });
 
-  it("fragments inside the element", async () => {
+  it("fragments inside the element", () => {
     const grocery = (
       <>
         <p>Grocery List</p>

--- a/jumble/src/components/DitherCube.tsx
+++ b/jumble/src/components/DitherCube.tsx
@@ -388,7 +388,6 @@ export const DitheredCube = ({
         <MorphingMesh animate={animate} animationSpeed={animationSpeed} />
         <OrbitControls enableZoom={false} />
         <Effects>
-          {/* @ts-expect-error DitheringPass is properly extended but TS doesn't recognize it */}
           <ditheringPass />
         </Effects>
       </Canvas>

--- a/recipes/counter.tsx
+++ b/recipes/counter.tsx
@@ -1,0 +1,73 @@
+import { h } from "@commontools/html";
+import {
+  cell,
+  derive,
+  handler,
+  ifElse,
+  JSONSchema,
+  NAME,
+  recipe,
+  schema,
+  str,
+  UI,
+} from "@commontools/builder";
+
+// Different way to define the same schema, using 'schema' helper function,
+// let's as leave off `as const satisfies JSONSchema`.
+const inputSchema = schema({
+  type: "object",
+  properties: {
+    value: { type: "number", default: 0 },
+  },
+  default: { value: 0 },
+});
+
+const outputSchema = {
+  type: "object",
+  properties: {
+    value: { type: "number", default: 0 },
+  },
+} as const satisfies JSONSchema;
+
+const updateSchema = {
+  type: "object",
+  properties: {
+    value: { type: "number", default: 0 },
+  },
+  title: "update values",
+} as const satisfies JSONSchema;
+
+const increment = handler(updateSchema, inputSchema, (_, state) => {
+  debugger;
+  console.log("increment");
+  state.value = state.value + 1;
+  console.log(state.value);
+});
+
+const decrement = handler(updateSchema, inputSchema, (_, state) => {
+  console.log("decrement");
+  state.value = state.value - 1;
+});
+
+const isOdd = (n: number) => n % 2 > 0;
+
+export default recipe(inputSchema, outputSchema, (cell) => {
+  return {
+    [NAME]: str`Simple counter: ${derive(cell.value, String)}`,
+    [UI]: (
+      <div>
+        <button type="button" onClick={increment(cell)}>+</button>
+        <p>{cell.value}</p>
+        {
+          /* {ifElse(
+          derive(cell.value, isOdd),
+          <i>{cell.value}</i>,
+          <b>{cell.value}</b>,
+        )} */
+        }
+        <button type="button" onClick={decrement(cell)}>-</button>
+      </div>
+    ),
+    value: cell.value,
+  };
+});

--- a/recipes/counter.tsx
+++ b/recipes/counter.tsx
@@ -38,14 +38,10 @@ export default recipe(model, model, (cell) => {
     [UI]: (
       <div>
         <button type="button" onClick={increment(cell)}>+</button>
-        {/* <span>{derive(cell.value, String)}</p> */}
-
-        {ifElse(
-          derive(cell.value, isOdd),
-          <i>{cell.value}</i>,
-          <b>{cell.value}</b>,
-        )}
-
+        {/* use html fragment to test that it works  */}
+        <>
+          <b>{cell.value}</b>
+        </>
         <button type="button" onClick={decrement(cell)}>-</button>
       </div>
     ),

--- a/recipes/counter.tsx
+++ b/recipes/counter.tsx
@@ -14,57 +14,38 @@ import {
 
 // Different way to define the same schema, using 'schema' helper function,
 // let's as leave off `as const satisfies JSONSchema`.
-const inputSchema = schema({
+const model = schema({
   type: "object",
   properties: {
-    value: { type: "number", default: 0 },
+    value: { type: "number", default: 0, asCell: true },
   },
   default: { value: 0 },
 });
 
-const outputSchema = {
-  type: "object",
-  properties: {
-    value: { type: "number", default: 0 },
-  },
-} as const satisfies JSONSchema;
-
-const updateSchema = {
-  type: "object",
-  properties: {
-    value: { type: "number", default: 0 },
-  },
-  title: "update values",
-} as const satisfies JSONSchema;
-
-const increment = handler(updateSchema, inputSchema, (_, state) => {
-  debugger;
-  console.log("increment");
-  state.value = state.value + 1;
-  console.log(state.value);
+const increment = handler({}, model, (_, state) => {
+  state.value.set(state.value.get() + 1);
 });
 
-const decrement = handler(updateSchema, inputSchema, (_, state) => {
-  console.log("decrement");
-  state.value = state.value - 1;
+const decrement = handler({}, model, (_, state) => {
+  state.value.set(state.value.get() - 1);
 });
 
 const isOdd = (n: number) => n % 2 > 0;
 
-export default recipe(inputSchema, outputSchema, (cell) => {
+export default recipe(model, model, (cell) => {
   return {
     [NAME]: str`Simple counter: ${derive(cell.value, String)}`,
     [UI]: (
       <div>
         <button type="button" onClick={increment(cell)}>+</button>
-        <p>{cell.value}</p>
-        {
-          /* {ifElse(
+        {/* <span>{derive(cell.value, String)}</p> */}
+
+        {ifElse(
           derive(cell.value, isOdd),
           <i>{cell.value}</i>,
           <b>{cell.value}</b>,
-        )} */
-        }
+        )}
+
         <button type="button" onClick={decrement(cell)}>-</button>
       </div>
     ),

--- a/recipes/counter.tsx
+++ b/recipes/counter.tsx
@@ -1,10 +1,8 @@
+// deno-lint-ignore-file jsx-no-useless-fragment
 import { h } from "@commontools/html";
 import {
-  cell,
   derive,
   handler,
-  ifElse,
-  JSONSchema,
   NAME,
   recipe,
   schema,
@@ -29,8 +27,6 @@ const increment = handler({}, model, (_, state) => {
 const decrement = handler({}, model, (_, state) => {
   state.value.set(state.value.get() - 1);
 });
-
-const isOdd = (n: number) => n % 2 > 0;
 
 export default recipe(model, model, (cell) => {
   return {

--- a/runner/src/runtime/local-build.ts
+++ b/runner/src/runtime/local-build.ts
@@ -138,7 +138,7 @@ export const tsToExports = async (
       strict: true,
       jsx: ts.JsxEmit.React,
       jsxFactory: "h",
-      jsxFragmentFactory: "Fragment",
+      jsxFragmentFactory: "h.fragment",
       esModuleInterop: true,
       sourceMap: true, // Enable source map generation
       inlineSources: false, // Don't include original source in source maps

--- a/ui/src/components/common-fragment.ts
+++ b/ui/src/components/common-fragment.ts
@@ -1,0 +1,8 @@
+export class CommonFragmentElement extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+  }
+}
+
+customElements.define("common-fragment", CommonFragmentElement);

--- a/ui/src/components/common-fragment.ts
+++ b/ui/src/components/common-fragment.ts
@@ -4,6 +4,9 @@ export class CommonFragmentElement extends HTMLElement {
     this.attachShadow({ mode: "open" })
       // Add a slot to display the children
       .appendChild(document.createElement("slot"));
+
+    // Tell engine to ignore this element for layout purposes
+    this.style.display = 'contents';
   }
 }
 

--- a/ui/src/components/common-fragment.ts
+++ b/ui/src/components/common-fragment.ts
@@ -1,7 +1,9 @@
 export class CommonFragmentElement extends HTMLElement {
   constructor() {
     super();
-    this.attachShadow({ mode: "open" });
+    this.attachShadow({ mode: "open" })
+      // Add a slot to display the children
+      .appendChild(document.createElement("slot"));
   }
 }
 

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -4,6 +4,7 @@ export * as CommonCharm from "./common-charm.ts";
 export * as CommonDatatable from "./common-datatable.ts";
 export * as CommonDict from "./common-dict.ts";
 export * as CommonForm from "./common-form.ts";
+export * as CommonFragment from "./common-fragment.ts";
 export * as CommonGoogleOauth from "./common-google-oauth.ts";
 export * as CommonGrid from "./common-grid.ts";
 export * as CommonHeroLayout from "./common-hero-layout.ts";


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added support for JSX fragments in the DOM renderer to allow grouping elements without extra nodes.

- **Bug Fixes**
  - Updated JSX factory settings and implementation to handle fragments.
  - Added tests to verify fragment support.

<!-- End of auto-generated description by mrge. -->

