### PR TITLE
Basic agentic recipe

### DIFF
--- a/packages/builder/src/built-in.ts
+++ b/packages/builder/src/built-in.ts
@@ -19,6 +19,25 @@ export interface BuiltInLLMState<T> {
   error: any;
 }
 
+export interface BuiltInCompileAndRunParams<T> {
+  files: Record<string, string>;
+  main: string;
+  input?: T;
+}
+
+export interface BuiltInCompileAndRunState<T> {
+  pending: boolean;
+  result?: T;
+  error?: any;
+}
+
+export const compileAndRun = createNodeFactory({
+  type: "ref",
+  implementation: "compileAndRun",
+}) as <T = any, S = any>(
+  params: Opaque<BuiltInCompileAndRunParams<T>>,
+) => OpaqueRef<BuiltInCompileAndRunState<S>>;
+
 export const llm = createNodeFactory({
   type: "ref",
   implementation: "llm",

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -23,8 +23,11 @@ export {
   recipeFromFrame,
 } from "./recipe.ts";
 export {
+  type BuiltInCompileAndRunParams,
+  type BuiltInCompileAndRunState,
   type BuiltInLLMParams,
   type BuiltInLLMState,
+  compileAndRun,
   createCell,
   fetchData,
   ifElse,

--- a/packages/cli/main.ts
+++ b/packages/cli/main.ts
@@ -14,7 +14,7 @@ import {
   Identity,
   type Session,
 } from "@commontools/identity";
-import { assert } from "@commontools/memory/fact";
+import { setLLMUrl } from "@commontools/llm";
 
 const {
   spaceName,
@@ -48,6 +48,7 @@ const OPERATOR_PASS = Deno.env.get("OPERATOR_PASS") ?? "common user";
 
 storage.setRemoteStorage(new URL(toolshedUrl));
 setBlobbyServerUrl(toolshedUrl);
+setLLMUrl(toolshedUrl);
 
 async function main() {
   if (!spaceName && !spaceDID) {

--- a/packages/runner/src/builtins/compile-and-run.ts
+++ b/packages/runner/src/builtins/compile-and-run.ts
@@ -3,7 +3,7 @@ import { runtime } from "../runtime/index.ts";
 import { type Action, idle } from "../scheduler.ts";
 import { refer } from "merkle-reference";
 import { type ReactivityLog } from "../scheduler.ts";
-import { cancels, run, stop } from "../runner.ts";
+import { cancels, runSynced, stop } from "../runner.ts";
 import {
   BuiltInCompileAndRunParams,
   RecipeFactory,
@@ -102,9 +102,9 @@ export function compileAndRun(
       compiling.setAtPath([], false, log);
     });
 
-    compilePromise.then((recipe) => {
+    compilePromise.then(async (recipe) => {
       if (thisRun !== currentRun) return;
-      if (recipe) run(recipe, input, result);
+      if (recipe) await runSynced(result.asCell(), recipe, input);
       // TODO(seefeld): Add capturing runtime errors.
     });
   };

--- a/packages/runner/src/builtins/compile-and-run.ts
+++ b/packages/runner/src/builtins/compile-and-run.ts
@@ -104,7 +104,6 @@ export function compileAndRun(
 
     compilePromise.then((recipe) => {
       if (thisRun !== currentRun) return;
-      console.log("got new compiled recipe for ", files[main]);
       if (recipe) run(recipe, input, result);
       // TODO(seefeld): Add capturing runtime errors.
     });

--- a/packages/runner/src/builtins/compile-and-run.ts
+++ b/packages/runner/src/builtins/compile-and-run.ts
@@ -1,0 +1,112 @@
+import { type DocImpl, getDoc } from "../doc.ts";
+import { runtime } from "../runtime/index.ts";
+import { type Action, idle } from "../scheduler.ts";
+import { refer } from "merkle-reference";
+import { type ReactivityLog } from "../scheduler.ts";
+import { cancels, run, stop } from "../runner.ts";
+import {
+  BuiltInCompileAndRunParams,
+  RecipeFactory,
+} from "@commontools/builder";
+
+/**
+ * Compile a recipe/module and run it.
+ *
+ * @param files - Map of `{ filename: string }` to source code.
+ * @param main - The name of the main recipe to run.
+ * @param input - Inputs passed to the recipe once compiled.
+ *
+ * @returns { result?: any, error?: string, compiling: boolean }
+ *   - `result` is the result of the recipe, or undefined.
+ *   - `error` error that occurred during compilation or execution, or
+ *     undefined.
+ *   - `compiling` is true if the recipe is still being compiled.
+ *
+ * Note that if an error occurs during execution, both `result` and `error` can
+ * be defined. (Note: Runtime errors are not currently handled).
+ */
+export function compileAndRun(
+  inputsDoc: DocImpl<BuiltInCompileAndRunParams<any>>,
+  sendResult: (result: any) => void,
+  _addCancel: (cancel: () => void) => void,
+  cause: any,
+  parentDoc: DocImpl<any>,
+): Action {
+  const compiling = getDoc<boolean>(
+    false,
+    { compile: { compiling: cause } },
+    parentDoc.space,
+  );
+  const result = getDoc<string | undefined>(
+    undefined,
+    { compile: { result: cause } },
+    parentDoc.space,
+  );
+  const error = getDoc<string | undefined>(
+    undefined,
+    { compile: { error: cause } },
+    parentDoc.space,
+  );
+
+  sendResult({ compiling, result, error });
+
+  let currentRun = 0;
+  let previousCallHash: string | undefined = undefined;
+
+  return (log: ReactivityLog) => {
+    const thisRun = ++currentRun;
+
+    const { files, main } = inputsDoc.getAsQueryResult([], log) ?? {};
+    const input = inputsDoc.asCell().withLog(log).key("input");
+
+    const hash = refer({ files: JSON.stringify(files ?? {}), main: main ?? "" })
+      .toString();
+
+    // Return if the same request is being made again, either concurrently (same
+    // as previousCallHash) or when rehydrated from storage (same as the
+    // contents of the requestHash doc).
+    if (hash === previousCallHash) return;
+    previousCallHash = hash;
+
+    if (cancels.has(result)) stop(result);
+    result.setAtPath([], undefined, log);
+    error.setAtPath([], undefined, log);
+
+    // Undefined inputs => Undefined output, not pending
+    if (!main || !files) {
+      compiling.setAtPath([], false, log);
+      return;
+    }
+
+    // Main file not found => Error, not pending
+    if (!(main in files)) {
+      error.setAtPath([], `"${main}" not found in files`, log);
+      compiling.setAtPath([], false, log);
+      return;
+    }
+
+    // Now we're sure that we have a new file to compile
+    compiling.setAtPath([], true, log);
+
+    const compilePromise = runtime.compile(files[main]).catch(
+      (error) => {
+        if (thisRun !== currentRun) return;
+        error.setAtPath(
+          [],
+          error.message + (error.stack ? "\n" + error.stack : ""),
+          log,
+        );
+      },
+    ).finally(() => {
+      if (thisRun !== currentRun) return;
+      compiling.setAtPath([], false, log);
+    });
+
+    compilePromise.then((recipe) => {
+      if (thisRun !== currentRun) return;
+      console.log("got new compiled recipe for ", files[main]);
+      if (recipe) run(recipe, input, result);
+      // TODO(seefeld): Add capturing runtime errors.
+    });
+  };
+}

--- a/packages/runner/src/builtins/index.ts
+++ b/packages/runner/src/builtins/index.ts
@@ -4,9 +4,11 @@ import { fetchData } from "./fetch-data.ts";
 import { streamData } from "./stream-data.ts";
 import { llm } from "./llm.ts";
 import { ifElse } from "./if-else.ts";
+import { compileAndRun } from "./compile-and-run.ts";
 
 addModuleByRef("map", raw(map));
 addModuleByRef("fetchData", raw(fetchData));
 addModuleByRef("streamData", raw(streamData));
 addModuleByRef("llm", raw(llm));
 addModuleByRef("ifElse", raw(ifElse));
+addModuleByRef("compileAndRun", raw(compileAndRun));

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -74,7 +74,7 @@ export function llm(
       system: system ?? "",
       messages: (messages ?? []).map((content: string, index: number) => ({
         role: index % 2 ? "assistant" : "user",
-        content,
+        content: content?.toString() ?? "",
       })),
       stop: stop ?? "",
       maxTokens: maxTokens ?? 4096,
@@ -88,7 +88,7 @@ export function llm(
       cache: true,
     };
 
-    const hash = refer(llmParams).toString();
+    const hash = refer(JSON.stringify(llmParams)).toString();
 
     // Return if the same request is being made again, either concurrently (same
     // as previousCallHash) or when rehydrated from storage (same as the

--- a/packages/runner/src/recipe-manager.ts
+++ b/packages/runner/src/recipe-manager.ts
@@ -82,16 +82,11 @@ class RecipeManager {
 
   generateRecipeId(recipe: Recipe | Module, src?: string) {
     let id = recipeMetaMap.get(recipe as Recipe)?.get()?.id;
-    if (id) {
-      console.log("generateRecipeId: existing recipe id", id);
-      return id;
-    }
+    if (id) return id;
 
     id = src
       ? createRef({ src }, "recipe source").toString()
       : createRef(recipe, "recipe").toString();
-
-    console.log("generateRecipeId: generated id", id);
 
     return id;
   }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -448,7 +448,7 @@ function instantiateJavaScriptNode(
     const inputsCell = getDoc(inputs, { immutable: inputs }, processCell.space);
     inputsCell.freeze(); // Freezes the bindings, not aliased cells.
 
-    let previousResultCell: DocImpl<any> | undefined;
+    let previousResultDoc: DocImpl<any> | undefined;
     let previousResultRecipeAsString: string | undefined;
 
     const action: Action = (log: ReactivityLog) => {
@@ -479,24 +479,24 @@ function instantiateJavaScriptNode(
           if (previousResultRecipeAsString === resultRecipeAsString) return;
           previousResultRecipeAsString = resultRecipeAsString;
 
-          const resultCell = run(
+          const resultDoc = run(
             resultRecipe,
             undefined,
-            previousResultCell ??
+            previousResultDoc ??
               getDoc(
                 undefined,
                 { resultFor: { inputs, outputs, fn: fn.toString() } },
                 processCell.space,
               ),
           );
-          addCancel(cancels.get(resultCell));
+          addCancel(cancels.get(resultDoc));
 
-          if (!previousResultCell) {
-            previousResultCell = resultCell;
+          if (!previousResultDoc) {
+            previousResultDoc = resultDoc;
             sendValueToBinding(
               processCell,
               outputs,
-              { cell: resultCell, path: [] },
+              { cell: resultDoc, path: [] },
               log,
             );
           }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -46,6 +46,7 @@ import { isQueryResultForDereferencing } from "./query-result-proxy.ts";
 import { getCellLinkOrThrow } from "./query-result-proxy.ts";
 import { storage } from "./storage.ts";
 import { runtime } from "./runtime/index.ts";
+import { createRef } from "./doc-map.ts";
 
 export const cancels = new WeakMap<DocImpl<any>, Cancel>();
 
@@ -561,7 +562,7 @@ function instantiateRawNode(
     (result: any) =>
       sendValueToBinding(processCell, mappedOutputBindings, result),
     addCancel,
-    inputCells, // cause
+    cause,
     processCell,
   );
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -448,6 +448,7 @@ function instantiateJavaScriptNode(
     inputsCell.freeze(); // Freezes the bindings, not aliased cells.
 
     let resultCell: DocImpl<any> | undefined;
+    let previousResultRecipeAsString: string | undefined;
 
     const action: Action = (log: ReactivityLog) => {
       const argument = module.argumentSchema
@@ -471,6 +472,11 @@ function instantiateJavaScriptNode(
             undefined,
             () => result,
           );
+
+          // If nothing changed, don't rerun the recipe
+          const resultRecipeAsString = JSON.stringify(resultRecipe);
+          if (previousResultRecipeAsString === resultRecipeAsString) return;
+          previousResultRecipeAsString = resultRecipeAsString;
 
           resultCell = run(
             resultRecipe,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -543,6 +543,9 @@ function instantiateRawNode(
   const inputCells = findAllAliasedCells(mappedInputBindings, processCell);
   const outputCells = findAllAliasedCells(mappedOutputBindings, processCell);
 
+  // If no input cells were provided, we have only static inputs, so use that as cause
+  const cause = inputCells.length > 0 ? inputCells : inputBindings;
+
   const action = module.implementation(
     getDoc(
       mappedInputBindings,

--- a/packages/runner/src/runtime/local-build.ts
+++ b/packages/runner/src/runtime/local-build.ts
@@ -2,6 +2,7 @@ import ts from "typescript";
 import { RawSourceMap, SourceMapConsumer } from "source-map-js";
 import * as commonHtml from "@commontools/html";
 import * as commonBuilder from "@commontools/builder";
+import * as commonRunner from "@commontools/runner";
 import * as zod from "zod";
 import * as zodToJsonSchema from "zod-to-json-schema";
 import * as merkleReference from "merkle-reference";
@@ -206,6 +207,9 @@ export const tsToExports = async (
         return commonHtml;
       case "@commontools/builder":
         return commonBuilder;
+      case "@commontools/runner":
+        // FIXME(seefeld): Expose compiliation as builtin instead
+        return commonRunner;
       case "zod":
         return zod;
       case "merkle-reference":

--- a/packages/runner/src/runtime/local-build.ts
+++ b/packages/runner/src/runtime/local-build.ts
@@ -207,9 +207,6 @@ export const tsToExports = async (
         return commonHtml;
       case "@commontools/builder":
         return commonBuilder;
-      case "@commontools/runner":
-        // FIXME(seefeld): Expose compiliation as builtin instead
-        return commonRunner;
       case "zod":
         return zod;
       case "merkle-reference":

--- a/recipes/agentic.tsx
+++ b/recipes/agentic.tsx
@@ -124,6 +124,7 @@ const step = recipe(
       const src = actionMatch?.[1].trim();
       if (!src) return undefined;
 
+      console.log("got action", src);
       const { result, error } = compileAndRun({
         files: { "toolcall.ts": wrapCode(src) },
         main: "toolcall.ts",
@@ -144,15 +145,26 @@ const step = recipe(
     return derive(
       { messages, result, actionResult, steps },
       ({ messages, result, actionResult, steps }): { messages: string[] } => {
+        console.log(
+          "derive step",
+          messages.length,
+          !!result,
+          !!actionResult,
+          steps,
+          JSON.stringify([messages, result, actionResult]),
+        );
         if (!result) return { messages };
         if (!actionResult) return { messages: [...messages, result] };
 
         const nextMessages = [
           ...messages,
           result,
-          str`<result>${actionResult}</result>`,
+          `<result>${actionResult}</result>`,
         ];
-        if (steps <= 0) return { messages: nextMessages };
+        if (typeof steps !== "number") steps = 5 as any; // Default to 5 steps
+        if (steps <= 0) {
+          return { messages: nextMessages };
+        }
 
         return step({
           messages: nextMessages,

--- a/recipes/agentic.tsx
+++ b/recipes/agentic.tsx
@@ -30,7 +30,7 @@ const InputSchema = {
       default: 5,
     },
   },
-  required: ["task", "systemPrompt", "maxSteps"],
+  required: ["task", "maxSteps"],
 } as const satisfies JSONSchema;
 
 // Define output schema

--- a/recipes/agentic.tsx
+++ b/recipes/agentic.tsx
@@ -1,6 +1,7 @@
 import { h } from "@commontools/html";
 import {
   derive,
+  ifElse,
   JSONSchema,
   lift,
   llm,
@@ -203,8 +204,35 @@ export default recipe(
     return {
       [NAME]: str`Answering: ${task}`,
       [UI]: (
-        <div>
-          {messages.map((message) => <div>{message}</div>)}
+        <div className="p-4 space-y-6">
+          <section>
+            <h2 className="text-lg font-semibold text-gray-800 mb-2">Task</h2>
+            <p className="rounded bg-slate-100 p-3 text-sm whitespace-pre-wrap">
+              {task}
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-800 mb-2">
+              Agent Steps
+            </h2>
+            <ol className="space-y-2 list-decimal list-inside">
+              {messages.map((message) => (
+                <li className="rounded border border-gray-200 bg-white p-3 text-sm whitespace-pre-wrap">
+                  {message}
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-gray-800 mb-2">
+              Result
+            </h2>
+            <p className="rounded bg-green-100 p-3 text-sm whitespace-pre-wrap">
+              {result}
+            </p>
+          </section>
         </div>
       ),
       messages,

--- a/recipes/agentic.tsx
+++ b/recipes/agentic.tsx
@@ -51,6 +51,12 @@ import { lift, recipe } from "@commontools/builder";
 const math = lift((expression: string) => {
   return eval(expression);
 });
+
+export default recipe("action", () =>
+`;
+
+const codePostfix = `
+);
 `;
 
 const systemPrompt = `
@@ -112,8 +118,7 @@ const step = recipe(
       if (!src) return undefined; // No action found, likely final response
 
       try {
-        const code =
-          `${codePrefix}\nexport default recipe("action", () => ${src});\n`;
+        const code = codePrefix + src + codePostfix;
         const fn = await runtime.compile(code) as RecipeFactory<any, any>;
         if (!fn) return undefined;
         return str`<result>${fn(undefined)}</result>`;

--- a/recipes/agentic.tsx
+++ b/recipes/agentic.tsx
@@ -52,6 +52,7 @@ const OutputSchema = {
 
 const codePrefix = `
 import { lift, recipe, derive, handler, llm } from "@commontools/builder";
+import { Result } from '../packages/memory/interface';
 
 const math = lift((expression: string) => {
   return eval(expression);
@@ -59,15 +60,6 @@ const math = lift((expression: string) => {
 
 const webresearch = lift((query: string) => {
   const call = llm({ messages: [query], model: "gpt-4o", stream: true });
-  derive(call.pending, (pending) => {
-    console.log("pending", pending);
-  });
-  derive(call.partial, (partial) => {
-    console.log("partial", partial);
-  });
-  derive(call.result, (result) => {
-    console.log("result", result);
-  });
   return call.result;
 });
 
@@ -169,8 +161,6 @@ Please try again.
         if (!result) return { messages };
         if (!actionResult) return { messages: [...messages, result] };
 
-        console.log("actionResult", actionResult);
-
         const nextMessages = [
           ...messages,
           result,
@@ -205,9 +195,9 @@ export default recipe(
       steps: maxSteps,
     });
 
-    const answer = finalAnswer(messages);
+    const result = finalAnswer(messages);
 
-    derive(answer, (answer) => answer && console.log("Answer:", answer));
+    derive(result, (result) => result && console.log("Answer:", result));
 
     // Return the recipe
     return {
@@ -218,7 +208,7 @@ export default recipe(
         </div>
       ),
       messages,
-      result: finalAnswer(messages),
+      result,
     };
   },
 );

--- a/recipes/agentic.tsx
+++ b/recipes/agentic.tsx
@@ -1,0 +1,183 @@
+import { h } from "@commontools/html";
+import {
+  derive,
+  JSONSchema,
+  lift,
+  llm,
+  NAME,
+  recipe,
+  RecipeFactory,
+  str,
+  UI,
+} from "@commontools/builder";
+import { runtime } from "@commontools/runner";
+
+// Define input schema
+const InputSchema = {
+  type: "object",
+  properties: {
+    task: {
+      type: "string",
+      title: "Task",
+      description: "The task for the agent to complete",
+      default: "Summarize the following text: Hello world, this is a test.",
+    },
+    maxSteps: {
+      type: "number",
+      title: "Max Steps",
+      description:
+        "Maximum number of steps the agent will take before stopping",
+      default: 5,
+    },
+  },
+  required: ["task", "systemPrompt", "maxSteps"],
+} as const satisfies JSONSchema;
+
+// Define output schema
+const OutputSchema = {
+  type: "object",
+  properties: {
+    result: {
+      type: "string",
+      description: "Final result from the agent",
+    },
+  },
+  required: ["result", "steps"],
+} as const satisfies JSONSchema;
+
+const codePrefix = `
+import { lift, recipe } from "@commontools/builder";
+
+const math = lift((expression: string) => {
+  return eval(expression);
+});
+`;
+
+const systemPrompt = `
+You are a helpful assistant that can think and act.
+
+Respond with a javascript snippet that calls the tools. Avoid any control flow or other logic, just call the function. Wrap the javascript snippet in <tool>...</tool> tags.
+
+Tool responses are wrapped in <result>...</result> tags.
+
+Available tools are:
+ - math(expression: string) -> number
+
+Example:
+User:
+What is 1 + 1?
+
+Assistant:
+<tool>
+math("1 + 1")
+</tool>
+
+User:
+<result>
+2
+</result>
+
+Assistant:
+The answer is 2.
+`;
+
+/**
+ * Executes a single step of the agentic process.
+ */
+const step = recipe(
+  {
+    type: "object",
+    properties: {
+      messages: { type: "array", items: { type: "string" } },
+      steps: { type: "number" },
+    },
+    required: ["messages", "steps"],
+  } as const satisfies JSONSchema,
+  {
+    type: "object",
+    properties: { messages: { type: "array", items: { type: "string" } } },
+    required: ["messages"],
+  } as const satisfies JSONSchema,
+  ({ messages, steps }) => {
+    const { result } = llm({
+      messages,
+      system: systemPrompt,
+    });
+
+    const actionResult = derive(result, async (result) => {
+      if (!result) return undefined;
+
+      const actionMatch = result.match(/<tool>(.*?)<\/tool>/is);
+      const src = actionMatch?.[1].trim();
+      if (!src) return undefined; // No action found, likely final response
+
+      try {
+        const code =
+          `${codePrefix}\nexport default recipe("action", () => ${src});\n`;
+        const fn = await runtime.compile(code) as RecipeFactory<any, any>;
+        if (!fn) return undefined;
+        return str`<result>${fn(undefined)}</result>`;
+      } catch (error) {
+        if (error instanceof Error) {
+          return `
+Got an error:
+
+${error.message}
+${error.stack ?? ""}
+
+Please try again.
+`;
+        }
+        return `Error: ${error}`;
+      }
+    });
+
+    // We need to wrap this in a derive that checks for undefined to wait for the
+    // async calls above to finish. Ideally we do something `ifElse` like and pass
+    // `step` into it, but right now that would always eagerly run the passed in
+    // recipe anyway. We have to wait until the scheduler supports pull
+    // scheduling.
+    return derive(
+      { messages, result, actionResult, steps },
+      ({ messages, result, actionResult, steps }): { messages: string[] } => {
+        if (!result) return { messages };
+        if (!actionResult) return { messages: [...messages, result] };
+        if (steps <= 0) {
+          return { messages: [...messages, result, actionResult] };
+        }
+
+        return step({
+          messages: [...messages, result, actionResult],
+          steps: steps - 1,
+        });
+      },
+    );
+  },
+);
+
+export default recipe(
+  InputSchema,
+  OutputSchema,
+  ({ task, maxSteps }) => {
+    const { messages } = step({
+      messages: [task],
+      steps: maxSteps,
+    });
+
+    derive(messages, (messages) => {
+      if (messages?.length) {
+        console.log(messages[messages.length - 1]);
+      }
+    });
+
+    // Return the recipe
+    return {
+      [NAME]: "Agentic Tool",
+      [UI]: (
+        <div>
+          {messages.map((message) => <div>{message}</div>)}
+        </div>
+      ),
+    };
+  },
+);


### PR DESCRIPTION
Progress towards CT-355

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added a basic agentic recipe that lets an agent solve tasks step-by-step using tool calls, starting with math operations.

- **New Features**
  - New agentic recipe in `recipes/agentic.tsx` that runs multi-step tasks with a simple tool interface.
  - Supports math tool calls and step limits.
  - Exposes runner utilities to recipes and sets LLM URL for tool access.

<!-- End of auto-generated description by mrge. -->

