### PR TITLE
Fix: Detect actual default exports in ts-transformer pipeline

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1909,6 +1909,11 @@
           "npm:@opentelemetry/api@^1.9.0"
         ]
       },
+      "packages/runner": {
+        "dependencies": [
+          "npm:typescript@*"
+        ]
+      },
       "packages/schema-generator": {
         "dependencies": [
           "npm:typescript@*"

--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -4,6 +4,9 @@
     "test": "deno test --allow-ffi --allow-env --allow-read test/*.test.ts",
     "integration": "LOG_LEVEL=warn deno test -A ./integration/*.test.ts"
   },
+  "imports": {
+    "typescript": "npm:typescript"
+  },
   "exports": {
     ".": "./src/index.ts",
     "./storage/inspector": "./src/storage/inspector.ts",


### PR DESCRIPTION
Previously, mapPrefixProgramFiles() incorrectly assumed files had default exports based on whether program.mainExport was undefined or "default". This caused compilation errors for files with only named exports.

Changes:
- Added hasDefaultExport() function that parses source AST to detect actual default exports (both "export default" and "export { X as default }")
- Updated mapPrefixProgramFiles() to check actual file contents instead of making assumptions
- Added TypeScript import to @commontools/runner package

This fixes transformation errors for patterns (eg like kanban-board-grouping) that only export named exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)