### PR TITLE
fix(runner): Hot-reload charms when recipe changes remotely (CT-1135)

### DIFF
--- a/packages/charm/src/manager.ts
+++ b/packages/charm/src/manager.ts
@@ -857,6 +857,12 @@ export class CharmManager {
       }
     });
 
+    // CT-1135: Clean up the TYPE watcher for this charm permanently
+    // This prevents memory leaks from hot-reload subscriptions
+    if (ok) {
+      this.runtime.runner.remove(charm);
+    }
+
     return !!ok;
   }
 

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -950,12 +950,17 @@ describe("setup/start", () => {
     expect(resultCell.getAsQueryResult()).toEqual({ output: 5 });
   });
 
-  it("CT-1135: hot-reloads when process cell TYPE changes", async () => {
-    // Recipe 1: multiplies input by 2
-    const recipe1: Recipe = {
+  // Helper to create a simple multiplier recipe for hot-reload tests
+  // Note: Uses a unique string in the argumentSchema to ensure different
+  // multipliers produce different recipe IDs (since function.toString()
+  // doesn't capture closure values).
+  function createMultiplierRecipe(multiplier: number): Recipe {
+    return {
       argumentSchema: {
         type: "object",
         properties: { input: { type: "number" } },
+        // Include multiplier in a way that affects the hash
+        title: `Multiplies input by ${multiplier}`,
       },
       resultSchema: {},
       result: { output: { $alias: { path: ["internal", "output"] } } },
@@ -963,64 +968,376 @@ describe("setup/start", () => {
         {
           module: {
             type: "javascript",
-            implementation: (v: { input: number }) => v.input * 2,
+            implementation: (v: { input: number }) => v.input * multiplier,
           },
           inputs: { $alias: { path: ["argument"] } },
           outputs: { $alias: { path: ["internal", "output"] } },
         },
       ],
     };
+  }
 
-    // Recipe 2: multiplies input by 3
-    const recipe2: Recipe = {
-      argumentSchema: {
-        type: "object",
-        properties: { input: { type: "number" } },
-      },
-      resultSchema: {},
-      result: { output: { $alias: { path: ["internal", "output"] } } },
-      nodes: [
-        {
-          module: {
-            type: "javascript",
-            implementation: (v: { input: number }) => v.input * 3,
-          },
-          inputs: { $alias: { path: ["argument"] } },
-          outputs: { $alias: { path: ["internal", "output"] } },
-        },
-      ],
-    };
-
-    // Start charm with recipe1
-    const resultCell = runtime.getCell(space, "hot-reload-test");
-    await runtime.runSynced(resultCell, recipe1, { input: 5 });
-    await runtime.idle();
-
-    // Verify recipe1 behavior (5 * 2 = 10)
-    expect(resultCell.getAsQueryResult()).toEqual({ output: 10 });
-
-    // Register and save recipe2
-    const recipe2Id = runtime.recipeManager.registerRecipe(recipe2);
-    await runtime.recipeManager.saveAndSyncRecipe({ recipeId: recipe2Id, space });
-
-    // Get process cell and directly update the TYPE field
+  // Helper to update TYPE field and wait for hot-reload
+  async function triggerHotReload(
+    rt: Runtime,
+    resultCell: ReturnType<typeof runtime.getCell>,
+    newRecipeId: string,
+  ): Promise<void> {
     const processCell = resultCell.getSourceCell()!;
-    const tx = runtime.edit();
+    const tx = rt.edit();
     const currentRaw = processCell.getRaw() as Record<string, unknown>;
     processCell.withTx(tx).setRaw({
       ...currentRaw,
-      "$TYPE": recipe2Id,
+      "$TYPE": newRecipeId,
     });
     await tx.commit();
-
-    // Wait for scheduler to detect change and hot-reload
-    await runtime.idle();
+    // Wait for scheduler to detect change
+    await rt.idle();
     // Allow queueMicrotask to execute
     await new Promise((resolve) => setTimeout(resolve, 50));
-    await runtime.idle();
+    await rt.idle();
+  }
 
-    // Should now use recipe2 (5 * 3 = 15)
-    expect(resultCell.getAsQueryResult()).toEqual({ output: 15 });
+  describe("CT-1135: hot-reload", () => {
+    it("reloads when process cell TYPE changes", async () => {
+      const recipe1 = createMultiplierRecipe(2);
+      const recipe2 = createMultiplierRecipe(3);
+
+      // Start charm with recipe1
+      const resultCell = runtime.getCell(space, "hot-reload-basic");
+      await runtime.runSynced(resultCell, recipe1, { input: 5 });
+      await runtime.idle();
+
+      // Verify recipe1 behavior (5 * 2 = 10)
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 10 });
+
+      // Register and save recipe2
+      const recipe2Id = runtime.recipeManager.registerRecipe(recipe2);
+      await runtime.recipeManager.saveAndSyncRecipe({
+        recipeId: recipe2Id,
+        space,
+      });
+
+      // Trigger hot-reload
+      await triggerHotReload(runtime, resultCell, recipe2Id);
+
+      // Should now use recipe2 (5 * 3 = 15)
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 15 });
+    });
+
+    it("supports multiple sequential hot-reloads", async () => {
+      const recipe1 = createMultiplierRecipe(2);
+      const recipe2 = createMultiplierRecipe(3);
+      const recipe3 = createMultiplierRecipe(5);
+
+      // Start with recipe1
+      const resultCell = runtime.getCell(space, "hot-reload-sequential");
+      await runtime.runSynced(resultCell, recipe1, { input: 10 });
+      await runtime.idle();
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 20 }); // 10 * 2
+
+      // Register all recipes upfront
+      const recipe2Id = runtime.recipeManager.registerRecipe(recipe2);
+      await runtime.recipeManager.saveAndSyncRecipe({
+        recipeId: recipe2Id,
+        space,
+      });
+      const recipe3Id = runtime.recipeManager.registerRecipe(recipe3);
+      await runtime.recipeManager.saveAndSyncRecipe({
+        recipeId: recipe3Id,
+        space,
+      });
+
+      // Hot-reload to recipe2
+      await triggerHotReload(runtime, resultCell, recipe2Id);
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 30 }); // 10 * 3
+
+      // Hot-reload to recipe3
+      await triggerHotReload(runtime, resultCell, recipe3Id);
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 50 }); // 10 * 5
+
+      // Hot-reload back to recipe2 (test going backwards)
+      await triggerHotReload(runtime, resultCell, recipe2Id);
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 30 }); // 10 * 3
+    });
+
+    it("TYPE watcher survives manual stop/start cycle", async () => {
+      const recipe1 = createMultiplierRecipe(2);
+      const recipe2 = createMultiplierRecipe(4);
+
+      // Start with recipe1
+      const resultCell = runtime.getCell(space, "hot-reload-stop-start");
+      await runtime.runSynced(resultCell, recipe1, { input: 7 });
+      await runtime.idle();
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 14 }); // 7 * 2
+
+      // Manually stop the charm (simulates user action)
+      runtime.runner.stop(resultCell);
+
+      // Manually restart (simulates user action)
+      runtime.start(resultCell);
+      await runtime.idle();
+
+      // Verify still works with original recipe
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 14 });
+
+      // Register recipe2
+      const recipe2Id = runtime.recipeManager.registerRecipe(recipe2);
+      await runtime.recipeManager.saveAndSyncRecipe({
+        recipeId: recipe2Id,
+        space,
+      });
+
+      // Hot-reload should still work after stop/start cycle
+      await triggerHotReload(runtime, resultCell, recipe2Id);
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 28 }); // 7 * 4
+    });
+
+    it("preserves input arguments across hot-reload", async () => {
+      const recipe1 = createMultiplierRecipe(2);
+      const recipe2 = createMultiplierRecipe(3);
+
+      // Start with recipe1 and specific input
+      const resultCell = runtime.getCell(space, "hot-reload-preserve-args");
+      await runtime.runSynced(resultCell, recipe1, { input: 42 });
+      await runtime.idle();
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 84 }); // 42 * 2
+
+      // Register recipe2
+      const recipe2Id = runtime.recipeManager.registerRecipe(recipe2);
+      await runtime.recipeManager.saveAndSyncRecipe({
+        recipeId: recipe2Id,
+        space,
+      });
+
+      // Hot-reload
+      await triggerHotReload(runtime, resultCell, recipe2Id);
+
+      // Input should be preserved, only multiplier changes
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 126 }); // 42 * 3
+
+      // Verify argument is still in process cell
+      const processCell = resultCell.getSourceCell()!;
+      const processData = processCell.getAsQueryResult() as Record<
+        string,
+        unknown
+      >;
+      expect((processData.argument as { input: number }).input).toEqual(42);
+    });
+
+    it("handles same recipe ID gracefully (no-op)", async () => {
+      const recipe1 = createMultiplierRecipe(2);
+
+      // Start with recipe1
+      const resultCell = runtime.getCell(space, "hot-reload-same-recipe");
+      await runtime.runSynced(resultCell, recipe1, { input: 5 });
+      await runtime.idle();
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 10 });
+
+      // Get current recipe ID
+      const processCell = resultCell.getSourceCell()!;
+      const currentRaw = processCell.getRaw() as Record<string, unknown>;
+      const currentRecipeId = currentRaw["$TYPE"] as string;
+
+      // "Hot-reload" to same recipe - should be a no-op
+      await triggerHotReload(runtime, resultCell, currentRecipeId);
+
+      // Should still work normally
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 10 });
+    });
+
+    it("triggers via storage notification path (not direct cell access)", async () => {
+      // This test verifies that the hot-reload is triggered through the
+      // storage notification mechanism, not through direct cell observation.
+      // This is important because real-world hot-reloads come from remote
+      // storage sync (via integrate/pull notifications).
+
+      const recipe1 = createMultiplierRecipe(2);
+      const recipe2 = createMultiplierRecipe(4);
+
+      // Start charm with recipe1
+      const resultCell = runtime.getCell(space, "hot-reload-notification-path");
+      await runtime.runSynced(resultCell, recipe1, { input: 7 });
+      await runtime.idle();
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 14 }); // 7 * 2
+
+      // Register recipe2
+      const recipe2Id = runtime.recipeManager.registerRecipe(recipe2);
+      await runtime.recipeManager.saveAndSyncRecipe({
+        recipeId: recipe2Id,
+        space,
+      });
+
+      // Get process cell info BEFORE triggering
+      const processCell = resultCell.getSourceCell()!;
+      const processLink = processCell.getAsNormalizedFullLink();
+
+      // Create a new transaction (simulating external update)
+      // This goes through tx.commit() which broadcasts a storage notification
+      const externalTx = runtime.edit();
+      const externalProcess = runtime.getCellFromLink(
+        processLink,
+        undefined,
+        externalTx,
+      );
+      const currentRaw = externalProcess.getRaw() as Record<string, unknown>;
+
+      // Update TYPE through the transaction (this simulates what CLI does)
+      externalProcess.setRaw({
+        ...currentRaw,
+        "$TYPE": recipe2Id,
+      });
+
+      // Commit - this broadcasts a storage notification
+      await externalTx.commit();
+
+      // Wait for scheduler to process the notification
+      await runtime.idle();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await runtime.idle();
+
+      // Should have hot-reloaded to recipe2
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 28 }); // 7 * 4
+    });
+
+    it("handles unknown recipe ID gracefully (charm stops)", async () => {
+      // When TYPE is changed to an unknown recipe ID, the charm should stop
+      // gracefully rather than crash. This can happen if recipe sync is delayed.
+
+      const recipe1 = createMultiplierRecipe(2);
+
+      // Start charm with recipe1
+      const resultCell = runtime.getCell(space, "hot-reload-unknown-recipe");
+      await runtime.runSynced(resultCell, recipe1, { input: 5 });
+      await runtime.idle();
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 10 });
+
+      // Create a fake recipe ID that doesn't exist
+      const fakeRecipeId =
+        "ba4jcfakerecipeidthatdoesnotexistxxxxxxxxxxxxxxxxxx";
+
+      // Trigger hot-reload to non-existent recipe
+      await triggerHotReload(runtime, resultCell, fakeRecipeId);
+
+      // The charm should have stopped (output will be stale/alias)
+      // The key is that it doesn't throw or crash
+      const result = resultCell.getAsQueryResult();
+      // Result could be the old value (if recipe load failed gracefully)
+      // or an alias (if the charm stopped). Either is acceptable.
+      expect(result).toBeDefined();
+    });
+
+    it("circuit breaker stops retrying after MAX_RELOAD_FAILURES", async () => {
+      // After multiple failed reload attempts, the circuit breaker should
+      // prevent further automatic reload attempts.
+
+      const recipe1 = createMultiplierRecipe(2);
+
+      // Start charm with recipe1
+      const resultCell = runtime.getCell(space, "hot-reload-circuit-breaker");
+      await runtime.runSynced(resultCell, recipe1, { input: 5 });
+      await runtime.idle();
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 10 });
+
+      // Create fake recipe IDs that don't exist
+      const fakeRecipeId1 =
+        "ba4jcfake1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+      const fakeRecipeId2 =
+        "ba4jcfake2bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+      const fakeRecipeId3 =
+        "ba4jcfake3cccccccccccccccccccccccccccccccccccccccc";
+      const fakeRecipeId4 =
+        "ba4jcfake4dddddddddddddddddddddddddddddddddddddddd";
+
+      // Trigger 4 failed hot-reloads (max is 3)
+      await triggerHotReload(runtime, resultCell, fakeRecipeId1);
+      await triggerHotReload(runtime, resultCell, fakeRecipeId2);
+      await triggerHotReload(runtime, resultCell, fakeRecipeId3);
+
+      // The 4th should be blocked by circuit breaker (no new error logged)
+      await triggerHotReload(runtime, resultCell, fakeRecipeId4);
+
+      // Charm is in failed state but didn't crash
+      expect(resultCell.getAsQueryResult()).toBeDefined();
+    });
+
+    it("remove() cleans up TYPE watcher (no memory leak)", async () => {
+      const recipe1 = createMultiplierRecipe(2);
+      const recipe2 = createMultiplierRecipe(3);
+
+      // Start charm with recipe1
+      const resultCell = runtime.getCell(space, "hot-reload-remove-test");
+      await runtime.runSynced(resultCell, recipe1, { input: 5 });
+      await runtime.idle();
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 10 });
+
+      // Register recipe2 for later
+      const recipe2Id = runtime.recipeManager.registerRecipe(recipe2);
+      await runtime.recipeManager.saveAndSyncRecipe({
+        recipeId: recipe2Id,
+        space,
+      });
+
+      // Remove the charm permanently (not just stop)
+      runtime.runner.remove(resultCell);
+
+      // Now try to trigger hot-reload - should NOT work because watcher is gone
+      await triggerHotReload(runtime, resultCell, recipe2Id);
+
+      // The result should still be stale (old value or alias), not updated
+      // because the TYPE watcher was removed
+      const result = resultCell.getAsQueryResult();
+      // Should NOT be 15 (which would indicate hot-reload worked)
+      expect(result).not.toEqual({ output: 15 });
+    });
+
+    it("handles rapid TYPE changes A→B→C correctly", async () => {
+      // When TYPE changes rapidly (A→B→C), the final state should be C,
+      // not B (which would indicate a race condition bug).
+
+      const recipe1 = createMultiplierRecipe(2); // A
+      const recipe2 = createMultiplierRecipe(3); // B
+      const recipe3 = createMultiplierRecipe(5); // C (target)
+
+      // Start charm with recipe1 (A)
+      const resultCell = runtime.getCell(space, "hot-reload-rapid-changes");
+      await runtime.runSynced(resultCell, recipe1, { input: 10 });
+      await runtime.idle();
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 20 }); // 10 * 2
+
+      // Register all recipes
+      const recipe2Id = runtime.recipeManager.registerRecipe(recipe2);
+      await runtime.recipeManager.saveAndSyncRecipe({
+        recipeId: recipe2Id,
+        space,
+      });
+      const recipe3Id = runtime.recipeManager.registerRecipe(recipe3);
+      await runtime.recipeManager.saveAndSyncRecipe({
+        recipeId: recipe3Id,
+        space,
+      });
+
+      // Rapidly change TYPE: A→B→C without waiting
+      const processCell = resultCell.getSourceCell()!;
+      const tx1 = runtime.edit();
+      const currentRaw = processCell.getRaw() as Record<string, unknown>;
+      processCell.withTx(tx1).setRaw({ ...currentRaw, "$TYPE": recipe2Id });
+      await tx1.commit();
+
+      // Immediately change to C before B finishes loading
+      const tx2 = runtime.edit();
+      const currentRaw2 = processCell.getRaw() as Record<string, unknown>;
+      processCell.withTx(tx2).setRaw({ ...currentRaw2, "$TYPE": recipe3Id });
+      await tx2.commit();
+
+      // Wait for all reloads to complete
+      await runtime.idle();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await runtime.idle();
+
+      // Final state should be C (recipe3), not B (recipe2)
+      expect(resultCell.getAsQueryResult()).toEqual({ output: 50 }); // 10 * 5
+    });
   });
 
   it("setup with Module wraps to recipe and runs on start", async () => {


### PR DESCRIPTION
## Summary

- Implements automatic hot-reload when a charm's recipe changes via storage sync (e.g., `ct charm setsrc`)
- Watches process cell's `$TYPE` field for recipe ID changes and restarts charm with new recipe
- Adds memory leak protection with `remove()` method for permanent TYPE watcher cleanup
- Adds circuit breaker (3 retries) to prevent infinite loops on broken recipes
- Handles rapid recipe changes (A→B→C) correctly via `targetRecipeIdRef` pattern

## Test plan

- [x] 10 new hot-reload tests covering all edge cases
- [x] `deno task test packages/runner/` passes
- [x] `deno task test packages/charm/` passes
- [x] `deno fmt` and `deno lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hot-reload charms when a recipe changes remotely (ct charm setsrc), addressing CT-1135. The runner watches the process cell’s $TYPE (recipe ID) and safely restarts the charm without memory leaks.

- **New Features**
  - Watch process cell $TYPE and hot-reload the charm on change.
  - Persist the TYPE watcher across restarts; add runner.remove() to clean it when a charm is deleted.
  - Handle rapid A→B→C changes and preserve arguments; add a 3-failure circuit breaker.

- **Bug Fixes**
  - Prevent race conditions with a reloadingCharms set and avoid watcher stacking by canceling existing subscriptions.
  - Fix memory leaks via a dedicated typeWatcherCancels map and cleanup in stopAll() and CharmManager.remove().
  - Add tests for hot-reload, stop/start, unknown recipe IDs, and rapid changes.

<sup>Written for commit e5f9b01b8ae5a9fe1081d4fc695511902c128c7c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

