### PR TITLE
Ct 446 replace docimpl with cell part4

### DIFF
--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -5,7 +5,7 @@ import {
 } from "./builder/types.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import { type DocImpl, isDoc } from "./doc.ts";
-import { type CellLink, isCell, isCellLink } from "./cell.ts";
+import { type Cell, type CellLink, isCell, isCellLink } from "./cell.ts";
 import { type ReactivityLog } from "./scheduler.ts";
 import {
   getCellLinkOrThrow,
@@ -263,10 +263,11 @@ export function maybeGetCellLink<T>(
 // Only logs interim aliases, not the first one, and not the non-alias value.
 export function followAliases<T = any>(
   alias: Alias,
-  doc: DocImpl<T>,
+  docOrCell: DocImpl<T> | Cell<T>,
   log?: ReactivityLog,
 ): CellLink {
   if (isAlias(alias)) {
+    const doc = isCell(docOrCell) ? docOrCell.getDoc() : docOrCell;
     return followLinks(
       { cell: doc, ...alias.$alias } as CellLink,
       log,

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -640,7 +640,7 @@ describe("asCell", () => {
       { cell: c.getDoc(), path: ["stream"] },
     );
 
-    (streamCell as any).send("event");
+    streamCell.send("event");
     await runtime.idle();
 
     expect(c.get()).toStrictEqual({ stream: { $stream: true } });

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -10,6 +10,7 @@ import { Runtime } from "../src/runtime.ts";
 import { addCommonIDfromObjectID } from "../src/data-updating.ts";
 import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
+import { expectCellLinksEqual } from "./test-helpers.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -518,11 +519,10 @@ describe("createProxy", () => {
     const proxy = c.getAsQueryResult([], log);
     proxy.length = 2;
     expect(c.get()).toEqual([1, 2]);
-    expect(log.writes.length).toBe(2);
-    expect(log.writes[0].cell).toBe(c.getDoc());
-    expect(log.writes[0].path).toEqual(["length"]);
-    expect(log.writes[1].cell).toBe(c.getDoc());
-    expect(log.writes[1].path).toEqual([2]);
+    expectCellLinksEqual(log.writes).toEqual([
+      c.key("length").getAsCellLink(),
+      c.key(2).getAsCellLink(),
+    ]);
     proxy.length = 4;
     expect(c.get()).toEqual([1, 2, undefined, undefined]);
     expect(log.writes.length).toBe(5);

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -629,7 +629,7 @@ describe("asCell", () => {
     expect(streamCell).not.toHaveProperty("set");
     expect(streamCell).not.toHaveProperty("key");
 
-    let lastEventSeen = "";
+    let lastEventSeen: any = null;
     let eventCount = 0;
 
     runtime.scheduler.addEventHandler(
@@ -640,12 +640,12 @@ describe("asCell", () => {
       { cell: c.getDoc(), path: ["stream"] },
     );
 
-    streamCell.send("event");
+    streamCell.send({ $stream: true });
     await runtime.idle();
 
     expect(c.get()).toStrictEqual({ stream: { $stream: true } });
     expect(eventCount).toBe(1);
-    expect(lastEventSeen).toBe("event");
+    expect(lastEventSeen).toEqual({ $stream: true });
   });
 
   it("should call sink only when the cell changes on the subpath", async () => {

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -277,14 +277,14 @@ describe("createProxy", () => {
   });
 
   it("should handle aliases when writing", () => {
-    const c = runtime.getCell(
+    const c = runtime.getCell<{ x: number; y: number }>(
       space,
       "should handle aliases when writing",
     );
     c.setRaw({ x: { $alias: { path: ["y"] } }, y: 42 });
     const proxy = c.getAsQueryResult();
     proxy.x = 100;
-    expect((c.get() as any).y).toBe(100);
+    expect(c.get().y).toBe(100);
   });
 
   it("should handle nested cells", () => {

--- a/packages/runner/test/test-helpers.ts
+++ b/packages/runner/test/test-helpers.ts
@@ -59,9 +59,8 @@ export function expectCellLinksEqual(actual: unknown) {
         assertEquals(normalizedActual, normalizedExpected, msg);
       } catch (error) {
         if (error instanceof AssertionError) {
-          throw new AssertionError(
-            `CellLinks are not equal (after normalization).\n${error.message}`
-          );
+          error.message = `CellLinks are not equal (after normalization).\n${error.message}`;
+          throw error;
         }
         throw error;
       }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated link-resolution tests and helpers to use the Cell API instead of DocImpl, and improved the followAliases function to accept both Cell and DocImpl types.

- **Tests**
  - Migrated link-resolution and cell tests to use the Cell API.
  - Enhanced expectCellLinksEqual to better compare CellLinks in tests.
  - Updated test cases for clearer and more accurate assertions.

<!-- End of auto-generated description by cubic. -->

