### PR TITLE
chore: Allow entry point patterns to reference files outside of their own directory

### DIFF
--- a/packages/cli/commands/charm.ts
+++ b/packages/cli/commands/charm.ts
@@ -102,18 +102,30 @@ export const charm = new Command()
     `ct charm new ${EX_ID} ${EX_URL} ./main.tsx`,
     `Create a new charm, using ./main.tsx as source.`,
   )
+  .example(
+    `ct charm new ${EX_ID} ${EX_COMP} --root ./patterns ./patterns/wip/main.tsx`,
+    `Create a charm that can import from parent directories within ./patterns.`,
+  )
   .arguments("<main:string>")
   .option("--start", "Start the charm after creation for one step")
   .option(
     "--main-export <export:string>",
     'Named export from entry for recipe definition. Defaults to "default".',
   )
+  .option(
+    "--root <path:string>",
+    "Root directory for resolving imports. Allows imports from parent directories within this root.",
+  )
   .action(
     async (options, main) =>
       render(
         await newCharm(
           parseSpaceOptions(options),
-          { mainPath: absPath(main), mainExport: options.mainExport },
+          {
+            mainPath: absPath(main),
+            mainExport: options.mainExport,
+            rootPath: options.root ? absPath(options.root) : undefined,
+          },
           { start: options.start },
         ),
       ),
@@ -184,11 +196,16 @@ export const charm = new Command()
     "--main-export <export:string>",
     'Named export from entry for recipe definition. Defaults to "default".',
   )
+  .option(
+    "--root <path:string>",
+    "Root directory for resolving imports. Allows imports from parent directories within this root.",
+  )
   .arguments("<main:string>")
   .action((options, mainPath) =>
     setCharmRecipe(parseCharmOptions(options), {
       mainPath: absPath(mainPath),
       mainExport: options.mainExport,
+      rootPath: options.root ? absPath(options.root) : undefined,
     })
   )
   /* charm inspect */

--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -19,6 +19,7 @@ import { setLLMUrl } from "@commontools/llm";
 export interface EntryConfig {
   mainPath: string;
   mainExport?: string;
+  rootPath?: string;
 }
 
 export interface SpaceConfig {
@@ -96,9 +97,8 @@ async function getProgramFromFile(
   manager: CharmManager,
   entry: EntryConfig,
 ): Promise<RuntimeProgram> {
-  // Walk entry file and collect all sources from fs.
   const program: RuntimeProgram = await manager.runtime.harness.resolve(
-    new FileSystemProgramResolver(entry.mainPath),
+    new FileSystemProgramResolver(entry.mainPath, entry.rootPath),
   );
   if (entry.mainExport) {
     program.mainExport = entry.mainExport;


### PR DESCRIPTION
`ct charm new --root . path/to/entry.tsx`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a --root option to ct charm so entry points can import files outside their own directory, constrained to a specified root. The resolver now enforces the root and blocks imports that escape it.

- **New Features**
  - CLI: --root on ct charm new and recipe set to resolve imports within a chosen root. Example: ct charm new --root . path/to/entry.tsx
  - Resolver: validates mainPath is inside root, normalizes import paths, and throws if an import resolves outside the root.

<sup>Written for commit 0616a0cb4095605542dc65fe0ad31dcd18beec28. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



