### PR TITLE
Remove `toSchema()` from `chatbot-list-view.tsx`

### DIFF
--- a/packages/patterns/chatbot-list-view.tsx
+++ b/packages/patterns/chatbot-list-view.tsx
@@ -188,9 +188,10 @@ const selectCharm = handler<
   },
 );
 
-const logCharmsList = lift(
-  toSchema<{ charmsList: Cell<CharmEntry[]> }>(),
-  undefined,
+const logCharmsList = lift<
+  { charmsList: Cell<CharmEntry[]> },
+  Cell<CharmEntry[]>
+>(
   ({ charmsList }) => {
     console.log("logCharmsList: ", charmsList.get());
     return charmsList;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed toSchema from chatbot-list-view and simplified logCharmsList to use lift with explicit generics. No runtime behavior change.

- **Refactors**
  - Replaced lift(toSchema(...), undefined, fn) with lift<...>(fn).
  - Removed toSchema usage; log and return of charmsList are unchanged.

<!-- End of auto-generated description by cubic. -->

