### PR TITLE
feat(chat): rely fully on jsdoc to bring in description and schema

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -266,10 +266,12 @@ export type BuiltInLLMMessage = {
   content: BuiltInLLMContent;
 };
 
-export type BuiltInLLMTool = {
-  description: string;
-  inputSchema?: JSONSchema;
-} & ({ handler: OpaqueRef<any> | Stream<any> } | { pattern: Recipe });
+export type BuiltInLLMTool =
+  & { description?: string; inputSchema?: JSONSchema }
+  & (
+    | { pattern: Recipe; handler?: never }
+    | { handler: Stream<any> | OpaqueRef<any>; pattern?: never }
+  );
 
 // Built-in types
 export interface BuiltInLLMParams {
@@ -288,12 +290,7 @@ export interface BuiltInLLMParams {
    * Tools that can be called by the LLM during generation.
    * Each tool has a description, input schema, and handler function that runs client-side.
    */
-  tools?: Record<string, {
-    description: string;
-    inputSchema?: JSONSchema;
-    handler?: Stream<any> | OpaqueRef<any>;
-    pattern?: Recipe;
-  }>;
+  tools?: Record<string, BuiltInLLMTool>;
 }
 
 export interface BuiltInLLMState<T> {

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -267,7 +267,7 @@ export type BuiltInLLMMessage = {
 };
 
 export type BuiltInLLMTool =
-  & { description?: string; inputSchema?: JSONSchema }
+  & { description?: string }
   & (
     | { pattern: Recipe; handler?: never }
     | { handler: Stream<any> | OpaqueRef<any>; pattern?: never }

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -26,7 +26,6 @@ export type LLMContent = BuiltInLLMContent;
 export interface LLMTool {
   description: string;
   inputSchema: JSONSchema;
-  handler?: (args: any) => any | Promise<any>; // Client-side only
 }
 
 export interface LLMToolCall {

--- a/packages/patterns/chatbot-tools.tsx
+++ b/packages/patterns/chatbot-tools.tsx
@@ -1,6 +1,7 @@
 /// <cts-enable />
 import {
   BuiltInLLMMessage,
+  BuiltInLLMTool,
   Cell,
   cell,
   Default,
@@ -9,13 +10,9 @@ import {
   h,
   handler,
   ifElse,
-  JSONSchema,
-  lift,
-  llm,
   llmDialog,
   NAME,
   recipe,
-  str,
   Stream,
   UI,
 } from "commontools";
@@ -38,9 +35,18 @@ type LLMTestResult = {
 
 /*** Tools ***/
 
+/**
+ * Calculate the result of a mathematical expression.
+ * Supports +, -, *, /, and parentheses.
+ */
+type CalculatorRequest = {
+  /** The mathematical expression to evaluate. */
+  expression: string;
+};
+
 const calculator = recipe<
-  { expression: string; result: Cell<string> },
-  { result: Cell<string> }
+  CalculatorRequest,
+  string | { error: string }
 >("Calculator", ({ expression }) => {
   return derive(expression, (expr) => {
     const sanitized = expr.replace(/[^0-9+\-*/().\s]/g, "");
@@ -54,8 +60,15 @@ const calculator = recipe<
   });
 });
 
+/** Add an item to the list. */
+type AddListItemRequest = {
+  /** The item to add to the list. */
+  item: string;
+  result: Cell<string>;
+};
+
 const addListItem = handler<
-  { item: string; result: Cell<string> },
+  AddListItemRequest,
   { list: Cell<ListItem[]> }
 >(
   (args, state) => {
@@ -68,6 +81,12 @@ const addListItem = handler<
   },
 );
 
+/** Search the web for information. */
+type SearchQuery = {
+  /** The query to search the web for. */
+  query: string;
+};
+
 type SearchWebResult = {
   results: {
     title: string;
@@ -77,7 +96,7 @@ type SearchWebResult = {
 };
 
 const searchWeb = recipe<
-  { query: string },
+  SearchQuery,
   SearchWebResult | { error: string }
 >("Search Web", ({ query }) => {
   const { result, error } = fetchData<SearchWebResult>({
@@ -101,6 +120,12 @@ const searchWeb = recipe<
   return ifElse(error, { error }, result);
 });
 
+/** Read and extract content from a specific webpage URL. */
+type ReadWebRequest = {
+  /** The URL of the webpage to read and extract content from. */
+  url: string;
+};
+
 type ReadWebResult = {
   content: string;
   metadata: {
@@ -112,7 +137,7 @@ type ReadWebResult = {
 };
 
 const readWebpage = recipe<
-  { url: string },
+  ReadWebRequest,
   ReadWebResult | { error: string }
 >("Read Webpage", ({ url }) => {
   const { result, error } = fetchData<ReadWebResult>({
@@ -138,64 +163,17 @@ export default recipe<LLMTestInput, LLMTestResult>(
   "LLM Test",
   ({ title, messages, list }) => {
     const model = cell<string>("anthropic:claude-sonnet-4-0");
-    const tools = {
+    const tools: Record<string, BuiltInLLMTool> = {
       search_web: {
-        description: "Search the web for information.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            query: {
-              type: "string",
-              description: "The query to search the web for.",
-            },
-          },
-          required: ["query"],
-        } as JSONSchema,
         pattern: searchWeb,
       },
       read_webpage: {
-        description: "Read and extract content from a specific webpage URL.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            url: {
-              type: "string",
-              description:
-                "The URL of the webpage to read and extract content from.",
-            },
-          },
-          required: ["url"],
-        } as JSONSchema,
         pattern: readWebpage,
       },
       calculator: {
-        description:
-          "Calculate the result of a mathematical expression. Supports +, -, *, /, and parentheses.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            expression: {
-              type: "string",
-              description:
-                "The mathematical expression to evaluate (e.g., '2 + 3 * 4')",
-            },
-          },
-          required: ["expression"],
-        } as JSONSchema,
         pattern: calculator,
       },
       addListItem: {
-        description: "Add an item to the list.",
-        inputSchema: {
-          type: "object",
-          properties: {
-            item: {
-              type: "string",
-              description: "The item to add to the list.",
-            },
-          },
-          required: ["item"],
-        } as JSONSchema,
         handler: addListItem({ list }),
       },
     };

--- a/packages/patterns/chatbot-tools.tsx
+++ b/packages/patterns/chatbot-tools.tsx
@@ -33,7 +33,7 @@ type LLMTestResult = {
   messages: Default<Array<BuiltInLLMMessage>, []>;
 };
 
-/*** Tools ***/
+///// TOOLS ////
 
 /**
  * Calculate the result of a mathematical expression.

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -13,6 +13,7 @@ import type {
   Schema,
 } from "commontools";
 import { getLogger } from "@commontools/utils/logger";
+import { isRecord } from "@commontools/utils/types";
 import type { Cell, MemorySpace, Stream } from "../cell.ts";
 import { ID, type Recipe } from "../builder/types.ts";
 import type { Action } from "../scheduler.ts";
@@ -432,9 +433,16 @@ function startRequest(
       const { description, inputSchema } = tool;
       const pattern = tool.pattern?.get();
       const handler = tool.handler;
+      let schema: JSONSchema = pattern?.argumentSchema ?? handler?.schema!;
+
+      // This isn't ideal, but I don't think the LLM API supports boolean schemas
+      if (schema === true) schema = { type: "object" };
+      else if (schema === false) schema = {};
+
       return [name, {
-        description,
-        inputSchema: inputSchema ?? pattern?.argumentSchema ?? handler?.schema!,
+        description: description ?? schema.description ??
+          "",
+        inputSchema: inputSchema ?? schema,
       }];
     }),
   );

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -13,7 +13,7 @@ import type {
   Schema,
 } from "commontools";
 import { getLogger } from "@commontools/utils/logger";
-import { isRecord } from "@commontools/utils/types";
+import { isBoolean } from "@commontools/utils/types";
 import type { Cell, MemorySpace, Stream } from "../cell.ts";
 import { ID, type Recipe } from "../builder/types.ts";
 import type { Action } from "../scheduler.ts";
@@ -412,39 +412,36 @@ function startRequest(
 
   // Just send the schemas for each handler to the server
   const toolsWithSchemas = Object.fromEntries(
-    Object.entries(toolsCell.get() ?? {}).filter(([name, tool]) => {
+    Object.entries(toolsCell.get() ?? {}).map(([name, tool]) => {
       const pattern = tool.pattern?.get();
       const handler = tool.handler;
-      if (
-        !(
-          // providing a schema always works
-          tool.inputSchema ||
-          // otherwise if pattern is provided, it must have an argument schema
-          pattern?.argumentSchema ||
-          // otherwise if handler is provided and pattern is not, it must have a schema
-          (!pattern && handler?.schema)
-        )
-      ) {
+
+      let inputSchema = pattern?.argumentSchema ?? handler?.schema;
+
+      if (inputSchema === undefined) {
         logger.error(`Tool ${name} has no schema`);
-        return false;
+        return [name, undefined];
       }
-      return true;
-    }).map(([name, tool]) => {
-      const { description, inputSchema } = tool;
-      const pattern = tool.pattern?.get();
-      const handler = tool.handler;
-      let schema: JSONSchema = pattern?.argumentSchema ?? handler?.schema!;
 
-      // This isn't ideal, but I don't think the LLM API supports boolean schemas
-      if (schema === true) schema = { type: "object" };
-      else if (schema === false) schema = {};
+      // Maps `any` and `never` to objects with either any or no properties
+      if (isBoolean(inputSchema)) {
+        inputSchema = {
+          type: "object",
+          properties: {},
+          additionalProperties: inputSchema,
+        };
+      }
 
-      return [name, {
-        description: description ?? schema.description ??
-          "",
-        inputSchema: inputSchema ?? schema,
-      }];
-    }),
+      let description = tool.description ?? inputSchema.description;
+
+      if (!description) {
+        logger.warn(`Tool ${name} has no description`);
+        // TODO(seefeld): Should we instead ignore the tool?
+        description = "";
+      }
+
+      return [name, { description, inputSchema }];
+    }).filter(([_, tool]) => tool !== undefined),
   );
 
   const llmParams: LLMRequest = {

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -158,12 +158,14 @@ export type BuiltInLLMMessage = {
     content: BuiltInLLMContent;
 };
 export type BuiltInLLMTool = {
-    description: string;
+    description?: string;
     inputSchema?: JSONSchema;
 } & ({
-    handler: OpaqueRef<any> | Stream<any>;
-} | {
     pattern: Recipe;
+    handler?: never;
+} | {
+    handler: Stream<any> | OpaqueRef<any>;
+    pattern?: never;
 });
 export interface BuiltInLLMParams {
     messages?: BuiltInLLMMessage[];
@@ -181,12 +183,7 @@ export interface BuiltInLLMParams {
      * Tools that can be called by the LLM during generation.
      * Each tool has a description, input schema, and handler function that runs client-side.
      */
-    tools?: Record<string, {
-        description: string;
-        inputSchema?: JSONSchema;
-        handler?: Stream<any> | OpaqueRef<any>;
-        pattern?: Recipe;
-    }>;
+    tools?: Record<string, BuiltInLLMTool>;
 }
 export interface BuiltInLLMState<T> {
     pending: boolean;

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -159,7 +159,6 @@ export type BuiltInLLMMessage = {
 };
 export type BuiltInLLMTool = {
     description?: string;
-    inputSchema?: JSONSchema;
 } & ({
     pattern: Recipe;
     handler?: never;

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -37,6 +37,15 @@ export function isString(value: unknown): value is string {
 }
 
 /**
+ * Predicate for narrowing a `boolean` type.
+ * @param value - The value to check
+ * @returns True if the value is a boolean
+ */
+export function isBoolean(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
+/**
  * Helper type to recursively remove `readonly` properties from type `T`.
  */
 export type Mutable<T> = T extends ReadonlyArray<infer U> ? Mutable<U>[]


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Tools now auto-generate their description and input schema from JSDoc/type info, removing manual JSONSchema and string descriptions. This simplifies tool authoring and enforces a clear “pattern or handler” contract.

- **Refactors**
  - Derive tool description and inputSchema from pattern.argumentSchema or handler.schema (via JSDoc); explicit fields remain optional overrides.
  - Normalize boolean schemas: true -> { type: "object" }, false -> {}.
  - BuiltInLLMTool is now an either/or union (pattern XOR handler); description is optional; BuiltInLLMParams.tools now uses this type.
  - Chatbot tools converted to typed request interfaces with JSDoc; removed manual JSONSchema and description strings.

- **Migration**
  - Remove explicit inputSchema/description from tools and document request types with JSDoc; keep description only if you need to override.
  - Provide either pattern or handler, not both.
  - If you relied on boolean schemas, note the normalization behavior above.

<!-- End of auto-generated description by cubic. -->

