### PR TITLE
fix(runner): add exponential backoff to websocket reconnection

### DIFF
--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -144,6 +144,24 @@ export interface IRemoteStorageProviderSettings {
    * abort.
    */
   connectionTimeout: number;
+
+  /**
+   * Base delay in milliseconds for reconnection attempts.
+   * This is the initial delay after the first disconnect.
+   */
+  reconnectBaseDelay: number;
+
+  /**
+   * Maximum delay in milliseconds between reconnection attempts.
+   * The delay will not exceed this value even with exponential backoff.
+   */
+  reconnectMaxDelay: number;
+
+  /**
+   * Maximum number of reconnection attempts before giving up.
+   * Set to -1 for unlimited attempts.
+   */
+  maxReconnectAttempts: number;
 }
 
 export interface LocalStorageOptions {


### PR DESCRIPTION
## Summary

- Adds exponential backoff to websocket reconnection logic in the shell
- Previously, failed connections would spam reconnect attempts ~15 times very quickly then give up
- Now starts at 100ms, doubles each attempt up to 30s max, with ±25% jitter to prevent thundering herd
- Backoff resets when connection succeeds

## Changes

New settings added to `IRemoteStorageProviderSettings`:
- `reconnectBaseDelay`: initial delay (default 100ms)
- `reconnectMaxDelay`: max delay cap (default 30s)  
- `maxReconnectAttempts`: max attempts before giving up (-1 = unlimited)

## Test plan

- [x] Type check passes
- [x] Runner package tests pass
- [ ] Manual testing with server unavailable to verify backoff behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds exponential backoff with jitter to websocket reconnection in the runner to stop rapid retry spam and stabilize reconnects. Retries start fast and grow up to a cap, reset on success, and are unlimited by default.

- **Bug Fixes**
  - Replace immediate reconnects with scheduled backoff (±25% jitter).
  - Reset attempts on successful connection; cancel pending retries on close.
  - Respect a configurable max attempt limit and log when giving up.

- **Migration**
  - IRemoteStorageProviderSettings now includes reconnectBaseDelay, reconnectMaxDelay, and maxReconnectAttempts.
  - If you provide custom settings objects, add these fields or rely on defaultSettings.

<sup>Written for commit c9068cdd72b13439f9d19314512893b3d9621079. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

