### PR TITLE
added named based guards and depth limits

### DIFF
--- a/packages/js-runtime/typescript/transformer/schema-generator.ts
+++ b/packages/js-runtime/typescript/transformer/schema-generator.ts
@@ -117,6 +117,63 @@ function safeGetPropertyType(
 }
 
 /**
+ * Extract the target symbol name for a TypeReference, if any.
+ */
+function getTargetSymbolName(type: ts.Type): string | undefined {
+  const typeRef = type as ts.TypeReference;
+  return (typeRef as any).target?.symbol?.name || type.symbol?.name;
+}
+
+/**
+ * Return the nth type argument if this is a TypeReference and available.
+ */
+function getTypeArgument(type: ts.Type, index: number): ts.Type | undefined {
+  const typeRef = type as ts.TypeReference;
+  const args = typeRef.typeArguments as ts.Type[] | undefined;
+  if (args && args.length > index) return args[index];
+  const resolved = (type as any).resolvedTypeArguments as ts.Type[] | undefined;
+  if (resolved && resolved.length > index) return resolved[index];
+  return undefined;
+}
+
+/**
+ * Determine if a TypeReferenceNode is Default<T, V> or an alias to it
+ */
+function isDefaultTypeRef(
+  node: ts.TypeReferenceNode,
+  checker: ts.TypeChecker,
+): boolean {
+  // Direct name match
+  if (ts.isIdentifier(node.typeName) && node.typeName.text === "Default") {
+    return true;
+  }
+  // Alias case: resolve symbol and inspect alias declaration target
+  const sym = checker.getSymbolAtLocation(node.typeName);
+  if (!sym) return false;
+  const decl = sym.declarations?.[0];
+  if (decl && ts.isTypeAliasDeclaration(decl)) {
+    const aliased = decl.type;
+    if (ts.isTypeReferenceNode(aliased) && ts.isIdentifier(aliased.typeName)) {
+      return aliased.typeName.text === "Default";
+    }
+  }
+  return false;
+}
+
+/**
+ * Return the symbol name for a type if it's a named interface/class/alias; otherwise undefined.
+ */
+function getNamedTypeKey(type: ts.Type): string | undefined {
+  const sym = (type as any).aliasSymbol as ts.Symbol | undefined;
+  const aliasName = sym?.name;
+  if (aliasName && aliasName !== "__type") return aliasName;
+  const direct = type.getSymbol?.();
+  const name = direct?.name;
+  if (!name || name === "__type") return undefined;
+  return name;
+}
+
+/**
  * Build an object schema for a given type. This is separated so we can reuse it
  * while guarding against self-recursion via definitionStack.
  */
@@ -129,7 +186,20 @@ function buildObjectSchema(
   cyclicTypes: Set<ts.Type> | undefined,
   definitions: Record<string, any> | undefined,
   definitionStack: Set<ts.Type>,
+  inProgressNames: Set<string>,
+  emittedRefs: Set<string>,
 ): any {
+  if (depth > 200) {
+    // If we hit an extreme depth, prefer a $ref if possible, else a permissive object
+    const namedKey = definitions ? getNamedTypeKey(type) : undefined;
+    if (namedKey && definitions) {
+      if (!definitions[namedKey]) {
+        definitions[namedKey] = { type: "object", properties: {} };
+      }
+      return { "$ref": `#/definitions/${namedKey}` };
+    }
+    return { type: "object", additionalProperties: true };
+  }
   const properties: any = {};
   const required: string[] = [];
 
@@ -164,6 +234,8 @@ function buildObjectSchema(
       definitions,
       definitionStack,
       false,
+      inProgressNames,
+      emittedRefs,
     );
 
     properties[propName] = propSchema;
@@ -187,8 +259,61 @@ function typeToJsonSchemaHelper(
   definitions?: Record<string, any>,
   definitionStack: Set<ts.Type> = new Set(),
   isRootType: boolean = false,
+  inProgressNames: Set<string> = new Set(),
+  emittedRefs: Set<string> = new Set(),
 ): any {
-  // If cyclicTypes is provided, check if this is a cyclic type
+  if (depth > 200) {
+    const namedKey = definitions ? getNamedTypeKey(type) : undefined;
+    if (namedKey && definitions) {
+      if (!definitions[namedKey]) {
+        definitions[namedKey] = { type: "object", properties: {} };
+      }
+      return { "$ref": `#/definitions/${namedKey}` };
+    }
+    return { type: "object", additionalProperties: true };
+  }
+  // If the type node explicitly represents Default<T,V>, handle it first so defaults propagate
+  if (
+    typeNode && ts.isTypeReferenceNode(typeNode) && typeNode.typeArguments &&
+    typeNode.typeArguments.length >= 2
+  ) {
+    if (isDefaultTypeRef(typeNode, checker)) {
+      const innerNode = typeNode.typeArguments[0]!;
+      const defaultNode = typeNode.typeArguments[1]!;
+      const innerType = checker.getTypeFromTypeNode(innerNode);
+      const schema = typeToJsonSchemaHelper(
+        innerType,
+        checker,
+        innerNode,
+        depth + 1,
+        seenTypes,
+        cyclicTypes,
+        definitions,
+        definitionStack,
+        false,
+        inProgressNames,
+        emittedRefs,
+      );
+      const extracted = extractValueFromTypeNode(defaultNode, checker);
+      if (extracted !== undefined) (schema as any).default = extracted as any;
+      return schema;
+    }
+  }
+
+  // Name-based guards/ref reuse: if a named type is in progress or already defined, return a $ref
+  const namedKey = definitions ? getNamedTypeKey(type) : undefined;
+  if (namedKey && definitions) {
+    if (inProgressNames.has(namedKey)) {
+      emittedRefs.add(namedKey);
+      return { "$ref": `#/definitions/${namedKey}` };
+    }
+    if (definitions[namedKey]) {
+      emittedRefs.add(namedKey);
+      return { "$ref": `#/definitions/${namedKey}` };
+    }
+  }
+
+  // If cyclicTypes is provided, check if this is a cyclic type by identity
   if (cyclicTypes && cyclicTypes.has(type) && definitions) {
     const typeName = getStableTypeName(type, definitions);
 
@@ -214,6 +339,8 @@ function typeToJsonSchemaHelper(
           cyclicTypes,
           definitions,
           definitionStack,
+          inProgressNames,
+          emittedRefs,
         );
         definitions[typeName] = defSchema;
         definitionStack.delete(type);
@@ -225,15 +352,6 @@ function typeToJsonSchemaHelper(
     // Mark as in-progress so inner references become $ref
     definitionStack.add(type);
     seenTypes.add(type);
-  }
-
-  // Old cycle detection for when cyclicTypes is not provided
-  if (!cyclicTypes && seenTypes.has(type)) {
-    return {
-      type: "object",
-      additionalProperties: true,
-      $comment: "Recursive type detected - placeholder schema",
-    };
   }
 
   // Create a new set with this type added for recursive calls where appropriate
@@ -252,197 +370,57 @@ function typeToJsonSchemaHelper(
       !["Date", "RegExp", "Promise", "Map", "Set", "WeakMap", "WeakSet"]
         .includes(symbol.name);
 
-    if (shouldTrack) {
+    if (shouldTrack && !newSeenTypes.has(type)) {
       newSeenTypes.add(type);
     }
   }
 
-  // If we have a type node, check if it's a type reference to Default<T, V>
-  if (typeNode && ts.isTypeReferenceNode(typeNode)) {
-    const typeName = typeNode.typeName;
-    // Check if this is Default or a type that resolves to Default
-    if (ts.isIdentifier(typeName)) {
-      // Check if the resolved type is Default
-      // Wrap in try-catch to handle potential stack overflow with recursive types
-      let symbol: ts.Symbol | undefined;
-      let resolvedType: ts.Type;
-
-      try {
-        symbol = checker.getSymbolAtLocation(typeName);
-        resolvedType = checker.getTypeFromTypeNode(typeNode);
-      } catch (error) {
-        // If we get a stack overflow, skip the Default type checking
-        // Don't log as it could cause another stack overflow
-        // Fall through to normal type processing
-        try {
-          logger.warn(() =>
-            "typeToJsonSchemaHelper: resolving Default type caused checker error; skipping Default handling"
-          );
-        } catch (_e) {
-          // Swallow any logging issues to remain safe
-        }
-        symbol = undefined;
-        resolvedType = type;
-      }
-
-      // Check if the symbol is a type alias that resolves to Default
-      let declaredType: ts.Type | undefined;
-      let isDefaultAlias = false;
-      if (symbol && symbol.flags & ts.SymbolFlags.TypeAlias) {
-        // Get the type alias declaration to check what it aliases to
-        const aliasDecl = symbol.declarations?.[0];
-        if (
-          aliasDecl && ts.isTypeAliasDeclaration(aliasDecl) && aliasDecl.type
-        ) {
-          // Check if the type node is a reference to Default
-          if (
-            ts.isTypeReferenceNode(aliasDecl.type) &&
-            ts.isIdentifier(aliasDecl.type.typeName) &&
-            aliasDecl.type.typeName.text === "Default"
-          ) {
-            isDefaultAlias = true;
-          }
-        }
-        declaredType = checker.getDeclaredTypeOfSymbol(symbol);
-      }
-
-      const isDefaultType = typeName.text === "Default" ||
-        (resolvedType as any).target?.symbol?.name === "Default" ||
-        resolvedType.symbol?.name === "Default" ||
-        (resolvedType as any).aliasSymbol?.name === "Default" ||
-        (declaredType &&
-          (declaredType as any).aliasSymbol?.name === "Default") ||
-        isDefaultAlias;
-
-      if (isDefaultType) {
-        // For type aliases that resolve to Default, we need to get the instantiated type
-        // The resolvedType is the final type (e.g., string), but we need the Default<string, "hello"> type
-        if (isDefaultAlias) {
-          // This is a type alias to Default - we need to instantiate it with the type arguments
-          const typeArgs = typeNode.typeArguments;
-          if (typeArgs && typeArgs.length >= 2) {
-            const innerTypeNode = typeArgs[0];
-            const defaultValueNode = typeArgs[1];
-
-            // Get the inner type
-            const innerType = checker.getTypeFromTypeNode(innerTypeNode);
-            const schema = typeToJsonSchemaHelper(
-              innerType,
-              checker,
-              innerTypeNode,
-              depth + 1,
-              newSeenTypes,
-              cyclicTypes,
-              definitions,
-              definitionStack,
-              false, // Default inner types are never root types
-            );
-
-            // Extract the default value from the type node
-            const defaultValue = extractValueFromTypeNode(
-              defaultValueNode,
-              checker,
-            );
-            if (defaultValue !== undefined) {
-              schema.default = defaultValue;
-            }
-
-            return schema;
-          }
-        }
-
-        // For type aliases, we need to check if the resolved type has type arguments
-        const typeRef = resolvedType as ts.TypeReference;
-        if (typeRef.typeArguments && typeRef.typeArguments.length >= 2) {
-          const innerType = typeRef.typeArguments[0];
-          const defaultValueType = typeRef.typeArguments[1];
-
-          // Get the schema for the inner type
-          const schema = typeToJsonSchemaHelper(
-            innerType,
-            checker,
-            typeNode,
-            depth + 1,
-            newSeenTypes,
-            cyclicTypes,
-            definitions,
-            definitionStack,
-            false, // Default inner types are never root types
-          );
-
-          // Try to extract the literal value from the default value type
-          if (defaultValueType.flags & ts.TypeFlags.NumberLiteral) {
-            // @ts-ignore - accessing value property
-            schema.default = (defaultValueType as any).value;
-          } else if (defaultValueType.flags & ts.TypeFlags.StringLiteral) {
-            // @ts-ignore - accessing value property
-            schema.default = (defaultValueType as any).value;
-          } else if (defaultValueType.flags & ts.TypeFlags.BooleanLiteral) {
-            // @ts-ignore - accessing intrinsicName property
-            schema.default = (defaultValueType as any).intrinsicName === "true";
-          } else if ((defaultValueType as any).intrinsicName === "true") {
-            schema.default = true;
-          } else if ((defaultValueType as any).intrinsicName === "false") {
-            schema.default = false;
-          }
-
-          return schema;
-        } else if (
-          typeNode.typeArguments && typeNode.typeArguments.length >= 2
-        ) {
-          // Fallback for direct Default<T, V> usage
-          const innerTypeNode = typeNode.typeArguments[0];
-          const defaultValueNode = typeNode.typeArguments[1];
-
-          // Get the inner type
-          const innerType = checker.getTypeFromTypeNode(innerTypeNode);
-          const schema = typeToJsonSchemaHelper(
-            innerType,
-            checker,
-            innerTypeNode,
-            depth + 1,
-            newSeenTypes,
-            cyclicTypes,
-            definitions,
-            definitionStack,
-            false, // Default inner types are never root types
-          );
-
-          // Extract the default value from the type node
-          const defaultValue = extractValueFromTypeNode(
-            defaultValueNode,
-            checker,
-          );
-          if (defaultValue !== undefined) {
-            schema.default = defaultValue;
-          }
-
-          return schema;
+  // Handle wrapper types before anything else to avoid deep recursion
+  const targetName = getTargetSymbolName(type);
+  if (targetName === "Default") {
+    const inner = getTypeArgument(type, 0);
+    const defaultValueType = getTypeArgument(type, 1);
+    if (inner) {
+      const schema = typeToJsonSchemaHelper(
+        inner,
+        checker,
+        typeNode,
+        depth + 1,
+        newSeenTypes,
+        cyclicTypes,
+        definitions,
+        definitionStack,
+        false,
+        inProgressNames,
+        emittedRefs,
+      );
+      // Prefer extracting default from typeNode if available (handles objects/arrays)
+      if (
+        typeNode && ts.isTypeReferenceNode(typeNode) &&
+        typeNode.typeArguments &&
+        typeNode.typeArguments.length >= 2
+      ) {
+        const defaultNode = typeNode.typeArguments[1]!;
+        const extracted = extractValueFromTypeNode(defaultNode, checker);
+        if (extracted !== undefined) schema.default = extracted as any;
+      } else if (defaultValueType) {
+        // Fallback to simple literal defaults from the type-level defaultValueType
+        if (defaultValueType.flags & ts.TypeFlags.NumberLiteral) {
+          // @ts-ignore: Accessing internal TypeScript API to read literal value
+          schema.default = (defaultValueType as any).value;
+        } else if (defaultValueType.flags & ts.TypeFlags.StringLiteral) {
+          // @ts-ignore: Accessing internal TypeScript API to read literal value
+          schema.default = (defaultValueType as any).value;
+        } else if (defaultValueType.flags & ts.TypeFlags.BooleanLiteral) {
+          // @ts-ignore: Accessing internal TypeScript API to read intrinsicName for boolean literal
+          schema.default = (defaultValueType as any).intrinsicName === "true";
         }
       }
+      return schema;
     }
   }
-
-  // Check if this is a Cell<T> or Stream<T> type at the top level
-  // Check for Cell type by symbol name (handles type aliases)
-  if (type.symbol?.name === "Cell") {
-    // This is a Cell<T> type
-    let innerType = type;
-
-    // Extract the inner type
-    if (type.symbol && type.symbol.getName() === "Cell") {
-      const typeRef = type as ts.TypeReference;
-      if (typeRef.typeArguments && typeRef.typeArguments.length > 0) {
-        innerType = typeRef.typeArguments[0];
-      }
-    } else if ((type as any).resolvedTypeArguments) {
-      const resolvedArgs = (type as any).resolvedTypeArguments;
-      if (resolvedArgs.length > 0) {
-        innerType = resolvedArgs[0];
-      }
-    }
-
-    // Get schema for the inner type
+  if (targetName === "Cell" || targetName === "Stream") {
+    const inner = getTypeArgument(type, 0) || type;
     let innerTypeNode: ts.TypeNode | undefined;
     if (
       typeNode && ts.isTypeReferenceNode(typeNode) && typeNode.typeArguments &&
@@ -451,7 +429,7 @@ function typeToJsonSchemaHelper(
       innerTypeNode = typeNode.typeArguments[0];
     }
     const schema = typeToJsonSchemaHelper(
-      innerType,
+      inner,
       checker,
       innerTypeNode || typeNode,
       depth + 1,
@@ -459,43 +437,12 @@ function typeToJsonSchemaHelper(
       cyclicTypes,
       definitions,
       definitionStack,
-      false, // Cell inner types are never root types
+      false,
+      inProgressNames,
+      emittedRefs,
     );
-    schema.asCell = true;
-    return schema;
-  }
-
-  // Check for Stream type by symbol name (handles type aliases)
-  if (type.symbol?.name === "Stream") {
-    // This is a Stream<T> type
-    let innerType = type;
-
-    // Extract the inner type
-    const typeRef = type as ts.TypeReference;
-    if (typeRef.typeArguments && typeRef.typeArguments.length > 0) {
-      innerType = typeRef.typeArguments[0];
-    }
-
-    // Get schema for the inner type
-    let innerTypeNode: ts.TypeNode | undefined;
-    if (
-      typeNode && ts.isTypeReferenceNode(typeNode) && typeNode.typeArguments &&
-      typeNode.typeArguments.length > 0
-    ) {
-      innerTypeNode = typeNode.typeArguments[0];
-    }
-    const schema = typeToJsonSchemaHelper(
-      innerType,
-      checker,
-      innerTypeNode || typeNode,
-      depth + 1,
-      newSeenTypes,
-      cyclicTypes,
-      definitions,
-      definitionStack,
-      false, // Stream inner types are never root types
-    );
-    schema.asStream = true;
+    if (targetName === "Cell") schema.asCell = true;
+    if (targetName === "Stream") schema.asStream = true;
     return schema;
   }
 
@@ -510,7 +457,6 @@ function typeToJsonSchemaHelper(
     return { type: "boolean" };
   }
   if (type.flags & ts.TypeFlags.BooleanLiteral) {
-    // Handle boolean literals (true/false) as boolean type
     return { type: "boolean" };
   }
   if (type.flags & ts.TypeFlags.Null) {
@@ -518,31 +464,28 @@ function typeToJsonSchemaHelper(
   }
 
   // Handle arrays BEFORE object types (arrays are objects too)
-  // First check if we have an array type node (most reliable)
   if (typeNode && ts.isArrayTypeNode(typeNode)) {
     const elementTypeNode = typeNode.elementType;
-    // Try to get the element type from the node
     const elementType = checker.getTypeFromTypeNode(elementTypeNode);
-    return {
-      type: "array",
-      items: typeToJsonSchemaHelper(
-        elementType,
-        checker,
-        elementTypeNode,
-        depth + 1,
-        newSeenTypes,
-        cyclicTypes,
-        definitions,
-        definitionStack,
-        false, // array elements are never root types
-      ),
-    };
+    const itemsSchema = typeToJsonSchemaHelper(
+      elementType,
+      checker,
+      elementTypeNode,
+      depth + 1,
+      newSeenTypes,
+      cyclicTypes,
+      definitions,
+      definitionStack,
+      false,
+      inProgressNames,
+      emittedRefs,
+    );
+    const schema: any = { type: "array", items: itemsSchema };
+    return schema;
   }
 
-  // Otherwise use type-based detection
   const arrayElementType = getArrayElementType(type, checker);
   if (arrayElementType) {
-    // Extract element type node if we have a type node
     let elementTypeNode: ts.TypeNode | undefined;
     if (
       typeNode && ts.isTypeReferenceNode(typeNode) &&
@@ -552,20 +495,20 @@ function typeToJsonSchemaHelper(
       elementTypeNode = typeNode.typeArguments[0];
     }
 
-    return {
-      type: "array",
-      items: typeToJsonSchemaHelper(
-        arrayElementType,
-        checker,
-        elementTypeNode,
-        depth + 1,
-        newSeenTypes,
-        cyclicTypes,
-        definitions,
-        definitionStack,
-        false, // array elements are never root types
-      ),
-    };
+    const itemsSchema = typeToJsonSchemaHelper(
+      arrayElementType,
+      checker,
+      elementTypeNode,
+      depth + 1,
+      newSeenTypes,
+      cyclicTypes,
+      definitions,
+      definitionStack,
+      false,
+      inProgressNames,
+      emittedRefs,
+    );
+    return { type: "array", items: itemsSchema };
   }
 
   // Handle Date
@@ -574,108 +517,47 @@ function typeToJsonSchemaHelper(
     return { type: "string", format: "date-time" };
   }
 
-  // Check if this is a type reference (e.g., Default<T, V>)
-  if ((type as any).target) {
-    const typeRef = type as ts.TypeReference;
-    const target = (typeRef as any).target;
+  // Handle object types (interfaces, type literals)
+  if (type.flags & ts.TypeFlags.Object) {
+    // If this is a named type and we can emit definitions, build via a placeholder and decide whether to keep a $ref
+    if (
+      namedKey &&
+      definitions &&
+      !(cyclicTypes && cyclicTypes.has(type) && isRootType)
+    ) {
+      // Set placeholder and mark in-progress
+      if (!definitions[namedKey]) definitions[namedKey] = {};
+      inProgressNames.add(namedKey);
 
-    // Check if it's Default type by checking the symbol name
-    if (target.symbol && target.symbol.name === "Default") {
-      // This is a generic type Default<T, V>
-      if (typeRef.typeArguments && typeRef.typeArguments.length >= 2) {
-        const innerType = typeRef.typeArguments[0];
-        const defaultValueType = typeRef.typeArguments[1];
-
-        // Get the schema for the inner type
-        const schema = typeToJsonSchemaHelper(
-          innerType,
-          checker,
-          typeNode,
-          depth + 1,
-          newSeenTypes,
-          cyclicTypes,
-          definitions,
-          definitionStack,
-          false, // Default inner types are never root types
-        );
-
-        // Try to extract the literal value from the default value type
-        if (defaultValueType.flags & ts.TypeFlags.NumberLiteral) {
-          // @ts-ignore - accessing value property
-          schema.default = (defaultValueType as any).value;
-        } else if (defaultValueType.flags & ts.TypeFlags.StringLiteral) {
-          // @ts-ignore - accessing value property
-          schema.default = (defaultValueType as any).value;
-        } else if (defaultValueType.flags & ts.TypeFlags.BooleanLiteral) {
-          // @ts-ignore - accessing intrinsicName property
-          schema.default = (defaultValueType as any).intrinsicName === "true";
-        } else if ((defaultValueType as any).intrinsicName === "true") {
-          schema.default = true;
-        } else if ((defaultValueType as any).intrinsicName === "false") {
-          schema.default = false;
-        } else if (defaultValueType.isLiteral && defaultValueType.isLiteral()) {
-          // Handle other literal types
-          const literalValue = (defaultValueType as any).value;
-          if (literalValue !== undefined) {
-            schema.default = literalValue;
-          }
-        }
-
-        return schema;
-      }
-    }
-  }
-
-  // Handle Default<T, V> type via symbol check (fallback)
-  // Also check if the type resolves to Default through an alias
-  if (
-    symbol &&
-    (symbol.name === "Default" ||
-      (type as any).target?.symbol?.name === "Default")
-  ) {
-    // This is a generic type Default<T, V>
-    const typeRef = type as ts.TypeReference;
-    if (typeRef.typeArguments && typeRef.typeArguments.length >= 2) {
-      const innerType = typeRef.typeArguments[0];
-      const defaultValueType = typeRef.typeArguments[1];
-
-      // Get the schema for the inner type
-      const schema = typeToJsonSchemaHelper(
-        innerType,
+      const defSchema = buildObjectSchema(
+        type,
         checker,
         typeNode,
-        depth + 1,
+        depth,
         newSeenTypes,
         cyclicTypes,
         definitions,
         definitionStack,
-        false, // Default inner types are never root types
+        inProgressNames,
+        emittedRefs,
       );
 
-      // Try to extract the literal value from the default value type
-      if (defaultValueType.flags & ts.TypeFlags.NumberLiteral) {
-        // @ts-ignore - accessing value property
-        schema.default = (defaultValueType as any).value;
-      } else if (defaultValueType.flags & ts.TypeFlags.StringLiteral) {
-        // @ts-ignore - accessing value property
-        schema.default = (defaultValueType as any).value;
-      } else if (defaultValueType.flags & ts.TypeFlags.BooleanLiteral) {
-        // @ts-ignore - accessing intrinsicName property
-        schema.default = (defaultValueType as any).intrinsicName === "true";
-      } else if ((defaultValueType as any).intrinsicName === "true") {
-        schema.default = true;
-      } else if ((defaultValueType as any).intrinsicName === "false") {
-        schema.default = false;
+      inProgressNames.delete(namedKey);
+
+      // Keep definition only if recursion occurred or identity-based cycle detected
+      if (emittedRefs.has(namedKey) || (cyclicTypes && cyclicTypes.has(type))) {
+        definitions[namedKey] = defSchema;
+        if (!isRootType) {
+          return { "$ref": `#/definitions/${namedKey}` };
+        }
+        return defSchema;
+      } else {
+        // No recursion: remove placeholder and inline schema
+        delete definitions[namedKey];
+        return defSchema;
       }
-
-      return schema;
     }
-    // If we can't extract type arguments, return a permissive schema
-    return { type: "object", additionalProperties: true };
-  }
 
-  // Handle object types (interfaces, type literals)
-  if (type.flags & ts.TypeFlags.Object) {
     return buildObjectSchema(
       type,
       checker,
@@ -685,30 +567,29 @@ function typeToJsonSchemaHelper(
       cyclicTypes,
       definitions,
       definitionStack,
+      inProgressNames,
+      emittedRefs,
     );
   }
 
   // Handle union types
   if (type.isUnion()) {
     const unionTypes = (type as ts.UnionType).types;
-    // Check if it's a nullable type (T | undefined)
     const nonNullTypes = unionTypes.filter((t) =>
       !(t.flags & ts.TypeFlags.Undefined)
     );
 
-    // Special handling for boolean | undefined (which appears as false | true | undefined)
+    // Special handling for boolean | undefined
     if (
       unionTypes.length === 3 &&
       unionTypes.filter((t) => t.flags & ts.TypeFlags.BooleanLiteral).length ===
         2 &&
       unionTypes.filter((t) => t.flags & ts.TypeFlags.Undefined).length === 1
     ) {
-      // This is boolean | undefined, return boolean schema
       return { type: "boolean" };
     }
 
     if (nonNullTypes.length === 1 && unionTypes.length === 2) {
-      // This is an optional type, just return the non-null type schema
       return typeToJsonSchemaHelper(
         nonNullTypes[0],
         checker,
@@ -718,10 +599,11 @@ function typeToJsonSchemaHelper(
         cyclicTypes,
         definitions,
         definitionStack,
-        false, // union members are never root types
+        false,
+        inProgressNames,
+        emittedRefs,
       );
     }
-    // Otherwise, use oneOf
     return {
       oneOf: unionTypes.map((t) =>
         typeToJsonSchemaHelper(
@@ -733,50 +615,52 @@ function typeToJsonSchemaHelper(
           cyclicTypes,
           definitions,
           definitionStack,
-          false, // union members are never root types
+          false,
+          inProgressNames,
+          emittedRefs,
         )
       ),
     };
   }
 
-  // Default fallback - for "any" type, use a permissive schema
+  // Fallback
   return { type: "object", additionalProperties: true };
 }
 
-// Helper function to extract values from type nodes (for Default<T, V>)
-function extractValueFromTypeNode(
-  node: ts.TypeNode,
-  checker: ts.TypeChecker,
-): any {
-  // Handle literal type nodes
+/**
+ * Extract literal/default value from a type node, when possible
+ */
+function extractValueFromTypeNode(node: ts.TypeNode, checker: ts.TypeChecker):
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | any[]
+  | Record<string, any> {
+  // Handle literal types directly
   if (ts.isLiteralTypeNode(node)) {
     const literal = node.literal;
-    if (ts.isStringLiteral(literal)) {
-      return literal.text;
-    } else if (ts.isNumericLiteral(literal)) {
-      return Number(literal.text);
-    } else if (literal.kind === ts.SyntaxKind.TrueKeyword) {
-      return true;
-    } else if (literal.kind === ts.SyntaxKind.FalseKeyword) {
-      return false;
-    } else if (literal.kind === ts.SyntaxKind.NullKeyword) {
-      return null;
-    }
+    if (ts.isStringLiteral(literal)) return literal.text;
+    if (ts.isNumericLiteral(literal)) return Number(literal.text);
+    if (literal.kind === ts.SyntaxKind.TrueKeyword) return true;
+    if (literal.kind === ts.SyntaxKind.FalseKeyword) return false;
+    if (literal.kind === ts.SyntaxKind.NullKeyword) return null;
   }
 
-  // Handle tuple types (array literals in type position)
+  // Tuple type nodes (e.g., ["a", "b"]) map to array defaults
   if (ts.isTupleTypeNode(node)) {
     const values: any[] = [];
     for (const elem of node.elements) {
-      const value = extractValueFromTypeNode(elem, checker);
-      values.push(value);
+      const v = extractValueFromTypeNode(elem, checker);
+      values.push(v);
     }
     return values;
   }
 
-  // Handle type literals (object literals in type position)
+  // Type literal nodes map to object defaults
   if (ts.isTypeLiteralNode(node)) {
-    const obj: any = {};
+    const obj: Record<string, any> = {};
     for (const member of node.members) {
       if (
         ts.isPropertySignature(member) && member.name &&
@@ -784,42 +668,25 @@ function extractValueFromTypeNode(
       ) {
         const key = member.name.text;
         if (member.type) {
-          const value = extractValueFromTypeNode(member.type, checker);
-          if (value !== undefined) {
-            obj[key] = value;
-          }
+          const v = extractValueFromTypeNode(member.type, checker);
+          obj[key] = v;
         }
       }
     }
     return obj;
   }
 
-  // Handle array type with literal elements
-  if (ts.isArrayTypeNode(node)) {
-    // For array types like string[], we can't extract a default value
-    return undefined;
-  }
-
-  // Handle union types (for nullable types)
+  // Union type with null/undefined handling (already above)
   if (ts.isUnionTypeNode(node)) {
-    // Check if one of the types is null
-    for (const type of node.types) {
-      if (type.kind === ts.SyntaxKind.NullKeyword) {
-        return null;
-      }
-      if (type.kind === ts.SyntaxKind.UndefinedKeyword) {
-        return undefined;
-      }
+    for (const t of node.types) {
+      if (t.kind === ts.SyntaxKind.NullKeyword) return null;
+      if (t.kind === ts.SyntaxKind.UndefinedKeyword) return undefined;
     }
   }
 
   // Handle direct null/undefined keywords
-  if (node.kind === ts.SyntaxKind.NullKeyword) {
-    return null;
-  }
-  if (node.kind === ts.SyntaxKind.UndefinedKeyword) {
-    return undefined;
-  }
+  if (node.kind === ts.SyntaxKind.NullKeyword) return null;
+  if (node.kind === ts.SyntaxKind.UndefinedKeyword) return undefined;
 
   return undefined;
 }
@@ -833,13 +700,31 @@ export function getCycles(
   checker: ts.TypeChecker,
   visiting: Set<ts.Type> = new Set(),
   cycles: Set<ts.Type> = new Set(),
+  depth: number = 0,
 ): Set<ts.Type> {
+  // Depth guard to avoid stack overflow in pathological cases
+  if (depth > 200) return cycles;
+
   // Skip primitive types - they can't have cycles
   if (
     type.flags &
     (ts.TypeFlags.String | ts.TypeFlags.Number | ts.TypeFlags.Boolean |
       ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void)
   ) {
+    return cycles;
+  }
+
+  // Unwrap known wrappers early (Default<T, V>, Cell<T>, Stream<T>)
+  const wrapperName = getTargetSymbolName(type);
+  if (
+    wrapperName === "Default" || wrapperName === "Cell" ||
+    wrapperName === "Stream"
+  ) {
+    const inner = getTypeArgument(type, 0);
+    if (inner) {
+      getCycles(inner, checker, visiting, cycles, depth + 1);
+    }
+    // For Default<T, V> we only care about T for cycles
     return cycles;
   }
 
@@ -860,7 +745,7 @@ export function getCycles(
       // Check if it's an array type using our helper
       const elementType = getArrayElementType(type, checker);
       if (elementType) {
-        getCycles(elementType, checker, visiting, cycles);
+        getCycles(elementType, checker, visiting, cycles, depth + 1);
       }
       return cycles;
     }
@@ -870,7 +755,6 @@ export function getCycles(
       // This type is part of a cycle
       cycles.add(type);
       // Also mark all types currently being visited as potentially cyclic
-      // This ensures parent types know they contain cyclic children
       visiting.forEach((t) => {
         cycles.add(t);
       });
@@ -887,7 +771,7 @@ export function getCycles(
       // No properties - might be an array type
       const elementType = getArrayElementType(type, checker);
       if (elementType) {
-        getCycles(elementType, checker, visiting, cycles);
+        getCycles(elementType, checker, visiting, cycles, depth + 1);
       }
     } else {
       for (const prop of props) {
@@ -930,12 +814,27 @@ export function getCycles(
               }
               continue;
             }
-            getCycles(elementType, checker, visiting, cycles);
+            getCycles(elementType, checker, visiting, cycles, depth + 1);
             continue;
+          }
+
+          // Unwrap Default<Cell<...>> style references by name when possible
+          if (ts.isTypeReferenceNode(propDecl.type)) {
+            const typeName = propDecl.type.typeName;
+            if (ts.isIdentifier(typeName)) {
+              const refSymbol = checker.getSymbolAtLocation(typeName);
+              const refType = refSymbol
+                ? checker.getDeclaredTypeOfSymbol(refSymbol)
+                : undefined;
+              if (refType) {
+                getCycles(refType, checker, visiting, cycles, depth + 1);
+                continue;
+              }
+            }
           }
         }
 
-        getCycles(propType, checker, visiting, cycles);
+        if (propType) getCycles(propType, checker, visiting, cycles, depth + 1);
       }
     }
 
@@ -947,7 +846,7 @@ export function getCycles(
   if (type.isUnion()) {
     const unionTypes = (type as ts.UnionType).types;
     for (const unionType of unionTypes) {
-      getCycles(unionType, checker, visiting, cycles);
+      getCycles(unionType, checker, visiting, cycles, depth + 1);
     }
   }
 
@@ -966,24 +865,11 @@ export function typeToJsonSchema(
   // First pass: detect cycles
   const cyclicTypes = getCycles(type, checker);
 
-  // If no cycles, just return the simple schema
-  if (cyclicTypes.size === 0) {
-    return typeToJsonSchemaHelper(
-      type,
-      checker,
-      typeNode,
-      0,
-      new Set(),
-      undefined,
-      undefined,
-      new Set(),
-      true,
-    );
-  }
-
-  // Second pass: generate schema with definitions
+  // Second pass: generate schema with definitions (always thread a definitions object)
   const definitions: Record<string, any> = {};
   const seenTypes = new Set<ts.Type>();
+  const inProgressNames = new Set<string>();
+  const emittedRefs = new Set<string>();
 
   // Generate the schema for the root type
   const rootSchema = typeToJsonSchemaHelper(
@@ -996,9 +882,11 @@ export function typeToJsonSchema(
     definitions,
     new Set<ts.Type>(),
     true, // isRootType
+    inProgressNames,
+    emittedRefs,
   );
 
-  // If the root type itself is cyclic, always return a top-level $ref with definitions
+  // If the root type itself is cyclic by identity, return a top-level $ref with definitions
   if (cyclicTypes.has(type)) {
     const typeName = getStableTypeName(type, definitions);
     if (!definitions[typeName]) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added name-based recursion guards and a depth limit to the TypeScript schema generator to stop runaway recursion and improve handling of cyclic and deeply nested types.

- **Refactors**
  - Named interfaces, type aliases, and classes now use $ref references if recursion or excessive depth is detected.
  - Default<T, V>, Cell<T>, and Stream<T> are handled with explicit unwrapping and no longer cause unnecessary deep recursion.
  - Added extraction of default values for object and tuple type nodes.
  - The generator now aborts recursion over depth 200, returning permissive schemas or $ref references as needed.

<!-- End of auto-generated description by cubic. -->

