### PR TITLE
Add basic `ct-list` types to `jsx.d.ts` [CT-715]

### DIFF
--- a/packages/static/assets/types/jsx.d.ts
+++ b/packages/static/assets/types/jsx.d.ts
@@ -1,7 +1,23 @@
+type Child = {
+  children: string[];
+};
+
+type Cell<T> = {
+  get(): T,
+  set(value: T): void;
+}
+
 declare global {
   namespace JSX {
     interface IntrinsicElements {
       [elemName: string]: any;
+      "ct-list": {
+              value?: { title: string }[],
+              $value?: Cell<{ title: string }[]>,
+              editable?: boolean,
+              title?: string,
+              onct-remove-item?: (e: { detail: { item: Cell<{ title: string }> } }) => void,
+            } & Child;
     }
   }
 }

--- a/packages/static/assets/types/jsx.d.ts
+++ b/packages/static/assets/types/jsx.d.ts
@@ -16,7 +16,7 @@ declare global {
               $value?: Cell<{ title: string }[]>,
               editable?: boolean,
               title?: string,
-              onct-remove-item?: (e: { detail: { item: Cell<{ title: string }> } }) => void,
+              'onct-remove-item'?: (e: { detail: { item: Cell<{ title: string }> } }) => void,
             } & Child;
     }
   }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added type definitions for the `ct-list` JSX element, including its props and event handler.

- **New Features**
  - Defined `ct-list` props: `value`, `$value`, `editable`, `title`, and `onct-remove-item`.
  - Added supporting `Child` and `Cell` types.

<!-- End of auto-generated description by cubic. -->

