### PR TITLE
Committing wip to change docIsSyncing to take into account the schema.

### DIFF
--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -1,3 +1,4 @@
+import { type Immutable, isObject } from "@commontools/utils/types";
 import type { JSONObject, JSONValue } from "@commontools/builder";
 import {
   BaseObjectManager,
@@ -10,7 +11,6 @@ import {
   SchemaObjectTraverser,
   type ValueEntry,
 } from "@commontools/builder/traverse";
-import { type Immutable, isObject } from "@commontools/utils/types";
 import { the as COMMIT_THE } from "./commit.ts";
 import type { CommitData, SchemaPathSelector } from "./consumer.ts";
 import { TheAuthorizationError } from "./error.ts";

--- a/packages/runner/src/selector-tracker.ts
+++ b/packages/runner/src/selector-tracker.ts
@@ -1,0 +1,40 @@
+import { refer, SchemaPathSelector } from "@commontools/memory";
+import { MapSet } from "@commontools/builder/traverse";
+
+// This class helps us maintain a client model of our server side subscriptions
+export class SelectorTracker<K> {
+  private refTracker = new MapSet<string, string>();
+  private selectors = new Map<string, SchemaPathSelector>();
+
+  constructor(protected toKey: (doc: K) => string) {
+  }
+
+  add(doc: K, selector: SchemaPathSelector | undefined) {
+    if (selector === undefined) {
+      return;
+    }
+    const selectorRef = refer(JSON.stringify(selector)).toString();
+    this.refTracker.add(this.toKey(doc), selectorRef);
+    this.selectors.set(selectorRef, selector);
+  }
+
+  has(doc: K): boolean {
+    return this.refTracker.has(this.toKey(doc));
+  }
+
+  hasSelector(doc: K, selector: SchemaPathSelector): boolean {
+    const selectorRefs = this.refTracker.get(this.toKey(doc));
+    if (selectorRefs !== undefined) {
+      const selectorRef = refer(JSON.stringify(selector)).toString();
+      return selectorRefs.has(selectorRef);
+    }
+    return false;
+  }
+
+  get(doc: K): IteratorObject<SchemaPathSelector> {
+    const selectorRefs = this.refTracker.get(this.toKey(doc)) ?? [];
+    return selectorRefs.values().map((selectorRef) =>
+      this.selectors.get(selectorRef)!
+    );
+  }
+}

--- a/packages/runner/test/storage.test.ts
+++ b/packages/runner/test/storage.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Runtime } from "../src/runtime.ts";
 import { StorageProvider } from "../src/storage/base.ts";
-import { type CellLink } from "../src/cell.ts";
 import { type DocImpl } from "../src/doc.ts";
 import { VolatileStorageProvider } from "../src/storage/volatile.ts";
 import { Identity } from "@commontools/identity";


### PR DESCRIPTION
This doesn't work because of a dependency cycle, but I wanted to commit it.
Since it looks like the dependency cycle may be resolved, I'm making this a draft PR, so I remember to maybe land it later.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated docIsSyncing to track syncing state by both document and schema, improving accuracy when loading documents with different schemas.

- **Refactors**
  - Replaced Set with SelectorTracker to handle schema-aware syncing.
  - Moved SelectorTracker to a shared location for reuse.

<!-- End of auto-generated description by cubic. -->

