### PR TITLE
test: add fixture for CT-1036 derived property access pattern

### DIFF
--- a/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.tsx
@@ -1,0 +1,353 @@
+import * as __ctHelpers from "commontools";
+import { Cell, derive, recipe, UI } from "commontools";
+interface Item {
+    name: string;
+    done: Cell<boolean>;
+}
+interface Assignment {
+    aisle: string;
+    item: Item;
+}
+// CT-1036: Property access on derived grouped objects with derived keys
+// This pattern groups items by a property, then maps over the group keys
+// and accesses the grouped object with each key.
+export default recipe({
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            }
+        }
+    },
+    required: ["items"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                done: {
+                    type: "boolean",
+                    asCell: true
+                }
+            },
+            required: ["name", "done"]
+        }
+    }
+} as const satisfies __ctHelpers.JSONSchema, ({ items }) => {
+    // Create assignments with aisle data
+    const itemsWithAisles = derive({
+        type: "object",
+        properties: {
+            items: {
+                type: "array",
+                items: {
+                    $ref: "#/$defs/Item"
+                },
+                asOpaque: true
+            }
+        },
+        required: ["items"],
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    done: {
+                        type: "boolean",
+                        asCell: true
+                    }
+                },
+                required: ["name", "done"]
+            }
+        }
+    } as const satisfies __ctHelpers.JSONSchema, {
+        type: "array",
+        items: {
+            type: "object",
+            properties: {
+                aisle: {
+                    type: "string"
+                },
+                item: {
+                    $ref: "#/$defs/Item",
+                    asOpaque: true
+                }
+            },
+            required: ["aisle", "item"]
+        },
+        asOpaque: true,
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    done: {
+                        type: "boolean",
+                        asCell: true
+                    }
+                },
+                required: ["name", "done"]
+            }
+        }
+    } as const satisfies __ctHelpers.JSONSchema, { items }, ({ items }) => items.map((item, idx) => ({
+        aisle: `Aisle ${(idx % 3) + 1}`,
+        item: item,
+    })));
+    // Group by aisle - returns Record<string, Assignment[]>
+    const groupedByAisle = derive({
+        type: "object",
+        properties: {
+            itemsWithAisles: {
+                type: "array",
+                items: {
+                    type: "object",
+                    properties: {
+                        aisle: {
+                            type: "string"
+                        },
+                        item: {
+                            $ref: "#/$defs/Item",
+                            asOpaque: true
+                        }
+                    },
+                    required: ["aisle", "item"]
+                },
+                asOpaque: true
+            }
+        },
+        required: ["itemsWithAisles"],
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    done: {
+                        type: "boolean",
+                        asCell: true
+                    }
+                },
+                required: ["name", "done"]
+            }
+        }
+    } as const satisfies __ctHelpers.JSONSchema, {
+        type: "object",
+        properties: {},
+        additionalProperties: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Assignment"
+            }
+        },
+        $defs: {
+            Assignment: {
+                type: "object",
+                properties: {
+                    aisle: {
+                        type: "string"
+                    },
+                    item: {
+                        $ref: "#/$defs/Item"
+                    }
+                },
+                required: ["aisle", "item"]
+            },
+            Item: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    done: {
+                        type: "boolean",
+                        asCell: true
+                    }
+                },
+                required: ["name", "done"]
+            }
+        }
+    } as const satisfies __ctHelpers.JSONSchema, { itemsWithAisles }, ({ itemsWithAisles }) => {
+        const groups: Record<string, Assignment[]> = {};
+        for (const assignment of itemsWithAisles) {
+            if (!groups[assignment.aisle]) {
+                groups[assignment.aisle] = [];
+            }
+            groups[assignment.aisle].push(assignment);
+        }
+        return groups;
+    });
+    // Derive sorted aisle names from grouped object
+    const aisleNames = derive({
+        type: "object",
+        properties: {
+            groupedByAisle: {
+                type: "object",
+                properties: {},
+                additionalProperties: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Assignment"
+                    }
+                },
+                asOpaque: true
+            }
+        },
+        required: ["groupedByAisle"],
+        $defs: {
+            Assignment: {
+                type: "object",
+                properties: {
+                    aisle: {
+                        type: "string"
+                    },
+                    item: {
+                        $ref: "#/$defs/Item"
+                    }
+                },
+                required: ["aisle", "item"]
+            },
+            Item: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    done: {
+                        type: "boolean",
+                        asCell: true
+                    }
+                },
+                required: ["name", "done"]
+            }
+        }
+    } as const satisfies __ctHelpers.JSONSchema, {
+        type: "array",
+        items: {
+            type: "string"
+        }
+    } as const satisfies __ctHelpers.JSONSchema, { groupedByAisle }, ({ groupedByAisle }) => Object.keys(groupedByAisle).sort());
+    // The pattern from CT-1036:
+    // - Map over derived keys (aisleNames)
+    // - Access derived object with derived key (groupedByAisle[aisleName])
+    // - Map over the result
+    return {
+        [UI]: (<div>
+          {aisleNames.mapWithPattern(__ctHelpers.recipe({
+                type: "object",
+                properties: {
+                    element: {
+                        type: "string"
+                    },
+                    params: {
+                        type: "object",
+                        properties: {
+                            groupedByAisle: {
+                                type: "object",
+                                properties: {},
+                                additionalProperties: {
+                                    type: "array",
+                                    items: {
+                                        $ref: "#/$defs/Assignment"
+                                    }
+                                },
+                                asOpaque: true
+                            }
+                        },
+                        required: ["groupedByAisle"]
+                    }
+                },
+                required: ["element", "params"],
+                $defs: {
+                    Assignment: {
+                        type: "object",
+                        properties: {
+                            aisle: {
+                                type: "string"
+                            },
+                            item: {
+                                $ref: "#/$defs/Item"
+                            }
+                        },
+                        required: ["aisle", "item"]
+                    },
+                    Item: {
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string"
+                            },
+                            done: {
+                                type: "boolean",
+                                asCell: true
+                            }
+                        },
+                        required: ["name", "done"]
+                    }
+                }
+            } as const satisfies __ctHelpers.JSONSchema, ({ element: aisleName, params: { groupedByAisle } }) => (<div>
+              <h3>{aisleName}</h3>
+              {(__ctHelpers.derive({
+                groupedByAisle: groupedByAisle,
+                aisleName: aisleName
+            }, ({ groupedByAisle, aisleName }) => groupedByAisle[aisleName] ?? [])).mapWithPattern(__ctHelpers.recipe({
+                type: "object",
+                properties: {
+                    element: {
+                        $ref: "#/$defs/Assignment"
+                    },
+                    params: {
+                        type: "object",
+                        properties: {}
+                    }
+                },
+                required: ["element", "params"],
+                $defs: {
+                    Assignment: {
+                        type: "object",
+                        properties: {
+                            aisle: {
+                                type: "string"
+                            },
+                            item: {
+                                $ref: "#/$defs/Item"
+                            }
+                        },
+                        required: ["aisle", "item"]
+                    },
+                    Item: {
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string"
+                            },
+                            done: {
+                                type: "boolean",
+                                asCell: true
+                            }
+                        },
+                        required: ["name", "done"]
+                    }
+                }
+            } as const satisfies __ctHelpers.JSONSchema, ({ element: assignment, params: {} }) => (<div>
+                  <span>{assignment.item.name}</span>
+                  <ct-checkbox $checked={assignment.item.done}/>
+                </div>)), {})}
+            </div>)), {
+                groupedByAisle: groupedByAisle
+            })}
+        </div>),
+    };
+});
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.input.tsx
@@ -1,0 +1,67 @@
+/// <cts-enable />
+import { Cell, derive, recipe, UI } from "commontools";
+
+interface Item {
+  name: string;
+  done: Cell<boolean>;
+}
+
+interface Assignment {
+  aisle: string;
+  item: Item;
+}
+
+// CT-1036: Property access on derived grouped objects with derived keys
+// This pattern groups items by a property, then maps over the group keys
+// and accesses the grouped object with each key.
+export default recipe<{ items: Item[] }>(
+  "Derived Property Access",
+  ({ items }) => {
+    // Create assignments with aisle data
+    const itemsWithAisles = derive({ items }, ({ items }) =>
+      items.map((item, idx) => ({
+        aisle: `Aisle ${(idx % 3) + 1}`,
+        item: item,
+      }))
+    );
+
+    // Group by aisle - returns Record<string, Assignment[]>
+    const groupedByAisle = derive({ itemsWithAisles }, ({ itemsWithAisles }) => {
+      const groups: Record<string, Assignment[]> = {};
+      for (const assignment of itemsWithAisles) {
+        if (!groups[assignment.aisle]) {
+          groups[assignment.aisle] = [];
+        }
+        groups[assignment.aisle].push(assignment);
+      }
+      return groups;
+    });
+
+    // Derive sorted aisle names from grouped object
+    const aisleNames = derive({ groupedByAisle }, ({ groupedByAisle }) =>
+      Object.keys(groupedByAisle).sort()
+    );
+
+    // The pattern from CT-1036:
+    // - Map over derived keys (aisleNames)
+    // - Access derived object with derived key (groupedByAisle[aisleName])
+    // - Map over the result
+    return {
+      [UI]: (
+        <div>
+          {aisleNames.map((aisleName) => (
+            <div>
+              <h3>{aisleName}</h3>
+              {(groupedByAisle[aisleName] ?? []).map((assignment) => (
+                <div>
+                  <span>{assignment.item.name}</span>
+                  <ct-checkbox $checked={assignment.item.done} />
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      ),
+    };
+  },
+);


### PR DESCRIPTION
Add test fixture pair for the pattern described in CT-1036:
- Grouping items by a property into Record<K, V[]>
- Deriving keys from the grouped object
- Mapping over derived keys and accessing grouped[key]
- Nested mapping over the accessed array

This pattern runs successfully and transforms correctly with the current transformer. The JSX transformer properly wraps the property access (groupedByAisle[aisleName]) in a derive with both values as parameters, enabling reactive property access with derived keys.

Related: CT-1036

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a test fixture pair for CT-1036 to validate derived property access with derived keys in JSX mapping. Confirms the transformer wraps groupedByAisle[aisleName] in a derive with both inputs, ensuring reactive updates as required by CT-1036.

<sup>Written for commit 29de552ccc8081b918a3304a4448542b12d9e8e0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

