### PR TITLE
remove runner integration test for now

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -374,13 +374,6 @@ jobs:
           FRONTEND_URL=http://localhost:8000/ \
           deno task integration
 
-      - name: Run runner integration tests
-        if: github.ref == 'refs/heads/main'
-        run: |
-          cd packages/runner
-          TOOLSHED_API_URL=http://localhost:8000/ \
-          deno task integration
-
   cli-integration-test:
     name: "CLI Integration Tests"
     runs-on: ubuntu-latest


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Temporarily removed the runner integration test from the CI workflow to prevent it from running on main.

<!-- End of auto-generated description by cubic. -->

