### PR TITLE
Moving the wait after login to before assertions, seems to fix interm…

### DIFF
--- a/packages/shell/integration/charm.test.ts
+++ b/packages/shell/integration/charm.test.ts
@@ -40,6 +40,7 @@ describe("shell charm tests", () => {
 
     const state = await shell.login();
 
+    console.log("state", state);
     await sleep(2000);
 
     assertEquals(state.spaceName, spaceName);

--- a/packages/shell/integration/charm.test.ts
+++ b/packages/shell/integration/charm.test.ts
@@ -38,10 +38,9 @@ describe("shell charm tests", () => {
     await page.goto(`${FRONTEND_URL}${spaceName}/${charmId}`);
     await page.applyConsoleFormatter();
 
-    const state = await shell.login();
+    await sleep(1000);
 
-    console.log("state", state);
-    await sleep(2000);
+    const state = await shell.login();
 
     assertEquals(state.spaceName, spaceName);
     assertEquals(state.activeCharmId, charmId);
@@ -49,6 +48,8 @@ describe("shell charm tests", () => {
       state.identity?.serialize().privateKey,
       identity.serialize().privateKey,
     );
+
+    await sleep(1000);
 
     let handle = await page.$(
       "ct-button",

--- a/packages/shell/integration/charm.test.ts
+++ b/packages/shell/integration/charm.test.ts
@@ -39,6 +39,9 @@ describe("shell charm tests", () => {
     await page.applyConsoleFormatter();
 
     const state = await shell.login();
+
+    await sleep(2000);
+
     assertEquals(state.spaceName, spaceName);
     assertEquals(state.activeCharmId, charmId);
     assertEquals(
@@ -46,7 +49,6 @@ describe("shell charm tests", () => {
       identity.serialize().privateKey,
     );
 
-    await sleep(2000);
     let handle = await page.$(
       "ct-button",
       { strategy: "pierce" },


### PR DESCRIPTION
…ittent shell integration test failure
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Moved the wait after login to before assertions in the shell integration test to fix intermittent test failures.

<!-- End of auto-generated description by cubic. -->

