### PR TITLE
fix(runner): return undefined instead of empty object, or an object with empty cells, for invalid input in validateAndTransform

### DIFF
--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -404,7 +404,7 @@ export function validateAndTransform(
   // below we might still create a new Cell and it should point to the top of
   // this set of links.
   const ref = resolveLink(tx ?? runtime.edit(), link);
-  let value = (tx ?? runtime.edit()).readValueOrThrow(ref);
+  const value = (tx ?? runtime.edit()).readValueOrThrow(ref);
 
   // Check for undefined value and return processed default if available
   if (value === undefined && resolvedSchema?.default !== undefined) {


### PR DESCRIPTION
When validateAndTransform receives a non-record value for an object schema and no properties would be populated (no defaults, no asCell/asStream), return undefined instead of creating an empty object. This prevents unnecessary empty objects from being created in the data structure.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
validateAndTransform now returns undefined instead of an empty object when given invalid input for an object schema, preventing unnecessary empty objects in the data.

- **Bug Fixes**
  - Skips creating empty objects when input is not a record and no properties are set.

<!-- End of auto-generated description by cubic. -->

