### PR TITLE
Use spell link instead of refer on recipe id if it's available.

### DIFF
--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -61,6 +61,7 @@ export type ErrorWithContext = Error & {
   charmId: string;
   space: MemorySpace;
   recipeId: string;
+  spellId: string | undefined;
 };
 
 export type ConsoleHandler = (

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -19,6 +19,7 @@ import type {
 import {
   areNormalizedLinksSame,
   type NormalizedFullLink,
+  parseLink,
 } from "./link-utils.ts";
 
 // Re-export types that tests expect from scheduler
@@ -227,11 +228,13 @@ export class Scheduler implements IScheduler {
   }
 
   private handleError(error: Error, action: any) {
-    const { charmId, recipeId, space } = getCharmMetadataFromFrame() ?? {};
+    const { charmId, spellId, recipeId, space } = getCharmMetadataFromFrame() ??
+      {};
 
     const errorWithContext = error as ErrorWithContext;
     errorWithContext.action = action;
     if (charmId) errorWithContext.charmId = charmId;
+    if (spellId) errorWithContext.spellId = spellId;
     if (recipeId) errorWithContext.recipeId = recipeId;
     if (space) errorWithContext.space = space as MemorySpace;
 
@@ -467,6 +470,7 @@ function pathAffected(
 }
 
 function getCharmMetadataFromFrame(): {
+  spellId?: string;
   recipeId?: string;
   space?: string;
   charmId?: string;
@@ -483,6 +487,8 @@ function getCharmMetadataFromFrame(): {
   }
   const result: ReturnType<typeof getCharmMetadataFromFrame> = {};
   const { cell: source } = getCellLinkOrThrow(sourceAsProxy);
+  const spellLink = parseLink(source?.get()?.["spell"]);
+  result.spellId = spellLink?.id;
   result.recipeId = source?.get()?.[TYPE];
   const resultDoc = source?.get()?.resultRef?.cell;
   result.space = resultDoc?.space;

--- a/packages/runner/test/recipes.test.ts
+++ b/packages/runner/test/recipes.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { Identity } from "@commontools/identity";
+import { StorageManager } from "@commontools/runner/storage/cache.deno";
 import { type Cell, type JSONSchema } from "../src/builder/types.ts";
 import { createBuilder } from "../src/builder/factory.ts";
 import { Runtime } from "../src/runtime.ts";
 import { type ErrorWithContext } from "../src/scheduler.ts";
 import { isCell } from "../src/cell.ts";
 import { resolveLinks } from "../src/link-resolution.ts";
-import { Identity } from "@commontools/identity";
-import { StorageManager } from "@commontools/runner/storage/cache.deno";
+import { isAnyCellLink, parseLink } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -774,9 +775,15 @@ describe("Recipe Runner", () => {
     expect(errors).toBe(1);
     expect(charm.getAsQueryResult()).toMatchObject({ result: 5 });
 
-    const recipeId = charm.getSourceCell()?.get()?.[TYPE];
+    const sourceCellValue = charm.getSourceCell()?.getRaw();
+    const recipeId = sourceCellValue?.[TYPE];
     expect(recipeId).toBeDefined();
     expect(lastError?.recipeId).toBe(recipeId);
+    expect(isAnyCellLink(sourceCellValue?.["spell"])).toBe(true);
+    const spellLink = parseLink(sourceCellValue["spell"]);
+    const spellId = spellLink?.id;
+    expect(spellId).toBeDefined();
+    expect(lastError?.spellId).toBe(spellId);
     expect(lastError?.space).toBe(space);
     expect(lastError?.charmId).toBe(
       JSON.parse(JSON.stringify(charm.entityId))["/"],


### PR DESCRIPTION
Attach a spellId to ErrorWithContext.
Test that our error has a valid spellId