### PR TITLE
feat: Introduce Page#applyConsoleFormatter to stringify objects in CI/seeder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ artifact
 _deno.lock
 
 !/packages/jumble/integration/cache
+packages/seeder/results
 .claude-prompt.tmp
 .pr-desc.tmp
 dist/

--- a/packages/integration/console.ts
+++ b/packages/integration/console.ts
@@ -1,0 +1,24 @@
+// Methods to stub out for Page#applyConsoleFormatter.
+// From `@commontools/runner` console patch
+export enum ConsoleMethod {
+  Assert = "assert",
+  Clear = "clear",
+  Count = "count",
+  CountReset = "countReset",
+  Debug = "debug",
+  Dir = "dir",
+  DirXml = "dirxml",
+  Error = "error",
+  Group = "group",
+  GroupCollapsed = "groupCollapsed",
+  GroupEnd = "groupEnd",
+  Info = "info",
+  Log = "log",
+  Table = "table",
+  Time = "time",
+  TimeEnd = "timeEnd",
+  TimeLog = "timeLog",
+  TimeStamp = "timeStamp",
+  Trace = "trace",
+  Warn = "warn",
+}

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -15,6 +15,7 @@ import { sleep } from "@commontools/utils/sleep";
 import { Mutable } from "@commontools/utils/types";
 import * as path from "@std/path";
 import { ensureDirSync } from "@std/fs";
+import { ConsoleMethod } from "./console.ts";
 
 // To handle `console` events from `Page`, logging to outer context:
 //
@@ -78,6 +79,48 @@ export class Page extends EventTarget {
   override dispatchEvent(event: Event): boolean {
     this.checkIsOk();
     return this.page!.dispatchEvent(event);
+  }
+
+  // Extended method: Rewrites the contents' `console.*` methods to stringify
+  // objects. The astral console handler only provides a concatenated
+  // string of all console arguments, with objects represented as `"undefined"`.
+  // Calling this method after navigating to a fresh document will properly
+  // stringify objects in `ConsoleEvent#detail.text`.
+  async applyConsoleFormatter() {
+    this.checkIsOk();
+
+    const trueConsoleKey: string = "__common_integration_console";
+    const methods: string[] = Object.values(ConsoleMethod);
+
+    await this.evaluate((trueConsoleKey: string, methods: string[]) => {
+      // @ts-ignore: this code is stringified and sent to browser context
+      // If console has already been stubbed for this document, abort.
+      if (globalThis[trueConsoleKey]) {
+        return;
+      }
+      const trueConsole = globalThis.console;
+      const newConsole = Object.create(null);
+      for (const method of methods) {
+        newConsole[method] = (...args: any[]) => {
+          const formatted = args.map((value) => {
+            if (value && typeof value === "object") {
+              try {
+                return JSON.stringify(value);
+              } catch (_e) {
+                // satisfy typescript's empty block
+              }
+            }
+            return value;
+          });
+          // @ts-ignore: this code is stringified and sent to browser context
+          return trueConsole[method].apply(trueConsole, formatted);
+        };
+      }
+      // @ts-ignore: this code is stringified and sent to browser context
+      globalThis[trueConsoleKey] = trueConsole;
+      // @ts-ignore: this code is stringified and sent to browser context
+      globalThis.console = newConsole;
+    }, { args: [trueConsoleKey, methods] });
   }
 
   // Extended method: Takes a screenshot, storing the result at `filename`.

--- a/packages/jumble/integration/basic-flow.test.ts
+++ b/packages/jumble/integration/basic-flow.test.ts
@@ -70,6 +70,7 @@ Deno.test({
           });
 
           await page.goto(FRONTEND_URL);
+          await page.applyConsoleFormatter();
 
           console.log(`Opened website at ${FRONTEND_URL}`);
         },
@@ -104,6 +105,7 @@ Deno.test({
           await page.goto(
             `${FRONTEND_URL}${testCharm.name}/${testCharm.charmId}`,
           );
+          await page.applyConsoleFormatter();
           if (TAKE_SNAPSHOTS) {
             await page.snapshot("Waiting for charm to render", SNAPSHOTS_DIR);
           }
@@ -129,6 +131,7 @@ Deno.test({
           await page.goto(
             `${FRONTEND_URL}${testCharm.name}/${testCharm.charmId}`,
           );
+          await page.applyConsoleFormatter();
 
           // Wait for initial render
           await page.waitForSelectorWithText(

--- a/packages/seeder/verifier.ts
+++ b/packages/seeder/verifier.ts
@@ -43,6 +43,7 @@ export class Verifier {
   ): Promise<CharmResult> {
     // FIXME(ja): can we navigate without causing a page reload?
     await this.page.goto(`${this.apiUrl}/${name!}/${id}`);
+    await this.page.applyConsoleFormatter();
     await sleep(1000);
     await addErrorListeners(this.page);
     await login(this.page);


### PR DESCRIPTION
Tempting to add this automatically to e.g. `.goto(url)`, but there are many reasons the document can reload, so lets make it explicit.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added Page#applyConsoleFormatter to rewrite console methods and ensure objects are stringified in logs during CI and seeder runs.

- **New Features**
  - Added applyConsoleFormatter method to Page for better console output.
  - Updated tests and seeder to use the new formatter.

<!-- End of auto-generated description by mrge. -->

