### PR TITLE
chore: Use tasks, not microtasks, to queue scheduler execution

### DIFF
--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -218,6 +218,8 @@ async function handleLLMError<T, P>(
   resultCell: Cell<T>,
   errorCell: Cell<unknown>,
   partialCell: Cell<P>,
+  requestHashCell: Cell<string | undefined>,
+  requestHash: string,
   getCurrentRun: () => number,
   thisRun: number,
   resetPreviousHash: () => void,
@@ -233,6 +235,7 @@ async function handleLLMError<T, P>(
     errorCell.withTx(tx).set(error);
     resultCell.withTx(tx).set(undefined as T);
     partialCell.withTx(tx).set(undefined as P);
+    requestHashCell.withTx(tx).set(requestHash);
   });
 
   resetPreviousHash();
@@ -382,6 +385,8 @@ export function llm(
         resultCell.key("result"),
         resultCell.key("error"),
         resultCell.key("partial"),
+        resultCell.key("requestHash"),
+        hash,
         () => currentRun,
         thisRun,
         () => {
@@ -478,10 +483,14 @@ export function generateText(
     const hash = refer(llmParams).toString();
     const currentRequestHash = requestHashWithLog.get();
     const currentResult = resultWithLog.get();
+    const currentError = errorWithLog.get();
 
     // Return if the same request is being made again
-    // Only skip if we have a result - otherwise we need to (re)make the request
-    if (currentResult !== undefined && hash === currentRequestHash) {
+    // Also return if there's an error for this request (don't retry automatically)
+    if (
+      (currentResult !== undefined || currentError !== undefined) &&
+      hash === currentRequestHash
+    ) {
       return;
     }
 
@@ -554,6 +563,8 @@ export function generateText(
         resultCell.key("result"),
         resultCell.key("error"),
         resultCell.key("partial"),
+        resultCell.key("requestHash"),
+        hash,
         () => currentRun,
         thisRun,
         () => {
@@ -665,9 +676,14 @@ export function generateObject<T extends Record<string, unknown>>(
       const hash = refer({ ...llmParams, schema }).toString();
       const currentRequestHash = requestHashWithLog.get();
       const currentResult = resultWithLog.get();
+      const currentError = errorWithLog.get();
 
       // Return if the same request is being made again
-      if (currentResult !== undefined && hash === currentRequestHash) {
+      // Also return if there's an error for this request (don't retry automatically)
+      if (
+        (currentResult !== undefined || currentError !== undefined) &&
+        hash === currentRequestHash
+      ) {
         return;
       }
 
@@ -817,6 +833,8 @@ export function generateObject<T extends Record<string, unknown>>(
             resultCell.key("result"),
             resultCell.key("error"),
             resultCell.key("partial"),
+            resultCell.key("requestHash"),
+            hash,
             () => currentRun,
             thisRun,
             () => {
@@ -845,10 +863,14 @@ export function generateObject<T extends Record<string, unknown>>(
       const hash = refer(generateObjectParams).toString();
       const currentRequestHash = requestHashWithLog.get();
       const currentResult = resultWithLog.get();
+      const currentError = errorWithLog.get();
 
       // Return if the same request is being made again
-      // Only skip if we have a result - otherwise we need to (re)make the request
-      if (currentResult !== undefined && hash === currentRequestHash) {
+      // Also return if there's an error for this request (don't retry automatically)
+      if (
+        (currentResult !== undefined || currentError !== undefined) &&
+        hash === currentRequestHash
+      ) {
         return;
       }
 
@@ -898,6 +920,8 @@ export function generateObject<T extends Record<string, unknown>>(
             resultCell.key("result"),
             resultCell.key("error"),
             resultCell.key("partial"),
+            resultCell.key("requestHash"),
+            hash,
             () => currentRun,
             thisRun,
             () => {

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -305,7 +305,11 @@ export class Scheduler implements IScheduler {
       } // Once nothing is running, see if more work is queued up. If not, then
       // resolve the idle promise, otherwise add it to the idle promises list
       // that will be resolved once all the work is done.
-      else if (this.pending.size === 0 && this.eventQueue.length === 0) {
+      // IMPORTANT: Also check !this.scheduled to wait for any queued macro task execution
+      else if (
+        this.pending.size === 0 && this.eventQueue.length === 0 &&
+        !this.scheduled
+      ) {
         resolve();
       } else {
         this.idlePromises.push(resolve);
@@ -436,7 +440,7 @@ export class Scheduler implements IScheduler {
 
   private queueExecution(): void {
     if (this.scheduled) return;
-    queueMicrotask(() => this.execute());
+    queueTask(() => this.execute());
     this.scheduled = true;
   }
 
@@ -572,7 +576,8 @@ export class Scheduler implements IScheduler {
       this.loopCounter = new WeakMap();
       this.scheduled = false;
     } else {
-      queueMicrotask(() => this.execute());
+      // Keep scheduled = true since we're queuing another execution
+      queueTask(() => this.execute());
     }
   }
 }
@@ -712,4 +717,8 @@ function getCharmMetadataFromFrame(frame?: Frame): {
     JSON.stringify(resultCell?.entityId ?? {}),
   )["/"];
   return result;
+}
+
+function queueTask(fn: () => void): void {
+  setTimeout(fn, 0);
 }


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched scheduler execution to use tasks (setTimeout 0) instead of microtasks. This prevents tight loops, makes idle() wait for queued callbacks, and stops auto-retrying the same LLM request after an error.

- **Refactors**
  - Added queueTask helper using setTimeout(fn, 0).
  - Replaced queueMicrotask with queueTask in Scheduler execution paths.

- **Bug Fixes**
  - idle() now resolves only when nothing is pending, no events are queued, and nothing is scheduled.
  - LLM builtins record requestHash on error and skip retries when the same hash already has an error.

<sup>Written for commit 24f2aececda82e34d1399b134f2dc681dc292b98. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





