### PR TITLE
Unify wish result format to fix multi-result wish

### DIFF
--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -599,13 +599,16 @@ export function wish(
               [UI]: cellLinkUI(resolvedCell),
             });
           } else {
-            // If it's multiple result, launch the wish pattern, which will
-            // immediately return the first candidate as result
+            // If it's multiple results, launch the wish pattern for the user
+            // to pick from. Navigation goes to the picker charm.
             const wishResultCell = await launchWishPattern({
               ...targetValue as WishParams,
               candidates: resultCells,
             }, tx);
-            sendResult(tx, wishResultCell);
+            sendResult(tx, {
+              result: wishResultCell,
+              [UI]: wishResultCell.get()[UI],
+            });
           }
         } catch (e) {
           const errorMsg = e instanceof WishError ? e.message : String(e);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unifies the wish result payload so multi-result flows return the same shape as single-result, fixing inconsistent handling and ensuring the right UI is shown.

- **Bug Fixes**
  - Multi-result wish now calls sendResult with { result: cell, [UI]: cell.get()[UI] } instead of returning the raw cell.
  - Ensures navigation goes to the picker charm and UI renders consistently.
  - Removes the need for downstream code to handle two different result shapes.

<sup>Written for commit 9c1e2e090b86466828c651ac624f5ce7fcce98bd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

