### PR TITLE
Ct 446 replace docimpl with cell part3

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,54 +1,51 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@astral/astral@*": "0.5.2",
+    "jsr:@astral/astral@*": "0.5.3",
     "jsr:@cmd-johnson/oauth2-client@2": "2.0.0",
     "jsr:@db/sqlite@0.12": "0.12.0",
     "jsr:@deno-library/progress@^1.5.1": "1.5.1",
-    "jsr:@denosaurs/plug@1": "1.0.6",
+    "jsr:@denosaurs/plug@1": "1.1.0",
     "jsr:@luca/esbuild-deno-loader@*": "0.11.1",
     "jsr:@std/assert@0.217": "0.217.0",
-    "jsr:@std/assert@0.221": "0.221.0",
     "jsr:@std/assert@1": "1.0.13",
-    "jsr:@std/assert@^1.0.10": "1.0.13",
-    "jsr:@std/assert@^1.0.11": "1.0.13",
-    "jsr:@std/async@1": "1.0.10",
-    "jsr:@std/async@^1.0.9": "1.0.10",
-    "jsr:@std/bytes@^1.0.2": "1.0.5",
-    "jsr:@std/cli@1": "1.0.13",
-    "jsr:@std/cli@^1.0.12": "1.0.13",
-    "jsr:@std/crypto@1": "1.0.4",
-    "jsr:@std/data-structures@^1.0.6": "1.0.6",
-    "jsr:@std/dotenv@~0.225.3": "0.225.3",
-    "jsr:@std/encoding@0.221": "0.221.0",
-    "jsr:@std/encoding@1": "1.0.7",
-    "jsr:@std/encoding@^1.0.5": "1.0.7",
-    "jsr:@std/encoding@^1.0.7": "1.0.7",
-    "jsr:@std/expect@1": "1.0.13",
-    "jsr:@std/fmt@0.221": "0.221.0",
+    "jsr:@std/assert@^1.0.13": "1.0.13",
+    "jsr:@std/async@1": "1.0.13",
+    "jsr:@std/async@^1.0.13": "1.0.13",
+    "jsr:@std/bytes@^1.0.2": "1.0.6",
+    "jsr:@std/cli@1": "1.0.19",
+    "jsr:@std/cli@^1.0.12": "1.0.19",
+    "jsr:@std/cli@^1.0.18": "1.0.19",
+    "jsr:@std/crypto@1": "1.0.5",
+    "jsr:@std/data-structures@^1.0.8": "1.0.8",
+    "jsr:@std/dotenv@~0.225.3": "0.225.5",
+    "jsr:@std/encoding@1": "1.0.10",
+    "jsr:@std/encoding@^1.0.10": "1.0.10",
+    "jsr:@std/encoding@^1.0.5": "1.0.10",
+    "jsr:@std/expect@1": "1.0.16",
+    "jsr:@std/fmt@1": "1.0.8",
     "jsr:@std/fmt@1.0.3": "1.0.3",
-    "jsr:@std/fmt@^1.0.5": "1.0.5",
-    "jsr:@std/fs@0.221": "0.221.0",
-    "jsr:@std/fs@1": "1.0.13",
-    "jsr:@std/fs@^1.0.9": "1.0.13",
-    "jsr:@std/html@^1.0.3": "1.0.3",
-    "jsr:@std/http@1": "1.0.13",
-    "jsr:@std/internal@^1.0.5": "1.0.6",
-    "jsr:@std/internal@^1.0.6": "1.0.6",
+    "jsr:@std/fmt@^1.0.8": "1.0.8",
+    "jsr:@std/fs@1": "1.0.18",
+    "jsr:@std/fs@^1.0.17": "1.0.18",
+    "jsr:@std/html@^1.0.4": "1.0.4",
+    "jsr:@std/http@1": "1.0.17",
+    "jsr:@std/internal@^1.0.6": "1.0.8",
+    "jsr:@std/internal@^1.0.7": "1.0.8",
+    "jsr:@std/internal@^1.0.8": "1.0.8",
     "jsr:@std/io@0.225.0": "0.225.0",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.4": "1.0.4",
     "jsr:@std/path@0.217": "0.217.0",
-    "jsr:@std/path@0.221": "0.221.0",
-    "jsr:@std/path@1": "1.0.8",
-    "jsr:@std/path@^1.0.6": "1.0.8",
-    "jsr:@std/path@^1.0.8": "1.0.8",
+    "jsr:@std/path@1": "1.1.0",
+    "jsr:@std/path@^1.0.6": "1.1.0",
+    "jsr:@std/path@^1.1.0": "1.1.0",
     "jsr:@std/streams@^1.0.9": "1.0.9",
-    "jsr:@std/testing@1": "1.0.9",
-    "jsr:@zip-js/zip-js@^2.7.52": "2.7.57",
+    "jsr:@std/testing@1": "1.0.13",
+    "jsr:@zip-js/zip-js@^2.7.52": "2.7.62",
     "npm:@ai-sdk/anthropic@^1.1.6": "1.2.12_zod@3.25.49",
     "npm:@ai-sdk/anthropic@^1.2.10": "1.2.12_zod@3.25.49",
-    "npm:@ai-sdk/google-vertex@^2.2.17": "2.2.23_zod@3.25.49",
+    "npm:@ai-sdk/google-vertex@^2.2.17": "2.2.24_zod@3.25.49",
     "npm:@ai-sdk/groq@^1.2.8": "1.2.9_zod@3.25.49",
     "npm:@ai-sdk/openai@^1.1.9": "1.3.22_zod@3.25.49",
     "npm:@ai-sdk/openai@^1.3.20": "1.3.22_zod@3.25.49",
@@ -84,13 +81,12 @@
     "npm:@react-three/fiber@^8.17.14": "8.18.0_react@18.3.1_react-dom@18.3.1__react@18.3.1_three@0.173.0_@types+react@18.3.23",
     "npm:@scalar/hono-api-reference@~0.5.165": "0.5.184_hono@4.7.11",
     "npm:@scure/bip39@^1.5.4": "1.6.0",
-    "npm:@sentry/deno@^9.3.0": "9.24.0",
-    "npm:@sentry/react@^9.7.0": "9.24.0_react@18.3.1",
+    "npm:@sentry/deno@^9.3.0": "9.25.1",
+    "npm:@sentry/react@^9.7.0": "9.25.1_react@18.3.1",
     "npm:@shoelace-style/shoelace@^2.19.1": "2.20.1_@types+react@18.3.23",
     "npm:@tailwindcss/typography@~0.5.16": "0.5.16_tailwindcss@4.1.8",
-    "npm:@tailwindcss/vite@^4.0.1": "4.1.8_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@types+node@22.15.29_@types+node@22.15.15",
+    "npm:@tailwindcss/vite@^4.0.1": "4.1.8_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@types+node@22.15.29",
     "npm:@types/jsdom@^21.1.7": "21.1.7",
-    "npm:@types/node@*": "22.15.15",
     "npm:@types/node@^22.12.0": "22.15.29",
     "npm:@types/node@^22.5.5": "22.15.29",
     "npm:@types/react-dom@^18.3.1": "18.3.7_@types+react@18.3.23",
@@ -101,7 +97,7 @@
     "npm:@uiw/react-json-view@2.0.0-alpha.30": "2.0.0-alpha.30_@babel+runtime@7.27.4_react@18.3.1_react-dom@18.3.1__react@18.3.1",
     "npm:@use-gesture/react@^10.3.1": "10.3.1_react@18.3.1",
     "npm:@vercel/otel@^1.10.1": "1.12.0_@opentelemetry+api@1.9.0_@opentelemetry+api-logs@0.202.0_@opentelemetry+instrumentation@0.202.0__@opentelemetry+api@1.9.0_@opentelemetry+resources@1.30.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-logs@0.202.0__@opentelemetry+api@1.9.0_@opentelemetry+sdk-metrics@1.30.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-trace-base@1.30.1__@opentelemetry+api@1.9.0",
-    "npm:@vitejs/plugin-react@^4.3.4": "4.5.0_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@babel+core@7.27.4_@types+node@22.15.29_@types+node@22.15.15",
+    "npm:@vitejs/plugin-react@^4.3.4": "4.5.1_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@babel+core@7.27.4_@types+node@22.15.29",
     "npm:@web/test-runner@*": "0.20.2",
     "npm:ai@^4.3.10": "4.3.16_react@18.3.1_zod@3.25.49",
     "npm:ai@^4.3.9": "4.3.16_react@18.3.1_zod@3.25.49",
@@ -143,15 +139,15 @@
     "npm:turndown@^7.1.2": "7.2.0",
     "npm:typescript@*": "5.8.3",
     "npm:typescript@^5.6.2": "5.8.3",
-    "npm:vite@*": "6.3.5_@types+node@22.15.29_picomatch@4.0.2_@types+node@22.15.15",
-    "npm:vite@^6.2.1": "6.3.5_@types+node@22.15.29_picomatch@4.0.2_@types+node@22.15.15",
-    "npm:vitest@^2.1.1": "2.1.9_@types+node@22.15.29_jsdom@26.1.0_vite@5.4.19__@types+node@22.15.29_@types+node@22.15.15",
+    "npm:vite@*": "6.3.5_@types+node@22.15.29_picomatch@4.0.2",
+    "npm:vite@^6.2.1": "6.3.5_@types+node@22.15.29_picomatch@4.0.2",
+    "npm:vitest@^2.1.1": "2.1.9_@types+node@22.15.29_jsdom@26.1.0_vite@5.4.19__@types+node@22.15.29",
     "npm:zod-to-json-schema@^3.24.1": "3.24.5_zod@3.25.49",
     "npm:zod@^3.24.1": "3.25.49"
   },
   "jsr": {
-    "@astral/astral@0.5.2": {
-      "integrity": "dc4b7e0ea5d8186fcd9e33e2c54e62913d7eb99d5a2d4f987b1c5399d8e295de",
+    "@astral/astral@0.5.3": {
+      "integrity": "d6a4628313d8be99aac0f51005c1dc090fa3b4c6b5c8335c26a52d4842aa1276",
       "dependencies": [
         "jsr:@deno-library/progress",
         "jsr:@std/async@1",
@@ -180,13 +176,13 @@
         "jsr:@std/io"
       ]
     },
-    "@denosaurs/plug@1.0.6": {
-      "integrity": "6cf5b9daba7799837b9ffbe89f3450510f588fafef8115ddab1ff0be9cb7c1a7",
+    "@denosaurs/plug@1.1.0": {
+      "integrity": "eb2f0b7546c7bca2000d8b0282c54d50d91cf6d75cb26a80df25a6de8c4bc044",
       "dependencies": [
-        "jsr:@std/encoding@0.221",
-        "jsr:@std/fmt@0.221",
-        "jsr:@std/fs@0.221",
-        "jsr:@std/path@0.221"
+        "jsr:@std/encoding@1",
+        "jsr:@std/fmt@1",
+        "jsr:@std/fs@1",
+        "jsr:@std/path@1"
       ]
     },
     "@luca/esbuild-deno-loader@0.11.1": {
@@ -200,86 +196,70 @@
     "@std/assert@0.217.0": {
       "integrity": "c98e279362ca6982d5285c3b89517b757c1e3477ee9f14eb2fdf80a45aaa9642"
     },
-    "@std/assert@0.221.0": {
-      "integrity": "a5f1aa6e7909dbea271754fd4ab3f4e687aeff4873b4cef9a320af813adb489a"
-    },
     "@std/assert@1.0.13": {
       "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
       "dependencies": [
         "jsr:@std/internal@^1.0.6"
       ]
     },
-    "@std/async@1.0.10": {
-      "integrity": "2ff1b1c7d33d1416159989b0f69e59ec7ee8cb58510df01e454def2108b3dbec"
+    "@std/async@1.0.13": {
+      "integrity": "1d76ca5d324aef249908f7f7fe0d39aaf53198e5420604a59ab5c035adc97c96"
     },
-    "@std/bytes@1.0.5": {
-      "integrity": "4465dd739d7963d964c809202ebea6d5c6b8e3829ef25c6a224290fbb8a1021e"
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
-    "@std/cli@1.0.13": {
-      "integrity": "5db2d95ab2dca3bca9fb6ad3c19908c314e93d6391c8b026725e4892d4615a69"
+    "@std/cli@1.0.19": {
+      "integrity": "b3601a54891f89f3f738023af11960c4e6f7a45dc76cde39a6861124cba79e88"
     },
-    "@std/crypto@1.0.4": {
-      "integrity": "cee245c453bd5366207f4d8aa25ea3e9c86cecad2be3fefcaa6cb17203d79340"
+    "@std/crypto@1.0.5": {
+      "integrity": "0dcfbb319fe0bba1bd3af904ceb4f948cde1b92979ec1614528380ed308a3b40"
     },
-    "@std/data-structures@1.0.6": {
-      "integrity": "76a7fd8080c66604c0496220a791860492ab21a04a63a969c0b9a0609bbbb760"
+    "@std/data-structures@1.0.8": {
+      "integrity": "2fb7219247e044c8fcd51341788547575653c82ae2c759ff209e0263ba7d9b66"
     },
-    "@std/dotenv@0.225.3": {
-      "integrity": "a95e5b812c27b0854c52acbae215856d9cce9d4bbf774d938c51d212711e8d4a"
+    "@std/dotenv@0.225.5": {
+      "integrity": "9ce6f9d0ec3311f74a32535aa1b8c62ed88b1ab91b7f0815797d77a6f60c922f"
     },
-    "@std/encoding@0.221.0": {
-      "integrity": "d1dd76ef0dc5d14088411e6dc1dede53bf8308c95d1537df1214c97137208e45"
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
-    "@std/encoding@1.0.7": {
-      "integrity": "f631247c1698fef289f2de9e2a33d571e46133b38d042905e3eac3715030a82d"
-    },
-    "@std/expect@1.0.13": {
-      "integrity": "d8e236c7089cd9fcf5e6032f27dadc3db6349d0aee48c15bc71d717bca5baa42",
+    "@std/expect@1.0.16": {
+      "integrity": "ceeef6dda21f256a5f0f083fcc0eaca175428b523359a9b1d9b3a1df11cc7391",
       "dependencies": [
-        "jsr:@std/assert@^1.0.11",
-        "jsr:@std/internal@^1.0.5"
+        "jsr:@std/assert@^1.0.13",
+        "jsr:@std/internal@^1.0.7"
       ]
-    },
-    "@std/fmt@0.221.0": {
-      "integrity": "379fed69bdd9731110f26b9085aeb740606b20428ce6af31ef6bd45ef8efa62a"
     },
     "@std/fmt@1.0.3": {
       "integrity": "97765c16aa32245ff4e2204ecf7d8562496a3cb8592340a80e7e554e0bb9149f"
     },
-    "@std/fmt@1.0.5": {
-      "integrity": "0cfab43364bc36650d83c425cd6d99910fc20c4576631149f0f987eddede1a4d"
+    "@std/fmt@1.0.8": {
+      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
     },
-    "@std/fs@0.221.0": {
-      "integrity": "028044450299de8ed5a716ade4e6d524399f035513b85913794f4e81f07da286",
+    "@std/fs@1.0.18": {
+      "integrity": "24bcad99eab1af4fde75e05da6e9ed0e0dce5edb71b7e34baacf86ffe3969f3a",
       "dependencies": [
-        "jsr:@std/assert@0.221",
-        "jsr:@std/path@0.221"
+        "jsr:@std/path@^1.1.0"
       ]
     },
-    "@std/fs@1.0.13": {
-      "integrity": "756d3ff0ade91c9e72b228e8012b6ff00c3d4a4ac9c642c4dac083536bf6c605",
-      "dependencies": [
-        "jsr:@std/path@^1.0.8"
-      ]
+    "@std/html@1.0.4": {
+      "integrity": "eff3497c08164e6ada49b7f81a28b5108087033823153d065e3f89467dd3d50e"
     },
-    "@std/html@1.0.3": {
-      "integrity": "7a0ac35e050431fb49d44e61c8b8aac1ebd55937e0dc9ec6409aa4bab39a7988"
-    },
-    "@std/http@1.0.13": {
-      "integrity": "d29618b982f7ae44380111f7e5b43da59b15db64101198bb5f77100d44eb1e1e",
+    "@std/http@1.0.17": {
+      "integrity": "98aec8ab4080d95c21f731e3008f69c29c5012d12f1b4e553f85935db601569f",
       "dependencies": [
-        "jsr:@std/cli@^1.0.12",
-        "jsr:@std/encoding@^1.0.7",
-        "jsr:@std/fmt@^1.0.5",
+        "jsr:@std/cli@^1.0.18",
+        "jsr:@std/encoding@^1.0.10",
+        "jsr:@std/fmt@^1.0.8",
         "jsr:@std/html",
         "jsr:@std/media-types",
         "jsr:@std/net",
-        "jsr:@std/path@^1.0.8",
+        "jsr:@std/path@^1.1.0",
         "jsr:@std/streams"
       ]
     },
-    "@std/internal@1.0.6": {
-      "integrity": "9533b128f230f73bd209408bb07a4b12f8d4255ab2a4d22a1fd6d87304aca9a4"
+    "@std/internal@1.0.8": {
+      "integrity": "fc66e846d8d38a47cffd274d80d2ca3f0de71040f855783724bb6b87f60891f5"
     },
     "@std/io@0.225.0": {
       "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3"
@@ -296,31 +276,25 @@
         "jsr:@std/assert@0.217"
       ]
     },
-    "@std/path@0.221.0": {
-      "integrity": "0a36f6b17314ef653a3a1649740cc8db51b25a133ecfe838f20b79a56ebe0095",
-      "dependencies": [
-        "jsr:@std/assert@0.221"
-      ]
-    },
-    "@std/path@1.0.8": {
-      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
+    "@std/path@1.1.0": {
+      "integrity": "ddc94f8e3c275627281cbc23341df6b8bcc874d70374f75fec2533521e3d6886"
     },
     "@std/streams@1.0.9": {
       "integrity": "a9d26b1988cdd7aa7b1f4b51e1c36c1557f3f252880fa6cc5b9f37078b1a5035"
     },
-    "@std/testing@1.0.9": {
-      "integrity": "9bdd4ac07cb13e7594ac30e90f6ceef7254ac83a9aeaa089be0008f33aab5cd4",
+    "@std/testing@1.0.13": {
+      "integrity": "74418be16f627dfe996937ab0ffbdbda9c1f35534b78724658d981492f121e71",
       "dependencies": [
-        "jsr:@std/assert@^1.0.10",
-        "jsr:@std/async@^1.0.9",
+        "jsr:@std/assert@^1.0.13",
+        "jsr:@std/async@^1.0.13",
         "jsr:@std/data-structures",
-        "jsr:@std/fs@^1.0.9",
-        "jsr:@std/internal@^1.0.5",
-        "jsr:@std/path@^1.0.8"
+        "jsr:@std/fs@^1.0.17",
+        "jsr:@std/internal@^1.0.8",
+        "jsr:@std/path@^1.1.0"
       ]
     },
-    "@zip-js/zip-js@2.7.57": {
-      "integrity": "15465ff627e321775870ad493bc043ca2d97940bda58d709c49908d39f4b0524"
+    "@zip-js/zip-js@2.7.62": {
+      "integrity": "11cbe0746fa1e52e6e0a601c89ba97365f16e38a07f139b9d9914f988aec9081"
     }
   },
   "npm": {
@@ -332,8 +306,8 @@
         "zod"
       ]
     },
-    "@ai-sdk/google-vertex@2.2.23_zod@3.25.49": {
-      "integrity": "sha512-q8rOXqEYBOTcgVW1+QlkYEd+bP1ZWfRYhRs3QzzAL1SP3AQqltuKM7ovO53AFDq5hwlodFMHQ4v9WmXmibgjAg==",
+    "@ai-sdk/google-vertex@2.2.24_zod@3.25.49": {
+      "integrity": "sha512-zi1ZN6jQEBRke/WMbZv0YkeqQ3nOs8ihxjVh/8z1tUn+S1xgRaYXf4+r6+Izh2YqVHIMNwjhUYryQRBGq20cgQ==",
       "dependencies": [
         "@ai-sdk/anthropic",
         "@ai-sdk/google",
@@ -343,8 +317,8 @@
         "zod"
       ]
     },
-    "@ai-sdk/google@1.2.18_zod@3.25.49": {
-      "integrity": "sha512-8B70+i+uB12Ae6Sn6B9Oc6W0W/XorGgc88Nx0pyUrcxFOdytHBaAVhTPqYsO3LLClfjYN8pQ9GMxd5cpGEnUcA==",
+    "@ai-sdk/google@1.2.19_zod@3.25.49": {
+      "integrity": "sha512-Xgl6eftIRQ4srUdCzxM112JuewVMij5q4JLcNmHcB68Bxn9dpr3MVUSPlJwmameuiQuISIA8lMB+iRiRbFsaqA==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -474,8 +448,8 @@
         "picocolors"
       ]
     },
-    "@babel/compat-data@7.27.3": {
-      "integrity": "sha512-V42wFfx1ymFte+ecf6iXghnnP8kWTO+ZLXIyZq+1LAXHHvTZdVxicn4yiVYdYMGaCO3tmqub11AorKkv+iodqw=="
+    "@babel/compat-data@7.27.5": {
+      "integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg=="
     },
     "@babel/core@7.27.4": {
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
@@ -497,8 +471,8 @@
         "semver@6.3.1"
       ]
     },
-    "@babel/generator@7.27.3": {
-      "integrity": "sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==",
+    "@babel/generator@7.27.5": {
+      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
       "dependencies": [
         "@babel/parser",
         "@babel/types",
@@ -552,8 +526,8 @@
         "@babel/types"
       ]
     },
-    "@babel/parser@7.27.4": {
-      "integrity": "sha512-BRmLHGwpUqLFR2jzx9orBuX/ABDkj2jLKOXrHDTN2aOKL+jFDDKaRNo9nyYsIl9h/UE/7lMKdDjKQQyxKKDZ7g==",
+    "@babel/parser@7.27.5": {
+      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
       "dependencies": [
         "@babel/types"
       ],
@@ -2132,40 +2106,40 @@
         "@scure/base"
       ]
     },
-    "@sentry-internal/browser-utils@9.24.0": {
-      "integrity": "sha512-fWIrHyui8KKufnbqhGyDvvr+u9wiOEEzxXEjs/CKp+6fa+jej6Mk8K+su1f/mz7R3HVzhxvht/gZ+y193uK4qw==",
+    "@sentry-internal/browser-utils@9.25.1": {
+      "integrity": "sha512-/E8NKoGpkZCiGfZ7OuROWjnhBDKs22JpeiLDpbvl+zdA11zJXOl/i99fDzwZZmx/yGH737Ai7KSLiw3HVcsH5A==",
       "dependencies": [
-        "@sentry/core@9.24.0"
+        "@sentry/core@9.25.1"
       ]
     },
-    "@sentry-internal/feedback@9.24.0": {
-      "integrity": "sha512-Z9jQqKzRppwAEqiytLWNV8JOo52vlxcSGz52FjKx3KXG75PXwk0M3sBXh762WoGLisUIRLTp8LOk6304L/O8dg==",
+    "@sentry-internal/feedback@9.25.1": {
+      "integrity": "sha512-wPyX68izXUGRHIpE2vz/LzgIJXtfnEL+LXjKJW11RA2yzAvd8SSmX+raBTuIr4dFhUJ8fn08OlYSAo4L1fY1RQ==",
       "dependencies": [
-        "@sentry/core@9.24.0"
+        "@sentry/core@9.25.1"
       ]
     },
-    "@sentry-internal/replay-canvas@9.24.0": {
-      "integrity": "sha512-506RdDF6iE8hMyzpzp9Vc0GM7kELxxs7UCoi/6KpvXFftcydWI3S2bru8dEZsxVoKh2hdle6SpbNgl+iPI0DSQ==",
+    "@sentry-internal/replay-canvas@9.25.1": {
+      "integrity": "sha512-KR/zvg9Oe7pH0OBioHNSYOsk/Og6Ih7emkfIUvN6RmVkVeycOERDqJyXmKM8mKC9wFXDpivBZRhrWgg/dtAAPw==",
       "dependencies": [
         "@sentry-internal/replay",
-        "@sentry/core@9.24.0"
+        "@sentry/core@9.25.1"
       ]
     },
-    "@sentry-internal/replay@9.24.0": {
-      "integrity": "sha512-312wMPeQI8K2vO/lA/CF6Uv5UReoZC7RarsNUJEoOKa9Bq1BXWUq929oTHzu/2NDv194H2u3eqSGsSp6xiuKTw==",
+    "@sentry-internal/replay@9.25.1": {
+      "integrity": "sha512-m5e2t8TolKeRYwZkUQ19Z9sjntVnEHomfI5ggiGyMGLobOgRpG40q1+BVwuO6sjaT7jMvDSZeIbjeEl/f+jABA==",
       "dependencies": [
         "@sentry-internal/browser-utils",
-        "@sentry/core@9.24.0"
+        "@sentry/core@9.25.1"
       ]
     },
-    "@sentry/browser@9.24.0": {
-      "integrity": "sha512-RP+27/owvIqD4J0TibIHK1UcA7iObxLOXBEilDKjaJOZMLhv3JkpU8A+UI9pFzEYqeIGVDDaBzYgbCHrLWcoCA==",
+    "@sentry/browser@9.25.1": {
+      "integrity": "sha512-wIpRGtwlO4SBqlO0E2xjM0ag3/J6H/zIySMz/zyG9onYThtjKVuM0I1IIWt4PN0cEO8eznBO/6cPSECVnIrQZA==",
       "dependencies": [
         "@sentry-internal/browser-utils",
         "@sentry-internal/feedback",
         "@sentry-internal/replay",
         "@sentry-internal/replay-canvas",
-        "@sentry/core@9.24.0"
+        "@sentry/core@9.25.1"
       ]
     },
     "@sentry/core@8.9.2": {
@@ -2175,20 +2149,20 @@
         "@sentry/utils"
       ]
     },
-    "@sentry/core@9.24.0": {
-      "integrity": "sha512-uRWrB4Y49ZOWcDLCXqdjd2Fs6Onill0GQI+JgXMw7wa+i03+QRiQvUAUyde8O62jR4dvP3GDo9PDWnDNhi3z5A=="
+    "@sentry/core@9.25.1": {
+      "integrity": "sha512-c87MOAJ7nAdysQgMFCnQXoKgWx30poLTJRsK+N72ZQhGiLIzp25xuIhCsTLuftxR852tZShd9X11yU0NuolmkA=="
     },
-    "@sentry/deno@9.24.0": {
-      "integrity": "sha512-DUfzKRF3ZdLKkMX8m6xKVa9wqw+Kmh+JmxT9FvnWJmvvi7YKCJfKDjxl19J5vsP0Vn1EKFIlDykZM00WPcunOw==",
+    "@sentry/deno@9.25.1": {
+      "integrity": "sha512-TbtCVqX4jpztNVNXwc56cxWiA1L1iuAJfvc/PP9KTzocBJGXQJs6hhV8BO+RsMiHR913661+1jjtzJicpdA1ow==",
       "dependencies": [
-        "@sentry/core@9.24.0"
+        "@sentry/core@9.25.1"
       ]
     },
-    "@sentry/react@9.24.0_react@18.3.1": {
-      "integrity": "sha512-CEgNuxnaax5JXvCJGO8MaPU6Doqf8OMK/52SwZxTwJJFsQBAC2v7Dl+Qot7H4GVb0exg3psumL4NjNeXAfGcpA==",
+    "@sentry/react@9.25.1_react@18.3.1": {
+      "integrity": "sha512-6rXImkzIUQ+c077xN31SYgM0TYGjT1iVqS/Affpq09zJGuWr/HDcIZru+YnrwUju0H7AdIcB1Fnv1uSFW4ggVQ==",
       "dependencies": [
         "@sentry/browser",
-        "@sentry/core@9.24.0",
+        "@sentry/core@9.25.1",
         "hoist-non-react-statics",
         "react"
       ]
@@ -2339,15 +2313,6 @@
         "@tailwindcss/oxide",
         "tailwindcss",
         "vite@6.3.5_@types+node@22.15.29_picomatch@4.0.2"
-      ]
-    },
-    "@tailwindcss/vite@4.1.8_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@types+node@22.15.29_@types+node@22.15.15": {
-      "integrity": "sha512-CQ+I8yxNV5/6uGaJjiuymgw0kEQiNKRinYbZXPdx1fk5WgiyReG0VaUx/Xq6aVNSUNJFzxm6o8FNKS5aMaim5A==",
-      "dependencies": [
-        "@tailwindcss/node",
-        "@tailwindcss/oxide",
-        "tailwindcss",
-        "vite@6.3.5_@types+node@22.15.29_picomatch@4.0.2_@types+node@22.15.15"
       ]
     },
     "@tootallnate/quickjs-emscripten@0.23.0": {
@@ -2751,8 +2716,8 @@
         "@opentelemetry/sdk-trace-base@1.30.1_@opentelemetry+api@1.9.0"
       ]
     },
-    "@vitejs/plugin-react@4.5.0_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@babel+core@7.27.4_@types+node@22.15.29": {
-      "integrity": "sha512-JuLWaEqypaJmOJPLWwO335Ig6jSgC1FTONCWAxnqcQthLTK/Yc9aH6hr9z/87xciejbQcnP3GnA1FWUSWeXaeg==",
+    "@vitejs/plugin-react@4.5.1_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@babel+core@7.27.4_@types+node@22.15.29": {
+      "integrity": "sha512-uPZBqSI0YD4lpkIru6M35sIfylLGTyhGHvDZbNLuMA73lMlwJKz5xweH7FajfcCAc2HnINciejA9qTz0dr0M7A==",
       "dependencies": [
         "@babel/core",
         "@babel/plugin-transform-react-jsx-self",
@@ -2761,18 +2726,6 @@
         "@types/babel__core",
         "react-refresh",
         "vite@6.3.5_@types+node@22.15.29_picomatch@4.0.2"
-      ]
-    },
-    "@vitejs/plugin-react@4.5.0_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@babel+core@7.27.4_@types+node@22.15.29_@types+node@22.15.15": {
-      "integrity": "sha512-JuLWaEqypaJmOJPLWwO335Ig6jSgC1FTONCWAxnqcQthLTK/Yc9aH6hr9z/87xciejbQcnP3GnA1FWUSWeXaeg==",
-      "dependencies": [
-        "@babel/core",
-        "@babel/plugin-transform-react-jsx-self",
-        "@babel/plugin-transform-react-jsx-source",
-        "@rolldown/pluginutils",
-        "@types/babel__core",
-        "react-refresh",
-        "vite@6.3.5_@types+node@22.15.29_picomatch@4.0.2_@types+node@22.15.15"
       ]
     },
     "@vitest/expect@2.1.9": {
@@ -2794,18 +2747,6 @@
       ],
       "optionalPeers": [
         "vite@5.4.19_@types+node@22.15.29"
-      ]
-    },
-    "@vitest/mocker@2.1.9_vite@5.4.19__@types+node@22.15.29_@types+node@22.15.29_@types+node@22.15.15": {
-      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
-      "dependencies": [
-        "@vitest/spy",
-        "estree-walker@3.0.3",
-        "magic-string",
-        "vite@5.4.19_@types+node@22.15.29_@types+node@22.15.15"
-      ],
-      "optionalPeers": [
-        "vite@5.4.19_@types+node@22.15.29_@types+node@22.15.15"
       ]
     },
     "@vitest/pretty-format@2.1.9": {
@@ -5944,8 +5885,8 @@
         "@hono/zod-openapi"
       ]
     },
-    "streamx@2.22.0": {
-      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+    "streamx@2.22.1": {
+      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
       "dependencies": [
         "fast-fifo",
         "text-decoder"
@@ -6411,17 +6352,6 @@
       ],
       "bin": true
     },
-    "vite-node@2.1.9_@types+node@22.15.29_@types+node@22.15.15": {
-      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
-      "dependencies": [
-        "cac",
-        "debug@4.4.1",
-        "es-module-lexer",
-        "pathe",
-        "vite@5.4.19_@types+node@22.15.29_@types+node@22.15.15"
-      ],
-      "bin": true
-    },
     "vite@5.4.19_@types+node@22.15.29": {
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dependencies": [
@@ -6435,22 +6365,6 @@
       ],
       "optionalPeers": [
         "@types/node@22.15.29"
-      ],
-      "bin": true
-    },
-    "vite@5.4.19_@types+node@22.15.29_@types+node@22.15.15": {
-      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
-      "dependencies": [
-        "@types/node@22.15.15",
-        "esbuild@0.21.5",
-        "postcss",
-        "rollup"
-      ],
-      "optionalDependencies": [
-        "fsevents"
-      ],
-      "optionalPeers": [
-        "@types/node@22.15.15"
       ],
       "bin": true
     },
@@ -6473,31 +6387,12 @@
       ],
       "bin": true
     },
-    "vite@6.3.5_@types+node@22.15.29_picomatch@4.0.2_@types+node@22.15.15": {
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
-      "dependencies": [
-        "@types/node@22.15.15",
-        "esbuild@0.25.5",
-        "fdir",
-        "picomatch@4.0.2",
-        "postcss",
-        "rollup",
-        "tinyglobby"
-      ],
-      "optionalDependencies": [
-        "fsevents"
-      ],
-      "optionalPeers": [
-        "@types/node@22.15.15"
-      ],
-      "bin": true
-    },
     "vitest@2.1.9_@types+node@22.15.29_jsdom@26.1.0_vite@5.4.19__@types+node@22.15.29": {
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dependencies": [
         "@types/node@22.15.29",
         "@vitest/expect",
-        "@vitest/mocker@2.1.9_vite@5.4.19__@types+node@22.15.29_@types+node@22.15.29",
+        "@vitest/mocker",
         "@vitest/pretty-format",
         "@vitest/runner",
         "@vitest/snapshot",
@@ -6515,43 +6410,11 @@
         "tinypool",
         "tinyrainbow",
         "vite@5.4.19_@types+node@22.15.29",
-        "vite-node@2.1.9_@types+node@22.15.29",
+        "vite-node",
         "why-is-node-running"
       ],
       "optionalPeers": [
         "@types/node@22.15.29",
-        "jsdom"
-      ],
-      "bin": true
-    },
-    "vitest@2.1.9_@types+node@22.15.29_jsdom@26.1.0_vite@5.4.19__@types+node@22.15.29_@types+node@22.15.15": {
-      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
-      "dependencies": [
-        "@types/node@22.15.15",
-        "@vitest/expect",
-        "@vitest/mocker@2.1.9_vite@5.4.19__@types+node@22.15.29_@types+node@22.15.29_@types+node@22.15.15",
-        "@vitest/pretty-format",
-        "@vitest/runner",
-        "@vitest/snapshot",
-        "@vitest/spy",
-        "@vitest/utils",
-        "chai",
-        "debug@4.4.1",
-        "expect-type",
-        "jsdom",
-        "magic-string",
-        "pathe",
-        "std-env",
-        "tinybench",
-        "tinyexec",
-        "tinypool",
-        "tinyrainbow",
-        "vite@5.4.19_@types+node@22.15.29_@types+node@22.15.15",
-        "vite-node@2.1.9_@types+node@22.15.29_@types+node@22.15.15",
-        "why-is-node-running"
-      ],
-      "optionalPeers": [
-        "@types/node@22.15.15",
         "jsdom"
       ],
       "bin": true
@@ -6750,11 +6613,16 @@
     }
   },
   "redirects": {
-    "https://esm.sh/@babel/standalone": "https://esm.sh/@babel/standalone@7.27.0",
-    "https://esm.sh/@types/babel__standalone@~7.1.9/index.d.ts": "https://esm.sh/@types/babel__standalone@7.1.9/index.d.ts"
+    "https://deno.land/x/is_docker/mod.ts": "https://deno.land/x/is_docker@v2.0.0/mod.ts"
   },
   "remote": {
-    "https://esm.sh/@babel/standalone@7.27.0": "82a6873adc960aaa2ab9fcb605fc634754f5cd39ea121b442a0a000fbd24ef58"
+    "https://deno.land/std@0.106.0/path/_constants.ts": "1247fee4a79b70c89f23499691ef169b41b6ccf01887a0abd131009c5581b853",
+    "https://deno.land/std@0.106.0/path/_interface.ts": "1fa73b02aaa24867e481a48492b44f2598cd9dfa513c7b34001437007d3642e4",
+    "https://deno.land/std@0.106.0/path/_util.ts": "2e06a3b9e79beaf62687196bd4b60a4c391d862cfa007a20fc3a39f778ba073b",
+    "https://deno.land/std@0.106.0/path/posix.ts": "b81974c768d298f8dcd2c720229639b3803ca4a241fa9a355c762fa2bc5ef0c1",
+    "https://deno.land/x/is_docker@v2.0.0/mod.ts": "4c8753346f4afbb6c251d7984a609aa84055559cf713fba828939a5d39c95cd0",
+    "https://deno.land/x/is_wsl@v1.1.0/mod.ts": "30996b09376652df7a4d495320e918154906ab94325745c1399e13e658dca5da",
+    "https://deno.land/x/open@v0.0.6/index.ts": "c7484a7bf2628236f33bbe354520e651811faf1a7cbc3c3f80958ce81b4c42ef"
   },
   "workspace": {
     "dependencies": [

--- a/deno.lock
+++ b/deno.lock
@@ -1,51 +1,54 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@astral/astral@*": "0.5.3",
+    "jsr:@astral/astral@*": "0.5.2",
     "jsr:@cmd-johnson/oauth2-client@2": "2.0.0",
     "jsr:@db/sqlite@0.12": "0.12.0",
     "jsr:@deno-library/progress@^1.5.1": "1.5.1",
-    "jsr:@denosaurs/plug@1": "1.1.0",
+    "jsr:@denosaurs/plug@1": "1.0.6",
     "jsr:@luca/esbuild-deno-loader@*": "0.11.1",
     "jsr:@std/assert@0.217": "0.217.0",
+    "jsr:@std/assert@0.221": "0.221.0",
     "jsr:@std/assert@1": "1.0.13",
-    "jsr:@std/assert@^1.0.13": "1.0.13",
-    "jsr:@std/async@1": "1.0.13",
-    "jsr:@std/async@^1.0.13": "1.0.13",
-    "jsr:@std/bytes@^1.0.2": "1.0.6",
-    "jsr:@std/cli@1": "1.0.19",
-    "jsr:@std/cli@^1.0.12": "1.0.19",
-    "jsr:@std/cli@^1.0.18": "1.0.19",
-    "jsr:@std/crypto@1": "1.0.5",
-    "jsr:@std/data-structures@^1.0.8": "1.0.8",
-    "jsr:@std/dotenv@~0.225.3": "0.225.5",
-    "jsr:@std/encoding@1": "1.0.10",
-    "jsr:@std/encoding@^1.0.10": "1.0.10",
-    "jsr:@std/encoding@^1.0.5": "1.0.10",
-    "jsr:@std/expect@1": "1.0.16",
-    "jsr:@std/fmt@1": "1.0.8",
+    "jsr:@std/assert@^1.0.10": "1.0.13",
+    "jsr:@std/assert@^1.0.11": "1.0.13",
+    "jsr:@std/async@1": "1.0.10",
+    "jsr:@std/async@^1.0.9": "1.0.10",
+    "jsr:@std/bytes@^1.0.2": "1.0.5",
+    "jsr:@std/cli@1": "1.0.13",
+    "jsr:@std/cli@^1.0.12": "1.0.13",
+    "jsr:@std/crypto@1": "1.0.4",
+    "jsr:@std/data-structures@^1.0.6": "1.0.6",
+    "jsr:@std/dotenv@~0.225.3": "0.225.3",
+    "jsr:@std/encoding@0.221": "0.221.0",
+    "jsr:@std/encoding@1": "1.0.7",
+    "jsr:@std/encoding@^1.0.5": "1.0.7",
+    "jsr:@std/encoding@^1.0.7": "1.0.7",
+    "jsr:@std/expect@1": "1.0.13",
+    "jsr:@std/fmt@0.221": "0.221.0",
     "jsr:@std/fmt@1.0.3": "1.0.3",
-    "jsr:@std/fmt@^1.0.8": "1.0.8",
-    "jsr:@std/fs@1": "1.0.18",
-    "jsr:@std/fs@^1.0.17": "1.0.18",
-    "jsr:@std/html@^1.0.4": "1.0.4",
-    "jsr:@std/http@1": "1.0.17",
-    "jsr:@std/internal@^1.0.6": "1.0.8",
-    "jsr:@std/internal@^1.0.7": "1.0.8",
-    "jsr:@std/internal@^1.0.8": "1.0.8",
+    "jsr:@std/fmt@^1.0.5": "1.0.5",
+    "jsr:@std/fs@0.221": "0.221.0",
+    "jsr:@std/fs@1": "1.0.13",
+    "jsr:@std/fs@^1.0.9": "1.0.13",
+    "jsr:@std/html@^1.0.3": "1.0.3",
+    "jsr:@std/http@1": "1.0.13",
+    "jsr:@std/internal@^1.0.5": "1.0.6",
+    "jsr:@std/internal@^1.0.6": "1.0.6",
     "jsr:@std/io@0.225.0": "0.225.0",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.4": "1.0.4",
     "jsr:@std/path@0.217": "0.217.0",
-    "jsr:@std/path@1": "1.1.0",
-    "jsr:@std/path@^1.0.6": "1.1.0",
-    "jsr:@std/path@^1.1.0": "1.1.0",
+    "jsr:@std/path@0.221": "0.221.0",
+    "jsr:@std/path@1": "1.0.8",
+    "jsr:@std/path@^1.0.6": "1.0.8",
+    "jsr:@std/path@^1.0.8": "1.0.8",
     "jsr:@std/streams@^1.0.9": "1.0.9",
-    "jsr:@std/testing@1": "1.0.13",
-    "jsr:@zip-js/zip-js@^2.7.52": "2.7.62",
+    "jsr:@std/testing@1": "1.0.9",
+    "jsr:@zip-js/zip-js@^2.7.52": "2.7.57",
     "npm:@ai-sdk/anthropic@^1.1.6": "1.2.12_zod@3.25.49",
     "npm:@ai-sdk/anthropic@^1.2.10": "1.2.12_zod@3.25.49",
-    "npm:@ai-sdk/google-vertex@^2.2.17": "2.2.24_zod@3.25.49",
+    "npm:@ai-sdk/google-vertex@^2.2.17": "2.2.23_zod@3.25.49",
     "npm:@ai-sdk/groq@^1.2.8": "1.2.9_zod@3.25.49",
     "npm:@ai-sdk/openai@^1.1.9": "1.3.22_zod@3.25.49",
     "npm:@ai-sdk/openai@^1.3.20": "1.3.22_zod@3.25.49",
@@ -81,12 +84,13 @@
     "npm:@react-three/fiber@^8.17.14": "8.18.0_react@18.3.1_react-dom@18.3.1__react@18.3.1_three@0.173.0_@types+react@18.3.23",
     "npm:@scalar/hono-api-reference@~0.5.165": "0.5.184_hono@4.7.11",
     "npm:@scure/bip39@^1.5.4": "1.6.0",
-    "npm:@sentry/deno@^9.3.0": "9.25.1",
-    "npm:@sentry/react@^9.7.0": "9.25.1_react@18.3.1",
+    "npm:@sentry/deno@^9.3.0": "9.24.0",
+    "npm:@sentry/react@^9.7.0": "9.24.0_react@18.3.1",
     "npm:@shoelace-style/shoelace@^2.19.1": "2.20.1_@types+react@18.3.23",
     "npm:@tailwindcss/typography@~0.5.16": "0.5.16_tailwindcss@4.1.8",
-    "npm:@tailwindcss/vite@^4.0.1": "4.1.8_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@types+node@22.15.29",
+    "npm:@tailwindcss/vite@^4.0.1": "4.1.8_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@types+node@22.15.29_@types+node@22.15.15",
     "npm:@types/jsdom@^21.1.7": "21.1.7",
+    "npm:@types/node@*": "22.15.15",
     "npm:@types/node@^22.12.0": "22.15.29",
     "npm:@types/node@^22.5.5": "22.15.29",
     "npm:@types/react-dom@^18.3.1": "18.3.7_@types+react@18.3.23",
@@ -97,7 +101,7 @@
     "npm:@uiw/react-json-view@2.0.0-alpha.30": "2.0.0-alpha.30_@babel+runtime@7.27.4_react@18.3.1_react-dom@18.3.1__react@18.3.1",
     "npm:@use-gesture/react@^10.3.1": "10.3.1_react@18.3.1",
     "npm:@vercel/otel@^1.10.1": "1.12.0_@opentelemetry+api@1.9.0_@opentelemetry+api-logs@0.202.0_@opentelemetry+instrumentation@0.202.0__@opentelemetry+api@1.9.0_@opentelemetry+resources@1.30.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-logs@0.202.0__@opentelemetry+api@1.9.0_@opentelemetry+sdk-metrics@1.30.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-trace-base@1.30.1__@opentelemetry+api@1.9.0",
-    "npm:@vitejs/plugin-react@^4.3.4": "4.5.1_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@babel+core@7.27.4_@types+node@22.15.29",
+    "npm:@vitejs/plugin-react@^4.3.4": "4.5.0_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@babel+core@7.27.4_@types+node@22.15.29_@types+node@22.15.15",
     "npm:@web/test-runner@*": "0.20.2",
     "npm:ai@^4.3.10": "4.3.16_react@18.3.1_zod@3.25.49",
     "npm:ai@^4.3.9": "4.3.16_react@18.3.1_zod@3.25.49",
@@ -139,15 +143,15 @@
     "npm:turndown@^7.1.2": "7.2.0",
     "npm:typescript@*": "5.8.3",
     "npm:typescript@^5.6.2": "5.8.3",
-    "npm:vite@*": "6.3.5_@types+node@22.15.29_picomatch@4.0.2",
-    "npm:vite@^6.2.1": "6.3.5_@types+node@22.15.29_picomatch@4.0.2",
-    "npm:vitest@^2.1.1": "2.1.9_@types+node@22.15.29_jsdom@26.1.0_vite@5.4.19__@types+node@22.15.29",
+    "npm:vite@*": "6.3.5_@types+node@22.15.29_picomatch@4.0.2_@types+node@22.15.15",
+    "npm:vite@^6.2.1": "6.3.5_@types+node@22.15.29_picomatch@4.0.2_@types+node@22.15.15",
+    "npm:vitest@^2.1.1": "2.1.9_@types+node@22.15.29_jsdom@26.1.0_vite@5.4.19__@types+node@22.15.29_@types+node@22.15.15",
     "npm:zod-to-json-schema@^3.24.1": "3.24.5_zod@3.25.49",
     "npm:zod@^3.24.1": "3.25.49"
   },
   "jsr": {
-    "@astral/astral@0.5.3": {
-      "integrity": "d6a4628313d8be99aac0f51005c1dc090fa3b4c6b5c8335c26a52d4842aa1276",
+    "@astral/astral@0.5.2": {
+      "integrity": "dc4b7e0ea5d8186fcd9e33e2c54e62913d7eb99d5a2d4f987b1c5399d8e295de",
       "dependencies": [
         "jsr:@deno-library/progress",
         "jsr:@std/async@1",
@@ -176,13 +180,13 @@
         "jsr:@std/io"
       ]
     },
-    "@denosaurs/plug@1.1.0": {
-      "integrity": "eb2f0b7546c7bca2000d8b0282c54d50d91cf6d75cb26a80df25a6de8c4bc044",
+    "@denosaurs/plug@1.0.6": {
+      "integrity": "6cf5b9daba7799837b9ffbe89f3450510f588fafef8115ddab1ff0be9cb7c1a7",
       "dependencies": [
-        "jsr:@std/encoding@1",
-        "jsr:@std/fmt@1",
-        "jsr:@std/fs@1",
-        "jsr:@std/path@1"
+        "jsr:@std/encoding@0.221",
+        "jsr:@std/fmt@0.221",
+        "jsr:@std/fs@0.221",
+        "jsr:@std/path@0.221"
       ]
     },
     "@luca/esbuild-deno-loader@0.11.1": {
@@ -196,70 +200,86 @@
     "@std/assert@0.217.0": {
       "integrity": "c98e279362ca6982d5285c3b89517b757c1e3477ee9f14eb2fdf80a45aaa9642"
     },
+    "@std/assert@0.221.0": {
+      "integrity": "a5f1aa6e7909dbea271754fd4ab3f4e687aeff4873b4cef9a320af813adb489a"
+    },
     "@std/assert@1.0.13": {
       "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
       "dependencies": [
         "jsr:@std/internal@^1.0.6"
       ]
     },
-    "@std/async@1.0.13": {
-      "integrity": "1d76ca5d324aef249908f7f7fe0d39aaf53198e5420604a59ab5c035adc97c96"
+    "@std/async@1.0.10": {
+      "integrity": "2ff1b1c7d33d1416159989b0f69e59ec7ee8cb58510df01e454def2108b3dbec"
     },
-    "@std/bytes@1.0.6": {
-      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
+    "@std/bytes@1.0.5": {
+      "integrity": "4465dd739d7963d964c809202ebea6d5c6b8e3829ef25c6a224290fbb8a1021e"
     },
-    "@std/cli@1.0.19": {
-      "integrity": "b3601a54891f89f3f738023af11960c4e6f7a45dc76cde39a6861124cba79e88"
+    "@std/cli@1.0.13": {
+      "integrity": "5db2d95ab2dca3bca9fb6ad3c19908c314e93d6391c8b026725e4892d4615a69"
     },
-    "@std/crypto@1.0.5": {
-      "integrity": "0dcfbb319fe0bba1bd3af904ceb4f948cde1b92979ec1614528380ed308a3b40"
+    "@std/crypto@1.0.4": {
+      "integrity": "cee245c453bd5366207f4d8aa25ea3e9c86cecad2be3fefcaa6cb17203d79340"
     },
-    "@std/data-structures@1.0.8": {
-      "integrity": "2fb7219247e044c8fcd51341788547575653c82ae2c759ff209e0263ba7d9b66"
+    "@std/data-structures@1.0.6": {
+      "integrity": "76a7fd8080c66604c0496220a791860492ab21a04a63a969c0b9a0609bbbb760"
     },
-    "@std/dotenv@0.225.5": {
-      "integrity": "9ce6f9d0ec3311f74a32535aa1b8c62ed88b1ab91b7f0815797d77a6f60c922f"
+    "@std/dotenv@0.225.3": {
+      "integrity": "a95e5b812c27b0854c52acbae215856d9cce9d4bbf774d938c51d212711e8d4a"
     },
-    "@std/encoding@1.0.10": {
-      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
+    "@std/encoding@0.221.0": {
+      "integrity": "d1dd76ef0dc5d14088411e6dc1dede53bf8308c95d1537df1214c97137208e45"
     },
-    "@std/expect@1.0.16": {
-      "integrity": "ceeef6dda21f256a5f0f083fcc0eaca175428b523359a9b1d9b3a1df11cc7391",
+    "@std/encoding@1.0.7": {
+      "integrity": "f631247c1698fef289f2de9e2a33d571e46133b38d042905e3eac3715030a82d"
+    },
+    "@std/expect@1.0.13": {
+      "integrity": "d8e236c7089cd9fcf5e6032f27dadc3db6349d0aee48c15bc71d717bca5baa42",
       "dependencies": [
-        "jsr:@std/assert@^1.0.13",
-        "jsr:@std/internal@^1.0.7"
+        "jsr:@std/assert@^1.0.11",
+        "jsr:@std/internal@^1.0.5"
       ]
+    },
+    "@std/fmt@0.221.0": {
+      "integrity": "379fed69bdd9731110f26b9085aeb740606b20428ce6af31ef6bd45ef8efa62a"
     },
     "@std/fmt@1.0.3": {
       "integrity": "97765c16aa32245ff4e2204ecf7d8562496a3cb8592340a80e7e554e0bb9149f"
     },
-    "@std/fmt@1.0.8": {
-      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
+    "@std/fmt@1.0.5": {
+      "integrity": "0cfab43364bc36650d83c425cd6d99910fc20c4576631149f0f987eddede1a4d"
     },
-    "@std/fs@1.0.18": {
-      "integrity": "24bcad99eab1af4fde75e05da6e9ed0e0dce5edb71b7e34baacf86ffe3969f3a",
+    "@std/fs@0.221.0": {
+      "integrity": "028044450299de8ed5a716ade4e6d524399f035513b85913794f4e81f07da286",
       "dependencies": [
-        "jsr:@std/path@^1.1.0"
+        "jsr:@std/assert@0.221",
+        "jsr:@std/path@0.221"
       ]
     },
-    "@std/html@1.0.4": {
-      "integrity": "eff3497c08164e6ada49b7f81a28b5108087033823153d065e3f89467dd3d50e"
-    },
-    "@std/http@1.0.17": {
-      "integrity": "98aec8ab4080d95c21f731e3008f69c29c5012d12f1b4e553f85935db601569f",
+    "@std/fs@1.0.13": {
+      "integrity": "756d3ff0ade91c9e72b228e8012b6ff00c3d4a4ac9c642c4dac083536bf6c605",
       "dependencies": [
-        "jsr:@std/cli@^1.0.18",
-        "jsr:@std/encoding@^1.0.10",
-        "jsr:@std/fmt@^1.0.8",
+        "jsr:@std/path@^1.0.8"
+      ]
+    },
+    "@std/html@1.0.3": {
+      "integrity": "7a0ac35e050431fb49d44e61c8b8aac1ebd55937e0dc9ec6409aa4bab39a7988"
+    },
+    "@std/http@1.0.13": {
+      "integrity": "d29618b982f7ae44380111f7e5b43da59b15db64101198bb5f77100d44eb1e1e",
+      "dependencies": [
+        "jsr:@std/cli@^1.0.12",
+        "jsr:@std/encoding@^1.0.7",
+        "jsr:@std/fmt@^1.0.5",
         "jsr:@std/html",
         "jsr:@std/media-types",
         "jsr:@std/net",
-        "jsr:@std/path@^1.1.0",
+        "jsr:@std/path@^1.0.8",
         "jsr:@std/streams"
       ]
     },
-    "@std/internal@1.0.8": {
-      "integrity": "fc66e846d8d38a47cffd274d80d2ca3f0de71040f855783724bb6b87f60891f5"
+    "@std/internal@1.0.6": {
+      "integrity": "9533b128f230f73bd209408bb07a4b12f8d4255ab2a4d22a1fd6d87304aca9a4"
     },
     "@std/io@0.225.0": {
       "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3"
@@ -276,25 +296,31 @@
         "jsr:@std/assert@0.217"
       ]
     },
-    "@std/path@1.1.0": {
-      "integrity": "ddc94f8e3c275627281cbc23341df6b8bcc874d70374f75fec2533521e3d6886"
+    "@std/path@0.221.0": {
+      "integrity": "0a36f6b17314ef653a3a1649740cc8db51b25a133ecfe838f20b79a56ebe0095",
+      "dependencies": [
+        "jsr:@std/assert@0.221"
+      ]
+    },
+    "@std/path@1.0.8": {
+      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
     },
     "@std/streams@1.0.9": {
       "integrity": "a9d26b1988cdd7aa7b1f4b51e1c36c1557f3f252880fa6cc5b9f37078b1a5035"
     },
-    "@std/testing@1.0.13": {
-      "integrity": "74418be16f627dfe996937ab0ffbdbda9c1f35534b78724658d981492f121e71",
+    "@std/testing@1.0.9": {
+      "integrity": "9bdd4ac07cb13e7594ac30e90f6ceef7254ac83a9aeaa089be0008f33aab5cd4",
       "dependencies": [
-        "jsr:@std/assert@^1.0.13",
-        "jsr:@std/async@^1.0.13",
+        "jsr:@std/assert@^1.0.10",
+        "jsr:@std/async@^1.0.9",
         "jsr:@std/data-structures",
-        "jsr:@std/fs@^1.0.17",
-        "jsr:@std/internal@^1.0.8",
-        "jsr:@std/path@^1.1.0"
+        "jsr:@std/fs@^1.0.9",
+        "jsr:@std/internal@^1.0.5",
+        "jsr:@std/path@^1.0.8"
       ]
     },
-    "@zip-js/zip-js@2.7.62": {
-      "integrity": "11cbe0746fa1e52e6e0a601c89ba97365f16e38a07f139b9d9914f988aec9081"
+    "@zip-js/zip-js@2.7.57": {
+      "integrity": "15465ff627e321775870ad493bc043ca2d97940bda58d709c49908d39f4b0524"
     }
   },
   "npm": {
@@ -306,8 +332,8 @@
         "zod"
       ]
     },
-    "@ai-sdk/google-vertex@2.2.24_zod@3.25.49": {
-      "integrity": "sha512-zi1ZN6jQEBRke/WMbZv0YkeqQ3nOs8ihxjVh/8z1tUn+S1xgRaYXf4+r6+Izh2YqVHIMNwjhUYryQRBGq20cgQ==",
+    "@ai-sdk/google-vertex@2.2.23_zod@3.25.49": {
+      "integrity": "sha512-q8rOXqEYBOTcgVW1+QlkYEd+bP1ZWfRYhRs3QzzAL1SP3AQqltuKM7ovO53AFDq5hwlodFMHQ4v9WmXmibgjAg==",
       "dependencies": [
         "@ai-sdk/anthropic",
         "@ai-sdk/google",
@@ -317,8 +343,8 @@
         "zod"
       ]
     },
-    "@ai-sdk/google@1.2.19_zod@3.25.49": {
-      "integrity": "sha512-Xgl6eftIRQ4srUdCzxM112JuewVMij5q4JLcNmHcB68Bxn9dpr3MVUSPlJwmameuiQuISIA8lMB+iRiRbFsaqA==",
+    "@ai-sdk/google@1.2.18_zod@3.25.49": {
+      "integrity": "sha512-8B70+i+uB12Ae6Sn6B9Oc6W0W/XorGgc88Nx0pyUrcxFOdytHBaAVhTPqYsO3LLClfjYN8pQ9GMxd5cpGEnUcA==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -448,8 +474,8 @@
         "picocolors"
       ]
     },
-    "@babel/compat-data@7.27.5": {
-      "integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg=="
+    "@babel/compat-data@7.27.3": {
+      "integrity": "sha512-V42wFfx1ymFte+ecf6iXghnnP8kWTO+ZLXIyZq+1LAXHHvTZdVxicn4yiVYdYMGaCO3tmqub11AorKkv+iodqw=="
     },
     "@babel/core@7.27.4": {
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
@@ -471,8 +497,8 @@
         "semver@6.3.1"
       ]
     },
-    "@babel/generator@7.27.5": {
-      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+    "@babel/generator@7.27.3": {
+      "integrity": "sha512-xnlJYj5zepml8NXtjkG0WquFUv8RskFqyFcVgTBp5k+NaA/8uw/K+OSVf8AMGw5e9HKP2ETd5xpK5MLZQD6b4Q==",
       "dependencies": [
         "@babel/parser",
         "@babel/types",
@@ -526,8 +552,8 @@
         "@babel/types"
       ]
     },
-    "@babel/parser@7.27.5": {
-      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+    "@babel/parser@7.27.4": {
+      "integrity": "sha512-BRmLHGwpUqLFR2jzx9orBuX/ABDkj2jLKOXrHDTN2aOKL+jFDDKaRNo9nyYsIl9h/UE/7lMKdDjKQQyxKKDZ7g==",
       "dependencies": [
         "@babel/types"
       ],
@@ -2106,40 +2132,40 @@
         "@scure/base"
       ]
     },
-    "@sentry-internal/browser-utils@9.25.1": {
-      "integrity": "sha512-/E8NKoGpkZCiGfZ7OuROWjnhBDKs22JpeiLDpbvl+zdA11zJXOl/i99fDzwZZmx/yGH737Ai7KSLiw3HVcsH5A==",
+    "@sentry-internal/browser-utils@9.24.0": {
+      "integrity": "sha512-fWIrHyui8KKufnbqhGyDvvr+u9wiOEEzxXEjs/CKp+6fa+jej6Mk8K+su1f/mz7R3HVzhxvht/gZ+y193uK4qw==",
       "dependencies": [
-        "@sentry/core@9.25.1"
+        "@sentry/core@9.24.0"
       ]
     },
-    "@sentry-internal/feedback@9.25.1": {
-      "integrity": "sha512-wPyX68izXUGRHIpE2vz/LzgIJXtfnEL+LXjKJW11RA2yzAvd8SSmX+raBTuIr4dFhUJ8fn08OlYSAo4L1fY1RQ==",
+    "@sentry-internal/feedback@9.24.0": {
+      "integrity": "sha512-Z9jQqKzRppwAEqiytLWNV8JOo52vlxcSGz52FjKx3KXG75PXwk0M3sBXh762WoGLisUIRLTp8LOk6304L/O8dg==",
       "dependencies": [
-        "@sentry/core@9.25.1"
+        "@sentry/core@9.24.0"
       ]
     },
-    "@sentry-internal/replay-canvas@9.25.1": {
-      "integrity": "sha512-KR/zvg9Oe7pH0OBioHNSYOsk/Og6Ih7emkfIUvN6RmVkVeycOERDqJyXmKM8mKC9wFXDpivBZRhrWgg/dtAAPw==",
+    "@sentry-internal/replay-canvas@9.24.0": {
+      "integrity": "sha512-506RdDF6iE8hMyzpzp9Vc0GM7kELxxs7UCoi/6KpvXFftcydWI3S2bru8dEZsxVoKh2hdle6SpbNgl+iPI0DSQ==",
       "dependencies": [
         "@sentry-internal/replay",
-        "@sentry/core@9.25.1"
+        "@sentry/core@9.24.0"
       ]
     },
-    "@sentry-internal/replay@9.25.1": {
-      "integrity": "sha512-m5e2t8TolKeRYwZkUQ19Z9sjntVnEHomfI5ggiGyMGLobOgRpG40q1+BVwuO6sjaT7jMvDSZeIbjeEl/f+jABA==",
+    "@sentry-internal/replay@9.24.0": {
+      "integrity": "sha512-312wMPeQI8K2vO/lA/CF6Uv5UReoZC7RarsNUJEoOKa9Bq1BXWUq929oTHzu/2NDv194H2u3eqSGsSp6xiuKTw==",
       "dependencies": [
         "@sentry-internal/browser-utils",
-        "@sentry/core@9.25.1"
+        "@sentry/core@9.24.0"
       ]
     },
-    "@sentry/browser@9.25.1": {
-      "integrity": "sha512-wIpRGtwlO4SBqlO0E2xjM0ag3/J6H/zIySMz/zyG9onYThtjKVuM0I1IIWt4PN0cEO8eznBO/6cPSECVnIrQZA==",
+    "@sentry/browser@9.24.0": {
+      "integrity": "sha512-RP+27/owvIqD4J0TibIHK1UcA7iObxLOXBEilDKjaJOZMLhv3JkpU8A+UI9pFzEYqeIGVDDaBzYgbCHrLWcoCA==",
       "dependencies": [
         "@sentry-internal/browser-utils",
         "@sentry-internal/feedback",
         "@sentry-internal/replay",
         "@sentry-internal/replay-canvas",
-        "@sentry/core@9.25.1"
+        "@sentry/core@9.24.0"
       ]
     },
     "@sentry/core@8.9.2": {
@@ -2149,20 +2175,20 @@
         "@sentry/utils"
       ]
     },
-    "@sentry/core@9.25.1": {
-      "integrity": "sha512-c87MOAJ7nAdysQgMFCnQXoKgWx30poLTJRsK+N72ZQhGiLIzp25xuIhCsTLuftxR852tZShd9X11yU0NuolmkA=="
+    "@sentry/core@9.24.0": {
+      "integrity": "sha512-uRWrB4Y49ZOWcDLCXqdjd2Fs6Onill0GQI+JgXMw7wa+i03+QRiQvUAUyde8O62jR4dvP3GDo9PDWnDNhi3z5A=="
     },
-    "@sentry/deno@9.25.1": {
-      "integrity": "sha512-TbtCVqX4jpztNVNXwc56cxWiA1L1iuAJfvc/PP9KTzocBJGXQJs6hhV8BO+RsMiHR913661+1jjtzJicpdA1ow==",
+    "@sentry/deno@9.24.0": {
+      "integrity": "sha512-DUfzKRF3ZdLKkMX8m6xKVa9wqw+Kmh+JmxT9FvnWJmvvi7YKCJfKDjxl19J5vsP0Vn1EKFIlDykZM00WPcunOw==",
       "dependencies": [
-        "@sentry/core@9.25.1"
+        "@sentry/core@9.24.0"
       ]
     },
-    "@sentry/react@9.25.1_react@18.3.1": {
-      "integrity": "sha512-6rXImkzIUQ+c077xN31SYgM0TYGjT1iVqS/Affpq09zJGuWr/HDcIZru+YnrwUju0H7AdIcB1Fnv1uSFW4ggVQ==",
+    "@sentry/react@9.24.0_react@18.3.1": {
+      "integrity": "sha512-CEgNuxnaax5JXvCJGO8MaPU6Doqf8OMK/52SwZxTwJJFsQBAC2v7Dl+Qot7H4GVb0exg3psumL4NjNeXAfGcpA==",
       "dependencies": [
         "@sentry/browser",
-        "@sentry/core@9.25.1",
+        "@sentry/core@9.24.0",
         "hoist-non-react-statics",
         "react"
       ]
@@ -2313,6 +2339,15 @@
         "@tailwindcss/oxide",
         "tailwindcss",
         "vite@6.3.5_@types+node@22.15.29_picomatch@4.0.2"
+      ]
+    },
+    "@tailwindcss/vite@4.1.8_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@types+node@22.15.29_@types+node@22.15.15": {
+      "integrity": "sha512-CQ+I8yxNV5/6uGaJjiuymgw0kEQiNKRinYbZXPdx1fk5WgiyReG0VaUx/Xq6aVNSUNJFzxm6o8FNKS5aMaim5A==",
+      "dependencies": [
+        "@tailwindcss/node",
+        "@tailwindcss/oxide",
+        "tailwindcss",
+        "vite@6.3.5_@types+node@22.15.29_picomatch@4.0.2_@types+node@22.15.15"
       ]
     },
     "@tootallnate/quickjs-emscripten@0.23.0": {
@@ -2716,8 +2751,8 @@
         "@opentelemetry/sdk-trace-base@1.30.1_@opentelemetry+api@1.9.0"
       ]
     },
-    "@vitejs/plugin-react@4.5.1_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@babel+core@7.27.4_@types+node@22.15.29": {
-      "integrity": "sha512-uPZBqSI0YD4lpkIru6M35sIfylLGTyhGHvDZbNLuMA73lMlwJKz5xweH7FajfcCAc2HnINciejA9qTz0dr0M7A==",
+    "@vitejs/plugin-react@4.5.0_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@babel+core@7.27.4_@types+node@22.15.29": {
+      "integrity": "sha512-JuLWaEqypaJmOJPLWwO335Ig6jSgC1FTONCWAxnqcQthLTK/Yc9aH6hr9z/87xciejbQcnP3GnA1FWUSWeXaeg==",
       "dependencies": [
         "@babel/core",
         "@babel/plugin-transform-react-jsx-self",
@@ -2726,6 +2761,18 @@
         "@types/babel__core",
         "react-refresh",
         "vite@6.3.5_@types+node@22.15.29_picomatch@4.0.2"
+      ]
+    },
+    "@vitejs/plugin-react@4.5.0_vite@6.3.5__@types+node@22.15.29__picomatch@4.0.2_@babel+core@7.27.4_@types+node@22.15.29_@types+node@22.15.15": {
+      "integrity": "sha512-JuLWaEqypaJmOJPLWwO335Ig6jSgC1FTONCWAxnqcQthLTK/Yc9aH6hr9z/87xciejbQcnP3GnA1FWUSWeXaeg==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/plugin-transform-react-jsx-self",
+        "@babel/plugin-transform-react-jsx-source",
+        "@rolldown/pluginutils",
+        "@types/babel__core",
+        "react-refresh",
+        "vite@6.3.5_@types+node@22.15.29_picomatch@4.0.2_@types+node@22.15.15"
       ]
     },
     "@vitest/expect@2.1.9": {
@@ -2747,6 +2794,18 @@
       ],
       "optionalPeers": [
         "vite@5.4.19_@types+node@22.15.29"
+      ]
+    },
+    "@vitest/mocker@2.1.9_vite@5.4.19__@types+node@22.15.29_@types+node@22.15.29_@types+node@22.15.15": {
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dependencies": [
+        "@vitest/spy",
+        "estree-walker@3.0.3",
+        "magic-string",
+        "vite@5.4.19_@types+node@22.15.29_@types+node@22.15.15"
+      ],
+      "optionalPeers": [
+        "vite@5.4.19_@types+node@22.15.29_@types+node@22.15.15"
       ]
     },
     "@vitest/pretty-format@2.1.9": {
@@ -5885,8 +5944,8 @@
         "@hono/zod-openapi"
       ]
     },
-    "streamx@2.22.1": {
-      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+    "streamx@2.22.0": {
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
       "dependencies": [
         "fast-fifo",
         "text-decoder"
@@ -6352,6 +6411,17 @@
       ],
       "bin": true
     },
+    "vite-node@2.1.9_@types+node@22.15.29_@types+node@22.15.15": {
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dependencies": [
+        "cac",
+        "debug@4.4.1",
+        "es-module-lexer",
+        "pathe",
+        "vite@5.4.19_@types+node@22.15.29_@types+node@22.15.15"
+      ],
+      "bin": true
+    },
     "vite@5.4.19_@types+node@22.15.29": {
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dependencies": [
@@ -6365,6 +6435,22 @@
       ],
       "optionalPeers": [
         "@types/node@22.15.29"
+      ],
+      "bin": true
+    },
+    "vite@5.4.19_@types+node@22.15.29_@types+node@22.15.15": {
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+      "dependencies": [
+        "@types/node@22.15.15",
+        "esbuild@0.21.5",
+        "postcss",
+        "rollup"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "optionalPeers": [
+        "@types/node@22.15.15"
       ],
       "bin": true
     },
@@ -6387,12 +6473,31 @@
       ],
       "bin": true
     },
+    "vite@6.3.5_@types+node@22.15.29_picomatch@4.0.2_@types+node@22.15.15": {
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "dependencies": [
+        "@types/node@22.15.15",
+        "esbuild@0.25.5",
+        "fdir",
+        "picomatch@4.0.2",
+        "postcss",
+        "rollup",
+        "tinyglobby"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "optionalPeers": [
+        "@types/node@22.15.15"
+      ],
+      "bin": true
+    },
     "vitest@2.1.9_@types+node@22.15.29_jsdom@26.1.0_vite@5.4.19__@types+node@22.15.29": {
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dependencies": [
         "@types/node@22.15.29",
         "@vitest/expect",
-        "@vitest/mocker",
+        "@vitest/mocker@2.1.9_vite@5.4.19__@types+node@22.15.29_@types+node@22.15.29",
         "@vitest/pretty-format",
         "@vitest/runner",
         "@vitest/snapshot",
@@ -6410,11 +6515,43 @@
         "tinypool",
         "tinyrainbow",
         "vite@5.4.19_@types+node@22.15.29",
-        "vite-node",
+        "vite-node@2.1.9_@types+node@22.15.29",
         "why-is-node-running"
       ],
       "optionalPeers": [
         "@types/node@22.15.29",
+        "jsdom"
+      ],
+      "bin": true
+    },
+    "vitest@2.1.9_@types+node@22.15.29_jsdom@26.1.0_vite@5.4.19__@types+node@22.15.29_@types+node@22.15.15": {
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dependencies": [
+        "@types/node@22.15.15",
+        "@vitest/expect",
+        "@vitest/mocker@2.1.9_vite@5.4.19__@types+node@22.15.29_@types+node@22.15.29_@types+node@22.15.15",
+        "@vitest/pretty-format",
+        "@vitest/runner",
+        "@vitest/snapshot",
+        "@vitest/spy",
+        "@vitest/utils",
+        "chai",
+        "debug@4.4.1",
+        "expect-type",
+        "jsdom",
+        "magic-string",
+        "pathe",
+        "std-env",
+        "tinybench",
+        "tinyexec",
+        "tinypool",
+        "tinyrainbow",
+        "vite@5.4.19_@types+node@22.15.29_@types+node@22.15.15",
+        "vite-node@2.1.9_@types+node@22.15.29_@types+node@22.15.15",
+        "why-is-node-running"
+      ],
+      "optionalPeers": [
+        "@types/node@22.15.15",
         "jsdom"
       ],
       "bin": true
@@ -6613,16 +6750,11 @@
     }
   },
   "redirects": {
-    "https://deno.land/x/is_docker/mod.ts": "https://deno.land/x/is_docker@v2.0.0/mod.ts"
+    "https://esm.sh/@babel/standalone": "https://esm.sh/@babel/standalone@7.27.0",
+    "https://esm.sh/@types/babel__standalone@~7.1.9/index.d.ts": "https://esm.sh/@types/babel__standalone@7.1.9/index.d.ts"
   },
   "remote": {
-    "https://deno.land/std@0.106.0/path/_constants.ts": "1247fee4a79b70c89f23499691ef169b41b6ccf01887a0abd131009c5581b853",
-    "https://deno.land/std@0.106.0/path/_interface.ts": "1fa73b02aaa24867e481a48492b44f2598cd9dfa513c7b34001437007d3642e4",
-    "https://deno.land/std@0.106.0/path/_util.ts": "2e06a3b9e79beaf62687196bd4b60a4c391d862cfa007a20fc3a39f778ba073b",
-    "https://deno.land/std@0.106.0/path/posix.ts": "b81974c768d298f8dcd2c720229639b3803ca4a241fa9a355c762fa2bc5ef0c1",
-    "https://deno.land/x/is_docker@v2.0.0/mod.ts": "4c8753346f4afbb6c251d7984a609aa84055559cf713fba828939a5d39c95cd0",
-    "https://deno.land/x/is_wsl@v1.1.0/mod.ts": "30996b09376652df7a4d495320e918154906ab94325745c1399e13e658dca5da",
-    "https://deno.land/x/open@v0.0.6/index.ts": "c7484a7bf2628236f33bbe354520e651811faf1a7cbc3c3f80958ce81b4c42ef"
+    "https://esm.sh/@babel/standalone@7.27.0": "82a6873adc960aaa2ab9fcb605fc634754f5cd39ea121b442a0a000fbd24ef58"
   },
   "workspace": {
     "dependencies": [

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -5,7 +5,7 @@ import {
 } from "./builder/types.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import { type DocImpl, isDoc } from "./doc.ts";
-import { type CellLink, isCell, isCellLink } from "./cell.ts";
+import { type Cell, type CellLink, isCell, isCellLink } from "./cell.ts";
 import { type ReactivityLog } from "./scheduler.ts";
 import {
   getCellLinkOrThrow,
@@ -263,10 +263,11 @@ export function maybeGetCellLink<T>(
 // Only logs interim aliases, not the first one, and not the non-alias value.
 export function followAliases<T = any>(
   alias: Alias,
-  doc: DocImpl<T>,
+  docOrCell: DocImpl<T> | Cell<T>,
   log?: ReactivityLog,
 ): CellLink {
   if (isAlias(alias)) {
+    const doc = isCell(docOrCell) ? docOrCell.getDoc() : docOrCell;
     return followLinks(
       { cell: doc, ...alias.$alias } as CellLink,
       log,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -132,6 +132,16 @@ export interface IRuntime {
     argument: T,
     resultCell: DocImpl<R>,
   ): DocImpl<R>;
+  run<T, R>(
+    recipeFactory: NodeFactory<T, R>,
+    argument: T,
+    resultCell: Cell<R>,
+  ): Cell<R>;
+  run<T, R = any>(
+    recipe: Recipe | Module | undefined,
+    argument: T,
+    resultCell: Cell<R>,
+  ): Cell<R>;
   runSynced(
     resultCell: Cell<any>,
     recipe: Recipe | Module,
@@ -214,6 +224,16 @@ export interface IRunner {
     argument: T,
     resultCell: DocImpl<R>,
   ): DocImpl<R>;
+  run<T, R>(
+    recipeFactory: NodeFactory<T, R>,
+    argument: T,
+    resultCell: Cell<R>,
+  ): Cell<R>;
+  run<T, R = any>(
+    recipe: Recipe | Module | undefined,
+    argument: T,
+    resultCell: Cell<R>,
+  ): Cell<R>;
 
   runSynced(
     resultCell: Cell<any>,
@@ -467,12 +487,22 @@ export class Runtime implements IRuntime {
     argument: T,
     resultCell: DocImpl<R>,
   ): DocImpl<R>;
+  run<T, R>(
+    recipeFactory: NodeFactory<T, R>,
+    argument: T,
+    resultCell: Cell<R>,
+  ): Cell<R>;
+  run<T, R = any>(
+    recipe: Recipe | Module | undefined,
+    argument: T,
+    resultCell: Cell<R>,
+  ): Cell<R>;
   run<T, R = any>(
     recipeOrModule: Recipe | Module | undefined,
     argument: T,
-    resultCell: DocImpl<R>,
-  ): DocImpl<R> {
-    return this.runner.run(recipeOrModule, argument, resultCell);
+    resultCell: DocImpl<R> | Cell<R>,
+  ): DocImpl<R> | Cell<R> {
+    return this.runner.run(recipeOrModule, argument, resultCell as any);
   }
 
   runSynced(

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -640,7 +640,7 @@ describe("asCell", () => {
       { cell: c.getDoc(), path: ["stream"] },
     );
 
-    (streamCell as any).send("event");
+    streamCell.send("event");
     await runtime.idle();
 
     expect(c.get()).toStrictEqual({ stream: { $stream: true } });

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -10,6 +10,7 @@ import { Runtime } from "../src/runtime.ts";
 import { addCommonIDfromObjectID } from "../src/data-updating.ts";
 import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
+import { expectCellLinksEqual } from "./test-helpers.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -518,11 +519,10 @@ describe("createProxy", () => {
     const proxy = c.getAsQueryResult([], log);
     proxy.length = 2;
     expect(c.get()).toEqual([1, 2]);
-    expect(log.writes.length).toBe(2);
-    expect(log.writes[0].cell).toBe(c.getDoc());
-    expect(log.writes[0].path).toEqual(["length"]);
-    expect(log.writes[1].cell).toBe(c.getDoc());
-    expect(log.writes[1].path).toEqual([2]);
+    expectCellLinksEqual(log.writes).toEqual([
+      c.key("length").getAsCellLink(),
+      c.key(2).getAsCellLink(),
+    ]);
     proxy.length = 4;
     expect(c.get()).toEqual([1, 2, undefined, undefined]);
     expect(log.writes.length).toBe(5);

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -629,7 +629,7 @@ describe("asCell", () => {
     expect(streamCell).not.toHaveProperty("set");
     expect(streamCell).not.toHaveProperty("key");
 
-    let lastEventSeen = "";
+    let lastEventSeen: any = null;
     let eventCount = 0;
 
     runtime.scheduler.addEventHandler(
@@ -640,12 +640,12 @@ describe("asCell", () => {
       { cell: c.getDoc(), path: ["stream"] },
     );
 
-    streamCell.send("event");
+    streamCell.send({ $stream: true });
     await runtime.idle();
 
     expect(c.get()).toStrictEqual({ stream: { $stream: true } });
     expect(eventCount).toBe(1);
-    expect(lastEventSeen).toBe("event");
+    expect(lastEventSeen).toEqual({ $stream: true });
   });
 
   it("should call sink only when the cell changes on the subpath", async () => {

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -277,14 +277,14 @@ describe("createProxy", () => {
   });
 
   it("should handle aliases when writing", () => {
-    const c = runtime.getCell(
+    const c = runtime.getCell<{ x: number; y: number }>(
       space,
       "should handle aliases when writing",
     );
     c.setRaw({ x: { $alias: { path: ["y"] } }, y: 42 });
     const proxy = c.getAsQueryResult();
     proxy.x = 100;
-    expect((c.get() as any).y).toBe(100);
+    expect(c.get().y).toBe(100);
   });
 
   it("should handle nested cells", () => {

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -109,34 +109,31 @@ describe("Cell", () => {
   });
 
   it("should get raw value using getRaw", () => {
-    const c = runtime.documentMap.getDoc(
-      { x: 1, y: 2 },
-      "should get raw value using getRaw",
+    const cell = runtime.getCell<{ x: number; y: number }>(
       space,
+      "should get raw value using getRaw",
     );
-    const cell = c.asCell();
+    cell.set({ x: 1, y: 2 });
     expect(cell.getRaw()).toEqual({ x: 1, y: 2 });
   });
 
   it("should set raw value using setRaw", () => {
-    const c = runtime.documentMap.getDoc(
-      { x: 1, y: 2 },
-      "should set raw value using setRaw",
+    const cell = runtime.getCell<{ x: number; y: number }>(
       space,
+      "should set raw value using setRaw",
     );
-    const cell = c.asCell();
+    cell.set({ x: 1, y: 2 });
     const result = cell.setRaw({ x: 10, y: 20 });
     expect(result).toBe(true); // setRaw returns boolean from doc.send()
     expect(cell.getRaw()).toEqual({ x: 10, y: 20 });
   });
 
   it("should work with primitive values in getRaw/setRaw", () => {
-    const c = runtime.documentMap.getDoc(
-      42,
-      "should work with primitive values in getRaw/setRaw",
+    const cell = runtime.getCell<number>(
       space,
+      "should work with primitive values in getRaw/setRaw",
     );
-    const cell = c.asCell();
+    cell.set(42);
 
     expect(cell.getRaw()).toBe(42);
 
@@ -146,12 +143,11 @@ describe("Cell", () => {
   });
 
   it("should work with arrays in getRaw/setRaw", () => {
-    const c = runtime.documentMap.getDoc(
-      [1, 2, 3],
-      "should work with arrays in getRaw/setRaw",
+    const cell = runtime.getCell<number[]>(
       space,
+      "should work with arrays in getRaw/setRaw",
     );
-    const cell = c.asCell();
+    cell.set([1, 2, 3]);
 
     expect(cell.getRaw()).toEqual([1, 2, 3]);
 
@@ -161,12 +157,12 @@ describe("Cell", () => {
   });
 
   it("should respect path in getRaw/setRaw for nested properties", () => {
-    const c = runtime.documentMap.getDoc(
-      { nested: { value: 42 } },
-      "should respect path in getRaw/setRaw for nested properties",
+    const c = runtime.getCell<{ nested: { value: number } }>(
       space,
+      "should respect path in getRaw/setRaw for nested properties",
     );
-    const nestedCell = c.asCell(["nested", "value"]);
+    c.set({ nested: { value: 42 } });
+    const nestedCell = c.key("nested").key("value");
 
     // getRaw should return only the nested value
     expect(nestedCell.getRaw()).toBe(42);
@@ -220,11 +216,11 @@ describe("Cell utility functions", () => {
   });
 
   it("should identify a cell proxy", () => {
-    const c = runtime.documentMap.getDoc(
-      { x: 1 },
-      "should identify a cell proxy",
+    const c = runtime.getCell<{ x: number }>(
       space,
+      "should identify a cell proxy",
     );
+    c.set({ x: 1 });
     const proxy = c.getAsQueryResult();
     expect(isQueryResult(proxy)).toBe(true);
     expect(isQueryResult({})).toBe(false);
@@ -250,81 +246,81 @@ describe("createProxy", () => {
   });
 
   it("should create a proxy for nested objects", () => {
-    const c = runtime.documentMap.getDoc(
-      { a: { b: { c: 42 } } },
-      "should create a proxy for nested objects",
+    const c = runtime.getCell<{ a: { b: { c: number } } }>(
       space,
+      "should create a proxy for nested objects",
     );
+    c.set({ a: { b: { c: 42 } } });
     const proxy = c.getAsQueryResult();
     expect(proxy.a.b.c).toBe(42);
   });
 
   it("should support regular assigments", () => {
-    const c = runtime.documentMap.getDoc(
-      { x: 1 },
-      "should support regular assigments",
+    const c = runtime.getCell<{ x: number }>(
       space,
+      "should support regular assigments",
     );
+    c.set({ x: 1 });
     const proxy = c.getAsQueryResult();
     proxy.x = 2;
     expect(c.get()).toStrictEqual({ x: 2 });
   });
 
   it("should handle $alias in objects", () => {
-    const c = runtime.documentMap.getDoc(
-      { x: { $alias: { path: ["y"] } }, y: 42 },
-      "should handle $alias in objects",
+    const c = runtime.getCell(
       space,
+      "should handle $alias in objects",
     );
+    c.setRaw({ x: { $alias: { path: ["y"] } }, y: 42 });
     const proxy = c.getAsQueryResult();
     expect(proxy.x).toBe(42);
   });
 
   it("should handle aliases when writing", () => {
-    const c = runtime.documentMap.getDoc(
-      { x: { $alias: { path: ["y"] } }, y: 42 },
-      "should handle aliases when writing",
+    const c = runtime.getCell(
       space,
+      "should handle aliases when writing",
     );
+    c.setRaw({ x: { $alias: { path: ["y"] } }, y: 42 });
     const proxy = c.getAsQueryResult();
     proxy.x = 100;
-    expect(c.get().y).toBe(100);
+    expect((c.get() as any).y).toBe(100);
   });
 
   it("should handle nested cells", () => {
-    const innerCell = runtime.documentMap.getDoc(
-      42,
-      "should handle nested cells",
+    const innerCell = runtime.getCell<number>(
       space,
+      "should handle nested cells inner",
     );
-    const outerCell = runtime.documentMap.getDoc(
-      { x: innerCell },
-      "should handle nested cells",
+    innerCell.set(42);
+    const outerCell = runtime.getCell<{ x: any }>(
       space,
+      "should handle nested cells outer",
     );
+    outerCell.set({ x: innerCell });
     const proxy = outerCell.getAsQueryResult();
     expect(proxy.x).toBe(42);
   });
 
   it("should handle cell references", () => {
-    const c = runtime.documentMap.getDoc(
-      { x: 42 },
-      "should handle cell references",
+    const c = runtime.getCell<{ x: number; y?: any }>(
       space,
+      "should handle cell references",
     );
-    const ref = { cell: c, path: ["x"] };
+    c.set({ x: 42 });
+    const ref = { cell: c.getDoc(), path: ["x"] };
     const proxy = c.getAsQueryResult();
     proxy.y = ref;
     expect(proxy.y).toBe(42);
   });
 
   it("should handle infinite loops in cell references", () => {
-    const c = runtime.documentMap.getDoc(
-      { x: 42 },
-      "should handle infinite loops in cell references",
+    const c = runtime.getCell<{ x: number; y?: any }>(
       space,
+      "should handle infinite loops in cell references",
     );
-    const ref = { cell: c, path: ["x"] };
+    c.set({ x: 42 });
+    const ref = { cell: c.getDoc(), path: ["x"] };
     const proxy = c.getAsQueryResult();
     proxy.x = ref;
     expect(() => proxy.x).toThrow();
@@ -332,11 +328,11 @@ describe("createProxy", () => {
 
   it("should support modifying array methods and log reads and writes", () => {
     const log: ReactivityLog = { reads: [], writes: [] };
-    const c = runtime.documentMap.getDoc(
-      { array: [1, 2, 3] },
-      "should support modifying array methods and log reads and writes",
+    const c = runtime.getCell<{ array: number[] }>(
       space,
+      "should support modifying array methods and log reads and writes",
     );
+    c.set({ array: [1, 2, 3] });
     const proxy = c.getAsQueryResult([], log);
     expect(log.reads.length).toBe(1);
     expect(proxy.array.length).toBe(3);
@@ -355,11 +351,11 @@ describe("createProxy", () => {
 
   it("should handle array methods on previously undefined arrays", () => {
     const log: ReactivityLog = { reads: [], writes: [] };
-    const c = runtime.documentMap.getDoc(
-      { data: {} },
-      "should handle array methods on previously undefined arrays",
+    const c = runtime.getCell<{ data: any }>(
       space,
+      "should handle array methods on previously undefined arrays",
     );
+    c.set({ data: {} });
     const proxy = c.getAsQueryResult([], log);
 
     // Array doesn't exist yet
@@ -385,11 +381,11 @@ describe("createProxy", () => {
   });
 
   it("should handle array results from array methods", () => {
-    const c = runtime.documentMap.getDoc(
-      { array: [1, 2, 3, 4, 5] },
-      "should handle array results from array methods",
+    const c = runtime.getCell<{ array: number[] }>(
       space,
+      "should handle array results from array methods",
     );
+    c.set({ array: [1, 2, 3, 4, 5] });
     const proxy = c.getAsQueryResult();
 
     // Methods that return arrays should return query result proxies
@@ -413,11 +409,11 @@ describe("createProxy", () => {
   });
 
   it("should maintain reactivity with nested array operations", () => {
-    const c = runtime.documentMap.getDoc(
-      { nested: { arrays: [[1, 2], [3, 4]] } },
-      "should maintain reactivity with nested array operations",
+    const c = runtime.getCell<{ nested: { arrays: number[][] } }>(
       space,
+      "should maintain reactivity with nested array operations",
     );
+    c.set({ nested: { arrays: [[1, 2], [3, 4]] } });
     const proxy = c.getAsQueryResult();
 
     // Access a nested array through multiple levels
@@ -447,11 +443,11 @@ describe("createProxy", () => {
   });
 
   it("should support pop() and only read the popped element", () => {
-    const c = runtime.documentMap.getDoc(
-      { a: [] as number[] },
-      "should support pop() and only read the popped element",
+    const c = runtime.getCell<{ a: number[] }>(
       space,
+      "should support pop() and only read the popped element",
     );
+    c.set({ a: [] as number[] });
     const log: ReactivityLog = { reads: [], writes: [] };
     const proxy = c.getAsQueryResult([], log);
     proxy.a = [1, 2, 3];
@@ -465,11 +461,11 @@ describe("createProxy", () => {
   });
 
   it("should correctly sort() with cell references", () => {
-    const c = runtime.documentMap.getDoc(
-      { a: [] as number[] },
-      "should correctly sort() with cell references",
+    const c = runtime.getCell<{ a: number[] }>(
       space,
+      "should correctly sort() with cell references",
     );
+    c.set({ a: [] as number[] });
     const log: ReactivityLog = { reads: [], writes: [] };
     const proxy = c.getAsQueryResult([], log);
     proxy.a = [3, 1, 2];
@@ -479,11 +475,11 @@ describe("createProxy", () => {
   });
 
   it("should support readonly array methods and log reads", () => {
-    const c = runtime.documentMap.getDoc<any>(
-      [1, 2, 3],
-      "should support readonly array methods and log reads",
+    const c = runtime.getCell<number[]>(
       space,
+      "should support readonly array methods and log reads",
     );
+    c.set([1, 2, 3]);
     const log: ReactivityLog = { reads: [], writes: [] };
     const proxy = c.getAsQueryResult([], log);
     const result = proxy.find((x: any) => x === 2);
@@ -494,11 +490,11 @@ describe("createProxy", () => {
   });
 
   it("should support mapping over a proxied array", () => {
-    const c = runtime.documentMap.getDoc(
-      { a: [1, 2, 3] },
-      "should support mapping over a proxied array",
+    const c = runtime.getCell<{ a: number[] }>(
       space,
+      "should support mapping over a proxied array",
     );
+    c.set({ a: [1, 2, 3] });
     const log: ReactivityLog = { reads: [], writes: [] };
     const proxy = c.getAsQueryResult([], log);
     const result = proxy.a.map((x: any) => x + 1);
@@ -513,45 +509,48 @@ describe("createProxy", () => {
   });
 
   it("should allow changing array lengths by writing length", () => {
-    const c = runtime.documentMap.getDoc(
-      [1, 2, 3],
-      "should allow changing array lengths by writing length",
+    const c = runtime.getCell<number[]>(
       space,
+      "should allow changing array lengths by writing length",
     );
+    c.set([1, 2, 3]);
     const log: ReactivityLog = { reads: [], writes: [] };
     const proxy = c.getAsQueryResult([], log);
     proxy.length = 2;
     expect(c.get()).toEqual([1, 2]);
-    expect(log.writes).toEqual([
-      { cell: c, path: ["length"] },
-      { cell: c, path: [2] },
-    ]);
+    expect(log.writes.length).toBe(2);
+    expect(log.writes[0].cell).toBe(c.getDoc());
+    expect(log.writes[0].path).toEqual(["length"]);
+    expect(log.writes[1].cell).toBe(c.getDoc());
+    expect(log.writes[1].path).toEqual([2]);
     proxy.length = 4;
     expect(c.get()).toEqual([1, 2, undefined, undefined]);
-    expect(log.writes).toEqual([
-      { cell: c, path: ["length"] },
-      { cell: c, path: [2] },
-      { cell: c, path: ["length"] },
-      { cell: c, path: [2] },
-      { cell: c, path: [3] },
-    ]);
+    expect(log.writes.length).toBe(5);
+    expect(log.writes[2].cell).toBe(c.getDoc());
+    expect(log.writes[2].path).toEqual(["length"]);
+    expect(log.writes[3].cell).toBe(c.getDoc());
+    expect(log.writes[3].path).toEqual([2]);
+    expect(log.writes[4].cell).toBe(c.getDoc());
+    expect(log.writes[4].path).toEqual([3]);
   });
 
   it("should allow changing array by splicing", () => {
-    const c = runtime.documentMap.getDoc(
-      [1, 2, 3],
-      "should allow changing array by splicing",
+    const c = runtime.getCell<number[]>(
       space,
+      "should allow changing array by splicing",
     );
+    c.set([1, 2, 3]);
     const log: ReactivityLog = { reads: [], writes: [] };
     const proxy = c.getAsQueryResult([], log);
     proxy.splice(1, 1, 4, 5);
     expect(c.get()).toEqual([1, 4, 5, 3]);
-    expect(log.writes).toEqual([
-      { cell: c, path: ["1"] },
-      { cell: c, path: ["2"] },
-      { cell: c, path: ["3"] },
-    ]);
+    expect(log.writes.length).toBe(3);
+    expect(log.writes[0].cell).toBe(c.getDoc());
+    expect(log.writes[0].path).toEqual(["1"]);
+    expect(log.writes[1].cell).toBe(c.getDoc());
+    expect(log.writes[1].path).toEqual(["2"]);
+    expect(log.writes[2].cell).toBe(c.getDoc());
+    expect(log.writes[2].path).toEqual(["3"]);
   });
 });
 
@@ -574,29 +573,28 @@ describe("asCell", () => {
   });
 
   it("should create a simple cell interface", () => {
-    const c = runtime.documentMap.getDoc(
-      { x: 1, y: 2 },
-      "should create a simple cell interface",
+    const simpleCell = runtime.getCell<{ x: number; y: number }>(
       space,
+      "should create a simple cell interface",
     );
-    const simpleCell = c.asCell();
+    simpleCell.set({ x: 1, y: 2 });
 
     expect(simpleCell.get()).toEqual({ x: 1, y: 2 });
 
     simpleCell.set({ x: 3, y: 4 });
-    expect(c.get()).toEqual({ x: 3, y: 4 });
+    expect(simpleCell.get()).toEqual({ x: 3, y: 4 });
 
     simpleCell.send({ x: 5, y: 6 });
-    expect(c.get()).toEqual({ x: 5, y: 6 });
+    expect(simpleCell.get()).toEqual({ x: 5, y: 6 });
   });
 
   it("should create a simple cell for nested properties", () => {
-    const c = runtime.documentMap.getDoc(
-      { nested: { value: 42 } },
-      "should create a simple cell for nested properties",
+    const c = runtime.getCell<{ nested: { value: number } }>(
       space,
+      "should create a simple cell for nested properties",
     );
-    const nestedCell = c.asCell(["nested", "value"]);
+    c.set({ nested: { value: 42 } });
+    const nestedCell = c.key("nested").key("value");
 
     expect(nestedCell.get()).toBe(42);
 
@@ -605,27 +603,26 @@ describe("asCell", () => {
   });
 
   it("should support the key method for nested access", () => {
-    const c = runtime.documentMap.getDoc(
-      { a: { b: { c: 42 } } },
-      "should support the key method for nested access",
+    const simpleCell = runtime.getCell<{ a: { b: { c: number } } }>(
       space,
+      "should support the key method for nested access",
     );
-    const simpleCell = c.asCell();
+    simpleCell.set({ a: { b: { c: 42 } } });
 
     const nestedCell = simpleCell.key("a").key("b").key("c");
     expect(nestedCell.get()).toBe(42);
 
     nestedCell.set(100);
-    expect(c.get()).toEqual({ a: { b: { c: 100 } } });
+    expect(simpleCell.get()).toEqual({ a: { b: { c: 100 } } });
   });
 
   it("should return a Sendable for stream aliases", async () => {
-    const c = runtime.documentMap.getDoc(
-      { stream: { $stream: true } },
-      "should return a Sendable for stream aliases",
+    const c = runtime.getCell<{ stream: { $stream: true } }>(
       space,
+      "should return a Sendable for stream aliases",
     );
-    const streamCell = c.asCell(["stream"]);
+    c.setRaw({ stream: { $stream: true } });
+    const streamCell = c.key("stream");
 
     expect(streamCell).toHaveProperty("send");
     expect(streamCell).not.toHaveProperty("get");
@@ -640,10 +637,10 @@ describe("asCell", () => {
         eventCount++;
         lastEventSeen = event;
       },
-      { cell: c, path: ["stream"] },
+      { cell: c.getDoc(), path: ["stream"] },
     );
 
-    streamCell.send("event");
+    (streamCell as any).send("event");
     await runtime.idle();
 
     expect(c.get()).toStrictEqual({ stream: { $stream: true } });
@@ -652,24 +649,24 @@ describe("asCell", () => {
   });
 
   it("should call sink only when the cell changes on the subpath", async () => {
-    const c = runtime.documentMap.getDoc(
-      { a: { b: 42, c: 10 }, d: 5 },
-      "should call sink only when the cell changes on the subpath",
+    const c = runtime.getCell<{ a: { b: number, c: number }, d: number }>(
       space,
+      "should call sink only when the cell changes on the subpath",
     );
+    c.set({ a: { b: 42, c: 10 }, d: 5 });
     const values: number[] = [];
-    c.asCell(["a", "b"]).sink((value) => {
+    c.key("a").key("b").sink((value) => {
       values.push(value);
     });
     expect(values).toEqual([42]); // Initial call
-    c.setAtPath(["d"], 50);
+    c.getAsQueryResult().d = 50;
     await runtime.idle();
-    c.setAtPath(["a", "c"], 100);
+    c.getAsQueryResult().a.c = 100;
     await runtime.idle();
-    c.setAtPath(["a", "b"], 42);
+    c.getAsQueryResult().a.b = 42;
     await runtime.idle();
     expect(values).toEqual([42]); // Didn't get called again
-    c.setAtPath(["a", "b"], 300);
+    c.getAsQueryResult().a.b = 300;
     await runtime.idle();
     expect(c.get()).toEqual({ a: { b: 300, c: 100 }, d: 50 });
     expect(values).toEqual([42, 300]); // Got called again
@@ -695,18 +692,23 @@ describe("asCell with schema", () => {
   });
 
   it("should validate and transform according to schema", () => {
-    const c = runtime.documentMap.getDoc(
-      {
-        name: "test",
-        age: 42,
-        tags: ["a", "b"],
-        nested: {
-          value: 123,
-        },
-      },
-      "should validate and transform according to schema",
+    const c = runtime.getCell<{
+      name: string;
+      age: number;
+      tags: string[];
+      nested: { value: number };
+    }>(
       space,
+      "should validate and transform according to schema",
     );
+    c.set({
+      name: "test",
+      age: 42,
+      tags: ["a", "b"],
+      nested: {
+        value: 123,
+      },
+    });
 
     const schema = {
       type: "object",
@@ -728,7 +730,7 @@ describe("asCell with schema", () => {
       required: ["name", "age", "tags", "nested"],
     } as const satisfies JSONSchema;
 
-    const cell = c.asCell([], undefined, schema);
+    const cell = c.asSchema(schema);
     const value = cell.get();
 
     expect(value.name).toBe("test");
@@ -738,17 +740,23 @@ describe("asCell with schema", () => {
   });
 
   it("should return a Cell for reference properties", () => {
-    const c = runtime.documentMap.getDoc(
-      {
-        id: 1,
-        metadata: {
-          createdAt: "2025-01-06",
-          type: "user",
-        },
-      },
-      "should return a Cell for reference properties",
+    const c = runtime.getCell<{
+      id: number;
+      metadata: {
+        createdAt: string;
+        type: string;
+      };
+    }>(
       space,
+      "should return a Cell for reference properties",
     );
+    c.set({
+      id: 1,
+      metadata: {
+        createdAt: "2025-01-06",
+        type: "user",
+      },
+    });
 
     const schema = {
       type: "object",
@@ -762,7 +770,7 @@ describe("asCell with schema", () => {
       required: ["id", "metadata"],
     } as const satisfies JSONSchema;
 
-    const value = c.asCell([], undefined, schema).get();
+    const value = c.asSchema(schema).get();
 
     expect(value.id).toBe(1);
     expect(isCell(value.metadata)).toBe(true);
@@ -774,28 +782,34 @@ describe("asCell with schema", () => {
   });
 
   it("should handle recursive schemas with $ref", () => {
-    const c = runtime.documentMap.getDoc(
-      {
-        name: "root",
-        children: [
-          {
-            name: "child1",
-            children: [],
-          },
-          {
-            name: "child2",
-            children: [
-              {
-                name: "grandchild",
-                children: [],
-              },
-            ],
-          },
-        ],
-      },
-      "should handle recursive schemas with $ref",
+    const c = runtime.getCell<{
+      name: string;
+      children: Array<{
+        name: string;
+        children: any[];
+      }>;
+    }>(
       space,
+      "should handle recursive schemas with $ref",
     );
+    c.set({
+      name: "root",
+      children: [
+        {
+          name: "child1",
+          children: [],
+        },
+        {
+          name: "child2",
+          children: [
+            {
+              name: "grandchild",
+              children: [],
+            },
+          ],
+        },
+      ],
+    });
 
     const schema = {
       type: "object",
@@ -809,7 +823,7 @@ describe("asCell with schema", () => {
       required: ["name", "children"],
     } as const satisfies JSONSchema;
 
-    const value = c.asCell([], undefined, schema).get();
+    const value = c.asSchema(schema).get();
 
     expect(value.name).toBe("root");
     expect(value.children[0].name).toBe("child1");
@@ -818,25 +832,39 @@ describe("asCell with schema", () => {
   });
 
   it("should propagate schema through key() navigation", () => {
-    const c = runtime.documentMap.getDoc(
-      {
-        user: {
-          profile: {
-            name: "John",
-            settings: {
-              theme: "dark",
-              notifications: true,
-            },
-          },
-          metadata: {
-            id: "123",
-            type: "admin",
+    const c = runtime.getCell<{
+      user: {
+        profile: {
+          name: string;
+          settings: {
+            theme: string;
+            notifications: boolean;
+          };
+        };
+        metadata: {
+          id: string;
+          type: string;
+        };
+      };
+    }>(
+      space,
+      "should propagate schema through key() navigation",
+    );
+    c.set({
+      user: {
+        profile: {
+          name: "John",
+          settings: {
+            theme: "dark",
+            notifications: true,
           },
         },
+        metadata: {
+          id: "123",
+          type: "admin",
+        },
       },
-      "should propagate schema through key() navigation",
-      space,
-    );
+    });
 
     const schema = {
       type: "object",
@@ -866,7 +894,7 @@ describe("asCell with schema", () => {
       required: ["user"],
     } as const satisfies JSONSchema;
 
-    const cell = c.asCell([], undefined, schema);
+    const cell = c.asSchema(schema);
     const userCell = cell.key("user");
     const profileCell = userCell.key("profile");
 
@@ -880,20 +908,27 @@ describe("asCell with schema", () => {
   });
 
   it("should fall back to query result proxy when no schema is present", () => {
-    const c = runtime.documentMap.getDoc(
-      {
-        data: {
-          value: 42,
-          nested: {
-            str: "hello",
-          },
+    const c = runtime.getCell<{
+      data: {
+        value: number;
+        nested: {
+          str: string;
+        };
+      };
+    }>(
+      space,
+      "should fall back to query result proxy when no schema is present",
+    );
+    c.set({
+      data: {
+        value: 42,
+        nested: {
+          str: "hello",
         },
       },
-      "should fall back to query result proxy when no schema is present",
-      space,
-    );
+    });
 
-    const value = c.asCell().get();
+    const value = c.get();
 
     // Should behave like a query result proxy
     expect(value.data.value).toBe(42);
@@ -901,17 +936,23 @@ describe("asCell with schema", () => {
   });
 
   it("should allow changing schema with asSchema", () => {
-    const c = runtime.documentMap.getDoc(
-      {
-        id: 1,
-        metadata: {
-          createdAt: "2025-01-06",
-          type: "user",
-        },
-      },
-      "should allow changing schema with asSchema",
+    const c = runtime.getCell<{
+      id: number;
+      metadata: {
+        createdAt: string;
+        type: string;
+      };
+    }>(
       space,
+      "should allow changing schema with asSchema",
     );
+    c.set({
+      id: 1,
+      metadata: {
+        createdAt: "2025-01-06",
+        type: "user",
+      },
+    });
 
     // Start with a schema that doesn't mark metadata as a reference
     const initialSchema = {
@@ -946,7 +987,7 @@ describe("asCell with schema", () => {
       required: ["id", "metadata"],
     } as const satisfies JSONSchema;
 
-    const cell = c.asCell([], undefined, initialSchema);
+    const cell = c.asSchema(initialSchema);
     const value = cell.get();
 
     // With initial schema, metadata is not a Cell
@@ -969,18 +1010,25 @@ describe("asCell with schema", () => {
   });
 
   it("should handle objects with additional properties as references", () => {
-    const c = runtime.documentMap.getDoc(
-      {
-        id: 1,
-        context: {
-          user: { name: "John" },
-          settings: { theme: "dark" },
-          data: { value: 42 },
-        },
-      },
-      "should handle objects with additional properties as references",
+    const c = runtime.getCell<{
+      id: number;
+      context: {
+        user: { name: string };
+        settings: { theme: string };
+        data: { value: number };
+      };
+    }>(
       space,
+      "should handle objects with additional properties as references",
     );
+    c.set({
+      id: 1,
+      context: {
+        user: { name: "John" },
+        settings: { theme: "dark" },
+        data: { value: 42 },
+      },
+    });
 
     const schema = {
       type: "object",
@@ -997,7 +1045,7 @@ describe("asCell with schema", () => {
       required: ["id", "context"],
     } as const satisfies JSONSchema;
 
-    const cell = c.asCell([], undefined, schema);
+    const cell = c.asSchema(schema);
     const value = cell.get();
 
     // Regular property works normally
@@ -1015,18 +1063,25 @@ describe("asCell with schema", () => {
   });
 
   it("should handle additional properties with just reference: true", () => {
-    const c = runtime.documentMap.getDoc(
-      {
-        context: {
-          number: 42,
-          string: "hello",
-          object: { value: 123 },
-          array: [1, 2, 3],
-        },
-      },
-      "should handle additional properties with just reference: true",
+    const c = runtime.getCell<{
+      context: {
+        number: number;
+        string: string;
+        object: { value: number };
+        array: number[];
+      };
+    }>(
       space,
+      "should handle additional properties with just reference: true",
     );
+    c.set({
+      context: {
+        number: 42,
+        string: "hello",
+        object: { value: 123 },
+        array: [1, 2, 3],
+      },
+    });
 
     const schema = {
       type: "object",
@@ -1039,7 +1094,7 @@ describe("asCell with schema", () => {
       required: ["context"],
     } as const satisfies JSONSchema;
 
-    const cell = c.asCell([], undefined, schema);
+    const cell = c.asSchema(schema);
     const value = cell.get();
 
     // All properties in context should be Cells regardless of their type
@@ -1057,22 +1112,26 @@ describe("asCell with schema", () => {
 
   it("should handle references in underlying cell", () => {
     // Create a cell with a reference
-    const innerCell = runtime.documentMap.getDoc(
-      { value: 42 },
-      "should handle references in underlying cell",
+    const innerCell = runtime.getCell<{ value: number }>(
       space,
+      "should handle references in underlying cell",
     );
+    innerCell.set({ value: 42 });
 
     // Create a cell that uses that reference
-    const c = runtime.documentMap.getDoc(
-      {
-        context: {
-          inner: innerCell,
-        },
-      },
-      "should handle references in underlying cell",
+    const c = runtime.getCell<{
+      context: {
+        inner: any;
+      };
+    }>(
       space,
+      "should handle references in underlying cell outer",
     );
+    c.set({
+      context: {
+        inner: innerCell,
+      },
+    });
 
     const schema = {
       type: "object",
@@ -1085,7 +1144,7 @@ describe("asCell with schema", () => {
       required: ["context"],
     } as const satisfies JSONSchema;
 
-    const cell = c.asCell([], undefined, schema);
+    const cell = c.asSchema(schema);
     const value = cell.get();
 
     // The inner reference should be preserved but wrapped in a new Cell
@@ -1099,26 +1158,32 @@ describe("asCell with schema", () => {
 
   it("should handle all types of references in underlying cell", () => {
     // Create cells with different types of references
-    const innerCell = runtime.documentMap.getDoc(
-      { value: 42 },
-      "should handle all types of references in underlying cell: inner",
+    const innerCell = runtime.getCell<{ value: number }>(
       space,
+      "should handle all types of references in underlying cell: inner",
     );
-    const cellRef = { cell: innerCell, path: [] };
-    const aliasRef = { $alias: { cell: innerCell, path: [] } };
+    innerCell.set({ value: 42 });
+    const cellRef = innerCell.getAsCellLink();
+    const aliasRef = { $alias: innerCell.getAsCellLink() };
 
     // Create a cell that uses all reference types
-    const c = runtime.documentMap.getDoc(
-      {
-        context: {
-          cell: innerCell,
-          reference: cellRef,
-          alias: aliasRef,
-        },
-      },
-      "should handle all types of references in underlying cell",
+    const c = runtime.getCell<{
+      context: {
+        cell: any;
+        reference: any;
+        alias: any;
+      };
+    }>(
       space,
+      "should handle all types of references in underlying cell main",
     );
+    c.set({
+      context: {
+        cell: innerCell,
+        reference: cellRef,
+        alias: aliasRef,
+      },
+    });
 
     const schema = {
       type: "object",
@@ -1131,7 +1196,7 @@ describe("asCell with schema", () => {
       required: ["context"],
     } as const satisfies JSONSchema;
 
-    const cell = c.asCell([], undefined, schema);
+    const cell = c.asSchema(schema);
     const value = cell.get();
 
     // All references should be preserved but wrapped in Cells
@@ -1153,39 +1218,42 @@ describe("asCell with schema", () => {
 
   it("should handle nested references", () => {
     // Create a chain of references
-    const innerCell = runtime.documentMap.getDoc(
-      { value: 42 },
-      "should handle nested references: inner",
+    const innerCell = runtime.getCell<{ value: number }>(
       space,
+      "should handle nested references: inner",
     );
-    const ref1 = { cell: innerCell, path: [] };
-    const ref2 = {
-      cell: runtime.documentMap.getDoc(
-        { ref: ref1 },
-        "should handle nested references: ref2",
-        space,
-      ),
-      path: ["ref"],
-    };
-    const ref3 = {
-      cell: runtime.documentMap.getDoc(
-        { ref: ref2 },
-        "should handle nested references: ref3",
-        space,
-      ),
-      path: ["ref"],
-    };
+    innerCell.set({ value: 42 });
+    
+    const ref1 = innerCell.getAsCellLink();
+    
+    const ref2Cell = runtime.getCell<{ ref: any }>(
+      space,
+      "should handle nested references: ref2",
+    );
+    ref2Cell.set({ ref: ref1 });
+    const ref2 = ref2Cell.key("ref").getAsCellLink();
+    
+    const ref3Cell = runtime.getCell<{ ref: any }>(
+      space,
+      "should handle nested references: ref3",
+    );
+    ref3Cell.setRaw({ ref: ref2 });
+    const ref3 = ref3Cell.key("ref").getAsCellLink();
 
     // Create a cell that uses the nested reference
-    const c = runtime.documentMap.getDoc(
-      {
-        context: {
-          nested: ref3,
-        },
-      },
-      "should handle nested references",
+    const c = runtime.getCell<{
+      context: {
+        nested: any;
+      };
+    }>(
       space,
+      "should handle nested references main",
     );
+    c.set({
+      context: {
+        nested: ref3,
+      },
+    });
 
     const schema = {
       type: "object",
@@ -1199,8 +1267,8 @@ describe("asCell with schema", () => {
     } as const satisfies JSONSchema;
 
     const log = { reads: [], writes: [] } as ReactivityLog;
-    const cell = c.asCell([], log, schema);
-    const value = cell.get();
+    const cell = c.asSchema(schema).withLog(log);
+    const value = cell.get() as any;
 
     // The nested reference should be followed all the way to the inner value
     expect(isCell(value.context.nested)).toBe(true);
@@ -1208,10 +1276,10 @@ describe("asCell with schema", () => {
 
     const readDocs = new Set<DocImpl<any>>(log.reads.map((r) => r.cell));
     expect(readDocs.size).toBe(4);
-    expect(readDocs.has(c)).toBe(true);
-    expect(readDocs.has(ref3.cell)).toBe(true);
-    expect(readDocs.has(ref2.cell)).toBe(true);
-    expect(readDocs.has(ref1.cell)).toBe(true);
+    expect(readDocs.has(c.getDoc())).toBe(true);
+    expect(readDocs.has(ref3Cell.getDoc())).toBe(true);
+    expect(readDocs.has(ref2Cell.getDoc())).toBe(true);
+    expect(readDocs.has(innerCell.getDoc())).toBe(true);
 
     // Changes to the original cell should propagate through the chain
     innerCell.send({ value: 100 });
@@ -1219,16 +1287,18 @@ describe("asCell with schema", () => {
   });
 
   it("should handle array schemas in key() navigation", () => {
-    const c = runtime.documentMap.getDoc(
-      {
-        items: [
-          { name: "item1", value: 1 },
-          { name: "item2", value: 2 },
-        ],
-      },
-      "should handle array schemas in key() navigation",
+    const c = runtime.getCell<{
+      items: Array<{ name: string; value: number }>;
+    }>(
       space,
+      "should handle array schemas in key() navigation",
     );
+    c.set({
+      items: [
+        { name: "item1", value: 1 },
+        { name: "item2", value: 2 },
+      ],
+    });
 
     const schema = {
       type: "object",
@@ -1248,7 +1318,7 @@ describe("asCell with schema", () => {
       required: ["items"],
     } as const satisfies JSONSchema;
 
-    const cell = c.asCell([], undefined, schema);
+    const cell = c.asSchema(schema);
     const itemsCell = cell.key("items");
     const firstItemCell = itemsCell.key(0);
     const secondItemCell = itemsCell.key(1);
@@ -1258,15 +1328,18 @@ describe("asCell with schema", () => {
   });
 
   it("should handle additionalProperties in key() navigation", () => {
-    const c = runtime.documentMap.getDoc(
-      {
-        defined: "known property",
-        extra1: { value: 1 },
-        extra2: { value: 2 },
-      },
-      "should handle additionalProperties in key() navigation",
+    const c = runtime.getCell<{
+      defined: string;
+      [key: string]: any;
+    }>(
       space,
+      "should handle additionalProperties in key() navigation",
     );
+    c.set({
+      defined: "known property",
+      extra1: { value: 1 },
+      extra2: { value: 2 },
+    });
 
     const schema = {
       type: "object",
@@ -1281,7 +1354,7 @@ describe("asCell with schema", () => {
       },
     } as const satisfies JSONSchema;
 
-    const cell = c.asCell([], undefined, schema);
+    const cell = c.asSchema(schema);
 
     // Test defined property
     const definedCell = cell.key("defined");
@@ -1295,14 +1368,17 @@ describe("asCell with schema", () => {
   });
 
   it("should handle additionalProperties: true in key() navigation", () => {
-    const c = runtime.documentMap.getDoc(
-      {
-        defined: "known property",
-        extra: { anything: "goes" },
-      },
-      "should handle additionalProperties: true in key() navigation",
+    const c = runtime.getCell<{
+      defined: string;
+      [key: string]: any;
+    }>(
       space,
+      "should handle additionalProperties: true in key() navigation",
     );
+    c.set({
+      defined: "known property",
+      extra: { anything: "goes" },
+    });
 
     const schema = {
       type: "object",
@@ -1315,7 +1391,7 @@ describe("asCell with schema", () => {
       },
     } as const satisfies JSONSchema;
 
-    const cell = c.asCell([], undefined, schema);
+    const cell = c.asSchema(schema);
 
     // Test defined property
     const definedCell = cell.key("defined");
@@ -1328,23 +1404,26 @@ describe("asCell with schema", () => {
   });
 
   it("should partially update object values using update method", () => {
-    const c = runtime.documentMap.getDoc(
-      { name: "test", age: 42, tags: ["a", "b"] },
-      "should partially update object values using update method",
+    const c = runtime.getCell<{
+      name: string;
+      age: number;
+      tags: string[];
+    }>(
       space,
+      "should partially update object values using update method",
     );
-    const cell = c.asCell();
+    c.set({ name: "test", age: 42, tags: ["a", "b"] });
 
-    cell.update({ age: 43, tags: ["a", "b", "c"] });
-    expect(cell.get()).toEqual({
+    c.update({ age: 43, tags: ["a", "b", "c"] });
+    expect(c.get()).toEqual({
       name: "test",
       age: 43,
       tags: ["a", "b", "c"],
     });
 
     // Should preserve unmodified fields
-    cell.update({ name: "updated" });
-    expect(cell.get()).toEqual({
+    c.update({ name: "updated" });
+    expect(c.get()).toEqual({
       name: "updated",
       age: 43,
       tags: ["a", "b", "c"],
@@ -1352,36 +1431,35 @@ describe("asCell with schema", () => {
   });
 
   it("should handle update when there is no previous value", () => {
-    const c = runtime.documentMap.getDoc<
+    const c = runtime.getCell<
       { name: string; age: number } | undefined
     >(
-      undefined,
-      "should handle update when there is no previous value",
       space,
+      "should handle update when there is no previous value",
     );
-    const cell = c.asCell();
+    c.set(undefined);
 
-    cell.update({ name: "test", age: 42 });
-    expect(cell.get()).toEqual({
+    c.update({ name: "test", age: 42 });
+    expect(c.get()).toEqual({
       name: "test",
       age: 42,
     });
 
     // Should still work for subsequent updates
-    cell.update({ age: 43 });
-    expect(cell.get()).toEqual({
+    c.update({ age: 43 });
+    expect(c.get()).toEqual({
       name: "test",
       age: 43,
     });
   });
 
   it("should push values to array using push method", () => {
-    const c = runtime.documentMap.getDoc(
-      { items: [1, 2, 3] },
-      "push-test",
+    const c = runtime.getCell<{ items: number[] }>(
       space,
+      "push-test",
     );
-    const arrayCell = c.asCell(["items"]);
+    c.set({ items: [1, 2, 3] });
+    const arrayCell = c.key("items");
     expect(arrayCell.get()).toEqual([1, 2, 3]);
     arrayCell.push(4);
     expect(arrayCell.get()).toEqual([1, 2, 3, 4]);
@@ -1391,12 +1469,12 @@ describe("asCell with schema", () => {
   });
 
   it("should throw when pushing values to `null`", () => {
-    const c = runtime.documentMap.getDoc(
-      { items: null },
-      "push-to-null",
+    const c = runtime.getCell<{ items: null }>(
       space,
+      "push-to-null",
     );
-    const arrayCell = c.asCell(["items"]);
+    c.set({ items: null });
+    const arrayCell = c.key("items");
     expect(arrayCell.get()).toBeNull();
 
     expect(() => arrayCell.push(1)).toThrow();
@@ -1408,12 +1486,12 @@ describe("asCell with schema", () => {
       default: [10, 20],
     } as const satisfies JSONSchema;
 
-    const c = runtime.documentMap.getDoc(
-      {},
-      "push-to-undefined-schema",
+    const c = runtime.getCell<{ items?: number[] }>(
       space,
+      "push-to-undefined-schema",
     );
-    const arrayCell = c.asCell(["items"], undefined, schema);
+    c.set({});
+    const arrayCell = c.key("items").asSchema(schema);
 
     arrayCell.push(30);
     expect(arrayCell.get()).toEqual([10, 20, 30]);
@@ -1429,12 +1507,12 @@ describe("asCell with schema", () => {
       default: [{ [ID]: "test", value: 10 }, { [ID]: "test2", value: 20 }],
     } as const satisfies JSONSchema;
 
-    const c = runtime.documentMap.getDoc(
-      {},
-      "push-to-undefined-schema-stable-id",
+    const c = runtime.getCell<{ items?: any[] }>(
       space,
+      "push-to-undefined-schema-stable-id",
     );
-    const arrayCell = c.asCell(["items"], undefined, schema);
+    c.set({});
+    const arrayCell = c.key("items").asSchema(schema);
 
     arrayCell.push({ [ID]: "test3", "value": 30 });
     expect(arrayCell.get()).toEqual([
@@ -1471,12 +1549,12 @@ describe("asCell with schema", () => {
       },
     } as const satisfies JSONSchema;
 
-    const testDoc = runtime.documentMap.getDoc<any>(
-      undefined,
-      "should transparently update ids when context changes",
+    const testDoc = runtime.getCell<any>(
       space,
+      "should transparently update ids when context changes",
     );
-    const testCell = testDoc.asCell([], undefined, schema);
+    testDoc.set(undefined);
+    const testCell = testDoc.asSchema(schema);
 
     const initialData = [
       {
@@ -1501,12 +1579,12 @@ describe("asCell with schema", () => {
     testCell.set(initialDataCopy);
     popFrame(frame1);
 
-    expect(isCellLink(testDoc.get()[0])).toBe(true);
-    expect(isCellLink(testDoc.get()[1])).toBe(true);
-    expect(testDoc.get()[0].cell.get().name).toEqual("First Item");
-    expect(testDoc.get()[1].cell.get().name).toEqual("Second Item");
+    expect(isCellLink(testDoc.getRaw()[0])).toBe(true);
+    expect(isCellLink(testDoc.getRaw()[1])).toBe(true);
+    expect(testDoc.getRaw()[0].cell.get().name).toEqual("First Item");
+    expect(testDoc.getRaw()[1].cell.get().name).toEqual("Second Item");
 
-    const docFromContext1 = testDoc.get()[0].cell;
+    const docFromContext1 = testDoc.getRaw()[0].cell;
 
     const returnedData = testCell.get();
     addCommonIDfromObjectID(returnedData);
@@ -1519,14 +1597,14 @@ describe("asCell with schema", () => {
     testCell.set(returnedData);
     popFrame(frame2);
 
-    expect(isCellLink(testDoc.get()[0])).toBe(true);
-    expect(isCellLink(testDoc.get()[1])).toBe(true);
-    expect(testDoc.get()[0].cell.get().name).toEqual("First Item");
-    expect(testDoc.get()[1].cell.get().name).toEqual("Second Item");
+    expect(isCellLink(testDoc.getRaw()[0])).toBe(true);
+    expect(isCellLink(testDoc.getRaw()[1])).toBe(true);
+    expect(testDoc.getRaw()[0].cell.get().name).toEqual("First Item");
+    expect(testDoc.getRaw()[1].cell.get().name).toEqual("Second Item");
 
     // Let's make sure we got a different doc with the different context
-    expect(testDoc.get()[0].cell).not.toBe(docFromContext1);
-    expect(testDoc.get()[0].cell.entityId.toString()).not.toBe(
+    expect(testDoc.getRaw()[0].cell).not.toBe(docFromContext1);
+    expect(testDoc.getRaw()[0].cell.entityId.toString()).not.toBe(
       docFromContext1.entityId.toString(),
     );
 
@@ -1534,55 +1612,66 @@ describe("asCell with schema", () => {
   });
 
   it("should push values that are already cells reusing the reference", () => {
-    const c = runtime.documentMap.getDoc<{ items: { value: number }[] }>(
-      { items: [] },
-      "should push values that are already cells reusing the reference",
+    const c = runtime.getCell<{ items: { value: number }[] }>(
       space,
-    );
-    const arrayCell = c.asCell().key("items");
-
-    const d = runtime.documentMap.getDoc<{ value: number }>(
-      { value: 1 },
       "should push values that are already cells reusing the reference",
-      space,
     );
-    const dCell = d.asCell();
+    c.set({ items: [] });
+    const arrayCell = c.key("items");
 
-    arrayCell.push(d);
+    const d = runtime.getCell<{ value: number }>(
+      space,
+      "should push values that are already cells reusing the reference d",
+    );
+    d.set({ value: 1 });
+    const dCell = d;
+
+    arrayCell.push(d.getDoc());
     arrayCell.push(dCell);
     arrayCell.push(d.getAsQueryResult());
-    arrayCell.push({ cell: d, path: [] });
+    arrayCell.push(d.getAsCellLink());
 
-    expect(c.get().items).toEqual([
-      { cell: d, path: [] },
-      dCell.getAsCellLink(),
-      { cell: d, path: [] },
-      { cell: d, path: [] },
+    // helper to normalize CellLinks because different push operations
+    // may result in CellLinks with different extra properties (ex: space)
+    const normalizeCellLink = (link: any) => ({
+      cell: link.cell,
+      path: link.path,
+    });
+
+    const rawItems = c.getRaw().items;
+    const expectedCellLink = normalizeCellLink(d.getAsCellLink());
+
+    expect(rawItems.map(normalizeCellLink)).toEqual([
+      expectedCellLink,
+      expectedCellLink,
+      expectedCellLink,
+      expectedCellLink,
     ]);
   });
 
   it("should handle push method on non-array values", () => {
-    const c = runtime.documentMap.getDoc(
-      { value: "not an array" },
-      "should handle push method on non-array values",
+    const c = runtime.getCell<{ value: string }>(
       space,
+      "should handle push method on non-array values",
     );
-    const cell = c.asCell(["value"]);
+    c.set({ value: "not an array" });
+    const cell = c.key("value");
 
     expect(() => cell.push(42)).toThrow();
   });
 
   it("should create new entities when pushing to array in frame, but reuse IDs", () => {
-    const c = runtime.documentMap.getDoc({ items: [] }, "push-with-id", space);
-    const arrayCell = c.asCell(["items"]);
+    const c = runtime.getCell<{ items: any[] }>(space, "push-with-id");
+    c.set({ items: [] });
+    const arrayCell = c.key("items");
     const frame = pushFrame();
     arrayCell.push({ value: 42 });
     expect(frame.generatedIdCounter).toEqual(1);
     arrayCell.push({ [ID]: "test", value: 43 });
     expect(frame.generatedIdCounter).toEqual(1); // No increment = no ID generated from it
     popFrame(frame);
-    expect(isCellLink(c.get().items[0])).toBe(true);
-    expect(isCellLink(c.get().items[1])).toBe(true);
+    expect(isCellLink(c.getRaw().items[0])).toBe(true);
+    expect(isCellLink(c.getRaw().items[1])).toBe(true);
     expect(arrayCell.get()).toEqual([{ value: 42 }, { value: 43 }]);
   });
 });

--- a/packages/runner/test/recipes.test.ts
+++ b/packages/runner/test/recipes.test.ts
@@ -740,7 +740,7 @@ describe("Recipe Runner", () => {
     expect(lastError?.recipeId).toBe(recipeId);
     expect(lastError?.space).toBe(space);
     expect(lastError?.charmId).toBe(
-      JSON.parse(JSON.stringify(charm.getDoc().entityId))["/"],
+      JSON.parse(JSON.stringify(charm.entityId))["/"],
     );
 
     // NOTE(ja): this test is really important after a handler
@@ -805,7 +805,7 @@ describe("Recipe Runner", () => {
     expect(lastError?.recipeId).toBe(recipeId);
     expect(lastError?.space).toBe(space);
     expect(lastError?.charmId).toBe(
-      JSON.parse(JSON.stringify(charm.getDoc().entityId))["/"],
+      JSON.parse(JSON.stringify(charm.entityId))["/"],
     );
 
     // Make sure it recovers:

--- a/packages/runner/test/recipes.test.ts
+++ b/packages/runner/test/recipes.test.ts
@@ -4,7 +4,7 @@ import { type Cell, type JSONSchema } from "../src/builder/types.ts";
 import { createBuilder } from "../src/builder/factory.ts";
 import { Runtime } from "../src/runtime.ts";
 import { type ErrorWithContext } from "../src/scheduler.ts";
-import { isCell } from "../src/cell.ts";
+import { isCell, isCellLink } from "../src/cell.ts";
 import { resolveLinks } from "../src/link-resolution.ts";
 import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
@@ -56,15 +56,11 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const result = runtime.run(
-      simpleRecipe,
-      { value: 5 },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should run a simple recipe",
-        space,
-      ),
+    const resultCell = runtime.getCell(
+      space,
+      "should run a simple recipe",
     );
+    const result = await runtime.runSynced(resultCell, simpleRecipe, { value: 5 });
 
     await runtime.idle();
 
@@ -90,15 +86,11 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const result = runtime.run(
-      outerRecipe,
-      { value: 4 },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should handle nested recipes",
-        space,
-      ),
+    const resultCell = runtime.getCell(
+      space,
+      "should handle nested recipes",
     );
+    const result = await runtime.runSynced(resultCell, outerRecipe, { value: 4 });
 
     await runtime.idle();
 
@@ -116,29 +108,21 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const result1 = runtime.run(
-      recipeWithDefaults,
-      {},
-      runtime.documentMap.getDoc(
-        undefined,
-        "should handle recipes with defaults",
-        space,
-      ),
+    const resultCell1 = runtime.getCell(
+      space,
+      "should handle recipes with defaults",
     );
+    const result1 = await runtime.runSynced(resultCell1, recipeWithDefaults, {});
 
     await runtime.idle();
 
     expect(result1.getAsQueryResult()).toMatchObject({ sum: 15 });
 
-    const result2 = runtime.run(
-      recipeWithDefaults,
-      { a: 20 },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should handle recipes with defaults (2)",
-        space,
-      ),
+    const resultCell2 = runtime.getCell(
+      space,
+      "should handle recipes with defaults (2)",
     );
+    const result2 = await runtime.runSynced(resultCell2, recipeWithDefaults, { a: 20 });
 
     await runtime.idle();
 
@@ -157,17 +141,13 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const result = runtime.run(
-      multipliedArray,
-      {
-        values: [{ x: 1 }, { x: 2 }, { x: 3 }],
-      },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should handle recipes with map nodes",
-        space,
-      ),
+    const resultCell = runtime.getCell(
+      space,
+      "should handle recipes with map nodes",
     );
+    const result = await runtime.runSynced(resultCell, multipliedArray, {
+      values: [{ x: 1 }, { x: 2 }, { x: 3 }],
+    });
 
     await runtime.idle();
 
@@ -189,18 +169,14 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const result = runtime.run(
-      doubleArray,
-      {
-        values: [1, 2, 3],
-        factor: 3,
-      },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should handle recipes with map nodes with closures",
-        space,
-      ),
+    const resultCell = runtime.getCell(
+      space,
+      "should handle recipes with map nodes with closures",
     );
+    const result = await runtime.runSynced(resultCell, doubleArray, {
+      values: [1, 2, 3],
+      factor: 3,
+    });
 
     await runtime.idle();
 
@@ -220,15 +196,11 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const result = runtime.run(
-      doubleArray,
-      { values: undefined },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should handle map nodes with undefined input",
-        space,
-      ),
+    const resultCell = runtime.getCell(
+      space,
+      "should handle map nodes with undefined input",
     );
+    const result = await runtime.runSynced(resultCell, doubleArray, { values: undefined });
 
     await runtime.idle();
 
@@ -252,19 +224,16 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const result = runtime.run(
-      incRecipe,
-      { counter: { value: 0 } },
-      runtime.documentMap.getDoc(undefined, "should execute handlers", space),
-    );
+    const resultCell = runtime.getCell(space, "should execute handlers");
+    const result = await runtime.runSynced(resultCell, incRecipe, { counter: { value: 0 } });
 
     await runtime.idle();
 
-    result.asCell(["stream"]).send({ amount: 1 });
+    result.key("stream").send({ amount: 1 });
     await runtime.idle();
     expect(result.getAsQueryResult()).toMatchObject({ counter: { value: 1 } });
 
-    result.asCell(["stream"]).send({ amount: 2 });
+    result.key("stream").send({ amount: 2 });
     await runtime.idle();
     expect(result.getAsQueryResult()).toMatchObject({ counter: { value: 3 } });
   });
@@ -288,23 +257,19 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const result = runtime.run(
-      incRecipe,
-      { counter: { value: 0 } },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should execute handlers that use bind and this",
-        space,
-      ),
+    const resultCell = runtime.getCell(
+      space,
+      "should execute handlers that use bind and this",
     );
+    const result = await runtime.runSynced(resultCell, incRecipe, { counter: { value: 0 } });
 
     await runtime.idle();
 
-    result.asCell(["stream"]).send({ amount: 1 });
+    result.key("stream").send({ amount: 1 });
     await runtime.idle();
     expect(result.getAsQueryResult()).toMatchObject({ counter: { value: 1 } });
 
-    result.asCell(["stream"]).send({ amount: 2 });
+    result.key("stream").send({ amount: 2 });
     await runtime.idle();
     expect(result.getAsQueryResult()).toMatchObject({ counter: { value: 3 } });
   });
@@ -324,38 +289,34 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const result = runtime.run(
-      incRecipe,
-      { counter: { value: 0 } },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should execute handlers that use bind and this (no types)",
-        space,
-      ),
+    const resultCell = runtime.getCell(
+      space,
+      "should execute handlers that use bind and this (no types)",
     );
+    const result = await runtime.runSynced(resultCell, incRecipe, { counter: { value: 0 } });
 
     await runtime.idle();
 
-    result.asCell(["stream"]).send({ amount: 1 });
+    result.key("stream").send({ amount: 1 });
     await runtime.idle();
     expect(result.getAsQueryResult()).toMatchObject({ counter: { value: 1 } });
 
-    result.asCell(["stream"]).send({ amount: 2 });
+    result.key("stream").send({ amount: 2 });
     await runtime.idle();
     expect(result.getAsQueryResult()).toMatchObject({ counter: { value: 3 } });
   });
 
   it("should execute recipes returned by handlers", async () => {
-    const counter = runtime.documentMap.getDoc(
-      { value: 0 },
+    const counter = runtime.getCell(
+      space,
       "should execute recipes returned by handlers 1",
-      space,
     );
-    const nested = runtime.documentMap.getDoc(
-      { a: { b: { c: 0 } } },
+    counter.set({ value: 0 });
+    const nested = runtime.getCell(
+      space,
       "should execute recipes returned by handlers 2",
-      space,
     );
+    nested.set({ a: { b: { c: 0 } } });
 
     const values: [number, number, number][] = [];
 
@@ -383,23 +344,19 @@ describe("Recipe Runner", () => {
       return { stream };
     });
 
-    const result = runtime.run(
-      incRecipe,
-      { counter, nested },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should execute recipes returned by handlers",
-        space,
-      ),
+    const resultCell = runtime.getCell(
+      space,
+      "should execute recipes returned by handlers",
     );
+    const result = await runtime.runSynced(resultCell, incRecipe, { counter, nested });
 
     await runtime.idle();
 
-    result.asCell(["stream"]).send({ amount: 1 });
+    result.key("stream").send({ amount: 1 });
     await runtime.idle();
     expect(values).toEqual([[1, 1, 0]]);
 
-    result.asCell(["stream"]).send({ amount: 2 });
+    result.key("stream").send({ amount: 2 });
     await runtime.idle();
     expect(values).toEqual([
       [1, 1, 0],
@@ -411,16 +368,16 @@ describe("Recipe Runner", () => {
   });
 
   it("should handle recipes returned by lifted functions", async () => {
-    const x = runtime.documentMap.getDoc(
-      2,
+    const x = runtime.getCell(
+      space,
       "should handle recipes returned by lifted functions 1",
-      space,
     );
-    const y = runtime.documentMap.getDoc(
-      3,
+    x.set(2);
+    const y = runtime.getCell(
+      space,
       "should handle recipes returned by lifted functions 2",
-      space,
     );
+    y.set(3);
 
     const runCounts = {
       multiply: 0,
@@ -455,15 +412,11 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const result = runtime.run(
-      multiplyRecipe,
-      { x, y },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should handle recipes returned by lifted functions",
-        space,
-      ),
+    const resultCell = runtime.getCell(
+      space,
+      "should handle recipes returned by lifted functions",
     );
+    const result = await runtime.runSynced(resultCell, multiplyRecipe, { x, y });
 
     await runtime.idle();
 
@@ -509,15 +462,11 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const result = runtime.run(
-      simpleRecipe,
-      { value: 5 },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should support referenced modules",
-        space,
-      ),
+    const resultCell = runtime.getCell(
+      space,
+      "should support referenced modules",
     );
+    const result = await runtime.runSynced(resultCell, simpleRecipe, { value: 5 });
 
     await runtime.idle();
 
@@ -552,23 +501,19 @@ describe("Recipe Runner", () => {
       return { result };
     });
 
-    const settingsCell = runtime.documentMap.getDoc(
-      { value: 5 },
-      "should handle schema with cell references 1",
+    const settingsCell = runtime.getCell(
       space,
+      "should handle schema with cell references 1",
     );
-    const result = runtime.run(
-      multiplyRecipe,
-      {
-        settings: settingsCell,
-        multiplier: 3,
-      },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should handle schema with cell references",
-        space,
-      ),
+    settingsCell.set({ value: 5 });
+    const resultCell = runtime.getCell(
+      space,
+      "should handle schema with cell references",
     );
+    const result = await runtime.runSynced(resultCell, multiplyRecipe, {
+      settings: settingsCell,
+      multiplier: 3,
+    });
 
     await runtime.idle();
 
@@ -622,25 +567,21 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const item1 = runtime.documentMap.getDoc(
-      { value: 1 },
+    const item1 = runtime.getCell(
+      space,
       "should handle nested cell references in schema 1",
-      space,
     );
-    const item2 = runtime.documentMap.getDoc(
-      { value: 2 },
+    item1.set({ value: 1 });
+    const item2 = runtime.getCell(
+      space,
       "should handle nested cell references in schema 2",
+    );
+    item2.set({ value: 2 });
+    const resultCell = runtime.getCell(
       space,
+      "should handle nested cell references in schema",
     );
-    const result = runtime.run(
-      sumRecipe,
-      { data: { items: [item1, item2] } },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should handle nested cell references in schema",
-        space,
-      ),
-    );
+    const result = await runtime.runSynced(resultCell, sumRecipe, { data: { items: [item1, item2] } });
 
     await runtime.idle();
 
@@ -679,30 +620,26 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const value1 = runtime.documentMap.getDoc(
-      5,
+    const value1 = runtime.getCell(
+      space,
       "should handle dynamic cell references with schema 1",
-      space,
     );
-    const value2 = runtime.documentMap.getDoc(
-      7,
+    value1.set(5);
+    const value2 = runtime.getCell(
+      space,
       "should handle dynamic cell references with schema 2",
+    );
+    value2.set(7);
+    const resultCell = runtime.getCell(
       space,
+      "should handle dynamic cell references with schema",
     );
-    const result = runtime.run(
-      dynamicRecipe,
-      {
-        context: {
-          first: value1,
-          second: value2,
-        },
+    const result = await runtime.runSynced(resultCell, dynamicRecipe, {
+      context: {
+        first: value1,
+        second: value2,
       },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should handle dynamic cell references with schema",
-        space,
-      ),
-    );
+    });
 
     await runtime.idle();
 
@@ -734,23 +671,19 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const result = runtime.run(
-      incRecipe,
-      { counter: 0 },
-      runtime.documentMap.getDoc(
-        undefined,
-        "should execute handlers with schemas",
-        space,
-      ),
+    const resultCell = runtime.getCell(
+      space,
+      "should execute handlers with schemas",
     );
+    const result = await runtime.runSynced(resultCell, incRecipe, { counter: 0 });
 
     await runtime.idle();
 
-    result.asCell(["stream"]).send({ amount: 1 });
+    result.key("stream").send({ amount: 1 });
     await runtime.idle();
     expect(result.getAsQueryResult()).toMatchObject({ counter: 1 });
 
-    result.asCell(["stream"]).send({ amount: 2 });
+    result.key("stream").send({ amount: 2 });
     await runtime.idle();
     expect(result.getAsQueryResult()).toMatchObject({ counter: 3 });
   });
@@ -783,40 +716,36 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const charm = runtime.run(
-      divRecipe,
-      { result: 1 },
-      runtime.documentMap.getDoc(
-        undefined,
-        "failed handlers should be ignored",
-        space,
-      ),
+    const charmCell = runtime.getCell(
+      space,
+      "failed handlers should be ignored",
     );
+    const charm = await runtime.runSynced(charmCell, divRecipe, { result: 1 });
 
     await runtime.idle();
 
-    charm.asCell(["updater"]).send({ divisor: 5, dividend: 1 });
+    charm.key("updater").send({ divisor: 5, dividend: 1 });
     await runtime.idle();
     expect(errors).toBe(0);
 
     expect(charm.getAsQueryResult()).toMatchObject({ result: 5 });
 
-    charm.asCell(["updater"]).send({ divisor: 10, dividend: 0 });
+    charm.key("updater").send({ divisor: 10, dividend: 0 });
     await runtime.idle();
     expect(errors).toBe(1);
     expect(charm.getAsQueryResult()).toMatchObject({ result: 5 });
 
-    const recipeId = charm.sourceCell?.get()?.[TYPE];
+    const recipeId = charm.getDoc().sourceCell?.get()?.[TYPE];
     expect(recipeId).toBeDefined();
     expect(lastError?.recipeId).toBe(recipeId);
     expect(lastError?.space).toBe(space);
     expect(lastError?.charmId).toBe(
-      JSON.parse(JSON.stringify(charm.entityId))["/"],
+      JSON.parse(JSON.stringify(charm.getDoc().entityId))["/"],
     );
 
     // NOTE(ja): this test is really important after a handler
     // fails the entire system crashes!!!!
-    charm.asCell(["updater"]).send({ divisor: 10, dividend: 5 });
+    charm.key("updater").send({ divisor: 10, dividend: 5 });
     await runtime.idle();
     expect(charm.getAsQueryResult()).toMatchObject({ result: 2 });
   });
@@ -849,44 +778,40 @@ describe("Recipe Runner", () => {
       },
     );
 
-    const dividend = runtime.documentMap.getDoc(
-      1,
-      "failed lifted functions should be ignored 1",
+    const dividend = runtime.getCell(
       space,
+      "failed lifted functions should be ignored 1",
     );
+    dividend.set(1);
 
-    const charm = runtime.run(
-      divRecipe,
-      { divisor: 10, dividend },
-      runtime.documentMap.getDoc(
-        undefined,
-        "failed lifted handlers should be ignored",
-        space,
-      ),
+    const charmCell = runtime.getCell(
+      space,
+      "failed lifted handlers should be ignored",
     );
+    const charm = await runtime.runSynced(charmCell, divRecipe, { divisor: 10, dividend });
 
     await runtime.idle();
 
     expect(errors).toBe(0);
-    expect(charm.getAsQueryResult()).toMatchObject({ result: 10 });
+    expect(charm.get()).toMatchObject({ result: 10 });
 
     dividend.send(0);
     await runtime.idle();
     expect(errors).toBe(1);
     expect(charm.getAsQueryResult()).toMatchObject({ result: 10 });
 
-    const recipeId = charm.sourceCell?.get()?.[TYPE];
+    const recipeId = charm.getDoc().sourceCell?.get()?.[TYPE];
     expect(recipeId).toBeDefined();
     expect(lastError?.recipeId).toBe(recipeId);
     expect(lastError?.space).toBe(space);
     expect(lastError?.charmId).toBe(
-      JSON.parse(JSON.stringify(charm.entityId))["/"],
+      JSON.parse(JSON.stringify(charm.getDoc().entityId))["/"],
     );
 
     // Make sure it recovers:
     dividend.send(2);
     await runtime.idle();
-    expect((charm.get() as any).result.$alias.cell).toBe(charm.sourceCell);
+    expect((charm.getRaw() as any).result.$alias.cell).toBe(charm.getDoc().sourceCell);
     expect(charm.getAsQueryResult()).toMatchObject({ result: 5 });
   });
 
@@ -1014,7 +939,7 @@ describe("Recipe Runner", () => {
       { result: 0 },
       runtime.documentMap.getDoc(
         undefined,
-        "idle should wait for slow async handlers",
+        "idle should not wait for deliberately async handlers",
         space,
       ),
     );

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -706,22 +706,21 @@ describe("runner utils", () => {
     });
 
     it("should treat cell aliases and references as values", () => {
-      const testCell = runtime.documentMap.getDoc(
-        undefined,
-        "should treat cell aliases and references as values 1",
+      const testCell = runtime.getCell<{ a: any }>(
         space,
+        "should treat cell aliases and references as values 1",
       );
       const obj1 = { a: { $alias: { path: [] } } };
-      const obj2 = { a: 2, b: { c: { cell: testCell, path: [] } } };
+      const obj2 = { a: 2, b: { c: testCell.getAsCellLink() } };
       const obj3 = {
-        a: { $alias: { cell: testCell, path: ["a"] } },
+        a: { $alias: testCell.key("a").getAsCellLink() },
         b: { c: 4 },
       };
 
       const result = mergeObjects<unknown>(obj1, obj2, obj3);
       expect(result).toEqual({
         a: { $alias: { path: [] } },
-        b: { c: { cell: testCell, path: [] } },
+        b: { c: testCell.getAsCellLink() },
       });
     });
   });

--- a/packages/runner/test/storage.test.ts
+++ b/packages/runner/test/storage.test.ts
@@ -71,7 +71,7 @@ describe("Storage", () => {
 
       await runtime.storage.syncCell(testDoc);
 
-      const entry = storageManager.open(space).get(refDoc.getDoc().entityId);
+      const entry = storageManager.open(space).get(refDoc.entityId!);
       expect(entry?.value).toEqual("hello");
     });
 
@@ -90,7 +90,7 @@ describe("Storage", () => {
 
       await runtime.storage.syncCell(testDoc);
 
-      const entry = storageManager.open(space).get(refDoc.getDoc().entityId);
+      const entry = storageManager.open(space).get(refDoc.entityId!);
       expect(entry?.value).toEqual("hello");
     });
   });
@@ -122,7 +122,7 @@ describe("Storage", () => {
     it("should wait for a doc to appear", async () => {
       let synced = false;
 
-      storageManager.open(space).sync(testDoc.getDoc().entityId!, true).then(
+      storageManager.open(space).sync(testDoc.entityId!, true).then(
         () => (synced = true),
       );
       expect(synced).toBe(false);
@@ -134,7 +134,7 @@ describe("Storage", () => {
 
     it("should wait for a undefined doc to appear", async () => {
       let synced = false;
-      storageManager.open(space).sync(testDoc.getDoc().entityId!, true).then(
+      storageManager.open(space).sync(testDoc.entityId!, true).then(
         () => (synced = true),
       );
       expect(synced).toBe(false);
@@ -155,8 +155,8 @@ describe("Storage", () => {
       await runtime.storage.syncCell(ephemeralDoc);
       const provider = storageManager.open(space);
 
-      await provider.sync(ephemeralDoc.getDoc().entityId!);
-      const record = provider.get(ephemeralDoc.getDoc().entityId!);
+      await provider.sync(ephemeralDoc.entityId!);
+      const record = provider.get(ephemeralDoc.entityId!);
       expect(record).toBeUndefined();
     });
   });

--- a/packages/runner/test/storage.test.ts
+++ b/packages/runner/test/storage.test.ts
@@ -65,7 +65,7 @@ describe("Storage", () => {
 
       const testValue = {
         data: "test",
-        ref: { cell: refDoc.getDoc(), path: [] },
+        ref: refDoc.getAsCellLink(),
       };
       testDoc.send(testValue);
 
@@ -80,11 +80,11 @@ describe("Storage", () => {
         space,
         "should persist a cells and referenced cells 1",
       );
-      refDoc.setRaw("hello");
+      refDoc.set("hello");
 
       const testValue = {
         data: "test",
-        otherDoc: refDoc.getDoc(),
+        otherDoc: refDoc,
       };
       testDoc.send(testValue);
 

--- a/packages/runner/test/test-helpers.ts
+++ b/packages/runner/test/test-helpers.ts
@@ -59,9 +59,8 @@ export function expectCellLinksEqual(actual: unknown) {
         assertEquals(normalizedActual, normalizedExpected, msg);
       } catch (error) {
         if (error instanceof AssertionError) {
-          throw new AssertionError(
-            `CellLinks are not equal (after normalization).\n${error.message}`
-          );
+          error.message = `CellLinks are not equal (after normalization).\n${error.message}`;
+          throw error;
         }
         throw error;
       }

--- a/packages/runner/test/test-helpers.ts
+++ b/packages/runner/test/test-helpers.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from "@std/assert";
+import { AssertionError } from "@std/assert";
+import { isAlias } from "../src/builder/types.ts";
+
+/**
+ * Normalizes an object by stripping extra metadata from CellLinks within aliases
+ * Strips out extra properties like space, schema, rootSchema from CellLinks
+ */
+function normalizeCellLinksInAliases(obj: any): any {
+  if (!obj || typeof obj !== 'object') {
+    return obj;
+  }
+  
+  const result: any = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (isAlias(value)) {
+      result[key] = {
+        $alias: { 
+          cell: value.$alias.cell, 
+          path: value.$alias.path 
+        }
+      };
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Custom expect-style matcher for CellLink equality
+ * Usage: expectCellLinksEqual(actual).toEqual(expected)
+ */
+export function expectCellLinksEqual(actual: unknown) {
+  return {
+    toEqual(expected: unknown, msg?: string) {
+      const normalizedActual = normalizeCellLinksInAliases(actual);
+      const normalizedExpected = normalizeCellLinksInAliases(expected);
+      
+      try {
+        assertEquals(normalizedActual, normalizedExpected, msg);
+      } catch (error) {
+        if (error instanceof AssertionError) {
+          throw new AssertionError(
+            `CellLinks are not equal (after normalization).\n${error.message}`
+          );
+        }
+        throw error;
+      }
+    }
+  };
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Replaced all remaining uses of DocImpl with the Cell API in runner code and tests, and updated core runner methods to accept both Cell and DocImpl for compatibility.

- **Refactors**
  - Updated runner, runtime, link-resolution, and recipe-binding to support Cell or DocImpl inputs.
  - Migrated all tests to use the Cell API instead of DocImpl.
  - Added a test helper for comparing CellLinks in assertions.

<!-- End of auto-generated description by cubic. -->

