### PR TITLE
debug(runner): add console.log for slow actions for now

### DIFF
--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -573,11 +573,15 @@ export class Scheduler implements IScheduler {
         this.runningPromise = Promise.resolve(
           this.runtime.harness.invoke(() => action(tx)),
         ).then(() => {
+          const duration = (performance.now() - actionStartTime) / 1000;
+          if (duration > 10) {
+            console.warn(`Slow action: ${duration.toFixed(3)}s`, action);
+          }
           logger.debug("action-timing", () => {
-            const duration = ((performance.now() - actionStartTime) / 1000)
-              .toFixed(3);
             return [
-              `Action ${action.name || "anonymous"} completed in ${duration}s`,
+              `Action ${action.name || "anonymous"} completed in ${
+                duration.toFixed(3)
+              }s`,
             ];
           });
           finalize();


### PR DESCRIPTION
this is temporary to get some data





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a console warning when a scheduler action takes longer than 10s, and keep precise timing in the debug log. The duration is computed once and reused for both the warning and the debug message.

<sup>Written for commit 151851493360bcbc34b60cc95c676640c2805da0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





