### PR TITLE
fix(ct-render): handle cells that transition from undefined to a charm

### DIFF
--- a/packages/ui/src/v2/components/ct-render/ct-render.test.ts
+++ b/packages/ui/src/v2/components/ct-render/ct-render.test.ts
@@ -1,6 +1,9 @@
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { CTRender } from "./ct-render.ts";
+import { type Cell, Runtime } from "@commontools/runner";
+import { Identity } from "@commontools/identity";
+import { StorageManager } from "@commontools/runner/storage/cache.deno";
 
 describe("CTRender", () => {
   it("should be defined", () => {
@@ -19,5 +22,211 @@ describe("CTRender", () => {
   it("should have cell property", () => {
     const element = new CTRender();
     expect(element.cell).toBeUndefined();
+  });
+
+  it("should have variant property", () => {
+    const element = new CTRender();
+    expect(element.variant).toBeUndefined();
+  });
+});
+
+describe("CTRender async cell handling", () => {
+  let runtime: Runtime;
+  let space: string;
+
+  beforeEach(async () => {
+    const signer = await Identity.fromPassphrase("test-ct-render");
+    space = signer.did();
+    const storageManager = StorageManager.emulate({ as: signer });
+
+    runtime = new Runtime({
+      storageManager,
+      apiUrl: new URL(import.meta.url),
+    });
+  });
+
+  afterEach(() => {
+    // Cleanup runtime if needed
+  });
+
+  it("should have _hasRendered false initially", () => {
+    const element = new CTRender();
+    // Access private property for testing
+    expect((element as any)._hasRendered).toBe(false);
+  });
+
+  it("should reset _hasRendered when cell property changes", async () => {
+    const element = new CTRender();
+    document.body.appendChild(element);
+
+    // Create a cell with a value
+    const tx = runtime.edit();
+    const cell1 = runtime.getCell<{ value: string }>(
+      space as any,
+      "test-cell-1",
+      undefined,
+      tx,
+    );
+    cell1.set({ value: "test1" });
+    await tx.commit();
+
+    // Set the first cell
+    element.cell = cell1 as unknown as Cell;
+    await element.updateComplete;
+
+    // Manually set _hasRendered for testing
+    (element as any)._hasRendered = true;
+
+    // Create a second cell
+    const tx2 = runtime.edit();
+    const cell2 = runtime.getCell<{ value: string }>(
+      space as any,
+      "test-cell-2",
+      undefined,
+      tx2,
+    );
+    cell2.set({ value: "test2" });
+    await tx2.commit();
+
+    // Change to a different cell - should reset _hasRendered
+    element.cell = cell2 as unknown as Cell;
+    await element.updateComplete;
+
+    // _hasRendered should be reset to false when cell changes
+    expect((element as any)._hasRendered).toBe(false);
+
+    document.body.removeChild(element);
+  });
+
+  it("should clean up subscription on disconnect", async () => {
+    const element = new CTRender();
+    document.body.appendChild(element);
+
+    // Create and set a cell
+    const tx = runtime.edit();
+    const cell = runtime.getCell<{ value: string }>(
+      space as any,
+      "test-cell-disconnect",
+      undefined,
+      tx,
+    );
+    cell.set({ value: "test" });
+    await tx.commit();
+
+    element.cell = cell as unknown as Cell;
+    await element.updateComplete;
+
+    // Verify subscription exists
+    expect((element as any)._cellValueUnsubscribe).toBeDefined();
+
+    // Disconnect
+    document.body.removeChild(element);
+
+    // Subscription should be cleaned up
+    expect((element as any)._cellValueUnsubscribe).toBeUndefined();
+    expect((element as any)._hasRendered).toBe(false);
+  });
+
+  it("should clean up old subscription when cell changes", async () => {
+    const element = new CTRender();
+    document.body.appendChild(element);
+
+    // Create first cell
+    const tx1 = runtime.edit();
+    const cell1 = runtime.getCell<{ value: string }>(
+      space as any,
+      "test-cell-sub-1",
+      undefined,
+      tx1,
+    );
+    cell1.set({ value: "test1" });
+    await tx1.commit();
+
+    element.cell = cell1 as unknown as Cell;
+    await element.updateComplete;
+
+    const firstSub = (element as any)._cellValueUnsubscribe;
+    expect(firstSub).toBeDefined();
+
+    // Create second cell
+    const tx2 = runtime.edit();
+    const cell2 = runtime.getCell<{ value: string }>(
+      space as any,
+      "test-cell-sub-2",
+      undefined,
+      tx2,
+    );
+    cell2.set({ value: "test2" });
+    await tx2.commit();
+
+    // Change cell
+    element.cell = cell2 as unknown as Cell;
+    await element.updateComplete;
+
+    // Should have a new subscription (different reference)
+    const secondSub = (element as any)._cellValueUnsubscribe;
+    expect(secondSub).toBeDefined();
+    // The subscriptions should be different functions
+    expect(secondSub).not.toBe(firstSub);
+
+    document.body.removeChild(element);
+  });
+
+  it("should not render when cell value is undefined", async () => {
+    const element = new CTRender();
+    document.body.appendChild(element);
+
+    // Create a cell with undefined value
+    const tx = runtime.edit();
+    const cell = runtime.getCell<{ value: string } | undefined>(
+      space as any,
+      "test-cell-undefined",
+      undefined,
+      tx,
+    );
+    // Don't set any value - it will be undefined
+    await tx.commit();
+
+    element.cell = cell as unknown as Cell;
+    await element.updateComplete;
+
+    // Allow time for async render attempt
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Should not have rendered because value is undefined
+    expect((element as any)._hasRendered).toBe(false);
+
+    document.body.removeChild(element);
+  });
+});
+
+describe("CTRender variant handling", () => {
+  it("should accept variant property", () => {
+    const element = new CTRender();
+    element.variant = "preview";
+    expect(element.variant).toBe("preview");
+  });
+
+  it("should accept embedded variant", () => {
+    const element = new CTRender();
+    element.variant = "embedded";
+    expect(element.variant).toBe("embedded");
+  });
+
+  it("should accept all valid variants", () => {
+    const element = new CTRender();
+    const variants = [
+      "default",
+      "preview",
+      "thumbnail",
+      "sidebar",
+      "fab",
+      "embedded",
+    ] as const;
+
+    for (const variant of variants) {
+      element.variant = variant;
+      expect(element.variant).toBe(variant);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Fixes CT-1146: `ct-render` now handles cells that start with `undefined` values and later transition to valid charms
- Adds cell value subscription to detect when async-loaded cells become available
- Uses the simple, idiomatic pattern from `ct-cell-link` and `ct-list`

## Problem

When using `<ct-render $cell={asyncLoadedCharm}>` where `asyncLoadedCharm` starts as `undefined` (e.g., from `fetchAndRunPattern`), ct-render would:
1. Attempt to render immediately when the Cell reference was set
2. Fail silently because the value was undefined
3. Never re-render when the value became available
4. Show the loading spinner forever

## Solution

- Subscribe to cell value changes via `.sink()`
- Return early from `_renderCell()` if cell value is undefined/null
- Trigger render when value becomes truthy and we haven't rendered yet
- Reset `_hasRendered` when cell property changes to a different cell
- Properly clean up subscriptions on disconnect and cell changes

## Test plan

- [x] Added unit tests for async cell handling
- [x] Existing tests pass
- [x] `deno fmt` and `deno lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ct-render so it correctly renders cells that start as undefined and later resolve, preventing the spinner from getting stuck. Addresses CT-1146.

- **Bug Fixes**
  - Subscribe to cell value changes via sink() to detect when async values arrive.
  - Skip rendering when the value is undefined/null; render once it becomes truthy.
  - Reset _hasRendered when the cell changes; clean up subscriptions on change/disconnect.
  - Added unit tests for async cell handling and subscription cleanup.

<sup>Written for commit 8b37ba80d1a5c890d79c0bd3a58d28cb650b5312. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

