### PR TITLE
chore: Explicitly require static cache

### DIFF
--- a/packages/charm/src/iframe/prompt.ts
+++ b/packages/charm/src/iframe/prompt.ts
@@ -7,6 +7,7 @@ import {
   type LLMRequest,
 } from "@commontools/llm";
 import { extractUserCode, staticSystemMd } from "./static.ts";
+import { type StaticCache } from "@commontools/static";
 
 export const RESPONSE_PREFILL = "```javascript\n";
 
@@ -16,12 +17,14 @@ export const buildPrompt = async ({
   newSpec,
   schema,
   steps,
+  staticCache,
 }: {
   src?: string;
   spec?: string;
   newSpec: string;
   schema: JSONSchema;
   steps?: string[];
+  staticCache: StaticCache;
 }, options: GenerationOptions): Promise<LLMRequest> => {
   const { model, cache, space, generationId } = applyDefaults(options);
 
@@ -69,7 +72,7 @@ ${steps.map((step, index) => `<step>${step}</step>`).join("\n")}
     content: RESPONSE_PREFILL,
   });
 
-  const systemPrompt = await staticSystemMd();
+  const systemPrompt = await staticSystemMd(staticCache);
   const system = hydratePrompt(systemPrompt, {
     SCHEMA: JSON.stringify(schema, null, 2),
   });

--- a/packages/charm/src/iframe/static.ts
+++ b/packages/charm/src/iframe/static.ts
@@ -1,5 +1,5 @@
 import { hydratePrompt, LlmPrompt, llmPrompt } from "@commontools/llm";
-import { cache as promptCache } from "@commontools/static";
+import { type StaticCache } from "@commontools/static";
 
 const libraries = {
   "imports": {
@@ -863,8 +863,10 @@ function onReady(mount, sourceData, libs) {
 );
 
 // Update the system message to reflect the new interface
-export const staticSystemMd = async (): Promise<LlmPrompt> => {
-  const promptText = await promptCache.getText("prompts/system.md");
+export const staticSystemMd = async (
+  staticCache: StaticCache,
+): Promise<LlmPrompt> => {
+  const promptText = await staticCache.getText("prompts/system.md");
   const prompt = llmPrompt(
     "iframe-react-system",
     promptText,

--- a/packages/charm/src/iterate.ts
+++ b/packages/charm/src/iterate.ts
@@ -27,6 +27,7 @@ import {
 import { injectUserCode } from "./iframe/static.ts";
 import { IFrameRecipe, WorkflowForm } from "./index.ts";
 import { console } from "./conditional-console.ts";
+import { StaticCache } from "@commontools/static";
 
 const llm = new LLMClient();
 
@@ -40,12 +41,14 @@ export const genSrc = async (
     newSpec,
     schema,
     steps,
+    staticCache,
   }: {
     src?: string;
     spec?: string;
     newSpec: string;
     schema: JSONSchema;
     steps?: string[];
+    staticCache: StaticCache;
   },
   options?: GenerationOptions,
 ): Promise<{ content: string; llmRequestId?: string }> => {
@@ -58,6 +61,7 @@ export const genSrc = async (
     newSpec,
     schema,
     steps,
+    staticCache,
   }, optionsWithDefaults);
 
   globalThis.dispatchEvent(
@@ -119,6 +123,7 @@ export async function iterate(
     newSpec,
     schema: iframe?.argumentSchema || { type: "object" },
     steps: plan?.features,
+    staticCache: charmManager.runtime.staticCache,
   }, optionsWithDefaults);
 
   return {
@@ -434,6 +439,7 @@ async function twoPhaseCodeGeneration(
     newSpec,
     schema,
     steps: form.plan?.features,
+    staticCache: form.meta.charmManager.runtime.staticCache,
   }, {
     model: form.meta.model,
     generationId: form.meta.generationId,

--- a/packages/cli/commands/init.ts
+++ b/packages/cli/commands/init.ts
@@ -2,6 +2,7 @@ import { Command } from "@cliffy/command";
 import { Engine } from "@commontools/runner";
 import { join } from "@std/path/join";
 import { getCompilerOptions } from "@commontools/js-runtime/typescript";
+import { StaticCache } from "@commontools/static";
 
 export const init = new Command()
   .name("init")
@@ -75,8 +76,11 @@ function createTsConfig() {
 // implicitly loaded jsx-runtime (`react/jsx-runtime`) and the
 // environment types (`commontoolsenv`) loaded by the `tsconfig.json`.
 async function initWorkspace(cwd: string) {
-  const runtimeModuleTypes = await Engine.getRuntimeModuleTypes();
-  const { dom, es2023, jsx } = await Engine.getEnvironmentTypes();
+  const cache = new StaticCache();
+  const runtimeModuleTypes = await Engine.getRuntimeModuleTypes(
+    cache,
+  );
+  const { dom, es2023, jsx } = await Engine.getEnvironmentTypes(cache);
 
   // Concatenate all environment types into a single "lib",
   // which will be referred to as "ct-env" in the typescript config

--- a/packages/js-runtime/test/runtime.test.ts
+++ b/packages/js-runtime/test/runtime.test.ts
@@ -7,8 +7,9 @@ import {
   TypeScriptCompiler,
   UnsafeEvalRuntime,
 } from "../mod.ts";
+import { StaticCache } from "@commontools/static";
 
-const types = await getTypeScriptEnvironmentTypes();
+const types = await getTypeScriptEnvironmentTypes(new StaticCache());
 
 describe("Runtime", () => {
   it("Compiles and executes a set of typescript files", async () => {

--- a/packages/js-runtime/test/typescript.compiler.test.ts
+++ b/packages/js-runtime/test/typescript.compiler.test.ts
@@ -6,6 +6,7 @@ import {
   TypeScriptCompiler,
   TypeScriptCompilerOptions,
 } from "../mod.ts";
+import { StaticCache } from "@commontools/static";
 
 type TestDef =
   & { name: string; source: string; expectedError?: string }
@@ -40,7 +41,7 @@ const TESTS: TestDef[] = [
   },
 ];
 
-const types = await getTypeScriptEnvironmentTypes();
+const types = await getTypeScriptEnvironmentTypes(new StaticCache());
 
 describe("TypeScriptCompiler", () => {
   it("compiles a filesystem graph", async () => {

--- a/packages/js-runtime/utils.ts
+++ b/packages/js-runtime/utils.ts
@@ -1,4 +1,4 @@
-import { cache } from "@commontools/static";
+import { type StaticCache } from "@commontools/static";
 
 // Returns an object mapping typescript lib name
 // to a string of standalone .d.ts content.
@@ -8,7 +8,7 @@ import { cache } from "@commontools/static";
 // * "dom"
 export const getTypeScriptEnvironmentTypes = (() => {
   let cached: Record<string, string> | undefined;
-  return async (): Promise<Record<string, string>> => {
+  return async (cache: StaticCache): Promise<Record<string, string>> => {
     if (cached) {
       return cached;
     }

--- a/packages/runner/src/harness/runtime-modules.ts
+++ b/packages/runner/src/harness/runtime-modules.ts
@@ -1,5 +1,5 @@
 import { createBuilder } from "../builder/factory.ts";
-import { cache } from "@commontools/static";
+import { StaticCache } from "@commontools/static";
 import turndown from "turndown";
 import { IRuntime } from "../runtime.ts";
 
@@ -33,7 +33,7 @@ export const getTypes = (() => {
   let depTypes:
     | Record<RuntimeModuleIdentifier, string>
     | undefined;
-  return async () => {
+  return async (cache: StaticCache) => {
     if (depTypes) {
       return depTypes;
     }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -47,6 +47,7 @@ import { RecipeManager, RecipeMeta } from "./recipe-manager.ts";
 import { ModuleRegistry } from "./module.ts";
 import { Runner } from "./runner.ts";
 import { registerBuiltins } from "./builtins/index.ts";
+import { StaticCache } from "@commontools/static";
 
 export type {
   IExtendedStorageTransaction,
@@ -85,6 +86,7 @@ export interface RuntimeOptions {
   blobbyServerUrl: string;
   recipeEnvironment?: RecipeEnvironment;
   navigateCallback?: NavigateCallback;
+  staticAssetServerUrl?: URL;
   debug?: boolean;
 }
 
@@ -100,6 +102,7 @@ export interface IRuntime {
   readonly blobbyServerUrl: string;
   readonly navigateCallback?: NavigateCallback;
   readonly cfc: ContextualFlowControl;
+  readonly staticCache: StaticCache;
 
   idle(): Promise<void>;
   dispose(): Promise<void>;
@@ -326,8 +329,14 @@ export class Runtime implements IRuntime {
   readonly blobbyServerUrl: string;
   readonly navigateCallback?: NavigateCallback;
   readonly cfc: ContextualFlowControl;
+  readonly staticCache: StaticCache;
 
   constructor(options: RuntimeOptions) {
+    this.staticCache = options.staticAssetServerUrl
+      ? new StaticCache({
+        baseUrl: options.staticAssetServerUrl,
+      })
+      : new StaticCache();
     // Create harness first (no dependencies on other services)
     this.harness = new Engine(this);
     this.id = options.storageManager.id;

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -3,6 +3,7 @@ import { Runtime } from "@commontools/runner";
 import { CharmManager } from "@commontools/charm";
 import { CharmsController } from "@commontools/charm/ops";
 import { StorageManager } from "@commontools/runner/storage/cache";
+import { API_URL } from "./env.ts";
 
 async function createSession(
   root: Identity,
@@ -74,6 +75,7 @@ export async function createCharmsController(
       address: new URL("/api/storage/memory", url),
     }),
     blobbyServerUrl: url,
+    staticAssetServerUrl: API_URL,
   });
   console.log("[createCharmsController] Creating CharmManager with session");
   const charmManager = new CharmManager(session, runtime);

--- a/packages/static/index.ts
+++ b/packages/static/index.ts
@@ -1,6 +1,3 @@
 import { StaticCache } from "./cache.ts";
 export { assets } from "./assets.ts";
-
-// Global cache for static assets.
-const cache = new StaticCache();
-export { cache, StaticCache };
+export { StaticCache };

--- a/packages/static/test/assets.test.ts
+++ b/packages/static/test/assets.test.ts
@@ -1,8 +1,9 @@
+import { StaticCache } from "@commontools/static";
 import { decode } from "@commontools/utils/encoding";
 import { assert } from "@std/assert";
-import { cache } from "../index.ts";
 
 Deno.test("get() and getText() returns static data", async () => {
+  const cache = new StaticCache();
   const buffer = await cache.get("prompts/system.md");
   const text = await cache.getText("prompts/system.md");
   assert(decode(buffer) === text, "buffer and text match");
@@ -13,6 +14,7 @@ Deno.test("get() and getText() returns static data", async () => {
 });
 
 Deno.test("getUrl() returns asset URL", async () => {
+  const cache = new StaticCache();
   const url = await cache.getUrl("prompts/system.md");
   assert(
     /prompts\/system.md/.test(url.toString()),

--- a/packages/toolshed/routes/static/static.index.ts
+++ b/packages/toolshed/routes/static/static.index.ts
@@ -1,9 +1,14 @@
 import { createRouter } from "@/lib/create-app.ts";
 import { cors } from "@hono/hono/cors";
-import { cache as staticCache } from "@commontools/static";
+import { StaticCache } from "@commontools/static";
 import { getMimeType } from "@/lib/mime-type.ts";
 
 const router = createRouter();
+
+// Notably this uses a different cache
+// than the runtime that runs in this context, negigible
+// cost of not incorporating the runtime here.
+const cache = new StaticCache();
 
 router.use(
   "*",
@@ -18,7 +23,7 @@ router.use(
 
 router.get("/static/*", async (c) => {
   const reqPath = c.req.path.substring("/static/".length);
-  const buffer = await staticCache.get(reqPath);
+  const buffer = await cache.get(reqPath);
   const mimeType = getMimeType(reqPath);
   return new Response(buffer, {
     status: 200,

--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-run
-import { assets, cache as staticCache } from "@commontools/static";
 import { exists } from "@std/fs";
 import * as path from "@std/path";
 
@@ -87,10 +86,6 @@ class BuildConfig {
       "src",
       "worker.ts",
     );
-  }
-
-  staticBundleFilePath(filename: string): string[] {
-    return this.path("packages", "static-bundle", "assets", filename);
   }
 
   toolshedEnvPath() {


### PR DESCRIPTION
Currently, the static asset server is a local file URI (deno) or browser page host. This was working in dev mode in jumble due to the vite proxies (e.g. proxying `localhost:5173` to the toolshed server, hosting static assets). Attempting to reduce the need for a proxy server, this patch adds a static cache to the runtime which is used throughout (mostly for text prompts and TS types), allowing us to thread through the correct location of the static server rather than relying on globals