### PR TITLE
Ellyse/fix container exiting

### DIFF
--- a/tools/ralph/DEPLOY.md
+++ b/tools/ralph/DEPLOY.md
@@ -38,13 +38,13 @@ The command will output a charm ID (e.g.,
 The URL format for localhost is:
 
 ```
-http://localhost:5173/<SPACE_NAME>/<CHARM_ID>
+http://localhost:8000/<SPACE_NAME>/<CHARM_ID>
 ```
 
 Example:
 
 ```
-http://localhost:5173/ellyse/baedreidon464mghox4uar46bbym5t6bnmlvn6wwzby5vvdmsw24oxaalp4
+http://localhost:8000/ellyse/baedreidon464mghox4uar46bbym5t6bnmlvn6wwzby5vvdmsw24oxaalp4
 ```
 
 ## Step 4: Test with Playwright
@@ -52,7 +52,7 @@ http://localhost:5173/ellyse/baedreidon464mghox4uar46bbym5t6bnmlvn6wwzby5vvdmsw2
 ### 4.1 Navigate to the Charm URL
 
 ```javascript
-await page.goto("http://localhost:5173/<SPACE_NAME>/<CHARM_ID>");
+await page.goto("http://localhost:8000/<SPACE_NAME>/<CHARM_ID>");
 ```
 
 ### 4.2 Register/Login (First Time Only)
@@ -81,7 +81,7 @@ deno task ct charm new --identity ./my.key --api-url http://127.0.0.1:8000 --spa
 # Output: baedreidon464mghox4uar46bbym5t6bnmlvn6wwzby5vvdmsw24oxaalp4
 
 # 3. URL will be:
-# http://localhost:5173/ellyse/baedreidon464mghox4uar46bbym5t6bnmlvn6wwzby5vvdmsw24oxaalp4
+# http://localhost:8000/ellyse/baedreidon464mghox4uar46bbym5t6bnmlvn6wwzby5vvdmsw24oxaalp4
 ```
 
 Then use Playwright to:
@@ -95,5 +95,6 @@ Then use Playwright to:
 There are two servers that need to be running: toolshed and shell
 
 1. kill deno processes
-2. toolshed: go into ./packages/toolshed and run `deno task dev`
+2. toolshed: go into ./packages/toolshed and run
+   `SHELL_URL=http://localhost:5173 deno task dev`
 3. shell: go into ./packages/shell and run `deno task dev-local`

--- a/tools/ralph/DEPLOY.md
+++ b/tools/ralph/DEPLOY.md
@@ -89,3 +89,11 @@ Then use Playwright to:
 1. Navigate to the URL
 2. Complete registration (first time)
 3. Test the charm functionality
+
+# Restarting servers
+
+There are two servers that need to be running: toolshed and shell
+
+1. kill deno processes
+2. toolshed: go into ./packages/toolshed and run `deno task dev`
+3. shell: go into ./packages/shell and run `deno task dev-local`

--- a/tools/ralph/Dockerfile
+++ b/tools/ralph/Dockerfile
@@ -80,5 +80,6 @@ RUN npm install -g @anthropic-ai/claude-code && \
 # --no-sandbox is required because Docker containers restrict namespace creation
 RUN claude mcp add --scope user playwright npx "@playwright/mcp@latest" -- --headless --isolated --no-sandbox
 
-# Start Common Tool servers
-CMD ["/app/start-servers.sh"]
+# Start Common Tool servers in background and keep container alive
+# the sleep ensures that restarting the server doesnt cause the container to exit
+CMD ["/bin/sh", "-c", "/app/start-servers.sh & sleep infinity"]

--- a/tools/ralph/README.md
+++ b/tools/ralph/README.md
@@ -77,11 +77,11 @@ $ docker push <user_name>/ralph
 ## TODO
 
 - add playwright to codex
-- push a working image to a docker hub
-- update README to use image from dockerhub
 - figure out how LLM tokens should be set for toolshed
 - sandbox the container (network config)
 - make ralph easy to run
+- DONE - update README to use image from dockerhub
+- DONE - push a working image to a docker hub
 - DONE - change permissions so claude auto updater will work
 - DONE - move ralph script into ./tools/ralph
 - DONE - Add codex and claude packages

--- a/tools/ralph/README.md
+++ b/tools/ralph/README.md
@@ -12,7 +12,7 @@ Claude CLI and Codex are installed
 
 ```bash
 $ docker pull ellyxir/ralph
-$ docker run -d --name ralph -p 8000:8000 -p 5173:5173 ellyxir/ralph
+$ docker run -d --name ralph -p 8000:8000 ellyxir/ralph
 ```
 
 To connect to the container (connecting as ralph user is recommended):
@@ -30,7 +30,7 @@ If you want to build the image yourself with local modifications:
 ```bash
 $ cd ./tools/ralph
 $ docker build -t <user_name>/ralph .
-$ docker run -d --name ralph -p 8000:8000 -p 5173:5173 <user_name>/ralph
+$ docker run -d --name ralph -p 8000:8000 <user_name>/ralph
 ```
 
 Note for `docker build`:

--- a/tools/ralph/start-servers.sh
+++ b/tools/ralph/start-servers.sh
@@ -2,7 +2,7 @@
 
 # Start toolshed server in background
 echo "Starting toolshed server..."
-cd /app/labs/packages/toolshed && deno task dev &
+cd /app/labs/packages/toolshed && SHELL_URL=http://localhost:5173 deno task dev &
 TOOLSHED_PID=$!
 
 # Start shell server in background


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the Ralph container exiting when toolshed/shell servers stop or restart. Servers now run in the background and the container stays alive.

- **Bug Fixes**
  - Start servers in the background and add sleep infinity to prevent container exit.

- **Documentation**
  - Add DEPLOY.md steps to restart toolshed and shell.
  - Update README TODOs; mark Docker Hub image and usage as done.

<!-- End of auto-generated description by cubic. -->

