### PR TITLE
chore: Remove stdin from 'ct charm new' command

### DIFF
--- a/packages/cli/commands/charm.ts
+++ b/packages/cli/commands/charm.ts
@@ -94,7 +94,6 @@ export const charm = new Command()
         await newCharm(
           parseSpaceOptions(options),
           absPath(entryPath),
-          await drainStdin(),
         ),
       ),
   )

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -31,7 +31,7 @@ if [ "$(ct charm ls $SPACE_ARGS)" != "" ]; then
 fi
 
 # Create a new charm with {value:5} as input
-CHARM_ID=$(echo '{"value":5}' | ct charm new $SPACE_ARGS $RECIPE_SRC)
+CHARM_ID=$(ct charm new $SPACE_ARGS $RECIPE_SRC)
 echo "Created charm: $CHARM_ID"
 
 # Retrieve the source code for $CHARM_ID to $WORK_DIR
@@ -55,6 +55,9 @@ grep -q "Simple counter 2" "$WORK_DIR/main.tsx"
 if [ $? -ne 0 ]; then
   error "Retrieved source code was not modified"
 fi
+
+# Apply new input to charm
+echo '{"value":5}' | ct charm apply $SPACE_ARGS --charm $CHARM_ID
 
 # Check space has new charm with correct inputs and title
 TITLE="Simple counter 2: 5"

--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -163,11 +163,10 @@ export async function listCharms(
 export async function newCharm(
   config: SpaceConfig,
   entryPath: string,
-  input: object | undefined,
 ): Promise<string> {
   const manager = await loadManager(config);
   const recipe = await getRecipeFromFile(manager, entryPath);
-  const charm = await exec({ manager, recipe, input });
+  const charm = await exec({ manager, recipe });
   return getCharmId(charm);
 }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed support for passing input via stdin to the 'ct charm new' command. Input should now be provided using 'ct charm apply' after creating a charm.

<!-- End of auto-generated description by cubic. -->

