### PR TITLE
added failing test for a nested recursive type, skipping for now but …

### DIFF
--- a/packages/js-runtime/test/fixture-based.test.ts
+++ b/packages/js-runtime/test/fixture-based.test.ts
@@ -125,7 +125,7 @@ const configs: FixtureConfig[] = [
       if (name === "with-opaque-ref") return "works with OpaqueRef transformer";
       return `transforms ${formatted}`;
     },
-    skip: ["no-directive"], // no-directive needs special handling
+    skip: ["no-directive", "recursive-type-nested"], // no-directive needs special handling, recursive-type-nested has stack overflow bug
   },
 ];
 

--- a/packages/js-runtime/test/fixtures/schema-transform/recursive-type-nested.expected.ts
+++ b/packages/js-runtime/test/fixtures/schema-transform/recursive-type-nested.expected.ts
@@ -1,0 +1,52 @@
+/// <cts-enable />
+import { JSONSchema, recipe } from "commontools";
+
+// NOTE: This expected output is currently a PLACEHOLDER.
+// The actual test causes a stack overflow due to a bug with nested recursive types.
+// Once the bug is fixed, this file should be updated with the actual expected
+// transformation output.
+
+interface LinkedList {
+    value: number;
+    next?: LinkedList;
+}
+
+interface RootType {
+    list: LinkedList;
+}
+
+const rootTypeSchema = {
+    $ref: "#/definitions/RootType",
+    $schema: "http://json-schema.org/draft-07/schema#",
+    definitions: {
+        LinkedList: {
+            type: "object",
+            properties: {
+                value: {
+                    type: "number"
+                },
+                next: {
+                    $ref: "#/definitions/LinkedList"
+                }
+            },
+            required: ["value"]
+        },
+        RootType: {
+            type: "object",
+            properties: {
+                list: {
+                    $ref: "#/definitions/LinkedList"
+                }
+            },
+            required: ["list"]
+        }
+    }
+} as const satisfies JSONSchema;
+export { rootTypeSchema };
+
+// Add a recipe export for ct dev testing
+export default recipe("Nested Recursive Type Test", () => {
+    return {
+        schema: rootTypeSchema,
+    };
+});

--- a/packages/js-runtime/test/fixtures/schema-transform/recursive-type-nested.input.ts
+++ b/packages/js-runtime/test/fixtures/schema-transform/recursive-type-nested.input.ts
@@ -1,0 +1,27 @@
+/// <cts-enable />
+import { toSchema, JSONSchema, recipe } from "commontools";
+
+// NOTE: The expected output for this test is currently a placeholder.
+// This test demonstrates a stack overflow bug when recursive types are
+// nested inside other types. Once the bug is fixed, the expected output
+// should be updated with the actual transformation result.
+
+interface LinkedList {
+  value: number;
+  next?: LinkedList;
+}
+
+interface RootType {
+  list: LinkedList;
+}
+
+const rootTypeSchema = toSchema<RootType>();
+
+export { rootTypeSchema };
+
+// Add a recipe export for ct dev testing
+export default recipe("Nested Recursive Type Test", () => {
+  return {
+    schema: rootTypeSchema,
+  };
+});


### PR DESCRIPTION
…we should turn it on when we support it
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a test for nested recursive types to highlight a stack overflow bug in schema transformation. The test is skipped for now and will be enabled once the bug is fixed.

<!-- End of auto-generated description by cubic. -->

