### PR TITLE
Finalize prepared statements

### DIFF
--- a/packages/memory/space.ts
+++ b/packages/memory/space.ts
@@ -782,11 +782,12 @@ const commit = <Space extends MemorySpace>(
   const the = COMMIT_LOG_TYPE;
   const of = transaction.sub;
   const stmt = session.store.prepare(EXPORT);
-  const row = stmt.get({ the, of }) as
-    | StateRow
-    | undefined;
-  stmt.finalize();
-
+  let row;
+  try {
+    row = stmt.get({ the, of }) as StateRow | undefined;
+  } finally {
+    stmt.finalize();
+  }
   const [since, cause] = row
     ? [
       (JSON.parse(row.is as string) as CommitData).since + 1,


### PR DESCRIPTION
This changes the places where we use prepared statements to properly dispose of them.
A future improvement is to only prepare the EXPORT statement once, and attach it to the Session or store.
I also converted the selectFacts to not use a generator, since it isn't needed there, and complicates the statement disposal.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalize all prepared statements to prevent resource leaks and improve stability in memory store operations. Also change selectFacts to return an array so statements can be properly finalized.

- **Bug Fixes**
  - Wrap EXPORT, CAUSE_CHAIN, and GET_FACT usage in try/finally with stmt.finalize().
  - Finalize the EXPORT statement in commit after get().

- **Refactors**
  - Replace selectFacts generator with an array return to support safe finalization.

<sup>Written for commit f3d9ad7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





