### PR TITLE
Fix debounce behaviour in `ct-message-input`

### DIFF
--- a/packages/ui/src/v2/components/ct-message-input/ct-message-input.ts
+++ b/packages/ui/src/v2/components/ct-message-input/ct-message-input.ts
@@ -126,6 +126,7 @@ export class CTMessageInput extends BaseElement {
           @ct-change="${this._handleInput}"
           @keydown="${this._handleKeyDown}"
           part="input"
+          timingStrategy="immediate"
         ></ct-input>
         <ct-button
           id="ct-message-input-send-button"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes debounce in ct-message-input so pressing Enter submits the full, latest message. Sets `ct-input` timingStrategy="immediate" so `ct-change` fires on each keystroke. Addresses Linear CT-847.

<!-- End of auto-generated description by cubic. -->

