### PR TITLE
When linking a recipe from a process cell, include the recipe link in a style that exposes the uri of the recipe

### DIFF
--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -67,6 +67,7 @@ export const charmSourceCellSchema = {
   type: "object",
   properties: {
     [TYPE]: { type: "string" },
+    recipe: { type: "object" },
     lineage: {
       type: "array",
       items: charmLineageSchema,
@@ -81,6 +82,7 @@ export const processSchema = {
   properties: {
     argument: { type: "object" },
     [TYPE]: { type: "string" },
+    recipe: { type: "object" },
   },
   required: [TYPE],
 } as const satisfies JSONSchema;

--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -67,7 +67,7 @@ export const charmSourceCellSchema = {
   type: "object",
   properties: {
     [TYPE]: { type: "string" },
-    recipe: { type: "object" },
+    spell: { type: "object" },
     lineage: {
       type: "array",
       items: charmLineageSchema,
@@ -82,7 +82,7 @@ export const processSchema = {
   properties: {
     argument: { type: "object" },
     [TYPE]: { type: "string" },
-    recipe: { type: "object" },
+    spell: { type: "object" },
   },
   required: [TYPE],
 } as const satisfies JSONSchema;

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1,3 +1,4 @@
+import { refer } from "merkle-reference";
 import { isObject, isRecord, type Mutable } from "@commontools/utils/types";
 import {
   isModule,
@@ -41,7 +42,11 @@ import { sendValueToBinding } from "./recipe-binding.ts";
 import { type AddCancel, type Cancel, useCancelGroup } from "./cancel.ts";
 import "./builtins/index.ts";
 import { isCell } from "./cell.ts";
-import { type LegacyDocCellLink } from "./sigil-types.ts";
+import {
+  type LegacyDocCellLink,
+  LINK_V1_TAG,
+  SigilLink,
+} from "./sigil-types.ts";
 import type { IRunner, IRuntime } from "./runtime.ts";
 
 export class Runner implements IRunner {
@@ -103,6 +108,7 @@ export class Runner implements IRunner {
 
     type ProcessCellData = {
       [TYPE]: string;
+      recipe?: SigilLink;
       argument?: T;
       internal?: JSONValue;
       resultRef: { cell: DocImpl<R>; path: PropertyKey[] };
@@ -220,6 +226,7 @@ export class Runner implements IRunner {
       [TYPE]: recipeId || "unknown",
       resultRef: resultDoc.getAsLegacyCellLink(),
       internal,
+      ...(recipeId !== undefined) ? { recipe: getFullRecipeId(recipeId) } : {},
     });
     if (argument) {
       diffAndUpdate(
@@ -819,6 +826,16 @@ export class Runner implements IRunner {
     // this as TODO.
     addCancel(this.cancels.get(resultCell.getSourceCell()!.getDoc()));
   }
+}
+
+// Default recipe id is the base32 encoding of the all but the first byte of the array.
+// Our entity ids are the base32 encoding of all the bytes of the array, including `1`.
+// This takes a `ba4...` id and returns a link with a `bae...` id.
+// In this case, the recipe id is only loosely linked, because the place where we save
+// the recipe is based on references to causes derived from the id, instead of just the id
+function getFullRecipeId(recipeId: string): SigilLink {
+  const id = refer({ causal: { recipeId, type: "recipe" } }).toJSON()["/"];
+  return { "/": { [LINK_V1_TAG]: { id: `of:${id}` } } };
 }
 
 function containsOpaqueRef(value: unknown): boolean {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -108,7 +108,7 @@ export class Runner implements IRunner {
 
     type ProcessCellData = {
       [TYPE]: string;
-      recipe?: SigilLink;
+      spell?: SigilLink;
       argument?: T;
       internal?: JSONValue;
       resultRef: { cell: DocImpl<R>; path: PropertyKey[] };
@@ -226,7 +226,7 @@ export class Runner implements IRunner {
       [TYPE]: recipeId || "unknown",
       resultRef: resultDoc.getAsLegacyCellLink(),
       internal,
-      ...(recipeId !== undefined) ? { recipe: getFullRecipeId(recipeId) } : {},
+      ...(recipeId !== undefined) ? { spell: getSpellLink(recipeId) } : {},
     });
     if (argument) {
       diffAndUpdate(
@@ -828,12 +828,8 @@ export class Runner implements IRunner {
   }
 }
 
-// Default recipe id is the base32 encoding of the all but the first byte of the array.
-// Our entity ids are the base32 encoding of all the bytes of the array, including `1`.
-// This takes a `ba4...` id and returns a link with a `bae...` id.
-// In this case, the recipe id is only loosely linked, because the place where we save
-// the recipe is based on references to causes derived from the id, instead of just the id
-function getFullRecipeId(recipeId: string): SigilLink {
+// This takes a recipe id and returns a sigil link with the corresponding entity.
+function getSpellLink(recipeId: string): SigilLink {
   const id = refer({ causal: { recipeId, type: "recipe" } }).toJSON()["/"];
   return { "/": { [LINK_V1_TAG]: { id: `of:${id}` } } };
 }


### PR DESCRIPTION
Added an optional recipe property to the process cell.
Eventually, we should be able to remove the special $TYPE handling, and just use this link to establish the dependency.
However, the main reason I added it is just so that it's easy to find the associated recipe.

I don't know if this is a good idea or not, but I find it handy for debugging.

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Process cells now include a recipe link that exposes the recipe's URI, making it easier to find the associated recipe. This prepares for future removal of special $TYPE handling.

<!-- End of auto-generated description by cubic. -->

