### PR TITLE
chore: Fix typings in gcal and email summarizer

### DIFF
--- a/recipes/email-summarizer.tsx
+++ b/recipes/email-summarizer.tsx
@@ -70,7 +70,7 @@ const EmailProperties = {
     title: "Markdown Content",
     description: "Email content converted to Markdown format",
   },
-} as const satisfies JSONSchema;
+} as const;
 
 const EmailSchema = {
   type: "object",
@@ -210,11 +210,7 @@ const getEmailContent = lift(
   {
     type: "object",
     properties: {
-      email: {
-        type: "object",
-        properties: EmailProperties,
-        required: Object.keys(EmailProperties),
-      },
+      email: EmailSchema,
     },
     required: ["email"],
   },

--- a/recipes/gcal.tsx
+++ b/recipes/gcal.tsx
@@ -391,7 +391,7 @@ const getCalendars = handler(
     }
 
     googleRequest(
-      auth,
+      state.auth,
       new URL(`https://www.googleapis.com/calendar/v3/users/me/calendarList`),
     )
       .then((res) => res.json())


### PR DESCRIPTION
Still two more issues:

```
This expression is not callable.
  Each member of the union type '((<S>(fn: (element: Opaque<{ email: Opaque<ObjectFromPropertiesWithoutCell<{ readonly id: { readonly type: "string"; readonly title: "Email ID"; readonly description: "Unique identifier for the email"; }; readonly threadId: { readonly type: "string"; readonly title: "Thread ID"; readonly description: "Identifier for...' has signatures, but none of those signatures are compatible with each other.
[/email-summarizer.tsx:273]
```

```
Type 'import("commontools").Opaque<ObjectFromPropertiesWithoutCell<{ readonly id: { readonly type: "string"; readonly title: "Email ID"; readonly description: "Unique identifier for the email"; }; readonly threadId: { readonly type: "string"; readonly title: "Thread ID"; readonly description: "Identifier for the email thr...' is not assignable to type 'import("commontools").Opaque<ObjectFromPropertiesWithoutCell<{ readonly id: { readonly type: "string"; readonly title: "Email ID"; readonly description: "Unique identifier for the email"; }; readonly threadId: { readonly type: "string"; readonly title: "Thread ID"; readonly description: "Identifier for the email thr...'. Two different types with this name exist, but they are unrelated.
Type 'OpaqueRef<ObjectFromPropertiesWithoutCell<{ readonly id: { readonly type: "string"; readonly title: "Email ID"; readonly description: "Unique identifier for the email"; }; readonly threadId: { readonly type: "string"; readonly title: "Thread ID"; readonly description: "Identifier for the email thread"; }; ... 8 more...' is not assignable to type 'Opaque<ObjectFromPropertiesWithoutCell<{ readonly id: { readonly type: "string"; readonly title: "Email ID"; readonly description: "Unique identifier for the email"; }; readonly threadId: { readonly type: "string"; readonly title: "Thread ID"; readonly description: "Identifier for the email thread"; }; ... 8 more .....'.
Type 'import("commontools").OpaqueRef<ObjectFromPropertiesWithoutCell<{ readonly id: { readonly type: "string"; readonly title: "Email ID"; readonly description: "Unique identifier for the email"; }; readonly threadId: { readonly type: "string"; readonly title: "Thread ID"; readonly description: "Identifier for the email ...' is not assignable to type 'import("commontools").OpaqueRef<ObjectFromPropertiesWithoutCell<{ readonly id: { readonly type: "string"; readonly title: "Email ID"; readonly description: "Unique identifier for the email"; }; readonly threadId: { readonly type: "string"; readonly title: "Thread ID"; readonly description: "Identifier for the email ...'. Two different types with this name exist, but they are unrelated.
Type 'OpaqueRef<ObjectFromPropertiesWithoutCell<{ readonly id: { readonly type: "string"; readonly title: "Email ID"; readonly description: "Unique identifier for the email"; }; readonly threadId: { readonly type: "string"; readonly title: "Thread ID"; readonly description: "Identifier for the email thread"; }; ... 8 more...' is not assignable to type 'OpaqueRefMethods<ObjectFromPropertiesWithoutCell<{ readonly id: { readonly type: "string"; readonly title: "Email ID"; readonly description: "Unique identifier for the email"; }; readonly threadId: { readonly type: "string"; readonly title: "Thread ID"; readonly description: "Identifier for the email thread"; }; ......'.
[/email-summarizer.tsx:259:46]
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed type errors in the gcal and email summarizer recipes to resolve type checking issues.

<!-- End of auto-generated description by cubic. -->

