### PR TITLE
added ralph/bin/llm.sh alternative for the llm package

### DIFF
--- a/tools/ralph/bin/llm.sh
+++ b/tools/ralph/bin/llm.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# llm.sh - Text-only LLM interface using Claude Code
+#
+# A lightweight alternative to llm (https://llm.datasette.io) that leverages
+# your existing Claude Code installation. No additional API tokens required.
+#
+# Usage:
+#   llm.sh "Your question here"              # Direct prompt
+#   echo "data" | llm.sh "Analyze this"      # Piped input
+#   cat file.txt | llm.sh "Summarize"        # File processing
+#
+# Note: Runs in text-only mode with all tools disabled for safety.
+#       Slower than native llm but requires no additional setup.
+
+# Check if input is piped
+if [ -p /dev/stdin ]; then
+    # Read from stdin
+    input=$(cat)
+    prompt="$* $input"
+else
+    # Use arguments as prompt
+    prompt="$*"
+fi
+
+# Create a temporary directory for Claude Code
+temp_dir=$(mktemp -d)
+cd "$temp_dir"
+
+# Run Claude Code with the prompt (--print for non-interactive, --disallowed-tools "*" prevents all tool use)
+echo "$prompt" | claude --print --disallowed-tools "*" 2>/dev/null
+
+# Cleanup
+cd - > /dev/null
+rm -rf "$temp_dir"


### PR DESCRIPTION
main advantage is no additional api token setup
for use with ralph script when needing to summarise things
pass flags for no tool use, shouldnt be vector for prompt injection