### PR TITLE
Bug/cell brand

### DIFF
--- a/cell-brand-bug-reproduction.ts
+++ b/cell-brand-bug-reproduction.ts
@@ -15,7 +15,7 @@ interface State {
 }
 
 // Accessing properties on OpaqueRef<Cell<T>> fails type-checking
-function reproducesBug(state: OpaqueRef<State>) {
+function _reproducesBug(state: OpaqueRef<State>) {
   state.counter.set(state.counter.get() + 1);
   //            ^^^ Property 'set' does not exist on type 'never'
   //                                  ^^^ Property 'get' does not exist on type 'never'

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -354,16 +354,12 @@ export interface WriteonlyCell<T>
  * This is temporary until AST transformation handles .key() automatically.
  *
  * Note: Symbol keys (like CELL_BRAND) are excluded from mapping to avoid
- * brand conflicts. Already-branded cells are preserved as-is rather than
- * being wrapped again to prevent cell-of-cell situations.
+ * brand conflicts when wrapping branded cells.
  */
 export type OpaqueRef<T> =
   & OpaqueCell<T>
   & (T extends Array<infer U> ? Array<OpaqueRef<U>>
-    : T extends object ? {
-        [K in keyof T as K extends symbol ? never : K]:
-          T[K] extends BrandedCell<any, any> ? T[K] : OpaqueRef<T[K]>
-      }
+    : T extends object ? { [K in keyof T as K extends symbol ? never : K]: OpaqueRef<T[K]> }
     : T);
 
 // ============================================================================


### PR DESCRIPTION
Exploration of how to fix bug with conflicting CELL_BRANDS in OpaqueRef<Cell<T>>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a type conflict in OpaqueRef<Cell<T>> where [CELL_BRAND] collisions reduced the type to never. OpaqueRef now skips symbol keys to prevent brand conflicts, restoring valid get/set access on cells.

- **Bug Fixes**
  - Exclude symbol keys (e.g., [CELL_BRAND]) from OpaqueRef mapping to prevent brand conflicts.
  - Added a minimal reproduction script to demonstrate the original error.

<sup>Written for commit dd12a0de68110ced6e6a96fb201da7f80587a5f4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



