### PR TITLE
Add getArgumentCell method to access recipe instance arguments

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -218,6 +218,10 @@ export interface ICreatable<C extends AnyBrandedCell<any>> {
  */
 export interface IResolvable<T, C extends AnyBrandedCell<T>> {
   resolveAsCell(): C;
+  getArgumentCell<S extends JSONSchema = JSONSchema>(
+    schema?: S,
+  ): Cell<Schema<S>> | undefined;
+  getArgumentCell<U>(): Cell<U> | undefined;
 }
 
 /**


### PR DESCRIPTION
This change introduces a new method `getArgumentCell()` that provides convenient
access to the argument cell of an instantiated recipe. This is useful when you
need to update the arguments of a running recipe instance and have the changes
automatically propagate through the reactive system.

Changes:
- Add `getArgumentCell()` method to IResolvable interface in packages/api/index.ts
  - Supports both generic type parameter and JSONSchema validation
  - Returns Cell<T> | undefined (undefined if no source cell exists)

- Implement `getArgumentCell()` in CellImpl (packages/runner/src/cell.ts)
  - Retrieves the source cell using existing getSourceCell() method
  - Kicks off sync to ensure latest data is available
  - Returns the "argument" key of the source cell with optional schema validation
  - Added to cellMethods set for proper proxy support

- Add comprehensive test in packages/runner/test/cell.test.ts
  - Tests reactive behavior: instantiates a doubling recipe with an initial argument
  - Updates the argument via getArgumentCell() and verifies output changes
  - Tests multiple updates to ensure continued reactivity

Use case: When working with recipe instances, you can now easily access and modify
their arguments without manually navigating to the source cell's argument field.
The method handles the complexity of retrieving the source cell and extracting
the argument field while ensuring proper synchronization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds getArgumentCell to recipe instance cells so you can directly read and update a running instance’s arguments. Edits propagate through the reactive graph automatically.

- **New Features**
  - API: IResolvable now exposes getArgumentCell with optional JSONSchema typing; returns a Cell or undefined if no source cell.
  - Runner: CellImpl pulls the source cell, triggers sync, and returns the "argument" subcell; added to cellMethods for proxy support.
  - Behavior: Update arguments via getArgumentCell and see outputs update reactively.
  - Tests: Added a doubling recipe test that verifies reactive output changes across multiple argument edits.

<sup>Written for commit a8e82a5c0091632db9ab5a1fcbda135012d525bc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

