### PR TITLE
Fix/cell embedding in schema default

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1417,6 +1417,7 @@ export function cellConstructorFactory<Wrap extends HKT>(kind: CellKind) {
       // Convert schema to object form and merge default value if value is defined
       // BUT: Don't embed Cell objects in the schema's default property, as this
       // causes infinite recursion when the schema is serialized
+      // TODO(ubik2): Use Cell links for default here once that's supported
       const schema: JSONSchema | undefined =
         value !== undefined && !isCell(value)
           ? {


### PR DESCRIPTION
Fix stack overflow bug that happened in certain cases w.r.t. cell embedding

Reproduction (on main without this patch):

`deno task ct dev --show-transformed packages/ts-transformers/test/fixtures/closures/cell-map-with-captures.input.tsx`







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stack overflow by preventing Cell values from being embedded in a schema’s default and normalizing the schema object for safe serialization.

- **Bug Fixes**
  - Guard default assignment with isCell(value); apply Cell initial values via setInitialValue() instead of serializing them.
  - Preserve undefined schemas; otherwise convert providedSchema to an object with ContextualFlowControl.toSchemaObj for consistent serialization.

<sup>Written for commit 2befb111c27046964b8f76ea26f2f0f0f247c079. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







