### PR TITLE
When we dispose of a provider session, unsubscribe from memory.

### DIFF
--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -482,6 +482,7 @@ export interface MemorySession<Space extends MemorySpace = MemorySpace>
 }
 
 export interface Subscriber<Space extends MemorySpace = MemorySpace> {
+  // Notifies a subscriber of a commit that has been applied
   commit(commit: Commit<Space>): AwaitResult<Unit, SystemError>;
   close(): AwaitResult<Unit, SystemError>;
 }

--- a/packages/memory/provider.ts
+++ b/packages/memory/provider.ts
@@ -247,6 +247,7 @@ class MemoryProviderSession<
     return { ok: {} };
   }
   dispose() {
+    this.memory.unsubscribe(this);
     this.controller = undefined;
     this.sessions?.delete(this);
     this.sessions = null;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Unsubscribe the provider session from memory when disposing to clean up resources and stop commit notifications after the session ends. Prevents dangling subscriptions and potential memory leaks.

<!-- End of auto-generated description by cubic. -->

