### PR TITLE
feat(runner): call sync directly when not in shim; allow URIs in .sync calls

### DIFF
--- a/packages/runner/src/storage.ts
+++ b/packages/runner/src/storage.ts
@@ -172,6 +172,16 @@ export class Storage implements IStorage {
       };
     }
 
+    if (!this.shim) {
+      const { space, id } = cell.getAsNormalizedFullLink();
+      const storageProvider = this._getStorageProviderForSpace(space);
+      return storageProvider.sync(
+        id,
+        false,
+        schemaContext,
+      ).then(() => cell);
+    }
+
     const doc = cell.getDoc();
     if (!isDoc(doc)) {
       throw new Error("Invalid subject: " + JSON.stringify(doc));

--- a/packages/runner/src/storage.ts
+++ b/packages/runner/src/storage.ts
@@ -175,11 +175,8 @@ export class Storage implements IStorage {
     if (!this.shim) {
       const { space, id } = cell.getAsNormalizedFullLink();
       const storageProvider = this._getStorageProviderForSpace(space);
-      return storageProvider.sync(
-        id,
-        false,
-        schemaContext,
-      ).then(() => cell);
+      await storageProvider.sync(id, false, schemaContext);
+      return cell;
     }
 
     const doc = cell.getDoc();

--- a/packages/runner/src/storage/base.ts
+++ b/packages/runner/src/storage/base.ts
@@ -80,7 +80,15 @@ export abstract class BaseStorageProvider implements IStorageProvider {
 
   abstract getReplica(): string | undefined;
 
-  static toEntity(source: EntityId): Entity {
+  static toEntity(source: EntityId | string): Entity {
+    if (typeof source === "string") {
+      if (!source.includes(":")) {
+        throw new TypeError(
+          `💣 Got entity ID that is a string, but not a URI: ${source}`,
+        );
+      }
+      return source as Entity;
+    }
     if (typeof source["/"] === "string") {
       return `of:${source["/"]}`;
     } else if (source.toJSON) {

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -1322,7 +1322,7 @@ class ProviderConnection implements IStorageProvider {
   }
 
   sync(
-    entityId: EntityId,
+    entityId: EntityId | Entity,
     expectedInStorage?: boolean,
     schemaContext?: SchemaContext,
   ) {
@@ -1442,7 +1442,7 @@ export class Provider implements IStorageProvider {
   }
 
   sync(
-    entityId: EntityId,
+    entityId: EntityId | Entity,
     expectedInStorage?: boolean,
     schemaContext?: SchemaContext,
   ) {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -132,7 +132,7 @@ export interface IStorageProvider {
    * @returns Promise that resolves when the value is synced.
    */
   sync(
-    entityId: EntityId,
+    entityId: EntityId | URI,
     expectedInStorage?: boolean,
     schemaContext?: SchemaContext,
   ): Promise<Result<Unit, Error>>;


### PR DESCRIPTION
- Update storage.ts to call sync directly when not running in a shim environment.
- Allow either EntityId or URIs on sync call (eventually we'll deprecate the former)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated storage to call sync directly when not running in a shim and added support for URIs in sync calls.

- **Refactors**
  - Calls sync on the storage provider directly if not in a shim environment.
  - Allows both EntityId and URI formats in sync methods.

<!-- End of auto-generated description by cubic. -->

