### PR TITLE
fix(shell): Use absolute path for worker.js to fix console error

### DIFF
--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -32,4 +32,4 @@ if (ENVIRONMENT !== "production") {
 await app.initializeKeys();
 
 const _navigation = new Navigation(app);
-(globalThis as any).worker = new Worker("./scripts/worker.js");
+(globalThis as any).worker = new Worker("/scripts/worker.js");


### PR DESCRIPTION
## Summary

- Fixes the remaining "Unexpected token '<'" console error that persisted after #2353

## Problem

The worker script was loaded with a relative path `./scripts/worker.js`, which resolves based on the current page URL. When the shell is at a nested route like `/common-knowledge/abc123`, the path resolved to `/common-knowledge/scripts/worker.js`. This path doesn't match any static file, so the server's SPA fallback returned `index.html` instead. The browser then failed to parse HTML as JavaScript:

```
Uncaught SyntaxError: Unexpected token '<'
scripts/worker.js:1
```

## Solution

Changed the Worker path from relative to absolute:
```diff
-(globalThis as any).worker = new Worker("./scripts/worker.js");
+(globalThis as any).worker = new Worker("/scripts/worker.js");
```

## Context

This is a follow-up to #2353 which fixed similar "Unexpected token '<'" errors in other places but missed this one. The worker was added in #2246 as a "dummy worker script for testing multi-entry build" and is currently unused - it's just instantiated and stored on `globalThis.worker`. Consider removing it entirely if there are no plans to use it.

## Test plan

- [x] Load shell at nested route (e.g., `/common-knowledge/test-charm`)
- [x] Verify no "Unexpected token '<'" errors in console
- [x] Verify "Worker initialized" appears in console logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Unexpected token '<'" console error by loading the worker with an absolute path. Switching from ./scripts/worker.js to /scripts/worker.js ensures it resolves correctly on nested routes and avoids the SPA fallback returning index.html.

<sup>Written for commit 37ddfb721c851abf45a29206cdc37bfaf0df46be. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

