### PR TITLE
fix(cell): handle circular references in stream events

### DIFF
--- a/packages/html/src/render.ts
+++ b/packages/html/src/render.ts
@@ -2,6 +2,7 @@ import { isObject } from "@commontools/utils/types";
 import {
   type Cancel,
   type Cell,
+  convertCellsToLinks,
   effect,
   isCell,
   isStream,
@@ -383,7 +384,7 @@ export function serializableEvent<T>(event: Event): T {
     eventObject.detail = (event as CustomEvent).detail;
   }
 
-  return JSON.parse(JSON.stringify(eventObject)) as T;
+  return convertCellsToLinks(eventObject) as T;
 }
 
 let sanitizeEvent: EventSanitizer<unknown> = serializableEvent;

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -808,7 +808,7 @@ function subscribeToReferencedDocs<T>(
   };
 }
 
-function convertCellsToLinks(
+export function convertCellsToLinks(
   value: readonly any[] | Record<string, any> | any,
   path: string[] = [],
   seen: Map<any, string[]> = new Map(),

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -835,6 +835,9 @@ export function convertCellsToLinks(
       if (!isRecord(value)) return value;
       // Fall through to process, so even if there is a .toJSON on the
       // result we don't call it again.
+    } else if (typeof value === "function") {
+      // Handle functions without toJSON like JSON.stringify does.
+      value = undefined;
     }
 
     // Recursively process arrays and objects.

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -18,7 +18,7 @@ export type { Action, ErrorWithContext, ReactivityLog } from "./scheduler.ts";
 export * as StorageInspector from "./storage/inspector.ts";
 export type { IExtendedStorageTransaction } from "./storage/interface.ts";
 export { isDoc } from "./doc.ts";
-export { isCell, isStream } from "./cell.ts";
+export { convertCellsToLinks, isCell, isStream } from "./cell.ts";
 export {
   getCellOrThrow,
   isQueryResult,

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -264,6 +264,9 @@ describe("Cell", () => {
 
     const value = c.get();
     expect(value.z.z).toBe(value.z);
+
+    const raw = c.getRaw();
+    expect(raw.z).toMatchObject({ "/": { [LINK_V1_TAG]: { path: [] } } });
   });
 
   it("should translate circular references into links across cells", () => {
@@ -717,6 +720,117 @@ describe("createProxy", () => {
   });
 });
 
+describe("Proxy", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+
+    runtime = new Runtime({
+      blobbyServerUrl: import.meta.url,
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("should return a Sendable for stream aliases", async () => {
+    const c = runtime.getCell<{ stream: { $stream: true } }>(
+      space,
+      "should return a Sendable for stream aliases",
+      undefined,
+      tx,
+    );
+    c.setRaw({ stream: { $stream: true } });
+    const streamCell = c.key("stream");
+
+    expect(streamCell).toHaveProperty("send");
+    expect(streamCell).not.toHaveProperty("get");
+    expect(streamCell).not.toHaveProperty("set");
+    expect(streamCell).not.toHaveProperty("key");
+
+    let lastEventSeen: any = null;
+    let eventCount = 0;
+
+    runtime.scheduler.addEventHandler(
+      (event: any) => {
+        eventCount++;
+        lastEventSeen = event;
+      },
+      streamCell.getAsNormalizedFullLink(),
+    );
+
+    streamCell.send({ $stream: true });
+    await runtime.idle();
+
+    expect(c.get()).toStrictEqual({ stream: { $stream: true } });
+    expect(eventCount).toBe(1);
+    expect(lastEventSeen).toEqual({ $stream: true });
+  });
+
+  it("should convert cells and proxies to links when sending events", async () => {
+    const c = runtime.getCell<any>(
+      space,
+      "should convert cells and proxies to links when sending events",
+    );
+    c.withTx(tx).setRaw({ stream: { $stream: true } });
+    tx.commit();
+    tx = runtime.edit();
+
+    const streamCell = c.key("stream");
+
+    let lastEventSeen: any = null;
+    let eventCount = 0;
+
+    runtime.scheduler.addEventHandler(
+      (event: any) => {
+        eventCount++;
+        lastEventSeen = event;
+      },
+      streamCell.getAsNormalizedFullLink(),
+    );
+
+    const c2 = runtime.getCell(
+      space,
+      "should convert cells and proxies to links when sending events: payload",
+      {
+        type: "object",
+        properties: { x: { type: "number" }, y: { type: "number" } },
+        required: ["x", "y"],
+      } as const satisfies JSONSchema,
+      tx,
+    );
+    c2.withTx(tx).set({ x: 1, y: 2 });
+    tx.commit();
+    tx = runtime.edit();
+
+    // Create event, with cell, query result and circular reference.
+    const event: any = { a: c2, b: c2.getAsQueryResult() };
+    event.c = event;
+
+    streamCell.send(event);
+
+    await runtime.idle();
+
+    expect(eventCount).toBe(1);
+    const { id } = c2.getAsNormalizedFullLink();
+    expect(lastEventSeen).toEqual(
+      {
+        a: { "/": { [LINK_V1_TAG]: { id, path: [], space } } },
+        b: { "/": { [LINK_V1_TAG]: { id, path: [], space } } },
+        c: { "/": { [LINK_V1_TAG]: { path: [] } } },
+      },
+    );
+  });
+});
+
 describe("asCell", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
@@ -786,40 +900,6 @@ describe("asCell", () => {
 
     nestedCell.set(100);
     expect(simpleCell.get()).toEqual({ a: { b: { c: 100 } } });
-  });
-
-  it("should return a Sendable for stream aliases", async () => {
-    const c = runtime.getCell<{ stream: { $stream: true } }>(
-      space,
-      "should return a Sendable for stream aliases",
-      undefined,
-      tx,
-    );
-    c.setRaw({ stream: { $stream: true } });
-    const streamCell = c.key("stream");
-
-    expect(streamCell).toHaveProperty("send");
-    expect(streamCell).not.toHaveProperty("get");
-    expect(streamCell).not.toHaveProperty("set");
-    expect(streamCell).not.toHaveProperty("key");
-
-    let lastEventSeen: any = null;
-    let eventCount = 0;
-
-    runtime.scheduler.addEventHandler(
-      (event: any) => {
-        eventCount++;
-        lastEventSeen = event;
-      },
-      streamCell.getAsNormalizedFullLink(),
-    );
-
-    streamCell.send({ $stream: true });
-    await runtime.idle();
-
-    expect(c.get()).toStrictEqual({ stream: { $stream: true } });
-    expect(eventCount).toBe(1);
-    expect(lastEventSeen).toEqual({ $stream: true });
   });
 
   it("should call sink only when the cell changes on the subpath", async () => {


### PR DESCRIPTION
Convert cells, including query result proxies and circular references to links when sending stream events to prevent JSON serialization errors. Added tests as well.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stream events now convert cells, query result proxies, and circular references to links before sending, preventing JSON serialization errors.

- **Bug Fixes**
  - Added logic to detect and replace circular references and cell-like objects with link representations in stream event payloads.
  - Added tests to cover these cases.

<!-- End of auto-generated description by cubic. -->

