### PR TITLE
  feat: Add LLM health monitoring with Discord alerting

### DIFF
--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -70,6 +70,8 @@ const EnvSchema = z.object({
   //   * /routes/integration/discord
   // ===========================================================================
   DISCORD_WEBHOOK_URL: z.string().default(""),
+  LLM_HEALTH_DISCORD_WEBHOOK: z.string().default(""),
+  HOSTNAME: z.string().default(""),
   // ===========================================================================
   // Memory Store
   //  - MEMORY_DIR is used by toolshed to access sqlite files for common-memory

--- a/packages/toolshed/routes/health/health.handlers.ts
+++ b/packages/toolshed/routes/health/health.handlers.ts
@@ -2,7 +2,8 @@ import * as HttpStatusCodes from "stoker/http-status-codes";
 import { z } from "zod";
 
 import type { AppRouteHandler } from "@/lib/types.ts";
-import type { IndexRoute } from "./health.routes.ts";
+import type { IndexRoute, LLMRoute } from "./health.routes.ts";
+import { checkLLMHealth } from "./llm-health.service.ts";
 
 export const HealthResponseSchema = z.object({
   status: z.literal("OK"),
@@ -10,10 +11,46 @@ export const HealthResponseSchema = z.object({
 });
 export type HealthResponse = z.infer<typeof HealthResponseSchema>;
 
+export const LLMHealthResponseSchema = z.object({
+  status: z.enum(["healthy", "degraded", "unhealthy"]),
+  timestamp: z.number(),
+  summary: z.object({
+    total: z.number(),
+    healthy: z.number(),
+    failed: z.number(),
+  }),
+  models: z.record(z.object({
+    status: z.enum(["healthy", "failed"]),
+    latencyMs: z.number().nullable(),
+    error: z.string().optional(),
+  })),
+  alertSent: z.boolean(),
+});
+export type LLMHealthResponse = z.infer<typeof LLMHealthResponseSchema>;
+
 export const index: AppRouteHandler<IndexRoute> = (c) => {
   const response: HealthResponse = {
     status: "OK",
     timestamp: Date.now(),
   };
   return c.json(response, HttpStatusCodes.OK);
+};
+
+export const llm: AppRouteHandler<LLMRoute> = async (c) => {
+  const { verbose, alert, models: modelFilter, forceAlert } = c.req.query();
+
+  // Call the service to perform the health check
+  const result = await checkLLMHealth({
+    modelFilter,
+    isVerbose: verbose === "true",
+    shouldAlert: alert === "true",
+    shouldForceAlert: forceAlert === "true",
+  });
+
+  // Return appropriate status code based on health status
+  const statusCode = result.status === "unhealthy"
+    ? HttpStatusCodes.SERVICE_UNAVAILABLE
+    : HttpStatusCodes.OK;
+
+  return c.json(result, statusCode);
 };

--- a/packages/toolshed/routes/health/health.index.ts
+++ b/packages/toolshed/routes/health/health.index.ts
@@ -4,6 +4,7 @@ import * as handlers from "./health.handlers.ts";
 import * as routes from "./health.routes.ts";
 
 const router = createRouter()
-  .openapi(routes.index, handlers.index);
+  .openapi(routes.index, handlers.index)
+  .openapi(routes.llm, handlers.llm);
 
 export default router;

--- a/packages/toolshed/routes/health/health.routes.ts
+++ b/packages/toolshed/routes/health/health.routes.ts
@@ -1,7 +1,11 @@
 import { createRoute } from "@hono/zod-openapi";
 import * as HttpStatusCodes from "stoker/http-status-codes";
 import { jsonContent } from "stoker/openapi/helpers";
-import { HealthResponseSchema } from "./health.handlers.ts";
+import { z } from "zod";
+import {
+  HealthResponseSchema,
+  LLMHealthResponseSchema,
+} from "./health.handlers.ts";
 
 const tags = ["Health"];
 
@@ -17,4 +21,27 @@ export const index = createRoute({
   },
 });
 
+export const llm = createRoute({
+  path: "/api/health/llm",
+  method: "get",
+  tags,
+  query: z.object({
+    verbose: z.string().optional(),
+    alert: z.string().optional(),
+    models: z.string().optional(),
+    forceAlert: z.string().optional(),
+  }),
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      LLMHealthResponseSchema,
+      "LLM health check status",
+    ),
+    [HttpStatusCodes.SERVICE_UNAVAILABLE]: jsonContent(
+      LLMHealthResponseSchema,
+      "LLM services are unhealthy",
+    ),
+  },
+});
+
 export type IndexRoute = typeof index;
+export type LLMRoute = typeof llm;

--- a/packages/toolshed/routes/health/llm-health.service.ts
+++ b/packages/toolshed/routes/health/llm-health.service.ts
@@ -1,0 +1,356 @@
+import env from "@/env.ts";
+
+// Discord webhook color constants
+const DISCORD_COLORS = {
+  GREEN: 3066993,
+  RED: 15158332,
+  YELLOW: 16776960,
+} as const;
+
+interface ModelTestResult {
+  name: string;
+  status: "healthy" | "failed";
+  latencyMs: number | null;
+  error?: string;
+}
+
+export interface ModelStatus {
+  status: "healthy" | "failed";
+  latencyMs: number | null;
+  error?: string;
+}
+
+export interface LLMHealthCheckOptions {
+  modelFilter?: string;
+  isVerbose?: boolean;
+  shouldAlert?: boolean;
+  shouldForceAlert?: boolean;
+}
+
+export interface LLMHealthCheckResult {
+  status: "healthy" | "degraded" | "unhealthy";
+  timestamp: number;
+  summary: {
+    total: number;
+    healthy: number;
+    failed: number;
+  };
+  models: Record<string, ModelStatus>;
+  alertSent: boolean;
+}
+
+/**
+ * Fetch available LLM models from the API
+ */
+async function fetchAvailableModels(): Promise<string[]> {
+  const modelsResponse = await fetch(
+    `http://localhost:${env.PORT}/api/ai/llm/models`,
+  );
+
+  if (!modelsResponse.ok) {
+    throw new Error("Failed to fetch available models");
+  }
+
+  const allModels = await modelsResponse.json();
+  return Object.keys(allModels);
+}
+
+/**
+ * Test a single LLM model
+ */
+async function testModel(
+  modelName: string,
+  isVerbose: boolean,
+): Promise<ModelTestResult> {
+  const startTime = Date.now();
+
+  try {
+    const response = await fetch(`http://localhost:${env.PORT}/api/ai/llm`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: modelName,
+        system: "You are a health check bot. Respond with exactly one word.",
+        messages: [{
+          role: "user",
+          content: "Say 'OK' to confirm you are working.",
+        }],
+        stream: false,
+        cache: false,
+      }),
+      signal: AbortSignal.timeout(30000), // 30s timeout per model
+    });
+
+    const latencyMs = Date.now() - startTime;
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return {
+        name: modelName,
+        status: "failed",
+        latencyMs: null,
+        error: isVerbose ? errorText : `HTTP ${response.status}`,
+      };
+    }
+
+    const data = await response.json();
+    if (!data.content) {
+      return {
+        name: modelName,
+        status: "failed",
+        latencyMs: null,
+        error: "No content in response",
+      };
+    }
+
+    return {
+      name: modelName,
+      status: "healthy",
+      latencyMs,
+      error: undefined,
+    };
+  } catch (error) {
+    return {
+      name: modelName,
+      status: "failed",
+      latencyMs: null,
+      error: isVerbose ? String(error) : "Request failed",
+    };
+  }
+}
+
+/**
+ * Send Discord webhook alert for health check results
+ */
+async function sendDiscordAlert(
+  failedCount: number,
+  totalCount: number,
+  healthyCount: number,
+  overallStatus: string,
+  failedModels: string[],
+  modelStatuses: Record<string, ModelStatus>,
+  shouldForceAlert: boolean,
+  startTime: number,
+): Promise<boolean> {
+  const webhookUrl = env.LLM_HEALTH_DISCORD_WEBHOOK;
+
+  if (!webhookUrl) {
+    return false;
+  }
+
+  try {
+    const environment = env.ENV || "development";
+    const hostname = env.HOSTNAME || "localhost";
+
+    // Determine alert severity
+    const severity = shouldForceAlert && failedCount === 0
+      ? "🟢 HEALTHY"
+      : overallStatus === "unhealthy"
+      ? "🔴 CRITICAL"
+      : "🟡 WARNING";
+
+    const color = shouldForceAlert && failedCount === 0
+      ? DISCORD_COLORS.GREEN
+      : overallStatus === "unhealthy"
+      ? DISCORD_COLORS.RED
+      : DISCORD_COLORS.YELLOW;
+
+    // Calculate average latency for healthy models
+    const healthyLatencies = Object.values(modelStatuses)
+      .filter((m) => m.status === "healthy" && m.latencyMs)
+      .map((m) => m.latencyMs as number);
+
+    const avgLatency = healthyLatencies.length > 0
+      ? Math.round(
+        healthyLatencies.reduce((a, b) => a + b, 0) / healthyLatencies.length,
+      )
+      : 0;
+
+    // Format failed models list (truncate if too long)
+    let failedModelsList = failedModels.join(", ");
+    if (failedModelsList.length > 1000) {
+      failedModelsList = failedModelsList.substring(0, 997) + "...";
+    }
+
+    // Infrastructure-focused webhook message
+    const webhookPayload = {
+      content: null,
+      embeds: [{
+        title: `${severity} - LLM Service Health Alert`,
+        description: shouldForceAlert && failedCount === 0
+          ? `Test alert triggered manually - all systems operational`
+          : `Automated health check detected ${failedCount} model failures`,
+        color,
+        fields: [
+          {
+            name: "📊 Status Overview",
+            value:
+              `• **Healthy**: ${healthyCount}/${totalCount}\n• **Failed**: ${failedCount}/${totalCount}\n• **Health Score**: ${
+                Math.round((healthyCount / totalCount) * 100)
+              }%`,
+            inline: true,
+          },
+          {
+            name: "🌍 Environment",
+            value: `• **Env**: ${environment}\n• **Host**: ${hostname}`,
+            inline: true,
+          },
+          {
+            name: "⚡ Performance",
+            value: `• **Avg Latency**: ${avgLatency}ms\n• **Check Duration**: ${
+              Date.now() - startTime
+            }ms`,
+            inline: true,
+          },
+          {
+            name: "❌ Failed Models",
+            value: failedModelsList || "None",
+            inline: false,
+          },
+        ],
+        footer: {
+          text: `LLM Health Monitor • ${new Date().toISOString()}`,
+        },
+        timestamp: new Date().toISOString(),
+      }],
+      username: "LLM Health Monitor",
+      avatar_url: "https://cdn.discordapp.com/embed/avatars/0.png",
+    };
+
+    // Send webhook directly
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(webhookPayload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("[LLM Health Alert] Webhook failed:", {
+        status: response.status,
+        error: errorText,
+        webhook: webhookUrl.substring(0, 50) + "...",
+      });
+      return false;
+    }
+
+    console.log(
+      `[LLM Health Alert] Alert sent: ${severity} - ${failedCount} failures`,
+    );
+    return true;
+  } catch (error) {
+    // Silent failure - don't crash the health check
+    console.error("[LLM Health Alert] Exception sending alert:", error);
+    return false;
+  }
+}
+
+/**
+ * Perform health check on LLM models
+ */
+export async function checkLLMHealth(
+  options: LLMHealthCheckOptions,
+): Promise<LLMHealthCheckResult> {
+  const startTime = Date.now();
+  const {
+    modelFilter,
+    isVerbose = false,
+    shouldAlert = false,
+    shouldForceAlert = false,
+  } = options;
+
+  try {
+    // Fetch available models
+    let modelNames = await fetchAvailableModels();
+
+    // Filter models if specified
+    if (modelFilter) {
+      const filters = modelFilter.split(",").map((s) => s.trim());
+      modelNames = modelNames.filter((name) =>
+        filters.some((filter) => name.includes(filter))
+      );
+    }
+
+    // Test all models concurrently
+    const testPromises = modelNames.map((modelName) =>
+      testModel(modelName, isVerbose)
+    );
+    const results = await Promise.allSettled(testPromises);
+
+    // Process results
+    const modelStatuses: Record<string, ModelStatus> = {};
+    let healthyCount = 0;
+    let failedCount = 0;
+    const failedModels: string[] = [];
+
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        const modelResult = result.value;
+        modelStatuses[modelResult.name] = {
+          status: modelResult.status,
+          latencyMs: modelResult.latencyMs,
+          error: modelResult.error,
+        };
+
+        if (modelResult.status === "healthy") {
+          healthyCount++;
+        } else {
+          failedCount++;
+          failedModels.push(modelResult.name);
+        }
+      } else {
+        // Promise rejected (shouldn't happen with our error handling)
+        failedCount++;
+      }
+    }
+
+    // Determine overall status
+    const totalCount = modelNames.length;
+    let overallStatus: "healthy" | "degraded" | "unhealthy";
+    if (failedCount === 0) {
+      overallStatus = "healthy";
+    } else if (failedCount / totalCount > 0.5) {
+      overallStatus = "unhealthy";
+    } else {
+      overallStatus = "degraded";
+    }
+
+    // Send infrastructure alert if needed (or forced)
+    let alertSent = false;
+    if ((shouldAlert && failedCount > 0) || shouldForceAlert) {
+      alertSent = await sendDiscordAlert(
+        failedCount,
+        totalCount,
+        healthyCount,
+        overallStatus,
+        failedModels,
+        modelStatuses,
+        shouldForceAlert,
+        startTime,
+      );
+    }
+
+    return {
+      status: overallStatus,
+      timestamp: Date.now(),
+      summary: {
+        total: totalCount,
+        healthy: healthyCount,
+        failed: failedCount,
+      },
+      models: modelStatuses,
+      alertSent,
+    };
+  } catch (error) {
+    // If we can't even fetch models, return unhealthy status
+    return {
+      status: "unhealthy",
+      timestamp: Date.now(),
+      summary: { total: 0, healthy: 0, failed: 0 },
+      models: {},
+      alertSent: false,
+    };
+  }
+}

--- a/packages/toolshed/scripts/llm-exercise.ts
+++ b/packages/toolshed/scripts/llm-exercise.ts
@@ -6,7 +6,8 @@ const API_URL = Deno.env.get("API_URL") || "http://localhost:8000";
 const MODEL_URL = `${API_URL}/api/ai/llm`;
 const MODELS_URL = `${API_URL}/api/ai/llm/models`;
 const TEST_SYSTEM_PROMPT = "Be creative.";
-const TEST_PROMPT = `What's your favorite color?`;
+const TEST_PROMPT =
+  `What's your favorite color? Responses must be 1 word only.`;
 
 class LLMTest {
   static async getModels(): Promise<string[]> {


### PR DESCRIPTION
  - Add /api/health/llm endpoint for concurrent model health checks
  - Test all LLM models in parallel (~7s vs 60s+ sequential)
  - Integrate Discord webhook alerts for infrastructure monitoring
  - Support query params: verbose, alert, models filter, forceAlert
  - Add health status levels: healthy, degraded (≤50% fail), unhealthy (>50% fail)
  - Include performance metrics: latency per model, average response time
  - Add TypeScript interfaces and constants for better type safety

  Health check returns structured data with model statuses, latencies, and
  failure reasons. Discord alerts include severity indicators (🟢 HEALTHY,
  🟡 WARNING, 🔴 CRITICAL) and detailed failure information.