### PR TITLE
Handle race condition in `ct-render`

### DIFF
--- a/packages/ui/src/v2/components/ct-render/ct-render.ts
+++ b/packages/ui/src/v2/components/ct-render/ct-render.ts
@@ -49,7 +49,9 @@ export class CTRender extends BaseElement {
     }
 
     @keyframes spin {
-      to { transform: rotate(360deg); }
+      to {
+        transform: rotate(360deg);
+      }
     }
   `;
 
@@ -76,11 +78,13 @@ export class CTRender extends BaseElement {
 
   protected override render() {
     return html`
-      ${!this._hasRendered ? html`
-        <div class="loading-spinner">
-          <div class="spinner"></div>
-        </div>
-      ` : null}
+      ${!this._hasRendered
+        ? html`
+          <div class="loading-spinner">
+            <div class="spinner"></div>
+          </div>
+        `
+        : null}
       <div class="render-container"></div>
     `;
   }


### PR DESCRIPTION
Wait for `this.cell.sync()` if we fail to load the first time.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a race condition in CTRender by syncing the cell and retrying once when the initial recipe load fails. Adds a simple loading spinner until the first render to improve UX.

- **Bug Fixes**
  - On initial load failure, call this.cell.sync() and retry once before failing.

- **New Features**
  - Show a small spinner while loading; hide after the first successful render.

<!-- End of auto-generated description by cubic. -->

