### PR TITLE
Note backlinks CT-896

### DIFF
--- a/packages/patterns/chatbot-note.tsx
+++ b/packages/patterns/chatbot-note.tsx
@@ -170,7 +170,13 @@ export default recipe<LLMTestInput, LLMTestResult>(
                 />
               </div>
 
-              <Note content={content} allCharms={allCharms} />
+              <ct-code-editor
+                $value={content}
+                $mentionable={allCharms}
+                onbacklink-click={handleCharmLinkClick({})}
+                language="text/markdown"
+                style="min-height: 400px;"
+              />
             </ct-screen>
 
             {ifElse(

--- a/packages/patterns/chatbot-note.tsx
+++ b/packages/patterns/chatbot-note.tsx
@@ -67,9 +67,11 @@ export const Note = recipe<NoteInput>(
   },
 );
 
-const handleCharmLinkClicked = handler((_: any, { charm }: { charm: Cell<Charm> }) => {
-  navigateTo(charm);
-})
+const handleCharmLinkClicked = handler(
+  (_: any, { charm }: { charm: Cell<Charm> }) => {
+    return navigateTo(charm);
+  },
+);
 
 
 type LLMTestInput = {
@@ -241,7 +243,9 @@ export default recipe<LLMTestInput, LLMTestResult>(
                 <summary>Mentioned Charms</summary>
                 <ct-vstack>
                   {mentioned.map((charm: Charm) => (
-                    <ct-button onClick={handleCharmLinkClicked({ charm })}>{charm[NAME]}</ct-button>
+                    <ct-button onClick={handleCharmLinkClicked({ charm })}>
+                      {charm[NAME]}
+                    </ct-button>
                   ))}
                 </ct-vstack>
               </details>
@@ -249,7 +253,9 @@ export default recipe<LLMTestInput, LLMTestResult>(
                 <summary>Backlinks</summary>
                 <ct-vstack>
                   {backlinks.map((charm: Charm) => (
-                    <ct-button onClick={handleCharmLinkClicked({ charm })}>{charm[NAME]}</ct-button>
+                    <ct-button onClick={handleCharmLinkClicked({ charm })}>
+                      {charm[NAME]}
+                    </ct-button>
                   ))}
                 </ct-vstack>
               </details>

--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -165,9 +165,9 @@ export class CTCodeEditor extends BaseElement {
       if (mentionable.length === 0) return null;
 
       // Determine the completion range and apply text based on whether ]] exists
-      let applyText: string;
+      let applyText: (text: string) => string;
       let completionTo: number;
-      
+
       if (afterCursor === "]]") {
         // We're inside existing backlinks like [[llm|]], just replace the content
         applyText = (text: string) => text;
@@ -180,7 +180,7 @@ export class CTCodeEditor extends BaseElement {
 
       const options: Completion[] = mentionable.map(charm => {
         const charmIdObj = getEntityId(charm);
-        const charmId = charmIdObj["/"] || "";
+        const charmId = charmIdObj?.["/"] || "";
         const charmName = charm[NAME] || "";
         const insertText = `${charmName} (${charmId})`;
         return {
@@ -307,7 +307,7 @@ export class CTCodeEditor extends BaseElement {
       const charm = this.mentionable.key(i).getAsQueryResult();
       if (charm) {
         const charmIdObj = getEntityId(charm);
-        const charmId = charmIdObj["/"] || "";
+        const charmId = charmIdObj?.["/"] || "";
         if (charmId === id) {
           return charm;
         }

--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -213,7 +213,11 @@ export class CTCodeEditor extends BaseElement {
 
     for (let i = 0; i < mentionableData.length; i++) {
       const mention = this.mentionable.key(i).get();
-      if (mention && this.mentionable.key(i).key(NAME).getAsQueryResult()?.toLowerCase()?.includes(queryLower)) {
+      if (
+        mention &&
+        this.mentionable.key(i).key(NAME).getAsQueryResult()?.toLowerCase()
+          ?.includes(queryLower)
+      ) {
         matches.push(this.mentionable.key(i));
       }
     }

--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -81,6 +81,7 @@ const getLangExtFromMimeType = (mime: MimeType) => {
  * @attr {string} timingStrategy - Input timing strategy: "immediate" | "debounce" | "throttle" | "blur"
  * @attr {number} timingDelay - Delay in milliseconds for debounce/throttle (default: 500)
  * @attr {Array} mentionable - Array of mentionable items with Charm structure for backlink autocomplete
+ * @attr {Array} mentioned - Optional Cell of live Charms mentioned in content
  *
  * @fires ct-change - Fired when content changes with detail: { value, oldValue, language }
  * @fires ct-focus - Fired on focus
@@ -102,6 +103,7 @@ export class CTCodeEditor extends BaseElement {
     timingStrategy: { type: String },
     timingDelay: { type: Number },
     mentionable: { type: Array },
+    mentioned: { type: Array },
   };
 
   declare value: Cell<string> | string;
@@ -112,6 +114,7 @@ export class CTCodeEditor extends BaseElement {
   declare timingStrategy: InputTimingOptions["strategy"];
   declare timingDelay: number;
   declare mentionable: Cell<Charm[]>;
+  declare mentioned?: Cell<Charm[]>;
 
   private _editorView: EditorView | undefined;
   private _lang = new Compartment();
@@ -128,6 +131,8 @@ export class CTCodeEditor extends BaseElement {
         oldValue,
         language: this.language,
       });
+      // Keep $mentioned in sync with content changes
+      this._updateMentionedFromContent();
     },
   });
 
@@ -170,7 +175,7 @@ export class CTCodeEditor extends BaseElement {
       const options: Completion[] = mentionable.map((charm) => {
         const charmIdObj = getEntityId(charm);
         const charmId = charmIdObj?.["/"] || "";
-        const charmName = charm[NAME] || "";
+        const charmName = charm.key(NAME).get() || "";
         const insertText = `${charmName} (${charmId})`;
         return {
           label: charmName,
@@ -192,7 +197,7 @@ export class CTCodeEditor extends BaseElement {
   /**
    * Get filtered mentionable items based on query
    */
-  private getFilteredMentionable(query: string): Charm[] {
+  private getFilteredMentionable(query: string): Cell<Charm>[] {
     if (!this.mentionable) {
       return [];
     }
@@ -204,12 +209,12 @@ export class CTCodeEditor extends BaseElement {
     }
 
     const queryLower = query.toLowerCase();
-    const matches: Charm[] = [];
+    const matches: Cell<Charm>[] = [];
 
     for (let i = 0; i < mentionableData.length; i++) {
-      const mention = this.mentionable.key(i).getAsQueryResult();
-      if (mention && mention[NAME]?.toLowerCase()?.includes(queryLower)) {
-        matches.push(mention);
+      const mention = this.mentionable.key(i).get();
+      if (mention && this.mentionable.key(i).key(NAME).getAsQueryResult()?.toLowerCase()?.includes(queryLower)) {
+        matches.push(this.mentionable.key(i));
       }
     }
 
@@ -279,14 +284,14 @@ export class CTCodeEditor extends BaseElement {
   /**
    * Find a charm by ID in the mentionable list
    */
-  private findCharmById(id: string): Charm | null {
+  private findCharmById(id: string): Cell<Charm> | null {
     if (!this.mentionable) return null;
 
     const mentionableData = this.mentionable.getAsQueryResult();
     if (!mentionableData) return null;
 
     for (let i = 0; i < mentionableData.length; i++) {
-      const charm = this.mentionable.key(i).getAsQueryResult();
+      const charm = this.mentionable.key(i);
       if (charm) {
         const charmIdObj = getEntityId(charm);
         const charmId = charmIdObj?.["/"] || "";
@@ -387,6 +392,8 @@ export class CTCodeEditor extends BaseElement {
         });
       }
     }
+    // Ensure mentioned charms reflect external value changes
+    this._updateMentionedFromContent();
   }
 
   private _setupCellSyncHandler(): void {
@@ -412,6 +419,18 @@ export class CTCodeEditor extends BaseElement {
         this._cleanupFns.push(unsubscribe);
       }
     }
+  }
+
+  /**
+   * Subscribe to mentionable changes to re-resolve mentioned charms when
+   * the source list updates.
+   */
+  private _setupMentionableSyncHandler(): void {
+    if (!this.mentionable) return;
+    const unsubscribe = this.mentionable.sink(() => {
+      this._updateMentionedFromContent();
+    });
+    this._cleanupFns.push(unsubscribe);
   }
 
   private _cleanup(): void {
@@ -459,6 +478,17 @@ export class CTCodeEditor extends BaseElement {
         delay: this.timingDelay,
       });
     }
+
+    // Re-subscribe if mentionable cell reference changes
+    if (changedProperties.has("mentionable")) {
+      this._setupMentionableSyncHandler();
+      this._updateMentionedFromContent();
+    }
+
+    // If `$mentioned` binding changes, push current state immediately
+    if (changedProperties.has("mentioned")) {
+      this._updateMentionedFromContent();
+    }
   }
 
   protected override firstUpdated(_changedProperties: PropertyValues): void {
@@ -476,6 +506,10 @@ export class CTCodeEditor extends BaseElement {
 
     // Set up custom cell sync handler for CodeMirror
     this._setupCellSyncHandler();
+
+    // Set up mentionable sync handler and initialize mentioned list
+    this._setupMentionableSyncHandler();
+    this._updateMentionedFromContent();
   }
 
   private _initializeEditor(): void {
@@ -494,6 +528,8 @@ export class CTCodeEditor extends BaseElement {
         if (update.docChanged && !this.readonly) {
           const value = update.state.doc.toString();
           this.setValue(value);
+          // Keep $mentioned current as user types
+          this._updateMentionedFromContent();
         }
       }),
       // Handle focus/blur events
@@ -564,6 +600,75 @@ export class CTCodeEditor extends BaseElement {
    */
   get editorView(): EditorView | undefined {
     return this._editorView;
+  }
+
+  /**
+   * Extract mentioned charms from current content and write to `$mentioned`.
+   *
+   * Link syntax: [[Name (id)]]. We parse ids and resolve them against
+   * `$mentionable` to produce live Charm instances.
+   */
+  private _updateMentionedFromContent(): void {
+    if (!this.mentioned) return;
+
+    const content = this.getValue() || "";
+    const newMentioned = this._extractMentionedCharms(content);
+
+    // Compare by id set to avoid unnecessary writes
+    const current = this.mentioned.getAsQueryResult?.() || [];
+    const curIds = new Set(
+      current
+        .map((c: Charm) => getEntityId(c)?.["/"] || "")
+        .filter((id: string) => id),
+    );
+    const newIds = new Set(
+      newMentioned
+        .map((c: Charm) => getEntityId(c)?.["/"] || "")
+        .filter((id: string) => id),
+    );
+
+    if (curIds.size === newIds.size) {
+      let same = true;
+      for (const id of newIds) {
+        if (!curIds.has(id)) {
+          same = false;
+          break;
+        }
+      }
+      if (same) return; // No change
+    }
+
+    const tx = this.mentioned.runtime.edit();
+    this.mentioned.withTx(tx).set(newMentioned);
+    tx.commit();
+  }
+
+  /**
+   * Parse content to a list of unique Charms referenced by [[...]] links.
+   */
+  private _extractMentionedCharms(content: string): Charm[] {
+    if (!content || !this.mentionable) return [];
+
+    const ids: string[] = [];
+    const regex = /\[\[[^\]]*?\(([^)]+)\)\]\]/g;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(content)) !== null) {
+      const id = match[1];
+      if (id) ids.push(id);
+    }
+
+    // Resolve unique ids to charms using mentionable list
+    const seen = new Set<string>();
+    const result: Charm[] = [];
+    for (const id of ids) {
+      if (seen.has(id)) continue;
+      const charm = this.findCharmById(id);
+      if (charm) {
+        result.push(charm);
+        seen.add(id);
+      }
+    }
+    return result;
   }
 }
 

--- a/packages/ui/src/v2/components/ct-code-editor/styles.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/styles.ts
@@ -54,7 +54,7 @@ export const styles = css`
   .cm-content .cm-line {
     position: relative;
   }
-  
+
   /* Style for backlinks - we'll use a highlight mark */
   .cm-backlink {
     background-color: var(--ring-alpha, hsla(212, 100%, 47%, 0.1));
@@ -63,7 +63,7 @@ export const styles = css`
     cursor: pointer;
     transition: background-color 0.2s;
   }
-  
+
   .cm-backlink:hover {
     background-color: var(--ring-alpha, hsla(212, 100%, 47%, 0.2));
   }

--- a/packages/ui/src/v2/components/ct-code-editor/styles.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/styles.ts
@@ -54,7 +54,7 @@ export const styles = css`
   .cm-content .cm-line {
     position: relative;
   }
-
+  
   /* Style for backlinks - we'll use a highlight mark */
   .cm-backlink {
     background-color: var(--ring-alpha, hsla(212, 100%, 47%, 0.1));
@@ -63,7 +63,7 @@ export const styles = css`
     cursor: pointer;
     transition: background-color 0.2s;
   }
-
+  
   .cm-backlink:hover {
     background-color: var(--ring-alpha, hsla(212, 100%, 47%, 0.2));
   }


### PR DESCRIPTION
- **`ct-code-editor` backlink support**
- **Fix type errors**
- **Format pass**
- **Clean up logging and code**
- **Workaround focus issue by inlining**
- **List mentions + backlinks**

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds backlink and mention support to notes. The editor now parses [[Name (id)]] links, keeps a live list of mentioned charms, and the Note UI shows mentions and backlinks with quick navigation.

- **New Features**
  - ct-code-editor: adds $mentioned; parses [[Name (id)]] links, resolves IDs via $mentionable, and keeps $mentioned in sync while typing and when mentionable updates.
  - ct-code-editor: improves [[ autocomplete using mentionable names and IDs.
  - Note pattern: embeds the editor, shows “Mentioned” and “Backlinks” lists, and lets users navigate to a charm on click.
  - Backlinks are derived from all charms that reference the current note.

- **Bug Fixes**
  - Fixes type errors and cleans up logs/formatting.
  - Inlines a handler to work around a focus issue.

<!-- End of auto-generated description by cubic. -->

