### PR TITLE
Fix memory route for subscribe to work on firefox

### DIFF
--- a/packages/toolshed/routes/storage/memory/memory.routes.ts
+++ b/packages/toolshed/routes/storage/memory/memory.routes.ts
@@ -339,7 +339,8 @@ export const subscribe = createRoute({
   tags,
   request: {
     headers: z.object({
-      connection: z.literal("Upgrade"),
+      // Connection header is a list of values that must include Upgrade
+      connection: z.string().regex(/(^|\s*,\s*)Upgrade(\s*,\s*|$)/),
       upgrade: z.literal("websocket"),
     }),
   },


### PR DESCRIPTION
Firefox sends `Connection: keep-alive, Upgrade` as the header, but the route was only matching `Upgrade` (which is what Chrome sends). This header is a list of options, so use a regex to check that it's one of the options in the list instead.