### PR TITLE
feat(runner): Add sample() method to Cell for non-reactive reads

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -76,6 +76,12 @@ export interface IAnyCell<T> {
  */
 export interface IReadable<T> {
   get(): Readonly<T>;
+  /**
+   * Read the cell's current value without creating a reactive dependency.
+   * Unlike `get()`, calling `sample()` inside a lift won't cause the lift
+   * to re-run when this cell's value changes.
+   */
+  sample(): Readonly<T>;
 }
 
 /**

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -921,3 +921,6 @@ export interface IAttestation {
   readonly address: IMemoryAddress;
   readonly value?: JSONValue;
 }
+
+// Re-export NonReactiveTransaction from implementation
+export { NonReactiveTransaction } from "./extended-storage-transaction.ts";


### PR DESCRIPTION
## Summary

- Adds a new `sample()` method to Cell that reads the current value without creating a reactive dependency
- Unlike `get()`, calling `sample()` inside a handler or lift won't cause it to re-run when the sampled cell changes
- Implemented using a `NonReactiveTransaction` wrapper that adds `ignoreReadForScheduling` meta to all reads
- Child cells created during the sample operation still behave normally with reactive reads

## Test plan

- [x] Added test in `recipes.test.ts` that verifies:
  - Initial lift runs and produces correct result
  - Updating a cell read with `sample()` does NOT trigger re-run
  - Updating a cell read reactively DOES trigger re-run and picks up latest sampled value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds sample() to Cell for non-reactive reads, so lifts/handlers don’t re-run when sampled values change. Implemented with a NonReactiveTransaction; child cells created during sampling stay reactive.

- **New Features**
  - New Cell.sample() API on IReadable for non-reactive reads.
  - NonReactiveTransaction marks reads with ignoreReadForScheduling; getTransactionForChildCells keeps child cells reactive.
  - Tests verify sample() doesn’t trigger re-runs, while reactive inputs still do.

<sup>Written for commit db8f21af1d7b330d510d7406c8178ce1c62a4520. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

