### PR TITLE
feat(record): Add LLM-callable handlers for Omnibot integration

### DIFF
--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -750,6 +750,12 @@ const handleSetTitle = handler<
   { newTitle: string; result?: Cell<unknown> },
   { title: Cell<string> }
 >(({ newTitle, result }, { title }) => {
+  if (newTitle === undefined || newTitle === null) {
+    if (result) {
+      result.set({ success: false, error: "newTitle parameter is required" });
+    }
+    return;
+  }
   title.set(newTitle);
   if (result) result.set({ success: true, title: newTitle });
 });


### PR DESCRIPTION
## Summary

Adds LLM-callable handlers to the Record pattern that Omnibot can invoke to read and modify record data:

- `getSummary` - Returns structured summary of record title and all modules with their data
- `addModule` - Adds a new module by type (email, phone, birthday, etc.)
- `removeModule` - Moves a module to trash by index
- `setTitle` - Updates the record title
- `updateModule` - Updates a field on a specific module
- `listModuleTypes` - Returns available module types that can be added

### Key Implementation Detail

Handlers must use `result.set()` to return data to the LLM - return statements are captured internally but NOT forwarded to Omnibot's invoke() tool. The `result` Cell is injected by `llm-dialog.ts` at runtime.

```typescript
const handleGetSummary = handler<
  { result?: Cell<unknown> },
  { title: Cell<string>; subCharms: Cell<SubCharmEntry[]>; }
>(({ result }, { title, subCharms }) => {
  const summary = { /* ... */ };
  if (result) result.set(summary);  // Required for LLM to receive data
});
```

This follows the pattern documented in the superstition `2025-11-27-llm-handler-tools-must-write-to-result-cell.md`.

## Test plan

- [x] Deployed to test space and tested with Omnibot
- [x] Verified `getSummary` returns full module data
- [x] Verified `setTitle` persists after page refresh
- [x] Verified `addModule` creates modules correctly
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds LLM-callable handlers to the Record pattern so Omnibot can read and modify record data via invoke(), enabling automated record management.

- **New Features**
  - getSummary: Returns title, modules, and schemas.
  - addModule: Creates a module by type with optional initial data.
  - updateModule: Updates a module field by index.
  - removeModule: Moves a module to trash by index.
  - setTitle: Sets the record title.
  - listModuleTypes: Lists addable module types.

- **Migration**
  - Handlers must use result.set() to return data; return statements are ignored.
  - Notes cannot be added via handler; extractor requires parent Cells.

<sup>Written for commit 250a5dd3b1ecf4af0e0918cc2373293df0d57c6b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





