### PR TITLE
Migrate wiki and research-report to cell-based API

### DIFF
--- a/recipes/research-report.tsx
+++ b/recipes/research-report.tsx
@@ -42,17 +42,15 @@ export default recipe(
         <div style="padding: 1rem; max-width: 1200px; margin: 0 auto;">
           <div style="margin-bottom: 1rem;">
             <ct-input
-              value={title}
+              $value={title}
               placeholder="Enter research report title..."
               style="width: 100%; font-size: 1.2rem; font-weight: bold;"
-              onInput={updateTitle({ title })}
             />
           </div>
           <div style="border: 1px solid #e2e8f0; border-radius: 8px; overflow: hidden;">
-            <common-code-editor
-              source={content}
+            <ct-code-editor
+              $value={content}
               language="text/plain"
-              onChange={updateContent({ content })}
               style="min-height: 400px;"
             />
           </div>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Migrated the wiki and research-report recipes to use the new cell-based API, updating UI components and improving the wiki page rename flow.

- **Refactors**
  - Replaced legacy input and code editor components with cell-based versions in both recipes.
  - Updated the wiki to use a dedicated rename button and modal, simplifying page title changes.

<!-- End of auto-generated description by cubic. -->

