### PR TITLE
chore: Do not create redundant runtimes or getting of charms

### DIFF
--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -2,6 +2,7 @@ import { css, html } from "lit";
 import { property } from "lit/decorators.js";
 import { BaseView } from "./BaseView.ts";
 import { RuntimeInternals } from "../lib/runtime.ts";
+import { CharmController } from "@commontools/charm/ops";
 
 export class XBodyView extends BaseView {
   static override styles = css`
@@ -16,15 +17,15 @@ export class XBodyView extends BaseView {
   rt?: RuntimeInternals;
 
   @property({ attribute: false })
-  activeCharmId?: string;
+  activeCharm?: CharmController;
 
   @property()
   showShellCharmListView = false;
 
   override render() {
     const charmView = html`
-      <x-charm-view .rt="${this.rt}" .charmId="${this
-        .activeCharmId}"></x-charm-view>
+      <x-charm-view .rt="${this.rt}" .charm="${this
+        .activeCharm}"></x-charm-view>
     `;
     const spaceView = html`
       <x-space-view
@@ -33,7 +34,7 @@ export class XBodyView extends BaseView {
         .showShellCharmListView}"
       ></x-space-view>
     `;
-    const view = this.activeCharmId ? charmView : spaceView;
+    const view = this.activeCharm ? charmView : spaceView;
     return html`
       <div>${view}</div>
     `;

--- a/packages/shell/src/views/CharmView.ts
+++ b/packages/shell/src/views/CharmView.ts
@@ -2,7 +2,7 @@ import { css, html } from "lit";
 import { property } from "lit/decorators.js";
 import { BaseView } from "./BaseView.ts";
 import { RuntimeInternals } from "../lib/runtime.ts";
-import { Task } from "@lit/task";
+import { CharmController } from "@commontools/charm/ops";
 
 export class XCharmView extends BaseView {
   static override styles = css`
@@ -15,25 +15,15 @@ export class XCharmView extends BaseView {
   rt?: RuntimeInternals;
 
   @property({ attribute: false })
-  charmId?: string;
-
-  private _charm = new Task(this, {
-    task: async ([charmId, rt]) => {
-      if (!charmId || !rt) {
-        return;
-      }
-      return await rt.cc().get(charmId!);
-    },
-    args: () => [this.charmId, this.rt],
-  });
+  charm?: CharmController;
 
   override render() {
-    if (!this._charm.value) {
+    if (!this.charm) {
       return html`
         <x-spinner></x-spinner>
       `;
     }
-    const cell = this._charm.value.getCell();
+    const cell = this.charm.getCell();
     return html`
       <ct-render .cell="${cell}"></ct-render>
     `;

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -8,6 +8,7 @@ import { styleMap } from "lit/directives/style-map.js";
 import { RuntimeInternals } from "../lib/runtime.ts";
 import { InspectorConflicts, InspectorUpdateEvent } from "../lib/inspector.ts";
 import "../components/Flex.ts";
+import { CharmController } from "@commontools/charm/ops";
 
 type ConnectionStatus =
   | "connecting"
@@ -89,16 +90,6 @@ export class XHeaderView extends BaseView {
     }
   `;
 
-  private _charm = new Task(this, {
-    task: async ([charmId, rt]) => {
-      if (!charmId || !rt) {
-        return;
-      }
-      return await rt.cc().get(charmId!);
-    },
-    args: () => [this.charmId, this.rt],
-  });
-
   @property()
   private keyStore?: KeyStore;
 
@@ -106,7 +97,7 @@ export class XHeaderView extends BaseView {
   private rt?: RuntimeInternals;
 
   @property({ attribute: false })
-  charmId?: string;
+  activeCharm?: CharmController;
 
   @property({ attribute: false })
   spaceName?: string;
@@ -211,8 +202,8 @@ export class XHeaderView extends BaseView {
   };
 
   override render() {
-    const activeCharmName = this._charm.value
-      ? this._charm.value.name()
+    const activeCharmName = this.activeCharm
+      ? this.activeCharm.name()
       : undefined;
     const spaceLink = this.spaceName
       ? html`
@@ -220,11 +211,11 @@ export class XHeaderView extends BaseView {
           .spaceName}</a>
       `
       : null;
-    const charmLink = activeCharmName && this.spaceName && this.charmId
+    const charmLink = activeCharmName && this.spaceName && this.activeCharm
       ? html`
         <a class="charm-link" href="${getNavigationHref(
           this.spaceName,
-          this.charmId,
+          this.activeCharm.id,
         )}">${activeCharmName}</a>
       `
       : null;

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -37,7 +37,7 @@ export class XRootView extends LitElement {
 
   @state()
   // Non-private for typing in `updated()` callback
-  _app = { apiUrl: API_URL, spaceName: "common-knowledge" } as AppState;
+  _app = { apiUrl: API_URL } as AppState;
 
   @property()
   keyStore?: KeyStore;

--- a/packages/shell/src/views/SpaceView.ts
+++ b/packages/shell/src/views/SpaceView.ts
@@ -94,7 +94,7 @@ export class XSpaceView extends BaseView {
         `)
       // TBD if we want to use x-charm or ct-render directly here
       : html`
-        <x-charm-view .charmId="${defaultRecipe.id}" .rt="${this
+        <x-charm-view .charm="${defaultRecipe}" .rt="${this
           .rt}"></x-charm-view>
       `;
 


### PR DESCRIPTION
Do not create a 'default' runtime with default space on initialization. Pass a single instance of CharmController for the active charm, rather than the ID so that the charm is only fetched once.

Addresses:

> something I noticed debugging: charmmanager gets created twice and charmmanager.get is also called twice when opening a charm in the shell
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stopped creating a default runtime on startup and now pass a single CharmController instance for the active charm, so each charm is only fetched once.

- **Refactors**
  - Removed duplicate charm fetching and redundant runtime initialization across views.

<!-- End of auto-generated description by cubic. -->

