### PR TITLE
Fix overflow in `ct-autolayout` with `ct-render`

### DIFF
--- a/packages/patterns/chatbot-list-view.tsx
+++ b/packages/patterns/chatbot-list-view.tsx
@@ -300,10 +300,10 @@ export default recipe<Input, Output>(
               {/* workaround: this seems to correctly start the sub-recipes on a refresh while directly rendering does not */}
               {/* this should be fixed after the builder-refactor (DX1) */}
               <ct-screen>
-              <ct-render $cell={selected.chat} />
+                <ct-render $cell={selected.chat} />
               </ct-screen>
               <ct-screen>
-              <ct-render $cell={selected.note} />
+                <ct-render $cell={selected.note} />
               </ct-screen>
 
               <aside slot="left">


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes autolayout overflow and scrolling issues in the chatbot list view, addressing CT-958.

- **Bug Fixes**
  - Render chat and note ct-render inside ct-screen to prevent overflow in ct-autolayout.
  - Restores expected scrolling and avoids content clipping.

<!-- End of auto-generated description by cubic. -->

