### PR TITLE
feat(omnibot): move navigateTo out

### DIFF
--- a/packages/patterns/counter-handlers.ts
+++ b/packages/patterns/counter-handlers.ts
@@ -1,9 +1,9 @@
 /// <cts-enable />
-import { Cell, handler } from "commontools";
+import { Cell, Default, handler } from "commontools";
 
 export const increment = handler<
   unknown,
-  { value: Cell<number> }
+  { value: Cell<Default<number, 0>> }
 >(
   (_args, state) => {
     state.value.set(state.value.get() + 1);
@@ -12,7 +12,7 @@ export const increment = handler<
 
 export const decrement = handler<
   unknown,
-  { value: Cell<number> }
+  { value: Cell<Default<number, 0>> }
 >(
   (_args, state) => {
     state.value.set(state.value.get() - 1);
@@ -21,7 +21,7 @@ export const decrement = handler<
 
 export const getValue = handler<
   { result: Cell<string> },
-  { value: Cell<number> }
+  { value: Cell<Default<number, 0>> }
 >(
   (args, state) => {
     args.result.set(`Value is ${state.value.get()}`);
@@ -38,9 +38,9 @@ export function nth(value: number) {
   if (value === 3) {
     return "3rd";
   }
-  return `${value}th`;
+  return `${(value ?? 0)}th`;
 }
 
 export function previous(value: number) {
-  return value - 1;
+  return (value ?? 0) - 1;
 }

--- a/packages/patterns/counter.tsx
+++ b/packages/patterns/counter.tsx
@@ -24,7 +24,7 @@ export default recipe<RecipeState, RecipeOutput>((state) => {
           Counter is the {nth(state.value)} number
         </span>
         <ct-button onClick={increment({ value: state.value })}>
-          inc to {state.value + 1}
+          inc to {(state.value ?? 0) + 1}
         </ct-button>
       </div>
     ),

--- a/packages/runner/src/builtins/compile-and-run.ts
+++ b/packages/runner/src/builtins/compile-and-run.ts
@@ -124,13 +124,12 @@ export function compileAndRun(
               contents: { type: "string" },
             },
             required: ["name", "contents"],
-            additionalProperties: false,
           },
+          default: [],
         },
-        main: { type: "string" },
+        main: { type: "string", default: "" },
       },
       required: ["files", "main"],
-      additionalProperties: false,
     }).withTx(tx).get();
     const input = inputsCell.withTx(tx).key("input");
 

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -114,6 +114,7 @@ declare module "@commontools/api" {
     ): Cell<Schema<S>>;
     asSchema<T>(
       schema?: JSONSchema,
+      rootSchema?: JSONSchema,
     ): Cell<T>;
     withTx(tx?: IExtendedStorageTransaction): Cell<T>;
     sink(callback: (value: Readonly<T>) => Cancel | undefined | void): Cancel;
@@ -732,14 +733,15 @@ export class CellImpl<T> implements ICell<T>, IStreamable<T> {
   ): Cell<Schema<S>>;
   asSchema<T>(
     schema?: JSONSchema,
+    rootSchema?: JSONSchema,
   ): Cell<T>;
-  asSchema(schema?: JSONSchema): Cell<any> {
+  asSchema(schema?: JSONSchema, rootSchema?: JSONSchema): Cell<any> {
     // asSchema creates a sibling with same identity but different schema
     // Create a new link with modified schema
     const siblingLink: NormalizedLink = {
       ...this._link,
       schema: schema,
-      rootSchema: schema,
+      rootSchema: rootSchema ?? schema,
     };
 
     return new CellImpl(


### PR DESCRIPTION
also add tool descriptions and schemas more properly.
simplify a few things.
fix the counter pattern to work around current bug where defaults don't properly propagate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved navigation out of llm-dialog and into the omnibox as a dedicated pattern tool. Tightened tool schemas and defaults, added small helpers, and fixed counter defaults.

- **New Features**
  - Added fetchAndRunPattern and navigateToPattern recipes; exposed via patternTool in omnibox-fab.
  - Added listPatternIndex recipe and tool with clear descriptions and schemas.
  - Navigate to instantiated patterns by passing the result cell to navigateTo.

- **Refactors**
  - Removed built-in navigateTo and listAttachments from llm-dialog; updated tool catalog and docs accordingly.
  - Simplified compileAndRun input schema with defaults (files=[], main="").
  - Converted fetchAndRun from pattern to recipe; args now a Cell.
  - Cell.asSchema now accepts an optional rootSchema.

- **Bug Fixes**
  - Counter handlers use Default<number, 0>; UI math is null-safe.
  - nth/previous handle undefined values correctly.

<sup>Written for commit 9724d29e0ecd3eef69974c2ad5dd4ab154bc20ce. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

