### PR TITLE
fix(runner): CT-1127 follow links to root charm in navigateTo

### DIFF
--- a/packages/runner/src/builtins/navigate-to.ts
+++ b/packages/runner/src/builtins/navigate-to.ts
@@ -56,7 +56,15 @@ export function navigateTo(
         throw new Error("navigateCallback is not set");
       }
 
-      runtime.navigateCallback(target);
+      // Early exit: if already at root, navigate directly.
+      // Otherwise resolve to root charm first (handles cells from wish().result
+      // which have non-empty paths like ["result"]).
+      const link = target.getAsNormalizedFullLink();
+      const resolvedTarget = link.path.length === 0
+        ? target
+        : target.resolveToRoot();
+
+      runtime.navigateCallback(resolvedTarget);
 
       navigated = true;
       resultCell.set(true);


### PR DESCRIPTION
## Summary

- Adds `Cell.resolveToRoot()` method that follows embedded link values until reaching a cell with `path.length === 0`
- Fixes `navigateTo` to resolve wish results (which have paths like `["result"]`) to their actual charm before navigating
- Includes cycle detection, max iteration limit (100), and proper error throwing

Fixes CT-1127

## Test plan

- [x] All runner tests pass (107 tests)
- [ ] Manual test: create a pattern that uses `wish()` to discover a charm, then `navigateTo` to navigate to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes navigateTo so it follows embedded links (e.g., wish().result) to the root charm before navigating. Prevents navigating to the wrong entity and satisfies CT-1127.

- **Bug Fixes**
  - navigateTo resolves non-root cells to the root charm, with an early exit when already at root.
  - Added Cell.resolveToRoot() to follow embedded links, with cycle detection and a 100-iteration cap.
  - Throws clear errors when encountering non-link values at non-empty paths.

<sup>Written for commit d3ff2dfa6d8763033eb2ab2d1b6487ae5fc5483c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

