### PR TITLE
feat: add --main-export flag to ct dev command

### DIFF
--- a/packages/cli/commands/dev.ts
+++ b/packages/cli/commands/dev.ts
@@ -33,6 +33,10 @@ export const dev = new Command()
     "--show-transformed",
     "Show only the transformed TypeScript source code without executing the recipe.",
   )
+  .option(
+    "--main-export <export:string>",
+    'Named export from entry for recipe definition. Defaults to "default".',
+  )
   .arguments("<main:string>")
   .action(async (options, main) => {
     const { main: exports } = await process({
@@ -42,11 +46,15 @@ export const dev = new Command()
       output: options.output,
       filename: options.filename,
       showTransformed: options.showTransformed,
+      mainExport: options.mainExport,
     });
     // If --show-transformed is used, the transformed source is already printed to stdout
     // and we don't want to print the JSON output
     if (!options.showTransformed && exports) {
-      const mainExport = "default" in exports ? exports.default : exports;
+      // Select the export to render. If no --main-export specified, use "default".
+      // This mirrors the logic in Engine.run() which uses program.mainExport ?? "default"
+      const exportName = options.mainExport ?? "default";
+      const mainExport = exportName in exports ? exports[exportName] : exports;
       try {
         // Stringify before rendering, as the exported
         // recipe is a function with extra properties via Object.assign

--- a/packages/cli/fixtures/named-export.tsx
+++ b/packages/cli/fixtures/named-export.tsx
@@ -1,0 +1,22 @@
+// Test file with named export instead of default export
+import { h, recipe, schema } from "commontools";
+
+const model = schema({
+  type: "object",
+  properties: {
+    message: { type: "string", default: "from named export" },
+  },
+  default: { message: "from named export" },
+});
+
+export const myNamedRecipe = recipe(model, model, (cell) => {
+  return {
+    message: cell.message,
+  };
+});
+
+export default recipe(model, model, (cell) => {
+  return {
+    message: "from default export",
+  };
+});

--- a/packages/cli/lib/dev.ts
+++ b/packages/cli/lib/dev.ts
@@ -21,6 +21,7 @@ export interface ProcessOptions {
   output?: string;
   filename?: string;
   showTransformed?: boolean;
+  mainExport?: string;
 }
 
 export async function process(
@@ -35,6 +36,9 @@ export async function process(
   const program = await engine.resolve(
     new FileSystemProgramResolver(options.main),
   );
+  if (options.mainExport) {
+    program.mainExport = options.mainExport;
+  }
   const getTransformedProgram = options.showTransformed
     ? renderTransformed
     : undefined;

--- a/packages/cli/test/dev.test.ts
+++ b/packages/cli/test/dev.test.ts
@@ -28,4 +28,27 @@ describe("cli dev", () => {
     const rendered = bytesToLines(await Deno.readFile(temp));
     expect(rendered[rendered.length - 1]).toEqual("//# sourceURL=test-file.js");
   });
+
+  it("Uses default export when no --main-export specified", async () => {
+    const { code, stdout, stderr } = await ct(
+      "dev fixtures/named-export.tsx",
+    );
+    checkStderr(stderr);
+    const output = JSON.parse(stdout.join("\n"));
+    expect(output.result.message).toBe("from default export");
+    expect(code).toBe(0);
+  });
+
+  it("Uses specified named export with --main-export", async () => {
+    const { code, stdout, stderr } = await ct(
+      "dev fixtures/named-export.tsx --main-export myNamedRecipe",
+    );
+    checkStderr(stderr);
+    const output = JSON.parse(stdout.join("\n"));
+    // Named export uses cell reference, so check the argument schema
+    expect(output.argumentSchema.default.message).toBe("from named export");
+    // Also verify mainExport was set correctly in program
+    expect(output.program.mainExport).toBe("myNamedRecipe");
+    expect(code).toBe(0);
+  });
 });


### PR DESCRIPTION
Take two :)

Add --main-export flag to ct dev command to specify which named export from the entry file should be used as the recipe definition. This brings ct dev into parity with ct charm new and ct charm setsrc commands.

Changes:
- Add --main-export option to dev command CLI interface
- Add mainExport field to ProcessOptions interface
- Set program.mainExport before processing in lib/dev.ts
- Use specified export name when accessing module exports
- Add test fixture with both default and named exports
- Add tests for default export behavior and named export behavior

The Engine already supports mainExport via RuntimeProgram, so this change only wires up the CLI flag to the existing infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds --main-export to ct dev so you can pick a named export from the entry file as the recipe. Keeps default behavior and brings ct dev in line with ct charm new and ct charm setsrc.

- **New Features**
  - New CLI flag: --main-export <name> (defaults to "default").
  - Wires program.mainExport into dev processing and selects the specified export.
  - Adds a fixture and tests for default and named-export flows.

- **Migration**
  - No breaking changes. Use --main-export myNamedRecipe when your recipe is a named export.

<!-- End of auto-generated description by cubic. -->

