### PR TITLE
deno test wants env permission for TSC_WATCHFILE

### DIFF
--- a/packages/js-runtime/deno.json
+++ b/packages/js-runtime/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@commontools/js-runtime",
   "tasks": {
-    "test": "deno test --allow-read"
+    "test": "deno test --allow-env --allow-read"
   },
   "imports": {
     "source-map-js": "npm:source-map-js"


### PR DESCRIPTION
These new tests complain on my system if we don't let them access the env.