### PR TITLE
feat: Support space DIDs in URLs

### DIFF
--- a/packages/cli/commands/acl.ts
+++ b/packages/cli/commands/acl.ts
@@ -121,6 +121,6 @@ function parseSpaceOptions(
   return {
     apiUrl: new URL(apiUrl),
     identityPath: identity,
-    spaceName: space,
+    space: space,
   };
 }

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -1,4 +1,4 @@
-import { createSession, Session } from "@commontools/identity";
+import { createSession, isDID, Session } from "@commontools/identity";
 import { loadIdentity } from "./identity.ts";
 import { Runtime } from "@commontools/runner";
 import { StorageManager } from "@commontools/runner/storage/cache";
@@ -13,17 +13,21 @@ import { ACLManager } from "@commontools/charm/ops";
 export interface SpaceConfig {
   apiUrl: URL;
   identityPath: string;
-  spaceName: string;
+  space: string;
 }
 
 // Create an identity and session from configuration.
 async function loadSession(config: SpaceConfig): Promise<Session> {
   const identity = await loadIdentity(config.identityPath);
-  const session = await createSession({
-    identity,
-    spaceName: config.spaceName,
-  });
-  return session;
+  return isDID(config.space)
+    ? createSession({
+      identity,
+      spaceDid: config.space,
+    })
+    : createSession({
+      identity,
+      spaceName: config.space,
+    });
 }
 
 // Creates a Runtime instance for ACL operations

--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -1,4 +1,4 @@
-import { createSession, Session } from "@commontools/identity";
+import { createSession, isDID, Session } from "@commontools/identity";
 import { ensureDir } from "@std/fs";
 import { loadIdentity } from "./identity.ts";
 import {
@@ -32,11 +32,12 @@ export interface CharmConfig extends SpaceConfig {
 }
 
 async function makeSession(config: SpaceConfig): Promise<Session> {
-  if (config.space.startsWith("did:key")) {
-    throw new Error("DID key spaces not yet supported.");
-  }
   const identity = await loadIdentity(config.identity);
-  return createSession({ identity, spaceName: config.space });
+  if (isDID(config.space)) {
+    return createSession({ identity, spaceDid: config.space });
+  } else {
+    return createSession({ identity, spaceName: config.space });
+  }
 }
 
 export async function loadManager(config: SpaceConfig): Promise<CharmManager> {

--- a/packages/shell/src/lib/app/view.ts
+++ b/packages/shell/src/lib/app/view.ts
@@ -46,7 +46,6 @@ export function appViewToUrlPath(view: AppView): `/${string}` {
       ? `/${view.spaceName}/${view.charmId}`
       : `/${view.spaceName}`;
   } else if ("spaceDid" in view) {
-    // did routes not yet supported
     return "charmId" in view
       ? `/${view.spaceDid}/${view.charmId}`
       : `/${view.spaceDid}`;
@@ -59,10 +58,12 @@ export function urlToAppView(url: URL): AppView {
   segments.shift(); // shift off the pathnames' prefix "/";
   const [first, charmId] = [segments[0], segments[1]];
 
-  if (charmId) {
-    return { spaceName: first, charmId };
-  } else if (first) {
-    return { spaceName: first };
+  if (!first) {
+    return { builtin: "home" };
   }
-  return { builtin: "home" };
+  if (isDID(first)) {
+    return charmId ? { spaceDid: first, charmId } : { spaceDid: first };
+  } else {
+    return charmId ? { spaceName: first, charmId } : { spaceName: first };
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for space DIDs in URLs and navigation across the CLI and Shell. You can now open spaces and charms by DID, not just by name.

- **New Features**
  - CLI sessions accept a space as either a DID or a name (acl and charm flow updated).
  - Shell routing parses and emits DID paths (e.g., /did:key:.../[charmId]).
  - Runtime navigation uses DID when no space name is available; home space uses the identity DID.

- **Refactors**
  - Introduced a PatternCache to cache patterns and track recent charms.
  - Simplified root pattern selection with an isHomeSpace flag.

<sup>Written for commit b2c57aafaed4872c666447383afa10bf377c4dd4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

