### PR TITLE
fix(runner/scheduler): retry reactive actions on commit conflict

### DIFF
--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -78,7 +78,8 @@ export type SpaceAndURI = `${MemorySpace}/${URI}`;
 export type SpaceURIAndType = `${MemorySpace}/${URI}/${MediaType}`;
 
 const MAX_ITERATIONS_PER_RUN = 100;
-const DEFAULT_RETRIES = 5;
+const DEFAULT_RETRIES_FOR_EVENTS = 5;
+const MAX_RETRIES_FOR_REACTIVE = 10;
 
 export class Scheduler implements IScheduler {
   private eventQueue: { action: Action; retriesLeft: number }[] = [];
@@ -88,6 +89,7 @@ export class Scheduler implements IScheduler {
   private dependencies = new WeakMap<Action, ReactivityLog>();
   private cancels = new WeakMap<Action, Cancel>();
   private triggers = new Map<SpaceAndURI, Map<Action, SortedAndCompactPaths>>();
+  private retries = new WeakMap<Action, number>();
 
   private idlePromises: (() => void)[] = [];
   private loopCounter = new WeakMap<Action, number>();
@@ -234,7 +236,28 @@ export class Scheduler implements IScheduler {
           }
         } finally {
           // Set up new reactive subscriptions after the action runs
-          tx.commit();
+          tx.commit().then(({ error }) => {
+            // On error, retry up to MAX_RETRIES_FOR_REACTIVE times. Note that
+            // on every attempt we still call the re-subscribe below, so that
+            // even after we run out of retries, this will be re-triggered when
+            // input data changes.
+            if (error) {
+              logger.info("Error committing transaction", error);
+
+              if (!this.retries.has(action)) this.retries.set(action, 1);
+              else this.retries.set(action, this.retries.get(action)! + 1);
+
+              if (this.retries.get(action)! < MAX_RETRIES_FOR_REACTIVE) {
+                // Re-schedule the action to run again on conflict failure.
+                // (Empty dependencies are fine, since it's already being
+                // scheduled for execution.)
+                this.subscribe(action, { reads: [], writes: [] }, true);
+              }
+            } else {
+              // Clear retries after successful commit.
+              this.retries.delete(action);
+            }
+          });
           const log = txToReactivityLog(tx);
 
           logger.debug(() => [
@@ -283,7 +306,7 @@ export class Scheduler implements IScheduler {
   queueEvent(
     eventLink: NormalizedFullLink,
     event: any,
-    retries: number = DEFAULT_RETRIES,
+    retries: number = DEFAULT_RETRIES_FOR_EVENTS,
   ): void {
     for (const [link, handler] of this.eventHandlers) {
       if (areNormalizedLinksSame(link, eventLink)) {


### PR DESCRIPTION
Reactive actions were not retried when a transaction commit failed (e.g. due to conflicts), which could leave reactive flows stuck until a separate input change happened. This change aligns reactive behavior with event handlers and makes reactive actions resilient to transient commit failures.

Implementation:
- Introduce MAX_RETRIES_FOR_REACTIVE (10) and track attempts per action via a WeakMap.
- When tx.commit() returns an error, increment the counter and re-schedule the action immediately (subscribe with scheduleImmediately = true).
- Always re-subscribe after run so actions still re-trigger on future input changes, even after retry budget is exhausted.
- Clear retries on successful commit.

Tests:
- Add "reactive retries" suite in `packages/runner/test/scheduler.test.ts`.
- New test "should retry reactive actions when commit fails, up to limit" forces commit aborts inside a reactive action, asserts 10 total attempts (initial + 9 retries), and verifies that a subsequent input change triggers one additional run.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Retries reactive actions when tx.commit fails due to conflicts, so reactive flows don’t stall. Reactive behavior now matches event handler retries.

- **Bug Fixes**
  - On commit error, reschedule the reactive action immediately and retry up to 10 times.
  - Always re-subscribe after each run so future input changes still trigger.
  - Added tests for the retry limit and re-trigger after a later input change.

- **Refactors**
  - Separated retry constants: DEFAULT_RETRIES_FOR_EVENTS (still 5) and a new MAX_RETRIES_FOR_REACTIVE.
  - Track per-action retry attempts in a WeakMap and clear on successful commit.

<!-- End of auto-generated description by cubic. -->

