### PR TITLE
Add CharmPreview schema

### DIFF
--- a/packages/charm/src/index.ts
+++ b/packages/charm/src/index.ts
@@ -3,6 +3,9 @@ export {
   charmId,
   charmListSchema,
   CharmManager,
+  type CharmPreview,
+  charmPreviewListSchema,
+  charmPreviewSchema,
   charmSchema,
   processSchema,
 } from "./manager.ts";

--- a/packages/cli/charm_demo.ts
+++ b/packages/cli/charm_demo.ts
@@ -5,7 +5,11 @@
  * I'm starting from the bottom (common memory) up and purposely calling
  * APIs that would normally call into common memory.
  */
-import { Charm, charmListSchema, CharmManager } from "../charm/src/manager.ts";
+import {
+  Charm,
+  CharmManager,
+  charmPreviewListSchema,
+} from "../charm/src/manager.ts";
 import { Cell, type CellLink } from "../runner/src/cell.ts";
 import { Session } from "../identity/src/index.ts";
 import { DocImpl, getDoc } from "../runner/src/doc.ts";
@@ -49,7 +53,11 @@ async function main() {
   storage.syncCell(charmsDoc);
 
   // the list of charms
-  const charms: Cell<any> = charmsDoc.asCell([], undefined, charmListSchema);
+  const charms: Cell<any> = charmsDoc.asCell(
+    [],
+    undefined,
+    charmPreviewListSchema,
+  );
   charms.sink((charmList) => {
     if (charmList.length > 0) {
       console.log(`\nFound ${charmList.length} charms`);


### PR DESCRIPTION
## Summary
- define `CharmPreview` type and schema
- add `charmPreviewListSchema`
- use new preview schema for pinned/trash lists
- export preview types from package index
- update charm_demo CLI to use new schema

## Testing
- `deno task test` *(fails: Test requires Chrome)*