### PR TITLE
chore: Update jsx CellLike<T> to recursively allow its wrapper types

### DIFF
--- a/packages/static/assets/types/jsx.d.ts
+++ b/packages/static/assets/types/jsx.d.ts
@@ -2,7 +2,8 @@ import type { OpaqueRef, Cell, Props, RenderNode, VNode, Stream } from "commonto
 
 // Helper type that allows any combination of OpaqueRef, Cell, and Stream wrappers
 // Supports arbitrary nesting like OpaqueRef<OpaqueRef<Cell<T>>>
-type CellLike<T> = OpaqueRef<T> | Cell<T> | Stream<T>;
+type InnerCellLike<T> = OpaqueRef<T> | Cell<T> | Stream<T>;
+type CellLike<T> = InnerCellLike<T> | InnerCellLike<InnerCellLike<T>>;
 
 // Minimal theme typing for ct-theme
 type CTColorToken = string | {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Expand JSX CellLike<T> to accept nested wrapper types (OpaqueRef, Cell, Stream). This prevents type errors when passing values like OpaqueRef<Cell<T>> or Stream<OpaqueRef<T>>.

<!-- End of auto-generated description by cubic. -->

