### PR TITLE
Ensure `getRecipeIdFromCharm` is within retry logic

### DIFF
--- a/packages/ui/src/v2/components/ct-render/ct-render.ts
+++ b/packages/ui/src/v2/components/ct-render/ct-render.ts
@@ -130,6 +130,11 @@ export class CTRender extends BaseElement {
     this._log("loading recipe:", recipeId);
 
     try {
+      const recipeId = getRecipeIdFromCharm(this.cell);
+      if (!recipeId) {
+        throw new Error("No recipe ID found in charm");
+      }
+
       // Load and run the recipe
       const recipe = await this.cell.runtime.recipeManager.loadRecipe(
         recipeId,
@@ -183,13 +188,8 @@ export class CTRender extends BaseElement {
         throw new Error("Invalid cell: expected a Cell object");
       }
 
-      const recipeId = getRecipeIdFromCharm(this.cell);
-      if (!recipeId) {
-        throw new Error("No recipe ID found in charm");
-      }
-
       // Load and render the recipe
-      await this._loadAndRenderRecipe(recipeId);
+      await this._loadAndRenderRecipe();
 
       // Mark as rendered and trigger re-render to hide spinner
       this._hasRendered = true;

--- a/packages/ui/src/v2/components/ct-render/ct-render.ts
+++ b/packages/ui/src/v2/components/ct-render/ct-render.ts
@@ -126,14 +126,13 @@ export class CTRender extends BaseElement {
     }
   }
 
-  private async _loadAndRenderRecipe(recipeId: string, retry: boolean = true) {
-    this._log("loading recipe:", recipeId);
-
+  private async _loadAndRenderRecipe(retry: boolean = true) {
     try {
       const recipeId = getRecipeIdFromCharm(this.cell);
       if (!recipeId) {
         throw new Error("No recipe ID found in charm");
       }
+      this._log("loading recipe:", recipeId);
 
       // Load and run the recipe
       const recipe = await this.cell.runtime.recipeManager.loadRecipe(
@@ -154,7 +153,7 @@ export class CTRender extends BaseElement {
         console.warn("Failed to load recipe, retrying...");
         // First failure, sync and retry once
         await this.cell.sync();
-        await this._loadAndRenderRecipe(recipeId, false);
+        await this._loadAndRenderRecipe(false);
       } else {
         // Second failure, give up
         throw error;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved recipe ID resolution into the retryable load/render path to prevent flaky "No recipe ID found in charm" errors and improve initial render reliability.

- **Bug Fixes**
  - Resolve recipeId via getRecipeIdFromCharm inside _loadAndRenderRecipe so it’s covered by existing retry logic.
  - Remove recipeId parameter and update call site to _loadAndRenderRecipe().
  - Throw a clear error when no recipe ID is found to trigger retry and aid debugging.

<!-- End of auto-generated description by cubic. -->

