### PR TITLE
chore: Align CharmManager/CharmController usage in integration tests

### DIFF
--- a/packages/background-charm-service/integration/counter.test.ts
+++ b/packages/background-charm-service/integration/counter.test.ts
@@ -1,35 +1,31 @@
 import { env } from "@commontools/integration";
 import { sleep } from "@commontools/utils/sleep";
-import {
-  registerCharm,
-  ShellIntegration,
-} from "@commontools/integration/shell-utils";
-import { describe, it } from "@std/testing/bdd";
+import { ShellIntegration } from "@commontools/integration/shell-utils";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { assert } from "@std/assert";
 import { Identity } from "@commontools/identity";
+import { CharmsController } from "@commontools/charm/ops";
 
-const { API_URL, FRONTEND_URL } = env;
+const { SPACE_NAME, API_URL, FRONTEND_URL } = env;
 
 describe("background charm counter tests", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
 
-  it.skip("can register and interact with background counter charm", async () => {
-    // FIXME(ja): currently bg process doesn't receive updates of bgCharms,
-    // and so we need to start it after we register :(  We should start it here
-    // this.charmCell.sink only seems to trigger when the service.ts starts -
-    // restarting is currently the only way to get the charmCell to update
+  let charmId: string;
+  let identity: Identity;
+  let cc: CharmsController;
 
-    const page = shell.page();
-    const identity = await Identity.generate({ implementation: "noble" });
-    const spaceName = globalThis.crypto.randomUUID();
-
-    const charmId = await registerCharm({
-      spaceName: spaceName,
+  beforeAll(async () => {
+    identity = await Identity.generate({ implementation: "noble" });
+    cc = await CharmsController.initialize({
+      spaceName: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity: identity,
-      source: await Deno.readTextFile(
+    });
+    const charm = await cc.create(
+      await Deno.readTextFile(
         join(
           import.meta.dirname!,
           "..",
@@ -39,11 +35,25 @@ describe("background charm counter tests", () => {
           "bgCounter.tsx",
         ),
       ),
-    });
+    );
+    charmId = charm.id;
+  });
+
+  afterAll(async () => {
+    if (cc) await cc.dispose();
+  });
+
+  it.skip("can register and interact with background counter charm", async () => {
+    // FIXME(ja): currently bg process doesn't receive updates of bgCharms,
+    // and so we need to start it after we register :(  We should start it here
+    // this.charmCell.sink only seems to trigger when the service.ts starts -
+    // restarting is currently the only way to get the charmCell to update
+
+    const page = shell.page();
 
     await shell.goto({
       frontendUrl: FRONTEND_URL,
-      spaceName,
+      spaceName: SPACE_NAME,
       charmId,
       identity,
     });

--- a/packages/patterns/integration/instantiate-recipe.test.ts
+++ b/packages/patterns/integration/instantiate-recipe.test.ts
@@ -1,13 +1,11 @@
 import { env } from "@commontools/integration";
 import { sleep } from "@commontools/utils/sleep";
-import {
-  registerCharm,
-  ShellIntegration,
-} from "@commontools/integration/shell-utils";
-import { beforeAll, describe, it } from "@std/testing/bdd";
+import { ShellIntegration } from "@commontools/integration/shell-utils";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { assert } from "@std/assert";
 import { Identity } from "@commontools/identity";
+import { CharmsController } from "@commontools/charm/ops";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
@@ -17,23 +15,29 @@ describe("instantiate-recipe integration test", () => {
 
   let charmId: string;
   let identity: Identity;
+  let cc: CharmsController;
 
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
-
-    // Register the instantiate-recipe charm
-    charmId = await registerCharm({
+    cc = await CharmsController.initialize({
       spaceName: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity: identity,
-      source: await Deno.readTextFile(
+    });
+    const charm = await cc.create(
+      await Deno.readTextFile(
         join(
           import.meta.dirname!,
           "..",
           "instantiate-recipe.tsx",
         ),
       ),
-    });
+    );
+    charmId = charm.id;
+  });
+
+  afterAll(async () => {
+    if (cc) await cc.dispose();
   });
 
   it("should deploy recipe, click button, and navigate to counter", async () => {


### PR DESCRIPTION
* Remove redundant helper utils (e.g. creating a manager/runtime) -- now use `await CharmsController.initialize({..})`
* Make runtime internals external to shell utils -- most tests only need one space and a charm, but not always.
* Fix erroneous `this.checkIsOk()` page check in ShellIntegration.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized all integration tests to use CharmsController.initialize for charm creation, removed redundant helper utilities, and simplified test setup.

- **Refactors**
 - Removed custom runtime and manager helpers from shell-utils.
 - Updated tests to create charms and manage lifecycle with CharmsController.
 - Fixed unnecessary page checks in ShellIntegration.

<!-- End of auto-generated description by cubic. -->

