### PR TITLE
Remove useSchemaQueries flag, since we essentially require it at this point.

### DIFF
--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -106,11 +106,6 @@ export interface IRemoteStorageProviderSettings {
    * abort.
    */
   connectionTimeout: number;
-
-  /**
-   * Flag to enable or disable remote schema subscriptions
-   */
-  useSchemaQueries: boolean;
 }
 
 export interface LocalStorageOptions {

--- a/scripts/curl.ts
+++ b/scripts/curl.ts
@@ -102,7 +102,6 @@ async function main() {
     settings: {
       maxSubscriptionsPerSpace: 50_000,
       connectionTimeout: 30_000,
-      useSchemaQueries: true,
     },
   }).open(spaceDID);
   // Before writing data, we need to read it to check if it's changed.


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the useSchemaQueries flag from storage settings and related code, since schema queries are now always required. This cleans up configuration and simplifies the code.

- **Refactors**
  - Removed useSchemaQueries properties and checks from cache, interface, and scripts.

<!-- End of auto-generated description by cubic. -->

