### PR TITLE
fix(default-app): remove "as unknown as" casting

### DIFF
--- a/packages/patterns/examples/drag-drop-demo.tsx
+++ b/packages/patterns/examples/drag-drop-demo.tsx
@@ -49,7 +49,7 @@ export default pattern<DragDropDemoInput, DragDropDemoOutput>(
     const items = computed(() => {
       const defaultItems: Item[] = [
         { title: "Item A", [UI]: <div>Hello World!!!</div> },
-        counter as unknown as Item,
+        counter as any, // TODO(seefeld): fix this, title is indeed missing
         { title: "Item C" },
       ];
 

--- a/packages/patterns/system/default-app.tsx
+++ b/packages/patterns/system/default-app.tsx
@@ -164,7 +164,7 @@ export default pattern<CharmsListInput, CharmsListOutput>((_) => {
   const index = BacklinksIndex({ allCharms });
 
   const fab = OmniboxFAB({
-    mentionable: index.mentionable as unknown as Writable<MentionableCharm[]>,
+    mentionable: index.mentionable,
   });
 
   return {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed unsafe "as unknown as" casts to fix default-app compilation and simplify types.

- **Bug Fixes**
  - Pass index.mentionable directly to OmniboxFAB instead of forcing a Writable<MentionableCharm[]> cast.
  - In drag-drop demo, replace the double cast with any as a temporary workaround (title missing).

<sup>Written for commit dd97b02ef0404cfe9bd58a3c494b3511b7205b71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

