### PR TITLE
Add gemini 3 model support

### DIFF
--- a/packages/toolshed/routes/ai/llm/models.ts
+++ b/packages/toolshed/routes/ai/llm/models.ts
@@ -356,34 +356,6 @@ if (env.CTTS_AI_LLM_GOOGLE_APPLICATION_CREDENTIALS) {
     },
   });
 
-  // // The api client probably does not allow for us to do the new
-  // // gemini 3 thinking stuff.  We will uncomment this when we can.
-  // // The providerOptions thing below is probably wrong.
-  // addModel({
-  //   provider: vertexProvider,
-  //   name: "google:gemini-3-pro-preview-thinking",
-  //   aliases: ["gemini-3-pro-thinking", "gemini-3-pro-thinking-latest"],
-  //   providerOptions: {
-  //     google: {
-  //       // Options are nested under 'google' for Vertex provider
-  //       thinkingConfig: {
-  //         includeThoughts: true,
-  //         // thinkingBudget: 2048, // Optional
-  //       },
-  //     },
-  //   },
-  //   capabilities: {
-  //     contextWindow: 1_000_000,
-  //     maxOutputTokens: 65_536,
-  //     images: true,
-  //     prefill: true,
-  //     systemPrompt: true,
-  //     stopSequences: true,
-  //     streaming: true,
-  //     reasoning: true,
-  //   },
-  // });
-
   addModel({
     provider: vertexProvider,
     name: "google:gemini-2.5-flash",


### PR DESCRIPTION
* Thinking model stubbed out and commented because the api client we use does not support the new gemini 3 api.

* Preview model added

* All gemini 2.5 models removed except gemini 2.5 flash, which is in use.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Gemini 3 Pro Preview support and made it the default for vision tasks. Removed older Gemini 2.5 models to simplify our model list.

- **New Features**
  - Registered google:gemini-3-pro-preview with aliases gemini-3-pro and gemini-3-pro-latest.
  - Vision tasks now use Gemini 3 Preview.

- **Refactors**
  - Removed Gemini 2.5 Pro and Thinking variants; 2.5 Flash remains.
  - Dropped separate “thinking” model; Gemini 3 handles thinking via prompt.

<sup>Written for commit 9a7f559c29b03680f1dde8aaeb85da45068f94d4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

