### PR TITLE
fix: update ct-outliner JSX types to match refactored component

### DIFF
--- a/packages/patterns/simple-list.tsx
+++ b/packages/patterns/simple-list.tsx
@@ -35,6 +35,7 @@ const ResultSchema = {
   required: ["title", "items"],
 } as const satisfies JSONSchema;
 
+// Example of a handler to add to the list manually, if you set `readonly` the list will lose its in-built add form
 const addItem = handler(
   {
     type: "object",

--- a/packages/static/assets/types/jsx.d.ts
+++ b/packages/static/assets/types/jsx.d.ts
@@ -17,6 +17,11 @@ type OutlinerNode = {
   attachments: Charm[]
 }
 
+type ListItem = {
+  title: string,
+  done?: boolean
+}
+
 declare global {
   namespace JSX {
     interface Element {
@@ -28,10 +33,19 @@ declare global {
     interface IntrinsicElements {
       [elemName: string]: any;
       "ct-outliner": {
-              $value: Cell<{ root: OutlinerNode }>,
-              $mentionable?: Cell<Charm[]>
-              'oncharm-link-click'?: any,
-            } & Child;
+        $value: Cell<{ root: OutlinerNode }>,
+        $mentionable?: Cell<Charm[]>
+        'oncharm-link-click'?: any,
+      } & Child;
+      "ct-list": {
+        $value: Cell<ListItem[]>,
+        /** setting this allows editing items inline */
+        editable?: boolean,
+        /** setting this hides the 'add item' form built into the list */
+        readonly?: boolean,
+        title?: string,
+        'onct-remove-item'?: any,
+      } & Child;
     }
   }
 }

--- a/packages/static/assets/types/jsx.d.ts
+++ b/packages/static/assets/types/jsx.d.ts
@@ -1,5 +1,7 @@
+type Children = JSX.Element[] | JSX.Element | string | number | boolean | null | undefined;
+
 type Child = {
-  children?: string[];
+  children?: Children;
 };
 
 type Cell<T> = {
@@ -15,9 +17,14 @@ type OutlinerNode = {
   attachments: Charm[]
 }
 
-
 declare global {
   namespace JSX {
+    interface Element {
+      type: string;
+      props: any;
+      children?: Children;
+    }
+
     interface IntrinsicElements {
       [elemName: string]: any;
       "ct-outliner": {

--- a/packages/static/assets/types/jsx.d.ts
+++ b/packages/static/assets/types/jsx.d.ts
@@ -29,7 +29,7 @@ declare global {
       [elemName: string]: any;
       "ct-outliner": {
               $value: Cell<{ root: OutlinerNode }>,
-              $mentionable: Cell<Charm[]>
+              $mentionable?: Cell<Charm[]>
               'oncharm-link-click'?: any,
             } & Child;
     }

--- a/packages/static/assets/types/jsx.d.ts
+++ b/packages/static/assets/types/jsx.d.ts
@@ -1,5 +1,5 @@
 type Child = {
-  children: string[];
+  children?: string[];
 };
 
 type Cell<T> = {
@@ -22,8 +22,8 @@ declare global {
       [elemName: string]: any;
       "ct-outliner": {
               $value: Cell<{ root: OutlinerNode }>,
-              $mentionable: Cell<{"$NAME": string, "$UI": any }[]>
-              'oncharm-link-click'?: (e: { detail: { item: Cell<Charm> } }) => void,
+              $mentionable: Cell<Charm[]>
+              'oncharm-link-click'?: any,
             } & Child;
     }
   }


### PR DESCRIPTION
- Change $mentionable type from Cell<{"$NAME": string, "$UI": any}[]> to Cell<Charm[]>
  to match how the component actually uses the NAME symbol
- Make children property optional in Child type since ct-outliner is self-closing
- Set oncharm-link-click to any to support handler proxy pattern

These changes fix type errors in recipes using ct-outliner after the component refactor in commit 4e37bfb2.

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated ct-outliner JSX types to match the refactored component and fix type errors in recipes.

- **Bug Fixes**
  - Changed $mentionable type to Cell<Charm[]>.
  - Made children optional in Child type.
  - Set oncharm-link-click to any for handler proxy support.

<!-- End of auto-generated description by cubic. -->

