### PR TITLE
Fix map with undefined input

### DIFF
--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -65,6 +65,9 @@ export function map(
     // distinguish empty inputs from undefined inputs?
     if (list === undefined) {
       result.setAtPath([], [], log);
+      // Reset progress so that once the list becomes defined again we
+      // recompute from the beginning.
+      initializedUpTo = 0;
       return;
     }
 

--- a/packages/runner/test/recipes.test.ts
+++ b/packages/runner/test/recipes.test.ts
@@ -163,6 +163,32 @@ describe("Recipe Runner", () => {
     });
   });
 
+  it("should handle map nodes with undefined input", async () => {
+    const double = lift((x: number) => x * 2);
+
+    const doubleArray = recipe<{ values?: number[] }>(
+      "Double numbers maybe undefined",
+      ({ values }) => {
+        const doubled = values.map((x) => double(x));
+        return { doubled };
+      },
+    );
+
+    const result = run(
+      doubleArray,
+      { values: undefined },
+      getDoc(
+        undefined,
+        "should handle map nodes with undefined input",
+        "test",
+      ),
+    );
+
+    await idle();
+
+    expect(result.getAsQueryResult()).toMatchObject({ doubled: [] });
+  });
+
   it("should execute handlers", async () => {
     const incHandler = handler<
       { amount: number },


### PR DESCRIPTION
## Summary
- handle undefined arrays in map builtin by resetting progress
- add regression test for undefined array input

## Testing
- `deno task test` in `packages/runner`
- `deno task test` *(fails: could not load packages due to network restrictions)*