### PR TITLE
Change to use examples instead of the older example in JSONSchema

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -78,7 +78,8 @@
     "proseWrap": "always",
     "exclude": [
       "packages/jumble/integration/cache/llm-api-cache/",
-      "packages/seeder/templates/"
+      "packages/seeder/templates/",
+      "packages/static/assets/"
     ]
   },
   "imports": {

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -148,8 +148,6 @@ export type JSONSchemaTypes =
 export type JSONSchema = {
   readonly $ref?: string;
   readonly $defs?: Readonly<Record<string, JSONSchema>>;
-  // TODO(@ubik2): I think this should be removed (use "examples")
-  readonly example?: Readonly<JSONValue>;
 
   // Subschema logic
   readonly allOf?: readonly (JSONSchema | boolean)[]; // not validated

--- a/packages/jumble/src/components/commands.ts
+++ b/packages/jumble/src/components/commands.ts
@@ -183,7 +183,7 @@ async function handleExecuteCharmAction(ctx: CommandContext) {
 
     // Create options for the select menu with key as the action name
     const actionOptions = actions.map(([key, stream]) => {
-      const example = JSON.stringify(charm.key(key).schema?.example);
+      const [example] = JSON.stringify(charm.key(key).schema?.examples) ?? [];
       return {
         id: key,
         title: key,

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -66,7 +66,6 @@ export type JSONSchemaTypes = "object" | "array" | "string" | "integer" | "numbe
 export type JSONSchema = {
     readonly $ref?: string;
     readonly $defs?: Readonly<Record<string, JSONSchema>>;
-    readonly example?: Readonly<JSONValue>;
     readonly allOf?: readonly (JSONSchema | boolean)[];
     readonly anyOf?: readonly JSONSchema[];
     readonly oneOf?: readonly (JSONSchema | boolean)[];

--- a/recipes/link-list.tsx
+++ b/recipes/link-list.tsx
@@ -52,7 +52,7 @@ const ResultSchema = {
       properties: {
         title: { type: "string" },
       },
-      example: { title: "New item" },
+      examples: [{ title: "New item" }],
       required: ["title"],
     },
   },

--- a/recipes/list.tsx
+++ b/recipes/list.tsx
@@ -46,7 +46,7 @@ const ResultSchema = {
       properties: {
         title: { type: "string" },
       },
-      example: { title: "New item" },
+      examples: [{ title: "New item" }],
       required: ["title"],
     },
     "/action/drop/schema": { type: "object" },

--- a/recipes/simpleValue.tsx
+++ b/recipes/simpleValue.tsx
@@ -1,6 +1,6 @@
 import {
-  h,
   derive,
+  h,
   handler,
   type JSONSchema,
   NAME,
@@ -17,7 +17,7 @@ const updaterSchema = {
   },
   title: "Update Values",
   description: "Append `newValues` to the list.",
-  example: { newValues: ["foo", "bar"] },
+  examples: [{ newValues: ["foo", "bar"] }],
   default: { newValues: [] },
 } as const satisfies JSONSchema;
 

--- a/recipes/todo-list.tsx
+++ b/recipes/todo-list.tsx
@@ -1,6 +1,6 @@
 import {
-  h,
   derive,
+  h,
   handler,
   JSONSchema,
   NAME,
@@ -46,7 +46,7 @@ const ResultSchema = {
       properties: {
         title: { type: "string" },
       },
-      example: { title: "New item" },
+      examples: [{ title: "New item" }],
       required: ["title"],
     },
     "/action/drop/schema": { type: "object" },


### PR DESCRIPTION
I also marked the static assets folder excluded by `deno fmt` formatting.
Possibly, we should still allow the `example` property, but I wanted to be more compliant with the current version of the standard.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced the deprecated "example" field with the "examples" array in JSONSchema definitions across the codebase. This updates schemas to follow the latest JSONSchema standards.

<!-- End of auto-generated description by cubic. -->

