### PR TITLE
chore: Target concrete Runtime interface rather than IRuntime 

### DIFF
--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -16,7 +16,7 @@ import {
 } from "./types.ts";
 import { getTopFrame } from "./recipe.ts";
 import { deepEqual } from "../path-utils.ts";
-import { IRuntime } from "../runtime.ts";
+import { Runtime } from "../runtime.ts";
 import { parseLink, sanitizeSchemaForLinks } from "../link-utils.ts";
 import {
   getCellOrThrow,
@@ -127,7 +127,7 @@ export function toJSONWithLegacyAliases(
 export function createJsonSchema(
   example: any,
   addDefaults = false,
-  runtime?: IRuntime,
+  runtime?: Runtime,
 ): JSONSchemaMutable {
   const seen = new Map<string, JSONSchemaMutable>();
 

--- a/packages/runner/src/builder/recipe.ts
+++ b/packages/runner/src/builder/recipe.ts
@@ -35,7 +35,7 @@ import {
   isCellResultForDereferencing,
 } from "../query-result-proxy.ts";
 import { isCell } from "../cell.ts";
-import { IRuntime } from "../runtime.ts";
+import { Runtime } from "../runtime.ts";
 import {
   IExtendedStorageTransaction,
   MemorySpace,
@@ -404,7 +404,7 @@ export function pushFrameFromCause(
   props: {
     unsafe_binding?: UnsafeBinding;
     inHandler?: boolean;
-    runtime?: IRuntime;
+    runtime?: Runtime;
     tx?: IExtendedStorageTransaction;
     space?: MemorySpace;
   },

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -54,7 +54,7 @@ import {
   type MemorySpace,
 } from "../storage/interface.ts";
 import { type RuntimeProgram } from "../harness/types.ts";
-import { type IRuntime } from "../runtime.ts";
+import { type Runtime } from "../runtime.ts";
 
 // Define runtime constants here - actual runtime values
 export const ID: typeof IDSymbol = Symbol("ID, unique to the context") as any;
@@ -217,7 +217,7 @@ export type Frame = {
   parent?: Frame;
   cause?: unknown;
   generatedIdCounter: number;
-  runtime?: IRuntime;
+  runtime?: Runtime;
   tx?: IExtendedStorageTransaction;
   space?: MemorySpace;
   inHandler?: boolean;

--- a/packages/runner/src/builtins/compile-and-run.ts
+++ b/packages/runner/src/builtins/compile-and-run.ts
@@ -2,7 +2,7 @@ import { type BuiltInCompileAndRunParams } from "commontools";
 import { refer } from "merkle-reference/json";
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
-import type { IRuntime } from "../runtime.ts";
+import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import type { Program } from "@commontools/js-compiler";
 import { CompilerError } from "@commontools/js-compiler/typescript";
@@ -31,7 +31,7 @@ export function compileAndRun(
   addCancel: (cancel: () => void) => void,
   cause: any,
   parentCell: Cell<any>,
-  runtime: IRuntime,
+  runtime: Runtime,
 ): Action {
   let requestId: string | undefined = undefined;
   let abortController: AbortController | undefined = undefined;

--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -1,6 +1,6 @@
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
-import type { IRuntime } from "../runtime.ts";
+import type { Runtime } from "../runtime.ts";
 import { getRecipeEnvironment } from "../builder/env.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import type { Schema } from "../builder/types.ts";
@@ -32,7 +32,7 @@ export function fetchData(
   addCancel: (cancel: () => void) => void,
   cause: Cell<any>[],
   parentCell: Cell<any>,
-  runtime: IRuntime, // Runtime will be injected by the registration function
+  runtime: Runtime, // Runtime will be injected by the registration function
 ): Action {
   let cellsInitialized = false;
   let pending: Cell<boolean>;
@@ -251,7 +251,7 @@ export function fetchData(
 }
 
 async function startFetch(
-  runtime: IRuntime,
+  runtime: Runtime,
   inputsCell: Cell<{
     url: string;
     mode?: "text" | "json";

--- a/packages/runner/src/builtins/fetch-program.ts
+++ b/packages/runner/src/builtins/fetch-program.ts
@@ -1,6 +1,6 @@
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
-import type { IRuntime } from "../runtime.ts";
+import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import type { JSONSchema } from "../builder/types.ts";
 import { HttpProgramResolver } from "@commontools/js-compiler";
@@ -100,7 +100,7 @@ export function fetchProgram(
   addCancel: (cancel: () => void) => void,
   cause: Cell<any>[],
   parentCell: Cell<any>,
-  runtime: IRuntime,
+  runtime: Runtime,
 ): Action {
   let cellsInitialized = false;
   let pending: Cell<boolean>;
@@ -271,7 +271,7 @@ export function fetchProgram(
  * the fetch can write the result.
  */
 async function startFetch(
-  runtime: IRuntime,
+  runtime: Runtime,
   cache: Cell<Record<string, FetchCacheEntry>>,
   inputHash: string,
   url: string,

--- a/packages/runner/src/builtins/fetch-utils.ts
+++ b/packages/runner/src/builtins/fetch-utils.ts
@@ -1,6 +1,6 @@
 import { refer } from "merkle-reference/json";
 import { type Cell } from "../cell.ts";
-import type { IRuntime } from "../runtime.ts";
+import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import type { JSONSchema, Schema } from "../builder/types.ts";
 
@@ -39,7 +39,7 @@ export function computeInputHash<T extends Record<string, any>>(
  * the invariant that result/error are undefined while pending.
  */
 export async function tryClaimMutex<T extends Record<string, any>>(
-  runtime: IRuntime,
+  runtime: Runtime,
   inputsCell: Cell<T>,
   pending: Cell<boolean>,
   _result: Cell<any>,
@@ -89,7 +89,7 @@ export async function tryClaimMutex<T extends Record<string, any>>(
  * to write the result as long as the inputs are still the same.
  */
 export async function tryWriteResult<T extends Record<string, any>>(
-  runtime: IRuntime,
+  runtime: Runtime,
   internal: Cell<Schema<typeof internalSchema>>,
   inputsCell: Cell<T>,
   expectedHash: string,

--- a/packages/runner/src/builtins/if-else.ts
+++ b/packages/runner/src/builtins/if-else.ts
@@ -1,6 +1,6 @@
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
-import { type IRuntime } from "../runtime.ts";
+import { type Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 
 export function ifElse(
@@ -9,7 +9,7 @@ export function ifElse(
   _addCancel: (cancel: () => void) => void,
   cause: Cell<any>[],
   parentCell: Cell<any>,
-  runtime: IRuntime, // Runtime will be injected by the registration function
+  runtime: Runtime, // Runtime will be injected by the registration function
 ): Action {
   return (tx: IExtendedStorageTransaction) => {
     const result = runtime.getCell<any>(

--- a/packages/runner/src/builtins/index.ts
+++ b/packages/runner/src/builtins/index.ts
@@ -7,7 +7,7 @@ import { generateObject, generateText, llm } from "./llm.ts";
 import { ifElse } from "./if-else.ts";
 import { when } from "./when.ts";
 import { unless } from "./unless.ts";
-import type { IRuntime } from "../runtime.ts";
+import type { Runtime } from "../runtime.ts";
 import { compileAndRun } from "./compile-and-run.ts";
 import { navigateTo } from "./navigate-to.ts";
 import { wish } from "./wish.ts";
@@ -21,7 +21,7 @@ import { llmDialog } from "./llm-dialog.ts";
 /**
  * Register all built-in modules with a runtime's module registry
  */
-export function registerBuiltins(runtime: IRuntime) {
+export function registerBuiltins(runtime: Runtime) {
   const moduleRegistry = runtime.moduleRegistry;
 
   moduleRegistry.addModuleByRef("map", raw(map));

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -25,7 +25,7 @@ import type { Cell, MemorySpace, Stream } from "../cell.ts";
 import { isCell, isStream } from "../cell.ts";
 import { ID, NAME, type Recipe } from "../builder/types.ts";
 import type { Action } from "../scheduler.ts";
-import type { IRuntime } from "../runtime.ts";
+import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { formatTransactionSummary } from "../storage/transaction-summary.ts";
 import {
@@ -235,7 +235,7 @@ function traverseAndSerialize(
  * @returns The cellified value
  */
 function traverseAndCellify(
-  runtime: IRuntime,
+  runtime: Runtime,
   space: MemorySpace,
   value: unknown,
 ): unknown {
@@ -539,7 +539,7 @@ function extractRunArguments(input: unknown): Record<string, any> {
  */
 function flattenTools(
   toolsCell: Cell<any>,
-  _runtime?: IRuntime,
+  _runtime?: Runtime,
 ): Record<
   string,
   {
@@ -762,7 +762,7 @@ function buildToolCatalog(
  * This is appended to the system prompt so the LLM has immediate context.
  */
 function buildAvailableCellsDocumentation(
-  runtime: IRuntime,
+  runtime: Runtime,
   space: MemorySpace,
   context: Record<string, Cell<any>> | undefined,
   pinnedCells: Cell<PinnedCell[]>,
@@ -925,7 +925,7 @@ type ResolvedToolCall =
   };
 
 function resolveToolCall(
-  runtime: IRuntime,
+  runtime: Runtime,
   space: MemorySpace,
   toolCallPart: BuiltInLLMToolCallPart,
   catalog: ToolCatalog,
@@ -1151,7 +1151,7 @@ type ToolCallExecutionResult = {
 };
 
 async function executeToolCalls(
-  runtime: IRuntime,
+  runtime: Runtime,
   space: MemorySpace,
   toolCatalog: ToolCatalog,
   toolCallParts: BuiltInLLMToolCallPart[],
@@ -1254,7 +1254,7 @@ export const llmToolExecutionHelpers = {
  * @returns true if the action was performed, false otherwise
  */
 async function safelyPerformUpdate(
-  runtime: IRuntime,
+  runtime: Runtime,
   pending: Cell<boolean>,
   internal: Cell<Schema<typeof internalSchema>>,
   requestId: string,
@@ -1283,7 +1283,7 @@ async function safelyPerformUpdate(
  * Handles the pin tool call.
  */
 function handlePin(
-  runtime: IRuntime,
+  runtime: Runtime,
   resolved: ResolvedToolCall & { type: "pin" },
   pinnedCells: Cell<PinnedCell[]>,
 ): { type: string; value: any } {
@@ -1313,7 +1313,7 @@ function handlePin(
  * Handles the unpin tool call.
  */
 function handleUnpin(
-  runtime: IRuntime,
+  runtime: Runtime,
   resolved: ResolvedToolCall & { type: "unpin" },
   pinnedCells: Cell<PinnedCell[]>,
 ): { type: string; value: any } {
@@ -1374,7 +1374,7 @@ function handleRead(
  * Handles the update Argument tool call.
  */
 function handleUpdateArgument(
-  runtime: IRuntime,
+  runtime: Runtime,
   resolved: ResolvedToolCall & { type: "updateArgument" },
 ): { type: string; value: any } {
   const cell = resolved.cellRef;
@@ -1419,7 +1419,7 @@ function handleUpdateArgument(
  * Handles the invoke tool call (both pattern and handler execution).
  */
 async function handleInvoke(
-  runtime: IRuntime,
+  runtime: Runtime,
   space: MemorySpace,
   resolved: ResolvedToolCall,
 ): Promise<{ type: string; value: any }> {
@@ -1556,7 +1556,7 @@ async function handleInvoke(
  * @returns Promise that resolves to the tool execution result
  */
 async function invokeToolCall(
-  runtime: IRuntime,
+  runtime: Runtime,
   space: MemorySpace,
   resolved: ResolvedToolCall,
   _catalog?: ToolCatalog,
@@ -1612,7 +1612,7 @@ export function llmDialog(
   addCancel: (cancel: () => void) => void,
   cause: any,
   parentCell: Cell<any>,
-  runtime: IRuntime, // Runtime will be injected by the registration function
+  runtime: Runtime, // Runtime will be injected by the registration function
 ): Action {
   const inputs = inputsCell.asSchema(LLMParamsSchema);
 
@@ -1840,7 +1840,7 @@ export function llmDialog(
 
 function startRequest(
   tx: IExtendedStorageTransaction,
-  runtime: IRuntime,
+  runtime: Runtime,
   space: MemorySpace,
   cause: any,
   inputs: Cell<Schema<typeof LLMParamsSchema>>,

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -19,7 +19,7 @@ import {
 import { refer } from "merkle-reference/json";
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
-import type { IRuntime } from "../runtime.ts";
+import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { llmToolExecutionHelpers } from "./llm-dialog.ts";
 import {
@@ -148,7 +148,7 @@ async function executeWithToolsLoop(params: {
   llmParams: LLMRequest;
   toolCatalog: ReturnType<typeof llmToolExecutionHelpers.buildToolCatalog>;
   updatePartial: (text: string) => void;
-  runtime: IRuntime;
+  runtime: Runtime;
   space: any;
   getCurrentRun: () => number;
   thisRun: number;
@@ -223,7 +223,7 @@ async function executeWithToolsLoop(params: {
  */
 async function handleLLMError<T, P>(
   error: unknown,
-  runtime: IRuntime,
+  runtime: Runtime,
   pendingCell: Cell<boolean>,
   resultCell: Cell<T>,
   errorCell: Cell<unknown>,
@@ -264,7 +264,7 @@ async function handleLLMError<T, P>(
  */
 function buildContextDocumentation(
   inputs: Cell<any>,
-  runtime: IRuntime,
+  runtime: Runtime,
   space: any,
   tx: IExtendedStorageTransaction,
 ): string {
@@ -323,7 +323,7 @@ export function llm(
   _addCancel: (cancel: () => void) => void,
   cause: any,
   parentCell: Cell<any>,
-  runtime: IRuntime, // Runtime will be injected by the registration function
+  runtime: Runtime, // Runtime will be injected by the registration function
 ): Action {
   const inputs = inputsCell.asSchema(LLMParamsSchema);
 
@@ -487,7 +487,7 @@ export function generateText(
   _addCancel: (cancel: () => void) => void,
   cause: any,
   parentCell: Cell<any>,
-  runtime: IRuntime,
+  runtime: Runtime,
 ): Action {
   const inputs = inputsCell.asSchema(GenerateTextParamsSchema);
 
@@ -673,7 +673,7 @@ export function generateObject<T extends Record<string, unknown>>(
   _addCancel: (cancel: () => void) => void,
   cause: any,
   parentCell: Cell<any>,
-  runtime: IRuntime,
+  runtime: Runtime,
 ): Action {
   const inputs = inputsCell.asSchema(GenerateObjectParamsSchema);
 

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -2,7 +2,7 @@ import { type JSONSchema, type Recipe } from "../builder/types.ts";
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
 import { type AddCancel } from "../cancel.ts";
-import type { IRuntime } from "../runtime.ts";
+import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 
 /**
@@ -42,7 +42,7 @@ export function map(
   addCancel: AddCancel,
   cause: any,
   parentCell: Cell<any>,
-  runtime: IRuntime, // Runtime will be injected by the registration function
+  runtime: Runtime, // Runtime will be injected by the registration function
 ): Action {
   // Tracks up to where in the source array we've handled entries. Right now we
   // start at zero, even though in principle the result doc above could have

--- a/packages/runner/src/builtins/navigate-to.ts
+++ b/packages/runner/src/builtins/navigate-to.ts
@@ -1,6 +1,6 @@
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
-import { type IRuntime } from "../runtime.ts";
+import { type Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 
 export function navigateTo(
@@ -9,7 +9,7 @@ export function navigateTo(
   _addCancel: (cancel: () => void) => void,
   cause: Cell<any>[],
   parentCell: Cell<any>,
-  runtime: IRuntime,
+  runtime: Runtime,
 ): Action {
   let isInitialized = false;
   let navigated = false;

--- a/packages/runner/src/builtins/stream-data.ts
+++ b/packages/runner/src/builtins/stream-data.ts
@@ -1,6 +1,6 @@
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
-import type { IRuntime } from "../runtime.ts";
+import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 
 /**
@@ -24,7 +24,7 @@ export function streamData(
   _addCancel: (cancel: () => void) => void,
   cause: Cell<any>[],
   parentCell: Cell<any>,
-  runtime: IRuntime, // Runtime will be injected by the registration function
+  runtime: Runtime, // Runtime will be injected by the registration function
 ): Action {
   const status = { run: 0, controller: undefined } as {
     run: number;

--- a/packages/runner/src/builtins/unless.ts
+++ b/packages/runner/src/builtins/unless.ts
@@ -1,6 +1,6 @@
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
-import { type IRuntime } from "../runtime.ts";
+import { type Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 
 /**
@@ -13,7 +13,7 @@ export function unless(
   _addCancel: (cancel: () => void) => void,
   cause: Cell<any>[],
   parentCell: Cell<any>,
-  runtime: IRuntime,
+  runtime: Runtime,
 ): Action {
   return (tx: IExtendedStorageTransaction) => {
     const result = runtime.getCell<any>(

--- a/packages/runner/src/builtins/when.ts
+++ b/packages/runner/src/builtins/when.ts
@@ -1,6 +1,6 @@
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
-import { type IRuntime } from "../runtime.ts";
+import { type Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 
 /**
@@ -13,7 +13,7 @@ export function when(
   _addCancel: (cancel: () => void) => void,
   cause: Cell<any>[],
   parentCell: Cell<any>,
-  runtime: IRuntime,
+  runtime: Runtime,
 ): Action {
   return (tx: IExtendedStorageTransaction) => {
     const result = runtime.getCell<any>(

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -8,7 +8,7 @@ import { h } from "@commontools/html";
 import { HttpProgramResolver } from "@commontools/js-compiler";
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
-import type { IRuntime } from "../runtime.ts";
+import type { Runtime } from "../runtime.ts";
 import type {
   IExtendedStorageTransaction,
   MemorySpace,
@@ -55,7 +55,7 @@ const WISH_TARGETS: Partial<Record<WishTag, WishResolution>> = {
 
 function resolveWishTarget(
   resolution: WishResolution,
-  runtime: IRuntime,
+  runtime: Runtime,
   space: MemorySpace,
   tx: IExtendedStorageTransaction,
 ): Cell<any> {
@@ -103,7 +103,7 @@ function parseWishTarget(target: string): ParsedWishTarget {
 }
 
 type WishContext = {
-  runtime: IRuntime;
+  runtime: Runtime;
   tx: IExtendedStorageTransaction;
   parentCell: Cell<any>;
   spaceCell?: Cell<unknown>;
@@ -268,7 +268,7 @@ let wishPatternFetchPromise: Promise<Recipe | undefined> | undefined;
 let wishPattern: Recipe | undefined;
 
 async function fetchWishPattern(
-  runtime: IRuntime,
+  runtime: Runtime,
 ): Promise<Recipe | undefined> {
   try {
     const program = await runtime.harness.resolve(
@@ -294,7 +294,7 @@ let suggestionPatternFetchPromise: Promise<Recipe | undefined> | undefined;
 let suggestionPattern: Recipe | undefined;
 
 async function fetchSuggestionPattern(
-  runtime: IRuntime,
+  runtime: Runtime,
 ): Promise<Recipe | undefined> {
   try {
     const program = await runtime.harness.resolve(
@@ -346,7 +346,7 @@ export function wish(
   addCancel: (cancel: () => void) => void,
   cause: Cell<any>[],
   parentCell: Cell<any>,
-  runtime: IRuntime,
+  runtime: Runtime,
 ): Action {
   // Per-instance wish pattern loading.
   let wishPatternInput: WishParams | undefined;

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -62,7 +62,7 @@ import {
   type URI,
 } from "./sigil-types.ts";
 import { areLinksSame, isLink } from "./link-utils.ts";
-import type { IRuntime } from "./runtime.ts";
+import type { Runtime } from "./runtime.ts";
 import {
   createSigilLinkFromParsedLink,
   findAndInlineDataURILinks,
@@ -187,7 +187,7 @@ declare module "@commontools/api" {
       boundTarget?: (...args: unknown[]) => unknown,
     ): OpaqueRef<T>;
     toJSON(): LegacyJSONCellLink | null;
-    runtime: IRuntime;
+    runtime: Runtime;
     tx: IExtendedStorageTransaction | undefined;
     schema?: JSONSchema;
     rootSchema?: JSONSchema;
@@ -248,7 +248,7 @@ const cellMethods = new Set<keyof ICell<unknown>>([
 ]);
 
 export function createCell<T>(
-  runtime: IRuntime,
+  runtime: Runtime,
   link?: NormalizedLink,
   tx?: IExtendedStorageTransaction,
   synced = false,
@@ -304,7 +304,7 @@ export class CellImpl<T> implements ICell<T>, IStreamable<T> {
   private _kind: CellKind;
 
   constructor(
-    public readonly runtime: IRuntime,
+    public readonly runtime: Runtime,
     public readonly tx: IExtendedStorageTransaction | undefined,
     link?: NormalizedLink,
     private synced: boolean = false,
@@ -1270,7 +1270,7 @@ export class CellImpl<T> implements ICell<T>, IStreamable<T> {
 
 function subscribeToReferencedDocs<T>(
   callback: (value: T) => Cancel | undefined | void,
-  runtime: IRuntime,
+  runtime: Runtime,
   link: NormalizedFullLink,
 ): Cancel {
   let cleanup: Cancel | undefined | void;

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -22,7 +22,7 @@ import {
   type IReadOptions,
   type JSONValue,
 } from "./storage/interface.ts";
-import { type IRuntime } from "./runtime.ts";
+import { type Runtime } from "./runtime.ts";
 import { toURI } from "./uri-utils.ts";
 
 const diffLogger = getLogger("normalizeAndDiff", {
@@ -46,7 +46,7 @@ const diffLogger = getLogger("normalizeAndDiff", {
  * @returns Whether any changes were made.
  */
 export function diffAndUpdate(
-  runtime: IRuntime,
+  runtime: Runtime,
   tx: IExtendedStorageTransaction,
   link: NormalizedFullLink,
   newValue: unknown,
@@ -96,7 +96,7 @@ type ChangeSet = {
  * @returns An array of changes that should be written.
  */
 export function normalizeAndDiff(
-  runtime: IRuntime,
+  runtime: Runtime,
   tx: IExtendedStorageTransaction,
   link: NormalizedFullLink,
   newValue: unknown,

--- a/packages/runner/src/ensure-charm-running.ts
+++ b/packages/runner/src/ensure-charm-running.ts
@@ -2,7 +2,7 @@ import { getLogger } from "@commontools/utils/logger";
 import { TYPE } from "./builder/types.ts";
 import type { Cell } from "./cell.ts";
 import { type NormalizedFullLink, parseLink } from "./link-utils.ts";
-import type { IRuntime } from "./runtime.ts";
+import type { Runtime } from "./runtime.ts";
 
 const logger = getLogger("ensure-charm-running", {
   enabled: false,
@@ -32,7 +32,7 @@ const logger = getLogger("ensure-charm-running", {
  * @returns Promise<boolean> - true if a charm was started, false otherwise
  */
 export async function ensureCharmRunning(
-  runtime: IRuntime,
+  runtime: Runtime,
   cellLink: NormalizedFullLink,
 ): Promise<boolean> {
   try {

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -18,7 +18,7 @@ import {
 import { UnsafeEvalIsolate, UnsafeEvalRuntime } from "./eval-runtime.ts";
 import { CommonToolsTransformerPipeline } from "@commontools/ts-transformers";
 import * as RuntimeModules from "./runtime-modules.ts";
-import { IRuntime } from "../runtime.ts";
+import { Runtime } from "../runtime.ts";
 import * as merkleReference from "merkle-reference";
 import { StaticCache } from "@commontools/static";
 import { pretransformProgram } from "./pretransform.ts";
@@ -88,9 +88,9 @@ interface Internals {
 
 export class Engine extends EventTarget implements Harness {
   private internals: Internals | undefined;
-  private ctRuntime: IRuntime;
+  private ctRuntime: Runtime;
 
-  constructor(ctRuntime: IRuntime) {
+  constructor(ctRuntime: Runtime) {
     super();
     this.ctRuntime = ctRuntime;
     // We install our console shim globally so that it can be referenced

--- a/packages/runner/src/module.ts
+++ b/packages/runner/src/module.ts
@@ -3,14 +3,14 @@ import { Module, type ModuleFactory } from "./builder/types.ts";
 import type { Cell } from "./cell.ts";
 import type { Action } from "./scheduler.ts";
 import type { AddCancel } from "./cancel.ts";
-import type { IModuleRegistry, IRuntime } from "./runtime.ts";
+import type { IModuleRegistry, Runtime } from "./runtime.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 
 export class ModuleRegistry implements IModuleRegistry {
   private moduleMap = new Map<string, Module>();
-  readonly runtime: IRuntime;
+  readonly runtime: Runtime;
 
-  constructor(runtime: IRuntime) {
+  constructor(runtime: Runtime) {
     this.runtime = runtime;
   }
 
@@ -40,7 +40,7 @@ export function raw<T, R>(
     addCancel: AddCancel,
     cause: any,
     parentCell: Cell<any>,
-    runtime: IRuntime,
+    runtime: Runtime,
   ) => Action,
 ): ModuleFactory<T, R> {
   return createNodeFactory({

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -6,7 +6,7 @@ import { diffAndUpdate } from "./data-updating.ts";
 import { resolveLink } from "./link-resolution.ts";
 import { type NormalizedFullLink } from "./link-utils.ts";
 import { type Cell, createCell } from "./cell.ts";
-import { type IRuntime } from "./runtime.ts";
+import { type Runtime } from "./runtime.ts";
 import { type IExtendedStorageTransaction } from "./storage/interface.ts";
 import { toURI } from "./uri-utils.ts";
 
@@ -75,7 +75,7 @@ const arrayMethods: { [key: string]: ArrayMethodType } = {
 };
 
 export function createQueryResultProxy<T>(
-  runtime: IRuntime,
+  runtime: Runtime,
   tx: IExtendedStorageTransaction | undefined,
   link: NormalizedFullLink,
   depth: number = 0,
@@ -324,7 +324,7 @@ type ProxyForArrayValue = {
 const originalIndex = Symbol("original index");
 
 const createProxyForArrayValue = (
-  runtime: IRuntime,
+  runtime: Runtime,
   tx: IExtendedStorageTransaction | undefined,
   source: number,
   link: NormalizedFullLink,

--- a/packages/runner/src/recipe-manager.ts
+++ b/packages/runner/src/recipe-manager.ts
@@ -7,7 +7,7 @@ import {
   unsafe_originalRecipe,
 } from "./builder/types.ts";
 import { Cell } from "./cell.ts";
-import type { IRecipeManager, IRuntime, MemorySpace } from "./runtime.ts";
+import type { IRecipeManager, MemorySpace, Runtime } from "./runtime.ts";
 import { createRef } from "./create-ref.ts";
 import { RuntimeProgram } from "./harness/types.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
@@ -58,7 +58,7 @@ export class RecipeManager implements IRecipeManager {
   // Pending metadata set before the meta cell exists (e.g., spec, parents)
   private pendingMetaById = new Map<string, Partial<RecipeMeta>>();
 
-  constructor(readonly runtime: IRuntime) {}
+  constructor(readonly runtime: Runtime) {}
 
   private getRecipeMetaCell(
     { recipeId, space }: { recipeId: string; space: MemorySpace },

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -46,7 +46,7 @@ import { deepEqual } from "./path-utils.ts";
 import { sendValueToBinding } from "./recipe-binding.ts";
 import { type AddCancel, type Cancel, useCancelGroup } from "./cancel.ts";
 import { LINK_V1_TAG, SigilLink } from "./sigil-types.ts";
-import type { IRunner, IRuntime } from "./runtime.ts";
+import type { IRunner, Runtime } from "./runtime.ts";
 import type {
   IExtendedStorageTransaction,
   IStorageSubscription,
@@ -68,7 +68,7 @@ export class Runner implements IRunner {
   // recipes as strings
   private resultRecipeCache = new Map<`${MemorySpace}/${URI}`, string>();
 
-  constructor(readonly runtime: IRuntime) {
+  constructor(readonly runtime: Runtime) {
     this.runtime.storageManager.subscribe(this.createStorageSubscription());
   }
 

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -155,20 +155,6 @@ export const homeSpaceCellSchema: JSONSchema = {
 } as JSONSchema;
 
 export interface IRuntime {
-  readonly id: string;
-  readonly scheduler: IScheduler;
-  readonly recipeManager: IRecipeManager;
-  readonly moduleRegistry: IModuleRegistry;
-  readonly harness: Engine;
-  readonly runner: IRunner;
-  readonly navigateCallback?: NavigateCallback;
-  readonly cfc: ContextualFlowControl;
-  readonly staticCache: StaticCache;
-  readonly storageManager: IStorageManager;
-  readonly telemetry: RuntimeTelemetry;
-  /** The user's identity DID, derived from storageManager.as.did() */
-  readonly userIdentityDID: DID;
-
   idle(): Promise<void>;
   dispose(): Promise<void>;
 
@@ -291,7 +277,7 @@ export interface IRuntime {
 }
 
 export interface IScheduler {
-  readonly runtime: IRuntime;
+  readonly runtime: Runtime;
   idle(): Promise<void>;
   subscribe(
     action: Action,
@@ -312,7 +298,7 @@ export interface IScheduler {
 }
 
 export interface IRecipeManager {
-  readonly runtime: IRuntime;
+  readonly runtime: Runtime;
   recipeById(id: string): any;
   registerRecipe(recipe: any, src?: string | RuntimeProgram): string;
   loadRecipe(
@@ -344,14 +330,14 @@ export interface IRecipeManager {
 }
 
 export interface IModuleRegistry {
-  readonly runtime: IRuntime;
+  readonly runtime: Runtime;
   addModuleByRef(ref: string, module: Module): void;
   getModule(ref: string): Module;
   clear(): void;
 }
 
 export interface IRunner {
-  readonly runtime: IRuntime;
+  readonly runtime: Runtime;
 
   setup<T, R>(
     tx: IExtendedStorageTransaction | undefined,

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -12,8 +12,8 @@ import type {
   ConsoleHandler,
   ErrorHandler,
   ErrorWithContext,
-  IRuntime,
   IScheduler,
+  Runtime,
 } from "./runtime.ts";
 import {
   areNormalizedLinksSame,
@@ -121,7 +121,7 @@ export class Scheduler implements IScheduler {
   }
 
   constructor(
-    readonly runtime: IRuntime,
+    readonly runtime: Runtime,
     consoleHandler?: ConsoleHandler,
     errorHandlers?: ErrorHandler[],
   ) {

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -8,7 +8,7 @@ import { createCell, isCell } from "./cell.ts";
 import { readMaybeLink, resolveLink } from "./link-resolution.ts";
 import { type IExtendedStorageTransaction } from "./storage/interface.ts";
 import { getTransactionForChildCells } from "./storage/extended-storage-transaction.ts";
-import { type IRuntime } from "./runtime.ts";
+import { type Runtime } from "./runtime.ts";
 import {
   createDataCellURI,
   type NormalizedFullLink,
@@ -107,7 +107,7 @@ export function resolveSchema(
  * For `required` objects and arrays assume {} and [] as default value.
  */
 export function processDefaultValue(
-  runtime: IRuntime,
+  runtime: Runtime,
   tx: IExtendedStorageTransaction | undefined,
   link: NormalizedFullLink,
   defaultValue: any,
@@ -306,7 +306,7 @@ function mergeDefaults(
 
 function annotateWithBackToCellSymbols(
   value: any,
-  runtime: IRuntime,
+  runtime: Runtime,
   link: NormalizedFullLink,
   tx: IExtendedStorageTransaction | undefined,
 ) {
@@ -326,7 +326,7 @@ function annotateWithBackToCellSymbols(
 }
 
 export function validateAndTransform(
-  runtime: IRuntime,
+  runtime: Runtime,
   tx: IExtendedStorageTransaction | undefined,
   link: NormalizedFullLink,
   synced: boolean = false,

--- a/packages/ui/src/v2/components/ct-cell-link/ct-cell-link.ts
+++ b/packages/ui/src/v2/components/ct-cell-link/ct-cell-link.ts
@@ -3,7 +3,7 @@ import { property, state } from "lit/decorators.js";
 import { consume } from "@lit/context";
 import { BaseElement } from "../../core/base-element.ts";
 import "../ct-chip/ct-chip.ts";
-import type { Cell, IRuntime, MemorySpace } from "@commontools/runner";
+import type { Cell, MemorySpace, Runtime } from "@commontools/runner";
 import { NAME } from "@commontools/runner";
 import { parseLLMFriendlyLink } from "@commontools/runner";
 import { runtimeContext, spaceContext } from "../../runtime-context.ts";
@@ -47,7 +47,7 @@ export class CTCellLink extends BaseElement {
 
   @consume({ context: runtimeContext, subscribe: true })
   @property({ attribute: false })
-  runtime?: IRuntime;
+  runtime?: Runtime;
 
   @consume({ context: spaceContext, subscribe: true })
   @property({ attribute: false })

--- a/packages/ui/src/v2/runtime-context.ts
+++ b/packages/ui/src/v2/runtime-context.ts
@@ -1,5 +1,5 @@
 import { createContext } from "@lit/context";
-import type { IRuntime, MemorySpace } from "@commontools/runner";
+import type { MemorySpace, Runtime } from "@commontools/runner";
 
-export const runtimeContext = createContext<IRuntime | undefined>("runtime");
+export const runtimeContext = createContext<Runtime | undefined>("runtime");
 export const spaceContext = createContext<MemorySpace | undefined>("space");


### PR DESCRIPTION
chore: Target concrete Runtime interface rather than IRuntime within runner package to minimize interface commonality between the single threaded Runtime vs a potential multi-threaded form

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardize on the concrete Runtime type across runner and UI by replacing IRuntime references. This tightens the API boundary and avoids unintentional overlap with a future multi-threaded runtime. No behavior changes.

- **Refactors**
  - Replaced IRuntime imports/usages with Runtime across runner modules and UI contexts/components.
  - Updated related interfaces to depend on Runtime (IScheduler, IRunner, IModuleRegistry, IRecipeManager).

- **Migration**
  - If you reference IRuntime, switch to Runtime from @commontools/runner. No other code changes needed.

<sup>Written for commit 6cffadd90a8efa88a1b31ac4ac15ee3f8cb69b52. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

