### PR TITLE
chore: Propagate using the /shell prefix in deployment

### DIFF
--- a/packages/shell/src/components/CharmList.ts
+++ b/packages/shell/src/components/CharmList.ts
@@ -3,6 +3,7 @@ import { property } from "lit/decorators.js";
 import { BaseView } from "../views/BaseView.ts";
 import { CharmsController } from "@commontools/charm/ops";
 import { Task } from "@lit/task";
+import { USE_SHELL_PREFIX } from "../lib/env.ts";
 
 export class XCharmListElement extends BaseView {
   static override styles = css`
@@ -31,8 +32,9 @@ export class XCharmListElement extends BaseView {
     const list = (charmList ?? []).map((charm) => {
       const name = charm.name();
       const id = charm.id;
+      const href = makeHref(spaceName, id);
       return html`
-        <li><a href="/${spaceName}/${id}">${name}</a></li>
+        <li><a href="${href}">${name}</a></li>
       `;
     });
     return html`
@@ -40,6 +42,11 @@ export class XCharmListElement extends BaseView {
       <ul>${list}</ul>
     `;
   }
+}
+
+function makeHref(spaceName: string, id: string) {
+  const href = `/${spaceName}/${id}`;
+  return USE_SHELL_PREFIX ? `/shell${href}` : href;
 }
 
 globalThis.customElements.define("x-charm-list", XCharmListElement);

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -1,5 +1,10 @@
 import "@commontools/ui/v2";
-import { API_URL, COMMIT_SHA, ENVIRONMENT } from "./lib/env.ts";
+import {
+  API_URL,
+  COMMIT_SHA,
+  ENVIRONMENT,
+  USE_SHELL_PREFIX,
+} from "./lib/env.ts";
 import { AppUpdateEvent } from "./lib/app/events.ts";
 import { XRootView } from "./views/RootView.ts";
 import "./components/index.ts";
@@ -27,10 +32,16 @@ if (ENVIRONMENT !== "production") {
   const location = new URL(globalThis.location.href);
   const segments = location.pathname.split("/");
   segments.shift(); // shift off the pathnames' prefix "/";
-  let [spaceName, charmId] = segments;
+  let [spaceName, charmId] = USE_SHELL_PREFIX
+    ? [segments[1], segments[2]]
+    : [segments[0], segments[1]];
   if (!spaceName) {
     spaceName = "common-knowledge";
-    globalThis.history.replaceState({}, "", "/common-knowledge");
+    globalThis.history.replaceState(
+      {},
+      "",
+      USE_SHELL_PREFIX ? "/shell/common-knowledge" : "/common-knowledge",
+    );
   }
   app.setSpace(spaceName);
   if (charmId) app.setActiveCharmId(charmId);

--- a/packages/shell/src/lib/env.ts
+++ b/packages/shell/src/lib/env.ts
@@ -13,3 +13,14 @@ export const API_URL: URL = new URL(
 );
 
 export const COMMIT_SHA: string | undefined = $COMMIT_SHA;
+
+// To deploy alongside the jumble instance, we have a host
+// serving this application via prefixed URL `/shell`.
+// On page load, if URL is `${HOST}/shell`, use that prefix
+// whenever rendering links or parsing URL etc.
+// This can be removed once we have a single deployment type.
+export const USE_SHELL_PREFIX: boolean = (() => {
+  const location = new URL(globalThis.location.href);
+  const firstSegment = location.pathname.split("/").filter(Boolean)[0];
+  return firstSegment === "shell";
+})();


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for a /shell URL prefix so the app works correctly when deployed under a subpath.

- **Refactors**
  - Updated link generation and URL parsing to use the /shell prefix when needed.
  - Added a flag to detect and handle the prefixed deployment environment.

<!-- End of auto-generated description by cubic. -->

