### PR TITLE
chore: Use newline when restoring the manifest during build.

### DIFF
--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -331,7 +331,10 @@ async function prepareWorkspace(
   // Remove `compilerOptions.types`
   const manifest = config.manifest();
   delete manifest.compilerOptions.types;
-  await Deno.writeTextFile(denoJsonPath, JSON.stringify(manifest, null, 2));
+  await Deno.writeTextFile(
+    denoJsonPath,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
   // Add a COMPILED file to toolshed. This could
   // contain buildargs/metadata in the future.
   await Deno.writeTextFile(config.toolshedEnvPath(), "");
@@ -354,7 +357,7 @@ async function revertWorkspace(config: BuildConfig): Promise<void> {
   // Restore the workspace manifest
   await Deno.writeTextFile(
     denoJsonPath,
-    JSON.stringify(config.manifest(), null, 2),
+    `${JSON.stringify(config.manifest(), null, 2)}\n`,
   );
 
   // Remove the COMPILED env file


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Write the manifest (deno.json) with a trailing newline during build and restore. This matches repo formatting and prevents noisy diffs and editor/lint warnings.

<sup>Written for commit 0bf5ec79c4381a8c4e0c2fef593d823dc198cec7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



