### PR TITLE
fix(ct-button): suppress click events when disabled

### DIFF
--- a/packages/ui/src/v2/components/ct-button/ct-button.test.ts
+++ b/packages/ui/src/v2/components/ct-button/ct-button.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for CTButton component
+ */
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { CTButton } from "./ct-button.ts";
+
+describe("CTButton", () => {
+  it("should be defined", () => {
+    expect(CTButton).toBeDefined();
+  });
+
+  it("should have customElement definition", () => {
+    expect(customElements.get("ct-button")).toBe(CTButton);
+  });
+
+  it("should create element instance", () => {
+    const element = new CTButton();
+    expect(element).toBeInstanceOf(CTButton);
+  });
+
+  it("should have default properties", () => {
+    const element = new CTButton();
+    expect(element.variant).toBe("primary");
+    expect(element.size).toBe("default");
+    expect(element.disabled).toBe(false);
+    expect(element.type).toBe("button");
+  });
+
+  it("should suppress click events when disabled via host listener", () => {
+    const element = new CTButton();
+    element.disabled = true;
+
+    // Verify the element has a capture-phase click listener that stops propagation
+    // We test this by creating a click event and dispatching it
+    let listenerCalled = false;
+    element.addEventListener("click", () => {
+      listenerCalled = true;
+    });
+
+    const clickEvent = new Event("click", { bubbles: true, cancelable: true });
+    element.dispatchEvent(clickEvent);
+
+    // When disabled, the capture-phase listener should stop immediate propagation
+    expect(listenerCalled).toBe(false);
+  });
+
+  it("should allow click events when not disabled", () => {
+    const element = new CTButton();
+    element.disabled = false;
+
+    let listenerCalled = false;
+    element.addEventListener("click", () => {
+      listenerCalled = true;
+    });
+
+    const clickEvent = new Event("click", { bubbles: true, cancelable: true });
+    element.dispatchEvent(clickEvent);
+
+    expect(listenerCalled).toBe(true);
+  });
+});

--- a/packages/ui/src/v2/components/ct-button/ct-button.ts
+++ b/packages/ui/src/v2/components/ct-button/ct-button.ts
@@ -295,6 +295,19 @@ export class CTButton extends BaseElement {
       this.size = "default";
       this.disabled = false;
       this.type = "button";
+
+      // Suppress click events on the host element when disabled.
+      // JSX attaches onClick handlers to the host element, but click events
+      // cross the shadow boundary and would fire even when disabled.
+      this.addEventListener(
+        "click",
+        (e) => {
+          if (this.disabled) {
+            e.stopImmediatePropagation();
+          }
+        },
+        { capture: true },
+      );
     }
 
     override firstUpdated(


### PR DESCRIPTION
The JSX runtime attaches onClick handlers to the host element, but click
events cross the shadow boundary and would fire even when the button is
disabled. Added a capture-phase click listener on the host element that
calls stopImmediatePropagation() when disabled.

Also added ct-button.test.ts with tests for disabled click suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1114: clicking a disabled ct-button no longer fires onClick.

- **Bug Fixes**
  - Add capture-phase click listener on the host that calls stopImmediatePropagation when disabled.
  - Add tests to confirm clicks are suppressed when disabled and allowed when enabled.

<sup>Written for commit 66bcae19a3fa2991fe6533dbe7995f3c7d04b883. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

