### PR TITLE
Make CT binary configurable in integration test

### DIFF
--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -6,6 +6,15 @@ error () {
   exit 1
 }
 
+# Use e.g. CT_BINARY="deno task cli" to run from repo without building binaries
+if [ "$CT_BINARY" != "" ]; then
+  echo "ct=$CT_BINARY"
+  ct() {
+    $CT_BINARY "$@"
+  }
+fi
+
+
 if [ "$#" -eq 0 ]; then
   error "Missing required argument: API_URL"
 fi


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Made the CT binary configurable in integration tests so you can run tests with a custom command.

- **New Features**
  - Added support for setting the CT_BINARY environment variable to override the default binary.

<!-- End of auto-generated description by cubic. -->

