### PR TITLE
chore: Prefix RuntimePrograms with a content-based ID in their path

### DIFF
--- a/packages/js-runtime/typescript/resolver.ts
+++ b/packages/js-runtime/typescript/resolver.ts
@@ -110,6 +110,13 @@ function getImports(
         imports.push(moduleSpecifier.text);
       }
     }
+    // `export * from "specifier";`
+    if (ts.isExportDeclaration(node)) {
+      const moduleSpecifier = node.moduleSpecifier;
+      if (moduleSpecifier && ts.isStringLiteral(moduleSpecifier)) {
+        imports.push(moduleSpecifier.text);
+      }
+    }
     ts.forEachChild(node, visit);
   }
 

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -33,7 +33,7 @@ import {
   streamData,
 } from "./built-in.ts";
 import { getRecipeEnvironment } from "./env.ts";
-import type { RuntimeProgram } from "../harness/harness.ts";
+import type { RuntimeProgram } from "../harness/types.ts";
 
 /**
  * Creates a set of builder functions with the given runtime

--- a/packages/runner/src/harness/index.ts
+++ b/packages/runner/src/harness/index.ts
@@ -4,5 +4,5 @@ export type {
   HarnessedFunction,
   RuntimeProgram,
   TypeScriptHarnessProcessOptions,
-} from "./harness.ts";
+} from "./types.ts";
 export { Console, ConsoleEvent, ConsoleMethod } from "./console.ts";

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -14,6 +14,9 @@ export interface TypeScriptHarnessProcessOptions {
   noCheck?: boolean;
   // Does not evaluate the recipe.
   noRun?: boolean;
+  // An identifer to use to uniquely identify the compiled
+  // code when applying source maps.
+  identifier?: string;
   // Filename to use in the compiled JS code, for engines
   // that apply source maps.
   filename?: string;

--- a/packages/runner/src/recipe-manager.ts
+++ b/packages/runner/src/recipe-manager.ts
@@ -2,7 +2,7 @@ import { JSONSchema, Module, Recipe, Schema } from "./builder/types.ts";
 import { Cell } from "./cell.ts";
 import type { IRecipeManager, IRuntime, MemorySpace } from "./runtime.ts";
 import { createRef } from "./doc-map.ts";
-import { RuntimeProgram } from "./harness/harness.ts";
+import { RuntimeProgram } from "./harness/types.ts";
 
 export const recipeMetaSchema = {
   type: "object",

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -26,7 +26,7 @@ import {
   type ReactivityLog,
   Scheduler,
 } from "./scheduler.ts";
-import type { Harness, RuntimeProgram } from "./harness/harness.ts";
+import type { RuntimeProgram } from "./harness/types.ts";
 import { Engine } from "./harness/index.ts";
 import { ConsoleMethod } from "./harness/console.ts";
 import {
@@ -95,7 +95,7 @@ export interface IRuntime {
   readonly recipeManager: IRecipeManager;
   readonly moduleRegistry: IModuleRegistry;
   readonly documentMap: IDocumentMap;
-  readonly harness: Harness;
+  readonly harness: Engine;
   readonly runner: IRunner;
   readonly blobbyServerUrl: string;
   readonly navigateCallback?: NavigateCallback;
@@ -321,7 +321,7 @@ export class Runtime implements IRuntime {
   readonly recipeManager: IRecipeManager;
   readonly moduleRegistry: IModuleRegistry;
   readonly documentMap: IDocumentMap;
-  readonly harness: Harness;
+  readonly harness: Engine;
   readonly runner: IRunner;
   readonly blobbyServerUrl: string;
   readonly navigateCallback?: NavigateCallback;


### PR DESCRIPTION
Uniquely identifies sources when loaded through browser devtools
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a content-based ID prefix to RuntimeProgram file paths to ensure each source is uniquely identified in browser devtools.

- **Refactors**
  - Updated program mapping to add the ID prefix and generate a new entry file for exports.
  - Moved type imports to a new types file for better organization.

<!-- End of auto-generated description by cubic. -->

