### PR TITLE
Create named cells within lifted functions or handlers

### DIFF
--- a/packages/builder/src/built-in.ts
+++ b/packages/builder/src/built-in.ts
@@ -122,7 +122,7 @@ export function createCell<T = any>(
   const cellLink = frame?.unsafe_binding?.materialize([]);
   if (!frame || !frame.cause || !cellLink) {
     throw new Error(
-      "Can't invoke namedCell outside of a lifted function or handler",
+      "Can't invoke createCell outside of a lifted function or handler",
     );
   }
   const space = getCellLinkOrThrow(cellLink).cell.space;

--- a/packages/builder/src/built-in.ts
+++ b/packages/builder/src/built-in.ts
@@ -1,5 +1,8 @@
 import { createNodeFactory, lift } from "./module.ts";
-import type { NodeFactory, Opaque, OpaqueRef } from "./types.ts";
+import { getTopFrame } from "./recipe.ts";
+import { type Cell, getCell, getCellLinkOrThrow } from "@commontools/runner";
+import type { JSONSchema, NodeFactory, Opaque, OpaqueRef } from "./types.ts";
+import type { Schema } from "./schema-to-ts.ts";
 
 export interface BuiltInLLMParams {
   messages?: string[];
@@ -86,4 +89,51 @@ export function str(
     );
 
   return lift(interpolatedString)({ strings, values });
+}
+
+/**
+ * Create a cell with a given schema and name.
+ *
+ * @param schema - Optional, The schema of the cell.
+ * @param name - Optional, a name for the cell. If provided, the cell id will be
+ *   derived from the current context and that name, otherwise it'll be derived
+ *   by the order of invocation, which is less stable.
+ * @param value - Optional, the initial value of the cell.
+ */
+export function createCell<T>(
+  schema?: JSONSchema,
+  name?: string,
+  value?: T,
+): Cell<T>;
+export function createCell<S extends JSONSchema = JSONSchema>(
+  schema: S,
+  name?: string,
+  value?: Schema<S>,
+): Cell<Schema<S>>;
+export function createCell<T = any>(
+  schema?: JSONSchema,
+  name?: string,
+  value?: T,
+): Cell<T> {
+  const frame = getTopFrame();
+  // TODO(seefeld): This is a rather hacky way to get the context, based on the
+  // unsafe_binding pattern. Once we replace that mechanism, let's add nicer
+  // abstractions for context here as well.
+  const cellLink = frame?.unsafe_binding?.materialize([]);
+  if (!frame || !frame.cause || !cellLink) {
+    throw new Error(
+      "Can't invoke namedCell outside of a lifted function or handler",
+    );
+  }
+  const space = getCellLinkOrThrow(cellLink).cell.space;
+
+  const cause = { parent: frame.cause } as Record<string, any>;
+  if (name) cause.name = name;
+  else cause.number = frame.generatedIdCounter++;
+
+  const cell = getCell<T>(space, cause, schema);
+
+  if (value !== undefined) cell.set(value);
+
+  return cell;
 }

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -25,6 +25,7 @@ export {
 export {
   type BuiltInLLMParams,
   type BuiltInLLMState,
+  createCell,
   fetchData,
   ifElse,
   llm,

--- a/packages/runner/src/utils.ts
+++ b/packages/runner/src/utils.ts
@@ -912,6 +912,7 @@ export function isEqualCellLink(a: CellLink, b: CellLink): boolean {
 
 export function containsOpaqueRef(value: any): boolean {
   if (isOpaqueRef(value)) return true;
+  if (isCell(value) || isCellLink(value) || isDoc(value)) return false;
   if (typeof value === "object" && value !== null) {
     return Object.values(value).some(containsOpaqueRef);
   }


### PR DESCRIPTION
Introduces

```
const newCell = createCell([schema, [name, [initial value]]]);
```

that creates a new cell, which can be returned or assigned to other values. Makes sure they are in their own document, which is useful when confidentiality boundaries are crossed (e.g. make sure sensitive key material is in its own document, separate from other less sensitive data) or to make sure they create referenceable data (by reading with `asCell: true` in a schema) that is for sure detached from its container. 

- `schema` is a schema.
- `name` is used to create a causal id. If omitted, it's by order in the current function (i.e. subsequent calls rely on order not changing to yield the same ids). That's fine in handlers, since each event is a new context anyway, but for lifted functions a name is highly recommended.
- `initial value` is set when this called (also, when reentering again -- if you only want an initial value that isn't overriden use defaults in the schema instead). Same as calling `.set()` right after creating the cell.
