### PR TITLE
feat: Felt dev server updates

### DIFF
--- a/packages/felt/builder.ts
+++ b/packages/felt/builder.ts
@@ -9,7 +9,14 @@ export class Builder extends EventTarget {
   }
 
   async watch(watchRoot: string, debounceTimeout: number = 200) {
-    const fn = debounce(this.build.bind(this), debounceTimeout);
+    const fn = debounce(async () => {
+      try {
+        await this.build();
+      } catch (e: any) {
+        const message = e && "message" in e ? e.message : e;
+        console.error(message);
+      }
+    }, debounceTimeout);
     const watcher = Deno.watchFs(watchRoot);
     for await (const _ of watcher) {
       await fn();

--- a/packages/felt/felt.ts
+++ b/packages/felt/felt.ts
@@ -10,7 +10,8 @@ export class Felt {
   ) {}
 
   async process() {
-    const { port, hostname, watchDir, publicDir, outDir } = this.config;
+    const { port, redirectToIndex, hostname, watchDir, publicDir, outDir } =
+      this.config;
     const isBuild = this.command === "build";
     const isServe = this.command === "serve";
     const isDev = this.command === "dev";
@@ -35,6 +36,7 @@ export class Felt {
     const server = new DevServer({
       useReloadSocket: isDev,
       hostname,
+      redirectToIndex,
       port,
       outDir,
     });

--- a/packages/felt/interface.ts
+++ b/packages/felt/interface.ts
@@ -22,6 +22,10 @@ export interface Config {
   // to cause a JS rebuild during `dev`.
   // Defaults to "src".
   watchDir?: string;
+  // While running a dev server, a regex to match
+  // against a path, and if successful, will return
+  // the root index.html.
+  redirectToIndex?: RegExp;
   esbuild?: ESBuildConfig;
 }
 
@@ -44,6 +48,7 @@ export class ResolvedConfig {
   port: number;
   publicDir: string;
   watchDir: string;
+  redirectToIndex?: RegExp;
   esbuild: {
     sourcemap: boolean;
     external: string[];
@@ -61,6 +66,7 @@ export class ResolvedConfig {
     this.watchDir = join(cwd, partial?.watchDir ?? "src");
     this.hostname = partial?.hostname ?? "127.0.0.1";
     this.port = partial?.port ?? 5173;
+    this.redirectToIndex = partial?.redirectToIndex;
     this.esbuild = {
       sourcemap: !!(partial?.esbuild?.sourcemap),
       minify: !!(partial?.esbuild?.minify),

--- a/packages/shell/felt.config.ts
+++ b/packages/shell/felt.config.ts
@@ -11,6 +11,7 @@ const config: Config = {
   port: 5173,
   publicDir: "public",
   watchDir: "src",
+  redirectToIndex: /^\/(?!(((assets)|(scripts)|(styles))\/.*))/,
   esbuild: {
     sourcemap: !PRODUCTION,
     minify: PRODUCTION,


### PR DESCRIPTION
* Allow continuous compiling in felt dev server even when compilation fails.
* Introduce 'redirectToIndex' for the felt dev server to serve the root index.html when the request pathname matches the provided pattern.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
The Felt dev server now keeps compiling even if there are build errors, and can serve index.html for custom routes using a new redirectToIndex option.

- **New Features**
  - Added redirectToIndex to serve index.html when the request path matches a given pattern.
  - Dev server continues watching and compiling after failed builds.

<!-- End of auto-generated description by cubic. -->

