### PR TITLE
Fix: Re-throw default pattern creation errors instead of swallowing

### DIFF
--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -85,6 +85,8 @@ export class XBodyView extends BaseView {
       await DefaultPattern.create(this.rt.cc());
     } catch (error) {
       console.error("Could not create default pattern:", error);
+      // Re-throw to expose errors instead of swallowing them
+      throw error;
     } finally {
       this.creatingDefaultPattern = false;
       this._charms.run();


### PR DESCRIPTION
## Problem

Errors in `DefaultPattern.create()` were caught and logged but not re-thrown, causing silent failures that broke the `[[` mentions feature.

## Why This Breaks Mentions

1. `linkDefaultPattern()` fails (network glitch, race condition, etc.)
2. Error is swallowed → no indication to user
3. `DefaultCharmList` charm created successfully
4. But `/defaultPattern` link in space cell is missing
5. `wish("#mentionable")` resolves path: `/defaultPattern/backlinksIndex/mentionable`
6. Path resolution fails because `/defaultPattern` doesn't exist
7. Returns empty array instead of charm list
8. `ct-code-editor` receives empty mentionable list
9. `[[` dropdown shows no completions

## Symptom

Type `[[` in notes field → dropdown is empty (even though backlinksIndex has data)

## Timeline

- **Oct 23** (947b471cb): linkDefaultPattern added
- **Nov 6** (or earlier): Spaces created with transient link failures
- **Today**: Error swallowing discovered during investigation

## Fix

Re-throw errors to surface failures immediately. Future spaces will fail loudly if linking doesn't work, preventing silent corruption.

## Workaround for Affected Spaces

```bash
rm -rf packages/toolshed/cache/memory/*.sqlite
# Then recreate spaces
```

## Testing

Created fresh test space - mentions work correctly when linking succeeds.

## Files Changed

- `packages/shell/src/views/BodyView.ts` - Added `throw error;` after console.error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-throw errors during default pattern creation to prevent silent failures that break [[ mentions]. Mentions now fail loudly instead of returning an empty list when linking the default pattern fails.

- **Bug Fixes**
  - Re-throw error after logging when DefaultPattern.create() fails in BodyView.
  - Prevents empty [[ dropdown caused by a missing /defaultPattern link.

- **Migration**
  - If you hit this earlier: delete packages/toolshed/cache/memory/*.sqlite and recreate spaces.

<sup>Written for commit 50011acbe986ead8019da83aa421f2625069cc5a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

