### PR TITLE
chore: Update js-runtime to export all user-authored files from the evaluated bundle CT-499

### DIFF
--- a/packages/cli/commands/dev.ts
+++ b/packages/cli/commands/dev.ts
@@ -30,7 +30,7 @@ export const dev = new Command()
   )
   .arguments("<main:string>")
   .action(async (options, main) => {
-    const { exports } = await process({
+    const { main: exports } = await process({
       main: join(Deno.cwd(), main),
       check: options.check,
       run: options.run,

--- a/packages/cli/lib/dev.ts
+++ b/packages/cli/lib/dev.ts
@@ -60,7 +60,7 @@ export interface ProcessOptions {
 
 export async function process(
   options: ProcessOptions,
-): Promise<{ output: JsScript; exports: any }> {
+): Promise<{ output: JsScript; main?: Record<string, any> }> {
   const filename = options.filename
     ? basename(options.filename)
     : options.output
@@ -68,7 +68,7 @@ export async function process(
     : undefined;
   const engine = new Engine(await createRuntime());
   const program = await engine.resolve(new CliProgram(options.main));
-  const { output, exports } = await engine.process(program, {
+  const { output, main } = await engine.process(program, {
     noCheck: !options.check,
     noRun: !options.run,
     filename,
@@ -77,5 +77,5 @@ export async function process(
   if (options.output) {
     await Deno.writeTextFile(options.output, output.js);
   }
-  return { output, exports };
+  return { output, main };
 }

--- a/packages/js-runtime/deno.json
+++ b/packages/js-runtime/deno.json
@@ -1,7 +1,6 @@
 {
   "name": "@commontools/js-runtime",
   "tasks": {
-    "cli": "deno run --allow-read --allow-write --allow-env=TOOLSHED_API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV ./cli/mod.ts",
     "test": "deno test --allow-read --allow-write --allow-run --allow-env=TOOLSHED_API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV test/*.test.ts"
   },
   "imports": {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the js-runtime to export all user-authored files from the evaluated bundle, making every file’s exports available at runtime.

- **New Features**
  - Bundles now return both the main export and a map of all user-authored file exports.
  - Added tests to verify all exports are accessible after evaluation.

<!-- End of auto-generated description by cubic. -->

