### PR TITLE
feat(storage/transaction-shim): add readValueOrThrow method to StorageTransaction

### DIFF
--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -18,7 +18,7 @@ import type {
   Variant,
 } from "@commontools/memory/interface";
 
-export type { MemorySpace, Result, SchemaContext, Unit };
+export type { JSONValue, MemorySpace, Result, SchemaContext, Unit };
 
 // This type is used to tag a document with any important metadata.
 // Currently, the only supported type is the classification.
@@ -160,6 +160,15 @@ export interface IStorageTransaction {
    * @returns Result containing the read value or an error.
    */
   read(address: IMemoryAddress): Result<Read, IReaderError>;
+
+  /**
+   * Reads a value from a (local) memory address and throws on error, except for
+   * `NotFoundError` which is returned as undefined.
+   *
+   * @param address - Memory address to read from.
+   * @returns The read value.
+   */
+  readValueOrThrow(address: IMemoryAddress): JSONValue | undefined;
 
   /**
    * Creates a memory space writer for this transaction. Fails if transaction is

--- a/packages/runner/src/storage/transaction-shim.ts
+++ b/packages/runner/src/storage/transaction-shim.ts
@@ -17,6 +17,7 @@ import type {
   ITransactionWriter,
   IUnsupportedMediaTypeError,
   IWriterError,
+  JSONValue,
   MemoryAddressPathComponent,
   Read,
   Result,
@@ -53,7 +54,7 @@ function validateParentPath(
   if (path.length === 1) {
     if (value === undefined || !isRecord(value)) {
       const pathError: INotFoundError = new Error(
-        `Cannot write to path [${String(path[0])}] - document is not a record`,
+        `Cannot access path [${String(path[0])}] - document is not a record`,
       ) as INotFoundError;
       pathError.name = "NotFoundError";
       return pathError;
@@ -70,7 +71,7 @@ function validateParentPath(
     value === undefined || parentValue === undefined || !isRecord(parentValue)
   ) {
     const pathError: INotFoundError = new Error(
-      `Cannot write to path [${
+      `Cannot access path [${
         path.map((p) => String(p)).join(", ")
       }] - parent path [${
         parentPath.map((p) => String(p)).join(", ")
@@ -423,6 +424,14 @@ export class StorageTransaction implements IStorageTransaction {
       return { ok: undefined, error: readResult.error as IReaderError };
     }
     return { ok: readResult.ok };
+  }
+
+  readValueOrThrow(address: IMemoryAddress): JSONValue | undefined {
+    const readResult = this.read(address);
+    if (readResult.error && readResult.error.name !== "NotFoundError") {
+      throw readResult.error;
+    }
+    return readResult.ok?.value;
   }
 
   writer(space: string): Result<ITransactionWriter, IWriterError> {


### PR DESCRIPTION
- Introduces readValueOrThrow to StorageTransaction, allowing direct retrieval of a value or throwing on error (except NotFoundError, which returns undefined).
- Improves developer ergonomics for common read patterns in storage transactions.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added readValueOrThrow to StorageTransaction for easier value retrieval. This method returns the value, throws on errors, and returns undefined if not found.

- **New Features**
  - Added readValueOrThrow method to the storage transaction interface and implementation.
  - Returns the value or throws, except for NotFoundError which returns undefined.
  - Added tests for value, not found, and error cases.

<!-- End of auto-generated description by cubic. -->

