### PR TITLE
Fix reference cycle error when setting a cell to it's own value.

### DIFF
--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -6,6 +6,7 @@ import { isCell } from "./cell.ts";
 import { followWriteRedirects } from "./link-resolution.ts";
 import {
   areLinksSame,
+  areMaybeLinkAndNormalizedLinkSame,
   areNormalizedLinksSame,
   createSigilLinkFromParsedLink,
   isAnyCellLink,
@@ -14,10 +15,7 @@ import {
   type NormalizedFullLink,
   parseLink,
 } from "./link-utils.ts";
-import {
-  getCellLinkOrThrow,
-  isQueryResultForDereferencing,
-} from "./query-result-proxy.ts";
+import { isQueryResultForDereferencing } from "./query-result-proxy.ts";
 import {
   type IExtendedStorageTransaction,
   type JSONValue,
@@ -143,6 +141,11 @@ export function normalizeAndDiff(
     throw new Error("Docs are not supported anymore");
   }
   if (isCell(newValue)) newValue = newValue.getAsLink();
+
+  // If we're about to create a reference to ourselves, no-op
+  if (areMaybeLinkAndNormalizedLinkSame(newValue, link)) {
+    return [];
+  }
 
   // Get current value to compare against
   let currentValue = tx.readValueOrThrow(link);

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -508,6 +508,16 @@ export function areLinksSame(
   return areNormalizedLinksSame(link1, link2);
 }
 
+export function areMaybeLinkAndNormalizedLinkSame(
+  link: any,
+  normalizedLink: NormalizedLink,
+  base?: Cell | NormalizedLink,
+): boolean {
+  const normalizedLink2 = parseLink(link, base);
+  if (!normalizedLink2) return false;
+  return areNormalizedLinksSame(normalizedLink, normalizedLink2);
+}
+
 /**
  * Compare two normalized links for equality
  */

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -780,7 +780,7 @@ describe("asCell", () => {
   });
 
   it("behaves correctly when setting a cell to itself, asCell schema", () => {
-    const c = runtime.getCell<{ a: number }>(
+    const c = runtime.getCell(
       space,
       "behaves correctly when setting a cell to itself, asCell schema",
       {
@@ -793,8 +793,7 @@ describe("asCell", () => {
     );
     c.set({ a: 1 });
     c.set(c.get());
-    // TODO(seefeld): This type cast should not be necessary, separate bug
-    expect((c.get() as any).get()).toEqual({ a: 1 });
+    expect(c.get()).toEqual({ a: 1 });
   });
 });
 

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -793,7 +793,7 @@ describe("asCell", () => {
     );
     c.set({ a: 1 });
     c.set(c.get());
-    expect(c.get()).toEqual({ a: 1 });
+    expect(c.get().get()).toEqual({ a: 1 });
   });
 });
 

--- a/packages/runner/test/schema-to-ts.test.ts
+++ b/packages/runner/test/schema-to-ts.test.ts
@@ -14,6 +14,9 @@ import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
+// This file primarily tests Schema<> & co from commontools/api/index.ts, which
+// gets transitively loaded by the above
+
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
 


### PR DESCRIPTION
- Updated data-updating.ts to prevent cycles when setting value to itself.
- Added/modified tests in cell.test.ts to cover scenarios that previously triggered the error.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where setting a cell to its own value could cause a reference cycle error.

- **Bug Fixes**
  - Prevented cycles by checking for self-references before updating cell values.
  - Added tests to confirm correct behavior when a cell is set to itself.

<!-- End of auto-generated description by cubic. -->

