### PR TITLE
chore: enable resource management/using polyfill in esbuild/felt

### DIFF
--- a/packages/deno-web-test/utils.ts
+++ b/packages/deno-web-test/utils.ts
@@ -51,6 +51,9 @@ export async function bundle(inputPath: string, outputPath: string) {
     plugins: [...denoPlugins()],
     entryPoints: [inputPath],
     outfile: outputPath,
+    supported: {
+      using: false,
+    },
     bundle: true,
     format: "esm",
   });

--- a/packages/felt/README.md
+++ b/packages/felt/README.md
@@ -27,6 +27,10 @@ export default {
     define: {
       "$DEBUG": Deno.env.get("DEBUG"),
     },
+    // https://esbuild.github.io/api/#supported
+    supported: {
+      using: false,
+    },
     tsconfigRaw: {
       compilerOptions: {
         useDefineForClassFields: false,

--- a/packages/felt/builder.ts
+++ b/packages/felt/builder.ts
@@ -37,6 +37,7 @@ export class Builder extends EventTarget {
       external: this.manifest.esbuild.external,
       bundle: true,
       format: "esm",
+      supported: this.manifest.esbuild.supported,
       // Explicitly compile decorators, as this what Jumble->Vite
       // does, and no browsers currently support (any form of) decorators,
       // and if we're bundling, we're probably running in a browser.

--- a/packages/felt/interface.ts
+++ b/packages/felt/interface.ts
@@ -39,6 +39,7 @@ export interface ESBuildConfig {
   // global variables in the bundled code.
   define?: Record<string, string | undefined>;
   metafile?: string;
+  supported?: Record<string, boolean>;
   tsconfigRaw: TsconfigRaw;
 }
 
@@ -57,6 +58,7 @@ export class ResolvedConfig {
     minify: boolean;
     metafile?: string;
     define: Record<string, string | undefined>;
+    supported?: Record<string, boolean>;
     tsconfigRaw?: TsconfigRaw;
   };
   cwd: string;
@@ -78,6 +80,7 @@ export class ResolvedConfig {
       metafile: partial?.esbuild?.metafile
         ? join(cwd, partial.esbuild?.metafile)
         : undefined,
+      supported: partial?.esbuild?.supported,
       tsconfigRaw: partial?.esbuild?.tsconfigRaw,
     };
   }

--- a/packages/jumble/vite.config.ts
+++ b/packages/jumble/vite.config.ts
@@ -13,6 +13,9 @@ console.log("Build source maps:", buildSourcemaps);
 // https://vite.dev/config/
 export default defineConfig({
   esbuild: {
+    supported: {
+      using: false
+    },
     tsconfigRaw: {
       compilerOptions: {
         experimentalDecorators: true,

--- a/packages/shell/felt.config.ts
+++ b/packages/shell/felt.config.ts
@@ -26,6 +26,10 @@ const config: Config = {
       "$API_URL": Deno.env.get("API_URL"),
       "$COMMIT_SHA": Deno.env.get("COMMIT_SHA"),
     },
+    supported: {
+      // Provide polyfills for `using` resource management
+      using: false,
+    },
     tsconfigRaw: {
       compilerOptions: {
         // `useDefineForClassFields` is critical when using Lit


### PR DESCRIPTION
Adds support for polyfilling the `using` keyword in esbuild inside of felt (shell) and deno-web-test and jumble's vite.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for polyfilling the `using` keyword in esbuild configs for felt and deno-web-test to enable resource management features.

- **Dependencies**
  - Updated esbuild config to set `supported.using: false` in felt, shell, and deno-web-test.

<!-- End of auto-generated description by cubic. -->

