### PR TITLE
feat(runner): normalize negative zero to positive zero in Cell storage

### DIFF
--- a/packages/runner/src/value-codec.ts
+++ b/packages/runner/src/value-codec.ts
@@ -23,7 +23,9 @@ export function isStorableValue(value: unknown): boolean {
     }
 
     case "number": {
-      if (Number.isFinite(value) && !Object.is(value, -0)) {
+      // Finite numbers are storable. Note: `-0` is accepted because it gets
+      // normalized to `0` during conversion (see `toStorableValue()`).
+      if (Number.isFinite(value)) {
         return true;
       }
       // TODO(@danfuzz): `NaN` isn't JSON-encodable; this case should return
@@ -71,8 +73,9 @@ export function toStorableValue(value: unknown): unknown {
     }
 
     case "number": {
-      if (Number.isFinite(value) && !Object.is(value, -0)) {
-        return value;
+      if (Number.isFinite(value)) {
+        // Normalize `-0` to `0` to avoid JSON serialization quirks.
+        return Object.is(value, -0) ? 0 : value;
       } else {
         if (Number.isNaN(value)) {
           // TODO(@danfuzz): This is allowed for now, even though it isn't
@@ -83,7 +86,7 @@ export function toStorableValue(value: unknown): unknown {
           // tweaked, and then this `if` statement should be removed.
           return null;
         }
-        throw new Error("Cannot store non-finite number or negative zero");
+        throw new Error("Cannot store non-finite number");
       }
     }
 

--- a/packages/runner/test/value-codec.test.ts
+++ b/packages/runner/test/value-codec.test.ts
@@ -22,6 +22,7 @@ describe("value-codec", () => {
 
       it("accepts finite numbers", () => {
         expect(isStorableValue(0)).toBe(true);
+        expect(isStorableValue(-0)).toBe(true);
         expect(isStorableValue(1)).toBe(true);
         expect(isStorableValue(-1)).toBe(true);
         expect(isStorableValue(3.14159)).toBe(true);
@@ -59,10 +60,6 @@ describe("value-codec", () => {
       it("rejects Infinity", () => {
         expect(isStorableValue(Infinity)).toBe(false);
         expect(isStorableValue(-Infinity)).toBe(false);
-      });
-
-      it("rejects negative zero", () => {
-        expect(isStorableValue(-0)).toBe(false);
       });
 
       it("rejects functions", () => {
@@ -106,6 +103,13 @@ describe("value-codec", () => {
         expect(toStorableValue(0)).toBe(0);
       });
 
+      it("converts negative zero to positive zero", () => {
+        const result = toStorableValue(-0);
+        expect(result).toBe(0);
+        expect(Object.is(result, -0)).toBe(false);
+        expect(Object.is(result, 0)).toBe(true);
+      });
+
       it("passes through null", () => {
         expect(toStorableValue(null)).toBe(null);
       });
@@ -135,16 +139,10 @@ describe("value-codec", () => {
     describe("throws for non-convertible values", () => {
       it("throws for Infinity", () => {
         expect(() => toStorableValue(Infinity)).toThrow(
-          "Cannot store non-finite number or negative zero",
+          "Cannot store non-finite number",
         );
         expect(() => toStorableValue(-Infinity)).toThrow(
-          "Cannot store non-finite number or negative zero",
-        );
-      });
-
-      it("throws for negative zero", () => {
-        expect(() => toStorableValue(-0)).toThrow(
-          "Cannot store non-finite number or negative zero",
+          "Cannot store non-finite number",
         );
       });
 


### PR DESCRIPTION
## Summary

- Accept `-0` in Cell storage but normalize it to positive `0`
- Previously `-0` was rejected outright; now it's accepted but converted
- Avoids JSON serialization quirks while being more permissive

Suggested by @seefeldb as an alternative to the current reject behavior.

## Test plan

- [x] Updated `isStorableValue` to return `true` for `-0`
- [x] Updated `toStorableValue` to return `0` when given `-0`
- [x] Added test verifying `-0` converts to `0` (using `Object.is` checks)
- [x] Removed tests that expected `-0` to be rejected
- [x] All unit tests pass (`deno task test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow -0 in Cell storage by normalizing it to 0 instead of rejecting it. This avoids JSON serialization quirks and makes number handling more permissive.

- **New Features**
  - isStorableValue now accepts -0.
  - toStorableValue converts -0 to 0 and updates the error to only cover non-finite numbers.
  - Tests updated to verify normalization and remove old rejection cases.

<sup>Written for commit 8df2374b8c1f3483bafff70362bf4382b4fa932a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

