### PR TITLE
move UI_TESTING.md to runtime, remove DEVELOPMENT.md for patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,12 +17,8 @@ Skills (recipe-dev) to do the work.
   ct-select, etc.) with bidirectional binding and event handling patterns
 - `docs/common/PATTERNS.md` - High-level patterns and examples for building
   applications, including common mistakes and debugging tips
-- `docs/common/DEVELOPMENT.md` - Coding style, design principles, and best
-  practices
 - `packages/patterns/INDEX.md` - Catalog of all pattern examples with summaries,
   data types, and keywords
-- `docs/common/UI_TESTING.md` - How to work with shadow dom in our integration
-  tests
 
 **Important:** Ignore the top level `recipes` folder - it is defunct.
 
@@ -34,3 +30,5 @@ If you are developing runtime code, read the following documentation:
   overview
 - `docs/common/DEVELOPMENT.md` - Coding style, design principles, and best
   practices
+- `docs/common/UI_TESTING.md` - How to work with shadow dom in our integration
+  tests


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated AGENTS.md to reflect doc reorg: moved UI_TESTING.md to the runtime docs section and removed the patterns DEVELOPMENT.md reference. This clarifies where to find UI testing guidance and removes an outdated link.

<!-- End of auto-generated description by cubic. -->

