### PR TITLE
revert previous workaround to handler fixtures now that ct-1171 is fixed

### DIFF
--- a/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.tsx
@@ -2,10 +2,7 @@ import * as __ctHelpers from "commontools";
 import { Cell, handler, recipe } from "commontools";
 interface State {
     value: Cell<number>;
-    // TODO(CT-1171): Optional Cell properties (name?: Cell<string>) cause type errors
-    // due to StripCell not handling Cell<T> | undefined unions correctly.
-    // Making this required as a workaround.
-    name: Cell<string>;
+    name?: Cell<string>;
 }
 const myHandler = handler(false as const satisfies __ctHelpers.JSONSchema, {
     type: "object",
@@ -19,7 +16,7 @@ const myHandler = handler(false as const satisfies __ctHelpers.JSONSchema, {
             asCell: true
         }
     },
-    required: ["value", "name"]
+    required: ["value"]
 } as const satisfies __ctHelpers.JSONSchema, (_, state: State) => {
     state.value.set(state.value.get() + 1);
 });
@@ -29,6 +26,7 @@ export default recipe({
         value: { type: "number", asCell: true },
         name: { type: "string", asCell: true },
     },
+    required: ["value"],
 }, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.input.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.input.tsx
@@ -3,10 +3,7 @@ import { Cell, handler, recipe } from "commontools";
 
 interface State {
   value: Cell<number>;
-  // TODO(CT-1171): Optional Cell properties (name?: Cell<string>) cause type errors
-  // due to StripCell not handling Cell<T> | undefined unions correctly.
-  // Making this required as a workaround.
-  name: Cell<string>;
+  name?: Cell<string>;
 }
 
 const myHandler = handler((_, state: State) => {
@@ -19,6 +16,7 @@ export default recipe({
     value: { type: "number", asCell: true },
     name: { type: "string", asCell: true },
   },
+  required: ["value"],
 }, (state) => {
   return {
     // Test case 1: Object literal with all properties from state


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reverts the temporary workaround in ts-transformers handler fixtures now that Linear CT-1171 is fixed. Restores an optional Cell for name and updates JSON schema required fields to only include value, matching the corrected StripCell union handling.

<sup>Written for commit 0f4aad1e0533847656225addb02cc700a942fe36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

