### PR TITLE
fix(scripts): log output path matches description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,6 @@ claude-research.key
 .page-agent-config.json
 .common.json
 .knowledge
-packages/local-dev-toolshed.log
+local-dev-toolshed.log
 local-dev-shell.log
 tools/ralph/logs/

--- a/scripts/start-local-dev.sh
+++ b/scripts/start-local-dev.sh
@@ -41,7 +41,7 @@ check_port 5173
 
 # Start shell dev server in background
 cd packages/shell
-deno task dev-local > ../../local-dev-shell.log 2>&1 &
+deno task dev-local > local-dev-shell.log 2>&1 &
 SHELL_PID=$!
 
 # Wait a moment for shell to start
@@ -49,7 +49,7 @@ sleep 2
 
 # Start toolshed dev server in background
 cd ../toolshed
-SHELL_URL=http://localhost:5173 deno task dev > ../local-dev-toolshed.log 2>&1 &
+SHELL_URL=http://localhost:5173 deno task dev > local-dev-toolshed.log 2>&1 &
 TOOLSHED_PID=$!
 
 # # Function to cleanup background processes


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Write dev logs to the package directories instead of the repo root, so paths match the script description. Update .gitignore to ignore local-dev-shell.log and local-dev-toolshed.log in any directory.

<!-- End of auto-generated description by cubic. -->

