### PR TITLE
chore: Use experimental decorators rather than standard decorators 

### DIFF
--- a/packages/jumble/vite.config.ts
+++ b/packages/jumble/vite.config.ts
@@ -12,6 +12,13 @@ console.log("Build source maps:", buildSourcemaps);
 
 // https://vite.dev/config/
 export default defineConfig({
+  esbuild: {
+    tsconfigRaw: {
+      compilerOptions: {
+        experimentalDecorators: true,
+      },
+   },
+  },
   plugins: [deno(), react(), tailwindcss() as any],
   server: {
     allowedHosts: [

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -1,4 +1,4 @@
-//import "@commontools/ui/v2";
+import "@commontools/ui/v2";
 import { KeyStore } from "@commontools/identity";
 import { API_URL, COMMIT_SHA, ENVIRONMENT } from "./lib/env.ts";
 import { AppUpdateEvent } from "./lib/app/events.ts";

--- a/packages/ui/src/v2/components/ct-form/ct-form.ts
+++ b/packages/ui/src/v2/components/ct-form/ct-form.ts
@@ -124,14 +124,14 @@ export class CTForm extends BaseElement {
     }
   `;
 
-  @property({ type: String })
-  accessor method: "GET" | "POST" = "GET";
+  @property()
+  method: "GET" | "POST" = "GET";
 
-  @property({ type: String })
-  accessor action = "";
+  @property()
+  action = "";
 
   @query("form")
-  private accessor _form!: HTMLFormElement;
+  private _form!: HTMLFormElement;
 
   override render() {
     return html`

--- a/packages/ui/src/v2/components/ct-list/ct-list.ts
+++ b/packages/ui/src/v2/components/ct-list/ct-list.ts
@@ -22,17 +22,17 @@ import { BaseElement } from "../../core/base-element.ts";
  */
 
 export class CTList extends BaseElement {
-  @property({ type: Object })
-  accessor list: {
+  @property()
+  list: {
     title: string;
     items: Array<{ title: string; done?: boolean }>;
   } = { title: "", items: [] };
 
-  @property({ type: Boolean })
-  accessor readonly: boolean = false;
+  @property()
+  readonly: boolean = false;
 
-  @property({ type: Object })
-  accessor action: {
+  @property()
+  action: {
     type: "remove" | "accept" | "custom";
     label?: string;
     event?: string;

--- a/packages/ui/src/v2/components/ct-tile/ct-tile.ts
+++ b/packages/ui/src/v2/components/ct-tile/ct-tile.ts
@@ -18,14 +18,14 @@ import { BaseElement } from "../../core/base-element.ts";
  */
 
 export class CTTile extends BaseElement {
-  @property({ type: Object })
-  accessor item: { title: string; [key: string]: any } = { title: "" };
+  @property()
+  item: { title: string; [key: string]: any } = { title: "" };
 
-  @property({ type: String })
-  accessor summary: string = "";
+  @property()
+  summary: string = "";
 
-  @property({ type: Boolean })
-  accessor clickable: boolean = true;
+  @property()
+  clickable: boolean = true;
 
   static override styles = css`
     :host {
@@ -44,7 +44,8 @@ export class CTTile extends BaseElement {
       --tile-padding: 1rem;
       --tile-border-radius: 0.5rem;
       --tile-border: 1px solid var(--border);
-      --tile-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+      --tile-shadow:
+        0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
     }
 
     .tile {
@@ -63,7 +64,9 @@ export class CTTile extends BaseElement {
 
     .tile.clickable:hover {
       border-color: var(--accent);
-      box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+      box-shadow:
+        0 4px 6px -1px rgb(0 0 0 / 0.1),
+        0 2px 4px -2px rgb(0 0 0 / 0.1);
       transform: translateY(-1px);
     }
 
@@ -125,7 +128,6 @@ export class CTTile extends BaseElement {
     }
   `;
 
-
   private handleClick() {
     if (this.clickable) {
       this.emit("ct-click", { item: this.item });
@@ -134,24 +136,25 @@ export class CTTile extends BaseElement {
 
   override render() {
     if (!this.item || !this.item.title) {
-      return html`<div class="empty-tile">No item data</div>`;
+      return html`
+        <div class="empty-tile">No item data</div>
+      `;
     }
 
     return html`
-      <div 
+      <div
         class="tile ${this.clickable ? "clickable" : ""}"
         @click="${this.handleClick}"
       >
         <div class="tile-content">
           <h3 class="tile-title">${this.item.title}</h3>
-          ${this.summary 
-            ? html`
-              <details class="summary-details">
-                <summary>${this.summary}</summary>
-              </details>
-            `
-            : ""
-          }
+          ${this.summary
+        ? html`
+          <details class="summary-details">
+            <summary>${this.summary}</summary>
+          </details>
+        `
+        : ""}
           <slot></slot>
         </div>
       </div>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched all decorators in UI components to use experimental decorators instead of standard decorators for compatibility with the latest TypeScript settings. Updated Vite config to enable experimentalDecorators in the build process.

<!-- End of auto-generated description by cubic. -->

