### PR TITLE
Updating shell to allow for charms to expand to the full content area

### DIFF
--- a/packages/patterns/chat.tsx
+++ b/packages/patterns/chat.tsx
@@ -54,10 +54,15 @@ export default recipe<LLMTestInput, LLMTestResult>(
     return {
       [NAME]: title,
       [UI]: (
-        <div>
-          <h2>{title}</h2>
+        <div style="display: flex; flex-direction: column; height: 100%;">
+          <h2 style="margin: 0 0 1rem 0; padding: 0 1rem;">{title}</h2>
 
-          <ct-vscroll showScrollbar height="320px" fadeEdges snapToBottom>
+          <ct-vscroll
+            showScrollbar
+            fadeEdges
+            snapToBottom
+            style="flex: 1; min-height: 0;"
+          >
             {chat.map((msg) => {
               return (
                 <ct-chat-message
@@ -88,7 +93,7 @@ export default recipe<LLMTestInput, LLMTestResult>(
             )}
           </ct-vscroll>
 
-          <div>
+          <div style="padding: 1rem; border-top: 1px solid #e0e0e0;">
             <ct-message-input
               name="Ask"
               placeholder="Ask the LLM a question..."

--- a/packages/patterns/chat.tsx
+++ b/packages/patterns/chat.tsx
@@ -54,14 +54,16 @@ export default recipe<LLMTestInput, LLMTestResult>(
     return {
       [NAME]: title,
       [UI]: (
-        <div style="display: flex; flex-direction: column; height: 100%;">
-          <h2 style="margin: 0 0 1rem 0; padding: 0 1rem;">{title}</h2>
+        <div
+          style={{ display: "flex", flexDirection: "column", height: "100%" }}
+        >
+          <h2 style={{ margin: "0 0 1rem 0", padding: "0 1rem" }}>{title}</h2>
 
           <ct-vscroll
             showScrollbar
             fadeEdges
             snapToBottom
-            style="flex: 1; min-height: 0;"
+            style={{ flex: 1, minHeight: 0 }}
           >
             {chat.map((msg) => {
               return (
@@ -93,7 +95,7 @@ export default recipe<LLMTestInput, LLMTestResult>(
             )}
           </ct-vscroll>
 
-          <div style="padding: 1rem; border-top: 1px solid #e0e0e0;">
+          <div style={{ padding: "1rem", borderTop: "1px solid #e0e0e0" }}>
             <ct-message-input
               name="Ask"
               placeholder="Ask the LLM a question..."

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -32,8 +32,11 @@ export class XAppView extends BaseView {
 
     .content-area {
       flex: 1;
+      display: flex;
+      flex-direction: column;
       overflow-y: auto;
       background-color: white;
+      min-height: 0; /* Important for flex children */
     }
   `;
 

--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -7,9 +7,26 @@ import { CharmController } from "@commontools/charm/ops";
 export class XBodyView extends BaseView {
   static override styles = css`
     :host {
-      display: block;
+      display: flex;
+      flex-direction: column;
+      height: 100%;
       padding: 1rem;
-      overflow: hidden;
+      box-sizing: border-box;
+    }
+
+    div {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0; /* Important for flex children */
+    }
+
+    x-charm-view,
+    x-space-view {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
     }
   `;
 

--- a/packages/shell/src/views/CharmView.ts
+++ b/packages/shell/src/views/CharmView.ts
@@ -9,12 +9,22 @@ export class XCharmView extends BaseView {
       display: flex;
       flex-direction: column;
       flex: 1;
+      height: 100%;
       min-height: 0; /* Important for flex children */
+    }
+
+    common-charm {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
     }
 
     ct-render {
       flex: 1;
-      display: block;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
       height: 100%;
     }
   `;


### PR DESCRIPTION
Also includes some inline styles in the chat.tsx pattern to expand to fit the area.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable charms to expand to the full content area by switching shell views to flex layouts and fixing overflow behavior. Updated the chat pattern to fill available space and scroll correctly.

- **Refactors**
  - AppView: make .content-area a flex column with min-height: 0.
  - BodyView: switch host to flex column; ensure inner container, x-charm-view, and x-space-view flex: 1 with min-height: 0.
  - CharmView: make common-charm and ct-render flex columns; set height: 100% and min-height: 0.
  - chat.tsx: convert wrapper to flex column; remove fixed height on ct-vscroll and set flex: 1; add padding/border to input area.

<!-- End of auto-generated description by cubic. -->

