### PR TITLE
Check initializedUpTo to make sure it's not pointing past a reverted result.

### DIFF
--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -76,7 +76,7 @@ export function map(
 
     // .getRaw() because we want the recipe itself and avoid following the
     // aliases in the recipe
-    const opRecipe = op.getRaw() as any;
+    const opRecipe = op.getRaw();
 
     // If the result's value is undefined, set it to the empty array.
     if (resultWithLog.get() === undefined) {
@@ -98,6 +98,11 @@ export function map(
     }
 
     const newArrayValue = resultWithLog.get().slice(0, initializedUpTo);
+    // If we rollback a change to result cell, and that causes it to be
+    // shorter, we need to re-initialize some cells.
+    if (initializedUpTo > newArrayValue.length) {
+      initializedUpTo = newArrayValue.length;
+    }
     // Add values that have been appended
     while (initializedUpTo < list.length) {
       const resultCell = runtime.getCell(


### PR DESCRIPTION
- If we revert a result cell (or get some other server driven change), our closure captured initializedUpTo state will be out of sync. If this means it points after the last element, re-initialize the missing elements.
