### PR TITLE
Ellyse/ct 846 explore figma like pattern2

### DIFF
--- a/packages/ui/src/v2/components/ct-canvas/ct-canvas.ts
+++ b/packages/ui/src/v2/components/ct-canvas/ct-canvas.ts
@@ -35,7 +35,6 @@ export class CtCanvas extends BaseElement {
 
     // If clicking on a child element (not the canvas background), ignore it
     if (target !== container) {
-      console.log(`Canvas click ignored - clicked on child element`);
       return;
     }
 
@@ -44,8 +43,6 @@ export class CtCanvas extends BaseElement {
     // Calculate relative position within the canvas
     const x = Math.round(event.clientX - rect.left);
     const y = Math.round(event.clientY - rect.top);
-
-    console.log(`Canvas clicked at: x=${x}, y=${y}`);
 
     // Emit event using BaseElement's emit method
     this.emit("ct-canvas-click", { x, y });

--- a/packages/ui/src/v2/components/ct-draggable/ct-draggable.ts
+++ b/packages/ui/src/v2/components/ct-draggable/ct-draggable.ts
@@ -10,6 +10,9 @@ export class CtDraggable extends BaseElement {
   @property({ type: Number })
   y = 0;
 
+  @property({ type: Boolean, reflect: true })
+  hidden = false;
+
   @state()
   private isDragging = false;
 

--- a/packages/ui/src/v2/components/ct-draggable/ct-draggable.ts
+++ b/packages/ui/src/v2/components/ct-draggable/ct-draggable.ts
@@ -39,7 +39,6 @@ export class CtDraggable extends BaseElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    console.log(`[Draggable] Connected: x=${this.x}, y=${this.y}`);
     // Set initial position from props
     this.style.left = `${this.x}px`;
     this.style.top = `${this.y}px`;
@@ -50,7 +49,6 @@ export class CtDraggable extends BaseElement {
   }
 
   override disconnectedCallback() {
-    console.log(`[Draggable] Disconnected: x=${this.x}, y=${this.y}`);
     super.disconnectedCallback();
     document.removeEventListener("mousemove", this.handleMouseMove);
     document.removeEventListener("mouseup", this.handleMouseUp);
@@ -66,9 +64,6 @@ export class CtDraggable extends BaseElement {
       return;
     }
 
-    console.log(
-      `[Draggable] Mouse down - starting drag from x=${this.x}, y=${this.y}`,
-    );
     event.preventDefault();
     this.isDragging = true;
     this.dragStartX = this.x;
@@ -105,14 +100,8 @@ export class CtDraggable extends BaseElement {
     const newX = this.dragStartX + deltaX;
     const newY = this.dragStartY + deltaY;
 
-    console.log(
-      `[Draggable] Before emit - current props: x=${this.x}, y=${this.y}, new position: x=${newX}, y=${newY}`,
-    );
-
     // Emit position change event with new coordinates
     this.emit("positionchange", { x: newX, y: newY });
-
-    console.log(`[Draggable] After emit - props should update soon`);
   };
 
   override updated(changedProperties: Map<string, any>) {
@@ -121,9 +110,6 @@ export class CtDraggable extends BaseElement {
       !this.isDragging &&
       (changedProperties.has("x") || changedProperties.has("y"))
     ) {
-      console.log(
-        `[Draggable] Props updated: x=${this.x}, y=${this.y} - updating styles`,
-      );
       this.style.left = `${this.x}px`;
       this.style.top = `${this.y}px`;
     }

--- a/packages/ui/src/v2/components/ct-draggable/ct-draggable.ts
+++ b/packages/ui/src/v2/components/ct-draggable/ct-draggable.ts
@@ -11,7 +11,7 @@ export class CtDraggable extends BaseElement {
   y = 0;
 
   @property({ type: Boolean, reflect: true })
-  hidden = false;
+  override hidden = false;
 
   @state()
   private isDragging = false;

--- a/recipes/simple-draw.tsx
+++ b/recipes/simple-draw.tsx
@@ -86,10 +86,6 @@ const handleCanvasClick = handler<
     user: Cell<User>;
   }
 >((event, { messages, user }) => {
-  console.log(
-    `Canvas clicked at position: x=${event.detail.x}, y=${event.detail.y}`,
-  );
-
   // Create a new message at the clicked position with empty text
   const currentMessages = messages.get();
   messages.push({
@@ -120,9 +116,6 @@ const updateMessagePosition = handler<
     index: number;
   }
 >((event, { messages, index }) => {
-  console.log(
-    `Updating message ${index} position to x=${event.detail.x}, y=${event.detail.y}`,
-  );
   messages.key(index).key("x").set(event.detail.x);
   messages.key(index).key("y").set(event.detail.y);
 });
@@ -197,7 +190,6 @@ export const UserSession = recipe<
                       name="Save"
                       placeholder="Type message..."
                       value={m.message}
-                      keepValue="true"
                       appearance="rounded"
                       onmessagesend={updateMessage({ messages, index })}
                       style="margin-top: 5px;"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a delete (×) button to notes in Simple Draw that soft-hides notes instead of removing them. Adds hidden support to ct-draggable and removes debug logs, aligning with Linear CT-846’s Figma-like pattern.

- **New Features**
  - Soft-delete notes via a delete button; sets hidden: true and hides the draggable.
  - ct-draggable: new hidden property (reflects to the hidden attribute) for native element hiding.

- **Refactors**
  - Removed debug console logs from ct-canvas and ct-draggable.

<!-- End of auto-generated description by cubic. -->

