### PR TITLE
feat(runner): add comprehensive benchmarks for cell operations

### DIFF
--- a/packages/runner/test/cell.bench.ts
+++ b/packages/runner/test/cell.bench.ts
@@ -30,16 +30,18 @@ async function cleanup(
 }
 
 // Benchmark: Cell creation
-Deno.bench("Cell creation - simple schemaless", async () => {
+Deno.bench("Cell creation - simple schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
-  const cell = runtime.getCell<number>(space, "bench-cell", undefined, tx);
-  cell.set(42);
+  for (let i = 0; i < 1000; i++) {
+    const cell = runtime.getCell<number>(space, `bench-cell-${i}`, undefined, tx);
+    cell.set(42);
+  }
   
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell creation - with JSON schema", async () => {
+Deno.bench("Cell creation - with JSON schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -51,37 +53,44 @@ Deno.bench("Cell creation - with JSON schema", async () => {
     required: ["name", "age"],
   } as const satisfies JSONSchema;
   
-  const cell = runtime.getCell(space, "bench-cell-schema", schema, tx);
-  cell.set({ name: "John", age: 30 });
+  for (let i = 0; i < 1000; i++) {
+    const cell = runtime.getCell(space, `bench-cell-schema-${i}`, schema, tx);
+    cell.set({ name: "John", age: 30 });
+  }
   
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell creation - immutable", async () => {
+Deno.bench("Cell creation - immutable (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
-  runtime.getImmutableCell(
-    space,
-    { value: 42 },
-    { type: "object", properties: { value: { type: "number" } } },
-    tx,
-  );
+  for (let i = 0; i < 1000; i++) {
+    runtime.getImmutableCell(
+      space,
+      { value: 42 + i },
+      { type: "object", properties: { value: { type: "number" } } },
+      tx,
+    );
+  }
   
   await cleanup(runtime, storageManager, tx);
 });
 
 // Schema-based cell creation benchmarks
-Deno.bench("Cell creation - simple with schema", async () => {
+Deno.bench("Cell creation - simple with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = { type: "number" } as const satisfies JSONSchema;
-  const cell = runtime.getCell(space, "bench-cell-schema", schema, tx);
-  cell.set(42);
+  
+  for (let i = 0; i < 1000; i++) {
+    const cell = runtime.getCell(space, `bench-cell-schema-${i}`, schema, tx);
+    cell.set(42);
+  }
   
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell creation - object with nested schema", async () => {
+Deno.bench("Cell creation - object with nested schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -105,20 +114,22 @@ Deno.bench("Cell creation - object with nested schema", async () => {
     required: ["user", "tags"],
   } as const satisfies JSONSchema;
   
-  const cell = runtime.getCell(space, "bench-nested-schema", schema, tx);
-  cell.set({
-    user: {
-      name: "John Doe",
-      age: 30,
-      email: "john@example.com",
-    },
-    tags: ["developer", "typescript"],
-  });
+  for (let i = 0; i < 1000; i++) {
+    const cell = runtime.getCell(space, `bench-nested-schema-${i}`, schema, tx);
+    cell.set({
+      user: {
+        name: "John Doe",
+        age: 30,
+        email: "john@example.com",
+      },
+      tags: ["developer", "typescript"],
+    });
+  }
   
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell creation - array with schema", async () => {
+Deno.bench("Cell creation - array with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -133,11 +144,13 @@ Deno.bench("Cell creation - array with schema", async () => {
     },
   } as const satisfies JSONSchema;
   
-  const cell = runtime.getCell(space, "bench-array-schema", schema, tx);
-  cell.set([
-    { id: 1, name: "Item 1" },
-    { id: 2, name: "Item 2" },
-  ]);
+  for (let i = 0; i < 1000; i++) {
+    const cell = runtime.getCell(space, `bench-array-schema-${i}`, schema, tx);
+    cell.set([
+      { id: 1, name: "Item 1" },
+      { id: 2, name: "Item 2" },
+    ]);
+  }
   
   await cleanup(runtime, storageManager, tx);
 });
@@ -264,34 +277,34 @@ Deno.bench("Cell get - complex object with schema (1000x)", async () => {
 });
 
 // Benchmark: Cell set operations
-Deno.bench("Cell set - simple value schemaless (100x)", async () => {
+Deno.bench("Cell set - simple value schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<number>(space, "bench-set", undefined, tx);
   
   // Measure set operation
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     cell.set(i);
   }
   
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell send - simple value schemaless (100x)", async () => {
+Deno.bench("Cell send - simple value schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<number>(space, "bench-send", undefined, tx);
   cell.set(0);
   
   // Measure send operation
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     cell.send(i);
   }
   
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell update - partial object update schemaless (100x)", async () => {
+Deno.bench("Cell update - partial object update schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{
@@ -303,7 +316,7 @@ Deno.bench("Cell update - partial object update schemaless (100x)", async () => 
   cell.set({ name: "test", age: 42, tags: ["a", "b"] });
   
   // Measure update operation
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     cell.update({ age: i });
   }
   
@@ -311,21 +324,21 @@ Deno.bench("Cell update - partial object update schemaless (100x)", async () => 
 });
 
 // Schema-based set operations
-Deno.bench("Cell set - simple value with schema (100x)", async () => {
+Deno.bench("Cell set - simple value with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
-  const schema = { type: "number", minimum: 0, maximum: 100 } as const satisfies JSONSchema;
+  const schema = { type: "number", minimum: 0, maximum: 1000 } as const satisfies JSONSchema;
   const cell = runtime.getCell(space, "bench-set-schema", schema, tx);
   
   // Measure set operation
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     cell.set(i);
   }
   
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell update - partial object update with schema (100x)", async () => {
+Deno.bench("Cell update - partial object update with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -346,7 +359,7 @@ Deno.bench("Cell update - partial object update with schema (100x)", async () =>
   cell.set({ name: "test", age: 42, tags: ["a", "b"] });
   
   // Measure update operation
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     cell.update({ age: i });
   }
   
@@ -371,7 +384,7 @@ Deno.bench("Cell key - nested access schemaless (1000x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell key - array access schemaless (100x)", async () => {
+Deno.bench("Cell key - array access schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{
@@ -386,8 +399,8 @@ Deno.bench("Cell key - array access schemaless (100x)", async () => {
   });
   
   // Measure array key access
-  for (let i = 0; i < 100; i++) {
-    cell.key("items").key(i).key("value").get();
+  for (let i = 0; i < 1000; i++) {
+    cell.key("items").key(i % 100).key("value").get();
   }
   
   await cleanup(runtime, storageManager, tx);
@@ -435,7 +448,7 @@ Deno.bench("Cell key - nested access with schema (1000x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell key - array access with schema (100x)", async () => {
+Deno.bench("Cell key - array access with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -466,8 +479,8 @@ Deno.bench("Cell key - array access with schema (100x)", async () => {
   });
   
   // Measure array key access
-  for (let i = 0; i < 100; i++) {
-    cell.key("items").key(i).key("value").get();
+  for (let i = 0; i < 1000; i++) {
+    cell.key("items").key(i % 100).key("value").get();
   }
   
   await cleanup(runtime, storageManager, tx);
@@ -549,7 +562,7 @@ Deno.bench("Cell getAsQueryResult - proxy creation schemaless (1000x)", async ()
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell proxy - property writes schemaless (100x)", async () => {
+Deno.bench("Cell proxy - property writes schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{
@@ -561,7 +574,7 @@ Deno.bench("Cell proxy - property writes schemaless (100x)", async () => {
   const proxy = cell.getAsQueryResult();
   
   // Measure proxy writes
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     proxy.x = i;
     proxy.y = i * 2;
   }
@@ -608,7 +621,7 @@ Deno.bench("Cell getAsQueryResult - proxy creation with schema (1000x)", async (
 });
 
 // Benchmark: Array operations
-Deno.bench("Cell push - array append schemaless (100x)", async () => {
+Deno.bench("Cell push - array append schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{ items: number[] }>(
@@ -621,14 +634,14 @@ Deno.bench("Cell push - array append schemaless (100x)", async () => {
   const arrayCell = cell.key("items");
   
   // Measure push operations
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     arrayCell.push(i);
   }
   
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell array - map operation schemaless (10x)", async () => {
+Deno.bench("Cell array - map operation schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{ items: number[] }>(
@@ -642,7 +655,7 @@ Deno.bench("Cell array - map operation schemaless (10x)", async () => {
   const proxy = cell.getAsQueryResult();
   
   // Measure array map operation
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 1000; i++) {
     proxy.items.map((x: number) => x * 2);
   }
   
@@ -650,7 +663,7 @@ Deno.bench("Cell array - map operation schemaless (10x)", async () => {
 });
 
 // Schema-based array operations
-Deno.bench("Cell push - array append with schema (100x)", async () => {
+Deno.bench("Cell push - array append with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -669,14 +682,14 @@ Deno.bench("Cell push - array append with schema (100x)", async () => {
   const arrayCell = cell.key("items");
   
   // Measure push operations
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     arrayCell.push(i);
   }
   
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell array - map operation with schema (10x)", async () => {
+Deno.bench("Cell array - map operation with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -696,7 +709,7 @@ Deno.bench("Cell array - map operation with schema (10x)", async () => {
   const proxy = cell.getAsQueryResult();
   
   // Measure array map operation
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 1000; i++) {
     proxy.items.map((x: number) => x * 2);
   }
   
@@ -751,7 +764,7 @@ Deno.bench("Cell getAsLink - with options (1000x)", async () => {
 });
 
 // Benchmark: Subscription operations
-Deno.bench("Cell sink - subscription execution (100x)", async () => {
+Deno.bench("Cell sink - subscription execution (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<number>(space, "bench-sink", undefined, tx);
@@ -765,14 +778,14 @@ Deno.bench("Cell sink - subscription execution (100x)", async () => {
   });
   
   // Measure sink execution with value changes
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     cell.set(i + 1); // Set different value each time
     await runtime.idle(); // Wait for sink to execute
   }
   
   // Verify sink was called
-  if (callCount !== 101) { // Initial + 100 updates
-    throw new Error(`Expected 101 sink calls, got ${callCount}`);
+  if (callCount !== 1001) { // Initial + 1000 updates
+    throw new Error(`Expected 1001 sink calls, got ${callCount}`);
   }
   
   // Cleanup subscription
@@ -781,7 +794,7 @@ Deno.bench("Cell sink - subscription execution (100x)", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell sink - subscription execution with schema (100x)", async () => {
+Deno.bench("Cell sink - subscription execution with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -804,14 +817,14 @@ Deno.bench("Cell sink - subscription execution with schema (100x)", async () => 
   });
   
   // Measure sink execution with value changes
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     cell.set({ count: i + 1, timestamp: Date.now() + i });
     await runtime.idle(); // Wait for sink to execute
   }
   
   // Verify sink was called
-  if (callCount !== 101) { // Initial + 100 updates
-    throw new Error(`Expected 101 sink calls, got ${callCount}`);
+  if (callCount !== 1001) { // Initial + 1000 updates
+    throw new Error(`Expected 1001 sink calls, got ${callCount}`);
   }
   
   // Cleanup subscription
@@ -917,7 +930,7 @@ Deno.bench("Cell complex - nested cell references (1000x)", async () => {
 });
 
 // Benchmark: Schema validation
-Deno.bench("Cell schema - complex validation (100x)", async () => {
+Deno.bench("Cell schema - complex validation (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const complexSchema = {
@@ -955,7 +968,7 @@ Deno.bench("Cell schema - complex validation (100x)", async () => {
   );
   
   // Measure complex object set with schema validation
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     cell.set({
       id: `user-${i}`,
       user: {
@@ -975,7 +988,7 @@ Deno.bench("Cell schema - complex validation (100x)", async () => {
 });
 
 // Benchmark: Large data structures
-Deno.bench("Cell large - array with 1000 items (10x get)", async () => {
+Deno.bench("Cell large - array with 1000 items (1000x get)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{ items: Array<{ id: number; data: string }> }>(
@@ -995,14 +1008,14 @@ Deno.bench("Cell large - array with 1000 items (10x get)", async () => {
   cell.set({ items });
   
   // Measure get operation with large data
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 1000; i++) {
     cell.get();
   }
   
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell large - deeply nested object (100x navigation)", async () => {
+Deno.bench("Cell large - deeply nested object (1000x navigation)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   // Create deeply nested structure
@@ -1022,7 +1035,7 @@ Deno.bench("Cell large - deeply nested object (100x navigation)", async () => {
   cell.set(deepData);
   
   // Measure deep navigation
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     let current = cell;
     for (let j = 0; j < 10; j++) {
       current = current.key("nested");
@@ -1034,7 +1047,7 @@ Deno.bench("Cell large - deeply nested object (100x navigation)", async () => {
 });
 
 // Benchmark: Concurrent operations
-Deno.bench("Cell concurrent - multiple cells (100x)", async () => {
+Deno.bench("Cell concurrent - multiple cells (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   // Create multiple cells
@@ -1046,7 +1059,7 @@ Deno.bench("Cell concurrent - multiple cells (100x)", async () => {
   cells.forEach((cell, i) => cell.set(i));
   
   // Measure concurrent access
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 1000; i++) {
     cells.forEach((cell) => cell.get());
   }
   

--- a/packages/runner/test/cell.bench.ts
+++ b/packages/runner/test/cell.bench.ts
@@ -32,18 +32,23 @@ async function cleanup(
 // Benchmark: Cell creation
 Deno.bench("Cell creation - simple schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   for (let i = 0; i < 1000; i++) {
-    const cell = runtime.getCell<number>(space, `bench-cell-${i}`, undefined, tx);
+    const cell = runtime.getCell<number>(
+      space,
+      `bench-cell-${i}`,
+      undefined,
+      tx,
+    );
     cell.set(42);
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell creation - with JSON schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const schema = {
     type: "object",
     properties: {
@@ -52,18 +57,18 @@ Deno.bench("Cell creation - with JSON schema (1000x)", async () => {
     },
     required: ["name", "age"],
   } as const satisfies JSONSchema;
-  
+
   for (let i = 0; i < 1000; i++) {
     const cell = runtime.getCell(space, `bench-cell-schema-${i}`, schema, tx);
     cell.set({ name: "John", age: 30 });
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell creation - immutable (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   for (let i = 0; i < 1000; i++) {
     runtime.getImmutableCell(
       space,
@@ -72,27 +77,27 @@ Deno.bench("Cell creation - immutable (1000x)", async () => {
       tx,
     );
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Schema-based cell creation benchmarks
 Deno.bench("Cell creation - simple with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const schema = { type: "number" } as const satisfies JSONSchema;
-  
+
   for (let i = 0; i < 1000; i++) {
     const cell = runtime.getCell(space, `bench-cell-schema-${i}`, schema, tx);
     cell.set(42);
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell creation - object with nested schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const schema = {
     type: "object",
     properties: {
@@ -113,7 +118,7 @@ Deno.bench("Cell creation - object with nested schema (1000x)", async () => {
     },
     required: ["user", "tags"],
   } as const satisfies JSONSchema;
-  
+
   for (let i = 0; i < 1000; i++) {
     const cell = runtime.getCell(space, `bench-nested-schema-${i}`, schema, tx);
     cell.set({
@@ -125,13 +130,13 @@ Deno.bench("Cell creation - object with nested schema (1000x)", async () => {
       tags: ["developer", "typescript"],
     });
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell creation - array with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const schema = {
     type: "array",
     items: {
@@ -143,7 +148,7 @@ Deno.bench("Cell creation - array with schema (1000x)", async () => {
       required: ["id", "name"],
     },
   } as const satisfies JSONSchema;
-  
+
   for (let i = 0; i < 1000; i++) {
     const cell = runtime.getCell(space, `bench-array-schema-${i}`, schema, tx);
     cell.set([
@@ -151,94 +156,94 @@ Deno.bench("Cell creation - array with schema (1000x)", async () => {
       { id: 2, name: "Item 2" },
     ]);
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Benchmark: Cell get operations
 Deno.bench("Cell get - simple value schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<number>(space, "bench-get", undefined, tx);
   cell.set(42);
-  
+
   // Measure get operation
   for (let i = 0; i < 1000; i++) {
     cell.get();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell get - complex object schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<{
     name: string;
     age: number;
     tags: string[];
     nested: { value: number };
   }>(space, "bench-get-complex", undefined, tx);
-  
+
   cell.set({
     name: "test",
     age: 42,
     tags: ["a", "b", "c"],
     nested: { value: 123 },
   });
-  
+
   // Measure get operation
   for (let i = 0; i < 1000; i++) {
     cell.get();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell getRaw - complex object schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<{
     name: string;
     age: number;
     tags: string[];
     nested: { value: number };
   }>(space, "bench-getRaw", undefined, tx);
-  
+
   cell.set({
     name: "test",
     age: 42,
     tags: ["a", "b", "c"],
     nested: { value: 123 },
   });
-  
+
   // Measure getRaw operation
   for (let i = 0; i < 1000; i++) {
     cell.getRaw();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Schema-based get operations
 Deno.bench("Cell get - simple value with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const schema = { type: "number", minimum: 0 } as const satisfies JSONSchema;
   const cell = runtime.getCell(space, "bench-get-schema", schema, tx);
   cell.set(42);
-  
+
   // Measure get operation
   for (let i = 0; i < 1000; i++) {
     cell.get();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell get - complex object with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const schema = {
     type: "object",
     properties: {
@@ -258,158 +263,168 @@ Deno.bench("Cell get - complex object with schema (1000x)", async () => {
     },
     required: ["name", "age", "tags", "nested"],
   } as const satisfies JSONSchema;
-  
+
   const cell = runtime.getCell(space, "bench-get-complex-schema", schema, tx);
-  
+
   cell.set({
     name: "test",
     age: 42,
     tags: ["a", "b", "c"],
     nested: { value: 123 },
   });
-  
+
   // Measure get operation
   for (let i = 0; i < 1000; i++) {
     cell.get();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Benchmark: Cell set operations
 Deno.bench("Cell set - simple value schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<number>(space, "bench-set", undefined, tx);
-  
+
   // Measure set operation
   for (let i = 0; i < 1000; i++) {
     cell.set(i);
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell send - simple value schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<number>(space, "bench-send", undefined, tx);
   cell.set(0);
-  
+
   // Measure send operation
   for (let i = 0; i < 1000; i++) {
     cell.send(i);
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell update - partial object update schemaless (1000x)", async () => {
-  const { runtime, storageManager, tx } = setup();
-  
-  const cell = runtime.getCell<{
-    name: string;
-    age: number;
-    tags: string[];
-  }>(space, "bench-update", undefined, tx);
-  
-  cell.set({ name: "test", age: 42, tags: ["a", "b"] });
-  
-  // Measure update operation
-  for (let i = 0; i < 1000; i++) {
-    cell.update({ age: i });
-  }
-  
-  await cleanup(runtime, storageManager, tx);
-});
+Deno.bench(
+  "Cell update - partial object update schemaless (1000x)",
+  async () => {
+    const { runtime, storageManager, tx } = setup();
+
+    const cell = runtime.getCell<{
+      name: string;
+      age: number;
+      tags: string[];
+    }>(space, "bench-update", undefined, tx);
+
+    cell.set({ name: "test", age: 42, tags: ["a", "b"] });
+
+    // Measure update operation
+    for (let i = 0; i < 1000; i++) {
+      cell.update({ age: i });
+    }
+
+    await cleanup(runtime, storageManager, tx);
+  },
+);
 
 // Schema-based set operations
 Deno.bench("Cell set - simple value with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
-  const schema = { type: "number", minimum: 0, maximum: 1000 } as const satisfies JSONSchema;
+
+  const schema = {
+    type: "number",
+    minimum: 0,
+    maximum: 1000,
+  } as const satisfies JSONSchema;
   const cell = runtime.getCell(space, "bench-set-schema", schema, tx);
-  
+
   // Measure set operation
   for (let i = 0; i < 1000; i++) {
     cell.set(i);
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell update - partial object update with schema (1000x)", async () => {
-  const { runtime, storageManager, tx } = setup();
-  
-  const schema = {
-    type: "object",
-    properties: {
-      name: { type: "string" },
-      age: { type: "number", minimum: 0 },
-      tags: {
-        type: "array",
-        items: { type: "string" },
+Deno.bench(
+  "Cell update - partial object update with schema (1000x)",
+  async () => {
+    const { runtime, storageManager, tx } = setup();
+
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "number", minimum: 0 },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+        },
       },
-    },
-    required: ["name", "age", "tags"],
-  } as const satisfies JSONSchema;
-  
-  const cell = runtime.getCell(space, "bench-update-schema", schema, tx);
-  
-  cell.set({ name: "test", age: 42, tags: ["a", "b"] });
-  
-  // Measure update operation
-  for (let i = 0; i < 1000; i++) {
-    cell.update({ age: i });
-  }
-  
-  await cleanup(runtime, storageManager, tx);
-});
+      required: ["name", "age", "tags"],
+    } as const satisfies JSONSchema;
+
+    const cell = runtime.getCell(space, "bench-update-schema", schema, tx);
+
+    cell.set({ name: "test", age: 42, tags: ["a", "b"] });
+
+    // Measure update operation
+    for (let i = 0; i < 1000; i++) {
+      cell.update({ age: i });
+    }
+
+    await cleanup(runtime, storageManager, tx);
+  },
+);
 
 // Benchmark: Nested cell operations
 Deno.bench("Cell key - nested access schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<{
     a: { b: { c: { d: number } } };
   }>(space, "bench-key", undefined, tx);
-  
+
   cell.set({ a: { b: { c: { d: 42 } } } });
-  
+
   // Measure nested key access
   for (let i = 0; i < 1000; i++) {
     cell.key("a").key("b").key("c").key("d").get();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell key - array access schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<{
     items: Array<{ name: string; value: number }>;
   }>(space, "bench-key-array", undefined, tx);
-  
+
   cell.set({
     items: Array.from({ length: 100 }, (_, i) => ({
       name: `item${i}`,
       value: i,
     })),
   });
-  
+
   // Measure array key access
   for (let i = 0; i < 1000; i++) {
     cell.key("items").key(i % 100).key("value").get();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Schema-based nested operations
 Deno.bench("Cell key - nested access with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const schema = {
     type: "object",
     properties: {
@@ -435,22 +450,22 @@ Deno.bench("Cell key - nested access with schema (1000x)", async () => {
     },
     required: ["a"],
   } as const satisfies JSONSchema;
-  
+
   const cell = runtime.getCell(space, "bench-key-schema", schema, tx);
-  
+
   cell.set({ a: { b: { c: { d: 42 } } } });
-  
+
   // Measure nested key access
   for (let i = 0; i < 1000; i++) {
     cell.key("a").key("b").key("c").key("d").get();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell key - array access with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const schema = {
     type: "object",
     properties: {
@@ -468,38 +483,38 @@ Deno.bench("Cell key - array access with schema (1000x)", async () => {
     },
     required: ["items"],
   } as const satisfies JSONSchema;
-  
+
   const cell = runtime.getCell(space, "bench-key-array-schema", schema, tx);
-  
+
   cell.set({
     items: Array.from({ length: 100 }, (_, i) => ({
       name: `item${i}`,
       value: i,
     })),
   });
-  
+
   // Measure array key access
   for (let i = 0; i < 1000; i++) {
     cell.key("items").key(i % 100).key("value").get();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Benchmark: Cell derivation
 Deno.bench("Cell asSchema - schema transformation (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<{
     id: number;
     metadata: { createdAt: string; type: string };
   }>(space, "bench-asSchema", undefined, tx);
-  
+
   cell.set({
     id: 1,
     metadata: { createdAt: "2025-01-06", type: "user" },
   });
-  
+
   const schema = {
     type: "object",
     properties: {
@@ -508,84 +523,87 @@ Deno.bench("Cell asSchema - schema transformation (1000x)", async () => {
     },
     required: ["id", "metadata"],
   } as const satisfies JSONSchema;
-  
+
   // Measure asSchema transformation
   for (let i = 0; i < 1000; i++) {
     const schemaCell = cell.asSchema(schema);
     schemaCell.get();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell withTx - transaction switching (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<number>(space, "bench-withTx", undefined, tx);
   cell.set(42);
-  
+
   const tx2 = runtime.edit();
-  
+
   // Measure withTx operation
   for (let i = 0; i < 1000; i++) {
     const newCell = cell.withTx(i % 2 === 0 ? tx : tx2);
     newCell.get();
   }
-  
+
   await tx2.commit();
   await cleanup(runtime, storageManager, tx);
 });
 
 // Benchmark: Query result proxy operations
-Deno.bench("Cell getAsQueryResult - proxy creation schemaless (1000x)", async () => {
-  const { runtime, storageManager, tx } = setup();
-  
-  const cell = runtime.getCell<{
-    name: string;
-    age: number;
-    nested: { value: number };
-  }>(space, "bench-proxy", undefined, tx);
-  
-  cell.set({
-    name: "test",
-    age: 42,
-    nested: { value: 123 },
-  });
-  
-  // Measure proxy creation and access
-  for (let i = 0; i < 1000; i++) {
-    const proxy = cell.getAsQueryResult();
-    proxy.name;
-    proxy.nested.value;
-  }
-  
-  await cleanup(runtime, storageManager, tx);
-});
+Deno.bench(
+  "Cell getAsQueryResult - proxy creation schemaless (1000x)",
+  async () => {
+    const { runtime, storageManager, tx } = setup();
+
+    const cell = runtime.getCell<{
+      name: string;
+      age: number;
+      nested: { value: number };
+    }>(space, "bench-proxy", undefined, tx);
+
+    cell.set({
+      name: "test",
+      age: 42,
+      nested: { value: 123 },
+    });
+
+    // Measure proxy creation and access
+    for (let i = 0; i < 1000; i++) {
+      const proxy = cell.getAsQueryResult();
+      proxy.name;
+      proxy.nested.value;
+    }
+
+    await cleanup(runtime, storageManager, tx);
+  },
+);
 
 Deno.bench("Cell proxy - property writes schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<{
     x: number;
     y: number;
   }>(space, "bench-proxy-write", undefined, tx);
-  
+
   cell.set({ x: 1, y: 2 });
   const proxy = cell.getAsQueryResult();
-  
+
   // Measure proxy writes
   for (let i = 0; i < 1000; i++) {
     proxy.x = i;
     proxy.y = i * 2;
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
-// Schema-based proxy operations
-Deno.bench("Cell getAsQueryResult - proxy creation with schema (1000x)", async () => {
+// Schema-based get operations for complex objects
+Deno.bench("Cell get - complex object with asCell schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const schema = {
     type: "object",
     properties: {
@@ -597,33 +615,35 @@ Deno.bench("Cell getAsQueryResult - proxy creation with schema (1000x)", async (
           value: { type: "number" },
         },
         required: ["value"],
+        asCell: true, // This creates a cell reference
       },
     },
     required: ["name", "age", "nested"],
   } as const satisfies JSONSchema;
-  
-  const cell = runtime.getCell(space, "bench-proxy-schema", schema, tx);
-  
+
+  const cell = runtime.getCell(space, "bench-get-asCell-schema", schema, tx);
+
   cell.set({
     name: "test",
     age: 42,
     nested: { value: 123 },
   });
-  
-  // Measure proxy creation and access
+
+  // Measure get with schema that creates cell references
   for (let i = 0; i < 1000; i++) {
-    const proxy = cell.getAsQueryResult();
-    proxy.name;
-    proxy.nested.value;
+    const value = cell.get();
+    value.name;
+    value.age;
+    value.nested.get(); // nested is a Cell due to asCell: true
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Benchmark: Array operations
 Deno.bench("Cell push - array append schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<{ items: number[] }>(
     space,
     "bench-push",
@@ -632,18 +652,18 @@ Deno.bench("Cell push - array append schemaless (1000x)", async () => {
   );
   cell.set({ items: [] });
   const arrayCell = cell.key("items");
-  
+
   // Measure push operations
   for (let i = 0; i < 1000; i++) {
     arrayCell.push(i);
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell array - map operation schemaless (1000x)", async () => {
+Deno.bench("Cell array - proxy map operation schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<{ items: number[] }>(
     space,
     "bench-array-map",
@@ -651,21 +671,21 @@ Deno.bench("Cell array - map operation schemaless (1000x)", async () => {
     tx,
   );
   cell.set({ items: Array.from({ length: 100 }, (_, i) => i) });
-  
+
   const proxy = cell.getAsQueryResult();
-  
-  // Measure array map operation
+
+  // Measure array map operation via proxy
   for (let i = 0; i < 1000; i++) {
     proxy.items.map((x: number) => x * 2);
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Schema-based array operations
 Deno.bench("Cell push - array append with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const schema = {
     type: "object",
     properties: {
@@ -676,22 +696,22 @@ Deno.bench("Cell push - array append with schema (1000x)", async () => {
     },
     required: ["items"],
   } as const satisfies JSONSchema;
-  
+
   const cell = runtime.getCell(space, "bench-push-schema", schema, tx);
   cell.set({ items: [] });
   const arrayCell = cell.key("items");
-  
+
   // Measure push operations
   for (let i = 0; i < 1000; i++) {
     arrayCell.push(i);
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell array - map operation with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const schema = {
     type: "object",
     properties: {
@@ -702,24 +722,23 @@ Deno.bench("Cell array - map operation with schema (1000x)", async () => {
     },
     required: ["items"],
   } as const satisfies JSONSchema;
-  
-  const cell = runtime.getCell(space, "bench-array-map-schema", schema, tx);
+
+  const cell = runtime.getCell(space, "bench-array-get-schema", schema, tx);
   cell.set({ items: Array.from({ length: 100 }, (_, i) => i) });
-  
-  const proxy = cell.getAsQueryResult();
-  
-  // Measure array map operation
+
+  // Measure get operation with schema validation
   for (let i = 0; i < 1000; i++) {
-    proxy.items.map((x: number) => x * 2);
+    const value = cell.get();
+    value.items.map((x: number) => x * 2);
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Benchmark: Link operations
 Deno.bench("Cell getAsLink - link generation schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<{ value: number }>(
     space,
     "bench-link",
@@ -727,18 +746,18 @@ Deno.bench("Cell getAsLink - link generation schemaless (1000x)", async () => {
     tx,
   );
   cell.set({ value: 42 });
-  
+
   // Measure link generation
   for (let i = 0; i < 1000; i++) {
     cell.getAsLink();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell getAsLink - with options (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell1 = runtime.getCell<{ value: number }>(
     space,
     "bench-link-1",
@@ -746,7 +765,7 @@ Deno.bench("Cell getAsLink - with options (1000x)", async () => {
     tx,
   );
   cell1.set({ value: 42 });
-  
+
   const cell2 = runtime.getCell<{ other: string }>(
     space,
     "bench-link-2",
@@ -754,89 +773,92 @@ Deno.bench("Cell getAsLink - with options (1000x)", async () => {
     tx,
   );
   cell2.set({ other: "test" });
-  
+
   // Measure link generation with options
   for (let i = 0; i < 1000; i++) {
     cell1.getAsLink({ base: cell2, includeSchema: true });
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Benchmark: Subscription operations
 Deno.bench("Cell sink - subscription execution (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<number>(space, "bench-sink", undefined, tx);
   cell.set(0);
-  
+
   let callCount = 0;
-  
+
   // Setup sink subscription
   const cancel = cell.sink(() => {
     callCount++;
   });
-  
+
   // Measure sink execution with value changes
   for (let i = 0; i < 1000; i++) {
     cell.set(i + 1); // Set different value each time
     await runtime.idle(); // Wait for sink to execute
   }
-  
+
   // Verify sink was called
   if (callCount !== 1001) { // Initial + 1000 updates
     throw new Error(`Expected 1001 sink calls, got ${callCount}`);
   }
-  
+
   // Cleanup subscription
   cancel();
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell sink - subscription execution with schema (1000x)", async () => {
-  const { runtime, storageManager, tx } = setup();
-  
-  const schema = {
-    type: "object",
-    properties: {
-      count: { type: "number", minimum: 0 },
-      timestamp: { type: "number" },
-    },
-    required: ["count", "timestamp"],
-  } as const satisfies JSONSchema;
-  
-  const cell = runtime.getCell(space, "bench-sink-schema", schema, tx);
-  cell.set({ count: 0, timestamp: Date.now() });
-  
-  let callCount = 0;
-  
-  // Setup sink subscription
-  const cancel = cell.sink(() => {
-    callCount++;
-  });
-  
-  // Measure sink execution with value changes
-  for (let i = 0; i < 1000; i++) {
-    cell.set({ count: i + 1, timestamp: Date.now() + i });
-    await runtime.idle(); // Wait for sink to execute
-  }
-  
-  // Verify sink was called
-  if (callCount !== 1001) { // Initial + 1000 updates
-    throw new Error(`Expected 1001 sink calls, got ${callCount}`);
-  }
-  
-  // Cleanup subscription
-  cancel();
-  
-  await cleanup(runtime, storageManager, tx);
-});
+Deno.bench(
+  "Cell sink - subscription execution with schema (1000x)",
+  async () => {
+    const { runtime, storageManager, tx } = setup();
+
+    const schema = {
+      type: "object",
+      properties: {
+        count: { type: "number", minimum: 0 },
+        timestamp: { type: "number" },
+      },
+      required: ["count", "timestamp"],
+    } as const satisfies JSONSchema;
+
+    const cell = runtime.getCell(space, "bench-sink-schema", schema, tx);
+    cell.set({ count: 0, timestamp: Date.now() });
+
+    let callCount = 0;
+
+    // Setup sink subscription
+    const cancel = cell.sink(() => {
+      callCount++;
+    });
+
+    // Measure sink execution with value changes
+    for (let i = 0; i < 1000; i++) {
+      cell.set({ count: i + 1, timestamp: Date.now() + i });
+      await runtime.idle(); // Wait for sink to execute
+    }
+
+    // Verify sink was called
+    if (callCount !== 1001) { // Initial + 1000 updates
+      throw new Error(`Expected 1001 sink calls, got ${callCount}`);
+    }
+
+    // Cleanup subscription
+    cancel();
+
+    await cleanup(runtime, storageManager, tx);
+  },
+);
 
 // Benchmark: Complex nested operations
 Deno.bench("Cell complex - schema with asCell references (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const schema = {
     type: "object",
     properties: {
@@ -860,9 +882,9 @@ Deno.bench("Cell complex - schema with asCell references (1000x)", async () => {
     },
     required: ["id", "metadata", "tags", "settings"],
   } as const satisfies JSONSchema;
-  
+
   const cell = runtime.getCell(space, "bench-asCell-schema", schema, tx);
-  
+
   cell.set({
     id: 1,
     metadata: {
@@ -875,7 +897,7 @@ Deno.bench("Cell complex - schema with asCell references (1000x)", async () => {
       notifications: true,
     },
   });
-  
+
   // Measure access with asCell references
   for (let i = 0; i < 1000; i++) {
     const value = cell.get();
@@ -884,13 +906,13 @@ Deno.bench("Cell complex - schema with asCell references (1000x)", async () => {
     value.tags;
     value.settings.get();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell complex - nested cell references (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   // Create inner cells
   const inner1 = runtime.getCell<{ value: number }>(
     space,
@@ -899,7 +921,7 @@ Deno.bench("Cell complex - nested cell references (1000x)", async () => {
     tx,
   );
   inner1.set({ value: 1 });
-  
+
   const inner2 = runtime.getCell<{ value: number }>(
     space,
     "bench-inner-2",
@@ -907,32 +929,32 @@ Deno.bench("Cell complex - nested cell references (1000x)", async () => {
     tx,
   );
   inner2.set({ value: 2 });
-  
+
   // Create outer cell with references
   const outer = runtime.getCell<{
     ref1: any;
     ref2: any;
   }>(space, "bench-outer", undefined, tx);
-  
+
   outer.set({
     ref1: inner1,
     ref2: inner2,
   });
-  
+
   // Measure nested reference access
   for (let i = 0; i < 1000; i++) {
     const proxy = outer.getAsQueryResult();
     proxy.ref1;
     proxy.ref2;
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Benchmark: Schema validation
 Deno.bench("Cell schema - complex validation (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const complexSchema = {
     type: "object",
     properties: {
@@ -959,14 +981,14 @@ Deno.bench("Cell schema - complex validation (1000x)", async () => {
     },
     required: ["id", "user", "tags"],
   } as const satisfies JSONSchema;
-  
+
   const cell = runtime.getCell(
     space,
     "bench-schema-complex",
     complexSchema,
     tx,
   );
-  
+
   // Measure complex object set with schema validation
   for (let i = 0; i < 1000; i++) {
     cell.set({
@@ -983,57 +1005,57 @@ Deno.bench("Cell schema - complex validation (1000x)", async () => {
       },
     });
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Benchmark: Large data structures
 Deno.bench("Cell large - array with 1000 items (1000x get)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell = runtime.getCell<{ items: Array<{ id: number; data: string }> }>(
     space,
     "bench-large-array",
     undefined,
     tx,
   );
-  
+
   // Create large array
   const items = Array.from({ length: 1000 }, (_, i) => ({
     id: i,
     data: `item-${i}`,
   }));
-  
+
   // Measure set operation with large data
   cell.set({ items });
-  
+
   // Measure get operation with large data
   for (let i = 0; i < 1000; i++) {
     cell.get();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 Deno.bench("Cell large - deeply nested object (1000x navigation)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   // Create deeply nested structure
   const createNested = (depth: number): any => {
     if (depth === 0) return { value: 42 };
     return { nested: createNested(depth - 1) };
   };
-  
+
   const cell = runtime.getCell<any>(
     space,
     "bench-deep-nested",
     undefined,
     tx,
   );
-  
+
   const deepData = createNested(10); // 10 levels deep
   cell.set(deepData);
-  
+
   // Measure deep navigation
   for (let i = 0; i < 1000; i++) {
     let current = cell;
@@ -1042,34 +1064,36 @@ Deno.bench("Cell large - deeply nested object (1000x navigation)", async () => {
     }
     current.key("value").get();
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Benchmark: Concurrent operations
 Deno.bench("Cell concurrent - multiple cells (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   // Create multiple cells
-  const cells = Array.from({ length: 10 }, (_, i) =>
-    runtime.getCell<number>(space, `bench-concurrent-${i}`, undefined, tx)
+  const cells = Array.from(
+    { length: 10 },
+    (_, i) =>
+      runtime.getCell<number>(space, `bench-concurrent-${i}`, undefined, tx),
   );
-  
+
   // Initialize cells
   cells.forEach((cell, i) => cell.set(i));
-  
+
   // Measure concurrent access
   for (let i = 0; i < 1000; i++) {
     cells.forEach((cell) => cell.get());
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });
 
 // Benchmark: Cell equals comparison
 Deno.bench("Cell equals - comparison operations (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
-  
+
   const cell1 = runtime.getCell<number>(space, "bench-equals-1", undefined, tx);
   const cell2 = runtime.getCell<number>(space, "bench-equals-2", undefined, tx);
   const cell1Same = runtime.getCell<number>(
@@ -1078,15 +1102,15 @@ Deno.bench("Cell equals - comparison operations (1000x)", async () => {
     undefined,
     tx,
   );
-  
+
   cell1.set(42);
   cell2.set(42);
-  
+
   // Measure equals operations
   for (let i = 0; i < 1000; i++) {
     cell1.equals(cell1Same); // Should be true
     cell1.equals(cell2); // Should be false
   }
-  
+
   await cleanup(runtime, storageManager, tx);
 });

--- a/packages/runner/test/cell.bench.ts
+++ b/packages/runner/test/cell.bench.ts
@@ -143,7 +143,7 @@ Deno.bench("Cell creation - array with schema", async () => {
 });
 
 // Benchmark: Cell get operations
-Deno.bench("Cell get - simple value schemaless", async () => {
+Deno.bench("Cell get - simple value schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<number>(space, "bench-get", undefined, tx);
@@ -157,7 +157,7 @@ Deno.bench("Cell get - simple value schemaless", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell get - complex object schemaless", async () => {
+Deno.bench("Cell get - complex object schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{
@@ -182,7 +182,7 @@ Deno.bench("Cell get - complex object schemaless", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell getRaw - complex object schemaless", async () => {
+Deno.bench("Cell getRaw - complex object schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{
@@ -208,7 +208,7 @@ Deno.bench("Cell getRaw - complex object schemaless", async () => {
 });
 
 // Schema-based get operations
-Deno.bench("Cell get - simple value with schema", async () => {
+Deno.bench("Cell get - simple value with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = { type: "number", minimum: 0 } as const satisfies JSONSchema;
@@ -223,7 +223,7 @@ Deno.bench("Cell get - simple value with schema", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell get - complex object with schema", async () => {
+Deno.bench("Cell get - complex object with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -264,7 +264,7 @@ Deno.bench("Cell get - complex object with schema", async () => {
 });
 
 // Benchmark: Cell set operations
-Deno.bench("Cell set - simple value schemaless", async () => {
+Deno.bench("Cell set - simple value schemaless (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<number>(space, "bench-set", undefined, tx);
@@ -277,7 +277,7 @@ Deno.bench("Cell set - simple value schemaless", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell send - simple value schemaless", async () => {
+Deno.bench("Cell send - simple value schemaless (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<number>(space, "bench-send", undefined, tx);
@@ -291,7 +291,7 @@ Deno.bench("Cell send - simple value schemaless", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell update - partial object update schemaless", async () => {
+Deno.bench("Cell update - partial object update schemaless (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{
@@ -311,7 +311,7 @@ Deno.bench("Cell update - partial object update schemaless", async () => {
 });
 
 // Schema-based set operations
-Deno.bench("Cell set - simple value with schema", async () => {
+Deno.bench("Cell set - simple value with schema (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = { type: "number", minimum: 0, maximum: 100 } as const satisfies JSONSchema;
@@ -325,7 +325,7 @@ Deno.bench("Cell set - simple value with schema", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell update - partial object update with schema", async () => {
+Deno.bench("Cell update - partial object update with schema (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -354,7 +354,7 @@ Deno.bench("Cell update - partial object update with schema", async () => {
 });
 
 // Benchmark: Nested cell operations
-Deno.bench("Cell key - nested access schemaless", async () => {
+Deno.bench("Cell key - nested access schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{
@@ -371,7 +371,7 @@ Deno.bench("Cell key - nested access schemaless", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell key - array access schemaless", async () => {
+Deno.bench("Cell key - array access schemaless (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{
@@ -394,7 +394,7 @@ Deno.bench("Cell key - array access schemaless", async () => {
 });
 
 // Schema-based nested operations
-Deno.bench("Cell key - nested access with schema", async () => {
+Deno.bench("Cell key - nested access with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -435,7 +435,7 @@ Deno.bench("Cell key - nested access with schema", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell key - array access with schema", async () => {
+Deno.bench("Cell key - array access with schema (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -474,7 +474,7 @@ Deno.bench("Cell key - array access with schema", async () => {
 });
 
 // Benchmark: Cell derivation
-Deno.bench("Cell asSchema - schema transformation", async () => {
+Deno.bench("Cell asSchema - schema transformation (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{
@@ -505,7 +505,7 @@ Deno.bench("Cell asSchema - schema transformation", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell withTx - transaction switching", async () => {
+Deno.bench("Cell withTx - transaction switching (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<number>(space, "bench-withTx", undefined, tx);
@@ -524,7 +524,7 @@ Deno.bench("Cell withTx - transaction switching", async () => {
 });
 
 // Benchmark: Query result proxy operations
-Deno.bench("Cell getAsQueryResult - proxy creation schemaless", async () => {
+Deno.bench("Cell getAsQueryResult - proxy creation schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{
@@ -549,7 +549,7 @@ Deno.bench("Cell getAsQueryResult - proxy creation schemaless", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell proxy - property writes schemaless", async () => {
+Deno.bench("Cell proxy - property writes schemaless (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{
@@ -570,7 +570,7 @@ Deno.bench("Cell proxy - property writes schemaless", async () => {
 });
 
 // Schema-based proxy operations
-Deno.bench("Cell getAsQueryResult - proxy creation with schema", async () => {
+Deno.bench("Cell getAsQueryResult - proxy creation with schema (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -608,7 +608,7 @@ Deno.bench("Cell getAsQueryResult - proxy creation with schema", async () => {
 });
 
 // Benchmark: Array operations
-Deno.bench("Cell push - array append schemaless", async () => {
+Deno.bench("Cell push - array append schemaless (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{ items: number[] }>(
@@ -628,7 +628,7 @@ Deno.bench("Cell push - array append schemaless", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell array - map operation schemaless", async () => {
+Deno.bench("Cell array - map operation schemaless (10x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{ items: number[] }>(
@@ -650,7 +650,7 @@ Deno.bench("Cell array - map operation schemaless", async () => {
 });
 
 // Schema-based array operations
-Deno.bench("Cell push - array append with schema", async () => {
+Deno.bench("Cell push - array append with schema (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -676,7 +676,7 @@ Deno.bench("Cell push - array append with schema", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell array - map operation with schema", async () => {
+Deno.bench("Cell array - map operation with schema (10x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -704,7 +704,7 @@ Deno.bench("Cell array - map operation with schema", async () => {
 });
 
 // Benchmark: Link operations
-Deno.bench("Cell getAsLink - link generation schemaless", async () => {
+Deno.bench("Cell getAsLink - link generation schemaless (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{ value: number }>(
@@ -723,7 +723,7 @@ Deno.bench("Cell getAsLink - link generation schemaless", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell getAsLink - with options", async () => {
+Deno.bench("Cell getAsLink - with options (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell1 = runtime.getCell<{ value: number }>(
@@ -751,7 +751,7 @@ Deno.bench("Cell getAsLink - with options", async () => {
 });
 
 // Benchmark: Subscription operations
-Deno.bench("Cell sink - subscription setup", async () => {
+Deno.bench("Cell sink - subscription setup (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<number>(space, "bench-sink", undefined, tx);
@@ -772,7 +772,7 @@ Deno.bench("Cell sink - subscription setup", async () => {
 });
 
 // Benchmark: Complex nested operations
-Deno.bench("Cell complex - schema with asCell references", async () => {
+Deno.bench("Cell complex - schema with asCell references (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const schema = {
@@ -826,7 +826,7 @@ Deno.bench("Cell complex - schema with asCell references", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell complex - nested cell references", async () => {
+Deno.bench("Cell complex - nested cell references (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   // Create inner cells
@@ -868,7 +868,7 @@ Deno.bench("Cell complex - nested cell references", async () => {
 });
 
 // Benchmark: Schema validation
-Deno.bench("Cell schema - complex validation", async () => {
+Deno.bench("Cell schema - complex validation (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const complexSchema = {
@@ -926,7 +926,7 @@ Deno.bench("Cell schema - complex validation", async () => {
 });
 
 // Benchmark: Large data structures
-Deno.bench("Cell large - array with 1000 items", async () => {
+Deno.bench("Cell large - array with 1000 items (10x get)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell = runtime.getCell<{ items: Array<{ id: number; data: string }> }>(
@@ -953,7 +953,7 @@ Deno.bench("Cell large - array with 1000 items", async () => {
   await cleanup(runtime, storageManager, tx);
 });
 
-Deno.bench("Cell large - deeply nested object", async () => {
+Deno.bench("Cell large - deeply nested object (100x navigation)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   // Create deeply nested structure
@@ -985,7 +985,7 @@ Deno.bench("Cell large - deeply nested object", async () => {
 });
 
 // Benchmark: Concurrent operations
-Deno.bench("Cell concurrent - multiple cells", async () => {
+Deno.bench("Cell concurrent - multiple cells (100x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   // Create multiple cells
@@ -1005,7 +1005,7 @@ Deno.bench("Cell concurrent - multiple cells", async () => {
 });
 
 // Benchmark: Cell equals comparison
-Deno.bench("Cell equals - comparison operations", async () => {
+Deno.bench("Cell equals - comparison operations (1000x)", async () => {
   const { runtime, storageManager, tx } = setup();
   
   const cell1 = runtime.getCell<number>(space, "bench-equals-1", undefined, tx);

--- a/packages/runner/test/cell.bench.ts
+++ b/packages/runner/test/cell.bench.ts
@@ -1,0 +1,633 @@
+import { Identity } from "@commontools/identity";
+import { StorageManager } from "@commontools/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { type JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("bench operator");
+const space = signer.did();
+
+// Setup helper to create runtime and transaction
+function setup() {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    blobbyServerUrl: import.meta.url,
+    storageManager,
+  });
+  const tx = runtime.edit();
+  return { runtime, storageManager, tx };
+}
+
+// Cleanup helper
+async function cleanup(
+  runtime: Runtime,
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+  tx: IExtendedStorageTransaction,
+) {
+  await tx.commit();
+  await runtime.dispose();
+  await storageManager.close();
+}
+
+// Benchmark: Cell creation
+Deno.bench("Cell creation - simple", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<number>(space, "bench-cell", undefined, tx);
+  cell.set(42);
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+Deno.bench("Cell creation - with schema", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const schema = {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      age: { type: "number" },
+    },
+    required: ["name", "age"],
+  } as const satisfies JSONSchema;
+  
+  const cell = runtime.getCell(space, "bench-cell-schema", schema, tx);
+  cell.set({ name: "John", age: 30 });
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+Deno.bench("Cell creation - immutable", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getImmutableCell(
+    space,
+    { value: 42 },
+    { type: "object", properties: { value: { type: "number" } } },
+    tx,
+  );
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+// Benchmark: Cell get operations
+Deno.bench("Cell get - simple value", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<number>(space, "bench-get", undefined, tx);
+  cell.set(42);
+  
+  // Measure get operation
+  for (let i = 0; i < 1000; i++) {
+    cell.get();
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+Deno.bench("Cell get - complex object", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<{
+    name: string;
+    age: number;
+    tags: string[];
+    nested: { value: number };
+  }>(space, "bench-get-complex", undefined, tx);
+  
+  cell.set({
+    name: "test",
+    age: 42,
+    tags: ["a", "b", "c"],
+    nested: { value: 123 },
+  });
+  
+  // Measure get operation
+  for (let i = 0; i < 1000; i++) {
+    cell.get();
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+Deno.bench("Cell getRaw - complex object", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<{
+    name: string;
+    age: number;
+    tags: string[];
+    nested: { value: number };
+  }>(space, "bench-getRaw", undefined, tx);
+  
+  cell.set({
+    name: "test",
+    age: 42,
+    tags: ["a", "b", "c"],
+    nested: { value: 123 },
+  });
+  
+  // Measure getRaw operation
+  for (let i = 0; i < 1000; i++) {
+    cell.getRaw();
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+// Benchmark: Cell set operations
+Deno.bench("Cell set - simple value", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<number>(space, "bench-set", undefined, tx);
+  
+  // Measure set operation
+  for (let i = 0; i < 100; i++) {
+    cell.set(i);
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+Deno.bench("Cell send - simple value", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<number>(space, "bench-send", undefined, tx);
+  cell.set(0);
+  
+  // Measure send operation
+  for (let i = 0; i < 100; i++) {
+    cell.send(i);
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+Deno.bench("Cell update - partial object update", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<{
+    name: string;
+    age: number;
+    tags: string[];
+  }>(space, "bench-update", undefined, tx);
+  
+  cell.set({ name: "test", age: 42, tags: ["a", "b"] });
+  
+  // Measure update operation
+  for (let i = 0; i < 100; i++) {
+    cell.update({ age: i });
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+// Benchmark: Nested cell operations
+Deno.bench("Cell key - nested access", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<{
+    a: { b: { c: { d: number } } };
+  }>(space, "bench-key", undefined, tx);
+  
+  cell.set({ a: { b: { c: { d: 42 } } } });
+  
+  // Measure nested key access
+  for (let i = 0; i < 1000; i++) {
+    cell.key("a").key("b").key("c").key("d").get();
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+Deno.bench("Cell key - array access", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<{
+    items: Array<{ name: string; value: number }>;
+  }>(space, "bench-key-array", undefined, tx);
+  
+  cell.set({
+    items: Array.from({ length: 100 }, (_, i) => ({
+      name: `item${i}`,
+      value: i,
+    })),
+  });
+  
+  // Measure array key access
+  for (let i = 0; i < 100; i++) {
+    cell.key("items").key(i).key("value").get();
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+// Benchmark: Cell derivation
+Deno.bench("Cell asSchema - schema transformation", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<{
+    id: number;
+    metadata: { createdAt: string; type: string };
+  }>(space, "bench-asSchema", undefined, tx);
+  
+  cell.set({
+    id: 1,
+    metadata: { createdAt: "2025-01-06", type: "user" },
+  });
+  
+  const schema = {
+    type: "object",
+    properties: {
+      id: { type: "number" },
+      metadata: { type: "object", asCell: true },
+    },
+    required: ["id", "metadata"],
+  } as const satisfies JSONSchema;
+  
+  // Measure asSchema transformation
+  for (let i = 0; i < 1000; i++) {
+    const schemaCell = cell.asSchema(schema);
+    schemaCell.get();
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+Deno.bench("Cell withTx - transaction switching", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<number>(space, "bench-withTx", undefined, tx);
+  cell.set(42);
+  
+  const tx2 = runtime.edit();
+  
+  // Measure withTx operation
+  for (let i = 0; i < 1000; i++) {
+    const newCell = cell.withTx(i % 2 === 0 ? tx : tx2);
+    newCell.get();
+  }
+  
+  await tx2.commit();
+  await cleanup(runtime, storageManager, tx);
+});
+
+// Benchmark: Query result proxy operations
+Deno.bench("Cell getAsQueryResult - proxy creation", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<{
+    name: string;
+    age: number;
+    nested: { value: number };
+  }>(space, "bench-proxy", undefined, tx);
+  
+  cell.set({
+    name: "test",
+    age: 42,
+    nested: { value: 123 },
+  });
+  
+  // Measure proxy creation and access
+  for (let i = 0; i < 1000; i++) {
+    const proxy = cell.getAsQueryResult();
+    proxy.name;
+    proxy.nested.value;
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+Deno.bench("Cell proxy - property writes", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<{
+    x: number;
+    y: number;
+  }>(space, "bench-proxy-write", undefined, tx);
+  
+  cell.set({ x: 1, y: 2 });
+  const proxy = cell.getAsQueryResult();
+  
+  // Measure proxy writes
+  for (let i = 0; i < 100; i++) {
+    proxy.x = i;
+    proxy.y = i * 2;
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+// Benchmark: Array operations
+Deno.bench("Cell push - array append", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<{ items: number[] }>(
+    space,
+    "bench-push",
+    undefined,
+    tx,
+  );
+  cell.set({ items: [] });
+  const arrayCell = cell.key("items");
+  
+  // Measure push operations
+  for (let i = 0; i < 100; i++) {
+    arrayCell.push(i);
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+Deno.bench("Cell array - map operation", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<{ items: number[] }>(
+    space,
+    "bench-array-map",
+    undefined,
+    tx,
+  );
+  cell.set({ items: Array.from({ length: 100 }, (_, i) => i) });
+  
+  const proxy = cell.getAsQueryResult();
+  
+  // Measure array map operation
+  for (let i = 0; i < 10; i++) {
+    proxy.items.map((x: number) => x * 2);
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+// Benchmark: Link operations
+Deno.bench("Cell getAsLink - link generation", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<{ value: number }>(
+    space,
+    "bench-link",
+    undefined,
+    tx,
+  );
+  cell.set({ value: 42 });
+  
+  // Measure link generation
+  for (let i = 0; i < 1000; i++) {
+    cell.getAsLink();
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+Deno.bench("Cell getAsLink - with options", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell1 = runtime.getCell<{ value: number }>(
+    space,
+    "bench-link-1",
+    undefined,
+    tx,
+  );
+  cell1.set({ value: 42 });
+  
+  const cell2 = runtime.getCell<{ other: string }>(
+    space,
+    "bench-link-2",
+    undefined,
+    tx,
+  );
+  cell2.set({ other: "test" });
+  
+  // Measure link generation with options
+  for (let i = 0; i < 1000; i++) {
+    cell1.getAsLink({ base: cell2, includeSchema: true });
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+// Benchmark: Subscription operations
+Deno.bench("Cell sink - subscription setup", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<number>(space, "bench-sink", undefined, tx);
+  cell.set(0);
+  
+  const cancels: Array<() => void> = [];
+  
+  // Measure sink subscription setup
+  for (let i = 0; i < 100; i++) {
+    const cancel = cell.sink(() => {});
+    cancels.push(cancel);
+  }
+  
+  // Cleanup subscriptions
+  cancels.forEach((cancel) => cancel());
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+// Benchmark: Complex nested operations
+Deno.bench("Cell complex - nested cell references", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  // Create inner cells
+  const inner1 = runtime.getCell<{ value: number }>(
+    space,
+    "bench-inner-1",
+    undefined,
+    tx,
+  );
+  inner1.set({ value: 1 });
+  
+  const inner2 = runtime.getCell<{ value: number }>(
+    space,
+    "bench-inner-2",
+    undefined,
+    tx,
+  );
+  inner2.set({ value: 2 });
+  
+  // Create outer cell with references
+  const outer = runtime.getCell<{
+    ref1: any;
+    ref2: any;
+  }>(space, "bench-outer", undefined, tx);
+  
+  outer.set({
+    ref1: inner1,
+    ref2: inner2,
+  });
+  
+  // Measure nested reference access
+  for (let i = 0; i < 1000; i++) {
+    const proxy = outer.getAsQueryResult();
+    proxy.ref1;
+    proxy.ref2;
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+// Benchmark: Schema validation
+Deno.bench("Cell schema - complex validation", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const complexSchema = {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      user: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          age: { type: "number", minimum: 0, maximum: 150 },
+          email: { type: "string", format: "email" },
+        },
+        required: ["name", "age"],
+      },
+      tags: {
+        type: "array",
+        items: { type: "string" },
+        minItems: 1,
+        maxItems: 10,
+      },
+      metadata: {
+        type: "object",
+        additionalProperties: { type: "string" },
+      },
+    },
+    required: ["id", "user", "tags"],
+  } as const satisfies JSONSchema;
+  
+  const cell = runtime.getCell(
+    space,
+    "bench-schema-complex",
+    complexSchema,
+    tx,
+  );
+  
+  // Measure complex object set with schema validation
+  for (let i = 0; i < 100; i++) {
+    cell.set({
+      id: `user-${i}`,
+      user: {
+        name: `User ${i}`,
+        age: 25 + (i % 50),
+        email: `user${i}@example.com`,
+      },
+      tags: ["tag1", "tag2", "tag3"],
+      metadata: {
+        created: "2025-01-01",
+        updated: "2025-01-22",
+      },
+    });
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+// Benchmark: Large data structures
+Deno.bench("Cell large - array with 1000 items", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell = runtime.getCell<{ items: Array<{ id: number; data: string }> }>(
+    space,
+    "bench-large-array",
+    undefined,
+    tx,
+  );
+  
+  // Create large array
+  const items = Array.from({ length: 1000 }, (_, i) => ({
+    id: i,
+    data: `item-${i}`,
+  }));
+  
+  // Measure set operation with large data
+  cell.set({ items });
+  
+  // Measure get operation with large data
+  for (let i = 0; i < 10; i++) {
+    cell.get();
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+Deno.bench("Cell large - deeply nested object", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  // Create deeply nested structure
+  const createNested = (depth: number): any => {
+    if (depth === 0) return { value: 42 };
+    return { nested: createNested(depth - 1) };
+  };
+  
+  const cell = runtime.getCell<any>(
+    space,
+    "bench-deep-nested",
+    undefined,
+    tx,
+  );
+  
+  const deepData = createNested(10); // 10 levels deep
+  cell.set(deepData);
+  
+  // Measure deep navigation
+  for (let i = 0; i < 100; i++) {
+    let current = cell;
+    for (let j = 0; j < 10; j++) {
+      current = current.key("nested");
+    }
+    current.key("value").get();
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+// Benchmark: Concurrent operations
+Deno.bench("Cell concurrent - multiple cells", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  // Create multiple cells
+  const cells = Array.from({ length: 10 }, (_, i) =>
+    runtime.getCell<number>(space, `bench-concurrent-${i}`, undefined, tx)
+  );
+  
+  // Initialize cells
+  cells.forEach((cell, i) => cell.set(i));
+  
+  // Measure concurrent access
+  for (let i = 0; i < 100; i++) {
+    cells.forEach((cell) => cell.get());
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});
+
+// Benchmark: Cell equals comparison
+Deno.bench("Cell equals - comparison operations", async () => {
+  const { runtime, storageManager, tx } = setup();
+  
+  const cell1 = runtime.getCell<number>(space, "bench-equals-1", undefined, tx);
+  const cell2 = runtime.getCell<number>(space, "bench-equals-2", undefined, tx);
+  const cell1Same = runtime.getCell<number>(
+    space,
+    "bench-equals-1",
+    undefined,
+    tx,
+  );
+  
+  cell1.set(42);
+  cell2.set(42);
+  
+  // Measure equals operations
+  for (let i = 0; i < 1000; i++) {
+    cell1.equals(cell1Same); // Should be true
+    cell1.equals(cell2); // Should be false
+  }
+  
+  await cleanup(runtime, storageManager, tx);
+});


### PR DESCRIPTION
## Summary
- Add extensive benchmark suite for Cell API performance testing
- Cover all major Cell operations including schemaless and schema-based variants
- Provide baseline metrics for future performance optimizations

## Changes
- **Core operations**: Benchmarks for creation, get/set, update, and send operations
- **Schema validation**: Compare performance between schemaless and schema-based cells
- **Nested access**: Test key() navigation and deeply nested object access
- **Array operations**: Measure push() and map() performance
- **Subscriptions**: Test sink() execution with value changes
- **Complex scenarios**: Include asCell references, proxy operations, and concurrent access
- **Large data structures**: Benchmark handling of 1000-item arrays and 10-level deep objects

## Technical Details
- All benchmarks run 1000 iterations for consistency
- Use proper setup/cleanup with transaction management
- Include both simple and complex data structures
- Test schema validation overhead across different schema types
- Measure real subscription execution with runtime.idle()

## Test Coverage
The benchmark suite covers:
- Cell creation (simple, with schema, immutable)
- Read operations (get, getRaw, getAsQueryResult)
- Write operations (set, send, update, push)
- Navigation (key access for objects and arrays)
- Transformations (asSchema, withTx)
- Links and references (getAsLink, nested cells)
- Proxy operations for both reads and writes
- Concurrent operations across multiple cells

----

Current results on my machine:

```
    CPU | Apple M3 Max
Runtime | Deno 2.3.5 (aarch64-apple-darwin)

file:///Users/berni/src/labs2/packages/runner/test/cell.bench.ts

benchmark                                                   time/iter (avg)        iter/s      (min … max)           p75      p99     p995
----------------------------------------------------------- ----------------------------- --------------------- --------------------------
Cell creation - simple schemaless (1000x)                           69.1 ms          14.5 ( 64.7 ms …  75.6 ms)  70.5 ms  75.6 ms  75.6 ms
Cell creation - with JSON schema (1000x)                            91.7 ms          10.9 ( 88.2 ms …  95.1 ms)  92.6 ms  95.1 ms  95.1 ms
Cell creation - immutable (1000x)                                   27.5 ms          36.4 ( 25.3 ms …  28.8 ms)  28.2 ms  28.8 ms  28.8 ms
Cell creation - simple with schema (1000x)                          66.4 ms          15.1 ( 64.0 ms …  68.6 ms)  68.0 ms  68.6 ms  68.6 ms
Cell creation - object with nested schema (1000x)                  156.8 ms           6.4 (147.3 ms … 226.0 ms) 155.1 ms 226.0 ms 226.0 ms
Cell creation - array with schema (1000x)                          141.5 ms           7.1 (134.2 ms … 146.5 ms) 145.7 ms 146.5 ms 146.5 ms
Cell get - simple value schemaless (1000x)                          40.4 ms          24.8 ( 39.0 ms …  42.8 ms)  41.1 ms  42.8 ms  42.8 ms
Cell get - complex object schemaless (1000x)                        41.3 ms          24.2 ( 40.1 ms …  43.2 ms)  41.5 ms  43.2 ms  43.2 ms
Cell getRaw - complex object schemaless (1000x)                    587.5 µs         1,702 (400.2 µs …  59.0 ms) 462.4 µs   3.5 ms   4.1 ms
Cell get - simple value with schema (1000x)                         41.7 ms          24.0 ( 40.3 ms …  43.8 ms)  42.7 ms  43.8 ms  43.8 ms
Cell get - complex object with schema (1000x)                         1.1 s           0.9 (   1.0 s …    1.1 s)    1.1 s    1.1 s    1.1 s
Cell set - simple value schemaless (1000x)                          19.4 ms          51.6 ( 17.6 ms …  21.6 ms)  19.9 ms  21.6 ms  21.6 ms
Cell send - simple value schemaless (1000x)                         19.0 ms          52.6 ( 18.0 ms …  20.5 ms)  19.4 ms  20.5 ms  20.5 ms
Cell update - partial object update schemaless (1000x)             129.8 ms           7.7 (121.3 ms … 175.7 ms) 126.2 ms 175.7 ms 175.7 ms
Cell set - simple value with schema (1000x)                         19.2 ms          52.0 ( 17.4 ms …  21.4 ms)  19.6 ms  21.4 ms  21.4 ms
Cell update - partial object update with schema (1000x)            127.9 ms           7.8 (125.5 ms … 132.1 ms) 128.3 ms 132.1 ms 132.1 ms
Cell key - nested access schemaless (1000x)                        632.7 ms           1.6 (616.3 ms … 642.6 ms) 642.0 ms 642.6 ms 642.6 ms
Cell key - array access schemaless (1000x)                         448.6 ms           2.2 (438.9 ms … 465.9 ms) 451.6 ms 465.9 ms 465.9 ms
Cell key - nested access with schema (1000x)                       661.8 ms           1.5 (644.6 ms … 672.5 ms) 668.0 ms 672.5 ms 672.5 ms
Cell key - array access with schema (1000x)                        453.1 ms           2.2 (444.2 ms … 466.5 ms) 456.9 ms 466.5 ms 466.5 ms
Cell asSchema - schema transformation (1000x)                      332.5 ms           3.0 (318.0 ms … 343.3 ms) 340.6 ms 343.3 ms 343.3 ms
Cell withTx - transaction switching (1000x)                         72.9 ms          13.7 ( 71.4 ms …  74.7 ms)  73.5 ms  74.7 ms  74.7 ms
Cell getAsQueryResult - proxy creation schemaless (1000x)          208.6 ms           4.8 (198.5 ms … 259.1 ms) 206.1 ms 259.1 ms 259.1 ms
Cell proxy - property writes schemaless (1000x)                      3.7 ms         268.2 (  3.2 ms …   7.4 ms)   3.6 ms   5.7 ms   7.4 ms
Cell get - complex object with asCell schema (1000x)               665.9 ms           1.5 (658.0 ms … 676.9 ms) 668.8 ms 676.9 ms 676.9 ms
Cell push - array append schemaless (1000x)                        304.6 ms           3.3 (290.4 ms … 333.8 ms) 306.5 ms 333.8 ms 333.8 ms
Cell array - proxy map operation schemaless (1000x)                   7.9 s           0.1 (   7.7 s …    8.1 s)    8.0 s    8.1 s    8.1 s
Cell push - array append with schema (1000x)                       304.1 ms           3.3 (292.5 ms … 347.6 ms) 301.4 ms 347.6 ms 347.6 ms
Cell array - map operation with schema (1000x)                       15.9 s           0.1 (  15.7 s …   16.2 s)   16.0 s   16.2 s   16.2 s
Cell getAsLink - link generation schemaless (1000x)                108.7 µs         9,202 ( 91.7 µs …   3.9 ms) 103.8 µs 222.1 µs 509.8 µs
Cell getAsLink - with options (1000x)                              237.1 µs         4,218 (213.2 µs …   1.9 ms) 230.1 µs 644.2 µs   1.1 ms
Cell sink - subscription execution (1000x)                         112.1 ms           8.9 (107.8 ms … 117.2 ms) 114.6 ms 117.2 ms 117.2 ms
Cell sink - subscription execution with schema (1000x)             529.5 ms           1.9 (510.1 ms … 539.7 ms) 537.6 ms 539.7 ms 539.7 ms
Cell complex - schema with asCell references (1000x)                  1.7 s           0.6 (   1.7 s …    1.7 s)    1.7 s    1.7 s    1.7 s
Cell complex - nested cell references (1000x)                      128.8 ms           7.8 (125.3 ms … 136.4 ms) 130.4 ms 136.4 ms 136.4 ms
Cell schema - complex validation (1000x)                            32.7 ms          30.5 ( 30.1 ms …  48.1 ms)  32.6 ms  48.1 ms  48.1 ms
Cell large - array with 1000 items (1000x get)                      84.7 ms          11.8 ( 81.5 ms …  88.1 ms)  85.7 ms  88.1 ms  88.1 ms
Cell large - deeply nested object (1000x navigation)                  2.6 s           0.4 (   2.6 s …    2.7 s)    2.6 s    2.7 s    2.7 s
Cell concurrent - multiple cells (1000x)                           468.9 ms           2.1 (446.2 ms … 483.1 ms) 475.3 ms 483.1 ms 483.1 ms
Cell equals - comparison operations (1000x)                        308.3 µs         3,244 (273.1 µs …   3.4 ms) 306.2 µs 423.6 µs 517.2 µs
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a comprehensive benchmark suite for the Cell API to measure performance across all major operations, including schemaless and schema-based variants.

- **New Features**
  - Benchmarks cover cell creation, get/set/update, nested access, array operations, schema validation, subscriptions, proxy operations, large data structures, and concurrent access.
  - Tests run 1000 iterations per operation for consistent metrics and include both simple and complex data structures.

<!-- End of auto-generated description by cubic. -->

