### PR TITLE
chore: Move shared schemas into a lightweight runner export

### DIFF
--- a/packages/charm/src/commands.ts
+++ b/packages/charm/src/commands.ts
@@ -6,7 +6,8 @@ import { getIframeRecipe } from "./iframe/recipe.ts";
 import { extractUserCode, injectUserCode } from "./iframe/static.ts";
 import { WorkflowForm } from "./index.ts";
 import { compileAndRunRecipe, generateNewRecipeVersion } from "./iterate.ts";
-import { CharmManager, nameSchema } from "./manager.ts";
+import { CharmManager } from "./manager.ts";
+import { nameSchema } from "@commontools/runner/schemas";
 import { processWorkflow, ProcessWorkflowOptions } from "./workflow.ts";
 
 export const castSpellAsCharm = async (

--- a/packages/charm/src/favorites.ts
+++ b/packages/charm/src/favorites.ts
@@ -1,5 +1,8 @@
 import { type Cell, type Runtime } from "@commontools/runner";
-import { type FavoriteList, favoriteListSchema } from "./manager.ts";
+import {
+  type FavoriteList,
+  favoriteListSchema,
+} from "@commontools/runner/schemas";
 
 /**
  * Get cell description (schema as string) for tag-based search.

--- a/packages/charm/src/format.ts
+++ b/packages/charm/src/format.ts
@@ -1,5 +1,6 @@
 import { Module, NAME, Recipe } from "@commontools/runner";
-import { CharmManager, nameSchema } from "./manager.ts";
+import { CharmManager } from "./manager.ts";
+import { nameSchema } from "@commontools/runner/schemas";
 import { Cell } from "@commontools/runner";
 
 /**

--- a/packages/charm/src/index.ts
+++ b/packages/charm/src/index.ts
@@ -1,15 +1,4 @@
-export {
-  charmId,
-  charmListSchema,
-  CharmManager,
-  favoriteListSchema,
-  getRecipeIdFromCharm,
-  type NameSchema,
-  nameSchema,
-  processSchema,
-  type UISchema,
-  uiSchema,
-} from "./manager.ts";
+export { charmId, CharmManager, getRecipeIdFromCharm } from "./manager.ts";
 export {
   addFavorite,
   getHomeFavorites,

--- a/packages/charm/src/iterate.ts
+++ b/packages/charm/src/iterate.ts
@@ -11,7 +11,8 @@ import {
   type Runtime,
   type RuntimeProgram,
 } from "@commontools/runner";
-import { CharmManager, charmSourceCellSchema } from "./manager.ts";
+import { CharmManager } from "./manager.ts";
+import { charmSourceCellSchema } from "@commontools/runner/schemas";
 import { buildFullRecipe, getIframeRecipe } from "./iframe/recipe.ts";
 import { buildPrompt, RESPONSE_PREFILL } from "./iframe/prompt.ts";
 import {

--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -9,21 +9,26 @@ import {
   JSONSchema,
   type MemorySpace,
   Module,
-  NAME,
   parseLink,
   Recipe,
   Runtime,
   type Schema,
   type SpaceCellContents,
   TYPE,
-  UI,
   URI,
 } from "@commontools/runner";
 import * as favorites from "./favorites.ts";
 import { ALL_CHARMS_ID } from "../../runner/src/builtins/well-known.ts";
-import { vdomSchema } from "@commontools/html";
 import { type Session } from "@commontools/identity";
 import { isObject, isRecord } from "@commontools/utils/types";
+import {
+  charmListSchema,
+  charmSourceCellSchema,
+  FavoriteList,
+  NameSchema,
+  nameSchema,
+  processSchema,
+} from "@commontools/runner/schemas";
 
 /**
  * Extracts the ID from a charm.
@@ -36,80 +41,6 @@ export function charmId(charm: Cell<unknown>): string | undefined {
   const idValue = id["/"];
   return typeof idValue === "string" ? idValue : undefined;
 }
-
-export const nameSchema = {
-  type: "object",
-  properties: { [NAME]: { type: "string" } },
-  required: [NAME],
-} as const satisfies JSONSchema;
-
-export type NameSchema = Schema<typeof nameSchema>;
-
-export const uiSchema = {
-  type: "object",
-  properties: { [UI]: vdomSchema },
-  required: [UI],
-} as const satisfies JSONSchema;
-
-export type UISchema = Schema<typeof uiSchema>;
-
-export const charmListSchema = {
-  type: "array",
-  items: { not: true, asCell: true },
-} as const satisfies JSONSchema;
-
-export const charmLineageSchema = {
-  type: "object",
-  properties: {
-    charm: { not: true, asCell: true },
-    relation: { type: "string" },
-    timestamp: { type: "number" },
-  },
-  required: ["charm", "relation", "timestamp"],
-} as const satisfies JSONSchema;
-export type CharmLineage = Schema<typeof charmLineageSchema>;
-
-export const favoriteEntrySchema = {
-  type: "object",
-  properties: {
-    cell: { not: true, asCell: true },
-    tag: { type: "string", default: "" },
-  },
-  required: ["cell"],
-} as const satisfies JSONSchema;
-
-export type FavoriteEntry = Schema<typeof favoriteEntrySchema>;
-
-export const favoriteListSchema = {
-  type: "array",
-  items: favoriteEntrySchema,
-} as const satisfies JSONSchema;
-
-export type FavoriteList = Schema<typeof favoriteListSchema>;
-
-export const charmSourceCellSchema = {
-  type: "object",
-  properties: {
-    [TYPE]: { type: "string" },
-    spell: { type: "object" },
-    lineage: {
-      type: "array",
-      items: charmLineageSchema,
-      default: [],
-    },
-    llmRequestId: { type: "string" },
-  },
-} as const satisfies JSONSchema;
-
-export const processSchema = {
-  type: "object",
-  properties: {
-    argument: { type: "object" },
-    [TYPE]: { type: "string" },
-    spell: { type: "object" },
-  },
-  required: [TYPE],
-} as const satisfies JSONSchema;
 
 /**
  * Filters an array of charms by removing any that match the target cell

--- a/packages/charm/src/ops/charm-controller.ts
+++ b/packages/charm/src/ops/charm-controller.ts
@@ -6,12 +6,8 @@ import {
   RuntimeProgram,
   TYPE,
 } from "@commontools/runner";
-import {
-  charmId,
-  CharmManager,
-  nameSchema,
-  processSchema,
-} from "../manager.ts";
+import { charmId, CharmManager } from "../manager.ts";
+import { nameSchema, processSchema } from "@commontools/runner/schemas";
 import { CellPath, compileProgram, resolveCellPath } from "./utils.ts";
 import { injectUserCode } from "../iframe/static.ts";
 import {

--- a/packages/charm/src/search.ts
+++ b/packages/charm/src/search.ts
@@ -1,9 +1,5 @@
-import {
-  charmId,
-  CharmManager,
-  DEFAULT_MODEL,
-  nameSchema,
-} from "@commontools/charm";
+import { charmId, CharmManager, DEFAULT_MODEL } from "@commontools/charm";
+import { nameSchema } from "@commontools/runner/schemas";
 import { NAME } from "@commontools/runner";
 import { extractTextFromLLMResponse, LLMClient } from "@commontools/llm";
 import { Cell } from "@commontools/runner";

--- a/packages/cli/lib/charm-render.ts
+++ b/packages/cli/lib/charm-render.ts
@@ -1,5 +1,6 @@
-import { render, vdomSchema, VNode } from "@commontools/html";
+import { render, VNode } from "@commontools/html";
 import { Cell, UI } from "@commontools/runner";
+import { vdomSchema } from "@commontools/runner/schemas";
 import { loadManager } from "./charm.ts";
 import { CharmsController } from "@commontools/charm/ops";
 import type { CharmConfig } from "./charm.ts";

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -4,7 +4,6 @@ export {
   setEventSanitizer,
   setNodeSanitizer,
   type SetPropHandler,
-  vdomSchema,
 } from "./render.ts";
 export { isVNode, type VNode } from "./jsx.ts";
 export { h } from "./h.ts";

--- a/packages/html/src/render.ts
+++ b/packages/html/src/render.ts
@@ -5,11 +5,11 @@ import {
   convertCellsToLinks,
   effect,
   isCell,
-  type JSONSchema,
   UI,
   useCancelGroup,
 } from "@commontools/runner";
 import { isVNode, type Props, type RenderNode, type VNode } from "./jsx.ts";
+import { vdomSchema } from "@commontools/runner/schemas";
 
 export type SetPropHandler = <T>(
   target: T,
@@ -23,32 +23,6 @@ export interface RenderOptions {
   /** The root cell for auto-wrapping with ct-cell-context on [UI] traversal */
   rootCell?: Cell;
 }
-
-export const vdomSchema: JSONSchema = {
-  type: "object",
-  properties: {
-    type: { type: "string" },
-    name: { type: "string" },
-    props: {
-      type: "object",
-      additionalProperties: { asCell: true },
-    },
-    children: {
-      type: "array",
-      items: {
-        anyOf: [
-          { $ref: "#", asCell: true },
-          { type: "string", asCell: true },
-          { type: "number", asCell: true },
-          { type: "boolean", asCell: true },
-          { type: "array", items: { $ref: "#", asCell: true } },
-        ],
-      },
-      asCell: true,
-    },
-    [UI]: { $ref: "#" },
-  },
-} as const;
 
 /**
  * Renders a view into a parent element, supporting both static VNodes and reactive cells.

--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -10,6 +10,8 @@
   },
   "exports": {
     ".": "./src/index.ts",
+    "./shared": "./src/shared.ts",
+    "./schemas": "./src/schemas.ts",
     "./storage/inspector": "./src/storage/inspector.ts",
     "./storage/telemetry": "./src/storage/telemetry.ts",
     "./traverse": "./src/traverse.ts",

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1,7 +1,7 @@
 import { refer } from "merkle-reference/json";
 import { getLogger } from "@commontools/utils/logger";
 import { isObject, isRecord, type Mutable } from "@commontools/utils/types";
-import { vdomSchema } from "@commontools/html";
+import { vdomSchema } from "./schemas.ts";
 import {
   type Frame,
   isModule,

--- a/packages/runner/src/schemas.ts
+++ b/packages/runner/src/schemas.ts
@@ -1,0 +1,107 @@
+/**
+ * /!\ Shared between client and runtime threads.
+ * /!\ Take care in only importing lightweight types,
+ * /!\ interfaces and utilities.
+ */
+
+import { JSONSchema, NAME, type Schema, TYPE, UI } from "./shared.ts";
+
+export const vdomSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    type: { type: "string" },
+    name: { type: "string" },
+    props: {
+      type: "object",
+      additionalProperties: { asCell: true },
+    },
+    children: {
+      type: "array",
+      items: {
+        anyOf: [
+          { $ref: "#", asCell: true },
+          { type: "string", asCell: true },
+          { type: "number", asCell: true },
+          { type: "boolean", asCell: true },
+          { type: "array", items: { $ref: "#", asCell: true } },
+        ],
+      },
+      asCell: true,
+    },
+    [UI]: { $ref: "#" },
+  },
+} as const;
+
+export const nameSchema = {
+  type: "object",
+  properties: { [NAME]: { type: "string" } },
+  required: [NAME],
+} as const satisfies JSONSchema;
+
+export type NameSchema = Schema<typeof nameSchema>;
+
+export const uiSchema = {
+  type: "object",
+  properties: { [UI]: vdomSchema },
+  required: [UI],
+} as const satisfies JSONSchema;
+
+export type UISchema = Schema<typeof uiSchema>;
+
+export const charmListSchema = {
+  type: "array",
+  items: { not: true, asCell: true },
+} as const satisfies JSONSchema;
+
+export const charmLineageSchema = {
+  type: "object",
+  properties: {
+    charm: { not: true, asCell: true },
+    relation: { type: "string" },
+    timestamp: { type: "number" },
+  },
+  required: ["charm", "relation", "timestamp"],
+} as const satisfies JSONSchema;
+export type CharmLineage = Schema<typeof charmLineageSchema>;
+
+export const favoriteEntrySchema = {
+  type: "object",
+  properties: {
+    cell: { not: true, asCell: true },
+    tag: { type: "string", default: "" },
+  },
+  required: ["cell"],
+} as const satisfies JSONSchema;
+
+export type FavoriteEntry = Schema<typeof favoriteEntrySchema>;
+
+export const favoriteListSchema = {
+  type: "array",
+  items: favoriteEntrySchema,
+} as const satisfies JSONSchema;
+
+export type FavoriteList = Schema<typeof favoriteListSchema>;
+
+export const charmSourceCellSchema = {
+  type: "object",
+  properties: {
+    [TYPE]: { type: "string" },
+    spell: { type: "object" },
+    lineage: {
+      type: "array",
+      items: charmLineageSchema,
+      default: [],
+    },
+    llmRequestId: { type: "string" },
+  },
+} as const satisfies JSONSchema;
+
+export const processSchema = {
+  type: "object",
+  properties: {
+    argument: { type: "object" },
+    [TYPE]: { type: "string" },
+    spell: { type: "object" },
+  },
+  required: [TYPE],
+} as const satisfies JSONSchema;

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -1,0 +1,29 @@
+/**
+ * /!\ Shared between client and runtime threads.
+ * /!\ Take care in only importing lightweight types,
+ * /!\ interfaces and utilities.
+ */
+
+export {
+  isLegacyAlias,
+  isSigilLink,
+  type NormalizedFullLink,
+  parseLLMFriendlyLink,
+} from "./link-types.ts";
+export { LINK_V1_TAG, type SigilLink, type URI } from "./sigil-types.ts";
+export {
+  ID,
+  type JSONSchema,
+  type JSONValue,
+  NAME,
+  type Schema,
+  TYPE,
+  UI,
+} from "./builder/types.ts";
+export { effect } from "./reactivity.ts";
+export { type Cancel, useCancelGroup } from "./cancel.ts";
+export type {
+  RuntimeTelemetry,
+  RuntimeTelemetryEvent,
+  RuntimeTelemetryMarkerResult,
+} from "./telemetry.ts";

--- a/packages/shell/src/lib/pattern-factory.ts
+++ b/packages/shell/src/lib/pattern-factory.ts
@@ -1,7 +1,7 @@
 import { CharmController, CharmsController } from "@commontools/charm/ops";
 import { HttpProgramResolver } from "@commontools/js-compiler";
 import { API_URL } from "./env.ts";
-import { NameSchema } from "@commontools/charm";
+import { type NameSchema } from "@commontools/runner/schemas";
 
 export type BuiltinPatternType = "home" | "space-root";
 

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -5,12 +5,8 @@ import {
   RuntimeTelemetryEvent,
   RuntimeTelemetryMarkerResult,
 } from "@commontools/runner";
-import {
-  charmId,
-  CharmManager,
-  NameSchema,
-  nameSchema,
-} from "@commontools/charm";
+import { charmId, CharmManager } from "@commontools/charm";
+import { NameSchema, nameSchema } from "@commontools/runner/schemas";
 import { CharmController, CharmsController } from "@commontools/charm/ops";
 import { StorageManager } from "@commontools/runner/storage/cache";
 import { navigate } from "./navigate.ts";

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -9,7 +9,7 @@ import { Task, TaskStatus } from "@lit/task";
 import { CharmController } from "@commontools/charm/ops";
 import { CellEventTarget, CellUpdateEvent } from "../lib/cell-event-target.ts";
 import { NAME } from "@commontools/runner";
-import { type NameSchema } from "@commontools/charm";
+import { type NameSchema } from "@commontools/runner/schemas";
 import { updatePageTitle } from "../lib/navigate.ts";
 import { KeyboardController } from "../lib/keyboard-router.ts";
 


### PR DESCRIPTION
eliminates circular dependencies and offers schemas without pulling in the entire runtime.
In service of #2245
`@commontools/runner/schemas`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved shared JSON schemas and lightweight types into @commontools/runner to eliminate circular dependencies and let consumers use schemas without loading the runtime. Aligns with #2245 by decoupling charm/html from runner internals.

- **Refactors**
  - Added new runner exports: ./schemas and ./shared.
  - Moved vdomSchema, nameSchema, uiSchema, charmListSchema, charmSourceCellSchema, FavoriteList, processSchema into runner/src/schemas.ts.
  - Added runner/src/shared.ts for minimal shared types and constants (JSONSchema, Schema, NAME, TYPE, UI, telemetry).
  - Updated charm, html, cli, and shell imports to use @commontools/runner/schemas.
  - Removed schema exports from @commontools/charm and vdomSchema from @commontools/html.

- **Migration**
  - Import schemas from @commontools/runner/schemas (not from @commontools/charm or @commontools/html).
  - Import lightweight shared types from @commontools/runner/shared when needed.
  - Replace previous uses of NameSchema and friends from charm with types from @commontools/runner/schemas.

<sup>Written for commit 80d9ad3c711fc6ef032877078cd5584d3e1b9419. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

