### PR TITLE
added stream.withTx no-op call to be in parity with cell version

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -272,6 +272,7 @@ export interface Stream<T> {
   getRaw(): any;
   getAsNormalizedFullLink(): NormalizedFullLink;
   getDoc(): DocImpl<any>;
+  withTx(tx?: IExtendedStorageTransaction): Stream<T>;
   schema?: JSONSchema;
   rootSchema?: JSONSchema;
   runtime: IRuntime;
@@ -339,6 +340,7 @@ function createStreamCell<T>(
     getRaw: () => self.getDoc().getAtPath(link.path as PropertyKey[]),
     getAsNormalizedFullLink: () => link,
     getDoc: () => runtime.documentMap.getDocByEntityId(link.space, link.id),
+    withTx: (_tx?: IExtendedStorageTransaction) => self, // No-op for streams
     schema: link.schema,
     rootSchema: link.rootSchema,
     [isStreamMarker]: true,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a no-op withTx method to Stream to match the Cell interface and ensure API consistency.

<!-- End of auto-generated description by cubic. -->

