### PR TITLE
Change StorageProvider.sync to take a SchemaPathSelector.

### DIFF
--- a/packages/memory/consumer.ts
+++ b/packages/memory/consumer.ts
@@ -552,9 +552,9 @@ class QueryView<
   }
 
   // Get the facts returned by the query, together with the associated
-  // schema context used to query
-  get schemaFacts(): [Revision<Fact>, SchemaContext | undefined][] {
-    return this.facts.map((fact) => [fact, this.getSchema(fact)]);
+  // SchemaPathSelector used to query
+  get schemaFacts(): [Revision<Fact>, SchemaPathSelector | undefined][] {
+    return this.facts.map((fact) => [fact, this.getSchemaPathSelector(fact)]);
   }
 
   subscribe() {
@@ -566,13 +566,9 @@ class QueryView<
 
   // Get the schema context used to fetch the specified fact.
   // If the fact was included from another fact, it will not have a schemaContext.
-  getSchema(fact: Revision<Fact>): SchemaContext | undefined {
+  getSchemaPathSelector(fact: Revision<Fact>): SchemaPathSelector | undefined {
     const factSelector = this.selector as SchemaSelector;
-    const revision = getSelectorRevision(factSelector, fact.of, fact.the);
-    if (revision !== undefined) {
-      return revision.schemaContext;
-    }
-    return undefined;
+    return getSelectorRevision(factSelector, fact.of, fact.the);
   }
 }
 

--- a/packages/runner/integration/reconnection.test.ts
+++ b/packages/runner/integration/reconnection.test.ts
@@ -34,7 +34,7 @@ const provider1 = storageManager1.open(signer.did());
 console.log(`Connected to memory server`);
 
 // Define test schema
-const testSchema: SchemaContext = {
+const testSchemaContext: SchemaContext = {
   schema: {
     type: "object",
     properties: {
@@ -52,6 +52,7 @@ const testSchema: SchemaContext = {
     required: ["value"],
   },
 };
+const testSelector = { path: [], schemaContext: testSchemaContext };
 
 interface UpdateValue {
   value: number;
@@ -89,8 +90,8 @@ provider3.sink(uri, (value) => {
 
 // Establish server-side subscription with schema
 console.log("Establishing subscriptions...");
-await provider1.sync(uri, true, testSchema);
-await provider3.sync(uri, true, testSchema);
+await provider1.sync(uri, testSelector);
+await provider3.sync(uri, testSelector);
 
 // Send initial value to server
 console.log("Sending initial value...");
@@ -155,7 +156,7 @@ console.log(`Connected to memory server as second client`);
 
 // Establish server-side subscription with schema
 console.log("Establishing subscription as second client...");
-await provider2.sync(uri, true, testSchema);
+await provider2.sync(uri, testSelector);
 
 // Send test updates and check if subscription still works
 console.log("Sending test updates after disconnection...");

--- a/packages/runner/src/storage.ts
+++ b/packages/runner/src/storage.ts
@@ -173,11 +173,15 @@ export class Storage implements IStorage {
           : cell.schema,
       };
     }
+    const selector = schemaContext === undefined ? undefined : {
+      path: cell.path.map((p) => p.toString()),
+      schemaContext,
+    };
 
     if (!this.shim) {
       const { space, id } = cell.getAsNormalizedFullLink();
       const storageProvider = this._getStorageProviderForSpace(space);
-      await storageProvider.sync(id, false, schemaContext);
+      await storageProvider.sync(id, selector);
       return cell;
     }
 
@@ -209,7 +213,7 @@ export class Storage implements IStorage {
     const storageProvider = this._getStorageProviderForSpace(doc.space);
     const uri = Storage.toURI(doc.entityId);
 
-    const result = await storageProvider.sync(uri, false, schemaContext);
+    const result = await storageProvider.sync(uri, selector);
     if (result.error) {
       // This will be a decoupled doc that is not persisted and cannot be edited
       doc.ephemeral = true;

--- a/packages/runner/src/storage/base.ts
+++ b/packages/runner/src/storage/base.ts
@@ -1,5 +1,9 @@
-import { SchemaContext } from "../builder/types.ts";
-import type { Result, Unit, URI } from "@commontools/memory/interface";
+import type {
+  Result,
+  SchemaPathSelector,
+  Unit,
+  URI,
+} from "@commontools/memory/interface";
 import type { Cancel } from "../cancel.ts";
 import { log } from "../log.ts";
 import { IStorageProvider, StorageValue } from "./interface.ts";
@@ -18,8 +22,7 @@ export abstract class BaseStorageProvider implements IStorageProvider {
 
   abstract sync(
     uri: URI,
-    expectedInStorage: boolean,
-    schemaContext?: SchemaContext,
+    selector?: SchemaPathSelector,
   ): Promise<Result<Unit, Error>>;
   // TODO(@ubik2)
   //): Promise<Result<Selection<FactAddress, Revision<State>>, Error>>;

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -33,7 +33,7 @@ import { assert, retract, unclaimed } from "@commontools/memory/fact";
 import { the, toRevision } from "@commontools/memory/commit";
 import * as Consumer from "@commontools/memory/consumer";
 import * as Codec from "@commontools/memory/codec";
-import { type Cancel, type EntityId } from "@commontools/runner";
+import type { Cancel } from "@commontools/runner";
 import type { JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import { deepEqual } from "../path-utils.ts";
@@ -311,17 +311,17 @@ class RevisionAddress {
 
 class PullQueue {
   constructor(
-    public members: Map<string, [FactAddress, SchemaContext?]> = new Map(),
+    public members: Map<string, [FactAddress, SchemaPathSelector?]> = new Map(),
   ) {
   }
-  add(entries: Iterable<[FactAddress, SchemaContext?]>) {
+  add(entries: Iterable<[FactAddress, SchemaPathSelector?]>) {
     // TODO(@ubik2) Ensure the schema context matches
-    for (const [entry, schema] of entries) {
-      this.members.set(toKey(entry), [entry, schema]);
+    for (const [entry, selector] of entries) {
+      this.members.set(toKey(entry), [entry, selector]);
     }
   }
 
-  consume(): [FactAddress, SchemaContext?][] {
+  consume(): [FactAddress, SchemaPathSelector?][] {
     const entries = [...this.members.values()];
     this.members.clear();
     return entries;
@@ -536,7 +536,7 @@ export class Replica {
    * local store in this session.
    */
   async pull(
-    entries: [FactAddress, SchemaContext?][] = this.queue.consume(),
+    entries: [FactAddress, SchemaPathSelector?][] = this.queue.consume(),
   ): Promise<
     Result<
       Selection<FactAddress, Revision<State>>,
@@ -551,21 +551,23 @@ export class Replica {
 
     // Otherwise we build a query selector to fetch requested entries from the
     // remote.
+    // this is the object with the of/the/cause nesting, then a SchemaPathSelector inside
     const schemaSelector = {};
     const querySelector = {};
     // We'll assert that we need all the classifications we expect to need.
     // If we don't actually have those, the server will reject our request.
     const classifications = new Set<string>();
-    for (const [{ the, of }, context] of entries) {
+    for (const [{ the, of }, schemaPathSelector] of entries) {
       if (this.useSchemaQueries) {
         // If we don't have a schema, use SchemaNone, which will only fetch the specified object
-        const schemaContext = context ?? SchemaNone;
-        setSelector(schemaSelector, of, the, "_", {
-          path: [],
-          schemaContext: schemaContext,
-        });
+        const selector = schemaPathSelector ??
+          { path: [], schemaContext: SchemaNone };
+        setSelector(schemaSelector, of, the, "_", selector);
         // Since we're accessing the entire document, we should base our classification on the rootSchema
-        this.cfc.joinSchema(classifications, schemaContext.rootSchema);
+        this.cfc.joinSchema(
+          classifications,
+          selector.schemaContext?.rootSchema ?? false,
+        );
       } else {
         // We're using the "cached" mode, and we don't use schema queries
         setSelector(querySelector, of, the, "_", {});
@@ -574,7 +576,8 @@ export class Replica {
 
     // We provided schema for the top level fact that we selected, but we
     // will have undefined schema for the entries included as links.
-    let fetchedEntries: [Revision<State>, SchemaContext | undefined][] = [];
+    let fetchedEntries: [Revision<State>, SchemaPathSelector | undefined][] =
+      [];
     // Run all our schema queries first
     if (Object.entries(schemaSelector).length > 0) {
       const queryArgs: SchemaQueryArgs = {
@@ -608,7 +611,7 @@ export class Replica {
       }
       fetchedEntries = [...fetchedEntries, ...query.schemaFacts];
     }
-    const fetched = fetchedEntries.map(([fact, _schema]) => fact);
+    const fetched = fetchedEntries.map(([fact, _selector]) => fact);
     const changes = Differential.create().update(this, fetched);
     this.heap.merge(fetched, Replica.put);
 
@@ -619,7 +622,7 @@ export class Replica {
     const notFound = [];
     const revisions = new Map<FactAddress, Revision<State>>();
     if (fetched.length < entries.length) {
-      for (const [entry, _schema] of entries) {
+      for (const [entry, _selector] of entries) {
         if (!this.get(entry)) {
           // Note we use `-1` as `since` timestamp so that any change will appear greater.
           const revision = { ...unclaimed(entry), since: -1 };
@@ -629,7 +632,7 @@ export class Replica {
       }
     }
 
-    for (const [revision, schema] of fetchedEntries) {
+    for (const [revision, _selector] of fetchedEntries) {
       const factAddress = { the: revision.the, of: revision.of };
       revisions.set(factAddress, revision);
     }
@@ -650,12 +653,9 @@ export class Replica {
 
     const result = await this.cache.merge(revisions.values(), Replica.put);
 
-    for (const [revision, schema] of fetchedEntries) {
+    for (const [revision, selector] of fetchedEntries) {
       const factAddress = { the: revision.the, of: revision.of };
-      this.selectorTracker.add(factAddress, {
-        path: [],
-        schemaContext: schema,
-      }, Promise.resolve(result));
+      this.selectorTracker.add(factAddress, selector, Promise.resolve(result));
     }
 
     if (result.error) {
@@ -671,7 +671,7 @@ export class Replica {
    * be fetched from the remote.
    */
   async load(
-    entries: [FactAddress, SchemaContext?][],
+    entries: [FactAddress, SchemaPathSelector?][],
   ): Promise<
     Result<
       Selection<FactAddress, Revision<State>>,
@@ -679,12 +679,11 @@ export class Replica {
     >
   > {
     // First we identify entries that we need to load from the store.
-    const need: [FactAddress, SchemaContext?][] = [];
-    for (const [address, schema] of entries) {
+    const need: [FactAddress, SchemaPathSelector?][] = [];
+    for (const [address, selector] of entries) {
       if (!this.get(address)) {
-        need.push([address, schema]);
-      } else if (schema !== undefined) {
-        const selector = { path: [], schemaContext: schema };
+        need.push([address, selector]);
+      } else if (selector !== undefined) {
         // Even though we have our root doc in local store, we may need
         // to re-issue our query, since our cached copy may have been run with a
         // different schema, and thus have different linked documents.
@@ -693,7 +692,7 @@ export class Replica {
           // server for this selector, we don't need to send a new one
           // (revisit this when we allow unsubscribe)
           // Otherwise, add it to the set of things we need
-          need.push([address, schema]);
+          need.push([address, selector]);
         }
       }
     }
@@ -713,8 +712,8 @@ export class Replica {
     // We only do this for entries without a schema, since we'll want the server
     // to track our subscription for the entries with a schema.
     const schemaless = need
-      .filter(([_addr, schema]) => schema === undefined)
-      .map(([addr, _schema]) => addr);
+      .filter(([_addr, selector]) => selector === undefined)
+      .map(([addr, _selector]) => addr);
     const { ok: pulled, error } = await this.cache.pull(schemaless);
 
     if (error) {
@@ -742,7 +741,9 @@ export class Replica {
       // Otherwise we are able to complete checkout and we schedule a pull in
       // the background so we can get latest entries if there are some available.
       else {
-        const simple = need.filter(([_addr, schema]) => schema === undefined);
+        const simple = need.filter(([_addr, selector]) =>
+          selector === undefined
+        );
         // schedule an update for any entries without a schema.
         this.queue.add(simple);
         this.sync();
@@ -777,11 +778,20 @@ export class Replica {
       PushError
     >
   > {
+    // Generate the selectors for the various change objects
+    const loadArgs: [(Assert | Retract | Claim), SchemaPathSelector?][] =
+      changes.map((
+        change,
+      ) => {
+        const schema = generateSchemaFromLabels(change);
+        const selector = schema === undefined
+          ? undefined
+          : { path: [], schemaContext: { schema: schema, rootSchema: schema } };
+        return [change, selector];
+      });
     // First we pull all the affected entries into heap so we can build a
     // transaction that is aware of latest state.
-    const { error } = await this.load(
-      changes.map((change) => [change, getSchema(change)]),
-    );
+    const { error } = await this.load(loadArgs);
     if (error) {
       return { error };
     } else {
@@ -1334,12 +1344,8 @@ class ProviderConnection implements IStorageProvider {
     return this.provider.sink(uri, callback);
   }
 
-  sync(
-    uri: URI,
-    expectedInStorage?: boolean,
-    schemaContext?: SchemaContext,
-  ) {
-    return this.provider.sync(uri, expectedInStorage, schemaContext);
+  sync(uri: URI, selector?: SchemaPathSelector) {
+    return this.provider.sync(uri, selector);
   }
 
   synced() {
@@ -1459,13 +1465,11 @@ export class Provider implements IStorageProvider {
 
   sync(
     uri: URI,
-    expectedInStorage?: boolean,
-    schemaContext?: SchemaContext,
+    selector?: SchemaPathSelector,
   ) {
     const { the } = this;
     const factAddress = { the, of: uri };
-    if (schemaContext) {
-      const selector = { path: [], schemaContext: schemaContext };
+    if (selector) {
       // We track this server subscription, and don't re-issue it --
       // we will instead return the existing promise, so we can wait until
       // we have the response.
@@ -1476,7 +1480,7 @@ export class Provider implements IStorageProvider {
       if (existingPromise) {
         return existingPromise;
       }
-      const promise = this.workspace.load([[factAddress, schemaContext]]);
+      const promise = this.workspace.load([[factAddress, selector]]);
       this.serverSubscriptions.add(factAddress, selector, promise);
       return promise;
     } else {
@@ -1581,7 +1585,7 @@ export class Provider implements IStorageProvider {
     this.workspace.reset();
 
     // Re-establish subscriptions
-    const need: [FactAddress, SchemaContext?][] = [];
+    const need: [FactAddress, SchemaPathSelector?][] = [];
 
     // Always include the space commit object to ensure proper query context
     const spaceCommitAddress: FactAddress = {
@@ -1592,7 +1596,7 @@ export class Provider implements IStorageProvider {
 
     // Add all tracked subscriptions
     for (const { factAddress, selector } of subscriptions) {
-      need.push([factAddress, selector.schemaContext]);
+      need.push([factAddress, selector]);
     }
 
     try {
@@ -1745,12 +1749,11 @@ export const getChanges = (
 };
 
 // Given an Assert statement with labels, return a SchemaContext with the ifc tags
-const getSchema = (
+const generateSchemaFromLabels = (
   change: Assert | Retract | Claim,
-): SchemaContext | undefined => {
+): JSONSchema | undefined => {
   if (isObject(change?.is) && "labels" in change.is) {
-    const schema = { ifc: change.is.labels } as JSONSchema;
-    return { schema: schema, rootSchema: schema };
+    return { ifc: change.is.labels } as JSONSchema;
   }
   return undefined;
 };

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -13,7 +13,7 @@ import type {
   QueryError as IQueryError,
   Result,
   Retraction,
-  SchemaContext,
+  SchemaPathSelector,
   Signer,
   State,
   The as MediaType,
@@ -31,7 +31,7 @@ export type {
   MediaType,
   MemorySpace,
   Result,
-  SchemaContext,
+  SchemaPathSelector,
   State,
   Unit,
   URI,
@@ -135,15 +135,12 @@ export interface IStorageProvider {
    * Sync a value from storage. Use `get()` to retrieve the value.
    *
    * @param uri - uri of the entity to sync.
-   * @param expectedInStorage - Wait for the value, it's assumed to be in
-   *   storage eventually.
-   * @param schemaContext - The schemaContext that determines what to sync.
+   * @param selector - The SchemaPathSelector with the path and schemaContext that determines what to sync.
    * @returns Promise that resolves when the value is synced.
    */
   sync(
     uri: URI,
-    expectedInStorage?: boolean,
-    schemaContext?: SchemaContext,
+    selector?: SchemaPathSelector,
   ): Promise<Result<Unit, Error>>;
 
   /**

--- a/packages/runner/test/provider-reconnection.test.ts
+++ b/packages/runner/test/provider-reconnection.test.ts
@@ -44,18 +44,20 @@ describe("Provider Reconnection", () => {
           properties: { name: { type: "string" } },
         },
       };
+      const selector1 = { path: [], schemaContext: schema1 };
 
       const schema2: SchemaContext = {
         schema: { type: "object", properties: { age: { type: "number" } } },
         rootSchema: { type: "object", properties: { age: { type: "number" } } },
       };
+      const selector2 = { path: [], schemaContext: schema2 };
 
       const uri1: URI = "of:user-1";
       const uri2: URI = "of:user-2";
 
       // Initial sync to establish subscriptions
-      await provider.sync(uri1, true, schema1);
-      await provider.sync(uri2, true, schema2);
+      await provider.sync(uri1, selector1);
+      await provider.sync(uri2, selector2);
 
       // Override the workspace's pull function to track calls
       const pullCalls: Array<[any, any?][]> = [];
@@ -89,14 +91,14 @@ describe("Provider Reconnection", () => {
         ([addr]) => addr.of === "of:user-1" && addr.the === "application/json",
       );
       expect(user1Entry).toBeDefined();
-      expect(user1Entry![1]).toEqual(schema1);
+      expect(user1Entry![1]).toEqual(selector1);
 
       // Check user-2 subscription
       const user2Entry = pullEntries.find(
         ([addr]) => addr.of === "of:user-2" && addr.the === "application/json",
       );
       expect(user2Entry).toBeDefined();
-      expect(user2Entry![1]).toEqual(schema2);
+      expect(user2Entry![1]).toEqual(selector2);
     });
 
     it("should handle pull failures gracefully", async () => {
@@ -105,8 +107,11 @@ describe("Provider Reconnection", () => {
         rootSchema: { type: "object" },
       };
 
-      await provider.sync("of:good-entity", true, schema);
-      await provider.sync("of:bad-entity", true, schema);
+      await provider.sync("of:good-entity", {
+        path: [],
+        schemaContext: schema,
+      });
+      await provider.sync("of:bad-entity", { path: [], schemaContext: schema });
 
       // Make pull fail
       const originalPull = provider.workspace.pull.bind(provider.workspace);

--- a/packages/runner/test/push-conflict.test.ts
+++ b/packages/runner/test/push-conflict.test.ts
@@ -89,7 +89,7 @@ describe.skip("Push conflict", () => {
     });
 
     // Update memory without notifying main storage
-    await memory.sync(listURI, true); // Get current value
+    await memory.sync(listURI); // Get current value
     expect(memory.get(listURI)).toEqual({ value: [] });
 
     await memory.send([{ uri: listURI, value: { value: [1, 2, 3] } }]);
@@ -153,8 +153,8 @@ describe.skip("Push conflict", () => {
     const nameURI = name.getAsNormalizedFullLink().id;
     const listURI = list.getAsNormalizedFullLink().id;
     // Update memory without notifying main storage
-    await memory.sync(nameURI, true); // Get current value
-    await memory.sync(listURI, true); // Get current value
+    await memory.sync(nameURI); // Get current value
+    await memory.sync(listURI); // Get current value
     await memory.send<any>([
       { uri: nameURI, value: { value: "foo" } },
       { uri: listURI, value: { value: [1, 2, 3] } },
@@ -220,8 +220,8 @@ describe.skip("Push conflict", () => {
     const nameURI = name.getAsNormalizedFullLink().id;
     const listURI = list.getAsNormalizedFullLink().id;
     // Update memory without notifying main storage
-    await memory.sync(nameURI, true); // Get current value
-    await memory.sync(listURI, true); // Get current value
+    await memory.sync(nameURI); // Get current value
+    await memory.sync(listURI); // Get current value
     await memory.send<any>([
       { uri: nameURI, value: { value: "foo" } },
       { uri: listURI, value: { value: [{ n: 1 }, { n: 2 }, { n: 3 }] } },

--- a/packages/runner/test/storage.test.ts
+++ b/packages/runner/test/storage.test.ts
@@ -154,7 +154,7 @@ describe("Storage", () => {
       let synced = false;
 
       const testCellURI = testCell.getAsNormalizedFullLink().id;
-      storageManager.open(space).sync(testCellURI, true).then(
+      storageManager.open(space).sync(testCellURI).then(
         () => (synced = true),
       );
       expect(synced).toBe(false);
@@ -167,7 +167,7 @@ describe("Storage", () => {
     it("should wait for a undefined doc to appear", async () => {
       let synced = false;
       const testCellURI = testCell.getAsNormalizedFullLink().id;
-      storageManager.open(space).sync(testCellURI, true).then(
+      storageManager.open(space).sync(testCellURI).then(
         () => (synced = true),
       );
       expect(synced).toBe(false);
@@ -178,13 +178,16 @@ describe("Storage", () => {
 
     it("should wait for a undefined doc to appear with schema and double sync", async () => {
       let synced = false;
-      const schemaContext = { schema: true, rootSchema: true };
+      const selector = {
+        path: [],
+        schemaContext: { schema: true, rootSchema: true },
+      };
       const testCellURI = testCell.getAsNormalizedFullLink().id;
-      storageManager.open(space).sync(testCellURI, true, schemaContext)
+      storageManager.open(space).sync(testCellURI, selector)
         .then(
           () => (synced = true),
         );
-      storageManager.open(space).sync(testCellURI, true, schemaContext)
+      storageManager.open(space).sync(testCellURI, selector)
         .then(
           () => (synced = true),
         );


### PR DESCRIPTION
- Removed the expectedInStorage and schemaContext arguments to StorageProvider.sync, since the former was unused and the latter is replaced by selector.
- Changed the structures that tracked the SchemaContext in cache to use SchemaPathSelectors instead.
- Renamed Replia.getSchema to generateSchemaFromLabels to better indicate the function's purpose.
- Updated curl to new api that takes URI instead of EntityId.