### PR TITLE
Don't compute the filteredCount if we aren't visible.

### DIFF
--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -1020,7 +1020,7 @@ export class XDebuggerView extends LitElement {
     const allEvents = this.isPaused
       ? this.pausedMarkers
       : this.telemetryMarkers;
-    const filteredCount = this.getFilteredEvents().length;
+    const filteredCount = this.visible ? this.getFilteredEvents().length : 0;
 
     return html`
       ${this.visible


### PR DESCRIPTION
I'm still tracking down the excessive events, but if we're not visible, we can skip evaluating the filter on them.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Skip computing filteredCount when the Debugger view isn’t visible. This avoids running the filter on background events and improves responsiveness when the panel is hidden.

<!-- End of auto-generated description by cubic. -->

