### PR TITLE
Change the map function so that when the result.get() is undefined, we set it to the empty array

### DIFF
--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -63,7 +63,7 @@ export function map(
     // If the list is undefined it means the input isn't available yet.
     // Correspondingly, the result should be []. TODO: Maybe it's important to
     // distinguish empty inputs from undefined inputs?
-    if (list === undefined) {
+    if (list === undefined || result.get() === undefined) {
       result.setAtPath([], [], log);
       return;
     }


### PR DESCRIPTION
Change the map function so that when the result.get() is undefined, we set it to the empty array. This prevents the subsequent read of length from failing.