### PR TITLE
Fix calendar null guard for seriesId in map derivations

### DIFF
--- a/packages/patterns/calendar.tsx
+++ b/packages/patterns/calendar.tsx
@@ -1672,7 +1672,9 @@ export default recipe<Input, Output>(
       (series: RecurringSeries[]) => {
         const map: Record<string, RecurringSeries> = {};
         for (const s of series) {
-          map[s.seriesId] = s;
+          if (s && s.seriesId) {
+            map[s.seriesId] = s;
+          }
         }
         return map;
       },
@@ -1684,7 +1686,9 @@ export default recipe<Input, Output>(
       (overrides: SeriesOverride[]) => {
         const map: Record<string, SeriesOverride> = {};
         for (const o of overrides) {
-          map[`${o.seriesId}:${o.recurrenceDate}`] = o;
+          if (o && o.seriesId && o.recurrenceDate) {
+            map[`${o.seriesId}:${o.recurrenceDate}`] = o;
+          }
         }
         return map;
       },


### PR DESCRIPTION
## Summary
- Add null/undefined guards when building series and override maps
- Prevents TypeError when arrays contain undefined entries during calendar month traversal with recurring events

## Test plan
- [ ] Create a calendar with a daily repeating event
- [ ] Navigate between months
- [ ] Verify no "Cannot read properties of undefined (reading 'seriesId')" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add null/undefined guards when building RecurringSeries and SeriesOverride maps, skipping entries without seriesId or recurrenceDate. Prevents runtime errors like "Cannot read properties of undefined (reading 'seriesId')" when navigating calendar months with recurring events.

<sup>Written for commit c210141fb0388b4c185a22704f67297c455965b5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

