### PR TITLE
using posix for join instead, gives us the proper / for file path separator

### DIFF
--- a/packages/js-runtime/program.ts
+++ b/packages/js-runtime/program.ts
@@ -1,6 +1,6 @@
 import { isDeno } from "@commontools/utils/env";
 import { ProgramResolver, Source } from "./interface.ts";
-import { dirname, join } from "@std/path";
+import { dirname, join } from "@std/path/posix";
 
 export class InMemoryProgram implements ProgramResolver {
   private modules: Record<string, string>;

--- a/packages/js-runtime/typescript/resolver.ts
+++ b/packages/js-runtime/typescript/resolver.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import { Program, ProgramResolver, Source } from "../interface.ts";
-import { dirname, join } from "@std/path";
+import { dirname, join } from "@std/path/posix";
 
 export type UnresolvedModuleHandling =
   | { type: "allow"; identifiers: string[] }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Use POSIX path joining so generated file paths always use forward slashes. Fixes recipe resolution failures on Windows/WSL where backslashes broke lookups (Linear CT-927).

- **Bug Fixes**
  - Import join and dirname from @std/path/posix in program.ts and typescript/resolver.ts.
  - Normalize paths to / across platforms to align with TS/module resolution.

<!-- End of auto-generated description by cubic. -->

