### PR TITLE
fix(notebook): use lift() for parent/sibling notebook display conditions

### DIFF
--- a/packages/patterns/notes/notebook.tsx
+++ b/packages/patterns/notes/notebook.tsx
@@ -1012,6 +1012,14 @@ const Notebook = pattern<Input, Output>(
       notebookList: notebooks,
     });
 
+    // Use lift() for proper reactive tracking of notebook list lengths
+    const hasParentNotebooks = lift((args: { list: unknown[] }) =>
+      args.list.length > 0
+    )({ list: parentNotebooks });
+    const hasSiblingNotebooks = lift((args: { list: unknown[] }) =>
+      args.list.length > 0
+    )({ list: siblingNotebooks });
+
     // Check if "All Notes" charm exists in the space
     const allNotesCharm = computed(() =>
       allCharms.find((charm: any) => {
@@ -1157,7 +1165,7 @@ const Notebook = pattern<Input, Output>(
                 <div
                   style={{
                     display: computed(() =>
-                      parentNotebooks.length > 0 ? "flex" : "none"
+                      hasParentNotebooks ? "flex" : "none"
                     ),
                     alignItems: "center",
                     gap: "4px",
@@ -1180,7 +1188,7 @@ const Notebook = pattern<Input, Output>(
                 <div
                   style={{
                     display: computed(() =>
-                      parentNotebooks.length > 0 ? "none" : "block"
+                      hasParentNotebooks ? "none" : "block"
                     ),
                   }}
                 />
@@ -1390,8 +1398,7 @@ const Notebook = pattern<Input, Output>(
                       {/* Checkbox column (32px + 4px padding) */}
                       <div style={{ width: "32px", padding: "0 4px" }}>
                         <ct-checkbox
-                          checked={computed(() =>
-                            notes.length > 0 &&
+                          checked={computed(() => notes.length > 0 &&
                             selectedNoteIndices.get().length === notes.length
                           )}
                           onct-change={computed(() =>
@@ -1483,7 +1490,7 @@ const Notebook = pattern<Input, Output>(
                 gap="2"
                 style={{
                   display: computed(() =>
-                    siblingNotebooks.length > 0 ? "flex" : "none"
+                    hasSiblingNotebooks ? "flex" : "none"
                   ),
                   marginTop: "16px",
                   paddingTop: "16px",


### PR DESCRIPTION
## Summary
- Apply the same `lift()` reactivity fix to `hasParentNotebooks` and `hasSiblingNotebooks` display conditions
- Without `lift()`, the `.length` access inside `computed()` doesn't properly track reactive changes
- This follows the same pattern as PR #2403 which fixed `noteCount`

## Changes
- Added `hasParentNotebooks` and `hasSiblingNotebooks` computed via `lift()` 
- Updated display conditions to use these reactive helpers

## Note
The parent notebook chip and "Other notebooks" section may still not appear if the parent/sibling notebooks aren't properly registered in `allCharms`. This fix addresses the reactivity issue - if there's still a visibility issue, it may be a separate bug in how notebooks are computed from `allCharms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reactive display of parent and sibling notebooks by using lift() for list-length checks. The parent chip and “Other notebooks” now update when lists change; if still hidden, it’s likely due to missing notebook registration in allCharms.

<sup>Written for commit b5599eada88b54b0ff9a602aacd8d9c3363ed8a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

