### PR TITLE
fix(charm): tighten manager queries with negative schema constraints

### DIFF
--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -53,7 +53,7 @@ export type UISchema = Schema<typeof uiSchema>;
 
 export const charmListSchema = {
   type: "array",
-  items: { asCell: true },
+  items: { not: true, asCell: true },
 } as const satisfies JSONSchema;
 
 export const spaceCellSchema = {
@@ -61,7 +61,7 @@ export const spaceCellSchema = {
   properties: {
     // Each field is a Cell<> reference to another cell
     allCharms: { ...charmListSchema, asCell: true },
-    defaultPattern: { type: "object", asCell: true },
+    defaultPattern: { not: true, asCell: true },
     recentCharms: { ...charmListSchema, asCell: true },
   },
 } as const satisfies JSONSchema;
@@ -71,7 +71,7 @@ export type SpaceCell = Schema<typeof spaceCellSchema>;
 export const charmLineageSchema = {
   type: "object",
   properties: {
-    charm: { type: "object", asCell: true },
+    charm: { not: true, asCell: true },
     relation: { type: "string" },
     timestamp: { type: "number" },
   },


### PR DESCRIPTION
Updates `charmListSchema`, `spaceCellSchema`, and `charmLineageSchema` to use `not: true` in specific fields. This aligns with the goal of making charm manager queries tighter, likely preventing over-fetching or specific matching behaviors for these cell references.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added negative schema constraints (not: true) to Cell-reference fields in charmListSchema, spaceCellSchema, and charmLineageSchema so manager queries only match Cell refs, not inline objects. This tightens results and prevents over-fetching or incorrect matches.

<sup>Written for commit 72fd4134c9634c6c0ae20719fdc56653f7a7c761. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

