### PR TITLE
support edit for regular recipes

### DIFF
--- a/packages/charm/src/index.ts
+++ b/packages/charm/src/index.ts
@@ -4,6 +4,7 @@ export {
   charmListSchema,
   CharmManager,
   charmSchema,
+  getRecipeIdFromCharm,
   processSchema,
 } from "./manager.ts";
 export { searchCharms } from "./search.ts";


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for editing and saving regular recipe code directly in the Charm detail view.

- **New Features**
  - Shows a code editor for regular recipes with a save button.
  - Updates the recipe and reloads the charm after saving changes.

<!-- End of auto-generated description by cubic. -->

