### PR TITLE
Add `ct charm link` command [CT-490]

### DIFF
--- a/.claude/commands/setup-space.md
+++ b/.claude/commands/setup-space.md
@@ -1,47 +1,178 @@
-Using `scripts/main.ts` we can create recipes and network them together in a space.
+# Interactive Space Setup Script
 
-Each space has a unique <SPACENAME> and every recipe has a unique cause it is created against. The <RECIPE_PATH> folder where recipes are stored may vary based on the user, ask them before beginning space setup. You will have to kill these shell commands once the output is complete.
+This script guides Claude through setting up a complete space with the `ct` utility. Claude should follow these steps to interactively help the user set up recipes and network them together in a space.
 
-Note: It's possible the user will point you at the wrong folder for recipes, if there is a subfolder in the passed folder called recipes that it probably the correct choice.
+## Script Flow for Claude
 
-```sh
-deno run --allow-all scripts/main.ts --spaceName <SPACENAME> --cause gmail --recipeFile <RECIPE_PATH>/coralreef/gmail.tsx --quit
-```
+### STEP 1: Initial Setup Check and Preparation
 
-When a recipe starts, it prints out its ID in the log. That ID can be used to network recipes together. e.g. if our above gmail recipe's ID is `baedreigjit5dhi5aogyxb5wqolep3m6cu7mbu4b5u7uk2c5o4k7brj2u2q` then:
+**Check if user is in the right directory:**
+- Run `pwd` to see current directory
+- If not in `labs`, ask user to `cd` to the labs directory
 
-```sh
-deno run --allow-all scripts/main.ts --spaceName <SPACENAME> --cause email-list --recipeFile <RECIPE_PATH>/email-list.tsx --input '{"emails": @#baedreigjit5dhi5aogyxb5wqolep3m6cu7mbu4b5u7uk2c5o4k7brj2u2q/emails }' --quit
-```
+**Check CT binary:**
+- Run `ls -la ./dist/ct`
+- If missing: Run `deno task build-binaries --cli-only` (this takes a few minutes)
+- Verify with `./dist/ct --help`
 
-Creates a list attached to the gmail recipe's data.
+**Check for identity keyfile:**
+- Run `ls -la *.key`
+- If no keyfiles found: Run `./dist/ct id new > space-identity.key`
+- If keyfiles exist, ask user which one to use or create a new one
 
-You will need to also create the `all-lists` and `all-pages` recipes. This is linked to the well-known ID of the `charms` list in any space `baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye`.
+**Set up environment (recommend but don't require):**
+- Ask if they want to set environment variables to make commands shorter
+- If yes: Guide them to set `CT_API_URL="[their-api-url]"` and `CT_IDENTITY="./their-keyfile.key"`
 
-```sh
-deno run --allow-all scripts/main.ts --spaceName <SPACENAME> --cause all-lists --recipeFile <RECIPE_PATH>/all-lists.tsx --input '{ "allCharms": @#baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye }' --quit
-```
+### STEP 2: Gather Parameters
 
-```sh
-deno run --allow-all scripts/main.ts --spaceName <SPACENAME> --cause all-pages --recipeFile <RECIPE_PATH>/all-pages.tsx --input '{ "allCharms": @#baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye }' --quit
-```
+**Get API URL:**
+- Ask user: "What is your CT API URL? (e.g., https://ct.dev, https://toolshed.saga-castor.ts.net/, or your custom instance)"
+- Store as variable for all commands
+- Test connectivity: `./dist/ct charm ls --identity [keyfile] --api-url [user-api-url] --space test-connection` (this might fail but shows if URL works)
 
-You can then add custom lists:
+**Get space name:**
+- Ask user what they want to name their space (no spaces, lowercase recommended)
+- Store as variable for commands
 
-```sh
-deno run --allow-all scripts/main.ts --spaceName <SPACENAME> --cause list-1 --recipeFile <RECIPE_PATH>/list.tsx --quit
-```
+**Find recipe path (recipes are in a separate repo, not in labs):**
+- Ask user: "Where is your recipe repository located? Please provide the full path (e.g., /Users/username/my-recipes or ../my-recipe-repo)"
+- User will need to provide the path to their recipe repository
+- Once they provide a path, verify it exists: `ls -la [user-provided-path]`
+- Look for recipe files in their repo: `find [user-provided-path] -name "*.tsx" | head -10`
+- Look specifically for key recipes: `find [user-provided-path] -name "*gmail*" -o -name "*email*" -o -name "*list*" | head -5`
+- Verify key recipes exist: `ls -la [user-provided-path]/coralreef/gmail.tsx` (or find where gmail.tsx is located)
+- If recipes are in a subfolder, help them find the right path: `find [user-provided-path] -name "recipes" -type d`
 
-Or pages:
+### STEP 3: Execute Space Setup Workflow
 
-```sh
-deno run --allow-all scripts/main.ts --spaceName <SPACENAME> --cause page-1 --recipeFile <RECIPE_PATH>/page.tsx --quit
-```
+**For each step below, Claude should:**
+1. Explain what we're doing
+2. Run the command
+3. Capture and show the charm ID from output
+4. Verify the operation worked
+5. Store charm IDs for later linking
 
-And finally, you can configure the page manager:
+**Create gmail charm:**
+- Run: `./dist/ct charm new --identity [keyfile] --api-url [api-url] --space [spacename] [recipe-path]/coralreef/gmail.tsx`
+- Extract and record the GMAIL_CHARM_ID from output
+- Verify: `./dist/ct charm ls --identity [keyfile] --api-url [api-url] --space [spacename]`
 
-```sh
-deno run --allow-all scripts/main.ts --spaceName <SPACE> --cause page-man-1 --recipeFile <RECIPE_PATH>/page-manager.tsx --input '{ "lists": @#<ALL_LISTS_ID>/lists, "pages": @#<ALL_PAGES_ID>/pages }' --quit
-```
+**Create email-list charm:**
+- Verify recipe exists: `ls -la [recipe-path]/email-list.tsx`
+- Run: `./dist/ct charm new --identity [keyfile] --api-url [api-url] --space [spacename] [recipe-path]/email-list.tsx`
+- Record EMAIL_LIST_CHARM_ID
+- Link: `./dist/ct charm link --identity [keyfile] --api-url [api-url] --space [spacename] [GMAIL_CHARM_ID]/emails [EMAIL_LIST_CHARM_ID]/emails`
 
-Optionally, you can offer to set up any other recipes in the folder for the user.
+**Create all-lists charm:**
+- Verify recipe exists: `ls -la [recipe-path]/all-lists.tsx`
+- Run: `./dist/ct charm new --identity [keyfile] --api-url [api-url] --space [spacename] [recipe-path]/all-lists.tsx`
+- Record ALL_LISTS_CHARM_ID
+- Link to well-known charms list: `./dist/ct charm link --identity [keyfile] --api-url [api-url] --space [spacename] baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye [ALL_LISTS_CHARM_ID]/allCharms`
+
+**Create all-pages charm:**
+- Verify recipe exists: `ls -la [recipe-path]/all-pages.tsx`
+- Run: `./dist/ct charm new --identity [keyfile] --api-url [api-url] --space [spacename] [recipe-path]/all-pages.tsx`
+- Record ALL_PAGES_CHARM_ID
+- Link to well-known charms list: `./dist/ct charm link --identity [keyfile] --api-url [api-url] --space [spacename] baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye [ALL_PAGES_CHARM_ID]/allCharms`
+
+**Create custom list charm:**
+- Verify recipe exists: `ls -la [recipe-path]/list.tsx`
+- Run: `./dist/ct charm new --identity [keyfile] --api-url [api-url] --space [spacename] [recipe-path]/list.tsx`
+- Record LIST_CHARM_ID
+
+**Create custom page charm:**
+- Verify recipe exists: `ls -la [recipe-path]/page.tsx`
+- Run: `./dist/ct charm new --identity [keyfile] --api-url [api-url] --space [spacename] [recipe-path]/page.tsx`
+- Record PAGE_CHARM_ID
+
+**Create page manager charm:**
+- Verify recipe exists: `ls -la [recipe-path]/page-manager.tsx`
+- Run: `./dist/ct charm new --identity [keyfile] --api-url [api-url] --space [spacename] [recipe-path]/page-manager.tsx`
+- Record PAGE_MANAGER_CHARM_ID
+- Link lists: `./dist/ct charm link --identity [keyfile] --api-url [api-url] --space [spacename] [ALL_LISTS_CHARM_ID]/lists [PAGE_MANAGER_CHARM_ID]/lists`
+- Link pages: `./dist/ct charm link --identity [keyfile] --api-url [api-url] --space [spacename] [ALL_PAGES_CHARM_ID]/pages [PAGE_MANAGER_CHARM_ID]/pages`
+
+### STEP 4: Final Verification and Optional Setup
+
+**Show final space:**
+- Run: `./dist/ct charm ls --identity [keyfile] --api-url [api-url] --space [spacename]`
+- Explain what each charm does
+
+**Offer additional recipes:**
+- Run: `find [recipe-path] -name "*.tsx" -type f`
+- Ask user if they want to deploy any additional recipes
+- For each additional recipe: verify, create charm, ask about linking needs
+
+### Error Handling
+
+**If any command fails:**
+- Show the error
+- Check common issues (file permissions, network, file existence)
+- Offer solutions or ask user for clarification
+- Don't continue to dependent steps until current step works
+
+**If recipe files are missing:**
+- Ask user to double-check the recipe repository path
+- Help user locate them: `find [user-provided-path] -name "*.tsx" -type f`
+- Look in common subdirectories: `find [user-provided-path] -name "recipes" -type d`
+- Ask user to provide the correct path to their recipe repository
+- Verify files exist before proceeding: `ls -la [corrected-path]/gmail.tsx`
+
+**If charm creation fails:**
+- Test recipe syntax with `./dist/ct dev [recipe] --no-run`
+- Check network connectivity
+- Verify identity file permissions
+
+### Notes for Claude
+
+- Always run commands and show real output to user
+- Extract and track charm IDs as you go (they start with "bafy")
+- Verify each step worked before proceeding
+- Be helpful if user needs to troubleshoot
+- Ask questions when paths or parameters are unclear
+- Keep track of what's been created to avoid duplicates
+
+### Important: External Recipe Repository Handling
+
+- **Recipes are NOT in the labs repo** - they are in a separate repository
+- **Always ask user for the full path** to their recipe repository first
+- **Example paths might be:**
+  - `/Users/username/my-recipes`
+  - `../my-recipe-repo` 
+  - `/home/user/projects/recipe-collection`
+- **Validate the path exists** before proceeding: `ls -la [user-path]`
+- **Find recipes in their repo** with: `find [user-path] -name "*.tsx" | head -10`
+- **Use full paths in all ct commands** - don't assume recipes are local to labs
+- **If user gives wrong path**, help them find the right location with find commands
+
+## Reference Information for Claude
+
+### Key Commands Claude Will Use:
+- `./dist/ct charm new --identity [keyfile] --api-url [api-url] --space [spacename] [recipe-path]` - Create charm
+- `./dist/ct charm link --identity [keyfile] --api-url [api-url] --space [spacename] [source]/[field] [target]/[field]` - Link charms
+- `./dist/ct charm ls --identity [keyfile] --api-url [api-url] --space [spacename]` - List charms
+- `./dist/ct charm view --identity [keyfile] --api-url [api-url] --space [spacename] --charm [id]` - View charm details
+
+### Expected Workflow:
+1. Gmail charm → extract emails field
+2. Email-list charm → link to gmail/emails  
+3. All-lists charm → link to well-known charms list (baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye)
+4. All-pages charm → link to well-known charms list
+5. Custom list charm → standalone
+6. Custom page charm → standalone  
+7. Page manager charm → link to all-lists/lists and all-pages/pages
+
+### Well-Known IDs:
+- Charms list in any space: `baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye`
+
+### Troubleshooting for Claude:
+- If commands fail, check file existence first
+- Charm IDs start with "bafy" and are long content hashes
+- Recipe files are .tsx files in a separate repository (not in labs)
+- Users must provide the full path to their recipe repository
+- Users must provide their CT API URL (not always https://ct.dev)
+- Environment variables CT_API_URL and CT_IDENTITY can simplify commands
+- Test recipes with `./dist/ct dev [full-path-to-recipe] --no-run` if there are issues
+- Always use absolute paths or full relative paths to the external recipe repo
+- If API connection fails, verify the URL is correct and accessible

--- a/packages/cli/commands/charm.ts
+++ b/packages/cli/commands/charm.ts
@@ -152,36 +152,50 @@ export const charm = new Command()
     `ct charm link ${EX_ID} ${EX_COMP} bafycharm1/outputEmails bafycharm2/emails`,
     `Link outputEmails field from charm "bafycharm1" to emails field in charm "bafycharm2".`,
   )
+  .example(
+    `ct charm link ${EX_ID} ${EX_COMP} bafycharm1/data/users/0/email bafycharm2/config/primaryEmail`,
+    `Link deep nested field including array access.`,
+  )
   .arguments("<source:string> <target:string>")
   .action(async (options, sourceRef, targetRef) => {
     const spaceConfig = parseSpaceOptions(options);
     
-    // Parse source reference (charmId/field)
+    // Parse source reference (charmId/path/to/field)
     const sourceParts = sourceRef.split("/");
-    if (sourceParts.length !== 2) {
+    if (sourceParts.length < 2) {
       throw new ValidationError(
-        `Invalid source reference format. Expected: charmId/fieldName`,
+        `Invalid source reference format. Expected: charmId/path/to/field`,
         { exitCode: 1 },
       );
     }
-    const [sourceCharmId, sourceField] = sourceParts;
+    const sourceCharmId = sourceParts[0];
+    const sourcePath = sourceParts.slice(1).map(segment => {
+      // Check if segment is a number (array index)
+      const index = parseInt(segment, 10);
+      return isNaN(index) ? segment : index;
+    });
     
-    // Parse target reference (charmId/field)
+    // Parse target reference (charmId/path/to/field)
     const targetParts = targetRef.split("/");
-    if (targetParts.length !== 2) {
+    if (targetParts.length < 2) {
       throw new ValidationError(
-        `Invalid target reference format. Expected: charmId/fieldName`,
+        `Invalid target reference format. Expected: charmId/path/to/field`,
         { exitCode: 1 },
       );
     }
-    const [targetCharmId, targetField] = targetParts;
+    const targetCharmId = targetParts[0];
+    const targetPath = targetParts.slice(1).map(segment => {
+      // Check if segment is a number (array index)
+      const index = parseInt(segment, 10);
+      return isNaN(index) ? segment : index;
+    });
     
     await linkCharms(
       spaceConfig,
       sourceCharmId,
-      sourceField,
+      sourcePath,
       targetCharmId,
-      targetField,
+      targetPath,
     );
     
     render(`Linked ${sourceRef} to ${targetRef}`);

--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -216,99 +216,37 @@ export async function linkCharms(
   targetPath: (string | number)[],
 ): Promise<void> {
   const manager = await loadManager(config);
-  
+
   const sourceCharm = await manager.get(sourceCharmId, false);
   if (!sourceCharm) {
     throw new Error(`Source charm "${sourceCharmId}" not found`);
   }
-  
+
   const targetCharm = await manager.get(targetCharmId, false);
   if (!targetCharm) {
     throw new Error(`Target charm "${targetCharmId}" not found`);
   }
-  
+
   // Navigate to the source path
   let sourceCell: Cell<any> = sourceCharm;
   for (const segment of sourcePath) {
     sourceCell = sourceCell.key(segment);
   }
   const sourceCellLink = sourceCell.getAsCellLink();
-  
+
   // Navigate to the parent of the target path
   let targetCell: Cell<any> = targetCharm;
   const targetKey = targetPath.pop();
   if (!targetKey) {
     throw new Error("Target path cannot be empty");
   }
-  
+
   for (const segment of targetPath) {
     targetCell = targetCell.key(segment);
   }
-  
+
   targetCell.key(targetKey).set(sourceCellLink);
-  
+
   await manager.runtime.idle();
   await manager.synced();
-}
-
-export async function viewCharm(
-  config: CharmConfig,
-): Promise<{
-  id: string;
-  name?: string;
-  recipeName?: string;
-  source: any;
-  result: any;
-  readingFrom: Array<{ id: string; name?: string }>;
-  readBy: Array<{ id: string; name?: string }>;
-}> {
-  const manager = await loadManager(config);
-  
-  const charm = await manager.get(config.charm, false);
-  if (!charm) {
-    throw new Error(`Charm "${config.charm}" not found`);
-  }
-  
-  const id = getCharmIdSafe(charm);
-  const name = charm.get()[NAME];
-  
-  // Get recipe metadata
-  const recipeMeta = await getRecipeMeta(manager, config.charm);
-  const recipeName = recipeMeta.recipeName;
-  
-  // Get source (arguments/inputs)
-  let source: any;
-  try {
-    const argumentCell = manager.getArgument(charm);
-    source = argumentCell.get();
-  } catch (err) {
-    source = { error: "Unable to get source/arguments", details: err instanceof Error ? err.message : String(err) };
-  }
-  
-  // Get result (charm data)
-  const result = charm.get();
-  
-  // Get charms this one reads from
-  const readingFromCharms = manager.getReadingFrom(charm);
-  const readingFrom = readingFromCharms.map(c => ({
-    id: getCharmIdSafe(c),
-    name: c.get()[NAME],
-  }));
-  
-  // Get charms that read from this one
-  const readByCharms = manager.getReadByCharms(charm);
-  const readBy = readByCharms.map(c => ({
-    id: getCharmIdSafe(c),
-    name: c.get()[NAME],
-  }));
-  
-  return {
-    id,
-    name,
-    recipeName,
-    source,
-    result,
-    readingFrom,
-    readBy,
-  };
 }

--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -206,3 +206,30 @@ export async function applyCharmInput(
   const recipe = await getRecipeFromService(manager, config.charm);
   await exec({ manager, recipe, charmId: config.charm, input });
 }
+
+export async function linkCharms(
+  config: SpaceConfig,
+  sourceCharmId: string,
+  sourceField: string,
+  targetCharmId: string,
+  targetField: string,
+): Promise<void> {
+  const manager = await loadManager(config);
+  
+  const sourceCharm = await manager.get(sourceCharmId, false);
+  if (!sourceCharm) {
+    throw new Error(`Source charm "${sourceCharmId}" not found`);
+  }
+  
+  const targetCharm = await manager.get(targetCharmId, false);
+  if (!targetCharm) {
+    throw new Error(`Target charm "${targetCharmId}" not found`);
+  }
+  
+  const sourceCellLink = sourceCharm.key(sourceField).getAsCellLink();
+  
+  targetCharm.key(targetField).set(sourceCellLink);
+  
+  await manager.runtime.idle();
+  await manager.synced();
+}

--- a/packages/cli/test/charm.test.ts
+++ b/packages/cli/test/charm.test.ts
@@ -154,4 +154,40 @@ describe("cli charm parsing", () => {
       })
     ).toThrow();
   });
+
+  describe("path parsing for link command", () => {
+    it("should parse simple paths correctly", () => {
+      const sourceParts = "charm1/field".split("/");
+      const sourceCharmId = sourceParts[0];
+      const sourcePath = sourceParts.slice(1).map(segment => {
+        const index = parseInt(segment, 10);
+        return isNaN(index) ? segment : index;
+      });
+      
+      expect(sourceCharmId).toBe("charm1");
+      expect(sourcePath).toEqual(["field"]);
+    });
+
+    it("should parse deep paths with array indices", () => {
+      const targetParts = "charm2/data/items/0/title".split("/");
+      const targetCharmId = targetParts[0];
+      const targetPath = targetParts.slice(1).map(segment => {
+        const index = parseInt(segment, 10);
+        return isNaN(index) ? segment : index;
+      });
+      
+      expect(targetCharmId).toBe("charm2");
+      expect(targetPath).toEqual(["data", "items", 0, "title"]);
+    });
+
+    it("should handle mixed string and numeric paths", () => {
+      const parts = "charm/users/5/profile/settings/2".split("/");
+      const path = parts.slice(1).map(segment => {
+        const index = parseInt(segment, 10);
+        return isNaN(index) ? segment : index;
+      });
+      
+      expect(path).toEqual(["users", 5, "profile", "settings", 2]);
+    });
+  });
 });


### PR DESCRIPTION
Add two new `charm` subcommands:

`ct charm link <cell-a> <cell-b>`

```sh
ct charm link --identity ~/dev/.ct.key --url https://toolshed.saga-castor.ts.net/2025-06-23-claude baedreie5iwq33jsdwequdw2zik2qk753ioxfq4xq73pgtku7gc3rq6zzea/lists/0 baedreic6bwcfdj5lyeunczdft4i4atkdscx7mfbzjsljqfve7uu3hzsora/items

// Linked baedreie5iwq33jsdwequdw2zik2qk753ioxfq4xq73pgtku7gc3rq6zzea/lists/0 to baedreic6bwcfdj5lyeunczdft4i4atkdscx7mfbzjsljqfve7uu3hzsora/items
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the ct charm link command to let users link fields between charms, supporting deep nested paths and array indices.

- **New Features**
  - New command: ct charm link <source> <target>
  - Supports linking any field depth, including arrays

<!-- End of auto-generated description by cubic. -->

