### PR TITLE
Add asOpaque as an option to JSONSchema

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -222,8 +222,10 @@ export type JSONSchemaObj = {
   readonly [ID_FIELD]?: unknown;
   // makes it so that your handler gets a Cell object for that property. So you can call .set()/.update()/.push()/etc on it.
   readonly asCell?: boolean;
-  // streams are what handler returns. if you pass that to another handler/lift and declare it as asSteam, you can call .send on it
+  // streams are what handler returns. if you pass that to another handler/lift and declare it as asStream, you can call .send on it
   readonly asStream?: boolean;
+  // OpaqueRef objects also have the OpaqueRefMethods
+  readonly asOpaque?: boolean;
   // temporarily used to assign labels like "confidential"
   readonly ifc?: { classification?: string[]; integrity?: string[] };
 };


### PR DESCRIPTION
Add the asOpaque option to JSONSchema (and fix typo in asStream comment)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added asOpaque to JSONSchema to mark fields that return OpaqueRef and expose OpaqueRefMethods in handlers. Also fixed the asStream comment typo.

- **New Features**
  - asOpaque?: boolean in JSONSchemaObj to annotate properties as OpaqueRef and enable OpaqueRefMethods.

- **Bug Fixes**
  - Corrected "asSteam" to "asStream" in the comment for asStream.

<!-- End of auto-generated description by cubic. -->

