### PR TITLE
AST: add descriptions to schema from JSDoc comments as per CT-667

### DIFF
--- a/ast-add-descriptions-to-schema.txt
+++ b/ast-add-descriptions-to-schema.txt
@@ -1,0 +1,136 @@
+Task: AST - Add descriptions to JSON Schema from JSDoc
+
+Objective
+- Populate JSON Schema `description` fields from TypeScript JSDoc comments on types and properties during schema generation (toSchema<T>(), handler, recipe).
+- Preserve explicit descriptions passed via options (they take precedence at the root).
+- Add careful handling for composition (intersections, extends, aliases), nested shapes, arrays, and edge cases.
+
+Comprehensive cases/considerations
+1) Root type descriptions
+   - interface Foo { ... }
+   - type Foo = { ... }
+   - Explicit options precedence: toSchema<Foo>({ description }) overrides root JSDoc
+   - Re-export/alias: type Foo = Bar; JSDoc may be on Bar
+2) Property descriptions
+   - Primitive properties with JSDoc
+   - Optional properties and union with undefined
+   - Wrappers: Cell<T>, Stream<T>, Default<T,V>
+   - Multi-line JSDoc; preserve newlines
+3) Nested shapes
+   - Nested object properties
+   - Arrays of objects (element object’s properties with JSDoc)
+   - Deeper nesting (array of objects containing arrays of objects)
+4) Type composition
+   - Intersections of object types with overlapping property names
+     - Same descriptions → keep one
+     - Conflicting descriptions → choose first non-empty, log warning, add $comment
+   - interface A extends B (inherit docs on properties/root where applicable)
+   - Aliases/re-exports: type X = Y; docs may be on Y
+5) Union types (property-level)
+   - Union of literals with JSDoc on the property: description applies to the property schema
+   - Union of object branches: do not attempt per-branch description merge
+6) Index signatures and mapped types
+   - String/number index signatures with JSDoc → attach description to additionalProperties if feasible; otherwise $comment
+   - Record<string, T> equivalent handling
+7) Conflicting/ambiguous documentation
+   - Multiple declarations/augmentations with different JSDoc
+   - Prefer first non-empty; add $comment and warn
+8) Formatting/markdown
+   - Preserve markdown formatting inside JSDoc; no stripping/escaping
+9) Recursive types
+   - Ensure property descriptions appear consistently even when using $ref
+10) Non-object properties
+   - JSDoc on array property applies to array itself (not items)
+
+V1 coverage decisions
+- Include in V1 tests and implementation:
+  - Root doc (interface and type), with precedence of explicit options
+  - Property docs (primitive, optional) and coexistence with Cell/Stream/Default
+  - Nested object and array-of-objects (one level deep)
+  - Intersections with overlapping property names
+    - Same doc → keep one
+    - Different docs → pick first non-empty, add $comment and logger warning
+  - Extends-based inheritance for properties’ docs
+  - Index signature (string) with doc → attach to additionalProperties; if ambiguous, add $comment
+  - Record<string, T> mapping treated like index signature
+  - Preserve markdown and multiline text as-is
+- Defer to V2 (document, not implement):
+  - Deeply nested arrays-of-objects-of-objects
+  - Union of object branches with per-branch doc propagation
+  - Cross-file complex augmentations; ensure current warning path is sufficient
+
+Initial failing tests already added
+- Consolidated into a single pair: descriptions-all.input.ts / descriptions-all.expected.ts covering:
+  - Root and precedence
+  - Properties (primitive/optional/wrappers)
+  - Nested array-of-objects
+  - Intersections (same vs conflicting docs → $comment + warn)
+  - Extends
+  - Index signature and Record
+  - Tag trimming at root
+
+Additional failing tests to add per V1 decisions
+- (Folded into descriptions-all.* as separate sections within the single file)
+
+Implementation plan (detailed)
+1) JSDoc extraction helpers (schema-generator.ts)
+   - create function extractDocFromSymbol(symbol, checker): string | undefined
+     - Use symbol.getDocumentationComment(checker) → ts.displayPartsToString()
+     - If empty, check first declaration’s JSDoc (when available) via declaration.symbol
+     - Normalize whitespace; trim; strip trailing/leading blank lines
+     - Remove lines that start with @ (tags), but preserve all other content; keep blank lines
+   - create function extractDocFromDeclarations(decls, checker): { text?: string; all: string[] }
+     - Collect unique non-empty doc strings from all declarations
+     - Return first non-empty as text and the list for conflict detection
+
+2) Root description (typeToJsonSchema)
+   - After computing rootSchema, attempt to obtain root type symbol (type.aliasSymbol || type.symbol || type.getSymbol?.()).
+   - Extract doc text; if present AND rootSchema has no description (it won’t), attach description.
+   - Precedence: schema.ts later merges options via { ...schema, ...optionsObj }, so an explicit description in options will override root description automatically (desired).
+
+3) Property descriptions (buildObjectSchema)
+   - For each property symbol:
+     - Extract doc across declarations: const { text, all } = extractDocFromDeclarations(prop.declarations ?? [], checker) falling back to extractDocFromSymbol(prop, checker).
+     - If text present: set properties[propName].description = text.
+     - If all contains >1 distinct non-empty strings: add properties[propName].$comment = "Consolidated property docs from intersection constituents" and logger.warn with short summary.
+
+4) Index signatures and mapped types (buildObjectSchema)
+   - Before/after building named properties, check:
+     - const stringIndex = checker.getIndexTypeOfType(type, IndexKind.String);
+     - const numberIndex = checker.getIndexTypeOfType(type, IndexKind.Number);
+   - If present, compute additionalProperties schema via typeToJsonSchemaHelper on the index type.
+   - For index signature JSDoc:
+     - Try to read from the type node when available (for interfaces) by inspecting members for index signatures and their JSDoc; otherwise fallback to a symbol-level doc.
+     - If a doc string is found, attach it to additionalProperties.description (avoid nonstandard $comment to satisfy JSONSchema type and linter).
+
+5) Intersections (already merged in prior fix)
+   - Our intersection merge path remains: buildObjectSchema runs on the merged type.
+   - For properties present in multiple constituents, the property symbol typically has multiple declarations; conflict handling from step 3 appends a parenthetical note to the description (e.g., "(Consolidated from intersection constituents)") and logs a warning.
+
+6) Tag trimming and multi-line preservation
+   - While extracting text, filter out lines starting with '@'. Do not alter remaining text; preserve blank lines and markdown.
+
+7) Logging
+   - Use existing schema-transformer logger. Warn on:
+     - Consolidated conflicting property docs (intersection)
+     - Index signature doc found and attached to $comment
+     - Unexpected checker errors during JSDoc extraction (non-fatal)
+
+8) Testing cadence
+   - We already have a single failing consolidated fixture; implement features incrementally:
+     a) Root + property descriptions
+     b) Nested array-of-objects
+     c) Extends
+     d) Intersections conflict note
+     e) Index signature / Record
+     f) Tag trimming on root
+   - Run full suite after each step; adjust only the descriptions-all pair.
+
+9) Safety and non-regression
+   - Only attach description/$comment when we have non-empty doc text.
+   - Do not modify schemas for types without JSDoc; existing tests without comments remain unchanged.
+   - For index signatures: only add additionalProperties when the type actually has an index signature (using checker API), matching TS semantics.
+
+Assumption corrections and notes
+- Ignore declaration-file docs: We now ignore JSDoc sourced from declaration files (e.g., lib.d.ts for built-ins like Map/Date) to avoid polluting schemas. Only user/project declarations contribute docs.
+- Intersection alias awareness (deferred here): Intersections expressed via named type aliases (e.g., `type AB = A & B`) require unwrapping the alias to ensure the intersection merge path runs. This work is part of CT-762 and not included in this branch; intersection-specific assertions were removed from the consolidated fixture accordingly.

--- a/ast-add-descriptions-to-schema.txt
+++ b/ast-add-descriptions-to-schema.txt
@@ -158,12 +158,12 @@ Progress to date (V1)
     - `descriptions-tags-only.*`
 
 Review against plan: gaps and next steps
-- Gaps in test coverage (still to add for completeness):
-  - Wrappers coexistence: property docs where the property type is `Cell<T>`, `Stream<T>`, or `Default<T, V>` (verify docs still attach to the property schema and wrappers add metadata as expected).
-  - Optional properties and union with undefined: ensure property-level docs persist when optionality is expressed via `?` or `| undefined`.
-  - Root alias docs: `type Foo = Bar` where docs live on `Bar` (confirm root description is pulled when using `toSchema<Foo>()`).
-  - Recursive types with $ref: confirm descriptions appear consistently when properties are emitted via `$ref` definitions.
-  - Array property doc semantics: ensure JSDoc on an array-typed property applies to the array node itself (not items), which is the current intended behavior.
+- V1 gaps addressed:
+  - Wrappers coexistence verified (Cell ⇒ `asCell`, Stream ⇒ `asStream`, Default ⇒ `default`; property docs attached correctly).
+  - Optional and `| undefined` unions verified (required set correct; docs retained).
+  - Root alias docs verified (alias root `type X = Y` pulls doc from aliased type).
+  - Recursive types with `$ref` verified (docs appear inside definition schema; top-level uses `$ref`).
+  - Array property docs verified on array node (not items).
 
 - Implementation notes:
   - We removed use of non-standard `$comment` in emitted schemas in favor of descriptions and logger warnings, matching the JSONSchema type.
@@ -171,5 +171,5 @@ Review against plan: gaps and next steps
   - Logging is present for consolidated intersection docs; we do not emit extra schema fields for warnings.
 
 Proposed follow-ups (post-V1 hardening)
-- Add the missing focused fixtures listed above to close test gaps without re-introducing fixture proliferation (can be consolidated into a small number of additional sections if desired).
+- All V1 items are now covered by tests. Keep the focused fixtures for clarity while the consolidated stays green.
 - Consider a minimal doc conflict mode toggle in the future (e.g., strict/warn) if consumers want to customize consolidation behavior.

--- a/ast-add-descriptions-to-schema.txt
+++ b/ast-add-descriptions-to-schema.txt
@@ -134,3 +134,42 @@ Implementation plan (detailed)
 Assumption corrections and notes
 - Ignore declaration-file docs: We now ignore JSDoc sourced from declaration files (e.g., lib.d.ts for built-ins like Map/Date) to avoid polluting schemas. Only user/project declarations contribute docs.
 - Intersection alias awareness (deferred here): Intersections expressed via named type aliases (e.g., `type AB = A & B`) require unwrapping the alias to ensure the intersection merge path runs. This work is part of CT-762 and not included in this branch; intersection-specific assertions were removed from the consolidated fixture accordingly.
+
+Progress to date (V1)
+- Implemented JSDoc extraction and description attachment for:
+  - Root types (with explicit options precedence)
+  - Properties (including multiline preservation and tag trimming)
+  - Nested object and array-of-objects (one level)
+  - Intersections of object types with overlapping properties:
+    - Same doc preserved
+    - Conflicting docs: choose first non-empty, append "(Consolidated from intersection constituents)", and log a warning
+  - Extends-based inheritance: derived schemas include docs from base and derived members
+  - Index signatures and Record-like types: attach doc to additionalProperties.description
+  - Ignored JSDoc from declaration files (lib.d.ts) as planned
+
+- Tests
+  - Consolidated fixture `descriptions-all.*` now green and includes sections for: nested/root, precedence, intersections (same/conflicting), extends, index/record, and tags.
+  - Added focused fixtures to iterate and lock behavior:
+    - `descriptions-nested-only.*`
+    - `descriptions-precedence-only.*`
+    - `descriptions-intersection-only.*`
+    - `descriptions-extends-only.*`
+    - `descriptions-index-record-only.*`
+    - `descriptions-tags-only.*`
+
+Review against plan: gaps and next steps
+- Gaps in test coverage (still to add for completeness):
+  - Wrappers coexistence: property docs where the property type is `Cell<T>`, `Stream<T>`, or `Default<T, V>` (verify docs still attach to the property schema and wrappers add metadata as expected).
+  - Optional properties and union with undefined: ensure property-level docs persist when optionality is expressed via `?` or `| undefined`.
+  - Root alias docs: `type Foo = Bar` where docs live on `Bar` (confirm root description is pulled when using `toSchema<Foo>()`).
+  - Recursive types with $ref: confirm descriptions appear consistently when properties are emitted via `$ref` definitions.
+  - Array property doc semantics: ensure JSDoc on an array-typed property applies to the array node itself (not items), which is the current intended behavior.
+
+- Implementation notes:
+  - We removed use of non-standard `$comment` in emitted schemas in favor of descriptions and logger warnings, matching the JSONSchema type.
+  - Intersection alias awareness is exercised by `type AB = A & B` in tests and works end-to-end after upstream intersection fixes were merged.
+  - Logging is present for consolidated intersection docs; we do not emit extra schema fields for warnings.
+
+Proposed follow-ups (post-V1 hardening)
+- Add the missing focused fixtures listed above to close test gaps without re-introducing fixture proliferation (can be consolidated into a small number of additional sections if desired).
+- Consider a minimal doc conflict mode toggle in the future (e.g., strict/warn) if consumers want to customize consolidation behavior.

--- a/packages/js-runtime/test/fixtures/schema-transform/descriptions-all.expected.ts
+++ b/packages/js-runtime/test/fixtures/schema-transform/descriptions-all.expected.ts
@@ -1,5 +1,5 @@
 /// <cts-enable />
-import { JSONSchema } from "commontools";
+import { Cell, Stream, Default, JSONSchema } from "commontools";
 // 1) Nested: Child/Doc with property docs and root doc
 interface ChildNode {
     /** The main text content of the child node */
@@ -213,4 +213,124 @@ const schemaTags = {
     required: ["value"],
     description: "Summary line\n\nLonger details here."
 } as const satisfies JSONSchema;
-export { schemaDoc, schemaPrecedence, schemaDerived, schemaDict, schemaCounts, schemaTags };
+// 7) Wrappers on properties
+interface WrappedProps {
+    /** Titles in a cell */
+    titles: Cell<string[]>;
+    /** Count as stream */
+    count: Stream<number>;
+    /** Level with default */
+    level: Default<number, 3>;
+}
+const schemaWrapped = {
+    type: "object",
+    properties: {
+        titles: {
+            type: "array",
+            items: {
+                type: "string"
+            },
+            asCell: true,
+            description: "Titles in a cell"
+        },
+        count: {
+            type: "number",
+            asStream: true,
+            description: "Count as stream"
+        },
+        level: {
+            type: "number",
+            default: 3,
+            description: "Level with default"
+        }
+    },
+    required: ["titles", "count", "level"]
+} as const satisfies JSONSchema;
+// 8) Optional and undefined unions
+interface OptionalProps {
+    /** maybe label */
+    label?: string;
+    /** maybe flag */
+    flag: boolean | undefined;
+}
+const schemaOptional = {
+    type: "object",
+    properties: {
+        label: {
+            type: "string",
+            description: "maybe label"
+        },
+        flag: {
+            type: "boolean",
+            description: "maybe flag"
+        }
+    },
+    required: ["flag"]
+} as const satisfies JSONSchema;
+// 9) Root alias docs
+/** Root alias doc */
+interface BaseRoot {
+    /** id */
+    id: string;
+}
+type RootAlias = BaseRoot;
+const schemaRootAlias = {
+    type: "object",
+    properties: {
+        id: {
+            type: "string",
+            description: "id"
+        }
+    },
+    required: ["id"],
+    description: "Root alias doc"
+} as const satisfies JSONSchema;
+// 10) Recursive with $ref
+interface Tree {
+    /** node name */
+    name: string;
+    /** Child nodes */
+    children: Tree[];
+}
+const schemaTree = {
+    $ref: "#/definitions/Tree",
+    $schema: "http://json-schema.org/draft-07/schema#",
+    definitions: {
+        Tree: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string",
+                    description: "node name"
+                },
+                children: {
+                    type: "array",
+                    items: {
+                        $ref: "#/definitions/Tree"
+                    },
+                    description: "Child nodes"
+                }
+            },
+            required: ["name", "children"]
+        }
+    }
+} as const satisfies JSONSchema;
+// 11) Array property JSDoc applies to array, not items
+interface ArrayDocProps {
+    /** tags of the item */
+    tags: string[];
+}
+const schemaArrayDoc = {
+    type: "object",
+    properties: {
+        tags: {
+            type: "array",
+            items: {
+                type: "string"
+            },
+            description: "tags of the item"
+        }
+    },
+    required: ["tags"]
+} as const satisfies JSONSchema;
+export { schemaDoc, schemaPrecedence, schemaDerived, schemaDict, schemaCounts, schemaTags, schemaWrapped, schemaOptional, schemaRootAlias, schemaTree, schemaArrayDoc };

--- a/packages/js-runtime/test/fixtures/schema-transform/descriptions-all.expected.ts
+++ b/packages/js-runtime/test/fixtures/schema-transform/descriptions-all.expected.ts
@@ -1,5 +1,6 @@
 /// <cts-enable />
 import { JSONSchema } from "commontools";
+// 1) Nested: Child/Doc with property docs and root doc
 interface ChildNode {
     /** The main text content of the child node */
     body: string;
@@ -19,42 +20,6 @@ type Doc = {
     /** Version of document */
     version: number;
 };
-/** Root docstring to be overridden */
-interface HasDocs {
-    /** Name of item */
-    name: string;
-}
-/** Base type */
-interface Base {
-    /** Base id */
-    id: string;
-}
-/** Derived type */
-interface Derived extends Base {
-    /** Derived name */
-    name: string;
-}
-/** Map of values */
-interface Dict {
-    /** Description for arbitrary keys */
-    [key: string]: number;
-}
-/** Record of counts */
-type Counts = {
-    /** per-key count */
-    [k: string]: number;
-};
-/** Summary line
- *
- * Longer details here.
- * @deprecated Use NewType instead.
- * @example
- *   const x = 1;
- */
-interface WithTags {
-    /** A value */
-    value: number;
-}
 const schemaDoc = {
     type: "object",
     properties: {
@@ -108,6 +73,12 @@ const schemaDoc = {
     required: ["body", "children", "attachments", "version"],
     description: "Outliner document"
 } as const satisfies JSONSchema;
+// 2) Precedence: explicit description overrides root JSDoc
+/** Root docstring to be overridden */
+interface HasDocs {
+    /** Name of item */
+    name: string;
+}
 const schemaPrecedence = {
     type: "object",
     properties: {
@@ -119,35 +90,118 @@ const schemaPrecedence = {
     required: ["name"],
     description: "Explicit description"
 } as const satisfies JSONSchema;
+// 3) Intersections: same vs conflicting property docs
+interface A {
+    /** Name doc */
+    name: string;
+}
+interface B {
+    /** Name doc */
+    name: string;
+    /** Age */
+    age: number;
+}
+type AB = A & B;
+const schemaAB = {
+    type: "object",
+    properties: {
+        name: {
+            type: "string",
+            description: "Name doc"
+        },
+        age: {
+            type: "number",
+            description: "Age"
+        }
+    },
+    required: ["name", "age"]
+} as const satisfies JSONSchema;
+interface C {
+    /** First name doc */
+    name: string;
+}
+interface D {
+    /** Second name doc */
+    name: string;
+}
+type CD = C & D;
+const schemaCD = {
+    type: "object",
+    properties: {
+        name: {
+            type: "string",
+            description: "First name doc (Consolidated from intersection constituents)"
+        }
+    },
+    required: ["name"]
+} as const satisfies JSONSchema;
+// 4) Extends-based inheritance of docs
+/** Base type */
+interface Base {
+    /** Base id */
+    id: string;
+}
+/** Derived type */
+interface Derived extends Base {
+    /** Derived name */
+    name: string;
+}
 const schemaDerived = {
     type: "object",
     properties: {
-        id: {
-            type: "string",
-            description: "Base id"
-        },
         name: {
             type: "string",
             description: "Derived name"
+        },
+        id: {
+            type: "string",
+            description: "Base id"
         }
     },
-    required: ["id", "name"],
+    required: ["name", "id"],
     description: "Derived type"
 } as const satisfies JSONSchema;
+// 5) Index signature and Record-like
+/** Map of values */
+interface Dict {
+    /** Description for arbitrary keys */
+    [key: string]: number;
+}
 const schemaDict = {
     type: "object",
+    properties: {},
     additionalProperties: {
         type: "number",
         description: "Description for arbitrary keys"
-    }
+    },
+    description: "Map of values"
 } as const satisfies JSONSchema;
+/** Record of counts */
+type Counts = {
+    /** per-key count */
+    [k: string]: number;
+};
 const schemaCounts = {
     type: "object",
+    properties: {},
     additionalProperties: {
         type: "number",
         description: "per-key count"
-    }
+    },
+    description: "Record of counts"
 } as const satisfies JSONSchema;
+// 6) Root JSDoc with tags; property doc
+/** Summary line
+ *
+ * Longer details here.
+ * @deprecated Use NewType instead.
+ * @example
+ *   const x = 1;
+ */
+interface WithTags {
+    /** A value */
+    value: number;
+}
 const schemaTags = {
     type: "object",
     properties: {
@@ -160,5 +214,3 @@ const schemaTags = {
     description: "Summary line\n\nLonger details here."
 } as const satisfies JSONSchema;
 export { schemaDoc, schemaPrecedence, schemaDerived, schemaDict, schemaCounts, schemaTags };
-
-

--- a/packages/js-runtime/test/fixtures/schema-transform/descriptions-all.expected.ts
+++ b/packages/js-runtime/test/fixtures/schema-transform/descriptions-all.expected.ts
@@ -1,0 +1,164 @@
+/// <cts-enable />
+import { JSONSchema } from "commontools";
+interface ChildNode {
+    /** The main text content of the child node */
+    body: string;
+    /** Children of the child node */
+    children: any[];
+    /** Attachments associated with the child node */
+    attachments: any[];
+}
+/** Outliner document */
+type Doc = {
+    /** The main text content of the node */
+    body: string;
+    /** Child nodes of this node */
+    children: ChildNode[];
+    /** Attachments associated with this node */
+    attachments: any[];
+    /** Version of document */
+    version: number;
+};
+/** Root docstring to be overridden */
+interface HasDocs {
+    /** Name of item */
+    name: string;
+}
+/** Base type */
+interface Base {
+    /** Base id */
+    id: string;
+}
+/** Derived type */
+interface Derived extends Base {
+    /** Derived name */
+    name: string;
+}
+/** Map of values */
+interface Dict {
+    /** Description for arbitrary keys */
+    [key: string]: number;
+}
+/** Record of counts */
+type Counts = {
+    /** per-key count */
+    [k: string]: number;
+};
+/** Summary line
+ *
+ * Longer details here.
+ * @deprecated Use NewType instead.
+ * @example
+ *   const x = 1;
+ */
+interface WithTags {
+    /** A value */
+    value: number;
+}
+const schemaDoc = {
+    type: "object",
+    properties: {
+        body: {
+            type: "string",
+            description: "The main text content of the node"
+        },
+        children: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    body: {
+                        type: "string",
+                        description: "The main text content of the child node"
+                    },
+                    children: {
+                        type: "array",
+                        items: {
+                            type: "object",
+                            additionalProperties: true
+                        },
+                        description: "Children of the child node"
+                    },
+                    attachments: {
+                        type: "array",
+                        items: {
+                            type: "object",
+                            additionalProperties: true
+                        },
+                        description: "Attachments associated with the child node"
+                    }
+                },
+                required: ["body", "children", "attachments"]
+            },
+            description: "Child nodes of this node"
+        },
+        attachments: {
+            type: "array",
+            items: {
+                type: "object",
+                additionalProperties: true
+            },
+            description: "Attachments associated with this node"
+        },
+        version: {
+            type: "number",
+            description: "Version of document"
+        }
+    },
+    required: ["body", "children", "attachments", "version"],
+    description: "Outliner document"
+} as const satisfies JSONSchema;
+const schemaPrecedence = {
+    type: "object",
+    properties: {
+        name: {
+            type: "string",
+            description: "Name of item"
+        }
+    },
+    required: ["name"],
+    description: "Explicit description"
+} as const satisfies JSONSchema;
+const schemaDerived = {
+    type: "object",
+    properties: {
+        id: {
+            type: "string",
+            description: "Base id"
+        },
+        name: {
+            type: "string",
+            description: "Derived name"
+        }
+    },
+    required: ["id", "name"],
+    description: "Derived type"
+} as const satisfies JSONSchema;
+const schemaDict = {
+    type: "object",
+    additionalProperties: {
+        type: "number",
+        description: "Description for arbitrary keys"
+    }
+} as const satisfies JSONSchema;
+const schemaCounts = {
+    type: "object",
+    additionalProperties: {
+        type: "number",
+        description: "per-key count"
+    }
+} as const satisfies JSONSchema;
+const schemaTags = {
+    type: "object",
+    properties: {
+        value: {
+            type: "number",
+            description: "A value"
+        }
+    },
+    required: ["value"],
+    description: "Summary line\n\nLonger details here."
+} as const satisfies JSONSchema;
+export { schemaDoc, schemaPrecedence, schemaDerived, schemaDict, schemaCounts, schemaTags };
+
+

--- a/packages/js-runtime/test/fixtures/schema-transform/descriptions-all.input.ts
+++ b/packages/js-runtime/test/fixtures/schema-transform/descriptions-all.input.ts
@@ -33,7 +33,30 @@ interface HasDocs {
 }
 const schemaPrecedence = toSchema<HasDocs>({ description: "Explicit description" });
 
-// 3) Intersection tests (deferred to CT-762 branch with intersection support)
+// 3) Intersections: same vs conflicting property docs
+interface A {
+  /** Name doc */
+  name: string;
+}
+interface B {
+  /** Name doc */
+  name: string;
+  /** Age */
+  age: number;
+}
+type AB = A & B;
+const schemaAB = toSchema<AB>();
+
+interface C {
+  /** First name doc */
+  name: string;
+}
+interface D {
+  /** Second name doc */
+  name: string;
+}
+type CD = C & D;
+const schemaCD = toSchema<CD>();
 
 // 4) Extends-based inheritance of docs
 /** Base type */

--- a/packages/js-runtime/test/fixtures/schema-transform/descriptions-all.input.ts
+++ b/packages/js-runtime/test/fixtures/schema-transform/descriptions-all.input.ts
@@ -1,0 +1,82 @@
+/// <cts-enable />
+import { toSchema } from "commontools";
+
+// 1) Nested: Child/Doc with property docs and root doc
+interface ChildNode {
+  /** The main text content of the child node */
+  body: string;
+  /** Children of the child node */
+  children: any[];
+  /** Attachments associated with the child node */
+  attachments: any[];
+}
+
+/** Outliner document */
+type Doc = {
+  /** The main text content of the node */
+  body: string;
+  /** Child nodes of this node */
+  children: ChildNode[];
+  /** Attachments associated with this node */
+  attachments: any[];
+  /** Version of document */
+  version: number;
+};
+
+const schemaDoc = toSchema<Doc>();
+
+// 2) Precedence: explicit description overrides root JSDoc
+/** Root docstring to be overridden */
+interface HasDocs {
+  /** Name of item */
+  name: string;
+}
+const schemaPrecedence = toSchema<HasDocs>({ description: "Explicit description" });
+
+// 3) Intersection tests (deferred to CT-762 branch with intersection support)
+
+// 4) Extends-based inheritance of docs
+/** Base type */
+interface Base {
+  /** Base id */
+  id: string;
+}
+/** Derived type */
+interface Derived extends Base {
+  /** Derived name */
+  name: string;
+}
+const schemaDerived = toSchema<Derived>();
+
+// 5) Index signature and Record-like
+/** Map of values */
+interface Dict {
+  /** Description for arbitrary keys */
+  [key: string]: number;
+}
+const schemaDict = toSchema<Dict>();
+
+/** Record of counts */
+type Counts = {
+  /** per-key count */
+  [k: string]: number;
+};
+const schemaCounts = toSchema<Counts>();
+
+// 6) Root JSDoc with tags; property doc
+/** Summary line
+ *
+ * Longer details here.
+ * @deprecated Use NewType instead.
+ * @example
+ *   const x = 1;
+ */
+interface WithTags {
+  /** A value */
+  value: number;
+}
+const schemaTags = toSchema<WithTags>();
+
+export { schemaDoc, schemaPrecedence, schemaDerived, schemaDict, schemaCounts, schemaTags };
+
+

--- a/packages/js-runtime/test/fixtures/schema-transform/descriptions-all.input.ts
+++ b/packages/js-runtime/test/fixtures/schema-transform/descriptions-all.input.ts
@@ -1,5 +1,5 @@
 /// <cts-enable />
-import { toSchema } from "commontools";
+import { toSchema, Cell, Stream, Default } from "commontools";
 
 // 1) Nested: Child/Doc with property docs and root doc
 interface ChildNode {
@@ -100,6 +100,50 @@ interface WithTags {
 }
 const schemaTags = toSchema<WithTags>();
 
-export { schemaDoc, schemaPrecedence, schemaDerived, schemaDict, schemaCounts, schemaTags };
 
+// 7) Wrappers on properties
+interface WrappedProps {
+  /** Titles in a cell */
+  titles: Cell<string[]>;
+  /** Count as stream */
+  count: Stream<number>;
+  /** Level with default */
+  level: Default<number, 3>;
+}
+const schemaWrapped = toSchema<WrappedProps>();
 
+// 8) Optional and undefined unions
+interface OptionalProps {
+  /** maybe label */
+  label?: string;
+  /** maybe flag */
+  flag: boolean | undefined;
+}
+const schemaOptional = toSchema<OptionalProps>();
+
+// 9) Root alias docs
+/** Root alias doc */
+interface BaseRoot {
+  /** id */
+  id: string;
+}
+type RootAlias = BaseRoot;
+const schemaRootAlias = toSchema<RootAlias>();
+
+// 10) Recursive with $ref
+interface Tree {
+  /** node name */
+  name: string;
+  /** Child nodes */
+  children: Tree[];
+}
+const schemaTree = toSchema<Tree>();
+
+// 11) Array property JSDoc applies to array, not items
+interface ArrayDocProps {
+  /** tags of the item */
+  tags: string[];
+}
+const schemaArrayDoc = toSchema<ArrayDocProps>();
+
+export { schemaDoc, schemaPrecedence, schemaDerived, schemaDict, schemaCounts, schemaTags, schemaWrapped, schemaOptional, schemaRootAlias, schemaTree, schemaArrayDoc };

--- a/packages/js-runtime/typescript/transformer/schema-generator.ts
+++ b/packages/js-runtime/typescript/transformer/schema-generator.ts
@@ -41,18 +41,18 @@ function getSymbolDoc(
  */
 function getDeclDocs(decl: ts.Declaration): string[] {
   const docs: string[] = [];
-  // TODO: stronger typing when TS compiler API exposes JSDoc types properly
+  // TODO(@gideon): stronger typing when TS compiler API exposes JSDoc types properly
   const jsDocs = (decl as any).jsDoc as Array<ts.JSDoc> | undefined;
   if (jsDocs && jsDocs.length > 0) {
     for (const d of jsDocs) {
-      // TODO: stronger typing when TS compiler API exposes JSDoc comment types properly
+      // TODO(@gideon): stronger typing when TS compiler API exposes JSDoc comment types properly
       const comment = (d as any).comment;
       let text = "";
       if (typeof comment === "string") text = comment;
       else if (Array.isArray(comment)) {
         text = comment.map((
           c,
-        ) => (typeof c === "string" ? c : (c as any).text ?? "")).join(""); // TODO: stronger typing for JSDoc text nodes
+        ) => (typeof c === "string" ? c : (c as any).text ?? "")).join(""); // TODO(@gideon): stronger typing for JSDoc text nodes
       }
       if (text) {
         const lines = String(text).split(/\r?\n/).filter((l) =>
@@ -338,7 +338,9 @@ function buildObjectSchema(
             logger.warn(() =>
               `Consolidated docs for property '${propName}' from multiple declarations.`
             );
-          } catch (_e) {}
+          } catch (_e) {
+            // Swallow logging issues to remain safe
+          }
         } else {
           propSchema.description = text;
         }


### PR DESCRIPTION
Summary

  Implements JSDoc description extraction for the AST transformer's JSON Schema generation. When users add /** JSDoc comments */ to their TypeScript interfaces and properties, these
  descriptions now automatically appear in the generated JSON schemas.

  Key Features

  - Root type descriptions: /** Interface description */ → schema.description
  - Property descriptions: /** Property description */ → schema.properties[name].description
  - Tag filtering: Automatically removes JSDoc tags like @deprecated, @example
  - Precedence handling: Explicit toSchema({ description: "..." }) overrides JSDoc
  - Conflict resolution: Intersection types with conflicting docs get consolidated with warnings
  - Inheritance support: extends relationships preserve documentation from base types
  - Index signature support: JSDoc on [key: string]: T appears in additionalProperties
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds JSDoc-driven descriptions to generated JSON Schemas so docs appear on root types, properties, and index signatures. Implements CT-667 to make schemas self-documented while keeping existing behavior unchanged.

- **New Features**
  - Root and property JSDoc → schema.description; preserves markdown and newlines.
  - Index signatures and Record → additionalProperties.description.
  - Filters JSDoc tags (@deprecated, @example); ignores docs from declaration files (e.g., lib.d.ts).
  - Explicit toSchema({ description }) still overrides root JSDoc.
  - Intersections and extends: merge docs; on conflicts keep the first, append a consolidation note, and warn.
  - Array property docs attach to the array (not items); wrappers (Cell/Stream/Default) retain property docs.

<!-- End of auto-generated description by cubic. -->

