### PR TITLE
cli: intercept navigateto in call/render and print charm id (CT-825)

### DIFF
--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -85,14 +85,45 @@ async function makeSession(config: SpaceConfig): Promise<Session> {
 export async function loadManager(config: SpaceConfig): Promise<CharmManager> {
   const spaceName = parseSpace(config.space);
   const session = await makeSession(config);
+  // Use a const ref object so we can assign later while keeping const binding
+  const charmManagerRef: { current?: CharmManager } = {};
   const runtime = new Runtime({
     storageManager: StorageManager.open({
       as: session.as,
       address: new URL("/api/storage/memory", config.apiUrl),
     }),
     blobbyServerUrl: config.apiUrl,
+    navigateCallback: (target) => {
+      try {
+        const id = charmId(target);
+        if (!id) {
+          console.error("navigateTo: target missing charm id");
+          return;
+        }
+        // Emit greppable line immediately so scripts can capture without waiting
+        console.log(`navigateTo new charm id ${id}`);
+        // Best-effort: ensure charm is present in list
+        runtime.storage.synced().then(async () => {
+          try {
+            const mgr = charmManagerRef.current!;
+            const list = mgr.getCharms().get();
+            const exists = list.some((c) => charmId(c) === id);
+            if (!exists) {
+              await mgr.add([target]);
+            }
+          } catch (e) {
+            console.error("navigateTo add error:", e);
+          }
+        }).catch((_err) => {
+          // ignore; we already emitted the id
+        });
+      } catch (e) {
+        console.error("navigateTo callback error:", e);
+      }
+    },
   });
   const charmManager = new CharmManager(session, runtime);
+  charmManagerRef.current = charmManager;
   await charmManager.synced();
   return charmManager;
 }


### PR DESCRIPTION
Enables CLI flows where recipes call navigateTo by injecting a navigateCallback into the CLI runtime used by both ct charm call and ct charm render. The callback immediately prints a greppable line so scripts can capture the new charm id: `navigateTo new charm id <ID>`. It also best-effort adds the target charm to the charm list (mirroring shell behavior). This is backward-compatible and requires no recipe changes.