### PR TITLE
ci: disable Toolshed Post-Deploy Patterns Test

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -445,9 +445,10 @@ jobs:
           echo "https://staging.commontools.dev/"
 
   # Post-deployment patterns test (runs after deployment, so this will NOT block deployments.)
+  # DISABLED: This test is currently disabled
   post-deploy-patterns-test:
     name: "Toolshed Post-Deploy Patterns Test"
-    if: github.ref == 'refs/heads/main'
+    if: false # Disabled - was: github.ref == 'refs/heads/main'
     needs: ["deploy-toolshed"]
     runs-on: ubuntu-latest
     environment: toolshed


### PR DESCRIPTION
## Summary
- Disables the "Toolshed Post-Deploy Patterns Test" job in the Deno workflow by setting `if: false`
- Preserves the original condition in a comment for easy re-enablement

Discussed this on discord and in standup.  This test has not been providing valuable signal.  We are still able to run these tests against toolshed manually if desired, but we're taking it out of the github actions config.