### PR TITLE
fix(builtin): Implement single-navigation and status reporting for `navigateTo` using a result cell.

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1243,7 +1243,7 @@ export type CompileAndRunFunction = <T = any, S = any>(
   params: Opaque<BuiltInCompileAndRunParams<T>>,
 ) => OpaqueRef<BuiltInCompileAndRunState<S>>;
 
-export type NavigateToFunction = (cell: OpaqueRef<any>) => OpaqueRef<string>;
+export type NavigateToFunction = (cell: OpaqueRef<any>) => OpaqueRef<boolean>;
 export type WishFunction = {
   <T = unknown>(target: Opaque<string>): OpaqueRef<T>;
   <S extends JSONSchema = JSONSchema>(

--- a/packages/patterns/omnibox-fab.tsx
+++ b/packages/patterns/omnibox-fab.tsx
@@ -84,8 +84,9 @@ const fetchAndRunPattern = recipe<FetchAndRunPatternInput>(
 type NavigateToPatternInput = { cell: Cell<any> }; // Hack to steer LLM
 const navigateToPattern = recipe<NavigateToPatternInput>(
   ({ cell }) => {
-    navigateTo(cell);
-    return { success: ifElse(cell, true, false) };
+    const success = navigateTo(cell);
+
+    return ifElse(success, { success }, undefined);
   },
 );
 

--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -115,7 +115,7 @@ let ifElseFactory:
 export const navigateTo = createNodeFactory({
   type: "ref",
   implementation: "navigateTo",
-}) as (cell: OpaqueRef<unknown>) => OpaqueRef<string>;
+}) as (cell: OpaqueRef<unknown>) => OpaqueRef<boolean>;
 
 export function wish<T = unknown>(
   target: Opaque<string>,

--- a/packages/runner/src/builtins/navigate-to.ts
+++ b/packages/runner/src/builtins/navigate-to.ts
@@ -5,23 +5,61 @@ import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 
 export function navigateTo(
   inputsCell: Cell<any>,
-  _sendResult: (tx: IExtendedStorageTransaction, result: any) => void,
+  sendResult: (tx: IExtendedStorageTransaction, result: any) => void,
   _addCancel: (cancel: () => void) => void,
-  _cause: Cell<any>[],
-  _parentCell: Cell<any>,
+  cause: Cell<any>[],
+  parentCell: Cell<any>,
   runtime: IRuntime,
 ): Action {
+  let isInitialized = false;
+  let navigated = false;
+  let resultCell: Cell<boolean>;
+
   return (tx: IExtendedStorageTransaction) => {
-    const inputsWithLog = inputsCell.asSchema({ asCell: true }).withTx(tx);
-
-    const target = inputsWithLog.get();
-
-    if (!runtime.navigateCallback) {
-      throw new Error("navigateCallback is not set");
+    // The main reason we might be called again after navigating is that the
+    // transaction to update the result cell failed, so we'll just set it again.
+    if (navigated) {
+      resultCell.set(true);
+      return;
     }
 
-    if (target && target.get()) {
+    // Initialize the result cell if it hasn't been initialized yet.
+    if (!isInitialized) {
+      resultCell = runtime.getCell<any>(
+        parentCell.space,
+        { navigateTo: { result: cause } },
+        { type: "boolean" },
+        tx,
+      );
+
+      resultCell.sync();
+
+      sendResult(tx, resultCell);
+
+      isInitialized = true;
+    }
+
+    // If the result cell is already true, we've already navigated.
+    if (resultCell.get()) return;
+
+    // Read with a schema that won't subscribe to the whole charm
+    const inputsWithLog = inputsCell.asSchema({ not: true, asCell: true })
+      .withTx(tx);
+    const target = inputsWithLog.get();
+
+    // If we have a target and the value isn't `undefined`, navigate to it.
+    // TODO(seefeld): This might break once we support the not operation in
+    // client-side schema validation. Then we'll need another way to check for
+    // not undefined without subscribing deeper than the first level.
+    if (target && target.asSchema({ not: true }).get()) {
+      if (!runtime.navigateCallback) {
+        throw new Error("navigateCallback is not set");
+      }
+
       runtime.navigateCallback(target);
+
+      navigated = true;
+      resultCell.set(true);
     }
   };
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implemented single-navigation for navigateTo and added a boolean success result via a dedicated cell. This prevents duplicate navigations and lets patterns branch on success.

- **Bug Fixes**
  - Navigate only once; track success in a result cell and sync it.
  - On re-invocation, set the result to true instead of navigating again.
  - Read inputs with a shallow “not” schema to avoid deep subscriptions.

- **Migration**
  - NavigateToFunction now returns OpaqueRef<boolean>.
  - Update callers to branch on success (omnibox pattern updated).

<sup>Written for commit 48200f3565e67d839f4a0c629b71becd46dcb3fd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

