### PR TITLE
chore: disable jsx-key lint rule

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -78,6 +78,7 @@
         "no-external-import"
       ],
       "exclude": [
+        "jsx-key",
         "jsx-no-useless-fragment",
         "no-explicit-any",
         "require-yield"

--- a/packages/patterns/deprecated/array-in-cell-ast-nocomponents.tsx
+++ b/packages/patterns/deprecated/array-in-cell-ast-nocomponents.tsx
@@ -34,10 +34,7 @@ export default recipe<InputSchema>(({ title, items }) => {
         <h3>{title}</h3>
         <p>Super Simple Array</p>
         <ul>
-          {
-            // deno-lint-ignore jsx-key
-            items.map((item) => <li>{item.text}</li>)
-          }
+          {items.map((item) => <li>{item.text}</li>)}
         </ul>
         <ct-message-input
           name="Send"


### PR DESCRIPTION
## Summary
- Disable the `jsx-key` Deno lint rule globally since our JSX system (`@commontools/html`) doesn't use React-style VDOM reconciliation
- Remove manual lint suppression that's no longer needed

## Test plan
- [x] `deno lint` passes without jsx-key warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the jsx-key Deno lint rule globally since @commontools/html doesn’t use React-style reconciliation, and remove the now-unneeded inline suppression in the deprecated pattern file.

<sup>Written for commit 3266b4bee14d64623f735e01a672168feffbb800. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

