### PR TITLE
fix(runner): update error messages to recommend computed() over derive

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -433,7 +433,7 @@ export class CellImpl<T> implements ICell<T>, IStreamable<T> {
     if (!space) {
       throw new Error(
         "Cannot create cell link: space is required.\n" +
-          "This can happen when manually calling .get() on closed-over cells.\n" +
+          "This can happen when accessing closed-over cells e.g. with .get().\n" +
           "Use `computed()` for reactive computations - it handles closures automatically.\n",
       );
     }


### PR DESCRIPTION
Both error messages previously recommended using `derive` with explicit parameters. Since `computed()` is the modern/ergonomic approach that handles closures automatically via the transformer, update the messages to recommend `computed()` instead.

- "Tried to directly access an opaque value" now suggests computed()
- "Cannot create cell link: space is required" now suggests computed()

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated runner error messages to recommend computed() instead of derive, aligning with the current reactive API. Clarifies closure behavior for opaque value access and cell link creation, guiding users to computed() for reactive computations.

<sup>Written for commit 7142dccd8e076003009ed7de0901fa3e3fb296c9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



