### PR TITLE
chore: Import v1 components in shell

### DIFF
--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -1,3 +1,4 @@
+import "@commontools/ui/v1";
 import "@commontools/ui/v2";
 import {
   API_URL,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added import for v1 UI components in the shell to support features that depend on both v1 and v2.

<!-- End of auto-generated description by cubic. -->

