### PR TITLE
Changes to match the semantics of IAttestation

### DIFF
--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -241,6 +241,8 @@ export const selectSchema = <Space extends MemorySpace>(
   return includedFacts;
 };
 
+// The fact passed in is the IAttestation for the top level 'is', so path
+// is empty.
 function loadFactsForDoc(
   manager: ServerObjectManager,
   fact: IAttestation,
@@ -250,10 +252,13 @@ function loadFactsForDoc(
 ) {
   if (isObject(fact.value)) {
     if (selector.schemaContext !== undefined) {
-      const factValue = (fact.value as Immutable<JSONObject>).value;
+      const factValue: IAttestation = {
+        address: { ...fact.address, path: [...fact.address.path, "value"] },
+        value: (fact.value as Immutable<JSONObject>).value,
+      };
       const [newDoc, newSelector] = getAtPath(
         manager,
-        { address: fact.address, value: factValue, rootValue: factValue },
+        factValue,
         selector.path,
         tracker,
         schemaTracker,

--- a/packages/runner/src/storage/query.ts
+++ b/packages/runner/src/storage/query.ts
@@ -179,7 +179,6 @@ export function querySchema(
     {
       address: { ...address, path: [] },
       value: factValue,
-      rootValue: factValue,
     },
     address.path,
     tracker,

--- a/packages/runner/test/query.test.ts
+++ b/packages/runner/test/query.test.ts
@@ -122,9 +122,8 @@ describe("Query", () => {
     );
     // We've provided a schema context for this, so traverse it
     traverser.traverse({
-      address: { id: assert2.of, type: assert2.the, path: [] },
+      address: { id: assert2.of, type: assert2.the, path: ["value"] },
       value: assert2.is.value,
-      rootValue: assert2.is.value,
     });
     const selectorSet1 = schemaTracker.get(
       `of:${entityId1["/"]}/application/json`,
@@ -209,9 +208,8 @@ describe("Query", () => {
     );
     // We've provided a schema context for this, so traverse it
     traverser.traverse({
-      address: { id: assert2.of, type: assert2.the, path: [] },
+      address: { id: assert2.of, type: assert2.the, path: ["value"] },
       value: assert2.is.value,
-      rootValue: assert2.is.value,
     });
     const selectorSet1 = schemaTracker.get(
       `of:${entityId1["/"]}/application/json`,
@@ -289,9 +287,8 @@ describe("Query", () => {
     );
     // We've provided a schema context for this, so traverse it
     traverser.traverse({
-      address: { id: assert1.of, type: assert1.the, path: [] },
+      address: { id: assert1.of, type: assert1.the, path: ["value"] },
       value: assert1.is.value,
-      rootValue: assert1.is.value,
     });
     const selectorSet1 = schemaTracker.get(
       `of:${entityId1["/"]}/application/json`,
@@ -373,9 +370,8 @@ describe("Query", () => {
     );
     // We've provided a schema context for this, so traverse it
     traverser.traverse({
-      address: { id: assert2.of, type: assert2.the, path: [] },
+      address: { id: assert2.of, type: assert2.the, path: ["value"] },
       value: assert2.is.value,
-      rootValue: assert2.is.value,
     });
     const selectorSet1 = schemaTracker.get(
       `of:${entityId1["/"]}/application/json`,


### PR DESCRIPTION
- IAttestation address paths are relative to `is`, while my previous changes made them relative to `value` in the traverse code. This change makes it so they are always relative to `is`.
- Change how we compare IAttestation paths to selector paths (relative to value) and link paths (relative to value).
- Eliminate the ValueAtPath class, since we can just use the IAttestation.
- Added a notFound helper to traverse to construct the return result for when we don't have a matching doc or path, or encounter a cycle.
- Lots of comments describing the expectations around "value" in paths, since it's often unclear.