### PR TITLE
JSX CT types inclusion

### DIFF
--- a/packages/static/assets/types/jsx.d.ts
+++ b/packages/static/assets/types/jsx.d.ts
@@ -1,3 +1,5 @@
+import type { OpaqueRef, Cell } from "commontools";
+
 type Children = JSX.Element[] | JSX.Element | string | number | boolean | null | undefined;
 
 type Child = {
@@ -8,7 +10,11 @@ type Elem = {
   id?: string
 }
 
-type Cell<T> = any
+type HandlerEvent<T> = {
+  detail: T,
+}
+
+// `Charm` is not a recipe type.
 type Charm = any
 
 type OutlinerNode = {
@@ -17,7 +23,7 @@ type OutlinerNode = {
   attachments: Charm[]
 }
 
-type ListItem = {
+type CtListItem = {
   title: string,
   done?: boolean
 }
@@ -33,55 +39,54 @@ declare global {
     interface IntrinsicElements {
       [elemName: string]: any;
       "ct-outliner": {
-        $value: Cell<{ root: OutlinerNode }>,
-        $mentionable?: Cell<Charm[]>
-        'oncharm-link-click'?: any,
+        "$value": OpaqueRef<Cell<{ root: OutlinerNode }>>,
+        "$mentionable"?: OpaqueRef<Cell<Charm[]>>,
+        "oncharm-link-click"?: OpaqueRef<HandlerEvent<{ charm: Cell<Charm> }>>,
       } & Child & Elem;
       "ct-list": {
-        $value: Cell<ListItem[]>,
+        "$value": OpaqueRef<CtListItem[]>,
         /** setting this allows editing items inline */
-        editable?: boolean,
+        "editable"?: boolean,
         /** setting this hides the 'add item' form built into the list */
-        readonly?: boolean,
-        title?: string,
-        'onct-remove-item'?: any,
+        "readonly"?: boolean,
+        "title"?: string,
+        "onct-remove-item"?: OpaqueRef<HandlerEvent<{ item: CtListItem }>>,
       } & Child & Elem;
       "ct-input": {
-        $value?: Cell<string>,
-        customStyle?: string, // bf: I think this is going to go away one day soon
-        type?: string,
-        placeholder?: string,
-        value?: string,
-        disabled?: boolean,
-        readonly?: boolean,
-        error?: boolean,
-        name?: string,
-        required?: boolean,
-        autofocus?: boolean,
-        autocomplete?: string,
-        min?: string,
-        max?: string,
-        step?: string,
-        pattern?: string,
-        maxlength?: string,
-        minlength?: string,
-        inputmode?: string,
-        size?: number,
-        multiple?: boolean,
-        accept?: string,
-        list?: string,
-        spellcheck?: boolean,
-        validationPattern?: string,
-        showValidation?: boolean,
-        timingStrategy?: string,
-        timingDelay?: number,
-
-        'onct-change'?: any,
-        'onct-focus'?: any,
-        'onct-blur'?: any,
-        'onct-keydown'?: any,
-        'onct-submit'?: any,
-        'onct-invalid'?: any,
+        "$value"?: OpaqueRef<string>,
+        "customStyle"?: string, // bf: I think this is going to go away one day soon
+        "type"?: string,
+        "placeholder"?: string,
+        "value"?: string,
+        "disabled"?: boolean,
+        "readonly"?: boolean,
+        "error"?: boolean,
+        "name"?: string,
+        "required"?: boolean,
+        "autofocus"?: boolean,
+        "autocomplete"?: string,
+        "min"?: string,
+        "max"?: string,
+        "step"?: string,
+        "pattern"?: string,
+        "maxlength"?: string,
+        "minlength"?: string,
+        "inputmode"?: string,
+        "size"?: number,
+        "multiple"?: boolean,
+        "accept"?: string,
+        "list"?: string,
+        "spellcheck"?: boolean,
+        "validationPattern"?: string,
+        "showValidation"?: boolean,
+        "timingStrategy"?: string,
+        "timingDelay"?: number,
+        "onct-change"?: any,
+        "onct-focus"?: any,
+        "onct-blur"?: any,
+        "onct-keydown"?: any,
+        "onct-submit"?: any,
+        "onct-invalid"?: any,
       } & Child & Elem;
     }
   }


### PR DESCRIPTION
Includes real `Cell`, `OpaqueRef` and handler methods to JSX types
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Centralized JSX typing and adopted real Cell and OpaqueRef across ct-* elements to improve type safety. Removed local JSX declarations and @types/react, and pointed Deno to our shared recipe jsx.d.ts.

- **Refactors**
  - Use packages/static/assets/types/jsx.d.ts as the workspace JSX types via compilerOptions.types.
  - Import OpaqueRef and Cell from commontools and add typed handler events; tighten ct-outliner, ct-list, and ct-input prop/event types ($value, onct-*, mentionable).
  - Remove the global JSX.IntrinsicElements shim from packages/html/src/jsx.ts.

- **Dependencies**
  - Remove @types/react from imports and the lockfile.

<!-- End of auto-generated description by cubic. -->

