### PR TITLE
Wrap `setsrc` mutation in a transaction + retry

### DIFF
--- a/packages/charm/src/iterate.ts
+++ b/packages/charm/src/iterate.ts
@@ -565,7 +565,7 @@ export async function compileRecipe(
   const recipeId = runtime.recipeManager.registerRecipe(recipe, recipeSrc);
 
   // Record metadata fields (spec, parents) for this recipe
-  runtime.recipeManager.setRecipeMetaFields(recipeId, {
+  await runtime.recipeManager.setRecipeMetaFields(recipeId, {
     spec,
     parents: parentsIds,
   } as Partial<Mutable<RecipeMeta>>);

--- a/packages/runner/src/recipe-manager.ts
+++ b/packages/runner/src/recipe-manager.ts
@@ -292,11 +292,14 @@ export class RecipeManager implements IRecipeManager {
    * If the metadata cell already exists, it updates it in-place.
    * Otherwise, it stores the fields to be applied on the next save.
    */
-  setRecipeMetaFields(recipeId: string, fields: Partial<RecipeMeta>): void {
+  async setRecipeMetaFields(
+    recipeId: string,
+    fields: Partial<RecipeMeta>,
+  ): Promise<void> {
     const cell = this.recipeMetaCellById.get(recipeId);
     if (cell) {
       const current = cell.get();
-      this.runtime.editWithRetry((tx) => {
+      await this.runtime.editWithRetry((tx) => {
         cell.withTx(tx).set({ ...current, ...fields, id: recipeId });
       });
     } else {

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -251,7 +251,10 @@ export interface IRecipeManager {
     },
     tx?: IExtendedStorageTransaction,
   ): Promise<void>;
-  setRecipeMetaFields(recipeId: string, fields: Partial<RecipeMeta>): void;
+  setRecipeMetaFields(
+    recipeId: string,
+    fields: Partial<RecipeMeta>,
+  ): Promise<void>;
 }
 
 export interface IModuleRegistry {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes setsrc failing with "transaction required" by performing the recipe meta update inside a runtime transaction with retry. Addresses Linear CT-1057 and makes setsrc updates reliable under concurrent edits.

<sup>Written for commit 3c03006df7303f8b855b1374d561149365b5cf64. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



