### PR TITLE
Before we call evaluateDocumentLinks, remove entries for the modified docs

### DIFF
--- a/packages/memory/provider.ts
+++ b/packages/memory/provider.ts
@@ -780,6 +780,10 @@ class MemoryProviderSession<
       for (const schema of schemas) {
         pendingPairs.push({ docKey, schema });
       }
+      // Remove these docs from our cached schemaTracker results, so we will
+      // re-evaluate them. We've run them before, but we may get different
+      // results when we run them with the new data, so re-run them.
+      this.sharedSchemaTracker.delete(docKey);
     }
 
     // Process pending pairs - may grow as we discover new links


### PR DESCRIPTION
Remove the schemaTracker entries for the modified docs, so we don't just skip evaluating them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clear cached schemaTracker entries for modified documents before evaluateDocumentLinks, so they’re re-evaluated instead of skipped. Fixes stale link results when docs change.

<sup>Written for commit bb7b39ef6be7ae1e9a346d8c122623a326bdda35. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

