### PR TITLE
chore: Disable certain leaky patterns until we can submit charms without running them

### DIFF
--- a/packages/patterns/DISABLED_PATTERNS.txt
+++ b/packages/patterns/DISABLED_PATTERNS.txt
@@ -1,0 +1,2 @@
+llm.tsx
+fetch-data.tsx

--- a/packages/patterns/integration/all.test.ts
+++ b/packages/patterns/integration/all.test.ts
@@ -7,10 +7,21 @@ import { Identity } from "@commontools/identity";
 
 const { API_URL, SPACE_NAME } = env;
 
+// TODO(CT-844): Re-enable these patterns once
+// we can submit charms without running them locally.
+const DISABLED_PATTERNS = (await Deno.readTextFile(
+  join(
+    import.meta.dirname!,
+    "..",
+    "DISABLED_PATTERNS.txt",
+  ),
+)).split("\n").map((p: string) => p.trim());
+
 describe("Compile all recipes", () => {
   for (const file of Deno.readDirSync(join(import.meta.dirname!, ".."))) {
     const { name } = file;
     if (!name.endsWith(".tsx")) continue;
+    if (DISABLED_PATTERNS.includes(name)) continue;
 
     let cc: CharmsController;
     let identity: Identity;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Temporarily disable leaky pattern tests by adding DISABLED_PATTERNS.txt and updating the integration suite to skip any .tsx listed (currently llm.tsx and fetch-data.tsx). This aligns with Linear CT-844 and stabilizes CI until we can submit charms without running them locally.

<!-- End of auto-generated description by cubic. -->

