### PR TITLE
feat: Apply Cache-Control headers to static assets from toolshed

### DIFF
--- a/packages/toolshed/routes/static/static.index.ts
+++ b/packages/toolshed/routes/static/static.index.ts
@@ -5,6 +5,8 @@ import { getMimeType } from "@/lib/mime-type.ts";
 
 const router = createRouter();
 
+const STATIC_CACHE_DURATION = 60 * 60 * 1; // 1 hour
+
 // Notably this uses a different cache
 // than the runtime that runs in this context, negigible
 // cost of not incorporating the runtime here.
@@ -29,6 +31,7 @@ router.get("/static/*", async (c) => {
     status: 200,
     headers: {
       "Content-Type": mimeType,
+      "Cache-Control": `max-age=${STATIC_CACHE_DURATION}`,
     },
   });
 });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added Cache-Control headers to static asset responses in toolshed to enable browser caching and improve load times.

- **New Features**
 - Static files now include a 1-hour Cache-Control header.
 - Assets are cached in memory for faster repeated requests.

<!-- End of auto-generated description by cubic. -->

