### PR TITLE
Add `ct charm map` [CT-479]

### DIFF
--- a/.claude/commands/common/ct.md
+++ b/.claude/commands/common/ct.md
@@ -61,6 +61,8 @@ This document contains shared setup instructions for the CT binary that are used
 - `./dist/ct charm inspect --identity [keyfile] --api-url [api-url] --space [spacename] --charm [id]` - Inspect charm details
 - `./dist/ct charm inspect --identity [keyfile] --url [full-url-with-charm-id]` - Inspect charm details (URL syntax)
 - `./dist/ct charm inspect --identity [keyfile] --api-url [api-url] --space [spacename] --charm [id] --json` - Output raw JSON data
+- `./dist/ct charm map --identity [keyfile] --api-url [api-url] --space [spacename]` - Display visual map of charms and connections
+- `./dist/ct charm map --identity [keyfile] --api-url [api-url] --space [spacename] --format dot` - Output Graphviz DOT format
 
 ### Recipe Development Commands:
 - `./dist/ct charm getsrc --identity [keyfile] --api-url [api-url] --space [spacename] --charm [id]` - Get recipe source code
@@ -84,6 +86,24 @@ This document contains shared setup instructions for the CT binary that are used
 - Source can be either `charmId/fieldName` (reads from charm result) or just `wellKnownId` (reads entire cell)
 - Target is always `charmId/fieldName` (writes to charm input)
 - The link creates live data flow - when source updates, target receives new data
+
+## Visualizing Space Maps
+
+The `ct charm map` command helps visualize the connections between charms in a space:
+
+**ASCII Format (default):**
+- Shows charms with their connections in a readable text format
+- Lists what each charm reads from and what reads from it
+- Sorted by connection count for better visibility
+
+**Graphviz DOT Format:**
+- Use `--format dot` to output in Graphviz format
+- Can be rendered to images using Graphviz tools:
+  ```bash
+  # Install Graphviz (macOS: brew install graphviz)
+  ct charm map --identity [key] --api-url [url] --space [space] --format dot | dot -Tpng -o map.png
+  ```
+- Alternatively, paste DOT output into online tools like https://dreampuf.github.io/GraphvizOnline/
 
 ## Important Notes
 

--- a/packages/cli/commands/charm.ts
+++ b/packages/cli/commands/charm.ts
@@ -3,6 +3,7 @@ import { Command, ValidationError } from "@cliffy/command";
 import {
   applyCharmInput,
   CharmConfig,
+  generateSpaceMap,
   inspectCharm,
   linkCharms,
   listCharms,
@@ -285,105 +286,10 @@ Recipe: ${charmData.recipeName || "<no recipe name>"}
   )
   .action(async (options) => {
     const spaceConfig = parseSpaceOptions(options);
+    const format = options.format as "ascii" | "dot";
     
-    // Get all charms in the space
-    const charms = await listCharms(spaceConfig);
-    
-    if (charms.length === 0) {
-      render("No charms found in space.");
-      return;
-    }
-
-    // Build a graph of connections
-    const connections: Map<string, {
-      name: string;
-      readingFrom: string[];
-      readBy: string[];
-    }> = new Map();
-
-    // First pass: get all charm details
-    for (const charm of charms) {
-      const charmConfig: CharmConfig = { ...spaceConfig, charm: charm.id };
-      try {
-        const details = await inspectCharm(charmConfig);
-        connections.set(charm.id, {
-          name: details.name || charm.id.slice(0, 8) + "...",
-          readingFrom: details.readingFrom.map(c => c.id),
-          readBy: details.readBy.map(c => c.id),
-        });
-      } catch (error) {
-        // Skip charms that can't be inspected
-        console.error(`Warning: Could not inspect charm ${charm.id}: ${error instanceof Error ? error.message : String(error)}`);
-        connections.set(charm.id, {
-          name: charm.name || charm.id.slice(0, 8) + "...",
-          readingFrom: [],
-          readBy: [],
-        });
-      }
-    }
-
-    if (options.format === "dot") {
-      // Generate Graphviz DOT format
-      let dot = "digraph CharmSpace {\n";
-      dot += "  rankdir=LR;\n";
-      dot += "  node [shape=box];\n\n";
-
-      // Add nodes
-      for (const [id, info] of connections) {
-        const shortId = id.slice(0, 8);
-        dot += `  "${id}" [label="${info.name}\\n${shortId}..."];\n`;
-      }
-      dot += "\n";
-
-      // Add edges
-      for (const [id, info] of connections) {
-        for (const targetId of info.readingFrom) {
-          dot += `  "${targetId}" -> "${id}";\n`;
-        }
-      }
-
-      dot += "}";
-      render(dot);
-    } else {
-      // Generate ASCII format
-      let output = "=== Charm Space Map ===\n\n";
-
-      // Sort charms by connection count for better visualization
-      const sortedCharms = Array.from(connections.entries()).sort(
-        ([, a], [, b]) => 
-          (b.readingFrom.length + b.readBy.length) - 
-          (a.readingFrom.length + a.readBy.length)
-      );
-
-      for (const [id, info] of sortedCharms) {
-        const shortId = id.slice(0, 8);
-        output += `📦 ${info.name} [${shortId}...]\n`;
-        
-        if (info.readingFrom.length > 0) {
-          output += "  ← reads from:\n";
-          for (const sourceId of info.readingFrom) {
-            const sourceName = connections.get(sourceId)?.name || sourceId.slice(0, 8) + "...";
-            output += `    • ${sourceName} [${sourceId.slice(0, 8)}...]\n`;
-          }
-        }
-        
-        if (info.readBy.length > 0) {
-          output += "  → read by:\n";
-          for (const targetId of info.readBy) {
-            const targetName = connections.get(targetId)?.name || targetId.slice(0, 8) + "...";
-            output += `    • ${targetName} [${targetId.slice(0, 8)}...]\n`;
-          }
-        }
-        
-        if (info.readingFrom.length === 0 && info.readBy.length === 0) {
-          output += "  (no connections)\n";
-        }
-        
-        output += "\n";
-      }
-
-      render(output);
-    }
+    const map = await generateSpaceMap(spaceConfig, format);
+    render(map);
   });
 
 interface CharmCLIOptions {

--- a/packages/cli/commands/charm.ts
+++ b/packages/cli/commands/charm.ts
@@ -7,6 +7,7 @@ import {
   inspectCharm,
   linkCharms,
   listCharms,
+  MapFormat,
   newCharm,
   saveCharmRecipe,
   setCharmRecipe,
@@ -286,7 +287,7 @@ Recipe: ${charmData.recipeName || "<no recipe name>"}
   )
   .action(async (options) => {
     const spaceConfig = parseSpaceOptions(options);
-    const format = options.format as "ascii" | "dot";
+    const format = options.format === "dot" ? MapFormat.DOT : MapFormat.ASCII;
     
     const map = await generateSpaceMap(spaceConfig, format);
     render(map);

--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -428,14 +428,29 @@ function generateDotMap(connections: CharmConnectionMap): string {
   return dot;
 }
 
-export async function generateSpaceMap(config: SpaceConfig, format: "ascii" | "dot" = "ascii"): Promise<string> {
-  const connections = await buildConnectionMap(config);
-  
-  if (format === "dot") {
-    return generateDotMap(connections);
-  } else {
-    return generateAsciiMap(connections);
+export enum MapFormat {
+  ASCII = "ascii",
+  DOT = "dot",
+}
+
+export async function getCharmConnections(config: SpaceConfig): Promise<CharmConnectionMap> {
+  return await buildConnectionMap(config);
+}
+
+export function formatSpaceMap(connections: CharmConnectionMap, format: MapFormat): string {
+  switch (format) {
+    case MapFormat.ASCII:
+      return generateAsciiMap(connections);
+    case MapFormat.DOT:
+      return generateDotMap(connections);
+    default:
+      throw new Error(`Unsupported format: ${format}`);
   }
+}
+
+export async function generateSpaceMap(config: SpaceConfig, format: MapFormat = MapFormat.ASCII): Promise<string> {
+  const connections = await getCharmConnections(config);
+  return formatSpaceMap(connections, format);
 }
 
 export async function inspectCharm(

--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -328,7 +328,12 @@ export type CharmConnectionMap = Map<string, CharmConnection>;
 
 // Helper functions for charm mapping
 function createShortId(id: string): string {
-  return id.slice(0, SHORT_ID_LENGTH) + "...";
+  if (id.length <= SHORT_ID_LENGTH * 2 + 3) {
+    return id; // Don't truncate if it's already short enough
+  }
+  const start = id.slice(0, SHORT_ID_LENGTH);
+  const end = id.slice(-SHORT_ID_LENGTH);
+  return `${start}...${end}`;
 }
 
 function createCharmConnection(
@@ -383,7 +388,7 @@ function generateAsciiMap(connections: CharmConnectionMap): string {
       output += "  ← reads from:\n";
       for (const sourceId of info.readingFrom) {
         const sourceName = connections.get(sourceId)?.name || createShortId(sourceId);
-        output += `    • ${sourceName} [${createShortId(sourceId)}]\n`;
+        output += `    • ${sourceName}\n`;
       }
     }
     
@@ -391,7 +396,7 @@ function generateAsciiMap(connections: CharmConnectionMap): string {
       output += "  → read by:\n";
       for (const targetId of info.readBy) {
         const targetName = connections.get(targetId)?.name || createShortId(targetId);
-        output += `    • ${targetName} [${createShortId(targetId)}]\n`;
+        output += `    • ${targetName}\n`;
       }
     }
     

--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -314,6 +314,130 @@ export async function linkCharms(
   await manager.synced();
 }
 
+// Constants for charm mapping
+const SHORT_ID_LENGTH = 8;
+
+// Types for charm mapping
+export interface CharmConnection {
+  name: string;
+  readingFrom: string[];
+  readBy: string[];
+}
+
+export type CharmConnectionMap = Map<string, CharmConnection>;
+
+// Helper functions for charm mapping
+function createShortId(id: string): string {
+  return id.slice(0, SHORT_ID_LENGTH) + "...";
+}
+
+function createCharmConnection(
+  charm: { id: string; name?: string },
+  details?: { name?: string; readingFrom: Array<{ id: string }>; readBy: Array<{ id: string }> },
+): CharmConnection {
+  return {
+    name: details?.name || charm.name || createShortId(charm.id),
+    readingFrom: details?.readingFrom.map(c => c.id) || [],
+    readBy: details?.readBy.map(c => c.id) || [],
+  };
+}
+
+async function buildConnectionMap(config: SpaceConfig): Promise<CharmConnectionMap> {
+  const charms = await listCharms(config);
+  const connections: CharmConnectionMap = new Map();
+
+  for (const charm of charms) {
+    const charmConfig: CharmConfig = { ...config, charm: charm.id };
+    try {
+      const details = await inspectCharm(charmConfig);
+      connections.set(charm.id, createCharmConnection(charm, details));
+    } catch (error) {
+      // Skip charms that can't be inspected, but include them with no connections
+      console.error(`Warning: Could not inspect charm ${charm.id}: ${error instanceof Error ? error.message : String(error)}`);
+      connections.set(charm.id, createCharmConnection(charm));
+    }
+  }
+
+  return connections;
+}
+
+function generateAsciiMap(connections: CharmConnectionMap): string {
+  if (connections.size === 0) {
+    return "No charms found in space.";
+  }
+
+  let output = "=== Charm Space Map ===\n\n";
+
+  // Sort charms by connection count for better visualization
+  const sortedCharms = Array.from(connections.entries()).sort(
+    ([, a], [, b]) => 
+      (b.readingFrom.length + b.readBy.length) - 
+      (a.readingFrom.length + a.readBy.length)
+  );
+
+  for (const [id, info] of sortedCharms) {
+    const shortId = createShortId(id);
+    output += `📦 ${info.name} [${shortId}]\n`;
+    
+    if (info.readingFrom.length > 0) {
+      output += "  ← reads from:\n";
+      for (const sourceId of info.readingFrom) {
+        const sourceName = connections.get(sourceId)?.name || createShortId(sourceId);
+        output += `    • ${sourceName} [${createShortId(sourceId)}]\n`;
+      }
+    }
+    
+    if (info.readBy.length > 0) {
+      output += "  → read by:\n";
+      for (const targetId of info.readBy) {
+        const targetName = connections.get(targetId)?.name || createShortId(targetId);
+        output += `    • ${targetName} [${createShortId(targetId)}]\n`;
+      }
+    }
+    
+    if (info.readingFrom.length === 0 && info.readBy.length === 0) {
+      output += "  (no connections)\n";
+    }
+    
+    output += "\n";
+  }
+
+  return output;
+}
+
+function generateDotMap(connections: CharmConnectionMap): string {
+  let dot = "digraph CharmSpace {\n";
+  dot += "  rankdir=LR;\n";
+  dot += "  node [shape=box];\n\n";
+
+  // Add nodes
+  for (const [id, info] of connections) {
+    const shortId = createShortId(id);
+    dot += `  "${id}" [label="${info.name}\\n${shortId}"];\n`;
+  }
+  dot += "\n";
+
+  // Add edges
+  for (const [id, info] of connections) {
+    for (const targetId of info.readingFrom) {
+      dot += `  "${targetId}" -> "${id}";\n`;
+    }
+  }
+
+  dot += "}";
+  return dot;
+}
+
+export async function generateSpaceMap(config: SpaceConfig, format: "ascii" | "dot" = "ascii"): Promise<string> {
+  const connections = await buildConnectionMap(config);
+  
+  if (format === "dot") {
+    return generateDotMap(connections);
+  } else {
+    return generateAsciiMap(connections);
+  }
+}
+
 export async function inspectCharm(
   config: CharmConfig,
 ): Promise<{


### PR DESCRIPTION
`ct charm map --identity ~/dev/.ct.key --api-url https://toolshed.saga-castor.ts.net/ --space 2025-06-25-mentions-dev --format dot`

![charm-map](https://github.com/user-attachments/assets/759487b0-bf90-492f-83fd-1a31f9b4a6c6)


    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added the `ct charm map` command to visualize all charms and their connections in a space, with support for ASCII and Graphviz DOT output.

- **New Features**
  - Shows a readable map of charms and their links in ASCII format.
  - Supports `--format dot` to generate Graphviz DOT output for visual diagrams.

<!-- End of auto-generated description by cubic. -->

