### PR TITLE
Spec for OpaqueRef->Cells transition

### DIFF
--- a/docs/specs/recipe-construction/capability-wrappers.md
+++ b/docs/specs/recipe-construction/capability-wrappers.md
@@ -1,0 +1,112 @@
+# Capability Wrappers Prototype
+
+## Objectives
+
+- Collapse `OpaqueRef` and runtime `Cell` APIs into a single object whose
+  surface area is gated by explicit capabilities (`Opaque`, `Readonly`,
+  `Mutable`, `Writeonly`).
+- Keep recipe ergonomics intact by continuing to expose property proxies and
+  helpers like `.map()` while steering operations through capability-aware
+  wrappers.
+- Provide a migration path that lets existing recipes run during the migration
+  window by adapting the current builder implementation incrementally.
+
+## Current Behaviors Informing Design
+
+- `opaqueRef` proxies in `packages/runner/src/builder/opaque-ref.ts` capture
+  nested schema information via `ContextualFlowControl` so that child property
+  accesses can inherit IFC annotations. They also record connected nodes with
+  `.connect` and export builder metadata used by `factoryFromRecipe`.
+- Builders rely on push/pop frames from `recipe.ts` to keep track of
+  `unsafe_binding` context, generated id counters, and the causal object used by
+  `createCell` during runtime invocation.
+- Runtime cells in `packages/runner/src/cell.ts` already expose read, write,
+  redirect, and schema-centric helpers. `createCell` injects causes derived from
+  the enclosing frame before delegating to `runtime.getCell`.
+- Helper factories such as `.map()` call back into `createNodeFactory` to build
+  nested recipes. That indirection means wrappers must cooperate with module
+  factories that expect builder-time proxies yet execute against runtime cells.
+
+## Wrapper Shape
+
+- Introduce a lightweight `CapabilityCell<T, C extends Capability>` interface
+  that wraps a concrete runtime cell and exposes operations allowed by
+  capability `C`. Capabilities map to subsets of the current `Cell` API:
+  - `Opaque`: property proxies, `.map`, `.filter`, `.derive`, structural
+    equality, read-only helpers.
+  - `Readonly`: everything in `Opaque` plus `.get`, `.getAsQueryResult`, and
+    schema navigation helpers that do not mutate state.
+  - `Mutable`: superset of `Readonly` plus `.set`, `.update`, `.push`, and
+    `.redirectTo`.
+  - `Writeonly`: `.send`, `.set`, `.redirectTo`, but intentionally hides `.get`
+    to encourage event-sink authoring disciplines.
+- Use `Proxy` objects to intercept property access and method calls. Each proxy
+  lazily constructs child proxies with the same capability so nested lookups
+  remain ergonomic (e.g. `mutable.todos[0].title.set("…")`).
+- When a helper like `.map` is invoked, delegate to a capability-aware shim that
+  wraps the callee recipe factory so the inner function receives wrappers
+  instead of raw cells or `OpaqueRef`s. Internally reuse the existing
+  `createNodeFactory` path to avoid reimplementing module registration.
+
+## Construction Flow
+
+1. Builder entry points (`recipe`, `lift`, `handler`) push a frame, wrap inputs
+   in `CapabilityCell` proxies instead of `opaqueRef`, and still record the
+   graph using existing traversal utilities.
+2. For compatibility, supply adapters that allow legacy `OpaqueRef` helper
+   affordances (`setDefault`, `unsafe_bindToRecipeAndPath`) to continue working
+   until all call sites migrate. These adapters simply forward to the wrapped
+   runtime cell or translate to snapshot metadata updates.
+3. During runtime execution, `pushFrameFromCause` already seeds the frame with
+   the `cause` and `unsafe_binding`. Wrappers created while executing a lifted
+   function can therefore call `runtime.getCell` immediately because the cause
+   data is ready.
+
+## Type System Notes
+
+- Export capability-specific TypeScript types from `@commontools/api` such as
+  `OpaqueCell<T>`, `ReadonlyCell<T>`, `MutableCell<T>`, and `WriteonlyCell<T>`.
+  These extend a shared base that keeps the proxy type information available to
+  recipe authors.
+- Extend our JSON Schema annotations so authors can declare capabilities at any
+  depth. When `asCell: true` is present, allow an `opaque`, `readonly`, or
+  `writeonly` flag (or the closest JSON Schema standard equivalent if one
+  exists). Builder proxies read these flags to choose the capability for the
+  proxy returned by `key()` or nested property access.
+- Provide conditional helper types to map schema metadata to helper surfaces
+  (e.g., array helpers only appear when `T` extends `readonly any[]`). Reuse the
+  IFC-aware schema lookup utilities to keep helper availability aligned with the
+  JSON schema.
+- Augment builders so `recipe` factories default to `OpaqueCell` inputs while
+  `lift` can declare stronger capabilities for each argument via a typed options
+  bag (e.g., `{ inputs: { item: Capability.Mutable } }`).
+
+## Cause Defaults
+
+- Capability helpers (e.g., `.map`, `.filter`) should emit deterministic
+  default causes that combine the parent cell's cause with a helper-specific
+  label. Authors can still pass explicit `cause` overrides to `lift` or
+  `handler`, but most call sites inherit stable defaults automatically.
+- Expose an optional `.setCause(cause: CauseDescriptor)` chain on newly created
+  capability cells. It overrides the derived id before the cell participates in
+  the graph. If the cell has already been connected to a node or materialized
+  into a runtime cell, `.setCause` must throw to avoid inconsistencies.
+
+## Migration Strategy
+
+- Step 1: Introduce wrappers with shims that forward to existing opaque ref
+  behavior. Dual-write metadata (`export()`) so `factoryFromRecipe` can continue
+  serializing the graph until the snapshot pipeline lands.
+- Step 2: Convert builtin helpers and modules to consume wrappers. Audit
+  `packages/runner/src/builder` to replace direct `OpaqueRef` imports with
+  wrapper types while keeping `opaqueRef` available as a thin adapter.
+- Step 3: Update recipes in `recipes/` iteratively. Provide codemods that swap
+  `cell()` usage for capability-specific constructors when explicit mutability is
+  required.
+- Step 4: Remove legacy-only APIs (`setDefault`, `setPreExisting`) once the
+  snapshot work replaces path-based aliasing and defaults come from schemas.
+
+## Open Questions
+
+- When migrating existing schemas to the new capability annotations, should we
+  store capability metadata in-line or factor it into shared schema manifests?

--- a/docs/specs/recipe-construction/cause-derivation.md
+++ b/docs/specs/recipe-construction/cause-derivation.md
@@ -1,0 +1,105 @@
+# Cause Derivation Plan
+
+## Scope
+
+Causes must be stable for the cells that builder helpers (`lift`, `.map`,
+`handler`, etc.) return while assembling a recipe graph. Those helpers execute
+inside a frame created by `pushFrameFromCause`, so the frame already carries the
+cause of the invocation (e.g., handler event, parent lift). The work here is to
+derive deterministic causes for the **new cells** produced inside that frame by
+combining the frame cause with deterministic fingerprints of the inputs and
+implementation.
+
+## Frame Cause Setup
+
+1. When a lift or handler is invoked at runtime, the runtime computes a
+   structured `frameCause` that captures the triggering context (event id,
+   result cell id, handler name, etc.) and pushes it with `pushFrameFromCause`.
+2. `createCell` and other builder helpers can read `frame.cause` when they need
+   baseline information. The frame cause remains untouched while the author’s
+   recipe factory runs.
+
+## Deriving Causes for Builder Outputs
+
+For every helper that returns a cell (including plain `lift`, `handler`,
+`.map`, `.filter`, `recipe`, etc.), derive a cause using the following inputs:
+
+- **Frame cause**: Treat the `frameCause` as the parent component. It ensures
+  all descendants remain tied to the invocation that spawned them.
+- **Input cell ids**: Gather the normalized ids of the input cells passed to the
+  helper. For `.map`, include the list/array cell id plus ids of captured cells
+  in the callback. Wrappers expose `cell.__metadata.cause` or similar to make the
+  ids available without forcing a read.
+- **Implementation fingerprint**: Hash the helper’s implementation. For inline
+  functions reuse the hash already stored in the function cache. For `ref`
+  modules or builtins use their canonical identifier.
+- **Helper discriminator**: Include a stable label describing the helper and its
+  position (e.g., `"lift"`, `"map"`, `"handler"`). If a helper can be invoked
+  multiple times within the same frame (like `.map`), add an index or property
+  path to disambiguate siblings.
+- **Literal/configuration inputs**: Serialize options or literal data that alter
+  behavior (e.g., `.map({ chunkSize: 10 })`).
+
+Combine these pieces into a structured object and feed it to `createRef`:
+
+```ts
+const cause = createRef({
+  parent: frameCause,
+  helper: "lift",
+  impl: implementationHash,
+  inputs: inputIds.sort(),
+  index: helperIndex,
+  config: stableConfigJson,
+});
+```
+
+The resulting entity id seeds the cause for the cell returned by the helper.
+
+### Explicit Overrides
+
+- Newly created capability cells expose `.setCause(cause: CauseDescriptor)` to
+  replace the derived cause with an explicit value (useful for hand-authored
+  stability keys). The override must occur **before** the cell participates in
+  the graph. If the cell has been connected to a node, read, or written, the
+  call must throw so we do not retroactively change ids that other nodes may
+  already reference.
+
+## Propagating Causes to Nested Frames
+
+- When a helper constructs nested recipes or lifts (e.g., `.map` wrapping a
+  callback recipe), push a new frame using the derived cause: `pushFrameFromCause
+  (cause, unsafeBinding)`. This ensures nested cells inherit the parent cause
+  while still deriving their own causes using the same recipe.
+- `createCell` inside the nested frame now starts its `generatedIdCounter` from
+  a hash of `{ parent: cause, path: currentPath }` so sibling inserts don’t
+  shift identifiers.
+
+## Integration Points
+
+- Update capability wrappers so every helper funnels through a single
+  `deriveCause` utility before calling `runtime.getCell`.
+- Extend `pushFrameFromCause` to accept structured causes (with optional
+  metadata) and make `createCell` resilient to both legacy and structured
+  inputs.
+- Ensure `.setCause` checks with the builder runtime whether the cell has been
+  connected or materialized; reject overrides when unsafe.
+- Persist the derived cause string in the graph snapshot so consecutive runs can
+  detect churn.
+
+## Tooling and Instrumentation
+
+- Log derived causes when `RuntimeOptions.debug` is enabled, including the inputs
+  that contributed to the hash. This helps diagnose instability during recipe
+  authoring.
+- Provide a CLI helper (`deno task inspect-causes`) that runs a recipe, prints
+  generated causes, and highlights differences between runs.
+
+## Risks
+
+- **Missing inputs**: Ensure wrappers consistently report input ids even when
+  proxies wrap literals. Fall back to a placeholder (e.g., `"literal"`) so the
+  hash remains deterministic.
+- **Hash collisions**: Use strong hashes (SHA-256) and compress for storage. Keep
+  the full hash available for debugging.
+- **Performance**: Gathering input ids should reuse dependency tracking already
+  performed by the scheduler to avoid extra instrumentation.

--- a/docs/specs/recipe-construction/graph-snapshot.md
+++ b/docs/specs/recipe-construction/graph-snapshot.md
@@ -1,0 +1,127 @@
+# Graph Snapshot Schema
+
+## Motivation
+
+- `Runner.setupInternal` currently stores recipe metadata inside the process
+  cell (`TYPE`, `argument`, `internal`, `resultRef`). We plan to deprecate
+  `TYPE` while still persisting the originating program reference (rename the
+  `spell` field to `pattern`). The runtime still lacks a persisted view of the
+  concrete nodes it instantiated.
+- `instantiateNode` performs alias gymnastics through
+  `unwrapOneLevelAndBindtoDoc` so nested recipes and closures work. A snapshot
+  that records the resolved nodes makes this machinery obsolete: future runs can
+  reconstruct bindings directly from the snapshot.
+- Persisting a snapshot on the result cell lets the runtime answer "what does
+  this graph look like" without re-running the factory, simplifying rehydration
+  and teardown.
+
+## Snapshot Envelope
+
+Store an additional `graph` payload on the result cell alongside the existing
+`value`, `source`, and renamed `pattern` metadata. The payload is versioned to
+allow future format changes.
+
+```ts
+interface GraphSnapshotV1 {
+  version: 1;
+  program?: RuntimeProgram;
+  generation?: number; // Incremented each time the runtime rebuilds the graph
+  nodes: Array<ReactiveNodeSnapshot | EventHandlerSnapshot>;
+}
+
+interface ReactiveNodeSnapshot {
+  module: ReactiveModuleDescriptor;
+  inputs: Record<string, Binding>;
+  output?: CellLink; // Optional; some modules only read
+  argumentSchema?: JSONSchema;
+  resultSchema?: JSONSchema;
+}
+
+interface EventHandlerSnapshot {
+  module: EventHandlerDescriptor;
+  inputs: Record<string, Binding>;
+  stream: CellLink; // Event stream destination
+  argumentSchema?: JSONSchema;
+}
+
+type Binding = CellLink | JSONValue | Record<string, Binding> | Array<Binding>;
+
+type ReactiveModuleDescriptor =
+  | {
+    type: "ref";
+    ref: string;
+    argumentSchema: JSONSchema;
+    resultSchema?: JSONSchema;
+  }
+  | {
+    type: "javascript";
+    implementation: string | { file: string; export: string };
+    argumentSchema: JSONSchema;
+    resultSchema?: JSONSchema;
+    metadata?: Record<string, JSONValue>;
+  };
+
+type EventHandlerDescriptor = ReactiveModuleDescriptor & { handler: true };
+```
+
+- Notes:
+
+  - Only nodes are serialized; cells and links are implied by the cell links
+    used in `inputs`, `output`, or `stream`.
+  - `CellLink` reuses the normalized link format the runtime already
+    understands.
+  - `Binding` supports nested structures so aliases into deeply nested inputs
+    are preserved without separate link tables.
+  - Optional `argumentSchema`/`resultSchema` on the node let nodes further
+    constrain or specialize module signatures without mutating the module
+    definition.
+  - `program` points to the main compiled artifact so tooling can correlate
+    modules with source files (see `packages/runner/src/harness/types.ts` for
+    `RuntimeProgram`).
+  - Descriptor-level `argumentSchema` values MUST describe array/prefix-array
+    schemas so reactive nodes can express tuple-style inputs used by lifts and
+    handlers.
+
+## Generation Flow
+
+1. When `Runner.startWithTx` iterates `recipe.nodes`, instrument each
+   `instantiateNode` call to record:
+   - The resolved module descriptor, including implementation reference.
+   - Normalized input links (aliases already resolved by the capability
+     wrappers so `unwrapOneLevelAndBindtoDoc` is no longer needed).
+   - Either an output link (for reactive nodes) or a stream link (for event
+     handlers), whichever applies.
+   - Optional argument/result schemas attached by the builder.
+2. Compute the final snapshot object, attach it to
+   `resultCell.withTx(tx).setMetadata("graph", snapshot)`, and persist it in the
+   same transaction that finishes setup.
+
+## Rehydration Strategy
+
+- On `Runner.setupInternal`, if a prior snapshot exists, load it before
+  unpacking defaults. The runtime can:
+  - Reattach scheduler subscriptions by walking the nodes, reusing modules whose
+    implementation reference matches.
+  - Rehydrate handler streams directly from their stored links.
+- When a handler or lift causes a graph to rebuild, diff the previous and new
+  node lists. Nodes that disappear are torn down by following their stored
+  output/stream links. Nodes with matching descriptors can reuse their existing
+  cells.
+
+## Teardown and Diffing
+
+- Nodes uniquely define the dependencies; links are inferred from the cell links
+  embedded inside each snapshot entry. Diffing node descriptors is sufficient to
+  drive teardown.
+- Maintain a monotonic `generation` counter on the snapshot. When a handler
+  triggers rehydration, increment the counter so logs can correlate actions with
+  rebuilds.
+
+## Outstanding Questions
+
+- Should snapshots include scheduler bookkeeping (e.g., dependency edges, last
+  run timestamps) or should that remain derived at runtime?
+- How do we store large schemas efficiently? Option: store a content hash in the
+  snapshot and persist the full schema in a shared manifest keyed by hash.
+- What is the cleanest way to encode the `pattern` reference alongside the
+  snapshot so older runtimes can ignore it while newer ones rely on it?

--- a/docs/specs/recipe-construction/implementation-plan-v2.md
+++ b/docs/specs/recipe-construction/implementation-plan-v2.md
@@ -1,0 +1,54 @@
+# Implementation Plan (V2 Opt-In)
+
+## Phase 0: Integration Test Harness
+
+- Build a recipe integration harness that can run `.tsx` recipes from
+  `packages/patterns/` (and other sample directories) inside the runtime.
+- Allow tests to declare:
+  - Initial arguments/documents (by path or schema-aware fixtures).
+  - Expected result snapshots (selective path assertions to keep fixtures small).
+  - Event sequences: each entry specifies the stream cell path to emit on and
+    the event payload, followed by updated expectations.
+- Run the harness against the current implementation to produce a baseline
+  digest. These tests must be shared between V1 and V2 so behavior stays aligned.
+
+## Phase 1: Introduce V2 Entry Points
+
+- Add `recipeV2`, `liftV2`, and `handlerV2` exports (plus builder re-exports via
+  `createBuilder`) that immediately expose capability wrappers and the deferred
+  execution lifecycle.
+- Keep existing `recipe`/`lift`/`handler` untouched; they continue invoking the
+  factory eagerly and serializing legacy metadata.
+- Wire the integration test harness to run each scenario twice: once under V1
+  entry points, once under V2.
+
+## Phase 2: Runtime Support Behind Opt-In
+
+- Teach the runtime to detect V2 recipes via metadata stored on result cells and
+  execute the new pipeline:
+  - Generate the node-only graph snapshot (`graph`, `pattern`, `generation`).
+  - Use capability wrappers for runtime instantiation instead of `OpaqueRef`.
+  - Apply deterministic causes and respect `.setCause`.
+- Ensure V2 code paths can coexist with legacy metadata so the runtime can run
+  both versions simultaneously.
+
+## Phase 3: Serializable Node Factories
+
+- Implement the `nodeFactory@1` sigil, `.curry`, and automatic deserialization
+  for V2 factories. Legacy V1 factories continue using current serialization.
+- Extend the integration harness to assert that serialized factories round-trip
+  correctly when returned from recipes or passed through cells/events.
+
+## Phase 4: Migration & Parity
+
+- Incrementally migrate internal recipes to `recipeV2`/`liftV2` once tests pass.
+- Keep running the dual-mode integration suite to confirm V1 and V2 stay in
+  sync. Fix divergences in V2 before moving additional recipes.
+- Provide documentation and codemods to ease recipe author migration.
+
+## Phase 5: Flip Default
+
+- After V2 covers all production-like scenarios, alias the default exports to
+  the V2 implementations (`recipe = recipeV2`, etc.).
+- Remove V1-only code paths, including `OpaqueRef`, `TYPE`, and legacy aliasing.
+- Retain the integration tests as regression coverage for the unified system.

--- a/docs/specs/recipe-construction/node-factory-shipping.md
+++ b/docs/specs/recipe-construction/node-factory-shipping.md
@@ -1,0 +1,97 @@
+# Serializable Node Factories
+
+## Goals
+
+- Allow lifts, handlers, and recipes to return reusable node factories that can
+  be shipped across spaces or persisted and later instantiated.
+- Support partial application via a `.curry(value, argIndex = 0)` helper that
+  yields another shippable node factory reflecting the bound argument.
+- Use a versioned sigil format (`nodeFactory@1`) that closely mirrors the graph
+  snapshot schema while capturing the additional data required to rehydrate the
+  factory and any curry operations performed on it.
+
+## User Experience
+
+- Any node factory created by `lift`, `handler`, or builder helpers returns a
+  callable object that also exposes `.toJSON()` producing the `nodeFactory@1`
+  sigil.
+- Recipes may return node factories or pass them into other lifts/recipes. When
+  the runtime encounters a `nodeFactory@1` payload (e.g., via `Cell.get()` or as
+  a recipe input), it materializes a callable node factory automatically.
+- `.curry(value, argIndex = 0)` returns a new factory that records the bound
+  argument. Currying is composable; each successive call appends metadata so the
+  runtime can reconstruct the applied arguments before instantiation.
+
+## Sigil Shape
+
+Serialized form:
+
+```json
+{
+  "/": {
+    "nodeFactory@1": {
+      "module": ReactiveModuleDescriptor | EventHandlerDescriptor,
+      "program": RuntimeProgram,
+      "curried": [
+        {
+          "index": 0,
+          "value": Binding
+        }
+      ],
+      "argumentSchema": JSONSchema,
+      "resultSchema": JSONSchema | null,
+      "metadata": Record<string, JSONValue> | null
+    }
+  }
+}
+```
+
+Notes:
+
+- `module` matches the descriptors used in `graph-snapshot.md`, including
+  implementation references and descriptor-level `argumentSchema`/`resultSchema`.
+- `program` stores the complete `RuntimeProgram` (as defined in
+  `packages/runner/src/harness/types.ts`) so the runtime knows how to load the
+  compiled artifact and entry symbol.
+- `curried` is ordered; each entry binds `value` to the given `index` (0-based by
+  default). `Binding` mirrors the nested binding structure from the snapshot so
+  bound values can include cell links.
+- `argumentSchema` on the sigil represents the effective schema after all
+  currying. It must continue to describe array/prefix-array inputs.
+- `resultSchema` is optional and may be omitted/`null` for handlers.
+- `metadata` carries optional helper information (e.g., helper names) and may be
+  omitted if unused.
+
+## Runtime Behavior
+
+- Deserialization: When the runtime reads a value containing the `nodeFactory@1`
+  sigil, it constructs a callable factory that:
+  1. Applies stored currying bindings before invoking the underlying module.
+  2. Exposes `.curry` to append additional entries to `curried` and returns a new
+     serialized-aware wrapper.
+  3. Implements `.toJSON()` to emit the sigil.
+- Invocation: Calling the materialized factory schedules a node instantiation
+  identical to calling the original lift/handler. Inputs are merged with stored
+  curry bindings using positional logic (array inputs) or schema-derived names.
+- Integration with snapshots: When a recipe instantiates a node from a serialized
+  factory, the resulting node appears in the graph snapshot exactly like a
+  regular node (same descriptor, inputs, etc.). The factory sigil itself can also
+  be stored in recipe state for later reuse.
+
+## Builder Integration
+
+- Builders surface `.curry` on node factories returned from `lift`, `handler`,
+  `.map`, etc. Currying prior to returning from a recipe automatically serializes
+  the bound arguments.
+- Recipes accepting factories receive them as callable objects. Internally the
+  runtime keeps the sigil available so passing the factory back to storage or
+  another recipe preserves currying metadata.
+
+## Open Questions
+
+- Do we need an explicit way to specify argument names alongside indexes for
+  currying when dealing with object-shaped schemas?
+- Should we limit the size of serialized `RuntimeProgram` payloads by hashing or
+  referencing a shared cache entry instead of embedding the entire program?
+- How do we ensure backwards compatibility if the module descriptor expands? The
+  sigil version (`nodeFactory@1`) gives us room to add future revisions.

--- a/docs/specs/recipe-construction/overview.md
+++ b/docs/specs/recipe-construction/overview.md
@@ -1,0 +1,192 @@
+# Recipe Graph Unification Spec
+
+## Summary
+
+Unify builder-time `OpaqueRef` proxies and runtime `Cell` objects into a single
+capability-driven cell model. The new model preserves recipe ergonomics
+(implicit property access, helpers like `.map`) while producing a concrete
+runtime graph with stable cell identifiers that the runtime can persist,
+rehydrate, and tear down. Result cells become the canonical owners of graph
+metadata, and lifts and handlers gain cause-based identifier stability.
+
+## Goals
+
+- Provide a single cell abstraction with explicit capabilities (`Opaque`,
+  `Mutable`, `Readonly`, `Writeonly`) that behaves consistently in builder code
+  and at runtime.
+- Preserve existing recipe ergonomics—automatic property proxies and helper
+  methods—so authored code remains concise.
+- Capture a post-instantiation graph snapshot with concrete cell ids so the
+  runtime can rehydrate or tear down dynamic graphs.
+- Stabilize ids across small edits by deriving causes from input cells plus
+  implementation details.
+
+## Non-goals
+
+- Redesigning scheduler semantics beyond the current "ignore self-writes" and
+  100-iteration cap.
+- Guaranteeing backward compatibility for the existing process cell layout; the
+  process cell will be replaced by the graph snapshot stored on the result
+  cell.
+- Delivering a full type-level capability system across the entire codebase in
+  this phase; scope is builder APIs and runtime interfaces.
+
+## Background
+
+### Current builder flow
+
+- `packages/runner/src/builder/recipe.ts` pushes a frame, runs the author’s
+  factory immediately, and records every `OpaqueRef` and node it touches.
+- Inputs are wrapped in `opaqueRef` proxies so the builder can serialize graphs
+  before runtime cells exist.
+- `factoryFromRecipe` walks the returned structure, synthesizes paths
+  ("argument" and `internal/__#n`), infers defaults, and emits JSON with
+  `argumentSchema`, `resultSchema`, `initial`, `result`, and serialized nodes.
+  No runtime cell ids exist yet.
+- `OpaqueRef` proxies track connected nodes, expose helpers like `.map()`, and
+  rely on shadow refs to reuse parent cells without leaking frames.
+- `lift` transforms a function into a module factory whose implementation runs
+  reactively once live. Handlers wrap functions to produce streams and run once
+  per event.
+
+### Runtime instantiation today
+
+- `Runner.setup` ensures each result cell has a paired process cell storing
+  `TYPE` (recipe id), `argument`, `internal` state, `resultRef`, and optional
+  spell links. Result cells expose generated data plus `source` metadata.
+- `setupInternal` merges defaults into the process cell and binds the serialized
+  recipe graph via `unwrapOneLevelAndBindtoDoc`; aliases remain path based.
+- `startWithTx` iterates serialized nodes, resolves modules, and calls
+  `instantiateNode`, turning aliases into real `Cell` instances through
+  `sendValueToBinding`. The scheduler maintains reactivity.
+- Handlers can emit new recipes; lifts that return recipes spawn fresh graphs
+  and register teardown hooks.
+
+## Problem Statement
+
+- Dual abstractions (`OpaqueRef` vs `Cell`) confuse authors and limit helper
+  availability.
+- Recipes lack persisted runtime graphs, making rehydration and teardown fragile
+  for handler-produced or reactive graphs.
+- Alias metadata hinges on synthesized paths that shift as recipes evolve.
+- Cause assignment for runtime-created cells is ad hoc, so ids change under
+  small edits.
+
+## Proposed Design
+
+### Capability-driven cells
+
+- Keep the core `Cell` implementation for runtime internals.
+- Introduce capability wrappers (`Mutable`, `Readonly`, `Writeonly`, `Opaque`)
+  that proxy `Cell` instances.
+- Proxies map property access (`cell.foo`) to `cell.key("foo")` and surface
+  helpers. `.map`, `.filter`, etc., appear on array-like cells; unknown schemas
+  fall back to property access semantics.
+- Invoking proxied helpers (`cell.map(...)`) routes through the proxy so we can
+  distinguish reading vs executing members.
+- Remove `.setDefault`; rely on schema defaults. Other helpers become available
+  wherever semantically valid.
+- Rename the combination of opaque refs and literals to `OpaqueValue` so lifts
+  can accept cells or plain data uniformly.
+
+### Recipe definition and authorship
+
+- Treat `recipe(...)` as sugar for a `lift` whose inputs default to `Opaque`
+  cells. The author’s factory still runs immediately, returning capability-
+  wrapped cells instead of opaque refs.
+- Property access in recipes continues to use proxy wrappers, so existing code
+  (e.g., `items.map(...)`) keeps working.
+- Lifts and handlers may accept an optional `cause`. When omitted, the runtime
+  derives the cause from input cell ids and a hash of the implementation body.
+
+### Runtime graph instantiation
+
+- Instantiating a recipe produces a concrete graph snapshot with real cell ids,
+  capability kinds, aliases, and module bindings.
+- The snapshot is stored alongside `value` and `source` metadata on the result
+  cell. Documents written by the graph keep `source` pointing back to that
+  result cell.
+- Snapshot metadata is sufficient to rehydrate handler-generated graphs and to
+  tear down dynamic graphs before rebuilding them on change.
+
+### Serialization format
+
+- Define a versioned structure containing `graphVersion`, `cells`, `nodes`, and
+  `links`.
+  - `cells`: id, capability, cause, schema hash, redirect targets.
+  - `nodes`: module reference plus input/output bindings rewritten to concrete
+    cell ids.
+- Maintain backward compatibility by leaving existing `resultRef`/`source`
+  fields untouched and appending a `graph` payload.
+
+### Cause generation
+
+- Default cause: hash of (input cell ids + implementation source).
+- Optional `cause` parameter on `lift`, `handler`, and recipe factories
+  overrides the default when authors provide stable names.
+- Causes feed into cell id derivation to keep ids stable under benign edits.
+
+## Impacted Areas
+
+- Builder APIs (`recipe`, `lift`, `handler`, helper exports).
+- Runtime cell creation, alias resolution, and recipe instantiation.
+- Serialization (`json-utils.ts`, recipe manager persistence, result metadata).
+- Tests and tooling that assume path-based aliases or opaque-ref-only helpers.
+
+## Implementation Plan
+
+1. **Capability wrappers**
+   - Implement proxy-based wrappers and surface them from the builder API.
+   - Update TypeScript definitions for capability-aware helpers.
+2. **Unify builder outputs**
+   - Adapt `recipe`/`lift` to emit capability-wrapped cells.
+   - Replace `OpaqueRef` internals with compatibility shims or adapters.
+3. **Graph snapshot generation**
+   - Build runtime graph snapshots during instantiation and store them in result
+     cell metadata.
+   - Update rehydration/teardown logic to consume the snapshot.
+4. **Cause derivation**
+   - Implement default hashing and expose explicit overrides.
+   - Ensure handler-spawned recipes reuse ids whenever inputs and code are
+     unchanged.
+5. **Cleanup**
+   - Deprecate shadow refs and frame gymnastics once proxies land.
+   - Remove `.setDefault`; rely on schema-level defaults.
+6. **Testing & documentation**
+   - Update builder/runner tests for new helper behavior and metadata.
+   - Document capability wrappers and graph metadata for recipe authors.
+
+## Testing Strategy
+
+- Extend recipe and runner tests (e.g., `recipes/todo-list.tsx`) to assert
+  capability wrapper behavior, array helpers, and redirect semantics.
+- Add instantiation tests that serialize the new graph snapshot and rehydrate
+  it, focusing on handler-generated graphs.
+- Verify scheduler behavior (ignored self-writes, iteration cap) with the new
+  cell model.
+- Regression tests for `cellA.set(cellB)` vs `cellA.redirectTo(cellB)`.
+
+## Risks & Mitigations
+
+- **TypeScript proxy typing gaps.** Provide dedicated wrapper types with helper
+  availability per schema; fall back to index signatures when needed.
+- **Snapshot size/performance.** Start with minimal metadata (ids, capabilities,
+  aliases) and profile before expanding.
+- **Backward compatibility.** Introduce shims so existing recipes run unchanged
+  during migration.
+
+## Open Questions
+
+- How can authors override default helper capability mapping without undermining
+  safety guarantees?
+- What exact schema/versioning do we use for the graph snapshot payload?
+
+## Next Steps
+
+- Prototype capability wrappers and convert a sample recipe to validate
+  ergonomics, including mixed-capability inputs (literals, `Opaque`,
+  `Mutable`) when invoking lifts.
+- Draft the graph snapshot schema and review with runtime/storage stakeholders.
+- Implement rehydration from the stored graph snapshot and exercise it with a
+  sample recipe.
+- Plan the rollout and documentation updates for existing recipes.

--- a/docs/specs/recipe-construction/overview.md
+++ b/docs/specs/recipe-construction/overview.md
@@ -62,6 +62,23 @@ metadata, and lifts and handlers gain cause-based identifier stability.
 - Handlers can emit new recipes; lifts that return recipes spawn fresh graphs
   and register teardown hooks.
 
+## Repository Observations
+
+- `packages/runner/src/builder/opaque-ref.ts` shows how `opaqueRef` proxies
+  track connected nodes via `.connect`, compute nested schema metadata with
+  `ContextualFlowControl`, and expose helpers such as `.map`. Capability
+  wrappers must recreate these affordances against real runtime cells.
+- `packages/runner/src/builder/factory.ts` pushes frames before calling the
+  author factory. `createCell` expects the frame to provide a `cause` and an
+  `unsafe_binding`, so the new wrappers must keep the frame lifecycle intact.
+- `packages/runner/src/runner.ts` writes recipe metadata into a process cell
+  (`TYPE`, `argument`, `internal`, `resultRef`) and later instantiates nodes by
+  unwrapping aliases in `unwrapOneLevelAndBindtoDoc`. Snapshot generation should
+  hook into this instantiation path to capture concrete cell ids.
+- `packages/runner/src/create-ref.ts` hashes the supplied `cause` and recorded
+  structure to derive entity ids. Stable causes therefore hinge on the data we
+  pass into frames when new cells are materialized.
+
 ## Problem Statement
 
 - Dual abstractions (`OpaqueRef` vs `Cell`) confuse authors and limit helper
@@ -184,9 +201,11 @@ metadata, and lifts and handlers gain cause-based identifier stability.
 ## Next Steps
 
 - Prototype capability wrappers and convert a sample recipe to validate
-  ergonomics, including mixed-capability inputs (literals, `Opaque`,
-  `Mutable`) when invoking lifts.
-- Draft the graph snapshot schema and review with runtime/storage stakeholders.
-- Implement rehydration from the stored graph snapshot and exercise it with a
-  sample recipe.
-- Plan the rollout and documentation updates for existing recipes.
+  ergonomics (see `capability-wrappers.md`).
+- Draft and iterate on the graph snapshot schema, then review with
+  runtime/storage stakeholders (`graph-snapshot.md`).
+- Implement rehydration against the stored graph snapshot and exercise it with
+  a sample recipe while observing cause stability (`graph-snapshot.md`,
+  `cause-derivation.md`).
+- Plan the migration and documentation rollout for existing recipes
+  (`rollout-plan.md`).

--- a/docs/specs/recipe-construction/recipe-integration-tests.md
+++ b/docs/specs/recipe-construction/recipe-integration-tests.md
@@ -1,0 +1,76 @@
+# Recipe Integration Test Harness
+
+## Objectives
+
+- Provide end-to-end coverage that exercises recipes (especially in
+  `packages/patterns/`) under both the legacy (V1) and new (V2) builder/runtime
+  pipelines.
+- Capture expected behavior as structured fixtures so we can compare outputs
+  before and after the V2 migration without rewriting tests.
+
+## Test Artifact Structure
+
+Each recipe test case consists of:
+
+- **Recipe module**: A `.tsx` or `.ts` file exporting a recipe, lift, or handler.
+- **Fixture file** (proposed `.recipe.test.json` or `.recipe.test.ts`):
+  - `arguments`: Optional initial argument payload (JSON) passed to the recipe.
+  - `initialState`: Optional set of documents/cells to seed before running.
+  - `assertions`: Array of checkpoints. Each checkpoint contains:
+    - `expect`: A list of `{ path: string, value: JSONValue }` assertions on the
+      result cell (paths use dot/bracket notation or JSON pointers).
+    - `events`: Optional array of events to dispatch before the next checkpoint.
+      Each event is `{ stream: string, payload: JSONValue }`, where `stream` is a
+      cell link/path within the result graph.
+- **Optional snapshot**: For debugging we can persist the generated graph
+  snapshot and compare it between runs. Assertions stay selective to avoid
+  brittle fixtures.
+
+Example fixture snippet:
+
+```json
+{
+  "arguments": { "initialCount": 1 },
+  "assertions": [
+    { "expect": [{ "path": "result.count", "value": 1 }] },
+    {
+      "events": [{ "stream": "result.increment", "payload": {} }],
+      "expect": [{ "path": "result.count", "value": 2 }]
+    }
+  ]
+}
+```
+
+## Harness Execution Flow
+
+1. Compile the recipe module (shared pipeline for V1 and V2).
+2. Run the recipe twice per fixture:
+   - **V1 mode**: Use current `recipe`/`lift`/`handler` exports.
+   - **V2 mode**: Swap in `recipeV2`/`liftV2`/`handlerV2` and new runtime paths.
+3. For each mode:
+   - Instantiate the runtime, seed initial state, run the recipe, and evaluate
+     assertions.
+   - For checkpoints with events, emit them sequentially via handler streams and
+     re-run assertions after the scheduler settles.
+4. Report differences clearly (e.g., mismatched values, missing paths).
+5. Optionally dump V1 vs V2 graph snapshots when failures occur to aid debugging.
+
+## Tooling Considerations
+
+- Implement harness using Deno test runner (`deno task test`) so it integrates
+  with existing CI scripts.
+- Provide utilities for referencing cells/streams via friendly syntax (e.g.,
+  resolve `result.increment` to the correct link automatically using the stored
+  snapshot or capability wrappers).
+- Allow fixtures to specify tolerance for unordered arrays or partial structures
+  when recipes return collections.
+
+## Rollout
+
+- Add the harness and fixtures under `packages/runner/integration/` so UI-facing
+  patterns remain focused on front-end rendering scenarios.
+- Seed the suite with high-impact recipes (mirroring those in
+  `packages/patterns/`) to validate end-to-end behavior.
+- Expand coverage to other workspaces once the harness stabilizes.
+- Keep fixtures mode-agnostic so future migrations (beyond V2) can reuse the
+  same tests.

--- a/docs/specs/recipe-construction/rollout-plan.md
+++ b/docs/specs/recipe-construction/rollout-plan.md
@@ -1,0 +1,42 @@
+# Migration and Rollout Plan
+
+## Phases
+
+1. **Prototype in Runner Sandbox**
+   - Implement capability wrappers behind a feature flag. Gate entry points in
+     `createBuilder` so recipes opt in per-runtime.
+   - Add regression tests under `packages/runner/src/builder/__tests__` that
+     exercise both legacy `OpaqueRef` paths and the new wrapper behavior.
+2. **Snapshot and Cause Pilot**
+   - Enable graph snapshot generation for internal recipes only. Use the
+     `RecipeManager` to tag participating recipes so telemetry can compare
+     runtime rebuild times pre- and post-snapshot.
+   - Surface snapshot diffs in a development panel (reuse existing harness UI)
+     to validate stability guarantees.
+3. **Recipe Migration**
+   - Provide codemods or manual guides to migrate high-traffic recipes in the
+     `recipes/` workspace. Update `recipes/README.md` to describe capabilities
+     and snapshot expectations.
+   - Teach docs and tutorials to reference capability wrappers instead of
+     `OpaqueRef`. Update `docs/common/COMPONENTS.md` once APIs stabilize.
+4. **Cleanup and Deprecation**
+   - Remove `OpaqueRef` exports from `@commontools/api` after recipes migrate.
+   - Delete shadow-ref utilities and legacy alias handling once snapshots power
+     rehydration. Simplify `factoryFromRecipe` to persist capability metadata
+     instead of path-derived aliases.
+
+## Testing Strategy
+
+- Extend existing recipe integration tests (`recipes/todo-list.tsx`, scheduler
+  suites) to assert snapshot creation, cause stability, and wrapper helper
+  behavior.
+- Add rehydration tests that serialize a snapshot, mutate result metadata, and
+  ensure the runtime can rebuild without rerunning the recipe factory.
+
+## Communication
+
+- Publish an ADR summarizing the capability model and snapshot design for review
+  by runtime, storage, and tooling stakeholders.
+- Coordinate with DX and documentation teams to schedule updates to learning
+  materials. Provide example migrations that highlight mixed-capability inputs
+  and handler rehydration flows.


### PR DESCRIPTION
- capture the end-to-end “Recipe Graph Unification” spec, replacing the opaque-ref/legacy metadata model with capability-wrapped cells, deterministic  causes, and runtime graph snapshots
- define supporting pillars: shippable node factory sigils, integration test harness design, phased rollout strategy, and V2-only builder/runtime entry points
- consolidate the repository observations, impacted areas, risks, open questions, and detailed implementation roadmap into the docs/specs/recipe-construction folder
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Defines the end-to-end plan to replace OpaqueRef with capability-wrapped Cells, add deterministic cause derivation, and persist runtime graph snapshots for stable, rehydratable recipe graphs. Also outlines V2 entry points, shippable node factories, and an integration harness to validate behavior during migration.

- **New Features**
  - Capability wrappers (Opaque/Readonly/Mutable/Writeonly) replacing OpaqueRef, preserving proxy ergonomics and helpers.
  - Deterministic cause derivation for lifts/handlers/helpers with optional overrides.
  - Graph snapshot schema stored on result cells for rehydration and teardown.
  - Serializable node factories with .curry and a nodeFactory@1 sigil.
  - Recipe integration test harness to run V1 vs V2 side-by-side.
  - V2 implementation plan and phased rollout/migration guidance.

<!-- End of auto-generated description by cubic. -->

