### PR TITLE
note about not running as root

### DIFF
--- a/tools/ralph/README.md
+++ b/tools/ralph/README.md
@@ -25,6 +25,9 @@ variable.
   sudo usermod -aG docker $USER
   # Log out and back in for changes to take effect
   ```
+  Your user must not be root, otherwise the container user will also be 'root'
+  and Claude will not agree to run.
+
   **Important:** Running the script with `sudo` will cause it to look for Claude
   credentials in `/root/.claude.json` instead of your user's home directory,
   causing the smoketests to fail.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a warning to tools/ralph/README to avoid running as root. Running as root makes the container user root and Claude won't run; using sudo reads credentials from /root and breaks smoketests.

<!-- End of auto-generated description by cubic. -->

