### PR TITLE
Guard against `undefined` charm when deleting chat list entries

### DIFF
--- a/packages/patterns/chatbot-list-view.tsx
+++ b/packages/patterns/chatbot-list-view.tsx
@@ -188,21 +188,10 @@ const selectCharm = handler<
   },
 );
 
-// const logCharmsList = lift<
-//   { charmsList: Cell<CharmEntry[]> }
-// >(
-//   ({ charmsList }) => {
-//     // charmsList is a ProxyArray
-//     console.log("logCharmsList: ", charmsList.get());
-//     return charmsList;
-//   },
-// );
-
 const logCharmsList = lift(
   toSchema<{ charmsList: Cell<CharmEntry[]> }>(),
   undefined,
   ({ charmsList }) => {
-    // charmsList is a Cell
     console.log("logCharmsList: ", charmsList.get());
     return charmsList;
   },
@@ -236,6 +225,10 @@ const getSelectedCharm = lift<
     return entry?.charm;
   },
 );
+
+const getCharmName = lift(({ charm }: { charm: any }) => {
+  return charm?.[NAME] || "Unknown";
+});
 
 // create the named cell inside the recipe body, so we do it just once
 export default recipe<Input, Output>(
@@ -318,7 +311,7 @@ export default recipe<Input, Output>(
                         charm: charmEntry.charm,
                       })}
                     >
-                      <span>{charmEntry.charm[NAME]}</span>
+                      <span>{getCharmName({ charm: charmEntry.charm })}</span>
                       <span slot="meta">{charmEntry.local_id}</span>
                       <ct-button
                         slot="actions"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Prevents runtime errors when a charm is undefined in the chatbot list view, particularly when deleting chats (CT-945). Adds a safe getCharmName fallback to "Unknown" and updates the list item to use it, improving stability.

<!-- End of auto-generated description by cubic. -->

