### PR TITLE
chore: Disable piping browser logs by default in integration tests

### DIFF
--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -54,11 +54,20 @@ export async function login(page: Page, identity: Identity): Promise<void> {
   );
 }
 
+export interface ShellIntegrationConfig {
+  pipeConsole?: boolean;
+}
+
 export class ShellIntegration {
   #browser?: Browser;
   #page?: Page;
   #exceptions: Array<string> = [];
   #errorLogs: Array<string> = [];
+  #config: ShellIntegrationConfig;
+
+  constructor(config: ShellIntegrationConfig = {}) {
+    this.#config = config;
+  }
 
   bindLifecycle() {
     beforeAll(this.#beforeAll);
@@ -161,7 +170,9 @@ export class ShellIntegration {
       if (e.detail.type === "error") {
         this.#errorLogs.push(e.detail.text);
       }
-      pipeConsole(e);
+      if (this.#config.pipeConsole) {
+        pipeConsole(e);
+      }
     });
     this.#page.addEventListener("dialog", dismissDialogs);
     this.#page.addEventListener("pageerror", (e: PageErrorEvent) => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable piping browser console logs to test output by default in integration tests to reduce noise. Adds a ShellIntegration config option (pipeConsole) to opt in when needed.

<sup>Written for commit aae1983d55004dd0d1f176225d99a64fd4e5a5f9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

