### PR TITLE
fix(transform): Add TaggedTemplateExpression emitter for str in styles

### DIFF
--- a/packages/ts-transformers/src/transformers/opaque-ref/emitters/mod.ts
+++ b/packages/ts-transformers/src/transformers/opaque-ref/emitters/mod.ts
@@ -5,4 +5,5 @@ export * from "./container-expression.ts";
 export * from "./element-access-expression.ts";
 export * from "./prefix-unary-expression.ts";
 export * from "./property-access.ts";
+export * from "./tagged-template-expression.ts";
 export * from "./template-expression.ts";

--- a/packages/ts-transformers/src/transformers/opaque-ref/emitters/tagged-template-expression.ts
+++ b/packages/ts-transformers/src/transformers/opaque-ref/emitters/tagged-template-expression.ts
@@ -1,0 +1,31 @@
+import ts from "typescript";
+
+import type { EmitterContext } from "../types.ts";
+import { createBindingPlan } from "../bindings.ts";
+import {
+  createDeriveCallForExpression,
+  filterRelevantDataFlows,
+} from "../helpers.ts";
+
+export const emitTaggedTemplateExpression = ({
+  expression,
+  dataFlows,
+  analysis,
+  context,
+}: EmitterContext) => {
+  if (!ts.isTaggedTemplateExpression(expression)) return undefined;
+  if (dataFlows.all.length === 0) return undefined;
+
+  const relevantDataFlows = filterRelevantDataFlows(
+    dataFlows.all,
+    analysis,
+    context,
+  );
+  if (relevantDataFlows.length === 0) return undefined;
+
+  // The tagged template expression contains opaque refs in its template spans
+  // We need to wrap the entire expression in a derive call
+  // No need to rewrite the template itself, just wrap it
+  const plan = createBindingPlan(relevantDataFlows);
+  return createDeriveCallForExpression(expression, plan, context);
+};

--- a/packages/ts-transformers/src/transformers/opaque-ref/rewrite.ts
+++ b/packages/ts-transformers/src/transformers/opaque-ref/rewrite.ts
@@ -15,6 +15,7 @@ import {
   emitElementAccessExpression,
   emitPrefixUnaryExpression,
   emitPropertyAccess,
+  emitTaggedTemplateExpression,
   emitTemplateExpression,
 } from "./emitters/mod.ts";
 
@@ -22,6 +23,7 @@ const EMITTERS: readonly Emitter[] = [
   emitPropertyAccess,
   emitBinaryExpression,
   emitCallExpression,
+  emitTaggedTemplateExpression,
   emitTemplateExpression,
   emitConditionalExpression,
   emitElementAccessExpression,


### PR DESCRIPTION
## Summary

Fixes a TypeScript compiler crash when using `str` template tags inside JSX style objects.

## Problem

When developers used the `str` helper in style attribute objects, the TypeScript compiler would crash with:

```
TypeError: Cannot read properties of undefined (reading 'templateFlags')
    at containsInvalidEscapeFlag (typescript.js:20016:19)
    at hasInvalidEscape (typescript.js:20019:107)
    at createTaggedTemplateExpression (typescript.js:26684:9)
```

### Minimal Reproduction

```typescript
<div style={{ width: str`${cellValue}%` }}>Test</div>
```

This pattern is useful for dynamic styling (e.g., progress bars, sizing based on cell values).

## Root Cause

The `emitTemplateExpression` emitter only handled `TemplateExpression` nodes (regular template literals), not `TaggedTemplateExpression` nodes (tagged templates like `str\`...\``).

When `str` templates appeared in style objects:
1. They weren't recognized by `emitTemplateExpression`
2. Fell through to default AST visiting
3. TypeScript's factory tried to update the node without proper handling
4. Crashed trying to access `templateFlags` on undefined

## Solution

Added `emitTaggedTemplateExpression` emitter that:
- Detects `TaggedTemplateExpression` nodes containing opaque refs
- Wraps the entire expression in a `derive()` call
- Enables `str` templates to work in any context, including style objects

## Before/After

**Before (required workaround):**
```typescript
const widthString = derive(cellValue, v => `${v}%`);
<div style={{ width: widthString }}>Test</div>
```

**After (now works directly):**
```typescript
<div style={{ width: str`${cellValue}%` }}>Test</div>
```

## Testing

- ✅ Minimal repro compiles successfully (previously crashed)
- ✅ Complex patterns with handlers compile
- ✅ All existing test cases still pass
- ✅ `str` still works correctly in NAME and JSX text content

Test files in recipes repo:
- `recipes/alex/WIP/test-template-minimal-repro.tsx` - 13 line minimal case
- `recipes/alex/WIP/test-template-error-*.tsx` - Progressive test cases
- `recipes/alex/BUG-REPORT-templateFlags.md` - Detailed analysis

## Use Cases Enabled

This fix enables:
- Dynamic progress bars with reactive widths
- Responsive sizing based on cell values  
- Color values computed from cells
- Any CSS property that needs cell interpolation

## Impact

Low risk - adds new emitter without changing existing logic. The emitter only activates for `TaggedTemplateExpression` nodes that contain opaque refs, leaving all other code paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a TypeScript crash when using str tagged templates in JSX style objects by adding an emitter for TaggedTemplateExpression that safely wraps these cases in derive().

- **Bug Fixes**
  - Added emitTaggedTemplateExpression and registered it in the emitter list.
  - Wraps tagged templates containing opaque refs in derive() to avoid templateFlags crashes.
  - Enables patterns like style={{ width: str`${value}%` }} without workarounds.
  - Low risk: only affects tagged templates with opaque refs; existing template handling unchanged.

<sup>Written for commit f6c5c112cecb46c71e182a037b3ebf99d3dd1a47. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

