### PR TITLE
chore: Isolate link types from runtime imports

### DIFF
--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -1,6 +1,5 @@
 import { isRecord } from "@commontools/utils/types";
 import { type LegacyAlias } from "../sigil-types.ts";
-import { isLegacyAlias, isLink } from "../link-utils.ts";
 import {
   isRecipe,
   type JSONSchema,
@@ -17,7 +16,12 @@ import {
 import { getTopFrame } from "./recipe.ts";
 import { deepEqual } from "../path-utils.ts";
 import { Runtime } from "../runtime.ts";
-import { parseLink, sanitizeSchemaForLinks } from "../link-utils.ts";
+import {
+  isCellLink,
+  isLegacyAlias,
+  parseLink,
+  sanitizeSchemaForLinks,
+} from "../link-utils.ts";
 import {
   getCellOrThrow,
   isCellResultForDereferencing,
@@ -132,7 +136,7 @@ export function createJsonSchema(
   const seen = new Map<string, JSONSchemaMutable>();
 
   function analyzeType(value: any): JSONSchema {
-    if (isLink(value)) {
+    if (isCellLink(value)) {
       const link = parseLink(value);
       const linkAsStr = JSON.stringify(link);
       if (seen.has(linkAsStr)) {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -61,11 +61,12 @@ import {
   type SigilWriteRedirectLink,
   type URI,
 } from "./sigil-types.ts";
-import { areLinksSame, isLink } from "./link-utils.ts";
 import type { Runtime } from "./runtime.ts";
 import {
+  areLinksSame,
   createSigilLinkFromParsedLink,
   findAndInlineDataURILinks,
+  isCellLink,
   type NormalizedFullLink,
   type NormalizedLink,
 } from "./link-utils.ts";
@@ -1400,7 +1401,7 @@ function recursivelyAddIDIfNeeded<T>(
   if (!frame) return value;
 
   // Not a record, no need to add IDs. Already a link, no need to add IDs.
-  if (!isRecord(value) || isLink(value)) return value;
+  if (!isRecord(value) || isCellLink(value)) return value;
 
   // Already seen, return previously annotated result.
   if (seen.has(value)) return seen.get(value) as T;
@@ -1415,7 +1416,7 @@ function recursivelyAddIDIfNeeded<T>(
       const value = recursivelyAddIDIfNeeded(v, frame, seen);
       // For objects on arrays only: Add ID if not already present.
       if (
-        isObject(value) && !isLink(value) && !(ID in value)
+        isObject(value) && !isCellLink(value) && !(ID in value)
       ) {
         return { [ID]: frame.generatedIdCounter++, ...value };
       } else {

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -10,8 +10,8 @@ import {
   areNormalizedLinksSame,
   createSigilLinkFromParsedLink,
   findAndInlineDataURILinks,
-  isAnyCellLink,
-  isLink,
+  isCellLink,
+  isPrimitiveCellLink,
   isWriteRedirectLink,
   type NormalizedFullLink,
   parseLink,
@@ -156,7 +156,7 @@ export function normalizeAndDiff(
       if (Array.isArray(parent)) {
         const base = runtime.getCellFromLink(link, undefined, tx);
         for (const v of parent) {
-          if (isLink(v)) {
+          if (isCellLink(v)) {
             const sibling = parseLink(v, base);
             const siblingId = tx.readValueOrThrow({
               ...sibling,
@@ -224,7 +224,9 @@ export function normalizeAndDiff(
 
   // Check for links that are data: URIs and inline them, by calling
   // normalizeAndDiff on the contents of the link.
-  if (isLink(newValue) && parseLink(newValue, link).id?.startsWith("data:")) {
+  if (
+    isCellLink(newValue) && parseLink(newValue, link).id?.startsWith("data:")
+  ) {
     return normalizeAndDiff(
       runtime,
       tx,
@@ -296,7 +298,7 @@ export function normalizeAndDiff(
     );
   }
 
-  if (isAnyCellLink(newValue)) {
+  if (isPrimitiveCellLink(newValue)) {
     diffLogger.debug(
       "diff",
       () =>
@@ -335,7 +337,7 @@ export function normalizeAndDiff(
       );
     }
     if (
-      isAnyCellLink(currentValue) &&
+      isPrimitiveCellLink(currentValue) &&
       areLinksSame(newValue, currentValue, link)
     ) {
       diffLogger.debug(
@@ -487,7 +489,7 @@ export function normalizeAndDiff(
     );
     // If the current value is not a (regular) object, set it to an empty object
     // Note that the alias case is handled above
-    if (!isRecord(currentValue) || isAnyCellLink(currentValue)) {
+    if (!isRecord(currentValue) || isPrimitiveCellLink(currentValue)) {
       diffLogger.debug(
         "diff",
         () =>
@@ -610,7 +612,7 @@ export function addCommonIDfromObjectID(
       obj[ID_FIELD] = fieldName;
     }
 
-    if (isRecord(obj) && !isCell(obj) && !isAnyCellLink(obj)) {
+    if (isRecord(obj) && !isCell(obj) && !isPrimitiveCellLink(obj)) {
       Object.values(obj).forEach((v) => traverse(v));
     }
   }

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -10,7 +10,7 @@ export type {
 export * from "./interface.ts";
 export { raw } from "./module.ts";
 export type { Cell, Stream } from "./cell.ts";
-export type { NormalizedLink } from "./link-utils.ts";
+export type { NormalizedLink } from "./link-types.ts";
 export type { SigilLink, URI } from "./sigil-types.ts";
 export { createRef, type EntityId, getEntityId } from "./create-ref.ts";
 export type { CellResult as QueryResult } from "./query-result-proxy.ts";
@@ -47,8 +47,7 @@ export { addCommonIDfromObjectID } from "./data-updating.ts";
 export { resolveLink } from "./link-resolution.ts";
 export {
   areLinksSame,
-  isLegacyCellLink,
-  isLink,
+  isCellLink as isLink,
   isWriteRedirectLink,
   parseLink,
   parseLinkOrThrow,

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -1,0 +1,336 @@
+import { isObject, isRecord } from "@commontools/utils/types";
+import { type JSONSchema } from "./builder/types.ts";
+import { type MemorySpace } from "./cell.ts";
+import {
+  type LegacyAlias,
+  type LegacyJSONCellLink,
+  LINK_V1_TAG,
+  type SigilLink,
+  type SigilValue,
+  type SigilWriteRedirectLink,
+  type URI,
+} from "./sigil-types.ts";
+import { toURI } from "./uri-utils.ts";
+import { arrayEqual } from "./path-utils.ts";
+import type {
+  IMemorySpaceAddress,
+  MemoryAddressPathComponent,
+} from "./storage/interface.ts";
+
+/**
+ * Normalized link structure returned by parsers
+ */
+export type NormalizedLink = {
+  id?: URI; // URI format with "of:" prefix
+  path: readonly MemoryAddressPathComponent[];
+  space?: MemorySpace;
+  type?: string; // Default is "application/json"
+  schema?: JSONSchema;
+  rootSchema?: JSONSchema;
+  overwrite?: "redirect"; // "this" gets normalized away to undefined
+};
+
+/**
+ * Full normalized link that from a complete link, i.e. with required id, space
+ * and type. Gets created by parseLink if a base is provided.
+ *
+ * Any such link can be used as a memory address.
+ */
+export type NormalizedFullLink = NormalizedLink & IMemorySpaceAddress;
+
+/**
+ * Primitive cell link types that can be serialized.
+ */
+export type PrimitiveCellLink =
+  | SigilLink
+  | LegacyJSONCellLink // @deprecated
+  | LegacyAlias // @deprecated
+  | { "/": string }; // @deprecated
+
+/**
+ * Check if value is a sigil value with any type
+ *
+ * Any object that is strictly `{ "/": Record<string, any> }`, no other props
+ */
+export function isSigilValue(value: any): value is SigilValue<any> {
+  return isRecord(value) &&
+    "/" in value &&
+    Object.keys(value).length === 1 &&
+    isObject(value["/"]);
+}
+
+/**
+ * Check if value is a JSON cell link (storage format).
+ * @deprecated Switch to isLink instead.
+ */
+export function isJSONCellLink(value: any): value is LegacyJSONCellLink {
+  return (
+    isRecord(value) &&
+    isRecord(value.cell) &&
+    typeof value.cell["/"] === "string" &&
+    Array.isArray(value.path)
+  );
+}
+
+export function isSigilLink(value: any): value is SigilLink {
+  return (isSigilValue(value) && LINK_V1_TAG in value["/"]);
+}
+
+/**
+ * Check if value is a sigil alias (link with overwrite field).
+ */
+export function isSigilWriteRedirectLink(
+  value: any,
+): value is SigilWriteRedirectLink {
+  return isSigilLink(value) &&
+    value["/"][LINK_V1_TAG].overwrite === "redirect";
+}
+
+/**
+ * Check if value is a deprecated link of type `{ "/": <string> }`
+ * @deprecated Switch to isLink instead.
+ */
+export function isDeprecatedStringLink(
+  value: any,
+): value is { "/": string } {
+  return isRecord(value) && "/" in value && typeof value["/"] === "string"; // EntityId format
+}
+
+export function isPrimitiveCellLink(
+  value: any,
+): value is PrimitiveCellLink {
+  return isSigilLink(value) ||
+    isJSONCellLink(value) ||
+    isLegacyAlias(value) || isDeprecatedStringLink(value);
+}
+
+export function isNormalizedLink(value: any): value is NormalizedLink {
+  if (!isRecord(value)) return false;
+  const { path, id, type, space } = value;
+  return Array.isArray(path) &&
+    (typeof id === "string" || id === undefined) &&
+    (typeof type === "string" || type === undefined) &&
+    (typeof space === "string" || space === undefined);
+}
+
+/**
+ * Check if value is a normalized link.
+ *
+ * Beware: Unlike all the other types that `isLinkLink` is checking for, this could
+ * appear in regular data and not actually be meant as a link. So only use this
+ * if you know for sure that the value is a link.
+ */
+export function isNormalizedFullLink(value: any): value is NormalizedFullLink {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.space === "string" &&
+    typeof value.type === "string" &&
+    Array.isArray(value.path)
+  );
+}
+
+/**
+ * Check if value is an alias in any format (old $alias or new sigil)
+ */
+export function isWriteRedirectLink(
+  value: any,
+): value is LegacyAlias | SigilWriteRedirectLink {
+  // Check legacy $alias format
+  if (isLegacyAlias(value)) {
+    return true;
+  }
+
+  // Check new sigil format (link@1 with overwrite field)
+  if (isSigilLink(value)) {
+    return value["/"][LINK_V1_TAG].overwrite === "redirect";
+  }
+
+  return false;
+}
+
+/**
+ * Check if value is a legacy alias.
+ * @deprecated Switch to isWriteRedirectLink instead.
+ */
+export function isLegacyAlias(value: any): value is LegacyAlias {
+  return isRecord(value) && "$alias" in value && isRecord(value.$alias) &&
+    Array.isArray(value.$alias.path);
+}
+
+/**
+ * Parse any link-like value to normalized format
+ *
+ * Overloads just help make fields non-optional that can be guaranteed to exist
+ * in various combinations.
+ */
+export function parseLinkPrimitive(
+  value: PrimitiveCellLink,
+  base?: NormalizedLink,
+): NormalizedLink {
+  if (isSigilLink(value)) {
+    const link = value["/"][LINK_V1_TAG];
+
+    // Resolve relative references
+    let id = link.id;
+    const path = link.path || [];
+    const resolvedSpace = link.space || base?.space;
+
+    // If no id provided, use base cell's document
+    if (!id && base) {
+      id = base.id;
+    }
+
+    return {
+      ...(id && { id }),
+      path: path.map((p) => p.toString()),
+      ...(resolvedSpace && { space: resolvedSpace }),
+      type: "application/json",
+      ...(link.schema !== undefined && { schema: link.schema }),
+      ...(link.rootSchema !== undefined && { rootSchema: link.rootSchema }),
+      ...(link.overwrite === "redirect" && { overwrite: "redirect" }),
+    };
+  } else if (isJSONCellLink(value)) {
+    return {
+      id: toURI(value.cell["/"]),
+      path: value.path.map((p) => p.toString()),
+      ...(base?.space && { space: base.space }),
+      type: "application/json",
+    };
+  } else if (isDeprecatedStringLink(value)) {
+    return {
+      id: toURI(value["/"]),
+      path: [],
+      ...(base?.space && { space: base.space }), // Space must come from context for JSON links
+      type: "application/json",
+    };
+  } else if (isLegacyAlias(value)) {
+    const alias = value.$alias;
+    let id: URI | undefined;
+
+    // If cell is provided, convert to URI
+    if (alias.cell) {
+      if (isRecord(alias.cell) && "/" in alias.cell) {
+        id = toURI(alias.cell);
+      }
+    }
+
+    // If no cell provided, use base cell's document
+    if (!id && base) {
+      id = base.id;
+    }
+
+    return {
+      ...(id && { id }),
+      path: Array.isArray(alias.path)
+        ? alias.path.map((p) => p.toString())
+        : [],
+      ...(base?.space && { space: base.space }),
+      type: "application/json",
+      ...(alias.schema !== undefined && { schema: alias.schema }),
+      ...(alias.rootSchema !== undefined && { rootSchema: alias.rootSchema }),
+      overwrite: "redirect",
+    };
+  }
+  throw new Error(`Link is not a primitive: ${value}`);
+}
+
+/**
+ * Compare two normalized links for equality
+ */
+export function areNormalizedLinksSame(
+  link1: NormalizedLink,
+  link2: NormalizedLink,
+): boolean {
+  return link1.id === link2.id && link1.space === link2.space &&
+    arrayEqual(link1.path, link2.path) &&
+    (link1.type ?? "application/json") === (link2.type ?? "application/json");
+}
+
+/**
+ * Encodes a JSON Pointer path according to RFC 6901.
+ * Each token has ~ replaced with ~0 and / replaced with ~1, then joined with /.
+ * @param path - Array of path tokens to encode
+ * @returns The encoded JSON Pointer string
+ */
+export function encodeJsonPointer(path: readonly string[]): string {
+  return path
+    .map((token) => token.replace(/~/g, "~0").replace(/\//g, "~1"))
+    .join("/");
+}
+
+/**
+ * Decodes a JSON Pointer string according to RFC 6901.
+ * Splits by / then replaces ~1 with / and ~0 with ~ in each token.
+ * @param pointer - The JSON Pointer string to decode
+ * @returns Array of decoded path tokens
+ */
+export function decodeJsonPointer(pointer: string): string[] {
+  return pointer
+    .split("/")
+    .map((token) => token.replace(/~1/g, "/").replace(/~0/g, "~"));
+}
+
+export const matchLLMFriendlyLink = new RegExp("^/[a-zA-Z0-9]+:");
+
+/**
+ * Parses a LLM friendly link from a target string.
+ *
+ * @param target - The target string to parse
+ * @param space - The space to use to get the cells
+ * @returns The parsed LLM friendly link
+ */
+export function parseLLMFriendlyLink(
+  target: string,
+  space: MemorySpace,
+): NormalizedFullLink;
+export function parseLLMFriendlyLink(
+  target: string,
+  space?: MemorySpace,
+): NormalizedLink;
+export function parseLLMFriendlyLink(
+  target: string,
+  space?: MemorySpace,
+): NormalizedLink {
+  target = target.trim();
+
+  if (!matchLLMFriendlyLink.test(target)) {
+    throw new Error(
+      'Target must include a charm handle, e.g. "/of:bafyabc123/path".',
+    );
+  }
+
+  const [empty, id, ...path] = decodeJsonPointer(target);
+
+  if (empty !== "") {
+    throw new Error("Target must start with a slash.");
+  }
+
+  // Check if first segment looks like a CID/handle by length
+  //
+  // CIDs are long encoded strings (typically 40+ chars), whereas human names
+  // are short. Use a conservative threshold to distinguish handles from
+  // human-readable names Handle format is "/of:..." (the internal storage
+  // format)
+  if (id === undefined || id.length < 20) {
+    throw new Error(
+      `Charm references must use handles (e.g., "/of:bafyabc123/path"), not human names (e.g., "${id}").`,
+    );
+  }
+
+  // Remove path element from trailing slash
+  if (path.length > 0 && path[path.length - 1] === "") {
+    path.pop();
+  }
+
+  return {
+    id: id as `${string}:${string}`,
+    path,
+    ...(space && { space }),
+    type: "application/json",
+  };
+}
+
+export function createLLMFriendlyLink(link: NormalizedFullLink): string {
+  return encodeJsonPointer(["", link.id, ...link.path]);
+}

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -1,4 +1,4 @@
-import { isObject, isRecord } from "@commontools/utils/types";
+import { isRecord } from "@commontools/utils/types";
 import { type AnyCell, type JSONSchema } from "./builder/types.ts";
 import {
   type Cell,
@@ -7,15 +7,7 @@ import {
   type MemorySpace,
   type Stream,
 } from "./cell.ts";
-import {
-  type LegacyAlias,
-  type LegacyJSONCellLink,
-  LINK_V1_TAG,
-  type SigilLink,
-  type SigilValue,
-  type SigilWriteRedirectLink,
-  type URI,
-} from "./sigil-types.ts";
+import { LINK_V1_TAG, type SigilLink, type URI } from "./sigil-types.ts";
 import { getJSONFromDataURI, toURI } from "./uri-utils.ts";
 import { arrayEqual } from "./path-utils.ts";
 import {
@@ -23,35 +15,20 @@ import {
   getCellOrThrow,
   isCellResultForDereferencing,
 } from "./query-result-proxy.ts";
-import type {
-  IMemorySpaceAddress,
-  MemoryAddressPathComponent,
-} from "./storage/interface.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import { resolveLink } from "./link-resolution.ts";
 import { IExtendedStorageTransaction } from "./storage/interface.ts";
 import type { Runtime } from "./runtime.ts";
+import {
+  isNormalizedLink,
+  isPrimitiveCellLink,
+  NormalizedFullLink,
+  NormalizedLink,
+  parseLinkPrimitive,
+  PrimitiveCellLink,
+} from "./link-types.ts";
 
-/**
- * Normalized link structure returned by parsers
- */
-export type NormalizedLink = {
-  id?: URI; // URI format with "of:" prefix
-  path: readonly MemoryAddressPathComponent[];
-  space?: MemorySpace;
-  type?: string; // Default is "application/json"
-  schema?: JSONSchema;
-  rootSchema?: JSONSchema;
-  overwrite?: "redirect"; // "this" gets normalized away to undefined
-};
-
-/**
- * Full normalized link that from a complete link, i.e. with required id, space
- * and type. Gets created by parseLink if a base is provided.
- *
- * Any such link can be used as a memory address.
- */
-export type NormalizedFullLink = NormalizedLink & IMemorySpaceAddress;
+export * from "./link-types.ts";
 
 /**
  * A type reflecting all possible link formats, including cells themselves.
@@ -59,95 +36,18 @@ export type NormalizedFullLink = NormalizedLink & IMemorySpaceAddress;
 export type CellLink =
   | Cell<any>
   | Stream<any>
-  | SigilLink
   | CellResultInternals
-  | LegacyJSONCellLink // @deprecated
-  | LegacyAlias // @deprecated
-  | { "/": string }; // @deprecated
-
-/**
- * Check if value is a sigil value with any type
- *
- * Any object that is strictly `{ "/": Record<string, any> }`, no other props
- */
-export function isSigilValue(value: any): value is SigilValue<any> {
-  return isRecord(value) &&
-    "/" in value &&
-    Object.keys(value).length === 1 &&
-    isObject(value["/"]);
-}
-
-/**
- * Check if value is a legacy cell link.
- *
- * @deprecated Switch to isLink instead.
- *
- * @param {any} value - The value to check.
- * @returns {boolean}
- */
-export function isLegacyCellLink(
-  value: any,
-): value is LegacyJSONCellLink {
-  return isJSONCellLink(value);
-}
-
-/**
- * Check if value is a JSON cell link (storage format).
- *
- * @deprecated Switch to isLink instead.
- *
- * @param {any} value - The value to check.
- * @returns {boolean}
- */
-export function isJSONCellLink(value: any): value is LegacyJSONCellLink {
-  return (
-    isRecord(value) &&
-    isRecord(value.cell) &&
-    typeof value.cell["/"] === "string" &&
-    Array.isArray(value.path)
-  );
-}
-
-/**
- * Check if value is a sigil link.
- */
-export function isSigilLink(value: any): value is SigilLink {
-  return (isSigilValue(value) && LINK_V1_TAG in value["/"]);
-}
-
-/**
- * Check if value is a sigil alias (link with overwrite field).
- */
-export function isSigilWriteRedirectLink(
-  value: any,
-): value is SigilWriteRedirectLink {
-  return isSigilLink(value) &&
-    value["/"][LINK_V1_TAG].overwrite === "redirect";
-}
-
-/**
- * Check if value is any kind of cell link format.
- *
- * @param {any} value - The value to check.
- * @returns {boolean}
- */
-export function isAnyCellLink(
-  value: any,
-): value is SigilLink | LegacyJSONCellLink | LegacyAlias {
-  return isLegacyCellLink(value) || isJSONCellLink(value) ||
-    isSigilLink(value) ||
-    isLegacyAlias(value);
-}
+  | PrimitiveCellLink;
 
 /**
  * Check if value is any kind of link or linkable entity
  */
-export function isLink(
+export function isCellLink(
   value: any,
 ): value is CellLink {
   return (
     isCellResultForDereferencing(value) ||
-    isAnyCellLink(value) ||
+    isPrimitiveCellLink(value) ||
     isCell(value) ||
     (isRecord(value) && "/" in value && typeof value["/"] === "string") // EntityId format
   );
@@ -168,38 +68,6 @@ export function isNormalizedFullLink(value: any): value is NormalizedFullLink {
     typeof value.type === "string" &&
     Array.isArray(value.path)
   );
-}
-
-/**
- * Check if value is an alias in any format (old $alias or new sigil)
- */
-export function isWriteRedirectLink(
-  value: any,
-): value is LegacyAlias | SigilWriteRedirectLink {
-  // Check legacy $alias format
-  if (isLegacyAlias(value)) {
-    return true;
-  }
-
-  // Check new sigil format (link@1 with overwrite field)
-  if (isSigilLink(value)) {
-    return value["/"][LINK_V1_TAG].overwrite === "redirect";
-  }
-
-  return false;
-}
-
-/**
- * Check if value is a legacy alias.
- *
- * @deprecated Switch to isWriteRedirectLink instead.
- *
- * @param {any} value - The value to check.
- * @returns {boolean}
- */
-export function isLegacyAlias(value: any): value is LegacyAlias {
-  return isRecord(value) && "$alias" in value && isRecord(value.$alias) &&
-    Array.isArray(value.$alias.path);
 }
 
 /**
@@ -237,80 +105,16 @@ export function parseLink(
 
   if (isCell(value)) return value.getAsNormalizedFullLink();
 
-  // Handle new sigil format
-  if (isSigilLink(value)) {
-    const link = value["/"][LINK_V1_TAG];
-
-    // Resolve relative references
-    let id = link.id;
-    const path = link.path || [];
-    const resolvedSpace = link.space || base?.space;
-
-    // If no id provided, use base cell's document
-    if (!id && base) {
-      id = isAnyCell(base) ? toURI(base.entityId) : base.id;
+  if (isPrimitiveCellLink(value)) {
+    if (!base) {
+      return parseLinkPrimitive(value);
+    } else if (isAnyCell(base)) {
+      return parseLinkPrimitive(value, base.getAsNormalizedFullLink());
+    } else if (isNormalizedLink(base)) {
+      return parseLinkPrimitive(value, base);
     }
-
-    return {
-      ...(id && { id }),
-      path: path.map((p) => p.toString()),
-      ...(resolvedSpace && { space: resolvedSpace }),
-      type: "application/json",
-      ...(link.schema !== undefined && { schema: link.schema }),
-      ...(link.rootSchema !== undefined && { rootSchema: link.rootSchema }),
-      ...(link.overwrite === "redirect" && { overwrite: "redirect" }),
-    };
+    throw new Error(`Unexpected link base: ${base}`);
   }
-
-  // Handle JSON CellLink format (storage format with { "/": string })
-  if (isJSONCellLink(value)) {
-    return {
-      id: toURI(value.cell["/"]),
-      path: value.path.map((p) => p.toString()),
-      ...(base?.space && { space: base.space }),
-      type: "application/json",
-    };
-  }
-
-  if (isRecord(value) && "/" in value) {
-    return {
-      id: toURI(value["/"]),
-      path: [],
-      ...(base?.space && { space: base.space }), // Space must come from context for JSON links
-      type: "application/json",
-    };
-  }
-
-  // Handle legacy alias format
-  if (isLegacyAlias(value)) {
-    const alias = value.$alias;
-    let id: URI | undefined;
-
-    // If cell is provided, convert to URI
-    if (alias.cell) {
-      if (isRecord(alias.cell) && "/" in alias.cell) {
-        id = toURI(alias.cell);
-      }
-    }
-
-    // If no cell provided, use base cell's document
-    if (!id && base) {
-      id = isAnyCell(base) ? toURI(base.entityId) : base.id;
-    }
-
-    return {
-      ...(id && { id }),
-      path: Array.isArray(alias.path)
-        ? alias.path.map((p) => p.toString())
-        : [],
-      ...(base?.space && { space: base.space }),
-      type: "application/json",
-      ...(alias.schema !== undefined && { schema: alias.schema }),
-      ...(alias.rootSchema !== undefined && { rootSchema: alias.rootSchema }),
-      overwrite: "redirect",
-    };
-  }
-
   return undefined;
 }
 
@@ -459,7 +263,7 @@ export function createSigilLinkFromParsedLink(
  * @returns The value with any data: URI links inlined.
  */
 export function findAndInlineDataURILinks(value: any): any {
-  if (isLink(value)) {
+  if (isCellLink(value)) {
     const dataLink = parseLink(value)!;
 
     if (dataLink.id?.startsWith("data:")) {
@@ -474,7 +278,7 @@ export function findAndInlineDataURILinks(value: any): any {
       // If there is a link on the way to `path`, follow it, appending remaining
       // path to the target link.
       while (dataValue !== undefined) {
-        if (isAnyCellLink(dataValue)) {
+        if (isPrimitiveCellLink(dataValue)) {
           // Parse the link found in the data URI
           // Do NOT pass parsedLink as base to avoid inheriting the data: URI id
           const newLink = parseLink(dataValue);
@@ -542,7 +346,7 @@ export function createDataCellURI(
     }
     seen.add(value);
     try {
-      if (isAnyCellLink(value)) {
+      if (isPrimitiveCellLink(value)) {
         const link = parseLink(value);
         if (!link.id) {
           return createSigilLinkFromParsedLink({ ...link, id: baseId });
@@ -628,92 +432,4 @@ function recursiveStripAsCellAndStreamFromSchema(
   }
 
   return result;
-}
-
-/**
- * Encodes a JSON Pointer path according to RFC 6901.
- * Each token has ~ replaced with ~0 and / replaced with ~1, then joined with /.
- * @param path - Array of path tokens to encode
- * @returns The encoded JSON Pointer string
- */
-export function encodeJsonPointer(path: readonly string[]): string {
-  return path
-    .map((token) => token.replace(/~/g, "~0").replace(/\//g, "~1"))
-    .join("/");
-}
-
-/**
- * Decodes a JSON Pointer string according to RFC 6901.
- * Splits by / then replaces ~1 with / and ~0 with ~ in each token.
- * @param pointer - The JSON Pointer string to decode
- * @returns Array of decoded path tokens
- */
-export function decodeJsonPointer(pointer: string): string[] {
-  return pointer
-    .split("/")
-    .map((token) => token.replace(/~1/g, "/").replace(/~0/g, "~"));
-}
-
-export const matchLLMFriendlyLink = new RegExp("^/[a-zA-Z0-9]+:");
-
-/**
- * Parses a LLM friendly link from a target string.
- *
- * @param target - The target string to parse
- * @param space - The space to use to get the cells
- * @returns The parsed LLM friendly link
- */
-export function parseLLMFriendlyLink(
-  target: string,
-  space: MemorySpace,
-): NormalizedFullLink;
-export function parseLLMFriendlyLink(
-  target: string,
-  space?: MemorySpace,
-): NormalizedLink;
-export function parseLLMFriendlyLink(
-  target: string,
-  space?: MemorySpace,
-): NormalizedLink {
-  target = target.trim();
-
-  if (!matchLLMFriendlyLink.test(target)) {
-    throw new Error(
-      'Target must include a charm handle, e.g. "/of:bafyabc123/path".',
-    );
-  }
-
-  const [empty, id, ...path] = decodeJsonPointer(target);
-
-  if (empty !== "") {
-    throw new Error("Target must start with a slash.");
-  }
-
-  // Check if first segment looks like a CID/handle by length
-  //
-  // CIDs are long encoded strings (typically 40+ chars), whereas human names
-  // are short. Use a conservative threshold to distinguish handles from
-  // human-readable names Handle format is "/of:..." (the internal storage
-  // format)
-  if (id === undefined || id.length < 20) {
-    throw new Error(
-      `Charm references must use handles (e.g., "/of:bafyabc123/path"), not human names (e.g., "${id}").`,
-    );
-  }
-
-  // Remove path element from trailing slash
-  if (path.length > 0 && path[path.length - 1] === "") {
-    path.pop();
-  }
-
-  return {
-    id: id as `${string}:${string}`,
-    path,
-    ...(space && { space }),
-    type: "application/json",
-  };
-}
-
-export function createLLMFriendlyLink(link: NormalizedFullLink): string {
-  return encodeJsonPointer(["", link.id, ...link.path]);
 }

--- a/packages/runner/src/recipe-binding.ts
+++ b/packages/runner/src/recipe-binding.ts
@@ -5,12 +5,13 @@ import {
   unsafe_originalRecipe,
   unsafe_parentRecipe,
 } from "./builder/types.ts";
-import { isLegacyAlias, isLink } from "./link-utils.ts";
 import { type AnyCell, type Cell } from "./cell.ts";
 import { resolveLink } from "./link-resolution.ts";
 import { diffAndUpdate } from "./data-updating.ts";
 import {
   areNormalizedLinksSame,
+  isCellLink,
+  isLegacyAlias,
   isWriteRedirectLink,
   type NormalizedFullLink,
   parseLink,
@@ -165,13 +166,13 @@ export function findAllWriteRedirectCells<T>(
       );
       if (!linkCell) throw new Error("Link cell not found");
       find(linkCell.getRaw({ meta: ignoreReadForScheduling }), baseCell);
-    } else if (isLink(binding)) {
+    } else if (isCellLink(binding)) {
       // Links that are not write redirects: Ignore them.
       return;
     } else if (Array.isArray(binding)) {
       // If the binding is an array, recurse into each element.
       for (const value of binding) find(value, baseCell);
-    } else if (isRecord(binding) && !isLink(binding)) {
+    } else if (isRecord(binding) && !isCellLink(binding)) {
       // If the binding is an object, recurse into each value.
       for (const value of Object.values(binding)) find(value, baseCell);
     }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -36,7 +36,7 @@ import { resolveLink } from "./link-resolution.ts";
 import {
   areNormalizedLinksSame,
   createSigilLinkFromParsedLink,
-  isLink,
+  isCellLink,
   isSigilLink,
   isWriteRedirectLink,
   type NormalizedFullLink,
@@ -238,7 +238,7 @@ export class Runner {
     }, tx);
 
     // If the bindings are a cell, doc or doc link, convert them to an alias
-    if (isLink(argument)) {
+    if (isCellLink(argument)) {
       argument = createSigilLinkFromParsedLink(
         parseLink(argument),
         { base: processCell, includeSchema: true, overwrite: "redirect" },
@@ -1342,7 +1342,7 @@ function getSpellLink(recipeId: string): SigilLink {
 
 function containsOpaqueRef(value: unknown): boolean {
   if (isOpaqueRef(value)) return true;
-  if (isLink(value)) return false;
+  if (isCellLink(value)) return false;
   if (isRecord(value)) {
     return Object.values(value).some(containsOpaqueRef);
   }
@@ -1350,7 +1350,7 @@ function containsOpaqueRef(value: unknown): boolean {
 }
 
 export function cellAwareDeepCopy<T = unknown>(value: T): Mutable<T> {
-  if (isLink(value)) return value as Mutable<T>;
+  if (isCellLink(value)) return value as Mutable<T>;
   if (isRecord(value)) {
     return Array.isArray(value)
       ? value.map(cellAwareDeepCopy) as unknown as Mutable<T>
@@ -1415,7 +1415,7 @@ export function mergeObjects<T>(
     // If we have a literal value, return it. Same for arrays, since we wouldn't
     // know how to merge them. Note that earlier objects take precedence, so if
     // an earlier was e.g. an object, we'll return that instead of the literal.
-    if (!isObject(obj) || isLink(obj)) {
+    if (!isObject(obj) || isCellLink(obj)) {
       return obj as T;
     }
 

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -28,7 +28,7 @@ import { Action, Scheduler } from "./scheduler.ts";
 import { Engine } from "./harness/index.ts";
 import {
   CellLink,
-  isLink,
+  isCellLink,
   isNormalizedFullLink,
   type NormalizedFullLink,
   NormalizedLink,
@@ -423,7 +423,7 @@ export class Runtime {
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
   ): Cell<any> {
-    let link = isLink(cellLink)
+    let link = isCellLink(cellLink)
       ? parseLink(cellLink)
       : isNormalizedFullLink(cellLink)
       ? cellLink

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -17,7 +17,7 @@ import type {
   SchemaPathSelector,
 } from "@commontools/memory/interface";
 import { deepEqual } from "./path-utils.ts";
-import { isAnyCellLink, parseLink } from "./link-utils.ts";
+import { isPrimitiveCellLink, parseLink } from "./link-utils.ts";
 import { fromURI } from "./uri-utils.ts";
 import type { IAttestation, IMemoryAddress } from "./storage/interface.ts";
 
@@ -317,7 +317,7 @@ export abstract class BaseObjectTraverser<S extends BaseMemoryAddress> {
       ) as Immutable<JSONValue>[];
     } else if (isRecord(doc.value)) {
       // First, see if we need special handling
-      if (isAnyCellLink(doc.value)) {
+      if (isPrimitiveCellLink(doc.value)) {
         // Check if target doc is already tracked BEFORE calling getAtPath,
         // since getAtPath/followPointer will add it to schemaTracker
         let alreadyTracked = false;
@@ -406,7 +406,7 @@ export function getAtPath<S extends BaseMemoryAddress>(
 ): [IAttestation, SchemaPathSelector | undefined] {
   let curDoc = doc;
   let remaining = [...path];
-  while (isAnyCellLink(curDoc.value)) {
+  while (isPrimitiveCellLink(curDoc.value)) {
     [curDoc, selector] = followPointer(
       manager,
       curDoc,
@@ -448,7 +448,7 @@ export function getAtPath<S extends BaseMemoryAddress>(
       }, selector];
     }
     // If this next value is a pointer, use the pointer resolution code
-    while (isAnyCellLink(curDoc.value)) {
+    while (isPrimitiveCellLink(curDoc.value)) {
       [curDoc, selector] = followPointer(
         manager,
         curDoc,
@@ -651,7 +651,7 @@ function loadLinkedRecipe<S extends BaseMemoryAddress>(
   let address;
   // Check for a spell link first, since this is more efficient
   // Older recipes will only have a $TYPE
-  if ("spell" in value && isAnyCellLink(value["spell"])) {
+  if ("spell" in value && isPrimitiveCellLink(value["spell"])) {
     const link = parseLink(value["spell"])!;
     address = manager.toAddress(fromURI(link.id!));
   } else if ("$TYPE" in value && isString(value["$TYPE"])) {
@@ -891,7 +891,7 @@ export class SchemaObjectTraverser<S extends BaseMemoryAddress>
       }
       return undefined;
     } else if (isObject(doc.value)) {
-      if (isAnyCellLink(doc.value)) {
+      if (isPrimitiveCellLink(doc.value)) {
         return this.traversePointerWithSchema(doc, {
           schema: schemaObj,
           rootSchema: schemaContext.rootSchema,

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -13,7 +13,11 @@ import { popFrame, pushFrame } from "../src/builder/recipe.ts";
 import { Runtime } from "../src/runtime.ts";
 import { txToReactivityLog } from "../src/scheduler.ts";
 import { addCommonIDfromObjectID } from "../src/data-updating.ts";
-import { areLinksSame, isAnyCellLink, parseLink } from "../src/link-utils.ts";
+import {
+  areLinksSame,
+  isPrimitiveCellLink,
+  parseLink,
+} from "../src/link-utils.ts";
 import { areNormalizedLinksSame } from "../src/link-utils.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
@@ -391,8 +395,8 @@ describe("Cell utility functions", () => {
     );
     c.set({ x: 10 });
     const ref = c.key("x").getAsLink();
-    expect(isAnyCellLink(ref)).toBe(true);
-    expect(isAnyCellLink({})).toBe(false);
+    expect(isPrimitiveCellLink(ref)).toBe(true);
+    expect(isPrimitiveCellLink({})).toBe(false);
   });
 
   it("should identify a cell proxy", () => {
@@ -2191,8 +2195,8 @@ describe("asCell with schema", () => {
     testCell.set(initialDataCopy);
     popFrame(frame1);
 
-    expect(isAnyCellLink(testCell.getRaw()[0])).toBe(true);
-    expect(isAnyCellLink(testCell.getRaw()[1])).toBe(true);
+    expect(isPrimitiveCellLink(testCell.getRaw()[0])).toBe(true);
+    expect(isPrimitiveCellLink(testCell.getRaw()[1])).toBe(true);
     expect(testCell.get()[0].name).toEqual("First Item");
     expect(testCell.get()[1].name).toEqual("Second Item");
     expect(testCell.key("0").key("nested").key("0").key("id").get()).toEqual(
@@ -2216,8 +2220,8 @@ describe("asCell with schema", () => {
     testCell.set(returnedData);
     popFrame(frame2);
 
-    expect(isAnyCellLink(testCell.getRaw()[0])).toBe(true);
-    expect(isAnyCellLink(testCell.getRaw()[1])).toBe(true);
+    expect(isPrimitiveCellLink(testCell.getRaw()[0])).toBe(true);
+    expect(isPrimitiveCellLink(testCell.getRaw()[1])).toBe(true);
     expect(testCell.get()[0].name).toEqual("First Item");
     expect(testCell.get()[1].name).toEqual("Second Item");
 
@@ -2294,8 +2298,8 @@ describe("asCell with schema", () => {
     arrayCell.push({ [ID]: "test", value: 43 });
     expect(frame.generatedIdCounter).toEqual(1); // No increment = no ID generated from it
     popFrame(frame);
-    expect(isAnyCellLink(c.getRaw()?.items[0])).toBe(true);
-    expect(isAnyCellLink(c.getRaw()?.items[1])).toBe(true);
+    expect(isPrimitiveCellLink(c.getRaw()?.items[0])).toBe(true);
+    expect(isPrimitiveCellLink(c.getRaw()?.items[1])).toBe(true);
     expect(arrayCell.get()).toEqualIgnoringSymbols([
       { value: 42 },
       { value: 43 },

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -12,7 +12,7 @@ import {
   areLinksSame,
   areNormalizedLinksSame,
   createSigilLinkFromParsedLink,
-  isAnyCellLink,
+  isPrimitiveCellLink,
   isSigilLink,
   parseLink,
 } from "../src/link-utils.ts";
@@ -568,8 +568,8 @@ describe("data-updating", () => {
         "should update the same document with ID-based entity objects",
       );
 
-      expect(isAnyCellLink(testCell.getRaw().items[0])).toBe(true);
-      expect(isAnyCellLink(testCell.getRaw().items[1])).toBe(true);
+      expect(isPrimitiveCellLink(testCell.getRaw().items[0])).toBe(true);
+      expect(isPrimitiveCellLink(testCell.getRaw().items[1])).toBe(true);
       expect(areLinksSame(testCell.getRaw().items[0], newLink)).toBe(false);
       expect(
         (tx.readValueOrThrow(
@@ -681,8 +681,8 @@ describe("data-updating", () => {
       );
 
       // Verify that the second item reused the existing document
-      expect(isAnyCellLink(testCell.getRaw().items[0])).toBe(true);
-      expect(isAnyCellLink(testCell.getRaw().items[1])).toBe(true);
+      expect(isPrimitiveCellLink(testCell.getRaw().items[0])).toBe(true);
+      expect(isPrimitiveCellLink(testCell.getRaw().items[1])).toBe(true);
       expect(areLinksSame(testCell.getRaw().items[1], initialLink)).toBe(true);
       expect(
         (tx.readValueOrThrow(
@@ -724,8 +724,8 @@ describe("data-updating", () => {
         "it should treat different properties as different ID namespaces",
       );
 
-      expect(isAnyCellLink(testCell.getRaw().a)).toBe(true);
-      expect(isAnyCellLink(testCell.getRaw().b)).toBe(true);
+      expect(isPrimitiveCellLink(testCell.getRaw().a)).toBe(true);
+      expect(isPrimitiveCellLink(testCell.getRaw().b)).toBe(true);
       expect(areLinksSame(testCell.getRaw().a, testCell.getRaw().b)).toBe(
         false,
       );
@@ -1019,7 +1019,7 @@ describe("data-updating", () => {
       expect(titleChange!.value).toBe("Data with Link");
       expect(referenceChange).toBeDefined();
       // The reference should be resolved to the actual cell link
-      expect(isAnyCellLink(referenceChange!.value)).toBe(true);
+      expect(isPrimitiveCellLink(referenceChange!.value)).toBe(true);
       expect(metadataChange).toBeDefined();
       expect(metadataChange!.value).toEqual("Contains a nested link");
       expect(objectChange).toBeDefined();
@@ -1207,8 +1207,8 @@ describe("data-updating", () => {
       );
 
       const result = testCell.getRaw();
-      expect(isAnyCellLink(result?.items[0])).toBe(true);
-      expect(isAnyCellLink(result?.items[1])).toBe(true);
+      expect(isPrimitiveCellLink(result?.items[0])).toBe(true);
+      expect(isPrimitiveCellLink(result?.items[1])).toBe(true);
       expect(areLinksSame(result?.items[0], result?.items[1]))
         .toBe(true);
       expect(

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -7,8 +7,8 @@ import {
   createSigilLinkFromParsedLink,
   decodeJsonPointer,
   encodeJsonPointer,
+  isCellLink,
   isLegacyAlias,
-  isLink,
   isSigilValue,
   isWriteRedirectLink,
   type NormalizedLink,
@@ -125,36 +125,36 @@ describe("link-utils", () => {
     });
   });
 
-  describe("isLink", () => {
+  describe("isCellLink", () => {
     it("should identify query results as links", () => {
       const cell = runtime.getCell(space, "test", undefined, tx);
       // Has to be an object, otherwise asQueryResult() returns a literal
       cell.set({ value: 42 });
       const queryResult = cell.getAsQueryResult();
-      expect(isLink(queryResult)).toBe(true);
+      expect(isCellLink(queryResult)).toBe(true);
     });
 
     it("should identify cell links as links", () => {
       const cell = runtime.getCell(space, "test", undefined, tx);
       const cellLink = cell.getAsLink();
-      expect(isLink(cellLink)).toBe(true);
+      expect(isCellLink(cellLink)).toBe(true);
     });
 
     it("should identify cells as links", () => {
       const cell = runtime.getCell(space, "test", undefined, tx);
-      expect(isLink(cell)).toBe(true);
+      expect(isCellLink(cell)).toBe(true);
     });
 
     it("should identify EntityId format as links", () => {
-      expect(isLink({ "/": "of:test" })).toBe(true);
+      expect(isCellLink({ "/": "of:test" })).toBe(true);
     });
 
     it("should not identify non-links as links", () => {
-      expect(isLink("string")).toBe(false);
-      expect(isLink(123)).toBe(false);
-      expect(isLink({ notLink: "value" })).toBe(false);
-      expect(isLink(null)).toBe(false);
-      expect(isLink(undefined)).toBe(false);
+      expect(isCellLink("string")).toBe(false);
+      expect(isCellLink(123)).toBe(false);
+      expect(isCellLink({ notLink: "value" })).toBe(false);
+      expect(isCellLink(null)).toBe(false);
+      expect(isCellLink(undefined)).toBe(false);
     });
   });
 

--- a/packages/runner/test/push-conflict.test.ts
+++ b/packages/runner/test/push-conflict.test.ts
@@ -5,7 +5,7 @@ import * as Memory from "@commontools/memory";
 import * as Consumer from "@commontools/memory/consumer";
 import { Cell, ID } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
-import { isAnyCellLink } from "../src/link-utils.ts";
+import { isPrimitiveCellLink } from "../src/link-types.ts";
 import { Provider } from "../src/storage/cache.ts";
 import * as Subscription from "../src/storage/subscription.ts";
 import {
@@ -228,7 +228,7 @@ describe.skip("Push conflict", () => {
     // This is locally ahead of the db, and retry wasn't called yet.
     expect(name.get()).toEqual("bar");
     expect(list.get()).toEqual([{ n: 4 }]);
-    expect(isAnyCellLink(list.getRaw()?.[0])).toBe(true);
+    expect(isPrimitiveCellLink(list.getRaw()?.[0])).toBe(true);
 
     await runtime.storageManager.synced();
 

--- a/packages/runner/test/recipes.test.ts
+++ b/packages/runner/test/recipes.test.ts
@@ -14,7 +14,7 @@ import { Runtime } from "../src/runtime.ts";
 import { type ErrorWithContext } from "../src/scheduler.ts";
 import { isCell, isStream } from "../src/cell.ts";
 import { resolveLink } from "../src/link-resolution.ts";
-import { isAnyCellLink, parseLink } from "../src/link-utils.ts";
+import { isPrimitiveCellLink, parseLink } from "../src/link-utils.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
@@ -800,7 +800,7 @@ describe("Recipe Runner", () => {
     const recipeId = sourceCellValue?.[TYPE];
     expect(recipeId).toBeDefined();
     expect(lastError?.recipeId).toBe(recipeId);
-    expect(isAnyCellLink(sourceCellValue?.["spell"])).toBe(true);
+    expect(isPrimitiveCellLink(sourceCellValue?.["spell"])).toBe(true);
     const spellLink = parseLink(sourceCellValue["spell"]);
     const spellId = spellLink?.id;
     expect(spellId).toBeDefined();


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Isolated link type guards and helpers into a new link-types module to decouple types from runtime logic and simplify imports. No behavior changes; names were clarified and references updated.

- **Refactors**
  - Added link-types.ts for NormalizedLink types, primitive link guards, equality, JSON Pointer, and LLM-friendly link helpers.
  - Updated link-utils.ts to use parseLinkPrimitive and re-export link-types.
  - Renamed isLink to isCellLink and isAnyCellLink to isPrimitiveCellLink across code and tests.
  - Adjusted exports: NormalizedLink now from link-types; isCellLink is exported as isLink for backward compatibility.

<sup>Written for commit 77564c6e7a9c738ff52a949f620180c2431d7c48. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



