### PR TITLE
Fix inconsistent `ct` invocation path

### DIFF
--- a/.claude/skills/ct/SKILL.md
+++ b/.claude/skills/ct/SKILL.md
@@ -97,7 +97,7 @@ Most commands require these parameters:
 
 ### 1. Testing Recipes Locally
 
-Use `ct dev` for rapid iteration during recipe development:
+Use `deno task ct dev` for rapid iteration during recipe development:
 
 ```bash
 # Type check and execute
@@ -115,10 +115,10 @@ deno task ct dev --help
 ### 2. Deploying and Managing Charms
 
 **Workflow pattern:**
-1. List charms → `ct charm ls`
-2. Deploy new → `ct charm new`
-3. Update existing → `ct charm setsrc` (faster than redeploying)
-4. Inspect state → `ct charm inspect`
+1. List charms → `deno task ct charm ls`
+2. Deploy new → `deno task ct charm new`
+3. Update existing → `deno task ct charm setsrc` (faster than redeploying)
+4. Inspect state → `deno task ct charm inspect`
 
 **Discover commands:**
 ```bash
@@ -133,9 +133,9 @@ deno task ct charm --help
 - **Path syntax**: Use forward slashes (e.g., `items/0/name`, `config/database/host`)
 
 **Commands:**
-- `ct charm get` - Read data from charm
-- `ct charm set` - Direct field modification
-- `ct charm call` - Execute handler (for validation/side effects)
+- `deno task ct charm get` - Read data from charm
+- `deno task ct charm set` - Direct field modification
+- `deno task ct charm call` - Execute handler (for validation/side effects)
 
 **Decision guide:**
 - Use **GET** to inspect charm state
@@ -165,7 +165,7 @@ deno task ct charm link --help
 
 ### 5. Visualizing Space Architecture
 
-Use `ct charm map` to understand charm relationships:
+Use `deno task ct charm map` to understand charm relationships:
 
 ```bash
 # ASCII map
@@ -213,8 +213,8 @@ echo '{"name": "John"}' | deno task ct charm set ... user
 **Debugging steps:**
 1. For recipe errors: Run `deno task ct dev [recipe] --no-run` to check syntax
 2. For connection issues: Verify Tailnet connection for `*.ts.net` URLs
-3. For data issues: Use `ct charm inspect` to examine charm state
-4. For linking issues: Use `ct charm map` to visualize connections
+3. For data issues: Use `deno task ct charm inspect` to examine charm state
+4. For linking issues: Use `deno task ct charm map` to visualize connections
 
 ## Building Complex Applications
 
@@ -222,7 +222,7 @@ echo '{"name": "John"}' | deno task ct charm set ... user
 1. Create small, focused recipes (each does one thing well)
 2. Deploy recipes as separate charms
 3. Link charms together for data flow
-4. Use `ct charm map` to visualize architecture
+4. Use `deno task ct charm map` to visualize architecture
 5. Add new functionality by deploying and linking new charms
 
 **Example architecture:**
@@ -243,7 +243,7 @@ Documentation of well-known charm IDs (like `allCharms`) that provide access to 
 ## Remember
 
 - **Use `--help` flags** - The tool itself is the documentation
-- **Check `ct charm --help`** before asking about available commands
+- **Check `deno task ct charm --help`** before asking about available commands
 - **Path syntax** - Always forward slashes, numeric array indices
 - **JSON format** - All values must be valid JSON (strings need quotes)
 - **Environment variables** - Set `CT_API_URL` and `CT_IDENTITY` for convenience

--- a/.claude/skills/pattern-dev/SKILL.md
+++ b/.claude/skills/pattern-dev/SKILL.md
@@ -114,7 +114,7 @@ const addItem = handler<
 
 ### Step 4: Test and Deploy
 
-Use the **ct** skill for testing with `ct dev` and deploying with `ct charm new/setsrc`.
+Use the **ct** skill for testing with `deno task ct dev` and deploying with `deno task ct charm new/setsrc`.
 
 ## Modifying Patterns
 
@@ -128,8 +128,8 @@ Use the **ct** skill to retrieve source:
 ### Making Changes
 
 1. Edit the pattern file
-2. Check syntax: Use **ct** skill for `ct dev pattern.tsx --no-run`
-3. Update charm: Use **ct** skill for `ct charm setsrc`
+2. Check syntax: Use **ct** skill for `deno task ct dev pattern.tsx --no-run`
+3. Update charm: Use **ct** skill for `deno task ct charm setsrc`
 
 ## Debugging Patterns
 
@@ -152,7 +152,7 @@ Use the **ct** skill to retrieve source:
 
 ### Debugging Process
 
-1. **Check TypeScript errors first** - Use **ct** skill for `ct dev pattern.tsx --no-run`
+1. **Check TypeScript errors first** - Use **ct** skill for `deno task ct dev pattern.tsx --no-run`
 2. **Consult the docs** - Match error pattern to relevant doc:
    - Type errors → `HANDLERS.md`
    - Component issues → `COMPONENTS.md`

--- a/.claude/skills/pattern-dev/references/workflow-guide.md
+++ b/.claude/skills/pattern-dev/references/workflow-guide.md
@@ -13,7 +13,7 @@ This guide covers high-level workflow patterns and best practices for developing
 1. **Write minimal pattern** - Basic types, minimal UI, single feature
 2. **Deploy and test** - Use ct skill for deployment commands
 3. **Inspect and verify** - Use ct skill for inspection commands
-4. **Iterate with updates** - Use `ct charm setsrc` for fast updates (via ct skill)
+4. **Iterate with updates** - Use `deno task ct charm setsrc` for fast updates (via ct skill)
 5. **Add next feature** - One at a time, repeat cycle
 
 **Why this works:**
@@ -93,7 +93,7 @@ patterns/feature/
    - Cell operations? → See `RECIPES.md`
 3. Find similar example in `packages/patterns/`
 4. Apply fix
-5. Verify with `ct dev --no-run` (via ct skill)
+5. Verify with `deno task ct dev --no-run` (via ct skill)
 
 ### Runtime Error → Solution Mapping
 
@@ -218,9 +218,9 @@ Use `derive()` judiciously for expensive operations.
 ### Using ct Effectively
 
 **Fast iteration:**
-- Deploy once with `ct charm new`
-- Update repeatedly with `ct charm setsrc`
-- Inspect with `ct charm inspect`
+- Deploy once with `deno task ct charm new`
+- Update repeatedly with `deno task ct charm setsrc`
+- Inspect with `deno task ct charm inspect`
 
 **See ct skill for all command details.**
 

--- a/docs/common/PATTERNS.md
+++ b/docs/common/PATTERNS.md
@@ -762,7 +762,7 @@ echo '{"title": "Test", "done": false}' | \
 
 ### Tips for Fast Iteration
 
-- ✅ Use `ct dev` first to catch TypeScript errors
+- ✅ Use `deno task ct dev` first to catch TypeScript errors
 - ✅ Deploy once, then use `setsrc` for updates
 - ✅ Test one feature at a time
 - ✅ Use `charm inspect` to debug data issues
@@ -917,4 +917,4 @@ const categories = derive(groupedItems, (groups) => Object.keys(groups).sort());
 2. Use handlers for side effects and structural changes
 3. Use `derive()` for reactive transformations
 4. Keep it simple - don't over-engineer
-5. Test incrementally with `ct dev` and `charm setsrc`
+5. Test incrementally with `deno task ct dev` and `deno task ct charm setsrc`


### PR DESCRIPTION
Updated all documentation to consistently use 'deno task ct' instead of direct 'ct' invocation to avoid issues with potentially out-of-date binaries.

Changes:
- docs/common/PATTERNS.md: 2 references updated
- .claude/skills/ct/SKILL.md: 12 references updated
- .claude/skills/pattern-dev/SKILL.md: 4 references updated
- .claude/skills/pattern-dev/references/workflow-guide.md: 5 references updated

This ensures Claude Code always invokes the ct binary via the deno task, which guarantees the source is up-to-date and prevents confusing errors during pattern development.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized all docs to use deno task ct instead of calling ct directly. This ensures the latest binary is used and prevents path/version issues that caused confusing errors during pattern development.

<sup>Written for commit 12dc128da2241395a395e897cf9da91a706540d9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

