### PR TITLE
Add `/maintain-docs` and, uh, maintain the docs

### DIFF
--- a/.claude/commands/common/ct.md
+++ b/.claude/commands/common/ct.md
@@ -65,8 +65,8 @@ This document contains shared setup instructions for the CT binary that are used
 - `./dist/ct charm map --identity [keyfile] --api-url [api-url] --space [spacename] --format dot` - Output Graphviz DOT format
 
 ### Recipe Development Commands:
-- `./dist/ct charm getsrc --identity [keyfile] --api-url [api-url] --space [spacename] --charm [id]` - Get recipe source code
-- `./dist/ct charm setsrc --identity [keyfile] --api-url [api-url] --space [spacename] --charm [id] [recipe-path]` - Update recipe source
+- `./dist/ct charm getsrc --identity [keyfile] --api-url [api-url] --space [spacename] --charm [id] [output-folder]` - Get recipe source code and save to folder
+- `./dist/ct charm setsrc --identity [keyfile] --api-url [api-url] --space [spacename] --charm [id] [recipe-path]` - Update recipe source from file or folder
 - `./dist/ct dev [recipe-path] --no-run` - Test recipe syntax locally
 
 ## Understanding Linking
@@ -111,3 +111,5 @@ The `ct charm map` command helps visualize the connections between charms in a s
 - Always use absolute paths or full relative paths to recipes
 - Charm IDs start with "bafy" and are long content hashes
 - Environment variables CT_API_URL and CT_IDENTITY can simplify commands
+- `getsrc` saves recipes to a folder, supporting both single-file recipes (saved as main.tsx) and multi-file recipes (preserving file structure)
+- `setsrc` can accept either a single file path or a folder path containing multiple recipe files

--- a/.claude/commands/common/ct.md
+++ b/.claude/commands/common/ct.md
@@ -16,6 +16,14 @@ This document contains shared setup instructions for the CT binary that are used
 - If no keyfiles found: Run `./dist/ct id new > space-identity.key`
 - If keyfiles exist, ask user which one to use or create a new one
 
+## Recipe Development Setup
+
+**Initialize TypeScript environment:**
+- Navigate to your recipes repository (or any folder where you'll develop recipes)
+- Run `./dist/ct init` to set up TypeScript types for recipe development
+- This creates/updates tsconfig.json and provides proper type definitions
+- Run this command whenever you update CT to get the latest types
+
 ## Environment Setup
 
 **Set up environment (recommend but don't require):**
@@ -28,7 +36,8 @@ This document contains shared setup instructions for the CT binary that are used
 **Get API URL:**
 - Ask user: "What is your CT API URL? (e.g., https://ct.dev, https://toolshed.saga-castor.ts.net/, or your custom instance)"
 - Store as variable for all commands
-- Test connectivity: `./dist/ct charm ls --identity [keyfile] --api-url [user-api-url] --space test-connection` (this might fail but shows if URL works)
+- **IMPORTANT:** For toolshed.saga-castor.ts.net or any *.ts.net URL, you must be connected to the CT Tailnet. If commands fail or hang, this is likely the issue.
+- Test connectivity: `./dist/ct charm ls --identity <keyfile> --api-url <user-api-url> --space test-connection` (this might fail but shows if URL works)
 
 **Get space name:**
 - Ask user what space they want to work with
@@ -51,23 +60,38 @@ This document contains shared setup instructions for the CT binary that are used
 - Verify the URL is correct and accessible
 - Check network connectivity
 - Verify identity file permissions
+- **For *.ts.net URLs:** Ensure you're connected to the CT Tailnet (commands will hang or timeout if not connected)
 
 ## Key CT Commands Reference
 
+### Identity Management:
+- `./dist/ct id new` - Create a new identity keyfile
+- `./dist/ct id` - Interact with common identities
+
+### Recipe Development Setup:
+- `./dist/ct init` - Initialize TypeScript environment for recipe development (run this in your recipes repo)
+
 ### Basic Commands:
-- `./dist/ct charm new --identity [keyfile] --api-url [api-url] --space [spacename] [recipe-path]` - Create charm
-- `./dist/ct charm link --identity [keyfile] --api-url [api-url] --space [spacename] [source] [target]/[field]` - Link data
-- `./dist/ct charm ls --identity [keyfile] --api-url [api-url] --space [spacename]` - List charms
-- `./dist/ct charm inspect --identity [keyfile] --api-url [api-url] --space [spacename] --charm [id]` - Inspect charm details
-- `./dist/ct charm inspect --identity [keyfile] --url [full-url-with-charm-id]` - Inspect charm details (URL syntax)
-- `./dist/ct charm inspect --identity [keyfile] --api-url [api-url] --space [spacename] --charm [id] --json` - Output raw JSON data
-- `./dist/ct charm map --identity [keyfile] --api-url [api-url] --space [spacename]` - Display visual map of charms and connections
-- `./dist/ct charm map --identity [keyfile] --api-url [api-url] --space [spacename] --format dot` - Output Graphviz DOT format
+- `./dist/ct charm new --identity <keyfile> --api-url <api-url> --space <spacename> <recipe-path>` - Create charm
+- `./dist/ct charm new --identity <keyfile> --api-url <api-url> --space <spacename> --main-export <export> <recipe-path>` - Create charm with named export
+- `./dist/ct charm link --identity <keyfile> --api-url <api-url> --space <spacename> <source> <target>/<field>` - Link data
+- `./dist/ct charm ls --identity <keyfile> --api-url <api-url> --space <spacename>` - List charms
+- `./dist/ct charm inspect --identity <keyfile> --api-url <api-url> --space <spacename> --charm <id>` - Inspect charm details
+- `./dist/ct charm inspect --identity <keyfile> --url <full-url-with-charm-id>` - Inspect charm details (URL syntax)
+- `./dist/ct charm inspect --identity <keyfile> --api-url <api-url> --space <spacename> --charm <id> --json` - Output raw JSON data
+- `./dist/ct charm map --identity <keyfile> --api-url <api-url> --space <spacename>` - Display visual map of charms and connections (ASCII format)
+- `./dist/ct charm map --identity <keyfile> --api-url <api-url> --space <spacename> --format dot` - Output Graphviz DOT format
+- `./dist/ct charm apply --identity <keyfile> --api-url <api-url> --space <spacename> --charm <id>` - Apply new inputs to charm (pipe JSON via stdin)
 
 ### Recipe Development Commands:
-- `./dist/ct charm getsrc --identity [keyfile] --api-url [api-url] --space [spacename] --charm [id] [output-folder]` - Get recipe source code and save to folder
-- `./dist/ct charm setsrc --identity [keyfile] --api-url [api-url] --space [spacename] --charm [id] [recipe-path]` - Update recipe source from file or folder
-- `./dist/ct dev [recipe-path] --no-run` - Test recipe syntax locally
+- `./dist/ct charm getsrc --identity <keyfile> --api-url <api-url> --space <spacename> --charm <id> <outpath>` - Get recipe source code
+- `./dist/ct charm setsrc --identity <keyfile> --api-url <api-url> --space <spacename> --charm <id> <recipe-path>` - Update recipe source
+- `./dist/ct charm setsrc --identity <keyfile> --api-url <api-url> --space <spacename> --charm <id> --main-export <export> <recipe-path>` - Update recipe source with named export
+- `./dist/ct dev <recipe-path>` - Compile and execute recipe locally
+- `./dist/ct dev <recipe-path> --no-run` - Type check recipe without executing
+- `./dist/ct dev <recipe-path> --no-check` - Execute recipe without type checking
+- `./dist/ct dev <recipe-path> --no-run --output <file>` - Compile recipe to JavaScript file
+- `./dist/ct dev <recipe-path> --filename <name>` - Set filename for source maps
 
 ## Understanding Linking
 
@@ -100,10 +124,14 @@ The `ct charm map` command helps visualize the connections between charms in a s
 - Use `--format dot` to output in Graphviz format
 - Can be rendered to images using Graphviz tools:
   ```bash
-  # Install Graphviz (macOS: brew install graphviz)
-  ct charm map --identity [key] --api-url [url] --space [space] --format dot | dot -Tpng -o map.png
+  # Install Graphviz (macOS: brew install graphviz, Linux: apt-get install graphviz)
+  ct charm map --identity <key> --api-url <url> --space <space> --format dot | dot -Tpng -o map.png
   ```
-- Alternatively, paste DOT output into online tools like https://dreampuf.github.io/GraphvizOnline/
+- Alternatively, use online visualization:
+  1. Run: `ct charm map --identity <key> --api-url <url> --space <space> --format dot`
+  2. Copy the DOT output
+  3. URL encode the output and append to: `https://dreampuf.github.io/GraphvizOnline/?engine=dot#`
+  4. Or paste directly into https://dreampuf.github.io/GraphvizOnline/
 
 ## Important Notes
 
@@ -111,5 +139,3 @@ The `ct charm map` command helps visualize the connections between charms in a s
 - Always use absolute paths or full relative paths to recipes
 - Charm IDs start with "bafy" and are long content hashes
 - Environment variables CT_API_URL and CT_IDENTITY can simplify commands
-- `getsrc` saves recipes to a folder, supporting both single-file recipes (saved as main.tsx) and multi-file recipes (preserving file structure)
-- `setsrc` can accept either a single file path or a folder path containing multiple recipe files

--- a/.claude/commands/maintain-docs.md
+++ b/.claude/commands/maintain-docs.md
@@ -1,0 +1,56 @@
+# Maintain Documentation
+
+This command helps maintain the accuracy of the CT documentation by comparing the ct.md file with the actual CLI help output and identifying discrepancies.
+
+## What this command does:
+
+1. **Reads ct.md** - Loads the current documentation file
+2. **Rebuilds the CT binary** - Ensures we're checking against the latest version
+3. **Runs help commands** - Executes various `--help` commands to get actual CLI documentation
+4. **Compares documentation** - Identifies discrepancies between ct.md and actual help output
+5. **Offers fixes** - Proposes updates to fix any inconsistencies found
+
+## How to use:
+
+Simply ask to "maintain docs" or "check ct documentation" and the command will:
+- Analyze all command signatures and examples
+- Check for missing or outdated commands
+- Verify parameter descriptions match
+- Ensure examples are up-to-date
+
+## Commands checked:
+
+The following ct commands will be verified:
+- `ct charm ls`
+- `ct charm new`
+- `ct charm link`
+- `ct charm inspect`
+- `ct charm getsrc`
+- `ct charm setsrc`
+- `ct charm apply`
+- `ct charm map`
+- `ct dev`
+
+## What gets verified:
+
+- Command syntax and usage patterns
+- Parameter names and descriptions
+- Example commands and their descriptions
+- Environment variable documentation
+- Any new commands not yet documented
+
+## Example usage:
+
+```
+User: maintain the ct docs
+Assistant: I'll check the ct.md documentation against the actual CLI help output...
+
+[Rebuilds binary, runs help commands, compares with documentation]
+
+Found the following discrepancies:
+1. The `getsrc` command now outputs to a folder, but docs show single file
+2. New `--main-export` parameter not documented for `setsrc`
+3. Missing documentation for new `ct charm map` command
+
+Would you like me to update the documentation to fix these issues?
+```

--- a/.claude/commands/recipe-dev.md
+++ b/.claude/commands/recipe-dev.md
@@ -19,6 +19,7 @@ This script guides Claude through recipe development with the `ct` utility after
   - Identity management
   - Environment setup
   - Parameter collection (API URL, space name, recipe path)
+  - Recipe development TypeScript setup (`ct init`)
 
 **Verify existing space:**
 - Run: `./dist/ct charm ls --identity [keyfile] --api-url [api-url] --space [spacename]`
@@ -57,10 +58,11 @@ This script guides Claude through recipe development with the `ct` utility after
    - What processing logic is required
 
 **Create recipe file:**
-1. Guide user through creating a new .tsx file
-2. Start with a template based on their requirements
-3. Test syntax: `./dist/ct dev [new-recipe-path] --no-run`
-4. Iterate on the recipe until it's correct
+1. Ensure TypeScript setup is current: `./dist/ct init` (run in recipes directory)
+2. Guide user through creating a new .tsx file
+3. Start with a template based on their requirements
+4. Test syntax: `./dist/ct dev [new-recipe-path] --no-run`
+5. Iterate on the recipe until it's correct
 
 **Deploy new charm:**
 1. Create the charm: `./dist/ct charm new --identity [keyfile] --api-url [api-url] --space [spacename] [new-recipe-path]`

--- a/.claude/commands/setup-space.md
+++ b/.claude/commands/setup-space.md
@@ -14,6 +14,7 @@ This script guides Claude through setting up a complete space with the `ct` util
   - Identity keyfile management
   - Environment variable setup (CT_API_URL and CT_IDENTITY)
   - API URL collection and connectivity test
+  - Recipe development TypeScript setup (`ct init`)
 
 ### STEP 2: Space-Specific Setup
 
@@ -23,6 +24,7 @@ This script guides Claude through setting up a complete space with the `ct` util
 
 **Find recipe path:**
 - Follow the recipe path discovery process from common/ct.md
+- Once recipe path is found, run `./dist/ct init` in the recipes directory to set up TypeScript types
 - Additionally, look specifically for these key recipes:
   - `find [user-provided-path] -name "*gmail*" -o -name "*email*" -o -name "*list*" | head -5`
   - Verify key recipes exist: `ls -la [user-provided-path]/coralreef/gmail.tsx` (or find where gmail.tsx is located)


### PR DESCRIPTION
- **Update `getsrc` and `setsrc` documentation**
- **Introduce `/maintain-docs`**
- **Run and review `/maintain-docs`**

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the `/maintain-docs` command to check CT documentation for accuracy, and updated docs for `getsrc`, `setsrc`, and recipe development setup.

- **New Features**
  - Added `/maintain-docs` to compare ct.md with CLI help output and suggest fixes.

- **Documentation**
  - Updated `getsrc` and `setsrc` docs for new folder and parameter support.
  - Improved TypeScript setup instructions in recipe and space setup guides.

<!-- End of auto-generated description by cubic. -->

