### PR TITLE
docs: add SELF reference and module-scope handler guidance

### DIFF
--- a/docs/common/concepts/lift.md
+++ b/docs/common/concepts/lift.md
@@ -25,3 +25,25 @@ export default pattern<Props, { combined: number }>(({
 ```
 
 Typically it's unusual to use `lift()` directly. It is almost always better to use `computed()`.
+
+## Module Scope Requirement
+
+Like `handler()`, the pattern transformer requires that `lift()` be defined **outside** the pattern body (at module scope) if you need to use it at all:
+
+```typescript
+// CORRECT - define at module scope
+const getByDate = lift((args: { grouped: Record<string, Item[]>; date: string }) =>
+  args.grouped[args.date]
+);
+
+// Then use inside pattern:
+const result = getByDate({ grouped, date });
+
+// WRONG - lift defined and immediately invoked inside pattern
+const result = lift((args) => args.grouped[args.date])({ grouped, date });
+
+// BETTER - use computed() instead of lift for inline use
+const result = computed(() => grouped[date]);
+```
+
+**Why:** The CTS transformer processes patterns at compile time and cannot handle closures over pattern-scoped variables in lifted functions.

--- a/docs/common/concepts/self-reference.md
+++ b/docs/common/concepts/self-reference.md
@@ -1,0 +1,55 @@
+# Self-Referential Types with SELF
+
+Use `SELF` to get a reference to the pattern's own output, useful for:
+- Creating children with a parent reference back to self
+- Adding self to a collection (e.g., registering in a list)
+
+## Example
+
+```typescript
+import { Default, pattern, SELF, UI, Writable } from "commontools";
+
+interface Input {
+  label: Default<string, "Untitled">;
+  parent: Default<Output | null, null>;
+  registry: Writable<Default<Output[], []>>;
+}
+interface Output {
+  label: string;
+  parent: Output | null;
+  children: Output[];
+}
+
+const Node = pattern<Input, Output>(
+  ({ label, parent, registry, [SELF]: self }) => {
+    const children = Writable.of<Output[]>([]);
+
+    return {
+      label,
+      parent,
+      children,
+      [UI]: (
+        <div>
+          <button onClick={() => children.push(Node({ label: "Child", parent: self, registry }))}>
+            Add Child
+          </button>
+          <button onClick={() => registry.push(self)}>
+            Add to Registry
+          </button>
+        </div>
+      ),
+    };
+  },
+);
+
+export default Node;
+```
+
+## Key Rules
+
+- **Both type params required:** Use `pattern<Input, Output>()` - single param `pattern<Input>()` will error if you access SELF
+- **`self` is typed as the output** - the instantiated charm itself, enabling recursive structures
+
+## See Also
+
+- `packages/patterns/self-reference-test.tsx` - Working example

--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -22,6 +22,9 @@ Quick error reference and debugging workflows. For detailed explanations, see li
 | Can't access variable in nested scope | Variable scoping limitation | Pre-compute grouped data or use lift() with explicit params ([reactivity-issues](reactivity-issues.md#variable-scoping-in-reactive-contexts)) |
 | "Cannot access cell via closure" | Using lift() with closure | Pass all reactive deps as params to lift() ([@reactivity](../../common/concepts/reactivity.md)) |
 | CLI `get` returns stale computed values | `charm set` doesn't trigger recompute | Run `charm step` after `set` to trigger re-evaluation ([cli-debugging](cli-debugging.md#stale-computed-values-after-charm-set)) |
+| "handler() should be defined at module scope" | handler() inside pattern body | Move handler() outside pattern ([gotchas/handler-inside-pattern](gotchas/handler-inside-pattern.md)) |
+| "Function creation is not allowed in pattern context" | Helper function inside pattern | Move function to module scope ([gotchas/handler-inside-pattern](gotchas/handler-inside-pattern.md)) |
+| "lift() should not be immediately invoked inside a pattern" | `lift(...)(args)` inside pattern | Use `computed()` instead, or define lift() at module scope ([gotchas/handler-inside-pattern](gotchas/handler-inside-pattern.md)) |
 
 ---
 
@@ -40,6 +43,7 @@ These issues compile without errors but fail at runtime.
 - [lift() Returns Stale/Empty Data](gotchas/lift-returns-stale-data.md) - Closure limitations
 - [Handler Binding Error](gotchas/handler-binding-error.md) - Two-step binding pattern
 - [Stream.of() / .subscribe() Don't Exist](gotchas/stream-subscribe-dont-exist.md) - Bound handlers ARE streams
+- [handler() or Function Inside Pattern](gotchas/handler-inside-pattern.md) - Module scope requirement
 
 ### Error Categories
 

--- a/docs/development/debugging/gotchas/handler-inside-pattern.md
+++ b/docs/development/debugging/gotchas/handler-inside-pattern.md
@@ -1,0 +1,68 @@
+# handler() or Function Inside Pattern
+
+**Error:** `handler() should be defined at module scope, not inside a pattern` or `Function creation is not allowed in pattern context` or `lift() should not be immediately invoked inside a pattern`
+
+**Cause:** The CTS transformer requires that `handler()`, `lift()`, and helper functions be defined at module scope (outside the pattern body). The transformer cannot process closures over pattern-scoped variables.
+
+## Wrong
+
+```typescript
+export default pattern<Input, Input>(({ items }) => {
+  const addItem = handler((_, { items }) => {  // Error!
+    items.push({ title: "New" });
+  });
+
+  const formatDate = (d: string) => new Date(d).toLocaleDateString();  // Error!
+
+  return { ... };
+});
+```
+
+## Correct
+
+```typescript
+// Handler at module scope
+const addItem = handler<unknown, { items: Writable<Item[]> }>(
+  (_, { items }) => {
+    items.push({ title: "New" });
+  }
+);
+
+// Helper function at module scope
+const formatDate = (d: string): string => new Date(d).toLocaleDateString();
+
+export default pattern<Input, Input>(({ items }) => ({
+  [UI]: <ct-button onClick={addItem({ items })}>Add</ct-button>,
+  items,
+}));
+```
+
+## For Immediately-Invoked lift()
+
+```typescript
+// WRONG - lift defined and invoked inside pattern
+const result = lift((args) => args.grouped[args.date])({ grouped, date });
+
+// CORRECT - use computed() instead
+const result = computed(() => grouped[date]);
+
+// OR define lift at module scope
+const getByDate = lift((args: { grouped: Record<string, Item[]>; date: string }) =>
+  args.grouped[args.date]
+);
+// Then use inside pattern:
+const result = getByDate({ grouped, date });
+```
+
+## Allowed Inside Patterns
+
+These are fine inside pattern context:
+- `computed()` callbacks
+- `action()` callbacks
+- `.map()` callbacks on cells/opaques
+- JSX event handlers (e.g., `onClick={() => ...}`)
+
+## See Also
+
+- [@handler](../../../common/concepts/handler.md) - Handler basics and module scope
+- [@lift](../../../common/concepts/lift.md) - Lift basics and module scope


### PR DESCRIPTION
Integrate documentation from main branch PRs into the simplified-docs structure:

- Add self-reference.md for SELF pattern documentation (from #2486)
- Add module-scope requirement sections to handler.md and lift.md
- Add handler-inside-pattern.md gotcha for transformer errors
- Update debugging README with three new error types
- Update runtime-errors.md examples to show handlers at module scope

Changes from #2466 (ts-transformers validation) and #2486 (SELF symbol) are now reflected in the new documentation structure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for SELF and module-scope rules for handler() and lift(), and updates debugging guides to prevent common transformer errors. Clarifies best practices and aligns examples with the simplified-docs structure.

- **New Features**
  - Added self-reference.md with SELF usage, examples, and key rules.
  - Documented module-scope requirement in handler.md and lift.md, with correct/wrong examples and rationale.
  - Added gotchas/handler-inside-pattern.md and updated the debugging README with three new error messages.
  - Updated runtime-errors.md examples to use module-scope handlers and show async guidance with fetchData.

<sup>Written for commit efc4f9782e6925e55aecce5dd76b75492d12a83a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

