### PR TITLE
fix(default-app): Change 'Patterns' header to 'Pages'

### DIFF
--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -177,7 +177,7 @@ export default recipe<CharmsListInput, CharmsListOutput>(
                 }
               `}
               </style>
-              <h2>Patterns</h2>
+              <h2>Pages</h2>
 
               <ct-table full-width hover>
                 <tbody>


### PR DESCRIPTION
## Summary
- Changed the header label in default-app.tsx from "Patterns" to "Pages"

This single-line change updates the UI label to better reflect the purpose of the charm list.

## Test plan
- [ ] Verify the header displays "Pages" instead of "Patterns" in the default app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the default app header from "Patterns" to "Pages" to better reflect the list contents. UI-only change with no functional impact.

<sup>Written for commit 27153a440a46720f5b1275cbd442d32b48d1793e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

