### PR TITLE
fix email-summarizer type issue

### DIFF
--- a/recipes/email-summarizer.tsx
+++ b/recipes/email-summarizer.tsx
@@ -1,6 +1,6 @@
 import {
-  h,
   derive,
+  h,
   handler,
   JSONSchema,
   lift,
@@ -12,70 +12,79 @@ import {
   UI,
 } from "commontools";
 
-// Email schema based on Gmail recipe
-const EmailProperties = {
-  id: {
-    type: "string",
-    title: "Email ID",
-    description: "Unique identifier for the email",
-  },
-  threadId: {
-    type: "string",
-    title: "Thread ID",
-    description: "Identifier for the email thread",
-  },
-  labelIds: {
-    type: "array",
-    items: { type: "string" },
-    title: "Labels",
-    description: "Gmail labels assigned to the email",
-  },
-  snippet: {
-    type: "string",
-    title: "Snippet",
-    description: "Brief preview of the email content",
-  },
-  subject: {
-    type: "string",
-    title: "Subject",
-    description: "Email subject line",
-  },
-  from: {
-    type: "string",
-    title: "From",
-    description: "Sender's email address",
-  },
-  date: {
-    type: "string",
-    title: "Date",
-    description: "Date and time when the email was sent",
-  },
-  to: {
-    type: "string",
-    title: "To",
-    description: "Recipient's email address",
-  },
-  plainText: {
-    type: "string",
-    title: "Plain Text Content",
-    description: "Email content in plain text format (often empty)",
-  },
-  htmlContent: {
-    type: "string",
-    title: "HTML Content",
-    description: "Email content in HTML format",
-  },
-  markdownContent: {
-    type: "string",
-    title: "Markdown Content",
-    description: "Email content converted to Markdown format",
-  },
-} as const;
-
 const EmailSchema = {
   type: "object",
-  properties: EmailProperties,
-  required: Object.keys(EmailProperties),
+  properties: {
+    id: {
+      type: "string",
+      title: "Email ID",
+      description: "Unique identifier for the email",
+    },
+    threadId: {
+      type: "string",
+      title: "Thread ID",
+      description: "Identifier for the email thread",
+    },
+    labelIds: {
+      type: "array",
+      items: { type: "string" },
+      title: "Labels",
+      description: "Gmail labels assigned to the email",
+    },
+    snippet: {
+      type: "string",
+      title: "Snippet",
+      description: "Brief preview of the email content",
+    },
+    subject: {
+      type: "string",
+      title: "Subject",
+      description: "Email subject line",
+    },
+    from: {
+      type: "string",
+      title: "From",
+      description: "Sender's email address",
+    },
+    date: {
+      type: "string",
+      title: "Date",
+      description: "Date and time when the email was sent",
+    },
+    to: {
+      type: "string",
+      title: "To",
+      description: "Recipient's email address",
+    },
+    plainText: {
+      type: "string",
+      title: "Plain Text Content",
+      description: "Email content in plain text format (often empty)",
+    },
+    htmlContent: {
+      type: "string",
+      title: "HTML Content",
+      description: "Email content in HTML format",
+    },
+    markdownContent: {
+      type: "string",
+      title: "Markdown Content",
+      description: "Email content converted to Markdown format",
+    },
+  },
+  required: [
+    "id",
+    "threadId",
+    "labelIds",
+    "snippet",
+    "subject",
+    "from",
+    "date",
+    "to",
+    "plainText",
+    "htmlContent",
+    "markdownContent",
+  ],
 } as const satisfies JSONSchema;
 
 type Email = Schema<typeof EmailSchema>;
@@ -91,10 +100,7 @@ const EmailSummarizerInputSchema = {
   properties: {
     emails: {
       type: "array",
-      items: {
-        type: "object",
-        properties: EmailProperties,
-      },
+      items: EmailSchema,
     },
     settings: {
       type: "object",
@@ -218,11 +224,7 @@ const getEmailContent = lift(
   {
     type: "object",
     properties: {
-      email: {
-        type: "object",
-        properties: EmailProperties,
-        required: Object.keys(EmailProperties),
-      },
+      email: EmailSchema,
       content: { type: "string" },
       hasContent: { type: "boolean" },
     },


### PR DESCRIPTION
had to make the required list explicit, so typescript sees it
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a TypeScript type issue in the email-summarizer by making the required fields in the email schema explicit. This ensures proper type checking and prevents schema errors.

<!-- End of auto-generated description by cubic. -->

