### PR TITLE
Added unit test for a reference cycle

### DIFF
--- a/packages/memory/test/space-test.ts
+++ b/packages/memory/test/space-test.ts
@@ -1889,3 +1889,126 @@ test(
     );
   },
 );
+
+test(
+  "list fact with cycle using schema query returns",
+  DB,
+  async (session) => {
+    const v1 = Fact.assert({
+      the,
+      of: doc1,
+      is: {
+        "value": {
+          "first": "Bob",
+        },
+      },
+    });
+
+    const v2 = Fact.assert({
+      the,
+      of: doc2,
+      is: {
+        "value": {
+          "home": {
+            "name": {
+              "$alias": {
+                "cell": {
+                  "/": doc1.slice(3), // strip off 'of:'
+                },
+                "path": [],
+              },
+            },
+            "street": "2466 Southridge Drive",
+            "city": "Palm Springs",
+          },
+          "work": {
+            "name": "Mr. Bob Hope",
+            "street": "2627 N Hollywood Way",
+            "city": "Burbank",
+          },
+        },
+      },
+    });
+
+    const v3 = Fact.assert({
+      the,
+      of: doc1,
+      is: {
+        "value": {
+          "first": "Bob",
+          "address": {
+            "$alias": {
+              "cell": {
+                "/": doc2.slice(3), // strip off 'of:'
+              },
+              "path": ["home"],
+            },
+          },
+        },
+      },
+      cause: v1,
+    });
+
+    const tr1 = Transaction.create({
+      issuer: alice.did(),
+      subject: space.did(),
+      changes: Changes.from([v1]),
+    });
+    const write1 = await session.transact(tr1);
+    assert(write1.ok);
+    const c1 = Commit.toRevision(write1.ok);
+    const tr2 = Transaction.create({
+      issuer: alice.did(),
+      subject: space.did(),
+      changes: Changes.from([v2]),
+    });
+    const write2 = await session.transact(tr2);
+    assert(write2.ok);
+    const c2 = Commit.toRevision(write2.ok);
+    const tr3 = Transaction.create({
+      issuer: alice.did(),
+      subject: space.did(),
+      changes: Changes.from([v3]),
+    });
+    const write3 = await session.transact(tr3);
+    assert(write3.ok);
+    const c3 = Commit.toRevision(write3.ok);
+
+    const schemaSelector: SchemaSelector = {
+      [doc1]: {
+        [the]: {
+          _: {
+            path: [],
+            schemaContext: {
+              schema: {
+                "type": "object",
+              },
+              rootSchema: {
+                "type": "object",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = session.querySchema({
+      cmd: "/memory/graph/query",
+      iss: alice.did(),
+      sub: space.did(),
+      args: {
+        selectSchema: schemaSelector,
+      },
+      prf: [],
+    });
+
+    assertExists(
+      getResultForDoc(result, space.did(), doc1),
+      "doc1 should be in the result",
+    );
+    assertExists(
+      getResultForDoc(result, space.did(), doc2),
+      "doc2 should be in the result",
+    );
+  },
+);


### PR DESCRIPTION
I saw lots of Cycle Detected messages in the toolshed-staging logs, so suspected that we might not be handling cycles correctly.
However, this unit test logs the cycle once and moves on.