### PR TITLE
Enable indentation with tab in `ct-code-editor`

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -68,6 +68,7 @@
     "npm:@arizeai/openinference-vercel@^2.0.1": "2.3.1_@opentelemetry+api@1.9.0",
     "npm:@babel/standalone@^7.28.2": "7.28.2",
     "npm:@codemirror/autocomplete@^6.15.0": "6.18.7",
+    "npm:@codemirror/commands@^6.8.1": "6.8.1",
     "npm:@codemirror/lang-css@^6.3.1": "6.3.1",
     "npm:@codemirror/lang-html@^6.4.9": "6.4.9",
     "npm:@codemirror/lang-javascript@^6.2.2": "6.2.4",
@@ -2125,6 +2126,7 @@
       "packages/ui": {
         "dependencies": [
           "npm:@codemirror/autocomplete@^6.15.0",
+          "npm:@codemirror/commands@^6.8.1",
           "npm:@codemirror/lang-css@^6.3.1",
           "npm:@codemirror/lang-html@^6.4.9",
           "npm:@codemirror/lang-javascript@^6.2.2",

--- a/packages/patterns/chatbot-note.tsx
+++ b/packages/patterns/chatbot-note.tsx
@@ -225,7 +225,8 @@ export default recipe<LLMTestInput, LLMTestResult>(
                 $mentioned={mentioned}
                 onbacklink-click={handleCharmLinkClick({})}
                 language="text/markdown"
-                style="min-height: 400px;"
+                wordWrap
+                tabIndent
               />
               <details>
                 <summary>Mentioned Charms</summary>

--- a/packages/ui/deno.json
+++ b/packages/ui/deno.json
@@ -10,6 +10,7 @@
     "test": "deno test --allow-env --allow-ffi --allow-read"
   },
   "imports": {
+    "@codemirror/commands": "npm:@codemirror/commands@^6.8.1",
     "@lit/context": "npm:@lit/context@^1.1.2",
     "marked": "npm:marked@^4.0.0",
     "codemirror": "npm:codemirror@^6.0.1",

--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -5,7 +5,7 @@ import { basicSetup } from "codemirror";
 import { EditorView, keymap, placeholder } from "@codemirror/view";
 import { indentWithTab } from "@codemirror/commands";
 import { Compartment, EditorState, Extension } from "@codemirror/state";
-import { LanguageSupport } from "@codemirror/language";
+import { LanguageSupport, indentUnit } from "@codemirror/language";
 import { javascript as createJavaScript } from "@codemirror/lang-javascript";
 import { markdown as createMarkdown } from "@codemirror/lang-markdown";
 import { css as createCss } from "@codemirror/lang-css";
@@ -142,6 +142,7 @@ export class CTCodeEditor extends BaseElement {
   private _tabSizeComp = new Compartment();
   private _tabIndentComp = new Compartment();
   private _maxLineWidthComp = new Compartment();
+  private _indentUnitComp = new Compartment();
   private _cleanupFns: Array<() => void> = [];
   private _cellController = createStringCellController(this, {
     timing: {
@@ -526,10 +527,12 @@ export class CTCodeEditor extends BaseElement {
 
     // Update tab size
     if (changedProperties.has("tabSize") && this._editorView) {
+      const size = this.tabSize ?? 2;
       this._editorView.dispatch({
-        effects: this._tabSizeComp.reconfigure(
-          EditorState.tabSize.of(this.tabSize ?? 2),
-        ),
+        effects: [
+          this._tabSizeComp.reconfigure(EditorState.tabSize.of(size)),
+          this._indentUnitComp.reconfigure(indentUnit.of(" ".repeat(size))),
+        ],
       });
     }
 
@@ -625,6 +628,9 @@ export class CTCodeEditor extends BaseElement {
       ),
       // Tab size
       this._tabSizeComp.of(EditorState.tabSize.of(this.tabSize ?? 2)),
+      this._indentUnitComp.of(
+        indentUnit.of(" ".repeat(this.tabSize ?? 2)),
+      ),
       // Optional max line width (in ch)
       this._maxLineWidthComp.of(
         typeof this.maxLineWidth === "number" && this.maxLineWidth > 0

--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -5,7 +5,7 @@ import { basicSetup } from "codemirror";
 import { EditorView, keymap, placeholder } from "@codemirror/view";
 import { indentWithTab } from "@codemirror/commands";
 import { Compartment, EditorState, Extension } from "@codemirror/state";
-import { LanguageSupport, indentUnit } from "@codemirror/language";
+import { indentUnit, LanguageSupport } from "@codemirror/language";
 import { javascript as createJavaScript } from "@codemirror/lang-javascript";
 import { markdown as createMarkdown } from "@codemirror/lang-markdown";
 import { css as createCss } from "@codemirror/lang-css";

--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -3,6 +3,7 @@ import { BaseElement } from "../../core/base-element.ts";
 import { styles } from "./styles.ts";
 import { basicSetup } from "codemirror";
 import { EditorView, keymap, placeholder } from "@codemirror/view";
+import { indentWithTab } from "@codemirror/commands";
 import { Compartment, EditorState, Extension } from "@codemirror/state";
 import { LanguageSupport } from "@codemirror/language";
 import { javascript as createJavaScript } from "@codemirror/lang-javascript";
@@ -525,6 +526,7 @@ export class CTCodeEditor extends BaseElement {
     // Create editor extensions
     const extensions: Extension[] = [
       basicSetup,
+      keymap.of([indentWithTab]),
       oneDark,
       this._lang.of(getLangExtFromMimeType(this.language)),
       this._readonly.of(EditorState.readOnly.of(this.readonly)),


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enable Tab indentation in ct-code-editor using CodeMirror’s indentWithTab, so pressing Tab indents the current line or selection instead of shifting focus. Adds @codemirror/commands as a dependency.

<!-- End of auto-generated description by cubic. -->

