### PR TITLE
feat(notes): add backlinks to notebook and fix import mention linking

### DIFF
--- a/packages/patterns/notes/notes-import-export.tsx
+++ b/packages/patterns/notes/notes-import-export.tsx
@@ -365,8 +365,10 @@ function performImport(
           // Skip if already has an ID: [[Name (id)]]
           if (name.includes("(") && name.endsWith(")")) return match;
 
-          // Look up by title (case-insensitive)
-          const id = titleToId.get(name.trim().toLowerCase());
+          // Look up by title (case-insensitive), stripping emoji prefixes like 📝 📓
+          const cleanName = name.trim().replace(/^(📝|📓)\s*/, "")
+            .toLowerCase();
+          const id = titleToId.get(cleanName);
           if (id) {
             return `[[${name.trim()} (${id})]]`;
           }
@@ -2769,6 +2771,8 @@ Note content here with any markdown...
     exportedMarkdown,
     importMarkdown,
     noteCount,
+    // Make notes discoverable via [[ autocomplete system-wide
+    mentionable: notes,
   };
 });
 


### PR DESCRIPTION
## Summary

- Add backlinks footer to notebook.tsx showing charms that link to it
- Add `#recent` wish to note.tsx for quick access to recently viewed notes
- Export `mentionable` from notebook.tsx and notes-import-export.tsx for `[[` autocomplete
- Fix import mention linking: strip emoji prefixes (📝 📓) when matching titles
- Inline MentionableCharm type to work around CLI path resolution bug with `..` relative imports

## Test plan

- [ ] Create a notebook, then create a note that mentions the notebook using `[[`
- [ ] Verify notebook shows "Linked from: [note name]" in footer
- [ ] Export notes with mentions, import to new space, verify mentions are re-linked with new IDs
- [ ] Verify Recent Notes section appears in note dropdown menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backlinks to notebooks and a quick “Recent” note menu for faster navigation. Fixes import mention linking by stripping emoji prefixes and exposes mentionable data for [[ autocomplete.

- **New Features**
  - Backlinks footer in notebooks with clickable links to referring charms.
  - “Recent” notes section in the note dropdown (#recent), limited to 5 items.
  - Expose mentionable lists from notebooks and import/export for [[ autocomplete.

- **Bug Fixes**
  - Import mention linking now strips 📝 and 📓 prefixes when matching titles.
  - Inline MentionableCharm type to avoid CLI path resolution issues.

<sup>Written for commit d375fa6a0650de78da33ed1cb5323f3421686bdb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

