### PR TITLE
feat(patterns): add multiplayer group chat pattern

### DIFF
--- a/packages/patterns/group-chat-lobby.tsx
+++ b/packages/patterns/group-chat-lobby.tsx
@@ -91,7 +91,7 @@ const joinChat = handler<
     sessionId: Cell<string>;
     nameInput: Cell<string>;
   }
->((_event, { chatName, messages, users, sessionId, nameInput }) => {
+>((_event, { messages, users, sessionId, nameInput }) => {
   const name = nameInput.get().trim();
   if (!name) {
     console.log("[joinChat] No name entered, returning");

--- a/packages/patterns/group-chat-room.tsx
+++ b/packages/patterns/group-chat-room.tsx
@@ -488,7 +488,7 @@ export default pattern<RoomInput, RoomOutput>(
                       msg,
                       (m: Message) => (m && m.reactions) || [],
                     );
-                    const hasReactions = derive(
+                    const _hasReactions = derive(
                       messageReactions,
                       (r: Reaction[]) => r.length > 0,
                     );


### PR DESCRIPTION
## Summary
- Add multiplayer group chat pattern with lobby and chat room components
- Users can join with name, set/change avatar, send text and image messages
- Emoji reactions on messages with click-to-toggle UI
- Apple iOS-style design with robust null guards for multi-user sync

## Features
- **Lobby Pattern**: Enter name to join, see who's chatting, reset session
- **Chat Room**: Real-time messaging, clickable avatar for profile pics, paperclip attachment button
- **Emoji Reactions**: Click + button to add reactions, toggle existing reactions
- **Session Management**: Session IDs invalidate old connections on reset

## Test plan
- [ ] Deploy lobby pattern to a space
- [ ] Open in two browser tabs and join with different names
- [ ] Verify messages sync between users
- [ ] Test avatar upload and image attachments
- [ ] Test emoji reactions on messages
- [ ] Test reset functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multiplayer group chat pattern with a lobby and chat room for real-time text and image messaging, avatar selection, and emoji reactions. Includes session reset logic to keep multi-user connections in sync and handle expired sessions safely.

- **New Features**
  - Lobby: join by name, see active users, reset session.
  - Chat room: send text and images (paperclip), iOS-style UI.
  - Avatars: click to set/change; color and initials fallback.
  - Emoji reactions: “+” opens picker; toggle existing reactions.
  - Session management: sessionId tracked; reset invalidates old rooms and shows an expired-session screen.

<sup>Written for commit d37b00644118caca8704c88109d5a9c2f3eb74a9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





