### PR TITLE
chore: Remove redundant workspace imports

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -116,7 +116,6 @@
     "merkle-reference": "npm:merkle-reference@^2.2.0",
     "multiformats": "npm:multiformats@^13.3.2",
     "turndown": "npm:turndown@^7.1.2",
-    "zod": "npm:zod@^3.24.1",
-    "@commontools/schema-generator/cell-brand": "./packages/schema-generator/src/typescript/cell-brand.ts"
+    "zod": "npm:zod@^3.24.1"
   }
 }

--- a/packages/schema-generator/deno.json
+++ b/packages/schema-generator/deno.json
@@ -4,13 +4,11 @@
   "exports": {
     ".": "./src/index.ts",
     "./interface": "./src/interface.ts",
-    "./typescript/cell-brand": "./src/typescript/cell-brand.ts",
-    "./typescript/type-traversal": "./src/typescript/type-traversal.ts"
+    "./cell-brand": "./src/typescript/cell-brand.ts",
+    "./type-traversal": "./src/typescript/type-traversal.ts"
   },
   "imports": {
-    "typescript": "npm:typescript",
-    "@commontools/utils": "../utils/src/index.ts",
-    "@commontools/static": "../static/index.ts"
+    "typescript": "npm:typescript"
   },
   "tasks": {
     "test": "deno test --allow-read --allow-write --allow-run --allow-env=API_URL,\"TSC_*\",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV,UPDATE_GOLDENS test/**/*.test.ts",

--- a/packages/ts-transformers/deno.json
+++ b/packages/ts-transformers/deno.json
@@ -7,8 +7,7 @@
     "./core/imports": "./src/core/imports.ts"
   },
   "imports": {
-    "typescript": "npm:typescript",
-    "@commontools/schema-generator/cell-brand": "../schema-generator/src/typescript/cell-brand.ts"
+    "typescript": "npm:typescript"
   },
   "tasks": {
     "test": "deno test --allow-read --allow-write --allow-env test/**/*.test.ts",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed redundant workspace import aliases and flattened schema-generator export paths to normalize module resolution and reduce cross-package coupling.

- **Refactors**
  - Root deno.json: removed "@commontools/schema-generator/cell-brand" import alias.
  - schema-generator: exports changed from "./typescript/*" to "./cell-brand" and "./type-traversal"; removed unused imports to utils/static.
  - ts-transformers: removed import alias for "@commontools/schema-generator/cell-brand".

- **Migration**
  - Update imports from "@commontools/schema-generator/typescript/cell-brand" to "@commontools/schema-generator/cell-brand".
  - Update imports from "@commontools/schema-generator/typescript/type-traversal" to "@commontools/schema-generator/type-traversal".

<sup>Written for commit 405704314395a8b48c2b7384ee33800d1d75d605. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

