### PR TITLE
fix: Add cycle detection to vdom renderer to prevent infinite loops

### DIFF
--- a/packages/html/src/jsx.ts
+++ b/packages/html/src/jsx.ts
@@ -9,6 +9,11 @@ export { type VNode };
  * @returns True if the value is a VNode
  */
 export const isVNode = (value: unknown): value is VNode => {
-  while (isObject(value) && UI in value) value = value[UI];
+  const visited = new Set<object>();
+  while (isObject(value) && UI in value) {
+    if (visited.has(value)) return false; // Cycle detected
+    visited.add(value);
+    value = value[UI];
+  }
   return (value as VNode)?.type === "vnode";
 };


### PR DESCRIPTION
## Summary

- Adds cycle detection to the vdom renderer to prevent infinite loops when cells form cyclic graphs (child references parent)
- When a cycle is detected, renders a 🔄 placeholder and logs a warning
- The same cell/node can still appear in different places in the UI (siblings), just not as parent-child

## Changes

- packages/html/src/jsx.ts: Fixed isVNode to detect cycles when following [UI] chains
- packages/html/src/render.ts: Added cycle detection in renderNode, renderChild, and updateChildren
- packages/html/test/render.test.ts: Added 6 tests for cycle detection

## Test plan

- [x] Existing render tests pass
- [x] New cycle detection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cycle detection to the VDOM renderer to stop infinite render loops caused by cyclic graphs (e.g., child referencing parent). When a cycle is found, the renderer shows a 🔄 placeholder and logs a warning; the same node can still appear as siblings.

- **Bug Fixes**
  - Detect cycles in [UI] chains in isVNode and skip rendering.
  - Track visited nodes in renderNode to catch child→parent cycles; render a 🔄 <span title="Circular reference detected">.
  - Guard bindChildren/effect against cell graph cycles using cell.equals(); render placeholder instead of looping.
  - Make child keying robust: fall back when JSON.stringify fails on circular structures.
  - Add tests covering self/indirect [UI] cycles, parent/child and deep cycles, sibling reuse, valid [UI] chains, and equal Cell wrappers.

<sup>Written for commit f467cb25f36c5418e090c020256f990bcd74943b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







