### PR TITLE
use logger.ts, downgrade error for cycle detected

### DIFF
--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -7,6 +7,7 @@ import {
   isObject,
   isString,
 } from "../../utils/src/types.ts";
+import { Logger } from "../../utils/src/logger.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import type {
   JSONObject,
@@ -18,6 +19,8 @@ import { deepEqual } from "./path-utils.ts";
 import { isAnyCellLink, parseLink } from "./link-utils.ts";
 import type { URI } from "./sigil-types.ts";
 import { fromURI } from "./uri-utils.ts";
+
+const logger = new Logger("traverse");
 
 export type SchemaPathSelector = {
   path: readonly string[];
@@ -94,11 +97,11 @@ export class CycleTracker<K> {
   }
   include(k: K, context?: unknown): Disposable | null {
     if (this.partial.has(k)) {
-      console.error(
+      logger.warn(() => [
         "Cycle Detected!",
         k,
         context,
-      );
+      ]);
       return null;
     }
     this.partial.add(k);
@@ -258,7 +261,7 @@ export abstract class BaseObjectTraverser<K, S> {
         ) as Immutable<JSONValue>;
       }
     } else {
-      console.error("Encountered unexpected object: ", doc.value);
+      logger.error(() => ["Encountered unexpected object: ", doc.value]);
       return null;
     }
   }
@@ -511,7 +514,7 @@ function narrowSchema(
   let docPathIndex = 0;
   while (docPathIndex < docPath.length && docPathIndex < selector.path.length) {
     if (docPath[docPathIndex] !== selector.path[docPathIndex]) {
-      console.warn("Mismatched paths", docPath, selector.path);
+      logger.warn(() => ["Mismatched paths", docPath, selector.path]);
       return MinimalSchemaSelector;
     }
     docPathIndex++;
@@ -634,22 +637,25 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
       // This value rejects all objects - just return
       return undefined;
     } else if (typeof schemaContext.schema !== "object") {
-      console.warn("Invalid schema is not an object", schemaContext.schema);
+      logger.warn(
+        () => ["Invalid schema is not an object", schemaContext.schema],
+      );
       return undefined;
     }
     if ("$ref" in schemaContext.schema) {
+      const schemaWithRef = schemaContext.schema as JSONSchema;
       // At some point, this should be extended to support more than just '#'
-      if (schemaContext.schema["$ref"] != "#") {
-        console.warn(
+      if (schemaWithRef["$ref"] != "#") {
+        logger.warn(() => [
           "Unsupported $ref in schema: ",
-          schemaContext.schema["$ref"],
-        );
+          schemaWithRef["$ref"],
+        ]);
       }
       if (schemaContext.rootSchema === undefined) {
-        console.warn(
+        logger.warn(() => [
           "Unsupported $ref without root schema: ",
-          schemaContext.schema["$ref"],
-        );
+          schemaWithRef["$ref"],
+        ]);
         return undefined;
       }
       schemaContext = {

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -7,7 +7,7 @@ import {
   isObject,
   isString,
 } from "../../utils/src/types.ts";
-import { Logger } from "../../utils/src/logger.ts";
+import { getLogger } from "../../utils/src/logger.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import type {
   JSONObject,
@@ -20,7 +20,7 @@ import { isAnyCellLink, parseLink } from "./link-utils.ts";
 import type { URI } from "./sigil-types.ts";
 import { fromURI } from "./uri-utils.ts";
 
-const logger = new Logger("traverse");
+const logger = getLogger("traverse", { enabled: true, level: "warn" });
 
 export type SchemaPathSelector = {
   path: readonly string[];


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Replaced direct console logging in traverse.ts with the shared logger and downgraded cycle detection from error to warning for clearer, more consistent logs.

- **Refactors**
  - Swapped all console.error and console.warn calls for logger methods.
  - Cycle detection now logs a warning instead of an error.

<!-- End of auto-generated description by cubic. -->

