### PR TITLE
Make types of deprecated links even clearer & add @deprecated tags

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -27,7 +27,7 @@ import { validateAndTransform } from "./schema.ts";
 import { toURI } from "./uri-utils.ts";
 import {
   type JSONCellLink,
-  type LegacyCellLink,
+  type LegacyDocCellLink,
   LINK_V1_TAG,
   type SigilLink,
   type SigilWriteRedirectLink,
@@ -56,7 +56,7 @@ import { areLinksSame, isLink } from "./link-utils.ts";
  * @returns {void}
  *
  * @method push Adds an item to the end of an array cell.
- * @param {U | DocImpl<U> | LegacyCellLink} value - The value to add, where U is
+ * @param {U | DocImpl<U> | LegacyDocCellLink} value - The value to add, where U is
  * the array element type.
  * @returns {void}
  *
@@ -88,7 +88,7 @@ import { areLinksSame, isLink } from "./link-utils.ts";
  * @returns {QueryResult<DeepKeyLookup<T, Path>>}
  *
  * @method getAsLegacyCellLink Returns a cell link for the cell (legacy format).
- * @returns {LegacyCellLink}
+ * @returns {LegacyDocCellLink}
  *
  * @method getAsLink Returns a cell link for the cell (new sigil format).
  * @returns {SigilLink}
@@ -134,7 +134,7 @@ import { areLinksSame, isLink } from "./link-utils.ts";
  * @returns {T}
  *
  * @property cellLink The cell link representing this cell.
- * @returns {LegacyCellLink}
+ * @returns {LegacyDocCellLink}
  */
 declare module "@commontools/api" {
   interface Cell<T> {
@@ -169,7 +169,7 @@ declare module "@commontools/api" {
       path?: Path,
       log?: ReactivityLog,
     ): QueryResult<DeepKeyLookup<T, Path>>;
-    getAsLegacyCellLink(): LegacyCellLink;
+    getAsLegacyCellLink(): LegacyDocCellLink;
     getAsLink(
       options?: {
         base?: Cell<any>;
@@ -210,7 +210,7 @@ declare module "@commontools/api" {
     schema?: JSONSchema;
     rootSchema?: JSONSchema;
     value: T;
-    cellLink: LegacyCellLink;
+    cellLink: LegacyDocCellLink;
     space: MemorySpace;
     entityId: EntityId;
     sourceURI: URI;
@@ -460,7 +460,7 @@ function createRegularCell<T>(
       subscribeToReferencedDocs(callback, doc, path, schema, rootSchema),
     getAsQueryResult: (subPath: PropertyKey[] = [], newLog?: ReactivityLog) =>
       createQueryResultProxy(doc, [...path, ...subPath], newLog ?? log),
-    getAsLegacyCellLink: (): LegacyCellLink => {
+    getAsLegacyCellLink: (): LegacyDocCellLink => {
       return { space: doc.space, cell: doc, path, schema, rootSchema };
     },
     getAsLink: (
@@ -503,7 +503,7 @@ function createRegularCell<T>(
     get value(): T {
       return self.get();
     },
-    get cellLink(): LegacyCellLink {
+    get cellLink(): LegacyDocCellLink {
       return { space: doc.space, cell: doc, path, schema, rootSchema };
     },
     get space(): MemorySpace {

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -5,7 +5,7 @@ import { type DocImpl, isDoc } from "./doc.ts";
 import { createRef } from "./doc-map.ts";
 import { isCell } from "./cell.ts";
 import { isAnyCellLink } from "./link-utils.ts";
-import { type LegacyCellLink } from "./sigil-types.ts";
+import { type LegacyDocCellLink } from "./sigil-types.ts";
 import { type ReactivityLog } from "./scheduler.ts";
 import { followWriteRedirects } from "./link-resolution.ts";
 import {
@@ -97,7 +97,7 @@ export function setNestedValue<T>(
  * @returns Whether any changes were made.
  */
 export function diffAndUpdate(
-  current: LegacyCellLink,
+  current: LegacyDocCellLink,
   newValue: unknown,
   log?: ReactivityLog,
   context?: unknown,
@@ -107,7 +107,7 @@ export function diffAndUpdate(
   return changes.length > 0;
 }
 
-type ChangeSet = { location: LegacyCellLink; value: unknown }[];
+type ChangeSet = { location: LegacyDocCellLink; value: unknown }[];
 
 /**
  * Traverses objects and returns an array of changes that should be written. An
@@ -131,7 +131,7 @@ type ChangeSet = { location: LegacyCellLink; value: unknown }[];
  * @returns An array of changes that should be written.
  */
 export function normalizeAndDiff(
-  current: LegacyCellLink,
+  current: LegacyDocCellLink,
   newValue: unknown,
   log?: ReactivityLog,
   context?: unknown,
@@ -187,7 +187,7 @@ export function normalizeAndDiff(
   }
 
   if (isDoc(newValue)) {
-    newValue = { cell: newValue, path: [] } satisfies LegacyCellLink;
+    newValue = { cell: newValue, path: [] } satisfies LegacyDocCellLink;
   }
   if (isCell(newValue)) newValue = newValue.getAsLegacyCellLink();
 

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -9,7 +9,7 @@ export type {
 export { raw } from "./module.ts";
 export type { DocImpl } from "./doc.ts";
 export type { Cell, Stream } from "./cell.ts";
-export type { LegacyCellLink, URI } from "./sigil-types.ts";
+export type { LegacyDocCellLink, URI } from "./sigil-types.ts";
 export type { EntityId } from "./doc-map.ts";
 export { createRef, getEntityId } from "./doc-map.ts";
 export type { QueryResult } from "./query-result-proxy.ts";
@@ -38,7 +38,7 @@ export { addCommonIDfromObjectID } from "./data-updating.ts";
 export { followWriteRedirects } from "./link-resolution.ts";
 export {
   areLinksSame,
-  isCellLink,
+  isLegacyCellLink,
   isLink,
   isWriteRedirectLink,
   parseLink,

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -2,7 +2,7 @@ import { isRecord } from "@commontools/utils/types";
 import { getTopFrame } from "./builder/recipe.ts";
 import { toOpaqueRef } from "./builder/types.ts";
 import { type DocImpl, makeOpaqueRef } from "./doc.ts";
-import { type LegacyCellLink } from "./sigil-types.ts";
+import { type LegacyDocCellLink } from "./sigil-types.ts";
 import { type ReactivityLog } from "./scheduler.ts";
 import { diffAndUpdate, setNestedValue } from "./data-updating.ts";
 import { resolveLinkToValue } from "./link-resolution.ts";
@@ -97,7 +97,10 @@ export function createQueryResultProxy<T>(
     get: (target, prop, receiver) => {
       if (typeof prop === "symbol") {
         if (prop === getCellLink) {
-          return { cell: valueCell, path: valuePath } satisfies LegacyCellLink;
+          return {
+            cell: valueCell,
+            path: valuePath,
+          } satisfies LegacyDocCellLink;
         } else if (prop === toOpaqueRef) {
           return () => makeOpaqueRef(valueCell, valuePath);
         }
@@ -302,9 +305,9 @@ function isProxyForArrayValue(value: any): value is ProxyForArrayValue {
  * Get cell link or return values as is if not a cell value proxy.
  *
  * @param {any} value - The value to get the cell link or value from.
- * @returns {LegacyCellLink | any}
+ * @returns {LegacyDocCellLink | any}
  */
-export function getCellLinkOrValue(value: any): LegacyCellLink {
+export function getCellLinkOrValue(value: any): LegacyDocCellLink {
   if (isQueryResult(value)) return value[getCellLink];
   else return value;
 }
@@ -313,10 +316,10 @@ export function getCellLinkOrValue(value: any): LegacyCellLink {
  * Get cell link or throw if not a cell value proxy.
  *
  * @param {any} value - The value to get the cell link from.
- * @returns {LegacyCellLink}
+ * @returns {LegacyDocCellLink}
  * @throws {Error} If the value is not a cell value proxy.
  */
-export function getCellLinkOrThrow(value: any): LegacyCellLink {
+export function getCellLinkOrThrow(value: any): LegacyDocCellLink {
   if (isQueryResult(value)) return value[getCellLink];
   else throw new Error("Value is not a cell proxy");
 }
@@ -347,7 +350,7 @@ export function isQueryResultForDereferencing(
 }
 
 export type QueryResultInternals = {
-  [getCellLink]: LegacyCellLink;
+  [getCellLink]: LegacyDocCellLink;
 };
 
 export type QueryResult<T> = T & QueryResultInternals;

--- a/packages/runner/src/recipe-binding.ts
+++ b/packages/runner/src/recipe-binding.ts
@@ -9,7 +9,7 @@ import {
 import { isLegacyAlias, isLink } from "./link-utils.ts";
 import { type DocImpl, isDoc } from "./doc.ts";
 import { type Cell, isCell } from "./cell.ts";
-import { type LegacyCellLink } from "./sigil-types.ts";
+import { type LegacyDocCellLink } from "./sigil-types.ts";
 import { type ReactivityLog } from "./scheduler.ts";
 import { followWriteRedirects } from "./link-resolution.ts";
 import { diffAndUpdate } from "./data-updating.ts";
@@ -149,8 +149,8 @@ export function unsafe_createParentBindings(
 export function findAllLegacyAliasedCells<T>(
   binding: unknown,
   doc: DocImpl<T>,
-): LegacyCellLink[] {
-  const docs: LegacyCellLink[] = [];
+): LegacyDocCellLink[] {
+  const docs: LegacyDocCellLink[] = [];
   function find(binding: unknown, origDoc: DocImpl<T>): void {
     if (isLegacyAlias(binding)) {
       // Numbered docs are yet to be unwrapped nested recipes. Ignore them.

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -40,7 +40,7 @@ import { sendValueToBinding } from "./recipe-binding.ts";
 import { type AddCancel, type Cancel, useCancelGroup } from "./cancel.ts";
 import "./builtins/index.ts";
 import { isCell } from "./cell.ts";
-import { type LegacyCellLink } from "./sigil-types.ts";
+import { type LegacyDocCellLink } from "./sigil-types.ts";
 import type { IRunner, IRuntime } from "./runtime.ts";
 
 export class Runner implements IRunner {
@@ -484,7 +484,7 @@ export class Runner implements IRunner {
     }
 
     // Check if any of the read cells is a stream alias
-    let streamRef: LegacyCellLink | undefined = undefined;
+    let streamRef: LegacyDocCellLink | undefined = undefined;
     if (isRecord(inputs)) {
       for (const key in inputs) {
         let doc = processCell;
@@ -497,7 +497,7 @@ export class Runner implements IRunner {
           value = doc.getAtPath(path);
         }
         if (isStreamValue(value)) {
-          streamRef = { cell: doc, path } satisfies LegacyCellLink;
+          streamRef = { cell: doc, path } satisfies LegacyDocCellLink;
           break;
         }
       }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -14,7 +14,7 @@ import type {
   MemorySpace,
 } from "./storage/interface.ts";
 import { type Cell } from "./cell.ts";
-import { type JSONCellLink, type LegacyCellLink } from "./sigil-types.ts";
+import { type JSONCellLink, type LegacyDocCellLink } from "./sigil-types.ts";
 import type { DocImpl } from "./doc.ts";
 import { isDoc } from "./doc.ts";
 import { type EntityId, getEntityId } from "./doc-map.ts";
@@ -23,7 +23,7 @@ import type { Action, EventHandler, ReactivityLog } from "./scheduler.ts";
 import type { Harness } from "./harness/harness.ts";
 import { Engine } from "./harness/index.ts";
 import { ConsoleMethod } from "./harness/console.ts";
-import { isCellLink, type NormalizedLink } from "./link-utils.ts";
+import { isLegacyCellLink, type NormalizedLink } from "./link-utils.ts";
 
 export type { IStorageManager, IStorageProvider, MemorySpace };
 
@@ -100,12 +100,12 @@ export interface IRuntime {
     log?: ReactivityLog,
   ): Cell<Schema<S>>;
   getCellFromLink<T>(
-    cellLink: LegacyCellLink | NormalizedLink,
+    cellLink: LegacyDocCellLink | NormalizedLink,
     schema?: JSONSchema,
     log?: ReactivityLog,
   ): Cell<T>;
   getCellFromLink<S extends JSONSchema = JSONSchema>(
-    cellLink: LegacyCellLink | NormalizedLink,
+    cellLink: LegacyDocCellLink | NormalizedLink,
     schema: S,
     log?: ReactivityLog,
   ): Cell<Schema<S>>;
@@ -159,8 +159,8 @@ export interface IScheduler {
   unschedule(action: Action): void;
   onConsole(fn: ConsoleHandler): void;
   onError(fn: ErrorHandler): void;
-  queueEvent(eventRef: LegacyCellLink, event: any): void;
-  addEventHandler(handler: EventHandler, ref: LegacyCellLink): Cancel;
+  queueEvent(eventRef: LegacyDocCellLink, event: any): void;
+  addEventHandler(handler: EventHandler, ref: LegacyDocCellLink): Cancel;
   runningPromise: Promise<unknown> | undefined;
 }
 
@@ -427,23 +427,23 @@ export class Runtime implements IRuntime {
   }
 
   getCellFromLink<T>(
-    cellLink: LegacyCellLink | JSONCellLink | NormalizedLink,
+    cellLink: LegacyDocCellLink | JSONCellLink | NormalizedLink,
     schema?: JSONSchema,
     log?: ReactivityLog,
   ): Cell<T>;
   getCellFromLink<S extends JSONSchema = JSONSchema>(
-    cellLink: LegacyCellLink | JSONCellLink | NormalizedLink,
+    cellLink: LegacyDocCellLink | JSONCellLink | NormalizedLink,
     schema: S,
     log?: ReactivityLog,
   ): Cell<Schema<S>>;
   getCellFromLink(
-    cellLink: LegacyCellLink | NormalizedLink,
+    cellLink: LegacyDocCellLink | NormalizedLink,
     schema?: JSONSchema,
     log?: ReactivityLog,
   ): Cell<any> {
     let doc;
 
-    if (isCellLink(cellLink)) {
+    if (isLegacyCellLink(cellLink)) {
       if (isDoc(cellLink.cell)) {
         doc = cellLink.cell;
       } else if (cellLink.space) {

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -2,7 +2,7 @@ import { getTopFrame } from "./builder/recipe.ts";
 import { TYPE } from "./builder/types.ts";
 import type { DocImpl } from "./doc.ts";
 import type { Cancel } from "./cancel.ts";
-import { type LegacyCellLink } from "./sigil-types.ts";
+import { type LegacyDocCellLink } from "./sigil-types.ts";
 import {
   getCellLinkOrThrow,
   isQueryResultForDereferencing,
@@ -30,8 +30,8 @@ export type EventHandler = (event: any) => any;
  * dependencies and to topologically sort pending actions before executing them.
  */
 export type ReactivityLog = {
-  reads: LegacyCellLink[];
-  writes: LegacyCellLink[];
+  reads: LegacyDocCellLink[];
+  writes: LegacyDocCellLink[];
 };
 
 const MAX_ITERATIONS_PER_RUN = 100;
@@ -39,7 +39,7 @@ const MAX_ITERATIONS_PER_RUN = 100;
 export class Scheduler implements IScheduler {
   private pending = new Set<Action>();
   private eventQueue: (() => void)[] = [];
-  private eventHandlers: [LegacyCellLink, EventHandler][] = [];
+  private eventHandlers: [LegacyDocCellLink, EventHandler][] = [];
   private dirty = new Set<DocImpl<any>>();
   private dependencies = new WeakMap<Action, ReactivityLog>();
   private cancels = new WeakMap<Action, Cancel[]>();
@@ -179,7 +179,7 @@ export class Scheduler implements IScheduler {
     });
   }
 
-  queueEvent(eventRef: LegacyCellLink, event: any): void {
+  queueEvent(eventRef: LegacyDocCellLink, event: any): void {
     for (const [ref, handler] of this.eventHandlers) {
       if (
         ref.cell === eventRef.cell &&
@@ -192,7 +192,7 @@ export class Scheduler implements IScheduler {
     }
   }
 
-  addEventHandler(handler: EventHandler, ref: LegacyCellLink): Cancel {
+  addEventHandler(handler: EventHandler, ref: LegacyDocCellLink): Cancel {
     this.eventHandlers.push([ref, handler]);
     return () => {
       const index = this.eventHandlers.findIndex(([r, h]) =>
@@ -219,7 +219,7 @@ export class Scheduler implements IScheduler {
   private setDependencies(
     action: Action,
     log: ReactivityLog,
-  ): LegacyCellLink[] {
+  ): LegacyDocCellLink[] {
     const reads = compactifyPaths(log.reads);
     const writes = compactifyPaths(log.writes);
     this.dependencies.set(action, { reads, writes });
@@ -426,7 +426,9 @@ function topologicalSort(
 }
 
 // Remove longer paths already covered by shorter paths
-export function compactifyPaths(entries: LegacyCellLink[]): LegacyCellLink[] {
+export function compactifyPaths(
+  entries: LegacyDocCellLink[],
+): LegacyDocCellLink[] {
   // First group by doc via a Map
   const docToPaths = new Map<DocImpl<any>, PropertyKey[][]>();
   for (const { cell: doc, path } of entries) {
@@ -437,7 +439,7 @@ export function compactifyPaths(entries: LegacyCellLink[]): LegacyCellLink[] {
 
   // For each cell, sort the paths by length, then only return those that don't
   // have a prefix earlier in the list
-  const result: LegacyCellLink[] = [];
+  const result: LegacyDocCellLink[] = [];
   for (const [doc, paths] of docToPaths.entries()) {
     paths.sort((a, b) => a.length - b.length);
     for (let i = 0; i < paths.length; i++) {

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -4,7 +4,7 @@ import { type JSONSchema, type JSONValue } from "./builder/types.ts";
 import { isAnyCellLink, isWriteRedirectLink, parseLink } from "./link-utils.ts";
 import { type DocImpl } from "./doc.ts";
 import { createCell, isCell } from "./cell.ts";
-import { type LegacyCellLink } from "./sigil-types.ts";
+import { type LegacyDocCellLink } from "./sigil-types.ts";
 import { type ReactivityLog } from "./scheduler.ts";
 import { resolveLinks, resolveLinkToWriteRedirect } from "./link-resolution.ts";
 
@@ -508,7 +508,7 @@ export function validateAndTransform(
 
       // Merge all the object extractions
       let merged: Record<string, any> = {};
-      const extraReads: LegacyCellLink[] = [];
+      const extraReads: LegacyDocCellLink[] = [];
       for (const { result, extraLog } of candidates) {
         if (isCell(result)) {
           merged = result;

--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -47,11 +47,13 @@ export type SigilWriteRedirectLink = SigilValue<WriteRedirectV1>;
  ****************/
 
 /**
- * Cell link.
+ * Legacy doc cell link.
  *
- * A cell link is a doc and a path within that doc.
+ * @deprecated Switch to sigil links instead.
+ *
+ * A legacy doc cell link is a doc and a path within that doc.
  */
-export type LegacyCellLink = {
+export type LegacyDocCellLink = {
   space?: MemorySpace;
   cell: DocImpl<any>;
   path: PropertyKey[];
@@ -61,6 +63,8 @@ export type LegacyCellLink = {
 
 /**
  * Legacy alias.
+ *
+ * @deprecated Switch to sigil write redirect links instead.
  *
  * A legacy alias is a cell and a path within that cell.
  */
@@ -74,7 +78,9 @@ export type LegacyAlias = {
 };
 
 /**
- * JSON cell link format used in storage
+ * JSON cell link format used in storage.
+ *
+ * @deprecated Switch to sigil links instead.
  */
 export type JSONCellLink = {
   cell: { "/": string };

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -8,7 +8,7 @@ import { ID, JSONSchema } from "../src/builder/types.ts";
 import { popFrame, pushFrame } from "../src/builder/recipe.ts";
 import { Runtime } from "../src/runtime.ts";
 import { addCommonIDfromObjectID } from "../src/data-updating.ts";
-import { isCellLink } from "../src/link-utils.ts";
+import { isLegacyCellLink } from "../src/link-utils.ts";
 import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 import { areLinksSame } from "../src/link-utils.ts";
@@ -216,8 +216,8 @@ describe("Cell utility functions", () => {
     );
     c.set({ x: 10 });
     const ref = c.key("x").getAsLegacyCellLink();
-    expect(isCellLink(ref)).toBe(true);
-    expect(isCellLink({})).toBe(false);
+    expect(isLegacyCellLink(ref)).toBe(true);
+    expect(isLegacyCellLink({})).toBe(false);
   });
 
   it("should identify a cell proxy", () => {
@@ -1588,8 +1588,8 @@ describe("asCell with schema", () => {
     testCell.set(initialDataCopy);
     popFrame(frame1);
 
-    expect(isCellLink(testDoc.getRaw()[0])).toBe(true);
-    expect(isCellLink(testDoc.getRaw()[1])).toBe(true);
+    expect(isLegacyCellLink(testDoc.getRaw()[0])).toBe(true);
+    expect(isLegacyCellLink(testDoc.getRaw()[1])).toBe(true);
     expect(testDoc.getRaw()[0].cell.get().name).toEqual("First Item");
     expect(testDoc.getRaw()[1].cell.get().name).toEqual("Second Item");
 
@@ -1606,8 +1606,8 @@ describe("asCell with schema", () => {
     testCell.set(returnedData);
     popFrame(frame2);
 
-    expect(isCellLink(testDoc.getRaw()[0])).toBe(true);
-    expect(isCellLink(testDoc.getRaw()[1])).toBe(true);
+    expect(isLegacyCellLink(testDoc.getRaw()[0])).toBe(true);
+    expect(isLegacyCellLink(testDoc.getRaw()[1])).toBe(true);
     expect(testDoc.getRaw()[0].cell.get().name).toEqual("First Item");
     expect(testDoc.getRaw()[1].cell.get().name).toEqual("Second Item");
 
@@ -1677,8 +1677,8 @@ describe("asCell with schema", () => {
     arrayCell.push({ [ID]: "test", value: 43 });
     expect(frame.generatedIdCounter).toEqual(1); // No increment = no ID generated from it
     popFrame(frame);
-    expect(isCellLink(c.getRaw().items[0])).toBe(true);
-    expect(isCellLink(c.getRaw().items[1])).toBe(true);
+    expect(isLegacyCellLink(c.getRaw().items[0])).toBe(true);
+    expect(isLegacyCellLink(c.getRaw().items[1])).toBe(true);
     expect(arrayCell.get()).toEqual([{ value: 42 }, { value: 43 }]);
   });
 });

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -12,10 +12,10 @@ import { Runtime } from "../src/runtime.ts";
 import {
   areLinksSame,
   isAnyCellLink,
-  isCellLink,
   isLegacyCellLink,
+  isLegacyDocCellLink,
 } from "../src/link-utils.ts";
-import type { LegacyCellLink } from "../src/sigil-types.ts";
+import type { LegacyDocCellLink } from "../src/sigil-types.ts";
 import { arrayEqual } from "../src/path-utils.ts";
 import { type ReactivityLog } from "../src/scheduler.ts";
 import { Identity } from "@commontools/identity";
@@ -177,7 +177,9 @@ describe("data-updating", () => {
       const changes = normalizeAndDiff(current, { name: "Jane", age: 30 });
 
       expect(changes.length).toBe(1);
-      expect(areLinksSame(changes[0].location, testCell.key("user").key("name"))).toBe(true);
+      expect(
+        areLinksSame(changes[0].location, testCell.key("user").key("name")),
+      ).toBe(true);
       expect(changes[0].value).toBe("Jane");
     });
 
@@ -193,7 +195,8 @@ describe("data-updating", () => {
       const changes = normalizeAndDiff(current, { name: "John", age: 30 });
 
       expect(changes.length).toBe(1);
-      expect(areLinksSame(changes[0].location, testCell.key("user").key("age"))).toBe(true);
+      expect(areLinksSame(changes[0].location, testCell.key("user").key("age")))
+        .toBe(true);
       expect(changes[0].value).toBe(30);
     });
 
@@ -207,7 +210,8 @@ describe("data-updating", () => {
       const changes = normalizeAndDiff(current, { name: "John" });
 
       expect(changes.length).toBe(1);
-      expect(areLinksSame(changes[0].location, testCell.key("user").key("age"))).toBe(true);
+      expect(areLinksSame(changes[0].location, testCell.key("user").key("age")))
+        .toBe(true);
       expect(changes[0].value).toBe(undefined);
     });
 
@@ -221,7 +225,9 @@ describe("data-updating", () => {
       const changes = normalizeAndDiff(current, [1, 2]);
 
       expect(changes.length).toBe(1);
-      expect(areLinksSame(changes[0].location, testCell.key("items").key("length"))).toBe(true);
+      expect(
+        areLinksSame(changes[0].location, testCell.key("items").key("length")),
+      ).toBe(true);
       expect(changes[0].value).toBe(2);
     });
 
@@ -235,7 +241,8 @@ describe("data-updating", () => {
       const changes = normalizeAndDiff(current, [1, 5, 3]);
 
       expect(changes.length).toBe(1);
-      expect(areLinksSame(changes[0].location, testCell.key("items").key(1))).toBe(true);
+      expect(areLinksSame(changes[0].location, testCell.key("items").key(1)))
+        .toBe(true);
       expect(changes[0].value).toBe(5);
     });
 
@@ -256,7 +263,9 @@ describe("data-updating", () => {
 
       // Should follow alias to value and change it there
       expect(changes.length).toBe(1);
-      expect(areLinksSame(changes[0].location, testCell.key("value"))).toBe(true);
+      expect(areLinksSame(changes[0].location, testCell.key("value"))).toBe(
+        true,
+      );
       expect(changes[0].value).toBe(100);
     });
 
@@ -279,7 +288,9 @@ describe("data-updating", () => {
 
       // Should follow alias to value and change it there
       expect(changes.length).toBe(1);
-      expect(areLinksSame(changes[0].location, testCell.key("value"))).toBe(true);
+      expect(areLinksSame(changes[0].location, testCell.key("value"))).toBe(
+        true,
+      );
       expect(changes[0].value).toBe(100);
 
       applyChangeSet(changes);
@@ -291,13 +302,17 @@ describe("data-updating", () => {
       applyChangeSet(changes2);
 
       expect(changes2.length).toBe(1);
-      expect(areLinksSame(changes2[0].location, testCell.key("alias"))).toBe(true);
+      expect(areLinksSame(changes2[0].location, testCell.key("alias"))).toBe(
+        true,
+      );
       expect(changes2[0].value).toEqual({ $alias: { path: ["value2"] } });
 
       const changes3 = normalizeAndDiff(current, 300);
 
       expect(changes3.length).toBe(1);
-      expect(areLinksSame(changes3[0].location, testCell.key("value2"))).toBe(true);
+      expect(areLinksSame(changes3[0].location, testCell.key("value2"))).toBe(
+        true,
+      );
       expect(changes3[0].value).toBe(300);
     });
 
@@ -340,9 +355,14 @@ describe("data-updating", () => {
       });
 
       expect(changes.length).toBe(1);
-      expect(areLinksSame(changes[0].location, testCell.key("user").key("profile").key("details").key("address").key(
-          "city",
-        ))).toBe(true);
+      expect(
+        areLinksSame(
+          changes[0].location,
+          testCell.key("user").key("profile").key("details").key("address").key(
+            "city",
+          ),
+        ),
+      ).toBe(true);
       expect(changes[0].value).toBe("Boston");
     });
 
@@ -492,8 +512,8 @@ describe("data-updating", () => {
       );
 
       // Verify that the second item reused the existing document
-      expect(isCellLink(testCell.getRaw().items[0])).toBe(true);
-      expect(isCellLink(testCell.getRaw().items[1])).toBe(true);
+      expect(isLegacyCellLink(testCell.getRaw().items[0])).toBe(true);
+      expect(isLegacyCellLink(testCell.getRaw().items[1])).toBe(true);
       expect(testCell.getRaw().items[1].cell).toBe(initialDoc);
       expect(testCell.getRaw().items[1].cell.get().name).toEqual(
         "Updated Item",
@@ -520,8 +540,8 @@ describe("data-updating", () => {
         "it should treat different properties as different ID namespaces",
       );
 
-      expect(isCellLink(testCell.getRaw().a)).toBe(true);
-      expect(isCellLink(testCell.getRaw().b)).toBe(true);
+      expect(isLegacyCellLink(testCell.getRaw().a)).toBe(true);
+      expect(isLegacyCellLink(testCell.getRaw().b)).toBe(true);
       expect(testCell.getRaw().a.cell).not.toBe(testCell.getRaw().b.cell);
       expect(testCell.getRaw().a.cell.get().name).toEqual("First Item");
       expect(testCell.getRaw().b.cell.get().name).toEqual("Second Item");
@@ -594,8 +614,11 @@ describe("data-updating", () => {
     });
 
     it("should reuse items", () => {
-      function isEqualCellLink(a: LegacyCellLink, b: LegacyCellLink): boolean {
-        return isLegacyCellLink(a) && isLegacyCellLink(b) &&
+      function isEqualCellLink(
+        a: LegacyDocCellLink,
+        b: LegacyDocCellLink,
+      ): boolean {
+        return isLegacyDocCellLink(a) && isLegacyDocCellLink(b) &&
           a.cell === b.cell &&
           arrayEqual(a.path, b.path);
       }

--- a/packages/runner/test/schema.test.ts
+++ b/packages/runner/test/schema.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { type Cell, isCell, isStream } from "../src/cell.ts";
-import { LegacyCellLink } from "../src/sigil-types.ts";
+import { LegacyDocCellLink } from "../src/sigil-types.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import { Identity } from "@commontools/identity";
@@ -56,10 +56,10 @@ describe("Schema Support", () => {
       // This is what the system (or someone manually) would create to remap
       // data to match the desired schema
       const mappingCell = runtime.getCell<{
-        id: LegacyCellLink;
-        changes: LegacyCellLink[];
-        kind: LegacyCellLink;
-        tag: LegacyCellLink;
+        id: LegacyDocCellLink;
+        changes: LegacyDocCellLink[];
+        kind: LegacyDocCellLink;
+        tag: LegacyDocCellLink;
       }>(
         space,
         "allows mapping of fields via interim cells 2",
@@ -120,7 +120,7 @@ describe("Schema Support", () => {
 
       const c = runtime.getCell<{
         value: string;
-        current: LegacyCellLink;
+        current: LegacyDocCellLink;
       }>(
         space,
         "should support nested sinks 2",
@@ -318,7 +318,7 @@ describe("Schema Support", () => {
       });
       expect(log.reads.length).toEqual(4);
       expect(
-        log.reads.map((r: LegacyCellLink) => ({
+        log.reads.map((r: LegacyDocCellLink) => ({
           cell: toURI(r.cell.entityId!),
           path: r.path,
         })),


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Renamed the LegacyCellLink type to LegacyDocCellLink and added clear @deprecated tags and comments to all legacy link types and helpers to make deprecated usage more obvious.

- **Refactors**
  - Updated all code and tests to use the new LegacyDocCellLink name.
  - Marked legacy link types and related functions with @deprecated and improved comments for clarity.

<!-- End of auto-generated description by cubic. -->

