### PR TITLE
chore: De-interface several runtime components

### DIFF
--- a/packages/background-charm-service/src/worker.ts
+++ b/packages/background-charm-service/src/worker.ts
@@ -2,7 +2,7 @@ import { CharmManager } from "@commontools/charm";
 import {
   Cell,
   type ConsoleHandler,
-  ConsoleMethod,
+  type ConsoleMessage,
   type ErrorHandler,
   type ErrorWithContext,
   isStream,
@@ -52,11 +52,10 @@ const console = {
 };
 // Console handler that will be passed to Runtime
 const consoleHandler: ConsoleHandler = (
-  metadata:
-    | { charmId?: string; recipeId?: string; space?: string }
-    | undefined,
-  _method: ConsoleMethod,
-  args: unknown[],
+  {
+    metadata,
+    args,
+  }: ConsoleMessage,
 ) => {
   if (!spaceId) {
     // Shouldn't happen.

--- a/packages/charm/src/favorites.ts
+++ b/packages/charm/src/favorites.ts
@@ -1,4 +1,4 @@
-import { type Cell, type IRuntime } from "@commontools/runner";
+import { type Cell, type Runtime } from "@commontools/runner";
 import { type FavoriteList, favoriteListSchema } from "./manager.ts";
 
 /**
@@ -35,7 +35,7 @@ function filterOutCell(
  * Get the favorites cell from the home space (singleton across all spaces).
  * See docs/common/HOME_SPACE.md for more details.
  */
-export function getHomeFavorites(runtime: IRuntime): Cell<FavoriteList> {
+export function getHomeFavorites(runtime: Runtime): Cell<FavoriteList> {
   return runtime.getHomeSpaceCell().key("favorites").asSchema(
     favoriteListSchema,
   );
@@ -45,7 +45,7 @@ export function getHomeFavorites(runtime: IRuntime): Cell<FavoriteList> {
  * Add a charm to the user's favorites (in home space)
  */
 export async function addFavorite(
-  runtime: IRuntime,
+  runtime: Runtime,
   charm: Cell<unknown>,
 ): Promise<void> {
   const favorites = getHomeFavorites(runtime);
@@ -76,7 +76,7 @@ export async function addFavorite(
  * @returns true if the charm was removed, false if it wasn't in favorites or tx failed
  */
 export async function removeFavorite(
-  runtime: IRuntime,
+  runtime: Runtime,
   charm: Cell<unknown>,
 ): Promise<boolean> {
   const favorites = getHomeFavorites(runtime);
@@ -99,7 +99,7 @@ export async function removeFavorite(
 /**
  * Check if a charm is in the user's favorites (in home space)
  */
-export function isFavorite(runtime: IRuntime, charm: Cell<unknown>): boolean {
+export function isFavorite(runtime: Runtime, charm: Cell<unknown>): boolean {
   try {
     const resolvedCharm = charm.resolveAsCell();
     const favorites = getHomeFavorites(runtime);

--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -157,17 +157,17 @@ export class CharmManager {
     );
     // Use the space DID as the cause - it's derived from the space name
     // and consistently available everywhere
-    // For home space (where space DID = user identity DID), getHomeSpaceCell()
-    // uses homeSpaceCellSchema which includes favorites for proper sync/query behavior.
+    // For home space (where space DID = user identity DID), getHomeSpaceCellContents()
+    // uses homeSpaceCellContentsSchema which includes favorites for proper sync/query behavior.
     const isHomeSpace = this.space === this.runtime.userIdentityDID;
     this.spaceCell = isHomeSpace
       ? this.runtime.getHomeSpaceCell()
       : this.runtime.getSpaceCell(this.space);
 
-    const syncSpaceCell = Promise.resolve(this.spaceCell.sync());
+    const syncSpaceCellContents = Promise.resolve(this.spaceCell.sync());
 
     // Initialize the space cell structure by linking to existing cells
-    const linkSpaceCell = syncSpaceCell.then(() =>
+    const linkSpaceCellContents = syncSpaceCellContents.then(() =>
       this.runtime.editWithRetry((tx) => {
         const spaceCellWithTx = this.spaceCell.withTx(tx);
 
@@ -213,8 +213,8 @@ export class CharmManager {
       this.syncCharms(this.charms),
       this.syncCharms(this.pinnedCharms),
       this.syncCharms(this.recentCharms),
-      syncSpaceCell,
-      linkSpaceCell,
+      syncSpaceCellContents,
+      linkSpaceCellContents,
     ]).then(() => {});
   }
 
@@ -264,7 +264,7 @@ export class CharmManager {
     return this.pinnedCharms;
   }
 
-  getSpaceCell(): Cell<SpaceCellContents> {
+  getSpaceCellContents(): Cell<SpaceCellContents> {
     return this.spaceCell;
   }
 

--- a/packages/charm/src/spellbook.ts
+++ b/packages/charm/src/spellbook.ts
@@ -103,7 +103,7 @@ export async function saveSpell(
 ): Promise<boolean> {
   try {
     // Get all the required data from commontools first
-    const recipeMetaResult = runtime.recipeManager.getRecipeMeta(spell);
+    const recipeMetaResult = runtime.recipeManager.getRecipeMeta(spell as any);
     const { src, spec, parents } = recipeMetaResult || {};
     if (!isRecord(spell)) {
       throw new Error("Invalid spell.");

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,13 +1,13 @@
-export { homeSpaceCellSchema, Runtime, spaceCellSchema } from "./runtime.ts";
+export { Runtime } from "./runtime.ts";
 export type {
-  CharmMetadata,
   ConsoleHandler,
   ErrorHandler,
   ErrorWithContext as RuntimeErrorWithContext,
-  IRuntime,
+  HomeSpaceCellContents,
   RuntimeOptions,
   SpaceCellContents,
 } from "./runtime.ts";
+export * from "./interface.ts";
 export { raw } from "./module.ts";
 export type { Cell, Stream } from "./cell.ts";
 export type { NormalizedLink } from "./link-utils.ts";

--- a/packages/runner/src/interface.ts
+++ b/packages/runner/src/interface.ts
@@ -1,0 +1,7 @@
+import { ConsoleMethod } from "./harness/console.ts";
+
+export type ConsoleMessage = {
+  metadata: { charmId?: string; recipeId?: string; space?: string } | undefined;
+  method: ConsoleMethod;
+  args: any[];
+};

--- a/packages/runner/src/module.ts
+++ b/packages/runner/src/module.ts
@@ -3,10 +3,10 @@ import { Module, type ModuleFactory } from "./builder/types.ts";
 import type { Cell } from "./cell.ts";
 import type { Action } from "./scheduler.ts";
 import type { AddCancel } from "./cancel.ts";
-import type { IModuleRegistry, Runtime } from "./runtime.ts";
+import type { Runtime } from "./runtime.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 
-export class ModuleRegistry implements IModuleRegistry {
+export class ModuleRegistry {
   private moduleMap = new Map<string, Module>();
   readonly runtime: Runtime;
 

--- a/packages/runner/src/recipe-manager.ts
+++ b/packages/runner/src/recipe-manager.ts
@@ -7,7 +7,7 @@ import {
   unsafe_originalRecipe,
 } from "./builder/types.ts";
 import { Cell } from "./cell.ts";
-import type { IRecipeManager, MemorySpace, Runtime } from "./runtime.ts";
+import type { MemorySpace, Runtime } from "./runtime.ts";
 import { createRef } from "./create-ref.ts";
 import { RuntimeProgram } from "./harness/types.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
@@ -48,7 +48,7 @@ export const recipeMetaSchema = {
 
 export type RecipeMeta = Schema<typeof recipeMetaSchema>;
 
-export class RecipeManager implements IRecipeManager {
+export class RecipeManager {
   private inProgressCompilations = new Map<string, Promise<Recipe>>();
   // Maps keyed by recipeId for consistent lookups
   private recipeMetaCellById = new Map<string, Cell<RecipeMeta>>();

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -46,7 +46,7 @@ import { deepEqual } from "./path-utils.ts";
 import { sendValueToBinding } from "./recipe-binding.ts";
 import { type AddCancel, type Cancel, useCancelGroup } from "./cancel.ts";
 import { LINK_V1_TAG, SigilLink } from "./sigil-types.ts";
-import type { IRunner, Runtime } from "./runtime.ts";
+import type { Runtime } from "./runtime.ts";
 import type {
   IExtendedStorageTransaction,
   IStorageSubscription,
@@ -60,7 +60,7 @@ import { isCellResult } from "./query-result-proxy.ts";
 
 const logger = getLogger("runner");
 
-export class Runner implements IRunner {
+export class Runner {
   readonly cancels = new Map<`${MemorySpace}/${URI}`, Cancel>();
   private allCancels = new Set<Cancel>();
   private functionCache = new FunctionCache();

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -12,7 +12,6 @@ import type {
   ConsoleHandler,
   ErrorHandler,
   ErrorWithContext,
-  IScheduler,
   Runtime,
 } from "./runtime.ts";
 import {
@@ -82,7 +81,7 @@ const MAX_ITERATIONS_PER_RUN = 100;
 const DEFAULT_RETRIES_FOR_EVENTS = 5;
 const MAX_RETRIES_FOR_REACTIVE = 10;
 
-export class Scheduler implements IScheduler {
+export class Scheduler {
   private eventQueue: {
     action: Action;
     retriesLeft: number;
@@ -126,9 +125,9 @@ export class Scheduler implements IScheduler {
     errorHandlers?: ErrorHandler[],
   ) {
     this.consoleHandler = consoleHandler ||
-      function (_metadata, _method, args) {
+      function (data) {
         // Default console handler returns arguments unaffected.
-        return args;
+        return data.args;
       };
 
     if (errorHandlers) {
@@ -144,7 +143,7 @@ export class Scheduler implements IScheduler {
       // called within the runtime.
       const { method, args } = e as ConsoleEvent;
       const metadata = getCharmMetadataFromFrame();
-      const result = this.consoleHandler(metadata, method, args);
+      const result = this.consoleHandler({ metadata, method, args });
       console[method].apply(console, result);
     });
   }

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -191,7 +191,7 @@ export class RuntimeInternals extends EventTarget {
         console.error(error);
       }],
       telemetry,
-      consoleHandler: (metadata, method, args) => {
+      consoleHandler: ({ metadata, method, args }) => {
         // Handle console messages depending on charm context.
         // This is essentially the same as the default handling currently,
         // but adding this here for future use.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed interface types across the runtime (IRuntime, IScheduler, IRunner, IRecipeManager, IModuleRegistry) and switched to concrete classes. Also unified console handling with a new ConsoleMessage type. No behavior changes expected.

- **Refactors**
  - Runtime, Scheduler, Runner, RecipeManager, and ModuleRegistry now use concrete classes (no interfaces).
  - Added ConsoleMessage and updated ConsoleHandler to accept a single object { metadata, method, args }.
  - Updated exports: index.ts now exports Runtime and types; removed homeSpaceCellSchema, spaceCellSchema, and CharmMetadata from index exports.
  - CharmManager method renamed to getSpaceCellContents().

- **Migration**
  - Replace IRuntime with Runtime in type signatures.
  - Update custom console handlers to (message: ConsoleMessage) => any[].
  - If you imported homeSpaceCellSchema or spaceCellSchema from @commontools/runner, use the HomeSpaceCellContents type instead.

<sup>Written for commit e8d73a5fd0f472e9515d57e153ec0ec68b7eb7b2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

