### PR TITLE
chore: Type style objects in JSX

### DIFF
--- a/packages/static/assets/types/jsx.d.ts
+++ b/packages/static/assets/types/jsx.d.ts
@@ -2902,6 +2902,12 @@ interface CTAttachmentsBarElement extends CTHTMLElement {}
 interface CTCTCollapsibleElement extends CTHTMLElement {}
 interface CTFragmentElement extends CTHTMLElement {}
 interface CTUpdaterElement extends CTHTMLElement {}
+interface CTGoogleOAuthElement extends CTHTMLElement {}
+
+interface CTGoogleOAuthAttributes<T> extends CTHTMLAttributes<T> {
+  "$auth"?: any;
+  "scopes"?: string[]
+}
 
 interface CTUpdaterAttributes<T> extends CTHTMLAttributes<T> {
   "integration"?: string;
@@ -3125,7 +3131,7 @@ interface CTInputAttributes<T> extends CTHTMLAttributes<T> {
 }
 
 interface CTInputLegacyAttributes<T> extends CTHTMLAttributes<T> {
-  "value"?: string;
+  "value"?: CellLike<string>;
   "placeholder"?: string;
   "appearance"?: string;
   "customStyle"?: string;
@@ -3789,6 +3795,10 @@ declare global {
         CTSendMessageAttributes<CTSendMessageElement>,
         CTSendMessageElement
       >;
+      "common-google-oauth": CTDOM.DetailedHTMLProps<
+        CTGoogleOAuthAttributes<CTGoogleOAuthElement>,
+        CTGoogleOAuthElement
+      >; 
       // Define both `ct-` and `common-` variants
       "ct-hstack": CTDOM.DetailedHTMLProps<
         CTStackAttributes<CTHStackElement>,


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Typed JSX style objects so the style prop supports a string or a typed object, and added types for the common-google-oauth element. Improves type safety and editor autocomplete for CSS and custom JSX elements.

- **Refactors**
  - Added CSSStyleDeclaration and DOMCSSProperties types; style now accepts string | DOMCSSProperties.
  - Added types for "common-google-oauth" with $auth and scopes attributes.
  - Updated CTInputLegacyAttributes: value is CellLike<string>.

- **Migration**
  - Use valid CSSStyleDeclaration keys in style objects (camelCase; vendor prefixes allowed).
  - Values must be string or number; remove booleans/arrays.
  - For custom CSS properties (e.g., --foo), use a style string or cast to DOMCSSProperties.

<sup>Written for commit f456c7efa772fce566b6b0c46bd39e9b67b92c44. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



