### PR TITLE
fixing deno-vite-plugin

### DIFF
--- a/packages/deno-vite-plugin/src/resolver.ts
+++ b/packages/deno-vite-plugin/src/resolver.ts
@@ -169,6 +169,17 @@ export async function resolveViteSpecifier(
     }
   }
 
+  // Check if import.meta.resolve gave us a local file path
+  if (id.startsWith("file://")) {
+    const filePath = fileURLToPath(id);
+    // If this is a local workspace package, return it directly
+    // This avoids expensive deno info calls on workspace packages
+    if (filePath.startsWith(path.resolve(root, "../"))) {
+      console.log("[resolver] Local workspace package, returning directly:", filePath);
+      return filePath;
+    }
+  }
+
   if (importer && isDenoSpecifier(importer)) {
     const { resolved: parent } = parseDenoSpecifier(importer);
 


### PR DESCRIPTION
This PR is a hack/patch to fix build-time module resolution errors from our `deno-vite-plugin` use.

This change unbricks my uiv2 branch, so I believe it is all working.

---

Description from claude

```
The Problem

    When Vite tries to resolve Deno workspace packages (like
    @commontools/runner), the deno-vite-plugin does this:

    1. Calls import.meta.resolve("@commontools/runner") → Successfully
    returns
    file:///Users/jakedahn/common/labs/packages/runner/src/index.ts
    2. Runs deno info --json on that file path → This is where it
    hangs/slows down

    The issue is that deno info --json analyzes the entire dependency
    tree of that file, which for workspace packages can be massive and
    slow.

    The Fix

    I added a check to detect local workspace packages and skip the deno
    info step:

    // Check if import.meta.resolve gave us a local file path
    if (id.startsWith("file://")) {
      const filePath = fileURLToPath(id);
      // If this is a local workspace package, return it directly
      // This avoids expensive deno info calls on workspace packages
      if (filePath.startsWith(path.resolve(root, "../"))) {
        console.log("[resolver] Local workspace package, returning
    directly:", filePath);
        return filePath;
      }
    }

    This detects when:
    - The resolved path is a file:// URL (from import.meta.resolve)
    - The path is outside the current package but within the monorepo
    (starts with ../)

    When both are true, it returns the file path directly to Vite,
    skipping the expensive deno info call entirely.
    ```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed slow build times in deno-vite-plugin by skipping expensive deno info calls for local workspace packages.

- **Bug Fixes**
  - Added a check to detect local workspace packages and return their paths directly, avoiding unnecessary processing.

<!-- End of auto-generated description by cubic. -->

