### PR TITLE
feat: Allow HttpProgramResolver to import files outside of the entry point's path.

### DIFF
--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -78,12 +78,10 @@ export class FileSystemProgramResolver implements ProgramResolver {
 
 // Resolve a program from HTTP.
 export class HttpProgramResolver implements ProgramResolver {
-  #httpRoot: string;
   #mainUrl: URL;
   #main?: Promise<Source>;
   constructor(main: string | URL) {
     this.#mainUrl = !(main instanceof URL) ? new URL(main) : main;
-    this.#httpRoot = dirname(this.#mainUrl.pathname);
   }
 
   main(): Promise<Source> {
@@ -98,10 +96,7 @@ export class HttpProgramResolver implements ProgramResolver {
       return Promise.resolve(undefined);
     }
     const url = new URL(this.#mainUrl);
-    url.pathname = join(
-      this.#httpRoot,
-      specifier.substring(1, specifier.length),
-    );
+    url.pathname = normalize(specifier);
     return this.#fetch(url);
   }
 
@@ -109,7 +104,7 @@ export class HttpProgramResolver implements ProgramResolver {
     const res = await fetch(url);
     const contents = await res.text();
     return {
-      name: url.pathname.substring(this.#httpRoot.length),
+      name: url.pathname,
       contents,
     };
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow HttpProgramResolver to import files outside the entry point directory by normalizing the specifier into the URL pathname. This lifts previous path bounds and enables absolute and parent-relative imports.

- **New Features**
  - Supports absolute and parent-relative specifiers (e.g., /lib/utils.ts, ../shared.ts).

- **Refactors**
  - Removed httpRoot; URL.pathname is set via normalize(specifier).
  - Source.name now returns the full pathname.

<sup>Written for commit 69fcd05f49e7ef02c81b651b574e44ed53db801a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

