### PR TITLE
feat: Only extract/inject usercode when pull/pushing iframe recipes with CLI

### DIFF
--- a/packages/charm/src/iframe/recipe.ts
+++ b/packages/charm/src/iframe/recipe.ts
@@ -68,6 +68,8 @@ export const getIframeRecipe = (
   runtime: Runtime,
 ): {
   recipeId: string;
+  // `src` is either a single file string source, or the entry
+  // file source code in a recipe.
   src?: string;
   iframe?: IFrameRecipe;
 } => {
@@ -76,9 +78,13 @@ export const getIframeRecipe = (
     console.warn("No recipeId found for charm", getEntityId(charm));
     return { recipeId, src: "", iframe: undefined };
   }
-  const src = runtime.recipeManager.getRecipeMeta({ recipeId })?.src;
+  const meta = runtime.recipeManager.getRecipeMeta({ recipeId });
+  const src = meta
+    ? (meta.src ??
+      meta.program?.files.find((file) => file.name === meta.program?.main)
+        ?.contents)
+    : undefined;
   if (!src) {
-    console.warn("No src found for charm", getEntityId(charm));
     return { recipeId };
   }
   try {

--- a/packages/charm/src/index.ts
+++ b/packages/charm/src/index.ts
@@ -29,7 +29,11 @@ export {
   modifyCharm,
   renameCharm,
 } from "./commands.ts";
-export { getIframeRecipe, type IFrameRecipe } from "./iframe/recipe.ts";
+export {
+  buildFullRecipe,
+  getIframeRecipe,
+  type IFrameRecipe,
+} from "./iframe/recipe.ts";
 export { type ParsedMention, type ProcessedPrompt } from "./imagine.ts";
 export { formatPromptWithMentions, parseComposerDocument } from "./format.ts";
 


### PR DESCRIPTION
Pull (user) source for charm:

* Pull:
  * `$ ct charm getsrc --identity my.key  --url https://toolshed.saga-castor.ts.net/myspace/baedreie4xrzi6in6l7cpeua5gliqzqvgzak7yye5dh2h4abigv7u6m5pry ./hyperlist`
* Modify: `./hyperlist/main.iframe.js`
* Push:
  * `$ ct charm setsrc --identity my.key  --url https://toolshed.saga-castor.ts.net/myspace/baedreie4xrzi6in6l7cpeua5gliqzqvgzak7yye5dh2h4abigv7u6m5pry ./hyperlist/main.iframe.js`

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
The CLI now only extracts or injects user code when pulling or pushing iframe recipes, instead of handling the full recipe file.

- **New Features**
  - When pulling an iframe recipe, only the user code is saved to main.iframe.js.
  - When pushing, only the user code from main.iframe.js is injected into the recipe.

<!-- End of auto-generated description by cubic. -->

