### PR TITLE
Fix precedence problem that caused us to clear from pending and seen when we shouldn't have.

### DIFF
--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -879,7 +879,7 @@ export class Replica {
       // facts (or gotten a conflict).
       // Server facts may have newer nursery changes that we want to keep.
       const freshFacts = revisions.filter((revision) =>
-        this.pendingNurseryChanges.get(toKey(revision))?.size ?? 0 === 0
+        (this.pendingNurseryChanges.get(toKey(revision))?.size ?? 0) === 0
       );
 
       // Evict redundant facts which we just merged into `heap` so that reads


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed a logic error in cache filtering that caused pending and seen items to be cleared incorrectly. This prevents data from being removed when it should be kept.

<!-- End of auto-generated description by cubic. -->

