### PR TITLE
Remove Sentry error tracking usage

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -391,27 +391,6 @@ jobs:
         with:
           cache: false
 
-      - name: 🔽 Pre-download Sentry CLI
-        run: |
-          echo "::group::Downloading Sentry CLI"
-          deno run --allow-all npm:@sentry/cli --version
-          echo "::endgroup::"
-
-      - name: 📊 Create Toolshed server Sentry release
-        run: |
-          # Create a release with version based on commit SHA
-          deno run --allow-all npm:@sentry/cli releases new ${{ github.sha }}
-
-          # Associate commits with the release
-          deno run --allow-all npm:@sentry/cli releases set-commits ${{ github.sha }} --auto
-
-          # Finalize the release
-          deno run --allow-all npm:@sentry/cli releases finalize ${{ github.sha }}
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ vars.SENTRY_TOOLSHED_PROJECT }}
-
       - name: 🚀 Deploy application to Toolshed (Staging)
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -51,27 +51,6 @@ jobs:
         with:
           cache: false
 
-      - name: 🔽 Pre-download Sentry CLI
-        run: |
-          echo "::group::Downloading Sentry CLI"
-          deno run --allow-all npm:@sentry/cli --version
-          echo "::endgroup::"
-
-      - name: 📊 Create Toolshed server Sentry release
-        run: |
-          # Create a release with version based on commit SHA
-          deno run --allow-all npm:@sentry/cli releases new ${{ github.event.inputs.commit_sha }}
-
-          # Associate commits with the release
-          deno run --allow-all npm:@sentry/cli releases set-commits ${{ github.event.inputs.commit_sha }} --auto
-
-          # Finalize the release
-          deno run --allow-all npm:@sentry/cli releases finalize ${{ github.event.inputs.commit_sha }}
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ vars.SENTRY_TOOLSHED_PROJECT }}
-
       - name: 🚀 Deploy application to Estuary (Production)
         id: deployment
         uses: appleboy/ssh-action@master

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -146,7 +146,6 @@ export class RuntimeInternals extends EventTarget {
       }),
       errorHandlers: [(error) => {
         console.error(error);
-        //Sentry.captureException(error);
       }],
       telemetry,
       consoleHandler: (metadata, method, args) => {

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -88,12 +88,6 @@ const EnvSchema = z.object({
     { message: "DB_PATH must be an absolute path" },
   ).optional(),
   MEMORY_URL: z.string().default("http://localhost:8000"),
-  // ===========================================================================
-  // Sentry DSN global middleware
-  //   * /lib/create-app.ts
-  // ===========================================================================
-  SENTRY_DSN: z.string().default(""),
-  // ===========================================================================
 
   GOOGLE_CLIENT_ID: z.string().default(""),
   GOOGLE_CLIENT_SECRET: z.string().default(""),

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -1,6 +1,5 @@
 import app from "@/app.ts";
 import env from "@/env.ts";
-import * as Sentry from "@sentry/deno";
 import { identity } from "@/lib/identity.ts";
 import { Runtime } from "@commontools/runner";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";
@@ -86,19 +85,12 @@ function startServer() {
   console.log(`Server is starting on port http://${env.HOST}:${env.PORT}`);
   initializeRuntime();
 
-  Sentry.init({
-    dsn: env.SENTRY_DSN,
-    tracesSampleRate: 1.0,
-    environment: env.ENV || "development",
-  });
-
   const serverOptions = {
     hostname: env.HOST,
     port: env.PORT,
     signal: ac.signal,
     onError: (error: unknown) => {
       console.error("Server error:", error);
-      Sentry.captureException(error);
       return new Response("Internal Server Error", { status: 500 });
     },
     onListen: ({ port, hostname }: { port: number; hostname: string }) => {

--- a/packages/toolshed/lib/create-app.ts
+++ b/packages/toolshed/lib/create-app.ts
@@ -3,7 +3,6 @@ import { notFound, serveEmojiFavicon } from "stoker/middlewares";
 import { defaultHook } from "stoker/openapi";
 import { pinoLogger } from "@/middlewares/pino-logger.ts";
 import { otelTracing } from "@/middlewares/opentelemetry.ts";
-import { sentry } from "@hono/sentry";
 import env from "@/env.ts";
 import type { AppBindings, AppOpenAPI } from "@/lib/types.ts";
 import { initOpenTelemetry } from "@/lib/otel.ts";
@@ -20,8 +19,6 @@ export default function createApp() {
   initOpenTelemetry();
 
   const app = createRouter();
-
-  app.use("*", sentry({ dsn: env.SENTRY_DSN }));
 
   // Add OpenTelemetry tracing if enabled
   if (env.OTEL_ENABLED) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed Sentry error tracking across the app and CI/CD. Errors now log to console; OpenTelemetry remains for tracing.

- **Migration**
  - Remove SENTRY_DSN from all environment configs.
  - Delete GitHub secrets/vars: SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_TOOLSHED_PROJECT.
  - If error monitoring is needed, configure an OpenTelemetry exporter or another provider.

<sup>Written for commit 9099de27cbc2ba6b06c99967757e65ba51f72ae9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

