### PR TITLE
Changed Replica to use BaseMemoryAddress instead of FactAddress.

### DIFF
--- a/packages/memory/commit.ts
+++ b/packages/memory/commit.ts
@@ -12,7 +12,7 @@ import type {
 import { assert } from "./fact.ts";
 import { fromString } from "merkle-reference";
 
-export const the = "application/commit+json" as const;
+export const COMMIT_LOG_TYPE = "application/commit+json" as const;
 export const create = <Space extends MemorySpace>({
   space,
   cause,
@@ -23,9 +23,9 @@ export const create = <Space extends MemorySpace>({
   since?: number;
   transaction: Transaction;
   cause?: Reference<Assertion> | Assertion | null | undefined;
-}): Assertion<typeof the, Space, CommitData> =>
+}): Assertion<typeof COMMIT_LOG_TYPE, Space, CommitData> =>
   assert({
-    the,
+    the: COMMIT_LOG_TYPE,
     of: space,
     is: {
       since,
@@ -38,11 +38,11 @@ export const toRevision = (
   commit: Commit,
 ): Revision<CommitFact> => {
   const [[space, attributes]] = Object.entries(commit);
-  const [[cause, { is }]] = Object.entries(attributes[the]);
+  const [[cause, { is }]] = Object.entries(attributes[COMMIT_LOG_TYPE]);
 
   return {
     ...assert({
-      the,
+      the: COMMIT_LOG_TYPE,
       of: space as MemorySpace,
       is,
       cause: fromString(cause) as Reference<Fact>,

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -13,7 +13,7 @@ import {
 } from "@commontools/runner/traverse";
 import { type Immutable, isObject } from "@commontools/utils/types";
 import { getLogger } from "@commontools/utils/logger";
-import { the as COMMIT_THE } from "./commit.ts";
+import { COMMIT_LOG_TYPE } from "./commit.ts";
 import type { CommitData, SchemaPathSelector } from "./consumer.ts";
 import { TheAuthorizationError } from "./error.ts";
 import type {
@@ -286,7 +286,7 @@ const redactCommits = <Space extends MemorySpace>(
   includedFacts: FactSelection,
   session: Session<Space>,
 ) => {
-  const change = getChange(includedFacts, session.subject, COMMIT_THE);
+  const change = getChange(includedFacts, session.subject, COMMIT_LOG_TYPE);
   if (change !== undefined) {
     const [cause, value] = change;
     const commitData = value.is as CommitData;
@@ -308,7 +308,7 @@ const redactCommits = <Space extends MemorySpace>(
     setRevision<FactSelectionValue>(
       includedFacts,
       session.subject,
-      COMMIT_THE,
+      COMMIT_LOG_TYPE,
       cause,
       redactedValue,
     );

--- a/packages/memory/space.ts
+++ b/packages/memory/space.ts
@@ -4,7 +4,7 @@ import {
   Transaction as DBTransaction,
 } from "@db/sqlite";
 
-import { create as createCommit, the as COMMIT_THE } from "./commit.ts";
+import { COMMIT_LOG_TYPE, create as createCommit } from "./commit.ts";
 import { unclaimed } from "./fact.ts";
 import { fromString, refer } from "./reference.ts";
 import { addMemoryAttributes, traceAsync, traceSync } from "./telemetry.ts";
@@ -708,7 +708,7 @@ const commit = <Space extends MemorySpace>(
   session: Session<Space>,
   transaction: Transaction<Space>,
 ): Commit<Space> => {
-  const the = COMMIT_THE;
+  const the = COMMIT_LOG_TYPE;
   const of = transaction.sub;
   const row = session.store.prepare(EXPORT).get({ the, of }) as
     | StateRow
@@ -878,7 +878,7 @@ export const querySchema = <Space extends MemorySpace>(
   });
 };
 
-export const LABEL_THE = "application/label+json" as const;
+export const LABEL_TYPE = "application/label+json" as const;
 export type FactSelectionValue = { is?: JSONValue; since: number };
 // Get the labels associated with a set of commits.
 // It's possible to get more than one label for a single doc because our
@@ -893,7 +893,7 @@ export function getLabels<
   const labels: OfTheCause<FactSelectionValue> = {};
   for (const fact of iterate(includedFacts)) {
     // We don't restrict acccess to labels
-    if (fact.the === LABEL_THE) {
+    if (fact.the === LABEL_TYPE) {
       continue;
     }
     const labelFact = getLabel(session, fact.of);
@@ -918,7 +918,7 @@ export function getLabel<Space extends MemorySpace>(
   session: Session<Space>,
   of: Entity,
 ) {
-  return selectFact(session, { of, the: LABEL_THE });
+  return selectFact(session, { of, the: LABEL_TYPE });
 }
 
 // Get the various classification tags required based on the collection of labels.
@@ -973,12 +973,12 @@ export function redactCommitData(
       continue;
     }
     // We treat all labels as unclassified
-    if (fact.the === LABEL_THE) {
+    if (fact.the === LABEL_TYPE) {
       set(newChanges, fact.of, fact.the, fact.cause, fact.value);
       continue;
     }
     // FIXME(@ubik2): Re-enable this once we've tracked down other issues
-    // const labelFact = getRevision(commitData.labels, fact.of, LABEL_THE);
+    // const labelFact = getRevision(commitData.labels, fact.of, LABEL_TYPE);
     // if (labelFact !== undefined && getClassifications(labelFact).size > 0) {
     //   setEmptyObj(newChanges, fact.of, fact.the);
     // } else {

--- a/packages/memory/subscription.ts
+++ b/packages/memory/subscription.ts
@@ -7,14 +7,14 @@ import {
   Selector,
   The,
 } from "./interface.ts";
-import { the as commitType } from "./commit.ts";
+import { COMMIT_LOG_TYPE } from "./commit.ts";
 
 export const match = (commit: Commit, watched: Set<string>) => {
   for (const at of Object.keys(commit) as MemorySpace[]) {
-    const commitObj = commit[at][commitType] ?? {};
+    const commitObj = commit[at][COMMIT_LOG_TYPE] ?? {};
     for (const { is: { transaction } } of Object.values(commitObj)) {
       // If commit on this space are watched we have a match
-      if (matchAddress(watched, { the: commitType, of: at, at })) {
+      if (matchAddress(watched, { the: COMMIT_LOG_TYPE, of: at, at })) {
         return true;
       }
 

--- a/packages/memory/test/consumer-test.ts
+++ b/packages/memory/test/consumer-test.ts
@@ -8,7 +8,7 @@ import * as Fact from "../fact.ts";
 import type { UTCUnixTimestampInSeconds } from "../interface.ts";
 import * as Provider from "../provider.ts";
 import * as Selection from "../selection.ts";
-import { LABEL_THE } from "../space.ts";
+import { LABEL_TYPE } from "../space.ts";
 import * as Transaction from "../transaction.ts";
 import { alice, bob, space as subject } from "./principal.ts";
 import { Identity } from "../../identity/src/identity.ts";
@@ -749,7 +749,7 @@ test(
     });
 
     const v1_label = Fact.assert({
-      the: LABEL_THE,
+      the: LABEL_TYPE,
       of: doc,
       is: { classification: ["confidential"] },
     });
@@ -795,7 +795,7 @@ test(
     });
 
     const v1_label = Fact.assert({
-      the: LABEL_THE,
+      the: LABEL_TYPE,
       of: doc,
       is: { classification: ["confidential"] },
     });
@@ -875,7 +875,7 @@ test(
     });
 
     const v1_label = Fact.assert({
-      the: LABEL_THE,
+      the: LABEL_TYPE,
       of: doc,
       is: { classification: ["confidential"] },
     });
@@ -990,7 +990,7 @@ test(
     });
 
     const v1_label = Fact.assert({
-      the: LABEL_THE,
+      the: LABEL_TYPE,
       of: doc,
       is: { classification: ["confidential"] },
     });
@@ -1116,7 +1116,7 @@ test(
       cause: v2,
     });
     const v3_label = Fact.assert({
-      the: LABEL_THE,
+      the: LABEL_TYPE,
       of: doc,
       is: { classification: ["confidential"] },
     });
@@ -1181,7 +1181,7 @@ test(
     });
 
     const v1_label = Fact.assert({
-      the: LABEL_THE,
+      the: LABEL_TYPE,
       of: doc,
       is: { classification: ["confidential"] },
     });

--- a/packages/runner/integration/pending-nursery.test.ts
+++ b/packages/runner/integration/pending-nursery.test.ts
@@ -52,7 +52,7 @@ async function test() {
 
   let s1Count = 0;
   provider1.replica.heap.subscribe(
-    { of: uri, the: "application/json" },
+    { id: uri, type: "application/json" },
     (v) => {
       s1Count++;
     },
@@ -71,7 +71,7 @@ async function test() {
     (runtime2.storageManager.open(identity.did()) as any).provider;
   let s2Count = 0;
   provider2.replica.heap.subscribe(
-    { of: uri, the: "application/json" },
+    { id: uri, type: "application/json" },
     (_v) => {
       s2Count++;
     },
@@ -88,7 +88,7 @@ async function test() {
   // Set up a wait for the last value (45)
   const deferred = Promise.withResolvers();
   provider2.replica.heap.subscribe(
-    { of: uri, the: "application/json" },
+    { id: uri, type: "application/json" },
     (v) => {
       if ((v?.is as any).value.count === 45) {
         deferred.resolve(true);

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -21,6 +21,7 @@ import type {
   URI,
   Variant,
 } from "@commontools/memory/interface";
+import { BaseMemoryAddress } from "@commontools/runner/traverse";
 
 export type {
   Assertion,
@@ -773,7 +774,7 @@ export interface ISpaceReplica extends ISpace {
    * Return a state for the requested entry or returns `undefined` if replica
    * does not have it.
    */
-  get(entry: FactAddress): State | undefined;
+  get(entry: BaseMemoryAddress): State | undefined;
 
   commit(
     transaction: ITransaction,

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -184,8 +184,8 @@ export const claim = (
   { address, value: expected }: IAttestation,
   replica: ISpaceReplica,
 ): Result<State, IStorageTransactionInconsistent> => {
-  const [the, of] = [address.type, address.id];
-  const state = replica.get({ the, of }) ?? unclaimed({ the, of });
+  const state = replica.get(address) ??
+    unclaimed({ of: address.id, the: address.type });
   const source = attest(state);
   const actual = read(source, address)?.ok?.value;
 

--- a/packages/runner/src/storage/transaction/chronicle.ts
+++ b/packages/runner/src/storage/transaction/chronicle.ts
@@ -86,10 +86,10 @@ export class Chronicle {
    * such fact exists yet.
    */
   load(address: Omit<IMemoryAddress, "path">): State {
-    const [the, of] = [address.type, address.id];
     // If we have not read nor written into overlapping memory address,
     // we'll read it from the local replica.
-    return this.#replica.get({ the, of }) ?? unclaimed({ the, of });
+    return this.#replica.get(address) ??
+      unclaimed({ of: address.id, the: address.type });
   }
 
   /**

--- a/packages/runner/test/pending-nursery.test.ts
+++ b/packages/runner/test/pending-nursery.test.ts
@@ -50,7 +50,7 @@ describe("Provider Subscriptions", () => {
       let s1Count = 0;
 
       provider.replica.heap.subscribe(
-        { of: uri, the: "application/json" },
+        { id: uri, type: "application/json" },
         (_v) => {
           s1Count++;
         },

--- a/packages/runner/test/storage-subscription.test.ts
+++ b/packages/runner/test/storage-subscription.test.ts
@@ -216,7 +216,7 @@ describe("Storage Subscription", () => {
       }, { version: 2 });
 
       // Check that before commit provider.replica.get returns undefined
-      const factAddress = { the: "application/json", of: entityId };
+      const factAddress = { id: entityId, type: "application/json" };
       expect(replica.get(factAddress)).toBeUndefined();
 
       // Send commit (without await) and check optimistic update
@@ -303,7 +303,7 @@ describe("Storage Subscription", () => {
 
       // Call pull on the replica
       const { replica } = storageManager.open(space);
-      const factAddress = { the: "application/json", of: entityId };
+      const factAddress = { id: entityId, type: "application/json" };
 
       await (replica as any).pull([[factAddress, undefined]]);
 

--- a/packages/runner/test/transaction-notfound.test.ts
+++ b/packages/runner/test/transaction-notfound.test.ts
@@ -6,7 +6,6 @@ import type {
   IStorageManager,
   MemorySpace,
 } from "../src/storage/interface.ts";
-import { unclaimed } from "@commontools/memory/fact";
 
 // Mock replica that simulates non-existent documents
 class MockReplica implements ISpaceReplica {
@@ -18,8 +17,8 @@ class MockReplica implements ISpaceReplica {
     return this.space;
   }
 
-  get(entry: { the: string; of: string }) {
-    const key = `${entry.of}:${entry.the}`;
+  get(entry: { id: string; type: string }) {
+    const key = `${entry.id}:${entry.type}`;
     return this.data.get(key);
   }
 

--- a/packages/runner/test/transaction.test.ts
+++ b/packages/runner/test/transaction.test.ts
@@ -507,8 +507,8 @@ describe("StorageTransaction", () => {
 
       // Verify the replica state actually changed
       const updatedState = replica.get({
-        the: "application/json",
-        of: "user:consistency",
+        id: "user:consistency",
+        type: "application/json",
       });
       expect(updatedState?.is).toEqual({ name: "Modified", version: 2 });
 


### PR DESCRIPTION
IndexedDB still uses FactAddress for backwards compatability.
Renamed COMMIT_THE to COMMIT_LOG_TYPE
Renamed LABEL_THE to LABEL_TYPE
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized storage addressing to BaseMemoryAddress ({id, type}) across Replica and storage layers, and renamed commit/label MIME type constants. Supports Linear CT-768; IndexedDB remains on FactAddress for backward compatibility.

- **Refactors**
  - Replica, cache, provider, and differential now use BaseMemoryAddress instead of FactAddress.
  - Renamed COMMIT_THE to COMMIT_LOG_TYPE and LABEL_THE to LABEL_TYPE.
  - Subscriptions, get/pull/load APIs and internal keys updated to use {id, type}; commit matching uses COMMIT_LOG_TYPE.

- **Migration**
  - Replace { of, the } with { id, type } when calling replica.get/subscribe/pull and provider/workspace methods.
  - Update imports and checks to use COMMIT_LOG_TYPE and LABEL_TYPE.
  - No changes needed for IndexedDB usage; it still accepts FactAddress.

<!-- End of auto-generated description by cubic. -->

