### PR TITLE
 persist authentication across page refresh

### DIFF
--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -106,7 +106,7 @@ export class XAppView extends BaseView {
     const cc = this._cc.value;
     const app = (this.app ?? {}) as AppState;
     const unauthenticated = html`
-      <x-login-view></x-login-view>
+      <x-login-view .keyStore="${app.keyStore}"></x-login-view>
     `;
     const authenticated = html`
       <x-body


### PR DESCRIPTION
 Connect keyStore to LoginView and save identity to browser storage
 when users authenticate via passkey or passphrase. This ensures
 users remain logged in after refreshing the page
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Authentication now persists across page refreshes by saving the user's identity to browser storage after login with passkey or passphrase.

- **Bug Fixes**
  - Connects keyStore to LoginView and stores identity on authentication, so users stay logged in after refreshing.

<!-- End of auto-generated description by cubic. -->

