### PR TITLE
fix(llm-builtin): turn json graphs into a cell links where they repeat

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -224,7 +224,7 @@ function traverseAndSerialize(
   value: unknown,
   seen: Set<unknown> = new Set(),
 ): unknown {
-  if (!isObject(value)) return value;
+  if (!isRecord(value)) return value;
 
   if (isCell(value)) {
     const link = value.getAsNormalizedFullLink();


### PR DESCRIPTION
since our data structure allows graphs, but we need to output json this can happen.

we will return everything after the first occurence as a link, which we can get back since this data must have been generated from a Cell.get()



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents infinite loops when serializing graph-shaped values to JSON by turning repeated references into LLM-friendly cell links. Output stays stable and can be dereferenced back to the original cell.

- **Bug Fixes**
  - Track seen objects during traversal to detect repeats.
  - When a repeat is dereferenceable, convert it to a cell link; otherwise throw.
  - Keep existing handling for cells, arrays, and records.

<sup>Written for commit 6cbf8a362166e9e7c58795b27666ff09e5c0d2a9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



