### PR TITLE
chore: Increase integration run timeout

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -460,7 +460,7 @@ jobs:
           host: ${{ secrets.BASTION_HOST }}
           username: bastion
           key: ${{ secrets.BASTION_SSH_PRIVATE_KEY }}
-          command_timeout: 10m
+          command_timeout: 20m
           script: |
             /opt/ct/run-pattern-tests-against-toolshed.sh ${{ github.sha }} \
               https://toolshed.saga-castor.ts.net \


### PR DESCRIPTION
We are seeing runs take > 10 minutes.

Increasing this timeout for troubleshooting / test stability purposes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the integration run timeout from 10m to 20m in the GitHub Actions workflow so longer integration runs don’t fail prematurely and troubleshooting is more stable.

<sup>Written for commit a1bc0147248b9527aafa9b231d3e8231ced5b237. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

