### PR TITLE
Some type consolidation and cleanup, mostly around traverse code

### DIFF
--- a/packages/memory/commit.ts
+++ b/packages/memory/commit.ts
@@ -12,7 +12,7 @@ import type {
 import { assert } from "./fact.ts";
 import { fromString } from "merkle-reference";
 
-export const the = "application/commit+json" as const;
+export const COMMIT_LOG_TYPE = "application/commit+json" as const;
 export const create = <Space extends MemorySpace>({
   space,
   cause,
@@ -23,9 +23,9 @@ export const create = <Space extends MemorySpace>({
   since?: number;
   transaction: Transaction;
   cause?: Reference<Assertion> | Assertion | null | undefined;
-}): Assertion<typeof the, Space, CommitData> =>
+}): Assertion<typeof COMMIT_LOG_TYPE, Space, CommitData> =>
   assert({
-    the,
+    the: COMMIT_LOG_TYPE,
     of: space,
     is: {
       since,
@@ -38,11 +38,11 @@ export const toRevision = (
   commit: Commit,
 ): Revision<CommitFact> => {
   const [[space, attributes]] = Object.entries(commit);
-  const [[cause, { is }]] = Object.entries(attributes[the]);
+  const [[cause, { is }]] = Object.entries(attributes[COMMIT_LOG_TYPE]);
 
   return {
     ...assert({
-      the,
+      the: COMMIT_LOG_TYPE,
       of: space as MemorySpace,
       is,
       cause: fromString(cause) as Reference<Fact>,

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -56,11 +56,6 @@ const logger = getLogger("space-schema", {
   level: "info",
 });
 
-type ExtendedMemoryAddress = BaseMemoryAddress & {
-  cause: Cause;
-  since: number;
-};
-
 // This class is used to manage the underlying objects in storage, so the
 // class that traverses the docs doesn't need to know the implementation.
 // It also lets us use one system on the server (where we have the sqlite db)
@@ -259,7 +254,7 @@ function loadFactsForDoc(
   if (isObject(fact.value)) {
     if (selector.schemaContext !== undefined) {
       const factValue = (fact.value as Immutable<JSONObject>).value;
-      const [newDoc, newSelector] = getAtPath<ExtendedMemoryAddress>(
+      const [newDoc, newSelector] = getAtPath(
         manager,
         { address: fact.address, value: factValue, rootValue: factValue },
         selector.path,

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -13,7 +13,7 @@ import {
 } from "@commontools/runner/traverse";
 import { type Immutable, isObject } from "@commontools/utils/types";
 import { getLogger } from "@commontools/utils/logger";
-import { the as COMMIT_THE } from "./commit.ts";
+import { COMMIT_LOG_TYPE } from "./commit.ts";
 import type { CommitData, SchemaPathSelector } from "./consumer.ts";
 import { TheAuthorizationError } from "./error.ts";
 import type {
@@ -286,7 +286,7 @@ const redactCommits = <Space extends MemorySpace>(
   includedFacts: FactSelection,
   session: Session<Space>,
 ) => {
-  const change = getChange(includedFacts, session.subject, COMMIT_THE);
+  const change = getChange(includedFacts, session.subject, COMMIT_LOG_TYPE);
   if (change !== undefined) {
     const [cause, value] = change;
     const commitData = value.is as CommitData;
@@ -308,7 +308,7 @@ const redactCommits = <Space extends MemorySpace>(
     setRevision<FactSelectionValue>(
       includedFacts,
       session.subject,
-      COMMIT_THE,
+      COMMIT_LOG_TYPE,
       cause,
       redactedValue,
     );

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -84,9 +84,7 @@ export class ServerObjectManager extends BaseObjectManager<
    * @returns an IAttestation with the value for the specified doc,
    * null if there is no matching fact, or undefined if there is a retraction.
    */
-  override load(
-    address: BaseMemoryAddress,
-  ): IAttestation | null {
+  override load(address: BaseMemoryAddress): IAttestation | null {
     const key = this.toKey(address);
     if (this.readValues.has(key)) {
       return this.readValues.get(key)!;

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -82,33 +82,36 @@ export class ServerObjectManager extends BaseObjectManager<
   }
 
   /**
-   * Load the facts for the provided doc
+   * Load the facts for the provided address
    *
-   * @param doc the address of the fact to load
+   * @param address the address of the fact to load
    * @returns an IAttestation with the value for the specified doc,
    * null if there is no matching fact, or undefined if there is a retraction.
    */
   override load(
-    doc: BaseMemoryAddress,
+    address: BaseMemoryAddress,
   ): IAttestation | null {
-    const key = this.toKey(doc);
+    const key = this.toKey(address);
     if (this.readValues.has(key)) {
       return this.readValues.get(key)!;
     } else if (this.restrictedValues.has(key)) {
       return null;
     }
-    const fact = selectFact(this.session, { of: doc.id, the: doc.type });
+    const fact = selectFact(this.session, {
+      of: address.id,
+      the: address.type,
+    });
     if (fact !== undefined) {
       const address = { id: fact.of, type: fact.the, path: [] };
       const valueEntry = {
         address: address,
         value: fact.is ? (fact.is as JSONObject) : undefined,
       };
-      if (!this.readLabels.has(doc.id)) {
-        const label = getLabel(this.session, doc.id);
-        this.readLabels.set(doc.id, label);
+      if (!this.readLabels.has(address.id)) {
+        const label = getLabel(this.session, address.id);
+        this.readLabels.set(address.id, label);
       }
-      const labelEntry = this.readLabels.get(doc.id);
+      const labelEntry = this.readLabels.get(address.id);
       if (labelEntry?.is) {
         const requiredClassifications = getClassifications({
           is: labelEntry.is,

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -77,10 +77,6 @@ export class ServerObjectManager extends BaseObjectManager<
     super();
   }
 
-  override getTarget(uri: URI): BaseMemoryAddress {
-    return { id: uri, type: "application/json" };
-  }
-
   /**
    * Load the facts for the provided address
    *

--- a/packages/memory/space.ts
+++ b/packages/memory/space.ts
@@ -4,7 +4,7 @@ import {
   Transaction as DBTransaction,
 } from "@db/sqlite";
 
-import { create as createCommit, the as COMMIT_THE } from "./commit.ts";
+import { COMMIT_LOG_TYPE, create as createCommit } from "./commit.ts";
 import { unclaimed } from "./fact.ts";
 import { fromString, refer } from "./reference.ts";
 import { addMemoryAttributes, traceAsync, traceSync } from "./telemetry.ts";
@@ -708,7 +708,7 @@ const commit = <Space extends MemorySpace>(
   session: Session<Space>,
   transaction: Transaction<Space>,
 ): Commit<Space> => {
-  const the = COMMIT_THE;
+  const the = COMMIT_LOG_TYPE;
   const of = transaction.sub;
   const row = session.store.prepare(EXPORT).get({ the, of }) as
     | StateRow
@@ -878,7 +878,7 @@ export const querySchema = <Space extends MemorySpace>(
   });
 };
 
-export const LABEL_THE = "application/label+json" as const;
+export const LABEL_TYPE = "application/label+json" as const;
 export type FactSelectionValue = { is?: JSONValue; since: number };
 // Get the labels associated with a set of commits.
 // It's possible to get more than one label for a single doc because our
@@ -893,7 +893,7 @@ export function getLabels<
   const labels: OfTheCause<FactSelectionValue> = {};
   for (const fact of iterate(includedFacts)) {
     // We don't restrict acccess to labels
-    if (fact.the === LABEL_THE) {
+    if (fact.the === LABEL_TYPE) {
       continue;
     }
     const labelFact = getLabel(session, fact.of);
@@ -918,7 +918,7 @@ export function getLabel<Space extends MemorySpace>(
   session: Session<Space>,
   of: Entity,
 ) {
-  return selectFact(session, { of, the: LABEL_THE });
+  return selectFact(session, { of, the: LABEL_TYPE });
 }
 
 // Get the various classification tags required based on the collection of labels.
@@ -973,12 +973,12 @@ export function redactCommitData(
       continue;
     }
     // We treat all labels as unclassified
-    if (fact.the === LABEL_THE) {
+    if (fact.the === LABEL_TYPE) {
       set(newChanges, fact.of, fact.the, fact.cause, fact.value);
       continue;
     }
     // FIXME(@ubik2): Re-enable this once we've tracked down other issues
-    // const labelFact = getRevision(commitData.labels, fact.of, LABEL_THE);
+    // const labelFact = getRevision(commitData.labels, fact.of, LABEL_TYPE);
     // if (labelFact !== undefined && getClassifications(labelFact).size > 0) {
     //   setEmptyObj(newChanges, fact.of, fact.the);
     // } else {

--- a/packages/memory/subscription.ts
+++ b/packages/memory/subscription.ts
@@ -7,14 +7,14 @@ import {
   Selector,
   The,
 } from "./interface.ts";
-import { the as commitType } from "./commit.ts";
+import { COMMIT_LOG_TYPE } from "./commit.ts";
 
 export const match = (commit: Commit, watched: Set<string>) => {
   for (const at of Object.keys(commit) as MemorySpace[]) {
-    const commitObj = commit[at][commitType] ?? {};
+    const commitObj = commit[at][COMMIT_LOG_TYPE] ?? {};
     for (const { is: { transaction } } of Object.values(commitObj)) {
       // If commit on this space are watched we have a match
-      if (matchAddress(watched, { the: commitType, of: at, at })) {
+      if (matchAddress(watched, { the: COMMIT_LOG_TYPE, of: at, at })) {
         return true;
       }
 

--- a/packages/memory/test/consumer-test.ts
+++ b/packages/memory/test/consumer-test.ts
@@ -8,7 +8,7 @@ import * as Fact from "../fact.ts";
 import type { UTCUnixTimestampInSeconds } from "../interface.ts";
 import * as Provider from "../provider.ts";
 import * as Selection from "../selection.ts";
-import { LABEL_THE } from "../space.ts";
+import { LABEL_TYPE } from "../space.ts";
 import * as Transaction from "../transaction.ts";
 import { alice, bob, space as subject } from "./principal.ts";
 import { Identity } from "../../identity/src/identity.ts";
@@ -749,7 +749,7 @@ test(
     });
 
     const v1_label = Fact.assert({
-      the: LABEL_THE,
+      the: LABEL_TYPE,
       of: doc,
       is: { classification: ["confidential"] },
     });
@@ -795,7 +795,7 @@ test(
     });
 
     const v1_label = Fact.assert({
-      the: LABEL_THE,
+      the: LABEL_TYPE,
       of: doc,
       is: { classification: ["confidential"] },
     });
@@ -875,7 +875,7 @@ test(
     });
 
     const v1_label = Fact.assert({
-      the: LABEL_THE,
+      the: LABEL_TYPE,
       of: doc,
       is: { classification: ["confidential"] },
     });
@@ -990,7 +990,7 @@ test(
     });
 
     const v1_label = Fact.assert({
-      the: LABEL_THE,
+      the: LABEL_TYPE,
       of: doc,
       is: { classification: ["confidential"] },
     });
@@ -1116,7 +1116,7 @@ test(
       cause: v2,
     });
     const v3_label = Fact.assert({
-      the: LABEL_THE,
+      the: LABEL_TYPE,
       of: doc,
       is: { classification: ["confidential"] },
     });
@@ -1181,7 +1181,7 @@ test(
     });
 
     const v1_label = Fact.assert({
-      the: LABEL_THE,
+      the: LABEL_TYPE,
       of: doc,
       is: { classification: ["confidential"] },
     });

--- a/packages/runner/integration/pending-nursery.test.ts
+++ b/packages/runner/integration/pending-nursery.test.ts
@@ -52,7 +52,7 @@ async function test() {
 
   let s1Count = 0;
   provider1.replica.heap.subscribe(
-    { of: uri, the: "application/json" },
+    { id: uri, type: "application/json" },
     (v) => {
       s1Count++;
     },
@@ -71,7 +71,7 @@ async function test() {
     (runtime2.storageManager.open(identity.did()) as any).provider;
   let s2Count = 0;
   provider2.replica.heap.subscribe(
-    { of: uri, the: "application/json" },
+    { id: uri, type: "application/json" },
     (_v) => {
       s2Count++;
     },
@@ -88,7 +88,7 @@ async function test() {
   // Set up a wait for the last value (45)
   const deferred = Promise.withResolvers();
   provider2.replica.heap.subscribe(
-    { of: uri, the: "application/json" },
+    { id: uri, type: "application/json" },
     (v) => {
       if ((v?.is as any).value.count === 45) {
         deferred.resolve(true);

--- a/packages/runner/src/storage.ts
+++ b/packages/runner/src/storage.ts
@@ -1,12 +1,13 @@
 import { refer } from "merkle-reference";
 import { Immutable, isRecord } from "@commontools/utils/types";
 import type {
-  FactAddress,
   JSONValue,
   MemorySpace,
   SchemaContext,
   SchemaPathSelector,
 } from "@commontools/memory/interface";
+import type { BaseMemoryAddress } from "@commontools/runner/traverse";
+import { getLogger } from "@commontools/utils/logger";
 import { type AddCancel, type Cancel, useCancelGroup } from "./cancel.ts";
 import { type Cell, isCell } from "./cell.ts";
 import { type DocImpl, isDoc } from "./doc.ts";
@@ -20,7 +21,6 @@ import type {
   StorageValue,
   URI,
 } from "./storage/interface.ts";
-import { getLogger } from "@commontools/utils/logger";
 import type { IRuntime, IStorage } from "./runtime.ts";
 import { DocObjectManager, querySchema } from "./storage/query.ts";
 import { deepEqual } from "./path-utils.ts";
@@ -298,7 +298,7 @@ export class Storage implements IStorage {
     // Run a schema query against our local content, so we can either send
     // the set of linked docs, or load them.
     const uri = Storage.toURI(doc.entityId);
-    const { missing, loaded, selected } = this._queryLocal(
+    const { missing, loaded } = this._queryLocal(
       doc.space,
       uri,
       storageProvider,
@@ -310,16 +310,16 @@ export class Storage implements IStorage {
     // be managed in our document map.
     const uris = loaded.values().map((valueEntry) => valueEntry.source)
       .filter((docAddr) =>
-        docAddr.the === "application/json" && docAddr.of.startsWith("of:")
-      ).map((docAddr) => docAddr.of).toArray();
+        docAddr.type === "application/json" && docAddr.id.startsWith("of:")
+      ).map((docAddr) => docAddr.id).toArray();
 
     // It's ok to be missing the primary record (this is the case when we are
     // creating it for the first time).
     if (
       missing.length === 1 &&
-      missing[0].of === uri
+      missing[0].id === uri
     ) {
-      uris.push(missing[0].of);
+      uris.push(missing[0].id);
       // } else if (missing.length > 1) {
       //   console.debug("missing", missing);
     }
@@ -467,7 +467,7 @@ export class Storage implements IStorage {
       this.runtime.documentMap,
       Storage._cellLinkToJSON,
     );
-    const docAddress = { of: uri, the: "application/json" };
+    const docAddress = { id: uri, type: "application/json" };
     const selector = { path: [], schemaContext: schemaContext };
     return querySchema(selector, [], docAddress, manager);
   }
@@ -517,9 +517,9 @@ export class Storage implements IStorage {
       // TODO(@ubik2) I've lost the schema here
       const linkedDoc = this.runtime.documentMap.getDocByEntityId(
         doc.space,
-        factAddress.of,
+        factAddress.id,
       );
-      logger.info(() => ["calling sync cell on missing doc", factAddress.of]);
+      logger.info(() => ["calling sync cell on missing doc", factAddress.id]);
       // We do need to call syncCell, because we may have pushed a new cell
       // without calling syncCell (e.g. map will create these cells).
       // I can modify the DocImpl class to automatically relay the doc updates
@@ -543,7 +543,7 @@ export class Storage implements IStorage {
 
   private async _sendDocValue(
     doc: DocImpl<unknown>,
-    docAddrs: FactAddress[],
+    docAddrs: BaseMemoryAddress[],
     labels?: Labels,
   ) {
     await this.runtime.idle();
@@ -569,7 +569,7 @@ export class Storage implements IStorage {
     for (const docAddr of docAddrs) {
       const linkedDoc = this.runtime.documentMap.getDocByEntityId(
         doc.space,
-        docAddr.of,
+        docAddr.id,
         false,
       );
       // if we don't have a local doc, the server's version should be fine
@@ -584,7 +584,7 @@ export class Storage implements IStorage {
       const linkedLabels = linkedDoc === doc ? labels : undefined;
       // Create storage value using the helper to ensure consistency
       const linkedValue = Storage._cellLinkToJSON(linkedDoc, linkedLabels);
-      docsToSend.push({ uri: docAddr.of, value: linkedValue });
+      docsToSend.push({ uri: docAddr.id, value: linkedValue });
     }
     await storageProvider.send(docsToSend);
   }

--- a/packages/runner/src/storage.ts
+++ b/packages/runner/src/storage.ts
@@ -467,9 +467,9 @@ export class Storage implements IStorage {
       this.runtime.documentMap,
       Storage._cellLinkToJSON,
     );
-    const docAddress = { id: uri, type: "application/json" };
+    const docAddress = { id: uri, type: "application/json", path: [] };
     const selector = { path: [], schemaContext: schemaContext };
-    return querySchema(selector, [], docAddress, manager);
+    return querySchema(selector, docAddress, manager);
   }
 
   // Update storage with the new doc value

--- a/packages/runner/src/storage.ts
+++ b/packages/runner/src/storage.ts
@@ -308,7 +308,7 @@ export class Storage implements IStorage {
     // per-space transaction entry, and may have labels.
     // We'll also ensure we're only dealing with the entity ids that will
     // be managed in our document map.
-    const uris = loaded.values().map((valueEntry) => valueEntry.source)
+    const uris = loaded.values().map((valueEntry) => valueEntry.address)
       .filter((docAddr) =>
         docAddr.type === "application/json" && docAddr.id.startsWith("of:")
       ).map((docAddr) => docAddr.id).toArray();
@@ -533,7 +533,7 @@ export class Storage implements IStorage {
     // Our queryLocal call has determined which docs are linked, so make sure
     // we're sending those to storage as well. If they're redundant, they will
     // be skipped by storage.
-    const docAddrs = [...missing, ...loaded.values().map((sv) => sv.source)];
+    const docAddrs = [...missing, ...loaded.values().map((sv) => sv.address)];
     const docToStoragePromise = this._sendDocValue(doc, docAddrs, labels);
     this.docToStoragePromises.add(docToStoragePromise);
     docToStoragePromise.finally(() =>

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -21,6 +21,7 @@ import type {
   URI,
   Variant,
 } from "@commontools/memory/interface";
+import { BaseMemoryAddress } from "@commontools/runner/traverse";
 
 export type {
   Assertion,
@@ -773,7 +774,7 @@ export interface ISpaceReplica extends ISpace {
    * Return a state for the requested entry or returns `undefined` if replica
    * does not have it.
    */
-  get(entry: FactAddress): State | undefined;
+  get(entry: BaseMemoryAddress): State | undefined;
 
   commit(
     transaction: ITransaction,

--- a/packages/runner/src/storage/query.ts
+++ b/packages/runner/src/storage/query.ts
@@ -32,11 +32,6 @@ export abstract class ClientObjectManager
     super();
   }
 
-  // get the fact address for the doc pointed to by the cell target
-  override getTarget(uri: URI): BaseMemoryAddress {
-    return { id: uri, type: "application/json" };
-  }
-
   getReadDocs(): Iterable<IAttestation> {
     return this.readValues.values();
   }

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -184,8 +184,8 @@ export const claim = (
   { address, value: expected }: IAttestation,
   replica: ISpaceReplica,
 ): Result<State, IStorageTransactionInconsistent> => {
-  const [the, of] = [address.type, address.id];
-  const state = replica.get({ the, of }) ?? unclaimed({ the, of });
+  const state = replica.get(address) ??
+    unclaimed({ of: address.id, the: address.type });
   const source = attest(state);
   const actual = read(source, address)?.ok?.value;
 

--- a/packages/runner/src/storage/transaction/chronicle.ts
+++ b/packages/runner/src/storage/transaction/chronicle.ts
@@ -86,10 +86,10 @@ export class Chronicle {
    * such fact exists yet.
    */
   load(address: Omit<IMemoryAddress, "path">): State {
-    const [the, of] = [address.type, address.id];
     // If we have not read nor written into overlapping memory address,
     // we'll read it from the local replica.
-    return this.#replica.get({ the, of }) ?? unclaimed({ the, of });
+    return this.#replica.get(address) ??
+      unclaimed({ of: address.id, the: address.type });
   }
 
   /**

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -5,7 +5,6 @@ import {
   type Immutable,
   isNumber,
   isObject,
-  isRecord,
   isString,
 } from "../../utils/src/types.ts";
 import { getLogger } from "../../utils/src/logger.ts";
@@ -20,8 +19,11 @@ import { deepEqual } from "./path-utils.ts";
 import { isAnyCellLink, parseLink } from "./link-utils.ts";
 import type { URI } from "./sigil-types.ts";
 import { fromURI } from "./uri-utils.ts";
+import type { IMemoryAddress } from "./storage/interface.ts";
 
 const logger = getLogger("traverse", { enabled: true, level: "warn" });
+
+export type { IMemoryAddress } from "./storage/interface.ts";
 
 export type SchemaPathSelector = {
   path: readonly string[];
@@ -127,8 +129,6 @@ export type PointerCycleTracker = CycleTracker<
   Immutable<JSONValue>
 >;
 
-export type CellTarget = { path: string[]; cellTarget: string | undefined };
-
 export interface ObjectStorageManager<K, S, V> {
   addRead(doc: K, value: V, source: S): void;
   addWrite(doc: K, value: V, source: S): void;
@@ -143,11 +143,17 @@ export type ValueEntry<T, V> = {
   source: T;
 };
 
-export type ValueAtPath<K> = {
-  doc: K;
-  docRoot: Immutable<JSONValue> | undefined;
-  path: string[];
-  value: Immutable<JSONValue> | undefined;
+export type BaseMemoryAddress = Omit<IMemoryAddress, "path">;
+
+// This is very similar to the IAttestation class, but with the addition of
+// the rootValue property.
+// There's also a difference where the address will not include the initial
+// "value" in the path, and the rootValue is actually the contents of the
+// "value" property of the document.
+export type ValueAtPath = {
+  readonly address: IMemoryAddress;
+  readonly value: Immutable<JSONValue> | undefined;
+  readonly rootValue: Immutable<JSONValue> | undefined;
 };
 
 // I've really got two different concepts here.
@@ -158,29 +164,29 @@ export type ValueAtPath<K> = {
 //  1. Loading objects from the DB (on the server)
 //  2. Loading objects from our memory interface (on the client)
 
-export abstract class BaseObjectManager<K, S, V>
-  implements ObjectStorageManager<K, S, V> {
+export abstract class BaseObjectManager<S extends BaseMemoryAddress, V>
+  implements ObjectStorageManager<BaseMemoryAddress, S, V> {
   constructor(
     protected readValues = new Map<string, ValueEntry<S, V>>(),
     protected writeValues = new Map<string, ValueEntry<S, V>>(),
   ) {}
 
-  addRead(doc: K, value: V, source: S) {
+  addRead(doc: S, value: V, source: S) {
     const key = this.toKey(doc);
     this.readValues.set(key, { value: value, source: source });
   }
 
-  addWrite(doc: K, value: V, source: S) {
+  addWrite(doc: S, value: V, source: S) {
     const key = this.toKey(doc);
     this.writeValues.set(key, { value: value, source: source });
   }
-  abstract getTarget(uri: URI): K;
+  abstract getTarget(uri: URI): BaseMemoryAddress;
   // load the doc from the underlying system.
   // implementations are responsible for adding this to the readValues
-  abstract load(doc: K): ValueEntry<S, V | undefined> | null;
+  abstract load(doc: BaseMemoryAddress): ValueEntry<S, V | undefined> | null;
   // get a string version of a key
-  abstract toKey(doc: K): string;
-  abstract toAddress(str: string): K;
+  abstract toKey(doc: BaseMemoryAddress): string;
+  abstract toAddress(str: string): BaseMemoryAddress;
 }
 
 export type OptJSONValue =
@@ -195,15 +201,11 @@ interface OptJSONObject {
 
 // Value traversed must be a DAG, though it may have aliases or cell links
 // that make it seem like it has cycles
-export abstract class BaseObjectTraverser<K, S> {
+export abstract class BaseObjectTraverser<S extends BaseMemoryAddress> {
   constructor(
-    protected manager: BaseObjectManager<
-      K,
-      S,
-      Immutable<JSONValue> | undefined
-    >,
+    protected manager: BaseObjectManager<S, Immutable<JSONValue> | undefined>,
   ) {}
-  abstract traverse(doc: ValueAtPath<K>): Immutable<OptJSONValue>;
+  abstract traverse(doc: ValueAtPath): Immutable<OptJSONValue>;
 
   /**
    * Attempt to traverse the document as a directed acyclic graph.
@@ -215,7 +217,7 @@ export abstract class BaseObjectTraverser<K, S> {
    * @returns
    */
   protected traverseDAG(
-    doc: ValueAtPath<K>,
+    doc: ValueAtPath,
     tracker: PointerCycleTracker,
     schemaTracker?: MapSet<string, SchemaPathSelector>,
   ): Immutable<JSONValue> | undefined {
@@ -228,7 +230,14 @@ export abstract class BaseObjectTraverser<K, S> {
       }
       return doc.value.map((item, index) =>
         this.traverseDAG(
-          { ...doc, path: [...doc.path, index.toString()], value: item },
+          {
+            ...doc,
+            address: {
+              ...doc.address,
+              path: [...doc.address.path, index.toString()],
+            },
+            value: item,
+          },
           tracker,
           schemaTracker,
         )
@@ -244,7 +253,7 @@ export abstract class BaseObjectTraverser<K, S> {
           schemaTracker,
           DefaultSchemaSelector,
         );
-        if (newDoc.value === undefined || newDoc.docRoot === undefined) {
+        if (newDoc.value === undefined || newDoc.rootValue === undefined) {
           return null;
         }
         return this.traverseDAG(newDoc, tracker, schemaTracker);
@@ -261,7 +270,7 @@ export abstract class BaseObjectTraverser<K, S> {
             this.traverseDAG(
               {
                 ...doc,
-                path: [...doc.path, k],
+                address: { ...doc.address, path: [...doc.address.path, k] },
                 value: value,
               },
               tracker,
@@ -292,16 +301,15 @@ export abstract class BaseObjectTraverser<K, S> {
  * docRoot, path, and value and also containing the updated selector that
  * applies to that target doc.
  */
-export function getAtPath<K, S>(
-  manager: BaseObjectManager<K, S, Immutable<JSONValue> | undefined>,
-  doc: ValueAtPath<K>,
+export function getAtPath<S extends BaseMemoryAddress>(
+  manager: BaseObjectManager<S, Immutable<JSONValue> | undefined>,
+  doc: ValueAtPath,
   path: readonly string[],
   tracker: PointerCycleTracker,
   schemaTracker?: MapSet<string, SchemaPathSelector>,
   selector?: SchemaPathSelector,
-): [ValueAtPath<K>, SchemaPathSelector | undefined] {
-  // we may mutate curDoc's value and path, so copy the object and the path
-  let curDoc = { ...doc, path: [...doc.path] };
+): [ValueAtPath, SchemaPathSelector | undefined] {
+  let curDoc = doc;
   let remaining = [...path];
   while (isAnyCellLink(curDoc.value)) {
     [curDoc, selector] = followPointer(
@@ -320,17 +328,27 @@ export function getAtPath<K, S>(
     part = remaining.shift()
   ) {
     if (Array.isArray(curDoc.value)) {
-      curDoc.value = elementAt(curDoc.value, part);
-      curDoc.path.push(part);
+      curDoc = {
+        ...curDoc,
+        address: { ...curDoc.address, path: [...curDoc.address.path, part] },
+        value: elementAt(curDoc.value, part),
+      };
     } else if (
       isObject(curDoc.value) && part in (curDoc.value as Immutable<JSONObject>)
     ) {
       const cursorObj = curDoc.value as Immutable<JSONObject>;
-      curDoc.value = cursorObj[part] as Immutable<JSONValue>;
-      curDoc.path.push(part);
+      curDoc = {
+        ...curDoc,
+        address: { ...curDoc.address, path: [...curDoc.address.path, part] },
+        value: cursorObj[part] as Immutable<JSONValue>,
+      };
     } else {
       // we can only descend into pointers, objects, and arrays
-      return [{ ...curDoc, path: [], value: undefined }, selector];
+      return [{
+        ...curDoc,
+        address: { ...curDoc.address, path: [] },
+        value: undefined,
+      }, selector];
     }
     // If this next value is a pointer, use the pointer resolution code
     while (isAnyCellLink(curDoc.value)) {
@@ -360,35 +378,44 @@ export function getAtPath<K, S>(
  *
  * @returns a ValueAtPath object with the target doc, docRoot, path, and value.
  */
-function followPointer<K, S>(
-  manager: BaseObjectManager<K, S, Immutable<JSONValue> | undefined>,
-  doc: ValueAtPath<K>,
+function followPointer<S extends BaseMemoryAddress>(
+  manager: BaseObjectManager<S, Immutable<JSONValue> | undefined>,
+  doc: ValueAtPath,
   path: readonly string[],
   tracker: PointerCycleTracker,
   schemaTracker?: MapSet<string, SchemaPathSelector>,
   selector?: SchemaPathSelector,
-): [ValueAtPath<K>, SchemaPathSelector | undefined] {
+): [ValueAtPath, SchemaPathSelector | undefined] {
   using t = tracker.include(doc.value!, doc);
   if (t === null) {
-    return [{ ...doc, path: [], value: undefined }, selector];
+    return [
+      { ...doc, address: { ...doc.address, path: [] }, value: undefined },
+      selector,
+    ];
   }
   const link = parseLink(doc.value)!;
-  const target = (link.id !== undefined) ? manager.getTarget(link.id) : doc.doc;
-  let [targetDoc, targetDocRoot] = [doc.doc, doc.docRoot];
+  const target = (link.id !== undefined)
+    ? manager.getTarget(link.id)
+    : doc.address;
+  let [targetDoc, targetDocRoot] = [doc.address, doc.rootValue];
   if (selector !== undefined) {
     // We'll need to re-root the selector for the target doc
     // Remove the portions of doc.path from selector.path, limiting schema if needed
     // Also insert the portions of cellTarget.path, so selector is relative to new target doc
     // We do this even if the target doc is the same doc, since we want the
     // selector path to match.
-    selector = narrowSchema(doc.path, selector, link.path as string[]);
+    selector = narrowSchema(doc.address.path, selector, link.path as string[]);
   }
   if (link.id !== undefined) {
     // We have a reference to a different cell, so track the dependency
     // and update our targetDoc and targetDocRoot
     const valueEntry = manager.load(target);
     if (valueEntry === null) {
-      return [{ ...doc, path: [], value: undefined }, selector];
+      return [{
+        ...doc,
+        address: { ...doc.address, path: [] },
+        value: undefined,
+      }, selector];
     }
     if (schemaTracker !== undefined && selector !== undefined) {
       schemaTracker.add(manager.toKey(target), selector);
@@ -397,14 +424,18 @@ function followPointer<K, S>(
     // We can't do a better match, but we do want to include the result so we watch this doc
     if (valueEntry.value === undefined) {
       return [
-        { doc: target, docRoot: undefined, path: [], value: undefined },
+        {
+          address: { ...target, path: [] },
+          value: undefined,
+          rootValue: undefined,
+        },
         selector,
       ];
     }
     // Otherwise, we can continue with the target.
     // an assertion fact.is will be an object with a value property, and
     // that's what our schema is relative to.
-    targetDoc = target;
+    targetDoc = { ...target, path: [] };
     const targetObj = valueEntry.value as Immutable<JSONObject>;
     targetDocRoot = targetObj["value"];
     // Load any sources (recursively) if they exist and any linked recipes
@@ -421,10 +452,9 @@ function followPointer<K, S>(
   return getAtPath(
     manager,
     {
-      doc: targetDoc,
-      docRoot: targetDocRoot,
-      path: [],
+      address: { ...targetDoc, path: [] },
       value: targetDocRoot,
+      rootValue: targetDocRoot,
     },
     [...link.path, ...path] as string[],
     tracker,
@@ -435,9 +465,9 @@ function followPointer<K, S>(
 
 // Recursively load the source from the doc ()
 // This will also load any recipes linked by the doc.
-export function loadSource<K, S>(
-  manager: BaseObjectManager<K, S, Immutable<JSONValue> | undefined>,
-  valueEntry: ValueEntry<S, Immutable<JSONValue> | undefined>,
+export function loadSource<S extends BaseMemoryAddress>(
+  manager: BaseObjectManager<S, Immutable<JSONValue> | undefined>,
+  valueEntry: ValueEntry<BaseMemoryAddress, Immutable<JSONValue> | undefined>,
   cycleCheck: Set<string> = new Set<string>(),
   schemaTracker?: MapSet<string, SchemaPathSelector>,
 ) {
@@ -478,9 +508,9 @@ export function loadSource<K, S>(
 
 // Load the linked recipe from the doc ()
 // We don't recurse, since that's not required for recipe links
-function loadLinkedRecipe<K, S>(
-  manager: BaseObjectManager<K, S, Immutable<JSONValue> | undefined>,
-  valueEntry: ValueEntry<S, Immutable<JSONValue> | undefined>,
+function loadLinkedRecipe<S extends BaseMemoryAddress>(
+  manager: BaseObjectManager<S, Immutable<JSONValue> | undefined>,
+  valueEntry: ValueEntry<BaseMemoryAddress, Immutable<JSONValue> | undefined>,
   schemaTracker?: MapSet<string, SchemaPathSelector>,
 ) {
   if (!isObject(valueEntry.value)) {
@@ -523,7 +553,7 @@ function loadLinkedRecipe<K, S>(
 // we want them relative to the new doc.
 // targetPath is the path in the target doc that the pointer points to
 function narrowSchema(
-  docPath: string[],
+  docPath: readonly string[],
   selector: SchemaPathSelector,
   targetPath: readonly string[],
 ): SchemaPathSelector {
@@ -584,9 +614,10 @@ export function isPrimitive(val: unknown): val is Primitive {
   return val === null || (type !== "object" && type !== "function");
 }
 
-export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
+export class SchemaObjectTraverser<S extends BaseMemoryAddress>
+  extends BaseObjectTraverser<S> {
   constructor(
-    manager: BaseObjectManager<K, S, Immutable<JSONValue> | undefined>,
+    manager: BaseObjectManager<S, Immutable<JSONValue> | undefined>,
     private selector: SchemaPathSelector,
     private tracker: PointerCycleTracker = new CycleTracker<
       Immutable<JSONValue>
@@ -600,9 +631,9 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
   }
 
   override traverse(
-    doc: ValueAtPath<K>,
+    doc: ValueAtPath,
   ): Immutable<OptJSONValue> {
-    this.schemaTracker.add(this.manager.toKey(doc.doc), this.selector);
+    this.schemaTracker.add(this.manager.toKey(doc.address), this.selector);
     return this.traverseWithSelector(doc, this.selector);
   }
 
@@ -610,21 +641,26 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
   // The selector should have been re-rooted if needed to be relative to the specified doc
   // The selector must have a valid (defined) schemaContext
   traverseWithSelector(
-    doc: ValueAtPath<K>,
+    doc: ValueAtPath,
     selector: SchemaPathSelector,
   ): Immutable<OptJSONValue> {
-    if (deepEqual(doc.path, selector.path)) {
+    if (deepEqual(doc.address.path, selector.path)) {
       return this.traverseWithSchemaContext(doc, selector.schemaContext!);
-    } else if (doc.path.length > selector.path.length) {
+    } else if (doc.address.path.length > selector.path.length) {
       throw new Error("Doc path should never exceed selector path");
-    } else if (!deepEqual(doc.path, selector.path.slice(0, doc.path.length))) {
+    } else if (
+      !deepEqual(
+        doc.address.path,
+        selector.path.slice(0, doc.address.path.length),
+      )
+    ) {
       // There's a mismatch in the initial part, so this will not match
       return undefined;
     } else { // doc path length < selector.path.length
       const [nextDoc, nextSelector] = getAtPath(
         this.manager,
         doc,
-        selector.path.slice(doc.path.length),
+        selector.path.slice(doc.address.path.length),
         this.tracker,
         this.schemaTracker,
         selector,
@@ -632,7 +668,7 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
       if (nextDoc.value === undefined) {
         return undefined;
       }
-      if (!deepEqual(nextDoc.path, nextSelector!.path)) {
+      if (!deepEqual(nextDoc.address.path, nextSelector!.path)) {
         throw new Error("New doc path doesn't match selector path");
       }
       return this.traverseWithSchemaContext(
@@ -643,7 +679,7 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
   }
 
   traverseWithSchemaContext(
-    doc: ValueAtPath<K>,
+    doc: ValueAtPath,
     schemaContext: Readonly<SchemaContext>,
   ): Immutable<OptJSONValue> {
     if (ContextualFlowControl.isTrueSchema(schemaContext.schema)) {
@@ -742,7 +778,7 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
   }
 
   private traverseArrayWithSchema(
-    doc: ValueAtPath<K>,
+    doc: ValueAtPath,
     schemaContext: SchemaContext,
   ): Immutable<OptJSONValue> {
     const arrayObj = [];
@@ -757,11 +793,14 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
         : true;
       const curDoc = {
         ...doc,
-        path: [...doc.path, index.toString()],
+        address: {
+          ...doc.address,
+          path: [...doc.address.path, index.toString()],
+        },
         value: item,
       };
       const selector = {
-        path: curDoc.path,
+        path: curDoc.address.path,
         schemaContext: {
           schema: itemSchema,
           rootSchema: schemaContext.rootSchema,
@@ -778,7 +817,7 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
   }
 
   private traverseObjectWithSchema(
-    doc: ValueAtPath<K>,
+    doc: ValueAtPath,
     schemaContext: SchemaContext,
   ): Immutable<OptJSONValue> {
     const filteredObj: Record<string, Immutable<OptJSONValue>> = {};
@@ -804,7 +843,10 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
       }
       const val = this.traverseWithSchemaContext({
         ...doc,
-        path: [...doc.path, propKey],
+        address: {
+          ...doc.address,
+          path: [...doc.address.path, propKey],
+        },
         value: propValue,
       }, {
         schema: propSchema,
@@ -828,9 +870,10 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
     return filteredObj;
   }
 
-  // This just has a schemaContext, since the doc.path would match the selector.path
+  // This just has a schemaContext, since the doc.address.path would match the
+  // selector.path
   private traversePointerWithSchema(
-    doc: ValueAtPath<K>,
+    doc: ValueAtPath,
     schemaContext: SchemaContext,
   ): Immutable<OptJSONValue> {
     const [newDoc, newSelector] = getAtPath(
@@ -839,7 +882,7 @@ export class SchemaObjectTraverser<K, S> extends BaseObjectTraverser<K, S> {
       [],
       this.tracker,
       this.schemaTracker,
-      { path: [...doc.path], schemaContext: schemaContext },
+      { path: [...doc.address.path], schemaContext: schemaContext },
     );
     if (newDoc.value === undefined) {
       return null;

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -130,27 +130,22 @@ export type PointerCycleTracker = CycleTracker<
 >;
 
 export interface ObjectStorageManager<K, S, V> {
-  addRead(doc: K, value: V, source: S): void;
-  addWrite(doc: K, value: V, source: S): void;
+  addRead(address: K, value: V, source: S): void;
+  addWrite(address: K, value: V, source: S): void;
   // get the key for the doc pointed to by the cell target
   getTarget(uri: URI): K;
   // load the object for the specified key
-  load(doc: K): IAttestation | null;
+  load(address: K): IAttestation | null;
 }
-
-// This is very similar to the IAttestation class.
-// There's a difference where the address will not include the initial
-// "value" in the path, and the rootValue is actually the contents of the
-// "value" property of the document.
-type BaseValueAtPath = {
-  readonly address: IMemoryAddress;
-  readonly value: Immutable<JSONValue> | undefined;
-};
 
 export type BaseMemoryAddress = Omit<IMemoryAddress, "path">;
 
-// This adds the rootValue property to the BaseValueAtPath
-export type ValueAtPath = BaseValueAtPath & {
+// This is very similar to the IAttestation class.
+// We do use the IAttestation class a little differently.
+// The address doesn't include the initial "value" in the path.
+// This adds the rootValue property to the BaseValueAtPath, which is actually
+//  the contents of the "value" property of the document.
+export type ValueAtPath = IAttestation & {
   readonly rootValue: Immutable<JSONValue> | undefined;
 };
 
@@ -171,24 +166,24 @@ export abstract class BaseObjectManager<
     protected writeValues = new Map<string, IAttestation>(),
   ) {}
 
-  addRead(doc: S, value: V, source: S) {
-    const key = this.toKey(doc);
+  addRead(address: S, value: V, source: S) {
+    const key = this.toKey(address);
     this.readValues.set(key, {
       value: value,
       address: { path: [], ...source },
     });
   }
 
-  addWrite(doc: S, value: V, source: S) {
-    const key = this.toKey(doc);
+  addWrite(address: S, value: V, source: S) {
+    const key = this.toKey(address);
     this.writeValues.set(key, {
       value: value,
       address: { path: [], ...source },
     });
   }
 
-  toKey(doc: BaseMemoryAddress): string {
-    return `${doc.id}/${doc.type}`;
+  toKey(address: BaseMemoryAddress): string {
+    return `${address.id}/${address.type}`;
   }
 
   toAddress(str: string): BaseMemoryAddress {
@@ -198,7 +193,7 @@ export abstract class BaseObjectManager<
   abstract getTarget(uri: URI): BaseMemoryAddress;
   // load the doc from the underlying system.
   // implementations are responsible for adding this to the readValues
-  abstract load(doc: BaseMemoryAddress): IAttestation | null;
+  abstract load(address: BaseMemoryAddress): IAttestation | null;
 }
 
 export type OptJSONValue =

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -132,8 +132,6 @@ export type PointerCycleTracker = CycleTracker<
 export interface ObjectStorageManager<K, S, V> {
   addRead(address: K, value: V, source: S): void;
   addWrite(address: K, value: V, source: S): void;
-  // get the key for the doc pointed to by the cell target
-  getTarget(uri: URI): K;
   // load the object for the specified key
   load(address: K): IAttestation | null;
 }
@@ -190,7 +188,6 @@ export abstract class BaseObjectManager<
     return { id: `of:${str}`, type: "application/json" };
   }
 
-  abstract getTarget(uri: URI): BaseMemoryAddress;
   // load the doc from the underlying system.
   // implementations are responsible for adding this to the readValues
   abstract load(address: BaseMemoryAddress): IAttestation | null;
@@ -402,7 +399,7 @@ function followPointer<S extends BaseMemoryAddress>(
   }
   const link = parseLink(doc.value)!;
   const target = (link.id !== undefined)
-    ? manager.getTarget(link.id)
+    ? { id: link.id, type: "application/json" }
     : doc.address;
   let [targetDoc, targetDocRoot] = [doc.address, doc.rootValue];
   if (selector !== undefined) {

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -502,13 +502,13 @@ export function loadSource<S extends BaseMemoryAddress>(
     return;
   }
   cycleCheck.add(of);
-  const entryDoc = manager.toAddress(of);
-  const entry = manager.load(entryDoc);
-  if (entry === null || entry.value === undefined || !entry.address) {
+  const address = manager.toAddress(of);
+  const entry = manager.load(address);
+  if (entry === null || entry.value === undefined) {
     return;
   }
   if (schemaTracker !== undefined) {
-    schemaTracker.add(manager.toKey(entryDoc), MinimalSchemaSelector);
+    schemaTracker.add(manager.toKey(address), MinimalSchemaSelector);
   }
   loadSource(manager, entry, cycleCheck, schemaTracker);
 }
@@ -532,26 +532,26 @@ function loadLinkedRecipe<S extends BaseMemoryAddress>(
   if (!isObject(value)) {
     return;
   }
-  let entryDoc;
+  let address;
   // Check for a spell link first, since this is more efficient
   // Older recipes will only have a $TYPE
   if ("spell" in value && isAnyCellLink(value["spell"])) {
     const link = parseLink(value["spell"])!;
-    entryDoc = manager.toAddress(fromURI(link.id!));
+    address = manager.toAddress(fromURI(link.id!));
   } else if ("$TYPE" in value && isString(value["$TYPE"])) {
     const recipeId = value["$TYPE"];
     const entityId = refer({ causal: { recipeId, type: "recipe" } });
-    entryDoc = manager.toAddress(entityId.toJSON()["/"]);
+    address = manager.toAddress(entityId.toJSON()["/"]);
   }
-  if (entryDoc === undefined) {
+  if (address === undefined) {
     return;
   }
-  const entry = manager.load(entryDoc);
+  const entry = manager.load(address);
   if (entry === null || entry.value === undefined) {
     return;
   }
   if (schemaTracker !== undefined) {
-    schemaTracker.add(manager.toKey(entryDoc), MinimalSchemaSelector);
+    schemaTracker.add(manager.toKey(address), MinimalSchemaSelector);
   }
 }
 

--- a/packages/runner/test/pending-nursery.test.ts
+++ b/packages/runner/test/pending-nursery.test.ts
@@ -50,7 +50,7 @@ describe("Provider Subscriptions", () => {
       let s1Count = 0;
 
       provider.replica.heap.subscribe(
-        { of: uri, the: "application/json" },
+        { id: uri, type: "application/json" },
         (_v) => {
           s1Count++;
         },

--- a/packages/runner/test/query.test.ts
+++ b/packages/runner/test/query.test.ts
@@ -122,10 +122,9 @@ describe("Query", () => {
     );
     // We've provided a schema context for this, so traverse it
     traverser.traverse({
-      doc: { the: assert2.the, of: assert2.of },
-      docRoot: assert2.is.value,
-      path: [],
+      address: { id: assert2.of, type: assert2.the, path: [] },
       value: assert2.is.value,
+      rootValue: assert2.is.value,
     });
     const selectorSet1 = schemaTracker.get(
       `of:${entityId1["/"]}/application/json`,
@@ -209,14 +208,11 @@ describe("Query", () => {
       schemaTracker,
     );
     // We've provided a schema context for this, so traverse it
-    traverser.traverse(
-      {
-        doc: { the: assert2.the, of: assert2.of },
-        docRoot: assert2.is.value,
-        path: [],
-        value: assert2.is.value,
-      },
-    );
+    traverser.traverse({
+      address: { id: assert2.of, type: assert2.the, path: [] },
+      value: assert2.is.value,
+      rootValue: assert2.is.value,
+    });
     const selectorSet1 = schemaTracker.get(
       `of:${entityId1["/"]}/application/json`,
     );
@@ -292,14 +288,11 @@ describe("Query", () => {
       schemaTracker,
     );
     // We've provided a schema context for this, so traverse it
-    traverser.traverse(
-      {
-        doc: { the: assert1.the, of: assert1.of },
-        docRoot: assert1.is.value,
-        path: [],
-        value: assert1.is.value,
-      },
-    );
+    traverser.traverse({
+      address: { id: assert1.of, type: assert1.the, path: [] },
+      value: assert1.is.value,
+      rootValue: assert1.is.value,
+    });
     const selectorSet1 = schemaTracker.get(
       `of:${entityId1["/"]}/application/json`,
     );
@@ -379,14 +372,11 @@ describe("Query", () => {
       schemaTracker,
     );
     // We've provided a schema context for this, so traverse it
-    traverser.traverse(
-      {
-        doc: { the: assert2.the, of: assert2.of },
-        docRoot: assert2.is.value,
-        path: [],
-        value: assert2.is.value,
-      },
-    );
+    traverser.traverse({
+      address: { id: assert2.of, type: assert2.the, path: [] },
+      value: assert2.is.value,
+      rootValue: assert2.is.value,
+    });
     const selectorSet1 = schemaTracker.get(
       `of:${entityId1["/"]}/application/json`,
     );

--- a/packages/runner/test/storage-subscription.test.ts
+++ b/packages/runner/test/storage-subscription.test.ts
@@ -216,7 +216,7 @@ describe("Storage Subscription", () => {
       }, { version: 2 });
 
       // Check that before commit provider.replica.get returns undefined
-      const factAddress = { the: "application/json", of: entityId };
+      const factAddress = { id: entityId, type: "application/json" };
       expect(replica.get(factAddress)).toBeUndefined();
 
       // Send commit (without await) and check optimistic update
@@ -303,7 +303,7 @@ describe("Storage Subscription", () => {
 
       // Call pull on the replica
       const { replica } = storageManager.open(space);
-      const factAddress = { the: "application/json", of: entityId };
+      const factAddress = { id: entityId, type: "application/json" };
 
       await (replica as any).pull([[factAddress, undefined]]);
 

--- a/packages/runner/test/transaction-notfound.test.ts
+++ b/packages/runner/test/transaction-notfound.test.ts
@@ -6,7 +6,6 @@ import type {
   IStorageManager,
   MemorySpace,
 } from "../src/storage/interface.ts";
-import { unclaimed } from "@commontools/memory/fact";
 
 // Mock replica that simulates non-existent documents
 class MockReplica implements ISpaceReplica {
@@ -18,8 +17,8 @@ class MockReplica implements ISpaceReplica {
     return this.space;
   }
 
-  get(entry: { the: string; of: string }) {
-    const key = `${entry.of}:${entry.the}`;
+  get(entry: { id: string; type: string }) {
+    const key = `${entry.id}:${entry.type}`;
     return this.data.get(key);
   }
 

--- a/packages/runner/test/transaction.test.ts
+++ b/packages/runner/test/transaction.test.ts
@@ -507,8 +507,8 @@ describe("StorageTransaction", () => {
 
       // Verify the replica state actually changed
       const updatedState = replica.get({
-        the: "application/json",
-        of: "user:consistency",
+        id: "user:consistency",
+        type: "application/json",
       });
       expect(updatedState?.is).toEqual({ name: "Modified", version: 2 });
 


### PR DESCRIPTION
- ValueEntry overlaps enough with IAttestation that I switched to IAttestation. There's a minor difference in whether we have the "value" in the address path.
- IMemoryAddress is a bit nicer than FactAddress, so use IMemoryAddress when it's easy

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized addresses and values across traverse, storage, and query. Replaced FactAddress/ValueEntry with IMemoryAddress/IAttestation to simplify path handling and align client/server behavior. Addresses CT-768.

- **Refactors**
  - Switched to IMemoryAddress (with BaseMemoryAddress) and IAttestation across runner, storage, and schema selection.
  - Reworked ValueAtPath to mirror IAttestation and added rootValue for the doc’s value payload.
  - Removed getTarget; toKey now uses address.id/type; added toAddress helper.
  - querySchema now accepts a single IMemoryAddress (with path) and returns loaded as IAttestation; removed separate path arg.
  - Updated getAtPath, followPointer, loadSource, and traverser to use address.path instead of standalone paths.
  - ServerObjectManager tracks cause/since internally and exposes getDetails(address); read labels keyed by address.id.
  - Storage uses address.id/type when collecting linked docs and when sending to storage.

- **Migration**
  - Replace FactAddress/ValueEntry types with IMemoryAddress/BaseMemoryAddress and IAttestation.
  - Update getAtPath calls to pass { address, value, rootValue } and stop passing a separate path.
  - Update querySchema call sites to pass a single address (with path) and handle loaded/missing types accordingly.
  - Remove getTarget usage; build addresses directly with id and type ("application/json").
  - When you need cause/since for selections, call ServerObjectManager.getDetails(address).

<!-- End of auto-generated description by cubic. -->

