### PR TITLE
fix(patterns): prevent OOM in integration tests with fresh controller per test

### DIFF
--- a/packages/patterns/deno.json
+++ b/packages/patterns/deno.json
@@ -1,8 +1,8 @@
 {
   "name": "@commontools/patterns",
   "tasks": {
-    "integration": "LOG_LEVEL=warn deno test --trace-leaks -A ./integration/*.test.ts",
-    "integration:all": "TEST_HTTP=1 TEST_LLM=1 LOG_LEVEL=warn deno test --trace-leaks -A ./integration/*.test.ts",
+    "integration": "LOG_LEVEL=warn deno test --v8-flags=--max-old-space-size=4096 --trace-leaks -A ./integration/*.test.ts",
+    "integration:all": "TEST_HTTP=1 TEST_LLM=1 LOG_LEVEL=warn deno test --v8-flags=--max-old-space-size=4096 --trace-leaks -A ./integration/*.test.ts",
     "test": "echo 'No tests defined.'"
   },
   "exports": {

--- a/packages/patterns/integration/all.test.ts
+++ b/packages/patterns/integration/all.test.ts
@@ -1,6 +1,6 @@
 import { env } from "@commontools/integration";
 import { CharmsController } from "@commontools/charm/ops";
-import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { assert } from "@std/assert";
 import { Identity } from "@commontools/identity";
@@ -9,27 +9,12 @@ import { FileSystemProgramResolver } from "@commontools/js-compiler";
 const { API_URL, SPACE_NAME } = env;
 
 describe("Compile all recipes", () => {
-  let cc: CharmsController;
-  let identity: Identity;
-
-  beforeAll(async () => {
-    identity = await Identity.generate();
-    cc = await CharmsController.initialize({
-      spaceName: SPACE_NAME,
-      apiUrl: new URL(API_URL),
-      identity: identity,
-    });
-  });
-
-  afterAll(async () => {
-    if (cc) await cc.dispose();
-  });
-
   const skippedPatterns = [
     "chatbot-list-view.tsx",
     "chatbot-note-composed.tsx",
     "system/link-tool.tsx", // Utility handlers, not a standalone pattern
   ];
+
   // Add a test for each pattern, but skip ones that have issues
   for (const file of Deno.readDirSync(join(import.meta.dirname!, ".."))) {
     const { name } = file;
@@ -37,13 +22,28 @@ describe("Compile all recipes", () => {
     if (skippedPatterns.includes(name)) continue;
 
     it(`Executes: ${name}`, async () => {
-      const sourcePath = join(import.meta.dirname!, "..", name);
-      const program = await cc.manager().runtime.harness
-        .resolve(
-          new FileSystemProgramResolver(sourcePath),
-        );
-      const charm = await cc!.create(program, { start: false });
-      assert(charm.id, `Received charm ID ${charm.id} for ${name}.`);
+      // Create a fresh CharmsController per test to prevent memory accumulation
+      // The RecipeManager caches compiled recipes indefinitely, so we need a
+      // fresh Runtime (via CharmsController) each time to avoid OOM in CI
+      const identity = await Identity.generate();
+      const cc = await CharmsController.initialize({
+        spaceName: SPACE_NAME,
+        apiUrl: new URL(API_URL),
+        identity: identity,
+      });
+
+      try {
+        const sourcePath = join(import.meta.dirname!, "..", name);
+        const program = await cc.manager().runtime.harness
+          .resolve(
+            new FileSystemProgramResolver(sourcePath),
+          );
+        const charm = await cc!.create(program, { start: false });
+        assert(charm.id, `Received charm ID ${charm.id} for ${name}.`);
+      } finally {
+        // Dispose the entire controller to free all memory including recipe cache
+        await cc.dispose();
+      }
     });
   }
 });


### PR DESCRIPTION
## Summary
- Creates a fresh CharmsController for each pattern test instead of reusing one
- Disposes the controller after each test to free memory including RecipeManager cache
- Adds V8 heap limit (4GB) as safety net

## Root Cause
The RecipeManager caches compiled recipes indefinitely in `recipeIdMap` and `recipeMetaCellById`. These caches are never cleared by `Runtime.dispose()` or `CharmsController.remove()`. After 30+ pattern tests, cumulative memory exceeds V8's heap limit.

## The Fix
Create a fresh CharmsController (with fresh Runtime and RecipeManager) per test, then dispose it. This ensures:
1. Each test starts with a clean slate
2. Memory is fully released after each test
3. No recipe cache accumulation

## Test plan
- [x] All 45 pattern integration tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents OOMs in patterns integration tests by creating a fresh CharmsController per test and disposing it after. Adds a 4GB V8 heap limit as a safety net.

- **Bug Fixes**
  - Create a new CharmsController and Identity inside each test; dispose in finally to release RecipeManager caches.
  - Remove shared beforeAll/afterAll controller to avoid cache accumulation across tests.
  - Pass --v8-flags=--max-old-space-size=4096 in deno.json test tasks.

<sup>Written for commit 3c011b281fc16be7c998b04238fdffe21e1b369e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

