### PR TITLE
fix(ct-select): Use areLinksSame for object value equality

### DIFF
--- a/packages/ui/src/v2/components/ct-select/ct-select.ts
+++ b/packages/ui/src/v2/components/ct-select/ct-select.ts
@@ -381,7 +381,9 @@ export class CTSelect extends BaseElement {
         const values = (currentValue as unknown[] | undefined) ?? [];
         Array.from(this._select.options).forEach((opt) => {
           const item = this._keyMap.get(opt.value);
-          opt.selected = item ? values.some(v => areLinksSame(v, item.value)) : false;
+          opt.selected = item
+            ? values.some((v) => areLinksSame(v, item.value))
+            : false;
         });
       } else {
         const val = currentValue;


### PR DESCRIPTION
Previously, ct-select used JavaScript's strict equality (===) to compare
values when determining which option should be selected. This worked fine
for primitives but failed for object values like Cells because it compared
by reference.

Now using areLinksSame() from @commontools/runner which properly compares
Cell objects and other link-based values by their identity rather than
reference.

Changes:
- Import areLinksSame from @commontools/runner
- Replace values.includes() with values.some(v => areLinksSame(v, item.value))
  for multiple select
- Replace item.value === val with areLinksSame(item.value, val) for
  single select

Fixes regression where charm objects and other Cell-based values weren't
being properly selected in ct-select dropdowns.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ct-select to compare values with areLinksSame from @commontools/runner, rather than strict equality. This restores correct selection for object values (Cells/charm objects) in both single and multiple selects.

<sup>Written for commit 2fa4f3b57519c73d5fb0cf7be9bd1f9178aa57c2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



