### PR TITLE
fix(api): handle intersection types in OpaqueRef to prevent double-wr…

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -492,8 +492,6 @@ export declare const WriteonlyCell: CellTypeConstructor<AsWriteonlyCell>;
  * OpaqueRef<Cell<T>> unwraps to Cell<T>.
  */
 export type OpaqueRef<T> = [T] extends [AnyBrandedCell<any>] ? T
-  // Handle intersection types like OpaqueCell<X> & Y - extract the OpaqueCell part
-  : T extends AnyBrandedCell<any> ? T
   :
     & OpaqueCell<T>
     & OpaqueRefInner<T>;
@@ -504,11 +502,11 @@ type OpaqueRefInner<T> = [T] extends
   [ArrayBuffer | ArrayBufferView | URL | Date] ? T
   : [T] extends [Array<infer U>] ? Array<OpaqueRef<U>>
   : [T] extends [AnyBrandedCell<any>] ? T
-  // Handle intersection types like OpaqueCell<X> & Y - don't wrap again
-  : T extends AnyBrandedCell<any> ? T
   : [T] extends [object] ? { [K in keyof T]: OpaqueRef<T[K]> }
-  // For nullable types (T | null | undefined), extract and map the non-null object/array part
+  // For nullable types (T | null | undefined), extract and map the non-null part
   : [NonNullable<T>] extends [never] ? T
+  // Handle nullable branded cells (e.g., (OpaqueCell<X> & X) | undefined) - don't wrap
+  : [NonNullable<T>] extends [AnyBrandedCell<any>] ? T
   : [NonNullable<T>] extends [Array<infer U>] ? Array<OpaqueRef<U>>
   : [NonNullable<T>] extends [object]
     ? { [K in keyof NonNullable<T>]: OpaqueRef<NonNullable<T>[K]> }

--- a/packages/runner/test/opaqueref-intersection.test.ts
+++ b/packages/runner/test/opaqueref-intersection.test.ts
@@ -9,8 +9,9 @@
  *   is not assignable to type 'NormalizedItem'.
  *   Types of property 'group' are incompatible.
  *
- * The fix adds `T extends AnyBrandedCell<any>` checks to OpaqueRef and
- * OpaqueRefInner to handle intersection types correctly.
+ * The fix adds `[NonNullable<T>] extends [AnyBrandedCell<any>]` check to
+ * OpaqueRefInner to handle nullable intersection types correctly without
+ * causing distribution over union types (which would lose null/undefined).
  *
  * NOTE: This is a type-level test. The assertions at runtime are trivial;
  * the real test is that this file compiles successfully.


### PR DESCRIPTION
…apping

The OpaqueRef<T> utility type wraps values in OpaqueCell<T> for the reactive proxy system, with special handling to avoid double-wrapping types that are already branded cells.

Problem:
The existing check `[T] extends [AnyBrandedCell<any>]` uses tuple wrapping to prevent distribution over union types. However, this pattern fails to recognize intersection types like `OpaqueCell<X> & Y` as branded cells, even though OpaqueCell<X> contributes the CELL_BRAND.

When this check fails, the intersection type falls through to the wrapping branch, creating `OpaqueCell<OpaqueCell<X> & Y>` - an incorrectly double-wrapped type that breaks type compatibility.

This manifests as pattern compilation errors like:
  Type 'OpaqueCell<{ value: OpaqueCell<string> & string; ... }> & {...}'
  is not assignable to type 'NormalizedItem'.

Solution:
Add a fallback check `T extends AnyBrandedCell<any>` (without tuple wrapper) after the primary check. The unwrapped conditional type correctly recognizes intersection types containing branded cells.

The check order is intentional:
1. `[T] extends [AnyBrandedCell<any>]` - handles unions without distribution
2. `T extends AnyBrandedCell<any>` - handles intersections correctly

This fix applies to both OpaqueRef and its helper type OpaqueRefInner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OpaqueRef to correctly handle intersection types, including nullable cases, that include branded cells, preventing double-wrapping. This removes TypeScript errors in pattern compilation and keeps types compatible.

- **Bug Fixes**
  - Use `[NonNullable<T>] extends [AnyBrandedCell<any>]` in OpaqueRefInner to detect branded intersections without union distribution, preserving null/undefined.
  - Added a regression test to validate assignability and string method calls on intersection-typed properties.

<sup>Written for commit eeb5d395e223513db470614fc59b86fdda933822. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



