### PR TITLE
fix lift usage

### DIFF
--- a/packages/patterns/system/default-app.tsx
+++ b/packages/patterns/system/default-app.tsx
@@ -4,7 +4,6 @@ import {
   equals,
   handler,
   ifElse,
-  lift,
   NAME,
   navigateTo,
   pattern,
@@ -281,12 +280,12 @@ export default pattern<CharmsListInput, CharmsListOutput>((_) => {
               <tbody>
                 {visibleCharms.map((charm) => {
                   // Check if charm is a notebook by NAME prefix (isNotebook prop not reliable through proxy)
-                  const isNotebook = lift((args: { c: unknown }) => {
-                    const name = (args.c as any)?.[NAME];
+                  const isNotebook = computed(() => {
+                    const name = charm[NAME];
                     const result = typeof name === "string" &&
                       name.startsWith("📓");
                     return result;
-                  })({ c: charm });
+                  });
 
                   const dragHandle = (
                     <ct-drag-source $cell={charm} type="note">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed notebook detection in the default app by replacing lift with computed. isNotebook now updates correctly as charms change and reads NAME directly from the charm.

<sup>Written for commit 06ea87d34d732dafbdc00db8a279bc150cce767a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

