### PR TITLE
chore: Add test for cross-space cell access

### DIFF
--- a/packages/runner/test/multispace.test.ts
+++ b/packages/runner/test/multispace.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { Runtime } from "../src/runtime.ts";
+import { Identity } from "@commontools/identity";
+import { StorageManager } from "@commontools/runner/storage/cache.deno";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space1 = await Identity.fromPassphrase("space1");
+const space2 = await Identity.fromPassphrase("space1");
+
+describe("Multi-space Runtime", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx1: IExtendedStorageTransaction;
+  let tx2: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx1 = runtime.edit();
+    tx2 = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx1.commit();
+    await tx2.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("should be able to modify cells from multiple spaces", async () => {
+    const a = runtime.getCell<number>(
+      space1.did(),
+      "cause1",
+      undefined,
+      tx1,
+    );
+    a.set(1);
+    const b = runtime.getCell<number>(
+      space2.did(),
+      "cause2",
+      undefined,
+      tx2,
+    );
+    b.setRaw(a.getAsLink());
+    tx1.commit();
+    tx2.commit();
+    await runtime.idle();
+    expect(b.get()).toBe(1);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a test that verifies the Runtime can edit cells across spaces and resolve links between them.
It sets a value in one space, links it from another using separate transactions, commits, waits for idle, and asserts the linked cell reads the source value.

<sup>Written for commit e9c7d40d7a5b1fdbd6f1e0159a03b3b641f761bb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

