### PR TITLE
chore: remove unused imports

### DIFF
--- a/packages/memory/provider.ts
+++ b/packages/memory/provider.ts
@@ -16,7 +16,6 @@ import {
   InvocationURL,
   MemorySession,
   MemorySpace,
-  MIME,
   Proto,
   Protocol,
   ProviderCommand,

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -26,7 +26,6 @@ import type {
   Entity,
   FactSelection,
   MemorySpace,
-  MIME,
   SchemaQuery,
 } from "./interface.ts";
 import { SelectAllString } from "./schema.ts";

--- a/packages/runner/test/query.test.ts
+++ b/packages/runner/test/query.test.ts
@@ -20,7 +20,6 @@ import type {
   State,
   URI,
 } from "@commontools/memory/interface";
-import type { Entity } from "@commontools/memory/interface";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 import { Identity } from "@commontools/identity";


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed unused MIME and Entity imports from memory provider, space schema, and query test modules. Cleans up code and eliminates lint warnings.

<!-- End of auto-generated description by cubic. -->

