### PR TITLE
fix(runner): initial .sink should not subscribe to child cell reads

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -41,7 +41,11 @@ import {
 } from "./query-result-proxy.ts";
 import { diffAndUpdate } from "./data-updating.ts";
 import { resolveLink } from "./link-resolution.ts";
-import { ignoreReadForScheduling, txToReactivityLog } from "./scheduler.ts";
+import {
+  type Action,
+  ignoreReadForScheduling,
+  txToReactivityLog,
+} from "./scheduler.ts";
 import { type Cancel, isCancel, useCancelGroup } from "./cancel.ts";
 import {
   processDefaultValue,
@@ -1269,25 +1273,9 @@ function subscribeToReferencedDocs<T>(
   runtime: IRuntime,
   link: NormalizedFullLink,
 ): Cancel {
-  // Get the value once to determine all the docs that need to be subscribed to.
-  const tx = runtime.edit();
-  const value = validateAndTransform(
-    runtime,
-    tx,
-    link,
-    true,
-  );
+  let cleanup: Cancel | undefined | void;
 
-  // Call the callback once with initial value.
-  let cleanup: Cancel | undefined | void = callback(value);
-  const log = txToReactivityLog(tx);
-
-  // Technically unnecessary since we don't expect/allow callbacks to sink to
-  // write to other cells, and we retry by design anyway below when read data
-  // changed. But ideally we enforce read-only as well.
-  tx.commit();
-
-  const cancel = runtime.scheduler.subscribe((tx) => {
+  const action: Action = (tx) => {
     if (isCancel(cleanup)) cleanup();
 
     // Using a new transaction for child cells, as we're only interested in
@@ -1304,7 +1292,20 @@ function subscribeToReferencedDocs<T>(
     // we add a retry? So far all sinks are read-only, so they get re-triggered
     // on changes already.
     extraTx.commit();
-  }, log);
+  };
+
+  // Call action once immediately, which also defines what docs need to be
+  // subscribed to.
+  const tx = runtime.edit();
+  action(tx);
+  const log = txToReactivityLog(tx);
+
+  // Technically unnecessary since we don't expect/allow callbacks to sink to
+  // write to other cells, and we retry by design anyway below when read data
+  // changed. But ideally we enforce read-only as well.
+  tx.commit();
+
+  const cancel = runtime.scheduler.subscribe(action, log);
 
   return () => {
     cancel();


### PR DESCRIPTION
main action already correctly set up a child tx for sub cells, refactored code to use that as well for the inital call.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed sink initialization so the first run doesn’t subscribe to child cell reads. We now reuse the scheduler action for the initial call and subscription to track only the intended docs.

- **Bug Fixes**
  - Refactored subscribeToReferencedDocs to define an Action, run it once, and subscribe using its reactivity log.
  - Ensured child cell reads run in a dedicated child transaction, preventing unintended subscriptions and redundant re-triggers.

<sup>Written for commit 716031ee2a58d09cd93078b417c097ea62b24eaa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

