### PR TITLE
docs: Document --root flag for parent directory imports (CT-1134)

### DIFF
--- a/docs/common/PATTERN_DEV_DEPLOY.md
+++ b/docs/common/PATTERN_DEV_DEPLOY.md
@@ -104,6 +104,22 @@ patterns/feature/
 
 Use relative imports. ct bundles dependencies automatically.
 
+### Importing from Parent Directories
+
+By default, patterns can only import files from their own directory or subdirectories. To import from parent directories, use the `--root` option:
+
+```bash
+# Allow imports from anywhere within ./patterns
+deno task ct charm new -i key.json -a URL -s space --root ./patterns ./patterns/wip/main.tsx
+```
+
+This allows `./patterns/wip/main.tsx` to import from `./patterns/shared/utils.tsx` (via `../shared/utils.tsx`), while preventing imports from outside the specified root.
+
+**Use cases:**
+- Shared type definitions across pattern directories
+- Common utility functions
+- Reusing blessed patterns as building blocks
+
 **Pitfall:** Schema mismatches between linked charms → export shared schemas from common file.
 
 ---


### PR DESCRIPTION
## Summary

Added documentation for the new `--root` CLI option that allows patterns to import from parent directories within a specified root boundary.

Updated `docs/common/PATTERN_DEV_DEPLOY.md` with:
- Explanation of the `--root` flag
- Example usage
- Use cases (shared types, utilities, reusing blessed patterns)

## Related

- [CT-1134](https://linear.app/common-tools/issue/CT-1134)
- Implementation: PR #2330

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the ct CLI --root flag to allow parent-directory imports within a defined root and block imports outside it. Includes a CLI example and common use cases; aligns with CT-1134.

<sup>Written for commit 601a09e3f4dd53c4838a4be4e305c02b14042786. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

