### PR TITLE
feat(runner): add editWithRetry transaction helper; add tests

### DIFF
--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -431,7 +431,7 @@ export class Runtime implements IRuntime {
    *
    * @param fn - Function to execute with the transaction.
    * @param maxRetries - Maximum number of retries.
-   * @returns Promise that resolves when the transaction is committed.
+   * @returns Promise<boolean> that resolves to true on success, or false after exhausting retries.
    */
   editWithRetry(
     fn: (tx: IExtendedStorageTransaction) => void,

--- a/packages/runner/test/runtime-edit-with-retry.test.ts
+++ b/packages/runner/test/runtime-edit-with-retry.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commontools/identity";
+import { StorageManager } from "@commontools/runner/storage/cache.deno";
+import { DEFAULT_MAX_RETRIES, Runtime } from "../src/runtime.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+describe("Runtime.editWithRetry", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({ blobbyServerUrl: import.meta.url, storageManager });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("commits successfully without retry", async () => {
+    const cell = runtime.getCell<number>(
+      space,
+      "editWithRetry-success",
+      undefined,
+      tx,
+    );
+    cell.set(0);
+    await tx.commit();
+
+    const ok = await runtime.editWithRetry((t) => {
+      cell.withTx(t).send(1);
+    });
+
+    expect(ok).toBe(true);
+    expect(cell.get()).toBe(1);
+  });
+
+  it("retries commit failures and eventually succeeds", async () => {
+    // Prepare a cell and commit initial value
+    const cell = runtime.getCell<number>(
+      space,
+      "editWithRetry-retry-succeed",
+      undefined,
+      tx,
+    );
+    cell.set(0);
+    await tx.commit();
+
+    // Track attempts and force early aborts to trigger retry
+    let attempts = 0;
+    const ok = await runtime.editWithRetry((t) => {
+      attempts++;
+      // Abort the first few attempts to force retry
+      if (attempts <= 2) {
+        t.abort("force-abort-for-retry");
+        return;
+      }
+      cell.withTx(t).send(2);
+    }, 5);
+
+    expect(ok).toBe(true);
+    expect(attempts).toBe(3); // initial + 2 retries
+    expect(cell.get()).toBe(2);
+  });
+
+  it("returns false after exhausting retries", async () => {
+    const cell = runtime.getCell<number>(
+      space,
+      "editWithRetry-retry-fail",
+      undefined,
+      tx,
+    );
+    cell.set(0);
+    await tx.commit();
+
+    let attempts = 0;
+    const max = 3;
+    const ok = await runtime.editWithRetry((t) => {
+      attempts++;
+      t.abort("always-fail");
+    }, max);
+
+    expect(ok).toBe(false);
+    // initial + max retries
+    expect(attempts).toBe(max + 1);
+    // Value unchanged
+    expect(cell.get()).toBe(0);
+  });
+
+  it("uses DEFAULT_MAX_RETRIES when not provided", async () => {
+    const cell = runtime.getCell<number>(
+      space,
+      "editWithRetry-default-retries",
+      undefined,
+      tx,
+    );
+    cell.set(0);
+    await tx.commit();
+
+    let attempts = 0;
+    const ok = await runtime.editWithRetry((t) => {
+      attempts++;
+      t.abort("always-fail");
+    });
+
+    expect(ok).toBe(false);
+    expect(attempts).toBe(DEFAULT_MAX_RETRIES + 1);
+    expect(cell.get()).toBe(0);
+  });
+});


### PR DESCRIPTION
Introduce Runtime.editWithRetry to simplify safe transactional writes with a bounded retry policy.

Core change:
- Add Runtime.editWithRetry(fn, maxRetries?)
  - Runs the provided function with a fresh transaction, commits, and retries on commit error up to maxRetries (default DEFAULT_MAX_RETRIES=5).
  - Returns boolean: true on success, false if all attempts fail.
  - Replays fn on each attempt; callers must keep side effects contained to the transaction or make fn idempotent.
- Export DEFAULT_MAX_RETRIES = 5.
- Extend IRuntime to include editWithRetry.
- Keep existing edit() and readTx() behavior unchanged.

Why:
- Centralizes conflict-retry logic for ad hoc writes outside scheduler/event handling, improving ergonomics and consistency.

Notes/limitations:
- No backoff or jitter (simple bounded retries).
- Recursive implementation; depth is bounded by maxRetries.

Tests:
- New: packages/runner/test/runtime-edit-with-retry.test.ts
  - commits successfully without retry
  - retries commit failures (via abort) then succeeds
  - exhausts retries and returns false
  - honors DEFAULT_MAX_RETRIES when not provided
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds Runtime.editWithRetry to run transactional writes with bounded retries and a simple success/fail result. No changes to edit() or readTx(); also exports DEFAULT_MAX_RETRIES=5 and adds tests.

- **New Features**
  - Runtime.editWithRetry(fn, maxRetries?) runs fn in a fresh transaction, commits, and retries on commit error up to maxRetries (default 5). Returns true on success, false if all attempts fail.
  - Replays fn on each attempt; keep side effects inside the transaction or make fn idempotent.
  - Export DEFAULT_MAX_RETRIES = 5 and extend IRuntime to include editWithRetry.
  - No backoff or jitter; retries are recursive and bounded by maxRetries.

<!-- End of auto-generated description by cubic. -->

