### PR TITLE
chore: Include jsx h function during pretransform, rather than requiring authors to provide

### DIFF
--- a/packages/patterns/array-in-cell-ast-nocomponents.tsx
+++ b/packages/patterns/array-in-cell-ast-nocomponents.tsx
@@ -1,5 +1,5 @@
 /// <cts-enable />
-import { Cell, Default, h, handler, NAME, recipe, UI } from "commontools";
+import { Cell, Default, handler, NAME, recipe, UI } from "commontools";
 
 interface Item {
   text: Default<string, "">;

--- a/packages/patterns/array-in-cell-with-remove-ast-nocomponents.tsx
+++ b/packages/patterns/array-in-cell-with-remove-ast-nocomponents.tsx
@@ -1,14 +1,5 @@
 /// <cts-enable />
-import {
-  Cell,
-  Default,
-  h,
-  handler,
-  NAME,
-  recipe,
-  Stream,
-  UI,
-} from "commontools";
+import { Cell, Default, handler, NAME, recipe, Stream, UI } from "commontools";
 
 interface Item {
   text: Default<string, "">;

--- a/packages/patterns/array-in-cell-with-remove-editable.tsx
+++ b/packages/patterns/array-in-cell-with-remove-editable.tsx
@@ -1,5 +1,5 @@
 /// <cts-enable />
-import { Cell, Default, h, handler, NAME, recipe, UI } from "commontools";
+import { Cell, Default, handler, NAME, recipe, UI } from "commontools";
 
 interface Item {
   text: Default<string, "">;

--- a/packages/patterns/aside.tsx
+++ b/packages/patterns/aside.tsx
@@ -4,7 +4,6 @@ import {
   cell,
   Default,
   derive,
-  h,
   handler,
   ifElse,
   lift,

--- a/packages/patterns/charm-ref-in-cell.tsx
+++ b/packages/patterns/charm-ref-in-cell.tsx
@@ -4,7 +4,6 @@ import {
   cell,
   Default,
   derive,
-  h,
   handler,
   ifElse,
   lift,

--- a/packages/patterns/charms-ref-in-cell.tsx
+++ b/packages/patterns/charms-ref-in-cell.tsx
@@ -4,7 +4,6 @@ import {
   cell,
   Default,
   derive,
-  h,
   handler,
   ifElse,
   lift,

--- a/packages/patterns/chatbot-list-view.tsx
+++ b/packages/patterns/chatbot-list-view.tsx
@@ -3,7 +3,6 @@ import {
   Cell,
   cell,
   Default,
-  h,
   handler,
   ID,
   ifElse,

--- a/packages/patterns/chatbot-note-composed.tsx
+++ b/packages/patterns/chatbot-note-composed.tsx
@@ -4,7 +4,6 @@ import {
   Cell,
   cell,
   Default,
-  h,
   handler,
   NAME,
   navigateTo,

--- a/packages/patterns/chatbot-outliner.tsx
+++ b/packages/patterns/chatbot-outliner.tsx
@@ -3,7 +3,6 @@ import {
   BuiltInLLMMessage,
   Cell,
   Default,
-  h,
   handler,
   ifElse,
   JSONSchema,

--- a/packages/patterns/chatbot.tsx
+++ b/packages/patterns/chatbot.tsx
@@ -7,7 +7,6 @@ import {
   derive,
   fetchData,
   generateObject,
-  h,
   handler,
   llmDialog,
   NAME,

--- a/packages/patterns/cheeseboard.tsx
+++ b/packages/patterns/cheeseboard.tsx
@@ -1,5 +1,5 @@
 /// <cts-enable />
-import { fetchData, h, lift, NAME, recipe, UI } from "commontools";
+import { fetchData, lift, NAME, recipe, UI } from "commontools";
 
 /**
  * Fetch the Cheeseboard pizza schedule via Toolshed's web-read endpoint and

--- a/packages/patterns/common-tools.tsx
+++ b/packages/patterns/common-tools.tsx
@@ -4,7 +4,6 @@ import {
   Cell,
   derive,
   fetchData,
-  h,
   handler,
   ifElse,
   recipe,

--- a/packages/patterns/counter.tsx
+++ b/packages/patterns/counter.tsx
@@ -1,5 +1,5 @@
 /// <cts-enable />
-import { Default, h, NAME, recipe, str, Stream, UI } from "commontools";
+import { Default, NAME, recipe, str, Stream, UI } from "commontools";
 import { decrement, increment, nth, previous } from "./counter-handlers.ts";
 
 interface RecipeState {

--- a/packages/patterns/ct-checkbox-cell.tsx
+++ b/packages/patterns/ct-checkbox-cell.tsx
@@ -1,14 +1,5 @@
 /// <cts-enable />
-import {
-  Cell,
-  Default,
-  h,
-  handler,
-  ifElse,
-  NAME,
-  recipe,
-  UI,
-} from "commontools";
+import { Cell, Default, handler, ifElse, NAME, recipe, UI } from "commontools";
 
 interface CheckboxSimpleInput {
   enabled: Default<boolean, false>;

--- a/packages/patterns/ct-checkbox-handler.tsx
+++ b/packages/patterns/ct-checkbox-handler.tsx
@@ -1,14 +1,5 @@
 /// <cts-enable />
-import {
-  Cell,
-  Default,
-  h,
-  handler,
-  ifElse,
-  NAME,
-  recipe,
-  UI,
-} from "commontools";
+import { Cell, Default, handler, ifElse, NAME, recipe, UI } from "commontools";
 
 interface CheckboxSimpleInput {
   enabled: Default<boolean, false>;

--- a/packages/patterns/ct-list.tsx
+++ b/packages/patterns/ct-list.tsx
@@ -1,5 +1,5 @@
 /// <cts-enable />
-import { Default, h, NAME, recipe, UI } from "commontools";
+import { Default, NAME, recipe, UI } from "commontools";
 
 interface Item {
   title: string;

--- a/packages/patterns/ct-render.tsx
+++ b/packages/patterns/ct-render.tsx
@@ -1,5 +1,5 @@
 /// <cts-enable />
-import { Cell, Default, h, handler, NAME, recipe, str, UI } from "commontools";
+import { Cell, Default, handler, NAME, recipe, str, UI } from "commontools";
 
 interface RecipeState {
   value: Default<number, 0>;

--- a/packages/patterns/ct-select.tsx
+++ b/packages/patterns/ct-select.tsx
@@ -1,6 +1,6 @@
 /// <cts-enable />
 
-import { Default, h, NAME, OpaqueRef, recipe, UI } from "commontools";
+import { Default, NAME, OpaqueRef, recipe, UI } from "commontools";
 
 type Input = {
   selected: Default<string, "">;

--- a/packages/patterns/ct-tags.tsx
+++ b/packages/patterns/ct-tags.tsx
@@ -1,6 +1,6 @@
 /// <cts-enable />
 
-import { Cell, Default, h, handler, NAME, recipe, UI } from "commontools";
+import { Cell, Default, handler, NAME, recipe, UI } from "commontools";
 
 type Input = {
   tags: string[];

--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -3,7 +3,6 @@ import {
   Cell,
   Default,
   derive,
-  h,
   handler,
   NAME,
   navigateTo,

--- a/packages/patterns/dice.tsx
+++ b/packages/patterns/dice.tsx
@@ -1,5 +1,5 @@
 /// <cts-enable />
-import { Default, h, NAME, recipe, Stream, UI } from "commontools";
+import { Default, NAME, recipe, Stream, UI } from "commontools";
 import { getValue, roll } from "./dice-handlers.ts";
 
 interface RecipeState {

--- a/packages/patterns/fetch-data.tsx
+++ b/packages/patterns/fetch-data.tsx
@@ -3,7 +3,6 @@ import {
   Default,
   derive,
   fetchData,
-  h,
   lift,
   NAME,
   recipe,

--- a/packages/patterns/instantiate-recipe.tsx
+++ b/packages/patterns/instantiate-recipe.tsx
@@ -2,7 +2,6 @@
 import {
   Cell,
   Default,
-  h,
   handler,
   NAME,
   navigateTo,

--- a/packages/patterns/linkedlist-in-cell.tsx
+++ b/packages/patterns/linkedlist-in-cell.tsx
@@ -4,7 +4,6 @@ import {
   cell,
   Default,
   derive,
-  h,
   handler,
   NAME,
   recipe,

--- a/packages/patterns/list-operations.tsx
+++ b/packages/patterns/list-operations.tsx
@@ -3,7 +3,6 @@ import {
   Cell,
   Default,
   derive,
-  h,
   handler,
   ID,
   lift,

--- a/packages/patterns/llm.tsx
+++ b/packages/patterns/llm.tsx
@@ -5,7 +5,6 @@ import {
   cell,
   Default,
   derive,
-  h,
   handler,
   llm,
   NAME,

--- a/packages/patterns/nested-counter.tsx
+++ b/packages/patterns/nested-counter.tsx
@@ -1,5 +1,5 @@
 /// <cts-enable />
-import { Default, h, NAME, recipe, str, UI } from "commontools";
+import { Default, NAME, recipe, str, UI } from "commontools";
 import { decrement, increment, nth, previous } from "./counter-handlers.ts";
 
 interface RecipeState {

--- a/packages/patterns/note.tsx
+++ b/packages/patterns/note.tsx
@@ -4,7 +4,6 @@ import {
   cell,
   Default,
   derive,
-  h,
   handler,
   lift,
   NAME,

--- a/packages/patterns/output_schema.tsx
+++ b/packages/patterns/output_schema.tsx
@@ -1,14 +1,5 @@
 /// <cts-enable />
-import {
-  Cell,
-  Default,
-  h,
-  handler,
-  NAME,
-  recipe,
-  UI,
-  VNode,
-} from "commontools";
+import { Cell, Default, handler, NAME, recipe, UI, VNode } from "commontools";
 
 const increment = handler<unknown, { value: Cell<number> }>((_, state) => {
   state.value.set(state.value.get() + 1);

--- a/packages/shell/integration/charm.test.ts
+++ b/packages/shell/integration/charm.test.ts
@@ -7,6 +7,7 @@ import { assert } from "@std/assert";
 import "../src/globals.ts";
 import { Identity } from "@commontools/identity";
 import { CharmsController } from "@commontools/charm/ops";
+import { FileSystemProgramResolver } from "@commontools/js-runtime";
 
 const { API_URL, SPACE_NAME, FRONTEND_URL } = env;
 
@@ -25,17 +26,19 @@ describe("shell charm tests", () => {
       apiUrl: new URL(API_URL),
       identity: identity,
     });
+    const sourcePath = join(
+      import.meta.dirname!,
+      "..",
+      "..",
+      "patterns",
+      "counter.tsx",
+    );
+    const program = await cc.manager().runtime.harness
+      .resolve(
+        new FileSystemProgramResolver(sourcePath),
+      );
     const charm = await cc.create(
-      await Deno.readTextFile(
-        join(
-          import.meta.dirname!,
-          "..",
-          "..",
-          "..",
-          "recipes",
-          "counter.tsx",
-        ),
-      ),
+      program,
       { start: false },
     );
     charmId = charm.id;

--- a/packages/ts-transformers/test/fixtures/ast-transform/builder-conditional.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/builder-conditional.expected.tsx
@@ -25,4 +25,7 @@ export default recipe({
       </section>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-recipe.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-recipe.expected.tsx
@@ -1,5 +1,5 @@
 import * as __ctHelpers from "commontools";
-import { Cell, Default, h, handler, NAME, recipe, str, UI } from "commontools";
+import { Cell, Default, handler, NAME, recipe, str, UI } from "commontools";
 interface CounterState {
     value: Cell<number>;
 }
@@ -54,4 +54,7 @@ export default recipe({
         value: state.value,
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-recipe.input.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-recipe.input.tsx
@@ -1,5 +1,5 @@
 /// <cts-enable />
-import { Cell, Default, h, handler, NAME, recipe, str, UI } from "commontools";
+import { Cell, Default, handler, NAME, recipe, str, UI } from "commontools";
 
 interface CounterState {
   value: Cell<number>;

--- a/packages/ts-transformers/test/fixtures/ast-transform/derive-object-literal-input.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/derive-object-literal-input.expected.tsx
@@ -54,4 +54,7 @@ const summary = derive({
     rejected: rejected,
 }, (snapshot) => `stage:${snapshot.stage} attempts:${snapshot.attempts}` +
     ` accepted:${snapshot.accepted} rejected:${snapshot.rejected}`);
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-derive.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-derive.expected.tsx
@@ -47,4 +47,7 @@ export default recipe({
         count,
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.tsx
@@ -30,4 +30,7 @@ export default recipe({ type: "object", properties: { value: { type: "number" },
         onClick3: myHandler(state),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/recipe-array-map.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/recipe-array-map.expected.tsx
@@ -48,4 +48,7 @@ export default recipe({
         values,
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.tsx
@@ -51,4 +51,7 @@ export default recipe({
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-alias.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-alias.expected.tsx
@@ -26,4 +26,7 @@ export const textLength = deriveAlias({
 } as const satisfies __ctHelpers.JSONSchema, state, (value) => ({
     length: value.text.length,
 }));
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-inside-jsx.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-inside-jsx.expected.tsx
@@ -8,4 +8,7 @@ export const result = (<div>
     type: "number"
 } as const satisfies __ctHelpers.JSONSchema, value, (v) => v * 2)}
   </div>);
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-multiple-returns.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-multiple-returns.expected.tsx
@@ -12,4 +12,7 @@ export const multiReturn = derive({
     }
     return 42;
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-untyped.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-untyped.expected.tsx
@@ -6,4 +6,7 @@ export const doubled = derive({
 } as const satisfies __ctHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __ctHelpers.JSONSchema, total, (value) => value * 2);
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive.expected.tsx
@@ -26,4 +26,7 @@ export const doubledValue = derive({
 } as const satisfies __ctHelpers.JSONSchema, source, (input) => ({
     doubled: input.count * 2,
 }));
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-both-inline.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-both-inline.expected.tsx
@@ -26,4 +26,7 @@ export const incrementer = handler({
 } as const satisfies __ctHelpers.JSONSchema, (event: IncrementEvent, state: CounterState) => {
     state.count += event.amount;
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-event-only.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-event-only.expected.tsx
@@ -15,4 +15,7 @@ export const incrementer = handler({
 } as const satisfies __ctHelpers.JSONSchema, true as const satisfies __ctHelpers.JSONSchema, (event: IncrementEvent, state) => {
     console.log("increment by", event.amount);
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-inside-jsx.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-inside-jsx.expected.tsx
@@ -48,4 +48,7 @@ export const result = (<div>
         lastPosition: { x: event.x, y: event.y },
     }))}
   </div>);
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-no-annotations.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-no-annotations.expected.tsx
@@ -4,4 +4,7 @@ import { handler } from "commontools";
 export const genericHandler = handler(true as const satisfies __ctHelpers.JSONSchema, true as const satisfies __ctHelpers.JSONSchema, (event, state) => {
     console.log("event:", event, "state:", state);
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-cell-array.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-cell-array.expected.tsx
@@ -59,4 +59,7 @@ const logCharmsList = lift({
     return charmsList;
 });
 export default logCharmsList;
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-inside-jsx.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-inside-jsx.expected.tsx
@@ -37,4 +37,7 @@ export const result = (<div>
         birthYear: currentYear - person.age,
     }))}
   </div>);
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-no-generics.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-no-generics.expected.tsx
@@ -25,4 +25,7 @@ export const doubleValue = lift({
 } as const satisfies __ctHelpers.JSONSchema, (args: LiftArgs): LiftResult => ({
     doubled: args.value * 2,
 }));
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-untyped.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-untyped.expected.tsx
@@ -3,4 +3,7 @@ import { lift } from "commontools";
 export const doubleValue = lift(true as const satisfies __ctHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __ctHelpers.JSONSchema, (value) => value * 2);
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift.expected.tsx
@@ -25,4 +25,7 @@ export const doubleValue = lift({
 } as const satisfies __ctHelpers.JSONSchema, ({ value }) => ({
     doubled: value * 2,
 }));
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/ast-transform/ternary_derive.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/ternary_derive.expected.tsx
@@ -20,4 +20,7 @@ export default recipe({
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/handler-schema/array-cell-remove-intersection.expected.ts
+++ b/packages/ts-transformers/test/fixtures/handler-schema/array-cell-remove-intersection.expected.ts
@@ -77,4 +77,7 @@ const removeItemAlias = handler(true as const satisfies __ctHelpers.JSONSchema, 
     items.set(next);
 });
 export { removeItem, removeItemAlias };
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.ts
+++ b/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.ts
@@ -121,4 +121,7 @@ export { userHandler };
 export default recipe("complex-nested-types test", () => {
     return { userHandler };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/handler-schema/date-and-map-types.expected.ts
+++ b/packages/ts-transformers/test/fixtures/handler-schema/date-and-map-types.expected.ts
@@ -63,4 +63,7 @@ const timedHandler = handler({
     });
 });
 export { timedHandler };
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas.expected.ts
+++ b/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas.expected.ts
@@ -16,4 +16,7 @@ const logHandler = handler(eventSchema, stateSchema, (event, state) => {
     state.log.push(event.message);
 });
 export { logHandler };
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/handler-schema/simple-handler.expected.ts
+++ b/packages/ts-transformers/test/fixtures/handler-schema/simple-handler.expected.ts
@@ -26,4 +26,7 @@ const myHandler = handler({
     state.value = state.value + event.increment;
 });
 export { myHandler };
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/handler-schema/unsupported-intersection-index.expected.ts
+++ b/packages/ts-transformers/test/fixtures/handler-schema/unsupported-intersection-index.expected.ts
@@ -19,4 +19,7 @@ const removeItem = handler(true as const satisfies __ctHelpers.JSONSchema, {
     items.get();
 });
 export { removeItem };
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/complex-expressions.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/complex-expressions.expected.tsx
@@ -28,4 +28,7 @@ export default recipe({
       </div>)
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-complex.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-complex.expected.tsx
@@ -169,4 +169,7 @@ export default recipe({
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-simple.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-simple.expected.tsx
@@ -51,4 +51,7 @@ export default recipe({
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-arithmetic-operations.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-arithmetic-operations.expected.tsx
@@ -45,4 +45,7 @@ export default recipe({
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.tsx
@@ -90,4 +90,7 @@ export default recipe({
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.tsx
@@ -61,4 +61,7 @@ export default recipe({
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-function-calls.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-function-calls.expected.tsx
@@ -79,4 +79,7 @@ export default recipe({
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.tsx
@@ -179,4 +179,7 @@ export default recipe({
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-string-operations.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-string-operations.expected.tsx
@@ -53,4 +53,7 @@ export default recipe({
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.tsx
@@ -184,4 +184,7 @@ export default recipe({
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/no-double-derive.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/no-double-derive.expected.tsx
@@ -20,4 +20,7 @@ export default function TestComponent({ items, cellRef }) {
       <span>Direct access: {cellRef.value}</span>
     </div>);
 }
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/no-transform-simple-ref.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/no-transform-simple-ref.expected.tsx
@@ -7,4 +7,7 @@ export default recipe("test", (state) => {
         [NAME]: "test",
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.tsx
@@ -113,4 +113,7 @@ export default recipe("Charms Launcher", () => {
         cellRef,
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-operations.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-operations.expected.tsx
@@ -12,4 +12,7 @@ export default recipe("OpaqueRefOperations", (state) => {
       </div>)
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-predicate.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-predicate.expected.tsx
@@ -9,4 +9,7 @@ export default recipe("Optional Chain Predicate", () => {
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.tsx
@@ -9,4 +9,7 @@ export default recipe("Optional Element Access", () => {
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/parent-suppression-edge.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/parent-suppression-edge.expected.tsx
@@ -391,4 +391,7 @@ export default recipe({
       </div>),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/recipe-statements-vs-jsx.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/recipe-statements-vs-jsx.expected.tsx
@@ -78,4 +78,7 @@ export default recipe({
         }
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/recipe-with-cells.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/recipe-with-cells.expected.tsx
@@ -18,4 +18,7 @@ export default recipe({
         value: cell.value,
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.tsx
@@ -106,4 +106,7 @@ export default recipe({
         increment: increment({ state }),
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/schema-transform/opaque-ref-map.expected.ts
+++ b/packages/ts-transformers/test/fixtures/schema-transform/opaque-ref-map.expected.ts
@@ -42,4 +42,7 @@ export default recipe({
     }));
     return { mapped, filtered };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/schema-transform/recipe-with-types.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/recipe-with-types.expected.tsx
@@ -142,4 +142,7 @@ export default recipe(inputSchema, outputSchema, ({ title, items }) => {
         items_count
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/schema-transform/with-opaque-ref.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/with-opaque-ref.expected.tsx
@@ -28,4 +28,7 @@ export default recipe(model, model, (cell) => {
         value: cell.value,
     };
 });
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/schema-transform/with-options.expected.ts
+++ b/packages/ts-transformers/test/fixtures/schema-transform/with-options.expected.ts
@@ -17,4 +17,7 @@ const configSchema = {
     description: "Configuration schema"
 } as const satisfies __ctHelpers.JSONSchema;
 export { configSchema };
-__ctHelpers.NAME; // <internals>
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/recipes/bgCounter.tsx
+++ b/recipes/bgCounter.tsx
@@ -3,7 +3,6 @@ import {
   Cell,
   Default,
   derive,
-  h,
   handler,
   NAME,
   recipe,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Automatically inject the JSX h function during pretransform so authors no longer need to import h. This also fixes prior treeshaking/binding issues with the helper module.

- **Refactors**
  - Pretransform defines a local h wrapper and h.fragment from commontools to make JSX work without explicit imports.
  - Removed h from imports across patterns.
  - Updated test fixtures to use the injected h wrapper instead of the previous internals sentinel.

<!-- End of auto-generated description by cubic. -->

