### PR TITLE
fix(runner): prevent storage race condition with idle() synchronization

### DIFF
--- a/packages/runner/src/storage.ts
+++ b/packages/runner/src/storage.ts
@@ -82,6 +82,10 @@ export class Storage implements IStorage {
   // They will be removed from here as soon as we call send, but they will
   // still be in the docToStoragePromises until the send returns.
   private dirtyDocs = new Set<string>();
+  // Track active _updateDoc operations to prevent race conditions
+  private activeUpdateFromStorageCount = 0;
+  private updateFromStoragePromise: Promise<void> | undefined;
+  private _updateFromStorageResolver: (() => void) | undefined;
 
   private cancel: Cancel;
   private addCancel: AddCancel;
@@ -184,6 +188,8 @@ export class Storage implements IStorage {
     this.docToStorageSubs.clear();
     this.docToStoragePromises.clear();
     this.dirtyDocs.clear();
+    this.activeUpdateFromStorageCount = 0;
+    this.updateFromStoragePromise = undefined;
     this.cancel();
   }
 
@@ -415,16 +421,7 @@ export class Storage implements IStorage {
         JSON.stringify(value),
       ],
     );
-    const storageValue: StorageValue<JSONValue> = {
-      value:
-        (doc.get() === undefined
-          ? undefined
-          : JSON.parse(JSON.stringify(doc.get()))),
-      ...(doc.sourceCell?.entityId !== undefined)
-        ? { source: doc.sourceCell.entityId }
-        : {},
-      ...(labels !== undefined) ? { labels: labels } : {},
-    };
+    const storageValue = Storage._cellLinkToJSON(doc, labels);
     const existingValue = this._getStorageProviderForSpace(doc.space).get<
       JSONValue
     >(
@@ -472,20 +469,34 @@ export class Storage implements IStorage {
 
   private async _sendDocValue(doc: DocImpl<unknown>, labels?: Labels) {
     await this.runtime.idle();
+
+    // Wait for all _updateDoc operations to complete, then wait for runtime to
+    // be idle again. Since more updates might have come in in the meantime,
+    // wait again. Repeat until the incoming queue is empty and the runtime is
+    // settled.
+    while (this.updateFromStoragePromise) {
+      await this.updateFromStoragePromise;
+      await this.runtime.idle();
+    }
+
     const docKey = `${doc.space}/${toURI(doc.entityId)}`;
     const storageProvider = this._getStorageProviderForSpace(doc.space);
     // We're dirty -- mark clean, then write to storage
     this.dirtyDocs.delete(docKey);
-    const storageValue: StorageValue<JSONValue> = {
-      value:
-        (doc.get() === undefined
-          ? undefined
-          : JSON.parse(JSON.stringify(doc.get()))),
-      ...(doc.sourceCell?.entityId !== undefined)
-        ? { source: doc.sourceCell.entityId }
-        : {},
-      ...(labels !== undefined) ? { labels: labels } : {},
-    };
+
+    // Create storage value using the helper to ensure consistency
+    const storageValue = Storage._cellLinkToJSON(doc, labels);
+
+    // Compare again, since the value might have changed since we last checked
+    const existingValue = this._getStorageProviderForSpace(doc.space).get<
+      JSONValue
+    >(
+      doc.entityId,
+    );
+    // If our value is the same as what storage has, we don't need to do anything.
+    if (deepEqual(storageValue, existingValue)) {
+      return;
+    }
 
     await storageProvider.send([{
       entityId: doc.entityId,
@@ -498,23 +509,51 @@ export class Storage implements IStorage {
     doc: DocImpl<JSONValue>,
     storageValue: StorageValue<JSONValue>,
   ) {
-    // Don't update docs while they might be updating.
-    await this.runtime.scheduler.idle();
+    // Increment the counter at the start
+    this.activeUpdateFromStorageCount++;
 
-    if (!deepEqual(storageValue.value, doc.get())) {
-      // values differ
-      const newDocValue = JSON.parse(JSON.stringify(storageValue.value));
-      doc.send(newDocValue);
+    // Create or update the promise if this is the first update
+    if (this.activeUpdateFromStorageCount === 1) {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      this.updateFromStoragePromise = promise;
+      // Store the resolver to call when count reaches 0
+      this._updateFromStorageResolver = resolve;
     }
-    const newSourceCell = (storageValue.source !== undefined)
-      ? this.runtime.documentMap.getDocByEntityId(
-        doc.space,
-        storageValue.source,
-        false,
-      )
-      : undefined;
-    if (doc.sourceCell !== newSourceCell) {
-      doc.sourceCell = newSourceCell;
+
+    try {
+      // Don't update docs while they might be updating.
+      await this.runtime.scheduler.idle();
+
+      if (!deepEqual(storageValue.value, doc.get())) {
+        // values differ
+        const newDocValue = JSON.parse(JSON.stringify(storageValue.value));
+        doc.send(newDocValue);
+      }
+      const newSourceCell = (storageValue.source !== undefined)
+        ? this.runtime.documentMap.getDocByEntityId(
+          doc.space,
+          storageValue.source,
+          false,
+        )
+        : undefined;
+      if (doc.sourceCell !== newSourceCell) {
+        doc.sourceCell = newSourceCell;
+      }
+    } finally {
+      // Decrement the counter
+      this.activeUpdateFromStorageCount--;
+
+      // If this was the last update, resolve the promise
+      if (
+        this.activeUpdateFromStorageCount === 0 && this.updateFromStoragePromise
+      ) {
+        const resolver = this._updateFromStorageResolver;
+        if (resolver) {
+          resolver();
+        }
+        this.updateFromStoragePromise = undefined;
+        this._updateFromStorageResolver = undefined;
+      }
     }
   }
 


### PR DESCRIPTION
Fix infinite loop caused by circular dependency between _updateDoc and _sendDocValue when both wait for runtime.idle(). The race condition occurred when storage updates triggered doc updates while doc changes were being sent to storage, causing stale data to be written.

Solution:
- Track all active _updateDoc operations with a global counter
- Make _sendDocValue wait for all pending _updateDoc operations to complete
- Use a shared promise that resolves when all updates finish
- Ensure proper sequencing: idle → wait for updates → idle again

This prevents the infinite loop where:

1. Storage update triggers _updateDoc (waits for idle)
2. Doc change triggers _updateStorage → _sendDocValue (waits for idle)
3. _sendDocValue sends stale data → triggers another storage update → repeat

Fixes the race condition identified in storage.ts where changes could be queued behind stale data, ensuring data consistency between docs and storage.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a race condition in storage synchronization that caused infinite loops and stale data by ensuring doc and storage updates wait for each other to finish.

- **Bug Fixes**
  - Tracked active doc update operations with a counter and shared promise.
  - Made storage updates wait for all pending doc updates before proceeding.
  - Improved sequencing to prevent circular dependencies and ensure data consistency.

<!-- End of auto-generated description by cubic. -->

