### PR TITLE
Improve flattenTools and buildAvailableCellsDocumentation performance

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -1896,7 +1896,9 @@ export function llmDialog(
       // Only write if the output actually changed
       const currentFlattened = result.withTx(tx).key("flattenedTools").get();
       if (toolsHaveChanged(cachedFlattenedTools, currentFlattened)) {
-        result.withTx(tx).key("flattenedTools").set(cachedFlattenedTools as any);
+        result.withTx(tx).key("flattenedTools").set(
+          cachedFlattenedTools as any,
+        );
       }
     }
 


### PR DESCRIPTION
- **Demo tweaks and fixes**
- **Optimize and reduce recalculation on flattenedTools and cell documentation**
- **Re-use CFC instance instead of making make copies**






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves LLM dialog performance by reducing recalculation of flattened tools and speeding up cell documentation generation. Also fixes code editor layout and tweaks demo patterns.

- **Refactors**
  - Cache flattenedTools and only recompute when tool keys change; write only when the output changes.
  - Reuse a shared ContextualFlowControl and add traverseAndSerializeSimple; switch documentation builder to the simple traversal for faster LLM docs.
  - Expand flattenedTools result schema to include description, inputSchema, handler, pattern schemas, and internal metadata.

- **Bug Fixes**
  - Update code editor to a flex layout to fix height/overflow issues.

<sup>Written for commit af46284419f9aad975fd4375de7f576a0c0199a3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





