### PR TITLE
fix(runner/fetchData): guard fetch-data updates during edit retry + force sync

### DIFF
--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -78,6 +78,12 @@ export function fetchData(
       error.setSourceCell(parentCell);
       requestHash.setSourceCell(parentCell);
 
+      // Kick off sync in the background
+      pending.sync();
+      result.sync();
+      error.sync();
+      requestHash.sync();
+
       sendResult(tx, {
         pending,
         result,


### PR DESCRIPTION
Move the run-staleness check into the editWithRetry callback so a new run that starts while we await runtime.idle() prevents older responses from overwriting fresher state.

Force sync of result helper cells, as some are otherwise never read and that can force conflicts.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Ensures fetchData only updates state for the current run by moving the staleness check into editWithRetry. Prevents older responses from overwriting newer state if a new run starts while waiting for runtime.idle().

<!-- End of auto-generated description by cubic. -->

