### PR TITLE
feat(ui): focus-aware backlink display in ct-code-editor

### DIFF
--- a/packages/ui/src/v2/components/ct-code-editor/styles.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/styles.ts
@@ -58,22 +58,57 @@ export const styles = css`
     border-radius: var(--ct-theme-border-radius, 0.375rem);
   }
 
-  /* Backlink styling - make [[backlinks]] visually distinct */
+  /* Backlink styling - focus-aware display */
   .cm-content .cm-line {
     position: relative;
   }
 
-  /* Style for backlinks - we'll use a highlight mark */
-  .cm-backlink {
-    background-color: var(--ring-alpha, hsla(212, 100%, 47%, 0.1));
-    border-radius: 0.25rem;
-    padding: 0.125rem 0.25rem;
+  /* Collapsed pill view - complete backlink with ID (click to navigate) */
+  .cm-backlink-pill {
+    background-color: var(--ct-color-primary-100, hsla(212, 100%, 47%, 0.15));
+    color: var(--ct-color-primary-700, hsl(212, 80%, 40%));
+    border-radius: 9999px;
+    padding: 0.125rem 0.5rem;
     cursor: pointer;
+    font-weight: 500;
+    text-decoration: none;
     transition: background-color var(--ct-theme-animation-duration, 150ms)
       var(--ct-transition-timing-ease);
     }
 
-    .cm-backlink:hover {
-      background-color: var(--ring-alpha, hsla(212, 100%, 47%, 0.2));
+    .cm-backlink-pill:hover {
+      background-color: var(--ct-color-primary-200, hsla(212, 100%, 47%, 0.25));
     }
-  `;
+
+    /* Pending pill - incomplete backlink without ID */
+    .cm-backlink-pending {
+      background-color: var(--ct-color-warning-100, hsla(45, 100%, 50%, 0.15));
+      color: var(--ct-color-warning-700, hsl(45, 80%, 35%));
+      border-radius: 9999px;
+      padding: 0.125rem 0.5rem;
+      cursor: text;
+      font-weight: 500;
+      border: 1px dashed var(--ct-color-warning-400, hsl(45, 70%, 50%));
+    }
+
+    /* Editing view - full [[Name (id)]] format visible */
+    .cm-backlink-editing {
+      background-color: var(--ring-alpha, hsla(212, 100%, 47%, 0.1));
+      border-radius: 0.25rem;
+      padding: 0.125rem 0.25rem;
+    }
+
+    /* Legacy fallback - keep for any old usages */
+    .cm-backlink {
+      background-color: var(--ring-alpha, hsla(212, 100%, 47%, 0.1));
+      border-radius: 0.25rem;
+      padding: 0.125rem 0.25rem;
+      cursor: pointer;
+      transition: background-color var(--ct-theme-animation-duration, 150ms)
+        var(--ct-transition-timing-ease);
+      }
+
+      .cm-backlink:hover {
+        background-color: var(--ring-alpha, hsla(212, 100%, 47%, 0.2));
+      }
+    `;


### PR DESCRIPTION
## Summary
- Streamlines backlink UX by hiding `[[]]` brackets and IDs when not editing
- Collapsed pill view when editor unfocused or cursor outside backlink
- Full `[[Name (id)]]` format visible only when cursor is inside for editing
- Blue pill for complete backlinks (click navigates to linked note)
- Yellow dashed "pending" pill for incomplete backlinks without ID
- Decorations update on focus changes, selection changes, and document changes

## Test plan
- [ ] Create a note with backlinks using `[[` autocomplete
- [ ] Verify backlinks collapse to pills when cursor moves away
- [ ] Verify clicking collapsed pill navigates to linked note
- [ ] Verify cursor entering backlink reveals full `[[Name (id)]]` format
- [ ] Verify incomplete backlinks show as pending pills with dashed border

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves backlink UX by collapsing [[links]] into clean, clickable pills when not editing, and adds a lightweight markdown “View” mode for reading notes and navigating backlinks.

- New Features
  - Backlinks collapse to pills when the cursor is outside; full [[Name (id)]] shows only while editing.
  - Pending backlinks (no ID) render as dashed yellow pills.
  - Clicking a pill navigates to the linked note; Cmd/Ctrl+Click still works.
  - Added NoteMd viewer and a “View” button that renders content and backlinks without edit chrome.
  - Decorations react to focus, selection, viewport, and document changes.

- Bug Fixes
  - Notes created via [[mention]] get a unique noteId and now appear in the charm list.
  - Non-mentionable viewer charms are excluded from mentions autocomplete.

<sup>Written for commit 90b7d1e07c8f945d005154e6404e5c1f8530bbf2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

