### PR TITLE
fix: Correct syntax error when shutdown called before BG service is running

### DIFF
--- a/packages/background-charm-service/src/main.ts
+++ b/packages/background-charm-service/src/main.ts
@@ -39,15 +39,16 @@ const service = new BackgroundCharmService({
   workerTimeoutMs,
 });
 
-const shutdown = () => {
-  // @ts-ignore: Object is possibly 'undefined'
-  service.stop().then(() => {
-    Deno.exit(0);
-  });
-};
+function shutdown(service: BackgroundCharmService) {
+  return () => {
+    service.stop().then(() => {
+      Deno.exit(0);
+    });
+  };
+}
 
-Deno.addSignalListener("SIGINT", shutdown);
-Deno.addSignalListener("SIGTERM", shutdown);
+Deno.addSignalListener("SIGINT", shutdown(service));
+Deno.addSignalListener("SIGTERM", shutdown(service));
 
 service.initialize().then(() => {
   console.log("Background Charm Service started successfully");

--- a/packages/background-charm-service/src/service.ts
+++ b/packages/background-charm-service/src/service.ts
@@ -57,11 +57,11 @@ export class BackgroundCharmService {
     this.charmsCell.sink((cs) => this.ensureCharms(cs));
   }
 
-  stop() {
+  stop(): Promise<PromiseSettledResult<void>[]> {
     // FIXME(ja): stop listening to the charms cell ?
     if (!this.isRunning) {
       console.log("Service is not running");
-      return;
+      return Promise.resolve([]);
     }
 
     const promises = Array.from(this.charmSchedulers.values()).map(


### PR DESCRIPTION
Occurs when running bg worker in prod. TBD on what is actually terminating the server to cause this

```
   at [0m[1m[3mshutdown[0m ([0m[36mfile:///tmp/deno-compile-bg-charm-service/packages/background-charm-service/src/main.ts[0m:[0m[33m44[0m:[0m[33m15[0m)
   service.stop().then(() => {
[0m[1m[31merror[0m: Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'then')
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a crash during shutdown when the background service isn’t running by making stop() always return a Promise and by binding signal handlers to a service-aware shutdown function. Prevents the TypeError and ensures graceful exits in production.

- **Bug Fixes**
  - stop() now returns a Promise in all cases (returns Promise.resolve([]) when not running), avoiding .then on undefined.
  - Reworked shutdown to capture the service (shutdown(service)) for SIGINT/SIGTERM, removing the ts-ignore and ensuring consistent behavior.

<!-- End of auto-generated description by cubic. -->

