### PR TITLE
Ellyse/webread pattern

### DIFF
--- a/packages/patterns/cheeseboard.tsx
+++ b/packages/patterns/cheeseboard.tsx
@@ -87,11 +87,25 @@ export default recipe("Cheeseboard", () => {
     [UI]: (
       <div>
         <h2>Cheeseboard</h2>
+        <p>
+          <a
+            href={cheeseBoardUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {cheeseBoardUrl}
+          </a>
+        </p>
         <div>
-          Pizza list:
-          {derive(pizzaList, (l) => l ? JSON.stringify(l) : "")}
+          <h3>Pizza list</h3>
+          <ul>
+            {pizzaList.map((pizza, index) => (
+              <li key={`pizza-${index}`}>
+                {pizza}
+              </li>
+            ))}
+          </ul>
         </div>
-        {/* <div>Full page: { result ? result : "No Result Yet"  }</div> */}
       </div>
     ),
   };

--- a/packages/patterns/cheeseboard.tsx
+++ b/packages/patterns/cheeseboard.tsx
@@ -14,6 +14,12 @@ import {
   UI,
 } from "commontools";
 
+/**
+ * Fetch the Cheeseboard pizza schedule via Toolshed's web-read endpoint and
+ * display a list of pizza descriptions inside the charm.
+ *
+ * Uses: fetchData, lift, map built-in, toolshed web-read endpoint
+ */
 /** Extract pizza descriptions from a web-read content blob. */
 function extractPizzas(content: string): string[] {
   const marker = "### Pizza";

--- a/packages/patterns/cheeseboard.tsx
+++ b/packages/patterns/cheeseboard.tsx
@@ -22,11 +22,13 @@ import {
  */
 const DATE_LINE_REGEX = /^[A-Z][a-z]{2}\s+[A-Z][a-z]{2}\s+\d{1,2}$/;
 
+type CheeseboardEntry = [date: string, pizza: string];
+
 /** Extract pizza descriptions from a web-read content blob. */
-function extractPizzas(content: string): string[] {
+function extractPizzas(content: string): CheeseboardEntry[] {
   const normalized = content.replace(/\r\n/g, "\n");
   const lines = normalized.split("\n");
-  const pizzas: string[] = [];
+  const pizzas: CheeseboardEntry[] = [];
 
   for (let i = 0; i < lines.length; i++) {
     const dateLine = lines[i].trim();
@@ -62,7 +64,10 @@ function extractPizzas(content: string): string[] {
     }
 
     if (descriptionLines.length > 0) {
-      pizzas.push(`${dateLine}: ${descriptionLines.join(" ")}`);
+      pizzas.push([
+        dateLine,
+        descriptionLines.join(" "),
+      ]);
     }
   }
 
@@ -84,7 +89,7 @@ type WebReadResult = {
   is updated. it also allows us to call our pure function
   `extractPizzas` and return the results
 */
-const createPizzaListCell = lift<{ result: WebReadResult }, string[]>(
+const createPizzaListCell = lift<{ result: WebReadResult }, CheeseboardEntry[]>(
   ({ result }) => {
     return extractPizzas(result?.content ?? "");
   },
@@ -127,9 +132,9 @@ export default recipe("Cheeseboard", () => {
         <div>
           <h3>Pizza list</h3>
           <ul>
-            {pizzaList.map((pizza, index) => (
+            {pizzaList.map(([date, pizza], index) => (
               <li key={`pizza-${index}`}>
-                {pizza}
+                {date}: {pizza}
               </li>
             ))}
           </ul>

--- a/packages/patterns/cheeseboard.tsx
+++ b/packages/patterns/cheeseboard.tsx
@@ -1,0 +1,108 @@
+/// <cts-enable />
+import {
+  Cell,
+  cell,
+  Default,
+  derive,
+  fetchData,
+  h,
+  handler,
+  ifElse,
+  lift,
+  NAME,
+  recipe,
+  toSchema,
+  UI,
+} from "commontools";
+
+/** Extract pizza descriptions from a web-read content blob. */
+function extractPizzas(content: string): string[] {
+  const marker = "### Pizza";
+  if (!content.includes(marker)) {
+    return [];
+  }
+
+  const sections: string[] = [];
+  const parts = content.split(marker).slice(1);
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const headingIndex = trimmed.indexOf("### ");
+    const slice = headingIndex === -1
+      ? trimmed
+      : trimmed.slice(0, headingIndex).trim();
+
+    if (slice) {
+      sections.push(slice);
+    }
+  }
+
+  return sections;
+}
+
+/** Shape of the Toolshed web-read response we care about. */
+type WebReadResult = {
+  content: string;
+  metadata: {
+    title?: string;
+    author?: string;
+    date?: string;
+    word_count: number;
+  };
+};
+
+/** Minimal schema the lift callback expects from fetchData. */
+interface FetchDataResult {
+  result: Cell<WebReadResult>;
+}
+
+/** Reactive system will call this lift when the fetched data
+  is updated. it also allows us to call our pure function
+  `extractPizzas` and return the results
+*/
+const createPizzaListCell = lift(
+  toSchema<FetchDataResult>(),
+  undefined,
+  ({ result }) => {
+    const data = result.get();
+    return data?.content ? extractPizzas(data.content) : [];
+  },
+);
+
+export default recipe("Cheeseboard", () => {
+  const cheeseBoardUrl =
+    "https://cheeseboardcollective.coop/home/pizza/pizza-schedule/";
+  const { result, pending, error } = fetchData<WebReadResult>({
+    url: "/api/agent-tools/web-read",
+    mode: "json",
+    options: {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: {
+        url: cheeseBoardUrl,
+        max_tokens: 4000,
+      },
+    },
+  });
+
+  const pizzaList = createPizzaListCell({ result });
+
+  return {
+    [NAME]: "Cheeseboard",
+    [UI]: (
+      <div>
+        <h2>Cheeseboard</h2>
+        <div>
+          Pizza list:
+          {derive(pizzaList, (l) => l ? JSON.stringify(l) : "")}
+        </div>
+        {/* <div>Full page: { result ? result : "No Result Yet"  }</div> */}
+      </div>
+    ),
+  };
+});

--- a/packages/patterns/cheeseboard.tsx
+++ b/packages/patterns/cheeseboard.tsx
@@ -11,7 +11,6 @@ import {
   lift,
   NAME,
   recipe,
-  toSchema,
   UI,
 } from "commontools";
 
@@ -39,7 +38,6 @@ function extractPizzas(content: string): string[] {
       sections.push(slice);
     }
   }
-
   return sections;
 }
 
@@ -54,21 +52,13 @@ type WebReadResult = {
   };
 };
 
-/** Minimal schema the lift callback expects from fetchData. */
-interface FetchDataResult {
-  result: Cell<WebReadResult>;
-}
-
 /** Reactive system will call this lift when the fetched data
   is updated. it also allows us to call our pure function
   `extractPizzas` and return the results
 */
-const createPizzaListCell = lift(
-  toSchema<FetchDataResult>(),
-  undefined,
+const createPizzaListCell = lift<{ result: WebReadResult }, string[]>(
   ({ result }) => {
-    const data = result.get();
-    return data?.content ? extractPizzas(data.content) : [];
+    return extractPizzas(result?.content ?? "");
   },
 );
 

--- a/packages/patterns/cheeseboard.tsx
+++ b/packages/patterns/cheeseboard.tsx
@@ -132,8 +132,8 @@ export default recipe("Cheeseboard", () => {
         <div>
           <h3>Pizza list</h3>
           <ul>
-            {pizzaList.map(([date, pizza], index) => (
-              <li key={`pizza-${index}`}>
+            {pizzaList.map(([date, pizza]) => (
+              <li>
                 {date}: {pizza}
               </li>
             ))}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a new Cheeseboard pattern that fetches the pizza schedule via Toolshed’s web-read API and shows a simple date-and-pizza list in the UI. Parses the page content to extract daily pizza descriptions.

- **New Features**
  - New pattern: packages/patterns/cheeseboard.tsx.
  - Uses fetchData to POST to /api/agent-tools/web-read for the Cheeseboard schedule.
  - Extracts entries with a date regex and builds a reactive pizza list via lift, rendered as a UL.

<!-- End of auto-generated description by cubic. -->

