### PR TITLE
Union types should use anyOf instead of oneOf

### DIFF
--- a/packages/js-runtime/test/fixtures/schema-transform/complex-defaults.expected.ts
+++ b/packages/js-runtime/test/fixtures/schema-transform/complex-defaults.expected.ts
@@ -151,7 +151,7 @@ export const nullDefaultsSchema = {
     type: "object",
     properties: {
         nullable: {
-            oneOf: [{
+            anyOf: [{
                     type: "null"
                 }, {
                     type: "string"

--- a/packages/js-runtime/typescript/transformer/schema-generator.ts
+++ b/packages/js-runtime/typescript/transformer/schema-generator.ts
@@ -676,7 +676,7 @@ function typeToJsonSchemaHelper(
       );
     }
     return {
-      oneOf: unionTypes.map((t) =>
+      anyOf: unionTypes.map((t) =>
         typeToJsonSchemaHelper(
           t,
           checker,


### PR DESCRIPTION
An object can match more than one of the union types, so a Dog should still match the following type:
```typescript
type Pet = Cat | Dog | Animal;
```

This is likely going to be dead code soon, but may as well commit the fix while I have it.