### PR TITLE
Ellyse/ct 616 fix array index check to use isinteger

### DIFF
--- a/packages/runner/src/storage/transaction-shim.ts
+++ b/packages/runner/src/storage/transaction-shim.ts
@@ -421,7 +421,10 @@ export class StorageTransaction implements IStorageTransaction {
     return { ok: reader };
   }
 
-  read(address: IMemorySpaceAddress, options?: IReadOptions): Result<Read, ReadError> {
+  read(
+    address: IMemorySpaceAddress,
+    options?: IReadOptions,
+  ): Result<Read, ReadError> {
     const readerResult = this.reader(address.space);
     if (readerResult.error) {
       return { ok: undefined, error: readerResult.error };
@@ -540,7 +543,10 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     return this.tx.reader(space);
   }
 
-  read(address: IMemorySpaceAddress, options?: IReadOptions): Result<Read, ReadError> {
+  read(
+    address: IMemorySpaceAddress,
+    options?: IReadOptions,
+  ): Result<Read, ReadError> {
     return this.tx.read(address, options);
   }
 
@@ -594,7 +600,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       for (const key of remainingPath) {
         nextValue =
           nextValue[key] =
-            (!Number.isNaN(Number(key)) ? [] : {}) as typeof nextValue;
+            (Number.isInteger(Number(key)) ? [] : {}) as typeof nextValue;
       }
       nextValue[lastKey] = value;
       const parentAddress = { ...address, path: lastValidPath ?? [] };

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,0 +1,249 @@
+/**
+ * Minimal logging library for both Deno and browser environments
+ */
+
+export type LogMessage = unknown | (() => unknown);
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+/**
+ * Numeric values for log levels to enable comparison
+ */
+const LOG_LEVELS: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+/**
+ * Current minimum log level - messages below this level are ignored
+ */
+let currentLogLevel: LogLevel = "info";
+
+/**
+ * Initialize log level from environment variable if available
+ */
+if (typeof Deno !== "undefined") {
+  const envLevel = Deno.env.get("LOG_LEVEL");
+  if (envLevel && envLevel in LOG_LEVELS) {
+    currentLogLevel = envLevel as LogLevel;
+  }
+}
+
+/**
+ * Set the minimum log level
+ * @param level - The minimum level to log (debug < info < warn < error)
+ */
+export function setLogLevel(level: LogLevel): void {
+  if (!(level in LOG_LEVELS)) {
+    throw new Error(`Invalid log level: ${level}`);
+  }
+  currentLogLevel = level;
+}
+
+/**
+ * Get the current log level
+ */
+export function getLogLevel(): LogLevel {
+  return currentLogLevel;
+}
+
+/**
+ * Check if a message at the given level should be logged
+ */
+function shouldLog(level: LogLevel): boolean {
+  return LOG_LEVELS[level] >= LOG_LEVELS[currentLogLevel];
+}
+
+/**
+ * Resolves log messages, evaluating functions if needed
+ */
+function resolveMessages(messages: LogMessage[]): unknown[] {
+  return messages.map((msg) => typeof msg === "function" ? msg() : msg);
+}
+
+/**
+ * Basic log function that accepts any message(s) and logs them to the console
+ * Messages can be values or zero-arity functions that return values (for lazy evaluation)
+ * @param messages - The messages to log
+ */
+export function log(...messages: LogMessage[]): void {
+  log.info(...messages);
+}
+
+/**
+ * Log a debug message
+ */
+log.debug = function (...messages: LogMessage[]): void {
+  if (shouldLog("debug")) {
+    console.debug(...resolveMessages(messages));
+  }
+};
+
+/**
+ * Log an info message
+ */
+log.info = function (...messages: LogMessage[]): void {
+  if (shouldLog("info")) {
+    console.log(...resolveMessages(messages));
+  }
+};
+
+/**
+ * Log a warning message
+ */
+log.warn = function (...messages: LogMessage[]): void {
+  if (shouldLog("warn")) {
+    console.warn(...resolveMessages(messages));
+  }
+};
+
+/**
+ * Log an error message
+ */
+log.error = function (...messages: LogMessage[]): void {
+  if (shouldLog("error")) {
+    console.error(...resolveMessages(messages));
+  }
+};
+
+/**
+ * Tagged logger interface - same as log but with module name prefix
+ */
+export interface TaggedLogger {
+  (...messages: LogMessage[]): void;
+  debug: (...messages: LogMessage[]) => void;
+  info: (...messages: LogMessage[]) => void;
+  warn: (...messages: LogMessage[]) => void;
+  error: (...messages: LogMessage[]) => void;
+
+  /**
+   * Controls whether this logger instance is disabled.
+   * - undefined: Use default behavior (currently enabled, future: check config)
+   * - true: Explicitly disabled, all logs are skipped
+   * - false: Explicitly enabled, all logs are shown
+   *
+   * When undefined, future versions can check global config for this module.
+   * Explicit true/false values will always override any global config.
+   */
+  disabled: boolean | undefined;
+}
+
+/**
+ * Extract module name from import.meta.url
+ * Examples:
+ * - file:///path/to/utils/math.ts → "math"
+ * - file:///path/to/index.ts → "index"
+ * - https://example.com/module.js → "module"
+ */
+function extractModuleName(url: string): string {
+  try {
+    const urlObj = new URL(url);
+    const pathname = urlObj.pathname;
+    const filename = pathname.split("/").pop() || "unknown";
+    // Remove extension
+    const moduleName = filename.replace(/\.[^.]+$/, "");
+    return moduleName;
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Extract caller's file URL from stack trace
+ */
+function getCallerUrl(): string | undefined {
+  const error = new Error();
+  const stack = error.stack;
+
+  if (!stack) return undefined;
+
+  // Parse stack trace to find the caller
+  // Stack trace format: "at functionName (file:///path/to/file.ts:line:col)"
+  const lines = stack.split("\n");
+
+  // Skip first 3 lines: Error message, getCallerUrl, and getLogger
+  for (let i = 3; i < lines.length; i++) {
+    const line = lines[i];
+    const match = line.match(/at\s+.*?\s+\((.*?):\d+:\d+\)|at\s+(.*?):\d+:\d+/);
+    if (match) {
+      const url = match[1] || match[2];
+      if (url && !url.includes("/logger.ts")) {
+        return url;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Options for creating a tagged logger
+ */
+export interface GetLoggerOptions {
+  /**
+   * Whether this logger should be enabled
+   * If not specified (undefined), follows default behavior
+   */
+  enabled?: boolean;
+}
+
+/**
+ * Create a logger tagged with the calling module name
+ * @param importMetaUrl - The import.meta.url from the calling module (optional - will auto-detect if not provided)
+ * @param options - Options for configuring the logger
+ * @returns A logger that prefixes all messages with [moduleName]
+ */
+export function getLogger(
+  importMetaUrl?: string,
+  options?: GetLoggerOptions,
+): TaggedLogger {
+  const url = importMetaUrl || getCallerUrl() || "unknown";
+  const tag = extractModuleName(url);
+
+  // Set initial disabled state from options
+  const initialDisabled = options?.enabled === undefined
+    ? undefined
+    : !options.enabled;
+
+  const taggedLog: TaggedLogger = (...messages: LogMessage[]) => {
+    // Check disabled state - undefined means enabled
+    if (taggedLog.disabled === true) return;
+    log.info(`[${tag}]`, ...messages);
+  };
+
+  taggedLog.debug = (...messages: LogMessage[]) => {
+    // Check disabled state first to skip everything including lazy eval
+    if (taggedLog.disabled === true) return;
+    if (shouldLog("debug")) {
+      console.debug(`[${tag}]`, ...resolveMessages(messages));
+    }
+  };
+
+  taggedLog.info = (...messages: LogMessage[]) => {
+    if (taggedLog.disabled === true) return;
+    if (shouldLog("info")) {
+      console.log(`[${tag}]`, ...resolveMessages(messages));
+    }
+  };
+
+  taggedLog.warn = (...messages: LogMessage[]) => {
+    if (taggedLog.disabled === true) return;
+    if (shouldLog("warn")) {
+      console.warn(`[${tag}]`, ...resolveMessages(messages));
+    }
+  };
+
+  taggedLog.error = (...messages: LogMessage[]) => {
+    if (taggedLog.disabled === true) return;
+    if (shouldLog("error")) {
+      console.error(`[${tag}]`, ...resolveMessages(messages));
+    }
+  };
+
+  // Set the disabled property
+  taggedLog.disabled = initialDisabled;
+
+  return taggedLog;
+}

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -1,0 +1,501 @@
+import { beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { getLogger, getLogLevel, log, setLogLevel } from "../src/logger.ts";
+
+describe("logger", () => {
+  // Save initial log level
+  let initialLogLevel: string;
+
+  beforeEach(() => {
+    // Reset to default log level before each test
+    setLogLevel("info");
+  });
+
+  // Helper to capture console output
+  function captureConsole<T>(
+    method: keyof Console,
+    fn: () => T,
+  ): { result: T; calls: unknown[][] } {
+    const originalMethod = console[method];
+    const calls: unknown[][] = [];
+
+    // Mock the console method
+    (console[method] as any) = (...args: unknown[]) => {
+      calls.push(args);
+    };
+
+    try {
+      const result = fn();
+      return { result, calls };
+    } finally {
+      // Restore original method
+      (console[method] as any) = originalMethod;
+    }
+  }
+
+  describe("basic log function", () => {
+    it("should log messages to console", () => {
+      const { calls } = captureConsole("log", () => {
+        log("hello", "world");
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["hello", "world"]);
+    });
+
+    it("should handle multiple arguments", () => {
+      const { calls } = captureConsole("log", () => {
+        log("a", 1, true, { key: "value" });
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["a", 1, true, { key: "value" }]);
+    });
+
+    it("should evaluate lazy functions", () => {
+      let evaluated = false;
+      const lazyMessage = () => {
+        evaluated = true;
+        return "lazy value";
+      };
+
+      const { calls } = captureConsole("log", () => {
+        log("static", lazyMessage);
+      });
+
+      expect(evaluated).toBe(true);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["static", "lazy value"]);
+    });
+
+    it("should handle mixed static and lazy messages", () => {
+      const { calls } = captureConsole("log", () => {
+        log(
+          "start",
+          () => "lazy1",
+          "middle",
+          () => "lazy2",
+          "end",
+        );
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["start", "lazy1", "middle", "lazy2", "end"]);
+    });
+  });
+
+  describe("severity levels", () => {
+    it("should log debug messages", () => {
+      setLogLevel("debug"); // Enable debug level
+      const { calls } = captureConsole("debug", () => {
+        log.debug("debug message");
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["debug message"]);
+    });
+
+    it("should log info messages", () => {
+      const { calls } = captureConsole("log", () => {
+        log.info("info message");
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["info message"]);
+    });
+
+    it("should log warning messages", () => {
+      const { calls } = captureConsole("warn", () => {
+        log.warn("warning message");
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["warning message"]);
+    });
+
+    it("should log error messages", () => {
+      const { calls } = captureConsole("error", () => {
+        log.error("error message");
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["error message"]);
+    });
+
+    it("should default to info level when using log()", () => {
+      const { calls } = captureConsole("log", () => {
+        log("default message");
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["default message"]);
+    });
+
+    it("should handle lazy evaluation for all levels", () => {
+      setLogLevel("debug"); // Enable all levels
+
+      const lazyDebug = () => "lazy debug";
+      const lazyInfo = () => "lazy info";
+      const lazyWarn = () => "lazy warn";
+      const lazyError = () => "lazy error";
+
+      const { calls: debugCalls } = captureConsole("debug", () => {
+        log.debug(lazyDebug);
+      });
+      const { calls: infoCalls } = captureConsole("log", () => {
+        log.info(lazyInfo);
+      });
+      const { calls: warnCalls } = captureConsole("warn", () => {
+        log.warn(lazyWarn);
+      });
+      const { calls: errorCalls } = captureConsole("error", () => {
+        log.error(lazyError);
+      });
+
+      expect(debugCalls[0]).toEqual(["lazy debug"]);
+      expect(infoCalls[0]).toEqual(["lazy info"]);
+      expect(warnCalls[0]).toEqual(["lazy warn"]);
+      expect(errorCalls[0]).toEqual(["lazy error"]);
+    });
+  });
+
+  describe("severity filtering", () => {
+    it("should filter messages below the current log level", () => {
+      setLogLevel("warn");
+
+      const { calls: debugCalls } = captureConsole("debug", () => {
+        log.debug("debug message");
+      });
+      const { calls: infoCalls } = captureConsole("log", () => {
+        log.info("info message");
+      });
+      const { calls: warnCalls } = captureConsole("warn", () => {
+        log.warn("warn message");
+      });
+      const { calls: errorCalls } = captureConsole("error", () => {
+        log.error("error message");
+      });
+
+      expect(debugCalls).toHaveLength(0); // Filtered out
+      expect(infoCalls).toHaveLength(0); // Filtered out
+      expect(warnCalls).toHaveLength(1); // Logged
+      expect(errorCalls).toHaveLength(1); // Logged
+    });
+
+    it("should NOT evaluate lazy functions when severity is filtered out", () => {
+      setLogLevel("error");
+
+      let debugEvaluated = false;
+      let infoEvaluated = false;
+      let warnEvaluated = false;
+      let errorEvaluated = false;
+
+      captureConsole("debug", () => {
+        log.debug(() => {
+          debugEvaluated = true;
+          return "expensive debug";
+        });
+      });
+
+      captureConsole("log", () => {
+        log.info(() => {
+          infoEvaluated = true;
+          return "expensive info";
+        });
+      });
+
+      captureConsole("warn", () => {
+        log.warn(() => {
+          warnEvaluated = true;
+          return "expensive warn";
+        });
+      });
+
+      captureConsole("error", () => {
+        log.error(() => {
+          errorEvaluated = true;
+          return "expensive error";
+        });
+      });
+
+      expect(debugEvaluated).toBe(false); // Not evaluated!
+      expect(infoEvaluated).toBe(false); // Not evaluated!
+      expect(warnEvaluated).toBe(false); // Not evaluated!
+      expect(errorEvaluated).toBe(true); // Evaluated
+    });
+
+    it("should respect setLogLevel changes", () => {
+      // Start with debug level (everything logs)
+      setLogLevel("debug");
+
+      const { calls: debugCalls1 } = captureConsole("debug", () => {
+        log.debug("debug 1");
+      });
+      expect(debugCalls1).toHaveLength(1);
+
+      // Change to error level
+      setLogLevel("error");
+
+      const { calls: debugCalls2 } = captureConsole("debug", () => {
+        log.debug("debug 2");
+      });
+      expect(debugCalls2).toHaveLength(0); // Now filtered
+    });
+
+    it("should get and set log levels correctly", () => {
+      expect(getLogLevel()).toBe("info"); // Default
+
+      setLogLevel("debug");
+      expect(getLogLevel()).toBe("debug");
+
+      setLogLevel("error");
+      expect(getLogLevel()).toBe("error");
+    });
+
+    it("should throw on invalid log level", () => {
+      expect(() => setLogLevel("invalid" as any)).toThrow(
+        "Invalid log level: invalid",
+      );
+    });
+  });
+
+  describe("module tagging with getLogger", () => {
+    it("should extract module name from file URLs", () => {
+      const mathLogger = getLogger("file:///home/user/project/utils/math.ts");
+      const { calls } = captureConsole("log", () => {
+        mathLogger.info("calculation complete");
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["[math]", "calculation complete"]);
+    });
+
+    it("should handle various URL formats", () => {
+      // Test different URL patterns
+      const testCases = [
+        { url: "file:///path/to/index.ts", expected: "index" },
+        { url: "file:///path/to/user-service.js", expected: "user-service" },
+        { url: "https://example.com/module.js", expected: "module" },
+        {
+          url: "file:///complex.name.with.dots.ts",
+          expected: "complex.name.with.dots",
+        },
+      ];
+
+      for (const { url, expected } of testCases) {
+        const logger = getLogger(url);
+        const { calls } = captureConsole("log", () => {
+          logger("test");
+        });
+
+        expect(calls[0][0]).toBe(`[${expected}]`);
+      }
+    });
+
+    it("should handle invalid URLs gracefully", () => {
+      const logger = getLogger("not-a-valid-url");
+      const { calls } = captureConsole("log", () => {
+        logger("test message");
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["[unknown]", "test message"]);
+    });
+
+    it("should work with all severity levels", () => {
+      setLogLevel("debug");
+      const logger = getLogger("file:///path/to/auth.ts");
+
+      const { calls: debugCalls } = captureConsole("debug", () => {
+        logger.debug("debug msg");
+      });
+      const { calls: infoCalls } = captureConsole("log", () => {
+        logger.info("info msg");
+      });
+      const { calls: warnCalls } = captureConsole("warn", () => {
+        logger.warn("warn msg");
+      });
+      const { calls: errorCalls } = captureConsole("error", () => {
+        logger.error("error msg");
+      });
+
+      expect(debugCalls[0]).toEqual(["[auth]", "debug msg"]);
+      expect(infoCalls[0]).toEqual(["[auth]", "info msg"]);
+      expect(warnCalls[0]).toEqual(["[auth]", "warn msg"]);
+      expect(errorCalls[0]).toEqual(["[auth]", "error msg"]);
+    });
+
+    it("should respect severity filtering with tagged loggers", () => {
+      setLogLevel("warn");
+      const logger = getLogger("file:///path/to/database.ts");
+
+      const { calls: debugCalls } = captureConsole("debug", () => {
+        logger.debug("should not appear");
+      });
+      const { calls: warnCalls } = captureConsole("warn", () => {
+        logger.warn("should appear");
+      });
+
+      expect(debugCalls).toHaveLength(0);
+      expect(warnCalls).toHaveLength(1);
+      expect(warnCalls[0]).toEqual(["[database]", "should appear"]);
+    });
+
+    it("should handle lazy evaluation with tags", () => {
+      setLogLevel("error");
+      const logger = getLogger("file:///path/to/service.ts");
+
+      let evaluated = false;
+      captureConsole("log", () => {
+        logger.info(() => {
+          evaluated = true;
+          return "expensive message";
+        });
+      });
+
+      expect(evaluated).toBe(false); // Not evaluated due to filtering
+
+      // Now test that it does evaluate when level allows
+      evaluated = false;
+      const { calls } = captureConsole("error", () => {
+        logger.error(() => {
+          evaluated = true;
+          return "error message";
+        });
+      });
+
+      expect(evaluated).toBe(true);
+      expect(calls[0]).toEqual(["[service]", "error message"]);
+    });
+
+    it("should use real import.meta.url", () => {
+      // This test uses the actual import.meta.url of this test file
+      const logger = getLogger(import.meta.url);
+      const { calls } = captureConsole("log", () => {
+        logger("test from logger.test");
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0][0]).toBe("[logger.test]");
+    });
+
+    it("should auto-detect caller when no URL provided", () => {
+      // Call getLogger without parameters
+      const logger = getLogger();
+      const { calls } = captureConsole("log", () => {
+        logger("auto-detected module");
+      });
+
+      expect(calls).toHaveLength(1);
+      // Should detect this test file
+      expect(calls[0][0]).toBe("[logger.test]");
+    });
+  });
+
+  describe("disabled property", () => {
+    it("should create enabled logger by default", () => {
+      const logger = getLogger();
+      expect(logger.disabled).toBe(undefined);
+
+      const { calls } = captureConsole("log", () => {
+        logger.info("should appear");
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["[logger.test]", "should appear"]);
+    });
+
+    it("should create disabled logger when enabled: false", () => {
+      const logger = getLogger(undefined, { enabled: false });
+      expect(logger.disabled).toBe(true);
+
+      const { calls } = captureConsole("log", () => {
+        logger.info("should not appear");
+      });
+
+      expect(calls).toHaveLength(0);
+    });
+
+    it("should create enabled logger when enabled: true", () => {
+      const logger = getLogger(undefined, { enabled: true });
+      expect(logger.disabled).toBe(false);
+
+      const { calls } = captureConsole("log", () => {
+        logger.info("should appear");
+      });
+
+      expect(calls).toHaveLength(1);
+    });
+
+    it("should respect runtime changes to disabled property", () => {
+      const logger = getLogger();
+
+      // Initially enabled
+      const { calls: calls1 } = captureConsole("log", () => {
+        logger.info("message 1");
+      });
+      expect(calls1).toHaveLength(1);
+
+      // Disable it
+      logger.disabled = true;
+      const { calls: calls2 } = captureConsole("log", () => {
+        logger.info("message 2");
+      });
+      expect(calls2).toHaveLength(0);
+
+      // Re-enable it
+      logger.disabled = false;
+      const { calls: calls3 } = captureConsole("log", () => {
+        logger.info("message 3");
+      });
+      expect(calls3).toHaveLength(1);
+    });
+
+    it("should NOT evaluate lazy functions when disabled", () => {
+      const logger = getLogger(undefined, { enabled: false });
+
+      let evaluated = false;
+      captureConsole("log", () => {
+        logger.info(() => {
+          evaluated = true;
+          return "expensive computation";
+        });
+      });
+
+      expect(evaluated).toBe(false); // Not evaluated!
+    });
+
+    it("should work with all severity levels when disabled", () => {
+      const logger = getLogger(undefined, { enabled: false });
+
+      const { calls: debugCalls } = captureConsole("debug", () => {
+        logger.debug("debug");
+      });
+      const { calls: infoCalls } = captureConsole("log", () => {
+        logger.info("info");
+      });
+      const { calls: warnCalls } = captureConsole("warn", () => {
+        logger.warn("warn");
+      });
+      const { calls: errorCalls } = captureConsole("error", () => {
+        logger.error("error");
+      });
+
+      expect(debugCalls).toHaveLength(0);
+      expect(infoCalls).toHaveLength(0);
+      expect(warnCalls).toHaveLength(0);
+      expect(errorCalls).toHaveLength(0);
+    });
+
+    it("should work with URL and options parameters", () => {
+      const logger = getLogger("file:///custom/module.ts", { enabled: false });
+
+      const { calls } = captureConsole("log", () => {
+        logger.info("test");
+      });
+
+      expect(calls).toHaveLength(0);
+      expect(logger.disabled).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed array index detection in transaction-shim to use Number.isInteger, and added a minimal logger utility with module tagging and severity filtering.

- **New Features**
  - Added a logger supporting debug, info, warn, and error levels, with module name tagging and lazy evaluation.
  - Included tests covering logger behavior, severity filtering, and module tagging.

<!-- End of auto-generated description by cubic. -->

