### PR TITLE
feat(patterns): add embeddedUI export to Note pattern

### DIFF
--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -11,6 +11,7 @@ import {
   patternTool,
   Stream,
   UI,
+  type VNode,
   wish,
 } from "commontools";
 
@@ -58,6 +59,8 @@ type Output = {
   grep: Stream<{ query: string }>;
   translate: Stream<{ language: string }>;
   editContent: Stream<{ detail: { value: string } }>;
+  /** Minimal UI for embedding in containers like Record. Use via ct-render variant="embedded". */
+  embeddedUI: VNode;
 };
 
 const _updateTitle = handler<
@@ -362,6 +365,23 @@ const Note = pattern<Input, Output>(({ title, content, isHidden, noteId }) => {
   // The only way to serialize a pattern, apparently?
   const patternJson = computed(() => JSON.stringify(Note));
 
+  // Editor component - used in both full UI and embeddedUI
+  const editorUI = (
+    <ct-code-editor
+      $value={content}
+      $mentionable={mentionable}
+      $mentioned={mentioned}
+      $pattern={patternJson}
+      onbacklink-click={handleCharmLinkClick({})}
+      onbacklink-create={handleNewBacklink({ mentionable })}
+      language="text/markdown"
+      theme="light"
+      wordWrap
+      tabIndent
+      lineNumbers
+    />
+  );
+
   return {
     [NAME]: computed(() => `📝 ${title.get()}`),
     [UI]: (
@@ -641,19 +661,7 @@ const Note = pattern<Input, Output>(({ title, content, isHidden, noteId }) => {
           </ct-hstack>
         </ct-vstack>
 
-        <ct-code-editor
-          $value={content}
-          $mentionable={mentionable}
-          $mentioned={mentioned}
-          $pattern={patternJson}
-          onbacklink-click={handleCharmLinkClick({})}
-          onbacklink-create={handleNewBacklink({ mentionable })}
-          language="text/markdown"
-          theme="light"
-          wordWrap
-          tabIndent
-          lineNumbers
-        />
+        {editorUI}
 
         <ct-hstack slot="footer">
           {backlinks?.map((charm) => (
@@ -701,6 +709,8 @@ const Note = pattern<Input, Output>(({ title, content, isHidden, noteId }) => {
       { content },
     ),
     editContent: handleEditContent({ content }),
+    // Minimal UI for embedding in containers (e.g., Record modules)
+    embeddedUI: editorUI,
   };
 });
 


### PR DESCRIPTION
## Summary
- Export `embeddedUI` from Note pattern - just the editor component without the header, notebooks menu, or footer
- Enables Record (and other containers) to render Note modules with minimal UI via `<ct-render variant="embedded">`
- Follows up on #2364 which added the `embedded` variant to ct-render

## Changes
- Extract editor JSX into `editorUI` variable (no behavior change)
- Add `embeddedUI: VNode` to Output type
- Export `embeddedUI: editorUI` 

## Test plan
- [x] Verified in Playwright: embedded variant shows only editor, default variant shows full UI with title/notebooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add embeddedUI export to the Note pattern so containers can render the editor-only UI via ct-render variant="embedded". The default Note UI remains unchanged.

- **New Features**
  - Export embeddedUI (editor-only view).
  - Extract editor JSX into editorUI for reuse.
  - Add embeddedUI: VNode to the Output type.

<sup>Written for commit 975d07b5ca7503cedbcd005bacb8b10470b781fe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





