### PR TITLE
Setting up post-deploy CI job to run patterns integration tests against a specific space named after the git sha

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -105,7 +105,6 @@ jobs:
           VITE_BUILD_SOURCEMAPS: "true"
           VITE_STORAGE_TYPE: "schema"
 
-
       - name: 🔐 Process & sign binaries
         if: github.ref == 'refs/heads/main'
         run: |
@@ -425,7 +424,6 @@ jobs:
           deno run --allow-all npm:@sentry/cli --version
           echo "::endgroup::"
 
-
       - name: 📊 Create Toolshed server Sentry release
         run: |
           # Create a release with version based on commit SHA
@@ -448,3 +446,11 @@ jobs:
           username: bastion
           key: ${{ secrets.BASTION_SSH_PRIVATE_KEY }}
           script: /opt/ct/deploy.sh ${{ vars.DEPLOYMENT_ENVIRONMENT }} ${{ github.sha }}
+
+      - name: 🧩 Run post-deploy Patterns integration tests against Toolshed (Staging)
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.BASTION_HOST }}
+          username: bastion
+          key: ${{ secrets.BASTION_SSH_PRIVATE_KEY }}
+          script: /opt/ct/run-pattern-tests-against-toolshed.sh ${{ github.sha }} https://toolshed.saga-castor.ts.net https://toolshed.saga-castor.ts.net

--- a/packages/patterns/integration/all.test.ts
+++ b/packages/patterns/integration/all.test.ts
@@ -8,7 +8,8 @@ import { Identity } from "@commontools/identity";
 const { API_URL } = env;
 
 describe("Compile all recipes", () => {
-  const spaceName = globalThis.crypto.randomUUID();
+  const spaceName = Deno.env.get("SPACE_NAME") ??
+    globalThis.crypto.randomUUID();
 
   for (const file of Deno.readDirSync(join(import.meta.dirname!, ".."))) {
     const { name } = file;

--- a/packages/patterns/integration/ct-list.test.ts
+++ b/packages/patterns/integration/ct-list.test.ts
@@ -19,7 +19,8 @@ describe("ct-list integration test", () => {
 
   beforeAll(async () => {
     const { identity } = shell.get();
-    spaceName = globalThis.crypto.randomUUID();
+    spaceName = Deno.env.get("SPACE_NAME") ??
+      globalThis.crypto.randomUUID();
 
     // Register the ct-list charm once for all tests
     charmId = await registerCharm({

--- a/packages/patterns/integration/instantiate-recipe.test.ts
+++ b/packages/patterns/integration/instantiate-recipe.test.ts
@@ -19,7 +19,8 @@ describe("instantiate-recipe integration test", () => {
 
   beforeAll(async () => {
     const { identity } = shell.get();
-    spaceName = globalThis.crypto.randomUUID();
+    spaceName = Deno.env.get("SPACE_NAME") ??
+      globalThis.crypto.randomUUID();
 
     // Register the instantiate-recipe charm
     charmId = await registerCharm({


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a post-deploy CI job to run patterns integration tests against a space named after the git SHA for each deployment.

- **CI Improvements**
 - Updated workflow to trigger integration tests after deployment.
 - Tests now use a consistent space name based on the current git SHA.

<!-- End of auto-generated description by cubic. -->

