### PR TITLE
iframe: Expose load state status as attributes for integration tests to select

### DIFF
--- a/packages/deno-web-test/utils.ts
+++ b/packages/deno-web-test/utils.ts
@@ -56,6 +56,14 @@ export async function bundle(inputPath: string, outputPath: string) {
     },
     bundle: true,
     format: "esm",
+    tsconfigRaw: {
+      compilerOptions: {
+        // `useDefineForClassFields` is critical when using Lit
+        // with esbuild, even when not using decorators.
+        useDefineForClassFields: false,
+        experimentalDecorators: true,
+      },
+    },
   });
 
   esbuild.stop();

--- a/packages/shell/integration/iframe-counter-charm.test.ts
+++ b/packages/shell/integration/iframe-counter-charm.test.ts
@@ -117,14 +117,17 @@ describe("shell iframe counter tests", () => {
       identity,
     });
 
-    // Wait for iframe content to load
-    // The charm uses nested iframes with sandbox restrictions, requiring coordinate-based interaction
-    await sleep(5000);
-
     // Get the iframe element using pierce selector to traverse shadow DOM
-    const counterIframe = await page.$("iframe", { strategy: "pierce" });
-    assert(counterIframe, "Outer iframe should be found");
+    const counterIframe = await page.waitForSelector(
+      'common-iframe-sandbox[load-state="loaded"]',
+      { strategy: "pierce" },
+    );
 
+    // TODO(js): No way currently to know when an iframe's react
+    // views are rendered, wait after the iframe's contents have been loaded.
+    await sleep(2000);
+
+    // The charm uses nested iframes with sandbox restrictions, requiring coordinate-based interaction
     // Click the right third of the iframe 5 times to increment (starting from 0)
     console.log("Clicking increment area 5 times...");
     for (let i = 0; i < 5; i++) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Exposed the iframe load state as a reflected attribute so integration tests can reliably select and interact with loaded iframes.

- **Integration Test Improvements**
  - Updated tests to wait for the new load-state attribute before interacting with iframe content.

<!-- End of auto-generated description by cubic. -->

