### PR TITLE
chore: Make LLM/HTTP side effects in pattern integration tests opt-in to support other surfaces running these tests

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -389,7 +389,7 @@ jobs:
           HEADLESS=1 \
           API_URL=http://localhost:8000/ \
           FRONTEND_URL=http://localhost:8000/ \
-          deno task integration:ci
+          deno task integration
 
       - name: 🧪 Run end-to-end shell integration tests
         working-directory: packages/shell

--- a/packages/patterns/deno.json
+++ b/packages/patterns/deno.json
@@ -2,7 +2,7 @@
   "name": "@commontools/patterns",
   "tasks": {
     "integration": "deno test --trace-leaks -A ./integration/*.test.ts",
-    "integration:ci": "CI=1 deno test --trace-leaks -A ./integration/*.test.ts",
+    "integration:all": "TEST_HTTP=1 TEST_LLM=1 deno test --trace-leaks -A ./integration/*.test.ts",
     "test": "echo 'No tests defined.'"
   },
   "exports": {

--- a/packages/patterns/integration/fetch-data.test.ts
+++ b/packages/patterns/integration/fetch-data.test.ts
@@ -7,9 +7,10 @@ import { join } from "@std/path";
 import { assert, assertEquals } from "@std/assert";
 import { getCharmInput, setCharmInput } from "@commontools/charm/ops";
 import { Identity } from "@commontools/identity";
+import { TEST_HTTP } from "./flags.ts";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
-const ignore = ["1", "true"].includes(Deno.env.get("CI") || ""); // Skip in CI
+const ignore = !TEST_HTTP;
 
 // Fetch data tests may require network access and are skipped in CI until we handle external dependencies properly in CI environments.
 // This requires either:

--- a/packages/patterns/integration/flags.ts
+++ b/packages/patterns/integration/flags.ts
@@ -1,0 +1,6 @@
+const enabled = ["1", "true", "yes"];
+
+// Binds tests that require LLM configurations.
+export const TEST_LLM = enabled.includes(Deno.env.get("TEST_LLM") ?? "");
+// Binds tests that are dependent on making external HTTP requests.
+export const TEST_HTTP = enabled.includes(Deno.env.get("TEST_HTTP") ?? "");

--- a/packages/patterns/integration/llm.test.ts
+++ b/packages/patterns/integration/llm.test.ts
@@ -6,9 +6,10 @@ import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commontools/identity";
+import { TEST_LLM } from "./flags.ts";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
-const ignore = ["1", "true"].includes(Deno.env.get("CI") || ""); // Skip in CI
+const ignore = !TEST_LLM;
 
 // LLM tests are skipped in CI until we handle llm() calls properly in CI environments.
 // This requires either:


### PR DESCRIPTION
The LLM tests still seems to be leaking, but no longer leaking when disabled