### PR TITLE
feat(notes): add Clone/Duplicate notebooks and Create Another note button

### DIFF
--- a/packages/patterns/notes/notebook.tsx
+++ b/packages/patterns/notes/notebook.tsx
@@ -89,6 +89,28 @@ const createNoteAndOpen = handler<
   return navigateTo(newNote);
 });
 
+// Handler to create note and stay in modal to create another
+const createNoteAndContinue = handler<
+  void,
+  {
+    newNoteTitle: Cell<string>;
+    notes: Cell<NoteCharm[]>;
+    allCharms: Cell<NoteCharm[]>;
+  }
+>((_, { newNoteTitle, notes, allCharms }) => {
+  const title = newNoteTitle.get() || "New Note";
+  const newNote = Note({
+    title,
+    content: "",
+    isHidden: true,
+    noteId: generateId(),
+  });
+  allCharms.push(newNote as unknown as NoteCharm);
+  notes.push(newNote as unknown as NoteCharm);
+  // Keep modal open, just clear the title for the next note
+  newNoteTitle.set("");
+});
+
 // Handler to cancel new note prompt
 const cancelNewNotePrompt = handler<
   void,
@@ -1248,6 +1270,16 @@ const Notebook = pattern<Input, Output>(({ title, notes, isNotebook }) => {
                   })}
                 >
                   Cancel
+                </ct-button>
+                <ct-button
+                  variant="ghost"
+                  onClick={createNoteAndContinue({
+                    newNoteTitle,
+                    notes,
+                    allCharms,
+                  })}
+                >
+                  Create Another
                 </ct-button>
                 <ct-button
                   variant="primary"


### PR DESCRIPTION
## Summary

- **Notebook Clone vs Duplicate**: Renamed existing "Duplicate" to "Clone" (shallow copy - same note references) and added new "Duplicate" action that creates truly independent copies with new Note instances
- **Create Another button**: Added "Create Another" button to notebook's New Note modal for batch note creation

## Changes

### Notebooks (notes-import-export.tsx)
| Action | Notebook | Notes |
|--------|----------|-------|
| **Clone** | New notebook | Same note references (shared) |
| **Duplicate** | New notebook | New note instances (independent, `isHidden: true`) |

### New Note Modal (notebook.tsx)
- Added "Create Another" button between Cancel and Create
- Creates note, clears input, keeps modal open for creating multiple notes quickly

## Test plan

- [ ] Select a notebook with notes, click "Clone" → verify new notebook shares same notes (edit one, both update)
- [ ] Select a notebook with notes, click "Duplicate" → verify new notebook has independent notes (edits isolated)
- [ ] Verify duplicated notes appear in All Notes list with `isHidden: true`
- [ ] Open New Note modal from notebook, click "Create Another" → verify note created and modal stays open
- [ ] Click "Create" → verify note created and modal closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Clone and Duplicate actions for notebooks, plus a “Create Another” button in the New Note modal to speed batch creation. Clone reuses existing note references; Duplicate creates independent note copies.

- **New Features**
  - Renamed old “Duplicate” to “Clone” (shallow copy that shares note references).
  - Added “Duplicate” (deep copy) that creates new notes with isHidden: true and adds them to All Notes.
  - Added “Create Another” in the New Note modal to create a note, clear the title, and keep the modal open.

<sup>Written for commit 33e3977401ea103b7546c78d2c70949d59197971. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

