### PR TITLE
Improved 'note' tools for LLM

### DIFF
--- a/packages/patterns/chatbot-list-view.tsx
+++ b/packages/patterns/chatbot-list-view.tsx
@@ -370,13 +370,15 @@ export default recipe<Input, Output>(
                         {selected?.mentioned?.map((
                           charm: MentionableCharm,
                         ) => (
-                          charm ?
-                          <ct-button
-                            onClick={handleCharmLinkClicked({ charm })}
-                          >
-                            {charm[NAME]}
-                          </ct-button>
-                          : null
+                          charm
+                            ? (
+                              <ct-button
+                                onClick={handleCharmLinkClicked({ charm })}
+                              >
+                                {charm[NAME]}
+                              </ct-button>
+                            )
+                            : null
                         ))}
                       </ct-vstack>
                     </ct-collapsible>

--- a/packages/patterns/chatbot-list-view.tsx
+++ b/packages/patterns/chatbot-list-view.tsx
@@ -370,11 +370,13 @@ export default recipe<Input, Output>(
                         {selected?.mentioned?.map((
                           charm: MentionableCharm,
                         ) => (
+                          charm ?
                           <ct-button
                             onClick={handleCharmLinkClicked({ charm })}
                           >
                             {charm[NAME]}
                           </ct-button>
+                          : null
                         ))}
                       </ct-vstack>
                     </ct-collapsible>

--- a/packages/patterns/chatbot-note-composed.tsx
+++ b/packages/patterns/chatbot-note-composed.tsx
@@ -172,11 +172,13 @@ const readNoteByIndex = handler<
     index: number;
     result: Cell<string>;
   },
-  { allCharms: { [NAME]: string, content?: string }[] }
+  { allCharms: { [NAME]: string; content?: string }[] }
 >(
   (args, state) => {
     try {
-      args.result.set(state.allCharms[args.index]?.content || "No content found");
+      args.result.set(
+        state.allCharms[args.index]?.content || "No content found",
+      );
     } catch (error) {
       args.result.set(`Error: ${(error as any)?.message || "<error>"}`);
     }
@@ -202,7 +204,7 @@ const editNoteByIndex = handler<
         return;
       }
 
-      state.allCharms.key(args.index).key('content').set(args.body);
+      state.allCharms.key(args.index).key("content").set(args.body);
       args.result.set(`Updated note at index ${args.index}!`);
     } catch (error) {
       args.result.set(`Error: ${(error as any)?.message || "<error>"}`);
@@ -282,7 +284,8 @@ export default recipe<ChatbotNoteInput, ChatbotNoteResult>(
         handler: readNote({ content }),
       },
       listNotes: {
-        description: "List all mentionable note titles (read the body with readNoteByIndex).",
+        description:
+          "List all mentionable note titles (read the body with readNoteByIndex).",
         inputSchema: {
           type: "object",
           properties: {},
@@ -293,7 +296,8 @@ export default recipe<ChatbotNoteInput, ChatbotNoteResult>(
         }),
       },
       readNoteByIndex: {
-        description: "Read the body of a note by its index in the listNotes() list.",
+        description:
+          "Read the body of a note by its index in the listNotes() list.",
         inputSchema: {
           type: "object",
           properties: {
@@ -309,7 +313,8 @@ export default recipe<ChatbotNoteInput, ChatbotNoteResult>(
         }),
       },
       editNoteByIndex: {
-        description: "Edit the body of a note by its index in the listNotes() list.",
+        description:
+          "Edit the body of a note by its index in the listNotes() list.",
         inputSchema: {
           type: "object",
           properties: {

--- a/packages/patterns/chatbot-note-composed.tsx
+++ b/packages/patterns/chatbot-note-composed.tsx
@@ -103,7 +103,7 @@ const newNote = handler<
         `Created note ${args.title}!`,
       );
 
-      return navigateTo(n);
+      state.allCharms.push(n as unknown as MentionableCharm);
     } catch (error) {
       args.result.set(`Error: ${(error as any)?.message || "<error>"}`);
     }

--- a/packages/patterns/chatbot-note-composed.tsx
+++ b/packages/patterns/chatbot-note-composed.tsx
@@ -166,6 +166,23 @@ const listMentionable = handler<
   },
 );
 
+const readNoteByIndex = handler<
+  {
+    /** A cell to store the result text */
+    index: number;
+    result: Cell<string>;
+  },
+  { allCharms: { [NAME]: string, content?: string }[] }
+>(
+  (args, state) => {
+    try {
+      args.result.set(state.allCharms[args.index]?.content || "No content found");
+    } catch (error) {
+      args.result.set(`Error: ${(error as any)?.message || "<error>"}`);
+    }
+  },
+);
+
 export default recipe<ChatbotNoteInput, ChatbotNoteResult>(
   "Chatbot + Note",
   ({ title, messages, content, allCharms }) => {
@@ -187,7 +204,7 @@ export default recipe<ChatbotNoteInput, ChatbotNoteResult>(
       readListItems: {
         handler: readListItems({ list }),
       },
-      editNote: {
+      editActiveNote: {
         description: "Modify the shared note.",
         inputSchema: {
           type: "object",
@@ -201,8 +218,8 @@ export default recipe<ChatbotNoteInput, ChatbotNoteResult>(
         } as JSONSchema,
         handler: editNote({ content }),
       },
-      readNote: {
-        description: "Read the shared note.",
+      readActiveNote: {
+        description: "Read the currently focused note.",
         inputSchema: {
           type: "object",
           properties: {},
@@ -211,13 +228,29 @@ export default recipe<ChatbotNoteInput, ChatbotNoteResult>(
         handler: readNote({ content }),
       },
       listNotes: {
-        description: "List all mentionable notes.",
+        description: "List all mentionable note titles (read the body with readNoteByIndex).",
         inputSchema: {
           type: "object",
           properties: {},
           required: [],
         } as JSONSchema,
         handler: listMentionable({
+          allCharms: allCharms as unknown as OpaqueRef<MentionableCharm[]>,
+        }),
+      },
+      readNoteByIndex: {
+        description: "Read the body of a note by its index in the listNotes() list.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            index: {
+              type: "number",
+              description: "The index of the note in the notes list.",
+            },
+          },
+          required: ["index"],
+        } as JSONSchema,
+        handler: readNoteByIndex({
           allCharms: allCharms as unknown as OpaqueRef<MentionableCharm[]>,
         }),
       },

--- a/packages/patterns/note.tsx
+++ b/packages/patterns/note.tsx
@@ -151,7 +151,10 @@ const Note = recipe<Input, Output>(
             $mentioned={mentioned}
             $pattern={pattern}
             onbacklink-click={handleCharmLinkClick({})}
-            onbacklink-create={handleNewBacklink({ content, allCharms: allCharms as unknown as MentionableCharm[] })}
+            onbacklink-create={handleNewBacklink({
+              content,
+              allCharms: allCharms as unknown as MentionableCharm[],
+            })}
             language="text/markdown"
             theme="light"
             wordWrap

--- a/packages/patterns/note.tsx
+++ b/packages/patterns/note.tsx
@@ -68,12 +68,14 @@ const handleNewBacklink = handler<
       text: string;
       charmId: any;
       charm: Cell<MentionableCharm>;
+      navigate: boolean;
     };
   },
   {
     content: Cell<string>;
+    allCharms: Cell<MentionableCharm[]>;
   }
->(({ detail }, { content }) => {
+>(({ detail }, { content, allCharms }) => {
   console.log("new charm", detail.text, detail.charmId);
 
   const text = content.get();
@@ -85,7 +87,12 @@ const handleNewBacklink = handler<
   );
 
   content.set(replaced);
-  return navigateTo(detail.charm);
+
+  if (detail.navigate) {
+    return navigateTo(detail.charm);
+  } else {
+    allCharms.push(detail.charm as unknown as MentionableCharm);
+  }
 });
 
 const handleCharmLinkClicked = handler(
@@ -144,7 +151,7 @@ const Note = recipe<Input, Output>(
             $mentioned={mentioned}
             $pattern={pattern}
             onbacklink-click={handleCharmLinkClick({})}
-            onbacklink-create={handleNewBacklink({ content })}
+            onbacklink-create={handleNewBacklink({ content, allCharms: allCharms as unknown as MentionableCharm[] })}
             language="text/markdown"
             theme="light"
             wordWrap

--- a/packages/patterns/note.tsx
+++ b/packages/patterns/note.tsx
@@ -77,7 +77,6 @@ const handleNewBacklink = handler<
 >(({ detail }, { allCharms }) => {
   console.log("new charm", detail.text, detail.charmId);
 
-
   if (detail.navigate) {
     return navigateTo(detail.charm);
   } else {

--- a/packages/patterns/note.tsx
+++ b/packages/patterns/note.tsx
@@ -72,21 +72,11 @@ const handleNewBacklink = handler<
     };
   },
   {
-    content: Cell<string>;
     allCharms: Cell<MentionableCharm[]>;
   }
->(({ detail }, { content, allCharms }) => {
+>(({ detail }, { allCharms }) => {
   console.log("new charm", detail.text, detail.charmId);
 
-  const text = content.get();
-  // find relevant area in the text content
-  // replace `[[${text}]]` with text + ID `[[${text} (${ID})]]`
-  const replaced = text.replace(
-    `[[${detail.text}]]`,
-    `[[${detail.text} (${detail.charmId["/"]})]]`,
-  );
-
-  content.set(replaced);
 
   if (detail.navigate) {
     return navigateTo(detail.charm);
@@ -152,7 +142,6 @@ const Note = recipe<Input, Output>(
             $pattern={pattern}
             onbacklink-click={handleCharmLinkClick({})}
             onbacklink-create={handleNewBacklink({
-              content,
               allCharms: allCharms as unknown as MentionableCharm[],
             })}
             language="text/markdown"

--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -406,15 +406,58 @@ export class CTCodeEditor extends BaseElement {
 
       // let the pattern know about the new backlink
       tx.commit();
+
+      const charmId = getEntityId(result);
+
+      // Insert the ID into the text if we have an editor
+      if (this._editorView && charmId) {
+        this._insertBacklinkId(backlinkText, charmId["/"], navigate);
+      }
+
       this.emit("backlink-create", {
         text: backlinkText,
-        charmId: getEntityId(result),
+        charmId,
         charm: result,
         navigate,
       });
     } catch (error) {
       console.error("Error creating backlink:", error);
     }
+  }
+
+  /**
+   * Insert the ID into an incomplete backlink and position cursor appropriately.
+   * Replaces [[text]] with [[text (id)]] and positions cursor after ]].
+   */
+  private _insertBacklinkId(
+    backlinkText: string,
+    id: string,
+    navigate: boolean,
+  ): void {
+    if (!this._editorView) return;
+
+    const view = this._editorView;
+    const state = view.state;
+    const doc = state.doc;
+    const content = doc.toString();
+
+    // Find the incomplete backlink: [[backlinkText]]
+    const searchPattern = `[[${backlinkText}]]`;
+    const index = content.indexOf(searchPattern);
+
+    if (index === -1) return;
+
+    // Replace with complete backlink including ID
+    const replacement = `[[${backlinkText} (${id})]]`;
+    const from = index;
+    const to = index + searchPattern.length;
+
+    view.dispatch({
+      changes: { from, to, insert: replacement },
+      selection: navigate
+        ? undefined // Keep current selection if navigating away
+        : { anchor: from + replacement.length }, // Position after ]] if staying
+    });
   }
 
   /**

--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -113,7 +113,7 @@ const getLangExtFromMimeType = (mime: MimeType) => {
  * @fires backlink-click - Fired when a backlink is clicked with Cmd/Ctrl+Enter with detail: { text, charm }
  * @fires backlink-create - Fired when a novel backlink is activated (Cmd/Ctrl+Click)
  *   or confirmed with Enter during autocomplete with no matches. Detail:
- *   { text }
+ *   { text: string, charmId: any, charm: Cell<MentionableCharm>, navigate: boolean }
  *
  * @example
  * <ct-code-editor language="text/javascript" placeholder="Enter code..."></ct-code-editor>
@@ -256,9 +256,9 @@ export class CTCodeEditor extends BaseElement {
             apply: () => {
               // Instantiate the pattern if available
               if (this.pattern) {
-                this.createBacklinkFromPattern(raw);
+                this.createBacklinkFromPattern(raw, false);
               } else {
-                this.emit("backlink-create", { text: raw });
+                this.emit("backlink-create", { text: raw, navigate: false });
               }
             },
           });
@@ -366,7 +366,7 @@ export class CTCodeEditor extends BaseElement {
 
         // Instantiate the pattern and pass the ID so we can insert it into the text
         if (this.pattern) {
-          this.createBacklinkFromPattern(backlinkText);
+          this.createBacklinkFromPattern(backlinkText, true);
         }
 
         return true;
@@ -379,7 +379,10 @@ export class CTCodeEditor extends BaseElement {
   /**
    * Create a backlink from pattern
    */
-  private createBacklinkFromPattern(backlinkText: string): void {
+  private createBacklinkFromPattern(
+    backlinkText: string,
+    navigate: boolean,
+  ): void {
     try {
       const rt = this.pattern.runtime;
       const tx = rt.edit();
@@ -407,6 +410,7 @@ export class CTCodeEditor extends BaseElement {
         text: backlinkText,
         charmId: getEntityId(result),
         charm: result,
+        navigate,
       });
     } catch (error) {
       console.error("Error creating backlink:", error);
@@ -813,9 +817,9 @@ export class CTCodeEditor extends BaseElement {
               if (text.length > 0) {
                 // Instantiate the pattern if available
                 if (this.pattern) {
-                  this.createBacklinkFromPattern(text);
+                  this.createBacklinkFromPattern(text, false);
                 } else {
-                  this.emit("backlink-create", { text });
+                  this.emit("backlink-create", { text, navigate: false });
                 }
                 return true;
               }


### PR DESCRIPTION
- **Allow reading note by index**
- **Tools for editing other notes**

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds index-based note tools so the assistant can read, edit, and navigate to any note from the list, not just the active one. Clarifies active-note tool names and improves error messages for invalid indexes.

- New Features
  - readNoteByIndex(index): read the body of a note by its list index.
  - editNoteByIndex(index, body): update a note’s content by index.
  - navigateToNote(index): focus a note by index.

- Refactors
  - Renamed editNote → editActiveNote and readNote → readActiveNote.
  - Updated listNotes description to direct body reads to readNoteByIndex.

<!-- End of auto-generated description by cubic. -->

