### PR TITLE
docs: Add charm linking guide

### DIFF
--- a/docs/common/CHARM_LINKING.md
+++ b/docs/common/CHARM_LINKING.md
@@ -117,8 +117,10 @@ A consumer charm declares expected linked data using `Default<T, null>` in its I
 ```typescript
 /// <cts-enable />
 import { Default, NAME, pattern, UI, lift } from "commontools";
+// You can import the Stats type from the source charm:
+// import type { Stats } from "./stats-source.tsx";
 
-// Must match the source charm's exposed structure
+// Or define it locally (must match the source charm's structure)
 interface Stats {
   average: number;
   q1: number;
@@ -135,34 +137,23 @@ interface Input {
 }
 ```
 
-### Step 2: Handle Both Linked and Unlinked States
+### Step 2: Use Linked Data in Your Pattern
 
 ```typescript
-// Helper functions handle null gracefully
-const hasData = lift((s: Stats | null) => s !== null);
-const getAverage = lift((s: Stats | null) => s?.average);
 const formatNumber = lift((val: number | undefined) =>
   val !== undefined ? val.toFixed(2) : "—"
 );
 
 export default pattern<Input, Input>(({ name, linkedStats }) => {
-  const dataPresent = hasData(linkedStats);
-
   return {
     [NAME]: "Stats Reader",
     [UI]: (
       <div>
         <h2>Stats Reader</h2>
-
-        {/* Always show something meaningful */}
         <div>
-          <p><strong>Average:</strong> {formatNumber(getAverage(linkedStats))}</p>
+          <p><strong>Average:</strong> {formatNumber(linkedStats?.average)}</p>
           <p><strong>Count:</strong> {linkedStats?.count ?? 0}</p>
         </div>
-
-        <p style={{ fontSize: "12px", color: "#666" }}>
-          Link this charm to a stats source using ct charm link.
-        </p>
       </div>
     ),
     name,
@@ -175,8 +166,6 @@ export default pattern<Input, Input>(({ name, linkedStats }) => {
 
 1. **Use `Default<T, null>` for linked fields** - provides fallback when unlinked
 2. **Interface must match source** - the Stats interface must be identical
-3. **Use `lift()` for null-safe access** - `lift((s) => s?.field)` handles null gracefully
-4. **Show helpful UI when unlinked** - guide users on how to link
 
 ---
 
@@ -416,9 +405,7 @@ echo "Linked! Open: http://localhost:8000/$SPACE"
 
 ### Consumer Charm Checklist
 - [ ] Use `Default<T, null>` for linked input fields
-- [ ] Match the interface structure exactly
-- [ ] Use `lift()` helpers for null-safe access
-- [ ] Handle unlinked state gracefully in UI
+- [ ] Match the interface structure exactly (or import the type from the source)
 
 ### CLI Commands
 ```bash


### PR DESCRIPTION
## Summary
- Add comprehensive documentation for charm linking in CommonTools patterns
- Covers source charms (data providers), consumer charms (data receivers), and the linking workflow
- Includes complete working examples with deployment scripts

## Contents
The guide covers:
1. **Source Charm Creation** - How to expose data with Output interfaces
2. **Consumer Charm Creation** - How to receive linked data with `Default<T, null>`
3. **Deployment & Linking** - CLI commands for `ct charm new` and `ct charm link`
4. **Complete Example** - Full GPA stats source/reader pattern pair
5. **Quick Reference** - Checklists and common type patterns

## Test plan
- [ ] Review documentation for accuracy
- [ ] Verify code examples compile correctly
- [ ] Check that CLI command syntax is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Charm Linking Guide to the docs with step-by-step instructions and examples for linking source and consumer charms in CommonTools. Includes Output/Input interface patterns, reactive linking, CLI commands (ct charm new/link), a full GPA stats example with a deployment script, and quick-reference checklists.

<sup>Written for commit e4e2709d2f575f742f1bd13fcd51a8f01c284f57. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







