### PR TITLE
feat: Compile multifile TypeScript projects as recipes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,6 @@
 {
   "workspace": [
+    "./packages/assets",
     "./packages/background-charm-service",
     "./packages/builder",
     "./packages/charm",
@@ -10,6 +11,7 @@
     "./packages/identity",
     "./packages/iframe-sandbox",
     "./packages/integration",
+    "./packages/js-runtime",
     "./packages/jumble",
     "./packages/llm",
     "./packages/memory",
@@ -49,6 +51,7 @@
   ],
   "lint": {
     "exclude": [
+      "./packages/assets/static",
       "./packages/deno-vite-plugin"
     ],
     "rules": {

--- a/deno.lock
+++ b/deno.lock
@@ -52,6 +52,7 @@
     "npm:@ai-sdk/openai@^1.1.9": "1.3.20_zod@3.24.3",
     "npm:@ai-sdk/openai@^1.3.20": "1.3.20_zod@3.24.3",
     "npm:@ai-sdk/xai@^1.2.15": "1.2.15_zod@3.24.3",
+    "npm:@ampproject/remapping@*": "2.3.0",
     "npm:@arizeai/openinference-semantic-conventions@1": "1.1.0",
     "npm:@arizeai/openinference-semantic-conventions@^1.1.0": "1.1.0",
     "npm:@arizeai/openinference-vercel@^2.0.1": "2.0.3_@opentelemetry+api@1.9.0",
@@ -141,7 +142,9 @@
     "npm:slate-history@0.100": "0.100.0_slate@0.112.0",
     "npm:slate-react@0.112": "0.112.1_react@18.3.1_react-dom@18.3.1__react@18.3.1_slate@0.112.0_slate-dom@0.112.2__slate@0.112.0",
     "npm:slate@0.112": "0.112.0",
+    "npm:source-map-js@*": "1.2.1",
     "npm:source-map-js@^1.2.1": "1.2.1",
+    "npm:source-map@*": "0.7.4",
     "npm:stoker@^1.4.2": "1.4.2_@asteasolutions+zod-to-openapi@7.3.0__zod@3.24.3_@hono+zod-openapi@0.18.4__hono@4.7.7__zod@3.24.3_hono@4.7.7_openapi3-ts@4.4.0_zod@3.24.3",
     "npm:tailwindcss@^4.0.6": "4.1.4",
     "npm:three@0.173": "0.173.0",
@@ -6281,6 +6284,11 @@
         "dependencies": [
           "npm:@noble/ed25519@^2.2.3",
           "npm:@scure/bip39@^1.5.4"
+        ]
+      },
+      "packages/js-runtime": {
+        "dependencies": [
+          "npm:source-map-js@*"
         ]
       },
       "packages/jumble": {

--- a/packages/assets/deno-web-test.config.ts
+++ b/packages/assets/deno-web-test.config.ts
@@ -1,0 +1,3 @@
+export default {
+  include: ["static/es2023.d.ts"],
+};

--- a/packages/assets/deno.json
+++ b/packages/assets/deno.json
@@ -1,0 +1,17 @@
+{
+  "name": "@commontools/assets",
+  "tasks": {
+    "test": {
+      "dependencies": [
+        "deno-test",
+        "browser-test"
+      ]
+    },
+    "deno-test": "deno test --allow-read",
+    "browser-test": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts test/*.test.ts",
+    "compile-type-lib": "./scripts/compile-type-lib.ts ../../../TypeScript/src/lib/ static/es2023.d.ts"
+  },
+  "exports": {
+    ".": "./index.ts"
+  }
+}

--- a/packages/assets/index.ts
+++ b/packages/assets/index.ts
@@ -1,0 +1,61 @@
+import { isBrowser, isDeno } from "@commontools/utils/env";
+import { decode } from "@commontools/utils/encoding";
+// Use `posix` path utils specifically so that the path lib
+// does not check `Deno?.build.os` for Windows, which will
+// be true in the `deno-web-test` environment as `Deno.test`
+// is shimmed, causing a fail to access `os` from `undefined`.
+import { toFileUrl } from "@std/path/posix/to-file-url";
+import { join } from "@std/path/posix/join";
+
+export const assets = [
+  "es2023.d.ts",
+];
+
+const DEFAULT_BASE: URL = (() => {
+  if (isBrowser()) {
+    return new URL(globalThis.location.href);
+  } else if (isDeno()) {
+    if (!import.meta.dirname) {
+      throw new Error("Must be executed from local file.");
+    }
+    return toFileUrl(join(import.meta.dirname, "static"));
+  }
+  throw new Error("Unsupported environment.");
+})();
+
+export interface GetAssetConfig {
+  overrideBase?: string;
+}
+
+export async function getAsset(
+  assetName: string,
+  config?: GetAssetConfig,
+): Promise<Uint8Array> {
+  if (!assets.includes(assetName)) {
+    throw new Error(`No static asset "${assetName}" found.`);
+  }
+  const url = getAssetUrl(assetName, config);
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Could not retrieve "${assetName}".`);
+  }
+  return new Uint8Array(await res.arrayBuffer());
+}
+
+export async function getAssetText(
+  assetName: string,
+  config?: GetAssetConfig,
+): Promise<string> {
+  return decode(await getAsset(assetName, config));
+}
+
+export function getAssetUrl(assetName: string, config?: GetAssetConfig): URL {
+  if (!assets.includes(assetName)) {
+    throw new Error(`No static asset "${assetName}" found.`);
+  }
+  const url = config?.overrideBase
+    ? new URL(config.overrideBase)
+    : new URL(DEFAULT_BASE);
+  url.pathname = `${url.pathname}/${assetName}`;
+  return url;
+}

--- a/packages/assets/scripts/compile-type-lib.ts
+++ b/packages/assets/scripts/compile-type-lib.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write
+import * as path from "@std/path";
+
+/**
+ * We compile TypeScript in Deno/browser environments.
+ * Typescript relies heavily on Node/FS during compilation,
+ * looking for its type libraries on disk e.g. `es2023.d.ts`, `dom.d.ts`.
+ *
+ * This script "compiles" a `.d.ts` file, resolving its imports,
+ * and creates a single `.d.ts` output file for use in browser and Deno environments.
+ */
+
+function help() {
+  const message = `
+compile-type-lib /path/to/typescript/src/lib/ lib.d.ts
+`;
+  Deno.stdout.writeSync(new TextEncoder().encode(message));
+}
+
+interface CompileOptions {
+  // Path to a typescript repo's library of .d.ts files.
+  libDir: string;
+  // Target type lib e.g. "es2023"
+  target: string;
+  // File to output the compiled .d.ts file
+  outFile: string;
+}
+
+function parseArgs(libDir?: string, outFile?: string): CompileOptions {
+  if (
+    typeof libDir !== "string" || libDir === "" ||
+    typeof outFile !== "string" || outFile === ""
+  ) {
+    help();
+    Deno.exit(1);
+  }
+  return {
+    target: "es2023", // Target used in js-runtime
+    libDir,
+    outFile,
+  };
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const EXTRACTOR = /\/\/\/ \<reference lib="([a-z0-9\.\-]+)"/;
+
+async function compile(
+  libDir: string,
+  name: string,
+  included: string[],
+): Promise<string> {
+  const filePath = path.join(libDir, `${name}.d.ts`);
+  const src = decoder.decode(await Deno.readFile(filePath));
+  let out = "";
+  for (const line of src.split("\r\n")) {
+    const result = line.match(EXTRACTOR);
+    if (result && result[1]) {
+      const dependent = result[1];
+      if (included.includes(dependent)) {
+        continue;
+      }
+      out += await compile(libDir, dependent, included);
+      included.push(dependent);
+    } else {
+      out += `${line}\r\n`;
+    }
+  }
+  return out;
+}
+
+async function compileMain(options: CompileOptions) {
+  const { target, libDir, outFile } = options;
+
+  const out = await compile(libDir, target, []);
+  await Deno.writeFile(outFile, encoder.encode(out));
+}
+compileMain(parseArgs(Deno.args[0], Deno.args[1]));

--- a/packages/assets/static/es2023.d.ts
+++ b/packages/assets/static/es2023.d.ts
@@ -1,0 +1,10530 @@
+/**
+ * The decorator context types provided to class element decorators.
+ */
+type ClassMemberDecoratorContext =
+    | ClassMethodDecoratorContext
+    | ClassGetterDecoratorContext
+    | ClassSetterDecoratorContext
+    | ClassFieldDecoratorContext
+    | ClassAccessorDecoratorContext;
+
+/**
+ * The decorator context types provided to any decorator.
+ */
+type DecoratorContext =
+    | ClassDecoratorContext
+    | ClassMemberDecoratorContext;
+
+type DecoratorMetadataObject = Record<PropertyKey, unknown> & object;
+
+type DecoratorMetadata = typeof globalThis extends { Symbol: { readonly metadata: symbol; }; } ? DecoratorMetadataObject : DecoratorMetadataObject | undefined;
+
+/**
+ * Context provided to a class decorator.
+ * @template Class The type of the decorated class associated with this context.
+ */
+interface ClassDecoratorContext<
+    Class extends abstract new (...args: any) => any = abstract new (...args: any) => any,
+> {
+    /** The kind of element that was decorated. */
+    readonly kind: "class";
+
+    /** The name of the decorated class. */
+    readonly name: string | undefined;
+
+    /**
+     * Adds a callback to be invoked after the class definition has been finalized.
+     *
+     * @example
+     * ```ts
+     * function customElement(name: string): ClassDecoratorFunction {
+     *   return (target, context) => {
+     *     context.addInitializer(function () {
+     *       customElements.define(name, this);
+     *     });
+     *   }
+     * }
+     *
+     * @customElement("my-element")
+     * class MyElement {}
+     * ```
+     */
+    addInitializer(initializer: (this: Class) => void): void;
+
+    readonly metadata: DecoratorMetadata;
+}
+
+/**
+ * Context provided to a class method decorator.
+ * @template This The type on which the class element will be defined. For a static class element, this will be
+ * the type of the constructor. For a non-static class element, this will be the type of the instance.
+ * @template Value The type of the decorated class method.
+ */
+interface ClassMethodDecoratorContext<
+    This = unknown,
+    Value extends (this: This, ...args: any) => any = (this: This, ...args: any) => any,
+> {
+    /** The kind of class element that was decorated. */
+    readonly kind: "method";
+
+    /** The name of the decorated class element. */
+    readonly name: string | symbol;
+
+    /** A value indicating whether the class element is a static (`true`) or instance (`false`) element. */
+    readonly static: boolean;
+
+    /** A value indicating whether the class element has a private name. */
+    readonly private: boolean;
+
+    /** An object that can be used to access the current value of the class element at runtime. */
+    readonly access: {
+        /**
+         * Determines whether an object has a property with the same name as the decorated element.
+         */
+        has(object: This): boolean;
+        /**
+         * Gets the current value of the method from the provided object.
+         *
+         * @example
+         * let fn = context.access.get(instance);
+         */
+        get(object: This): Value;
+    };
+
+    /**
+     * Adds a callback to be invoked either after static methods are defined but before
+     * static initializers are run (when decorating a `static` element), or before instance
+     * initializers are run (when decorating a non-`static` element).
+     *
+     * @example
+     * ```ts
+     * const bound: ClassMethodDecoratorFunction = (value, context) {
+     *   if (context.private) throw new TypeError("Not supported on private methods.");
+     *   context.addInitializer(function () {
+     *     this[context.name] = this[context.name].bind(this);
+     *   });
+     * }
+     *
+     * class C {
+     *   message = "Hello";
+     *
+     *   @bound
+     *   m() {
+     *     console.log(this.message);
+     *   }
+     * }
+     * ```
+     */
+    addInitializer(initializer: (this: This) => void): void;
+
+    readonly metadata: DecoratorMetadata;
+}
+
+/**
+ * Context provided to a class getter decorator.
+ * @template This The type on which the class element will be defined. For a static class element, this will be
+ * the type of the constructor. For a non-static class element, this will be the type of the instance.
+ * @template Value The property type of the decorated class getter.
+ */
+interface ClassGetterDecoratorContext<
+    This = unknown,
+    Value = unknown,
+> {
+    /** The kind of class element that was decorated. */
+    readonly kind: "getter";
+
+    /** The name of the decorated class element. */
+    readonly name: string | symbol;
+
+    /** A value indicating whether the class element is a static (`true`) or instance (`false`) element. */
+    readonly static: boolean;
+
+    /** A value indicating whether the class element has a private name. */
+    readonly private: boolean;
+
+    /** An object that can be used to access the current value of the class element at runtime. */
+    readonly access: {
+        /**
+         * Determines whether an object has a property with the same name as the decorated element.
+         */
+        has(object: This): boolean;
+        /**
+         * Invokes the getter on the provided object.
+         *
+         * @example
+         * let value = context.access.get(instance);
+         */
+        get(object: This): Value;
+    };
+
+    /**
+     * Adds a callback to be invoked either after static methods are defined but before
+     * static initializers are run (when decorating a `static` element), or before instance
+     * initializers are run (when decorating a non-`static` element).
+     */
+    addInitializer(initializer: (this: This) => void): void;
+
+    readonly metadata: DecoratorMetadata;
+}
+
+/**
+ * Context provided to a class setter decorator.
+ * @template This The type on which the class element will be defined. For a static class element, this will be
+ * the type of the constructor. For a non-static class element, this will be the type of the instance.
+ * @template Value The type of the decorated class setter.
+ */
+interface ClassSetterDecoratorContext<
+    This = unknown,
+    Value = unknown,
+> {
+    /** The kind of class element that was decorated. */
+    readonly kind: "setter";
+
+    /** The name of the decorated class element. */
+    readonly name: string | symbol;
+
+    /** A value indicating whether the class element is a static (`true`) or instance (`false`) element. */
+    readonly static: boolean;
+
+    /** A value indicating whether the class element has a private name. */
+    readonly private: boolean;
+
+    /** An object that can be used to access the current value of the class element at runtime. */
+    readonly access: {
+        /**
+         * Determines whether an object has a property with the same name as the decorated element.
+         */
+        has(object: This): boolean;
+        /**
+         * Invokes the setter on the provided object.
+         *
+         * @example
+         * context.access.set(instance, value);
+         */
+        set(object: This, value: Value): void;
+    };
+
+    /**
+     * Adds a callback to be invoked either after static methods are defined but before
+     * static initializers are run (when decorating a `static` element), or before instance
+     * initializers are run (when decorating a non-`static` element).
+     */
+    addInitializer(initializer: (this: This) => void): void;
+
+    readonly metadata: DecoratorMetadata;
+}
+
+/**
+ * Context provided to a class `accessor` field decorator.
+ * @template This The type on which the class element will be defined. For a static class element, this will be
+ * the type of the constructor. For a non-static class element, this will be the type of the instance.
+ * @template Value The type of decorated class field.
+ */
+interface ClassAccessorDecoratorContext<
+    This = unknown,
+    Value = unknown,
+> {
+    /** The kind of class element that was decorated. */
+    readonly kind: "accessor";
+
+    /** The name of the decorated class element. */
+    readonly name: string | symbol;
+
+    /** A value indicating whether the class element is a static (`true`) or instance (`false`) element. */
+    readonly static: boolean;
+
+    /** A value indicating whether the class element has a private name. */
+    readonly private: boolean;
+
+    /** An object that can be used to access the current value of the class element at runtime. */
+    readonly access: {
+        /**
+         * Determines whether an object has a property with the same name as the decorated element.
+         */
+        has(object: This): boolean;
+
+        /**
+         * Invokes the getter on the provided object.
+         *
+         * @example
+         * let value = context.access.get(instance);
+         */
+        get(object: This): Value;
+
+        /**
+         * Invokes the setter on the provided object.
+         *
+         * @example
+         * context.access.set(instance, value);
+         */
+        set(object: This, value: Value): void;
+    };
+
+    /**
+     * Adds a callback to be invoked immediately after the auto `accessor` being
+     * decorated is initialized (regardless if the `accessor` is `static` or not).
+     */
+    addInitializer(initializer: (this: This) => void): void;
+
+    readonly metadata: DecoratorMetadata;
+}
+
+/**
+ * Describes the target provided to class `accessor` field decorators.
+ * @template This The `this` type to which the target applies.
+ * @template Value The property type for the class `accessor` field.
+ */
+interface ClassAccessorDecoratorTarget<This, Value> {
+    /**
+     * Invokes the getter that was defined prior to decorator application.
+     *
+     * @example
+     * let value = target.get.call(instance);
+     */
+    get(this: This): Value;
+
+    /**
+     * Invokes the setter that was defined prior to decorator application.
+     *
+     * @example
+     * target.set.call(instance, value);
+     */
+    set(this: This, value: Value): void;
+}
+
+/**
+ * Describes the allowed return value from a class `accessor` field decorator.
+ * @template This The `this` type to which the target applies.
+ * @template Value The property type for the class `accessor` field.
+ */
+interface ClassAccessorDecoratorResult<This, Value> {
+    /**
+     * An optional replacement getter function. If not provided, the existing getter function is used instead.
+     */
+    get?(this: This): Value;
+
+    /**
+     * An optional replacement setter function. If not provided, the existing setter function is used instead.
+     */
+    set?(this: This, value: Value): void;
+
+    /**
+     * An optional initializer mutator that is invoked when the underlying field initializer is evaluated.
+     * @param value The incoming initializer value.
+     * @returns The replacement initializer value.
+     */
+    init?(this: This, value: Value): Value;
+}
+
+/**
+ * Context provided to a class field decorator.
+ * @template This The type on which the class element will be defined. For a static class element, this will be
+ * the type of the constructor. For a non-static class element, this will be the type of the instance.
+ * @template Value The type of the decorated class field.
+ */
+interface ClassFieldDecoratorContext<
+    This = unknown,
+    Value = unknown,
+> {
+    /** The kind of class element that was decorated. */
+    readonly kind: "field";
+
+    /** The name of the decorated class element. */
+    readonly name: string | symbol;
+
+    /** A value indicating whether the class element is a static (`true`) or instance (`false`) element. */
+    readonly static: boolean;
+
+    /** A value indicating whether the class element has a private name. */
+    readonly private: boolean;
+
+    /** An object that can be used to access the current value of the class element at runtime. */
+    readonly access: {
+        /**
+         * Determines whether an object has a property with the same name as the decorated element.
+         */
+        has(object: This): boolean;
+
+        /**
+         * Gets the value of the field on the provided object.
+         */
+        get(object: This): Value;
+
+        /**
+         * Sets the value of the field on the provided object.
+         */
+        set(object: This, value: Value): void;
+    };
+
+    /**
+     * Adds a callback to be invoked immediately after the field being decorated
+     * is initialized (regardless if the field is `static` or not).
+     */
+    addInitializer(initializer: (this: This) => void): void;
+
+    readonly metadata: DecoratorMetadata;
+}
+
+declare type ClassDecorator = <TFunction extends Function>(target: TFunction) => TFunction | void;
+declare type PropertyDecorator = (target: Object, propertyKey: string | symbol) => void;
+declare type MethodDecorator = <T>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T> | void;
+declare type ParameterDecorator = (target: Object, propertyKey: string | symbol | undefined, parameterIndex: number) => void;
+
+
+/////////////////////////////
+/// ECMAScript APIs
+/////////////////////////////
+
+declare var NaN: number;
+declare var Infinity: number;
+
+/**
+ * Evaluates JavaScript code and executes it.
+ * @param x A String value that contains valid JavaScript code.
+ */
+declare function eval(x: string): any;
+
+/**
+ * Converts a string to an integer.
+ * @param string A string to convert into a number.
+ * @param radix A value between 2 and 36 that specifies the base of the number in `string`.
+ * If this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.
+ * All other strings are considered decimal.
+ */
+declare function parseInt(string: string, radix?: number): number;
+
+/**
+ * Converts a string to a floating-point number.
+ * @param string A string that contains a floating-point number.
+ */
+declare function parseFloat(string: string): number;
+
+/**
+ * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a number).
+ * @param number A numeric value.
+ */
+declare function isNaN(number: number): boolean;
+
+/**
+ * Determines whether a supplied number is finite.
+ * @param number Any numeric value.
+ */
+declare function isFinite(number: number): boolean;
+
+/**
+ * Gets the unencoded version of an encoded Uniform Resource Identifier (URI).
+ * @param encodedURI A value representing an encoded URI.
+ */
+declare function decodeURI(encodedURI: string): string;
+
+/**
+ * Gets the unencoded version of an encoded component of a Uniform Resource Identifier (URI).
+ * @param encodedURIComponent A value representing an encoded URI component.
+ */
+declare function decodeURIComponent(encodedURIComponent: string): string;
+
+/**
+ * Encodes a text string as a valid Uniform Resource Identifier (URI)
+ * @param uri A value representing an unencoded URI.
+ */
+declare function encodeURI(uri: string): string;
+
+/**
+ * Encodes a text string as a valid component of a Uniform Resource Identifier (URI).
+ * @param uriComponent A value representing an unencoded URI component.
+ */
+declare function encodeURIComponent(uriComponent: string | number | boolean): string;
+
+/**
+ * Computes a new string in which certain characters have been replaced by a hexadecimal escape sequence.
+ * @deprecated A legacy feature for browser compatibility
+ * @param string A string value
+ */
+declare function escape(string: string): string;
+
+/**
+ * Computes a new string in which hexadecimal escape sequences are replaced with the character that it represents.
+ * @deprecated A legacy feature for browser compatibility
+ * @param string A string value
+ */
+declare function unescape(string: string): string;
+
+interface Symbol {
+    /** Returns a string representation of an object. */
+    toString(): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): symbol;
+}
+
+declare type PropertyKey = string | number | symbol;
+
+interface PropertyDescriptor {
+    configurable?: boolean;
+    enumerable?: boolean;
+    value?: any;
+    writable?: boolean;
+    get?(): any;
+    set?(v: any): void;
+}
+
+interface PropertyDescriptorMap {
+    [key: PropertyKey]: PropertyDescriptor;
+}
+
+interface Object {
+    /** The initial value of Object.prototype.constructor is the standard built-in Object constructor. */
+    constructor: Function;
+
+    /** Returns a string representation of an object. */
+    toString(): string;
+
+    /** Returns a date converted to a string using the current locale. */
+    toLocaleString(): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): Object;
+
+    /**
+     * Determines whether an object has a property with the specified name.
+     * @param v A property name.
+     */
+    hasOwnProperty(v: PropertyKey): boolean;
+
+    /**
+     * Determines whether an object exists in another object's prototype chain.
+     * @param v Another object whose prototype chain is to be checked.
+     */
+    isPrototypeOf(v: Object): boolean;
+
+    /**
+     * Determines whether a specified property is enumerable.
+     * @param v A property name.
+     */
+    propertyIsEnumerable(v: PropertyKey): boolean;
+}
+
+interface ObjectConstructor {
+    new (value?: any): Object;
+    (): any;
+    (value: any): any;
+
+    /** A reference to the prototype for a class of objects. */
+    readonly prototype: Object;
+
+    /**
+     * Returns the prototype of an object.
+     * @param o The object that references the prototype.
+     */
+    getPrototypeOf(o: any): any;
+
+    /**
+     * Gets the own property descriptor of the specified object.
+     * An own property descriptor is one that is defined directly on the object and is not inherited from the object's prototype.
+     * @param o Object that contains the property.
+     * @param p Name of the property.
+     */
+    getOwnPropertyDescriptor(o: any, p: PropertyKey): PropertyDescriptor | undefined;
+
+    /**
+     * Returns the names of the own properties of an object. The own properties of an object are those that are defined directly
+     * on that object, and are not inherited from the object's prototype. The properties of an object include both fields (objects) and functions.
+     * @param o Object that contains the own properties.
+     */
+    getOwnPropertyNames(o: any): string[];
+
+    /**
+     * Creates an object that has the specified prototype or that has null prototype.
+     * @param o Object to use as a prototype. May be null.
+     */
+    create(o: object | null): any;
+
+    /**
+     * Creates an object that has the specified prototype, and that optionally contains specified properties.
+     * @param o Object to use as a prototype. May be null
+     * @param properties JavaScript object that contains one or more property descriptors.
+     */
+    create(o: object | null, properties: PropertyDescriptorMap & ThisType<any>): any;
+
+    /**
+     * Adds a property to an object, or modifies attributes of an existing property.
+     * @param o Object on which to add or modify the property. This can be a native JavaScript object (that is, a user-defined object or a built in object) or a DOM object.
+     * @param p The property name.
+     * @param attributes Descriptor for the property. It can be for a data property or an accessor property.
+     */
+    defineProperty<T>(o: T, p: PropertyKey, attributes: PropertyDescriptor & ThisType<any>): T;
+
+    /**
+     * Adds one or more properties to an object, and/or modifies attributes of existing properties.
+     * @param o Object on which to add or modify the properties. This can be a native JavaScript object or a DOM object.
+     * @param properties JavaScript object that contains one or more descriptor objects. Each descriptor object describes a data property or an accessor property.
+     */
+    defineProperties<T>(o: T, properties: PropertyDescriptorMap & ThisType<any>): T;
+
+    /**
+     * Prevents the modification of attributes of existing properties, and prevents the addition of new properties.
+     * @param o Object on which to lock the attributes.
+     */
+    seal<T>(o: T): T;
+
+    /**
+     * Prevents the modification of existing property attributes and values, and prevents the addition of new properties.
+     * @param f Object on which to lock the attributes.
+     */
+    freeze<T extends Function>(f: T): T;
+
+    /**
+     * Prevents the modification of existing property attributes and values, and prevents the addition of new properties.
+     * @param o Object on which to lock the attributes.
+     */
+    freeze<T extends { [idx: string]: U | null | undefined | object; }, U extends string | bigint | number | boolean | symbol>(o: T): Readonly<T>;
+
+    /**
+     * Prevents the modification of existing property attributes and values, and prevents the addition of new properties.
+     * @param o Object on which to lock the attributes.
+     */
+    freeze<T>(o: T): Readonly<T>;
+
+    /**
+     * Prevents the addition of new properties to an object.
+     * @param o Object to make non-extensible.
+     */
+    preventExtensions<T>(o: T): T;
+
+    /**
+     * Returns true if existing property attributes cannot be modified in an object and new properties cannot be added to the object.
+     * @param o Object to test.
+     */
+    isSealed(o: any): boolean;
+
+    /**
+     * Returns true if existing property attributes and values cannot be modified in an object, and new properties cannot be added to the object.
+     * @param o Object to test.
+     */
+    isFrozen(o: any): boolean;
+
+    /**
+     * Returns a value that indicates whether new properties can be added to an object.
+     * @param o Object to test.
+     */
+    isExtensible(o: any): boolean;
+
+    /**
+     * Returns the names of the enumerable string properties and methods of an object.
+     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
+    keys(o: object): string[];
+}
+
+/**
+ * Provides functionality common to all JavaScript objects.
+ */
+declare var Object: ObjectConstructor;
+
+/**
+ * Creates a new function.
+ */
+interface Function {
+    /**
+     * Calls the function, substituting the specified object for the this value of the function, and the specified array for the arguments of the function.
+     * @param thisArg The object to be used as the this object.
+     * @param argArray A set of arguments to be passed to the function.
+     */
+    apply(this: Function, thisArg: any, argArray?: any): any;
+
+    /**
+     * Calls a method of an object, substituting another object for the current object.
+     * @param thisArg The object to be used as the current object.
+     * @param argArray A list of arguments to be passed to the method.
+     */
+    call(this: Function, thisArg: any, ...argArray: any[]): any;
+
+    /**
+     * For a given function, creates a bound function that has the same body as the original function.
+     * The this object of the bound function is associated with the specified object, and has the specified initial parameters.
+     * @param thisArg An object to which the this keyword can refer inside the new function.
+     * @param argArray A list of arguments to be passed to the new function.
+     */
+    bind(this: Function, thisArg: any, ...argArray: any[]): any;
+
+    /** Returns a string representation of a function. */
+    toString(): string;
+
+    prototype: any;
+    readonly length: number;
+
+    // Non-standard extensions
+    arguments: any;
+    caller: Function;
+}
+
+interface FunctionConstructor {
+    /**
+     * Creates a new function.
+     * @param args A list of arguments the function accepts.
+     */
+    new (...args: string[]): Function;
+    (...args: string[]): Function;
+    readonly prototype: Function;
+}
+
+declare var Function: FunctionConstructor;
+
+/**
+ * Extracts the type of the 'this' parameter of a function type, or 'unknown' if the function type has no 'this' parameter.
+ */
+type ThisParameterType<T> = T extends (this: infer U, ...args: never) => any ? U : unknown;
+
+/**
+ * Removes the 'this' parameter from a function type.
+ */
+type OmitThisParameter<T> = unknown extends ThisParameterType<T> ? T : T extends (...args: infer A) => infer R ? (...args: A) => R : T;
+
+interface CallableFunction extends Function {
+    /**
+     * Calls the function with the specified object as the this value and the elements of specified array as the arguments.
+     * @param thisArg The object to be used as the this object.
+     */
+    apply<T, R>(this: (this: T) => R, thisArg: T): R;
+
+    /**
+     * Calls the function with the specified object as the this value and the elements of specified array as the arguments.
+     * @param thisArg The object to be used as the this object.
+     * @param args An array of argument values to be passed to the function.
+     */
+    apply<T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg: T, args: A): R;
+
+    /**
+     * Calls the function with the specified object as the this value and the specified rest arguments as the arguments.
+     * @param thisArg The object to be used as the this object.
+     * @param args Argument values to be passed to the function.
+     */
+    call<T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg: T, ...args: A): R;
+
+    /**
+     * For a given function, creates a bound function that has the same body as the original function.
+     * The this object of the bound function is associated with the specified object, and has the specified initial parameters.
+     * @param thisArg The object to be used as the this object.
+     */
+    bind<T>(this: T, thisArg: ThisParameterType<T>): OmitThisParameter<T>;
+
+    /**
+     * For a given function, creates a bound function that has the same body as the original function.
+     * The this object of the bound function is associated with the specified object, and has the specified initial parameters.
+     * @param thisArg The object to be used as the this object.
+     * @param args Arguments to bind to the parameters of the function.
+     */
+    bind<T, A extends any[], B extends any[], R>(this: (this: T, ...args: [...A, ...B]) => R, thisArg: T, ...args: A): (...args: B) => R;
+}
+
+interface NewableFunction extends Function {
+    /**
+     * Calls the function with the specified object as the this value and the elements of specified array as the arguments.
+     * @param thisArg The object to be used as the this object.
+     */
+    apply<T>(this: new () => T, thisArg: T): void;
+    /**
+     * Calls the function with the specified object as the this value and the elements of specified array as the arguments.
+     * @param thisArg The object to be used as the this object.
+     * @param args An array of argument values to be passed to the function.
+     */
+    apply<T, A extends any[]>(this: new (...args: A) => T, thisArg: T, args: A): void;
+
+    /**
+     * Calls the function with the specified object as the this value and the specified rest arguments as the arguments.
+     * @param thisArg The object to be used as the this object.
+     * @param args Argument values to be passed to the function.
+     */
+    call<T, A extends any[]>(this: new (...args: A) => T, thisArg: T, ...args: A): void;
+
+    /**
+     * For a given function, creates a bound function that has the same body as the original function.
+     * The this object of the bound function is associated with the specified object, and has the specified initial parameters.
+     * @param thisArg The object to be used as the this object.
+     */
+    bind<T>(this: T, thisArg: any): T;
+
+    /**
+     * For a given function, creates a bound function that has the same body as the original function.
+     * The this object of the bound function is associated with the specified object, and has the specified initial parameters.
+     * @param thisArg The object to be used as the this object.
+     * @param args Arguments to bind to the parameters of the function.
+     */
+    bind<A extends any[], B extends any[], R>(this: new (...args: [...A, ...B]) => R, thisArg: any, ...args: A): new (...args: B) => R;
+}
+
+interface IArguments {
+    [index: number]: any;
+    length: number;
+    callee: Function;
+}
+
+interface String {
+    /** Returns a string representation of a string. */
+    toString(): string;
+
+    /**
+     * Returns the character at the specified index.
+     * @param pos The zero-based index of the desired character.
+     */
+    charAt(pos: number): string;
+
+    /**
+     * Returns the Unicode value of the character at the specified location.
+     * @param index The zero-based index of the desired character. If there is no character at the specified index, NaN is returned.
+     */
+    charCodeAt(index: number): number;
+
+    /**
+     * Returns a string that contains the concatenation of two or more strings.
+     * @param strings The strings to append to the end of the string.
+     */
+    concat(...strings: string[]): string;
+
+    /**
+     * Returns the position of the first occurrence of a substring.
+     * @param searchString The substring to search for in the string
+     * @param position The index at which to begin searching the String object. If omitted, search starts at the beginning of the string.
+     */
+    indexOf(searchString: string, position?: number): number;
+
+    /**
+     * Returns the last occurrence of a substring in the string.
+     * @param searchString The substring to search for.
+     * @param position The index at which to begin searching. If omitted, the search begins at the end of the string.
+     */
+    lastIndexOf(searchString: string, position?: number): number;
+
+    /**
+     * Determines whether two strings are equivalent in the current locale.
+     * @param that String to compare to target string
+     */
+    localeCompare(that: string): number;
+
+    /**
+     * Matches a string with a regular expression, and returns an array containing the results of that search.
+     * @param regexp A variable name or string literal containing the regular expression pattern and flags.
+     */
+    match(regexp: string | RegExp): RegExpMatchArray | null;
+
+    /**
+     * Replaces text in a string, using a regular expression or search string.
+     * @param searchValue A string or regular expression to search for.
+     * @param replaceValue A string containing the text to replace. When the {@linkcode searchValue} is a `RegExp`, all matches are replaced if the `g` flag is set (or only those matches at the beginning, if the `y` flag is also present). Otherwise, only the first match of {@linkcode searchValue} is replaced.
+     */
+    replace(searchValue: string | RegExp, replaceValue: string): string;
+
+    /**
+     * Replaces text in a string, using a regular expression or search string.
+     * @param searchValue A string to search for.
+     * @param replacer A function that returns the replacement text.
+     */
+    replace(searchValue: string | RegExp, replacer: (substring: string, ...args: any[]) => string): string;
+
+    /**
+     * Finds the first substring match in a regular expression search.
+     * @param regexp The regular expression pattern and applicable flags.
+     */
+    search(regexp: string | RegExp): number;
+
+    /**
+     * Returns a section of a string.
+     * @param start The index to the beginning of the specified portion of stringObj.
+     * @param end The index to the end of the specified portion of stringObj. The substring includes the characters up to, but not including, the character indicated by end.
+     * If this value is not specified, the substring continues to the end of stringObj.
+     */
+    slice(start?: number, end?: number): string;
+
+    /**
+     * Split a string into substrings using the specified separator and return them as an array.
+     * @param separator A string that identifies character or characters to use in separating the string. If omitted, a single-element array containing the entire string is returned.
+     * @param limit A value used to limit the number of elements returned in the array.
+     */
+    split(separator: string | RegExp, limit?: number): string[];
+
+    /**
+     * Returns the substring at the specified location within a String object.
+     * @param start The zero-based index number indicating the beginning of the substring.
+     * @param end Zero-based index number indicating the end of the substring. The substring includes the characters up to, but not including, the character indicated by end.
+     * If end is omitted, the characters from start through the end of the original string are returned.
+     */
+    substring(start: number, end?: number): string;
+
+    /** Converts all the alphabetic characters in a string to lowercase. */
+    toLowerCase(): string;
+
+    /** Converts all alphabetic characters to lowercase, taking into account the host environment's current locale. */
+    toLocaleLowerCase(locales?: string | string[]): string;
+
+    /** Converts all the alphabetic characters in a string to uppercase. */
+    toUpperCase(): string;
+
+    /** Returns a string where all alphabetic characters have been converted to uppercase, taking into account the host environment's current locale. */
+    toLocaleUpperCase(locales?: string | string[]): string;
+
+    /** Removes the leading and trailing white space and line terminator characters from a string. */
+    trim(): string;
+
+    /** Returns the length of a String object. */
+    readonly length: number;
+
+    // IE extensions
+    /**
+     * Gets a substring beginning at the specified location and having the specified length.
+     * @deprecated A legacy feature for browser compatibility
+     * @param from The starting position of the desired substring. The index of the first character in the string is zero.
+     * @param length The number of characters to include in the returned substring.
+     */
+    substr(from: number, length?: number): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): string;
+
+    readonly [index: number]: string;
+}
+
+interface StringConstructor {
+    new (value?: any): String;
+    (value?: any): string;
+    readonly prototype: String;
+    fromCharCode(...codes: number[]): string;
+}
+
+/**
+ * Allows manipulation and formatting of text strings and determination and location of substrings within strings.
+ */
+declare var String: StringConstructor;
+
+interface Boolean {
+    /** Returns the primitive value of the specified object. */
+    valueOf(): boolean;
+}
+
+interface BooleanConstructor {
+    new (value?: any): Boolean;
+    <T>(value?: T): boolean;
+    readonly prototype: Boolean;
+}
+
+declare var Boolean: BooleanConstructor;
+
+interface Number {
+    /**
+     * Returns a string representation of an object.
+     * @param radix Specifies a radix for converting numeric values to strings. This value is only used for numbers.
+     */
+    toString(radix?: number): string;
+
+    /**
+     * Returns a string representing a number in fixed-point notation.
+     * @param fractionDigits Number of digits after the decimal point. Must be in the range 0 - 20, inclusive.
+     */
+    toFixed(fractionDigits?: number): string;
+
+    /**
+     * Returns a string containing a number represented in exponential notation.
+     * @param fractionDigits Number of digits after the decimal point. Must be in the range 0 - 20, inclusive.
+     */
+    toExponential(fractionDigits?: number): string;
+
+    /**
+     * Returns a string containing a number represented either in exponential or fixed-point notation with a specified number of digits.
+     * @param precision Number of significant digits. Must be in the range 1 - 21, inclusive.
+     */
+    toPrecision(precision?: number): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): number;
+}
+
+interface NumberConstructor {
+    new (value?: any): Number;
+    (value?: any): number;
+    readonly prototype: Number;
+
+    /** The largest number that can be represented in JavaScript. Equal to approximately 1.79E+308. */
+    readonly MAX_VALUE: number;
+
+    /** The closest number to zero that can be represented in JavaScript. Equal to approximately 5.00E-324. */
+    readonly MIN_VALUE: number;
+
+    /**
+     * A value that is not a number.
+     * In equality comparisons, NaN does not equal any value, including itself. To test whether a value is equivalent to NaN, use the isNaN function.
+     */
+    readonly NaN: number;
+
+    /**
+     * A value that is less than the largest negative number that can be represented in JavaScript.
+     * JavaScript displays NEGATIVE_INFINITY values as -infinity.
+     */
+    readonly NEGATIVE_INFINITY: number;
+
+    /**
+     * A value greater than the largest number that can be represented in JavaScript.
+     * JavaScript displays POSITIVE_INFINITY values as infinity.
+     */
+    readonly POSITIVE_INFINITY: number;
+}
+
+/** An object that represents a number of any kind. All JavaScript numbers are 64-bit floating-point numbers. */
+declare var Number: NumberConstructor;
+
+interface TemplateStringsArray extends ReadonlyArray<string> {
+    readonly raw: readonly string[];
+}
+
+/**
+ * The type of `import.meta`.
+ *
+ * If you need to declare that a given property exists on `import.meta`,
+ * this type may be augmented via interface merging.
+ */
+interface ImportMeta {
+}
+
+/**
+ * The type for the optional second argument to `import()`.
+ *
+ * If your host environment supports additional options, this type may be
+ * augmented via interface merging.
+ */
+interface ImportCallOptions {
+    /** @deprecated*/ assert?: ImportAssertions;
+    with?: ImportAttributes;
+}
+
+/**
+ * The type for the `assert` property of the optional second argument to `import()`.
+ * @deprecated
+ */
+interface ImportAssertions {
+    [key: string]: string;
+}
+
+/**
+ * The type for the `with` property of the optional second argument to `import()`.
+ */
+interface ImportAttributes {
+    [key: string]: string;
+}
+
+interface Math {
+    /** The mathematical constant e. This is Euler's number, the base of natural logarithms. */
+    readonly E: number;
+    /** The natural logarithm of 10. */
+    readonly LN10: number;
+    /** The natural logarithm of 2. */
+    readonly LN2: number;
+    /** The base-2 logarithm of e. */
+    readonly LOG2E: number;
+    /** The base-10 logarithm of e. */
+    readonly LOG10E: number;
+    /** Pi. This is the ratio of the circumference of a circle to its diameter. */
+    readonly PI: number;
+    /** The square root of 0.5, or, equivalently, one divided by the square root of 2. */
+    readonly SQRT1_2: number;
+    /** The square root of 2. */
+    readonly SQRT2: number;
+    /**
+     * Returns the absolute value of a number (the value without regard to whether it is positive or negative).
+     * For example, the absolute value of -5 is the same as the absolute value of 5.
+     * @param x A numeric expression for which the absolute value is needed.
+     */
+    abs(x: number): number;
+    /**
+     * Returns the arc cosine (or inverse cosine) of a number.
+     * @param x A numeric expression.
+     */
+    acos(x: number): number;
+    /**
+     * Returns the arcsine of a number.
+     * @param x A numeric expression.
+     */
+    asin(x: number): number;
+    /**
+     * Returns the arctangent of a number.
+     * @param x A numeric expression for which the arctangent is needed.
+     */
+    atan(x: number): number;
+    /**
+     * Returns the angle (in radians) between the X axis and the line going through both the origin and the given point.
+     * @param y A numeric expression representing the cartesian y-coordinate.
+     * @param x A numeric expression representing the cartesian x-coordinate.
+     */
+    atan2(y: number, x: number): number;
+    /**
+     * Returns the smallest integer greater than or equal to its numeric argument.
+     * @param x A numeric expression.
+     */
+    ceil(x: number): number;
+    /**
+     * Returns the cosine of a number.
+     * @param x A numeric expression that contains an angle measured in radians.
+     */
+    cos(x: number): number;
+    /**
+     * Returns e (the base of natural logarithms) raised to a power.
+     * @param x A numeric expression representing the power of e.
+     */
+    exp(x: number): number;
+    /**
+     * Returns the greatest integer less than or equal to its numeric argument.
+     * @param x A numeric expression.
+     */
+    floor(x: number): number;
+    /**
+     * Returns the natural logarithm (base e) of a number.
+     * @param x A numeric expression.
+     */
+    log(x: number): number;
+    /**
+     * Returns the larger of a set of supplied numeric expressions.
+     * @param values Numeric expressions to be evaluated.
+     */
+    max(...values: number[]): number;
+    /**
+     * Returns the smaller of a set of supplied numeric expressions.
+     * @param values Numeric expressions to be evaluated.
+     */
+    min(...values: number[]): number;
+    /**
+     * Returns the value of a base expression taken to a specified power.
+     * @param x The base value of the expression.
+     * @param y The exponent value of the expression.
+     */
+    pow(x: number, y: number): number;
+    /** Returns a pseudorandom number between 0 and 1. */
+    random(): number;
+    /**
+     * Returns a supplied numeric expression rounded to the nearest integer.
+     * @param x The value to be rounded to the nearest integer.
+     */
+    round(x: number): number;
+    /**
+     * Returns the sine of a number.
+     * @param x A numeric expression that contains an angle measured in radians.
+     */
+    sin(x: number): number;
+    /**
+     * Returns the square root of a number.
+     * @param x A numeric expression.
+     */
+    sqrt(x: number): number;
+    /**
+     * Returns the tangent of a number.
+     * @param x A numeric expression that contains an angle measured in radians.
+     */
+    tan(x: number): number;
+}
+/** An intrinsic object that provides basic mathematics functionality and constants. */
+declare var Math: Math;
+
+/** Enables basic storage and retrieval of dates and times. */
+interface Date {
+    /** Returns a string representation of a date. The format of the string depends on the locale. */
+    toString(): string;
+    /** Returns a date as a string value. */
+    toDateString(): string;
+    /** Returns a time as a string value. */
+    toTimeString(): string;
+    /** Returns a value as a string value appropriate to the host environment's current locale. */
+    toLocaleString(): string;
+    /** Returns a date as a string value appropriate to the host environment's current locale. */
+    toLocaleDateString(): string;
+    /** Returns a time as a string value appropriate to the host environment's current locale. */
+    toLocaleTimeString(): string;
+    /** Returns the stored time value in milliseconds since midnight, January 1, 1970 UTC. */
+    valueOf(): number;
+    /** Returns the stored time value in milliseconds since midnight, January 1, 1970 UTC. */
+    getTime(): number;
+    /** Gets the year, using local time. */
+    getFullYear(): number;
+    /** Gets the year using Universal Coordinated Time (UTC). */
+    getUTCFullYear(): number;
+    /** Gets the month, using local time. */
+    getMonth(): number;
+    /** Gets the month of a Date object using Universal Coordinated Time (UTC). */
+    getUTCMonth(): number;
+    /** Gets the day-of-the-month, using local time. */
+    getDate(): number;
+    /** Gets the day-of-the-month, using Universal Coordinated Time (UTC). */
+    getUTCDate(): number;
+    /** Gets the day of the week, using local time. */
+    getDay(): number;
+    /** Gets the day of the week using Universal Coordinated Time (UTC). */
+    getUTCDay(): number;
+    /** Gets the hours in a date, using local time. */
+    getHours(): number;
+    /** Gets the hours value in a Date object using Universal Coordinated Time (UTC). */
+    getUTCHours(): number;
+    /** Gets the minutes of a Date object, using local time. */
+    getMinutes(): number;
+    /** Gets the minutes of a Date object using Universal Coordinated Time (UTC). */
+    getUTCMinutes(): number;
+    /** Gets the seconds of a Date object, using local time. */
+    getSeconds(): number;
+    /** Gets the seconds of a Date object using Universal Coordinated Time (UTC). */
+    getUTCSeconds(): number;
+    /** Gets the milliseconds of a Date, using local time. */
+    getMilliseconds(): number;
+    /** Gets the milliseconds of a Date object using Universal Coordinated Time (UTC). */
+    getUTCMilliseconds(): number;
+    /** Gets the difference in minutes between Universal Coordinated Time (UTC) and the time on the local computer. */
+    getTimezoneOffset(): number;
+    /**
+     * Sets the date and time value in the Date object.
+     * @param time A numeric value representing the number of elapsed milliseconds since midnight, January 1, 1970 GMT.
+     */
+    setTime(time: number): number;
+    /**
+     * Sets the milliseconds value in the Date object using local time.
+     * @param ms A numeric value equal to the millisecond value.
+     */
+    setMilliseconds(ms: number): number;
+    /**
+     * Sets the milliseconds value in the Date object using Universal Coordinated Time (UTC).
+     * @param ms A numeric value equal to the millisecond value.
+     */
+    setUTCMilliseconds(ms: number): number;
+
+    /**
+     * Sets the seconds value in the Date object using local time.
+     * @param sec A numeric value equal to the seconds value.
+     * @param ms A numeric value equal to the milliseconds value.
+     */
+    setSeconds(sec: number, ms?: number): number;
+    /**
+     * Sets the seconds value in the Date object using Universal Coordinated Time (UTC).
+     * @param sec A numeric value equal to the seconds value.
+     * @param ms A numeric value equal to the milliseconds value.
+     */
+    setUTCSeconds(sec: number, ms?: number): number;
+    /**
+     * Sets the minutes value in the Date object using local time.
+     * @param min A numeric value equal to the minutes value.
+     * @param sec A numeric value equal to the seconds value.
+     * @param ms A numeric value equal to the milliseconds value.
+     */
+    setMinutes(min: number, sec?: number, ms?: number): number;
+    /**
+     * Sets the minutes value in the Date object using Universal Coordinated Time (UTC).
+     * @param min A numeric value equal to the minutes value.
+     * @param sec A numeric value equal to the seconds value.
+     * @param ms A numeric value equal to the milliseconds value.
+     */
+    setUTCMinutes(min: number, sec?: number, ms?: number): number;
+    /**
+     * Sets the hour value in the Date object using local time.
+     * @param hours A numeric value equal to the hours value.
+     * @param min A numeric value equal to the minutes value.
+     * @param sec A numeric value equal to the seconds value.
+     * @param ms A numeric value equal to the milliseconds value.
+     */
+    setHours(hours: number, min?: number, sec?: number, ms?: number): number;
+    /**
+     * Sets the hours value in the Date object using Universal Coordinated Time (UTC).
+     * @param hours A numeric value equal to the hours value.
+     * @param min A numeric value equal to the minutes value.
+     * @param sec A numeric value equal to the seconds value.
+     * @param ms A numeric value equal to the milliseconds value.
+     */
+    setUTCHours(hours: number, min?: number, sec?: number, ms?: number): number;
+    /**
+     * Sets the numeric day-of-the-month value of the Date object using local time.
+     * @param date A numeric value equal to the day of the month.
+     */
+    setDate(date: number): number;
+    /**
+     * Sets the numeric day of the month in the Date object using Universal Coordinated Time (UTC).
+     * @param date A numeric value equal to the day of the month.
+     */
+    setUTCDate(date: number): number;
+    /**
+     * Sets the month value in the Date object using local time.
+     * @param month A numeric value equal to the month. The value for January is 0, and other month values follow consecutively.
+     * @param date A numeric value representing the day of the month. If this value is not supplied, the value from a call to the getDate method is used.
+     */
+    setMonth(month: number, date?: number): number;
+    /**
+     * Sets the month value in the Date object using Universal Coordinated Time (UTC).
+     * @param month A numeric value equal to the month. The value for January is 0, and other month values follow consecutively.
+     * @param date A numeric value representing the day of the month. If it is not supplied, the value from a call to the getUTCDate method is used.
+     */
+    setUTCMonth(month: number, date?: number): number;
+    /**
+     * Sets the year of the Date object using local time.
+     * @param year A numeric value for the year.
+     * @param month A zero-based numeric value for the month (0 for January, 11 for December). Must be specified if numDate is specified.
+     * @param date A numeric value equal for the day of the month.
+     */
+    setFullYear(year: number, month?: number, date?: number): number;
+    /**
+     * Sets the year value in the Date object using Universal Coordinated Time (UTC).
+     * @param year A numeric value equal to the year.
+     * @param month A numeric value equal to the month. The value for January is 0, and other month values follow consecutively. Must be supplied if numDate is supplied.
+     * @param date A numeric value equal to the day of the month.
+     */
+    setUTCFullYear(year: number, month?: number, date?: number): number;
+    /** Returns a date converted to a string using Universal Coordinated Time (UTC). */
+    toUTCString(): string;
+    /** Returns a date as a string value in ISO format. */
+    toISOString(): string;
+    /** Used by the JSON.stringify method to enable the transformation of an object's data for JavaScript Object Notation (JSON) serialization. */
+    toJSON(key?: any): string;
+}
+
+interface DateConstructor {
+    new (): Date;
+    new (value: number | string): Date;
+    /**
+     * Creates a new Date.
+     * @param year The full year designation is required for cross-century date accuracy. If year is between 0 and 99 is used, then year is assumed to be 1900 + year.
+     * @param monthIndex The month as a number between 0 and 11 (January to December).
+     * @param date The date as a number between 1 and 31.
+     * @param hours Must be supplied if minutes is supplied. A number from 0 to 23 (midnight to 11pm) that specifies the hour.
+     * @param minutes Must be supplied if seconds is supplied. A number from 0 to 59 that specifies the minutes.
+     * @param seconds Must be supplied if milliseconds is supplied. A number from 0 to 59 that specifies the seconds.
+     * @param ms A number from 0 to 999 that specifies the milliseconds.
+     */
+    new (year: number, monthIndex: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date;
+    (): string;
+    readonly prototype: Date;
+    /**
+     * Parses a string containing a date, and returns the number of milliseconds between that date and midnight, January 1, 1970.
+     * @param s A date string
+     */
+    parse(s: string): number;
+    /**
+     * Returns the number of milliseconds between midnight, January 1, 1970 Universal Coordinated Time (UTC) (or GMT) and the specified date.
+     * @param year The full year designation is required for cross-century date accuracy. If year is between 0 and 99 is used, then year is assumed to be 1900 + year.
+     * @param monthIndex The month as a number between 0 and 11 (January to December).
+     * @param date The date as a number between 1 and 31.
+     * @param hours Must be supplied if minutes is supplied. A number from 0 to 23 (midnight to 11pm) that specifies the hour.
+     * @param minutes Must be supplied if seconds is supplied. A number from 0 to 59 that specifies the minutes.
+     * @param seconds Must be supplied if milliseconds is supplied. A number from 0 to 59 that specifies the seconds.
+     * @param ms A number from 0 to 999 that specifies the milliseconds.
+     */
+    UTC(year: number, monthIndex: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): number;
+    /** Returns the number of milliseconds elapsed since midnight, January 1, 1970 Universal Coordinated Time (UTC). */
+    now(): number;
+}
+
+declare var Date: DateConstructor;
+
+interface RegExpMatchArray extends Array<string> {
+    /**
+     * The index of the search at which the result was found.
+     */
+    index?: number;
+    /**
+     * A copy of the search string.
+     */
+    input?: string;
+    /**
+     * The first match. This will always be present because `null` will be returned if there are no matches.
+     */
+    0: string;
+}
+
+interface RegExpExecArray extends Array<string> {
+    /**
+     * The index of the search at which the result was found.
+     */
+    index: number;
+    /**
+     * A copy of the search string.
+     */
+    input: string;
+    /**
+     * The first match. This will always be present because `null` will be returned if there are no matches.
+     */
+    0: string;
+}
+
+interface RegExp {
+    /**
+     * Executes a search on a string using a regular expression pattern, and returns an array containing the results of that search.
+     * @param string The String object or string literal on which to perform the search.
+     */
+    exec(string: string): RegExpExecArray | null;
+
+    /**
+     * Returns a Boolean value that indicates whether or not a pattern exists in a searched string.
+     * @param string String on which to perform the search.
+     */
+    test(string: string): boolean;
+
+    /** Returns a copy of the text of the regular expression pattern. Read-only. The regExp argument is a Regular expression object. It can be a variable name or a literal. */
+    readonly source: string;
+
+    /** Returns a Boolean value indicating the state of the global flag (g) used with a regular expression. Default is false. Read-only. */
+    readonly global: boolean;
+
+    /** Returns a Boolean value indicating the state of the ignoreCase flag (i) used with a regular expression. Default is false. Read-only. */
+    readonly ignoreCase: boolean;
+
+    /** Returns a Boolean value indicating the state of the multiline flag (m) used with a regular expression. Default is false. Read-only. */
+    readonly multiline: boolean;
+
+    lastIndex: number;
+
+    // Non-standard extensions
+    /** @deprecated A legacy feature for browser compatibility */
+    compile(pattern: string, flags?: string): this;
+}
+
+interface RegExpConstructor {
+    new (pattern: RegExp | string): RegExp;
+    new (pattern: string, flags?: string): RegExp;
+    (pattern: RegExp | string): RegExp;
+    (pattern: string, flags?: string): RegExp;
+    readonly "prototype": RegExp;
+
+    // Non-standard extensions
+    /** @deprecated A legacy feature for browser compatibility */
+    "$1": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "$2": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "$3": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "$4": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "$5": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "$6": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "$7": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "$8": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "$9": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "input": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "$_": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "lastMatch": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "$&": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "lastParen": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "$+": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "leftContext": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "$`": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "rightContext": string;
+    /** @deprecated A legacy feature for browser compatibility */
+    "$'": string;
+}
+
+declare var RegExp: RegExpConstructor;
+
+interface Error {
+    name: string;
+    message: string;
+    stack?: string;
+}
+
+interface ErrorConstructor {
+    new (message?: string): Error;
+    (message?: string): Error;
+    readonly prototype: Error;
+}
+
+declare var Error: ErrorConstructor;
+
+interface EvalError extends Error {
+}
+
+interface EvalErrorConstructor extends ErrorConstructor {
+    new (message?: string): EvalError;
+    (message?: string): EvalError;
+    readonly prototype: EvalError;
+}
+
+declare var EvalError: EvalErrorConstructor;
+
+interface RangeError extends Error {
+}
+
+interface RangeErrorConstructor extends ErrorConstructor {
+    new (message?: string): RangeError;
+    (message?: string): RangeError;
+    readonly prototype: RangeError;
+}
+
+declare var RangeError: RangeErrorConstructor;
+
+interface ReferenceError extends Error {
+}
+
+interface ReferenceErrorConstructor extends ErrorConstructor {
+    new (message?: string): ReferenceError;
+    (message?: string): ReferenceError;
+    readonly prototype: ReferenceError;
+}
+
+declare var ReferenceError: ReferenceErrorConstructor;
+
+interface SyntaxError extends Error {
+}
+
+interface SyntaxErrorConstructor extends ErrorConstructor {
+    new (message?: string): SyntaxError;
+    (message?: string): SyntaxError;
+    readonly prototype: SyntaxError;
+}
+
+declare var SyntaxError: SyntaxErrorConstructor;
+
+interface TypeError extends Error {
+}
+
+interface TypeErrorConstructor extends ErrorConstructor {
+    new (message?: string): TypeError;
+    (message?: string): TypeError;
+    readonly prototype: TypeError;
+}
+
+declare var TypeError: TypeErrorConstructor;
+
+interface URIError extends Error {
+}
+
+interface URIErrorConstructor extends ErrorConstructor {
+    new (message?: string): URIError;
+    (message?: string): URIError;
+    readonly prototype: URIError;
+}
+
+declare var URIError: URIErrorConstructor;
+
+interface JSON {
+    /**
+     * Converts a JavaScript Object Notation (JSON) string into an object.
+     * @param text A valid JSON string.
+     * @param reviver A function that transforms the results. This function is called for each member of the object.
+     * If a member contains nested objects, the nested objects are transformed before the parent object is.
+     * @throws {SyntaxError} If `text` is not valid JSON.
+     */
+    parse(text: string, reviver?: (this: any, key: string, value: any) => any): any;
+    /**
+     * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+     * @param value A JavaScript value, usually an object or array, to be converted.
+     * @param replacer A function that transforms the results.
+     * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+     * @throws {TypeError} If a circular reference or a BigInt value is found.
+     */
+    stringify(value: any, replacer?: (this: any, key: string, value: any) => any, space?: string | number): string;
+    /**
+     * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+     * @param value A JavaScript value, usually an object or array, to be converted.
+     * @param replacer An array of strings and numbers that acts as an approved list for selecting the object properties that will be stringified.
+     * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+     * @throws {TypeError} If a circular reference or a BigInt value is found.
+     */
+    stringify(value: any, replacer?: (number | string)[] | null, space?: string | number): string;
+}
+
+/**
+ * An intrinsic object that provides functions to convert JavaScript values to and from the JavaScript Object Notation (JSON) format.
+ */
+declare var JSON: JSON;
+
+/////////////////////////////
+/// ECMAScript Array API (specially handled by compiler)
+/////////////////////////////
+
+interface ReadonlyArray<T> {
+    /**
+     * Gets the length of the array. This is a number one higher than the highest element defined in an array.
+     */
+    readonly length: number;
+    /**
+     * Returns a string representation of an array.
+     */
+    toString(): string;
+    /**
+     * Returns a string representation of an array. The elements are converted to string using their toLocaleString methods.
+     */
+    toLocaleString(): string;
+    /**
+     * Combines two or more arrays.
+     * @param items Additional items to add to the end of array1.
+     */
+    concat(...items: ConcatArray<T>[]): T[];
+    /**
+     * Combines two or more arrays.
+     * @param items Additional items to add to the end of array1.
+     */
+    concat(...items: (T | ConcatArray<T>)[]): T[];
+    /**
+     * Adds all the elements of an array separated by the specified separator string.
+     * @param separator A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.
+     */
+    join(separator?: string): string;
+    /**
+     * Returns a section of an array.
+     * @param start The beginning of the specified portion of the array.
+     * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+     */
+    slice(start?: number, end?: number): T[];
+    /**
+     * Returns the index of the first occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.
+     */
+    indexOf(searchElement: T, fromIndex?: number): number;
+    /**
+     * Returns the index of the last occurrence of a specified value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at the last index in the array.
+     */
+    lastIndexOf(searchElement: T, fromIndex?: number): number;
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every<S extends T>(predicate: (value: T, index: number, array: readonly T[]) => value is S, thisArg?: any): this is readonly S[];
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every(predicate: (value: T, index: number, array: readonly T[]) => unknown, thisArg?: any): boolean;
+    /**
+     * Determines whether the specified callback function returns true for any element of an array.
+     * @param predicate A function that accepts up to three arguments. The some method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value true, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    some(predicate: (value: T, index: number, array: readonly T[]) => unknown, thisArg?: any): boolean;
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach(callbackfn: (value: T, index: number, array: readonly T[]) => void, thisArg?: any): void;
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that contains the results.
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
+    map<U>(callbackfn: (value: T, index: number, array: readonly T[]) => U, thisArg?: any): U[];
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
+     */
+    filter<S extends T>(predicate: (value: T, index: number, array: readonly T[]) => value is S, thisArg?: any): S[];
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
+     */
+    filter(predicate: (value: T, index: number, array: readonly T[]) => unknown, thisArg?: any): T[];
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+     */
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: readonly T[]) => T): T;
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: readonly T[]) => T, initialValue: T): T;
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+     */
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: readonly T[]) => U, initialValue: U): U;
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+     */
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: readonly T[]) => T): T;
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: readonly T[]) => T, initialValue: T): T;
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+     */
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: readonly T[]) => U, initialValue: U): U;
+
+    readonly [n: number]: T;
+}
+
+interface ConcatArray<T> {
+    readonly length: number;
+    readonly [n: number]: T;
+    join(separator?: string): string;
+    slice(start?: number, end?: number): T[];
+}
+
+interface Array<T> {
+    /**
+     * Gets or sets the length of the array. This is a number one higher than the highest index in the array.
+     */
+    length: number;
+    /**
+     * Returns a string representation of an array.
+     */
+    toString(): string;
+    /**
+     * Returns a string representation of an array. The elements are converted to string using their toLocaleString methods.
+     */
+    toLocaleString(): string;
+    /**
+     * Removes the last element from an array and returns it.
+     * If the array is empty, undefined is returned and the array is not modified.
+     */
+    pop(): T | undefined;
+    /**
+     * Appends new elements to the end of an array, and returns the new length of the array.
+     * @param items New elements to add to the array.
+     */
+    push(...items: T[]): number;
+    /**
+     * Combines two or more arrays.
+     * This method returns a new array without modifying any existing arrays.
+     * @param items Additional arrays and/or items to add to the end of the array.
+     */
+    concat(...items: ConcatArray<T>[]): T[];
+    /**
+     * Combines two or more arrays.
+     * This method returns a new array without modifying any existing arrays.
+     * @param items Additional arrays and/or items to add to the end of the array.
+     */
+    concat(...items: (T | ConcatArray<T>)[]): T[];
+    /**
+     * Adds all the elements of an array into a string, separated by the specified separator string.
+     * @param separator A string used to separate one element of the array from the next in the resulting string. If omitted, the array elements are separated with a comma.
+     */
+    join(separator?: string): string;
+    /**
+     * Reverses the elements in an array in place.
+     * This method mutates the array and returns a reference to the same array.
+     */
+    reverse(): T[];
+    /**
+     * Removes the first element from an array and returns it.
+     * If the array is empty, undefined is returned and the array is not modified.
+     */
+    shift(): T | undefined;
+    /**
+     * Returns a copy of a section of an array.
+     * For both start and end, a negative index can be used to indicate an offset from the end of the array.
+     * For example, -2 refers to the second to last element of the array.
+     * @param start The beginning index of the specified portion of the array.
+     * If start is undefined, then the slice begins at index 0.
+     * @param end The end index of the specified portion of the array. This is exclusive of the element at the index 'end'.
+     * If end is undefined, then the slice extends to the end of the array.
+     */
+    slice(start?: number, end?: number): T[];
+    /**
+     * Sorts an array in place.
+     * This method mutates the array and returns a reference to the same array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending, UTF-16 code unit order.
+     * ```ts
+     * [11,2,22,1].sort((a, b) => a - b)
+     * ```
+     */
+    sort(compareFn?: (a: T, b: T) => number): this;
+    /**
+     * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
+     * @param start The zero-based location in the array from which to start removing elements.
+     * @param deleteCount The number of elements to remove.
+     * @returns An array containing the elements that were deleted.
+     */
+    splice(start: number, deleteCount?: number): T[];
+    /**
+     * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
+     * @param start The zero-based location in the array from which to start removing elements.
+     * @param deleteCount The number of elements to remove.
+     * @param items Elements to insert into the array in place of the deleted elements.
+     * @returns An array containing the elements that were deleted.
+     */
+    splice(start: number, deleteCount: number, ...items: T[]): T[];
+    /**
+     * Inserts new elements at the start of an array, and returns the new length of the array.
+     * @param items Elements to insert at the start of the array.
+     */
+    unshift(...items: T[]): number;
+    /**
+     * Returns the index of the first occurrence of a value in an array, or -1 if it is not present.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.
+     */
+    indexOf(searchElement: T, fromIndex?: number): number;
+    /**
+     * Returns the index of the last occurrence of a specified value in an array, or -1 if it is not present.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin searching backward. If fromIndex is omitted, the search starts at the last index in the array.
+     */
+    lastIndexOf(searchElement: T, fromIndex?: number): number;
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): this is S[];
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+    /**
+     * Determines whether the specified callback function returns true for any element of an array.
+     * @param predicate A function that accepts up to three arguments. The some method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value true, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    some(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that contains the results.
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
+    map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
+     */
+    filter<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): S[];
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
+     */
+    filter(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T[];
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+     */
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T;
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+     */
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+     */
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T;
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+     */
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+
+    [n: number]: T;
+}
+
+interface ArrayConstructor {
+    new (arrayLength?: number): any[];
+    new <T>(arrayLength: number): T[];
+    new <T>(...items: T[]): T[];
+    (arrayLength?: number): any[];
+    <T>(arrayLength: number): T[];
+    <T>(...items: T[]): T[];
+    isArray(arg: any): arg is any[];
+    readonly prototype: any[];
+}
+
+declare var Array: ArrayConstructor;
+
+interface TypedPropertyDescriptor<T> {
+    enumerable?: boolean;
+    configurable?: boolean;
+    writable?: boolean;
+    value?: T;
+    get?: () => T;
+    set?: (value: T) => void;
+}
+
+declare type PromiseConstructorLike = new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void) => PromiseLike<T>;
+
+interface PromiseLike<T> {
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): PromiseLike<TResult1 | TResult2>;
+}
+
+/**
+ * Represents the completion of an asynchronous operation
+ */
+interface Promise<T> {
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+}
+
+/**
+ * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
+ */
+type Awaited<T> = T extends null | undefined ? T : // special case for `null | undefined` when not in `--strictNullChecks` mode
+    T extends object & { then(onfulfilled: infer F, ...args: infer _): any; } ? // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+        F extends ((value: infer V, ...args: infer _) => any) ? // if the argument to `then` is callable, extracts the first argument
+            Awaited<V> : // recursively unwrap the value
+        never : // the argument to `then` was not callable
+    T; // non-object or non-thenable
+
+interface ArrayLike<T> {
+    readonly length: number;
+    readonly [n: number]: T;
+}
+
+/**
+ * Make all properties in T optional
+ */
+type Partial<T> = {
+    [P in keyof T]?: T[P];
+};
+
+/**
+ * Make all properties in T required
+ */
+type Required<T> = {
+    [P in keyof T]-?: T[P];
+};
+
+/**
+ * Make all properties in T readonly
+ */
+type Readonly<T> = {
+    readonly [P in keyof T]: T[P];
+};
+
+/**
+ * From T, pick a set of properties whose keys are in the union K
+ */
+type Pick<T, K extends keyof T> = {
+    [P in K]: T[P];
+};
+
+/**
+ * Construct a type with a set of properties K of type T
+ */
+type Record<K extends keyof any, T> = {
+    [P in K]: T;
+};
+
+/**
+ * Exclude from T those types that are assignable to U
+ */
+type Exclude<T, U> = T extends U ? never : T;
+
+/**
+ * Extract from T those types that are assignable to U
+ */
+type Extract<T, U> = T extends U ? T : never;
+
+/**
+ * Construct a type with the properties of T except for those in type K.
+ */
+type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+
+/**
+ * Exclude null and undefined from T
+ */
+type NonNullable<T> = T & {};
+
+/**
+ * Obtain the parameters of a function type in a tuple
+ */
+type Parameters<T extends (...args: any) => any> = T extends (...args: infer P) => any ? P : never;
+
+/**
+ * Obtain the parameters of a constructor function type in a tuple
+ */
+type ConstructorParameters<T extends abstract new (...args: any) => any> = T extends abstract new (...args: infer P) => any ? P : never;
+
+/**
+ * Obtain the return type of a function type
+ */
+type ReturnType<T extends (...args: any) => any> = T extends (...args: any) => infer R ? R : any;
+
+/**
+ * Obtain the return type of a constructor function type
+ */
+type InstanceType<T extends abstract new (...args: any) => any> = T extends abstract new (...args: any) => infer R ? R : any;
+
+/**
+ * Convert string literal type to uppercase
+ */
+type Uppercase<S extends string> = intrinsic;
+
+/**
+ * Convert string literal type to lowercase
+ */
+type Lowercase<S extends string> = intrinsic;
+
+/**
+ * Convert first character of string literal type to uppercase
+ */
+type Capitalize<S extends string> = intrinsic;
+
+/**
+ * Convert first character of string literal type to lowercase
+ */
+type Uncapitalize<S extends string> = intrinsic;
+
+/**
+ * Marker for non-inference type position
+ */
+type NoInfer<T> = intrinsic;
+
+/**
+ * Marker for contextual 'this' type
+ */
+interface ThisType<T> {}
+
+/**
+ * Stores types to be used with WeakSet, WeakMap, WeakRef, and FinalizationRegistry
+ */
+interface WeakKeyTypes {
+    object: object;
+}
+
+type WeakKey = WeakKeyTypes[keyof WeakKeyTypes];
+
+/**
+ * Represents a raw buffer of binary data, which is used to store data for the
+ * different typed arrays. ArrayBuffers cannot be read from or written to directly,
+ * but can be passed to a typed array or DataView Object to interpret the raw
+ * buffer as needed.
+ */
+interface ArrayBuffer {
+    /**
+     * Read-only. The length of the ArrayBuffer (in bytes).
+     */
+    readonly byteLength: number;
+
+    /**
+     * Returns a section of an ArrayBuffer.
+     */
+    slice(begin?: number, end?: number): ArrayBuffer;
+}
+
+/**
+ * Allowed ArrayBuffer types for the buffer of an ArrayBufferView and related Typed Arrays.
+ */
+interface ArrayBufferTypes {
+    ArrayBuffer: ArrayBuffer;
+}
+type ArrayBufferLike = ArrayBufferTypes[keyof ArrayBufferTypes];
+
+interface ArrayBufferConstructor {
+    readonly prototype: ArrayBuffer;
+    new (byteLength: number): ArrayBuffer;
+    isView(arg: any): arg is ArrayBufferView;
+}
+declare var ArrayBuffer: ArrayBufferConstructor;
+
+interface ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    /**
+     * The ArrayBuffer instance referenced by the array.
+     */
+    readonly buffer: TArrayBuffer;
+
+    /**
+     * The length in bytes of the array.
+     */
+    readonly byteLength: number;
+
+    /**
+     * The offset in bytes of the array.
+     */
+    readonly byteOffset: number;
+}
+
+interface DataView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    readonly buffer: TArrayBuffer;
+    readonly byteLength: number;
+    readonly byteOffset: number;
+    /**
+     * Gets the Float32 value at the specified byte offset from the start of the view. There is
+     * no alignment constraint; multi-byte values may be fetched from any offset.
+     * @param byteOffset The place in the buffer at which the value should be retrieved.
+     * @param littleEndian If false or undefined, a big-endian value should be read.
+     */
+    getFloat32(byteOffset: number, littleEndian?: boolean): number;
+
+    /**
+     * Gets the Float64 value at the specified byte offset from the start of the view. There is
+     * no alignment constraint; multi-byte values may be fetched from any offset.
+     * @param byteOffset The place in the buffer at which the value should be retrieved.
+     * @param littleEndian If false or undefined, a big-endian value should be read.
+     */
+    getFloat64(byteOffset: number, littleEndian?: boolean): number;
+
+    /**
+     * Gets the Int8 value at the specified byte offset from the start of the view. There is
+     * no alignment constraint; multi-byte values may be fetched from any offset.
+     * @param byteOffset The place in the buffer at which the value should be retrieved.
+     */
+    getInt8(byteOffset: number): number;
+
+    /**
+     * Gets the Int16 value at the specified byte offset from the start of the view. There is
+     * no alignment constraint; multi-byte values may be fetched from any offset.
+     * @param byteOffset The place in the buffer at which the value should be retrieved.
+     * @param littleEndian If false or undefined, a big-endian value should be read.
+     */
+    getInt16(byteOffset: number, littleEndian?: boolean): number;
+    /**
+     * Gets the Int32 value at the specified byte offset from the start of the view. There is
+     * no alignment constraint; multi-byte values may be fetched from any offset.
+     * @param byteOffset The place in the buffer at which the value should be retrieved.
+     * @param littleEndian If false or undefined, a big-endian value should be read.
+     */
+    getInt32(byteOffset: number, littleEndian?: boolean): number;
+
+    /**
+     * Gets the Uint8 value at the specified byte offset from the start of the view. There is
+     * no alignment constraint; multi-byte values may be fetched from any offset.
+     * @param byteOffset The place in the buffer at which the value should be retrieved.
+     */
+    getUint8(byteOffset: number): number;
+
+    /**
+     * Gets the Uint16 value at the specified byte offset from the start of the view. There is
+     * no alignment constraint; multi-byte values may be fetched from any offset.
+     * @param byteOffset The place in the buffer at which the value should be retrieved.
+     * @param littleEndian If false or undefined, a big-endian value should be read.
+     */
+    getUint16(byteOffset: number, littleEndian?: boolean): number;
+
+    /**
+     * Gets the Uint32 value at the specified byte offset from the start of the view. There is
+     * no alignment constraint; multi-byte values may be fetched from any offset.
+     * @param byteOffset The place in the buffer at which the value should be retrieved.
+     * @param littleEndian If false or undefined, a big-endian value should be read.
+     */
+    getUint32(byteOffset: number, littleEndian?: boolean): number;
+
+    /**
+     * Stores an Float32 value at the specified byte offset from the start of the view.
+     * @param byteOffset The place in the buffer at which the value should be set.
+     * @param value The value to set.
+     * @param littleEndian If false or undefined, a big-endian value should be written.
+     */
+    setFloat32(byteOffset: number, value: number, littleEndian?: boolean): void;
+
+    /**
+     * Stores an Float64 value at the specified byte offset from the start of the view.
+     * @param byteOffset The place in the buffer at which the value should be set.
+     * @param value The value to set.
+     * @param littleEndian If false or undefined, a big-endian value should be written.
+     */
+    setFloat64(byteOffset: number, value: number, littleEndian?: boolean): void;
+
+    /**
+     * Stores an Int8 value at the specified byte offset from the start of the view.
+     * @param byteOffset The place in the buffer at which the value should be set.
+     * @param value The value to set.
+     */
+    setInt8(byteOffset: number, value: number): void;
+
+    /**
+     * Stores an Int16 value at the specified byte offset from the start of the view.
+     * @param byteOffset The place in the buffer at which the value should be set.
+     * @param value The value to set.
+     * @param littleEndian If false or undefined, a big-endian value should be written.
+     */
+    setInt16(byteOffset: number, value: number, littleEndian?: boolean): void;
+
+    /**
+     * Stores an Int32 value at the specified byte offset from the start of the view.
+     * @param byteOffset The place in the buffer at which the value should be set.
+     * @param value The value to set.
+     * @param littleEndian If false or undefined, a big-endian value should be written.
+     */
+    setInt32(byteOffset: number, value: number, littleEndian?: boolean): void;
+
+    /**
+     * Stores an Uint8 value at the specified byte offset from the start of the view.
+     * @param byteOffset The place in the buffer at which the value should be set.
+     * @param value The value to set.
+     */
+    setUint8(byteOffset: number, value: number): void;
+
+    /**
+     * Stores an Uint16 value at the specified byte offset from the start of the view.
+     * @param byteOffset The place in the buffer at which the value should be set.
+     * @param value The value to set.
+     * @param littleEndian If false or undefined, a big-endian value should be written.
+     */
+    setUint16(byteOffset: number, value: number, littleEndian?: boolean): void;
+
+    /**
+     * Stores an Uint32 value at the specified byte offset from the start of the view.
+     * @param byteOffset The place in the buffer at which the value should be set.
+     * @param value The value to set.
+     * @param littleEndian If false or undefined, a big-endian value should be written.
+     */
+    setUint32(byteOffset: number, value: number, littleEndian?: boolean): void;
+}
+interface DataViewConstructor {
+    readonly prototype: DataView<ArrayBufferLike>;
+    new <TArrayBuffer extends ArrayBufferLike & { BYTES_PER_ELEMENT?: never; }>(buffer: TArrayBuffer, byteOffset?: number, byteLength?: number): DataView<TArrayBuffer>;
+}
+declare var DataView: DataViewConstructor;
+
+/**
+ * A typed array of 8-bit integer values. The contents are initialized to 0. If the requested
+ * number of bytes could not be allocated an exception is raised.
+ */
+interface Int8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * The ArrayBuffer instance referenced by the array.
+     */
+    readonly buffer: TArrayBuffer;
+
+    /**
+     * The length in bytes of the array.
+     */
+    readonly byteLength: number;
+
+    /**
+     * The offset in bytes of the array.
+     */
+    readonly byteOffset: number;
+
+    /**
+     * Returns the this object after copying a section of the array identified by start and end
+     * to the same array starting at position target
+     * @param target If target is negative, it is treated as length+target where length is the
+     * length of the array.
+     * @param start If start is negative, it is treated as length+start. If end is negative, it
+     * is treated as length+end.
+     * @param end If not specified, length of the this object is used as its default value.
+     */
+    copyWithin(target: number, start: number, end?: number): this;
+
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+     * @param value value to fill array section with
+     * @param start index to start filling the array at. If start is negative, it is treated as
+     * length+start where length is the length of the array.
+     * @param end index to stop filling the array at. If end is negative, it is treated as
+     * length+end.
+     */
+    fill(value: number, start?: number, end?: number): this;
+
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls
+     * the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    filter(predicate: (value: number, index: number, array: this) => any, thisArg?: any): Int8Array<ArrayBuffer>;
+
+    /**
+     * Returns the value of the first element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
+
+    /**
+     * Returns the index of the first element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number;
+
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
+
+    /**
+     * Returns the index of the first occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    indexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * Adds all the elements of an array separated by the specified separator string.
+     * @param separator A string used to separate one element of an array from the next in the
+     * resulting String. If omitted, the array elements are separated with a comma.
+     */
+    join(separator?: string): string;
+
+    /**
+     * Returns the index of the last occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    lastIndexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * The length of the array.
+     */
+    readonly length: number;
+
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that
+     * contains the results.
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Int8Array<ArrayBuffer>;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an
+     * argument instead of an array value.
+     */
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Reverses the elements in an Array.
+     */
+    reverse(): this;
+
+    /**
+     * Sets a value or an array of values.
+     * @param array A typed or untyped array of values to set.
+     * @param offset The index in the current array at which the values are to be written.
+     */
+    set(array: ArrayLike<number>, offset?: number): void;
+
+    /**
+     * Returns a section of an array.
+     * @param start The beginning of the specified portion of the array.
+     * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+     */
+    slice(start?: number, end?: number): Int8Array<ArrayBuffer>;
+
+    /**
+     * Determines whether the specified callback function returns true for any element of an array.
+     * @param predicate A function that accepts up to three arguments. The some method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value true, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    some(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Sorts an array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if first argument is less than second argument, zero if they're equal and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * [11,2,22,1].sort((a, b) => a - b)
+     * ```
+     */
+    sort(compareFn?: (a: number, b: number) => number): this;
+
+    /**
+     * Gets a new Int8Array view of the ArrayBuffer store for this array, referencing the elements
+     * at begin, inclusive, up to end, exclusive.
+     * @param begin The index of the beginning of the array.
+     * @param end The index of the end of the array.
+     */
+    subarray(begin?: number, end?: number): Int8Array<TArrayBuffer>;
+
+    /**
+     * Converts a number to a string by using the current locale.
+     */
+    toLocaleString(): string;
+
+    /**
+     * Returns a string representation of an array.
+     */
+    toString(): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): this;
+
+    [index: number]: number;
+}
+interface Int8ArrayConstructor {
+    readonly prototype: Int8Array<ArrayBufferLike>;
+    new (length: number): Int8Array<ArrayBuffer>;
+    new (array: ArrayLike<number>): Int8Array<ArrayBuffer>;
+    new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): Int8Array<TArrayBuffer>;
+    new (buffer: ArrayBuffer, byteOffset?: number, length?: number): Int8Array<ArrayBuffer>;
+    new (array: ArrayLike<number> | ArrayBuffer): Int8Array<ArrayBuffer>;
+
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * Returns a new array from a set of elements.
+     * @param items A set of elements to include in the new array object.
+     */
+    of(...items: number[]): Int8Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     */
+    from(arrayLike: ArrayLike<number>): Int8Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Int8Array<ArrayBuffer>;
+}
+declare var Int8Array: Int8ArrayConstructor;
+
+/**
+ * A typed array of 8-bit unsigned integer values. The contents are initialized to 0. If the
+ * requested number of bytes could not be allocated an exception is raised.
+ */
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * The ArrayBuffer instance referenced by the array.
+     */
+    readonly buffer: TArrayBuffer;
+
+    /**
+     * The length in bytes of the array.
+     */
+    readonly byteLength: number;
+
+    /**
+     * The offset in bytes of the array.
+     */
+    readonly byteOffset: number;
+
+    /**
+     * Returns the this object after copying a section of the array identified by start and end
+     * to the same array starting at position target
+     * @param target If target is negative, it is treated as length+target where length is the
+     * length of the array.
+     * @param start If start is negative, it is treated as length+start. If end is negative, it
+     * is treated as length+end.
+     * @param end If not specified, length of the this object is used as its default value.
+     */
+    copyWithin(target: number, start: number, end?: number): this;
+
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+     * @param value value to fill array section with
+     * @param start index to start filling the array at. If start is negative, it is treated as
+     * length+start where length is the length of the array.
+     * @param end index to stop filling the array at. If end is negative, it is treated as
+     * length+end.
+     */
+    fill(value: number, start?: number, end?: number): this;
+
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls
+     * the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    filter(predicate: (value: number, index: number, array: this) => any, thisArg?: any): Uint8Array<ArrayBuffer>;
+
+    /**
+     * Returns the value of the first element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
+
+    /**
+     * Returns the index of the first element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number;
+
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
+
+    /**
+     * Returns the index of the first occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    indexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * Adds all the elements of an array separated by the specified separator string.
+     * @param separator A string used to separate one element of an array from the next in the
+     * resulting String. If omitted, the array elements are separated with a comma.
+     */
+    join(separator?: string): string;
+
+    /**
+     * Returns the index of the last occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    lastIndexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * The length of the array.
+     */
+    readonly length: number;
+
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that
+     * contains the results.
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Uint8Array<ArrayBuffer>;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an
+     * argument instead of an array value.
+     */
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Reverses the elements in an Array.
+     */
+    reverse(): this;
+
+    /**
+     * Sets a value or an array of values.
+     * @param array A typed or untyped array of values to set.
+     * @param offset The index in the current array at which the values are to be written.
+     */
+    set(array: ArrayLike<number>, offset?: number): void;
+
+    /**
+     * Returns a section of an array.
+     * @param start The beginning of the specified portion of the array.
+     * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+     */
+    slice(start?: number, end?: number): Uint8Array<ArrayBuffer>;
+
+    /**
+     * Determines whether the specified callback function returns true for any element of an array.
+     * @param predicate A function that accepts up to three arguments. The some method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value true, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    some(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Sorts an array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if first argument is less than second argument, zero if they're equal and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * [11,2,22,1].sort((a, b) => a - b)
+     * ```
+     */
+    sort(compareFn?: (a: number, b: number) => number): this;
+
+    /**
+     * Gets a new Uint8Array view of the ArrayBuffer store for this array, referencing the elements
+     * at begin, inclusive, up to end, exclusive.
+     * @param begin The index of the beginning of the array.
+     * @param end The index of the end of the array.
+     */
+    subarray(begin?: number, end?: number): Uint8Array<TArrayBuffer>;
+
+    /**
+     * Converts a number to a string by using the current locale.
+     */
+    toLocaleString(): string;
+
+    /**
+     * Returns a string representation of an array.
+     */
+    toString(): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): this;
+
+    [index: number]: number;
+}
+interface Uint8ArrayConstructor {
+    readonly prototype: Uint8Array<ArrayBufferLike>;
+    new (length: number): Uint8Array<ArrayBuffer>;
+    new (array: ArrayLike<number>): Uint8Array<ArrayBuffer>;
+    new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): Uint8Array<TArrayBuffer>;
+    new (buffer: ArrayBuffer, byteOffset?: number, length?: number): Uint8Array<ArrayBuffer>;
+    new (array: ArrayLike<number> | ArrayBuffer): Uint8Array<ArrayBuffer>;
+
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * Returns a new array from a set of elements.
+     * @param items A set of elements to include in the new array object.
+     */
+    of(...items: number[]): Uint8Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     */
+    from(arrayLike: ArrayLike<number>): Uint8Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint8Array<ArrayBuffer>;
+}
+declare var Uint8Array: Uint8ArrayConstructor;
+
+/**
+ * A typed array of 8-bit unsigned integer (clamped) values. The contents are initialized to 0.
+ * If the requested number of bytes could not be allocated an exception is raised.
+ */
+interface Uint8ClampedArray<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * The ArrayBuffer instance referenced by the array.
+     */
+    readonly buffer: TArrayBuffer;
+
+    /**
+     * The length in bytes of the array.
+     */
+    readonly byteLength: number;
+
+    /**
+     * The offset in bytes of the array.
+     */
+    readonly byteOffset: number;
+
+    /**
+     * Returns the this object after copying a section of the array identified by start and end
+     * to the same array starting at position target
+     * @param target If target is negative, it is treated as length+target where length is the
+     * length of the array.
+     * @param start If start is negative, it is treated as length+start. If end is negative, it
+     * is treated as length+end.
+     * @param end If not specified, length of the this object is used as its default value.
+     */
+    copyWithin(target: number, start: number, end?: number): this;
+
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+     * @param value value to fill array section with
+     * @param start index to start filling the array at. If start is negative, it is treated as
+     * length+start where length is the length of the array.
+     * @param end index to stop filling the array at. If end is negative, it is treated as
+     * length+end.
+     */
+    fill(value: number, start?: number, end?: number): this;
+
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls
+     * the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    filter(predicate: (value: number, index: number, array: this) => any, thisArg?: any): Uint8ClampedArray<ArrayBuffer>;
+
+    /**
+     * Returns the value of the first element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
+
+    /**
+     * Returns the index of the first element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number;
+
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
+
+    /**
+     * Returns the index of the first occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    indexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * Adds all the elements of an array separated by the specified separator string.
+     * @param separator A string used to separate one element of an array from the next in the
+     * resulting String. If omitted, the array elements are separated with a comma.
+     */
+    join(separator?: string): string;
+
+    /**
+     * Returns the index of the last occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    lastIndexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * The length of the array.
+     */
+    readonly length: number;
+
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that
+     * contains the results.
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Uint8ClampedArray<ArrayBuffer>;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an
+     * argument instead of an array value.
+     */
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Reverses the elements in an Array.
+     */
+    reverse(): this;
+
+    /**
+     * Sets a value or an array of values.
+     * @param array A typed or untyped array of values to set.
+     * @param offset The index in the current array at which the values are to be written.
+     */
+    set(array: ArrayLike<number>, offset?: number): void;
+
+    /**
+     * Returns a section of an array.
+     * @param start The beginning of the specified portion of the array.
+     * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+     */
+    slice(start?: number, end?: number): Uint8ClampedArray<ArrayBuffer>;
+
+    /**
+     * Determines whether the specified callback function returns true for any element of an array.
+     * @param predicate A function that accepts up to three arguments. The some method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value true, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    some(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Sorts an array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if first argument is less than second argument, zero if they're equal and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * [11,2,22,1].sort((a, b) => a - b)
+     * ```
+     */
+    sort(compareFn?: (a: number, b: number) => number): this;
+
+    /**
+     * Gets a new Uint8ClampedArray view of the ArrayBuffer store for this array, referencing the elements
+     * at begin, inclusive, up to end, exclusive.
+     * @param begin The index of the beginning of the array.
+     * @param end The index of the end of the array.
+     */
+    subarray(begin?: number, end?: number): Uint8ClampedArray<TArrayBuffer>;
+
+    /**
+     * Converts a number to a string by using the current locale.
+     */
+    toLocaleString(): string;
+
+    /**
+     * Returns a string representation of an array.
+     */
+    toString(): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): this;
+
+    [index: number]: number;
+}
+interface Uint8ClampedArrayConstructor {
+    readonly prototype: Uint8ClampedArray<ArrayBufferLike>;
+    new (length: number): Uint8ClampedArray<ArrayBuffer>;
+    new (array: ArrayLike<number>): Uint8ClampedArray<ArrayBuffer>;
+    new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): Uint8ClampedArray<TArrayBuffer>;
+    new (buffer: ArrayBuffer, byteOffset?: number, length?: number): Uint8ClampedArray<ArrayBuffer>;
+    new (array: ArrayLike<number> | ArrayBuffer): Uint8ClampedArray<ArrayBuffer>;
+
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * Returns a new array from a set of elements.
+     * @param items A set of elements to include in the new array object.
+     */
+    of(...items: number[]): Uint8ClampedArray<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     */
+    from(arrayLike: ArrayLike<number>): Uint8ClampedArray<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint8ClampedArray<ArrayBuffer>;
+}
+declare var Uint8ClampedArray: Uint8ClampedArrayConstructor;
+
+/**
+ * A typed array of 16-bit signed integer values. The contents are initialized to 0. If the
+ * requested number of bytes could not be allocated an exception is raised.
+ */
+interface Int16Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * The ArrayBuffer instance referenced by the array.
+     */
+    readonly buffer: TArrayBuffer;
+
+    /**
+     * The length in bytes of the array.
+     */
+    readonly byteLength: number;
+
+    /**
+     * The offset in bytes of the array.
+     */
+    readonly byteOffset: number;
+
+    /**
+     * Returns the this object after copying a section of the array identified by start and end
+     * to the same array starting at position target
+     * @param target If target is negative, it is treated as length+target where length is the
+     * length of the array.
+     * @param start If start is negative, it is treated as length+start. If end is negative, it
+     * is treated as length+end.
+     * @param end If not specified, length of the this object is used as its default value.
+     */
+    copyWithin(target: number, start: number, end?: number): this;
+
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+     * @param value value to fill array section with
+     * @param start index to start filling the array at. If start is negative, it is treated as
+     * length+start where length is the length of the array.
+     * @param end index to stop filling the array at. If end is negative, it is treated as
+     * length+end.
+     */
+    fill(value: number, start?: number, end?: number): this;
+
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls
+     * the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    filter(predicate: (value: number, index: number, array: this) => any, thisArg?: any): Int16Array<ArrayBuffer>;
+
+    /**
+     * Returns the value of the first element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
+
+    /**
+     * Returns the index of the first element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number;
+
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
+    /**
+     * Returns the index of the first occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    indexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * Adds all the elements of an array separated by the specified separator string.
+     * @param separator A string used to separate one element of an array from the next in the
+     * resulting String. If omitted, the array elements are separated with a comma.
+     */
+    join(separator?: string): string;
+
+    /**
+     * Returns the index of the last occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    lastIndexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * The length of the array.
+     */
+    readonly length: number;
+
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that
+     * contains the results.
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Int16Array<ArrayBuffer>;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an
+     * argument instead of an array value.
+     */
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Reverses the elements in an Array.
+     */
+    reverse(): this;
+
+    /**
+     * Sets a value or an array of values.
+     * @param array A typed or untyped array of values to set.
+     * @param offset The index in the current array at which the values are to be written.
+     */
+    set(array: ArrayLike<number>, offset?: number): void;
+
+    /**
+     * Returns a section of an array.
+     * @param start The beginning of the specified portion of the array.
+     * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+     */
+    slice(start?: number, end?: number): Int16Array<ArrayBuffer>;
+
+    /**
+     * Determines whether the specified callback function returns true for any element of an array.
+     * @param predicate A function that accepts up to three arguments. The some method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value true, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    some(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Sorts an array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if first argument is less than second argument, zero if they're equal and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * [11,2,22,1].sort((a, b) => a - b)
+     * ```
+     */
+    sort(compareFn?: (a: number, b: number) => number): this;
+
+    /**
+     * Gets a new Int16Array view of the ArrayBuffer store for this array, referencing the elements
+     * at begin, inclusive, up to end, exclusive.
+     * @param begin The index of the beginning of the array.
+     * @param end The index of the end of the array.
+     */
+    subarray(begin?: number, end?: number): Int16Array<TArrayBuffer>;
+
+    /**
+     * Converts a number to a string by using the current locale.
+     */
+    toLocaleString(): string;
+
+    /**
+     * Returns a string representation of an array.
+     */
+    toString(): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): this;
+
+    [index: number]: number;
+}
+interface Int16ArrayConstructor {
+    readonly prototype: Int16Array<ArrayBufferLike>;
+    new (length: number): Int16Array<ArrayBuffer>;
+    new (array: ArrayLike<number>): Int16Array<ArrayBuffer>;
+    new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): Int16Array<TArrayBuffer>;
+    new (buffer: ArrayBuffer, byteOffset?: number, length?: number): Int16Array<ArrayBuffer>;
+    new (array: ArrayLike<number> | ArrayBuffer): Int16Array<ArrayBuffer>;
+
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * Returns a new array from a set of elements.
+     * @param items A set of elements to include in the new array object.
+     */
+    of(...items: number[]): Int16Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     */
+    from(arrayLike: ArrayLike<number>): Int16Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Int16Array<ArrayBuffer>;
+}
+declare var Int16Array: Int16ArrayConstructor;
+
+/**
+ * A typed array of 16-bit unsigned integer values. The contents are initialized to 0. If the
+ * requested number of bytes could not be allocated an exception is raised.
+ */
+interface Uint16Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * The ArrayBuffer instance referenced by the array.
+     */
+    readonly buffer: TArrayBuffer;
+
+    /**
+     * The length in bytes of the array.
+     */
+    readonly byteLength: number;
+
+    /**
+     * The offset in bytes of the array.
+     */
+    readonly byteOffset: number;
+
+    /**
+     * Returns the this object after copying a section of the array identified by start and end
+     * to the same array starting at position target
+     * @param target If target is negative, it is treated as length+target where length is the
+     * length of the array.
+     * @param start If start is negative, it is treated as length+start. If end is negative, it
+     * is treated as length+end.
+     * @param end If not specified, length of the this object is used as its default value.
+     */
+    copyWithin(target: number, start: number, end?: number): this;
+
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+     * @param value value to fill array section with
+     * @param start index to start filling the array at. If start is negative, it is treated as
+     * length+start where length is the length of the array.
+     * @param end index to stop filling the array at. If end is negative, it is treated as
+     * length+end.
+     */
+    fill(value: number, start?: number, end?: number): this;
+
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls
+     * the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    filter(predicate: (value: number, index: number, array: this) => any, thisArg?: any): Uint16Array<ArrayBuffer>;
+
+    /**
+     * Returns the value of the first element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
+
+    /**
+     * Returns the index of the first element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number;
+
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
+
+    /**
+     * Returns the index of the first occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    indexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * Adds all the elements of an array separated by the specified separator string.
+     * @param separator A string used to separate one element of an array from the next in the
+     * resulting String. If omitted, the array elements are separated with a comma.
+     */
+    join(separator?: string): string;
+
+    /**
+     * Returns the index of the last occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    lastIndexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * The length of the array.
+     */
+    readonly length: number;
+
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that
+     * contains the results.
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Uint16Array<ArrayBuffer>;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an
+     * argument instead of an array value.
+     */
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Reverses the elements in an Array.
+     */
+    reverse(): this;
+
+    /**
+     * Sets a value or an array of values.
+     * @param array A typed or untyped array of values to set.
+     * @param offset The index in the current array at which the values are to be written.
+     */
+    set(array: ArrayLike<number>, offset?: number): void;
+
+    /**
+     * Returns a section of an array.
+     * @param start The beginning of the specified portion of the array.
+     * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+     */
+    slice(start?: number, end?: number): Uint16Array<ArrayBuffer>;
+
+    /**
+     * Determines whether the specified callback function returns true for any element of an array.
+     * @param predicate A function that accepts up to three arguments. The some method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value true, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    some(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Sorts an array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if first argument is less than second argument, zero if they're equal and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * [11,2,22,1].sort((a, b) => a - b)
+     * ```
+     */
+    sort(compareFn?: (a: number, b: number) => number): this;
+
+    /**
+     * Gets a new Uint16Array view of the ArrayBuffer store for this array, referencing the elements
+     * at begin, inclusive, up to end, exclusive.
+     * @param begin The index of the beginning of the array.
+     * @param end The index of the end of the array.
+     */
+    subarray(begin?: number, end?: number): Uint16Array<TArrayBuffer>;
+
+    /**
+     * Converts a number to a string by using the current locale.
+     */
+    toLocaleString(): string;
+
+    /**
+     * Returns a string representation of an array.
+     */
+    toString(): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): this;
+
+    [index: number]: number;
+}
+interface Uint16ArrayConstructor {
+    readonly prototype: Uint16Array<ArrayBufferLike>;
+    new (length: number): Uint16Array<ArrayBuffer>;
+    new (array: ArrayLike<number>): Uint16Array<ArrayBuffer>;
+    new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): Uint16Array<TArrayBuffer>;
+    new (buffer: ArrayBuffer, byteOffset?: number, length?: number): Uint16Array<ArrayBuffer>;
+    new (array: ArrayLike<number> | ArrayBuffer): Uint16Array<ArrayBuffer>;
+
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * Returns a new array from a set of elements.
+     * @param items A set of elements to include in the new array object.
+     */
+    of(...items: number[]): Uint16Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     */
+    from(arrayLike: ArrayLike<number>): Uint16Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint16Array<ArrayBuffer>;
+}
+declare var Uint16Array: Uint16ArrayConstructor;
+/**
+ * A typed array of 32-bit signed integer values. The contents are initialized to 0. If the
+ * requested number of bytes could not be allocated an exception is raised.
+ */
+interface Int32Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * The ArrayBuffer instance referenced by the array.
+     */
+    readonly buffer: TArrayBuffer;
+
+    /**
+     * The length in bytes of the array.
+     */
+    readonly byteLength: number;
+
+    /**
+     * The offset in bytes of the array.
+     */
+    readonly byteOffset: number;
+
+    /**
+     * Returns the this object after copying a section of the array identified by start and end
+     * to the same array starting at position target
+     * @param target If target is negative, it is treated as length+target where length is the
+     * length of the array.
+     * @param start If start is negative, it is treated as length+start. If end is negative, it
+     * is treated as length+end.
+     * @param end If not specified, length of the this object is used as its default value.
+     */
+    copyWithin(target: number, start: number, end?: number): this;
+
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+     * @param value value to fill array section with
+     * @param start index to start filling the array at. If start is negative, it is treated as
+     * length+start where length is the length of the array.
+     * @param end index to stop filling the array at. If end is negative, it is treated as
+     * length+end.
+     */
+    fill(value: number, start?: number, end?: number): this;
+
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls
+     * the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    filter(predicate: (value: number, index: number, array: this) => any, thisArg?: any): Int32Array<ArrayBuffer>;
+
+    /**
+     * Returns the value of the first element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
+
+    /**
+     * Returns the index of the first element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number;
+
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
+
+    /**
+     * Returns the index of the first occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    indexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * Adds all the elements of an array separated by the specified separator string.
+     * @param separator A string used to separate one element of an array from the next in the
+     * resulting String. If omitted, the array elements are separated with a comma.
+     */
+    join(separator?: string): string;
+
+    /**
+     * Returns the index of the last occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    lastIndexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * The length of the array.
+     */
+    readonly length: number;
+
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that
+     * contains the results.
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Int32Array<ArrayBuffer>;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an
+     * argument instead of an array value.
+     */
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Reverses the elements in an Array.
+     */
+    reverse(): this;
+
+    /**
+     * Sets a value or an array of values.
+     * @param array A typed or untyped array of values to set.
+     * @param offset The index in the current array at which the values are to be written.
+     */
+    set(array: ArrayLike<number>, offset?: number): void;
+
+    /**
+     * Returns a section of an array.
+     * @param start The beginning of the specified portion of the array.
+     * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+     */
+    slice(start?: number, end?: number): Int32Array<ArrayBuffer>;
+
+    /**
+     * Determines whether the specified callback function returns true for any element of an array.
+     * @param predicate A function that accepts up to three arguments. The some method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value true, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    some(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Sorts an array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if first argument is less than second argument, zero if they're equal and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * [11,2,22,1].sort((a, b) => a - b)
+     * ```
+     */
+    sort(compareFn?: (a: number, b: number) => number): this;
+
+    /**
+     * Gets a new Int32Array view of the ArrayBuffer store for this array, referencing the elements
+     * at begin, inclusive, up to end, exclusive.
+     * @param begin The index of the beginning of the array.
+     * @param end The index of the end of the array.
+     */
+    subarray(begin?: number, end?: number): Int32Array<TArrayBuffer>;
+
+    /**
+     * Converts a number to a string by using the current locale.
+     */
+    toLocaleString(): string;
+
+    /**
+     * Returns a string representation of an array.
+     */
+    toString(): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): this;
+
+    [index: number]: number;
+}
+interface Int32ArrayConstructor {
+    readonly prototype: Int32Array<ArrayBufferLike>;
+    new (length: number): Int32Array<ArrayBuffer>;
+    new (array: ArrayLike<number>): Int32Array<ArrayBuffer>;
+    new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): Int32Array<TArrayBuffer>;
+    new (buffer: ArrayBuffer, byteOffset?: number, length?: number): Int32Array<ArrayBuffer>;
+    new (array: ArrayLike<number> | ArrayBuffer): Int32Array<ArrayBuffer>;
+
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * Returns a new array from a set of elements.
+     * @param items A set of elements to include in the new array object.
+     */
+    of(...items: number[]): Int32Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     */
+    from(arrayLike: ArrayLike<number>): Int32Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Int32Array<ArrayBuffer>;
+}
+declare var Int32Array: Int32ArrayConstructor;
+
+/**
+ * A typed array of 32-bit unsigned integer values. The contents are initialized to 0. If the
+ * requested number of bytes could not be allocated an exception is raised.
+ */
+interface Uint32Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * The ArrayBuffer instance referenced by the array.
+     */
+    readonly buffer: TArrayBuffer;
+
+    /**
+     * The length in bytes of the array.
+     */
+    readonly byteLength: number;
+
+    /**
+     * The offset in bytes of the array.
+     */
+    readonly byteOffset: number;
+
+    /**
+     * Returns the this object after copying a section of the array identified by start and end
+     * to the same array starting at position target
+     * @param target If target is negative, it is treated as length+target where length is the
+     * length of the array.
+     * @param start If start is negative, it is treated as length+start. If end is negative, it
+     * is treated as length+end.
+     * @param end If not specified, length of the this object is used as its default value.
+     */
+    copyWithin(target: number, start: number, end?: number): this;
+
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+     * @param value value to fill array section with
+     * @param start index to start filling the array at. If start is negative, it is treated as
+     * length+start where length is the length of the array.
+     * @param end index to stop filling the array at. If end is negative, it is treated as
+     * length+end.
+     */
+    fill(value: number, start?: number, end?: number): this;
+
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls
+     * the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    filter(predicate: (value: number, index: number, array: this) => any, thisArg?: any): Uint32Array<ArrayBuffer>;
+
+    /**
+     * Returns the value of the first element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
+
+    /**
+     * Returns the index of the first element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number;
+
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
+    /**
+     * Returns the index of the first occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    indexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * Adds all the elements of an array separated by the specified separator string.
+     * @param separator A string used to separate one element of an array from the next in the
+     * resulting String. If omitted, the array elements are separated with a comma.
+     */
+    join(separator?: string): string;
+
+    /**
+     * Returns the index of the last occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    lastIndexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * The length of the array.
+     */
+    readonly length: number;
+
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that
+     * contains the results.
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Uint32Array<ArrayBuffer>;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an
+     * argument instead of an array value.
+     */
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Reverses the elements in an Array.
+     */
+    reverse(): this;
+
+    /**
+     * Sets a value or an array of values.
+     * @param array A typed or untyped array of values to set.
+     * @param offset The index in the current array at which the values are to be written.
+     */
+    set(array: ArrayLike<number>, offset?: number): void;
+
+    /**
+     * Returns a section of an array.
+     * @param start The beginning of the specified portion of the array.
+     * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+     */
+    slice(start?: number, end?: number): Uint32Array<ArrayBuffer>;
+
+    /**
+     * Determines whether the specified callback function returns true for any element of an array.
+     * @param predicate A function that accepts up to three arguments. The some method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value true, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    some(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Sorts an array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if first argument is less than second argument, zero if they're equal and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * [11,2,22,1].sort((a, b) => a - b)
+     * ```
+     */
+    sort(compareFn?: (a: number, b: number) => number): this;
+
+    /**
+     * Gets a new Uint32Array view of the ArrayBuffer store for this array, referencing the elements
+     * at begin, inclusive, up to end, exclusive.
+     * @param begin The index of the beginning of the array.
+     * @param end The index of the end of the array.
+     */
+    subarray(begin?: number, end?: number): Uint32Array<TArrayBuffer>;
+
+    /**
+     * Converts a number to a string by using the current locale.
+     */
+    toLocaleString(): string;
+
+    /**
+     * Returns a string representation of an array.
+     */
+    toString(): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): this;
+
+    [index: number]: number;
+}
+interface Uint32ArrayConstructor {
+    readonly prototype: Uint32Array<ArrayBufferLike>;
+    new (length: number): Uint32Array<ArrayBuffer>;
+    new (array: ArrayLike<number>): Uint32Array<ArrayBuffer>;
+    new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): Uint32Array<TArrayBuffer>;
+    new (buffer: ArrayBuffer, byteOffset?: number, length?: number): Uint32Array<ArrayBuffer>;
+    new (array: ArrayLike<number> | ArrayBuffer): Uint32Array<ArrayBuffer>;
+
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * Returns a new array from a set of elements.
+     * @param items A set of elements to include in the new array object.
+     */
+    of(...items: number[]): Uint32Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     */
+    from(arrayLike: ArrayLike<number>): Uint32Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint32Array<ArrayBuffer>;
+}
+declare var Uint32Array: Uint32ArrayConstructor;
+
+/**
+ * A typed array of 32-bit float values. The contents are initialized to 0. If the requested number
+ * of bytes could not be allocated an exception is raised.
+ */
+interface Float32Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * The ArrayBuffer instance referenced by the array.
+     */
+    readonly buffer: TArrayBuffer;
+
+    /**
+     * The length in bytes of the array.
+     */
+    readonly byteLength: number;
+
+    /**
+     * The offset in bytes of the array.
+     */
+    readonly byteOffset: number;
+
+    /**
+     * Returns the this object after copying a section of the array identified by start and end
+     * to the same array starting at position target
+     * @param target If target is negative, it is treated as length+target where length is the
+     * length of the array.
+     * @param start If start is negative, it is treated as length+start. If end is negative, it
+     * is treated as length+end.
+     * @param end If not specified, length of the this object is used as its default value.
+     */
+    copyWithin(target: number, start: number, end?: number): this;
+
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+     * @param value value to fill array section with
+     * @param start index to start filling the array at. If start is negative, it is treated as
+     * length+start where length is the length of the array.
+     * @param end index to stop filling the array at. If end is negative, it is treated as
+     * length+end.
+     */
+    fill(value: number, start?: number, end?: number): this;
+
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls
+     * the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    filter(predicate: (value: number, index: number, array: this) => any, thisArg?: any): Float32Array<ArrayBuffer>;
+
+    /**
+     * Returns the value of the first element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
+
+    /**
+     * Returns the index of the first element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number;
+
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
+
+    /**
+     * Returns the index of the first occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    indexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * Adds all the elements of an array separated by the specified separator string.
+     * @param separator A string used to separate one element of an array from the next in the
+     * resulting String. If omitted, the array elements are separated with a comma.
+     */
+    join(separator?: string): string;
+
+    /**
+     * Returns the index of the last occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    lastIndexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * The length of the array.
+     */
+    readonly length: number;
+
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that
+     * contains the results.
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Float32Array<ArrayBuffer>;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an
+     * argument instead of an array value.
+     */
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Reverses the elements in an Array.
+     */
+    reverse(): this;
+
+    /**
+     * Sets a value or an array of values.
+     * @param array A typed or untyped array of values to set.
+     * @param offset The index in the current array at which the values are to be written.
+     */
+    set(array: ArrayLike<number>, offset?: number): void;
+
+    /**
+     * Returns a section of an array.
+     * @param start The beginning of the specified portion of the array.
+     * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+     */
+    slice(start?: number, end?: number): Float32Array<ArrayBuffer>;
+
+    /**
+     * Determines whether the specified callback function returns true for any element of an array.
+     * @param predicate A function that accepts up to three arguments. The some method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value true, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    some(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Sorts an array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if first argument is less than second argument, zero if they're equal and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * [11,2,22,1].sort((a, b) => a - b)
+     * ```
+     */
+    sort(compareFn?: (a: number, b: number) => number): this;
+
+    /**
+     * Gets a new Float32Array view of the ArrayBuffer store for this array, referencing the elements
+     * at begin, inclusive, up to end, exclusive.
+     * @param begin The index of the beginning of the array.
+     * @param end The index of the end of the array.
+     */
+    subarray(begin?: number, end?: number): Float32Array<TArrayBuffer>;
+
+    /**
+     * Converts a number to a string by using the current locale.
+     */
+    toLocaleString(): string;
+
+    /**
+     * Returns a string representation of an array.
+     */
+    toString(): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): this;
+
+    [index: number]: number;
+}
+interface Float32ArrayConstructor {
+    readonly prototype: Float32Array<ArrayBufferLike>;
+    new (length: number): Float32Array<ArrayBuffer>;
+    new (array: ArrayLike<number>): Float32Array<ArrayBuffer>;
+    new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): Float32Array<TArrayBuffer>;
+    new (buffer: ArrayBuffer, byteOffset?: number, length?: number): Float32Array<ArrayBuffer>;
+    new (array: ArrayLike<number> | ArrayBuffer): Float32Array<ArrayBuffer>;
+
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * Returns a new array from a set of elements.
+     * @param items A set of elements to include in the new array object.
+     */
+    of(...items: number[]): Float32Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     */
+    from(arrayLike: ArrayLike<number>): Float32Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Float32Array<ArrayBuffer>;
+}
+declare var Float32Array: Float32ArrayConstructor;
+
+/**
+ * A typed array of 64-bit float values. The contents are initialized to 0. If the requested
+ * number of bytes could not be allocated an exception is raised.
+ */
+interface Float64Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * The ArrayBuffer instance referenced by the array.
+     */
+    readonly buffer: TArrayBuffer;
+
+    /**
+     * The length in bytes of the array.
+     */
+    readonly byteLength: number;
+
+    /**
+     * The offset in bytes of the array.
+     */
+    readonly byteOffset: number;
+
+    /**
+     * Returns the this object after copying a section of the array identified by start and end
+     * to the same array starting at position target
+     * @param target If target is negative, it is treated as length+target where length is the
+     * length of the array.
+     * @param start If start is negative, it is treated as length+start. If end is negative, it
+     * is treated as length+end.
+     * @param end If not specified, length of the this object is used as its default value.
+     */
+    copyWithin(target: number, start: number, end?: number): this;
+
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value false, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+     * @param value value to fill array section with
+     * @param start index to start filling the array at. If start is negative, it is treated as
+     * length+start where length is the length of the array.
+     * @param end index to stop filling the array at. If end is negative, it is treated as
+     * length+end.
+     */
+    fill(value: number, start?: number, end?: number): this;
+
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls
+     * the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    filter(predicate: (value: number, index: number, array: this) => any, thisArg?: any): Float64Array<ArrayBuffer>;
+
+    /**
+     * Returns the value of the first element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
+
+    /**
+     * Returns the index of the first element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number;
+
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
+
+    /**
+     * Returns the index of the first occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    indexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * Adds all the elements of an array separated by the specified separator string.
+     * @param separator A string used to separate one element of an array from the next in the
+     * resulting String. If omitted, the array elements are separated with a comma.
+     */
+    join(separator?: string): string;
+
+    /**
+     * Returns the index of the last occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    lastIndexOf(searchElement: number, fromIndex?: number): number;
+
+    /**
+     * The length of the array.
+     */
+    readonly length: number;
+
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that
+     * contains the results.
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Float64Array<ArrayBuffer>;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an
+     * argument instead of an array value.
+     */
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue: number): number;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
+
+    /**
+     * Reverses the elements in an Array.
+     */
+    reverse(): this;
+
+    /**
+     * Sets a value or an array of values.
+     * @param array A typed or untyped array of values to set.
+     * @param offset The index in the current array at which the values are to be written.
+     */
+    set(array: ArrayLike<number>, offset?: number): void;
+
+    /**
+     * Returns a section of an array.
+     * @param start The beginning of the specified portion of the array.
+     * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+     */
+    slice(start?: number, end?: number): Float64Array<ArrayBuffer>;
+
+    /**
+     * Determines whether the specified callback function returns true for any element of an array.
+     * @param predicate A function that accepts up to three arguments. The some method calls
+     * the predicate function for each element in the array until the predicate returns a value
+     * which is coercible to the Boolean value true, or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    some(predicate: (value: number, index: number, array: this) => unknown, thisArg?: any): boolean;
+
+    /**
+     * Sorts an array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if first argument is less than second argument, zero if they're equal and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * [11,2,22,1].sort((a, b) => a - b)
+     * ```
+     */
+    sort(compareFn?: (a: number, b: number) => number): this;
+
+    /**
+     * Gets a new Float64Array view of the ArrayBuffer store for this array, referencing the elements
+     * at begin, inclusive, up to end, exclusive.
+     * @param begin The index of the beginning of the array.
+     * @param end The index of the end of the array.
+     */
+    subarray(begin?: number, end?: number): Float64Array<TArrayBuffer>;
+
+    /**
+     * Converts a number to a string by using the current locale.
+     */
+    toLocaleString(): string;
+
+    /**
+     * Returns a string representation of an array.
+     */
+    toString(): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): this;
+
+    [index: number]: number;
+}
+interface Float64ArrayConstructor {
+    readonly prototype: Float64Array<ArrayBufferLike>;
+    new (length: number): Float64Array<ArrayBuffer>;
+    new (array: ArrayLike<number>): Float64Array<ArrayBuffer>;
+    new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): Float64Array<TArrayBuffer>;
+    new (buffer: ArrayBuffer, byteOffset?: number, length?: number): Float64Array<ArrayBuffer>;
+    new (array: ArrayLike<number> | ArrayBuffer): Float64Array<ArrayBuffer>;
+
+    /**
+     * The size in bytes of each element in the array.
+     */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * Returns a new array from a set of elements.
+     * @param items A set of elements to include in the new array object.
+     */
+    of(...items: number[]): Float64Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     */
+    from(arrayLike: ArrayLike<number>): Float64Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Float64Array<ArrayBuffer>;
+}
+declare var Float64Array: Float64ArrayConstructor;
+
+/////////////////////////////
+/// ECMAScript Internationalization API
+/////////////////////////////
+
+declare namespace Intl {
+    interface CollatorOptions {
+        usage?: "sort" | "search" | undefined;
+        localeMatcher?: "lookup" | "best fit" | undefined;
+        numeric?: boolean | undefined;
+        caseFirst?: "upper" | "lower" | "false" | undefined;
+        sensitivity?: "base" | "accent" | "case" | "variant" | undefined;
+        collation?: "big5han" | "compat" | "dict" | "direct" | "ducet" | "emoji" | "eor" | "gb2312" | "phonebk" | "phonetic" | "pinyin" | "reformed" | "searchjl" | "stroke" | "trad" | "unihan" | "zhuyin" | undefined;
+        ignorePunctuation?: boolean | undefined;
+    }
+
+    interface ResolvedCollatorOptions {
+        locale: string;
+        usage: string;
+        sensitivity: string;
+        ignorePunctuation: boolean;
+        collation: string;
+        caseFirst: string;
+        numeric: boolean;
+    }
+
+    interface Collator {
+        compare(x: string, y: string): number;
+        resolvedOptions(): ResolvedCollatorOptions;
+    }
+
+    interface CollatorConstructor {
+        new (locales?: string | string[], options?: CollatorOptions): Collator;
+        (locales?: string | string[], options?: CollatorOptions): Collator;
+        supportedLocalesOf(locales: string | string[], options?: CollatorOptions): string[];
+    }
+
+    var Collator: CollatorConstructor;
+
+    interface NumberFormatOptionsStyleRegistry {
+        decimal: never;
+        percent: never;
+        currency: never;
+    }
+
+    type NumberFormatOptionsStyle = keyof NumberFormatOptionsStyleRegistry;
+
+    interface NumberFormatOptionsCurrencyDisplayRegistry {
+        code: never;
+        symbol: never;
+        name: never;
+    }
+
+    type NumberFormatOptionsCurrencyDisplay = keyof NumberFormatOptionsCurrencyDisplayRegistry;
+
+    interface NumberFormatOptionsUseGroupingRegistry {}
+
+    type NumberFormatOptionsUseGrouping = {} extends NumberFormatOptionsUseGroupingRegistry ? boolean : keyof NumberFormatOptionsUseGroupingRegistry | "true" | "false" | boolean;
+    type ResolvedNumberFormatOptionsUseGrouping = {} extends NumberFormatOptionsUseGroupingRegistry ? boolean : keyof NumberFormatOptionsUseGroupingRegistry | false;
+
+    interface NumberFormatOptions {
+        localeMatcher?: "lookup" | "best fit" | undefined;
+        style?: NumberFormatOptionsStyle | undefined;
+        currency?: string | undefined;
+        currencyDisplay?: NumberFormatOptionsCurrencyDisplay | undefined;
+        useGrouping?: NumberFormatOptionsUseGrouping | undefined;
+        minimumIntegerDigits?: number | undefined;
+        minimumFractionDigits?: number | undefined;
+        maximumFractionDigits?: number | undefined;
+        minimumSignificantDigits?: number | undefined;
+        maximumSignificantDigits?: number | undefined;
+    }
+
+    interface ResolvedNumberFormatOptions {
+        locale: string;
+        numberingSystem: string;
+        style: NumberFormatOptionsStyle;
+        currency?: string;
+        currencyDisplay?: NumberFormatOptionsCurrencyDisplay;
+        minimumIntegerDigits: number;
+        minimumFractionDigits?: number;
+        maximumFractionDigits?: number;
+        minimumSignificantDigits?: number;
+        maximumSignificantDigits?: number;
+        useGrouping: ResolvedNumberFormatOptionsUseGrouping;
+    }
+
+    interface NumberFormat {
+        format(value: number): string;
+        resolvedOptions(): ResolvedNumberFormatOptions;
+    }
+
+    interface NumberFormatConstructor {
+        new (locales?: string | string[], options?: NumberFormatOptions): NumberFormat;
+        (locales?: string | string[], options?: NumberFormatOptions): NumberFormat;
+        supportedLocalesOf(locales: string | string[], options?: NumberFormatOptions): string[];
+        readonly prototype: NumberFormat;
+    }
+
+    var NumberFormat: NumberFormatConstructor;
+
+    interface DateTimeFormatOptions {
+        localeMatcher?: "best fit" | "lookup" | undefined;
+        weekday?: "long" | "short" | "narrow" | undefined;
+        era?: "long" | "short" | "narrow" | undefined;
+        year?: "numeric" | "2-digit" | undefined;
+        month?: "numeric" | "2-digit" | "long" | "short" | "narrow" | undefined;
+        day?: "numeric" | "2-digit" | undefined;
+        hour?: "numeric" | "2-digit" | undefined;
+        minute?: "numeric" | "2-digit" | undefined;
+        second?: "numeric" | "2-digit" | undefined;
+        timeZoneName?: "short" | "long" | "shortOffset" | "longOffset" | "shortGeneric" | "longGeneric" | undefined;
+        formatMatcher?: "best fit" | "basic" | undefined;
+        hour12?: boolean | undefined;
+        timeZone?: string | undefined;
+    }
+
+    interface ResolvedDateTimeFormatOptions {
+        locale: string;
+        calendar: string;
+        numberingSystem: string;
+        timeZone: string;
+        hour12?: boolean;
+        weekday?: string;
+        era?: string;
+        year?: string;
+        month?: string;
+        day?: string;
+        hour?: string;
+        minute?: string;
+        second?: string;
+        timeZoneName?: string;
+    }
+
+    interface DateTimeFormat {
+        format(date?: Date | number): string;
+        resolvedOptions(): ResolvedDateTimeFormatOptions;
+    }
+
+    interface DateTimeFormatConstructor {
+        new (locales?: string | string[], options?: DateTimeFormatOptions): DateTimeFormat;
+        (locales?: string | string[], options?: DateTimeFormatOptions): DateTimeFormat;
+        supportedLocalesOf(locales: string | string[], options?: DateTimeFormatOptions): string[];
+        readonly prototype: DateTimeFormat;
+    }
+
+    var DateTimeFormat: DateTimeFormatConstructor;
+}
+
+interface String {
+    /**
+     * Determines whether two strings are equivalent in the current or specified locale.
+     * @param that String to compare to target string
+     * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used. This parameter must conform to BCP 47 standards; see the Intl.Collator object for details.
+     * @param options An object that contains one or more properties that specify comparison options. see the Intl.Collator object for details.
+     */
+    localeCompare(that: string, locales?: string | string[], options?: Intl.CollatorOptions): number;
+}
+
+interface Number {
+    /**
+     * Converts a number to a string by using the current or specified locale.
+     * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
+     * @param options An object that contains one or more properties that specify comparison options.
+     */
+    toLocaleString(locales?: string | string[], options?: Intl.NumberFormatOptions): string;
+}
+
+interface Date {
+    /**
+     * Converts a date and time to a string by using the current or specified locale.
+     * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
+     * @param options An object that contains one or more properties that specify comparison options.
+     */
+    toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
+    /**
+     * Converts a date to a string by using the current or specified locale.
+     * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
+     * @param options An object that contains one or more properties that specify comparison options.
+     */
+    toLocaleDateString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
+
+    /**
+     * Converts a time to a string by using the current or specified locale.
+     * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
+     * @param options An object that contains one or more properties that specify comparison options.
+     */
+    toLocaleTimeString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
+}
+
+interface Array<T> {
+    /**
+     * Returns the value of the first element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    find<S extends T>(predicate: (value: T, index: number, obj: T[]) => value is S, thisArg?: any): S | undefined;
+    find(predicate: (value: T, index: number, obj: T[]) => unknown, thisArg?: any): T | undefined;
+
+    /**
+     * Returns the index of the first element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findIndex(predicate: (value: T, index: number, obj: T[]) => unknown, thisArg?: any): number;
+
+    /**
+     * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+     * @param value value to fill array section with
+     * @param start index to start filling the array at. If start is negative, it is treated as
+     * length+start where length is the length of the array.
+     * @param end index to stop filling the array at. If end is negative, it is treated as
+     * length+end.
+     */
+    fill(value: T, start?: number, end?: number): this;
+
+    /**
+     * Returns the this object after copying a section of the array identified by start and end
+     * to the same array starting at position target
+     * @param target If target is negative, it is treated as length+target where length is the
+     * length of the array.
+     * @param start If start is negative, it is treated as length+start. If end is negative, it
+     * is treated as length+end.
+     * @param end If not specified, length of the this object is used as its default value.
+     */
+    copyWithin(target: number, start: number, end?: number): this;
+
+    toLocaleString(locales: string | string[], options?: Intl.NumberFormatOptions & Intl.DateTimeFormatOptions): string;
+}
+
+interface ArrayConstructor {
+    /**
+     * Creates an array from an array-like object.
+     * @param arrayLike An array-like object to convert to an array.
+     */
+    from<T>(arrayLike: ArrayLike<T>): T[];
+
+    /**
+     * Creates an array from an iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T, U>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): U[];
+
+    /**
+     * Returns a new array from a set of elements.
+     * @param items A set of elements to include in the new array object.
+     */
+    of<T>(...items: T[]): T[];
+}
+
+interface DateConstructor {
+    new (value: number | string | Date): Date;
+}
+
+interface Function {
+    /**
+     * Returns the name of the function. Function names are read-only and can not be changed.
+     */
+    readonly name: string;
+}
+
+interface Math {
+    /**
+     * Returns the number of leading zero bits in the 32-bit binary representation of a number.
+     * @param x A numeric expression.
+     */
+    clz32(x: number): number;
+
+    /**
+     * Returns the result of 32-bit multiplication of two numbers.
+     * @param x First number
+     * @param y Second number
+     */
+    imul(x: number, y: number): number;
+
+    /**
+     * Returns the sign of the x, indicating whether x is positive, negative or zero.
+     * @param x The numeric expression to test
+     */
+    sign(x: number): number;
+
+    /**
+     * Returns the base 10 logarithm of a number.
+     * @param x A numeric expression.
+     */
+    log10(x: number): number;
+
+    /**
+     * Returns the base 2 logarithm of a number.
+     * @param x A numeric expression.
+     */
+    log2(x: number): number;
+
+    /**
+     * Returns the natural logarithm of 1 + x.
+     * @param x A numeric expression.
+     */
+    log1p(x: number): number;
+
+    /**
+     * Returns the result of (e^x - 1), which is an implementation-dependent approximation to
+     * subtracting 1 from the exponential function of x (e raised to the power of x, where e
+     * is the base of the natural logarithms).
+     * @param x A numeric expression.
+     */
+    expm1(x: number): number;
+
+    /**
+     * Returns the hyperbolic cosine of a number.
+     * @param x A numeric expression that contains an angle measured in radians.
+     */
+    cosh(x: number): number;
+
+    /**
+     * Returns the hyperbolic sine of a number.
+     * @param x A numeric expression that contains an angle measured in radians.
+     */
+    sinh(x: number): number;
+
+    /**
+     * Returns the hyperbolic tangent of a number.
+     * @param x A numeric expression that contains an angle measured in radians.
+     */
+    tanh(x: number): number;
+
+    /**
+     * Returns the inverse hyperbolic cosine of a number.
+     * @param x A numeric expression that contains an angle measured in radians.
+     */
+    acosh(x: number): number;
+
+    /**
+     * Returns the inverse hyperbolic sine of a number.
+     * @param x A numeric expression that contains an angle measured in radians.
+     */
+    asinh(x: number): number;
+
+    /**
+     * Returns the inverse hyperbolic tangent of a number.
+     * @param x A numeric expression that contains an angle measured in radians.
+     */
+    atanh(x: number): number;
+
+    /**
+     * Returns the square root of the sum of squares of its arguments.
+     * @param values Values to compute the square root for.
+     *     If no arguments are passed, the result is +0.
+     *     If there is only one argument, the result is the absolute value.
+     *     If any argument is +Infinity or -Infinity, the result is +Infinity.
+     *     If any argument is NaN, the result is NaN.
+     *     If all arguments are either +0 or −0, the result is +0.
+     */
+    hypot(...values: number[]): number;
+
+    /**
+     * Returns the integral part of the a numeric expression, x, removing any fractional digits.
+     * If x is already an integer, the result is x.
+     * @param x A numeric expression.
+     */
+    trunc(x: number): number;
+
+    /**
+     * Returns the nearest single precision float representation of a number.
+     * @param x A numeric expression.
+     */
+    fround(x: number): number;
+
+    /**
+     * Returns an implementation-dependent approximation to the cube root of number.
+     * @param x A numeric expression.
+     */
+    cbrt(x: number): number;
+}
+
+interface NumberConstructor {
+    /**
+     * The value of Number.EPSILON is the difference between 1 and the smallest value greater than 1
+     * that is representable as a Number value, which is approximately:
+     * 2.2204460492503130808472633361816 x 10‍−‍16.
+     */
+    readonly EPSILON: number;
+
+    /**
+     * Returns true if passed value is finite.
+     * Unlike the global isFinite, Number.isFinite doesn't forcibly convert the parameter to a
+     * number. Only finite values of the type number, result in true.
+     * @param number A numeric value.
+     */
+    isFinite(number: unknown): boolean;
+
+    /**
+     * Returns true if the value passed is an integer, false otherwise.
+     * @param number A numeric value.
+     */
+    isInteger(number: unknown): boolean;
+
+    /**
+     * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a
+     * number). Unlike the global isNaN(), Number.isNaN() doesn't forcefully convert the parameter
+     * to a number. Only values of the type number, that are also NaN, result in true.
+     * @param number A numeric value.
+     */
+    isNaN(number: unknown): boolean;
+
+    /**
+     * Returns true if the value passed is a safe integer.
+     * @param number A numeric value.
+     */
+    isSafeInteger(number: unknown): boolean;
+
+    /**
+     * The value of the largest integer n such that n and n + 1 are both exactly representable as
+     * a Number value.
+     * The value of Number.MAX_SAFE_INTEGER is 9007199254740991 2^53 − 1.
+     */
+    readonly MAX_SAFE_INTEGER: number;
+
+    /**
+     * The value of the smallest integer n such that n and n − 1 are both exactly representable as
+     * a Number value.
+     * The value of Number.MIN_SAFE_INTEGER is −9007199254740991 (−(2^53 − 1)).
+     */
+    readonly MIN_SAFE_INTEGER: number;
+
+    /**
+     * Converts a string to a floating-point number.
+     * @param string A string that contains a floating-point number.
+     */
+    parseFloat(string: string): number;
+
+    /**
+     * Converts A string to an integer.
+     * @param string A string to convert into a number.
+     * @param radix A value between 2 and 36 that specifies the base of the number in `string`.
+     * If this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.
+     * All other strings are considered decimal.
+     */
+    parseInt(string: string, radix?: number): number;
+}
+
+interface ObjectConstructor {
+    /**
+     * Copy the values of all of the enumerable own properties from one or more source objects to a
+     * target object. Returns the target object.
+     * @param target The target object to copy to.
+     * @param source The source object from which to copy properties.
+     */
+    assign<T extends {}, U>(target: T, source: U): T & U;
+
+    /**
+     * Copy the values of all of the enumerable own properties from one or more source objects to a
+     * target object. Returns the target object.
+     * @param target The target object to copy to.
+     * @param source1 The first source object from which to copy properties.
+     * @param source2 The second source object from which to copy properties.
+     */
+    assign<T extends {}, U, V>(target: T, source1: U, source2: V): T & U & V;
+
+    /**
+     * Copy the values of all of the enumerable own properties from one or more source objects to a
+     * target object. Returns the target object.
+     * @param target The target object to copy to.
+     * @param source1 The first source object from which to copy properties.
+     * @param source2 The second source object from which to copy properties.
+     * @param source3 The third source object from which to copy properties.
+     */
+    assign<T extends {}, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
+
+    /**
+     * Copy the values of all of the enumerable own properties from one or more source objects to a
+     * target object. Returns the target object.
+     * @param target The target object to copy to.
+     * @param sources One or more source objects from which to copy properties
+     */
+    assign(target: object, ...sources: any[]): any;
+
+    /**
+     * Returns an array of all symbol properties found directly on object o.
+     * @param o Object to retrieve the symbols from.
+     */
+    getOwnPropertySymbols(o: any): symbol[];
+
+    /**
+     * Returns the names of the enumerable string properties and methods of an object.
+     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
+    keys(o: {}): string[];
+
+    /**
+     * Returns true if the values are the same value, false otherwise.
+     * @param value1 The first value.
+     * @param value2 The second value.
+     */
+    is(value1: any, value2: any): boolean;
+
+    /**
+     * Sets the prototype of a specified object o to object proto or null. Returns the object o.
+     * @param o The object to change its prototype.
+     * @param proto The value of the new prototype or null.
+     */
+    setPrototypeOf(o: any, proto: object | null): any;
+}
+
+interface ReadonlyArray<T> {
+    /**
+     * Returns the value of the first element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    find<S extends T>(predicate: (value: T, index: number, obj: readonly T[]) => value is S, thisArg?: any): S | undefined;
+    find(predicate: (value: T, index: number, obj: readonly T[]) => unknown, thisArg?: any): T | undefined;
+
+    /**
+     * Returns the index of the first element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findIndex(predicate: (value: T, index: number, obj: readonly T[]) => unknown, thisArg?: any): number;
+
+    toLocaleString(locales: string | string[], options?: Intl.NumberFormatOptions & Intl.DateTimeFormatOptions): string;
+}
+
+interface RegExp {
+    /**
+     * Returns a string indicating the flags of the regular expression in question. This field is read-only.
+     * The characters in this string are sequenced and concatenated in the following order:
+     *
+     *    - "g" for global
+     *    - "i" for ignoreCase
+     *    - "m" for multiline
+     *    - "u" for unicode
+     *    - "y" for sticky
+     *
+     * If no flags are set, the value is the empty string.
+     */
+    readonly flags: string;
+
+    /**
+     * Returns a Boolean value indicating the state of the sticky flag (y) used with a regular
+     * expression. Default is false. Read-only.
+     */
+    readonly sticky: boolean;
+
+    /**
+     * Returns a Boolean value indicating the state of the Unicode flag (u) used with a regular
+     * expression. Default is false. Read-only.
+     */
+    readonly unicode: boolean;
+}
+
+interface RegExpConstructor {
+    new (pattern: RegExp | string, flags?: string): RegExp;
+    (pattern: RegExp | string, flags?: string): RegExp;
+}
+
+interface String {
+    /**
+     * Returns a nonnegative integer Number less than 1114112 (0x110000) that is the code point
+     * value of the UTF-16 encoded code point starting at the string element at position pos in
+     * the String resulting from converting this object to a String.
+     * If there is no element at that position, the result is undefined.
+     * If a valid UTF-16 surrogate pair does not begin at pos, the result is the code unit at pos.
+     */
+    codePointAt(pos: number): number | undefined;
+
+    /**
+     * Returns true if searchString appears as a substring of the result of converting this
+     * object to a String, at one or more positions that are
+     * greater than or equal to position; otherwise, returns false.
+     * @param searchString search string
+     * @param position If position is undefined, 0 is assumed, so as to search all of the String.
+     */
+    includes(searchString: string, position?: number): boolean;
+
+    /**
+     * Returns true if the sequence of elements of searchString converted to a String is the
+     * same as the corresponding elements of this object (converted to a String) starting at
+     * endPosition – length(this). Otherwise returns false.
+     */
+    endsWith(searchString: string, endPosition?: number): boolean;
+
+    /**
+     * Returns the String value result of normalizing the string into the normalization form
+     * named by form as specified in Unicode Standard Annex #15, Unicode Normalization Forms.
+     * @param form Applicable values: "NFC", "NFD", "NFKC", or "NFKD", If not specified default
+     * is "NFC"
+     */
+    normalize(form: "NFC" | "NFD" | "NFKC" | "NFKD"): string;
+
+    /**
+     * Returns the String value result of normalizing the string into the normalization form
+     * named by form as specified in Unicode Standard Annex #15, Unicode Normalization Forms.
+     * @param form Applicable values: "NFC", "NFD", "NFKC", or "NFKD", If not specified default
+     * is "NFC"
+     */
+    normalize(form?: string): string;
+
+    /**
+     * Returns a String value that is made from count copies appended together. If count is 0,
+     * the empty string is returned.
+     * @param count number of copies to append
+     */
+    repeat(count: number): string;
+
+    /**
+     * Returns true if the sequence of elements of searchString converted to a String is the
+     * same as the corresponding elements of this object (converted to a String) starting at
+     * position. Otherwise returns false.
+     */
+    startsWith(searchString: string, position?: number): boolean;
+
+    /**
+     * Returns an `<a>` HTML anchor element and sets the name attribute to the text value
+     * @deprecated A legacy feature for browser compatibility
+     * @param name
+     */
+    anchor(name: string): string;
+
+    /**
+     * Returns a `<big>` HTML element
+     * @deprecated A legacy feature for browser compatibility
+     */
+    big(): string;
+
+    /**
+     * Returns a `<blink>` HTML element
+     * @deprecated A legacy feature for browser compatibility
+     */
+    blink(): string;
+
+    /**
+     * Returns a `<b>` HTML element
+     * @deprecated A legacy feature for browser compatibility
+     */
+    bold(): string;
+
+    /**
+     * Returns a `<tt>` HTML element
+     * @deprecated A legacy feature for browser compatibility
+     */
+    fixed(): string;
+
+    /**
+     * Returns a `<font>` HTML element and sets the color attribute value
+     * @deprecated A legacy feature for browser compatibility
+     */
+    fontcolor(color: string): string;
+
+    /**
+     * Returns a `<font>` HTML element and sets the size attribute value
+     * @deprecated A legacy feature for browser compatibility
+     */
+    fontsize(size: number): string;
+
+    /**
+     * Returns a `<font>` HTML element and sets the size attribute value
+     * @deprecated A legacy feature for browser compatibility
+     */
+    fontsize(size: string): string;
+
+    /**
+     * Returns an `<i>` HTML element
+     * @deprecated A legacy feature for browser compatibility
+     */
+    italics(): string;
+
+    /**
+     * Returns an `<a>` HTML element and sets the href attribute value
+     * @deprecated A legacy feature for browser compatibility
+     */
+    link(url: string): string;
+
+    /**
+     * Returns a `<small>` HTML element
+     * @deprecated A legacy feature for browser compatibility
+     */
+    small(): string;
+
+    /**
+     * Returns a `<strike>` HTML element
+     * @deprecated A legacy feature for browser compatibility
+     */
+    strike(): string;
+
+    /**
+     * Returns a `<sub>` HTML element
+     * @deprecated A legacy feature for browser compatibility
+     */
+    sub(): string;
+
+    /**
+     * Returns a `<sup>` HTML element
+     * @deprecated A legacy feature for browser compatibility
+     */
+    sup(): string;
+}
+
+interface StringConstructor {
+    /**
+     * Return the String value whose elements are, in order, the elements in the List elements.
+     * If length is 0, the empty string is returned.
+     */
+    fromCodePoint(...codePoints: number[]): string;
+
+    /**
+     * String.raw is usually used as a tag function of a Tagged Template String. When called as
+     * such, the first argument will be a well formed template call site object and the rest
+     * parameter will contain the substitution values. It can also be called directly, for example,
+     * to interleave strings and values from your own tag function, and in this case the only thing
+     * it needs from the first argument is the raw property.
+     * @param template A well-formed template string call site representation.
+     * @param substitutions A set of substitution values.
+     */
+    raw(template: { raw: readonly string[] | ArrayLike<string>; }, ...substitutions: any[]): string;
+}
+
+interface Int8Array<TArrayBuffer extends ArrayBufferLike> {
+    toLocaleString(locales: string | string[], options?: Intl.NumberFormatOptions): string;
+}
+
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike> {
+    toLocaleString(locales: string | string[], options?: Intl.NumberFormatOptions): string;
+}
+
+interface Uint8ClampedArray<TArrayBuffer extends ArrayBufferLike> {
+    toLocaleString(locales: string | string[], options?: Intl.NumberFormatOptions): string;
+}
+
+interface Int16Array<TArrayBuffer extends ArrayBufferLike> {
+    toLocaleString(locales: string | string[], options?: Intl.NumberFormatOptions): string;
+}
+
+interface Uint16Array<TArrayBuffer extends ArrayBufferLike> {
+    toLocaleString(locales: string | string[], options?: Intl.NumberFormatOptions): string;
+}
+
+interface Int32Array<TArrayBuffer extends ArrayBufferLike> {
+    toLocaleString(locales: string | string[], options?: Intl.NumberFormatOptions): string;
+}
+
+interface Uint32Array<TArrayBuffer extends ArrayBufferLike> {
+    toLocaleString(locales: string | string[], options?: Intl.NumberFormatOptions): string;
+}
+
+interface Float32Array<TArrayBuffer extends ArrayBufferLike> {
+    toLocaleString(locales: string | string[], options?: Intl.NumberFormatOptions): string;
+}
+
+interface Float64Array<TArrayBuffer extends ArrayBufferLike> {
+    toLocaleString(locales: string | string[], options?: Intl.NumberFormatOptions): string;
+}
+
+interface Map<K, V> {
+    clear(): void;
+    /**
+     * @returns true if an element in the Map existed and has been removed, or false if the element does not exist.
+     */
+    delete(key: K): boolean;
+    /**
+     * Executes a provided function once per each key/value pair in the Map, in insertion order.
+     */
+    forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void;
+    /**
+     * Returns a specified element from the Map object. If the value that is associated to the provided key is an object, then you will get a reference to that object and any change made to that object will effectively modify it inside the Map.
+     * @returns Returns the element associated with the specified key. If no element is associated with the specified key, undefined is returned.
+     */
+    get(key: K): V | undefined;
+    /**
+     * @returns boolean indicating whether an element with the specified key exists or not.
+     */
+    has(key: K): boolean;
+    /**
+     * Adds a new element with a specified key and value to the Map. If an element with the same key already exists, the element will be updated.
+     */
+    set(key: K, value: V): this;
+    /**
+     * @returns the number of elements in the Map.
+     */
+    readonly size: number;
+}
+
+interface MapConstructor {
+    new (): Map<any, any>;
+    new <K, V>(entries?: readonly (readonly [K, V])[] | null): Map<K, V>;
+    readonly prototype: Map<any, any>;
+}
+declare var Map: MapConstructor;
+
+interface ReadonlyMap<K, V> {
+    forEach(callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void, thisArg?: any): void;
+    get(key: K): V | undefined;
+    has(key: K): boolean;
+    readonly size: number;
+}
+
+interface WeakMap<K extends WeakKey, V> {
+    /**
+     * Removes the specified element from the WeakMap.
+     * @returns true if the element was successfully removed, or false if it was not present.
+     */
+    delete(key: K): boolean;
+    /**
+     * @returns a specified element.
+     */
+    get(key: K): V | undefined;
+    /**
+     * @returns a boolean indicating whether an element with the specified key exists or not.
+     */
+    has(key: K): boolean;
+    /**
+     * Adds a new element with a specified key and value.
+     * @param key Must be an object or symbol.
+     */
+    set(key: K, value: V): this;
+}
+
+interface WeakMapConstructor {
+    new <K extends WeakKey = WeakKey, V = any>(entries?: readonly (readonly [K, V])[] | null): WeakMap<K, V>;
+    readonly prototype: WeakMap<WeakKey, any>;
+}
+declare var WeakMap: WeakMapConstructor;
+
+interface Set<T> {
+    /**
+     * Appends a new element with a specified value to the end of the Set.
+     */
+    add(value: T): this;
+
+    clear(): void;
+    /**
+     * Removes a specified value from the Set.
+     * @returns Returns true if an element in the Set existed and has been removed, or false if the element does not exist.
+     */
+    delete(value: T): boolean;
+    /**
+     * Executes a provided function once per each value in the Set object, in insertion order.
+     */
+    forEach(callbackfn: (value: T, value2: T, set: Set<T>) => void, thisArg?: any): void;
+    /**
+     * @returns a boolean indicating whether an element with the specified value exists in the Set or not.
+     */
+    has(value: T): boolean;
+    /**
+     * @returns the number of (unique) elements in Set.
+     */
+    readonly size: number;
+}
+
+interface SetConstructor {
+    new <T = any>(values?: readonly T[] | null): Set<T>;
+    readonly prototype: Set<any>;
+}
+declare var Set: SetConstructor;
+
+interface ReadonlySet<T> {
+    forEach(callbackfn: (value: T, value2: T, set: ReadonlySet<T>) => void, thisArg?: any): void;
+    has(value: T): boolean;
+    readonly size: number;
+}
+
+interface WeakSet<T extends WeakKey> {
+    /**
+     * Appends a new value to the end of the WeakSet.
+     */
+    add(value: T): this;
+    /**
+     * Removes the specified element from the WeakSet.
+     * @returns Returns true if the element existed and has been removed, or false if the element does not exist.
+     */
+    delete(value: T): boolean;
+    /**
+     * @returns a boolean indicating whether a value exists in the WeakSet or not.
+     */
+    has(value: T): boolean;
+}
+
+interface WeakSetConstructor {
+    new <T extends WeakKey = WeakKey>(values?: readonly T[] | null): WeakSet<T>;
+    readonly prototype: WeakSet<WeakKey>;
+}
+declare var WeakSet: WeakSetConstructor;
+
+interface SymbolConstructor {
+    /**
+     * A reference to the prototype.
+     */
+    readonly prototype: Symbol;
+
+    /**
+     * Returns a new unique Symbol value.
+     * @param  description Description of the new Symbol object.
+     */
+    (description?: string | number): symbol;
+
+    /**
+     * Returns a Symbol object from the global symbol registry matching the given key if found.
+     * Otherwise, returns a new symbol with this key.
+     * @param key key to search for.
+     */
+    for(key: string): symbol;
+
+    /**
+     * Returns a key from the global symbol registry matching the given Symbol if found.
+     * Otherwise, returns a undefined.
+     * @param sym Symbol to find the key for.
+     */
+    keyFor(sym: symbol): string | undefined;
+}
+
+declare var Symbol: SymbolConstructor;
+
+
+interface SymbolConstructor {
+    /**
+     * A method that returns the default iterator for an object. Called by the semantics of the
+     * for-of statement.
+     */
+    readonly iterator: unique symbol;
+}
+
+interface IteratorYieldResult<TYield> {
+    done?: false;
+    value: TYield;
+}
+
+interface IteratorReturnResult<TReturn> {
+    done: true;
+    value: TReturn;
+}
+
+type IteratorResult<T, TReturn = any> = IteratorYieldResult<T> | IteratorReturnResult<TReturn>;
+
+interface Iterator<T, TReturn = any, TNext = any> {
+    // NOTE: 'next' is defined using a tuple to ensure we report the correct assignability errors in all places.
+    next(...[value]: [] | [TNext]): IteratorResult<T, TReturn>;
+    return?(value?: TReturn): IteratorResult<T, TReturn>;
+    throw?(e?: any): IteratorResult<T, TReturn>;
+}
+
+interface Iterable<T, TReturn = any, TNext = any> {
+    [Symbol.iterator](): Iterator<T, TReturn, TNext>;
+}
+
+/**
+ * Describes a user-defined {@link Iterator} that is also iterable.
+ */
+interface IterableIterator<T, TReturn = any, TNext = any> extends Iterator<T, TReturn, TNext> {
+    [Symbol.iterator](): IterableIterator<T, TReturn, TNext>;
+}
+
+/**
+ * Describes an {@link Iterator} produced by the runtime that inherits from the intrinsic `Iterator.prototype`.
+ */
+interface IteratorObject<T, TReturn = unknown, TNext = unknown> extends Iterator<T, TReturn, TNext> {
+    [Symbol.iterator](): IteratorObject<T, TReturn, TNext>;
+}
+
+/**
+ * Defines the `TReturn` type used for built-in iterators produced by `Array`, `Map`, `Set`, and others.
+ * This is `undefined` when `strictBuiltInIteratorReturn` is `true`; otherwise, this is `any`.
+ */
+type BuiltinIteratorReturn = intrinsic;
+
+interface ArrayIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+    [Symbol.iterator](): ArrayIterator<T>;
+}
+
+interface Array<T> {
+    /** Iterator */
+    [Symbol.iterator](): ArrayIterator<T>;
+
+    /**
+     * Returns an iterable of key, value pairs for every entry in the array
+     */
+    entries(): ArrayIterator<[number, T]>;
+
+    /**
+     * Returns an iterable of keys in the array
+     */
+    keys(): ArrayIterator<number>;
+
+    /**
+     * Returns an iterable of values in the array
+     */
+    values(): ArrayIterator<T>;
+}
+
+interface ArrayConstructor {
+    /**
+     * Creates an array from an iterable object.
+     * @param iterable An iterable object to convert to an array.
+     */
+    from<T>(iterable: Iterable<T> | ArrayLike<T>): T[];
+
+    /**
+     * Creates an array from an iterable object.
+     * @param iterable An iterable object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T, U>(iterable: Iterable<T> | ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): U[];
+}
+
+interface ReadonlyArray<T> {
+    /** Iterator of values in the array. */
+    [Symbol.iterator](): ArrayIterator<T>;
+
+    /**
+     * Returns an iterable of key, value pairs for every entry in the array
+     */
+    entries(): ArrayIterator<[number, T]>;
+
+    /**
+     * Returns an iterable of keys in the array
+     */
+    keys(): ArrayIterator<number>;
+
+    /**
+     * Returns an iterable of values in the array
+     */
+    values(): ArrayIterator<T>;
+}
+
+interface IArguments {
+    /** Iterator */
+    [Symbol.iterator](): ArrayIterator<any>;
+}
+
+interface MapIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+    [Symbol.iterator](): MapIterator<T>;
+}
+
+interface Map<K, V> {
+    /** Returns an iterable of entries in the map. */
+    [Symbol.iterator](): MapIterator<[K, V]>;
+
+    /**
+     * Returns an iterable of key, value pairs for every entry in the map.
+     */
+    entries(): MapIterator<[K, V]>;
+
+    /**
+     * Returns an iterable of keys in the map
+     */
+    keys(): MapIterator<K>;
+
+    /**
+     * Returns an iterable of values in the map
+     */
+    values(): MapIterator<V>;
+}
+
+interface ReadonlyMap<K, V> {
+    /** Returns an iterable of entries in the map. */
+    [Symbol.iterator](): MapIterator<[K, V]>;
+
+    /**
+     * Returns an iterable of key, value pairs for every entry in the map.
+     */
+    entries(): MapIterator<[K, V]>;
+
+    /**
+     * Returns an iterable of keys in the map
+     */
+    keys(): MapIterator<K>;
+
+    /**
+     * Returns an iterable of values in the map
+     */
+    values(): MapIterator<V>;
+}
+
+interface MapConstructor {
+    new (): Map<any, any>;
+    new <K, V>(iterable?: Iterable<readonly [K, V]> | null): Map<K, V>;
+}
+
+interface WeakMap<K extends WeakKey, V> {}
+
+interface WeakMapConstructor {
+    new <K extends WeakKey, V>(iterable: Iterable<readonly [K, V]>): WeakMap<K, V>;
+}
+
+interface SetIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+    [Symbol.iterator](): SetIterator<T>;
+}
+
+interface Set<T> {
+    /** Iterates over values in the set. */
+    [Symbol.iterator](): SetIterator<T>;
+
+    /**
+     * Returns an iterable of [v,v] pairs for every value `v` in the set.
+     */
+    entries(): SetIterator<[T, T]>;
+
+    /**
+     * Despite its name, returns an iterable of the values in the set.
+     */
+    keys(): SetIterator<T>;
+
+    /**
+     * Returns an iterable of values in the set.
+     */
+    values(): SetIterator<T>;
+}
+
+interface ReadonlySet<T> {
+    /** Iterates over values in the set. */
+    [Symbol.iterator](): SetIterator<T>;
+
+    /**
+     * Returns an iterable of [v,v] pairs for every value `v` in the set.
+     */
+    entries(): SetIterator<[T, T]>;
+
+    /**
+     * Despite its name, returns an iterable of the values in the set.
+     */
+    keys(): SetIterator<T>;
+
+    /**
+     * Returns an iterable of values in the set.
+     */
+    values(): SetIterator<T>;
+}
+
+interface SetConstructor {
+    new <T>(iterable?: Iterable<T> | null): Set<T>;
+}
+
+interface WeakSet<T extends WeakKey> {}
+
+interface WeakSetConstructor {
+    new <T extends WeakKey = WeakKey>(iterable: Iterable<T>): WeakSet<T>;
+}
+
+interface Promise<T> {}
+
+interface PromiseConstructor {
+    /**
+     * Creates a Promise that is resolved with an array of results when all of the provided Promises
+     * resolve, or rejected when any Promise is rejected.
+     * @param values An iterable of Promises.
+     * @returns A new Promise.
+     */
+    all<T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>[]>;
+
+    /**
+     * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
+     * or rejected.
+     * @param values An iterable of Promises.
+     * @returns A new Promise.
+     */
+    race<T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>;
+}
+
+interface StringIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+    [Symbol.iterator](): StringIterator<T>;
+}
+
+interface String {
+    /** Iterator */
+    [Symbol.iterator](): StringIterator<string>;
+}
+
+interface Int8Array<TArrayBuffer extends ArrayBufferLike> {
+    [Symbol.iterator](): ArrayIterator<number>;
+
+    /**
+     * Returns an array of key, value pairs for every entry in the array
+     */
+    entries(): ArrayIterator<[number, number]>;
+
+    /**
+     * Returns an list of keys in the array
+     */
+    keys(): ArrayIterator<number>;
+
+    /**
+     * Returns an list of values in the array
+     */
+    values(): ArrayIterator<number>;
+}
+
+interface Int8ArrayConstructor {
+    new (elements: Iterable<number>): Int8Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     */
+    from(elements: Iterable<number>): Int8Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(elements: Iterable<T>, mapfn?: (v: T, k: number) => number, thisArg?: any): Int8Array<ArrayBuffer>;
+}
+
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike> {
+    [Symbol.iterator](): ArrayIterator<number>;
+
+    /**
+     * Returns an array of key, value pairs for every entry in the array
+     */
+    entries(): ArrayIterator<[number, number]>;
+
+    /**
+     * Returns an list of keys in the array
+     */
+    keys(): ArrayIterator<number>;
+
+    /**
+     * Returns an list of values in the array
+     */
+    values(): ArrayIterator<number>;
+}
+
+interface Uint8ArrayConstructor {
+    new (elements: Iterable<number>): Uint8Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     */
+    from(elements: Iterable<number>): Uint8Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(elements: Iterable<T>, mapfn?: (v: T, k: number) => number, thisArg?: any): Uint8Array<ArrayBuffer>;
+}
+
+interface Uint8ClampedArray<TArrayBuffer extends ArrayBufferLike> {
+    [Symbol.iterator](): ArrayIterator<number>;
+
+    /**
+     * Returns an array of key, value pairs for every entry in the array
+     */
+    entries(): ArrayIterator<[number, number]>;
+
+    /**
+     * Returns an list of keys in the array
+     */
+    keys(): ArrayIterator<number>;
+
+    /**
+     * Returns an list of values in the array
+     */
+    values(): ArrayIterator<number>;
+}
+
+interface Uint8ClampedArrayConstructor {
+    new (elements: Iterable<number>): Uint8ClampedArray<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     */
+    from(elements: Iterable<number>): Uint8ClampedArray<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(elements: Iterable<T>, mapfn?: (v: T, k: number) => number, thisArg?: any): Uint8ClampedArray<ArrayBuffer>;
+}
+
+interface Int16Array<TArrayBuffer extends ArrayBufferLike> {
+    [Symbol.iterator](): ArrayIterator<number>;
+    /**
+     * Returns an array of key, value pairs for every entry in the array
+     */
+    entries(): ArrayIterator<[number, number]>;
+
+    /**
+     * Returns an list of keys in the array
+     */
+    keys(): ArrayIterator<number>;
+
+    /**
+     * Returns an list of values in the array
+     */
+    values(): ArrayIterator<number>;
+}
+
+interface Int16ArrayConstructor {
+    new (elements: Iterable<number>): Int16Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     */
+    from(elements: Iterable<number>): Int16Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(elements: Iterable<T>, mapfn?: (v: T, k: number) => number, thisArg?: any): Int16Array<ArrayBuffer>;
+}
+
+interface Uint16Array<TArrayBuffer extends ArrayBufferLike> {
+    [Symbol.iterator](): ArrayIterator<number>;
+
+    /**
+     * Returns an array of key, value pairs for every entry in the array
+     */
+    entries(): ArrayIterator<[number, number]>;
+
+    /**
+     * Returns an list of keys in the array
+     */
+    keys(): ArrayIterator<number>;
+
+    /**
+     * Returns an list of values in the array
+     */
+    values(): ArrayIterator<number>;
+}
+
+interface Uint16ArrayConstructor {
+    new (elements: Iterable<number>): Uint16Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     */
+    from(elements: Iterable<number>): Uint16Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(elements: Iterable<T>, mapfn?: (v: T, k: number) => number, thisArg?: any): Uint16Array<ArrayBuffer>;
+}
+
+interface Int32Array<TArrayBuffer extends ArrayBufferLike> {
+    [Symbol.iterator](): ArrayIterator<number>;
+
+    /**
+     * Returns an array of key, value pairs for every entry in the array
+     */
+    entries(): ArrayIterator<[number, number]>;
+
+    /**
+     * Returns an list of keys in the array
+     */
+    keys(): ArrayIterator<number>;
+
+    /**
+     * Returns an list of values in the array
+     */
+    values(): ArrayIterator<number>;
+}
+
+interface Int32ArrayConstructor {
+    new (elements: Iterable<number>): Int32Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     */
+    from(elements: Iterable<number>): Int32Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(elements: Iterable<T>, mapfn?: (v: T, k: number) => number, thisArg?: any): Int32Array<ArrayBuffer>;
+}
+
+interface Uint32Array<TArrayBuffer extends ArrayBufferLike> {
+    [Symbol.iterator](): ArrayIterator<number>;
+
+    /**
+     * Returns an array of key, value pairs for every entry in the array
+     */
+    entries(): ArrayIterator<[number, number]>;
+
+    /**
+     * Returns an list of keys in the array
+     */
+    keys(): ArrayIterator<number>;
+
+    /**
+     * Returns an list of values in the array
+     */
+    values(): ArrayIterator<number>;
+}
+
+interface Uint32ArrayConstructor {
+    new (elements: Iterable<number>): Uint32Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     */
+    from(elements: Iterable<number>): Uint32Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(elements: Iterable<T>, mapfn?: (v: T, k: number) => number, thisArg?: any): Uint32Array<ArrayBuffer>;
+}
+
+interface Float32Array<TArrayBuffer extends ArrayBufferLike> {
+    [Symbol.iterator](): ArrayIterator<number>;
+
+    /**
+     * Returns an array of key, value pairs for every entry in the array
+     */
+    entries(): ArrayIterator<[number, number]>;
+
+    /**
+     * Returns an list of keys in the array
+     */
+    keys(): ArrayIterator<number>;
+
+    /**
+     * Returns an list of values in the array
+     */
+    values(): ArrayIterator<number>;
+}
+
+interface Float32ArrayConstructor {
+    new (elements: Iterable<number>): Float32Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     */
+    from(elements: Iterable<number>): Float32Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(elements: Iterable<T>, mapfn?: (v: T, k: number) => number, thisArg?: any): Float32Array<ArrayBuffer>;
+}
+
+interface Float64Array<TArrayBuffer extends ArrayBufferLike> {
+    [Symbol.iterator](): ArrayIterator<number>;
+
+    /**
+     * Returns an array of key, value pairs for every entry in the array
+     */
+    entries(): ArrayIterator<[number, number]>;
+
+    /**
+     * Returns an list of keys in the array
+     */
+    keys(): ArrayIterator<number>;
+
+    /**
+     * Returns an list of values in the array
+     */
+    values(): ArrayIterator<number>;
+}
+
+interface Float64ArrayConstructor {
+    new (elements: Iterable<number>): Float64Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     */
+    from(elements: Iterable<number>): Float64Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(elements: Iterable<T>, mapfn?: (v: T, k: number) => number, thisArg?: any): Float64Array<ArrayBuffer>;
+}
+
+
+interface Generator<T = unknown, TReturn = any, TNext = any> extends IteratorObject<T, TReturn, TNext> {
+    // NOTE: 'next' is defined using a tuple to ensure we report the correct assignability errors in all places.
+    next(...[value]: [] | [TNext]): IteratorResult<T, TReturn>;
+    return(value: TReturn): IteratorResult<T, TReturn>;
+    throw(e: any): IteratorResult<T, TReturn>;
+    [Symbol.iterator](): Generator<T, TReturn, TNext>;
+}
+
+interface GeneratorFunction {
+    /**
+     * Creates a new Generator object.
+     * @param args A list of arguments the function accepts.
+     */
+    new (...args: any[]): Generator;
+    /**
+     * Creates a new Generator object.
+     * @param args A list of arguments the function accepts.
+     */
+    (...args: any[]): Generator;
+    /**
+     * The length of the arguments.
+     */
+    readonly length: number;
+    /**
+     * Returns the name of the function.
+     */
+    readonly name: string;
+    /**
+     * A reference to the prototype.
+     */
+    readonly prototype: Generator;
+}
+
+interface GeneratorFunctionConstructor {
+    /**
+     * Creates a new Generator function.
+     * @param args A list of arguments the function accepts.
+     */
+    new (...args: string[]): GeneratorFunction;
+    /**
+     * Creates a new Generator function.
+     * @param args A list of arguments the function accepts.
+     */
+    (...args: string[]): GeneratorFunction;
+    /**
+     * The length of the arguments.
+     */
+    readonly length: number;
+    /**
+     * Returns the name of the function.
+     */
+    readonly name: string;
+    /**
+     * A reference to the prototype.
+     */
+    readonly prototype: GeneratorFunction;
+}
+
+interface PromiseConstructor {
+    /**
+     * A reference to the prototype.
+     */
+    readonly prototype: Promise<any>;
+
+    /**
+     * Creates a new Promise.
+     * @param executor A callback used to initialize the promise. This callback is passed two arguments:
+     * a resolve callback used to resolve the promise with a value or the result of another promise,
+     * and a reject callback used to reject the promise with a provided reason or error.
+     */
+    new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
+
+    /**
+     * Creates a Promise that is resolved with an array of results when all of the provided Promises
+     * resolve, or rejected when any Promise is rejected.
+     * @param values An array of Promises.
+     * @returns A new Promise.
+     */
+    all<T extends readonly unknown[] | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }>;
+
+    // see: lib.es2015.iterable.d.ts
+    // all<T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>[]>;
+
+    /**
+     * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
+     * or rejected.
+     * @param values An array of Promises.
+     * @returns A new Promise.
+     */
+    race<T extends readonly unknown[] | []>(values: T): Promise<Awaited<T[number]>>;
+
+    // see: lib.es2015.iterable.d.ts
+    // race<T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>;
+
+    /**
+     * Creates a new rejected promise for the provided reason.
+     * @param reason The reason the promise was rejected.
+     * @returns A new rejected Promise.
+     */
+    reject<T = never>(reason?: any): Promise<T>;
+
+    /**
+     * Creates a new resolved promise.
+     * @returns A resolved promise.
+     */
+    resolve(): Promise<void>;
+    /**
+     * Creates a new resolved promise for the provided value.
+     * @param value A promise.
+     * @returns A promise whose internal state matches the provided promise.
+     */
+    resolve<T>(value: T): Promise<Awaited<T>>;
+    /**
+     * Creates a new resolved promise for the provided value.
+     * @param value A promise.
+     * @returns A promise whose internal state matches the provided promise.
+     */
+    resolve<T>(value: T | PromiseLike<T>): Promise<Awaited<T>>;
+}
+
+declare var Promise: PromiseConstructor;
+
+interface ProxyHandler<T extends object> {
+    /**
+     * A trap method for a function call.
+     * @param target The original callable object which is being proxied.
+     */
+    apply?(target: T, thisArg: any, argArray: any[]): any;
+
+    /**
+     * A trap for the `new` operator.
+     * @param target The original object which is being proxied.
+     * @param newTarget The constructor that was originally called.
+     */
+    construct?(target: T, argArray: any[], newTarget: Function): object;
+
+    /**
+     * A trap for `Object.defineProperty()`.
+     * @param target The original object which is being proxied.
+     * @returns A `Boolean` indicating whether or not the property has been defined.
+     */
+    defineProperty?(target: T, property: string | symbol, attributes: PropertyDescriptor): boolean;
+
+    /**
+     * A trap for the `delete` operator.
+     * @param target The original object which is being proxied.
+     * @param p The name or `Symbol` of the property to delete.
+     * @returns A `Boolean` indicating whether or not the property was deleted.
+     */
+    deleteProperty?(target: T, p: string | symbol): boolean;
+
+    /**
+     * A trap for getting a property value.
+     * @param target The original object which is being proxied.
+     * @param p The name or `Symbol` of the property to get.
+     * @param receiver The proxy or an object that inherits from the proxy.
+     */
+    get?(target: T, p: string | symbol, receiver: any): any;
+
+    /**
+     * A trap for `Object.getOwnPropertyDescriptor()`.
+     * @param target The original object which is being proxied.
+     * @param p The name of the property whose description should be retrieved.
+     */
+    getOwnPropertyDescriptor?(target: T, p: string | symbol): PropertyDescriptor | undefined;
+
+    /**
+     * A trap for the `[[GetPrototypeOf]]` internal method.
+     * @param target The original object which is being proxied.
+     */
+    getPrototypeOf?(target: T): object | null;
+
+    /**
+     * A trap for the `in` operator.
+     * @param target The original object which is being proxied.
+     * @param p The name or `Symbol` of the property to check for existence.
+     */
+    has?(target: T, p: string | symbol): boolean;
+
+    /**
+     * A trap for `Object.isExtensible()`.
+     * @param target The original object which is being proxied.
+     */
+    isExtensible?(target: T): boolean;
+
+    /**
+     * A trap for `Reflect.ownKeys()`.
+     * @param target The original object which is being proxied.
+     */
+    ownKeys?(target: T): ArrayLike<string | symbol>;
+
+    /**
+     * A trap for `Object.preventExtensions()`.
+     * @param target The original object which is being proxied.
+     */
+    preventExtensions?(target: T): boolean;
+
+    /**
+     * A trap for setting a property value.
+     * @param target The original object which is being proxied.
+     * @param p The name or `Symbol` of the property to set.
+     * @param receiver The object to which the assignment was originally directed.
+     * @returns A `Boolean` indicating whether or not the property was set.
+     */
+    set?(target: T, p: string | symbol, newValue: any, receiver: any): boolean;
+
+    /**
+     * A trap for `Object.setPrototypeOf()`.
+     * @param target The original object which is being proxied.
+     * @param newPrototype The object's new prototype or `null`.
+     */
+    setPrototypeOf?(target: T, v: object | null): boolean;
+}
+
+interface ProxyConstructor {
+    /**
+     * Creates a revocable Proxy object.
+     * @param target A target object to wrap with Proxy.
+     * @param handler An object whose properties define the behavior of Proxy when an operation is attempted on it.
+     */
+    revocable<T extends object>(target: T, handler: ProxyHandler<T>): { proxy: T; revoke: () => void; };
+
+    /**
+     * Creates a Proxy object. The Proxy object allows you to create an object that can be used in place of the
+     * original object, but which may redefine fundamental Object operations like getting, setting, and defining
+     * properties. Proxy objects are commonly used to log property accesses, validate, format, or sanitize inputs.
+     * @param target A target object to wrap with Proxy.
+     * @param handler An object whose properties define the behavior of Proxy when an operation is attempted on it.
+     */
+    new <T extends object>(target: T, handler: ProxyHandler<T>): T;
+}
+declare var Proxy: ProxyConstructor;
+
+declare namespace Reflect {
+    /**
+     * Calls the function with the specified object as the this value
+     * and the elements of specified array as the arguments.
+     * @param target The function to call.
+     * @param thisArgument The object to be used as the this object.
+     * @param argumentsList An array of argument values to be passed to the function.
+     */
+    function apply<T, A extends readonly any[], R>(
+        target: (this: T, ...args: A) => R,
+        thisArgument: T,
+        argumentsList: Readonly<A>,
+    ): R;
+    function apply(target: Function, thisArgument: any, argumentsList: ArrayLike<any>): any;
+
+    /**
+     * Constructs the target with the elements of specified array as the arguments
+     * and the specified constructor as the `new.target` value.
+     * @param target The constructor to invoke.
+     * @param argumentsList An array of argument values to be passed to the constructor.
+     * @param newTarget The constructor to be used as the `new.target` object.
+     */
+    function construct<A extends readonly any[], R>(
+        target: new (...args: A) => R,
+        argumentsList: Readonly<A>,
+        newTarget?: new (...args: any) => any,
+    ): R;
+    function construct(target: Function, argumentsList: ArrayLike<any>, newTarget?: Function): any;
+
+    /**
+     * Adds a property to an object, or modifies attributes of an existing property.
+     * @param target Object on which to add or modify the property. This can be a native JavaScript object
+     *        (that is, a user-defined object or a built in object) or a DOM object.
+     * @param propertyKey The property name.
+     * @param attributes Descriptor for the property. It can be for a data property or an accessor property.
+     */
+    function defineProperty(target: object, propertyKey: PropertyKey, attributes: PropertyDescriptor & ThisType<any>): boolean;
+
+    /**
+     * Removes a property from an object, equivalent to `delete target[propertyKey]`,
+     * except it won't throw if `target[propertyKey]` is non-configurable.
+     * @param target Object from which to remove the own property.
+     * @param propertyKey The property name.
+     */
+    function deleteProperty(target: object, propertyKey: PropertyKey): boolean;
+
+    /**
+     * Gets the property of target, equivalent to `target[propertyKey]` when `receiver === target`.
+     * @param target Object that contains the property on itself or in its prototype chain.
+     * @param propertyKey The property name.
+     * @param receiver The reference to use as the `this` value in the getter function,
+     *        if `target[propertyKey]` is an accessor property.
+     */
+    function get<T extends object, P extends PropertyKey>(
+        target: T,
+        propertyKey: P,
+        receiver?: unknown,
+    ): P extends keyof T ? T[P] : any;
+
+    /**
+     * Gets the own property descriptor of the specified object.
+     * An own property descriptor is one that is defined directly on the object and is not inherited from the object's prototype.
+     * @param target Object that contains the property.
+     * @param propertyKey The property name.
+     */
+    function getOwnPropertyDescriptor<T extends object, P extends PropertyKey>(
+        target: T,
+        propertyKey: P,
+    ): TypedPropertyDescriptor<P extends keyof T ? T[P] : any> | undefined;
+
+    /**
+     * Returns the prototype of an object.
+     * @param target The object that references the prototype.
+     */
+    function getPrototypeOf(target: object): object | null;
+
+    /**
+     * Equivalent to `propertyKey in target`.
+     * @param target Object that contains the property on itself or in its prototype chain.
+     * @param propertyKey Name of the property.
+     */
+    function has(target: object, propertyKey: PropertyKey): boolean;
+
+    /**
+     * Returns a value that indicates whether new properties can be added to an object.
+     * @param target Object to test.
+     */
+    function isExtensible(target: object): boolean;
+
+    /**
+     * Returns the string and symbol keys of the own properties of an object. The own properties of an object
+     * are those that are defined directly on that object, and are not inherited from the object's prototype.
+     * @param target Object that contains the own properties.
+     */
+    function ownKeys(target: object): (string | symbol)[];
+
+    /**
+     * Prevents the addition of new properties to an object.
+     * @param target Object to make non-extensible.
+     * @return Whether the object has been made non-extensible.
+     */
+    function preventExtensions(target: object): boolean;
+
+    /**
+     * Sets the property of target, equivalent to `target[propertyKey] = value` when `receiver === target`.
+     * @param target Object that contains the property on itself or in its prototype chain.
+     * @param propertyKey Name of the property.
+     * @param receiver The reference to use as the `this` value in the setter function,
+     *        if `target[propertyKey]` is an accessor property.
+     */
+    function set<T extends object, P extends PropertyKey>(
+        target: T,
+        propertyKey: P,
+        value: P extends keyof T ? T[P] : any,
+        receiver?: any,
+    ): boolean;
+    function set(target: object, propertyKey: PropertyKey, value: any, receiver?: any): boolean;
+
+    /**
+     * Sets the prototype of a specified object o to object proto or null.
+     * @param target The object to change its prototype.
+     * @param proto The value of the new prototype or null.
+     * @return Whether setting the prototype was successful.
+     */
+    function setPrototypeOf(target: object, proto: object | null): boolean;
+}
+
+
+interface SymbolConstructor {
+    /**
+     * A method that determines if a constructor object recognizes an object as one of the
+     * constructor’s instances. Called by the semantics of the instanceof operator.
+     */
+    readonly hasInstance: unique symbol;
+
+    /**
+     * A Boolean value that if true indicates that an object should flatten to its array elements
+     * by Array.prototype.concat.
+     */
+    readonly isConcatSpreadable: unique symbol;
+
+    /**
+     * A regular expression method that matches the regular expression against a string. Called
+     * by the String.prototype.match method.
+     */
+    readonly match: unique symbol;
+
+    /**
+     * A regular expression method that replaces matched substrings of a string. Called by the
+     * String.prototype.replace method.
+     */
+    readonly replace: unique symbol;
+
+    /**
+     * A regular expression method that returns the index within a string that matches the
+     * regular expression. Called by the String.prototype.search method.
+     */
+    readonly search: unique symbol;
+
+    /**
+     * A function valued property that is the constructor function that is used to create
+     * derived objects.
+     */
+    readonly species: unique symbol;
+
+    /**
+     * A regular expression method that splits a string at the indices that match the regular
+     * expression. Called by the String.prototype.split method.
+     */
+    readonly split: unique symbol;
+
+    /**
+     * A method that converts an object to a corresponding primitive value.
+     * Called by the ToPrimitive abstract operation.
+     */
+    readonly toPrimitive: unique symbol;
+
+    /**
+     * A String value that is used in the creation of the default string description of an object.
+     * Called by the built-in method Object.prototype.toString.
+     */
+    readonly toStringTag: unique symbol;
+
+    /**
+     * An Object whose truthy properties are properties that are excluded from the 'with'
+     * environment bindings of the associated objects.
+     */
+    readonly unscopables: unique symbol;
+}
+
+interface Symbol {
+    /**
+     * Converts a Symbol object to a symbol.
+     */
+    [Symbol.toPrimitive](hint: string): symbol;
+
+    readonly [Symbol.toStringTag]: string;
+}
+
+interface Array<T> {
+    /**
+     * Is an object whose properties have the value 'true'
+     * when they will be absent when used in a 'with' statement.
+     */
+    readonly [Symbol.unscopables]: {
+        [K in keyof any[]]?: boolean;
+    };
+}
+
+interface ReadonlyArray<T> {
+    /**
+     * Is an object whose properties have the value 'true'
+     * when they will be absent when used in a 'with' statement.
+     */
+    readonly [Symbol.unscopables]: {
+        [K in keyof readonly any[]]?: boolean;
+    };
+}
+
+interface Date {
+    /**
+     * Converts a Date object to a string.
+     */
+    [Symbol.toPrimitive](hint: "default"): string;
+    /**
+     * Converts a Date object to a string.
+     */
+    [Symbol.toPrimitive](hint: "string"): string;
+    /**
+     * Converts a Date object to a number.
+     */
+    [Symbol.toPrimitive](hint: "number"): number;
+    /**
+     * Converts a Date object to a string or number.
+     *
+     * @param hint The strings "number", "string", or "default" to specify what primitive to return.
+     *
+     * @throws {TypeError} If 'hint' was given something other than "number", "string", or "default".
+     * @returns A number if 'hint' was "number", a string if 'hint' was "string" or "default".
+     */
+    [Symbol.toPrimitive](hint: string): string | number;
+}
+
+interface Map<K, V> {
+    readonly [Symbol.toStringTag]: string;
+}
+
+interface WeakMap<K extends WeakKey, V> {
+    readonly [Symbol.toStringTag]: string;
+}
+
+interface Set<T> {
+    readonly [Symbol.toStringTag]: string;
+}
+
+interface WeakSet<T extends WeakKey> {
+    readonly [Symbol.toStringTag]: string;
+}
+
+interface JSON {
+    readonly [Symbol.toStringTag]: string;
+}
+
+interface Function {
+    /**
+     * Determines whether the given value inherits from this function if this function was used
+     * as a constructor function.
+     *
+     * A constructor function can control which objects are recognized as its instances by
+     * 'instanceof' by overriding this method.
+     */
+    [Symbol.hasInstance](value: any): boolean;
+}
+
+interface GeneratorFunction {
+    readonly [Symbol.toStringTag]: string;
+}
+
+interface Math {
+    readonly [Symbol.toStringTag]: string;
+}
+
+interface Promise<T> {
+    readonly [Symbol.toStringTag]: string;
+}
+
+interface PromiseConstructor {
+    readonly [Symbol.species]: PromiseConstructor;
+}
+
+interface RegExp {
+    /**
+     * Matches a string with this regular expression, and returns an array containing the results of
+     * that search.
+     * @param string A string to search within.
+     */
+    [Symbol.match](string: string): RegExpMatchArray | null;
+
+    /**
+     * Replaces text in a string, using this regular expression.
+     * @param string A String object or string literal whose contents matching against
+     *               this regular expression will be replaced
+     * @param replaceValue A String object or string literal containing the text to replace for every
+     *                     successful match of this regular expression.
+     */
+    [Symbol.replace](string: string, replaceValue: string): string;
+
+    /**
+     * Replaces text in a string, using this regular expression.
+     * @param string A String object or string literal whose contents matching against
+     *               this regular expression will be replaced
+     * @param replacer A function that returns the replacement text.
+     */
+    [Symbol.replace](string: string, replacer: (substring: string, ...args: any[]) => string): string;
+
+    /**
+     * Finds the position beginning first substring match in a regular expression search
+     * using this regular expression.
+     *
+     * @param string The string to search within.
+     */
+    [Symbol.search](string: string): number;
+
+    /**
+     * Returns an array of substrings that were delimited by strings in the original input that
+     * match against this regular expression.
+     *
+     * If the regular expression contains capturing parentheses, then each time this
+     * regular expression matches, the results (including any undefined results) of the
+     * capturing parentheses are spliced.
+     *
+     * @param string string value to split
+     * @param limit if not undefined, the output array is truncated so that it contains no more
+     * than 'limit' elements.
+     */
+    [Symbol.split](string: string, limit?: number): string[];
+}
+
+interface RegExpConstructor {
+    readonly [Symbol.species]: RegExpConstructor;
+}
+
+interface String {
+    /**
+     * Matches a string or an object that supports being matched against, and returns an array
+     * containing the results of that search, or null if no matches are found.
+     * @param matcher An object that supports being matched against.
+     */
+    match(matcher: { [Symbol.match](string: string): RegExpMatchArray | null; }): RegExpMatchArray | null;
+
+    /**
+     * Passes a string and {@linkcode replaceValue} to the `[Symbol.replace]` method on {@linkcode searchValue}. This method is expected to implement its own replacement algorithm.
+     * @param searchValue An object that supports searching for and replacing matches within a string.
+     * @param replaceValue The replacement text.
+     */
+    replace(searchValue: { [Symbol.replace](string: string, replaceValue: string): string; }, replaceValue: string): string;
+
+    /**
+     * Replaces text in a string, using an object that supports replacement within a string.
+     * @param searchValue A object can search for and replace matches within a string.
+     * @param replacer A function that returns the replacement text.
+     */
+    replace(searchValue: { [Symbol.replace](string: string, replacer: (substring: string, ...args: any[]) => string): string; }, replacer: (substring: string, ...args: any[]) => string): string;
+
+    /**
+     * Finds the first substring match in a regular expression search.
+     * @param searcher An object which supports searching within a string.
+     */
+    search(searcher: { [Symbol.search](string: string): number; }): number;
+
+    /**
+     * Split a string into substrings using the specified separator and return them as an array.
+     * @param splitter An object that can split a string.
+     * @param limit A value used to limit the number of elements returned in the array.
+     */
+    split(splitter: { [Symbol.split](string: string, limit?: number): string[]; }, limit?: number): string[];
+}
+
+interface ArrayBuffer {
+    readonly [Symbol.toStringTag]: "ArrayBuffer";
+}
+
+interface DataView<TArrayBuffer extends ArrayBufferLike> {
+    readonly [Symbol.toStringTag]: string;
+}
+
+interface Int8Array<TArrayBuffer extends ArrayBufferLike> {
+    readonly [Symbol.toStringTag]: "Int8Array";
+}
+
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike> {
+    readonly [Symbol.toStringTag]: "Uint8Array";
+}
+
+interface Uint8ClampedArray<TArrayBuffer extends ArrayBufferLike> {
+    readonly [Symbol.toStringTag]: "Uint8ClampedArray";
+}
+
+interface Int16Array<TArrayBuffer extends ArrayBufferLike> {
+    readonly [Symbol.toStringTag]: "Int16Array";
+}
+
+interface Uint16Array<TArrayBuffer extends ArrayBufferLike> {
+    readonly [Symbol.toStringTag]: "Uint16Array";
+}
+
+interface Int32Array<TArrayBuffer extends ArrayBufferLike> {
+    readonly [Symbol.toStringTag]: "Int32Array";
+}
+
+interface Uint32Array<TArrayBuffer extends ArrayBufferLike> {
+    readonly [Symbol.toStringTag]: "Uint32Array";
+}
+
+interface Float32Array<TArrayBuffer extends ArrayBufferLike> {
+    readonly [Symbol.toStringTag]: "Float32Array";
+}
+
+interface Float64Array<TArrayBuffer extends ArrayBufferLike> {
+    readonly [Symbol.toStringTag]: "Float64Array";
+}
+
+interface ArrayConstructor {
+    readonly [Symbol.species]: ArrayConstructor;
+}
+interface MapConstructor {
+    readonly [Symbol.species]: MapConstructor;
+}
+interface SetConstructor {
+    readonly [Symbol.species]: SetConstructor;
+}
+interface ArrayBufferConstructor {
+    readonly [Symbol.species]: ArrayBufferConstructor;
+}
+
+
+interface Array<T> {
+    /**
+     * Determines whether an array includes a certain element, returning true or false as appropriate.
+     * @param searchElement The element to search for.
+     * @param fromIndex The position in this array at which to begin searching for searchElement.
+     */
+    includes(searchElement: T, fromIndex?: number): boolean;
+}
+
+interface ReadonlyArray<T> {
+    /**
+     * Determines whether an array includes a certain element, returning true or false as appropriate.
+     * @param searchElement The element to search for.
+     * @param fromIndex The position in this array at which to begin searching for searchElement.
+     */
+    includes(searchElement: T, fromIndex?: number): boolean;
+}
+
+interface Int8Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Determines whether an array includes a certain element, returning true or false as appropriate.
+     * @param searchElement The element to search for.
+     * @param fromIndex The position in this array at which to begin searching for searchElement.
+     */
+    includes(searchElement: number, fromIndex?: number): boolean;
+}
+
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Determines whether an array includes a certain element, returning true or false as appropriate.
+     * @param searchElement The element to search for.
+     * @param fromIndex The position in this array at which to begin searching for searchElement.
+     */
+    includes(searchElement: number, fromIndex?: number): boolean;
+}
+
+interface Uint8ClampedArray<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Determines whether an array includes a certain element, returning true or false as appropriate.
+     * @param searchElement The element to search for.
+     * @param fromIndex The position in this array at which to begin searching for searchElement.
+     */
+    includes(searchElement: number, fromIndex?: number): boolean;
+}
+
+interface Int16Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Determines whether an array includes a certain element, returning true or false as appropriate.
+     * @param searchElement The element to search for.
+     * @param fromIndex The position in this array at which to begin searching for searchElement.
+     */
+    includes(searchElement: number, fromIndex?: number): boolean;
+}
+
+interface Uint16Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Determines whether an array includes a certain element, returning true or false as appropriate.
+     * @param searchElement The element to search for.
+     * @param fromIndex The position in this array at which to begin searching for searchElement.
+     */
+    includes(searchElement: number, fromIndex?: number): boolean;
+}
+
+interface Int32Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Determines whether an array includes a certain element, returning true or false as appropriate.
+     * @param searchElement The element to search for.
+     * @param fromIndex The position in this array at which to begin searching for searchElement.
+     */
+    includes(searchElement: number, fromIndex?: number): boolean;
+}
+
+interface Uint32Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Determines whether an array includes a certain element, returning true or false as appropriate.
+     * @param searchElement The element to search for.
+     * @param fromIndex The position in this array at which to begin searching for searchElement.
+     */
+    includes(searchElement: number, fromIndex?: number): boolean;
+}
+
+interface Float32Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Determines whether an array includes a certain element, returning true or false as appropriate.
+     * @param searchElement The element to search for.
+     * @param fromIndex The position in this array at which to begin searching for searchElement.
+     */
+    includes(searchElement: number, fromIndex?: number): boolean;
+}
+
+interface Float64Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Determines whether an array includes a certain element, returning true or false as appropriate.
+     * @param searchElement The element to search for.
+     * @param fromIndex The position in this array at which to begin searching for searchElement.
+     */
+    includes(searchElement: number, fromIndex?: number): boolean;
+}
+
+declare namespace Intl {
+    /**
+     * The `Intl.getCanonicalLocales()` method returns an array containing
+     * the canonical locale names. Duplicates will be omitted and elements
+     * will be validated as structurally valid language tags.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales)
+     *
+     * @param locale A list of String values for which to get the canonical locale names
+     * @returns An array containing the canonical and validated locale names.
+     */
+    function getCanonicalLocales(locale?: string | readonly string[]): string[];
+}
+
+
+interface ArrayBufferConstructor {
+    new (): ArrayBuffer;
+}
+
+interface DateConstructor {
+    /**
+     * Returns the number of milliseconds between midnight, January 1, 1970 Universal Coordinated Time (UTC) (or GMT) and the specified date.
+     * @param year The full year designation is required for cross-century date accuracy. If year is between 0 and 99 is used, then year is assumed to be 1900 + year.
+     * @param monthIndex The month as a number between 0 and 11 (January to December).
+     * @param date The date as a number between 1 and 31.
+     * @param hours Must be supplied if minutes is supplied. A number from 0 to 23 (midnight to 11pm) that specifies the hour.
+     * @param minutes Must be supplied if seconds is supplied. A number from 0 to 59 that specifies the minutes.
+     * @param seconds Must be supplied if milliseconds is supplied. A number from 0 to 59 that specifies the seconds.
+     * @param ms A number from 0 to 999 that specifies the milliseconds.
+     */
+    UTC(year: number, monthIndex?: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): number;
+}
+
+declare namespace Intl {
+    interface DateTimeFormatPartTypesRegistry {
+        day: any;
+        dayPeriod: any;
+        era: any;
+        hour: any;
+        literal: any;
+        minute: any;
+        month: any;
+        second: any;
+        timeZoneName: any;
+        weekday: any;
+        year: any;
+    }
+
+    type DateTimeFormatPartTypes = keyof DateTimeFormatPartTypesRegistry;
+
+    interface DateTimeFormatPart {
+        type: DateTimeFormatPartTypes;
+        value: string;
+    }
+
+    interface DateTimeFormat {
+        formatToParts(date?: Date | number): DateTimeFormatPart[];
+    }
+}
+
+interface ObjectConstructor {
+    /**
+     * Returns an array of values of the enumerable own properties of an object
+     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
+    values<T>(o: { [s: string]: T; } | ArrayLike<T>): T[];
+
+    /**
+     * Returns an array of values of the enumerable own properties of an object
+     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
+    values(o: {}): any[];
+
+    /**
+     * Returns an array of key/values of the enumerable own properties of an object
+     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
+    entries<T>(o: { [s: string]: T; } | ArrayLike<T>): [string, T][];
+
+    /**
+     * Returns an array of key/values of the enumerable own properties of an object
+     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
+    entries(o: {}): [string, any][];
+
+    /**
+     * Returns an object containing all own property descriptors of an object
+     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
+    getOwnPropertyDescriptors<T>(o: T): { [P in keyof T]: TypedPropertyDescriptor<T[P]>; } & { [x: string]: PropertyDescriptor; };
+}
+
+
+interface SharedArrayBuffer {
+    /**
+     * Read-only. The length of the ArrayBuffer (in bytes).
+     */
+    readonly byteLength: number;
+
+    /**
+     * Returns a section of an SharedArrayBuffer.
+     */
+    slice(begin?: number, end?: number): SharedArrayBuffer;
+    readonly [Symbol.toStringTag]: "SharedArrayBuffer";
+}
+
+interface SharedArrayBufferConstructor {
+    readonly prototype: SharedArrayBuffer;
+    new (byteLength?: number): SharedArrayBuffer;
+    readonly [Symbol.species]: SharedArrayBufferConstructor;
+}
+declare var SharedArrayBuffer: SharedArrayBufferConstructor;
+
+interface ArrayBufferTypes {
+    SharedArrayBuffer: SharedArrayBuffer;
+}
+
+interface Atomics {
+    /**
+     * Adds a value to the value at the given position in the array, returning the original value.
+     * Until this atomic operation completes, any other read or write operation against the array
+     * will block.
+     */
+    add(typedArray: Int8Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike>, index: number, value: number): number;
+
+    /**
+     * Stores the bitwise AND of a value with the value at the given position in the array,
+     * returning the original value. Until this atomic operation completes, any other read or
+     * write operation against the array will block.
+     */
+    and(typedArray: Int8Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike>, index: number, value: number): number;
+
+    /**
+     * Replaces the value at the given position in the array if the original value equals the given
+     * expected value, returning the original value. Until this atomic operation completes, any
+     * other read or write operation against the array will block.
+     */
+    compareExchange(typedArray: Int8Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike>, index: number, expectedValue: number, replacementValue: number): number;
+
+    /**
+     * Replaces the value at the given position in the array, returning the original value. Until
+     * this atomic operation completes, any other read or write operation against the array will
+     * block.
+     */
+    exchange(typedArray: Int8Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike>, index: number, value: number): number;
+
+    /**
+     * Returns a value indicating whether high-performance algorithms can use atomic operations
+     * (`true`) or must use locks (`false`) for the given number of bytes-per-element of a typed
+     * array.
+     */
+    isLockFree(size: number): boolean;
+
+    /**
+     * Returns the value at the given position in the array. Until this atomic operation completes,
+     * any other read or write operation against the array will block.
+     */
+    load(typedArray: Int8Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike>, index: number): number;
+
+    /**
+     * Stores the bitwise OR of a value with the value at the given position in the array,
+     * returning the original value. Until this atomic operation completes, any other read or write
+     * operation against the array will block.
+     */
+    or(typedArray: Int8Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike>, index: number, value: number): number;
+
+    /**
+     * Stores a value at the given position in the array, returning the new value. Until this
+     * atomic operation completes, any other read or write operation against the array will block.
+     */
+    store(typedArray: Int8Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike>, index: number, value: number): number;
+
+    /**
+     * Subtracts a value from the value at the given position in the array, returning the original
+     * value. Until this atomic operation completes, any other read or write operation against the
+     * array will block.
+     */
+    sub(typedArray: Int8Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike>, index: number, value: number): number;
+
+    /**
+     * If the value at the given position in the array is equal to the provided value, the current
+     * agent is put to sleep causing execution to suspend until the timeout expires (returning
+     * `"timed-out"`) or until the agent is awoken (returning `"ok"`); otherwise, returns
+     * `"not-equal"`.
+     */
+    wait(typedArray: Int32Array<ArrayBufferLike>, index: number, value: number, timeout?: number): "ok" | "not-equal" | "timed-out";
+
+    /**
+     * Wakes up sleeping agents that are waiting on the given index of the array, returning the
+     * number of agents that were awoken.
+     * @param typedArray A shared Int32Array<ArrayBufferLike>.
+     * @param index The position in the typedArray to wake up on.
+     * @param count The number of sleeping agents to notify. Defaults to +Infinity.
+     */
+    notify(typedArray: Int32Array<ArrayBufferLike>, index: number, count?: number): number;
+
+    /**
+     * Stores the bitwise XOR of a value with the value at the given position in the array,
+     * returning the original value. Until this atomic operation completes, any other read or write
+     * operation against the array will block.
+     */
+    xor(typedArray: Int8Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike>, index: number, value: number): number;
+
+    readonly [Symbol.toStringTag]: "Atomics";
+}
+
+declare var Atomics: Atomics;
+
+interface String {
+    /**
+     * Pads the current string with a given string (possibly repeated) so that the resulting string reaches a given length.
+     * The padding is applied from the start (left) of the current string.
+     *
+     * @param maxLength The length of the resulting string once the current string has been padded.
+     *        If this parameter is smaller than the current string's length, the current string will be returned as it is.
+     *
+     * @param fillString The string to pad the current string with.
+     *        If this string is too long, it will be truncated and the left-most part will be applied.
+     *        The default value for this parameter is " " (U+0020).
+     */
+    padStart(maxLength: number, fillString?: string): string;
+
+    /**
+     * Pads the current string with a given string (possibly repeated) so that the resulting string reaches a given length.
+     * The padding is applied from the end (right) of the current string.
+     *
+     * @param maxLength The length of the resulting string once the current string has been padded.
+     *        If this parameter is smaller than the current string's length, the current string will be returned as it is.
+     *
+     * @param fillString The string to pad the current string with.
+     *        If this string is too long, it will be truncated and the left-most part will be applied.
+     *        The default value for this parameter is " " (U+0020).
+     */
+    padEnd(maxLength: number, fillString?: string): string;
+}
+
+interface Int8ArrayConstructor {
+    new (): Int8Array<ArrayBuffer>;
+}
+
+interface Uint8ArrayConstructor {
+    new (): Uint8Array<ArrayBuffer>;
+}
+
+interface Uint8ClampedArrayConstructor {
+    new (): Uint8ClampedArray<ArrayBuffer>;
+}
+
+interface Int16ArrayConstructor {
+    new (): Int16Array<ArrayBuffer>;
+}
+
+interface Uint16ArrayConstructor {
+    new (): Uint16Array<ArrayBuffer>;
+}
+
+interface Int32ArrayConstructor {
+    new (): Int32Array<ArrayBuffer>;
+}
+
+interface Uint32ArrayConstructor {
+    new (): Uint32Array<ArrayBuffer>;
+}
+
+interface Float32ArrayConstructor {
+    new (): Float32Array<ArrayBuffer>;
+}
+
+interface Float64ArrayConstructor {
+    new (): Float64Array<ArrayBuffer>;
+}
+
+
+
+interface SymbolConstructor {
+    /**
+     * A method that returns the default async iterator for an object. Called by the semantics of
+     * the for-await-of statement.
+     */
+    readonly asyncIterator: unique symbol;
+}
+
+interface AsyncIterator<T, TReturn = any, TNext = any> {
+    // NOTE: 'next' is defined using a tuple to ensure we report the correct assignability errors in all places.
+    next(...[value]: [] | [TNext]): Promise<IteratorResult<T, TReturn>>;
+    return?(value?: TReturn | PromiseLike<TReturn>): Promise<IteratorResult<T, TReturn>>;
+    throw?(e?: any): Promise<IteratorResult<T, TReturn>>;
+}
+
+interface AsyncIterable<T, TReturn = any, TNext = any> {
+    [Symbol.asyncIterator](): AsyncIterator<T, TReturn, TNext>;
+}
+
+/**
+ * Describes a user-defined {@link AsyncIterator} that is also async iterable.
+ */
+interface AsyncIterableIterator<T, TReturn = any, TNext = any> extends AsyncIterator<T, TReturn, TNext> {
+    [Symbol.asyncIterator](): AsyncIterableIterator<T, TReturn, TNext>;
+}
+
+/**
+ * Describes an {@link AsyncIterator} produced by the runtime that inherits from the intrinsic `AsyncIterator.prototype`.
+ */
+interface AsyncIteratorObject<T, TReturn = unknown, TNext = unknown> extends AsyncIterator<T, TReturn, TNext> {
+    [Symbol.asyncIterator](): AsyncIteratorObject<T, TReturn, TNext>;
+}
+
+
+interface AsyncGenerator<T = unknown, TReturn = any, TNext = any> extends AsyncIteratorObject<T, TReturn, TNext> {
+    // NOTE: 'next' is defined using a tuple to ensure we report the correct assignability errors in all places.
+    next(...[value]: [] | [TNext]): Promise<IteratorResult<T, TReturn>>;
+    return(value: TReturn | PromiseLike<TReturn>): Promise<IteratorResult<T, TReturn>>;
+    throw(e: any): Promise<IteratorResult<T, TReturn>>;
+    [Symbol.asyncIterator](): AsyncGenerator<T, TReturn, TNext>;
+}
+
+interface AsyncGeneratorFunction {
+    /**
+     * Creates a new AsyncGenerator object.
+     * @param args A list of arguments the function accepts.
+     */
+    new (...args: any[]): AsyncGenerator;
+    /**
+     * Creates a new AsyncGenerator object.
+     * @param args A list of arguments the function accepts.
+     */
+    (...args: any[]): AsyncGenerator;
+    /**
+     * The length of the arguments.
+     */
+    readonly length: number;
+    /**
+     * Returns the name of the function.
+     */
+    readonly name: string;
+    /**
+     * A reference to the prototype.
+     */
+    readonly prototype: AsyncGenerator;
+}
+
+interface AsyncGeneratorFunctionConstructor {
+    /**
+     * Creates a new AsyncGenerator function.
+     * @param args A list of arguments the function accepts.
+     */
+    new (...args: string[]): AsyncGeneratorFunction;
+    /**
+     * Creates a new AsyncGenerator function.
+     * @param args A list of arguments the function accepts.
+     */
+    (...args: string[]): AsyncGeneratorFunction;
+    /**
+     * The length of the arguments.
+     */
+    readonly length: number;
+    /**
+     * Returns the name of the function.
+     */
+    readonly name: string;
+    /**
+     * A reference to the prototype.
+     */
+    readonly prototype: AsyncGeneratorFunction;
+}
+
+/**
+ * Represents the completion of an asynchronous operation
+ */
+interface Promise<T> {
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+}
+
+interface RegExpMatchArray {
+    groups?: {
+        [key: string]: string;
+    };
+}
+
+interface RegExpExecArray {
+    groups?: {
+        [key: string]: string;
+    };
+}
+
+interface RegExp {
+    /**
+     * Returns a Boolean value indicating the state of the dotAll flag (s) used with a regular expression.
+     * Default is false. Read-only.
+     */
+    readonly dotAll: boolean;
+}
+
+declare namespace Intl {
+    // http://cldr.unicode.org/index/cldr-spec/plural-rules#TOC-Determining-Plural-Categories
+    type LDMLPluralRule = "zero" | "one" | "two" | "few" | "many" | "other";
+    type PluralRuleType = "cardinal" | "ordinal";
+
+    interface PluralRulesOptions {
+        localeMatcher?: "lookup" | "best fit" | undefined;
+        type?: PluralRuleType | undefined;
+        minimumIntegerDigits?: number | undefined;
+        minimumFractionDigits?: number | undefined;
+        maximumFractionDigits?: number | undefined;
+        minimumSignificantDigits?: number | undefined;
+        maximumSignificantDigits?: number | undefined;
+    }
+
+    interface ResolvedPluralRulesOptions {
+        locale: string;
+        pluralCategories: LDMLPluralRule[];
+        type: PluralRuleType;
+        minimumIntegerDigits: number;
+        minimumFractionDigits: number;
+        maximumFractionDigits: number;
+        minimumSignificantDigits?: number;
+        maximumSignificantDigits?: number;
+    }
+
+    interface PluralRules {
+        resolvedOptions(): ResolvedPluralRulesOptions;
+        select(n: number): LDMLPluralRule;
+    }
+
+    interface PluralRulesConstructor {
+        new (locales?: string | readonly string[], options?: PluralRulesOptions): PluralRules;
+        (locales?: string | readonly string[], options?: PluralRulesOptions): PluralRules;
+        supportedLocalesOf(locales: string | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[];
+    }
+
+    const PluralRules: PluralRulesConstructor;
+
+    interface NumberFormatPartTypeRegistry {
+        literal: never;
+        nan: never;
+        infinity: never;
+        percent: never;
+        integer: never;
+        group: never;
+        decimal: never;
+        fraction: never;
+        plusSign: never;
+        minusSign: never;
+        percentSign: never;
+        currency: never;
+    }
+
+    type NumberFormatPartTypes = keyof NumberFormatPartTypeRegistry;
+
+    interface NumberFormatPart {
+        type: NumberFormatPartTypes;
+        value: string;
+    }
+
+    interface NumberFormat {
+        formatToParts(number?: number | bigint): NumberFormatPart[];
+    }
+}
+
+
+type FlatArray<Arr, Depth extends number> = {
+    done: Arr;
+    recur: Arr extends ReadonlyArray<infer InnerArr> ? FlatArray<InnerArr, [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20][Depth]>
+        : Arr;
+}[Depth extends -1 ? "done" : "recur"];
+
+interface ReadonlyArray<T> {
+    /**
+     * Calls a defined callback function on each element of an array. Then, flattens the result into
+     * a new array.
+     * This is identical to a map followed by flat with depth 1.
+     *
+     * @param callback A function that accepts up to three arguments. The flatMap method calls the
+     * callback function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callback function. If
+     * thisArg is omitted, undefined is used as the this value.
+     */
+    flatMap<U, This = undefined>(
+        callback: (this: This, value: T, index: number, array: T[]) => U | ReadonlyArray<U>,
+        thisArg?: This,
+    ): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<A, D extends number = 1>(
+        this: A,
+        depth?: D,
+    ): FlatArray<A, D>[];
+}
+
+interface Array<T> {
+    /**
+     * Calls a defined callback function on each element of an array. Then, flattens the result into
+     * a new array.
+     * This is identical to a map followed by flat with depth 1.
+     *
+     * @param callback A function that accepts up to three arguments. The flatMap method calls the
+     * callback function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callback function. If
+     * thisArg is omitted, undefined is used as the this value.
+     */
+    flatMap<U, This = undefined>(
+        callback: (this: This, value: T, index: number, array: T[]) => U | ReadonlyArray<U>,
+        thisArg?: This,
+    ): U[];
+
+    /**
+     * Returns a new array with all sub-array elements concatenated into it recursively up to the
+     * specified depth.
+     *
+     * @param depth The maximum recursion depth
+     */
+    flat<A, D extends number = 1>(
+        this: A,
+        depth?: D,
+    ): FlatArray<A, D>[];
+}
+
+
+interface ObjectConstructor {
+    /**
+     * Returns an object created by key-value entries for properties and methods
+     * @param entries An iterable object that contains key-value entries for properties and methods.
+     */
+    fromEntries<T = any>(entries: Iterable<readonly [PropertyKey, T]>): { [k: string]: T; };
+
+    /**
+     * Returns an object created by key-value entries for properties and methods
+     * @param entries An iterable object that contains key-value entries for properties and methods.
+     */
+    fromEntries(entries: Iterable<readonly any[]>): any;
+}
+
+interface String {
+    /** Removes the trailing white space and line terminator characters from a string. */
+    trimEnd(): string;
+
+    /** Removes the leading white space and line terminator characters from a string. */
+    trimStart(): string;
+
+    /**
+     * Removes the leading white space and line terminator characters from a string.
+     * @deprecated A legacy feature for browser compatibility. Use `trimStart` instead
+     */
+    trimLeft(): string;
+
+    /**
+     * Removes the trailing white space and line terminator characters from a string.
+     * @deprecated A legacy feature for browser compatibility. Use `trimEnd` instead
+     */
+    trimRight(): string;
+}
+
+interface Symbol {
+    /**
+     * Expose the [[Description]] internal slot of a symbol directly.
+     */
+    readonly description: string | undefined;
+}
+
+declare namespace Intl {
+    interface DateTimeFormatPartTypesRegistry {
+        unknown: never;
+    }
+}
+
+
+declare namespace Intl {
+    /**
+     * A string that is a valid [Unicode BCP 47 Locale Identifier](https://unicode.org/reports/tr35/#Unicode_locale_identifier).
+     *
+     * For example: "fa", "es-MX", "zh-Hant-TW".
+     *
+     * See [MDN - Intl - locales argument](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument).
+     */
+    type UnicodeBCP47LocaleIdentifier = string;
+
+    /**
+     * Unit to use in the relative time internationalized message.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/format#Parameters).
+     */
+    type RelativeTimeFormatUnit =
+        | "year"
+        | "years"
+        | "quarter"
+        | "quarters"
+        | "month"
+        | "months"
+        | "week"
+        | "weeks"
+        | "day"
+        | "days"
+        | "hour"
+        | "hours"
+        | "minute"
+        | "minutes"
+        | "second"
+        | "seconds";
+
+    /**
+     * Value of the `unit` property in objects returned by
+     * `Intl.RelativeTimeFormat.prototype.formatToParts()`. `formatToParts` and
+     * `format` methods accept either singular or plural unit names as input,
+     * but `formatToParts` only outputs singular (e.g. "day") not plural (e.g.
+     * "days").
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/formatToParts#Using_formatToParts).
+     */
+    type RelativeTimeFormatUnitSingular =
+        | "year"
+        | "quarter"
+        | "month"
+        | "week"
+        | "day"
+        | "hour"
+        | "minute"
+        | "second";
+
+    /**
+     * The locale matching algorithm to use.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_negotiation).
+     */
+    type RelativeTimeFormatLocaleMatcher = "lookup" | "best fit";
+
+    /**
+     * The format of output message.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat#Parameters).
+     */
+    type RelativeTimeFormatNumeric = "always" | "auto";
+
+    /**
+     * The length of the internationalized message.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat#Parameters).
+     */
+    type RelativeTimeFormatStyle = "long" | "short" | "narrow";
+
+    /**
+     * The locale or locales to use
+     *
+     * See [MDN - Intl - locales argument](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument).
+     */
+    type LocalesArgument = UnicodeBCP47LocaleIdentifier | Locale | readonly (UnicodeBCP47LocaleIdentifier | Locale)[] | undefined;
+
+    /**
+     * An object with some or all of properties of `options` parameter
+     * of `Intl.RelativeTimeFormat` constructor.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat#Parameters).
+     */
+    interface RelativeTimeFormatOptions {
+        /** The locale matching algorithm to use. For information about this option, see [Intl page](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_negotiation). */
+        localeMatcher?: RelativeTimeFormatLocaleMatcher;
+        /** The format of output message. */
+        numeric?: RelativeTimeFormatNumeric;
+        /** The length of the internationalized message. */
+        style?: RelativeTimeFormatStyle;
+    }
+
+    /**
+     * An object with properties reflecting the locale
+     * and formatting options computed during initialization
+     * of the `Intl.RelativeTimeFormat` object
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/resolvedOptions#Description).
+     */
+    interface ResolvedRelativeTimeFormatOptions {
+        locale: UnicodeBCP47LocaleIdentifier;
+        style: RelativeTimeFormatStyle;
+        numeric: RelativeTimeFormatNumeric;
+        numberingSystem: string;
+    }
+
+    /**
+     * An object representing the relative time format in parts
+     * that can be used for custom locale-aware formatting.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/formatToParts#Using_formatToParts).
+     */
+    type RelativeTimeFormatPart =
+        | {
+            type: "literal";
+            value: string;
+        }
+        | {
+            type: Exclude<NumberFormatPartTypes, "literal">;
+            value: string;
+            unit: RelativeTimeFormatUnitSingular;
+        };
+
+    interface RelativeTimeFormat {
+        /**
+         * Formats a value and a unit according to the locale
+         * and formatting options of the given
+         * [`Intl.RelativeTimeFormat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat)
+         * object.
+         *
+         * While this method automatically provides the correct plural forms,
+         * the grammatical form is otherwise as neutral as possible.
+         *
+         * It is the caller's responsibility to handle cut-off logic
+         * such as deciding between displaying "in 7 days" or "in 1 week".
+         * This API does not support relative dates involving compound units.
+         * e.g "in 5 days and 4 hours".
+         *
+         * @param value -  Numeric value to use in the internationalized relative time message
+         *
+         * @param unit - [Unit](https://tc39.es/ecma402/#sec-singularrelativetimeunit) to use in the relative time internationalized message.
+         *
+         * @throws `RangeError` if `unit` was given something other than `unit` possible values
+         *
+         * @returns {string} Internationalized relative time message as string
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/format).
+         */
+        format(value: number, unit: RelativeTimeFormatUnit): string;
+
+        /**
+         *  Returns an array of objects representing the relative time format in parts that can be used for custom locale-aware formatting.
+         *
+         *  @param value - Numeric value to use in the internationalized relative time message
+         *
+         *  @param unit - [Unit](https://tc39.es/ecma402/#sec-singularrelativetimeunit) to use in the relative time internationalized message.
+         *
+         *  @throws `RangeError` if `unit` was given something other than `unit` possible values
+         *
+         *  [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/formatToParts).
+         */
+        formatToParts(value: number, unit: RelativeTimeFormatUnit): RelativeTimeFormatPart[];
+
+        /**
+         * Provides access to the locale and options computed during initialization of this `Intl.RelativeTimeFormat` object.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/resolvedOptions).
+         */
+        resolvedOptions(): ResolvedRelativeTimeFormatOptions;
+    }
+
+    /**
+     * The [`Intl.RelativeTimeFormat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat)
+     * object is a constructor for objects that enable language-sensitive relative time formatting.
+     *
+     * [Compatibility](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat#Browser_compatibility).
+     */
+    const RelativeTimeFormat: {
+        /**
+         * Creates [Intl.RelativeTimeFormat](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat) objects
+         *
+         * @param locales - A string with a [BCP 47 language tag](http://tools.ietf.org/html/rfc5646), or an array of such strings.
+         *  For the general form and interpretation of the locales argument,
+         *  see the [`Intl` page](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation).
+         *
+         * @param options - An [object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat#Parameters)
+         *  with some or all of options of `RelativeTimeFormatOptions`.
+         *
+         * @returns [Intl.RelativeTimeFormat](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat) object.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat).
+         */
+        new (
+            locales?: LocalesArgument,
+            options?: RelativeTimeFormatOptions,
+        ): RelativeTimeFormat;
+
+        /**
+         * Returns an array containing those of the provided locales
+         * that are supported in date and time formatting
+         * without having to fall back to the runtime's default locale.
+         *
+         * @param locales - A string with a [BCP 47 language tag](http://tools.ietf.org/html/rfc5646), or an array of such strings.
+         *  For the general form and interpretation of the locales argument,
+         *  see the [`Intl` page](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation).
+         *
+         * @param options - An [object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat#Parameters)
+         *  with some or all of options of the formatting.
+         *
+         * @returns An array containing those of the provided locales
+         *  that are supported in date and time formatting
+         *  without having to fall back to the runtime's default locale.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/supportedLocalesOf).
+         */
+        supportedLocalesOf(
+            locales?: LocalesArgument,
+            options?: RelativeTimeFormatOptions,
+        ): UnicodeBCP47LocaleIdentifier[];
+    };
+
+    interface NumberFormatOptionsStyleRegistry {
+        unit: never;
+    }
+
+    interface NumberFormatOptionsCurrencyDisplayRegistry {
+        narrowSymbol: never;
+    }
+
+    interface NumberFormatOptionsSignDisplayRegistry {
+        auto: never;
+        never: never;
+        always: never;
+        exceptZero: never;
+    }
+
+    type NumberFormatOptionsSignDisplay = keyof NumberFormatOptionsSignDisplayRegistry;
+
+    interface NumberFormatOptions {
+        numberingSystem?: string | undefined;
+        compactDisplay?: "short" | "long" | undefined;
+        notation?: "standard" | "scientific" | "engineering" | "compact" | undefined;
+        signDisplay?: NumberFormatOptionsSignDisplay | undefined;
+        unit?: string | undefined;
+        unitDisplay?: "short" | "long" | "narrow" | undefined;
+        currencySign?: "standard" | "accounting" | undefined;
+    }
+
+    interface ResolvedNumberFormatOptions {
+        compactDisplay?: "short" | "long";
+        notation: "standard" | "scientific" | "engineering" | "compact";
+        signDisplay: NumberFormatOptionsSignDisplay;
+        unit?: string;
+        unitDisplay?: "short" | "long" | "narrow";
+        currencySign?: "standard" | "accounting";
+    }
+
+    interface NumberFormatPartTypeRegistry {
+        compact: never;
+        exponentInteger: never;
+        exponentMinusSign: never;
+        exponentSeparator: never;
+        unit: never;
+        unknown: never;
+    }
+
+    interface DateTimeFormatOptions {
+        calendar?: string | undefined;
+        dayPeriod?: "narrow" | "short" | "long" | undefined;
+        numberingSystem?: string | undefined;
+
+        dateStyle?: "full" | "long" | "medium" | "short" | undefined;
+        timeStyle?: "full" | "long" | "medium" | "short" | undefined;
+        hourCycle?: "h11" | "h12" | "h23" | "h24" | undefined;
+    }
+
+    type LocaleHourCycleKey = "h12" | "h23" | "h11" | "h24";
+    type LocaleCollationCaseFirst = "upper" | "lower" | "false";
+
+    interface LocaleOptions {
+        /** A string containing the language, and the script and region if available. */
+        baseName?: string;
+        /** The part of the Locale that indicates the locale's calendar era. */
+        calendar?: string;
+        /** Flag that defines whether case is taken into account for the locale's collation rules. */
+        caseFirst?: LocaleCollationCaseFirst;
+        /** The collation type used for sorting */
+        collation?: string;
+        /** The time keeping format convention used by the locale. */
+        hourCycle?: LocaleHourCycleKey;
+        /** The primary language subtag associated with the locale. */
+        language?: string;
+        /** The numeral system used by the locale. */
+        numberingSystem?: string;
+        /** Flag that defines whether the locale has special collation handling for numeric characters. */
+        numeric?: boolean;
+        /** The region of the world (usually a country) associated with the locale. Possible values are region codes as defined by ISO 3166-1. */
+        region?: string;
+        /** The script used for writing the particular language used in the locale. Possible values are script codes as defined by ISO 15924. */
+        script?: string;
+    }
+
+    interface Locale extends LocaleOptions {
+        /** A string containing the language, and the script and region if available. */
+        baseName: string;
+        /** The primary language subtag associated with the locale. */
+        language: string;
+        /** Gets the most likely values for the language, script, and region of the locale based on existing values. */
+        maximize(): Locale;
+        /** Attempts to remove information about the locale that would be added by calling `Locale.maximize()`. */
+        minimize(): Locale;
+        /** Returns the locale's full locale identifier string. */
+        toString(): UnicodeBCP47LocaleIdentifier;
+    }
+
+    /**
+     * Constructor creates [Intl.Locale](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale)
+     * objects
+     *
+     * @param tag - A string with a [BCP 47 language tag](http://tools.ietf.org/html/rfc5646).
+     *  For the general form and interpretation of the locales argument,
+     *  see the [`Intl` page](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation).
+     *
+     * @param options - An [object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/Locale#Parameters) with some or all of options of the locale.
+     *
+     * @returns [Intl.Locale](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) object.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale).
+     */
+    const Locale: {
+        new (tag: UnicodeBCP47LocaleIdentifier | Locale, options?: LocaleOptions): Locale;
+    };
+
+    type DisplayNamesFallback =
+        | "code"
+        | "none";
+
+    type DisplayNamesType =
+        | "language"
+        | "region"
+        | "script"
+        | "calendar"
+        | "dateTimeField"
+        | "currency";
+
+    type DisplayNamesLanguageDisplay =
+        | "dialect"
+        | "standard";
+
+    interface DisplayNamesOptions {
+        localeMatcher?: RelativeTimeFormatLocaleMatcher;
+        style?: RelativeTimeFormatStyle;
+        type: DisplayNamesType;
+        languageDisplay?: DisplayNamesLanguageDisplay;
+        fallback?: DisplayNamesFallback;
+    }
+
+    interface ResolvedDisplayNamesOptions {
+        locale: UnicodeBCP47LocaleIdentifier;
+        style: RelativeTimeFormatStyle;
+        type: DisplayNamesType;
+        fallback: DisplayNamesFallback;
+        languageDisplay?: DisplayNamesLanguageDisplay;
+    }
+
+    interface DisplayNames {
+        /**
+         * Receives a code and returns a string based on the locale and options provided when instantiating
+         * [`Intl.DisplayNames()`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames)
+         *
+         * @param code The `code` to provide depends on the `type` passed to display name during creation:
+         *  - If the type is `"region"`, code should be either an [ISO-3166 two letters region code](https://www.iso.org/iso-3166-country-codes.html),
+         *    or a [three digits UN M49 Geographic Regions](https://unstats.un.org/unsd/methodology/m49/).
+         *  - If the type is `"script"`, code should be an [ISO-15924 four letters script code](https://unicode.org/iso15924/iso15924-codes.html).
+         *  - If the type is `"language"`, code should be a `languageCode` ["-" `scriptCode`] ["-" `regionCode` ] *("-" `variant` )
+         *    subsequence of the unicode_language_id grammar in [UTS 35's Unicode Language and Locale Identifiers grammar](https://unicode.org/reports/tr35/#Unicode_language_identifier).
+         *    `languageCode` is either a two letters ISO 639-1 language code or a three letters ISO 639-2 language code.
+         *  - If the type is `"currency"`, code should be a [3-letter ISO 4217 currency code](https://www.iso.org/iso-4217-currency-codes.html).
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/of).
+         */
+        of(code: string): string | undefined;
+        /**
+         * Returns a new object with properties reflecting the locale and style formatting options computed during the construction of the current
+         * [`Intl/DisplayNames`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames) object.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/resolvedOptions).
+         */
+        resolvedOptions(): ResolvedDisplayNamesOptions;
+    }
+
+    /**
+     * The [`Intl.DisplayNames()`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames)
+     * object enables the consistent translation of language, region and script display names.
+     *
+     * [Compatibility](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames#browser_compatibility).
+     */
+    const DisplayNames: {
+        prototype: DisplayNames;
+
+        /**
+         * @param locales A string with a BCP 47 language tag, or an array of such strings.
+         *   For the general form and interpretation of the `locales` argument, see the [Intl](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#locale_identification_and_negotiation)
+         *   page.
+         *
+         * @param options An object for setting up a display name.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/DisplayNames).
+         */
+        new (locales: LocalesArgument, options: DisplayNamesOptions): DisplayNames;
+
+        /**
+         * Returns an array containing those of the provided locales that are supported in display names without having to fall back to the runtime's default locale.
+         *
+         * @param locales A string with a BCP 47 language tag, or an array of such strings.
+         *   For the general form and interpretation of the `locales` argument, see the [Intl](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#locale_identification_and_negotiation)
+         *   page.
+         *
+         * @param options An object with a locale matcher.
+         *
+         * @returns An array of strings representing a subset of the given locale tags that are supported in display names without having to fall back to the runtime's default locale.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames/supportedLocalesOf).
+         */
+        supportedLocalesOf(locales?: LocalesArgument, options?: { localeMatcher?: RelativeTimeFormatLocaleMatcher; }): UnicodeBCP47LocaleIdentifier[];
+    };
+
+    interface CollatorConstructor {
+        new (locales?: LocalesArgument, options?: CollatorOptions): Collator;
+        (locales?: LocalesArgument, options?: CollatorOptions): Collator;
+        supportedLocalesOf(locales: LocalesArgument, options?: CollatorOptions): string[];
+    }
+
+    interface DateTimeFormatConstructor {
+        new (locales?: LocalesArgument, options?: DateTimeFormatOptions): DateTimeFormat;
+        (locales?: LocalesArgument, options?: DateTimeFormatOptions): DateTimeFormat;
+        supportedLocalesOf(locales: LocalesArgument, options?: DateTimeFormatOptions): string[];
+    }
+
+    interface NumberFormatConstructor {
+        new (locales?: LocalesArgument, options?: NumberFormatOptions): NumberFormat;
+        (locales?: LocalesArgument, options?: NumberFormatOptions): NumberFormat;
+        supportedLocalesOf(locales: LocalesArgument, options?: NumberFormatOptions): string[];
+    }
+
+    interface PluralRulesConstructor {
+        new (locales?: LocalesArgument, options?: PluralRulesOptions): PluralRules;
+        (locales?: LocalesArgument, options?: PluralRulesOptions): PluralRules;
+
+        supportedLocalesOf(locales: LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[];
+    }
+}
+
+
+interface BigIntToLocaleStringOptions {
+    /**
+     * The locale matching algorithm to use.The default is "best fit". For information about this option, see the {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_negotiation Intl page}.
+     */
+    localeMatcher?: string;
+    /**
+     * The formatting style to use , the default is "decimal".
+     */
+    style?: string;
+
+    numberingSystem?: string;
+    /**
+     * The unit to use in unit formatting, Possible values are core unit identifiers, defined in UTS #35, Part 2, Section 6. A subset of units from the full list was selected for use in ECMAScript. Pairs of simple units can be concatenated with "-per-" to make a compound unit. There is no default value; if the style is "unit", the unit property must be provided.
+     */
+    unit?: string;
+
+    /**
+     * The unit formatting style to use in unit formatting, the defaults is "short".
+     */
+    unitDisplay?: string;
+
+    /**
+     * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB — see the Current currency & funds code list. There is no default value; if the style is "currency", the currency property must be provided. It is only used when [[Style]] has the value "currency".
+     */
+    currency?: string;
+
+    /**
+     * How to display the currency in currency formatting. It is only used when [[Style]] has the value "currency". The default is "symbol".
+     *
+     * "symbol" to use a localized currency symbol such as €,
+     *
+     * "code" to use the ISO currency code,
+     *
+     * "name" to use a localized currency name such as "dollar"
+     */
+    currencyDisplay?: string;
+
+    /**
+     * Whether to use grouping separators, such as thousands separators or thousand/lakh/crore separators. The default is true.
+     */
+    useGrouping?: boolean;
+
+    /**
+     * The minimum number of integer digits to use. Possible values are from 1 to 21; the default is 1.
+     */
+    minimumIntegerDigits?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21;
+
+    /**
+     * The minimum number of fraction digits to use. Possible values are from 0 to 20; the default for plain number and percent formatting is 0; the default for currency formatting is the number of minor unit digits provided by the {@link http://www.currency-iso.org/en/home/tables/table-a1.html ISO 4217 currency codes list} (2 if the list doesn't provide that information).
+     */
+    minimumFractionDigits?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20;
+
+    /**
+     * The maximum number of fraction digits to use. Possible values are from 0 to 20; the default for plain number formatting is the larger of minimumFractionDigits and 3; the default for currency formatting is the larger of minimumFractionDigits and the number of minor unit digits provided by the {@link http://www.currency-iso.org/en/home/tables/table-a1.html ISO 4217 currency codes list} (2 if the list doesn't provide that information); the default for percent formatting is the larger of minimumFractionDigits and 0.
+     */
+    maximumFractionDigits?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20;
+
+    /**
+     * The minimum number of significant digits to use. Possible values are from 1 to 21; the default is 1.
+     */
+    minimumSignificantDigits?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21;
+
+    /**
+     * The maximum number of significant digits to use. Possible values are from 1 to 21; the default is 21.
+     */
+    maximumSignificantDigits?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21;
+
+    /**
+     * The formatting that should be displayed for the number, the defaults is "standard"
+     *
+     *     "standard" plain number formatting
+     *
+     *     "scientific" return the order-of-magnitude for formatted number.
+     *
+     *     "engineering" return the exponent of ten when divisible by three
+     *
+     *     "compact" string representing exponent, defaults is using the "short" form
+     */
+    notation?: string;
+
+    /**
+     * used only when notation is "compact"
+     */
+    compactDisplay?: string;
+}
+
+interface BigInt {
+    /**
+     * Returns a string representation of an object.
+     * @param radix Specifies a radix for converting numeric values to strings.
+     */
+    toString(radix?: number): string;
+
+    /** Returns a string representation appropriate to the host environment's current locale. */
+    toLocaleString(locales?: Intl.LocalesArgument, options?: BigIntToLocaleStringOptions): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): bigint;
+
+    readonly [Symbol.toStringTag]: "BigInt";
+}
+
+interface BigIntConstructor {
+    (value: bigint | boolean | number | string): bigint;
+    readonly prototype: BigInt;
+
+    /**
+     * Interprets the low bits of a BigInt as a 2's-complement signed integer.
+     * All higher bits are discarded.
+     * @param bits The number of low bits to use
+     * @param int The BigInt whose bits to extract
+     */
+    asIntN(bits: number, int: bigint): bigint;
+    /**
+     * Interprets the low bits of a BigInt as an unsigned integer.
+     * All higher bits are discarded.
+     * @param bits The number of low bits to use
+     * @param int The BigInt whose bits to extract
+     */
+    asUintN(bits: number, int: bigint): bigint;
+}
+
+declare var BigInt: BigIntConstructor;
+
+/**
+ * A typed array of 64-bit signed integer values. The contents are initialized to 0. If the
+ * requested number of bytes could not be allocated, an exception is raised.
+ */
+interface BigInt64Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    /** The size in bytes of each element in the array. */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /** The ArrayBuffer instance referenced by the array. */
+    readonly buffer: TArrayBuffer;
+
+    /** The length in bytes of the array. */
+    readonly byteLength: number;
+
+    /** The offset in bytes of the array. */
+    readonly byteOffset: number;
+
+    /**
+     * Returns the this object after copying a section of the array identified by start and end
+     * to the same array starting at position target
+     * @param target If target is negative, it is treated as length+target where length is the
+     * length of the array.
+     * @param start If start is negative, it is treated as length+start. If end is negative, it
+     * is treated as length+end.
+     * @param end If not specified, length of the this object is used as its default value.
+     */
+    copyWithin(target: number, start: number, end?: number): this;
+
+    /** Yields index, value pairs for every entry in the array. */
+    entries(): ArrayIterator<[number, bigint]>;
+
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns false,
+     * or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every(predicate: (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) => boolean, thisArg?: any): boolean;
+
+    /**
+     * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+     * @param value value to fill array section with
+     * @param start index to start filling the array at. If start is negative, it is treated as
+     * length+start where length is the length of the array.
+     * @param end index to stop filling the array at. If end is negative, it is treated as
+     * length+end.
+     */
+    fill(value: bigint, start?: number, end?: number): this;
+
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls
+     * the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    filter(predicate: (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) => any, thisArg?: any): BigInt64Array<ArrayBuffer>;
+
+    /**
+     * Returns the value of the first element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    find(predicate: (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) => boolean, thisArg?: any): bigint | undefined;
+
+    /**
+     * Returns the index of the first element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findIndex(predicate: (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) => boolean, thisArg?: any): number;
+
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach(callbackfn: (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) => void, thisArg?: any): void;
+
+    /**
+     * Determines whether an array includes a certain element, returning true or false as appropriate.
+     * @param searchElement The element to search for.
+     * @param fromIndex The position in this array at which to begin searching for searchElement.
+     */
+    includes(searchElement: bigint, fromIndex?: number): boolean;
+
+    /**
+     * Returns the index of the first occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    indexOf(searchElement: bigint, fromIndex?: number): number;
+
+    /**
+     * Adds all the elements of an array separated by the specified separator string.
+     * @param separator A string used to separate one element of an array from the next in the
+     * resulting String. If omitted, the array elements are separated with a comma.
+     */
+    join(separator?: string): string;
+
+    /** Yields each index in the array. */
+    keys(): ArrayIterator<number>;
+
+    /**
+     * Returns the index of the last occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    lastIndexOf(searchElement: bigint, fromIndex?: number): number;
+
+    /** The length of the array. */
+    readonly length: number;
+
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that
+     * contains the results.
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    map(callbackfn: (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) => bigint, thisArg?: any): BigInt64Array<ArrayBuffer>;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce(callbackfn: (previousValue: bigint, currentValue: bigint, currentIndex: number, array: BigInt64Array<TArrayBuffer>) => bigint): bigint;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce<U>(callbackfn: (previousValue: U, currentValue: bigint, currentIndex: number, array: BigInt64Array<TArrayBuffer>) => U, initialValue: U): U;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an
+     * argument instead of an array value.
+     */
+    reduceRight(callbackfn: (previousValue: bigint, currentValue: bigint, currentIndex: number, array: BigInt64Array<TArrayBuffer>) => bigint): bigint;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: bigint, currentIndex: number, array: BigInt64Array<TArrayBuffer>) => U, initialValue: U): U;
+
+    /** Reverses the elements in the array. */
+    reverse(): this;
+
+    /**
+     * Sets a value or an array of values.
+     * @param array A typed or untyped array of values to set.
+     * @param offset The index in the current array at which the values are to be written.
+     */
+    set(array: ArrayLike<bigint>, offset?: number): void;
+
+    /**
+     * Returns a section of an array.
+     * @param start The beginning of the specified portion of the array.
+     * @param end The end of the specified portion of the array.
+     */
+    slice(start?: number, end?: number): BigInt64Array<ArrayBuffer>;
+
+    /**
+     * Determines whether the specified callback function returns true for any element of an array.
+     * @param predicate A function that accepts up to three arguments. The some method calls the
+     * predicate function for each element in the array until the predicate returns true, or until
+     * the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    some(predicate: (value: bigint, index: number, array: BigInt64Array<TArrayBuffer>) => boolean, thisArg?: any): boolean;
+
+    /**
+     * Sorts the array.
+     * @param compareFn The function used to determine the order of the elements. If omitted, the elements are sorted in ascending order.
+     */
+    sort(compareFn?: (a: bigint, b: bigint) => number | bigint): this;
+
+    /**
+     * Gets a new BigInt64Array view of the ArrayBuffer store for this array, referencing the elements
+     * at begin, inclusive, up to end, exclusive.
+     * @param begin The index of the beginning of the array.
+     * @param end The index of the end of the array.
+     */
+    subarray(begin?: number, end?: number): BigInt64Array<TArrayBuffer>;
+
+    /** Converts the array to a string by using the current locale. */
+    toLocaleString(locales?: string | string[], options?: Intl.NumberFormatOptions): string;
+
+    /** Returns a string representation of the array. */
+    toString(): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): BigInt64Array<TArrayBuffer>;
+
+    /** Yields each value in the array. */
+    values(): ArrayIterator<bigint>;
+
+    [Symbol.iterator](): ArrayIterator<bigint>;
+
+    readonly [Symbol.toStringTag]: "BigInt64Array";
+
+    [index: number]: bigint;
+}
+interface BigInt64ArrayConstructor {
+    readonly prototype: BigInt64Array<ArrayBufferLike>;
+    new (length?: number): BigInt64Array<ArrayBuffer>;
+    new (array: ArrayLike<bigint> | Iterable<bigint>): BigInt64Array<ArrayBuffer>;
+    new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): BigInt64Array<TArrayBuffer>;
+    new (buffer: ArrayBuffer, byteOffset?: number, length?: number): BigInt64Array<ArrayBuffer>;
+    new (array: ArrayLike<bigint> | ArrayBuffer): BigInt64Array<ArrayBuffer>;
+
+    /** The size in bytes of each element in the array. */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * Returns a new array from a set of elements.
+     * @param items A set of elements to include in the new array object.
+     */
+    of(...items: bigint[]): BigInt64Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     */
+    from(arrayLike: ArrayLike<bigint>): BigInt64Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<U>(arrayLike: ArrayLike<U>, mapfn: (v: U, k: number) => bigint, thisArg?: any): BigInt64Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     */
+    from(elements: Iterable<bigint>): BigInt64Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(elements: Iterable<T>, mapfn?: (v: T, k: number) => bigint, thisArg?: any): BigInt64Array<ArrayBuffer>;
+}
+declare var BigInt64Array: BigInt64ArrayConstructor;
+
+/**
+ * A typed array of 64-bit unsigned integer values. The contents are initialized to 0. If the
+ * requested number of bytes could not be allocated, an exception is raised.
+ */
+interface BigUint64Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
+    /** The size in bytes of each element in the array. */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /** The ArrayBuffer instance referenced by the array. */
+    readonly buffer: TArrayBuffer;
+
+    /** The length in bytes of the array. */
+    readonly byteLength: number;
+
+    /** The offset in bytes of the array. */
+    readonly byteOffset: number;
+
+    /**
+     * Returns the this object after copying a section of the array identified by start and end
+     * to the same array starting at position target
+     * @param target If target is negative, it is treated as length+target where length is the
+     * length of the array.
+     * @param start If start is negative, it is treated as length+start. If end is negative, it
+     * is treated as length+end.
+     * @param end If not specified, length of the this object is used as its default value.
+     */
+    copyWithin(target: number, start: number, end?: number): this;
+
+    /** Yields index, value pairs for every entry in the array. */
+    entries(): ArrayIterator<[number, bigint]>;
+
+    /**
+     * Determines whether all the members of an array satisfy the specified test.
+     * @param predicate A function that accepts up to three arguments. The every method calls
+     * the predicate function for each element in the array until the predicate returns false,
+     * or until the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    every(predicate: (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) => boolean, thisArg?: any): boolean;
+
+    /**
+     * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+     * @param value value to fill array section with
+     * @param start index to start filling the array at. If start is negative, it is treated as
+     * length+start where length is the length of the array.
+     * @param end index to stop filling the array at. If end is negative, it is treated as
+     * length+end.
+     */
+    fill(value: bigint, start?: number, end?: number): this;
+
+    /**
+     * Returns the elements of an array that meet the condition specified in a callback function.
+     * @param predicate A function that accepts up to three arguments. The filter method calls
+     * the predicate function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    filter(predicate: (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) => any, thisArg?: any): BigUint64Array<ArrayBuffer>;
+
+    /**
+     * Returns the value of the first element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found, find
+     * immediately returns that element value. Otherwise, find returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    find(predicate: (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) => boolean, thisArg?: any): bigint | undefined;
+
+    /**
+     * Returns the index of the first element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate find calls predicate once for each element of the array, in ascending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findIndex(predicate: (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) => boolean, thisArg?: any): number;
+
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach(callbackfn: (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) => void, thisArg?: any): void;
+
+    /**
+     * Determines whether an array includes a certain element, returning true or false as appropriate.
+     * @param searchElement The element to search for.
+     * @param fromIndex The position in this array at which to begin searching for searchElement.
+     */
+    includes(searchElement: bigint, fromIndex?: number): boolean;
+
+    /**
+     * Returns the index of the first occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    indexOf(searchElement: bigint, fromIndex?: number): number;
+
+    /**
+     * Adds all the elements of an array separated by the specified separator string.
+     * @param separator A string used to separate one element of an array from the next in the
+     * resulting String. If omitted, the array elements are separated with a comma.
+     */
+    join(separator?: string): string;
+
+    /** Yields each index in the array. */
+    keys(): ArrayIterator<number>;
+
+    /**
+     * Returns the index of the last occurrence of a value in an array.
+     * @param searchElement The value to locate in the array.
+     * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the
+     * search starts at index 0.
+     */
+    lastIndexOf(searchElement: bigint, fromIndex?: number): number;
+
+    /** The length of the array. */
+    readonly length: number;
+
+    /**
+     * Calls a defined callback function on each element of an array, and returns an array that
+     * contains the results.
+     * @param callbackfn A function that accepts up to three arguments. The map method calls the
+     * callbackfn function one time for each element in the array.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    map(callbackfn: (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) => bigint, thisArg?: any): BigUint64Array<ArrayBuffer>;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce(callbackfn: (previousValue: bigint, currentValue: bigint, currentIndex: number, array: BigUint64Array<TArrayBuffer>) => bigint): bigint;
+
+    /**
+     * Calls the specified callback function for all the elements in an array. The return value of
+     * the callback function is the accumulated result, and is provided as an argument in the next
+     * call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+     * callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduce<U>(callbackfn: (previousValue: U, currentValue: bigint, currentIndex: number, array: BigUint64Array<TArrayBuffer>) => U, initialValue: U): U;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an
+     * argument instead of an array value.
+     */
+    reduceRight(callbackfn: (previousValue: bigint, currentValue: bigint, currentIndex: number, array: BigUint64Array<TArrayBuffer>) => bigint): bigint;
+
+    /**
+     * Calls the specified callback function for all the elements in an array, in descending order.
+     * The return value of the callback function is the accumulated result, and is provided as an
+     * argument in the next call to the callback function.
+     * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+     * the callbackfn function one time for each element in the array.
+     * @param initialValue If initialValue is specified, it is used as the initial value to start
+     * the accumulation. The first call to the callbackfn function provides this value as an argument
+     * instead of an array value.
+     */
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: bigint, currentIndex: number, array: BigUint64Array<TArrayBuffer>) => U, initialValue: U): U;
+
+    /** Reverses the elements in the array. */
+    reverse(): this;
+
+    /**
+     * Sets a value or an array of values.
+     * @param array A typed or untyped array of values to set.
+     * @param offset The index in the current array at which the values are to be written.
+     */
+    set(array: ArrayLike<bigint>, offset?: number): void;
+
+    /**
+     * Returns a section of an array.
+     * @param start The beginning of the specified portion of the array.
+     * @param end The end of the specified portion of the array.
+     */
+    slice(start?: number, end?: number): BigUint64Array<ArrayBuffer>;
+
+    /**
+     * Determines whether the specified callback function returns true for any element of an array.
+     * @param predicate A function that accepts up to three arguments. The some method calls the
+     * predicate function for each element in the array until the predicate returns true, or until
+     * the end of the array.
+     * @param thisArg An object to which the this keyword can refer in the predicate function.
+     * If thisArg is omitted, undefined is used as the this value.
+     */
+    some(predicate: (value: bigint, index: number, array: BigUint64Array<TArrayBuffer>) => boolean, thisArg?: any): boolean;
+
+    /**
+     * Sorts the array.
+     * @param compareFn The function used to determine the order of the elements. If omitted, the elements are sorted in ascending order.
+     */
+    sort(compareFn?: (a: bigint, b: bigint) => number | bigint): this;
+
+    /**
+     * Gets a new BigUint64Array view of the ArrayBuffer store for this array, referencing the elements
+     * at begin, inclusive, up to end, exclusive.
+     * @param begin The index of the beginning of the array.
+     * @param end The index of the end of the array.
+     */
+    subarray(begin?: number, end?: number): BigUint64Array<TArrayBuffer>;
+
+    /** Converts the array to a string by using the current locale. */
+    toLocaleString(locales?: string | string[], options?: Intl.NumberFormatOptions): string;
+
+    /** Returns a string representation of the array. */
+    toString(): string;
+
+    /** Returns the primitive value of the specified object. */
+    valueOf(): BigUint64Array<TArrayBuffer>;
+
+    /** Yields each value in the array. */
+    values(): ArrayIterator<bigint>;
+
+    [Symbol.iterator](): ArrayIterator<bigint>;
+
+    readonly [Symbol.toStringTag]: "BigUint64Array";
+
+    [index: number]: bigint;
+}
+interface BigUint64ArrayConstructor {
+    readonly prototype: BigUint64Array<ArrayBufferLike>;
+    new (length?: number): BigUint64Array<ArrayBuffer>;
+    new (array: ArrayLike<bigint> | Iterable<bigint>): BigUint64Array<ArrayBuffer>;
+    new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number, length?: number): BigUint64Array<TArrayBuffer>;
+    new (buffer: ArrayBuffer, byteOffset?: number, length?: number): BigUint64Array<ArrayBuffer>;
+    new (array: ArrayLike<bigint> | ArrayBuffer): BigUint64Array<ArrayBuffer>;
+
+    /** The size in bytes of each element in the array. */
+    readonly BYTES_PER_ELEMENT: number;
+
+    /**
+     * Returns a new array from a set of elements.
+     * @param items A set of elements to include in the new array object.
+     */
+    of(...items: bigint[]): BigUint64Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     */
+    from(arrayLike: ArrayLike<bigint>): BigUint64Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param arrayLike An array-like object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<U>(arrayLike: ArrayLike<U>, mapfn: (v: U, k: number) => bigint, thisArg?: any): BigUint64Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     */
+    from(elements: Iterable<bigint>): BigUint64Array<ArrayBuffer>;
+
+    /**
+     * Creates an array from an array-like or iterable object.
+     * @param elements An iterable object to convert to an array.
+     * @param mapfn A mapping function to call on every element of the array.
+     * @param thisArg Value of 'this' used to invoke the mapfn.
+     */
+    from<T>(elements: Iterable<T>, mapfn?: (v: T, k: number) => bigint, thisArg?: any): BigUint64Array<ArrayBuffer>;
+}
+declare var BigUint64Array: BigUint64ArrayConstructor;
+
+interface DataView<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Gets the BigInt64 value at the specified byte offset from the start of the view. There is
+     * no alignment constraint; multi-byte values may be fetched from any offset.
+     * @param byteOffset The place in the buffer at which the value should be retrieved.
+     * @param littleEndian If false or undefined, a big-endian value should be read.
+     */
+    getBigInt64(byteOffset: number, littleEndian?: boolean): bigint;
+
+    /**
+     * Gets the BigUint64 value at the specified byte offset from the start of the view. There is
+     * no alignment constraint; multi-byte values may be fetched from any offset.
+     * @param byteOffset The place in the buffer at which the value should be retrieved.
+     * @param littleEndian If false or undefined, a big-endian value should be read.
+     */
+    getBigUint64(byteOffset: number, littleEndian?: boolean): bigint;
+
+    /**
+     * Stores a BigInt64 value at the specified byte offset from the start of the view.
+     * @param byteOffset The place in the buffer at which the value should be set.
+     * @param value The value to set.
+     * @param littleEndian If false or undefined, a big-endian value should be written.
+     */
+    setBigInt64(byteOffset: number, value: bigint, littleEndian?: boolean): void;
+
+    /**
+     * Stores a BigUint64 value at the specified byte offset from the start of the view.
+     * @param byteOffset The place in the buffer at which the value should be set.
+     * @param value The value to set.
+     * @param littleEndian If false or undefined, a big-endian value should be written.
+     */
+    setBigUint64(byteOffset: number, value: bigint, littleEndian?: boolean): void;
+}
+
+declare namespace Intl {
+    interface NumberFormat {
+        format(value: number | bigint): string;
+    }
+}
+
+
+interface Date {
+    /**
+     * Converts a date and time to a string by using the current or specified locale.
+     * @param locales A locale string, array of locale strings, Intl.Locale object, or array of Intl.Locale objects that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
+     * @param options An object that contains one or more properties that specify comparison options.
+     */
+    toLocaleString(locales?: Intl.LocalesArgument, options?: Intl.DateTimeFormatOptions): string;
+
+    /**
+     * Converts a date to a string by using the current or specified locale.
+     * @param locales A locale string, array of locale strings, Intl.Locale object, or array of Intl.Locale objects that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
+     * @param options An object that contains one or more properties that specify comparison options.
+     */
+    toLocaleDateString(locales?: Intl.LocalesArgument, options?: Intl.DateTimeFormatOptions): string;
+
+    /**
+     * Converts a time to a string by using the current or specified locale.
+     * @param locales A locale string, array of locale strings, Intl.Locale object, or array of Intl.Locale objects that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
+     * @param options An object that contains one or more properties that specify comparison options.
+     */
+    toLocaleTimeString(locales?: Intl.LocalesArgument, options?: Intl.DateTimeFormatOptions): string;
+}
+
+
+interface Number {
+    /**
+     * Converts a number to a string by using the current or specified locale.
+     * @param locales A locale string, array of locale strings, Intl.Locale object, or array of Intl.Locale objects that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
+     * @param options An object that contains one or more properties that specify comparison options.
+     */
+    toLocaleString(locales?: Intl.LocalesArgument, options?: Intl.NumberFormatOptions): string;
+}
+
+interface PromiseFulfilledResult<T> {
+    status: "fulfilled";
+    value: T;
+}
+
+interface PromiseRejectedResult {
+    status: "rejected";
+    reason: any;
+}
+
+type PromiseSettledResult<T> = PromiseFulfilledResult<T> | PromiseRejectedResult;
+
+interface PromiseConstructor {
+    /**
+     * Creates a Promise that is resolved with an array of results when all
+     * of the provided Promises resolve or reject.
+     * @param values An array of Promises.
+     * @returns A new Promise.
+     */
+    allSettled<T extends readonly unknown[] | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>;
+
+    /**
+     * Creates a Promise that is resolved with an array of results when all
+     * of the provided Promises resolve or reject.
+     * @param values An array of Promises.
+     * @returns A new Promise.
+     */
+    allSettled<T>(values: Iterable<T | PromiseLike<T>>): Promise<PromiseSettledResult<Awaited<T>>[]>;
+}
+
+
+interface Atomics {
+    /**
+     * Adds a value to the value at the given position in the array, returning the original value.
+     * Until this atomic operation completes, any other read or write operation against the array
+     * will block.
+     */
+    add(typedArray: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike>, index: number, value: bigint): bigint;
+
+    /**
+     * Stores the bitwise AND of a value with the value at the given position in the array,
+     * returning the original value. Until this atomic operation completes, any other read or
+     * write operation against the array will block.
+     */
+    and(typedArray: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike>, index: number, value: bigint): bigint;
+
+    /**
+     * Replaces the value at the given position in the array if the original value equals the given
+     * expected value, returning the original value. Until this atomic operation completes, any
+     * other read or write operation against the array will block.
+     */
+    compareExchange(typedArray: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike>, index: number, expectedValue: bigint, replacementValue: bigint): bigint;
+
+    /**
+     * Replaces the value at the given position in the array, returning the original value. Until
+     * this atomic operation completes, any other read or write operation against the array will
+     * block.
+     */
+    exchange(typedArray: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike>, index: number, value: bigint): bigint;
+
+    /**
+     * Returns the value at the given position in the array. Until this atomic operation completes,
+     * any other read or write operation against the array will block.
+     */
+    load(typedArray: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike>, index: number): bigint;
+
+    /**
+     * Stores the bitwise OR of a value with the value at the given position in the array,
+     * returning the original value. Until this atomic operation completes, any other read or write
+     * operation against the array will block.
+     */
+    or(typedArray: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike>, index: number, value: bigint): bigint;
+
+    /**
+     * Stores a value at the given position in the array, returning the new value. Until this
+     * atomic operation completes, any other read or write operation against the array will block.
+     */
+    store(typedArray: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike>, index: number, value: bigint): bigint;
+
+    /**
+     * Subtracts a value from the value at the given position in the array, returning the original
+     * value. Until this atomic operation completes, any other read or write operation against the
+     * array will block.
+     */
+    sub(typedArray: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike>, index: number, value: bigint): bigint;
+
+    /**
+     * If the value at the given position in the array is equal to the provided value, the current
+     * agent is put to sleep causing execution to suspend until the timeout expires (returning
+     * `"timed-out"`) or until the agent is awoken (returning `"ok"`); otherwise, returns
+     * `"not-equal"`.
+     */
+    wait(typedArray: BigInt64Array<ArrayBufferLike>, index: number, value: bigint, timeout?: number): "ok" | "not-equal" | "timed-out";
+
+    /**
+     * Wakes up sleeping agents that are waiting on the given index of the array, returning the
+     * number of agents that were awoken.
+     * @param typedArray A shared BigInt64Array.
+     * @param index The position in the typedArray to wake up on.
+     * @param count The number of sleeping agents to notify. Defaults to +Infinity.
+     */
+    notify(typedArray: BigInt64Array<ArrayBufferLike>, index: number, count?: number): number;
+
+    /**
+     * Stores the bitwise XOR of a value with the value at the given position in the array,
+     * returning the original value. Until this atomic operation completes, any other read or write
+     * operation against the array will block.
+     */
+    xor(typedArray: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike>, index: number, value: bigint): bigint;
+}
+
+
+interface SymbolConstructor {
+    /**
+     * A regular expression method that matches the regular expression against a string. Called
+     * by the String.prototype.matchAll method.
+     */
+    readonly matchAll: unique symbol;
+}
+
+interface RegExpStringIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+    [Symbol.iterator](): RegExpStringIterator<T>;
+}
+
+interface RegExp {
+    /**
+     * Matches a string with this regular expression, and returns an iterable of matches
+     * containing the results of that search.
+     * @param string A string to search within.
+     */
+    [Symbol.matchAll](str: string): RegExpStringIterator<RegExpMatchArray>;
+}
+
+
+interface String {
+    /**
+     * Matches a string with a regular expression, and returns an iterable of matches
+     * containing the results of that search.
+     * @param regexp A variable name or string literal containing the regular expression pattern and flags.
+     */
+    matchAll(regexp: RegExp): RegExpStringIterator<RegExpExecArray>;
+
+    /** Converts all alphabetic characters to lowercase, taking into account the host environment's current locale. */
+    toLocaleLowerCase(locales?: Intl.LocalesArgument): string;
+
+    /** Returns a string where all alphabetic characters have been converted to uppercase, taking into account the host environment's current locale. */
+    toLocaleUpperCase(locales?: Intl.LocalesArgument): string;
+
+    /**
+     * Determines whether two strings are equivalent in the current or specified locale.
+     * @param that String to compare to target string
+     * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used. This parameter must conform to BCP 47 standards; see the Intl.Collator object for details.
+     * @param options An object that contains one or more properties that specify comparison options. see the Intl.Collator object for details.
+     */
+    localeCompare(that: string, locales?: Intl.LocalesArgument, options?: Intl.CollatorOptions): number;
+}
+
+
+interface AggregateError extends Error {
+    errors: any[];
+}
+
+interface AggregateErrorConstructor {
+    new (errors: Iterable<any>, message?: string): AggregateError;
+    (errors: Iterable<any>, message?: string): AggregateError;
+    readonly prototype: AggregateError;
+}
+
+declare var AggregateError: AggregateErrorConstructor;
+
+/**
+ * Represents the completion of an asynchronous operation
+ */
+interface PromiseConstructor {
+    /**
+     * The any function returns a promise that is fulfilled by the first given promise to be fulfilled, or rejected with an AggregateError containing an array of rejection reasons if all of the given promises are rejected. It resolves all elements of the passed iterable to promises as it runs this algorithm.
+     * @param values An array or iterable of Promises.
+     * @returns A new Promise.
+     */
+    any<T extends readonly unknown[] | []>(values: T): Promise<Awaited<T[number]>>;
+
+    /**
+     * The any function returns a promise that is fulfilled by the first given promise to be fulfilled, or rejected with an AggregateError containing an array of rejection reasons if all of the given promises are rejected. It resolves all elements of the passed iterable to promises as it runs this algorithm.
+     * @param values An array or iterable of Promises.
+     * @returns A new Promise.
+     */
+    any<T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>;
+}
+
+interface String {
+    /**
+     * Replace all instances of a substring in a string, using a regular expression or search string.
+     * @param searchValue A string to search for.
+     * @param replaceValue A string containing the text to replace for every successful match of searchValue in this string.
+     */
+    replaceAll(searchValue: string | RegExp, replaceValue: string): string;
+
+    /**
+     * Replace all instances of a substring in a string, using a regular expression or search string.
+     * @param searchValue A string to search for.
+     * @param replacer A function that returns the replacement text.
+     */
+    replaceAll(searchValue: string | RegExp, replacer: (substring: string, ...args: any[]) => string): string;
+}
+
+
+interface WeakRef<T extends WeakKey> {
+    readonly [Symbol.toStringTag]: "WeakRef";
+
+    /**
+     * Returns the WeakRef instance's target value, or undefined if the target value has been
+     * reclaimed.
+     * In es2023 the value can be either a symbol or an object, in previous versions only object is permissible.
+     */
+    deref(): T | undefined;
+}
+
+interface WeakRefConstructor {
+    readonly prototype: WeakRef<any>;
+
+    /**
+     * Creates a WeakRef instance for the given target value.
+     * In es2023 the value can be either a symbol or an object, in previous versions only object is permissible.
+     * @param target The target value for the WeakRef instance.
+     */
+    new <T extends WeakKey>(target: T): WeakRef<T>;
+}
+
+declare var WeakRef: WeakRefConstructor;
+
+interface FinalizationRegistry<T> {
+    readonly [Symbol.toStringTag]: "FinalizationRegistry";
+
+    /**
+     * Registers a value with the registry.
+     * In es2023 the value can be either a symbol or an object, in previous versions only object is permissible.
+     * @param target The target value to register.
+     * @param heldValue The value to pass to the finalizer for this value. This cannot be the
+     * target value.
+     * @param unregisterToken The token to pass to the unregister method to unregister the target
+     * value. If not provided, the target cannot be unregistered.
+     */
+    register(target: WeakKey, heldValue: T, unregisterToken?: WeakKey): void;
+
+    /**
+     * Unregisters a value from the registry.
+     * In es2023 the value can be either a symbol or an object, in previous versions only object is permissible.
+     * @param unregisterToken The token that was used as the unregisterToken argument when calling
+     * register to register the target value.
+     */
+    unregister(unregisterToken: WeakKey): boolean;
+}
+
+interface FinalizationRegistryConstructor {
+    readonly prototype: FinalizationRegistry<any>;
+
+    /**
+     * Creates a finalization registry with an associated cleanup callback
+     * @param cleanupCallback The callback to call after a value in the registry has been reclaimed.
+     */
+    new <T>(cleanupCallback: (heldValue: T) => void): FinalizationRegistry<T>;
+}
+
+declare var FinalizationRegistry: FinalizationRegistryConstructor;
+
+declare namespace Intl {
+    interface DateTimeFormatPartTypesRegistry {
+        fractionalSecond: any;
+    }
+
+    interface DateTimeFormatOptions {
+        formatMatcher?: "basic" | "best fit" | "best fit" | undefined;
+        dateStyle?: "full" | "long" | "medium" | "short" | undefined;
+        timeStyle?: "full" | "long" | "medium" | "short" | undefined;
+        dayPeriod?: "narrow" | "short" | "long" | undefined;
+        fractionalSecondDigits?: 1 | 2 | 3 | undefined;
+    }
+
+    interface DateTimeRangeFormatPart extends DateTimeFormatPart {
+        source: "startRange" | "endRange" | "shared";
+    }
+
+    interface DateTimeFormat {
+        formatRange(startDate: Date | number | bigint, endDate: Date | number | bigint): string;
+        formatRangeToParts(startDate: Date | number | bigint, endDate: Date | number | bigint): DateTimeRangeFormatPart[];
+    }
+
+    interface ResolvedDateTimeFormatOptions {
+        formatMatcher?: "basic" | "best fit" | "best fit";
+        dateStyle?: "full" | "long" | "medium" | "short";
+        timeStyle?: "full" | "long" | "medium" | "short";
+        hourCycle?: "h11" | "h12" | "h23" | "h24";
+        dayPeriod?: "narrow" | "short" | "long";
+        fractionalSecondDigits?: 1 | 2 | 3;
+    }
+
+    /**
+     * The locale matching algorithm to use.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat#parameters).
+     */
+    type ListFormatLocaleMatcher = "lookup" | "best fit";
+
+    /**
+     * The format of output message.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat#parameters).
+     */
+    type ListFormatType = "conjunction" | "disjunction" | "unit";
+
+    /**
+     * The length of the formatted message.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat#parameters).
+     */
+    type ListFormatStyle = "long" | "short" | "narrow";
+
+    /**
+     * An object with some or all properties of the `Intl.ListFormat` constructor `options` parameter.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat#parameters).
+     */
+    interface ListFormatOptions {
+        /** The locale matching algorithm to use. For information about this option, see [Intl page](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_negotiation). */
+        localeMatcher?: ListFormatLocaleMatcher | undefined;
+        /** The format of output message. */
+        type?: ListFormatType | undefined;
+        /** The length of the internationalized message. */
+        style?: ListFormatStyle | undefined;
+    }
+
+    interface ResolvedListFormatOptions {
+        locale: string;
+        style: ListFormatStyle;
+        type: ListFormatType;
+    }
+
+    interface ListFormat {
+        /**
+         * Returns a string with a language-specific representation of the list.
+         *
+         * @param list - An iterable object, such as an [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array).
+         *
+         * @throws `TypeError` if `list` includes something other than the possible values.
+         *
+         * @returns {string} A language-specific formatted string representing the elements of the list.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/format).
+         */
+        format(list: Iterable<string>): string;
+
+        /**
+         * Returns an Array of objects representing the different components that can be used to format a list of values in a locale-aware fashion.
+         *
+         * @param list - An iterable object, such as an [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array), to be formatted according to a locale.
+         *
+         * @throws `TypeError` if `list` includes something other than the possible values.
+         *
+         * @returns {{ type: "element" | "literal", value: string; }[]} An Array of components which contains the formatted parts from the list.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/formatToParts).
+         */
+        formatToParts(list: Iterable<string>): { type: "element" | "literal"; value: string; }[];
+
+        /**
+         * Returns a new object with properties reflecting the locale and style
+         * formatting options computed during the construction of the current
+         * `Intl.ListFormat` object.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/resolvedOptions).
+         */
+        resolvedOptions(): ResolvedListFormatOptions;
+    }
+
+    const ListFormat: {
+        prototype: ListFormat;
+
+        /**
+         * Creates [Intl.ListFormat](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) objects that
+         * enable language-sensitive list formatting.
+         *
+         * @param locales - A string with a [BCP 47 language tag](http://tools.ietf.org/html/rfc5646), or an array of such strings.
+         *  For the general form and interpretation of the `locales` argument,
+         *  see the [`Intl` page](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation).
+         *
+         * @param options - An [object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat#parameters)
+         *  with some or all options of `ListFormatOptions`.
+         *
+         * @returns [Intl.ListFormatOptions](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) object.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat).
+         */
+        new (locales?: LocalesArgument, options?: ListFormatOptions): ListFormat;
+
+        /**
+         * Returns an array containing those of the provided locales that are
+         * supported in list formatting without having to fall back to the runtime's default locale.
+         *
+         * @param locales - A string with a [BCP 47 language tag](http://tools.ietf.org/html/rfc5646), or an array of such strings.
+         *  For the general form and interpretation of the `locales` argument,
+         *  see the [`Intl` page](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation).
+         *
+         * @param options - An [object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/supportedLocalesOf#parameters).
+         *  with some or all possible options.
+         *
+         * @returns An array of strings representing a subset of the given locale tags that are supported in list
+         *  formatting without having to fall back to the runtime's default locale.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/supportedLocalesOf).
+         */
+        supportedLocalesOf(locales: LocalesArgument, options?: Pick<ListFormatOptions, "localeMatcher">): UnicodeBCP47LocaleIdentifier[];
+    };
+}
+
+
+interface Array<T> {
+    /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): T | undefined;
+}
+
+interface ReadonlyArray<T> {
+    /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): T | undefined;
+}
+
+interface Int8Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): number | undefined;
+}
+
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): number | undefined;
+}
+
+interface Uint8ClampedArray<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): number | undefined;
+}
+
+interface Int16Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): number | undefined;
+}
+
+interface Uint16Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): number | undefined;
+}
+
+interface Int32Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): number | undefined;
+}
+
+interface Uint32Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): number | undefined;
+}
+
+interface Float32Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): number | undefined;
+}
+
+interface Float64Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): number | undefined;
+}
+
+interface BigInt64Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): bigint | undefined;
+}
+
+interface BigUint64Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the item located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): bigint | undefined;
+}
+
+
+interface ErrorOptions {
+    cause?: unknown;
+}
+
+interface Error {
+    cause?: unknown;
+}
+
+interface ErrorConstructor {
+    new (message?: string, options?: ErrorOptions): Error;
+    (message?: string, options?: ErrorOptions): Error;
+}
+
+interface EvalErrorConstructor {
+    new (message?: string, options?: ErrorOptions): EvalError;
+    (message?: string, options?: ErrorOptions): EvalError;
+}
+
+interface RangeErrorConstructor {
+    new (message?: string, options?: ErrorOptions): RangeError;
+    (message?: string, options?: ErrorOptions): RangeError;
+}
+
+interface ReferenceErrorConstructor {
+    new (message?: string, options?: ErrorOptions): ReferenceError;
+    (message?: string, options?: ErrorOptions): ReferenceError;
+}
+
+interface SyntaxErrorConstructor {
+    new (message?: string, options?: ErrorOptions): SyntaxError;
+    (message?: string, options?: ErrorOptions): SyntaxError;
+}
+
+interface TypeErrorConstructor {
+    new (message?: string, options?: ErrorOptions): TypeError;
+    (message?: string, options?: ErrorOptions): TypeError;
+}
+
+interface URIErrorConstructor {
+    new (message?: string, options?: ErrorOptions): URIError;
+    (message?: string, options?: ErrorOptions): URIError;
+}
+
+interface AggregateErrorConstructor {
+    new (
+        errors: Iterable<any>,
+        message?: string,
+        options?: ErrorOptions,
+    ): AggregateError;
+    (
+        errors: Iterable<any>,
+        message?: string,
+        options?: ErrorOptions,
+    ): AggregateError;
+}
+
+declare namespace Intl {
+    /**
+     * An object with some or all properties of the `Intl.Segmenter` constructor `options` parameter.
+     *
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/Segmenter#parameters)
+     */
+    interface SegmenterOptions {
+        /** The locale matching algorithm to use. For information about this option, see [Intl page](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_negotiation). */
+        localeMatcher?: "best fit" | "lookup" | undefined;
+        /** The type of input to be split */
+        granularity?: "grapheme" | "word" | "sentence" | undefined;
+    }
+
+    interface Segmenter {
+        /**
+         * Returns `Segments` object containing the segments of the input string, using the segmenter's locale and granularity.
+         *
+         * @param input - The text to be segmented as a `string`.
+         *
+         * @returns A new iterable Segments object containing the segments of the input string, using the segmenter's locale and granularity.
+         */
+        segment(input: string): Segments;
+        resolvedOptions(): ResolvedSegmenterOptions;
+    }
+
+    interface ResolvedSegmenterOptions {
+        locale: string;
+        granularity: "grapheme" | "word" | "sentence";
+    }
+
+    interface SegmentIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+        [Symbol.iterator](): SegmentIterator<T>;
+    }
+
+    interface Segments {
+        /**
+         * Returns an object describing the segment in the original string that includes the code unit at a specified index.
+         *
+         * @param codeUnitIndex - A number specifying the index of the code unit in the original input string. If the value is omitted, it defaults to `0`.
+         */
+        containing(codeUnitIndex?: number): SegmentData;
+
+        /** Returns an iterator to iterate over the segments. */
+        [Symbol.iterator](): SegmentIterator<SegmentData>;
+    }
+
+    interface SegmentData {
+        /** A string containing the segment extracted from the original input string. */
+        segment: string;
+        /** The code unit index in the original input string at which the segment begins. */
+        index: number;
+        /** The complete input string that was segmented. */
+        input: string;
+        /**
+         * A boolean value only if granularity is "word"; otherwise, undefined.
+         * If granularity is "word", then isWordLike is true when the segment is word-like (i.e., consists of letters/numbers/ideographs/etc.); otherwise, false.
+         */
+        isWordLike?: boolean;
+    }
+
+    const Segmenter: {
+        prototype: Segmenter;
+
+        /**
+         * Creates a new `Intl.Segmenter` object.
+         *
+         * @param locales - A string with a [BCP 47 language tag](http://tools.ietf.org/html/rfc5646), or an array of such strings.
+         *  For the general form and interpretation of the `locales` argument,
+         *  see the [`Intl` page](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation).
+         *
+         * @param options - An [object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/Segmenter#parameters)
+         *  with some or all options of `SegmenterOptions`.
+         *
+         * @returns [Intl.Segmenter](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments) object.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter).
+         */
+        new (locales?: LocalesArgument, options?: SegmenterOptions): Segmenter;
+
+        /**
+         * Returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.
+         *
+         * @param locales - A string with a [BCP 47 language tag](http://tools.ietf.org/html/rfc5646), or an array of such strings.
+         *  For the general form and interpretation of the `locales` argument,
+         *  see the [`Intl` page](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation).
+         *
+         * @param options An [object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/supportedLocalesOf#parameters).
+         *  with some or all possible options.
+         *
+         * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/supportedLocalesOf)
+         */
+        supportedLocalesOf(locales: LocalesArgument, options?: Pick<SegmenterOptions, "localeMatcher">): UnicodeBCP47LocaleIdentifier[];
+    };
+
+    /**
+     * Returns a sorted array of the supported collation, calendar, currency, numbering system, timezones, and units by the implementation.
+     * [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf)
+     *
+     * @param key A string indicating the category of values to return.
+     * @returns A sorted array of the supported values.
+     */
+    function supportedValuesOf(key: "calendar" | "collation" | "currency" | "numberingSystem" | "timeZone" | "unit"): string[];
+}
+
+interface ObjectConstructor {
+    /**
+     * Determines whether an object has a property with the specified name.
+     * @param o An object.
+     * @param v A property name.
+     */
+    hasOwn(o: object, v: PropertyKey): boolean;
+}
+
+interface RegExpMatchArray {
+    indices?: RegExpIndicesArray;
+}
+
+interface RegExpExecArray {
+    indices?: RegExpIndicesArray;
+}
+
+interface RegExpIndicesArray extends Array<[number, number]> {
+    groups?: {
+        [key: string]: [number, number];
+    };
+}
+
+interface RegExp {
+    /**
+     * Returns a Boolean value indicating the state of the hasIndices flag (d) used with a regular expression.
+     * Default is false. Read-only.
+     */
+    readonly hasIndices: boolean;
+}
+
+interface String {
+    /**
+     * Returns a new String consisting of the single UTF-16 code unit located at the specified index.
+     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+     */
+    at(index: number): string | undefined;
+}
+
+
+interface Array<T> {
+    /**
+     * Returns the value of the last element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate findLast calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found, findLast
+     * immediately returns that element value. Otherwise, findLast returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLast<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): S | undefined;
+    findLast(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T | undefined;
+
+    /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate findLastIndex calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): number;
+
+    /**
+     * Returns a copy of an array with its elements reversed.
+     */
+    toReversed(): T[];
+
+    /**
+     * Returns a copy of an array with its elements sorted.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending, UTF-16 code unit order.
+     * ```ts
+     * [11, 2, 22, 1].toSorted((a, b) => a - b) // [1, 2, 11, 22]
+     * ```
+     */
+    toSorted(compareFn?: (a: T, b: T) => number): T[];
+
+    /**
+     * Copies an array and removes elements and, if necessary, inserts new elements in their place. Returns the copied array.
+     * @param start The zero-based location in the array from which to start removing elements.
+     * @param deleteCount The number of elements to remove.
+     * @param items Elements to insert into the copied array in place of the deleted elements.
+     * @returns The copied array.
+     */
+    toSpliced(start: number, deleteCount: number, ...items: T[]): T[];
+
+    /**
+     * Copies an array and removes elements while returning the remaining elements.
+     * @param start The zero-based location in the array from which to start removing elements.
+     * @param deleteCount The number of elements to remove.
+     * @returns A copy of the original array with the remaining elements.
+     */
+    toSpliced(start: number, deleteCount?: number): T[];
+
+    /**
+     * Copies an array, then overwrites the value at the provided index with the
+     * given value. If the index is negative, then it replaces from the end
+     * of the array.
+     * @param index The index of the value to overwrite. If the index is
+     * negative, then it replaces from the end of the array.
+     * @param value The value to write into the copied array.
+     * @returns The copied array with the updated value.
+     */
+    with(index: number, value: T): T[];
+}
+
+interface ReadonlyArray<T> {
+    /**
+     * Returns the value of the last element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate findLast calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found, findLast
+     * immediately returns that element value. Otherwise, findLast returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLast<S extends T>(
+        predicate: (value: T, index: number, array: readonly T[]) => value is S,
+        thisArg?: any,
+    ): S | undefined;
+    findLast(
+        predicate: (value: T, index: number, array: readonly T[]) => unknown,
+        thisArg?: any,
+    ): T | undefined;
+
+    /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate findLastIndex calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex(
+        predicate: (value: T, index: number, array: readonly T[]) => unknown,
+        thisArg?: any,
+    ): number;
+
+    /**
+     * Copies the array and returns the copied array with all of its elements reversed.
+     */
+    toReversed(): T[];
+
+    /**
+     * Copies and sorts the array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending, UTF-16 code unit order.
+     * ```ts
+     * [11, 2, 22, 1].toSorted((a, b) => a - b) // [1, 2, 11, 22]
+     * ```
+     */
+    toSorted(compareFn?: (a: T, b: T) => number): T[];
+
+    /**
+     * Copies an array and removes elements while, if necessary, inserting new elements in their place, returning the remaining elements.
+     * @param start The zero-based location in the array from which to start removing elements.
+     * @param deleteCount The number of elements to remove.
+     * @param items Elements to insert into the copied array in place of the deleted elements.
+     * @returns A copy of the original array with the remaining elements.
+     */
+    toSpliced(start: number, deleteCount: number, ...items: T[]): T[];
+
+    /**
+     * Copies an array and removes elements while returning the remaining elements.
+     * @param start The zero-based location in the array from which to start removing elements.
+     * @param deleteCount The number of elements to remove.
+     * @returns A copy of the original array with the remaining elements.
+     */
+    toSpliced(start: number, deleteCount?: number): T[];
+
+    /**
+     * Copies an array, then overwrites the value at the provided index with the
+     * given value. If the index is negative, then it replaces from the end
+     * of the array
+     * @param index The index of the value to overwrite. If the index is
+     * negative, then it replaces from the end of the array.
+     * @param value The value to insert into the copied array.
+     * @returns A copy of the original array with the inserted value.
+     */
+    with(index: number, value: T): T[];
+}
+
+interface Int8Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the value of the last element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate findLast calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found, findLast
+     * immediately returns that element value. Otherwise, findLast returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLast<S extends number>(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => value is S,
+        thisArg?: any,
+    ): S | undefined;
+    findLast(
+        predicate: (value: number, index: number, array: this) => unknown,
+        thisArg?: any,
+    ): number | undefined;
+
+    /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate findLastIndex calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex(
+        predicate: (value: number, index: number, array: this) => unknown,
+        thisArg?: any,
+    ): number;
+
+    /**
+     * Copies the array and returns the copy with the elements in reverse order.
+     */
+    toReversed(): Int8Array<ArrayBuffer>;
+
+    /**
+     * Copies and sorts the array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * const myNums = Int8Array.from([11, 2, 22, 1]);
+     * myNums.toSorted((a, b) => a - b) // Int8Array(4) [1, 2, 11, 22]
+     * ```
+     */
+    toSorted(compareFn?: (a: number, b: number) => number): Int8Array<ArrayBuffer>;
+
+    /**
+     * Copies the array and inserts the given number at the provided index.
+     * @param index The index of the value to overwrite. If the index is
+     * negative, then it replaces from the end of the array.
+     * @param value The value to insert into the copied array.
+     * @returns A copy of the original array with the inserted value.
+     */
+    with(index: number, value: number): Int8Array<ArrayBuffer>;
+}
+
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the value of the last element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate findLast calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found, findLast
+     * immediately returns that element value. Otherwise, findLast returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLast<S extends number>(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => value is S,
+        thisArg?: any,
+    ): S | undefined;
+    findLast(
+        predicate: (value: number, index: number, array: this) => unknown,
+        thisArg?: any,
+    ): number | undefined;
+
+    /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate findLastIndex calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex(
+        predicate: (value: number, index: number, array: this) => unknown,
+        thisArg?: any,
+    ): number;
+
+    /**
+     * Copies the array and returns the copy with the elements in reverse order.
+     */
+    toReversed(): Uint8Array<ArrayBuffer>;
+
+    /**
+     * Copies and sorts the array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * const myNums = Uint8Array.from([11, 2, 22, 1]);
+     * myNums.toSorted((a, b) => a - b) // Uint8Array(4) [1, 2, 11, 22]
+     * ```
+     */
+    toSorted(compareFn?: (a: number, b: number) => number): Uint8Array<ArrayBuffer>;
+
+    /**
+     * Copies the array and inserts the given number at the provided index.
+     * @param index The index of the value to overwrite. If the index is
+     * negative, then it replaces from the end of the array.
+     * @param value The value to insert into the copied array.
+     * @returns A copy of the original array with the inserted value.
+     */
+    with(index: number, value: number): Uint8Array<ArrayBuffer>;
+}
+
+interface Uint8ClampedArray<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the value of the last element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate findLast calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found, findLast
+     * immediately returns that element value. Otherwise, findLast returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLast<S extends number>(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => value is S,
+        thisArg?: any,
+    ): S | undefined;
+    findLast(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): number | undefined;
+
+    /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate findLastIndex calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): number;
+
+    /**
+     * Copies the array and returns the copy with the elements in reverse order.
+     */
+    toReversed(): Uint8ClampedArray<ArrayBuffer>;
+
+    /**
+     * Copies and sorts the array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * const myNums = Uint8ClampedArray.from([11, 2, 22, 1]);
+     * myNums.toSorted((a, b) => a - b) // Uint8ClampedArray(4) [1, 2, 11, 22]
+     * ```
+     */
+    toSorted(compareFn?: (a: number, b: number) => number): Uint8ClampedArray<ArrayBuffer>;
+
+    /**
+     * Copies the array and inserts the given number at the provided index.
+     * @param index The index of the value to overwrite. If the index is
+     * negative, then it replaces from the end of the array.
+     * @param value The value to insert into the copied array.
+     * @returns A copy of the original array with the inserted value.
+     */
+    with(index: number, value: number): Uint8ClampedArray<ArrayBuffer>;
+}
+
+interface Int16Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the value of the last element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate findLast calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found, findLast
+     * immediately returns that element value. Otherwise, findLast returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLast<S extends number>(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => value is S,
+        thisArg?: any,
+    ): S | undefined;
+    findLast(
+        predicate: (value: number, index: number, array: this) => unknown,
+        thisArg?: any,
+    ): number | undefined;
+
+    /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate findLastIndex calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex(
+        predicate: (value: number, index: number, array: this) => unknown,
+        thisArg?: any,
+    ): number;
+
+    /**
+     * Copies the array and returns the copy with the elements in reverse order.
+     */
+    toReversed(): Int16Array<ArrayBuffer>;
+
+    /**
+     * Copies and sorts the array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * const myNums = Int16Array.from([11, 2, -22, 1]);
+     * myNums.toSorted((a, b) => a - b) // Int16Array(4) [-22, 1, 2, 11]
+     * ```
+     */
+    toSorted(compareFn?: (a: number, b: number) => number): Int16Array<ArrayBuffer>;
+
+    /**
+     * Copies the array and inserts the given number at the provided index.
+     * @param index The index of the value to overwrite. If the index is
+     * negative, then it replaces from the end of the array.
+     * @param value The value to insert into the copied array.
+     * @returns A copy of the original array with the inserted value.
+     */
+    with(index: number, value: number): Int16Array<ArrayBuffer>;
+}
+
+interface Uint16Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the value of the last element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate findLast calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found, findLast
+     * immediately returns that element value. Otherwise, findLast returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLast<S extends number>(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => value is S,
+        thisArg?: any,
+    ): S | undefined;
+    findLast(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): number | undefined;
+
+    /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate findLastIndex calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): number;
+
+    /**
+     * Copies the array and returns the copy with the elements in reverse order.
+     */
+    toReversed(): Uint16Array<ArrayBuffer>;
+
+    /**
+     * Copies and sorts the array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * const myNums = Uint16Array.from([11, 2, 22, 1]);
+     * myNums.toSorted((a, b) => a - b) // Uint16Array(4) [1, 2, 11, 22]
+     * ```
+     */
+    toSorted(compareFn?: (a: number, b: number) => number): Uint16Array<ArrayBuffer>;
+
+    /**
+     * Copies the array and inserts the given number at the provided index.
+     * @param index The index of the value to overwrite. If the index is
+     * negative, then it replaces from the end of the array.
+     * @param value The value to insert into the copied array.
+     * @returns A copy of the original array with the inserted value.
+     */
+    with(index: number, value: number): Uint16Array<ArrayBuffer>;
+}
+
+interface Int32Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the value of the last element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate findLast calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found, findLast
+     * immediately returns that element value. Otherwise, findLast returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLast<S extends number>(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => value is S,
+        thisArg?: any,
+    ): S | undefined;
+    findLast(
+        predicate: (value: number, index: number, array: this) => unknown,
+        thisArg?: any,
+    ): number | undefined;
+
+    /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate findLastIndex calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex(
+        predicate: (value: number, index: number, array: this) => unknown,
+        thisArg?: any,
+    ): number;
+
+    /**
+     * Copies the array and returns the copy with the elements in reverse order.
+     */
+    toReversed(): Int32Array<ArrayBuffer>;
+
+    /**
+     * Copies and sorts the array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * const myNums = Int32Array.from([11, 2, -22, 1]);
+     * myNums.toSorted((a, b) => a - b) // Int32Array(4) [-22, 1, 2, 11]
+     * ```
+     */
+    toSorted(compareFn?: (a: number, b: number) => number): Int32Array<ArrayBuffer>;
+
+    /**
+     * Copies the array and inserts the given number at the provided index.
+     * @param index The index of the value to overwrite. If the index is
+     * negative, then it replaces from the end of the array.
+     * @param value The value to insert into the copied array.
+     * @returns A copy of the original array with the inserted value.
+     */
+    with(index: number, value: number): Int32Array<ArrayBuffer>;
+}
+
+interface Uint32Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the value of the last element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate findLast calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found, findLast
+     * immediately returns that element value. Otherwise, findLast returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLast<S extends number>(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => value is S,
+        thisArg?: any,
+    ): S | undefined;
+    findLast(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): number | undefined;
+
+    /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate findLastIndex calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): number;
+
+    /**
+     * Copies the array and returns the copy with the elements in reverse order.
+     */
+    toReversed(): Uint32Array<ArrayBuffer>;
+
+    /**
+     * Copies and sorts the array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * const myNums = Uint32Array.from([11, 2, 22, 1]);
+     * myNums.toSorted((a, b) => a - b) // Uint32Array(4) [1, 2, 11, 22]
+     * ```
+     */
+    toSorted(compareFn?: (a: number, b: number) => number): Uint32Array<ArrayBuffer>;
+
+    /**
+     * Copies the array and inserts the given number at the provided index.
+     * @param index The index of the value to overwrite. If the index is
+     * negative, then it replaces from the end of the array.
+     * @param value The value to insert into the copied array.
+     * @returns A copy of the original array with the inserted value.
+     */
+    with(index: number, value: number): Uint32Array<ArrayBuffer>;
+}
+
+interface Float32Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the value of the last element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate findLast calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found, findLast
+     * immediately returns that element value. Otherwise, findLast returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLast<S extends number>(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => value is S,
+        thisArg?: any,
+    ): S | undefined;
+    findLast(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): number | undefined;
+
+    /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate findLastIndex calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): number;
+
+    /**
+     * Copies the array and returns the copy with the elements in reverse order.
+     */
+    toReversed(): Float32Array<ArrayBuffer>;
+
+    /**
+     * Copies and sorts the array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * const myNums = Float32Array.from([11.25, 2, -22.5, 1]);
+     * myNums.toSorted((a, b) => a - b) // Float32Array(4) [-22.5, 1, 2, 11.5]
+     * ```
+     */
+    toSorted(compareFn?: (a: number, b: number) => number): Float32Array<ArrayBuffer>;
+
+    /**
+     * Copies the array and inserts the given number at the provided index.
+     * @param index The index of the value to overwrite. If the index is
+     * negative, then it replaces from the end of the array.
+     * @param value The value to insert into the copied array.
+     * @returns A copy of the original array with the inserted value.
+     */
+    with(index: number, value: number): Float32Array<ArrayBuffer>;
+}
+
+interface Float64Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the value of the last element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate findLast calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found, findLast
+     * immediately returns that element value. Otherwise, findLast returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLast<S extends number>(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => value is S,
+        thisArg?: any,
+    ): S | undefined;
+    findLast(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): number | undefined;
+
+    /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate findLastIndex calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex(
+        predicate: (
+            value: number,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): number;
+
+    /**
+     * Copies the array and returns the copy with the elements in reverse order.
+     */
+    toReversed(): Float64Array<ArrayBuffer>;
+
+    /**
+     * Copies and sorts the array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * const myNums = Float64Array.from([11.25, 2, -22.5, 1]);
+     * myNums.toSorted((a, b) => a - b) // Float64Array(4) [-22.5, 1, 2, 11.5]
+     * ```
+     */
+    toSorted(compareFn?: (a: number, b: number) => number): Float64Array<ArrayBuffer>;
+
+    /**
+     * Copies the array and inserts the given number at the provided index.
+     * @param index The index of the value to overwrite. If the index is
+     * negative, then it replaces from the end of the array.
+     * @param value The value to insert into the copied array.
+     * @returns A copy of the original array with the inserted value.
+     */
+    with(index: number, value: number): Float64Array<ArrayBuffer>;
+}
+
+interface BigInt64Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the value of the last element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate findLast calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found, findLast
+     * immediately returns that element value. Otherwise, findLast returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLast<S extends bigint>(
+        predicate: (
+            value: bigint,
+            index: number,
+            array: this,
+        ) => value is S,
+        thisArg?: any,
+    ): S | undefined;
+    findLast(
+        predicate: (
+            value: bigint,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): bigint | undefined;
+
+    /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate findLastIndex calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex(
+        predicate: (
+            value: bigint,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): number;
+
+    /**
+     * Copies the array and returns the copy with the elements in reverse order.
+     */
+    toReversed(): BigInt64Array<ArrayBuffer>;
+
+    /**
+     * Copies and sorts the array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * const myNums = BigInt64Array.from([11n, 2n, -22n, 1n]);
+     * myNums.toSorted((a, b) => Number(a - b)) // BigInt64Array(4) [-22n, 1n, 2n, 11n]
+     * ```
+     */
+    toSorted(compareFn?: (a: bigint, b: bigint) => number): BigInt64Array<ArrayBuffer>;
+
+    /**
+     * Copies the array and inserts the given bigint at the provided index.
+     * @param index The index of the value to overwrite. If the index is
+     * negative, then it replaces from the end of the array.
+     * @param value The value to insert into the copied array.
+     * @returns A copy of the original array with the inserted value.
+     */
+    with(index: number, value: bigint): BigInt64Array<ArrayBuffer>;
+}
+
+interface BigUint64Array<TArrayBuffer extends ArrayBufferLike> {
+    /**
+     * Returns the value of the last element in the array where predicate is true, and undefined
+     * otherwise.
+     * @param predicate findLast calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found, findLast
+     * immediately returns that element value. Otherwise, findLast returns undefined.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLast<S extends bigint>(
+        predicate: (
+            value: bigint,
+            index: number,
+            array: this,
+        ) => value is S,
+        thisArg?: any,
+    ): S | undefined;
+    findLast(
+        predicate: (
+            value: bigint,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): bigint | undefined;
+
+    /**
+     * Returns the index of the last element in the array where predicate is true, and -1
+     * otherwise.
+     * @param predicate findLastIndex calls predicate once for each element of the array, in descending
+     * order, until it finds one where predicate returns true. If such an element is found,
+     * findLastIndex immediately returns that element index. Otherwise, findLastIndex returns -1.
+     * @param thisArg If provided, it will be used as the this value for each invocation of
+     * predicate. If it is not provided, undefined is used instead.
+     */
+    findLastIndex(
+        predicate: (
+            value: bigint,
+            index: number,
+            array: this,
+        ) => unknown,
+        thisArg?: any,
+    ): number;
+
+    /**
+     * Copies the array and returns the copy with the elements in reverse order.
+     */
+    toReversed(): BigUint64Array<ArrayBuffer>;
+
+    /**
+     * Copies and sorts the array.
+     * @param compareFn Function used to determine the order of the elements. It is expected to return
+     * a negative value if the first argument is less than the second argument, zero if they're equal, and a positive
+     * value otherwise. If omitted, the elements are sorted in ascending order.
+     * ```ts
+     * const myNums = BigUint64Array.from([11n, 2n, 22n, 1n]);
+     * myNums.toSorted((a, b) => Number(a - b)) // BigUint64Array(4) [1n, 2n, 11n, 22n]
+     * ```
+     */
+    toSorted(compareFn?: (a: bigint, b: bigint) => number): BigUint64Array<ArrayBuffer>;
+
+    /**
+     * Copies the array and inserts the given bigint at the provided index.
+     * @param index The index of the value to overwrite. If the index is
+     * negative, then it replaces from the end of the array.
+     * @param value The value to insert into the copied array.
+     * @returns A copy of the original array with the inserted value.
+     */
+    with(index: number, value: bigint): BigUint64Array<ArrayBuffer>;
+}
+
+interface WeakKeyTypes {
+    symbol: symbol;
+}
+
+declare namespace Intl {
+    interface NumberFormatOptionsUseGroupingRegistry {
+        min2: never;
+        auto: never;
+        always: never;
+    }
+
+    interface NumberFormatOptionsSignDisplayRegistry {
+        negative: never;
+    }
+
+    interface NumberFormatOptions {
+        roundingPriority?: "auto" | "morePrecision" | "lessPrecision" | undefined;
+        roundingIncrement?: 1 | 2 | 5 | 10 | 20 | 25 | 50 | 100 | 200 | 250 | 500 | 1000 | 2000 | 2500 | 5000 | undefined;
+        roundingMode?: "ceil" | "floor" | "expand" | "trunc" | "halfCeil" | "halfFloor" | "halfExpand" | "halfTrunc" | "halfEven" | undefined;
+        trailingZeroDisplay?: "auto" | "stripIfInteger" | undefined;
+    }
+
+    interface ResolvedNumberFormatOptions {
+        roundingPriority: "auto" | "morePrecision" | "lessPrecision";
+        roundingMode: "ceil" | "floor" | "expand" | "trunc" | "halfCeil" | "halfFloor" | "halfExpand" | "halfTrunc" | "halfEven";
+        roundingIncrement: 1 | 2 | 5 | 10 | 20 | 25 | 50 | 100 | 200 | 250 | 500 | 1000 | 2000 | 2500 | 5000;
+        trailingZeroDisplay: "auto" | "stripIfInteger";
+    }
+
+    interface NumberRangeFormatPart extends NumberFormatPart {
+        source: "startRange" | "endRange" | "shared";
+    }
+
+    type StringNumericLiteral = `${number}` | "Infinity" | "-Infinity" | "+Infinity";
+
+    interface NumberFormat {
+        format(value: number | bigint | StringNumericLiteral): string;
+        formatToParts(value: number | bigint | StringNumericLiteral): NumberFormatPart[];
+        formatRange(start: number | bigint | StringNumericLiteral, end: number | bigint | StringNumericLiteral): string;
+        formatRangeToParts(start: number | bigint | StringNumericLiteral, end: number | bigint | StringNumericLiteral): NumberRangeFormatPart[];
+    }
+}
+
+

--- a/packages/assets/test/assets.test.ts
+++ b/packages/assets/test/assets.test.ts
@@ -1,0 +1,15 @@
+import { decode } from "@commontools/utils/encoding";
+import { assert } from "@std/assert";
+import { getAsset, getAssetText, getAssetUrl } from "../index.ts";
+
+Deno.test("getAsset() and getAssetText() returns static data", async () => {
+  const buffer = await getAsset("es2023.d.ts");
+  const text = await getAssetText("es2023.d.ts");
+  assert(decode(buffer) === text, "buffer and text match");
+  assert(/interface ClassDecoratorContext/.test(text), "es2023.d.ts in text");
+});
+
+Deno.test("getAssetUrl() returns URL", async () => {
+  const url = await getAssetUrl("es2023.d.ts");
+  assert(/es2023.d.ts/.test(url.toString()));
+});

--- a/packages/charm/src/iterate.ts
+++ b/packages/charm/src/iterate.ts
@@ -514,7 +514,7 @@ export async function compileRecipe(
   charmManager: CharmManager,
   parents?: string[],
 ) {
-  const recipe = await runtime.compile(recipeSrc);
+  const recipe = await runtime.runSingle(recipeSrc);
   if (!recipe) {
     throw new Error("No default recipe found in the compiled exports.");
   }

--- a/packages/deno-web-test/README.md
+++ b/packages/deno-web-test/README.md
@@ -27,6 +27,7 @@ export default {
   product: "chrome",
   args: ["--enable-experimental-web-platform-features"],
   pipeConsole: true,
+  include: ["path/static-asset.json"],
 };
 ```
 

--- a/packages/deno-web-test/config.ts
+++ b/packages/deno-web-test/config.ts
@@ -13,6 +13,8 @@ export type Config = {
   args?: string[];
   // Whether or not console commands should be propagated to the deno-web-test process.
   pipeConsole?: boolean;
+  // An array of files to host on the test http server.
+  include?: string[];
 };
 
 export const applyDefaults = (config: object): Config => {

--- a/packages/deno-web-test/interface.ts
+++ b/packages/deno-web-test/interface.ts
@@ -1,17 +1,3 @@
-// These are @astral/astral configurations.
-export type AstralConfig = {
-  headless?: boolean;
-  devtools?: boolean;
-  product?: "chrome" | "firefox";
-  args?: string[];
-};
-
-// These configurations can be applied
-// by placing a `deno-web-test.config.ts` in package root.
-export type Config = {
-  astral?: AstralConfig;
-};
-
 export type TestResultError = {
   message: string;
   name: string;

--- a/packages/deno-web-test/utils.ts
+++ b/packages/deno-web-test/utils.ts
@@ -20,6 +20,17 @@ export const buildTestDir = async (manifest: Manifest) => {
     await bundle(input, output);
   }
 
+  // Bundle all extra includes and move to server root.
+  for (const staticPath of (manifest.config.include ?? [])) {
+    const filename = path.basename(staticPath);
+    const input = path.join(manifest.projectDir, staticPath);
+    const output = path.join(
+      manifest.serverDir,
+      filename,
+    );
+    await Deno.copyFile(input, output);
+  }
+
   // Deploy harness files to server root.
   if (!import.meta.dirname) {
     throw new Error("Cannot resolve local dirname");

--- a/packages/js-runtime/bundler/bundler.ts
+++ b/packages/js-runtime/bundler/bundler.ts
@@ -1,0 +1,87 @@
+import { ExecutableJs, JsArtifact } from "../interface.ts";
+import { JsSourceConcat } from "./js-source-concat.ts";
+import { resolvePath } from "./normalize-path.ts";
+
+// Template string providing implementations mapping a `require`
+// function to an `export`.
+const BOILERPLATE_START = `
+(() => {
+const [__GET_EXPORTS, __INIT_MODULE] = (() => {
+  const modules = Object.create(null);
+
+  ${resolvePath.toString()}
+ 
+  function require(requesterFilename, path) {
+    const resolved = resolvePath(requesterFilename, path);
+    const exports = __GET_EXPORTS(resolved);
+    if (exports) {
+      return exports;
+    }
+    throw new Error("Could not resolve " + path + " from " + requesterFilename);
+  }
+
+  function __GET_EXPORTS(filename) {
+    return modules[filename];
+  }
+
+  function __INIT_MODULE(filename, callback) {
+    if (modules[filename]) {
+       throw new Error("Duplicate modules with name: " + filename);
+    }
+    modules[filename] = callback(require.bind(null, filename)); 
+  }
+  return [__GET_EXPORTS, __INIT_MODULE];
+})();`;
+
+export interface BundleConfig {
+  // A set of JS modules.
+  source: JsArtifact;
+  // An additional string to inject into the bundle.
+  injectedScript?: string;
+  // The filename to use in source maps.
+  filename?: string;
+  // By default, the bundle evaluates to the `exports`
+  // of the entry module.
+  // If `runtimeDependencies` is true, the bundle instead
+  // evaluates to a function that takes a single argument
+  // containing runtime dependencies, mapping bare specifier name
+  // to the dependency's `exports`.
+  runtimeDependencies?: boolean;
+}
+
+// Bundles a set of JS modules together into
+// a single JS file.
+export const bundle = ({
+  source,
+  injectedScript,
+  filename,
+  runtimeDependencies,
+}: BundleConfig): ExecutableJs => {
+  const builder = new JsSourceConcat("OUTNAME-WHERE-IS-THIS-USED");
+
+  builder.push(BOILERPLATE_START);
+  if (injectedScript) {
+    builder.push(injectedScript);
+  }
+
+  for (const filename of Object.keys(source.modules)) {
+    const module = source.modules[filename];
+    builder.push(
+      `\n__INIT_MODULE("${module.originalFilename}", (require) => { const exports = Object.create(null);\n`,
+    );
+    builder.pushMapped(module);
+    builder.push(`\nreturn exports; });\n`);
+  }
+
+  const maybeInvoke = runtimeDependencies === true ? "" : "()";
+  builder.push(`\nreturn __GET_EXPORTS("${source.entry}");})${maybeInvoke}`);
+
+  const out = builder.render({
+    filename,
+    inlineSourceMaps: true,
+  }) as ExecutableJs;
+  if (filename) {
+    out.filename = filename;
+  }
+  return out;
+};

--- a/packages/js-runtime/bundler/js-source-concat.ts
+++ b/packages/js-runtime/bundler/js-source-concat.ts
@@ -1,0 +1,101 @@
+import {
+  RawSourceMap,
+  SourceMapConsumer,
+  SourceMapGenerator,
+} from "source-map-js";
+import { ExecutableJs, JsModule, SourceMap } from "../interface.ts";
+
+class StringBuilder {
+  private _out: string = "";
+  private _lineCount: number = 0;
+
+  push(str: string) {
+    str = str.replace(/^\/\/# sourceMappingURL=.*$/m, "");
+    this._out += str;
+    this._lineCount += str.split("\n").length;
+  }
+
+  output(): string {
+    return this._out;
+  }
+
+  lineCount(): number {
+    return this._lineCount;
+  }
+}
+
+// Concatenates JS strings, generating a source map,
+// mapping to any existing source maps.
+export class JsSourceConcat {
+  private builder: StringBuilder = new StringBuilder();
+  private map: SourceMapGenerator;
+
+  constructor(outName: string) {
+    this.map = new SourceMapGenerator({ file: outName });
+  }
+
+  // Push an unmapped string.
+  push(lines: string) {
+    this.builder.push(lines);
+  }
+
+  pushMapped(module: JsModule) {
+    const lineCount = this.builder.lineCount();
+    const { originalFilename, contents, sourceMap } = module;
+    this.builder.push(contents);
+
+    const consumer = new SourceMapConsumer(sourceMap);
+    consumer.eachMapping((mapping) => {
+      if (mapping.source === null) {
+        return;
+      }
+      this.map.addMapping({
+        generated: {
+          line: lineCount + mapping.generatedLine,
+          column: mapping.generatedColumn,
+        },
+        original: {
+          line: mapping.originalLine ?? 0,
+          column: mapping.originalColumn ?? 0,
+        },
+        source: mapping.source,
+        name: mapping.name,
+      });
+    });
+    if (consumer.sourcesContent) {
+      for (let i = 0; i < consumer.sourcesContent.length; i++) {
+        this.map.setSourceContent(
+          consumer.sources[i],
+          consumer.sourcesContent[i],
+        );
+      }
+    }
+  }
+
+  render(
+    { inlineSourceMaps, filename }: {
+      inlineSourceMaps?: boolean;
+      filename?: string;
+    } = {},
+  ): { sourceMap: SourceMap; js: string } {
+    const sourceMap = JSON.parse(this.map.toString());
+    let js = this.builder.output();
+
+    if (inlineSourceMaps === true) {
+      const encodedMap = btoa(JSON.stringify(sourceMap));
+      // ${"sourceMappingURL"} prevents confusion with this file's source map
+      js += `
+//# ${"sourceMappingURL"}=data:application/json;base64,${encodedMap}
+`;
+    }
+
+    if (filename) {
+      // ${"sourceURL"} prevents confusion with this file's source map
+      js += `
+//# ${"sourceURL"}=${filename}
+`;
+    }
+
+    return { js, sourceMap };
+  }
+}

--- a/packages/js-runtime/bundler/mod.ts
+++ b/packages/js-runtime/bundler/mod.ts
@@ -1,0 +1,1 @@
+export { bundle } from "./bundler.ts";

--- a/packages/js-runtime/bundler/normalize-path.ts
+++ b/packages/js-runtime/bundler/normalize-path.ts
@@ -1,0 +1,100 @@
+/**
+ * Ported from https://jsr.io/@std/path/1.0.9/_common/normalize_string.ts,
+ * inlining some elements so that this can be used via `.toString()`
+ * as a standalone function executed during the bundling process.
+ * Any additions should be fully defined within this function.
+ */
+
+// Copyright 2018-2025 the Deno authors. MIT license.
+// Copyright the Browserify authors. MIT License.
+// Ported from https://github.com/browserify/path-browserify/
+// This module is browser compatible.
+
+// Resolves . and .. elements in a path with directory names
+export function resolvePath(
+  pathBase: string,
+  pathExt: string,
+): string {
+  const separator = "/";
+  const CHAR_FORWARD_SLASH = 47; // "/"
+  const CHAR_DOT = 46; // "."
+  const isPathSeparator = (code: number) => code === CHAR_FORWARD_SLASH;
+  const allowAboveRoot = false;
+  const isAbsolute = isPathSeparator(pathBase.charCodeAt(0));
+
+  // Pop off the first element of the base, as it's always
+  // a file, not a directory.
+  {
+    const pathSplit = pathBase.split("/");
+    pathSplit.pop();
+    pathBase = pathSplit.join("/");
+  }
+
+  const path = [pathBase, pathExt].join("/");
+
+  const normalized = normalize(path);
+  return isAbsolute ? `${separator}${normalized}` : normalized;
+
+  ///////////////////////////////////
+  function normalize(path: string) {
+    let res = "";
+    let lastSegmentLength = 0;
+    let lastSlash = -1;
+    let dots = 0;
+    let code: number | undefined;
+    for (let i = 0; i <= path.length; ++i) {
+      if (i < path.length) code = path.charCodeAt(i);
+      else if (isPathSeparator(code!)) break;
+      else code = CHAR_FORWARD_SLASH;
+
+      if (isPathSeparator(code!)) {
+        if (lastSlash === i - 1 || dots === 1) {
+          // NOOP
+        } else if (lastSlash !== i - 1 && dots === 2) {
+          if (
+            res.length < 2 ||
+            lastSegmentLength !== 2 ||
+            res.charCodeAt(res.length - 1) !== CHAR_DOT ||
+            res.charCodeAt(res.length - 2) !== CHAR_DOT
+          ) {
+            if (res.length > 2) {
+              const lastSlashIndex = res.lastIndexOf(separator);
+              if (lastSlashIndex === -1) {
+                res = "";
+                lastSegmentLength = 0;
+              } else {
+                res = res.slice(0, lastSlashIndex);
+                lastSegmentLength = res.length - 1 - res.lastIndexOf(separator);
+              }
+              lastSlash = i;
+              dots = 0;
+              continue;
+            } else if (res.length === 2 || res.length === 1) {
+              res = "";
+              lastSegmentLength = 0;
+              lastSlash = i;
+              dots = 0;
+              continue;
+            }
+          }
+          if (allowAboveRoot) {
+            if (res.length > 0) res += `${separator}..`;
+            else res = "..";
+            lastSegmentLength = 2;
+          }
+        } else {
+          if (res.length > 0) res += separator + path.slice(lastSlash + 1, i);
+          else res = path.slice(lastSlash + 1, i);
+          lastSegmentLength = i - lastSlash - 1;
+        }
+        lastSlash = i;
+        dots = 0;
+      } else if (code === CHAR_DOT && dots !== -1) {
+        ++dots;
+      } else {
+        dots = -1;
+      }
+    }
+    return res;
+  }
+}

--- a/packages/js-runtime/deno.json
+++ b/packages/js-runtime/deno.json
@@ -1,0 +1,12 @@
+{
+  "name": "@commontools/js-runtime",
+  "tasks": {
+    "test": "deno test --allow-read"
+  },
+  "imports": {
+    "source-map-js": "npm:source-map-js"
+  },
+  "exports": {
+    ".": "./mod.ts"
+  }
+}

--- a/packages/js-runtime/eval-runtime.ts
+++ b/packages/js-runtime/eval-runtime.ts
@@ -1,0 +1,63 @@
+import { ExecutableJs, JsIsolate, JsRuntime } from "./interface.ts";
+import { SourceMapParser } from "./source-map.ts";
+
+export class UnsafeEvalJsValue {
+  private value: any;
+  constructor(value: any) {
+    this.value = value;
+  }
+  invoke(...args: any[]): UnsafeEvalJsValue {
+    if (typeof this.value !== "function") {
+      throw new Error("Cannot invoke non function");
+    }
+    return new UnsafeEvalJsValue(this.value.apply(null, args));
+  }
+  inner(): any {
+    return this.value;
+  }
+  asObject(): object {
+    if (!this.isObject()) {
+      throw new Error("Value is not an object");
+    }
+    return this.value as object;
+  }
+  isObject(): boolean {
+    return this.value && typeof this.value === "object";
+  }
+}
+
+export class UnsafeEvalIsolate implements JsIsolate {
+  private sourceMaps = new SourceMapParser();
+  execute(
+    input: string | ExecutableJs,
+  ): UnsafeEvalJsValue {
+    const { js, filename, sourceMap } = typeof input === "string"
+      ? { js: input, filename: "NO-NAME.tsx" }
+      : input;
+
+    if (filename && sourceMap) {
+      this.sourceMaps.load(filename, sourceMap);
+    }
+    try {
+      return new UnsafeEvalJsValue(eval(js));
+    } catch (e: any) {
+      const error = e as Error;
+      if (error.stack) {
+        const result = this.sourceMaps.parse(error.stack);
+        throw new Error(result);
+      }
+      throw error;
+    }
+  }
+}
+
+export class UnsafeEvalRuntime extends EventTarget implements JsRuntime {
+  private isolateSingleton = new UnsafeEvalIsolate();
+  constructor() {
+    super();
+  }
+
+  getIsolate(key: string): UnsafeEvalIsolate {
+    return this.isolateSingleton;
+  }
+}

--- a/packages/js-runtime/interface.ts
+++ b/packages/js-runtime/interface.ts
@@ -1,0 +1,93 @@
+import { Recipe } from "@commontools/builder";
+import { type RawSourceMap } from "source-map-js";
+
+export class CompilerError extends Error {
+  override name = "CompilerError";
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export interface JsValue {
+  invoke(...args: any[]): JsValue;
+  inner(): any;
+  asObject(): object;
+  isObject(): boolean;
+}
+
+// A JS runtime context.
+export interface JsIsolate {
+  // Execute `js` within this `JsIsolate`, returning the value.
+  execute(js: string | ExecutableJs): JsValue;
+}
+
+// A `JsRuntime` can host several `JsIsolate`s, capable
+// of executing JavaScript.
+export interface JsRuntime extends EventTarget {
+  // Get `JsIsolate` by `key`.
+  getIsolate(key: string): JsIsolate;
+}
+
+// A map of filename to typescript source.
+export interface TsArtifact {
+  entry: string;
+  // Keys are an absolute FS-like path
+  // starting with `/` and must contain
+  // one `/main.ts` or `/main.tsx` file.
+  files: Record<string, string>;
+}
+
+// A transformed (TypeScript) module.
+export interface JsModule {
+  // The generated JS from the source TS.
+  contents: string;
+  // Input source filename.
+  originalFilename: string;
+  // The generated source map definition.
+  sourceMap: SourceMap;
+  // The generated .d.ts source.
+  // Not currently generated, but typechecked
+  typesSrc?: string;
+}
+
+export const isJsModule = (value: unknown): value is JsModule =>
+  !!(typeof value === "object" && value &&
+      "originalFilename" in value &&
+      typeof value.originalFilename === "string" &&
+      "contents" in value && typeof value.contents === "string" &&
+      "sourceMap" in value && typeof value.sourceMap === "object" &&
+      value.sourceMap &&
+      "typesSrc" in value
+    ? typeof value.typesSrc === "string"
+    : true);
+
+// A collection of JS modules with an entry point.
+export interface JsArtifact {
+  entry: string;
+  modules: Record<string, JsModule>;
+}
+
+// A ready-to-execute string of JavaScript,
+// with optional metadata.
+export interface ExecutableJs {
+  js: string;
+  sourceMap?: SourceMap;
+  filename?: string;
+}
+
+// An interface for transforming a source file bundle `T` into `JsArtifact`s.
+export interface Compiler<T> {
+  // Compiles `source` into `JsArtifact`.
+  compile(source: T): JsArtifact;
+}
+
+export interface SourceMap extends RawSourceMap {}
+
+export const isSourceMap = (value: unknown): value is SourceMap =>
+  !!(value && typeof value === "object" &&
+    "version" in value && value.version === "3" &&
+    "file" in value && typeof value.file === "string" &&
+    "sourceRoot" in value && typeof value.sourceRoot === "string" &&
+    "sources" in value && Array.isArray(value.sources) &&
+    "names" in value && Array.isArray(value.names) &&
+    "mappings" in value && typeof value.mappings === "string");

--- a/packages/js-runtime/mod.ts
+++ b/packages/js-runtime/mod.ts
@@ -1,0 +1,10 @@
+export type {
+  Compiler,
+  CompilerError,
+  JsIsolate,
+  JsRuntime,
+  TsArtifact,
+} from "./interface.ts";
+export { TypeScriptCompiler } from "./typescript/mod.ts";
+export { bundle } from "./bundler/bundler.ts";
+export { UnsafeEvalRuntime } from "./eval-runtime.ts";

--- a/packages/js-runtime/source-map.ts
+++ b/packages/js-runtime/source-map.ts
@@ -1,0 +1,56 @@
+import { SourceMap } from "./interface.ts";
+import { SourceMapConsumer } from "source-map-js";
+
+const stackTracePattern =
+  /at (?:[A-Z][a-zA-Z]+\.)?eval \((.+?)(?:, <anonymous>)?(?:\):|\:)(\d+):(\d+)\)/;
+
+export class SourceMapParser {
+  private sourceMaps = new Map<string, SourceMap>();
+  private consumers = new Map<string, SourceMapConsumer>();
+
+  load(filename: string, sourceMap: SourceMap) {
+    this.sourceMaps.set(filename, sourceMap);
+  }
+
+  // Fixes stack traces to use source map from eval. Strangely, both Deno and
+  // Chrome at least only observe `sourceURL` but not the source map, so we can
+  // use the former to find the right source map and then apply this.
+  parse(stack: string): string {
+    const lines = stack.split("\n");
+    const mappedLines = lines.map((line) => {
+      const match = line.match(stackTracePattern);
+
+      if (match) {
+        const fileName = match[1];
+        const lineNum = parseInt(match[2], 10);
+        const columnNum = parseInt(match[3], 10);
+
+        if (!this.sourceMaps.has(fileName)) return line;
+
+        if (!this.consumers.has(fileName)) {
+          this.consumers.set(
+            fileName,
+            new SourceMapConsumer(this.sourceMaps.get(fileName)!),
+          );
+        }
+
+        const consumer = this.consumers.get(fileName)!;
+        const originalPosition = consumer.originalPositionFor({
+          line: lineNum,
+          column: columnNum,
+        });
+        console.log(
+          "from " + JSON.stringify(originalPosition) + " to " +
+            `${fileName}:${lineNum}:${columnNum}`,
+        );
+
+        // Replace the original line with the mapped position information
+        return `    at ${originalPosition.source}:${originalPosition.line}:${originalPosition.column}`;
+      } else {
+        return line;
+      }
+    });
+
+    return mappedLines.join("\n");
+  }
+}

--- a/packages/js-runtime/test/bundler.test.ts
+++ b/packages/js-runtime/test/bundler.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from "@std/testing/bdd";
+import { bundle, TypeScriptCompiler } from "../mod.ts";
+import { expect } from "@std/expect/expect";
+
+describe("Bundler", () => {
+  it("bundles a graph", async () => {
+    const files = {
+      "/main.tsx":
+        "import { sub } from './math/subtract.ts';export default sub(10,2)",
+      "/utils.ts": "export const add=(x:number,y:number):number =>x+y;",
+      "/math/subtract.ts":
+        "import { add } from '../utils.ts';export const sub = (x:number,y:number)=>add(x,y*-1)",
+    };
+    const compiler = await TypeScriptCompiler.initialize();
+    const compiled = compiler.compile({ entry: "/main.tsx", files });
+    const bundled = bundle({ source: compiled });
+  });
+});

--- a/packages/js-runtime/test/compiler.test.ts
+++ b/packages/js-runtime/test/compiler.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { TypeScriptCompiler } from "../mod.ts";
+
+describe("TypeScriptCompiler", () => {
+  it("compiles a filesystem graph", async () => {
+    const files = {
+      "/main.tsx":
+        "import { sub } from './math/subtract.ts';export default sub(10,2)",
+      "/utils.ts": "export const add=(x:number,y:number):number =>x+y;",
+      "/math/subtract.ts":
+        "import { add } from '../utils.ts';export const sub = (x:number,y:number)=>add(x,y*-1)",
+    };
+    const compiler = await TypeScriptCompiler.initialize();
+    const compiled = compiler.compile({ entry: "/main.tsx", files });
+    expect(compiled.modules["/main.js"].originalFilename).toBe("/main.tsx");
+    expect(compiled.modules["/utils.js"].originalFilename).toBe("/utils.ts");
+    expect(compiled.modules["/math/subtract.js"].originalFilename).toBe(
+      "/math/subtract.ts",
+    );
+  });
+
+  it("type checks", async () => {
+    const files = {
+      "/main.tsx":
+        "import { add } from './utils.ts';export default add(`0`, 2);",
+      "/utils.ts": "export const add=(x:number,y:number):number =>x+y;",
+    };
+    const compiler = await TypeScriptCompiler.initialize();
+    expect(() => compiler.compile({ entry: "/main.tsx", files })).toThrow(
+      "Argument of type 'string' is not assignable to parameter of type 'number'.",
+    );
+  });
+
+  // Tests that the proper type "lib"s are loaded.
+  it("Default es2023 types applied", async () => {
+    const files = {
+      "/main.tsx": "export default new Map();",
+    };
+    const compiler = await TypeScriptCompiler.initialize();
+    const compiled = compiler.compile({ entry: "/main.tsx", files });
+    expect(Object.keys(compiled.modules).length).toBe(1);
+  });
+});
+
+describe("TypeScriptCompiler failures", () => {
+  it("throws on invalid JS", async () => {
+    const files = {
+      "/main.tsx": "}x",
+    };
+    const compiler = await TypeScriptCompiler.initialize();
+    expect(() => compiler.compile({ entry: "/main.tsx", files })).toThrow(
+      "Cannot find name 'x'.",
+    );
+  });
+
+  it("throws if invalid graph", async () => {
+    const files = {
+      "/main.tsx": "import { foo } from './foo.ts';export default foo()",
+    };
+    const compiler = await TypeScriptCompiler.initialize();
+    expect(() => compiler.compile({ entry: "/main.tsx", files })).toThrow(
+      "Cannot find module './foo.ts'",
+    );
+  });
+});

--- a/packages/js-runtime/test/normalize-path.test.ts
+++ b/packages/js-runtime/test/normalize-path.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { resolvePath } from "../bundler/normalize-path.ts";
+
+describe("normalize-path", () => {
+  it("resolvePath", () => {
+    expect(resolvePath("/root.ts", "./foo.ts")).toBe("/foo.ts");
+    expect(resolvePath("/a/b/c.ts", "./foo.ts")).toBe("/a/b/foo.ts");
+    expect(resolvePath("/a/b/c.ts", ".././../foo.ts")).toBe("/foo.ts");
+  });
+});

--- a/packages/js-runtime/test/runtime.test.ts
+++ b/packages/js-runtime/test/runtime.test.ts
@@ -1,0 +1,69 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { bundle, TypeScriptCompiler, UnsafeEvalRuntime } from "../mod.ts";
+
+describe("Runtime", () => {
+  it("Compiles and executes a set of typescript files", async () => {
+    const files = {
+      "/main.tsx": "import { add } from './utils.ts';export default add(10,2)",
+      "/utils.ts": "export const add=(x:number,y:number):number =>x+y;",
+    };
+    const compiler = await TypeScriptCompiler.initialize();
+    const compiled = compiler.compile({ entry: "/main.tsx", files });
+    const bundled = bundle({ source: compiled, filename: "out.js" });
+    const runtime = new UnsafeEvalRuntime();
+    const isolate = runtime.getIsolate("");
+    const exports = isolate.execute(bundled);
+    expect(exports.inner().default).toBe(12);
+  });
+});
+
+describe("Runtime TODO", () => {
+  it.skip("Executes with runtime dependencies", async () => {
+    const files = {
+      "/main.tsx": "import { add } from '@std/math';export default add(10,2)",
+    };
+    const compiler = await TypeScriptCompiler.initialize();
+    const compiled = compiler.compile({ entry: "/main.tsx", files });
+    const bundled = bundle({
+      source: compiled,
+      filename: "out.js",
+      runtimeDependencies: true,
+    });
+    const runtime = new UnsafeEvalRuntime();
+    const isolate = runtime.getIsolate("");
+    const exports = isolate.execute(bundled).invoke({
+      "@std/math": {
+        add(x: number, y: number): number {
+          return x + y;
+        },
+      },
+    });
+    expect(exports.inner().default).toBe(12);
+  });
+
+  it.skip("Source maps errors on invoke", async () => {
+    const files = {
+      "/main.tsx":
+        "import { throwIfNot1 } from './utils.ts';export default throwIfNot1(0);",
+      "/utils.ts":
+        "export const throwIfNot1 =(x:number)=>{if(x!==1)throw new Error('not 1')};",
+    };
+    const compiler = await TypeScriptCompiler.initialize();
+    const compiled = compiler.compile({ entry: "/main.tsx", files });
+    const bundled = bundle({ filename: "abcdef.tsx", source: compiled });
+    const runtime = new UnsafeEvalRuntime();
+    const isolate = runtime.getIsolate("");
+    try {
+      const result = isolate.execute(bundled);
+      expect(result.inner().default).toBe(12);
+    } catch (e: any) {
+      console.log(
+        "INVOKE ERROR",
+        e,
+        "message" in e && e.message,
+        "stack" in e && e.stack,
+      );
+    }
+  });
+});

--- a/packages/js-runtime/typescript/compiler.ts
+++ b/packages/js-runtime/typescript/compiler.ts
@@ -1,0 +1,363 @@
+import {
+  Compiler,
+  CompilerError,
+  isJsModule,
+  isSourceMap,
+  JsArtifact,
+  JsModule,
+  TsArtifact,
+} from "../interface.ts";
+// Only import types from `typescript`
+import type {
+  CompilerHost,
+  CompilerOptions,
+  Diagnostic,
+  FileReference,
+  ModuleResolutionHost,
+  ResolvedModuleWithFailedLookupLocations,
+  ResolvedProjectReference,
+  ResolvedTypeReferenceDirectiveWithFailedLookupLocations,
+  ScriptTarget,
+  SourceFile,
+  StringLiteralLike,
+} from "typescript";
+import { getTSCompiler, getTypeLibs, TypeScriptAPI } from "./utils.ts";
+import * as path from "@std/path";
+
+const TARGET_TYPE_LIB = "es2023";
+const IS_MAP = /\.js\.map$/;
+const IS_TYPE = /\.d\.ts$/;
+const IS_JS = /\.js$/;
+
+const VFS_TYPES_DIR = "$types/";
+const VFS_DEPS_DIR = "$ext/";
+
+// Mapping from virtual type path (e.g. `$types/es2023.d.ts`)
+type TypeLibs = Record<string, string>;
+
+class VirtualFs implements ModuleResolutionHost {
+  private readonly types: Record<string, string>;
+  private readonly fsRead: Record<string, string>;
+  private readonly fsWrite: Record<string, string> = Object.create(null);
+  constructor(
+    source: TsArtifact,
+    typeLib: TypeLibs,
+  ) {
+    this.fsRead = source.files;
+    this.types = typeLib;
+  }
+
+  writeFile(fileName: any, content: any) {
+    if (typeof fileName !== "string") {
+      throw new Error("file name not string:" + typeof fileName);
+    }
+    if (typeof content !== "string") {
+      throw new Error("content not string:" + typeof content);
+    }
+    this.fsWrite[fileName] = content;
+  }
+
+  getCurrentDirectory(): string {
+    return "/";
+  }
+
+  getDirectories(_path: string): string[] {
+    throw new Error("getDirectories() not implemented.");
+  }
+
+  fileExists(fileName: string): boolean {
+    return !!this.innerRead(fileName);
+  }
+
+  readFile(fileName: string): string | undefined {
+    return this.innerRead(fileName);
+  }
+
+  useCaseSensitiveFileNames() {
+    return true;
+  }
+
+  getCompiledModules(): Record<string, JsModule> {
+    const modules = Object.create(null) as Record<
+      string,
+      Partial<JsModule>
+    >;
+    for (const key of Object.keys(this.fsWrite)) {
+      if (IS_MAP.test(key)) {
+        const root = key.slice(0, -4);
+        modules[root] = modules[root] ?? {};
+        try {
+          const sourceMap = JSON.parse(this.fsWrite[key]);
+          if (sourceMap && "version" in sourceMap) {
+            // TypeScript correctly generates `version` as an integer,
+            // but the `source-map-js` library's `RawSourceMap` we use
+            // elsewhere expects `version` to be a string.
+            sourceMap.version = `${sourceMap.version}`;
+          }
+          if (isSourceMap(sourceMap)) {
+            modules[root].sourceMap = sourceMap;
+          } else {
+            throw new Error(
+              "DEV: Source map type check failure: " +
+                JSON.stringify(sourceMap, null, 2),
+            );
+          }
+        } catch (e) {
+          console.warn(`There was an error parsing "${key}" source map: ${e}`);
+        }
+      } else if (IS_TYPE.test(key)) {
+        const root = `${key.slice(0, -5)}.js`;
+        modules[root] = modules[root] ?? {};
+        modules[root].typesSrc = this.fsWrite[key];
+      } else if (IS_JS.test(key)) {
+        const root = key;
+        modules[root] = modules[root] ?? {};
+        modules[root].contents = this.fsWrite[key];
+        // Attempt to map to source filename here -- this could be tsx,
+        // ts, or js.
+        let ext;
+        const keyNoExt = key.slice(0, -3);
+        if (this.fsRead[`${keyNoExt}.tsx`]) {
+          ext = ".tsx";
+        } else if (this.fsRead[`${keyNoExt}.ts`]) {
+          ext = ".ts";
+        } else if (this.fsRead[`${keyNoExt}.js`]) {
+          ext = ".js";
+        } else {
+          throw new Error("Could not find original source extension.");
+        }
+        modules[root].originalFilename = `${keyNoExt}${ext}`;
+      } else {
+        throw new Error(`Unknown generated file: ${key}`);
+      }
+    }
+
+    for (const key of Object.keys(modules)) {
+      if (typeof key !== "string") {
+        throw new Error("Invalid module key.");
+      }
+      const module = modules[key];
+      if (!isJsModule(module)) {
+        throw new Error(
+          `Incomplete compiled module "${key}": ${JSON.stringify(module)}`,
+        );
+      }
+    }
+    return modules as Record<string, JsModule>;
+  }
+
+  private innerRead(fileName: string): string | undefined {
+    let innerRecord;
+    if (fileName.startsWith(VFS_TYPES_DIR)) {
+      innerRecord = this.types;
+    } else {
+      innerRecord = this.fsRead;
+    }
+    return innerRecord[fileName];
+  }
+}
+
+class TypeScriptHost extends VirtualFs implements CompilerHost {
+  private ts: TypeScriptAPI;
+
+  constructor(
+    ts: TypeScriptAPI,
+    source: TsArtifact,
+    typeLibs: TypeLibs,
+  ) {
+    super(source, typeLibs);
+    this.ts = ts;
+  }
+
+  getDefaultLibFileName(options: CompilerOptions): string {
+    return "lib.d.ts";
+  }
+
+  getDefaultLibLocation(): string {
+    return VFS_TYPES_DIR;
+  }
+
+  resolveTypeReferenceDirectiveReferences?<T extends FileReference | string>(
+    typeDirectiveReferences: readonly T[],
+    containingFile: string,
+    redirectedReference: ResolvedProjectReference | undefined,
+    options: CompilerOptions,
+    containingSourceFile: SourceFile | undefined,
+    reusedNames: readonly T[] | undefined,
+  ): readonly ResolvedTypeReferenceDirectiveWithFailedLookupLocations[] {
+    throw new Error("ResolveTypeReferenceDirectiveReferences");
+  }
+
+  getCanonicalFileName(fileName: any) {
+    return fileName;
+  }
+
+  getNewLine() {
+    return "\n";
+  }
+
+  getSourceFile(
+    fileName: string,
+    languageVersion: ScriptTarget,
+    onError?: (message: string) => void,
+  ): SourceFile | undefined {
+    const sourceText = this.readFile(fileName);
+    return sourceText !== undefined
+      ? this.ts.createSourceFile(fileName, sourceText, languageVersion)
+      : undefined;
+  }
+
+  resolveModuleNameLiterals(
+    moduleLiterals: readonly StringLiteralLike[],
+    containingFile: string,
+  ): readonly ResolvedModuleWithFailedLookupLocations[] {
+    return moduleLiterals.map((literal) => {
+      const name = literal.text;
+      if (name[0] === "." || name[0] === "/") {
+        const resolved = path.join(path.dirname(containingFile), name);
+        return {
+          resolvedModule: {
+            resolvedFileName: resolved,
+            extension: ".ts",
+          },
+        };
+      } else {
+        return {
+          resolvedModule: {
+            resolvedFileName: `${VFS_DEPS_DIR}${name}.js`,
+            extension: ".js",
+          },
+        };
+      }
+    });
+  }
+}
+
+export class TypeScriptCompiler implements Compiler<TsArtifact> {
+  private ts: TypeScriptAPI;
+  private typeLibs: TypeLibs;
+  private constructor(ts: TypeScriptAPI, typeLibs: TypeLibs) {
+    this.ts = ts;
+    this.typeLibs = typeLibs;
+  }
+
+  static async initialize(): Promise<TypeScriptCompiler> {
+    const ts = await getTSCompiler();
+    const es2023Types = await getTypeLibs();
+    const typeLibs = {
+      [`${VFS_TYPES_DIR}${TARGET_TYPE_LIB}.d.ts`]: es2023Types,
+    };
+    return new TypeScriptCompiler(ts, typeLibs);
+  }
+
+  compile(source: TsArtifact): JsArtifact {
+    validateSource(source);
+    const sourceNames = Object.keys(source.files);
+    const options = this.getCompilerOptions();
+    const host = new TypeScriptHost(
+      this.ts,
+      source,
+      this.typeLibs,
+    );
+    const program = this.ts.createProgram(
+      sourceNames,
+      options,
+      host,
+    );
+
+    // Filter out the default type lib of generated sources
+    const sourceFiles = program.getSourceFiles().filter((source) =>
+      !source.fileName.startsWith(VFS_TYPES_DIR)
+    );
+
+    assert(
+      sourceFiles.length === sourceNames.length,
+      `Some inputs were not converted to source files.`,
+    );
+
+    for (const sourceFile of sourceFiles) {
+      // check types
+      let diagnostics = program.getSemanticDiagnostics(sourceFile);
+      checkDiagnostics(this.ts, diagnostics);
+      // check compilation
+      diagnostics = program.getDeclarationDiagnostics(sourceFile);
+      checkDiagnostics(this.ts, diagnostics);
+    }
+
+    const { diagnostics } = program.emit();
+    checkDiagnostics(this.ts, diagnostics);
+
+    return {
+      entry: source.entry,
+      modules: host.getCompiledModules(),
+    };
+  }
+
+  private getCompilerOptions(): CompilerOptions {
+    return {
+      declarations: true,
+      module: this.ts.ModuleKind.CommonJS,
+      target: this.ts.ScriptTarget.ES2023,
+      // `lib` should autoapply, but we need to manage default libraries since
+      // we are running outside of node. Ensure this lib matches `target`.
+      lib: [TARGET_TYPE_LIB],
+      strict: true,
+      jsx: this.ts.JsxEmit.React,
+      jsxFactory: "h",
+      jsxFragmentFactory: "h.fragment",
+      esModuleInterop: true,
+      sourceMap: true, // Enable source map generation
+      inlineSources: true, // We want the source map to include the original TypeScript files
+      inlineSourceMap: false, // Generate separate source map instead of inline
+      allowImportingTsExtensions: true,
+    };
+  }
+}
+
+function validateSource(source: TsArtifact) {
+  const sourceNames = Object.keys(source.files);
+  if (!sourceNames.includes(source.entry)) {
+    throw new Error(`No entry module "${source.entry}" in source.`);
+  }
+  for (const name of sourceNames) {
+    if (name[0] !== "/") {
+      throw new Error(`File "${name}" must have a "/" root.`);
+    }
+  }
+}
+
+// Generates and throws an error if any diagnostics found in the input.
+function checkDiagnostics(
+  ts: TypeScriptAPI,
+  diagnostics: readonly Diagnostic[] | undefined,
+) {
+  if (!diagnostics || diagnostics.length === 0) {
+    return;
+  }
+  const message = diagnostics
+    .map((diagnostic) => {
+      const message = ts.flattenDiagnosticMessageText(
+        diagnostic.messageText,
+        "\n",
+      );
+      let locationInfo = "";
+
+      if (diagnostic.file && diagnostic.start !== undefined) {
+        const { line, character } = diagnostic.file
+          .getLineAndCharacterOfPosition(
+            diagnostic.start,
+          );
+        locationInfo = `[${line + 1}:${character + 1}] `; // +1 because TypeScript uses 0-based positions
+      }
+
+      return `Compilation Error: ${locationInfo}${message}`;
+    })
+    .join("\n");
+  throw new CompilerError(message);
+}
+
+function assert(expr: boolean, message: string) {
+  if (!expr) {
+    throw new Error(`${message}`);
+  }
+}

--- a/packages/js-runtime/typescript/mod.ts
+++ b/packages/js-runtime/typescript/mod.ts
@@ -1,0 +1,1 @@
+export { TypeScriptCompiler } from "./compiler.ts";

--- a/packages/js-runtime/typescript/utils.ts
+++ b/packages/js-runtime/typescript/utils.ts
@@ -1,0 +1,27 @@
+import { getAssetText } from "@commontools/assets";
+
+export type TypeScriptAPI = typeof import("typescript");
+
+export const getTSCompiler = (() => {
+  let ts: Promise<TypeScriptAPI> | void;
+  return function getTSCompiler(): Promise<TypeScriptAPI> {
+    if (ts) {
+      return ts;
+    }
+    ts = import("typescript").then((exports) => exports.default);
+    return ts;
+  };
+})();
+
+// Returns a string payload of "es2023.d.ts", loading differently
+// depending on the environment.
+export const getTypeLibs = (() => {
+  let cached: string | undefined;
+  return async (): Promise<string> => {
+    if (cached) {
+      return cached;
+    }
+    cached = await getAssetText("es2023.d.ts");
+    return cached;
+  };
+})();

--- a/packages/runner/src/recipe-manager.ts
+++ b/packages/runner/src/recipe-manager.ts
@@ -167,7 +167,7 @@ class RecipeManager {
     if (!recipeMeta.src) {
       throw new Error(`Recipe ${recipeId} has no stored source`);
     }
-    const recipe = await runtime.compile(recipeMeta.src);
+    const recipe = await runtime.runSingle(recipeMeta.src);
 
     metaCell.set(recipeMeta);
     await storage.syncCell(metaCell);
@@ -216,7 +216,7 @@ class RecipeManager {
       parents?: string[];
     };
 
-    const recipe = await runtime.compile(recipeJson.src!);
+    const recipe = await runtime.runSingle(recipeJson.src!);
 
     return {
       recipe,

--- a/packages/runner/src/runtime/ct-runtime.ts
+++ b/packages/runner/src/runtime/ct-runtime.ts
@@ -1,0 +1,17 @@
+import { Recipe } from "@commontools/builder";
+import { TsArtifact } from "@commontools/js-runtime";
+
+export type RuntimeFunction = (input: any) => void;
+
+// A `CtRuntime` wraps a flow of compiling, bundling,
+// and executing typescript.
+export interface CtRuntime extends EventTarget {
+  // Compiles and executes `source`, returning the default export
+  // of that module.
+  run(source: TsArtifact): Promise<Recipe>;
+  // Compiles and executes a single tsx string, returning the default
+  // export of that module.
+  runSingle(source: string): Promise<Recipe>;
+  getInvocation(source: string): RuntimeFunction;
+  mapStackTrace(stack: string): string;
+}

--- a/packages/runner/src/runtime/eval-runtime-multi.ts
+++ b/packages/runner/src/runtime/eval-runtime-multi.ts
@@ -1,0 +1,72 @@
+import { Recipe } from "@commontools/builder";
+import { Console } from "./console.ts";
+import { CtRuntime, RuntimeFunction } from "./ct-runtime.ts";
+import {
+  bundle,
+  TsArtifact,
+  TypeScriptCompiler,
+} from "@commontools/js-runtime";
+import * as commonHtml from "@commontools/html";
+import * as commonBuilder from "@commontools/builder";
+import * as zod from "zod";
+import * as zodToJsonSchema from "zod-to-json-schema";
+import * as merkleReference from "merkle-reference";
+import turndown from "turndown";
+
+function createLibExports(): Record<string, object> {
+  return {
+    "@commontools/html": commonHtml,
+    "@commontools/builder": commonBuilder,
+    "zod": zod,
+    "merkle-reference": merkleReference,
+    "zod-to-json-schema": zodToJsonSchema,
+    "turndown": turndown,
+  };
+}
+
+const MULTI_RUNTIME_CONSOLE_HOOK = "MULTI_RUNTIME_CONSOLE_HOOK";
+declare global {
+  var [MULTI_RUNTIME_CONSOLE_HOOK]: any;
+}
+
+export class UnsafeEvalRuntimeMulti extends EventTarget implements CtRuntime {
+  private compiler: TypeScriptCompiler | undefined;
+  constructor() {
+    super();
+    // We install our console shim globally so that it can be referenced
+    // by the eval script scope.
+    globalThis[MULTI_RUNTIME_CONSOLE_HOOK] = new Console(this);
+  }
+
+  runSingle(source: string): Promise<Recipe> {
+    return this.run({
+      entry: "/main.tsx",
+      files: { "/main.tsx": source },
+    });
+  }
+
+  async run(source: TsArtifact): Promise<Recipe> {
+    if (!this.compiler) {
+      this.compiler = await TypeScriptCompiler.initialize();
+    }
+    if (!source) {
+      throw new Error("No source provided.");
+    }
+    const injectedScript =
+      `const console = globalThis.${RUNTIME_CONSOLE_HOOK};`;
+    const compiled = this.compiler.compile(source);
+    const jsSrc = await bundle({ source: compiled, injectedScript });
+    const exports = eval(jsSrc.js);
+    if (!("default" in exports)) {
+      throw new Error("No default export found in compiled recipe.");
+    }
+    return exports.default;
+  }
+  getInvocation(source: string): RuntimeFunction {
+    return eval(source);
+  }
+  mapStackTrace(stack: string): string {
+    //return mapSourceMapsOnStacktrace(stack);
+    return stack;
+  }
+}

--- a/packages/runner/src/runtime/eval-runtime.ts
+++ b/packages/runner/src/runtime/eval-runtime.ts
@@ -1,6 +1,7 @@
 import { Recipe } from "@commontools/builder";
+import { CtRuntime, RuntimeFunction } from "./ct-runtime.ts";
+import { TsArtifact } from "@commontools/js-runtime";
 import { mapSourceMapsOnStacktrace, tsToExports } from "./local-build.ts";
-import { Runtime, RuntimeFunction } from "./runtime.ts";
 import { Console } from "./console.ts";
 
 const RUNTIME_CONSOLE_HOOK = "RUNTIME_CONSOLE_HOOK";
@@ -8,19 +9,32 @@ declare global {
   var [RUNTIME_CONSOLE_HOOK]: any;
 }
 
-export class UnsafeEvalRuntime extends EventTarget implements Runtime {
+export class UnsafeEvalRuntime extends EventTarget implements CtRuntime {
   constructor() {
     super();
     // We install our console shim globally so that it can be referenced
     // by the eval script scope.
     globalThis[RUNTIME_CONSOLE_HOOK] = new Console(this);
   }
-  // FIXME(ja): perhaps we need the errors?
-  async compile(source: string): Promise<Recipe> {
-    if (!source) {
+
+  runSingle(source: string): Promise<Recipe> {
+    return this.run({
+      entry: "/main.tsx",
+      files: { "/main.tsx": source },
+    });
+  }
+
+  async run(source: TsArtifact): Promise<Recipe> {
+    if (!source || !source.files) {
       throw new Error("No source provided.");
     }
-    const exports = await tsToExports(source, {
+    const filename = Object.keys(source.files).shift();
+    if (!filename) {
+      throw new Error("Needs one source.");
+    }
+    const fileSource = source.files[filename];
+
+    const exports = await tsToExports(fileSource, {
       injection: `const console = globalThis.${RUNTIME_CONSOLE_HOOK};`,
     });
     if (!("default" in exports)) {

--- a/packages/runner/src/runtime/index.ts
+++ b/packages/runner/src/runtime/index.ts
@@ -1,6 +1,8 @@
 import { UnsafeEvalRuntime } from "./eval-runtime.ts";
 export { UnsafeEvalRuntime };
-export { type Runtime } from "./runtime.ts";
+import { UnsafeEvalRuntimeMulti } from "./eval-runtime-multi.ts";
+export { UnsafeEvalRuntimeMulti };
+export { type CtRuntime } from "./ct-runtime.ts";
 export { ConsoleMethod } from "./console.ts";
 
 export const runtime = new UnsafeEvalRuntime();

--- a/packages/runner/src/runtime/runtime.ts
+++ b/packages/runner/src/runtime/runtime.ts
@@ -1,8 +1,0 @@
-import { Recipe } from "@commontools/builder";
-
-export type RuntimeFunction = (input: any) => void;
-export interface Runtime extends EventTarget {
-  compile(source: string): Promise<Recipe | undefined>;
-  getInvocation(source: string): RuntimeFunction;
-  mapStackTrace(stack: string): string;
-}

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -1,5 +1,7 @@
 export function isDeno(): boolean {
-  return ("Deno" in globalThis);
+  // Also check for `Deno.build`, because in `deno-web-test`,
+  // a shim of `Deno.test` runs in the browser in order to run the same test suite.
+  return ("Deno" in globalThis) && "build" in globalThis.Deno;
 }
 
 export function isBrowser(): boolean {

--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
 deno check \
+  packages/assets/*.ts \
+  packages/assets/test \
+  packages/assets/scripts \
   packages/background-charm-service \
   packages/builder \
   packages/charm \
@@ -10,6 +13,7 @@ deno check \
   packages/identity \
   packages/iframe-sandbox \
   packages/integration \
+  packages/js-runtime \
   packages/jumble \
   packages/llm \
   packages/memory \


### PR DESCRIPTION
* Introduce `@commontools/js-runtime`
  * `TypeScriptCompiler` for type checking and compiling a TS project as a set of files.
    * `tsc` reads type files from disk, and we need target type files (e.g. `es2023.d.ts`) in order to type check. Compiling and serving these types detailed below.
    * Mechanisms to support additional modules are available (e.g. `@commontools/builder` or `moment`), but types are needed to type check, and TBD how to create definitions from our own modules via the node-dependent `tsc`, resolving Deno workspace dependencies. Ultimately both source (or exports in the eval case) and `.d.ts` types are needed.
      * `builder`, once minified, could be served/with types from server
      * Could skip type checking, but if not typechecking, there are better tools for compiling TSX->JS
      * [ ] Typecheck with "imports"
    * [ ] Typecheck JSX
  * `bundle()` to bundle output generated from a `TypeScriptCompiler`
    * [ ] Properly map source maps to bundled output
  * `JsRuntime` to abstract executing JS scripts.
* `@commontools/runner`'s `CtRuntime`
  * Used by the rest of the system.
  * Updated to continue to compile a single file, or multiple
    * TBD on how to "use" multi file compile in workflow
  * Now a `MultiUnsafeEvalRuntime` using the new compiler, alongside `UnsafeEvalRuntime`. Opting into the new version in `runner` during development, though more features needed in order to support existing recipe features.
* Introduce `@commontools/asset`
  * A way of lazily accessing static content in both deno/browser.
  * [ ] Jumble build and toolshed compile must include these assets
  * Currently only using for large `.d.ts` type files, but there was interest in using similar for prompts, or referencing a wasm artifact.
  * Tested in both deno/browser.
  * Script for compiling `es2023.d.ts` in this package from an adjacent `microsoft/TypeScript` checkout
* Update `deno-web-test` to include additional static content in the test server
  * Needed for testing `@commontools/assets`
  * Noted issue that since `Deno.test` is stubbed in for `deno-web-test`, the `isDeno()` utility in `@commontools/utils/env` needed to be more precise, and avoided using non-posix `@std/path` imports (that fail on `Deno?.build.os`). This is only an issue in the unique bundled environment that `deno-web-test` runs in.