### PR TITLE
chore: add pre-command hook to block git commit --amend

### DIFF
--- a/.claude/scripts/block-git-amend.ts
+++ b/.claude/scripts/block-git-amend.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env -S deno run --allow-read
+/**
+ * .claude/scripts/block-git-amend.ts
+ *
+ * Claude Code Pre-Tool hook.
+ * - Blocks `git commit --amend` commands
+ * - Allows all other commands through
+ */
+
+const rawInput = await new Response(Deno.stdin.readable).text();
+
+let cmd = "";
+try {
+  const payload = JSON.parse(rawInput);
+  cmd = payload?.tool_input?.command ?? "";
+} catch {
+  // If JSON is malformed, allow the call
+  Deno.exit(0);
+}
+
+// Block git commit --amend (including abbreviated forms: --am, --ame, --amen, --amend)
+if (/\bgit\s+commit\b/.test(cmd) && /--am(e(nd?)?)?\b/.test(cmd)) {
+  console.error(
+    "git commit --amend is not allowed. Create a new commit instead.",
+  );
+  Deno.exit(2);
+}
+
+// Allow all other commands
+Deno.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "deno run --allow-read \"$CLAUDE_PROJECT_DIR/.claude/scripts/block-git-amend.ts\""
+          },
+          {
+            "type": "command",
             "command": "deno run --allow-read \"$CLAUDE_PROJECT_DIR/.claude/scripts/block-node.ts\""
           },
           {


### PR DESCRIPTION
## Summary
- Adds a Claude Code pre-command hook that blocks `git commit --amend` commands
- Catches all valid git abbreviations: `--am`, `--ame`, `--amen`, `--amend`
- Ensures commits are always new rather than amended

## Test plan
- [x] Try running `git commit --amend` in Claude Code and verify it's blocked
- [x] Try abbreviated forms like `git commit --am` and verify they're blocked
- [x] Verify normal `git commit` commands still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Claude Code pre-command hook that blocks git commit --amend to enforce creating new commits. Abbreviations (--am, --ame, --amen) are also blocked; normal git commit and other commands still work.

<sup>Written for commit ebc38123b8910d8d038b815139fa0aa635bab8af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

