### PR TITLE
feat(default-app): Simplify charm list UI by renaming to Patterns and removing table headers

### DIFF
--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -170,15 +170,9 @@ export default recipe<CharmsListInput, CharmsListOutput>(
 
           <ct-vscroll flex showScrollbar>
             <ct-vstack gap="4" padding="6">
-              <h2>Charms ({allCharms.length})</h2>
+              <h2>Patterns</h2>
 
               <ct-table full-width hover>
-                <thead>
-                  <tr>
-                    <th>Charm Name</th>
-                    <th>Actions</th>
-                  </tr>
-                </thead>
                 <tbody>
                   {allCharms.map((charm) => (
                     <tr>


### PR DESCRIPTION
## Summary

- Changed the main heading from "Charms (N)" to just "Patterns" for better alignment with pattern-centric terminology
- Removed table header row ("Charm Name" and "Actions") for a cleaner, more minimal UI

## Visual Changes

**Before:**
- Title: "Charms (6)"
- Table headers: "Charm Name" | "Actions"

**After:**
- Title: "Patterns"
- No table headers (cleaner look)

## Test Plan

- [x] Modified pattern file at `packages/patterns/default-app.tsx`
- [x] Verified API serves updated pattern
- [ ] Refresh browser to see changes in default charm list view

🤖 Generated with [Claude Code](https://claude.com/claude-code)