### PR TITLE
add 'deno task ct' to workspace

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -25,6 +25,7 @@
   ],
   "tasks": {
     "check": "./tasks/check.sh",
+    "ct": "deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env ./packages/cli/mod.ts",
     "test": "./tasks/test.ts",
     "test-all": "echo \"Use 'deno task test' instead.\" && exit 1",
     "build-binaries": "./tasks/build-binaries.ts",


### PR DESCRIPTION
whether in jumble, cli, toolshed, or elsewhere, this let's you use `deno task ct`

this replaces the need for a compiled / up-to-date version of ct to be in your path
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new "ct" task to the workspace so you can run `deno task ct` without needing a compiled version of ct in your path.

<!-- End of auto-generated description by cubic. -->

