### PR TITLE
Remove `ct-render` from record.tsx

### DIFF
--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -1413,7 +1413,7 @@ const Record = pattern<RecordInput, RecordOutput>(
                               minHeight: isExpanded ? "0" : "auto",
                             }}
                           >
-                            {(entry.charm as any)["embeddedUI"]}
+                            {(entry.charm as any)["embeddedUI"] || (entry.charm as any)[UI]}
                           </div>,
                           null,
                         )}
@@ -1688,7 +1688,7 @@ const Record = pattern<RecordInput, RecordOutput>(
                                 minHeight: isExpanded ? "0" : "auto",
                               }}
                             >
-                              {(entry.charm as any)["embeddedUI"]}
+                              {(entry.charm as any)["embeddedUI"] || (entry.charm as any)[UI]}
                             </div>,
                             null,
                           )}
@@ -1956,7 +1956,7 @@ const Record = pattern<RecordInput, RecordOutput>(
                             minHeight: isExpanded ? "0" : "auto",
                           }}
                         >
-                          {(entry.charm as any)["embeddedUI"]}
+                          {(entry.charm as any)["embeddedUI"] || (entry.charm as any)[UI]}
                         </div>,
                         null,
                       )}

--- a/packages/patterns/record/types.ts
+++ b/packages/patterns/record/types.ts
@@ -1,5 +1,5 @@
 // types.ts - Shared types for the record pattern system
-
+import { UI } from 'commontools'
 import type { JSONSchema } from "./extraction/schema-utils-pure.ts";
 
 // ===== Sub-Charm Architecture Types =====
@@ -30,7 +30,7 @@ export interface SubCharmEntry {
   type: string; // Module type identifier (e.g., "birthday", "email")
   pinned: boolean; // Pin state owned by Record (not the sub-charm)
   collapsed?: boolean; // Collapse state - when true, only header is shown (default: false/expanded)
-  charm: { embeddedUI: unknown } | unknown; // Reference to the actual sub-charm pattern instance
+  charm: { embeddedUI?: unknown, [UI]: unknown } | unknown; // Reference to the actual sub-charm pattern instance
   schema?: JSONSchema; // Schema captured at creation time for dynamic discovery
   note?: string; // User annotation about this module (visible to LLM reads, not extraction)
 }


### PR DESCRIPTION
- **Remove `ct-render` from `record.tsx`**
- **Fallback to regular UI if embedded is missing**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed ct-render from record.tsx and now render sub-charm UIs directly. Uses embeddedUI when available and falls back to the standard UI via the UI symbol.

- **Refactors**
  - Render entry.charm.embeddedUI or entry.charm[UI] instead of ct-render.
  - Updated SubCharmEntry typing and imported UI from commontools to support the new accessors.

<sup>Written for commit 516a70d0ce03e6a4984da79eb41443c446b62d3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

