### PR TITLE
Actually apply `model` in `chatbot-tools.tsx`

### DIFF
--- a/packages/patterns/chatbot-tools.tsx
+++ b/packages/patterns/chatbot-tools.tsx
@@ -273,6 +273,7 @@ export default recipe<LLMTestInput, LLMTestResult>(
       system: "You are a helpful assistant with some tools.",
       messages: chat,
       tools: tools,
+      model,
     });
 
     // Debug logging


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Pass the selected LLM model into the chat call so the correct model is used instead of the default. Fixes incorrect model selection in chatbot-tools.tsx.

<!-- End of auto-generated description by cubic. -->

