### PR TITLE
fix(builtins): avoid undefined errors by using json variant of refer

### DIFF
--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -1,4 +1,4 @@
-import { refer } from "merkle-reference";
+import { refer } from "merkle-reference/json";
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
 import type { IRuntime } from "../runtime.ts";

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -10,7 +10,7 @@ import {
   BuiltInLLMParams,
   BuiltInLLMState,
 } from "@commontools/api";
-import { refer } from "merkle-reference";
+import { refer } from "merkle-reference/json";
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
 import type { IRuntime } from "../runtime.ts";


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switch to refer from merkle-reference/json in llm.ts and fetch-data.ts to hash inputs via JSON serialization. This prevents undefined-related runtime errors and ensures stable cache keys.

<!-- End of auto-generated description by cubic. -->

