### PR TITLE
update schema for new literal behavior

### DIFF
--- a/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.tsx
@@ -243,8 +243,13 @@ export default pattern((state) => {
             },
             required: ["state"]
         } as const satisfies __ctHelpers.JSONSchema, {
-            type: "number",
-            asOpaque: true
+            anyOf: [{
+                    type: "number",
+                    "enum": [0]
+                }, {
+                    type: "number",
+                    asOpaque: true
+                }]
         } as const satisfies __ctHelpers.JSONSchema, { state: {
                 items: state.items,
                 selectedIndex: state.selectedIndex


### PR DESCRIPTION
Fix broken test on main, oops

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the JSON schema in the closures/map-and-handler test fixture to match the new literal behavior. Replaces a plain number schema with anyOf: a number literal 0 (enum) or an opaque number, fixing the failing test on main.

<sup>Written for commit cbdb19eace50a11be0d22fdd2e3bd9f00891a14e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

