### PR TITLE
chore(builtin): refactor llm calls to use schema for inputs

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -14,6 +14,11 @@ import type {
   JSONSchema,
   Schema,
 } from "commontools";
+import {
+  LLMMessageSchema,
+  LLMParamsSchema,
+  LLMToolSchema,
+} from "./llm-schemas.ts";
 import { getLogger } from "@commontools/utils/logger";
 import { isBoolean, isObject } from "@commontools/utils/types";
 import type { Cell, MemorySpace, Stream } from "../cell.ts";
@@ -336,78 +341,6 @@ function traverseAndCellify(
   }
   return value;
 }
-
-export const LLMMessageSchema = {
-  type: "object",
-  properties: {
-    role: { type: "string" },
-    content: {
-      anyOf: [{
-        type: "array",
-        items: {
-          anyOf: [{
-            type: "object",
-            properties: {
-              // This should be anyOf with const values for type
-              type: { type: "string" },
-              text: { type: "string" },
-              image: { type: "string" },
-              toolCallId: { type: "string" },
-              toolName: { type: "string" },
-              input: { type: "object" },
-              output: {},
-            },
-            required: ["type"],
-          }, { type: "string" }],
-        },
-      }, { type: "string" }],
-    },
-  },
-  required: ["role", "content"],
-} as const satisfies JSONSchema;
-
-export const LLMToolSchema = {
-  type: "object",
-  properties: {
-    description: { type: "string" },
-    inputSchema: { type: "object" },
-    handler: {
-      // Deliberately no schema, so it gets populated from the handler
-      asStream: true,
-    },
-    pattern: {
-      type: "object",
-      properties: {
-        argumentSchema: { type: "object" },
-        resultSchema: { type: "object" },
-        nodes: { type: "array", items: { type: "object" } },
-        program: { type: "object" },
-        initial: { type: "object" },
-      },
-      required: ["argumentSchema", "resultSchema", "nodes"],
-      asCell: true,
-    },
-    extraParams: { type: "object" },
-    charm: {
-      // Accept whole charm - its own schema defines its handlers
-      asCell: true,
-    },
-  },
-  required: [],
-} as const satisfies JSONSchema;
-
-export const LLMParamsSchema = {
-  type: "object",
-  properties: {
-    messages: { type: "array", items: LLMMessageSchema, default: [] },
-    model: { type: "string" },
-    maxTokens: { type: "number" },
-    system: { type: "string" },
-    stop: { type: "string" },
-    tools: { type: "object", additionalProperties: LLMToolSchema, default: {} },
-  },
-  required: ["messages"],
-} as const satisfies JSONSchema;
 
 const resultSchema = {
   type: "object",

--- a/packages/runner/src/builtins/llm-schemas.ts
+++ b/packages/runner/src/builtins/llm-schemas.ts
@@ -1,0 +1,73 @@
+import type { JSONSchema } from "@commontools/api";
+
+export const LLMMessageSchema = {
+  type: "object",
+  properties: {
+    role: { type: "string" },
+    content: {
+      anyOf: [{
+        type: "array",
+        items: {
+          anyOf: [{
+            type: "object",
+            properties: {
+              // This should be anyOf with const values for type
+              type: { type: "string" },
+              text: { type: "string" },
+              image: { type: "string" },
+              toolCallId: { type: "string" },
+              toolName: { type: "string" },
+              input: { type: "object" },
+              output: {},
+            },
+            required: ["type"],
+          }, { type: "string" }],
+        },
+      }, { type: "string" }],
+    },
+  },
+  required: ["role", "content"],
+} as const satisfies JSONSchema;
+
+export const LLMToolSchema = {
+  type: "object",
+  properties: {
+    description: { type: "string" },
+    inputSchema: { type: "object" },
+    handler: {
+      // Deliberately no schema, so it gets populated from the handler
+      asStream: true,
+    },
+    pattern: {
+      type: "object",
+      properties: {
+        argumentSchema: { type: "object" },
+        resultSchema: { type: "object" },
+        nodes: { type: "array", items: { type: "object" } },
+        program: { type: "object" },
+        initial: { type: "object" },
+      },
+      required: ["argumentSchema", "resultSchema", "nodes"],
+      asCell: true,
+    },
+    extraParams: { type: "object" },
+    charm: {
+      // Accept whole charm - its own schema defines its handlers
+      asCell: true,
+    },
+  },
+  required: [],
+} as const satisfies JSONSchema;
+
+export const LLMParamsSchema = {
+  type: "object",
+  properties: {
+    messages: { type: "array", items: LLMMessageSchema, default: [] },
+    model: { type: "string" },
+    maxTokens: { type: "number" },
+    system: { type: "string" },
+    stop: { type: "string" },
+    tools: { type: "object", additionalProperties: LLMToolSchema, default: {} },
+  },
+  required: ["messages"],
+} as const satisfies JSONSchema;

--- a/packages/runner/test/generate-object-tools.test.ts
+++ b/packages/runner/test/generate-object-tools.test.ts
@@ -43,6 +43,7 @@ describe("generateObject with tools", () => {
   let generateObject: ReturnType<
     typeof createBuilder
   >["commontools"]["generateObject"];
+  let dummyRecipe: any;
 
   beforeEach(() => {
     clearMockResponses(); // Clear mocks from previous tests
@@ -55,6 +56,7 @@ describe("generateObject with tools", () => {
 
     const { commontools } = createBuilder();
     ({ recipe, generateObject, handler, Cell, patternTool, str } = commontools);
+    dummyRecipe = recipe("Dummy Tool", () => ({}));
   });
 
   afterEach(async () => {
@@ -108,7 +110,12 @@ describe("generateObject with tools", () => {
         const result = generateObject({
           prompt: testPrompt,
           schema: resultSchema,
-          tools: {}, // Empty tools object triggers the finalResult path
+          tools: {
+            dummy: {
+              description: "A dummy tool to force tool-calling path",
+              pattern: dummyRecipe,
+            },
+          },
         });
         return result;
       },
@@ -313,7 +320,12 @@ describe("generateObject with tools", () => {
         const result = generateObject({
           prompt: testPrompt,
           schema: resultSchema,
-          tools: {},
+          tools: {
+            dummy: {
+              description: "A dummy tool to force tool-calling path",
+              pattern: dummyRecipe,
+            },
+          },
         });
         return result;
       },
@@ -391,7 +403,12 @@ describe("generateObject with tools", () => {
         const result = generateObject({
           prompt: testPrompt,
           schema: resultSchema,
-          tools: {},
+          tools: {
+            dummy: {
+              description: "A dummy tool to force tool-calling path",
+              pattern: dummyRecipe,
+            },
+          },
         });
         return result;
       },
@@ -475,7 +492,12 @@ describe("generateObject with tools", () => {
         const result = generateObject({
           messages,
           schema: resultSchema,
-          tools: {},
+          tools: {
+            dummy: {
+              description: "A dummy tool to force tool-calling path",
+              pattern: dummyRecipe,
+            },
+          },
         });
         return result;
       },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored LLM built-ins to validate inputs and standardize results using JSON schemas, with shared schemas extracted to a new module to resolve circular dependencies and simplify cell management.

- **Refactors**
  - Inputs now use JSON schemas (LLMParams, GenerateText, GenerateObject).
  - Results consolidated into a single typed cell with keys: pending, result, error, partial, requestHash.
  - Shared schemas moved to packages/runner/src/builtins/llm-schemas.ts.
  - Added stop to LLM params and enforced tool shapes via LLMToolSchema.
  - Stabilized request hashing to avoid re-running identical requests.

- **Migration**
  - Provide at least one tool in tools to use the tool-calling path; an empty object now uses the direct path.
  - If consuming separate result cells, read from the consolidated result cell and its keys instead.

<sup>Written for commit 715c11d2c13174008c2836a481b9684c0e8ab6ce. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

