### PR TITLE
feat(notes): add name modal for new notebooks

### DIFF
--- a/packages/patterns/notes/notes-import-export.tsx
+++ b/packages/patterns/notes/notes-import-export.tsx
@@ -715,8 +715,8 @@ const cancelStandaloneNotebookPrompt = handler<
   standaloneNotebookTitle.set("");
 });
 
-// Handler to create a new notebook (without navigating) - kept for compatibility
-const createNotebook = handler<
+// Handler to create a new notebook (without navigating) - kept for potential future use
+const _createNotebook = handler<
   Record<string, never>,
   { allCharms: Cell<NoteCharm[]> }
 >((_, { allCharms }) => {


### PR DESCRIPTION
## Summary
- Add modal prompt when creating new notebooks from the "All Notes" view
- User can name the notebook before creation instead of defaulting to "New Notebook"
- Add "Create Another" button to create multiple notebooks without closing modal
- "Create" navigates to the new notebook, "Create Another" stays in modal
- Inline MentionableCharm type in note.tsx to fix import path resolution issue

## Test plan
- [ ] Open All Notes charm
- [ ] Click "New" button in Notebooks section
- [ ] Verify modal appears with name input
- [ ] Enter a name and click "Create Another" - verify notebook is created and modal stays open
- [ ] Enter another name and click "Create" - verify notebook is created and navigates to it
- [ ] Click "Cancel" to close modal without creating

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “New Notebook” modal in All Notes so users can name notebooks before creation and quickly create multiple. Improves deletion safety and keeps the action bar mounted to preserve handlers.

- **New Features**
  - Standalone “New Notebook” modal triggered by the Notebooks “New” button.
  - Name input with blank-name fallback to “New Notebook”.
  - “Create” opens the new notebook; “Create Another” keeps the modal open and clears the input.

- **Bug Fixes**
  - Safer notebook deletion: requires an explicit selection and deletes by mapped allCharms indices.
  - Keep action bar DOM mounted (toggle via CSS) to preserve handler streams.

<sup>Written for commit 27adc4b2df7be64dbbc0d414e9c2cbba4d21264e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





