### PR TITLE
When logging links to ephemeral docs, include better information

### DIFF
--- a/packages/runner/src/storage.ts
+++ b/packages/runner/src/storage.ts
@@ -276,7 +276,12 @@ export class Storage implements IStorage {
       const newDoc = docMap.getDocByEntityId(doc.space, entityId, false)!;
       // We don't need to hook up ephemeral docs
       if (newDoc.ephemeral) {
-        console.log("Found link to ephemeral doc from", doc.entityId);
+        console.log(
+          "Found link to ephemeral doc",
+          entityIdStr(newDoc.entityId),
+          "from",
+          entityIdStr(doc.entityId),
+        );
         continue;
       }
       // NOTE(@ubik2): I can't recall if a retraction will come over as a missing isValue.


### PR DESCRIPTION
This just adds better logging when we encounter an ephemeral doc link.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved logging for ephemeral doc links by including both the linked and source entity IDs for better traceability.

<!-- End of auto-generated description by cubic. -->

