### PR TITLE
chore: Allow specifying additional allowed hosts over CSP

### DIFF
--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -9,6 +9,7 @@ import {
   HealthCheckTimeout,
 } from "./health-check.ts";
 import { sleep } from "@commontools/utils/sleep";
+import createOuterFrame from "./outer-frame.ts";
 
 let FRAME_IDS = 0;
 
@@ -54,28 +55,28 @@ export class CommonIframeSandboxElement extends LitElement {
   }
 
   static override styles = css`
-  :host {
-    display: block;
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-    background-color: #ddd;
-  }
-  #crash-message {
-    width: 50%;
-    margin: 20px auto;
-    display: flex;
-    flex-direction: column;
-    text-align: center;
-  }
-  #crash-message > * {
-    flex: 1; 
-  }
-  #crash-message button {
-    font-size: 20px;
-    background-color: white;
-    border: 1px solid black;
-  }
+    :host {
+      display: block;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background-color: #ddd;
+    }
+    #crash-message {
+      width: 50%;
+      margin: 20px auto;
+      display: flex;
+      flex-direction: column;
+      text-align: center;
+    }
+    #crash-message > * {
+      flex: 1;
+    }
+    #crash-message button {
+      font-size: 20px;
+      background-color: white;
+      border: 1px solid black;
+    }
   `;
 
   // Static id for this component for its lifetime.
@@ -492,18 +493,21 @@ export class CommonIframeSandboxElement extends LitElement {
   override render() {
     if (this.crashed) {
       return html`
-      <div id="crash-message">
-        <div class="message">🤨 Charm crashed! 🤨</div>
-        <button @click=${this.onCrashReload}>Reload</button>
-      </div>
+        <div id="crash-message">
+          <div class="message">🤨 Charm crashed! 🤨</div>
+          <button @click="${this.onCrashReload}">Reload</button>
+        </div>
       `;
     }
+    const additionalAllowedHosts =
+      getIframeContextHandler()?.additionalAllowedHosts() ?? [];
+    const outerFrame = createOuterFrame(additionalAllowedHosts);
     return html`
       <iframe
         ${ref(this.iframeRef)}
         allow="clipboard-write"
         sandbox="allow-scripts allow-pointer-lock allow-popups allow-popups-to-escape-sandbox"
-        .srcdoc=${OuterFrame}
+        .srcdoc="${outerFrame}"
         height="100%"
         width="100%"
         style="border: none;"

--- a/packages/iframe-sandbox/src/context.ts
+++ b/packages/iframe-sandbox/src/context.ts
@@ -4,6 +4,7 @@ import { CommonIframeSandboxElement } from "./common-iframe-sandbox.ts";
 // An `IframeContextHandler` is used by consumers to
 // register how read/writing values from frames are handled.
 export interface IframeContextHandler {
+  additionalAllowedHosts(): string[];
   read(element: CommonIframeSandboxElement, context: any, key: string): any;
   write(
     element: CommonIframeSandboxElement,

--- a/packages/iframe-sandbox/src/csp.ts
+++ b/packages/iframe-sandbox/src/csp.ts
@@ -15,44 +15,47 @@ const FONT_CDNS = [
 // In Chromium browsers, "'self'" selects the top frame origin from
 // null origins. In Firefox this does not apply. Instead, use
 // the top frame origin explicitly.
-export const HOST_ORIGIN =
-  new URL(globalThis?.location?.href || "http://localhost").origin;
-
 // This CSP directive uses 'unsafe-inline' to allow
 // origin-less styles and scripts to be used, defeating
 // many traditional uses of CSP.
-export const CSP = `` +
-  // Disable all fetch directives. Re-enable
-  // each specific fetch directive as needed.
-  `default-src 'none';` +
-  // Scripts: Allow 1P, inline, and CDNs.
-  `script-src ${HOST_ORIGIN} 'unsafe-inline' ${SCRIPT_CDNS.join(" ")};` +
-  // Styles: Allow 1P, inline, Google Fonts.
-  `style-src ${HOST_ORIGIN} 'unsafe-inline' ${STYLE_CDNS.join(" ")};` +
-  // Fonts: Allow 1P, inline.
-  `font-src ${HOST_ORIGIN} 'unsafe-inline' ${FONT_CDNS.join(" ")};` +
-  // Images: Allow 1P, data URIs.
-  `img-src ${HOST_ORIGIN} data:;` +
-  // Disabling until we have a concrete case.
-  `form-action 'none';` +
-  // Disable <base> element
-  `base-uri 'none';` +
-  // Iframes/Workers: Use default (disabled)
-  `child-src 'none';` +
-  // Ping/XHR/Fetch/Sockets: Allow 1P only
-  `connect-src 'self';` +
-  // This is a deprecated/Chrome-only CSP directive.
-  // This blocks `<link rel=`prefetch`>` and
-  // the Chrome-only `<link rel=`prerender`>`.
-  // `default-src` is used correctly as a fallback for
-  // prefetch
-  //`prefetch-src 'none';` +
-  // Fonts: Use default (disabled)
-  //`font-src 'none';` +
-  // Media: Use default (disabled)
-  //`media-src 'none';` +
-  // Manifest: Use default (disabled)
-  //`manifest-src 'none';` +
-  // Object/Embeds: Use default (disabled)
-  //`object-src 'none';` +
-  ``;
+export const createCSP = function (
+  hostOrigin: string,
+  additionalAllowedHosts: string[],
+): string {
+  const origins = [hostOrigin, ...additionalAllowedHosts].join(" ");
+  return "" +
+    // Disable all fetch directives. Re-enable
+    // each specific fetch directive as needed.
+    `default-src 'none';` +
+    // Scripts: Allow 1P, inline, and CDNs.
+    `script-src ${origins} 'unsafe-inline' ${SCRIPT_CDNS.join(" ")};` +
+    // Styles: Allow 1P, inline, Google Fonts.
+    `style-src ${origins} 'unsafe-inline' ${STYLE_CDNS.join(" ")};` +
+    // Fonts: Allow 1P, inline.
+    `font-src ${origins} 'unsafe-inline' ${FONT_CDNS.join(" ")};` +
+    // Images: Allow 1P, data URIs.
+    `img-src ${origins} data:;` +
+    // Disabling until we have a concrete case.
+    `form-action 'none';` +
+    // Disable <base> element
+    `base-uri 'none';` +
+    // Iframes/Workers: Use default (disabled)
+    `child-src 'none';` +
+    // Ping/XHR/Fetch/Sockets: Allow 1P only
+    `connect-src 'self';` +
+    // This is a deprecated/Chrome-only CSP directive.
+    // This blocks `<link rel=`prefetch`>` and
+    // the Chrome-only `<link rel=`prerender`>`.
+    // `default-src` is used correctly as a fallback for
+    // prefetch
+    //`prefetch-src 'none';` +
+    // Fonts: Use default (disabled)
+    //`font-src 'none';` +
+    // Media: Use default (disabled)
+    //`media-src 'none';` +
+    // Manifest: Use default (disabled)
+    //`manifest-src 'none';` +
+    // Object/Embeds: Use default (disabled)
+    //`object-src 'none';` +
+    ``;
+};

--- a/packages/iframe-sandbox/src/outer-frame.ts
+++ b/packages/iframe-sandbox/src/outer-frame.ts
@@ -1,7 +1,12 @@
-import { CSP, HOST_ORIGIN } from "./csp.ts";
+import { createCSP } from "./csp.ts";
 
-export default `
-<!DOCTYPE html>
+export default function createOuterFrame(
+  additionalAllowedHosts: string[],
+): string {
+  const hostOrigin =
+    new URL(globalThis?.location?.href || "http://localhost").origin;
+  const CSP = createCSP(hostOrigin, additionalAllowedHosts);
+  return `<!DOCTYPE html>
 <html>
 <head>
 <meta http-equiv="Content-Security-Policy" content="${CSP}" \/>
@@ -33,7 +38,7 @@ iframe {
   sandbox="allow-popups allow-popups-to-escape-sandbox allow-scripts allow-modals"><\/iframe>
 <script>
 const iframe = document.querySelector("iframe");
-const HOST_ORIGIN = "${HOST_ORIGIN}";
+const HOST_ORIGIN = "${hostOrigin}";
 const HOST_WINDOW = window.parent;
 const INNER_WINDOW = iframe.contentWindow;
 let FRAME_ID = null;
@@ -120,3 +125,4 @@ function toInner(data) {
 <\/html>
 <\/html>
 `;
+}

--- a/packages/iframe-sandbox/test/utils.ts
+++ b/packages/iframe-sandbox/test/utils.ts
@@ -54,6 +54,9 @@ export class ContextShim {
 
 export function setIframeTestHandler() {
   setIframeContextHandler({
+    additionalAllowedHosts(): string[] {
+      return [];
+    },
     read(element, context, key) {
       return context.get(element, key);
     },

--- a/packages/jumble/src/iframe-ctx.ts
+++ b/packages/jumble/src/iframe-ctx.ts
@@ -166,6 +166,9 @@ function setPreviousValue(context: any, key: string, value: any) {
 
 export const setupIframe = (runtime: Runtime) =>
   setIframeContextHandler({
+    additionalAllowedHosts(): string[] {
+      return [];
+    },
     read(_element: CommonIframeSandboxElement, context: any, key: string): any {
       const data = key === "*"
         ? isCell(context) ? context.get() : context


### PR DESCRIPTION
 to allow connections to either the frontend or backend services
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for specifying extra allowed hosts in the iframe sandbox Content Security Policy, so connections can be made to additional frontend or backend services.

- **New Features**
  - Exposed an `additionalAllowedHosts` method in the iframe context handler to add custom origins to the CSP.
  - Updated CSP generation and iframe creation to include these extra hosts.

<!-- End of auto-generated description by cubic. -->

