### PR TITLE
fix(runner): Cell.setRaw ensures value is serializable and removes undefined

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -648,6 +648,12 @@ export class RegularCell<T> implements Cell<T> {
 
   setRaw(value: any): void {
     if (!this.tx) throw new Error("Transaction required for setRaw");
+    try {
+      value = JSON.parse(JSON.stringify(value));
+    } catch (e) {
+      console.error("Can't set raw value, it's not JSON serializable", e);
+      return;
+    }
     this.tx.writeValueOrThrow(this.link, value);
   }
 


### PR DESCRIPTION
Fixes errors with `refer` calls further down in the stack
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Cell.setRaw now checks that values are JSON serializable and removes undefined values to prevent downstream errors.

<!-- End of auto-generated description by cubic. -->

