### PR TITLE
Ensure `home.tsx` is actually removed, recreated and added to list

### DIFF
--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -60,14 +60,16 @@ export class XBodyView extends BaseView {
   private hasSidebarContent = false;
 
   private _charms = new Task(this, {
-    task: async ([rt]) => {
+    task: async ([rt, _spaceRootPattern]) => {
       if (!rt) return undefined;
+      // Include spaceRootPattern in args so we re-fetch when it changes.
+      // This ensures newly created default patterns appear in the list.
 
       const manager = rt.cc().manager();
       await manager.synced();
       return rt.cc().getAllCharms();
     },
-    args: () => [this.rt],
+    args: () => [this.rt, this.spaceRootPattern],
   });
 
   override render() {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix deletion and recreation of the default home pattern so `home.tsx` is actually removed and the new pattern appears in the charms list.

- **Bug Fixes**
  - Clear the `defaultPattern` link when deleting the default pattern to avoid stale references.
  - Re-fetch charms when `spaceRootPattern` changes so newly created defaults are included.

<sup>Written for commit a8353a293b77d1995f69e2148de610c733dbced0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

