### PR TITLE
fix(api): narrow BuiltInGenerateTextParams prompt type to string

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -935,7 +935,7 @@ export type BuiltInGenerateObjectParams =
 
 export type BuiltInGenerateTextParams =
   | {
-    prompt: BuiltInLLMContent;
+    prompt: string;
     messages?: never;
     system?: string;
     model?: string;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Narrowed BuiltInGenerateTextParams.prompt to a plain string to match generateText behavior and improve type safety. Prevents passing content arrays when using prompt mode.

- **Bug Fixes**
  - Changed prompt type from BuiltInLLMContent to string.
  - Clarifies separation between prompt and messages and prevents invalid inputs.
  - Type-only change; no runtime impact.

<sup>Written for commit 503748c7508a00e35f289252dfa3a95562c40ec1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

