### PR TITLE
feat: Move CliProgram to a deno-only js-runtime export FileSystemProgramResolver

### DIFF
--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -17,9 +17,8 @@ import {
 } from "@commontools/charm";
 import { CharmsController } from "@commontools/charm/ops";
 import { join } from "@std/path";
-import { CliProgram } from "./dev.ts";
-import { ValidationError } from "@cliffy/command";
 import { isVNode } from "@commontools/html";
+import { FileSystemProgramResolver } from "@commontools/js-runtime/deno";
 
 export interface EntryConfig {
   mainPath: string;
@@ -129,7 +128,7 @@ async function getProgramFromFile(
 ): Promise<RuntimeProgram> {
   // Walk entry file and collect all sources from fs.
   const program: RuntimeProgram = await manager.runtime.harness.resolve(
-    new CliProgram(entry.mainPath),
+    new FileSystemProgramResolver(entry.mainPath),
   );
   if (entry.mainExport) {
     program.mainExport = entry.mainExport;

--- a/packages/js-runtime/deno.json
+++ b/packages/js-runtime/deno.json
@@ -10,7 +10,7 @@
   "exports": {
     ".": "./mod.ts",
     "./typescript": "./typescript/mod.ts",
-    "./cli": "./cli/mod.ts"
+    "./deno": "./deno.ts"
   },
   "fmt": {
     "exclude": ["test/fixtures/"]

--- a/packages/js-runtime/deno.ts
+++ b/packages/js-runtime/deno.ts
@@ -1,0 +1,35 @@
+import { ProgramResolver, Source } from "./interface.ts";
+import { dirname, join } from "@std/path";
+
+// Extend `EngineProgramResolver` to add the necessary 3P module
+// types when needed, but otherwise lazily crawl the filesystem
+// while walking source files
+export class FileSystemProgramResolver implements ProgramResolver {
+  private fsRoot: string;
+  private _main: Source;
+  constructor(mainPath: string) {
+    this.fsRoot = dirname(mainPath);
+    this._main = {
+      name: mainPath.substring(this.fsRoot.length),
+      contents: Deno.readTextFileSync(mainPath),
+    };
+  }
+
+  main(): Source {
+    return this._main;
+  }
+
+  resolveSource(specifier: string): Promise<Source | undefined> {
+    if (specifier && specifier[0] === "/") {
+      const absPath = join(
+        this.fsRoot,
+        specifier.substring(1, specifier.length),
+      );
+      return Promise.resolve({
+        name: specifier,
+        contents: Deno.readTextFileSync(absPath),
+      });
+    }
+    return Promise.resolve(undefined);
+  }
+}

--- a/packages/patterns/counter-handlers.ts
+++ b/packages/patterns/counter-handlers.ts
@@ -1,0 +1,29 @@
+/// <cts-enable />
+import { Cell, handler } from "commontools";
+
+export const increment = handler<unknown, { value: Cell<number> }>(
+  (_, state) => {
+    state.value.set(state.value.get() + 1);
+  },
+);
+
+export const decrement = handler((_, state: { value: Cell<number> }) => {
+  state.value.set(state.value.get() - 1);
+});
+
+export function nth(value: number) {
+  if (value === 1) {
+    return "1st";
+  }
+  if (value === 2) {
+    return "2nd";
+  }
+  if (value === 3) {
+    return "3rd";
+  }
+  return `${value}th`;
+}
+
+export function previous(value: number) {
+  return value - 1;
+}

--- a/packages/patterns/counter.tsx
+++ b/packages/patterns/counter.tsx
@@ -1,45 +1,9 @@
 /// <cts-enable />
-import {
-  Cell,
-  Default,
-  derive,
-  h,
-  handler,
-  NAME,
-  Opaque,
-  OpaqueRef,
-  recipe,
-  str,
-  UI,
-} from "commontools";
+import { Default, h, NAME, recipe, str, UI } from "commontools";
+import { decrement, increment, nth, previous } from "./counter-handlers.ts";
 
 interface RecipeState {
   value: Default<number, 0>;
-}
-
-const increment = handler<unknown, { value: Cell<number> }>((_, state) => {
-  state.value.set(state.value.get() + 1);
-});
-
-const decrement = handler((_, state: { value: Cell<number> }) => {
-  state.value.set(state.value.get() - 1);
-});
-
-function previous(value: number) {
-  return value - 1;
-}
-
-function nth(value: number) {
-  if (value === 1) {
-    return "1st";
-  }
-  if (value === 2) {
-    return "2nd";
-  }
-  if (value === 3) {
-    return "3rd";
-  }
-  return `${value}th`;
 }
 
 export default recipe<RecipeState>("Counter", (state) => {

--- a/packages/patterns/integration/all.test.ts
+++ b/packages/patterns/integration/all.test.ts
@@ -4,6 +4,8 @@ import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { assert } from "@std/assert";
 import { Identity } from "@commontools/identity";
+import { FileSystemProgramResolver } from "@commontools/js-runtime/deno";
+import { RuntimeProgram } from "@commontools/runner";
 
 const { API_URL, SPACE_NAME } = env;
 
@@ -29,16 +31,12 @@ describe("Compile all recipes", () => {
     });
 
     it(`Executes: ${name}`, async () => {
-      const charm = await cc!.create(
-        await Deno.readTextFile(
-          join(
-            import.meta.dirname!,
-            "..",
-            name,
-          ),
-        ),
-        { start: false },
-      );
+      const sourcePath = join(import.meta.dirname!, "..", name);
+      const program = await cc.manager().runtime.harness
+        .resolve(
+          new FileSystemProgramResolver(sourcePath),
+        );
+      const charm = await cc!.create(program, { start: false });
       assert(charm.id, `Received charm ID ${charm.id} for ${name}.`);
     });
   }

--- a/packages/patterns/integration/counter.test.ts
+++ b/packages/patterns/integration/counter.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commontools/identity";
+import { FileSystemProgramResolver } from "@commontools/js-runtime/deno";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
@@ -24,15 +25,13 @@ describe("counter direct operations test", () => {
       apiUrl: new URL(API_URL),
       identity: identity,
     });
+    const sourcePath = join(import.meta.dirname!, "..", "counter.tsx");
+    const program = await cc.manager().runtime.harness
+      .resolve(
+        new FileSystemProgramResolver(sourcePath),
+      );
     charm = await cc.create(
-      await Deno.readTextFile(
-        join(
-          import.meta.dirname!,
-          "..",
-          "counter.tsx",
-        ),
-      ),
-      // We operate on the charm in this thread
+      program, // We operate on the charm in this thread
       { start: true },
     );
   });

--- a/packages/patterns/integration/nested-counter.test.ts
+++ b/packages/patterns/integration/nested-counter.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commontools/identity";
+import { FileSystemProgramResolver } from "@commontools/js-runtime/deno";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
@@ -24,15 +25,14 @@ describe("nested counter integration test", () => {
       apiUrl: new URL(API_URL),
       identity: identity,
     });
+    const sourcePath = join(import.meta.dirname!, "..", "nested-counter.tsx");
+    const program = await cc.manager().runtime.harness
+      .resolve(
+        new FileSystemProgramResolver(sourcePath),
+      );
+
     charm = await cc.create(
-      await Deno.readTextFile(
-        join(
-          import.meta.dirname!,
-          "..",
-          "nested-counter.tsx",
-        ),
-      ),
-      // We operate on the charm in this thread
+      program, // We operate on the charm in this thread
       { start: true },
     );
   });

--- a/packages/patterns/nested-counter.tsx
+++ b/packages/patterns/nested-counter.tsx
@@ -1,48 +1,9 @@
 /// <cts-enable />
-import {
-  Cell,
-  Default,
-  derive,
-  h,
-  handler,
-  NAME,
-  Opaque,
-  OpaqueRef,
-  recipe,
-  str,
-  UI,
-} from "commontools";
+import { Default, h, NAME, recipe, str, UI } from "commontools";
+import { decrement, increment, nth, previous } from "./counter-handlers.ts";
 
 interface RecipeState {
   value: Default<number, 0>;
-}
-
-// In this case we do not have to type our event parameter because it is not used in the body.
-// By requesting a Cell<number> we get a mutable handle when our handler is invoked.
-const increment = handler<unknown, { value: Cell<number> }>((_, state) => {
-  state.value.set(state.value.get() + 1);
-});
-
-// This can also be done with inline types + inference
-const decrement = handler((_, state: { value: Cell<number> }) => {
-  state.value.set(state.value.get() - 1);
-});
-
-function previous(value: number) {
-  return value - 1;
-}
-
-function nth(value: number) {
-  if (value === 1) {
-    return "1st";
-  }
-  if (value === 2) {
-    return "2nd";
-  }
-  if (value === 3) {
-    return "3rd";
-  }
-  return `${value}th`;
 }
 
 export const Counter = recipe<RecipeState>("Counter", (state) => {

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -111,7 +111,7 @@ export class Engine extends EventTarget implements Harness {
   }
 
   // Resolve a `ProgramResolver` into a `Program`.
-  async resolve(program: ProgramResolver): Promise<Program> {
+  async resolve(program: ProgramResolver): Promise<RuntimeProgram> {
     const { compiler } = await this.getInternals();
     return await compiler.resolveProgram(program, {
       runtimeModules: Engine.runtimeModuleNames(),


### PR DESCRIPTION
For use in integration tests for multifile patterns.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Introduces a Deno-only FileSystemProgramResolver for resolving multi-file programs from the filesystem, and switches CLI and tests to use it. Also extracts counter handlers into a shared module for reuse.

- **New Features**
  - Export FileSystemProgramResolver from @commontools/js-runtime/deno.

- **Refactors**
  - Replace CliProgram with FileSystemProgramResolver in CLI and integration tests; tests now resolve a RuntimeProgram from files instead of raw source.
  - Extract increment/decrement/nth/previous into counter-handlers.ts and reuse in counter.tsx and nested-counter.tsx.
  - Update exports and tasks: js-runtime deno export path, and patterns integration task to run integration/all.test.ts.

<!-- End of auto-generated description by cubic. -->

