### PR TITLE
fix: Add response.ok checks and remove dead cast-spell workflow

### DIFF
--- a/packages/charm/src/commands.ts
+++ b/packages/charm/src/commands.ts
@@ -126,6 +126,11 @@ export async function addGithubRecipe(
   const response = await fetch(
     `https://raw.githubusercontent.com/commontoolsinc/labs/refs/heads/main/recipes/${filename}?${Date.now()}`,
   );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch recipe from GitHub: ${response.status} ${response.statusText}`,
+    );
+  }
   const src = await response.text();
   return await compileAndRunRecipe(
     charmManager,

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -102,6 +102,11 @@ export class HttpProgramResolver implements ProgramResolver {
 
   async #fetch(url: URL): Promise<Source> {
     const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(
+        `Failed to fetch ${url}: ${res.status} ${res.statusText}`,
+      );
+    }
     const contents = await res.text();
     return {
       name: url.pathname,

--- a/packages/llm/src/prompts/workflow-classification.ts
+++ b/packages/llm/src/prompts/workflow-classification.ts
@@ -215,10 +215,6 @@ export async function classifyWorkflow(
       `\`imagine\`: Create something new, potentially combining multiple data sources
    - Example: "Create a dashboard combining my tasks and calendar"
    - Creates new code, specification, and potentially new schema`,
-
-    "cast-spell":
-      `\`cast-spell\`: Find a spell from the spellbook that fits the user's needs and can be used on their mentioned data
-   - Example: "Find a spell to optimize my code for performance"`,
     //  'fix': `\`fix\`: Repair existing functionality without changing core behavior
     // - Example: "Fix the bug in my sorting function"
     // - Preserves specification and schema exactly as-is`,

--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -269,9 +269,12 @@ async function startFetch(
   internal: Cell<Schema<typeof internalSchema>>,
   abortSignal: AbortSignal,
 ) {
-  const processResponse = (mode || "json") === "json"
-    ? (r: Response) => r.json()
-    : (r: Response) => r.text();
+  const processResponse = async (r: Response) => {
+    if (!r.ok) {
+      throw new Error(`HTTP ${r.status}: ${r.statusText}`);
+    }
+    return (mode || "json") === "json" ? await r.json() : await r.text();
+  };
 
   const fetchOptions = { ...options };
   if (


### PR DESCRIPTION
## Summary

- **Fixes confusing "unexpected token" errors** when HTTP requests fail and return HTML error pages instead of JSON/TypeScript
- **Removes dead `cast-spell` workflow** that was calling a non-existent API endpoint

## Problem

When HTTP requests fail (e.g., 404, 500), servers often return HTML error pages. Without checking `response.ok`, the code would:
- Try to parse HTML as JSON → `SyntaxError: Unexpected token '<'`
- Try to compile HTML as TypeScript → cryptic compilation errors

These errors are confusing because they don't indicate the actual problem (HTTP failure).

## Solution

Add `response.ok` checks before parsing responses in:
- `addGithubRecipe()` - throws clear error on GitHub fetch failure
- `HttpProgramResolver.#fetch()` - throws clear error instead of compiling HTML
- `fetchData` builtin - properly sets error cell for non-2xx responses

## Bonus: Dead Code Removal

Oracle investigation revealed the `cast-spell` workflow was dead code:
- The `/api/ai/spell/find-by-schema` endpoint was removed in July 2025
- No code sets `permittedWorkflows: ["cast-spell"]`
- Removed ~190 lines of unreachable code

## Test plan

- [x] `deno lint` passes on all modified files
- [x] `deno task test packages/charm/` passes
- [x] `deno task test packages/runner/` passes  
- [x] `deno task test packages/js-compiler/` passes
- [x] `deno task test packages/llm/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds response.ok checks to all HTTP fetch paths to surface clear HTTP errors instead of “Unexpected token '<'”. Removes the dead cast-spell workflow and its related code.

- **Bug Fixes**
  - Check response.ok in addGithubRecipe, HttpProgramResolver.#fetch, and fetchData before parsing.
  - Throw clear HTTP errors (status + statusText) for non-2xx responses.
  - Prevent parsing HTML as JSON or compiling HTML as TypeScript.

- **Refactors**
  - Remove cast-spell workflow, types, search flow, and prompt references.
  - Drop cast-spell from WORKFLOWS and classification; default to imagine when no spec/schema.

<sup>Written for commit 0f24b9aacd726542c5e4e87342639fb023523aa1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



