### PR TITLE
chore: Add initial telemetry probes

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -788,7 +788,15 @@ export class Runner implements IRunner {
         }
       };
 
-      addCancel(this.runtime.scheduler.addEventHandler(handler, streamLink));
+      const wrappedHandler = Object.assign(handler, {
+        reads,
+        writes,
+        module,
+        recipe,
+      });
+      addCancel(
+        this.runtime.scheduler.addEventHandler(wrappedHandler, streamLink),
+      );
     } else {
       if (isRecord(inputs) && "$event" in inputs) {
         throw new Error(
@@ -880,7 +888,15 @@ export class Runner implements IRunner {
         }
       };
 
-      addCancel(this.runtime.scheduler.schedule(action, { reads, writes }));
+      const wrappedAction = Object.assign(action, {
+        reads,
+        writes,
+        module,
+        recipe,
+      });
+      addCancel(
+        this.runtime.scheduler.schedule(wrappedAction, { reads, writes }),
+      );
     }
   }
 

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -2,12 +2,29 @@
 // to record events that can be subscribed to in other
 // contexts to visualize or log events inside the runtime.
 
+import { IMemoryChange } from "./storage/interface.ts";
+import {
+  Action,
+  AnnotatedAction,
+  AnnotatedEventHandler,
+  EventHandler,
+} from "./scheduler.ts";
+
 // Types of markers that can be submitted by the runtime.
 // NOTE: Only one type currently supported for illustrative
 // purposes. We can extend this with additional types.
 export type RuntimeTelemetryMarker = {
   type: "scheduler.run";
-  action: string;
+  action: Action | AnnotatedAction;
+  error?: string;
+} | {
+  type: "cell.update";
+  change: IMemoryChange;
+  error?: string;
+} | {
+  type: "scheduler.invocation";
+  handler: EventHandler | AnnotatedEventHandler;
+  error?: string;
 };
 
 export type RuntimeTelemetryMarkerResult = RuntimeTelemetryMarker & {

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -16,6 +16,12 @@ import {
   StorageInspectorUpdateEvent,
 } from "./storage-inspector.ts";
 import { setupIframe } from "./iframe-ctx.ts";
+import { getLogger } from "@commontools/utils/logger";
+
+const logger = getLogger("shell.telemetry", {
+  enabled: false,
+  level: "debug",
+});
 
 async function createSession(
   root: Identity,
@@ -83,10 +89,12 @@ export class RuntimeInternals extends EventTarget {
 
   #onTelemetry = (event: Event) => {
     this.#check();
-    this.#telemetryMarkers.push((event as RuntimeTelemetryEvent).marker);
+    const marker = (event as RuntimeTelemetryEvent).marker;
+    this.#telemetryMarkers.push(marker);
     // Dispatch an event here so that views may subscribe,
     // and know when to rerender, fetching the markers
     this.dispatchEvent(new CustomEvent("telemetryupdate"));
+    logger.log(marker.type, marker);
   };
 
   #check() {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added telemetry probes to the scheduler and runtime to record key events like action runs, cell updates, and event handler invocations.

- **New Features**
 - Scheduler now submits telemetry markers for action execution, cell changes, and event handler calls.
 - Telemetry events are logged and can be subscribed to for visualization or debugging.

<!-- End of auto-generated description by cubic. -->

