### PR TITLE
store charm reference in a cell

### DIFF
--- a/packages/patterns/charm-ref-in-cell.tsx
+++ b/packages/patterns/charm-ref-in-cell.tsx
@@ -58,7 +58,8 @@ const createCellRef = lift(
 // pass isInitialized to make sure we dont call this each time
 // we change cellRef, otherwise creates a loop
 // also, we need to only navigateTo if not initialized so that
-// we know we have the charm ready
+// the other lifts we created compete and try to
+// navigateTo at the same time.
 // note there is a separate isInitialized for each created charm
 const storeCharmAndNavigate = lift(
   {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a Launcher recipe that creates a Simple Recipe charm, stores its reference in a cell, and navigates to it. Supports CT-865 by persisting the last-created charm for future use.

- **New Features**
  - Added charm-ref-in-cell pattern with createCellRef and storeCharmInCell lifts.
  - Stores the created charm in a named cell (cellRef), then navigateTo(charm).
  - Launcher UI adds a “Create Sub Charm” button to trigger the flow.

<!-- End of auto-generated description by cubic. -->

