### PR TITLE
chore: Initial work specializing cell collection methods

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -23,9 +23,15 @@ export interface Cell<T = any> {
   set(value: T): void;
   send(value: T): void; // alias for set
   update(values: Partial<T>): void;
-  push(...value: T extends (infer U)[] ? U[] : never): void;
   equals(other: Cell<any>): boolean;
-  key<K extends keyof T>(valueKey: K): Cell<T[K]>;
+  push(
+    this: Cell<JSONArray | JSONObject>,
+    ...value: T extends (infer U)[] ? U[] : never
+  ): void;
+  key<K extends keyof T>(
+    this: Cell<JSONArray | JSONObject>,
+    valueKey: K,
+  ): Cell<T[K]>;
 }
 
 // Cell type with only public methods
@@ -58,6 +64,7 @@ export interface OpaqueRefMethods<T> {
   setName(name: string): void;
   setSchema(schema: JSONSchema): void;
   map<S>(
+    this: OpaqueRefMethods<JSONArray | JSONObject>,
     fn: (
       element: T extends Array<infer U> ? Opaque<U> : Opaque<T>,
       index: Opaque<number>,

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -63,6 +63,7 @@ export type {
   CreateCellFunction,
   Handler,
   HandlerFactory,
+  JSONArray,
   JSONObject,
   JSONSchema,
   JSONSchemaTypes,

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -6,6 +6,8 @@ import {
   ID,
   ID_FIELD,
   isStreamValue,
+  JSONArray,
+  JSONObject,
   type JSONSchema,
   type OpaqueRef,
   type Schema,
@@ -171,6 +173,7 @@ declare module "@commontools/api" {
       values: V extends object ? V : never,
     ): void;
     push(
+      this: Cell<JSONArray | JSONObject>,
       ...value: Array<
         | (T extends Array<infer U> ? (Cellify<U> | U) : any)
         | Cell
@@ -178,6 +181,7 @@ declare module "@commontools/api" {
     ): void;
     equals(other: any): boolean;
     key<K extends T extends Cell<infer S> ? keyof S : keyof T>(
+      this: Cell<JSONArray | JSONObject>,
       valueKey: K,
     ): Cell<
       T extends Cell<infer S> ? S[K & keyof S] : T[K] extends never ? any : T[K]
@@ -519,14 +523,19 @@ export class RegularCell<T> implements Cell<T> {
     }
   }
 
-  push(...value: T extends Array<infer U> ? U[] : never): void;
   push(
+    this: RegularCell<JSONArray | JSONObject>,
+    ...value: T extends Array<infer U> ? U[] : never
+  ): void;
+  push(
+    this: RegularCell<JSONArray | JSONObject>,
     ...value: Array<
       | (T extends Array<infer U> ? (Cellify<U> | U) : any)
       | Cell
     >
   ): void;
   push(
+    this: RegularCell<JSONArray | JSONObject>,
     ...value: any[]
   ): void {
     if (!this.tx) throw new Error("Transaction required for push");

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -14,9 +14,9 @@ export interface Cell<T = any> {
     set(value: T): void;
     send(value: T): void;
     update(values: Partial<T>): void;
-    push(...value: T extends (infer U)[] ? U[] : never): void;
     equals(other: Cell<any>): boolean;
-    key<K extends keyof T>(valueKey: K): Cell<T[K]>;
+    push(this: Cell<JSONArray | JSONObject>, ...value: T extends (infer U)[] ? U[] : never): void;
+    key<K extends keyof T>(this: Cell<JSONArray | JSONObject>, valueKey: K): Cell<T[K]>;
 }
 export interface Stream<T> {
     send(event: T): void;
@@ -34,7 +34,7 @@ export interface OpaqueRefMethods<T> {
     setDefault(value: Opaque<T> | T): void;
     setName(name: string): void;
     setSchema(schema: JSONSchema): void;
-    map<S>(fn: (element: T extends Array<infer U> ? Opaque<U> : Opaque<T>, index: Opaque<number>, array: T) => Opaque<S>): Opaque<S[]>;
+    map<S>(this: OpaqueRefMethods<JSONArray | JSONObject>, fn: (element: T extends Array<infer U> ? Opaque<U> : Opaque<T>, index: Opaque<number>, array: T) => Opaque<S>): Opaque<S[]>;
 }
 export interface Recipe {
     argumentSchema: JSONSchema;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Specialized Cell collection methods so push, key, and map only work on array/object cells, improving type safety and catching misuse at compile time. No runtime behavior changes; typings are tightened.

- **Refactors**
  - Restricted Cell.push and Cell.key via this: Cell<JSONArray | JSONObject>.
  - Restricted OpaqueRefMethods.map via this: OpaqueRefMethods<JSONArray | JSONObject>.
  - Exported JSONArray from runner types and updated generated .d.ts accordingly.

- **Migration**
  - If push/key/map were used on non-collection cells, update those call sites or adjust types.

<!-- End of auto-generated description by cubic. -->

