### PR TITLE
chore: Run charms on creation for CI tests that operate on the charm within the deno thread

### DIFF
--- a/packages/patterns/integration/counter.test.ts
+++ b/packages/patterns/integration/counter.test.ts
@@ -32,7 +32,8 @@ describe("counter direct operations test", () => {
           "counter.tsx",
         ),
       ),
-      { start: false },
+      // We operate on the charm in this thread
+      { start: true },
     );
   });
 

--- a/packages/patterns/integration/ct-render.test.ts
+++ b/packages/patterns/integration/ct-render.test.ts
@@ -31,7 +31,8 @@ describe("ct-render integration test", () => {
           "ct-render.tsx",
         ),
       ),
-      { start: false },
+      // We operate on the charm in this thread
+      { start: true },
     );
   });
 

--- a/packages/patterns/integration/nested-counter.test.ts
+++ b/packages/patterns/integration/nested-counter.test.ts
@@ -32,7 +32,8 @@ describe("nested counter integration test", () => {
           "nested-counter.tsx",
         ),
       ),
-      { start: false },
+      // We operate on the charm in this thread
+      { start: true },
     );
   });
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Start charms on creation in three integration tests that operate on the charm within the Deno thread. This ensures the charm is running before operations and reduces CI flakiness.

<!-- End of auto-generated description by cubic. -->

