### PR TITLE
Prevent self-referencing schema cycles in Default wrapper type

### DIFF
--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -125,7 +125,9 @@ export class SchemaGenerator implements ISchemaGenerator {
     context: GenerationContext,
   ): string {
     const existing = context.anonymousNames.get(type);
-    if (existing) return existing;
+    if (existing) {
+      return existing;
+    }
     const synthetic = `AnonymousType_${++context.anonymousNameCounter}`;
     context.anonymousNames.set(type, synthetic);
     return synthetic;
@@ -156,10 +158,25 @@ export class SchemaGenerator implements ISchemaGenerator {
     // Hoist every named type (excluding wrappers filtered by getNamedTypeKey)
     // into definitions and return $ref for non-root uses. Cycle detection
     // still applies via definitionStack.
+
+    // Check if we're in a wrapper context (Default/Cell/Stream/OpaqueRef).
+    // Wrapper types erase to their inner type, so we must check typeNode to
+    // distinguish wrapper context from inner context.
+    const typeNodeName = context.typeNode && ts.isTypeReferenceNode(context.typeNode) &&
+      ts.isIdentifier(context.typeNode.typeName)
+      ? context.typeNode.typeName.text
+      : undefined;
+    const isWrapperContext = typeNodeName &&
+      ["Default", "Cell", "Stream", "OpaqueRef"].includes(typeNodeName);
+
     let namedKey = getNamedTypeKey(type, context.typeNode);
-    if (!namedKey) {
+
+    if (!namedKey && !isWrapperContext) {
+      // Only use synthetic names if we're not processing a wrapper type
       const synthetic = context.anonymousNames.get(type);
-      if (synthetic) namedKey = synthetic;
+      if (synthetic) {
+        namedKey = synthetic;
+      }
     }
     if (namedKey) {
       if (
@@ -204,7 +221,11 @@ export class SchemaGenerator implements ISchemaGenerator {
         const result = formatter.formatType(type, context);
 
         // If this is a named type (all-named policy), store in definitions.
-        const keyForDef = namedKey ?? context.anonymousNames.get(type);
+        // We already computed namedKey above with wrapper checks, so reuse it.
+        // Only look up synthetic names if namedKey wasn't already set and we're
+        // not in a wrapper context (to avoid storing wrapper results).
+        const keyForDef = namedKey ??
+          (isWrapperContext ? undefined : context.anonymousNames.get(type));
         if (keyForDef) {
           context.definitions[keyForDef] = result;
           context.inProgressNames.delete(keyForDef);

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -246,7 +246,9 @@ export function getNamedTypeKey(
     name = ref.target?.symbol?.name ?? name;
   }
   // Fall back to alias symbol when present (type aliases) if we haven't used it yet
-  if (!name && aliasName) {
+  // This includes the case where symbol.name is "__type" (anonymous object literal)
+  // but the type has an explicit alias name
+  if ((!name || name === "__type") && aliasName) {
     name = aliasName;
   }
   if (!name || name === "__type") {

--- a/packages/schema-generator/test/fixtures/schema/default-array-recursive.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/default-array-recursive.expected.json
@@ -1,0 +1,39 @@
+{
+  "$defs": {
+    "AnonymousType_1": {
+      "items": {
+        "$ref": "#/$defs/RecursiveItem"
+      },
+      "type": "array"
+    },
+    "RecursiveItem": {
+      "properties": {
+        "children": {
+          "$ref": "#/$defs/AnonymousType_1"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "items": {
+      "$ref": "#/$defs/AnonymousType_1",
+      "default": []
+    },
+    "moreItems": {
+      "$ref": "#/$defs/AnonymousType_1",
+      "default": []
+    }
+  },
+  "required": [
+    "items",
+    "moreItems"
+  ],
+  "type": "object"
+}

--- a/packages/schema-generator/test/fixtures/schema/default-array-recursive.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/default-array-recursive.input.ts
@@ -1,0 +1,11 @@
+type Default<T, V extends T = T> = T;
+
+type RecursiveItem = {
+  name: string;
+  children?: RecursiveItem[];
+};
+
+interface SchemaRoot {
+  items: Default<Array<RecursiveItem>, []>;
+  moreItems: Default<Array<RecursiveItem>, []>;
+}

--- a/packages/schema-generator/test/fixtures/schema/shared-type.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/shared-type.expected.json
@@ -1,34 +1,27 @@
 {
+  "$defs": {
+    "Shared": {
+      "properties": {
+        "a": {
+          "type": "number"
+        },
+        "b": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "type": "object"
+    }
+  },
   "properties": {
     "one": {
-      "properties": {
-        "a": {
-          "type": "number"
-        },
-        "b": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "a",
-        "b"
-      ],
-      "type": "object"
+      "$ref": "#/$defs/Shared"
     },
     "two": {
-      "properties": {
-        "a": {
-          "type": "number"
-        },
-        "b": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "a",
-        "b"
-      ],
-      "type": "object"
+      "$ref": "#/$defs/Shared"
     }
   },
   "required": [


### PR DESCRIPTION
This commit fixes two related bugs in the schema generator:

1. **Wrapper type self-reference bug**: Default<Array<T>, []> was creating self-referencing schema definitions because type erasure caused the wrapper and inner types to have the same identity. Fixed by checking typeNode context to detect wrapper types (Default/Cell/Stream/OpaqueRef) and preventing their results from being stored as definitions.

2. **Type alias recognition bug**: Type aliases like `type Foo = {...}` weren't being recognized as named types because `symbol.name === "__type"` is truthy but should trigger fallback to `aliasName`. Fixed by changing the condition to properly handle the "__type" case.

Changes:
- schema-generator.ts: Added isWrapperContext check to prevent wrapper type results from being stored with synthetic names
- type-utils.ts: Fixed getNamedTypeKey to properly recognize type aliases with `__type` symbol by falling back to aliasName
- Added test fixture: default-array-recursive (validates the fix)
- Updated test fixture: shared-type (now correctly hoists named type aliases)

All tests pass (17 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)