### PR TITLE
feat: Use empty space name as Home space, creating profile.tsx

### DIFF
--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -225,7 +225,7 @@ export class CharmManager {
     return this.space;
   }
 
-  getSpaceName(): string {
+  getSpaceName(): string | undefined {
     return this.session.spaceName;
   }
 

--- a/packages/identity/src/session.ts
+++ b/packages/identity/src/session.ts
@@ -2,7 +2,7 @@ import { Identity } from "./identity.ts";
 import { type DID } from "./interface.ts";
 
 export type Session = {
-  spaceName: string;
+  spaceName?: string;
   spaceIdentity?: Identity;
   space: DID;
   as: Identity;
@@ -13,7 +13,7 @@ export const createSessionFromDid = (
   { identity, space, spaceName }: {
     identity: Identity;
     space: DID;
-    spaceName: string;
+    spaceName?: string;
   },
 ): Promise<Session> => {
   return Promise.resolve({

--- a/packages/patterns/profile.tsx
+++ b/packages/patterns/profile.tsx
@@ -1,0 +1,9 @@
+/// <cts-enable />
+import { NAME, pattern, UI } from "commontools";
+
+export default pattern((_) => {
+  return {
+    [NAME]: `User Profile`,
+    [UI]: <h1>User Profile</h1>,
+  };
+});

--- a/packages/shell/CLAUDE.md
+++ b/packages/shell/CLAUDE.md
@@ -69,7 +69,6 @@ RootView (authentication wrapper)
 4. **Routing**:
    - URL pattern: `/{spaceName}/{charmId}`
    - History API integration with back/forward support
-   - Default space: "common-knowledge"
 
 ### Important Patterns
 

--- a/packages/shell/src/lib/app/commands.ts
+++ b/packages/shell/src/lib/app/commands.ts
@@ -3,7 +3,7 @@ import { Identity } from "@commontools/identity";
 export type Command =
   | { type: "set-active-charm-id"; charmId?: string }
   | { type: "set-identity"; identity: Identity }
-  | { type: "set-space"; spaceName: string }
+  | { type: "set-space"; spaceName?: string }
   | { type: "clear-authentication" }
   | { type: "set-show-charm-list-view"; show: boolean }
   | { type: "set-show-debugger-view"; show: boolean }
@@ -22,8 +22,9 @@ export function isCommand(value: unknown): value is Command {
       return "identity" in value && value.identity instanceof Identity;
     }
     case "set-space": {
-      return "spaceName" in value && !!value.spaceName &&
-        typeof value.spaceName === "string";
+      return "spaceName" in value && (value.spaceName === undefined || (
+        typeof value.spaceName === "string" && !!value.spaceName
+      ));
     }
     case "set-active-charm-id": {
       return "charmId" in value && !!value.charmId &&

--- a/packages/shell/src/lib/app/controller.ts
+++ b/packages/shell/src/lib/app/controller.ts
@@ -35,7 +35,7 @@ export class App extends EventTarget {
     return serialize(this.state());
   }
 
-  async setSpace(spaceName: string) {
+  async setSpace(spaceName?: string) {
     await this.apply({ type: "set-space", spaceName });
   }
 

--- a/packages/shell/src/lib/known-patterns.ts
+++ b/packages/shell/src/lib/known-patterns.ts
@@ -4,16 +4,31 @@ import { API_URL } from "./env.ts";
 
 const DEFAULT_CHARM_NAME = "DefaultCharmList";
 const DEFAULT_APP_URL = `${API_URL}api/patterns/default-app.tsx`;
+const PROFILE_CHARM_NAME = "Profile";
+const PROFILE_APP_URL = `${API_URL}api/patterns/profile.tsx`;
 
-export async function create(cc: CharmsController): Promise<CharmController> {
+export enum KnownPatternType {
+  Default,
+  Profile,
+}
+
+export async function create(
+  cc: CharmsController,
+  type: KnownPatternType,
+): Promise<CharmController> {
   const manager = cc.manager();
   const runtime = manager.runtime;
-
+  const url = type === KnownPatternType.Default
+    ? DEFAULT_APP_URL
+    : PROFILE_APP_URL;
+  const cause = type === KnownPatternType.Default
+    ? DEFAULT_CHARM_NAME
+    : PROFILE_CHARM_NAME;
   const program = await cc.manager().runtime.harness.resolve(
-    new HttpProgramResolver(DEFAULT_APP_URL),
+    new HttpProgramResolver(url),
   );
 
-  const charm = await cc.create(program, undefined, "default-charm");
+  const charm = await cc.create(program, undefined, cause);
 
   // Wait for the link to be processed
   await runtime.idle();
@@ -25,11 +40,15 @@ export async function create(cc: CharmsController): Promise<CharmController> {
   return charm;
 }
 
-export function getDefaultPattern(
+export function getPattern(
   charms: CharmController[],
+  type: KnownPatternType,
 ): CharmController | undefined {
+  const patternName = type === KnownPatternType.Default
+    ? DEFAULT_CHARM_NAME
+    : PROFILE_CHARM_NAME;
   return charms.find((c) => {
     const name = c.name();
-    return name && name.startsWith(DEFAULT_CHARM_NAME);
+    return name && name.startsWith(patternName);
   });
 }

--- a/packages/shell/src/lib/navigate.ts
+++ b/packages/shell/src/lib/navigate.ts
@@ -13,10 +13,10 @@ export type NavigationCommandType = "charm" | "space";
 export type NavigationCommand = {
   type: "charm";
   charmId: string;
-  spaceName: string;
+  spaceName?: string;
 } | {
   type: "space";
-  spaceName: string;
+  spaceName?: string;
 };
 
 const NavigationEventName = "ct-navigate";
@@ -157,9 +157,8 @@ function generateCommandFromPageLoad(): NavigationCommand {
   const location = new URL(globalThis.location.href);
   const segments = location.pathname.split("/");
   segments.shift(); // shift off the pathnames' prefix "/";
-  const [first, charmId] = [segments[0], segments[1]];
+  const [spaceName, charmId] = [segments[0], segments[1]];
 
-  const spaceName = first || "common-knowledge";
   if (charmId) {
     return { type: "charm", spaceName, charmId };
   } else {

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -93,7 +93,7 @@ export class XAppView extends BaseView {
       this.keyboard.register(
         { code: "KeyW", alt: true, preventDefault: true },
         () => {
-          const spaceName = this.app?.spaceName ?? "common-knowledge";
+          const spaceName = this.app?.spaceName;
           navigate({ type: "space", spaceName });
         },
       ),

--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -4,7 +4,7 @@ import { Task } from "@lit/task";
 import { BaseView } from "./BaseView.ts";
 import { RuntimeInternals } from "../lib/runtime.ts";
 import { CharmController } from "@commontools/charm/ops";
-import * as DefaultPattern from "../lib/default-pattern.ts";
+import * as KnownPattern from "../lib/known-patterns.ts";
 import "../components/OmniLayout.ts";
 
 export class XBodyView extends BaseView {
@@ -79,7 +79,10 @@ export class XBodyView extends BaseView {
 
     this.creatingDefaultPattern = true;
     try {
-      await DefaultPattern.create(this.rt.cc());
+      await KnownPattern.create(
+        this.rt.cc(),
+        KnownPattern.KnownPatternType.Default,
+      );
     } catch (error) {
       console.error("Could not create default pattern:", error);
       // Re-throw to expose errors instead of swallowing them
@@ -117,7 +120,7 @@ export class XBodyView extends BaseView {
     }
 
     const defaultPattern = charms
-      ? DefaultPattern.getDefaultPattern(charms)
+      ? KnownPattern.getPattern(charms, KnownPattern.KnownPatternType.Default)
       : undefined;
     const activeCharm = this.activeCharm;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Empty space name now routes to the user's Home space (their DID), instead of defaulting to "common-knowledge". Adds a simple Profile pattern and updates the shell to handle optional space names.

- **New Features**
  - Home space: when spaceName is empty, connect via user DID.
  - Added Profile pattern (User Profile UI).
  - Known patterns support Default and Profile types.
  - On Home space, ensure a default charm exists if no Profile charm is found.

- **Refactors**
  - spaceName is optional across session, manager, commands, navigation, and views.
  - Removed automatic "common-knowledge" fallback in URL parsing and navigation.
  - Runtime uses createSessionFromDid when spaceName is undefined.

<sup>Written for commit bd3612db09fe2b99e2b913ac12dfc52174cae3e8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

