### PR TITLE
syntax question: thoughts on inline types?

### DIFF
--- a/packages/patterns/array-in-cell-ast-nocomponents.tsx
+++ b/packages/patterns/array-in-cell-ast-nocomponents.tsx
@@ -15,28 +15,18 @@ interface Item {
   text: Default<string, "">;
 }
 
-interface InputSchema {
-  title: Default<string, "untitled">;
-  items: Default<Item[], []>;
-}
-
-type InputEventType = {
-  detail: {
-    message: string;
-  };
-};
-
-interface ListState {
-  items: Cell<Item[]>;
-}
-
-const addItem = handler<InputEventType, ListState>(
-  (event: InputEventType, state: ListState) => {
-    state.items.push({ text: event.detail.message });
+const addItem = handler(
+  (event: { detail: { message: string } }, { items }: {
+    items: Cell<Item[]>;
+  }) => {
+    items.push({ text: event.detail.message });
   },
 );
 
-export default recipe("Simple List", ({ title, items }: InputSchema) => {
+export default recipe<{
+  title: Default<string, "untitled">;
+  items: Default<Item[], []>;
+}>("Simple List", ({ title, items }) => {
   return {
     [NAME]: title,
     [UI]: (

--- a/packages/patterns/array-in-cell-with-remove-ast-nocomponents.tsx
+++ b/packages/patterns/array-in-cell-with-remove-ast-nocomponents.tsx
@@ -15,38 +15,35 @@ interface Item {
   text: Default<string, "">;
 }
 
-interface InputSchema {
-  title: Default<string, "untitled">;
-  items: Default<Item[], []>;
-}
-
+// Should be imported, once we have types for all events
 type InputEventType = {
   detail: {
     message: string;
   };
 };
 
-interface ListState {
-  items: Cell<Item[]>;
-}
-
-const addItem = handler<InputEventType, ListState>(
-  (event: InputEventType, state: ListState) => {
-    state.items.push({ text: event.detail.message });
+const addItem = handler(
+  (event: InputEventType, { items }: {
+    items: Cell<Item[]>;
+  }) => {
+    items.push({ text: event.detail.message });
   },
 );
 
-const removeItem = handler<unknown, { items: Cell<Item[]>; index: number }>(
-  (_, { items, index }) => {
+const removeItem = handler(
+  (_, { items, index }: { items: Cell<Item[]>; index: number }) => {
     const next = items.get().slice();
     if (index >= 0 && index < next.length) next.splice(index, 1);
     items.set(next);
   },
 );
 
-export default recipe(
+export default recipe<{
+  title: Default<string, "untitled">;
+  items: Default<Item[], []>;
+}>(
   "Simple List with Remove",
-  ({ title, items }: InputSchema) => {
+  ({ title, items }) => {
     return {
       [NAME]: title,
       [UI]: (

--- a/packages/patterns/counter.tsx
+++ b/packages/patterns/counter.tsx
@@ -13,16 +13,12 @@ import {
   UI,
 } from "commontools";
 
-interface RecipeState {
-  value: Default<number, 0>;
-}
-
-const increment = handler<unknown, { value: Cell<number> }>((_, state) => {
-  state.value.set(state.value.get() + 1);
+const increment = handler((_, { value }: { value: Cell<number> }) => {
+  value.set(value.get() + 1);
 });
 
-const decrement = handler((_, state: { value: Cell<number> }) => {
-  state.value.set(state.value.get() - 1);
+const decrement = handler((_, { value }: { value: Cell<number> }) => {
+  value.set(value.get() - 1);
 });
 
 function previous(value: number) {
@@ -42,22 +38,22 @@ function nth(value: number) {
   return `${value}th`;
 }
 
-export default recipe<RecipeState>("Counter", (state) => {
+export default recipe<{ value: Default<number, 0> }>("Counter", ({ value }) => {
   return {
-    [NAME]: str`Simple counter: ${state.value}`,
+    [NAME]: str`Simple counter: ${value}`,
     [UI]: (
       <div>
-        <ct-button onClick={decrement(state)}>
-          dec to {previous(state.value)}
+        <ct-button onClick={decrement({ value })}>
+          dec to {previous(value)}
         </ct-button>
         <span id="counter-result">
-          Counter is the {nth(state.value)} number
+          Counter is the {nth(value)} number
         </span>
-        <ct-button onClick={increment({ value: state.value })}>
-          inc to {state.value + 1}
+        <ct-button onClick={increment({ value })}>
+          inc to {value + 1}
         </ct-button>
       </div>
     ),
-    value: state.value,
+    value,
   };
 });


### PR DESCRIPTION
I wondered whether the extensive type definitions at the top are a left-over from directly translating JSON Schema based recipes and so here I'm reducing global definitions to core concepts, e.g. `Item` and otherwise inline types to get closer to how one would e.g. define a function with several parameters.

The event type should probably actually be imported, once we define standard types for all events, so I included both variants.

There's also a mix of providing the type in the generic:
```recipe<{ items: Default<Items[], []> }("..", ({ items }) => ...```
vs inline
```handler((_, { value }: { value: Cell<number> }) => ...```

the latter seems to not currently work with recipes, at least when `Default` is involved.

I think we should support all variations, but my question is whether there is one style or another that we should prefer. What should go into the style guide, so that all example patterns are consistent?
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched recipe and handler definitions to use inline TypeScript types instead of global interface declarations for function parameters and state.

- **Refactors**
 - Removed separate interface/type declarations for state and parameters.
 - Used inline types directly in handler and recipe function signatures.
 - Made patterns more consistent and easier to read.

<!-- End of auto-generated description by cubic. -->

