### PR TITLE
hack to remove a particular foot gun around streams

### DIFF
--- a/packages/runner/src/builder/recipe.ts
+++ b/packages/runner/src/builder/recipe.ts
@@ -239,7 +239,7 @@ function factoryFromRecipe<T, R>(
         // HACK(seefeld): For unnamed cells, we've run into an issue when the
         // order changes that a stream might clobber a previously used
         // non-stream, which means the default value won't be assigned and the
-        // cell won't be treated as recipe. So we'll namespace those separately.
+        // cell won't be treated as stream. So we'll namespace those separately.
         const streamMarker = isRecord(value) && value.$stream === true
           ? "stream"
           : "";


### PR DESCRIPTION
When the order of unnamed cells changes, a stream might be assigned to a previously existing value, typically what was the output for a derive/lift. That means `$stream: true` won't be set, and so it won't be treated as stream. This fixes this particular case by namespacing the streams away. Still not great overall.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where unnamed stream cells could overwrite non-stream cells when cell order changed, causing streams to be misclassified. Streams are now namespaced to prevent this conflict.

<!-- End of auto-generated description by cubic. -->

