### PR TITLE
When we encounter a conflict, include the history, so we have a chance of knowing why

### DIFF
--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -903,6 +903,11 @@ export type Conflict = {
    * Actual memory state in the replica repository.
    */
   actual: Revision<Fact> | null;
+
+  /**
+   * Actual history
+   */
+  history: Revision<Fact>[];
 };
 
 export type ToJSON<T> = T & {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
When a conflict is detected, the system now includes the full history of related facts to help understand the cause.

- **New Features**
 - Added a recursive query to collect and return the history of fact revisions during conflict detection.
 - Updated the Conflict type to include a history field.

<!-- End of auto-generated description by cubic. -->

