### PR TITLE
chore: Update LOCAL_DEV_SERVERS.md docs to link the shell start command to local toolshed

### DIFF
--- a/docs/common/LOCAL_DEV_SERVERS.md
+++ b/docs/common/LOCAL_DEV_SERVERS.md
@@ -24,7 +24,7 @@ SHELL_URL=http://localhost:5173 deno task dev
 ### Terminal 2: Start Frontend (Shell)
 ```bash
 cd packages/shell
-deno task dev
+deno task dev-local
 ```
 
 **Expected output:**
@@ -93,7 +93,7 @@ cd packages/toolshed && SHELL_URL=http://localhost:5173 deno task dev &
 TOOLSHED_PID=$!
 
 # Start frontend in background
-cd packages/shell && deno task dev &
+cd packages/shell && deno task dev-local &
 SHELL_PID=$!
 
 # Wait for both to start


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated LOCAL_DEV_SERVERS.md to use deno task dev-local for the shell so it connects to the local toolshed instance.
Adjusted both the step-by-step and background startup examples.

<sup>Written for commit 95aeb5db476880cff8bb838c82a953434a9722d2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

