### PR TITLE
Fix schema generated by a handler to handle definitions properly

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -147,20 +147,20 @@ export type JSONSchemaTypes =
 // That will require reworking some things, so for now, I'm not doing it
 export type JSONSchema = {
   readonly $ref?: string;
-  readonly $defs?: Readonly<Record<string, JSONSchema>>;
+  readonly $defs?: Readonly<Record<string, JSONSchema | boolean>>;
   /** @deprecated Use `$defs` for 2019-09/Draft 8 or later */
   readonly definitions?: Readonly<Record<string, JSONSchema | boolean>>;
 
   // Subschema logic
   readonly allOf?: readonly (JSONSchema | boolean)[]; // not validated
-  readonly anyOf?: readonly JSONSchema[]; // not always validated
+  readonly anyOf?: readonly (JSONSchema | boolean)[]; // not always validated
   readonly oneOf?: readonly (JSONSchema | boolean)[]; // not validated
   readonly not?: JSONSchema | boolean;
   // Subschema conditionally - none applied
   readonly if?: JSONSchema | boolean;
   readonly then?: JSONSchema | boolean;
   readonly else?: JSONSchema | boolean;
-  readonly dependentSchemas?: Readonly<Record<string, JSONSchema>>;
+  readonly dependentSchemas?: Readonly<Record<string, JSONSchema | boolean>>;
   // Subschema for array
   readonly prefixItems?: (JSONSchema | boolean)[]; // not validated
   readonly items?: Readonly<JSONSchema>;

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -21,6 +21,7 @@ import {
 import { moduleToJSON } from "./json-utils.ts";
 import { traverseValue } from "./traverse-utils.ts";
 import { getTopFrame } from "./recipe.ts";
+import { generateHandlerSchema } from "../schema.ts";
 
 export function createNodeFactory<T = any, R = any>(
   moduleSpec: Module,
@@ -136,15 +137,10 @@ export function handler<E, T>(
     }
   }
 
-  const schema: JSONSchema | undefined = eventSchema || stateSchema
-    ? {
-      type: "object",
-      properties: {
-        $event: eventSchema ?? {},
-        $ctx: (stateSchema ?? {}) as JSONSchema,
-      },
-    }
-    : undefined;
+  const schema = generateHandlerSchema(
+    eventSchema,
+    stateSchema as JSONSchema | undefined,
+  );
 
   const module: Handler<T, E> & toJSON & {
     bind: (inputs: Opaque<StripCell<T>>) => OpaqueRef<E>;

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -65,17 +65,17 @@ export interface IDFields {
 export type JSONSchemaTypes = "object" | "array" | "string" | "integer" | "number" | "boolean" | "null";
 export type JSONSchema = {
     readonly $ref?: string;
-    readonly $defs?: Readonly<Record<string, JSONSchema>>;
+    readonly $defs?: Readonly<Record<string, JSONSchema | boolean>>;
     /** @deprecated Use `$defs` for 2019-09/Draft 8 or later */
     readonly definitions?: Readonly<Record<string, JSONSchema | boolean>>;
     readonly allOf?: readonly (JSONSchema | boolean)[];
-    readonly anyOf?: readonly JSONSchema[];
+    readonly anyOf?: readonly (JSONSchema | boolean)[];
     readonly oneOf?: readonly (JSONSchema | boolean)[];
     readonly not?: JSONSchema | boolean;
     readonly if?: JSONSchema | boolean;
     readonly then?: JSONSchema | boolean;
     readonly else?: JSONSchema | boolean;
-    readonly dependentSchemas?: Readonly<Record<string, JSONSchema>>;
+    readonly dependentSchemas?: Readonly<Record<string, JSONSchema | boolean>>;
     readonly prefixItems?: (JSONSchema | boolean)[];
     readonly items?: Readonly<JSONSchema>;
     readonly contains?: JSONSchema | boolean;


### PR DESCRIPTION
- Since the event and state were nested, the links to the top level definitions failed to resolve. Instead, extract $defs and definitions entries from either, and include them in the combined schema.
- Enabled boolean JSONSchema in a couple more places