### PR TITLE
made simple editable version, does not use bidirectional binding

### DIFF
--- a/packages/patterns/array-in-cell-with-remove-editable.tsx
+++ b/packages/patterns/array-in-cell-with-remove-editable.tsx
@@ -1,0 +1,106 @@
+/// <cts-enable />
+import {
+  Cell,
+  Default,
+  derive,
+  h,
+  handler,
+  NAME,
+  recipe,
+  Stream,
+  UI,
+} from "commontools";
+
+interface Item {
+  text: Default<string, "">;
+}
+
+interface InputSchema {
+  title: Default<string, "untitled">;
+  items: Default<Item[], []>;
+}
+
+type InputEventType = {
+  detail: {
+    message: string;
+  };
+};
+
+interface ListState {
+  items: Cell<Item[]>;
+}
+
+const addItem = handler<InputEventType, ListState>(
+  (event: InputEventType, state: ListState) => {
+    state.items.push({ text: event.detail.message });
+  },
+);
+
+const removeItem = handler<unknown, { items: Cell<Item[]>; index: number }>(
+  (_, { items, index }) => {
+    const itemsCopy = items.get().slice();
+    if (index >= 0 && index < itemsCopy.length) itemsCopy.splice(index, 1);
+    items.set(itemsCopy);
+  },
+);
+
+const updateItem = handler<
+  { detail: { value: string } },
+  { items: Cell<Item[]>; index: number }
+>(({ detail: { value } }, { items, index }) => {
+  const itemsCopy = items.get().slice();
+  if (index >= 0 && index < itemsCopy.length) {
+    itemsCopy[index] = { text: value };
+    items.set(itemsCopy);
+  }
+});
+
+export default recipe(
+  "Simple List with Remove and Edit",
+  ({ title, items }: InputSchema) => {
+    return {
+      [NAME]: title,
+      [UI]: (
+        <div style="padding: 1rem; max-width: 600px;">
+          <h3>{title}</h3>
+          <p>Editable Array with Remove</p>
+          <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+            {items.map((item: Item, index: number) => (
+              <div
+                key={index}
+                style="display: flex; align-items: center; gap: 0.5rem;"
+              >
+                <ct-button
+                  variant="destructive"
+                  size="sm"
+                  onClick={removeItem({ items, index })}
+                >
+                  Remove
+                </ct-button>
+                <div style="flex: 1;">
+                  <ct-input
+                    value={item.text}
+                    onct-change={updateItem({ items, index })}
+                    placeholder="Enter text..."
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+          <div style="margin-top: 1rem;">
+            <common-send-message
+              name="Send"
+              placeholder="Type a message..."
+              appearance="rounded"
+              onmessagesend={addItem({ items })}
+            />
+          </div>
+        </div>
+      ),
+      title,
+      items,
+      addItem: addItem({ items }),
+      updateItem,
+    };
+  },
+);

--- a/packages/patterns/array-in-cell-with-remove-editable.tsx
+++ b/packages/patterns/array-in-cell-with-remove-editable.tsx
@@ -61,14 +61,16 @@ export default recipe(
     return {
       [NAME]: title,
       [UI]: (
-        <div style="padding: 1rem; max-width: 600px;">
+        <div style={{ padding: "1rem", maxWidth: "600px" }}>
           <h3>{title}</h3>
           <p>Editable Array with Remove</p>
-          <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
+          >
             {items.map((item: Item, index: number) => (
               <div
                 key={index}
-                style="display: flex; align-items: center; gap: 0.5rem;"
+                style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
               >
                 <ct-button
                   variant="destructive"
@@ -77,7 +79,7 @@ export default recipe(
                 >
                   Remove
                 </ct-button>
-                <div style="flex: 1;">
+                <div style={{ flex: 1 }}>
                   <ct-input
                     value={item.text}
                     onct-change={updateItem({ items, index })}
@@ -87,7 +89,7 @@ export default recipe(
               </div>
             ))}
           </div>
-          <div style="margin-top: 1rem;">
+          <div style={{ marginTop: "1rem" }}>
             <common-send-message
               name="Send"
               placeholder="Type a message..."


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a simple editable array-in-cell recipe with remove and inline editing, built without bidirectional binding. Aligns with Linear CT-783 by providing a minimal pattern to add, edit, and remove list items.

- **New Features**
  - New recipe: array-in-cell-with-remove-editable.tsx ("Simple List with Remove and Edit").
  - Add items via common-send-message; edit inline with ct-input; remove with a destructive button.
  - No bidirectional binding; explicit handlers (addItem, updateItem, removeItem) update a Cell<Item[]>.

<!-- End of auto-generated description by cubic. -->

