### PR TITLE
Use env to set log level

### DIFF
--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -123,7 +123,7 @@ export interface SyncStore<Model, Address>
   extends SyncPull<Model, Address>, SyncPush<Model> {
 }
 
-const logger = getLogger("storage.cache", { level: "info", enabled: true });
+const logger = getLogger("storage.cache");
 
 interface NotFoundError extends Error {
   name: "NotFound";
@@ -1102,7 +1102,7 @@ export class Replica {
       ) {
         logger.info(() => ["Transaction failed (aready exists)", result.error]);
       } else {
-        logger.error(() => ["Transaction failed", result.error]);
+        logger.warn(() => ["Transaction failed", result.error]);
       }
 
       // Checkout current state of facts so we can compute

--- a/packages/shell/deno.json
+++ b/packages/shell/deno.json
@@ -6,7 +6,7 @@
     "serve": "deno run -A ../felt/cli.ts serve .",
     "dev": "API_URL=https://toolshed.saga-castor.ts.net deno run -A ../felt/cli.ts dev .",
     "dev-local": "API_URL=http://localhost:8000 deno run -A ../felt/cli.ts dev .",
-    "integration": "deno test -A ./integration/*.test.ts",
+    "integration": "LOG_LEVEL=warn deno test -A ./integration/*.test.ts",
     "test": "deno test test/*.test.ts"
   },
   "exports": "./src/index.ts",

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -160,7 +160,7 @@ export class Logger {
     this._disabled = options?.enabled === undefined ? false : !options.enabled;
 
     // Set logger-specific level if provided
-    this.level = options?.level;
+    this.level = options?.level ?? getEnvLevel();
   }
 
   /**
@@ -256,17 +256,20 @@ export class Logger {
 export const log = new Logger();
 
 /**
- * Initialize log level from environment variable if available
+ * We may want to initialize log level from environment variable if available
  */
-if (isDeno()) {
-  try {
-    const envLevel = Deno.env.get("LOG_LEVEL");
-    if (envLevel && envLevel in LOG_LEVELS) {
-      log.level = envLevel as LogLevel;
+function getEnvLevel() {
+  if (isDeno()) {
+    try {
+      const envLevel = Deno.env.get("LOG_LEVEL");
+      if (envLevel && envLevel in LOG_LEVELS) {
+        return envLevel as LogLevel;
+      }
+    } catch {
+      // Ignore permission errors - use default log level
     }
-  } catch {
-    // Ignore permission errors - use default log level
   }
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
- When creating a logger, if no level threshold is passed in the options, check the env
- In cache.ts, don't specify a level threshold (so we default to env). Also downgrade the bad ConflictError to `warn`, since things still work.
- In deno.json for shell, set the LOG_LEVEL to `warn`, so that `info` messages won't be logged