### PR TITLE
Render `favorites-manager.tsx` on `home.tsx`

### DIFF
--- a/packages/patterns/home.tsx
+++ b/packages/patterns/home.tsx
@@ -1,13 +1,22 @@
 /// <cts-enable />
 import { NAME, pattern, UI } from "commontools";
+import FavoritesManager from "./favorites-manager.tsx";
 
 export default pattern((_) => {
+  const favorites = FavoritesManager({});
+
   return {
     [NAME]: `Home`,
     [UI]: (
-      <h1>
-        home<strong>space</strong>
-      </h1>
+      <ct-screen>
+        <h1>
+          home<strong>space</strong>
+        </h1>
+
+        <ct-card>
+          {favorites}
+        </ct-card>
+      </ct-screen>
     ),
   };
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Home now renders FavoritesManager inside a ct-card, showing the favorites list under the header. This fulfills Linear CT-1115 by listing favorites on home.tsx using favorites-manager.tsx.

<sup>Written for commit 154fc11d24a66ab5ad9c6919adfcd7e98f85b92a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

