### PR TITLE
chore: Use waitForSelectors for pattern integration tests to be less time dependent

### DIFF
--- a/packages/integration/env.ts
+++ b/packages/integration/env.ts
@@ -13,6 +13,11 @@ export const FRONTEND_URL = ensureTrailing(
 
 export const HEADLESS = envToBool(Deno.env.get("HEADLESS"));
 
+// Some tests take a SPACE_NAME, targeting a specific space.
+// If not defined, uses a random UUID.
+export const SPACE_NAME = Deno.env.get("SPACE_NAME") ??
+  globalThis.crypto.randomUUID();
+
 function ensureTrailing(value: string): string {
   return value.substr(-1) === "/" ? value : `${value}/`;
 }

--- a/packages/patterns/integration/all.test.ts
+++ b/packages/patterns/integration/all.test.ts
@@ -5,12 +5,9 @@ import { join } from "@std/path";
 import { assert } from "@std/assert";
 import { Identity } from "@commontools/identity";
 
-const { API_URL } = env;
+const { API_URL, SPACE_NAME } = env;
 
 describe("Compile all recipes", () => {
-  const spaceName = Deno.env.get("SPACE_NAME") ??
-    globalThis.crypto.randomUUID();
-
   for (const file of Deno.readDirSync(join(import.meta.dirname!, ".."))) {
     const { name } = file;
     if (!name.endsWith(".tsx")) continue;
@@ -18,7 +15,7 @@ describe("Compile all recipes", () => {
     it(`Executes: ${name}`, async () => {
       const identity = await Identity.generate();
       const charmId = await registerCharm({
-        spaceName: spaceName,
+        spaceName: SPACE_NAME,
         apiUrl: new URL(API_URL),
         identity: identity,
         source: await Deno.readTextFile(

--- a/packages/patterns/integration/ct-list.test.ts
+++ b/packages/patterns/integration/ct-list.test.ts
@@ -8,23 +8,20 @@ import { beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { assert, assertEquals } from "@std/assert";
 
-const { API_URL, FRONTEND_URL } = env;
+const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
 describe("ct-list integration test", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
 
-  let spaceName: string;
   let charmId: string;
 
   beforeAll(async () => {
     const { identity } = shell.get();
-    spaceName = Deno.env.get("SPACE_NAME") ??
-      globalThis.crypto.randomUUID();
 
     // Register the ct-list charm once for all tests
     charmId = await registerCharm({
-      spaceName: spaceName,
+      spaceName: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity: identity,
       source: await Deno.readTextFile(
@@ -41,26 +38,24 @@ describe("ct-list integration test", () => {
     const { page } = shell.get();
 
     // Navigate to the charm
-    await page.goto(`${FRONTEND_URL}${spaceName}/${charmId}`);
+    await page.goto(`${FRONTEND_URL}${SPACE_NAME}/${charmId}`);
     await page.applyConsoleFormatter();
 
     // Login
     const state = await shell.login();
-    assertEquals(state.spaceName, spaceName);
+    assertEquals(state.spaceName, SPACE_NAME);
     assertEquals(state.activeCharmId, charmId);
 
-    // Wait for charm to load and verify ct-list exists
-    await sleep(5000);
-    const ctList = await page.$("ct-list", { strategy: "pierce" });
-    assert(ctList, "Should find ct-list component");
+    await page.waitForSelector("ct-list", { strategy: "pierce" });
   });
 
   it("should add items to the list", async () => {
     const { page } = shell.get();
 
     // Find the add item input in ct-list
-    const addInput = await page.$(".add-item-input", { strategy: "pierce" });
-    assert(addInput, "Should find add item input");
+    const addInput = await page.waitForSelector(".add-item-input", {
+      strategy: "pierce",
+    });
 
     // Add first item
     await addInput.click();

--- a/packages/patterns/integration/instantiate-recipe.test.ts
+++ b/packages/patterns/integration/instantiate-recipe.test.ts
@@ -8,23 +8,20 @@ import { beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { assert, assertEquals } from "@std/assert";
 
-const { API_URL, FRONTEND_URL } = env;
+const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
 describe("instantiate-recipe integration test", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
 
-  let spaceName: string;
   let charmId: string;
 
   beforeAll(async () => {
     const { identity } = shell.get();
-    spaceName = Deno.env.get("SPACE_NAME") ??
-      globalThis.crypto.randomUUID();
 
     // Register the instantiate-recipe charm
     charmId = await registerCharm({
-      spaceName: spaceName,
+      spaceName: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity: identity,
       source: await Deno.readTextFile(
@@ -41,12 +38,12 @@ describe("instantiate-recipe integration test", () => {
     const { page } = shell.get();
 
     // Navigate to the charm
-    await page.goto(`${FRONTEND_URL}${spaceName}/${charmId}`);
+    await page.goto(`${FRONTEND_URL}${SPACE_NAME}/${charmId}`);
     await page.applyConsoleFormatter();
 
     // Login
     const state = await shell.login();
-    assertEquals(state.spaceName, spaceName);
+    assertEquals(state.spaceName, SPACE_NAME);
     assertEquals(state.activeCharmId, charmId);
 
     // Wait for charm to load and render
@@ -56,22 +53,18 @@ describe("instantiate-recipe integration test", () => {
     const urlBefore = await page.evaluate(() => globalThis.location.href);
     console.log("URL before action:", urlBefore);
 
-    // Find and type in the input using data attribute with pierce strategy
-    const input = await page.$("[data-ct-input]", {
+    const input = await page.waitForSelector("[data-ct-input]", {
       strategy: "pierce",
     });
-    assert(input, "Should find input element");
 
     await input.type("New counter");
 
     // Wait for input to be processed
     await sleep(200);
 
-    // Find and click the button using data attribute with pierce strategy
-    const button = await page.$("[data-ct-button]", {
+    const button = await page.waitForSelector("[data-ct-button]", {
       strategy: "pierce",
     });
-    assert(button, "Should find button element");
 
     await button.click();
 
@@ -89,7 +82,7 @@ describe("instantiate-recipe integration test", () => {
     );
 
     // Verify we're now on a counter page by checking for counter-specific elements
-    const counterResult = await page.$("#counter-result", {
+    const counterResult = await page.waitForSelector("#counter-result", {
       strategy: "pierce",
     });
     assert(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated pattern integration tests to use waitForSelector instead of fixed sleep times, making tests more reliable and less dependent on timing.

- **Refactors**
 - Replaced sleep calls with waitForSelector in all relevant test files.
 - Centralized space name generation for consistency across tests.

<!-- End of auto-generated description by cubic. -->

