### PR TITLE
feat(runner): Switch scheduler to new storage updates and reactive dependencies

### DIFF
--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -140,7 +140,7 @@ export function createQueryResultProxy<T>(
               createQueryResultProxy(
                 runtime,
                 tx,
-                { ...link, path: [...link.path, index] },
+                { ...link, path: [...link.path, String(index)] },
                 depth + 1,
               )
             );
@@ -160,7 +160,7 @@ export function createQueryResultProxy<T>(
                   runtime,
                   tx,
                   index,
-                  { ...link, path: [...link.path, index] },
+                  { ...link, path: [...link.path, String(index)] },
                 )
               );
             }

--- a/packages/runner/src/reactive-dependencies.ts
+++ b/packages/runner/src/reactive-dependencies.ts
@@ -7,8 +7,9 @@ import type {
   MemoryAddressPathComponent,
 } from "./storage/interface.ts";
 
-export type TriggerPaths = MemoryAddressPathComponent[][];
-export type SortedAndCompactPaths = MemoryAddressPathComponent[][];
+export type SortedAndCompactPaths = Array<
+  readonly MemoryAddressPathComponent[]
+>;
 
 type Keyable = Record<MemoryAddressPathComponent, JSONValue | undefined>;
 
@@ -59,18 +60,18 @@ export function sortAndCompactPaths(
 /**
  * Converts a list of paths to a map of space/id to paths.
  *
- * @param paths - The paths to convert.
+ * @param addresses - The paths to convert.
  * @returns A map of space/id to paths.
  */
-export function pathsToMapByEntity(
-  paths: IMemorySpaceAddress[],
-): Map<SpaceAndURI, IMemorySpaceAddress[]> {
-  const map = new Map<SpaceAndURI, IMemorySpaceAddress[]>();
-  for (const path of paths) {
-    if (path.type !== "application/json") continue;
-    const key: SpaceAndURI = `${path.space}/${path.id}`;
+export function addresssesToPathByEntity(
+  addresses: IMemorySpaceAddress[],
+): Map<SpaceAndURI, SortedAndCompactPaths> {
+  const map = new Map<SpaceAndURI, SortedAndCompactPaths>();
+  for (const address of addresses) {
+    if (address.type !== "application/json") continue;
+    const key: SpaceAndURI = `${address.space}/${address.id}`;
     if (!map.has(key)) map.set(key, []);
-    map.get(key)!.push(path);
+    map.get(key)!.push(address.path);
   }
   return map;
 }
@@ -125,7 +126,7 @@ export function determineTriggeredActions(
   subscribers.sort((a, b) => comparePaths(b.paths[0], a.paths[0]));
 
   // Traversal state:
-  let currentPath: string[] = [];
+  let currentPath: readonly MemoryAddressPathComponent[] = [];
 
   // *Values: An array of data values along currentPath
   const beforeValues: (JSONValue | undefined)[] = [before];

--- a/packages/runner/src/reactive-dependencies.ts
+++ b/packages/runner/src/reactive-dependencies.ts
@@ -92,7 +92,7 @@ export function determineTriggeredActions(
   dependencies: Map<Action, SortedAndCompactPaths>,
   before: JSONValue | undefined,
   after: JSONValue | undefined,
-  startPath: MemoryAddressPathComponent[] = [],
+  startPath: readonly MemoryAddressPathComponent[] = [],
 ): Action[] {
   const triggeredActions: Action[] = [];
 

--- a/packages/runner/src/reactive-dependencies.ts
+++ b/packages/runner/src/reactive-dependencies.ts
@@ -48,7 +48,8 @@ export function sortAndCompactPaths(
       sorted[i].space !== previous.space ||
       sorted[i].id !== previous.id ||
       sorted[i].type !== previous.type ||
-      !startsWith(sorted[i].path, previous.path)
+      // Is the previous path a prefix of the current path?
+      !previous.path.every((value, index) => value === sorted[i].path[index])
     ) {
       result.push(sorted[i]);
       previous = sorted[i];
@@ -112,7 +113,7 @@ export function determineTriggeredActions(
     // include those that start with that path.
     subscribers = subscribers.map(({ action, paths }) => ({
       action,
-      paths: paths.filter((path) => startsWith(path, startPath)),
+      paths: paths.filter((path) => arraysOverlap(path, startPath)),
     })).filter(({ paths }) => paths.length > 0);
 
     // And prepend path to data, so we don't have to special case this.
@@ -196,11 +197,13 @@ export function determineTriggeredActions(
   return triggeredActions;
 }
 
-function startsWith(
-  path: readonly MemoryAddressPathComponent[],
-  prefix: readonly MemoryAddressPathComponent[],
+export function arraysOverlap(
+  a: readonly MemoryAddressPathComponent[],
+  b: readonly MemoryAddressPathComponent[],
 ): boolean {
-  return prefix.every((value, index) => value === path[index]);
+  return (a.length > b.length)
+    ? b.every((value, index) => value === a[index])
+    : a.every((value, index) => value === b[index]);
 }
 
 function commonPrefixLength(

--- a/packages/runner/src/reactive-dependencies.ts
+++ b/packages/runner/src/reactive-dependencies.ts
@@ -64,7 +64,7 @@ export function sortAndCompactPaths(
  * @param addresses - The paths to convert.
  * @returns A map of space/id to paths.
  */
-export function addresssesToPathByEntity(
+export function addressesToPathByEntity(
   addresses: IMemorySpaceAddress[],
 ): Map<SpaceAndURI, SortedAndCompactPaths> {
   const map = new Map<SpaceAndURI, SortedAndCompactPaths>();

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -27,7 +27,7 @@ import type {
   Metadata,
 } from "./storage/interface.ts";
 import {
-  addresssesToPathByEntity,
+  addressesToPathByEntity,
   arraysOverlap,
   determineTriggeredActions,
   sortAndCompactPaths,
@@ -147,7 +147,7 @@ export class Scheduler implements IScheduler {
 
   subscribe(action: Action, log: ReactivityLog): Cancel {
     const reads = this.setDependencies(action, log);
-    const pathsByEntity = addresssesToPathByEntity(reads);
+    const pathsByEntity = addressesToPathByEntity(reads);
     const entities = new Set<SpaceAndURI>();
 
     for (const [spaceAndURI, paths] of pathsByEntity) {

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -22,8 +22,15 @@ import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
   IStorageSubscription,
+  MediaType,
   Metadata,
 } from "./storage/interface.ts";
+import {
+  addresssesToPathByEntity,
+  determineTriggeredActions,
+  sortAndCompactPaths,
+  type SortedAndCompactPaths,
+} from "./reactive-dependencies.ts";
 
 // Re-export types that tests expect from scheduler
 export type { ErrorWithContext };
@@ -51,6 +58,7 @@ export const ignoreReadForScheduling: Metadata = {
 };
 
 export type SpaceAndURI = `${MemorySpace}/${URI}`;
+export type SpaceURIAndType = `${MemorySpace}/${URI}/${MediaType}`;
 
 const MAX_ITERATIONS_PER_RUN = 100;
 
@@ -58,9 +66,11 @@ export class Scheduler implements IScheduler {
   private pending = new Set<Action>();
   private eventQueue: (() => any)[] = [];
   private eventHandlers: [NormalizedFullLink, EventHandler][] = [];
-  private dirty = new Set<SpaceAndURI>();
+  private dirty = new Set<SpaceURIAndType>();
   private dependencies = new WeakMap<Action, ReactivityLog>();
-  private cancels = new WeakMap<Action, Cancel[]>();
+  private cancels = new WeakMap<Action, Cancel>();
+  private triggers = new Map<SpaceAndURI, Map<Action, SortedAndCompactPaths>>();
+
   private idlePromises: (() => void)[] = [];
   private loopCounter = new WeakMap<Action, number>();
   private errorHandlers = new Set<ErrorHandler>();
@@ -127,7 +137,7 @@ export class Scheduler implements IScheduler {
   }
 
   unschedule(action: Action): void {
-    this.cancels.get(action)?.forEach((cancel) => cancel());
+    this.cancels.get(action)?.();
     this.cancels.delete(action);
     this.dependencies.delete(action);
     this.pending.delete(action);
@@ -135,26 +145,22 @@ export class Scheduler implements IScheduler {
 
   subscribe(action: Action, log: ReactivityLog): Cancel {
     const reads = this.setDependencies(action, log);
-    // Use runtime to get docs and call .updates
-    this.cancels.set(
-      action,
-      reads.filter((addr) => !addr.id.startsWith("data:")).map((addr) => {
-        const doc = this.runtime.documentMap.getDocByEntityId(
-          addr.space,
-          addr.id,
-          true,
-        );
-        return doc.updates(
-          (_newValue: any, changedPath: readonly PropertyKey[]) => {
-            if (pathAffected(changedPath, addr.path)) {
-              this.dirty.add(`${addr.space}/${addr.id}/${addr.type}`);
-              this.queueExecution();
-              this.pending.add(action);
-            }
-          },
-        );
-      }),
-    );
+    const pathsByEntity = addresssesToPathByEntity(reads);
+    const entities = new Set<SpaceAndURI>();
+
+    for (const [spaceAndURI, paths] of pathsByEntity) {
+      entities.add(spaceAndURI);
+      if (!this.triggers.has(spaceAndURI)) {
+        this.triggers.set(spaceAndURI, new Map());
+      }
+      this.triggers.get(spaceAndURI)!.set(action, paths);
+    }
+    this.cancels.set(action, () => {
+      for (const spaceAndURI of entities) {
+        this.triggers.get(spaceAndURI)?.delete(action);
+      }
+    });
+
     return () => this.unschedule(action);
   }
 
@@ -244,8 +250,29 @@ export class Scheduler implements IScheduler {
    */
   private createStorageSubscription(): IStorageSubscription {
     return {
-      next(_notification) {
-        // TODO(seefeld): Implement this
+      next: (notification) => {
+        const space = notification.space;
+        if ("changes" in notification) {
+          for (const change of notification.changes) {
+            if (change.address.type !== "application/json") continue;
+            const spaceAndURI = `${space}/${change.address.id}` as SpaceAndURI;
+            const paths = this.triggers.get(spaceAndURI);
+            if (paths) {
+              const triggeredActions = determineTriggeredActions(
+                paths,
+                change.before,
+                change.after,
+              );
+              for (const action of triggeredActions) {
+                this.dirty.add(
+                  `${spaceAndURI}/${change.address.type}` as SpaceURIAndType,
+                );
+                this.queueExecution();
+                this.pending.add(action);
+              }
+            }
+          }
+        }
         return { done: false };
       },
     } satisfies IStorageSubscription;
@@ -261,8 +288,8 @@ export class Scheduler implements IScheduler {
     action: Action,
     log: ReactivityLog,
   ): IMemorySpaceAddress[] {
-    const reads = compactifyPaths(log.reads);
-    const writes = compactifyPaths(log.writes);
+    const reads = sortAndCompactPaths(log.reads);
+    const writes = sortAndCompactPaths(log.writes);
     this.dependencies.set(action, { reads, writes });
     return reads;
   }
@@ -321,7 +348,7 @@ export class Scheduler implements IScheduler {
     this.pending.clear();
     this.dirty.clear();
     for (const fn of order) {
-      this.cancels.get(fn)?.forEach((cancel) => cancel());
+      this.cancels.get(fn)?.();
     }
 
     // Now run all functions. This will create new listeners to mark docs dirty
@@ -496,43 +523,6 @@ export function txToReactivityLog(
     }
   }
   return log;
-}
-
-// Remove longer paths already covered by shorter paths
-export function compactifyPaths(
-  entries: IMemorySpaceAddress[],
-): IMemorySpaceAddress[] {
-  // Group by space+id
-  const idToPaths = new Map<
-    SpaceAndURI,
-    { paths: (string[])[]; space: MemorySpace; id: URI }
-  >();
-  for (const entry of entries) {
-    const key = `${entry.space}:${entry.id}` as SpaceAndURI;
-    const paths = idToPaths.get(key)?.paths || [];
-    paths.push(entry.path.map((k: string | number) => k.toString()));
-    idToPaths.set(key, { paths, space: entry.space, id: entry.id });
-  }
-
-  // For each cell, sort the paths by length, then only return those that don't
-  // have a prefix earlier in the list
-  const result: IMemorySpaceAddress[] = [];
-  for (const { paths, space, id } of idToPaths.values()) {
-    paths.sort((a, b) => a.length - b.length);
-    for (let i = 0; i < paths.length; i++) {
-      const earlier = paths.slice(0, i);
-      if (earlier.some((path) => path.every((k, idx) => k === paths[i][idx]))) {
-        continue;
-      }
-      result.push({
-        space: space as any,
-        id: id as any,
-        type: "application/json",
-        path: paths[i],
-      });
-    }
-  }
-  return result;
 }
 
 function pathAffected(

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -741,7 +741,7 @@ export interface IMemorySpaceAddress extends IMemoryAddress {
   space: MemorySpace;
 }
 
-export type MemoryAddressPathComponent = string | number;
+export type MemoryAddressPathComponent = string;
 
 export interface Assert {
   the: MediaType;

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -28,6 +28,7 @@ export type {
   Fact,
   IClaim,
   JSONValue,
+  MediaType,
   MemorySpace,
   Result,
   SchemaContext,

--- a/packages/runner/test/reactive-dependencies.test.ts
+++ b/packages/runner/test/reactive-dependencies.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
-  addresssesToPathByEntity,
+  addressesToPathByEntity,
   arraysOverlap,
   determineTriggeredActions,
   sortAndCompactPaths,
@@ -70,11 +70,17 @@ describe("arraysOverlap", () => {
 
   it("handles arrays of different lengths correctly", () => {
     // Shorter array is prefix of longer
-    expect(arraysOverlap(["users"], ["users", "123", "profile", "name"])).toBe(true);
-    expect(arraysOverlap(["users", "123"], ["users", "123", "profile"])).toBe(true);
-    
+    expect(arraysOverlap(["users"], ["users", "123", "profile", "name"])).toBe(
+      true,
+    );
+    expect(arraysOverlap(["users", "123"], ["users", "123", "profile"])).toBe(
+      true,
+    );
+
     // Longer array is not prefix of shorter when they differ
-    expect(arraysOverlap(["users", "123", "profile"], ["users", "456"])).toBe(false);
+    expect(arraysOverlap(["users", "123", "profile"], ["users", "456"])).toBe(
+      false,
+    );
   });
 
   it("works with numeric strings", () => {
@@ -87,7 +93,7 @@ describe("arraysOverlap", () => {
     // One empty array
     expect(arraysOverlap([], ["a"])).toBe(true);
     expect(arraysOverlap(["a"], [])).toBe(true);
-    
+
     // Arrays with undefined or null (if they can occur)
     expect(arraysOverlap(["a", "b"], ["a", "b", "c"])).toBe(true);
   });
@@ -323,7 +329,7 @@ describe("sortAndCompactPaths", () => {
 
 describe("addresssesToPathByEntity", () => {
   it("returns empty map for empty input", () => {
-    const result = addresssesToPathByEntity([]);
+    const result = addressesToPathByEntity([]);
     expect(result.size).toBe(0);
   });
 
@@ -355,7 +361,7 @@ describe("addresssesToPathByEntity", () => {
       ),
     ];
 
-    const result = addresssesToPathByEntity(addresses);
+    const result = addressesToPathByEntity(addresses);
 
     expect(result.size).toBe(3);
     expect(
@@ -416,7 +422,7 @@ describe("addresssesToPathByEntity", () => {
       ),
     ];
 
-    const result = addresssesToPathByEntity(addresses);
+    const result = addressesToPathByEntity(addresses);
 
     expect(result.size).toBe(2);
 
@@ -455,7 +461,7 @@ describe("addresssesToPathByEntity", () => {
       ),
     ];
 
-    const result = addresssesToPathByEntity(addresses);
+    const result = addressesToPathByEntity(addresses);
 
     const paths = result.get(
       "did:test:space1/https://example.com/entity1" as SpaceAndURI,
@@ -519,7 +525,7 @@ describe("addresssesToPathByEntity", () => {
       ),
     ];
 
-    const result = addresssesToPathByEntity(addresses);
+    const result = addressesToPathByEntity(addresses);
 
     expect(result.size).toBe(4);
 
@@ -939,24 +945,24 @@ describe("determineTriggeredActions", () => {
       const action2 = createAction("action2");
       const action3 = createAction("action3");
       const dependencies = new Map<Action, SortedAndCompactPaths>([
-        [action1, [["users"]]],  // Shorter than startPath
-        [action2, [["users", "123"]]],  // Same length as startPath
-        [action3, [["users", "123", "profile"]]],  // Longer than startPath
+        [action1, [["users"]]], // Shorter than startPath
+        [action2, [["users", "123"]]], // Same length as startPath
+        [action3, [["users", "123", "profile"]]], // Longer than startPath
       ]);
 
       const result = determineTriggeredActions(
         dependencies,
-        { 
+        {
           profile: { name: "Alice" },
-          settings: { theme: "dark" }
+          settings: { theme: "dark" },
         },
-        { 
-          profile: { name: "Alice Updated" },  // Changed
-          settings: { theme: "dark" }
+        {
+          profile: { name: "Alice Updated" }, // Changed
+          settings: { theme: "dark" },
         },
         ["users", "123"],
       );
-      
+
       // All three actions should trigger because:
       // - action1 watches ["users"] which is a parent of the startPath
       // - action2 watches ["users", "123"] which matches the startPath
@@ -977,27 +983,27 @@ describe("determineTriggeredActions", () => {
 
       const result = determineTriggeredActions(
         dependencies,
-        { 
-          a: { 
-            b: { 
-              c: { 
-                d: "old value" 
-              } 
-            } 
-          } 
+        {
+          a: {
+            b: {
+              c: {
+                d: "old value",
+              },
+            },
+          },
         },
-        { 
-          a: { 
-            b: { 
-              c: { 
-                d: "new value" 
-              } 
-            } 
-          } 
+        {
+          a: {
+            b: {
+              c: {
+                d: "new value",
+              },
+            },
+          },
         },
-        ["a", "b", "c", "d"],  // StartPath is deeper than any dependency
+        ["a", "b", "c", "d"], // StartPath is deeper than any dependency
       );
-      
+
       // Both actions should trigger because they watch ancestor paths
       expect(result).toContain(action1);
       expect(result).toContain(action2);
@@ -1497,17 +1503,17 @@ describe("determineTriggeredActions", () => {
 
       const result = determineTriggeredActions(
         dependencies,
-        { 
-          data: { 
-            items: [1, 2, 3], 
-            tags: ["red", "blue"] 
-          } 
+        {
+          data: {
+            items: [1, 2, 3],
+            tags: ["red", "blue"],
+          },
         },
-        { 
-          data: { 
-            items: [1, 2, 3], 
-            tags: ["red", "green"] 
-          } 
+        {
+          data: {
+            items: [1, 2, 3],
+            tags: ["red", "green"],
+          },
         },
       );
       expect(result).toEqual([action2]); // only tags changed

--- a/packages/runner/test/scheduler.test.ts
+++ b/packages/runner/test/scheduler.test.ts
@@ -3,8 +3,11 @@ import { expect } from "@std/expect";
 import { assertSpyCall, assertSpyCalls, spy } from "@std/testing/mock";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { Runtime } from "../src/runtime.ts";
-import { type Action, type EventHandler } from "../src/scheduler.ts";
-import { ignoreReadForScheduling } from "../src/scheduler.ts";
+import {
+  type Action,
+  type EventHandler,
+  ignoreReadForScheduling,
+} from "../src/scheduler.ts";
 import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 

--- a/packages/runner/test/scheduler.test.ts
+++ b/packages/runner/test/scheduler.test.ts
@@ -4,7 +4,7 @@ import { assertSpyCall, assertSpyCalls, spy } from "@std/testing/mock";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { Runtime } from "../src/runtime.ts";
 import { type Action, type EventHandler } from "../src/scheduler.ts";
-import { compactifyPaths, ignoreReadForScheduling } from "../src/scheduler.ts";
+import { ignoreReadForScheduling } from "../src/scheduler.ts";
 import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 
@@ -657,110 +657,5 @@ describe("event handling", () => {
     expect(eventResultCell.get()).toBe(2);
     expect(actionCount).toBe(3);
     expect(lastEventSeen).toBe(2);
-  });
-});
-
-describe("compactifyPaths", () => {
-  let storageManager: ReturnType<typeof StorageManager.emulate>;
-  let runtime: Runtime;
-  let tx: IExtendedStorageTransaction;
-
-  beforeEach(() => {
-    storageManager = StorageManager.emulate({ as: signer });
-    // Create runtime with the shared storage provider
-    // We need to bypass the URL-based configuration for this test
-    runtime = new Runtime({
-      blobbyServerUrl: import.meta.url,
-      storageManager,
-    });
-    tx = runtime.edit();
-  });
-
-  afterEach(async () => {
-    await tx.commit();
-    await runtime?.dispose();
-    await storageManager?.close();
-  });
-
-  it("should compactify paths", () => {
-    const testCell = runtime.getCell<Record<string, any>>(
-      space,
-      "should compactify paths 1",
-      undefined,
-      tx,
-    );
-    testCell.set({});
-    const paths = [
-      testCell.key("a").key("b").getAsNormalizedFullLink(),
-      testCell.key("a").getAsNormalizedFullLink(),
-      testCell.key("c").getAsNormalizedFullLink(),
-    ];
-    const result = compactifyPaths(paths);
-    const expected = [
-      testCell.key("a").getAsNormalizedFullLink(),
-      testCell.key("c").getAsNormalizedFullLink(),
-    ];
-    expect(result).toEqual(expected);
-  });
-
-  it("should remove duplicate paths", () => {
-    const testCell = runtime.getCell<Record<string, any>>(
-      space,
-      "should remove duplicate paths 1",
-      undefined,
-      tx,
-    );
-    testCell.set({});
-    const paths = [
-      testCell.key("a").key("b").getAsNormalizedFullLink(),
-      testCell.key("a").key("b").getAsNormalizedFullLink(),
-    ];
-    const result = compactifyPaths(paths);
-    const expected = [testCell.key("a").key("b").getAsNormalizedFullLink()];
-    expect(result).toEqual(expected);
-  });
-
-  it("should not compactify across cells", () => {
-    const cellA = runtime.getCell<Record<string, any>>(
-      space,
-      "should not compactify across cells 1",
-      undefined,
-      tx,
-    );
-    cellA.set({});
-    const cellB = runtime.getCell<Record<string, any>>(
-      space,
-      "should not compactify across cells 2",
-      undefined,
-      tx,
-    );
-    cellB.set({});
-    const paths = [
-      cellA.key("a").key("b").getAsNormalizedFullLink(),
-      cellB.key("a").key("b").getAsNormalizedFullLink(),
-    ];
-    const result = compactifyPaths(paths);
-    expect(result).toEqual(paths);
-  });
-
-  it("empty paths should trump all other ones", () => {
-    const cellA = runtime.getCell<Record<string, any>>(
-      space,
-      "should remove duplicate paths 1",
-      undefined,
-      tx,
-    );
-    cellA.set({});
-
-    const expectedResult = cellA.getAsNormalizedFullLink();
-    const paths = [
-      cellA.key("a").key("b").getAsNormalizedFullLink(),
-      cellA.key("c").getAsNormalizedFullLink(),
-      cellA.key("d").getAsNormalizedFullLink(),
-      expectedResult,
-    ];
-    const result = compactifyPaths(paths);
-
-    expect(result).toEqual([expectedResult]);
   });
 });

--- a/packages/runner/test/schema.test.ts
+++ b/packages/runner/test/schema.test.ts
@@ -8,7 +8,8 @@ import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 import { toURI } from "../src/uri-utils.ts";
 import { parseLink, sanitizeSchemaForLinks } from "../src/link-utils.ts";
-import { compactifyPaths, txToReactivityLog } from "../src/scheduler.ts";
+import { txToReactivityLog } from "../src/scheduler.ts";
+import { sortAndCompactPaths } from "../src/reactive-dependencies.ts";
 import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
@@ -346,7 +347,7 @@ describe("Schema Support", () => {
         rootSchema: sanitizeSchemaForLinks(schema),
       });
       const log = txToReactivityLog(tx2);
-      const reads = compactifyPaths(log.reads);
+      const reads = sortAndCompactPaths(log.reads);
       expect(reads.length).toEqual(3);
       expect(
         reads.map((r: IMemorySpaceAddress) => ({ id: r.id, path: r.path }))


### PR DESCRIPTION
Refactor the scheduler to use the new storage notifications API instead of per-document update callbacks. This provides a more efficient and unified approach to tracking changes across the memory space.

- Replace document.updates() with IStorageSubscription notifications
- Migrate from per-document callbacks to centralized change handling
- Update reactive dependencies to use IMemorySpaceAddress throughout
- Add addressesToPathByEntity() utility for path organization
- Improve path-based change detection with proper prefix matching
- Fix edge cases where startPath is longer than triggering paths
- Add comprehensive tests for literal values and complex scenarios

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Refactored the scheduler to use the new storage notifications API and updated reactive dependency tracking for better efficiency and accuracy across memory spaces.

- **Refactors**
  - Replaced per-document update callbacks with centralized storage notifications.
  - Updated dependency tracking to use IMemorySpaceAddress and improved path compaction and overlap detection.
  - Fixed edge cases where dependency paths and triggering paths differ in length.
  - Added addressesToPathByEntity utility and comprehensive tests for literal and complex value scenarios.

<!-- End of auto-generated description by cubic. -->

