### PR TITLE
feat(runner): Add onCommit callback support for Cell and Stream operations

### DIFF
--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -209,7 +209,12 @@ export interface IScheduler {
   unsubscribe(action: Action): void;
   onConsole(fn: ConsoleHandler): void;
   onError(fn: ErrorHandler): void;
-  queueEvent(eventRef: NormalizedFullLink, event: any): void;
+  queueEvent(
+    eventRef: NormalizedFullLink,
+    event: any,
+    retries?: number,
+    onCommit?: (tx: IExtendedStorageTransaction) => void,
+  ): void;
   addEventHandler(handler: EventHandler, ref: NormalizedFullLink): Cancel;
   runningPromise: Promise<unknown> | undefined;
 }

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -497,6 +497,18 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
   tx: IStorageTransaction;
 
   /**
+   * Add a callback to be called when the transaction commit completes.
+   * The callback receives the transaction as a parameter and is called
+   * regardless of whether the commit succeeded or failed.
+   *
+   * Note: Callbacks are called synchronously after commit completes.
+   * If a callback throws, the error is logged but doesn't affect other callbacks.
+   *
+   * @param callback - Function to call after commit
+   */
+  addCommitCallback(callback: (tx: IExtendedStorageTransaction) => void): void;
+
+  /**
    * Reads a value from a (local) memory address and throws on error, except for
    * `NotFoundError` which is returned as undefined.
    *


### PR DESCRIPTION
This change adds the ability to register callbacks that are invoked when Cell.set(), Cell.send(), or Stream.send() operations commit to storage, regardless of whether the commit succeeds or fails.

## What Changed

### API Changes
- Added optional `onCommit` parameter to:
  - `Cell.set(value, onCommit?)`
  - `Cell.send(value, onCommit?)`
  - `Stream.send(event, onCommit?)`
  - `IScheduler.queueEvent(eventRef, event, retries?, onCommit?)`

- Added `IExtendedStorageTransaction.addCommitCallback(callback)` method

### Callback Behavior
- **For Cell operations**: Callback is invoked after the transaction commits, whether the commit succeeds or fails. Multiple set() calls on the same transaction can each register callbacks - all are invoked on commit.

- **For Stream events**: Callback is invoked when either:
  - The event handler commits successfully, OR
  - The event handler fails and all retry attempts are exhausted
  - Callbacks are NOT invoked during intermediate retry attempts

- **Error handling**: Each callback is wrapped in try/catch to prevent one failing callback from breaking others. Errors are logged but don't affect transaction outcome.

- **Inspecting results**: Callbacks receive the transaction as a parameter and can call `tx.status()` to determine if the commit succeeded or failed.

### Implementation Details
- `ExtendedStorageTransaction` maintains a Set of callbacks and invokes them in its commit().then() handler after the commit completes
- `Scheduler.execute()` calls the callback when commit succeeds OR when the final retry fails (retriesLeft === 0)
- All callbacks are invoked synchronously within the microtask queue after commit resolution

## Why This Matters

This feature enables:
- Tracking completion of writes for UI updates or synchronization
- Implementing retry logic or error handling at the call site
- Coordinating dependent operations across transaction boundaries
- Debugging and observability of storage operations

The callbacks provide a way to observe transaction outcomes without blocking the synchronous flow of Cell/Stream operations, maintaining the existing non-blocking API while adding observability.

## Testing
- Added 7 new tests covering success cases, failure cases, error handling, multiple callbacks, and retry behavior
- All existing tests continue to pass (backward compatible)
- Total: 79 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)