### PR TITLE
fix: Show charm name in default charms list view

### DIFF
--- a/packages/shell/src/views/CharmListView.ts
+++ b/packages/shell/src/views/CharmListView.ts
@@ -94,7 +94,7 @@ export class XCharmListView extends BaseView {
           <x-charm-link
             .charmId="${id}"
             .spaceName="${spaceName}"
-          ></x-charm-link>
+          >${name}</x-charm-link>
           <x-button
             class="remove-button"
             size="small"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
The default charms list view now displays the charm name instead of leaving it blank.

<!-- End of auto-generated description by cubic. -->

