### PR TITLE
feat(notes): add markdown view mode via separate note-md pattern

### DIFF
--- a/packages/patterns/notes/note-md.tsx
+++ b/packages/patterns/notes/note-md.tsx
@@ -1,0 +1,164 @@
+/// <cts-enable />
+import {
+  computed,
+  type Default,
+  handler,
+  NAME,
+  navigateTo,
+  pattern,
+  UI,
+  type VNode,
+  wish,
+} from "commontools";
+
+// Type for backlinks (same as note.tsx)
+type MentionableCharm = {
+  [NAME]?: string;
+  isHidden?: boolean;
+  mentioned: MentionableCharm[];
+  backlinks: MentionableCharm[];
+};
+
+interface NoteData {
+  title?: string;
+  content?: string;
+  backlinks?: MentionableCharm[];
+  noteId?: string;
+}
+
+interface Input {
+  /** Cell reference to note data (title + content + backlinks + noteId) */
+  note?: Default<
+    NoteData,
+    { title: ""; content: ""; backlinks: []; noteId: "" }
+  >;
+}
+
+interface Output {
+  /** Passthrough note reference */
+  note: NoteData;
+  /** Hidden from default-app charm list */
+  isHidden: true;
+  /** Excluded from mentions autocomplete (notes in notebooks may be hidden but still mentionable) */
+  isMentionable: false;
+  /** Minimal UI for embedding in other patterns */
+  embeddedUI: VNode;
+}
+
+export default pattern<Input, Output>(({ note }) => {
+  const displayName = computed(() => {
+    const title = note?.title || "Untitled";
+    return `📖 ${title}`;
+  });
+
+  const hasBacklinks = computed(() => (note?.backlinks?.length ?? 0) > 0);
+
+  // Convert [[Name (id)]] wiki-links to markdown links [Name](/of:id)
+  // ct-markdown will then convert these to clickable ct-cell-link components
+  const processedContent = computed(() => {
+    const raw = note?.content || "";
+    // Match [[Name (id)]] pattern and convert to [Name](/of:id)
+    return raw.replace(
+      /\[\[([^\]]*?)\s*\(([^)]+)\)\]\]/g,
+      (_match, name, id) => `[${name.trim()}](/of:${id})`,
+    );
+  });
+
+  // Handler for clicking a backlink chip
+  const handleBacklinkClick = (charm: MentionableCharm) => {
+    return navigateTo(charm as any);
+  };
+
+  // Find source note by noteId using wish()
+  const { allCharms } = wish<{ allCharms: any[] }>("/");
+  const sourceNote = computed(() => {
+    const myNoteId = note?.noteId;
+    if (!myNoteId) return null;
+    return allCharms.find((charm: any) => charm?.noteId === myNoteId);
+  });
+
+  // Handler for Edit button - go back to note editor
+  const goToEdit = handler<void, { sourceNote: any }>(
+    (_, { sourceNote }) => {
+      const noteRef = sourceNote?.get?.() ?? sourceNote;
+      if (noteRef) {
+        return navigateTo(noteRef);
+      }
+    },
+  );
+
+  // Scrollable content with markdown + backlinks (for print support)
+  const markdownViewer = (
+    <ct-vscroll flex showScrollbar fadeEdges>
+      <div style={{ padding: "1rem", minHeight: "100%" }}>
+        {/* Markdown content with wiki-links converted to clickable links */}
+        <ct-markdown content={processedContent} />
+
+        {/* Backlinks section - ct-chips at bottom */}
+        <div
+          style={{
+            display: computed(() => (hasBacklinks ? "block" : "none")),
+            marginTop: "2rem",
+            paddingTop: "1rem",
+            borderTop: "1px solid var(--ct-color-border, #e5e5e7)",
+          }}
+        >
+          <span
+            style={{
+              fontSize: "0.75rem",
+              fontWeight: "600",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+              color: "var(--ct-color-gray-500, #6b7280)",
+              marginBottom: "0.5rem",
+              display: "block",
+            }}
+          >
+            Linked from:
+          </span>
+          <ct-hstack gap="2" wrap>
+            {note?.backlinks?.map((charm) => (
+              <ct-chip
+                label={charm?.[NAME] ?? "Untitled"}
+                interactive
+                onct-click={() => handleBacklinkClick(charm)}
+              />
+            ))}
+          </ct-hstack>
+        </div>
+      </div>
+    </ct-vscroll>
+  );
+
+  return {
+    [NAME]: displayName,
+    [UI]: (
+      <ct-screen>
+        <ct-hstack
+          slot="header"
+          padding="4"
+          gap="3"
+          align="center"
+          style={{ borderBottom: "1px solid var(--ct-color-border, #e5e5e7)" }}
+        >
+          <ct-heading level={1} style={{ flex: "1" }}>
+            {computed(() => note?.title || "Untitled Note")}
+          </ct-heading>
+          {/* Edit button - navigates back to source note for editing */}
+          <ct-button
+            variant="secondary"
+            size="sm"
+            onClick={goToEdit({ sourceNote })}
+          >
+            Edit
+          </ct-button>
+        </ct-hstack>
+        {markdownViewer}
+      </ct-screen>
+    ),
+    note,
+    isHidden: true,
+    isMentionable: false,
+    embeddedUI: markdownViewer,
+  };
+});

--- a/packages/patterns/system/backlinks-index.tsx
+++ b/packages/patterns/system/backlinks-index.tsx
@@ -4,6 +4,7 @@ import { Cell, lift, NAME, OpaqueRef, pattern, UI } from "commontools";
 export type MentionableCharm = {
   [NAME]?: string;
   isHidden?: boolean;
+  isMentionable?: boolean;
   mentioned: MentionableCharm[];
   backlinks: MentionableCharm[];
 };
@@ -64,16 +65,20 @@ const computeMentionable = lift<
   const cs = charmList ?? [];
   const out: MentionableCharm[] = [];
   for (const c of cs) {
+    // Skip charms explicitly marked as not mentionable (like note-md viewer charms)
+    // Note: We check isMentionable === false, not isHidden, because notes in
+    // notebooks are hidden but should still be mentionable
+    if (c.isMentionable === false) continue;
     out.push(c);
     const exported = (c as unknown as {
       mentionable?: MentionableCharm[] | { get?: () => MentionableCharm[] };
     }).mentionable;
     if (Array.isArray(exported)) {
-      for (const m of exported) if (m) out.push(m);
+      for (const m of exported) if (m && m.isMentionable !== false) out.push(m);
     } else if (exported && typeof (exported as any).get === "function") {
       const arr = (exported as { get: () => MentionableCharm[] }).get() ??
         [];
-      for (const m of arr) if (m) out.push(m);
+      for (const m of arr) if (m && m.isMentionable !== false) out.push(m);
     }
   }
   return out;

--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -443,10 +443,15 @@ export class CTCodeEditor extends BaseElement {
 
       // parse + start the recipe + link the inputs
       const pattern = JSON.parse(this.pattern.get());
+      // Simple random ID generator for noteId (matches pattern used in note.tsx)
+      const generateId = () =>
+        `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 11)}`;
+
       // Provide mentionable list so the pattern can wire backlinks immediately
       const inputs: Record<string, unknown> = {
         title: backlinkText,
         content: "",
+        noteId: generateId(), // Ensure notes created via [[mention]] have unique IDs
       };
 
       rt.run(tx, pattern, inputs, result);


### PR DESCRIPTION
## Summary

Adds a lightweight markdown viewer pattern (`note-md.tsx`) that cooperates with `note.tsx` to provide a "View" mode for rendered markdown display. This keeps `note.tsx` focused on editing while offloading view rendering to a dedicated pattern.

### Key Changes

- **New `note-md.tsx` pattern**: Dedicated markdown viewer with `isHidden: true` and `isMentionable: false`
  - Renders note content as formatted markdown via `<ct-markdown>`
  - Shows backlinks section at bottom
  - "Edit" button navigates back to source note
  
- **`note.tsx` updates**: 
  - Added "View" button that dynamically creates `note-md` charm
  - NoteMd is invoked inside the handler (not during pattern construction) to avoid recipe serialization issues with `$pattern`
  
- **`backlinks-index.tsx`**: Filter charms with `isMentionable: false` from mentionable list
  - Uses explicit `isMentionable` property instead of `isHidden`
  - This preserves mentionability for notes in notebooks (which are hidden but should still be mentionable)
  
- **`ct-code-editor.ts`**: Generate unique `noteId` for notes created via `[[mention]]`

### Why This Architecture

The note-md pattern is created dynamically when the user clicks "View" rather than being embedded as a sub-pattern. This avoids serialization issues where sub-recipe implementations get converted to strings during `JSON.stringify(Note)`, breaking the `$pattern` prop used by ct-code-editor for backlink creation.

### Testing

- Create a note, add some markdown content
- Click "View" → navigates to markdown viewer (hidden from charm list)
- Click "Edit" → returns to editor
- Create `[[backlink]]` → works correctly, new note appears in Patterns list
- note-md charms don't appear in charm list or mentions autocomplete
- Notes in notebooks (hidden) still appear in mentions autocomplete

## Test plan

- [ ] Verify "View" button navigates to markdown viewer
- [ ] Verify "Edit" button in viewer returns to note editor
- [ ] Verify `[[mention]]` backlink creation works
- [ ] Verify note-md charms are hidden from Patterns list
- [ ] Verify note-md charms don't appear in mentions autocomplete
- [ ] Verify hidden notes in notebooks still appear in mentions autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)