### PR TITLE
Pass `allCharms` to `chatbot-note.tsx`

### DIFF
--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -117,6 +117,7 @@ export default recipe<CharmsListInput, CharmsListOutput>(
                 onClick={spawnPattern(Note, {
                   title: "New Note",
                   content: "",
+                  allCharms,
                 })({})}
               >
                 📄 Note


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Passes allCharms to the Note pattern when creating a new note so chatbot-note.tsx has the full charm list. This enables charm-aware UI and avoids undefined errors when charms are needed.

<!-- End of auto-generated description by cubic. -->

