### PR TITLE
chore: Remove CharmsController usage for deriving a Result cell

### DIFF
--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -83,3 +83,8 @@ export function getCell(runtime: Runtime, ref: CellRef): Cell<unknown> {
   // contain all this information. Maybe the upstream function should change.
   return runtime.getCellFromLink(ref);
 }
+
+export function getPageResultCell(cell: Cell<any>): Cell<any> {
+  const processCell = cell.getSourceCell();
+  return processCell ? processCell.key("resultRef").resolveAsCell() : cell;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced CharmController-based result resolution with a lightweight helper, reducing overhead and simplifying page handling.

- **Refactors**
  - Added getPageResultCell(cell) to resolve a page’s result via processCell.resultRef, with a safe fallback.
  - Updated PatternCreate and GetSpaceRootPattern to use charm.getCell() + getPageResultCell instead of charm.result.getCell().
  - Simplified handlePageGet: removed CharmController, use asSchema(nameSchema) + getPageResultCell, and made it synchronous.
  - Updated request routing to call handlePageGet without await.

<sup>Written for commit 5f47b6063ff748d0042761fd21a6c85b7a64be49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

