### PR TITLE
chore: Sync a cell from CharmsController when creating a CharmController

### DIFF
--- a/packages/charm/src/ops/charms-controller.ts
+++ b/packages/charm/src/ops/charms-controller.ts
@@ -64,10 +64,7 @@ export class CharmsController<T = unknown> {
     schema?: JSONSchema,
   ): Promise<CharmController> {
     this.disposeCheck();
-    const cell = await this.#manager.get(charmId, runIt, schema);
-    if (!cell) {
-      throw new Error(`Charm "${charmId}" not found.`);
-    }
+    const cell = await (await this.#manager.get(charmId, runIt, schema)).sync();
     return new CharmController(this.#manager, cell);
   }
 


### PR DESCRIPTION
Displays synced cells in CLI when inspecting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the cell when creating a CharmController so CLI inspect shows the latest, synced state. This avoids stale data during inspection.

<sup>Written for commit 8ef0379310e864ab304c223f18b23ef593872a9f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

