### PR TITLE
chore: Use deno 2.5.2 in CI

### DIFF
--- a/.github/actions/deno-setup/action.yml
+++ b/.github/actions/deno-setup/action.yml
@@ -8,10 +8,10 @@ runs:
   using: "composite"
   steps:
     # Keep in sync with `./tasks/check.sh` version
-    - name: 🦕 Setup Deno 2.4.5
+    - name: 🦕 Setup Deno 2.5.2
       uses: denoland/setup-deno@v2
       with:
-        deno-version: "2.4.5"
+        deno-version: "2.5.2"
 
     - name: 📦 Cache Deno dependencies
       if: inputs.cache


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Update CI to use Deno 2.5.2 (was 2.4.5) in the shared deno-setup action. Keeps CI in sync with ./tasks/check.sh and pulls in recent fixes.

<!-- End of auto-generated description by cubic. -->

