### PR TITLE
Remove a couple places where we create a new ContextualFlowControl

### DIFF
--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1,6 +1,5 @@
 import { isRecord } from "@commontools/utils/types";
 import { ID, ID_FIELD, type JSONSchema } from "./builder/types.ts";
-import { ContextualFlowControl } from "./cfc.ts";
 import { type DocImpl, isDoc } from "./doc.ts";
 import { createRef } from "./doc-map.ts";
 import { appendTxToReactivityLog, isCell } from "./cell.ts";
@@ -281,7 +280,7 @@ export function normalizeAndDiff(
     ];
   }
 
-  const cfc = new ContextualFlowControl();
+  const cfc = current.cell.runtime.cfc;
   // Handle arrays
   if (Array.isArray(newValue)) {
     // If the current value is not an array, set it to an empty array

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -561,10 +561,9 @@ export function validateAndTransform(
     seen.push([seenKey, result]);
 
     // Handle explicitly defined properties
-    const cfc = new ContextualFlowControl();
     if (resolvedSchema.properties) {
       for (const key of Object.keys(resolvedSchema.properties)) {
-        const childSchema = cfc.getSchemaAtPath(
+        const childSchema = runtime.cfc.getSchemaAtPath(
           resolvedSchema,
           [key],
           rootSchema,
@@ -597,7 +596,7 @@ export function validateAndTransform(
     const keys = Object.keys(value);
     for (const key of keys) {
       if (!resolvedSchema.properties || !(key in resolvedSchema.properties)) {
-        const childSchema = cfc.getSchemaAtPath(
+        const childSchema = runtime.cfc.getSchemaAtPath(
           resolvedSchema,
           [key],
           rootSchema,


### PR DESCRIPTION
Remove a couple places where we create a new ContextualFlowControl objects when we have access to the runtime.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reused the existing ContextualFlowControl from the runtime instead of creating new instances in data-updating and schema modules.

<!-- End of auto-generated description by cubic. -->

