### PR TITLE
fix(default-app): Make charm name updates reactive in list

### DIFF
--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -3,6 +3,7 @@ import {
   Cell,
   derive,
   handler,
+  lift,
   NAME,
   navigateTo,
   recipe,
@@ -98,6 +99,10 @@ const spawnNote = handler<void, void>((_, __) => {
   }));
 });
 
+const getCharmName = lift(({ charm }: { charm: MinimalCharm }) => {
+  return charm?.[NAME] || "Untitled Charm";
+});
+
 export default recipe<CharmsListInput, CharmsListOutput>(
   "DefaultCharmList",
   (_) => {
@@ -177,7 +182,7 @@ export default recipe<CharmsListInput, CharmsListOutput>(
                 <tbody>
                   {allCharms.map((charm) => (
                     <tr>
-                      <td>{charm?.[NAME] || "Untitled Charm"}</td>
+                      <td>{getCharmName({ charm })}</td>
                       <td>
                         <ct-hstack gap="2">
                           <ct-button


### PR DESCRIPTION
## Summary

Fixes a bug where the Default Charm List does not update charm names when they are changed from within the charm (e.g., editing a Note's title).

## Problem

When you open a Note from the Default Charm List and change its title, the title does not update in the list when you navigate back. The list continues to show the old name.

**Root Cause**: The UI was directly accessing `charm?.[NAME]` inside a `.map()` function, which doesn't create a reactive binding. When a charm's title changes internally, it updates that charm's `[NAME]` property, but since the `allCharms` array reference itself doesn't change, the reactive system doesn't know to re-render.

## Solution

This PR implements the same reactive pattern already used in `chatbot-list-view.tsx`:

1. Import `lift` from commontools
2. Create a `getCharmName` lift function to extract charm names reactively
3. Use `getCharmName({ charm })` in the table rendering instead of direct property access

This creates a proper reactive dependency so when any charm's `[NAME]` property changes, the UI automatically re-renders that specific table row.

## Changes

**File**: `packages/patterns/default-app.tsx`
- Added `lift` import (line 6)
- Added `getCharmName` lift function (lines 102-104)
- Updated table rendering to use `getCharmName({ charm })` instead of `charm?.[NAME]` (line 185)

## Testing

To test this fix:

1. Start the development server with `deno task dev-local` (shell) and the toolshed backend
2. Open the Default Charm List
3. Click "📄 Note" to create a new note
4. Change the note's title (e.g., from "New Note" to "My Test Note")
5. Navigate back to the Default Charm List
6. **Expected**: The charm name in the list should now show "My Test Note"
7. **Before this fix**: It would stay as "New Note"

## References

- Pattern established in `packages/patterns/chatbot-list-view.tsx:221-223`
- Related to reactive data flow documentation in `docs/common/RECIPES.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed non-reactive charm name rendering in the Default Charm List. Renaming a charm now updates its name in the list immediately.

- **Bug Fix**
  - Import lift and add getCharmName to derive the name reactively.
  - Replace charm[NAME] in the table with getCharmName({ charm }).
  - Aligns with the existing pattern in chatbot-list-view.tsx.

<sup>Written for commit 28bd6900c6366d8d9bfd6a18e31f5a50a031b6ca. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

