### PR TITLE
When updating storage, run a local query to get the linked docs that are missing in storage, and sync them.

### DIFF
--- a/packages/runner/src/storage/query.ts
+++ b/packages/runner/src/storage/query.ts
@@ -21,6 +21,7 @@ import {
   SchemaObjectTraverser,
   type ValueEntry,
 } from "../traverse.ts";
+import { uriToEntityId } from "./transaction-shim.ts";
 
 export abstract class ClientObjectManager extends BaseObjectManager<
   FactAddress,
@@ -110,7 +111,7 @@ export class DocObjectManager extends ClientObjectManager {
       return this.readValues.get(key)!;
     }
     // strip off the leading "of:"
-    const entityId = { "/": doc.of.slice(3) };
+    const entityId = uriToEntityId(doc.of);
     // First, check the document map
     const docMapEntry = this.documentMap.getDocByEntityId(
       this.space,

--- a/packages/runner/src/storage/transaction-shim.ts
+++ b/packages/runner/src/storage/transaction-shim.ts
@@ -36,7 +36,7 @@ import { getJSONFromDataURI } from "../uri-utils.ts";
 /**
  * Convert a URI string to an EntityId object
  */
-function uriToEntityId(uri: string): EntityId {
+export function uriToEntityId(uri: string): EntityId {
   if (!uri.startsWith("of:")) {
     throw new Error(`Invalid URI: ${uri}`);
   }


### PR DESCRIPTION
When updating storage, run a local query to get the linked docs that are missing in storage, and sync them.
Use the transaction shim's uriToEntityId method where possible, so we don't replicate this logic.
Minor change to use Promise.withResolvers instead of defer.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
When syncing storage, the system now checks for linked documents missing in storage and syncs them automatically. Also switched to using a shared uriToEntityId method and updated some async handling.

- **Bug Fixes**
  - Ensures all linked docs are synced if missing from storage.
  - Uses Promise.withResolvers for cleaner async code.

<!-- End of auto-generated description by cubic. -->

