### PR TITLE
docs: add guide for invoking handlers from outside a pattern

### DIFF
--- a/docs/development/handlers/invocation-outside-pattern.md
+++ b/docs/development/handlers/invocation-outside-pattern.md
@@ -1,0 +1,49 @@
+# Invoking Handlers from Outside a Pattern
+
+This guide explains how to programmatically invoke a handler stream from `RuntimeProcessor` or anywhere outside the pattern context.
+
+## Steps
+
+### 1. Get the charm cell
+
+```typescript
+const charmCell = someCell.resolveAsCell();
+```
+
+### 2. Apply schema with `{ asStream: true }` on the handler property
+
+```typescript
+const cell = charmCell.asSchema({
+  type: "object",
+  properties: {
+    handlerName: { asStream: true },  // <-- THIS IS THE KEY
+  },
+  required: ["handlerName"],
+});
+```
+
+### 3. Get the handler and call `.send()` directly
+
+No transaction needed:
+
+```typescript
+const handlerStream = cell.key("handlerName");
+handlerStream.send({ eventData });
+```
+
+### 4. Wait for processing
+
+```typescript
+await runtime.idle();
+```
+
+## Why it works
+
+The `{ asStream: true }` in the schema tells the cell that this property is a stream. When you call `.send()` on a stream-marked cell, it internally uses `scheduler.queueEvent()` which triggers the registered handler.
+
+## What doesn't work
+
+| Approach | Result |
+|----------|--------|
+| `.send()` without the schema | Treated as a regular cell, just stores the value |
+| `scheduler.queueEvent()` directly | Handler wasn't registered |


### PR DESCRIPTION
Explains how to use asSchema with { asStream: true } to programmatically trigger handler streams from RuntimeProcessor or other external contexts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a guide for invoking handler streams from RuntimeProcessor or other external contexts using asSchema({ asStream: true }). Covers sending events with .send(), waiting with runtime.idle(), and common pitfalls to avoid (e.g., missing stream schema or direct scheduler calls).

<sup>Written for commit 8be17bcbec8cb876ebeb00d0c373cf8ec2936c31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

