### PR TITLE
need sync'd deno write for rendering the json and text versions

### DIFF
--- a/packages/cli/lib/render.ts
+++ b/packages/cli/lib/render.ts
@@ -35,11 +35,11 @@ export function render(value: unknown, { json }: { json?: boolean } = {}) {
   if (json) {
     // For JSON mode, output raw JSON without additional formatting
     const jsonValue = `${JSON.stringify(value, null, 2)}\n`;
-    Deno.stdout.write(encode(jsonValue));
+    Deno.stdout.writeSync(encode(jsonValue));
     return;
   }
   // Append a `\n` to the stdout for TTY legibility and
   // unix file compatibility.
   const stringValue = `${stringify(value)}\n`;
-  Deno.stdout.write(encode(stringValue));
+  Deno.stdout.writeSync(encode(stringValue));
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched to using Deno.stdout.writeSync for rendering JSON and text output to ensure all data is written before the process exits.

<!-- End of auto-generated description by cubic. -->

