### PR TITLE
feat: ACLs in spaces.

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -99,6 +99,7 @@
   "imports": {
     "commontools": "./packages/api/index.ts",
     "core-js/proposals/explicit-resource-management": "https://esm.sh/core-js/proposals/explicit-resource-management",
+    "core-js/proposals/async-explicit-resource-management": "https://esm.sh/core-js/proposals/async-explicit-resource-management",
     "@astral/astral": "./packages/vendor-astral/mod.ts",
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.8",
     "@std/assert": "jsr:@std/assert@^1",

--- a/deno.lock
+++ b/deno.lock
@@ -1767,10 +1767,13 @@
     }
   },
   "redirects": {
+    "https://esm.sh/core-js/proposals/async-explicit-resource-management": "https://esm.sh/core-js@3.44.0/proposals/async-explicit-resource-management",
     "https://esm.sh/core-js/proposals/explicit-resource-management": "https://esm.sh/core-js@3.44.0/proposals/explicit-resource-management"
   },
   "remote": {
+    "https://esm.sh/core-js@3.44.0/denonext/proposals/async-explicit-resource-management.mjs": "8fc19e1aaec982c8920a598a2e5cdc01a865f65bee8421b04edd7e5bb6c45564",
     "https://esm.sh/core-js@3.44.0/denonext/proposals/explicit-resource-management.mjs": "4850503a2650ba47368eb95b1aa2565b47bad32efe9738766811f6de75cf51e1",
+    "https://esm.sh/core-js@3.44.0/proposals/async-explicit-resource-management": "7298a78cddda0e6a5f0ee8cf6fd3ca963e7820daa5553469c2a52ead4be1cdb1",
     "https://esm.sh/core-js@3.44.0/proposals/explicit-resource-management": "06969d679705ab37fd058cc66a50cd7648f79bf5fd86fb13b29cb93c2667ebc7"
   },
   "workspace": {

--- a/packages/charm/src/ops/acl-manager.ts
+++ b/packages/charm/src/ops/acl-manager.ts
@@ -1,0 +1,60 @@
+import { ACL, ACL_TYPE, ACLUser, DID } from "@commontools/memory/acl";
+import { Capability } from "@commontools/memory/interface";
+import { Cell, Runtime } from "@commontools/runner";
+
+export class ACLManager {
+  #runtime: Runtime;
+  #spaceDid: DID;
+  constructor(runtime: Runtime, spaceDid: DID) {
+    this.#runtime = runtime;
+    this.#spaceDid = spaceDid;
+  }
+
+  // Returns the `ACL` for this space.
+  // Throws if the space failed to initialize an ACL.
+  async get(): Promise<ACL> {
+    const aclCell = this.#getCell();
+    await aclCell.sync();
+    const aclData = aclCell.get();
+    await this.#runtime.storageManager.synced();
+
+    if (!aclData || Object.keys(aclData).length === 0) {
+      throw new Error("No ACL initialized for space.");
+    }
+
+    return JSON.parse(JSON.stringify(aclData)) as ACL;
+  }
+
+  // Add or update an ACL entry for a DID.
+  // Throws if the space failed to initialize an ACL.
+  async set(user: ACLUser, capability: Capability): Promise<void> {
+    const acl = await this.get();
+    acl[user] = capability;
+    await this.#write(acl);
+  }
+
+  // Remove an ACL entry for a DID
+  // Throws if the space failed to initialize an ACL.
+  async remove(user: ACLUser): Promise<void> {
+    const acl = await this.get();
+    delete acl[user];
+    await this.#write(acl);
+  }
+
+  async #write(acl: ACL): Promise<void> {
+    await this.#runtime.editWithRetry((tx) => {
+      this.#getCell().withTx(tx).set(acl);
+    });
+    await this.#runtime.idle();
+    await this.#runtime.storageManager.synced();
+  }
+
+  #getCell(): Cell<unknown> {
+    return this.#runtime.getCellFromLink({
+      id: this.#spaceDid,
+      path: [],
+      space: this.#spaceDid,
+      type: ACL_TYPE,
+    });
+  }
+}

--- a/packages/charm/src/ops/charms-controller.ts
+++ b/packages/charm/src/ops/charms-controller.ts
@@ -9,6 +9,7 @@ import { CharmManager } from "../index.ts";
 import { CharmController } from "./charm-controller.ts";
 import { compileProgram } from "./utils.ts";
 import { createSession, Identity } from "@commontools/identity";
+import { ACLManager } from "./acl-manager.ts";
 
 export interface CreateCharmOptions {
   input?: object;
@@ -120,11 +121,16 @@ export class CharmsController<T = unknown> {
       storageManager: StorageManager.open({
         as: session.as,
         address: new URL("/api/storage/memory", apiUrl),
+        spaceIdentity: session.spaceIdentity,
       }),
     });
 
     const manager = new CharmManager(session, runtime);
     await manager.synced();
     return new CharmsController(manager);
+  }
+
+  acl(): ACLManager {
+    return new ACLManager(this.#manager.runtime, this.#manager.getSpace());
   }
 }

--- a/packages/charm/src/ops/mod.ts
+++ b/packages/charm/src/ops/mod.ts
@@ -1,3 +1,4 @@
 export { CharmsController } from "./charms-controller.ts";
+export { ACLManager } from "./acl-manager.ts";
 export type { CharmController } from "./charm-controller.ts";
 export * from "./utils.ts";

--- a/packages/cli/commands/acl.ts
+++ b/packages/cli/commands/acl.ts
@@ -1,0 +1,126 @@
+import { Command } from "@cliffy/command";
+import { Table } from "@cliffy/table";
+import {
+  getAcl,
+  removeAclEntry,
+  setAclEntry,
+  SpaceConfig,
+} from "../lib/acl.ts";
+import { render } from "../lib/render.ts";
+import { isCapability } from "@commontools/memory";
+
+// Usage patterns for examples
+const spaceUsage = `--identity <identity> --api-url <api-url> --space <space>`;
+
+export const acl = new Command()
+  .name("acl")
+  .description("Manage Access Control Lists for spaces.")
+  .default("help")
+  .globalEnv("CT_API_URL=<url:string>", "URL of the fabric instance.", {
+    prefix: "CT_",
+  })
+  .globalOption("-a,--api-url <url:string>", "URL of the fabric instance.")
+  .globalEnv("CT_IDENTITY=<path:string>", "Path to an identity keyfile.", {
+    prefix: "CT_",
+  })
+  .globalOption("-i,--identity <path:string>", "Path to an identity keyfile.")
+  .globalOption("-s,--space <space:string>", "The space name or DID")
+  /* acl ls */
+  .command("ls", "List all ACL entries for a space.")
+  .usage(spaceUsage)
+  .example(
+    "ct acl ls --identity ./my.key --api-url https://api.example.com --space my-space",
+    "List all ACL entries for my-space",
+  )
+  .action(async (options) => {
+    const config = parseSpaceOptions(options);
+    const aclData = await getAcl(config);
+
+    if (!aclData || Object.keys(aclData).length === 0) {
+      render("No ACL entries found.");
+      return;
+    }
+
+    new Table()
+      .header(["DID", "CAPABILITY"])
+      .body(
+        Object.entries(aclData).map(([did, capability]) => [did, capability]),
+      )
+      .border(true)
+      .render();
+  })
+  /* acl set */
+  .command(
+    "set <did:string> <capability:string>",
+    "Applies a capability (READ, WRITE, OWNER) to an identity (DID) to the space ACL.",
+  )
+  .usage(`${spaceUsage} <did> <capability>`)
+  .example(
+    "ct acl set did:key:z6Mkk... WRITE --identity ./my.key --api-url https://api.example.com --space my-space",
+    "Grant WRITE capability to a DID",
+  )
+  .action(async (options, did, capability) => {
+    const cap = capability.toUpperCase();
+    if (!isCapability(cap)) {
+      render(
+        `Invalid capability: ${capability}. Must be one of: READ, WRITE, OWNER`,
+      );
+      Deno.exit(1);
+    }
+
+    const config = parseSpaceOptions(options);
+    await setAclEntry(
+      config,
+      did,
+      cap as "READ" | "WRITE" | "OWNER",
+    );
+    render(`Added ${did} with ${cap} capability`);
+  })
+  /* acl remove */
+  .command("remove <did:string>", "Remove a DID from the space ACL.")
+  .usage(`${spaceUsage} <did>`)
+  .example(
+    "ct acl remove did:key:z6Mkk... --identity ./my.key --api-url https://api.example.com --space my-space",
+    "Remove a DID from the ACL",
+  )
+  .action(async (options, did) => {
+    const config = parseSpaceOptions(options);
+    await removeAclEntry(config, did);
+    render(`Removed ${did} from ACL`);
+  });
+
+/**
+ * Parse space-related options from command arguments
+ */
+function parseSpaceOptions(
+  options: Record<string, string | undefined>,
+): SpaceConfig {
+  const apiUrl = options.apiUrl || Deno.env.get("CT_API_URL");
+  const identity = options.identity || Deno.env.get("CT_IDENTITY");
+  const space = options.space;
+
+  if (!apiUrl) {
+    render(
+      "Error: --api-url is required or set CT_API_URL environment variable",
+    );
+    Deno.exit(1);
+  }
+
+  if (!identity) {
+    render(
+      "Error: --identity is required or set CT_IDENTITY environment variable",
+    );
+    Deno.exit(1);
+  }
+
+  if (!space) {
+    render("Error: --space is required");
+    Deno.exit(1);
+  }
+
+  return {
+    apiUrl: new URL(apiUrl),
+    identityPath: identity,
+    spaceName: space,
+  };
+}

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -1,5 +1,6 @@
 import { Command } from "@cliffy/command";
 import { HelpCommand } from "@cliffy/command/help";
+import { acl } from "./acl.ts";
 import { dev } from "./dev.ts";
 import { init } from "./init.ts";
 import { charm } from "./charm.ts";
@@ -20,6 +21,8 @@ export const main = new Command()
   // and cannot match. Still seeing IDE typing errors, but at least
   // deno checker is satisfied.
   .reset()
+  // @ts-ignore for the above type issue
+  .command("acl", acl)
   // @ts-ignore for the above type issue
   .command("charm", charm)
   .command("dev", dev)

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -4,7 +4,8 @@
     "cli": "ROOT=$(pwd) && cd $INIT_CWD && deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env \"$ROOT/mod.ts\"",
     "cli-no-pwd-override": "deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env ./mod.ts",
     "test": "deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env test/*.test.ts",
-    "integration": "CT_CLI_INTEGRATION_USE_LOCAL=1 LOG_LEVEL=warn ./integration/integration.sh"
+    "integration": "CT_CLI_INTEGRATION_USE_LOCAL=1 LOG_LEVEL=warn ./integration/integration.sh",
+    "acl-integration": "CT_CLI_INTEGRATION_USE_LOCAL=1 LOG_LEVEL=warn ./integration/acl.sh"
   },
   "exports": {
     ".": "./mod.ts"

--- a/packages/cli/integration/acl.sh
+++ b/packages/cli/integration/acl.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+error () {
+  >&2 echo "ERROR: $1"
+  exit 1
+}
+
+success () {
+  echo "✓ $1"
+}
+
+if [ -n "$CT_CLI_INTEGRATION_USE_LOCAL" ]; then
+ ct() {
+   deno task cli "$@"
+ }
+fi
+
+if [ -z "$API_URL" ]; then
+  error "API_URL must be defined."
+fi
+
+# Setup test environment
+SPACE=$(mktemp -u XXXXXXXXXX) # generates a random space name
+IDENTITY_OWNER=$(mktemp)
+IDENTITY_USER1=$(mktemp)
+IDENTITY_USER2=$(mktemp)
+IDENTITY_USER3=$(mktemp)
+RECIPE_SRC="$SCRIPT_DIR/recipe/main.tsx"
+WORK_DIR=$(mktemp -d)
+
+# Create identities
+ct id new > $IDENTITY_OWNER
+ct id new > $IDENTITY_USER1
+ct id new > $IDENTITY_USER2
+ct id new > $IDENTITY_USER3
+
+DID_OWNER=$(ct id did $IDENTITY_OWNER)
+DID_USER1=$(ct id did $IDENTITY_USER1)
+DID_USER2=$(ct id did $IDENTITY_USER2)
+DID_USER3=$(ct id did $IDENTITY_USER3)
+
+# Helper to create space args for each identity
+SPACE_ARGS_OWNER="--api-url=$API_URL --identity=$IDENTITY_OWNER --space=$SPACE"
+SPACE_ARGS_USER1="--api-url=$API_URL --identity=$IDENTITY_USER1 --space=$SPACE"
+SPACE_ARGS_USER2="--api-url=$API_URL --identity=$IDENTITY_USER2 --space=$SPACE"
+SPACE_ARGS_USER3="--api-url=$API_URL --identity=$IDENTITY_USER3 --space=$SPACE"
+
+echo "=========================================="
+echo "ACL Integration Test Suite"
+echo "=========================================="
+echo "API_URL=$API_URL"
+echo "SPACE=$SPACE"
+echo "DID_OWNER=$DID_OWNER"
+echo "DID_USER1=$DID_USER1"
+echo "DID_USER2=$DID_USER2"
+echo "DID_USER3=$DID_USER3"
+echo "WORK_DIR=$WORK_DIR"
+echo ""
+
+# Test 1: Initial space creation - owner should have automatic access
+echo "Test 1: Initial space creation and owner access"
+CHARM_ID=$(ct charm new --main-export customRecipeExport $SPACE_ARGS_OWNER $RECIPE_SRC)
+echo "Created charm: $CHARM_ID"
+
+if ! ct charm ls $SPACE_ARGS_OWNER | grep -q "$CHARM_ID"; then
+  error "Owner should be able to list their own charm"
+fi
+success "Owner has automatic access to newly created space"
+
+# Test 2: ACL initialization - owner should be in initial ACL
+echo ""
+echo "Test 2: ACL initialization"
+ACL_OUTPUT=$(ct acl ls $SPACE_ARGS_OWNER)
+if ! echo "$ACL_OUTPUT" | grep -q "$DID_OWNER"; then
+  error "Owner DID should be in ACL after space creation"
+fi
+if ! echo "$ACL_OUTPUT" | grep -q "OWNER"; then
+  error "Owner should have OWNER capability"
+fi
+success "ACL initialized with owner having OWNER capability"
+
+# Test 3: Non-authorized users cannot access space
+echo ""
+echo "Test 3: Access control - unauthorized users"
+if ct charm ls $SPACE_ARGS_USER1 2>/dev/null | grep -q "$CHARM_ID"; then
+  error "USER1 should not have access without ACL entry"
+fi
+success "Unauthorized user cannot access space"
+
+if ct charm ls $SPACE_ARGS_USER2 2>/dev/null | grep -q "$CHARM_ID"; then
+  error "USER2 should not have access without ACL entry"
+fi
+success "Multiple unauthorized users correctly denied access"
+
+# Test 4: Set READ capability
+echo ""
+echo "Test 4: Set READ capability"
+ct acl set $DID_USER1 READ $SPACE_ARGS_OWNER
+success "Added USER1 with READ capability"
+
+# Verify USER1 appears in ACL
+ACL_OUTPUT=$(ct acl ls $SPACE_ARGS_OWNER)
+if ! echo "$ACL_OUTPUT" | grep -q "$DID_USER1"; then
+  error "USER1 should appear in ACL after addition"
+fi
+if ! echo "$ACL_OUTPUT" | grep "$DID_USER1" | grep -q "READ"; then
+  error "USER1 should have READ capability"
+fi
+success "USER1 correctly listed in ACL with READ capability"
+
+# Verify USER1 can now read
+if ! ct charm ls $SPACE_ARGS_USER1 | grep -q "$CHARM_ID"; then
+  error "USER1 with READ capability should be able to list charms"
+fi
+success "USER1 with READ capability can query/read data"
+
+# Test 5: READ capability does not allow writes
+echo ""
+echo "Test 5: READ capability restrictions"
+if ct charm new --main-export customRecipeExport $SPACE_ARGS_USER1 $RECIPE_SRC 2>/dev/null; then
+  error "USER1 with READ should not be able to create charms"
+fi
+success "READ capability correctly prevents write operations"
+
+# Test 6: Set WRITE capability
+echo ""
+echo "Test 6: Set WRITE capability"
+ct acl set $DID_USER2 WRITE $SPACE_ARGS_OWNER
+success "Added USER2 with WRITE capability"
+
+# Verify USER2 can read
+if ! ct charm ls $SPACE_ARGS_USER2 | grep -q "$CHARM_ID"; then
+  error "USER2 with WRITE capability should be able to read"
+fi
+success "USER2 with WRITE capability can read data"
+
+# Verify USER2 can write
+CHARM_ID2=$(ct charm new --main-export customRecipeExport $SPACE_ARGS_USER2 $RECIPE_SRC)
+if [ -z "$CHARM_ID2" ]; then
+  error "USER2 with WRITE capability should be able to create charms"
+fi
+success "USER2 with WRITE capability can write data"
+
+# Test 7: Upgrade capability from READ to WRITE
+echo ""
+echo "Test 7: Upgrade capability (READ -> WRITE)"
+ct acl set $DID_USER1 WRITE $SPACE_ARGS_OWNER
+success "Upgraded USER1 from READ to WRITE"
+
+# Verify upgrade
+ACL_OUTPUT=$(ct acl ls $SPACE_ARGS_OWNER)
+if ! echo "$ACL_OUTPUT" | grep "$DID_USER1" | grep -q "WRITE"; then
+  error "USER1 should now have WRITE capability"
+fi
+success "USER1 capability correctly upgraded to WRITE"
+
+# Verify USER1 can now write
+CHARM_ID3=$(ct charm new --main-export customRecipeExport $SPACE_ARGS_USER1 $RECIPE_SRC)
+if [ -z "$CHARM_ID3" ]; then
+  error "USER1 with upgraded WRITE capability should be able to create charms"
+fi
+success "USER1 with upgraded WRITE capability can now write"
+
+# Test 8: Add OWNER capability
+echo ""
+echo "Test 8: Set OWNER capability"
+ct acl set $DID_USER3 OWNER $SPACE_ARGS_OWNER
+success "Added USER3 with OWNER capability"
+
+# Verify USER3 can manage ACL (owner capability)
+ct acl set $DID_USER2 OWNER $SPACE_ARGS_USER3
+success "USER3 with OWNER capability can modify ACL"
+
+# Verify the change
+ACL_OUTPUT=$(ct acl ls $SPACE_ARGS_OWNER)
+if ! echo "$ACL_OUTPUT" | grep "$DID_USER2" | grep -q "OWNER"; then
+  error "USER2 should now have OWNER capability"
+fi
+success "USER3 successfully modified ACL with OWNER capability"
+
+# Test 9: Remove ACL entry
+echo ""
+echo "Test 9: Remove ACL entry"
+ct acl remove $DID_USER1 $SPACE_ARGS_OWNER
+success "Removed USER1 from ACL"
+
+# Verify removal
+ACL_OUTPUT=$(ct acl ls $SPACE_ARGS_OWNER)
+if echo "$ACL_OUTPUT" | grep -q "$DID_USER1"; then
+  error "USER1 should not appear in ACL after removal"
+fi
+success "USER1 successfully removed from ACL"
+
+# Verify USER1 no longer has access
+if ct charm ls $SPACE_ARGS_USER1 2>/dev/null | grep -q "$CHARM_ID"; then
+  error "USER1 should not have access after removal from ACL"
+fi
+success "USER1 access revoked after ACL removal"
+
+# Test 10: Multiple ACL entries
+echo ""
+echo "Test 10: List multiple ACL entries"
+ACL_OUTPUT=$(ct acl ls $SPACE_ARGS_OWNER)
+ACL_COUNT=$(echo "$ACL_OUTPUT" | grep -c "did:key:" || true)
+
+# Should have at least: OWNER (original), USER2 (OWNER), USER3 (OWNER)
+if [ "$ACL_COUNT" -lt 3 ]; then
+  error "ACL should contain at least 3 entries"
+fi
+success "ACL correctly lists multiple entries"
+
+# Verify specific capabilities are correct
+if ! echo "$ACL_OUTPUT" | grep "$DID_OWNER" | grep -q "OWNER"; then
+  error "Original owner should still have OWNER capability"
+fi
+if ! echo "$ACL_OUTPUT" | grep "$DID_USER2" | grep -q "OWNER"; then
+  error "USER2 should have OWNER capability"
+fi
+if ! echo "$ACL_OUTPUT" | grep "$DID_USER3" | grep -q "OWNER"; then
+  error "USER3 should have OWNER capability"
+fi
+success "All ACL entries have correct capabilities"
+
+# Test 11: Non-owner with OWNER capability can remove others
+echo ""
+echo "Test 11: OWNER capability allows removing other users"
+ct acl remove $DID_USER3 $SPACE_ARGS_USER2
+success "USER2 (OWNER) successfully removed USER3"
+
+# Verify removal
+ACL_OUTPUT=$(ct acl ls $SPACE_ARGS_OWNER)
+if echo "$ACL_OUTPUT" | grep -q "$DID_USER3"; then
+  error "USER3 should not appear in ACL after removal by USER2"
+fi
+success "USER3 successfully removed by non-original owner with OWNER capability"
+
+# Test 12: Downgrade capability (OWNER -> READ)
+echo ""
+echo "Test 12: Downgrade capability (OWNER -> READ)"
+ct acl set $DID_USER2 READ $SPACE_ARGS_OWNER
+success "Downgraded USER2 from OWNER to READ"
+
+# Verify downgrade
+ACL_OUTPUT=$(ct acl ls $SPACE_ARGS_OWNER)
+if ! echo "$ACL_OUTPUT" | grep "$DID_USER2" | grep -q "READ"; then
+  error "USER2 should now have READ capability"
+fi
+success "USER2 capability correctly downgraded to READ"
+
+# Verify USER2 can no longer write
+if ct charm new --main-export customRecipeExport $SPACE_ARGS_USER2 $RECIPE_SRC 2>/dev/null; then
+  error "USER2 with downgraded READ should not be able to create charms"
+fi
+success "Downgraded USER2 correctly restricted to READ operations"
+
+# Verify USER2 can no longer manage ACL
+if ct acl set $DID_USER1 READ $SPACE_ARGS_USER2 2>/dev/null; then
+  error "USER2 with READ should not be able to modify ACL"
+fi
+success "Downgraded USER2 cannot manage ACL"
+
+# Cleanup
+echo ""
+echo "=========================================="
+echo "Cleaning up test artifacts..."
+rm -f $IDENTITY_OWNER $IDENTITY_USER1 $IDENTITY_USER2 $IDENTITY_USER3
+rm -rf $WORK_DIR
+echo "Cleanup complete"
+
+echo ""
+echo "=========================================="
+echo "✓ All ACL tests passed!"
+echo "=========================================="

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -1,0 +1,94 @@
+import { createSession, Session } from "@commontools/identity";
+import { loadIdentity } from "./identity.ts";
+import { Runtime } from "@commontools/runner";
+import { StorageManager } from "@commontools/runner/storage/cache";
+import {
+  ACL,
+  ACLUser,
+  type Capability,
+  isACLUser,
+} from "@commontools/memory/acl";
+import { ACLManager } from "@commontools/charm/ops";
+
+export interface SpaceConfig {
+  apiUrl: URL;
+  identityPath: string;
+  spaceName: string;
+}
+
+// Create an identity and session from configuration.
+async function loadSession(config: SpaceConfig): Promise<Session> {
+  const identity = await loadIdentity(config.identityPath);
+  const session = await createSession({
+    identity,
+    spaceName: config.spaceName,
+  });
+  return session;
+}
+
+// Creates a Runtime instance for ACL operations
+export async function createRuntime(
+  config: SpaceConfig,
+  session: Session,
+): Promise<Runtime> {
+  const runtime = new Runtime({
+    apiUrl: config.apiUrl,
+    storageManager: StorageManager.open({
+      as: session.as,
+      address: new URL("/api/storage/memory", config.apiUrl),
+      spaceIdentity: session.spaceIdentity,
+    }),
+  });
+
+  if (!(await runtime.healthCheck())) {
+    throw new Error(`Could not connect to "${config.apiUrl.toString()}".`);
+  }
+
+  await runtime.storageManager.synced();
+  return runtime;
+}
+
+// Add or update an ACL entry for a DID
+export async function setAclEntry(
+  config: SpaceConfig,
+  user: string,
+  capability: Capability,
+): Promise<void> {
+  const userDid = userToACLUser(user);
+  const session = await loadSession(config);
+  await using runtime = await createRuntime(config, session);
+  const aclManager = new ACLManager(runtime, session.space);
+  await aclManager.set(userDid, capability);
+}
+
+// Remove an ACL entry for a DID
+export async function removeAclEntry(
+  config: SpaceConfig,
+  user: string,
+): Promise<void> {
+  const userDid = userToACLUser(user);
+  const session = await loadSession(config);
+  await using runtime = await createRuntime(config, session);
+  const aclManager = new ACLManager(runtime, session.space);
+  await aclManager.remove(userDid);
+}
+
+// Get the current ACL for a space
+export async function getAcl(
+  config: SpaceConfig,
+): Promise<ACL | null> {
+  const session = await loadSession(config);
+  await using runtime = await createRuntime(config, session);
+  const aclManager = new ACLManager(runtime, session.space);
+  return await aclManager.get();
+}
+
+// Use "ANYONE" on the command line to map to "*"
+// to avoid shell expansion.
+function userToACLUser(user: string): ACLUser {
+  user = user === "ANYONE" ? "*" : user;
+  if (!isACLUser(user)) {
+    throw new Error(`${user} is not "ANYONE" or a valid DID.`);
+  }
+  return user as ACLUser;
+}

--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -49,6 +49,7 @@ export async function loadManager(config: SpaceConfig): Promise<CharmManager> {
     storageManager: StorageManager.open({
       as: session.as,
       address: new URL("/api/storage/memory", config.apiUrl),
+      spaceIdentity: session.spaceIdentity,
     }),
     navigateCallback: (target) => {
       try {

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -7,7 +7,6 @@ export {
 export { KeyStore } from "./key-store.ts";
 export * from "./interface.ts";
 export {
-  ANYONE,
   createSession,
   createSessionFromDid,
   type Session,

--- a/packages/identity/src/session.ts
+++ b/packages/identity/src/session.ts
@@ -1,10 +1,9 @@
 import { Identity } from "./identity.ts";
 import { type DID } from "./interface.ts";
-export const ANYONE = "common user";
 
 export type Session = {
-  isPrivate: boolean;
   spaceName: string;
+  spaceIdentity?: Identity;
   space: DID;
   as: Identity;
 };
@@ -17,9 +16,7 @@ export const createSessionFromDid = (
     spaceName: string;
   },
 ): Promise<Session> => {
-  const isPrivate = spaceName.startsWith("~");
   return Promise.resolve({
-    isPrivate,
     spaceName,
     space,
     as: identity,
@@ -30,14 +27,14 @@ export const createSessionFromDid = (
 export const createSession = async (
   { identity, spaceName }: { identity: Identity; spaceName: string },
 ): Promise<Session> => {
-  const isPrivate = spaceName.startsWith("~");
-  const account = isPrivate ? identity : await Identity.fromPassphrase(ANYONE);
-
-  const user = await account.derive(spaceName);
+  const spaceIdentity = await (await Identity.fromPassphrase("common user"))
+    .derive(
+      spaceName,
+    );
   return {
-    isPrivate,
     spaceName,
-    space: user.did(),
-    as: user,
+    spaceIdentity,
+    space: spaceIdentity.did(),
+    as: identity,
   };
 };

--- a/packages/memory/acl.ts
+++ b/packages/memory/acl.ts
@@ -1,0 +1,94 @@
+import { isRecord } from "@commontools/utils/types";
+import {
+  ACL,
+  ACLUser,
+  ANYONE,
+  Capability,
+  DID,
+  DIDKey,
+  MIME,
+} from "./interface.ts";
+import { isDID } from "../identity/src/interface.ts";
+
+export type { ACL, ACLUser, ANYONE, Capability, DID, DIDKey };
+
+/**
+ * Well-known MIME type for the Access Control List
+ *
+ * Syncing requires `"application/json"`, but could be e.g.
+ * `"application/acl+json"` in the future.
+ */
+export const ACL_TYPE: MIME = "application/json" as const;
+
+export const ANYONE_USER: ANYONE = "*";
+
+export function isACLUser(value: unknown): value is ACLUser {
+  return value === ANYONE_USER || isDID(value);
+}
+
+export function isCapability(value: unknown): value is Capability {
+  return value === "READ" || value === "WRITE" || value === "OWNER";
+}
+
+export function isACL(value: unknown): value is ACL {
+  if (!isRecord(value)) return false;
+  for (const [did, cap] of Object.entries(value)) {
+    if (!isACLUser(did)) return false;
+    if (!isCapability(cap)) return false;
+  }
+  return true;
+}
+
+/**
+ * Checks if an issuer has the required capability in the ACL.
+ * Returns true if authorized, false otherwise.
+ */
+export function checkACL(
+  acl: ACL,
+  issuerDid: DID,
+  command: string,
+): boolean {
+  if (
+    acl[issuerDid] && isCapable(acl[issuerDid], commandRequirement(command))
+  ) {
+    return true;
+  }
+  if (
+    acl[ANYONE_USER] && isCapable(acl[ANYONE_USER], commandRequirement(command))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+const CapabilityMap: Record<Capability, number> = {
+  READ: 0,
+  WRITE: 1,
+  OWNER: 2,
+};
+
+function isCapable(
+  capability: Capability,
+  requirement: Capability,
+): boolean {
+  return CapabilityMap[capability] >=
+    CapabilityMap[requirement];
+}
+
+/**
+ * Determines required capability based on the command.
+ * - /memory/transact requires WRITE or OWNER
+ * - /memory/query requires READ, WRITE, or OWNER
+ * - Other commands require OWNER
+ */
+function commandRequirement(cmd: string): Capability {
+  if (cmd === "/memory/transact") {
+    return "WRITE";
+  } else if (
+    cmd === "/memory/query" || cmd.startsWith("/memory/query/") ||
+    cmd.startsWith("/memory/graph/")
+  ) {
+    return "READ";
+  }
+  return "OWNER";
+}

--- a/packages/memory/consumer.ts
+++ b/packages/memory/consumer.ts
@@ -319,6 +319,7 @@ class MemoryConsumerSession<
 }
 
 export interface MemorySession<Space extends MemorySpace> {
+  as: Signer;
   mount<Subject extends Space>(space: Subject): MemorySpaceSession<Subject>;
 }
 
@@ -329,9 +330,11 @@ export interface MemoryConsumer<Space extends MemorySpace>
       ProviderCommand<Protocol>,
       UCAN<ConsumerCommandInvocation<Protocol>>
     > {
+  as: Signer;
 }
 
 export interface MemorySpaceSession<Space extends MemorySpace = MemorySpace> {
+  as: Signer;
   transact(source: Transaction<Space>["args"]): TransactionResult<Space>;
   query(
     source: Query["args"] | SchemaQuery["args"],
@@ -342,10 +345,13 @@ export type { QueryView };
 
 class MemorySpaceConsumerSession<Space extends MemorySpace>
   implements MemorySpaceSession<Space> {
+  as: Signer;
   constructor(
     public space: Space,
     public session: MemoryConsumerSession<Space, Protocol<Space>>,
-  ) {}
+  ) {
+    this.as = session.as;
+  }
   transact(source: Transaction["args"]) {
     return this.session.invoke({
       cmd: "/memory/transact",

--- a/packages/memory/deno.json
+++ b/packages/memory/deno.json
@@ -26,6 +26,7 @@
   },
   "exports": {
     ".": "./lib.ts",
+    "./acl": "./acl.ts",
     "./deno": "./deno.ts",
     "./interface": "./interface.ts",
     "./fact": "./fact.ts",

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -722,6 +722,25 @@ export type DID = `did:${string}:${string}`;
 
 export type DIDKey = `did:key:${string}`;
 
+export type ANYONE = "*";
+
+export type ACLUser = DID | ANYONE;
+
+/**
+ * Capability levels for space access control.
+ * - READ: Can query and read data from the space
+ * - WRITE: Can read and transact (write) data to the space
+ * - OWNER: Full control including ACL management
+ */
+export type Capability = "READ" | "WRITE" | "OWNER";
+
+/**
+ * Access Control List entry mapping DIDs to their capabilities
+ */
+export type ACL = {
+  [user in ACLUser]?: Capability;
+};
+
 // Entity identifier (typically `of:<base32-digest>`, but sometimes `did:<something>`).
 export type URI = `${string}:${string}`;
 // Mime type or Media Type -- often called 'the'

--- a/packages/memory/lib.ts
+++ b/packages/memory/lib.ts
@@ -13,4 +13,5 @@ export * as SelectionBuilder from "./selection.ts";
 export * as TransactionBuilder from "./transaction.ts";
 export * as CommitBuilder from "./commit.ts";
 export * as Telemetry from "./telemetry.ts";
+export * from "./acl.ts";
 export * from "./reference.ts";

--- a/packages/memory/test/acl-test.ts
+++ b/packages/memory/test/acl-test.ts
@@ -1,0 +1,173 @@
+import { assert, assertMatch } from "@std/assert";
+import { alice, bob, space } from "./principal.ts";
+import * as Access from "../access.ts";
+import { refer } from "../reference.ts";
+import { type ACL, type Invocation } from "../interface.ts";
+import { ANYONE_USER, checkACL } from "../acl.ts";
+
+// Some generated service key.
+const serviceDid = "did:key:z6MkfJPMCrTyDmurrAHPUsEjCgvcjvLtAuzyZ7nSqwZwb8KQ";
+
+Deno.test("checkACL - READ capability allows query commands", () => {
+  const acl: ACL = {
+    [bob.did()]: "READ",
+  };
+
+  assert(checkACL(acl, bob.did(), "/memory/query"));
+  assert(checkACL(acl, bob.did(), "/memory/query/schema"));
+  assert(checkACL(acl, bob.did(), "/memory/graph/query"));
+  assert(!checkACL(acl, bob.did(), "/memory/transact"));
+  assert(!checkACL(acl, bob.did(), "/other/command"));
+});
+
+Deno.test("checkACL - WRITE capability allows query and transact", () => {
+  const acl: ACL = {
+    [bob.did()]: "WRITE",
+  };
+
+  assert(checkACL(acl, bob.did(), "/memory/query"));
+  assert(checkACL(acl, bob.did(), "/memory/transact"));
+  assert(!checkACL(acl, bob.did(), "/other/command"));
+});
+
+Deno.test("checkACL - OWNER capability allows all commands", () => {
+  const acl: ACL = {
+    [bob.did()]: "OWNER",
+  };
+
+  assert(checkACL(acl, bob.did(), "/memory/query"));
+  assert(checkACL(acl, bob.did(), "/memory/transact"));
+  assert(checkACL(acl, bob.did(), "/other/command"));
+});
+
+Deno.test("checkACL - returns false for DID not in ACL", () => {
+  const acl: ACL = {
+    [alice.did()]: "WRITE",
+  };
+
+  assert(!checkACL(acl, bob.did(), "/memory/query"));
+  assert(!checkACL(acl, bob.did(), "/memory/transact"));
+});
+
+Deno.test("checkACL - '*' allows public access", () => {
+  const acl: ACL = {
+    [ANYONE_USER]: "READ",
+  };
+
+  assert(checkACL(acl, bob.did(), "/memory/query"));
+  assert(!checkACL(acl, bob.did(), "/memory/transact"));
+});
+
+Deno.test("Access.claim - allows space owner without ACL", async () => {
+  const invocation: Invocation = {
+    iss: alice.did(),
+    cmd: "/memory/transact",
+    sub: alice.did(),
+    args: {},
+    prf: [],
+  };
+
+  const result = await Access.authorize([refer(invocation)], alice);
+  assert(result.ok, "authorization was issued");
+  const authorization = result.ok;
+
+  const claim = await Access.claim(invocation, authorization, serviceDid);
+  assert(claim.ok, "space owner should be authorized");
+});
+
+Deno.test("Access.claim - allows service DID by matching issuer", async () => {
+  // For this test, we'll use space identity as if it were the service
+  // The key point is testing that when iss matches serviceDid, it's authorized
+  const invocation: Invocation = {
+    iss: space.did(),
+    cmd: "/memory/transact",
+    sub: alice.did(),
+    args: {},
+    prf: [],
+  };
+
+  const result = await Access.authorize([refer(invocation)], space);
+  assert(result.ok, "authorization was issued");
+  const authorization = result.ok;
+
+  // Pass space.did() as the serviceDid to test service authorization
+  const claim = await Access.claim(invocation, authorization, space.did());
+  assert(claim.ok, "service DID should be authorized");
+});
+
+Deno.test("Access.claim - denies non-owner without ACL", async () => {
+  const invocation: Invocation = {
+    iss: bob.did(),
+    cmd: "/memory/transact",
+    sub: alice.did(),
+    args: {},
+    prf: [],
+  };
+
+  const result = await Access.authorize([refer(invocation)], bob);
+  assert(result.ok, "authorization was issued");
+  const authorization = result.ok;
+
+  const claim = await Access.claim(invocation, authorization, serviceDid);
+  assertMatch(
+    claim.error?.message ?? "",
+    /has no authority over/,
+    "non-owner should be denied without ACL",
+  );
+});
+
+Deno.test("Access.claim - allows authorized user with ACL", async () => {
+  const acl: ACL = {
+    [bob.did()]: "WRITE",
+  };
+
+  const invocation: Invocation = {
+    iss: bob.did(),
+    cmd: "/memory/transact",
+    sub: alice.did(),
+    args: {},
+    prf: [],
+  };
+
+  const result = await Access.authorize([refer(invocation)], bob);
+  assert(result.ok, "authorization was issued");
+  const authorization = result.ok;
+
+  const claim = await Access.claim(
+    invocation,
+    authorization,
+    serviceDid,
+    acl,
+  );
+  assert(claim.ok, "authorized user should have access via ACL");
+});
+
+Deno.test("Access.claim - denies user without sufficient capability", async () => {
+  const acl: ACL = {
+    [bob.did()]: "READ",
+  };
+
+  const invocation: Invocation = {
+    iss: bob.did(),
+    cmd: "/memory/transact",
+    sub: alice.did(),
+    args: {},
+    prf: [],
+  };
+
+  const result = await Access.authorize([refer(invocation)], bob);
+  assert(result.ok, "authorization was issued");
+  const authorization = result.ok;
+
+  const claim = await Access.claim(
+    invocation,
+    authorization,
+    serviceDid,
+    acl,
+  );
+  assertMatch(
+    claim.error?.message ?? "",
+    /has no authority over/,
+    "user with insufficient capability should be denied",
+  );
+});

--- a/packages/patterns/integration/ct-checkbox.test.ts
+++ b/packages/patterns/integration/ct-checkbox.test.ts
@@ -6,6 +6,7 @@ import { join } from "@std/path";
 import { assertEquals } from "@std/assert";
 import { Identity } from "@commontools/identity";
 import { CharmsController } from "@commontools/charm/ops";
+import { ANYONE_USER } from "@commontools/memory/acl";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
@@ -41,6 +42,9 @@ testComponents.forEach(({ name, file }) => {
         { start: false },
       );
       charmId = charm.id;
+
+      // Add permissions for ANYONE in the first test
+      await cc.acl().set(ANYONE_USER, "WRITE");
     });
 
     afterAll(async () => {

--- a/packages/runner/integration/array_push.test.ts
+++ b/packages/runner/integration/array_push.test.ts
@@ -6,7 +6,7 @@
  * fast the client can render 100 mapped elements, which often ends up creating a
  * lot of vdom nodes
  */
-import { ANYONE, Identity, Session } from "@commontools/identity";
+import { Identity, Session } from "@commontools/identity";
 import { env } from "@commontools/integration";
 import { StorageManager } from "../src/storage/cache.ts";
 import { Runtime, Stream } from "../src/index.ts";
@@ -29,7 +29,7 @@ console.log(`API URL: ${API_URL}`);
 
 // Main test function
 async function runTest() {
-  const account = await Identity.fromPassphrase(ANYONE);
+  const account = await Identity.fromPassphrase("common user");
   const space_thingy = await account.derive(SPACE_NAME);
   const space_thingy_space = space_thingy.did();
   const session = {

--- a/packages/runner/integration/derive_array_leak.test.ts
+++ b/packages/runner/integration/derive_array_leak.test.ts
@@ -9,7 +9,7 @@
  * Expected behavior: Memory should stabilize or grow modestly
  * Actual behavior: Memory grows by gigabytes (1GB+ per 100 increments)
  */
-import { ANYONE, Identity, Session } from "@commontools/identity";
+import { Identity, Session } from "@commontools/identity";
 import { env } from "@commontools/integration";
 import { StorageManager } from "../src/storage/cache.ts";
 import { Runtime } from "../src/index.ts";
@@ -81,7 +81,7 @@ async function getServerMemoryMB(): Promise<number> {
 
 // Main test function
 async function runTest() {
-  const account = await Identity.fromPassphrase(ANYONE);
+  const account = await Identity.fromPassphrase("common user");
   const space_thingy = await account.derive(SPACE_NAME);
   const space_thingy_space = space_thingy.did();
   const session = {

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -424,6 +424,10 @@ export class Runtime implements IRuntime {
     // Removed setCurrentRuntime call - no longer using singleton pattern
   }
 
+  async [Symbol.asyncDispose]() {
+    await this.dispose();
+  }
+
   /**
    * Creates a storage transaction that can be used to read / write data into
    * locally replicated memory spaces. Transaction allows reading from many

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -62,6 +62,7 @@ import * as Transaction from "./transaction.ts";
 import * as SubscriptionManager from "./subscription.ts";
 import * as Differential from "./differential.ts";
 import * as Address from "./transaction/address.ts";
+import { ACL_TYPE, ANYONE_USER } from "@commontools/memory/acl";
 
 export type { Result, Unit };
 export interface Selector<Key> extends Iterable<Key> {
@@ -639,6 +640,7 @@ export class Replica {
         value: RevisionCodec,
       })
       : new NoCache(),
+    public spaceIdentity: Signer | undefined,
     /**
      * Represents cache of the memory state that was loaded from the persisted
      * cache during this session.
@@ -667,6 +669,8 @@ export class Replica {
   }
 
   async poll() {
+    await this.requestACLInit();
+
     // Poll re-fetches the commit log, then subscribes to that
     // We don't use the autosubscribing query, since we want the
     // Commit object, and the autosubscribe returns a Selection.
@@ -1223,6 +1227,58 @@ export class Replica {
       space: this.did(),
     });
   }
+
+  // On connection, assert the initial ACL ownership, transferring
+  // ownership from the empty ACL (space identity only) to the
+  // Session Identity. Skips if ACL already exists, or if
+  // there is no user or space identity.
+  private async requestACLInit() {
+    if (!this.spaceIdentity) {
+      return;
+    }
+    const aclKey = this.spaceIdentity.did();
+    const userIdentity = (this.remote as any).as as Signer | undefined;
+    if (!userIdentity) {
+      return;
+    }
+
+    const initialACL: JSONValue = {
+      value: {
+        [userIdentity.did()]: "OWNER",
+        [ANYONE_USER]: "WRITE",
+      },
+    };
+
+    const aclFact = assert({
+      the: ACL_TYPE,
+      of: aclKey,
+      is: initialACL,
+      cause: null,
+    });
+
+    // Temporarily swap the signer to use spaceIdentity for this commit
+    // We need to swap both the MemorySpaceSession and underlying MemoryConsumerSession
+    const remoteSession = (this.remote as any).session;
+    const originalSpaceSigner = this.remote.as;
+    const originalConsumerSigner = remoteSession?.as;
+
+    this.remote.as = this.spaceIdentity;
+    if (remoteSession) {
+      remoteSession.as = this.spaceIdentity;
+    }
+
+    try {
+      await this.commit({ facts: [aclFact], claims: [] });
+    } catch (_) {
+      // Ignore transaction errors here
+    } finally {
+      // Restore the original signers
+      this.remote.as = originalSpaceSigner;
+      if (remoteSession) {
+        remoteSession.as = originalConsumerSigner;
+      }
+    }
+  }
 }
 
 export interface RemoteStorageProviderSettings {
@@ -1245,6 +1301,7 @@ export interface RemoteStorageProviderOptions {
   space: MemorySpace;
   the?: string;
   settings?: IRemoteStorageProviderSettings;
+  spaceIdentity?: Signer;
 }
 
 export const defaultSettings: IRemoteStorageProviderSettings = {
@@ -1260,6 +1317,7 @@ export interface ConnectionOptions {
   id: string;
   address: URL;
   inspector?: Channel;
+  spaceIdentity?: Signer;
 }
 
 export interface ProviderConnectionOptions extends ConnectionOptions {
@@ -1273,6 +1331,7 @@ class ProviderConnection implements IStorageProvider {
   timeoutID = 0;
   inspector?: Channel;
   provider: Provider;
+  spaceIdentity?: Signer;
   reader: ReadableStreamDefaultReader<
     UCAN<ConsumerCommandInvocation<Protocol>>
   >;
@@ -1285,11 +1344,13 @@ class ProviderConnection implements IStorageProvider {
   queue: Set<UCAN<ConsumerCommandInvocation<Protocol>>> = new Set();
 
   constructor(
-    { id, address, provider, inspector }: ProviderConnectionOptions,
+    { id, address, provider, inspector, spaceIdentity }:
+      ProviderConnectionOptions,
   ) {
     this.address = address;
     this.provider = provider;
     this.handleEvent = this.handleEvent.bind(this);
+    this.spaceIdentity = spaceIdentity;
     // Do not use a default inspector when in Deno:
     // Requires `--unstable-broadcast-channel` flags and it is not used
     // in that environment.
@@ -1560,6 +1621,7 @@ export class Provider implements IStorageProvider {
   spaces: Map<string, Replica>;
   settings: IRemoteStorageProviderSettings;
   subscription: IStorageSubscription;
+  spaceIdentity?: Signer;
 
   subscribers: Map<string, Set<(value: StorageValue<JSONValue>) => void>> =
     new Map();
@@ -1583,12 +1645,14 @@ export class Provider implements IStorageProvider {
     space,
     the = "application/json",
     settings = defaultSettings,
+    spaceIdentity,
   }: RemoteStorageProviderOptions) {
     this.the = the as MIME;
     this.settings = settings;
     this.session = session;
     this.spaces = new Map();
     this.subscription = subscription;
+    this.spaceIdentity = spaceIdentity;
     this.workspace = this.mount(space);
   }
 
@@ -1597,6 +1661,7 @@ export class Provider implements IStorageProvider {
       id: options.id,
       provider: this,
       address: options.address,
+      spaceIdentity: options.spaceIdentity,
     });
   }
   get replica() {
@@ -1615,6 +1680,7 @@ export class Provider implements IStorageProvider {
         session,
         this.subscription,
         new NoCache(),
+        this.spaceIdentity,
       );
       replica.poll();
       this.spaces.set(space, replica);
@@ -1825,6 +1891,11 @@ export interface Options {
    * Various settings to configure storage provider.
    */
   settings?: IRemoteStorageProviderSettings;
+
+  /**
+   * (Temporary) Space identity.
+   */
+  spaceIdentity?: Signer;
 }
 
 export class StorageManager implements IStorageManager {
@@ -1832,6 +1903,7 @@ export class StorageManager implements IStorageManager {
   as: Signer;
   id: string;
   settings: IRemoteStorageProviderSettings;
+  spaceIdentity?: Signer;
   #providers: Map<string, IStorageProviderWithReplica> = new Map();
   #subscription = SubscriptionManager.create();
 
@@ -1846,13 +1918,19 @@ export class StorageManager implements IStorageManager {
   }
 
   protected constructor(
-    { address, as, id = crypto.randomUUID(), settings = defaultSettings }:
-      Options,
+    {
+      address,
+      as,
+      id = crypto.randomUUID(),
+      settings = defaultSettings,
+      spaceIdentity,
+    }: Options,
   ) {
     this.address = address;
     this.settings = settings;
     this.as = as;
     this.id = id;
+    this.spaceIdentity = spaceIdentity;
   }
 
   /**
@@ -1879,6 +1957,7 @@ export class StorageManager implements IStorageManager {
       settings,
       subscription: this.#subscription,
       session: Consumer.create({ as }),
+      spaceIdentity: this.spaceIdentity,
     });
   }
 

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -1,4 +1,5 @@
 import "core-js/proposals/explicit-resource-management";
+import "core-js/proposals/async-explicit-resource-management";
 import "@commontools/ui/v1";
 import "@commontools/ui/v2";
 import { setLLMUrl } from "@commontools/llm";

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -18,6 +18,11 @@ const logger = getLogger("shell.telemetry", {
   level: "debug",
 });
 
+const identityLogger = getLogger("shell.telemetry", {
+  enabled: true,
+  level: "debug",
+});
+
 // RuntimeInternals bundles all of the lifetimes
 // of resources bound to an identity,host,space triplet,
 // containing runtime, inspector, and charm references.
@@ -86,6 +91,10 @@ export class RuntimeInternals extends EventTarget {
   ): Promise<RuntimeInternals> {
     const session = await createSession({ identity, spaceName });
 
+    // Log user identity for debugging and sharing
+    identityLogger.log([`[Identity] User DID: ${session.as.did()}`]);
+    identityLogger.log([`[Identity] Space: ${spaceName} (${session.space})`]);
+
     // We're hoisting CharmManager so that
     // we can create it after the runtime, but still reference
     // its `getSpaceName` method in a runtime callback.
@@ -97,6 +106,7 @@ export class RuntimeInternals extends EventTarget {
       apiUrl: new URL(apiUrl),
       storageManager: StorageManager.open({
         as: session.as,
+        spaceIdentity: session.spaceIdentity,
         address: new URL("/api/storage/memory", apiUrl),
       }),
       errorHandlers: [(error) => {


### PR DESCRIPTION
* Server/provider has a single, global namespace. All spaces created are private by default. Tilte `~spacenames` will have no special meaning.
  * derived from (public) space name for now representing user owning of
    space. Eventually we'll have a look up table to not need publicly
derivable spaces.
* Add a well-known `ACL` cell to each Space. This contains a `Map<DID, CAPABILITY>` that applies to the current space.
* User transactions are signed with the User key directly (`session.as`).
* Each transaction requires the signer to either be the space identity, or an identity located in the `ACL`, or have `ANYONE` identity in the `ACL`.
  * This changes the previous "personas" indirection in signing, but will simplify the `ACL` stored identities.
  * To remedy the shortcomings of [1], only allow the space identity to write if and only if it's writing the initial `ACL` value.
* Add to CLI ability to add identities to a space with a capability.
* Log current user's identity in browser console for sharing.
































































<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-space ACLs (READ/WRITE/OWNER) and enforces them across memory requests. On first connect, spaces auto-create an ACL granting OWNER to the user and WRITE to ANYONE; transactions are signed with the user key, and a new CLI manages ACL entries.

- **New Features**
  - ACL stored in a well-known cell per space; supports DID entries and ANYONE.
  - Provider checks owner, service DID, or ACL capability on requests.
  - ACL auto-initializes on first connect, granting OWNER to the user and WRITE to ANYONE.
  - New CLI: ct acl ls | set | remove.
  - CharmsController exposes an ACL manager (get/set/remove).
  - Runtime supports async disposal; browser logs user DID and space.

- **Migration**
  - Transactions must be signed as the user (no personas).
  - Spaces start with ANYONE WRITE; remove or change via ACL to make private.
  - Public “~space” semantics removed—use ACL to share.

<sup>Written for commit 1ab3f351465dda27b35ff5fc259444e08d7a8e7e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->































































