### PR TITLE
fix: data uri write prevention

### DIFF
--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -481,13 +481,15 @@ export type ReadError =
 export type WriteError =
   | INotFoundError
   | IUnsupportedMediaTypeError
-  | InactiveTransactionError;
+  | InactiveTransactionError
+  | IReadOnlyAddressError;
 
 export type ReaderError = InactiveTransactionError;
 
 export type WriterError =
   | InactiveTransactionError
-  | IStorageTransactionWriteIsolationError;
+  | IStorageTransactionWriteIsolationError
+  | IReadOnlyAddressError;
 
 export interface IStorageTransactionComplete extends Error {
   name: "StorageTransactionCompleteError";
@@ -656,6 +658,20 @@ export interface IStorageTransactionWriteIsolationError extends Error {
    * Memory space writer could not be opened for.
    */
   requested: MemorySpace;
+}
+
+/**
+ * Error returned when attempting to write to a read-only address (data: URI).
+ */
+export interface IReadOnlyAddressError extends Error {
+  name: "ReadOnlyAddressError";
+
+  /**
+   * The read-only address that was attempted to be written to.
+   */
+  address: IMemoryAddress;
+
+  from(space: MemorySpace): IReadOnlyAddressError;
 }
 
 /**

--- a/packages/runner/test/journal.test.ts
+++ b/packages/runner/test/journal.test.ts
@@ -356,7 +356,9 @@ describe("Journal", () => {
 
       const newReaderResult = journal.reader(space);
       expect(newReaderResult.error).toBeDefined();
-      expect(newReaderResult.error?.name).toBe("StorageTransactionCompleteError");
+      expect(newReaderResult.error?.name).toBe(
+        "StorageTransactionCompleteError",
+      );
 
       const readResult = reader!.read({
         id: "test:closed",
@@ -394,7 +396,9 @@ describe("Journal", () => {
 
       const newWriterResult = journal.writer(space);
       expect(newWriterResult.error).toBeDefined();
-      expect(newWriterResult.error?.name).toBe("StorageTransactionCompleteError");
+      expect(newWriterResult.error?.name).toBe(
+        "StorageTransactionCompleteError",
+      );
 
       const readResult = writer!.read({
         id: "test:closed-write",


### PR DESCRIPTION
Adds data URI write prevention
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevented writes to data URI addresses by marking them as read-only and returning a clear error when a write is attempted.

- **Bug Fixes**
  - Added checks to block writes to any data URI address.
  - Introduced a specific error for write attempts to read-only addresses.
  - Added tests to cover various data URI write scenarios.

<!-- End of auto-generated description by cubic. -->

