### PR TITLE
chore: Remove duplicate JSX definitions, start to build out intrinsic types from static defs.

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -808,11 +808,3 @@ export type VNode = {
   props: Props;
   children: Array<Child> | Cell<Array<Child>>;
 };
-
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      [elemName: string]: any;
-    }
-  }
-}

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -8,7 +8,12 @@ export function bytesToLines(stream: Uint8Array): string[] {
 }
 
 export function checkStderr(stderr: string[]) {
-  expect(stderr.length).toBe(2);
+  try {
+    expect(stderr.length).toBe(2);
+  } catch (e) {
+    console.error(stderr);
+    throw e;
+  }
   expect(stderr[0]).toMatch(/deno run /);
   expect(stderr[1]).toMatch(/experimentalDecorators compiler option/);
 }

--- a/packages/html/src/jsx.ts
+++ b/packages/html/src/jsx.ts
@@ -2,6 +2,18 @@ import { type VNode } from "@commontools/runner";
 export type { Child, Props } from "@commontools/runner";
 export { type VNode };
 
+// This declaration is for code within our workspace
+// (e.g. jumble and @commontools/html tests.)
+// Recipe code uses JSX definitions found at:
+// `packages/static/assets/types/jsx.d.ts`
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      [elemName: string]: any;
+    }
+  }
+}
+
 /**
  * Type guard to check if a value is a VNode.
  * @param value - The value to check

--- a/packages/js-runtime/typescript/options.ts
+++ b/packages/js-runtime/typescript/options.ts
@@ -62,7 +62,7 @@ export const getCompilerOptions = (): CompilerOptions => {
     target: TARGET,
     // `lib` should autoapply, but we need to manage default libraries since
     // we are running outside of node. Ensure this lib matches `target`.
-    lib: [TARGET_TYPE_LIB, "dom"],
+    lib: [TARGET_TYPE_LIB, "dom", "jsx"],
     // Dynamic import/requires and `<reference` pragmas
     // should not be respected.
     noResolve: true,

--- a/packages/js-runtime/utils.ts
+++ b/packages/js-runtime/utils.ts
@@ -4,6 +4,7 @@ import { cache } from "@commontools/static";
 // to a string of standalone .d.ts content.
 // Includes the following types:
 // * "es2023"
+// * "jsx"
 // * "dom"
 export const getTypeScriptEnvironmentTypes = (() => {
   let cached: Record<string, string> | undefined;
@@ -17,10 +18,8 @@ export const getTypeScriptEnvironmentTypes = (() => {
 
     cached = {
       es2023,
-      // Combine jsx types in our "DOM" types -- having jsx types
-      // in commontools module definition was a problem as it's imported
-      // multiple times when shimming older modules with the "commontools" types.
-      dom: `${dom}\n${jsx}`,
+      dom,
+      jsx,
     };
     return cached;
   };

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -396,11 +396,4 @@ export type VNode = {
     props: Props;
     children: Array<Child> | Cell<Array<Child>>;
 };
-declare global {
-    namespace JSX {
-        interface IntrinsicElements {
-            [elemName: string]: any;
-        }
-    }
-}
 export {};

--- a/packages/static/assets/types/jsx.d.ts
+++ b/packages/static/assets/types/jsx.d.ts
@@ -1,5 +1,9 @@
-namespace JSX {
-  interface IntrinsicElements {
-    [elemName: string]: any;
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      [elemName: string]: any;
+    }
   }
 }
+
+export {};


### PR DESCRIPTION
This uses the static type definition at `packages/static/assets/types/jsx.d.ts` in such a way that we can extend for both runtime usage as well as "vanilla typescript" in a standalone IDE.

While we probably eventually want to generate types dynamically, custom component types can be added to  `packages/static/assets/types/jsx.d.ts`, for example adding the `common-hstack` element and its `gap` property:

```ts
declare global {
  type Children = {
    children: any;
  }
  namespace JSX {
    interface IntrinsicElements {
      [elemName: string]: any;
      "common-hstack": {
        "gap": string;
      } & Children;
    }
  }
}
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed duplicate JSX type definitions and updated the static JSX types to support both runtime and standalone TypeScript environments.

- **Refactors**
  - Centralized JSX intrinsic element types in a single static definition.
  - Updated type loading logic to use the new static JSX types.

<!-- End of auto-generated description by cubic. -->

