### PR TITLE
Track the schema in the cycle tracker

### DIFF
--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -1,8 +1,8 @@
-import type { JSONObject, JSONValue, URI } from "@commontools/runner";
+import type { JSONObject, JSONValue, SchemaContext } from "@commontools/runner";
 import {
   BaseMemoryAddress,
   BaseObjectManager,
-  CycleTracker,
+  CompoundCycleTracker,
   DefaultSchemaSelector,
   getAtPath,
   type IAttestation,
@@ -154,7 +154,10 @@ export const selectSchema = <Space extends MemorySpace>(
   // Track any docs loaded while traversing the factSelection
   const manager = new ServerObjectManager(session, providedClassifications);
   // while loading dependent docs, we want to avoid cycles
-  const tracker = new CycleTracker<Immutable<JSONValue>>();
+  const tracker = new CompoundCycleTracker<
+    Immutable<JSONValue>,
+    SchemaContext | undefined
+  >();
   const schemaTracker = new MapSet<string, SchemaPathSelector>();
 
   const includedFacts: FactSelection = {}; // we'll store all the raw facts we accesed here

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -1,4 +1,9 @@
-import type { JSONObject, JSONValue, SchemaContext } from "@commontools/runner";
+import {
+  deepEqual,
+  type JSONObject,
+  type JSONValue,
+  type SchemaContext,
+} from "@commontools/runner";
 import {
   BaseMemoryAddress,
   BaseObjectManager,
@@ -158,7 +163,7 @@ export const selectSchema = <Space extends MemorySpace>(
     Immutable<JSONValue>,
     SchemaContext | undefined
   >();
-  const schemaTracker = new MapSet<string, SchemaPathSelector>();
+  const schemaTracker = new MapSet<string, SchemaPathSelector>(deepEqual);
 
   const includedFacts: FactSelection = {}; // we'll store all the raw facts we accesed here
   // First, collect all the potentially relevant facts (without dereferencing pointers)

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1,4 +1,5 @@
 import { refer } from "merkle-reference";
+import { SchemaAll } from "@commontools/memory/schema";
 // TODO(@ubik2): Ideally this would use the following, but rollup has issues
 //import { isNumber, isObject, isString } from "@commontools/utils/types";
 import {
@@ -20,7 +21,6 @@ import { deepEqual } from "./path-utils.ts";
 import { isAnyCellLink, parseLink } from "./link-utils.ts";
 import { fromURI } from "./uri-utils.ts";
 import type { IAttestation, IMemoryAddress } from "./storage/interface.ts";
-import { SchemaAll } from "@commontools/memory/schema";
 
 const logger = getLogger("traverse", { enabled: true, level: "warn" });
 

--- a/packages/runner/test/query.test.ts
+++ b/packages/runner/test/query.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { refer } from "merkle-reference/json";
-import type { JSONSchema, JSONValue } from "../src/index.ts";
+import type { JSONSchema, JSONValue, SchemaContext } from "../src/index.ts";
 import {
-  CycleTracker,
+  CompoundCycleTracker,
   MapSet,
   SchemaObjectTraverser,
 } from "../src/traverse.ts";
@@ -31,7 +31,7 @@ describe("Query", () => {
     Revision<State>
   >();
   let manager: StoreObjectManager;
-  let tracker: CycleTracker<JSONValue>;
+  let tracker: CompoundCycleTracker<JSONValue, SchemaContext | undefined>;
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
@@ -43,7 +43,7 @@ describe("Query", () => {
     });
     tx = runtime.edit();
     manager = new StoreObjectManager(store);
-    tracker = new CycleTracker<JSONValue>();
+    tracker = new CompoundCycleTracker<JSONValue, SchemaContext | undefined>();
   });
 
   afterEach(async () => {


### PR DESCRIPTION
This change makes it so we don't consider it a cycle when we are at the same place in a doc, but our schema differs.
This is important, because the schema we use the first time we evaluate a doc might be different than a schema we use later, and since the cycle tracker would stop traversing when we encountered a cycle, it wouldn't follow some links that would only be included by the later schema.

### AI Summary
- Replaced the simple cycle tracking in the schema selector with the richer compound tracker and a MapSet that deduplicates selectors via deepEqual, preventing repeated schema traversals while loading facts
- Extended traversal infrastructure with a customizable MapSet, a schema-aware CompoundCycleTracker, and schema-sensitive pointer handling so cycles are only reported when the schema contexts match
- Updated query tests to use the new tracker API and added a regression that exercises cycle detection when schema paths converge, ensuring the traversal guard behaves as expected