### PR TITLE
Don't run the update for charms that are no longer active

### DIFF
--- a/packages/background-charm-service/src/worker.ts
+++ b/packages/background-charm-service/src/worker.ts
@@ -1,11 +1,8 @@
-import { type Charm, charmListSchema, CharmManager } from "@commontools/charm";
+import { type Charm, CharmManager } from "@commontools/charm";
 import {
   Cell,
   ConsoleMethod,
-  getCell,
   idle,
-  isCell,
-  isCellLink,
   isErrorWithContext,
   isStream,
   onConsole,

--- a/packages/background-charm-service/src/worker.ts
+++ b/packages/background-charm-service/src/worker.ts
@@ -167,6 +167,12 @@ async function runCharm(data: RunData): Promise<void> {
     // Reset error tracking
     latestError = null;
 
+    // Check whether the charm is still active (in charms or pinned-charms)
+    if (!manager.isActiveCharm({ "/": charmId })) {
+      // Skip any charms that aren't still in one of the lists
+      throw new Error(`No charms list entry found for charm: ${charmId}`);
+    }
+
     // Check if we've already loaded this charm
     let runningCharm = loadedCharms.get(charmId);
 
@@ -183,15 +189,6 @@ async function runCharm(data: RunData): Promise<void> {
       loadedCharms.set(charmId, runningCharm);
     } else {
       console.log(`Using previously loaded charm ${charmId}`);
-    }
-
-    if (
-      !await isInCharmList(spaceId, "charms", charmId) &&
-      !await isInCharmList(spaceId, "pinned-charms", charmId)
-    ) {
-      // Skip any charms that aren't still in one of the lists
-      console.log("Not found in charm list", charmId);
-      throw new Error(`No charms list entry found for charm: ${charmId}`);
     }
 
     // Find the updater stream

--- a/packages/background-charm-service/src/worker.ts
+++ b/packages/background-charm-service/src/worker.ts
@@ -130,31 +130,6 @@ async function cleanup(): Promise<void> {
   initialized = false;
 }
 
-async function isInCharmList(
-  spaceId: string,
-  charmsListCause: string,
-  charmId: string,
-) {
-  // Check that the charm is active in its space
-  const spaceCharmsList = getCell(spaceId, charmsListCause, charmListSchema);
-  // By loading with a false schema, we will avoid traversing into children
-  await storage.syncCell(spaceCharmsList, false, {
-    rootSchema: false,
-    schema: false,
-  });
-  const len = spaceCharmsList.key("length").get();
-  for (let i = 0; i < len; i++) {
-    const entry = spaceCharmsList.key(i).get();
-    if (isCellLink(entry) || isCell(entry)) {
-      const entryCharmId = entry.entityId ? entry.entityId["/"] : undefined;
-      if (entryCharmId === charmId) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 async function runCharm(data: RunData): Promise<void> {
   if (!manager) {
     throw new Error("Worker session not initialized");

--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -1284,6 +1284,11 @@ export class CharmManager {
   async sync(entity: Cell<any>, waitForStorage: boolean = false) {
     await storage.syncCell(entity, waitForStorage);
   }
+
+  isActiveCharm(charmId: Cell<Charm> | EntityId | string) {
+    return (this.charms.get().some((charm) => isSameEntity(charm, charmId)) ||
+      this.pinnedCharms.get().some((charm) => isSameEntity(charm, charmId)));
+  }
 }
 
 export const getRecipeIdFromCharm = (charm: Cell<Charm>): string => {


### PR DESCRIPTION
I should be able to fetch these lists without fetching everything, but currently, I think we do fetch the whole bit.
When I have client side schema traversal, I should be in better shape.

Fixes CT-39