### PR TITLE
fix: produce NotFoundError's when reading paths that don't exist

### DIFF
--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -656,10 +656,6 @@ export type CommitError =
   | InactiveTransactionError
   | StorageTransactionRejected;
 
-export interface INotFoundError extends Error {
-  name: "NotFoundError";
-  path?: MemoryAddressPathComponent[];
-}
 
 /**
  * Error returned when the media type is not supported by the storage transaction.
@@ -688,6 +684,7 @@ export type ReadError =
 
 export type WriteError =
   | INotFoundError
+  | IStorageTransactionInconsistent
   | IUnsupportedMediaTypeError
   | InactiveTransactionError
   | IReadOnlyAddressError;
@@ -714,6 +711,13 @@ export interface INotFoundError extends Error {
    * Address that we could not resolve.
    */
   address: IMemoryAddress;
+
+  /**
+   * @deprecated Use `address.path` instead. This property exists for backward compatibility.
+   */
+  path?: MemoryAddressPathComponent[];
+
+  from(space: MemorySpace): INotFoundError;
 }
 
 /**

--- a/packages/runner/src/storage/transaction/chronicle.ts
+++ b/packages/runner/src/storage/transaction/chronicle.ts
@@ -2,6 +2,7 @@ import type {
   IAttestation,
   IInvalidDataURIError,
   IMemoryAddress,
+  INotFoundError,
   IReadOnlyAddressError,
   ISpaceReplica,
   IStorageTransactionInconsistent,
@@ -86,7 +87,7 @@ export class Chronicle {
    * Takes an invariant and applies all the changes that were written to this
    * chonicle that fall under the given source.
    */
-  rebase(source: IAttestation) {
+  rebase(source: IAttestation): Result<IAttestation, IStorageTransactionInconsistent> {
     const changes = this.#novelty.select(source.address);
     return changes ? changes.rebase(source) : { ok: source };
   }
@@ -124,6 +125,7 @@ export class Chronicle {
   ): Result<
     IAttestation,
     | IStorageTransactionInconsistent
+    | INotFoundError
     | IInvalidDataURIError
     | IUnsupportedMediaTypeError
   > {
@@ -170,7 +172,7 @@ export class Chronicle {
   /**
    * Attempts to derives transaction that can be commited to an underlying
    * replica. Function fails with {@link IStorageTransactionInconsistent} if
-   * this contains somer read invariant that no longer holds, that is same
+   * this contains some read invariant that no longer holds, that is same
    * read produces different result.
    */
   commit(): Result<

--- a/packages/runner/test/attestation.test.ts
+++ b/packages/runner/test/attestation.test.ts
@@ -231,9 +231,9 @@ describe("Attestation Module", () => {
       });
 
       expect(result.error).toBeDefined();
-      expect(result.error?.name).toBe("StorageTransactionInconsistent");
-      expect(result.error?.message).toContain("cannot read");
-      expect(result.error?.message).toContain("encountered: 42");
+      expect(result.error?.name).toBe("NotFoundError");
+      expect(result.error?.message).toContain("Can not resolve");
+      expect(result.error?.message).toContain("42");
     });
 
     it("should fail when reading through null", () => {
@@ -249,7 +249,7 @@ describe("Attestation Module", () => {
       });
 
       expect(result.error).toBeDefined();
-      expect(result.error?.name).toBe("StorageTransactionInconsistent");
+      expect(result.error?.name).toBe("NotFoundError");
     });
 
     it("should handle array access", () => {
@@ -309,7 +309,7 @@ describe("Attestation Module", () => {
       });
 
       expect(result.error).toBeDefined();
-      expect(result.error?.name).toBe("StorageTransactionInconsistent");
+      expect(result.error?.name).toBe("NotFoundError");
     });
   });
 
@@ -517,7 +517,7 @@ describe("Attestation Module", () => {
       });
 
       expect(result.error).toBeDefined();
-      expect(result.error?.name).toBe("StorageTransactionInconsistent");
+      expect(result.error?.name).toBe("NotFoundError");
     });
 
     it("should handle partial source paths", () => {

--- a/packages/runner/test/chronicle.test.ts
+++ b/packages/runner/test/chronicle.test.ts
@@ -452,7 +452,7 @@ describe("Chronicle", () => {
       });
 
       expect(result.error).toBeDefined();
-      expect(result.error?.name).toBe("StorageTransactionInconsistent");
+      expect(result.error?.name).toBe("NotFoundError");
     });
 
     it("should handle writing to invalid nested paths", () => {
@@ -1597,9 +1597,9 @@ describe("Chronicle", () => {
         const result = chronicle.read(address);
 
         expect(result.error).toBeDefined();
-        expect(result.error!.name).toBe("StorageTransactionInconsistent");
-        expect(result.error!.message).toContain("cannot read");
-        expect(result.error!.message).toContain("expected an object");
+        expect(result.error!.name).toBe("NotFoundError");
+        expect(result.error!.message).toContain("Can not resolve");
+        expect(result.error!.message).toContain("non-object");
       });
 
       it("should not interfere with regular replica reads", () => {

--- a/packages/runner/test/journal.test.ts
+++ b/packages/runner/test/journal.test.ts
@@ -632,7 +632,7 @@ describe("Journal", () => {
       });
 
       expect(result.error).toBeDefined();
-      expect(result.error?.name).toBe("StorageTransactionInconsistent");
+      expect(result.error?.name).toBe("NotFoundError");
     });
 
     it("should handle writing to invalid nested paths", () => {

--- a/packages/runner/test/storage-transaction-shim.test.ts
+++ b/packages/runner/test/storage-transaction-shim.test.ts
@@ -481,7 +481,7 @@ describe("StorageTransaction", () => {
       space,
       id: "of:test-entity-new",
       type: "application/json",
-      path: ["value"],
+      path: [],
     }, { foo: 123 });
     const result = await transaction.commit();
     expect(result.ok).toBeDefined();

--- a/packages/runner/test/transaction.test.ts
+++ b/packages/runner/test/transaction.test.ts
@@ -609,7 +609,7 @@ describe("StorageTransaction", () => {
 
       const result = transaction.read(nestedAddress);
       expect(result.error).toBeDefined();
-      expect(result.error?.name).toBe("StorageTransactionInconsistent");
+      expect(result.error?.name).toBe("NotFoundError");
     });
 
     it("should handle writing to invalid nested paths", () => {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Changed storage transaction logic to return NotFoundError when reading or writing to paths that do not exist, instead of StorageTransactionInconsistent.

- **Bug Fixes**
  - Updated error handling to use NotFoundError for missing paths in storage operations.
  - Adjusted related tests and error messages to expect NotFoundError.

<!-- End of auto-generated description by cubic. -->

