### PR TITLE
_actually_ pass `allCharms` to `chatbot-note.tsx`

### DIFF
--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -109,6 +109,7 @@ export default recipe<CharmsListInput, CharmsListOutput>(
                 onClick={spawnPattern(ChatbotNote, {
                   title: "New Note",
                   content: "",
+                  allCharms,
                 })({})}
               >
                 🤖 Chatbot Note
@@ -117,7 +118,6 @@ export default recipe<CharmsListInput, CharmsListOutput>(
                 onClick={spawnPattern(Note, {
                   title: "New Note",
                   content: "",
-                  allCharms,
                 })({})}
               >
                 📄 Note

--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -117,6 +117,7 @@ export default recipe<CharmsListInput, CharmsListOutput>(
                 onClick={spawnPattern(Note, {
                   title: "New Note",
                   content: "",
+                  allCharms,
                 })({})}
               >
                 📄 Note


### PR DESCRIPTION
- **Pass `allCharms` to `chatbot-note.tsx`**
- **Change the RIGHT line in `default-app.tsx`**

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Pass allCharms to Chatbot Note when spawning it from default-app, restoring access to the full charms list. Fixes missing prop issues in chatbot-note features that rely on the charms registry.

<!-- End of auto-generated description by cubic. -->

