### PR TITLE
Adding Sonnet 4.5, and swapping it in as the new default

### DIFF
--- a/packages/charm/src/index.ts
+++ b/packages/charm/src/index.ts
@@ -40,7 +40,7 @@ export { type ParsedMention, type ProcessedPrompt } from "./imagine.ts";
 export { formatPromptWithMentions, parseComposerDocument } from "./format.ts";
 
 export const DEFAULT_MODEL = [
-  "anthropic:claude-sonnet-4-0",
+  "anthropic:claude-sonnet-4-5",
 ][0];
 
 // Export workflow module

--- a/packages/llm/src/prompts/charm-describe.ts
+++ b/packages/llm/src/prompts/charm-describe.ts
@@ -43,7 +43,7 @@ Provide your one-sentence description inside <description> tags.
  * @param spec - The specification/description of the web application.
  * @param code - The code of the web application.
  * @param schema - The schema of the web application.
- * @param model - The model to use to generate the description. (default: "anthropic:claude-sonnet-4-0")
+ * @param model - The model to use to generate the description. (default: "anthropic:claude-sonnet-4-5")
  * @returns The generated description.
  */
 export async function describeCharm(

--- a/packages/llm/src/prompts/charm-suggestions.ts
+++ b/packages/llm/src/prompts/charm-suggestions.ts
@@ -81,7 +81,7 @@ export interface CharmSuggestion {
  * @param code - The code of the web app.
  * @param schema - The schema of the web app.
  * @param count - The number of charm suggestions to generate. (default: 3)
- * @param model - The model to use to generate the charm suggestions. (default: "anthropic:claude-sonnet-4-0")
+ * @param model - The model to use to generate the charm suggestions. (default: "anthropic:claude-sonnet-4-5")
  * @returns The generated charm suggestions.
  */
 export async function generateCharmSuggestions(

--- a/packages/llm/src/prompts/code-and-schema-gen.ts
+++ b/packages/llm/src/prompts/code-and-schema-gen.ts
@@ -196,7 +196,7 @@ Return ONLY the requested XML tags, no other commentary.
  * Generates a schema and code from a goal.
  * @param goal The user's goal or request
  * @param existingSchema Optional existing schema to use as a basis
- * @param model Optional model identifier to use (defaults to claude-sonnet-4-0)
+ * @param model Optional model identifier to use (defaults to claude-sonnet-4-5)
  * @returns Object containing title, description, specification, schema
  */
 export async function generateCodeAndSchema(

--- a/packages/llm/src/prompts/recipe-fix.ts
+++ b/packages/llm/src/prompts/recipe-fix.ts
@@ -77,7 +77,7 @@ Remember to consider the context of the code running inside an iframe and ensure
  * @param code - The code of the web application.
  * @param schema - The schema of the web application.
  * @param error - The error stacktrace that resulted from running the code.
- * @param model - The model to use to generate the description. (default: "anthropic:claude-sonnet-4-0")
+ * @param model - The model to use to generate the description. (default: "anthropic:claude-sonnet-4-5")
  * @returns The recipe.
  */
 export async function fixRecipePrompt(

--- a/packages/llm/src/prompts/spec-and-schema-gen.ts
+++ b/packages/llm/src/prompts/spec-and-schema-gen.ts
@@ -242,13 +242,13 @@ ${
  * Generates a complete specification, schema, and plan from a goal.
  * @param goal The user's goal or request
  * @param existingSchema Optional existing schema to use as a basis
- * @param model Optional model identifier to use (defaults to claude-sonnet-4-0)
+ * @param model Optional model identifier to use (defaults to claude-sonnet-4-5)
  * @returns Object containing title, description, specification, schema
  */
 export async function generateSpecAndSchema(
   form: WorkflowForm,
   existingSchema?: JSONSchema,
-  model: string = "anthropic:claude-sonnet-4-0",
+  model: string = "anthropic:claude-sonnet-4-5",
 ): Promise<{
   spec: string;
   plan: string;
@@ -384,7 +384,7 @@ Based on this goal and the existing schema, please provide a title, description,
  * Generates a complete specification, schema, and plan from a goal.
  * @param goal The user's goal or request
  * @param existingSchema Optional existing schema to use as a basis
- * @param model Optional model identifier to use (defaults to claude-sonnet-4-0)
+ * @param model Optional model identifier to use (defaults to claude-sonnet-4-5)
  * @returns Object containing title, description, specification, schema
  */
 export async function generateSpecAndSchemaAndCode(

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -6,7 +6,7 @@ import type {
   JSONSchema,
 } from "@commontools/api";
 
-export const DEFAULT_MODEL_NAME: ModelName = "anthropic:claude-sonnet-4-0";
+export const DEFAULT_MODEL_NAME: ModelName = "anthropic:claude-sonnet-4-5";
 
 // NOTE(ja): This should be an array of models, the first model will be tried, if it
 // fails, the second model will be tried, etc.

--- a/packages/patterns/chatbot.tsx
+++ b/packages/patterns/chatbot.tsx
@@ -101,7 +101,7 @@ export const TitleGenerator = recipe<
 export default recipe<ChatInput, ChatOutput>(
   "Chat",
   ({ messages, tools, theme }) => {
-    const model = cell<string>("anthropic:claude-sonnet-4-0");
+    const model = cell<string>("anthropic:claude-sonnet-4-5");
 
     const { addMessage, cancelGeneration, pending } = llmDialog({
       system: "You are a helpful assistant with some tools.",

--- a/packages/seeder/cli.ts
+++ b/packages/seeder/cli.ts
@@ -17,7 +17,7 @@ const {
   "no-cache": noCache,
   "no-verify": noVerify,
   "no-report": noReport,
-  model = "anthropic:claude-sonnet-4-0",
+  model = "anthropic:claude-sonnet-4-5",
 } = parseArgs(
   Deno.args,
   {

--- a/packages/toolshed/routes/ai/llm/llm.routes.ts
+++ b/packages/toolshed/routes/ai/llm/llm.routes.ts
@@ -51,7 +51,7 @@ export const LLMRequestSchema = toZod<LLMRequest>().with({
   messages: z.array(MessageSchema) as any, // Trust our BuiltInLLMMessage = CoreMessage alignment
   system: z.string().optional(),
   model: z.string().openapi({
-    example: "claude-sonnet-4-0",
+    example: "claude-sonnet-4-5",
   }),
   maxTokens: z.number().optional(),
   stop: z.string().optional(),
@@ -181,7 +181,7 @@ export const generateText = createRoute({
         "application/json": {
           schema: LLMRequestSchema.openapi({
             example: {
-              model: "anthropic:claude-sonnet-4-0",
+              model: "anthropic:claude-sonnet-4-5",
               system: "You are a pirate, make sure you talk like one.",
               stream: false,
               cache: true,

--- a/packages/toolshed/routes/ai/llm/models.ts
+++ b/packages/toolshed/routes/ai/llm/models.ts
@@ -35,8 +35,8 @@ export const ALIAS_NAMES: string[] = [];
 export const PROVIDER_NAMES: Set<string> = new Set();
 
 export const TASK_MODELS = {
-  coding: "anthropic:claude-sonnet-4-0", // Best for code
-  json: "anthropic:claude-sonnet-4-0", // Fast & good at structured output
+  coding: "anthropic:claude-sonnet-4-5", // Best for code
+  json: "anthropic:claude-sonnet-4-5", // Fast & good at structured output
   creative: "openai:gpt-5", // Best for creative tasks
   vision: "google:gemini-2.5-pro", // Best for vision tasks
 } as const;
@@ -161,6 +161,43 @@ if (env.CTTS_AI_LLM_ANTHROPIC_API_KEY) {
       "anthropic:claude-sonnet-4-0-thinking-latest",
       "claude-sonnet-4-0-thinking",
     ],
+    capabilities: {
+      contextWindow: 200_000,
+      maxOutputTokens: 64000,
+      images: true,
+      prefill: true,
+      systemPrompt: true,
+      stopSequences: true,
+      streaming: true,
+      reasoning: true,
+    },
+    providerOptions: {
+      anthropic: {
+        thinking: { type: "enabled", budgetTokens: 64000 },
+      },
+    },
+  });
+
+  addModel({
+    provider: anthropicProvider,
+    name: "anthropic:claude-sonnet-4-5",
+    aliases: ["sonnet-4-5", "sonnet-4.5"],
+    capabilities: {
+      contextWindow: 200_000,
+      maxOutputTokens: 64000,
+      images: true,
+      prefill: true,
+      systemPrompt: true,
+      stopSequences: true,
+      streaming: true,
+      reasoning: false,
+    },
+  });
+
+  addModel({
+    provider: anthropicProvider,
+    name: "anthropic:claude-sonnet-4-5-thinking",
+    aliases: ["sonnet-4-5-thinking", "sonnet-4.5-thinking"],
     capabilities: {
       contextWindow: 200_000,
       maxOutputTokens: 64000,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched the default model to Anthropic Claude Sonnet 4.5 and added Sonnet 4.5 (and 4.5-thinking) to the model registry to improve code and structured output tasks. Updated defaults and examples across prompts, chatbot, seeder CLI, and API routes.

- **New Features**
  - Set DEFAULT_MODEL and DEFAULT_MODEL_NAME to "anthropic:claude-sonnet-4-5"; updated prompt docs, chatbot pattern, seeder CLI, and API examples.
  - Registered "anthropic:claude-sonnet-4-5" and "anthropic:claude-sonnet-4-5-thinking" with aliases and capabilities (200k context, 64k output, images, streaming; thinking variant enables reasoning with budget tokens).
  - Updated TASK_MODELS: coding and json now default to Sonnet 4.5.

- **Migration**
  - No action needed. Calls without a model will use Sonnet 4.5; specify a different model to override.

<!-- End of auto-generated description by cubic. -->

