### PR TITLE
Add tests and better comments to findAllWriteRedirectCells

### DIFF
--- a/packages/runner/src/recipe-binding.ts
+++ b/packages/runner/src/recipe-binding.ts
@@ -154,7 +154,7 @@ export function unsafe_createParentBindings(
  *
  * @param binding - The binding to traverse.
  * @param baseCell - The base cell to use for resolving links.
- * @returns All cells reacheable through write redirects.
+ * @returns All links reachable through write redirects.
  */
 export function findAllWriteRedirectCells<T>(
   binding: unknown,

--- a/packages/runner/src/recipe-binding.ts
+++ b/packages/runner/src/recipe-binding.ts
@@ -150,7 +150,7 @@ export function unsafe_createParentBindings(
 }
 
 /**
- * Traverses binding and returns all cells reacheable through write redirects.
+ * Traverses binding and returns all cells reachable through write redirects.
  *
  * @param binding - The binding to traverse.
  * @param baseCell - The base cell to use for resolving links.

--- a/packages/runner/test/recipe-binding.test.ts
+++ b/packages/runner/test/recipe-binding.test.ts
@@ -169,7 +169,6 @@ describe("recipe-binding", () => {
         [binding, nestedBinding],
         testCell,
       );
-      console.log(links);
       expect(links.length).toBe(3);
       expect(links[0].path).toEqual(["a"]);
       expect(links[1].path).toEqual(["b", "c"]);

--- a/packages/runner/test/recipe-binding.test.ts
+++ b/packages/runner/test/recipe-binding.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
+  findAllWriteRedirectCells,
   sendValueToBinding,
   unwrapOneLevelAndBindtoDoc,
 } from "../src/recipe-binding.ts";
@@ -8,6 +9,7 @@ import { Runtime } from "../src/runtime.ts";
 import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 import { areLinksSame } from "../src/link-utils.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -137,6 +139,100 @@ describe("recipe-binding", () => {
           $alias: testCell.key("b").key("c").getAsLegacyCellLink(),
         }),
       ).toBe(true);
+    });
+  });
+
+  describe("findAllWriteRedirectCells", () => {
+    it("should find a single legacy alias binding", () => {
+      const testCell = runtime.getCell<{ foo: number }>(space, "single legacy");
+      testCell.set({ foo: 123 });
+      const binding = { $alias: { path: ["foo"] } };
+      const links = findAllWriteRedirectCells(binding, testCell);
+      expect(links.length).toBe(1);
+      expect(links[0].path).toEqual(["foo"]);
+      expect(links[0].id).toBeDefined();
+      expect(links[0].space).toBe(space);
+    });
+
+    it("should find nested legacy alias bindings", () => {
+      const testCell = runtime.getCell<{ a: Record<string, any> }>(
+        space,
+        "nested legacy",
+      );
+      testCell.set({ a: { b: { c: 42 } } });
+      const binding = { $alias: { path: ["a"] } };
+      // Add a nested alias inside the value at path 'a'
+      testCell.key("a").set({
+        b: { c: 42 },
+        inner: { $alias: { path: ["b", "c"] } },
+      });
+      const nestedBinding = { $alias: { path: ["a", "inner"] } };
+      const links = findAllWriteRedirectCells(
+        [binding, nestedBinding],
+        testCell,
+      );
+      console.log(links);
+      expect(links.length).toBe(3);
+      expect(links[0].path).toEqual(["a"]);
+      expect(links[1].path).toEqual(["b", "c"]);
+      expect(links[2].path).toEqual(["a", "inner"]);
+    });
+
+    it("should find all write redirect links in an array", () => {
+      const testCell = runtime.getCell<{ arr: number[] }>(
+        space,
+        "array legacy",
+      );
+      testCell.set({ arr: [1, 2, 3] });
+      const binding = [
+        { $alias: { path: ["arr", 0] } },
+        { $alias: { path: ["arr", 1] } },
+        { $alias: { path: ["arr", 2] } },
+      ];
+      const links = findAllWriteRedirectCells(binding, testCell);
+      expect(links.length).toBe(3);
+      expect(links.map((l) => l.path)).toEqual([
+        ["arr", "0"],
+        ["arr", "1"],
+        ["arr", "2"],
+      ]);
+    });
+
+    it("should find write redirect links in an object with multiple links", () => {
+      const testCell = runtime.getCell<{ x: number; y: number }>(
+        space,
+        "object legacy",
+      );
+      testCell.set({ x: 1, y: 2 });
+      const binding = {
+        a: { $alias: { path: ["x"] } },
+        b: { $alias: { path: ["y"] } },
+        c: 3,
+      };
+      const links = findAllWriteRedirectCells(binding, testCell);
+      expect(links.length).toBe(2);
+      expect(links.map((l) => l.path)).toEqual([["x"], ["y"]]);
+    });
+
+    it("should return empty array if there are no write redirect links", () => {
+      const testCell = runtime.getCell<{ foo: number }>(space, "no links");
+      testCell.set({ foo: 1 });
+      const binding = { bar: 2 };
+      const links = findAllWriteRedirectCells(binding, testCell);
+      expect(links.length).toBe(0);
+    });
+
+    it("should find write redirect links using sigil format", () => {
+      const testCell = runtime.getCell<{ foo: number }>(space, "sigil link");
+      testCell.set({ foo: 99 });
+      const links = findAllWriteRedirectCells(
+        testCell.key("foo").getAsWriteRedirectLink({ base: testCell }),
+        testCell,
+      );
+      expect(links.length).toBe(1);
+      expect(links[0].path).toEqual(["foo"]);
+      expect(links[0].id).toBeDefined();
+      expect(links[0].space).toBe(space);
     });
   });
 });

--- a/packages/runner/test/recipe-binding.test.ts
+++ b/packages/runner/test/recipe-binding.test.ts
@@ -9,8 +9,6 @@ import { Runtime } from "../src/runtime.ts";
 import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 import { areLinksSame } from "../src/link-utils.ts";
-import { LINK_V1_TAG } from "../src/sigil-types.ts";
-
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added comprehensive tests and improved comments for the findAllWriteRedirectCells function to clarify its behavior and ensure reliability.

- **Tests**
  - Added cases for legacy alias bindings, nested and array bindings, object bindings, and sigil format.
  - Verified correct detection and handling of write redirect links.

<!-- End of auto-generated description by cubic. -->

