### PR TITLE
Revert to promise-based waiting for pattern tool results

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -390,8 +390,6 @@ async function invokeToolCall(
     await runtime.idle();
     return { type: "json", value: result.get() };
   }
-
-
 }
 
 /**


### PR DESCRIPTION
Fixes `searchWeb`

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reverted pattern tool result handling to promise-based waiting so we wait for the actual output, not just the transaction commit. Fixes searchWeb returning incomplete results.

- **Bug Fixes**
  - For pattern calls, use a sink + Promise to resolve when a result is available.
  - Stop the runner after receiving the result and return the JSON value.
  - Non-pattern calls keep idle + get behavior.

<!-- End of auto-generated description by cubic. -->

