### PR TITLE
chore: Align tsconfig options used in runtime with the lightweight tsconfig used in authoring

### DIFF
--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -19,7 +19,7 @@ async function main(args: string[]) {
     }
     Deno.exit(0);
   } catch (e) {
-    console.error(e && typeof e.toString === "function" ? e.toString() : e);
+    console.error(e);
     Deno.exit(1);
   }
 }

--- a/packages/js-runtime/deno.json
+++ b/packages/js-runtime/deno.json
@@ -9,6 +9,7 @@
   },
   "exports": {
     ".": "./mod.ts",
+    "./typescript": "./typescript/mod.ts",
     "./cli": "./cli/mod.ts"
   }
 }

--- a/packages/js-runtime/typescript/mod.ts
+++ b/packages/js-runtime/typescript/mod.ts
@@ -7,3 +7,4 @@ export {
   type CompilationErrorType,
   CompilerError,
 } from "./error.ts";
+export { getCompilerOptions } from "./options.ts";

--- a/packages/js-runtime/typescript/options.ts
+++ b/packages/js-runtime/typescript/options.ts
@@ -12,6 +12,8 @@ export const getCompilerOptions = (): CompilerOptions => {
      */
 
     strict: true,
+    strictNullChecks: true,
+    strictFunctionTypes: true,
 
     /**
      * Module
@@ -28,7 +30,7 @@ export const getCompilerOptions = (): CompilerOptions => {
 
     removeComments: true,
     noEmitOnError: true,
-    declarations: true,
+    declaration: true,
     // Enable source map generation.
     sourceMap: true,
     // We want the source map to include the original TypeScript files


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Aligned the TypeScript config options used at runtime with those used for authoring to ensure consistency across environments.

- **Refactors**
  - Updated CLI init command to generate tsconfig.json using shared compiler options.
  - Exposed getCompilerOptions from the runtime for reuse.
  - Synced strictness and output options between runtime and authoring configs.

<!-- End of auto-generated description by cubic. -->

