### PR TITLE
refactor: move KeyStore ownership to LoginView

### DIFF
--- a/packages/shell/src/lib/app/state.ts
+++ b/packages/shell/src/lib/app/state.ts
@@ -1,4 +1,4 @@
-import { Identity, KeyStore } from "@commontools/identity";
+import { Identity } from "@commontools/identity";
 import { Command } from "../commands.ts";
 
 // Primary application state.
@@ -7,7 +7,6 @@ export interface AppState {
   spaceName?: string;
   activeCharmId?: string;
   apiUrl: URL;
-  keyStore?: KeyStore;
 }
 
 export function clone(state: AppState): AppState {
@@ -33,10 +32,6 @@ export function applyCommand(
     }
     case "set-space": {
       next.spaceName = command.spaceName;
-      break;
-    }
-    case "set-keystore": {
-      next.keyStore = command.keyStore;
       break;
     }
     case "clear-authentication": {

--- a/packages/shell/src/lib/commands.ts
+++ b/packages/shell/src/lib/commands.ts
@@ -1,10 +1,9 @@
-import { Identity, KeyStore } from "@commontools/identity";
+import { Identity } from "@commontools/identity";
 
 export type Command =
   | { type: "set-active-charm-id"; charmId: string }
   | { type: "set-identity"; identity: Identity }
   | { type: "set-space"; spaceName: string }
-  | { type: "set-keystore"; keyStore: KeyStore }
   | { type: "clear-authentication" };
 
 export function isCommand(value: unknown): value is Command {
@@ -25,9 +24,6 @@ export function isCommand(value: unknown): value is Command {
     case "set-active-charm-id": {
       return "charmId" in value && !!value.charmId &&
         typeof value.charmId === "string";
-    }
-    case "set-keystore": {
-      return "keyStore" in value && value.keyStore instanceof KeyStore;
     }
     case "clear-authentication": {
       return true;

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -106,7 +106,7 @@ export class XAppView extends BaseView {
     const cc = this._cc.value;
     const app = (this.app ?? {}) as AppState;
     const unauthenticated = html`
-      <x-login-view .keyStore="${app.keyStore}"></x-login-view>
+      <x-login-view></x-login-view>
     `;
     const authenticated = html`
       <x-body

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -91,27 +91,30 @@ export class XRootView extends LitElement {
       // Apply command synchronously
       const state = applyCommand(this._provider.value, command);
 
-      // Handle clear-authentication specially - need to clear ROOT_KEY from IDB
-      if (command.type === "clear-authentication") {
-        try {
-          const keyStore = await KeyStore.open();
-          await keyStore.clear();
-          console.log("[RootView] Cleared ROOT_KEY from keystore");
-        } catch (error) {
-          console.error(
-            "[RootView] Failed to clear ROOT_KEY from keystore:",
-            error,
-          );
+      // Handle command-specific side effects
+      switch (command.type) {
+        case "clear-authentication": {
+          try {
+            const keyStore = await KeyStore.open();
+            await keyStore.clear();
+            console.log("[RootView] Cleared ROOT_KEY from keystore");
+          } catch (error) {
+            console.error(
+              "[RootView] Failed to clear ROOT_KEY from keystore:",
+              error,
+            );
+          }
+          break;
+        }
+        case "set-identity": {
+          console.log("[RootView] Identity set in app state:", {
+            did: state.identity?.did(),
+          });
+          break;
         }
       }
 
       this._provider.setValue(state);
-
-      if (command.type === "set-identity") {
-        console.log("[RootView] Identity set in app state:", {
-          did: state.identity?.did(),
-        });
-      }
 
       this.dispatchEvent(new AppUpdateEvent(command, { state }));
     } catch (e) {


### PR DESCRIPTION
  - Remove keyStore from AppState and related commands
  - Move all KeyStore operations to LoginView where authentication happens
  - LoginView now handles checking existing auth on mount
  - RootView still clears the keystore on logout for proper cleanup
  - Remove 100ms sleep workaround per feedback

  This simplifies the architecture by keeping KeyStore management
  localized to the component that actually uses it for authentication.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Moved all KeyStore logic from global app state to LoginView, so authentication and key management are now handled locally in the login flow. RootView still clears the keystore on logout for cleanup.

- **Refactors**
  - Removed keyStore from AppState and related commands.
  - LoginView now checks for existing authentication and manages KeyStore access.
  - Removed 100ms sleep workaround from RootView.

<!-- End of auto-generated description by cubic. -->

