### PR TITLE
Add `ct-render` pattern

### DIFF
--- a/packages/patterns/ct-render.tsx
+++ b/packages/patterns/ct-render.tsx
@@ -1,0 +1,90 @@
+/// <cts-enable />
+import {
+  Cell,
+  Default,
+  derive,
+  h,
+  handler,
+  NAME,
+  Opaque,
+  OpaqueRef,
+  recipe,
+  str,
+  UI,
+} from "commontools";
+
+interface RecipeState {
+  value: Default<number, 0>;
+}
+
+// In this case we do not have to type our event parameter because it is not used in the body.
+// By requesting a Cell<number> we get a mutable handle when our handler is invoked.
+const increment = handler<unknown, { value: Cell<number> }>((_, state) => {
+  state.value.set(state.value.get() + 1);
+});
+
+// This can also be done with inline types + inference
+const decrement = handler((_, state: { value: Cell<number> }) => {
+  state.value.set(state.value.get() - 1);
+});
+
+function previous(value: number) {
+  return value - 1;
+}
+
+function nth(value: number) {
+  if (value === 1) {
+    return "1st";
+  }
+  if (value === 2) {
+    return "2nd";
+  }
+  if (value === 3) {
+    return "3rd";
+  }
+  return `${value}th`;
+}
+
+export const Counter = recipe<RecipeState>("Counter", (state) => {
+  return {
+    // str is used so we can directly interpolate the OpaqueRef<number> into the string
+    [NAME]: str`Simple counter: ${state.value}`,
+    [UI]: (
+      <div>
+        {
+          /* Even though we could end up passing extra data to decrement, our schema prevents that actually reaching the handler.
+          In fact, we are passing `value` as an OpaqueRef<number> here but it becomes a Cell<number> at invocation time */
+        }
+        <ct-button onClick={decrement(state)}>
+          dec to {previous(state.value)}
+        </ct-button>
+        <span id="counter-result">
+          {/* <cts-enable /> transforms pure functions (like nth) into the `derive(c, nth)` equivalent */}
+          Counter is the {nth(state.value)} number
+        </span>
+        <ct-button onClick={increment({ value: state.value })}>
+          inc to {state.value + 1}
+        </ct-button>
+      </div>
+    ),
+    value: state.value,
+  };
+});
+
+/*
+This demonstrates a pattern of passing a Cell to a sub-recipe and keeping the value in sync between all locations.
+It also demonstrates that any recipe can be invoked using JSX syntax.
+*/
+export default recipe<RecipeState>("Counter", (state) => {
+  const counter = Counter({ value: state.value });
+
+  return {
+    [NAME]: str`Double counter: ${state.value}`,
+    [UI]: (
+      <div>
+        <ct-render $cell={counter} />
+      </div>
+    ),
+    value: state.value,
+  };
+});

--- a/packages/patterns/integration/ct-render.test.ts
+++ b/packages/patterns/integration/ct-render.test.ts
@@ -1,0 +1,144 @@
+import { env } from "@commontools/integration";
+import { sleep } from "@commontools/utils/sleep";
+import { CharmsController } from "@commontools/charm/ops";
+import { ShellIntegration } from "@commontools/integration/shell-utils";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import { assert, assertEquals } from "@std/assert";
+import { getCharmResult, setCharmResult } from "@commontools/charm/ops";
+import { Identity } from "@commontools/identity";
+
+const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
+
+describe("ct-render integration test", () => {
+  const shell = new ShellIntegration();
+  shell.bindLifecycle();
+
+  let charmId: string;
+  let identity: Identity;
+  let cc: CharmsController;
+
+  beforeAll(async () => {
+    identity = await Identity.generate({ implementation: "noble" });
+    cc = await CharmsController.initialize({
+      spaceName: SPACE_NAME,
+      apiUrl: new URL(API_URL),
+      identity: identity,
+    });
+    const charm = await cc.create(
+      await Deno.readTextFile(
+        join(
+          import.meta.dirname!,
+          "..",
+          "ct-render.tsx",
+        ),
+      ),
+    );
+    charmId = charm.id;
+  });
+
+  afterAll(async () => {
+    if (cc) await cc.dispose();
+  });
+
+  it("should load the nested counter charm and verify initial state", async () => {
+    const page = shell.page();
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      spaceName: SPACE_NAME,
+      charmId,
+      identity,
+    });
+
+    const counterResult = await page.waitForSelector("#counter-result", {
+      strategy: "pierce",
+    });
+    assert(counterResult, "Should find counter-result element");
+
+    // Verify initial value is 0
+    const initialText = await counterResult.evaluate((el: HTMLElement) =>
+      el.textContent
+    );
+    assertEquals(initialText?.trim(), "Counter is the 0th number");
+
+    // Verify via direct operations that the ct-render structure works
+    const value = await getCharmResult(cc!.manager(), charmId, ["value"]);
+    assertEquals(value, 0);
+  });
+
+  it("should click the increment button and update the counter", async () => {
+    const page = shell.page();
+
+    // Find all buttons and click the increment button (second button)
+    const buttons = await page.$$("[data-ct-button]", {
+      strategy: "pierce",
+    });
+    assert(buttons.length >= 2, "Should find at least 2 buttons");
+    
+    // Click increment button (second button - first is decrement)
+    await buttons[1].click();
+
+    await sleep(1000);
+
+    const counterResult = await page.$("#counter-result", {
+      strategy: "pierce",
+    });
+    assert(counterResult, "Should find counter-result element");
+    const counterText = await counterResult.evaluate((el: HTMLElement) =>
+      el.textContent
+    );
+    assertEquals(counterText?.trim(), "Counter is the 1st number");
+
+    // Verify via direct operations
+    const value = await getCharmResult(cc!.manager(), charmId, ["value"]);
+    assertEquals(value, 1);
+  });
+
+  it("should update counter value via direct operations and verify UI", async () => {
+    const page = shell.page();
+    const manager = cc!.manager();
+
+    // Set value to 5 via direct operation
+    await setCharmResult(manager, charmId, ["value"], 5);
+
+    // Verify we can read the value back via operations
+    const updatedValue = await getCharmResult(manager, charmId, ["value"]);
+    assertEquals(updatedValue, 5, "Value should be 5 in backend");
+
+    // Navigate to the charm to see if UI reflects the change
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      spaceName: SPACE_NAME,
+      charmId,
+      identity,
+    });
+
+    // Check if the UI shows the updated value
+    const counterResult = await page.waitForSelector("#counter-result", {
+      strategy: "pierce",
+    });
+    const textAfterUpdate = await counterResult.evaluate((el: HTMLElement) =>
+      el.textContent
+    );
+    assertEquals(
+      textAfterUpdate?.trim(),
+      "Counter is the 5th number",
+      "UI should show updated value from direct operation",
+    );
+  });
+
+  it("should verify ct-render has only ONE counter display", async () => {
+    const page = shell.page();
+
+    // Find all counter result elements (should be 1 for ct-render, not 2 like nested-counter)
+    const counterResults = await page.$$("#counter-result", {
+      strategy: "pierce",
+    });
+    assertEquals(counterResults.length, 1, "Should find exactly 1 counter-result element in ct-render");
+
+    // Verify it shows the correct value
+    const counter = counterResults[0];
+    const text = await counter.evaluate((el: HTMLElement) => el.textContent);
+    assertEquals(text?.trim(), "Counter is the 5th number", "Single counter should show correct value");
+  });
+});


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds the ct-render pattern to render a sub-recipe instance via JSX and keep its Cell-backed state in sync with the parent. Addresses CT-788 by enabling a declared recipe sub-instance to be displayed with a single, synced UI.

- New Features
  - Introduce <ct-render $cell={...} /> to mount a recipe instance.
  - Add Counter recipe with increment/decrement handlers and nth formatting via <cts-enable />.
  - Share state via Cell between parent and child.
  - Integration test verifies initial state, UI increment, backend-driven updates, and single counter display.

<!-- End of auto-generated description by cubic. -->

