### PR TITLE
Fix iframe object updates to use transaction

### DIFF
--- a/packages/jumble/src/iframe-ctx.ts
+++ b/packages/jumble/src/iframe-ctx.ts
@@ -195,7 +195,9 @@ export const setupIframe = (runtime: Runtime) =>
           const type = context.key(key).schema?.type ??
             currentValueType ?? typeof value;
           if (type === "object" && isObject(value)) {
-            context.key(key).update(value);
+            const tx = context.runtime.edit();
+            context.withTx(tx).key(key).update(value);
+            tx.commit();
           } else if (
             (type === "array" && Array.isArray(value)) ||
             (type === "integer" && typeof value === "number") ||


### PR DESCRIPTION
Modified iframe-ctx.ts to wrap object updates in a transaction using runtime.edit() and tx.commit(). This ensures that object updates in iframes are properly handled within the transaction system, preventing potential state inconsistencies.

The change specifically affects how object-type values are updated through the iframe context API.    

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed object updates in iframes to use transactions, ensuring changes are applied correctly.

<!-- End of auto-generated description by cubic. -->

