### PR TITLE
restore previous topological sort function

### DIFF
--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -365,16 +365,17 @@ function topologicalSort(
   // Build the graph
   for (const actionA of relevantActions) {
     const { writes } = dependencies.get(actionA)!;
+    const graphA = graph.get(actionA)!;
     for (const write of writes) {
       for (const actionB of relevantActions) {
-        if (actionA !== actionB) {
+        if (actionA !== actionB && !graphA.has(actionB)) {
           const { reads } = dependencies.get(actionB)!;
           if (
             reads.some(({ cell, path }) =>
               cell === write.cell && pathAffected(write.path, path)
             )
           ) {
-            graph.get(actionA)!.add(actionB);
+            graphA.add(actionB);
             inDegree.set(actionB, (inDegree.get(actionB) || 0) + 1);
           }
         }


### PR DESCRIPTION
claude randomly changed it in the refactor :(
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Restored the previous topological sort function in the scheduler to fix dependency ordering and cycle handling.

- **Refactors**
  - Reinstated the original logic for identifying relevant actions and building the dependency graph.
  - Improved cycle detection to ensure all actions are processed correctly.

<!-- End of auto-generated description by cubic. -->

