### PR TITLE
chore: shell: Separate the derivation of active pattern and space root pattern, syncing state

### DIFF
--- a/packages/charm/src/ops/charms-controller.ts
+++ b/packages/charm/src/ops/charms-controller.ts
@@ -29,14 +29,14 @@ export class CharmsController<T = unknown> {
     return this.#manager;
   }
 
-  async create(
+  async create<U = T>(
     program: RuntimeProgram | string,
     options: CreateCharmOptions = {},
     cause: string | undefined = undefined,
-  ): Promise<CharmController<T>> {
+  ): Promise<CharmController<U>> {
     this.disposeCheck();
     const recipe = await compileProgram(this.#manager, program);
-    const charm = await this.#manager.runPersistent<T>(
+    const charm = await this.#manager.runPersistent<U>(
       recipe,
       options.input,
       cause,
@@ -45,7 +45,7 @@ export class CharmsController<T = unknown> {
     );
     await this.#manager.runtime.idle();
     await this.#manager.synced();
-    return new CharmController<T>(this.#manager, charm);
+    return new CharmController<U>(this.#manager, charm);
   }
 
   async get<S extends JSONSchema = JSONSchema>(

--- a/packages/patterns/integration/ct-checkbox.test.ts
+++ b/packages/patterns/integration/ct-checkbox.test.ts
@@ -1,9 +1,7 @@
-import { env } from "@commontools/integration";
-import { sleep } from "@commontools/utils/sleep";
+import { env, waitFor } from "@commontools/integration";
 import { ShellIntegration } from "@commontools/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
-import { assertEquals } from "@std/assert";
 import { Identity } from "@commontools/identity";
 import { CharmsController } from "@commontools/charm/ops";
 import { ANYONE_USER } from "@commontools/memory/acl";
@@ -67,49 +65,62 @@ testComponents.forEach(({ name, file }) => {
     it("should show disabled content initially", async () => {
       const page = shell.page();
 
-      const featureStatus = await page.waitForSelector("#feature-status", {
-        strategy: "pierce",
+      await waitFor(async () => {
+        const featureStatus = await page.waitForSelector("#feature-status", {
+          strategy: "pierce",
+        });
+        const statusText = await featureStatus.evaluate((el: HTMLElement) =>
+          el.textContent
+        );
+        return statusText?.trim() === "⚠ Feature is disabled";
       });
-      const statusText = await featureStatus.evaluate((el: HTMLElement) =>
-        el.textContent
-      );
-      assertEquals(statusText?.trim(), "⚠ Feature is disabled");
     });
 
     it("should toggle to enabled content when checkbox is clicked", async () => {
       const page = shell.page();
 
-      const checkbox = await page.waitForSelector("ct-checkbox", {
-        strategy: "pierce",
+      await waitFor(async () => {
+        const checkbox = await page.waitForSelector("ct-checkbox", {
+          strategy: "pierce",
+        });
+        // This could throw due to lacking a box model to click on.
+        // Catch in lieu of handling time sensitivity.
+        try {
+          await checkbox.click();
+        } catch (_) {
+          return false;
+        }
+        const featureStatus = await page.waitForSelector("#feature-status", {
+          strategy: "pierce",
+        });
+        const statusText = await featureStatus.evaluate((el: HTMLElement) =>
+          el.textContent
+        );
+        return statusText?.trim() === "✓ Feature is enabled!";
       });
-      await checkbox.click();
-      await sleep(500);
-
-      const featureStatus = await page.$("#feature-status", {
-        strategy: "pierce",
-      });
-      const statusText = await featureStatus?.evaluate((el: HTMLElement) =>
-        el.textContent
-      );
-      assertEquals(statusText?.trim(), "✓ Feature is enabled!");
     });
 
     it("should toggle back to disabled content when checkbox is clicked again", async () => {
       const page = shell.page();
-
-      const checkbox = await page.$("ct-checkbox", {
-        strategy: "pierce",
+      await waitFor(async () => {
+        const checkbox = await page.waitForSelector("ct-checkbox", {
+          strategy: "pierce",
+        });
+        // This could throw due to lacking a box model to click on.
+        // Catch in lieu of handling time sensitivity.
+        try {
+          await checkbox.click();
+        } catch (_) {
+          return false;
+        }
+        const featureStatus = await page.waitForSelector("#feature-status", {
+          strategy: "pierce",
+        });
+        const statusText = await featureStatus.evaluate((el: HTMLElement) =>
+          el.textContent
+        );
+        return statusText?.trim() === "⚠ Feature is disabled";
       });
-      await checkbox?.click();
-      await sleep(1000);
-
-      const featureStatus = await page.$("#feature-status", {
-        strategy: "pierce",
-      });
-      const statusText = await featureStatus?.evaluate((el: HTMLElement) =>
-        el.textContent
-      );
-      assertEquals(statusText?.trim(), "⚠ Feature is disabled");
     });
   });
 });

--- a/packages/patterns/integration/ct-list.test.ts
+++ b/packages/patterns/integration/ct-list.test.ts
@@ -1,11 +1,11 @@
-import { env } from "@commontools/integration";
-import { sleep } from "@commontools/utils/sleep";
+import { env, Page, waitFor } from "@commontools/integration";
 import { ShellIntegration } from "@commontools/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commontools/identity";
 import { CharmsController } from "@commontools/charm/ops";
+import { ElementHandle } from "@astral/astral";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
@@ -56,102 +56,30 @@ describe("ct-list integration test", () => {
 
   it("should add items to the list", async () => {
     const page = shell.page();
+    const list = new List(page);
 
-    // Find the add item input in ct-list
-    const addInput = await page.waitForSelector(".add-item-input", {
-      strategy: "pierce",
-    });
+    await list.addItem("First item");
+    await list.waitForItemCount(1);
 
-    // Add first item
-    await addInput.click();
-    await addInput.type("First item");
-    await page.keyboard.press("Enter");
-    await sleep(50); // Quick wait for DOM update
+    await list.addItem("Second item");
+    await list.waitForItemCount(2);
 
-    // Add second item - the input should be cleared automatically
-    await addInput.type("Second item");
-    await page.keyboard.press("Enter");
-    await sleep(50); // Quick wait for DOM update
+    await list.addItem("Third item");
+    await list.waitForItemCount(3);
 
-    // Add third item
-    await addInput.type("Third item");
-    await page.keyboard.press("Enter");
-    await sleep(50); // Quick wait for DOM update
-
-    // Verify items were added
-    const listItems = await page.$$(".list-item", { strategy: "pierce" });
-    assertEquals(listItems.length, 3, "Should have 3 items in the list");
-
-    // Debug: Log the structure of list items
-    console.log("List item structure:");
-    for (let i = 0; i < listItems.length; i++) {
-      const itemInfo = await listItems[i].evaluate(
-        (el: HTMLElement, idx: number) => {
-          const buttons = el.querySelectorAll("button");
-          return {
-            index: idx,
-            className: el.className,
-            innerText: el.innerText,
-            buttonCount: buttons.length,
-            buttons: Array.from(buttons).map((b) => ({
-              className: b.className,
-              title: b.title || "no title",
-              innerText: b.innerText,
-            })),
-          };
-        },
-        { args: [i] } as any,
-      );
-      console.log(`Item ${i}:`, itemInfo);
-    }
-
-    // Quick wait for content to render
-    await sleep(100);
-
-    // Verify item content
-    const firstItemText = await listItems[0].evaluate((el: HTMLElement) => {
-      const content = el.querySelector(".item-content") ||
-        el.querySelector("div.item-content");
-      return content?.textContent || el.textContent;
-    });
-    assertEquals(firstItemText?.trim(), "First item");
-
-    const secondItemText = await listItems[1].evaluate((el: HTMLElement) => {
-      const content = el.querySelector(".item-content") ||
-        el.querySelector("div.item-content");
-      return content?.textContent || el.textContent;
-    });
-    assertEquals(secondItemText?.trim(), "Second item");
-
-    const thirdItemText = await listItems[2].evaluate((el: HTMLElement) => {
-      const content = el.querySelector(".item-content") ||
-        el.querySelector("div.item-content");
-      return content?.textContent || el.textContent;
-    });
-    assertEquals(thirdItemText?.trim(), "Third item");
+    assertEquals(await list.getItemsText(), [
+      "First item",
+      "Second item",
+      "Third item",
+    ]);
   });
 
   it("should update the list title", async () => {
     const page = shell.page();
+    const list = new List(page);
 
-    // Find the title input
-    const titleInput = await page.$("input[placeholder='List title']", {
-      strategy: "pierce",
-    });
-    assert(titleInput, "Should find title input");
-
-    // Clear the existing text first
-    await titleInput.click();
-    await titleInput.evaluate((el: HTMLInputElement) => {
-      el.select(); // Select all text
-    });
-    await titleInput.type("My Shopping List");
-
-    // Verify title was updated (no wait needed for input value)
-    const titleValue = await titleInput.evaluate((el: HTMLInputElement) =>
-      el.value
-    );
-    assertEquals(titleValue, "My Shopping List");
+    await list.setTitle("My Shopping List");
+    assertEquals(await list.getTitle(), "My Shopping List");
   });
 
   // TODO(#CT-703): Fix this test - there's a bug where programmatic clicks on the remove button
@@ -160,142 +88,85 @@ describe("ct-list integration test", () => {
   // versus real user clicks.
   it("should remove items from the list", async () => {
     const page = shell.page();
+    const list = new List(page);
 
-    console.log("Waiting for component to stabilize...");
-    await sleep(500);
+    const items = await list.getItems();
+    assert(items.length > 0, "Should have items to remove");
+    const initialCount = items.length;
 
-    // Get initial count
-    const initialItems = await page.$$(".list-item", { strategy: "pierce" });
-    const initialCount = initialItems.length;
-    console.log(`Initial item count: ${initialCount}`);
-    assert(initialCount > 0, "Should have items to remove");
+    await list.removeItem(items[0]);
+    await list.waitForItemCount(initialCount - 1);
 
-    // Find and click the first remove button
-    const removeButtons = await page.$$("button.item-action.remove", {
-      strategy: "pierce",
-    });
-    console.log(`Found ${removeButtons.length} remove buttons`);
-    assert(removeButtons.length > 0, "Should find remove buttons");
-
-    // Debug: check what we're about to click
-    const buttonText = await removeButtons[0].evaluate((el: HTMLElement) => {
-      return {
-        className: el.className,
-        title: el.title,
-        innerText: el.innerText,
-        parentText: el.parentElement?.innerText || "no parent",
-      };
-    });
-    console.log("About to click button:", buttonText);
-
-    // Try clicking more carefully
-    console.log("Waiting before click...");
-    await sleep(100);
-
-    // Alternative approach: dispatch click event
-    await removeButtons[0].evaluate((button: HTMLElement) => {
-      console.log("About to dispatch click event on button:", button);
-      button.dispatchEvent(
-        new MouseEvent("click", {
-          bubbles: true,
-          cancelable: true,
-          view: window,
-        }),
-      );
-    });
-    console.log("Dispatched click event on first remove button");
-
-    // Check immediately after click
-    await sleep(50);
-    const immediateItems = await page.$$(".list-item", { strategy: "pierce" });
-    console.log(
-      `Immediately after click, found ${immediateItems.length} items`,
-    );
-
-    // Wait for DOM to update after removal using Astral's waitForFunction
-    await page.waitForFunction((expectedCount) => {
-      const items = document.querySelectorAll(".list-item");
-      return items.length !== expectedCount;
-    }, { args: [initialCount] });
-
-    // Verify item was removed - try multiple times
-    let remainingItems = await page.$$(".list-item", { strategy: "pierce" });
-    console.log(`After removal, found ${remainingItems.length} items`);
-
-    // If still showing same count, wait a bit more and try again
-    if (remainingItems.length === initialCount) {
-      console.log("DOM not updated yet, waiting more...");
-      await sleep(500);
-      remainingItems = await page.$$(".list-item", { strategy: "pierce" });
-      console.log(
-        `After additional wait, found ${remainingItems.length} items`,
-      );
-    }
-
-    assertEquals(
-      remainingItems.length,
-      initialCount - 1,
-      "Should have one less item after removal",
-    );
-
-    // Verify the first item is now what was the second item
-    if (remainingItems.length > 0) {
-      const firstRemainingText = await remainingItems[0].evaluate(
-        (el: HTMLElement) => {
-          const content = el.querySelector(".item-content") ||
-            el.querySelector("div.item-content");
-          return content?.textContent || el.textContent;
-        },
-      );
-      assertEquals(
-        firstRemainingText?.trim(),
-        "Second item",
-        "First item should now be the second item",
-      );
-    }
+    assertEquals(await list.getItemsText(), [
+      "Second item",
+      "Third item",
+    ]);
   });
 
   it("should edit items in the list", async () => {
     const page = shell.page();
+    const list = new List(page);
 
-    console.log("Waiting for component to stabilize...");
-    await sleep(500);
+    const items = await list.getItems();
+    assert(items.length > 0, "Should have items to edit");
 
-    // Get initial items
-    const initialItems = await page.$$(".list-item", { strategy: "pierce" });
-    const initialCount = initialItems.length;
-    console.log(`Initial item count: ${initialCount}`);
-    assert(initialCount > 0, "Should have items to edit");
+    const newText = "Edited Second Item";
+    await list.editItem(items[0], newText);
+    await waitFor(() =>
+      list.getItems().then((els) => list.getItemText(els[0])).then((text) =>
+        text === newText
+      )
+    );
 
-    // Get the initial text of the first item
-    const initialText = await initialItems[0].evaluate((el: HTMLElement) => {
+    assertEquals(await list.getItemsText(), [
+      "Edited Second Item",
+      "Third item",
+    ]);
+  });
+});
+
+class List {
+  #page: Page;
+  constructor(page: Page) {
+    this.#page = page;
+  }
+
+  getItems(): Promise<ElementHandle[]> {
+    return this.#page.$$(".list-item", { strategy: "pierce" });
+  }
+
+  async getItemsText(): Promise<Array<string | undefined>> {
+    const elements = await this.getItems();
+    return Promise.all(elements.map((el) => this.getItemText(el)));
+  }
+
+  async getItemText(element: ElementHandle): Promise<string | undefined> {
+    return await element.evaluate((el: HTMLElement) => {
       const content = el.querySelector(".item-content") ||
         el.querySelector("div.item-content");
-      return content?.textContent || el.textContent;
+      return (content?.textContent || el.textContent)?.trim();
     });
-    console.log(`Initial text of first item: "${initialText?.trim()}"`);
+  }
 
-    // Find and click the first edit button
-    const editButtons = await page.$$("button.item-action.edit", {
+  async waitForItemCount(expected: number): Promise<void> {
+    await waitFor(() => this.getItems().then((els) => els.length === expected));
+  }
+
+  async addItem(text: string): Promise<void> {
+    const addInput = await this.#page.waitForSelector(".add-item-input", {
       strategy: "pierce",
     });
-    console.log(`Found ${editButtons.length} edit buttons`);
-    assert(editButtons.length > 0, "Should find edit buttons");
+    await addInput.click();
+    await addInput.type(text);
+    await this.#page.keyboard.press("Enter");
+  }
 
-    // Debug: check what we're about to click
-    const buttonText = await editButtons[0].evaluate((el: HTMLElement) => {
-      return {
-        className: el.className,
-        title: el.title,
-        innerText: el.innerText,
-        parentText: el.parentElement?.innerText || "no parent",
-      };
-    });
-    console.log("About to click edit button:", buttonText);
+  async removeItem(element: ElementHandle): Promise<void> {
+    // Find the remove button within this item
+    const removeButton = await element.$("button.item-action.remove");
+    assert(removeButton, "Should find remove button in item");
 
-    // Click the edit button to enter edit mode
-    await editButtons[0].evaluate((button: HTMLElement) => {
-      console.log("About to dispatch click event on edit button:", button);
+    await removeButton.evaluate((button: HTMLElement) => {
       button.dispatchEvent(
         new MouseEvent("click", {
           bubbles: true,
@@ -304,59 +175,56 @@ describe("ct-list integration test", () => {
         }),
       );
     });
-    console.log("Dispatched click event on first edit button");
+  }
 
-    // Wait for edit mode to activate and look for the editing state
-    await page.waitForSelector(".list-item.editing", { strategy: "pierce" });
-    console.log("Edit mode activated - found .list-item.editing");
+  async editItem(element: ElementHandle, newText: string): Promise<void> {
+    // Find the edit button within this item
+    const editButton = await element.$("button.item-action.edit");
+    assert(editButton, "Should find edit button in item");
 
-    // Look for the specific edit input field that appears only during editing
-    const editInput = await page.$(".edit-input", {
+    await editButton.evaluate((button: HTMLElement) => {
+      button.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        }),
+      );
+    });
+
+    // Wait for edit mode to activate
+    await this.#page.waitForSelector(".list-item.editing", {
       strategy: "pierce",
     });
-    assert(editInput, "Should find .edit-input field during editing");
 
-    // Verify the input is focused (it should have autofocus)
-    const isFocused = await editInput.evaluate((el: HTMLInputElement) =>
-      document.activeElement === el
-    );
-    console.log(`Edit input is focused: ${isFocused}`);
-
-    // Clear the existing text and type new text
+    // Find the edit input and type new text
+    const editInput = await this.#page.waitForSelector(".edit-input", {
+      strategy: "pierce",
+    });
     await editInput.evaluate((el: HTMLInputElement) => {
-      el.select(); // Select all text
+      el.select();
     });
-    const newText = "Edited First Item";
     await editInput.type(newText);
-    console.log(`Typed new text: "${newText}"`);
+    await this.#page.keyboard.press("Enter");
+  }
 
-    // Press Enter to confirm the edit
-    await page.keyboard.press("Enter");
-    console.log("Pressed Enter to confirm edit");
-
-    // Wait for the edit to be processed
-    await sleep(200);
-
-    // Verify the item was edited
-    const updatedItems = await page.$$(".list-item", { strategy: "pierce" });
-    assertEquals(
-      updatedItems.length,
-      initialCount,
-      "Should have same number of items after edit",
+  async setTitle(title: string): Promise<void> {
+    const titleInput = await this.#page.waitForSelector(
+      "input[placeholder='List title']",
+      { strategy: "pierce" },
     );
-
-    // Check that the first item's text has been updated
-    const updatedText = await updatedItems[0].evaluate((el: HTMLElement) => {
-      const content = el.querySelector(".item-content") ||
-        el.querySelector("div.item-content");
-      return content?.textContent || el.textContent;
+    await titleInput.click();
+    await titleInput.evaluate((el: HTMLInputElement) => {
+      el.select();
     });
-    console.log(`Updated text of first item: "${updatedText?.trim()}"`);
+    await titleInput.type(title);
+  }
 
-    assertEquals(
-      updatedText?.trim(),
-      newText,
-      "First item should have updated text",
+  async getTitle(): Promise<string> {
+    const titleInput = await this.#page.waitForSelector(
+      "input[placeholder='List title']",
+      { strategy: "pierce" },
     );
-  });
-});
+    return await titleInput.evaluate((el: HTMLInputElement) => el.value);
+  }
+}

--- a/packages/patterns/integration/ct-render.test.ts
+++ b/packages/patterns/integration/ct-render.test.ts
@@ -51,16 +51,15 @@ describe("ct-render integration test", () => {
       identity,
     });
 
-    const counterResult = await page.waitForSelector("#counter-result", {
-      strategy: "pierce",
+    await waitFor(async () => {
+      const counterResult = await page.waitForSelector("#counter-result", {
+        strategy: "pierce",
+      });
+      const initialText = await counterResult.evaluate((el: HTMLElement) =>
+        el.textContent
+      );
+      return initialText?.trim() === "Counter is the 0th number";
     });
-    assert(counterResult, "Should find counter-result element");
-
-    // Verify initial value is 0
-    const initialText = await counterResult.evaluate((el: HTMLElement) =>
-      el.textContent
-    );
-    assertEquals(initialText?.trim(), "Counter is the 0th number");
 
     // Verify via direct operations that the ct-render structure works
     const value = charm.result.get(["value"]);
@@ -107,18 +106,16 @@ describe("ct-render integration test", () => {
       identity,
     });
 
-    // Check if the UI shows the updated value
-    const counterResult = await page.waitForSelector("#counter-result", {
-      strategy: "pierce",
+    await waitFor(async () => {
+      const counterResult = await page.waitForSelector("#counter-result", {
+        strategy: "pierce",
+      });
+      const textAfterUpdate = await counterResult.evaluate((el: HTMLElement) =>
+        el.textContent
+      );
+      return textAfterUpdate?.trim() ===
+        "Counter is the 5th number";
     });
-    const textAfterUpdate = await counterResult.evaluate((el: HTMLElement) =>
-      el.textContent
-    );
-    assertEquals(
-      textAfterUpdate?.trim(),
-      "Counter is the 5th number",
-      "UI should show updated value from direct operation",
-    );
   });
 
   it("should verify only ONE counter display", async () => {

--- a/packages/patterns/integration/ct-tags.test.ts
+++ b/packages/patterns/integration/ct-tags.test.ts
@@ -1,11 +1,12 @@
-import { env } from "@commontools/integration";
+import { env, Page, waitFor } from "@commontools/integration";
 import { sleep } from "@commontools/utils/sleep";
 import { ShellIntegration } from "@commontools/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
-import { assert, assertEquals } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { Identity } from "@commontools/identity";
 import { CharmsController } from "@commontools/charm/ops";
+import { ElementHandle } from "@astral/astral";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
@@ -56,212 +57,188 @@ describe("ct-tags integration test", () => {
 
   it("should add tags to the list", async () => {
     const page = shell.page();
-
-    // Helper function to add a tag
-    const addTag = async (tagText: string) => {
-      // Find the add tag button
-      const addTagButton = await page.waitForSelector(".add-tag", {
-        strategy: "pierce",
-      });
-
-      // Click using evaluate to ensure it works
-      await addTagButton.evaluate((el: HTMLElement) => {
-        el.click();
-      });
-      await sleep(100); // Wait for input to appear
-
-      const addInput = await page.waitForSelector(".add-tag-input", {
-        strategy: "pierce",
-      });
-      await addInput.type(tagText);
-      await page.keyboard.press("Enter");
-      await sleep(100); // Wait for DOM update
-    };
-
-    // Add first tag
-    await addTag("frontend");
-
-    // Add second tag
-    await addTag("javascript");
-
-    // Add third tag
-    await addTag("testing");
-
-    // Verify tags were added
-    const tags = await page.$$(".tag", { strategy: "pierce" });
-    assertEquals(tags.length, 3, "Should have 3 tags");
-
-    // Debug: Log the structure of tags
-    console.log("Tag structure:");
-    for (let i = 0; i < tags.length; i++) {
-      const tagInfo = await tags[i].evaluate(
-        (el: HTMLElement, idx: number) => {
-          const tagText = el.querySelector(".tag-text");
-          const removeButton = el.querySelector(".tag-remove");
-          return {
-            index: idx,
-            className: el.className,
-            tagText: tagText?.textContent || "no text",
-            hasRemoveButton: !!removeButton,
-          };
-        },
-        { args: [i] } as any,
-      );
-      console.log(`Tag ${i}:`, tagInfo);
-    }
-
-    // Verify tag content
-    const firstTagText = await tags[0].evaluate((el: HTMLElement) => {
-      const tagText = el.querySelector(".tag-text");
-      return tagText?.textContent || el.textContent;
-    });
-    assertEquals(firstTagText?.trim(), "frontend");
-
-    const secondTagText = await tags[1].evaluate((el: HTMLElement) => {
-      const tagText = el.querySelector(".tag-text");
-      return tagText?.textContent || el.textContent;
-    });
-    assertEquals(secondTagText?.trim(), "javascript");
-
-    const thirdTagText = await tags[2].evaluate((el: HTMLElement) => {
-      const tagText = el.querySelector(".tag-text");
-      return tagText?.textContent || el.textContent;
-    });
-    assertEquals(thirdTagText?.trim(), "testing");
+    const tags = new Tags(page);
+    await tags.addTag("frontend");
+    await tags.waitForTagCount(1);
+    await tags.addTag("javascript");
+    await tags.waitForTagCount(2);
+    await tags.addTag("testing");
+    await tags.waitForTagCount(3);
+    assertEquals(await tags.getTagsText(), [
+      "frontend",
+      "javascript",
+      "testing",
+    ]);
   });
 
   it("should not add duplicate tags", async () => {
     const page = shell.page();
-
-    // Helper function to add a tag
-    const addTag = async (tagText: string) => {
-      const addTagButton = await page.waitForSelector(".add-tag", {
-        strategy: "pierce",
-      });
-
-      await addTagButton.evaluate((el: HTMLElement) => {
-        el.click();
-      });
-      await sleep(100);
-
-      const addInput = await page.waitForSelector(".add-tag-input", {
-        strategy: "pierce",
-      });
-      await addInput.type(tagText);
-      await page.keyboard.press("Enter");
-      await sleep(100);
-    };
+    const tags = new Tags(page);
+    assertEquals((await tags.getTags()).length, 3);
 
     // Try to add a duplicate tag
-    await addTag("frontend"); // This already exists
-
-    // Should still have 3 tags, not 4
-    const tags = await page.$$(".tag", { strategy: "pierce" });
-    assertEquals(tags.length, 3, "Should still have 3 tags (no duplicates)");
+    await tags.addTag("frontend");
+    await tags.waitForTagCount(3);
+    assertEquals(await tags.getTagsText(), [
+      "frontend",
+      "javascript",
+      "testing",
+    ]);
   });
 
   it("should edit tags", async () => {
     const page = shell.page();
+    const tags = new Tags(page);
+    assertEquals(
+      (await tags.getTags()).length,
+      3,
+      "Should still have 3 tags (no duplicates)",
+    );
 
-    console.log("Waiting for component to stabilize...");
-    await sleep(500);
+    const newText = "backend";
+    const tagEls = await tags.getTags();
+    await tags.editTag(tagEls[0], newText);
+    await waitFor(() =>
+      tags.getTags().then((els) => tags.getTagText(els[0])).then((text) =>
+        text === newText
+      )
+    );
+    assertEquals(await tags.getTagsText(), [
+      "backend",
+      "javascript",
+      "testing",
+    ]);
+  });
 
-    // Get initial tags
-    const initialTags = await page.$$(".tag", { strategy: "pierce" });
-    const initialCount = initialTags.length;
-    console.log(`Initial tag count: ${initialCount}`);
-    assert(initialCount > 0, "Should have tags to edit");
+  it("should remove tags", async () => {
+    const page = shell.page();
+    const tags = new Tags(page);
+    assertEquals((await tags.getTags()).length, 3);
+    const elements = await tags.getTags();
+    await tags.removeTag(elements[0]);
+    await tags.waitForTagCount(2);
+    assertEquals(await tags.getTagsText(), [
+      "javascript",
+      "testing",
+    ]);
+  });
 
-    // Click on the first tag to edit it
-    await initialTags[0].click();
-    console.log("Clicked on first tag");
+  it("should cancel tag editing with Escape key", async () => {
+    const page = shell.page();
+    const tags = new Tags(page);
+    assertEquals((await tags.getTags()).length, 2);
+    const originalTexts = await tags.getTagsText();
 
-    // Wait for edit mode to activate
+    const elements = await tags.getTags();
+    const element = elements[0];
+    await element.click();
     await page.waitForSelector(".tag.editing", { strategy: "pierce" });
-    console.log("Edit mode activated - found .tag.editing");
-
-    // Look for the tag input field that appears during editing
     const editInput = await page.waitForSelector(".tag-input", {
       strategy: "pierce",
     });
-    assert(editInput, "Should find .tag-input field during editing");
+    await editInput.evaluate((el: HTMLInputElement) => el.select());
+    await editInput.type("should-be-cancelled");
+    await page.keyboard.press("Escape");
+    await sleep(100);
+    assertEquals(await tags.getTagsText(), originalTexts);
+  });
+
+  it("should delete empty tags when backspacing", async () => {
+    const page = shell.page();
+    const tags = new Tags(page);
+    assertEquals((await tags.getTags()).length, 2);
+
+    const elements = await tags.getTags();
+    const element = elements[0];
+    await element.click();
+    await page.waitForSelector(".tag.editing", { strategy: "pierce" });
+    const editInput = await page.waitForSelector(".tag-input", {
+      strategy: "pierce",
+    });
+    await editInput.evaluate((el: HTMLInputElement) => el.select());
+    await page.keyboard.press("Delete");
+    await sleep(50); // Wait for input to be cleared
+    // Press Backspace on empty input
+    await page.keyboard.press("Backspace");
+    await sleep(200);
+
+    await tags.waitForTagCount(1);
+  });
+});
+
+class Tags {
+  #page: Page;
+  constructor(page: Page) {
+    this.#page = page;
+  }
+
+  getTags(): Promise<ElementHandle[]> {
+    return this.#page.$$(".tag", { strategy: "pierce" });
+  }
+
+  async getTagsText(): Promise<Array<string | undefined>> {
+    const elements = await this.getTags();
+    return Promise.all(elements.map((el) => this.getTagText(el)));
+  }
+
+  async editTag(element: ElementHandle, newText: string) {
+    await element.click();
+    await this.#page.waitForSelector(".tag.editing", { strategy: "pierce" });
+    // Look for the tag input field that appears during editing
+    const editInput = await this.#page.waitForSelector(".tag-input", {
+      strategy: "pierce",
+    });
 
     // Clear and type new text
     await editInput.evaluate((el: HTMLInputElement) => {
       el.select(); // Select all text
     });
-    const newText = "backend";
     await editInput.type(newText);
-    console.log(`Typed new text: "${newText}"`);
+    await this.#page.keyboard.press("Enter");
+  }
 
-    // Press Enter to confirm the edit
-    await page.keyboard.press("Enter");
-    console.log("Pressed Enter to confirm edit");
+  async waitForTagCount(expected: number): Promise<void> {
+    await waitFor(() => this.getTags().then((els) => els.length === expected));
+  }
 
-    // Wait for the edit to be processed
-    await sleep(200);
-
-    // Verify the tag was edited
-    const updatedTags = await page.$$(".tag", { strategy: "pierce" });
-    assertEquals(
-      updatedTags.length,
-      initialCount,
-      "Should have same number of tags after edit",
+  async waitForTagText(element: ElementHandle, text: string): Promise<void> {
+    await waitFor(() =>
+      element.evaluate((el: HTMLInputElement) => el.value).then((value) =>
+        value === text
+      )
     );
+  }
 
-    // Check that the first tag's text has been updated
-    const updatedText = await updatedTags[0].evaluate((el: HTMLElement) => {
+  async getTagText(element: ElementHandle): Promise<string | undefined> {
+    return await element.evaluate((el: HTMLElement) => {
       const tagText = el.querySelector(".tag-text");
       return tagText?.textContent || el.textContent;
     });
-    console.log(`Updated text of first tag: "${updatedText?.trim()}"`);
+  }
 
-    assertEquals(
-      updatedText?.trim(),
-      newText,
-      "First tag should have updated text",
-    );
-  });
-
-  it("should remove tags", async () => {
-    const page = shell.page();
-
-    console.log("Waiting for component to stabilize...");
-    await sleep(500);
-
-    // Get initial count
-    const initialTags = await page.$$(".tag", { strategy: "pierce" });
-    const initialCount = initialTags.length;
-    console.log(`Initial tag count: ${initialCount}`);
-    assert(initialCount > 0, "Should have tags to remove");
-
-    // Hover over the first tag to make the remove button visible
-    await initialTags[0].evaluate((el: HTMLElement) => {
-      el.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
-    });
-    await sleep(100); // Wait for hover effect
-
-    // Find and click the first remove button
-    const removeButtons = await page.$$(".tag-remove", {
+  async addTag(text: string) {
+    const addTagButton = await this.#page.waitForSelector(".add-tag", {
       strategy: "pierce",
     });
-    console.log(`Found ${removeButtons.length} remove buttons`);
-    assert(removeButtons.length > 0, "Should find remove buttons");
-
-    // Debug: check what we're about to click
-    const buttonInfo = await removeButtons[0].evaluate((el: HTMLElement) => {
-      return {
-        className: el.className,
-        title: el.title,
-        innerText: el.innerText,
-        parentText: el.parentElement?.innerText || "no parent",
-      };
+    await addTagButton.click();
+    const addInput = await this.#page.waitForSelector(".add-tag-input", {
+      strategy: "pierce",
     });
-    console.log("About to click remove button:", buttonInfo);
+    await addInput.type(text);
+    await this.#page.keyboard.press("Enter");
+  }
 
-    // Click the remove button
-    await removeButtons[0].evaluate((button: HTMLElement) => {
-      console.log("About to dispatch click event on remove button:", button);
+  async removeTag(element: ElementHandle): Promise<void> {
+    // Hover over the first tag to make the remove button visible
+    await element.evaluate((el: HTMLElement) => {
+      el.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+
+    // Find and click the first remove button
+    const removeButtons = await this.#page.waitForSelector(".tag-remove", {
+      strategy: "pierce",
+    });
+    await removeButtons.evaluate((button: HTMLElement) => {
       button.dispatchEvent(
         new MouseEvent("click", {
           bubbles: true,
@@ -270,175 +247,5 @@ describe("ct-tags integration test", () => {
         }),
       );
     });
-    console.log("Dispatched click event on first remove button");
-
-    // Wait for DOM to update after removal
-    await sleep(200);
-
-    // Verify tag was removed
-    const remainingTags = await page.$$(".tag", { strategy: "pierce" });
-    console.log(`After removal, found ${remainingTags.length} tags`);
-
-    assertEquals(
-      remainingTags.length,
-      initialCount - 1,
-      "Should have one less tag after removal",
-    );
-
-    // Verify the first tag is now what was the second tag
-    if (remainingTags.length > 0) {
-      const firstRemainingText = await remainingTags[0].evaluate(
-        (el: HTMLElement) => {
-          const tagText = el.querySelector(".tag-text");
-          return tagText?.textContent || el.textContent;
-        },
-      );
-      assertEquals(
-        firstRemainingText?.trim(),
-        "javascript",
-        "First tag should now be the second tag",
-      );
-    }
-  });
-
-  it("should cancel tag editing with Escape key", async () => {
-    const page = shell.page();
-
-    console.log("Waiting for component to stabilize...");
-    await sleep(500);
-
-    // Helper function to add a tag if needed
-    const addTag = async (tagText: string) => {
-      const addTagButton = await page.waitForSelector(".add-tag", {
-        strategy: "pierce",
-      });
-
-      await addTagButton.evaluate((el: HTMLElement) => {
-        el.click();
-      });
-      await sleep(100);
-
-      const addInput = await page.waitForSelector(".add-tag-input", {
-        strategy: "pierce",
-      });
-      await addInput.type(tagText);
-      await page.keyboard.press("Enter");
-      await sleep(100);
-    };
-
-    let tags = await page.$$(".tag", { strategy: "pierce" });
-
-    // Add a tag if none exist
-    if (tags.length === 0) {
-      await addTag("test-tag");
-      tags = await page.$$(".tag", { strategy: "pierce" });
-    }
-
-    assert(tags.length > 0, "Should have tags to test escape behavior");
-
-    // Get the original text of the first tag
-    const originalText = await tags[0].evaluate((el: HTMLElement) => {
-      const tagText = el.querySelector(".tag-text");
-      return tagText?.textContent || el.textContent;
-    });
-
-    // Click on the first tag to edit it
-    await tags[0].click();
-
-    // Wait for edit mode
-    await page.waitForSelector(".tag.editing", { strategy: "pierce" });
-
-    // Find the edit input and type some text
-    const editInput = await page.waitForSelector(".tag-input", {
-      strategy: "pierce",
-    });
-    await editInput.evaluate((el: HTMLInputElement) => {
-      el.select();
-    });
-    await editInput.type("should-be-cancelled");
-
-    // Press Escape to cancel
-    await page.keyboard.press("Escape");
-    await sleep(100);
-
-    // Verify the edit was cancelled and original text is preserved
-    const updatedTags = await page.$$(".tag", { strategy: "pierce" });
-    const currentText = await updatedTags[0].evaluate((el: HTMLElement) => {
-      const tagText = el.querySelector(".tag-text");
-      return tagText?.textContent || el.textContent;
-    });
-
-    assertEquals(
-      currentText?.trim(),
-      originalText?.trim(),
-      "Tag text should be unchanged after Escape",
-    );
-  });
-
-  it("should delete empty tags when backspacing", async () => {
-    const page = shell.page();
-
-    console.log("Waiting for component to stabilize...");
-    await sleep(500);
-
-    // Helper function to add a tag if needed
-    const addTag = async (tagText: string) => {
-      const addTagButton = await page.waitForSelector(".add-tag", {
-        strategy: "pierce",
-      });
-
-      await addTagButton.evaluate((el: HTMLElement) => {
-        el.click();
-      });
-      await sleep(100);
-
-      const addInput = await page.waitForSelector(".add-tag-input", {
-        strategy: "pierce",
-      });
-      await addInput.type(tagText);
-      await page.keyboard.press("Enter");
-      await sleep(100);
-    };
-
-    // Get initial count
-    let initialTags = await page.$$(".tag", { strategy: "pierce" });
-
-    // Add a tag if none exist
-    if (initialTags.length === 0) {
-      await addTag("test-tag");
-      initialTags = await page.$$(".tag", { strategy: "pierce" });
-    }
-
-    const initialCount = initialTags.length;
-
-    // Click on the first tag to edit it
-    await initialTags[0].click();
-
-    // Wait for edit mode
-    await page.waitForSelector(".tag.editing", { strategy: "pierce" });
-
-    // Find the edit input and clear all text using keyboard
-    const editInput = await page.waitForSelector(".tag-input", {
-      strategy: "pierce",
-    });
-
-    // Select all text and delete it
-    await editInput.evaluate((el: HTMLInputElement) => {
-      el.select();
-    });
-    await page.keyboard.press("Delete");
-    await sleep(50); // Wait for input to be cleared
-
-    // Press Backspace on empty input
-    await page.keyboard.press("Backspace");
-    await sleep(200);
-
-    // Verify the tag was removed
-    const remainingTags = await page.$$(".tag", { strategy: "pierce" });
-    assertEquals(
-      remainingTags.length,
-      initialCount - 1,
-      "Should have one less tag after backspacing empty tag",
-    );
-  });
-});
+  }
+}

--- a/packages/patterns/integration/instantiate-recipe.test.ts
+++ b/packages/patterns/integration/instantiate-recipe.test.ts
@@ -9,6 +9,9 @@ import { CharmsController } from "@commontools/charm/ops";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
+// TODO(CT-1101) Need to re-enable these tests to make them more robust
+const ignore = true;
+
 describe("instantiate-recipe integration test", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
@@ -41,61 +44,65 @@ describe("instantiate-recipe integration test", () => {
     if (cc) await cc.dispose();
   });
 
-  it("should deploy recipe, click button, and navigate to counter", async () => {
-    const page = shell.page();
+  it({
+    name: "should deploy recipe, click button, and navigate to counter",
+    ignore,
+    fn: async () => {
+      const page = shell.page();
 
-    await shell.goto({
-      frontendUrl: FRONTEND_URL,
-      view: {
-        spaceName: SPACE_NAME,
-        charmId,
-      },
-      identity,
-    });
+      await shell.goto({
+        frontendUrl: FRONTEND_URL,
+        view: {
+          spaceName: SPACE_NAME,
+          charmId,
+        },
+        identity,
+      });
 
-    // Wait for charm to load by waiting for first interactive element
-    await page.waitForSelector("[data-ct-input]", { strategy: "pierce" });
+      // Wait for charm to load by waiting for first interactive element
+      await page.waitForSelector("[data-ct-input]", { strategy: "pierce" });
 
-    // Store the current URL before any action
-    const urlBefore = await page.evaluate(() => globalThis.location.href);
-    console.log("URL before action:", urlBefore);
+      // Store the current URL before any action
+      const urlBefore = await page.evaluate(() => globalThis.location.href);
+      console.log("URL before action:", urlBefore);
 
-    const input = await page.waitForSelector("[data-ct-input]", {
-      strategy: "pierce",
-    });
+      const input = await page.waitForSelector("[data-ct-input]", {
+        strategy: "pierce",
+      });
 
-    await input.type("New counter");
+      await input.type("New counter");
 
-    // Quick wait for input processing
-    await sleep(100);
+      // Quick wait for input processing
+      await sleep(100);
 
-    const button = await page.waitForSelector("[data-ct-button]", {
-      strategy: "pierce",
-    });
+      const button = await page.waitForSelector("[data-ct-button]", {
+        strategy: "pierce",
+      });
 
-    await button.click();
+      await button.click();
 
-    // Wait for page to soft navigate
-    await page.waitForFunction((urlBefore) => {
-      return globalThis.location.href !== urlBefore;
-    }, { args: [urlBefore] });
+      // Wait for page to soft navigate
+      await page.waitForFunction((urlBefore) => {
+        return globalThis.location.href !== urlBefore;
+      }, { args: [urlBefore] });
 
-    const urlAfter = await page.evaluate(() => globalThis.location.href);
-    console.log("URL after clicking:", urlAfter);
+      const urlAfter = await page.evaluate(() => globalThis.location.href);
+      console.log("URL after clicking:", urlAfter);
 
-    // Verify navigation happened (URL should have changed)
-    assert(
-      urlBefore !== urlAfter,
-      "Should navigate to a new URL after clicking Add button",
-    );
+      // Verify navigation happened (URL should have changed)
+      assert(
+        urlBefore !== urlAfter,
+        "Should navigate to a new URL after clicking Add button",
+      );
 
-    // Verify we're now on a counter page by checking for counter-specific elements
-    const counterResult = await page.waitForSelector("#counter-result", {
-      strategy: "pierce",
-    });
-    assert(
-      counterResult,
-      "Should find counter-result element after navigation",
-    );
+      // Verify we're now on a counter page by checking for counter-specific elements
+      const counterResult = await page.waitForSelector("#counter-result", {
+        strategy: "pierce",
+      });
+      assert(
+        counterResult,
+        "Should find counter-result element after navigation",
+      );
+    },
   });
 });

--- a/packages/patterns/integration/list-operations.test.ts
+++ b/packages/patterns/integration/list-operations.test.ts
@@ -3,7 +3,7 @@ import { CharmController, CharmsController } from "@commontools/charm/ops";
 import { ShellIntegration } from "@commontools/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
-import { assert, assertEquals } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { Identity } from "@commontools/identity";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
@@ -54,23 +54,27 @@ describe("list-operations simple test", () => {
     await page.waitForSelector("#main-list", { strategy: "pierce" });
 
     // Click reset to populate with initial data
-    const resetBtn = await page.$("#reset-demo", { strategy: "pierce" });
-    assert(resetBtn, "Should find reset button");
+    const resetBtn = await page.waitForSelector("#reset-demo", {
+      strategy: "pierce",
+    });
     await resetBtn.click();
 
     // Wait for the reset operation to complete by checking the text content
-    const mainList = await page.$("#main-list", { strategy: "pierce" });
-    assert(mainList, "Should find main list element");
-
     await waitFor(async () => {
-      const initialText = await mainList!.evaluate((el: HTMLElement) =>
+      const mainList = await page.waitForSelector("#main-list", {
+        strategy: "pierce",
+      });
+      const initialText = await mainList.evaluate((el: HTMLElement) =>
         el.textContent || ""
       );
       return initialText === "A, B, C, D (4)";
     });
 
     // Verify the list populated correctly
-    const initialText = await mainList!.evaluate((el: HTMLElement) =>
+    const mainList = await page.waitForSelector("#main-list", {
+      strategy: "pierce",
+    });
+    const initialText = await mainList.evaluate((el: HTMLElement) =>
       el.textContent || ""
     );
     assertEquals(
@@ -80,24 +84,26 @@ describe("list-operations simple test", () => {
     );
 
     // Test delete first item
-    const deleteFirstBtn = await page.$("#delete-first", {
+    const deleteFirstBtn = await page.waitForSelector("#delete-first", {
       strategy: "pierce",
     });
-    await deleteFirstBtn!.click();
+    await deleteFirstBtn.click();
 
     // Wait for delete to complete
     await waitFor(async () => {
-      const currentMainList = await page.$("#main-list", {
+      const currentMainList = await page.waitForSelector("#main-list", {
         strategy: "pierce",
       });
-      const text = await currentMainList!.evaluate((el: HTMLElement) =>
+      const text = await currentMainList.evaluate((el: HTMLElement) =>
         el.textContent || ""
       );
       return text === "B, C, D (3)";
     });
 
-    const currentMainList = await page.$("#main-list", { strategy: "pierce" });
-    const afterDeleteText = await currentMainList!.evaluate((el: HTMLElement) =>
+    const currentMainList = await page.waitForSelector("#main-list", {
+      strategy: "pierce",
+    });
+    const afterDeleteText = await currentMainList.evaluate((el: HTMLElement) =>
       el.textContent || ""
     );
     assertEquals(
@@ -107,22 +113,26 @@ describe("list-operations simple test", () => {
     );
 
     // Test insert at start
-    const insertStartBtn = await page.$("#insert-start", {
+    const insertStartBtn = await page.waitForSelector("#insert-start", {
       strategy: "pierce",
     });
-    await insertStartBtn!.click();
+    await insertStartBtn.click();
 
     // Wait for insert to complete
     await waitFor(async () => {
-      const insertMainList = await page.$("#main-list", { strategy: "pierce" });
-      const text = await insertMainList!.evaluate((el: HTMLElement) =>
+      const insertMainList = await page.waitForSelector("#main-list", {
+        strategy: "pierce",
+      });
+      const text = await insertMainList.evaluate((el: HTMLElement) =>
         el.textContent || ""
       );
       return text === "New Start, B, C, D (4)";
     });
 
-    const insertMainList = await page.$("#main-list", { strategy: "pierce" });
-    const afterInsertText = await insertMainList!.evaluate((el: HTMLElement) =>
+    const insertMainList = await page.waitForSelector("#main-list", {
+      strategy: "pierce",
+    });
+    const afterInsertText = await insertMainList.evaluate((el: HTMLElement) =>
       el.textContent || ""
     );
     assertEquals(
@@ -132,21 +142,25 @@ describe("list-operations simple test", () => {
     );
 
     // Test one more operation: delete-last to see if it works
-    const deleteLastBtn = await page.$("#delete-last", { strategy: "pierce" });
-    await deleteLastBtn!.click();
+    const deleteLastBtn = await page.waitForSelector("#delete-last", {
+      strategy: "pierce",
+    });
+    await deleteLastBtn.click();
 
     await waitFor(async () => {
-      const deleteLastMainList = await page.$("#main-list", {
+      const deleteLastMainList = await page.waitForSelector("#main-list", {
         strategy: "pierce",
       });
-      const text = await deleteLastMainList!.evaluate((el: HTMLElement) =>
+      const text = await deleteLastMainList.evaluate((el: HTMLElement) =>
         el.textContent || ""
       );
       return text === "New Start, B, C (3)";
     });
 
-    const finalMainList = await page.$("#main-list", { strategy: "pierce" });
-    const finalText = await finalMainList!.evaluate((el: HTMLElement) =>
+    const finalMainList = await page.waitForSelector("#main-list", {
+      strategy: "pierce",
+    });
+    const finalText = await finalMainList.evaluate((el: HTMLElement) =>
       el.textContent || ""
     );
     assertEquals(

--- a/packages/patterns/integration/nested-counter.test.ts
+++ b/packages/patterns/integration/nested-counter.test.ts
@@ -51,16 +51,15 @@ describe("nested counter integration test", () => {
       identity,
     });
 
-    const counterResult = await page.waitForSelector("#counter-result", {
-      strategy: "pierce",
+    await waitFor(async () => {
+      const counterResult = await page.waitForSelector("#counter-result", {
+        strategy: "pierce",
+      });
+      const initialText = await counterResult.evaluate((el: HTMLElement) =>
+        el.textContent
+      );
+      return initialText?.trim() === "Counter is the 0th number";
     });
-    assert(counterResult, "Should find counter-result element");
-
-    // Verify initial value is 0
-    const initialText = await counterResult.evaluate((el: HTMLElement) =>
-      el.textContent
-    );
-    assertEquals(initialText?.trim(), "Counter is the 0th number");
 
     // Verify via direct operations that the nested structure works
     assertEquals(charm.result.get(["value"]), 0);

--- a/packages/shell/integration/charm.test.ts
+++ b/packages/shell/integration/charm.test.ts
@@ -59,20 +59,25 @@ describe("shell charm tests", () => {
       identity,
     });
 
-    let handle = await page.waitForSelector(
-      "#counter-decrement",
-      { strategy: "pierce" },
-    );
-    handle.click();
-    await sleep(1000);
-    handle.click();
-    await sleep(1000);
-    handle = await page.waitForSelector(
+    // Click twice
+    for (let i = 0; i < 2; i++) {
+      const handle = await page.waitForSelector(
+        "#counter-decrement",
+        { strategy: "pierce" },
+      );
+      // Wait for inner text. There's some
+      // race here where we can click before the
+      // box model is available.
+      const _ = await handle.innerText();
+      handle.click();
+      await sleep(1000);
+    }
+    const handle = await page.waitForSelector(
       "#counter-result",
       { strategy: "pierce" },
     );
-    await sleep(1000);
-    const text = await handle?.innerText();
+    await sleep(1500);
+    const text = await handle.innerText();
     assert(text === "Counter is the -2th number");
   });
 });

--- a/packages/shell/integration/iframe-counter-charm.disabled_test.ts
+++ b/packages/shell/integration/iframe-counter-charm.disabled_test.ts
@@ -65,7 +65,7 @@ async function getCharmResult(page: Page): Promise<{ count: number }> {
   // Use the element handle to evaluate in its context
   return await appView.evaluate((element: XAppView) => {
     // Access the private _activeCharm property
-    const activeCharmTask = element._activePatterns;
+    const activeCharmTask = element._patterns;
 
     if (!activeCharmTask) {
       throw new Error("No _activeCharm property found on element");
@@ -77,6 +77,9 @@ async function getCharmResult(page: Page): Promise<{ count: number }> {
 
     // Get the charm controller from the Task's value
     const charmController = activeCharmTask.value.activePattern;
+    if (!charmController) {
+      throw new Error("No active charm controller found");
+    }
 
     // Get the result from the charm controller
     const result = charmController.result.get();

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -5,14 +5,20 @@ import {
   RuntimeTelemetryEvent,
   RuntimeTelemetryMarkerResult,
 } from "@commontools/runner";
-import { charmId, CharmManager } from "@commontools/charm";
-import { CharmsController } from "@commontools/charm/ops";
+import {
+  charmId,
+  CharmManager,
+  NameSchema,
+  nameSchema,
+} from "@commontools/charm";
+import { CharmController, CharmsController } from "@commontools/charm/ops";
 import { StorageManager } from "@commontools/runner/storage/cache";
 import { navigate } from "./navigate.ts";
 import * as Inspector from "@commontools/runner/storage/inspector";
 import { setupIframe } from "./iframe-ctx.ts";
 import { getLogger } from "@commontools/utils/logger";
 import { AppView } from "./app/view.ts";
+import * as PatternFactory from "./pattern-factory.ts";
 
 const logger = getLogger("shell.telemetry", {
   enabled: false,
@@ -34,15 +40,20 @@ export class RuntimeInternals extends EventTarget {
   #inspector: Inspector.Channel;
   #disposed = false;
   #space: string; // The MemorySpace DID
+  #spaceRootPattern?: CharmController<NameSchema>;
+  #spaceRootPatternType: PatternFactory.BuiltinPatternType;
+  #patternCache: Map<string, CharmController<NameSchema>> = new Map();
 
   private constructor(
     cc: CharmsController,
     telemetry: RuntimeTelemetry,
     space: string,
+    spaceRootPatternType: PatternFactory.BuiltinPatternType,
   ) {
     super();
     this.#cc = cc;
     this.#space = space;
+    this.#spaceRootPatternType = spaceRootPatternType;
     const runtimeId = this.#cc.manager().runtime.id;
     this.#inspector = new Inspector.Channel(
       runtimeId,
@@ -67,6 +78,45 @@ export class RuntimeInternals extends EventTarget {
 
   space(): string {
     return this.#space;
+  }
+
+  // Returns the space root pattern, creating it if it doesn't exist.
+  // The space root pattern type is determined at RuntimeInternals creation
+  // based on the view type (home vs space).
+  async getSpaceRootPattern(): Promise<CharmController<NameSchema>> {
+    this.#check();
+    if (this.#spaceRootPattern) {
+      return this.#spaceRootPattern;
+    }
+
+    const pattern = await PatternFactory.getOrCreate(
+      this.#cc,
+      this.#spaceRootPatternType,
+    );
+
+    // Track as recently accessed
+    await this.#cc.manager().trackRecentCharm(pattern.getCell());
+
+    this.#patternCache.set(pattern.id, pattern);
+    return pattern;
+  }
+
+  // Returns a pattern by ID, starting it if requested.
+  // Patterns are cached by ID.
+  async getPattern(id: string): Promise<CharmController<NameSchema>> {
+    this.#check();
+    const cached = this.#patternCache.get(id);
+    if (cached) {
+      return cached;
+    }
+
+    const pattern = await this.#cc.get(id, true, nameSchema);
+
+    // Track as recently accessed
+    await this.#cc.manager().trackRecentCharm(pattern.getCell());
+
+    this.#patternCache.set(id, pattern);
+    return pattern;
   }
 
   async dispose() {
@@ -106,20 +156,24 @@ export class RuntimeInternals extends EventTarget {
   ): Promise<RuntimeInternals> {
     let session;
     let spaceName;
+    let spaceRootPatternType: PatternFactory.BuiltinPatternType;
     if ("builtin" in view) {
       switch (view.builtin) {
         case "home":
           session = await createSession({ identity, spaceDid: identity.did() });
           spaceName = "<home>";
+          spaceRootPatternType = "home";
           break;
       }
     } else if ("spaceName" in view) {
       session = await createSession({ identity, spaceName: view.spaceName });
       spaceName = view.spaceName;
+      spaceRootPatternType = "space-root";
     } else if ("spaceDid" in view) {
       session = await createSession({ identity, spaceDid: view.spaceDid });
+      spaceRootPatternType = "space-root";
     }
-    if (!session) {
+    if (!session || !spaceRootPatternType!) {
       throw new Error("Unexpected view provided.");
     }
 
@@ -234,6 +288,11 @@ export class RuntimeInternals extends EventTarget {
     charmManager = new CharmManager(session, runtime);
     await charmManager.synced();
     const cc = new CharmsController(charmManager);
-    return new RuntimeInternals(cc, telemetry, session.space);
+    return new RuntimeInternals(
+      cc,
+      telemetry,
+      session.space,
+      spaceRootPatternType,
+    );
   }
 }

--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -45,10 +45,10 @@ export class XBodyView extends BaseView {
   rt?: RuntimeInternals;
 
   @property({ attribute: false })
-  activeCharm?: CharmController;
+  activePattern?: CharmController;
 
   @property({ attribute: false })
-  defaultCharm?: CharmController;
+  spaceRootPattern?: CharmController;
 
   @property()
   showShellCharmListView = false;
@@ -96,16 +96,16 @@ export class XBodyView extends BaseView {
       `;
     }
 
-    const mainContent = this.activeCharm
+    const mainContent = this.activePattern
       ? html`
-        <ct-charm slot="main" .charmId="${this.activeCharm.id}">
-          <ct-render .cell="${this.activeCharm.getCell()}"></ct-render>
+        <ct-charm slot="main" .charmId="${this.activePattern.id}">
+          <ct-render .cell="${this.activePattern.getCell()}"></ct-render>
         </ct-charm>
       `
       : null;
 
-    const sidebarCell = this.activeCharm?.getCell().key("sidebarUI");
-    const fabCell = this.defaultCharm?.getCell().key("fabUI");
+    const sidebarCell = this.activePattern?.getCell().key("sidebarUI");
+    const fabCell = this.spaceRootPattern?.getCell().key("fabUI");
 
     // Update sidebar content detection
     // TODO(seefeld): Fix possible race here where charm is already set, but

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -17,9 +17,10 @@ import { runtimeContext, spaceContext } from "@commontools/ui";
 import { provide } from "@lit/context";
 
 // The root element for the shell application.
-// Handles processing `Command`s from children elements,
-// updating the `AppState`, and providing changes
-// to children elements.
+//
+// Derives `RuntimeInternals` for the application from its `AppState`.
+// `Command` mutates the app state, which can be fired as events
+// from children elements.
 export class XRootView extends BaseView {
   static override styles = css`
     :host {


### PR DESCRIPTION


























<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Separated the derivation of the active pattern from the space root pattern and added runtime pattern caching to keep UI state in sync and reduce flicker. Updated AppView/BodyView to use the new pattern model and tightened typing with NameSchema.

- **Refactors**
  - Split space root and active pattern derivation in AppView using separate tasks (_spaceRootPattern, _selectedPattern, _patterns).
  - RuntimeInternals now exposes getSpaceRootPattern and getPattern, caches patterns by ID, tracks recent access, and derives the space root pattern type from the view.
  - PatternFactory renamed "space-default" to "space-root" and returns CharmController<NameSchema>.
  - BodyView props renamed: activeCharm -> activePattern, defaultCharm -> spaceRootPattern; sidebar/fab derive from active/space root respectively.
  - CharmsController.create is now generic and returns typed CharmController<U>.
  - Integration tests stabilized using waitFor/waitForSelector; iframe test updated to read _patterns; temporarily disabled instantiate-recipe test (CT-1101).

- **Migration**
  - Rename BodyView inputs to activePattern and spaceRootPattern.
  - Replace AppView usage of _activePatterns with _patterns; use charmId for explicit selection.
  - Use "space-root" in PatternFactory instead of "space-default".
  - Adjust types to CharmController<NameSchema> where patterns are returned.
  - Add a type parameter to CharmsController.create where needed.

<sup>Written for commit 6f7f3b536a4b15ace8ff34fb46aa27a6383d7573. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

























