### PR TITLE
feat: Add metadata support to storage read operations

### DIFF
--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -36,6 +36,18 @@ export type {
 };
 
 /**
+ * Metadata that can be attached to read operations
+ */
+export interface Metadata extends Record<PropertyKey, unknown> {}
+
+/**
+ * Options for read operations
+ */
+export interface IReadOptions {
+  meta?: Metadata;
+}
+
+/**
  * @deprecated - Use IAttestation instead
  */
 export type Read = IAttestation;
@@ -412,9 +424,13 @@ export interface IStorageTransaction {
    * opposed to value stored.
    *
    * @param address - Memory address to read from.
+   * @param options - Optional read options including metadata
    * @returns Result containing the read value or an error.
    */
-  read(address: IMemorySpaceAddress): Result<IAttestation, ReadError>;
+  read(
+    address: IMemorySpaceAddress,
+    options?: IReadOptions,
+  ): Result<IAttestation, ReadError>;
 
   /**
    * Creates a memory space writer for this transaction. Fails if transaction is
@@ -587,8 +603,14 @@ export interface ITransactionReader {
    *  // Referencing non-existing facts produces errors
    *  assert(tx.read({ the: 'bad/mime' , of, at: ['author'] }).error.name === 'NotFoundError')
    * ```
+   *
+   * @param address - Memory address to read from
+   * @param options - Optional read options including metadata
    */
-  read(address: IMemoryAddress): Result<IAttestation, ReadError>;
+  read(
+    address: IMemoryAddress,
+    options?: IReadOptions,
+  ): Result<IAttestation, ReadError>;
 }
 
 export interface ITransactionWriter extends ITransactionReader {
@@ -859,9 +881,13 @@ export interface IStorageEdit {
 }
 
 export type Activity = Variant<{
-  read: IMemorySpaceAddress;
+  read: IReadActivity;
   write: IMemorySpaceAddress;
 }>;
+
+export interface IReadActivity extends IMemorySpaceAddress {
+  meta: Metadata;
+}
 
 /**
  * Error is returned on an attempt to open writer in a transaction that already

--- a/packages/runner/src/storage/transaction-shim.ts
+++ b/packages/runner/src/storage/transaction-shim.ts
@@ -6,6 +6,7 @@ import type {
   IMemorySpaceAddress,
   InactiveTransactionError,
   INotFoundError,
+  IReadOptions,
   IStorageInvariant,
   IStorageTransaction,
   IStorageTransactionComplete,
@@ -140,6 +141,7 @@ class TransactionReader implements ITransactionReader {
 
   read(
     address: IMemorySpaceAddress,
+    options?: IReadOptions,
   ): Result<Read, ReadError> {
     if (address.type !== "application/json") {
       const error = new Error(
@@ -413,13 +415,13 @@ export class StorageTransaction implements IStorageTransaction {
     return { ok: reader };
   }
 
-  read(address: IMemorySpaceAddress): Result<Read, ReadError> {
+  read(address: IMemorySpaceAddress, options?: IReadOptions): Result<Read, ReadError> {
     const readerResult = this.reader(address.space);
     if (readerResult.error) {
       return { ok: undefined, error: readerResult.error };
     }
 
-    const readResult = readerResult.ok!.read(address);
+    const readResult = readerResult.ok!.read(address, options);
     if (readResult.error) {
       return { ok: undefined, error: readResult.error };
     }
@@ -532,8 +534,8 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     return this.tx.reader(space);
   }
 
-  read(address: IMemorySpaceAddress): Result<Read, ReadError> {
-    return this.tx.read(address);
+  read(address: IMemorySpaceAddress, options?: IReadOptions): Result<Read, ReadError> {
+    return this.tx.read(address, options);
   }
 
   readOrThrow(address: IMemorySpaceAddress): JSONValue | undefined {

--- a/packages/runner/src/storage/transaction.ts
+++ b/packages/runner/src/storage/transaction.ts
@@ -3,6 +3,7 @@ import type {
   IAttestation,
   IMemorySpaceAddress,
   InactiveTransactionError,
+  IReadOptions,
   IStorageManager,
   IStorageTransaction,
   IStorageTransactionAborted,
@@ -84,8 +85,8 @@ class StorageTransaction implements IStorageTransaction {
     return writer(this, space);
   }
 
-  read(address: IMemorySpaceAddress) {
-    return read(this, address);
+  read(address: IMemorySpaceAddress, options?: IReadOptions) {
+    return read(this, address, options);
   }
 
   write(address: IMemorySpaceAddress, value?: JSONValue) {
@@ -199,13 +200,14 @@ export const writer = (
 export const read = (
   transaction: StorageTransaction,
   address: IMemorySpaceAddress,
+  options?: IReadOptions,
 ) => {
   const { ok: space, error } = reader(transaction, address.space);
   if (error) {
     return { error };
   } else {
     const { space: _, ...memoryAddress } = address;
-    return space.read(memoryAddress);
+    return space.read(memoryAddress, options);
   }
 };
 

--- a/packages/runner/src/storage/transaction/chronicle.ts
+++ b/packages/runner/src/storage/transaction/chronicle.ts
@@ -120,6 +120,7 @@ export class Chronicle {
 
   read(
     address: IMemoryAddress,
+    options?: { meta?: unknown },
   ): Result<
     IAttestation,
     | IStorageTransactionInconsistent


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for passing metadata to storage read operations, allowing extra context to be attached and tracked during reads.

- **New Features**
  - Introduced a `meta` option for all storage read methods.
  - Read activity now records metadata in the activity log.
  - Tests cover reading with various metadata types and verify activity tracking.

<!-- End of auto-generated description by cubic. -->

