### PR TITLE
fix(runner): prevent type-change reactions in reactively launched patterns

### DIFF
--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -140,6 +140,7 @@ export function map(
         opRecipe,
         recipeInputs,
         resultCell,
+        { doNotUpdateOnPatternChange: true },
       );
       resultCell.getSourceCell()!.setSourceCell(parentCell);
       // Add cancel from runtime's runner


### PR DESCRIPTION
## Summary

- Add `noSink` option to `startCore` that skips type watcher setup
- Pass `noSink: true` from `startWithTx` for reactively spawned patterns
- Move `cancelNodes()` after successful recipe load to avoid premature cleanup

This prevents patterns launched within transactions (via `startWithTx`) from watching `$TYPE` changes, which could cause infinite loops or unnecessary re-instantiation when patterns are nested or reactively spawned.

## Test plan

- [x] Verify existing tests pass
- [x] Test that reactively launched patterns no longer cause infinite instantiation loops
- [x] Verify that top-level patterns still react to type changes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops reactively launched patterns (started within a transaction) from reacting to $TYPE changes, preventing infinite loops and unnecessary re-instantiation. Also delays node cancellation until a new recipe is successfully loaded.

- **Bug Fixes**
  - Renamed noSink to doNotUpdateOnPatternChange and threaded it through startCore/startWithTx/run; reactive spawns (including map’s child recipes) pass doNotUpdateOnPatternChange: true to skip the $TYPE watcher.
  - Moved cancelNodes() to run after a valid recipe loads, avoiding premature cleanup on transient type changes.
  - Top-level patterns continue to watch type changes.

<sup>Written for commit 1064d3ffa2dfc1e5cc06de95724a7ae7df4e3327. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

