### PR TITLE
prevent circular proxy loop by collapsing immediate‑parent deref links

### DIFF
--- a/packages/patterns/linkedlist-in-cell.tsx
+++ b/packages/patterns/linkedlist-in-cell.tsx
@@ -1,10 +1,10 @@
 /// <cts-enable />
 import {
-  h,
   Cell,
   cell,
   Default,
   derive,
+  h,
   handler,
   NAME,
   recipe,
@@ -30,21 +30,11 @@ interface ListState {
   items_list: Cell<LinkedList>;
 }
 
-// Helper function to copy a linked list
-function copyList(list: LinkedList): LinkedList {
-  return {
-    value: list.value,
-    next: list.next ? copyList(list.next) : undefined,
-  };
-}
-
 // Helper function to add a node to the linked list
-// copy the list because it has reactive symbols in it
-// FIXME(@ellyxir): why do these symbols break things?
 function addNodeToList(list: LinkedList, value: string): LinkedList {
   return {
     value: value,
-    next: copyList(list),
+    next: list,
   };
 }
 

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -523,11 +523,6 @@ export function normalizeAndDiff(
     seen.set(newValue, link);
 
     for (const key in newValue) {
-      // Skip symbol keys
-      //if (typeof key === "symbol") {
-      //  continue;
-      //}
-
       const childPath = [...link.path, key].join(".");
       diffLogger.debug(() =>
         `[DIFF_RECURSE] Recursing into key='${key}' childPath=${childPath}`

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -523,10 +523,10 @@ export function normalizeAndDiff(
     seen.set(newValue, link);
 
     for (const key in newValue) {
-      const childPath = [...link.path, key].join(".");
-      diffLogger.debug(() =>
-        `[DIFF_RECURSE] Recursing into key='${key}' childPath=${childPath}`
-      );
+      diffLogger.debug(() => {
+        const childPath = [...link.path, key].join(".");
+        return `[DIFF_RECURSE] Recursing into key='${key}' childPath=${childPath}`;
+      });
 
       const childSchema = runtime.cfc.getSchemaAtPath(
         link.schema,


### PR DESCRIPTION
- add guard in `normalizeAndDiff` cell-link branch: when a link comes from query-result dereferencing and targets the same-doc immediate parent, embed a snapshot via `tx.readValueOrThrow` instead of writing the link
- switch snapshot/alias reads to `tx.readValueOrThrow` for transaction consistency
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents a circular proxy loop when a dereferenced link targets its same-doc immediate parent by embedding a snapshot instead of writing the link. Also switches reads to tx.readValueOrThrow for transaction consistency, addressing Linear CT-773.

- **Bug Fixes**
  - Collapse immediate-parent deref links to a JSON snapshot via tx.readValueOrThrow to avoid tight self-loops (e.g., obj.next -> obj).
  - Use tx.readValueOrThrow for alias/data reads to keep all reads within the active transaction.

<!-- End of auto-generated description by cubic. -->

