### PR TITLE
chore(storage): log "already in history" and thus expected conflicts as info

### DIFF
--- a/packages/memory/error.ts
+++ b/packages/memory/error.ts
@@ -50,9 +50,7 @@ export class TheConflictError extends Error implements ConflictError {
     super(
       conflict.expected == null
         ? `The ${conflict.the} of ${conflict.of} in ${conflict.space} already exists as ${
-          refer(
-            actual,
-          )
+          refer(actual)
         }`
         : conflict.actual == null
         ? `The ${conflict.the} of ${conflict.of} in ${conflict.space} was expected to be ${conflict.expected}, but it does not exist`

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -1099,7 +1099,7 @@ export class Replica {
       }
       if (
         result.error.name === "ConflictError" &&
-        result.error.conflict.existsInHistory
+        result.error.conflict.expected == null
       ) {
         logger.info(() => ["Transaction failed (aready exists)", result.error]);
       } else {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Downgraded logging for expected “already exists” conflicts in storage to info by checking conflict.expected == null, reducing noisy error logs. Also cleaned up TheConflictError message formatting with no behavior change.

<!-- End of auto-generated description by cubic. -->

