### PR TITLE
fix(ct-message-input): retain focus after send for rapid entry workflows

### DIFF
--- a/packages/ui/src/v2/components/ct-message-input/ct-message-input.ts
+++ b/packages/ui/src/v2/components/ct-message-input/ct-message-input.ts
@@ -101,6 +101,9 @@ export class CTMessageInput extends BaseElement {
 
     // Emit the send event
     this.emit("ct-send", { message });
+
+    // Restore focus to input for rapid entry (chat, list-building workflows)
+    input.focus();
   }
 
   private _handleKeyDown(event: KeyboardEvent) {


### PR DESCRIPTION
## Summary

- Fixes focus loss after sending a message in `ct-message-input`
- Adds `input.focus()` call after emit in `_handleSend()` method
- Enables rapid-entry workflows (chat, list-building) without re-clicking

## Problem

After sending a message, focus was lost from the input field:
- **Button click**: Browser naturally moves focus to the clicked button
- **Enter key**: Parent re-renders can cause Lit to lose focus in nested shadow DOMs

## Design Rationale

Unconditional refocus is the correct behavior because:

1. **Industry standard**: Slack, Discord, iMessage, Todoist all retain focus after send
2. **Component purpose**: Named "message-input" for "messages/chat interfaces" - implies rapid entry
3. **No counter-cases**: Can't find a real use case where you'd choose this component AND not want focus retained
4. **Low cost**: If user doesn't want to type more, they click elsewhere (1 click). If they do want to type, we save them a click every time.

## Test plan

- [x] Deploy shopping list pattern
- [x] Add item via Enter key → verify focus stays in input
- [x] Add item via Send button click → verify focus returns to input  
- [x] Verify rapid entry works (type → enter → type → enter without clicking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep ct-message-input focused after sending a message to support rapid entry without extra clicks. Implemented by calling input.focus() after emitting ct-send, covering both Enter and Send button flows.

<sup>Written for commit c91449fdaf4b430345c99392e11fa89fe8565eaa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

