### PR TITLE
Re-enable the runner integration tests

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -367,8 +367,15 @@ jobs:
       - name: 🛡️ Disable AppArmor for browser tests
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
-      - name: 🧪 Run end-to-end integration tests
+      - name: 🧪 Run end-to-end jumble integration tests
         working-directory: packages/jumble
+        run: |
+          TOOLSHED_API_URL=http://localhost:8000/ \
+          FRONTEND_URL=http://localhost:8000/ \
+          deno task integration
+
+      - name: 🧪 Run end-to-end runner integration tests
+        working-directory: packages/runner
         run: |
           TOOLSHED_API_URL=http://localhost:8000/ \
           FRONTEND_URL=http://localhost:8000/ \


### PR DESCRIPTION
I disabled these runner integration tests when they were failing earlier.
Re-enabling them now.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Re-enabled the runner integration tests in the CI workflow to restore automated test coverage for the runner package.

<!-- End of auto-generated description by cubic. -->

