### PR TITLE
chore: Fix some CI race conditions by waiting for expected state

### DIFF
--- a/packages/patterns/integration/counter.test.ts
+++ b/packages/patterns/integration/counter.test.ts
@@ -1,5 +1,5 @@
 import { env } from "@commontools/integration";
-import { sleep } from "@commontools/utils/sleep";
+import { waitFor } from "@commontools/utils/sleep";
 import { CharmsController } from "@commontools/charm/ops";
 import { ShellIntegration } from "@commontools/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
@@ -77,22 +77,17 @@ describe("counter direct operations test", () => {
     console.log("Setting counter value to 42 via direct operation");
     await setCharmResult(manager, charmId, ["value"], 42);
 
-    // Wait for the update to propagate
-    await sleep(1000);
-
-    // Verify the UI updated
-    const updatedText = await counterResult.evaluate((el: HTMLElement) =>
-      el.textContent
-    );
-    assertEquals(
-      updatedText?.trim(),
-      "Counter is the 42th number",
-      "UI should update to show 42th",
-    );
+    await waitFor(async () => {
+      const updatedText = await counterResult.evaluate((el: HTMLElement) =>
+        el.textContent
+      );
+      return updatedText?.trim() === "Counter is the 42th number";
+    });
 
     // Verify we can also read the value back
-    const finalValue = await getCharmResult(manager, charmId, ["value"]);
-    assertEquals(finalValue, 42);
+    await waitFor(async () =>
+      (await getCharmResult(manager, charmId, ["value"])) === 42
+    );
   });
 
   it("should update counter value and verify after page refresh", async () => {

--- a/packages/patterns/integration/ct-render.test.ts
+++ b/packages/patterns/integration/ct-render.test.ts
@@ -1,5 +1,5 @@
 import { env } from "@commontools/integration";
-import { sleep } from "@commontools/utils/sleep";
+import { sleep, waitFor } from "@commontools/utils/sleep";
 import { CharmsController } from "@commontools/charm/ops";
 import { ShellIntegration } from "@commontools/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
@@ -121,17 +121,16 @@ describe("ct-render integration test", () => {
   it("should verify only ONE counter display", async () => {
     const page = shell.page();
 
-    await sleep(500);
-
-    // Find all counter result elements (should be 1 for ct-render, not 2 like nested-counter)
+    await waitFor(async () => {
+      // Find all counter result elements (should be 1 for ct-render, not 2 like nested-counter)
+      const counterResults = await page.$$("#counter-result", {
+        strategy: "pierce",
+      });
+      return counterResults.length === 3;
+    });
     const counterResults = await page.$$("#counter-result", {
       strategy: "pierce",
     });
-    assertEquals(
-      counterResults.length,
-      3,
-      "Should find exactly 3 counter-result elements",
-    );
 
     // Verify it shows the correct value
     const counter = counterResults[0];

--- a/packages/utils/src/sleep.ts
+++ b/packages/utils/src/sleep.ts
@@ -5,3 +5,31 @@
  */
 export const sleep = (timeout: number) =>
   new Promise((resolve) => setTimeout(resolve, timeout));
+
+/**
+ * Receives an async predicate function to executed repeatedly
+ * until either the predicate returns `true`, or throws once
+ * the timeout limit has been reached.
+ *
+ * @param predicate - The predicate callback.
+ * @param config.timeout - The number of milliseconds to wait before throwing. [60000]
+ * @param config.delay - The number of milliseconds to wait between predicate calls. [500]
+ */
+export const waitFor = async (
+  predicate: () => Promise<boolean>,
+  { timeout: _timeout, delay: _delay }: { timeout?: number; delay?: number } =
+    {},
+): Promise<void> => {
+  const timeout = _timeout ?? 60_000;
+  const delay = _delay ?? 500;
+  const end = Date.now() + timeout;
+  while (Date.now() < end) {
+    if ((await predicate())) {
+      return;
+    }
+    await sleep(delay);
+  }
+  throw new Error(
+    `Timeout: waitFor predicate could not complete after ${timeout}ms.`,
+  );
+};


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Introduce a waitFor utility and update integration tests to wait for expected UI/state instead of fixed delays. This reduces CI flakiness by removing race conditions.

- **New Features**
  - Added waitFor(predicate, { timeout, delay }) with 60s default timeout and 500ms polling.

- **Bug Fixes**
  - Replaced sleep() with waitFor() across counter, ct-render, and nested-counter tests.
  - Used state/selector waits (e.g., waitForSelector, charm value checks) before assertions to ensure stability.

<!-- End of auto-generated description by cubic. -->

