### PR TITLE
chore: Only support our latest deno version 2.5.2

### DIFF
--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-DENO_VERSIONS_ALLOWED=("2.5.2" "2.4.5")
+DENO_VERSIONS_ALLOWED=("2.5.2")
 # This is more portable than parsing `deno --version`
 DENO_VERSION=$(echo "console.log(Deno.version.deno)" | deno run -)
 if [[ ! " ${DENO_VERSIONS_ALLOWED[@]} " =~ " ${DENO_VERSION} " ]]; then


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restricts our tooling to Deno 2.5.2 by updating the version check to only allow that version. Local and CI checks will fail if another Deno version is used.

<sup>Written for commit 1ab0c6b97e93099421f0df10436a425239c3c4f7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



