### PR TITLE
Resolve intermediate links when calling `.getRaw()`

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -672,6 +672,7 @@ export class RegularCell<T> implements Cell<T> {
     if (!this.synced) this.sync(); // No await, just kicking this off
 
     const tx = this.runtime.readTx(this.tx);
+    // Resolve all links ON THE WAY to the target, but don't resolve the final link
     return tx.readValueOrThrow(resolveLink(tx, this.link, "top"), options) as
       | Immutable<T>
       | undefined;

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -670,7 +670,9 @@ export class RegularCell<T> implements Cell<T> {
 
   getRaw(options?: IReadOptions): Immutable<T> | undefined {
     if (!this.synced) this.sync(); // No await, just kicking this off
-    return this.runtime.readTx(this.tx).readValueOrThrow(this.link, options) as
+
+    const tx = this.runtime.readTx(this.tx);
+    return tx.readValueOrThrow(resolveLink(tx, this.link, "top"), options) as
       | Immutable<T>
       | undefined;
   }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Ensure RegularCell.getRaw() resolves intermediate links before reading, so it returns the correct underlying value for linked cells. Fixes cases where chained links returned wrong or missing data.

- **Bug Fixes**
  - Resolve link chains with resolveLink(tx, this.link, "top") before readValueOrThrow, preventing incorrect or missing reads when links point to other links.

<!-- End of auto-generated description by cubic. -->

