### PR TITLE
feat(html): add serializableEvent sanitizer and tests for event serialization

### DIFF
--- a/packages/html/src/render.ts
+++ b/packages/html/src/render.ts
@@ -314,9 +314,70 @@ export const setNodeSanitizer = (fn: (node: VNode) => VNode | null) => {
 
 export type EventSanitizer<T> = (event: Event) => T;
 
-const passthroughEvent: EventSanitizer<Event> = (event: Event): Event => event;
+export const passthroughEvent: EventSanitizer<Event> = (event: Event): Event =>
+  event;
 
-let sanitizeEvent: EventSanitizer<unknown> = passthroughEvent;
+const allowListedEventProperties = [
+  "type", // general
+  "key", // keyboard event
+  "code", // keyboard event
+  "repeat", // keyboard event
+  "altKey", // keyboard & mouse event
+  "ctrlKey", // keyboard & mouse event
+  "metaKey", // keyboard & mouse event
+  "shiftKey", // keyboard & mouse event
+  "inputType", // input event
+  "data", // input event
+  "button", // mouse event
+  "buttons", // mouse event
+];
+
+const allowListedEventTargetProperties = [
+  "name", // general input
+  "value", // general input
+  "checked", // checkbox
+  "selected", // option
+  "selectedIndex", // select
+  "selectedOptions", // select, multiple
+];
+
+/**
+ * Sanitize an event so it can be serialized.
+ *
+ * NOTE: This isn't yet vetted for security, it's just a coarse first pass with
+ * the primary objective of making events serializable.
+ *
+ * E.g. one glaring omission is that this can leak data via bubbling and we
+ * should sanitize quite differently if the target isn't the same as
+ * eventTarget.
+ *
+ * This code also doesn't make any effort to only copy properties that are
+ * allowed on various event types, or otherwise tailor sanitization to the event
+ * type.
+ *
+ * @param event - The event to sanitize.
+ * @returns The serializable event.
+ */
+export function serializableEvent<T>(event: Event): T {
+  const eventObject: Record<string, any> = {};
+  for (const property of allowListedEventProperties) {
+    eventObject[property] = event[property as keyof Event];
+  }
+
+  const targetObject: Record<string, any> = {};
+  for (const property of allowListedEventTargetProperties) {
+    targetObject[property] = event.target?.[property as keyof EventTarget];
+  }
+  if (Object.keys(targetObject).length > 0) eventObject.target = targetObject;
+
+  if ((event as CustomEvent).detail !== undefined) {
+    eventObject.detail = (event as CustomEvent).detail;
+  }
+
+  return JSON.parse(JSON.stringify(eventObject)) as T;
+}
+
+let sanitizeEvent: EventSanitizer<unknown> = serializableEvent;
 
 export const setEventSanitizer = (sanitize: EventSanitizer<unknown>) => {
   sanitizeEvent = sanitize;


### PR DESCRIPTION
- Introduce `serializableEvent` in `render.ts` to sanitize DOM events, making them serializable by extracting a safe subset of properties.
- Add allow-lists for event and event target properties to control what gets serialized.
- Update `render.test.ts` to include comprehensive tests for `serializableEvent`, covering Event, KeyboardEvent, MouseEvent, InputEvent (with target value), and CustomEvent (with detail).
- Ensure all serialized events are plain objects suitable for structured cloning.