### PR TITLE
Revert "chore: Use tasks, not microtasks, to queue scheduler execution (#2115)"

### DIFF
--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -228,8 +228,6 @@ async function handleLLMError<T, P>(
   resultCell: Cell<T>,
   errorCell: Cell<unknown>,
   partialCell: Cell<P>,
-  requestHashCell: Cell<string | undefined>,
-  requestHash: string,
   getCurrentRun: () => number,
   thisRun: number,
   resetPreviousHash: () => void,
@@ -245,7 +243,6 @@ async function handleLLMError<T, P>(
     errorCell.withTx(tx).set(error);
     resultCell.withTx(tx).set(undefined as T);
     partialCell.withTx(tx).set(undefined as P);
-    requestHashCell.withTx(tx).set(requestHash);
   });
 
   resetPreviousHash();
@@ -450,8 +447,6 @@ export function llm(
         resultCell.key("result"),
         resultCell.key("error"),
         resultCell.key("partial"),
-        resultCell.key("requestHash"),
-        hash,
         () => currentRun,
         thisRun,
         () => {
@@ -556,14 +551,10 @@ export function generateText(
     const hash = refer(llmParams).toString();
     const currentRequestHash = requestHashWithLog.get();
     const currentResult = resultWithLog.get();
-    const currentError = errorWithLog.get();
 
     // Return if the same request is being made again
-    // Also return if there's an error for this request (don't retry automatically)
-    if (
-      (currentResult !== undefined || currentError !== undefined) &&
-      hash === currentRequestHash
-    ) {
+    // Only skip if we have a result - otherwise we need to (re)make the request
+    if (currentResult !== undefined && hash === currentRequestHash) {
       return;
     }
 
@@ -636,8 +627,6 @@ export function generateText(
         resultCell.key("result"),
         resultCell.key("error"),
         resultCell.key("partial"),
-        resultCell.key("requestHash"),
-        hash,
         () => currentRun,
         thisRun,
         () => {
@@ -757,14 +746,9 @@ export function generateObject<T extends Record<string, unknown>>(
       const hash = refer({ ...llmParams, schema }).toString();
       const currentRequestHash = requestHashWithLog.get();
       const currentResult = resultWithLog.get();
-      const currentError = errorWithLog.get();
 
       // Return if the same request is being made again
-      // Also return if there's an error for this request (don't retry automatically)
-      if (
-        (currentResult !== undefined || currentError !== undefined) &&
-        hash === currentRequestHash
-      ) {
+      if (currentResult !== undefined && hash === currentRequestHash) {
         return;
       }
 
@@ -916,8 +900,6 @@ export function generateObject<T extends Record<string, unknown>>(
             resultCell.key("result"),
             resultCell.key("error"),
             resultCell.key("partial"),
-            resultCell.key("requestHash"),
-            hash,
             () => currentRun,
             thisRun,
             () => {
@@ -945,14 +927,10 @@ export function generateObject<T extends Record<string, unknown>>(
       const hash = refer(generateObjectParams).toString();
       const currentRequestHash = requestHashWithLog.get();
       const currentResult = resultWithLog.get();
-      const currentError = errorWithLog.get();
 
       // Return if the same request is being made again
-      // Also return if there's an error for this request (don't retry automatically)
-      if (
-        (currentResult !== undefined || currentError !== undefined) &&
-        hash === currentRequestHash
-      ) {
+      // Only skip if we have a result - otherwise we need to (re)make the request
+      if (currentResult !== undefined && hash === currentRequestHash) {
         return;
       }
 
@@ -1002,8 +980,6 @@ export function generateObject<T extends Record<string, unknown>>(
             resultCell.key("result"),
             resultCell.key("error"),
             resultCell.key("partial"),
-            resultCell.key("requestHash"),
-            hash,
             () => currentRun,
             thisRun,
             () => {

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -306,11 +306,7 @@ export class Scheduler implements IScheduler {
       } // Once nothing is running, see if more work is queued up. If not, then
       // resolve the idle promise, otherwise add it to the idle promises list
       // that will be resolved once all the work is done.
-      // IMPORTANT: Also check !this.scheduled to wait for any queued macro task execution
-      else if (
-        this.pending.size === 0 && this.eventQueue.length === 0 &&
-        !this.scheduled
-      ) {
+      else if (this.pending.size === 0 && this.eventQueue.length === 0) {
         resolve();
       } else {
         this.idlePromises.push(resolve);
@@ -441,7 +437,7 @@ export class Scheduler implements IScheduler {
 
   private queueExecution(): void {
     if (this.scheduled) return;
-    queueTask(() => this.execute());
+    queueMicrotask(() => this.execute());
     this.scheduled = true;
   }
 
@@ -581,8 +577,7 @@ export class Scheduler implements IScheduler {
       this.loopCounter = new WeakMap();
       this.scheduled = false;
     } else {
-      // Keep scheduled = true since we're queuing another execution
-      queueTask(() => this.execute());
+      queueMicrotask(() => this.execute());
     }
   }
 }
@@ -722,8 +717,4 @@ function getCharmMetadataFromFrame(frame?: Frame): {
     JSON.stringify(resultCell?.entityId ?? {}),
   )["/"];
   return result;
-}
-
-function queueTask(fn: () => void): void {
-  setTimeout(fn, 0);
 }


### PR DESCRIPTION

This reverts commit 5b414ef00535e13b92a78f215b7b5099304e15ca.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverted the scheduler back to microtask-based execution for predictable ordering and faster idle resolution, and fixed LLM request de-duplication to allow retries after errors.

- **Bug Fixes**
  - Scheduler now uses queueMicrotask instead of setTimeout and removes the extra idle wait logic tied to macro tasks.
  - LLM requests no longer write requestHash on errors and only skip duplicates when a result exists, enabling immediate retries after failures.

<sup>Written for commit f4f8905ec1f3b458d792e917b121b36effa04545. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

