### PR TITLE
chore: Shell: Add an optional render debugger to highlight when components change

### DIFF
--- a/packages/shell/src/lib/debug-controller.ts
+++ b/packages/shell/src/lib/debug-controller.ts
@@ -1,0 +1,45 @@
+import { ReactiveController, type ReactiveControllerHost } from "lit";
+
+const DEBUG_BORDER_WIDTH = 5;
+const ANIMATION_DURATION_SECONDS = 1.5;
+const ANIMATION_FALLOFF_PERCENT = 0.5;
+
+const keyframes = [
+  {
+    outline: `rgba(255, 0, 0, 1) ${DEBUG_BORDER_WIDTH}px solid`,
+  },
+  {
+    outline: `rgba(255, 0, 0, 1) ${DEBUG_BORDER_WIDTH}px solid`,
+    offset: ANIMATION_FALLOFF_PERCENT,
+  },
+  {
+    outline: `rgba(255, 0, 0, 0) ${DEBUG_BORDER_WIDTH}px solid`,
+  },
+];
+
+// Renders an outline on host LitElement on every render.
+export class DebugController implements ReactiveController {
+  #host: ReactiveControllerHost & HTMLElement;
+  #connected = false;
+
+  constructor(host: ReactiveControllerHost & HTMLElement, enabled: boolean) {
+    this.#host = host;
+    if (enabled) {
+      this.#host.addController(this);
+    }
+  }
+
+  hostConnected(): void {
+    this.#connected = true;
+  }
+  hostDisconnected(): void {
+    this.#connected = false;
+  }
+
+  hostUpdated() {
+    if (!this.#connected) {
+      return;
+    }
+    this.#host.animate(keyframes, ANIMATION_DURATION_SECONDS * 1000);
+  }
+}

--- a/packages/shell/src/views/BaseView.ts
+++ b/packages/shell/src/views/BaseView.ts
@@ -1,9 +1,16 @@
 import { LitElement } from "lit";
 import { Command } from "../lib/app/commands.ts";
+import { DebugController } from "../lib/debug-controller.ts";
+
+// Set to `true` to render outlines everytime a
+// LitElement renders.
+const DEBUG_RENDERER = false;
 
 export const SHELL_COMMAND = "shell-command";
 
 export class BaseView extends LitElement {
+  // deno-lint-ignore no-unused-vars
+  #debugController = new DebugController(this, DEBUG_RENDERER);
   command(command: Command) {
     this.dispatchEvent(
       new CustomEvent(SHELL_COMMAND, {

--- a/packages/shell/src/views/CharmView.ts
+++ b/packages/shell/src/views/CharmView.ts
@@ -1,7 +1,6 @@
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
 import { BaseView } from "./BaseView.ts";
-import { RuntimeInternals } from "../lib/runtime.ts";
 import { CharmController } from "@commontools/charm/ops";
 
 export class XCharmView extends BaseView {

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -10,7 +10,6 @@ import {
   StorageInspectorUpdateEvent,
 } from "../lib/storage-inspector.ts";
 import "../components/Flex.ts";
-import { CharmController } from "@commontools/charm/ops";
 
 type ConnectionStatus =
   | "connecting"

--- a/packages/shell/src/views/InspectorView.ts
+++ b/packages/shell/src/views/InspectorView.ts
@@ -1,7 +1,8 @@
-import { css, html, LitElement } from "lit";
+import { css, html } from "lit";
 import { property, state } from "lit/decorators.js";
 import { StorageInspectorState } from "../lib/storage-inspector.ts";
 import { ResizableDrawerController } from "../lib/resizable-drawer-controller.ts";
+import { BaseView } from "./BaseView.ts";
 
 /**
  * Network inspector view for monitoring storage operations in real-time.
@@ -15,7 +16,7 @@ import { ResizableDrawerController } from "../lib/resizable-drawer-controller.ts
  * Features a resizable drawer interface with keyboard shortcuts
  * and operation counters for tracking activity.
  */
-export class XInspectorView extends LitElement {
+export class XInspectorView extends BaseView {
   static override styles = css`
     :host {
       position: fixed;

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -1,6 +1,6 @@
-import { css, html, LitElement, PropertyValues } from "lit";
+import { css, html, PropertyValues } from "lit";
 import { applyCommand, AppState } from "../lib/app/mod.ts";
-import { SHELL_COMMAND } from "./BaseView.ts";
+import { BaseView, SHELL_COMMAND } from "./BaseView.ts";
 import { Command, isCommand } from "../lib/app/commands.ts";
 import { API_URL } from "../lib/env.ts";
 import { AppUpdateEvent } from "../lib/app/events.ts";
@@ -14,7 +14,7 @@ import { RuntimeInternals } from "../lib/runtime.ts";
 // Handles processing `Command`s from children elements,
 // updating the `AppState`, and providing changes
 // to children elements.
-export class XRootView extends LitElement {
+export class XRootView extends BaseView {
   static override styles = css`
     :host {
       display: block;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added an optional render debugger that highlights components with a red outline whenever they re-render, making it easier to spot updates during development.

- **New Features**
 - Introduced a DebugController for LitElement views to animate outlines on render.
 - Enabled with a single flag in BaseView; disabled by default.

<!-- End of auto-generated description by cubic. -->

