### PR TITLE
include the query args when we log a query failure error

### DIFF
--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -528,7 +528,7 @@ export class Replica {
       const { error } = await query.promise;
       // If query fails we propagate the error.
       if (error) {
-        console.error("query failure", error);
+        console.error("query failure", queryArgs, error);
         return { error };
       }
       fetchedEntries = query.schemaFacts;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Now logs query arguments along with errors when a query fails, making it easier to debug issues.

<!-- End of auto-generated description by cubic. -->

