### PR TITLE
feat(ui): backlink autocomplete with Enter key behavior

### DIFF
--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -230,7 +230,11 @@ const backlinkEditFilter = EditorState.transactionFilter.of((tr) => {
       }
 
       if (shouldInclude) {
-        specs.push({ from: adjustedFrom, to: adjustedTo, insert: inserted.toString() });
+        specs.push({
+          from: adjustedFrom,
+          to: adjustedTo,
+          insert: inserted.toString(),
+        });
       }
     });
 
@@ -884,7 +888,9 @@ export class CTCodeEditor extends BaseElement {
    */
   private createBacklinkDecorationPlugin() {
     const editingMark = Decoration.mark({ class: "cm-backlink-editing" });
-    const editingNameMark = Decoration.mark({ class: "cm-backlink-editing-name" });
+    const editingNameMark = Decoration.mark({
+      class: "cm-backlink-editing-name",
+    });
     const pillMark = Decoration.mark({ class: "cm-backlink-pill" });
     const pendingMark = Decoration.mark({ class: "cm-backlink-pending" });
     const hiddenReplace = Decoration.replace({});
@@ -932,12 +938,15 @@ export class CTCodeEditor extends BaseElement {
             const cursorInName = hasFocus && cursorPos >= nameFrom &&
               cursorPos <= nameTo;
             // Check if cursor is adjacent to the backlink (right before [[ or right after ]])
-            const cursorAdjacent = hasFocus && (cursorPos === start || cursorPos === end);
+            const cursorAdjacent = hasFocus &&
+              (cursorPos === start || cursorPos === end);
             // Check if selection overlaps with the entire backlink
             const selectionOverlaps = hasFocus && selectionFrom < end &&
               selectionTo > start;
 
-            if (hasId && (cursorInName || cursorAdjacent || selectionOverlaps)) {
+            if (
+              hasId && (cursorInName || cursorAdjacent || selectionOverlaps)
+            ) {
               // EDITING MODE: User is editing the name of a complete backlink
               // Hide [[ and (id)]], show only the name with editing style
               decorations.push(hiddenReplace.range(start, nameFrom)); // Hide [[
@@ -945,7 +954,8 @@ export class CTCodeEditor extends BaseElement {
               decorations.push(hiddenReplace.range(nameTo, end)); // Hide (id)]]
             } else if (!hasId) {
               // Incomplete backlink - show as pending pill or full text when editing
-              const cursorInside = hasFocus && cursorPos > start && cursorPos < end;
+              const cursorInside = hasFocus && cursorPos > start &&
+                cursorPos < end;
               if (cursorInside || cursorAdjacent || selectionOverlaps) {
                 // Cursor inside or adjacent - show full [[mention]] with editing style
                 decorations.push(editingMark.range(start, end));
@@ -1538,17 +1548,25 @@ export class CTCodeEditor extends BaseElement {
   /**
    * Update a charm's NAME property when the backlink text changes.
    */
-  private _updateCharmName(charmId: string, newName: string, oldName: string): void {
+  private _updateCharmName(
+    charmId: string,
+    newName: string,
+    oldName: string,
+  ): void {
     const charmCell = this.findCharmById(charmId);
     if (!charmCell) {
-      console.warn(`[ct-code-editor] Cannot update name: charm ${charmId} not found`);
+      console.warn(
+        `[ct-code-editor] Cannot update name: charm ${charmId} not found`,
+      );
       return;
     }
 
     // Get the runtime from the charm cell and update NAME
     const runtime = charmCell.runtime;
     if (!runtime) {
-      console.warn(`[ct-code-editor] Cannot update name: no runtime for charm ${charmId}`);
+      console.warn(
+        `[ct-code-editor] Cannot update name: no runtime for charm ${charmId}`,
+      );
       return;
     }
 
@@ -1557,7 +1575,9 @@ export class CTCodeEditor extends BaseElement {
     charmCell.key(NAME).withTx(tx).set(newName);
     tx.commit();
 
-    console.log(`[ct-code-editor] Updated charm ${charmId} name: "${oldName}" → "${newName}"`);
+    console.log(
+      `[ct-code-editor] Updated charm ${charmId} name: "${oldName}" → "${newName}"`,
+    );
 
     // Emit event for external listeners
     this.emit("backlink-name-changed", {

--- a/packages/ui/src/v2/components/ct-code-editor/styles.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/styles.ts
@@ -109,20 +109,21 @@ export const styles = css`
       font-weight: 500;
       text-decoration: none;
       /* Focus ring to indicate editing */
-      box-shadow: 0 0 0 2px var(--ct-color-primary-300, hsla(212, 100%, 47%, 0.3));
-    }
-
-    /* Legacy fallback - keep for any old usages */
-    .cm-backlink {
-      background-color: var(--ring-alpha, hsla(212, 100%, 47%, 0.1));
-      border-radius: 0.25rem;
-      padding: 0.125rem 0.25rem;
-      cursor: pointer;
-      transition: background-color var(--ct-theme-animation-duration, 150ms)
-        var(--ct-transition-timing-ease);
+      box-shadow: 0 0 0 2px
+        var(--ct-color-primary-300, hsla(212, 100%, 47%, 0.3));
       }
 
-      .cm-backlink:hover {
-        background-color: var(--ring-alpha, hsla(212, 100%, 47%, 0.2));
-      }
-    `;
+      /* Legacy fallback - keep for any old usages */
+      .cm-backlink {
+        background-color: var(--ring-alpha, hsla(212, 100%, 47%, 0.1));
+        border-radius: 0.25rem;
+        padding: 0.125rem 0.25rem;
+        cursor: pointer;
+        transition: background-color var(--ct-theme-animation-duration, 150ms)
+          var(--ct-transition-timing-ease);
+        }
+
+        .cm-backlink:hover {
+          background-color: var(--ring-alpha, hsla(212, 100%, 47%, 0.2));
+        }
+      `;


### PR DESCRIPTION
## Summary
- Add autocomplete dropdown for `[[backlinks]]` that stays open while typing
- Enter key behavior: exact match links to existing charm, no match creates new charm (without navigation)
- Add backlink protection with `atomicRanges` and `transactionFilter` to prevent ID corruption
- Add CSS styles for editing-name state

## Test plan
- [ ] Type `[[` and verify dropdown appears with mentionable items
- [ ] Type partial name and verify dropdown filters
- [ ] Press Enter on exact match - should insert `[[Name (id)]]` as blue pill
- [ ] Press Enter on non-match - should create new charm and insert `[[NewName (newId)]]` as blue pill without navigating
- [ ] Click on blue pill - should navigate to linked charm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds persistent autocomplete for [[backlinks]] with Enter key behavior: exact match inserts [[Name (id)]], no match creates a new charm in place. Protects backlink IDs during edits and improves the editing UI.

- **New Features**
  - Autocomplete stays open while typing inside [[...]]; shows existing charms only. Press Enter to insert exact matches or create a new charm without navigating.
  - Backlink completion inserts [[Name (id)]] and handles auto-closed brackets correctly.
  - Backlink ID protection using a StateField, atomic ranges, and a transaction filter to block edits inside the ID and prevent corruption.
  - UI updates: new name-only editing style for complete backlinks; improved pending/editing pill styles.
  - Sync: editing a backlink’s name updates the linked charm’s NAME and emits a backlink-name-changed event.

<sup>Written for commit 1d9e530d7f2d3d6a69eccd990b626cab36e74b65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

