### PR TITLE
chore(CI): run new pattern tests in parallel

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -118,13 +118,6 @@ jobs:
           API_URL=http://localhost:8000/ \
           deno task integration
 
-      - name: 🧪 Run pattern-tests integration tests
-        working-directory: packages/pattern-tests
-        run: |
-          HEADLESS=1 \
-          API_URL=http://localhost:8000/ \
-          deno task integration
-
   cli-integration-test:
     name: "CLI Integration Tests"
     runs-on: ubuntu-latest
@@ -186,6 +179,22 @@ jobs:
           HEADLESS=1 \
           API_URL=http://localhost:8000/ \
           deno task integration
+
+  pattern-tests-integration-test:
+    name: "Pattern Tests Integration Tests"
+    runs-on: ubuntu-latest
+    needs: ["build"]
+    environment: ci
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+
+      - name: 🧪 Run pattern tests integration tests
+        working-directory: packages/pattern-tests
+        run: deno task integration
 
   attest-binaries:
     name: "Attest and Upload Binaries"

--- a/packages/pattern-tests/deno.json
+++ b/packages/pattern-tests/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@commontools/pattern-tests",
   "tasks": {
-    "integration": "LOG_LEVEL=warn deno test --trace-leaks -A ./integration/*.test.ts",
+    "integration": "LOG_LEVEL=warn deno test --trace-leaks -A --parallel ./integration/*.test.ts",
     "test": "echo 'No tests defined.'"
   },
   "lint": {


### PR DESCRIPTION
Refactors pattern tests integration tests to run as a separate parallel CI job instead of running sequentially within the main integration test job.

Changes:

- Created new dedicated `pattern-tests-integration-test` job in the GitHub Actions workflow
- Removed pattern tests step from the main `integration-test` job
- Updated pattern tests to run with `--parallel` flag for faster execution
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Split pattern tests into their own CI job and run them in parallel to speed up builds and isolate failures.

- **Refactors**
  - Added a dedicated "pattern-tests-integration-test" job in deno.yml.
  - Removed pattern test step from the main integration-test job.
  - Enabled parallel execution via --parallel in packages/pattern-tests/deno.json.

<!-- End of auto-generated description by cubic. -->

