### PR TITLE
Fix `ct charm link` (needs `tx`)

### DIFF
--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -1028,8 +1028,9 @@ export class CharmManager {
       targetInputCell = targetInputCell.key(segment);
     }
 
-    targetInputCell.key(targetKey).set(sourceResultCell);
-
+    const tx = this.runtime.edit();
+    targetInputCell.key(targetKey).withTx(tx).set(sourceResultCell);
+    await tx.commit();
     await this.runtime.idle();
     await this.synced();
   }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed the `ct charm link` operation by adding a transaction to ensure changes are committed correctly. This prevents issues when linking charms that require transactional updates.

<!-- End of auto-generated description by cubic. -->

