### PR TITLE
Capture stdout when running patterns via ansible script

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -402,11 +402,8 @@ jobs:
   deploy-toolshed:
     name: "Deploy to Toolshed (Staging)"
     if: github.ref == 'refs/heads/main'
-    needs: [
-      "integration-test",
-      "cli-integration-test",
-      "shell-integration-test",
-    ]
+    needs:
+      ["integration-test", "cli-integration-test", "shell-integration-test"]
     runs-on: ubuntu-latest
     environment: toolshed
     steps:
@@ -462,4 +459,5 @@ jobs:
           host: ${{ secrets.BASTION_HOST }}
           username: bastion
           key: ${{ secrets.BASTION_SSH_PRIVATE_KEY }}
+          capture_stdout: true
           script: /opt/ct/run-pattern-tests-against-toolshed.sh ${{ github.sha }} https://toolshed.saga-castor.ts.net https://toolshed.saga-castor.ts.net


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Capture stdout from the remote pattern test script in the Toolshed deploy job so CI logs show the script output and failures are easier to debug.

- **New Features**
  - Enabled capture_stdout on the SSH step to surface remote script output in GitHub Actions logs.

- **Refactors**
  - Inlined the needs array formatting with no behavior changes.

<!-- End of auto-generated description by cubic. -->

