### PR TITLE
fix(runner): clean up debounce timers on scheduler dispose

### DIFF
--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -254,6 +254,9 @@ export class Runtime {
     // Wait for any pending operations
     await this.scheduler.idle();
 
+    // Clean up scheduler timers
+    this.scheduler.dispose();
+
     // Pop the default frame
     if (this.defaultFrame) {
       popFrame(this.defaultFrame);


### PR DESCRIPTION
This PR fixes the flakiness in the generated-patterns integration test.

## Summary
- Added `activeDebounceTimers` Set to track active debounce timers (WeakMap can't be iterated)
- Added `dispose()` method to Scheduler that clears all pending debounce timers
- Called `scheduler.dispose()` from runtime's dispose method

## Test plan
- [x] Verify existing scheduler tests pass
- [x] Confirm no timer callbacks fire after runtime disposal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents debounce timer callbacks from firing after runtime teardown by clearing all scheduler timers on dispose. This avoids stray actions and potential leaks during shutdown.

- **Bug Fixes**
  - Track active debounce timers in a Set for proper iteration and cleanup.
  - Added Scheduler.dispose() to clear all pending timers; Runtime.dispose() now calls it.
  - Remove timers from the tracking Set on cancel and after execution.

<sup>Written for commit b905f0dab35b5bc49384db5790b69e23e8d1be61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

