### PR TITLE
Fix/schema traversal mismatch - CT-541

### DIFF
--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -614,7 +614,10 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
       if (!deepEqual(nextDoc.path, nextSelector!.path)) {
         throw new Error("New doc path doesn't match selector path");
       }
-      this.traverseWithSchemaContext(nextDoc, nextSelector!.schemaContext!);
+      return this.traverseWithSchemaContext(
+        nextDoc,
+        nextSelector!.schemaContext!,
+      );
     }
   }
 
@@ -664,7 +667,7 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
       if (this.isValidType(schemaObj, "array")) {
         if (this.tracker.enter(doc.value)) {
           try {
-            this.traverseArrayWithSchema(doc, {
+            return this.traverseArrayWithSchema(doc, {
               schema: schemaObj,
               rootSchema: schemaContext.rootSchema,
             });
@@ -688,7 +691,7 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
       } else if (this.isValidType(schemaObj, "object")) {
         if (this.tracker.enter(doc.value)) {
           try {
-            this.traverseObjectWithSchema(doc, {
+            return this.traverseObjectWithSchema(doc, {
               schema: schemaObj,
               rootSchema: schemaContext.rootSchema,
             });


### PR DESCRIPTION
Fix some spots where I wasn't returning the value, so I returned undefined instead (which indicates that the object didn't match the schema).
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug in schema traversal where some functions did not return values, causing undefined results for valid objects.

- **Bug Fixes**
  - Updated traversal methods to always return the correct value.
  - Added a test to confirm all entries are returned from a charm list.

<!-- End of auto-generated description by cubic. -->

