### PR TITLE
feat: add navigateTo builtin for charm navigation

### DIFF
--- a/packages/jumble/src/components/CommandCenter.tsx
+++ b/packages/jumble/src/components/CommandCenter.tsx
@@ -32,6 +32,7 @@ import {
   ModelSelector,
   useUserPreferredModel,
 } from "@/components/common/ModelSelector.tsx";
+import { createPath } from "@/routes.ts";
 
 function CommandProcessor({
   mode,
@@ -413,15 +414,14 @@ export function CommandCenter() {
         setMode({
           type: "input",
           command: newCharmCommand,
-          placeholder: (newCharmCommand as InputCommandItem).placeholder || "What would you like to create?",
+          placeholder: (newCharmCommand as InputCommandItem).placeholder ||
+            "What would you like to create?",
         });
       }
     };
 
     const handleNewCharmEvent = () => {
-      const newCharmCommand = allCommands.find((cmd) =>
-        cmd.id === "new-charm"
-      );
+      const newCharmCommand = allCommands.find((cmd) => cmd.id === "new-charm");
       if (!newCharmCommand) {
         console.warn("New charm command not found");
         return;
@@ -430,12 +430,42 @@ export function CommandCenter() {
       setMode({
         type: "input",
         command: newCharmCommand,
-        placeholder: (newCharmCommand as InputCommandItem).placeholder || "What would you like to create?",
+        placeholder: (newCharmCommand as InputCommandItem).placeholder ||
+          "What would you like to create?",
       });
+    };
+
+    const handleNavigateToCharm = (event: CustomEvent) => {
+      const { charmId, replicaName } = event.detail || {};
+      if (charmId && replicaName) {
+        navigate(
+          createPath("charmShow", {
+            charmId,
+            replicaName,
+          }),
+        );
+      } else if (charmId && focusedReplicaId) {
+        // Use current replica if not specified
+        navigate(
+          createPath("charmShow", {
+            charmId,
+            replicaName: focusedReplicaId,
+          }),
+        );
+      } else {
+        console.warn("Navigate to charm event missing required parameters:", {
+          charmId,
+          replicaName,
+        });
+      }
     };
 
     document.addEventListener("keydown", handleNewCharm);
     globalThis.addEventListener("new-charm-command", handleNewCharmEvent);
+    globalThis.addEventListener(
+      "navigate-to-charm",
+      handleNavigateToCharm as EventListener,
+    );
 
     return () => {
       document.removeEventListener("keydown", handleNewCharm);
@@ -443,8 +473,12 @@ export function CommandCenter() {
         "new-charm-command",
         handleNewCharmEvent,
       );
+      globalThis.removeEventListener(
+        "navigate-to-charm",
+        handleNavigateToCharm as EventListener,
+      );
     };
-  }, [focusedCharmId, allCommands]);
+  }, [focusedCharmId, allCommands, navigate, focusedReplicaId]);
 
   const handleBack = () => {
     if (commandPathIds.length === 1) {

--- a/packages/jumble/src/contexts/RuntimeContext.tsx
+++ b/packages/jumble/src/contexts/RuntimeContext.tsx
@@ -11,6 +11,7 @@ import {
   StorageManager,
 } from "@commontools/runner/storage/cache";
 import { useAuthentication } from "./AuthenticationContext.tsx";
+import { navigateToCharm } from "@/utils/navigation.ts";
 import { setupIframe } from "@/iframe-ctx.ts";
 import * as Sentry from "@sentry/react";
 interface RuntimeContextType {
@@ -66,6 +67,7 @@ export function RuntimeProvider({
         }
         return [`Console [${method}]:`, ...args];
       },
+      navigateCallback: (target) => navigateToCharm(target),
     });
 
     setupIframe(runtime);

--- a/packages/jumble/src/utils/navigation.ts
+++ b/packages/jumble/src/utils/navigation.ts
@@ -1,0 +1,21 @@
+import type { Cell } from "@commontools/runner";
+import { charmId } from "@commontools/charm";
+
+/**
+ * Navigate to a charm from outside the React UI
+ * This dispatches a global event that the CommandCenter component listens to
+ */
+export function navigateToCharm(charm: Cell<any>, replicaName?: string): void {
+  const id = charmId(charm);
+
+  if (!id) {
+    console.warn("navigateToCharm: charmId is required");
+    return;
+  }
+
+  globalThis.dispatchEvent(
+    new CustomEvent("navigate-to-charm", {
+      detail: { charmId: id, replicaName },
+    }),
+  );
+}

--- a/packages/runner/src/builtins/index.ts
+++ b/packages/runner/src/builtins/index.ts
@@ -2,10 +2,11 @@ import { raw } from "../module.ts";
 import { map } from "./map.ts";
 import { fetchData } from "./fetch-data.ts";
 import { streamData } from "./stream-data.ts";
-import { llm, generateObject } from "./llm.ts";
+import { generateObject, llm } from "./llm.ts";
 import { ifElse } from "./if-else.ts";
 import type { IRuntime } from "../runtime.ts";
 import { compileAndRun } from "./compile-and-run.ts";
+import { navigateTo } from "./navigate-to.ts";
 import type { Cell } from "../cell.ts";
 import type { BuiltInGenerateObjectParams } from "@commontools/api";
 
@@ -21,10 +22,14 @@ export function registerBuiltins(runtime: IRuntime) {
   moduleRegistry.addModuleByRef("llm", raw(llm));
   moduleRegistry.addModuleByRef("ifElse", raw(ifElse));
   moduleRegistry.addModuleByRef("compileAndRun", raw(compileAndRun));
-  moduleRegistry.addModuleByRef("generateObject", raw<BuiltInGenerateObjectParams, {
-    pending: Cell<boolean>;
-    result: Cell<Record<string, unknown> | undefined>;
-    partial: Cell<string | undefined>;
-    requestHash: Cell<string | undefined>;
-  }>(generateObject));
+  moduleRegistry.addModuleByRef(
+    "generateObject",
+    raw<BuiltInGenerateObjectParams, {
+      pending: Cell<boolean>;
+      result: Cell<Record<string, unknown> | undefined>;
+      partial: Cell<string | undefined>;
+      requestHash: Cell<string | undefined>;
+    }>(generateObject),
+  );
+  moduleRegistry.addModuleByRef("navigateTo", raw(navigateTo));
 }

--- a/packages/runner/src/builtins/navigate-to.ts
+++ b/packages/runner/src/builtins/navigate-to.ts
@@ -1,0 +1,25 @@
+import { type Cell } from "../cell.ts";
+import { type Action } from "../scheduler.ts";
+import { type ReactivityLog } from "../scheduler.ts";
+import { type IRuntime } from "../runtime.ts";
+
+export function navigateTo(
+  inputsCell: Cell<any>,
+  _sendResult: (result: any) => void,
+  _addCancel: (cancel: () => void) => void,
+  _cause: Cell<any>[],
+  _parentCell: Cell<any>,
+  runtime: IRuntime,
+): Action {
+  return (log: ReactivityLog) => {
+    const inputsWithLog = inputsCell.asSchema({ asCell: true }).withLog(log);
+
+    const target = inputsWithLog.get();
+
+    if (!runtime.navigateCallback) {
+      throw new Error("navigateCallback is not set");
+    }
+
+    runtime.navigateCallback(target);
+  };
+}

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -41,6 +41,8 @@ export type ConsoleHandler = (
 ) => any[];
 export type ErrorHandler = (error: ErrorWithContext) => void;
 
+export type NavigateCallback = (target: Cell<any>) => void;
+
 export interface CharmMetadata {
   name?: string;
   description?: string;
@@ -54,6 +56,7 @@ export interface RuntimeOptions {
   errorHandlers?: ErrorHandler[];
   blobbyServerUrl: string;
   recipeEnvironment?: RecipeEnvironment;
+  navigateCallback?: NavigateCallback;
   debug?: boolean;
 }
 
@@ -67,6 +70,7 @@ export interface IRuntime {
   readonly harness: Harness;
   readonly runner: IRunner;
   readonly blobbyServerUrl: string;
+  readonly navigateCallback?: NavigateCallback;
   readonly cfc: ContextualFlowControl;
 
   idle(): Promise<void>;
@@ -289,6 +293,7 @@ export class Runtime implements IRuntime {
   readonly harness: Harness;
   readonly runner: IRunner;
   readonly blobbyServerUrl: string;
+  readonly navigateCallback?: NavigateCallback;
   readonly cfc: ContextualFlowControl;
 
   constructor(options: RuntimeOptions) {
@@ -326,6 +331,9 @@ export class Runtime implements IRuntime {
       "/api/storage/blobby",
       options.blobbyServerUrl,
     ).toString();
+
+    // Set the navigate callback
+    this.navigateCallback = options.navigateCallback;
 
     // Handle recipe environment configuration
     if (options.recipeEnvironment) {


### PR DESCRIPTION
- Add navigateTo builtin function to runner package for programmatic navigation
- Implement navigation utility in jumble for dispatching charm navigation events
- Add event listener in CommandCenter to handle navigate-to-charm events
- Integrate navigation callback in RuntimeContext for charm-to-charm navigation
- Support navigation with optional replica name parameter
- Add proper TypeScript types for navigation callback interface

This enables charms to programmatically navigate to other charms using the navigateTo builtin function.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a navigateTo builtin function so charms can programmatically navigate to other charms, with support for an optional replica name.

- **New Features**
  - Added navigateTo to the runner package and registered it as a builtin.
  - Implemented a navigation utility and event listener in jumble to handle navigation events.
  - Integrated a navigation callback in RuntimeContext for charm-to-charm navigation.

<!-- End of auto-generated description by cubic. -->

