### PR TITLE
Fix ETag comparison to handle weak ETags from nginx compression

### DIFF
--- a/packages/static/test/etag-cache.test.ts
+++ b/packages/static/test/etag-cache.test.ts
@@ -79,6 +79,24 @@ Deno.test("ETag Comparison - handles empty string If-None-Match", () => {
   assertEquals(compareETags(etag, ""), false);
 });
 
+Deno.test("ETag Comparison - handles weak ETags (W/ prefix)", () => {
+  const etag = '"abc123"';
+  const ifNoneMatch = 'W/"abc123"';
+  assertEquals(compareETags(etag, ifNoneMatch), true);
+});
+
+Deno.test("ETag Comparison - handles weak ETags in server response", () => {
+  const etag = 'W/"abc123"';
+  const ifNoneMatch = '"abc123"';
+  assertEquals(compareETags(etag, ifNoneMatch), true);
+});
+
+Deno.test("ETag Comparison - handles both weak ETags", () => {
+  const etag = 'W/"abc123"';
+  const ifNoneMatch = 'W/"abc123"';
+  assertEquals(compareETags(etag, ifNoneMatch), true);
+});
+
 Deno.test("Cache Headers - generates 'public, no-cache' by default", () => {
   const etag = '"abc123"';
   const headers = createCacheHeaders(etag);

--- a/packages/toolshed/routes/static/static.test.ts
+++ b/packages/toolshed/routes/static/static.test.ts
@@ -145,4 +145,19 @@ describe("Caching Behavior", () => {
     });
     expect(response2.status).toBe(304);
   });
+
+  it("returns 304 for weak ETag match", async () => {
+    // First request to get the ETag
+    const response1 = await app.request("/static/prompts/system.md");
+    const etag = response1.headers.get("ETag");
+    expect(etag).toBeTruthy();
+
+    // Second request with weak ETag (W/ prefix)
+    const response2 = await app.request("/static/prompts/system.md", {
+      headers: {
+        "If-None-Match": `W/${etag}`,
+      },
+    });
+    expect(response2.status).toBe(304);
+  });
 });


### PR DESCRIPTION
When nginx applies compression (brotli/gzip), it converts strong ETags to weak ETags by adding the W/ prefix. Updated compareETags to strip the W/ prefix before comparison so that both weak and strong ETags work correctly for cache validation.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes ETag comparison to handle weak ETags (W/ prefix) added by nginx compression. Ensures proper 304 responses when If-None-Match or server ETags are weak.

- **Bug Fixes**
  - Normalized ETags in compareETags by stripping the W/ prefix before matching.
  - Added tests covering weak/strong combinations and an integration test confirming 304 on weak ETag match.

<!-- End of auto-generated description by cubic. -->

