### PR TITLE
Break circular dependency between memory and runner packages

### DIFF
--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -1,8 +1,17 @@
 import type { Reference } from "merkle-reference";
-import { JSONValue, SchemaContext } from "@commontools/runner";
-import { SchemaPathSelector } from "@commontools/runner/traverse";
+import type { JSONSchema, JSONValue } from "@commontools/api";
 
-export type { JSONValue, Reference, SchemaContext, SchemaPathSelector };
+export type SchemaContext = {
+  schema: JSONSchema;
+  rootSchema: JSONSchema;
+};
+
+export type SchemaPathSelector = {
+  path: readonly string[];
+  schemaContext?: Readonly<SchemaContext>;
+};
+
+export type { JSONValue, Reference };
 
 export interface Clock {
   now(): UTCUnixTimestampInSeconds;

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -1,5 +1,6 @@
 import { isObject, type Mutable } from "@commontools/utils/types";
 import { toOpaqueRef } from "../back-to-cell.ts";
+import type { SchemaContext } from "@commontools/memory/interface";
 
 import type {
   ByRefFunction,
@@ -158,11 +159,7 @@ export type NodeRef = {
   frame: Frame | undefined;
 };
 
-// This is a schema, together with its rootSchema for resolving $ref entries
-export type SchemaContext = {
-  schema: JSONSchema;
-  rootSchema: JSONSchema;
-};
+export type { SchemaContext };
 
 export type StreamValue = {
   $stream: true;

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -11,12 +11,11 @@ import {
 } from "../../utils/src/types.ts";
 import { getLogger } from "../../utils/src/logger.ts";
 import { ContextualFlowControl } from "./cfc.ts";
+import type { JSONObject, JSONSchema, JSONValue } from "./builder/types.ts";
 import type {
-  JSONObject,
-  JSONSchema,
-  JSONValue,
   SchemaContext,
-} from "./builder/types.ts";
+  SchemaPathSelector,
+} from "@commontools/memory/interface";
 import { deepEqual } from "./path-utils.ts";
 import { isAnyCellLink, parseLink } from "./link-utils.ts";
 import { fromURI } from "./uri-utils.ts";
@@ -25,12 +24,7 @@ import type { IAttestation, IMemoryAddress } from "./storage/interface.ts";
 const logger = getLogger("traverse", { enabled: true, level: "warn" });
 
 export type { IAttestation, IMemoryAddress } from "./storage/interface.ts";
-
-// Both path and schemaContext are relative to the fact.is.value
-export type SchemaPathSelector = {
-  path: readonly string[];
-  schemaContext?: Readonly<SchemaContext>;
-};
+export type { SchemaPathSelector };
 
 /**
  * A data structure that maps keys to sets of values, allowing multiple values


### PR DESCRIPTION
## Problem

The `@commontools/memory` and `@commontools/runner` packages had a circular dependency:

- **memory/interface.ts** imported `JSONValue`, `SchemaContext`, and `SchemaPathSelector` from `@commontools/runner`
- **runner** extensively imports from `@commontools/memory/interface`

This circular dependency caused:
- Every file in runner to pull in 267 dependencies (34.55MB) during typechecking
- Even simple 50-line utility files took 0.5s to typecheck instead of 0.013s
- Slow language server performance when editing runner files

## Solution

Moved two simple type definitions from runner to memory:

1. **`SchemaContext`** - wraps two JSONSchema fields
2. **`SchemaPathSelector`** - wraps path + optional SchemaContext

These types conceptually belong in memory as they're used in memory's query interface (`SchemaSelector`).

### Changes

- **packages/memory/interface.ts**: Define `SchemaContext` and `SchemaPathSelector` locally, import `JSONSchema` from `@commontools/api` instead of runner
- **packages/runner/src/builder/types.ts**: Import `SchemaContext` from memory
- **packages/runner/src/traverse.ts**: Import `SchemaContext` and `SchemaPathSelector` from memory

## Impact

### Performance Improvements

- **Simple utility files** now compile **30-40x faster** (0.013s vs 0.5s)
- **Dependency reduction**: Simple files went from 267 dependencies (34MB) to 2-5 dependencies (~116KB)
- **Total typecheck time**: Reduced by 3 seconds for runner package (104s → 101s)

### Before vs After

#### cancel.ts (simple utility):
- **Before**: 267 dependencies, 34.55MB
- **After**: 2 dependencies, 116.5KB
- **Speedup**: 36x faster typecheck

#### memory/interface.ts:
- **Before**: Imported from `@commontools/runner` → circular dependency
- **After**: Only imports from `merkle-reference` and `@commontools/api` → no circle ✅

## Testing

All packages typecheck successfully:
```bash
deno check --all packages/runner/src/index.ts   # ✅
deno check --all packages/memory/interface.ts   # ✅
deno check --all packages/api/index.ts          # ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broke the circular dependency between @commontools/memory and @commontools/runner by moving SchemaContext and SchemaPathSelector to memory. This cuts typecheck overhead and speeds up runner builds.

- **Refactors**
  - Define SchemaContext and SchemaPathSelector in memory/interface.ts.
  - Import JSONSchema from @commontools/api in memory; remove runner imports.
  - Update runner builder/types.ts and traverse.ts to import these types from memory.

- **Performance**
  - Simple runner files compile ~30–40x faster (0.013s vs 0.5s).
  - Dependencies per simple file drop from 267 (~34MB) to 2–5 (~116KB).
  - Runner typecheck time reduced by ~3s (104s → 101s).

<sup>Written for commit 2a8c72048b111a60f2ad719c93d717283db06c0e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

