### PR TITLE
fix(llm-dialog): move expensive operations out of reactive path for now

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -1764,6 +1764,7 @@ export function llmDialog(
             pending,
             internal,
             pinnedCells,
+            result,
             requestId,
             abortController.signal,
           );
@@ -1832,6 +1833,7 @@ function startRequest(
   pending: Cell<boolean>,
   internal: Cell<Schema<typeof internalSchema>>,
   pinnedCells: Cell<PinnedCell[]>,
+  result: Cell<Schema<typeof resultSchema>>,
   requestId: string,
   abortSignal: AbortSignal,
 ) {
@@ -1862,7 +1864,7 @@ function startRequest(
   const mergedPinnedCells = [...contextAsPinnedCells, ...toolPinnedCells];
 
   // Write to result cell
-  pinnedCells.withTx(tx).set(mergedPinnedCells as any);
+  result.withTx(tx).key("pinnedCells").set(mergedPinnedCells as any);
 
   const toolCatalog = buildToolCatalog(toolsCell);
 
@@ -2079,6 +2081,7 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
               pending,
               internal,
               pinnedCells,
+              result,
               requestId,
               abortSignal,
             );


### PR DESCRIPTION
On my machine both of these parts together often took 80-150ms









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved expensive tool flattening and context/pinned-cell merging out of the reactive loop in llm-dialog to reduce recomputation and improve responsiveness. Flattened tools are no longer calculated reactively; pinned cells are consolidated once at request start.

- **Refactors**
  - Compute and merge context cells with tool-pinned cells in startRequest, de-duplicate by path, and write to result.pinnedCells.
  - Remove reactive updates for flattenedTools and pinnedCells in the dialog path (UI handles tool flattening).

<sup>Written for commit af1843a026463087737a38d39c4bf13107645c6b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









