### PR TITLE
Handle undefined children in html render

### DIFF
--- a/packages/html/src/render.ts
+++ b/packages/html/src/render.ts
@@ -136,7 +136,12 @@ const bindChildren = (
   };
 
   // When the children array changes, diff its flattened values against what we previously rendered.
-  const updateChildren = (childrenArr: Array<Child | Array<Child>>) => {
+  const updateChildren = (
+    childrenArr: Array<Child | Array<Child>> | undefined | null,
+  ) => {
+    if (!Array.isArray(childrenArr)) {
+      childrenArr = [];
+    }
     const newChildren = childrenArr.flat();
     const newKeyOrder: string[] = [];
     const newMapping = new Map<string, { node: ChildNode; cancel: Cancel }>();

--- a/packages/html/src/render.ts
+++ b/packages/html/src/render.ts
@@ -139,10 +139,7 @@ const bindChildren = (
   const updateChildren = (
     childrenArr: Array<Child | Array<Child>> | undefined | null,
   ) => {
-    if (!Array.isArray(childrenArr)) {
-      childrenArr = [];
-    }
-    const newChildren = childrenArr.flat();
+    const newChildren = Array.isArray(childrenArr) ? childrenArr.flat() : [];
     const newKeyOrder: string[] = [];
     const newMapping = new Map<string, { node: ChildNode; cancel: Cancel }>();
     const occurrence = new Map<string, number>();


### PR DESCRIPTION
## Summary
- robustify `bindChildren` in `html` renderer to treat `undefined` or `null` children arrays as empty

## Testing
- `deno task check` *(fails: No route to host)*
- `deno task test` *(fails: JSR package manifest failed to load)*