### PR TITLE
chore: Rename remaining uses of TOOLSHED_API_URL to API_URL

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -139,7 +139,7 @@ jobs:
           # Wrap in an if/else, we don't want the job to fail yet
           # until we can confidently expect passing results.
           if
-            TOOLSHED_API_URL=http://localhost:8000/ \
+            API_URL=http://localhost:8000/ \
             OPENAI_API_KEY=${{ secrets.CTTS_AI_LLM_OPENAI_API_KEY }} \
             deno task start --name ${{ env.target_sha }} $FLAGS ; then
             echo "All charms have been successfully verified!"

--- a/README.md
+++ b/README.md
@@ -121,5 +121,5 @@ If you are not actively making updates to the backend, you can also point to the
 backend running in the cloud, by running the following command:
 
 ```shell
-TOOLSHED_API_URL=https://toolshed.saga-castor.ts.net/ deno task dev
+API_URL=https://toolshed.saga-castor.ts.net/ deno task dev
 ```

--- a/docs/charm_exploration.ipynb
+++ b/docs/charm_exploration.ipynb
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "f7936edf-cc47-4f4e-a886-92faaedb3497",
    "metadata": {},
    "outputs": [
@@ -140,10 +140,10 @@
     "import { storage } from \"../runner/src/storage.ts\";\n",
     "\n",
     "// where our server is\n",
-    "const TOOLSHED_API_URL = \"https://toolshed.saga-castor.ts.net/\";\n",
+    "const API_URL = \"https://toolshed.saga-castor.ts.net/\";\n",
     "\n",
     "// `storage` is a singleton and you have to give it the server URL\n",
-    "storage.setRemoteStorage(new URL(TOOLSHED_API_URL));\n",
+    "storage.setRemoteStorage(new URL(API_URL));\n",
     "storage; // notice signer is undefined"
    ]
   },
@@ -482,7 +482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "0714bfaa-cc87-420e-b64d-bb90bb89db48",
    "metadata": {},
    "outputs": [
@@ -564,7 +564,7 @@
     "}\n",
     "\n",
     "// use `space_key` the derived space-based identity as the signer for the storage\n",
-    "const myStorage = initializeStorage(storage, TOOLSHED_API_URL, space_key);\n",
+    "const myStorage = initializeStorage(storage, API_URL, space_key);\n",
     "\n",
     "log(user_identity, \"user identity (looks empty but its just private fields\");\n",
     "myStorage; // notice signer is no longer undefined"

--- a/packages/background-charm-service/README.md
+++ b/packages/background-charm-service/README.md
@@ -82,12 +82,12 @@ This model enables:
 Start the service:
 
 ```sh
-TOOLSHED_API_URL=http://localhost:8000 OPERATOR_PASS=your-passphrase deno task start
+API_URL=http://localhost:8000 OPERATOR_PASS=your-passphrase deno task start
 ```
 
 ### Environment Variables
 
-- `TOOLSHED_API_URL`: URL to the toolshed API
+- `API_URL`: URL to the toolshed API
 - `OPERATOR_PASS`: Passphrase for the operator identity
 - `POLLING_INTERVAL_MS`: (Optional) Interval for job queue polling
 - `MAX_CONCURRENT_JOBS`: (Optional) Maximum concurrent jobs per space

--- a/packages/background-charm-service/cast-admin.ts
+++ b/packages/background-charm-service/cast-admin.ts
@@ -30,7 +30,7 @@ if (!recipePath) {
   Deno.exit(1);
 }
 
-const toolshedUrl = Deno.env.get("TOOLSHED_API_URL") ??
+const toolshedUrl = Deno.env.get("API_URL") ??
   "https://toolshed.saga-castor.ts.net/";
 
 const identity = await getIdentity(

--- a/packages/background-charm-service/src/env.ts
+++ b/packages/background-charm-service/src/env.ts
@@ -20,7 +20,7 @@ const envSchema = z.object({
   // runs as.
   IDENTITY: z.string().optional(),
   // Toolshed configuration
-  TOOLSHED_API_URL: z.string().default("http://localhost:8000"),
+  API_URL: z.string().default("http://localhost:8000"),
   // Background Charm Service: default is public space "toolshed-system"
   //SERVICE_DID: z.string().default(
   //  "did:key:z6Mkfuw7h6jDwqVb6wimYGys14JFcyTem4Kqvdj9DjpFhY88",

--- a/packages/background-charm-service/src/main.ts
+++ b/packages/background-charm-service/src/main.ts
@@ -28,13 +28,13 @@ const identity = await getIdentity(env.IDENTITY, env.OPERATOR_PASS);
 const runtime = new Runtime({
   storageManager: StorageManager.open({
     as: identity,
-    address: new URL("/api/storage/memory", env.TOOLSHED_API_URL),
+    address: new URL("/api/storage/memory", env.API_URL),
   }),
-  blobbyServerUrl: env.TOOLSHED_API_URL,
+  blobbyServerUrl: env.API_URL,
 });
 const service = new BackgroundCharmService({
   identity,
-  toolshedUrl: env.TOOLSHED_API_URL,
+  toolshedUrl: env.API_URL,
   runtime,
   workerTimeoutMs,
 });

--- a/packages/js-runtime/deno.json
+++ b/packages/js-runtime/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@commontools/js-runtime",
   "tasks": {
-    "test": "deno test --allow-read --allow-write --allow-run --allow-env=TOOLSHED_API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV test/*.test.ts"
+    "test": "deno test --allow-read --allow-write --allow-run --allow-env=API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV test/*.test.ts"
   },
   "imports": {
     "typescript": "npm:typescript",

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -12,8 +12,8 @@ type PartialCallback = (text: string) => void;
 let llmApiUrl = typeof globalThis.location !== "undefined"
   ? globalThis.location.protocol + "//" + globalThis.location.host +
     "/api/ai/llm"
-  : Deno?.env.get("TOOLSHED_API_URL")
-  ? new URL("/api/ai/llm", Deno.env.get("TOOLSHED_API_URL")).toString()
+  : Deno?.env.get("API_URL")
+  ? new URL("/api/ai/llm", Deno.env.get("API_URL")).toString()
   : "//api/ai/llm";
 
 export const setLLMUrl = (toolshedUrl: string) => {

--- a/packages/seeder/README.md
+++ b/packages/seeder/README.md
@@ -23,15 +23,15 @@ phoenix.
     cd toolshed; deno task dev
     cd shell; deno task dev
 
-    TOOLSHED_API_URL=http://localhost:8000 deno task start --name blue42
+    API_URL=http://localhost:8000 deno task start --name blue42
 
 staging:
 
-    TOOLSHED_API_URL=https://toolshed.saga-castor.ts.net deno task start --name blue42
+    API_URL=https://toolshed.saga-castor.ts.net deno task start --name blue42
 
 estuary:
 
-    TOOLSHED_API_URL=https://estuary.saga-castor.ts.net deno task start --name blue42
+    API_URL=https://estuary.saga-castor.ts.net deno task start --name blue42
 
 To run the seeder with a specific tag, use the `--tag` flag.
 

--- a/packages/seeder/cli.ts
+++ b/packages/seeder/cli.ts
@@ -31,7 +31,7 @@ if (!noVerify && !Deno.env.get("OPENAI_API_KEY")) {
 }
 const headless = !(Deno.env.get("HEADLESS") === "false");
 const cache = !noCache;
-const apiUrl = Deno.env.get("TOOLSHED_API_URL") ??
+const apiUrl = Deno.env.get("API_URL") ??
   "https://toolshed.saga-castor.ts.net/";
 
 if (!name) {

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -105,7 +105,7 @@ const EnvSchema = z.object({
   // ===========================================================================
 
   // URL of the toolshed API, for self-referring requests
-  TOOLSHED_API_URL: z.string().default("http://localhost:8000"),
+  API_URL: z.string().default("http://localhost:8000"),
 
   // DEPRECATED: Identity signer passphrase for storage authentication
   IDENTITY_PASSPHRASE: z.string().default("implicit trust"),

--- a/packages/toolshed/lib/llm.ts
+++ b/packages/toolshed/lib/llm.ts
@@ -6,7 +6,7 @@ import { LLMContent } from "@commontools/llm/types";
 // able to get it all wired up. Importing the route definition is fine for now.
 import type { GetModelsRouteQueryParams } from "@/routes/ai/llm/llm.routes.ts";
 
-const client = hc<AppType>(env.TOOLSHED_API_URL);
+const client = hc<AppType>(env.API_URL);
 
 export async function listAvailableModels({
   capability,

--- a/packages/toolshed/routes/hc_example/index.ts
+++ b/packages/toolshed/routes/hc_example/index.ts
@@ -27,7 +27,7 @@ export const indexHandler: AppRouteHandler<typeof index> = async (c) => {
   // calls to endpoints within the application.
 
   // Create a client that points to the server. The URL would change for production.
-  const client = hc<AppType>(env.TOOLSHED_API_URL);
+  const client = hc<AppType>(env.API_URL);
 
   // Call the health endpoint.
   const res = await client._health.$get();

--- a/packages/toolshed/scripts/test-toolshed-llm.ts
+++ b/packages/toolshed/scripts/test-toolshed-llm.ts
@@ -3,8 +3,8 @@
 import { parseArgs } from "@std/cli/parse-args";
 import { colors } from "@/routes/ai/llm/cli.ts";
 
-const API_URL = Deno.env.get("TOOLSHED_API_URL")
-  ? `${Deno.env.get("TOOLSHED_API_URL")}/api/ai/llm`
+const API_URL = Deno.env.get("API_URL")
+  ? `${Deno.env.get("API_URL")}/api/ai/llm`
   : "http://localhost:8000/api/ai/llm";
 const TEST_SYSTEM_PROMPT = "Be creative.";
 const TEST_PROMPT = `What's your favorite color?`;

--- a/recipes/discord.tsx
+++ b/recipes/discord.tsx
@@ -13,7 +13,7 @@ import {
 // README:
 // sudo tailscale serve --https=443 localhost:8080
 // you need OPERATOR_PASS set so that it doesn't default to "implicit trust"
-// OPERATOR_PASS="common user" TOOLSHED_API_URL=https://toolshed.saga-castor.ts.net deno task start --spaceName discordstuff --cause 420 --recipeFile ../recipes/discord.tsx
+// OPERATOR_PASS="common user" API_URL=https://toolshed.saga-castor.ts.net deno task start --spaceName discordstuff --cause 420 --recipeFile ../recipes/discord.tsx
 // then you go to
 // TOOLSHED_URL/discordstuff
 

--- a/scripts/curl.ts
+++ b/scripts/curl.ts
@@ -23,7 +23,7 @@ const flags = parseArgs(Deno.args, {
   default: { the: "application/json", admin: false, raw: false, delete: false },
 });
 
-const toolshedUrl = Deno.env.get("TOOLSHED_API_URL") ??
+const toolshedUrl = Deno.env.get("API_URL") ??
   "http://localhost:8000/";
 
 const ANYONE = "common user";

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -42,7 +42,7 @@ const {
   default: { quit: false },
 });
 
-const toolshedUrl = Deno.env.get("TOOLSHED_API_URL") ??
+const toolshedUrl = Deno.env.get("API_URL") ??
   "https://toolshed.saga-castor.ts.net/";
 
 const OPERATOR_PASS = Deno.env.get("OPERATOR_PASS") ?? "common user";

--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -245,7 +245,7 @@ async function buildCli(config: BuildConfig): Promise<void> {
   // friends
   // Globs don't work for compile(?)
   const envs = [
-    "TOOLSHED_API_URL",
+    "API_URL",
     "TSC_WATCHFILE",
     "TSC_NONPOLLING_WATCHER",
     "TSC_WATCHDIRECTORY",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Renamed the API environment variable from TOOLSHED_API_URL to API_URL across the repo for consistency. No functional changes; code, scripts, and docs now read API_URL.

- **Refactors**
  - Updated background-charm-service, seeder, toolshed env, LLM client, test scripts, and READMEs to use API_URL.

- **Migration**
  - Replace TOOLSHED_API_URL with API_URL in .env files, CI secrets, and local commands.
  - Example: API_URL=http://localhost:8000 deno task start
  - The old variable is no longer read. Defaults remain http://localhost:8000.

<!-- End of auto-generated description by cubic. -->

