### PR TITLE
fix some inferred types for recipes and async lifts

### DIFF
--- a/packages/builder/src/module.ts
+++ b/packages/builder/src/module.ts
@@ -166,8 +166,8 @@ export function handler<E, T>(
 
 export const derive = <In, Out>(
   input: Opaque<In>,
-  f: (input: In) => Out,
-): OpaqueRef<Out> => lift(f)(input);
+  f: (input: In) => Out | Promise<Out>,
+): OpaqueRef<Out> => lift(f)(input) as OpaqueRef<Out>;
 
 // unsafe closures: like derive, but doesn't need any arguments
 export const compute: <T>(fn: () => T) => OpaqueRef<T> = (fn: () => any) =>

--- a/packages/builder/src/recipe.ts
+++ b/packages/builder/src/recipe.ts
@@ -51,19 +51,6 @@ import { SchemaWithoutCell } from "./schema-to-ts.ts";
  * @returns A recipe node factory that also serializes as recipe.
  */
 
-export function recipe<T>(
-  argumentSchema: string | JSONSchema,
-  fn: (input: OpaqueRef<Required<T>>) => any,
-): RecipeFactory<T, ReturnType<typeof fn>>;
-export function recipe<T, R>(
-  argumentSchema: string | JSONSchema,
-  fn: (input: OpaqueRef<Required<T>>) => Opaque<R>,
-): RecipeFactory<T, R>;
-export function recipe<T, R>(
-  argumentSchema: string | JSONSchema,
-  resultSchema: JSONSchema,
-  fn: (input: OpaqueRef<Required<T>>) => Opaque<R>,
-): RecipeFactory<T, R>;
 export function recipe<S extends JSONSchema>(
   argumentSchema: S,
   fn: (input: OpaqueRef<Required<SchemaWithoutCell<S>>>) => any,
@@ -79,6 +66,19 @@ export function recipe<S extends JSONSchema, RS extends JSONSchema>(
     input: OpaqueRef<Required<SchemaWithoutCell<S>>>,
   ) => Opaque<SchemaWithoutCell<RS>>,
 ): RecipeFactory<SchemaWithoutCell<S>, SchemaWithoutCell<RS>>;
+export function recipe<T>(
+  argumentSchema: string | JSONSchema,
+  fn: (input: OpaqueRef<Required<T>>) => any,
+): RecipeFactory<T, ReturnType<typeof fn>>;
+export function recipe<T, R>(
+  argumentSchema: string | JSONSchema,
+  fn: (input: OpaqueRef<Required<T>>) => Opaque<R>,
+): RecipeFactory<T, R>;
+export function recipe<T, R>(
+  argumentSchema: string | JSONSchema,
+  resultSchema: JSONSchema,
+  fn: (input: OpaqueRef<Required<T>>) => Opaque<R>,
+): RecipeFactory<T, R>;
 export function recipe<T, R>(
   argumentSchema: string | JSONSchema,
   resultSchema:

--- a/packages/builder/test/schema-to-ts.test.ts
+++ b/packages/builder/test/schema-to-ts.test.ts
@@ -456,23 +456,13 @@ describe("Schema-to-TS Type Conversion", () => {
     // Verify that the recipe function parameter matches our expected input type
     expectType<ExpectedInput, InferredInput>();
 
-    // Test the actual nested OpaqueRef structure that recipe creates
-    type DeepOpaqueOutput = OpaqueRef<{
-      result: OpaqueRef<string>;
-      processedCount: OpaqueRef<number>;
-      status: {
-        success: OpaqueRef<boolean>;
-      };
-    }>;
+    // The expected output is the output schema wrapped in a single OpaqueRef.
+    type DeepOpaqueOutput = OpaqueRef<Schema<typeof outputSchema>>;
     expectType<DeepOpaqueOutput, InferredOutput>();
 
     // Uncomment for debugging - shows what the actual structure is
     // This should help us see what the real type looks like
     // type Debug = ReturnType<typeof processRecipe>;
-
-    // Since recipe returns an OpaqueRef rather than the actual value,
-    // we can't directly test the output type here.
-    // Instead, we verify that the Schema type correctly maps the JSONSchema
   });
 
   // Runtime tests to verify the Schema type works with actual data


### PR DESCRIPTION
## Summary by mrge
Fixed type inference for recipes and async lifts to ensure correct types are returned, especially for async functions.

- **Bug Fixes**
  - Updated type signatures in recipe and derive to better handle async and nested types.
  - Simplified test type checks to reuse declared output structure.
