### PR TITLE
Unify "source" property treatment

### DIFF
--- a/packages/runner/src/doc.ts
+++ b/packages/runner/src/doc.ts
@@ -414,14 +414,21 @@ export function createDoc<T>(
       }
 
       if (runtime.storage.shim) {
+        // EntityId may be in non-json form, so stringify and parse
+        const sourceBefore = sourceCell?.entityId
+          ? JSON.parse(JSON.stringify(sourceCell.entityId))
+          : undefined;
+        const sourceAfter = cell?.entityId
+          ? JSON.parse(JSON.stringify(cell.entityId))
+          : undefined;
         const change: IMemoryChange = {
           address: {
             id: toURI(entityId),
             type: "application/json",
             path: ["source"],
           },
-          before: { source: JSON.stringify(sourceCell?.entityId) },
-          after: { source: JSON.stringify(cell?.entityId) },
+          before: { source: sourceBefore },
+          after: { source: sourceAfter },
         };
 
         const notification: ICommitNotification = {

--- a/packages/runner/src/storage/transaction-shim.ts
+++ b/packages/runner/src/storage/transaction-shim.ts
@@ -341,8 +341,8 @@ class TransactionReader implements ITransactionReader {
       const sourceCell = doc.sourceCell;
       let value: string | undefined = undefined;
       if (sourceCell) {
-        // Convert EntityId to string
-        value = JSON.stringify(sourceCell.entityId);
+        // Convert EntityId to nice form
+        value = JSON.parse(JSON.stringify(sourceCell.entityId));
       }
       const read: Read = {
         address,
@@ -471,6 +471,9 @@ class TransactionWriter extends TransactionReader
       }
       // Value must be a JSON EntityId string
       if (typeof value === "string") {
+        logger.info(
+          () => ["Encountered string source", value, "for", address.id],
+        );
         try {
           value = JSON.parse(value);
         } catch (error) {

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -443,6 +443,12 @@ export function loadSource<K, S>(
   // We also want to include the source cells
   const source = targetObj["source"];
   if (!isObject(source) || !("/" in source) || !isString(source["/"])) {
+    // undefined is strange, but acceptable
+    if (source !== undefined) {
+      logger.warn(
+        () => ["Invalid source link", source, "in", valueEntry.source],
+      );
+    }
     return;
   }
   const of: string = source["/"];

--- a/packages/runner/test/storage-subscription.test.ts
+++ b/packages/runner/test/storage-subscription.test.ts
@@ -529,7 +529,9 @@ describe("Storage Subscription", () => {
       expect([...commit.changes].length).toBeGreaterThanOrEqual(1);
       const change = [...commit.changes][0];
       // The actual value contains the full document where source field has the JSON string
-      expect(change.after).toEqual({ source: JSON.stringify(cell.entityId) });
+      expect(change.after).toEqual({
+        source: JSON.parse(JSON.stringify(cell.entityId)),
+      });
       expect((change.before as any)?.source).toBeUndefined();
     });
   });

--- a/packages/runner/test/storage-transaction-shim.test.ts
+++ b/packages/runner/test/storage-transaction-shim.test.ts
@@ -350,7 +350,9 @@ describe("StorageTransaction", () => {
         path: ["source"],
       });
       expect(readSource.ok).toBeDefined();
-      expect(readSource.ok?.value).toBe(JSON.stringify(getEntityId(doc2Id)));
+      expect(readSource.ok?.value).toEqual(
+        JSON.parse(JSON.stringify(getEntityId(doc2Id))),
+      );
     });
 
     it("should error if path beyond 'source' is used", () => {


### PR DESCRIPTION
When setting the source, always use the `{"/": "baedfoo"}` style link
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized the "source" property to always use the `{"/": "id"}` link format across storage, transactions, and related tests.

- **Refactors**
  - Updated all code paths to serialize and parse the "source" property as an object, not a string.
  - Adjusted tests to expect the new object format.

<!-- End of auto-generated description by cubic. -->

