### PR TITLE
Update rss recipe

### DIFF
--- a/recipes/dom-parser.test.ts
+++ b/recipes/dom-parser.test.ts
@@ -1,0 +1,62 @@
+import { DOMParser } from "./dom-parser.ts";
+import { assert } from "@std/assert";
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xml:lang="en-US" xmlns="http://www.w3.org/2005/Atom">
+  <id>tag:www.githubstatus.com,2005:/history</id>
+  <link rel="alternate" type="text/html" href="https://www.githubstatus.com"/>
+  <link rel="self" type="application/atom+xml" href="https://www.githubstatus.com/history.atom"/>
+  <title>GitHub Status - Incident History</title>
+  <updated>2025-10-21T20:25:22Z</updated>
+  <author>
+    <name>GitHub</name>
+  </author>
+  <entry>
+    <id>tag:www.githubstatus.com,2005:Incident/26837586</id>
+    <published>2025-10-21T17:39:34Z</published>
+    <updated>2025-10-21T17:39:34Z</updated>
+    <link rel="alternate" type="text/html" href="https://www.githubstatus.com/incidents/v61nk2fpysnq"/>
+    <title>Disruption with some GitHub services</title>
+    <content type="html">&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;21&lt;/var&gt;, &lt;var data-var='time'&gt;17:39&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Resolved&lt;/strong&gt; - This incident has been resolved. Thank you for your patience and understanding as we addressed this issue. A detailed root cause analysis will be shared as soon as it is available.&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;21&lt;/var&gt;, &lt;var data-var='time'&gt;17:18&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Update&lt;/strong&gt; - Mitigation continues, the impact is limited to Enterprise Cloud customers who have configured SAML at the organization level.&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;21&lt;/var&gt;, &lt;var data-var='time'&gt;17:11&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Update&lt;/strong&gt; - We continuing to work on mitigation of this issue.&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;21&lt;/var&gt;, &lt;var data-var='time'&gt;16:33&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Update&lt;/strong&gt; - We’ve identified the issue affecting some users with SAML/OIDC authentication and are actively working on mitigation. Some users may not be able to authenticate during this time.&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;21&lt;/var&gt;, &lt;var data-var='time'&gt;16:03&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Update&lt;/strong&gt; - We're seeing issues for a small amount of customers with SAML/OIDC authentication for GitHub.com users. We are investigating.&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;21&lt;/var&gt;, &lt;var data-var='time'&gt;16:00&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Investigating&lt;/strong&gt; - We are currently investigating this issue.&lt;/p&gt;</content>
+  </entry>
+  <entry>
+    <id>tag:www.githubstatus.com,2005:Incident/26833707</id>
+    <published>2025-10-21T12:28:19Z</published>
+    <updated>2025-10-21T12:28:19Z</updated>
+    <link rel="alternate" type="text/html" href="https://www.githubstatus.com/incidents/qqd6b1xb63tq"/>
+    <title>Incident with Actions</title>
+    <content type="html">&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;21&lt;/var&gt;, &lt;var data-var='time'&gt;12:28&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Resolved&lt;/strong&gt; - This incident has been resolved. Thank you for your patience and understanding as we addressed this issue. A detailed root cause analysis will be shared as soon as it is available.&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;21&lt;/var&gt;, &lt;var data-var='time'&gt;11:59&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Update&lt;/strong&gt; - We were able to apply a mitigation and we are now seeing recovery.&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;21&lt;/var&gt;, &lt;var data-var='time'&gt;11:37&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Update&lt;/strong&gt; - We are seeing about 10% of Actions runs taking longer than 5 minutes to start, we're still investigating and will provide an update by 12:00 UTC.&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;21&lt;/var&gt;, &lt;var data-var='time'&gt;09:59&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Update&lt;/strong&gt; - We are still seeing delays in starting some Actions runs and are currently investigating. We will provide updates as we have more information.&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;21&lt;/var&gt;, &lt;var data-var='time'&gt;09:25&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Update&lt;/strong&gt; - We are seeing delays in starting some Actions runs and are currently investigating.&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;21&lt;/var&gt;, &lt;var data-var='time'&gt;09:12&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Investigating&lt;/strong&gt; - We are investigating reports of degraded performance for Actions&lt;/p&gt;</content>
+  </entry>
+  <entry>
+    <id>tag:www.githubstatus.com,2005:Incident/26820913</id>
+    <published>2025-10-20T16:40:02Z</published>
+    <updated>2025-10-21T20:25:22Z</updated>
+    <link rel="alternate" type="text/html" href="https://www.githubstatus.com/incidents/9klytnsknx20"/>
+    <title>Disruption with Grok Code Fast 1 in Copilot</title>
+    <content type="html">&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;20&lt;/var&gt;, &lt;var data-var='time'&gt;16:40&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Resolved&lt;/strong&gt; - From October 20th at 14:10 UTC until 16:40 UTC, the Copilot service experienced degradation due to an infrastructure issue which impacted the Grok Code Fast 1 model, leading to a spike in errors affecting 30% of users. No other models were impacted. The incident was caused due to an outage with an upstream provider.&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;20&lt;/var&gt;, &lt;var data-var='time'&gt;16:39&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Update&lt;/strong&gt; - The issues with our upstream model provider continue to improve, and Grok Code Fast 1 is once again stable in Copilot Chat, VS Code and other Copilot products.&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;20&lt;/var&gt;, &lt;var data-var='time'&gt;16:07&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Update&lt;/strong&gt; - We are continuing to work with our provider on resolving the incident with Grok Code Fast 1 which is impacting 6% of users. We’ve been informed they are implementing fixes but users can expect some requests to intermittently fail until all issues are resolved.&lt;br /&gt;&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;20&lt;/var&gt;, &lt;var data-var='time'&gt;14:47&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Update&lt;/strong&gt; - We are experiencing degraded availability for the Grok Code Fast 1 model in Copilot Chat, VS Code and other Copilot products. This is due to an issue with an upstream model provider. We are working with them to resolve the issue.&lt;br /&gt;&lt;br /&gt;Other models are available and working as expected.&lt;/p&gt;&lt;p&gt;&lt;small&gt;Oct &lt;var data-var='date'&gt;20&lt;/var&gt;, &lt;var data-var='time'&gt;14:46&lt;/var&gt; UTC&lt;/small&gt;&lt;br&gt;&lt;strong&gt;Investigating&lt;/strong&gt; - We are investigating reports of degraded performance for Copilot&lt;/p&gt;</content>
+  </entry>
+</feed>
+`;
+
+Deno.test("DOMParser parsers XML", () => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xml, "text/xml");
+  const entries = doc.getElementsByTagName("entry");
+  assert(entries.length === 3, "Got 3 entries");
+  const entry = entries[0]!;
+  assert(
+    entry.getElementsByTagName("link")[0]!.getAttribute("rel") ===
+      "alternate",
+    "Get attribute from element",
+  );
+  assert(
+    entry.getElementsByTagName("title")[0]!.innerHTML ===
+      "Disruption with some GitHub services",
+    "Get innerHTML",
+  );
+  assert(
+    entry.getElementsByTagName("title")[0]!.textContent ===
+      "Disruption with some GitHub services",
+    "Get textContent",
+  );
+});

--- a/recipes/dom-parser.ts
+++ b/recipes/dom-parser.ts
@@ -1,0 +1,399 @@
+// LLM Generated
+// Simple DOM Parser interface for browser/deno execution.
+// In lieu of 3P module support, and the alternate solution requiring all
+// 3P modules to be checked into the workspace, this seems like the most simple solution.
+
+interface Node {
+  nodeType: number;
+  nodeName: string;
+  parentNode: Node | null;
+  childNodes: Node[];
+  textContent: string | null;
+}
+
+interface Element extends Node {
+  tagName: string;
+  attributes: Map<string, string>;
+  children: Element[];
+
+  // Query methods
+  getElementsByTagName(tagName: string): Element[];
+  querySelector(selector: string): Element | null;
+  querySelectorAll(selector: string): Element[];
+
+  // Attribute methods
+  getAttribute(name: string): string | null;
+  setAttribute(name: string, value: string): void;
+  hasAttribute(name: string): boolean;
+  removeAttribute(name: string): void;
+
+  // Content methods
+  appendChild(child: Element): Element;
+  removeChild(child: Element): Element;
+
+  // Properties
+  innerHTML: string;
+  outerHTML: string;
+  id: string;
+  className: string;
+}
+
+interface Document extends Node {
+  documentElement: Element | null;
+
+  // Query methods
+  getElementsByTagName(tagName: string): Element[];
+  querySelector(selector: string): Element | null;
+  querySelectorAll(selector: string): Element[];
+  getElementById(id: string): Element | null;
+
+  // Creation methods
+  createElement(tagName: string): Element;
+}
+
+class MinimalElement implements Element {
+  nodeType = 1;
+  nodeName: string;
+  tagName: string;
+  parentNode: Node | null = null;
+  childNodes: Node[] = [];
+  children: Element[] = [];
+  attributes: Map<string, string> = new Map();
+  textContent: string | null = null;
+  innerHTML = "";
+
+  constructor(tagName: string) {
+    this.tagName = tagName.toUpperCase();
+    this.nodeName = this.tagName;
+  }
+
+  // Attribute methods
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name.toLowerCase()) || null;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name.toLowerCase(), value);
+  }
+
+  hasAttribute(name: string): boolean {
+    return this.attributes.has(name.toLowerCase());
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name.toLowerCase());
+  }
+
+  // Query methods
+  getElementsByTagName(tagName: string): Element[] {
+    const results: Element[] = [];
+    const tag = tagName.toUpperCase();
+
+    if (tag === "*" || this.tagName === tag) {
+      results.push(this);
+    }
+
+    for (const child of this.children) {
+      results.push(...child.getElementsByTagName(tagName));
+    }
+
+    return results;
+  }
+
+  querySelector(selector: string): Element | null {
+    const results = this.querySelectorAll(selector);
+    return results[0] || null;
+  }
+
+  querySelectorAll(selector: string): Element[] {
+    // Very basic selector support: tagName, #id, .class, [attr]
+    const results: Element[] = [];
+
+    // Tag selector
+    if (/^[a-z]+$/i.test(selector)) {
+      return this.getElementsByTagName(selector);
+    }
+
+    // ID selector
+    if (selector.startsWith("#")) {
+      const id = selector.slice(1);
+      this.traverse((el) => {
+        if (el.id === id) results.push(el);
+      });
+      return results;
+    }
+
+    // Class selector
+    if (selector.startsWith(".")) {
+      const className = selector.slice(1);
+      this.traverse((el) => {
+        if (el.className.split(/\s+/).includes(className)) {
+          results.push(el);
+        }
+      });
+      return results;
+    }
+
+    // Attribute selector [attr] or [attr=value]
+    const attrMatch = selector.match(/^\[([^=\]]+)(?:="?([^"\]]+)"?)?\]$/);
+    if (attrMatch) {
+      const [, attrName, attrValue] = attrMatch;
+      this.traverse((el) => {
+        if (attrValue !== undefined) {
+          if (el.getAttribute(attrName) === attrValue) {
+            results.push(el);
+          }
+        } else {
+          if (el.hasAttribute(attrName)) {
+            results.push(el);
+          }
+        }
+      });
+      return results;
+    }
+
+    return results;
+  }
+
+  private traverse(callback: (el: Element) => void): void {
+    callback(this);
+    for (const child of this.children) {
+      (child as MinimalElement).traverse(callback);
+    }
+  }
+
+  // DOM manipulation
+  appendChild(child: Element): Element {
+    child.parentNode = this;
+    this.children.push(child);
+    this.childNodes.push(child);
+    return child;
+  }
+
+  removeChild(child: Element): Element {
+    const index = this.children.indexOf(child);
+    if (index > -1) {
+      this.children.splice(index, 1);
+      this.childNodes.splice(index, 1);
+      child.parentNode = null;
+    }
+    return child;
+  }
+
+  // Properties
+  get id(): string {
+    return this.getAttribute("id") || "";
+  }
+
+  set id(value: string) {
+    this.setAttribute("id", value);
+  }
+
+  get className(): string {
+    return this.getAttribute("class") || "";
+  }
+
+  set className(value: string) {
+    this.setAttribute("class", value);
+  }
+
+  get outerHTML(): string {
+    const attrs = Array.from(this.attributes.entries())
+      .map(([name, value]) => ` ${name}="${value}"`)
+      .join("");
+
+    if (this.children.length === 0 && !this.innerHTML) {
+      return `<${this.tagName.toLowerCase()}${attrs} />`;
+    }
+
+    return `<${this.tagName.toLowerCase()}${attrs}>${this.innerHTML}</${this.tagName.toLowerCase()}>`;
+  }
+
+  set outerHTML(value: string) {
+    this.innerHTML = value;
+  }
+}
+
+class MinimalDocument implements Document {
+  nodeType = 9;
+  nodeName = "#document";
+  parentNode: Node | null = null;
+  childNodes: Node[] = [];
+  textContent: string | null = null;
+  documentElement: Element | null = null;
+
+  createElement(tagName: string): Element {
+    return new MinimalElement(tagName);
+  }
+
+  getElementsByTagName(tagName: string): Element[] {
+    if (!this.documentElement) return [];
+    return this.documentElement.getElementsByTagName(tagName);
+  }
+
+  querySelector(selector: string): Element | null {
+    if (!this.documentElement) return null;
+    return this.documentElement.querySelector(selector);
+  }
+
+  querySelectorAll(selector: string): Element[] {
+    if (!this.documentElement) return [];
+    return this.documentElement.querySelectorAll(selector);
+  }
+
+  getElementById(id: string): Element | null {
+    return this.querySelector(`#${id}`);
+  }
+}
+
+class DOMParser {
+  parseFromString(source: string, mimeType: DOMParserSupportedType): Document {
+    if (mimeType === "text/html" || mimeType === "application/xhtml+xml") {
+      return this.parseHTML(source);
+    } else if (mimeType === "text/xml" || mimeType === "application/xml") {
+      return this.parseXML(source);
+    }
+
+    throw new Error(`Unsupported MIME type: ${mimeType}`);
+  }
+
+  private parseHTML(source: string): Document {
+    const doc = new MinimalDocument();
+    const html = doc.createElement("html");
+    doc.documentElement = html;
+
+    // Very basic parsing - extract body
+    const bodyMatch = source.match(/<body[^>]*>([\s\S]*)<\/body>/i);
+    if (bodyMatch) {
+      const body = this.parseElement(source, "body", doc);
+      if (body) html.appendChild(body);
+    }
+
+    return doc;
+  }
+
+  private parseXML(source: string): Document {
+    const doc = new MinimalDocument();
+
+    // Remove XML declaration and other processing instructions
+    let cleanSource = source.replace(/<\?xml[^?]*\?>/gi, "");
+    cleanSource = cleanSource.replace(/<\?[^?]*\?>/g, "");
+    cleanSource = cleanSource.trim();
+
+    // Find the root element (first opening tag)
+    const rootMatch = cleanSource.match(/<([^>\s/]+)/);
+
+    if (rootMatch) {
+      const tagName = rootMatch[1];
+      const root = this.parseElement(cleanSource, tagName, doc);
+      if (root) doc.documentElement = root;
+    }
+
+    return doc;
+  }
+
+  private parseElement(
+    source: string,
+    tagName: string,
+    doc: Document,
+  ): Element | null {
+    const element = doc.createElement(tagName);
+
+    // Parse attributes
+    const tagPattern = new RegExp(`<${tagName}([^>]*)>`, "i");
+    const tagMatch = source.match(tagPattern);
+
+    if (tagMatch && tagMatch[1]) {
+      const attrPattern = /(\w+)="([^"]*)"/g;
+      let attrMatch;
+      while ((attrMatch = attrPattern.exec(tagMatch[1])) !== null) {
+        element.setAttribute(attrMatch[1], attrMatch[2]);
+      }
+    }
+
+    // Parse innerHTML (simplified)
+    const contentPattern = new RegExp(
+      `<${tagName}[^>]*>([\\s\\S]*?)</${tagName}>`,
+      "i",
+    );
+    const contentMatch = source.match(contentPattern);
+    if (!contentMatch || !contentMatch[1]) {
+      return element;
+    }
+
+    const content = contentMatch[1];
+
+    // Parse child elements recursively
+    const childTagPattern = /<([^>\s/]+)(?:\s[^>]*)?\/?>/g;
+    let match;
+    let lastIndex = 0;
+
+    while ((match = childTagPattern.exec(content)) !== null) {
+      const childTagName = match[1];
+      const childStartIndex = match.index;
+
+      // Add any text content before this child element
+      if (childStartIndex > lastIndex) {
+        const textContent = content.substring(lastIndex, childStartIndex)
+          .trim();
+        if (textContent) {
+          // Store as innerHTML for text nodes (simplified)
+          element.innerHTML += textContent;
+          element.textContent = textContent;
+        }
+      }
+
+      // Find the full child element (from opening to closing tag or self-closing)
+      let childSource;
+      if (match[0].endsWith("/>")) {
+        // Self-closing tag
+        childSource = match[0];
+        lastIndex = childStartIndex + match[0].length;
+      } else {
+        // Find matching closing tag
+        const childContentPattern = new RegExp(
+          `<${childTagName}[^>]*>([\\s\\S]*?)</${childTagName}>`,
+          "i",
+        );
+        const childContentMatch = content.substring(childStartIndex).match(
+          childContentPattern,
+        );
+
+        if (childContentMatch) {
+          childSource = childContentMatch[0];
+          lastIndex = childStartIndex + childSource.length;
+        } else {
+          lastIndex = childStartIndex + match[0].length;
+          continue;
+        }
+      }
+
+      // Recursively parse the child element
+      const childElement = this.parseElement(childSource, childTagName, doc);
+      if (childElement) {
+        element.appendChild(childElement);
+      }
+    }
+
+    // Add any remaining text content after the last child
+    if (lastIndex < content.length) {
+      const textContent = content.substring(lastIndex).trim();
+      if (textContent) {
+        element.innerHTML += textContent;
+        element.textContent = textContent;
+      }
+    }
+
+    return element;
+  }
+}
+
+type DOMParserSupportedType =
+  | "text/html"
+  | "text/xml"
+  | "application/xml"
+  | "application/xhtml+xml"
+  | "image/svg+xml";
+
+export { DOMParser };
+export type { Document, Element, Node };


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the RSS importer to use a lightweight, built-in DOM parser and a reactive fetch/parse pipeline, reducing dependencies and preventing duplicates. The UI was simplified and sensible defaults were added for easier setup.

- **New Features**
  - Added a minimal DOMParser for XML/HTML with basic selectors.
  - Included a test validating XML parsing against an Atom sample.

- **Refactors**
  - Reworked rss.tsx to use fetchData + derive + lift and split parsing into parseRSSFeed.
  - Switched to ct-input and inline style objects; removed the “Import Limit” input.
  - Improved Atom detection and item de-duplication using a Set of IDs.
  - Set default settings in the recipe (feedUrl "", limit 100).

<!-- End of auto-generated description by cubic. -->

