### PR TITLE
feat(logger): register logger instances globally for runtime access

### DIFF
--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -284,5 +284,19 @@ export function getLogger(
   moduleName: string,
   options?: GetLoggerOptions,
 ): Logger {
-  return new Logger(moduleName, options);
+  const logger = new Logger(moduleName, options);
+
+  // Store logger in globalThis for access via console
+  const global = globalThis as unknown as {
+    commontools: { logger: Record<string, Logger> };
+  };
+  if (!global.commontools) {
+    global.commontools = { logger: {} };
+  }
+  if (!global.commontools.logger) {
+    global.commontools.logger = {};
+  }
+  global.commontools.logger[moduleName] = logger;
+
+  return logger;
 }


### PR DESCRIPTION
Register each created logger instance in `globalThis.commontools.logger` keyed by module name. This enables runtime inspection and control of logger instances via the browser console (e.g., enabling/disabling specific loggers or adjusting log levels dynamically).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Register each logger created by getLogger under globalThis.commontools.logger[moduleName] for easy runtime access. You can inspect and change logger settings from the console (e.g., adjust log levels or toggle a specific logger) without code changes.

<sup>Written for commit 817be37303447003e997ec9e7fcb55e27189681b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

