### PR TITLE
chore: Allow ffi/net for @db/sqlite in CLI

### DIFF
--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -233,6 +233,7 @@ async function buildCli(config: BuildConfig): Promise<void> {
   console.log("Building CLI binary...");
   // Figure out the full list requested by typescript and
   // friends
+  // Globs don't work for compile(?)
   const envs = [
     "TOOLSHED_API_URL",
     "TSC_WATCHFILE",
@@ -269,8 +270,9 @@ async function buildCli(config: BuildConfig): Promise<void> {
       "--no-check",
       "--allow-write",
       "--allow-read",
-      // Globs don't work for compile(?)
       "--allow-env",
+      "--allow-ffi", // for @db/sqlite
+      "--allow-net", // for @db/sqlite lazy download
       "--include",
       config.staticTypesPath(),
       config.cliEntryPath(),


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added --allow-ffi and --allow-net permissions to the CLI build to support @db/sqlite features. This lets the CLI use FFI and network access when working with SQLite.

<!-- End of auto-generated description by cubic. -->

