### PR TITLE
feat(runner): change immutable cells to use data: URIs

### DIFF
--- a/packages/runner/src/builder/docs/shadowrefs-documentation.md
+++ b/packages/runner/src/builder/docs/shadowrefs-documentation.md
@@ -1,0 +1,338 @@
+# Opaque Values, Closures, and ShadowRefs Documentation
+
+## Overview
+
+This document explains how opaque values, closures, and shadowrefs work in the
+CommonTools builder system, with a focus on what should be seen in a shadowref.
+
+## Opaque Values and OpaqueRef
+
+### What are Opaque Values?
+
+Opaque values are wrapped values that represent future cells in the recipe
+system. They are created using the `opaqueRef()` function and serve as proxies
+for values that will eventually be materialized.
+
+### OpaqueRef Implementation
+
+From `packages/runner/src/builder/opaque-ref.ts`:
+
+```typescript
+export function opaqueRef<T>(
+  value?: Opaque<T> | T,
+  schema?: JSONSchema,
+): OpaqueRef<T>;
+```
+
+Key features:
+
+- **Proxy-based**: Uses JavaScript Proxy to intercept property access
+- **Nested access**: Supports deep property access (e.g., `ref.a.b.c`)
+- **Methods**: Provides `.set()`, `.get()`, `.setDefault()`, `.setName()`,
+  `.setSchema()`
+- **Frame tracking**: Each OpaqueRef is associated with a recipe frame
+- **Connection tracking**: Tracks which nodes use this ref
+
+### Internal Structure
+
+An OpaqueRef maintains:
+
+```typescript
+const store = {
+  value, // The actual value
+  defaultValue: undefined, // Default value if not set
+  nodes: new Set<NodeRef>(), // Connected nodes
+  frame: getTopFrame()!, // Recipe frame context
+  name: undefined, // Optional name
+  schema: schema, // JSON schema
+};
+```
+
+## Closures in Recipes
+
+### Recipe Closures
+
+Closures occur when recipes capture variables from their surrounding scope. This
+is particularly important for:
+
+- Map operations that use external factors
+- Lifted functions that reference outer variables
+- Computed values that depend on parent recipe context
+
+Example from tests:
+
+```typescript
+const doubleArray = recipe<{ values: number[]; factor: number }>(
+  "Double numbers",
+  ({ values, factor }) => {
+    const doubled = values.map((x) => double({ x, factor }));
+    return { doubled };
+  },
+);
+```
+
+### Unsafe Closures
+
+The system tracks "unsafe closures" - recipes that reference values from parent
+frames:
+
+- Marked with `unsafe_originalRecipe` symbol
+- Require special materialization handling
+- Must track parent recipe relationships
+
+## ShadowRefs
+
+### What is a ShadowRef?
+
+A ShadowRef is a reference to an OpaqueRef from a different (parent) frame. It
+acts as a cross-frame pointer to maintain referential integrity across recipe
+boundaries.
+
+### ShadowRef Structure
+
+From `packages/runner/src/builder/types.ts`:
+
+```typescript
+export type ShadowRef = {
+  shadowOf: OpaqueRef<any> | ShadowRef;
+};
+```
+
+### When are ShadowRefs Created?
+
+ShadowRefs are created when:
+
+1. An OpaqueRef from a parent frame is referenced in a child frame
+2. During recipe factory creation when collecting cells and nodes
+3. When connecting nodes across frame boundaries
+
+From `packages/runner/src/builder/node-utils.ts`:
+
+```typescript
+if (value.export().frame !== node.frame) return createShadowRef(value);
+```
+
+### What Should Be Seen in a ShadowRef?
+
+A ShadowRef should contain:
+
+1. **shadowOf property**: Reference to the original OpaqueRef (or another
+   ShadowRef)
+   - Points to the actual value holder
+   - Maintains the chain back to the original ref
+
+2. **Cross-frame reference**: Indicates that the referenced value exists in a
+   different recipe frame
+   - Prevents direct cross-frame mutations
+   - Ensures proper value propagation
+
+3. **Serialization format**: When serialized to JSON:
+   ```typescript
+   {
+     $alias: {
+       cell: shadowRef,  // The shadow reference itself
+       path: [...],      // Path to the value
+       schema: {...},    // Optional schema information
+       rootSchema: {...} // Optional root schema
+     }
+   }
+   ```
+
+### When are ShadowRefs Dereferenced?
+
+ShadowRefs are dereferenced in several key scenarios:
+
+#### 1. During Recipe Factory Creation
+
+From `packages/runner/src/builder/recipe.ts`:
+
+```typescript
+if (isShadowRef(value)) {
+  shadows.add(value);
+  if (
+    isOpaqueRef(value.shadowOf) &&
+    value.shadowOf.export().frame === getTopFrame()
+  ) {
+    cells.add(value.shadowOf); // Dereference to add the actual cell
+  }
+}
+```
+
+**Purpose**: When collecting cells and nodes for a recipe, shadowrefs are
+dereferenced to:
+
+- Add the actual OpaqueRef to the cells collection if it belongs to the current
+  frame
+- Ensure proper graph traversal and dependency tracking
+- Maintain the connection between shadowrefs and their target cells
+
+#### 2. During JSON Serialization
+
+From `packages/runner/src/builder/json-utils.ts`:
+
+```typescript
+if (isShadowRef(alias.cell)) {
+  const cell = alias.cell.shadowOf; // Dereference to get the actual cell
+  if (cell.export().frame !== getTopFrame()) {
+    // Frame validation logic...
+  }
+  if (!paths.has(cell)) throw new Error(`Cell not found in paths`);
+  return {
+    $alias: {
+      path: [...paths.get(cell)!, ...alias.path] as (string | number)[],
+    },
+  } satisfies LegacyAlias;
+}
+```
+
+**Purpose**: During serialization, shadowrefs are dereferenced to:
+
+- Access the actual OpaqueRef for path resolution
+- Validate frame relationships
+- Create proper alias structures with resolved paths
+- Ensure the serialized form correctly represents the cross-frame reference
+
+#### 3. During Node Connection
+
+From `packages/runner/src/builder/node-utils.ts`:
+
+```typescript
+if (isOpaqueRef(value)) {
+  // Return shadow ref if this is a parent opaque ref. Note: No need to
+  // connect to the cell. The connection is there to traverse the graph to
+  // find all other nodes, but this points to the parent graph instead.
+  if (value.export().frame !== node.frame) return createShadowRef(value);
+  value.connect(node);
+}
+```
+
+### ShadowRef Resolution During Recipe Instantiation
+
+When a recipe is instantiated and executed, shadowrefs are resolved through the
+`unsafe_materialize` mechanism. This happens when OpaqueRefs (including those
+referenced by shadowrefs) are accessed during recipe execution.
+
+#### The Resolution Process
+
+From `packages/runner/src/builder/opaque-ref.ts`:
+
+```typescript
+function unsafe_materialize(
+  binding: { recipe: Recipe; path: PropertyKey[] } | undefined,
+  path: PropertyKey[],
+) {
+  if (!binding) throw new Error("Can't read value during recipe creation.");
+
+  // Find first frame with unsafe binding
+  let frame = getTopFrame();
+  let unsafe_binding: UnsafeBinding | undefined;
+  while (frame && !unsafe_binding) {
+    unsafe_binding = frame.unsafe_binding;
+    frame = frame.parent;
+  }
+
+  // Walk up the chain until we find the original recipe
+  while (unsafe_binding && unsafe_binding.parent?.recipe === binding.recipe) {
+    unsafe_binding = unsafe_binding.parent;
+  }
+
+  if (!unsafe_binding) throw new Error("Can't find recipe in parent frames.");
+
+  return unsafe_binding.materialize([...binding.path, ...path]);
+}
+```
+
+#### How ShadowRef Resolution Works
+
+The resolution process follows this flow:
+
+1. **OpaqueRef Access**: When an OpaqueRef is accessed (via `.get()`, property
+   access, or `Symbol.toPrimitive`), it calls `unsafe_materialize`
+
+2. **Frame Traversal**: `unsafe_materialize` walks up the frame stack to find
+   the first frame with an `unsafe_binding`
+
+3. **Recipe Chain Resolution**: It then walks up the chain of
+   `unsafe_binding.parent` references until it finds the original recipe that
+   contains the shadowref
+
+4. **Materialization**: Finally, it calls
+   `unsafe_binding.materialize([...binding.path, ...path])` which resolves the
+   actual value
+
+#### Where UnsafeBinding is Set Up
+
+The `unsafe_binding` is created during recipe execution in
+`packages/runner/src/runner.ts`:
+
+```typescript
+const frame = pushFrameFromCause(
+  { inputs, outputs, fn: fn.toString() },
+  {
+    recipe,
+    materialize: (path: readonly PropertyKey[]) =>
+      processCell.getAsQueryResult(path, tx),
+    space: processCell.space,
+    tx,
+  } satisfies UnsafeBinding,
+);
+```
+
+#### ShadowRef to Real Value Conversion
+
+During this process:
+
+- **ShadowRefs** → **OpaqueRefs** → **Real Values**
+- When a shadowref is accessed, `unsafe_materialize` follows the `shadowOf`
+  chain
+- The `materialize` function uses `processCell.getAsQueryResult(path, tx)` to
+  get the actual value
+- This resolves cross-frame references by accessing the actual cell data in the
+  correct execution context
+
+#### When Resolution Occurs
+
+Shadowref resolution happens automatically when:
+
+1. **Property Access**: Accessing properties on OpaqueRefs that reference
+   shadowrefs
+2. **Value Retrieval**: Calling `.get()` on OpaqueRefs
+3. **Primitive Conversion**: When OpaqueRefs are converted to primitives (via
+   `Symbol.toPrimitive`)
+4. **Recipe Execution**: During the execution of recipes that contain shadowrefs
+
+This resolution is essential for:
+
+- **Value Access**: Converting cross-frame references into accessible values
+- **Reactivity**: Ensuring that changes to shadowrefs propagate correctly
+- **Execution Context**: Binding shadowrefs to the correct execution frame
+- **Data Flow**: Maintaining proper data flow across recipe boundaries
+
+### ShadowRef Usage in JSON Serialization
+
+From `packages/runner/src/builder/json-utils.ts`:
+
+- ShadowRefs are handled specially during serialization
+- They maintain the reference structure when converting to JSON
+- The system tracks paths to resolve shadow references correctly
+
+### Key Properties of ShadowRefs
+
+1. **Immutability**: ShadowRefs are read-only references
+2. **Frame safety**: Prevent direct cross-frame mutations
+3. **Path preservation**: Maintain the path to the original value
+4. **Type checking**: `isShadowRef()` function for runtime type checking
+
+## Summary
+
+- **OpaqueRef**: Proxy-based future value holders within a recipe frame
+- **Closures**: Captured variables requiring special handling for cross-recipe
+  references
+- **ShadowRef**: Cross-frame references that maintain referential integrity
+
+ShadowRefs should be seen as lightweight pointers that:
+
+- Reference values from parent frames
+- Prevent direct cross-frame mutations
+- Preserve the connection to the original OpaqueRef
+- Enable proper serialization and deserialization of cross-frame references

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -15,6 +15,7 @@ import {
   type Opaque,
   type OpaqueRef,
   type Recipe,
+  type toJSON,
   unsafe_originalRecipe,
 } from "./types.ts";
 import { getTopFrame } from "./recipe.ts";
@@ -107,6 +108,9 @@ export function toJSONWithLegacyAliases(
   }
 
   if (isRecord(value) || isRecipe(value)) {
+    if (isRecipe(value) && typeof (value as toJSON).toJSON === "function") {
+      value = (value as toJSON).toJSON();
+    }
     const result: any = {};
     let hasValue = false;
     for (const key in value as any) {
@@ -218,8 +222,9 @@ export function createJsonSchema(
 }
 
 export function moduleToJSON(module: Module) {
+  const { toJSON: _, ...rest } = module as Module & { toJSON: () => any };
   return {
-    ...module,
+    ...rest,
     implementation: typeof module.implementation === "function"
       ? module.implementation.toString()
       : module.implementation,

--- a/packages/runner/src/function-cache.ts
+++ b/packages/runner/src/function-cache.ts
@@ -1,0 +1,65 @@
+import type { Module } from "./builder/types.ts";
+
+/**
+ * Cache for JavaScript functions keyed by their stringified module.
+ * This allows us to avoid re-evaluating the same function strings multiple times
+ * during recipe execution.
+ */
+export class FunctionCache {
+  private cache = new Map<string, Function>();
+
+  /**
+   * Get a cached function by its module key.
+   * @param module The module to use as a cache key
+   * @returns The cached function, or undefined if not found
+   */
+  get(module: Module): Function | undefined {
+    const key = this.getKey(module);
+    return this.cache.get(key);
+  }
+
+  /**
+   * Cache a function with its module as the key.
+   * @param module The module to use as a cache key
+   * @param fn The function to cache
+   */
+  set(module: Module, fn: Function): void {
+    const key = this.getKey(module);
+    this.cache.set(key, fn);
+  }
+
+  /**
+   * Check if a function is cached for the given module.
+   * @param module The module to check
+   * @returns True if a function is cached for this module
+   */
+  has(module: Module): boolean {
+    const key = this.getKey(module);
+    return this.cache.has(key);
+  }
+
+  /**
+   * Clear all cached functions.
+   */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  /**
+   * Get the cache key for a module.
+   * Uses JSON.stringify to create a stable key from the module object.
+   * @param module The module to generate a key for
+   * @returns The cache key
+   */
+  private getKey(module: Module): string {
+    return JSON.stringify(module);
+  }
+
+  /**
+   * Get the current cache size.
+   * @returns Number of cached functions
+   */
+  get size(): number {
+    return this.cache.size;
+  }
+}

--- a/packages/runner/src/function-cache.ts
+++ b/packages/runner/src/function-cache.ts
@@ -13,7 +13,7 @@ export class FunctionCache {
    * @param module The module to use as a cache key
    * @returns The cached function, or undefined if not found
    */
-  get(module: Module): (...args: any[]) => any | undefined {
+  get(module: Module): ((...args: any[]) => any) | undefined {
     const key = this.getKey(module);
     return this.cache.get(key);
   }

--- a/packages/runner/src/function-cache.ts
+++ b/packages/runner/src/function-cache.ts
@@ -6,14 +6,14 @@ import type { Module } from "./builder/types.ts";
  * during recipe execution.
  */
 export class FunctionCache {
-  private cache = new Map<string, Function>();
+  private cache = new Map<string, (...args: any[]) => any>();
 
   /**
    * Get a cached function by its module key.
    * @param module The module to use as a cache key
    * @returns The cached function, or undefined if not found
    */
-  get(module: Module): Function | undefined {
+  get(module: Module): (...args: any[]) => any | undefined {
     const key = this.getKey(module);
     return this.cache.get(key);
   }
@@ -23,7 +23,7 @@ export class FunctionCache {
    * @param module The module to use as a cache key
    * @param fn The function to cache
    */
-  set(module: Module, fn: Function): void {
+  set(module: Module, fn: (...args: any[]) => any): void {
     const key = this.getKey(module);
     this.cache.set(key, fn);
   }

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -346,6 +346,7 @@ export function parseLink(
       type: "application/json",
       schema: alias.schema as JSONSchema | undefined,
       rootSchema: alias.rootSchema as JSONSchema | undefined,
+      overwrite: "redirect",
     };
   }
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -477,7 +477,7 @@ export class Runner implements IRunner {
           );
           this.discoverAndCacheFunctionsFromModule(referencedModule);
         } catch (error) {
-          console.warn("Failed to resolve module reference:", error);
+          console.warn(`Failed to resolve module reference for implementation "${module.implementation}":`, error);
         }
         break;
     }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -535,10 +535,16 @@ export class Runtime implements IRuntime {
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
   ): Cell<any> {
-    const doc = this.documentMap.getDoc<any>(data, { immutable: data }, space);
-    doc.freeze("immutable cell");
-    doc.ephemeral = true; // Since soon these will be data: URIs
-    return doc.asCell([], schema, undefined, tx);
+    const asDataURI = `data:application/json,${
+      encodeURIComponent(JSON.stringify({ value: data }))
+    }` as const as `${string}:${string}`;
+    return createCell(this, {
+      space,
+      path: [],
+      id: asDataURI,
+      type: "application/json",
+      schema,
+    }, tx);
   }
 
   // Convenience methods that delegate to the runner

--- a/packages/runner/src/uri-utils.ts
+++ b/packages/runner/src/uri-utils.ts
@@ -1,3 +1,4 @@
+import { refer } from "merkle-reference/json";
 import { isRecord } from "@commontools/utils/types";
 import type { URI } from "./sigil-types.ts";
 
@@ -37,6 +38,8 @@ export function fromURI(uri: URI | string): string {
     return uri;
   } else if (uri.startsWith("of:")) {
     return uri.slice(3);
+  } else if (uri.startsWith("data:")) {
+    return refer(uri).toString();
   } else {
     // TODO(seefeld): Remove this once we want to support any URI
     throw new Error(`Invalid URI: ${uri}`);

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -996,8 +996,6 @@ describe("data-updating", () => {
 
       // Write the data cell link to the target
       const changes = normalizeAndDiff(runtime, tx, current, dataCell);
-
-      console.log(changes);
       // Should write the contents of the data cell, resolving nested links
       expect(changes.length).toBe(5);
 

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -1085,7 +1085,6 @@ describe("data-updating", () => {
       dataCell.key("reference").key("value").getAsLink(),
     );
 
-    console.log(changes);
     // Should write the contents of the data cell, resolving nested links
     expect(changes.length).toBe(1);
 

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { ID, ID_FIELD } from "../src/builder/types.ts";
+import { ID, ID_FIELD, JSONSchema } from "../src/builder/types.ts";
 import {
   addCommonIDfromObjectID,
   applyChangeSet,
@@ -11,13 +11,10 @@ import { Runtime } from "../src/runtime.ts";
 import {
   areLinksSame,
   areNormalizedLinksSame,
+  createSigilLinkFromParsedLink,
   isAnyCellLink,
-  isLegacyCellLink,
-  isLegacyDocCellLink,
   parseLink,
 } from "../src/link-utils.ts";
-import type { LegacyDocCellLink } from "../src/sigil-types.ts";
-import { arrayEqual } from "../src/path-utils.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
@@ -809,6 +806,295 @@ describe("data-updating", () => {
 
       expect(changes2.length).toBe(0);
     });
+
+    it("should handle data: URI links by writing their contents", () => {
+      // Create a data cell with some content using getImmutableCell
+      // This creates a cell with an actual data: URI that should trigger the data URI handling
+      const dataCell = runtime.getImmutableCell<
+        { message: string; count: number }
+      >(
+        space,
+        { message: "Hello from data", count: 42 },
+        undefined,
+        tx,
+      );
+
+      // Create a target cell to write to
+      const targetCell = runtime.getCell<{ value: any }>(
+        space,
+        "normalizeAndDiff data URI target",
+        undefined,
+        tx,
+      );
+      targetCell.set({ value: "original" });
+
+      const current = targetCell.key("value").getAsNormalizedFullLink();
+
+      // Write the data cell link to the target
+      const changes = normalizeAndDiff(runtime, tx, current, dataCell);
+
+      // Should write the contents of the data cell, not the link itself
+      // The data URI handling writes each property individually
+      expect(changes.length).toBe(3);
+
+      // Find the changes for each property
+      const messageChange = changes.find((c) =>
+        c.location.path.includes("message")
+      );
+      const countChange = changes.find((c) =>
+        c.location.path.includes("count")
+      );
+      const objectChange = changes.find((c) => c.location.path.length === 1);
+
+      expect(messageChange).toBeDefined();
+      expect(messageChange!.value).toBe("Hello from data");
+      expect(countChange).toBeDefined();
+      expect(countChange!.value).toBe(42);
+      expect(objectChange).toBeDefined();
+      expect(objectChange!.value).toEqual({});
+    });
+
+    it("should handle data: URI links with nested paths", () => {
+      // Create a data cell with nested content using getImmutableCell
+      const dataCell = runtime.getImmutableCell<{
+        nested: {
+          deep: {
+            value: string;
+            numbers: number[];
+          };
+        };
+      }>(
+        space,
+        {
+          nested: {
+            deep: {
+              value: "nested value",
+              numbers: [1, 2, 3],
+            },
+          },
+        },
+        undefined,
+        tx,
+      );
+
+      // Create a target cell
+      const targetCell = runtime.getCell<{ result: any }>(
+        space,
+        "normalizeAndDiff data URI nested target",
+        undefined,
+        tx,
+      );
+      targetCell.set({ result: "original" });
+
+      const current = targetCell.key("result").getAsNormalizedFullLink();
+
+      // Create a link to a nested path in the data cell
+      const nestedDataLink = dataCell.key("nested").key("deep").getAsLink();
+
+      // Write the nested data link to the target
+      const changes = normalizeAndDiff(runtime, tx, current, nestedDataLink);
+
+      // Should write the contents at the nested path
+      // The data URI handling writes each property individually
+      expect(changes.length).toBe(6);
+
+      // Find the changes for each property
+      const valueChange = changes.find((c) =>
+        c.location.path.includes("value") &&
+        !c.location.path.includes("numbers")
+      );
+      const numbersArrayChange = changes.find((c) =>
+        c.location.path.length === 2 && c.location.path[1] === "numbers"
+      );
+      const numbersElements = changes.filter((c) =>
+        c.location.path.length === 3 && c.location.path[1] === "numbers"
+      );
+
+      expect(valueChange).toBeDefined();
+      expect(valueChange!.value).toBe("nested value");
+      expect(numbersArrayChange).toBeDefined();
+      expect(numbersArrayChange!.value).toEqual([]);
+      expect(numbersElements).toHaveLength(3);
+      expect(numbersElements[0].value).toBe(1);
+      expect(numbersElements[1].value).toBe(2);
+      expect(numbersElements[2].value).toBe(3);
+    });
+
+    it("should handle data: URI links that resolve to undefined", () => {
+      // Create a data cell with some content using getImmutableCell
+      const dataCell = runtime.getImmutableCell<{ exists: string }>(
+        space,
+        { exists: "this exists" },
+        undefined,
+        tx,
+      );
+
+      // Create a target cell
+      const targetCell = runtime.getCell<{ value: any }>(
+        space,
+        "normalizeAndDiff data URI undefined target",
+        undefined,
+        tx,
+      );
+      targetCell.set({ value: "original" });
+
+      const current = targetCell.key("value").getAsNormalizedFullLink();
+
+      // Create a link to a non-existent path in the data cell
+      // Use getAsLink() directly on the cell and then manually construct the path
+      const dataLink = dataCell.getAsLink();
+      const nonExistentLink = createSigilLinkFromParsedLink({
+        ...parseLink(dataLink),
+        path: ["doesNotExist"],
+      });
+
+      // Write the non-existent data link to the target
+      const changes = normalizeAndDiff(runtime, tx, current, nonExistentLink);
+
+      // Should write undefined since the path doesn't exist
+      expect(changes.length).toBe(1);
+      expect(changes[0].location).toEqual(current);
+      expect(changes[0].value).toBeUndefined();
+    });
+
+    it("should handle data: URI links that contain nested links", () => {
+      // Create a regular cell that will be referenced
+      const referencedCell = runtime.getCell<{ name: string; value: number }>(
+        space,
+        "data URI nested link referenced",
+        undefined,
+        tx,
+      );
+      referencedCell.set({ name: "Referenced Cell", value: 100 });
+
+      // Create a data cell that contains a link to the referenced cell
+      const dataCell = runtime.getImmutableCell<{
+        title: string;
+        reference: any;
+        metadata: { description: string };
+      }>(
+        space,
+        {
+          title: "Data with Link",
+          reference: referencedCell.getAsLink(),
+          metadata: { description: "Contains a nested link" },
+        },
+        undefined,
+        tx,
+      );
+
+      // Create a target cell to write to
+      const targetCell = runtime.getCell<{ result: any }>(
+        space,
+        "normalizeAndDiff data URI nested link target",
+        undefined,
+        tx,
+      );
+      targetCell.set({ result: "original" });
+
+      const current = targetCell.key("result").getAsNormalizedFullLink();
+
+      // Write the data cell link to the target
+      const changes = normalizeAndDiff(runtime, tx, current, dataCell);
+
+      console.log(changes);
+      // Should write the contents of the data cell, resolving nested links
+      expect(changes.length).toBe(5);
+
+      // Find the changes for each property
+      const titleChange = changes.find((c) =>
+        c.location.path.includes("title")
+      );
+      const referenceChange = changes.find((c) =>
+        c.location.path.includes("reference")
+      );
+      const metadataChange = changes.find((c) =>
+        c.location.path.length === 3 &&
+        c.location.path[1] === "metadata" &&
+        c.location.path[2] === "description"
+      );
+      const objectChange = changes.find((c) => c.location.path.length === 1);
+
+      expect(titleChange).toBeDefined();
+      expect(titleChange!.value).toBe("Data with Link");
+      expect(referenceChange).toBeDefined();
+      // The reference should be resolved to the actual cell link
+      expect(isAnyCellLink(referenceChange!.value)).toBe(true);
+      expect(metadataChange).toBeDefined();
+      expect(metadataChange!.value).toEqual("Contains a nested link");
+      expect(objectChange).toBeDefined();
+      expect(objectChange!.value).toEqual({});
+
+      applyChangeSet(tx, changes);
+
+      const value = targetCell.get();
+      expect(value.result).toEqual({
+        title: "Data with Link",
+        reference: { name: "Referenced Cell", value: 100 },
+        metadata: { description: "Contains a nested link" },
+      });
+    });
+  });
+
+  it("should handle data: URI links that contain nested links and references go through it", () => {
+    // Create a regular cell that will be referenced
+    const referencedCell = runtime.getCell(
+      space,
+      "data URI nested link referenced",
+      {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          nested: { type: "object", properties: { value: { type: "number" } } },
+        },
+      } as const satisfies JSONSchema,
+      tx,
+    );
+    referencedCell.set({ name: "Referenced Cell", nested: { value: 100 } });
+
+    // Create a data cell that contains a link to the referenced cell
+    const dataCell = runtime.getImmutableCell<{
+      title: string;
+      reference: any;
+      metadata: { description: string };
+    }>(
+      space,
+      {
+        title: "Data with Link",
+        reference: referencedCell.key("nested").getAsLink(),
+        metadata: { description: "Contains a nested link" },
+      },
+      undefined,
+      tx,
+    );
+
+    // Create a target cell to write to
+    const targetCell = runtime.getCell<{ result: any }>(
+      space,
+      "normalizeAndDiff data URI nested link target",
+      undefined,
+      tx,
+    );
+    targetCell.set({ result: "original" });
+
+    const current = targetCell.key("result").getAsNormalizedFullLink();
+
+    // Write the data cell link to the target
+    const changes = normalizeAndDiff(
+      runtime,
+      tx,
+      current,
+      dataCell.key("reference").key("value").getAsLink(),
+    );
+
+    console.log(changes);
+    // Should write the contents of the data cell, resolving nested links
+    expect(changes.length).toBe(1);
+
+    applyChangeSet(tx, changes);
+
+    const value = targetCell.get();
+    expect(value.result).toBe(100);
   });
 
   describe("addCommonIDfromObjectID", () => {

--- a/packages/runner/test/function-cache.test.ts
+++ b/packages/runner/test/function-cache.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { FunctionCache } from "../src/function-cache.ts";
+import type { Module } from "../src/builder/types.ts";
+
+describe("FunctionCache", () => {
+  it("should cache and retrieve functions by module", () => {
+    const cache = new FunctionCache();
+    const module: Module = {
+      type: "javascript",
+      implementation: "() => 42",
+    };
+    const fn = () => 42;
+
+    cache.set(module, fn);
+    expect(cache.get(module)).toBe(fn);
+    expect(cache.has(module)).toBe(true);
+    expect(cache.size).toBe(1);
+  });
+
+  it("should use JSON.stringify for cache keys", () => {
+    const cache = new FunctionCache();
+    const module1: Module = {
+      type: "javascript",
+      implementation: "() => 1",
+    };
+    const module2: Module = {
+      type: "javascript",
+      implementation: "() => 1", // Same content
+    };
+    const fn = () => 1;
+
+    cache.set(module1, fn);
+    expect(cache.get(module2)).toBe(fn); // Should retrieve the same function
+  });
+
+  it("should overwrite functions with the same module key", () => {
+    const cache = new FunctionCache();
+    const module: Module = {
+      type: "javascript",
+      implementation: "() => 1",
+    };
+    const fn1 = () => 1;
+    const fn2 = () => 2;
+
+    cache.set(module, fn1);
+    expect(cache.get(module)).toBe(fn1);
+
+    cache.set(module, fn2);
+    expect(cache.get(module)).toBe(fn2);
+    expect(cache.size).toBe(1);
+  });
+
+  it("should differentiate modules with different properties", () => {
+    const cache = new FunctionCache();
+    const module1: Module = {
+      type: "javascript",
+      implementation: "() => 1",
+    };
+    const module2: Module = {
+      type: "javascript",
+      implementation: "() => 1",
+      wrapper: "handler",
+    };
+    const fn1 = () => 1;
+    const fn2 = () => 2;
+
+    cache.set(module1, fn1);
+    cache.set(module2, fn2);
+
+    expect(cache.get(module1)).toBe(fn1);
+    expect(cache.get(module2)).toBe(fn2);
+    expect(cache.size).toBe(2);
+  });
+
+  it("should clear all cached functions", () => {
+    const cache = new FunctionCache();
+    const module1: Module = {
+      type: "javascript",
+      implementation: "() => 1",
+    };
+    const module2: Module = {
+      type: "javascript",
+      implementation: "() => 2",
+    };
+
+    cache.set(module1, () => 1);
+    cache.set(module2, () => 2);
+    expect(cache.size).toBe(2);
+
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.has(module1)).toBe(false);
+    expect(cache.has(module2)).toBe(false);
+  });
+
+  it("should return undefined for non-cached modules", () => {
+    const cache = new FunctionCache();
+    const module: Module = {
+      type: "javascript",
+      implementation: "() => 1",
+    };
+
+    expect(cache.get(module)).toBeUndefined();
+    expect(cache.has(module)).toBe(false);
+  });
+});

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -400,6 +400,7 @@ describe("link-utils", () => {
         type: "application/json",
         schema: { type: "number" },
         rootSchema: { type: "object" },
+        overwrite: "redirect",
       });
     });
 
@@ -419,6 +420,7 @@ describe("link-utils", () => {
         space: space,
         schema: undefined,
         rootSchema: undefined,
+        overwrite: "redirect",
       });
     });
 


### PR DESCRIPTION
Also requires preserving functions through serialization

- Convert immutable cells to data URIs
- Add FunctionCache class to avoid re-evaluating JavaScript functions
- Fix ShadowRefs leaking into runner via .toJSON in serialization
- Improve data link resolution with proper path handling
- Update link parsing to support redirect overwrites
- Enhance URI utilities to handle data URI references

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Immutable cells now use data: URIs for storage and linking, allowing their contents to be inlined and resolved directly. JavaScript functions are now cached to avoid repeated evaluation, and data link resolution has improved path handling.

- **New Features**
  - Immutable cells are serialized as data: URIs.
  - Added a FunctionCache to store and reuse JavaScript functions.
  - Data link resolution now supports nested paths and proper redirect handling.
  - URI utilities and link parsing updated to handle data: URIs and redirect overwrites.

- **Bug Fixes**
  - Fixed ShadowRefs leaking into the runner during serialization.
  - Improved test coverage for data: URI handling and link resolution.

<!-- End of auto-generated description by cubic. -->

