### PR TITLE
feat: Use recipe jsx.d.ts for workspace types.

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -32,6 +32,9 @@
     "initialize-db": "./tasks/initialize-db.sh"
   },
   "compilerOptions": {
+    "types": [
+      "./packages/static/assets/types/jsx.d.ts"
+    ],
     "jsx": "react-jsxdev",
     "lib": [
       "deno.ns",
@@ -84,7 +87,6 @@
     ]
   },
   "imports": {
-    "@types/react": "npm:@types/react@^18.3.1",
     "react": "npm:react@^18.3.1",
     "react-dom": "npm:react-dom@^18.3.1",
     "@babel/standalone": "npm:@babel/standalone@^7.28.2",

--- a/deno.lock
+++ b/deno.lock
@@ -2048,7 +2048,6 @@
       "jsr:@std/path@1",
       "jsr:@std/testing@1",
       "npm:@babel/standalone@^7.28.2",
-      "npm:@types/react@^18.3.1",
       "npm:jsdom@*",
       "npm:lit@^3.3.0",
       "npm:merkle-reference@^2.2.0",

--- a/packages/html/src/jsx.ts
+++ b/packages/html/src/jsx.ts
@@ -3,18 +3,6 @@ import { UI, type VNode } from "@commontools/runner";
 export type { Child, Props } from "@commontools/runner";
 export { type VNode };
 
-// This declaration is for code within our workspace
-// (e.g. shell and @commontools/html tests.)
-// Recipe code uses JSX definitions found at:
-// `packages/static/assets/types/jsx.d.ts`
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      [elemName: string]: any;
-    }
-  }
-}
-
 /**
  * Type guard to check if a value is a VNode.
  * @param value - The value to check


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched workspace JSX type definitions to use the shared recipe jsx.d.ts file for consistency across packages.

- **Refactors**
 - Removed duplicate JSX type declarations from html/src/jsx.ts.
 - Updated deno.json to reference the shared jsx.d.ts.
 - Cleaned up unused @types/react imports.

<!-- End of auto-generated description by cubic. -->

