### PR TITLE
chore: Use local workspace when running CLI integration tests via deno

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -411,7 +411,7 @@ jobs:
       - name: 🧪 Run CLI integration tests
         working-directory: packages/cli
         run: |
-          deno task integration http://localhost:8000
+          ./integration/integration.sh http://localhost:8000
 
   seeder-integration-test:
     name: "Seeder Integration Tests"

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -3,7 +3,7 @@
   "tasks": {
     "cli": "deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env ./mod.ts",
     "test": "deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env test/*.test.ts",
-    "integration": "./integration/integration.sh"
+    "integration": "CT_CLI_INTEGRATION_USE_LOCAL=1 ./integration/integration.sh"
   },
   "exports": {
     ".": "./mod.ts"

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -6,10 +6,11 @@ error () {
   exit 1
 }
 
+
+CT="$([[ -n "$CT_CLI_INTEGRATION_USE_LOCAL" ]] && echo "deno task cli" || echo "ct")"
 if [ "$#" -eq 0 ]; then
   error "Missing required argument: API_URL"
 fi
-
 API_URL="$1"
 SPACE=$(mktemp -u XXXXXXXXXX) # generates a random space
 IDENTITY=$(mktemp)
@@ -23,19 +24,19 @@ echo "IDENTITY=$IDENTITY"
 echo "WORK_DIR=$WORK_DIR"
 
 # Create a key
-ct id new > $IDENTITY
+$CT id new > $IDENTITY
 
 # Check space is empty
-if [ "$(ct charm ls $SPACE_ARGS)" != "" ]; then
+if [ "$($CT charm ls $SPACE_ARGS)" != "" ]; then
   error "Space not empty." 
 fi
 
 # Create a new charm with {value:5} as input
-CHARM_ID=$(ct charm new $SPACE_ARGS $RECIPE_SRC)
+CHARM_ID=$($CT charm new $SPACE_ARGS $RECIPE_SRC)
 echo "Created charm: $CHARM_ID"
 
 # Retrieve the source code for $CHARM_ID to $WORK_DIR
-ct charm getsrc $SPACE_ARGS --charm $CHARM_ID $WORK_DIR
+$CT charm getsrc $SPACE_ARGS --charm $CHARM_ID $WORK_DIR
 
 # Check file was retrieved
 if [ ! -f "$WORK_DIR/main.tsx" ]; then
@@ -44,11 +45,11 @@ fi
 
 # Update the charm's source code
 sed -i 's/Simple counter:/Simple counter 2:/g' "$WORK_DIR/main.tsx"
-ct charm setsrc $SPACE_ARGS --charm $CHARM_ID $WORK_DIR/main.tsx
+$CT charm setsrc $SPACE_ARGS --charm $CHARM_ID $WORK_DIR/main.tsx
 
 # (Again) Retrieve the source code for $CHARM_ID to $WORK_DIR
 rm "$WORK_DIR/main.tsx"
-ct charm getsrc $SPACE_ARGS --charm $CHARM_ID $WORK_DIR
+$CT charm getsrc $SPACE_ARGS --charm $CHARM_ID $WORK_DIR
 
 # Check file was retrieved with modifications
 grep -q "Simple counter 2" "$WORK_DIR/main.tsx"
@@ -57,11 +58,11 @@ if [ $? -ne 0 ]; then
 fi
 
 # Apply new input to charm
-echo '{"value":5}' | ct charm apply $SPACE_ARGS --charm $CHARM_ID
+echo '{"value":5}' | $CT charm apply $SPACE_ARGS --charm $CHARM_ID
 
 # Check space has new charm with correct inputs and title
 TITLE="Simple counter 2: 5"
-ct charm ls $SPACE_ARGS | grep -q "$CHARM_ID $TITLE <unnamed>"
+$CT charm ls $SPACE_ARGS | grep -q "$CHARM_ID $TITLE <unnamed>"
 if [ $? -ne 0 ]; then
   error "Charm did not appear in list of space charms."
 fi


### PR DESCRIPTION
Otherwise, use ct binary found in path.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated CLI integration tests to use the local workspace build when running via Deno, falling back to the installed ct binary if not set.

- **Refactors**
  - Added environment variable to control which CLI is used during integration tests.
  - Updated test script and workflow to support this change.

<!-- End of auto-generated description by cubic. -->

