### PR TITLE
fix(runner): Fix array index string comparison bug in transaction address handling

### DIFF
--- a/packages/runner/src/storage/transaction/address.ts
+++ b/packages/runner/src/storage/transaction/address.ts
@@ -9,21 +9,44 @@ export const toString = (address: IMemoryAddress) =>
 export const includes = (
   source: IMemoryAddress,
   candidate: IMemoryAddress,
-) =>
-  source.id === candidate.id &&
-  source.type === candidate.type &&
-  candidate.path.join("/").startsWith(source.path.join("/"));
+) => {
+  if (source.id !== candidate.id || source.type !== candidate.type) {
+    return false;
+  }
+  
+  // Check if candidate path starts with source path
+  if (candidate.path.length < source.path.length) {
+    return false;
+  }
+  
+  // Compare each path element
+  for (let i = 0; i < source.path.length; i++) {
+    if (source.path[i] !== candidate.path[i]) {
+      return false;
+    }
+  }
+  
+  return true;
+};
 
 export const intersects = (
   source: IMemoryAddress,
   candidate: IMemoryAddress,
 ) => {
-  if (source.id === candidate.id && source.type === candidate.type) {
-    const left = source.path.join("/");
-    const right = candidate.path.join("/");
-    return left.startsWith(right) || right.startsWith(left);
+  if (source.id !== candidate.id || source.type !== candidate.type) {
+    return false;
   }
-  return false;
+  
+  // Check if either path is a prefix of the other
+  const minLength = Math.min(source.path.length, candidate.path.length);
+  
+  for (let i = 0; i < minLength; i++) {
+    if (source.path[i] !== candidate.path[i]) {
+      return false;
+    }
+  }
+  
+  return true;
 };
 
 /**


### PR DESCRIPTION
The Address.includes() and Address.intersects() functions were using string-based path comparison which caused incorrect matching - e.g., path "10" would match as a child of path "1" because "10".startsWith("1") is true.

This caused transaction consistency errors when pushing more than 10 elements to an array, as array[10] would incorrectly be considered a child of array[1].

- Replace string concatenation/comparison with element-by-element array comparison
- Fix both includes() and intersects() functions in address.ts

The bug manifested as "StorageTransactionInconsistent" errors with messages like: 'Transaction consistency violated: The "application/json" of "..." at "value.internal.my_array.1" hash changed. Previously it used to be: 1 and currently it is: undefined'