### PR TITLE
feat: Run tests in parallel when executing via tasks, speeding up total execution

### DIFF
--- a/packages/utils/src/encoding.ts
+++ b/packages/utils/src/encoding.ts
@@ -6,7 +6,8 @@ const decoder = new TextDecoder();
  * @param input - The string to encode
  * @returns The encoded Uint8Array
  */
-export const encode = (input: string): Uint8Array => encoder.encode(input);
+export const encode = (input: string): Uint8Array<ArrayBuffer> =>
+  encoder.encode(input);
 
 /**
  * Decodes a Uint8Array into a string using UTF-8 decoding.

--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -9,6 +9,7 @@ if [[ ! " ${DENO_VERSIONS_ALLOWED[@]} " =~ " ${DENO_VERSION} " ]]; then
   exit 1
 fi
 
+deno check tasks/*.ts
 deno check recipes/[!_]*.ts*
 deno check \
   packages/api \


### PR DESCRIPTION
### serialized tests

* Local: 1m45s - 2m32s
* CI: [2m45s](https://github.com/commontoolsinc/labs/actions/runs/19905093540/job/57059110238)

### parallelized tests

* Local: 44s
* CI: [1m](https://github.com/commontoolsinc/labs/actions/runs/19906875691/job/57065285800?pr=2194)

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run package tests in parallel via tasks to reduce total runtime. Failures now include package name with its stdout and stderr for faster debugging.

- **New Features**
  - Parallelize tests across workspace members using Promise.all.
  - Print stdout and stderr for each failed package.
  - Type-check task scripts with `deno check tasks/*.ts`.

- **Refactors**
  - Use shared encode/decode utilities; updated encode return type.
  - testPackage returns structured results and handles command errors cleanly.

<sup>Written for commit 5cfb5418988ece8ae0b4bff31175935247093e82. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

