### PR TITLE
refactor(runner): simplify link resolution and improve cycle detection

### DIFF
--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -3,7 +3,7 @@ import { ID, ID_FIELD, type JSONSchema } from "./builder/types.ts";
 import { type DocImpl, isDoc } from "./doc.ts";
 import { createRef } from "./doc-map.ts";
 import { isCell, RegularCell } from "./cell.ts";
-import { followWriteRedirects } from "./link-resolution.ts";
+import { resolveLink } from "./link-resolution.ts";
 import {
   areLinksSame,
   areMaybeLinkAndNormalizedLinkSame,
@@ -199,7 +199,11 @@ export function normalizeAndDiff(
   // Handle alias in current value (at this point: if newValue is not an alias)
   if (isWriteRedirectLink(currentValue)) {
     // Log reads of the alias, so that changing aliases cause refreshes
-    const redirectLink = followWriteRedirects(tx, currentValue, link);
+    const redirectLink = resolveLink(
+      tx,
+      parseLink(currentValue, link),
+      "writeRedirect",
+    );
     return normalizeAndDiff(
       runtime,
       tx,

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -36,7 +36,7 @@ export {
   type TypeScriptHarnessProcessOptions,
 } from "./harness/index.ts";
 export { addCommonIDfromObjectID } from "./data-updating.ts";
-export { followWriteRedirects } from "./link-resolution.ts";
+export { resolveLink } from "./link-resolution.ts";
 export {
   areLinksSame,
   isLegacyCellLink,

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -1,187 +1,123 @@
 import { isRecord } from "@commontools/utils/types";
-import { ContextualFlowControl } from "./cfc.ts";
-import { type Cell } from "./cell.ts";
+import { getLogger } from "@commontools/utils/logger";
+import { LINK_V1_TAG } from "./sigil-types.ts";
 import {
-  type LegacyAlias,
-  LINK_V1_TAG,
-  type SigilWriteRedirectLink,
-  type URI,
-} from "./sigil-types.ts";
-import {
-  areNormalizedLinksSame,
   type CellLink,
-  isWriteRedirectLink,
   type NormalizedFullLink,
   parseLink,
 } from "./link-utils.ts";
 import type {
   IExtendedStorageTransaction,
-  IMemorySpaceAddress,
+  MemoryAddressPathComponent,
 } from "./storage/interface.ts";
-import type { MemorySpace } from "@commontools/memory/interface";
+
+const logger = getLogger("link-resolution");
+
+export type LastNode = "value" | "writeRedirect" | "top";
 
 /**
- * Track visited cell links and memoize results during path resolution
- * and link following to prevent redundant work.
+ * A resolved link is a link that has been resolved to a document that no longer
+ * has any links between the top and the value at `link.path`.
  */
-interface Visits {
-  /** Tracks visited cell links to detect cycles */
-  seen: IMemorySpaceAddress[];
-  /** Cache for resolvePath results */
-  resolvePathCache: Map<string, IMemorySpaceAddress>;
-  /** Cache for followLinks results */
-  followLinksCache: Map<string, IMemorySpaceAddress>;
-}
+declare const resolvedFullLinkBrand: unique symbol;
+export type ResolvedFullLink = NormalizedFullLink & {
+  // type-script only marker, doesn't appear in actual data
+  [resolvedFullLinkBrand]: true;
+};
+
+const MAX_PATH_RESOLUTION_LENGTH = 1000;
 
 /**
- * Creates a new visits tracking object.
+ * Resolves a document path with support for links inside documents.
+ *
+ * It returns a `ResolvedFullLink` that points to a document that no longer has
+ * any links between the top and the value at `link.path`. When a cycle is
+ * detected, a warning is logged and a static link to `undefined` returned.
+ *
+ * `lastNode` controls whether to follow links on the last path segment. By
+ * default all links are followed, but if `lastNode` is `LastNode.WriteRedirect`
+ * only write redirects are followed and if `lastNode` is `LastNode.Top` no
+ * links are followed at all.
+ *
+ * Links can point to another (document, path) pair, and may appear either at
+ * leaf nodes or in the middle of a document. This resolver transparently
+ * follows such links and detects cycles.
+ *
+ * A cycle is detected if the exact (document, path) pair is visited more than
+ * once. This detects cycles like:
+ * - A/foo → A/foo
+ * - A → B → C → A
+ *
+ * But there are cycles that can lead to growing paths, e.g.
+ * - A → A/foo
+ * - A → B, B → A/foo
+ *
+ * These are difficult to detect, since there are many legitimate cases for the
+ * same link to be followed several times, so instead we just have an upper
+ * bound of 1000 iterations, and log a warning.
+ *
+ * @param tx - The storage transaction to read from.
+ * @param link - The link to read.
+ * @param lastNode - The last node in the path.
+ * @returns The resolved link.
  */
-export function createVisits(): Visits {
-  return {
-    seen: [],
-    resolvePathCache: new Map(),
-    followLinksCache: new Map(),
-  };
-}
-
-/**
- * Creates a cache key for a doc and path combination.
- */
-function createPathCacheKey<T>(
-  address: IMemorySpaceAddress,
-  aliases: boolean = false,
-): string {
-  return JSON.stringify([
-    address.space,
-    address.id,
-    address.path,
-    address.type,
-    aliases,
-  ]);
-}
-
-/**
- * Helper to create an IMemoryAddress from a URI and path
- */
-function createMemoryAddress(
-  uri: URI,
-  path: PropertyKey[],
-  space: MemorySpace,
-): IMemorySpaceAddress {
-  // Add the 'value' path prefix for entity data
-  const actualPath = path.length === 0 ? ["value"] : ["value", ...path];
-  return {
-    id: uri,
-    space,
-    path: actualPath.map((p) => p.toString()),
-    type: "application/json",
-  };
-}
-
-export function resolveLinkToValue<T>(
-  tx: IExtendedStorageTransaction,
-  address: IMemorySpaceAddress,
-): NormalizedFullLink {
-  const visits = createVisits();
-  const link = resolvePath(tx, address, visits);
-  return followLinks(tx, link, visits);
-}
-
-export function resolveLinkToWriteRedirect<T>(
-  tx: IExtendedStorageTransaction,
-  address: IMemorySpaceAddress,
-): NormalizedFullLink {
-  const visits = createVisits();
-  const link = resolvePath(tx, address, visits);
-  return followLinks(tx, link, visits, true);
-}
-
-export function resolveLinks(
-  tx: IExtendedStorageTransaction,
-  link: IMemorySpaceAddress,
-): NormalizedFullLink {
-  const visits = createVisits();
-  return followLinks(tx, link, visits);
-}
-
-function resolvePath<T>(
+export function resolveLink(
   tx: IExtendedStorageTransaction,
   link: NormalizedFullLink,
-  visits: Visits = createVisits(),
-): NormalizedFullLink {
-  // Follow aliases, doc links, etc. in path, so that we end up on the right
-  // doc, meaning the one that contains the value we want to access without any
-  // redirects in between.
-  //
-  // If the path points to a redirect itself, we don't want to follow it: Other
-  // functions like followLinks will do that. We just want to skip the interim ones.
-  //
-  // All taken links are logged, but not the final one.
-  //
-  // Let's look at a few examples:
-  //
-  // Doc: { link }, path: [] --> no change
-  // Doc: { link }, path: ["foo"] --> follow link, path: ["foo"]
-  // Doc: { foo: { link } }, path: ["foo"] --> no change
-  // Doc: { foo: { link } }, path: ["foo", "bar"] --> follow link, path: ["bar"]
+  lastNode: LastNode = "value",
+): ResolvedFullLink {
+  const seen = new Set<string>();
 
-  // Check if we already resolved this exact path
-  const fullPathKey = createPathCacheKey(link);
-  const exactMatch = visits.resolvePathCache.get(fullPathKey);
-  if (exactMatch) {
-    return exactMatch;
-  }
+  const remainingPath = [...link.path];
+  const traversedPath: MemoryAddressPathComponent[] = [];
+  let result: NormalizedFullLink = { ...link, path: traversedPath };
 
-  // To resolve the path, we need to start at the empty path and traverse in
-  let keys = [...link.path];
-  link = { ...link, path: [] };
+  let iteration = 0;
 
-  // Try to find a cached result for a shorter path
-  // Look for the longest matching prefix path in the cache
-  for (let i = link.path.length - 1; i >= 0; i--) {
-    const prefixKey = createPathCacheKey({
-      ...link,
-      path: link.path.slice(0, i),
-    });
-    const prefixMatch = visits.resolvePathCache.get(prefixKey);
-
-    if (prefixMatch) {
-      keys = [...link.path.slice(i)];
-      link = { ...prefixMatch };
+  while (true) {
+    if (iteration++ > MAX_PATH_RESOLUTION_LENGTH) {
+      logger.warn(`Link resolution iteration limit reached`);
+      result = emptyResolvedFullLink;
       break;
     }
-  }
 
-  const origSchema = { schema: link.schema, rootSchema: link.rootSchema };
-  const cfc = new ContextualFlowControl();
-
-  while (keys.length) {
-    // First follow all the aliases and links, _before_ accessing the key.
-    link = { ...followLinks(tx, link, visits) };
-
-    // Now access the key.
-    const key = keys.shift()!;
-
-    link.path = [...link.path, key];
-    if (
-      link.schema === undefined && origSchema.schema !== undefined &&
-      keys.length === 0
-    ) {
-      // Since path is childPath, restore schema
-      link.schema = origSchema.schema;
-      link.rootSchema = origSchema.rootSchema;
-    } else {
-      link.schema = cfc.getSchemaAtPath(
-        link.schema,
-        [key.toString()],
-        link.rootSchema,
-      );
+    if (lastNode === "top" && remainingPath.length === 0) {
+      break; // = return before following links on last path segment
     }
+
+    // Detect cycles. Only have to do this at top of path, since link folloowing
+    // will always go through this at least once.
+    if (traversedPath.length === 0) {
+      const key = JSON.stringify([result.space, result.id, remainingPath]);
+      if (seen.has(key)) {
+        logger.warn(`Link cycle detected ${key}`);
+        result = emptyResolvedFullLink;
+        break; // = return link to empty document
+      }
+      seen.add(key);
+    }
+
+    const onlyRedirects = remainingPath.length === 0 &&
+      lastNode === "writeRedirect"; // For "value", follow all
+    const nextLink = readMaybeLink(tx, result, onlyRedirects);
+    if (nextLink !== undefined) {
+      // We have to start walking the the destination from the top, as it might
+      // contain links in the middle, so we prepend it's path to the remaining
+      // path and reset the current path to empty.
+      remainingPath.unshift(...nextLink.path);
+      traversedPath.length = 0;
+      result = { ...nextLink, path: traversedPath };
+      continue; // = continue following links at same remainingPath
+    }
+
+    if (remainingPath.length === 0) {
+      break; // = both the "value" and "writeRedirect" cases
+    }
+
+    traversedPath.push(remainingPath.shift()!);
   }
 
-  // Cache the final result
-  visits.resolvePathCache.set(fullPathKey, link);
-  return link;
+  return result as ResolvedFullLink;
 }
 
 /**
@@ -222,85 +158,9 @@ export function readMaybeLink(
   }
 }
 
-// Follows links and returns the last one, which is pointing to a value. It'll
-// log all taken links, so not the returned one, and thus nothing if the ref
-// already pointed to a value.
-export function followLinks(
-  tx: IExtendedStorageTransaction,
-  link: NormalizedFullLink,
-  visits: Visits,
-  onlyWriteRedirects = false,
-): NormalizedFullLink {
-  // Check if we already followed these links
-  const cacheKey = createPathCacheKey(link, onlyWriteRedirects);
-  const cached = visits.followLinksCache.get(cacheKey);
-  if (cached) {
-    return cached;
-  }
-
-  let nextLink: NormalizedFullLink | undefined;
-  let result: NormalizedFullLink = link;
-
-  do {
-    const resolvedLink = resolvePath(tx, result, visits);
-
-    // Add schema back if we didn't get a new one
-    if (!resolvedLink.schema && result.schema) {
-      result = {
-        ...resolvedLink,
-        schema: result.schema,
-        rootSchema: result.rootSchema,
-      };
-    } else {
-      result = resolvedLink;
-    }
-
-    nextLink = readMaybeLink(tx, result, onlyWriteRedirects);
-
-    if (nextLink !== undefined) {
-      // Add schema back if we didn't get a new one
-      if (!nextLink.schema && result.schema) {
-        nextLink = {
-          ...nextLink,
-          schema: result.schema,
-          rootSchema: result.rootSchema,
-        };
-      }
-
-      result = nextLink;
-
-      // Detect cycles (at this point these are all references that point to something)
-      if (visits.seen.some((r) => areNormalizedLinksSame(r, result))) {
-        throw new Error(
-          `Reference cycle detected ${result.id}/[${
-            result.path.join(", ")
-          }]\n\n  ${
-            visits.seen.map((r) => `${r.id}/[${r.path.join(", ")}]`).join("\n ")
-          }`,
-        );
-      }
-      visits.seen.push(result);
-    }
-  } while (nextLink);
-
-  // Cache the result
-  visits.followLinksCache.set(cacheKey, result);
-  return result;
-}
-
-// Follows aliases and returns cell reference describing the last alias.
-// Only logs interim aliases, not the first one, and not the non-alias value.
-export function followWriteRedirects<T = any>(
-  tx: IExtendedStorageTransaction,
-  writeRedirect: LegacyAlias | SigilWriteRedirectLink,
-  base: Cell<T> | NormalizedFullLink,
-): NormalizedFullLink {
-  if (isWriteRedirectLink(writeRedirect)) {
-    const link = parseLink(writeRedirect, base);
-    return followLinks(tx, link, createVisits(), true);
-  } else {
-    throw new Error(
-      `Write redirect expected: ${JSON.stringify(writeRedirect)}`,
-    );
-  }
-}
+const emptyResolvedFullLink: NormalizedFullLink = {
+  space: "did:null:null",
+  id: "data:application/json,",
+  path: [],
+  type: "application/json",
+};

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -4,9 +4,8 @@ import { getTopFrame } from "./builder/recipe.ts";
 import { type Frame, type OpaqueRef } from "./builder/types.ts";
 import { toCell, toOpaqueRef } from "./back-to-cell.ts";
 import { opaqueRef } from "./builder/opaque-ref.ts";
-import { type LegacyDocCellLink } from "./sigil-types.ts";
 import { diffAndUpdate } from "./data-updating.ts";
-import { resolveLinkToValue } from "./link-resolution.ts";
+import { resolveLink } from "./link-resolution.ts";
 import { type NormalizedFullLink } from "./link-utils.ts";
 import { type Cell, createCell } from "./cell.ts";
 import { type IRuntime } from "./runtime.ts";
@@ -93,7 +92,7 @@ export function createQueryResultProxy<T>(
   // Resolve path and follow links to actual value.
   const txStatus = tx?.status();
   const readTx = (txStatus?.status === "ready" && tx) ? tx : runtime.edit();
-  link = resolveLinkToValue(readTx, link);
+  link = resolveLink(readTx, link);
   const target = readTx.readValueOrThrow(link) as any;
 
   if (!isRecord(target)) return target;

--- a/packages/runner/src/recipe-binding.ts
+++ b/packages/runner/src/recipe-binding.ts
@@ -8,7 +8,7 @@ import {
 import { isLegacyAlias, isLink } from "./link-utils.ts";
 import { isDoc } from "./doc.ts";
 import { type Cell } from "./cell.ts";
-import { followWriteRedirects } from "./link-resolution.ts";
+import { resolveLink } from "./link-resolution.ts";
 import { diffAndUpdate } from "./data-updating.ts";
 import {
   areNormalizedLinksSame,
@@ -37,7 +37,7 @@ export function sendValueToBinding<T>(
   value: unknown,
 ): void {
   if (isLegacyAlias(binding)) {
-    const ref = followWriteRedirects(tx, binding, cell);
+    const ref = resolveLink(tx, parseLink(binding, cell), "writeRedirect");
     diffAndUpdate(
       cell.runtime,
       tx,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -29,7 +29,7 @@ import {
   unsafe_noteParentOnRecipes,
   unwrapOneLevelAndBindtoDoc,
 } from "./recipe-binding.ts";
-import { followWriteRedirects } from "./link-resolution.ts";
+import { resolveLink } from "./link-resolution.ts";
 import {
   areNormalizedLinksSame,
   createSigilLinkFromParsedLink,
@@ -648,7 +648,11 @@ export class Runner implements IRunner {
       for (const key in inputs) {
         let value = inputs[key];
         while (isWriteRedirectLink(value)) {
-          const maybeStreamLink = followWriteRedirects(tx, value, processCell);
+          const maybeStreamLink = resolveLink(
+            tx,
+            parseLink(value, processCell),
+            "writeRedirect",
+          );
           value = tx.readValueOrThrow(maybeStreamLink);
         }
         if (isStreamValue(value)) {

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -6,11 +6,7 @@ import {
 } from "./builder/types.ts";
 import { createCell, isCell, isStream } from "./cell.ts";
 import { type ReactivityLog } from "./scheduler.ts";
-import {
-  readMaybeLink,
-  resolveLinks,
-  resolveLinkToWriteRedirect,
-} from "./link-resolution.ts";
+import { readMaybeLink, resolveLink } from "./link-resolution.ts";
 import { type IExtendedStorageTransaction } from "./storage/interface.ts";
 import { type IRuntime } from "./runtime.ts";
 import { type NormalizedFullLink } from "./link-utils.ts";
@@ -306,7 +302,7 @@ export function validateAndTransform(
   // Follow aliases, etc. to last element on path + just aliases on that last one
   // When we generate cells below, we want them to be based off this value, as that
   // is what a setter would change when they update a value or reference.
-  const resolvedLink = resolveLinkToWriteRedirect(tx ?? runtime.edit(), link);
+  const resolvedLink = resolveLink(tx ?? runtime.edit(), link, "writeRedirect");
 
   // Use schema from alias if provided and no explicit schema was set
   if (!resolvedSchema && resolvedLink.schema) {
@@ -409,7 +405,7 @@ export function validateAndTransform(
   // and `path` will still point to the parent, as in e.g. the `anyOf` case
   // below we might still create a new Cell and it should point to the top of
   // this set of links.
-  const ref = resolveLinks(tx ?? runtime.edit(), link);
+  const ref = resolveLink(tx ?? runtime.edit(), link);
   let value = (tx ?? runtime.edit()).readValueOrThrow(ref);
 
   // Check for undefined value and return processed default if available

--- a/packages/runner/src/uri-utils.ts
+++ b/packages/runner/src/uri-utils.ts
@@ -92,5 +92,5 @@ export function getJSONFromDataURI(uri: URI | string): any {
 
   const decodedData = isBase64 ? atob(data) : decodeURIComponent(data);
 
-  return JSON.parse(decodedData);
+  return decodedData.length > 0 ? JSON.parse(decodedData) : undefined;
 }

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -266,7 +266,7 @@ describe("Cell", () => {
     expect(proxy.z).toBe(proxy);
 
     const value = c.get();
-    expect(value.z.z).toBe(value.z);
+    expect(value.z.z.z).toBe(value.z.z);
 
     const raw = c.getRaw();
     expect(raw.z).toMatchObject({ "/": { [LINK_V1_TAG]: { path: [] } } });

--- a/packages/runner/test/link-resolution.bench.ts
+++ b/packages/runner/test/link-resolution.bench.ts
@@ -1,0 +1,234 @@
+import { Identity } from "@commontools/identity";
+import { StorageManager } from "@commontools/runner/storage/cache.deno";
+
+import {
+  followWriteRedirects,
+  resolveLink,
+} from "../src/link-resolution.ts";
+import { Runtime } from "../src/runtime.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+// Benchmarks using Deno.bench
+Deno.bench("followWriteRedirects with simple alias", () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    blobbyServerUrl: import.meta.url,
+    storageManager,
+  });
+  const tx = runtime.edit();
+  
+  const testCell = runtime.getCell<{ value: number }>(
+    space,
+    "bench-simple-alias",
+    undefined,
+    tx,
+  );
+  testCell.set({ value: 42 });
+  const binding = { $alias: { path: ["value"] } };
+  
+  followWriteRedirects(tx, binding, testCell);
+  
+  tx.commit();
+  runtime.dispose();
+  storageManager.close();
+});
+
+Deno.bench("followWriteRedirects with nested aliases (5 levels)", () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    blobbyServerUrl: import.meta.url,
+    storageManager,
+  });
+  const tx = runtime.edit();
+  
+  const depth = 5;
+  const cells: any[] = [];
+  
+  for (let i = 0; i < depth; i++) {
+    const cell = runtime.getCell<any>(
+      space,
+      `bench-nested-${i}`,
+      undefined,
+      tx,
+    );
+    cells.push(cell);
+  }
+  
+  cells[depth - 1].set({ finalValue: 999 });
+  
+  for (let i = depth - 2; i >= 0; i--) {
+    cells[i].setRaw({
+      next: cells[i + 1].key("finalValue").getAsWriteRedirectLink(),
+    });
+  }
+  
+  const binding = { $alias: { path: ["next"] } };
+  followWriteRedirects(tx, binding, cells[0]);
+  
+  tx.commit();
+  runtime.dispose();
+  storageManager.close();
+});
+
+Deno.bench("resolveLink with direct reference", () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    blobbyServerUrl: import.meta.url,
+    storageManager,
+  });
+  const tx = runtime.edit();
+  
+  const cell = runtime.getCell<{ id: number; data: string }>(
+    space,
+    "bench-resolve",
+    undefined,
+    tx,
+  );
+  cell.set({ id: 1, data: "Test data" });
+  
+  resolveLink(tx, cell.getAsNormalizedFullLink());
+  
+  tx.commit();
+  runtime.dispose();
+  storageManager.close();
+});
+
+Deno.bench("circular reference navigation (A->B->A->value)", () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    blobbyServerUrl: import.meta.url,
+    storageManager,
+  });
+  const tx = runtime.edit();
+  
+  const cellA = runtime.getCell<{ b: any; value: string }>(
+    space,
+    "bench-circular-A",
+    undefined,
+    tx,
+  );
+  const cellB = runtime.getCell<{ a: any; value: string }>(
+    space,
+    "bench-circular-B",
+    undefined,
+    tx,
+  );
+  
+  cellA.set({ b: cellB, value: "A" });
+  cellB.set({ a: cellA, value: "B" });
+  
+  cellA.key("b").key("a").key("value").get();
+  
+  tx.commit();
+  runtime.dispose();
+  storageManager.close();
+});
+
+Deno.bench("complex path navigation (6 hops through 3 cells)", () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    blobbyServerUrl: import.meta.url,
+    storageManager,
+  });
+  const tx = runtime.edit();
+  
+  const cellA = runtime.getCell<{ b: any; c: any; data: { value: number } }>(
+    space,
+    "bench-complex-A",
+    undefined,
+    tx,
+  );
+  const cellB = runtime.getCell<{ a: any; c: any; data: { value: number } }>(
+    space,
+    "bench-complex-B",
+    undefined,
+    tx,
+  );
+  const cellC = runtime.getCell<{ a: any; b: any; data: { value: number } }>(
+    space,
+    "bench-complex-C",
+    undefined,
+    tx,
+  );
+  
+  cellA.set({ b: cellB, c: cellC, data: { value: 100 } });
+  cellB.set({ a: cellA, c: cellC, data: { value: 200 } });
+  cellC.set({ a: cellA, b: cellB, data: { value: 300 } });
+  
+  cellA.key("b").key("c").key("a").key("c").key("data").key("value").get();
+  
+  tx.commit();
+  runtime.dispose();
+  storageManager.close();
+});
+
+Deno.bench("array element resolution in circular structures", () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    blobbyServerUrl: import.meta.url,
+    storageManager,
+  });
+  const tx = runtime.edit();
+  
+  const cellA = runtime.getCell<{ items: any[]; name: string }>(
+    space,
+    "bench-array-A",
+    undefined,
+    tx,
+  );
+  const cellB = runtime.getCell<{ parent: any; index: number }>(
+    space,
+    "bench-array-B",
+    undefined,
+    tx,
+  );
+  const cellC = runtime.getCell<{ parent: any; index: number }>(
+    space,
+    "bench-array-C",
+    undefined,
+    tx,
+  );
+  
+  cellA.set({ items: [cellB, cellC], name: "Array Parent" });
+  cellB.set({ parent: cellA, index: 0 });
+  cellC.set({ parent: cellA, index: 1 });
+  
+  cellA.key("items").key(0).key("parent").key("items").key(1).key("index").get();
+  
+  tx.commit();
+  runtime.dispose();
+  storageManager.close();
+});
+
+Deno.bench("resolveLink with infinitely growing path (A->A/foo)", () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    blobbyServerUrl: import.meta.url,
+    storageManager,
+  });
+  const tx = runtime.edit();
+  
+  const cellA = runtime.getCell<any>(
+    space,
+    "bench-growing-path",
+    undefined,
+    tx,
+  );
+  
+  // Create a link from A to A/foo using setRaw to bypass cycle detection on write
+  cellA.setRaw(cellA.key("foo").getAsLink());
+  
+  // This should detect the growing path cycle and return the empty document
+  const resolved = resolveLink(tx, cellA.getAsNormalizedFullLink());
+  
+  // Verify it returned the empty document
+  if (resolved.id !== "data:application/json,") {
+    throw new Error("Expected empty document for growing path cycle");
+  }
+  
+  tx.commit();
+  runtime.dispose();
+  storageManager.close();
+});

--- a/packages/runner/test/link-resolution.test.ts
+++ b/packages/runner/test/link-resolution.test.ts
@@ -4,7 +4,7 @@ import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 
 import { type JSONSchema } from "../src/builder/types.ts";
-import { followWriteRedirects, resolveLink } from "../src/link-resolution.ts";
+import { resolveLink } from "../src/link-resolution.ts";
 import { Runtime } from "../src/runtime.ts";
 import { areNormalizedLinksSame } from "../src/link-utils.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";

--- a/packages/runner/test/link-resolution.test.ts
+++ b/packages/runner/test/link-resolution.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { followWriteRedirects } from "../src/link-resolution.ts";
-import { Runtime } from "../src/runtime.ts";
 import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
+
+import { type JSONSchema } from "../src/builder/types.ts";
+import { followWriteRedirects, resolveLink } from "../src/link-resolution.ts";
+import { Runtime } from "../src/runtime.ts";
 import { areNormalizedLinksSame } from "../src/link-utils.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { parseLink } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -42,7 +45,11 @@ describe("link-resolution", () => {
       );
       testCell.set({ value: 42 });
       const binding = { $alias: { path: ["value"] } };
-      const result = followWriteRedirects(tx, binding, testCell);
+      const result = resolveLink(
+        tx,
+        parseLink(binding, testCell)!,
+        "writeRedirect",
+      );
       expect(tx.readValueOrThrow(result)).toBe(42);
     });
 
@@ -64,7 +71,11 @@ describe("link-resolution", () => {
         outer: innerCell.key("inner").getAsWriteRedirectLink(),
       });
       const binding = { $alias: { path: ["outer"] } };
-      const result = followWriteRedirects(tx, binding, outerCell);
+      const result = resolveLink(
+        tx,
+        parseLink(binding, outerCell)!,
+        "writeRedirect",
+      );
       expect(
         areNormalizedLinksSame(
           result,
@@ -98,9 +109,10 @@ describe("link-resolution", () => {
         alias: cellA.key("alias").getAsWriteRedirectLink(),
       });
       const binding = { $alias: { path: ["alias"] } };
-      expect(() => followWriteRedirects(tx, binding, cellA)).toThrow(
-        "cycle detected",
-      );
+      expect(() => resolveLink(tx, parseLink(binding, cellA)!, "writeRedirect"))
+        .toThrow(
+          "cycle detected",
+        );
     });
 
     it("should allow aliases in aliased paths", () => {
@@ -114,7 +126,11 @@ describe("link-resolution", () => {
         a: { a: { $alias: { path: ["a", "b"] } }, b: { c: 1 } },
       });
       const binding = { $alias: { path: ["a", "a", "c"] } };
-      const result = followWriteRedirects(tx, binding, testCell);
+      const result = resolveLink(
+        tx,
+        parseLink(binding, testCell)!,
+        "writeRedirect",
+      );
       expect(
         areNormalizedLinksSame(
           result,
@@ -123,5 +139,414 @@ describe("link-resolution", () => {
       ).toBe(true);
       expect(tx.readValueOrThrow(result)).toBe(1);
     });
+  });
+});
+
+describe("Cycle detection with circular references", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+
+    runtime = new Runtime({
+      blobbyServerUrl: import.meta.url,
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("handles circular references correctly without overtriggering cycle detection", () => {
+    // This test verifies that the cycle detection does NOT overtrigger.
+    // The scenario described in the bug report works correctly:
+    // - Two cells reference each other in a cycle
+    // - We can still access properties through the cycle without errors
+    // Create cellA with a reference to cellB and a non-cyclic property
+    const cellA = runtime.getCell(
+      space,
+      "cycle-detection-bug-cellA",
+      {
+        type: "object",
+        properties: { foo: { $ref: "#" }, bar: { type: "string" } },
+      } as const as JSONSchema,
+      tx,
+    );
+
+    // Create cellB with a reference to cellA
+    const cellB = runtime.getCell<any>(
+      space,
+      "cycle-detection-bug-cellB",
+      undefined,
+      tx,
+    );
+
+    // Set up the circular reference structure as described:
+    // cellA.set({ foo: cellB, bar: "baz" })
+    // cellB.set(cellA)
+    cellA.set({ foo: cellB, bar: "baz" });
+    cellB.set(cellA);
+
+    // Test 1: A.get() should work
+    const result = cellA.get();
+    expect(result.bar).toBe("baz");
+    // When we get(), cells are automatically dereferenced, so result.foo
+    // is the actual value (not a cell)
+    expect(result.foo.bar).toBe("baz");
+    expect(result.foo.foo).toEqual(result.foo);
+
+    // Test 2: A.key("foo").get() should work and return the value of cellB (which is cellA)
+    const fooResult = cellA.key("foo").get();
+    expect(fooResult.bar).toBe("baz");
+
+    // Test 3: A.key("foo").key("bar").get() should work and return "baz"
+    // This is where the overtrigger might happen - accessing bar through the cycle
+    let barResult: string;
+    try {
+      barResult = cellA.key("foo").key("bar").get();
+      expect(barResult).toBe("baz");
+    } catch (e) {
+      // If this throws, we've hit the overtrigger bug
+      console.error(
+        "Overtrigger bug detected at A.key('foo').key('bar').get():",
+        e,
+      );
+      throw e;
+    }
+
+    // Test 4: A.key("foo").key("foo").key("foo").get() should work
+    // Multiple levels of following the references
+    let deepResult: any;
+    try {
+      deepResult = cellA.key("foo").key("foo").key("foo").get();
+      expect(deepResult.bar).toBe("baz");
+    } catch (e) {
+      // If this throws, we've hit the overtrigger bug
+      console.error(
+        "Overtrigger bug detected at A.key('foo').key('foo').key('foo').get():",
+        e,
+      );
+      throw e;
+    }
+  });
+
+  it("handles complex circular reference scenarios", () => {
+    // More complex scenario with multiple cells and properties
+    const cellA = runtime.getCell<{ b: any; c: any; value: string }>(
+      space,
+      "complex-cycle-cellA",
+      undefined,
+      tx,
+    );
+
+    const cellB = runtime.getCell<{ a: any; c: any; value: string }>(
+      space,
+      "complex-cycle-cellB",
+      undefined,
+      tx,
+    );
+
+    const cellC = runtime.getCell<{ a: any; b: any; value: string }>(
+      space,
+      "complex-cycle-cellC",
+      undefined,
+      tx,
+    );
+
+    // Create a triangle of references
+    cellA.set({ b: cellB, c: cellC, value: "A" });
+    cellB.set({ a: cellA, c: cellC, value: "B" });
+    cellC.set({ a: cellA, b: cellB, value: "C" });
+
+    // Test accessing values through different paths
+    // A -> B -> C -> value
+    expect(cellA.key("b").key("c").key("value").get()).toBe("C");
+
+    // A -> C -> B -> A -> value
+    expect(cellA.key("c").key("b").key("a").key("value").get()).toBe("A");
+
+    // Multiple hops through the same cycle
+    expect(cellA.key("b").key("a").key("b").key("a").key("value").get()).toBe(
+      "A",
+    );
+  });
+
+  it("handles deeply nested circular references with aliases", () => {
+    // Test with a mix of direct cell references and aliases
+    const cellA = runtime.getCell<any>(
+      space,
+      "deep-cycle-cellA",
+      undefined,
+      tx,
+    );
+
+    const cellB = runtime.getCell<any>(
+      space,
+      "deep-cycle-cellB",
+      undefined,
+      tx,
+    );
+
+    // Create a structure where cells reference each other at different depths
+    cellA.set({
+      direct: cellB,
+      nested: {
+        ref: cellB,
+        data: "nested-a",
+      },
+      value: "a",
+    });
+
+    cellB.set({
+      back: cellA,
+      deep: {
+        path: {
+          to: {
+            a: cellA,
+          },
+        },
+      },
+      value: "b",
+    });
+
+    // Test navigation through various paths
+    expect(cellA.key("direct").key("back").key("value").get()).toBe("a");
+    expect(
+      cellA.key("nested").key("ref").key("deep").key("path").key("to").key("a")
+        .key("value").get(),
+    ).toBe("a");
+
+    // This path should work even though it visits the same cells multiple times
+    expect(
+      cellA.key("direct").key("back").key("direct").key("back").key("nested")
+        .key("data").get(),
+    ).toBe("nested-a");
+  });
+
+  it("handles circular references with array elements", () => {
+    // This test demonstrates the cycle detection overtrigger bug
+    // The bug occurs when navigating through circular references multiple times
+    // even when accessing different properties
+    const cellA = runtime.getCell<{ items: any[]; name: string }>(
+      space,
+      "array-cycle-cellA",
+      undefined,
+      tx,
+    );
+
+    const cellB = runtime.getCell<{ parent: any; name: string }>(
+      space,
+      "array-cycle-cellB",
+      undefined,
+      tx,
+    );
+
+    const cellC = runtime.getCell<{ root: any; name: string }>(
+      space,
+      "array-cycle-cellC",
+      undefined,
+      tx,
+    );
+
+    // Create circular references through array
+    cellA.set({ items: [cellB, cellC], name: "A" });
+    cellB.set({ parent: cellA, name: "B" });
+    cellC.set({ root: cellA, name: "C" });
+
+    // Navigate through array indices and back
+    expect(cellA.key("items").key(0).key("parent").key("name").get()).toBe("A");
+
+    expect(
+      cellA.key("items").key(1).key("root").key("items").key(0).key("name")
+        .get(),
+    ).toBe("B");
+
+    // Complex path through multiple array elements
+    // This is where the bug triggers: A → items[0] (B) → parent (A) → items[1] (C) → root (A) → name
+    // The cycle detector sees we're visiting A multiple times and throws an error,
+    // even though we're legitimately navigating through the structure to access "name"
+    expect(
+      cellA.key("items").key(0).key("parent").key("items").key(1).key("root")
+        .key("name").get(),
+    ).toBe("A");
+  });
+
+  it("properly detects true circular references", () => {
+    // Test cases where circular references SHOULD be detected
+    // When a cycle is detected, the system logs a warning and returns an empty document
+
+    // Case 1: Direct circular reference A -> A
+    const cellA = runtime.getCell<any>(
+      space,
+      "direct-cycle-A",
+      undefined,
+      tx,
+    );
+    // Using setRaw to circumvent cycle detection on write
+    // This allows us to create the cycle for testing purposes
+    cellA.setRaw(cellA.getAsLink());
+
+    // When we resolve a circular reference, it should return undefined
+    // (the empty document resolves to undefined)
+    const value = cellA.get();
+    expect(value).toBeUndefined();
+
+    // Case 2: Mutual references A -> B -> A
+    const cellB = runtime.getCell<any>(
+      space,
+      "direct-cycle-B",
+      undefined,
+      tx,
+    );
+
+    // Using setRaw to circumvent cycle detection on write
+    const linkToA = cellA.getAsLink();
+    const linkToB = cellB.getAsLink();
+
+    cellA.setRaw(linkToB);
+    cellB.setRaw(linkToA);
+
+    // Both should resolve to undefined
+    expect(cellA.get()).toBeUndefined();
+    expect(cellB.get()).toBeUndefined();
+  });
+
+  it("detects cycle when resolving link to its own subpath", async () => {
+    // Test case: A -> A/foo creates an infinite growing path
+    const cellA = runtime.getCell<any>(
+      space,
+      "self-subpath-cycle",
+      undefined,
+      tx,
+    );
+
+    // Create a link from A to A/foo
+    cellA.setRaw(cellA.key("foo").getAsLink());
+
+    // Race the resolution against a 1 second timeout to ensure it doesn't hang
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error("Resolution timed out after 1 second")),
+        1000,
+      );
+    });
+
+    const resolutionPromise = new Promise<any>((resolve) => {
+      // When we resolve this link, it should detect the growing path cycle
+      // and return the empty document with a data: URI
+      resolve(resolveLink(tx, cellA.getAsNormalizedFullLink()));
+    });
+
+    try {
+      const resolved = await Promise.race([resolutionPromise, timeoutPromise]);
+
+      // This creates: A -> A/foo -> A/foo/foo -> A/foo/foo/foo -> ...
+      // The iteration limit should catch this and return the empty document
+      expect(resolved.id).toBe("data:application/json,");
+      expect(resolved.space).toBe("did:null:null");
+    } finally {
+      // Clean up the timeout if it was set
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    }
+  });
+
+  it("detects cycles in nested paths", () => {
+    // Test case: A/x -> B/y -> A/x (cycle at a specific path)
+    const cellA = runtime.getCell<any>(
+      space,
+      "nested-cycle-A",
+      undefined,
+      tx,
+    );
+    const cellB = runtime.getCell<any>(
+      space,
+      "nested-cycle-B",
+      undefined,
+      tx,
+    );
+
+    // Create the cycle using setRaw to circumvent cycle detection on write
+    const linkToAx = cellA.key("x").getAsLink();
+    const linkToBy = cellB.key("y").getAsLink();
+
+    cellA.setRaw({ x: linkToBy });
+    cellB.setRaw({ y: linkToAx });
+
+    const value = cellA.key("x").get();
+    expect(value).toBeUndefined();
+  });
+
+  it("shows data URI when resolving cyclic links", () => {
+    // To see the data: URI, we need to use the lower-level resolveLink function
+    const cellA = runtime.getCell<any>(
+      space,
+      "data-uri-cycle-A",
+      undefined,
+      tx,
+    );
+
+    // Create a self-referencing cycle using setRaw to circumvent cycle
+    // detection on write
+    cellA.setRaw(cellA.getAsLink());
+
+    // When we resolve this link at a low level, it should return the empty document
+    // with a data: URI indicating the cycle was detected
+    const resolved = resolveLink(
+      tx,
+      cellA.getAsNormalizedFullLink(),
+      "value",
+    );
+    expect(resolved.id).toBe("data:application/json,");
+    expect(resolved.space).toBe("did:null:null");
+  });
+
+  it("allows non-cyclic references to the same cell", () => {
+    // This should NOT trigger cycle detection - accessing different properties
+    const cellA = runtime.getCell<any>(
+      space,
+      "non-cycle-A",
+      undefined,
+      tx,
+    );
+    const cellB = runtime.getCell<any>(
+      space,
+      "non-cycle-B",
+      undefined,
+      tx,
+    );
+
+    // A has two different references to B at different paths
+    cellA.set({
+      ref1: cellB,
+      ref2: cellB,
+      data: "A data",
+    });
+
+    cellB.set({
+      value: "B value",
+      nested: { deep: "deep value" },
+    });
+
+    // These should all work without cycle detection
+    expect(cellA.key("ref1").key("value").get()).toBe("B value");
+    expect(cellA.key("ref2").key("nested").key("deep").get()).toBe(
+      "deep value",
+    );
+
+    // The resolved links should NOT be data: URIs
+    const link1 = cellA.key("ref1").key("value").getAsNormalizedFullLink();
+    const link2 = cellA.key("ref2").key("nested").getAsNormalizedFullLink();
+
+    expect(link1.id).not.toMatch(/^data:/);
+    expect(link2.id).not.toMatch(/^data:/);
   });
 });

--- a/packages/runner/test/link-resolution.test.ts
+++ b/packages/runner/test/link-resolution.test.ts
@@ -87,34 +87,6 @@ describe("link-resolution", () => {
       expect(tx.readValueOrThrow(result)).toBe(10);
     });
 
-    it("should throw an error on circular aliases", () => {
-      const cellA = runtime.getCell<any>(
-        space,
-        "should throw an error on circular aliases 1",
-        undefined,
-        tx,
-      );
-      cellA.set({});
-      const cellB = runtime.getCell<any>(
-        space,
-        "should throw an error on circular aliases 2",
-        undefined,
-        tx,
-      );
-      cellB.set({});
-      cellA.setRaw({
-        alias: cellB.key("alias").getAsWriteRedirectLink(),
-      });
-      cellB.setRaw({
-        alias: cellA.key("alias").getAsWriteRedirectLink(),
-      });
-      const binding = { $alias: { path: ["alias"] } };
-      expect(() => resolveLink(tx, parseLink(binding, cellA)!, "writeRedirect"))
-        .toThrow(
-          "cycle detected",
-        );
-    });
-
     it("should allow aliases in aliased paths", () => {
       const testCell = runtime.getCell<any>(
         space,

--- a/packages/runner/test/link-resolution.test.ts
+++ b/packages/runner/test/link-resolution.test.ts
@@ -112,413 +112,931 @@ describe("link-resolution", () => {
       expect(tx.readValueOrThrow(result)).toBe(1);
     });
   });
-});
 
-describe("Cycle detection with circular references", () => {
-  let runtime: Runtime;
-  let storageManager: ReturnType<typeof StorageManager.emulate>;
-  let tx: IExtendedStorageTransaction;
-
-  beforeEach(() => {
-    storageManager = StorageManager.emulate({ as: signer });
-
-    runtime = new Runtime({
-      blobbyServerUrl: import.meta.url,
-      storageManager,
-    });
-    tx = runtime.edit();
-  });
-
-  afterEach(async () => {
-    await tx.commit();
-    await runtime?.dispose();
-    await storageManager?.close();
-  });
-
-  it("handles circular references correctly without overtriggering cycle detection", () => {
-    // This test verifies that the cycle detection does NOT overtrigger.
-    // The scenario described in the bug report works correctly:
-    // - Two cells reference each other in a cycle
-    // - We can still access properties through the cycle without errors
-    // Create cellA with a reference to cellB and a non-cyclic property
-    const cellA = runtime.getCell(
-      space,
-      "cycle-detection-bug-cellA",
-      {
+  describe("Schema handling in links", () => {
+    it("should preserve schema when resolving links", () => {
+      const schema = {
         type: "object",
-        properties: { foo: { $ref: "#" }, bar: { type: "string" } },
-      } as const as JSONSchema,
-      tx,
-    );
+        properties: {
+          name: { type: "string" },
+          age: { type: "number" },
+        },
+      } as const;
 
-    // Create cellB with a reference to cellA
-    const cellB = runtime.getCell<any>(
-      space,
-      "cycle-detection-bug-cellB",
-      undefined,
-      tx,
-    );
-
-    // Set up the circular reference structure as described:
-    // cellA.set({ foo: cellB, bar: "baz" })
-    // cellB.set(cellA)
-    cellA.set({ foo: cellB, bar: "baz" });
-    cellB.set(cellA);
-
-    // Test 1: A.get() should work
-    const result = cellA.get();
-    expect(result.bar).toBe("baz");
-    // When we get(), cells are automatically dereferenced, so result.foo
-    // is the actual value (not a cell)
-    expect(result.foo.bar).toBe("baz");
-    expect(result.foo.foo).toEqual(result.foo);
-
-    // Test 2: A.key("foo").get() should work and return the value of cellB (which is cellA)
-    const fooResult = cellA.key("foo").get();
-    expect(fooResult.bar).toBe("baz");
-
-    // Test 3: A.key("foo").key("bar").get() should work and return "baz"
-    // This is where the overtrigger might happen - accessing bar through the cycle
-    let barResult: string;
-    try {
-      barResult = cellA.key("foo").key("bar").get();
-      expect(barResult).toBe("baz");
-    } catch (e) {
-      // If this throws, we've hit the overtrigger bug
-      console.error(
-        "Overtrigger bug detected at A.key('foo').key('bar').get():",
-        e,
+      const targetCell = runtime.getCell<{ name: string; age: number }>(
+        space,
+        "schema-target-cell",
+        schema,
+        tx,
       );
-      throw e;
-    }
+      targetCell.set({ name: "John", age: 30 });
 
-    // Test 4: A.key("foo").key("foo").key("foo").get() should work
-    // Multiple levels of following the references
-    let deepResult: any;
-    try {
-      deepResult = cellA.key("foo").key("foo").key("foo").get();
-      expect(deepResult.bar).toBe("baz");
-    } catch (e) {
-      // If this throws, we've hit the overtrigger bug
-      console.error(
-        "Overtrigger bug detected at A.key('foo').key('foo').key('foo').get():",
-        e,
+      const sourceCell = runtime.getCell<any>(
+        space,
+        "schema-source-cell",
+        undefined,
+        tx,
       );
-      throw e;
-    }
-  });
 
-  it("handles complex circular reference scenarios", () => {
-    // More complex scenario with multiple cells and properties
-    const cellA = runtime.getCell<{ b: any; c: any; value: string }>(
-      space,
-      "complex-cycle-cellA",
-      undefined,
-      tx,
-    );
+      // Create a link with schema included
+      sourceCell.setRaw({
+        link: targetCell.getAsLink({ includeSchema: true }),
+      });
 
-    const cellB = runtime.getCell<{ a: any; c: any; value: string }>(
-      space,
-      "complex-cycle-cellB",
-      undefined,
-      tx,
-    );
-
-    const cellC = runtime.getCell<{ a: any; b: any; value: string }>(
-      space,
-      "complex-cycle-cellC",
-      undefined,
-      tx,
-    );
-
-    // Create a triangle of references
-    cellA.set({ b: cellB, c: cellC, value: "A" });
-    cellB.set({ a: cellA, c: cellC, value: "B" });
-    cellC.set({ a: cellA, b: cellB, value: "C" });
-
-    // Test accessing values through different paths
-    // A -> B -> C -> value
-    expect(cellA.key("b").key("c").key("value").get()).toBe("C");
-
-    // A -> C -> B -> A -> value
-    expect(cellA.key("c").key("b").key("a").key("value").get()).toBe("A");
-
-    // Multiple hops through the same cycle
-    expect(cellA.key("b").key("a").key("b").key("a").key("value").get()).toBe(
-      "A",
-    );
-  });
-
-  it("handles deeply nested circular references with aliases", () => {
-    // Test with a mix of direct cell references and aliases
-    const cellA = runtime.getCell<any>(
-      space,
-      "deep-cycle-cellA",
-      undefined,
-      tx,
-    );
-
-    const cellB = runtime.getCell<any>(
-      space,
-      "deep-cycle-cellB",
-      undefined,
-      tx,
-    );
-
-    // Create a structure where cells reference each other at different depths
-    cellA.set({
-      direct: cellB,
-      nested: {
-        ref: cellB,
-        data: "nested-a",
-      },
-      value: "a",
+      // When resolving a link to a cell that has a schema,
+      // the resolved link should point to the target cell with its schema
+      const linkValue = sourceCell.key("link").get();
+      const parsedLink = parseLink(linkValue, sourceCell)!;
+      const resolved = resolveLink(tx, parsedLink);
+      expect(resolved.schema).toEqual(schema);
     });
 
-    cellB.set({
-      back: cellA,
-      deep: {
-        path: {
-          to: {
-            a: cellA,
+    it("should adjust schema for nested paths", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          user: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              email: { type: "string" },
+            },
           },
         },
-      },
-      value: "b",
+      } as const satisfies JSONSchema;
+
+      const targetCell = runtime.getCell<any>(
+        space,
+        "nested-schema-target",
+        schema,
+        tx,
+      );
+      targetCell.set({ user: { name: "Jane", email: "jane@example.com" } });
+
+      const sourceCell = runtime.getCell<any>(
+        space,
+        "nested-schema-source",
+        undefined,
+        tx,
+      );
+      // Create a link pointing to targetCell/user with schema included
+      sourceCell.setRaw({
+        link: targetCell.key("user").getAsLink({ includeSchema: true }),
+      });
+
+      // The resolved link should have the adjusted schema for the user object
+      const linkValue = sourceCell.key("link").get();
+      const parsedLink = parseLink(linkValue, sourceCell)!;
+      const resolved = resolveLink(tx, parsedLink);
+      expect(resolved.schema).toEqual({
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          email: { type: "string" },
+        },
+      });
     });
 
-    // Test navigation through various paths
-    expect(cellA.key("direct").key("back").key("value").get()).toBe("a");
-    expect(
-      cellA.key("nested").key("ref").key("deep").key("path").key("to").key("a")
-        .key("value").get(),
-    ).toBe("a");
+    it("should preserve schema through write redirects", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          value: { type: "number" },
+        },
+      } as const satisfies JSONSchema;
 
-    // This path should work even though it visits the same cells multiple times
-    expect(
-      cellA.key("direct").key("back").key("direct").key("back").key("nested")
-        .key("data").get(),
-    ).toBe("nested-a");
+      const targetCell = runtime.getCell<{ value: number }>(
+        space,
+        "redirect-schema-target",
+        schema,
+        tx,
+      );
+      targetCell.set({ value: 42 });
+
+      const sourceCell = runtime.getCell<any>(
+        space,
+        "redirect-schema-source",
+        undefined,
+        tx,
+      );
+      sourceCell.setRaw({
+        alias: targetCell.getAsWriteRedirectLink({ includeSchema: true }),
+      });
+
+      // Resolve with writeRedirect mode
+      const linkValue = sourceCell.key("alias").get();
+      const parsedLink = parseLink(linkValue, sourceCell)!;
+      const resolved = resolveLink(tx, parsedLink, "writeRedirect");
+      expect(resolved.schema).toEqual(schema);
+    });
+
+    it("should handle undefined schemas gracefully", () => {
+      // Cell without schema
+      const targetCell = runtime.getCell<any>(
+        space,
+        "no-schema-target",
+        undefined,
+        tx,
+      );
+      targetCell.set({ data: "test" });
+
+      const sourceCell = runtime.getCell<any>(
+        space,
+        "no-schema-source",
+        undefined,
+        tx,
+      );
+      sourceCell.set({ link: targetCell });
+
+      const linkValue = sourceCell.key("link").get();
+      const parsedLink = parseLink(linkValue, sourceCell)!;
+      const resolved = resolveLink(tx, parsedLink);
+      expect(resolved.schema).toBeUndefined();
+    });
+
+    it("should preserve rootSchema when available", () => {
+      // Use a simple schema without $ref since it's not supported yet
+      const rootSchema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+        },
+      } as const;
+
+      const schema = rootSchema;
+
+      const targetCell = runtime.getCell<any>(
+        space,
+        "rootschema-target",
+        schema,
+        tx,
+      );
+      targetCell.set({ name: "Test User" });
+
+      // Create a link with setRaw to preserve rootSchema
+      const sourceCell = runtime.getCell<any>(
+        space,
+        "rootschema-source",
+        undefined,
+        tx,
+      );
+      const linkData = targetCell.getAsLink();
+      // Manually add rootSchema to the link
+      if (linkData["/"] && linkData["/"]["link@1"]) {
+        linkData["/"]["link@1"].rootSchema = rootSchema;
+      }
+      sourceCell.setRaw({ link: linkData });
+
+      const link = parseLink(sourceCell.get().link, sourceCell)!;
+      const resolved = resolveLink(tx, link);
+      expect(resolved.rootSchema).toEqual(rootSchema);
+    });
+
+    it("should handle schema through multiple link hops", () => {
+      const schema1 = {
+        type: "object",
+        properties: {
+          nested: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+          },
+        },
+      };
+
+      const schema2 = {
+        type: "object",
+        properties: {
+          data: { type: "number" },
+        },
+      };
+
+      const cell1 = runtime.getCell<any>(
+        space,
+        "multi-hop-1",
+        schema1,
+        tx,
+      );
+      cell1.set({ nested: { value: "test" } });
+
+      const cell2 = runtime.getCell<any>(
+        space,
+        "multi-hop-2",
+        schema2,
+        tx,
+      );
+      // Link to cell1's nested object with schema
+      cell2.setRaw({
+        data: cell1.key("nested").getAsLink({ includeSchema: true }),
+      });
+
+      const cell3 = runtime.getCell<any>(
+        space,
+        "multi-hop-3",
+        undefined,
+        tx,
+      );
+      // Link to cell2
+      cell3.set({ ref: cell2 });
+
+      // Following through cell3 -> cell2 -> cell1.nested
+      // We need to resolve step by step since getAsNormalizedFullLink doesn't preserve schema
+      const linkValue = cell2.key("data").get();
+      const parsedLink = parseLink(linkValue, cell2)!;
+      const resolved = resolveLink(tx, parsedLink);
+
+      // Should have the schema of cell1.nested
+      expect(resolved.schema).toEqual({
+        type: "object",
+        properties: {
+          value: { type: "string" },
+        },
+      });
+    });
+
+    it("should handle schema with array paths", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "number" },
+                name: { type: "string" },
+              },
+            },
+          },
+        },
+      };
+
+      const targetCell = runtime.getCell<any>(
+        space,
+        "array-schema-target",
+        schema,
+        tx,
+      );
+      targetCell.set({
+        items: [
+          { id: 1, name: "Item 1" },
+          { id: 2, name: "Item 2" },
+        ],
+      });
+
+      const sourceCell = runtime.getCell<any>(
+        space,
+        "array-schema-source",
+        undefined,
+        tx,
+      );
+      // Link to a specific array element with schema
+      sourceCell.setRaw({
+        link: targetCell.key("items").key(0).getAsLink({ includeSchema: true }),
+      });
+
+      const linkValue = sourceCell.key("link").get();
+      const parsedLink = parseLink(linkValue, sourceCell)!;
+      const resolved = resolveLink(tx, parsedLink);
+
+      // Should have the schema of an array item
+      expect(resolved.schema).toEqual({
+        type: "object",
+        properties: {
+          id: { type: "number" },
+          name: { type: "string" },
+        },
+      });
+    });
+
+    it("should preserve schema when link has no schema but destination does", () => {
+      const destinationSchema = {
+        type: "object",
+        properties: {
+          status: { type: "string" },
+        },
+      } as const;
+
+      const destCell = runtime.getCell<any>(
+        space,
+        "preserve-dest-schema",
+        destinationSchema,
+        tx,
+      );
+      destCell.set({ status: "active" });
+
+      // Create another cell that links to destCell with schema
+      const linkCell = runtime.getCell<any>(
+        space,
+        "link-without-schema",
+        undefined,
+        tx,
+      );
+      linkCell.setRaw(destCell.getAsLink({ includeSchema: true }));
+
+      // Source cell links to linkCell
+      const sourceCell = runtime.getCell<any>(
+        space,
+        "source-preserve-schema",
+        undefined,
+        tx,
+      );
+      sourceCell.set({ ref: linkCell });
+
+      // Following the chain should preserve the destination schema
+      const linkValue = sourceCell.key("ref").get();
+      const parsedLink = parseLink(linkValue, sourceCell)!;
+      const resolved = resolveLink(tx, parsedLink);
+      expect(resolved.schema).toEqual(destinationSchema);
+    });
+
+    it("should handle empty schema objects", () => {
+      const emptySchema = {} as const;
+
+      const targetCell = runtime.getCell<any>(
+        space,
+        "empty-schema-target",
+        emptySchema,
+        tx,
+      );
+      targetCell.set({ any: "value" });
+
+      const sourceCell = runtime.getCell<any>(
+        space,
+        "empty-schema-source",
+        undefined,
+        tx,
+      );
+      sourceCell.setRaw({
+        link: targetCell.getAsLink({ includeSchema: true }),
+      });
+
+      const linkValue = sourceCell.key("link").get();
+      const parsedLink = parseLink(linkValue, sourceCell)!;
+      const resolved = resolveLink(tx, parsedLink);
+
+      // Empty schema should be preserved
+      expect(resolved.schema).toEqual(emptySchema);
+    });
+
+    it("should handle complex nested schemas with multiple levels", () => {
+      const complexSchema = {
+        type: "object",
+        properties: {
+          level1: {
+            type: "object",
+            properties: {
+              level2: {
+                type: "object",
+                properties: {
+                  level3: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        deep: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as const;
+
+      const targetCell = runtime.getCell<any>(
+        space,
+        "complex-nested-schema",
+        complexSchema,
+        tx,
+      );
+      targetCell.set({
+        level1: {
+          level2: {
+            level3: [{ deep: "value1" }, { deep: "value2" }],
+          },
+        },
+      });
+
+      const sourceCell = runtime.getCell<any>(
+        space,
+        "complex-nested-source",
+        undefined,
+        tx,
+      );
+
+      // Link to a deeply nested path
+      sourceCell.setRaw({
+        link: targetCell.key("level1").key("level2").key("level3").key(0)
+          .getAsLink({ includeSchema: true }),
+      });
+
+      const linkValue = sourceCell.key("link").get();
+      const parsedLink = parseLink(linkValue, sourceCell)!;
+      const resolved = resolveLink(tx, parsedLink);
+
+      // Should have the schema of the array item
+      expect(resolved.schema).toEqual({
+        type: "object",
+        properties: {
+          deep: { type: "string" },
+        },
+      });
+    });
+
+    it("should handle schemas with additionalProperties", () => {
+      const schemaWithAdditional = {
+        type: "object",
+        properties: {
+          known: { type: "string" },
+        },
+        additionalProperties: { type: "number" },
+      } as const;
+
+      const targetCell = runtime.getCell<any>(
+        space,
+        "additional-props-target",
+        schemaWithAdditional,
+        tx,
+      );
+      targetCell.set({ known: "value", extra1: 42, extra2: 100 });
+
+      const sourceCell = runtime.getCell<any>(
+        space,
+        "additional-props-source",
+        undefined,
+        tx,
+      );
+      sourceCell.setRaw({
+        link: targetCell.getAsLink({ includeSchema: true }),
+      });
+
+      const linkValue = sourceCell.key("link").get();
+      const parsedLink = parseLink(linkValue, sourceCell)!;
+      const resolved = resolveLink(tx, parsedLink);
+
+      expect(resolved.schema).toEqual(schemaWithAdditional);
+    });
+
+    it("should handle schemas with both top-level and nested links", () => {
+      // Test case where a document has both regular properties and links
+      const schema1 = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          ref: { type: "object" }, // Will be a link
+        },
+      } as const;
+
+      const schema2 = {
+        type: "object",
+        properties: {
+          value: { type: "number" },
+        },
+      } as const;
+
+      const targetCell = runtime.getCell<any>(
+        space,
+        "mixed-schema-target",
+        schema2,
+        tx,
+      );
+      targetCell.set({ value: 42 });
+
+      const sourceCell = runtime.getCell<any>(
+        space,
+        "mixed-schema-source",
+        schema1,
+        tx,
+      );
+      sourceCell.setRaw({
+        name: "test",
+        ref: targetCell.getAsLink({ includeSchema: true }),
+      });
+
+      // Resolving the ref should give us the target schema
+      const linkValue = sourceCell.key("ref").get();
+      const parsedLink = parseLink(linkValue, sourceCell)!;
+      const resolved = resolveLink(tx, parsedLink);
+      expect(resolved.schema).toEqual(schema2);
+    });
   });
 
-  it("handles circular references with array elements", () => {
-    // This test demonstrates the cycle detection overtrigger bug
-    // The bug occurs when navigating through circular references multiple times
-    // even when accessing different properties
-    const cellA = runtime.getCell<{ items: any[]; name: string }>(
-      space,
-      "array-cycle-cellA",
-      undefined,
-      tx,
-    );
+  describe("Cycle detection with circular references", () => {
+    let runtime: Runtime;
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+    let tx: IExtendedStorageTransaction;
 
-    const cellB = runtime.getCell<{ parent: any; name: string }>(
-      space,
-      "array-cycle-cellB",
-      undefined,
-      tx,
-    );
+    beforeEach(() => {
+      storageManager = StorageManager.emulate({ as: signer });
 
-    const cellC = runtime.getCell<{ root: any; name: string }>(
-      space,
-      "array-cycle-cellC",
-      undefined,
-      tx,
-    );
+      runtime = new Runtime({
+        blobbyServerUrl: import.meta.url,
+        storageManager,
+      });
+      tx = runtime.edit();
+    });
 
-    // Create circular references through array
-    cellA.set({ items: [cellB, cellC], name: "A" });
-    cellB.set({ parent: cellA, name: "B" });
-    cellC.set({ root: cellA, name: "C" });
+    afterEach(async () => {
+      await tx.commit();
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
 
-    // Navigate through array indices and back
-    expect(cellA.key("items").key(0).key("parent").key("name").get()).toBe("A");
+    it("handles circular references correctly without overtriggering cycle detection", () => {
+      // This test verifies that the cycle detection does NOT overtrigger.
+      // The scenario described in the bug report works correctly:
+      // - Two cells reference each other in a cycle
+      // - We can still access properties through the cycle without errors
+      // Create cellA with a reference to cellB and a non-cyclic property
+      const cellA = runtime.getCell(
+        space,
+        "cycle-detection-bug-cellA",
+        {
+          type: "object",
+          properties: { foo: { $ref: "#" }, bar: { type: "string" } },
+        } as const as any,
+        tx,
+      );
 
-    expect(
-      cellA.key("items").key(1).key("root").key("items").key(0).key("name")
-        .get(),
-    ).toBe("B");
+      // Create cellB with a reference to cellA
+      const cellB = runtime.getCell<any>(
+        space,
+        "cycle-detection-bug-cellB",
+        undefined,
+        tx,
+      );
 
-    // Complex path through multiple array elements
-    // This is where the bug triggers: A → items[0] (B) → parent (A) → items[1] (C) → root (A) → name
-    // The cycle detector sees we're visiting A multiple times and throws an error,
-    // even though we're legitimately navigating through the structure to access "name"
-    expect(
-      cellA.key("items").key(0).key("parent").key("items").key(1).key("root")
-        .key("name").get(),
-    ).toBe("A");
-  });
+      // Set up the circular reference structure as described:
+      // cellA.set({ foo: cellB, bar: "baz" })
+      // cellB.set(cellA)
+      cellA.set({ foo: cellB, bar: "baz" });
+      cellB.set(cellA);
 
-  it("properly detects true circular references", () => {
-    // Test cases where circular references SHOULD be detected
-    // When a cycle is detected, the system logs a warning and returns an empty document
+      // Test 1: A.get() should work
+      const result = cellA.get();
+      expect(result.bar).toBe("baz");
+      // When we get(), cells are automatically dereferenced, so result.foo
+      // is the actual value (not a cell)
+      expect(result.foo.bar).toBe("baz");
+      expect(result.foo.foo.foo).toEqual(result.foo.foo);
 
-    // Case 1: Direct circular reference A -> A
-    const cellA = runtime.getCell<any>(
-      space,
-      "direct-cycle-A",
-      undefined,
-      tx,
-    );
-    // Using setRaw to circumvent cycle detection on write
-    // This allows us to create the cycle for testing purposes
-    cellA.setRaw(cellA.getAsLink());
+      // Test 2: A.key("foo").get() should work and return the value of cellB (which is cellA)
+      const fooResult = cellA.key("foo").get();
+      expect(fooResult.bar).toBe("baz");
 
-    // When we resolve a circular reference, it should return undefined
-    // (the empty document resolves to undefined)
-    const value = cellA.get();
-    expect(value).toBeUndefined();
+      // Test 3: A.key("foo").key("bar").get() should work and return "baz"
+      // This is where the overtrigger might happen - accessing bar through the cycle
+      let barResult: string;
+      try {
+        barResult = cellA.key("foo").key("bar").get();
+        expect(barResult).toBe("baz");
+      } catch (e) {
+        // If this throws, we've hit the overtrigger bug
+        console.error(
+          "Overtrigger bug detected at A.key('foo').key('bar').get():",
+          e,
+        );
+        throw e;
+      }
 
-    // Case 2: Mutual references A -> B -> A
-    const cellB = runtime.getCell<any>(
-      space,
-      "direct-cycle-B",
-      undefined,
-      tx,
-    );
+      // Test 4: A.key("foo").key("foo").key("foo").get() should work
+      // Multiple levels of following the references
+      let deepResult: any;
+      try {
+        deepResult = cellA.key("foo").key("foo").key("foo").get();
+        expect(deepResult.bar).toBe("baz");
+      } catch (e) {
+        // If this throws, we've hit the overtrigger bug
+        console.error(
+          "Overtrigger bug detected at A.key('foo').key('foo').key('foo').get():",
+          e,
+        );
+        throw e;
+      }
+    });
 
-    // Using setRaw to circumvent cycle detection on write
-    const linkToA = cellA.getAsLink();
-    const linkToB = cellB.getAsLink();
+    it("handles complex circular reference scenarios", () => {
+      // More complex scenario with multiple cells and properties
+      const cellA = runtime.getCell<{ b: any; c: any; value: string }>(
+        space,
+        "complex-cycle-cellA",
+        undefined,
+        tx,
+      );
 
-    cellA.setRaw(linkToB);
-    cellB.setRaw(linkToA);
+      const cellB = runtime.getCell<{ a: any; c: any; value: string }>(
+        space,
+        "complex-cycle-cellB",
+        undefined,
+        tx,
+      );
 
-    // Both should resolve to undefined
-    expect(cellA.get()).toBeUndefined();
-    expect(cellB.get()).toBeUndefined();
-  });
+      const cellC = runtime.getCell<{ a: any; b: any; value: string }>(
+        space,
+        "complex-cycle-cellC",
+        undefined,
+        tx,
+      );
 
-  it("detects cycle when resolving link to its own subpath", async () => {
-    // Test case: A -> A/foo creates an infinite growing path
-    const cellA = runtime.getCell<any>(
-      space,
-      "self-subpath-cycle",
-      undefined,
-      tx,
-    );
+      // Create a triangle of references
+      cellA.set({ b: cellB, c: cellC, value: "A" });
+      cellB.set({ a: cellA, c: cellC, value: "B" });
+      cellC.set({ a: cellA, b: cellB, value: "C" });
 
-    // Create a link from A to A/foo
-    cellA.setRaw(cellA.key("foo").getAsLink());
+      // Test accessing values through different paths
+      // A -> B -> C -> value
+      expect(cellA.key("b").key("c").key("value").get()).toBe("C");
 
-    // Race the resolution against a 1 second timeout to ensure it doesn't hang
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(
-        () => reject(new Error("Resolution timed out after 1 second")),
-        1000,
+      // A -> C -> B -> A -> value
+      expect(cellA.key("c").key("b").key("a").key("value").get()).toBe("A");
+
+      // Multiple hops through the same cycle
+      expect(cellA.key("b").key("a").key("b").key("a").key("value").get()).toBe(
+        "A",
       );
     });
 
-    const resolutionPromise = new Promise<any>((resolve) => {
-      // When we resolve this link, it should detect the growing path cycle
-      // and return the empty document with a data: URI
-      resolve(resolveLink(tx, cellA.getAsNormalizedFullLink()));
+    it("handles deeply nested circular references with aliases", () => {
+      // Test with a mix of direct cell references and aliases
+      const cellA = runtime.getCell<any>(
+        space,
+        "deep-cycle-cellA",
+        undefined,
+        tx,
+      );
+
+      const cellB = runtime.getCell<any>(
+        space,
+        "deep-cycle-cellB",
+        undefined,
+        tx,
+      );
+
+      // Create a structure where cells reference each other at different depths
+      cellA.set({
+        direct: cellB,
+        nested: {
+          ref: cellB,
+          data: "nested-a",
+        },
+        value: "a",
+      });
+
+      cellB.set({
+        back: cellA,
+        deep: {
+          path: {
+            to: {
+              a: cellA,
+            },
+          },
+        },
+        value: "b",
+      });
+
+      // Test navigation through various paths
+      expect(cellA.key("direct").key("back").key("value").get()).toBe("a");
+      expect(
+        cellA.key("nested").key("ref").key("deep").key("path").key("to").key(
+          "a",
+        )
+          .key("value").get(),
+      ).toBe("a");
+
+      // This path should work even though it visits the same cells multiple times
+      expect(
+        cellA.key("direct").key("back").key("direct").key("back").key("nested")
+          .key("data").get(),
+      ).toBe("nested-a");
     });
 
-    try {
-      const resolved = await Promise.race([resolutionPromise, timeoutPromise]);
+    it("handles circular references with array elements", () => {
+      // This test demonstrates the cycle detection overtrigger bug
+      // The bug occurs when navigating through circular references multiple times
+      // even when accessing different properties
+      const cellA = runtime.getCell<{ items: any[]; name: string }>(
+        space,
+        "array-cycle-cellA",
+        undefined,
+        tx,
+      );
 
-      // This creates: A -> A/foo -> A/foo/foo -> A/foo/foo/foo -> ...
-      // The iteration limit should catch this and return the empty document
+      const cellB = runtime.getCell<{ parent: any; name: string }>(
+        space,
+        "array-cycle-cellB",
+        undefined,
+        tx,
+      );
+
+      const cellC = runtime.getCell<{ root: any; name: string }>(
+        space,
+        "array-cycle-cellC",
+        undefined,
+        tx,
+      );
+
+      // Create circular references through array
+      cellA.set({ items: [cellB, cellC], name: "A" });
+      cellB.set({ parent: cellA, name: "B" });
+      cellC.set({ root: cellA, name: "C" });
+
+      // Navigate through array indices and back
+      expect(cellA.key("items").key(0).key("parent").key("name").get()).toBe(
+        "A",
+      );
+
+      expect(
+        cellA.key("items").key(1).key("root").key("items").key(0).key("name")
+          .get(),
+      ).toBe("B");
+
+      // Complex path through multiple array elements
+      // This is where the bug triggers: A → items[0] (B) → parent (A) → items[1] (C) → root (A) → name
+      // The cycle detector sees we're visiting A multiple times and throws an error,
+      // even though we're legitimately navigating through the structure to access "name"
+      expect(
+        cellA.key("items").key(0).key("parent").key("items").key(1).key("root")
+          .key("name").get(),
+      ).toBe("A");
+    });
+
+    it("properly detects true circular references", () => {
+      // Test cases where circular references SHOULD be detected
+      // When a cycle is detected, the system logs a warning and returns an empty document
+
+      // Case 1: Direct circular reference A -> A
+      const cellA = runtime.getCell<any>(
+        space,
+        "direct-cycle-A",
+        undefined,
+        tx,
+      );
+      // Using setRaw to circumvent cycle detection on write
+      // This allows us to create the cycle for testing purposes
+      cellA.setRaw(cellA.getAsLink());
+
+      // When we resolve a circular reference, it should return undefined
+      // (the empty document resolves to undefined)
+      const value = cellA.get();
+      expect(value).toBeUndefined();
+
+      // Case 2: Mutual references A -> B -> A
+      const cellB = runtime.getCell<any>(
+        space,
+        "direct-cycle-B",
+        undefined,
+        tx,
+      );
+
+      // Using setRaw to circumvent cycle detection on write
+      const linkToA = cellA.getAsLink();
+      const linkToB = cellB.getAsLink();
+
+      cellA.setRaw(linkToB);
+      cellB.setRaw(linkToA);
+
+      // Both should resolve to undefined
+      expect(cellA.get()).toBeUndefined();
+      expect(cellB.get()).toBeUndefined();
+    });
+
+    it("detects cycle when resolving link to its own subpath", async () => {
+      // Test case: A -> A/foo creates an infinite growing path
+      const cellA = runtime.getCell<any>(
+        space,
+        "self-subpath-cycle",
+        undefined,
+        tx,
+      );
+
+      // Create a link from A to A/foo
+      cellA.setRaw(cellA.key("foo").getAsLink());
+
+      // Race the resolution against a 1 second timeout to ensure it doesn't hang
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error("Resolution timed out after 1 second")),
+          1000,
+        );
+      });
+
+      const resolutionPromise = new Promise<any>((resolve) => {
+        // When we resolve this link, it should detect the growing path cycle
+        // and return the empty document with a data: URI
+        resolve(resolveLink(tx, cellA.getAsNormalizedFullLink()));
+      });
+
+      try {
+        const resolved = await Promise.race([
+          resolutionPromise,
+          timeoutPromise,
+        ]);
+
+        // This creates: A -> A/foo -> A/foo/foo -> A/foo/foo/foo -> ...
+        // The iteration limit should catch this and return the empty document
+        expect(resolved.id).toBe("data:application/json,");
+        expect(resolved.space).toBe("did:null:null");
+      } finally {
+        // Clean up the timeout if it was set
+        if (timeoutId !== undefined) {
+          clearTimeout(timeoutId);
+        }
+      }
+    });
+
+    it("detects cycles in nested paths", () => {
+      // Test case: A/x -> B/y -> A/x (cycle at a specific path)
+      const cellA = runtime.getCell<any>(
+        space,
+        "nested-cycle-A",
+        undefined,
+        tx,
+      );
+      const cellB = runtime.getCell<any>(
+        space,
+        "nested-cycle-B",
+        undefined,
+        tx,
+      );
+
+      // Create the cycle using setRaw to circumvent cycle detection on write
+      const linkToAx = cellA.key("x").getAsLink();
+      const linkToBy = cellB.key("y").getAsLink();
+
+      cellA.setRaw({ x: linkToBy });
+      cellB.setRaw({ y: linkToAx });
+
+      const value = cellA.key("x").get();
+      expect(value).toBeUndefined();
+    });
+
+    it("shows data URI when resolving cyclic links", () => {
+      // To see the data: URI, we need to use the lower-level resolveLink function
+      const cellA = runtime.getCell<any>(
+        space,
+        "data-uri-cycle-A",
+        undefined,
+        tx,
+      );
+
+      // Create a self-referencing cycle using setRaw to circumvent cycle
+      // detection on write
+      cellA.setRaw(cellA.getAsLink());
+
+      // When we resolve this link at a low level, it should return the empty document
+      // with a data: URI indicating the cycle was detected
+      const resolved = resolveLink(
+        tx,
+        cellA.getAsNormalizedFullLink(),
+        "value",
+      );
       expect(resolved.id).toBe("data:application/json,");
       expect(resolved.space).toBe("did:null:null");
-    } finally {
-      // Clean up the timeout if it was set
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-      }
-    }
-  });
-
-  it("detects cycles in nested paths", () => {
-    // Test case: A/x -> B/y -> A/x (cycle at a specific path)
-    const cellA = runtime.getCell<any>(
-      space,
-      "nested-cycle-A",
-      undefined,
-      tx,
-    );
-    const cellB = runtime.getCell<any>(
-      space,
-      "nested-cycle-B",
-      undefined,
-      tx,
-    );
-
-    // Create the cycle using setRaw to circumvent cycle detection on write
-    const linkToAx = cellA.key("x").getAsLink();
-    const linkToBy = cellB.key("y").getAsLink();
-
-    cellA.setRaw({ x: linkToBy });
-    cellB.setRaw({ y: linkToAx });
-
-    const value = cellA.key("x").get();
-    expect(value).toBeUndefined();
-  });
-
-  it("shows data URI when resolving cyclic links", () => {
-    // To see the data: URI, we need to use the lower-level resolveLink function
-    const cellA = runtime.getCell<any>(
-      space,
-      "data-uri-cycle-A",
-      undefined,
-      tx,
-    );
-
-    // Create a self-referencing cycle using setRaw to circumvent cycle
-    // detection on write
-    cellA.setRaw(cellA.getAsLink());
-
-    // When we resolve this link at a low level, it should return the empty document
-    // with a data: URI indicating the cycle was detected
-    const resolved = resolveLink(
-      tx,
-      cellA.getAsNormalizedFullLink(),
-      "value",
-    );
-    expect(resolved.id).toBe("data:application/json,");
-    expect(resolved.space).toBe("did:null:null");
-  });
-
-  it("allows non-cyclic references to the same cell", () => {
-    // This should NOT trigger cycle detection - accessing different properties
-    const cellA = runtime.getCell<any>(
-      space,
-      "non-cycle-A",
-      undefined,
-      tx,
-    );
-    const cellB = runtime.getCell<any>(
-      space,
-      "non-cycle-B",
-      undefined,
-      tx,
-    );
-
-    // A has two different references to B at different paths
-    cellA.set({
-      ref1: cellB,
-      ref2: cellB,
-      data: "A data",
     });
 
-    cellB.set({
-      value: "B value",
-      nested: { deep: "deep value" },
+    it("allows non-cyclic references to the same cell", () => {
+      // This should NOT trigger cycle detection - accessing different properties
+      const cellA = runtime.getCell<any>(
+        space,
+        "non-cycle-A",
+        undefined,
+        tx,
+      );
+      const cellB = runtime.getCell<any>(
+        space,
+        "non-cycle-B",
+        undefined,
+        tx,
+      );
+
+      // A has two different references to B at different paths
+      cellA.set({
+        ref1: cellB,
+        ref2: cellB,
+        data: "A data",
+      });
+
+      cellB.set({
+        value: "B value",
+        nested: { deep: "deep value" },
+      });
+
+      // These should all work without cycle detection
+      expect(cellA.key("ref1").key("value").get()).toBe("B value");
+      expect(cellA.key("ref2").key("nested").key("deep").get()).toBe(
+        "deep value",
+      );
+
+      // The resolved links should NOT be data: URIs
+      const link1 = cellA.key("ref1").key("value").getAsNormalizedFullLink();
+      const link2 = cellA.key("ref2").key("nested").getAsNormalizedFullLink();
+
+      expect(link1.id).not.toMatch(/^data:/);
+      expect(link2.id).not.toMatch(/^data:/);
     });
-
-    // These should all work without cycle detection
-    expect(cellA.key("ref1").key("value").get()).toBe("B value");
-    expect(cellA.key("ref2").key("nested").key("deep").get()).toBe(
-      "deep value",
-    );
-
-    // The resolved links should NOT be data: URIs
-    const link1 = cellA.key("ref1").key("value").getAsNormalizedFullLink();
-    const link2 = cellA.key("ref2").key("nested").getAsNormalizedFullLink();
-
-    expect(link1.id).not.toMatch(/^data:/);
-    expect(link2.id).not.toMatch(/^data:/);
   });
 });

--- a/packages/runner/test/recipes.test.ts
+++ b/packages/runner/test/recipes.test.ts
@@ -9,7 +9,7 @@ import { createBuilder } from "../src/builder/factory.ts";
 import { Runtime } from "../src/runtime.ts";
 import { type ErrorWithContext } from "../src/scheduler.ts";
 import { isCell } from "../src/cell.ts";
-import { resolveLinks } from "../src/link-resolution.ts";
+import { resolveLink } from "../src/link-resolution.ts";
 import { isAnyCellLink, parseLink } from "../src/link-utils.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
@@ -1139,7 +1139,7 @@ describe("Recipe Runner", () => {
     expect(wrapperCell.get()).toBe(5);
 
     // Follow all the links until we get to the doc holding the value
-    const ref = resolveLinks(
+    const ref = resolveLink(
       tx,
       wrapperCell.getAsNormalizedFullLink(),
     );


### PR DESCRIPTION
Refactors the link resolution system to consolidate multiple functions into a single resolveLink() function with better cycle detection. The new implementation:

- Merges resolvePath, followLinks, and followWriteRedirects into resolveLink()
- Improves cycle detection to avoid false positives with circular references
- Adds iteration limit (1000) for growing path cycles that are hard to detect
- Returns empty document (data:application/json,) when cycles are detected
- Introduces LastNode parameter to control link following behavior
- Removes complex caching mechanisms in favor of simpler approach
- Updates all callers to use the new unified API

This fixes issues where legitimate navigation through circular data structures would incorrectly trigger cycle detection errors.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Simplified link resolution by merging multiple functions into a single resolveLink() with improved cycle detection, preventing false positives when navigating circular references.

- **Refactors**
  - Combined resolvePath, followLinks, and followWriteRedirects into resolveLink().
  - Improved cycle detection logic and added a 1000-iteration limit for complex cycles.
  - Removed caching and updated all code to use the new API.
  - Returns an empty document when a cycle is detected.

<!-- End of auto-generated description by cubic. -->

