### PR TITLE
Don't create shadow refs in toJSONWithAliases

### DIFF
--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -30,9 +30,12 @@ export function toJSONWithAliases(
 ): JSONValue | undefined {
   // Convert regular cells to opaque refs
   if (canBeOpaqueRef(value)) value = makeOpaqueRef(value);
-  // Convert parent opaque refs to shadow refs
-  else if (isOpaqueRef(value) && value.export().frame !== getTopFrame()) {
-    value = createShadowRef(value);
+
+  // Verify that opaque refs are not in a parent frame
+  if (isOpaqueRef(value) && value.export().frame !== getTopFrame()) {
+    throw new Error(
+      `Opaque ref with parent cell not found in current frame. Should have been converted to a shadow ref.`,
+    );
   }
 
   // If this is an external reference, just copy the reference as is.


### PR DESCRIPTION
Those should have been created earlier. Also, this would have never worked here, since those shadowrefs aren't in `paths`.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed shadow ref creation from toJSONWithAliases and now throw an error if an opaque ref from a parent frame is found. This ensures shadow refs are created earlier in the process.

<!-- End of auto-generated description by cubic. -->

