### PR TITLE
Fix `ct-render` interactivity

### DIFF
--- a/packages/ui/src/v2/components/ct-render/ct-render.test.ts
+++ b/packages/ui/src/v2/components/ct-render/ct-render.test.ts
@@ -11,32 +11,13 @@ describe("CTRender", () => {
     expect(CTRender.name).toBe("CTRender");
   });
 
-  it("should format fallback for primitive values", () => {
+  it("should create element instance", () => {
     const element = new CTRender();
-    
-    // Test the _formatFallback method (access private method for testing)
-    const formatFallback = (element as any)._formatFallback;
-    
-    expect(formatFallback("hello")).toBe("hello");
-    expect(formatFallback(123)).toBe("123");
-    expect(formatFallback(null)).toBe("");
-    expect(formatFallback(undefined)).toBe("");
-    
-    // Test with mock cell
-    const mockCell = {
-      get: () => "cell value"
-    };
-    expect(formatFallback(mockCell)).toBe("cell value");
+    expect(element).toBeInstanceOf(CTRender);
   });
 
-  it("should handle basic property setting", () => {
+  it("should have cell property", () => {
     const element = new CTRender();
-    
-    const mockCell = {
-      get: () => "test"
-    };
-    
-    element.cell = mockCell;
-    expect(element.cell).toBe(mockCell);
+    expect(element.cell).toBeUndefined();
   });
 });


### PR DESCRIPTION
- **Fix `ct-render` activity**
- **Clean up `ct-render` and add debug logging feature**

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed interactivity in `ct-render` by ensuring the recipe is started before rendering, and added an optional debug logging feature for easier troubleshooting.

- **Bug Fixes**
  - Recipes are now loaded and run before UI rendering, fixing missing interactivity.

- **New Features**
  - Added debug logging (disabled by default) to help trace rendering issues.

<!-- End of auto-generated description by cubic. -->

