### PR TITLE
refactor(runner/scheduler): simplify API; remove dirty tracking; add immediate subscribe

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -894,7 +894,11 @@ export class Runner implements IRunner {
         recipe,
       });
       addCancel(
-        this.runtime.scheduler.schedule(wrappedAction, { reads, writes }),
+        this.runtime.scheduler.subscribe(
+          wrappedAction,
+          { reads, writes },
+          true,
+        ),
       );
     }
   }
@@ -960,10 +964,11 @@ export class Runner implements IRunner {
     );
 
     addCancel(
-      this.runtime.scheduler.schedule(action, {
-        reads: inputCells,
-        writes: outputCells,
-      }),
+      this.runtime.scheduler.subscribe(
+        action,
+        { reads: inputCells, writes: outputCells },
+        true,
+      ),
     );
   }
 

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -184,10 +184,12 @@ export interface IRuntime {
 export interface IScheduler {
   readonly runtime: IRuntime;
   idle(): Promise<void>;
-  schedule(action: Action, log: ReactivityLog): Cancel;
-  subscribe(action: Action, log: ReactivityLog): Cancel;
-  run(action: Action): Promise<any>;
-  unschedule(action: Action): void;
+  subscribe(
+    action: Action,
+    log: ReactivityLog,
+    scheduleImmediately?: boolean,
+  ): Cancel;
+  unsubscribe(action: Action): void;
   onConsole(fn: ConsoleHandler): void;
   onError(fn: ErrorHandler): void;
   queueEvent(eventRef: NormalizedFullLink, event: any): void;

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -80,10 +80,10 @@ export type SpaceURIAndType = `${MemorySpace}/${URI}/${MediaType}`;
 const MAX_ITERATIONS_PER_RUN = 100;
 
 export class Scheduler implements IScheduler {
-  private pending = new Set<Action>();
   private eventQueue: ((tx: IExtendedStorageTransaction) => any)[] = [];
   private eventHandlers: [NormalizedFullLink, EventHandler][] = [];
-  private dirty = new Set<SpaceURIAndType>();
+
+  private pending = new Set<Action>();
   private dependencies = new WeakMap<Action, ReactivityLog>();
   private cancels = new WeakMap<Action, Cancel>();
   private triggers = new Map<SpaceAndURI, Map<Action, SortedAndCompactPaths>>();
@@ -141,68 +141,69 @@ export class Scheduler implements IScheduler {
     });
   }
 
-  schedule(action: Action, log: ReactivityLog): Cancel {
+  subscribe(
+    action: Action,
+    log: ReactivityLog,
+    scheduleImmediately: boolean = false,
+  ): Cancel {
     const reads = this.setDependencies(action, log);
-    logger.debug(() => ["Scheduling action:", action, reads]);
-    reads.forEach((addr) =>
-      this.dirty.add(`${addr.space}/${addr.id}/${addr.type}`)
+
+    logger.debug(
+      () => ["Subscribing to action:", action, reads, scheduleImmediately],
     );
 
-    this.queueExecution();
-    this.pending.add(action);
+    if (scheduleImmediately) {
+      this.queueExecution();
+      this.pending.add(action);
+    } else {
+      const pathsByEntity = addressesToPathByEntity(reads);
 
-    return () => this.unschedule(action);
+      logger.debug(() => [
+        `[SUBSCRIBE] Action: ${action.name || "anonymous"}`,
+        `Entities: ${pathsByEntity.size}`,
+        `Reads: ${reads.length}`,
+      ]);
+
+      const entities = new Set<SpaceAndURI>();
+
+      for (const [spaceAndURI, paths] of pathsByEntity) {
+        entities.add(spaceAndURI);
+        if (!this.triggers.has(spaceAndURI)) {
+          this.triggers.set(spaceAndURI, new Map());
+        }
+        const pathsWithValues = paths.map((path) =>
+          [
+            "value",
+            ...path,
+          ] as readonly MemoryAddressPathComponent[]
+        );
+        this.triggers.get(spaceAndURI)!.set(action, pathsWithValues);
+
+        logger.debug(() => [
+          `[SUBSCRIBE] Registered action for ${spaceAndURI}`,
+          `Paths: ${pathsWithValues.map((p) => p.join("/")).join(", ")}`,
+        ]);
+      }
+
+      this.cancels.set(action, () => {
+        logger.debug(() => [
+          `[UNSUBSCRIBE] Action: ${action.name || "anonymous"}`,
+          `Entities: ${entities.size}`,
+        ]);
+        for (const spaceAndURI of entities) {
+          this.triggers.get(spaceAndURI)?.delete(action);
+        }
+      });
+    }
+
+    return () => this.unsubscribe(action);
   }
 
-  unschedule(action: Action): void {
+  unsubscribe(action: Action): void {
     this.cancels.get(action)?.();
     this.cancels.delete(action);
     this.dependencies.delete(action);
     this.pending.delete(action);
-  }
-
-  subscribe(action: Action, log: ReactivityLog): Cancel {
-    const reads = this.setDependencies(action, log);
-    const pathsByEntity = addressesToPathByEntity(reads);
-
-    logger.debug(() => [
-      `[SUBSCRIBE] Action: ${action.name || "anonymous"}`,
-      `Entities: ${pathsByEntity.size}`,
-      `Reads: ${reads.length}`,
-    ]);
-
-    const entities = new Set<SpaceAndURI>();
-
-    for (const [spaceAndURI, paths] of pathsByEntity) {
-      entities.add(spaceAndURI);
-      if (!this.triggers.has(spaceAndURI)) {
-        this.triggers.set(spaceAndURI, new Map());
-      }
-      const pathsWithValues = paths.map((path) =>
-        [
-          "value",
-          ...path,
-        ] as readonly MemoryAddressPathComponent[]
-      );
-      this.triggers.get(spaceAndURI)!.set(action, pathsWithValues);
-
-      logger.debug(() => [
-        `[SUBSCRIBE] Registered action for ${spaceAndURI}`,
-        `Paths: ${pathsWithValues.map((p) => p.join("/")).join(", ")}`,
-      ]);
-    }
-
-    this.cancels.set(action, () => {
-      logger.debug(() => [
-        `[UNSUBSCRIBE] Action: ${action.name || "anonymous"}`,
-        `Entities: ${entities.size}`,
-      ]);
-      for (const spaceAndURI of entities) {
-        this.triggers.get(spaceAndURI)?.delete(action);
-      }
-    });
-
-    return () => this.unschedule(action);
   }
 
   async run(action: Action): Promise<any> {
@@ -231,8 +232,7 @@ export class Scheduler implements IScheduler {
             this.handleError(error as Error, action);
           }
         } finally {
-          // Set up reactive subscriptions after the action runs
-          // This matches the original scheduler behavior
+          // Set up new reactive subscriptions after the action runs
           tx.commit();
           const log = txToReactivityLog(tx);
 
@@ -378,9 +378,6 @@ export class Scheduler implements IScheduler {
                   }`,
                   `Action name: ${action.name || "anonymous"}`,
                 ]);
-                this.dirty.add(
-                  `${spaceAndURI}/${change.address.type}` as SpaceURIAndType,
-                );
                 this.queueExecution();
                 this.pending.add(action);
               }
@@ -440,7 +437,12 @@ export class Scheduler implements IScheduler {
     // In case a directly invoked `run` is still running, wait for it to finish.
     if (this.runningPromise) await this.runningPromise;
 
-    // Process next event from the event queue. Will mark more docs as dirty.
+    // Process next event from the event queue.
+
+    // TODO(seefeld): This should maybe run _after_ all pending actions, so it's
+    // based on the newest state. OTOH, if it has no dependencies and changes
+    // data, then this causes redundant runs. So really we should add this to
+    // the topological sort in the right way.
     const handler = this.eventQueue.shift();
     if (handler) {
       this.runtime.telemetry.submit({
@@ -466,27 +468,20 @@ export class Scheduler implements IScheduler {
       }
     }
 
-    const order = topologicalSort(
-      this.pending,
-      this.dependencies,
-      this.dirty,
-    );
-
-    // Clear pending and dirty sets, and cancel all listeners for docs on already
-    // scheduled actions.
-    this.pending.clear();
-    this.dirty.clear();
+    const order = topologicalSort(this.pending, this.dependencies);
 
     logger.debug(() => [
       `[EXECUTE] Canceling subscriptions for ${order.length} actions before execution`,
     ]);
 
+    // Cancel all listeners for docs on already scheduled actions.
+    this.pending.clear();
     for (const fn of order) {
-      this.cancels.get(fn)?.();
+      this.unsubscribe(fn);
     }
 
-    // Now run all functions. This will create new listeners to mark docs dirty
-    // and schedule the next run.
+    // Now run all functions. This will resubscribe actions with their new
+    // dependencies.
     for (const fn of order) {
       this.loopCounter.set(fn, (this.loopCounter.get(fn) || 0) + 1);
       if (this.loopCounter.get(fn)! > MAX_ITERATIONS_PER_RUN) {
@@ -516,67 +511,22 @@ export class Scheduler implements IScheduler {
 function topologicalSort(
   actions: Set<Action>,
   dependencies: WeakMap<Action, ReactivityLog>,
-  dirty: Set<SpaceAndURI>,
 ): Action[] {
-  const relevantActions = new Set<Action>();
   const graph = new Map<Action, Set<Action>>();
   const inDegree = new Map<Action, number>();
 
-  // First pass: identify relevant actions
-  for (const action of actions) {
-    const { reads } = dependencies.get(action)!;
-    // TODO(seefeld): Keep track of affected paths
-    if (reads.length === 0) {
-      // Actions with no dependencies are always relevant. Note that they must
-      // be manually added to `pending`, which happens only once on `schedule`.
-      relevantActions.add(action);
-    } else if (
-      reads.some((addr) => dirty.has(`${addr.space}/${addr.id}/${addr.type}`))
-    ) {
-      relevantActions.add(action);
-    }
-  }
-
-  // Second pass: add downstream actions
-  let size;
-  do {
-    size = relevantActions.size;
-    for (const action of actions) {
-      if (!relevantActions.has(action)) {
-        const { writes } = dependencies.get(action)!;
-        for (const write of writes) {
-          if (
-            Array.from(relevantActions).some((relevantAction) =>
-              dependencies
-                .get(relevantAction)!
-                .reads.some(
-                  (addr) =>
-                    addr.space === write.space &&
-                    addr.id === write.id &&
-                    arraysOverlap(write.path, addr.path),
-                )
-            )
-          ) {
-            relevantActions.add(action);
-            break;
-          }
-        }
-      }
-    }
-  } while (relevantActions.size > size);
-
   // Initialize graph and inDegree for relevant actions
-  for (const action of relevantActions) {
+  for (const action of actions) {
     graph.set(action, new Set());
     inDegree.set(action, 0);
   }
 
   // Build the graph
-  for (const actionA of relevantActions) {
+  for (const actionA of actions) {
     const { writes } = dependencies.get(actionA)!;
     const graphA = graph.get(actionA)!;
     for (const write of writes) {
-      for (const actionB of relevantActions) {
+      for (const actionB of actions) {
         if (actionA !== actionB && !graphA.has(actionB)) {
           const { reads } = dependencies.get(actionB)!;
           if (
@@ -607,10 +557,10 @@ function topologicalSort(
     }
   }
 
-  while (queue.length > 0 || visited.size < relevantActions.size) {
+  while (queue.length > 0 || visited.size < actions.size) {
     if (queue.length === 0) {
       // Handle cycle: choose an unvisited node with the lowest in-degree
-      const unvisitedAction = Array.from(relevantActions)
+      const unvisitedAction = Array.from(actions)
         .filter((action) => !visited.has(action))
         .reduce((a, b) => (inDegree.get(a)! < inDegree.get(b)! ? a : b));
       queue.push(unvisitedAction);

--- a/packages/shell/src/lib/iframe-ctx.ts
+++ b/packages/shell/src/lib/iframe-ctx.ts
@@ -118,13 +118,17 @@ export const setupIframe = (runtime: Runtime) =>
 
         // Remove * support after first call (legacy compatibility)
         if (key === "*") {
-          runtime.idle().then(() => runtime.scheduler.unschedule(action));
+          runtime.idle().then(() => runtime.scheduler.unsubscribe(action));
         }
       };
 
       // Schedule the action with appropriate reactivity log
       const reads = isCell(context) ? [context.getAsNormalizedFullLink()] : [];
-      const cancel = runtime.scheduler.schedule(action, { reads, writes: [] });
+      const cancel = runtime.scheduler.subscribe(
+        action,
+        { reads, writes: [] },
+        true,
+      );
       return { action, cancel };
     },
 
@@ -142,7 +146,7 @@ export const setupIframe = (runtime: Runtime) =>
       } else {
         // Fallback for direct action
         if (typeof receipt === "function") {
-          runtime.scheduler.unschedule(receipt as Action);
+          runtime.scheduler.unsubscribe(receipt as Action);
         } else {
           throw new Error("Invalid receipt.");
         }


### PR DESCRIPTION
- Simplify `Scheduler` by removing the "dirty" set and related filtering.
- Unify scheduling API around `subscribe(action, log, scheduleImmediately?)` and `unsubscribe(action)`.
- Support immediate, one-off execution via `subscribe(..., true)`; subsequent executions re-subscribe based on newly observed dependencies.
- Topological ordering now considers all pending actions and their dependency graph without pre-filtering by "dirty".
- Improve debug logs around subscribe/unsubscribe/execute phases.

API changes:
- Remove `schedule(action, log)` and `unschedule(action)`.
- Remove `run(action)` from `IScheduler` (method still exists on the class but is no longer part of the interface).
- Add `subscribe(action, log, scheduleImmediately?: boolean)` and `unsubscribe(action)`.

Callers updated:
- `packages/runner/src/runner.ts`: replace `schedule` with `subscribe(..., true)` for initial execution.
- `packages/shell/src/lib/iframe-ctx.ts`: replace `schedule`/`unschedule` with `subscribe(..., true)`/`unsubscribe`.
- `packages/runner/test/scheduler.test.ts`: replace `run`/`schedule` with `subscribe(..., true)` and await `runtime.idle()` for initial runs.

Behavioral notes:
- Immediate actions (`subscribe(..., true)`) are queued and executed once, then re-subscribed with their new dependency graph after completion.
- Event-triggered actions are queued directly when their registered read paths change; no "dirty" tracking required.
- Execution order still respects dependencies via topological sort.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Simplified the Scheduler by removing dirty tracking and unifying the API around subscribe/unsubscribe. Adds an option to run an action immediately and re-subscribe based on observed dependencies.

- **Refactors**
  - Removed the dirty set; scheduling now uses pending actions and their dependency graph.
  - Unified API: subscribe(action, log, scheduleImmediately?) and unsubscribe(action).
  - subscribe(..., true) queues a one-off run, then re-subscribes with new dependencies.
  - Topological ordering considers all pending actions; no pre-filtering.

- **Migration**
  - Replace schedule(...) with subscribe(..., log, true).
  - Replace unschedule(...) with unsubscribe(...).
  - Replace run(action) with subscribe(..., true) and await runtime.idle() for initial runs.
  - Update IScheduler references to the new method signatures.

<!-- End of auto-generated description by cubic. -->

