### PR TITLE
Do not set `maxTokens` unless provided to `llm-dialog.ts`

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -92,9 +92,6 @@ async function invokeHandlerAsToolCall(
   return resultValue;
 }
 
-// Default token limits
-const DEFAULT_LLM_MAX_TOKENS = 4096;
-
 /**
  * Run a (tool using) dialog with an LLM.
  *
@@ -202,7 +199,7 @@ function mainLogic(
     system: system ?? "",
     messages: messagesCell.getAsQueryResult([], tx) ?? [],
     stop: stop ?? "",
-    maxTokens: maxTokens ?? DEFAULT_LLM_MAX_TOKENS,
+    maxTokens: maxTokens,
     stream: true,
     model: model ?? DEFAULT_MODEL_NAME,
     metadata: {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Remove the hardcoded 4096 maxTokens default in llm-dialog. We now only pass maxTokens when a value is provided, so model defaults are used and outputs aren’t unintentionally truncated.

<!-- End of auto-generated description by cubic. -->

