### PR TITLE
feat: register recipes with corresponding exports

### DIFF
--- a/packages/charm/src/iterate.ts
+++ b/packages/charm/src/iterate.ts
@@ -546,7 +546,7 @@ export async function compileRecipe(
   } else {
     recipeMeta.program = recipeSrc;
   }
-  await runtime.recipeManager.registerRecipe({
+  await runtime.recipeManager.saveAndSyncRecipe({
     recipeId,
     space,
     recipe,

--- a/packages/charm/src/iterate.ts
+++ b/packages/charm/src/iterate.ts
@@ -530,7 +530,7 @@ export async function compileRecipe(
     throw new Error("No default recipe found in the compiled exports.");
   }
   const parentsIds = parents?.map((id) => id.toString());
-  const recipeId = runtime.recipeManager.generateRecipeId(
+  const recipeId = runtime.recipeManager.registerRecipe(
     recipe,
     recipeSrc,
   );

--- a/packages/html/test/html-recipes.test.ts
+++ b/packages/html/test/html-recipes.test.ts
@@ -15,10 +15,10 @@ describe("recipes with HTML", () => {
   let document: Document;
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
-  let lift: ReturnType<typeof createBuilder>["lift"];
-  let recipe: ReturnType<typeof createBuilder>["recipe"];
-  let str: ReturnType<typeof createBuilder>["str"];
-  let UI: ReturnType<typeof createBuilder>["UI"];
+  let lift: ReturnType<typeof createBuilder>["commontools"]["lift"];
+  let recipe: ReturnType<typeof createBuilder>["commontools"]["recipe"];
+  let str: ReturnType<typeof createBuilder>["commontools"]["str"];
+  let UI: ReturnType<typeof createBuilder>["commontools"]["UI"];
 
   beforeEach(() => {
     // Set up a fresh JSDOM instance for each test
@@ -39,8 +39,8 @@ describe("recipes with HTML", () => {
       storageManager,
     });
 
-    const builder = createBuilder(runtime);
-    ({ lift, recipe, str, UI } = builder);
+    const { commontools } = createBuilder(runtime);
+    ({ lift, recipe, str, UI } = commontools);
   });
 
   afterEach(async () => {

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -81,6 +81,9 @@ export const createBuilder = (
     return cell;
   } as CreateCellFunction;
 
+  // Associate runtime programs with recipes after compilation and initial eval
+  // and before compilation returns, so before any e.g. recipe would be
+  // instantiated. This way they get saved with a way to rehydrate them.
   const exportsCallback = (exports: Map<any, RuntimeProgram>) => {
     for (const [value, program] of exports) {
       if (isRecipe(value)) {

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -1,7 +1,6 @@
 /**
  * Factory function to create builder functions with runtime dependency injection
  */
-
 import { getCellLinkOrThrow, type Runtime } from "../index.ts";
 import type {
   BuilderFunctionsAndConstants,
@@ -14,6 +13,7 @@ import {
   h,
   ID,
   ID_FIELD,
+  isRecipe,
   NAME,
   schema,
   TYPE,
@@ -33,6 +33,7 @@ import {
   streamData,
 } from "./built-in.ts";
 import { getRecipeEnvironment } from "./env.ts";
+import type { RuntimeProgram } from "../harness/harness.ts";
 
 /**
  * Creates a set of builder functions with the given runtime
@@ -41,7 +42,10 @@ import { getRecipeEnvironment } from "./env.ts";
  */
 export const createBuilder = (
   runtime: Runtime,
-): BuilderFunctionsAndConstants => {
+): {
+  commontools: BuilderFunctionsAndConstants;
+  exportsCallback: (exports: Map<any, RuntimeProgram>) => void;
+} => {
   // Implementation of createCell moved from runner/harness
   const createCell: CreateCellFunction = function createCell<T = any>(
     schema?: JSONSchema,
@@ -77,50 +81,62 @@ export const createBuilder = (
     return cell;
   } as CreateCellFunction;
 
+  const exportsCallback = (exports: Map<any, RuntimeProgram>) => {
+    for (const [value, program] of exports) {
+      if (isRecipe(value)) {
+        // This will associate the program with the recipe
+        runtime.recipeManager.generateRecipeId(value, program);
+      }
+    }
+  };
+
   return {
-    // Recipe creation
-    recipe,
+    commontools: {
+      // Recipe creation
+      recipe,
 
-    // Module creation
-    lift,
-    handler,
-    derive,
-    compute,
-    render,
+      // Module creation
+      lift,
+      handler,
+      derive,
+      compute,
+      render,
 
-    // Built-in modules
-    str,
-    ifElse,
-    llm,
-    generateObject,
-    fetchData,
-    streamData,
-    compileAndRun,
-    navigateTo,
+      // Built-in modules
+      str,
+      ifElse,
+      llm,
+      generateObject,
+      fetchData,
+      streamData,
+      compileAndRun,
+      navigateTo,
 
-    // Cell creation
-    createCell,
-    cell: opaqueRef,
-    stream,
+      // Cell creation
+      createCell,
+      cell: opaqueRef,
+      stream,
 
-    // Utility
-    byRef,
+      // Utility
+      byRef,
 
-    // Environment
-    getRecipeEnvironment,
+      // Environment
+      getRecipeEnvironment,
 
-    // Constants
-    ID,
-    ID_FIELD,
-    TYPE,
-    NAME,
-    UI,
+      // Constants
+      ID,
+      ID_FIELD,
+      TYPE,
+      NAME,
+      UI,
 
-    // Schema utilities
-    schema,
-    AuthSchema,
+      // Schema utilities
+      schema,
+      AuthSchema,
 
-    // Render utils
-    h,
+      // Render utils
+      h,
+    },
+    exportsCallback,
   };
 };

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -88,7 +88,7 @@ export const createBuilder = (
     for (const [value, program] of exports) {
       if (isRecipe(value)) {
         // This will associate the program with the recipe
-        runtime.recipeManager.generateRecipeId(value, program);
+        runtime.recipeManager.registerRecipe(value, program);
       }
     }
   };

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -163,19 +163,20 @@ export class Engine extends EventTarget implements Harness {
 
         // Create a map from exported values to `RuntimeProgram` that can
         // generate them and pass to the callback from the exports.
-        if (exportsCallback) {
-          const exportsByValue = new Map<any, RuntimeProgram>();
-          for (const [fileName, exports] of Object.entries(exportMap)) {
-            for (const [exportName, exportValue] of Object.entries(exports)) {
-              exportsByValue.set(exportValue, {
-                main: fileName,
-                mainExport: exportName,
-                files: program.files,
-              });
-            }
+        const exportsByValue = new Map<any, RuntimeProgram>();
+        for (const [fileName, exports] of Object.entries(exportMap)) {
+          for (const [exportName, exportValue] of Object.entries(exports)) {
+            exportsByValue.set(exportValue, {
+              main: fileName,
+              mainExport: exportName,
+              // TODO(seefeld): Sending all `program.files` is sub-optimal, as
+              // it is the super set of files actually needed by main. We should
+              // only send the files actually needed by main.
+              files: program.files,
+            });
           }
-          exportsCallback(exportsByValue);
         }
+        exportsCallback(exportsByValue);
 
         return { output, main, exportMap };
       }

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -75,6 +75,9 @@ interface Internals {
   runtime: UnsafeEvalRuntime;
   isolate: UnsafeEvalIsolate;
   runtimeExports: Record<string, any> | undefined;
+  // Callback will be called with a map of exported values to `RuntimeProgram`
+  // after compilation and initial eval and before compilation returns, so
+  // before any e.g. recipe would be instantiated.
   exportsCallback: (exports: Map<any, RuntimeProgram>) => void;
 }
 
@@ -157,6 +160,9 @@ export class Engine extends EventTarget implements Harness {
       ) {
         const main = result.main as Exports;
         const exportMap = result.exportMap as Record<string, Exports>;
+
+        // Create a map from exported values to `RuntimeProgram` that can
+        // generate them and pass to the callback from the exports.
         if (exportsCallback) {
           const exportsByValue = new Map<any, RuntimeProgram>();
           for (const [fileName, exports] of Object.entries(exportMap)) {
@@ -170,6 +176,7 @@ export class Engine extends EventTarget implements Harness {
           }
           exportsCallback(exportsByValue);
         }
+
         return { output, main, exportMap };
       }
     }

--- a/packages/runner/src/harness/runtime-modules.ts
+++ b/packages/runner/src/harness/runtime-modules.ts
@@ -2,6 +2,7 @@ import { createBuilder } from "../builder/factory.ts";
 import { cache } from "@commontools/static";
 import turndown from "turndown";
 import { IRuntime } from "../runtime.ts";
+import type { Program } from "@commontools/js-runtime";
 
 export type RuntimeModuleIdentifier =
   | "commontools"
@@ -55,17 +56,20 @@ export const getTypes = (() => {
 })();
 
 export async function getExports(runtime: IRuntime) {
-  const builder = createBuilder(runtime);
+  const { commontools, exportsCallback } = createBuilder(runtime);
   const DOMParser = await getDOMParser();
   return {
-    "commontools": builder,
-    "dom-parser": { DOMParser },
-    // __esModule lets this load in the AMD loader
-    // when finding the "default"
-    "turndown": { default: turndown, __esModule: true },
-    "@commontools/html": builder,
-    "@commontools/builder": builder,
-    "@commontools/runner": builder,
+    runtimeExports: {
+      "commontools": commontools,
+      "dom-parser": { DOMParser },
+      // __esModule lets this load in the AMD loader
+      // when finding the "default"
+      "turndown": { default: turndown, __esModule: true },
+      "@commontools/html": commontools,
+      "@commontools/builder": commontools,
+      "@commontools/runner": commontools,
+    },
+    exportsCallback,
   };
 }
 

--- a/packages/runner/src/harness/runtime-modules.ts
+++ b/packages/runner/src/harness/runtime-modules.ts
@@ -2,7 +2,6 @@ import { createBuilder } from "../builder/factory.ts";
 import { cache } from "@commontools/static";
 import turndown from "turndown";
 import { IRuntime } from "../runtime.ts";
-import type { Program } from "@commontools/js-runtime";
 
 export type RuntimeModuleIdentifier =
   | "commontools"

--- a/packages/runner/src/recipe-manager.ts
+++ b/packages/runner/src/recipe-manager.ts
@@ -69,7 +69,7 @@ export class RecipeManager implements IRecipeManager {
     return this.recipeMetaMap.get(input as Recipe)?.get()!;
   }
 
-  generateRecipeId(
+  registerRecipe(
     recipe: Recipe | Module,
     src?: string | RuntimeProgram,
   ): string {
@@ -127,20 +127,19 @@ export class RecipeManager implements IRecipeManager {
     return true;
   }
 
-  saveAndSyncRecipe(
+  async saveAndSyncRecipe(
     { recipeId, space, recipe, recipeMeta }: {
       recipeId: string;
       space: MemorySpace;
       recipe: Recipe | Module;
       recipeMeta: RecipeMeta;
     },
-  ): Promise<boolean> {
-    if (!this.saveRecipe({ recipeId, space, recipe, recipeMeta })) {
-      return Promise.resolve(false);
+  ) {
+    if (this.saveRecipe({ recipeId, space, recipe, recipeMeta })) {
+      await this.runtime.storage.syncCell(
+        this.getRecipeMetaCell({ recipeId, space }),
+      );
     }
-    return Promise.resolve(this.runtime.storage
-      .syncCell(this.getRecipeMetaCell({ recipeId, space })))
-      .then(() => true);
   }
 
   // returns a recipe already loaded

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -160,6 +160,11 @@ export class Runner implements IRunner {
     }
 
     recipeId ??= this.runtime.recipeManager.generateRecipeId(recipe);
+    this.runtime.recipeManager.saveRecipe({
+      recipeId,
+      space: resultDoc.space,
+      recipe,
+    });
 
     if (this.cancels.has(resultDoc)) {
       // If it's already running and no new recipe or argument are given,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -141,7 +141,7 @@ export class Runner implements IRunner {
     // passing arguments in unmodified and passing all results through as is
     if (isModule(recipeOrModule)) {
       const module = recipeOrModule as Module;
-      recipeId ??= this.runtime.recipeManager.generateRecipeId(module);
+      recipeId ??= this.runtime.recipeManager.registerRecipe(module);
 
       recipe = {
         argumentSchema: module.argumentSchema ?? {},
@@ -159,7 +159,7 @@ export class Runner implements IRunner {
       recipe = recipeOrModule as Recipe;
     }
 
-    recipeId ??= this.runtime.recipeManager.generateRecipeId(recipe);
+    recipeId ??= this.runtime.recipeManager.registerRecipe(recipe);
     this.runtime.recipeManager.saveRecipe({
       recipeId,
       space: resultDoc.space,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -203,12 +203,20 @@ export interface IRecipeManager {
   loadRecipe(id: string, space?: MemorySpace): Promise<Recipe>;
   compileRecipe(input: string | RuntimeProgram): Promise<Recipe>;
   getRecipeMeta(input: any): RecipeMeta;
-  registerRecipe(
+  saveRecipe(
     params: {
       recipeId: string;
       space: MemorySpace;
-      recipe: Recipe | Module;
-      recipeMeta: RecipeMeta;
+      recipe?: Recipe | Module;
+      recipeMeta?: RecipeMeta;
+    },
+  ): boolean;
+  saveAndSyncRecipe(
+    params: {
+      recipeId: string;
+      space: MemorySpace;
+      recipe?: Recipe | Module;
+      recipeMeta?: RecipeMeta;
     },
   ): Promise<boolean>;
 }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -199,7 +199,7 @@ export interface IStorage {
 export interface IRecipeManager {
   readonly runtime: IRuntime;
   recipeById(id: string): any;
-  generateRecipeId(recipe: any, src?: string | RuntimeProgram): string;
+  registerRecipe(recipe: any, src?: string | RuntimeProgram): string;
   loadRecipe(id: string, space?: MemorySpace): Promise<Recipe>;
   compileRecipe(input: string | RuntimeProgram): Promise<Recipe>;
   getRecipeMeta(input: any): RecipeMeta;
@@ -218,7 +218,7 @@ export interface IRecipeManager {
       recipe?: Recipe | Module;
       recipeMeta?: RecipeMeta;
     },
-  ): Promise<boolean>;
+  ): Promise<void>;
 }
 
 export interface IModuleRegistry {

--- a/packages/runner/test/opaque-ref-schema.test.ts
+++ b/packages/runner/test/opaque-ref-schema.test.ts
@@ -14,8 +14,8 @@ describe("OpaqueRef Schema Support", () => {
   let frame: Frame;
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
-  let recipe: ReturnType<typeof createBuilder>["recipe"];
-  let cell: ReturnType<typeof createBuilder>["cell"];
+  let recipe: ReturnType<typeof createBuilder>["commontools"]["recipe"];
+  let cell: ReturnType<typeof createBuilder>["commontools"]["cell"];
 
   beforeEach(() => {
     // Setup frame for the test
@@ -28,8 +28,8 @@ describe("OpaqueRef Schema Support", () => {
       blobbyServerUrl: import.meta.url,
       storageManager,
     });
-    const builder = createBuilder(runtime);
-    ({ recipe, cell } = builder);
+    const { commontools } = createBuilder(runtime);
+    ({ recipe, cell } = commontools);
   });
 
   afterEach(async () => {

--- a/packages/runner/test/recipes.test.ts
+++ b/packages/runner/test/recipes.test.ts
@@ -15,12 +15,12 @@ const space = signer.did();
 describe("Recipe Runner", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
-  let lift: ReturnType<typeof createBuilder>["lift"];
-  let recipe: ReturnType<typeof createBuilder>["recipe"];
-  let createCell: ReturnType<typeof createBuilder>["createCell"];
-  let handler: ReturnType<typeof createBuilder>["handler"];
-  let byRef: ReturnType<typeof createBuilder>["byRef"];
-  let TYPE: ReturnType<typeof createBuilder>["TYPE"];
+  let lift: ReturnType<typeof createBuilder>["commontools"]["lift"];
+  let recipe: ReturnType<typeof createBuilder>["commontools"]["recipe"];
+  let createCell: ReturnType<typeof createBuilder>["commontools"]["createCell"];
+  let handler: ReturnType<typeof createBuilder>["commontools"]["handler"];
+  let byRef: ReturnType<typeof createBuilder>["commontools"]["byRef"];
+  let TYPE: ReturnType<typeof createBuilder>["commontools"]["TYPE"];
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
@@ -31,7 +31,7 @@ describe("Recipe Runner", () => {
       storageManager,
     });
 
-    const builder = createBuilder(runtime);
+    const { commontools } = createBuilder(runtime);
     ({
       lift,
       recipe,
@@ -39,7 +39,7 @@ describe("Recipe Runner", () => {
       handler,
       byRef,
       TYPE,
-    } = builder);
+    } = commontools);
   });
 
   afterEach(async () => {

--- a/packages/runner/test/schema-lineage.test.ts
+++ b/packages/runner/test/schema-lineage.test.ts
@@ -13,8 +13,8 @@ const space = signer.did();
 describe("Schema Lineage", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
-  let recipe: ReturnType<typeof createBuilder>["recipe"];
-  let UI: ReturnType<typeof createBuilder>["UI"];
+  let recipe: ReturnType<typeof createBuilder>["commontools"]["recipe"];
+  let UI: ReturnType<typeof createBuilder>["commontools"]["UI"];
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
@@ -24,8 +24,8 @@ describe("Schema Lineage", () => {
       blobbyServerUrl: import.meta.url,
       storageManager,
     });
-    const builder = createBuilder(runtime);
-    ({ recipe, UI } = builder);
+    const { commontools } = createBuilder(runtime);
+    ({ recipe, UI } = commontools);
   });
 
   afterEach(async () => {
@@ -236,8 +236,8 @@ describe("Schema Lineage", () => {
 describe("Schema propagation end-to-end example", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
-  let recipe: ReturnType<typeof createBuilder>["recipe"];
-  let UI: ReturnType<typeof createBuilder>["UI"];
+  let recipe: ReturnType<typeof createBuilder>["commontools"]["recipe"];
+  let UI: ReturnType<typeof createBuilder>["commontools"]["UI"];
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
@@ -247,8 +247,8 @@ describe("Schema propagation end-to-end example", () => {
       blobbyServerUrl: import.meta.url,
       storageManager,
     });
-    const builder = createBuilder(runtime);
-    ({ recipe, UI } = builder);
+    const { commontools } = createBuilder(runtime);
+    ({ recipe, UI } = commontools);
   });
 
   afterEach(async () => {


### PR DESCRIPTION
- Refactor RecipeManager to track recipe programs and generate IDs
- Add exportsCallback to builder factory for recipe-program association
- Update Engine to handle exports callback from RuntimeModules
- Modify recipe registration flow to save recipes with their source programs
- Update tests to reflect new recipe management structure
- Improve recipe ID generation and metadata handling

This change enables recipes to be properly associated with their corresponding export programs, improving the recipe management system's ability to track and reference recipes by their source code.

Implements CT-455
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Recipes are now registered with their corresponding export programs, allowing the system to track and reference recipes by their source code.

- **Refactors**
  - Updated RecipeManager to associate recipes with export programs and generate IDs.
  - Added an exports callback to link recipes and programs during registration.
  - Updated tests and recipe registration flow to use the new structure.

<!-- End of auto-generated description by cubic. -->

