### PR TITLE
fix(runner): map replaces array instead of setting length

### DIFF
--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -127,7 +127,7 @@ export function map(
 
     // Shorten the result if the list got shorter
     if (resultWithLog.get().length > list.length) {
-      resultWithLog.key("length").set(list.length);
+      resultWithLog.set(resultWithLog.get().slice(0, list.length));
       initializedUpTo = list.length;
     }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the map function so it properly replaces the result array when shortening, instead of just setting its length. This ensures the output array matches the mapped items as expected.

<!-- End of auto-generated description by cubic. -->

