### PR TITLE
Remove experimentalDecorators compiler flag from deno.json

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -42,8 +42,7 @@
     ],
     "types": [
       "./packages/jumble/src/global.d.ts"
-    ],
-    "experimentalDecorators": true
+    ]
   },
   "exclude": [
     "packages/jumble/.vite/deps/",


### PR DESCRIPTION
This is part of an effort to clean up cli logs in the shell package.

There's a persistent warning that `experimentalDecorators` is deprecated, and will be removed at any time.

I believe we are only using this compiler flag for lit web components-- which are now being primarily rendered/viewed downstream from an esbuild in the shell package, which is explicitly configured for `experimentalDecorators` here: https://github.com/commontoolsinc/labs/blob/main/packages/shell/felt.config.ts#L38

Making this its own PR, just in case it breaks something, and we need a simple path to revert.