### PR TITLE
chore: Add lift to bgAdmin util function

### DIFF
--- a/packages/background-charm-service/bgAdmin.tsx
+++ b/packages/background-charm-service/bgAdmin.tsx
@@ -1,5 +1,14 @@
 /// <cts-enable />
-import { Cell, Default, derive, handler, NAME, recipe, UI } from "commontools";
+import {
+  Cell,
+  Default,
+  derive,
+  handler,
+  lift,
+  NAME,
+  recipe,
+  UI,
+} from "commontools";
 
 const DISABLED_VIA_UI = "Disabled via UI";
 
@@ -112,9 +121,9 @@ function StatusIcon(
   );
 }
 
-function getRenderData(
+const getRenderData = lift((
   charm: BGCharmEntry,
-) {
+) => {
   const {
     integration,
     space: rawSpace,
@@ -150,7 +159,7 @@ Last run ${lastRunDate ? fromNow(lastRunDate) : "never"} ${
     integration,
     name,
   };
-}
+});
 
 const css = `
 .bg-charm-container {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Use commontools lift for getRenderData in bgAdmin to improve composability. No user-facing or behavioral changes.

- **Refactors**
  - Import lift and convert getRenderData to a lifted const function.
  - Render data shape and UI remain the same.

<!-- End of auto-generated description by cubic. -->

