### PR TITLE
Fix wish() object syntax not working after compilation (CT-1084)

### DIFF
--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -158,8 +158,19 @@ export function wish<T = unknown>(
     type: "ref",
     implementation: "wish",
     argumentSchema: {
-      type: "string",
-      default: "",
+      anyOf: [{
+        type: "string",
+        default: "",
+      }, {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          path: { type: "array", items: { type: "string" } },
+          schema: { type: "object" },
+          context: { type: "object", additionalProperties: { asCell: true } },
+          scope: { type: "array", items: { type: "string" } },
+        },
+      }],
     } as const satisfies JSONSchema,
     resultSchema,
   })(param);


### PR DESCRIPTION
## Summary

- The `argumentSchema` in `built-in.ts` only accepted strings, causing object parameters like `{ query: "#favorites" }` to be coerced to `"{}"` during the compilation pipeline
- Updated `argumentSchema` to use `anyOf` with both string and object schemas, matching the `TARGET_SCHEMA` in `wish.ts` that the builtin implementation uses
- Added two compilation-level tests that verify object syntax works through the full `compileRecipe -> loadRecipe -> run` pipeline

## Root Cause

In `packages/runner/src/builder/built-in.ts`, the wish function's `argumentSchema` was:

```typescript
argumentSchema: {
  type: "string",
  default: "",
}
```

This caused the framework to coerce object inputs to strings before reaching the wish builtin. Meanwhile, `wish.ts` had the correct schema:

```typescript
const TARGET_SCHEMA = {
  anyOf: [{
    type: "string",
    default: "",
  }, {
    type: "object",
    properties: {
      query: { type: "string" },
      path: { type: "array", items: { type: "string" } },
      context: { type: "object", additionalProperties: { asCell: true } },
      scope: { type: "array", items: { type: "string" } },
    },
  }],
}
```

## Why Tests Passed But Deployment Failed

The existing unit tests in `wish.test.ts` call `runtime.run()` directly, which doesn't go through the full compilation pipeline. The tests worked because they bypassed the `argumentSchema` coercion that happens during pattern compilation.

The new tests use `compileRecipe()` → `loadRecipe()` → `run()` to exercise the full pipeline.

## Test plan

- [x] All existing wish tests pass (19 tests)
- [x] Added 2 new compilation pipeline tests that verify object syntax works through compilation
- [x] TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wish() object syntax failing after compilation by updating the built-in argumentSchema to accept objects as well as strings. Addresses CT-1084 so compiled patterns can use wish({ query, path, ... }) end to end.

- **Bug Fixes**
  - Changed argumentSchema to anyOf string | object (query, path, schema, context, scope) to match TARGET_SCHEMA.
  - Prevents object args from being coerced to "{}" during compileRecipe → loadRecipe → run.
  - Added two compilation pipeline tests for object syntax and path selection.

<sup>Written for commit b8e810daa3db566022728d85182033e9938c72aa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

