### PR TITLE
generate schemas for 'derive'

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -442,10 +442,24 @@ export type HandlerFunction = {
   ): ModuleFactory<StripCell<T>, E>;
 };
 
-export type DeriveFunction = <In, Out>(
-  input: Opaque<In>,
-  f: (input: In) => Out | Promise<Out>,
-) => OpaqueRef<Out>;
+export type DeriveFunction = {
+  <
+    InputSchema extends JSONSchema = JSONSchema,
+    ResultSchema extends JSONSchema = JSONSchema,
+  >(
+    argumentSchema: InputSchema,
+    resultSchema: ResultSchema,
+    input: Opaque<SchemaWithoutCell<InputSchema>>,
+    f: (
+      input: Schema<InputSchema>,
+    ) => Schema<ResultSchema> | Promise<Schema<ResultSchema>>,
+  ): OpaqueRef<SchemaWithoutCell<ResultSchema>>;
+
+  <In, Out>(
+    input: Opaque<In>,
+    f: (input: In) => Out | Promise<Out>,
+  ): OpaqueRef<Out>;
+};
 
 export type ComputeFunction = <T>(fn: () => T) => OpaqueRef<T>;
 

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -177,10 +177,42 @@ export function handler<E, T>(
   return factory;
 }
 
-export const derive = <In, Out>(
+export function derive<
+  InputSchema extends JSONSchema = JSONSchema,
+  ResultSchema extends JSONSchema = JSONSchema,
+>(
+  argumentSchema: InputSchema,
+  resultSchema: ResultSchema,
+  input: Opaque<SchemaWithoutCell<InputSchema>>,
+  f: (
+    input: Schema<InputSchema>,
+  ) => Schema<ResultSchema> | Promise<Schema<ResultSchema>>,
+): OpaqueRef<SchemaWithoutCell<ResultSchema>>;
+export function derive<In, Out>(
   input: Opaque<In>,
   f: (input: In) => Out | Promise<Out>,
-): OpaqueRef<Out> => lift(f)(input) as OpaqueRef<Out>;
+): OpaqueRef<Out>;
+export function derive<In, Out>(...args: any[]): OpaqueRef<any> {
+  if (args.length === 4) {
+    const [argumentSchema, resultSchema, input, f] = args as [
+      JSONSchema,
+      JSONSchema,
+      Opaque<SchemaWithoutCell<any>>,
+      (input: Schema<any>) => Schema<any> | Promise<Schema<any>>,
+    ];
+    return lift(
+      argumentSchema,
+      resultSchema,
+      f as (input: Schema<any>) => Schema<any> | Promise<Schema<any>>,
+    )(input);
+  }
+
+  const [input, f] = args as [
+    Opaque<In>,
+    (input: In) => Out | Promise<Out>,
+  ];
+  return lift(f)(input);
+}
 
 // unsafe closures: like derive, but doesn't need any arguments
 export const compute: <T>(fn: () => T) => OpaqueRef<T> = (fn: () => any) =>

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -259,7 +259,10 @@ export type HandlerFunction = {
     }): ModuleFactory<StripCell<T>, E>;
     <E, T>(handler: (event: E, props: HandlerState<T>) => any): ModuleFactory<StripCell<T>, E>;
 };
-export type DeriveFunction = <In, Out>(input: Opaque<In>, f: (input: In) => Out | Promise<Out>) => OpaqueRef<Out>;
+export type DeriveFunction = {
+    <InputSchema extends JSONSchema = JSONSchema, ResultSchema extends JSONSchema = JSONSchema>(argumentSchema: InputSchema, resultSchema: ResultSchema, input: Opaque<SchemaWithoutCell<InputSchema>>, f: (input: Schema<InputSchema>) => Schema<ResultSchema> | Promise<Schema<ResultSchema>>): OpaqueRef<SchemaWithoutCell<ResultSchema>>;
+    <In, Out>(input: Opaque<In>, f: (input: In) => Out | Promise<Out>): OpaqueRef<Out>;
+};
 export type ComputeFunction = <T>(fn: () => T) => OpaqueRef<T>;
 export type RenderFunction = <T>(fn: () => T) => OpaqueRef<T>;
 export type StrFunction = (strings: TemplateStringsArray, ...values: any[]) => OpaqueRef<string>;

--- a/packages/ts-transformers/src/opaque-ref/rules/schema-injection.ts
+++ b/packages/ts-transformers/src/opaque-ref/rules/schema-injection.ts
@@ -134,6 +134,39 @@ export function createSchemaInjectionRule(): OpaqueRefRule {
           }
         }
 
+        if (callKind?.kind === "derive") {
+          const factory = transformation.factory;
+
+          if (node.typeArguments && node.typeArguments.length >= 2) {
+            const argumentType = node.typeArguments[0];
+            const resultType = node.typeArguments[1];
+            if (!argumentType || !resultType) {
+              return ts.visitEachChild(node, visit, transformation);
+            }
+
+            const toSchemaArgument = factory.createCallExpression(
+              factory.createIdentifier("toSchema"),
+              [argumentType],
+              [],
+            );
+            const toSchemaResult = factory.createCallExpression(
+              factory.createIdentifier("toSchema"),
+              [resultType],
+              [],
+            );
+
+            ensureToSchemaImport();
+
+            const updated = factory.createCallExpression(
+              node.expression,
+              undefined,
+              [toSchemaArgument, toSchemaResult, ...node.arguments],
+            );
+
+            return ts.visitEachChild(updated, visit, transformation);
+          }
+        }
+
         if (callKind?.kind === "builder" && callKind.builderName === "lift") {
           const factory = transformation.factory;
 

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-alias.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-alias.expected.tsx
@@ -1,0 +1,28 @@
+/// <cts-enable />
+import { derive as deriveAlias, JSONSchema } from "commontools";
+type AliasInput = {
+    text: string;
+};
+type AliasResult = {
+    length: number;
+};
+declare const state: AliasInput;
+export const textLength = deriveAlias({
+    type: "object",
+    properties: {
+        text: {
+            type: "string"
+        }
+    },
+    required: ["text"]
+} as const satisfies JSONSchema, {
+    type: "object",
+    properties: {
+        length: {
+            type: "number"
+        }
+    },
+    required: ["length"]
+} as const satisfies JSONSchema, state, (value) => ({
+    length: value.text.length,
+}));

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-alias.input.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-alias.input.tsx
@@ -1,0 +1,19 @@
+/// <cts-enable />
+import { derive as deriveAlias } from "commontools";
+
+type AliasInput = {
+  text: string;
+};
+
+type AliasResult = {
+  length: number;
+};
+
+declare const state: AliasInput;
+
+export const textLength = deriveAlias<AliasInput, AliasResult>(
+  state,
+  (value) => ({
+    length: value.text.length,
+  }),
+);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-no-generics.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-no-generics.expected.tsx
@@ -1,0 +1,4 @@
+/// <cts-enable />
+import { derive } from "commontools";
+declare const total: number;
+export const doubled = derive(total, (value: number) => value * 2);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-no-generics.input.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-no-generics.input.tsx
@@ -1,0 +1,6 @@
+/// <cts-enable />
+import { derive } from "commontools";
+
+declare const total: number;
+
+export const doubled = derive(total, (value: number) => value * 2);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive.expected.tsx
@@ -1,0 +1,28 @@
+/// <cts-enable />
+import { derive, JSONSchema } from "commontools";
+type DeriveInput = {
+    count: number;
+};
+type DeriveResult = {
+    doubled: number;
+};
+declare const source: DeriveInput;
+export const doubledValue = derive({
+    type: "object",
+    properties: {
+        count: {
+            type: "number"
+        }
+    },
+    required: ["count"]
+} as const satisfies JSONSchema, {
+    type: "object",
+    properties: {
+        doubled: {
+            type: "number"
+        }
+    },
+    required: ["doubled"]
+} as const satisfies JSONSchema, source, (input) => ({
+    doubled: input.count * 2,
+}));

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive.input.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive.input.tsx
@@ -1,0 +1,19 @@
+/// <cts-enable />
+import { derive } from "commontools";
+
+type DeriveInput = {
+  count: number;
+};
+
+type DeriveResult = {
+  doubled: number;
+};
+
+declare const source: DeriveInput;
+
+export const doubledValue = derive<DeriveInput, DeriveResult>(
+  source,
+  (input) => ({
+    doubled: input.count * 2,
+  }),
+);


### PR DESCRIPTION
same pattern as `lift` except that in this case we need to change the overload signatures for `derive` because there previously wasn't the right one
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds schema-aware support to derive and updates the transformer to auto-inject input/result JSON Schemas, matching lift behavior. Backward compatible with the existing derive(input, f) call.

- **New Features**
  - Added overload: derive(argumentSchema, resultSchema, input, f) -> OpaqueRef without cell.
  - Transformer now injects schemas for derive<TIn, TOut>(input, f).
  - Runtime derive accepts both signatures and delegates to lift.
  - API types and .d.ts updated; tests cover derive schema generation.

<!-- End of auto-generated description by cubic. -->

