### PR TITLE
Fix `ct charm set` and `ct charm link` with deep paths containing links [CT-731]

### DIFF
--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -1011,8 +1011,10 @@ export class CharmManager {
         "Target",
       );
 
+    const tx = this.runtime.edit();
+
     // Navigate to the source path
-    let sourceResultCell = sourceCell;
+    let sourceResultCell = sourceCell.withTx(tx);
     // For charms, manager.get() already returns the result cell, so no need to add "result"
 
     for (const segment of sourcePath) {
@@ -1025,22 +1027,21 @@ export class CharmManager {
       throw new Error("Target path cannot be empty");
     }
 
-    let targetInputCell = targetCell;
+    let targetInputCell = targetCell.withTx(tx);
     if (targetIsCharm) {
       // For charms, target fields are in the source cell's argument
       const sourceCell = targetCell.getSourceCell(processSchema);
       if (!sourceCell) {
         throw new Error("Target charm has no source cell");
       }
-      targetInputCell = sourceCell.key("argument");
+      targetInputCell = sourceCell.key("argument").withTx(tx);
     }
 
     for (const segment of targetPath) {
       targetInputCell = targetInputCell.key(segment);
     }
 
-    const tx = this.runtime.edit();
-    targetInputCell.key(targetKey).withTx(tx).set(sourceResultCell);
+    targetInputCell.key(targetKey).set(sourceResultCell);
     await tx.commit();
     await this.runtime.idle();
     await this.synced();

--- a/packages/charm/src/ops/cell-operations.ts
+++ b/packages/charm/src/ops/cell-operations.ts
@@ -115,11 +115,14 @@ export async function setCharmInput(
 
   const tx = manager.runtime.edit();
   const inputCell = manager.getArgument(charmCell);
+  
+  // Build the path with transaction context
   let targetCell = inputCell.withTx(tx);
   for (const segment of path) {
     targetCell = targetCell.key(segment);
   }
-
+  
+  // Set the value
   targetCell.set(value as any);
   await tx.commit();
 
@@ -139,11 +142,14 @@ export async function setCharmResult(
   }
 
   const tx = manager.runtime.edit();
+  
+  // Build the path with transaction context
   let targetCell = charmCell.withTx(tx);
   for (const segment of path) {
     targetCell = targetCell.key(segment);
   }
-
+  
+  // Set the value
   targetCell.set(value as any);
   await tx.commit();
 

--- a/packages/charm/src/ops/cell-operations.ts
+++ b/packages/charm/src/ops/cell-operations.ts
@@ -113,14 +113,14 @@ export async function setCharmInput(
     throw new Error(`Charm with ID "${charmId}" not found`);
   }
 
+  const tx = manager.runtime.edit();
   const inputCell = manager.getArgument(charmCell);
-  let targetCell = inputCell;
+  let targetCell = inputCell.withTx(tx);
   for (const segment of path) {
     targetCell = targetCell.key(segment);
   }
 
-  const tx = manager.runtime.edit();
-  targetCell.withTx(tx).set(value as any);
+  targetCell.set(value as any);
   await tx.commit();
 
   await manager.runtime.idle();
@@ -138,13 +138,13 @@ export async function setCharmResult(
     throw new Error(`Charm with ID "${charmId}" not found`);
   }
 
-  let targetCell = charmCell;
+  const tx = manager.runtime.edit();
+  let targetCell = charmCell.withTx(tx);
   for (const segment of path) {
     targetCell = targetCell.key(segment);
   }
 
-  const tx = manager.runtime.edit();
-  targetCell.withTx(tx).set(value as any);
+  targetCell.set(value as any);
   await tx.commit();
 
   await manager.runtime.idle();

--- a/packages/static/assets/types/jsx.d.ts
+++ b/packages/static/assets/types/jsx.d.ts
@@ -46,6 +46,43 @@ declare global {
         title?: string,
         'onct-remove-item'?: any,
       } & Child;
+      "ct-input": {
+        $value?: Cell<string>,
+        customStyle?: string, // bf: I think this is going to go away one day soon
+        type?: string,
+        placeholder?: string,
+        value?: string,
+        disabled?: boolean,
+        readonly?: boolean,
+        error?: boolean,
+        name?: string,
+        required?: boolean,
+        autofocus?: boolean,
+        autocomplete?: string,
+        min?: string,
+        max?: string,
+        step?: string,
+        pattern?: string,
+        maxlength?: string,
+        minlength?: string,
+        inputmode?: string,
+        size?: number,
+        multiple?: boolean,
+        accept?: string,
+        list?: string,
+        spellcheck?: boolean,
+        validationPattern?: string,
+        showValidation?: boolean,
+        timingStrategy?: string,
+        timingDelay?: number,
+
+        'onct-change'?: any,
+        'onct-focus'?: any,
+        'onct-blur'?: any,
+        'onct-keydown'?: any,
+        'onct-submit'?: any,
+        'onct-invalid'?: any,
+      } & Child;
     }
   }
 }


### PR DESCRIPTION
- **Add `pattern` example of instantiating and `navigateTo()` on a recipe**
- **Combined recipe, which compiles**
- **Attach transaction BEFORE traversal**
- **Confirm fix for `ct charm set` and `ct charm link`**

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed `ct charm set` and `ct charm link` to handle deep paths with links by ensuring transactions are attached before traversing cells. Added new recipe examples showing how to instantiate and navigate to recipes, and extended JSX types for input elements.

- **Bug Fixes**
  - Attach transaction context before traversing cell paths in charm operations to prevent errors with deep links.

- **New Features**
  - Added `instantiate-recipe.tsx` and `instantiate-recipe2.tsx` as examples for recipe instantiation and navigation.
  - Extended `ct-input` JSX type definitions with more attributes.

<!-- End of auto-generated description by cubic. -->

