### PR TITLE
fix(ct-code-editor): Use getCellFromEntityId for backlink navigation

### DIFF
--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -347,19 +347,54 @@ export class CTCodeEditor extends BaseElement {
         // Extract ID from "Name (id)" format
         const idMatch = backlinkText.match(/\(([^)]+)\)$/);
         const backlinkId = idMatch ? idMatch[1] : undefined;
-        const charm = backlinkId ? this.findCharmById(backlinkId) : null;
 
-        if (charm) {
-          this.emit("backlink-click", {
-            id: backlinkId,
-            text: backlinkText,
-            charm: charm,
-          });
-          return true;
+        // If we have a valid ID, navigate directly using getCellFromEntityId.
+        // This bypasses the mentionable array and eliminates a race condition
+        // where findCharmById returns null because the array hasn't synced yet
+        // (common when clicking a backlink immediately after creating it).
+        if (backlinkId) {
+          const runtime =
+            this.pattern?.runtime ??
+            this.mentionable?.runtime ??
+            this.mentioned?.runtime;
+          const space =
+            this.pattern?.space ??
+            this.mentionable?.space ??
+            this.mentioned?.space;
+
+          if (runtime && space) {
+            // Get cell directly by entity ID - no array search needed
+            const charmCell = runtime.getCellFromEntityId(space, {
+              "/": backlinkId,
+            });
+
+            // Use navigateCallback (same pattern as ct-cell-link)
+            if (runtime.navigateCallback) {
+              runtime.navigateCallback(charmCell);
+            }
+
+            this.emit("backlink-click", {
+              id: backlinkId,
+              text: backlinkText,
+              charm: charmCell,
+            });
+            return true;
+          } else {
+            // Log warning instead of silent failure
+            console.warn(
+              "[ct-code-editor] Cannot navigate to backlink: runtime or space unavailable",
+            );
+            this.emit("backlink-click", {
+              id: backlinkId,
+              text: backlinkText,
+              charm: null,
+            });
+            return true;
+          }
         }
 
-        // Instantiate the pattern and pass the ID so we can insert it into the text
-        if (this.pattern) {
+        // Only create new backlink if there's NO ID (text-only like [[Name]])
+        if (!backlinkId && this.pattern) {
           this.createBacklinkFromPattern(backlinkText, true);
         }
 


### PR DESCRIPTION
## Summary

Fixes backlink navigation to use `getCellFromEntityId` instead of searching the mentionable array, eliminating a race condition where clicking a backlink would create a new charm instead of navigating to the existing one.

## The Bug

When Ctrl/Cmd+clicking on `[[Name (baedrei...)]]`:
- **Expected**: Navigate to the charm with that ID
- **Actual**: Creates a NEW charm (with different ID)

**Reproduction**: Create a backlink via `[[New Name]]`, immediately Cmd+click it. A second charm is created instead of navigating to the first. This happened every time.

## Root Cause

`findCharmById()` searches the `$mentionable` array, which may not have synced yet after creating a backlink. When it returns `null`, the code falls through to `createBacklinkFromPattern()`.

`findCharmById()` is used in two places:
1. `handleBacklinkActivation()` - navigation on click ← **this fix**
2. `_extractMentionedCharms()` - tracking mentions in content ← unchanged

For mention tracking (#2), array search is correct. For navigation (#1), direct ID lookup is more appropriate.

## The Fix

Use `getCellFromEntityId()` to create a Cell reference directly from the ID, bypassing the mentionable array. This is the same pattern used by `ct-cell-link` for navigation.

Also adds warning logging if runtime/space unavailable (no silent failure).

## Historical Context

| API | Available Since | Backlinks Written |
|-----|-----------------|-------------------|
| `getCellFromEntityId` | May 2025 | Sept 2025 |
| `navigateCallback` | June 2025 | Sept 2025 |

The original implementation predates the established `navigateCallback` pattern.

## Counterarguments Considered

We considered whether this was working-as-designed:

### 1. "Mentionable array as semantic gate"
Maybe charms not in mentionable shouldn't be navigable (permissions, different spaces, etc.)?

**Rejected**: The charm was just created by this very component via `createBacklinkFromPattern`. It's definitely supposed to be linkable.

### 2. "Create-if-missing is a feature"
Like wiki software creating pages on click - graceful handling of stale/invalid links?

**Rejected**: The charm exists (we have its ID embedded in the text), we just created it. This isn't a stale link.

### 3. "getCellFromEntityId returns cells for non-existent entities"
Could navigate to empty/broken cells instead of helpfully creating new ones?

**Acknowledged**: True, but in our reproduction scenario the entity definitely exists - we just created it. The mentionable array is simply slow to sync.

### 4. "Cell reactivity differences"
`findCharmById` returns `mentionableCell.key(i)` (keyed cell), `getCellFromEntityId` returns a standalone cell?

**Acknowledged**: Different cell provenance, but functionally equivalent for navigation purposes.

**Conclusion**: The reproduction scenario (every newly-created backlink fails) confirms this is a race condition bug, not intentional behavior.

## Test Plan

- [x] Manual testing: Create backlink, immediately Cmd+click → navigates to same charm
- [x] Manual testing: Text-only backlink `[[Name]]` → creates new charm (unchanged behavior)
- [ ] Review by @benfollington (original author)

---

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes backlink navigation in ct-code-editor by using getCellFromEntityId and navigateCallback, removing the race that created a new charm on click. Clicking [[Name (id)]] now reliably navigates to the existing charm, even immediately after creation.

- **Bug Fixes**
  - Use runtime.getCellFromEntityId for direct ID-based navigation (no mentionable array search).
  - Only create a new charm when the backlink has no ID (e.g., [[Name]]).
  - Add a warning log if runtime or space is unavailable.

<sup>Written for commit 326c0baaa8b9509fe8d420088d0541a574082f03. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

