### PR TITLE
fix(api): handler returns OpaqueRef<Stream<E>> to be compatible with explicit types of stream

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1087,24 +1087,27 @@ export type HandlerFunction = {
     eventSchema: E,
     stateSchema: T,
     handler: (event: Schema<E>, props: Schema<T>) => any,
-  ): ModuleFactory<StripCell<SchemaWithoutCell<T>>, SchemaWithoutCell<E>>;
+  ): ModuleFactory<
+    StripCell<SchemaWithoutCell<T>>,
+    Stream<SchemaWithoutCell<E>>
+  >;
 
   // With inferred types
   <E, T>(
     eventSchema: JSONSchema,
     stateSchema: JSONSchema,
     handler: (event: E, props: HandlerState<T>) => any,
-  ): ModuleFactory<StripCell<T>, StripCell<E>>;
+  ): ModuleFactory<StripCell<T>, Stream<StripCell<E>>>;
 
   // Without schemas
   <E, T>(
     handler: (event: E, props: T) => any,
     options: { proxy: true },
-  ): ModuleFactory<StripCell<T>, StripCell<E>>;
+  ): ModuleFactory<StripCell<T>, Stream<StripCell<E>>>;
 
   <E, T>(
     handler: (event: E, props: HandlerState<T>) => any,
-  ): ModuleFactory<StripCell<T>, StripCell<E>>;
+  ): ModuleFactory<StripCell<T>, Stream<StripCell<E>>>;
 };
 
 /**


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated HandlerFunction overloads to return Stream<E> instead of E, making handlers compatible with explicit stream types. Fixes TypeScript mismatches with Stream/OpaqueRef usage, with no runtime changes.

<sup>Written for commit a339c4691e728670e560e61c628cfc2b075e1e3a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



