### PR TITLE
Reduce recipe saving and loading to top-level charms

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -666,7 +666,10 @@ async function syncCellsForRunningRecipe(
 
   const sourceCell = resultCell.getSourceCell({
     type: "object",
-    properties: { [TYPE]: { type: "string" } },
+    properties: {
+      [TYPE]: { type: "string" },
+      argument: recipe.argumentSchema ?? {},
+    },
     required: [TYPE],
   });
   if (!sourceCell) return false;


### PR DESCRIPTION
This PR removes a bunch of recipe saving of writing for inner charmlets that doesn't correctly work anyway. Inner charmlets, e.g. those for `.map` calls, work by being spawned by parent charms. That is, we can't correctly rehydrate them individually anyway right now, so let's not also keep storing all these recipes that are at best sometimes working as intended.

Code changes:
* move recipe loading and saving out of runSynced - it now assumes there already is a recipe provided
* move inputs syncing from CharmManager to runSynced
* removed redundant syncRecipe call
* fixed post-run sync call