### PR TITLE
Adding special handling for prompts when the given model does not support system prompts

### DIFF
--- a/packages/toolshed/routes/ai/llm/generateText.ts
+++ b/packages/toolshed/routes/ai/llm/generateText.ts
@@ -205,7 +205,24 @@ export async function generateText(
     !modelConfig.capabilities.systemPrompt && params.system &&
     messages.length > 0
   ) {
-    messages[0].content = `${params.system}\n\n${messages[0].content}`;
+    // Prepend system prompt to first message content
+    // Content can be a string or an array of content parts
+    const firstMessage = messages[0];
+    if (typeof firstMessage.content === "string") {
+      firstMessage.content = `${params.system}\n\n${firstMessage.content}`;
+    } else if (Array.isArray(firstMessage.content)) {
+      // Use type assertion to handle the union type properly
+      firstMessage.content = [
+        { type: "text" as const, text: params.system },
+        ...firstMessage.content,
+      ] as typeof firstMessage.content;
+    } else {
+      // Handle edge case: single object or unexpected type
+      firstMessage.content = [
+        { type: "text" as const, text: params.system },
+        firstMessage.content,
+      ] as typeof firstMessage.content;
+    }
     streamParams.system = undefined;
   }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds type-safe handling for models that don’t support system prompts by injecting the system text into the first message without breaking content types. Prevents “[object Object]” from appearing in prompts and keeps behavior consistent. Addresses Linear CT-885.

- **Bug Fixes**
  - Inserts system text as a proper text part when content is an array or object, or as a string when content is a string.
  - Unsets streamParams.system to avoid sending unsupported fields to the model.

<!-- End of auto-generated description by cubic. -->

