### PR TITLE
feat: Update felt to support multiple file inputs

### DIFF
--- a/packages/felt/interface.ts
+++ b/packages/felt/interface.ts
@@ -1,11 +1,16 @@
 import { join } from "@std/path/join";
 import { type TsconfigRaw } from "esbuild";
 
-export interface Config {
+export interface EntryPoint {
   // JS entry from root
-  entry: string;
+  in: string;
   // JS output from `outDir`
   out: string;
+}
+
+export interface Config {
+  // Entry points to build
+  entries: EntryPoint[];
   // Output directory from root to place build artifacts.
   // Defaults to "dist".
   outDir: string;
@@ -51,9 +56,13 @@ export interface ESBuildConfig {
   >;
 }
 
-export class ResolvedConfig {
-  entry: string;
+export interface ResolvedEntryPoint {
+  in: string;
   out: string;
+}
+
+export class ResolvedConfig {
+  entries: ResolvedEntryPoint[];
   outDir: string;
   hostname: string;
   port: number;
@@ -77,9 +86,11 @@ export class ResolvedConfig {
   cwd: string;
   constructor(partial: Config, cwd = Deno.cwd()) {
     this.cwd = cwd;
-    this.entry = join(cwd, partial.entry);
     this.outDir = join(cwd, partial.outDir ?? "dist");
-    this.out = join(this.outDir, partial.out);
+    this.entries = partial.entries.map(({ in: entry, out }) => ({
+      in: join(cwd, entry),
+      out: join(this.outDir, out),
+    }));
     this.publicDir = join(cwd, partial?.publicDir ?? "public");
     this.watchDir = join(cwd, partial?.watchDir ?? "src");
     this.hostname = partial?.hostname ?? "127.0.0.1";

--- a/packages/felt/mod.ts
+++ b/packages/felt/mod.ts
@@ -1,2 +1,2 @@
-export type { Config, ESBuildConfig } from "./interface.ts";
+export type { Config, EntryPoint, ESBuildConfig } from "./interface.ts";
 export { build } from "./builder.ts";

--- a/packages/shell/felt.config.ts
+++ b/packages/shell/felt.config.ts
@@ -4,8 +4,10 @@ const PRODUCTION = !!Deno.env.get("PRODUCTION");
 const ENVIRONMENT = PRODUCTION ? "production" : "development";
 
 const config: Config = {
-  entry: "src/index.ts",
-  out: "scripts/index.js",
+  entries: [
+    { in: "src/index.ts", out: "scripts/index" },
+    { in: "src/worker.ts", out: "scripts/worker" },
+  ],
   outDir: "dist",
   hostname: "127.0.0.1",
   port: 5173,

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -32,3 +32,4 @@ if (ENVIRONMENT !== "production") {
 await app.initializeKeys();
 
 const _navigation = new Navigation(app);
+(globalThis as any).worker = new Worker("./scripts/worker.js");

--- a/packages/shell/src/worker.ts
+++ b/packages/shell/src/worker.ts
@@ -1,0 +1,7 @@
+// Dummy worker script for testing multi-entry build
+self.onmessage = (e: MessageEvent) => {
+  console.log("Worker received:", e.data);
+  self.postMessage({ received: e.data });
+};
+
+console.log("Worker initialized");

--- a/packages/toolshed/routes/shell/shell.index.ts
+++ b/packages/toolshed/routes/shell/shell.index.ts
@@ -132,23 +132,19 @@ if (COMPILED) {
 
   // Handle root-level resources that shell app requests
   router.get("/DEV_SOCKET.js", async (_) => {
-    const response = await fetch(`${SHELL_URL}/DEV_SOCKET.js`);
-    return response;
+    return await fetch(`${SHELL_URL}/DEV_SOCKET.js`);
   });
 
   router.get("/scripts/*", async (c) => {
-    const response = await fetch(`${SHELL_URL}${c.req.path}`);
-    return response;
+    return await fetch(`${SHELL_URL}${c.req.path}`);
   });
 
   router.get("/styles/*", async (c) => {
-    const response = await fetch(`${SHELL_URL}${c.req.path}`);
-    return response;
+    return await fetch(`${SHELL_URL}${c.req.path}`);
   });
 
   router.get("/assets/*", async (c) => {
-    const response = await fetch(`${SHELL_URL}${c.req.path}`);
-    return response;
+    return await fetch(`${SHELL_URL}${c.req.path}`);
   });
 
   router.get("/*", async (c) => {


### PR DESCRIPTION
in service of running a web worker in shell.

* Add a dummy web worker in shell for future RuntimeWorker.
* Runs in local dev servers, and compiled toolshed environments





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multi-entry support to felt to build multiple bundles, including a shell web worker. Shell now loads a dummy worker that runs in local dev and Toolshed builds.

- **New Features**
  - Felt builder accepts an entries array and builds each entry separately.
  - Added src/worker.ts and spawned it via new Worker("./scripts/worker.js").
  - Toolshed router proxies DEV_SOCKET.js, /scripts, /styles, and /assets to the shell server.

- **Migration**
  - Update felt.config.ts: replace entry/out with entries: [{ in, out }, ...].

<sup>Written for commit 0a73efc2423002f383dc6fdccca87f07bf5362ef. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





