### PR TITLE
chore: Fail CI when derived artifacts are not checked in.

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -34,6 +34,15 @@ jobs:
       - name: 🔎 Type check codebase
         run: deno task check
 
+      - name: 🔎 Check derived artifacts
+        working-directory: packages/static
+        run: |
+          deno task compile-api-types
+          if ! git diff --quiet . ; then
+            echo "Run 'deno task compile-api-types' inside the 'static' package."
+            exit 1
+          fi
+
       - name: 🧹 Lint codebase
         run: deno lint
 
@@ -171,7 +180,7 @@ jobs:
           # Copy to signed directory
           cp ./dist/bg-charm-service ./signed/
           cp ./dist/bg-charm-service.sig ./signed/
-          
+
           # Process ct binary
           echo "Processing binary: ct"
           sha256sum ./dist/ct > ./dist/ct.hash.txt
@@ -211,7 +220,7 @@ jobs:
         with:
           subject-name: ./dist/bg-charm-service
           subject-digest: sha256:${{ steps.binary_processing.outputs.bg_charm_service_hash }}
-      
+
       - name: 📝 Generate attestation for ct binary
         if: github.ref == 'refs/heads/main'
         id: attest_ct
@@ -277,7 +286,7 @@ jobs:
             echo -e "\033[31m✗ bg-charm-service attestation verification failed\033[0m"
             exit 1
           fi
-          
+
           # Verify ct binary attestation
           echo "::group::ct attestation details"
           gh attestation verify ./dist/ct -R ${{ github.repository }} --format json | jq

--- a/packages/static/scripts/compile-api-types.sh
+++ b/packages/static/scripts/compile-api-types.sh
@@ -7,5 +7,6 @@ SOURCE=../api/index.ts
 OUT=../api/index.d.ts
 STATIC=./assets/types/commontools.d.ts
 
-deno run -A npm:typescript/tsc $SOURCE --declaration --emitDeclarationOnly
+# When running in CI, we need to specific libs
+deno run -A npm:typescript/tsc $SOURCE --declaration --emitDeclarationOnly --lib esnext,dom
 mv $OUT $STATIC


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
CI now fails if derived artifacts in the static package are not checked in, ensuring generated files stay up to date. 

- **CI Update**
  - Added a step to check for uncommitted changes after running the compile-api-types task.

<!-- End of auto-generated description by cubic. -->

