### PR TITLE
change refs emission to be for all named non-container types

### DIFF
--- a/packages/js-runtime/test/fixtures/handler-schema/array-cell-remove-intersection.expected.ts
+++ b/packages/js-runtime/test/fixtures/handler-schema/array-cell-remove-intersection.expected.ts
@@ -7,18 +7,13 @@ interface ListState {
     items: Cell<Item[]>;
 }
 const removeItem = handler({} as const satisfies JSONSchema, {
+    $schema: "https://json-schema.org/draft-07/schema#",
     type: "object",
     properties: {
         items: {
             type: "array",
             items: {
-                type: "object",
-                properties: {
-                    text: {
-                        type: "string"
-                    }
-                },
-                required: ["text"]
+                $ref: "#/definitions/Item"
             },
             asCell: true
         },
@@ -26,7 +21,18 @@ const removeItem = handler({} as const satisfies JSONSchema, {
             type: "number"
         }
     },
-    required: ["items", "index"]
+    required: ["items", "index"],
+    definitions: {
+        Item: {
+            type: "object",
+            properties: {
+                text: {
+                    type: "string"
+                }
+            },
+            required: ["text"]
+        }
+    }
 } as const satisfies JSONSchema, (_, { items, index }) => {
     const next = items.get().slice();
     if (index >= 0 && index < next.length)
@@ -38,18 +44,13 @@ type ListStateWithIndex = ListState & {
     index: number;
 };
 const removeItemAlias = handler({} as const satisfies JSONSchema, {
+    $schema: "https://json-schema.org/draft-07/schema#",
     type: "object",
     properties: {
         items: {
             type: "array",
             items: {
-                type: "object",
-                properties: {
-                    text: {
-                        type: "string"
-                    }
-                },
-                required: ["text"]
+                $ref: "#/definitions/Item"
             },
             asCell: true
         },
@@ -57,7 +58,18 @@ const removeItemAlias = handler({} as const satisfies JSONSchema, {
             type: "number"
         }
     },
-    required: ["items", "index"]
+    required: ["items", "index"],
+    definitions: {
+        Item: {
+            type: "object",
+            properties: {
+                text: {
+                    type: "string"
+                }
+            },
+            required: ["text"]
+        }
+    }
 } as const satisfies JSONSchema, (_, { items, index }) => {
     const next = items.get().slice();
     if (index >= 0 && index < next.length)

--- a/packages/js-runtime/test/fixtures/handler-schema/date-and-map-types.expected.ts
+++ b/packages/js-runtime/test/fixtures/handler-schema/date-and-map-types.expected.ts
@@ -25,16 +25,45 @@ const timedHandler = handler({
         Map: {
             type: "object",
             properties: {
-                clear: { type: "object", properties: {} },
-                delete: { type: "object", properties: {} },
-                forEach: { type: "object", properties: {} },
-                get: { type: "object", properties: {} },
-                has: { type: "object", properties: {} },
-                set: { type: "object", properties: {} },
-                size: { type: "number" },
-                entries: { type: "object", properties: {} },
-                keys: { type: "object", properties: {} },
-                values: { type: "object", properties: {} }
+                clear: {
+                    type: "object",
+                    properties: {}
+                },
+                delete: {
+                    type: "object",
+                    properties: {}
+                },
+                forEach: {
+                    type: "object",
+                    properties: {}
+                },
+                get: {
+                    type: "object",
+                    properties: {}
+                },
+                has: {
+                    type: "object",
+                    properties: {}
+                },
+                set: {
+                    type: "object",
+                    properties: {}
+                },
+                size: {
+                    type: "number"
+                },
+                entries: {
+                    type: "object",
+                    properties: {}
+                },
+                keys: {
+                    type: "object",
+                    properties: {}
+                },
+                values: {
+                    type: "object",
+                    properties: {}
+                }
             },
             required: ["clear", "delete", "forEach", "get", "has", "set", "size", "entries", "keys", "values"]
         }
@@ -56,16 +85,45 @@ const timedHandler = handler({
         Map: {
             type: "object",
             properties: {
-                clear: { type: "object", properties: {} },
-                delete: { type: "object", properties: {} },
-                forEach: { type: "object", properties: {} },
-                get: { type: "object", properties: {} },
-                has: { type: "object", properties: {} },
-                set: { type: "object", properties: {} },
-                size: { type: "number" },
-                entries: { type: "object", properties: {} },
-                keys: { type: "object", properties: {} },
-                values: { type: "object", properties: {} }
+                clear: {
+                    type: "object",
+                    properties: {}
+                },
+                delete: {
+                    type: "object",
+                    properties: {}
+                },
+                forEach: {
+                    type: "object",
+                    properties: {}
+                },
+                get: {
+                    type: "object",
+                    properties: {}
+                },
+                has: {
+                    type: "object",
+                    properties: {}
+                },
+                set: {
+                    type: "object",
+                    properties: {}
+                },
+                size: {
+                    type: "number"
+                },
+                entries: {
+                    type: "object",
+                    properties: {}
+                },
+                keys: {
+                    type: "object",
+                    properties: {}
+                },
+                values: {
+                    type: "object",
+                    properties: {}
+                }
             },
             required: ["clear", "delete", "forEach", "get", "has", "set", "size", "entries", "keys", "values"]
         }

--- a/packages/js-runtime/test/fixtures/handler-schema/date-and-map-types.expected.ts
+++ b/packages/js-runtime/test/fixtures/handler-schema/date-and-map-types.expected.ts
@@ -9,6 +9,7 @@ interface TimedState {
     history: Map<string, Date>;
 }
 const timedHandler = handler({
+    $schema: "https://json-schema.org/draft-07/schema#",
     type: "object",
     properties: {
         timestamp: {
@@ -16,53 +17,30 @@ const timedHandler = handler({
             format: "date-time"
         },
         data: {
+            $ref: "#/definitions/Map"
+        }
+    },
+    required: ["timestamp", "data"],
+    definitions: {
+        Map: {
             type: "object",
             properties: {
-                clear: {
-                    type: "object",
-                    properties: {}
-                },
-                delete: {
-                    type: "object",
-                    properties: {}
-                },
-                forEach: {
-                    type: "object",
-                    properties: {}
-                },
-                get: {
-                    type: "object",
-                    properties: {}
-                },
-                has: {
-                    type: "object",
-                    properties: {}
-                },
-                set: {
-                    type: "object",
-                    properties: {}
-                },
-                size: {
-                    type: "number"
-                },
-                entries: {
-                    type: "object",
-                    properties: {}
-                },
-                keys: {
-                    type: "object",
-                    properties: {}
-                },
-                values: {
-                    type: "object",
-                    properties: {}
-                }
+                clear: { type: "object", properties: {} },
+                delete: { type: "object", properties: {} },
+                forEach: { type: "object", properties: {} },
+                get: { type: "object", properties: {} },
+                has: { type: "object", properties: {} },
+                set: { type: "object", properties: {} },
+                size: { type: "number" },
+                entries: { type: "object", properties: {} },
+                keys: { type: "object", properties: {} },
+                values: { type: "object", properties: {} }
             },
             required: ["clear", "delete", "forEach", "get", "has", "set", "size", "entries", "keys", "values"]
         }
-    },
-    required: ["timestamp", "data"]
+    }
 } as const satisfies JSONSchema, {
+    $schema: "https://json-schema.org/draft-07/schema#",
     type: "object",
     properties: {
         lastUpdate: {
@@ -70,52 +48,28 @@ const timedHandler = handler({
             format: "date-time"
         },
         history: {
+            $ref: "#/definitions/Map"
+        }
+    },
+    required: ["lastUpdate", "history"],
+    definitions: {
+        Map: {
             type: "object",
             properties: {
-                clear: {
-                    type: "object",
-                    properties: {}
-                },
-                delete: {
-                    type: "object",
-                    properties: {}
-                },
-                forEach: {
-                    type: "object",
-                    properties: {}
-                },
-                get: {
-                    type: "object",
-                    properties: {}
-                },
-                has: {
-                    type: "object",
-                    properties: {}
-                },
-                set: {
-                    type: "object",
-                    properties: {}
-                },
-                size: {
-                    type: "number"
-                },
-                entries: {
-                    type: "object",
-                    properties: {}
-                },
-                keys: {
-                    type: "object",
-                    properties: {}
-                },
-                values: {
-                    type: "object",
-                    properties: {}
-                }
+                clear: { type: "object", properties: {} },
+                delete: { type: "object", properties: {} },
+                forEach: { type: "object", properties: {} },
+                get: { type: "object", properties: {} },
+                has: { type: "object", properties: {} },
+                set: { type: "object", properties: {} },
+                size: { type: "number" },
+                entries: { type: "object", properties: {} },
+                keys: { type: "object", properties: {} },
+                values: { type: "object", properties: {} }
             },
             required: ["clear", "delete", "forEach", "get", "has", "set", "size", "entries", "keys", "values"]
         }
-    },
-    required: ["lastUpdate", "history"]
+    }
 } as const satisfies JSONSchema, (event, state) => {
     state.lastUpdate = event.timestamp;
     event.data.forEach((value, key) => {

--- a/packages/js-runtime/test/fixtures/handler-schema/date-and-map-types.expected.ts
+++ b/packages/js-runtime/test/fixtures/handler-schema/date-and-map-types.expected.ts
@@ -25,47 +25,11 @@ const timedHandler = handler({
         Map: {
             type: "object",
             properties: {
-                clear: {
-                    type: "object",
-                    properties: {}
-                },
-                delete: {
-                    type: "object",
-                    properties: {}
-                },
-                forEach: {
-                    type: "object",
-                    properties: {}
-                },
-                get: {
-                    type: "object",
-                    properties: {}
-                },
-                has: {
-                    type: "object",
-                    properties: {}
-                },
-                set: {
-                    type: "object",
-                    properties: {}
-                },
                 size: {
                     type: "number"
-                },
-                entries: {
-                    type: "object",
-                    properties: {}
-                },
-                keys: {
-                    type: "object",
-                    properties: {}
-                },
-                values: {
-                    type: "object",
-                    properties: {}
                 }
             },
-            required: ["clear", "delete", "forEach", "get", "has", "set", "size", "entries", "keys", "values"]
+            required: ["size"]
         }
     }
 } as const satisfies JSONSchema, {
@@ -85,47 +49,11 @@ const timedHandler = handler({
         Map: {
             type: "object",
             properties: {
-                clear: {
-                    type: "object",
-                    properties: {}
-                },
-                delete: {
-                    type: "object",
-                    properties: {}
-                },
-                forEach: {
-                    type: "object",
-                    properties: {}
-                },
-                get: {
-                    type: "object",
-                    properties: {}
-                },
-                has: {
-                    type: "object",
-                    properties: {}
-                },
-                set: {
-                    type: "object",
-                    properties: {}
-                },
                 size: {
                     type: "number"
-                },
-                entries: {
-                    type: "object",
-                    properties: {}
-                },
-                keys: {
-                    type: "object",
-                    properties: {}
-                },
-                values: {
-                    type: "object",
-                    properties: {}
                 }
             },
-            required: ["clear", "delete", "forEach", "get", "has", "set", "size", "entries", "keys", "values"]
+            required: ["size"]
         }
     }
 } as const satisfies JSONSchema, (event, state) => {

--- a/packages/js-runtime/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.tsx
+++ b/packages/js-runtime/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.tsx
@@ -51,27 +51,6 @@ export default recipe({
                 }
             },
             required: ["id", "name", "price", "active"]
-        },
-        State: {
-            type: "object",
-            properties: {
-                items: {
-                    type: "array",
-                    items: {
-                        $ref: "#/definitions/Item"
-                    }
-                },
-                filter: {
-                    type: "string"
-                },
-                discount: {
-                    type: "number"
-                },
-                taxRate: {
-                    type: "number"
-                }
-            },
-            required: ["items", "filter", "discount", "taxRate"]
         }
     }
 } as const satisfies JSONSchema, (state) => {

--- a/packages/js-runtime/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.tsx
+++ b/packages/js-runtime/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.tsx
@@ -13,27 +13,13 @@ interface State {
     taxRate: number;
 }
 export default recipe({
+    $schema: "https://json-schema.org/draft-07/schema#",
     type: "object",
     properties: {
         items: {
             type: "array",
             items: {
-                type: "object",
-                properties: {
-                    id: {
-                        type: "number"
-                    },
-                    name: {
-                        type: "string"
-                    },
-                    price: {
-                        type: "number"
-                    },
-                    active: {
-                        type: "boolean"
-                    }
-                },
-                required: ["id", "name", "price", "active"]
+                $ref: "#/definitions/Item"
             }
         },
         filter: {
@@ -46,7 +32,48 @@ export default recipe({
             type: "number"
         }
     },
-    required: ["items", "filter", "discount", "taxRate"]
+    required: ["items", "filter", "discount", "taxRate"],
+    definitions: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                },
+                price: {
+                    type: "number"
+                },
+                active: {
+                    type: "boolean"
+                }
+            },
+            required: ["id", "name", "price", "active"]
+        },
+        State: {
+            type: "object",
+            properties: {
+                items: {
+                    type: "array",
+                    items: {
+                        $ref: "#/definitions/Item"
+                    }
+                },
+                filter: {
+                    type: "string"
+                },
+                discount: {
+                    type: "number"
+                },
+                taxRate: {
+                    type: "number"
+                }
+            },
+            required: ["items", "filter", "discount", "taxRate"]
+        }
+    }
 } as const satisfies JSONSchema, (state) => {
     return {
         [UI]: (<div>
@@ -84,4 +111,3 @@ export default recipe({
       </div>),
     };
 });
-

--- a/packages/js-runtime/test/fixtures/jsx-expressions/jsx-property-access.expected.tsx
+++ b/packages/js-runtime/test/fixtures/jsx-expressions/jsx-property-access.expected.tsx
@@ -32,9 +32,34 @@ interface State {
     numbers: number[];
 }
 export default recipe({
+    $schema: "https://json-schema.org/draft-07/schema#",
     type: "object",
     properties: {
         user: {
+            $ref: "#/definitions/User"
+        },
+        config: {
+            $ref: "#/definitions/Config"
+        },
+        items: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        },
+        index: {
+            type: "number"
+        },
+        numbers: {
+            type: "array",
+            items: {
+                type: "number"
+            }
+        }
+    },
+    required: ["user", "config", "items", "index", "numbers"],
+    definitions: {
+        User: {
             type: "object",
             properties: {
                 name: {
@@ -73,7 +98,7 @@ export default recipe({
             },
             required: ["name", "age", "active", "profile"]
         },
-        config: {
+        Config: {
             type: "object",
             properties: {
                 theme: {
@@ -106,23 +131,34 @@ export default recipe({
             },
             required: ["theme", "features"]
         },
-        items: {
-            type: "array",
-            items: {
-                type: "string"
-            }
-        },
-        index: {
-            type: "number"
-        },
-        numbers: {
-            type: "array",
-            items: {
-                type: "number"
-            }
+        State: {
+            type: "object",
+            properties: {
+                user: {
+                    $ref: "#/definitions/User"
+                },
+                config: {
+                    $ref: "#/definitions/Config"
+                },
+                items: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                },
+                index: {
+                    type: "number"
+                },
+                numbers: {
+                    type: "array",
+                    items: {
+                        type: "number"
+                    }
+                }
+            },
+            required: ["user", "config", "items", "index", "numbers"]
         }
-    },
-    required: ["user", "config", "items", "index", "numbers"]
+    }
 } as const satisfies JSONSchema, (state) => {
     return {
         [UI]: (<div>
@@ -170,4 +206,3 @@ export default recipe({
       </div>),
     };
 });
-

--- a/packages/js-runtime/test/fixtures/jsx-expressions/jsx-property-access.expected.tsx
+++ b/packages/js-runtime/test/fixtures/jsx-expressions/jsx-property-access.expected.tsx
@@ -59,6 +59,39 @@ export default recipe({
     },
     required: ["user", "config", "items", "index", "numbers"],
     definitions: {
+        Config: {
+            type: "object",
+            properties: {
+                theme: {
+                    type: "object",
+                    properties: {
+                        primaryColor: {
+                            type: "string"
+                        },
+                        secondaryColor: {
+                            type: "string"
+                        },
+                        fontSize: {
+                            type: "number"
+                        }
+                    },
+                    required: ["primaryColor", "secondaryColor", "fontSize"]
+                },
+                features: {
+                    type: "object",
+                    properties: {
+                        darkMode: {
+                            type: "boolean"
+                        },
+                        beta: {
+                            type: "boolean"
+                        }
+                    },
+                    required: ["darkMode", "beta"]
+                }
+            },
+            required: ["theme", "features"]
+        },
         User: {
             type: "object",
             properties: {
@@ -97,66 +130,6 @@ export default recipe({
                 }
             },
             required: ["name", "age", "active", "profile"]
-        },
-        Config: {
-            type: "object",
-            properties: {
-                theme: {
-                    type: "object",
-                    properties: {
-                        primaryColor: {
-                            type: "string"
-                        },
-                        secondaryColor: {
-                            type: "string"
-                        },
-                        fontSize: {
-                            type: "number"
-                        }
-                    },
-                    required: ["primaryColor", "secondaryColor", "fontSize"]
-                },
-                features: {
-                    type: "object",
-                    properties: {
-                        darkMode: {
-                            type: "boolean"
-                        },
-                        beta: {
-                            type: "boolean"
-                        }
-                    },
-                    required: ["darkMode", "beta"]
-                }
-            },
-            required: ["theme", "features"]
-        },
-        State: {
-            type: "object",
-            properties: {
-                user: {
-                    $ref: "#/definitions/User"
-                },
-                config: {
-                    $ref: "#/definitions/Config"
-                },
-                items: {
-                    type: "array",
-                    items: {
-                        type: "string"
-                    }
-                },
-                index: {
-                    type: "number"
-                },
-                numbers: {
-                    type: "array",
-                    items: {
-                        type: "number"
-                    }
-                }
-            },
-            required: ["user", "config", "items", "index", "numbers"]
         }
     }
 } as const satisfies JSONSchema, (state) => {

--- a/packages/js-runtime/test/fixtures/schema-transform/opaque-ref-map.expected.ts
+++ b/packages/js-runtime/test/fixtures/schema-transform/opaque-ref-map.expected.ts
@@ -4,25 +4,31 @@ interface TodoItem {
     done: boolean;
 }
 export default recipe({
+    $schema: "https://json-schema.org/draft-07/schema#",
     type: "object",
     properties: {
         items: {
             type: "array",
             items: {
-                type: "object",
-                properties: {
-                    title: {
-                        type: "string"
-                    },
-                    done: {
-                        type: "boolean"
-                    }
-                },
-                required: ["title", "done"]
+                $ref: "#/definitions/TodoItem"
             }
         }
     },
-    required: ["items"]
+    required: ["items"],
+    definitions: {
+        TodoItem: {
+            type: "object",
+            properties: {
+                title: {
+                    type: "string"
+                },
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["title", "done"]
+        }
+    }
 } as const satisfies JSONSchema, ({ items }) => {
     // This should NOT be transformed to items.get().map()
     // because OpaqueRef has its own map method

--- a/packages/js-runtime/test/fixtures/schema-transform/recipe-with-types.expected.tsx
+++ b/packages/js-runtime/test/fixtures/schema-transform/recipe-with-types.expected.tsx
@@ -17,6 +17,7 @@ type InputEventType = {
     };
 };
 const inputSchema = {
+    $schema: "https://json-schema.org/draft-07/schema#",
     type: "object",
     properties: {
         title: {
@@ -26,21 +27,44 @@ const inputSchema = {
         items: {
             type: "array",
             items: {
-                type: "object",
-                properties: {
-                    text: {
-                        type: "string",
-                        default: ""
-                    }
-                },
-                required: ["text"]
+                $ref: "#/definitions/Item"
             },
             default: []
         }
     },
-    required: ["title", "items"]
+    required: ["title", "items"],
+    definitions: {
+        Item: {
+            type: "object",
+            properties: {
+                text: {
+                    type: "string",
+                    default: ""
+                }
+            },
+            required: ["text"]
+        },
+        InputSchemaInterface: {
+            type: "object",
+            properties: {
+                title: {
+                    type: "string",
+                    default: "untitled"
+                },
+                items: {
+                    type: "array",
+                    items: {
+                        $ref: "#/definitions/Item"
+                    },
+                    default: []
+                }
+            },
+            required: ["title", "items"]
+        }
+    }
 } as const satisfies JSONSchema;
 const outputSchema = {
+    $schema: "https://json-schema.org/draft-07/schema#",
     type: "object",
     properties: {
         items_count: {
@@ -53,19 +77,44 @@ const outputSchema = {
         items: {
             type: "array",
             items: {
-                type: "object",
-                properties: {
-                    text: {
-                        type: "string",
-                        default: ""
-                    }
-                },
-                required: ["text"]
+                $ref: "#/definitions/Item"
             },
             default: []
         }
     },
-    required: ["items_count", "title", "items"]
+    required: ["items_count", "title", "items"],
+    definitions: {
+        Item: {
+            type: "object",
+            properties: {
+                text: {
+                    type: "string",
+                    default: ""
+                }
+            },
+            required: ["text"]
+        },
+        OutputSchemaInterface: {
+            type: "object",
+            properties: {
+                items_count: {
+                    type: "number"
+                },
+                title: {
+                    type: "string",
+                    default: "untitled"
+                },
+                items: {
+                    type: "array",
+                    items: {
+                        $ref: "#/definitions/Item"
+                    },
+                    default: []
+                }
+            },
+            required: ["items_count", "title", "items"]
+        }
+    }
 } as const satisfies JSONSchema;
 // Handler that logs the message event
 const addItem = handler({
@@ -83,24 +132,30 @@ const addItem = handler({
     },
     required: ["detail"]
 } as const satisfies JSONSchema, {
+    $schema: "https://json-schema.org/draft-07/schema#",
     type: "object",
     properties: {
         items: {
             type: "array",
             items: {
-                type: "object",
-                properties: {
-                    text: {
-                        type: "string",
-                        default: ""
-                    }
-                },
-                required: ["text"]
+                $ref: "#/definitions/Item"
             },
             asCell: true
         }
     },
-    required: ["items"]
+    required: ["items"],
+    definitions: {
+        Item: {
+            type: "object",
+            properties: {
+                text: {
+                    type: "string",
+                    default: ""
+                }
+            },
+            required: ["text"]
+        }
+    }
 } as const satisfies JSONSchema, (event: InputEventType, { items }: {
     items: Cell<Item[]>;
 }) => {
@@ -124,4 +179,3 @@ export default recipe(inputSchema, outputSchema, ({ title, items }) => {
         items_count
     };
 });
-

--- a/packages/js-runtime/test/fixtures/schema-transform/recipe-with-types.expected.tsx
+++ b/packages/js-runtime/test/fixtures/schema-transform/recipe-with-types.expected.tsx
@@ -43,23 +43,6 @@ const inputSchema = {
                 }
             },
             required: ["text"]
-        },
-        InputSchemaInterface: {
-            type: "object",
-            properties: {
-                title: {
-                    type: "string",
-                    default: "untitled"
-                },
-                items: {
-                    type: "array",
-                    items: {
-                        $ref: "#/definitions/Item"
-                    },
-                    default: []
-                }
-            },
-            required: ["title", "items"]
         }
     }
 } as const satisfies JSONSchema;
@@ -93,26 +76,6 @@ const outputSchema = {
                 }
             },
             required: ["text"]
-        },
-        OutputSchemaInterface: {
-            type: "object",
-            properties: {
-                items_count: {
-                    type: "number"
-                },
-                title: {
-                    type: "string",
-                    default: "untitled"
-                },
-                items: {
-                    type: "array",
-                    items: {
-                        $ref: "#/definitions/Item"
-                    },
-                    default: []
-                }
-            },
-            required: ["items_count", "title", "items"]
         }
     }
 } as const satisfies JSONSchema;

--- a/packages/runner/src/builder/node-utils.ts
+++ b/packages/runner/src/builder/node-utils.ts
@@ -56,12 +56,13 @@ export function applyInputIfcToOutput<T, R>(
   const cfc = new ContextualFlowControl();
   traverseValue(inputs, (item: unknown) => {
     if (isOpaqueRef(item)) {
-      const { schema: inputSchema } = (item as OpaqueRef<T>).export();
+      const { schema: inputSchema, rootSchema } = (item as OpaqueRef<T>)
+        .export();
       if (inputSchema !== undefined) {
         ContextualFlowControl.joinSchema(
           collectedClassifications,
           inputSchema,
-          inputSchema,
+          rootSchema ?? inputSchema,
         );
       }
     }

--- a/packages/schema-generator/README.md
+++ b/packages/schema-generator/README.md
@@ -6,9 +6,9 @@ Short notes on the JSON Schema generator and ref/definitions behavior.
 
 - Hoists every named type into `definitions` and emits `$ref` for non‑root
   occurrences.
-- Excludes wrapper/container names and native leaf types from hoisting:
-  `Array`, `ReadonlyArray`, `Cell`, `Stream`, `Default`, `Date`, `URL`,
-  `Uint8Array`, `ArrayBuffer`.
+- Excludes wrapper/container names and native leaf types from hoisting: `Array`,
+  `ReadonlyArray`, `Cell`, `Stream`, `Default`, `Date`, `URL`, `Uint8Array`,
+  `ArrayBuffer`.
 - Root types remain inline; `definitions` are included only if at least one
   `$ref` is emitted.
 - Anonymous/type‑literal shapes (including aliases that resolve to anonymous
@@ -27,9 +27,14 @@ Implementation: see `src/schema-generator.ts` (`formatType`) and
 - Maps ECMAScript built-ins directly when they appear as properties:
   - `Date` → `{ type: "string", format: "date-time" }`
   - `URL` → `{ type: "string", format: "uri" }`
-  - `Uint8Array` and `ArrayBuffer` → `true` (permissive JSON Schema leaf)
-- These shortcuts keep schemas inline without emitting `$ref` definitions,
-  while avoiding conflicts with array detection or hoisting.
+  - Typed array family (`Uint8Array`, `Uint8ClampedArray`, `Int8Array`,
+    `Uint16Array`, `Int16Array`, `Uint32Array`, `Int32Array`, `Float32Array`,
+    `Float64Array`, `BigInt64Array`, `BigUint64Array`) plus `ArrayBuffer`,
+    `ArrayBufferLike`, `SharedArrayBuffer`, and `ArrayBufferView` → `true`
+    (permissive JSON Schema leaf)
+- These shortcuts keep schemas inline without emitting `$ref` definitions, while
+  avoiding conflicts with array detection or hoisting, even when the compiler
+  widens them via intersections or aliases.
 
 ## Function Properties
 

--- a/packages/schema-generator/README.md
+++ b/packages/schema-generator/README.md
@@ -21,6 +21,20 @@ keeping wrapper semantics explicit and simple.
 Implementation: see `src/schema-generator.ts` (`formatType`) and
 `src/type-utils.ts` (`getNamedTypeKey` filtering).
 
+## Function Properties
+
+- Properties whose resolved type is callable or constructable are skipped
+  entirely so we do not emit function shapes in JSON Schema output.
+- Method signatures, declared methods, and properties whose type exposes call
+  signatures are all filtered before we decide on `required` membership or emit
+  attribute metadata (docs, default wrappers, etc.).
+- This keeps schemas focused on serialisable data: JSON Schema cannot describe
+  runtime function values, and downstream tooling expects objects, arrays, and
+  primitives only.
+
+Implementation: see `src/formatters/object-formatter.ts` and
+`src/type-utils.ts:isFunctionLike`.
+
 ## Running
 
 - Check typings: `deno task check`

--- a/packages/schema-generator/README.md
+++ b/packages/schema-generator/README.md
@@ -6,8 +6,9 @@ Short notes on the JSON Schema generator and ref/definitions behavior.
 
 - Hoists every named type into `definitions` and emits `$ref` for non‑root
   occurrences.
-- Excludes wrapper/container names from hoisting: `Array`, `ReadonlyArray`,
-  `Cell`, `Stream`, `Default`, `Date`.
+- Excludes wrapper/container names and native leaf types from hoisting:
+  `Array`, `ReadonlyArray`, `Cell`, `Stream`, `Default`, `Date`, `URL`,
+  `Uint8Array`, `ArrayBuffer`.
 - Root types remain inline; `definitions` are included only if at least one
   `$ref` is emitted.
 - Anonymous/type‑literal shapes (including aliases that resolve to anonymous
@@ -20,6 +21,15 @@ keeping wrapper semantics explicit and simple.
 
 Implementation: see `src/schema-generator.ts` (`formatType`) and
 `src/type-utils.ts` (`getNamedTypeKey` filtering).
+
+## Native Type Schemas
+
+- Maps ECMAScript built-ins directly when they appear as properties:
+  - `Date` → `{ type: "string", format: "date-time" }`
+  - `URL` → `{ type: "string", format: "uri" }`
+  - `Uint8Array` and `ArrayBuffer` → `true` (permissive JSON Schema leaf)
+- These shortcuts keep schemas inline without emitting `$ref` definitions,
+  while avoiding conflicts with array detection or hoisting.
 
 ## Function Properties
 

--- a/packages/schema-generator/README.md
+++ b/packages/schema-generator/README.md
@@ -1,0 +1,28 @@
+# @commontools/schema-generator
+
+Short notes on the JSON Schema generator and ref/definitions behavior.
+
+## All‑Named Hoisting (default)
+
+- Hoists every named type into `definitions` and emits `$ref` for non‑root
+  occurrences.
+- Excludes wrapper/container names from hoisting: `Array`, `ReadonlyArray`,
+  `Cell`, `Stream`, `Default`, `Date`.
+- Root types remain inline; `definitions` are included only if at least one
+  `$ref` is emitted.
+- Anonymous/type‑literal shapes (including aliases that resolve to anonymous
+  types) are inlined.
+- `$ref` may appear with Common Tools extensions as siblings (e.g.
+  `{ "$ref": "#/definitions/Foo", asStream: true }`).
+
+Rationale: Improves human readability and re‑use of complex shared shapes while
+keeping wrapper semantics explicit and simple.
+
+Implementation: see `src/schema-generator.ts` (`formatType`) and
+`src/type-utils.ts` (`getNamedTypeKey` filtering).
+
+## Running
+
+- Check typings: `deno task check`
+- Run tests: `deno task test`
+

--- a/packages/schema-generator/README.md
+++ b/packages/schema-generator/README.md
@@ -25,4 +25,3 @@ Implementation: see `src/schema-generator.ts` (`formatType`) and
 
 - Check typings: `deno task check`
 - Run tests: `deno task test`
-

--- a/packages/schema-generator/promote-all-named-options.txt
+++ b/packages/schema-generator/promote-all-named-options.txt
@@ -1,0 +1,98 @@
+Title: Options for making hoisted named-type $ref schemas resolvable
+
+Context
+  We changed the generator to an "all-named" policy: Every named type (except
+  wrappers/containers like Array, ReadonlyArray, Cell, Stream, Default, Date)
+  is hoisted into `definitions`, and non-root uses emit `$ref` to that entry.
+
+Problem observed in CT builder (chatbot-outliner)
+  The builder sometimes operates on schema fragments (e.g., after merges or
+  link steps). Those fragments can now contain `$ref` without a local
+  `definitions`, leading to unresolved `$ref` at runtime.
+
+Goal
+  Keep the all-named behavior (for readability/reuse), while ensuring
+  `$ref`-bearing fragments remain resolvable in the CT runner/builder.
+
+Option A — Embed subset `definitions` into non-root fragments (short-term)
+  Idea:
+    - When the generator returns a non-root schema that contains `$ref`, attach
+      the minimal subset of `definitions` required by that fragment (including
+      transitive dependencies).
+    - This makes fragments self-contained and resolvable, regardless of how the
+      builder slices schemas later.
+  Changes required:
+    - Generator: After formatting a non-root schema, detect referenced names,
+      compute a transitive closure over `definitions`, and attach that subset
+      under `definitions` on the fragment.
+    - Tests/fixtures: Update expectations for places where nested fragments are
+      asserted to include a small `definitions` block.
+  Pros:
+    - Unblocks current use-cases without touching the CT builder.
+    - Keeps the all-named policy intact.
+  Cons:
+    - Slight duplication/bloat in nested fragments.
+    - Requires fixture updates and careful subset computation.
+
+Option B — Inline in fragments, hoist only at root (hybrid)
+  Idea:
+    - Keep all-named hoisting at the root level, but when returning schemas for
+      nested positions (likely to be lifted out by the builder), inline named
+      types (no `$ref`).
+  Changes required:
+    - Generator: Introduce a policy toggle or heuristics to inline named types
+      when formatting non-root schemas that are likely to be used in isolation.
+    - Tests/fixtures: Update to expect inlined shapes in fragments.
+  Pros:
+    - Fragments remain self-contained; fewer nested `definitions`.
+  Cons:
+    - Hybrid policy is more complex and less predictable for readers.
+    - Loses some reuse within fragments.
+
+Option C — Patch CT runner to resolve `$ref` from parent/root (long-term)
+  Idea:
+    - In the CT builder/runner, when operating on a fragment that contains a
+      `$ref` without local `definitions`, resolve against the nearest parent
+      schema that carries `definitions` (e.g., the component's input/output
+      root). Alternatively, thread a shared `definitions` map through the
+      joinSchema/resolveRef code paths.
+  Changes required:
+    - packages/runner: ContextualFlowControl.resolveSchemaRefOrThrow and
+      related joinSchema helpers need to accept an optional "definitions
+      provider" or resolve upward to find a root `definitions` map.
+    - Tests: Add builder-level tests where fragments contain `$ref` and validate
+      successful resolution from the parent context.
+  Pros:
+    - Clean architecture; avoids duplicating `definitions` into fragments.
+    - Keeps all-named behavior consistent and DRY.
+  Cons:
+    - Requires a multi-package change (runner + tests); coordination needed.
+
+Recommended sequence
+  1) Implement Option A now to unblock current work:
+     - Add a helper: collectReferencedDefinitions(fragment, fullDefs) → subset
+       map of needed definitions (including transitive deps).
+     - Attach subset `definitions` for non-root results that contain `$ref`.
+     - Update fixtures to account for nested `definitions` where applicable.
+
+  2) Plan Option C as a follow-up:
+     - Add a "definitions context" resolver in the CT runner so fragments with
+       `$ref` can be resolved against the root schema. This preserves compact
+       fragments and centralizes definition storage.
+     - Once runner support lands, Option A's nested `definitions` can be
+       simplified or removed (guards remain for extreme edge cases).
+
+Implementation notes for Option A
+  - Definition subset:
+    • Start with the set of `$ref` names found in the fragment (scan keys and
+      nested values). For each referenced name N, include `definitions[N]` and
+      recursively scan that definition for further `$ref`s.
+    • Use a visited set to avoid cycles.
+  - Attachment point:
+    • Only attach `definitions` on non-root returns from the generator (root is
+      handled by buildFinalSchema which already includes full `definitions`).
+    • Keep the subset minimal; do not attach the entire `definitions` map.
+  - Tests:
+    • Where unit tests assert nested fragments, expect a small `definitions`
+      block, and assert that required definitions exist and shape is correct.
+

--- a/packages/schema-generator/src/formatters/intersection-formatter.ts
+++ b/packages/schema-generator/src/formatters/intersection-formatter.ts
@@ -10,11 +10,13 @@ import { isRecord } from "@commontools/utils/types";
 import { extractDocFromType } from "../doc-utils.ts";
 
 const logger = getLogger("schema-generator.intersection");
+const DOC_CONFLICT_COMMENT =
+  "Conflicting docs across intersection constituents; using first";
 
 export class IntersectionFormatter implements TypeFormatter {
   constructor(private schemaGenerator: SchemaGenerator) {}
 
-  supportsType(type: ts.Type, context: GenerationContext): boolean {
+  supportsType(type: ts.Type, _context: GenerationContext): boolean {
     return (type.flags & ts.TypeFlags.Intersection) !== 0;
   }
 
@@ -24,10 +26,11 @@ export class IntersectionFormatter implements TypeFormatter {
     const parts = inter.types ?? [];
 
     if (parts.length === 0) {
-      throw new Error("IntersectionFormatter received empty intersection type");
+      throw new Error(
+        "IntersectionFormatter received empty intersection type",
+      );
     }
 
-    // Validate constituents to ensure safe merging
     const failureReason = this.validateIntersectionParts(parts, checker);
     if (failureReason) {
       return {
@@ -37,7 +40,6 @@ export class IntersectionFormatter implements TypeFormatter {
       };
     }
 
-    // Merge object-like constituents: combine properties and required arrays
     const merged = this.mergeIntersectionParts(parts, context);
     return this.applyIntersectionDocs(merged);
   }
@@ -47,13 +49,11 @@ export class IntersectionFormatter implements TypeFormatter {
     checker: ts.TypeChecker,
   ): string | null {
     for (const part of parts) {
-      // Only support object-like types for safe merging
       if ((part.flags & ts.TypeFlags.Object) === 0) {
         return "non-object constituent";
       }
 
       try {
-        // Reject types with index signatures as they can't be safely merged
         const stringIndex = checker.getIndexTypeOfType(
           part,
           ts.IndexKind.String,
@@ -65,15 +65,12 @@ export class IntersectionFormatter implements TypeFormatter {
         if (stringIndex || numberIndex) {
           return "index signature on constituent";
         }
-
-        // Note: Call/construct signatures are ignored (consistent with other formatters)
-        // They cannot be represented in JSON Schema, so we just extract regular properties
       } catch (error) {
         return `checker error while validating intersection: ${error}`;
       }
     }
 
-    return null; // All parts are valid
+    return null;
   }
 
   private mergeIntersectionParts(
@@ -86,7 +83,7 @@ export class IntersectionFormatter implements TypeFormatter {
     missingSources: string[];
   } {
     const mergedProps: Record<string, SchemaDefinition> = {};
-    const requiredSet: Set<string> = new Set();
+    const requiredSet = new Set<string>();
 
     const docTexts: string[] = [];
     const documentedSources: string[] = [];
@@ -101,56 +98,44 @@ export class IntersectionFormatter implements TypeFormatter {
         missingSources.push(docInfo.typeName);
       }
 
-      const schema = this.schemaGenerator.generateSchema(
-        part,
-        context.typeChecker,
-        undefined, // No specific type node for intersection parts
-      );
+      const schema = this.schemaGenerator.formatChildType(part, context);
+      const objSchema = this.resolveObjectSchema(schema, context);
+      if (!objSchema) continue;
 
-      if (this.isObjectSchema(schema)) {
-        // Merge properties from this part
-        if (schema.properties) {
-          for (const [key, value] of Object.entries(schema.properties)) {
-            const existing = mergedProps[key];
-            if (existing) {
-              // If both are object schemas, check description conflicts
-              if (isRecord(existing) && isRecord(value)) {
-                const aDesc = typeof existing.description === "string"
-                  ? (existing.description as string)
+      if (objSchema.properties) {
+        for (const [key, value] of Object.entries(objSchema.properties)) {
+          const existing = mergedProps[key];
+          if (existing) {
+            if (isRecord(existing) && isRecord(value)) {
+              const aDesc = typeof existing.description === "string"
+                ? existing.description as string
+                : undefined;
+              const bDesc = typeof value.description === "string"
+                ? value.description as string
+                : undefined;
+              if (aDesc && bDesc && aDesc !== bDesc) {
+                const priorComment = typeof existing.$comment === "string"
+                  ? existing.$comment as string
                   : undefined;
-                const bDesc = typeof value.description === "string"
-                  ? (value.description as string)
-                  : undefined;
-                if (aDesc && bDesc && aDesc !== bDesc) {
-                  const priorComment = typeof existing.$comment === "string"
-                    ? (existing.$comment as string)
-                    : undefined;
-                  (existing as Record<string, unknown>).$comment =
-                    priorComment ??
-                      "Conflicting docs across intersection constituents; using first";
-                  logger.warn(() =>
-                    `Intersection doc conflict for '${key}'; using first`
-                  );
-                }
+                (existing as Record<string, unknown>).$comment = priorComment ??
+                  DOC_CONFLICT_COMMENT;
+                logger.warn(() =>
+                  `Intersection doc conflict for '${key}'; using first`
+                );
               }
-              // Prefer the first definition by default; emit debug for visibility
-              logger.debug(() =>
-                `Intersection kept first definition for '${key}'`
-              );
-              // Keep existing
-              continue;
             }
-            mergedProps[key] = value as SchemaDefinition;
+            logger.debug(() =>
+              `Intersection kept first definition for '${key}'`
+            );
+            continue;
           }
+          mergedProps[key] = value as SchemaDefinition;
         }
+      }
 
-        // Merge required properties
-        if (Array.isArray(schema.required)) {
-          for (const req of schema.required) {
-            if (typeof req === "string") {
-              requiredSet.add(req);
-            }
-          }
+      if (Array.isArray(objSchema.required)) {
+        for (const req of objSchema.required) {
+          if (typeof req === "string") requiredSet.add(req);
         }
       }
     }
@@ -180,6 +165,32 @@ export class IntersectionFormatter implements TypeFormatter {
     );
   }
 
+  private resolveObjectSchema(
+    schema: SchemaDefinition,
+    context: GenerationContext,
+  ):
+    | (SchemaDefinition & {
+      properties?: Record<string, SchemaDefinition>;
+      required?: string[];
+    })
+    | undefined {
+    if (this.isObjectSchema(schema)) return schema;
+    if (
+      typeof schema === "object" &&
+      schema !== null &&
+      typeof (schema as Record<string, unknown>).$ref === "string"
+    ) {
+      const ref = (schema as Record<string, unknown>).$ref as string;
+      const prefix = "#/definitions/";
+      if (ref.startsWith(prefix)) {
+        const name = ref.slice(prefix.length);
+        const def = context.definitions[name];
+        if (def && this.isObjectSchema(def)) return def;
+      }
+    }
+    return undefined;
+  }
+
   private applyIntersectionDocs(
     data: {
       schema: SchemaDefinition;
@@ -205,26 +216,24 @@ export class IntersectionFormatter implements TypeFormatter {
 
     const commentParts: string[] = [];
     const existingComment = typeof schema.$comment === "string"
-      ? (schema.$comment as string)
+      ? schema.$comment as string
       : undefined;
 
     const uniqueDocumented = Array.from(new Set(documentedSources)).filter((
-      s,
-    ) => s);
-    const uniqueMissing = Array.from(new Set(missingSources)).filter((s) => s);
+      name,
+    ) => name);
+    const uniqueMissing = Array.from(new Set(missingSources)).filter((name) =>
+      name
+    );
 
     if (uniqueDocTexts.length > 0) {
       commentParts.push("Docs inherited from intersection constituents.");
     }
     if (uniqueDocTexts.length > 1 && uniqueDocumented.length > 0) {
-      commentParts.push(
-        `Sources: ${uniqueDocumented.join(", ")}.`,
-      );
+      commentParts.push(`Sources: ${uniqueDocumented.join(", ")}.`);
     }
     if (uniqueDocTexts.length > 0 && uniqueMissing.length > 0) {
-      commentParts.push(
-        `Missing docs for: ${uniqueMissing.join(", ")}.`,
-      );
+      commentParts.push(`Missing docs for: ${uniqueMissing.join(", ")}.`);
     }
 
     if (commentParts.length > 0) {

--- a/packages/schema-generator/src/formatters/intersection-formatter.ts
+++ b/packages/schema-generator/src/formatters/intersection-formatter.ts
@@ -5,6 +5,7 @@ import type {
   TypeFormatter,
 } from "../interface.ts";
 import type { SchemaGenerator } from "../schema-generator.ts";
+import { cloneSchemaDefinition, getNativeTypeSchema } from "../type-utils.ts";
 import { getLogger } from "@commontools/utils/logger";
 import { isRecord } from "@commontools/utils/types";
 import { extractDocFromType } from "../doc-utils.ts";
@@ -22,6 +23,10 @@ export class IntersectionFormatter implements TypeFormatter {
 
   formatType(type: ts.Type, context: GenerationContext): SchemaDefinition {
     const checker = context.typeChecker;
+    const native = getNativeTypeSchema(type, checker);
+    if (native !== undefined) {
+      return cloneSchemaDefinition(native);
+    }
     const inter = type as ts.IntersectionType;
     const parts = inter.types ?? [];
 

--- a/packages/schema-generator/src/formatters/object-formatter.ts
+++ b/packages/schema-generator/src/formatters/object-formatter.ts
@@ -4,7 +4,11 @@ import type {
   SchemaDefinition,
   TypeFormatter,
 } from "../interface.ts";
-import { isFunctionLike, safeGetPropertyType } from "../type-utils.ts";
+import {
+  getPrimarySymbol,
+  isFunctionLike,
+  safeGetPropertyType,
+} from "../type-utils.ts";
 import type { SchemaGenerator } from "../schema-generator.ts";
 import { extractDocFromSymbolAndDecls, getDeclDocs } from "../doc-utils.ts";
 import { getLogger } from "@commontools/utils/logger";
@@ -167,8 +171,6 @@ export class ObjectFormatter implements TypeFormatter {
   }
 
   private lookupBuiltInSchema(type: ts.Type): SchemaDefinition | undefined {
-    const symbol = type.symbol;
-    if (!symbol?.valueDeclaration) return undefined;
     const builtin = BUILT_IN_SCHEMAS.find((entry) => entry.test(type));
     return builtin ? structuredClone(builtin.schema) : undefined;
   }
@@ -184,19 +186,37 @@ const BUILT_IN_SCHEMAS: BuiltInSchemaEntry[] = [
     test: isNativeType("Date"),
     schema: { type: "string", format: "date-time" },
   },
+  {
+    test: isNativeType("URL"),
+    schema: { type: "string", format: "uri" },
+  },
+  {
+    test: isNativeType("Uint8Array"),
+    schema: true,
+  },
+  {
+    test: isNativeType("ArrayBuffer"),
+    schema: true,
+  },
 ];
 
 function isNativeType(name: string) {
   return (type: ts.Type) => {
-    const symbol = type.symbol;
-    if (!symbol || symbol.name !== name || !symbol.valueDeclaration) {
+    const symbol = getPrimarySymbol(type);
+    if (!symbol || symbol.name !== name) {
       return false;
     }
-    const sourceFile = symbol.valueDeclaration.getSourceFile();
-    const fileName = sourceFile.fileName;
-    return fileName.includes("lib.") ||
-      fileName.includes("typescript/lib") ||
-      fileName.includes("ES2023.d.ts") ||
-      fileName.includes("DOM.d.ts");
+    const declarations = [
+      symbol.valueDeclaration,
+      ...(symbol.declarations ?? []),
+    ].filter((decl): decl is ts.Declaration => Boolean(decl));
+    if (declarations.length === 0) return false;
+    return declarations.some((decl) => {
+      const fileName = decl.getSourceFile().fileName;
+      return fileName.includes("lib.") ||
+        fileName.includes("typescript/lib") ||
+        fileName.includes("ES2023.d.ts") ||
+        fileName.includes("DOM.d.ts");
+    });
   };
 }

--- a/packages/schema-generator/src/interface.ts
+++ b/packages/schema-generator/src/interface.ts
@@ -24,6 +24,10 @@ export interface GenerationContext {
   definitions: Record<string, SchemaDefinition>;
   /** Which $refs have been emitted */
   emittedRefs: Set<string>;
+  /** Synthetic names for anonymous recursive types */
+  anonymousNames: WeakMap<ts.Type, string>;
+  /** Counter to generate stable synthetic identifiers */
+  anonymousNameCounter: number;
 
   // Stack state (push/pop during recursion)
   /** Current recursion path for cycle detection */

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -139,6 +139,19 @@ export class SchemaGenerator implements ISchemaGenerator {
     context: GenerationContext,
     isRootType: boolean = false,
   ): SchemaDefinition {
+    if ((type.flags & ts.TypeFlags.TypeParameter) !== 0) {
+      const checker = context.typeChecker;
+      const baseConstraint = checker.getBaseConstraintOfType(type);
+      if (baseConstraint && baseConstraint !== type) {
+        return this.formatType(baseConstraint, context, isRootType);
+      }
+      const defaultConstraint = checker.getDefaultFromTypeParameter?.(type);
+      if (defaultConstraint && defaultConstraint !== type) {
+        return this.formatType(defaultConstraint, context, isRootType);
+      }
+      return {};
+    }
+
     // All-named strategy:
     // Hoist every named type (excluding wrappers filtered by getNamedTypeKey)
     // into definitions and return $ref for non-root uses. Cycle detection

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -274,17 +274,11 @@ export class SchemaGenerator implements ISchemaGenerator {
 
     // Handle boolean schemas (rare, but supported by JSON Schema)
     if (typeof base === "boolean") {
-      const filtered = this.collectReferencedDefinitions(base, definitions);
-      if (Object.keys(filtered).length === 0) return base;
-      return base === false
-        ? {
-          $schema: "https://json-schema.org/draft-07/schema#",
-          not: true,
-          definitions: filtered,
-        }
+      return base
+        ? { $schema: "https://json-schema.org/draft-07/schema#" }
         : {
           $schema: "https://json-schema.org/draft-07/schema#",
-          definitions: filtered,
+          not: true,
         };
     }
 

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -124,7 +124,7 @@ export class SchemaGenerator implements ISchemaGenerator {
     type: ts.Type,
     context: GenerationContext,
   ): string {
-    let existing = context.anonymousNames.get(type);
+    const existing = context.anonymousNames.get(type);
     if (existing) return existing;
     const synthetic = `AnonymousType_${++context.anonymousNameCounter}`;
     context.anonymousNames.set(type, synthetic);

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -274,12 +274,10 @@ export class SchemaGenerator implements ISchemaGenerator {
 
     // Handle boolean schemas (rare, but supported by JSON Schema)
     if (typeof base === "boolean") {
-      return base
-        ? { $schema: "https://json-schema.org/draft-07/schema#" }
-        : {
-          $schema: "https://json-schema.org/draft-07/schema#",
-          not: true,
-        };
+      return base ? { $schema: "https://json-schema.org/draft-07/schema#" } : {
+        $schema: "https://json-schema.org/draft-07/schema#",
+        not: true,
+      };
     }
 
     // Object schema: attach only the definitions actually referenced by the

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -156,7 +156,8 @@ export function getNamedTypeKey(
     (symFlags & ts.SymbolFlags.Property) !== 0 ||
     (symFlags & ts.SymbolFlags.Method) !== 0 ||
     (symFlags & ts.SymbolFlags.Signature) !== 0 ||
-    (symFlags & ts.SymbolFlags.Function) !== 0
+    (symFlags & ts.SymbolFlags.Function) !== 0 ||
+    (symFlags & ts.SymbolFlags.TypeParameter) !== 0
   ) {
     return undefined;
   }

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -166,6 +166,28 @@ export function getNamedTypeKey(
 }
 
 /**
+ * Determine if a type represents a callable/constructable function value.
+ */
+export function isFunctionLike(type: ts.Type): boolean {
+  if (type.getCallSignatures().length > 0) return true;
+  if (type.getConstructSignatures().length > 0) return true;
+
+  const symbol = type.symbol;
+  if (!symbol) return false;
+
+  const flags = symbol.flags;
+  if (
+    (flags & ts.SymbolFlags.Function) !== 0 ||
+    (flags & ts.SymbolFlags.Method) !== 0 ||
+    (flags & ts.SymbolFlags.Signature) !== 0
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
  * Helper to extract array element type using multiple detection methods
  */
 export type ArrayElementInfo = {

--- a/packages/schema-generator/test/fixtures/schema/alias-edge-cases.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/alias-edge-cases.expected.json
@@ -1,18 +1,10 @@
 {
   "properties": {
-    "veryDeepCell": {
-      "asCell": true,
-      "type": "string"
-    },
-    "deepStream": {
+    "deepNestedStream": {
       "asStream": true,
       "type": "number"
     },
-    "stringCellStream": {
-      "asStream": true,
-      "type": "string"
-    },
-    "deepNestedStream": {
+    "deepStream": {
       "asStream": true,
       "type": "number"
     },
@@ -30,39 +22,47 @@
       },
       "type": "array"
     },
+    "stringCellStream": {
+      "asStream": true,
+      "type": "string"
+    },
+    "userStore": {
+      "asCell": true,
+      "type": "string"
+    },
     "users": {
       "asCell": true,
       "items": {
         "properties": {
-          "name": {
-            "type": "string"
-          },
           "id": {
             "type": "number"
+          },
+          "name": {
+            "type": "string"
           }
         },
         "required": [
-          "name",
-          "id"
+          "id",
+          "name"
         ],
         "type": "object"
       },
       "type": "array"
     },
-    "userStore": {
+    "veryDeepCell": {
       "asCell": true,
       "type": "string"
     }
   },
   "required": [
-    "veryDeepCell",
-    "deepStream",
-    "stringCellStream",
     "deepNestedStream",
+    "deepStream",
     "indirectArray",
     "numberListCell",
+    "stringCellStream",
+    "userStore",
     "users",
-    "userStore"
+    "veryDeepCell"
   ],
   "type": "object"
 }

--- a/packages/schema-generator/test/fixtures/schema/date-types.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/date-types.expected.json
@@ -48,25 +48,6 @@
       ],
       "type": "object"
     },
-    "SchemaRoot": {
-      "properties": {
-        "document": {
-          "$ref": "#/definitions/Document"
-        },
-        "eventLog": {
-          "$ref": "#/definitions/EventLog"
-        },
-        "userProfile": {
-          "$ref": "#/definitions/UserProfile"
-        }
-      },
-      "required": [
-        "document",
-        "eventLog",
-        "userProfile"
-      ],
-      "type": "object"
-    },
     "UserProfile": {
       "properties": {
         "createdAt": {

--- a/packages/schema-generator/test/fixtures/schema/date-types.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/date-types.expected.json
@@ -1,6 +1,6 @@
 {
-  "properties": {
-    "document": {
+  "definitions": {
+    "Document": {
       "properties": {
         "archivedAt": {
           "anyOf": [
@@ -31,7 +31,7 @@
       ],
       "type": "object"
     },
-    "eventLog": {
+    "EventLog": {
       "properties": {
         "eventType": {
           "type": "string"
@@ -48,7 +48,26 @@
       ],
       "type": "object"
     },
-    "userProfile": {
+    "SchemaRoot": {
+      "properties": {
+        "document": {
+          "$ref": "#/definitions/Document"
+        },
+        "eventLog": {
+          "$ref": "#/definitions/EventLog"
+        },
+        "userProfile": {
+          "$ref": "#/definitions/UserProfile"
+        }
+      },
+      "required": [
+        "document",
+        "eventLog",
+        "userProfile"
+      ],
+      "type": "object"
+    },
+    "UserProfile": {
       "properties": {
         "createdAt": {
           "format": "date-time",
@@ -92,6 +111,17 @@
         "preferences"
       ],
       "type": "object"
+    }
+  },
+  "properties": {
+    "document": {
+      "$ref": "#/definitions/Document"
+    },
+    "eventLog": {
+      "$ref": "#/definitions/EventLog"
+    },
+    "userProfile": {
+      "$ref": "#/definitions/UserProfile"
     }
   },
   "required": [

--- a/packages/schema-generator/test/fixtures/schema/default-nullable-null.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/default-nullable-null.expected.json
@@ -1,7 +1,6 @@
 {
   "properties": {
     "maybe": {
-      "default": null,
       "anyOf": [
         {
           "type": "null"
@@ -9,7 +8,8 @@
         {
           "type": "string"
         }
-      ]
+      ],
+      "default": null
     }
   },
   "required": [

--- a/packages/schema-generator/test/fixtures/schema/default-type.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/default-type.expected.json
@@ -1,6 +1,6 @@
 {
-  "properties": {
-    "appConfig": {
+  "definitions": {
+    "AppConfig": {
       "properties": {
         "features": {
           "properties": {
@@ -55,7 +55,7 @@
       ],
       "type": "object"
     },
-    "cellDefaults": {
+    "CellDefaults": {
       "properties": {
         "counter": {
           "asCell": true,
@@ -77,7 +77,7 @@
       ],
       "type": "object"
     },
-    "complexDefault": {
+    "ComplexDefault": {
       "properties": {
         "config": {
           "default": {
@@ -124,7 +124,7 @@
       ],
       "type": "object"
     },
-    "listConfig": {
+    "ListConfig": {
       "properties": {
         "items": {
           "default": [
@@ -152,7 +152,7 @@
       ],
       "type": "object"
     },
-    "optionalDefaults": {
+    "OptionalWithDefaults": {
       "properties": {
         "nestedOptional": {
           "properties": {
@@ -176,7 +176,38 @@
       ],
       "type": "object"
     },
-    "userSettings": {
+    "SchemaRoot": {
+      "properties": {
+        "appConfig": {
+          "$ref": "#/definitions/AppConfig"
+        },
+        "cellDefaults": {
+          "$ref": "#/definitions/CellDefaults"
+        },
+        "complexDefault": {
+          "$ref": "#/definitions/ComplexDefault"
+        },
+        "listConfig": {
+          "$ref": "#/definitions/ListConfig"
+        },
+        "optionalDefaults": {
+          "$ref": "#/definitions/OptionalWithDefaults"
+        },
+        "userSettings": {
+          "$ref": "#/definitions/UserSettings"
+        }
+      },
+      "required": [
+        "appConfig",
+        "cellDefaults",
+        "complexDefault",
+        "listConfig",
+        "optionalDefaults",
+        "userSettings"
+      ],
+      "type": "object"
+    },
+    "UserSettings": {
       "properties": {
         "fontSize": {
           "default": 16,
@@ -197,6 +228,26 @@
         "theme"
       ],
       "type": "object"
+    }
+  },
+  "properties": {
+    "appConfig": {
+      "$ref": "#/definitions/AppConfig"
+    },
+    "cellDefaults": {
+      "$ref": "#/definitions/CellDefaults"
+    },
+    "complexDefault": {
+      "$ref": "#/definitions/ComplexDefault"
+    },
+    "listConfig": {
+      "$ref": "#/definitions/ListConfig"
+    },
+    "optionalDefaults": {
+      "$ref": "#/definitions/OptionalWithDefaults"
+    },
+    "userSettings": {
+      "$ref": "#/definitions/UserSettings"
     }
   },
   "required": [

--- a/packages/schema-generator/test/fixtures/schema/default-type.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/default-type.expected.json
@@ -176,37 +176,6 @@
       ],
       "type": "object"
     },
-    "SchemaRoot": {
-      "properties": {
-        "appConfig": {
-          "$ref": "#/definitions/AppConfig"
-        },
-        "cellDefaults": {
-          "$ref": "#/definitions/CellDefaults"
-        },
-        "complexDefault": {
-          "$ref": "#/definitions/ComplexDefault"
-        },
-        "listConfig": {
-          "$ref": "#/definitions/ListConfig"
-        },
-        "optionalDefaults": {
-          "$ref": "#/definitions/OptionalWithDefaults"
-        },
-        "userSettings": {
-          "$ref": "#/definitions/UserSettings"
-        }
-      },
-      "required": [
-        "appConfig",
-        "cellDefaults",
-        "complexDefault",
-        "listConfig",
-        "optionalDefaults",
-        "userSettings"
-      ],
-      "type": "object"
-    },
     "UserSettings": {
       "properties": {
         "fontSize": {

--- a/packages/schema-generator/test/fixtures/schema/defaults-complex-array.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/defaults-complex-array.expected.json
@@ -1,21 +1,72 @@
 {
+  "definitions": {
+    "SchemaRoot": {
+      "properties": {
+        "emptyItems": {
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/TodoItem"
+          },
+          "type": "array"
+        },
+        "matrix": {
+          "default": [
+            [
+              1,
+              2
+            ],
+            [
+              3,
+              4
+            ]
+          ],
+          "items": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "prefilledItems": {
+          "default": [
+            "item1",
+            "item2"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "emptyItems",
+        "matrix",
+        "prefilledItems"
+      ],
+      "type": "object"
+    },
+    "TodoItem": {
+      "properties": {
+        "done": {
+          "type": "boolean"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "done",
+        "title"
+      ],
+      "type": "object"
+    }
+  },
   "properties": {
     "emptyItems": {
       "default": [],
       "items": {
-        "properties": {
-          "done": {
-            "type": "boolean"
-          },
-          "title": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "done",
-          "title"
-        ],
-        "type": "object"
+        "$ref": "#/definitions/TodoItem"
       },
       "type": "array"
     },

--- a/packages/schema-generator/test/fixtures/schema/defaults-complex-array.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/defaults-complex-array.expected.json
@@ -1,51 +1,5 @@
 {
   "definitions": {
-    "SchemaRoot": {
-      "properties": {
-        "emptyItems": {
-          "default": [],
-          "items": {
-            "$ref": "#/definitions/TodoItem"
-          },
-          "type": "array"
-        },
-        "matrix": {
-          "default": [
-            [
-              1,
-              2
-            ],
-            [
-              3,
-              4
-            ]
-          ],
-          "items": {
-            "items": {
-              "type": "number"
-            },
-            "type": "array"
-          },
-          "type": "array"
-        },
-        "prefilledItems": {
-          "default": [
-            "item1",
-            "item2"
-          ],
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "required": [
-        "emptyItems",
-        "matrix",
-        "prefilledItems"
-      ],
-      "type": "object"
-    },
     "TodoItem": {
       "properties": {
         "done": {

--- a/packages/schema-generator/test/fixtures/schema/defaults-complex-object.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/defaults-complex-object.expected.json
@@ -14,8 +14,8 @@
         }
       },
       "required": [
-        "theme",
-        "count"
+        "count",
+        "theme"
       ],
       "type": "object"
     },
@@ -41,8 +41,8 @@
             }
           },
           "required": [
-            "notifications",
-            "email"
+            "email",
+            "notifications"
           ],
           "type": "object"
         }

--- a/packages/schema-generator/test/fixtures/schema/descriptions-nested.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-nested.expected.json
@@ -1,4 +1,30 @@
 {
+  "definitions": {
+    "ChildNode": {
+      "properties": {
+        "attachments": {
+          "description": "Attachments associated with the child node",
+          "items": true,
+          "type": "array"
+        },
+        "body": {
+          "description": "The main text content of the child node",
+          "type": "string"
+        },
+        "children": {
+          "description": "Children of the child node",
+          "items": true,
+          "type": "array"
+        }
+      },
+      "required": [
+        "attachments",
+        "body",
+        "children"
+      ],
+      "type": "object"
+    }
+  },
   "description": "Outliner document",
   "properties": {
     "attachments": {
@@ -13,28 +39,7 @@
     "children": {
       "description": "Child nodes of this node",
       "items": {
-        "properties": {
-          "attachments": {
-            "description": "Attachments associated with the child node",
-            "items": true,
-            "type": "array"
-          },
-          "body": {
-            "description": "The main text content of the child node",
-            "type": "string"
-          },
-          "children": {
-            "description": "Children of the child node",
-            "items": true,
-            "type": "array"
-          }
-        },
-        "required": [
-          "body",
-          "children",
-          "attachments"
-        ],
-        "type": "object"
+        "$ref": "#/definitions/ChildNode"
       },
       "type": "array"
     },
@@ -44,9 +49,9 @@
     }
   },
   "required": [
+    "attachments",
     "body",
     "children",
-    "attachments",
     "version"
   ],
   "type": "object"

--- a/packages/schema-generator/test/fixtures/schema/nested-default-aliases.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/nested-default-aliases.expected.json
@@ -4,19 +4,19 @@
       "default": "direct",
       "type": "string"
     },
-    "singleAlias": {
-      "default": "single",
-      "type": "string"
-    },
     "doubleAlias": {
       "default": "double",
+      "type": "string"
+    },
+    "singleAlias": {
+      "default": "single",
       "type": "string"
     }
   },
   "required": [
     "directDefault",
-    "singleAlias",
-    "doubleAlias"
+    "doubleAlias",
+    "singleAlias"
   ],
   "type": "object"
 }

--- a/packages/schema-generator/test/fixtures/schema/recipe-with-types-input.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/recipe-with-types-input.expected.json
@@ -1,25 +1,5 @@
 {
   "definitions": {
-    "InputSchemaInterface": {
-      "properties": {
-        "items": {
-          "default": [],
-          "items": {
-            "$ref": "#/definitions/Item"
-          },
-          "type": "array"
-        },
-        "title": {
-          "default": "untitled",
-          "type": "string"
-        }
-      },
-      "required": [
-        "items",
-        "title"
-      ],
-      "type": "object"
-    },
     "Item": {
       "properties": {
         "text": {

--- a/packages/schema-generator/test/fixtures/schema/recipe-with-types-input.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/recipe-with-types-input.expected.json
@@ -1,29 +1,54 @@
 {
-  "type": "object",
-  "properties": {
-    "title": {
-      "type": "string",
-      "default": "untitled"
-    },
-    "items": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "text": {
-            "type": "string",
-            "default": ""
-          }
+  "definitions": {
+    "InputSchemaInterface": {
+      "properties": {
+        "items": {
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/Item"
+          },
+          "type": "array"
         },
-        "required": [
-          "text"
-        ]
+        "title": {
+          "default": "untitled",
+          "type": "string"
+        }
       },
-      "default": []
+      "required": [
+        "items",
+        "title"
+      ],
+      "type": "object"
+    },
+    "Item": {
+      "properties": {
+        "text": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "items": {
+      "default": [],
+      "items": {
+        "$ref": "#/definitions/Item"
+      },
+      "type": "array"
+    },
+    "title": {
+      "default": "untitled",
+      "type": "string"
     }
   },
   "required": [
     "items",
     "title"
-  ]
+  ],
+  "type": "object"
 }

--- a/packages/schema-generator/test/fixtures/schema/recipe-with-types-output.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/recipe-with-types-output.expected.json
@@ -1,33 +1,62 @@
 {
-  "type": "object",
+  "definitions": {
+    "Item": {
+      "properties": {
+        "text": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "type": "object"
+    },
+    "OutputSchemaInterface": {
+      "properties": {
+        "items": {
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/Item"
+          },
+          "type": "array"
+        },
+        "items_count": {
+          "type": "number"
+        },
+        "title": {
+          "default": "untitled",
+          "type": "string"
+        }
+      },
+      "required": [
+        "items",
+        "items_count",
+        "title"
+      ],
+      "type": "object"
+    }
+  },
   "properties": {
+    "items": {
+      "default": [],
+      "items": {
+        "$ref": "#/definitions/Item"
+      },
+      "type": "array"
+    },
     "items_count": {
       "type": "number"
     },
     "title": {
-      "type": "string",
-      "default": "untitled"
-    },
-    "items": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "text": {
-            "type": "string",
-            "default": ""
-          }
-        },
-        "required": [
-          "text"
-        ]
-      },
-      "default": []
+      "default": "untitled",
+      "type": "string"
     }
   },
   "required": [
     "items",
     "items_count",
     "title"
-  ]
+  ],
+  "type": "object"
 }

--- a/packages/schema-generator/test/fixtures/schema/recipe-with-types-output.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/recipe-with-types-output.expected.json
@@ -11,30 +11,6 @@
         "text"
       ],
       "type": "object"
-    },
-    "OutputSchemaInterface": {
-      "properties": {
-        "items": {
-          "default": [],
-          "items": {
-            "$ref": "#/definitions/Item"
-          },
-          "type": "array"
-        },
-        "items_count": {
-          "type": "number"
-        },
-        "title": {
-          "default": "untitled",
-          "type": "string"
-        }
-      },
-      "required": [
-        "items",
-        "items_count",
-        "title"
-      ],
-      "type": "object"
     }
   },
   "properties": {

--- a/packages/schema-generator/test/fixtures/schema/recursive-type-nested.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/recursive-type-nested.expected.json
@@ -13,6 +13,17 @@
         "value"
       ],
       "type": "object"
+    },
+    "RootType": {
+      "properties": {
+        "list": {
+          "$ref": "#/definitions/LinkedList"
+        }
+      },
+      "required": [
+        "list"
+      ],
+      "type": "object"
     }
   },
   "properties": {

--- a/packages/schema-generator/test/fixtures/schema/recursive-type-nested.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/recursive-type-nested.expected.json
@@ -13,17 +13,6 @@
         "value"
       ],
       "type": "object"
-    },
-    "RootType": {
-      "properties": {
-        "list": {
-          "$ref": "#/definitions/LinkedList"
-        }
-      },
-      "required": [
-        "list"
-      ],
-      "type": "object"
     }
   },
   "properties": {

--- a/packages/schema-generator/test/fixtures/schema/simple-interface.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/simple-interface.expected.json
@@ -8,8 +8,8 @@
     }
   },
   "required": [
-    "name",
-    "age"
+    "age",
+    "name"
   ],
   "type": "object"
 }

--- a/packages/schema-generator/test/native-type-parameters.test.ts
+++ b/packages/schema-generator/test/native-type-parameters.test.ts
@@ -1,0 +1,24 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { SchemaGenerator } from "../src/schema-generator.ts";
+import { getTypeFromCode } from "./utils.ts";
+
+describe("Native type parameters", () => {
+  it("unwraps Uint8Array with defaulted typed buffer", async () => {
+    const code = `
+interface Wrapper {
+  value: Uint8Array;
+  pointer: Uint8Array<ArrayBufferLike & { foo?: number }>;
+}
+`;
+    const { type, checker } = await getTypeFromCode(code, "Wrapper");
+    const generator = new SchemaGenerator();
+    const schema = generator.generateSchema(type, checker);
+    const props = (schema as Record<string, any>).properties as
+      | Record<string, unknown>
+      | undefined;
+    expect(props?.value).toBe(true);
+    expect(props?.pointer).toBe(true);
+    expect((schema as Record<string, unknown>).definitions).toBeUndefined();
+  });
+});

--- a/packages/schema-generator/test/schema-generator.test.ts
+++ b/packages/schema-generator/test/schema-generator.test.ts
@@ -147,5 +147,62 @@ interface HasDate {
         format: "date-time",
       });
     });
+
+    it("formats URL as string with uri format without hoisting", async () => {
+      const generator = new SchemaGenerator();
+      const code = `
+interface HasUrl {
+  homepage: URL;
+}`;
+      const { type, checker } = await getTypeFromCode(code, "HasUrl");
+
+      const schema = generator.generateSchema(type, checker);
+      const objectSchema = schema as Record<string, unknown>;
+      const props = objectSchema.properties as
+        | Record<string, Record<string, unknown>>
+        | undefined;
+
+      expect(objectSchema.definitions).toBeUndefined();
+      expect(props?.homepage).toEqual({
+        type: "string",
+        format: "uri",
+      });
+    });
+
+    it("formats Uint8Array as permissive true schema", async () => {
+      const generator = new SchemaGenerator();
+      const code = `
+interface BinaryHolder {
+  data: Uint8Array;
+}`;
+      const { type, checker } = await getTypeFromCode(code, "BinaryHolder");
+
+      const schema = generator.generateSchema(type, checker);
+      const objectSchema = schema as Record<string, unknown>;
+      const props = objectSchema.properties as
+        | Record<string, unknown>
+        | undefined;
+
+      expect(objectSchema.definitions).toBeUndefined();
+      expect(props?.data).toBe(true);
+    });
+
+    it("formats ArrayBuffer as permissive true schema", async () => {
+      const generator = new SchemaGenerator();
+      const code = `
+interface BufferHolder {
+  buffer: ArrayBuffer;
+}`;
+      const { type, checker } = await getTypeFromCode(code, "BufferHolder");
+
+      const schema = generator.generateSchema(type, checker);
+      const objectSchema = schema as Record<string, unknown>;
+      const props = objectSchema.properties as
+        | Record<string, unknown>
+        | undefined;
+
+      expect(objectSchema.definitions).toBeUndefined();
+      expect(props?.buffer).toBe(true);
+    });
   });
 });

--- a/packages/schema-generator/test/schema-generator.test.ts
+++ b/packages/schema-generator/test/schema-generator.test.ts
@@ -125,4 +125,27 @@ type Wrapper = {
       );
     });
   });
+
+  describe("built-in mappings", () => {
+    it("formats Date as string with date-time format without hoisting", async () => {
+      const generator = new SchemaGenerator();
+      const code = `
+interface HasDate {
+  createdAt: Date;
+}`;
+      const { type, checker } = await getTypeFromCode(code, "HasDate");
+
+      const schema = generator.generateSchema(type, checker);
+      const objectSchema = schema as Record<string, unknown>;
+      const props = objectSchema.properties as
+        | Record<string, Record<string, unknown>>
+        | undefined;
+
+      expect(objectSchema.definitions).toBeUndefined();
+      expect(props?.createdAt).toEqual({
+        type: "string",
+        format: "date-time",
+      });
+    });
+  });
 });

--- a/packages/schema-generator/test/schema/complex-defaults.test.ts
+++ b/packages/schema-generator/test/schema/complex-defaults.test.ts
@@ -22,8 +22,18 @@ describe("Schema: Complex defaults", () => {
 
     const empty = s.properties?.emptyItems as any;
     expect(empty.type).toBe("array");
-    expect(empty.items?.type).toBe("object");
-    expect(empty.items?.required).toEqual(["title", "done"]);
+    const emptyItems = empty.items as any;
+    if (emptyItems.$ref) {
+      expect(emptyItems.$ref).toBe("#/definitions/TodoItem");
+      const def = (s as any).definitions?.TodoItem as any;
+      expect(def.type).toBe("object");
+      expect(def.properties?.title?.type).toBe("string");
+      expect(def.properties?.done?.type).toBe("boolean");
+      expect(def.required).toEqual(["title", "done"]);
+    } else {
+      expect(emptyItems.type).toBe("object");
+      expect(emptyItems.required).toEqual(["title", "done"]);
+    }
     expect(Array.isArray(empty.default)).toBe(true);
 
     const pre = s.properties?.prefilledItems as any;

--- a/packages/schema-generator/test/schema/type-aliases-and-shared.test.ts
+++ b/packages/schema-generator/test/schema/type-aliases-and-shared.test.ts
@@ -50,7 +50,7 @@ describe("Schema: Type aliases and shared types", () => {
     expect(na.items?.items?.type).toBe("string");
   });
 
-  it("duplicates shared object type structure where referenced twice", async () => {
+  it("hoists shared object type to definitions and references via $ref", async () => {
     const code = `
       interface B { value: string; }
       interface A { b1: B; b2: B; }
@@ -59,10 +59,11 @@ describe("Schema: Type aliases and shared types", () => {
     const s = createSchemaTransformerV2()(type, checker);
     const b1 = s.properties?.b1 as any;
     const b2 = s.properties?.b2 as any;
-    for (const bx of [b1, b2]) {
-      expect(bx.type).toBe("object");
-      expect(bx.properties?.value?.type).toBe("string");
-      expect(bx.required).toContain("value");
-    }
+    expect(b1.$ref).toBe("#/definitions/B");
+    expect(b2.$ref).toBe("#/definitions/B");
+    const defB = (s as any).definitions?.B as any;
+    expect(defB.type).toBe("object");
+    expect(defB.properties?.value?.type).toBe("string");
+    expect(defB.required).toContain("value");
   });
 });

--- a/packages/schema-generator/test/schema/type-to-schema.test.ts
+++ b/packages/schema-generator/test/schema/type-to-schema.test.ts
@@ -34,7 +34,12 @@ describe("Schema: type-to-schema parity", () => {
     // RecipeOutput
     expect(o.properties?.values?.type).toBe("array");
     expect(o.properties?.values?.items?.type).toBe("string");
-    expect(o.properties?.updater?.type).toBe("object");
-    expect(o.properties?.updater?.asStream).toBe(true);
+    const upd = o.properties?.updater as any;
+    expect(upd.asStream).toBe(true);
+    expect(upd.$ref).toBe("#/definitions/UpdaterInput");
+    const defU = (o as any).definitions?.UpdaterInput as any;
+    expect(defU.type).toBe("object");
+    expect(defU.properties?.newValues?.type).toBe("array");
+    expect(defU.properties?.newValues?.items?.type).toBe("string");
   });
 });


### PR DESCRIPTION
Addresses/fixes Robin's feedback in https://linear.app/common-tools/issue/CT-884/named-types-should-get-entry-in-dollardefs.

Still does not auto-promote the root. Can easily change this, reviewers let me know your thoughts!
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switches the schema generator to hoist all named non-container types into definitions and use $ref for non-root uses. This reduces duplication, improves readability, and satisfies Linear CT-884.

- **Refactors**
  - Emit $ref for every named type except wrappers: Array, ReadonlyArray, Cell, Stream, Default, Date.
  - Root types remain inline (no auto-promotion yet).
  - $ref can appear with Common Tools extensions as siblings (e.g., asStream: true).
  - Updated fixtures/tests to expect definitions and $ref; added README notes.

<!-- End of auto-generated description by cubic. -->

