### PR TITLE
Fix ct-draggable to exclude ct-input and other interactive custom elements

### DIFF
--- a/packages/ui/src/v2/components/ct-draggable/ct-draggable.ts
+++ b/packages/ui/src/v2/components/ct-draggable/ct-draggable.ts
@@ -62,6 +62,8 @@ export class CtDraggable extends BaseElement {
     const target = event.target as HTMLElement;
     if (
       target.tagName === "INPUT" || target.tagName === "BUTTON" ||
+      target.tagName === "CT-INPUT" || target.tagName === "CT-TEXTAREA" ||
+      target.tagName === "CT-SELECT" || target.tagName === "CT-BUTTON" ||
       target.closest("common-send-message")
     ) {
       return;


### PR DESCRIPTION
## Summary

Fixes ct-draggable to properly exclude ct-input and other interactive custom elements from drag operations, allowing bidirectional binding with `$value` to work correctly.

## Problem

ct-draggable was only checking for native INPUT/BUTTON elements by `tagName`, which meant custom elements like `ct-input`, `ct-textarea`, etc. would trigger drag operations when clicked for editing. This prevented patterns from using ct-input with `$value` for bidirectional binding inside draggable containers.

## Solution

Added CT-INPUT, CT-TEXTAREA, CT-SELECT, and CT-BUTTON to the exclusion list in the `handleMouseDown` event handler.

## Changes

- Modified `packages/ui/src/v2/components/ct-draggable/ct-draggable.ts`
- Added custom element tagNames to exclusion check: `CT-INPUT`, `CT-TEXTAREA`, `CT-SELECT`, `CT-BUTTON`

## Testing

Tested with ClusterBoard pattern (community-patterns):
- ✅ ct-input editing works without triggering drag
- ✅ Dragging from drag handles still functions correctly
- ✅ Bidirectional binding via `$value` works as expected
- ✅ Screenshot verification in Playwright

## Benefits

- Enables idiomatic Common Tools pattern code with `$value` binding
- No need for workarounds like native input elements with manual event handlers
- Consistent behavior across all interactive custom elements
- Better developer experience for pattern authors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed ct-draggable so clicks on ct-input and other interactive elements don't start a drag. This lets editing work normally and keeps $value bindings working inside draggable containers.

- **Bug Fixes**
  - Updated handleMouseDown to skip drag for INPUT, BUTTON, CT-INPUT, CT-TEXTAREA, CT-SELECT, CT-BUTTON.

<sup>Written for commit 127067ecb6ac7279088e1a6cdf8e25f40d476454. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

