### PR TITLE
fix: add logging to silent catch block in type-utils.ts

### DIFF
--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -91,8 +91,12 @@ export function safeGetPropertyType(
         typeFromParent = undefined;
       }
     }
-  } catch {
-    // Type resolution can fail for some edge cases
+  } catch (error) {
+    // Type resolution can fail for some edge cases - fall back to declaration type
+    console.warn(
+      `Failed to resolve property type from parent for "${prop.getName()}":`,
+      error,
+    );
   }
 
   // Try to get type from declaration


### PR DESCRIPTION
Add console.warn logging to the previously silent catch block in safeGetPropertyType function. This catch was handling type resolution failures when getting property types from parent types, but wasn't logging any information about the failure.

Now all 4 catch blocks in type-utils.ts properly log errors with context about what failed.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added console.warn logging to the previously silent catch in safeGetPropertyType to surface failures when resolving a property’s type from its parent. This improves debugging and makes all four catch blocks in type-utils.ts consistently log context (property name and error).

<!-- End of auto-generated description by cubic. -->

