### PR TITLE
Fix local LLM API calls from shell

### DIFF
--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -1,6 +1,7 @@
 import "core-js/proposals/explicit-resource-management";
 import "@commontools/ui/v1";
 import "@commontools/ui/v2";
+import { setLLMUrl } from "@commontools/llm";
 import { API_URL, COMMIT_SHA, ENVIRONMENT } from "./lib/env.ts";
 import { AppUpdateEvent } from "./lib/app/events.ts";
 import { XRootView } from "./views/RootView.ts";
@@ -12,6 +13,9 @@ import "./globals.ts";
 console.log(`ENVIRONMENT=${ENVIRONMENT}`);
 console.log(`API_URL=${API_URL}`);
 console.log(`COMMIT_SHA=${COMMIT_SHA}`);
+
+// Configure LLM client to use the correct API URL
+setLLMUrl(API_URL.toString());
 
 const root = document.querySelector("x-root-view");
 if (!root) throw new Error("No root view found.");

--- a/packages/toolshed/routes/ai/llm/llm.index.ts
+++ b/packages/toolshed/routes/ai/llm/llm.index.ts
@@ -4,11 +4,7 @@ import * as routes from "./llm.routes.ts";
 import env from "@/env.ts";
 import { cors } from "@hono/hono/cors";
 
-const router = createRouter()
-  .openapi(routes.getModels, handlers.getModels)
-  .openapi(routes.generateText, handlers.generateText)
-  .openapi(routes.feedback, handlers.submitFeedback)
-  .openapi(routes.generateObject, handlers.generateObject);
+const router = createRouter();
 
 router.use(
   "/api/ai/llm/*",
@@ -16,10 +12,16 @@ router.use(
     origin: "*",
     allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allowHeaders: ["Content-Type", "Authorization"],
-    exposeHeaders: ["Content-Length", "X-Disk-Cache"],
+    exposeHeaders: ["Content-Length", "X-Disk-Cache", "x-ct-llm-trace-id"],
     maxAge: 3600,
     credentials: true,
   }),
 );
+
+router
+  .openapi(routes.getModels, handlers.getModels)
+  .openapi(routes.generateText, handlers.generateText)
+  .openapi(routes.feedback, handlers.submitFeedback)
+  .openapi(routes.generateObject, handlers.generateObject);
 
 export default router;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes local LLM calls from the shell by setting the client base URL from env and applying correct CORS on LLM routes. Shell requests now hit the right API and include the exposed trace header.

- **Bug Fixes**
  - Set LLM client URL via env in the shell to avoid defaulting to localhost.
  - Apply CORS to /api/ai/llm/* and expose x-ct-llm-trace-id.

<!-- End of auto-generated description by cubic. -->

