### PR TITLE
Added an existsInHistory flag to ConflictError

### DIFF
--- a/packages/memory/error.ts
+++ b/packages/memory/error.ts
@@ -56,6 +56,10 @@ export class TheConflictError extends Error implements ConflictError {
         }`
         : conflict.actual == null
         ? `The ${conflict.the} of ${conflict.of} in ${conflict.space} was expected to be ${conflict.expected}, but it does not exist`
+        : conflict.existsInHistory
+        ? `The ${conflict.the} of ${conflict.of} in ${conflict.space} was expected to be ${conflict.expected}, but now it is ${
+          refer(actual)
+        }`
         : `The ${conflict.the} of ${conflict.of} in ${conflict.space} was expected to be ${conflict.expected}, but it is ${
           refer(actual)
         }`,

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -905,6 +905,11 @@ export type Conflict = {
   actual: Revision<Fact> | null;
 
   /**
+   * Whether the fact exists in the history of the entity.
+   */
+  existsInHistory: boolean;
+
+  /**
    * Actual history
    */
   history: Revision<Fact>[];

--- a/packages/memory/test/consumer-test.ts
+++ b/packages/memory/test/consumer-test.ts
@@ -173,6 +173,7 @@ test("create memory fails if already exists", store, async (session) => {
     the,
     of: doc,
     expected: null,
+    existsInHistory: false,
     actual: { ...v1, since: 0 },
   });
 });

--- a/packages/memory/test/memory-test.ts
+++ b/packages/memory/test/memory-test.ts
@@ -148,6 +148,7 @@ test("create memory fails if already exists", memory, async (session) => {
     the,
     of: doc,
     expected: null,
+    existsInHistory: false,
     actual: { ...v1, since: 0 },
   });
 });

--- a/packages/memory/test/space-test.ts
+++ b/packages/memory/test/space-test.ts
@@ -347,6 +347,7 @@ test("fails updating non-existing memory", DB, async (session) => {
     the,
     of: doc,
     expected: refer(v1),
+    existsInHistory: false,
     actual: null,
   });
 });
@@ -382,6 +383,7 @@ test("create memory fails if already exists", DB, async (session) => {
     the,
     of: doc,
     expected: null,
+    existsInHistory: false,
     actual: { ...v1, since: 0 },
   });
 });
@@ -419,6 +421,7 @@ test("update does not confuse the/of", DB, async (session) => {
     the,
     of: malformed.of,
     expected: refer(initial),
+    existsInHistory: false,
     actual: null,
   });
 });
@@ -473,6 +476,7 @@ test("concurrent update fails", DB, async (session) => {
     the,
     of: doc,
     expected: refer(v1),
+    existsInHistory: false,
     actual: { ...v2, since: 1 },
   });
 });
@@ -748,6 +752,7 @@ test(
       the,
       of: doc,
       expected: refer(v2),
+      existsInHistory: false,
       actual: { ...v3, since: 2 },
     });
 
@@ -819,6 +824,7 @@ test(
       the,
       of: doc,
       expected: null,
+      existsInHistory: false,
       actual: { ...v2, since: 1 },
     });
   },
@@ -990,6 +996,7 @@ test("batch updates", DB, async (session) => {
     the,
     of: hi,
     expected: refer(hi1),
+    existsInHistory: true,
     actual: { ...hi2, since: 1 },
   });
 

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -1096,8 +1096,14 @@ export class Replica {
           fact.cause.toString(),
         );
       }
-
-      logger.error(() => ["Transaction failed", result.error]);
+      if (
+        result.error.name === "ConflictError" &&
+        result.error.conflict.existsInHistory
+      ) {
+        logger.info(() => ["Transaction failed (aready exists)", result.error]);
+      } else {
+        logger.error(() => ["Transaction failed", result.error]);
+      }
 
       // Checkout current state of facts so we can compute
       // changes after we update underlying stores.


### PR DESCRIPTION
When a conflicting fact already exists in the history, this can generally be ignored, so downgrade this to an info level log.