### PR TITLE
fix(ts-transformers): align pattern explicit type handling with recipe

### DIFF
--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -468,6 +468,32 @@ export class SchemaInjectionTransformer extends Transformer {
           return ts.visitEachChild(node, visit, transformation);
         }
 
+        // Handle explicit type arguments: pattern<Input, Output>(fn)
+        if (typeArgs && typeArgs.length >= 2) {
+          const [inputType, resultType] = typeArgs;
+
+          if (inputType && resultType) {
+            const argSchemaCall = createSchemaCallWithRegistryTransfer(
+              context,
+              inputType,
+              typeRegistry,
+            );
+            const resSchemaCall = createSchemaCallWithRegistryTransfer(
+              context,
+              resultType,
+              typeRegistry,
+            );
+
+            const updated = factory.createCallExpression(
+              node.expression,
+              undefined,
+              [patternFunction, argSchemaCall, resSchemaCall],
+            );
+
+            return ts.visitEachChild(updated, visit, transformation);
+          }
+        }
+
         // Use type arguments as a hint for inference
         const typeArgHints: ts.Type[] = [];
         if (typeArgs) {

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.tsx
@@ -29,11 +29,9 @@ export default pattern(({ multiplier }) => {
             type: "number"
         }
     },
-    required: ["multiplier"],
-    asOpaque: true
+    required: ["multiplier"]
 } as const satisfies __ctHelpers.JSONSchema, {
-    type: "number",
-    asOpaque: true
+    type: "number"
 } as const satisfies __ctHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.tsx
@@ -1,0 +1,34 @@
+import * as __ctHelpers from "commontools";
+import { pattern, } from "commontools";
+interface Input {
+    foo: string;
+}
+interface Output extends Input {
+    bar: number;
+}
+export default pattern((input) => {
+    return { ...input, bar: 123 };
+}, {
+    type: "object",
+    properties: {
+        foo: {
+            type: "string"
+        }
+    },
+    required: ["foo"]
+} as const satisfies __ctHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        bar: {
+            type: "number"
+        },
+        foo: {
+            type: "string"
+        }
+    },
+    required: ["bar", "foo"]
+} as const satisfies __ctHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.input.tsx
@@ -1,0 +1,16 @@
+/// <cts-enable />
+import {
+  pattern,
+} from "commontools";
+
+interface Input {
+  foo: string;
+}
+
+interface Output extends Input {
+  bar: number;
+}
+
+export default pattern<Input, Output>((input) => {
+  return { ...input, bar: 123 };
+});


### PR DESCRIPTION
Aligns `pattern` explicit type argument handling with `recipe`. Now `pattern<In, Out>(fn)` generates schemas directly from the type arguments, bypassing inference. Includes regression test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns pattern() explicit type handling with recipe. pattern<Input, Output>(fn) now generates schemas directly from the type arguments, bypassing inference.

<sup>Written for commit 9817f999772249886a67dd74ed706d04bea0e50b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

