### PR TITLE
skipping bg service counter.test.ts test for now

### DIFF
--- a/packages/background-charm-service/integration/counter.test.ts
+++ b/packages/background-charm-service/integration/counter.test.ts
@@ -14,7 +14,7 @@ describe("background charm counter tests", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
 
-  it("can register and interact with background counter charm", async () => {
+  it.skip("can register and interact with background counter charm", async () => {
     // FIXME(ja): currently bg process doesn't receive updates of bgCharms,
     // and so we need to start it after we register :(  We should start it here
     // this.charmCell.sink only seems to trigger when the service.ts starts -


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Temporarily skipped the background counter charm integration test to prevent failures while the background process update issue is investigated.

<!-- End of auto-generated description by cubic. -->

