### PR TITLE
When running the map function, instead of just setting the child elements, also set the full array value.

### DIFF
--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -97,6 +97,9 @@ export function map(
       throw new Error("map currently only supports arrays");
     }
 
+    const newArrayValue = [
+      ...resultWithLog.getRaw()!.slice(0, initializedUpTo),
+    ];
     // Add values that have been appended
     while (initializedUpTo < list.length) {
       const resultCell = runtime.getCell(
@@ -121,6 +124,7 @@ export function map(
 
       // Send the result value to the result cell
       resultWithLog.key(initializedUpTo).set(resultCell);
+      newArrayValue.push(resultCell);
 
       initializedUpTo++;
     }
@@ -129,6 +133,8 @@ export function map(
     if (resultWithLog.get().length > list.length) {
       resultWithLog.key("length").set(list.length);
       initializedUpTo = list.length;
+    } else if (resultWithLog.get().length < list.length) {
+      resultWithLog.set(newArrayValue);
     }
 
     // NOTE: We leave prior results in the list for now, so they reuse prior

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -361,7 +361,7 @@ export function normalizeAndDiff(
     }
 
     // Handle array length changes
-    if (Array.isArray(currentValue) && currentValue.length > newValue.length) {
+    if (Array.isArray(currentValue) && currentValue.length != newValue.length) {
       // We need to add the schema here, since the array may be secret, so the length should be too
       const lub = (link.schema !== undefined)
         ? runtime.cfc.lubSchema(link.schema)


### PR DESCRIPTION
When setting an array that is shorter, include a change to the array's length that shortens it.