### PR TITLE
feat: Allow specifying a named export from an entry file as recipe entry.

### DIFF
--- a/packages/charm/src/iterate.ts
+++ b/packages/charm/src/iterate.ts
@@ -11,6 +11,7 @@ import {
   createJsonSchema,
   JSONSchema,
   JSONSchemaMutable,
+  RuntimeProgram,
 } from "@commontools/runner";
 import { Charm, CharmManager, charmSourceCellSchema } from "./manager.ts";
 import { buildFullRecipe, getIframeRecipe } from "./iframe/recipe.ts";
@@ -26,7 +27,6 @@ import {
 import { injectUserCode } from "./iframe/static.ts";
 import { IFrameRecipe, WorkflowForm } from "./index.ts";
 import { console } from "./conditional-console.ts";
-import { Program } from "@commontools/js-runtime";
 
 const llm = new LLMClient();
 
@@ -518,7 +518,7 @@ export async function castNewRecipe(
 }
 
 export async function compileRecipe(
-  recipeSrc: string | Program,
+  recipeSrc: string | RuntimeProgram,
   spec: string,
   runtime: Runtime,
   space: MemorySpace,

--- a/packages/cli/commands/charm.ts
+++ b/packages/cli/commands/charm.ts
@@ -90,12 +90,16 @@ export const charm = new Command()
     `Create a new charm, using ./main.tsx as source.`,
   )
   .arguments("<main:string>")
+  .option(
+    "--main-export <export:string>",
+    'Named export from entry for recipe definition. Defaults to "default".',
+  )
   .action(
     async (options, main) =>
       render(
         await newCharm(
           parseSpaceOptions(options),
-          absPath(main),
+          { mainPath: absPath(main), mainExport: options.mainExport },
         ),
       ),
   )
@@ -142,9 +146,16 @@ export const charm = new Command()
     `Update the source for "${RAW_EX_COMP.charm!}" with ./main.tsx`,
   )
   .option("-c,--charm <charm:string>", "The target charm ID.")
+  .option(
+    "--main-export <export:string>",
+    'Named export from entry for recipe definition. Defaults to "default".',
+  )
   .arguments("<main:string>")
   .action((options, mainPath) =>
-    setCharmRecipe(parseCharmOptions(options), absPath(mainPath))
+    setCharmRecipe(parseCharmOptions(options), {
+      mainPath: absPath(mainPath),
+      mainExport: options.mainExport,
+    })
   )
   /* charm inspect */
   .command("inspect", "Inspect detailed information about a charm")

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -28,6 +28,7 @@ IDENTITY=$(mktemp)
 SPACE_ARGS="--api-url=$API_URL --identity=$IDENTITY --space=$SPACE"
 RECIPE_SRC="$SCRIPT_DIR/recipe/main.tsx"
 WORK_DIR=$(mktemp -d)
+CUSTOM_EXPORT="customRecipeExport" # for testing this feature
 
 echo "API_URL=$API_URL"
 echo "SPACE=$SPACE"
@@ -42,8 +43,8 @@ if [ "$(ct charm ls $SPACE_ARGS)" != "" ]; then
   error "Space not empty." 
 fi
 
-# Create a new charm with {value:5} as input
-CHARM_ID=$(ct charm new $SPACE_ARGS $RECIPE_SRC)
+# Create a new charm using custom default export as input
+CHARM_ID=$(ct charm new --main-export $CUSTOM_EXPORT $SPACE_ARGS $RECIPE_SRC)
 echo "Created charm: $CHARM_ID"
 
 echo "Fetching charm source to $WORK_DIR"
@@ -62,7 +63,7 @@ echo "Updating charm source."
 
 # Update the charm's source code
 replace 's/Simple counter:/Simple counter 2:/g' "$WORK_DIR/main.tsx"
-ct charm setsrc $SPACE_ARGS --charm $CHARM_ID $WORK_DIR/main.tsx
+ct charm setsrc --main-export $CUSTOM_EXPORT $SPACE_ARGS --charm $CHARM_ID $WORK_DIR/main.tsx
 
 # (Again) Retrieve the source code for $CHARM_ID to $WORK_DIR
 rm "$WORK_DIR/main.tsx"

--- a/packages/cli/integration/recipe/main.tsx
+++ b/packages/cli/integration/recipe/main.tsx
@@ -1,8 +1,8 @@
 // deno-lint-ignore-file jsx-no-useless-fragment
 import { derive, h, NAME, recipe, str, UI } from "commontools";
-import { model, increment, decrement } from "./utils.ts";
+import { decrement, increment, model } from "./utils.ts";
 
-export default recipe(model, model, (cell) => {
+export const customRecipeExport = recipe(model, model, (cell) => {
   return {
     [NAME]: str`Simple counter: ${derive(cell.value, String)}`,
     [UI]: (

--- a/packages/runner/src/harness/harness.ts
+++ b/packages/runner/src/harness/harness.ts
@@ -1,16 +1,31 @@
 import { type Recipe } from "../builder/types.ts";
 import type { Program, ProgramResolver } from "@commontools/js-runtime";
-import { type EngineProcessOptions } from "./engine.ts";
 
 export type HarnessedFunction = (input: any) => void;
+
+export type RuntimeProgram = Program & {
+  // The named export from the program's entry file to run.
+  // Defaults to "default".
+  mainExport?: string;
+};
+
+export interface TypeScriptHarnessProcessOptions {
+  // Disables typechecking of the program.
+  noCheck?: boolean;
+  // Does not evaluate the recipe.
+  noRun?: boolean;
+  // Filename to use in the compiled JS code, for engines
+  // that apply source maps.
+  filename?: string;
+}
 
 // A `Harness` wraps a flow of compiling, bundling, and executing typescript.
 export interface Harness extends EventTarget {
   // Compiles and executes `source`, returning the default export
   // of that module.
   run(
-    source: Program,
-    options?: EngineProcessOptions,
+    source: RuntimeProgram,
+    options?: TypeScriptHarnessProcessOptions,
   ): Promise<Recipe>;
 
   // Resolves a `ProgramResolver` into a `Program` using the engine's

--- a/packages/runner/src/harness/index.ts
+++ b/packages/runner/src/harness/index.ts
@@ -1,7 +1,8 @@
-export {
-  Engine,
-  type EngineProcessOptions,
-  EngineProgramResolver,
-} from "./engine.ts";
-export { type Harness } from "./harness.ts";
+export { Engine, EngineProgramResolver } from "./engine.ts";
+export type {
+  Harness,
+  HarnessedFunction,
+  RuntimeProgram,
+  TypeScriptHarnessProcessOptions,
+} from "./harness.ts";
 export { Console, ConsoleEvent, ConsoleMethod } from "./console.ts";

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -30,8 +30,8 @@ export {
   type ConsoleEvent,
   ConsoleMethod,
   Engine,
-  type EngineProcessOptions,
-  EngineProgramResolver,
+  type RuntimeProgram,
+  type TypeScriptHarnessProcessOptions,
 } from "./harness/index.ts";
 export { addCommonIDfromObjectID } from "./data-updating.ts";
 export { followWriteRedirects } from "./link-resolution.ts";

--- a/packages/runner/src/recipe-manager.ts
+++ b/packages/runner/src/recipe-manager.ts
@@ -2,7 +2,7 @@ import { JSONSchema, Module, Recipe, Schema } from "./builder/types.ts";
 import { Cell } from "./cell.ts";
 import type { IRecipeManager, IRuntime, MemorySpace } from "./runtime.ts";
 import { createRef } from "./doc-map.ts";
-import { Program } from "@commontools/js-runtime";
+import { RuntimeProgram } from "./harness/harness.ts";
 
 export const recipeMetaSchema = {
   type: "object",
@@ -17,6 +17,7 @@ export const recipeMetaSchema = {
       type: "object",
       properties: {
         main: { type: "string" },
+        mainExport: { type: "string" },
         files: {
           type: "array",
           items: {
@@ -69,7 +70,10 @@ export class RecipeManager implements IRecipeManager {
     return this.recipeMetaMap.get(input as Recipe)?.get()!;
   }
 
-  generateRecipeId(recipe: Recipe | Module, src?: string | Program): string {
+  generateRecipeId(
+    recipe: Recipe | Module,
+    src?: string | RuntimeProgram,
+  ): string {
     const id = this.recipeMetaMap.get(recipe as Recipe)?.get()?.id;
     if (id) {
       return id;
@@ -114,8 +118,8 @@ export class RecipeManager implements IRecipeManager {
     return this.recipeIdMap.get(recipeId);
   }
 
-  async compileRecipe(input: string | Program): Promise<Recipe> {
-    let program: Program | undefined;
+  async compileRecipe(input: string | RuntimeProgram): Promise<Recipe> {
+    let program: RuntimeProgram | undefined;
     if (typeof input === "string") {
       program = {
         main: "/main.tsx",
@@ -141,7 +145,7 @@ export class RecipeManager implements IRecipeManager {
     }
 
     const source = recipeMeta.program
-      ? (recipeMeta.program as Program)
+      ? (recipeMeta.program as RuntimeProgram)
       : recipeMeta.src!;
     const recipe = await this.compileRecipe(source);
     this.recipeIdMap.set(recipeId, recipe);

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -20,7 +20,7 @@ import { isDoc } from "./doc.ts";
 import { type EntityId, getEntityId } from "./doc-map.ts";
 import type { Cancel } from "./cancel.ts";
 import type { Action, EventHandler, ReactivityLog } from "./scheduler.ts";
-import type { Harness } from "./harness/harness.ts";
+import type { Harness, RuntimeProgram } from "./harness/harness.ts";
 import { Engine } from "./harness/index.ts";
 import { ConsoleMethod } from "./harness/console.ts";
 import { isLegacyCellLink, type NormalizedLink } from "./link-utils.ts";
@@ -178,9 +178,9 @@ export interface IStorage {
 export interface IRecipeManager {
   readonly runtime: IRuntime;
   recipeById(id: string): any;
-  generateRecipeId(recipe: any, src?: string | Program): string;
+  generateRecipeId(recipe: any, src?: string | RuntimeProgram): string;
   loadRecipe(id: string, space?: MemorySpace): Promise<Recipe>;
-  compileRecipe(input: string | Program): Promise<Recipe>;
+  compileRecipe(input: string | RuntimeProgram): Promise<Recipe>;
   getRecipeMeta(input: any): RecipeMeta;
   registerRecipe(
     params: {
@@ -258,7 +258,6 @@ import { ModuleRegistry } from "./module.ts";
 import { DocumentMap } from "./doc-map.ts";
 import { Runner } from "./runner.ts";
 import { registerBuiltins } from "./builtins/index.ts";
-import { Program } from "@commontools/js-runtime";
 
 /**
  * Main Runtime class that orchestrates all services in the runner package.


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
You can now specify a named export from an entry file to use as the recipe entry, instead of always using the default export.

- **New Features**
  - Added a --main-export option to CLI commands for creating and updating charms.
  - Updated the runner to support loading recipes from any named export.

<!-- End of auto-generated description by cubic. -->

