### PR TITLE
feat(runner): throw errors instead of returning empty document on link cycles

### DIFF
--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -70,15 +70,17 @@ export function resolveLink(
 
   while (true) {
     if (iteration++ > MAX_PATH_RESOLUTION_LENGTH) {
-      logger.warn(`Link resolution iteration limit reached`);
-      return createEmptyResolvedFullLink(link); // = return link to empty document
+      logger.error(`Link resolution iteration limit reached`);
+      throw new Error(`Link resolution iteration limit reached`);
     }
 
     // Detect cycles.
     const key = JSON.stringify([link.space, link.id, link.path]);
     if (seen.has(key)) {
-      logger.warn(`Link cycle detected ${key}`);
-      return createEmptyResolvedFullLink(link); // = return link to empty document
+      logger.error(`Link cycle detected ${key} [${JSON.stringify([...seen])}]`);
+      throw new Error(
+        `Link cycle detected at ${key} [${JSON.stringify([...seen])}]`,
+      );
     }
     seen.add(key);
 
@@ -257,16 +259,4 @@ export function readMaybeLink(
   } else {
     return undefined;
   }
-}
-
-function createEmptyResolvedFullLink(
-  link: NormalizedFullLink,
-): ResolvedFullLink {
-  return {
-    ...link,
-    id: "data:application/json,{}",
-    path: [],
-    type: "application/json",
-    space: "did:null:null",
-  } satisfies NormalizedFullLink as unknown as ResolvedFullLink;
 }


### PR DESCRIPTION
Changed link resolution behavior to throw errors when detecting cycles or hitting iteration limits, rather than silently returning an empty document with a `did:null:null` space.

Changes:
- Modified `resolveLink()` to throw when cycle detected or iteration limit reached
- Removed `createEmptyResolvedFullLink()` helper that created the empty document
- Updated all related tests to expect thrown errors instead of undefined values
- Changed logger severity from warn to error for these conditions
- Enhanced cycle detection error message to include the seen path for debugging

This makes link resolution errors more explicit and easier to debug, rather than silently failing with an empty document that might be missed.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Link resolution now throws when detecting cycles or hitting the iteration limit, instead of returning an empty document (did:null:null). Error messages include the seen path and logs are raised to error.

- **Migration**
  - Catch and handle thrown errors from resolveLink() and cell.get().
  - Update tests to expect thrown errors instead of undefined or data:application/json,{}.

<!-- End of auto-generated description by cubic. -->

