### PR TITLE
refactor: update js-runtime logging to use utils/src/logger.ts

### DIFF
--- a/packages/js-runtime/test/fixture-based.test.ts
+++ b/packages/js-runtime/test/fixture-based.test.ts
@@ -16,12 +16,12 @@ function createUnifiedDiff(
   const maxLines = Math.max(expectedLines.length, actualLines.length);
 
   const diffRanges: Array<{ start: number; end: number }> = [];
-  
+
   // First, find all ranges with differences
   for (let i = 0; i < maxLines; i++) {
     const expectedLine = expectedLines[i] ?? "";
     const actualLine = actualLines[i] ?? "";
-    
+
     if (expectedLine !== actualLine) {
       // Find or extend a range
       const lastRange = diffRanges[diffRanges.length - 1];
@@ -40,13 +40,13 @@ function createUnifiedDiff(
   for (const range of diffRanges) {
     const blockStart = Math.max(0, range.start - context);
     const blockEnd = Math.min(maxLines - 1, range.end + context);
-    
+
     const lines: string[] = [];
-    
+
     for (let i = blockStart; i <= blockEnd; i++) {
       const expectedLine = expectedLines[i] ?? "";
       const actualLine = actualLines[i] ?? "";
-      
+
       if (expectedLine === actualLine) {
         lines.push(`  ${expectedLine}`);
       } else {
@@ -58,12 +58,14 @@ function createUnifiedDiff(
         }
       }
     }
-    
+
     // Create the hunk header
-    const expectedCount = lines.filter(l => !l.startsWith("+")).length;
-    const actualCount = lines.filter(l => !l.startsWith("-")).length;
-    
-    diff += `@@ -${blockStart + 1},${expectedCount} +${blockStart + 1},${actualCount} @@\n`;
+    const expectedCount = lines.filter((l) => !l.startsWith("+")).length;
+    const actualCount = lines.filter((l) => !l.startsWith("-")).length;
+
+    diff += `@@ -${blockStart + 1},${expectedCount} +${
+      blockStart + 1
+    },${actualCount} @@\n`;
     diff += lines.join("\n") + "\n\n";
   }
 
@@ -234,8 +236,12 @@ for (const config of configsWithFixtures) {
               let diffMessage =
                 `\n\nTransformation output does not match expected for: ${testName}\n`;
               diffMessage += `\nFiles:\n`;
-              diffMessage += `  Input:    ${resolve(`test/fixtures/${inputPath}.input${ext}`)}\n`;
-              diffMessage += `  Expected: ${resolve(`test/fixtures/${inputPath}.expected${ext}`)}\n`;
+              diffMessage += `  Input:    ${
+                resolve(`test/fixtures/${inputPath}.input${ext}`)
+              }\n`;
+              diffMessage += `  Expected: ${
+                resolve(`test/fixtures/${inputPath}.expected${ext}`)
+              }\n`;
               diffMessage += `\n${"=".repeat(80)}\n`;
               diffMessage += `UNIFIED DIFF (expected vs actual):\n`;
               diffMessage += `${"=".repeat(80)}\n`;
@@ -274,8 +280,12 @@ for (const config of configsWithFixtures) {
           let diffMessage =
             `\n\nTransformation output does not match expected for: ${testName}\n`;
           diffMessage += `\nFiles:\n`;
-          diffMessage += `  Input:    ${resolve(`test/fixtures/${inputPath}.input${ext}`)}\n`;
-          diffMessage += `  Expected: ${resolve(`test/fixtures/${inputPath}.expected${ext}`)}\n`;
+          diffMessage += `  Input:    ${
+            resolve(`test/fixtures/${inputPath}.input${ext}`)
+          }\n`;
+          diffMessage += `  Expected: ${
+            resolve(`test/fixtures/${inputPath}.expected${ext}`)
+          }\n`;
           diffMessage += `\n${"=".repeat(80)}\n`;
           diffMessage += `UNIFIED DIFF (expected vs actual):\n`;
           diffMessage += `${"=".repeat(80)}\n`;

--- a/packages/js-runtime/test/opaque-ref.test.ts
+++ b/packages/js-runtime/test/opaque-ref.test.ts
@@ -50,7 +50,9 @@ const el = <div>{count + 1}</div>;
 
       await expect(
         transformSource(source, { mode: "error", types }),
-      ).rejects.toThrow(/JSX expression with OpaqueRef computation should use derive/);
+      ).rejects.toThrow(
+        /JSX expression with OpaqueRef computation should use derive/,
+      );
     });
 
     it("reports multiple errors", async () => {
@@ -90,7 +92,9 @@ const el = <div>{count + 1}</div>;
       // Check that debug mode produces some output
       expect(logs.length).toBeGreaterThan(0);
       // Check for the test transformer output that test-utils.ts generates
-      expect(logs.some((log) => log.includes("TEST TRANSFORMER OUTPUT"))).toBe(true);
+      expect(logs.some((log) => log.includes("TEST TRANSFORMER OUTPUT"))).toBe(
+        true,
+      );
     });
   });
 

--- a/packages/js-runtime/test/recipe-map.test.ts
+++ b/packages/js-runtime/test/recipe-map.test.ts
@@ -35,9 +35,9 @@ export default recipe<{ items: string[] }>("Test Recipe", ({ items }) => {
     // The transformation should work correctly
     assertStringIncludes(result, "items.map((item, index)");
     assertStringIncludes(result, "{item}");
-    
+
     // Schema should be generated
-    assertStringIncludes(result, "type: \"array\"");
+    assertStringIncludes(result, 'type: "array"');
     assertStringIncludes(result, "items: {");
   });
 

--- a/packages/js-runtime/test/test-utils.ts
+++ b/packages/js-runtime/test/test-utils.ts
@@ -178,12 +178,11 @@ export async function transformSource(
   // Always add OpaqueRef transformer first
   transformers.push(createOpaqueRefTransformer(program, {
     mode,
-    logger,
   }));
 
   // Optionally add schema transformer
   if (applySchemaTransformer) {
-    transformers.push(createSchemaTransformer(program, { logger }));
+    transformers.push(createSchemaTransformer(program));
   }
 
   // Transform the source file

--- a/packages/js-runtime/typescript/transformer/debug.ts
+++ b/packages/js-runtime/typescript/transformer/debug.ts
@@ -2,8 +2,7 @@
  * Base options for all transformers
  */
 export interface TransformerOptions {
-  /** Optional logger function for debugging output */
-  logger?: (message: string) => void;
+  // Currently no shared options
 }
 
 /**

--- a/packages/js-runtime/typescript/transformer/debug.ts
+++ b/packages/js-runtime/typescript/transformer/debug.ts
@@ -1,11 +1,4 @@
 /**
- * Base options for all transformers
- */
-export interface TransformerOptions {
-  // Currently no shared options
-}
-
-/**
  * Transformation types for type safety and consistency
  */
 export const TRANSFORMATION_TYPES = {

--- a/packages/js-runtime/typescript/transformer/logging.ts
+++ b/packages/js-runtime/typescript/transformer/logging.ts
@@ -1,9 +1,9 @@
 import ts from "typescript";
-import { TransformerOptions } from "./debug.ts";
 import { hasCtsEnableDirective } from "./utils.ts";
 
-export interface LoggingTransformerOptions extends TransformerOptions {
+export interface LoggingTransformerOptions {
   showTransformed?: boolean;
+  logger?: (message: string) => void;
 }
 
 /**

--- a/packages/js-runtime/typescript/transformer/mod.ts
+++ b/packages/js-runtime/typescript/transformer/mod.ts
@@ -12,7 +12,7 @@ export { createSchemaTransformer } from "./schema.ts";
 export { createLoggingTransformer } from "./logging.ts";
 
 // Debug utilities
-export { TRANSFORMATION_TYPES, type TransformerOptions } from "./debug.ts";
+export { TRANSFORMATION_TYPES } from "./debug.ts";
 
 // Type checking utilities
 export {

--- a/packages/js-runtime/typescript/transformer/opaque-ref.ts
+++ b/packages/js-runtime/typescript/transformer/opaque-ref.ts
@@ -13,7 +13,7 @@ import {
   TransformationTypeString,
   transformExpressionWithOpaqueRef,
 } from "./transforms.ts";
-import { TRANSFORMATION_TYPES, TransformerOptions } from "./debug.ts";
+import { TRANSFORMATION_TYPES } from "./debug.ts";
 
 // Create logger for OpaqueRef transformer
 const logger = getLogger("opaque-ref-transformer", {


### PR DESCRIPTION
  - replace console.log/warn/error with getLogger from @commontools/utils/logger
  - remove logger parameter passing to transformers - each module creates its own
  - keep console.log for --show-transformed raw output only
  - update tests to not pass logger to transformer functions
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Refactored js-runtime logging to use getLogger from @commontools/utils/logger instead of console methods, and removed logger parameter passing to transformers.

- **Refactors**
  - Each transformer module now creates its own logger.
  - Console output is only used for --show-transformed raw output.
  - Updated tests to stop passing logger to transformer functions.

<!-- End of auto-generated description by cubic. -->

