### PR TITLE
Update `todo-list.tsx` with `ct-textarea` and `wish()`

### DIFF
--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -2864,6 +2864,7 @@ interface CTListElement extends CTHTMLElement {}
 interface CTListItemElement extends CTHTMLElement {}
 interface CTLoaderElement extends CTHTMLElement {}
 interface CTInputElement extends CTHTMLElement {}
+interface CTTextAreaElement extends CTHTMLElement {}
 interface CTFileInputElement extends CTHTMLElement {}
 interface CTImageInputElement extends CTHTMLElement {}
 interface CTInputLegacyElement extends CTHTMLElement {}
@@ -3259,6 +3260,47 @@ interface CTInputAttributes<T> extends CTHTMLAttributes<T> {
   "onct-keydown"?: any;
   "onct-submit"?: any;
   "onct-invalid"?: any;
+}
+
+interface CTTextAreaAttributes<T> extends CTHTMLAttributes<T> {
+  "$value"?: CellLike<string>;
+  "value"?: CellLike<string> | string;
+  "placeholder"?: string;
+  "disabled"?: boolean;
+  "readonly"?: boolean;
+  "error"?: boolean;
+  "name"?: string;
+  "required"?: boolean;
+  "autofocus"?: boolean;
+  "rows"?: number;
+  "cols"?: number;
+  "maxlength"?: string;
+  "minlength"?: string;
+  "wrap"?: string;
+  "spellcheck"?: boolean;
+  "autocomplete"?: string;
+  "resize"?: string;
+  "auto-resize"?: boolean;
+  "timing-strategy"?: "immediate" | "debounce" | "throttle" | "blur";
+  "timing-delay"?: number;
+  "onct-input"?: EventHandler<
+    { value: string; oldValue: string; name: string }
+  >;
+  "onct-change"?: EventHandler<
+    { value: string; oldValue: string; name: string }
+  >;
+  "onct-focus"?: EventHandler<{ value: string; name: string }>;
+  "onct-blur"?: EventHandler<{ value: string; name: string }>;
+  "onct-keydown"?: EventHandler<{
+    key: string;
+    value: string;
+    shiftKey: boolean;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    altKey: boolean;
+    name: string;
+  }>;
+  "onct-submit"?: EventHandler<{ value: string; name: string }>;
 }
 
 interface CTInputLegacyAttributes<T> extends CTHTMLAttributes<T> {
@@ -3904,6 +3946,10 @@ declare global {
       "ct-input": CTDOM.DetailedHTMLProps<
         CTInputAttributes<CTInputElement>,
         CTInputElement
+      >;
+      "ct-textarea": CTDOM.DetailedHTMLProps<
+        CTTextAreaAttributes<CTTextAreaElement>,
+        CTTextAreaElement
       >;
       "ct-file-input": CTDOM.DetailedHTMLProps<
         CTFileInputAttributes<CTFileInputElement>,

--- a/packages/patterns/todo-list.tsx
+++ b/packages/patterns/todo-list.tsx
@@ -1,6 +1,5 @@
 /// <cts-enable />
-import { Cell, Default, derive, NAME, pattern, UI } from "commontools";
-import Suggestion from "./suggestion.tsx";
+import { Cell, Default, NAME, pattern, UI, wish } from "commontools";
 
 interface TodoItem {
   title: string;
@@ -16,13 +15,6 @@ interface Output {
 }
 
 export default pattern<Input, Output>(({ items }) => {
-  // AI suggestion based on current todos
-  const suggestion = Suggestion({
-    situation:
-      "Based on my todo list, use a pattern to help me. For sub-tasks and additional tasks, use a todo list.",
-    context: { items },
-  });
-
   return {
     [NAME]: "Todo with Suggestions",
     [UI]: (
@@ -43,6 +35,12 @@ export default pattern<Input, Output>(({ items }) => {
         {/* Todo items with per-item suggestions */}
         <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
           {items.map((item) => {
+            // AI suggestion based on current todos
+            const wishResult = wish({
+              query: item.title,
+              context: { item, items },
+            });
+
             return (
               <div
                 style={{
@@ -63,7 +61,7 @@ export default pattern<Input, Output>(({ items }) => {
                         ? { textDecoration: "line-through", opacity: 0.6 }
                         : {}}
                     >
-                      {item.title}
+                      <ct-textarea $value={item.title} />
                     </span>
                   </ct-checkbox>
                   <ct-button
@@ -80,31 +78,17 @@ export default pattern<Input, Output>(({ items }) => {
                     ×
                   </ct-button>
                 </div>
+
+                <details open>
+                  <summary>AI Suggestion</summary>
+                  {wishResult}
+                </details>
               </div>
             );
           })}
         </div>
-
-        {/* AI Suggestion */}
-        <ct-cell-context $cell={suggestion} label="AI Suggestion">
-          <div
-            style={{
-              marginTop: "16px",
-              padding: "12px",
-              backgroundColor: "#f5f5f5",
-              borderRadius: "8px",
-            }}
-          >
-            <h3>AI Suggestion</h3>
-            {derive(suggestion, (s) =>
-              s?.result ?? (
-                <span style={{ opacity: 0.6 }}>Getting suggestion...</span>
-              ))}
-          </div>
-        </ct-cell-context>
       </div>
     ),
     items,
-    suggestion,
   };
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds ct-textarea typings and updates the todo list to use it for inline editing. Replaces the old Suggestion pattern with per-item suggestions using wish().

- New Features
  - Added CTTextAreaElement and CTTextAreaAttributes to JSX types and registered "ct-textarea".
  - Switched todo titles to inline editing with <ct-textarea $value={item.title}>.
  - Replaced the global suggestion block with per-item suggestions via wish(query: item.title, context: { item, items }) displayed in a details section.

<sup>Written for commit 668a40ecad9d0a55ed812476460ecebd5d6964b5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

