### PR TITLE
Fix ct-list deletion with readonly arrays [CT-717]

### DIFF
--- a/packages/ui/src/v2/components/ct-list/ct-list.ts
+++ b/packages/ui/src/v2/components/ct-list/ct-list.ts
@@ -369,10 +369,11 @@ export class CTList extends BaseElement {
       return;
     }
 
-    const index = findCellIndex(this.value, itemToRemove);
-    if (index !== -1) {
-      mutateCell(this.value, (cell) => cell.get().splice(index, 1));
-    }
+    // Use filter with .equals() to remove the item
+    mutateCell(this.value, (cell) => {
+      const filtered = cell.get().filter((_, i) => !cell.key(i).equals(itemToRemove));
+      cell.set(filtered);
+    });
 
     this.requestUpdate();
   }


### PR DESCRIPTION
## Summary
- Fixed ct-list deletion error when working with readonly arrays from `Cell.get()`
- Updated `removeItem` method to use filter pattern instead of direct mutation
- Properly uses `Cell.equals()` for cell comparison as specified in the issue

## Problem
Since CT-690 made `Cell.get()` return readonly values, the ct-list deletion pattern using `splice()` was failing with:
```
Cannot assign to read only property '0' of object '[object Array]'
```

## Solution
Changed from:
```typescript
mutateCell(this.value, (cell) => cell.get().splice(index, 1));
```

To:
```typescript
mutateCell(this.value, (cell) => {
  const filtered = cell.get().filter((_, i) => \!cell.key(i).equals(itemToRemove));
  cell.set(filtered);
});
```

## Test Plan
- [x] Type checking passes (`deno task check`)
- [x] All tests pass (`deno task test`)
- [x] The deletion operation now works without throwing readonly errors

Closes CT-717

🤖 Generated with [Claude Code](https://claude.ai/code)