### PR TITLE
add advanced email processing recipes

### DIFF
--- a/packages/jumble/src/components/commands.ts
+++ b/packages/jumble/src/components/commands.ts
@@ -527,6 +527,44 @@ async function handleUseSpellOnOtherData(ctx: CommandContext) {
   }
 }
 
+async function handleAddRemoteEmailRecipe(
+  ctx: CommandContext,
+  filename: string,
+  name: string,
+) {
+  if (!ctx.focusedCharmId) {
+    ctx.setOpen(false);
+    return;
+  }
+
+  const emailCharm = await ctx.charmManager.get(ctx.focusedCharmId);
+  if (!emailCharm) {
+    console.error("Failed to load charm", ctx.focusedCharmId);
+    return;
+  }
+
+  const emails = emailCharm.getAsQueryResult().emails;
+
+  ctx.setLoading(true);
+  try {
+    const newCharm = await addGithubRecipe(
+      ctx.charmManager,
+      filename,
+      name,
+      {
+        emails,
+      },
+    );
+
+    navigateToCharm(ctx, newCharm);
+  } catch (error) {
+    console.error(`Error loading ${filename}:`, error);
+  } finally {
+    ctx.setLoading(false);
+    ctx.setOpen(false);
+  }
+}
+
 async function handleAddRemoteRecipe(
   ctx: CommandContext,
   filename: string,
@@ -865,6 +903,30 @@ export function getCommands(ctx: CommandContext): CommandItem[] {
           title: "Add Gmail Importer",
           handler: () =>
             handleAddRemoteRecipe(ctx, "gmail.tsx", "GMail Importer"),
+        },
+        {
+          id: "add-email-summarizer",
+          type: "action",
+          title: "Add Email Summarizer",
+          predicate: !!ctx.focusedCharmId,
+          handler: () =>
+            handleAddRemoteEmailRecipe(
+              ctx,
+              "email-summarizer.tsx",
+              "Email Summarizer",
+            ),
+        },
+        {
+          id: "add-email-date-extractor",
+          type: "action",
+          title: "Add Email Date Extractor",
+          predicate: !!ctx.focusedCharmId,
+          handler: () =>
+            handleAddRemoteEmailRecipe(
+              ctx,
+              "email-date-extractor.tsx",
+              "Email Date Extractor",
+            ),
         },
         {
           id: "add-gcal-importer",

--- a/recipes/email-date-extractor.tsx
+++ b/recipes/email-date-extractor.tsx
@@ -397,7 +397,7 @@ export default recipe(
       const extractionResult = llm({
         system: systemPrompt,
         messages: [userPrompt],
-        model: "google:gemini-2.0-flash",
+        model: "google:gemini-2.5-flash",
         mode: "json",
       });
 


### PR DESCRIPTION
- if you are on an email charm, you can use `advanced -> add email summarizer` / `date extractor`
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added new commands to let users add an email summarizer or date extractor to email charms for advanced email processing.

- **New Features**
  - "Add Email Summarizer" and "Add Email Date Extractor" actions now available for email charms.
  - Updated date extractor to use the latest Gemini 2.5 model.

<!-- End of auto-generated description by cubic. -->

