### PR TITLE
fix(patterns): handle flaky clicks in list-operations integration test

### DIFF
--- a/packages/patterns/integration/list-operations.test.ts
+++ b/packages/patterns/integration/list-operations.test.ts
@@ -54,10 +54,8 @@ describe("list-operations simple test", () => {
     await page.waitForSelector("#main-list", { strategy: "pierce" });
 
     // Click reset to populate with initial data
-    const resetBtn = await page.waitForSelector("#reset-demo", {
-      strategy: "pierce",
-    });
-    await resetBtn.click();
+    // Use waitFor with try/catch to handle unstable box model during page settling
+    await clickButton(page, "#reset-demo");
 
     // Wait for the reset operation to complete by checking the text content
     await waitFor(async () => {
@@ -66,10 +64,7 @@ describe("list-operations simple test", () => {
     });
 
     // Test delete first item
-    const deleteFirstBtn = await page.waitForSelector("#delete-first", {
-      strategy: "pierce",
-    });
-    await deleteFirstBtn.click();
+    await clickButton(page, "#delete-first");
 
     // Wait for delete to complete
     await waitFor(async () => {
@@ -84,10 +79,7 @@ describe("list-operations simple test", () => {
     );
 
     // Test insert at start
-    const insertStartBtn = await page.waitForSelector("#insert-start", {
-      strategy: "pierce",
-    });
-    await insertStartBtn.click();
+    await clickButton(page, "#insert-start");
 
     // Wait for insert to complete
     await waitFor(async () => {
@@ -102,10 +94,7 @@ describe("list-operations simple test", () => {
     );
 
     // Test one more operation: delete-last to see if it works
-    const deleteLastBtn = await page.waitForSelector("#delete-last", {
-      strategy: "pierce",
-    });
-    await deleteLastBtn.click();
+    await clickButton(page, "#delete-last");
 
     await waitFor(async () => {
       const text = await getMainListText(page);
@@ -134,4 +123,19 @@ async function getMainListText(page: Page): Promise<string | null> {
   } catch (_) {
     return null;
   }
+}
+
+// Clicks a button, retrying if the element lacks a stable box model.
+// This handles timing issues where the element is found but the page
+// is still settling (re-renders, layout shifts, hydration).
+function clickButton(page: Page, selector: string): Promise<void> {
+  return waitFor(async () => {
+    const btn = await page.waitForSelector(selector, { strategy: "pierce" });
+    try {
+      await btn.click();
+      return true;
+    } catch (_) {
+      return false;
+    }
+  });
 }


### PR DESCRIPTION
Wrap button clicks in waitFor with try/catch to handle "Unable to get stable box model" errors that occur when the page is still settling during re-renders, layout shifts, or hydration.

This follows the same pattern used in ct-checkbox.test.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the list-operations integration test resilient to flaky clicks by retrying button clicks until the element has a stable box model. Prevents "Unable to get stable box model" errors during hydration and layout shifts.

- **Bug Fixes**
  - Added a clickButton helper that wraps clicks in waitFor with try/catch.
  - Replaced direct clicks for reset, delete-first, insert-start, and delete-last with the helper, matching the pattern used in ct-checkbox.test.ts.

<sup>Written for commit 5c1d1613c3603c1fbba30512f59719daa556b0aa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

