### PR TITLE
Implement `note.tsx` pattern

### DIFF
--- a/packages/patterns/note.tsx
+++ b/packages/patterns/note.tsx
@@ -1,0 +1,62 @@
+/// <cts-enable />
+import {
+  Cell,
+  Default,
+  h,
+  handler,
+  NAME,
+  recipe,
+  toSchema,
+  UI,
+} from "commontools";
+
+type Input = {
+  title: Default<string, "Untitled Note">;
+  content: Default<string, "">;
+};
+
+type Output = Input;
+
+const updateTitle = handler<
+  { detail: { value: string } },
+  { title: Cell<string> }
+>(
+  (event, state) => {
+    state.title.set(event.detail?.value ?? "");
+  },
+);
+
+const updateContent = handler<
+  { detail: { value: string } },
+  { content: Cell<string> }
+>(
+  (event, state) => {
+    state.content.set(event.detail?.value ?? "");
+  },
+);
+
+export default recipe<Input, Output>(
+  "Note",
+  ({ title, content }) => {
+    return {
+      [NAME]: title,
+      [UI]: (
+        <ct-screen>
+          <div slot="header">
+            <ct-input
+              $value={title}
+              placeholder="Enter title..."
+            />
+          </div>
+          <ct-code-editor
+            $value={content}
+            language="text/markdown"
+            style="min-height: 400px;"
+          />
+        </ct-screen>
+      ),
+      title,
+      content,
+    };
+  },
+);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a Note pattern that lets users edit a title and markdown content in a simple screen. It renders a header title input and a content editor, and exposes both values.

- New Features
  - Note recipe with title (default "Untitled Note") and content fields bound to UI.
  - Sets NAME to the title and returns title/content in the output.

<!-- End of auto-generated description by cubic. -->

