### PR TITLE
Change from time-based Cache-Control headers to Etag based asset caching

### DIFF
--- a/packages/static/deno.json
+++ b/packages/static/deno.json
@@ -13,6 +13,7 @@
     "compile-api-types": "./scripts/compile-api-types.sh"
   },
   "exports": {
-    ".": "./index.ts"
+    ".": "./index.ts",
+    "./etag": "./etag.ts"
   }
 }

--- a/packages/static/etag.ts
+++ b/packages/static/etag.ts
@@ -1,0 +1,65 @@
+/**
+ * ETag generation utilities for static asset caching.
+ * Uses SHA-256 content hashing for strong ETags.
+ */
+
+/**
+ * Generate a strong ETag from content using SHA-256 hash.
+ * Returns a base64-encoded hash in quotes.
+ */
+export async function generateETag(content: Uint8Array): Promise<string> {
+  const hash = await crypto.subtle.digest("SHA-256", content);
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(hash)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+
+  return `"${base64}"`;
+}
+
+/**
+ * Compare ETags for equality.
+ * Supports comma-separated lists of ETags from If-None-Match headers.
+ */
+export function compareETags(
+  etag: string,
+  ifNoneMatch: string | null | undefined,
+): boolean {
+  if (!ifNoneMatch) return false;
+
+  // Handle comma-separated list of ETags
+  const clientETags = ifNoneMatch.split(",").map((tag) => tag.trim());
+
+  return clientETags.some((clientETag) => {
+    // Handle wildcard
+    if (clientETag === "*") return true;
+    return clientETag === etag;
+  });
+}
+
+/**
+ * Create cache headers with ETag support.
+ * Uses no-cache strategy to always validate with ETag.
+ */
+export function createCacheHeaders(
+  etag: string,
+  options: {
+    noCache?: boolean;
+    public?: boolean;
+  } = {},
+): Record<string, string> {
+  const {
+    noCache = true,
+    public: isPublic = true,
+  } = options;
+
+  const headers: Record<string, string> = {
+    "ETag": etag,
+  };
+
+  if (noCache) {
+    headers["Cache-Control"] = isPublic ? "public, no-cache" : "no-cache";
+  }
+
+  return headers;
+}

--- a/packages/static/test/etag-cache.test.ts
+++ b/packages/static/test/etag-cache.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assert } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import {
   compareETags,
   createCacheHeaders,

--- a/packages/static/test/etag-cache.test.ts
+++ b/packages/static/test/etag-cache.test.ts
@@ -1,0 +1,160 @@
+import { assertEquals, assert } from "@std/assert";
+import {
+  compareETags,
+  createCacheHeaders,
+  generateETag,
+} from "@commontools/static/etag";
+import { StaticCache } from "@commontools/static";
+import { decode } from "@commontools/utils/encoding";
+
+Deno.test("ETag Generation - generates same ETag for same content", async () => {
+  const content = new TextEncoder().encode("Hello, World!");
+  const etag1 = await generateETag(content);
+  const etag2 = await generateETag(content);
+  assertEquals(etag1, etag2);
+});
+
+Deno.test("ETag Generation - generates different ETags for different content", async () => {
+  const content1 = new TextEncoder().encode("Hello, World!");
+  const content2 = new TextEncoder().encode("Goodbye, World!");
+  const etag1 = await generateETag(content1);
+  const etag2 = await generateETag(content2);
+  assert(etag1 !== etag2);
+});
+
+Deno.test("ETag Generation - generates valid ETag format (quoted base64)", async () => {
+  const content = new TextEncoder().encode("Test content");
+  const etag = await generateETag(content);
+
+  // Should be wrapped in quotes
+  assert(etag.startsWith('"') && etag.endsWith('"'));
+
+  // Should be valid base64-like format (URL-safe)
+  const base64Part = etag.slice(1, -1);
+  assert(/^[A-Za-z0-9_-]+$/.test(base64Part));
+});
+
+Deno.test("ETag Comparison - matches single matching ETag", () => {
+  const etag = '"abc123"';
+  const ifNoneMatch = '"abc123"';
+  assertEquals(compareETags(etag, ifNoneMatch), true);
+});
+
+Deno.test("ETag Comparison - does not match non-matching ETag", () => {
+  const etag = '"abc123"';
+  const ifNoneMatch = '"xyz789"';
+  assertEquals(compareETags(etag, ifNoneMatch), false);
+});
+
+Deno.test("ETag Comparison - matches ETag in comma-separated list", () => {
+  const etag = '"abc123"';
+  const ifNoneMatch = '"xyz789", "abc123", "def456"';
+  assertEquals(compareETags(etag, ifNoneMatch), true);
+});
+
+Deno.test("ETag Comparison - handles comma-separated list with spaces", () => {
+  const etag = '"abc123"';
+  const ifNoneMatch = '"xyz789" , "abc123" , "def456"';
+  assertEquals(compareETags(etag, ifNoneMatch), true);
+});
+
+Deno.test("ETag Comparison - matches wildcard *", () => {
+  const etag = '"abc123"';
+  const ifNoneMatch = "*";
+  assertEquals(compareETags(etag, ifNoneMatch), true);
+});
+
+Deno.test("ETag Comparison - handles undefined If-None-Match", () => {
+  const etag = '"abc123"';
+  assertEquals(compareETags(etag, undefined), false);
+});
+
+Deno.test("ETag Comparison - handles null If-None-Match", () => {
+  const etag = '"abc123"';
+  assertEquals(compareETags(etag, null), false);
+});
+
+Deno.test("ETag Comparison - handles empty string If-None-Match", () => {
+  const etag = '"abc123"';
+  assertEquals(compareETags(etag, ""), false);
+});
+
+Deno.test("Cache Headers - generates 'public, no-cache' by default", () => {
+  const etag = '"abc123"';
+  const headers = createCacheHeaders(etag);
+  assertEquals(headers["Cache-Control"], "public, no-cache");
+});
+
+Deno.test("Cache Headers - includes ETag header", () => {
+  const etag = '"abc123"';
+  const headers = createCacheHeaders(etag);
+  assertEquals(headers["ETag"], etag);
+});
+
+Deno.test("Cache Headers - respects noCache: false option", () => {
+  const etag = '"abc123"';
+  const headers = createCacheHeaders(etag, { noCache: false });
+  assertEquals("Cache-Control" in headers, false);
+  assertEquals(headers["ETag"], etag);
+});
+
+Deno.test("Cache Headers - respects public: false option", () => {
+  const etag = '"abc123"';
+  const headers = createCacheHeaders(etag, { public: false });
+  assertEquals(headers["Cache-Control"], "no-cache");
+});
+
+Deno.test("Cache Headers - respects both options together", () => {
+  const etag = '"abc123"';
+  const headers = createCacheHeaders(etag, {
+    noCache: false,
+    public: false,
+  });
+  assertEquals("Cache-Control" in headers, false);
+  assertEquals(headers["ETag"], etag);
+});
+
+Deno.test("StaticCache ETag - getWithETag returns both buffer and ETag", async () => {
+  const cache = new StaticCache();
+  const result = await cache.getWithETag("prompts/system.md");
+
+  assert(result.buffer instanceof Uint8Array);
+  assertEquals(typeof result.etag, "string");
+  assert(result.etag.startsWith('"') && result.etag.endsWith('"'));
+});
+
+Deno.test("StaticCache ETag - returns same ETag for same asset (caching works)", async () => {
+  const cache = new StaticCache();
+  const result1 = await cache.getWithETag("prompts/system.md");
+  const result2 = await cache.getWithETag("prompts/system.md");
+
+  assertEquals(result1.etag, result2.etag);
+  // Should be the exact same promise/object from cache
+  assert(result1 === result2 || result1.etag === result2.etag);
+});
+
+Deno.test("StaticCache ETag - get() method still works (backward compatibility)", async () => {
+  const cache = new StaticCache();
+  const buffer = await cache.get("prompts/system.md");
+
+  assert(buffer instanceof Uint8Array);
+  const text = decode(buffer);
+  assert(/# React Component Builder/.test(text));
+});
+
+Deno.test("StaticCache ETag - ETag is consistent for same content", async () => {
+  const cache = new StaticCache();
+  const result = await cache.getWithETag("prompts/system.md");
+
+  // Generate ETag directly from the buffer
+  const expectedETag = await generateETag(result.buffer);
+  assertEquals(result.etag, expectedETag);
+});
+
+Deno.test("StaticCache ETag - different assets have different ETags", async () => {
+  const cache = new StaticCache();
+  const result1 = await cache.getWithETag("prompts/system.md");
+  const result2 = await cache.getWithETag("types/es2023.d.ts");
+
+  assert(result1.etag !== result2.etag);
+});

--- a/packages/toolshed/routes/static/static.test.ts
+++ b/packages/toolshed/routes/static/static.test.ts
@@ -1,3 +1,5 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
 import { assert } from "@std/assert";
 import env from "@/env.ts";
 import createApp from "@/lib/create-app.ts";
@@ -9,13 +11,138 @@ if (env.ENV !== "test") {
 
 const app = createApp().route("/", router);
 
-Deno.test("static routes", async (t) => {
-  await t.step(
-    "GET /static/prompts/system.md returns 200 with prompt",
-    async () => {
-      const response = await app.request("/static/prompts/system.md");
-      assert(response.status === 200);
-      assert(/# React Component Builder/.test(await response.text()));
-    },
-  );
+describe("Static Routes", () => {
+  it("serves static files with correct content", async () => {
+    const response = await app.request("/static/prompts/system.md");
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(/# React Component Builder/.test(text)).toBe(true);
+  });
+});
+
+describe("ETag HTTP Responses", () => {
+  it("returns 200 with ETag header", async () => {
+    const response = await app.request("/static/prompts/system.md");
+    expect(response.status).toBe(200);
+
+    const etag = response.headers.get("ETag");
+    expect(etag).toBeTruthy();
+    expect(etag!.startsWith('"') && etag!.endsWith('"')).toBe(true);
+  });
+
+  it("returns 304 with matching If-None-Match", async () => {
+    // First request to get the ETag
+    const response1 = await app.request("/static/prompts/system.md");
+    const etag = response1.headers.get("ETag");
+    expect(etag).toBeTruthy();
+
+    // Second request with If-None-Match
+    const response2 = await app.request("/static/prompts/system.md", {
+      headers: {
+        "If-None-Match": etag!,
+      },
+    });
+    expect(response2.status).toBe(304);
+  });
+
+  it("returns 200 with non-matching If-None-Match", async () => {
+    const response = await app.request("/static/prompts/system.md", {
+      headers: {
+        "If-None-Match": '"non-matching-etag"',
+      },
+    });
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  it("includes Cache-Control: public, no-cache header", async () => {
+    const response = await app.request("/static/prompts/system.md");
+    const cacheControl = response.headers.get("Cache-Control");
+    expect(cacheControl).toBe("public, no-cache");
+  });
+
+  it("serves files with correct MIME types", async () => {
+    // Test TypeScript file
+    const tsResponse = await app.request("/static/types/es2023.d.ts");
+    const tsContentType = tsResponse.headers.get("Content-Type");
+    expect(tsContentType).toBeTruthy();
+
+    // Test Markdown file
+    const mdResponse = await app.request("/static/prompts/system.md");
+    const mdContentType = mdResponse.headers.get("Content-Type");
+    expect(mdContentType).toBeTruthy();
+  });
+});
+
+describe("Caching Behavior", () => {
+  it("returns same ETag for multiple requests", async () => {
+    const response1 = await app.request("/static/prompts/system.md");
+    const etag1 = response1.headers.get("ETag");
+
+    const response2 = await app.request("/static/prompts/system.md");
+    const etag2 = response2.headers.get("ETag");
+
+    expect(etag1).toBe(etag2);
+  });
+
+  it("returns empty body for 304 response", async () => {
+    // First request to get the ETag
+    const response1 = await app.request("/static/prompts/system.md");
+    const etag = response1.headers.get("ETag");
+    expect(etag).toBeTruthy();
+
+    // Second request with If-None-Match
+    const response2 = await app.request("/static/prompts/system.md", {
+      headers: {
+        "If-None-Match": etag!,
+      },
+    });
+
+    expect(response2.status).toBe(304);
+    const body = await response2.text();
+    expect(body).toBe("");
+  });
+
+  it("includes ETag header in 304 response", async () => {
+    // First request to get the ETag
+    const response1 = await app.request("/static/prompts/system.md");
+    const etag = response1.headers.get("ETag");
+    expect(etag).toBeTruthy();
+
+    // Second request with If-None-Match
+    const response2 = await app.request("/static/prompts/system.md", {
+      headers: {
+        "If-None-Match": etag!,
+      },
+    });
+
+    expect(response2.status).toBe(304);
+    const responseETag = response2.headers.get("ETag");
+    expect(responseETag).toBe(etag);
+  });
+
+  it("returns 304 for wildcard If-None-Match", async () => {
+    const response = await app.request("/static/prompts/system.md", {
+      headers: {
+        "If-None-Match": "*",
+      },
+    });
+    expect(response.status).toBe(304);
+  });
+
+  it("returns 304 for comma-separated If-None-Match with matching ETag", async () => {
+    // First request to get the ETag
+    const response1 = await app.request("/static/prompts/system.md");
+    const etag = response1.headers.get("ETag");
+    expect(etag).toBeTruthy();
+
+    // Second request with comma-separated list including the matching ETag
+    const response2 = await app.request("/static/prompts/system.md", {
+      headers: {
+        "If-None-Match": `"fake-etag-1", ${etag}, "fake-etag-2"`,
+      },
+    });
+    expect(response2.status).toBe(304);
+  });
 });


### PR DESCRIPTION
This should mean that when static assets are modified, clients immediately get the latest version.

When static assets are unchanged (via etag), they will return a 304 response from toolshed.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch static asset caching from time-based headers to strong ETag validation. Clients get updated assets immediately; unchanged assets return 304.

- **New Features**
  - Added ETag utilities (SHA-256 strong ETags, compareETags, createCacheHeaders with public, no-cache).
  - Updated StaticCache to compute/cache ETags; new getWithETag while get stays backward compatible.
  - Updated /static and compiled shell routes to send ETag, honor If-None-Match, and return 304 when unchanged.
  - Exported the ETag module and added tests for ETag generation, headers, 304 behavior, and MIME types.

<!-- End of auto-generated description by cubic. -->

