### PR TITLE
Adding `ct charm rm <id>` cli call, along with CharmsController remove interface

### DIFF
--- a/packages/charm/src/ops/charms-controller.ts
+++ b/packages/charm/src/ops/charms-controller.ts
@@ -44,6 +44,18 @@ export class CharmsController {
     return charms.map((charm) => new CharmController(this.#manager, charm));
   }
 
+  async remove(charmId: string): Promise<boolean> {
+    this.disposeCheck();
+    const removed = await this.#manager.remove(charmId);
+    // Empty trash and ensure full synchronization
+    if (removed) {
+      await this.#manager.emptyTrash();
+      await this.#manager.runtime.idle();
+      await this.#manager.synced();
+    }
+    return removed;
+  }
+
   async dispose() {
     this.disposeCheck();
     this.#disposed = true;

--- a/packages/cli/commands/charm.ts
+++ b/packages/cli/commands/charm.ts
@@ -13,6 +13,7 @@ import {
   listCharms,
   MapFormat,
   newCharm,
+  removeCharm,
   saveCharmRecipe,
   setCellValue,
   setCharmRecipe,
@@ -390,7 +391,8 @@ Recipe: ${charmData.recipeName || "<no recipe name>"}
   )
   .example(
     `ct charm call ${EX_ID} ${EX_COMP_CHARM} setName '{"value":"My Name"}'`,
-    `Call the "setName" handler with arguments on charm "${RAW_EX_COMP.charm!}".`,
+    `Call the "setName" handler with arguments on charm "${RAW_EX_COMP
+      .charm!}".`,
   )
   .option("-c,--charm <charm:string>", "The target charm ID.")
   .arguments("<handler:string> [args:string]")
@@ -399,6 +401,21 @@ Recipe: ${charmData.recipeName || "<no recipe name>"}
     const args = argsJson ? JSON.parse(argsJson) : await drainStdin();
     await callCharmHandler(charmConfig, handlerName, args);
     render(`Called handler "${handlerName}" on charm ${charmConfig.charm}`);
+  })
+  /* charm rm */
+  .command("rm", "Remove a charm")
+  .alias("remove")
+  .usage(spaceUsage)
+  .example(
+    `ct charm rm baed..43mi ${EX_ID} ${EX_COMP}`,
+    `Remove charm "baed..43mi".`,
+  )
+  .arguments("<charm:string>")
+  .action(async (options, charmId) => {
+    const spaceConfig = parseSpaceOptions(options);
+    const charmConfig = { ...spaceConfig, charm: charmId };
+    await removeCharm(charmConfig);
+    render(`Removed charm ${charmId}`);
   });
 
 interface CharmCLIOptions {

--- a/packages/cli/commands/charm.ts
+++ b/packages/cli/commands/charm.ts
@@ -405,17 +405,20 @@ Recipe: ${charmData.recipeName || "<no recipe name>"}
   /* charm rm */
   .command("rm", "Remove a charm")
   .alias("remove")
-  .usage(spaceUsage)
+  .usage(charmUsage)
   .example(
-    `ct charm rm baed..43mi ${EX_ID} ${EX_COMP}`,
-    `Remove charm "baed..43mi".`,
+    `ct charm rm ${EX_ID} ${EX_COMP_CHARM}`,
+    `Remove charm "${RAW_EX_COMP.charm!}".`,
   )
-  .arguments("<charm:string>")
-  .action(async (options, charmId) => {
-    const spaceConfig = parseSpaceOptions(options);
-    const charmConfig = { ...spaceConfig, charm: charmId };
+  .example(
+    `ct charm rm ${EX_ID} ${EX_URL}`,
+    `Remove charm "${RAW_EX_COMP.charm!}".`,
+  )
+  .option("-c,--charm <charm:string>", "The target charm ID.")
+  .action(async (options) => {
+    const charmConfig = parseCharmOptions(options);
     await removeCharm(charmConfig);
-    render(`Removed charm ${charmId}`);
+    render(`Removed charm ${charmConfig.charm}`);
   });
 
 interface CharmCLIOptions {

--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -1,7 +1,13 @@
 import { ANYONE, Identity, Session } from "@commontools/identity";
 import { ensureDir } from "@std/fs";
 import { loadIdentity } from "./identity.ts";
-import { Cell, Runtime, RuntimeProgram, UI, isStream } from "@commontools/runner";
+import {
+  Cell,
+  isStream,
+  Runtime,
+  RuntimeProgram,
+  UI,
+} from "@commontools/runner";
 import { StorageManager } from "@commontools/runner/storage/cache";
 import {
   Charm,
@@ -18,6 +24,7 @@ import {
 } from "@commontools/charm/ops";
 import { join } from "@std/path";
 import { CliProgram } from "./dev.ts";
+import { ValidationError } from "@cliffy/command";
 
 export interface EntryConfig {
   mainPath: string;
@@ -477,20 +484,38 @@ export async function callCharmHandler(
   const manager = await loadManager(config);
   const charms = new CharmsController(manager);
   const charm = await charms.get(config.charm);
-  
+
   // Get the cell and traverse to the handler using .key()
   const cell = charm.getCell();
   const handlerStream = cell.key(handlerName);
-  
+
   // The handlerStream should be the actual stream object
   if (!handlerStream || !isStream(handlerStream)) {
     throw new Error(`Handler "${handlerName}" not found or not a stream`);
   }
-  
+
   // Send the event to trigger the handler
   handlerStream.send(args);
-  
+
   // Wait for processing to complete
   await manager.runtime.idle();
   await manager.synced();
+}
+
+/**
+ * Removes a charm from the space (moves it to trash).
+ */
+export async function removeCharm(
+  config: CharmConfig,
+): Promise<void> {
+  const manager = await loadManager(config);
+  const charms = new CharmsController(manager);
+  const removed = await charms.remove(config.charm);
+
+  if (!removed) {
+    throw new ValidationError(
+      `Charm "${config.charm}" not found`,
+      { exitCode: 1 },
+    );
+  }
 }

--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -513,9 +513,6 @@ export async function removeCharm(
   const removed = await charms.remove(config.charm);
 
   if (!removed) {
-    throw new ValidationError(
-      `Charm "${config.charm}" not found`,
-      { exitCode: 1 },
-    );
+    throw new Error(`Charm "${config.charm}" not found`);
   }
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added the `ct charm rm <id>` CLI command to remove a charm by ID, including a new remove method in the CharmsController.

- **New Features**
  - Users can now remove charms from the CLI with `ct charm rm <id>`.
  - The CharmsController exposes a `remove` method to handle charm deletion and cleanup.

<!-- End of auto-generated description by cubic. -->

