### PR TITLE
Suppress empty bubble appearing in empty `chat.tsx`

### DIFF
--- a/packages/patterns/chat.tsx
+++ b/packages/patterns/chat.tsx
@@ -76,10 +76,15 @@ export default recipe<LLMTestInput, LLMTestResult>(
                   "...",
                 )}
               />,
-              <ct-chat-message
-                role="assistant"
-                content={llmResponse.result}
-              />,
+              derive(llmResponse.result, (result) =>
+                result
+                  ? (
+                    <ct-chat-message
+                      role="assistant"
+                      content={result}
+                    />
+                  )
+                  : null),
             )}
           </ct-vscroll>
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Prevent empty assistant message bubble from appearing when there is no LLM response. The assistant message now renders only when llmResponse.result has content, keeping empty chats clean.

<!-- End of auto-generated description by cubic. -->

