### PR TITLE
Allow common element properties like `id` for `ct-` JSX types

### DIFF
--- a/packages/static/assets/types/jsx.d.ts
+++ b/packages/static/assets/types/jsx.d.ts
@@ -4,6 +4,10 @@ type Child = {
   children?: Children;
 };
 
+type Elem = {
+  id?: string
+}
+
 type Cell<T> = any
 type Charm = any
 
@@ -32,7 +36,7 @@ declare global {
         $value: Cell<{ root: OutlinerNode }>,
         $mentionable?: Cell<Charm[]>
         'oncharm-link-click'?: any,
-      } & Child;
+      } & Child & Elem;
       "ct-list": {
         $value: Cell<ListItem[]>,
         /** setting this allows editing items inline */
@@ -41,7 +45,7 @@ declare global {
         readonly?: boolean,
         title?: string,
         'onct-remove-item'?: any,
-      } & Child;
+      } & Child & Elem;
       "ct-input": {
         $value?: Cell<string>,
         customStyle?: string, // bf: I think this is going to go away one day soon
@@ -78,7 +82,7 @@ declare global {
         'onct-keydown'?: any,
         'onct-submit'?: any,
         'onct-invalid'?: any,
-      } & Child;
+      } & Child & Elem;
     }
   }
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for common element properties like `id` to all `ct-` JSX components, making it easier to assign unique identifiers in the UI.

<!-- End of auto-generated description by cubic. -->

