### PR TITLE
feat: JSX.Element now extends VNode, allowing vnode typechecked in JSX

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -792,9 +792,9 @@ const FRAGMENT_ELEMENT = "common-fragment";
  * @returns A virtual DOM node
  */
 export const h = Object.assign(function h(
-  name: string | ((...args: any[]) => any),
+  name: string | ((...args: any[]) => VNode),
   props: { [key: string]: any } | null,
-  ...children: Child[]
+  ...children: RenderNode[]
 ): VNode {
   if (typeof name === "function") {
     return name({
@@ -810,8 +810,8 @@ export const h = Object.assign(function h(
     };
   }
 }, {
-  fragment({ children }: { children: Child[] }) {
-    return h(FRAGMENT_ELEMENT, null, children);
+  fragment({ children }: { children: RenderNode[] }) {
+    return h(FRAGMENT_ELEMENT, null, ...children);
   },
 });
 
@@ -832,19 +832,19 @@ export type Props = {
 };
 
 /** A child in a view can be one of a few things */
-export type Child =
+export type RenderNode =
   | VNode
   | string
   | number
   | boolean
-  | Cell<Child>
-  | Array<Child>;
+  | Cell<RenderNode>
+  | RenderNode[];
 
 /** A "virtual view node", e.g. a virtual DOM element */
 export type VNode = {
   type: "vnode";
   name: string;
   props: Props;
-  children: Array<Child> | Cell<Array<Child>>;
+  children?: RenderNode;
   [UI]?: VNode;
 };

--- a/packages/html/src/jsx.ts
+++ b/packages/html/src/jsx.ts
@@ -1,6 +1,6 @@
 import { isObject } from "@commontools/utils/types";
 import { UI, type VNode } from "@commontools/runner";
-export type { Child, Props } from "@commontools/runner";
+export type { Props, RenderNode } from "@commontools/runner";
 export { type VNode };
 
 /**

--- a/packages/html/src/render.ts
+++ b/packages/html/src/render.ts
@@ -10,7 +10,7 @@ import {
   UI,
   useCancelGroup,
 } from "@commontools/runner";
-import { type Child, isVNode, type Props, type VNode } from "./jsx.ts";
+import { isVNode, type Props, type RenderNode, type VNode } from "./jsx.ts";
 import * as logger from "./logger.ts";
 
 export const vdomSchema: JSONSchema = {
@@ -100,15 +100,17 @@ const renderNode = (node: VNode): [HTMLElement | null, Cancel] => {
   const cancelProps = bindProps(element, sanitizedNode.props);
   addCancel(cancelProps);
 
-  const cancelChildren = bindChildren(element, sanitizedNode.children);
-  addCancel(cancelChildren);
+  if (sanitizedNode.children !== undefined) {
+    const cancelChildren = bindChildren(element, sanitizedNode.children);
+    addCancel(cancelChildren);
+  }
 
   return [element, cancel];
 };
 
 const bindChildren = (
   element: HTMLElement,
-  children: Array<Child> | Cell<Array<Child>>,
+  children: RenderNode,
 ): Cancel => {
   // Mapping from stable key to its rendered node and cancel function.
   let keyedChildren = new Map<string, { node: ChildNode; cancel: Cancel }>();
@@ -117,7 +119,7 @@ const bindChildren = (
   // the already-rendered node (using replaceWith) so that we never add an extra
   // container.
   const renderChild = (
-    child: Child,
+    child: RenderNode,
     key: string,
   ): { node: ChildNode; cancel: Cancel } => {
     let currentNode: ChildNode | null = null;
@@ -162,7 +164,7 @@ const bindChildren = (
 
   // When the children array changes, diff its flattened values against what we previously rendered.
   const updateChildren = (
-    childrenArr: Array<Child | Array<Child>> | undefined | null,
+    childrenArr: RenderNode | RenderNode[] | undefined | null,
   ) => {
     const newChildren = Array.isArray(childrenArr) ? childrenArr.flat() : [];
     const newKeyOrder: string[] = [];

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -56,7 +56,6 @@ export {
 export { h } from "@commontools/api";
 export type {
   Cell,
-  Child,
   CreateCellFunction,
   Handler,
   HandlerFactory,
@@ -72,6 +71,7 @@ export type {
   Props,
   Recipe,
   RecipeFactory,
+  RenderNode,
   Stream,
   StripCell,
   toJSON,

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -73,7 +73,6 @@ export {
 export {
   AuthSchema,
   type Cell as BuilderCell,
-  type Child,
   type Frame,
   h,
   type HandlerFactory,
@@ -97,6 +96,7 @@ export {
   type Props,
   type Recipe,
   type RecipeFactory,
+  type RenderNode,
   type Schema,
   schema,
   type SchemaContext,

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -387,11 +387,11 @@ type ObjectFromPropertiesWithoutCell<P extends Record<string, JSONSchema>, R ext
  * @param children - Child elements
  * @returns A virtual DOM node
  */
-export declare const h: ((name: string | ((...args: any[]) => any), props: {
+export declare const h: ((name: string | ((...args: any[]) => VNode), props: {
     [key: string]: any;
-} | null, ...children: Child[]) => VNode) & {
+} | null, ...children: RenderNode[]) => VNode) & {
     fragment({ children }: {
-        children: Child[];
+        children: RenderNode[];
     }): VNode;
 };
 /**
@@ -402,13 +402,13 @@ export type Props = {
     [key: string]: string | number | boolean | object | Array<any> | null | Cell<any> | Stream<any>;
 };
 /** A child in a view can be one of a few things */
-export type Child = VNode | string | number | boolean | Cell<Child> | Array<Child>;
+export type RenderNode = VNode | string | number | boolean | Cell<RenderNode> | RenderNode[];
 /** A "virtual view node", e.g. a virtual DOM element */
 export type VNode = {
     type: "vnode";
     name: string;
     props: Props;
-    children: Array<Child> | Cell<Array<Child>>;
+    children?: RenderNode;
     [UI]?: VNode;
 };
 export {};

--- a/packages/static/assets/types/jsx.d.ts
+++ b/packages/static/assets/types/jsx.d.ts
@@ -1,15 +1,13 @@
-import type { OpaqueRef, Cell } from "commontools";
+import type { OpaqueRef, Cell, Props, RenderNode, VNode } from "commontools";
 
-type Children = JSX.Element[] | JSX.Element | string | number | boolean | null | undefined;
-
-type Child = {
-  children?: Children;
-};
-
-type Elem = {
-  id?: string;
+type HTMLElementProps = {
+  id?: string,
   style?: string;
 }
+
+type Children = {
+  children?: RenderNode;
+};
 
 type HandlerEvent<T> = {
   detail: T,
@@ -31,11 +29,16 @@ type CtListItem = {
 
 declare global {
   namespace JSX {
-    interface Element {
+    // The output of a JSX renderer is a JSX.Element.
+    // Our renderer (`@commontools/api#h`) outputs
+    // `VNode`s. Redefine `JSX.Element` here as a `VNode`
+    // for consistency.
+    interface Element extends VNode {
       type: "vnode";
       name: string;
-      props: any;
-      children: any;
+      props: Props;
+      children?: RenderNode;
+      $UI?: VNode;
     }
 
     interface IntrinsicElements {
@@ -44,7 +47,7 @@ declare global {
         "$value": OpaqueRef<Cell<{ root: OutlinerNode }>>,
         "$mentionable"?: OpaqueRef<Cell<Charm[]>>,
         "oncharm-link-click"?: OpaqueRef<HandlerEvent<{ charm: Cell<Charm> }>>,
-      } & Child & Elem;
+      } & Children & HTMLElementProps;
       "ct-list": {
         "$value": OpaqueRef<CtListItem[]>,
         /** setting this allows editing items inline */
@@ -53,7 +56,7 @@ declare global {
         "readonly"?: boolean,
         "title"?: string,
         "onct-remove-item"?: OpaqueRef<HandlerEvent<{ item: CtListItem }>>,
-      } & Child & Elem;
+      } & Children & HTMLElementProps;
       "ct-input": {
         "$value"?: OpaqueRef<string>,
         "customStyle"?: string, // bf: I think this is going to go away one day soon
@@ -89,7 +92,7 @@ declare global {
         "onct-keydown"?: any,
         "onct-submit"?: any,
         "onct-invalid"?: any,
-      } & Child & Elem;
+      } & Children & HTMLElementProps;
     }
   }
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
JSX.Element now extends commontools VNode, enabling proper VNode type checking in JSX. Simplifies intrinsic element props; no runtime changes.

- **Refactors**
  - Replaced custom JSX.Element shape with VNode.
  - Removed Children/Child/Elem; added HTMLElementProps { id? }.
  - Updated ct-* IntrinsicElements to use HTMLElementProps.

<!-- End of auto-generated description by cubic. -->

