### PR TITLE
chore: Align creation of sessions across the workspace

### DIFF
--- a/packages/background-charm-service/cast-admin.ts
+++ b/packages/background-charm-service/cast-admin.ts
@@ -3,7 +3,7 @@ import { CharmManager, compileRecipe } from "@commontools/charm";
 import { Runtime } from "@commontools/runner";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 import { type DID } from "@commontools/identity";
-import { createAdminSession } from "@commontools/identity";
+import { createSessionFromDid } from "@commontools/identity";
 import {
   BG_CELL_CAUSE,
   BG_SYSTEM_SPACE_ID,
@@ -87,9 +87,9 @@ async function castRecipe() {
     console.log("Casting recipe...");
 
     // Create session and charm manager (matching main.ts pattern)
-    const session = await createAdminSession({
+    const session = await createSessionFromDid({
       identity,
-      name: "recipe-caster",
+      spaceName: "recipe-caster",
       space: spaceId as DID,
     });
 

--- a/packages/background-charm-service/src/worker.ts
+++ b/packages/background-charm-service/src/worker.ts
@@ -12,7 +12,7 @@ import {
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
 
 import {
-  createAdminSession,
+  createSessionFromDid,
   type DID,
   Identity,
   Session,
@@ -93,9 +93,9 @@ async function initialize(
 
   // Initialize session
   spaceId = did as DID;
-  currentSession = await createAdminSession({
+  currentSession = await createSessionFromDid({
     identity,
-    name: "~background-service-worker",
+    spaceName: "~background-service-worker",
     space: spaceId,
   });
 

--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -226,7 +226,7 @@ export class CharmManager {
   }
 
   getSpaceName(): string {
-    return this.session.name;
+    return this.session.spaceName;
   }
 
   async synced(): Promise<void> {

--- a/packages/charm/src/ops/charms-controller.ts
+++ b/packages/charm/src/ops/charms-controller.ts
@@ -8,7 +8,7 @@ import { StorageManager } from "@commontools/runner/storage/cache";
 import { CharmManager } from "../index.ts";
 import { CharmController } from "./charm-controller.ts";
 import { compileProgram } from "./utils.ts";
-import { ANYONE, Identity } from "@commontools/identity";
+import { createSession, Identity } from "@commontools/identity";
 
 export interface CreateCharmOptions {
   input?: object;
@@ -114,17 +114,7 @@ export class CharmsController<T = unknown> {
     identity: Identity;
     spaceName: string;
   }): Promise<CharmsController> {
-    const account = spaceName.startsWith("~")
-      ? identity
-      : await Identity.fromPassphrase(ANYONE);
-    const user = await account.derive(spaceName);
-    const session = {
-      private: account.did() === identity.did(),
-      name: spaceName,
-      space: user.did(),
-      as: user,
-    };
-
+    const session = await createSession({ identity, spaceName });
     const runtime = new Runtime({
       apiUrl: new URL(apiUrl),
       storageManager: StorageManager.open({

--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -1,4 +1,4 @@
-import { ANYONE, Identity, Session } from "@commontools/identity";
+import { createSession, Session } from "@commontools/identity";
 import { ensureDir } from "@std/fs";
 import { loadIdentity } from "./identity.ts";
 import {
@@ -35,17 +35,8 @@ async function makeSession(config: SpaceConfig): Promise<Session> {
   if (config.space.startsWith("did:key")) {
     throw new Error("DID key spaces not yet supported.");
   }
-  const root = await loadIdentity(config.identity);
-  const account = config.space.startsWith("~")
-    ? root
-    : await Identity.fromPassphrase(ANYONE);
-  const user = await account.derive(config.space);
-  return {
-    private: account.did() === root.did(),
-    name: config.space,
-    space: user.did(),
-    as: user,
-  };
+  const identity = await loadIdentity(config.identity);
+  return createSession({ identity, spaceName: config.space });
 }
 
 export async function loadManager(config: SpaceConfig): Promise<CharmManager> {

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -8,7 +8,7 @@ export { KeyStore } from "./key-store.ts";
 export * from "./interface.ts";
 export {
   ANYONE,
-  createAdminSession,
   createSession,
+  createSessionFromDid,
   type Session,
 } from "./session.ts";

--- a/packages/runner/integration/array_push.test.ts
+++ b/packages/runner/integration/array_push.test.ts
@@ -33,8 +33,8 @@ async function runTest() {
   const space_thingy = await account.derive(SPACE_NAME);
   const space_thingy_space = space_thingy.did();
   const session = {
-    private: false,
-    name: SPACE_NAME,
+    isPrivate: false,
+    spaceName: SPACE_NAME,
     space: space_thingy_space,
     as: space_thingy,
   } as Session;

--- a/packages/runner/integration/derive_array_leak.test.ts
+++ b/packages/runner/integration/derive_array_leak.test.ts
@@ -85,8 +85,8 @@ async function runTest() {
   const space_thingy = await account.derive(SPACE_NAME);
   const space_thingy_space = space_thingy.did();
   const session = {
-    private: false,
-    name: SPACE_NAME,
+    isPrivate: false,
+    spaceName: SPACE_NAME,
     space: space_thingy_space,
     as: space_thingy,
   } as Session;

--- a/packages/seeder/cli.ts
+++ b/packages/seeder/cli.ts
@@ -46,7 +46,7 @@ setLLMUrl(apiUrl);
 const identity = await Identity.fromPassphrase("common user");
 const session = await createSession({
   identity,
-  name,
+  spaceName: name,
 });
 
 const runtime = new Runtime({

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -1,4 +1,4 @@
-import { ANYONE, Identity, Session } from "@commontools/identity";
+import { createSession, Identity } from "@commontools/identity";
 import {
   Runtime,
   RuntimeTelemetry,
@@ -17,25 +17,6 @@ const logger = getLogger("shell.telemetry", {
   enabled: false,
   level: "debug",
 });
-
-async function createSession(
-  root: Identity,
-  spaceName: string,
-): Promise<Session> {
-  const account = spaceName.startsWith("~")
-    ? root
-    : await Identity.fromPassphrase(ANYONE);
-
-  const user = await account.derive(spaceName);
-  const session = {
-    private: account.did() === root.did(),
-    name: spaceName,
-    space: user.did(),
-    as: user,
-  };
-
-  return session;
-}
 
 // RuntimeInternals bundles all of the lifetimes
 // of resources bound to an identity,host,space triplet,
@@ -103,7 +84,7 @@ export class RuntimeInternals extends EventTarget {
       apiUrl: URL;
     },
   ): Promise<RuntimeInternals> {
-    const session = await createSession(identity, spaceName);
+    const session = await createSession({ identity, spaceName });
 
     // We're hoisting CharmManager so that
     // we can create it after the runtime, but still reference

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -10,7 +10,7 @@ import {
 } from "@commontools/runner";
 import { StorageManager } from "@commontools/runner/storage/cache";
 import {
-  createAdminSession,
+  createSessionFromDid,
   type DID,
   Identity,
   type Session,
@@ -85,10 +85,10 @@ async function main() {
 
   const space: DID = spaceDID as DID ?? identity.did();
 
-  const session = await createAdminSession({
+  const session = await createSessionFromDid({
     identity,
     space,
-    name: spaceName ?? "unknown",
+    spaceName: spaceName ?? "unknown",
   }) satisfies Session;
 
   // TODO(seefeld): It only wants the space, so maybe we simplify the above and just space the space did?


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized session creation across packages by introducing createSession and createSessionFromDid, and renaming Session fields to spaceName and isPrivate. This removes duplicated logic and prepares for identity signing.

- **Refactors**
  - Replaced createAdminSession with createSessionFromDid in background service and scripts.
  - Centralized session derivation via createSession; removed local helpers in CLI and shell runtime.
  - Updated CharmManager and tests to use Session.spaceName.

- **Migration**
  - Rename Session.name to Session.spaceName and Session.private to Session.isPrivate.
  - Use createSession({ identity, spaceName }) for derived spaces; use createSessionFromDid({ identity, space, spaceName }) when a space DID is known.
  - Update imports from @commontools/identity to use createSession and createSessionFromDid.

<sup>Written for commit cfbaabe75ead08cf168e245856d11ae63688ba40. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



