### PR TITLE
Remove no longer unused getQueryResultOrValue

### DIFF
--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -19,7 +19,6 @@ export { isDoc } from "./doc.ts";
 export { isCell, isStream } from "./cell.ts";
 export {
   getCellLinkOrThrow,
-  getCellLinkOrValue,
   isQueryResult,
   isQueryResultForDereferencing,
 } from "./query-result-proxy.ts";

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -302,17 +302,6 @@ function isProxyForArrayValue(value: any): value is ProxyForArrayValue {
 }
 
 /**
- * Get cell link or return values as is if not a cell value proxy.
- *
- * @param {any} value - The value to get the cell link or value from.
- * @returns {LegacyDocCellLink | any}
- */
-export function getCellLinkOrValue(value: any): LegacyDocCellLink {
-  if (isQueryResult(value)) return value[getCellLink];
-  else return value;
-}
-
-/**
  * Get cell link or throw if not a cell value proxy.
  *
  * @param {any} value - The value to get the cell link from.


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the unused getCellLinkOrValue function and its export to clean up the codebase.

<!-- End of auto-generated description by cubic. -->

