### PR TITLE
feat(patterns): add multiplayer Scrabble game

### DIFF
--- a/packages/patterns/scrabble-game.tsx
+++ b/packages/patterns/scrabble-game.tsx
@@ -1151,7 +1151,7 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
 
     // Board version for forcing re-render (changes when boardJson length changes)
     // IMPORTANT: derive() may pass a Cell proxy instead of the value - need to unwrap
-    const boardVersion = derive(boardJson, (input: any) => {
+    const _boardVersion = derive(boardJson, (input: any) => {
       const actualInput =
         typeof input === "object" && input && typeof input.get === "function"
           ? input.get()

--- a/packages/patterns/scrabble.tsx
+++ b/packages/patterns/scrabble.tsx
@@ -24,20 +24,15 @@ import {
 } from "commontools";
 
 import ScrabbleGame, {
-  AllPlaced,
-  AllRacks,
   createTileBag,
   drawTilesFromBag,
-  GameEvent,
   getInitials,
   getRandomColor,
-  Letter,
   MAX_PLAYERS,
   parseAllPlacedJson,
   parseAllRacksJson,
   parseGameEventsJson,
   parsePlayersJson,
-  PlacedTile,
   Player,
 } from "./scrabble-game.tsx";
 


### PR DESCRIPTION
## Summary
- Add 2-player free-for-all Scrabble pattern with lobby and game room components
- Players can join, draw tiles, place words, and score in real-time
- All shared state stored as JSON strings to work around Cell array proxy issues

## Key Files
- `packages/patterns/scrabble.tsx` - Lobby pattern for player joining
- `packages/patterns/scrabble-game.tsx` - Per-player game room pattern

## Technical Notes
The `derive()` function passes Cell proxies (not values) to callbacks. All derive callbacks must unwrap the input:
```typescript
const myRack = derive(allRacksJson, (input: any) => {
  const actualInput = typeof input === "object" && input && typeof input.get === "function"
    ? input.get()
    : input;
  // use actualInput
});
```

Pattern props declared as `Default<string, "">` are also Cells at runtime, not plain values.

## Test plan
- [ ] Deploy to local and verify 2 players can join
- [ ] Test word placement and scoring
- [ ] Verify board sync between players

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 2-player multiplayer Scrabble pattern with a lobby and per-player game rooms. Players can join, draw tiles, place words, and score in real time with shared board state.

- **New Features**
  - Lobby for joining and starting games
  - Per-player game room with synchronized board, racks, and tile bag
  - Standard Scrabble rules: word validation, scoring, bonus squares

- **Migration**
  - In derive() callbacks, unwrap Cell proxies with .get() before use
  - Pattern props declared as Default<string, ""> are Cells at runtime; read via .get()
  - Shared game state is passed as JSON strings; use provided parse helpers

<sup>Written for commit fd2df269c838ce25abb4b4d1944b7dabd6596a1e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





