### PR TITLE
feat: Handle browser history events as to not reload the page

### DIFF
--- a/packages/shell/src/components/CharmLink.ts
+++ b/packages/shell/src/components/CharmLink.ts
@@ -1,0 +1,45 @@
+import { css, html, LitElement } from "lit";
+import { property } from "lit/decorators.js";
+import { navigate, NavigationCommandType } from "../lib/navigate.ts";
+
+export class CharmLinkElement extends LitElement {
+  static override styles = css`
+    a, a:visited {
+      color: var(--primary-font, "#000");
+    }
+  `;
+
+  @property()
+  charmId?: string;
+
+  @property()
+  spaceName?: string;
+
+  #onClick = (e: Event) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!this.spaceName) {
+      throw new Error("Cannot navigate with space name.");
+    }
+    if (this.charmId) {
+      navigate({
+        type: "charm",
+        spaceName: this.spaceName,
+        charmId: this.charmId,
+      });
+    } else {
+      navigate({
+        type: "space",
+        spaceName: this.spaceName,
+      });
+    }
+  };
+
+  override render() {
+    return html`
+      <a class="charm-link" href="#" @click="${this.#onClick}"><slot></slot></a>
+    `;
+  }
+}
+
+globalThis.customElements.define("x-charm-link", CharmLinkElement);

--- a/packages/shell/src/components/index.ts
+++ b/packages/shell/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./Button.ts";
+export * from "./CharmLink.ts";
 export * from "./CTLogo.ts";
 export * from "./Flex.ts";
 export * from "./Spinner.ts";

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -12,7 +12,7 @@ import { XRootView } from "./views/RootView.ts";
 import "./components/index.ts";
 import "./views/index.ts";
 import { App } from "./lib/app/controller.ts";
-import { getNavigationHref } from "./lib/navigate.ts";
+import { Navigation } from "./lib/navigate.ts";
 import "./globals.ts";
 console.log(`ENVIRONMENT=${ENVIRONMENT}`);
 console.log(`API_URL=${API_URL}`);
@@ -46,22 +46,4 @@ await app.initializeKeys();
   app.setSpace(spaceName);
   if (charmId) app.setActiveCharmId(charmId);
 }
-
-globalThis.addEventListener("navigate-to-charm", (e) => {
-  const { spaceName, charmId } = (e as CustomEvent).detail ?? {};
-  if (!spaceName) {
-    console.warn(`Navigation event missing 'spaceName'.`);
-    return;
-  }
-  if (!charmId) {
-    console.warn(`Navigation event missing 'charmId'.`);
-    return;
-  }
-  app.setSpace(spaceName);
-  app.setActiveCharmId(charmId);
-
-  // Update the browser URL to reflect the new location
-  // (DefaultCharmList should not use this event, it sets activeCharmId directly)
-  const href = getNavigationHref(spaceName, charmId);
-  globalThis.history.pushState({}, "", href);
-});
+const navigation = new Navigation(app);

--- a/packages/shell/src/lib/app/commands.ts
+++ b/packages/shell/src/lib/app/commands.ts
@@ -1,7 +1,7 @@
 import { Identity } from "@commontools/identity";
 
 export type Command =
-  | { type: "set-active-charm-id"; charmId: string }
+  | { type: "set-active-charm-id"; charmId?: string }
   | { type: "set-identity"; identity: Identity }
   | { type: "set-space"; spaceName: string }
   | { type: "clear-authentication" }
@@ -25,7 +25,7 @@ export function isCommand(value: unknown): value is Command {
     }
     case "set-active-charm-id": {
       return "charmId" in value && !!value.charmId &&
-        typeof value.charmId === "string";
+        (typeof value.charmId === "string" || value.charmId === undefined);
     }
     case "clear-authentication": {
       return true;

--- a/packages/shell/src/lib/app/controller.ts
+++ b/packages/shell/src/lib/app/controller.ts
@@ -36,7 +36,7 @@ export class App extends EventTarget {
     await this.apply({ type: "set-space", spaceName });
   }
 
-  async setActiveCharmId(charmId: string) {
+  async setActiveCharmId(charmId?: string) {
     await this.apply({ type: "set-active-charm-id", charmId });
   }
 

--- a/packages/shell/src/lib/navigate.ts
+++ b/packages/shell/src/lib/navigate.ts
@@ -1,15 +1,169 @@
+import { App } from "./app/controller.ts";
 import { USE_SHELL_PREFIX } from "./env.ts";
+import { getLogger } from "@commontools/utils/logger";
 
-export function getNavigationHref(spaceName: string, charmId?: string): string {
-  const prefix = USE_SHELL_PREFIX ? `/shell` : "";
-  const charm = charmId ? `/${charmId}` : "";
-  return `${prefix}/${spaceName}${charm}`;
+const logger = getLogger("shell.navigation");
+
+// Could contain other nav types, like external pages,
+// or viewing a User's "Settings" etc.
+export type NavigationCommandType = "charm" | "space";
+
+export type NavigationCommand = {
+  type: "charm";
+  charmId: string;
+  spaceName: string;
+} | {
+  type: "space";
+  spaceName: string;
+};
+
+const NavigationEventName = "ct-navigate";
+
+class NavigationEvent extends CustomEvent<NavigationCommand> {
+  command: NavigationCommand;
+  constructor(command: NavigationCommand) {
+    super(NavigationEventName, { detail: command });
+    this.command = command;
+  }
 }
 
-export function navigateToCharm(spaceName: string, charmId: string) {
-  globalThis.dispatchEvent(
-    new CustomEvent("navigate-to-charm", {
-      detail: { spaceName, charmId },
-    }),
-  );
+export function navigate(command: NavigationCommand) {
+  globalThis.dispatchEvent(new NavigationEvent(command));
+}
+
+const UpdatePageTitleEventName = "ct-update-page-title";
+
+class UpdatePageTitleEvent extends CustomEvent<string> {
+  title: string;
+  constructor(title: string) {
+    super(UpdatePageTitleEventName, { detail: title });
+    this.title = title;
+  }
+}
+
+export function updatePageTitle(title: string) {
+  globalThis.dispatchEvent(new UpdatePageTitleEvent(title));
+}
+
+// Handles synchronizing of browser history state and application state.
+//
+// Navigation can occur in the following scenarios:
+// * Browser back/forward buttons/shortcuts
+// * Clicking on a `<x-charm-link>`
+//
+// On instantiation, parses the current URL and applies app state as needed.
+export class Navigation {
+  #app: App;
+  constructor(app: App) {
+    this.#app = app;
+
+    globalThis.addEventListener(NavigationEventName, this.onNavigate);
+    globalThis.addEventListener(
+      UpdatePageTitleEventName,
+      this.onUpdatePageTitle,
+    );
+    globalThis.addEventListener("popstate", this.onPopState);
+
+    const init = generateCommandFromPageLoad();
+    // Initial state is `null` -- reflect the state given
+    // from the current URL.
+    this.replace(init);
+    this.apply(init);
+  }
+
+  private onUpdatePageTitle = (e: Event) => {
+    const title = (e as UpdatePageTitleEvent).title;
+    logger.log("SetTitle", title);
+    // Thought this needed to interact with the history.
+    // Maybe it doesn't.
+    document.title = title;
+  };
+
+  private onPopState = (e: Event) => {
+    const state = (e as PopStateEvent).state as NavigationCommand | null;
+    logger.log("Pop", state);
+    if (!state) {
+      console.warn("No state from history!");
+      return;
+    }
+    this.apply(state);
+  };
+
+  private onNavigate = (e: Event) => {
+    const command = (e as NavigationEvent).command;
+    logger.log("Navigate", command);
+    this.push(command);
+    this.apply(command);
+  };
+
+  // Push a new command state to the browser's history.
+  private push(command: NavigationCommand) {
+    logger.log("Push", command);
+    globalThis.history.pushState(command, "", getNavigationHref(command));
+  }
+
+  // Updates the current browser history state and page with a new title.
+  private replace(command: NavigationCommand, title?: string) {
+    logger.log("Replace", command, title);
+    globalThis.history.replaceState(
+      command,
+      title || "",
+      getNavigationHref(command),
+    );
+  }
+
+  // Propagates the command state into the App.
+  private apply(command: NavigationCommand) {
+    logger.log("Apply", command);
+    switch (command.type) {
+      case "charm": {
+        this.#app.setSpace(command.spaceName);
+        this.#app.setActiveCharmId(command.charmId);
+        break;
+      }
+      case "space": {
+        this.#app.setSpace(command.spaceName);
+        this.#app.setActiveCharmId(undefined);
+        break;
+      }
+      default: {
+        throw new Error("Unsupported navigation type.");
+      }
+    }
+  }
+}
+
+function getNavigationHref(command: NavigationCommand): string {
+  let content = "";
+  switch (command.type) {
+    case "charm": {
+      content = `${command.spaceName}/${command.charmId}`;
+      break;
+    }
+    case "space": {
+      content = `${command.spaceName}`;
+      break;
+    }
+    default: {
+      throw new Error("Unsupported navigation type.");
+    }
+  }
+  const prefix = USE_SHELL_PREFIX ? `/shell` : "";
+  return `${prefix}/${content}`;
+}
+
+function generateCommandFromPageLoad(): NavigationCommand {
+  const location = new URL(globalThis.location.href);
+  const segments = location.pathname.split("/");
+  segments.shift(); // shift off the pathnames' prefix "/";
+  const [first, charmId] = USE_SHELL_PREFIX
+    ? [segments[1], segments[2]]
+    : [segments[0], segments[1]];
+
+  const spaceName = first || "common-knowledge";
+  if (charmId) {
+    return { type: "charm", spaceName, charmId };
+  } else {
+    return { type: "space", spaceName };
+  }
 }

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -9,7 +9,7 @@ import { charmId, CharmManager } from "@commontools/charm";
 import { CharmsController } from "@commontools/charm/ops";
 import { StorageManager } from "@commontools/runner/storage/cache";
 import { API_URL } from "./env.ts";
-import { navigateToCharm } from "./navigate.ts";
+import { navigate } from "./navigate.ts";
 import * as Inspector from "@commontools/runner/storage/inspector";
 import {
   StorageInspectorState,
@@ -152,7 +152,11 @@ export class RuntimeInternals extends EventTarget {
         // need this anymore
         runtime.storage.synced().then(() => {
           // Use the human-readable space name from CharmManager instead of DID
-          navigateToCharm(charmManager.getSpaceName(), id);
+          navigate({
+            type: "charm",
+            spaceName: charmManager.getSpaceName(),
+            charmId: id,
+          });
         });
       },
     });
@@ -165,80 +169,4 @@ export class RuntimeInternals extends EventTarget {
     const cc = new CharmsController(charmManager);
     return new RuntimeInternals(cc, telemetry);
   }
-}
-
-export async function createCharmsController(
-  { identity, spaceName, apiUrl }: {
-    identity: Identity;
-    spaceName: string;
-    apiUrl: URL;
-  },
-): Promise<CharmsController> {
-  console.log("[createCharmsController] Starting with:", {
-    identityDid: identity.did(),
-    spaceName,
-    apiUrl: apiUrl.toString(),
-  });
-
-  const session = await createSession(identity, spaceName);
-  const url = apiUrl.toString();
-
-  console.log("[createCharmsController] Creating Runtime with:", {
-    storageUrl: new URL("/api/storage/memory", url).toString(),
-    blobbyServerUrl: url,
-    sessionIdentity: session.as.did(),
-    sessionSpace: session.space,
-    isPrivateSpace: session.private,
-  });
-
-  const staticAssetUrl = new URL(API_URL);
-  staticAssetUrl.pathname = "/static";
-
-  // We're hoisting CharmManager so that
-  // we can create it after the runtime, but still reference
-  // its `getSpaceName` method in a runtime callback.
-  // deno-lint-ignore prefer-const
-  let charmManager: CharmManager;
-
-  const runtime = new Runtime({
-    storageManager: StorageManager.open({
-      as: session.as,
-      address: new URL("/api/storage/memory", url),
-    }),
-    blobbyServerUrl: url,
-    staticAssetServerUrl: staticAssetUrl,
-    errorHandlers: [(error) => {
-      console.error(error);
-      //Sentry.captureException(error);
-    }],
-    consoleHandler: (metadata, method, args) => {
-      // Handle console messages depending on charm context.
-      // This is essentially the same as the default handling currently,
-      // but adding this here for future use.
-      if (metadata?.charmId) {
-        return [`Charm(${metadata.charmId}) [${method}]:`, ...args];
-      }
-      return [`Console [${method}]:`, ...args];
-    },
-    navigateCallback: (target) => {
-      const id = charmId(target);
-      if (!id) {
-        throw new Error(`Could not navigate to cell that is not a charm.`);
-      }
-
-      // NOTE(jake): Eventually, once we're doing multi-space navigation, we will
-      // need to replace this charmManager.getSpaceName() with a call to some
-      // sort of address book / dns-style server, OR just navigate to the DID.
-
-      // Use the human-readable space name from CharmManager instead of the DID
-      navigateToCharm(charmManager.getSpaceName(), id);
-    },
-  });
-
-  // Set up iframe context handler
-  setupIframe(runtime);
-
-  charmManager = new CharmManager(session, runtime);
-  await charmManager.synced();
-  return new CharmsController(charmManager);
 }

--- a/packages/shell/src/views/CharmListView.ts
+++ b/packages/shell/src/views/CharmListView.ts
@@ -1,7 +1,6 @@
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
 import { BaseView } from "./BaseView.ts";
-import { getNavigationHref } from "../lib/navigate.ts";
 import { RuntimeInternals } from "../lib/runtime.ts";
 import { CharmController } from "@commontools/charm/ops";
 
@@ -90,10 +89,12 @@ export class XCharmListView extends BaseView {
     const list = charms.map((charm) => {
       const name = charm.name();
       const id = charm.id;
-      const href = getNavigationHref(spaceName, id);
       return html`
         <li class="charm-item">
-          <a class="charm-link" href="${href}">${name}</a>
+          <x-charm-link
+            .charmId="${id}"
+            .spaceName="${spaceName}"
+          ></x-charm-link>
           <x-button
             class="remove-button"
             size="small"

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -3,13 +3,12 @@ import { property, state } from "lit/decorators.js";
 import { Identity, KeyStore } from "@commontools/identity";
 import { BaseView } from "./BaseView.ts";
 import { Task } from "@lit/task";
-import { getNavigationHref } from "../lib/navigate.ts";
 import { styleMap } from "lit/directives/style-map.js";
 import { RuntimeInternals } from "../lib/runtime.ts";
 import {
   StorageInspectorConflicts,
   StorageInspectorUpdateEvent,
-} from "../lib/inspector.ts";
+} from "../lib/storage-inspector.ts";
 import "../components/Flex.ts";
 import { CharmController } from "@commontools/charm/ops";
 
@@ -86,10 +85,6 @@ export class XHeaderView extends BaseView {
 
     ct-logo:hover {
       transform: scale(1.05);
-    }
-
-    a, a:visited {
-      color: var(--primary-font, "#000");
     }
   `;
 
@@ -211,16 +206,17 @@ export class XHeaderView extends BaseView {
       : undefined;
     const spaceLink = this.spaceName
       ? html`
-        <a class="space-link" href="${getNavigationHref(this.spaceName)}">${this
-          .spaceName}</a>
+        <x-charm-link
+          .spaceName="${this.spaceName}"
+        >${this.spaceName}</x-charm-link>
       `
       : null;
     const charmLink = activeCharmName && this.spaceName && this.activeCharm
       ? html`
-        <a class="charm-link" href="${getNavigationHref(
-          this.spaceName,
-          this.activeCharm.id,
-        )}">${activeCharmName}</a>
+        <x-charm-link
+          .charmId="${this.activeCharm.id}"
+          .spaceName="${this.spaceName}"
+        >${activeCharmName}</x-charm-link>
       `
       : null;
     const title = html`


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added in-app navigation that updates browser history without reloading the page, so users can move between spaces and charms smoothly.

- **New Features**
  - Introduced a navigation system that syncs app state with browser history.
  - Added a `<x-charm-link>` component for internal navigation.
  - Updated views to use the new navigation and link component.

<!-- End of auto-generated description by cubic. -->

