### PR TITLE
fix(runner): incorrectly detected and logged tx errors

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -505,7 +505,7 @@ export class Runner implements IRunner {
       if (!givenTx) {
         // Should be unnecessary as the start itself is read-only
         // TODO(seefeld): Enforce this by adding a read-only flag for tx
-        await tx.commit().then((error) => {
+        await tx.commit().then(({ error }) => {
           if (error) {
             logger.error("Error committing transaction", error);
           }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed transaction commit error handling in the runner by correctly reading the error field from tx.commit()’s result. This prevents false error logs for successful transactions.

<!-- End of auto-generated description by cubic. -->

