### PR TITLE
fix(runner): ifElse no longer uses array to encode parameters

### DIFF
--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -105,10 +105,12 @@ export function ifElse<T = unknown, U = unknown, V = unknown>(
     type: "ref",
     implementation: "ifElse",
   });
-  return ifElseFactory([condition, ifTrue, ifFalse]) as OpaqueRef<U | V>;
+  return ifElseFactory({ condition, ifTrue, ifFalse }) as OpaqueRef<U | V>;
 }
 
-let ifElseFactory: NodeFactory<[unknown, unknown, unknown], any> | undefined;
+let ifElseFactory:
+  | NodeFactory<{ condition: unknown; ifTrue: unknown; ifFalse: unknown }, any>
+  | undefined;
 
 export const navigateTo = createNodeFactory({
   type: "ref",

--- a/packages/runner/src/builtins/if-else.ts
+++ b/packages/runner/src/builtins/if-else.ts
@@ -22,9 +22,9 @@ export function ifElse(
     const resultWithLog = result.withTx(tx);
     const inputsWithLog = inputsCell.withTx(tx);
 
-    const condition = inputsWithLog.key(0).get();
+    const condition = inputsWithLog.key("condition").get();
 
-    const ref = inputsWithLog.key(condition ? 1 : 2)
+    const ref = inputsWithLog.key(condition ? "ifTrue" : "ifFalse")
       .getAsLink({ base: result });
 
     // When writing links, we need to use setRaw


### PR DESCRIPTION
JSON serialization turns `undefined` to `null` in arrays, so `ifElse(.., undefined, ..)` returned `null` instead of `undefined`. So now we're just using a regular object.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ifElse parameter encoding by switching from an array to a named object so undefined values survive JSON serialization. This resolves cases where ifElse(..., undefined, ...) incorrectly returned null.

- **Bug Fixes**
  - Store inputs as { condition, ifTrue, ifFalse } instead of [condition, ifTrue, ifFalse].
  - Preserve undefined through serialization; prevents null from replacing undefined.
  - Updated NodeFactory types and key access to use named keys.

<sup>Written for commit ef254c66a0707945301fa5571022fcb5a537b0c3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

