### PR TITLE
fix(scheduler,html): avoid dropping subscriptions; unsubscribe only pending actions

### DIFF
--- a/packages/html/src/render.ts
+++ b/packages/html/src/render.ts
@@ -147,11 +147,10 @@ const bindChildren = (
       if (currentNode) {
         // Replace the previous DOM node, if any
         currentNode.replaceWith(newRendered.node);
-        keyedChildren.get(key)?.cancel();
         // Update the mapping entry to capture any newly-rendered node.
         keyedChildren.set(key, {
           ...keyedChildren.get(key)!,
-          ...newRendered,
+          node: newRendered.node,
         });
       }
 


### PR DESCRIPTION
…ending actions

- runner/scheduler: During execution, stop clearing the entire pending set and unsubscribing everything up front. Instead, for each action in the run order, only proceed if it is still pending, then remove it from pending and unsubscribe just that action before running it. This prevents unsubscribing actions that have since been removed, avoids lost dependencies, and reduces unnecessary resubscribe cycles.
- html/render: When replacing a keyed child's DOM node, do not cancel the child; keep its subscriptions and only update the stored node reference. This avoids dropping listeners/state during keyed re-renders.

This fixes intermittent missed updates and event storms caused by over-eager cancellation/unsubscribe in both the scheduler and keyed DOM updates.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents dropped subscriptions during scheduling and keyed DOM replacements. Reduces missed updates and event storms by unsubscribing only pending actions and preserving child subscriptions.

- **Bug Fixes**
  - Scheduler: stop clearing all pending and unsubscribing upfront; for each action, if still pending, remove from pending, unsubscribe it, then run. Avoids unnecessary resubscribes and lost dependencies.
  - HTML renderer: when replacing a keyed child’s node, do not cancel the child; keep subscriptions and only update the stored node reference.

<!-- End of auto-generated description by cubic. -->

