### PR TITLE
Add AND/OR hashtag query support for wish

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1270,10 +1270,19 @@ export type CompileAndRunFunction = <T = any, S = any>(
 
 export type WishTag = `/${string}` | `#${string}`;
 
+/**
+ * Query for multiple hashtags with explicit AND/OR logic.
+ * - `{ and: ["#tag1", "#tag2"] }` - matches items with ALL specified tags
+ * - `{ or: ["#tag1", "#tag2"] }` - matches items with ANY of the specified tags
+ */
+export type HashtagQuery =
+  | { and: WishTag[] }
+  | { or: WishTag[] };
+
 export type DID = `did:${string}:${string}`;
 
 export type WishParams = {
-  query: WishTag | string;
+  query: WishTag | string | HashtagQuery;
   path?: string[];
   context?: Record<string, any>;
   schema?: JSONSchema;


### PR DESCRIPTION
## Summary

Adds `HashtagQuery` type that allows filtering favorites by multiple hashtags with explicit AND/OR semantics.

## Usage

```typescript
// Single tag (existing - unchanged)
wish({ query: "#tag1" })

// AND - matches items with ALL specified tags
wish({ query: { and: ["#tag1", "#tag2"] } })

// OR - matches items with ANY specified tag  
wish({ query: { or: ["#tag1", "#tag2"] } })
```

## Changes

- Add `HashtagQuery` type to `api/index.ts`
- Extend `WishParams.query` to accept `HashtagQuery`
- Add `resolveHashtagQuery()` function in `wish.ts` with AND/OR filtering logic
- Add `isHashtagQuery()` type guard and `parseHashtagQuery()` helper
- Add tests for AND, OR, and error cases

## Design Notes

The API follows the pattern used by Notion/GraphQL for compound filters - explicit `{ and: [...] }` / `{ or: [...] }` wrapper objects. This was chosen over:
- Comma-separated strings (GitHub style) - less type-safe
- Bare arrays with implicit default - ambiguous semantics
- `$and`/`$or` operators (MongoDB style) - less idiomatic for TypeScript

Bare arrays are intentionally not supported yet to avoid committing to a default behavior prematurely.

## Test plan

- [x] AND query matches items with ALL specified tags
- [x] OR query matches items with ANY specified tag
- [x] Error returned when no matches found
- [x] All existing wish tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add AND/OR hashtag query support to wish so you can filter favorites by multiple tags. Single-tag queries still work, and we return clear errors when nothing matches.

- **New Features**
  - Added HashtagQuery type and extended WishParams.query to accept it.
  - Implemented resolveHashtagQuery with AND (all tags) and OR (any tag) matching.
  - Added isHashtagQuery type guard and parseHashtagQuery helper.
  - When multiple matches are found, launches the wish pattern; when none, returns an error.
  - Added tests for AND, OR, and no-match cases.

<sup>Written for commit 054d52fd7b67db33f015b1cba853d5487860634a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

