### PR TITLE
Fix accidental object reuse

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -184,8 +184,8 @@ export class Runner implements IRunner {
     const defaults = extractDefaultValues(recipe.argumentSchema);
 
     const internal = {
-      ...(deepCopy(defaults) as { internal: any })?.internal,
-      ...(recipe.initial as { internal: any } | void)?.internal,
+      ...deepCopy((defaults as { internal: any })?.internal),
+      ...deepCopy((recipe.initial as { internal: any })?.internal),
       ...processCell.get()?.internal,
     };
 


### PR DESCRIPTION
# Fix: Deep copy initial values in recipe runner

## Problem
When running multiple instances of the same recipe, they were sharing the same object reference for initial values. This caused unintended state sharing between recipe instances, where modifying state in one instance would affect other instances.

## Solution
Added `deepCopy` when applying initial values in the recipe runner to ensure each recipe instance gets its own copy of the initial state. This prevents unintended state sharing between recipe instances.

## Changes
- Modified `runner.ts` to use `deepCopy` when applying initial values from recipe
- Added test case to verify each recipe instance gets its own copy of initial values

## Testing
Added a test case that:
1. Creates two instances of the same recipe with nested initial values
2. Verifies the internal state objects are different references
3. Verifies modifying state in one instance doesn't affect the other instance

## Impact
This fix ensures proper isolation between recipe instances, preventing unintended state sharing that could lead to bugs in applications using multiple instances of the same recipe.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where multiple recipe instances shared the same initial state object, causing unintended state sharing.

- **Bug Fixes**
  - Used deep copy for initial values in the recipe runner to ensure each instance has its own state.
  - Added a test to confirm state isolation between recipe instances.

<!-- End of auto-generated description by cubic. -->

