### PR TITLE
allows start script to run from relative directories

### DIFF
--- a/scripts/start-local-dev.sh
+++ b/scripts/start-local-dev.sh
@@ -1,3 +1,7 @@
+# Change to repository root (parent of scripts directory)
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR/.."
+
 # Parse command line arguments
 FORCE=false
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update start-local-dev.sh to change to the repo root based on its own location, so it works when run from any directory. Fixes path errors when starting local dev from relative paths.

<!-- End of auto-generated description by cubic. -->

