### PR TITLE
chore: Parse identifiers for __ctHelpers usage rather than a naive string check

### DIFF
--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
-import { assert } from "@std/assert";
+import { assert, assertRejects } from "@std/assert";
 import { transformFiles } from "./utils.ts";
 
 const fixture = `
@@ -32,5 +32,39 @@ describe("CommonToolsTransformerPipeline", () => {
       /import \* as __ctHelpers/.test(enabled["/main.ts"]!),
       "no replacements without <cts-enable />",
     );
+  });
+});
+
+describe("CTHelpers handling", () => {
+  it("Throws if __ctHelpers variable is used in source", async () => {
+    const statements = [
+      "function __ctHelpers() {}",
+      "function foo(): number { var __ctHelpers = 5; return __ctHelpers; }",
+      "var __ctHelpers: number = 5;",
+      "declare global { var __ctHelpers: any; }\nglobalThis.__ctHelpers = 5;",
+    ];
+
+    for (const statement of statements) {
+      await assertRejects(() =>
+        transformFiles({
+          "/main.ts": fixture + `\n${statement}`,
+        })
+      );
+    }
+  });
+
+  it("Allows '__ctHelpers' in comments and in other forms", async () => {
+    const statements = [
+      "var x = 5; // __ctHelpers",
+      "// __ctHelpers",
+      "/* __ctHelpers */",
+      "var __ctHelpers123: number = 5;",
+      "declare global {\nvar __ctHelpers1: any;\n}\nglobalThis.__ctHelpers1 = 5;",
+    ];
+    for (const statement of statements) {
+      await transformFiles({
+        "/main.ts": fixture + `\n${statement}`,
+      });
+    }
   });
 });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Detect the reserved __ctHelpers only when used as an identifier, instead of using a raw string check. This removes false positives from comments and similar names.

- **Bug Fixes**
  - Parse the TypeScript AST and throw only on Identifier("__ctHelpers").
  - Allow occurrences in comments and substrings (e.g., __ctHelpers123).
  - Added tests for both error and allowed cases.

<!-- End of auto-generated description by cubic. -->

