### PR TITLE
perf(patterns): batch push operations in notes patterns

### DIFF
--- a/packages/patterns/notes/notes-import-export.tsx
+++ b/packages/patterns/notes/notes-import-export.tsx
@@ -910,17 +910,19 @@ const duplicateSelectedNotes = handler<
   const selected = selectedIndices.get();
   const notesList = notes.get();
 
+  // Collect copies first, then batch push (reduces N reactive cycles to 1)
+  const copies: NoteCharm[] = [];
   for (const idx of selected) {
     const original = notesList[idx];
     if (original) {
-      const copy = Note({
+      copies.push(Note({
         title: (original.title ?? "Note") + " (Copy)",
         content: original.content ?? "",
         noteId: generateId(),
-      });
-      allCharms.push(copy as unknown as NoteCharm);
+      }) as unknown as NoteCharm);
     }
   }
+  allCharms.push(...copies);
   selectedIndices.set([]);
 });
 
@@ -1205,6 +1207,8 @@ const duplicateSelectedNotebooks = handler<
   const selected = selectedNotebookIndices.get();
   const notebooksList = notebooks.get();
 
+  // Collect copies first, then batch push (reduces N reactive cycles to 1)
+  const copies: NoteCharm[] = [];
   for (const idx of selected) {
     const original = notebooksList[idx];
     if (original) {
@@ -1216,13 +1220,13 @@ const duplicateSelectedNotebooks = handler<
         "",
       );
 
-      const copy = Notebook({
+      copies.push(Notebook({
         title: baseTitle + " (Copy)",
         notes: [...(original?.notes ?? [])], // Shallow copy - reference same notes
-      });
-      allCharms.push(copy as unknown as NoteCharm);
+      }) as unknown as NoteCharm);
     }
   }
+  allCharms.push(...copies);
   selectedNotebookIndices.set([]);
 });
 


### PR DESCRIPTION
## Summary

- Use `allCharms.push(...items)` instead of individual pushes in loops
- Reduces N reactive update cycles to 1, improving performance when duplicating, moving, or creating multiple notes/notebooks
- Reverts ct-modal back to div-based modals in notebook.tsx for compatibility

## Optimized handlers

**notebook.tsx:**
- `duplicateSelectedNotes`
- `addSelectedToNotebook`
- `moveSelectedToNotebook`
- `handleCreateNotes`
- `handleCreateNotebook`

**notes-import-export.tsx:**
- `duplicateSelectedNotes`
- `duplicateSelectedNotebooks`

## Technical details

Each `Cell.push()` call triggers a complete `diffAndUpdate` cycle. By collecting items first and using spread syntax (`push(...items)`), we batch the operation into a single reactive update instead of N updates.

## Test plan

- [ ] Test duplicating multiple notes in a notebook
- [ ] Test adding multiple notes to another notebook
- [ ] Test moving multiple notes between notebooks
- [ ] Test creating multiple notes via LLM handler
- [ ] Test duplicating multiple notebooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch push note/notebook operations to cut reactive updates from N to 1, speeding up duplicate, move, add, and create actions. Also replaced ct-modal with div-based overlays in notebook.tsx for better compatibility.

- **Performance**
  - Use push(...items) in handlers: duplicateSelectedNotes, addSelectedToNotebook, moveSelectedToNotebook, handleCreateNotes, handleCreateNotebook, duplicateSelectedNotebooks.

- **Refactors**
  - Replaced ct-modal components with CSS-based div overlays in notebook.tsx to maintain reactivity and avoid modal compatibility issues.

<sup>Written for commit e665bffb2ac0829cb1587525e9c94e8a6f1fa105. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

