### PR TITLE
Changed Cell.getRaw to return Immutable<T> or undefined

### DIFF
--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -76,7 +76,7 @@ export function map(
 
     // .getRaw() because we want the recipe itself and avoid following the
     // aliases in the recipe
-    const opRecipe = op.getRaw();
+    const opRecipe = op.getRaw() as any;
 
     // If the result's value is undefined, set it to the empty array.
     if (resultWithLog.get() === undefined) {

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -251,7 +251,7 @@ describe("Cell", () => {
     expect(value.z.z.z).toBe(value.z.z);
 
     const raw = c.getRaw();
-    expect(raw.z).toMatchObject({ "/": { [LINK_V1_TAG]: { path: [] } } });
+    expect(raw?.z).toMatchObject({ "/": { [LINK_V1_TAG]: { path: [] } } });
   });
 
   it("should translate circular references into links across cells", () => {
@@ -1997,10 +1997,10 @@ describe("asCell with schema", () => {
     arrayCell.push(dCell);
     arrayCell.push(d.getAsQueryResult());
 
-    const rawItems = c.getRaw().items;
+    const rawItems = c.getRaw()?.items;
     const expectedCellLink = d.getAsNormalizedFullLink();
 
-    expect(rawItems.map((item: any) => parseLink(item, c))).toEqual([
+    expect(rawItems?.map((item) => parseLink(item, c))).toEqual([
       expectedCellLink,
       expectedCellLink,
       expectedCellLink,
@@ -2035,8 +2035,8 @@ describe("asCell with schema", () => {
     arrayCell.push({ [ID]: "test", value: 43 });
     expect(frame.generatedIdCounter).toEqual(1); // No increment = no ID generated from it
     popFrame(frame);
-    expect(isAnyCellLink(c.getRaw().items[0])).toBe(true);
-    expect(isAnyCellLink(c.getRaw().items[1])).toBe(true);
+    expect(isAnyCellLink(c.getRaw()?.items[0])).toBe(true);
+    expect(isAnyCellLink(c.getRaw()?.items[1])).toBe(true);
     expect(arrayCell.get()).toEqualIgnoringSymbols([
       { value: 42 },
       { value: 43 },

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -1132,12 +1132,12 @@ describe("data-updating", () => {
       );
 
       const result = testCell.getRaw();
-      expect(isAnyCellLink(result.items[0])).toBe(true);
-      expect(isAnyCellLink(result.items[1])).toBe(true);
-      expect(areLinksSame(result.items[0], result.items[1]))
+      expect(isAnyCellLink(result?.items[0])).toBe(true);
+      expect(isAnyCellLink(result?.items[1])).toBe(true);
+      expect(areLinksSame(result?.items[0], result?.items[1]))
         .toBe(true);
       expect(
-        (tx.readValueOrThrow(parseLink(result.items[1], testCell)!) as any)
+        (tx.readValueOrThrow(parseLink(result?.items[1], testCell)!) as any)
           .name,
       )
         .toBe("New Item");

--- a/packages/runner/test/push-conflict.test.ts
+++ b/packages/runner/test/push-conflict.test.ts
@@ -240,7 +240,7 @@ describe.skip("Push conflict", () => {
     expect(name.get()).toEqual("bar");
     expect(list.get()).toEqual([{ n: 4 }]);
     expect(isAnyCellLink(list.getRaw()?.[0])).toBe(true);
-    const entry = list.getRaw()[0].cell?.asCell();
+    //const entry = list.getRaw()[0].cell?.asCell();
     expect(retryCalled).toEqual(0);
 
     await storage.synced();

--- a/packages/runner/test/query.test.ts
+++ b/packages/runner/test/query.test.ts
@@ -92,7 +92,7 @@ describe("Query", () => {
     const assert2 = {
       the: "application/json",
       of: `of:${entityId2["/"]}` as Entity,
-      is: { value: testCell2.getRaw() },
+      is: { value: docValue2 },
       cause: refer({ the: "application/json", of: `of:${entityId2["/"]}` }),
       since: 2,
     };
@@ -176,17 +176,18 @@ describe("Query", () => {
       undefined,
       tx,
     );
-    testCell2.setRaw({
+    const docValue2 = {
       name: {
         cell: entityId1,
         path: ["employees", "0", "name"],
       },
-    });
+    };
+    testCell2.setRaw(docValue2);
     const entityId2 = testCell2.entityId!;
     const assert2 = {
       the: "application/json",
       of: `of:${entityId2["/"]}` as Entity,
-      is: { value: testCell2.getRaw() },
+      is: { value: docValue2 },
       cause: refer({ the: "application/json", of: `of:${entityId2["/"]}` }),
       since: 2,
     };

--- a/packages/runner/test/recipes.test.ts
+++ b/packages/runner/test/recipes.test.ts
@@ -814,7 +814,8 @@ describe("Recipe Runner", () => {
     expect(errors).toBe(1);
     expect(charm.getAsQueryResult()).toMatchObject({ result: 5 });
 
-    const sourceCellValue = charm.getSourceCell()?.getRaw();
+    // Cast to any to avoid type checking
+    const sourceCellValue = charm.getSourceCell()?.getRaw() as any;
     const recipeId = sourceCellValue?.[TYPE];
     expect(recipeId).toBeDefined();
     expect(lastError?.recipeId).toBe(recipeId);

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -722,8 +722,9 @@ describe("runRecipe", () => {
     await runtime.idle();
 
     // Get the internal state objects
-    const internal1 = result1.getSourceCell()?.getRaw().internal;
-    const internal2 = result2.getSourceCell()?.getRaw().internal;
+    // We cast away our Immutable, so we can do this test
+    const internal1 = (result1.getSourceCell()?.getRaw() as any).internal;
+    const internal2 = (result2.getSourceCell()?.getRaw() as any).internal;
 
     // Verify they are different objects
     expect(internal1).not.toBe(internal2);


### PR DESCRIPTION
This prevents accidental modification of the object.
I did not alter `get()` or `value`, nor did I change other methods where a similar restriction could apply.
I made some minor changes to the cell.ts imports
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Changed Cell.getRaw to return an Immutable<T> or undefined, making raw cell data read-only and preventing accidental modification.

- **Refactors**
  - Updated getRaw return type and related code to use Immutable<T>.
  - Adjusted tests and internal usage to handle the new return type.

<!-- End of auto-generated description by cubic. -->

