### PR TITLE
chore: Reorganize controller usage in AppView

### DIFF
--- a/packages/shell/src/lib/app/commands.ts
+++ b/packages/shell/src/lib/app/commands.ts
@@ -1,14 +1,11 @@
 import { Identity } from "@commontools/identity";
 import { AppView, isAppView } from "./view.ts";
+import { AppStateConfigKey } from "./state.ts";
 
 export type Command =
   | { type: "set-view"; view: AppView }
-  | { type: "set-identity"; identity: Identity }
-  | { type: "clear-authentication" }
-  | { type: "set-show-charm-list-view"; show: boolean }
-  | { type: "set-show-debugger-view"; show: boolean }
-  | { type: "set-show-quick-jump-view"; show: boolean }
-  | { type: "set-show-sidebar"; show: boolean }
+  | { type: "set-identity"; identity: Identity | undefined }
+  | { type: "set-config"; key: AppStateConfigKey; value: boolean }
   | { type: "toggle-favorite"; charmId: string };
 
 export function isCommand(value: unknown): value is Command {
@@ -20,25 +17,15 @@ export function isCommand(value: unknown): value is Command {
   }
   switch (value.type) {
     case "set-identity": {
-      return "identity" in value && value.identity instanceof Identity;
+      return "identity" in value &&
+        (value.identity === undefined || value.identity instanceof Identity);
     }
     case "set-view": {
       return "view" in value && isAppView(value.view);
     }
-    case "clear-authentication": {
-      return true;
-    }
-    case "set-show-charm-list-view": {
-      return "show" in value && typeof value.show === "boolean";
-    }
-    case "set-show-debugger-view": {
-      return "show" in value && typeof value.show === "boolean";
-    }
-    case "set-show-quick-jump-view": {
-      return "show" in value && typeof value.show === "boolean";
-    }
-    case "set-show-sidebar": {
-      return "show" in value && typeof value.show === "boolean";
+    case "set-config": {
+      return "key" in value && typeof value.key === "string" &&
+        "value" in value && typeof value.value === "boolean";
     }
     case "toggle-favorite": {
       return "charmId" in value && typeof value.charmId === "string";

--- a/packages/shell/src/lib/app/state.ts
+++ b/packages/shell/src/lib/app/state.ts
@@ -12,16 +12,30 @@ export interface AppState {
   identity?: Identity;
   view: AppView;
   apiUrl: URL;
+  config: AppStateConfig;
+}
+
+export interface AppStateConfig {
   showShellCharmListView?: boolean;
   showDebuggerView?: boolean;
   showQuickJumpView?: boolean;
   showSidebar?: boolean;
 }
 
+export type AppStateConfigKey = keyof AppStateConfig;
+
 export type AppStateSerialized = Omit<AppState, "identity" | "apiUrl"> & {
   identity?: TransferrableInsecureCryptoKeyPair | null;
   apiUrl: string;
 };
+
+export function createAppState(
+  initial: Pick<AppState, "view" | "apiUrl" | "identity"> & {
+    config?: AppStateConfig;
+  },
+): AppState {
+  return Object.assign({}, initial, { config: initial.config ?? {} });
+}
 
 export function clone(state: AppState): AppState {
   const view = typeof state.view === "object"
@@ -45,28 +59,12 @@ export function applyCommand(
     case "set-view": {
       next.view = command.view;
       if ("charmId" in command.view && command.view.charmId) {
-        next.showShellCharmListView = false;
+        next.config.showShellCharmListView = false;
       }
       break;
     }
-    case "clear-authentication": {
-      next.identity = undefined;
-      break;
-    }
-    case "set-show-charm-list-view": {
-      next.showShellCharmListView = command.show;
-      break;
-    }
-    case "set-show-debugger-view": {
-      next.showDebuggerView = command.show;
-      break;
-    }
-    case "set-show-quick-jump-view": {
-      next.showQuickJumpView = command.show;
-      break;
-    }
-    case "set-show-sidebar": {
-      next.showSidebar = command.show;
+    case "set-config": {
+      next.config[command.key] = command.value;
       break;
     }
   }

--- a/packages/shell/src/views/BaseView.ts
+++ b/packages/shell/src/views/BaseView.ts
@@ -1,6 +1,8 @@
 import { LitElement } from "lit";
 import { Command } from "../lib/app/commands.ts";
 import { DebugController } from "@commontools/ui";
+import { createAppState, urlToAppView } from "../lib/app/mod.ts";
+import { API_URL } from "../lib/env.ts";
 
 // Set to `true` to render outlines everytime a
 // LitElement renders.
@@ -19,4 +21,11 @@ export class BaseView extends LitElement {
       }),
     );
   }
+}
+
+export function createDefaultAppState() {
+  return createAppState({
+    apiUrl: API_URL,
+    view: urlToAppView(new URL(globalThis.location.href)),
+  });
 }

--- a/packages/shell/src/views/CharmListView.ts
+++ b/packages/shell/src/views/CharmListView.ts
@@ -3,7 +3,6 @@ import { property } from "lit/decorators.js";
 import { BaseView } from "./BaseView.ts";
 import { RuntimeInternals } from "../lib/runtime.ts";
 import { CharmController } from "@commontools/charm/ops";
-import "./ACLView.ts";
 
 export class XCharmListView extends BaseView {
   static override styles = css`

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -122,15 +122,16 @@ export class XHeaderView extends BaseView {
     } else {
       this.keyStore.clear().catch(console.error);
     }
-    this.command({ type: "clear-authentication" });
+    this.command({ type: "set-identity", identity: undefined });
   }
 
   private handleToggleClick(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     this.command({
-      type: "set-show-charm-list-view",
-      show: !this.showShellCharmListView,
+      type: "set-config",
+      key: "showShellCharmListView",
+      value: !this.showShellCharmListView,
     });
   }
 
@@ -138,8 +139,9 @@ export class XHeaderView extends BaseView {
     e.preventDefault();
     e.stopPropagation();
     this.command({
-      type: "set-show-debugger-view",
-      show: !this.showDebuggerView,
+      type: "set-config",
+      key: "showDebuggerView",
+      value: !this.showDebuggerView,
     });
   }
 
@@ -147,8 +149,9 @@ export class XHeaderView extends BaseView {
     e.preventDefault();
     e.stopPropagation();
     this.command({
-      type: "set-show-sidebar",
-      show: !this.showSidebar,
+      type: "set-config",
+      key: "showSidebar",
+      value: !this.showSidebar,
     });
   }
 

--- a/packages/shell/src/views/QuickJumpView.ts
+++ b/packages/shell/src/views/QuickJumpView.ts
@@ -200,7 +200,11 @@ export class XQuickJumpView extends BaseView {
   private close() {
     this.query = "";
     this.selectedIndex = 0;
-    this.command({ type: "set-show-quick-jump-view", show: false });
+    this.command({
+      type: "set-config",
+      key: "showQuickJumpView",
+      value: false,
+    });
   }
 
   private getItems(): CharmItem[] {

--- a/packages/shell/test/app-state.test.ts
+++ b/packages/shell/test/app-state.test.ts
@@ -19,6 +19,7 @@ describe("AppState", () => {
       view: {
         spaceName: SPACE_NAME,
       },
+      config: {},
     };
 
     let serialized = serialize(state);
@@ -59,6 +60,7 @@ describe("AppState", () => {
     const serialized: AppStateSerialized = {
       apiUrl: API_URL,
       view: { spaceName: SPACE_NAME },
+      config: {},
     };
 
     let state = await deserialize(serialized);
@@ -77,7 +79,9 @@ describe("AppState", () => {
     const initial: AppState = {
       apiUrl: new URL(API_URL),
       view: { builtin: "home" },
-      showShellCharmListView: true,
+      config: {
+        showShellCharmListView: true,
+      },
     };
 
     const next = applyCommand(initial, {
@@ -88,6 +92,6 @@ describe("AppState", () => {
       },
     });
 
-    assert(next.showShellCharmListView === false);
+    assert(next.config.showShellCharmListView === false);
   });
 });


### PR DESCRIPTION
* Moved cell watching, telemetry into DebuggerController from AppView
* Moved keyboard listeners into KeyboardController, now a ReactiveController, from AppView
* `AppState` now non-optional for AppView
* `AppState` configurations now `app.config`
* Single command for setting app configurations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorganized AppView to use dedicated controllers for telemetry and keyboard shortcuts, and consolidated UI flags under app.config with a single set-config command. This simplifies state management and improves cleanup and stability.

- **Refactors**
  - Moved cell watching and telemetry into DebuggerController; AppView no longer handles these events.
  - Added KeyboardController as a ReactiveController; global shortcuts registered and cleaned up via the controller.
  - AppState now required in AppView; UI flags moved to app.config.
  - Replaced set-show-* and clear-authentication with set-config and set-identity (can be undefined).

- **Migration**
  - Use command { type: "set-config", key, value } for UI toggles.
  - Read flags from app.config.* instead of app.show*.
  - Clear auth with { type: "set-identity", identity: undefined }.
  - Initialize AppState when creating AppView (use createDefaultAppState if needed).

<sup>Written for commit 6d033f6d70bb4fc33372b370d8d406f20536c09e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

