### PR TITLE
chore: Unify integration test usage

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -371,14 +371,14 @@ jobs:
       - name: 🧪 Run end-to-end jumble integration tests
         working-directory: packages/jumble
         run: |
-          TOOLSHED_API_URL=http://localhost:8000/ \
-          FRONTEND_URL=http://localhost:8000/ \
+          HEADLESS=1 \
+          API_URL=http://localhost:8000/ \
           deno task integration
 
       - name: 🧪 Run end-to-end runner integration tests
         working-directory: packages/runner
         run: |
-          TOOLSHED_API_URL=http://localhost:8000/ \
+          API_URL=http://localhost:8000/ \
           deno task integration
 
   cli-integration-test:
@@ -418,45 +418,7 @@ jobs:
       - name: 🧪 Run CLI integration tests
         working-directory: packages/cli
         run: |
-          ./integration/integration.sh http://localhost:8000
-
-  seeder-integration-test:
-    name: "Seeder Integration Tests"
-    runs-on: ubuntu-latest
-    needs: ["build-binaries"]
-    environment: ci
-    services:
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
-
-      - name: 🦕 Setup Deno
-        uses: ./.github/actions/deno-setup
-
-      - name: 📥 Download built binaries
-        uses: actions/download-artifact@v4
-
-      - name: 🚀 Start Toolshed server for testing
-        run: |
-          chmod +x ./common-binaries/toolshed
-          CTTS_AI_LLM_ANTHROPIC_API_KEY=fake \
-          CACHE_DIR=${GITHUB_WORKSPACE}/packages/jumble/integration/cache \
-          ./common-binaries/toolshed &
-
-      - name: 🧪 Run seeder integration tests
-        working-directory: packages/seeder
-        run: |
-          TOOLSHED_API_URL=http://localhost:8000/ \
-          deno task start --tag smol --no-verify --no-report --name ${{ github.run_id }}
+          API_URL=http://localhost:8000 ./integration/integration.sh
 
   shell-integration-test:
     name: "Shell Integration Tests"
@@ -509,7 +471,6 @@ jobs:
     needs: [
       "integration-test",
       "cli-integration-test",
-      "seeder-integration-test",
       "shell-integration-test",
     ]
     runs-on: ubuntu-latest

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -19,10 +19,9 @@ if [ -n "$CT_CLI_INTEGRATION_USE_LOCAL" ]; then
  }
 fi
 
-if [ "$#" -eq 0 ]; then
-  error "Missing required argument: API_URL"
+if [ -z "$API_URL" ]; then
+  error "API_URL must be defined."
 fi
-API_URL="$1"
 SPACE=$(mktemp -u XXXXXXXXXX) # generates a random space
 IDENTITY=$(mktemp)
 SPACE_ARGS="--api-url=$API_URL --identity=$IDENTITY --space=$SPACE"

--- a/packages/integration/browser.ts
+++ b/packages/integration/browser.ts
@@ -7,6 +7,8 @@ import {
 } from "@astral/astral";
 import { Page } from "./page.ts";
 
+const DEFAULT_ASTRAL_TIMEOUT = 60_000;
+
 // Wrapper around `@astral/astral`'s `Browser`.
 export class Browser {
   private browser: AstralBrowser | null;
@@ -25,7 +27,7 @@ export class Browser {
   ): Promise<Browser> {
     const headless = config?.headless ?? true;
     const args = config?.args ?? [];
-    const timeout = config?.timeout ?? 10_000;
+    const timeout = config?.timeout ?? DEFAULT_ASTRAL_TIMEOUT;
 
     const browser = await launch({
       args,

--- a/packages/integration/env.ts
+++ b/packages/integration/env.ts
@@ -1,0 +1,22 @@
+// Server URL. Defaults to `http://localhost:8000`
+export const API_URL = ensureTrailing(
+  Deno.env.get("API_URL") ?? "http://localhost:8000",
+);
+
+// Frontend URL. Defaults to `API_URL`.
+// Only needs to differ from `API_URL` when running
+// integration tests via a dev shell build
+// e.g. `http://localhost:5173`.
+export const FRONTEND_URL = ensureTrailing(
+  Deno.env.get("FRONTEND_URL") ?? API_URL,
+);
+
+export const HEADLESS = envToBool(Deno.env.get("HEADLESS"));
+
+function ensureTrailing(value: string): string {
+  return value.substr(-1) === "/" ? value : `${value}/`;
+}
+
+function envToBool(value?: string): boolean {
+  return value ? (value === "true" || value === "1") : false;
+}

--- a/packages/integration/index.ts
+++ b/packages/integration/index.ts
@@ -1,2 +1,3 @@
 export { Browser } from "./browser.ts";
 export { dismissDialogs, Page, pipeConsole } from "./page.ts";
+export * as env from "./env.ts";

--- a/packages/jumble/integration/basic-flow.test.ts
+++ b/packages/jumble/integration/basic-flow.test.ts
@@ -2,6 +2,7 @@ import { PageErrorEvent } from "@astral/astral";
 import {
   Browser,
   dismissDialogs,
+  env,
   Page,
   pipeConsole,
 } from "@commontools/integration";
@@ -14,11 +15,7 @@ import { sleep } from "@commontools/utils/sleep";
 import { decode } from "@commontools/utils/encoding";
 
 const TAKE_SNAPSHOTS = false;
-const TOOLSHED_API_URL = Deno.env.get("TOOLSHED_API_URL") ??
-  "http://localhost:8000/";
-const FRONTEND_URL = Deno.env.get("FRONTEND_URL") ?? "http://localhost:5173/";
-const HEADLESS = !Deno.env.get("RUN_IN_BROWSER");
-const ASTRAL_TIMEOUT = 60_000;
+const { API_URL, FRONTEND_URL, HEADLESS } = env;
 const RECIPE_PATH = "../../recipes/simpleValue.tsx";
 const COMMON_CLI_PATH = path.join(
   import.meta.dirname!,
@@ -26,7 +23,7 @@ const COMMON_CLI_PATH = path.join(
 );
 const SNAPSHOTS_DIR = join(Deno.cwd(), "test_snapshots");
 
-console.log(`TOOLSHED_API_URL=${TOOLSHED_API_URL}`);
+console.log(`API_URL=${API_URL}`);
 console.log(`FRONTEND_URL=${FRONTEND_URL}`);
 
 let browser: Browser | void = undefined;
@@ -44,7 +41,7 @@ Deno.test({
         name: "add charm via cli",
         ignore: failed || exceptions.length > 0,
         fn: async () => {
-          testCharm = await addCharm(TOOLSHED_API_URL, RECIPE_PATH);
+          testCharm = await addCharm(API_URL, RECIPE_PATH);
           console.log(`Charm added`, testCharm);
         },
       });
@@ -54,7 +51,6 @@ Deno.test({
         ignore: failed || exceptions.length > 0,
         fn: async () => {
           browser = await Browser.launch({
-            timeout: ASTRAL_TIMEOUT,
             headless: HEADLESS,
           });
 
@@ -185,7 +181,7 @@ Deno.test({
             "Inspecting charm to verify updates propagated from browser.",
           );
           const charm = await inspectCharm(
-            TOOLSHED_API_URL,
+            API_URL,
             testCharm.name,
             testCharm.charmId,
           );

--- a/packages/runner/integration/array_push.test.ts
+++ b/packages/runner/integration/array_push.test.ts
@@ -13,6 +13,7 @@ import {
   Identity,
   Session,
 } from "@commontools/identity";
+import { env } from "@commontools/integration";
 import { StorageManager } from "../src/storage/cache.ts";
 import { getEntityId, type JSONSchema, Runtime } from "../src/index.ts";
 import { createBuilder } from "../src/builder/factory.ts";
@@ -20,10 +21,9 @@ import { CharmManager, compileRecipe } from "@commontools/charm";
 
 (Error as any).stackTraceLimit = 100;
 
-const TOOLSHED_URL = Deno.env.get("TOOLSHED_API_URL") ||
-  "http://localhost:8000";
+const { API_URL } = env;
 const MEMORY_WS_URL = `${
-  TOOLSHED_URL.replace("http://", "ws://")
+  API_URL.replace("http://", "ws://")
 }/api/storage/memory`;
 const SPACE_NAME = "runner_integration";
 
@@ -32,7 +32,7 @@ const TIMEOUT_MS = 30000; // timeout for the test in ms
 
 console.log("Array Push Test");
 console.log(`Connecting to: ${MEMORY_WS_URL}`);
-console.log(`Toolshed URL: ${TOOLSHED_URL}`);
+console.log(`API URL: ${API_URL}`);
 
 // Set up timeout
 const timeoutPromise = new Promise((_, reject) => {
@@ -56,12 +56,12 @@ async function runTest() {
   // Create storage manager
   const storageManager = StorageManager.open({
     as: session.as,
-    address: new URL("/api/storage/memory", TOOLSHED_URL),
+    address: new URL("/api/storage/memory", API_URL),
   });
 
   // Create runtime
   const runtime = new Runtime({
-    blobbyServerUrl: TOOLSHED_URL,
+    blobbyServerUrl: API_URL,
     storageManager,
   });
 

--- a/packages/runner/integration/basic-persistence.test.ts
+++ b/packages/runner/integration/basic-persistence.test.ts
@@ -4,6 +4,8 @@ import { deepEqual, Runtime } from "@commontools/runner";
 import { Identity, IdentityCreateConfig } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 import { type JSONSchema } from "@commontools/runner";
+import { env } from "@commontools/integration";
+const { API_URL } = env;
 
 // Create test identity
 const keyConfig: IdentityCreateConfig = {
@@ -12,17 +14,15 @@ const keyConfig: IdentityCreateConfig = {
 const identity = await Identity.fromPassphrase("test operator", keyConfig);
 
 console.log("\n=== TEST: Simple object persistence ===");
-const TOOLSHED_API_URL = Deno.env.get("TOOLSHED_API_URL") ??
-  "http://localhost:8000/";
 
 async function test() {
   // First runtime - save data
   const runtime1 = new Runtime({
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", TOOLSHED_API_URL),
+      address: new URL("/api/storage/memory", API_URL),
     }),
-    blobbyServerUrl: "http://localhost:8000",
+    blobbyServerUrl: API_URL,
   });
 
   const schema = {
@@ -51,9 +51,9 @@ async function test() {
   const runtime2 = new Runtime({
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", TOOLSHED_API_URL),
+      address: new URL("/api/storage/memory", API_URL),
     }),
-    blobbyServerUrl: "http://localhost:8000",
+    blobbyServerUrl: API_URL,
   });
 
   const cell2 = runtime2.getCell(identity.did(), cause, schema);

--- a/packages/runner/integration/pending-nursery.test.ts
+++ b/packages/runner/integration/pending-nursery.test.ts
@@ -6,6 +6,8 @@ import { Identity, IdentityCreateConfig } from "@commontools/identity";
 import { Provider, StorageManager } from "@commontools/runner/storage/cache";
 import { type JSONSchema } from "@commontools/runner";
 import { toURI } from "../src/uri-utils.ts";
+import { env } from "@commontools/integration";
+const { API_URL } = env;
 
 // Create test identity
 const keyConfig: IdentityCreateConfig = {
@@ -14,17 +16,15 @@ const keyConfig: IdentityCreateConfig = {
 const identity = await Identity.fromPassphrase("test operator", keyConfig);
 
 console.log("\n=== TEST: Simple object persistence ===");
-const TOOLSHED_API_URL = Deno.env.get("TOOLSHED_API_URL") ??
-  "http://localhost:8000/";
 
 async function test() {
   // First runtime - save data
   const runtime1 = new Runtime({
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", TOOLSHED_API_URL),
+      address: new URL("/api/storage/memory", API_URL),
     }),
-    blobbyServerUrl: "http://localhost:8000",
+    blobbyServerUrl: API_URL,
   });
   const provider1: Provider =
     (runtime1.storageManager.open(identity.did()) as any).provider;
@@ -62,9 +62,9 @@ async function test() {
   const runtime2 = new Runtime({
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", TOOLSHED_API_URL),
+      address: new URL("/api/storage/memory", API_URL),
     }),
-    blobbyServerUrl: "http://localhost:8000",
+    blobbyServerUrl: API_URL,
   });
 
   const provider2: Provider =

--- a/packages/runner/integration/reconnection.test.ts
+++ b/packages/runner/integration/reconnection.test.ts
@@ -8,11 +8,11 @@
 import { Identity } from "@commontools/identity";
 import { StorageManager } from "../src/storage/cache.ts";
 import type { SchemaContext, URI } from "@commontools/memory/interface";
+import { env } from "@commontools/integration";
+const { API_URL } = env;
 
-const TOOLSHED_URL = Deno.env.get("TOOLSHED_API_URL") ||
-  "http://localhost:8000";
 const MEMORY_WS_URL = `${
-  TOOLSHED_URL.replace("http://", "ws://")
+  API_URL.replace("http://", "ws://")
 }/api/storage/memory`;
 const TEST_DOC_ID = "test-reconnection-counter";
 

--- a/packages/runner/integration/sync-schema-path.test.ts
+++ b/packages/runner/integration/sync-schema-path.test.ts
@@ -6,6 +6,8 @@ import { Identity, type IdentityCreateConfig } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 import type { JSONSchema } from "@commontools/runner";
 import { parseLink } from "../src/link-utils.ts";
+import { env } from "@commontools/integration";
+const { API_URL } = env;
 
 // Create test identity
 const keyConfig: IdentityCreateConfig = {
@@ -14,17 +16,15 @@ const keyConfig: IdentityCreateConfig = {
 const identity = await Identity.fromPassphrase("test operator", keyConfig);
 
 console.log("\n=== TEST: Sync Schema uses Path ===");
-const TOOLSHED_API_URL = Deno.env.get("TOOLSHED_API_URL") ??
-  "http://localhost:8000/";
 
 async function test() {
   // First runtime - save data
   const runtime1 = new Runtime({
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", TOOLSHED_API_URL),
+      address: new URL("/api/storage/memory", API_URL),
     }),
-    blobbyServerUrl: "http://localhost:8000",
+    blobbyServerUrl: API_URL,
   });
   const addressSchema = {
     type: "object",
@@ -94,9 +94,9 @@ async function test() {
   const runtime2 = new Runtime({
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", TOOLSHED_API_URL),
+      address: new URL("/api/storage/memory", API_URL),
     }),
-    blobbyServerUrl: "http://localhost:8000",
+    blobbyServerUrl: API_URL,
   });
 
   // When we build a cell from a cell link, we don't do the right thing with

--- a/packages/shell/integration/charm.test.ts
+++ b/packages/shell/integration/charm.test.ts
@@ -1,58 +1,25 @@
-import { PageErrorEvent } from "@astral/astral";
-import {
-  Browser,
-  dismissDialogs,
-  Page,
-  pipeConsole,
-} from "@commontools/integration";
-import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
-import { assert, assertObjectMatch } from "@std/assert";
-import { Identity } from "@commontools/identity";
-import { login, registerCharm } from "./utils.ts";
-import { join } from "@std/path";
-import "../src/globals.ts";
+import { env } from "@commontools/integration";
 import { sleep } from "@commontools/utils/sleep";
+import { registerCharm, ShellIntegration } from "./utils.ts";
+import { describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import { assert, assertEquals } from "@std/assert";
+import "../src/globals.ts";
 
-const API_URL = (() => {
-  const url = Deno.env.get("API_URL") ?? "http://localhost:8000";
-  return url.substr(-1) === "/" ? url : `${url}/`;
-})();
-const HEADLESS = !!Deno.env.get("HEADLESS");
-const ASTRAL_TIMEOUT = 60_000;
+const { API_URL, FRONTEND_URL } = env;
 
 describe("shell charm tests", () => {
-  let browser: Browser | undefined;
-  let page: Page | undefined;
-  let identity: Identity | undefined;
-  const exceptions: string[] = [];
-
-  beforeAll(async () => {
-    browser = await Browser.launch({
-      timeout: ASTRAL_TIMEOUT,
-      headless: HEADLESS,
-    });
-    page = await browser.newPage();
-    page.addEventListener("console", pipeConsole);
-    page.addEventListener("dialog", dismissDialogs);
-    page.addEventListener("pageerror", (e: PageErrorEvent) => {
-      console.error("Browser Page Error:", e.detail.message);
-      exceptions.push(e.detail.message);
-    });
-    identity = await Identity.generate({ implementation: "noble" });
-  });
-
-  afterAll(async () => {
-    await page?.close();
-    await browser?.close();
-  });
+  const shell = new ShellIntegration();
+  shell.bindLifecycle();
 
   it("can view and interact with a charm", async () => {
+    const { page, identity } = shell.get();
     const spaceName = globalThis.crypto.randomUUID();
 
     const charmId = await registerCharm({
       spaceName: spaceName,
       apiUrl: new URL(API_URL),
-      identity: identity!,
+      identity: identity,
       source: await Deno.readTextFile(
         join(
           import.meta.dirname!,
@@ -66,24 +33,19 @@ describe("shell charm tests", () => {
     });
 
     // TODO(js): Remove /shell when no longer prefixed
-    await page!.goto(`${API_URL}shell/${spaceName}/${charmId}`);
-    await page!.applyConsoleFormatter();
+    await page.goto(`${FRONTEND_URL}shell/${spaceName}/${charmId}`);
+    await page.applyConsoleFormatter();
 
-    const state = await login(page!, identity!);
-    assertObjectMatch({
-      apiUrl: state.apiUrl,
-      spaceName: state.spaceName,
-      activeCharmId: state.activeCharmId,
-      privateKey: state.identity?.serialize().privateKey,
-    }, {
-      apiUrl: state.apiUrl,
-      spaceName,
-      activeCharmId: charmId,
-      privateKey: identity!.serialize().privateKey,
-    }, "Expected app state with identity");
+    const state = await shell.login();
+    assertEquals(state.spaceName, spaceName);
+    assertEquals(state.activeCharmId, charmId);
+    assertEquals(
+      state.identity?.serialize().privateKey,
+      identity.serialize().privateKey,
+    );
 
     await sleep(2000);
-    let handle = await page!.$(
+    let handle = await page.$(
       "pierce/ct-button",
     );
     assert(handle);
@@ -91,7 +53,7 @@ describe("shell charm tests", () => {
     await sleep(1000);
     handle.click();
     await sleep(1000);
-    handle = await page!.$(
+    handle = await page.$(
       "pierce/span",
     );
     await sleep(2000);


### PR DESCRIPTION
normalize integration test usage, provide some utilities to normalize env vars used in integration, and initial work on a helper to scaffold shell integration tests.

Integration tests written in typescript should use this pattern for targeting a running server:

```ts
import { env } from "@commontools/integration";
const { API_URL, FRONTEND_URL, HEADLESS } = env;
```

`API_URL` uses `localhost:8000` by default, and `FRONTEND_URL` is identical unless explicitly set, which is only relevant when running a shell local-dev server (e.g. `http://localhost:5173`).

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized integration test setup by unifying environment variable usage, adding shared utilities, and introducing a helper for shell integration test scaffolding.

- **Refactors**
  - Replaced ad-hoc environment variable handling with a shared env utility.
  - Updated test scripts and workflows to use the new API_URL convention.
  - Added a ShellIntegration helper to simplify shell test lifecycle management.

<!-- End of auto-generated description by cubic. -->

