### PR TITLE
fix: allow source cell IDs to be objects in getSourceCell

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -693,7 +693,7 @@ export class RegularCell<T> implements Cell<T> {
       sourceCellId = toURI(JSON.parse(sourceCellId));
     }
 
-    if (!sourceCellId?.startsWith("of:")) {
+    if (typeof sourceCellId !== "string" || !sourceCellId.startsWith("of:")) {
       throw new Error("Source cell ID must start with 'of:'");
     }
     return createCell(this.runtime, {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -684,13 +684,16 @@ export class RegularCell<T> implements Cell<T> {
     let sourceCellId = this.runtime.readTx(this.tx).readOrThrow(
       { ...this.link, path: ["source"] },
     ) as string | undefined;
-    if (!sourceCellId || typeof sourceCellId !== "string") {
-      return undefined;
-    }
-    if (sourceCellId.startsWith('{"/":')) {
+    if (!sourceCellId) return undefined;
+    if (isRecord(sourceCellId)) {
+      sourceCellId = toURI(sourceCellId);
+    } else if (
+      typeof sourceCellId === "string" && sourceCellId.startsWith('{"/":')
+    ) {
       sourceCellId = toURI(JSON.parse(sourceCellId));
     }
-    if (!sourceCellId.startsWith("of:")) {
+
+    if (!sourceCellId?.startsWith("of:")) {
       throw new Error("Source cell ID must start with 'of:'");
     }
     return createCell(this.runtime, {


### PR DESCRIPTION
- Add support for object-based source cell IDs using isRecord() check
- Convert object IDs to URI format with toURI() helper
- Improve conditional logic for handling different source cell ID formats
- Maintain backward compatibility with string-based source cell IDs
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated getSourceCell to support object-based source cell IDs, converting them to URI format and keeping compatibility with string IDs.

- **Bug Fixes**
 - Handles both object and string source cell IDs safely.
 - Uses optional chaining to prevent errors with null or undefined values.

<!-- End of auto-generated description by cubic. -->

