### PR TITLE
Removed seenNurseryChanges, since this shouldn't be needed.

### DIFF
--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -421,7 +421,6 @@ export class Replica {
 
   // Track the causes of pending nursery changes
   private pendingNurseryChanges = new MapSet<string, string>();
-  private seenNurseryChanges = new MapSet<string, string>();
 
   constructor(
     /**
@@ -831,7 +830,6 @@ export class Replica {
           toKey(fact),
           fact.cause.toString(),
         );
-        this.seenNurseryChanges.delete(toKey(fact));
       }
 
       // Checkout current state of facts so we can compute
@@ -889,7 +887,6 @@ export class Replica {
 
       for (const fact of freshFacts) {
         this.pendingNurseryChanges.delete(toKey(fact));
-        this.seenNurseryChanges.delete(toKey(fact));
       }
     }
 
@@ -955,10 +952,7 @@ export class Replica {
       const factKey = toKey(revision);
       const factCause = revision.cause.toString();
       if (this.pendingNurseryChanges.hasValue(factKey, factCause)) {
-        this.seenNurseryChanges.add(factKey, factCause);
         this.pendingNurseryChanges.deleteValue(factKey, factCause);
-      }
-      if (this.seenNurseryChanges.hasValue(factKey, factCause)) {
         matches.add(revision);
       }
     }
@@ -973,7 +967,6 @@ export class Replica {
   reset() {
     // Clear nursery tracking
     this.pendingNurseryChanges = new MapSet<string, string>();
-    this.seenNurseryChanges = new MapSet<string, string>();
     // Clear the nursery itself
     this.nursery = new Nursery();
     // Save subscribers before clearing heap


### PR DESCRIPTION
While we can receive a message that we've sent more than once, its revision will be the same as the first time we saw it, so we don't have to track them to avoid sending subscription notifications