### PR TITLE
feat(runner): add abort/retry, full schemas, etc. to llm-dialog

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -288,7 +288,7 @@ export interface BuiltInLLMParams {
   tools?: Record<string, {
     description: string;
     inputSchema: JSONSchema;
-    handler?: (args: any) => any | Promise<any>;
+    handler: Stream<any> | OpaqueRef<any>;
   }>;
 }
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -265,7 +265,7 @@ export type BuiltInLLMMessage = {
 export interface BuiltInLLMTool {
   description: string;
   inputSchema: JSONSchema;
-  handler?: (args: any) => any | Promise<any>; // Client-side only
+  handler?: OpaqueRef<any> | Stream<any>; // Client-side only
 }
 
 // Built-in types

--- a/packages/charm/src/index.ts
+++ b/packages/charm/src/index.ts
@@ -38,7 +38,16 @@ export { type ParsedMention, type ProcessedPrompt } from "./imagine.ts";
 export { formatPromptWithMentions, parseComposerDocument } from "./format.ts";
 
 export const DEFAULT_MODEL = [
+  // "groq:llama-3.3-70b-specdec",
+  // "cerebras:llama-3.3-70b",
+  // "anthropic:claude-3-5-sonnet-latest",
   "anthropic:claude-sonnet-4-0",
+  // "gemini-2.0-flash",
+  // "gemini-2.0-flash-thinking",
+  // "gemini-2.0-pro",
+  // "o3-mini-low",
+  // "o3-mini-medium",
+  // "o3-mini-high",
 ][0];
 
 // Export workflow module

--- a/packages/charm/src/index.ts
+++ b/packages/charm/src/index.ts
@@ -38,16 +38,7 @@ export { type ParsedMention, type ProcessedPrompt } from "./imagine.ts";
 export { formatPromptWithMentions, parseComposerDocument } from "./format.ts";
 
 export const DEFAULT_MODEL = [
-  // "groq:llama-3.3-70b-specdec",
-  // "cerebras:llama-3.3-70b",
-  // "anthropic:claude-3-5-sonnet-latest",
   "anthropic:claude-sonnet-4-0",
-  // "gemini-2.0-flash",
-  // "gemini-2.0-flash-thinking",
-  // "gemini-2.0-pro",
-  // "o3-mini-low",
-  // "o3-mini-medium",
-  // "o3-mini-high",
 ][0];
 
 // Export workflow module

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -25,11 +25,13 @@ export const setLLMUrl = (toolshedUrl: string) => {
 export class LLMClient {
   async generateObject(
     request: LLMGenerateObjectRequest,
+    abortSignal?: AbortSignal,
   ): Promise<LLMGenerateObjectResponse> {
     const response = await fetch(llmApiUrl + "/generateObject", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(request),
+      signal: abortSignal,
     });
 
     if (!response.ok) {
@@ -55,6 +57,7 @@ export class LLMClient {
   async sendRequest(
     request: LLMRequest,
     callback?: PartialCallback,
+    abortSignal?: AbortSignal,
   ): Promise<LLMResponse> {
     if (request.stream && !callback) {
       throw new Error(
@@ -71,6 +74,7 @@ export class LLMClient {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(request),
+      signal: abortSignal,
     });
 
     if (!response.ok) {

--- a/packages/llm/src/prompts/charm-describe.ts
+++ b/packages/llm/src/prompts/charm-describe.ts
@@ -43,7 +43,7 @@ Provide your one-sentence description inside <description> tags.
  * @param spec - The specification/description of the web application.
  * @param code - The code of the web application.
  * @param schema - The schema of the web application.
- * @param model - The model to use to generate the description. (default: "anthropic:claude-3-7-sonnet-latest")
+ * @param model - The model to use to generate the description. (default: "anthropic:claude-sonnet-4-0")
  * @returns The generated description.
  */
 export async function describeCharm(

--- a/packages/llm/src/prompts/charm-suggestions.ts
+++ b/packages/llm/src/prompts/charm-suggestions.ts
@@ -81,7 +81,7 @@ export interface CharmSuggestion {
  * @param code - The code of the web app.
  * @param schema - The schema of the web app.
  * @param count - The number of charm suggestions to generate. (default: 3)
- * @param model - The model to use to generate the charm suggestions. (default: "anthropic:claude-3-7-sonnet-latest")
+ * @param model - The model to use to generate the charm suggestions. (default: "anthropic:claude-sonnet-4-0")
  * @returns The generated charm suggestions.
  */
 export async function generateCharmSuggestions(

--- a/packages/llm/src/prompts/code-and-schema-gen.ts
+++ b/packages/llm/src/prompts/code-and-schema-gen.ts
@@ -194,7 +194,7 @@ Return ONLY the requested XML tags, no other commentary.
  * Generates a schema and code from a goal.
  * @param goal The user's goal or request
  * @param existingSchema Optional existing schema to use as a basis
- * @param model Optional model identifier to use (defaults to claude-3-7-sonnet)
+ * @param model Optional model identifier to use (defaults to claude-sonnet-4-0)
  * @returns Object containing title, description, specification, schema
  */
 export async function generateCodeAndSchema(

--- a/packages/llm/src/prompts/recipe-fix.ts
+++ b/packages/llm/src/prompts/recipe-fix.ts
@@ -77,7 +77,7 @@ Remember to consider the context of the code running inside an iframe and ensure
  * @param code - The code of the web application.
  * @param schema - The schema of the web application.
  * @param error - The error stacktrace that resulted from running the code.
- * @param model - The model to use to generate the description. (default: "anthropic:claude-3-7-sonnet-latest")
+ * @param model - The model to use to generate the description. (default: "anthropic:claude-sonnet-4-0")
  * @returns The recipe.
  */
 export async function fixRecipePrompt(

--- a/packages/llm/src/prompts/spec-and-schema-gen.ts
+++ b/packages/llm/src/prompts/spec-and-schema-gen.ts
@@ -240,7 +240,7 @@ ${
  * Generates a complete specification, schema, and plan from a goal.
  * @param goal The user's goal or request
  * @param existingSchema Optional existing schema to use as a basis
- * @param model Optional model identifier to use (defaults to claude-3-7-sonnet)
+ * @param model Optional model identifier to use (defaults to claude-sonnet-4-0)
  * @returns Object containing title, description, specification, schema
  */
 export async function generateSpecAndSchema(
@@ -381,7 +381,7 @@ Based on this goal and the existing schema, please provide a title, description,
  * Generates a complete specification, schema, and plan from a goal.
  * @param goal The user's goal or request
  * @param existingSchema Optional existing schema to use as a basis
- * @param model Optional model identifier to use (defaults to claude-3-7-sonnet)
+ * @param model Optional model identifier to use (defaults to claude-sonnet-4-0)
  * @returns Object containing title, description, specification, schema
  */
 export async function generateSpecAndSchemaAndCode(

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -82,7 +82,7 @@ const resultSchema = {
   properties: {
     pending: { type: "boolean", default: false },
     addMessage: { ...LLMMessageSchema, asStream: true },
-    cancelGeneration: { ...LLMMessageSchema, asStream: true },
+    cancelGeneration: { asStream: true },
   },
   required: ["pending", "addMessage", "cancelGeneration"],
 } as const satisfies JSONSchema;

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -227,7 +227,7 @@ export function llmDialog(
   // This is called when the recipe containing this node is being stopped.
   addCancel(() => {
     // Abort the request if it's still pending.
-    abortController?.abort();
+    abortController?.abort("Recipe stopped");
 
     const tx = runtime.edit();
 
@@ -251,7 +251,7 @@ export function llmDialog(
       // (but this if branch will be skipped then).
       result = runtime.getCell(
         parentCell.space,
-        { llmDialog: cause },
+        { llmDialog: { result: cause } },
         resultSchema,
         tx,
       );
@@ -261,7 +261,7 @@ export function llmDialog(
       // to the same input cells will coordinate via the same cell.
       internal = runtime.getCell(
         parentCell.space,
-        { llmDialog: cause },
+        { llmDialog: { internal: cause } },
         internalSchema,
         tx,
       );
@@ -306,7 +306,7 @@ export function llmDialog(
 
           // Set up new request (abort existing ones just in case) by allocating
           // a new request Id and setting up a new abort controller.
-          abortController?.abort();
+          abortController?.abort("New request started");
           abortController = new AbortController();
           requestId = crypto.randomUUID();
           internal.withTx(tx).set({
@@ -357,7 +357,7 @@ export function llmDialog(
     ) {
       // We have a pending request and either something set pending to false or
       // another request started, so we have to abort this one.
-      abortController?.abort();
+      abortController?.abort("Another request started");
       requestId = undefined;
     }
   };

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -545,6 +545,7 @@ function startRequest(
             messagesCell.withTx(tx).push(
               assistantMessage as Schema<typeof LLMMessageSchema>,
             );
+            pending.withTx(tx).set(false);
           },
         );
       }

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -1,6 +1,12 @@
 import { isObject, isRecord } from "@commontools/utils/types";
 import { type JSONSchema } from "./builder/types.ts";
-import { type Cell, isCell, type MemorySpace } from "./cell.ts";
+import {
+  type Cell,
+  isCell,
+  isStream,
+  type MemorySpace,
+  type Stream,
+} from "./cell.ts";
 import {
   type LegacyAlias,
   type LegacyJSONCellLink,
@@ -48,6 +54,7 @@ export type NormalizedFullLink = NormalizedLink & IMemorySpaceAddress;
  */
 export type CellLink =
   | Cell<any>
+  | Stream<any>
   | SigilLink
   | QueryResultInternals
   | LegacyJSONCellLink // @deprecated
@@ -198,7 +205,7 @@ export function isLegacyAlias(value: any): value is LegacyAlias {
  * in various combinations.
  */
 export function parseLink(
-  value: Cell<any>,
+  value: Cell<any> | Stream<any>,
   base?: Cell | NormalizedLink,
 ): NormalizedFullLink;
 export function parseLink(
@@ -225,7 +232,7 @@ export function parseLink(
   // see userland "/".
   if (isQueryResultForDereferencing(value)) value = getCellOrThrow(value);
 
-  if (isCell(value)) return value.getAsNormalizedFullLink();
+  if (isCell(value) || isStream(value)) return value.getAsNormalizedFullLink();
 
   // Handle new sigil format
   if (isSigilLink(value)) {

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -145,6 +145,7 @@ export function isLink(
     isQueryResultForDereferencing(value) ||
     isAnyCellLink(value) ||
     isCell(value) ||
+    isStream(value) ||
     (isRecord(value) && "/" in value && typeof value["/"] === "string") // EntityId format
   );
 }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -505,7 +505,7 @@ export class Runner implements IRunner {
       if (!givenTx) {
         // Should be unnecessary as the start itself is read-only
         // TODO(seefeld): Enforce this by adding a read-only flag for tx
-        await tx.commit().then((error) => {
+        await tx.commit().then(({ error }) => {
           if (error) {
             logger.error("Error committing transaction", error);
           }

--- a/packages/seeder/cli.ts
+++ b/packages/seeder/cli.ts
@@ -17,7 +17,7 @@ const {
   "no-cache": noCache,
   "no-verify": noVerify,
   "no-report": noReport,
-  model = "anthropic:claude-3-7-sonnet-20250219",
+  model = "anthropic:claude-sonnet-4-0",
 } = parseArgs(
   Deno.args,
   {

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -172,7 +172,7 @@ export interface BuiltInLLMParams {
     tools?: Record<string, {
         description: string;
         inputSchema: JSONSchema;
-        handler?: (args: any) => any | Promise<any>;
+        handler: Stream<any> | OpaqueRef<any>;
     }>;
 }
 export interface BuiltInLLMState<T> {

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -151,7 +151,7 @@ export type BuiltInLLMMessage = {
 export interface BuiltInLLMTool {
     description: string;
     inputSchema: JSONSchema;
-    handler?: (args: any) => any | Promise<any>;
+    handler?: OpaqueRef<any> | Stream<any>;
 }
 export interface BuiltInLLMParams {
     messages?: BuiltInLLMMessage[];

--- a/packages/toolshed/routes/ai/llm/llm.routes.ts
+++ b/packages/toolshed/routes/ai/llm/llm.routes.ts
@@ -51,7 +51,7 @@ export const LLMRequestSchema = toZod<LLMRequest>().with({
   messages: z.array(MessageSchema) as any, // Trust our BuiltInLLMMessage = CoreMessage alignment
   system: z.string().optional(),
   model: z.string().openapi({
-    example: "claude-3-7-sonnet",
+    example: "claude-sonnet-4-0",
   }),
   maxTokens: z.number().optional(),
   stop: z.string().optional(),
@@ -181,7 +181,7 @@ export const generateText = createRoute({
         "application/json": {
           schema: LLMRequestSchema.openapi({
             example: {
-              model: "anthropic:claude-3-7-sonnet-latest",
+              model: "anthropic:claude-sonnet-4-0",
               system: "You are a pirate, make sure you talk like one.",
               stream: false,
               cache: true,


### PR DESCRIPTION
- Introduce robust request lifecycle control in `llm-dialog`:
  - Add `REQUEST_TIMEOUT` and internal request tracking via `internal` cell with `requestId` and `lastActivity`.
  - Implement `AbortController` support; abort previous in-flight request when a new message is sent or when `pending` is toggled off elsewhere.
  - Replace ad-hoc mutation with `safelyPerformUpdate(...)` that:
    - Uses `editWithRetry` and checks both `pending` and matching `requestId` before mutating.
    - Updates `lastActivity` on each successful write to guard stale writes.
  - Start requests through `startRequest(...)` (formerly `mainLogic(...)`) to make re-entry and restarts explicit and scoped by `requestId`.
  - Convert result surface to a single `result` cell holding:
    - `pending` boolean state
    - `addMessage` and `cancelGeneration` as stream fields
  - Drop messages submitted while a generation is pending (UI should disable send or repurpose to stop during generation).

- Stronger schema-driven safety and streams:
  - Define `LLMMessageSchema`, `LLMToolSchema`, `LLMParamsSchema`, `resultSchema`, and `internalSchema` using JSON Schema.
  - Use `inputsCell.asSchema(...)` for typed access and `Stream<>` for `addMessage`/`cancelGeneration`.
  - Update `link-utils.parseLink(...)` to accept `Stream` in addition to `Cell` so event handlers can be registered with stream links.

- Wire abort through LLM client:
  - Add `AbortSignal` support to `LLMClient.generateObject(...)` and `LLMClient.sendRequest(...)`.
  - Pass the active request’s `abortSignal` from `llm-dialog` into `sendRequest(...)`.

- Defaults and examples:
  - Update default model to `anthropic:claude-sonnet-4-0`.
  - Refresh API examples in `toolshed` routes to reference the new model.

- Minor/cleanup:
  - Import cleanups (use `import type` and centralize types), adjust to use `MemorySpace`, and align message pushes to schema-backed arrays.
  - Ensure error paths clear `pending` via `editWithRetry`.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds robust request lifecycle control to llm-dialog with abort/retry, request scoping, and schema-backed streams to prevent stale writes and cross-tab conflicts. Also updates the default model to anthropic:claude-sonnet-4-0 and adds AbortSignal support to the LLM client.

- New Features
  - Request lifecycle: Abort in-flight generations when a new message arrives or pending is cleared; track requestId and lastActivity with a 5‑minute timeout; safe writes via editWithRetry; explicit restarts via startRequest(...).
  - Result surface: Single result cell with pending plus addMessage and cancelGeneration as streams; messages sent while pending are ignored.
  - Schema and streams: JSON Schemas for messages/tools/params/result/internal; inputsCell.asSchema(...); parseLink(...) now accepts Stream for event handler registration.
  - LLM client: generateObject(...) and sendRequest(...) accept an AbortSignal; llm-dialog passes the active signal.
  - Defaults: Switch default model and API examples to anthropic:claude-sonnet-4-0.

- Migration
  - Tool handlers: BuiltInLLMParams.tools[].handler is now required and must be a Stream<any> or OpaqueRef<any> (not a function).
  - UI: Disable “send” during generation or use it to cancel; messages submitted while pending are dropped.
  - Consumers: Use the unified result cell and its addMessage/cancelGeneration streams instead of previous ad-hoc cells/links.
  - Optional: Pass an AbortSignal when calling LLMClient directly to support user-initiated cancel.

<!-- End of auto-generated description by cubic. -->

