### PR TITLE
CT-886 conflict sync error unit test and improvements

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -85,8 +85,15 @@ export class Runner implements IRunner {
         const space = notification.space;
         if ("changes" in notification) {
           for (const change of notification.changes) {
-            this.resultRecipeCache.delete(`${space}/${change.address.id}`);
+            if (change.address.type === "application/json") {
+              this.resultRecipeCache.delete(`${space}/${change.address.id}`);
+            }
           }
+        } else if (notification.type === "reset") {
+          // copy keys, since we'll mutate the collection while iterating
+          const cacheKeys = [...this.resultRecipeCache.keys()];
+          cacheKeys.filter((key) => key.startsWith(`${notification.space}/`))
+            .forEach(this.resultRecipeCache.delete);
         }
         return { done: false };
       },
@@ -656,6 +663,9 @@ export class Runner implements IRunner {
       }
     }
     this.allCancels.clear();
+    // Clear the result recipe cache as well, since the actions have been
+    // canceled
+    this.resultRecipeCache.clear();
   }
 
   /**


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes conflict sync errors by invalidating cached recipe results when storage updates occur. The runner now reruns a recipe only when its result cell actually changes. Addresses Linear CT-886.

- Bug Fixes
  - Added resultRecipeCache keyed by result cell to skip unnecessary reruns.
  - Subscribed to storage notifications and clear cache for changed cells.
  - Reused the existing result cell instead of recreating it; ensured proper cancel.
  - Added a test confirming cache invalidation on commit notifications.

<!-- End of auto-generated description by cubic. -->

