### PR TITLE
feat(patterns): multiplayer Scrabble game with clean lobby UI

### DIFF
--- a/packages/patterns/scrabble-game.tsx
+++ b/packages/patterns/scrabble-game.tsx
@@ -1151,7 +1151,7 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
 
     // Board version for forcing re-render (changes when boardJson length changes)
     // IMPORTANT: derive() may pass a Cell proxy instead of the value - need to unwrap
-    const boardVersion = derive(boardJson, (input: any) => {
+    const _boardVersion = derive(boardJson, (input: any) => {
       const actualInput =
         typeof input === "object" && input && typeof input.get === "function"
           ? input.get()

--- a/packages/patterns/scrabble.tsx
+++ b/packages/patterns/scrabble.tsx
@@ -336,6 +336,7 @@ const ScrabbleLobby = pattern<LobbyInput, LobbyOutput>(
                   timingStrategy="immediate"
                 />
                 <button
+                  type="button"
                   style={{
                     width: "100%",
                     padding: "0.75rem 1.5rem",
@@ -393,6 +394,7 @@ const ScrabbleLobby = pattern<LobbyInput, LobbyOutput>(
                   timingStrategy="immediate"
                 />
                 <button
+                  type="button"
                   style={{
                     width: "100%",
                     padding: "0.75rem 1.5rem",
@@ -424,6 +426,7 @@ const ScrabbleLobby = pattern<LobbyInput, LobbyOutput>(
 
             {/* Reset Button */}
             <button
+              type="button"
               style={{
                 marginTop: "1rem",
                 padding: "0.5rem 1rem",


### PR DESCRIPTION
## Summary

- Add multiplayer Scrabble game pattern with separate lobby and game room
- Implement explicit Player 1 / Player 2 join slots to avoid race conditions  
- Free-for-all gameplay (no turns) with real-time board synchronization

## Changes

**New files:**
- `scrabble-game.tsx` - Game room pattern with board, rack, word validation, scoring

**Updated files:**
- `scrabble.tsx` - Lobby pattern with explicit Player 1 / Player 2 join sections

## Test plan

- [ ] Open lobby, enter name as Player 1, click Join
- [ ] In second browser/tab, enter name as Player 2, click Join
- [ ] Verify both players see shared board and can place tiles
- [ ] Verify word submission works and scores update
- [ ] Verify Reset clears all state

🤖 Generated with [Claude Code](https://claude.com/claude-code)