### PR TITLE
chore: Refactor shell's view to use same flow for home and default charms

### DIFF
--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -284,6 +284,22 @@ export class CharmManager {
   }
 
   /**
+   * Get the default pattern cell from the space cell.
+   * @returns The default pattern cell, or undefined if not set
+   */
+  async getDefaultPattern(): Promise<Cell<NameSchema> | undefined> {
+    const cell = await this.spaceCell.key("defaultPattern").sync();
+    if (!cell.get().get()) {
+      return undefined;
+    }
+    return this.get(
+      cell.get(),
+      true,
+      nameSchema,
+    );
+  }
+
+  /**
    * Track a charm as recently viewed/interacted with.
    * Maintains a list of up to 10 most recent charms.
    * @param charm - The charm to track

--- a/packages/charm/src/ops/mod.ts
+++ b/packages/charm/src/ops/mod.ts
@@ -1,4 +1,4 @@
 export { CharmsController } from "./charms-controller.ts";
 export { ACLManager } from "./acl-manager.ts";
-export type { CharmController } from "./charm-controller.ts";
+export { CharmController } from "./charm-controller.ts";
 export * from "./utils.ts";

--- a/packages/patterns/counter.tsx
+++ b/packages/patterns/counter.tsx
@@ -17,7 +17,7 @@ export default recipe<RecipeState, RecipeOutput>((state) => {
     [NAME]: str`Simple counter: ${state.value}`,
     [UI]: (
       <div>
-        <ct-button onClick={decrement(state)}>
+        <ct-button id="counter-decrement" onClick={decrement(state)}>
           dec to {previous(state.value)}
         </ct-button>
         <ct-cell-context $cell={state.value} inline>
@@ -25,7 +25,10 @@ export default recipe<RecipeState, RecipeOutput>((state) => {
             Counter is the {nth(state.value)} number
           </span>
         </ct-cell-context>
-        <ct-button onClick={increment({ value: state.value })}>
+        <ct-button
+          id="counter-increment"
+          onClick={increment({ value: state.value })}
+        >
           inc to {(state.value ?? 0) + 1}
         </ct-button>
       </div>

--- a/packages/shell/integration/charm.test.ts
+++ b/packages/shell/integration/charm.test.ts
@@ -60,7 +60,7 @@ describe("shell charm tests", () => {
     });
 
     let handle = await page.waitForSelector(
-      "ct-button",
+      "#counter-decrement",
       { strategy: "pierce" },
     );
     handle.click();

--- a/packages/shell/integration/iframe-counter-charm.disabled_test.ts
+++ b/packages/shell/integration/iframe-counter-charm.disabled_test.ts
@@ -65,7 +65,7 @@ async function getCharmResult(page: Page): Promise<{ count: number }> {
   // Use the element handle to evaluate in its context
   return await appView.evaluate((element: XAppView) => {
     // Access the private _activeCharm property
-    const activeCharmTask = element._activeCharm;
+    const activeCharmTask = element._activePatterns;
 
     if (!activeCharmTask) {
       throw new Error("No _activeCharm property found on element");
@@ -76,7 +76,7 @@ async function getCharmResult(page: Page): Promise<{ count: number }> {
     }
 
     // Get the charm controller from the Task's value
-    const charmController = activeCharmTask.value;
+    const charmController = activeCharmTask.value.activePattern;
 
     // Get the result from the charm controller
     const result = charmController.result.get();

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -16,7 +16,6 @@ console.log(`ENVIRONMENT=${ENVIRONMENT}`);
 console.log(`API_URL=${API_URL}`);
 console.log(`COMMIT_SHA=${COMMIT_SHA}`);
 
-// Configure LLM client to use the correct API URL
 setLLMUrl(API_URL.toString());
 
 setRecipeEnvironment({ apiUrl: API_URL });

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -7,11 +7,10 @@ import { AppUpdateEvent } from "../lib/app/events.ts";
 import { clone } from "../lib/app/state.ts";
 import { KeyStore } from "@commontools/identity";
 import { property, state } from "lit/decorators.js";
-import { provide } from "@lit/context";
 import { Task } from "@lit/task";
 import { type MemorySpace, Runtime } from "@commontools/runner";
 import { RuntimeInternals } from "../lib/runtime.ts";
-import { runtimeContext, spaceContext } from "@commontools/ui";
+import { urlToAppView } from "../lib/app/view.ts";
 
 // The root element for the shell application.
 // Handles processing `Command`s from children elements,
@@ -42,19 +41,15 @@ export class XRootView extends BaseView {
   // Non-private for typing in `updated()` callback
   _app = {
     apiUrl: API_URL,
-    view: { builtin: "home" },
+    view: urlToAppView(new URL(globalThis.location.href)),
   } as AppState;
 
   @property()
   keyStore?: KeyStore;
 
-  // The runtime instance provided to descendant components via context
-  @provide({ context: runtimeContext })
   @state()
   private runtime?: Runtime;
 
-  // The current space name provided to descendant components via context
-  @provide({ context: spaceContext })
   @state()
   private space?: MemorySpace;
 


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unifies how the shell loads and renders the “home” and space default patterns. AppView now derives both the active and default patterns from the current view and passes them to BodyView, simplifying rendering and removing ad‑hoc default creation.

- **Refactors**
  - CharmManager: added getDefaultPattern to read the default pattern from the space cell.
  - PatternFactory: charms start on create and always link as default; added get and getOrCreate helpers backed by the manager.
  - AppView: replaced _activeCharmId/_activeCharm with _activePatterns; viewToPatterns maps the URL view to active + default patterns and tracks recents.
  - BodyView: now receives activeCharm and defaultCharm; removed default pattern creation UI; uses the default pattern for FAB and sidebar UI.
  - RootView and tests: derive AppView from the URL via urlToAppView; updated integration test to use _activePatterns; exported CharmController from ops.

<sup>Written for commit 215ead56e7cf1495d342ef98d1d8fe563b4b4a92. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





