### PR TITLE
feat(runner): hydrate Cells in generateObject finalResult

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -198,6 +198,11 @@ function parseLLMFriendlyLink(
     );
   }
 
+  // Remove path element from trailing slash
+  if (path.length > 0 && path[path.length - 1] === "") {
+    path.pop();
+  }
+
   return {
     id: id as `${string}:${string}`,
     path,
@@ -1472,7 +1477,6 @@ async function handleInvoke(
 
   // Wait for the pattern/handler to complete and write the result
   const cancel = result.sink((r) => {
-    console.log("result", r);
     r !== undefined && resolve(r);
   });
 
@@ -1576,7 +1580,7 @@ async function invokeToolCall(
 
   if (resolved.type === "finalResult") {
     // Return the structured result directly
-    return { type: "json", value: resolved.result };
+    return traverseAndCellify(runtime, space, resolved.result);
   }
 
   // Handle run-type tools (external, run with pattern/handler)

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -758,13 +758,15 @@ export function generateObject<T extends Record<string, unknown>>(
               toolCallParts,
             );
 
-            // Check if finalResult was called
-            const finalResultCall = toolCallParts.find(
+            // Check if finalResult was called and grab the result.
+            // It's post de-serialization so might contain cells
+            // (unlike the input to the tool)
+            const finalResultCall = toolResults.find(
               (p) =>
                 p.toolName === llmToolExecutionHelpers.FINAL_RESULT_TOOL_NAME,
             );
             if (finalResultCall) {
-              finalResult = finalResultCall.input as T;
+              finalResult = finalResultCall.result as T;
             }
 
             const toolResultMessages = llmToolExecutionHelpers

--- a/packages/runner/test/llm-dialog-helpers.test.ts
+++ b/packages/runner/test/llm-dialog-helpers.test.ts
@@ -49,7 +49,7 @@ Deno.test("parseTargetString recognizes ~ encoded path elements", () => {
     parsed.id,
     "of:baedreidptbmcghfoqcb2xa3l3qsvype5gjcfuektmzdjalfb7yqztjda5q",
   );
-  assertEquals(parsed.path, ["foo/bar", "~", ""]);
+  assertEquals(parsed.path, ["foo/bar", "~"]);
 });
 
 Deno.test("parseTargetString errors on human name", () => {


### PR DESCRIPTION
Updates `generateObject` to correctly handle `Cell` references (serialized as `@link` objects) when they are returned as part of the final result.

Previously, `generateObject` extracted the final result directly from the LLM's tool call arguments (`input`). This bypassed the `traverseAndCellify` logic that normally runs during tool execution, causing `@link` objects to remain as plain JSON objects instead of being hydrated into `Cell` instances.

This commit:
1. Modifies `llm-dialog.ts` to ensure `finalResult` tool calls run through `traverseAndCellify`.
2. Updates `llm.ts` to retrieve the `finalResult` from the executed `toolResults` (which contain the hydrated values) rather than the raw `toolCallParts`.
3. Adds a regression test ensuring that `@link` objects returned by the LLM are correctly resolved to Cells.
4. Remove trailing slashes in @links

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hydrates Cell references in generateObject finalResult so @link objects returned by the LLM resolve to Cells instead of plain JSON. Also normalizes @links by removing trailing slashes.

- **Bug Fixes**
  - Run finalResult tool calls through traverseAndCellify.
  - Read final result from executed toolResults (hydrated), not toolCallParts input.
  - Strip trailing slashes from parsed link paths.
  - Added regression test to verify @link → Cell resolution.

<sup>Written for commit e4b0833bd48596b96a7dbe355333cda110e035be. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

