### PR TITLE
Fix ct-card empty section whitespace and title/description/action slots

### DIFF
--- a/packages/ui/src/v2/components/ct-card/ct-card.ts
+++ b/packages/ui/src/v2/components/ct-card/ct-card.ts
@@ -236,18 +236,23 @@ export class CTCard extends BaseElement {
     /** Update empty state classes based on slot content */
     private _updateEmptyStates(): void {
       const getSlot = (name: string) =>
-        this.shadowRoot?.querySelector(`slot[name="${name}"]`) as HTMLSlotElement | null;
+        this.shadowRoot?.querySelector(`slot[name="${name}"]`) as
+          | HTMLSlotElement
+          | null;
 
       const headerSlot = getSlot("header");
       const contentSlot = getSlot("content");
-      const defaultSlot = contentSlot?.querySelector("slot:not([name])") as HTMLSlotElement | null;
+      const defaultSlot = contentSlot?.querySelector("slot:not([name])") as
+        | HTMLSlotElement
+        | null;
       const footerSlot = getSlot("footer");
       const titleSlot = getSlot("title");
       const actionSlot = getSlot("action");
       const descriptionSlot = getSlot("description");
 
       const hasHeader = this._slotHasContent(headerSlot);
-      const hasContent = this._slotHasContent(contentSlot) || this._slotHasContent(defaultSlot);
+      const hasContent = this._slotHasContent(contentSlot) ||
+        this._slotHasContent(defaultSlot);
       const hasFooter = this._slotHasContent(footerSlot);
       const hasTitle = this._slotHasContent(titleSlot);
       const hasAction = this._slotHasContent(actionSlot);
@@ -256,10 +261,22 @@ export class CTCard extends BaseElement {
       const showHeader = hasHeader || hasTitle || hasAction || hasDescription;
       const showTitleWrapper = hasTitle || hasAction;
 
-      this.shadowRoot?.querySelector(".card-header")?.classList.toggle("empty", !showHeader);
-      this.shadowRoot?.querySelector(".card-content")?.classList.toggle("empty", !hasContent);
-      this.shadowRoot?.querySelector(".card-footer")?.classList.toggle("empty", !hasFooter);
-      this.shadowRoot?.querySelector(".card-title-wrapper")?.classList.toggle("empty", !showTitleWrapper);
+      this.shadowRoot?.querySelector(".card-header")?.classList.toggle(
+        "empty",
+        !showHeader,
+      );
+      this.shadowRoot?.querySelector(".card-content")?.classList.toggle(
+        "empty",
+        !hasContent,
+      );
+      this.shadowRoot?.querySelector(".card-footer")?.classList.toggle(
+        "empty",
+        !hasFooter,
+      );
+      this.shadowRoot?.querySelector(".card-title-wrapper")?.classList.toggle(
+        "empty",
+        !showTitleWrapper,
+      );
     }
 
     private _handleClick = (_event: Event): void => {


### PR DESCRIPTION
## Summary

Fixes excessive vertical whitespace in ct-card by replacing broken CSS-only empty detection with reliable JS-based slot monitoring. Also fixes title/description/action slots not displaying.

## Problem

1. **Empty sections showing whitespace**: Previous CSS approach using `:not(:has(*))` never worked because slots with fallback content always have children, even when empty
2. **Title/description/action slots hidden**: CSS rule `.card-title-wrapper:not(:has([slot]))` couldn't detect slot assignment since slotted elements are in light DOM

## Solution

**Commit 1cf9a655**: Replaced CSS-only detection with JS-based approach
- Listen to `slotchange` events on all slots
- Check `assignedNodes()` to detect actual slotted content
- Toggle `.empty` class on sections based on slot state
- Added comprehensive documentation explaining why CSS-only approaches fail

**Commit 500004de**: Fixed title/description/action slot visibility
- Extended `_updateEmptyStates()` to check nested title/action/description slots
- Toggle `.empty` class on title-wrapper based on slot assignment
- Header section now shows when using title/description/action pattern

## Testing

Created comprehensive test pattern with 9 test cases covering all slot usage patterns:
- Default slot only ✅
- Named content slot ✅
- Header + default content ✅
- Header + footer + default ✅
- Title/description/action ✅ (was broken, now fixed)
- All named slots ✅
- Empty card ✅
- Header only ✅
- Footer only ✅

All cards now show symmetric 25px padding on all sides with no excess whitespace.

## Impact

- Fixes food-recipe pattern spacing issues
- Enables proper use of title/description/action slot pattern
- More reliable empty section handling for all ct-card users

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>











<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed excess whitespace in ct-card and restored visibility of title/description/action slots with JS-based slot monitoring. Empty sections now hide correctly, headers render for nested title/action/description, and header-only cards have proper spacing.

- **Bug Fixes**
  - Use slotchange + assignedNodes() with content detection that ignores whitespace-only text and correctly counts icons/images/custom elements.
  - Check both named "content" and default slots; spacing is consistent (25px) and header-only cards get bottom padding.

<sup>Written for commit dd06fc28efadeacf9f70962936d3fae3417e47cb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











