### PR TITLE
feat: Move favorite charm logic to its own view and discerns between local and remote state

### DIFF
--- a/packages/shell/src/components/FavoriteButton.ts
+++ b/packages/shell/src/components/FavoriteButton.ts
@@ -1,0 +1,127 @@
+import { css, html, LitElement, PropertyValues } from "lit";
+import { property, state } from "lit/decorators.js";
+import { RuntimeInternals } from "../lib/runtime.ts";
+import { Task } from "@lit/task";
+
+export class XFavoriteButtonElement extends LitElement {
+  static override styles = css`
+    x-button.emoji-button {
+      opacity: 0.7;
+      transition: opacity 0.2s;
+      font-size: 1rem;
+    }
+
+    x-button.emoji-button:hover {
+      opacity: 1;
+    }
+
+    x-button.auth-button {
+      font-size: 1rem;
+    }
+  `;
+
+  @property()
+  rt?: RuntimeInternals;
+
+  @property({ attribute: false })
+  charmId?: string;
+
+  // Local state for favoriting, used when
+  // modifying state inbetween server syncs.
+  @state()
+  isFavorite: boolean | undefined = undefined;
+
+  private async handleFavoriteClick(e: Event) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!this.rt || !this.charmId) return;
+    const manager = this.rt.cc().manager();
+
+    const isFavorite = this.deriveIsFavorite();
+
+    // Update local state, and use until overridden by
+    // syncing state, or another click.
+    this.isFavorite = !isFavorite;
+
+    const charmCell = (await this.rt.cc().get(this.charmId, true)).getCell();
+    if (isFavorite) {
+      await manager.removeFavorite(charmCell);
+    } else {
+      await manager.addFavorite(charmCell);
+    }
+
+    this.isFavoriteSync.run();
+  }
+
+  protected override willUpdate(changedProperties: PropertyValues): void {
+    if (changedProperties.has("charmId")) {
+      this.isFavorite = undefined;
+    }
+  }
+
+  private deriveIsFavorite(): boolean {
+    // If `isFavorite` is defined, we have local state that is not
+    // yet synced. Prefer local state if defined, otherwise use server state.
+    return this.isFavorite ?? this.isFavoriteSync.value ?? false;
+  }
+
+  isFavoriteSync = new Task(this, {
+    task: async (
+      [charmId, rt],
+      { signal },
+    ): Promise<boolean> => {
+      const isFavorite = await isFavoriteSync(rt, charmId);
+
+      // If another favorite request was initiated, store
+      // the sync status, but don't overwrite the local state.
+      if (signal.aborted) return isFavorite;
+
+      // We update `this.isFavorite` here to `undefined`,
+      // indicating that the synced state should be preferred
+      // now that it's fresh.
+      this.isFavorite = undefined;
+      return isFavorite;
+    },
+    args: () => [this.charmId, this.rt],
+  });
+
+  override render() {
+    const isFavorite = this.deriveIsFavorite();
+
+    return html`
+      <x-button
+        class="emoji-button"
+        size="small"
+        @click="${this.handleFavoriteClick}"
+        title="${isFavorite ? "Remove from Favorites" : "Add to Favorites"}"
+      >
+        ${isFavorite ? "⭐" : "☆"}
+      </x-button>
+    `;
+  }
+}
+
+globalThis.customElements.define("x-favorite-button", XFavoriteButtonElement);
+
+async function isFavoriteSync(
+  rt?: RuntimeInternals,
+  charmId?: string,
+): Promise<boolean> {
+  if (!charmId || !rt) {
+    return false;
+  }
+  const manager = rt.cc().manager();
+  try {
+    const charm = await manager.get(charmId, true);
+    if (charm) {
+      const favorites = manager.getFavorites();
+      await favorites.sync();
+      return manager.isFavorite(charm);
+    } else {
+      return false;
+    }
+  } catch (_) {
+    //
+  }
+  return false;
+}

--- a/packages/shell/src/components/index.ts
+++ b/packages/shell/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from "./Button.ts";
 export * from "./CharmLink.ts";
 export * from "./CTLogo.ts";
+export * from "./FavoriteButton.ts";
 export * from "./Flex.ts";
 export * from "./Spinner.ts";

--- a/packages/shell/src/lib/app/commands.ts
+++ b/packages/shell/src/lib/app/commands.ts
@@ -5,8 +5,7 @@ import { AppStateConfigKey } from "./state.ts";
 export type Command =
   | { type: "set-view"; view: AppView }
   | { type: "set-identity"; identity: Identity | undefined }
-  | { type: "set-config"; key: AppStateConfigKey; value: boolean }
-  | { type: "toggle-favorite"; charmId: string };
+  | { type: "set-config"; key: AppStateConfigKey; value: boolean };
 
 export function isCommand(value: unknown): value is Command {
   if (
@@ -26,9 +25,6 @@ export function isCommand(value: unknown): value is Command {
     case "set-config": {
       return "key" in value && typeof value.key === "string" &&
         "value" in value && typeof value.value === "boolean";
-    }
-    case "toggle-favorite": {
-      return "charmId" in value && typeof value.charmId === "string";
     }
   }
   return false;

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -152,11 +152,11 @@ export class XRootView extends BaseView {
     if (!isCommand(command)) {
       throw new Error(`Received a non-command: ${command}`);
     }
-    this.processCommand(command).catch(console.error);
+    this.processCommand(command);
   };
 
-  async apply(command: Command): Promise<void> {
-    await this.processCommand(command);
+  apply(command: Command): Promise<void> {
+    this.processCommand(command);
     this.requestUpdate();
     return this.updateComplete.then((_) => undefined);
   }
@@ -165,34 +165,8 @@ export class XRootView extends BaseView {
     return clone(this.app);
   }
 
-  private async processCommand(command: Command) {
+  private processCommand(command: Command) {
     try {
-      // Handle async commands that don't affect state
-      if (command.type === "toggle-favorite") {
-        const rt = this._rt.value;
-        if (!rt) return;
-
-        const manager = rt.cc().manager();
-        const charm = await rt.cc().get(command.charmId, true);
-        const isFavorite = manager.isFavorite(charm.getCell());
-
-        if (isFavorite) {
-          await manager.removeFavorite(charm.getCell());
-        } else {
-          await manager.addFavorite(charm.getCell());
-        }
-
-        // Trigger HeaderView to update its favorite state
-        this.dispatchEvent(
-          new CustomEvent("favorite-changed", {
-            detail: { charmId: command.charmId, isFavorite: !isFavorite },
-            bubbles: true,
-            composed: true,
-          }),
-        );
-        return;
-      }
-
       // Apply command synchronously for state changes
       const state = applyCommand(this.app, command);
       this.app = state;


### PR DESCRIPTION


















<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved favorite charm handling into a dedicated FavoriteButton component with optimistic local state and server sync. Simplifies the header and removes the toggle-favorite command from the command pipeline.

- **New Features**
  - Added x-favorite-button that toggles favorites instantly, then syncs with the server; prefers local state until sync completes.
  - Star icon with tooltip; exported via components index.

- **Refactors**
  - HeaderView now uses x-favorite-button and removes custom favorite listeners/state; small button-group style tweak.
  - Removed toggle-favorite command from RootView; processCommand is synchronous with try/catch.

<sup>Written for commit 327837681086f39a0b7e1373c0538d739c1b1199. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

















