### PR TITLE
docs: Add LOCAL_DEV_SERVERS.md reference to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,5 @@ If you are developing runtime code, read the following documentation:
   practices
 - `docs/common/UI_TESTING.md` - How to work with shadow dom in our integration
   tests
+- `docs/common/LOCAL_DEV_SERVERS.md` - **CRITICAL**: How to start local dev
+  servers correctly (use `dev-local` for shell, not `dev`)


### PR DESCRIPTION
## Summary
- Adds a reference to `docs/common/LOCAL_DEV_SERVERS.md` in the Runtime Development section of AGENTS.md
- This ensures AI agents discover the existing local dev documentation and use `dev-local` instead of `dev` for shell

## Problem
When Claude Code starts local dev servers, it was using `deno task dev` (which points to remote `toolshed.saga-castor.ts.net`) instead of `deno task dev-local` (which points to `localhost:8000`).

The root cause: `AGENTS.md` didn't reference the existing `LOCAL_DEV_SERVERS.md` documentation.

## Test plan
- [ ] Verify AGENTS.md now includes the reference
- [ ] Future Claude Code sessions should read LOCAL_DEV_SERVERS.md and use correct commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a reference to docs/common/LOCAL_DEV_SERVERS.md in AGENTS.md to ensure local dev servers are started with deno task dev-local. This prevents using dev (remote toolshed) and keeps development on localhost:8000.

<sup>Written for commit c861dd64b7f44407d7c23f3a7ccd6a4577fc13fb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



