### PR TITLE
fix(shell): Enable cross-space navigation in navigateCallback

### DIFF
--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -1,4 +1,4 @@
-import { createSession, DID, Identity, isDID } from "@commontools/identity";
+import { createSession, Identity, isDID } from "@commontools/identity";
 import {
   Runtime,
   RuntimeTelemetry,


### PR DESCRIPTION
## Summary

The `navigateCallback` was ignoring `target.space` and always using `session.space` (current space), causing `ct-cell-link` and `navigateTo` to fail when navigating to charms in different spaces.

**The Bug:**
```typescript
navigateCallback: (target) => {
  const id = charmId(target);
  const navigateCallback = createNavCallback(
    session.space,              // BUG: Always uses current space
    charmManager.getSpaceName(), // BUG: Always uses current space name
  );
  // ...
  navigateCallback(id);
}
```

The `target` cell has `target.space` available with the correct target space, but it was being ignored.

## Changes

- Extract `target.space` from the cell being navigated to
- Compare with current space to detect cross-space navigation
- For cross-space: use target's spaceDid (no way to know its name)
- For same-space: preserve existing behavior (use spaceName if available for readable URLs)
- Skip adding cross-space charms to current space's charm list (they belong to their own space)
- Remove unused `createNavCallback` function

## Relationship to PR #2301

This fix is orthogonal to #2301 (which adds `resolveToRoot()` for following wish links):
- PR #2301 ensures we navigate to the **right charm** (following embedded links)
- This PR ensures we navigate to the **right space** (using target's space DID)

Both fixes are needed for wish-based cross-space navigation to work correctly. No file overlap - can be merged in any order.

## Test plan

- [x] All tests pass (107 tests in runner, all packages pass)
- [x] Type check passes
- [ ] Manual test: Navigate to a charm in a different space via ct-cell-link
- [ ] Manual test: Use navigateTo() to a cross-space charm

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-space navigation by making navigateCallback use the target cell’s space instead of the current session space. ct-cell-link and navigateTo now work across spaces with correct URLs.

- **Bug Fixes**
  - Safely read target.space and validate it; detect cross-space only when it’s a valid DID and differs from session.space.
  - For cross-space, navigate with target space DID; for same-space, use space name when available.
  - Do not add cross-space charms to the current space’s charm list.
  - Perform navigation after storage sync; on sync errors, still navigate.

- **Refactors**
  - Removed createNavCallback and inlined navigation via a small doNavigate helper.

<sup>Written for commit cbe22b0760ced8e8b49d217a91598e90c304e6e9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







