### PR TITLE
feat: Add New Record button to default-app

### DIFF
--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -11,6 +11,7 @@ import {
 } from "commontools";
 
 import { default as Note } from "./note.tsx";
+import { default as Record } from "./record.tsx";
 import BacklinksIndex, { type MentionableCharm } from "./backlinks-index.tsx";
 import OmniboxFAB from "./omnibox-fab.tsx";
 import NotesImportExport from "./notes-import-export.tsx";
@@ -70,6 +71,12 @@ const spawnNote = handler<void, void>((_, __) => {
   }));
 });
 
+const spawnRecord = handler<void, void>((_, __) => {
+  return navigateTo(Record({
+    title: "",
+  }));
+});
+
 const spawnNotesImportExport = handler<void, void>((_, __) => {
   return navigateTo(NotesImportExport({
     importMarkdown: "",
@@ -115,6 +122,18 @@ export default pattern<CharmsListInput, CharmsListOutput>((_) => {
               }}
             >
               📄 New Note
+            </ct-button>
+            <ct-button
+              variant="ghost"
+              onClick={spawnRecord()}
+              style={{
+                padding: "12px 20px",
+                fontSize: "22px",
+                borderRadius: "12px",
+                minHeight: "48px",
+              }}
+            >
+              📋 New Record
             </ct-button>
           </div>
           <div slot="end">


### PR DESCRIPTION
## Summary
- Adds a "New Record" button to the default-app toolbar alongside the existing "New Note" button
- Clicking the button creates a new Record charm with empty title and navigates to it

## Test plan
- [x] Deployed to local dev server and tested in Playwright
- [x] Button appears correctly in toolbar next to "New Note"
- [x] Clicking button creates new Record and navigates to it
- [x] Type check passes (`deno task ct dev --no-run`)
- [x] Lint and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a New Record button to the default-app toolbar next to New Note. Clicking it creates a Record with an empty title and navigates to it.

<sup>Written for commit 23cb2d571ac0941b81707f22f0e1173b58c5b8b4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

