### PR TITLE
fix(default-app): fix deletion by using boxed value of allCharms

### DIFF
--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -101,8 +101,11 @@ const spawnNote = handler<void, void>((_, __) => {
 export default recipe<CharmsListInput, CharmsListOutput>(
   "DefaultCharmList",
   (_) => {
-    const allCharms = derive<MentionableCharm[], MentionableCharm[]>(
-      wish<MentionableCharm[]>("#allCharms"),
+    const { allCharms } = derive<
+      { allCharms: MentionableCharm[] },
+      { allCharms: MentionableCharm[] }
+    >(
+      wish<{ allCharms: MentionableCharm[] }>("/"),
       (c) => c,
     );
     const index = BacklinksIndex({ allCharms });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix deletion in DefaultCharmList by reading allCharms from the boxed root value instead of the raw list. This ensures BacklinksIndex and derived state update correctly when charms are removed.

<sup>Written for commit f2d0967. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

