### PR TITLE
chore: Align isObject/isRecord usage

### DIFF
--- a/background-charm-service/src/space-manager.ts
+++ b/background-charm-service/src/space-manager.ts
@@ -1,4 +1,4 @@
-import { sleep } from "@commontools/utils";
+import { sleep } from "@commontools/utils/sleep";
 import { Cell } from "@commontools/runner";
 import { type Cancel, useCancelGroup } from "@commontools/runner";
 import {

--- a/builder/src/types.ts
+++ b/builder/src/types.ts
@@ -1,5 +1,4 @@
-import { isObj } from "@commontools/utils";
-import { Mutable } from "@commontools/utils/types";
+import { isObject, Mutable } from "@commontools/utils/types";
 
 export const ID: unique symbol = Symbol("ID, unique to the context");
 export const ID_FIELD: unique symbol = Symbol(
@@ -166,7 +165,8 @@ export type Alias = {
 };
 
 export function isAlias(value: any): value is Alias {
-  return isObj(value) && isObj(value.$alias) &&
+  return isObject(value) && "$alias" in value && isObject(value.$alias) &&
+    "path" in value.$alias &&
     Array.isArray(value.$alias.path);
 }
 

--- a/charm/src/iterate.ts
+++ b/charm/src/iterate.ts
@@ -5,7 +5,7 @@ import {
   recipeManager,
   runtime,
 } from "@commontools/runner";
-import { isObj } from "@commontools/utils";
+import { isObject } from "@commontools/utils/types";
 import {
   createJsonSchema,
   JSONSchema,
@@ -215,7 +215,7 @@ export function scrub(data: any): any {
       // If there are properties, remove $UI and $NAME and any streams
       const scrubbed = Object.fromEntries(
         Object.entries(data.schema.properties).filter(([key, value]) =>
-          !key.startsWith("$") && (!isObj(value) || !value.asStream)
+          !key.startsWith("$") && (!isObject(value) || !value.asStream)
         ),
       );
       console.log("scrubbed modified schema", scrubbed, data.schema);
@@ -227,7 +227,7 @@ export function scrub(data: any): any {
       );
     } else {
       const value = data.asSchema().get();
-      if (isObj(value)) {
+      if (isObject(value)) {
         // Generate a new schema for all properties except $UI and $NAME and streams
         const scrubbed = {
           type: "object",
@@ -248,7 +248,7 @@ export function scrub(data: any): any {
     }
   } else if (Array.isArray(data)) {
     return data.map((value) => scrub(value));
-  } else if (isObj(data)) {
+  } else if (isObject(data)) {
     return Object.fromEntries(
       Object.entries(data).map(([key, value]) => [key, scrub(value)]),
     );
@@ -264,7 +264,7 @@ function turnCellsIntoAliases(data: any): any {
     return { $alias: data.getAsCellLink() };
   } else if (Array.isArray(data)) {
     return data.map((value) => turnCellsIntoAliases(value));
-  } else if (isObj(data)) {
+  } else if (isObject(data)) {
     return Object.fromEntries(
       Object.entries(data).map((
         [key, value],

--- a/charm/src/manager.ts
+++ b/charm/src/manager.ts
@@ -27,7 +27,7 @@ import {
 } from "@commontools/runner";
 import { storage } from "@commontools/runner";
 import { type Session } from "@commontools/identity";
-import { isObj } from "@commontools/utils";
+import { isObject } from "@commontools/utils/types";
 
 export function charmId(charm: Charm): string | undefined {
   const id = getEntityId(charm);
@@ -343,7 +343,7 @@ export class CharmManager {
     // If there is no result schema, create one from top level properties that omits UI, NAME
     if (!resultSchema) {
       const resultValue = charm.get();
-      if (isObj(resultValue)) {
+      if (isObject(resultValue)) {
         resultSchema = {
           type: "object",
           properties: Object.fromEntries(

--- a/html/deno.jsonc
+++ b/html/deno.jsonc
@@ -2,6 +2,7 @@
   "name": "@commontools/html",
   "exports": "./src/index.ts",
   "tasks": {
+    // JSDOM dependencies require env.
     "test": "deno test --allow-env"
   },
   "imports": {

--- a/html/src/path.ts
+++ b/html/src/path.ts
@@ -1,8 +1,5 @@
 import * as logger from "./logger.ts";
-
-export const isObject = (value: unknown): value is object => {
-  return typeof value === "object" && value !== null;
-};
+import { isObject } from "@commontools/utils/types";
 
 /** A keypath is an array of property keys */
 export type KeyPath = Array<PropertyKey>;

--- a/html/src/render.ts
+++ b/html/src/render.ts
@@ -8,7 +8,7 @@ import {
   useCancelGroup,
 } from "@commontools/runner";
 import { JSONSchema } from "@commontools/builder";
-import { isObj } from "@commontools/utils";
+import { isObject } from "@commontools/utils/types";
 import * as logger from "./logger.ts";
 
 const vdomSchema: JSONSchema = {
@@ -271,7 +271,7 @@ const sanitizeScripts = (node: VNode): VNode | null => {
   if (node.name === "script") {
     return null;
   }
-  if (!isCell(node.props) && !isObj(node.props)) {
+  if (!isCell(node.props) && !isObject(node.props)) {
     node = { ...node, props: {} };
   }
   if (!isCell(node.children) && !Array.isArray(node.children)) {

--- a/html/test/assert.ts
+++ b/html/test/assert.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "@commontools/utils/types";
+
 export class AssertionError<A, E> extends Error {
   actual: A | undefined;
   expected: E | undefined;
@@ -43,7 +45,7 @@ export const matchObject = (
   expected: unknown,
   message = "",
 ) => {
-  if (!isObject(actual) || !isObject(expected)) {
+  if (!isRecord(actual) || !isRecord(expected)) {
     throw new AssertionError({
       message: message || "Both arguments must be objects",
       actual,
@@ -61,7 +63,7 @@ export const matchObject = (
         });
       }
 
-      if (isObject(expected[key]) && isObject(actual[key])) {
+      if (isRecord(expected[key]) && isRecord(actual[key])) {
         // Recursively check nested objects
         matchObject(actual[key], expected[key], message);
       } else if (actual[key] !== expected[key]) {
@@ -83,10 +85,6 @@ export const matchObject = (
     });
   }
 };
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 export const throws = (run: () => void, message = "") => {
   try {

--- a/iframe-sandbox/src/ipc.ts
+++ b/iframe-sandbox/src/ipc.ts
@@ -1,4 +1,28 @@
 import { type JSONSchema } from "@commontools/builder";
+import { isObject } from "@commontools/utils/types";
+
+export const isJSONSchema = (source: unknown): source is JSONSchema => {
+  if (!isObject(source)) {
+    return false;
+  }
+
+  if (!("type" in source) || !source.type) {
+    return "anyOf" in source && Array.isArray(source.anyOf);
+  }
+
+  switch (source.type) {
+    case "object":
+    case "array":
+    case "string":
+    case "integer":
+    case "number":
+    case "boolean":
+    case "null":
+      return true;
+    default:
+      return false;
+  }
+};
 
 // Types used by the `common-iframe-sandbox` IPC.
 
@@ -107,34 +131,12 @@ export function isGuestError(e: object): e is GuestError {
     "stacktrace" in e && typeof e.stacktrace === "string";
 }
 
-const isObject = (source: unknown): source is Record<string, unknown> =>
-  typeof source === "object" && source != null;
 export const isTaskPerform = (source: unknown): source is TaskPerform =>
   isObject(source) &&
-  typeof source?.intent === "string" &&
-  typeof source?.description === "string" &&
-  isObject(source?.input) &&
-  isJSONSchema(source?.output);
-
-export const isJSONSchema = (source: unknown): source is JSONSchema => {
-  if (!isObject(source)) {
-    return false;
-  }
-
-  switch (source?.type) {
-    case "object":
-    case "array":
-    case "string":
-    case "integer":
-    case "number":
-    case "boolean":
-    case "null":
-      return true;
-    default: {
-      return Array.isArray(source?.anyOf);
-    }
-  }
-};
+  "intent" in source && typeof source.intent === "string" &&
+  "description" in source && typeof source.description === "string" &&
+  "input" in source && isObject(source.input) &&
+  "output" in source && isJSONSchema(source.output);
 
 export enum HostMessageType {
   Ping = "ping",

--- a/jumble/src/iframe-ctx.ts
+++ b/jumble/src/iframe-ctx.ts
@@ -14,7 +14,7 @@ import {
   removeAction,
 } from "@commontools/runner";
 import { DEFAULT_IFRAME_MODELS, LLMClient } from "@commontools/llm";
-import { isObj } from "@commontools/utils";
+import { isObject } from "@commontools/utils/types";
 import {
   completeJob,
   failJob,
@@ -196,7 +196,7 @@ export const setupIframe = () =>
             : undefined;
           const type = context.key(key).schema?.type ??
             currentValueType ?? typeof value;
-          if (type === "object" && isObj(value) && !Array.isArray(value)) {
+          if (type === "object" && isObject(value)) {
             context.key(key).update(value);
           } else if (
             (type === "array" && Array.isArray(value)) ||

--- a/jumble/src/views/CharmDetailView.tsx
+++ b/jumble/src/views/CharmDetailView.tsx
@@ -7,7 +7,7 @@ import {
 } from "@commontools/charm";
 import { useCharmReferences } from "@/hooks/use-charm-references.ts";
 import { isCell, isStream } from "@commontools/runner";
-import { isObj } from "@commontools/utils";
+import { isObject } from "@commontools/utils/types";
 import {
   CheckboxToggle,
   CommonCheckbox,
@@ -1339,7 +1339,7 @@ function translateCellsAndStreamsToPlainJSON(
     result = data.map((value) =>
       translateCellsAndStreamsToPlainJSON(value, partial, complete)
     );
-  } else if (isObj(data)) {
+  } else if (isObject(data)) {
     result = Object.fromEntries(
       Object.entries(data).map(([key, value]) => [
         key,

--- a/memory/space-schema.ts
+++ b/memory/space-schema.ts
@@ -9,7 +9,7 @@ import type {
   SchemaContext,
   SchemaQuery,
 } from "./interface.ts";
-import { isNumber, isObject, isString } from "./util.ts";
+import { isNumber, isObject, isString } from "@commontools/utils/types";
 import { FactSelector, SelectAll, selectFacts, Session } from "./space.ts";
 import { FactAddress } from "../runner/src/storage/cache.ts";
 import {

--- a/memory/traverse.ts
+++ b/memory/traverse.ts
@@ -3,7 +3,7 @@
 
 import { isAlias } from "../builder/src/index.ts";
 import { JSONObject, JSONValue } from "./consumer.ts";
-import { isObject } from "./provider.ts";
+import { isObject } from "@commontools/utils/types";
 
 export class CycleTracker<K> {
   private partial: Set<K>;
@@ -361,7 +361,8 @@ export function isPointer(value: any): boolean {
  * @returns {boolean}
  */
 function isJSONCellLink(value: any): value is JSONCellLink {
-  return (isObject(value) && isObject(value.cell) && "/" in value.cell &&
+  return (isObject(value) && "cell" in value && isObject(value.cell) &&
+    "/" in value.cell && "path" in value &&
     Array.isArray(value.path));
 }
 

--- a/memory/util.ts
+++ b/memory/util.ts
@@ -41,15 +41,3 @@ export const fromDID = async <ID extends DIDKey>(
     }
   }
 };
-
-export function isObject(value: unknown): boolean {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-export function isNumber(value: unknown): value is number {
-  return typeof value === "number" && Number.isFinite(value);
-}
-
-export function isString(value: unknown): value is string {
-  return typeof value === "string";
-}

--- a/runner/src/cfc.ts
+++ b/runner/src/cfc.ts
@@ -1,7 +1,7 @@
 // This is a simple form of the policy, where you express the basics of the partial ordering.
 
 import type { JSONSchema, JSONValue } from "@commontools/builder";
-import { isObject } from "../../memory/util.ts";
+import { isObject } from "@commontools/utils/types";
 import { extractDefaultValues } from "./utils.ts";
 
 // We'll often work with the transitive closure of this graph.

--- a/runner/src/storage.ts
+++ b/runner/src/storage.ts
@@ -22,9 +22,9 @@ import { VolatileStorageProvider } from "./storage/volatile.ts";
 import { Signer } from "@commontools/identity";
 import { isBrowser } from "@commontools/utils/env";
 import { sleep } from "@commontools/utils/sleep";
+import { defer } from "@commontools/utils/defer";
 import { TransactionResult } from "@commontools/memory";
 import { refer } from "@commontools/memory/reference";
-import { defer } from "@commontools/utils";
 import { SchemaContext, SchemaNone } from "@commontools/memory/interface";
 
 export function log(fn: () => any[]) {

--- a/toolshed/routes/ai/spell/handlers/find-spell-by-schema.ts
+++ b/toolshed/routes/ai/spell/handlers/find-spell-by-schema.ts
@@ -12,7 +12,7 @@ import { captureException } from "@sentry/deno";
 import { FindSpellBySchemaRequest } from "@/routes/ai/spell/spell.handlers.ts";
 
 import { checkSchemaMatch } from "@/lib/schema-match.ts";
-import { isObject } from "@/routes/ai/spell/schema.ts";
+import { isObject } from "@commontools/utils/types";
 import { Schema } from "jsonschema";
 import { Recipe, RecipeSchema } from "../spell.ts";
 

--- a/toolshed/routes/ai/spell/schema.ts
+++ b/toolshed/routes/ai/spell/schema.ts
@@ -1,5 +1,6 @@
 import { checkSchemaMatch } from "@/lib/schema-match.ts";
 import { Logger } from "@/lib/prefixed-logger.ts";
+import { isObject } from "@commontools/utils/types";
 
 export interface SchemaMatch<T = Record<string, unknown>> {
   key: string;
@@ -89,10 +90,6 @@ export function findExactSubtreeMatches(
   }
 
   return matches;
-}
-
-export function isObject(value: unknown): boolean {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 export function decomposeSchema(

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -1,4 +1,1 @@
-export * from "./defer.ts";
-export * from "./env.ts";
-export * from "./isObj.ts";
-export * from "./sleep.ts";
+throw new Error(`Import individual exports for utils: \`import { defer } from "@commontools/utils/defer"\``);

--- a/utils/src/isObj.ts
+++ b/utils/src/isObj.ts
@@ -1,5 +1,0 @@
-export function isObj(
-  value: unknown,
-): value is Record<string | number | symbol, unknown> {
-  return typeof value === "object" && value !== null;
-}

--- a/utils/src/types.ts
+++ b/utils/src/types.ts
@@ -1,3 +1,27 @@
+// Predicate for narrowing a `Record` type, with string,
+// symbol, or number (arrays) keys.
+export function isRecord(
+  value: unknown,
+): value is Record<string | number | symbol, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+// Predicate for narrowing a non-array/non-null `object` type.
+export function isObject(value: unknown): value is object {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Predicate for narrowing a `number` type.
+export function isNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+// Predicate for narrowing a `string` type.
+export function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+// Helper type to recursively remove `readonly` properties from type `T`.
 export type Mutable<T> = T extends ReadonlyArray<infer U> ? Mutable<U>[]
   : T extends object ? ({ -readonly [P in keyof T]: Mutable<T[P]> })
   : T;


### PR DESCRIPTION
* Align the multiple, slightly different implementations of `isObject` (and `isRecord`) -- sometimes as "non-array" objects, sometimes including arrays, and the differences between `object` and `Record` usage.
* Remove the root entry for `@commontools/utils` (originally tracking down a bug for something pulling in too many modules, but was misleading). Deno requires a root export, so a compile time (no exports) or runtime error fires if doing so to avoid inadvertantly pulling in all utils
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Standardized all isObject and isRecord checks across the codebase by providing consistent utility functions in utils/types, and removed duplicate or inconsistent implementations.

- **Refactors**
  - Replaced custom isObject/isRecord functions with shared versions from utils/types.
  - Removed unused or duplicate type-checking helpers.
  - Updated imports to use the new shared utilities.

<!-- End of auto-generated description by mrge. -->

