### PR TITLE
chore: Use provided SPACE_NAME for list-operations.test.ts

### DIFF
--- a/packages/patterns/integration/list-operations.test.ts
+++ b/packages/patterns/integration/list-operations.test.ts
@@ -15,16 +15,11 @@ describe("list-operations simple test", () => {
   let identity: Identity;
   let cc: CharmsController;
   let charm: CharmController;
-  let spaceName: string;
 
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
-    // Use a unique space name to avoid conflicts between test runs
-    spaceName = `${SPACE_NAME}-${Date.now()}-${
-      Math.random().toString(36).slice(2)
-    }`;
     cc = await CharmsController.initialize({
-      spaceName: spaceName,
+      spaceName: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity: identity,
     });
@@ -48,7 +43,7 @@ describe("list-operations simple test", () => {
     const page = shell.page();
     await shell.goto({
       frontendUrl: FRONTEND_URL,
-      spaceName: spaceName,
+      spaceName: SPACE_NAME,
       charmId: charm.id,
       identity,
     });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Update list-operations integration test to use the provided SPACE_NAME instead of generating a unique name. This makes runs deterministic and aligns with the shared test environment configuration.

<!-- End of auto-generated description by cubic. -->

