### PR TITLE
Work around `newNote` stack overflow

### DIFF
--- a/packages/patterns/chatbot-note-composed.tsx
+++ b/packages/patterns/chatbot-note-composed.tsx
@@ -66,7 +66,9 @@ const newNote = handler<
         `Created note ${args.title}!`,
       );
 
-      state.allCharms.push(n as unknown as MentionableCharm);
+      // TODO(bf): we have to navigate here until DX1 lands
+      // then we go back to pushing to allCharms
+      return navigateTo(n);
     } catch (error) {
       args.result.set(`Error: ${(error as any)?.message || "<error>"}`);
     }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Prevented a stack overflow when creating a new note by navigating to the new note instead of pushing it to allCharms.
This is a temporary workaround until DX1 lands.

<!-- End of auto-generated description by cubic. -->

