### PR TITLE
Allow caching of tool calls

### DIFF
--- a/packages/toolshed/routes/ai/llm/llm.handlers.ts
+++ b/packages/toolshed/routes/ai/llm/llm.handlers.ts
@@ -126,16 +126,21 @@ export const generateText: AppRouteHandler<GenerateTextRoute> = async (c) => {
     payload.metadata.user = user;
   }
 
-  // Disable caching for requests with tools to prevent incomplete cached responses
-  // Tool calls are executed client-side, so server cache doesn't include tool results
-  const hasTools = payload.tools && Object.keys(payload.tools).length > 0;
-  const shouldCache = payload.cache && !hasTools;
-
-  if (payload.cache && hasTools) {
-    console.log(
-      "Caching disabled for request with tools to prevent incomplete cached responses",
-    );
-  }
+  // Enable caching for all requests including those with tools.
+  // With the sequential request architecture, each request includes complete context
+  // (including tool results from previous rounds), making each response cacheable.
+  //
+  // Cache key naturally includes:
+  // - Original user message
+  // - Tool definitions
+  // - Tool results (in messages array for subsequent rounds)
+  // - Full conversation history
+  //
+  // Note: Non-deterministic tools will be cached. If tool results change for the
+  // same inputs, the different results will produce different cache keys, resulting
+  // in a cache miss (correct behavior). For intentional cache invalidation, use
+  // the cache eviction utilities or modify the request to produce a different hash.
+  const shouldCache = payload.cache === true;
 
   let cacheKey: string | undefined;
   if (shouldCache) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable caching for requests that include tool calls, honoring payload.cache across all LLM requests. Cache keys already include the full context (user message, tool definitions, tool results, and conversation history), so cached responses are complete and non-deterministic tools naturally produce misses when inputs differ.

<sup>Written for commit baf873bc765ec6e41cc8bbb93f009d7d4bbd2fe5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

