### PR TITLE
Use `ct-render` to work around charms not running correctly after refresh

### DIFF
--- a/packages/patterns/chatbot-list-view.tsx
+++ b/packages/patterns/chatbot-list-view.tsx
@@ -297,8 +297,10 @@ export default recipe<Input, Output>(
               rightOpen={false}
               tabNames={["Chat", "Note"]}
             >
-              {selected.chat}
-              {selected.note}
+              {/* workaround: this seems to correctly start the sub-recipes on a refresh while directly rendering does not */}
+              {/* this should be fixed after the builder-refactor (DX1) */}
+              <ct-render $cell={selected.chat} />
+              <ct-render $cell={selected.note} />
 
               <aside slot="left">
                 <div>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes chat and note charms not starting after refresh by rendering them with ct-render in ChatbotListView. Ensures sub-recipes initialize reliably until the builder refactor (DX1) addresses the root cause.

<!-- End of auto-generated description by cubic. -->

