### PR TITLE
fix(html): cancel previous DOM element subscriptions on replacement

### DIFF
--- a/packages/html/src/render.ts
+++ b/packages/html/src/render.ts
@@ -127,7 +127,7 @@ const bindChildren = (
         const [childElement, childCancel] = renderNode(childValue);
         newRendered = {
           node: childElement ?? document.createTextNode(""),
-          cancel: childCancel,
+          cancel: childCancel ?? (() => {}),
         };
       } else {
         if (childValue === null || childValue === undefined) {
@@ -145,10 +145,11 @@ const bindChildren = (
       if (currentNode) {
         // Replace the previous DOM node, if any
         currentNode.replaceWith(newRendered.node);
+        keyedChildren.get(key)?.cancel();
         // Update the mapping entry to capture any newly-rendered node.
         keyedChildren.set(key, {
           ...keyedChildren.get(key)!,
-          node: newRendered.node,
+          ...newRendered,
         });
       }
 


### PR DESCRIPTION
- Call cancel() on previous DOM elements when replacing them in keyed children
- Ensure cancel function is always defined (default to noop) to prevent undefined errors
- Properly spread the entire newRendered object when updating keyedChildren map