### PR TITLE
chore: Disable log checker in integration

### DIFF
--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -172,9 +172,10 @@ export class ShellIntegration {
     if (this.#exceptions.length > 0) {
       throw new Error(`Exceptions recorded: \n${this.#exceptions.join("\n")}`);
     }
-    if (this.#errorLogs.length > 0) {
-      throw new Error(`Errors logged: \n${this.#errorLogs.join("\n")}`);
-    }
+    // TODO(CT-840)
+    // if (this.#errorLogs.length > 0) {
+    //  throw new Error(`Errors logged: \n${this.#errorLogs.join("\n")}`);
+    // }
   };
 
   #afterAll = async () => {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Temporarily disable the error log assertion in ShellIntegration to prevent flaky integration test failures while we address CT-840. Exceptions are still enforced; only log-based failures are skipped.

<!-- End of auto-generated description by cubic. -->

