### PR TITLE
chore: Wait for page to update url rather than wait in instantiate recipe integration

### DIFF
--- a/packages/patterns/integration/instantiate-recipe.test.ts
+++ b/packages/patterns/integration/instantiate-recipe.test.ts
@@ -72,10 +72,11 @@ describe("instantiate-recipe integration test", () => {
 
     await button.click();
 
-    // Reduced wait for navigation (was 2000ms)
-    await sleep(400);
+    // Wait for page to soft navigate
+    await page.waitForFunction((urlBefore) => {
+      return globalThis.location.href !== urlBefore;
+    }, { args: [urlBefore] });
 
-    // Check if we navigated to a new counter instance
     const urlAfter = await page.evaluate(() => globalThis.location.href);
     console.log("URL after clicking:", urlAfter);
 
@@ -93,7 +94,5 @@ describe("instantiate-recipe integration test", () => {
       counterResult,
       "Should find counter-result element after navigation",
     );
-
-    await sleep(200);
   });
 });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Replaced fixed sleeps in the instantiate-recipe integration test with an explicit wait for soft navigation (URL change). This reduces CI flakiness and makes the test deterministic.

- **Bug Fixes**
  - Wait for location.href to change via page.waitForFunction and remove extra delays.

<!-- End of auto-generated description by cubic. -->

