### PR TITLE
fix(runner): Use JSON.stringify for address path serialization

### DIFF
--- a/packages/runner/src/storage/differential.ts
+++ b/packages/runner/src/storage/differential.ts
@@ -1,5 +1,6 @@
 import { FactAddress } from "@commontools/memory";
 import { IMemoryChange, IMergedChanges, State } from "./interface.ts";
+import * as Address from "./transaction/address.ts";
 
 export const create = () => new Changes();
 
@@ -97,9 +98,7 @@ class Changes implements IMergedChanges {
   }
 
   add(change: IMemoryChange) {
-    const key = `/${change.address.type}/${change.address.id}/${
-      change.address.path.join("/")
-    }`;
+    const key = Address.toString(change.address);
 
     if (!this.#model.has(key)) {
       this.#model.set(key, change);

--- a/packages/runner/src/storage/transaction/address.ts
+++ b/packages/runner/src/storage/transaction/address.ts
@@ -1,6 +1,6 @@
 import type { IMemoryAddress } from "../interface.ts";
 export const toString = (address: IMemoryAddress) =>
-  `/${address.id}/${address.type}/${address.path.join("/")}`;
+  `/${address.id}/${address.type}/${JSON.stringify(address.path)}`;
 
 /**
  * Returns true if `candidate` address references location within the
@@ -13,19 +13,19 @@ export const includes = (
   if (source.id !== candidate.id || source.type !== candidate.type) {
     return false;
   }
-  
+
   // Check if candidate path starts with source path
   if (candidate.path.length < source.path.length) {
     return false;
   }
-  
+
   // Compare each path element
   for (let i = 0; i < source.path.length; i++) {
     if (source.path[i] !== candidate.path[i]) {
       return false;
     }
   }
-  
+
   return true;
 };
 
@@ -36,16 +36,16 @@ export const intersects = (
   if (source.id !== candidate.id || source.type !== candidate.type) {
     return false;
   }
-  
+
   // Check if either path is a prefix of the other
   const minLength = Math.min(source.path.length, candidate.path.length);
-  
+
   for (let i = 0; i < minLength; i++) {
     if (source.path[i] !== candidate.path[i]) {
       return false;
     }
   }
-  
+
   return true;
 };
 

--- a/packages/runner/src/storage/transaction/chronicle.ts
+++ b/packages/runner/src/storage/transaction/chronicle.ts
@@ -514,11 +514,8 @@ class Changes {
   get(at: IMemoryAddress["path"]): IAttestation | undefined {
     let candidate: undefined | IAttestation = undefined;
     for (const invariant of this.#model.values()) {
-      // Check if invariant's path is a prefix of requested path
-      const path = invariant.address.path.join("/");
-
       // For exact match or if invariant is parent of requested path
-      if (at.join("/").startsWith(path)) {
+      if (invariant.address.path.every((p, i) => p === at[i])) {
         const size = invariant.address.path.length;
         if ((candidate?.address?.path?.length ?? -1) < size) {
           candidate = invariant;
@@ -530,10 +527,10 @@ class Changes {
   }
 
   put(invariant: IAttestation) {
-    this.#model.set(invariant.address.path.join("/"), invariant);
+    this.#model.set(JSON.stringify(invariant.address.path), invariant);
   }
   delete(invariant: IAttestation) {
-    this.#model.delete(invariant.address.path.join("/"));
+    this.#model.delete(JSON.stringify(invariant.address.path));
   }
 
   /**

--- a/packages/runner/test/address.test.ts
+++ b/packages/runner/test/address.test.ts
@@ -14,7 +14,7 @@ describe("Address Module", () => {
 
       const result = Address.toString(address);
 
-      expect(result).toBe("/user:1/application/json/");
+      expect(result).toBe("/user:1/application/json/[]");
     });
 
     it("should convert address with single path element to string", () => {
@@ -26,7 +26,7 @@ describe("Address Module", () => {
 
       const result = Address.toString(address);
 
-      expect(result).toBe("/user:1/application/json/profile");
+      expect(result).toBe('/user:1/application/json/["profile"]');
     });
 
     it("should convert address with nested path to string", () => {
@@ -38,7 +38,9 @@ describe("Address Module", () => {
 
       const result = Address.toString(address);
 
-      expect(result).toBe("/user:1/application/json/profile/settings/theme");
+      expect(result).toBe(
+        '/user:1/application/json/["profile","settings","theme"]',
+      );
     });
 
     it("should handle address with numeric path elements", () => {
@@ -50,7 +52,7 @@ describe("Address Module", () => {
 
       const result = Address.toString(address);
 
-      expect(result).toBe("/array:1/application/json/items/0/name");
+      expect(result).toBe('/array:1/application/json/["items","0","name"]');
     });
 
     it("should handle address with special characters in id", () => {
@@ -62,7 +64,9 @@ describe("Address Module", () => {
 
       const result = Address.toString(address);
 
-      expect(result).toBe("/user:special-chars_123/application/json/data");
+      expect(result).toBe(
+        '/user:special-chars_123/application/json/["data"]',
+      );
     });
 
     it("should handle different content types", () => {
@@ -74,7 +78,7 @@ describe("Address Module", () => {
 
       const result = Address.toString(address);
 
-      expect(result).toBe("/document:1/text/plain/metadata/title");
+      expect(result).toBe('/document:1/text/plain/["metadata","title"]');
     });
   });
 
@@ -596,7 +600,7 @@ describe("Address Module", () => {
         path: [],
       } as const;
 
-      expect(Address.toString(address1)).toBe("/user:1/application/json/");
+      expect(Address.toString(address1)).toBe("/user:1/application/json/[]");
       expect(Address.includes(address1, address2)).toBe(true);
       expect(Address.intersects(address1, address2)).toBe(true);
     });
@@ -611,7 +615,7 @@ describe("Address Module", () => {
       const result = Address.toString(address);
 
       expect(result).toBe(
-        "/namespace:complex-id-with-dashes_and_underscores.123/application/vnd.api+json/data/attributes/nested-property",
+        '/namespace:complex-id-with-dashes_and_underscores.123/application/vnd.api+json/["data","attributes","nested-property"]',
       );
     });
 


### PR DESCRIPTION
- Replace path.join('/') with JSON.stringify(path) for consistent serialization
- Update address.toString() to use JSON format for paths
- Fix differential.ts to use Address.toString() instead of manual concatenation
- Update chronicle.ts to use JSON.stringify for path-based map keys
- Ensure consistent path comparison logic across the codebase

This change prevents issues with path elements containing slashes or special characters by using JSON serialization instead of simple string joining.