### PR TITLE
refactor(runner): Use single TransactionWrapper class and optimize Cell.sink()

### DIFF
--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -922,5 +922,9 @@ export interface IAttestation {
   readonly value?: JSONValue;
 }
 
-// Re-export NonReactiveTransaction from implementation
-export { NonReactiveTransaction } from "./extended-storage-transaction.ts";
+// Re-export transaction wrapper utilities from implementation
+export {
+  createChildCellTransaction,
+  createNonReactiveTransaction,
+  TransactionWrapper,
+} from "./extended-storage-transaction.ts";


### PR DESCRIPTION
## Summary

- Refactors transaction wrappers to use a single configurable `TransactionWrapper` class instead of multiple wrapper classes
- Uses `TransactionWrapper` to optimize `Cell.sink()` by removing the duplicate `validateAndTransform` call
- Previously sink called `validateAndTransform` twice: once to capture dependencies, once with a fresh tx for child cells
- Now we wrap the transaction to capture dependencies while child cells use a separate transaction via `getTransactionForChildCells()`

## Test plan

- [x] All existing tests pass
- [x] `sample()` test verifies non-reactive reads still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored transaction wrappers into a single configurable TransactionWrapper and removed the extra validateAndTransform in Cell.sink() to reduce duplicate work and dependency capture.

- **Refactors**
  - Introduced TransactionWrapper with options: nonReactive and childCellTx.
  - Added helpers: createNonReactiveTransaction (for sample) and createChildCellTransaction (for sink).
  - Updated getTransactionForChildCells to support wrapped transactions.
  - Replaced NonReactiveTransaction exports with wrapper utilities.

- **Performance**
  - Cell.sink() now runs validateAndTransform once using a wrapper: dependencies are captured on the parent tx while child cells use a separate tx.
  - Fewer reads and less scheduling overhead during subscriptions.

<sup>Written for commit 9a2558d7f2906962f6166f99f217b8eda3e6657f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

