### PR TITLE
chore: Add a try around evaluate in integration tests for elements that flicker

### DIFF
--- a/packages/patterns/integration/ct-checkbox.test.ts
+++ b/packages/patterns/integration/ct-checkbox.test.ts
@@ -107,12 +107,20 @@ function clickCtCheckbox(page: Page) {
   });
 }
 
-async function getFeatureStatus(page: Page): Promise<string | undefined> {
+async function getFeatureStatus(
+  page: Page,
+): Promise<string | undefined | null> {
   const featureStatus = await page.waitForSelector("#feature-status", {
     strategy: "pierce",
   });
-  const statusText = await featureStatus.evaluate((el: HTMLElement) =>
-    el.textContent
-  );
-  return statusText?.trim();
+  // This could throw due to lacking a box model to click on.
+  // Catch in lieu of handling time sensitivity.
+  try {
+    const statusText = await featureStatus.evaluate((el: HTMLElement) =>
+      el.textContent
+    );
+    return statusText?.trim();
+  } catch (_) {
+    return null;
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened the ct-checkbox integration test to prevent flaky failures by wrapping #feature-status evaluation in a try/catch and returning null when the element flickers.

- **Bug Fixes**
  - Catch evaluation errors when the element lacks a box model during flicker.
  - Return null instead of throwing; update getFeatureStatus to return string | undefined | null.

<sup>Written for commit e2598a659d2e5667c34fbd5f28af5d5377987c3d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

