### PR TITLE
Consolidate JSONValue classes

### DIFF
--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -43,6 +43,7 @@ export {
   isRecipe,
   isStatic,
   isStreamAlias,
+  type JSONObject,
   type JSONSchema,
   type JSONSchemaMutable,
   type JSONValue,

--- a/packages/memory/fact.ts
+++ b/packages/memory/fact.ts
@@ -1,10 +1,10 @@
+import { JSONValue } from "@commontools/builder";
 import {
   Assertion,
   Entity,
   Fact,
   FactSelection,
   Invariant,
-  JSONValue,
   Reference,
   Retraction,
   Revision,

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -1,5 +1,5 @@
 import { refer, type Reference } from "merkle-reference";
-import { JSONSchema, JSONValue } from "../builder/src/types.ts";
+import { JSONSchema, JSONValue } from "@commontools/builder";
 
 export type { Reference };
 

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -1,5 +1,5 @@
 import { refer, type Reference } from "merkle-reference";
-import { JSONSchema } from "../builder/src/types.ts";
+import { JSONSchema, JSONValue } from "../builder/src/types.ts";
 
 export type { Reference };
 
@@ -829,18 +829,6 @@ export type Unit = NonNullable<unknown>;
  * Generic type used to annotate underlying type with a context of the replica.
  */
 export type In<T> = { [For: MemorySpace]: T };
-
-export type JSONValue =
-  | null
-  | boolean
-  | number
-  | string
-  | JSONObject
-  | JSONArray;
-
-export interface JSONObject extends Record<string, JSONValue> {}
-
-export interface JSONArray extends ArrayLike<JSONValue> {}
 
 export type AsyncResult<T extends Unit = Unit, E extends Error = Error> =
   Promise<Result<T, E>>;

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -28,10 +28,9 @@ import {
   OptJSONValue,
   ValueEntry,
 } from "./traverse.ts";
-import { JSONSchema, JSONValue } from "@commontools/builder";
+import { JSONObject, JSONSchema, JSONValue } from "@commontools/builder";
 import { ContextualFlowControl } from "@commontools/runner";
 import { TheAuthorizationError } from "./error.ts";
-import { JSONObject } from "../builder/src/types.ts";
 export * from "./interface.ts";
 
 export type FullFactAddress = FactAddress & { cause: Cause; since: number };

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -3,8 +3,6 @@ import type {
   Cause,
   Entity,
   FactSelection,
-  JSONObject,
-  JSONValue,
   MemorySpace,
   SchemaContext,
   SchemaQuery,
@@ -30,9 +28,10 @@ import {
   OptJSONValue,
   ValueEntry,
 } from "./traverse.ts";
-import { JSONSchema } from "../builder/src/index.ts";
-import { ContextualFlowControl } from "../runner/src/index.ts";
+import { JSONSchema, JSONValue } from "@commontools/builder";
+import { ContextualFlowControl } from "@commontools/runner";
 import { TheAuthorizationError } from "./error.ts";
+import { JSONObject } from "../builder/src/types.ts";
 export * from "./interface.ts";
 
 export type FullFactAddress = FactAddress & { cause: Cause; since: number };

--- a/packages/memory/space.ts
+++ b/packages/memory/space.ts
@@ -13,7 +13,6 @@ import type {
   Assertion,
   AsyncResult,
   AuthorizationError,
-  AwaitResult,
   Cause,
   Claim,
   Commit,
@@ -23,7 +22,6 @@ import type {
   DIDKey,
   Entity,
   Fact,
-  JSONValue,
   MemorySpace,
   Query,
   QueryError,
@@ -42,6 +40,7 @@ import type {
 } from "./interface.ts";
 import * as Error from "./error.ts";
 import { selectSchema } from "./space-schema.ts";
+import { JSONValue } from "@commontools/builder";
 export * from "./interface.ts";
 
 export const PREPARE = `

--- a/packages/memory/traverse.ts
+++ b/packages/memory/traverse.ts
@@ -1,9 +1,8 @@
 // This is the same structure as in space.ts, but there's also a different
 // Session interface in memory/interface, so the space version isn't exported.
 
-import { isAlias, JSONValue } from "@commontools/builder";
+import { isAlias, JSONObject, JSONValue } from "@commontools/builder";
 import { isObject } from "@commontools/utils/types";
-import { JSONObject } from "../builder/src/types.ts";
 
 export class CycleTracker<K> {
   private partial: Set<K>;

--- a/packages/memory/traverse.ts
+++ b/packages/memory/traverse.ts
@@ -1,9 +1,9 @@
 // This is the same structure as in space.ts, but there's also a different
 // Session interface in memory/interface, so the space version isn't exported.
 
-import { isAlias } from "../builder/src/index.ts";
-import { JSONObject, JSONValue } from "./consumer.ts";
+import { isAlias, JSONValue } from "@commontools/builder";
 import { isObject } from "@commontools/utils/types";
+import { JSONObject } from "../builder/src/types.ts";
 
 export class CycleTracker<K> {
   private partial: Set<K>;

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -5,7 +5,6 @@ import type {
   ConnectionError,
   Entity,
   Fact,
-  JSONValue,
   MemorySpace,
   QueryError,
   Result,
@@ -38,7 +37,7 @@ export * from "@commontools/memory/interface";
 import * as Codec from "@commontools/memory/codec";
 import { Channel, RawCommand } from "./inspector.ts";
 import { isBrowser } from "@commontools/utils/env";
-import { deepEqual } from "@commontools/builder";
+import { deepEqual, JSONValue } from "@commontools/builder";
 
 export type { Result, Unit };
 export interface Selector<Key> extends Iterable<Key> {


### PR DESCRIPTION
The two versions of JSONValue had been made similar, but I wanted to just have one version of this type.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Replaced duplicate JSONValue type definitions with a single shared version from @commontools/builder to simplify the codebase.

<!-- End of auto-generated description by mrge. -->

