### PR TITLE
fix(query-result-proxy): add object methods like hasOwnProperty

### DIFF
--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -60,14 +60,21 @@ const arrayMethods: { [key: string]: ArrayMethodType } = {
   some: ArrayMethodType.ReadOnly,
   sort: ArrayMethodType.ReadWrite,
   splice: ArrayMethodType.ReadWrite,
-  toLocaleString: ArrayMethodType.ReadOnly,
   toReversed: ArrayMethodType.ReadOnly,
   toSorted: ArrayMethodType.ReadOnly,
   toSpliced: ArrayMethodType.ReadOnly,
-  toString: ArrayMethodType.ReadOnly,
   unshift: ArrayMethodType.WriteOnly,
   values: ArrayMethodType.ReadOnly,
   with: ArrayMethodType.ReadOnly,
+
+  hasOwnProperty: ArrayMethodType.ReadOnly,
+  isPrototypeOf: ArrayMethodType.ReadOnly,
+  propertyIsEnumerable: ArrayMethodType.ReadOnly,
+  valueOf: ArrayMethodType.ReadOnly,
+  isExtensible: ArrayMethodType.ReadOnly,
+  isFrozen: ArrayMethodType.ReadOnly,
+  toString: ArrayMethodType.ReadOnly,
+  toLocaleString: ArrayMethodType.ReadOnly,
 };
 
 export function createQueryResultProxy<T>(
@@ -125,7 +132,10 @@ export function createQueryResultProxy<T>(
 
       if (Array.isArray(target) && prop in arrayMethods) {
         const method = Array.prototype[prop as keyof typeof Array.prototype];
-        const isReadWrite = arrayMethods[prop as keyof typeof arrayMethods];
+        const isReadWrite = arrayMethods[prop as keyof typeof arrayMethods] ??
+          // Default to ReadOnly to catch other methods on object (so the "prop
+          // in" is true) but not in the list.
+          ArrayMethodType.ReadOnly;
 
         return isReadWrite === ArrayMethodType.ReadOnly
           ? (...args: any[]) => {

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -129,14 +129,12 @@ export function createQueryResultProxy<T>(
       }
 
       if (
-        Array.isArray(target) && prop in arrayMethods &&
+        Array.isArray(target) &&
+        Object.prototype.hasOwnProperty.call(arrayMethods, prop) &&
         typeof (target[prop as keyof typeof target]) === "function"
       ) {
         const method = Array.prototype[prop as keyof typeof Array.prototype];
-        const isReadWrite = arrayMethods[prop as keyof typeof arrayMethods] ??
-          // Default to ReadOnly to catch other methods on object (so the "prop
-          // in" is true) but not in the list.
-          ArrayMethodType.ReadOnly;
+        const isReadWrite = arrayMethods[prop as keyof typeof arrayMethods];
 
         return isReadWrite === ArrayMethodType.ReadOnly
           ? (...args: any[]) => {

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -71,8 +71,6 @@ const arrayMethods: { [key: string]: ArrayMethodType } = {
   isPrototypeOf: ArrayMethodType.ReadOnly,
   propertyIsEnumerable: ArrayMethodType.ReadOnly,
   valueOf: ArrayMethodType.ReadOnly,
-  isExtensible: ArrayMethodType.ReadOnly,
-  isFrozen: ArrayMethodType.ReadOnly,
   toString: ArrayMethodType.ReadOnly,
   toLocaleString: ArrayMethodType.ReadOnly,
 };
@@ -130,7 +128,10 @@ export function createQueryResultProxy<T>(
         else return value;
       }
 
-      if (Array.isArray(target) && prop in arrayMethods) {
+      if (
+        Array.isArray(target) && prop in arrayMethods &&
+        typeof (target[prop]) === "function"
+      ) {
         const method = Array.prototype[prop as keyof typeof Array.prototype];
         const isReadWrite = arrayMethods[prop as keyof typeof arrayMethods] ??
           // Default to ReadOnly to catch other methods on object (so the "prop

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -130,7 +130,7 @@ export function createQueryResultProxy<T>(
 
       if (
         Array.isArray(target) && prop in arrayMethods &&
-        typeof (target[prop]) === "function"
+        typeof (target[prop as keyof typeof target]) === "function"
       ) {
         const method = Array.prototype[prop as keyof typeof Array.prototype];
         const isReadWrite = arrayMethods[prop as keyof typeof arrayMethods] ??


### PR DESCRIPTION
Added support for standard object methods (e.g., hasOwnProperty) to QueryResultProxy, improving compatibility with typical JavaScript object usage patterns.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for standard object methods like hasOwnProperty, isPrototypeOf, and toString to QueryResultProxy for better compatibility with JavaScript object usage.

<!-- End of auto-generated description by cubic. -->

