### PR TITLE
Shell: Load and run default recipe in fresh spaces

### DIFF
--- a/packages/charm/src/ops/charms-controller.ts
+++ b/packages/charm/src/ops/charms-controller.ts
@@ -15,7 +15,7 @@ export class CharmsController {
   }
 
   async create(
-    program: RuntimeProgram,
+    program: RuntimeProgram | string,
     input?: object,
   ): Promise<CharmController> {
     const recipe = await compileProgram(this.#manager, program);

--- a/packages/shell/src/components/Body.ts
+++ b/packages/shell/src/components/Body.ts
@@ -21,19 +21,15 @@ export class XBodyElement extends BaseView {
   activeCharmId?: string;
 
   override render() {
-    const connected = this.cc ? "Connected" : "Not Connected";
     const charmView = html`
       <x-charm .cc="${this.cc}" .charmId="${this.activeCharmId}"></x-charm>
     `;
-    const charmList = html`
-      <x-charm-list .cc="${this.cc}"></x-charm-list>
+    const spaceView = html`
+      <x-space .cc="${this.cc}"></x-space>
     `;
-    const view = this.activeCharmId ? charmView : charmList;
+    const view = this.activeCharmId ? charmView : spaceView;
     return html`
-      <div>
-        <h2>App!! (${connected})</h2>
-        <div>${view}</div>
-      </div>
+      <div>${view}</div>
     `;
   }
 }

--- a/packages/shell/src/components/CharmList.ts
+++ b/packages/shell/src/components/CharmList.ts
@@ -1,11 +1,8 @@
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
 import { BaseView } from "../views/BaseView.ts";
-import { CharmsController } from "@commontools/charm/ops";
-import { Task } from "@lit/task";
-import { getNavigationHref, navigateToCharm } from "../lib/navigate.ts";
-import type { RuntimeProgram } from "@commontools/runner";
-import { processSchema } from "@commontools/charm";
+import { CharmController } from "@commontools/charm/ops";
+import { getNavigationHref } from "../lib/navigate.ts";
 
 export class XCharmListElement extends BaseView {
   static override styles = css`
@@ -18,152 +15,21 @@ export class XCharmListElement extends BaseView {
     }
   `;
 
-  // Track charm creation in progress to prevent duplicates
-  private static creatingCharms = new Map<string, Promise<void>>();
+  @property({ attribute: false })
+  charms?: CharmController[];
 
   @property({ attribute: false })
-  cc?: CharmsController;
-
-  private _charmList = new Task(this, {
-    task: async ([cc]) => {
-      if (!cc) return undefined;
-
-      // Ensure charms are synced before checking
-      const manager = cc.manager();
-      await manager.synced();
-
-      const charms = await cc.getAllCharms();
-      console.log(`[CharmList] Found ${charms.length} charms after syncing`);
-
-      // Check if we already have a DefaultCharmList charm
-      const defaultCharmList = charms.find((charm) => {
-        const name = charm.name();
-        console.log(`[CharmList] Checking charm ${charm.id}: name="${name}"`);
-        return name && name.startsWith("DefaultCharmList");
-      });
-
-      if (defaultCharmList) {
-        console.log(
-          `[CharmList] Found existing DefaultCharmList: ${defaultCharmList.id}`,
-        );
-        // Set the activeCharmId but don't update the URL
-        // This will cause Body to render the charm without changing the URL
-        app.setActiveCharmId(defaultCharmList.id);
-        return undefined;
-      }
-
-      console.log(`[CharmList] No DefaultCharmList found, creating new one...`);
-      // If no DefaultCharmList exists (whether space is empty or not), create one
-      await this.createDefaultCharm(cc);
-      // Don't return anything, let the navigation handle the update
-      return undefined;
-    },
-    args: () => [this.cc],
-  });
-
-  private async createDefaultCharm(cc: CharmsController) {
-    const spaceName = cc.manager().getSpaceName();
-
-    // Check if creation is already in progress for this space
-    const existingCreation = XCharmListElement.creatingCharms.get(spaceName);
-    if (existingCreation) {
-      // Wait for the existing creation to complete
-      await existingCreation;
-      return;
-    }
-
-    // Create a promise for this creation attempt
-    const creationPromise = this.doCreateDefaultCharm(cc);
-    XCharmListElement.creatingCharms.set(spaceName, creationPromise);
-
-    try {
-      await creationPromise;
-    } finally {
-      // Clean up the promise from the map
-      XCharmListElement.creatingCharms.delete(spaceName);
-    }
-  }
-
-  private async doCreateDefaultCharm(cc: CharmsController) {
-    try {
-      const manager = cc.manager();
-      const runtime = manager.runtime;
-      const spaceName = manager.getSpaceName();
-
-      // Load the charm-list recipe from static cache
-      const recipeContent = await runtime.staticCache.getText(
-        "recipes/charm-list.tsx",
-      );
-
-      // Create RuntimeProgram
-      const program: RuntimeProgram = {
-        main: "/main.tsx",
-        files: [{ name: "/main.tsx", contents: recipeContent }],
-      };
-
-      // Create the charm (no initial input needed)
-      const charm = await cc.create(program);
-      console.log(`[CharmList] Created new charm: ${charm.id}`);
-
-      // Check the charm's name immediately after creation
-      const charmName = charm.name();
-      console.log(`[CharmList] New charm name: "${charmName}"`);
-
-      // Link the well-known allCharms cell to the charm's input
-      const allCharmsId =
-        "baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye";
-
-      // Create a transaction and use withTx to wrap the link operation
-      const tx = runtime.edit();
-
-      // Get the charm cell and wrap it with the transaction
-      const charmCell = await manager.get(charm.id);
-      const sourceCell = charmCell.getSourceCell(processSchema);
-
-      if (sourceCell) {
-        // Get the well-known allCharms cell using its EntityId format
-        const allCharmsCell = await manager.getCellById({ "/": allCharmsId });
-        sourceCell.withTx(tx).key("argument").key("allCharms").set(
-          allCharmsCell.withTx(tx),
-        );
-        await tx.commit();
-      }
-
-      // Wait for the link to be processed
-      await runtime.idle();
-      await manager.synced();
-
-      // Double-check: see if another DefaultCharmList was created while we were creating ours
-      const allCharms = await cc.getAllCharms();
-      const existingDefaultCharm = allCharms.find((c) => {
-        const name = c.name();
-        return name && name.startsWith("DefaultCharmList") && c.id !== charm.id;
-      });
-
-      if (existingDefaultCharm) {
-        // Another one was created, use that one instead
-        app.setActiveCharmId(existingDefaultCharm.id);
-      } else {
-        // Set the activeCharmId directly instead of navigating
-        // This shows the DefaultCharmList without updating the URL
-        app.setActiveCharmId(charm.id);
-      }
-    } catch (error) {
-      console.error("Failed to create default charm:", error);
-    }
-  }
+  spaceName?: string;
 
   override render() {
-    const spaceName = this.cc ? this.cc.manager().getSpaceName() : undefined;
-    const charmList = this._charmList.value;
-
-    if (!spaceName || !charmList) {
+    const { charms, spaceName } = this;
+    if (!spaceName || !charms) {
       return html`
         <x-spinner></x-spinner>
       `;
     }
 
-    const list = (charmList ?? []).map((charm) => {
+    const list = charms.map((charm) => {
       const name = charm.name();
       const id = charm.id;
       const href = getNavigationHref(spaceName, id);

--- a/packages/shell/src/components/CharmList.ts
+++ b/packages/shell/src/components/CharmList.ts
@@ -3,7 +3,9 @@ import { property } from "lit/decorators.js";
 import { BaseView } from "../views/BaseView.ts";
 import { CharmsController } from "@commontools/charm/ops";
 import { Task } from "@lit/task";
-import { getNavigationHref } from "../lib/navigate.ts";
+import { getNavigationHref, navigateToCharm } from "../lib/navigate.ts";
+import type { RuntimeProgram } from "@commontools/runner";
+import { processSchema } from "@commontools/charm";
 
 export class XCharmListElement extends BaseView {
   static override styles = css`
@@ -16,15 +18,140 @@ export class XCharmListElement extends BaseView {
     }
   `;
 
+  // Track charm creation in progress to prevent duplicates
+  private static creatingCharms = new Map<string, Promise<void>>();
+
   @property({ attribute: false })
   cc?: CharmsController;
 
   private _charmList = new Task(this, {
-    task: ([cc]) => {
-      return cc ? cc.getAllCharms() : undefined;
+    task: async ([cc]) => {
+      if (!cc) return undefined;
+
+      // Ensure charms are synced before checking
+      const manager = cc.manager();
+      await manager.synced();
+
+      const charms = await cc.getAllCharms();
+      console.log(`[CharmList] Found ${charms.length} charms after syncing`);
+
+      // Check if we already have a DefaultCharmList charm
+      const defaultCharmList = charms.find((charm) => {
+        const name = charm.name();
+        console.log(`[CharmList] Checking charm ${charm.id}: name="${name}"`);
+        return name && name.startsWith("DefaultCharmList");
+      });
+
+      if (defaultCharmList) {
+        console.log(
+          `[CharmList] Found existing DefaultCharmList: ${defaultCharmList.id}`,
+        );
+        // Set the activeCharmId but don't update the URL
+        // This will cause Body to render the charm without changing the URL
+        app.setActiveCharmId(defaultCharmList.id);
+        return undefined;
+      }
+
+      console.log(`[CharmList] No DefaultCharmList found, creating new one...`);
+      // If no DefaultCharmList exists (whether space is empty or not), create one
+      await this.createDefaultCharm(cc);
+      // Don't return anything, let the navigation handle the update
+      return undefined;
     },
     args: () => [this.cc],
   });
+
+  private async createDefaultCharm(cc: CharmsController) {
+    const spaceName = cc.manager().getSpaceName();
+
+    // Check if creation is already in progress for this space
+    const existingCreation = XCharmListElement.creatingCharms.get(spaceName);
+    if (existingCreation) {
+      // Wait for the existing creation to complete
+      await existingCreation;
+      return;
+    }
+
+    // Create a promise for this creation attempt
+    const creationPromise = this.doCreateDefaultCharm(cc);
+    XCharmListElement.creatingCharms.set(spaceName, creationPromise);
+
+    try {
+      await creationPromise;
+    } finally {
+      // Clean up the promise from the map
+      XCharmListElement.creatingCharms.delete(spaceName);
+    }
+  }
+
+  private async doCreateDefaultCharm(cc: CharmsController) {
+    try {
+      const manager = cc.manager();
+      const runtime = manager.runtime;
+      const spaceName = manager.getSpaceName();
+
+      // Load the charm-list recipe from static cache
+      const recipeContent = await runtime.staticCache.getText(
+        "recipes/charm-list.tsx",
+      );
+
+      // Create RuntimeProgram
+      const program: RuntimeProgram = {
+        main: "/main.tsx",
+        files: [{ name: "/main.tsx", contents: recipeContent }],
+      };
+
+      // Create the charm (no initial input needed)
+      const charm = await cc.create(program);
+      console.log(`[CharmList] Created new charm: ${charm.id}`);
+
+      // Check the charm's name immediately after creation
+      const charmName = charm.name();
+      console.log(`[CharmList] New charm name: "${charmName}"`);
+
+      // Link the well-known allCharms cell to the charm's input
+      const allCharmsId =
+        "baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye";
+
+      // Create a transaction and use withTx to wrap the link operation
+      const tx = runtime.edit();
+
+      // Get the charm cell and wrap it with the transaction
+      const charmCell = await manager.get(charm.id);
+      const sourceCell = charmCell.getSourceCell(processSchema);
+
+      if (sourceCell) {
+        // Get the well-known allCharms cell using its EntityId format
+        const allCharmsCell = await manager.getCellById({ "/": allCharmsId });
+        sourceCell.withTx(tx).key("argument").key("allCharms").set(
+          allCharmsCell.withTx(tx),
+        );
+        await tx.commit();
+      }
+
+      // Wait for the link to be processed
+      await runtime.idle();
+      await manager.synced();
+
+      // Double-check: see if another DefaultCharmList was created while we were creating ours
+      const allCharms = await cc.getAllCharms();
+      const existingDefaultCharm = allCharms.find((c) => {
+        const name = c.name();
+        return name && name.startsWith("DefaultCharmList") && c.id !== charm.id;
+      });
+
+      if (existingDefaultCharm) {
+        // Another one was created, use that one instead
+        app.setActiveCharmId(existingDefaultCharm.id);
+      } else {
+        // Set the activeCharmId directly instead of navigating
+        // This shows the DefaultCharmList without updating the URL
+        app.setActiveCharmId(charm.id);
+      }
+    } catch (error) {
+      console.error("Failed to create default charm:", error);
+    }
+  }
 
   override render() {
     const spaceName = this.cc ? this.cc.manager().getSpaceName() : undefined;

--- a/packages/shell/src/components/Space.ts
+++ b/packages/shell/src/components/Space.ts
@@ -1,0 +1,117 @@
+import { css, html } from "lit";
+import { property, state } from "lit/decorators.js";
+import { BaseView } from "../views/BaseView.ts";
+import { CharmsController } from "@commontools/charm/ops";
+import { Task } from "@lit/task";
+import * as DefaultRecipe from "../lib/default-recipe.ts";
+
+type CharmData = {
+  name: string;
+  id: string;
+  href: string;
+};
+
+export class XSpaceElement extends BaseView {
+  static override styles = css`
+    :host {
+      display: block;
+      width: 100%;
+      height: 100%;
+      background-color: white;
+      padding: 1rem;
+    }
+  `;
+
+  @property({ attribute: false })
+  cc?: CharmsController;
+
+  @state()
+  showCharmList = false;
+
+  @state()
+  creatingDefaultRecipe = false;
+
+  private _charms = new Task(this, {
+    task: async ([cc]) => {
+      if (!cc) return undefined;
+
+      // Ensure charms are synced before checking
+      const manager = cc.manager();
+      await manager.synced();
+      return await cc.getAllCharms();
+    },
+    args: () => [this.cc],
+  });
+
+  async onRequestDefaultRecipe(e: Event) {
+    e.preventDefault();
+    if (this.creatingDefaultRecipe) {
+      return;
+    }
+    if (!this.cc) {
+      throw new Error(
+        "Cannot create default recipe without a charms controller.",
+      );
+    }
+    this.creatingDefaultRecipe = true;
+    try {
+      await DefaultRecipe.create(this.cc);
+    } catch (e) {
+      console.error(`Could not create default recipe: ${e}`);
+    } finally {
+      this.creatingDefaultRecipe = false;
+      this._charms.run();
+    }
+  }
+
+  onViewToggle(e: Event) {
+    e.preventDefault();
+    this.showCharmList = !this.showCharmList;
+  }
+
+  override render() {
+    const spaceName = this.cc ? this.cc.manager().getSpaceName() : undefined;
+    const charms = this._charms.value;
+    const defaultRecipe = charms
+      ? DefaultRecipe.getDefaultRecipe(charms)
+      : undefined;
+
+    const inner = !charms
+      ? html`
+        <x-spinner></x-spinner>
+      `
+      : this.showCharmList
+      ? html`
+        <x-charm-list .charms="${charms}" .spaceName="${spaceName}"></x-charm-list>
+      `
+      : !defaultRecipe
+      ? (this.creatingDefaultRecipe
+        ? html`
+          <div>
+            <span>Creating default recipe...</span>
+            <x-spinner></x-spinner>
+          </div>
+        `
+        : html`
+          <div>
+            <span>Create default recipe?</span>
+            <button @click="${this.onRequestDefaultRecipe}">Go!</button>
+          </div>
+        `)
+      // TBD if we want to use x-charm or ct-render directly here
+      : html`
+        <x-charm .charmId="${defaultRecipe.id}" .cc="${this.cc}"></x-charm>
+      `;
+
+    return html`
+      <div>
+        <button @click="${this.onViewToggle}">${this.showCharmList
+        ? "show default"
+        : "show list"}</button>
+        ${inner}
+      </div>
+    `;
+  }
+}
+
+globalThis.customElements.define("x-space", XSpaceElement);

--- a/packages/shell/src/components/index.ts
+++ b/packages/shell/src/components/index.ts
@@ -2,5 +2,6 @@ export * from "./Header.ts";
 export * from "./Body.ts";
 export * from "./Charm.ts";
 export * from "./CharmList.ts";
+export * from "./Space.ts";
 export * from "./CTLogo.ts";
 export * from "./Spinner.ts";

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -11,6 +11,7 @@ import { XRootView } from "./views/RootView.ts";
 import "./components/index.ts";
 import "./views/index.ts";
 import { AppController } from "./lib/app/controller.ts";
+import { getNavigationHref } from "./lib/navigate.ts";
 
 console.log(`ENVIRONMENT=${ENVIRONMENT}`);
 console.log(`API_URL=${API_URL}`);
@@ -60,4 +61,9 @@ globalThis.addEventListener("navigate-to-charm", (e) => {
   }
   app.setSpace(spaceName);
   app.setActiveCharmId(charmId);
+  
+  // Update the browser URL to reflect the new location
+  // (DefaultCharmList should not use this event, it sets activeCharmId directly)
+  const href = getNavigationHref(spaceName, charmId);
+  globalThis.history.pushState({}, "", href);
 });

--- a/packages/shell/src/lib/default-recipe.ts
+++ b/packages/shell/src/lib/default-recipe.ts
@@ -1,0 +1,47 @@
+import { CharmController, CharmsController } from "@commontools/charm/ops";
+import { processSchema } from "@commontools/charm";
+
+const ALL_CHARMS_ID =
+  "baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye";
+const DEFAULT_CHARM_NAME = "DefaultCharmList";
+
+export async function create(cc: CharmsController): Promise<CharmController> {
+  const manager = cc.manager();
+  const runtime = manager.runtime;
+
+  const recipeContent = await runtime.staticCache.getText(
+    "recipes/charm-list.tsx",
+  );
+  const charm = await cc.create(recipeContent);
+
+  const tx = runtime.edit();
+  const charmCell = charm.getCell();
+  const sourceCell = charmCell.getSourceCell(processSchema);
+
+  if (!sourceCell) {
+    // Not sure how/when this happens
+    throw new Error("Could not create and link default recipe.");
+  }
+
+  // Get the well-known allCharms cell using its EntityId format
+  const allCharmsCell = await manager.getCellById({ "/": ALL_CHARMS_ID });
+  sourceCell.withTx(tx).key("argument").key("allCharms").set(
+    allCharmsCell.withTx(tx),
+  );
+  await tx.commit();
+
+  // Wait for the link to be processed
+  await runtime.idle();
+  await manager.synced();
+
+  return charm;
+}
+
+export function getDefaultRecipe(
+  charms: CharmController[],
+): CharmController | undefined {
+  return charms.find((c) => {
+    const name = c.name();
+    return name && name.startsWith(DEFAULT_CHARM_NAME);
+  });
+}

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -1,6 +1,6 @@
 import { ANYONE, Identity, Session } from "@commontools/identity";
 import { Runtime } from "@commontools/runner";
-import { charmId, CharmManager } from "@commontools/charm";
+import { charmId, CharmManager, processSchema } from "@commontools/charm";
 import { CharmsController } from "@commontools/charm/ops";
 import { StorageManager } from "@commontools/runner/storage/cache";
 import { API_URL } from "./env.ts";
@@ -73,7 +73,10 @@ export async function createCharmsController(
   const staticAssetUrl = new URL(API_URL);
   staticAssetUrl.pathname = "/static";
 
-  // Create a variable to hold the charmManager reference
+  // We're hoisting CharmManager so that
+  // we can create it after the runtime, but still reference
+  // its `getSpaceName` method in a runtime callback.
+  // deno-lint-ignore prefer-const
   let charmManager: CharmManager;
 
   const runtime = new Runtime({

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -72,6 +72,10 @@ export async function createCharmsController(
 
   const staticAssetUrl = new URL(API_URL);
   staticAssetUrl.pathname = "/static";
+
+  // Create a variable to hold the charmManager reference
+  let charmManager: CharmManager;
+
   const runtime = new Runtime({
     storageManager: StorageManager.open({
       as: session.as,
@@ -97,12 +101,19 @@ export async function createCharmsController(
       if (!id) {
         throw new Error(`Could not navigate to cell that is not a charm.`);
       }
-      navigateToCharm(target.space, id);
+
+      // NOTE(jake): Eventually, once we're doing multi-space navigation, we will
+      // need to replace this charmManager.getSpaceName() with a call to some
+      // sort of address book / dns-style server, OR just navigate to the DID.
+
+      // Use the human-readable space name from CharmManager instead of the DID
+      navigateToCharm(charmManager.getSpaceName(), id);
     },
   });
 
   console.log("[createCharmsController] Creating CharmManager with session");
-  const charmManager = new CharmManager(session, runtime);
+  charmManager = new CharmManager(session, runtime);
+
   await charmManager.synced();
   console.log("[createCharmsController] Creating CharmsController");
   return new CharmsController(charmManager);

--- a/packages/static/assets.ts
+++ b/packages/static/assets.ts
@@ -6,4 +6,5 @@ export const assets: Readonly<string[]> = [
   "types/es2023.d.ts",
   "types/jsx.d.ts",
   "types/turndown.d.ts",
+  "recipes/charm-list.tsx",
 ];

--- a/packages/static/assets/recipes/charm-list.tsx
+++ b/packages/static/assets/recipes/charm-list.tsx
@@ -1,0 +1,82 @@
+import {
+  h,
+  derive,
+  JSONSchema,
+  NAME,
+  recipe,
+  str,
+  UI,
+  handler,
+  navigateTo,
+} from "commontools";
+
+const CharmsListInputSchema = {
+  type: "object",
+  properties: {
+    allCharms: {
+      type: "array",
+      items: {},
+      default: [],
+    },
+  },
+  required: ["allCharms"],
+} as const satisfies JSONSchema;
+
+const CharmsListOutputSchema = {
+  type: "object",
+  properties: {
+    items: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          charm: {},
+        },
+        required: ["name", "charm"],
+      },
+    },
+  },
+  required: ["items"],
+} as const satisfies JSONSchema;
+
+const visit = handler<{}, { charm: any }>((_, state) => {
+  return navigateTo(state.charm);
+});
+
+export default recipe(
+  CharmsListInputSchema,
+  CharmsListOutputSchema,
+  ({ allCharms }) => {
+    const charmCount = derive(allCharms, (allCharms) => allCharms.length);
+
+    return {
+      [NAME]: str`DefaultCharmList (${charmCount})`,
+      [UI]: (
+        <div style="padding: 2rem; max-width: 600px;">
+          <h2 style="margin-bottom: 1.5rem;">
+            Charms ({charmCount})
+          </h2>
+
+          <div style="display: flex; flex-direction: column; gap: 0.75rem;">
+            {derive(allCharms, (allCharms) =>
+              allCharms.map((charm) => (
+                <div style="display: flex; align-items: center; justify-content: space-between; padding: 1rem; border: 1px solid #e2e8f0; border-radius: 8px; background: #f8fafc;">
+                  <span style="font-weight: 500;">
+                    {charm[NAME] || "Untitled Charm"}
+                  </span>
+                  <ct-button 
+                    size="sm"
+                    onClick={visit({ charm })}
+                  >
+                    Visit
+                  </ct-button>
+                </div>
+              )),
+            )}
+          </div>
+        </div>
+      ),
+    };
+  },
+);


### PR DESCRIPTION
Optionally toggle between default recipe and charm list while in a space.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a default recipe for new spaces that shows a charm list, with a toggle to switch between the default recipe and the full charm list view.

- **New Features**
  - Loads and runs a default charm list recipe in empty spaces.
  - Users can toggle between the default recipe and the full charm list.
  - Added UI for creating the default recipe if it does not exist.

<!-- End of auto-generated description by cubic. -->

