### PR TITLE
When writing the link in ifElse, use setRaw

### DIFF
--- a/packages/runner/src/builtins/if-else.ts
+++ b/packages/runner/src/builtins/if-else.ts
@@ -27,6 +27,7 @@ export function ifElse(
     const ref = inputsWithLog.key(condition ? 1 : 2)
       .getAsLink({ base: result });
 
-    resultWithLog.send(ref);
+    // When writing links, we need to use setRaw
+    resultWithLog.setRaw(ref);
   };
 }


### PR DESCRIPTION
This is @seefeldb's change, but since we didn't have a PR yet, I made one.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes ifElse to write link outputs with setRaw instead of send, so links are preserved as links and resolve correctly downstream.

- **Bug Fixes**
  - Prevents links from being serialized/treated as values when emitted by ifElse.

<!-- End of auto-generated description by cubic. -->

