### PR TITLE
Add Github Markdown style checkbox support to `ct-outliner` items [CT-574]

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -105,8 +105,9 @@
     "npm:@sentry/react@^9.7.0": "9.41.0_react@18.3.1",
     "npm:@shoelace-style/shoelace@^2.19.1": "2.20.1_@types+react@18.3.23",
     "npm:@tailwindcss/typography@~0.5.16": "0.5.16_tailwindcss@4.1.11",
-    "npm:@tailwindcss/vite@^4.0.1": "4.1.11_vite@6.3.5__@types+node@22.16.5__picomatch@4.0.3_@types+node@22.16.5",
+    "npm:@tailwindcss/vite@^4.0.1": "4.1.11_vite@6.3.5__@types+node@22.16.5__picomatch@4.0.3_@types+node@22.16.5_@types+node@22.15.15",
     "npm:@types/jsdom@^21.1.7": "21.1.7",
+    "npm:@types/node@*": "22.15.15",
     "npm:@types/node@^22.12.0": "22.16.5",
     "npm:@types/node@^22.5.5": "22.16.5",
     "npm:@types/react-dom@^18.3.1": "18.3.7_@types+react@18.3.23",
@@ -117,7 +118,7 @@
     "npm:@uiw/react-json-view@2.0.0-alpha.30": "2.0.0-alpha.30_@babel+runtime@7.28.2_react@18.3.1_react-dom@18.3.1__react@18.3.1",
     "npm:@use-gesture/react@^10.3.1": "10.3.1_react@18.3.1",
     "npm:@vercel/otel@^1.10.1": "1.13.0_@opentelemetry+api@1.9.0_@opentelemetry+api-logs@0.57.2_@opentelemetry+instrumentation@0.57.2__@opentelemetry+api@1.9.0_@opentelemetry+resources@1.30.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-logs@0.57.2__@opentelemetry+api@1.9.0_@opentelemetry+sdk-metrics@1.30.1__@opentelemetry+api@1.9.0_@opentelemetry+sdk-trace-base@1.30.1__@opentelemetry+api@1.9.0",
-    "npm:@vitejs/plugin-react@^4.3.4": "4.7.0_vite@6.3.5__@types+node@22.16.5__picomatch@4.0.3_@babel+core@7.28.0_@types+node@22.16.5",
+    "npm:@vitejs/plugin-react@^4.3.4": "4.7.0_vite@6.3.5__@types+node@22.16.5__picomatch@4.0.3_@babel+core@7.28.0_@types+node@22.16.5_@types+node@22.15.15",
     "npm:@web/test-runner@*": "0.20.2",
     "npm:ai@^4.3.10": "4.3.19_react@18.3.1_zod@3.25.76",
     "npm:ai@^4.3.9": "4.3.19_react@18.3.1_zod@3.25.76",
@@ -162,8 +163,8 @@
     "npm:turndown@^7.1.2": "7.2.0",
     "npm:typescript@*": "5.8.3",
     "npm:typescript@^5.6.2": "5.8.3",
-    "npm:vite@^6.2.1": "6.3.5_@types+node@22.16.5_picomatch@4.0.3",
-    "npm:vitest@^2.1.1": "2.1.9_@types+node@22.16.5_jsdom@26.1.0_vite@5.4.19__@types+node@22.16.5",
+    "npm:vite@^6.2.1": "6.3.5_@types+node@22.16.5_picomatch@4.0.3_@types+node@22.15.15",
+    "npm:vitest@^2.1.1": "2.1.9_@types+node@22.16.5_jsdom@26.1.0_vite@5.4.19__@types+node@22.16.5_@types+node@22.15.15",
     "npm:zod-to-json-schema@^3.24.1": "3.24.6_zod@3.25.76",
     "npm:zod@^3.24.1": "3.25.76"
   },
@@ -2389,6 +2390,15 @@
         "vite@6.3.5_@types+node@22.16.5_picomatch@4.0.3"
       ]
     },
+    "@tailwindcss/vite@4.1.11_vite@6.3.5__@types+node@22.16.5__picomatch@4.0.3_@types+node@22.16.5_@types+node@22.15.15": {
+      "integrity": "sha512-RHYhrR3hku0MJFRV+fN2gNbDNEh3dwKvY8XJvTxCSXeMOsCRSr+uKvDWQcbizrHgjML6ZmTE5OwMrl5wKcujCw==",
+      "dependencies": [
+        "@tailwindcss/node",
+        "@tailwindcss/oxide",
+        "tailwindcss",
+        "vite@6.3.5_@types+node@22.16.5_picomatch@4.0.3_@types+node@22.15.15"
+      ]
+    },
     "@tootallnate/quickjs-emscripten@0.23.0": {
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
     },
@@ -2811,6 +2821,18 @@
         "vite@6.3.5_@types+node@22.16.5_picomatch@4.0.3"
       ]
     },
+    "@vitejs/plugin-react@4.7.0_vite@6.3.5__@types+node@22.16.5__picomatch@4.0.3_@babel+core@7.28.0_@types+node@22.16.5_@types+node@22.15.15": {
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dependencies": [
+        "@babel/core",
+        "@babel/plugin-transform-react-jsx-self",
+        "@babel/plugin-transform-react-jsx-source",
+        "@rolldown/pluginutils",
+        "@types/babel__core",
+        "react-refresh",
+        "vite@6.3.5_@types+node@22.16.5_picomatch@4.0.3_@types+node@22.15.15"
+      ]
+    },
     "@vitest/expect@2.1.9": {
       "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
       "dependencies": [
@@ -2830,6 +2852,18 @@
       ],
       "optionalPeers": [
         "vite@5.4.19_@types+node@22.16.5"
+      ]
+    },
+    "@vitest/mocker@2.1.9_vite@5.4.19__@types+node@22.16.5_@types+node@22.16.5_@types+node@22.15.15": {
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dependencies": [
+        "@vitest/spy",
+        "estree-walker@3.0.3",
+        "magic-string",
+        "vite@5.4.19_@types+node@22.16.5_@types+node@22.15.15"
+      ],
+      "optionalPeers": [
+        "vite@5.4.19_@types+node@22.16.5_@types+node@22.15.15"
       ]
     },
     "@vitest/pretty-format@2.1.9": {
@@ -6495,6 +6529,17 @@
       ],
       "bin": true
     },
+    "vite-node@2.1.9_@types+node@22.16.5_@types+node@22.15.15": {
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dependencies": [
+        "cac",
+        "debug@4.4.1",
+        "es-module-lexer",
+        "pathe",
+        "vite@5.4.19_@types+node@22.16.5_@types+node@22.15.15"
+      ],
+      "bin": true
+    },
     "vite@5.4.19_@types+node@22.16.5": {
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dependencies": [
@@ -6508,6 +6553,22 @@
       ],
       "optionalPeers": [
         "@types/node@22.16.5"
+      ],
+      "bin": true
+    },
+    "vite@5.4.19_@types+node@22.16.5_@types+node@22.15.15": {
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+      "dependencies": [
+        "@types/node@22.15.15",
+        "esbuild@0.21.5",
+        "postcss",
+        "rollup"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "optionalPeers": [
+        "@types/node@22.15.15"
       ],
       "bin": true
     },
@@ -6530,12 +6591,31 @@
       ],
       "bin": true
     },
+    "vite@6.3.5_@types+node@22.16.5_picomatch@4.0.3_@types+node@22.15.15": {
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "dependencies": [
+        "@types/node@22.15.15",
+        "esbuild@0.25.8",
+        "fdir",
+        "picomatch@4.0.3",
+        "postcss",
+        "rollup",
+        "tinyglobby"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "optionalPeers": [
+        "@types/node@22.15.15"
+      ],
+      "bin": true
+    },
     "vitest@2.1.9_@types+node@22.16.5_jsdom@26.1.0_vite@5.4.19__@types+node@22.16.5": {
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dependencies": [
         "@types/node@22.16.5",
         "@vitest/expect",
-        "@vitest/mocker",
+        "@vitest/mocker@2.1.9_vite@5.4.19__@types+node@22.16.5_@types+node@22.16.5",
         "@vitest/pretty-format",
         "@vitest/runner",
         "@vitest/snapshot",
@@ -6553,11 +6633,43 @@
         "tinypool",
         "tinyrainbow",
         "vite@5.4.19_@types+node@22.16.5",
-        "vite-node",
+        "vite-node@2.1.9_@types+node@22.16.5",
         "why-is-node-running"
       ],
       "optionalPeers": [
         "@types/node@22.16.5",
+        "jsdom"
+      ],
+      "bin": true
+    },
+    "vitest@2.1.9_@types+node@22.16.5_jsdom@26.1.0_vite@5.4.19__@types+node@22.16.5_@types+node@22.15.15": {
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dependencies": [
+        "@types/node@22.15.15",
+        "@vitest/expect",
+        "@vitest/mocker@2.1.9_vite@5.4.19__@types+node@22.16.5_@types+node@22.16.5_@types+node@22.15.15",
+        "@vitest/pretty-format",
+        "@vitest/runner",
+        "@vitest/snapshot",
+        "@vitest/spy",
+        "@vitest/utils",
+        "chai",
+        "debug@4.4.1",
+        "expect-type",
+        "jsdom",
+        "magic-string",
+        "pathe",
+        "std-env",
+        "tinybench",
+        "tinyexec",
+        "tinypool",
+        "tinyrainbow",
+        "vite@5.4.19_@types+node@22.16.5_@types+node@22.15.15",
+        "vite-node@2.1.9_@types+node@22.16.5_@types+node@22.15.15",
+        "why-is-node-running"
+      ],
+      "optionalPeers": [
+        "@types/node@22.15.15",
         "jsdom"
       ],
       "bin": true
@@ -6756,9 +6868,12 @@
     }
   },
   "redirects": {
+    "https://esm.sh/@babel/standalone": "https://esm.sh/@babel/standalone@7.27.6",
+    "https://esm.sh/@types/babel__standalone@~7.1.9/index.d.ts": "https://esm.sh/@types/babel__standalone@7.1.9/index.d.ts",
     "https://esm.sh/core-js/proposals/explicit-resource-management": "https://esm.sh/core-js@3.44.0/proposals/explicit-resource-management"
   },
   "remote": {
+    "https://esm.sh/@babel/standalone@7.27.6": "e9eb3bdd4f4d18158dbe040d6cfbd5b543eade71ea1b92ecede902f5ae34b9b9",
     "https://esm.sh/core-js@3.44.0/denonext/proposals/explicit-resource-management.mjs": "4850503a2650ba47368eb95b1aa2565b47bad32efe9738766811f6de75cf51e1",
     "https://esm.sh/core-js@3.44.0/proposals/explicit-resource-management": "06969d679705ab37fd058cc66a50cd7648f79bf5fd86fb13b29cb93c2667ebc7"
   },

--- a/packages/ui/src/v2/components/ct-input/ct-input.ts
+++ b/packages/ui/src/v2/components/ct-input/ct-input.ts
@@ -500,7 +500,6 @@ export class CTInput extends BaseElement {
     }
   }
 
-
   override render() {
     const pattern = this.getPattern();
     const inputMode = this.getInputMode();

--- a/packages/ui/src/v2/components/ct-input/ct-input.ts
+++ b/packages/ui/src/v2/components/ct-input/ct-input.ts
@@ -547,6 +547,7 @@ export class CTInput extends BaseElement {
 
   private _handleInput(event: Event) {
     const input = event.target as HTMLInputElement;
+    const oldValue = this.getValue();
 
     // For file inputs, we can't set the value programmatically
     if (this.type !== "file") {
@@ -555,10 +556,19 @@ export class CTInput extends BaseElement {
       // For file inputs, still emit the event with files
       this.setValue("", input.files);
     }
+
+    // Emit ct-input event directly for non-cell interop
+    this.emit("ct-input", {
+      value: this.type === "file" ? "" : input.value,
+      oldValue,
+      name: this.name,
+      files: this.type === "file" ? input.files : undefined,
+    });
   }
 
   private _handleChange(event: Event) {
     const input = event.target as HTMLInputElement;
+    const oldValue = this.getValue();
 
     // Change events use the same setValue logic as input events
     // The timing controller will determine when to actually emit
@@ -567,6 +577,15 @@ export class CTInput extends BaseElement {
     } else {
       this.setValue("", input.files);
     }
+
+    // Emit ct-change event directly for non-cell interop
+    // This ensures the event is emitted regardless of timing strategy
+    this.emit("ct-change", {
+      value: this.type === "file" ? "" : input.value,
+      oldValue,
+      name: this.name,
+      files: this.type === "file" ? input.files : undefined,
+    });
   }
 
   private _handleFocus(_event: Event) {

--- a/packages/ui/src/v2/components/ct-message-input/ct-message-input.ts
+++ b/packages/ui/src/v2/components/ct-message-input/ct-message-input.ts
@@ -123,8 +123,7 @@ export class CTMessageInput extends BaseElement {
           .placeholder="${this.placeholder}"
           .value="${this.value}"
           ?disabled="${this.disabled}"
-          @keydown="${this._handleKeyDown}"
-          @ct-input="${this._handleInput}"
+          @ct-change="${this._handleInput}"
           part="input"
         ></ct-input>
         <ct-button

--- a/packages/ui/src/v2/components/ct-outliner/test-checkbox.html
+++ b/packages/ui/src/v2/components/ct-outliner/test-checkbox.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CT Outliner Checkbox Test</title>
+  <script type="module">
+    import './ct-outliner.ts';
+    import { TreeOperations } from './tree-operations.ts';
+    
+    // Create test data with checkboxes
+    const testTree = {
+      root: {
+        body: "",
+        children: [
+          {
+            body: "[] Unchecked task with empty brackets",
+            children: [],
+            attachments: []
+          },
+          {
+            body: "[ ] Unchecked task with space",
+            children: [],
+            attachments: []
+          },
+          {
+            body: "[x] Completed task",
+            children: [],
+            attachments: []
+          },
+          {
+            body: "Regular item without checkbox",
+            children: [
+              {
+                body: "[x] Nested checked item",
+                children: [],
+                attachments: []
+              }
+            ],
+            attachments: []
+          }
+        ]
+      }
+    };
+    
+    // Create outliner component
+    const outliner = document.createElement('ct-outliner');
+    outliner.value = testTree;
+    document.body.appendChild(outliner);
+    
+    // Add some styling
+    const style = document.createElement('style');
+    style.textContent = `
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        max-width: 800px;
+        margin: 40px auto;
+        padding: 20px;
+        background: #f5f5f5;
+      }
+      ct-outliner {
+        background: white;
+        border: 1px solid #e0e0e0;
+        border-radius: 8px;
+        padding: 20px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      }
+      h1 {
+        color: #333;
+        margin-bottom: 10px;
+      }
+      .instructions {
+        color: #666;
+        margin-bottom: 20px;
+        line-height: 1.6;
+      }
+    `;
+    document.head.appendChild(style);
+    
+    // Add instructions
+    const instructions = document.createElement('div');
+    instructions.className = 'instructions';
+    instructions.innerHTML = `
+      <h1>CT Outliner Checkbox Test</h1>
+      <p>
+        <strong>Instructions:</strong><br>
+        • Click on checkboxes to toggle their state<br>
+        • Press <kbd>Ctrl/Cmd + L</kbd> on a focused item to toggle or add checkbox<br>
+        • Double-click to edit items (checkbox syntax is preserved)<br>
+        • Both <code>[]</code> and <code>[ ]</code> work as unchecked states
+      </p>
+    `;
+    document.body.insertBefore(instructions, outliner);
+  </script>
+</head>
+<body>
+</body>
+</html>

--- a/packages/ui/src/v2/components/ct-outliner/tree-operations.ts
+++ b/packages/ui/src/v2/components/ct-outliner/tree-operations.ts
@@ -501,4 +501,60 @@ export const TreeOperations = {
 
     return null;
   },
+
+  /**
+   * Check if a node has a checkbox prefix
+   */
+  hasCheckbox(node: Node): boolean {
+    return /^\s*\[[ x]?\]\s*/.test(node.body);
+  },
+
+  /**
+   * Check if a node's checkbox is checked
+   */
+  isCheckboxChecked(node: Node): boolean {
+    return /^\s*\[x\]\s*/.test(node.body);
+  },
+
+  /**
+   * Toggle the checkbox state of a node
+   * Cycles: unchecked ([] or [ ]) → checked ([x]) → unchecked ([ ])
+   */
+  toggleCheckbox(tree: Tree, targetNode: Node): void {
+    const mutableNode = targetNode as MutableNode;
+    
+    if (TreeOperations.hasCheckbox(targetNode)) {
+      // Toggle existing checkbox
+      if (TreeOperations.isCheckboxChecked(targetNode)) {
+        // Checked -> Unchecked (normalize to [ ])
+        mutableNode.body = mutableNode.body.replace(/^\s*\[x\]\s*/, '[ ] ');
+      } else {
+        // Unchecked -> Checked
+        mutableNode.body = mutableNode.body.replace(/^\s*\[[ ]?\]\s*/, '[x] ');
+      }
+    } else {
+      // Add checkbox if none exists
+      mutableNode.body = '[ ] ' + mutableNode.body;
+    }
+  },
+
+  /**
+   * Get the body text without the checkbox prefix
+   */
+  getBodyWithoutCheckbox(node: Node): string {
+    return node.body.replace(/^\s*\[[ x]?\]\s*/, '');
+  },
+
+  /**
+   * Extract checkbox state from node body
+   * Returns: 'checked', 'unchecked', or null if no checkbox
+   */
+  getCheckboxState(node: Node): 'checked' | 'unchecked' | null {
+    if (TreeOperations.isCheckboxChecked(node)) {
+      return 'checked';
+    } else if (TreeOperations.hasCheckbox(node)) {
+      return 'unchecked';
+    }
+    return null;
+  },
 };

--- a/packages/ui/src/v2/components/ct-outliner/types.ts
+++ b/packages/ui/src/v2/components/ct-outliner/types.ts
@@ -119,7 +119,8 @@ export interface OutlinerOperations {
   requestUpdate(): void;
   getAllVisibleNodes(): Node[];
 
-  // Checkbox operations
+  // Checkbox operations  
+  setNodeCheckbox(node: Node, isChecked: boolean): void;
   toggleNodeCheckbox(node: Node): void;
 
   // Legacy method - CellController handles change events automatically

--- a/packages/ui/src/v2/components/ct-outliner/types.ts
+++ b/packages/ui/src/v2/components/ct-outliner/types.ts
@@ -119,6 +119,9 @@ export interface OutlinerOperations {
   requestUpdate(): void;
   getAllVisibleNodes(): Node[];
 
+  // Checkbox operations
+  toggleNodeCheckbox(node: Node): void;
+
   // Legacy method - CellController handles change events automatically
   emitChange(): void;
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for GitHub-style Markdown checkboxes in ct-outliner items, allowing users to add, toggle, and display checkboxes using [ ] and [x] syntax.

- **New Features**
  - Checkbox UI appears for items starting with [ ] or [x].
  - Clicking a checkbox or pressing Ctrl/Cmd+L toggles its state.
  - Checkbox state is preserved in edit mode and supports both [] and [ ] as unchecked.

<!-- End of auto-generated description by cubic. -->

