### PR TITLE
feat(ui): Add pointer coordinates and drop zone rect to ct-drop event

### DIFF
--- a/packages/ui/src/v2/components/ct-drop-zone/ct-drop-zone.ts
+++ b/packages/ui/src/v2/components/ct-drop-zone/ct-drop-zone.ts
@@ -164,10 +164,21 @@ export class CTDropZone extends BaseElement {
       // Emit leave event before drop (dropping is a form of leaving)
       this.emit("ct-drag-leave", {});
 
-      // Emit drop event
+      // Get drop zone bounding rect for position calculation in handler
+      const dropZoneRect = this.getBoundingClientRect();
+
+      // Emit drop event with pointer coordinates and drop zone rect
       this.emit("ct-drop", {
         sourceCell: dragState.cell,
         type: dragState.type,
+        pointerX: dragState.pointerX,
+        pointerY: dragState.pointerY,
+        dropZoneRect: {
+          left: dropZoneRect.left,
+          top: dropZoneRect.top,
+          width: dropZoneRect.width,
+          height: dropZoneRect.height,
+        },
       });
     }
   }


### PR DESCRIPTION
## Summary

- Adds `pointerX` and `pointerY` (cursor coordinates at drop time) to the `ct-drop` event
- Adds `dropZoneRect` (bounding rect with `left`, `top`, `width`, `height`) to the `ct-drop` event

## Motivation

Pattern handlers need to calculate precise drop positions within a drop zone. Due to shadow DOM isolation, patterns cannot use `document.querySelector()` or `document.elementFromPoint()` to find elements. By providing the drop zone's bounding rect and pointer coordinates directly in the event, handlers can compute relative positions.

**Example use case**: Placing tiles on a game board where you need to know which cell the tile was dropped on.

## Test plan

- [x] Verified changes compile and are included in shell bundle
- [ ] Test drag-drop in a pattern that uses `ct-drop-zone` (e.g., scrabble pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
ct-drop now includes pointerX/pointerY and dropZoneRect (left, top, width, height) so handlers can compute precise drop positions inside the drop zone. This removes the need for DOM queries blocked by shadow DOM.

<sup>Written for commit a118d4572a8a6bdd616333a7372f442757c6180e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

