### PR TITLE
Allow input while chatbot is pending

### DIFF
--- a/packages/ui/src/v2/components/ct-prompt-input/ct-prompt-input.ts
+++ b/packages/ui/src/v2/components/ct-prompt-input/ct-prompt-input.ts
@@ -183,8 +183,7 @@ export class CTPromptInput extends BaseElement {
           }
 
           /* Pending state - allow editing, just block submit */
-          :host([pending]) textarea {
-          }
+          :host([pending]) textarea {}
 
           /* Disabled state */
           :host([disabled]) .container {


### PR DESCRIPTION
- **Allow input during pending state in ct-prompt-input**
- **Format pass**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow typing and file uploads in ct-prompt-input while a chatbot reply is pending, aligning with ChatGPT/Claude UX and addressing CT-1024. Submit actions (Enter, Cmd/Ctrl+Enter, Send) are blocked during pending; the stop button remains available and the model picker stays disabled.

<sup>Written for commit 1546f48. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

