### PR TITLE
spec(runner): added more details for OpaqueRef / RegularCell merge

### DIFF
--- a/docs/specs/recipe-construction/rollout-plan.md
+++ b/docs/specs/recipe-construction/rollout-plan.md
@@ -19,7 +19,7 @@
   - [ ] Update `CellLike` to be based on `AnyCell` but allow nesting.
   - [ ] `Opaque<T>` accepts `T` or any `CellLike<T>` at any nesting level
   - [ ] Simplify most wrap/unwrap types to use `CellLike`. We need
-    - [ ] "Accept any T where any sub part of T can be wrapped in one ore more
+    - [ ] "Accept any T where any sub part of T can be wrapped in one or more
       `AnyCell`" (for inputs to node factories)
     - [ ] "Strip any `AnyCell` from T and then wrap it in OpaqueRef<>" (for
       outputs of node factories, where T is the output of the inner function)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expanded the rollout-plan spec to detail merging OpaqueRef with RegularCell and to unify the cell type system. This simplifies cell APIs, removes the need for toOpaqueRef, and supports cells without initial links.

- **Refactors**
  - Introduced AnyCell, OpaqueCell, ComparableCell, ReadonlyCell, and WriteonlyCell; OpaqueRef is now a variant of OpaqueCell.
  - Updated CellLike to allow nested AnyCell; Opaque<T> accepts nested CellLike.
  - Simplified wrap/unwrap types to strip AnyCell in inputs and wrap outputs in OpaqueRef.
  - Enabled creating cells without a link; added .for to set a cause; .key works before a cause exists.
  - First merge steps: linking to node invocations, connect with direction, export, map/mapWithPattern, and toJSON returning null when unlinked.
  - Deprecated setPreExisting and setDefault; removed toOpaqueRef.
  - Made the recipe name parameter optional.

<!-- End of auto-generated description by cubic. -->

