### PR TITLE
Replace `ifElse` with `derive` to fix `commontools_1` error

### DIFF
--- a/packages/patterns/chatbot-list-view.tsx
+++ b/packages/patterns/chatbot-list-view.tsx
@@ -107,7 +107,7 @@ const createChatRecipe = handler<
       messages: [],
       expandChat: false,
       content: "",
-      allCharms
+      allCharms,
     });
     // store the charm ref in a cell (pass isInitialized to prevent recursive calls)
     return storeCharm({ charm, selectedCharm, charmsList, isInitialized });
@@ -155,9 +155,13 @@ const handleCharmLinkClicked = handler(
   },
 );
 
-const combineLists = lift(({ allCharms, charmsList } : { allCharms: any[], charmsList: CharmEntry[] }) => {
-  return [...charmsList.map(c => c.charm), ...allCharms]
-})
+const combineLists = lift(
+  (
+    { allCharms, charmsList }: { allCharms: any[]; charmsList: CharmEntry[] },
+  ) => {
+    return [...charmsList.map((c) => c.charm), ...allCharms];
+  },
+);
 
 // create the named cell inside the recipe body, so we do it just once
 export default recipe<Input, Output>(
@@ -165,7 +169,10 @@ export default recipe<Input, Output>(
   ({ selectedCharm, charmsList, allCharms }) => {
     logCharmsList({ charmsList });
 
-    const combined = combineLists({ allCharms: allCharms as unknown as any[], charmsList });
+    const combined = combineLists({
+      allCharms: allCharms as unknown as any[],
+      charmsList,
+    });
 
     return {
       [NAME]: "Launcher",
@@ -212,34 +219,40 @@ export default recipe<Input, Output>(
             </aside>
 
             <aside slot="right">
-              {derive(selectedCharm.charm, selected => {
+              {derive(selectedCharm.charm, (selected) => {
                 if (selected) {
-                  return <>
-                    <div>
-                      <label>Backlinks</label>
-                      <ct-vstack>
-                        {selected?.backlinks?.map((
-                          charm: MentionableCharm,
-                        ) => (
-                          <ct-button onClick={handleCharmLinkClicked({ charm })}>
-                            {charm[NAME]}
-                          </ct-button>
-                        ))}
-                      </ct-vstack>
-                    </div>
-                    <details>
-                      <summary>Mentioned Charms</summary>
-                      <ct-vstack>
-                        {selected?.mentioned?.map((
-                          charm: MentionableCharm,
-                        ) => (
-                          <ct-button onClick={handleCharmLinkClicked({ charm })}>
-                            {charm[NAME]}
-                          </ct-button>
-                        ))}
-                      </ct-vstack>
-                    </details>
-                  </>
+                  return (
+                    <>
+                      <div>
+                        <label>Backlinks</label>
+                        <ct-vstack>
+                          {selected?.backlinks?.map((
+                            charm: MentionableCharm,
+                          ) => (
+                            <ct-button
+                              onClick={handleCharmLinkClicked({ charm })}
+                            >
+                              {charm[NAME]}
+                            </ct-button>
+                          ))}
+                        </ct-vstack>
+                      </div>
+                      <details>
+                        <summary>Mentioned Charms</summary>
+                        <ct-vstack>
+                          {selected?.mentioned?.map((
+                            charm: MentionableCharm,
+                          ) => (
+                            <ct-button
+                              onClick={handleCharmLinkClicked({ charm })}
+                            >
+                              {charm[NAME]}
+                            </ct-button>
+                          ))}
+                        </ct-vstack>
+                      </details>
+                    </>
+                  );
                 } else {
                   return null;
                 }

--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -6,8 +6,8 @@ import {
   h,
   handler,
   NAME,
-  Opaque,
   navigateTo,
+  Opaque,
   OpaqueRef,
   recipe,
   str,
@@ -23,7 +23,7 @@ import {
   type MentionableCharm,
 } from "./chatbot-note.tsx";
 import { default as Note } from "./note.tsx";
-import ChatList from './chatbot-list-view.tsx';
+import ChatList from "./chatbot-list-view.tsx";
 
 export type Charm = {
   [NAME]?: string;
@@ -74,7 +74,7 @@ const spawnChatList = handler<
   return navigateTo(ChatList({
     selectedCharm: { charm: undefined },
     charmsList: [],
-    allCharms: state.allCharms
+    allCharms: state.allCharms,
   }));
 });
 
@@ -151,8 +151,10 @@ export default recipe<CharmsListInput, CharmsListOutput>(
               <h3>Quicklaunch:</h3>
               <ct-button
                 onClick={spawnChatList({
-                  allCharms: allCharms as unknown as OpaqueRef<MentionableCharm[]>, })
-                }
+                  allCharms: allCharms as unknown as OpaqueRef<
+                    MentionableCharm[]
+                  >,
+                })}
               >
                 📂 Chat List
               </ct-button>


### PR DESCRIPTION
Also replace `derive` with `lift` to combine lists reactively

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a runtime error in Chat List by replacing ifElse with derive and makes list merging reactive with lift. Also exposes the Chat List from the default app via a Quicklaunch button to address CT-933.

- **New Features**
  - Added “Chat List” button to Quicklaunch in default-app.tsx that navigates to ChatList with allCharms.

- **Bug Fixes**
  - Replaced ifElse with derive for rendering backlinks/mentioned, resolving the commontools_1 error and keeping the panel reactive.
  - Combined charmsList with allCharms using lift so the list updates when either source changes.

<!-- End of auto-generated description by cubic. -->

