### PR TITLE
Fix(chat): Fix chat UI and expose schemas on handlers

### DIFF
--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -157,8 +157,10 @@ export function handler<E, T>(
   };
 
   const factory = Object.assign((props: Opaque<StripCell<T>>): OpaqueRef<E> => {
-    const stream = opaqueRef();
-    stream.set({ $stream: true });
+    const stream = opaqueRef<E>(undefined, eventSchema);
+
+    // Set stream marker (cast to E as stream is typed for the events it accepts)
+    stream.set({ $stream: true } as E);
     const node: NodeRef = {
       module,
       inputs: { $ctx: props, $event: stream },
@@ -169,7 +171,7 @@ export function handler<E, T>(
     connectInputAndOutputs(node);
     stream.connect(node);
 
-    return stream as unknown as OpaqueRef<E>;
+    return stream;
   }, module);
 
   return factory;

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -61,9 +61,7 @@ const LLMToolSchema = {
     description: { type: "string" },
     inputSchema: { type: "object" },
     handler: {
-      type: "object",
-      properties: { result: { type: "object" } },
-      additionalProperties: true,
+      // Deliberately no schema, so it gets populated from the handler
       asStream: true,
     },
   },

--- a/packages/ui/src/v2/components/ct-chat/ct-chat.ts
+++ b/packages/ui/src/v2/components/ct-chat/ct-chat.ts
@@ -133,8 +133,8 @@ export class CTChat extends BaseElement {
     this.pending = false;
   }
 
-  private get _messagesArray(): BuiltInLLMMessage[] {
-    return [...(this._cellController.getValue() || [])];
+  private get _messagesArray(): readonly BuiltInLLMMessage[] {
+    return this._cellController.getValue() || [];
   }
 
   override firstUpdated(changedProperties: Map<string, any>) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes chat message rendering and exposes handler event schemas so tools can surface accurate input/output shapes.

- **New Features**
  - Handler streams now carry their event schema (opaqueRef<E>(..., eventSchema)); schema is exposed to consumers.
  - Removed hardcoded handler schema in LLMToolSchema so it auto-populates from the handler.

- **Bug Fixes**
  - Chat: use a readonly messages array without copying to avoid rerenders and UI glitches.

<!-- End of auto-generated description by cubic. -->

