### PR TITLE
draft: sign with identity key

### DIFF
--- a/packages/identity/src/session.ts
+++ b/packages/identity/src/session.ts
@@ -31,13 +31,14 @@ export const createSession = async (
   { identity, spaceName }: { identity: Identity; spaceName: string },
 ): Promise<Session> => {
   const isPrivate = spaceName.startsWith("~");
-  const account = isPrivate ? identity : await Identity.fromPassphrase(ANYONE);
-
-  const user = await account.derive(spaceName);
+  const derivedUser = await identity.derive(spaceName);
+  const spaceIdentity = isPrivate
+    ? derivedUser
+    : await (await Identity.fromPassphrase(ANYONE)).derive(spaceName);
   return {
     isPrivate,
     spaceName,
-    space: user.did(),
-    as: user,
+    space: spaceIdentity.did(),
+    as: derivedUser,
   };
 };


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Always derive the session identity (as) from the provided user identity, while keeping the public space DID derived from ANYONE.
This signs all sessions with the user’s key and preserves public space addressing.

<sup>Written for commit ba3961b8486d74ffedf992b31b06aad49fe262c3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



