### PR TITLE
feat(api): tigther types everywhere, explicitly handling Cell<> and Stream<>

### DIFF
--- a/packages/patterns/chatbot-list-view.tsx
+++ b/packages/patterns/chatbot-list-view.tsx
@@ -154,7 +154,7 @@ const createChatRecipe = handler<
   {
     selectedCharm: Cell<{ charm: any }>;
     charmsList: Cell<CharmEntry[]>;
-    allCharms: Cell<any[]>;
+    allCharms: Cell<MentionableCharm[]>;
   }
 >(
   (_, { selectedCharm, charmsList, allCharms }) => {
@@ -235,7 +235,7 @@ const getCharmName = lift(({ charm }: { charm: any }) => {
 export default recipe<Input, Output>(
   "Launcher",
   ({ selectedCharm, charmsList, allCharms, theme }) => {
-    logCharmsList({ charmsList: charmsList as unknown as Cell<CharmEntry[]> });
+    logCharmsList({ charmsList: charmsList });
 
     populateChatList({
       selectedCharm: selectedCharm as unknown as Cell<

--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -23,8 +23,6 @@ import ChatList from "./chatbot-list-view.tsx";
 
 export type Charm = {
   [NAME]?: string;
-  [UI]?: unknown;
-  [key: string]: any;
 };
 
 type CharmsListInput = {
@@ -33,7 +31,7 @@ type CharmsListInput = {
 
 // Recipe returns only UI, no data outputs (only symbol properties)
 interface CharmsListOutput {
-  [key: string]: unknown;
+  [UI]: unknown;
 }
 
 const visit = handler<

--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -5,6 +5,7 @@ import type {
   JSONSchema,
   NodeFactory,
   Opaque,
+  OpaqueOrCells,
   OpaqueRef,
   Schema,
 } from "./types.ts";
@@ -22,57 +23,57 @@ export const compileAndRun = createNodeFactory({
   type: "ref",
   implementation: "compileAndRun",
 }) as <T = any, S = any>(
-  params: Opaque<BuiltInCompileAndRunParams<T>>,
+  params: OpaqueOrCells<BuiltInCompileAndRunParams<T>>,
 ) => OpaqueRef<BuiltInCompileAndRunState<S>>;
 
 export const llm = createNodeFactory({
   type: "ref",
   implementation: "llm",
 }) as (
-  params: Opaque<BuiltInLLMParams>,
+  params: OpaqueOrCells<BuiltInLLMParams>,
 ) => OpaqueRef<BuiltInLLMState>;
 
 export const llmDialog = createNodeFactory({
   type: "ref",
   implementation: "llmDialog",
 }) as (
-  params: Opaque<BuiltInLLMParams>,
+  params: OpaqueOrCells<BuiltInLLMParams>,
 ) => OpaqueRef<BuiltInLLMDialogState>;
 
 export const generateObject = createNodeFactory({
   type: "ref",
   implementation: "generateObject",
 }) as <T = any>(
-  params: Opaque<BuiltInGenerateObjectParams>,
+  params: OpaqueOrCells<BuiltInGenerateObjectParams>,
 ) => OpaqueRef<BuiltInLLMGenerateObjectState<T>>;
 
 export const fetchData = createNodeFactory({
   type: "ref",
   implementation: "fetchData",
 }) as <T>(
-  params: Opaque<{
+  params: OpaqueOrCells<{
     url: string;
     mode?: "json" | "text";
     options?: FetchOptions;
     result?: T;
   }>,
-) => Opaque<{ pending: boolean; result: T; error: unknown }>;
+) => OpaqueRef<{ pending: boolean; result: T; error: unknown }>;
 
 export const streamData = createNodeFactory({
   type: "ref",
   implementation: "streamData",
 }) as <T>(
-  params: Opaque<{
+  params: OpaqueOrCells<{
     url: string;
     options?: FetchOptions;
     result?: T;
   }>,
-) => Opaque<{ pending: boolean; result: T; error: unknown }>;
+) => OpaqueRef<{ pending: boolean; result: T; error: unknown }>;
 
 export function ifElse<T = unknown, U = unknown, V = unknown>(
-  condition: Opaque<T>,
-  ifTrue: Opaque<U>,
-  ifFalse: Opaque<V>,
+  condition: OpaqueOrCells<T>,
+  ifTrue: OpaqueOrCells<U>,
+  ifFalse: OpaqueOrCells<V>,
 ): OpaqueRef<U | V> {
   ifElseFactory ||= createNodeFactory({
     type: "ref",
@@ -86,7 +87,7 @@ let ifElseFactory: NodeFactory<[unknown, unknown, unknown], any> | undefined;
 export const navigateTo = createNodeFactory({
   type: "ref",
   implementation: "navigateTo",
-}) as (cell: OpaqueRef<unknown>) => OpaqueRef<string>;
+}) as (cell: OpaqueOrCells<unknown>) => OpaqueRef<string>;
 
 // Example:
 // str`Hello, ${name}!`

--- a/packages/runner/src/builder/opaque-ref.ts
+++ b/packages/runner/src/builder/opaque-ref.ts
@@ -71,6 +71,7 @@ export function opaqueRef<T>(
           unsafe_materialize(unsafe_binding, path); // TODO(seefeld): Set value
         } else setValueAtPath(store, ["value", ...path], newValue);
       },
+      send: (newValue: Opaque<any>) => proxy.set(newValue),
       key: (key: PropertyKey) => {
         // Determine child schema when accessing a property
         const childSchema = key in methods

--- a/packages/runner/src/builder/recipe.ts
+++ b/packages/runner/src/builder/recipe.ts
@@ -11,6 +11,7 @@ import {
   type Node,
   type NodeRef,
   type Opaque,
+  type OpaqueOrCells,
   type OpaqueRef,
   type Recipe,
   type RecipeFactory,
@@ -349,26 +350,29 @@ function factoryFromRecipe<T, R>(
     toJSON: () => recipeToJSON(recipeFactory),
   };
 
-  const recipeFactory = Object.assign((inputs: Opaque<T>): OpaqueRef<R> => {
-    const module: Module & toJSON = {
-      type: "recipe",
-      implementation: recipeFactory,
-      toJSON: () => moduleToJSON(module),
-    };
+  const recipeFactory = Object.assign(
+    (inputs: OpaqueOrCells<T>): OpaqueRef<R> => {
+      const module: Module & toJSON = {
+        type: "recipe",
+        implementation: recipeFactory,
+        toJSON: () => moduleToJSON(module),
+      };
 
-    const outputs = opaqueRef<R>();
-    const node: NodeRef = {
-      module,
-      inputs,
-      outputs,
-      frame: getTopFrame(),
-    };
+      const outputs = opaqueRef<R>();
+      const node: NodeRef = {
+        module,
+        inputs,
+        outputs,
+        frame: getTopFrame(),
+      };
 
-    connectInputAndOutputs(node);
-    outputs.connect(node);
+      connectInputAndOutputs(node);
+      outputs.connect(node);
 
-    return outputs;
-  }, recipe) satisfies RecipeFactory<T, R>;
+      return outputs;
+    },
+    recipe,
+  ) satisfies RecipeFactory<T, R>;
 
   // Bind all cells to the recipe
   // TODO(seefeld): Does OpaqueRef cause issues here?

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -70,6 +70,7 @@ export type {
   ModuleFactory,
   NodeFactory,
   Opaque,
+  OpaqueOrCells,
   OpaqueRef,
   Props,
   Recipe,

--- a/packages/runner/test/schema-to-ts.test.ts
+++ b/packages/runner/test/schema-to-ts.test.ts
@@ -486,7 +486,7 @@ describe("Schema-to-TS Type Conversion", () => {
     expectType<ExpectedOutput, Schema<typeof outputSchema>>();
 
     // Verify that the recipe function parameter matches our expected input type
-    expectType<ExpectedInput, InferredInput>();
+    expectType<InferredInput, ExpectedInput>();
 
     // The expected output is the output schema wrapped in a single OpaqueRef.
     type DeepOpaqueOutput = OpaqueRef<Schema<typeof outputSchema>>;


### PR DESCRIPTION
**Note:** This PR currently causes significant TypeScript language server slowness. Investigation and optimization needed before merge.

---

## Tighter Types for Recipe/Module Patterns

This PR introduces stricter typing throughout the recipe/module system by replacing the broad `Opaque<T>` type with `OpaqueOrCells<T>`, which more precisely captures the allowed input types while improving type inference.

### Key Changes

**Type System Improvements:**
- Introduced `OpaqueOrCells<T>` type that explicitly allows `OpaqueRef<T>`, `Cell<T>`, `Stream<T>`, or their wrapped variants
- Updated all factory types (`RecipeFactory`, `ModuleFactory`, `HandlerFactory`) to use `OpaqueOrCells<T>` for inputs
- Moved `StripCell<T>` helper type earlier in the type definitions for better reusability
- Added `send()` method to `OpaqueRefMethods` interface

**Pattern Updates:**
- [note.tsx](packages/patterns/note.tsx): Refactored backlinks computation to use `this` binding for self-reference instead of content matching
- [chatbot-list-view.tsx](packages/patterns/chatbot-list-view.tsx): Improved type annotations for `allCharms`
- [chatbot-note-composed.tsx](packages/patterns/chatbot-note-composed.tsx): Changed `allCharms` from `Cell<T[]>` to `Default<T[], []>`
- [default-app.tsx](packages/patterns/default-app.tsx): Tightened `Charm` type to remove index signature

**Built-in Functions:**
- Updated all built-in function signatures (`llm`, `compileAndRun`, `fetchData`, etc.) to use `OpaqueOrCells<T>`
- Ensured consistent return type of `OpaqueRef<T>` for all built-ins

### Breaking Changes

- Function signatures across the API have changed from `Opaque<T>` to `OpaqueOrCells<T>`
- `StripCell<T>` now also handles `Stream<T>` removal in addition to `Cell<T>`

### Testing

- All existing tests pass