### PR TITLE
Improve `ct` documentation for `/commands`

### DIFF
--- a/.claude/commands/recipe-dev.md
+++ b/.claude/commands/recipe-dev.md
@@ -6,7 +6,7 @@ This script guides Claude through recipe development with the `ct` utility after
 
 **Before starting recipe development:**
 - User should have already run the space setup script or have an existing space
-- Claude should read the common CT setup instructions in `.claude/commands/common/ct.md`
+- Claude MUST read the common CT setup instructions in `.claude/commands/common/ct.md`
 
 ## Script Flow for Claude
 
@@ -157,7 +157,7 @@ Multi-file recipes allow you to compose functionality from multiple source files
    // list.tsx
    export const TodoItemSchema = { ... };
    export const TodoListSchema = { ... };
-   
+
    // suggestions.tsx
    import { TodoListSchema } from "./list.tsx";
    ```

--- a/.claude/commands/search-wiki.md
+++ b/.claude/commands/search-wiki.md
@@ -18,6 +18,8 @@ You are a wiki search specialist. Your job is to search the project wiki for rel
 - Wiki Charm ID: baedreigkqfmhscbwwfhkjxicogsw3m66nxbetlhlnjkscgbs56hsqjrmkq
 
 **Your Task:**
+0. **First, learn how to use ct:** Read .claude/commands/common/ct.md to understand how to use the CommonTools system.
+
 1. Get all wiki content: `./dist/ct charm get --identity claude.key --api-url https://toolshed.saga-castor.ts.net/ --space 2025-wiki --charm baedreigkqfmhscbwwfhkjxicogsw3m66nxbetlhlnjkscgbs56hsqjrmkq wiki`
 
 2. Search through the content for: [specific search criteria]
@@ -35,9 +37,11 @@ You are a wiki search specialist. Your job is to search the project wiki for rel
 
 ## When to Search
 - Before starting new development work
-- When encountering errors or problems  
+- When encountering errors or problems
 - Before asking user for help
 - When exploring unfamiliar code areas
 - When debugging complex issues
 
 The subagent will handle the command execution and content analysis, returning organized results.
+
+The final response should be a report based on what was found by the subagent giving as much detail as appropriate to the user's query.

--- a/.claude/commands/todos.md
+++ b/.claude/commands/todos.md
@@ -5,26 +5,22 @@ Manage todo lists using CommonTools. Deploy new lists or work with existing ones
 ## Usage
 
 `/todos [item]` - Add item to todo list (deploys new if needed)
-`/todos [URL]` - Work with existing todo list 
+`/todos [URL]` - Work with existing todo list
 `/todos` - Deploy new empty todo list
 
 ## Command Pattern
 
-Launch a todo subagent using the Task tool:
-
-```
-Task: [Todo operation]
-
-You are a todo specialist. See `.claude/commands/common/ct.md` for CT command reference.
+Direct todo management using CommonTools:
 
 **Standard Parameters:**
 - Identity: claude.key
 - API URL: https://toolshed.saga-castor.ts.net/
 - Recipe: recipes/todo-list.tsx
+- Space: Use date-based naming like `2025-07-15-claude-dev` (format: YYYY-MM-DD-claude-dev)
 
 **Quick CT Commands:**
 - READ: `./dist/ct charm get [params] --charm [id] [path]`
-- SET: `echo '[value]' | ./dist/ct charm set [params] --charm [id] [path]`  
+- SET: `echo '[value]' | ./dist/ct charm set [params] --charm [id] [path]`
 - CALL: `echo '[json]' | ./dist/ct charm call [params] --charm [id] [handler]`
 
 **Todo Operations:**
@@ -32,13 +28,12 @@ You are a todo specialist. See `.claude/commands/common/ct.md` for CT command re
 - Mark done: `echo 'true' | ct charm set [params] --charm [id] items/0/done`
 - Read items: `ct charm get [params] --charm [id] items`
 
-**Your Task:**
-[SCENARIO A: URL provided] Extract space/charm from URL, work with existing list
-[SCENARIO B: Add item] Find/deploy todo list in suggested space, add item
-[SCENARIO C: Deploy only] Deploy new list, provide URL and usage
+**Scenarios:**
+- [SCENARIO A: URL provided] Extract space/charm from URL, work with existing list
+- [SCENARIO B: Add item] Find/deploy todo list in date-based space (YYYY-MM-DD-claude-dev), add item
+- [SCENARIO C: Deploy only] Deploy new list, provide URL and usage
 
 **Return**: Confirmation, URL, current items, usage instructions
-```
 
 ## Benefits
 

--- a/.claude/commands/update-wiki.md
+++ b/.claude/commands/update-wiki.md
@@ -4,12 +4,7 @@ Add knowledge, solutions, progress reports, and documentation to the project wik
 
 ## Command Pattern
 
-When you need to update the wiki, launch an update subagent using the Task tool:
-
-```
-Task: Add [content-type] to wiki
-
-You are a wiki documentation specialist. Your job is to add well-formatted, useful content to the project wiki.
+When you need to update the wiki, follow these steps:
 
 **Standard Parameters:**
 - Identity: claude.key
@@ -17,10 +12,10 @@ You are a wiki documentation specialist. Your job is to add well-formatted, usef
 - Space: 2025-wiki
 - Wiki Charm ID: baedreigkqfmhscbwwfhkjxicogsw3m66nxbetlhlnjkscgbs56hsqjrmkq
 
-**Content to Document:**
-[Provide the specific information/solution/discovery to document]
+**Process:**
 
-**Your Task:**
+0. **First, learn how to use ct:** Read .claude/commands/common/ct.md to understand how to use the CommonTools system.
+
 1. Choose appropriate page key following naming conventions:
    - Solutions: `[problem-type]-solution` or `fix-[specific-issue]`
    - How-to guides: `how-to-[action]`
@@ -41,7 +36,7 @@ You are a wiki documentation specialist. Your job is to add well-formatted, usef
      "value": "# Title\n\nFormatted content here..."
    }
    EOF
-   
+
    cat /tmp/wiki-update.json | ./dist/ct charm call --identity claude.key --api-url https://toolshed.saga-castor.ts.net/ --space 2025-wiki --charm baedreigkqfmhscbwwfhkjxicogsw3m66nxbetlhlnjkscgbs56hsqjrmkq update
    ```
 
@@ -50,9 +45,6 @@ You are a wiki documentation specialist. Your job is to add well-formatted, usef
    ./dist/ct charm get --identity claude.key --api-url https://toolshed.saga-castor.ts.net/ --space 2025-wiki --charm baedreigkqfmhscbwwfhkjxicogsw3m66nxbetlhlnjkscgbs56hsqjrmkq wiki/[your-page-key]
    ```
 
-**Return to me**: Confirmation of what was added, including the page key and a brief summary of the content.
-```
-
 ## When to Update
 - After solving non-trivial problems
 - When discovering useful patterns or techniques
@@ -60,4 +52,4 @@ You are a wiki documentation specialist. Your job is to add well-formatted, usef
 - When finding workarounds for common issues
 - At end of debugging sessions with lessons learned
 
-The subagent will handle content formatting, command execution, and verification of the update.
+Updates should be well-formatted and include all necessary context for future reference.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,10 @@ The instructions in this document apply to the entire repository.
 - To test a specific package, `cd` into the package directory and run
   `deno task test`.
 
+### `ct`
+
+Before ever calling `ct` you MUST read `.claude/commands/common/ct.md`.
+
 ### Formatting
 
 - Line width is **80 characters**.
@@ -288,7 +292,7 @@ async function getData(): Promise<string | undefined> {
     throw new Error("Unsuccessful HTTP response");
   } catch(e) {
     console.error(e);
-  } 
+  }
 }
 
 async function run() {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved documentation for all `/commands` to clarify that `.claude/commands/common/ct.md` must be read before using `ct`, and simplified instructions for todo and wiki workflows.

- **Documentation Updates**
  - Added clear steps to ensure users read the common CT guide before running commands.
  - Streamlined todo and wiki command patterns for easier use and understanding.

<!-- End of auto-generated description by cubic. -->

