### PR TITLE
worker can be slow due to downloading sqlite

### DIFF
--- a/packages/background-charm-service/src/space-manager.ts
+++ b/packages/background-charm-service/src/space-manager.ts
@@ -288,8 +288,6 @@ export class SpaceManager {
     );
     this.workerController = newWorker;
 
-    const initialize = newWorker.initialize();
-
     if (previousWorker) {
       console.log(`${this.did} Restarting Worker Controller`);
       previousWorker.removeEventListener("error", this.onTerminalError);
@@ -301,7 +299,7 @@ export class SpaceManager {
     }
 
     try {
-      await initialize;
+      await newWorker.initializeResolve;
       console.log(`${this.did} Worker controller ready for work`);
     } catch (e) {
       // Initialization error. This "should not" occur, but is seen on invalid IPC requests

--- a/packages/background-charm-service/src/worker-ipc.ts
+++ b/packages/background-charm-service/src/worker-ipc.ts
@@ -60,10 +60,12 @@ export function isWorkerIPCRequest(value: any): value is WorkerIPCRequest {
 export type WorkerIPCResponse = {
   msgId: number;
   error?: string;
+  type?: string;
 };
 
 export function isWorkerIPCResponse(value: any): value is WorkerIPCResponse {
   return !!(value && typeof value === "object" &&
     typeof value.msgId === "number" &&
-    ("error" in value ? typeof value.error === "string" : true));
+    ("error" in value ? typeof value.error === "string" : true) &&
+    ("type" in value ? typeof value.type === "string" : true));
 }

--- a/packages/background-charm-service/src/worker.ts
+++ b/packages/background-charm-service/src/worker.ts
@@ -268,3 +268,10 @@ self.addEventListener("message", async (event: MessageEvent) => {
     });
   }
 });
+
+// Signal to the controller that the worker is ready to receive messages.
+// This handshake prevents race conditions where the controller might send
+// the initialization message before the worker has set up its message listener.
+if (typeof self !== "undefined" && self.postMessage) {
+  self.postMessage({ type: "ready", msgId: -1 });
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved worker startup by adding a handshake to ensure the worker is ready before initialization, preventing delays caused by early messages during sqlite downloads.

- **Bug Fixes**
  - Added a "ready" signal from the worker to avoid race conditions at startup.
  - Updated controller logic to wait for this signal before sending initialization messages.

<!-- End of auto-generated description by cubic. -->

