### PR TITLE
chore: Render compiler messages pointing to the culprit source inline.

### DIFF
--- a/packages/js-runtime/test/typescript.compiler.test.ts
+++ b/packages/js-runtime/test/typescript.compiler.test.ts
@@ -90,15 +90,24 @@ describe("TypeScriptCompiler", () => {
     await compiler.resolveAndCompile(program);
   });
 
-  /*
-  it("Handles runtime modules without types", async () => {
+  it("Inlines errors", async () => {
+    const compiler = new TypeScriptCompiler(types);
     const program = new InMemoryProgram("/main.tsx", {
-      "/main.tsx": "import { add } from '@std/math';export default add(10,2)",
+      "/main.tsx": `
+function add(x: number, y: number): number {
+  return x + y;
+} 
+
+export default add(5, "5");`,
     });
-    const compiler = new TypeScriptCompiler(await getTypeLibs());
-    compiler.compile(program, { runtimeModules: ["@std/math"] });
+
+    const expected = `4 | } 
+5 | 
+6 | export default add(5, \"5\");
+  |                       ^
+`;
+    await expect(compiler.resolveAndCompile(program)).rejects.toThrow(expected);
   });
-  */
 
   for (const { name, source, expectedError, ...options } of TESTS) {
     it(name, () => {

--- a/packages/js-runtime/typescript/diagnostics/checker.ts
+++ b/packages/js-runtime/typescript/diagnostics/checker.ts
@@ -1,0 +1,50 @@
+import { type Diagnostic, type Program } from "typescript";
+import { CompilerError, ErrorDetails } from "./errors.ts";
+
+export class Checker {
+  private program: Program;
+  constructor(program: Program) {
+    this.program = program;
+  }
+
+  typeCheck() {
+    const errors = this.sources().reduce((output, sourceFile) => {
+      const diagnostics = this.program.getSemanticDiagnostics(sourceFile);
+      for (const diagnostic of diagnostics) {
+        output.push({ diagnostic, source: sourceFile.text });
+      }
+      return output;
+    }, [] as ErrorDetails[]);
+    if (errors.length) {
+      throw new CompilerError(errors);
+    }
+  }
+
+  declarationCheck() {
+    const errors = this.sources().reduce((output, sourceFile) => {
+      const diagnostics = this.program.getDeclarationDiagnostics(sourceFile);
+      for (const diagnostic of diagnostics) {
+        output.push({ diagnostic, source: sourceFile.text });
+      }
+      return output;
+    }, [] as ErrorDetails[]);
+    if (errors.length) {
+      throw new CompilerError(errors);
+    }
+  }
+
+  check(diagnostics: readonly Diagnostic[] | undefined) {
+    if (!diagnostics || diagnostics.length === 0) {
+      return;
+    }
+    throw new CompilerError(diagnostics.map((diagnostic) => ({
+      diagnostic,
+    })));
+  }
+
+  private sources() {
+    return this.program.getSourceFiles().filter((source) =>
+      !source.fileName.startsWith("$types/")
+    );
+  }
+}

--- a/packages/js-runtime/typescript/diagnostics/mod.ts
+++ b/packages/js-runtime/typescript/diagnostics/mod.ts
@@ -1,0 +1,6 @@
+export { Checker } from "./checker.ts";
+export {
+  CompilationError,
+  type CompilationErrorType,
+  CompilerError,
+} from "./errors.ts";

--- a/packages/js-runtime/typescript/diagnostics/render.ts
+++ b/packages/js-runtime/typescript/diagnostics/render.ts
@@ -1,0 +1,69 @@
+export interface ErrorRenderLocation {
+  line: number;
+  column: number;
+  source: string;
+}
+
+export interface ErrorRenderInlineConfig extends ErrorRenderLocation {
+  // The number of lines before and after the failing
+  // line to render.
+  contextLines: number;
+}
+
+function repeat(character: string, times: number): string {
+  return new Array(times).fill(character).join("");
+}
+function renderLine(
+  line: number | string,
+  content: string,
+  lineNumPad: number,
+) {
+  return `${String(line).padStart(lineNumPad, " ")} | ${content}\n`;
+}
+
+// Renders the inline portion of an error.
+//
+// ```
+// 1 |
+// 2 |
+// 3 |
+// 4 |
+// ```
+export function renderInline(
+  { contextLines, line, source, column }: ErrorRenderInlineConfig,
+): string {
+  const lines = source.split("\n");
+  const targetLine = line - 1;
+  const preambleLineStart = Math.max(targetLine - contextLines, 0);
+  const preambleLineEnd = targetLine;
+  const postambleLineStart = targetLine + 1;
+  const postambleLineEnd = Math.min(
+    postambleLineStart + contextLines,
+    lines.length - 1,
+  );
+  // Find the number of digits in the largest line
+  // that will be displayed
+  const lineNumPad = Math.min(
+    String(targetLine + contextLines).length,
+    10,
+  );
+
+  let inline = "";
+
+  inline += lines.slice(
+    preambleLineStart,
+    preambleLineEnd,
+  ).map((line, index) =>
+    renderLine(preambleLineStart + index + 1, line, lineNumPad)
+  ).join("");
+  inline += renderLine(targetLine + 1, lines[targetLine], lineNumPad);
+  inline += renderLine("", `${repeat(" ", column - 1)}^`, lineNumPad);
+  inline += lines.slice(
+    postambleLineStart,
+    postambleLineEnd,
+  ).map((line, index) =>
+    renderLine(targetLine + 1 + index + 1, line, lineNumPad)
+  ).join("");
+
+  return inline;
+}

--- a/packages/js-runtime/typescript/mod.ts
+++ b/packages/js-runtime/typescript/mod.ts
@@ -6,5 +6,5 @@ export {
   CompilationError,
   type CompilationErrorType,
   CompilerError,
-} from "./error.ts";
+} from "./diagnostics/mod.ts";
 export { getCompilerOptions } from "./options.ts";


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Compiler errors now show the exact source line and column inline, making it easier to spot and fix issues.

- **Refactors**
  - Added logic to render error messages with code context and a pointer to the error location.
  - Moved and reorganized diagnostic code for better structure.

<!-- End of auto-generated description by cubic. -->

