### PR TITLE
chore(runner): minor type cleanup related to wishes

### DIFF
--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -24,12 +24,11 @@ function resolveWishTarget(
   runtime: IRuntime,
   space: MemorySpace,
   tx: IExtendedStorageTransaction,
-): Cell<unknown> | undefined {
-  const path = resolution.path ? [...resolution.path] : [];
+): Cell<any> | undefined {
   return runtime.getCellFromEntityId(
     space,
     resolution.entityId,
-    path,
+    resolution.path,
     undefined,
     tx,
   );
@@ -122,13 +121,12 @@ export function wish(
       return;
     }
 
-    let resolvedCell = baseCell;
+    let resolvedCell = baseCell.withTx(tx);
     for (const segment of parsed.path) {
-      resolvedCell = resolvedCell.withTx(tx).key(
-        segmentToPropertyKey(segment) as never,
-      );
+      resolvedCell = resolvedCell.key(segmentToPropertyKey(segment));
     }
+    resolvedCell = resolvedCell.resolveAsCell();
 
-    sendResult(tx, resolvedCell.withTx(tx));
+    sendResult(tx, resolvedCell);
   };
 }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -132,14 +132,14 @@ export interface IRuntime {
   getCellFromEntityId<S extends JSONSchema = JSONSchema>(
     space: MemorySpace,
     entityId: EntityId,
-    path: PropertyKey[],
-    schema: S,
+    path: readonly PropertyKey[],
+    schema: JSONSchema,
     tx?: IExtendedStorageTransaction,
   ): Cell<Schema<S>>;
   getCellFromEntityId<T>(
     space: MemorySpace,
     entityId: EntityId,
-    path?: PropertyKey[],
+    path?: readonly PropertyKey[],
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
   ): Cell<T>;
@@ -490,21 +490,21 @@ export class Runtime implements IRuntime {
   getCellFromEntityId<T>(
     space: MemorySpace,
     entityId: EntityId | string,
-    path?: PropertyKey[],
+    path?: readonly PropertyKey[],
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
   ): Cell<T>;
   getCellFromEntityId<S extends JSONSchema = JSONSchema>(
     space: MemorySpace,
     entityId: EntityId | string,
-    path: PropertyKey[],
+    path: readonly PropertyKey[],
     schema: S,
     tx?: IExtendedStorageTransaction,
   ): Cell<Schema<S>>;
   getCellFromEntityId(
     space: MemorySpace,
     entityId: EntityId | string,
-    path: PropertyKey[] = [],
+    path: readonly PropertyKey[] = [],
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
   ): Cell<any> {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Streamlined wish resolution and runtime cell access by using readonly paths and removing redundant transaction binding. This clarifies types and avoids unnecessary path copies and casts.

- **Refactors**
  - getCellFromEntityId now accepts readonly PropertyKey[]; default path updated; schema parameter normalized to JSONSchema.
  - wish: pass resolution.path directly, bind tx once (baseCell.withTx(tx)), remove per-segment withTx and final withTx, and resolveAsCell before sending.
  - Updated types for consistency (e.g., resolveWishTarget returns Cell<any>).

<!-- End of auto-generated description by cubic. -->

