### PR TITLE
adding explicit proxy:true, to fix default charm list in new CTS check

### DIFF
--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -123,8 +123,17 @@ export function handler<E, T>(
   handler?: (event: E, props: T) => any,
 ): HandlerFactory<T, E> {
   if (typeof eventSchema === "function") {
-    handler = eventSchema;
-    eventSchema = stateSchema = undefined;
+    if (
+      stateSchema && typeof stateSchema === "object" &&
+      "proxy" in stateSchema && stateSchema.proxy === true
+    ) {
+      handler = eventSchema;
+      eventSchema = stateSchema = undefined;
+    } else {
+      throw new Error(
+        "invalid handler, no schema provided - did you forget to enable CTS?",
+      );
+    }
   }
 
   const schema: JSONSchema | undefined = eventSchema || stateSchema

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -100,6 +100,7 @@ describe("module", () => {
           props.x = event.clientX;
           props.y = event.clientY;
         },
+        { proxy: true },
       );
       expect(typeof clickHandler).toBe("function");
       expect(isModule(clickHandler)).toBe(true);
@@ -111,6 +112,7 @@ describe("module", () => {
           props.x = event.clientX;
           props.y = event.clientY;
         },
+        { proxy: true },
       );
       const stream = clickHandler({ x: opaqueRef(10), y: opaqueRef(20) });
       expect(isOpaqueRef(stream)).toBe(true);
@@ -201,6 +203,7 @@ describe("module", () => {
           props.x = event.clientX;
           props.y = event.clientY;
         },
+        { proxy: true },
       );
       const stream = clickHandler.with({ x: opaqueRef(10), y: opaqueRef(20) });
       expect(isOpaqueRef(stream)).toBe(true);

--- a/packages/static/assets/recipes/charm-list.tsx
+++ b/packages/static/assets/recipes/charm-list.tsx
@@ -44,7 +44,7 @@ const CharmsListOutputSchema = {
 
 const visit = handler<{}, { charm: any }>((_, state) => {
   return navigateTo(state.charm);
-});
+}, { proxy: true });
 
 
 const removeCharm = handler({}, {

--- a/recipes/simpleValue.tsx
+++ b/recipes/simpleValue.tsx
@@ -1,3 +1,4 @@
+/// <cts-enable />
 import {
   Cell,
   derive,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Set proxy: true in the charm list handler to fix loading of the default charm list in the new CTS check.

<!-- End of auto-generated description by cubic. -->

