### PR TITLE
feat(patterns): add note-search pattern with regex and semantic search

### DIFF
--- a/packages/patterns/note-search-regex.tsx
+++ b/packages/patterns/note-search-regex.tsx
@@ -1,0 +1,149 @@
+/// <cts-enable />
+import {
+  Cell,
+  Default,
+  handler,
+  ifElse,
+  lift,
+  NAME,
+  navigateTo,
+  OpaqueRef,
+  pattern,
+  UI,
+} from "commontools";
+
+/**
+ * Represents a note charm that can be searched.
+ */
+export type NoteCharm = {
+  [NAME]?: string;
+  title?: string;
+  content?: string;
+};
+
+type Input = {
+  /** Notes to search through */
+  notes: Default<NoteCharm[], []>;
+  /** Regex pattern (without surrounding slashes) */
+  regexPattern: Default<string, "">;
+};
+
+type Output = {
+  /** Count of matches */
+  matchCount: number;
+};
+
+/**
+ * RegexNoteSearch - Searches notes using regex pattern matching.
+ *
+ * Uses .map() on the input notes array to evaluate each note against the pattern.
+ * This ensures proper reactivity since .map() only works on input arrays.
+ */
+export default pattern<Input, Output>(({ notes, regexPattern }) => {
+  // Compute match count using a single lift on the notes array
+  const matchCount = lift(({ ns, pat }: { ns: NoteCharm[]; pat: string }) => {
+    const pattern = (pat ?? "").trim();
+    if (!pattern || !ns) return 0;
+    try {
+      const regex = new RegExp(pattern, "i");
+      return ns.filter((n) => {
+        const content = n?.content ?? "";
+        const title = n?.title ?? n?.[NAME] ?? "";
+        return regex.test(content) || regex.test(title);
+      }).length;
+    } catch {
+      return 0;
+    }
+  })({ ns: notes, pat: regexPattern });
+
+  // Map over input notes to evaluate each one for display
+  const evaluations = notes.map((note: OpaqueRef<NoteCharm>) => {
+    // Check if this note matches the regex
+    const matches = lift(({ n, pat }: { n: NoteCharm; pat: string }) => {
+      const pattern = (pat ?? "").trim();
+      if (!pattern) return false;
+
+      try {
+        const regex = new RegExp(pattern, "i");
+        const content = n?.content ?? "";
+        const title = n?.title ?? n?.[NAME] ?? "";
+        return regex.test(content) || regex.test(title);
+      } catch {
+        return false;
+      }
+    })({ n: note, pat: regexPattern });
+
+    // Get note title
+    const noteTitle = lift((n: NoteCharm) =>
+      n?.title ?? n?.[NAME] ?? "Untitled"
+    )(note);
+
+    // Generate snippet
+    const snippet = lift(({ n, pat }: { n: NoteCharm; pat: string }) => {
+      const pattern = (pat ?? "").trim();
+      const content = n?.content ?? "";
+      if (!pattern || !content) {
+        return content.slice(0, 100) + (content.length > 100 ? "..." : "");
+      }
+
+      try {
+        const regex = new RegExp(pattern, "i");
+        const match = content.match(regex);
+        if (match && match.index !== undefined) {
+          const start = Math.max(0, match.index - 30);
+          const end = Math.min(
+            content.length,
+            match.index + match[0].length + 30,
+          );
+          let s = content.slice(start, end);
+          if (start > 0) s = "..." + s;
+          if (end < content.length) s = s + "...";
+          return s;
+        }
+      } catch {
+        // Invalid regex
+      }
+      return content.slice(0, 100) + (content.length > 100 ? "..." : "");
+    })({ n: note, pat: regexPattern });
+
+    // Handler to navigate to this note
+    const goToNote = handler<void, { n: Cell<NoteCharm> }>(
+      (_, { n }) => {
+        return navigateTo(n);
+      },
+      { proxy: true },
+    )({ n: note });
+
+    return { note, matches, noteTitle, snippet, goToNote };
+  });
+
+  return {
+    [NAME]: "Regex Note Search",
+    [UI]: (
+      <ct-vstack gap={1}>
+        {evaluations.map((ev) => (
+          <div>
+            {ifElse(
+              ev.matches,
+              <ct-card style={{ cursor: "pointer" }} onClick={ev.goToNote}>
+                <ct-vstack gap={1}>
+                  <strong>{ev.noteTitle}</strong>
+                  <div style={{ fontSize: "0.9em", color: "#555" }}>
+                    {ev.snippet}
+                  </div>
+                </ct-vstack>
+              </ct-card>,
+              null,
+            )}
+          </div>
+        ))}
+        {ifElse(
+          lift((c: number) => c === 0)(matchCount),
+          <div style={{ color: "#888", padding: "8px" }}>No matches found</div>,
+          null,
+        )}
+      </ct-vstack>
+    ),
+    matchCount,
+  };
+});

--- a/packages/patterns/note-search-semantic.tsx
+++ b/packages/patterns/note-search-semantic.tsx
@@ -1,0 +1,230 @@
+/// <cts-enable />
+import {
+  Cell,
+  Default,
+  generateObject,
+  handler,
+  ifElse,
+  lift,
+  NAME,
+  navigateTo,
+  OpaqueRef,
+  pattern,
+  UI,
+} from "commontools";
+
+/**
+ * Represents a note charm that can be searched.
+ */
+export type NoteCharm = {
+  [NAME]?: string;
+  title?: string;
+  content?: string;
+};
+
+/**
+ * LLM evaluation result for semantic matching.
+ */
+interface MatchResult {
+  matches: boolean;
+  reason: string;
+}
+
+type Input = {
+  /** Notes to search through */
+  notes: Default<NoteCharm[], []>;
+  /** Natural language search query */
+  query: Default<string, "">;
+};
+
+type Output = {
+  /** Count of matches */
+  matchCount: number;
+  /** Count of pending evaluations */
+  pendingCount: number;
+};
+
+/**
+ * SemanticNoteSearch - Searches notes using LLM-powered semantic matching.
+ *
+ * Input:
+ * - notes: Array of note charms to search
+ * - query: Natural language description of what to find
+ *
+ * Output:
+ * - matchCount: Number of matches
+ * - pendingCount: Number of evaluations still in progress
+ */
+export default pattern<Input, Output>(({ notes, query }) => {
+  // Process each note with LLM evaluation
+  // Map directly on input notes array
+  const evaluations = notes.map((note: OpaqueRef<NoteCharm>) => {
+    // Check if this note has content/title (skip if not)
+    const hasContent = lift((n: NoteCharm) =>
+      n?.content !== undefined || n?.title !== undefined
+    )(note);
+
+    const noteTitle = lift((n: NoteCharm) =>
+      n?.title ?? n?.[NAME] ?? "Untitled"
+    )(note);
+
+    const noteContentPreview = lift((n: NoteCharm) => {
+      const content = n?.content ?? "";
+      if (!content) return "(no content)";
+      if (content.length <= 100) return content;
+      return content.slice(0, 100) + "...";
+    })(note);
+
+    // Build prompt for LLM - empty string if no query or no content
+    const semanticPrompt = lift(({ n, q }: { n: NoteCharm; q: string }) => {
+      const trimmed = (q ?? "").trim();
+      if (!trimmed) return "";
+      // Skip notes without content/title
+      if (n?.content === undefined && n?.title === undefined) return "";
+
+      const title = n?.title ?? n?.[NAME] ?? "Untitled";
+      const content = n?.content ?? "(empty)";
+
+      return `Search query: "${trimmed}"
+
+Note to evaluate:
+Title: ${title}
+Content: ${content}
+
+Does this note match the search query? Be generous - if there's any reasonable connection, consider it a match.`;
+    })({ n: note, q: query });
+
+    // LLM evaluation - only runs when prompt is non-empty
+    const llmResult = generateObject<MatchResult>({
+      system: `You are evaluating whether a note matches a search query.
+The search query is a natural language description of what the user is looking for.
+Return matches: true if the note content is relevant to what the user is searching for.
+Return reason: a brief explanation of why it matches (or doesn't).`,
+      prompt: semanticPrompt,
+    });
+
+    const matches = lift(
+      (
+        { q, pending, error, result, has }: {
+          q: string;
+          pending: boolean;
+          error: unknown;
+          result?: MatchResult;
+          has: boolean;
+        },
+      ) => {
+        if (!has) return false; // Skip notes without content
+        const trimmed = (q ?? "").trim();
+        if (!trimmed) return false;
+        if (pending) return false;
+        if (error) return false;
+        return result?.matches === true;
+      },
+    )({
+      q: query,
+      pending: llmResult.pending,
+      error: llmResult.error,
+      result: llmResult.result,
+      has: hasContent,
+    });
+
+    const pending = lift(
+      ({ q, p, has }: { q: string; p: boolean; has: boolean }) => {
+        if (!has) return false; // Skip notes without content
+        const trimmed = (q ?? "").trim();
+        return trimmed.length > 0 && p;
+      },
+    )({ q: query, p: llmResult.pending, has: hasContent });
+
+    const reason = lift(({ result }: { result?: MatchResult }) =>
+      result?.reason ?? ""
+    )({ result: llmResult.result });
+
+    // Combined state for simpler rendering
+    const showPending = lift(({ has, pend }: { has: boolean; pend: boolean }) =>
+      has && pend
+    )({ has: hasContent, pend: pending });
+
+    const showMatch = lift((
+      { has, pend, match }: { has: boolean; pend: boolean; match: boolean },
+    ) => has && !pend && match)({
+      has: hasContent,
+      pend: pending,
+      match: matches,
+    });
+
+    // Handler to navigate to this note
+    const goToNote = handler<void, { n: Cell<NoteCharm> }>(
+      (_, { n }) => {
+        return navigateTo(n);
+      },
+      { proxy: true },
+    )({ n: note });
+
+    return {
+      note,
+      noteTitle,
+      noteContentPreview,
+      showPending,
+      showMatch,
+      reason,
+      goToNote,
+    };
+  });
+
+  // Aggregate counts from evaluations
+  const matchCount = lift(
+    (evals: Array<{ showMatch: boolean }>) =>
+      (evals ?? []).filter((e) => e.showMatch).length,
+  )(evaluations);
+
+  const pendingCount = lift(
+    (evals: Array<{ showPending: boolean }>) =>
+      (evals ?? []).filter((e) => e.showPending).length,
+  )(evaluations);
+
+  return {
+    [NAME]: "Semantic Note Search",
+    [UI]: (
+      <ct-vstack gap={1}>
+        {evaluations.map((ev) => (
+          <div>
+            {ifElse(
+              ev.showPending,
+              <ct-card>
+                <ct-hstack gap={1}>
+                  <ct-loader size="sm" />
+                  <span>Evaluating: {ev.noteTitle}</span>
+                </ct-hstack>
+              </ct-card>,
+              null,
+            )}
+            {ifElse(
+              ev.showMatch,
+              <ct-card style={{ cursor: "pointer" }} onClick={ev.goToNote}>
+                <ct-vstack gap={1}>
+                  <strong>{ev.noteTitle}</strong>
+                  <div style={{ fontSize: "0.9em", color: "#555" }}>
+                    {ev.noteContentPreview}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: "0.8em",
+                      color: "#888",
+                      fontStyle: "italic",
+                    }}
+                  >
+                    {ev.reason}
+                  </div>
+                </ct-vstack>
+              </ct-card>,
+              null,
+            )}
+          </div>
+        ))}
+      </ct-vstack>
+    ),
+    matchCount,
+    pendingCount,
+  };
+});

--- a/packages/patterns/note-search.tsx
+++ b/packages/patterns/note-search.tsx
@@ -1,0 +1,213 @@
+/// <cts-enable />
+import {
+  Cell,
+  handler,
+  ifElse,
+  lift,
+  NAME,
+  pattern,
+  UI,
+  wish,
+} from "commontools";
+
+import RegexSearch, { type NoteCharm } from "./note-search-regex.tsx";
+import SemanticSearch from "./note-search-semantic.tsx";
+
+type Input = void;
+
+type Output = {
+  query: string;
+  isRegexMode: boolean;
+  debugMode: boolean;
+};
+
+// Toggle debug mode
+const toggleDebug = handler<
+  void,
+  { debugMode: Cell<boolean> }
+>((_, { debugMode }) => {
+  debugMode.set(!debugMode.get());
+});
+
+/**
+ * NoteSearch - Search all notes in a space using either:
+ * - Regex mode: /pattern/ syntax for direct text matching
+ * - Semantic mode: Natural language queries evaluated by LLM
+ *
+ * Composes note-search-regex and note-search-semantic patterns.
+ * Uses wish("/") to automatically get allCharms from the space.
+ */
+export default pattern<Input, Output>((_) => {
+  // Get allCharms automatically from the space
+  const { allCharms } = wish<{ allCharms: NoteCharm[] }>("/");
+  // ===================
+  // CORE STATE
+  // ===================
+  const query = Cell.of("");
+  const debugMode = Cell.of(false);
+
+  // ===================
+  // QUERY ANALYSIS (using lift for proper reactivity)
+  // ===================
+  const isRegexMode = lift((q: string) => {
+    const trimmed = (q ?? "").trim();
+    return trimmed.length >= 2 && trimmed.startsWith("/") &&
+      trimmed.endsWith("/");
+  })(query);
+
+  const isSemanticMode = lift((q: string) => {
+    const trimmed = (q ?? "").trim();
+    const isRegex = trimmed.length >= 2 && trimmed.startsWith("/") &&
+      trimmed.endsWith("/");
+    return trimmed.length > 0 && !isRegex;
+  })(query);
+
+  const regexPattern = lift((q: string) => {
+    const trimmed = (q ?? "").trim();
+    const isRegex = trimmed.length >= 2 && trimmed.startsWith("/") &&
+      trimmed.endsWith("/");
+    if (!isRegex) return "";
+    return trimmed.slice(1, -1); // Remove surrounding slashes
+  })(query);
+
+  // ===================
+  // NOTES FILTERING
+  // ===================
+  const allCharmsCount = lift((charms: NoteCharm[]) => (charms ?? []).length)(
+    allCharms,
+  );
+
+  // Filter to only notes (charms with content or title)
+  const notesOnly = lift((charms: NoteCharm[]) => {
+    return (charms ?? []).filter(
+      (charm: NoteCharm) =>
+        charm?.content !== undefined || charm?.title !== undefined,
+    );
+  })(allCharms);
+  const notesCount = lift((notes: NoteCharm[]) => notes.length)(notesOnly);
+
+  // ===================
+  // COMPOSED SEARCH PATTERNS
+  // ===================
+  const regexSearch = RegexSearch({
+    notes: notesOnly,
+    regexPattern: regexPattern,
+  });
+
+  const semanticSearch = SemanticSearch({
+    notes: notesOnly,
+    query: query,
+  });
+
+  // ===================
+  // UI
+  // ===================
+  return {
+    [NAME]: "Note Search",
+    [UI]: (
+      <ct-screen>
+        <div slot="header">
+          <ct-hstack gap={2} style="align-items: center;">
+            <h2 style={{ margin: 0 }}>Note Search</h2>
+            <ct-button onClick={toggleDebug({ debugMode })}>
+              {ifElse(debugMode, "Hide Debug", "Show Debug")}
+            </ct-button>
+          </ct-hstack>
+        </div>
+
+        <ct-vstack gap={2}>
+          {/* Search Input */}
+          <ct-card>
+            <ct-vstack gap={1}>
+              <ct-input
+                $value={query}
+                placeholder="Search notes... (use /regex/ for pattern matching)"
+              />
+              <div style={{ fontSize: "0.85em", color: "#666" }}>
+                {ifElse(
+                  isRegexMode,
+                  <span>🔍 Regex mode - pattern: {regexPattern}</span>,
+                  ifElse(
+                    isSemanticMode,
+                    <span>🤖 Semantic mode - AI-powered search</span>,
+                    <span>Type to search...</span>,
+                  ),
+                )}
+              </div>
+            </ct-vstack>
+          </ct-card>
+
+          {/* Debug Panel */}
+          {ifElse(
+            debugMode,
+            <ct-card>
+              <ct-vstack gap={1}>
+                <strong>🐛 Debug Info</strong>
+                <div
+                  style={{
+                    fontSize: "0.8em",
+                    fontFamily: "monospace",
+                    background: "#f5f5f5",
+                    padding: "8px",
+                    borderRadius: "4px",
+                  }}
+                >
+                  <div>query: "{query}"</div>
+                  <div>isRegexMode: {ifElse(isRegexMode, "true", "false")}</div>
+                  <div>
+                    isSemanticMode: {ifElse(isSemanticMode, "true", "false")}
+                  </div>
+                  <div>regexPattern: "{regexPattern}"</div>
+                  <div>---</div>
+                  <div>allCharmsCount: {allCharmsCount}</div>
+                  <div>notesCount: {notesCount}</div>
+                  <div>---</div>
+                  <div>regexMatchCount: {regexSearch.matchCount}</div>
+                  <div>semanticMatchCount: {semanticSearch.matchCount}</div>
+                  <div>semanticPendingCount: {semanticSearch.pendingCount}</div>
+                </div>
+              </ct-vstack>
+            </ct-card>,
+            null,
+          )}
+
+          {/* Regex Results */}
+          {ifElse(
+            isRegexMode,
+            <ct-vstack gap={1}>
+              <div style={{ fontSize: "0.9em", color: "#666", padding: "4px" }}>
+                Regex Results ({regexSearch.matchCount} matches)
+              </div>
+              <ct-render $cell={regexSearch} />
+            </ct-vstack>,
+            null,
+          )}
+
+          {/* Semantic Results */}
+          {ifElse(
+            isSemanticMode,
+            <ct-vstack gap={1}>
+              <div style={{ fontSize: "0.9em", color: "#666", padding: "4px" }}>
+                Semantic Results ({semanticSearch.matchCount} matches,{" "}
+                {semanticSearch.pendingCount} pending)
+              </div>
+              <ct-render $cell={semanticSearch} />
+            </ct-vstack>,
+            null,
+          )}
+
+          {/* Footer */}
+          <ct-card>
+            <div style={{ fontSize: "0.85em", color: "#888" }}>
+              Found {notesCount} notes in space (from {allCharmsCount}{" "}
+              total charms)
+            </div>
+          </ct-card>
+        </ct-vstack>
+      </ct-screen>
+    ),
+    query,
+    isRegexMode,
+    debugMode,
+  };
+});


### PR DESCRIPTION
## Summary

- Adds a composable note search system with two search modes:
  - **Regex mode**: `/pattern/` syntax for direct text matching
  - **Semantic mode**: Natural language queries evaluated by LLM
- Split into three patterns for modularity:
  - `note-search.tsx`: Main UI composing the search patterns
  - `note-search-regex.tsx`: Regex search with click-to-navigate
  - `note-search-semantic.tsx`: Semantic search with per-note LLM evaluation
- Uses `wish("/")` to automatically get allCharms from the space - no manual linking required on deploy

## Test plan

- [ ] Deploy pattern to a space with notes: `deno task ct charm new -i claude.key -a http://localhost:8000 -s <space> packages/patterns/note-search.tsx`
- [ ] Test regex mode by typing `/cat/` to find notes containing "cat"
- [ ] Test semantic mode by typing natural language like "notes about animals"
- [ ] Verify clicking a result navigates to the note
- [ ] Toggle debug mode to verify counts are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Note Search pattern with two modes: regex (/pattern/) and semantic (natural language). It scans all notes in the space automatically and shows clickable results with snippets and counts.

- New Features
  - note-search.tsx: Main UI that auto-loads notes via wish("/"), detects mode from input, and includes a debug toggle with live counts.
  - note-search-regex.tsx: Case-insensitive matching on title/content, match-focused snippets, and click-to-navigate.
  - note-search-semantic.tsx: Per-note semantic evaluation with a short reason, pending state indicators, and click-to-navigate.

<sup>Written for commit 49e451d57d9fe1a2498e715c5c0f2f7eda78e9d3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









