### PR TITLE
Handle multiple OpaqueRefs in property access expressions

### DIFF
--- a/packages/js-runtime/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.tsx
+++ b/packages/js-runtime/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.tsx
@@ -52,15 +52,15 @@ export default recipe({
         [UI]: (<div>
         <h3>Array Operations</h3>
         <p>Total items: {commontools_1.derive(state.items, _v1 => _v1.length)}</p>
-        <p>Filtered count: {commontools_1.derive(state.items, _v1 => _v1.filter(i => i.name.includes(state.filter)).length)}</p>
+        <p>Filtered count: {commontools_1.derive({ state_items: state.items, state_filter: state.filter }, ({ state_items: _v1, state_filter: _v2 }) => _v1.filter(i => i.name.includes(_v2)).length)}</p>
         
         <h3>Array with Complex Expressions</h3>
         <ul>
           {state.items.map(item => (<li key={item.id}>
               <span>{item.name}</span>
               <span> - Original: ${item.price}</span>
-              <span> - Discounted: ${commontools_1.derive({ item_price: item.price, state_discount: state.discount }, ({ item_price: _v1, state_discount: _v2 }) => (_v1 * (1 - _v2)).toFixed(2))}</span>
-              <span> - With tax: ${commontools_1.derive({ item_price: item.price, state_discount: state.discount, state_taxRate: state.taxRate }, ({ item_price: _v1, state_discount: _v2, state_taxRate: _v3 }) => (_v1 * (1 - _v2) * (1 + _v3)).toFixed(2))}</span>
+              <span> - Discounted: ${commontools_1.derive(state.discount, _v1 => (item.price * (1 - _v1)).toFixed(2))}</span>
+              <span> - With tax: ${commontools_1.derive({ state_discount: state.discount, state_taxRate: state.taxRate }, ({ state_discount: _v1, state_taxRate: _v2 }) => (item.price * (1 - _v1) * (1 + _v2)).toFixed(2))}</span>
             </li>))}
         </ul>
         
@@ -73,9 +73,9 @@ export default recipe({
         <p>Tax percent: {commontools_1.derive(state.taxRate, _v1 => _v1 * 100)}%</p>
         
         <h3>Array Predicates</h3>
-        <p>All active: {commontools_1.ifElse(commontools_1.derive({ state_items: state.items, i, i_active: i.active }, ({ state_items: _v1, i: _v2, i_active: _v3 }) => _v1.every(_v2 => _v3)), "Yes", "No")}</p>
-        <p>Any active: {commontools_1.ifElse(commontools_1.derive({ state_items: state.items, i, i_active: i.active }, ({ state_items: _v1, i: _v2, i_active: _v3 }) => _v1.some(_v2 => _v3)), "Yes", "No")}</p>
-        <p>Has expensive (gt 100): {commontools_1.ifElse(commontools_1.derive({ state_items: state.items, i, i_price: i.price }, ({ state_items: _v1, i: _v2, i_price: _v3 }) => _v1.some(_v2 => _v3 > 100)), "Yes", "No")}</p>
+        <p>All active: {commontools_1.ifElse(commontools_1.derive(state.items, _v1 => _v1.every(i => i.active)), "Yes", "No")}</p>
+        <p>Any active: {commontools_1.ifElse(commontools_1.derive(state.items, _v1 => _v1.some(i => i.active)), "Yes", "No")}</p>
+        <p>Has expensive (gt 100): {commontools_1.ifElse(commontools_1.derive(state.items, _v1 => _v1.some(i => i.price > 100)), "Yes", "No")}</p>
         
         <h3>Object Operations</h3>
         <div data-item-count={commontools_1.derive(state.items, _v1 => _v1.length)} data-has-filter={commontools_1.derive(state.filter, _v1 => _v1.length > 0)} data-discount={state.discount}>

--- a/packages/js-runtime/test/fixtures/jsx-expressions/jsx-function-calls.expected.tsx
+++ b/packages/js-runtime/test/fixtures/jsx-expressions/jsx-function-calls.expected.tsx
@@ -67,7 +67,7 @@ export default recipe({
         <p>Parse Float: {commontools_1.derive(state.float, _v1 => parseFloat(_v1))}</p>
         
         <h3>Array Method Calls</h3>
-        <p>Sum: {state.values.reduce((a, b) => a + b, 0)}</p>
+        <p>Sum: {commontools_1.derive(state.values, _v1 => _v1.reduce((a, b) => a + b, 0))}</p>
         <p>Max value: {commontools_1.derive(state.values, _v1 => Math.max(..._v1))}</p>
         <p>Joined: {commontools_1.derive(state.values, _v1 => _v1.join(", "))}</p>
         

--- a/packages/js-runtime/typescript/transformer/types.ts
+++ b/packages/js-runtime/typescript/transformer/types.ts
@@ -199,7 +199,7 @@ function isFunctionParameter(node: ts.Identifier, checker: ts.TypeChecker): bool
         for (const decl of declarations) {
           if (ts.isParameter(decl)) {
             // Find the containing function
-            let parent = decl.parent;
+            const parent = decl.parent;
             if (ts.isFunctionExpression(parent) || 
                 ts.isArrowFunction(parent) || 
                 ts.isFunctionDeclaration(parent) ||


### PR DESCRIPTION
This fixes an issue where expressions containing multiple OpaqueRef dependencies were not being properly transformed. The primary changes are:
  - Add support for multiple OpaqueRefs in PropertyAccessExpression, CallExpression, BinaryExpression, and TemplateExpression transformations
  - Implement deduplication logic to avoid creating redundant parameters for the same OpaqueRef appearing multiple times
  - Skip parameter type checking for methods called ON OpaqueRef objects to prevent incorrect early returns (fixes reduce transformation issue)
  - Add isFunctionParameter helper to properly identify and skip callback parameters in collectOpaqueRefs

The fix ensures that complex expressions like:
  state.items.filter(i => i.name.includes(state.filter)).length
properly collect both state.items and state.filter as dependencies while excluding callback parameters like 'i'.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed transformation of expressions with multiple OpaqueRef dependencies so that all relevant state references are collected, and callback parameters are excluded.

- **Bug Fixes**
  - Added support for multiple OpaqueRefs in property access, call, binary, and template expressions.
  - Deduplicated OpaqueRefs to avoid redundant parameters.
  - Skipped parameter type checks for methods called on OpaqueRef objects to fix issues with array methods like reduce.
  - Improved detection of function parameters to prevent collecting callback variables as dependencies.

<!-- End of auto-generated description by cubic. -->

