### PR TITLE
fix(api): HandlerFunction type returns HandlerFactory instead of Modu…

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1120,27 +1120,24 @@ export type HandlerFunction = {
     eventSchema: E,
     stateSchema: T,
     handler: (event: Schema<E>, props: Schema<T>) => any,
-  ): ModuleFactory<
-    StripCell<SchemaWithoutCell<T>>,
-    Stream<SchemaWithoutCell<E>>
-  >;
+  ): HandlerFactory<SchemaWithoutCell<T>, SchemaWithoutCell<E>>;
 
   // With inferred types
   <E, T>(
     eventSchema: JSONSchema,
     stateSchema: JSONSchema,
     handler: (event: E, props: HandlerState<T>) => any,
-  ): ModuleFactory<StripCell<T>, Stream<StripCell<E>>>;
+  ): HandlerFactory<T, E>;
 
   // Without schemas
   <E, T>(
     handler: (event: E, props: T) => any,
     options: { proxy: true },
-  ): ModuleFactory<StripCell<T>, Stream<StripCell<E>>>;
+  ): HandlerFactory<T, E>;
 
   <E, T>(
     handler: (event: E, props: HandlerState<T>) => any,
-  ): ModuleFactory<StripCell<T>, Stream<StripCell<E>>>;
+  ): HandlerFactory<T, E>;
 };
 
 /**

--- a/packages/patterns/counter.tsx
+++ b/packages/patterns/counter.tsx
@@ -35,7 +35,7 @@ export default recipe<RecipeState, RecipeOutput>((state) => {
       </div>
     ),
     value: state.value,
-    increment: increment(state) as unknown as Stream<void>,
-    decrement: decrement(state) as unknown as Stream<void>,
+    increment: increment(state),
+    decrement: decrement(state),
   };
 });

--- a/packages/patterns/dice.tsx
+++ b/packages/patterns/dice.tsx
@@ -34,7 +34,7 @@ export default recipe<RecipeState, RecipeOutput>((state) => {
       </div>
     ),
     value: state.value,
-    roll: roll(state) as unknown as Stream<{ sides?: number }>,
+    roll: roll(state),
     something: {
       nested: "a secret surprise!",
     },

--- a/packages/runner/integration/derive_array_leak.test.tsx
+++ b/packages/runner/integration/derive_array_leak.test.tsx
@@ -84,7 +84,7 @@ export default recipe<RecipeState, RecipeOutput>("Counter", (state) => {
       </div>
     ),
     value: state.value,
-    increment: increment(state) as unknown as Stream<void>,
-    decrement: decrement(state) as unknown as Stream<void>,
+    increment: increment(state),
+    decrement: decrement(state),
   };
 });


### PR DESCRIPTION
…leFactory

The HandlerFunction type declaration was incorrectly returning ModuleFactory, which wraps the result in OpaqueRef<R>. The actual handler() implementation returns HandlerFactory, which returns Stream<R> directly when called.

This mismatch required patterns to use `as unknown as Stream<T>` casts when exposing handlers in Output interfaces. With this fix, those casts are no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HandlerFunction’s return type to use HandlerFactory instead of ModuleFactory, matching the runtime handler() behavior and returning Stream directly. Removes unsafe Stream casts in patterns and tests.

- **Bug Fixes**
  - Updated HandlerFunction overloads to return HandlerFactory<T, E>.
  - Removed `as unknown as Stream<...>` casts from counter, dice, and integration test.
  - Aligns type definitions with runtime (no OpaqueRef wrapping).

<sup>Written for commit 46521eb32c50f0b4af4229cae072cf92f3d7bd44. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

