### PR TITLE
Treat the absence of additionalProperties similarly to false.

### DIFF
--- a/packages/memory/test/space-test.ts
+++ b/packages/memory/test/space-test.ts
@@ -2059,6 +2059,8 @@ test(
     assert(write3.ok);
     const c3 = Commit.toRevision(write3.ok);
 
+    // Check that with object, but no additionalProperties,
+    // we should not include doc2
     const schemaSelector: SchemaSelector = {
       [doc1]: {
         [the]: {
@@ -2091,8 +2093,74 @@ test(
       getResultForDoc(result, space.did(), doc1),
       "doc1 should be in the result",
     );
-    assertExists(
+    assertEquals(
       getResultForDoc(result, space.did(), doc2),
+      undefined,
+      "doc2 should not be in the result",
+    );
+
+    // Check that the `{}` schema does include doc2
+    const result2 = session.querySchema({
+      cmd: "/memory/graph/query",
+      iss: alice.did(),
+      sub: space.did(),
+      args: {
+        selectSchema: {
+          [doc1]: {
+            [the]: {
+              _: {
+                path: [],
+                schemaContext: {
+                  schema: {},
+                  rootSchema: {},
+                },
+              },
+            },
+          },
+        },
+      },
+      prf: [],
+    });
+
+    assertExists(
+      getResultForDoc(result2, space.did(), doc1),
+      "doc1 should be in the result",
+    );
+    assertExists(
+      getResultForDoc(result2, space.did(), doc2),
+      "doc2 should be in the result",
+    );
+
+    // Check that with object, and additionalProperties true,
+    // we should include doc2
+    const result3 = session.querySchema({
+      cmd: "/memory/graph/query",
+      iss: alice.did(),
+      sub: space.did(),
+      args: {
+        selectSchema: {
+          [doc1]: {
+            [the]: {
+              _: {
+                path: [],
+                schemaContext: {
+                  schema: { type: "object", additionalProperties: true },
+                  rootSchema: { type: "object", additionalProperties: true },
+                },
+              },
+            },
+          },
+        },
+      },
+      prf: [],
+    });
+
+    assertExists(
+      getResultForDoc(result3, space.did(), doc1),
+      "doc1 should be in the result",
+    );
+    assertExists(
+      getResultForDoc(result3, space.did(), doc2),
       "doc2 should be in the result",
     );
   },

--- a/packages/runner/test/query.test.ts
+++ b/packages/runner/test/query.test.ts
@@ -196,6 +196,7 @@ describe("Query", () => {
     const schemaContext = {
       schema: {
         "type": "object",
+        "additionalProperties": true,
       } as const satisfies JSONSchema,
       rootSchema: true,
     };


### PR DESCRIPTION
JSONSchema defaults this to true, but we want an intermediate behavior where if it's missing, we don't traverse the property, but we also don't reject the object as invalid.

The `{}` value is still treated as a true schema, and will traverse the property values.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Changed how missing additionalProperties in JSONSchema is handled. Now, if additionalProperties is not set, we skip traversing unknown properties but do not mark the object as invalid.

- **Bug Fixes**
  - Updated schema traversal logic to treat absent additionalProperties as "do not traverse" instead of defaulting to true.
  - Added tests to cover this behavior.

<!-- End of auto-generated description by cubic. -->

