### PR TITLE
feat(test): track and display failed test packages

### DIFF
--- a/tasks/test.ts
+++ b/tasks/test.ts
@@ -32,7 +32,8 @@ export async function runTests(disabledPackages: string[]): Promise<boolean> {
   const manifest = JSON.parse(await Deno.readTextFile("./deno.json"));
   const members: string[] = manifest.workspace;
 
-  let success = true;
+  const failedPackages: string[] = [];
+
   for (const memberPath of members) {
     // Convert "./packages/memory" to "memory"
     const packageName = memberPath.substring(2).split("/")[1];
@@ -43,18 +44,22 @@ export async function runTests(disabledPackages: string[]): Promise<boolean> {
     console.log(`Testing ${packageName}...`);
     const packagePath = path.join(workspaceCwd, "packages", packageName);
     if (!await testPackage(packagePath)) {
-      success = false;
+      failedPackages.push(packageName);
     }
   }
 
-  if (success) {
+  if (failedPackages.length === 0) {
     console.log("All tests passing!");
   } else {
     console.error("One or more tests failed.");
+    console.error("Failed packages:");
+    for (const pkg of failedPackages) {
+      console.error(`- ${pkg}`);
+    }
     Deno.exit(1);
   }
 
-  return success;
+  return failedPackages.length === 0;
 }
 
 // Only run if this is the main module


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Test runs now track and list failed packages, making it easier to see which ones need attention.

- **New Features**
  - Collects names of packages with failing tests.
  - Prints a list of failed packages after test runs.

<!-- End of auto-generated description by cubic. -->

