### PR TITLE
fix(runner): Fix default value resolution for chained $ref in schemas

### DIFF
--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -80,9 +80,9 @@ export function resolveSchema(
       !noFollowNestedRefs && typeof resolvedSchema.$ref === "string" &&
       rootSchema !== undefined
     ) {
-      // Detect cycles - if we've seen this $ref before, return current schema with the repeating $ref
+      // Detect cycles - if we've seen this $ref before, stop resolving
       if (seenRefs.has(resolvedSchema.$ref)) {
-        return resolvedSchema;
+        break;
       }
       seenRefs.add(resolvedSchema.$ref);
 

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -76,7 +76,10 @@ export function resolveSchema(
     // unless noFollowNestedRefs is true (for backwards compatibility)
     // Track seen refs to detect cycles - if we hit a cycle, return the schema with the repeating $ref
     const seenRefs = new Set<string>();
-    while (!noFollowNestedRefs && typeof resolvedSchema.$ref === "string" && rootSchema !== undefined) {
+    while (
+      !noFollowNestedRefs && typeof resolvedSchema.$ref === "string" &&
+      rootSchema !== undefined
+    ) {
       // Detect cycles - if we've seen this $ref before, return current schema with the repeating $ref
       if (seenRefs.has(resolvedSchema.$ref)) {
         return resolvedSchema;
@@ -687,7 +690,8 @@ export function validateAndTransform(
             (isObject(childSchema) &&
               (childSchema.asCell || childSchema.asStream))) &&
           (isRecord(value) ||
-            (isObject(resolvedChildSchema) && resolvedChildSchema.default !== undefined))
+            (isObject(resolvedChildSchema) &&
+              resolvedChildSchema.default !== undefined))
         ) {
           result[key] = validateAndTransform(
             runtime,
@@ -696,7 +700,10 @@ export function validateAndTransform(
             synced,
             seen,
           );
-        } else if (isObject(resolvedChildSchema) && resolvedChildSchema.default !== undefined) {
+        } else if (
+          isObject(resolvedChildSchema) &&
+          resolvedChildSchema.default !== undefined
+        ) {
           // Process default value for missing properties that have defaults
           result[key] = processDefaultValue(
             runtime,

--- a/packages/runner/test/schema-ref-default.test.ts
+++ b/packages/runner/test/schema-ref-default.test.ts
@@ -66,8 +66,8 @@ describe("$ref with default support", () => {
         default: "outermost",
       };
 
-      const resolved = resolveSchema(schema, schema, false);
-      // resolveSchema only resolves one level, so we still have a $ref
+      const resolved = resolveSchema(schema, schema, false, true);
+      // With noFollowNestedRefs=true, resolveSchema only resolves one level, so we still have a $ref
       expect(resolved).toHaveProperty("default", "outermost");
       expect(resolved).toHaveProperty("$ref");
     });

--- a/packages/runner/test/schema-ref-default.test.ts
+++ b/packages/runner/test/schema-ref-default.test.ts
@@ -316,5 +316,36 @@ describe("$ref with default support", () => {
         asStream: true,
       });
     });
+
+    it("should filter asCell when circular $ref is detected with filterAsCell=true", () => {
+      const rootSchema: JSONSchema = {
+        $defs: {
+          Circular: { $ref: "#/$defs/Circular", asCell: true },
+        },
+        $ref: "#/$defs/Circular",
+        asCell: true,
+      };
+
+      const resolved = resolveSchema(rootSchema, rootSchema, true);
+
+      // Even with circular ref, asCell should be filtered when filterAsCell=true
+      expect(resolved).not.toHaveProperty("asCell");
+    });
+
+    it("should preserve asCell when circular $ref is detected with filterAsCell=false", () => {
+      const rootSchema: JSONSchema = {
+        $defs: {
+          Circular: { $ref: "#/$defs/Circular", asCell: true },
+        },
+        $ref: "#/$defs/Circular",
+        asCell: true,
+      };
+
+      const resolved = resolveSchema(rootSchema, rootSchema, false);
+
+      // With filterAsCell=false, asCell should remain even with circular ref
+      expect(resolved).toHaveProperty("asCell", true);
+      expect(resolved).toHaveProperty("$ref");
+    });
   });
 });

--- a/packages/runner/test/schema.test.ts
+++ b/packages/runner/test/schema.test.ts
@@ -1591,7 +1591,7 @@ describe("Schema Support", () => {
       });
     });
 
-    it("should resolve defaults when using $ref in property schemas", () => {
+    it("should resolve defaults in $ref when using $ref in property schemas", () => {
       const schema = {
         $defs: {
           Settings: {

--- a/packages/runner/test/schema.test.ts
+++ b/packages/runner/test/schema.test.ts
@@ -1619,7 +1619,7 @@ describe("Schema Support", () => {
         config?: { enabled: boolean; label: string };
       }>(
         space,
-        "should resolve defaults when using $ref in property schemas",
+        "should resolve defaults in $ref when using $ref in property schemas",
         undefined,
         tx,
       );

--- a/packages/runner/test/schema.test.ts
+++ b/packages/runner/test/schema.test.ts
@@ -1591,6 +1591,49 @@ describe("Schema Support", () => {
       });
     });
 
+    it("should resolve defaults when using $ref in property schemas", () => {
+      const schema = {
+        $defs: {
+          Settings: {
+            type: "object",
+            properties: {
+              enabled: { type: "boolean" },
+              label: { type: "string" },
+            },
+            default: { enabled: true, label: "from ref" },
+          },
+          SettingsWithDefault: {
+            $ref: "#/$defs/Settings",
+            default: { enabled: false, label: "from default" },
+          },
+        },
+        type: "object",
+        properties: {
+          config: {
+            $ref: "#/$defs/SettingsWithDefault",
+          },
+        },
+      } as const satisfies JSONSchema;
+
+      const c = runtime.getCell<{
+        config?: { enabled: boolean; label: string };
+      }>(
+        space,
+        "should resolve defaults when using $ref in property schemas",
+        undefined,
+        tx,
+      );
+      c.set({});
+
+      const cell = c.asSchema(schema);
+      const value = cell.get();
+
+      expect(value.config).toEqualIgnoringSymbols({
+        enabled: false,
+        label: "from property",
+      });
+    });
+
     it("should use the default value with asCell for objects", () => {
       const c = runtime.getCell<{
         name: string;

--- a/packages/runner/test/schema.test.ts
+++ b/packages/runner/test/schema.test.ts
@@ -1630,7 +1630,7 @@ describe("Schema Support", () => {
 
       expect(value.config).toEqualIgnoringSymbols({
         enabled: false,
-        label: "from property",
+        label: "from default",
       });
     });
 


### PR DESCRIPTION
## Fix default value resolution for chained $ref in schemas

### Problem

When a property schema contains a `$ref` that points to another schema definition which itself contains a `$ref` (chained references), default values were not being applied correctly. The system only resolved one level of `$ref`, meaning defaults defined in intermediate references were never discovered.

**Example scenario that was broken:**

```typescript
const schema = {
  $defs: {
    Settings: {
      type: "object",
      properties: {
        enabled: { type: "boolean" },
        label: { type: "string" }
      },
      default: { enabled: true, label: "from ref" }
    },
    SettingsWithDefault: {
      $ref: "#/$defs/Settings",
      default: { enabled: false, label: "from default" }  // This default was being ignored!
    }
  },
  type: "object",
  properties: {
    config: {
      $ref: "#/$defs/SettingsWithDefault"
    }
  }
}
```

When reading `config` from an object with undefined config, the expected behavior was to use the default from `SettingsWithDefault` (`{ enabled: false, label: "from default" }`), but instead nothing was returned because the system didn't resolve the chained `$ref` to discover the default value.

### Solution

1. **Enhanced `resolveSchema()`** to support full resolution of chained `$ref`s
   - Added cycle detection to prevent infinite loops with circular references
   - When a cycle is detected, returns the schema with the repeating `$ref`
   
2. **Updated default value handling** in `processDefaultValue()` and `validateAndTransform()`
   - Now fully resolves schemas before checking for defaults
   - Ensures defaults in intermediate `$ref` chains are discovered and applied

### Testing

Added tests to verify:
- Defaults are correctly applied from property-level `$ref` schemas
- Defaults in chained `$ref`s (A -> B -> C) work correctly
- Precedence rules are maintained (ref site default overrides target default)
- Cycle detection prevents infinite loops

All existing tests continue to pass.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes default value resolution for schemas with chained $refs so defaults on intermediate refs are applied. Adds safe ref resolution with cycle detection. Addresses Linear CT-966.

- **Bug Fixes**
  - Resolve chained $refs fully in resolveSchema, with cycle detection.
  - Resolve schemas before checking defaults to honor intermediate ref defaults and precedence.
  - Added tests for property-level $refs, chained $refs (A→B→C), and default precedence.

<!-- End of auto-generated description by cubic. -->

