### PR TITLE
prevent derive wrapping on jsx event handlers

### DIFF
--- a/packages/js-runtime/test/fixtures/ast-transform/event-handler-no-derive.expected.tsx
+++ b/packages/js-runtime/test/fixtures/ast-transform/event-handler-no-derive.expected.tsx
@@ -1,0 +1,53 @@
+/// <cts-enable />
+import { Cell, Default, h, handler, recipe, UI, derive, JSONSchema } from "commontools";
+declare global {
+    namespace JSX {
+        interface IntrinsicElements {
+            "ct-button": any;
+        }
+    }
+}
+const handleClick = handler({
+    type: "object",
+    additionalProperties: true
+} as const satisfies JSONSchema, {
+    type: "object",
+    properties: {
+        count: {
+            type: "number",
+            asCell: true
+        }
+    },
+    required: ["count"]
+} as const satisfies JSONSchema, (_, { count }) => {
+    count.set(count.get() + 1);
+});
+export default recipe({
+    type: "object",
+    properties: {
+        count: {
+            type: "number",
+            default: 0
+        }
+    },
+    required: ["count"]
+} as const satisfies JSONSchema, ({ count }) => {
+    return {
+        [UI]: (<div>
+          {/* Regular JSX expression - should be wrapped in derive */}
+          <span>Count: {commontools_1.derive(count, count => count + 1)}</span>
+          
+          {/* Event handler with OpaqueRef - should NOT be wrapped in derive */}
+          <ct-button onClick={handleClick({ count })}>
+            Click me
+          </ct-button>
+          
+          {/* Event handler inside map - should NOT be wrapped in derive */}
+          {[1, 2, 3].map((n) => (<ct-button key={n} onClick={handleClick({ count })}>
+              Button {n}
+            </ct-button>))}
+        </div>),
+        count,
+    };
+});
+

--- a/packages/js-runtime/test/fixtures/ast-transform/event-handler-no-derive.input.tsx
+++ b/packages/js-runtime/test/fixtures/ast-transform/event-handler-no-derive.input.tsx
@@ -1,0 +1,41 @@
+/// <cts-enable />
+import { Cell, Default, h, handler, recipe, UI } from "commontools";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "ct-button": any;
+    }
+  }
+}
+
+const handleClick = handler<unknown, { count: Cell<number> }>((_, { count }) => {
+  count.set(count.get() + 1);
+});
+
+export default recipe<{ count: Default<number, 0> }>(
+  "Event Handler Test",
+  ({ count }) => {
+    return {
+      [UI]: (
+        <div>
+          {/* Regular JSX expression - should be wrapped in derive */}
+          <span>Count: {count + 1}</span>
+          
+          {/* Event handler with OpaqueRef - should NOT be wrapped in derive */}
+          <ct-button onClick={handleClick({ count })}>
+            Click me
+          </ct-button>
+          
+          {/* Event handler inside map - should NOT be wrapped in derive */}
+          {[1, 2, 3].map((n) => (
+            <ct-button key={n} onClick={handleClick({ count })}>
+              Button {n}
+            </ct-button>
+          ))}
+        </div>
+      ),
+      count,
+    };
+  },
+);

--- a/packages/js-runtime/typescript/transformer/opaque-ref.ts
+++ b/packages/js-runtime/typescript/transformer/opaque-ref.ts
@@ -2,6 +2,7 @@ import ts from "typescript";
 import { getLogger } from "@commontools/utils/logger";
 import {
   containsOpaqueRef,
+  isEventHandlerJsxAttribute,
   isOpaqueRefType,
   isSimpleOpaqueRefAccess,
 } from "./types.ts";
@@ -607,6 +608,12 @@ export function createOpaqueRefTransformer(
           // Only transform if we're inside a JSX expression
           const hasOpaqueRef = containsOpaqueRef(node, checker);
           const isInJsx = isInsideJsxExpression(node);
+
+          // If this CallExpression is ultimately inside a JSX event handler attribute (e.g., onClick),
+          // do not wrap the entire call in derive. Let child nodes handle OpaqueRefs.
+          if (isInJsx && isEventHandlerJsxAttribute(node)) {
+            return ts.visitEachChild(node, visit, context);
+          }
 
           if (hasOpaqueRef && isInJsx) {
             // log(`Found function call transformation at ${sourceFile.fileName}:${sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1}`);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Stopped automatic derive wrapping for JSX event handler attributes like onClick, so event handlers now receive functions as expected.

- **Bug Fixes**
 - Updated the transformer to skip derive wrapping for event handler props.
 - Added tests to confirm event handlers are not wrapped in derive.

<!-- End of auto-generated description by cubic. -->

