### PR TITLE
dockerfile used to edit the AGENTS.md but then that

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,3 +351,12 @@ Sometimes a low-level try/catch is appropriate, of course:
   ED25519 features we need supported natively for this platform? if not use a
   polyfill), then this is not a fatal error, and we explicitly do not want to
   throw and handle it elsewhere.
+
+## Ralph Container Information
+
+If you are running inside the Ralph Docker container (user is "ralph" or
+`/app/start-servers.sh` exists):
+
+- See `tools/ralph/DEPLOY.md` for Playwright MCP testing and server restart
+  instructions
+- The servers are already running on localhost (toolshed on 8000, shell on 5173)

--- a/tools/ralph/Dockerfile
+++ b/tools/ralph/Dockerfile
@@ -54,11 +54,6 @@ WORKDIR /app
 RUN git clone https://github.com/commontoolsinc/labs.git /app/labs && \
     chown -R ralph:ralph /app/labs
 
-# Copy and append DEPLOY.md to AGENTS.md
-COPY --chown=ralph:ralph DEPLOY.md /tmp/DEPLOY.md
-RUN cat /tmp/DEPLOY.md >> /app/labs/AGENTS.md && \
-    rm /tmp/DEPLOY.md
-
 # Copy the startup script from local directory
 COPY --chown=ralph:ralph start-servers.sh /app/start-servers.sh
 RUN chmod +x /app/start-servers.sh


### PR DESCRIPTION
left the git repository as modified which doesnt work well with how ralph works, it wants to commit any changes. therefore just added to the end of AGENTS.md to read the ralph/DEPLOY.md if its running as ralph
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stop mutating AGENTS.md during the Ralph Docker build to keep the repo clean and prevent unintended commits. Added a short note in AGENTS.md that points Ralph users to tools/ralph/DEPLOY.md and lists local server ports.

- **Bug Fixes**
  - Removed the Dockerfile step that appended DEPLOY.md into AGENTS.md, which left a dirty working tree and triggered Ralph’s commit flow.

<!-- End of auto-generated description by cubic. -->

