### PR TITLE
fix: resolve array elements to nested documents instead of array indices

### DIFF
--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -147,6 +147,11 @@ export function resolveLink(
 
   const result = { ...last, path: traversedPath } satisfies NormalizedFullLink;
 
+  // Remove overwrite field, i.e. when the last followed link was a write
+  // redirect. The idea is that this is a link pointing to the final value, it
+  // doesn't matter how we got there.
+  delete result.overwrite;
+
   // The casting is a workaround for the branding, we don't actually want to add
   // the symbol to the result.
   return result as unknown as ResolvedFullLink;

--- a/recipes/todo-list.tsx
+++ b/recipes/todo-list.tsx
@@ -55,7 +55,7 @@ const updateItem = handler<
 
 const deleteItem = handler<never, { items: Cell<TodoItem[]>; item: TodoItem }>(
   (_, { item, items }) => {
-    const data = items.get();
+    const data = [...items.get()];
     const idx = data.findIndex((i) => i.title === item.title);
     if (idx !== -1) {
       data.splice(idx, 1);


### PR DESCRIPTION
When arrays contain nested documents (objects with [ID] property), array elements now resolve to the actual nested document links rather than array index paths. This fixes array splice operations that were failing because elements were incorrectly resolving to array positions.

- Modified link resolution to follow nested document links in arrays
- Removed overwrite field from resolved links for cleaner references
- Updated todo-list recipe to use spread operator for proper array copying
- Added comprehensive tests for array element link resolution
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Array elements that are nested documents (with [ID]) now resolve to their own document links instead of array index paths. This fixes issues with array operations like splice, so items are tracked by their identity, not position.

- **Bug Fixes**
  - Link resolution in arrays now follows nested document links, not array indices.
  - Removed the overwrite field from resolved links for cleaner references.
  - Updated todo-list recipe to use array spread for correct copying.
  - Added tests to cover array element link resolution.

<!-- End of auto-generated description by cubic. -->

