### PR TITLE
fix(ts-transformers): clarify allowed callbacks in pattern context errors

### DIFF
--- a/packages/ts-transformers/src/transformers/pattern-context-validation.ts
+++ b/packages/ts-transformers/src/transformers/pattern-context-validation.ts
@@ -241,7 +241,7 @@ export class PatternContextValidationTransformer extends Transformer {
       type: "pattern-context:function-creation",
       message: `Function creation is not allowed in pattern context. ` +
         `Move this function to module scope and add explicit type parameters. ` +
-        `Example: const myFn = (price: number) => price * 2;`,
+        `Note: callbacks inside computed(), action(), and .map() are allowed.`,
       node,
     });
   }
@@ -334,7 +334,8 @@ export class PatternContextValidationTransformer extends Transformer {
         type: "pattern-context:builder-placement",
         message:
           `${builderName}() should be defined at module scope, not inside a pattern. ` +
-          `Move this ${builderName}() call outside the pattern/recipe and add explicit type parameters.`,
+          `Move this ${builderName}() call outside the pattern/recipe and add explicit type parameters. ` +
+          `Note: computed(), action(), and .map() callbacks are allowed inside patterns.`,
         node,
       });
     }


### PR DESCRIPTION
## Summary
- Update error message for function creation in pattern context to note that callbacks inside `computed()`, `action()`, and `.map()` are allowed
- Update error message for `lift()`/`handler()` placement to include the same clarification
- Removes the example code from the function-creation error (could be confusing for non-arrow functions)

## Test plan
- [x] Existing tests pass (`deno task test` in ts-transformers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies pattern-context errors in ts-transformers: callbacks inside computed(), action(), and .map() are allowed. Updates the function-creation and lift()/handler() placement messages, and removes the misleading arrow-function example.

<sup>Written for commit 2609cd6f7aaf4399f14c7a8278eb7d0c185c09ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

