### PR TITLE
Enable CTS in all pattern recipes

### DIFF
--- a/packages/patterns/ct-list.tsx
+++ b/packages/patterns/ct-list.tsx
@@ -21,19 +21,8 @@ interface ListInput {
 
 interface ListOutput extends ListInput {}
 
-type MessageEvent = { detail: { message: string } };
-
-const addItem = handler<MessageEvent, { items: Cell<Item[]> }>((e, state) => {
-  const newItem = e.detail?.message?.trim();
-  if (newItem) {
-    const currentItems = state.items.get();
-    state.items.set([...currentItems, { title: newItem }]);
-  }
-});
-
-export default recipe(
-  toSchema<ListInput>(),
-  toSchema<ListOutput>(),
+export default recipe<ListInput, ListOutput>(
+  "ct-list demo",
   ({ title, items }) => {
     return {
       [NAME]: title,
@@ -46,13 +35,11 @@ export default recipe(
           />
 
           <ct-card>
-            <common-vstack gap="sm">
-              <ct-list
-                $value={items}
-                editable
-                title="Items"
-              />
-            </common-vstack>
+            <ct-list
+              $value={items}
+              editable
+              title="Items"
+            />
           </ct-card>
         </common-vstack>
       ),

--- a/packages/patterns/instantiate-recipe.tsx
+++ b/packages/patterns/instantiate-recipe.tsx
@@ -73,7 +73,7 @@ type FactoryOutput = {
 
 type InputEvent = { detail: { message: string } };
 
-const newCounter = handler((_: InputEvent) => {
+const newCounter = handler<InputEvent, Record<string, never>>((_, __) => {
   const charm = Counter({ value: Math.round(Math.random() * 10) });
   return navigateTo(charm);
 });

--- a/packages/patterns/instantiate-recipe.tsx
+++ b/packages/patterns/instantiate-recipe.tsx
@@ -2,16 +2,13 @@
 import {
   Cell,
   Default,
-  compileAndRun,
-  derive,
   h,
   handler,
-  ifElse,
-  JSONSchema,
   NAME,
   navigateTo,
   recipe,
   str,
+  toSchema,
   UI,
 } from "commontools";
 
@@ -64,49 +61,37 @@ export const Counter = recipe<RecipeState>("Counter", (state) => {
   };
 });
 
+interface FactoryInput {
+  // Provided by the shell; not used directly here
+  allCharms: Default<unknown[], []>;
+}
 
-const InputSchema = {
-  type: "object",
-  properties: {
-    allCharms: {
-      type: "array",
-      items: {
-        type: "object",
-        asCell: true,
-      },
-    },
-  },
-  required: ["allCharms"],
-} as const satisfies JSONSchema;
+// No additional outputs beyond name and UI
+interface FactoryOutput {}
 
-// Define output schema
-const OutputSchema = {
-  type: "object",
-  properties: {},
-  required: [],
-} as const satisfies JSONSchema;
+type InputEvent = { detail: { message: string } };
 
-const newCounter = handler(
-  { type: 'object', properties: { detail: { type: 'object', properties: { message: { type: 'string' } } } } },
-  { type: 'object' },
-  (e, _) => {
-    const charm = Counter({ value: Math.round(Math.random()*10) });
-    return navigateTo(charm);
+const newCounter = handler<InputEvent, {}>((_e, _state) => {
+  const charm = Counter({ value: Math.round(Math.random() * 10) });
+  return navigateTo(charm);
+});
+
+export default recipe(
+  toSchema<FactoryInput>(),
+  toSchema<FactoryOutput>(),
+  (_) => {
+    return {
+      [NAME]: "Counter Factory",
+      [UI]: (
+        <div>
+          <ct-message-input
+            button-text="Add"
+            placeholder="New counter"
+            appearance="rounded"
+            onct-send={newCounter({})}
+          />
+        </div>
+      ),
+    };
   },
 );
-
-export default recipe(InputSchema, OutputSchema, (_) => {
-  return {
-    [NAME]: "Counter Factory",
-    [UI]: (
-      <div>
-        <ct-message-input
-          button-text="Add"
-          placeholder="New counter"
-          appearance="rounded"
-          onct-send={newCounter({ })}
-        />
-      </div>
-    ),
-  };
-});

--- a/packages/patterns/instantiate-recipe.tsx
+++ b/packages/patterns/instantiate-recipe.tsx
@@ -67,11 +67,11 @@ interface FactoryInput {
 }
 
 // No additional outputs beyond name and UI
-interface FactoryOutput {}
+type FactoryOutput = Record<PropertyKey, never>;
 
 type InputEvent = { detail: { message: string } };
 
-const newCounter = handler<InputEvent, {}>((_e, _state) => {
+const newCounter = handler((_: InputEvent) => {
   const charm = Counter({ value: Math.round(Math.random() * 10) });
   return navigateTo(charm);
 });

--- a/packages/patterns/instantiate-recipe.tsx
+++ b/packages/patterns/instantiate-recipe.tsx
@@ -8,7 +8,6 @@ import {
   navigateTo,
   recipe,
   str,
-  toSchema,
   UI,
 } from "commontools";
 
@@ -67,7 +66,10 @@ interface FactoryInput {
 }
 
 // No additional outputs beyond name and UI
-type FactoryOutput = Record<PropertyKey, never>;
+type FactoryOutput = {
+  [NAME]: string;
+  [UI]: any;
+};
 
 type InputEvent = { detail: { message: string } };
 
@@ -76,9 +78,8 @@ const newCounter = handler((_: InputEvent) => {
   return navigateTo(charm);
 });
 
-export default recipe(
-  toSchema<FactoryInput>(),
-  toSchema<FactoryOutput>(),
+export default recipe<FactoryInput, FactoryOutput>(
+  "Counter Factory",
   (_) => {
     return {
       [NAME]: "Counter Factory",

--- a/packages/patterns/integration/ct-list.test.ts
+++ b/packages/patterns/integration/ct-list.test.ts
@@ -10,7 +10,7 @@ import { assert, assertEquals } from "@std/assert";
 
 const { API_URL, FRONTEND_URL } = env;
 
-describe("simple-list integration test", () => {
+describe("ct-list integration test", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
 
@@ -21,7 +21,7 @@ describe("simple-list integration test", () => {
     const { identity } = shell.get();
     spaceName = globalThis.crypto.randomUUID();
 
-    // Register the simple-list charm once for all tests
+    // Register the ct-list charm once for all tests
     charmId = await registerCharm({
       spaceName: spaceName,
       apiUrl: new URL(API_URL),
@@ -30,13 +30,13 @@ describe("simple-list integration test", () => {
         join(
           import.meta.dirname!,
           "..",
-          "simple-list.tsx",
+          "ct-list.tsx",
         ),
       ),
     });
   });
 
-  it("should load the simple-list charm", async () => {
+  it("should load the ct-list charm", async () => {
     const { page } = shell.get();
 
     // Navigate to the charm

--- a/packages/patterns/simple-list.tsx
+++ b/packages/patterns/simple-list.tsx
@@ -1,92 +1,63 @@
-import { h, handler, JSONSchema, NAME, recipe, UI } from "commontools";
+/// <cts-enable />
+import {
+  Cell,
+  Default,
+  h,
+  handler,
+  NAME,
+  recipe,
+  toSchema,
+  UI,
+} from "commontools";
 
-const ItemSchema = {
-  type: "object",
-  properties: {
-    title: { type: "string" },
-  },
-  required: ["title"],
-} as const satisfies JSONSchema;
+interface Item {
+  title: string;
+}
 
-const ListSchema = {
-  type: "object",
-  properties: {
-    title: {
-      type: "string",
-      default: "My List",
-      asCell: true,
-    },
-    items: {
-      type: "array",
-      items: ItemSchema,
-      default: [],
-      asCell: true,
-    },
-  },
-  required: ["title", "items"],
-} as const satisfies JSONSchema;
+interface ListInput {
+  title: Default<string, "My List">;
+  items: Default<Item[], []>;
+}
 
-const ResultSchema = {
-  type: "object",
-  properties: {
-    title: { type: "string" },
-    items: { type: "array", items: ItemSchema },
-  },
-  required: ["title", "items"],
-} as const satisfies JSONSchema;
+interface ListOutput extends ListInput {}
 
-// Example of a handler to add to the list manually, if you set `readonly` the list will lose its in-built add form
-const addItem = handler(
-  {
-    type: "object",
-    properties: {
-      detail: {
-        type: "object",
-        properties: { message: { type: "string" } },
-        required: ["message"],
-      },
-    },
-    required: ["detail"],
-  },
-  {
-    type: "object",
-    properties: {
-      items: { type: "array", items: ItemSchema, asCell: true },
-    },
-    required: ["items"],
-  },
-  (e, state) => {
-    const newItem = e.detail?.message?.trim();
-    if (newItem) {
-      const currentItems = state.items.get();
-      state.items.set([...currentItems, { title: newItem }]);
-    }
+type MessageEvent = { detail: { message: string } };
+
+const addItem = handler<MessageEvent, { items: Cell<Item[]> }>((e, state) => {
+  const newItem = e.detail?.message?.trim();
+  if (newItem) {
+    const currentItems = state.items.get();
+    state.items.set([...currentItems, { title: newItem }]);
+  }
+});
+
+export default recipe(
+  toSchema<ListInput>(),
+  toSchema<ListOutput>(),
+  ({ title, items }) => {
+    return {
+      [NAME]: title,
+      [UI]: (
+        <common-vstack gap="md" style="padding: 1rem; max-width: 600px;">
+          <ct-input
+            $value={title}
+            placeholder="List title"
+            customStyle="font-size: 24px; font-weight: bold;"
+          />
+
+          <ct-card>
+            <common-vstack gap="sm">
+              <ct-list
+                $value={items}
+                editable
+                title="Items"
+              />
+            </common-vstack>
+          </ct-card>
+        </common-vstack>
+      ),
+      title,
+      items,
+    };
   },
 );
-
-export default recipe(ListSchema, ResultSchema, ({ title, items }) => {
-  return {
-    [NAME]: title,
-    [UI]: (
-      <common-vstack gap="md" style="padding: 1rem; max-width: 600px;">
-        <ct-input
-          $value={title}
-          placeholder="List title"
-          customStyle="font-size: 24px; font-weight: bold;"
-        />
-
-        <ct-card>
-          <common-vstack gap="sm">
-            <ct-list
-              $value={items}
-              editable
-              title="Items"
-            />
-          </common-vstack>
-        </ct-card>
-      </common-vstack>
-    ),
-    title,
-    items,
-  };
-});


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enabled CTS support in all pattern recipes by updating schema definitions and handler usage for better type safety and consistency.

- **Refactors**
 - Replaced manual JSONSchema objects with toSchema utility in both instantiate-recipe and simple-list.
 - Updated handler signatures to use typed interfaces.
 - Removed redundant schema code for cleaner recipes.

<!-- End of auto-generated description by cubic. -->

