### PR TITLE
Add `todo-list` to `index.md`

### DIFF
--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -25,32 +25,29 @@ interface CounterOutput {
 }
 ```
 
-## `chatbot.tsx`
+## `todo-list.tsx`
 
-A chatbot demo.
+A todo list with AI suggestions.
 
 ### Input Schema
 
 ```ts
-type ChatInput = {
-  /** The system prompt */
-  system: string;
-};
+interface TodoItem {
+  title: string;
+  done: Default<boolean, false>;
+}
+
+interface Input {
+  items: Cell<TodoItem[]>;
+}
 ```
 
 ### Result Schema
 
 ```ts
-type ChatOutput = {
-  messages: Array<BuiltInLLMMessage>;
-  pending: boolean | undefined;
-  addMessage: Stream<BuiltInLLMMessage>;
-  clearChat: Stream<void>;
-  cancelGeneration: Stream<void>;
-  title: string;
-  attachments: Array<PromptAttachment>;
-  tools: any;
-};
+interface Output {
+  items: Cell<TodoItem[]>;
+}
 ```
 
 ## `note.tsx`

--- a/packages/patterns/todo-list.tsx
+++ b/packages/patterns/todo-list.tsx
@@ -18,7 +18,8 @@ interface Output {
 export default pattern<Input, Output>(({ items }) => {
   // AI suggestion based on current todos
   const suggestion = Suggestion({
-    situation: "Based on my todo list, use a pattern to help me.",
+    situation:
+      "Based on my todo list, use a pattern to help me. For sub-tasks and additional tasks, use a todo list.",
     context: { items },
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the todo-list pattern to patterns/index.md with clear input/output schemas, replacing the chatbot example. Also tightens the Suggestion prompt in todo-list.tsx to route sub-tasks and extra tasks into a todo list for clearer guidance.

<sup>Written for commit 3cb24194fba8629584345a13ded5c92073fbcbe0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

