### PR TITLE
chore: Update typescript to 5.9.2, update related tests

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -125,7 +125,7 @@
     "npm:source-map-js@^1.2.1": "1.2.1",
     "npm:stoker@^1.4.2": "1.4.3_@hono+zod-openapi@0.18.4__hono@4.9.6__zod@3.25.76_hono@4.9.6_zod@3.25.76",
     "npm:turndown@^7.1.2": "7.2.0",
-    "npm:typescript@*": "5.8.3",
+    "npm:typescript@*": "5.9.2",
     "npm:zod@^3.24.1": "3.25.76"
   },
   "jsr": {
@@ -1791,8 +1791,8 @@
         "@mixmark-io/domino"
       ]
     },
-    "typescript@5.8.3": {
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+    "typescript@5.9.2": {
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "bin": true
     },
     "undici-types@6.21.0": {

--- a/packages/schema-generator/test/schema/circular-alias-error.test.ts
+++ b/packages/schema-generator/test/schema/circular-alias-error.test.ts
@@ -1,7 +1,9 @@
+import ts from "typescript";
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { SchemaGenerator } from "../../src/schema-generator.ts";
 import { createTestProgram } from "../utils.ts";
+import { assert } from "@std/assert";
 
 describe("Circular alias error handling", () => {
   it("should throw descriptive error for circular Default aliases", async () => {
@@ -14,14 +16,17 @@ describe("Circular alias error handling", () => {
       }
     `;
 
-    const { program, checker, sourceFile } = await createTestProgram(code);
+    const { checker, sourceFile } = await createTestProgram(code);
 
     const rootInterface = sourceFile.statements.find((stmt) =>
-      stmt.kind === 264 && // InterfaceDeclaration
-      (stmt as any).name.text === "SchemaRoot"
-    ) as any;
+      ts.isInterfaceDeclaration(stmt) && stmt.name.text === "SchemaRoot"
+    ) as ts.InterfaceDeclaration | undefined;
+    assert(rootInterface, "Found SchemaRoot");
 
     const circularProperty = rootInterface.members[0];
+    assert(circularProperty, "Found circular prop");
+    assert(ts.isPropertySignature(circularProperty), "Is property signature.");
+    assert(circularProperty.type, "Prop has type node.");
     const type = checker.getTypeFromTypeNode(circularProperty.type);
 
     const generator = new SchemaGenerator();
@@ -42,14 +47,17 @@ describe("Circular alias error handling", () => {
       }
     `;
 
-    const { program, checker, sourceFile } = await createTestProgram(code);
+    const { checker, sourceFile } = await createTestProgram(code);
 
     const rootInterface = sourceFile.statements.find((stmt) =>
-      stmt.kind === 264 && // InterfaceDeclaration
-      (stmt as any).name.text === "SchemaRoot"
-    ) as any;
+      ts.isInterfaceDeclaration(stmt) && stmt.name.text === "SchemaRoot"
+    ) as ts.InterfaceDeclaration | undefined;
+    assert(rootInterface, "Found SchemaRoot");
 
     const circularProperty = rootInterface.members[0];
+    assert(circularProperty, "Found circular prop");
+    assert(ts.isPropertySignature(circularProperty), "Is property signature.");
+    assert(circularProperty.type, "Prop has type node.");
     const type = checker.getTypeFromTypeNode(circularProperty.type);
 
     const generator = new SchemaGenerator();


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Upgrade TypeScript to 5.9.2 and refactor schema-generator circular-alias tests to use official TS node guards and stronger assertions. This keeps us current and makes tests more robust.

- **Dependencies**
  - Bump TypeScript from 5.8.3 to 5.9.2 in deno.lock.

- **Refactors**
  - Replace numeric node kinds with ts.isInterfaceDeclaration and PropertySignature checks.
  - Add asserts for found nodes and types; remove unused program from test setup.

<!-- End of auto-generated description by cubic. -->

