### PR TITLE
Expose `searchWeb`, `readWebpage` and `calculator` tools to omnibot

### DIFF
--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -18,6 +18,7 @@ import ChatbotOutliner from "./chatbot-outliner.tsx";
 import { default as Note } from "./note.tsx";
 import BacklinksIndex, { type MentionableCharm } from "./backlinks-index.tsx";
 import ChatList from "./chatbot-list-view.tsx";
+import { calculator, readWebpage, searchWeb } from "./common-tools.tsx";
 
 export type Charm = {
   [NAME]?: string;
@@ -112,7 +113,17 @@ export default recipe<CharmsListInput, CharmsListOutput>(
 
     const omnibot = Chatbot({
       messages: [],
-      tools: undefined,
+      tools: {
+        searchWeb: {
+          pattern: searchWeb,
+        },
+        readWebpage: {
+          pattern: readWebpage,
+        },
+        calculator: {
+          pattern: calculator,
+        },
+      },
     });
 
     return {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Expose web search, webpage reading, and calculator tools to omnibot to deliver richer answers and on-the-fly math. These tools are now registered in the Chatbot config.

- **New Features**
  - Exposed searchWeb, readWebpage, and calculator from common-tools.
  - Registered them under Chatbot.tools for omnibot.

<!-- End of auto-generated description by cubic. -->

