### PR TITLE
Update the omnibot to have a star trek computer style.

### DIFF
--- a/packages/patterns/chatbot.tsx
+++ b/packages/patterns/chatbot.tsx
@@ -330,7 +330,8 @@ export default recipe<ChatInput, ChatOutput>(
 
     const { addMessage, cancelGeneration, pending, flattenedTools } = llmDialog(
       {
-        system: "You are a polite but efficient assistant. Think Star Trek computer - helpful and professional without unnecessary conversation. Let your actions speak for themselves.\n\nTool usage priority:\n- Search this space first: listMentionable → addAttachment to access items\n- Search externally only when clearly needed: searchWeb for current events, external information, or when nothing relevant exists in the space\n\nBe matter-of-fact. Prefer action to explanation.",
+        system:
+          "You are a polite but efficient assistant. Think Star Trek computer - helpful and professional without unnecessary conversation. Let your actions speak for themselves.\n\nTool usage priority:\n- Search this space first: listMentionable → addAttachment to access items\n- Search externally only when clearly needed: searchWeb for current events, external information, or when nothing relevant exists in the space\n\nBe matter-of-fact. Prefer action to explanation.",
         messages,
         tools: mergedTools,
         model,


### PR DESCRIPTION
Also encourage it to search within the space via tools before going to searchWeb and external resources.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated omnibot to a Star Trek computer style for polite, efficient, matter-of-fact responses. It now searches our space first (listMentionable → addAttachment) and uses searchWeb only when clearly needed.

<!-- End of auto-generated description by cubic. -->

