### PR TITLE
Revert 6e979d0b0c021877882e8f3c13262073bcf36103

### DIFF
--- a/packages/charm/src/ops/charms-controller.ts
+++ b/packages/charm/src/ops/charms-controller.ts
@@ -29,14 +29,14 @@ export class CharmsController<T = unknown> {
     return this.#manager;
   }
 
-  async create<U = T>(
+  async create(
     program: RuntimeProgram | string,
     options: CreateCharmOptions = {},
     cause: string | undefined = undefined,
-  ): Promise<CharmController<U>> {
+  ): Promise<CharmController<T>> {
     this.disposeCheck();
     const recipe = await compileProgram(this.#manager, program);
-    const charm = await this.#manager.runPersistent<U>(
+    const charm = await this.#manager.runPersistent<T>(
       recipe,
       options.input,
       cause,
@@ -45,7 +45,7 @@ export class CharmsController<T = unknown> {
     );
     await this.#manager.runtime.idle();
     await this.#manager.synced();
-    return new CharmController<U>(this.#manager, charm);
+    return new CharmController<T>(this.#manager, charm);
   }
 
   async get<S extends JSONSchema = JSONSchema>(

--- a/packages/patterns/integration/counter.test.ts
+++ b/packages/patterns/integration/counter.test.ts
@@ -3,7 +3,7 @@ import { CharmController, CharmsController } from "@commontools/charm/ops";
 import { ShellIntegration } from "@commontools/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commontools/identity";
 import { FileSystemProgramResolver } from "@commontools/js-compiler";
 
@@ -50,16 +50,16 @@ describe("counter direct operations test", () => {
       identity,
     });
 
-    // Verify initial value is 0
-    await waitFor(async () => {
-      const counterResult = await page.waitForSelector("#counter-result", {
-        strategy: "pierce",
-      });
-      const initialText = await counterResult.evaluate((el: HTMLElement) =>
-        el.textContent
-      );
-      return initialText?.trim() === "Counter is the 0th number";
+    const counterResult = await page.waitForSelector("#counter-result", {
+      strategy: "pierce",
     });
+    assert(counterResult, "Should find counter-result element");
+
+    // Verify initial value is 0
+    const initialText = await counterResult.evaluate((el: HTMLElement) =>
+      el.textContent
+    );
+    assertEquals(initialText?.trim(), "Counter is the 0th number");
 
     assertEquals(charm.result.get(["value"]), 0);
   });
@@ -67,17 +67,15 @@ describe("counter direct operations test", () => {
   it("should update counter value via direct operation (live)", async () => {
     const page = shell.page();
 
-    await page.waitForSelector("#counter-result", {
+    // Get the counter result element
+    const counterResult = await page.waitForSelector("#counter-result", {
       strategy: "pierce",
     });
 
+    console.log("Setting counter value to 42 via direct operation");
     await charm.result.set(42, ["value"]);
 
     await waitFor(async () => {
-      const counterResult = await page.waitForSelector("#counter-result", {
-        strategy: "pierce",
-      });
-
       const updatedText = await counterResult.evaluate((el: HTMLElement) =>
         el.textContent
       );
@@ -107,15 +105,19 @@ describe("counter direct operations test", () => {
     });
 
     // Get the counter result element after refresh
-    await waitFor(async () => {
-      const counterResult = await page.waitForSelector("#counter-result", {
-        strategy: "pierce",
-      });
-
-      const textAfterRefresh = await counterResult.evaluate((el: HTMLElement) =>
-        el.textContent
-      );
-      return textAfterRefresh?.trim() === "Counter is the 42th number";
+    const counterResult = await page.waitForSelector("#counter-result", {
+      strategy: "pierce",
     });
+    assert(counterResult, "Should find counter-result element after refresh");
+
+    // Check if the UI shows the updated value after refresh
+    const textAfterRefresh = await counterResult.evaluate((el: HTMLElement) =>
+      el.textContent
+    );
+    assertEquals(
+      textAfterRefresh?.trim(),
+      "Counter is the 42th number",
+      "UI should show persisted value after refresh",
+    );
   });
 });

--- a/packages/patterns/integration/ct-checkbox.test.ts
+++ b/packages/patterns/integration/ct-checkbox.test.ts
@@ -1,7 +1,9 @@
-import { env, waitFor } from "@commontools/integration";
+import { env } from "@commontools/integration";
+import { sleep } from "@commontools/utils/sleep";
 import { ShellIntegration } from "@commontools/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
+import { assertEquals } from "@std/assert";
 import { Identity } from "@commontools/identity";
 import { CharmsController } from "@commontools/charm/ops";
 import { ANYONE_USER } from "@commontools/memory/acl";
@@ -65,62 +67,49 @@ testComponents.forEach(({ name, file }) => {
     it("should show disabled content initially", async () => {
       const page = shell.page();
 
-      await waitFor(async () => {
-        const featureStatus = await page.waitForSelector("#feature-status", {
-          strategy: "pierce",
-        });
-        const statusText = await featureStatus.evaluate((el: HTMLElement) =>
-          el.textContent
-        );
-        return statusText?.trim() === "⚠ Feature is disabled";
+      const featureStatus = await page.waitForSelector("#feature-status", {
+        strategy: "pierce",
       });
+      const statusText = await featureStatus.evaluate((el: HTMLElement) =>
+        el.textContent
+      );
+      assertEquals(statusText?.trim(), "⚠ Feature is disabled");
     });
 
     it("should toggle to enabled content when checkbox is clicked", async () => {
       const page = shell.page();
 
-      await waitFor(async () => {
-        const checkbox = await page.waitForSelector("ct-checkbox", {
-          strategy: "pierce",
-        });
-        // This could throw due to lacking a box model to click on.
-        // Catch in lieu of handling time sensitivity.
-        try {
-          await checkbox.click();
-        } catch (_) {
-          return false;
-        }
-        const featureStatus = await page.waitForSelector("#feature-status", {
-          strategy: "pierce",
-        });
-        const statusText = await featureStatus.evaluate((el: HTMLElement) =>
-          el.textContent
-        );
-        return statusText?.trim() === "✓ Feature is enabled!";
+      const checkbox = await page.waitForSelector("ct-checkbox", {
+        strategy: "pierce",
       });
+      await checkbox.click();
+      await sleep(500);
+
+      const featureStatus = await page.$("#feature-status", {
+        strategy: "pierce",
+      });
+      const statusText = await featureStatus?.evaluate((el: HTMLElement) =>
+        el.textContent
+      );
+      assertEquals(statusText?.trim(), "✓ Feature is enabled!");
     });
 
     it("should toggle back to disabled content when checkbox is clicked again", async () => {
       const page = shell.page();
-      await waitFor(async () => {
-        const checkbox = await page.waitForSelector("ct-checkbox", {
-          strategy: "pierce",
-        });
-        // This could throw due to lacking a box model to click on.
-        // Catch in lieu of handling time sensitivity.
-        try {
-          await checkbox.click();
-        } catch (_) {
-          return false;
-        }
-        const featureStatus = await page.waitForSelector("#feature-status", {
-          strategy: "pierce",
-        });
-        const statusText = await featureStatus.evaluate((el: HTMLElement) =>
-          el.textContent
-        );
-        return statusText?.trim() === "⚠ Feature is disabled";
+
+      const checkbox = await page.$("ct-checkbox", {
+        strategy: "pierce",
       });
+      await checkbox?.click();
+      await sleep(1000);
+
+      const featureStatus = await page.$("#feature-status", {
+        strategy: "pierce",
+      });
+      const statusText = await featureStatus?.evaluate((el: HTMLElement) =>
+        el.textContent
+      );
+      assertEquals(statusText?.trim(), "⚠ Feature is disabled");
     });
   });
 });

--- a/packages/patterns/integration/ct-list.test.ts
+++ b/packages/patterns/integration/ct-list.test.ts
@@ -1,11 +1,11 @@
-import { env, Page, waitFor } from "@commontools/integration";
+import { env } from "@commontools/integration";
+import { sleep } from "@commontools/utils/sleep";
 import { ShellIntegration } from "@commontools/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commontools/identity";
 import { CharmsController } from "@commontools/charm/ops";
-import { ElementHandle } from "@astral/astral";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
@@ -56,30 +56,102 @@ describe("ct-list integration test", () => {
 
   it("should add items to the list", async () => {
     const page = shell.page();
-    const list = new List(page);
 
-    await list.addItem("First item");
-    await list.waitForItemCount(1);
+    // Find the add item input in ct-list
+    const addInput = await page.waitForSelector(".add-item-input", {
+      strategy: "pierce",
+    });
 
-    await list.addItem("Second item");
-    await list.waitForItemCount(2);
+    // Add first item
+    await addInput.click();
+    await addInput.type("First item");
+    await page.keyboard.press("Enter");
+    await sleep(50); // Quick wait for DOM update
 
-    await list.addItem("Third item");
-    await list.waitForItemCount(3);
+    // Add second item - the input should be cleared automatically
+    await addInput.type("Second item");
+    await page.keyboard.press("Enter");
+    await sleep(50); // Quick wait for DOM update
 
-    assertEquals(await list.getItemsText(), [
-      "First item",
-      "Second item",
-      "Third item",
-    ]);
+    // Add third item
+    await addInput.type("Third item");
+    await page.keyboard.press("Enter");
+    await sleep(50); // Quick wait for DOM update
+
+    // Verify items were added
+    const listItems = await page.$$(".list-item", { strategy: "pierce" });
+    assertEquals(listItems.length, 3, "Should have 3 items in the list");
+
+    // Debug: Log the structure of list items
+    console.log("List item structure:");
+    for (let i = 0; i < listItems.length; i++) {
+      const itemInfo = await listItems[i].evaluate(
+        (el: HTMLElement, idx: number) => {
+          const buttons = el.querySelectorAll("button");
+          return {
+            index: idx,
+            className: el.className,
+            innerText: el.innerText,
+            buttonCount: buttons.length,
+            buttons: Array.from(buttons).map((b) => ({
+              className: b.className,
+              title: b.title || "no title",
+              innerText: b.innerText,
+            })),
+          };
+        },
+        { args: [i] } as any,
+      );
+      console.log(`Item ${i}:`, itemInfo);
+    }
+
+    // Quick wait for content to render
+    await sleep(100);
+
+    // Verify item content
+    const firstItemText = await listItems[0].evaluate((el: HTMLElement) => {
+      const content = el.querySelector(".item-content") ||
+        el.querySelector("div.item-content");
+      return content?.textContent || el.textContent;
+    });
+    assertEquals(firstItemText?.trim(), "First item");
+
+    const secondItemText = await listItems[1].evaluate((el: HTMLElement) => {
+      const content = el.querySelector(".item-content") ||
+        el.querySelector("div.item-content");
+      return content?.textContent || el.textContent;
+    });
+    assertEquals(secondItemText?.trim(), "Second item");
+
+    const thirdItemText = await listItems[2].evaluate((el: HTMLElement) => {
+      const content = el.querySelector(".item-content") ||
+        el.querySelector("div.item-content");
+      return content?.textContent || el.textContent;
+    });
+    assertEquals(thirdItemText?.trim(), "Third item");
   });
 
   it("should update the list title", async () => {
     const page = shell.page();
-    const list = new List(page);
 
-    await list.setTitle("My Shopping List");
-    assertEquals(await list.getTitle(), "My Shopping List");
+    // Find the title input
+    const titleInput = await page.$("input[placeholder='List title']", {
+      strategy: "pierce",
+    });
+    assert(titleInput, "Should find title input");
+
+    // Clear the existing text first
+    await titleInput.click();
+    await titleInput.evaluate((el: HTMLInputElement) => {
+      el.select(); // Select all text
+    });
+    await titleInput.type("My Shopping List");
+
+    // Verify title was updated (no wait needed for input value)
+    const titleValue = await titleInput.evaluate((el: HTMLInputElement) =>
+      el.value
+    );
+    assertEquals(titleValue, "My Shopping List");
   });
 
   // TODO(#CT-703): Fix this test - there's a bug where programmatic clicks on the remove button
@@ -88,85 +160,142 @@ describe("ct-list integration test", () => {
   // versus real user clicks.
   it("should remove items from the list", async () => {
     const page = shell.page();
-    const list = new List(page);
 
-    const items = await list.getItems();
-    assert(items.length > 0, "Should have items to remove");
-    const initialCount = items.length;
+    console.log("Waiting for component to stabilize...");
+    await sleep(500);
 
-    await list.removeItem(items[0]);
-    await list.waitForItemCount(initialCount - 1);
+    // Get initial count
+    const initialItems = await page.$$(".list-item", { strategy: "pierce" });
+    const initialCount = initialItems.length;
+    console.log(`Initial item count: ${initialCount}`);
+    assert(initialCount > 0, "Should have items to remove");
 
-    assertEquals(await list.getItemsText(), [
-      "Second item",
-      "Third item",
-    ]);
+    // Find and click the first remove button
+    const removeButtons = await page.$$("button.item-action.remove", {
+      strategy: "pierce",
+    });
+    console.log(`Found ${removeButtons.length} remove buttons`);
+    assert(removeButtons.length > 0, "Should find remove buttons");
+
+    // Debug: check what we're about to click
+    const buttonText = await removeButtons[0].evaluate((el: HTMLElement) => {
+      return {
+        className: el.className,
+        title: el.title,
+        innerText: el.innerText,
+        parentText: el.parentElement?.innerText || "no parent",
+      };
+    });
+    console.log("About to click button:", buttonText);
+
+    // Try clicking more carefully
+    console.log("Waiting before click...");
+    await sleep(100);
+
+    // Alternative approach: dispatch click event
+    await removeButtons[0].evaluate((button: HTMLElement) => {
+      console.log("About to dispatch click event on button:", button);
+      button.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        }),
+      );
+    });
+    console.log("Dispatched click event on first remove button");
+
+    // Check immediately after click
+    await sleep(50);
+    const immediateItems = await page.$$(".list-item", { strategy: "pierce" });
+    console.log(
+      `Immediately after click, found ${immediateItems.length} items`,
+    );
+
+    // Wait for DOM to update after removal using Astral's waitForFunction
+    await page.waitForFunction((expectedCount) => {
+      const items = document.querySelectorAll(".list-item");
+      return items.length !== expectedCount;
+    }, { args: [initialCount] });
+
+    // Verify item was removed - try multiple times
+    let remainingItems = await page.$$(".list-item", { strategy: "pierce" });
+    console.log(`After removal, found ${remainingItems.length} items`);
+
+    // If still showing same count, wait a bit more and try again
+    if (remainingItems.length === initialCount) {
+      console.log("DOM not updated yet, waiting more...");
+      await sleep(500);
+      remainingItems = await page.$$(".list-item", { strategy: "pierce" });
+      console.log(
+        `After additional wait, found ${remainingItems.length} items`,
+      );
+    }
+
+    assertEquals(
+      remainingItems.length,
+      initialCount - 1,
+      "Should have one less item after removal",
+    );
+
+    // Verify the first item is now what was the second item
+    if (remainingItems.length > 0) {
+      const firstRemainingText = await remainingItems[0].evaluate(
+        (el: HTMLElement) => {
+          const content = el.querySelector(".item-content") ||
+            el.querySelector("div.item-content");
+          return content?.textContent || el.textContent;
+        },
+      );
+      assertEquals(
+        firstRemainingText?.trim(),
+        "Second item",
+        "First item should now be the second item",
+      );
+    }
   });
 
   it("should edit items in the list", async () => {
     const page = shell.page();
-    const list = new List(page);
 
-    const items = await list.getItems();
-    assert(items.length > 0, "Should have items to edit");
+    console.log("Waiting for component to stabilize...");
+    await sleep(500);
 
-    const newText = "Edited Second Item";
-    await list.editItem(items[0], newText);
-    await waitFor(() =>
-      list.getItems().then((els) => list.getItemText(els[0])).then((text) =>
-        text === newText
-      )
-    );
+    // Get initial items
+    const initialItems = await page.$$(".list-item", { strategy: "pierce" });
+    const initialCount = initialItems.length;
+    console.log(`Initial item count: ${initialCount}`);
+    assert(initialCount > 0, "Should have items to edit");
 
-    assertEquals(await list.getItemsText(), [
-      "Edited Second Item",
-      "Third item",
-    ]);
-  });
-});
-
-class List {
-  #page: Page;
-  constructor(page: Page) {
-    this.#page = page;
-  }
-
-  getItems(): Promise<ElementHandle[]> {
-    return this.#page.$$(".list-item", { strategy: "pierce" });
-  }
-
-  async getItemsText(): Promise<Array<string | undefined>> {
-    const elements = await this.getItems();
-    return Promise.all(elements.map((el) => this.getItemText(el)));
-  }
-
-  async getItemText(element: ElementHandle): Promise<string | undefined> {
-    return await element.evaluate((el: HTMLElement) => {
+    // Get the initial text of the first item
+    const initialText = await initialItems[0].evaluate((el: HTMLElement) => {
       const content = el.querySelector(".item-content") ||
         el.querySelector("div.item-content");
-      return (content?.textContent || el.textContent)?.trim();
+      return content?.textContent || el.textContent;
     });
-  }
+    console.log(`Initial text of first item: "${initialText?.trim()}"`);
 
-  async waitForItemCount(expected: number): Promise<void> {
-    await waitFor(() => this.getItems().then((els) => els.length === expected));
-  }
-
-  async addItem(text: string): Promise<void> {
-    const addInput = await this.#page.waitForSelector(".add-item-input", {
+    // Find and click the first edit button
+    const editButtons = await page.$$("button.item-action.edit", {
       strategy: "pierce",
     });
-    await addInput.click();
-    await addInput.type(text);
-    await this.#page.keyboard.press("Enter");
-  }
+    console.log(`Found ${editButtons.length} edit buttons`);
+    assert(editButtons.length > 0, "Should find edit buttons");
 
-  async removeItem(element: ElementHandle): Promise<void> {
-    // Find the remove button within this item
-    const removeButton = await element.$("button.item-action.remove");
-    assert(removeButton, "Should find remove button in item");
+    // Debug: check what we're about to click
+    const buttonText = await editButtons[0].evaluate((el: HTMLElement) => {
+      return {
+        className: el.className,
+        title: el.title,
+        innerText: el.innerText,
+        parentText: el.parentElement?.innerText || "no parent",
+      };
+    });
+    console.log("About to click edit button:", buttonText);
 
-    await removeButton.evaluate((button: HTMLElement) => {
+    // Click the edit button to enter edit mode
+    await editButtons[0].evaluate((button: HTMLElement) => {
+      console.log("About to dispatch click event on edit button:", button);
       button.dispatchEvent(
         new MouseEvent("click", {
           bubbles: true,
@@ -175,56 +304,59 @@ class List {
         }),
       );
     });
-  }
+    console.log("Dispatched click event on first edit button");
 
-  async editItem(element: ElementHandle, newText: string): Promise<void> {
-    // Find the edit button within this item
-    const editButton = await element.$("button.item-action.edit");
-    assert(editButton, "Should find edit button in item");
+    // Wait for edit mode to activate and look for the editing state
+    await page.waitForSelector(".list-item.editing", { strategy: "pierce" });
+    console.log("Edit mode activated - found .list-item.editing");
 
-    await editButton.evaluate((button: HTMLElement) => {
-      button.dispatchEvent(
-        new MouseEvent("click", {
-          bubbles: true,
-          cancelable: true,
-          view: window,
-        }),
-      );
-    });
-
-    // Wait for edit mode to activate
-    await this.#page.waitForSelector(".list-item.editing", {
+    // Look for the specific edit input field that appears only during editing
+    const editInput = await page.$(".edit-input", {
       strategy: "pierce",
     });
+    assert(editInput, "Should find .edit-input field during editing");
 
-    // Find the edit input and type new text
-    const editInput = await this.#page.waitForSelector(".edit-input", {
-      strategy: "pierce",
-    });
+    // Verify the input is focused (it should have autofocus)
+    const isFocused = await editInput.evaluate((el: HTMLInputElement) =>
+      document.activeElement === el
+    );
+    console.log(`Edit input is focused: ${isFocused}`);
+
+    // Clear the existing text and type new text
     await editInput.evaluate((el: HTMLInputElement) => {
-      el.select();
+      el.select(); // Select all text
     });
+    const newText = "Edited First Item";
     await editInput.type(newText);
-    await this.#page.keyboard.press("Enter");
-  }
+    console.log(`Typed new text: "${newText}"`);
 
-  async setTitle(title: string): Promise<void> {
-    const titleInput = await this.#page.waitForSelector(
-      "input[placeholder='List title']",
-      { strategy: "pierce" },
+    // Press Enter to confirm the edit
+    await page.keyboard.press("Enter");
+    console.log("Pressed Enter to confirm edit");
+
+    // Wait for the edit to be processed
+    await sleep(200);
+
+    // Verify the item was edited
+    const updatedItems = await page.$$(".list-item", { strategy: "pierce" });
+    assertEquals(
+      updatedItems.length,
+      initialCount,
+      "Should have same number of items after edit",
     );
-    await titleInput.click();
-    await titleInput.evaluate((el: HTMLInputElement) => {
-      el.select();
+
+    // Check that the first item's text has been updated
+    const updatedText = await updatedItems[0].evaluate((el: HTMLElement) => {
+      const content = el.querySelector(".item-content") ||
+        el.querySelector("div.item-content");
+      return content?.textContent || el.textContent;
     });
-    await titleInput.type(title);
-  }
+    console.log(`Updated text of first item: "${updatedText?.trim()}"`);
 
-  async getTitle(): Promise<string> {
-    const titleInput = await this.#page.waitForSelector(
-      "input[placeholder='List title']",
-      { strategy: "pierce" },
+    assertEquals(
+      updatedText?.trim(),
+      newText,
+      "First item should have updated text",
     );
-    return await titleInput.evaluate((el: HTMLInputElement) => el.value);
-  }
-}
+  });
+});

--- a/packages/patterns/integration/ct-render.test.ts
+++ b/packages/patterns/integration/ct-render.test.ts
@@ -51,15 +51,16 @@ describe("ct-render integration test", () => {
       identity,
     });
 
-    await waitFor(async () => {
-      const counterResult = await page.waitForSelector("#counter-result", {
-        strategy: "pierce",
-      });
-      const initialText = await counterResult.evaluate((el: HTMLElement) =>
-        el.textContent
-      );
-      return initialText?.trim() === "Counter is the 0th number";
+    const counterResult = await page.waitForSelector("#counter-result", {
+      strategy: "pierce",
     });
+    assert(counterResult, "Should find counter-result element");
+
+    // Verify initial value is 0
+    const initialText = await counterResult.evaluate((el: HTMLElement) =>
+      el.textContent
+    );
+    assertEquals(initialText?.trim(), "Counter is the 0th number");
 
     // Verify via direct operations that the ct-render structure works
     const value = charm.result.get(["value"]);
@@ -106,16 +107,18 @@ describe("ct-render integration test", () => {
       identity,
     });
 
-    await waitFor(async () => {
-      const counterResult = await page.waitForSelector("#counter-result", {
-        strategy: "pierce",
-      });
-      const textAfterUpdate = await counterResult.evaluate((el: HTMLElement) =>
-        el.textContent
-      );
-      return textAfterUpdate?.trim() ===
-        "Counter is the 5th number";
+    // Check if the UI shows the updated value
+    const counterResult = await page.waitForSelector("#counter-result", {
+      strategy: "pierce",
     });
+    const textAfterUpdate = await counterResult.evaluate((el: HTMLElement) =>
+      el.textContent
+    );
+    assertEquals(
+      textAfterUpdate?.trim(),
+      "Counter is the 5th number",
+      "UI should show updated value from direct operation",
+    );
   });
 
   it("should verify only ONE counter display", async () => {

--- a/packages/patterns/integration/ct-tags.test.ts
+++ b/packages/patterns/integration/ct-tags.test.ts
@@ -1,12 +1,11 @@
-import { env, Page, waitFor } from "@commontools/integration";
+import { env } from "@commontools/integration";
 import { sleep } from "@commontools/utils/sleep";
 import { ShellIntegration } from "@commontools/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commontools/identity";
 import { CharmsController } from "@commontools/charm/ops";
-import { ElementHandle } from "@astral/astral";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
@@ -57,188 +56,212 @@ describe("ct-tags integration test", () => {
 
   it("should add tags to the list", async () => {
     const page = shell.page();
-    const tags = new Tags(page);
-    await tags.addTag("frontend");
-    await tags.waitForTagCount(1);
-    await tags.addTag("javascript");
-    await tags.waitForTagCount(2);
-    await tags.addTag("testing");
-    await tags.waitForTagCount(3);
-    assertEquals(await tags.getTagsText(), [
-      "frontend",
-      "javascript",
-      "testing",
-    ]);
+
+    // Helper function to add a tag
+    const addTag = async (tagText: string) => {
+      // Find the add tag button
+      const addTagButton = await page.waitForSelector(".add-tag", {
+        strategy: "pierce",
+      });
+
+      // Click using evaluate to ensure it works
+      await addTagButton.evaluate((el: HTMLElement) => {
+        el.click();
+      });
+      await sleep(100); // Wait for input to appear
+
+      const addInput = await page.waitForSelector(".add-tag-input", {
+        strategy: "pierce",
+      });
+      await addInput.type(tagText);
+      await page.keyboard.press("Enter");
+      await sleep(100); // Wait for DOM update
+    };
+
+    // Add first tag
+    await addTag("frontend");
+
+    // Add second tag
+    await addTag("javascript");
+
+    // Add third tag
+    await addTag("testing");
+
+    // Verify tags were added
+    const tags = await page.$$(".tag", { strategy: "pierce" });
+    assertEquals(tags.length, 3, "Should have 3 tags");
+
+    // Debug: Log the structure of tags
+    console.log("Tag structure:");
+    for (let i = 0; i < tags.length; i++) {
+      const tagInfo = await tags[i].evaluate(
+        (el: HTMLElement, idx: number) => {
+          const tagText = el.querySelector(".tag-text");
+          const removeButton = el.querySelector(".tag-remove");
+          return {
+            index: idx,
+            className: el.className,
+            tagText: tagText?.textContent || "no text",
+            hasRemoveButton: !!removeButton,
+          };
+        },
+        { args: [i] } as any,
+      );
+      console.log(`Tag ${i}:`, tagInfo);
+    }
+
+    // Verify tag content
+    const firstTagText = await tags[0].evaluate((el: HTMLElement) => {
+      const tagText = el.querySelector(".tag-text");
+      return tagText?.textContent || el.textContent;
+    });
+    assertEquals(firstTagText?.trim(), "frontend");
+
+    const secondTagText = await tags[1].evaluate((el: HTMLElement) => {
+      const tagText = el.querySelector(".tag-text");
+      return tagText?.textContent || el.textContent;
+    });
+    assertEquals(secondTagText?.trim(), "javascript");
+
+    const thirdTagText = await tags[2].evaluate((el: HTMLElement) => {
+      const tagText = el.querySelector(".tag-text");
+      return tagText?.textContent || el.textContent;
+    });
+    assertEquals(thirdTagText?.trim(), "testing");
   });
 
   it("should not add duplicate tags", async () => {
     const page = shell.page();
-    const tags = new Tags(page);
-    assertEquals((await tags.getTags()).length, 3);
+
+    // Helper function to add a tag
+    const addTag = async (tagText: string) => {
+      const addTagButton = await page.waitForSelector(".add-tag", {
+        strategy: "pierce",
+      });
+
+      await addTagButton.evaluate((el: HTMLElement) => {
+        el.click();
+      });
+      await sleep(100);
+
+      const addInput = await page.waitForSelector(".add-tag-input", {
+        strategy: "pierce",
+      });
+      await addInput.type(tagText);
+      await page.keyboard.press("Enter");
+      await sleep(100);
+    };
 
     // Try to add a duplicate tag
-    await tags.addTag("frontend");
-    await tags.waitForTagCount(3);
-    assertEquals(await tags.getTagsText(), [
-      "frontend",
-      "javascript",
-      "testing",
-    ]);
+    await addTag("frontend"); // This already exists
+
+    // Should still have 3 tags, not 4
+    const tags = await page.$$(".tag", { strategy: "pierce" });
+    assertEquals(tags.length, 3, "Should still have 3 tags (no duplicates)");
   });
 
   it("should edit tags", async () => {
     const page = shell.page();
-    const tags = new Tags(page);
-    assertEquals(
-      (await tags.getTags()).length,
-      3,
-      "Should still have 3 tags (no duplicates)",
-    );
 
-    const newText = "backend";
-    const tagEls = await tags.getTags();
-    await tags.editTag(tagEls[0], newText);
-    await waitFor(() =>
-      tags.getTags().then((els) => tags.getTagText(els[0])).then((text) =>
-        text === newText
-      )
-    );
-    assertEquals(await tags.getTagsText(), [
-      "backend",
-      "javascript",
-      "testing",
-    ]);
-  });
+    console.log("Waiting for component to stabilize...");
+    await sleep(500);
 
-  it("should remove tags", async () => {
-    const page = shell.page();
-    const tags = new Tags(page);
-    assertEquals((await tags.getTags()).length, 3);
-    const elements = await tags.getTags();
-    await tags.removeTag(elements[0]);
-    await tags.waitForTagCount(2);
-    assertEquals(await tags.getTagsText(), [
-      "javascript",
-      "testing",
-    ]);
-  });
+    // Get initial tags
+    const initialTags = await page.$$(".tag", { strategy: "pierce" });
+    const initialCount = initialTags.length;
+    console.log(`Initial tag count: ${initialCount}`);
+    assert(initialCount > 0, "Should have tags to edit");
 
-  it("should cancel tag editing with Escape key", async () => {
-    const page = shell.page();
-    const tags = new Tags(page);
-    assertEquals((await tags.getTags()).length, 2);
-    const originalTexts = await tags.getTagsText();
+    // Click on the first tag to edit it
+    await initialTags[0].click();
+    console.log("Clicked on first tag");
 
-    const elements = await tags.getTags();
-    const element = elements[0];
-    await element.click();
+    // Wait for edit mode to activate
     await page.waitForSelector(".tag.editing", { strategy: "pierce" });
-    const editInput = await page.waitForSelector(".tag-input", {
-      strategy: "pierce",
-    });
-    await editInput.evaluate((el: HTMLInputElement) => el.select());
-    await editInput.type("should-be-cancelled");
-    await page.keyboard.press("Escape");
-    await sleep(100);
-    assertEquals(await tags.getTagsText(), originalTexts);
-  });
+    console.log("Edit mode activated - found .tag.editing");
 
-  it("should delete empty tags when backspacing", async () => {
-    const page = shell.page();
-    const tags = new Tags(page);
-    assertEquals((await tags.getTags()).length, 2);
-
-    const elements = await tags.getTags();
-    const element = elements[0];
-    await element.click();
-    await page.waitForSelector(".tag.editing", { strategy: "pierce" });
-    const editInput = await page.waitForSelector(".tag-input", {
-      strategy: "pierce",
-    });
-    await editInput.evaluate((el: HTMLInputElement) => el.select());
-    await page.keyboard.press("Delete");
-    await sleep(50); // Wait for input to be cleared
-    // Press Backspace on empty input
-    await page.keyboard.press("Backspace");
-    await sleep(200);
-
-    await tags.waitForTagCount(1);
-  });
-});
-
-class Tags {
-  #page: Page;
-  constructor(page: Page) {
-    this.#page = page;
-  }
-
-  getTags(): Promise<ElementHandle[]> {
-    return this.#page.$$(".tag", { strategy: "pierce" });
-  }
-
-  async getTagsText(): Promise<Array<string | undefined>> {
-    const elements = await this.getTags();
-    return Promise.all(elements.map((el) => this.getTagText(el)));
-  }
-
-  async editTag(element: ElementHandle, newText: string) {
-    await element.click();
-    await this.#page.waitForSelector(".tag.editing", { strategy: "pierce" });
     // Look for the tag input field that appears during editing
-    const editInput = await this.#page.waitForSelector(".tag-input", {
+    const editInput = await page.waitForSelector(".tag-input", {
       strategy: "pierce",
     });
+    assert(editInput, "Should find .tag-input field during editing");
 
     // Clear and type new text
     await editInput.evaluate((el: HTMLInputElement) => {
       el.select(); // Select all text
     });
+    const newText = "backend";
     await editInput.type(newText);
-    await this.#page.keyboard.press("Enter");
-  }
+    console.log(`Typed new text: "${newText}"`);
 
-  async waitForTagCount(expected: number): Promise<void> {
-    await waitFor(() => this.getTags().then((els) => els.length === expected));
-  }
+    // Press Enter to confirm the edit
+    await page.keyboard.press("Enter");
+    console.log("Pressed Enter to confirm edit");
 
-  async waitForTagText(element: ElementHandle, text: string): Promise<void> {
-    await waitFor(() =>
-      element.evaluate((el: HTMLInputElement) => el.value).then((value) =>
-        value === text
-      )
+    // Wait for the edit to be processed
+    await sleep(200);
+
+    // Verify the tag was edited
+    const updatedTags = await page.$$(".tag", { strategy: "pierce" });
+    assertEquals(
+      updatedTags.length,
+      initialCount,
+      "Should have same number of tags after edit",
     );
-  }
 
-  async getTagText(element: ElementHandle): Promise<string | undefined> {
-    return await element.evaluate((el: HTMLElement) => {
+    // Check that the first tag's text has been updated
+    const updatedText = await updatedTags[0].evaluate((el: HTMLElement) => {
       const tagText = el.querySelector(".tag-text");
       return tagText?.textContent || el.textContent;
     });
-  }
+    console.log(`Updated text of first tag: "${updatedText?.trim()}"`);
 
-  async addTag(text: string) {
-    const addTagButton = await this.#page.waitForSelector(".add-tag", {
-      strategy: "pierce",
-    });
-    await addTagButton.click();
-    const addInput = await this.#page.waitForSelector(".add-tag-input", {
-      strategy: "pierce",
-    });
-    await addInput.type(text);
-    await this.#page.keyboard.press("Enter");
-  }
+    assertEquals(
+      updatedText?.trim(),
+      newText,
+      "First tag should have updated text",
+    );
+  });
 
-  async removeTag(element: ElementHandle): Promise<void> {
+  it("should remove tags", async () => {
+    const page = shell.page();
+
+    console.log("Waiting for component to stabilize...");
+    await sleep(500);
+
+    // Get initial count
+    const initialTags = await page.$$(".tag", { strategy: "pierce" });
+    const initialCount = initialTags.length;
+    console.log(`Initial tag count: ${initialCount}`);
+    assert(initialCount > 0, "Should have tags to remove");
+
     // Hover over the first tag to make the remove button visible
-    await element.evaluate((el: HTMLElement) => {
+    await initialTags[0].evaluate((el: HTMLElement) => {
       el.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
     });
+    await sleep(100); // Wait for hover effect
 
     // Find and click the first remove button
-    const removeButtons = await this.#page.waitForSelector(".tag-remove", {
+    const removeButtons = await page.$$(".tag-remove", {
       strategy: "pierce",
     });
-    await removeButtons.evaluate((button: HTMLElement) => {
+    console.log(`Found ${removeButtons.length} remove buttons`);
+    assert(removeButtons.length > 0, "Should find remove buttons");
+
+    // Debug: check what we're about to click
+    const buttonInfo = await removeButtons[0].evaluate((el: HTMLElement) => {
+      return {
+        className: el.className,
+        title: el.title,
+        innerText: el.innerText,
+        parentText: el.parentElement?.innerText || "no parent",
+      };
+    });
+    console.log("About to click remove button:", buttonInfo);
+
+    // Click the remove button
+    await removeButtons[0].evaluate((button: HTMLElement) => {
+      console.log("About to dispatch click event on remove button:", button);
       button.dispatchEvent(
         new MouseEvent("click", {
           bubbles: true,
@@ -247,5 +270,175 @@ class Tags {
         }),
       );
     });
-  }
-}
+    console.log("Dispatched click event on first remove button");
+
+    // Wait for DOM to update after removal
+    await sleep(200);
+
+    // Verify tag was removed
+    const remainingTags = await page.$$(".tag", { strategy: "pierce" });
+    console.log(`After removal, found ${remainingTags.length} tags`);
+
+    assertEquals(
+      remainingTags.length,
+      initialCount - 1,
+      "Should have one less tag after removal",
+    );
+
+    // Verify the first tag is now what was the second tag
+    if (remainingTags.length > 0) {
+      const firstRemainingText = await remainingTags[0].evaluate(
+        (el: HTMLElement) => {
+          const tagText = el.querySelector(".tag-text");
+          return tagText?.textContent || el.textContent;
+        },
+      );
+      assertEquals(
+        firstRemainingText?.trim(),
+        "javascript",
+        "First tag should now be the second tag",
+      );
+    }
+  });
+
+  it("should cancel tag editing with Escape key", async () => {
+    const page = shell.page();
+
+    console.log("Waiting for component to stabilize...");
+    await sleep(500);
+
+    // Helper function to add a tag if needed
+    const addTag = async (tagText: string) => {
+      const addTagButton = await page.waitForSelector(".add-tag", {
+        strategy: "pierce",
+      });
+
+      await addTagButton.evaluate((el: HTMLElement) => {
+        el.click();
+      });
+      await sleep(100);
+
+      const addInput = await page.waitForSelector(".add-tag-input", {
+        strategy: "pierce",
+      });
+      await addInput.type(tagText);
+      await page.keyboard.press("Enter");
+      await sleep(100);
+    };
+
+    let tags = await page.$$(".tag", { strategy: "pierce" });
+
+    // Add a tag if none exist
+    if (tags.length === 0) {
+      await addTag("test-tag");
+      tags = await page.$$(".tag", { strategy: "pierce" });
+    }
+
+    assert(tags.length > 0, "Should have tags to test escape behavior");
+
+    // Get the original text of the first tag
+    const originalText = await tags[0].evaluate((el: HTMLElement) => {
+      const tagText = el.querySelector(".tag-text");
+      return tagText?.textContent || el.textContent;
+    });
+
+    // Click on the first tag to edit it
+    await tags[0].click();
+
+    // Wait for edit mode
+    await page.waitForSelector(".tag.editing", { strategy: "pierce" });
+
+    // Find the edit input and type some text
+    const editInput = await page.waitForSelector(".tag-input", {
+      strategy: "pierce",
+    });
+    await editInput.evaluate((el: HTMLInputElement) => {
+      el.select();
+    });
+    await editInput.type("should-be-cancelled");
+
+    // Press Escape to cancel
+    await page.keyboard.press("Escape");
+    await sleep(100);
+
+    // Verify the edit was cancelled and original text is preserved
+    const updatedTags = await page.$$(".tag", { strategy: "pierce" });
+    const currentText = await updatedTags[0].evaluate((el: HTMLElement) => {
+      const tagText = el.querySelector(".tag-text");
+      return tagText?.textContent || el.textContent;
+    });
+
+    assertEquals(
+      currentText?.trim(),
+      originalText?.trim(),
+      "Tag text should be unchanged after Escape",
+    );
+  });
+
+  it("should delete empty tags when backspacing", async () => {
+    const page = shell.page();
+
+    console.log("Waiting for component to stabilize...");
+    await sleep(500);
+
+    // Helper function to add a tag if needed
+    const addTag = async (tagText: string) => {
+      const addTagButton = await page.waitForSelector(".add-tag", {
+        strategy: "pierce",
+      });
+
+      await addTagButton.evaluate((el: HTMLElement) => {
+        el.click();
+      });
+      await sleep(100);
+
+      const addInput = await page.waitForSelector(".add-tag-input", {
+        strategy: "pierce",
+      });
+      await addInput.type(tagText);
+      await page.keyboard.press("Enter");
+      await sleep(100);
+    };
+
+    // Get initial count
+    let initialTags = await page.$$(".tag", { strategy: "pierce" });
+
+    // Add a tag if none exist
+    if (initialTags.length === 0) {
+      await addTag("test-tag");
+      initialTags = await page.$$(".tag", { strategy: "pierce" });
+    }
+
+    const initialCount = initialTags.length;
+
+    // Click on the first tag to edit it
+    await initialTags[0].click();
+
+    // Wait for edit mode
+    await page.waitForSelector(".tag.editing", { strategy: "pierce" });
+
+    // Find the edit input and clear all text using keyboard
+    const editInput = await page.waitForSelector(".tag-input", {
+      strategy: "pierce",
+    });
+
+    // Select all text and delete it
+    await editInput.evaluate((el: HTMLInputElement) => {
+      el.select();
+    });
+    await page.keyboard.press("Delete");
+    await sleep(50); // Wait for input to be cleared
+
+    // Press Backspace on empty input
+    await page.keyboard.press("Backspace");
+    await sleep(200);
+
+    // Verify the tag was removed
+    const remainingTags = await page.$$(".tag", { strategy: "pierce" });
+    assertEquals(
+      remainingTags.length,
+      initialCount - 1,
+      "Should have one less tag after backspacing empty tag",
+    );
+  });
+});

--- a/packages/patterns/integration/instantiate-recipe.test.ts
+++ b/packages/patterns/integration/instantiate-recipe.test.ts
@@ -9,9 +9,6 @@ import { CharmsController } from "@commontools/charm/ops";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 
-// TODO(CT-1101) Need to re-enable these tests to make them more robust
-const ignore = true;
-
 describe("instantiate-recipe integration test", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
@@ -44,65 +41,61 @@ describe("instantiate-recipe integration test", () => {
     if (cc) await cc.dispose();
   });
 
-  it({
-    name: "should deploy recipe, click button, and navigate to counter",
-    ignore,
-    fn: async () => {
-      const page = shell.page();
+  it("should deploy recipe, click button, and navigate to counter", async () => {
+    const page = shell.page();
 
-      await shell.goto({
-        frontendUrl: FRONTEND_URL,
-        view: {
-          spaceName: SPACE_NAME,
-          charmId,
-        },
-        identity,
-      });
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: {
+        spaceName: SPACE_NAME,
+        charmId,
+      },
+      identity,
+    });
 
-      // Wait for charm to load by waiting for first interactive element
-      await page.waitForSelector("[data-ct-input]", { strategy: "pierce" });
+    // Wait for charm to load by waiting for first interactive element
+    await page.waitForSelector("[data-ct-input]", { strategy: "pierce" });
 
-      // Store the current URL before any action
-      const urlBefore = await page.evaluate(() => globalThis.location.href);
-      console.log("URL before action:", urlBefore);
+    // Store the current URL before any action
+    const urlBefore = await page.evaluate(() => globalThis.location.href);
+    console.log("URL before action:", urlBefore);
 
-      const input = await page.waitForSelector("[data-ct-input]", {
-        strategy: "pierce",
-      });
+    const input = await page.waitForSelector("[data-ct-input]", {
+      strategy: "pierce",
+    });
 
-      await input.type("New counter");
+    await input.type("New counter");
 
-      // Quick wait for input processing
-      await sleep(100);
+    // Quick wait for input processing
+    await sleep(100);
 
-      const button = await page.waitForSelector("[data-ct-button]", {
-        strategy: "pierce",
-      });
+    const button = await page.waitForSelector("[data-ct-button]", {
+      strategy: "pierce",
+    });
 
-      await button.click();
+    await button.click();
 
-      // Wait for page to soft navigate
-      await page.waitForFunction((urlBefore) => {
-        return globalThis.location.href !== urlBefore;
-      }, { args: [urlBefore] });
+    // Wait for page to soft navigate
+    await page.waitForFunction((urlBefore) => {
+      return globalThis.location.href !== urlBefore;
+    }, { args: [urlBefore] });
 
-      const urlAfter = await page.evaluate(() => globalThis.location.href);
-      console.log("URL after clicking:", urlAfter);
+    const urlAfter = await page.evaluate(() => globalThis.location.href);
+    console.log("URL after clicking:", urlAfter);
 
-      // Verify navigation happened (URL should have changed)
-      assert(
-        urlBefore !== urlAfter,
-        "Should navigate to a new URL after clicking Add button",
-      );
+    // Verify navigation happened (URL should have changed)
+    assert(
+      urlBefore !== urlAfter,
+      "Should navigate to a new URL after clicking Add button",
+    );
 
-      // Verify we're now on a counter page by checking for counter-specific elements
-      const counterResult = await page.waitForSelector("#counter-result", {
-        strategy: "pierce",
-      });
-      assert(
-        counterResult,
-        "Should find counter-result element after navigation",
-      );
-    },
+    // Verify we're now on a counter page by checking for counter-specific elements
+    const counterResult = await page.waitForSelector("#counter-result", {
+      strategy: "pierce",
+    });
+    assert(
+      counterResult,
+      "Should find counter-result element after navigation",
+    );
   });
 });

--- a/packages/patterns/integration/list-operations.test.ts
+++ b/packages/patterns/integration/list-operations.test.ts
@@ -3,7 +3,7 @@ import { CharmController, CharmsController } from "@commontools/charm/ops";
 import { ShellIntegration } from "@commontools/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commontools/identity";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
@@ -54,27 +54,23 @@ describe("list-operations simple test", () => {
     await page.waitForSelector("#main-list", { strategy: "pierce" });
 
     // Click reset to populate with initial data
-    const resetBtn = await page.waitForSelector("#reset-demo", {
-      strategy: "pierce",
-    });
+    const resetBtn = await page.$("#reset-demo", { strategy: "pierce" });
+    assert(resetBtn, "Should find reset button");
     await resetBtn.click();
 
     // Wait for the reset operation to complete by checking the text content
+    const mainList = await page.$("#main-list", { strategy: "pierce" });
+    assert(mainList, "Should find main list element");
+
     await waitFor(async () => {
-      const mainList = await page.waitForSelector("#main-list", {
-        strategy: "pierce",
-      });
-      const initialText = await mainList.evaluate((el: HTMLElement) =>
+      const initialText = await mainList!.evaluate((el: HTMLElement) =>
         el.textContent || ""
       );
       return initialText === "A, B, C, D (4)";
     });
 
     // Verify the list populated correctly
-    const mainList = await page.waitForSelector("#main-list", {
-      strategy: "pierce",
-    });
-    const initialText = await mainList.evaluate((el: HTMLElement) =>
+    const initialText = await mainList!.evaluate((el: HTMLElement) =>
       el.textContent || ""
     );
     assertEquals(
@@ -84,26 +80,24 @@ describe("list-operations simple test", () => {
     );
 
     // Test delete first item
-    const deleteFirstBtn = await page.waitForSelector("#delete-first", {
+    const deleteFirstBtn = await page.$("#delete-first", {
       strategy: "pierce",
     });
-    await deleteFirstBtn.click();
+    await deleteFirstBtn!.click();
 
     // Wait for delete to complete
     await waitFor(async () => {
-      const currentMainList = await page.waitForSelector("#main-list", {
+      const currentMainList = await page.$("#main-list", {
         strategy: "pierce",
       });
-      const text = await currentMainList.evaluate((el: HTMLElement) =>
+      const text = await currentMainList!.evaluate((el: HTMLElement) =>
         el.textContent || ""
       );
       return text === "B, C, D (3)";
     });
 
-    const currentMainList = await page.waitForSelector("#main-list", {
-      strategy: "pierce",
-    });
-    const afterDeleteText = await currentMainList.evaluate((el: HTMLElement) =>
+    const currentMainList = await page.$("#main-list", { strategy: "pierce" });
+    const afterDeleteText = await currentMainList!.evaluate((el: HTMLElement) =>
       el.textContent || ""
     );
     assertEquals(
@@ -113,26 +107,22 @@ describe("list-operations simple test", () => {
     );
 
     // Test insert at start
-    const insertStartBtn = await page.waitForSelector("#insert-start", {
+    const insertStartBtn = await page.$("#insert-start", {
       strategy: "pierce",
     });
-    await insertStartBtn.click();
+    await insertStartBtn!.click();
 
     // Wait for insert to complete
     await waitFor(async () => {
-      const insertMainList = await page.waitForSelector("#main-list", {
-        strategy: "pierce",
-      });
-      const text = await insertMainList.evaluate((el: HTMLElement) =>
+      const insertMainList = await page.$("#main-list", { strategy: "pierce" });
+      const text = await insertMainList!.evaluate((el: HTMLElement) =>
         el.textContent || ""
       );
       return text === "New Start, B, C, D (4)";
     });
 
-    const insertMainList = await page.waitForSelector("#main-list", {
-      strategy: "pierce",
-    });
-    const afterInsertText = await insertMainList.evaluate((el: HTMLElement) =>
+    const insertMainList = await page.$("#main-list", { strategy: "pierce" });
+    const afterInsertText = await insertMainList!.evaluate((el: HTMLElement) =>
       el.textContent || ""
     );
     assertEquals(
@@ -142,25 +132,21 @@ describe("list-operations simple test", () => {
     );
 
     // Test one more operation: delete-last to see if it works
-    const deleteLastBtn = await page.waitForSelector("#delete-last", {
-      strategy: "pierce",
-    });
-    await deleteLastBtn.click();
+    const deleteLastBtn = await page.$("#delete-last", { strategy: "pierce" });
+    await deleteLastBtn!.click();
 
     await waitFor(async () => {
-      const deleteLastMainList = await page.waitForSelector("#main-list", {
+      const deleteLastMainList = await page.$("#main-list", {
         strategy: "pierce",
       });
-      const text = await deleteLastMainList.evaluate((el: HTMLElement) =>
+      const text = await deleteLastMainList!.evaluate((el: HTMLElement) =>
         el.textContent || ""
       );
       return text === "New Start, B, C (3)";
     });
 
-    const finalMainList = await page.waitForSelector("#main-list", {
-      strategy: "pierce",
-    });
-    const finalText = await finalMainList.evaluate((el: HTMLElement) =>
+    const finalMainList = await page.$("#main-list", { strategy: "pierce" });
+    const finalText = await finalMainList!.evaluate((el: HTMLElement) =>
       el.textContent || ""
     );
     assertEquals(

--- a/packages/patterns/integration/nested-counter.test.ts
+++ b/packages/patterns/integration/nested-counter.test.ts
@@ -51,15 +51,16 @@ describe("nested counter integration test", () => {
       identity,
     });
 
-    await waitFor(async () => {
-      const counterResult = await page.waitForSelector("#counter-result", {
-        strategy: "pierce",
-      });
-      const initialText = await counterResult.evaluate((el: HTMLElement) =>
-        el.textContent
-      );
-      return initialText?.trim() === "Counter is the 0th number";
+    const counterResult = await page.waitForSelector("#counter-result", {
+      strategy: "pierce",
     });
+    assert(counterResult, "Should find counter-result element");
+
+    // Verify initial value is 0
+    const initialText = await counterResult.evaluate((el: HTMLElement) =>
+      el.textContent
+    );
+    assertEquals(initialText?.trim(), "Counter is the 0th number");
 
     // Verify via direct operations that the nested structure works
     assertEquals(charm.result.get(["value"]), 0);

--- a/packages/shell/integration/charm.test.ts
+++ b/packages/shell/integration/charm.test.ts
@@ -59,25 +59,20 @@ describe("shell charm tests", () => {
       identity,
     });
 
-    // Click twice
-    for (let i = 0; i < 2; i++) {
-      const handle = await page.waitForSelector(
-        "#counter-decrement",
-        { strategy: "pierce" },
-      );
-      // Wait for inner text. There's some
-      // race here where we can click before the
-      // box model is available.
-      const _ = await handle.innerText();
-      handle.click();
-      await sleep(1000);
-    }
-    const handle = await page.waitForSelector(
+    let handle = await page.waitForSelector(
+      "#counter-decrement",
+      { strategy: "pierce" },
+    );
+    handle.click();
+    await sleep(1000);
+    handle.click();
+    await sleep(1000);
+    handle = await page.waitForSelector(
       "#counter-result",
       { strategy: "pierce" },
     );
-    await sleep(1500);
-    const text = await handle.innerText();
+    await sleep(1000);
+    const text = await handle?.innerText();
     assert(text === "Counter is the -2th number");
   });
 });

--- a/packages/shell/integration/iframe-counter-charm.disabled_test.ts
+++ b/packages/shell/integration/iframe-counter-charm.disabled_test.ts
@@ -65,7 +65,7 @@ async function getCharmResult(page: Page): Promise<{ count: number }> {
   // Use the element handle to evaluate in its context
   return await appView.evaluate((element: XAppView) => {
     // Access the private _activeCharm property
-    const activeCharmTask = element._patterns;
+    const activeCharmTask = element._activePatterns;
 
     if (!activeCharmTask) {
       throw new Error("No _activeCharm property found on element");
@@ -77,9 +77,6 @@ async function getCharmResult(page: Page): Promise<{ count: number }> {
 
     // Get the charm controller from the Task's value
     const charmController = activeCharmTask.value.activePattern;
-    if (!charmController) {
-      throw new Error("No active charm controller found");
-    }
 
     // Get the result from the charm controller
     const result = charmController.result.get();

--- a/packages/shell/src/lib/pattern-factory.ts
+++ b/packages/shell/src/lib/pattern-factory.ts
@@ -1,9 +1,8 @@
 import { CharmController, CharmsController } from "@commontools/charm/ops";
 import { HttpProgramResolver } from "@commontools/js-compiler";
 import { API_URL } from "./env.ts";
-import { NameSchema } from "@commontools/charm";
 
-export type BuiltinPatternType = "home" | "space-root";
+export type BuiltinPatternType = "home" | "space-default";
 
 type BuiltinPatternConfig = {
   url: URL;
@@ -17,17 +16,17 @@ const Configs: Record<BuiltinPatternType, BuiltinPatternConfig> = {
     url: new URL(`/api/patterns/home.tsx`, API_URL),
     cause: "home-pattern",
   },
-  "space-root": {
+  "space-default": {
     name: "DefaultCharmList",
     url: new URL(`/api/patterns/default-app.tsx`, API_URL),
-    cause: "space-root",
+    cause: "default-charm",
   },
 };
 
 export async function create(
   cc: CharmsController,
   type: BuiltinPatternType,
-): Promise<CharmController<NameSchema>> {
+): Promise<CharmController> {
   const config = Configs[type];
   const manager = cc.manager();
   const runtime = manager.runtime;
@@ -36,11 +35,7 @@ export async function create(
     new HttpProgramResolver(config.url.href),
   );
 
-  const charm = await cc.create<NameSchema>(
-    program,
-    { start: true },
-    config.cause,
-  );
+  const charm = await cc.create(program, { start: true }, config.cause);
 
   // Wait for the link to be processed
   await runtime.idle();
@@ -54,7 +49,7 @@ export async function create(
 
 export async function get(
   cc: CharmsController,
-): Promise<CharmController<NameSchema> | undefined> {
+): Promise<CharmController | undefined> {
   const pattern = await cc.manager().getDefaultPattern();
   if (!pattern) {
     return undefined;
@@ -65,7 +60,7 @@ export async function get(
 export async function getOrCreate(
   cc: CharmsController,
   type: BuiltinPatternType,
-): Promise<CharmController<NameSchema>> {
+): Promise<CharmController> {
   const pattern = await get(cc);
   if (pattern) {
     return pattern;

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -5,20 +5,14 @@ import {
   RuntimeTelemetryEvent,
   RuntimeTelemetryMarkerResult,
 } from "@commontools/runner";
-import {
-  charmId,
-  CharmManager,
-  NameSchema,
-  nameSchema,
-} from "@commontools/charm";
-import { CharmController, CharmsController } from "@commontools/charm/ops";
+import { charmId, CharmManager } from "@commontools/charm";
+import { CharmsController } from "@commontools/charm/ops";
 import { StorageManager } from "@commontools/runner/storage/cache";
 import { navigate } from "./navigate.ts";
 import * as Inspector from "@commontools/runner/storage/inspector";
 import { setupIframe } from "./iframe-ctx.ts";
 import { getLogger } from "@commontools/utils/logger";
 import { AppView } from "./app/view.ts";
-import * as PatternFactory from "./pattern-factory.ts";
 
 const logger = getLogger("shell.telemetry", {
   enabled: false,
@@ -40,20 +34,15 @@ export class RuntimeInternals extends EventTarget {
   #inspector: Inspector.Channel;
   #disposed = false;
   #space: string; // The MemorySpace DID
-  #spaceRootPattern?: CharmController<NameSchema>;
-  #spaceRootPatternType: PatternFactory.BuiltinPatternType;
-  #patternCache: Map<string, CharmController<NameSchema>> = new Map();
 
   private constructor(
     cc: CharmsController,
     telemetry: RuntimeTelemetry,
     space: string,
-    spaceRootPatternType: PatternFactory.BuiltinPatternType,
   ) {
     super();
     this.#cc = cc;
     this.#space = space;
-    this.#spaceRootPatternType = spaceRootPatternType;
     const runtimeId = this.#cc.manager().runtime.id;
     this.#inspector = new Inspector.Channel(
       runtimeId,
@@ -78,45 +67,6 @@ export class RuntimeInternals extends EventTarget {
 
   space(): string {
     return this.#space;
-  }
-
-  // Returns the space root pattern, creating it if it doesn't exist.
-  // The space root pattern type is determined at RuntimeInternals creation
-  // based on the view type (home vs space).
-  async getSpaceRootPattern(): Promise<CharmController<NameSchema>> {
-    this.#check();
-    if (this.#spaceRootPattern) {
-      return this.#spaceRootPattern;
-    }
-
-    const pattern = await PatternFactory.getOrCreate(
-      this.#cc,
-      this.#spaceRootPatternType,
-    );
-
-    // Track as recently accessed
-    await this.#cc.manager().trackRecentCharm(pattern.getCell());
-
-    this.#patternCache.set(pattern.id, pattern);
-    return pattern;
-  }
-
-  // Returns a pattern by ID, starting it if requested.
-  // Patterns are cached by ID.
-  async getPattern(id: string): Promise<CharmController<NameSchema>> {
-    this.#check();
-    const cached = this.#patternCache.get(id);
-    if (cached) {
-      return cached;
-    }
-
-    const pattern = await this.#cc.get(id, true, nameSchema);
-
-    // Track as recently accessed
-    await this.#cc.manager().trackRecentCharm(pattern.getCell());
-
-    this.#patternCache.set(id, pattern);
-    return pattern;
   }
 
   async dispose() {
@@ -156,24 +106,20 @@ export class RuntimeInternals extends EventTarget {
   ): Promise<RuntimeInternals> {
     let session;
     let spaceName;
-    let spaceRootPatternType: PatternFactory.BuiltinPatternType;
     if ("builtin" in view) {
       switch (view.builtin) {
         case "home":
           session = await createSession({ identity, spaceDid: identity.did() });
           spaceName = "<home>";
-          spaceRootPatternType = "home";
           break;
       }
     } else if ("spaceName" in view) {
       session = await createSession({ identity, spaceName: view.spaceName });
       spaceName = view.spaceName;
-      spaceRootPatternType = "space-root";
     } else if ("spaceDid" in view) {
       session = await createSession({ identity, spaceDid: view.spaceDid });
-      spaceRootPatternType = "space-root";
     }
-    if (!session || !spaceRootPatternType!) {
+    if (!session) {
       throw new Error("Unexpected view provided.");
     }
 
@@ -288,11 +234,6 @@ export class RuntimeInternals extends EventTarget {
     charmManager = new CharmManager(session, runtime);
     await charmManager.synced();
     const cc = new CharmsController(charmManager);
-    return new RuntimeInternals(
-      cc,
-      telemetry,
-      session.space,
-      spaceRootPatternType,
-    );
+    return new RuntimeInternals(cc, telemetry, session.space);
   }
 }

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -1,17 +1,20 @@
 import { css, html } from "lit";
 import { property, state } from "lit/decorators.js";
+
+import { AppView } from "../lib/app/mod.ts";
 import { BaseView, createDefaultAppState } from "./BaseView.ts";
 import { KeyStore } from "@commontools/identity";
 import { RuntimeInternals } from "../lib/runtime.ts";
 import { DebuggerController } from "../lib/debugger-controller.ts";
 import "./DebuggerView.ts";
-import { Task, TaskStatus } from "@lit/task";
-import { CharmController } from "@commontools/charm/ops";
+import { Task } from "@lit/task";
+import { CharmController, CharmsController } from "@commontools/charm/ops";
 import { CellEventTarget, CellUpdateEvent } from "../lib/cell-event-target.ts";
 import { NAME } from "@commontools/runner";
-import { type NameSchema } from "@commontools/charm";
+import { type NameSchema, nameSchema } from "@commontools/charm";
 import { updatePageTitle } from "../lib/navigate.ts";
 import { KeyboardController } from "../lib/keyboard-router.ts";
+import * as PatternFactory from "../lib/pattern-factory.ts";
 
 export class XAppView extends BaseView {
   static override styles = css`
@@ -49,7 +52,7 @@ export class XAppView extends BaseView {
   @property({ attribute: false })
   keyStore?: KeyStore;
 
-  @state()
+  @property({ attribute: false })
   charmTitle?: string;
 
   @property({ attribute: false })
@@ -82,78 +85,43 @@ export class XAppView extends BaseView {
     this.hasSidebarContent = event.detail.hasSidebarContent;
   };
 
-  // Fetches the space root pattern from the space.
-  _spaceRootPattern = new Task(this, {
-    task: async (
-      [rt],
-    ): Promise<
-      | CharmController<NameSchema>
-      | undefined
-    > => {
-      if (!rt) return;
-      return await rt.getSpaceRootPattern();
-    },
-    args: () => [this.rt],
-  });
-
-  // This fetches the selected pattern, the explicitly chosen pattern
-  // to render via URL e.g. `/space/someCharmId`.
-  _selectedPattern = new Task(this, {
+  // Do not make private, integration tests access this directly.
+  //
+  // This fetches the active pattern and space default pattern derived
+  // from the current view.
+  _activePatterns = new Task(this, {
     task: async (
       [app, rt],
     ): Promise<
-      | CharmController<NameSchema>
+      | { activePattern: CharmController; defaultPattern: CharmController }
       | undefined
     > => {
-      if (!rt) return;
-      if ("charmId" in app.view && app.view.charmId) {
-        return await rt.getPattern(app.view.charmId);
+      if (!rt) {
+        this.#setTitleSubscription();
+        return;
       }
+
+      const patterns = await viewToPatterns(
+        rt.cc(),
+        app.view,
+        this._activePatterns.value?.activePattern,
+      );
+      if (!patterns) {
+        this.#setTitleSubscription();
+        return;
+      }
+
+      // Record the charm as recently accessed so recents stay fresh.
+      await rt.cc().manager().trackRecentCharm(
+        patterns.activePattern.getCell(),
+      );
+      this.#setTitleSubscription(
+        patterns.activePattern as CharmController<NameSchema>,
+      );
+
+      return patterns;
     },
     args: () => [this.app, this.rt],
-  });
-
-  // This derives a space root pattern as well as an "active" (main)
-  // pattern for use in child views.
-  // This hybrid task intentionally only uses completed/fresh
-  // source patterns to avoid unsyncing state.
-  _patterns = new Task(this, {
-    task: function (
-      [
-        app,
-        spaceRootPatternValue,
-        spaceRootPatternStatus,
-        selectedPatternValue,
-        selectedPatternStatus,
-      ],
-    ): {
-      activePattern: CharmController<NameSchema> | undefined;
-      spaceRootPattern: CharmController<NameSchema> | undefined;
-    } {
-      const spaceRootPattern = spaceRootPatternStatus === TaskStatus.COMPLETE
-        ? spaceRootPatternValue
-        : undefined;
-      // The "active" pattern is the main pattern to be rendered.
-      // This may be the same as the space root pattern, unless we're
-      // in a view that specifies a different pattern to use.
-      const useSpaceRootAsActive = !("charmId" in app.view && app.view.charmId);
-      const activePattern = useSpaceRootAsActive
-        ? spaceRootPattern
-        : selectedPatternStatus === TaskStatus.COMPLETE
-        ? selectedPatternValue
-        : undefined;
-      return {
-        activePattern,
-        spaceRootPattern,
-      };
-    },
-    args: () => [
-      this.app,
-      this._spaceRootPattern.value,
-      this._spaceRootPattern.status,
-      this._selectedPattern.value,
-      this._selectedPattern.status,
-    ],
   });
 
   #setTitleSubscription(activeCharm?: CharmController<NameSchema>) {
@@ -206,42 +174,31 @@ export class XAppView extends BaseView {
     }
 
     // Update debugger visibility from app state
-    if (changedProperties.has("app")) {
+    if (changedProperties.has("app") && this.app) {
       this.debuggerController.setVisibility(
         this.app.config.showDebuggerView ?? false,
       );
     }
   }
 
-  // Always defer to the loaded active pattern for the ID,
-  // but until that loads, use an ID in the view if available.
-  private getActivePatternId(): string | undefined {
-    const activePattern = this._patterns.value?.activePattern;
-    if (activePattern?.id) return activePattern.id;
-    if ("charmId" in this.app.view && this.app.view.charmId) {
-      return this.app.view.charmId;
-    }
-  }
-
   override render() {
     const config = this.app.config ?? {};
-    const { activePattern, spaceRootPattern } = this._patterns.value ?? {};
-    this.#setTitleSubscription(activePattern);
-
+    const unauthenticated = html`
+      <x-login-view .keyStore="${this.keyStore}"></x-login-view>
+    `;
+    const patterns = this._activePatterns.value;
+    const activePattern = patterns?.activePattern;
+    const defaultPattern = patterns?.defaultPattern;
     const authenticated = html`
       <x-body-view
         .rt="${this.rt}"
-        .activePattern="${activePattern}"
-        .spaceRootPattern="${spaceRootPattern}"
+        .activeCharm="${activePattern}"
+        .defaultCharm="${defaultPattern}"
         .showShellCharmListView="${config.showShellCharmListView ?? false}"
         .showSidebar="${config.showSidebar ?? false}"
       ></x-body-view>
     `;
-    const unauthenticated = html`
-      <x-login-view .keyStore="${this.keyStore}"></x-login-view>
-    `;
 
-    const charmId = this.getActivePatternId();
     const spaceName = this.app && "spaceName" in this.app.view
       ? this.app.view.spaceName
       : undefined;
@@ -254,7 +211,7 @@ export class XAppView extends BaseView {
           .rt="${this.rt}"
           .keyStore="${this.keyStore}"
           .charmTitle="${this.charmTitle}"
-          .charmId="${charmId}"
+          .charmId="${activePattern?.id}"
           .showShellCharmListView="${config.showShellCharmListView ?? false}"
           .showDebuggerView="${config.showDebuggerView ?? false}"
           .showSidebar="${config.showSidebar ?? false}"
@@ -264,7 +221,7 @@ export class XAppView extends BaseView {
           ${content}
         </div>
       </div>
-      ${this.app.identity
+      ${this.app?.identity
         ? html`
           <x-debugger-view
             .visible="${this.debuggerController.isVisible()}"
@@ -278,6 +235,51 @@ export class XAppView extends BaseView {
         `
         : ""}
     `;
+  }
+}
+
+async function viewToPatterns(
+  cc: CharmsController,
+  view: AppView,
+  currentActive?: CharmController<unknown>,
+): Promise<
+  {
+    activePattern: CharmController<unknown>;
+    defaultPattern: CharmController<unknown>;
+  } | undefined
+> {
+  if ("builtin" in view) {
+    if (view.builtin !== "home") {
+      console.warn("Unsupported view type");
+      return;
+    }
+    const pattern = await PatternFactory.getOrCreate(cc, "home");
+    return { activePattern: pattern, defaultPattern: pattern };
+  } else if ("spaceDid" in view) {
+    console.warn("Unsupported view type");
+    return;
+  } else if ("spaceName" in view) {
+    const defaultPattern = await PatternFactory.getOrCreate(
+      cc,
+      "space-default",
+    );
+
+    let activePattern: CharmController<unknown> | undefined;
+    // If viewing a specific charm, use it as active; otherwise use default
+    if (view.charmId) {
+      if (currentActive && currentActive.id === view.charmId) {
+        activePattern = currentActive;
+      } else {
+        activePattern = await cc.get(
+          view.charmId,
+          true,
+          nameSchema,
+        );
+      }
+    } else {
+      activePattern = defaultPattern;
+    }
+    return { activePattern, defaultPattern };
   }
 }
 

--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -45,10 +45,10 @@ export class XBodyView extends BaseView {
   rt?: RuntimeInternals;
 
   @property({ attribute: false })
-  activePattern?: CharmController;
+  activeCharm?: CharmController;
 
   @property({ attribute: false })
-  spaceRootPattern?: CharmController;
+  defaultCharm?: CharmController;
 
   @property()
   showShellCharmListView = false;
@@ -96,16 +96,16 @@ export class XBodyView extends BaseView {
       `;
     }
 
-    const mainContent = this.activePattern
+    const mainContent = this.activeCharm
       ? html`
-        <ct-charm slot="main" .charmId="${this.activePattern.id}">
-          <ct-render .cell="${this.activePattern.getCell()}"></ct-render>
+        <ct-charm slot="main" .charmId="${this.activeCharm.id}">
+          <ct-render .cell="${this.activeCharm.getCell()}"></ct-render>
         </ct-charm>
       `
       : null;
 
-    const sidebarCell = this.activePattern?.getCell().key("sidebarUI");
-    const fabCell = this.spaceRootPattern?.getCell().key("fabUI");
+    const sidebarCell = this.activeCharm?.getCell().key("sidebarUI");
+    const fabCell = this.defaultCharm?.getCell().key("fabUI");
 
     // Update sidebar content detection
     // TODO(seefeld): Fix possible race here where charm is already set, but

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -17,10 +17,9 @@ import { runtimeContext, spaceContext } from "@commontools/ui";
 import { provide } from "@lit/context";
 
 // The root element for the shell application.
-//
-// Derives `RuntimeInternals` for the application from its `AppState`.
-// `Command` mutates the app state, which can be fired as events
-// from children elements.
+// Handles processing `Command`s from children elements,
+// updating the `AppState`, and providing changes
+// to children elements.
 export class XRootView extends BaseView {
   static override styles = css`
     :host {


### PR DESCRIPTION
This reverts commit 6e979d0b0c021877882e8f3c13262073bcf36103.

Still too many intermittent failures due to timing changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the recent pattern selection changes and restores the previous active/default charm flow to reduce intermittent timing failures. Also stabilizes integration tests with simpler, more deterministic checks.

- **Refactors**
  - Restore unified pattern resolution in AppView via viewToPatterns and remove pattern caching/helpers from RuntimeInternals.
  - Rename built-in type from "space-root" to "space-default" and align PatternFactory/BodyView APIs; iframe test now reads _activePatterns.
  - Simplify CharmsController.create to return CharmController<T> consistently.

- **Bug Fixes**
  - Replace fragile wait loops with direct queries and assert-based checks across integration tests; add small sleeps where needed.
  - Make ct-list and ct-tags edits/removals reliable by dispatching clicks and waiting for DOM changes.
  - Re-enable instantiate-recipe flow and assert navigation via URL change.

<sup>Written for commit d64c5078a32907a9bd3aac1f759184f1ad126cac. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

