### PR TITLE
Feat/include recipe

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -34,6 +34,15 @@ jobs:
       - name: 🔎 Type check codebase
         run: deno task check
 
+      - name: 🔎 Check derived artifacts
+        working-directory: packages/static
+        run: |
+          deno task compile-api-types
+          if ! git diff --quiet . ; then
+            echo "Run 'deno task compile-api-types' inside the 'static' package."
+            exit 1
+          fi
+
       - name: 🧹 Lint codebase
         run: deno lint
 
@@ -171,7 +180,7 @@ jobs:
           # Copy to signed directory
           cp ./dist/bg-charm-service ./signed/
           cp ./dist/bg-charm-service.sig ./signed/
-          
+
           # Process ct binary
           echo "Processing binary: ct"
           sha256sum ./dist/ct > ./dist/ct.hash.txt
@@ -211,7 +220,7 @@ jobs:
         with:
           subject-name: ./dist/bg-charm-service
           subject-digest: sha256:${{ steps.binary_processing.outputs.bg_charm_service_hash }}
-      
+
       - name: 📝 Generate attestation for ct binary
         if: github.ref == 'refs/heads/main'
         id: attest_ct
@@ -277,7 +286,7 @@ jobs:
             echo -e "\033[31m✗ bg-charm-service attestation verification failed\033[0m"
             exit 1
           fi
-          
+
           # Verify ct binary attestation
           echo "::group::ct attestation details"
           gh attestation verify ./dist/ct -R ${{ github.repository }} --format json | jq

--- a/docs/future-tasks/unified-storage-stack.md
+++ b/docs/future-tasks/unified-storage-stack.md
@@ -194,6 +194,8 @@ This plan should be entirely incremental and can be rolled out step by step.
         and `.updates()` calls on `DocImpl`.
   - [ ] `Cell.sink()` creates a (read-only) transaction, which might be nested.
         Very similar to the current `ReactivityLog`.
+  - [ ] `Cell.freeze()` makes cell read-only
+  - [ ] `Cell.ephemeral` whether cell is persisted
   - [ ] When cells are being created, active transactions are being passed in,
         just like `log` now. Change `withLog()` to `withTX()` or so. When there
         is no TX associated on a read, create one. Don't allow writes without a

--- a/packages/charm/src/index.ts
+++ b/packages/charm/src/index.ts
@@ -4,6 +4,7 @@ export {
   charmListSchema,
   CharmManager,
   charmSchema,
+  getRecipeIdFromCharm,
   processSchema,
 } from "./manager.ts";
 export { searchCharms } from "./search.ts";

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -272,15 +272,13 @@ function loadFactsForDoc(
       // We don't actually use the return value here, but we've built up
       // a list of all the documents we need to watch.
       traverser.traverse(newDoc);
-
-      // Also load any source links
-      loadSource(manager, fact, new Set<string>(), schemaTracker);
     } else {
       // If we didn't provide a schema context, we still want the selected
       // object in our manager, so load it directly.
       manager.load(factAddress);
-      loadSource(manager, fact, new Set<string>(), schemaTracker);
     }
+    // Also load any source links and recipes
+    loadSource(manager, fact, new Set<string>(), schemaTracker);
   }
 }
 

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -102,6 +102,10 @@ export type JSONSchema = {
     readonly minProperties?: number;
     readonly required?: readonly string[];
     readonly dependentRequired?: Readonly<Record<string, readonly string[]>>;
+    readonly format?: string;
+    readonly contentEncoding?: string;
+    readonly contentMediaType?: string;
+    readonly contentSchema?: JSONSchema | boolean;
     readonly title?: string;
     readonly description?: string;
     readonly default?: Readonly<JSONValue>;

--- a/packages/static/scripts/compile-api-types.sh
+++ b/packages/static/scripts/compile-api-types.sh
@@ -7,5 +7,6 @@ SOURCE=../api/index.ts
 OUT=../api/index.d.ts
 STATIC=./assets/types/commontools.d.ts
 
-deno run -A npm:typescript/tsc $SOURCE --declaration --emitDeclarationOnly
+# When running in CI, we need to specific libs
+deno run -A npm:typescript/tsc $SOURCE --declaration --emitDeclarationOnly --lib esnext,dom
 mv $OUT $STATIC

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -3,7 +3,6 @@
 import { parseArgs } from "@std/cli/parse-args";
 import { CharmManager, compileRecipe } from "@commontools/charm";
 import {
-  entityIdStr,
   getEntityId,
   isStream,
   type MemorySpace,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for editing and saving regular recipes in the Charm detail view, and improved backend logic to load linked recipes alongside source cells.

- **New Features**
  - Users can now view and edit regular recipe code directly in the UI.
  - Save button added for regular recipes with live update and navigation.

- **Refactors**
  - Backend now loads linked recipes when loading documents, ensuring all dependencies are available.
  - Improved server subscription tracking to avoid redundant queries.

<!-- End of auto-generated description by cubic. -->

