### PR TITLE
fix: update OAuth refresh route schema to match handler

### DIFF
--- a/packages/toolshed/routes/integrations/google-oauth/google-oauth.routes.ts
+++ b/packages/toolshed/routes/integrations/google-oauth/google-oauth.routes.ts
@@ -122,16 +122,15 @@ export const refresh = createRoute({
         "application/json": {
           schema: z
             .object({
-              authCellId: z
+              refreshToken: z
                 .string()
                 .describe(
-                  "The authentication cell ID containing the refresh token",
+                  "The refresh token to use for obtaining new access tokens",
                 ),
             })
             .openapi({
               example: {
-                authCellId:
-                  '{"/" : {"link-v0.1" : {"id" : "of:bafe...", "space" : "did:key:bafe...", "path" : ["path", "to", "value"]}}}',
+                refreshToken: "1//0abc123...",
               },
             }),
         },


### PR DESCRIPTION
## Summary

Fixes the OpenAPI route schema for the `/api/integrations/google-oauth/refresh` endpoint to match the handler implementation.

**Fixes CT-1112**

## The Problem

The refresh endpoint handler was changed in PR #677 to expect `{ refreshToken }` instead of `{ authCellId }`, but the OpenAPI route schema was never updated. This causes **HTTP 422 validation errors** for all callers.

### Affected Code

| Component | Expected Field |
|-----------|---------------|
| Route schema (`routes.ts:125`) | `authCellId` ❌ |
| Handler (`handlers.ts:270`) | `refreshToken` ✅ |
| Labs recipes | `refreshToken` ✅ |

### Affected Recipes

All of these send `{ refreshToken }` and fail validation:
- `recipes/gmail-importer.tsx`
- `recipes/gcal.tsx`
- `recipes/_gpeople.tsx`

## The Fix

One-line change: update route schema from `authCellId` to `refreshToken`.

```diff
           schema: z
             .object({
-              authCellId: z
+              refreshToken: z
                 .string()
                 .describe(
-                  "The authentication cell ID containing the refresh token",
+                  "The refresh token to use for obtaining new access tokens",
                 ),
             })
```

## Test Plan

- [ ] Call refresh endpoint with `{ refreshToken: "..." }` - should no longer return 422
- [ ] Verify gmail-importer token refresh works
- [ ] Verify gcal token refresh works

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the OpenAPI schema for /api/integrations/google-oauth/refresh to accept refreshToken instead of authCellId, matching the handler. Fixes 422 validation errors and unblocks recipe calls. Fixes CT-1112.

- **Bug Fixes**
  - Request body now expects { refreshToken: string }.
  - Updated example payload in the route schema.

<sup>Written for commit 8588a651d7e3d28453dde2060d38ea485590b93e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

