### PR TITLE
Use `getEntityId` with `resolveAsCell`

### DIFF
--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -218,7 +218,7 @@ export class CTCodeEditor extends BaseElement {
 
       // Build options from existing mentionable items
       const options: Completion[] = mentionable.map((charm) => {
-        const charmIdObj = getEntityId(charm);
+        const charmIdObj = getEntityId(charm.resolveAsCell());
         const charmId = charmIdObj?.["/"] || "";
         const charmName = charm.key(NAME).get() || "";
         const insertText = `${charmName} (${charmId})`;
@@ -400,7 +400,7 @@ export class CTCodeEditor extends BaseElement {
       // let the pattern know about the new backlink
       tx.commit();
 
-      const charmId = getEntityId(result);
+      const charmId = getEntityId(result.resolveAsCell());
 
       // Insert the ID into the text if we have an editor
       if (this._editorView && charmId) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix getEntityId to return the underlying entity’s ID for Cells with paths (e.g., array items via .key(i)) instead of a path-based composite. This removes ID mismatches and simplifies mention resolution in the code editor.

- **Bug Fixes**
  - getEntityId now dereferences Cells with non-empty paths and uses the inner entity ID when present; falls back to path-based ID otherwise.
  - Added tests covering arrays of Cells accessed via .key() to ensure IDs match the underlying items.
  - Simplified CTCodeEditor mention lookup to rely on the consistent ID from getEntityId.

<!-- End of auto-generated description by cubic. -->

