### PR TITLE
feat: Reenable debugger controller, now compatible with the IPC

### DIFF
--- a/packages/runtime-client/client/connection.ts
+++ b/packages/runtime-client/client/connection.ts
@@ -14,8 +14,10 @@ import {
   isIPCRemoteNotification,
   isIPCRemoteResponse,
   isNavigateRequestNotification,
+  isTelemetryNotification,
   NavigateRequestNotification,
   RequestType,
+  TelemetryNotification,
 } from "../protocol/mod.ts";
 import { RuntimeTransport } from "./transport.ts";
 import { EventEmitter } from "./emitter.ts";
@@ -37,6 +39,7 @@ export type RuntimeConnectionEvents = {
   console: [ConsoleNotification];
   navigaterequest: [NavigateRequestNotification];
   error: [ErrorNotification];
+  telemetry: [TelemetryNotification];
 };
 
 export interface InitializedRuntimeConnection extends RuntimeConnection {}
@@ -179,6 +182,8 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
     if (isIPCRemoteNotification(message)) {
       if (isCellUpdateNotification(message)) {
         this._handleCellUpdate(message);
+      } else if (isTelemetryNotification(message)) {
+        this.emit("telemetry", message);
       } else if (isConsoleNotification(message)) {
         this.emit("console", message);
       } else if (isNavigateRequestNotification(message)) {

--- a/packages/runtime-client/protocol/guards.ts
+++ b/packages/runtime-client/protocol/guards.ts
@@ -16,6 +16,7 @@ import {
   NavigateRequestNotification,
   NotificationType,
   RequestType,
+  TelemetryNotification,
 } from "./types.ts";
 export { JSONSchema, JSONValue, Program };
 
@@ -73,7 +74,7 @@ export function isIPCRemoteResponse(
 export function isIPCRemoteNotification(
   value: unknown,
 ): value is IPCRemoteNotification {
-  return isCellUpdateNotification(value) ||
+  return isTelemetryNotification(value) || isCellUpdateNotification(value) ||
     isConsoleNotification(value) ||
     isNavigateRequestNotification(value) || isErrorNotification(value);
 }
@@ -117,5 +118,15 @@ export function isErrorNotification(
     isRecord(value) &&
     value.type === NotificationType.ErrorReport &&
     typeof value.message === "string"
+  );
+}
+
+export function isTelemetryNotification(
+  value: unknown,
+): value is TelemetryNotification {
+  return (
+    isRecord(value) &&
+    value.type === NotificationType.Telemetry &&
+    typeof value.marker === "object"
   );
 }

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -2,9 +2,11 @@ import type {
   JSONSchema,
   JSONValue,
   NormalizedFullLink,
+  SchedulerGraphSnapshot,
 } from "@commontools/runner/shared";
 import type { DID, KeyPairRaw } from "@commontools/identity";
 import { type Program } from "@commontools/js-compiler/interface";
+import { RuntimeTelemetryMarkerResult } from "@commontools/runtime-client";
 export type { JSONSchema, JSONValue, Program };
 
 export type MessageId = number;
@@ -32,6 +34,7 @@ export enum RequestType {
   // Runtime operations
   GetCell = "runtime:getCell",
   Idle = "runtime:idle",
+  GetGraphSnapshot = "runtime:getGraphSnapshot",
 
   // Page operations (main -> worker)
   GetSpaceRootPattern = "pattern:getSpaceRoot",
@@ -49,6 +52,7 @@ export enum NotificationType {
   ConsoleMessage = "callback:console",
   NavigateRequest = "callback:navigate",
   ErrorReport = "callback:error",
+  Telemetry = "callback:telemetry",
 }
 
 export interface IPCClientMessage {
@@ -133,6 +137,10 @@ export interface IdleRequest extends BaseRequest {
   type: RequestType.Idle;
 }
 
+export interface GetGraphSnapshotRequest extends BaseRequest {
+  type: RequestType.GetGraphSnapshot;
+}
+
 export interface PageCreateRequest extends BaseRequest {
   type: RequestType.PageCreate;
   source: {
@@ -187,6 +195,7 @@ export type IPCClientRequest =
   | CellSubscribeRequest
   | CellUnsubscribeRequest
   | GetCellRequest
+  | GetGraphSnapshotRequest
   | IdleRequest
   | PageCreateRequest
   | PageGetSpaceDefault
@@ -217,6 +226,10 @@ export interface PageResponse {
   page: PageRef;
 }
 
+export interface GraphSnapshotResponse {
+  snapshot: SchedulerGraphSnapshot;
+}
+
 export interface CellUpdateNotification {
   type: NotificationType.CellUpdate;
   cell: CellRef;
@@ -244,12 +257,18 @@ export interface ErrorNotification {
   spellId?: string;
 }
 
+export interface TelemetryNotification {
+  type: NotificationType.Telemetry;
+  marker: RuntimeTelemetryMarkerResult;
+}
+
 export type RemoteResponse =
   | EmptyResponse
   | NullResponse
   | BooleanResponse
   | JSONValueResponse
   | CellResponse
+  | GraphSnapshotResponse
   | PageResponse;
 
 export type IPCRemoteNotification =
@@ -275,6 +294,10 @@ export type Commands = {
   [RequestType.Idle]: {
     request: IdleRequest;
     response: EmptyResponse;
+  };
+  [RequestType.GetGraphSnapshot]: {
+    request: GetGraphSnapshotRequest;
+    response: GraphSnapshotResponse;
   };
   // Cell requests
   [RequestType.CellGet]: {

--- a/packages/shell/src/lib/debugger-controller.ts
+++ b/packages/shell/src/lib/debugger-controller.ts
@@ -334,19 +334,14 @@ export class DebuggerController implements ReactiveController {
   /**
    * Request a fresh graph snapshot from the scheduler
    */
-  requestGraphSnapshot(): void {
+  async requestGraphSnapshot(): Promise<void> {
     if (!this.runtime) return;
 
     const rt = this.runtime.runtime();
     if (!rt) return;
-
-    // TODO(runtime-worker-refactor)
-    // re-enable
-    /*
-    const snapshot = rt.scheduler.getGraphSnapshot();
+    const snapshot = await rt.getGraphSnapshot();
     this.processGraphSnapshot(snapshot);
     this.host.requestUpdate();
-    */
   }
 
   /**

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -53,6 +53,7 @@ export class RuntimeInternals extends EventTarget {
     this.#client.on("console", this.#onConsole);
     this.#client.on("navigaterequest", this.#onNavigateRequest);
     this.#client.on("error", this.#onError);
+    this.#client.on("telemetry", this.#onTelemetry);
   }
 
   runtime(): RuntimeClient {
@@ -156,6 +157,11 @@ export class RuntimeInternals extends EventTarget {
 
   #onError = (event: RuntimeClientEvents["error"][0]) => {
     console.error("[RuntimeClient Error]", event);
+  };
+
+  #onTelemetry = (marker: RuntimeTelemetryMarkerResult) => {
+    this.#telemetryMarkers.push(marker);
+    this.dispatchEvent(new CustomEvent("telemetryupdate"));
   };
 
   #check() {

--- a/packages/shell/src/views/index.ts
+++ b/packages/shell/src/views/index.ts
@@ -2,8 +2,7 @@ import "./ACLView.ts";
 import "./AppView.ts";
 import "./BodyView.ts";
 import "./CharmListView.ts";
-// TODO(runtime-worker-refactor)
-// import "./DebuggerView.ts";
+import "./DebuggerView.ts";
 import "./HeaderView.ts";
 import "./LoginView.ts";
 import "./RootView.ts";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reenabled the debugger with IPC support. The app can now request scheduler graph snapshots and receive runtime telemetry markers from the worker.

- **New Features**
  - Added RequestType.GetGraphSnapshot and GraphSnapshotResponse; runtime-processor returns scheduler snapshots; RuntimeClient.getGraphSnapshot() exposes it.
  - Updated DebuggerController to fetch snapshots via IPC and restored DebuggerView.
  - Added telemetry streaming over IPC: NotificationType.Telemetry, guards, and connection/client events; shell captures markers and emits telemetryupdate.
  - Hooked telemetry listener lifecycle to runtime init/dispose.

<sup>Written for commit ffd0788168ed763591d24f34c97834c199d3ee02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

