### PR TITLE
Auto-attach recently viewed charms and add `listRecent()` tool

### DIFF
--- a/packages/patterns/omnibox-fab.tsx
+++ b/packages/patterns/omnibox-fab.tsx
@@ -39,6 +39,8 @@ export default recipe<OmniboxFABInput>(
   "OmniboxFAB",
   ({ mentionable: _mentionable }) => {
     const omnibot = Chatbot({
+      system:
+        "You are a polite but efficient assistant. Think Star Trek computer - helpful and professional without unnecessary conversation. Let your actions speak for themselves.\n\nTool usage priority:\n- Search this space first: listMentionable → addAttachment to access items\n- Search externally only when clearly needed: searchWeb for current events, external information, or when nothing relevant exists in the space\n\nBe matter-of-fact. Prefer action to explanation.",
       messages: [],
       tools: {
         searchWeb: {


### PR DESCRIPTION
- **Auto-attach currently viewed charm**
- **Make system prompt customizable for `chatbot.tsx`**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-attaches the most recently viewed charm to each chat and adds a listRecent tool so the assistant can pull in recent items without extra clicks, addressing Linear CT-1013. The chatbot system prompt is now configurable; Omnibox keeps the previous behavior by passing the existing prompt.

- **New Features**
  - Auto-attaches the most recent charm; merges with user attachments, avoids duplicates, and prepends it.
  - Added listRecent tool to list recently viewed charm NAMEs as JSON.
  - Chatbot accepts a customizable system prompt; OmniboxFAB sets the previous prompt to preserve behavior.
  - Tools and UI now use attachmentsWithRecent for consistent navigation, listing, and sending.

<!-- End of auto-generated description by cubic. -->

