### PR TITLE
Revert "without CTS, our types allow invalid handler (#1551)"

### DIFF
--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -123,17 +123,8 @@ export function handler<E, T>(
   handler?: (event: E, props: T) => any,
 ): HandlerFactory<T, E> {
   if (typeof eventSchema === "function") {
-    if (
-      stateSchema && typeof stateSchema === "object" &&
-      "proxy" in stateSchema && stateSchema.proxy === true
-    ) {
-      handler = eventSchema;
-      eventSchema = stateSchema = undefined;
-    } else {
-      throw new Error(
-        "invalid handler, no schema provided - did you forget to enable CTS?",
-      );
-    }
+    handler = eventSchema;
+    eventSchema = stateSchema = undefined;
   }
 
   const schema: JSONSchema | undefined = eventSchema || stateSchema

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -100,7 +100,6 @@ describe("module", () => {
           props.x = event.clientX;
           props.y = event.clientY;
         },
-        { proxy: true },
       );
       expect(typeof clickHandler).toBe("function");
       expect(isModule(clickHandler)).toBe(true);
@@ -112,7 +111,6 @@ describe("module", () => {
           props.x = event.clientX;
           props.y = event.clientY;
         },
-        { proxy: true },
       );
       const stream = clickHandler({ x: opaqueRef(10), y: opaqueRef(20) });
       expect(isOpaqueRef(stream)).toBe(true);
@@ -203,7 +201,6 @@ describe("module", () => {
           props.x = event.clientX;
           props.y = event.clientY;
         },
-        { proxy: true },
       );
       const stream = clickHandler.with({ x: opaqueRef(10), y: opaqueRef(20) });
       expect(isOpaqueRef(stream)).toBe(true);

--- a/recipes/simpleValue.tsx
+++ b/recipes/simpleValue.tsx
@@ -1,4 +1,3 @@
-/// <cts-enable />
 import {
   Cell,
   derive,


### PR DESCRIPTION
This reverts commit 2b7fa35868b379ae06b15ec959b34048383edeea.

The reason to revert, is that this seems to unintentionally break recipes that have _**NOT**_ opted into the new CTS setup with `/// <enable-cts>` flag

```
common➜  labs git:(main) deno task ct charm new --api-url http://localhost:8000 --space q2 ../recipes/recipes/coralreef/factory.tsx
Task ct ROOT=$(pwd) && cd $INIT_CWD && deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env "$ROOT/packages/cli/mod.ts" "charm" "new" "--api-url" "http://localhost:8000" "--space" "q2" "../recipes/recipes/coralreef/factory.tsx"

Error: invalid handler, no schema provided - did you forget to enable CTS?
    at handler (file:///Users/username/common/labs/packages/runner/src/builder/module.ts:133:13)
    at Object.eval (ba4jcbavc36uu4ibrbin2s6oy4ffaz4tdvcpll46onkpiwic553yfrizn/page.tsx:120:2)
    at <CT_INTERNAL>
    at <CT_INTERNAL>
    at Array.map (<anonymous>)
    at <CT_INTERNAL>
    at <CT_INTERNAL>
    at Array.map (<anonymous>)
    at <CT_INTERNAL>
    at <CT_INTERNAL>
    at <CT_INTERNAL>
    at file:///Users/username/common/labs/packages/js-runtime/runtime/eval-runtime.ts:15:57
    at IsolateInternals.exec (file:///Users/username/common/labs/packages/js-runtime/runtime/eval-runtime.ts:37:14)
    at UnsafeEvalJsValue.invoke (file:///Users/username/common/labs/packages/js-runtime/runtime/eval-runtime.ts:15:35)
    at Engine.process (file:///Users/username/common/labs/packages/runner/src/harness/engine.ts:168:46)
    at eventLoopTick (ext:core/01_core.js:178:7)
    at async Engine.run (file:///Users/username/common/labs/packages/runner/src/harness/engine.ts:126:45)
    at async RecipeManager.compileRecipe (file:///Users/username/common/labs/packages/runner/src/recipe-manager.ts:168:12)
    at async compileRecipe (file:///Users/username/common/labs/packages/charm/src/iterate.ts:537:18)
    at async compileProgram (file:///Users/username/common/labs/packages/charm/src/ops/utils.ts:9:18)
    at async CharmsController.create (file:///Users/username/common/labs/packages/charm/src/ops/charms-controller.ts:24:20)
    at async newCharm (file:///Users/username/common/labs/packages/cli/lib/charm.ts:139:17)
    at async Command.actionHandler (file:///Users/username/common/labs/packages/cli/commands/charm.ts:110:9)
    at async Command.execute (https://jsr.io/@cliffy/command/1.0.0-rc.8/command.ts:1940:7)
    at async Command.parseCommand (https://jsr.io/@cliffy/command/1.0.0-rc.8/command.ts:1772:14)
    at async parse (file:///Users/username/common/labs/packages/cli/commands/mod.ts:4:10)
    at async main (file:///Users/username/common/labs/packages/cli/mod.ts:5:5)
```

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reverted recent changes that enforced stricter handler validation when CTS is not enabled, restoring previous handler behavior. 

- **Refactors**
 - Removed error throwing for missing schemas and proxy checks in the handler function.
 - Cleaned up related test cases and removed the CTS enable comment from a recipe.

<!-- End of auto-generated description by cubic. -->

