### PR TITLE
fix(schema-generator): support Stream types nested in OpaqueRef wrappers

### DIFF
--- a/packages/schema-generator/test/fixtures/schema/opaque-opaqueref-stream.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/opaque-opaqueref-stream.expected.json
@@ -1,0 +1,34 @@
+{
+  "$defs": {
+    "LLMState": {
+      "properties": {
+        "cancelGeneration": {
+          "asStream": true
+        },
+        "error": true,
+        "pending": {
+          "type": "boolean"
+        },
+        "result": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cancelGeneration",
+        "error",
+        "pending"
+      ],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "state": {
+      "$ref": "#/$defs/LLMState",
+      "asOpaque": true
+    }
+  },
+  "required": [
+    "state"
+  ],
+  "type": "object"
+}

--- a/packages/schema-generator/test/fixtures/schema/opaque-opaqueref-stream.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/opaque-opaqueref-stream.input.ts
@@ -1,0 +1,40 @@
+// Test case for CT-1006: Stream type nested in OpaqueRef inside Opaque union
+// This mimics the structure of BuiltInLLMState where cancelGeneration: Stream<void>
+// becomes Opaque<OpaqueRef<Stream<void>>> when returned inside OpaqueRef<BuiltInLLMState>
+
+interface Stream<T> {
+  send(event: T): void;
+}
+
+interface OpaqueRefMethods<T> {
+  get(): T;
+  set(value: T): void;
+}
+
+// OpaqueRef<T> is an intersection of OpaqueRefMethods<T> and T
+type OpaqueRef<T> = OpaqueRefMethods<T> & (
+  T extends Array<infer U> ? Array<OpaqueRef<U>>
+  : T extends object ? { [K in keyof T]: OpaqueRef<T[K]> }
+  : T
+);
+
+// Opaque<T> is a union: T | OpaqueRef<T>
+type Opaque<T> =
+  | OpaqueRef<T>
+  | (T extends Array<infer U> ? Array<Opaque<U>>
+    : T extends object ? { [K in keyof T]: Opaque<T[K]> }
+    : T);
+
+// This mimics BuiltInLLMState structure
+interface LLMState {
+  pending: boolean;
+  result?: string;
+  error: unknown;
+  cancelGeneration: Stream<void>;  // This becomes problematic when wrapped
+}
+
+// When we have OpaqueRef<LLMState>, the cancelGeneration property becomes:
+// Opaque<OpaqueRef<Stream<void>>> which is the nested structure that triggered CT-1006
+interface SchemaRoot {
+  state: OpaqueRef<LLMState>;
+}


### PR DESCRIPTION
Fixes CT-1006: "Error: Unexpected CommonTools type: Stream" when building patterns with llm() function.

The issue occurred when Stream types were wrapped in nested OpaqueRef layers (e.g., Opaque<OpaqueRef<Stream<void>>>). The schema generator's wrapper detection via typeNode worked, but getWrapperTypeInfo(type) failed due to complex union structure.

Solution: Added recursivelyUnwrapOpaqueRef() method that:
- Reuses existing isOpaqueRefType() and extractOpaqueRefTypeArgument()
- Recursively unwraps nested OpaqueRef layers in unions
- Finds the base wrapper type (Cell/Stream/OpaqueRef)

Includes test fixture opaque-opaqueref-stream to verify the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes handling of Stream types wrapped in nested OpaqueRef layers in the schema generator. Resolves CT-1006 so patterns using llm() build without the “Unexpected CommonTools type: Stream” error.

- **Bug Fixes**
  - Added recursivelyUnwrapOpaqueRef to peel nested OpaqueRef layers in unions and find the base wrapper type (Cell/Stream/OpaqueRef) using existing helpers.
  - Correctly outputs Stream<void> properties (asStream) even when wrapped as Opaque<OpaqueRef<...>>.
  - Added test fixture opaque-opaqueref-stream to verify the fix.

<!-- End of auto-generated description by cubic. -->

