### PR TITLE
feat: add harness for (Deno) unit tests in shell. Add de/serialization app state tests.

### DIFF
--- a/packages/shell/deno.json
+++ b/packages/shell/deno.json
@@ -6,8 +6,8 @@
     "serve": "deno run -A ../felt/cli.ts serve .",
     "dev": "API_URL=https://toolshed.saga-castor.ts.net deno run -A ../felt/cli.ts dev .",
     "dev-local": "API_URL=http://localhost:8000 deno run -A ../felt/cli.ts dev .",
-    "test": "deno run build",
-    "integration": "deno test -A ./integration/*.test.ts"
+    "integration": "deno test -A ./integration/*.test.ts",
+    "test": "deno test test/*.test.ts"
   },
   "exports": "./src/index.ts",
   "imports": {

--- a/packages/shell/src/lib/app/controller.ts
+++ b/packages/shell/src/lib/app/controller.ts
@@ -1,8 +1,6 @@
 import {
   deserializeKeyPairRaw,
   Identity,
-  isKeyPairRaw,
-  KeyPairRaw,
   KeyStore,
   TransferrableInsecureCryptoKeyPair,
 } from "@commontools/identity";
@@ -65,7 +63,7 @@ export class App extends EventTarget {
     this.#element.requestUpdate("keyStore", undefined);
     const root = await ks.get(ROOT_KEY);
     if (root) {
-      await app.setIdentity(root);
+      await this.setIdentity(root);
     }
   }
 }

--- a/packages/shell/test/app-state.test.ts
+++ b/packages/shell/test/app-state.test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from "@std/testing/bdd";
+import {
+  AppState,
+  AppStateSerialized,
+  deserialize,
+  serialize,
+} from "../src/lib/app/mod.ts";
+import { Identity, serializeKeyPairRaw } from "@commontools/identity";
+import { assert } from "@std/assert";
+
+const API_URL = "http://common.test/";
+const SPACE_NAME = "common-knowledge";
+
+describe("AppState", () => {
+  it("serialize", async () => {
+    const state: AppState = {
+      apiUrl: new URL(API_URL),
+      spaceName: SPACE_NAME,
+    };
+
+    let serialized = serialize(state);
+    assert(serialized.apiUrl === API_URL);
+    assert(serialized.spaceName === SPACE_NAME);
+    assert(
+      serialized.identity === undefined,
+      "Identity not provided (undefined).",
+    );
+
+    state.identity = await Identity.generate({ implementation: "webcrypto" }),
+      serialized = serialize(state);
+    assert(serialized.apiUrl === API_URL);
+    assert(serialized.spaceName === SPACE_NAME);
+    assert(
+      serialized.identity === null,
+      "WebCrypto keys cannot be serialized (null).",
+    );
+
+    state.identity = await Identity.generate({ implementation: "noble" });
+    serialized = serialize(state);
+    assert(serialized.apiUrl === API_URL);
+    assert(serialized.spaceName === SPACE_NAME);
+    assert(serialized.identity);
+    assert(
+      (await Identity.fromRaw(Uint8Array.from(serialized.identity.privateKey)))
+        .did() ===
+        state.identity.did(),
+      "Insecure keys are serializable.",
+    );
+  });
+
+  it("deserialize", async () => {
+    const identity = await Identity.generate({ implementation: "noble" });
+    const identityRaw = serializeKeyPairRaw(identity.serialize());
+    assert(identityRaw, "Deserialized, transferrable identity.");
+
+    const serialized: AppStateSerialized = {
+      apiUrl: API_URL,
+      spaceName: SPACE_NAME,
+    };
+
+    let state = await deserialize(serialized);
+    assert(state.apiUrl.toString() === API_URL.toString());
+    assert(state.spaceName === SPACE_NAME);
+    assert(state.identity === undefined);
+
+    serialized.identity = identityRaw;
+    state = await deserialize(serialized);
+    assert(state.apiUrl.toString() === API_URL.toString());
+    assert(state.spaceName === SPACE_NAME);
+    assert(state.identity?.did() === identity.did(), "deserializes identity.");
+  });
+});


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a Deno unit test harness for the shell package and new tests for app state serialization and deserialization. Updated test script in deno.json for easier test runs.

<!-- End of auto-generated description by cubic. -->

