### PR TITLE
chore: Re-enable CI compilation tests for side effect patterns

### DIFF
--- a/packages/patterns/DISABLED_PATTERNS.txt
+++ b/packages/patterns/DISABLED_PATTERNS.txt
@@ -1,2 +1,0 @@
-llm.tsx
-fetch-data.tsx

--- a/packages/patterns/integration/all.test.ts
+++ b/packages/patterns/integration/all.test.ts
@@ -7,21 +7,10 @@ import { Identity } from "@commontools/identity";
 
 const { API_URL, SPACE_NAME } = env;
 
-// TODO(CT-844): Re-enable these patterns once
-// we can submit charms without running them locally.
-const DISABLED_PATTERNS = (await Deno.readTextFile(
-  join(
-    import.meta.dirname!,
-    "..",
-    "DISABLED_PATTERNS.txt",
-  ),
-)).split("\n").map((p: string) => p.trim());
-
 describe("Compile all recipes", () => {
   for (const file of Deno.readDirSync(join(import.meta.dirname!, ".."))) {
     const { name } = file;
     if (!name.endsWith(".tsx")) continue;
-    if (DISABLED_PATTERNS.includes(name)) continue;
 
     let cc: CharmsController;
     let identity: Identity;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Re-enabled CI compilation tests for all pattern .tsx files, including side-effect patterns, to catch compile errors early. Removed the DISABLED_PATTERNS file and skip logic so llm.tsx and fetch-data.tsx are compiled in CI, addressing Linear CT-844.

<!-- End of auto-generated description by cubic. -->

