### PR TITLE
feat(patterns): Add module maximize feature to Record pattern

### DIFF
--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -341,7 +341,10 @@ const trashSubCharm = handler<
     expandedIndex: Cell<number | undefined>;
     index: number;
   }
->((_event, { subCharms: sc, trashedSubCharms: trash, expandedIndex, index }) => {
+>((
+  _event,
+  { subCharms: sc, trashedSubCharms: trash, expandedIndex, index },
+) => {
   const current = sc.get() || [];
   const entry = current[index];
   if (!entry) return;
@@ -550,13 +553,22 @@ const Record = pattern<RecordInput, RecordOutput>(
 
     // Entry with index for rendering - preserves charm references (no spreading!)
     // isExpanded is pre-computed to avoid closure issues inside .map() callbacks
-    type EntryWithIndex = { entry: SubCharmEntry; index: number; isExpanded: boolean };
+    type EntryWithIndex = {
+      entry: SubCharmEntry;
+      index: number;
+      isExpanded: boolean;
+    };
 
     // Pre-compute entries with their indices AND expanded state for stable reference during render
     // IMPORTANT: We do NOT spread entry properties - that breaks charm rendering
     // IMPORTANT: isExpanded must be computed here, not inside .map() - closures over cells in .map() don't work correctly
     const entriesWithIndex = lift(
-      ({ sc, expandedIdx }: { sc: SubCharmEntry[]; expandedIdx: number | undefined }) => {
+      (
+        { sc, expandedIdx }: {
+          sc: SubCharmEntry[];
+          expandedIdx: number | undefined;
+        },
+      ) => {
         const entries = sc || [];
         return entries.map((entry, index) => ({
           entry,
@@ -780,28 +792,28 @@ const Record = pattern<RecordInput, RecordOutput>(
                       <div
                         style={isExpanded
                           ? {
-                              position: "fixed",
-                              top: "50%",
-                              left: "50%",
-                              transform: "translate(-50%, -50%)",
-                              zIndex: "1001",
-                              width: "95%",
-                              maxWidth: "1200px",
-                              height: "90%",
-                              maxHeight: "800px",
-                              background: "white",
-                              borderRadius: "12px",
-                              boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
-                              overflow: "hidden",
-                              display: "flex",
-                              flexDirection: "column",
-                            }
+                            position: "fixed",
+                            top: "50%",
+                            left: "50%",
+                            transform: "translate(-50%, -50%)",
+                            zIndex: "1001",
+                            width: "95%",
+                            maxWidth: "1200px",
+                            height: "90%",
+                            maxHeight: "800px",
+                            background: "white",
+                            borderRadius: "12px",
+                            boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
+                            overflow: "hidden",
+                            display: "flex",
+                            flexDirection: "column",
+                          }
                           : {
-                              background: "white",
-                              borderRadius: "8px",
-                              border: "1px solid #e5e7eb",
-                              overflow: "hidden",
-                            }}
+                            background: "white",
+                            borderRadius: "8px",
+                            border: "1px solid #e5e7eb",
+                            overflow: "hidden",
+                          }}
                       >
                         <div
                           style={computed(() => ({
@@ -938,10 +950,17 @@ const Record = pattern<RecordInput, RecordOutput>(
                               )}
                               <button
                                 type="button"
-                                onClick={toggleExpanded({ expandedIndex, index })}
+                                onClick={toggleExpanded({
+                                  expandedIndex,
+                                  index,
+                                })}
                                 style={{
-                                  background: isExpanded ? "#3b82f6" : "transparent",
-                                  border: isExpanded ? "1px solid #3b82f6" : "1px solid #e5e7eb",
+                                  background: isExpanded
+                                    ? "#3b82f6"
+                                    : "transparent",
+                                  border: isExpanded
+                                    ? "1px solid #3b82f6"
+                                    : "1px solid #e5e7eb",
                                   borderRadius: "4px",
                                   cursor: "pointer",
                                   padding: "4px 8px",
@@ -1018,28 +1037,29 @@ const Record = pattern<RecordInput, RecordOutput>(
                         <div
                           style={isExpanded
                             ? {
-                                position: "fixed",
-                                top: "50%",
-                                left: "50%",
-                                transform: "translate(-50%, -50%)",
-                                zIndex: "1001",
-                                width: "95%",
-                                maxWidth: "1200px",
-                                height: "90%",
-                                maxHeight: "800px",
-                                background: "white",
-                                borderRadius: "12px",
-                                boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
-                                overflow: "hidden",
-                                display: "flex",
-                                flexDirection: "column",
-                              }
+                              position: "fixed",
+                              top: "50%",
+                              left: "50%",
+                              transform: "translate(-50%, -50%)",
+                              zIndex: "1001",
+                              width: "95%",
+                              maxWidth: "1200px",
+                              height: "90%",
+                              maxHeight: "800px",
+                              background: "white",
+                              borderRadius: "12px",
+                              boxShadow:
+                                "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
+                              overflow: "hidden",
+                              display: "flex",
+                              flexDirection: "column",
+                            }
                             : {
-                                background: "white",
-                                borderRadius: "8px",
-                                border: "1px solid #e5e7eb",
-                                overflow: "hidden",
-                              }}
+                              background: "white",
+                              borderRadius: "8px",
+                              border: "1px solid #e5e7eb",
+                              overflow: "hidden",
+                            }}
                         >
                           <div
                             style={computed(() => ({
@@ -1179,10 +1199,17 @@ const Record = pattern<RecordInput, RecordOutput>(
                                 )}
                                 <button
                                   type="button"
-                                  onClick={toggleExpanded({ expandedIndex, index })}
+                                  onClick={toggleExpanded({
+                                    expandedIndex,
+                                    index,
+                                  })}
                                   style={{
-                                    background: isExpanded ? "#3b82f6" : "transparent",
-                                    border: isExpanded ? "1px solid #3b82f6" : "1px solid #e5e7eb",
+                                    background: isExpanded
+                                      ? "#3b82f6"
+                                      : "transparent",
+                                    border: isExpanded
+                                      ? "1px solid #3b82f6"
+                                      : "1px solid #e5e7eb",
                                     borderRadius: "4px",
                                     cursor: "pointer",
                                     padding: "4px 8px",
@@ -1259,28 +1286,28 @@ const Record = pattern<RecordInput, RecordOutput>(
                     <div
                       style={isExpanded
                         ? {
-                            position: "fixed",
-                            top: "50%",
-                            left: "50%",
-                            transform: "translate(-50%, -50%)",
-                            zIndex: "1001",
-                            width: "95%",
-                            maxWidth: "1200px",
-                            height: "90%",
-                            maxHeight: "800px",
-                            background: "white",
-                            borderRadius: "12px",
-                            boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
-                            overflow: "hidden",
-                            display: "flex",
-                            flexDirection: "column",
-                          }
+                          position: "fixed",
+                          top: "50%",
+                          left: "50%",
+                          transform: "translate(-50%, -50%)",
+                          zIndex: "1001",
+                          width: "95%",
+                          maxWidth: "1200px",
+                          height: "90%",
+                          maxHeight: "800px",
+                          background: "white",
+                          borderRadius: "12px",
+                          boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
+                          overflow: "hidden",
+                          display: "flex",
+                          flexDirection: "column",
+                        }
                         : {
-                            background: "white",
-                            borderRadius: "8px",
-                            border: "1px solid #e5e7eb",
-                            overflow: "hidden",
-                          }}
+                          background: "white",
+                          borderRadius: "8px",
+                          border: "1px solid #e5e7eb",
+                          overflow: "hidden",
+                        }}
                     >
                       <div
                         style={computed(() => ({
@@ -1419,8 +1446,12 @@ const Record = pattern<RecordInput, RecordOutput>(
                               type="button"
                               onClick={toggleExpanded({ expandedIndex, index })}
                               style={{
-                                background: isExpanded ? "#3b82f6" : "transparent",
-                                border: isExpanded ? "1px solid #3b82f6" : "1px solid #e5e7eb",
+                                background: isExpanded
+                                  ? "#3b82f6"
+                                  : "transparent",
+                                border: isExpanded
+                                  ? "1px solid #3b82f6"
+                                  : "1px solid #e5e7eb",
                                 borderRadius: "4px",
                                 cursor: "pointer",
                                 padding: "4px 8px",
@@ -1804,11 +1835,13 @@ const Record = pattern<RecordInput, RecordOutput>(
             null,
           )}
 
-          {/*
-           * Expanded (Maximize) Module Overlay
-           * Just provides backdrop + escape handler.
-           * Module card itself becomes position:fixed when expanded.
-           */}
+          {
+            /*
+             * Expanded (Maximize) Module Overlay
+             * Just provides backdrop + escape handler.
+             * Module card itself becomes position:fixed when expanded.
+             */
+          }
           {ifElse(
             hasExpandedModule,
             <div>


### PR DESCRIPTION
## Summary

- Add maximize/expand feature to Record modules - click ⛶ to show module in full-screen centered modal overlay
- Close via ✕ button, Escape key, or clicking the backdrop
- Hide action buttons (note, pin, remove) when maximized to avoid confusion with the close button
- Fix stale index bug: adjust expandedIndex when modules are deleted to prevent wrong module being shown

## Implementation Details

- Uses index-based state tracking (`expandedIndex: Cell<number | undefined>`) for simplicity and robustness
- Pre-computes `isExpanded` in `entriesWithIndex` via `lift()` to avoid closure issues in `.map()` callbacks
- Backdrop blur with z-index layering (1000 backdrop, 1001 modal)
- Only one module can be expanded at a time

## Test plan

- [x] Click maximize button → module expands to modal
- [x] Click close button → modal closes
- [x] Press Escape → modal closes  
- [x] Click backdrop → modal closes
- [x] Only close button visible when maximized (note/pin/remove hidden)
- [x] Delete a module while another is expanded → correct module stays expanded
- [x] Deployment works after merge from main

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a maximize mode to Record modules so users can view a module in a focused overlay and close it via Escape, backdrop, or a close button. Refactors handlers to index-based state and fixes stale index issues when deleting modules. Aligns with CT-1137 by scoping the overlay to the Record charm.

- **New Features**
  - Maximize button (⛶) opens the module in a centered overlay with a blurred backdrop; only one module can be expanded.
  - When maximized, hide note, pin, and remove buttons; show a single close toggle (⛶ ↔ ✕).

- **Bug Fixes**
  - Adjust expandedIndex on delete to avoid showing the wrong module or invalid indices.
  - Switch pin/collapse/note/trash/restore/delete handlers to index-based lookups for stable behavior and to avoid Cell.equals errors.
  - Backdrop visibility and Escape key handling reliably close the overlay.

<sup>Written for commit a8e97359a352c83c4c8b63357e5d453c140b9b24. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



