### PR TITLE
CT-518 add charm on navigateTo in jumble

### DIFF
--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -251,7 +251,7 @@ export class CharmManager {
     return this.charms;
   }
 
-  private async add(newCharms: Cell<Charm>[]) {
+  async add(newCharms: Cell<Charm>[]) {
     await this.syncCharms(this.charms);
     await this.runtime.idle();
 

--- a/packages/jumble/src/components/CommandCenter.tsx
+++ b/packages/jumble/src/components/CommandCenter.tsx
@@ -435,16 +435,14 @@ export function CommandCenter() {
       });
     };
 
-    const handleNavigateToCharm = async (event: CustomEvent) => {
+    const handleNavigateToCharm = (event: CustomEvent) => {
       const { charmId, charm, replicaName } = event.detail || {};
 
       // If we have a charm object, ensure it's added to the charm manager
       if (charm && charmManager) {
-        try {
-          await charmManager.add([charm]);
-        } catch (error) {
-          console.error("Failed to add charm to manager:", error);
-        }
+        charmManager.add([charm]).catch((err) => {
+          console.error("Failed to add charm to manager:", err);
+        });
       }
 
       if (charmId && replicaName) {
@@ -474,7 +472,7 @@ export function CommandCenter() {
     globalThis.addEventListener("new-charm-command", handleNewCharmEvent);
     globalThis.addEventListener(
       "navigate-to-charm",
-      handleNavigateToCharm as unknown as EventListener,
+      handleNavigateToCharm as EventListener,
     );
 
     return () => {
@@ -485,7 +483,7 @@ export function CommandCenter() {
       );
       globalThis.removeEventListener(
         "navigate-to-charm",
-        handleNavigateToCharm as unknown as EventListener,
+        handleNavigateToCharm as EventListener,
       );
     };
   }, [focusedCharmId, allCommands, navigate, focusedReplicaId]);

--- a/packages/jumble/src/components/CommandCenter.tsx
+++ b/packages/jumble/src/components/CommandCenter.tsx
@@ -435,8 +435,18 @@ export function CommandCenter() {
       });
     };
 
-    const handleNavigateToCharm = (event: CustomEvent) => {
-      const { charmId, replicaName } = event.detail || {};
+    const handleNavigateToCharm = async (event: CustomEvent) => {
+      const { charmId, charm, replicaName } = event.detail || {};
+
+      // If we have a charm object, ensure it's added to the charm manager
+      if (charm && charmManager) {
+        try {
+          await charmManager.add([charm]);
+        } catch (error) {
+          console.error("Failed to add charm to manager:", error);
+        }
+      }
+
       if (charmId && replicaName) {
         navigate(
           createPath("charmShow", {
@@ -464,7 +474,7 @@ export function CommandCenter() {
     globalThis.addEventListener("new-charm-command", handleNewCharmEvent);
     globalThis.addEventListener(
       "navigate-to-charm",
-      handleNavigateToCharm as EventListener,
+      handleNavigateToCharm as unknown as EventListener,
     );
 
     return () => {
@@ -475,7 +485,7 @@ export function CommandCenter() {
       );
       globalThis.removeEventListener(
         "navigate-to-charm",
-        handleNavigateToCharm as EventListener,
+        handleNavigateToCharm as unknown as EventListener,
       );
     };
   }, [focusedCharmId, allCommands, navigate, focusedReplicaId]);

--- a/packages/jumble/src/components/CommandCenter.tsx
+++ b/packages/jumble/src/components/CommandCenter.tsx
@@ -486,7 +486,7 @@ export function CommandCenter() {
         handleNavigateToCharm as EventListener,
       );
     };
-  }, [focusedCharmId, allCommands, navigate, focusedReplicaId]);
+  }, [focusedCharmId, allCommands, navigate, focusedReplicaId, charmManager]);
 
   const handleBack = () => {
     if (commandPathIds.length === 1) {

--- a/packages/jumble/src/utils/navigation.ts
+++ b/packages/jumble/src/utils/navigation.ts
@@ -15,7 +15,7 @@ export function navigateToCharm(charm: Cell<any>, replicaName?: string): void {
 
   globalThis.dispatchEvent(
     new CustomEvent("navigate-to-charm", {
-      detail: { charmId: id, replicaName },
+      detail: { charmId: id, charm, replicaName },
     }),
   );
 }

--- a/packages/runner/src/builtins/navigate-to.ts
+++ b/packages/runner/src/builtins/navigate-to.ts
@@ -20,6 +20,8 @@ export function navigateTo(
       throw new Error("navigateCallback is not set");
     }
 
-    runtime.navigateCallback(target);
+    if (target && target.get()) {
+      runtime.navigateCallback(target);
+    }
   };
 }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -735,7 +735,7 @@ export class Runner implements IRunner {
       (result: any) =>
         sendValueToBinding(processCell, mappedOutputBindings, result),
       addCancel,
-      inputCells, // cause
+      { inputs: inputsCell, parents: processCell.getDoc() },
       processCell,
       this.runtime,
     );

--- a/recipes/compiler.tsx
+++ b/recipes/compiler.tsx
@@ -55,10 +55,17 @@ const updateCode = handler<{ detail: { value: string } }, { code: string }>(
 
 const visit = handler<
   { detail: { value: string } },
-  { result: { [UI]: any; [NAME]: string } }
+  { code: string }
 >(
   (_, state) => {
-    return navigateTo(state.result);
+    const { result } = compileAndRun({
+      files: [{ name: "/main.tsx", contents: state.code }],
+      main: "/main.tsx",
+    });
+
+    console.log("result", result);
+
+    return navigateTo(result);
   },
 );
 
@@ -66,13 +73,9 @@ export default recipe(
   InputSchema,
   OutputSchema,
   ({ code }) => {
-    const { result, error, errors } = compileAndRun({
+    const { error, errors } = compileAndRun({
       files: [{ name: "/main.tsx", contents: code }],
       main: "/main.tsx",
-    });
-
-    derive(result, (result) => {
-      console.log("result", result);
     });
 
     return {
@@ -87,9 +90,9 @@ export default recipe(
           />
           {ifElse(
             error,
-            <pre>{error}</pre>,
+            <b>fix the errors</b>,
             <common-button
-              onClick={visit({ result })}
+              onClick={visit({ code })}
             >
               Navigate To Charm
             </common-button>,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added logic to ensure charms are added to the charm manager when navigating to them in Jumble, and fixed an issue where navigating to a charm could fail or reuse cells incorrectly.

- **Bug Fixes**
  - Prevented navigation to undefined charms.
  - Fixed cell sharing issues when creating multiple charms from the compiler.

<!-- End of auto-generated description by cubic. -->

