### PR TITLE
Set `disabled` when chat is generating

### DIFF
--- a/packages/patterns/chat.tsx
+++ b/packages/patterns/chat.tsx
@@ -93,6 +93,7 @@ export default recipe<LLMTestInput, LLMTestResult>(
               name="Ask"
               placeholder="Ask the LLM a question..."
               appearance="rounded"
+              disabled={llmResponse.pending}
               onct-send={sendMessage({
                 chat,
                 lastLlmResponse: llmResponse.result,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Disable the chat input while a response is generating to prevent duplicate sends and accidental resubmissions.
Added disabled={llmResponse.pending} to the Ask input.

<!-- End of auto-generated description by cubic. -->

