### PR TITLE
Ct 446 replace docimpl with cell part5

### DIFF
--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -364,7 +364,7 @@ describe("data-updating", () => {
 
       // Should create an entity and return changes to that entity
       expect(changes.length).toBe(3);
-      expect(changes[0].location.cell).toBe(testCell.getDoc());
+      expect(changes[0].location.cell.asCell().equals(testCell)).toBe(true);
       expect(changes[0].location.path).toEqual(["items", 0]);
       expect(changes[1].location.cell).not.toBe(changes[0].location.cell);
       expect(changes[1].location.path).toEqual([]);
@@ -546,7 +546,7 @@ describe("data-updating", () => {
 
       expect(changes.length).toBe(1);
       expect(changes[0].location).toEqual(current);
-      expect(changes[0].value).toEqual({ cell: cellA.getDoc(), path: [] });
+      expectCellLinksEqual(changes[0].value).toEqual(cellA.getAsCellLink());
     });
 
     it("should handle doc and cell references that don't change", () => {
@@ -566,7 +566,7 @@ describe("data-updating", () => {
 
       expect(changes.length).toBe(1);
       expect(changes[0].location).toEqual(current);
-      expect(changes[0].value).toEqual({ cell: cellA.getDoc(), path: [] });
+      expectCellLinksEqual(changes[0].value).toEqual(cellA.getAsCellLink());
 
       applyChangeSet(changes);
 
@@ -594,7 +594,7 @@ describe("data-updating", () => {
         space,
         "addCommonIDfromObjectID arrays",
       );
-      testCell.setRaw({ items: [{ cell: itemCell.getDoc(), path: [] }] });
+      testCell.setRaw({ items: [itemCell.getAsCellLink()] });
 
       const data = {
         items: [{ id: "item1", name: "New Item" }, itemCell],

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -14,6 +14,7 @@ import { CellLink, isCellLink } from "../src/cell.ts";
 import { type ReactivityLog } from "../src/scheduler.ts";
 import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
+import { expectCellLinksEqual } from "./test-helpers.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -39,48 +40,48 @@ describe("data-updating", () => {
 
   describe("setNestedValue", () => {
     it("should set a value at a path", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { a: 1, b: { c: 2 } },
-        "should set a value at a path 1",
+      const testCell = runtime.getCell<{ a: number; b: { c: number } }>(
         space,
+        "should set a value at a path 1",
       );
-      const success = setNestedValue(testCell, ["b", "c"], 3);
+      testCell.set({ a: 1, b: { c: 2 } });
+      const success = setNestedValue(testCell.getDoc(), ["b", "c"], 3);
       expect(success).toBe(true);
       expect(testCell.get()).toEqual({ a: 1, b: { c: 3 } });
     });
 
     it("should delete no longer used fields when setting a nested value", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { a: 1, b: { c: 2, d: 3 } },
-        "should delete no longer used fields 1",
+      const testCell = runtime.getCell<{ a: number; b: { c: number; d?: number } }>(
         space,
+        "should delete no longer used fields 1",
       );
-      const success = setNestedValue(testCell, ["b"], { c: 4 });
+      testCell.set({ a: 1, b: { c: 2, d: 3 } });
+      const success = setNestedValue(testCell.getDoc(), ["b"], { c: 4 });
       expect(success).toBe(true);
       expect(testCell.get()).toEqual({ a: 1, b: { c: 4 } });
     });
 
     it("should log no changes when setting a nested value that is already set", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { a: 1, b: { c: 2 } },
-        "should log no changes 1",
+      const testCell = runtime.getCell<{ a: number; b: { c: number } }>(
         space,
+        "should log no changes 1",
       );
+      testCell.set({ a: 1, b: { c: 2 } });
       const log: ReactivityLog = { reads: [], writes: [] };
-      const success = setNestedValue(testCell, [], { a: 1, b: { c: 2 } }, log);
+      const success = setNestedValue(testCell.getDoc(), [], { a: 1, b: { c: 2 } }, log);
       expect(success).toBe(true); // No changes is still a success
       expect(testCell.get()).toEqual({ a: 1, b: { c: 2 } });
       expect(log.writes).toEqual([]);
     });
 
     it("should log minimal changes when setting a nested value", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { a: 1, b: { c: 2 } },
-        "should log minimal changes 1",
+      const testCell = runtime.getCell<{ a: number; b: { c: number } }>(
         space,
+        "should log minimal changes 1",
       );
+      testCell.set({ a: 1, b: { c: 2 } });
       const log: ReactivityLog = { reads: [], writes: [] };
-      const success = setNestedValue(testCell, [], { a: 1, b: { c: 3 } }, log);
+      const success = setNestedValue(testCell.getDoc(), [], { a: 1, b: { c: 3 } }, log);
       expect(success).toBe(true);
       expect(testCell.get()).toEqual({ a: 1, b: { c: 3 } });
       expect(log.writes.length).toEqual(1);
@@ -88,46 +89,46 @@ describe("data-updating", () => {
     });
 
     it("should fail when setting a nested value on a frozen cell", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { a: 1, b: { c: 2 } },
-        "should fail when setting a nested value on a frozen cell 1",
+      const testCell = runtime.getCell<{ a: number; b: { c: number } }>(
         space,
+        "should fail when setting a nested value on a frozen cell 1",
       );
-      testCell.freeze("test");
+      testCell.set({ a: 1, b: { c: 2 } });
+      testCell.getDoc().freeze("test");
       const log: ReactivityLog = { reads: [], writes: [] };
-      const success = setNestedValue(testCell, [], { a: 1, b: { c: 3 } }, log);
+      const success = setNestedValue(testCell.getDoc(), [], { a: 1, b: { c: 3 } }, log);
       expect(success).toBe(false);
     });
 
     it("should correctly update with shorter arrays", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { a: [1, 2, 3] },
-        "should correctly update with shorter arrays 1",
+      const testCell = runtime.getCell<{ a: number[] }>(
         space,
+        "should correctly update with shorter arrays 1",
       );
-      const success = setNestedValue(testCell, ["a"], [1, 2]);
+      testCell.set({ a: [1, 2, 3] });
+      const success = setNestedValue(testCell.getDoc(), ["a"], [1, 2]);
       expect(success).toBe(true);
       expect(testCell.getAsQueryResult()).toEqual({ a: [1, 2] });
     });
 
     it("should correctly update with a longer arrays", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { a: [1, 2, 3] },
-        "should correctly update with a longer arrays 1",
+      const testCell = runtime.getCell<{ a: number[] }>(
         space,
+        "should correctly update with a longer arrays 1",
       );
-      const success = setNestedValue(testCell, ["a"], [1, 2, 3, 4]);
+      testCell.set({ a: [1, 2, 3] });
+      const success = setNestedValue(testCell.getDoc(), ["a"], [1, 2, 3, 4]);
       expect(success).toBe(true);
       expect(testCell.getAsQueryResult()).toEqual({ a: [1, 2, 3, 4] });
     });
 
     it("should overwrite an object with an array", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { a: { b: 1 } },
-        "should overwrite an object with an array 1",
+      const testCell = runtime.getCell<{ a: any }>(
         space,
+        "should overwrite an object with an array 1",
       );
-      const success = setNestedValue(testCell, ["a"], [1, 2, 3]);
+      testCell.set({ a: { b: 1 } });
+      const success = setNestedValue(testCell.getDoc(), ["a"], [1, 2, 3]);
       expect(success).toBeTruthy();
       expect(testCell.get()).toHaveProperty("a");
       expect(testCell.get().a).toHaveLength(3);
@@ -137,12 +138,12 @@ describe("data-updating", () => {
 
   describe("normalizeAndDiff", () => {
     it("should detect simple value changes", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { value: 42 },
-        "normalizeAndDiff simple value changes",
+      const testCell = runtime.getCell<{ value: number }>(
         space,
+        "normalizeAndDiff simple value changes",
       );
-      const current: CellLink = { cell: testCell, path: ["value"] };
+      testCell.set({ value: 42 });
+      const current = testCell.key("value").getAsCellLink();
       const changes = normalizeAndDiff(current, 100);
 
       expect(changes.length).toBe(1);
@@ -151,126 +152,130 @@ describe("data-updating", () => {
     });
 
     it("should detect object property changes", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { user: { name: "John", age: 30 } },
-        "normalizeAndDiff object property changes",
+      const testCell = runtime.getCell<{ user: { name: string; age: number } }>(
         space,
+        "normalizeAndDiff object property changes",
       );
-      const current: CellLink = { cell: testCell, path: ["user"] };
+      testCell.set({ user: { name: "John", age: 30 } });
+      const current = testCell.key("user").getAsCellLink();
       const changes = normalizeAndDiff(current, { name: "Jane", age: 30 });
 
       expect(changes.length).toBe(1);
-      expect(changes[0].location).toEqual({
-        cell: testCell,
-        path: ["user", "name"],
-      });
+      expectCellLinksEqual(changes[0].location).toEqual(
+        testCell.key("user").key("name").getAsCellLink()
+      );
       expect(changes[0].value).toBe("Jane");
     });
 
     it("should detect added object properties", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { user: { name: "John" } },
-        "normalizeAndDiff added object properties",
+      const testCell = runtime.getCell<{ user: { name: string; age?: number } }>(
         space,
+        "normalizeAndDiff added object properties",
       );
-      const current: CellLink = { cell: testCell, path: ["user"] };
+      testCell.set({ user: { name: "John" } });
+      const current = testCell.key("user").getAsCellLink();
       const changes = normalizeAndDiff(current, { name: "John", age: 30 });
 
       expect(changes.length).toBe(1);
-      expect(changes[0].location).toEqual({
-        cell: testCell,
-        path: ["user", "age"],
-      });
+      expectCellLinksEqual(changes[0].location).toEqual(
+        testCell.key("user").key("age").getAsCellLink()
+      );
       expect(changes[0].value).toBe(30);
     });
 
     it("should detect removed object properties", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { user: { name: "John", age: 30 } },
-        "normalizeAndDiff removed object properties",
+      const testCell = runtime.getCell<{ user: { name: string; age: number } }>(
         space,
+        "normalizeAndDiff removed object properties",
       );
-      const current: CellLink = { cell: testCell, path: ["user"] };
+      testCell.set({ user: { name: "John", age: 30 } });
+      const current = testCell.key("user").getAsCellLink();
       const changes = normalizeAndDiff(current, { name: "John" });
 
       expect(changes.length).toBe(1);
-      expect(changes[0].location).toEqual({
-        cell: testCell,
-        path: ["user", "age"],
-      });
+      expectCellLinksEqual(changes[0].location).toEqual(
+        testCell.key("user").key("age").getAsCellLink()
+      );
       expect(changes[0].value).toBe(undefined);
     });
 
     it("should handle array length changes", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { items: [1, 2, 3] },
-        "normalizeAndDiff array length changes",
+      const testCell = runtime.getCell<{ items: number[] }>(
         space,
+        "normalizeAndDiff array length changes",
       );
-      const current: CellLink = { cell: testCell, path: ["items"] };
+      testCell.set({ items: [1, 2, 3] });
+      const current = testCell.key("items").getAsCellLink();
       const changes = normalizeAndDiff(current, [1, 2]);
 
       expect(changes.length).toBe(1);
-      expect(changes[0].location).toEqual({
-        cell: testCell,
-        path: ["items", "length"],
-        schema: { type: "number" },
-        rootSchema: undefined,
-      });
+      expectCellLinksEqual(changes[0].location).toEqual(
+        testCell.key("items").key("length").getAsCellLink()
+      );
       expect(changes[0].value).toBe(2);
     });
 
     it("should handle array element changes", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { items: [1, 2, 3] },
-        "normalizeAndDiff array element changes",
+      const testCell = runtime.getCell<{ items: number[] }>(
         space,
+        "normalizeAndDiff array element changes",
       );
-      const current: CellLink = { cell: testCell, path: ["items"] };
+      testCell.set({ items: [1, 2, 3] });
+      const current = testCell.key("items").getAsCellLink();
       const changes = normalizeAndDiff(current, [1, 5, 3]);
 
       expect(changes.length).toBe(1);
-      expect(changes[0].location).toEqual({
-        cell: testCell,
-        path: ["items", "1"],
-      });
+      expectCellLinksEqual(changes[0].location).toEqual(
+        testCell.key("items").key(1).getAsCellLink()
+      );
       expect(changes[0].value).toBe(5);
     });
 
     it("should follow aliases", () => {
-      const testCell = runtime.documentMap.getDoc(
-        {
-          value: 42,
-          alias: { $alias: { path: ["value"] } },
-        },
-        "normalizeAndDiff follow aliases",
+      const testCell = runtime.getCell<{
+        value: number;
+        alias: any;
+      }>(
         space,
+        "normalizeAndDiff follow aliases",
       );
-      const current: CellLink = { cell: testCell, path: ["alias"] };
+      testCell.setRaw({
+        value: 42,
+        alias: { $alias: { path: ["value"] } },
+      });
+      const current = testCell.key("alias").getAsCellLink();
       const changes = normalizeAndDiff(current, 100);
 
       // Should follow alias to value and change it there
       expect(changes.length).toBe(1);
-      expect(changes[0].location).toEqual({ cell: testCell, path: ["value"] });
+      expectCellLinksEqual(changes[0].location).toEqual(
+        testCell.key("value").getAsCellLink()
+      );
       expect(changes[0].value).toBe(100);
     });
 
     it("should update aliases", () => {
-      const testCell = runtime.documentMap.getDoc(
-        {
-          value: 42,
-          value2: 200,
-          alias: { $alias: { path: ["value"] } },
-        },
-        "normalizeAndDiff update aliases",
+      const testCell = runtime.getCell<{
+        value: number;
+        value2: number;
+        alias: any;
+      }>(
         space,
+        "normalizeAndDiff update aliases",
       );
-      const current: CellLink = { cell: testCell, path: ["alias"] };
+      testCell.setRaw({
+        value: 42,
+        value2: 200,
+        alias: { $alias: { path: ["value"] } },
+      });
+      const current = testCell.key("alias").getAsCellLink();
       const changes = normalizeAndDiff(current, 100);
 
       // Should follow alias to value and change it there
       expect(changes.length).toBe(1);
-      expect(changes[0].location).toEqual({ cell: testCell, path: ["value"] });
+      expectCellLinksEqual(changes[0].location).toEqual(
+        testCell.key("value").getAsCellLink()
+      );
       expect(changes[0].value).toBe(100);
 
       applyChangeSet(changes);
@@ -282,37 +287,49 @@ describe("data-updating", () => {
       applyChangeSet(changes2);
 
       expect(changes2.length).toBe(1);
-      expect(changes2[0].location).toEqual({ cell: testCell, path: ["alias"] });
+      expectCellLinksEqual(changes2[0].location).toEqual(
+        testCell.key("alias").getAsCellLink()
+      );
       expect(changes2[0].value).toEqual({ $alias: { path: ["value2"] } });
 
       const changes3 = normalizeAndDiff(current, 300);
 
       expect(changes3.length).toBe(1);
-      expect(changes3[0].location).toEqual({
-        cell: testCell,
-        path: ["value2"],
-      });
+      expectCellLinksEqual(changes3[0].location).toEqual(
+        testCell.key("value2").getAsCellLink()
+      );
       expect(changes3[0].value).toBe(300);
     });
 
     it("should handle nested changes", () => {
-      const testCell = runtime.documentMap.getDoc(
-        {
-          user: {
-            profile: {
-              details: {
-                address: {
-                  city: "New York",
-                  zipcode: 10001,
-                },
+      const testCell = runtime.getCell<{
+        user: {
+          profile: {
+            details: {
+              address: {
+                city: string;
+                zipcode: number;
+              };
+            };
+          };
+        };
+      }>(
+        space,
+        "normalizeAndDiff nested changes",
+      );
+      testCell.set({
+        user: {
+          profile: {
+            details: {
+              address: {
+                city: "New York",
+                zipcode: 10001,
               },
             },
           },
         },
-        "normalizeAndDiff nested changes",
-        space,
-      );
-      const current: CellLink = { cell: testCell, path: ["user", "profile"] };
+      });
+      const current = testCell.key("user").key("profile").getAsCellLink();
       const changes = normalizeAndDiff(current, {
         details: {
           address: {
@@ -323,20 +340,19 @@ describe("data-updating", () => {
       });
 
       expect(changes.length).toBe(1);
-      expect(changes[0].location).toEqual({
-        cell: testCell,
-        path: ["user", "profile", "details", "address", "city"],
-      });
+      expectCellLinksEqual(changes[0].location).toEqual(
+        testCell.key("user").key("profile").key("details").key("address").key("city").getAsCellLink()
+      );
       expect(changes[0].value).toBe("Boston");
     });
 
     it("should handle ID-based entity objects", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { items: [] },
-        "should handle ID-based entity objects",
+      const testCell = runtime.getCell<{ items: any[] }>(
         space,
+        "should handle ID-based entity objects",
       );
-      const current: CellLink = { cell: testCell, path: ["items", 0] };
+      testCell.set({ items: [] });
+      const current = testCell.key("items").key(0).getAsCellLink();
 
       const newValue = { [ID]: "item1", name: "First Item" };
       const changes = normalizeAndDiff(
@@ -348,7 +364,7 @@ describe("data-updating", () => {
 
       // Should create an entity and return changes to that entity
       expect(changes.length).toBe(3);
-      expect(changes[0].location.cell).toBe(testCell);
+      expect(changes[0].location.cell).toBe(testCell.getDoc());
       expect(changes[0].location.path).toEqual(["items", 0]);
       expect(changes[1].location.cell).not.toBe(changes[0].location.cell);
       expect(changes[1].location.path).toEqual([]);
@@ -357,12 +373,12 @@ describe("data-updating", () => {
     });
 
     it("should update the same document with ID-based entity objects", () => {
-      const testDoc = runtime.documentMap.getDoc<any>(
-        { items: [] },
-        "should update the same document with ID-based entity objects",
+      const testCell = runtime.getCell<any>(
         space,
+        "should update the same document with ID-based entity objects",
       );
-      const current: CellLink = { cell: testDoc, path: ["items", 0] };
+      testCell.set({ items: [] });
+      const current = testCell.key("items").key(0).getAsCellLink();
 
       const newValue = { [ID]: "item1", name: "First Item" };
       diffAndUpdate(
@@ -372,7 +388,7 @@ describe("data-updating", () => {
         "should update the same document with ID-based entity objects",
       );
 
-      const newDoc = testDoc.get().items[0].cell;
+      const newDoc = testCell.getRaw().items[0]?.cell;
 
       const newValue2 = {
         items: [
@@ -381,25 +397,27 @@ describe("data-updating", () => {
         ],
       };
       diffAndUpdate(
-        { cell: testDoc, path: [] },
+        testCell.getAsCellLink(),
         newValue2,
         undefined,
         "should update the same document with ID-based entity objects",
       );
-
-      expect(testDoc.get().items[0].cell).not.toBe(newDoc);
-      expect(testDoc.get().items[0].cell.get().name).toEqual("Inserted before");
-      expect(testDoc.get().items[1].cell).toBe(newDoc);
-      expect(testDoc.get().items[1].cell.get().name).toEqual("Second Value");
+      
+      expect(isCellLink(testCell.getRaw().items[0])).toBe(true);
+      expect(isCellLink(testCell.getRaw().items[1])).toBe(true);
+      expect(testCell.getRaw().items[0].cell).not.toBe(newDoc);
+      expect(testCell.getRaw().items[0].cell.get().name).toEqual("Inserted before");
+      expect(testCell.getRaw().items[1].cell).toBe(newDoc);
+      expect(testCell.getRaw().items[1].cell.get().name).toEqual("Second Value");
     });
 
     it("should update the same document with numeric ID-based entity objects", () => {
-      const testDoc = runtime.documentMap.getDoc<any>(
-        { items: [] },
-        "should update the same document with ID-based entity objects",
+      const testCell = runtime.getCell<any>(
         space,
+        "should update the same document with ID-based entity objects",
       );
-      const current: CellLink = { cell: testDoc, path: ["items", 0] };
+      testCell.set({ items: [] });
+      const current = testCell.key("items").key(0).getAsCellLink();
 
       const newValue = { [ID]: 1, name: "First Item" };
       diffAndUpdate(
@@ -409,7 +427,7 @@ describe("data-updating", () => {
         "should update the same document with ID-based entity objects",
       );
 
-      const newDoc = testDoc.get().items[0].cell;
+      const newDoc = testCell.getRaw().items[0].cell;
 
       const newValue2 = {
         items: [
@@ -418,36 +436,36 @@ describe("data-updating", () => {
         ],
       };
       diffAndUpdate(
-        { cell: testDoc, path: [] },
+        testCell.getAsCellLink(),
         newValue2,
         undefined,
         "should update the same document with ID-based entity objects",
       );
 
-      expect(testDoc.get().items[0].cell).not.toBe(newDoc);
-      expect(testDoc.get().items[0].cell.get().name).toEqual("Inserted before");
-      expect(testDoc.get().items[1].cell).toBe(newDoc);
-      expect(testDoc.get().items[1].cell.get().name).toEqual("Second Value");
+      expect(testCell.getRaw().items[0].cell).not.toBe(newDoc);
+      expect(testCell.getRaw().items[0].cell.get().name).toEqual("Inserted before");
+      expect(testCell.getRaw().items[1].cell).toBe(newDoc);
+      expect(testCell.getRaw().items[1].cell.get().name).toEqual("Second Value");
     });
 
     it("should handle ID_FIELD redirects and reuse existing documents", () => {
-      const testDoc = runtime.documentMap.getDoc<any>(
-        { items: [] },
-        "should handle ID_FIELD redirects",
+      const testCell = runtime.getCell<any>(
         space,
+        "should handle ID_FIELD redirects",
       );
+      testCell.set({ items: [] });
 
       // Create an initial item
       const data = { id: "item1", name: "First Item" };
       addCommonIDfromObjectID(data);
       diffAndUpdate(
-        { cell: testDoc, path: ["items", 0] },
+        testCell.key("items").key(0).getAsCellLink(),
         data,
         undefined,
         "test ID_FIELD redirects",
       );
 
-      const initialDoc = testDoc.get().items[0].cell;
+      const initialDoc = testCell.getRaw().items[0].cell;
 
       // Update with another item using ID_FIELD to point to the 'id' field
       const newValue = {
@@ -459,27 +477,27 @@ describe("data-updating", () => {
       addCommonIDfromObjectID(newValue);
 
       diffAndUpdate(
-        { cell: testDoc, path: [] },
+        testCell.getAsCellLink(),
         newValue,
         undefined,
         "test ID_FIELD redirects",
       );
 
       // Verify that the second item reused the existing document
-      expect(isCellLink(testDoc.get().items[0])).toBe(true);
-      expect(isCellLink(testDoc.get().items[1])).toBe(true);
-      expect(testDoc.get().items[1].cell).toBe(initialDoc);
-      expect(testDoc.get().items[1].cell.get().name).toEqual("Updated Item");
-      expect(testDoc.get().items[0].cell.get().name).toEqual("New Item");
+      expect(isCellLink(testCell.getRaw().items[0])).toBe(true);
+      expect(isCellLink(testCell.getRaw().items[1])).toBe(true);
+      expect(testCell.getRaw().items[1].cell).toBe(initialDoc);
+      expect(testCell.getRaw().items[1].cell.get().name).toEqual("Updated Item");
+      expect(testCell.getRaw().items[0].cell.get().name).toEqual("New Item");
     });
 
     it("should treat different properties as different ID namespaces", () => {
-      const testDoc = runtime.documentMap.getDoc<any>(
-        undefined,
-        "it should treat different properties as different ID namespaces",
+      const testCell = runtime.getCell<any>(
         space,
+        "it should treat different properties as different ID namespaces",
       );
-      const current: CellLink = { cell: testDoc, path: [] };
+      testCell.set(undefined);
+      const current = testCell.getAsCellLink();
 
       const newValue = {
         a: { [ID]: "item1", name: "First Item" },
@@ -492,67 +510,67 @@ describe("data-updating", () => {
         "it should treat different properties as different ID namespaces",
       );
 
-      expect(isCellLink(testDoc.get().a)).toBe(true);
-      expect(isCellLink(testDoc.get().b)).toBe(true);
-      expect(testDoc.get().a.cell).not.toBe(testDoc.get().b.cell);
-      expect(testDoc.get().a.cell.get().name).toEqual("First Item");
-      expect(testDoc.get().b.cell.get().name).toEqual("Second Item");
+      expect(isCellLink(testCell.getRaw().a)).toBe(true);
+      expect(isCellLink(testCell.getRaw().b)).toBe(true);
+      expect(testCell.getRaw().a.cell).not.toBe(testCell.getRaw().b.cell);
+      expect(testCell.getRaw().a.cell.get().name).toEqual("First Item");
+      expect(testCell.getRaw().b.cell.get().name).toEqual("Second Item");
     });
 
     it("should return empty array when no changes", () => {
-      const testCell = runtime.documentMap.getDoc(
-        { value: 42 },
-        "normalizeAndDiff no changes",
+      const testCell = runtime.getCell<{ value: number }>(
         space,
+        "normalizeAndDiff no changes",
       );
-      const current: CellLink = { cell: testCell, path: ["value"] };
+      testCell.set({ value: 42 });
+      const current = testCell.key("value").getAsCellLink();
       const changes = normalizeAndDiff(current, 42);
 
       expect(changes.length).toBe(0);
     });
 
     it("should handle doc and cell references", () => {
-      const docA = runtime.documentMap.getDoc(
-        { name: "Doc A" },
+      const cellA = runtime.getCell<{ name: string }>(
+        space,
         "normalizeAndDiff doc reference A",
-        space,
       );
-      const docB = runtime.documentMap.getDoc(
-        { value: { name: "Original" } },
+      cellA.set({ name: "Doc A" });
+      const cellB = runtime.getCell<{ value: { name: string } }>(
+        space,
         "normalizeAndDiff doc reference B",
-        space,
       );
+      cellB.set({ value: { name: "Original" } });
 
-      const current: CellLink = { cell: docB, path: ["value"] };
-      const changes = normalizeAndDiff(current, docA);
+      const current = cellB.key("value").getAsCellLink();
+      const changes = normalizeAndDiff(current, cellA.getDoc());
 
       expect(changes.length).toBe(1);
       expect(changes[0].location).toEqual(current);
-      expect(changes[0].value).toEqual({ cell: docA, path: [] });
+      expect(changes[0].value).toEqual({ cell: cellA.getDoc(), path: [] });
     });
 
     it("should handle doc and cell references that don't change", () => {
-      const docA = runtime.documentMap.getDoc(
-        { name: "Doc A" },
+      const cellA = runtime.getCell<{ name: string }>(
+        space,
         "normalizeAndDiff doc reference no change A",
-        space,
       );
-      const docB = runtime.documentMap.getDoc(
-        { value: { name: "Original" } },
+      cellA.set({ name: "Doc A" });
+      const cellB = runtime.getCell<{ value: { name: string } }>(
+        space,
         "normalizeAndDiff doc reference no change B",
-        space,
       );
+      cellB.set({ value: { name: "Original" } });
 
-      const current: CellLink = { cell: docB, path: ["value"] };
-      const changes = normalizeAndDiff(current, docA);
+      const current = cellB.key("value").getAsCellLink();
+      const changes = normalizeAndDiff(current, cellA.getDoc());
 
       expect(changes.length).toBe(1);
       expect(changes[0].location).toEqual(current);
-      expect(changes[0].value).toEqual({ cell: docA, path: [] });
+      expect(changes[0].value).toEqual({ cell: cellA.getDoc(), path: [] });
 
       applyChangeSet(changes);
 
-      const changes2 = normalizeAndDiff(current, docA);
+      const changes2 = normalizeAndDiff(current, cellA.getDoc());
 
       expect(changes2.length).toBe(0);
     });
@@ -566,29 +584,30 @@ describe("data-updating", () => {
     });
 
     it("should reuse items", () => {
-      const itemDoc = runtime.documentMap.getDoc(
-        { id: "item1", name: "Original Item" },
+      const itemCell = runtime.getCell<{ id: string; name: string }>(
+        space,
         "addCommonIDfromObjectID reuse items",
-        space,
       );
-      const testDoc = runtime.documentMap.getDoc(
-        { items: [{ cell: itemDoc, path: [] }] },
+      itemCell.set({ id: "item1", name: "Original Item" });
+      
+      const testCell = runtime.getCell<{ items: any[] }>(
+        space,
         "addCommonIDfromObjectID arrays",
-        space,
       );
+      testCell.setRaw({ items: [{ cell: itemCell.getDoc(), path: [] }] });
 
       const data = {
-        items: [{ id: "item1", name: "New Item" }, itemDoc.asCell()],
+        items: [{ id: "item1", name: "New Item" }, itemCell],
       };
       addCommonIDfromObjectID(data);
       diffAndUpdate(
-        { cell: testDoc, path: [] },
+        testCell.getAsCellLink(),
         data,
         undefined,
         "addCommonIDfromObjectID reuse items",
       );
 
-      const result = testDoc.get();
+      const result = testCell.getRaw();
       expect(isCellLink(result.items[0])).toBe(true);
       expect(isCellLink(result.items[1])).toBe(true);
       expect(isEqualCellLink(result.items[0] as any, result.items[1] as any))

--- a/packages/runner/test/doc-map.test.ts
+++ b/packages/runner/test/doc-map.test.ts
@@ -59,7 +59,6 @@ describe("cell-map", () => {
       const id = getEntityId(cell);
       
       expect(getEntityId(cell)).toEqual(id);
-      expect(getEntityId(cell.getDoc())).toEqual(id);
       expect(getEntityId(cell.getAsQueryResult())).toEqual(id);
       expect(getEntityId(cell.getAsCellLink())).toEqual(id);
     });
@@ -101,8 +100,8 @@ describe("cell-map", () => {
       expect(retrievedCell.entityId).toEqual(c.entityId);
       expect(retrievedCell.get()).toEqual({ value: 42 });
       
-      // Also verify the underlying docs are the same
-      expect(retrievedCell.getDoc()).toBe(c.getDoc());
+      // Also verify the cells are equal
+      expect(retrievedCell.equals(c)).toBe(true);
     });
 
     it("should return undefined for non-existent entity ID", () => {
@@ -118,7 +117,12 @@ describe("cell-map", () => {
     it("should serialize the entity ID", () => {
       const c = runtime.getCell<{ value: number }>(space, "test-json");
       c.set({ value: 42 });
-      expect(JSON.stringify(c.getDoc())).toEqual(JSON.stringify(c.getDoc().entityId));
+      
+      const expected = JSON.stringify({
+        cell: c.entityId,
+        path: []
+      });
+      expect(JSON.stringify(c)).toEqual(expected);
     });
   });
 });

--- a/packages/runner/test/doc-map.test.ts
+++ b/packages/runner/test/doc-map.test.ts
@@ -54,51 +54,61 @@ describe("cell-map", () => {
     });
 
     it("should return the entity ID for a cell", () => {
-      const c = runtime.documentMap.getDoc({}, undefined, space);
-      const id = getEntityId(c);
-
-      expect(getEntityId(c)).toEqual(id);
-      expect(getEntityId(c.getAsQueryResult())).toEqual(id);
-      expect(getEntityId(c.asCell())).toEqual(id);
-      expect(getEntityId({ cell: c, path: [] })).toEqual(id);
+      const cell = runtime.getCell(space, "test-cell");
+      cell.set({});
+      const id = getEntityId(cell);
+      
+      expect(getEntityId(cell)).toEqual(id);
+      expect(getEntityId(cell.getDoc())).toEqual(id);
+      expect(getEntityId(cell.getAsQueryResult())).toEqual(id);
+      expect(getEntityId(cell.getAsCellLink())).toEqual(id);
     });
 
     it("should return a different entity ID for reference with paths", () => {
-      const c = runtime.documentMap.getDoc(
-        { foo: { bar: 42 } },
-        undefined,
+      const c = runtime.getCell<{ foo: { bar: number } }>(
         space,
+        "test-with-paths",
       );
+      c.set({ foo: { bar: 42 } });
       const id = getEntityId(c);
 
       expect(getEntityId(c.getAsQueryResult())).toEqual(id);
       expect(getEntityId(c.getAsQueryResult(["foo"]))).not.toEqual(id);
-      expect(getEntityId(c.asCell(["foo"]))).not.toEqual(id);
-      expect(getEntityId({ cell: c, path: ["foo"] })).not.toEqual(id);
+      expect(getEntityId(c.key("foo"))).not.toEqual(id);
+      expect(getEntityId(c.key("foo").getAsCellLink())).not.toEqual(id);
 
       expect(getEntityId(c.getAsQueryResult(["foo"]))).toEqual(
-        getEntityId(c.asCell(["foo"])),
+        getEntityId(c.key("foo")),
       );
       expect(getEntityId(c.getAsQueryResult(["foo"]))).toEqual(
-        getEntityId({ cell: c, path: ["foo"] }),
+        getEntityId(c.key("foo").getAsCellLink()),
       );
     });
   });
 
   describe("getCellByEntityId and setCellByEntityId", () => {
     it("should set and get a cell by entity ID", () => {
-      const c = runtime.documentMap.getDoc({ value: 42 }, undefined, space);
+      const c = runtime.getCell<{ value: number }>(space, "test-by-entity-id");
+      c.set({ value: 42 });
 
-      const retrievedCell = runtime.documentMap.getDocByEntityId(
-        c.space,
+      // Use Cell API to retrieve by entity ID
+      const retrievedCell = runtime.getCellFromEntityId<{ value: number }>(
+        space,
         c.entityId!,
       );
 
-      expect(retrievedCell).toBe(c);
+      // Verify we got the same cell
+      expect(retrievedCell.entityId).toEqual(c.entityId);
+      expect(retrievedCell.get()).toEqual({ value: 42 });
+      
+      // Also verify the underlying docs are the same
+      expect(retrievedCell.getDoc()).toBe(c.getDoc());
     });
 
     it("should return undefined for non-existent entity ID", () => {
       const nonExistentId = createRef() as EntityId;
+      // Note: We must use getDocByEntityId directly here because getCellFromEntityId
+      // always creates a new doc if not found (createIfNotFound: true)
       expect(runtime.documentMap.getDocByEntityId(space, nonExistentId, false))
         .toBeUndefined();
     });
@@ -106,8 +116,9 @@ describe("cell-map", () => {
 
   describe("cells as JSON", () => {
     it("should serialize the entity ID", () => {
-      const c = runtime.documentMap.getDoc({ value: 42 }, "cause", space);
-      expect(JSON.stringify(c)).toEqual(JSON.stringify(c.entityId));
+      const c = runtime.getCell<{ value: number }>(space, "test-json");
+      c.set({ value: 42 });
+      expect(JSON.stringify(c.getDoc())).toEqual(JSON.stringify(c.getDoc().entityId));
     });
   });
 });

--- a/packages/runner/test/query.test.ts
+++ b/packages/runner/test/query.test.ts
@@ -13,23 +13,14 @@ import type {
   State,
 } from "@commontools/memory/interface";
 import type { Entity } from "@commontools/memory/interface";
-import type { EntityId } from "../src/doc-map.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 import { Identity } from "@commontools/identity";
 import { ClientObjectManager } from "../src/storage/query.ts";
+import { entityIdToJSON } from "./test-helpers.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
-
-// Helper to convert EntityId to JSON representation for use in CellLinks
-function entityIdToJSON(entityId: EntityId): { "/": string } {
-  if (entityId.toJSON) {
-    return entityId.toJSON();
-  }
-  // Fallback: construct the object manually
-  return { "/": entityId["/"].toString() };
-}
 
 describe("Query", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;

--- a/packages/runner/test/query.test.ts
+++ b/packages/runner/test/query.test.ts
@@ -13,6 +13,7 @@ import type {
   State,
 } from "@commontools/memory/interface";
 import type { Entity } from "@commontools/memory/interface";
+import type { EntityId } from "../src/doc-map.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 import { Identity } from "@commontools/identity";
@@ -20,6 +21,15 @@ import { ClientObjectManager } from "../src/storage/query.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
+
+// Helper to convert EntityId to JSON representation for use in CellLinks
+function entityIdToJSON(entityId: EntityId): { "/": string } {
+  if (entityId.toJSON) {
+    return entityId.toJSON();
+  }
+  // Fallback: construct the object manually
+  return { "/": entityId["/"].toString() };
+}
 
 describe("Query", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
@@ -52,39 +62,39 @@ describe("Query", () => {
     const docValue1 = {
       employees: [{ fulllName: { first: "Bob", last: "Hope" } }],
     };
-    const testDoc1 = runtime.documentMap.getDoc<
+    const testCell1 = runtime.getCell<
       { employees: { fulllName: { first: string } }[] }
     >(
-      docValue1,
-      `query test cell 1`,
       space,
+      `query test cell 1`,
     );
-    const entityId1 = testDoc1.entityId.toJSON!();
+    testCell1.set(docValue1);
+    const entityId1 = testCell1.entityId!;
     const assert1 = {
       the: "application/json",
       of: `of:${entityId1["/"]}` as Entity,
-      is: { value: testDoc1.value },
+      is: { value: testCell1.get() },
       cause: refer({ the: "application/json", of: `of:${entityId1["/"]}` }),
       since: 1,
     };
     const docValue2 = {
       name: {
-        cell: entityId1,
+        cell: entityIdToJSON(entityId1),
         path: ["employees", "0", "fullName"],
       },
     };
-    const testDoc2 = runtime.documentMap.getDoc<
+    const testCell2 = runtime.getCell<
       { name: { cell: { ["/"]: string }; path: string[] } }
     >(
-      docValue2,
-      `query test cell 2`,
       space,
+      `query test cell 2`,
     );
-    const entityId2 = testDoc2.entityId.toJSON!();
+    testCell2.setRaw(docValue2);
+    const entityId2 = testCell2.entityId!;
     const assert2 = {
       the: "application/json",
       of: `of:${entityId2["/"]}` as Entity,
-      is: { value: testDoc2.value },
+      is: { value: testCell2.getRaw() },
       cause: refer({ the: "application/json", of: `of:${entityId2["/"]}` }),
       since: 2,
     };
@@ -143,38 +153,38 @@ describe("Query", () => {
   });
 
   it("should handle true schema", () => {
-    const testDoc1 = runtime.documentMap.getDoc<
+    const testCell1 = runtime.getCell<
       { employees: { name: { first: string } }[] }
     >(
-      { employees: [{ name: { first: "Bob" } }] },
-      `query test cell 1`,
       space,
+      `query test cell 1`,
     );
-    const entityId1 = testDoc1.entityId.toJSON!();
+    testCell1.set({ employees: [{ name: { first: "Bob" } }] });
+    const entityId1 = testCell1.entityId!;
     const assert1 = {
       the: "application/json",
       of: `of:${entityId1["/"]}` as Entity,
-      is: { value: testDoc1.value },
+      is: { value: testCell1.get() },
       cause: refer({ the: "application/json", of: `of:${entityId1["/"]}` }),
       since: 1,
     };
-    const testDoc2 = runtime.documentMap.getDoc<
+    const testCell2 = runtime.getCell<
       { name: { cell: { ["/"]: string }; path: string[] } }
     >(
-      {
-        name: {
-          cell: entityId1,
-          path: ["employees", "0", "name"],
-        },
-      },
-      `query test cell 2`,
       space,
+      `query test cell 2`,
     );
-    const entityId2 = testDoc2.entityId.toJSON!();
+    testCell2.setRaw({
+      name: {
+        cell: entityIdToJSON(entityId1),
+        path: ["employees", "0", "name"],
+      },
+    });
+    const entityId2 = testCell2.entityId!;
     const assert2 = {
       the: "application/json",
       of: `of:${entityId2["/"]}` as Entity,
-      is: { value: testDoc2.value },
+      is: { value: testCell2.getRaw() },
       cause: refer({ the: "application/json", of: `of:${entityId2["/"]}` }),
       since: 2,
     };
@@ -236,26 +246,26 @@ describe("Query", () => {
       },
     } as const satisfies JSONSchema;
     // Now we make the doc with the cycle
-    const testDoc1 = runtime.documentMap.getDoc<
+    const testCell1 = runtime.getCell<
       { name: { cell: { ["/"]: string }; path: string[] } }
     >(
-      {
-        name: {
-          cell: { "/": "<placeholder>" },
-          path: ["name"],
-        },
-      },
-      `query test cell 1`,
       space,
+      `query test cell 1`,
     );
-    const entityId1 = testDoc1.entityId.toJSON!();
+    testCell1.setRaw({
+      name: {
+        cell: { "/": "<placeholder>" },
+        path: ["name"],
+      },
+    });
+    const entityId1 = testCell1.entityId!;
     const assert1 = {
       the: "application/json",
       of: `of:${entityId1["/"]}` as Entity,
       is: {
         value: {
           name: {
-            cell: entityId1,
+            cell: entityIdToJSON(entityId1),
             path: ["name"],
           },
         },
@@ -300,30 +310,30 @@ describe("Query", () => {
 
   it("should handle paths in schema and cell links", () => {
     const docValue1 = { home: { street: "1 Infinite Loop" } };
-    const testDoc1 = runtime.documentMap.getDoc<
+    const testCell1 = runtime.getCell<
       { home: { street: string } }
     >(
-      docValue1,
-      `query test cell 1`,
       space,
+      `query test cell 1`,
     );
-    const entityId1 = testDoc1.entityId.toJSON!();
+    testCell1.set(docValue1);
+    const entityId1 = testCell1.entityId!;
     const assert1 = {
       the: "application/json",
       of: `of:${entityId1["/"]}` as Entity,
-      is: { value: testDoc1.value },
+      is: { value: testCell1.get() },
       cause: refer({ the: "application/json", of: `of:${entityId1["/"]}` }),
       since: 1,
     };
 
     const docValue2 = {
-      employees: [{ address: { cell: entityId1, path: ["home"] } }],
+      employees: [{ address: { cell: entityIdToJSON(entityId1), path: ["home"] } }],
     };
-    const testDoc2 = runtime.documentMap.getDoc<any>(
-      docValue2,
-      `query test cell 2`,
+    const testCell2 = runtime.getCell<any>(
       space,
+      `query test cell 2`,
     );
+    testCell2.setRaw(docValue2);
 
     const schema = { "type": "string" } as const satisfies JSONSchema;
     const selector = {
@@ -334,11 +344,11 @@ describe("Query", () => {
       },
     };
 
-    const entityId2 = testDoc2.entityId.toJSON!();
+    const entityId2 = testCell2.entityId!;
     const assert2 = {
       the: "application/json",
       of: `of:${entityId2["/"]}` as Entity,
-      is: { value: testDoc2.value },
+      is: { value: testCell2.getRaw() },
       cause: refer({ the: "application/json", of: `of:${entityId2["/"]}` }),
       since: 2,
     };

--- a/packages/runner/test/test-helpers.ts
+++ b/packages/runner/test/test-helpers.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "@std/assert";
 import { AssertionError } from "@std/assert";
 import { isAlias } from "../src/builder/types.ts";
 import { isCellLink } from "../src/cell.ts";
+import type { EntityId } from "../src/doc-map.ts";
 
 /**
  * Normalizes CellLinks by keeping only cell and path properties
@@ -76,4 +77,24 @@ export function expectCellLinksEqual(actual: unknown) {
       }
     }
   };
+}
+
+/**
+ * Helper to convert objects with toJSON methods to plain objects
+ * Useful for test expectations that need to compare serialized forms
+ */
+export function toPlainObject<T>(obj: T): any {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+/**
+ * Helper to convert EntityId to JSON representation
+ * Handles EntityId objects that may or may not have toJSON method
+ */
+export function entityIdToJSON(entityId: EntityId): { "/": string } {
+  if (entityId.toJSON) {
+    return entityId.toJSON();
+  }
+  // Fallback: construct the object manually
+  return { "/": entityId["/"].toString() };
 }

--- a/packages/runner/test/test-helpers.ts
+++ b/packages/runner/test/test-helpers.ts
@@ -7,7 +7,7 @@ import { isCellLink } from "../src/cell.ts";
  * Normalizes CellLinks by keeping only cell and path properties
  * Also normalizes path elements so numeric strings and numbers are equivalent
  */
-function normalizeCellLink(link: any): any {
+export function normalizeCellLink(link: any): any {
   // Normalize path elements: convert numeric strings to numbers for comparison
   const normalizedPath = link.path.map((element: any) => {
     // If it's a string that represents a valid array index, convert to number

--- a/packages/runner/test/test-helpers.ts
+++ b/packages/runner/test/test-helpers.ts
@@ -5,9 +5,19 @@ import { isCellLink } from "../src/cell.ts";
 
 /**
  * Normalizes CellLinks by keeping only cell and path properties
+ * Also normalizes path elements so numeric strings and numbers are equivalent
  */
 function normalizeCellLink(link: any): any {
-  return { cell: link.cell, path: link.path };
+  // Normalize path elements: convert numeric strings to numbers for comparison
+  const normalizedPath = link.path.map((element: any) => {
+    // If it's a string that represents a valid array index, convert to number
+    if (typeof element === 'string' && /^\d+$/.test(element)) {
+      return parseInt(element, 10);
+    }
+    return element;
+  });
+  
+  return { cell: link.cell, path: normalizedPath };
 }
 
 /**


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Replaced all uses of the old docimpl API in test files with the new cell API for creating and managing test data.

- **Refactors**
  - Updated tests to use runtime.getCell instead of runtime.documentMap.getDoc.
  - Adjusted test helpers and assertions to work with the new cell structure.

<!-- End of auto-generated description by cubic. -->

