### PR TITLE
Revert "Capture stdout when running patterns via ansible script"

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -402,8 +402,11 @@ jobs:
   deploy-toolshed:
     name: "Deploy to Toolshed (Staging)"
     if: github.ref == 'refs/heads/main'
-    needs:
-      ["integration-test", "cli-integration-test", "shell-integration-test"]
+    needs: [
+      "integration-test",
+      "cli-integration-test",
+      "shell-integration-test",
+    ]
     runs-on: ubuntu-latest
     environment: toolshed
     steps:
@@ -459,5 +462,4 @@ jobs:
           host: ${{ secrets.BASTION_HOST }}
           username: bastion
           key: ${{ secrets.BASTION_SSH_PRIVATE_KEY }}
-          capture_stdout: true
           script: /opt/ct/run-pattern-tests-against-toolshed.sh ${{ github.sha }} https://toolshed.saga-castor.ts.net https://toolshed.saga-castor.ts.net


### PR DESCRIPTION
Reverts commontoolsinc/labs#1669

This didn't help, but did reveal the output is being truncated: https://github.com/commontoolsinc/labs/actions/runs/17138879034/job/48622157261