### PR TITLE
feat(schema-generator): inherit intersection docs with provenance

### DIFF
--- a/packages/schema-generator/test/fixtures/schema/descriptions-intersection-concat.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-intersection-concat.expected.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "foo": {
+      "type": "string"
+    },
+    "bar": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "foo",
+    "bar"
+  ],
+  "description": "Doc A\n\nDoc B",
+  "$comment": "Docs inherited from intersection constituents. Sources: TypeA, TypeB."
+}

--- a/packages/schema-generator/test/fixtures/schema/descriptions-intersection-concat.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-intersection-concat.input.ts
@@ -1,0 +1,11 @@
+/** Doc A */
+type TypeA = {
+  foo: string;
+};
+
+/** Doc B */
+type TypeB = {
+  bar: number;
+};
+
+type SchemaRoot = TypeA & TypeB;

--- a/packages/schema-generator/test/fixtures/schema/descriptions-intersection-missing.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-intersection-missing.expected.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "foo": {
+      "type": "string"
+    },
+    "bar": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "foo",
+    "bar"
+  ],
+  "description": "Doc A",
+  "$comment": "Docs inherited from intersection constituents. Missing docs for: { bar: number; }."
+}

--- a/packages/schema-generator/test/fixtures/schema/descriptions-intersection-missing.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-intersection-missing.input.ts
@@ -1,0 +1,8 @@
+/** Doc A */
+type TypeA = {
+  foo: string;
+};
+
+type SchemaRoot = TypeA & {
+  bar: number;
+};

--- a/packages/schema-generator/test/fixtures/schema/descriptions-intersection-none.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-intersection-none.expected.json
@@ -1,0 +1,15 @@
+{
+  "properties": {
+    "bar": {
+      "type": "number"
+    },
+    "foo": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "bar",
+    "foo"
+  ],
+  "type": "object"
+}

--- a/packages/schema-generator/test/fixtures/schema/descriptions-intersection-none.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-intersection-none.input.ts
@@ -1,0 +1,5 @@
+type SchemaRoot = {
+  foo: string;
+} & {
+  bar: number;
+};


### PR DESCRIPTION
Fix to address https://linear.app/common-tools/issue/CT-895/follow-ups-on-jsdocs-in-schemas
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds doc inheritance for intersection types in the schema generator, with provenance. Concatenates constituent JSDoc into description and notes sources and missing docs, addressing Linear CT-895.

- **New Features**
  - Intersection schemas now inherit docs from each constituent; deduplicated docs are joined into description only if none exists.
  - Adds $comment showing sources of inherited docs and which constituents lacked docs.
  - New extractDocFromType utility reads docs from alias and direct symbols; used by intersection handling.
  - Tests cover concat, missing-doc, and no-doc cases.

- **Refactors**
  - SchemaGenerator now uses extractDocFromType instead of inline doc-picking logic.

<!-- End of auto-generated description by cubic. -->

