### PR TITLE
fix(api): fn in OpaqueRef.map(fn) gets OpaqueRef arguments

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -60,11 +60,11 @@ export interface OpaqueRefMethods<T> {
   setSchema(schema: JSONSchema): void;
   map<S>(
     fn: (
-      element: T extends Array<infer U> ? Opaque<U> : Opaque<T>,
-      index: Opaque<number>,
-      array: T,
+      element: T extends Array<infer U> ? OpaqueRef<U> : OpaqueRef<T>,
+      index: OpaqueRef<number>,
+      array: OpaqueRef<T>,
     ) => Opaque<S>,
-  ): Opaque<S[]>;
+  ): OpaqueRef<S[]>;
 }
 
 // Factory types

--- a/packages/runner/src/builder/opaque-ref.ts
+++ b/packages/runner/src/builder/opaque-ref.ts
@@ -120,8 +120,8 @@ export function opaqueRef<T>(
       },
       map: <S>(
         fn: (
-          element: Opaque<Required<T extends Array<infer U> ? U : T>>,
-          index: Opaque<number>,
+          element: OpaqueRef<Required<T extends Array<infer U> ? U : T>>,
+          index: OpaqueRef<number>,
           array: T,
         ) => Opaque<S>,
       ) => {

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -123,11 +123,11 @@ declare module "@commontools/api" {
     unsafe_getExternal(): OpaqueRef<T>;
     map<S>(
       fn: (
-        element: T extends Array<infer U> ? Opaque<U> : Opaque<T>,
-        index: Opaque<number>,
-        array: T,
+        element: T extends Array<infer U> ? OpaqueRef<U> : OpaqueRef<T>,
+        index: OpaqueRef<number>,
+        array: OpaqueRef<T>,
       ) => Opaque<S>,
-    ): Opaque<S[]>;
+    ): OpaqueRef<S[]>;
     toJSON(): unknown;
     [Symbol.iterator](): Iterator<T>;
     [Symbol.toPrimitive](hint: string): T;

--- a/packages/static/assets/types/commontools.d.ts
+++ b/packages/static/assets/types/commontools.d.ts
@@ -35,7 +35,7 @@ export interface OpaqueRefMethods<T> {
     setDefault(value: Opaque<T> | T): void;
     setName(name: string): void;
     setSchema(schema: JSONSchema): void;
-    map<S>(fn: (element: T extends Array<infer U> ? Opaque<U> : Opaque<T>, index: Opaque<number>, array: T) => Opaque<S>): Opaque<S[]>;
+    map<S>(fn: (element: T extends Array<infer U> ? OpaqueRef<U> : OpaqueRef<T>, index: OpaqueRef<number>, array: OpaqueRef<T>) => Opaque<S>): OpaqueRef<S[]>;
 }
 export interface Recipe {
     argumentSchema: JSONSchema;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix OpaqueRef.map so the callback receives OpaqueRef arguments (element, index, array) and the method returns OpaqueRef<S[]> instead of Opaque types. This aligns types across the API, runner, and d.ts and improves type safety and consistency.

<!-- End of auto-generated description by cubic. -->

