### PR TITLE
fix(runner): simplify types a little bit

### DIFF
--- a/packages/runner/src/builder/recipe.ts
+++ b/packages/runner/src/builder/recipe.ts
@@ -145,7 +145,7 @@ export function recipeFromFrame<T, R>(
   resultSchema: JSONSchema | undefined,
   fn: (input: OpaqueRef<Required<T>>) => Opaque<R>,
 ): RecipeFactory<T, R> {
-  const inputs = opaqueRef<Required<T>>(
+  const inputs = opaqueRef(
     undefined,
     typeof argumentSchema === "string"
       ? undefined


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified runner recipe types by removing Required<T> from opaqueRef, so optional input fields aren’t forced to be required. This improves type inference and reduces friction in consuming code.

<sup>Written for commit d90864998b39229164b306a58d695ba44402ca1a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





