### PR TITLE
fix for jsdocs in schemas to prefer the nearest jsdoc comment

### DIFF
--- a/packages/schema-generator/src/doc-utils.ts
+++ b/packages/schema-generator/src/doc-utils.ts
@@ -26,7 +26,12 @@ export function getDeclDocs(decl: ts.Declaration): string[] {
   const docs: string[] = [];
   const jsDocs = (decl as any).jsDoc as Array<ts.JSDoc> | undefined;
   if (jsDocs && jsDocs.length > 0) {
-    for (const d of jsDocs) {
+    // Prefer comments that are closest to the declaration by iterating in
+    // reverse source order. TypeScript keeps JSDoc entries ordered as they
+    // appear in the source, so sorting by position places the comment nearest
+    // to the declaration at the front of the list.
+    const sorted = [...jsDocs].sort((a, b) => b.pos - a.pos);
+    for (const d of sorted) {
       const comment = (d as any).comment as unknown;
       let text = "";
       if (typeof comment === "string") {

--- a/packages/schema-generator/test/schema-generator.test.ts
+++ b/packages/schema-generator/test/schema-generator.test.ts
@@ -46,6 +46,40 @@ describe("SchemaGenerator", () => {
     });
   });
 
+  describe("jsdoc integration", () => {
+    it("prefers the comment closest to the type declaration", async () => {
+      const generator = new SchemaGenerator();
+      const code = `/*** Tool ***/
+
+/**
+ * Calculate the result of a mathematical expression.
+ * Supports +, -, *, /, and parentheses.
+ */
+type CalculatorRequest = {
+  /** The mathematical expression to evaluate. */
+  expression: string;
+};`;
+      const { type, checker, typeNode } = await getTypeFromCode(
+        code,
+        "CalculatorRequest",
+      );
+
+      const schema = generator.generateSchema(type, checker, typeNode);
+      const typedSchema = schema as Record<string, unknown>;
+      const properties = typedSchema.properties as
+        | Record<string, Record<string, unknown>>
+        | undefined;
+
+      expect(typedSchema.description).toBe(
+        "Calculate the result of a mathematical expression.\n" +
+          "Supports +, -, *, /, and parentheses.",
+      );
+      expect(properties?.expression?.description).toBe(
+        "The mathematical expression to evaluate.",
+      );
+    });
+  });
+
   describe("error handling", () => {
     it("should handle unknown types gracefully", async () => {
       const generator = new SchemaGenerator();


### PR DESCRIPTION
Attempted fix for https://linear.app/common-tools/issue/CT-898/cts-and-jsdoc-use-description-closest-to-type
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Schema generator now uses the JSDoc comment closest to a type or property when setting schema descriptions. Fixes wrong descriptions pulled from header comments and aligns with Linear CT-898.

- **Bug Fixes**
  - Sort JSDoc nodes by source position (desc) to prefer the nearest comment.
  - Added a unit test to confirm the closest comment is used for type and field descriptions.

<!-- End of auto-generated description by cubic. -->

