### PR TITLE
restart server script

### DIFF
--- a/scripts/restart-local-dev.sh
+++ b/scripts/restart-local-dev.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Change to repository root (parent of scripts directory)
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR/.."
+
+# Parse command line arguments
+CLEAR_CACHE=false
+FORCE=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --clear-cache)
+            CLEAR_CACHE=true
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--clear-cache] [--force]"
+            exit 1
+            ;;
+    esac
+done
+
+echo "Stopping local dev servers..."
+./scripts/stop-local-dev.sh
+
+if [[ "$CLEAR_CACHE" == "true" ]]; then
+    echo "Clearing cache..."
+    rm -rf packages/toolshed/cache/*
+    echo "Cache cleared."
+fi
+
+echo "Starting local dev servers..."
+if [[ "$FORCE" == "true" ]]; then
+    ./scripts/start-local-dev.sh --force
+else
+    ./scripts/start-local-dev.sh
+fi


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a restart-local-dev.sh script to restart local dev servers in one step, with optional cache clearing and forced start for clean rebuilds. Speeds up local iteration by automating stop/start and cache cleanup.

- **New Features**
  - Stops servers, optionally clears packages/toolshed/cache/*, then starts servers.
  - Supports --clear-cache and --force (forwarded to start-local-dev.sh).
  - Runs from repo root and shows usage on invalid flags.

<sup>Written for commit 68c2a7eccd13e40ac08b2e3b78e8450f205e7b4b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

