### PR TITLE
fix(llm-dialog): when re-creating schema via source cell, follow cell path

### DIFF
--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -505,7 +505,7 @@ export class ContextualFlowControl {
    */
   schemaAtPath(
     schema: JSONSchema,
-    path: string[],
+    path: readonly string[],
     rootSchema?: JSONSchema,
     extraClassifications?: Set<string>,
   ): JSONSchema {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix schema resolution in llm-dialog when deriving a cell’s schema from a source cell. We now follow the cell’s path in the source schema so nested outputs get the correct schema.

- **Bug Fixes**
  - Derive schema from the source cell’s resultRef and the current cell path using schemaAtPath.
  - Keep fallback to a minimal schema when no source schema is available.
  - Update schemaAtPath to accept a readonly string[] path.

<sup>Written for commit dd531b27ad98dc47f3c6d259cfa34e872d880b89. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

