### PR TITLE
Revert: perf(memory): optimize SHA-256 hashing and remove intern()

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -116,7 +116,6 @@
     "@std/http": "jsr:@std/http@^1",
     "@std/path": "jsr:@std/path@^1",
     "@std/testing": "jsr:@std/testing@^1",
-    "hash-wasm": "npm:hash-wasm@^4.11.0",
     "lit": "npm:lit@^3.3.0",
     "merkle-reference": "npm:merkle-reference@^2.2.0",
     "multiformats": "npm:multiformats@^13.3.2",

--- a/deno.lock
+++ b/deno.lock
@@ -89,7 +89,7 @@
     "npm:@opentelemetry/core@^1.19.0": "1.30.1_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/exporter-trace-otlp-proto@0.46": "0.46.0_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/resources@^1.19.0": "1.30.1_@opentelemetry+api@1.9.0",
-    "npm:@opentelemetry/sdk-trace-base@^1.19.0": "1.19.0_@opentelemetry+api@1.9.0",
+    "npm:@opentelemetry/sdk-trace-base@^1.19.0": "1.30.1_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/semantic-conventions@^1.19.0": "1.38.0",
     "npm:@scalar/hono-api-reference@~0.5.165": "0.5.184_hono@4.10.5",
     "npm:@scure/bip39@^1.5.4": "1.6.0",
@@ -102,7 +102,6 @@
     "npm:domhandler@*": "5.0.3",
     "npm:esbuild@~0.25.5": "0.25.12",
     "npm:gcp-metadata@6.1.0": "6.1.0",
-    "npm:hash-wasm@^4.11.0": "4.12.0",
     "npm:hono-pino@0.7": "0.7.2_hono@4.10.5_pino@9.14.0",
     "npm:hono@^4.7.0": "4.10.5",
     "npm:htmlparser2@*": "10.0.0",
@@ -871,7 +870,7 @@
         "@opentelemetry/otlp-proto-exporter-base",
         "@opentelemetry/otlp-transformer",
         "@opentelemetry/resources@1.19.0_@opentelemetry+api@1.9.0",
-        "@opentelemetry/sdk-trace-base"
+        "@opentelemetry/sdk-trace-base@1.19.0_@opentelemetry+api@1.9.0"
       ]
     },
     "@opentelemetry/otlp-exporter-base@0.46.0_@opentelemetry+api@1.9.0": {
@@ -900,7 +899,7 @@
         "@opentelemetry/resources@1.19.0_@opentelemetry+api@1.9.0",
         "@opentelemetry/sdk-logs",
         "@opentelemetry/sdk-metrics",
-        "@opentelemetry/sdk-trace-base"
+        "@opentelemetry/sdk-trace-base@1.19.0_@opentelemetry+api@1.9.0"
       ]
     },
     "@opentelemetry/resources@1.19.0_@opentelemetry+api@1.9.0": {
@@ -944,6 +943,15 @@
         "@opentelemetry/core@1.19.0_@opentelemetry+api@1.9.0",
         "@opentelemetry/resources@1.19.0_@opentelemetry+api@1.9.0",
         "@opentelemetry/semantic-conventions@1.19.0"
+      ]
+    },
+    "@opentelemetry/sdk-trace-base@1.30.1_@opentelemetry+api@1.9.0": {
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@opentelemetry/core@1.30.1_@opentelemetry+api@1.9.0",
+        "@opentelemetry/resources@1.30.1_@opentelemetry+api@1.9.0",
+        "@opentelemetry/semantic-conventions@1.28.0"
       ]
     },
     "@opentelemetry/semantic-conventions@1.19.0": {
@@ -1054,10 +1062,16 @@
     "@standard-schema/spec@1.0.0": {
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
     },
+    "@types/node@24.10.1": {
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "dependencies": [
+        "undici-types@7.16.0"
+      ]
+    },
     "@types/node@24.2.0": {
       "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
       "dependencies": [
-        "undici-types"
+        "undici-types@7.10.0"
       ]
     },
     "@types/trusted-types@2.0.7": {
@@ -1375,9 +1389,6 @@
         "has-symbols"
       ]
     },
-    "hash-wasm@4.12.0": {
-      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ=="
-    },
     "hasown@2.0.2": {
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": [
@@ -1618,7 +1629,7 @@
         "@protobufjs/path",
         "@protobufjs/pool",
         "@protobufjs/utf8",
-        "@types/node",
+        "@types/node@24.10.1",
         "long"
       ],
       "scripts": true
@@ -1721,6 +1732,9 @@
     "undici-types@7.10.0": {
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
     },
+    "undici-types@7.16.0": {
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
+    },
     "uuid@9.0.1": {
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "bin": true
@@ -1776,7 +1790,6 @@
       "jsr:@std/http@1",
       "jsr:@std/path@1",
       "jsr:@std/testing@1",
-      "npm:hash-wasm@^4.11.0",
       "npm:lit@^3.3.0",
       "npm:merkle-reference@^2.2.0",
       "npm:multiformats@^13.3.2",

--- a/packages/memory/HASHING.md
+++ b/packages/memory/HASHING.md
@@ -1,0 +1,564 @@
+# Merkle Hashing Performance in Memory Package
+
+This document describes the performance optimizations made to merkle hashing in
+the memory package, what we learned, and decisions made along the way.
+
+## Executive Summary
+
+For a typical `setFact` operation with a 16KB payload:
+
+- Total time: ~664µs
+- ~71% spent in `refer()` calls (~470µs)
+- Of that, **only ~10% is actual SHA-256 hashing**
+- **90% of refer() time is structural overhead** (sorting, traversal,
+  allocations)
+
+## Background
+
+The memory package uses `merkle-reference` to compute content-addressable hashes
+for facts. Every `set`, `update`, and `retract` operation requires computing
+merkle hashes for assertions, transactions, and payloads.
+
+Initial profiling showed that hashing was a significant bottleneck, with
+`refer()` calls dominating transaction time despite SQLite being very fast
+(~20µs for 16KB inserts).
+
+## How merkle-reference Works Internally
+
+The library computes content-addressed hashes via:
+
+```
+refer(source) → toTree(source) → digest(tree) → Reference
+```
+
+### Algorithm Steps
+
+1. **toTree()**: Recursively converts JS objects to a tree structure
+   - WeakMap lookup per node (cache check)
+   - Type dispatch (object, array, string, number, etc.)
+   - For objects: UTF-8 encode all keys, sort alphabetically, encode each value
+
+2. **digest()**: Computes hash of tree
+   - WeakMap lookup per node (cache check)
+   - Leaf nodes: hash directly
+   - Branch nodes: collect child digests, fold into binary tree
+
+3. **fold()**: Combines digests via binary tree reduction
+   - Pairs of digests hashed together
+   - Repeated until single root hash
+
+### Object Encoding (The Expensive Part)
+
+```javascript
+// From merkle-reference map.js
+for (const [name, value] of entries) {
+  const key = builder.toTree(name);
+  const order = typeof name === "string"
+    ? String.toUTF8(name) // UTF-8 encode for sorting
+    : builder.digest(key);
+
+  attributes.push({ order, key, value: builder.toTree(value) });
+}
+
+// EXPENSIVE: Sort all attributes by byte comparison
+return attributes.sort((left, right) => compare(left.order, right.order));
+```
+
+**Key insight**: Every object requires UTF-8 encoding all keys + sorting them.
+This is required for deterministic merkle tree construction across different
+systems, but it's expensive.
+
+## Time Breakdown: Where Does refer() Time Go?
+
+For a 16KB payload taking ~190µs:
+
+| Operation                  | Time    | %   | Notes                          |
+| -------------------------- | ------- | --- | ------------------------------ |
+| Actual SHA-256 hashing     | 10-20µs | 10% | Native crypto on ~16KB         |
+| Key sorting (objects)      | 40-50µs | 25% | UTF-8 encode + byte comparison |
+| Object traversal + WeakMap | 30-40µs | 20% | ~2µs per node × ~15-20 nodes   |
+| UTF-8 encoding overhead    | 20-30µs | 15% | TextEncoder on string keys     |
+| Tree node allocations      | 30-40µs | 20% | Arrays for branches            |
+| Fold operation             | 20-30µs | 10% | Binary tree reduction          |
+
+**Key finding**: Only ~10% of time is actual hashing. The other ~90% is
+structural overhead required for deterministic merkle tree construction.
+
+## Why Nested Transaction Schema is Expensive
+
+### Current Changes Structure (4 levels deep)
+
+```typescript
+{
+  changes: {
+    [of]: {                    // Level 1: entity URI
+      [the]: {                 // Level 2: MIME type
+        [cause]: {             // Level 3: cause reference
+          is: { /* payload */ } // Level 4: actual data
+        }
+      }
+    }
+  }
+}
+```
+
+### Full Transaction Tree (~7 nested objects)
+
+```
+Transaction (8 keys) → args (1 key) → changes (1 key) → entity (1 key)
+  → mime (1 key) → cause (1 key) → is (payload with ~5 keys)
+```
+
+### Cost Per Object Level
+
+Each nested object requires:
+
+- WeakMap lookup (nodes): ~2µs
+- WeakMap lookup (digests): ~2µs
+- Sort operation: ~5-10µs (small), ~20-40µs (many keys)
+- Array allocations: ~2-5µs
+
+**Total per level: ~11-19µs**
+
+For 7 nested objects: **~77-133µs just for structure overhead**
+
+## setFact Operation Breakdown (~664µs)
+
+| Component             | Time     | %     |
+| --------------------- | -------- | ----- |
+| refer(user assertion) | ~370µs   | 56%   |
+| refer(commit)         | ~100µs   | 15%   |
+| intern(transaction)   | ~60µs    | 9%    |
+| SQLite (3-4 INSERTs)  | ~60-80µs | 9-12% |
+| JSON.stringify        | ~8µs     | 1%    |
+| Other overhead        | ~30-66µs | 5-10% |
+
+### Why Two swap() Calls Per Transaction?
+
+Each `setFact` triggers two `swap()` calls:
+
+1. **User fact**: The actual assertion (~350-550µs)
+2. **Commit record**: Audit trail containing full transaction (~100-150µs)
+
+The commit record embeds the entire transaction for audit/sync purposes.
+
+## Key Findings
+
+### 1. SHA-256 Implementation Matters
+
+`merkle-reference` uses `@noble/hashes` for SHA-256, which is a pure JavaScript
+implementation. On modern CPUs with SHA-NI (hardware SHA acceleration),
+`node:crypto` is significantly faster for raw hashing operations.
+
+The exact speedup varies by payload size, but native crypto typically provides
+2-10x improvement on the hash computation itself. The gap widens with payload
+size because node:crypto uses native OpenSSL with hardware SHA-NI instructions.
+
+Note: The end-to-end `refer()` time includes more than just hashing (sorting,
+tree traversal, object allocation), so the overall speedup is smaller than the
+raw hash speedup.
+
+**Environment-Specific Behavior**: The memory package uses conditional crypto:
+
+- **Browser environments** (shell): Uses `@noble/hashes` (pure JS, works
+  everywhere)
+- **Server environments** (toolshed, Node.js, Deno): Uses `node:crypto` for
+  hardware-accelerated performance
+
+This is detected at module load time via
+`globalThis.document`/`globalThis.window` and uses dynamic import to avoid
+bundler issues with `node:crypto` in browsers.
+
+### 2. merkle-reference Caches Sub-objects by Identity
+
+`merkle-reference` uses a `WeakMap` internally to cache computed tree nodes and
+digests by object identity. When computing a merkle hash:
+
+1. It recursively traverses the object tree
+2. For each sub-object, it checks its WeakMap cache
+3. If the same object instance was seen before, it reuses the cached digest
+4. Only new/unseen objects require hash computation
+
+This means:
+
+- If you pass the **same object instance** multiple times, subsequent calls are
+  very fast (WeakMap lookup ~300ns)
+- If you pass a **new object with identical content**, it must recompute the
+  full hash (different object identity = cache miss)
+
+This is crucial for our use case: assertions contain a payload (`is` field). If
+the payload object is reused across assertions, merkle-reference can skip
+re-hashing it entirely:
+
+```typescript
+const payload = { content: "..." }; // 16KB
+
+// First assertion - full hash computation for payload + assertion wrapper
+refer({ the: "app/json", of: "doc1", is: payload }); // ~250µs
+
+// Second assertion with SAME payload object - only hash the new wrapper
+// The payload's digest is retrieved from WeakMap cache
+refer({ the: "app/json", of: "doc2", is: payload }); // ~70µs (3.5x faster)
+```
+
+**Cache size:** The cache is automatically bounded by the garbage collector
+because it uses `WeakMap`. When a source object is no longer referenced anywhere
+in your application, its cache entry is automatically collected.
+
+### 3. Order of refer() Calls Matters
+
+In `swap()`, we compute hashes in a specific order to maximize cache hits:
+
+```typescript
+// IMPORTANT: Compute fact hash BEFORE importing datum. When refer() traverses
+// the assertion/retraction, it computes and caches the hash of all sub-objects
+// including the datum (payload). By hashing the fact first, the subsequent
+// refer(datum) call in importDatum() becomes a ~300ns cache hit instead of a
+// ~50-100µs full hash computation.
+const fact = refer(source.assert).toString(); // Caches payload hash
+const datumRef = importDatum(session, is); // Cache hit on payload!
+```
+
+### 4. intern(transaction) is Beneficial
+
+The `intern(transaction)` call (~18µs) provides ~26% speedup on `refer(commit)`:
+
+| Scenario       | refer(commit) | Total |
+| -------------- | ------------- | ----- |
+| Without intern | 116µs         | 146µs |
+| With intern    | 58µs          | 108µs |
+
+**Mechanism**: Interning ensures all nested objects share identity. When
+`refer(assertion)` runs first, it caches all sub-object hashes. When
+`refer(commit)` runs, it hits those caches because the assertion objects inside
+the commit are the exact same instances.
+
+### 5. Tree Builder API
+
+`merkle-reference` exposes `Tree.createBuilder(hashFn)` which allows overriding
+the hash function while preserving the merkle tree structure and caching
+behavior.
+
+```typescript
+import { Tree } from "merkle-reference";
+import { createHash } from "node:crypto";
+
+const nodeSha256 = (payload: Uint8Array): Uint8Array => {
+  return createHash("sha256").update(payload).digest();
+};
+
+const treeBuilder = Tree.createBuilder(nodeSha256);
+treeBuilder.refer(source); // Uses node:crypto, same hash output
+```
+
+**Important:** Hashes are identical regardless of which SHA-256 implementation
+is used. The tree structure and encoding are the same; only the underlying hash
+function differs.
+
+## What Didn't Work
+
+### Small Object Cache for `{the, of}` Patterns
+
+We tried caching `{the, of}` patterns (unclaimed references) using a
+string-keyed Map:
+
+```typescript
+// REMOVED - actually hurt performance
+const unclaimedCache = new Map<string, Reference.View>();
+if (isUnclaimedPattern(source)) {
+  const key = source.the + "\0" + source.of;
+  // ...cache lookup...
+}
+```
+
+This added ~20µs overhead per call due to:
+
+- `Object.keys()` check to detect the pattern
+- String concatenation for cache key
+- Map lookup
+
+merkle-reference's internal WeakMap is faster for repeated access to the same
+object, and for unique objects there's no cache benefit anyway.
+
+**However**: `unclaimedRef()` with a simple Map cache DOES work well because it
+caches the final Reference, not intermediate objects. This saves the entire
+`refer()` call (~29µs) for repeated `{the, of}` combinations.
+
+## Current Implementation
+
+### 1. Conditional crypto hashing (browser vs server)
+
+Use merkle-reference's default `refer()` in browsers (which uses `@noble/hashes`
+internally), upgrade to a custom TreeBuilder with `node:crypto` in server
+environments for hardware acceleration:
+
+```typescript
+import * as Reference from "merkle-reference";
+
+// Default to merkle-reference's built-in refer (uses @noble/hashes)
+let referImpl: <T>(source: T) => Reference.View<T> = Reference.refer;
+
+// In server environments, upgrade to node:crypto for better performance
+const isBrowser = typeof globalThis.document !== "undefined" ||
+  typeof globalThis.window !== "undefined";
+
+if (!isBrowser) {
+  try {
+    // Dynamic import avoids bundler resolution in browsers
+    const nodeCrypto = await import("node:crypto");
+    const nodeSha256 = (payload: Uint8Array): Uint8Array => {
+      return nodeCrypto.createHash("sha256").update(payload).digest();
+    };
+    const treeBuilder = Reference.Tree.createBuilder(nodeSha256);
+    referImpl = <T>(source: T): Reference.View<T> => {
+      return treeBuilder.refer(source) as unknown as Reference.View<T>;
+    };
+  } catch {
+    // node:crypto not available, use merkle-reference's default
+  }
+}
+
+export const refer = <T>(source: T): Reference.View<T> => {
+  return referImpl(source);
+};
+```
+
+**Key design points:**
+
+- Browser: Uses `Reference.refer()` directly (merkle-reference uses
+  @noble/hashes)
+- Server: Creates custom TreeBuilder with `node:crypto` for ~1.5-2x speedup
+- Dynamic import (`await import()`) prevents bundlers from resolving
+  `node:crypto`
+- Environment detection via `globalThis.document`/`globalThis.window`
+
+### 2. Recursive object interning
+
+To enable cache hits on identical content (not just identical object instances),
+we intern objects recursively with a strong LRU cache:
+
+```typescript
+const INTERN_CACHE_MAX_SIZE = 10000;
+const internCache = new Map<string, object>();
+const internedObjects = new WeakSet<object>();
+
+export const intern = <T>(source: T): T => {
+  if (source === null || typeof source !== "object") return source;
+  if (internedObjects.has(source)) return source; // Fast path
+
+  // Recursively intern nested objects first
+  const internedObj = Array.isArray(source)
+    ? source.map((item) => intern(item))
+    : Object.fromEntries(
+      Object.entries(source).map(([k, v]) => [k, intern(v)]),
+    );
+
+  const key = JSON.stringify(internedObj);
+  const cached = internCache.get(key);
+  if (cached) return cached as T;
+
+  // LRU eviction
+  if (internCache.size >= INTERN_CACHE_MAX_SIZE) {
+    const firstKey = internCache.keys().next().value;
+    if (firstKey) internCache.delete(firstKey);
+  }
+
+  internCache.set(key, internedObj);
+  internedObjects.add(internedObj);
+  return internedObj as T;
+};
+```
+
+### 3. unclaimedRef() caching
+
+For the common `{the, of}` pattern (unclaimed facts), we cache the entire
+Reference to avoid repeated `refer()` calls:
+
+```typescript
+const unclaimedRefCache = new Map<string, Reference<Unclaimed>>();
+
+export const unclaimedRef = (
+  { the, of }: { the: MIME; of: URI },
+): Reference<Unclaimed> => {
+  const key = `${the}|${of}`;
+  let ref = unclaimedRefCache.get(key);
+  if (!ref) {
+    ref = refer(unclaimed({ the, of }));
+    unclaimedRefCache.set(key, ref);
+  }
+  return ref;
+};
+```
+
+## Optimization Opportunities
+
+### Immediate Wins (No Breaking Changes)
+
+#### 1. Use Shared Empty Arrays (~5-10µs savings)
+
+```typescript
+// Before
+prf: []; // New array each time
+
+// After
+const EMPTY_ARRAY = Object.freeze([]);
+prf: EMPTY_ARRAY; // Reuse, enables WeakMap cache hits
+```
+
+### Medium-Term (Requires Library Support)
+
+#### 2. Pre-sort Transaction Keys (~20-30µs potential)
+
+If merkle-reference detected pre-sorted keys, we could skip sorting:
+
+```typescript
+// Keys in alphabetical order
+return {
+  args: { changes }, // 'a' comes first
+  cmd: "/memory/transact",
+  exp: iat + ttl,
+  iat,
+  iss: issuer,
+  prf: EMPTY_ARRAY,
+  sub: subject,
+};
+```
+
+**Note**: Currently merkle-reference doesn't detect this, so no benefit yet.
+
+#### 3. Library Optimizations (Upstream Contributions)
+
+- Skip sorting for single-key objects
+- Cache UTF-8 encoded keys for common strings
+- Detect pre-sorted keys
+
+### Long-Term (Breaking Changes)
+
+#### 4. Flatten Changes Structure (~50-70µs savings, 26-37% faster)
+
+**Current** (4 levels):
+
+```typescript
+{ [of]: { [the]: { [cause]: { is } } } }
+```
+
+**Proposed** (flat array):
+
+```typescript
+[ { of, the, cause, is }, { of, the, cause, is }, ... ]
+```
+
+**Benefits**:
+
+- Eliminates 2 object traversals (~40µs)
+- Arrays don't require key sorting (~20-30µs)
+- Simpler tree = fewer allocations (~10µs)
+
+**Tradeoffs**:
+
+- Breaking change to transaction format
+- Larger serialized size (repeated keys)
+- Less convenient for lookups
+
+#### 5. Skip Commit Records for Single-Fact Transactions (~100-150µs savings)
+
+Currently every transaction writes a commit record for audit trail. For
+single-fact transactions, this could be optional.
+
+**Tradeoff**: Loses transaction-level audit trail.
+
+## Realistic Expectations
+
+| Optimization Level     | Expected Time | Improvement |
+| ---------------------- | ------------- | ----------- |
+| Current                | 664µs         | baseline    |
+| With immediate wins    | ~640µs        | 4%          |
+| With all non-breaking  | ~600µs        | 10%         |
+| With flattened Changes | ~540µs        | 19%         |
+| With skip commit       | ~440µs        | 34%         |
+
+**Fundamental floor**: Object traversal + deterministic ordering will always
+consume ~100-120µs for nested structures. This is inherent to
+content-addressing.
+
+## Performance Results
+
+### Core Operations (16KB payloads)
+
+| Operation         | Time   | Throughput |
+| ----------------- | ------ | ---------- |
+| get fact (single) | ~65µs  | 15,000/s   |
+| set fact (single) | ~664µs | 1,500/s    |
+| update fact       | ~756µs | 1,320/s    |
+| retract fact      | ~436µs | 2,300/s    |
+
+### Component Breakdown
+
+| Component                | Time    | Notes                      |
+| ------------------------ | ------- | -------------------------- |
+| Raw SQLite INSERT        | 20-35µs | Hardware floor             |
+| JSON.stringify 16KB      | ~8µs    |                            |
+| refer() on 16KB          | ~190µs  | Payload only               |
+| refer() on assertion     | ~470µs  | Includes 16KB payload      |
+| refer() small object     | ~34µs   | {the, of} pattern          |
+| unclaimedRef() cache hit | ~0.4µs  | Returns cached Reference   |
+| intern() cache hit       | <1µs    | Returns canonical instance |
+
+## Benchmarks Reference
+
+Run benchmarks with:
+
+```bash
+deno task bench
+```
+
+Key isolation benchmarks to watch:
+
+- `refer() on 16KB payload (isolation)`: ~190µs
+- `refer() on assertion (16KB is + metadata)`: ~470µs
+- `memoized: 3x refer() same payload (cache hits)`: ~24µs
+- `refer() small {the, of} - with intern (cache hit)`: ~0.4µs
+
+## Architecture Notes
+
+### Why Content-Addressing?
+
+merkle-reference provides:
+
+- Deduplication (same content = same hash)
+- Integrity verification
+- Distributed sync compatibility
+- Deterministic references
+
+**Cannot be eliminated** without breaking the architecture.
+
+### Deterministic Ordering Requirement
+
+For merkle trees to produce consistent hashes across different systems, object
+keys must be sorted deterministically. This is why:
+
+- Every object incurs sorting cost
+- UTF-8 encoding needed for byte-comparison
+- This overhead is fundamental to the approach
+
+## Current Optimizations Applied
+
+1. **Conditional crypto** (node:crypto in server, @noble/hashes in browser):
+   ~1.5-2x speedup on hashing in server environments, while maintaining browser
+   compatibility
+2. **Recursive object interning**: ~2.5x on shared content
+3. **Prepared statement caching**: ~2x on queries
+4. **Batch label lookups**: Eliminated N queries
+5. **Fact hash ordering**: Payload hash reused from assertion traversal
+6. **Stored fact hashes**: Avoid recomputing in conflict detection
+7. **unclaimedRef() caching**: ~62x faster for repeated {the, of} patterns
+8. **intern(transaction)**: ~26% faster commits via cache hits
+
+## Files Reference
+
+- `reference.ts`: TreeBuilder with conditional crypto (noble/node:crypto),
+  intern() function
+- `fact.ts`: Fact.assert(), unclaimedRef() caching
+- `space.ts`: swap(), commit(), transact() - core write path
+- `transaction.ts`: Transaction structure definition
+- `changes.ts`: Changes structure (candidate for flattening)

--- a/packages/memory/fact.ts
+++ b/packages/memory/fact.ts
@@ -12,22 +12,44 @@ import {
   Unclaimed,
 } from "./interface.ts";
 import * as Ref from "./reference.ts";
-import { fromJSON, fromString, is as isReference, refer } from "./reference.ts";
+import {
+  fromJSON,
+  fromString,
+  intern,
+  is as isReference,
+  refer,
+} from "./reference.ts";
 
 /**
  * Creates an unclaimed fact.
+ * Interned so repeated {the, of} patterns share identity for cache hits.
  */
 export const unclaimed = (
   { the, of }: { the: MIME; of: URI },
-): Unclaimed => ({ the, of });
+): Unclaimed => intern({ the, of });
+
+/**
+ * Cache for unclaimed references.
+ * Caches the refer() result so repeated calls with same {the, of} are O(1).
+ * This saves ~29µs per call (refer cost on small objects).
+ */
+const unclaimedRefCache = new Map<string, Ref.View<Unclaimed>>();
 
 /**
  * Returns a cached merkle reference to an unclaimed fact.
- * Caching is handled by refer() for {the, of} patterns.
+ * Use this instead of `refer(unclaimed({the, of}))` for better performance.
  */
 export const unclaimedRef = (
   { the, of }: { the: MIME; of: URI },
-): Ref.View<Unclaimed> => refer({ the, of });
+): Ref.View<Unclaimed> => {
+  const key = `${the}|${of}`;
+  let ref = unclaimedRefCache.get(key);
+  if (!ref) {
+    ref = refer(unclaimed({ the, of }));
+    unclaimedRefCache.set(key, ref);
+  }
+  return ref;
+};
 
 export const assert = <Is extends JSONValue, T extends MIME, Of extends URI>({
   the,
@@ -43,7 +65,8 @@ export const assert = <Is extends JSONValue, T extends MIME, Of extends URI>({
   ({
     the,
     of,
-    is,
+    // Intern the payload so identical content shares identity for cache hits
+    is: intern(is),
     cause: isReference(cause)
       ? cause
       : cause == null
@@ -52,7 +75,7 @@ export const assert = <Is extends JSONValue, T extends MIME, Of extends URI>({
         the: cause.the,
         of: cause.of,
         cause: cause.cause,
-        ...(cause.is ? { is: cause.is } : undefined),
+        ...(cause.is ? { is: intern(cause.is) } : undefined),
       }),
   }) as Assertion<T, Of, Is>;
 
@@ -159,13 +182,13 @@ export function normalizeFact<
       the: arg.cause.the,
       of: arg.cause.of,
       cause: arg.cause.cause,
-      ...(arg.cause.is ? { is: arg.cause.is } : undefined),
+      ...(arg.cause.is ? { is: intern(arg.cause.is) } : undefined),
     });
   if (arg.is !== undefined) {
     return ({
       the: arg.the,
       of: arg.of,
-      is: arg.is,
+      is: intern(arg.is),
       cause: newCause,
     }) as Assertion<T, Of, Is>;
   } else {

--- a/packages/memory/reference.ts
+++ b/packages/memory/reference.ts
@@ -1,14 +1,6 @@
 import * as Reference from "merkle-reference";
 import { isDeno } from "@commontools/utils/env";
-import { createSHA256, type IHasher } from "hash-wasm";
 export * from "merkle-reference";
-
-/**
- * Which SHA-256 implementation is currently in use.
- */
-export type HashImplementation = "node:crypto" | "hash-wasm" | "noble";
-
-let activeHashImpl: HashImplementation = "noble";
 
 // Don't know why deno does not seem to see there is a `fromString` so we just
 // workaround it like this.
@@ -17,19 +9,18 @@ export const fromString = Reference.fromString as (
 ) => Reference.View;
 
 /**
- * Internal refer implementation - set based on environment.
+ * Refer function - uses merkle-reference's default in browsers (@noble/hashes),
+ * upgrades to node:crypto in server environments for ~1.5-2x speedup.
  *
- * Priority:
- * 1. Server (Deno): node:crypto - hardware accelerated via OpenSSL
- * 2. Browser: hash-wasm - WASM SHA-256, ~3x faster than pure JS
- * 3. Fallback: merkle-reference default (@noble/hashes)
+ * Browser environments use merkle-reference's default (pure JS, works everywhere).
+ * Server environments (Node.js, Deno) use node:crypto when available.
  */
 let referImpl: <T>(source: T) => Reference.View<T> = Reference.refer;
 
-// Initialize hash implementation based on environment
+// In Deno, try to use node:crypto for better performance
 if (isDeno()) {
-  // Server: use node:crypto for hardware acceleration
   try {
+    // Dynamic import to avoid bundler resolution in browsers
     const nodeCrypto = await import("node:crypto");
     const nodeSha256 = (payload: Uint8Array): Uint8Array => {
       return nodeCrypto.createHash("sha256").update(payload).digest();
@@ -38,93 +29,113 @@ if (isDeno()) {
     referImpl = <T>(source: T): Reference.View<T> => {
       return treeBuilder.refer(source) as unknown as Reference.View<T>;
     };
-    activeHashImpl = "node:crypto";
   } catch {
     // node:crypto not available, use merkle-reference's default
-  }
-} else {
-  // Browser: use hash-wasm (WASM SHA-256, ~3x faster than @noble/hashes)
-  try {
-    const hasher: IHasher = await createSHA256();
-    // Note: This hash function is synchronous (no awaits between init/update/digest).
-    // In JS's single-threaded model, synchronous code runs to completion without
-    // interruption, so the shared hasher instance is safe from interleaving.
-    const wasmSha256 = (payload: Uint8Array): Uint8Array => {
-      hasher.init();
-      hasher.update(payload);
-      return hasher.digest("binary");
-    };
-    const treeBuilder = Reference.Tree.createBuilder(wasmSha256);
-    referImpl = <T>(source: T): Reference.View<T> => {
-      return treeBuilder.refer(source) as unknown as Reference.View<T>;
-    };
-    activeHashImpl = "hash-wasm";
-  } catch {
-    // hash-wasm failed, keep merkle-reference's default (@noble/hashes)
   }
 }
 
 /**
- * Cache for {the, of} references (unclaimed facts).
- * These patterns repeat constantly in claims, so caching avoids redundant hashing.
- * Bounded with LRU eviction to prevent unbounded memory growth.
+ * Object interning cache: maps JSON content to a canonical object instance.
+ * Uses strong references with LRU eviction to ensure cache hits.
+ *
+ * Previously used WeakRef, but this caused cache misses because GC would
+ * collect interned objects between calls when no strong reference held them.
+ * This prevented merkle-reference's WeakMap from getting cache hits.
+ *
+ * With strong references + LRU eviction, interned objects stay alive long
+ * enough for refer() to benefit from merkle-reference's identity-based cache.
  */
-const UNCLAIMED_CACHE_MAX_SIZE = 50_000; // ~50KB overhead (small string keys + refs)
-const unclaimedCache = new Map<string, Reference.View<unknown>>();
+const INTERN_CACHE_MAX_SIZE = 10000;
+const internCache = new Map<string, object>();
 
 /**
- * Check if source is exactly {the, of} with string values and no other keys.
+ * WeakSet to track objects that are already interned (canonical instances).
+ * This allows O(1) early return for already-interned objects.
  */
-const isUnclaimed = (
-  source: unknown,
-): source is { the: string; of: string } => {
-  if (source === null || typeof source !== "object" || Array.isArray(source)) {
-    return false;
+const internedObjects = new WeakSet<object>();
+
+/**
+ * Recursively intern an object and all its nested objects.
+ * Returns a new object where all sub-objects are canonical instances,
+ * enabling merkle-reference's WeakMap cache to hit on shared sub-content.
+ *
+ * Example:
+ *   const obj1 = intern({ id: "uuid-1", content: { large: "data" } });
+ *   const obj2 = intern({ id: "uuid-2", content: { large: "data" } });
+ *   // obj1.content === obj2.content (same object instance)
+ *   // refer(obj1) then refer(obj2) will cache-hit on content
+ */
+export const intern = <T>(source: T): T => {
+  // Only intern objects (not primitives)
+  if (source === null || typeof source !== "object") {
+    return source;
   }
-  const keys = Object.keys(source);
-  if (keys.length !== 2) return false;
-  const obj = source as Record<string, unknown>;
-  return typeof obj.the === "string" && typeof obj.of === "string";
+
+  // Fast path: if this object is already interned, return it immediately
+  if (internedObjects.has(source)) {
+    return source;
+  }
+
+  // Handle arrays
+  if (Array.isArray(source)) {
+    const internedArray = source.map((item) => intern(item));
+    const key = JSON.stringify(internedArray);
+    const cached = internCache.get(key);
+
+    if (cached !== undefined) {
+      // Move to end (most recently used) by re-inserting
+      internCache.delete(key);
+      internCache.set(key, cached);
+      return cached as T;
+    }
+
+    // Evict oldest entry if cache is full
+    if (internCache.size >= INTERN_CACHE_MAX_SIZE) {
+      const oldest = internCache.keys().next().value;
+      if (oldest !== undefined) internCache.delete(oldest);
+    }
+    internCache.set(key, internedArray);
+    internedObjects.add(internedArray);
+    return internedArray as T;
+  }
+
+  // Handle plain objects: recursively intern all values first
+  const internedObj: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(source)) {
+    internedObj[k] = intern(v);
+  }
+
+  const key = JSON.stringify(internedObj);
+  const cached = internCache.get(key);
+
+  if (cached !== undefined) {
+    // Move to end (most recently used) by re-inserting
+    internCache.delete(key);
+    internCache.set(key, cached);
+    return cached as T;
+  }
+
+  // Evict oldest entry if cache is full
+  if (internCache.size >= INTERN_CACHE_MAX_SIZE) {
+    const oldest = internCache.keys().next().value;
+    if (oldest !== undefined) internCache.delete(oldest);
+  }
+  // Store this object as the canonical instance
+  internCache.set(key, internedObj);
+  internedObjects.add(internedObj);
+
+  return internedObj as T;
 };
 
 /**
  * Compute a merkle reference for the given source.
  *
- * For {the, of} objects (unclaimed facts), results are cached since these
- * patterns repeat constantly in claims.
+ * In server environments, uses node:crypto SHA-256 (with hardware acceleration)
+ * for ~1.5-2x speedup. In browsers, uses merkle-reference's default (@noble/hashes).
  *
- * In server environments, uses node:crypto SHA-256 (hardware accelerated).
- * In browsers, uses hash-wasm (WASM, ~3x faster than pure JS).
- * Falls back to @noble/hashes if neither is available.
+ * merkle-reference's internal WeakMap caches sub-objects by identity, so passing
+ * the same payload object to multiple assertions will benefit from caching.
  */
 export const refer = <T>(source: T): Reference.View<T> => {
-  // Cache {the, of} patterns (unclaimed facts)
-  if (isUnclaimed(source)) {
-    // Use null character as delimiter to avoid collisions if the/of contain '|'
-    const key = `${source.the}\0${source.of}`;
-    const cached = unclaimedCache.get(key);
-    if (cached) {
-      // Move to end for LRU behavior
-      unclaimedCache.delete(key);
-      unclaimedCache.set(key, cached);
-      return cached as Reference.View<T>;
-    }
-    const result = referImpl(source);
-    // Evict oldest entry if at capacity
-    if (unclaimedCache.size >= UNCLAIMED_CACHE_MAX_SIZE) {
-      const oldest = unclaimedCache.keys().next().value;
-      if (oldest !== undefined) unclaimedCache.delete(oldest);
-    }
-    unclaimedCache.set(key, result);
-    return result;
-  }
-
   return referImpl(source);
-};
-
-/**
- * Get the currently active SHA-256 implementation.
- */
-export const getHashImplementation = (): HashImplementation => {
-  return activeHashImpl;
 };

--- a/packages/memory/space.ts
+++ b/packages/memory/space.ts
@@ -7,7 +7,7 @@ import {
 
 import { COMMIT_LOG_TYPE, create as createCommit } from "./commit.ts";
 import { unclaimedRef } from "./fact.ts";
-import { fromString, refer } from "./reference.ts";
+import { fromString, intern, refer } from "./reference.ts";
 import { addMemoryAttributes, traceAsync, traceSync } from "./telemetry.ts";
 import type {
   Assert,
@@ -911,14 +911,20 @@ const commit = <Space extends MemorySpace>(
     ]
     : [0, unclaimedRef({ the, of })];
 
+  // Intern the transaction first so that:
+  // 1. createCommit() will reuse this exact transaction object (via WeakSet fast path)
+  // 2. iterateTransaction() uses the same objects that are in commit.is.transaction
+  // 3. When swap() hashes payloads, those same objects are in commit.is.transaction
+  // 4. refer(commit) can cache-hit on all sub-objects
+  const internedTransaction = intern(transaction);
   const commit = createCommit({
     space: of,
     since,
-    transaction,
+    transaction: internedTransaction,
     cause,
   });
 
-  for (const fact of iterateTransaction(transaction)) {
+  for (const fact of iterateTransaction(internedTransaction)) {
     swap(session, fact, commit.is);
   }
 

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -1,4 +1,4 @@
-import { refer } from "@commontools/memory/reference";
+import { refer } from "merkle-reference";
 import { isRecord } from "@commontools/utils/types";
 import { isOpaqueRef } from "./builder/types.ts";
 import {

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -19,7 +19,7 @@ import { UnsafeEvalIsolate, UnsafeEvalRuntime } from "./eval-runtime.ts";
 import { CommonToolsTransformerPipeline } from "@commontools/ts-transformers";
 import * as RuntimeModules from "./runtime-modules.ts";
 import { Runtime } from "../runtime.ts";
-import { refer } from "@commontools/memory/reference";
+import * as merkleReference from "merkle-reference";
 import { StaticCache } from "@commontools/static";
 import { pretransformProgram } from "./pretransform.ts";
 
@@ -247,5 +247,5 @@ function computeId(program: Program): string {
     program.main,
     ...program.files.filter(({ name }) => !name.endsWith(".d.ts")),
   ];
-  return refer(source).toString();
+  return merkleReference.refer(source).toString();
 }

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -1,4 +1,4 @@
-import { fromString, refer } from "@commontools/memory/reference";
+import { fromString, refer } from "merkle-reference";
 import type {
   CauseString,
   Changes as MemoryChanges,

--- a/packages/runner/src/storage/transaction/chronicle.ts
+++ b/packages/runner/src/storage/transaction/chronicle.ts
@@ -29,7 +29,7 @@ import {
   UnsupportedMediaTypeError,
   write,
 } from "./attestation.ts";
-import { refer } from "@commontools/memory/reference";
+import { refer } from "merkle-reference";
 import * as Edit from "./edit.ts";
 
 export const open = (replica: ISpaceReplica) => new Chronicle(replica);

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1,4 +1,4 @@
-import { refer } from "@commontools/memory/reference";
+import { refer } from "merkle-reference";
 import { SchemaAll } from "@commontools/memory/schema";
 // TODO(@ubik2): Ideally this would use the following, but rollup has issues
 //import { isNumber, isObject, isString } from "@commontools/utils/types";

--- a/packages/runner/test/doc-map.test.ts
+++ b/packages/runner/test/doc-map.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createRef, getEntityId } from "../src/create-ref.ts";
-import { refer } from "@commontools/memory/reference";
+import { refer } from "merkle-reference";
 import { Runtime } from "../src/runtime.ts";
 import { Identity } from "@commontools/identity";
 import { StorageManager } from "@commontools/runner/storage/cache.deno";

--- a/packages/toolshed/lib/otel.ts
+++ b/packages/toolshed/lib/otel.ts
@@ -26,17 +26,15 @@ export const provider = new BasicTracerProvider({
     "deployment.environment": env.ENV || "development",
     "openinference.project.name": env.CTTS_AI_LLM_PHOENIX_PROJECT,
   }),
+  spanProcessors: [
+    new OpenInferenceBatchSpanProcessor({
+      exporter: otlpExporter,
+      spanFilter: (span) => {
+        return isOpenInferenceSpan(span);
+      },
+    }),
+  ],
 });
-
-// Add span processor after construction (API changed in newer SDK versions)
-provider.addSpanProcessor(
-  new OpenInferenceBatchSpanProcessor({
-    exporter: otlpExporter,
-    spanFilter: (span) => {
-      return isOpenInferenceSpan(span);
-    },
-  }),
-);
 
 export function getTracerProvider() {
   return _provider;


### PR DESCRIPTION
## Summary

This PR reverts #2356 in case the hash optimization causes issues in production.

**Do not merge unless there are problems with the optimization.**

This is a safety net - if the optimization causes any issues, merge this PR to quickly roll back to the previous behavior.

## What was changed in #2356
- Optimized SHA-256 hashing with streaming and caching
- Removed `intern()` function (profiling showed overhead exceeded benefit)
- Consolidated hash caching

## When to merge this
- If you observe performance regressions
- If you see incorrect hashing behavior
- If there are any production issues related to the memory package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the SHA-256 optimization from #2356 and restores the previous merkle hashing behavior to stabilize memory hashing. Brings back object interning and removes the browser WASM hashing path.

- **Refactors**
  - Restored intern() with a small LRU cache and used it in assert(), unclaimed(), and commit paths for better cache hits.
  - Returned to merkle-reference default hashing in browsers; kept node:crypto in server (Deno) environments; removed hash-wasm usage.
  - Added unclaimedRef() caching to avoid repeated hashing of common {the, of} patterns.
  - Runner now imports refer directly from merkle-reference.
  - Added HASHING.md and new benchmarks to document performance and trade-offs.

- **Dependencies**
  - Removed hash-wasm.
  - Updated OpenTelemetry sdk-trace-base and switched to spanProcessors on provider to match the new SDK API.

<sup>Written for commit 1cee17790b6e3dbd0dcc39483faa31d85b586618. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

