### PR TITLE
docs(runner): add behavioral specs for runner

### DIFF
--- a/docs/spec/runner/README.md
+++ b/docs/spec/runner/README.md
@@ -1,0 +1,19 @@
+Runner Spec
+
+- Scope: `packages/runner` core runtime behavior. Focus on Cell abstraction,
+  data updating and links, schema-driven reads (asCell/asStream/anyOf), and the
+  scheduler. Storage backends and docs UI are out of scope except for the
+  high-level transactions API used by runner.
+
+- Audience: contributors building recipes, modules, or runtime features that
+  need precise semantics for reads/writes, link resolution, and reactivity.
+
+Contents
+
+- `cell.md`: Cell abstraction and API semantics
+- `data-updating-and-links.md`: Write normalization and link handling
+- `schema.md`: Schema-driven read behavior
+- `scheduler.md`: Reactive dependency tracking and execution
+- `transactions.md`: Transactions contract used by runner
+- `builder.md`: Behavioral spec of builder authoring model
+- `runner.md`: Runner engine behavior (process cells, nodes, handlers)

--- a/docs/spec/runner/builder.md
+++ b/docs/spec/runner/builder.md
@@ -1,0 +1,133 @@
+Builder (Behavioral Spec)
+
+- Scope: High-level recipe authoring model, opaque references, node
+  instantiation, and how builder artifacts translate into executable graphs.
+  Behaviorally specifies how to construct recipes, modules, and cells for a new
+  implementation.
+
+Core Abstractions
+
+- Recipe: A declarative graph with input schema, output schema, initial
+  defaults, and a list of nodes. Recipes serialize and can be registered and
+  rehydrated at runtime.
+- Module: Executable unit. Types include: javascript (function), recipe (nested
+  recipe), ref (registry lookup), raw (provides an Action factory), passthrough
+  (wire values), isolated/passthrough as needed by environment. Each module may
+  have argument/result schemas.
+- OpaqueRef: Typed placeholders for values (cells/streams/primitives) used
+  during recipe construction. They support `.set`, `.key`, `.setDefault`,
+  `.setSchema`, and can connect to NodeRefs. They serialize to allow
+  re-materialization into runtime bindings.
+- Node: A module invocation with bound input/output shapes expressed as JSON
+  containing OpaqueRefs, links, or literals.
+
+Recipe Construction API
+
+- `recipe(argumentSchema, [resultSchema], fn)`: Creates a factory that, when
+  invoked, yields a Recipe object. Within `fn`, authors operate on an
+  `OpaqueRef` representing the argument, construct outputs using OpaqueRefs and
+  literals, and compose modules.
+- `lift`, `handler`, `derive`, `compute`, `render`: Builder utilities to
+  construct modules from functions, define event handlers/transformations, and
+  renderers. Lifted code runs within a frame that provides a cause (used for
+  causal ids) and materialization helpers.
+- `cell(schema?, name?, value?)`: Produces an `OpaqueRef` that represents a cell
+  to be created; new implementations must associate it with a runtime space and
+  tx available from the current builder frame; optionally set an initial value.
+- Built-ins: `str`, `ifElse`, `llm`, `generateObject`, `fetchData`,
+  `streamData`, `compileAndRun`, `navigateTo` represent common modules with
+  standardized shapes and schemas.
+
+Frames and Materialization
+
+- Builder operations occur within a “frame” capturing context: current recipe,
+  cause for identity, space, and a materialize function to turn a path into a
+  query result proxy. Frames nest (e.g., lifted code, handlers) and propagate
+  cause information for deterministic identities.
+- OpaqueRefs created inside a frame must capture the frame and serialize with
+  their bindings (cell link + path, defaults, schema, nodes referencing them).
+
+Graph Extraction
+
+- After `fn` completes, the system traverses the constructed value graph to
+  collect:
+  - Cells and ShadowRefs referenced by OpaqueRefs.
+  - NodeRefs (module invocations) connected to these cells via input/output
+    bindings.
+  - Names/paths for OpaqueRefs: Inputs receive `argument` path; internal cells
+    receive `internal/...` paths, with deterministic but implementation-defined
+    identifiers; outputs may be aliased to `internal` or mapped to `result`.
+- Apply input interface to outputs so types/schemas flow from inputs to outputs;
+  augment names based on node assignments for usability.
+
+Schemas
+
+- `argumentSchema` describes the input shape; `resultSchema` describes the
+  output shape. During construction, builder should propagate schemas into
+  OpaqueRefs and sanitize schemas to ensure no `asCell/asStream` wrappers are
+  serialized where not intended.
+- Defaults: Extract default values from schemas to seed initial internal state
+  for recipes at runtime.
+
+Serialization
+
+- Recipes and modules must serialize to pure data: modules serialize by type and
+  implementation identifier/body; recipes serialize with nodes, schemas, and
+  enough metadata to re-materialize frames and bindings within the runtime.
+
+Constraints
+
+- Builder functions must throw if invoked outside an active frame (e.g.,
+  creating a cell outside a lifted function or handler).
+- Names/paths chosen during extraction must be stable across runs for a given
+  recipe structure to avoid unnecessary churn; however, perfect stability is not
+  required provided semantic links are preserved.
+
+Examples
+
+- Recipe Extraction
+  - Author code:
+    - `recipe({ argsSchema }, (input) => { const c = cell(...); return { out: compute(f)(input.x, c) }; })`
+  - Builder behavior:
+    1. Frame created; `input` is OpaqueRef with schema.
+    2. `cell(...)` creates an OpaqueRef bound to frame; registered as internal
+       cell.
+    3. `compute(...)(...)` constructs a NodeRef with inputs/outputs referencing
+       OpaqueRefs.
+    4. After fn returns, traversal collects OpaqueRefs and NodeRefs; assigns
+       paths: `input` -> `argument`, internal cell -> `internal/__#0`, output
+       mapping -> `result`.
+    5. Recipe serializes to JSON with nodes and bindings using sanitized
+       schemas.
+
+- map-like Raw Module
+  - Author passes a closure recipe as an input (e.g., a map transformation).
+  - Builder behavior:
+    - Traversal sees a nested recipe in an input value; marks closure recipes
+      and their OpaqueRefs, creating ShadowRefs when crossing frame boundaries.
+      Names and paths assigned as if those were internal nodes bound under the
+      current frame.
+
+  Code
+  ```ts
+  const mapModule: Module = {
+    type: "raw",
+    implementation: (
+      inputsCell,
+      send,
+      addCancel,
+      ctx,
+      processCell,
+      runtime,
+    ) => {
+      const action = (tx) => {
+        const items = inputsCell.key("items").get();
+        const fnRecipe = inputsCell.key("fn").get(); // closure recipe
+        // Runner will have extracted fnRecipe and its OpaqueRefs as shadow refs
+        const mapped = items.map((x) => /* invoke fnRecipe on x */ x);
+        send(tx, { mapped });
+      };
+      return action;
+    },
+  };
+  ```

--- a/docs/spec/runner/cell.md
+++ b/docs/spec/runner/cell.md
@@ -1,0 +1,135 @@
+Cell Abstraction (Behavioral Spec)
+
+- File: `packages/runner/src/cell.ts`
+- Purpose: A typed, reactive façade over a location in storage identified by a
+  normalized link (space + entity URI + path + type), optionally constrained by
+  a JSON schema. This document specifies observable behaviors and invariants for
+  a new implementation; internal structure is flexible as long as behavior is
+  preserved.
+
+Core Concepts
+
+- Link-backed: Every `Cell<T>` is defined by a normalized identity (space, URI,
+  type, path, schema, rootSchema). Methods operate against that identity,
+  resolving redirects/aliases as defined in the Links spec.
+- Transactions: Mutations require an open transaction bound to the cell. Reads
+  may use ephemeral transactions for dependency tracking.
+- Schema-aware reads: `get()` must interpret schema features
+  (asCell/asStream/anyOf/defaults) and follow redirects for the final path
+  segment where required.
+- Sync: `sync()` should opportunistically request storage synchronization for
+  non-`data:` entities.
+- Reactivity: `sink(cb)` re-invokes `cb` when any document read during
+  evaluation changes.
+
+API Summary
+
+- `get(): Readonly<T>`: Returns current value after schema-driven
+  transformation. Should trigger `sync()` if needed.
+- `set(value) / send(value)`: Assigns a new value respecting link redirects and
+  normalization rules. Requires `tx`.
+- `update(partial)`: For object cells; initializes `{}` when permitted; applies
+  per-key updates. Requires `tx`.
+- `push(...values)`: For array cells; creates `[]` if needed; appends values
+  with entity conversion and link semantics. Requires `tx`.
+- `equals(other)`: Structural equality by link identity via `areLinksSame`.
+- `key(k)`: Returns a child cell addressed by extended path, with child schema
+  calculated via `runtime.cfc.getSchemaAtPath(schema, [k], rootSchema)` and
+  preserved `rootSchema`.
+- `asSchema(schema?)`: Returns a new cell with provided schema and `rootSchema`
+  set; resets `synced` false so future reads re-evaluate with new schema rules.
+- `withTx(tx)`: Binds a transaction for subsequent writes.
+- `sink(cb)`: Subscribes based on reads observed during evaluation; re-invokes
+  on changes.
+- `sync()`: Marks as synced and asks storage to synchronize unless `data:` URI.
+- Link queries: Must support producing a live query result proxy for raw reads
+  and serializable links for the cell identity (and write-redirect destination
+  when requested).
+- Raw access: `getRaw(options?)` and `setRaw(value)` bypass schema validation
+  and alias following for writes/reads.
+- Source cell: `getSourceCell(schema?)`/`setSourceCell(cell)` allow mapping to
+  original source when schema-based extraction returns derived cells. Useful for
+  edits that should target origin.
+- Metadata: `runtime`, `tx`, `schema`, `rootSchema`, `space`, `entityId`,
+  `sourceURI`, `path`. Debug helpers: `value` and `cellLink`. `copyTrap` throws
+  to prevent copying/traversal of cells unexpectedly.
+- Opaque refs: `[toOpaqueRef]()` returns a stable opaque reference for identity
+  comparison or serialization.
+
+Read/Write Semantics
+
+- Reads: Must follow intermediary links and write-redirects on the leaf to
+  ensure subsequent writes target the same destination. Apply schema defaults
+  when undefined.
+- Writes: Must normalize new values (unwrap proxies, convert cells to links,
+  apply `[ID]`/`ID_FIELD`, handle `data:` links), resolve write-redirects,
+  compute minimal change sets, and write them transactionally.
+- Links: Provide canonical link serialization and equality based on normalized
+  identity.
+
+Common Patterns
+
+- Object edits: `cell.update({title: "New"})` is equivalent to
+  `cell.key("title").set("New")` per key with schema-aware writes.
+- Array edits: `cell.push(itemOrCell)` appends; if first write, ensures array
+  exists; supports inserting objects that will be turned into entities using
+  `[ID]` or `[ID_FIELD]` rules.
+- Subcells: `cell.key("foo").asSchema(childSchema).withTx(tx).set(value)`
+  targets nested structures under a different schema while preserving identity
+  semantics.
+
+Constraints and Errors
+
+- Mutations without `tx` must throw. Updating non-objects with `update` must
+  throw. Pushing into non-array must throw. Implementations should trap
+  structural traversal of Cells to surface misuse.
+
+Additional Requirements
+
+- Returned object/array read views must be frozen or otherwise immutable and
+  carry the ability to reconstruct a `Cell` at the same identity (e.g., via a
+  symbol method) and to produce an opaque reference suitable for identity
+  comparison/serialization.
+
+Examples
+
+- asCell Read/Write Path
+  - Schema:
+    `{ properties: { current: { asCell: true, $ref: '#/defs/Item' } }, defs: { Item: { type: 'object', properties: { name: { type: 'string' }}}}}`
+  - Read: `cell.key('current').get()` yields a Cell pointing to the referenced
+    item (after following redirects).
+    `cell.key('current').get().key('name').get()` returns the live name.
+  - Write: `cell.key('current').get().key('name').withTx(tx).set('X')` writes to
+    the referenced item’s `name`, not the alias. ASCII
+  ```
+  current (alias) -> Item#42
+  Item#42.name = "Old"
+        |
+        v
+  set name("X")
+        |
+        v
+  write redirect follows -> Item#42.name := "X"
+  ```
+
+- Array Push with ID_FIELD
+  - Given `list` is an array cell,
+    `list.push({ [ID_FIELD]: 'slug', slug: 'a', title: 'A' })` searches siblings
+    for an element whose `slug` equals `'a'`; if found, updates that entity;
+    else creates a new entity with a random id and sets the array element to a
+    link to it.
+  ```ts
+  const tx = runtime.edit();
+  list.withTx(tx).push({ [ID_FIELD]: "slug", slug: "a", title: "A" });
+  tx.commit();
+  ```
+
+Gotchas
+
+- copyTrap: Cells should not be traversed as plain objects. Attempting to
+  spread/iterate a Cell should throw early to reveal misuse.
+- Source cell optionality: `getSourceCell()` is best-effort; do not rely on it
+  being present for all read projections.
+- Read-only defaults: Default values materialized from schema are immutable
+  views; mutating them directly is a no-op—use writes on the corresponding
+  cells.

--- a/docs/spec/runner/data-updating-and-links.md
+++ b/docs/spec/runner/data-updating-and-links.md
@@ -1,0 +1,124 @@
+Data Updating and Links (Behavioral Spec)
+
+- Scope: Define observable behavior for normalization of inputs, interpretation
+  of links and aliases, conversion to entities, diffing strategy, and
+  application of change sets for writes. Internal function structure is
+  flexible; behavior must match this spec.
+
+Link Forms
+
+- Detected link-like values: cells, sigil links (`{"/": {"link@1": ...}}`),
+  legacy JSON cell links, legacy alias objects, `DocImpl` (deprecated), query
+  result proxies, or entity id `{"/": string}`.
+- Normalization: `parseLink(value, base?)` produces a `NormalizedFullLink` with
+  `space`, `id`, `type`, `path`, optional `schema` and `rootSchema`, and
+  optional `overwrite: "redirect"` for write-redirect links.
+- Write-redirects: `isWriteRedirectLink(value)` returns true for legacy `$alias`
+  and sigil links with `overwrite: "redirect"`.
+
+Read Resolution
+
+- Resolution must follow links encountered along the path; cycles or excessive
+  hops must fall back to a static empty data link. Three leaf behaviors must be
+  supported: follow all links; follow only write-redirects; follow none.
+  Resolution must propagate schema hints to reflect destination depth and drop
+  overwrite flags from the final identity.
+
+Normalization and Diff
+
+- Inputs to writes must be normalized prior to diffing. The result is an ordered
+  list of writes `(location, value)` that transforms current state into the
+  desired state. The list should be minimal with respect to observable JSON
+  state.
+
+- High-level behavior:
+  - Circular inputs: detect object reference cycles and serialize repeats as
+    relative links to their first appearance.
+  - ID_FIELD: If input has `[ID_FIELD]: fieldName`, and target is an array, scan
+    siblings for matching `fieldName` value; if found, reuse that entity and
+    diff its value. Else, convert to a fresh entity using a random id.
+  - Links as new value:
+    - Data links: treat link content as the effective input; if content itself
+      is a link, rebase with concatenated path and continue.
+    - Non-data links: if equal to the current link, no-op; otherwise write the
+      link as the new value.
+  - Objects with `[ID]`: Convert to an entity reference using a derived id based
+    on parent/space/path and optional context (excluding array indices when
+    deriving). Emit a write of the link at the current location and a diff of
+    the target entity’s content against the object without `[ID]`.
+  - Arrays: if current is not an array, write `[]` first. Diff per index. If
+    current is longer than new, write `length` and deletions for truncated
+    indices. Respect classification when writing `length` for secret arrays.
+  - Objects: if current is not a plain object or is a link, write `{}` first.
+    Recurse into provided keys; delete keys missing in input.
+  - Primitive/other: compare via `Object.is`; write only when different.
+
+- Redirects in current value: if the current value is a write-redirect, resolve
+  it and perform writes at the destination.
+
+Applying Changes
+
+- Apply the change set in order within the transaction, writing JSON values or
+  `undefined` to delete. Partial writes (e.g., to `length`) must be consistent
+  with overall state.
+
+Helper Conversions
+
+- Provide a conversion utility to serialize cells/streams/query-results to
+  links, preserving cycles with relative links and honoring `toJSON` like
+  JSON.stringify.
+
+Equality and Identity
+
+- Implement link equality across shapes to avoid redundant writes and enable
+  `Cell.equals`.
+
+Guidelines for Authors
+
+- Always provide a transaction for writes. Prefer cell operations. Use
+  `[ID_FIELD]` for array upserts. Avoid bypassing normalization rules.
+
+Examples
+
+- Writing a Data Link
+  - Input: set value to a link with `id: 'data:application/json,{"x":1}'` and
+    `path: ['y']`.
+  - Behavior: resolve data link content; traverse to path `['y']` if present;
+    write the resulting JSON value at the destination. ASCII
+  ```
+  newValue = link(data:{ x: { y: 5 }}, path:['y'])
+  -> resolve -> 5
+  -> write destination := 5
+  ```
+
+- Upsert into Array with ID_FIELD
+  - Input: set array to
+    `[ { [ID_FIELD]: 'slug', slug: 'a', v: 1}, { [ID_FIELD]: 'slug', slug: 'b', v: 2} ]`
+    where the current array contains an entity with `slug: 'b'`.
+  - Behavior: reuse the entity for `b` (diff its content), create a fresh entity
+    for `a`, and set the array to links for both in order; truncate or extend as
+    needed. ASCII
+  ```
+  current: [ Link(Entity b) ]
+  new:     [ {slug:'a',v:1}, {slug:'b',v:2} ] w/ ID_FIELD='slug'
+         -> [ Link(Entity a*), Link(Entity b) ] and diff(Entity b).v := 2
+  ```
+
+- Redirect at Destination
+  - Input: current value is a write-redirect; new value is a primitive.
+  - Behavior: resolve redirect to destination and write primitive there; do not
+    overwrite redirect link at the source.
+  ```
+  src := { $alias: { path: ['dst'] } }
+  set src := 7  =>  write dst := 7 (leave alias intact)
+  ```
+
+Gotchas
+
+- Data links: Treat `data:` links as read-through content only. Writing a
+  `data:` link at a destination should be a structural write (i.e., overwrite
+  with the link) unless normalization explicitly inlines its content.
+- Array length writes: When truncating arrays, ensure index deletions are
+  applied consistently so observers don’t see ghost items.
+- Circular references: For cycles in input objects, use relative links back to
+  the first occurrence to avoid infinite recursion or duplication.

--- a/docs/spec/runner/runner.md
+++ b/docs/spec/runner/runner.md
@@ -1,0 +1,266 @@
+Runner (Behavioral Spec)
+
+- Scope: Execution engine for recipes and modules. Manages process cells,
+  argument/default state, node instantiation, function caching, event handling,
+  and reactive scheduling. This spec defines the observable behaviors for a new
+  implementation.
+
+Top-Level Responsibilities
+
+- Start/stop/update recipe executions bound to a result cell in a memory space.
+- Materialize arguments from literals/links/cells, apply defaults, and maintain
+  internal state.
+- Instantiate nodes according to module types and wire their inputs/outputs.
+- Register actions and event handlers with the scheduler using explicit
+  read/write dependencies.
+- Cache function implementations for javascript modules across invocations.
+
+Process Cell and Result Cell
+
+- For a provided `resultCell`, the runner must maintain a paired “process cell”
+  that stores runtime execution state:
+  - TYPE: recipe identifier used to resolve and resume executions.
+  - spell: link to a causal spell reference for the recipe.
+  - argument: normalized argument (literals and links), writable for live
+    updates.
+  - internal: internal runtime state seeded from schema defaults and
+    recipe.initial.
+  - resultRef: a link to the current result tree or to nested result cells.
+- If `resultCell` already has a `sourceCell`, reuse it as the process cell;
+  otherwise, create one in the same space and link it as the source of
+  `resultCell` for future runs.
+
+Running and Updating
+
+- If called without a recipe and the process cell records a previous recipe id,
+  resolve and resume that recipe; otherwise do nothing and return the provided
+  result cell.
+- If the recipe argument is a link/cell/doc, normalize it into a write-redirect
+  sigil link relative to the process cell so runtime can track live changes.
+- If an execution for the same process cell is already active:
+  - If both recipe id and argument are unchanged, return early without
+    restarting.
+  - If recipe id is unchanged but argument differs, update the process cell’s
+    argument in place and continue running without a restart.
+  - If recipe id is different, stop the previous execution and start a new one.
+
+Defaults and Internal State
+
+- Before node instantiation, compute `internal` by merging:
+  - Defaults extracted from `argumentSchema` (object traversal producing
+    defaults for nested properties).
+  - `recipe.initial.internal` when provided.
+  - Previously stored `internal` values from the process cell.
+- On first run, if no process cell exists, seed TYPE and spell fields and write
+  `internal` and `argument` entries.
+
+Node Instantiation
+
+- For each node in the recipe, instantiate based on `module.type`:
+  - ref: resolve the module from a registry, then instantiate per resolved type.
+  - javascript: obtain implementation (cached function, harness invocation, or
+    provided function), optionally wrap with a module wrapper, and build an
+    Action that:
+    - Reads bound inputs (resolving write-redirect aliases and streams) and
+      materializes argument via schema when provided.
+    - Computes result (sync/async). If result contains OpaqueRefs (i.e., is a
+      recipe subtree), create a sub-recipe from the current frame and run it
+      into a nested result cell; bind output link to process outputs.
+    - Otherwise, send raw result to bound outputs using binding utilities.
+  - raw: call the module’s factory to obtain an Action given input cells, a
+    result sender, addCancel, execution context, process cell, and runtime;
+    schedule with declared read/write cells.
+  - passthrough: forward unwrapped inputs to outputs immediately.
+  - recipe: unwrap nested recipe and run it with unwrapped inputs into a fresh
+    nested result cell; set output binding to link to that result cell.
+
+Streams and Event Handlers
+
+- When any input binding resolves (through write-redirects) to a stream marker
+  value, treat the javascript module as an event handler for that stream:
+  - Subscribe a handler that, upon receiving an event, clones inputs, replaces
+    the stream input with the event payload, pushes a new frame with a fresh
+    cause, materializes arguments using schema if present, runs the module
+    function, and writes outputs (spawning sub-recipes if the result contains
+    OpaqueRefs).
+  - Event handlers should be scheduled via the scheduler’s subscription
+    mechanism keyed to the stream address; the handler receives a transaction
+    when invoked.
+
+Scheduling and Dependencies
+
+- For each instantiated node, determine read/write dependencies by scanning the
+  unwrapped input and output bindings for write-redirect cells/links. Provide
+  these addresses to the scheduler when registering Actions or event handlers so
+  the scheduler can invalidate and re-run nodes in dependency order.
+
+Function Caching and Module Discovery
+
+- The runner must proactively discover and cache function implementations:
+  - For javascript modules with function objects, cache directly on first sight.
+  - For recipe modules, recursively discover nested modules and cache their
+    javascript implementations.
+  - For ref modules, resolve once and cache for reuse.
+  - When recipes appear as values in inputs/outputs (e.g., closures for map),
+    recursively discover and cache functions within those values too.
+
+Stopping Executions
+
+- Runner must track cancel functions for each active result/process pair.
+  Stopping an execution cancels all scheduled actions and event handlers
+  associated with that pair and cleans up internal tracking. Nested executions
+  created for sub-recipes should be canceled when their parent is stopped unless
+  elevated (e.g., navigated to a charm) per product rules.
+
+Error Handling and Logging
+
+- Errors during instantiation, execution, or module resolution should be
+  surfaced with context and should not leave the runner in a
+  partially-initialized state. Non-fatal module resolution failures (e.g.,
+  missing ref) should log warnings and skip that node.
+
+Interoperability
+
+- Runner must work with the scheduler’s run/subscribe APIs and with the
+  storage/transaction semantics described in the Transactions spec.
+  Inputs/outputs bindings use the same link and diffing semantics described in
+  the Data Updating and Links spec.
+
+Cross-Links
+
+- See: `./cell.md` for Cell behavior, `./schema.md` for schema-driven reads,
+  `./data-updating-and-links.md` for write normalization, and
+  `./scheduler.md` for scheduler semantics.
+
+Examples
+
+- Process Cell Lifecycle Code
+  ```ts
+  const tx = runtime.edit();
+  const result = runtime.getCell(space, { name: "demo" }, {}, tx);
+
+  // First run
+  runner.run(tx, recipeFactoryR, { x: 1 }, result);
+  tx.commit();
+
+  // Update argument without restart (same recipe)
+  const tx2 = runtime.edit();
+  runner.run(tx2, undefined, { x: 2 }, result);
+  tx2.commit();
+
+  // Restart with new recipe
+  const tx3 = runtime.edit();
+  runner.run(tx3, recipeFactoryR2, { y: 3 }, result);
+  tx3.commit();
+  ```
+  1. First run:
+     - Input: `run(tx, recipe R, arg A, resultCell)` where `A` is a literal.
+     - Runner creates/uses a process cell `P` in the same space as `resultCell`
+       and sets:
+       - `P.TYPE = R.id`; `P.spell = spellLink(R.id)`;
+       - `P.argument = A` (normalized; links become write-redirect sigils);
+       - `P.internal = merge(defaults(R.argumentSchema).internal, R.initial.internal, P.internal)`;
+       - `P.resultRef = link(result subtree or nested result cell)`.
+     - Instantiate nodes and schedule actions/handlers; return `resultCell`.
+  2. Update argument without restart:
+     - Input: `run(tx, undefined, A2, resultCell)` and `P.TYPE === R.id`.
+     - Runner writes `P.argument = A2` (normalized) and continues; no restart.
+  3. Restart on recipe change:
+     - Input: `run(tx, recipe R2, A3, resultCell)`.
+     - Runner cancels previous subscriptions for `P`; updates `P.TYPE`/`spell`;
+       re-seeds internal defaults; re-instantiates nodes for R2.
+
+  Sequence (first run)
+  - Caller -> Runner: run(R, A, resultCell)
+  - Runner -> Storage: create/find processCell P; seed TYPE, spell, argument,
+    internal; set resultRef
+  - Runner -> Scheduler: schedule actions/handlers with (reads, writes)
+  - Runner -> Caller: return resultCell
+
+  ASCII
+  ```
+  Caller      Runner           Storage          Scheduler
+    |           |                 |                 |
+    | run(R,A)  |                 |                 |
+    |---------> |                 |                 |
+    |           | create P        |                 |
+    |           |---------------> |                 |
+    |           | write fields    |                 |
+    |           |---------------> |                 |
+    |           | deps (reads/writes)               |
+    |           |---------------------------------> |
+    |           |                 |    enqueue      |
+    |           |                 |<----------------|
+    |  return   |                 |                 |
+    |<----------|                 |                 |
+  ```
+
+- JavaScript Node With Stream Input Code
+  ```ts
+  // Module N: (evt is a stream, foo is literal or link)
+  const N: Module = {
+    type: "javascript",
+    argumentSchema: { type: "object", properties: { evt: {}, foo: {} } },
+    resultSchema: { type: "object", properties: { out: {} } },
+    implementation: ({ evt, foo }) => ({ out: `${foo}:${evt.payload}` }),
+  };
+  ```
+  - Context: node N has inputs `{ evt: <link to stream S>, foo: X }` and output
+    `{ out: Y }`.
+  - Runner detects `evt` resolves to a stream marker; registers handler H:
+    1. On event E at S:
+       - Clone inputs; replace `evt` with E; create cause; push frame.
+       - Materialize argument via `argumentSchema` if present, else proxy.
+       - Call function `fn(argument)`; await if Promise.
+       - If result contains OpaqueRefs: build sub-recipe Rsub from frame and run
+         into nested `resultCell_sub`; bind Y to `resultCell_sub` link.
+       - Else: write result to Y directly.
+
+  Sequence (event)
+  - Storage -> Scheduler: write at S triggers H
+  - Scheduler -> Runner/H: invoke H(tx, E)
+  - H -> Harness/Function: fn(argument)
+  - H -> Storage: writes to bound outputs (possibly via sub-recipe)
+
+  ASCII
+  ```
+  Storage (S)   Scheduler     Handler(H)      Storage
+      |             |             |              |
+      | event(E)    |             |              |
+      |-----------> |             |              |
+      |             | invoke H    |              |
+      |             |-----------> |              |
+      |             |   read args |              |
+      |             |<------------|              |
+      |             |   fn(arg)   |              |
+      |             |------------>|              |
+      |             |   writes    |              |
+      |             |<------------|--------------|
+  ```
+
+- Nested Recipe Node Wiring Code
+  ```ts
+  const child = recipe(childArgSchema, (input) => ({ out: input.x }));
+  const parent = recipe(parentArgSchema, (input) => ({
+    nested: { $alias: { path: ["internal"] } },
+  })); // runner instantiates child and stores link in `nested`
+  ```
+  - Module type `recipe` with implementation Rchild; inputs `I` and outputs `O`.
+    Runner:
+    1. Unwraps Rchild and `I` relative to process cell P.
+    2. Creates a fresh child `resultCell_child` in P.space.
+    3. Runs Rchild with `I` into `resultCell_child`.
+    4. Binds parent `O` to a link referencing `resultCell_child`.
+
+  Result
+  - Parent outputs now contain a link; consumers can treat it as a cell and read
+    `resultCell_child.get()` or follow links depending on schema.
+
+Gotchas
+
+- Function caching: If modules are referenced by id and later change their
+  implementation, ensure cache invalidation on recipe/module update events.
+- Event handler reentrancy: Avoid long-running handlers blocking scheduler
+  progress; consider yielding and ensuring handler execution is bounded.
+- Resuming without recipe: Only resume when a valid recipe id is present;
+  otherwise, do not start execution implicitly.

--- a/docs/spec/runner/scheduler.md
+++ b/docs/spec/runner/scheduler.md
@@ -1,0 +1,65 @@
+Scheduler (Behavioral Spec)
+
+- Scope: Define reactive execution semantics based on read/write dependencies.
+  Implementations may vary internally but must preserve dependency tracking,
+  invalidation, ordering, and error/console behavior described here.
+
+Key Concepts
+
+- Actions are synchronous or async functions executed with a fresh transaction;
+  reads/writes performed within populate a journal from which dependencies are
+  inferred. A reactivity log consists of read and write addresses (space, id,
+  type, and value paths).
+
+Lifecycle
+
+- Schedule: When an action is scheduled with a known dependency log, mark the
+  corresponding entities dirty and add the action to the pending set.
+- Run: Execute an action with a fresh transaction. On completion, commit and
+  derive the reactivity log from the journal. Register subscriptions based on
+  reads observed.
+- Subscribe: Group read addresses by entity and compact paths. Store as triggers
+  per entity. When storage changes overlap any stored paths, queue the action.
+- Execute: Drain an event queue first (if present). Determine relevant pending
+  actions from the dirty set, cancel prior subscriptions for those actions, and
+  run them in dependency order. If queues are empty after execution, resolve
+  idle waiters; otherwise, schedule another execute pass.
+
+Dependency Tracking
+
+- The system must derive read and write addresses from the transaction journal
+  and compact them. Reads marked with `ignoreReadForScheduling` metadata must
+  not be considered dependencies.
+
+Invalidation
+
+- Storage must provide notifications describing which addresses changed. The
+  scheduler computes overlapping subscriptions and marks those entities dirty;
+  relevant actions are queued.
+
+Ordering
+
+- Determine relevant actions as those with no dependencies or with reads
+  intersecting the dirty set. Build a graph where edges point from a writer to
+  actions that read overlapping paths. Order actions using a topological
+  strategy (e.g., Kahn’s algorithm). If cycles exist, break ties by selecting a
+  node with the lowest in-degree to proceed. Include downstream actions that
+  depend on writes of relevant actions even if they didn’t directly intersect
+  the dirty set.
+- Implement a loop guard to prevent unbounded reruns within a single execution
+  wave; exceeding the limit constitutes an error.
+
+Console/Error Handling
+
+- Intercept console events originating from within actions and pass them through
+  an optional console handler that can augment with metadata before forwarding.
+  Wrap errors thrown by actions or event handlers with contextual metadata
+  (e.g., charmId, spellId, recipeId, space) and pass to registered error
+  handlers. If none are registered, log to console.
+
+Author Guidance
+
+- Write actions so that they synchronously read the cells they depend on; using
+  the run pathway will set up subscriptions automatically from those reads. Use
+  “ignore read” metadata for non-semantic reads that should not participate in
+  scheduling.

--- a/docs/spec/runner/schema.md
+++ b/docs/spec/runner/schema.md
@@ -1,0 +1,127 @@
+Schema-Driven Reads (Behavioral Spec)
+
+- Scope: Defines how schemas influence read shapes and identity, including
+  `asCell`, `asStream`, `$ref` resolution, `anyOf` handling, defaults, array
+  element link-following, and annotations enabling reconstruction of Cells from
+  read values. Internal structure is flexible; behavior must match this spec.
+
+Schema Resolution
+
+- `$ref` must be resolved against `rootSchema` for child lookups. When
+  interpreting the destination for writes, `asCell`/`asStream` flags are not
+  part of the destination type. Boolean/“true” schemas imply no constraints and
+  can be treated as absent.
+
+Defaults and Construction
+
+- When an underlying value is `undefined` and a schema has a `default`, a read
+  must materialize a value shaped by the schema:
+- `asCell`: return a Cell that references the current destination. If the cell
+  branch itself specifies a `default` and the current value is falsy, return a
+  separate immutable cell referencing that default value to keep identity stable
+  across later changes.
+- `asStream`: return a stream placeholder object (implementation-defined),
+  suitable for receiving events later.
+- Objects: recursively construct properties from schema/defaults. `asCell`
+  properties are constructed even if `undefined`. Required object/array
+  properties without defaults should be materialized as `{}`/`[]` respectively.
+- Arrays: map item schema over default array to produce elements.
+- Primitives: return the literal.
+
+Back-To-Cell Annotations
+
+- Returned plain objects/arrays must be immutable and annotated so that callers
+  can reconstruct a Cell at the same identity and obtain an opaque reference for
+  identity/serialization needs.
+
+Validation and Transformation on Read
+
+- Reads must follow intermediary links and write-redirects on the leaf to
+  establish the effective destination for consistent write backs.
+- When links carry schema hints, child schema must be computed at the remaining
+  path depth and applied to the destination; otherwise, carry forward the
+  original schema/root schema.
+- Self-referential structures must not cause infinite recursion; implementations
+  must ensure repeated visits yield the same object identity for that read.
+
+Return Shapes
+
+- No schema: return a live query result view that yields raw values and records
+  reads for reactivity.
+- asCell/asStream, or anyOf whose options are exclusively asCell/asStream:
+  return a Cell or stream reference based on the current value, after following
+  aliases. If link appears mid-path, splice destination path with the remainder
+  to build the correct identity and compute child schema accordingly.
+- anyOf:
+- Arrays: if value is an array and multiple `array` options exist, merge item
+  branches (flatten `items.anyOf` when present) and process as a single array
+  with a merged `anyOf` for items.
+- Objects: evaluate each object-typed branch and merge resulting plain-object
+  projections. If any branch yields a Cell, that Cell takes precedence for the
+  entire object branch.
+- Primitives: choose a branch matching the primitive type; if multiple match,
+  prefer the branch with no `type` (acts as catch-all), otherwise choose the
+  first.
+- Objects: build an object with keys from schema, including defaults and
+  `asCell` properties. For additional properties not explicitly declared,
+  compute a child schema via path lookup and process. If the underlying value is
+  not an object and the projection is empty, return `undefined`.
+- Arrays: if underlying value is not an array, return an immutable empty array.
+  If elements are links, follow them so that element values reflect current
+  items rather than positional links; this enables copy/splice patterns that
+  remove by position without changing element identities inadvertently.
+- Primitives: return the current value. If `undefined` and the schema has a
+  `default`, materialize the default value according to the schema rules above.
+
+asCell/asStream Semantics
+
+- `asCell`: reading yields a Cell whose identity is based on the current
+  referenced value (after following redirects). Destination schema for that Cell
+  must exclude `asCell` so writes operate against data, not the wrapper.
+- `asStream`: reading yields a stream placeholder; event producers bind later.
+  Reads do not create active bindings.
+
+Source Cells
+
+- When a read produces values derived from other storage locations, the system
+  should expose a way (e.g., via `getSourceCell`) to obtain a Cell pointing at
+  the origin of that value for editing. Exposing this is implementation-defined
+  and may not always be available.
+
+Examples
+
+- anyOf Object Merge
+  - AnyOf:
+    `[ { type: 'object', properties: { a: { type: 'number' }}}, { type: 'object', properties: { b: { type: 'string' }}} ]`
+  - Underlying value: `{ a: 1, b: 'x', c: true }`
+  - Read result: `{ a: 1, b: 'x' }` (merged projection). If one branch specifies
+    `asCell`, that cell takes precedence as the representation. ASCII
+  ```
+  value:   { a: 1, b: "x", c: true }
+  anyOf:   [ Obj{a}, Obj{b} ]
+  project:   { a: 1 }  +  { b: "x" }  =>  { a: 1, b: "x" }
+  ```
+
+- Array of Links
+  - Schema: `{ type: 'array', items: { $ref: '#/defs/Item' }}` and underlying
+    array contains links to items.
+  - Read: For each element, follow the link and return the item’s current value;
+    pushing a copy of the array back with an element removed updates length and
+    deletes trailing indices.
+  ```ts
+  const arr = cell.asSchema({ type: "array", items: { $ref: "#/defs/Item" } })
+    .get();
+  const copy = [...arr];
+  copy.splice(2, 1);
+  cell.withTx(tx).set(copy);
+  ```
+
+Gotchas
+
+- Mixed anyOf branches: If some anyOf branches return Cells and others plain
+  objects, a Cell branch takes precedence. This is intentional but can be
+  surprising if not documented.
+- Boolean schemas: A `true` (catch-all) schema in anyOf acts as a default; it
+  may overshadow more specific branches if ordered first.
+- `$ref` with asCell: Remember that `asCell` applies to reads; destination
+  schema used for writes must strip `asCell`.

--- a/docs/spec/runner/testing.md
+++ b/docs/spec/runner/testing.md
@@ -1,0 +1,196 @@
+Runner Test Plan
+
+- Goal: Validate behavioral specs for Cell, Data Updating & Links, Schema,
+  Scheduler, Runner, Builder, and Transactions using unit and integration
+  tests. Use existing tests in packages/runner/test as inspiration and
+  expand to cover edge cases called out in these specs.
+
+How To Run
+
+- All: `deno task test`
+- Single file: `deno test packages/runner/test/<file>.ts`
+- Type checks: `deno task check`
+
+Test Structure
+
+- Unit tests (fast, focused): exercise a single module (e.g., link resolution,
+  diff normalization, schema transformation).
+- Integration tests (recipe-level): run full recipes through the Runner to
+  validate process cell lifecycle, node instantiation, scheduling, and
+  persistence flows.
+
+Coverage Map (existing tests to learn from)
+
+- Cells: `cell.test.ts`, `nested_cell_array.test.ts`
+- Data Updating & Links: `data-updating.test.ts`, `link-utils.test.ts`,
+  `link-resolution.test.ts`, `path-utils.test.ts`, `traverse-utils.test.ts`
+- Schema: `schema.test.ts`, `schema-lineage.test.ts`, `schema-to-ts.test.ts`,
+  `opaque-ref-schema.test.ts`
+- Scheduler & Reactivity: `scheduler.test.ts`, `reactive-dependencies.test.ts`
+- Runner & Recipes: `runner.test.ts`, `recipe.test.ts`, `recipes.test.ts`,
+  `recipe-binding.test.ts`, `function-cache.test.ts`, `module.test.ts`
+- Storage & Transactions: `storage.test.ts`, `storage-subscription.test.ts`,
+  `journal.test.ts`, `transaction.test.ts`,
+  `transaction-notfound.test.ts`, `push-conflict.test.ts`,
+  `provider-reconnection.test.ts`
+- Integration flows: `integration/*`, `array_push.test.ts[x]`,
+  `basic-persistence.test.ts`, `pending-nursery.test.ts`,
+  `reconnection.test.ts`, `sync-schema-path.test.ts`
+
+Test Matrix (what to add/ensure)
+
+1) Cell
+- get: follows redirects on leaf; applies defaults; returns immutable views.
+- set/send: writes via write-redirect; minimal diffs for primitives/objects.
+- update: initializes `{}` when schema allows; per-key writes; rejects non-
+  objects.
+- push: creates array when missing; ID_FIELD sibling reuse; ID creates entity;
+  rejects non-array parent.
+- key/asSchema/withTx: child schema resolution; schema swap re-reads; tx
+  binding for mutations.
+- equals: normalized identity equality.
+- sink: re-executes on underlying doc changes (verify by updating a read key).
+- getAsLink/getAsWriteRedirectLink: round trip matches normalized link.
+- getRaw/setRaw: bypass validation/redirects; sanity-check via storage read.
+- getSourceCell: returns undefined for pure literals; returns cell for derived
+  references.
+- copyTrap: throws on traversal attempts.
+
+2) Data Updating & Links
+- normalizeAndDiff basics: primitives, objects (add/update/delete), arrays
+  (grow/shrink + `length`), circular references (relative links).
+- Links as values: data: link content traversal; non-data links equality vs
+  write; link rebasing when content contains links.
+- Write-redirect in current: write at destination without overwriting source.
+- ID_FIELD sibling reuse within arrays; no reuse when not in array context.
+- ID-based object: derived id excludes indices of nested arrays; writes two-
+  phase: link set + entity content diff.
+- convertCellsToLinks: converts cells/streams/query results; respects toJSON;
+  preserves cycles via relative path links.
+
+3) Schema-Driven Reads
+- $ref resolution against root; child schema computation along link jumps.
+- defaults: objects/arrays (required `{}`/`[]`), primitives, asCell/asStream
+  behaviors; immutable annotated values carry toCell/toOpaqueRef symbols.
+- anyOf arrays: merge item branches, flatten items.anyOf.
+- anyOf objects: merge projections; precedence when a branch is `asCell`.
+- Primitives: choose matching branch; fallback to catch-all (type omitted).
+- Arrays of links: element link following; copy/splice then write back updates
+  `length` and deletes indices.
+
+4) Scheduler & Reactivity
+- schedule + subscribe: actions with no reads run; actions with reads blocked
+  until dirty; subscriptions created after run.
+- dirty invalidation: entity-level dirty marks rerun actions whose reads
+  intersect changed paths.
+- topological order: writer-before-reader; include downstream actions that read
+  writer’s outputs.
+- cycle handling: topological sort breaks cycles by lowest in-degree; runs all
+  actions exactly once per wave.
+- ignoreReadForScheduling: reads with metadata do not create dependencies.
+- MAX_ITERATIONS_PER_RUN guard triggers on self-retriggering action.
+
+5) Runner
+- process cell lifecycle: first run creates P with TYPE/spell/argument/internal
+  and resultRef; second run updates argument without restart; recipe change
+  stops and restarts.
+- module types:
+  - javascript: function caching from string id; wrapper invocation; reads/writes
+    detection from bindings; plain result writes vs OpaqueRef result spawning
+    a sub-recipe.
+  - raw: action factory receives inputsCell/send/addCancel/context; schedule
+    with explicit read/write sets.
+  - recipe: nested result cell linking.
+  - ref: resolves and behaves as resolved module type.
+- streams: input resolves to stream marker; event handler registered; on event,
+  argument materialization and writes occur; verify scheduling via injected
+  event.
+
+6) Builder
+- recipe extraction: OpaqueRef inputs, internal cell OpaqueRefs, NodeRefs;
+  path/name assignment (argument/internal/result); serialization stable.
+- shadow refs: nested/closure recipes captured as ShadowRefs across frames.
+- frame enforcement: creating a cell outside lift/handler frame throws.
+
+7) Transactions
+- journal records reads/writes with `value` prefix removed; commit publishes
+  writes and closes tx; open reads visible within tx.
+- syncCell: no-op for `data:` URIs; otherwise requests sync.
+
+Suggested New Tests (missing or to deepen)
+
+- Schema anyOf precedence with mixed cells/objects.
+- Circular reference write: relative link back to first occurrence.
+- Derived id path context: nested arrays strip indices when deriving entity id.
+- Scheduler cycle: A writes X; B reads X and writes Y; C reads Y and writes X;
+  verify bounded execution and ordering choice.
+- Runner stream handler: end-to-end with event injection and assertion of
+  output bindings.
+- Builder shadow ref stability: closures carry parent recipe id; extracted
+  nodes/names stable across runs.
+
+Test Snippets (patterns)
+
+- Cell sink reactivity
+```ts
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+describe("cell sink", () => {
+  it("re-executes on dependency change", () => {
+    const tx = runtime.edit();
+    const c = runtime.getCell(space, { name: "t" }, {}, tx);
+    tx.commit();
+
+    let values: any[] = [];
+    const cancel = c.sink((v) => { values.push(v); });
+
+    const tx2 = runtime.edit();
+    c.withTx(tx2).set({ foo: 1 });
+    tx2.commit();
+
+    expect(values.length).toBeGreaterThan(1);
+    cancel();
+  });
+});
+```
+
+- normalizeAndDiff ID_FIELD
+```ts
+const tx = runtime.edit();
+const base = runtime.getCell(space, { name: "arr" }, { type: "array" }, tx);
+tx.commit();
+const tx2 = runtime.edit();
+base.withTx(tx2).set([]);
+base.withTx(tx2).push({ [ID_FIELD]: "slug", slug: "b", v: 1 });
+tx2.commit();
+const tx3 = runtime.edit();
+base.withTx(tx3).set([
+  { [ID_FIELD]: "slug", slug: "a", v: 1 },
+  { [ID_FIELD]: "slug", slug: "b", v: 2 },
+]);
+tx3.commit();
+// assert: arr[1] still refers to same entity; entity(b).v == 2
+```
+
+- Scheduler topological order
+```ts
+const a = (tx) => { /* write X */ };
+const b = (tx) => { /* read X, write Y */ };
+const c = (tx) => { /* read Y */ };
+const logA = { reads: [], writes: [addrX] };
+const logB = { reads: [addrX], writes: [addrY] };
+const logC = { reads: [addrY], writes: [] };
+runtime.scheduler.schedule(a, logA);
+runtime.scheduler.schedule(b, logB);
+runtime.scheduler.schedule(c, logC);
+// expect execution order compatible with a -> b -> c
+```
+
+Execution Guidance
+
+- Keep unit tests deterministic (no timers/network). For event-based tests,
+  inject events via storage notifications or a test harness. When asserting
+  reactivity, prefer direct storage writes or cell mutations inside a tx and
+  wait for the scheduler to become idle before asserting.
+

--- a/docs/spec/runner/transactions.md
+++ b/docs/spec/runner/transactions.md
@@ -1,0 +1,44 @@
+Transactions API (Behavioral Spec)
+
+- Scope: High-level contract between runner components and storage transactions,
+  with emphasis on read/write recording for reactivity and atomic application of
+  change sets.
+
+Core Behaviors
+
+- Creating transactions: A fresh transaction must be used to run actions and
+  group related writes. For read-only operations, ephemeral transactions are
+  acceptable, but must still record reads to the journal for dependency
+  tracking.
+- Reads: `readValueOrThrow(address, options?)` returns a JSON value at that
+  address and records the read (space, id, type, path) in the journal. Reads may
+  carry metadata; reads marked as “ignore for scheduling” must not create
+  dependencies.
+- Writes: `writeValueOrThrow(address, value)` writes a JSON value (or
+  `undefined` to delete) and records the write in the journal. Writes are
+  visible to reads performed within the same transaction.
+- Commit: `commit()` finalizes the transaction, publishes writes, and closes the
+  journal for dependency extraction.
+- Journal: `journal.activity()` exposes a sequence of read/write activities for
+  scheduler dependency extraction; value paths include a leading “value” prefix
+  that is removed for dependency matching.
+- Sync: For non-`data:` entities, a `syncCell(cell)` operation should be
+  available to kick off background synchronization.
+
+Usage Patterns
+
+- Read phase: Reads performed by Cells or schema transforms should occur under a
+  transaction to capture dependencies consistently. These reads define reactive
+  triggers for subsequent scheduler runs.
+- Write phase: Value normalization and diffing produce a change set that must be
+  applied as writes within a single transaction to ensure atomicity and conflict
+  handling.
+- Reactivity: After an action commits, the scheduler derives the reactivity log
+  from the journal and registers subscriptions accordingly.
+
+Notes
+
+- All mutating Cell operations must have a transaction provided. Implementations
+  may automatically create ephemeral transactions for readonly code paths but
+  should not do so for mutations. Group related writes into a single transaction
+  whenever possible for predictable behavior.


### PR DESCRIPTION
(This is an experiment: I wanted to see how good GPT-5 is at reverse-engineering a spec from our code. Haven't looked too closely yet, just sharing it here)

Covering: Cell, Schema, Data Updating & Links, Scheduler, Runner, Builder; include examples, gotchas, and testing plan