### PR TITLE
Minimal support for definitions

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -148,6 +148,7 @@ export type JSONSchemaTypes =
 export type JSONSchema = {
   readonly $ref?: string;
   readonly $defs?: Readonly<Record<string, JSONSchema>>;
+  readonly definitions?: Readonly<Record<string, JSONSchema | boolean>>;
 
   // Subschema logic
   readonly allOf?: readonly (JSONSchema | boolean)[]; // not validated

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -148,6 +148,7 @@ export type JSONSchemaTypes =
 export type JSONSchema = {
   readonly $ref?: string;
   readonly $defs?: Readonly<Record<string, JSONSchema>>;
+  /** @deprecated Use `$defs` for 2019-09/Draft 8 or later */
   readonly definitions?: Readonly<Record<string, JSONSchema | boolean>>;
 
   // Subschema logic
@@ -331,7 +332,7 @@ export type LiftFunction = {
   ): ModuleFactory<Parameters<T>[0], ReturnType<T>>;
 
   <T, R>(
-    argumentSchema?: JSONSchema | ((input: any) => any),
+    argumentSchema?: JSONSchema,
     resultSchema?: JSONSchema,
     implementation?: (input: T) => R,
   ): ModuleFactory<T, R>;

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -329,6 +329,12 @@ export type LiftFunction = {
   <T extends (...args: any[]) => any>(
     implementation: T,
   ): ModuleFactory<Parameters<T>[0], ReturnType<T>>;
+
+  <T, R>(
+    argumentSchema?: JSONSchema | ((input: any) => any),
+    resultSchema?: JSONSchema,
+    implementation?: (input: T) => R,
+  ): ModuleFactory<T, R>;
 };
 
 // Helper type to make non-Cell and non-Stream properties readonly in handler state

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -651,7 +651,10 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
       return undefined;
     }
     const schemaRef = schemaContext.schema["$ref"];
-    const pathToDef = schemaRef.split("/");
+    // schemaRef is a JSONPointer, so split and unescape
+    const pathToDef = schemaRef.split("/").map((p) =>
+      p.replace("~1", "/").replace("~0", "~")
+    );
     if (pathToDef[0] === "#") {
       let schemaCursor: unknown = schemaContext.rootSchema;
       // start at 1, since the 0 element is "#"

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -524,6 +524,7 @@ function narrowSchema(
     const schema = cfc.schemaAtPath(
       selector.schemaContext!.schema,
       docPath.slice(docPathIndex),
+      selector.schemaContext!.rootSchema,
     );
     return {
       path: [...targetPath],

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -66,6 +66,7 @@ export type JSONSchemaTypes = "object" | "array" | "string" | "integer" | "numbe
 export type JSONSchema = {
     readonly $ref?: string;
     readonly $defs?: Readonly<Record<string, JSONSchema>>;
+    /** @deprecated Use `$defs` for 2019-09/Draft 8 or later */
     readonly definitions?: Readonly<Record<string, JSONSchema | boolean>>;
     readonly allOf?: readonly (JSONSchema | boolean)[];
     readonly anyOf?: readonly JSONSchema[];
@@ -182,7 +183,7 @@ export type LiftFunction = {
     <T, R>(implementation: (input: T) => R): ModuleFactory<T, R>;
     <T>(implementation: (input: T) => any): ModuleFactory<T, ReturnType<typeof implementation>>;
     <T extends (...args: any[]) => any>(implementation: T): ModuleFactory<Parameters<T>[0], ReturnType<T>>;
-    <T, R>(argumentSchema?: JSONSchema | ((input: any) => any), resultSchema?: JSONSchema, implementation?: (input: T) => R): ModuleFactory<T, R>;
+    <T, R>(argumentSchema?: JSONSchema, resultSchema?: JSONSchema, implementation?: (input: T) => R): ModuleFactory<T, R>;
 };
 export type HandlerState<T> = T extends Cell<any> ? T : T extends Stream<any> ? T : T extends Array<infer U> ? ReadonlyArray<HandlerState<U>> : T extends object ? {
     readonly [K in keyof T]: HandlerState<T[K]>;

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -66,6 +66,7 @@ export type JSONSchemaTypes = "object" | "array" | "string" | "integer" | "numbe
 export type JSONSchema = {
     readonly $ref?: string;
     readonly $defs?: Readonly<Record<string, JSONSchema>>;
+    readonly definitions?: Readonly<Record<string, JSONSchema | boolean>>;
     readonly allOf?: readonly (JSONSchema | boolean)[];
     readonly anyOf?: readonly JSONSchema[];
     readonly oneOf?: readonly (JSONSchema | boolean)[];
@@ -181,6 +182,7 @@ export type LiftFunction = {
     <T, R>(implementation: (input: T) => R): ModuleFactory<T, R>;
     <T>(implementation: (input: T) => any): ModuleFactory<T, ReturnType<typeof implementation>>;
     <T extends (...args: any[]) => any>(implementation: T): ModuleFactory<Parameters<T>[0], ReturnType<T>>;
+    <T, R>(argumentSchema?: JSONSchema | ((input: any) => any), resultSchema?: JSONSchema, implementation?: (input: T) => R): ModuleFactory<T, R>;
 };
 export type HandlerState<T> = T extends Cell<any> ? T : T extends Stream<any> ? T : T extends Array<infer U> ? ReadonlyArray<HandlerState<U>> : T extends object ? {
     readonly [K in keyof T]: HandlerState<T[K]>;


### PR DESCRIPTION
Add basic support for the definitions block of JSONSchema, and use this in the schema traversal.
Also added a missing signature for LiftFunction.

See #CT-672 for limitations
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added minimal support for the definitions block in JSONSchema, allowing schema traversal to resolve $ref references to definitions.

- **New Features**
  - Schema traversal now resolves $ref values pointing to definitions and $defs.
  - Updated type definitions and tests to cover schemas using definitions.

<!-- End of auto-generated description by cubic. -->

