### PR TITLE
Expect cycles when traversing $ref

### DIFF
--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -175,7 +175,7 @@ export class ContextualFlowControl {
     joined: Set<string>,
     schema: JSONSchema | boolean,
     rootSchema: JSONSchema | boolean,
-    cycleTracker: CycleTracker<JSONSchema> = new CycleTracker<JSONSchema>(),
+    cycleTracker: CycleTracker<JSONSchema> = new CycleTracker<JSONSchema>(true),
   ): Set<string> {
     if (typeof schema === "boolean") {
       return joined;

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -93,16 +93,20 @@ export const MinimalSchemaSelector = {
 
 export class CycleTracker<K> {
   private partial: Set<K>;
-  constructor() {
+  private expectCycles: boolean;
+  constructor(expectCycles = false) {
+    this.expectCycles = expectCycles;
     this.partial = new Set<K>();
   }
   include(k: K, context?: unknown): Disposable | null {
     if (this.partial.has(k)) {
-      logger.warn(() => [
-        "Cycle Detected!",
-        k,
-        context,
-      ]);
+      if (!this.expectCycles) {
+        logger.warn(() => [
+          "Cycle Detected!",
+          k,
+          context,
+        ]);
+      }
       return null;
     }
     this.partial.add(k);


### PR DESCRIPTION
Add a flag to indicate whether cycles are expected to CycleTracker. Only log the cycle if they are unexpected (like cell links)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a flag to CycleTracker to control whether cycles are expected during schema traversal. Now, cycle warnings are only logged if cycles are unexpected.

<!-- End of auto-generated description by cubic. -->

