### PR TITLE
chore: Wire up the rest of shell framework

### DIFF
--- a/packages/shell/src/components/index.ts
+++ b/packages/shell/src/components/index.ts
@@ -1,0 +1,1 @@
+// Import all web components here, registering

--- a/packages/shell/src/contexts/app.ts
+++ b/packages/shell/src/contexts/app.ts
@@ -1,4 +1,4 @@
 import { createContext } from "@lit/context";
-import { App } from "../models/app.ts";
+import { AppState } from "../models/app.ts";
 
-export const appContext = createContext<App>("app");
+export const appContext = createContext<AppState>("app");

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -1,10 +1,30 @@
 import { API_URL, COMMIT_SHA, ENVIRONMENT } from "./lib/env.ts";
+import { AppUpdateEvent } from "./lib/app-update.ts";
+import { XRootView } from "./views/RootView.ts";
 
-import "./views/RootView.ts";
-import "./views/HeaderView.ts";
-import "./views/BodyView.ts";
-import "./views/LoginView.ts";
+import "./components/index.ts";
+import "./views/index.ts";
 
 console.log(`ENVIRONMENT=${ENVIRONMENT}`);
 console.log(`API_URL=${API_URL}`);
 console.log(`COMMIT_SHA=${COMMIT_SHA}`);
+
+declare global {
+  var app: XRootView;
+}
+
+const root = document.querySelector("x-root-view");
+if (!root) throw new Error("No root view found.");
+const app = root as XRootView;
+globalThis.app = app;
+if (ENVIRONMENT !== "production") {
+  app.addEventListener("appupdate", (e) => {
+    (e as AppUpdateEvent).prettyPrint();
+  });
+}
+{
+  const location = new URL(globalThis.location.href);
+  const match = location.pathname.match(/^\/([^\/]+)\//);
+  const spaceName = match && match.length > 1 ? match[1] : "common-knowledge";
+  await app.setSpace(spaceName);
+}

--- a/packages/shell/src/lib/app-update.ts
+++ b/packages/shell/src/lib/app-update.ts
@@ -1,0 +1,50 @@
+import { Command } from "./commands.ts";
+import { AppState } from "./app.ts";
+
+export class AppUpdateEvent extends Event {
+  command: Command;
+  state?: AppState;
+  error?: Error;
+
+  constructor(
+    command: Command,
+    { state, error }: { state?: AppState; error?: Error },
+  ) {
+    super("appupdate");
+    this.command = command;
+    this.state = state;
+    this.error = error;
+  }
+
+  // Logs this `AppUpdateEvent` into the global console.
+  prettyPrint() {
+    const ENTRY_STYLE = "font-weight:bold;";
+    const ERROR_STYLE = "font-weight:bold;color:red";
+    const RESET_STYLE = "";
+    const { command, error, state } = this;
+    const { type } = command;
+    const jsonCommand = JSON.stringify(command);
+    const time = `${(globalThis.performance.now() / 1000).toFixed(3)}s`;
+    if (error) {
+      const message = error.message;
+      const label = `Command|${type}|ERROR`;
+      console.groupCollapsed(label);
+      console.log(`%cType: %c${type}`, ENTRY_STYLE, RESET_STYLE);
+      console.log(`%cCommand: %c${jsonCommand}`, ENTRY_STYLE, RESET_STYLE);
+      console.log(`%cError:`, ERROR_STYLE, message);
+      console.log(`%cTime: %c${time}`, ENTRY_STYLE, RESET_STYLE);
+    } else if (state) {
+      const label = `Command|${type}`;
+      console.groupCollapsed(label);
+      console.log(`%cType: %c${type}`, ENTRY_STYLE, RESET_STYLE);
+      console.log(`%cCommand: %c${jsonCommand}`, ENTRY_STYLE, RESET_STYLE);
+      console.log(
+        `%cState:`,
+        ENTRY_STYLE,
+        state,
+      );
+      console.log(`%cTime: %c${time}`, ENTRY_STYLE, RESET_STYLE);
+    }
+    console.groupEnd();
+  }
+}

--- a/packages/shell/src/lib/app.ts
+++ b/packages/shell/src/lib/app.ts
@@ -1,0 +1,58 @@
+import { ANYONE, Identity, Session } from "@commontools/identity";
+import { Command } from "./commands.ts";
+
+export interface AppState {
+  identity?: Identity;
+  spaceName?: string;
+  activeCharmId?: string;
+  session?: Session;
+  apiUrl: URL;
+}
+
+export function clone(state: AppState): AppState {
+  return Object.assign({}, state);
+}
+
+export async function applyCommand(
+  state: AppState,
+  command: Command,
+): Promise<AppState> {
+  const next = clone(state);
+  switch (command.type) {
+    case "set-identity": {
+      next.identity = command.identity;
+      next.session = undefined;
+      break;
+    }
+    case "set-space": {
+      next.spaceName = command.spaceName;
+      next.session = undefined;
+      break;
+    }
+  }
+  // If space or identity was set, and session reset,
+  // compute a Session.
+  if (next.spaceName && next.identity && !next.session) {
+    next.session = await createSession(
+      next.identity,
+      next.spaceName,
+    );
+  }
+  return next;
+}
+
+async function createSession(
+  root: Identity,
+  spaceName: string,
+): Promise<Session> {
+  const account = spaceName.startsWith("~")
+    ? root
+    : await Identity.fromPassphrase(ANYONE);
+  const user = await account.derive(spaceName);
+  return {
+    private: account.did() === root.did(),
+    name: spaceName,
+    space: user.did(),
+    as: user,
+  };
+}

--- a/packages/shell/src/lib/commands.ts
+++ b/packages/shell/src/lib/commands.ts
@@ -1,0 +1,24 @@
+import { Identity } from "@commontools/identity";
+
+export type Command =
+  | { type: "set-identity"; identity: Identity }
+  | { type: "set-space"; spaceName: string };
+
+export function isCommand(value: unknown): value is Command {
+  if (
+    !value || typeof value !== "object" || !("type" in value) ||
+    typeof value.type !== "string"
+  ) {
+    return false;
+  }
+  switch (value.type) {
+    case "set-identity": {
+      return "identity" in value && value.identity instanceof Identity;
+    }
+    case "set-space": {
+      return "spaceName" in value && !!value.spaceName &&
+        typeof value.spaceName === "string";
+    }
+  }
+  return false;
+}

--- a/packages/shell/src/models/app.ts
+++ b/packages/shell/src/models/app.ts
@@ -1,5 +1,0 @@
-import { Identity } from "@commontools/identity";
-
-export class App {
-  identity?: Identity;
-}

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -1,0 +1,38 @@
+import { css, html } from "lit";
+import { state } from "lit/decorators.js";
+import { AppState } from "../lib/app.ts";
+import { appContext } from "../contexts/app.ts";
+import { consume } from "@lit/context";
+import { BaseView } from "./BaseView.ts";
+
+export class XAppView extends BaseView {
+  static override styles = css`
+    :host {
+      display: block;
+      width: 100%;
+      height: 100vh;
+      background-color: #eee;
+    }
+    #body {
+      height: 100%;
+      width: 100%;
+    }
+  `;
+
+  @consume({ context: appContext, subscribe: true })
+  @state()
+  private app?: AppState;
+
+  override render() {
+    const unauthenticated = html`
+      <x-login-view></x-login-view>
+    `;
+    const authenticated = html`
+      <x-header-view></x-header-view>
+      <x-body-view></x-body-view>
+    `;
+    return this.app?.identity ? authenticated : unauthenticated;
+  }
+}
+
+globalThis.customElements.define("x-app-view", XAppView);

--- a/packages/shell/src/views/BaseView.ts
+++ b/packages/shell/src/views/BaseView.ts
@@ -1,0 +1,16 @@
+import { LitElement } from "lit";
+import { Command } from "../lib/commands.ts";
+
+export const SHELL_COMMAND = "shell-command";
+
+export class BaseView extends LitElement {
+  command(command: Command) {
+    this.dispatchEvent(
+      new CustomEvent(SHELL_COMMAND, {
+        detail: command,
+        composed: true,
+        bubbles: true,
+      }),
+    );
+  }
+}

--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -1,10 +1,11 @@
-import { css, html, LitElement } from "lit";
+import { css, html } from "lit";
 import { property } from "lit/decorators.js";
 import { consume } from "@lit/context";
-import { App } from "../models/app.ts";
+import { AppState } from "../models/app.ts";
 import { appContext } from "../contexts/app.ts";
+import { BaseView } from "./BaseView.ts";
 
-export class XBodyView extends LitElement {
+export class XBodyView extends BaseView {
   static override styles = css`
     :host {
       display: block;
@@ -14,9 +15,9 @@ export class XBodyView extends LitElement {
     }
   `;
 
-  @consume({ context: appContext })
+  @consume({ context: appContext, subscribe: true })
   @property({ attribute: false })
-  app = new App();
+  private app?: AppState;
 
   override render() {
     return html`

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -1,7 +1,7 @@
 import { css, html, LitElement } from "lit";
 import { property } from "lit/decorators.js";
 import { consume } from "@lit/context";
-import { App } from "../models/app.ts";
+import { AppState } from "../models/app.ts";
 import { appContext } from "../contexts/app.ts";
 
 export class XHeaderView extends LitElement {
@@ -14,9 +14,9 @@ export class XHeaderView extends LitElement {
     }
   `;
 
-  @consume({ context: appContext })
+  @consume({ context: appContext, subscribe: true })
   @property({ attribute: false })
-  app = new App();
+  private app?: AppState;
 
   override render() {
     return html`

--- a/packages/shell/src/views/LoginView.ts
+++ b/packages/shell/src/views/LoginView.ts
@@ -1,10 +1,8 @@
-import { css, html, LitElement } from "lit";
-import { property } from "lit/decorators.js";
-import { consume } from "@lit/context";
-import { App } from "../models/app.ts";
-import { appContext } from "../contexts/app.ts";
+import { css, html } from "lit";
+import { ANYONE, Identity } from "@commontools/identity";
+import { BaseView } from "./BaseView.ts";
 
-export class XLoginView extends LitElement {
+export class XLoginView extends BaseView {
   static override styles = css`
     :host {
       display: block;
@@ -14,13 +12,15 @@ export class XLoginView extends LitElement {
     }
   `;
 
-  @consume({ context: appContext })
-  @property({ attribute: false })
-  app = new App();
+  async onLogin(e: Event) {
+    e.preventDefault();
+    const identity = await Identity.fromPassphrase(ANYONE);
+    this.command({ type: "set-identity", identity });
+  }
 
   override render() {
     return html`
-      <span>TODO LOGIN!</span>
+      <button @click="${this.onLogin}">Anonymous Login</button>
     `;
   }
 }

--- a/packages/shell/src/views/index.ts
+++ b/packages/shell/src/views/index.ts
@@ -1,0 +1,5 @@
+import "./AppView.ts";
+import "./BodyView.ts";
+import "./HeaderView.ts";
+import "./LoginView.ts";
+import "./RootView.ts";


### PR DESCRIPTION
Implement Lit context for propagating state downwards and fire Commands to modify application state.

* Views send `Command` upward to the root. Similar to Redux actions.
* Root view applies change to an immutable `AppState`. As a Lit Context Provider, this state rerenders children views that are subscribed to state.
* Example of listening for app update events on the root and logging the commands, state, and/or errors.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Connected the shell framework by wiring up Lit context for state management and adding a command system for updating application state.

- **New Features**
  - Views now send commands upward to the root, which updates an immutable app state and propagates changes to subscribed children.
  - Added event logging for commands, state updates, and errors at the root level.
  - Introduced new base and app views to support the updated state flow.

<!-- End of auto-generated description by cubic. -->

