### PR TITLE
fix(html): treat false as null/undefined in render (skip rendering)

### DIFF
--- a/packages/html/src/render.ts
+++ b/packages/html/src/render.ts
@@ -161,7 +161,10 @@ const bindChildren = (
           cancel: childCancel ?? (() => {}),
         };
       } else {
-        if (childValue === null || childValue === undefined) {
+        if (
+          childValue === null || childValue === undefined ||
+          childValue === false
+        ) {
           childValue = "";
         } else if (typeof childValue === "object") {
           console.warn("unexpected object when value was expected", childValue);

--- a/packages/html/test/html-recipes.test.ts
+++ b/packages/html/test/html-recipes.test.ts
@@ -218,7 +218,7 @@ describe("recipes with HTML", () => {
               "ul",
               null,
               entries(row).map((input: Opaque<[string, unknown]>) =>
-                h("li", null, [input[0] as string, ": ", input[1] as VNode])
+                h("li", null, [input[0] as string, ": ", str`${input[1]}`])
               ) as VNode[],
             )
           ) as VNode[],

--- a/packages/html/test/render.test.ts
+++ b/packages/html/test/render.test.ts
@@ -125,6 +125,24 @@ describe("renderImpl", () => {
     cancel();
     assert.equal(parent.children.length, 0);
   });
+
+  it("does not render false as text content", () => {
+    const { renderOptions, document } = mock;
+    const vnode = {
+      type: "vnode" as const,
+      name: "div",
+      props: {},
+      children: [false, "visible", null, undefined, true],
+    } as VNode;
+    const parent = document.getElementById("root")!;
+    const cancel = renderImpl(parent, vnode, renderOptions);
+    const div = parent.getElementsByTagName("div")[0]!;
+    // false, null, and undefined should render as empty text nodes
+    // true should render as "true"
+    // So innerHTML should be "visibletrue" (no "false")
+    assert.equal(div.innerHTML, "visibletrue");
+    cancel();
+  });
 });
 
 describe("serializableEvent", () => {


### PR DESCRIPTION
Previously, false values in children would render as the text 'false'. Now false is treated the same as null and undefined - it renders as an empty text element (nothing visible).

This aligns with common JSX/React behavior where boolean false is used for conditional rendering and should not produce output.

- Updated render.ts to check for false in addition to null/undefined
- Added test case verifying false, null, undefined render as empty
- Updated html-recipes test to use str template for explicit string conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat boolean false like null/undefined during HTML rendering, so it doesn’t produce visible text. This prevents stray “false” in the DOM and matches JSX/React conditional rendering.

- **Bug Fixes**
  - Normalize false to empty text in children handling in render.ts.
  - Add tests asserting false/null/undefined render empty and true renders "true".
  - Update html-recipes test to use str template for explicit string conversion.

<!-- End of auto-generated description by cubic. -->

