### PR TITLE
Ellyse/smoketest mac

### DIFF
--- a/tools/ralph/Dockerfile
+++ b/tools/ralph/Dockerfile
@@ -40,7 +40,8 @@ RUN add-apt-repository -y ppa:maveonair/helix-editor && \
 RUN npm install -g mystmd
 
 # Install Playwright browser and dependencies
-RUN npx playwright install --with-deps chromium
+RUN npx playwright install chrome && \
+    npx playwright install-deps chrome
 
 # Install Claude CLI and Codex globally (accessible to all users)
 RUN npm install -g @anthropic-ai/claude-code && \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make run_smoketest.sh work reliably on macOS by pulling Claude credentials from the Keychain and fixing Playwright sandboxing in Docker.

- **Bug Fixes**
  - On macOS, read credentials from the Keychain and write them into /tmp/home; keep file copy on Linux.
  - Add Docker flags (SYS_ADMIN, seccomp=unconfined) and pass --disable-setuid-sandbox to the Playwright MCP to avoid permission errors.

<!-- End of auto-generated description by cubic. -->

