### PR TITLE
remove .get and .set from IOpaquable interface

### DIFF
--- a/docs/common/TYPES_AND_SCHEMAS.md
+++ b/docs/common/TYPES_AND_SCHEMAS.md
@@ -36,6 +36,22 @@ With `Cell<T>` in your signature:
 
 Without `Cell<>`, you can still display values in JSX, pass to `computed()`, and map over arrays - all reactively. Note: filtering and transformations must be done in `computed()` outside JSX, then the result can be mapped inside JSX.
 
+### Cell<> with Default<>
+
+When you need write access on a pattern input with a default value, wrap `Default<>` in `Cell<>`:
+
+```typescript
+// ❌ No write access - .get()/.set() won't work in handlers
+interface Input {
+  rating: Default<number | null, null>;
+}
+
+// ✅ Write access - .get()/.set() work in handlers
+interface Input {
+  rating: Cell<Default<number | null, null>>;
+}
+```
+
 ---
 
 ## Type Contexts

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -270,10 +270,6 @@ export interface IDerivable<T> {
 
 export interface IOpaquable<T> {
   /** deprecated */
-  get(): T;
-  /** deprecated */
-  set(newValue: Opaque<Partial<T>>): void;
-  /** deprecated */
   setSchema(schema: JSONSchema): void;
 }
 

--- a/packages/patterns/deprecated/list-operations.tsx
+++ b/packages/patterns/deprecated/list-operations.tsx
@@ -21,7 +21,7 @@ interface Item {
 }
 
 interface ListInput {
-  items: Default<Item[], []>;
+  items: Cell<Default<Item[], []>>;
 }
 
 interface ListOutput extends ListInput {}
@@ -101,7 +101,7 @@ export default recipe<ListInput, ListOutput>(
     // caveat: behaviour is only guaranteed to be correct for all operations IF the items include an [ID] property.
     // excluding the [ID] in this recipe leads to item alignment bugs when insertig or removing from items at the FRONT of an array
     const itemsLessThanB = computed(
-      () => items.filter((item) => item.title < "B"),
+      () => items.get().filter((item) => item.title < "B"),
     );
     const extendedItems = computed(
       () =>
@@ -111,7 +111,8 @@ export default recipe<ListInput, ListOutput>(
         ]),
     );
     const combinedItems = computed(
-      () => items.reduce((acc: string, item: Item) => acc += item.title, ""),
+      () =>
+        items.get().reduce((acc: string, item: Item) => acc += item.title, ""),
     );
 
     // Notice that you can bind the same cell to many types

--- a/packages/patterns/rating.tsx
+++ b/packages/patterns/rating.tsx
@@ -35,7 +35,7 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface RatingModuleInput {
   /** Rating from 1-5 stars */
-  rating: Default<number | null, null>;
+  rating: Cell<Default<number | null, null>>;
 }
 
 // ===== Handlers =====

--- a/packages/runner/test/derive-type-inference.test.tsx
+++ b/packages/runner/test/derive-type-inference.test.tsx
@@ -13,10 +13,6 @@ describe("derive type inference", () => {
   function _doNotRun(): void {
     it("should unwrap OpaqueRef<T[]> to T[] in callback", () => {
       const messages = Cell.of<BuiltInLLMMessage[]>().getAsOpaqueRefProxy();
-      messages.set([
-        { role: "user", content: [{ type: "text", text: "hello" }] },
-        { role: "assistant", content: [{ type: "text", text: "hi" }] },
-      ]);
 
       const assistantCount = derive(messages, (msgs) => {
         // Type assertion to verify the type inference is correct
@@ -35,13 +31,6 @@ describe("derive type inference", () => {
       }
 
       const messages = Cell.of<ComplexMessage[]>().getAsOpaqueRefProxy();
-      messages.set([
-        { role: "assistant", content: "hello" },
-        {
-          role: "user",
-          content: [{ text: "hi", type: "text" }],
-        },
-      ]);
 
       const lastMessage = derive(messages, (msgs) => {
         // Verify we can access array properties and methods
@@ -88,7 +77,6 @@ describe("derive type inference", () => {
 
     it("should handle primitive array types", () => {
       const numbers = Cell.of<number[]>().getAsOpaqueRefProxy();
-      numbers.set([1, 2, 3, 4, 5]);
 
       const sum = derive(numbers, (nums) => {
         // Type check: nums should be number[]
@@ -101,7 +89,6 @@ describe("derive type inference", () => {
 
     it("should handle nested array types", () => {
       const matrix = Cell.of<number[][]>().getAsOpaqueRefProxy();
-      matrix.set([[1, 2], [3, 4], [5, 6]]);
 
       const flattened = derive(matrix, (m) => {
         // Type check: m should be number[][]
@@ -124,11 +111,6 @@ describe("derive type inference", () => {
       }
 
       const user = Cell.of<User>().getAsOpaqueRefProxy();
-      user.set({
-        name: "Alice",
-        email: "alice@example.com",
-        profile: { age: 30, city: "NYC" },
-      });
 
       const displayName = derive(user, (u) => {
         // Type check: u should be User
@@ -151,11 +133,6 @@ describe("derive type inference", () => {
       }
 
       const user = Cell.of<User>().getAsOpaqueRefProxy();
-      user.set({
-        name: "Alice",
-        email: "alice@example.com",
-        profile: { age: 30, city: "NYC" },
-      });
 
       const displayName = derive({ user }, ({ user }) => {
         // Type check: u should be User
@@ -179,16 +156,6 @@ describe("derive type inference", () => {
       }
 
       const chatbot = Cell.of<ChatbotState>().getAsOpaqueRefProxy();
-      chatbot.set({
-        messages: [
-          { role: "user", content: "hello" },
-          { role: "assistant", content: "hi there" },
-          { role: "user", content: "how are you?" },
-          { role: "assistant", content: "I'm doing well!" },
-        ],
-        system: "You are a helpful assistant",
-        pending: false,
-      });
 
       // This simulates the exact pattern from omnibox-fab.tsx:
       // derive(omnibot.messages, (messages) => ...)
@@ -234,13 +201,6 @@ describe("derive type inference", () => {
 
       // Simulate what happens when you call a recipe
       const chatbot = Cell.of<ChatOutput>().getAsOpaqueRefProxy();
-      chatbot.set({
-        messages: [
-          { role: "user", content: "hello" },
-          { role: "assistant", content: "response" },
-        ],
-        pending: false,
-      });
 
       // Access messages property - this has type OpaqueCell<Message[]> & Array<OpaqueRef<Message>>
       const messages = chatbot.messages;
@@ -269,12 +229,6 @@ describe("derive type inference", () => {
       }
 
       const parent = Cell.of<{ items: Item[] }>().getAsOpaqueRefProxy();
-      parent.set({
-        items: [
-          { id: 1, name: "first" },
-          { id: 2, name: "second" },
-        ],
-      });
 
       // parent.items has type: OpaqueCell<Item[]> & Array<OpaqueRef<Item>>
       const items = parent.items;
@@ -302,10 +256,6 @@ describe("derive type inference", () => {
       const Chatbot = recipe<ChatbotInput, ChatbotOutput>("TestChatbot", () => {
         const messagesRef = Cell.of<BuiltInLLMMessage[]>()
           .getAsOpaqueRefProxy();
-        messagesRef.set([
-          { role: "user", content: "hello" },
-          { role: "assistant", content: "response" },
-        ]);
 
         return {
           messages: messagesRef,
@@ -335,10 +285,6 @@ describe("derive type inference", () => {
         () => {
           const messagesRef = Cell.of<BuiltInLLMMessage[]>()
             .getAsOpaqueRefProxy();
-          messagesRef.set([
-            { role: "user", content: "hello" },
-            { role: "assistant", content: "response" },
-          ]);
           return {
             messages: messagesRef,
           };
@@ -413,7 +359,6 @@ describe("derive type inference", () => {
     it("should honor explicit derive<In, Out> typing", () => {
       type ExplicitInput = { role: "user"; text: string };
       const explicitCell = Cell.of<ExplicitInput>().getAsOpaqueRefProxy();
-      explicitCell.set({ role: "user", text: "hello" });
 
       const derived = derive<ExplicitInput, number>(
         explicitCell,
@@ -429,7 +374,6 @@ describe("derive type inference", () => {
     it("should honor explicit parameter typing", () => {
       type ExplicitInput = { role: "user"; text: string };
       const explicitCell = Cell.of<ExplicitInput>().getAsOpaqueRefProxy();
-      explicitCell.set({ role: "user", text: "hello" });
 
       const derived = derive(
         explicitCell,
@@ -445,7 +389,6 @@ describe("derive type inference", () => {
     it("should honor explicit Cell<T> inputs", () => {
       type ExplicitInput = { role: "user"; text: string };
       const explicitCell = Cell.of<Cell<ExplicitInput>>().getAsOpaqueRefProxy();
-      explicitCell.set({ role: "user", text: "hello" });
 
       const derived = derive(
         explicitCell,

--- a/packages/runner/test/opaque-ref.test.ts
+++ b/packages/runner/test/opaque-ref.test.ts
@@ -31,6 +31,8 @@ describe("opaqueRef function", () => {
 
   it("throws on get", () => {
     const c = opaqueRef<number>();
-    expect(() => c.get()).toThrow();
+    // Use type assertion since .get() is no longer on OpaqueRef type
+    // but we want to verify runtime still throws
+    expect(() => (c as any).get()).toThrow();
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed deprecated IOpaquable.get/set and updated patterns/docs to use Cell<Default<>> for write access. This clarifies OpaqueRef usage and prevents misuse, with small updates to computed reads and tests.

- **Refactors**
  - Removed .get()/.set() from IOpaquable.
  - Wrapped Default<> inputs in Cell<> for list-operations and rating patterns.
  - Switched computed transforms to items.get().filter/reduce where needed.
  - Cleaned tests by removing .set() on OpaqueRef proxies; adjusted opaqueRef get throw test.
  - Added docs on using Cell<Default<>> to enable writes.

- **Migration**
  - Wrap Default<> in Cell<> when handlers need write access.
  - Use cell.get() for reads inside computed or non-JSX transforms.
  - Do not call .get()/.set() on OpaqueRef; use Cell APIs instead.

<sup>Written for commit 46263ad03d7fee139da784234bc6d32d09ada184. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

