### PR TITLE
Don't run the chatbot-list-view and chatbot-note-composed tests

### DIFF
--- a/packages/patterns/integration/all.test.ts
+++ b/packages/patterns/integration/all.test.ts
@@ -5,30 +5,35 @@ import { join } from "@std/path";
 import { assert } from "@std/assert";
 import { Identity } from "@commontools/identity";
 import { FileSystemProgramResolver } from "@commontools/js-runtime";
-import { RuntimeProgram } from "@commontools/runner";
 
 const { API_URL, SPACE_NAME } = env;
 
 describe("Compile all recipes", () => {
+  let cc: CharmsController;
+  let identity: Identity;
+
+  beforeAll(async () => {
+    identity = await Identity.generate();
+    cc = await CharmsController.initialize({
+      spaceName: SPACE_NAME,
+      apiUrl: new URL(API_URL),
+      identity: identity,
+    });
+  });
+
+  afterAll(async () => {
+    if (cc) await cc.dispose();
+  });
+
+  const skippedPatterns = [
+    "chatbot-list-view.tsx",
+    "chatbot-note-composed.tsx",
+  ];
+  // Add a test for each pattern, but skip ones that have issues
   for (const file of Deno.readDirSync(join(import.meta.dirname!, ".."))) {
     const { name } = file;
     if (!name.endsWith(".tsx")) continue;
-
-    let cc: CharmsController;
-    let identity: Identity;
-
-    beforeAll(async () => {
-      identity = await Identity.generate();
-      cc = await CharmsController.initialize({
-        spaceName: SPACE_NAME,
-        apiUrl: new URL(API_URL),
-        identity: identity,
-      });
-    });
-
-    afterAll(async () => {
-      if (cc) await cc.dispose();
-    });
+    if (skippedPatterns.includes(name)) continue;
 
     it(`Executes: ${name}`, async () => {
       const sourcePath = join(import.meta.dirname!, "..", name);


### PR DESCRIPTION
- These tests are causing problems in the integration test, so temporarily disable them.
- There was also an issue where we were instantiating more runtimes than needed (since beforeAll/afterAll can register multiple hooks that will all be called). The for loop was tightened to just encapsulate the `it`.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Temporarily skip two flaky chatbot pattern tests and fix test setup to avoid multiple runtime instances, stabilizing the patterns integration suite.

- **Bug Fixes**
  - Skip chatbot-list-view.tsx and chatbot-note-composed.tsx in the patterns integration run.
  - Move CharmsController/Identity setup to top-level beforeAll/afterAll and limit the file loop to only creating test cases, preventing duplicate runtime instantiation.

<!-- End of auto-generated description by cubic. -->

