### PR TITLE
Make labels public

### DIFF
--- a/packages/memory/space.ts
+++ b/packages/memory/space.ts
@@ -908,6 +908,7 @@ export function redactCommitData(
     }
     // We treat all labels as unclassified
     if (fact.the === LABEL_THE) {
+      set(newChanges, fact.of, fact.the, fact.cause, fact.value);
       continue;
     }
     const labelFact = getRevision(commitData.labels, fact.of, LABEL_THE);

--- a/packages/memory/space.ts
+++ b/packages/memory/space.ts
@@ -826,6 +826,10 @@ export function getLabels<
 ): OfTheCause<FactSelectionValue> {
   const labels: OfTheCause<FactSelectionValue> = {};
   for (const fact of iterate(includedFacts)) {
+    // We don't restrict acccess to labels
+    if (fact.the === LABEL_THE) {
+      continue;
+    }
     const labelFact = getLabel(session, fact.of);
     if (labelFact !== undefined) {
       set<FactSelectionValue, OfTheCause<FactSelectionValue>>(
@@ -900,6 +904,10 @@ export function redactCommitData(
   // Add any non-redacted changes to the newCommitData
   for (const fact of iterate(commitData.transaction.args.changes)) {
     if (fact.value === true) {
+      continue;
+    }
+    // We treat all labels as unclassified
+    if (fact.the === LABEL_THE) {
       continue;
     }
     const labelFact = getRevision(commitData.labels, fact.of, LABEL_THE);

--- a/packages/memory/test/consumer-test.ts
+++ b/packages/memory/test/consumer-test.ts
@@ -1142,7 +1142,11 @@ test(
                       changes: {
                         [doc]: {
                           "application/json": {},
-                          "application/label+json": {},
+                          "application/label+json": {
+                            [v3_label.cause.toString()]: {
+                              is: { classification: ["confidential"] },
+                            },
+                          },
                         },
                       },
                     },


### PR DESCRIPTION
This makes it easier to determine what's going on for a client, and it's not really a security issue.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Labels are now always public and included in commit data, making it easier for clients to access label information.

- **Bug Fixes**
  - Updated logic to treat all labels as unclassified and ensure they are not restricted.
  - Added tests to confirm labels are included in responses.

<!-- End of auto-generated description by cubic. -->

