### PR TITLE
remove non-iframe recipe warning, since now we'll have many of those

### DIFF
--- a/packages/charm/src/iframe/recipe.ts
+++ b/packages/charm/src/iframe/recipe.ts
@@ -63,7 +63,7 @@ function parseIframeRecipe(source: string): IFrameRecipe {
 
 export const getIframeRecipe = (
   charm: Cell<Charm>,
-  runtime: Runtime
+  runtime: Runtime,
 ): {
   recipeId: string;
   src?: string;
@@ -82,7 +82,6 @@ export const getIframeRecipe = (
   try {
     return { recipeId, src, iframe: parseIframeRecipe(src) };
   } catch (error) {
-    console.warn("Error parsing iframe recipe:", error);
     return { recipeId, src };
   }
 };


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the console warning for non-iframe recipes, since these cases are now expected.

<!-- End of auto-generated description by cubic. -->

