### PR TITLE
When loading the charm lists, provide the "secret" classification.

### DIFF
--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -136,13 +136,10 @@ export class CharmManager {
     this.pinnedCharms = getCell(this.space, "pinned-charms", charmListSchema);
     this.trashedCharms = getCell(this.space, "trash", charmListSchema);
 
-    // FIXME(@ubik2) We use elevated permissions here temporarily.
+    // TODO(@ubik2) We use elevated permissions here temporarily.
     // Our request for the charm list will walk the schema tree, and that will
     // take us into classified data of charms. If that happens, we still want
     // this bit to work, so we elevate this request.
-    // If we don't do this, we get an error, and wipe out the charms list,
-    // since we think we've loaded it, but it's undefined, so we write the
-    // undefined value.
     const privilegedSchema = {
       ...charmListSchema,
       ifc: { classification: [Classification.Secret] },

--- a/packages/runner/src/storage.ts
+++ b/packages/runner/src/storage.ts
@@ -407,7 +407,14 @@ class StorageImpl implements Storage {
     // Start loading the doc and safe the promise for processBatch to await for
     const loadingPromise = this._getStorageProviderForSpace(doc.space)
       .sync(doc.entityId!, expectedInStorage, schemaContext)
-      .then(() => doc);
+      .then((result) => {
+        if (result.error) {
+          // This will be a decoupled doc that is not persisted and cannot be edited
+          doc.ephemeral = true;
+          doc.freeze();
+        }
+        return doc;
+      });
     this.loadingPromises.set(doc, loadingPromise);
 
     // Create a promise that gets resolved once the doc and all its

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -891,7 +891,7 @@ export class Provider implements StorageProvider {
     for (const { entityId, value } of batch) {
       const of = BaseStorageProvider.toEntity(entityId);
       const content = value.value != undefined
-        ? JSON.stringify({ value: value.value })
+        ? JSON.stringify({ value: value.value, source: value.source })
         : undefined;
 
       const current = workspace.get({ the, of });

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -890,26 +890,28 @@ export class Provider implements StorageProvider {
     const changes = [];
     for (const { entityId, value } of batch) {
       const of = BaseStorageProvider.toEntity(entityId);
-      const content = JSON.stringify(value);
+      const content = value.value != undefined
+        ? JSON.stringify({ value: value.value })
+        : undefined;
 
       const current = workspace.get({ the, of });
       if (JSON.stringify(current?.is) !== content) {
-        changes.push({
-          the,
-          of,
-          // ⚠️ We do JSON roundtrips to strip of the undefined values that
+        if (content !== undefined) {
+          // ⚠️ We do JSON roundtrips to strip off the undefined values that
           // cause problems with serialization.
-          is: JSON.parse(content) as JSONValue,
-        });
+          changes.push({ the, of, is: JSON.parse(content) as JSONValue });
+        } else {
+          changes.push({ the, of });
+        }
       }
       if (value.labels !== undefined) {
         const currentLabel = workspace.get({ the: TheLabel, of });
         if (!deepEqual(currentLabel?.is, value.labels)) {
-          changes.push({
-            the: TheLabel,
-            of,
-            is: value.labels as JSONValue,
-          });
+          if (value.labels !== undefined) {
+            changes.push({ the: TheLabel, of, is: value.labels as JSONValue });
+          } else {
+            changes.push({ the: TheLabel, of });
+          }
         }
       }
     }


### PR DESCRIPTION
There are a number of other approaches possible here, which can be discussed in CT-399, but this is a minimal fix that doesn't commit to any specific approach.

- I provide the secret classification when loading the charms list
- When we have an error loading a doc, I mark the doc ephemeral and freeze it. This prevents us from saving it or changing it.
- I do a better job comparing the value I'm going to set with the current value, so I don't write `{}` if it was undefined.

Not really part of the core fix, but I also removed the retry and labels from the primary doc write, since these don't belong in there.
Surprisingly, we need the source field from there when it's available.