### PR TITLE
feat(link-utils): make parsed links complete memory addresses

### DIFF
--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -212,6 +212,7 @@ describe("link-utils", () => {
         id: expect.stringContaining("of:"),
         path: [],
         space: space,
+        type: "application/json",
         schema: undefined,
         rootSchema: undefined,
       });
@@ -227,6 +228,7 @@ describe("link-utils", () => {
         id: expect.stringContaining("of:"),
         path: ["nested"],
         space: space,
+        type: "application/json",
         schema: undefined,
         rootSchema: undefined,
       });
@@ -241,6 +243,7 @@ describe("link-utils", () => {
         id: expect.stringContaining("of:"),
         path: [],
         space: space,
+        type: "application/json",
       });
     });
 
@@ -262,6 +265,7 @@ describe("link-utils", () => {
         id: "of:test",
         path: ["nested", "value"],
         space: space,
+        type: "application/json",
         schema: { type: "number" },
         rootSchema: { type: "object" },
       });
@@ -286,6 +290,7 @@ describe("link-utils", () => {
         id: "of:test",
         path: ["nested", "value"],
         space: space,
+        type: "application/json",
         schema: { type: "number" },
         rootSchema: { type: "object" },
       });
@@ -298,6 +303,7 @@ describe("link-utils", () => {
             id: "of:test",
             path: ["nested", "value"],
             space: space,
+            type: "application/json",
             schema: { type: "number" },
             rootSchema: { type: "object" },
             overwrite: "redirect",
@@ -310,6 +316,7 @@ describe("link-utils", () => {
         id: "of:test",
         path: ["nested", "value"],
         space: space,
+        type: "application/json",
         schema: { type: "number" },
         rootSchema: { type: "object" },
         overwrite: "redirect",
@@ -332,6 +339,7 @@ describe("link-utils", () => {
         id: expect.stringContaining("of:"),
         path: ["nested", "value"],
         space: space,
+        type: "application/json",
         schema: undefined,
         rootSchema: undefined,
       });
@@ -346,6 +354,7 @@ describe("link-utils", () => {
         id: expect.stringContaining("of:"),
         path: [],
         space: space,
+        type: "application/json",
         schema: undefined,
         rootSchema: undefined,
       });
@@ -363,6 +372,7 @@ describe("link-utils", () => {
         id: "of:test",
         path: ["nested", "value"],
         space: space,
+        type: "application/json",
       });
     });
 
@@ -382,6 +392,7 @@ describe("link-utils", () => {
         id: expect.stringContaining("of:"),
         path: ["nested", "value"],
         space: space,
+        type: "application/json",
         schema: { type: "number" },
         rootSchema: { type: "object" },
       });
@@ -399,6 +410,7 @@ describe("link-utils", () => {
       expect(result).toEqual({
         id: expect.stringContaining("of:"),
         path: ["nested", "value"],
+        type: "application/json",
         space: space,
         schema: undefined,
         rootSchema: undefined,

--- a/packages/runner/test/schema.test.ts
+++ b/packages/runner/test/schema.test.ts
@@ -290,6 +290,7 @@ describe("Schema Support", () => {
         space,
         schema: current.schema,
         rootSchema: current.rootSchema,
+        type: "application/json",
       });
 
       // .get() the currently selected cell. This should not change when
@@ -313,6 +314,7 @@ describe("Schema Support", () => {
         id: toURI(initialEntityId),
         path: ["foo"],
         space,
+        type: "application/json",
         schema: omitSchema,
         rootSchema: schema,
       });


### PR DESCRIPTION
feat(link-utils): introduce `type` field for parsed links, making them memory addresses

- Added a new `type` property to normalized link structures in `link-utils.ts`, defaulting to `application/json`.
- Updated link parsing, normalization, and equality logic to handle the new `type` field.
- Refactored related functions and tests to ensure correct handling and propagation of the `type` property.
- Enhanced test cases in `link-utils.test.ts` to cover scenarios involving the `type` field and its default value.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a type field to parsed links in link-utils, making them complete memory addresses and defaulting to application/json.

- **Refactors**
  - Updated link parsing, normalization, and equality checks to handle the new type field.
  - Refactored related functions and tests to support and verify the type property.

<!-- End of auto-generated description by cubic. -->

