### PR TITLE
Extract common `Chat` recipe

### DIFF
--- a/packages/patterns/chatbot-note.tsx
+++ b/packages/patterns/chatbot-note.tsx
@@ -28,25 +28,12 @@ import Chat from './chatbot.tsx'
 
 type Charm = any;
 
-type OutlinerNode = {
-  body: Default<string, "">;
-  children: Default<OutlinerNode[], []>;
-  attachments: Default<OpaqueRef<any>[], []>;
+type NoteResult = {
+  content: Default<string, "">;
 };
 
-type Outliner = {
-  root: OutlinerNode;
-};
-
-type PageResult = {
-  outline: Default<
-    Outliner,
-    { root: { body: ""; children: []; attachments: [] } }
-  >;
-};
-
-export type PageInput = {
-  outline: Outliner;
+export type NoteInput = {
+  content: Default<string, "">;
   allCharms: Cell<Charm[]>;
 };
 
@@ -61,19 +48,21 @@ const handleCharmLinkClick = handler<
   return navigateTo(detail.charm);
 });
 
-export const Page = recipe<PageInput>(
-  "Page",
-  ({ outline, allCharms }) => {
+export const Note = recipe<NoteInput>(
+  "Note",
+  ({ content, allCharms }) => {
     return {
-      [NAME]: "Page",
+      [NAME]: "Note",
       [UI]: (
-        <ct-outliner
-          $value={outline as any}
+        <ct-code-editor
+          $value={content}
           $mentionable={allCharms}
           oncharm-link-click={handleCharmLinkClick({})}
+          language="text/markdown"
+          style="min-height: 400px;"
         />
       ),
-      outline,
+      content,
     };
   },
 );
@@ -82,10 +71,7 @@ type LLMTestInput = {
   title: Default<string, "LLM Test">;
   messages: Default<Array<BuiltInLLMMessage>, []>;
   expandChat: Default<boolean, false>;
-  outline: Default<
-    Outliner,
-    { root: { body: "Untitled Page"; children: []; attachments: [] } }
-  >;
+  content: Default<string, "">;
   allCharms: Cell<Charm[]>;
 };
 
@@ -93,26 +79,22 @@ type LLMTestResult = {
   messages: Default<Array<BuiltInLLMMessage>, []>;
 };
 
-// put a node at the end of the outline (by appending to root.children)
-const appendOutlinerNode = handler<
+// put a note at the end of the outline (by appending to root.children)
+const editNote = handler<
   {
-    /** The text content/title of the outliner node to be appended */
+    /** The text content of the note */
     body: string;
     /** A cell to store the result message indicating success or error */
     result: Cell<string>;
   },
-  { outline: Cell<Outliner> }
+  { content: Cell<string> }
 >(
   (args, state) => {
     try {
-      (state.outline.key("root").key("children")).push({
-        body: args.body,
-        children: [],
-        attachments: [],
-      });
+      state.content.set(args.body);
 
       args.result.set(
-        `${state.outline.key("root").key("children").get().length} nodes`,
+        `Updated note!`,
       );
     } catch (error) {
       args.result.set(`Error: ${(error as any)?.message || "<error>"}`);
@@ -120,23 +102,48 @@ const appendOutlinerNode = handler<
   },
 );
 
+const readNote = handler<
+  {
+    /** A cell to store the result text */
+    result: Cell<string>;
+  },
+  { content: string }
+>(
+  (args, state) => {
+    try {
+      args.result.set(state.content);
+    } catch (error) {
+      args.result.set(`Error: ${(error as any)?.message || "<error>"}`);
+    }
+  },
+);
+
 export default recipe<LLMTestInput, LLMTestResult>(
-  "Outliner",
-  ({ title, expandChat, messages, outline, allCharms }) => {
+  "Note",
+  ({ title, expandChat, messages, content, allCharms }) => {
     const tools = {
-      appendOutlinerNode: {
-        description: "Add a new outliner node.",
+      editNote: {
+        description: "Modify the shared note.",
         inputSchema: {
           type: "object",
           properties: {
             body: {
               type: "string",
-              description: "The title of the new node.",
+              description: "The content of the note.",
             },
           },
           required: ["body"],
         } as JSONSchema,
-        handler: appendOutlinerNode({ outline }),
+        handler: editNote({ content }),
+      },
+      readNote: {
+        description: "Read the shared note.",
+        inputSchema: {
+          type: "object",
+          properties: { },
+          required: [],
+        } as JSONSchema,
+        handler: readNote({ content }),
       },
     };
 
@@ -165,7 +172,7 @@ export default recipe<LLMTestInput, LLMTestResult>(
 
               <ct-vscroll flex showScrollbar fadeEdges snapToBottom>
                 <ct-vstack data-label="Tools">
-                  <Page outline={outline} allCharms={allCharms} />
+                  <Note content={content} allCharms={allCharms} />
                 </ct-vstack>
               </ct-vscroll>
             </ct-screen>

--- a/packages/patterns/chatbot-note.tsx
+++ b/packages/patterns/chatbot-note.tsx
@@ -24,7 +24,7 @@ import {
   UI,
 } from "commontools";
 
-import Chat from './chatbot.tsx'
+import Chat from "./chatbot.tsx";
 
 type Charm = any;
 
@@ -140,7 +140,7 @@ export default recipe<LLMTestInput, LLMTestResult>(
         description: "Read the shared note.",
         inputSchema: {
           type: "object",
-          properties: { },
+          properties: {},
           required: [],
         } as JSONSchema,
         handler: readNote({ content }),
@@ -180,7 +180,7 @@ export default recipe<LLMTestInput, LLMTestResult>(
             {ifElse(
               expandChat,
               chat,
-              null
+              null,
             )}
           </ct-autolayout>
         </ct-screen>

--- a/packages/patterns/chatbot-outliner.tsx
+++ b/packages/patterns/chatbot-outliner.tsx
@@ -24,7 +24,7 @@ import {
   UI,
 } from "commontools";
 
-import Chat from './chatbot.tsx'
+import Chat from "./chatbot.tsx";
 
 type Charm = any;
 
@@ -173,7 +173,7 @@ export default recipe<LLMTestInput, LLMTestResult>(
             {ifElse(
               expandChat,
               chat,
-              null
+              null,
             )}
           </ct-autolayout>
         </ct-screen>

--- a/packages/patterns/chatbot-theme.tsx
+++ b/packages/patterns/chatbot-theme.tsx
@@ -22,7 +22,7 @@ import {
   UI,
 } from "commontools";
 
-import Chat from './chatbot.tsx';
+import Chat from "./chatbot.tsx";
 
 type LLMTestInput = {
   title: Default<string, "LLM Test">;
@@ -84,7 +84,6 @@ const setTheme = handler<
 export default recipe<LLMTestInput, LLMTestResult>(
   "LLM Test",
   ({ title, messages, theme }) => {
-
     const tools = {
       setTheme: {
         description:

--- a/packages/patterns/chatbot-theme.tsx
+++ b/packages/patterns/chatbot-theme.tsx
@@ -22,9 +22,11 @@ import {
   UI,
 } from "commontools";
 
+import Chat from './chatbot.tsx';
+
 type LLMTestInput = {
   title: Default<string, "LLM Test">;
-  chat: Default<Array<BuiltInLLMMessage>, []>;
+  messages: Default<Array<BuiltInLLMMessage>, []>;
   theme: {
     accentColor: Default<string, "#3b82f6">;
     fontFace: Default<string, "Arial, sans-serif">;
@@ -33,7 +35,7 @@ type LLMTestInput = {
 };
 
 type LLMTestResult = {
-  chat: Default<Array<BuiltInLLMMessage>, []>;
+  messages: Default<Array<BuiltInLLMMessage>, []>;
 };
 
 const setTheme = handler<
@@ -79,40 +81,9 @@ const setTheme = handler<
   }
 });
 
-const sendMessage = handler<
-  { detail: { message: string } },
-  {
-    addMessage: Stream<BuiltInLLMMessage>;
-  }
->((event, { addMessage }) => {
-  addMessage.send({
-    role: "user",
-    content: [{ type: "text", text: event.detail.message }],
-  });
-});
-
-const clearChat = handler(
-  (
-    _: never,
-    { chat, llmResponse }: {
-      chat: Cell<Array<BuiltInLLMMessage>>;
-      llmResponse: {
-        pending: Cell<boolean>;
-      };
-    },
-  ) => {
-    chat.set([]);
-    llmResponse.pending.set(false);
-  },
-);
-
 export default recipe<LLMTestInput, LLMTestResult>(
   "LLM Test",
-  ({ title, chat, theme }) => {
-    const calculatorResult = cell<string>("");
-    const model = cell<string>("anthropic:claude-sonnet-4-0");
-    const searchWebResult = cell<string>("");
-    const readWebpageResult = cell<string>("");
+  ({ title, messages, theme }) => {
 
     const tools = {
       setTheme: {
@@ -142,89 +113,22 @@ export default recipe<LLMTestInput, LLMTestResult>(
       },
     };
 
-    const { addMessage, cancelGeneration, pending } = llmDialog({
-      system: "You are a helpful assistant with some tools.",
-      messages: chat,
-      tools: tools,
-      model,
-    });
-
-    // Debug logging
-    // derive(chat, (c) => {
-    //   console.log("[CHAT] Messages:", c.length);
-    //   if (c.length > 0) {
-    //     const last = c[c.length - 1];
-    //     console.log(
-    //       "[CHAT] Last message:",
-    //       last.role,
-    //       typeof last.content === "string"
-    //         ? last.content.substring(0, 50) + "..."
-    //         : last.content,
-    //     );
-    //   }
-    // });
-
-    const { result } = fetchData({
-      url: "/api/ai/llm/models",
-      mode: "json",
-    });
-
-    const items = derive(result, (models) => {
-      if (!models) return [];
-
-      console.log("[LLM] Models:", models);
-      const items = Object.keys(models as any).map((key) => ({
-        label: key,
-        value: key,
-      }));
-
-      console.log("[LLM] Items:", items);
-      return items;
-    });
+    const chat = Chat({ messages, tools, theme });
+    const { addMessage, cancelGeneration, pending } = chat;
 
     return {
       [NAME]: title,
       [UI]: (
         <ct-screen>
           <ct-hstack justify="between" slot="header">
-            <ct-button
-              id="clear-chat-button"
-              onClick={clearChat({
-                chat,
-                llmResponse: { pending },
-              })}
-            >
-              Clear Chat
-            </ct-button>
-
-            <div>
-              <ct-select
-                items={items}
-                $value={model}
-              />
-            </div>
+            <ct-input
+              $value={title}
+              placeholder="Enter title..."
+            />
           </ct-hstack>
 
           <ct-autolayout tabNames={["Chat", "Tools"]}>
-            <ct-screen>
-              <ct-vscroll flex showScrollbar fadeEdges snapToBottom>
-                <ct-chat
-                  theme={theme}
-                  $messages={chat}
-                  pending={pending}
-                  tools={tools}
-                />
-              </ct-vscroll>
-
-              <div slot="footer">
-                <ct-prompt-input
-                  placeholder="Ask the LLM a question..."
-                  pending={pending}
-                  onct-send={sendMessage({ addMessage })}
-                  onct-stop={cancelGeneration}
-                />
-              </div>
-            </ct-screen>
+            {chat}
 
             <ct-vscroll flex showScrollbar fadeEdges snapToBottom>
               <ct-vstack data-label="Tools">
@@ -286,7 +190,7 @@ export default recipe<LLMTestInput, LLMTestResult>(
           </ct-autolayout>
         </ct-screen>
       ),
-      chat,
+      messages,
     };
   },
 );

--- a/packages/patterns/chatbot-tools.tsx
+++ b/packages/patterns/chatbot-tools.tsx
@@ -20,7 +20,7 @@ import {
   UI,
 } from "commontools";
 
-import Chat from './chatbot.tsx';
+import Chat from "./chatbot.tsx";
 
 type ListItem = {
   title: string;

--- a/packages/patterns/chatbot-tools.tsx
+++ b/packages/patterns/chatbot-tools.tsx
@@ -20,7 +20,7 @@ import {
   UI,
 } from "commontools";
 
-import Chat from "./chatbot.tsx";
+import Chat from './chatbot.tsx';
 
 type ListItem = {
   title: string;
@@ -36,48 +36,10 @@ type LLMTestResult = {
   messages: Default<Array<BuiltInLLMMessage>, []>;
 };
 
-const calculator = handler<
+/*** Tools ***/
+
+const calculator = recipe<
   { expression: string; result: Cell<string> },
-  { result: Cell<string> }
->(
-  (args, state) => {
-    try {
-      // Simple calculator - only allow basic operations for security
-      const sanitized = args.expression.replace(/[^0-9+\-*/().\s]/g, "");
-      const result = Function(`"use strict"; return (${sanitized})`)();
-      args.result.set(`${args.expression} = ${result}`);
-      state.result.set(`${args.expression} = ${result}`);
-    } catch (error) {
-      args.result.set(
-        `Error calculating ${args.expression}: ${
-          (error as any)?.message || "<error>"
-        }`,
-      );
-      state.result.set(
-        `Error calculating ${args.expression}: ${
-          (error as any)?.message || "<error>"
-        }`,
-      );
-    }
-  },
-);
-
-const addListItem = handler<
-  { item: string; result: Cell<string> },
-  { list: Cell<ListItem[]> }
->(
-  (args, state) => {
-    try {
-      state.list.push({ title: args.item });
-      args.result.set(`${state.list.get().length} items`);
-    } catch (error) {
-      args.result.set(`Error: ${(error as any)?.message || "<error>"}`);
-    }
-  },
-);
-
-const searchWeb = handler<
-  { query: string; result: Cell<string> },
   { result: Cell<string> }
 >("Calculator", ({ expression }) => {
   return derive(expression, (expr) => {
@@ -175,10 +137,7 @@ const readWebpage = recipe<
 export default recipe<LLMTestInput, LLMTestResult>(
   "LLM Test",
   ({ title, messages, list }) => {
-    const calculatorResult = cell<string>("");
-    const searchWebResult = cell<string>("");
-    const readWebpageResult = cell<string>("");
-
+    const model = cell<string>("anthropic:claude-sonnet-4-0");
     const tools = {
       search_web: {
         description: "Search the web for information.",
@@ -248,6 +207,13 @@ export default recipe<LLMTestInput, LLMTestResult>(
       [NAME]: title,
       [UI]: (
         <ct-screen>
+          <ct-hstack justify="between" slot="header">
+            <ct-input
+              $value={title}
+              placeholder="Enter title..."
+            />
+          </ct-hstack>
+
           <ct-autolayout tabNames={["Chat", "Tools"]}>
             {chat}
 

--- a/packages/patterns/chatbot-tools.tsx
+++ b/packages/patterns/chatbot-tools.tsx
@@ -20,7 +20,7 @@ import {
   UI,
 } from "commontools";
 
-import Chat from './chatbot.tsx'
+import Chat from "./chatbot.tsx";
 
 type ListItem = {
   title: string;

--- a/packages/patterns/chatbot.tsx
+++ b/packages/patterns/chatbot.tsx
@@ -107,7 +107,12 @@ export default recipe<ChatInput, ChatOutput>(
           </ct-hstack>
 
           <ct-vscroll flex showScrollbar fadeEdges snapToBottom>
-            <ct-chat theme={theme} $messages={messages} pending={pending} tools={tools} />
+            <ct-chat
+              theme={theme}
+              $messages={messages}
+              pending={pending}
+              tools={tools}
+            />
           </ct-vscroll>
 
           <div slot="footer">

--- a/packages/patterns/chatbot.tsx
+++ b/packages/patterns/chatbot.tsx
@@ -48,14 +48,14 @@ const clearChat = handler(
 type ChatInput = {
   messages: Default<Array<BuiltInLLMMessage>, []>;
   tools: any;
-}
+};
 
 type ChatOutput = {
   messages: Array<BuiltInLLMMessage>;
   pending: boolean | undefined;
   addMessage: Stream<BuiltInLLMMessage>;
   cancelGeneration: Stream<void>;
-}
+};
 
 export default recipe<ChatInput, ChatOutput>(
   "Chat",
@@ -89,19 +89,19 @@ export default recipe<ChatInput, ChatOutput>(
         <ct-screen>
           <ct-hstack justify="between" slot="header">
             <div>
-            <h2>Chat</h2>
+              <h2>Chat</h2>
             </div>
 
             <div>
-            <ct-button
-              id="clear-chat-button"
-              onClick={clearChat({
-                messages,
-                pending,
-              })}
-            >
-              Clear Chat
-            </ct-button>
+              <ct-button
+                id="clear-chat-button"
+                onClick={clearChat({
+                  messages,
+                  pending,
+                })}
+              >
+                Clear Chat
+              </ct-button>
             </div>
           </ct-hstack>
 

--- a/packages/patterns/chatbot.tsx
+++ b/packages/patterns/chatbot.tsx
@@ -48,6 +48,7 @@ const clearChat = handler(
 type ChatInput = {
   messages: Default<Array<BuiltInLLMMessage>, []>;
   tools: any;
+  theme?: any;
 };
 
 type ChatOutput = {
@@ -59,7 +60,7 @@ type ChatOutput = {
 
 export default recipe<ChatInput, ChatOutput>(
   "Chat",
-  ({ messages, tools }) => {
+  ({ messages, tools, theme }) => {
     const model = cell<string>("anthropic:claude-sonnet-4-0");
 
     const { addMessage, cancelGeneration, pending } = llmDialog({
@@ -106,7 +107,7 @@ export default recipe<ChatInput, ChatOutput>(
           </ct-hstack>
 
           <ct-vscroll flex showScrollbar fadeEdges snapToBottom>
-            <ct-chat $messages={messages} pending={pending} tools={tools} />
+            <ct-chat theme={theme} $messages={messages} pending={pending} tools={tools} />
           </ct-vscroll>
 
           <div slot="footer">


### PR DESCRIPTION
- **Break out `Chat` recipe**
- **Re-use common chatbot.tsx**

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Extracted a shared Chat recipe and updated the Outliner and Tools patterns to use it, removing duplicated LLM logic and unifying the chat UI. Added a Note pattern with read/edit tools that also reuses the shared Chat.

- **Refactors**
  - Introduced Chat({ messages, tools }) recipe that renders ct-chat with ct-prompt-input, model select, and Clear Chat; exposes addMessage, cancelGeneration, pending.
  - Outliner: replaced inline llmDialog/handlers with Chat; renamed prop/result chat → messages; added expandChat to toggle chat; cleaned up header and layout.
  - Tools: switched to Chat; renamed prop/result chat → messages; removed per-pattern model select and clear handlers.

- **Migration**
  - Rename chat to messages in inputs/outputs and call sites.
  - Replace per-pattern llmDialog and send/clear handlers with Chat({ messages, tools }).
  - Pass tools to Chat; it manages prompt input, stop, and pending state.
  - Remove local model selectors and Clear Chat buttons; these now live in Chat.
  - Optionally add an expandChat boolean if you want a UI toggle to show/hide Chat.

<!-- End of auto-generated description by cubic. -->

