### PR TITLE
Chore/circular dependencies

### DIFF
--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -42,6 +42,8 @@ export {
   ID,
   ID_FIELD,
   isAlias,
+  isCellMarker,
+  isDocMarker,
   isModule,
   isOpaqueRef,
   isRecipe,

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -38,6 +38,7 @@ export {
 } from "./built-in.ts";
 export {
   type Alias,
+  type DeepKeyLookup,
   type Frame,
   ID,
   ID_FIELD,

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -296,3 +296,19 @@ export function markAsStatic(value: any): any {
   value[isStaticMarker] = true;
   return value;
 }
+
+export type EntityId = {
+  "/": string | Uint8Array;
+  toJSON?: () => { "/": string };
+};
+
+export type DeepKeyLookup<T, Path extends PropertyKey[]> = Path extends [] ? T
+  : Path extends [infer First, ...infer Rest]
+    ? First extends keyof T
+      ? Rest extends PropertyKey[] ? DeepKeyLookup<T[First], Rest>
+      : any
+    : any
+  : any;
+
+export const isCellMarker = Symbol("isCell");
+export const isDocMarker = Symbol("isDoc");

--- a/packages/builder/src/types.ts
+++ b/packages/builder/src/types.ts
@@ -297,11 +297,6 @@ export function markAsStatic(value: any): any {
   return value;
 }
 
-export type EntityId = {
-  "/": string | Uint8Array;
-  toJSON?: () => { "/": string };
-};
-
 export type DeepKeyLookup<T, Path extends PropertyKey[]> = Path extends [] ? T
   : Path extends [infer First, ...infer Rest]
     ? First extends keyof T

--- a/packages/builder/src/utils.ts
+++ b/packages/builder/src/utils.ts
@@ -3,7 +3,7 @@ import { createShadowRef } from "./opaque-ref.ts";
 import {
   type Alias,
   canBeOpaqueRef,
-  DeepKeyLookup,
+  type DeepKeyLookup,
   isAlias,
   isCellMarker,
   isDocMarker,

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1,4 +1,4 @@
-import { isStreamAlias, TYPE } from "@commontools/builder";
+import { isCellMarker, isStreamAlias, TYPE } from "@commontools/builder";
 import {
   getTopFrame,
   ID,
@@ -499,8 +499,6 @@ export function isCell(value: any): value is Cell<any> {
   return typeof value === "object" && value !== null &&
     value[isCellMarker] === true;
 }
-
-const isCellMarker = Symbol("isCell");
 
 /**
  * Type guard to check if a value is a Stream.

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1,13 +1,16 @@
-import { isCellMarker, isStreamAlias, TYPE } from "@commontools/builder";
 import {
+  type DeepKeyLookup,
   getTopFrame,
   ID,
   ID_FIELD,
+  isCellMarker,
+  isStreamAlias,
   type JSONSchema,
   type Schema,
+  TYPE,
 } from "@commontools/builder";
-import { type DeepKeyLookup, type DocImpl, isDoc } from "./doc.ts";
-import { getEntityId } from "./doc-map.ts";
+import { type DocImpl, isDoc } from "./doc.ts";
+import { type EntityId, getEntityId } from "./doc-map.ts";
 import {
   createQueryResultProxy,
   type QueryResult,
@@ -18,7 +21,6 @@ import {
   resolveLinkToValue,
 } from "./utils.ts";
 import type { ReactivityLog } from "./scheduler.ts";
-import { type EntityId } from "./doc-map.ts";
 import { type Cancel, isCancel, useCancelGroup } from "./cancel.ts";
 import { validateAndTransform } from "./schema.ts";
 

--- a/packages/runner/src/doc.ts
+++ b/packages/runner/src/doc.ts
@@ -4,6 +4,7 @@ import {
   type Frame,
   getTopFrame,
   getValueAtPath,
+  isDocMarker,
   type JSONSchema,
   type OpaqueRef,
   type Schema,
@@ -423,5 +424,3 @@ export function isDoc(value: any): value is DocImpl<any> {
   return typeof value === "object" && value !== null &&
     value[isDocMarker] === true;
 }
-
-const isDocMarker = Symbol("isDoc");

--- a/packages/runner/src/doc.ts
+++ b/packages/runner/src/doc.ts
@@ -1,6 +1,7 @@
 import {
   cell as opaqueRef,
   deepEqual,
+  type DeepKeyLookup,
   type Frame,
   getTopFrame,
   getValueAtPath,
@@ -232,14 +233,6 @@ export type DocImpl<T> = {
    */
   copyTrap: boolean;
 };
-
-export type DeepKeyLookup<T, Path extends PropertyKey[]> = Path extends [] ? T
-  : Path extends [infer First, ...infer Rest]
-    ? First extends keyof T
-      ? Rest extends PropertyKey[] ? DeepKeyLookup<T[First], Rest>
-      : any
-    : any
-  : any;
 
 /**
  * Creates a new document with the specified value, entity ID, and space.

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1,13 +1,4 @@
 import type { Signer } from "@commontools/identity";
-import type { Cell, CellLink } from "./cell.ts";
-import type { DocImpl } from "./doc.ts";
-import { isDoc } from "./doc.ts";
-import type { EntityId } from "./doc-map.ts";
-import { getEntityId } from "./doc-map.ts";
-import type { Cancel } from "./cancel.ts";
-import type { Action, EventHandler, ReactivityLog } from "./scheduler.ts";
-import type { Harness } from "./harness/harness.ts";
-import { UnsafeEvalHarness } from "./harness/index.ts";
 import type {
   JSONSchema,
   Module,
@@ -16,7 +7,18 @@ import type {
   RecipeEnvironment,
   Schema,
 } from "@commontools/builder";
-import { setRecipeEnvironment } from "@commontools/builder";
+import {
+  ContextualFlowControl,
+  setRecipeEnvironment,
+} from "@commontools/builder";
+import type { Cell, CellLink } from "./cell.ts";
+import type { DocImpl } from "./doc.ts";
+import { isDoc } from "./doc.ts";
+import { type EntityId, getEntityId } from "./doc-map.ts";
+import type { Cancel } from "./cancel.ts";
+import type { Action, EventHandler, ReactivityLog } from "./scheduler.ts";
+import type { Harness } from "./harness/harness.ts";
+import { UnsafeEvalHarness } from "./harness/index.ts";
 
 export type ErrorWithContext = Error & {
   action: Action;
@@ -227,7 +229,6 @@ import { ModuleRegistry } from "./module.ts";
 import { DocumentMap } from "./doc-map.ts";
 import { Runner } from "./runner.ts";
 import { registerBuiltins } from "./builtins/index.ts";
-import { ContextualFlowControl } from "@commontools/builder";
 
 /**
  * Main Runtime class that orchestrates all services in the runner package.

--- a/packages/runner/src/storage.ts
+++ b/packages/runner/src/storage.ts
@@ -1,8 +1,11 @@
-import { isStatic, markAsStatic, SchemaContext } from "@commontools/builder";
 import { Signer } from "@commontools/identity";
 import { defer } from "@commontools/utils/defer";
 import { sleep } from "@commontools/utils/sleep";
-
+import {
+  isStatic,
+  markAsStatic,
+  type SchemaContext,
+} from "@commontools/builder";
 import { type AddCancel, type Cancel, useCancelGroup } from "./cancel.ts";
 import { Cell, type CellLink, isCell, isCellLink, isStream } from "./cell.ts";
 import { type DocImpl, isDoc } from "./doc.ts";


### PR DESCRIPTION
This breaks the core dependency loop with builder and runner.
I created stub types for ICell, IDocImpl and ICellLink, together with variant methods that check for these.
I moved DeepKeyLookup into builder, since that's needed for IDocImpl's getAtPath method.
I also moved the isCellMarker and isDocMarker symbols into builder, since we need those to check the object types.

There was some minor import shuffling as well, where I generally try to import other modules before local files.

I don't plan on landing this directly, but do want to get feedback (since I have it in my client-schema-query branch).

In terms of general graph, runner uses memory and builder, and memory uses builder.