### PR TITLE
chore: Follow up changes to shell.

### DIFF
--- a/packages/shell/src/components/FavoriteButton.ts
+++ b/packages/shell/src/components/FavoriteButton.ts
@@ -43,14 +43,16 @@ export class XFavoriteButtonElement extends LitElement {
     // syncing state, or another click.
     this.isFavorite = !isFavorite;
 
-    const charmCell = (await this.rt.cc().get(this.charmId, true)).getCell();
-    if (isFavorite) {
-      await manager.removeFavorite(charmCell);
-    } else {
-      await manager.addFavorite(charmCell);
+    try {
+      const charmCell = (await this.rt.cc().get(this.charmId, true)).getCell();
+      if (isFavorite) {
+        await manager.removeFavorite(charmCell);
+      } else {
+        await manager.addFavorite(charmCell);
+      }
+    } finally {
+      this.isFavoriteSync.run();
     }
-
-    this.isFavoriteSync.run();
   }
 
   protected override willUpdate(changedProperties: PropertyValues): void {

--- a/packages/shell/src/lib/app/commands.ts
+++ b/packages/shell/src/lib/app/commands.ts
@@ -1,6 +1,6 @@
 import { Identity } from "@commontools/identity";
 import { AppView, isAppView } from "./view.ts";
-import { AppStateConfigKey } from "./state.ts";
+import { AppStateConfigKey, isAppStateConfigKey } from "./state.ts";
 
 export type Command =
   | { type: "set-view"; view: AppView }
@@ -23,7 +23,7 @@ export function isCommand(value: unknown): value is Command {
       return "view" in value && isAppView(value.view);
     }
     case "set-config": {
-      return "key" in value && typeof value.key === "string" &&
+      return "key" in value && isAppStateConfigKey(value.key) &&
         "value" in value && typeof value.value === "boolean";
     }
   }

--- a/packages/shell/src/lib/app/state.ts
+++ b/packages/shell/src/lib/app/state.ts
@@ -29,6 +29,20 @@ export type AppStateSerialized = Omit<AppState, "identity" | "apiUrl"> & {
   apiUrl: string;
 };
 
+export function isAppStateConfigKey(
+  value: unknown,
+): value is AppStateConfigKey {
+  if (typeof value !== "string") return false;
+  switch (value) {
+    case "showShellCharmListView":
+    case "showDebuggerView":
+    case "showQuickJumpView":
+    case "showSidebar":
+      return true;
+  }
+  return false;
+}
+
 export function createAppState(
   initial: Pick<AppState, "view" | "apiUrl" | "identity"> & {
     config?: AppStateConfig;
@@ -38,12 +52,12 @@ export function createAppState(
 }
 
 export function clone(state: AppState): AppState {
-  const view = typeof state.view === "object"
-    ? Object.assign({}, state.view)
-    : state.view;
-  const cloned = Object.assign({}, state);
-  cloned.view = view;
-  return cloned;
+  return Object.assign({}, state, {
+    config: Object.assign({}, state.config),
+    view: typeof state.view === "object"
+      ? Object.assign({}, state.view)
+      : state.view,
+  });
 }
 
 export function applyCommand(
@@ -64,6 +78,9 @@ export function applyCommand(
       break;
     }
     case "set-config": {
+      if (!isAppStateConfigKey(command.key)) {
+        throw new Error(`Invalid config key: ${command.key}`);
+      }
       next.config[command.key] = command.value;
       break;
     }


### PR DESCRIPTION
* Ensure config values stored are legal keys.
* Clone app config in `clone()`
* Ensure XFavoriteButton resets the remote favorite task in the event of an error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened shell state safety and made the Favorite button more robust by validating config keys, cloning app config, and always resetting sync after remote operations. This prevents invalid config writes and stale UI states.

- **Bug Fixes**
  - Validate config keys via isAppStateConfigKey; reject unknown keys.
  - Clone config in clone() to avoid shared references.
  - FavoriteButton: use try/finally to always run isFavoriteSync after add/remove, even on errors.

<sup>Written for commit 2d652edc400344dba45844623c1c63d761ab3401. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

