### PR TITLE
fix(patterns): use dynamic module loading to fix OOM in Record (CT-1143)

### DIFF
--- a/packages/patterns/record/types.ts
+++ b/packages/patterns/record/types.ts
@@ -25,12 +25,16 @@ import type { JSONSchema } from "./extraction/schema-utils-pure.ts";
 /**
  * SubCharmEntry - An entry in the Record's sub-charms array.
  * Each entry holds a reference to an actual sub-charm pattern instance.
+ *
+ * Modules can be loaded asynchronously via fetchAndRunPattern.
+ * While loading, charm may be { cell: undefined, error: undefined }.
+ * When loaded, charm becomes { cell: <pattern output>, error?: string }.
  */
 export interface SubCharmEntry {
   type: string; // Module type identifier (e.g., "birthday", "email")
   pinned: boolean; // Pin state owned by Record (not the sub-charm)
   collapsed?: boolean; // Collapse state - when true, only header is shown (default: false/expanded)
-  charm: unknown; // Reference to the actual sub-charm pattern instance
+  charm: unknown; // Reference to the actual sub-charm pattern instance (may be { cell, error } for async modules)
   schema?: JSONSchema; // Schema captured at creation time for dynamic discovery
   note?: string; // User annotation about this module (visible to LLM reads, not extraction)
 }


### PR DESCRIPTION
## Summary
- Convert Record's sub-charm registry from static imports to URL-based metadata
- Avoids TypeScript compiling all 20+ module patterns at once, which caused OOM errors during CI type checking
- Uses `fetchAndRunPattern()` for async module loading with `getCharmCell()` helper

## Test plan
- [ ] Verify Record pattern still loads sub-modules correctly
- [ ] Confirm CI type checking no longer OOMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Record sub-charm loading from static imports to URL-based dynamic modules to fix CI type-check OOM (CT-1143) and load modules on demand. Notes and Extractor stay sync; other modules load via fetchAndRunPattern and render safely with getCharmCell.

- **Bug Fixes**
  - Stops TypeScript from compiling all module patterns at once, eliminating OOM in CI.
  - Supports async module render in Record via ct-render; relies on CT-1146 behavior for undefined→cell transitions.
  - Import flow handles unknown types and pending loads without crashing.

- **Refactors**
  - Replaced static registry imports with URL metadata and getModuleUrl; URLs built from getRecipeEnvironment baseUrl.
  - Removed createSubCharm; modules are created via fetchAndRunPattern with reactive storage of the loaded result.
  - Record now unwraps async results with getCharmCell and renders via computed($cell).
  - Updated template-registry and TypePicker to create modules through dynamic loading (Notes created directly).
  - Extractor and record-backup imports now use getModuleUrl + fetchAndRunPattern and can track pending/error states.

<sup>Written for commit da0da3ea768a249d4d8aeb612092ad7e0b1752a5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

