### PR TITLE
chore: Set the LLM client's global host value to the provided API URL in CLI environment

### DIFF
--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -8,6 +8,7 @@ import { CharmsController } from "@commontools/charm/ops";
 import { join } from "@std/path";
 import { isVNode, type VNode } from "@commontools/html";
 import { FileSystemProgramResolver } from "@commontools/js-runtime";
+import { setLLMUrl } from "@commontools/llm";
 
 export interface EntryConfig {
   mainPath: string;
@@ -42,6 +43,7 @@ async function makeSession(config: SpaceConfig): Promise<Session> {
 }
 
 export async function loadManager(config: SpaceConfig): Promise<CharmManager> {
+  setLLMUrl(config.apiUrl);
   const session = await makeSession(config);
   // Use a const ref object so we can assign later while keeping const binding
   const charmManagerRef: { current?: CharmManager } = {};


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Set the CLI LLM client to use the configured API URL by calling setLLMUrl(config.apiUrl) during manager load. Ensures all CLI LLM requests go to the provided endpoint instead of the default.

<!-- End of auto-generated description by cubic. -->

