### PR TITLE
refactor(runner): convert array_push test to use type-safe handlers

### DIFF
--- a/packages/runner/integration/array_push.test.tsx
+++ b/packages/runner/integration/array_push.test.tsx
@@ -95,12 +95,14 @@ export default recipe(
           <p>Array length: {derive(my_numbers_array, (arr) => arr.length)}</p>
           <p>
             <ul>
-              Current values: {my_numbers_array.map((e) => <li>{e}</li>)}
+              Current values:{" "}
+              {my_numbers_array.map((e, i) => <li key={i}>{e}</li>)}
             </ul>
           </p>
           <p>
             <ul>
-              Current values: {my_objects_array.map((e) => <li>{e.count}</li>)}
+              Current values:{" "}
+              {my_objects_array.map((e, i) => <li key={i}>{e.count}</li>)}
             </ul>
           </p>
         </div>


### PR DESCRIPTION
- Replace proxy-based handlers with typed handler signatures
- Add test coverage for both primitive (number) and object arrays
- Add explicit ID field to objects to ensure proper tracking
- Update UI to display both array types separately

This change aligns with the codebase direction of avoiding proxy usage and ensuring type safety throughout the handler system.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Refactored the array_push test to use type-safe handler signatures instead of proxies, added coverage for both number and object arrays, and updated the UI to show both array types.

- **Refactors**
  - Replaced proxy handlers with typed handlers for better type safety.
  - Added explicit ID field to objects for tracking.
  - Updated test and UI to handle and display both numbers and objects in arrays.

<!-- End of auto-generated description by cubic. -->

