### PR TITLE
user should be first

### DIFF
--- a/runner/src/builtins/llm.ts
+++ b/runner/src/builtins/llm.ts
@@ -73,7 +73,7 @@ export function llm(
     const llmParams: LLMRequest = {
       system: system ?? "",
       messages: (messages ?? []).map((content: string, index: number) => ({
-        role: index % 2 ? "user" : "assistant",
+        role: index % 2 ? "assistant" : "user",
         content,
       })),
       stop: stop ?? "",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Changed the message role assignment so that the first message is always from the user, not the assistant.

<!-- End of auto-generated description by mrge. -->

