### PR TITLE
runner: refactor recipeManager and save Program without added local identifier

### DIFF
--- a/packages/charm/src/iterate.ts
+++ b/packages/charm/src/iterate.ts
@@ -540,27 +540,16 @@ export async function compileRecipe(
     throw new Error("No default recipe found in the compiled exports.");
   }
   const parentsIds = parents?.map((id) => id.toString());
-  const recipeId = runtime.recipeManager.registerRecipe(
-    recipe,
-    recipeSrc,
-  );
+  const recipeId = runtime.recipeManager.registerRecipe(recipe, recipeSrc);
 
-  const recipeMeta: Partial<Mutable<RecipeMeta>> = {
-    id: recipeId,
+  // Record metadata fields (spec, parents) for this recipe
+  runtime.recipeManager.setRecipeMetaFields(recipeId, {
     spec,
     parents: parentsIds,
-  };
-
-  if (typeof recipeSrc === "string") {
-    recipeMeta.src = recipeSrc;
-  } else {
-    recipeMeta.program = recipeSrc;
-  }
+  } as Partial<Mutable<RecipeMeta>>);
   await runtime.recipeManager.saveAndSyncRecipe({
     recipeId,
     space,
-    recipe,
-    recipeMeta: recipeMeta as RecipeMeta,
   });
 
   return recipe;

--- a/packages/charm/src/ops/charm-controller.ts
+++ b/packages/charm/src/ops/charm-controller.ts
@@ -61,10 +61,11 @@ export class CharmController {
     return recipe;
   }
 
-  async getRecipeMeta(): Promise<RecipeMeta> {
-    return this.#manager.runtime.recipeManager.getRecipeMeta(
-      await this.getRecipe(),
-    ) as RecipeMeta;
+  getRecipeMeta(): Promise<RecipeMeta> {
+    return this.#manager.runtime.recipeManager.loadRecipeMeta(
+      getRecipeIdFromCharm(this.#cell),
+      this.#manager.getSpace(),
+    );
   }
 
   // Returns an `IFrameRecipe` for the charm, or `undefined`

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -89,7 +89,7 @@ export const createBuilder = (
     for (const [value, program] of exports) {
       if (isRecipe(value)) {
         // This will associate the program with the recipe
-        runtime.recipeManager.registerRecipe(value, program);
+        value.program = program;
       }
     }
   };

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -108,14 +108,16 @@ export function toJSONWithLegacyAliases(
   }
 
   if (isRecord(value) || isRecipe(value)) {
-    if (isRecipe(value) && typeof (value as toJSON).toJSON === "function") {
-      value = (value as toJSON).toJSON();
-    }
+    const valueToProcess =
+      (isRecipe(value) && typeof (value as toJSON).toJSON === "function")
+        ? (value as toJSON).toJSON() as Record<string, any>
+        : (value as Record<string, any>);
+
     const result: any = {};
     let hasValue = false;
-    for (const key in value as any) {
+    for (const key in valueToProcess as any) {
       const jsonValue = toJSONWithLegacyAliases(
-        value[key],
+        valueToProcess[key],
         paths,
         ignoreSelfAliases,
         [...path, key],

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -240,5 +240,6 @@ export function recipeToJSON(recipe: Recipe) {
     ...(recipe.initial ? { initial: recipe.initial } : {}),
     result: recipe.result,
     nodes: recipe.nodes,
+    program: recipe.program,
   };
 }

--- a/packages/runner/src/builder/recipe.ts
+++ b/packages/runner/src/builder/recipe.ts
@@ -330,13 +330,13 @@ function factoryFromRecipe<T, R>(
     toJSON: () => recipeToJSON(recipeFactory),
   };
 
-  const module: Module & toJSON = {
-    type: "recipe",
-    implementation: recipe,
-    toJSON: () => moduleToJSON(module),
-  };
-
   const recipeFactory = Object.assign((inputs: Opaque<T>): OpaqueRef<R> => {
+    const module: Module & toJSON = {
+      type: "recipe",
+      implementation: recipeFactory,
+      toJSON: () => moduleToJSON(module),
+    };
+
     const outputs = opaqueRef<R>();
     const node: NodeRef = {
       module,

--- a/packages/runner/src/builder/recipe.ts
+++ b/packages/runner/src/builder/recipe.ts
@@ -325,7 +325,9 @@ function factoryFromRecipe<T, R>(
     initial,
     result,
     nodes: serializedNodes,
-    toJSON: () => recipeToJSON(recipe),
+    // Important that this refers to recipeFactory, as .program will be set on
+    // recipe afterwards (see factory.ts:exportsCallback)
+    toJSON: () => recipeToJSON(recipeFactory),
   };
 
   const module: Module & toJSON = {

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -81,6 +81,7 @@ import {
   type IExtendedStorageTransaction,
   type MemorySpace,
 } from "../storage/interface.ts";
+import { type RuntimeProgram } from "../harness/types.ts";
 
 export type JSONSchemaMutable = Mutable<JSONSchema>;
 
@@ -195,6 +196,7 @@ declare module "@commontools/api" {
     initial?: JSONValue;
     result: JSONValue;
     nodes: Node[];
+    program?: RuntimeProgram;
     [unsafe_originalRecipe]?: Recipe;
     [unsafe_parentRecipe]?: Recipe;
     [unsafe_materializeFactory]?: (

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -177,7 +177,11 @@ export class Engine extends EventTarget implements Harness {
         // Create a map from exported values to `RuntimeProgram` that can
         // generate them and pass to the callback from the exports.
         const exportsByValue = new Map<any, RuntimeProgram>();
-        for (const [fileName, exports] of Object.entries(exportMap)) {
+        const prefix = `/${id}`;
+        for (let [fileName, exports] of Object.entries(exportMap)) {
+          if (fileName.startsWith(prefix)) {
+            fileName = fileName.substring(prefix.length);
+          }
           for (const [exportName, exportValue] of Object.entries(exports)) {
             exportsByValue.set(exportValue, {
               main: fileName,

--- a/packages/runner/src/recipe-manager.ts
+++ b/packages/runner/src/recipe-manager.ts
@@ -81,6 +81,15 @@ export class RecipeManager implements IRecipeManager {
     return recipe;
   }
 
+  async loadRecipeMeta(
+    recipeId: string,
+    space: MemorySpace,
+  ): Promise<RecipeMeta> {
+    const cell = this.getRecipeMetaCell({ recipeId, space });
+    await cell.sync();
+    return cell.get();
+  }
+
   getRecipeMeta(
     input: Recipe | Module | { recipeId: string },
   ): RecipeMeta {

--- a/packages/runner/src/recipe-manager.ts
+++ b/packages/runner/src/recipe-manager.ts
@@ -1,4 +1,10 @@
-import { JSONSchema, Module, Recipe, Schema } from "./builder/types.ts";
+import {
+  JSONSchema,
+  Module,
+  Recipe,
+  Schema,
+  unsafe_originalRecipe,
+} from "./builder/types.ts";
 import { Cell } from "./cell.ts";
 import type { IRecipeManager, IRuntime, MemorySpace } from "./runtime.ts";
 import { createRef } from "./doc-map.ts";
@@ -41,9 +47,14 @@ export type RecipeMeta = Schema<typeof recipeMetaSchema>;
 
 export class RecipeManager implements IRecipeManager {
   private inProgressCompilations = new Map<string, Promise<Recipe>>();
-  private recipeMetaMap = new WeakMap<Recipe, Cell<RecipeMeta>>();
-  private recipeProgramMap = new WeakMap<Recipe, string | RuntimeProgram>();
+  // Maps keyed by recipeId for consistent lookups
+  private recipeMetaCellById = new Map<string, Cell<RecipeMeta>>();
+  private recipeProgramById = new Map<string, string | RuntimeProgram>();
   private recipeIdMap = new Map<string, Recipe>();
+  // Map from recipe object instance to recipeId
+  private recipeToIdMap = new WeakMap<Recipe, string>();
+  // Pending metadata set before the meta cell exists (e.g., spec, parents)
+  private pendingMetaById = new Map<string, Partial<RecipeMeta>>();
 
   constructor(readonly runtime: IRuntime) {}
 
@@ -61,91 +72,119 @@ export class RecipeManager implements IRecipeManager {
     return cell;
   }
 
+  private findOriginalRecipe(recipe: Recipe): Recipe {
+    while (recipe[unsafe_originalRecipe]) {
+      recipe = recipe[unsafe_originalRecipe];
+    }
+    return recipe;
+  }
+
   getRecipeMeta(
     input: Recipe | Module | { recipeId: string },
   ): RecipeMeta {
+    let recipeId: string | undefined;
     if ("recipeId" in input) {
-      const recipe = this.recipeById(input.recipeId);
-      if (!recipe) throw new Error(`Recipe ${input.recipeId} not loaded`);
-      return this.recipeMetaMap.get(recipe)?.get()!;
+      recipeId = input.recipeId;
+    } else if (input && typeof input === "object") {
+      recipeId = this.recipeToIdMap.get(
+        this.findOriginalRecipe(input as Recipe),
+      );
     }
-    return this.recipeMetaMap.get(input as Recipe)?.get()!;
+
+    if (!recipeId) throw new Error("Recipe is not registered");
+
+    const cell = this.recipeMetaCellById.get(recipeId);
+    if (cell) return cell.get();
+
+    // If we don't have a stored cell yet, return whatever pending/meta we have
+    const pending = this.pendingMetaById.get(recipeId) ?? {};
+    const source = this.recipeProgramById.get(recipeId);
+    if (!source && Object.keys(pending).length === 0) {
+      throw new Error(`Recipe ${recipeId} has no metadata available`);
+    }
+    const meta: RecipeMeta = {
+      id: recipeId,
+      ...(typeof source === "string" ? { src: source } : {}),
+      ...(typeof source === "object" ? { program: source } : {}),
+      ...(pending as Partial<RecipeMeta>),
+    } as RecipeMeta;
+    return meta;
   }
 
   registerRecipe(
     recipe: Recipe | Module,
     src?: string | RuntimeProgram,
   ): string {
-    const id = this.recipeMetaMap.get(recipe as Recipe)?.get()?.id;
-    if (id) {
-      return id;
-    }
+    // Walk up derivation copies to original
+    recipe = this.findOriginalRecipe(recipe as Recipe);
+
+    // If this recipe object was already registered, return its id
+    const existingId = this.recipeToIdMap.get(recipe);
+    if (existingId) return existingId;
 
     const generatedId = src
       ? createRef({ src }, "recipe source").toString()
       : createRef(recipe, "recipe").toString();
 
+    // If an id already exists for this source/recipe, reuse it
+    if (this.recipeIdMap.has(generatedId)) return generatedId;
+
+    // Register fresh
     this.recipeIdMap.set(generatedId, recipe as Recipe);
-    if (src) this.recipeProgramMap.set(recipe as Recipe, src);
+    this.recipeToIdMap.set(recipe as Recipe, generatedId);
+    if (src) this.recipeProgramById.set(generatedId, src);
 
     return generatedId;
   }
 
   saveRecipe(
-    { recipeId, space, recipe, recipeMeta }: {
+    { recipeId, space }: {
       recipeId: string;
       space: MemorySpace;
-      recipe?: Recipe | Module;
-      recipeMeta?: RecipeMeta;
     },
     providedTx?: IExtendedStorageTransaction,
   ): boolean {
     const tx = providedTx ?? this.runtime.edit();
 
-    // FIXME(ja): should we update the recipeMeta if it already exists? when does this happen?
-    if (this.recipeMetaMap.has(recipe as Recipe)) {
+    // Already saved
+    if (this.recipeMetaCellById.has(recipeId)) {
       return true;
     }
 
-    if (!recipe) {
-      recipe = this.recipeById(recipeId);
-      if (!recipe) {
-        throw new Error(`Recipe ${recipeId} not loaded`);
-      }
-    }
+    const srcOrProgram = this.recipeProgramById.get(recipeId);
+    if (!srcOrProgram) return false;
 
-    if (!recipeMeta) {
-      const src = this.recipeProgramMap.get(recipe as Recipe);
-      recipeMeta = {
-        id: recipeId,
-        src: typeof src === "string" ? src : undefined,
-        program: typeof src === "object" ? src : undefined,
-      };
-    }
-
-    if (!recipeMeta.src && !recipeMeta.program) {
-      return false;
-    }
+    const pending = this.pendingMetaById.get(recipeId) ?? {};
+    const recipeMeta: RecipeMeta = {
+      id: recipeId,
+      ...(typeof srcOrProgram === "string"
+        ? { src: srcOrProgram }
+        : { program: srcOrProgram }),
+      ...(pending as Partial<RecipeMeta>),
+    } as RecipeMeta;
 
     const recipeMetaCell = this.getRecipeMetaCell({ recipeId, space }, tx);
     recipeMetaCell.set(recipeMeta);
 
     if (!providedTx) tx.commit();
 
-    this.recipeMetaMap.set(recipe as Recipe, recipeMetaCell.withTx());
+    this.recipeMetaCellById.set(recipeId, recipeMetaCell.withTx());
+    // If we have a recipe object for this id, ensure the back mapping exists
+    const recipe = this.recipeIdMap.get(recipeId);
+    if (recipe) this.recipeToIdMap.set(recipe, recipeId);
+    // Clear pending once persisted
+    this.pendingMetaById.delete(recipeId);
     return true;
   }
 
   async saveAndSyncRecipe(
-    { recipeId, space, recipe, recipeMeta }: {
+    { recipeId, space }: {
       recipeId: string;
       space: MemorySpace;
-      recipe: Recipe | Module;
-      recipeMeta: RecipeMeta;
     },
     tx?: IExtendedStorageTransaction,
   ) {
-    if (this.saveRecipe({ recipeId, space, recipe, recipeMeta }, tx)) {
+    if (this.saveRecipe({ recipeId, space }, tx)) {
       await this.getRecipeMetaCell({ recipeId, space }, tx).sync();
     }
   }
@@ -188,7 +227,8 @@ export class RecipeManager implements IRecipeManager {
       : recipeMeta.src!;
     const recipe = await this.compileRecipe(source);
     this.recipeIdMap.set(recipeId, recipe);
-    this.recipeMetaMap.set(recipe, metaCell.withTx());
+    this.recipeToIdMap.set(recipe, recipeId);
+    this.recipeMetaCellById.set(recipeId, metaCell.withTx());
     return recipe;
   }
 
@@ -213,5 +253,21 @@ export class RecipeManager implements IRecipeManager {
     this.inProgressCompilations.set(id, compilationPromise);
 
     return await compilationPromise;
+  }
+
+  /**
+   * Set or update metadata fields for a recipe before or after saving.
+   * If the metadata cell already exists, it updates it in-place.
+   * Otherwise, it stores the fields to be applied on the next save.
+   */
+  setRecipeMetaFields(recipeId: string, fields: Partial<RecipeMeta>): void {
+    const cell = this.recipeMetaCellById.get(recipeId);
+    if (cell) {
+      const current = cell.get();
+      cell.set({ ...current, ...fields, id: recipeId });
+    } else {
+      const pending = this.pendingMetaById.get(recipeId) ?? {};
+      this.pendingMetaById.set(recipeId, { ...pending, ...fields });
+    }
   }
 }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -181,7 +181,6 @@ export class Runner implements IRunner {
     this.runtime.recipeManager.saveRecipe({
       recipeId,
       space: resultCell.space,
-      recipe,
     }, tx);
 
     // If the bindings are a cell, doc or doc link, convert them to an alias

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -237,6 +237,7 @@ export interface IRecipeManager {
     tx?: IExtendedStorageTransaction,
   ): Promise<Recipe>;
   compileRecipe(input: string | RuntimeProgram): Promise<Recipe>;
+  loadRecipeMeta(recipeId: string, space: MemorySpace): Promise<RecipeMeta>;
   getRecipeMeta(input: any): RecipeMeta;
   saveRecipe(
     params: {

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -242,8 +242,6 @@ export interface IRecipeManager {
     params: {
       recipeId: string;
       space: MemorySpace;
-      recipe?: Recipe | Module;
-      recipeMeta?: RecipeMeta;
     },
     tx?: IExtendedStorageTransaction,
   ): boolean;
@@ -251,11 +249,10 @@ export interface IRecipeManager {
     params: {
       recipeId: string;
       space: MemorySpace;
-      recipe?: Recipe | Module;
-      recipeMeta?: RecipeMeta;
     },
     tx?: IExtendedStorageTransaction,
   ): Promise<void>;
+  setRecipeMetaFields(recipeId: string, fields: Partial<RecipeMeta>): void;
 }
 
 export interface IModuleRegistry {

--- a/packages/runner/test/recipe-manager.test.ts
+++ b/packages/runner/test/recipe-manager.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commontools/identity";
+import { StorageManager } from "@commontools/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+describe("RecipeManager program persistence", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      blobbyServerUrl: import.meta.url,
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("compiles multi-file program, attaches program, saves and reloads by id", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/util.ts",
+          contents: "export const double = (x:number)=>x*2;",
+        },
+        {
+          name: "/main.tsx",
+          contents: [
+            "import { recipe, lift } from 'commontools';",
+            "import { double } from './util.ts';",
+            "export default recipe<{ value: number }>('Test', ({ value }) => {",
+            "  const dbl = lift((x:number)=>double(x))(value);",
+            "  return { result: dbl };",
+            "});",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const compiled = await runtime.recipeManager.compileRecipe(program);
+    expect(compiled.program).toBeDefined();
+    expect(compiled.program?.main).toEqual("/main.tsx");
+    // Ensure original file names are preserved (no injected prefix leaked here)
+    const fileNames = (compiled.program?.files ?? []).map((f) => f.name).sort();
+    expect(fileNames).toEqual(["/main.tsx", "/util.ts"].sort());
+
+    const recipeId = runtime.recipeManager.registerRecipe(compiled, program);
+    await runtime.recipeManager.saveAndSyncRecipe({ recipeId, space });
+
+    const meta = runtime.recipeManager.getRecipeMeta({ recipeId });
+    expect(meta.id).toEqual(recipeId);
+    expect(meta.program).toBeDefined();
+    expect(meta.program?.main).toEqual("/main.tsx");
+    const metaFileNames = (meta.program?.files ?? []).map((f) => f.name).sort();
+    expect(metaFileNames).toEqual(["/main.tsx", "/util.ts"].sort());
+
+    // Verify we can re-load and run the saved recipe
+    const loaded = await runtime.recipeManager.loadRecipe(recipeId, space, tx);
+    const resultCell = runtime.getCell<{ result: number }>(
+      space,
+      "recipe-manager: run loaded",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, loaded, { value: 3 }, resultCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.idle();
+    expect(result.getAsQueryResult()).toEqual({ result: 6 });
+  });
+
+  it("register/save idempotency: saving same recipe id twice is harmless", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.ts",
+      files: [
+        {
+          name: "/main.ts",
+          contents: [
+            "import { recipe } from 'commontools';",
+            "export default recipe<{ x: number }>('Idempotent', ({ x }) => ({ x }));",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const compiled = await runtime.recipeManager.compileRecipe(program);
+    const recipeId = runtime.recipeManager.registerRecipe(compiled, program);
+    const first = runtime.recipeManager.saveRecipe({ recipeId, space });
+    const second = runtime.recipeManager.saveRecipe({ recipeId, space });
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+
+    const meta = runtime.recipeManager.getRecipeMeta({ recipeId });
+    expect(meta.program?.main).toEqual("/main.ts");
+  });
+});


### PR DESCRIPTION
This fixes issues when saving recipes:
- Recipe objects can get copied and so basing all maps on recipes meant we missed the
   original src assignment. By moving everything to recipe ids quickly, this is now much better.
- If the recipe already existed on disk, we failed the whole creation of the charm because
   overwriting the prior recipe failed the tranaction

Details:

- Replace WeakMap<Recipe, ...> maps with recipeId-based maps:
  - recipeMetaCellById: Map<string, Cell<RecipeMeta>>
  - recipeProgramById: Map<string, string | RuntimeProgram>
  - recipeIdMap: Map<string, Recipe>
  - recipeToIdMap: WeakMap<Recipe, string>
  - pendingMetaById: Map<string, Partial<RecipeMeta>> for staging fields like spec/parents

- Add findOriginalRecipe(...) to normalize derived/duplicated recipe objects
  - Ensure all registration and lookups use the original recipe instance

- registerRecipe(recipe, src?)
  - First resolve to original recipe
  - Return existing id if recipe object already registered
  - Generate id from src or recipe and return existing if id already present
  - Otherwise register new entry and store src/program by id

- saveRecipe({ recipeId, space }, tx?)
  - No longer accepts recipe or recipeMeta
  - Build RecipeMeta from stored src/program + any pending fields
  - Persist to meta cell and wire up id-based maps

- saveAndSyncRecipe({ recipeId, space }, tx?) simplified to call saveRecipe then sync

- getRecipeMeta(input)
  - Resolve id from {recipeId} or recipe object via recipeToIdMap (after resolving to original)
  - Prefer persisted meta cell; otherwise synthesize from stored src/program + pending fields

- compileRecipeOnce(...)
  - Update recipeIdMap, recipeToIdMap and recipeMetaCellById when loading

- Add setRecipeMetaFields(recipeId, fields) to stage spec/parents before first save

- Update IRecipeManager interface in runtime.ts to new signatures and add setRecipeMetaFields

- Update runner.ts to call saveRecipe({ recipeId, space })

- Update charm/iterate.ts compileRecipe(...) to:
  - register recipe with src/program
  - set spec/parents via setRecipeMetaFields
  - call saveAndSyncRecipe({ recipeId, space })

Tests/lint
- Linted edited files: no errors
- Ran charm package tests: all passing
- Ran runner tests: executed; no linter errors (integration warning retained)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Refactored RecipeManager to use recipeId-based maps for all lookups and persistence, fixing issues with duplicated recipe objects and failed recipe overwrites.

- **Refactors**
 - Replaced WeakMap<Recipe, ...> with recipeId-centric maps for metadata and program storage.
 - Added findOriginalRecipe to normalize derived recipe objects.
 - Updated registerRecipe, saveRecipe, and getRecipeMeta to use recipeId for all operations.
 - Introduced setRecipeMetaFields to stage metadata before saving.
 - Updated interfaces and usage in runner and charm/iterate to match new signatures.

<!-- End of auto-generated description by cubic. -->

