### PR TITLE
chore: Allow env vars that node's typescript reads that doesn't fail silently in deon > 2.2.2ish

### DIFF
--- a/packages/js-runtime/deno.json
+++ b/packages/js-runtime/deno.json
@@ -1,8 +1,8 @@
 {
   "name": "@commontools/js-runtime",
   "tasks": {
-    "run": "deno run --allow-read ./cli/mod.ts",
-    "test": "deno test --allow-read --allow-run"
+    "run": "deno run --allow-read --allow-env=\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV ./cli/mod.ts",
+    "test": "deno test --allow-read --allow-run --allow-env=\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV"
   },
   "imports": {
     "source-map-js": "npm:source-map-js"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated Deno run and test tasks to allow environment variables used by Node's TypeScript, preventing silent failures in Deno versions above 2.2.2.

<!-- End of auto-generated description by cubic. -->

