### PR TITLE
style(scrabble): change lobby status text to "Now playing"

### DIFF
--- a/packages/patterns/scrabble.tsx
+++ b/packages/patterns/scrabble.tsx
@@ -356,7 +356,7 @@ const ScrabbleLobby = pattern<LobbyInput, LobbyOutput>(
                         {player1Name}
                       </div>
                       <div style={{ fontSize: "0.875rem", color: "#86868b" }}>
-                        Ready to play
+                        Now playing
                       </div>
                     </div>
                   )
@@ -436,7 +436,7 @@ const ScrabbleLobby = pattern<LobbyInput, LobbyOutput>(
                         {player2Name}
                       </div>
                       <div style={{ fontSize: "0.875rem", color: "#86868b" }}>
-                        Ready to play
+                        Now playing
                       </div>
                     </div>
                   )


### PR DESCRIPTION
## Summary
- Change lobby player status from "Ready to play" to "Now playing" for joined players

## Test plan
- [ ] Open Scrabble lobby
- [ ] Join as Player 1 or 2
- [ ] Verify status shows "Now playing" instead of "Ready to play"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Scrabble lobby status text to "Now playing" for joined Player 1 and Player 2, replacing "Ready to play" to clearly indicate active players.

<sup>Written for commit 563d483548fc016fbd50f13150b1b60adc556b43. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

