### PR TITLE
Changes how schema subscriptions communicate changes to the client

### DIFF
--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -152,7 +152,7 @@ export type Protocol<Space extends MemorySpace = MemorySpace> = {
           source: Subscribe<Space>["args"],
         ): Task<
           Result<Unit, SystemError | AuthorizationError>,
-          Commit<Space>
+          EnhancedCommit<Space>
         >;
         unsubscribe(
           source: Unsubscribe<Space>["args"],
@@ -641,6 +641,11 @@ export type Commit<Subject extends string = MemorySpace> = {
       };
     };
   };
+};
+
+export type EnhancedCommit<Subject extends string = MemorySpace> = {
+  revisions: Revision<State>[];
+  commit: Commit<Subject>;
 };
 
 // We include labels here so we can use the commit data to redact the transaction

--- a/packages/memory/test/consumer-test.ts
+++ b/packages/memory/test/consumer-test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertMatch } from "@std/assert";
+import { assert, assertEquals, assertFalse, assertMatch } from "@std/assert";
 import { refer } from "merkle-reference";
 import type { JSONSchema } from "@commontools/runner";
 import * as Changes from "../changes.ts";
@@ -718,17 +718,13 @@ test("subscribe to commits", store, async (session) => {
 
   const c3 = Commit.toRevision(r3.ok);
 
-  assertEquals(await p1, {
-    done: false,
-    value: {
-      [alice.did()]: {
-        [alice.did()]: {
-          ["application/commit+json"]: {
-            [c3.cause.toString()]: {
-              is: c3.is,
-              since: c3.is.since,
-            },
-          },
+  const res1 = await p1;
+  assertFalse(res1.done);
+  assertEquals(res1.value?.commit, {
+    [alice.did() as Consumer.DID]: {
+      ["application/commit+json"]: {
+        [c3.cause.toString()]: {
+          is: c3.is,
         },
       },
     },
@@ -1129,32 +1125,29 @@ test(
     assert(r3.ok);
     const c3 = Commit.toRevision(r3.ok);
 
-    assertEquals(await p1, {
-      done: false,
-      value: {
-        [alice.did()]: {
-          [alice.did()]: {
-            ["application/commit+json"]: {
-              [c3.cause.toString()]: {
-                is: {
-                  since: c3.is.since,
-                  transaction: {
-                    ...c3.is.transaction,
-                    args: {
-                      changes: {
-                        [doc]: {
-                          "application/json": {},
-                          "application/label+json": {
-                            [v3_label.cause.toString()]: {
-                              is: { classification: ["confidential"] },
-                            },
-                          },
+    // ts-ignore
+    const res1 = await p1;
+    assertFalse(res1.done);
+    assertEquals(res1.value.commit, {
+      [alice.did()]: {
+        ["application/commit+json"]: {
+          [c3.cause.toString()]: {
+            is: {
+              since: c3.is.since,
+              transaction: {
+                ...c3.is.transaction,
+                args: {
+                  changes: {
+                    [doc]: {
+                      "application/json": {},
+                      "application/label+json": {
+                        [v3_label.cause.toString()]: {
+                          is: { classification: ["confidential"] },
                         },
                       },
                     },
                   },
                 },
-                since: c3.is.since,
               },
             },
           },

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -1,5 +1,4 @@
 import type {
-  Assertion,
   AuthorizationError,
   Changes as MemoryChanges,
   Commit,
@@ -14,9 +13,7 @@ import type {
   MemorySpace,
   Protocol,
   ProviderCommand,
-  ProviderSession,
   QueryError,
-  Reference,
   Result,
   Revision,
   SchemaContext,
@@ -29,12 +26,11 @@ import type {
   TransactionError,
   UCAN,
   Unit,
-  Variant,
 } from "@commontools/memory/interface";
 import { set, setSelector } from "@commontools/memory/selection";
 import type { MemorySpaceSession } from "@commontools/memory/consumer";
-import { assert, claim, retract, unclaimed } from "@commontools/memory/fact";
-import { the, toChanges, toRevision } from "@commontools/memory/commit";
+import { assert, retract, unclaimed } from "@commontools/memory/fact";
+import { the, toRevision } from "@commontools/memory/commit";
 import * as Consumer from "@commontools/memory/consumer";
 import * as Codec from "@commontools/memory/codec";
 import { type Cancel, type EntityId } from "@commontools/runner";
@@ -498,7 +494,7 @@ export class Replica {
       if (next.done) {
         break;
       }
-      this.integrate(next.value[this.space] as unknown as Commit);
+      this.integrate(next.value.revisions);
     }
   }
 
@@ -822,7 +818,7 @@ export class Replica {
       this.heap.merge(
         revisions,
         Replica.put,
-        (revision) => !localFacts.has(revision),
+        (revision) => revision === undefined || !localFacts.has(revision),
       );
       // We only delete from the nursery when we've seen all of our pending
       // facts (or gotten a conflict).
@@ -878,22 +874,18 @@ export class Replica {
     this.heap.unsubscribe(entry, subscriber);
   }
 
-  integrate(commit: Commit) {
-    const { the, of, cause, is, since } = toRevision(commit);
-    const revisions = [
-      { the, of, cause, is: { since: is.since }, since },
-      ...toChanges(commit),
-    ];
-
+  integrate(revisions: Revision<State>[]) {
     // Store newer revisions into the heap.
-    // It's possible to get the same fact (including cause) twice, and we'll
-    // have a new since field on the second, so we can't clear them from
+    // It's possible to get the same fact (including cause) twice, but we
+    // should have the same since on the second, so we can clear them from
     // tracking when we see them.
     const resolvedFacts = this.getLocalFacts(revisions);
+    // We use update here instead of put, since we may have received new docs
+    // that we weren't already tracking.
     this.heap.merge(
       revisions,
-      Replica.update,
-      (state) => !resolvedFacts.has(state),
+      Replica.put,
+      (state) => state === undefined || !resolvedFacts.has(state),
     );
     return this.cache.merge(revisions, Replica.update);
   }
@@ -916,7 +908,7 @@ export class Replica {
   private getLocalFacts(
     revisions: (Revision<State> | undefined)[],
   ) {
-    const matches = new Set();
+    const matches = new Set<Revision<State>>();
     for (const revision of revisions) {
       if (revision === undefined || revision.cause === undefined) {
         continue;

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -880,7 +880,7 @@ export class Replica {
     // should have the same since on the second, so we can clear them from
     // tracking when we see them.
     const resolvedFacts = this.getLocalFacts(revisions);
-    // We use update here instead of put, since we may have received new docs
+    // We use put here instead of update, since we may have received new docs
     // that we weren't already tracking.
     this.heap.merge(
       revisions,


### PR DESCRIPTION
Changes how schema subscriptions communicate changes to the client
- When we send over commit messages, we send them as an EnhancedCommit that has the commit and all the facts that our schema subscriptions would include based on this commit.
- The QuerySubscriptionInvocation object forwards all EnhancedCommits to the controller, where they will be picked up by the cache.
- The Replica (cache) integrates the revisions in the EnhancedCommit, instead of attempting to extract the data from the commit itself.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Schema subscriptions now send EnhancedCommit objects to the client, bundling the commit and all related facts, so the cache can directly integrate all relevant revisions.

- **Refactors**
  - QuerySubscriptionInvocation streams EnhancedCommit objects instead of raw commits.
  - The cache (Replica) now integrates revisions from EnhancedCommit, simplifying data handling.

<!-- End of auto-generated description by cubic. -->

