### PR TITLE
fix: Address valid Cubic review feedback from recent PRs

### DIFF
--- a/packages/patterns/address.tsx
+++ b/packages/patterns/address.tsx
@@ -28,7 +28,7 @@ export const MODULE_METADATA: ModuleMetadata = {
       description: "Address label (Home, Work, etc.)",
     },
   },
-  fieldMapping: ["street", "city", "state", "zip", "address"],
+  fieldMapping: ["street", "city", "state", "zip", "label"],
 };
 
 // ===== Types =====

--- a/packages/patterns/giftprefs.tsx
+++ b/packages/patterns/giftprefs.tsx
@@ -24,7 +24,7 @@ export const MODULE_METADATA: ModuleMetadata = {
   schema: {
     giftTier: {
       type: "string",
-      enum: ["always", "occasions", "reciprocal", "none"],
+      enum: ["", "always", "occasions", "reciprocal", "none"],
       description: "Gift giving tier",
     },
     favorites: {

--- a/packages/patterns/rating.tsx
+++ b/packages/patterns/rating.tsx
@@ -54,7 +54,9 @@ const setRating = handler<
 export const RatingModule = recipe<RatingModuleInput, RatingModuleInput>(
   "RatingModule",
   ({ rating }) => {
-    const displayText = computed(() => rating ? `${rating}/5` : "Not rated");
+    const displayText = computed(() =>
+      rating.get() ? `${rating.get()}/5` : "Not rated"
+    );
 
     return {
       [NAME]: computed(() => `${MODULE_METADATA.icon} Rating: ${displayText}`),
@@ -72,7 +74,7 @@ export const RatingModule = recipe<RatingModuleInput, RatingModuleInput>(
                   cursor: "pointer",
                   fontSize: "24px",
                   padding: "4px",
-                  opacity: (rating ?? 0) >= value ? "1" : "0.3",
+                  opacity: (rating.get() ?? 0) >= value ? "1" : "0.3",
                   transition: "opacity 0.1s, transform 0.1s",
                 }}
                 title={`Rate ${value} star${value > 1 ? "s" : ""}`}

--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -934,12 +934,12 @@ const Record = pattern<RecordInput, RecordOutput>(
                   }}
                 >
                   <span
-                    style={{
-                      transform: trashExpanded
+                    style={computed(() => ({
+                      transform: trashExpanded.get()
                         ? "rotate(90deg)"
                         : "rotate(0deg)",
                       transition: "transform 0.2s",
-                    }}
+                    }))}
                   >
                     ▶
                   </span>
@@ -947,7 +947,7 @@ const Record = pattern<RecordInput, RecordOutput>(
                 </button>
 
                 {ifElse(
-                  trashExpanded,
+                  computed(() => trashExpanded.get()),
                   <div style={{ paddingLeft: "16px", marginTop: "8px" }}>
                     {trashedSubCharms.map(
                       (entry) => {

--- a/packages/patterns/record/template-registry.ts
+++ b/packages/patterns/record/template-registry.ts
@@ -129,14 +129,6 @@ export function inferTypeFromModules(moduleTypes: string[]): InferredType {
     return { type: "project", icon: "\u{1F4BC}", confidence: 0.85 };
   }
 
-  // Place: has location OR address (but not birthday - that's a person)
-  if (
-    (typeSet.has("location") || typeSet.has("address")) &&
-    !typeSet.has("birthday")
-  ) {
-    return { type: "place", icon: "\u{1F4CD}", confidence: 0.8 };
-  }
-
   // Family: has address AND relationship (but not birthday - individual person)
   if (
     typeSet.has("address") && typeSet.has("relationship") &&
@@ -147,6 +139,14 @@ export function inferTypeFromModules(moduleTypes: string[]): InferredType {
       icon: "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}",
       confidence: 0.75,
     };
+  }
+
+  // Place: has location OR address (but not birthday - that's a person)
+  if (
+    (typeSet.has("location") || typeSet.has("address")) &&
+    !typeSet.has("birthday")
+  ) {
+    return { type: "place", icon: "\u{1F4CD}", confidence: 0.8 };
   }
 
   // Default: generic record

--- a/packages/patterns/status.tsx
+++ b/packages/patterns/status.tsx
@@ -16,7 +16,7 @@ export const MODULE_METADATA: ModuleMetadata = {
   schema: {
     status: {
       type: "string",
-      enum: ["planned", "active", "blocked", "done", "archived"],
+      enum: ["", "planned", "active", "blocked", "done", "archived"],
       description: "Project status",
     },
   },

--- a/packages/patterns/timing.tsx
+++ b/packages/patterns/timing.tsx
@@ -126,7 +126,9 @@ export const TimingModule = recipe<TimingModuleInput, TimingModuleInput>(
             }}
           >
             <span style={{ fontSize: "14px", color: "#6b7280" }}>Total:</span>
-            <span style={{ fontSize: "18px", fontWeight: "600" }}>
+            <span
+              style={{ fontSize: "18px", fontWeight: "600", marginLeft: "4px" }}
+            >
               {displayText}
             </span>
           </div>


### PR DESCRIPTION
## Summary

- Addresses unresolved Cubic review comments from PRs #2305, #2307, #2310, #2315
- Fixes bugs related to Cell value access, type inference ordering, schema consistency, and UI spacing

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `rating.tsx` | Cell used directly in truthy check and comparison | Added `.get()` calls |
| `template-registry.ts` | Family type inferred as "place" (Place check matched first) | Reordered checks - Family before Place |
| `timing.tsx` | Missing space after "Total:" label | Added `marginLeft: 4px` to value span |
| `giftprefs.tsx` | Schema enum missing "" for "Not set" state | Added "" to enum |
| `status.tsx` | Schema enum missing "" for "Not set" state | Added "" to enum |
| `address.tsx` | fieldMapping has "address" but property is "label" | Changed to "label" |
| `record.tsx` | trashExpanded Cell used directly in ternary/ifElse | Wrapped in `computed()` |

## Not Applied

Cubic's suggestion to add `key` props to mapped elements was **not** applied - CommonTools' JSX system has automatic content-based keying and key props are intentionally unused (documented in jsx-runtime.ts).

## Test plan

- [ ] Type check passes (`deno check`)
- [ ] Lint passes (`deno lint`)
- [ ] Rating module stars highlight correctly based on rating value
- [ ] Family templates are correctly inferred (not as "place")
- [ ] Timing module shows "Total: 2h 30m" with proper spacing
- [ ] Trash section arrow rotates when expanded/collapsed

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes review feedback across multiple patterns to improve correctness and UI polish. Covers cell value handling, type inference order, schema defaults, field mapping, and spacing.

- **Bug Fixes**
  - Rating: use rating.get() for truthy checks and comparisons.
  - Record: wrap trashExpanded in computed() for reactive updates.
  - Type inference: check Family before Place in template registry.
  - Schemas: add "" to status and giftprefs enums to match default.
  - Address: map "label" instead of "address" in fieldMapping.
  - Timing: add 4px margin after "Total:" label.

<sup>Written for commit e445f97f0651bee8a08ff7401cd4a4491f736eeb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

