### PR TITLE
feat(default-app): add Notes dropdown menu

### DIFF
--- a/packages/patterns/default-app.tsx
+++ b/packages/patterns/default-app.tsx
@@ -11,7 +11,6 @@ import {
 } from "commontools";
 
 import { default as Note } from "./note.tsx";
-import { default as Record } from "./record.tsx";
 
 // Simple random ID generator (crypto.randomUUID not available in pattern env)
 const generateId = () =>
@@ -100,11 +99,6 @@ const menuNewNotebook = handler<void, { menuOpen: Cell<boolean> }>(
   },
 );
 
-// Standalone: New Record
-const spawnRecord = handler<void, void>((_, __) => {
-  return navigateTo(Record({ title: "" }));
-});
-
 // Helper to find existing All Notes charm
 const findAllNotebooksCharm = (allCharms: Cell<MinimalCharm[]>) => {
   const charms = allCharms.get();
@@ -172,18 +166,6 @@ export default pattern<CharmsListInput, CharmsListOutput>((_) => {
             <h2 style={{ margin: 0, fontSize: "20px" }}>Pages</h2>
           </div>
           <div slot="end">
-            <ct-button
-              variant="ghost"
-              onClick={spawnRecord()}
-              style={{
-                padding: "12px 20px",
-                fontSize: "22px",
-                borderRadius: "12px",
-                minHeight: "48px",
-              }}
-            >
-              📋 New Record
-            </ct-button>
             <ct-button
               variant="ghost"
               onClick={toggleMenu({ menuOpen })}


### PR DESCRIPTION
## Summary
- Adds a Notes dropdown menu to the default-app toolbar
- Menu includes: 📝 New Note, 📓 New Notebook, 📁 All Notes
- Removes the standalone Record button (can be added back separately if needed)

## Test plan
- [ ] Verify Notes dropdown appears in default-app header
- [ ] Click "New Note" creates a new note and navigates to it
- [ ] Click "New Notebook" creates a new notebook and navigates to it
- [ ] Click "All Notes" navigates to the All Notes view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Notes dropdown to the default-app toolbar for quick note actions, and removed the standalone Record button to simplify the header. The menu includes New Note, New Notebook, and All Notes, each creating or navigating accordingly.

<sup>Written for commit afa2ffa1362c25280ce6278edc3bdecb1f19ac81. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

