### PR TITLE
feat: Add extraParams support to LLM tool definitions

### DIFF
--- a/packages/patterns/common-tools.tsx
+++ b/packages/patterns/common-tools.tsx
@@ -18,17 +18,21 @@ import {
 type CalculatorRequest = {
   /** The mathematical expression to evaluate. */
   expression: string;
+  /** The base to use for the calculation. */
+  base?: number;
 };
 
 export const calculator = recipe<
   CalculatorRequest,
   string | { error: string }
->("Calculator", ({ expression }) => {
+>("Calculator", ({ expression, base }) => {
   return derive(expression, (expr) => {
     const sanitized = expr.replace(/[^0-9+\-*/().\s]/g, "");
     let result;
     try {
-      result = Function(`"use strict"; return (${sanitized})`)();
+      result = Function(
+        `"use strict"; return Number(${sanitized}).toString(${base} ?? 10)`,
+      )();
     } catch (error) {
       result = { error: (error as any)?.message || "<error>" };
     }

--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -171,6 +171,9 @@ export default recipe<CharmsListInput, CharmsListOutput>(
           pattern: readWebpage,
         },
         calculator: {
+          extraParams: {
+            base: 10, // Just an example of how to pass extra params to a tool
+          },
           pattern: calculator,
         },
       },

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -209,6 +209,7 @@ const LLMToolSchema = {
       required: ["argumentSchema", "resultSchema", "nodes"],
       asCell: true,
     },
+    extraParams: { type: "object" },
     charm: {
       // Accept whole charm - its own schema defines its handlers
       asCell: true,
@@ -430,6 +431,7 @@ async function invokeToolCall(
   const pattern = toolDef?.key("pattern").getRaw() as unknown as
     | Readonly<Recipe>
     | undefined;
+  const extraParams = toolDef?.key("extraParams").get() ?? {};
   const handler = charmMeta?.handler ?? toolDef?.key("handler");
   // FIXME(bf): in practice, toolCall has toolCall.toolCallId not .id
   const result = runtime.getCell<any>(space, toolCall.id);
@@ -455,7 +457,7 @@ async function invokeToolCall(
 
   runtime.editWithRetry((tx) => {
     if (pattern) {
-      runtime.run(tx, pattern, toolCall.input, result);
+      runtime.run(tx, pattern, { ...toolCall.input, ...extraParams }, result);
     } else if (handler) {
       handler.withTx(tx).send({
         ...toolCall.input,


### PR DESCRIPTION
Adds the ability to pass extra parameters to pattern-based tools in LLM dialog tool invocations. This allows tool definitions to specify additional static parameters that get merged with the LLM-provided input when invoking the underlying pattern.

Changes:
- Add extraParams field to LLMToolSchema for pattern-based tools
- Merge extraParams with tool call input when invoking patterns
- Update calculator pattern to accept optional base parameter
- Add example usage in default-app with base: 10 for calculator tool

This enables use cases like configuring tool behavior (e.g., number base for calculator) without requiring the LLM to provide those values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds extraParams to pattern-based LLM tools so tool definitions can include static params that merge with LLM input at runtime. Updates the calculator tool to accept an optional base; default app shows base: 10.

- **New Features**
  - Added extraParams to LLMToolSchema and runtime invocation.
  - Merged extraParams with toolCall.input for pattern executions.
  - Updated calculator pattern to support a base parameter; configured in default-app example.

<!-- End of auto-generated description by cubic. -->

