### PR TITLE
fix(memory): fix SQLite transaction and iterator issues

### DIFF
--- a/packages/memory/space.ts
+++ b/packages/memory/space.ts
@@ -697,18 +697,17 @@ export const selectFact = function <Space extends MemorySpace>(
   { the, of, since }: { the: MIME; of: URI; since?: number },
 ): SelectedFact | undefined {
   const stmt = getPreparedStatement(store, "export", EXPORT);
-  for (
-    const row of stmt.iter({
-      the: the,
-      of: of,
-      cause: null,
-      is: null,
-      since: since ?? null,
-    }) as Iterable<StateRow>
-  ) {
-    return toFact(row);
-  }
-  return undefined;
+  // Use get() instead of iter() to avoid leaving an active iterator
+  // when we only need the first row. Active iterators cause
+  // "cannot commit transaction - SQL statements in progress" errors.
+  const row = stmt.get({
+    the: the,
+    of: of,
+    cause: null,
+    is: null,
+    since: since ?? null,
+  }) as StateRow | undefined;
+  return row ? toFact(row) : undefined;
 };
 
 /**
@@ -983,7 +982,13 @@ export const transact = <Space extends MemorySpace>(
       span.setAttribute("memory.has_changes", true);
     }
 
-    return execute(session.store.transaction(commit), session, transaction);
+    // Use IMMEDIATE transaction to acquire write lock at start, reducing
+    // lock contention with external processes like litestream
+    return execute(
+      session.store.transaction(commit).immediate,
+      session,
+      transaction,
+    );
   });
 };
 


### PR DESCRIPTION
Two fixes for SQLite-related errors:

1. Use stmt.get() in selectFact instead of stmt.iter() with early return
   - The old code left iterators in an active state when returning early
   - This caused "cannot commit transaction - SQL statements in progress" errors
   - Using stmt.get() properly retrieves just the first row without leaving active iterators

2. Use IMMEDIATE transactions for writes
   - Changed from default DEFERRED to IMMEDIATE transaction mode
   - Acquires write lock at transaction start rather than at first write
   - Reduces lock contention race conditions with external processes like litestream

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SQLite transaction issues that caused commit failures and lock contention. Prevents “cannot commit transaction - SQL statements in progress” errors and reduces conflicts with external tools like litestream.

- **Bug Fixes**
  - selectFact uses stmt.get() to fetch the first row, avoiding active iterators.
  - Write transactions use IMMEDIATE mode to acquire the lock at the start.

<sup>Written for commit 5f6f6707513b72800101e52c90e4e2c87aebf2ff. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



