### PR TITLE
Add Cell support to ct-textarea for two-way binding

### DIFF
--- a/packages/ui/src/v2/components/ct-textarea/ct-textarea.ts
+++ b/packages/ui/src/v2/components/ct-textarea/ct-textarea.ts
@@ -183,403 +183,404 @@ export class CTTextarea extends BaseElement {
       border-color: var(--ring);
       box-shadow: 0 0 0 3px
         var(--ct-theme-color-primary, rgba(59, 130, 246, 0.15));
-    }
+      }
 
-    textarea:focus-visible {
-      outline: 2px solid transparent;
-      outline-offset: 2px;
-      border-color: var(--ring);
-      box-shadow: 0 0 0 3px
-        var(--ct-theme-color-primary, rgba(59, 130, 246, 0.15));
-    }
+      textarea:focus-visible {
+        outline: 2px solid transparent;
+        outline-offset: 2px;
+        border-color: var(--ring);
+        box-shadow: 0 0 0 3px
+          var(--ct-theme-color-primary, rgba(59, 130, 246, 0.15));
+        }
 
-    /* Disabled state */
-    textarea:disabled {
-      cursor: not-allowed;
-      opacity: 0.5;
-      background-color: var(--muted);
-      resize: none;
-    }
+        /* Disabled state */
+        textarea:disabled {
+          cursor: not-allowed;
+          opacity: 0.5;
+          background-color: var(--muted);
+          resize: none;
+        }
 
-    /* Readonly state */
-    textarea:read-only {
-      background-color: var(--muted);
-      cursor: default;
-    }
+        /* Readonly state */
+        textarea:read-only {
+          background-color: var(--muted);
+          cursor: default;
+        }
 
-    /* Error state */
-    textarea.error {
-      border-color: var(--destructive);
-    }
+        /* Error state */
+        textarea.error {
+          border-color: var(--destructive);
+        }
 
-    textarea.error:focus,
-    textarea.error:focus-visible {
-      border-color: var(--destructive);
-      box-shadow: 0 0 0 3px var(--ct-theme-color-error, rgba(220, 38, 38, 0.1));
-    }
+        textarea.error:focus,
+        textarea.error:focus-visible {
+          border-color: var(--destructive);
+          box-shadow: 0 0 0 3px var(--ct-theme-color-error, rgba(220, 38, 38, 0.1));
+        }
 
-    /* Scrollbar styling */
-    textarea::-webkit-scrollbar {
-      width: 0.5rem;
-      height: 0.5rem;
-    }
+        /* Scrollbar styling */
+        textarea::-webkit-scrollbar {
+          width: 0.5rem;
+          height: 0.5rem;
+        }
 
-    textarea::-webkit-scrollbar-track {
-      background-color: var(--muted);
-      border-radius: calc(var(--textarea-border-radius) * 0.5);
-    }
+        textarea::-webkit-scrollbar-track {
+          background-color: var(--muted);
+          border-radius: calc(var(--textarea-border-radius) * 0.5);
+        }
 
-    textarea::-webkit-scrollbar-thumb {
-      background-color: var(--border);
-      border-radius: calc(var(--textarea-border-radius) * 0.5);
-      transition: background-color var(--ct-theme-animation-duration, 150ms);
-    }
+        textarea::-webkit-scrollbar-thumb {
+          background-color: var(--border);
+          border-radius: calc(var(--textarea-border-radius) * 0.5);
+          transition: background-color var(--ct-theme-animation-duration, 150ms);
+        }
 
-    textarea::-webkit-scrollbar-thumb:hover {
-      background-color: var(--muted-foreground);
-    }
+        textarea::-webkit-scrollbar-thumb:hover {
+          background-color: var(--muted-foreground);
+        }
 
-    /* Firefox scrollbar styling */
-    textarea {
-      scrollbar-width: thin;
-      scrollbar-color: var(--border) var(--muted);
-    }
+        /* Firefox scrollbar styling */
+        textarea {
+          scrollbar-width: thin;
+          scrollbar-color: var(--border) var(--muted);
+        }
 
-    /* Autofill styles */
-    textarea:-webkit-autofill,
-    textarea:-webkit-autofill:hover,
-    textarea:-webkit-autofill:focus {
-      -webkit-text-fill-color: var(--foreground);
-      -webkit-box-shadow: 0 0 0px 1000px var(--muted) inset;
-      transition: background-color 5000s ease-in-out 0s;
-    }
+        /* Autofill styles */
+        textarea:-webkit-autofill,
+        textarea:-webkit-autofill:hover,
+        textarea:-webkit-autofill:focus {
+          -webkit-text-fill-color: var(--foreground);
+          -webkit-box-shadow: 0 0 0px 1000px var(--muted) inset;
+          transition: background-color 5000s ease-in-out 0s;
+        }
 
-    /* Selection styles */
-    textarea::selection {
-      background-color: var(--ring);
-      color: var(--background);
-      opacity: 0.3;
-    }
+        /* Selection styles */
+        textarea::selection {
+          background-color: var(--ring);
+          color: var(--background);
+          opacity: 0.3;
+        }
 
-    textarea::-moz-selection {
-      background-color: var(--ring);
-      color: var(--background);
-      opacity: 0.3;
-    }
+        textarea::-moz-selection {
+          background-color: var(--ring);
+          color: var(--background);
+          opacity: 0.3;
+        }
 
-    /* Auto-resize specific styles */
-    :host([auto-resize]) textarea {
-      overflow-y: hidden;
-    }
-  `;
+        /* Auto-resize specific styles */
+        :host([auto-resize]) textarea {
+          overflow-y: hidden;
+        }
+      `;
 
-  // Theme consumption
-  @consume({ context: themeContext, subscribe: true })
-  @property({ attribute: false })
-  declare theme?: CTTheme;
+      // Theme consumption
+      @consume({ context: themeContext, subscribe: true })
+      @property({ attribute: false })
+      declare theme?: CTTheme;
 
-  // Cache + initial setup
-  private _textarea: HTMLTextAreaElement | null = null;
-  private _cellController = createStringCellController(this, {
-    timing: {
-      strategy: "debounce",
-      delay: 300,
-    },
-  });
-
-  constructor() {
-    super();
-    this.placeholder = "";
-    this.value = "";
-    this.disabled = false;
-    this.readonly = false;
-    this.error = false;
-    this.rows = 4;
-    this.cols = 50;
-    this.name = "";
-    this.required = false;
-    this.autofocus = false;
-    this.maxlength = "";
-    this.minlength = "";
-    this.wrap = "soft";
-    this.spellcheck = true;
-    this.autocomplete = "off";
-    this.resize = "vertical";
-    this.autoResize = false;
-    this.timingStrategy = "debounce";
-    this.timingDelay = 300;
-  }
-
-  private getValue(): string {
-    return this._cellController.getValue();
-  }
-
-  private setValue(newValue: string): void {
-    this._cellController.setValue(newValue);
-  }
-
-  get textarea(): HTMLTextAreaElement | null {
-    if (!this._textarea) {
-      this._textarea = this.shadowRoot?.querySelector("textarea") as
-        | HTMLTextAreaElement
-        | null;
-    }
-    return this._textarea;
-  }
-
-  private _minHeight = 0;
-
-  override firstUpdated() {
-    // Cache reference
-    this._textarea = this.shadowRoot?.querySelector("textarea") as
-      | HTMLTextAreaElement
-      | null;
-
-    // Bind the initial value to the cell controller
-    this._cellController.bind(this.value);
-
-    // Update timing options to match current properties
-    this._cellController.updateTimingOptions({
-      strategy: this.timingStrategy,
-      delay: this.timingDelay,
-    });
-
-    // Apply theme on mount
-    applyThemeToElement(this, this.theme ?? defaultTheme);
-
-    if (this.autofocus) {
-      this.textarea?.focus();
-    }
-
-    // Store initial height for auto-resize
-    if (this.autoResize && this.textarea) {
-      this._minHeight = this.textarea.scrollHeight;
-      this.adjustHeight();
-    }
-  }
-
-  override updated(changedProperties: Map<string | number | symbol, unknown>) {
-    super.updated(changedProperties);
-
-    if (changedProperties.has("value")) {
-      // Bind the new value (Cell or plain) to the controller
-      this._cellController.bind(this.value);
-    }
-
-    // Update timing options if they changed
-    if (
-      changedProperties.has("timingStrategy") ||
-      changedProperties.has("timingDelay")
-    ) {
-      this._cellController.updateTimingOptions({
-        strategy: this.timingStrategy,
-        delay: this.timingDelay,
+      // Cache + initial setup
+      private _textarea: HTMLTextAreaElement | null = null;
+      private _cellController = createStringCellController(this, {
+        timing: {
+          strategy: "debounce",
+          delay: 300,
+        },
       });
-    }
 
-    if (changedProperties.has("theme")) {
-      applyThemeToElement(this, this.theme ?? defaultTheme);
-    }
+      constructor() {
+        super();
+        this.placeholder = "";
+        this.value = "";
+        this.disabled = false;
+        this.readonly = false;
+        this.error = false;
+        this.rows = 4;
+        this.cols = 50;
+        this.name = "";
+        this.required = false;
+        this.autofocus = false;
+        this.maxlength = "";
+        this.minlength = "";
+        this.wrap = "soft";
+        this.spellcheck = true;
+        this.autocomplete = "off";
+        this.resize = "vertical";
+        this.autoResize = false;
+        this.timingStrategy = "debounce";
+        this.timingDelay = 300;
+      }
 
-    if (changedProperties.has("value") && this.autoResize) {
-      this.adjustHeight();
-    }
+      private getValue(): string {
+        return this._cellController.getValue();
+      }
 
-    if (changedProperties.has("autoResize")) {
-      if (this.autoResize) {
-        this.resize = "none";
-        if (this.textarea) {
+      private setValue(newValue: string): void {
+        this._cellController.setValue(newValue);
+      }
+
+      get textarea(): HTMLTextAreaElement | null {
+        if (!this._textarea) {
+          this._textarea = this.shadowRoot?.querySelector("textarea") as
+            | HTMLTextAreaElement
+            | null;
+        }
+        return this._textarea;
+      }
+
+      private _minHeight = 0;
+
+      override firstUpdated() {
+        // Cache reference
+        this._textarea = this.shadowRoot?.querySelector("textarea") as
+          | HTMLTextAreaElement
+          | null;
+
+        // Bind the initial value to the cell controller
+        this._cellController.bind(this.value);
+
+        // Update timing options to match current properties
+        this._cellController.updateTimingOptions({
+          strategy: this.timingStrategy,
+          delay: this.timingDelay,
+        });
+
+        // Apply theme on mount
+        applyThemeToElement(this, this.theme ?? defaultTheme);
+
+        if (this.autofocus) {
+          this.textarea?.focus();
+        }
+
+        // Store initial height for auto-resize
+        if (this.autoResize && this.textarea) {
           this._minHeight = this.textarea.scrollHeight;
           this.adjustHeight();
         }
-      } else {
-        this.resize = "vertical";
+      }
+
+      override updated(
+        changedProperties: Map<string | number | symbol, unknown>,
+      ) {
+        super.updated(changedProperties);
+
+        if (changedProperties.has("value")) {
+          // Bind the new value (Cell or plain) to the controller
+          this._cellController.bind(this.value);
+        }
+
+        // Update timing options if they changed
+        if (
+          changedProperties.has("timingStrategy") ||
+          changedProperties.has("timingDelay")
+        ) {
+          this._cellController.updateTimingOptions({
+            strategy: this.timingStrategy,
+            delay: this.timingDelay,
+          });
+        }
+
+        if (changedProperties.has("theme")) {
+          applyThemeToElement(this, this.theme ?? defaultTheme);
+        }
+
+        if (changedProperties.has("value") && this.autoResize) {
+          this.adjustHeight();
+        }
+
+        if (changedProperties.has("autoResize")) {
+          if (this.autoResize) {
+            this.resize = "none";
+            if (this.textarea) {
+              this._minHeight = this.textarea.scrollHeight;
+              this.adjustHeight();
+            }
+          } else {
+            this.resize = "vertical";
+          }
+        }
+      }
+
+      override render() {
+        const resizeStyle = this.resize === "none" || this.autoResize
+          ? "resize: none;"
+          : `resize: ${this.resize};`;
+
+        return html`
+          <textarea
+            class="${this.error ? "error" : ""}"
+            style="${resizeStyle}"
+            placeholder="${ifDefined(this.placeholder || undefined)}"
+            .value="${this.getValue()}"
+            ?disabled="${this.disabled}"
+            ?readonly="${this.readonly}"
+            ?required="${this.required}"
+            name="${ifDefined(this.name || undefined)}"
+            rows="${this.rows}"
+            cols="${this.cols}"
+            wrap="${this.wrap}"
+            ?spellcheck="${this.spellcheck}"
+            autocomplete="${this.autocomplete}"
+            maxlength="${ifDefined(this.maxlength || undefined)}"
+            minlength="${ifDefined(this.minlength || undefined)}"
+            @input="${this._handleInput}"
+            @change="${this._handleChange}"
+            @focus="${this._handleFocus}"
+            @blur="${this._handleBlur}"
+            @keydown="${this._handleKeyDown}"
+            part="textarea"
+          ></textarea>
+        `;
+      }
+
+      private _handleInput(event: Event) {
+        const textarea = event.target as HTMLTextAreaElement;
+        const oldValue = this.getValue();
+        this.setValue(textarea.value);
+
+        // Auto-resize if enabled
+        if (this.autoResize) {
+          this.adjustHeight();
+        }
+
+        // Emit custom input event
+        this.emit("ct-input", {
+          value: textarea.value,
+          oldValue,
+          name: this.name,
+        });
+      }
+
+      private _handleChange(event: Event) {
+        const textarea = event.target as HTMLTextAreaElement;
+        const oldValue = this.getValue();
+
+        // Emit custom change event
+        this.emit("ct-change", {
+          value: textarea.value,
+          oldValue,
+          name: this.name,
+        });
+      }
+
+      private _handleFocus(_event: Event) {
+        this._cellController.onFocus();
+        this.emit("ct-focus", {
+          value: this.getValue(),
+          name: this.name,
+        });
+      }
+
+      private _handleBlur(_event: Event) {
+        this._cellController.onBlur();
+        this.emit("ct-blur", {
+          value: this.getValue(),
+          name: this.name,
+        });
+      }
+
+      private _handleKeyDown(event: KeyboardEvent) {
+        this.emit("ct-keydown", {
+          key: event.key,
+          value: this.getValue(),
+          shiftKey: event.shiftKey,
+          ctrlKey: event.ctrlKey,
+          metaKey: event.metaKey,
+          altKey: event.altKey,
+          name: this.name,
+        });
+
+        // Special handling for Enter key with modifiers
+        if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
+          this.emit("ct-submit", {
+            value: this.getValue(),
+            name: this.name,
+          });
+        }
+      }
+
+      /**
+       * Adjust height for auto-resize functionality
+       */
+      private adjustHeight(): void {
+        if (!this.textarea || !this.autoResize) return;
+
+        // Reset height to recalculate
+        (this.textarea as HTMLTextAreaElement).style.height = "auto";
+
+        // Set new height based on scrollHeight
+        const newHeight = Math.max(
+          this._minHeight,
+          (this.textarea as HTMLTextAreaElement).scrollHeight,
+        );
+        (this.textarea as HTMLTextAreaElement).style.height = `${newHeight}px`;
+      }
+
+      /**
+       * Focus the textarea programmatically
+       */
+      override focus(): void {
+        this.textarea?.focus();
+      }
+
+      /**
+       * Blur the textarea programmatically
+       */
+      override blur(): void {
+        this.textarea?.blur();
+      }
+
+      /**
+       * Select all text in the textarea
+       */
+      select(): void {
+        this.textarea?.select();
+      }
+
+      /**
+       * Set selection range in the textarea
+       */
+      setSelectionRange(
+        start: number,
+        end: number,
+        direction?: "forward" | "backward" | "none",
+      ): void {
+        this.textarea?.setSelectionRange(start, end, direction);
+      }
+
+      /**
+       * Check validity of the textarea
+       */
+      checkValidity(): boolean {
+        return this.textarea?.checkValidity() ?? true;
+      }
+
+      /**
+       * Report validity of the textarea
+       */
+      reportValidity(): boolean {
+        return this.textarea?.reportValidity() ?? true;
+      }
+
+      /**
+       * Get the validity state
+       */
+      get validity(): ValidityState | undefined {
+        return this.textarea?.validity;
+      }
+
+      /**
+       * Get validation message
+       */
+      get validationMessage(): string {
+        return this.textarea?.validationMessage || "";
+      }
+
+      /**
+       * Set custom validity message
+       */
+      setCustomValidity(message: string): void {
+        this.textarea?.setCustomValidity(message);
       }
     }
-  }
 
-  override render() {
-    const resizeStyle =
-      this.resize === "none" || this.autoResize
-        ? "resize: none;"
-        : `resize: ${this.resize};`;
-
-    return html`
-      <textarea
-        class="${this.error ? "error" : ""}"
-        style="${resizeStyle}"
-        placeholder="${ifDefined(this.placeholder || undefined)}"
-        .value="${this.getValue()}"
-        ?disabled="${this.disabled}"
-        ?readonly="${this.readonly}"
-        ?required="${this.required}"
-        name="${ifDefined(this.name || undefined)}"
-        rows="${this.rows}"
-        cols="${this.cols}"
-        wrap="${this.wrap}"
-        ?spellcheck="${this.spellcheck}"
-        autocomplete="${this.autocomplete}"
-        maxlength="${ifDefined(this.maxlength || undefined)}"
-        minlength="${ifDefined(this.minlength || undefined)}"
-        @input="${this._handleInput}"
-        @change="${this._handleChange}"
-        @focus="${this._handleFocus}"
-        @blur="${this._handleBlur}"
-        @keydown="${this._handleKeyDown}"
-        part="textarea"
-      ></textarea>
-    `;
-  }
-
-  private _handleInput(event: Event) {
-    const textarea = event.target as HTMLTextAreaElement;
-    const oldValue = this.getValue();
-    this.setValue(textarea.value);
-
-    // Auto-resize if enabled
-    if (this.autoResize) {
-      this.adjustHeight();
-    }
-
-    // Emit custom input event
-    this.emit("ct-input", {
-      value: textarea.value,
-      oldValue,
-      name: this.name,
-    });
-  }
-
-  private _handleChange(event: Event) {
-    const textarea = event.target as HTMLTextAreaElement;
-    const oldValue = this.getValue();
-
-    // Emit custom change event
-    this.emit("ct-change", {
-      value: textarea.value,
-      oldValue,
-      name: this.name,
-    });
-  }
-
-  private _handleFocus(_event: Event) {
-    this._cellController.onFocus();
-    this.emit("ct-focus", {
-      value: this.getValue(),
-      name: this.name,
-    });
-  }
-
-  private _handleBlur(_event: Event) {
-    this._cellController.onBlur();
-    this.emit("ct-blur", {
-      value: this.getValue(),
-      name: this.name,
-    });
-  }
-
-  private _handleKeyDown(event: KeyboardEvent) {
-    this.emit("ct-keydown", {
-      key: event.key,
-      value: this.getValue(),
-      shiftKey: event.shiftKey,
-      ctrlKey: event.ctrlKey,
-      metaKey: event.metaKey,
-      altKey: event.altKey,
-      name: this.name,
-    });
-
-    // Special handling for Enter key with modifiers
-    if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
-      this.emit("ct-submit", {
-        value: this.getValue(),
-        name: this.name,
-      });
-    }
-  }
-
-  /**
-   * Adjust height for auto-resize functionality
-   */
-  private adjustHeight(): void {
-    if (!this.textarea || !this.autoResize) return;
-
-    // Reset height to recalculate
-    (this.textarea as HTMLTextAreaElement).style.height = "auto";
-
-    // Set new height based on scrollHeight
-    const newHeight = Math.max(
-      this._minHeight,
-      (this.textarea as HTMLTextAreaElement).scrollHeight,
-    );
-    (this.textarea as HTMLTextAreaElement).style.height = `${newHeight}px`;
-  }
-
-  /**
-   * Focus the textarea programmatically
-   */
-  override focus(): void {
-    this.textarea?.focus();
-  }
-
-  /**
-   * Blur the textarea programmatically
-   */
-  override blur(): void {
-    this.textarea?.blur();
-  }
-
-  /**
-   * Select all text in the textarea
-   */
-  select(): void {
-    this.textarea?.select();
-  }
-
-  /**
-   * Set selection range in the textarea
-   */
-  setSelectionRange(
-    start: number,
-    end: number,
-    direction?: "forward" | "backward" | "none",
-  ): void {
-    this.textarea?.setSelectionRange(start, end, direction);
-  }
-
-  /**
-   * Check validity of the textarea
-   */
-  checkValidity(): boolean {
-    return this.textarea?.checkValidity() ?? true;
-  }
-
-  /**
-   * Report validity of the textarea
-   */
-  reportValidity(): boolean {
-    return this.textarea?.reportValidity() ?? true;
-  }
-
-  /**
-   * Get the validity state
-   */
-  get validity(): ValidityState | undefined {
-    return this.textarea?.validity;
-  }
-
-  /**
-   * Get validation message
-   */
-  get validationMessage(): string {
-    return this.textarea?.validationMessage || "";
-  }
-
-  /**
-   * Set custom validity message
-   */
-  setCustomValidity(message: string): void {
-    this.textarea?.setCustomValidity(message);
-  }
-}
-
-globalThis.customElements.define("ct-textarea", CTTextarea);
+    globalThis.customElements.define("ct-textarea", CTTextarea);


### PR DESCRIPTION
## Summary
- Adds `Cell<string>` support to `ct-textarea`, matching `ct-input` behavior
- Uses `createStringCellController` for unified value handling
- Adds `timingStrategy` and `timingDelay` properties for debounce/throttle/blur control
- Now you can pass a Cell directly: `<ct-textarea .value="${myCell}" />`

## Changes
- Import `Cell` type and `createStringCellController`
- Add `timingStrategy` ("immediate" | "debounce" | "throttle" | "blur") and `timingDelay` properties
- Use CellController for `getValue()`/`setValue()` operations
- Bind value (Cell or plain string) to controller in `firstUpdated`/`updated`
- Add focus/blur hooks for timing controller integration
- Add `name` to all event details for consistency with `ct-input`

## Test plan
- [ ] Create a pattern using `ct-textarea` with a Cell value
- [ ] Verify two-way binding works (typing updates cell, cell changes update textarea)
- [ ] Test timing strategies (debounce, blur, immediate)

🤖 Generated with [Claude Code](https://claude.ai/code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two-way Cell<string> binding to ct-textarea and configurable input timing. This matches ct-input behavior and standardizes event payloads.

- **New Features**
  - Accepts Cell<string> via value for reactive two-way updates.
  - timingStrategy ("immediate", "debounce", "throttle", "blur") and timingDelay to control update timing.

- **Refactors**
  - Unified value handling via createStringCellController (get/set and focus/blur hooks).
  - Events now include name on all ct-* events, and oldValue on ct-input and ct-change.

<sup>Written for commit 8cd50b5167ca36262503e3fa4c26c92b229b4542. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



