### PR TITLE
chore: source map invocations CT-500

### DIFF
--- a/packages/js-runtime/runtime/eval-runtime.ts
+++ b/packages/js-runtime/runtime/eval-runtime.ts
@@ -66,6 +66,12 @@ export class UnsafeEvalIsolate implements JsIsolate {
     const result = this.internals.exec(() => eval(js));
     return new UnsafeEvalJsValue(this.internals, result);
   }
+
+  // Make a new `UnsafeEvalJsValue` for this isolate from input.
+  // Does not verify the providence of input.
+  value<T>(value: T) {
+    return new UnsafeEvalJsValue(this.internals, value);
+  }
 }
 
 export class UnsafeEvalRuntime extends EventTarget implements JsRuntime {

--- a/packages/jumble/src/contexts/RuntimeContext.tsx
+++ b/packages/jumble/src/contexts/RuntimeContext.tsx
@@ -53,8 +53,7 @@ export function RuntimeProvider({
             "Uncaught error in recipe: " + error.message + "\n" + error.stack,
           );
         }
-        console.error("Uncaught error in recipe:", error.message);
-        console.error("Stack trace:", error.stack);
+        console.error(error);
         // Also send to Sentry
         Sentry.captureException(error);
       }],

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -144,13 +144,22 @@ export class Engine extends EventTarget implements Harness {
     return { exports, output: compiled };
   }
 
-  getInvocation(source: string): HarnessedFunction {
-    return eval(source);
+  // Invokes a function that should've came from this isolate (unverifiable).
+  // We use this to hook into the isolate's source mapping functionality.
+  invoke(fn: () => any): any {
+    // Scheduler dictates this is a synchronous function,
+    // and if we have functions from this source, this should already
+    // be set up.
+    // Some tests invoke values outside of this isolate, so just
+    // execute and return if internals have not been initialized.
+    if (!this.internals) {
+      return fn();
+    }
+    return this.internals.isolate.value(fn).invoke().inner();
   }
 
-  mapStackTrace(stack: string): string {
-    //return mapSourceMapsOnStacktrace(stack);
-    return stack;
+  getInvocation(source: string): HarnessedFunction {
+    return eval(source);
   }
 
   // Returns a map of runtime module types.

--- a/packages/runner/src/harness/harness.ts
+++ b/packages/runner/src/harness/harness.ts
@@ -19,7 +19,7 @@ export interface Harness extends EventTarget {
     source: ProgramResolver,
   ): Promise<Program>;
 
-  getInvocation(source: string): HarnessedFunction;
+  invoke(fn: () => any): any;
 
-  mapStackTrace(stack: string): string;
+  getInvocation(source: string): HarnessedFunction;
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Refactored function invocation in the runner to use a new invoke method, preparing for improved source map support and error handling.

- **Refactors**
  - Replaced direct function calls with an invoke method in the engine and scheduler.
  - Simplified error logging in RuntimeContext.

<!-- End of auto-generated description by cubic. -->

