### PR TITLE
Allow overriding `index.md` URL for `listPatternIndex`

### DIFF
--- a/packages/patterns/common-tools.tsx
+++ b/packages/patterns/common-tools.tsx
@@ -11,6 +11,7 @@ import {
   ifElse,
   navigateTo,
   recipe,
+  wish,
 } from "commontools";
 
 ///// COMMON TOOLS (get it?) ////
@@ -270,8 +271,12 @@ type ListPatternIndexInput = Record<string, never>;
 
 export const listPatternIndex = recipe<ListPatternIndexInput>(
   ({ _ }) => {
+    const patternIndexUrl = wish<{ url: string }>({ query: "#pattern-index" });
+
     const { pending, result } = fetchData({
-      url: "/api/patterns/index.md",
+      url: computed(() =>
+        patternIndexUrl.result.url ?? "/api/patterns/index.md"
+      ),
       mode: "text",
     });
     return ifElse(computed(() => pending || !result), undefined, { result });

--- a/packages/patterns/pattern-index.tsx
+++ b/packages/patterns/pattern-index.tsx
@@ -1,0 +1,23 @@
+/// <cts-enable />
+import { type Default, NAME, pattern, str, UI } from "commontools";
+
+type Input = { url: Default<string, "/api/patterns/index.md"> };
+
+/** A URL to a #pattern-index */
+type Output = { url: string };
+
+const PatternIndexUrl = pattern<Input, Output>(
+  ({ url }) => {
+    return {
+      [NAME]: str`Pattern Index: ${url}`,
+      [UI]: (
+        <ct-screen>
+          <ct-input $value={url} />
+        </ct-screen>
+      ),
+      url,
+    };
+  },
+);
+
+export default PatternIndexUrl;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow overriding the pattern index markdown URL used by listPatternIndex. Added a PatternIndexUrl pattern and UI to set the source; listPatternIndex reads an optional URL from #pattern-index and falls back to /api/patterns/index.md.

<sup>Written for commit 721d75a29e5c0e408e45ea5f0189b35368e17661. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

