### PR TITLE
Optionally log the selector in our spans, so we can track down which queries are slow.

### DIFF
--- a/packages/memory/space.ts
+++ b/packages/memory/space.ts
@@ -235,6 +235,7 @@ class Space<Subject extends MemorySpace = MemorySpace>
       addMemoryAttributes(span, {
         operation: "querySchema",
         space: this.subject,
+        selector: JSON.stringify(source.args.selectSchema),
       });
 
       return querySchema(this, source);

--- a/packages/memory/telemetry.ts
+++ b/packages/memory/telemetry.ts
@@ -164,6 +164,7 @@ export function addMemoryAttributes(
     the?: string;
     cause?: string;
     changeCount?: number;
+    selector?: string;
   },
 ): void {
   if (!span || !config.enabled) return;
@@ -173,6 +174,7 @@ export function addMemoryAttributes(
   if (info.entity) span.setAttribute("memory.entity", info.entity);
   if (info.the) span.setAttribute("memory.the", info.the);
   if (info.cause) span.setAttribute("memory.cause", info.cause);
+  if (info.selector) span.setAttribute("memory.selector", info.selector);
   if (info.changeCount !== undefined) {
     span.setAttribute("memory.change_count", info.changeCount);
   }


### PR DESCRIPTION
With this logging, we should be able to see which queries are actually slow, and ideally do a deeper dive if we have any that take more than a second.