### PR TITLE
feat(ct-autocomplete): Add data field to pass objects through selection

### DIFF
--- a/packages/ui/src/v2/components/ct-autocomplete/ct-autocomplete.ts
+++ b/packages/ui/src/v2/components/ct-autocomplete/ct-autocomplete.ts
@@ -24,7 +24,21 @@ export interface AutocompleteItem {
   group?: string;
   /** Additional search terms that match this item */
   searchAliases?: string[];
-  /** Arbitrary data to pass through with ct-select event (preserved as-is) */
+  /**
+   * Arbitrary data to pass through with ct-select event.
+   *
+   * NOTE: Cell references passed here will be converted to link representations
+   * during event sanitization. The original Cell instance is NOT preserved.
+   * Use `Cell.equals()` for comparisons - it handles both Cells and links.
+   *
+   * @example
+   * // In pattern - pass charm reference
+   * items={charms.map(c => ({ value: c[NAME], data: c }))}
+   *
+   * // In handler - compare with Cell.equals()
+   * const { data: charm } = event.detail;
+   * const isDuplicate = members.some(m => Cell.equals(m.charm, charm));
+   */
   data?: unknown;
 }
 
@@ -97,6 +111,7 @@ function processItem(item: AutocompleteItem): ProcessedItem {
  *
  * @fires ct-change - Fired when value changes: { value, oldValue }
  * @fires ct-select - Fired when an item is selected: { value, label, group?, isCustom, data? }
+ *                   Note: Cell refs in `data` become link representations; use Cell.equals() to compare
  * @fires ct-open - Fired when dropdown opens
  * @fires ct-close - Fired when dropdown closes
  *


### PR DESCRIPTION
## Summary

- Add `data?: unknown` field to AutocompleteItem interface
- Pass data through ct-select event, enabling patterns to access selected item data directly
- Document Cell-to-link transformation behavior and recommend using `Cell.equals()` for comparisons

## Motivation

Patterns using ct-autocomplete often need to access the original object (like a charm reference) after selection. Previously, patterns had to re-lookup items by matching value/label strings, which was fragile and verbose.

With this change, patterns can pass charm references directly:
```typescript
// Pass charm reference in data field
items={charms.map(c => ({ value: c[NAME], data: c }))}

// Access directly in handler
onct-select={(event) => {
  const { data: charm } = event.detail;
}}
```

## Important Note

Cell references in the `data` field are converted to link representations during event sanitization (at the UI→pattern boundary). Use `Cell.equals()` for comparisons - it handles both Cells and links correctly.

## Test plan

- [ ] Manual test: ct-autocomplete passes data through ct-select events
- [ ] Existing ct-autocomplete tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a data field to ct-autocomplete items and passes it through ct-select so patterns can access the selected object directly. This removes fragile re-lookups by value/label.

- **New Features**
  - AutocompleteItem supports data?: unknown.
  - ct-select includes event.detail.data when present.

- **Migration**
  - No changes needed. If you pass Cell refs, they become links; use Cell.equals() for comparisons.

<sup>Written for commit 74a29ef33500cdb9464093ec7d6ad96521e7a1fe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

