### PR TITLE
Introduce CharmPreview schema

### DIFF
--- a/packages/charm/src/index.ts
+++ b/packages/charm/src/index.ts
@@ -1,9 +1,12 @@
 export {
   type Charm,
+  type CharmPreview,
   charmId,
-  charmListSchema,
+  charmPreviewListSchema,
   CharmManager,
+  charmPreviewSchema,
   charmSchema,
+  charmListSchema,
   processSchema,
 } from "./manager.ts";
 export { searchCharms } from "./search.ts";

--- a/packages/cli/charm_demo.ts
+++ b/packages/cli/charm_demo.ts
@@ -5,7 +5,11 @@
  * I'm starting from the bottom (common memory) up and purposely calling
  * APIs that would normally call into common memory.
  */
-import { Charm, charmListSchema, CharmManager } from "../charm/src/manager.ts";
+import {
+  Charm,
+  charmPreviewListSchema,
+  CharmManager,
+} from "../charm/src/manager.ts";
 import { Cell, type CellLink } from "../runner/src/cell.ts";
 import { Session } from "../identity/src/index.ts";
 import { DocImpl, getDoc } from "../runner/src/doc.ts";
@@ -49,7 +53,7 @@ async function main() {
   storage.syncCell(charmsDoc);
 
   // the list of charms
-  const charms: Cell<any> = charmsDoc.asCell([], undefined, charmListSchema);
+  const charms: Cell<any> = charmsDoc.asCell([], undefined, charmPreviewListSchema);
   charms.sink((charmList) => {
     if (charmList.length > 0) {
       console.log(`\nFound ${charmList.length} charms`);


### PR DESCRIPTION
## Summary
- add `CharmPreview` type and schema for pinned/trash lists
- provide `charmPreviewListSchema` and alias existing `charmListSchema`
- expose new schema from index exports
- update CLI demo to use `charmPreviewListSchema`

## Testing
- `./tasks/check.sh` *(fails: Import failed - no route to host)*
- `deno test` in `packages/charm`