### PR TITLE
feat: Initial JS sandbox primitives.

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -11,6 +11,7 @@
     "./packages/iframe-sandbox",
     "./packages/integration",
     "./packages/js-runtime",
+    "./packages/js-sandbox",
     "./packages/schema-generator",
     "./packages/llm",
     "./packages/memory",

--- a/deno.lock
+++ b/deno.lock
@@ -67,20 +67,21 @@
     "npm:@arizeai/openinference-semantic-conventions@^1.1.0": "1.1.0",
     "npm:@arizeai/openinference-vercel@^2.0.1": "2.3.1_@opentelemetry+api@1.9.0",
     "npm:@babel/standalone@^7.28.2": "7.28.2",
-    "npm:@codemirror/autocomplete@^6.15.0": "6.18.6",
+    "npm:@codemirror/autocomplete@^6.15.0": "6.18.7",
     "npm:@codemirror/lang-css@^6.3.1": "6.3.1",
     "npm:@codemirror/lang-html@^6.4.9": "6.4.9",
     "npm:@codemirror/lang-javascript@^6.2.2": "6.2.4",
     "npm:@codemirror/lang-json@^6.0.1": "6.0.2",
-    "npm:@codemirror/lang-markdown@^6.3.0": "6.3.3",
-    "npm:@codemirror/language@^6.10.8": "6.11.2",
+    "npm:@codemirror/lang-markdown@^6.3.0": "6.3.4",
+    "npm:@codemirror/language@^6.10.8": "6.11.3",
     "npm:@codemirror/state@^6.5.1": "6.5.2",
     "npm:@codemirror/theme-one-dark@^6.1.2": "6.1.3",
-    "npm:@codemirror/view@^6.26.0": "6.38.1",
+    "npm:@codemirror/view@^6.26.0": "6.38.2",
     "npm:@fal-ai/client@^1.2.2": "1.6.1",
     "npm:@hono/sentry@^1.2.0": "1.2.2_hono@4.8.10",
     "npm:@hono/zod-openapi@~0.18.3": "0.18.4_hono@4.8.10_zod@3.25.76",
     "npm:@hono/zod-validator@~0.4.2": "0.4.3_hono@4.8.10_zod@3.25.76",
+    "npm:@jitl/quickjs-singlefile-mjs-debug-sync@*": "0.31.0",
     "npm:@lit/context@^1.1.2": "1.1.6",
     "npm:@lit/context@^1.1.5": "1.1.6",
     "npm:@lit/task@^1.0.2": "1.0.3",
@@ -117,6 +118,7 @@
     "npm:pino-pretty@13": "13.0.0",
     "npm:pino@^9.6.0": "9.7.0",
     "npm:plaid@36": "36.0.0",
+    "npm:quickjs-emscripten-core@*": "0.31.0",
     "npm:react-dom@^18.3.1": "18.3.1_react@18.3.1",
     "npm:react@^18.3.1": "18.3.1",
     "npm:source-map-js@^1.2.1": "1.2.1",
@@ -494,8 +496,8 @@
     "@babel/standalone@7.28.2": {
       "integrity": "sha512-1kjA8XzBRN68HoDDYKP38bucHtxYWCIX8XdYwe1drRNUOjOVNt8EMy9jiE6UwaGFfU7NOHCG+C8KgBc9CR08nA=="
     },
-    "@codemirror/autocomplete@6.18.6": {
-      "integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
+    "@codemirror/autocomplete@6.18.7": {
+      "integrity": "sha512-8EzdeIoWPJDsMBwz3zdzwXnUpCzMiCyz5/A3FIPpriaclFCGDkAzK13sMcnsu5rowqiyeQN2Vs2TsOcoDPZirQ==",
       "dependencies": [
         "@codemirror/language",
         "@codemirror/state",
@@ -555,8 +557,8 @@
         "@lezer/json"
       ]
     },
-    "@codemirror/lang-markdown@6.3.3": {
-      "integrity": "sha512-1fn1hQAPWlSSMCvnF810AkhWpNLkJpl66CRfIy3vVl20Sl4NwChkorCHqpMtNbXr1EuMJsrDnhEpjZxKZ2UX3A==",
+    "@codemirror/lang-markdown@6.3.4": {
+      "integrity": "sha512-fBm0BO03azXnTAsxhONDYHi/qWSI+uSEIpzKM7h/bkIc9fHnFp9y7KTMXKON0teNT97pFhc1a9DQTtWBYEZ7ug==",
       "dependencies": [
         "@codemirror/autocomplete",
         "@codemirror/lang-html",
@@ -567,8 +569,8 @@
         "@lezer/markdown"
       ]
     },
-    "@codemirror/language@6.11.2": {
-      "integrity": "sha512-p44TsNArL4IVXDTbapUmEkAlvWs2CFQbcfc0ymDsis1kH2wh0gcY96AS29c/vp2d0y2Tquk1EDSaawpzilUiAw==",
+    "@codemirror/language@6.11.3": {
+      "integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
       "dependencies": [
         "@codemirror/state",
         "@codemirror/view",
@@ -609,8 +611,8 @@
         "@lezer/highlight"
       ]
     },
-    "@codemirror/view@6.38.1": {
-      "integrity": "sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==",
+    "@codemirror/view@6.38.2": {
+      "integrity": "sha512-bTWAJxL6EOFLPzTx+O5P5xAO3gTqpatQ2b/ARQ8itfU/v2LlpS3pH2fkL0A3E/Fx8Y2St2KES7ZEV0sHTsSW/A==",
       "dependencies": [
         "@codemirror/state",
         "crelt",
@@ -826,6 +828,15 @@
         "zod"
       ]
     },
+    "@jitl/quickjs-ffi-types@0.31.0": {
+      "integrity": "sha512-1yrgvXlmXH2oNj3eFTrkwacGJbmM0crwipA3ohCrjv52gBeDaD7PsTvFYinlAnqU8iPME3LGP437yk05a2oejw=="
+    },
+    "@jitl/quickjs-singlefile-mjs-debug-sync@0.31.0": {
+      "integrity": "sha512-z7umztXCfzbPPAN0loy1GJKgns2Jp4P4isGoEJaKR/+Hq6IsksXvsbZ8cUG8uFMzr0IxZ6MQBTGdxRVVJrLrsA==",
+      "dependencies": [
+        "@jitl/quickjs-ffi-types"
+      ]
+    },
     "@lezer/common@1.2.3": {
       "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA=="
     },
@@ -851,8 +862,8 @@
         "@lezer/lr"
       ]
     },
-    "@lezer/javascript@1.5.1": {
-      "integrity": "sha512-ATOImjeVJuvgm3JQ/bpo2Tmv55HSScE2MTPnKRMRIPx2cLhHGyX2VnqpHhtIV1tVzIjZDbcWQm+NCTF40ggZVw==",
+    "@lezer/javascript@1.5.3": {
+      "integrity": "sha512-jexmlKq5NpGiB7t+0QkyhSXRgaiab5YisHIQW9C7EcU19KSUsDguZe9WY+rmRDg34nXoNH2LQ4SxpC+aJUchSQ==",
       "dependencies": [
         "@lezer/common",
         "@lezer/highlight",
@@ -1829,6 +1840,12 @@
     "quick-format-unescaped@4.0.4": {
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
+    "quickjs-emscripten-core@0.31.0": {
+      "integrity": "sha512-oQz8p0SiKDBc1TC7ZBK2fr0GoSHZKA0jZIeXxsnCyCs4y32FStzCW4d1h6E1sE0uHDMbGITbk2zhNaytaoJwXQ==",
+      "dependencies": [
+        "@jitl/quickjs-ffi-types"
+      ]
+    },
     "react-dom@18.3.1_react@18.3.1": {
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dependencies": [
@@ -2084,6 +2101,12 @@
         "dependencies": [
           "npm:source-map-js@^1.2.1",
           "npm:typescript@*"
+        ]
+      },
+      "packages/js-sandbox": {
+        "dependencies": [
+          "npm:@jitl/quickjs-singlefile-mjs-debug-sync@*",
+          "npm:quickjs-emscripten-core@*"
         ]
       },
       "packages/llm": {

--- a/packages/js-sandbox/deno-web-test.config.ts
+++ b/packages/js-sandbox/deno-web-test.config.ts
@@ -1,0 +1,24 @@
+export default {
+  include: {
+    "../static/assets": "static",
+  },
+  esbuildConfig: {
+    supported: {
+      using: false,
+    },
+    external: [
+      "jsdom",
+      "source-map-support",
+      "canvas",
+      "inspector",
+    ],
+    tsconfigRaw: {
+      compilerOptions: {
+        // `useDefineForClassFields` is critical when using Lit
+        // with esbuild, even when not using decorators.
+        useDefineForClassFields: false,
+        experimentalDecorators: true,
+      },
+    },
+  },
+};

--- a/packages/js-sandbox/deno.json
+++ b/packages/js-sandbox/deno.json
@@ -1,0 +1,20 @@
+{
+  "name": "@commontools/js-sandbox",
+  "tasks": {
+    "test": {
+      "dependencies": [
+        "deno-test",
+        "browser-test"
+      ]
+    },
+    "deno-test": "deno test --unstable-raw-imports --allow-env --allow-read test/*.test.ts",
+    "browser-test": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts test/*.test.ts"
+  },
+  "imports": {
+    "quickjs-emscripten-core": "npm:quickjs-emscripten-core",
+    "@jitl/quickjs-singlefile-mjs-debug-sync": "npm:@jitl/quickjs-singlefile-mjs-debug-sync"
+  },
+  "exports": {
+    ".": "./mod.ts"
+  }
+}

--- a/packages/js-sandbox/mod.ts
+++ b/packages/js-sandbox/mod.ts
@@ -1,0 +1,3 @@
+export { RecipeSandbox } from "./recipe-sandbox.ts";
+export type { SandboxConfig, SandboxStats } from "./sandbox/mod.ts";
+export * from "./types.ts";

--- a/packages/js-sandbox/recipe-sandbox.ts
+++ b/packages/js-sandbox/recipe-sandbox.ts
@@ -1,0 +1,83 @@
+import { QuickJSHandle } from "./sandbox/quick.ts";
+import { type JsScript } from "@commontools/js-runtime";
+import { GuestMessage, SandboxValue } from "./types.ts";
+import { Sandbox, SandboxConfig, SandboxStats } from "./sandbox/mod.ts";
+
+type SandboxState = "unloaded" | "loaded" | "disposed";
+
+// A VM to execute recipe code.
+//
+// Before usage, `await RecipeSandbox.initialize()`
+// must be called at least once.
+//
+// Each sandbox can load a single recipe compiled with
+// `js-runtime`, and then loaded via `sandbox.load(..)`.
+// Functions exported by the typescript modules can be
+// then be invoked.
+export class RecipeSandbox {
+  #state: SandboxState;
+  #sandbox: Sandbox;
+  // Bundle function return value containing
+  // "main" property, and "exportMap" property.
+  #exports?: QuickJSHandle;
+
+  constructor(config: SandboxConfig = {}) {
+    this.#sandbox = new Sandbox(config);
+    this.#state = "unloaded";
+  }
+
+  messages(): GuestMessage[] {
+    return this.#sandbox.messages();
+  }
+
+  // Invoke function exported by load script.
+  invoke(
+    exportFile: string,
+    exportName: string,
+    args: SandboxValue[],
+  ): unknown {
+    if (this.#state !== "loaded" || !this.#exports) {
+      throw new Error(`Cannot invoke a non-loaded sandbox.`);
+    }
+    const vm = this.#sandbox.vm();
+    using exportMap = vm.getProp(this.#exports, "exportMap");
+    using fileExports = vm.getProp(exportMap, exportFile);
+    using fn = vm.getProp(fileExports, exportName);
+
+    return this.#sandbox.invoke(fn, vm.undefined, args);
+  }
+
+  // Load and evaluate a compiled recipe script within the sandbox.
+  load(module: JsScript): unknown {
+    if (this.#state !== "unloaded") {
+      throw new Error(`Cannot load script in ${this.#state} sandbox.`);
+    }
+    const vm = this.#sandbox.vm();
+    using result = this.#sandbox.loadRaw(module);
+    this.#exports = this.#sandbox.invokeRaw(result, vm.undefined, [{}]);
+    using main = vm.getProp(this.#exports, "main");
+    this.#state = "loaded";
+    return this.#sandbox.fromVm(main);
+  }
+
+  stats(): SandboxStats {
+    return this.#sandbox.stats();
+  }
+
+  [Symbol.dispose]() {
+    this.dispose();
+  }
+
+  dispose() {
+    if (this.#state === "disposed") {
+      return;
+    }
+    this.#state = "disposed";
+    if (this.#exports) this.#exports.dispose();
+    this.#sandbox.dispose();
+  }
+
+  static async initialize() {
+    await Sandbox.initialize();
+  }
+}

--- a/packages/js-sandbox/sandbox/bindings/bindings.ts
+++ b/packages/js-sandbox/sandbox/bindings/bindings.ts
@@ -1,0 +1,110 @@
+import { GuestMessage, isGuestMessage, SandboxValue } from "../../types.ts";
+import { QuickJSContext, QuickJSHandle } from "../quick.ts";
+import Script_00_Primordials from "./environment/00_primordials.js" with {
+  type: "text",
+};
+import Script_01_Console from "./environment/01_console.js" with {
+  type: "text",
+};
+import { fromVm, toVm } from "./encoding.ts";
+import { Primordials } from "./primordials.ts";
+
+// Order of scripts to be injected. Primordials
+// must be registered first, as they're used as args
+// for later injected scripts.
+const injectScripts = [
+  Script_01_Console,
+];
+
+export class Bindings {
+  #vm: QuickJSContext;
+  #primordials: Primordials;
+  #messages: GuestMessage[] = [];
+
+  constructor(vm: QuickJSContext) {
+    this.#vm = vm;
+
+    // Create IPC
+    using ipc = vm.newObject();
+    using sendHandle = vm.newFunction("send", (data) => {
+      this.#onGuestMessage(this.fromVm(data));
+    });
+    vm.setProp(ipc, "send", sendHandle);
+    vm.setProp(vm.global, "__ipc", ipc);
+
+    // Register primordials
+    this.#primordials = new Primordials(
+      vm,
+      vm.unwrapResult(
+        vm.evalCode(Script_00_Primordials),
+      ),
+    );
+
+    // Register other scripts
+    for (const script of injectScripts) {
+      using handle = vm.unwrapResult(
+        vm.evalCode(script),
+      );
+      vm.unwrapResult(
+        vm.callFunction(handle, vm.null, [this.#primordials.handle()]),
+      )
+        .dispose();
+    }
+  }
+
+  primordials(): Primordials {
+    return this.#primordials;
+  }
+
+  vm(): QuickJSContext {
+    return this.#vm;
+  }
+
+  drainMessages(): GuestMessage[] {
+    const messages = [...this.#messages];
+    this.#messages.length = 0;
+    return messages;
+  }
+
+  // Cast a value into the VM, returning an owned handle.
+  toVm(value: SandboxValue): QuickJSHandle {
+    return toVm(this, value);
+  }
+
+  // Cast a value from the VM.
+  fromVm(value: QuickJSHandle): SandboxValue {
+    return fromVm(this, value);
+  }
+
+  #onGuestMessage = (message: unknown) => {
+    if (!isGuestMessage(message)) {
+      let formatted;
+      try {
+        formatted = JSON.stringify(message);
+      } catch (e) {
+        if (
+          message && typeof message === "object" && "toString" in message &&
+          typeof message.toString === "function"
+        ) {
+          formatted = message.toString() as string;
+        } else {
+          formatted = message;
+        }
+      }
+      this.#messages.push({
+        type: "error",
+        error: `Received invalid message: ${formatted}`,
+      });
+      return;
+    }
+    this.#messages.push(message);
+  };
+
+  [Symbol.dispose]() {
+    this.dispose();
+  }
+
+  dispose() {
+    this.#primordials.dispose();
+  }
+}

--- a/packages/js-sandbox/sandbox/bindings/encoding.ts
+++ b/packages/js-sandbox/sandbox/bindings/encoding.ts
@@ -1,0 +1,75 @@
+import { QuickJSContext, QuickJSHandle } from "../quick.ts";
+import { SandboxValue } from "../../types.ts";
+import { Primordials } from "./primordials.ts";
+
+type BindingsProvider = {
+  vm(): QuickJSContext;
+  primordials(): Primordials;
+};
+
+export function toVm(
+  provider: BindingsProvider,
+  input: SandboxValue,
+): QuickJSHandle {
+  const vm = provider.vm();
+  const primordials = provider.primordials();
+  switch (typeof input) {
+    case "undefined": {
+      return vm.undefined;
+    }
+    case "number": {
+      return vm.newNumber(input);
+    }
+    case "boolean": {
+      return input ? vm.true : vm.false;
+    }
+    case "string": {
+      return vm.newString(input);
+    }
+    case "object": {
+      if (input === null) {
+        return vm.null;
+      } else if (input instanceof Uint8Array) {
+        return primordials.newUint8Array(input.buffer as ArrayBuffer);
+      } else if (Array.isArray(input)) {
+        const array = vm.newArray();
+        for (let i = 0; i < input.length; i++) {
+          using child = toVm(provider, input[i] as SandboxValue);
+          vm.setProp(array, i, child);
+        }
+        return array;
+      } else {
+        const obj = vm.newObject();
+        for (const [key, value] of Object.entries(input)) {
+          using child = toVm(provider, value as SandboxValue);
+          vm.setProp(obj, key, child);
+        }
+        return obj;
+      }
+    }
+    default: {
+      throw new Error("Cannot serialize type.");
+    }
+  }
+}
+
+// Currently, we use the VM's `dump` method to essentially
+// JSON stringify/parse the value from the VM. This fails
+// to translate complex objects like Uint8Array or Map.
+//
+// Options to marshall e.g. a typed array from the VM, all
+// involving overhead compared to `dump`, a challenge to support
+// both Uint8Array in a nested object, as well as large arrays
+// with polymorphic values:
+//
+// * Manually walk a value graph: would require many calls to the VM
+// for type inspection.
+// * Parse once in VM with sigils: We could replace complex
+// objects that can be represented by some internal symbol
+// e.g. `{ @SandboxType: "uint8array", value: Uint8Array }`
+export function fromVm(
+  provider: BindingsProvider,
+  input: QuickJSHandle,
+): any {
+  return provider.vm().dump(input);
+}

--- a/packages/js-sandbox/sandbox/bindings/environment/00_primordials.js
+++ b/packages/js-sandbox/sandbox/bindings/environment/00_primordials.js
@@ -1,0 +1,38 @@
+// A collection of native references to store
+// before introducing user-code to ensure the host
+// is calling the original values.
+//
+// Primordials are used mainly in two ways:
+// * Provided to other injected environment scripts
+//   (e.g. FunctionBind for binding console methods)
+// * Invoked by host to marshall types between environments
+//   (e.g. using the VM's Uint8Array to pass a typed array
+//   into the VM)
+(() => {
+  const IpcSend = __ipc.send;
+
+  // From (both) Deno and Node, they maintain very similar collection of
+  // primordials. We use the `uncurryThis` utility to handle Function.prototype.bind
+  // for now.
+  // https://github.com/nodejs/node/blob/f1a8f447d7363e9a5e1c412c1a425a9771bc691f/lib/internal/per_context/primordials.js
+  //
+  // `uncurryThis` is equivalent to `func => Function.prototype.call.bind(func)`.
+  // It is using `bind.bind(call)` to avoid using `Function.prototype.bind`
+  // and `Function.prototype.call` after it may have been mutated by users.
+  const { bind, call } = Function.prototype;
+  const uncurryThis = bind.bind(call);
+
+  const FunctionBind = uncurryThis(Function.prototype.bind);
+  const ObjectCreate = Object.create;
+  const ObjectFreeze = Object.freeze;
+  const Uint8ArrayConstructor = Uint8Array;
+
+  return {
+    IpcSend,
+
+    FunctionBind,
+    NewUint8Array: (...args) => new Uint8ArrayConstructor(...args),
+    ObjectCreate,
+    ObjectFreeze,
+  };
+})();

--- a/packages/js-sandbox/sandbox/bindings/environment/01_console.js
+++ b/packages/js-sandbox/sandbox/bindings/environment/01_console.js
@@ -1,0 +1,38 @@
+((PRIMORDIALS) => {
+  const methods = [
+    "assert",
+    "clear",
+    "count",
+    "countReset",
+    "debug",
+    "dir",
+    "dirxml",
+    "error",
+    "group",
+    "groupCollapsed",
+    "groupEnd",
+    "info",
+    "log",
+    "table",
+    "time",
+    "timeEnd",
+    "timeLog",
+    "timeStamp",
+    "trace",
+    "warn",
+  ];
+
+  const console = globalThis.console = PRIMORDIALS.ObjectCreate(null);
+  for (const method of methods) {
+    console[method] = PRIMORDIALS.FunctionBind(consoleHandler, console, method);
+  }
+  PRIMORDIALS.ObjectFreeze(console);
+
+  function consoleHandler(method, ...args) {
+    PRIMORDIALS.IpcSend({
+      type: "console",
+      method,
+      args,
+    });
+  }
+});

--- a/packages/js-sandbox/sandbox/bindings/mod.ts
+++ b/packages/js-sandbox/sandbox/bindings/mod.ts
@@ -1,0 +1,1 @@
+export { Bindings } from "./bindings.ts";

--- a/packages/js-sandbox/sandbox/bindings/primordials.ts
+++ b/packages/js-sandbox/sandbox/bindings/primordials.ts
@@ -1,0 +1,30 @@
+import { QuickJSContext, QuickJSHandle } from "../quick.ts";
+
+export class Primordials {
+  #vm: QuickJSContext;
+  #handle: QuickJSHandle;
+  constructor(vm: QuickJSContext, handle: QuickJSHandle) {
+    this.#vm = vm;
+    this.#handle = handle;
+  }
+
+  handle(): QuickJSHandle {
+    return this.#handle;
+  }
+
+  newUint8Array(input: ArrayBuffer): QuickJSHandle {
+    const vm = this.#vm;
+    using arrayBuffer = vm.newArrayBuffer(input);
+    return vm.unwrapResult(
+      vm.callMethod(this.#handle, "NewUint8Array", [arrayBuffer]),
+    );
+  }
+
+  [Symbol.dispose]() {
+    this.dispose();
+  }
+
+  dispose() {
+    this.#handle.dispose();
+  }
+}

--- a/packages/js-sandbox/sandbox/mod.ts
+++ b/packages/js-sandbox/sandbox/mod.ts
@@ -1,0 +1,7 @@
+export {
+  DEFAULT_MEMORY_LIMIT,
+  DEFAULT_STACK_SIZE,
+  Sandbox,
+  type SandboxConfig,
+  type SandboxStats,
+} from "./sandbox.ts";

--- a/packages/js-sandbox/sandbox/quick.ts
+++ b/packages/js-sandbox/sandbox/quick.ts
@@ -1,0 +1,19 @@
+/**
+ * quickjs-emscripten bundles 4 runtimes ([release|debug] x [sync|async])
+ * in its package. Use a specific release and expose a similar interface
+ * from this quick.ts wrapper.
+ */
+import {
+  newQuickJSWASMModuleFromVariant,
+  QuickJSWASMModule,
+} from "quickjs-emscripten-core";
+
+export * from "quickjs-emscripten-core";
+
+export async function getQuickJS(): Promise<QuickJSWASMModule> {
+  return await newQuickJSWASMModuleFromVariant(
+    // Use `singlefile` version in lieu of needing to handle
+    // the wasm artifact separately across various build types
+    import("@jitl/quickjs-singlefile-mjs-debug-sync"),
+  );
+}

--- a/packages/js-sandbox/sandbox/sandbox.ts
+++ b/packages/js-sandbox/sandbox/sandbox.ts
@@ -1,0 +1,173 @@
+import { Bindings } from "./bindings/mod.ts";
+import {
+  DefaultIntrinsics,
+  getQuickJS,
+  type QuickJSContext,
+  QuickJSHandle,
+  type QuickJSRuntime,
+  type QuickJSWASMModule,
+} from "./quick.ts";
+import { GuestMessage, SandboxValue } from "../types.ts";
+import { Primordials } from "./bindings/primordials.ts";
+
+export interface SandboxStats {
+  memoryUsed: number;
+}
+
+export const DEFAULT_MEMORY_LIMIT = 1024 * 640;
+export const DEFAULT_STACK_SIZE = 1024 * 320;
+
+export interface SandboxConfig {
+  // The runtime memory limit, in bytes.
+  memoryLimit?: number;
+  // The maximum stack size allowed, in bytes.
+  stackSize?: number;
+}
+
+let QuickJS: QuickJSWASMModule | undefined;
+
+export class Sandbox {
+  #bindings: Bindings;
+  #rt: QuickJSRuntime;
+  #vm: QuickJSContext;
+  #disposed: boolean;
+
+  constructor(config: SandboxConfig = {}) {
+    if (!QuickJS) {
+      throw new Error("Sandbox.initialize() must be called before use.");
+    }
+    const rt = QuickJS.newRuntime({
+      memoryLimitBytes: config.memoryLimit ?? DEFAULT_MEMORY_LIMIT,
+      maxStackSizeBytes: config.stackSize ?? DEFAULT_STACK_SIZE,
+    });
+    this.#vm = rt.newContext({
+      // Disable some intrinsics that we cannot yet
+      // marshall back to the host
+      intrinsics: {
+        ...DefaultIntrinsics,
+        BigDecimal: false,
+        BigInt: false,
+        BigFloat: false,
+        BignumExt: false,
+        OperatorOverloading: false,
+        Proxy: false,
+        Promise: false,
+        // This prevents `vm.evalCode` from working!
+        // Eval: false,
+      },
+    });
+    this.#rt = rt;
+    this.#bindings = new Bindings(this.#vm);
+    this.#disposed = false;
+  }
+
+  stats(): SandboxStats {
+    using handle = this.#rt.computeMemoryUsage();
+    const usage = this.#vm.dump(handle);
+    return {
+      memoryUsed: usage.memory_used_size as number,
+    };
+  }
+
+  vm(): QuickJSContext {
+    return this.#vm;
+  }
+
+  primordials(): Primordials {
+    return this.#bindings.primordials();
+  }
+
+  messages(): GuestMessage[] {
+    return this.#bindings.drainMessages();
+  }
+
+  // Invoke a function handle, optionally casting values to the VM,
+  // and returning result as a SandboxValue.
+  invoke(
+    fn: QuickJSHandle,
+    self: QuickJSHandle,
+    args: QuickJSHandle[] | SandboxValue[],
+  ): SandboxValue {
+    using result = this.invokeRaw(fn, self, args);
+    return this.#bindings.fromVm(result);
+  }
+
+  // Invoke a function handle, returning an owned handle.
+  invokeRaw(
+    fn: QuickJSHandle,
+    self: QuickJSHandle,
+    args: QuickJSHandle[] | SandboxValue[],
+  ): QuickJSHandle {
+    const argsAreHandles = args.length > 0 &&
+      (typeof args[0] === "object" && args[0] && "dispose" in args[0] &&
+        typeof args[0].dispose === "function");
+
+    const input = argsAreHandles
+      ? args as QuickJSHandle[]
+      : args.map((arg) => this.#bindings.toVm(arg));
+    const result = this.#vm.unwrapResult(
+      this.#vm.callFunction(
+        fn,
+        self,
+        input,
+      ),
+    );
+    if (!argsAreHandles) {
+      for (const arg of input) arg.dispose();
+    }
+    return result;
+  }
+
+  // Invoke a global function by its global name.
+  invokeGlobal(
+    global: string,
+    self: QuickJSHandle,
+    args: QuickJSHandle[] | SandboxValue[],
+  ): SandboxValue {
+    using fn = this.#vm.getProp(this.#vm.global, global);
+    return this.invoke(fn, self, args);
+  }
+
+  // Load a raw (non-compiled recipe) script.
+  // Returns an owned reference to the return value.
+  loadRaw(script: string | { js: string; filename?: string }): QuickJSHandle {
+    if (this.#disposed) {
+      throw new Error(`Sandbox already disposed.`);
+    }
+    const { js, filename } = typeof script === "object"
+      ? script
+      : { js: script };
+    const result = this.#vm.unwrapResult(
+      this.#vm.evalCode(js, filename),
+    );
+    return result;
+  }
+
+  [Symbol.dispose]() {
+    this.dispose();
+  }
+
+  toVm(value: SandboxValue): QuickJSHandle {
+    return this.#bindings.toVm(value);
+  }
+
+  fromVm(value: QuickJSHandle): SandboxValue {
+    return this.#bindings.fromVm(value);
+  }
+
+  dispose() {
+    if (this.#disposed) {
+      return;
+    }
+    this.#disposed = true;
+    this.#bindings.dispose();
+    this.#vm.dispose();
+    this.#rt.dispose();
+  }
+
+  static async initialize() {
+    if (!QuickJS) {
+      QuickJS = await getQuickJS();
+    }
+  }
+}

--- a/packages/js-sandbox/test/console.test.ts
+++ b/packages/js-sandbox/test/console.test.ts
@@ -1,0 +1,40 @@
+import { Sandbox } from "../sandbox/mod.ts";
+import { assertEquals } from "@std/assert";
+
+const SCRIPT = {
+  js: `
+globalThis.callConsole = (method, ...args) => {
+  if (method in globalThis.console) {
+    globalThis.console[method](...args);
+  }
+};
+`,
+};
+
+Deno.test("sandbox - console hooks", async function () {
+  await Sandbox.initialize();
+  using sandbox = new Sandbox();
+  sandbox.loadRaw(SCRIPT).dispose();
+  const messages = sandbox.messages();
+  assertEquals(messages.length, 0);
+
+  const args = [
+    "helloworld",
+    10,
+    // `undefined` is cast to null when nested.
+    //undefined,
+    null,
+    {
+      "bar": 2,
+    },
+  ] as [string, number, null, Record<string, number | undefined>];
+
+  sandbox.invokeGlobal("callConsole", sandbox.vm().undefined, ["log", ...args]);
+
+  const message = sandbox.messages().pop()!;
+  assertEquals(message, {
+    type: "console",
+    method: "log",
+    args,
+  }, "Fires a console message with args.");
+});

--- a/packages/js-sandbox/test/recipe-sandbox.test.ts
+++ b/packages/js-sandbox/test/recipe-sandbox.test.ts
@@ -1,0 +1,39 @@
+import { RecipeSandbox, SandboxValue } from "../mod.ts";
+import { assert, assertEquals } from "@std/assert";
+import { compile } from "./utils.ts";
+import { expect } from "@std/expect";
+
+const SCRIPT = await compile(`
+export const reflectArgs = (...args: any[]) => args;
+export default "mainexport";
+`);
+
+Deno.test("RecipeSandbox - state", async function () {
+  await RecipeSandbox.initialize();
+  const sandbox = new RecipeSandbox();
+  expect(() => sandbox.invoke("no", "no", [])).toThrow();
+  sandbox.load(SCRIPT);
+  expect(() => sandbox.load(SCRIPT)).toThrow();
+  sandbox.dispose();
+  sandbox.dispose();
+  expect(() => sandbox.invoke("no", "no", [])).toThrow();
+});
+
+Deno.test("RecipeSandbox - main export", async function () {
+  await RecipeSandbox.initialize();
+  using sandbox = new RecipeSandbox();
+  const main = sandbox.load(SCRIPT);
+  assert(main && typeof main === "object" && "default" in main);
+  assert(main.default === "mainexport", "Load returns the main export.");
+});
+
+Deno.test("RecipeSandbox - invoke", async function () {
+  await RecipeSandbox.initialize();
+  using sandbox = new RecipeSandbox();
+  sandbox.load(SCRIPT);
+  assertEquals(sandbox.invoke("/main.tsx", "reflectArgs", [1, "hi", false]), [
+    1,
+    "hi",
+    false,
+  ], "Invokes function by bundle filename and export.");
+});

--- a/packages/js-sandbox/test/sandbox.test.ts
+++ b/packages/js-sandbox/test/sandbox.test.ts
@@ -1,0 +1,101 @@
+import { SandboxValue } from "../mod.ts";
+import { Sandbox } from "../sandbox/mod.ts";
+import { assert, assertEquals } from "@std/assert";
+
+const SCRIPT = `
+globalThis.reflectArgs = (...args) => args;
+`;
+
+Deno.test("Sandbox - types", async function () {
+  await Sandbox.initialize();
+  using sandbox = new Sandbox();
+  sandbox.loadRaw({ js: SCRIPT }).dispose();
+
+  function invoke(arg: SandboxValue): any {
+    const result = sandbox.invokeGlobal("reflectArgs", sandbox.vm().undefined, [
+      arg,
+    ]);
+    if (!Array.isArray(result)) {
+      throw new Error("Expected array result");
+    }
+    return result[0];
+  }
+
+  assertEquals(invoke(5), 5, "reflects numbers.");
+  assertEquals(invoke("hi"), "hi", "reflects strings.");
+  assertEquals(invoke(true), true, "reflects `true`.");
+  assertEquals(invoke(false), false, "reflects `false`.");
+  assertEquals(invoke(null), null, "reflects `null`.");
+  // `undefined` in an array when returned from a sandboxed function casts to null.(???)
+  assertEquals(invoke(undefined), null, "reflects `undefined`.");
+  assertEquals(invoke({ foo: 1, bar: { baz: 2 } }), {
+    foo: 1,
+    bar: { baz: 2 },
+  }, "reflects objects.");
+  assertEquals(invoke([1, 2, 3]), [1, 2, 3], "reflects arrays.");
+});
+
+Deno.test("Sandbox - environment", async function () {
+  await Sandbox.initialize();
+  using sandbox = new Sandbox();
+
+  sandbox.loadRaw(`
+  globalThis.assert = (cond, message) => {
+    if (!cond) throw new Error("Assertion failed: " + message); }`).dispose();
+
+  const supported: [string, string][] = [
+    ["JSON.parse()", "JSON.parse('{\"a\":5}')"],
+    ["JSON.stringify()", "JSON.stringify({a:5})"],
+    ["Date.now()", "Date.now()"],
+    ["eval()", "eval('1+1')"], // we must support `eval` for `vm.evalCode` to even work
+    ["new Uint8Array()", "new Uint8Array([1,2,3])"],
+  ];
+  check(supported, true);
+
+  const unsupported: [string, string][] = [
+    ["new Promise()", "new Promise()"],
+    ["BigInt()", "BigInt(100000000000)"],
+  ];
+  check(unsupported, false);
+
+  function check(cases: [string, string][], expectToPass: boolean) {
+    for (const [name, testCase] of cases) {
+      let thrown = false;
+      try {
+        sandbox.loadRaw(testCase).dispose();
+      } catch (e) {
+        thrown = true;
+      }
+      assert(
+        expectToPass !== thrown,
+        `${name} is${expectToPass ? "" : "not"} supported in the environment.`,
+      );
+    }
+  }
+});
+
+Deno.test("Sandbox - primordials", async function () {
+  await Sandbox.initialize();
+  using sandbox = new Sandbox();
+  // Clobber global
+  sandbox.loadRaw(
+    `globalThis.Uint8Array = function Uint8Array() { throw new Error("USERLAND") }`,
+  ).dispose();
+
+  using handle = sandbox.primordials().newUint8Array(
+    new Uint8Array([1, 2, 3]).buffer,
+  );
+  sandbox.loadRaw(`globalThis.testUint8Array = function test(input) {
+    if (input instanceof Uint8Array) return 0;
+    const array = Array.from(input);
+    if (array[0] !== 1 || array[1] !== 2 || array[2] !== 3) return 0;
+    return 1;
+  }`).dispose();
+  const result = sandbox.invokeGlobal("testUint8Array", sandbox.vm().null, [
+    handle,
+  ]);
+  assert(
+    result === 1,
+    "Primordial Uint8Array was used instead of userland.",
+  );
+});

--- a/packages/js-sandbox/test/utils.ts
+++ b/packages/js-sandbox/test/utils.ts
@@ -1,0 +1,27 @@
+import {
+  getTypeScriptEnvironmentTypes,
+  InMemoryProgram,
+  JsScript,
+  TypeScriptCompiler,
+} from "@commontools/js-runtime";
+import { StaticCache } from "@commontools/static";
+
+const types = await getTypeScriptEnvironmentTypes(new StaticCache());
+
+export async function compile(
+  code: string | Record<string, string>,
+): Promise<JsScript> {
+  const compiler = new TypeScriptCompiler(types);
+  const program = new InMemoryProgram(
+    "/main.tsx",
+    typeof code === "string"
+      ? {
+        "/main.tsx": code,
+      }
+      : code,
+  );
+  const compiled = await compiler.resolveAndCompile(program, {
+    bundleExportAll: true,
+  });
+  return compiled;
+}

--- a/packages/js-sandbox/types.ts
+++ b/packages/js-sandbox/types.ts
@@ -1,0 +1,38 @@
+import { isRecord } from "@commontools/utils/types";
+
+export type SandboxValue =
+  | null
+  | undefined
+  | boolean
+  | number
+  | string
+  | object
+  | Array<SandboxValue>;
+
+export type GuestMessage = {
+  type: "error";
+  error: string;
+} | {
+  type: "console";
+  method: string;
+  args: unknown[];
+};
+
+export type HostMessage = {
+  type: "invoke";
+  export: string;
+};
+
+export function isGuestMessage(value: unknown): value is GuestMessage {
+  if (
+    !isRecord(value) || !("type" in value) || typeof value.type !== "string"
+  ) {
+    return false;
+  }
+
+  return value.type === "console"
+    ? typeof value.method === "string" && Array.isArray(value.args)
+    : value.type === "error"
+    ? typeof value.error === "string"
+    : false;
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Introduces a new QuickJS-powered JavaScript sandbox package to run bundled TypeScript in a WASM VM with console capture and safe invocation of exports.

- **New Features**
  - Added @commontools/js-sandbox with a Sandbox class.
    - Initialize via Sandbox.initialize(), then load JsScript and invoke named exports.
    - Serializes basic values, arrays, and plain objects into VM handles.
    - Captures console.* calls and exposes them via messages().
    - Enforces memory and stack limits; supports dispose() to free resources.
  - Console bindings to forward console methods to the host.
  - IPC scaffold and type-safe GuestMessage validation.
  - QuickJS wrapper to load the release-sync variant consistently.
  - Basic tests covering load, console message capture, and function invocation.

- **Dependencies**
  - Added quickjs-emscripten-core and @jitl/quickjs-wasmfile-release-sync.
  - Registered the new package in the workspace deno.json and export map.

<!-- End of auto-generated description by cubic. -->

