### PR TITLE
feat: Add variant prop to ct-render for UI variant support

### DIFF
--- a/packages/ui/src/v2/components/ct-picker/ct-picker.ts
+++ b/packages/ui/src/v2/components/ct-picker/ct-picker.ts
@@ -387,9 +387,10 @@ export class CTPicker extends BaseElement {
                           aria-selected="${index === currentIndex}"
                           id="picker-item-${index}"
                         >
-                          <ct-render .cell="${this.items.key(
-                            index,
-                          )}"></ct-render>
+                          <ct-render
+                            .cell="${this.items.key(index)}"
+                            variant="preview"
+                          ></ct-render>
                         </div>
                       `
                     )


### PR DESCRIPTION
## Summary

- Add `variant` prop to ct-render for selecting alternative UI exports from charms
- Update ct-picker to use `variant="preview"` for compact rendering in picker view

## Changes

### ct-render.ts
- New `UIVariant` type: `"default" | "preview" | "thumbnail" | "sidebar" | "fab"`
- New `variant` prop that maps to charm property keys (e.g., `"preview"` → `"previewUI"`)
- Fallback logic: if the variant property doesn't exist, renders default `[UI]`
- Re-renders when variant prop changes

### ct-picker.ts
- Uses `variant="preview"` when rendering items, allowing charms to show compact previews

## Usage

Pattern authors can now export `previewUI` for simplified picker display:

```tsx
return {
  [UI]: <full-ui />,
  previewUI: <compact-preview />,  // optional - falls back to [UI] if missing
};
```

## Test plan

- [x] Created test pattern with `previewUI` export
- [x] Deployed and verified picker shows preview content
- [x] Verified full UI still renders when viewing charm directly
- [x] Type checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a variant prop to ct-render to render alternative charm UIs with a safe fallback to the default [UI]. Updates ct-picker to use the preview variant for compact item previews.

- **New Features**
  - Added UIVariant type: default | preview | thumbnail | sidebar | fab, mapped to previewUI/thumbnailUI/sidebarUI/fabUI with fallback to [UI].
  - ct-render now re-renders when the cell or variant changes.
  - ct-picker renders items with variant="preview" for compact previews.

<sup>Written for commit e9bfe53af09464354e5973885f643cd5741e64b7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

