### PR TITLE
RFC: Dynamic tags via [TAGS] export for pattern discovery

### DIFF
--- a/docs/common/PATTERNS.md
+++ b/docs/common/PATTERNS.md
@@ -278,6 +278,42 @@ return {
 - They do NOT appear in the sidebar charm list
 - Use this instead of writing to `allCharms` directly
 
+### Making Patterns Searchable with Tags
+
+Export `[TAGS]` to make your pattern findable via `wish({ query: "#tag" })`:
+
+```typescript
+import { TAGS, NAME, UI, pattern } from "commontools";
+
+export default pattern<Input, Output>(({ ... }) => ({
+  [NAME]: "Gmail Client",
+  [TAGS]: ["#gmail", "#email-client"],  // Static tags
+  [UI]: <div>...</div>,
+}));
+```
+
+**Dynamic Tags** - advertise capabilities based on state:
+```typescript
+[TAGS]: computed(() => [
+  "#oauth",
+  ...(isLoggedIn.get() ? ["#authenticated"] : []),
+])
+```
+
+**Compound Queries** - combine multiple tag requirements:
+```typescript
+// AND: Must have both tags
+wish({ query: { and: ["#auth", "#google"] } })
+
+// OR: Any of these tags
+wish({ query: { or: ["#gmail", "#outlook"] } })
+```
+
+**Notes:**
+- Tags must start with `#` (e.g., `#auth`, `#gmail`)
+- Patterns must be **favorited** before they're searchable via tags
+- `[TAGS]` accepts `string[]` or `Cell<string[]>` (for reactive tags)
+
 ---
 
 ## Quick Reference
@@ -294,6 +330,8 @@ return {
 | Filter/sort lists | `computed()` |
 | Cross-charm mutation | `Stream.send()` |
 | Make charm discoverable | Export `mentionable` |
+| Make pattern searchable | Export `[TAGS]` |
+| Find pattern by tag | `wish({ query: "#tag" })` |
 
 ### Cell<> in Type Signatures
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1303,10 +1303,26 @@ export type CompileAndRunFunction = <T = any, S = any>(
 
 export type WishTag = `/${string}` | `#${string}`;
 
+/**
+ * Query for hashtags with explicit AND/OR logic.
+ * - AND: All tags must match (intersection)
+ * - OR: Any tag can match (union)
+ *
+ * @example
+ * // All must match
+ * wish({ query: { and: ["#auth", "#google"] } })
+ *
+ * // Any can match
+ * wish({ query: { or: ["#gmail", "#outlook"] } })
+ */
+export type HashtagQuery =
+  | { and: WishTag[] }
+  | { or: WishTag[] };
+
 export type DID = `did:${string}:${string}`;
 
 export type WishParams = {
-  query: WishTag | string;
+  query: WishTag | HashtagQuery | string;
   path?: string[];
   context?: Record<string, any>;
   schema?: JSONSchema;

--- a/packages/patterns/favorites-manager.tsx
+++ b/packages/patterns/favorites-manager.tsx
@@ -5,9 +5,14 @@
  *
  * @reviewed 2025-12-10 docs-rationalization
  */
-import { Cell, handler, NAME, pattern, UI, wish } from "commontools";
+import { Cell, computed, handler, NAME, pattern, UI, wish } from "commontools";
 
-type Favorite = { cell: Cell<{ [NAME]?: string }>; tag: string };
+// Updated type to support both new tagsCell and legacy tag field
+type Favorite = {
+  cell: Cell<{ [NAME]?: string }>;
+  tagsCell?: Cell<string[]>; // New: reactive tags array
+  tag?: string; // Legacy: single tag string
+};
 
 const onRemoveFavorite = handler<
   Record<string, never>,
@@ -25,22 +30,33 @@ export default pattern<Record<string, never>>((_) => {
     [NAME]: "Favorites Manager",
     [UI]: (
       <div>
-        {wishResult.result.map((item) => (
-          <ct-cell-context $cell={item.cell}>
-            <div>
-              <ct-cell-link $cell={item.cell} />
-              <ct-button
-                onClick={onRemoveFavorite({
-                  favorites: wishResult.result,
-                  item: item.cell,
-                })}
-              >
-                Remove
-              </ct-button>
-              <pre>{item.tag}</pre>
-            </div>
-          </ct-cell-context>
-        ))}
+        {wishResult.result.map((item) => {
+          // Display tags from tagsCell (new) or tag (legacy)
+          const tags = computed(() => {
+            if (item.tagsCell) {
+              const cellTags = item.tagsCell.get();
+              return Array.isArray(cellTags) ? cellTags.join(", ") : "";
+            }
+            return item.tag ?? "";
+          });
+
+          return (
+            <ct-cell-context $cell={item.cell}>
+              <div>
+                <ct-cell-link $cell={item.cell} />
+                <ct-button
+                  onClick={onRemoveFavorite({
+                    favorites: wishResult.result,
+                    item: item.cell,
+                  })}
+                >
+                  Remove
+                </ct-button>
+                <pre>{tags}</pre>
+              </div>
+            </ct-cell-context>
+          );
+        })}
       </div>
     ),
   };

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -68,6 +68,31 @@ export const TYPE = "$TYPE";
 export const NAME = "$NAME";
 export const UI = "$UI";
 
+/**
+ * Export [TAGS] to make a pattern discoverable via wish({ query: ... }).
+ *
+ * Tags must be strings starting with '#'. Supports:
+ * - Static tags: `[TAGS]: ["#googleAuth", "#oauth2"]`
+ * - Dynamic tags: `[TAGS]: computed(() => isActive.get() ? ["#active"] : [])`
+ *
+ * Patterns are only searchable after being favorited by the user.
+ *
+ * @example
+ * // Static tags
+ * export default pattern(({ ... }) => ({
+ *   [NAME]: "Gmail Client",
+ *   [TAGS]: ["#gmail", "#email-client"],
+ *   [UI]: <div>...</div>,
+ * }));
+ *
+ * // Dynamic tags based on state
+ * [TAGS]: computed(() => [
+ *   "#oauth",
+ *   ...(isLoggedIn.get() ? ["#authenticated"] : []),
+ * ]),
+ */
+export const TAGS = "$TAGS";
+
 export const schema: typeof schemaFunction = (schema) => schema;
 
 export { AuthSchema } from "./schema-lib.ts";

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -107,6 +107,7 @@ export {
   type SchemaContext,
   type SchemaWithoutCell,
   type StreamValue,
+  TAGS,
   type toJSON,
   TYPE,
   UI,

--- a/packages/runner/src/schemas.ts
+++ b/packages/runner/src/schemas.ts
@@ -64,11 +64,14 @@ export const charmLineageSchema = {
 } as const satisfies JSONSchema;
 export type CharmLineage = Schema<typeof charmLineageSchema>;
 
+// Note: wish.ts also defines a local copy of this schema to avoid circular deps.
+// Keep both schemas in sync when making changes.
 export const favoriteEntrySchema = {
   type: "object",
   properties: {
     cell: { not: true, asCell: true },
-    tag: { type: "string", default: "" },
+    tagsCell: { not: true, asCell: true }, // Reference to [TAGS] Cell<string[]> export
+    tag: { type: "string", default: "" }, // Legacy: single tag string (backward compatibility)
   },
   required: ["cell"],
 } as const satisfies JSONSchema;


### PR DESCRIPTION
## Summary

This PR proposes one approach to enabling **dynamic, reactive tags** for pattern discovery. Currently, patterns opt-in to searchability via JSDoc annotations and their schema gets serialized as a searchable string. This works, but:

1. Patterns can't control or easily know what they're searchable by
2. Tags are static - set at favorite-time, never change
3. Schema-as-search-string is opaque to pattern authors

This proposal replaces that with explicit `[TAGS]` exports.

## The Use Case

A Google Auth pattern that becomes more discoverable as the user interacts with it:

```typescript
[TAGS]: computed(() => {
  const tags = ["#googleAuth"];
  
  if (isAuthenticated.get()) {
    tags.push("#authenticated");
    
    // Account type
    if (user.get().email.endsWith("@gmail.com")) {
      tags.push("#personal");
    } else {
      tags.push("#work");
    }
    
    // Granted scopes
    for (const scope of scopes.get()) {
      tags.push(`#${scope}`);  // #gmail, #docs, #calendar
    }
  }
  
  return tags;
})
```

Now other patterns can discover based on current state:

```typescript
// Find auth that's logged in with gmail AND docs access on a personal account
wish({ query: { and: ["#googleAuth", "#authenticated", "#gmail", "#docs", "#personal"] } })
```

## What Changed

### Pattern authoring

Patterns export `[TAGS]` - either static or dynamic:

```typescript
// Static (simple case)
[TAGS]: ["#oauth", "#google"]

// Dynamic (reactive)
[TAGS]: computed(() => [...])
```

Both work the same way. Static is just an array literal. Dynamic is `computed()` which authors already use everywhere.

### Storage

Favorites now store `tagsCell: Cell<string[]>` instead of `tag: string`. For static tags, we wrap in an immutable cell. For dynamic, we store the reference directly.

### Querying

`wish()` now supports AND/OR compound queries:

```typescript
wish({ query: "#oauth" })                        // Single tag
wish({ query: { and: ["#oauth", "#gmail"] } })   // Must have both
wish({ query: { or: ["#gmail", "#outlook"] } })  // Either one
```

## Design Tradeoffs

**Explicit > Implicit**: The old JSDoc + schema approach was magical - you opted in but didn't control what you were searchable by. Now tags are intentional and visible.

**Unified API**: Static and dynamic use the same `[TAGS]` export. No separate concepts to learn.

**Cell overhead for static**: Static arrays get wrapped in immutable cells. This adds slight overhead but simplifies the read path (everything is a Cell).

**Breaking change**: Patterns must export `[TAGS]` to be discoverable. Old JSDoc-based patterns won't be searchable until updated. (Backward compat for reading legacy `tag` field is included.)

## Files Changed

- `packages/runner/src/builder/types.ts` - `TAGS` symbol export
- `packages/charm/src/favorites.ts` - Store `tagsCell` reference
- `packages/runner/src/builtins/wish.ts` - AND/OR query logic, tag matching
- `packages/runner/src/schemas.ts` - Updated schema with `tagsCell`
- `packages/patterns/favorites-manager.tsx` - Display tags
- `docs/common/PATTERNS.md` - Documentation

## Test Plan

- [x] Static tags work
- [x] Dynamic tags update reactively
- [x] AND queries require all tags
- [x] OR queries match any tag
- [x] Empty AND/OR arrays return errors (not silent misbehavior)
- [x] Legacy `tag` field still works (backward compat)

---

This is marked as draft because it's proposing an approach, not necessarily the final implementation. Feedback welcome on the design!

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce dynamic, reactive pattern tags via [TAGS] and compound hashtag queries in wish() to make discovery explicit and state-aware. Favorites now store a tagsCell so tags update in real time, with backward compatibility for legacy tags.

- **New Features**
  - Patterns export [TAGS] as string[] or Cell<string[]>.
  - wish() supports hashtag queries and AND/OR (HashtagQuery added to API).
  - Favorites store tagsCell; matching is case-insensitive with invalid tags warned.
  - Favorites Manager displays tags from tagsCell or legacy tag.
  - Docs and tests updated to cover dynamic tags and edge cases.

- **Migration**
  - Add [TAGS] to patterns; tags must start with '#'.
  - Favorite the pattern to make it searchable.
  - Queries support "#tag", { and: [...] }, { or: [...] }; empty arrays return errors.

<sup>Written for commit 0b04c3e451ea320fee2594d32c72910bbca9131b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

