### PR TITLE
chore: Disable shell navigation logs by default

### DIFF
--- a/packages/shell/src/lib/navigate.ts
+++ b/packages/shell/src/lib/navigate.ts
@@ -1,7 +1,10 @@
 import { App } from "./app/controller.ts";
 import { getLogger } from "@commontools/utils/logger";
 
-const logger = getLogger("shell.navigation");
+const logger = getLogger("shell.navigation", {
+  enabled: false,
+  level: "debug",
+});
 
 // Could contain other nav types, like external pages,
 // or viewing a User's "Settings" etc.


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Disabled shell navigation logs by default to reduce console noise during development.

<!-- End of auto-generated description by cubic. -->

