### PR TITLE
Revert: Remove Record button from default-app (fixes new space bootstrap)

### DIFF
--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -11,7 +11,6 @@ import {
 } from "commontools";
 
 import { default as Note } from "./note.tsx";
-import { default as Record } from "./record.tsx";
 import BacklinksIndex, { type MentionableCharm } from "./backlinks-index.tsx";
 import OmniboxFAB from "./omnibox-fab.tsx";
 import NotesImportExport from "./notes-import-export.tsx";
@@ -71,12 +70,6 @@ const spawnNote = handler<void, void>((_, __) => {
   }));
 });
 
-const spawnRecord = handler<void, void>((_, __) => {
-  return navigateTo(Record({
-    title: "",
-  }));
-});
-
 const spawnNotesImportExport = handler<void, void>((_, __) => {
   return navigateTo(NotesImportExport({
     importMarkdown: "",
@@ -122,18 +115,6 @@ export default pattern<CharmsListInput, CharmsListOutput>((_) => {
               }}
             >
               📄 New Note
-            </ct-button>
-            <ct-button
-              variant="ghost"
-              onClick={spawnRecord()}
-              style={{
-                padding: "12px 20px",
-                fontSize: "22px",
-                borderRadius: "12px",
-                minHeight: "48px",
-              }}
-            >
-              📋 New Record
             </ct-button>
           </div>
           <div slot="end">


### PR DESCRIPTION
## Summary

- Reverts the "New Record" button addition to default-app that broke new space creation

## Problem

Commit 7361d3e30 added a "New Record" button to default-app.tsx which imports `record.tsx`. The Record pattern imports from subdirectories like `./record/registry.ts`, but the toolshed patterns API (created in Sept) blocks any filename containing `/` as a path traversal security measure.

This caused **all new spaces to fail to bootstrap** because:
1. New space → fetch `/api/patterns/default-app.tsx`
2. default-app imports record.tsx → fetch `/api/patterns/record.tsx`  
3. record.tsx imports `./record/registry.ts` → fetch `/api/patterns/record/registry.ts`
4. **400 error** - filename contains `/`

## Fix

A proper fix is in #2319 which updates the patterns API to allow subdirectory paths while maintaining path traversal protection. That PR needs security review before merging.

Once #2319 is approved and merged, the Record button can be re-added.

## Test plan

- [ ] Create a new space and verify it loads correctly
- [ ] Verify existing spaces still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)