### PR TITLE
fix capture bug

### DIFF
--- a/packages/ts-transformers/src/closures/transformer.ts
+++ b/packages/ts-transformers/src/closures/transformer.ts
@@ -128,6 +128,12 @@ function shouldCaptureIdentifier(
     return undefined;
   }
 
+  // Skip if this identifier is the property name in an object literal (e.g., 'label' in '{ label: value }')
+  // We only want to capture the VALUE, not the property name itself
+  if (ts.isPropertyAssignment(node.parent) && node.parent.name === node) {
+    return undefined;
+  }
+
   // For shorthand property assignments (e.g., {id} instead of {id: id}), we need special handling
   // because getSymbolAtLocation returns the property symbol, not the variable being referenced
   if (ts.isShorthandPropertyAssignment(node.parent)) {


### PR DESCRIPTION
fix bug in capture detection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix capture detection by skipping object literal property names and improving function-scope checks to work across source and transformed ASTs.

- **Bug Fixes**
  - Do not capture identifiers used as object literal keys (e.g., label in { label: value }).
  - In isDeclaredWithinFunction, add position-based matching to handle nodes cloned by transformers while still stopping at nested function boundaries.

<sup>Written for commit c8a4e8d9d55bd8d49c64c1a2d5adb214d2312aec. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

