### PR TITLE
Minor tweaks to runner integration tests

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -379,7 +379,6 @@ jobs:
         working-directory: packages/runner
         run: |
           TOOLSHED_API_URL=http://localhost:8000/ \
-          FRONTEND_URL=http://localhost:8000/ \
           deno task integration
 
   cli-integration-test:

--- a/packages/runner/integration/basic-persistence.test.ts
+++ b/packages/runner/integration/basic-persistence.test.ts
@@ -12,13 +12,15 @@ const keyConfig: IdentityCreateConfig = {
 const identity = await Identity.fromPassphrase("test operator", keyConfig);
 
 console.log("\n=== TEST: Simple object persistence ===");
+const TOOLSHED_API_URL = Deno.env.get("TOOLSHED_API_URL") ??
+  "http://localhost:8000/";
 
 async function test() {
   // First runtime - save data
   const runtime1 = new Runtime({
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", "http://localhost:8000"),
+      address: new URL("/api/storage/memory", TOOLSHED_API_URL),
     }),
     blobbyServerUrl: "http://localhost:8000",
   });
@@ -47,7 +49,7 @@ async function test() {
   const runtime2 = new Runtime({
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", "http://localhost:8000"),
+      address: new URL("/api/storage/memory", TOOLSHED_API_URL),
     }),
     blobbyServerUrl: "http://localhost:8000",
   });


### PR DESCRIPTION
Remove FRONTEND_URL from env params for the runner integration test, since it's unused

Use the TOOLSHED_API_URL from env if available for the runner integration test.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the unused FRONTEND_URL from runner integration test env params and updated the test to use TOOLSHED_API_URL from the environment if set.

<!-- End of auto-generated description by cubic. -->

