### PR TITLE
runner(schema): respect schema additionalProperties during validation

### DIFF
--- a/packages/charm/src/ops/charm-controller.ts
+++ b/packages/charm/src/ops/charm-controller.ts
@@ -61,7 +61,7 @@ class CharmPropIo implements CharmCellIo {
     if (this.#type === "input") {
       return this.#cc.manager().getArgument(this.#cc.getCell());
     } else if (this.#type === "result") {
-      return this.#cc.getCell();
+      return this.#cc.manager().getResult(this.#cc.getCell());
     }
     throw new Error(`Unknown property type "${this.#type}"`);
   }

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -155,8 +155,8 @@ test_value "Nested path set" "userData/user/name" '"Jane"' '"Jane"'
 echo "Testing --input flag operations..."
 
 # Test input flag operations
-test_json_value "Input flag set" "config" '{"inputConfig":"test"}' "--input"
-test_value "Nested input path" "config/inputConfig" '"inputValue"' '"inputValue"' "--input"
+test_json_value "Input flag set" "userData" '{"user":{"name":"test"}}' "--input"
+test_value "Nested input path" "userData/user/name" '"inputValue"' '"inputValue"' "--input"
 
 # Check space has new charm with correct inputs and title
 TITLE="Simple counter 2: 10"

--- a/packages/html/src/render.ts
+++ b/packages/html/src/render.ts
@@ -90,7 +90,7 @@ export const renderImpl = (
     return cancel;
   }
   parent.append(root);
-  logger.debug("Rendered", root);
+  logger.debug("Rendered root", root);
   return () => {
     root.remove();
     cancel();

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1259,7 +1259,7 @@ export class Runner implements IRunner {
     // TODO(seefeld): Make sure to not cancel after a recipe is elevated to a
     // charm, e.g. via navigateTo. Nothing is cancelling right now, so leaving
     // this as TODO.
-    addCancel(this.cancels.get(this.getDocKey(resultCell.getSourceCell()!)));
+    addCancel(() => this.stop(resultCell));
   }
 }
 

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -683,11 +683,11 @@ export function validateAndTransform(
     }
 
     // Handle additional properties if defined
-    if (resolvedSchema.additionalProperties) {
+    if (resolvedSchema.additionalProperties || !resolvedSchema.properties) {
       for (const key of keys) {
         // Skip properties that were already processed above:
         if (!resolvedSchema.properties || !(key in resolvedSchema.properties)) {
-          // Will use additionalProperties:
+          // Will use additionalProperties if present
           const childSchema = runtime.cfc.getSchemaAtPath(
             resolvedSchema,
             [key],

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1,4 +1,5 @@
 import { JSONSchemaObj } from "@commontools/api";
+import { getLogger } from "@commontools/utils/logger";
 import { isObject, isRecord } from "@commontools/utils/types";
 import { JSONSchemaMutable } from "@commontools/runner";
 import { ContextualFlowControl } from "./cfc.ts";
@@ -15,6 +16,11 @@ import {
   makeOpaqueRef,
 } from "./query-result-proxy.ts";
 import { toCell, toOpaqueRef } from "./back-to-cell.ts";
+
+const logger = getLogger("validateAndTransform", {
+  enabled: true,
+  level: "debug",
+});
 
 /**
  * Schemas are mostly a subset of JSONSchema.
@@ -677,23 +683,35 @@ export function validateAndTransform(
     }
 
     // Handle additional properties if defined
-    for (const key of keys) {
-      if (!resolvedSchema.properties || !(key in resolvedSchema.properties)) {
-        const childSchema = runtime.cfc.getSchemaAtPath(
-          resolvedSchema,
-          [key],
-          rootSchema,
-        );
-        if (childSchema === undefined) {
-          continue;
+    if (resolvedSchema.additionalProperties) {
+      for (const key of keys) {
+        // Skip properties that were already processed above:
+        if (!resolvedSchema.properties || !(key in resolvedSchema.properties)) {
+          // Will use additionalProperties:
+          const childSchema = runtime.cfc.getSchemaAtPath(
+            resolvedSchema,
+            [key],
+            rootSchema,
+          );
+          if (childSchema === undefined) {
+            // This should never happen
+            logger.warn(() => [
+              "validateAndTransform: unexpected undefined schema for additional property",
+              key,
+              resolvedSchema,
+              rootSchema,
+              link,
+            ]);
+            continue;
+          }
+          result[key] = validateAndTransform(
+            runtime,
+            tx,
+            { ...link, path: [...link.path, key], schema: childSchema },
+            synced,
+            seen,
+          );
         }
-        result[key] = validateAndTransform(
-          runtime,
-          tx,
-          { ...link, path: [...link.path, key], schema: childSchema },
-          synced,
-          seen,
-        );
       }
     }
 

--- a/packages/runner/test/schema.test.ts
+++ b/packages/runner/test/schema.test.ts
@@ -102,7 +102,7 @@ describe("Schema Support", () => {
       // Let type inference work through the schema
       const result = mappingCell.asSchema(schema).get();
 
-      (expect(result) as any).toEqualIgnoringSymbols({
+      expect(result).toEqualIgnoringSymbols({
         id: 1,
         changes: ["2025-01-06"],
         kind: "user",
@@ -179,7 +179,7 @@ describe("Schema Support", () => {
       // Find the currently selected cell and update it
       const first = cell.key("current").get();
       expect(isCell(first)).toBe(true);
-      (expect(first.get()) as any).toEqualIgnoringSymbols({ label: "first" });
+      expect(first.get()).toEqualIgnoringSymbols({ label: "first" });
       first.withTx(tx).set({ label: "first - update" });
 
       tx.commit();
@@ -222,24 +222,24 @@ describe("Schema Support", () => {
 
       await runtime.idle();
 
-      (expect(currentByGetValues) as any).toEqualIgnoringSymbols([
+      expect(currentByGetValues).toEqualIgnoringSymbols([
         "first",
         "first - update",
         "first - updated again",
       ]);
-      (expect(currentByKeyValues) as any).toEqualIgnoringSymbols([
+      expect(currentByKeyValues).toEqualIgnoringSymbols([
         "first",
         "first - update",
         "second",
         "second - update",
       ]);
-      (expect(currentValues) as any).toEqualIgnoringSymbols([
+      expect(currentValues).toEqualIgnoringSymbols([
         "first",
         "first - update",
         "second",
         "second - update",
       ]);
-      (expect(rootValues) as any).toEqualIgnoringSymbols([
+      expect(rootValues).toEqualIgnoringSymbols([
         "root",
         "cancelled",
         "root",
@@ -247,7 +247,7 @@ describe("Schema Support", () => {
 
       cancel();
 
-      (expect(rootValues) as any).toEqualIgnoringSymbols([
+      expect(rootValues).toEqualIgnoringSymbols([
         "root",
         "cancelled",
         "root",
@@ -355,7 +355,7 @@ describe("Schema Support", () => {
       // Find the currently selected cell and read it
       const first = root.key("current").withTx(tx).get();
       expect(isCell(first)).toBe(true);
-      (expect(first.get()) as any).toEqualIgnoringSymbols({ label: "first" });
+      expect(first.get()).toEqualIgnoringSymbols({ label: "first" });
       const { asCell: _ignore, ...omitSchema } = schema.properties.current;
       expect(parseLink(first.getAsLink({ includeSchema: true }))).toEqual({
         id: toURI(initialEntityId),
@@ -392,7 +392,7 @@ describe("Schema Support", () => {
       tx = runtime.edit();
 
       await runtime.idle();
-      (expect(first.get()) as any).toEqualIgnoringSymbols({
+      expect(first.get()).toEqualIgnoringSymbols({
         label: "first - update",
       });
 
@@ -446,7 +446,7 @@ describe("Schema Support", () => {
 
       await runtime.idle();
 
-      (expect(rootValues) as any).toEqualIgnoringSymbols([
+      expect(rootValues).toEqualIgnoringSymbols([
         "root",
         "cancelled",
         "root",
@@ -479,13 +479,13 @@ describe("Schema Support", () => {
 
       await runtime.idle();
 
-      (expect(currentByGetValues) as any).toEqualIgnoringSymbols([
+      expect(currentByGetValues).toEqualIgnoringSymbols([
         "first",
         "first - update",
         "first - updated again",
         "first - updated yet again",
       ]);
-      (expect(currentByKeyValues) as any).toEqualIgnoringSymbols([
+      expect(currentByKeyValues).toEqualIgnoringSymbols([
         "first",
         "first - update",
         "second",
@@ -493,7 +493,7 @@ describe("Schema Support", () => {
         "third",
         "third - updated",
       ]);
-      (expect(currentValues) as any).toEqualIgnoringSymbols([
+      expect(currentValues).toEqualIgnoringSymbols([
         "first",
         "first - update",
         "second", // That was changing `value` on root
@@ -502,7 +502,7 @@ describe("Schema Support", () => {
         "third",
         "third - updated",
       ]);
-      (expect(rootValues) as any).toEqualIgnoringSymbols([
+      expect(rootValues).toEqualIgnoringSymbols([
         "root",
         "cancelled",
         "root",
@@ -623,7 +623,7 @@ describe("Schema Support", () => {
       const cell = c.asSchema(schema);
       const value = cell.get();
 
-      (expect(value.items) as any).toEqualIgnoringSymbols([1, 2, 3]);
+      expect(value.items).toEqualIgnoringSymbols([1, 2, 3]);
     });
   });
 
@@ -1247,11 +1247,11 @@ describe("Schema Support", () => {
       const cellArray = cArray.asSchema(schemaArray);
       const resultArray = cellArray.get();
       // Verify that the array candidate is chosen and returns the intended array.
-      (expect(resultArray) as any).toEqualIgnoringSymbols({
+      expect(resultArray).toEqualIgnoringSymbols({
         mixed: ["bar", "baz"],
       });
       expect(Array.isArray(resultArray.mixed)).toBe(true);
-      (expect(resultArray.mixed) as any).toEqualIgnoringSymbols(["bar", "baz"]);
+      expect(resultArray.mixed).toEqualIgnoringSymbols(["bar", "baz"]);
     });
 
     describe("Array anyOf Support", () => {
@@ -1277,7 +1277,7 @@ describe("Schema Support", () => {
 
         const cell = c.asSchema(schema);
         const result = cell.get();
-        (expect(result.data) as any).toEqualIgnoringSymbols([1, 2, 3]);
+        expect(result.data).toEqualIgnoringSymbols([1, 2, 3]);
       });
 
       it("should merge item schemas when multiple array options exist", () => {
@@ -1303,7 +1303,7 @@ describe("Schema Support", () => {
         const cell = c.asSchema(schema);
         const result = cell.get();
         // Should keep string and number values, drop boolean
-        (expect(result.data) as any).toEqualIgnoringSymbols([
+        expect(result.data).toEqualIgnoringSymbols([
           "hello",
           42,
           undefined,
@@ -1354,7 +1354,7 @@ describe("Schema Support", () => {
 
         const cell = c.asSchema(schema);
         const result = cell.get();
-        (expect(result.data) as any).toEqualIgnoringSymbols([
+        expect(result.data).toEqualIgnoringSymbols([
           { type: "text", value: "hello" },
           { type: "number", value: 42 },
         ]);
@@ -1588,14 +1588,14 @@ describe("Schema Support", () => {
 
       expect(value.name).toBe("John");
       expect(isCell(value.profile)).toBe(true);
-      (expect(value.profile.get()) as any).toEqualIgnoringSymbols({
+      expect(value.profile.get()).toEqualIgnoringSymbols({
         bio: "Default bio",
         avatar: "default.png",
       });
 
       // Verify the profile cell can be updated
       value.profile.set({ bio: "Updated bio", avatar: "new.png" });
-      (expect(value.profile.get()) as any).toEqualIgnoringSymbols({
+      expect(value.profile.get()).toEqualIgnoringSymbols({
         bio: "Updated bio",
         avatar: "new.png",
       });
@@ -1635,14 +1635,14 @@ describe("Schema Support", () => {
 
       expect(value.name).toBe("John");
       expect(isCell(value.tags)).toBe(true);
-      (expect(value.tags.get()) as any).toEqualIgnoringSymbols([
+      expect(value.tags.get()).toEqualIgnoringSymbols([
         "default",
         "tags",
       ]);
 
       // Verify the tags cell can be updated
       value.tags.set(["updated", "tags", "list"]);
-      (expect(value.tags.get()) as any).toEqualIgnoringSymbols([
+      expect(value.tags.get()).toEqualIgnoringSymbols([
         "updated",
         "tags",
         "list",
@@ -1712,7 +1712,7 @@ describe("Schema Support", () => {
       expect(settings.notifications).toBe(true);
       expect(isCell(settings.theme)).toBe(true);
       expect(isCell(settings.theme.get())).toBe(false);
-      (expect(settings.theme.get()) as any).toEqualIgnoringSymbols({
+      expect(settings.theme.get()).toEqualIgnoringSymbols({
         mode: "light",
         color: "red",
       });
@@ -1746,7 +1746,7 @@ describe("Schema Support", () => {
       const settings2 = value2.user.settings.get();
       expect(settings2.notifications).toBe(false);
       expect(isCell(settings2.theme)).toBe(true);
-      (expect(settings2.theme.get()) as any).toEqualIgnoringSymbols({
+      expect(settings2.theme.get()).toEqualIgnoringSymbols({
         mode: "dark",
         color: "blue",
       });
@@ -1829,12 +1829,12 @@ describe("Schema Support", () => {
       expect(isCell(value2.items?.[0].metadata)).toBe(true);
       expect(isCell(value2.items?.[1].metadata)).toBe(true);
 
-      (expect(value2.items?.[0].metadata?.get()) as any).toEqualIgnoringSymbols(
+      expect(value2.items?.[0].metadata?.get()).toEqualIgnoringSymbols(
         {
           createdAt: "2023-01-01",
         },
       );
-      (expect(value2.items?.[1].metadata?.get()) as any).toEqualIgnoringSymbols(
+      expect(value2.items?.[1].metadata?.get()).toEqualIgnoringSymbols(
         {
           createdAt: "2023-01-02",
         },
@@ -1885,11 +1885,11 @@ describe("Schema Support", () => {
       expect(isCell(value.config.feature1)).toBe(true);
       expect(isCell(value.config.feature2)).toBe(true);
 
-      (expect(value.config.feature1?.get()) as any).toEqualIgnoringSymbols({
+      expect(value.config.feature1?.get()).toEqualIgnoringSymbols({
         enabled: true,
         value: "feature1",
       });
-      (expect(value.config.feature2?.get()) as any).toEqualIgnoringSymbols({
+      expect(value.config.feature2?.get()).toEqualIgnoringSymbols({
         enabled: false,
         value: "feature2",
       });
@@ -1976,7 +1976,7 @@ describe("Schema Support", () => {
 
         expect(value.config.knownProp).toBe("in schema");
         expect(isCell(value.config.featureFlag)).toBe(true);
-        (expect(value.config.featureFlag?.get()) as any).toEqualIgnoringSymbols(
+        expect(value.config.featureFlag?.get()).toEqualIgnoringSymbols(
           {
             enabled: true,
             value: "beta",
@@ -2018,7 +2018,7 @@ describe("Schema Support", () => {
       const cellValue = cell.get();
       expect(isCell(cellValue)).toBe(true);
       const value = cellValue.get();
-      (expect(value) as any).toEqualIgnoringSymbols({
+      expect(value).toEqualIgnoringSymbols({
         name: "Default User",
         settings: { theme: "light" },
       });
@@ -2030,7 +2030,7 @@ describe("Schema Support", () => {
           settings: { theme: "dark" },
         }),
       );
-      (expect(cell.get().get()) as any).toEqualIgnoringSymbols({
+      expect(cell.get().get()).toEqualIgnoringSymbols({
         name: "Updated User",
         settings: { theme: "dark" },
       });

--- a/packages/runner/test/schema.test.ts
+++ b/packages/runner/test/schema.test.ts
@@ -1976,10 +1976,12 @@ describe("Schema Support", () => {
 
         expect(value.config.knownProp).toBe("in schema");
         expect(isCell(value.config.featureFlag)).toBe(true);
-        (expect(value.config.featureFlag?.get()) as any).toEqualIgnoringSymbols({
-          enabled: true,
-          value: "beta",
-        });
+        (expect(value.config.featureFlag?.get()) as any).toEqualIgnoringSymbols(
+          {
+            enabled: true,
+            value: "beta",
+          },
+        );
       },
     );
 


### PR DESCRIPTION
- Skip the additional-property traversal unless the schema explicitly enables additionalProperties, so we stop including all other keys with `any` schemas.
- Emit a contextual warning if resolving a schema for an allowed additional key still returns undefined, making downstream schema drift visible.
- Fix various integration tests and helper functions that relied on old behavior

This fixes CT-897 by no longer over triggering.

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Respect schema.additionalProperties during validation to stop treating unknown keys as “any” and reduce unnecessary triggers. Fixes Linear CT-897 by preventing over-triggering that led to unstable editor behavior.

- **Bug Fixes**
  - Only traverse additional keys when additionalProperties is enabled; ignore others.
  - Log a warning when an allowed additional key resolves to undefined to surface schema drift.

- **Refactors**
  - Call stop(resultCell) for cancel handling in Runner.
  - Clarify render debug log: “Rendered root”.

<!-- End of auto-generated description by cubic. -->

