### PR TITLE
feat(patterns): add SELF reference to Record pattern for parent access

### DIFF
--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -20,6 +20,7 @@ import {
   lift,
   NAME,
   pattern,
+  SELF,
   str,
   toSchema,
   UI,
@@ -90,6 +91,8 @@ interface RecordOutput {
   title?: Default<string, "">;
   subCharms?: Default<SubCharmEntry[], []>;
   trashedSubCharms?: Default<TrashedSubCharmEntry[], []>;
+  /** Self-reference for sub-charms to access their parent Record */
+  parentRecord?: RecordOutput | null;
 }
 
 // ===== Auto-Initialize Notes + TypePicker (Two-Lift Pattern) =====
@@ -840,7 +843,7 @@ function getDisplayInfo(
 
 // ===== The Record Pattern =====
 const Record = pattern<RecordInput, RecordOutput>(
-  ({ title, subCharms, trashedSubCharms }) => {
+  ({ title, subCharms, trashedSubCharms, [SELF]: self }) => {
     // Local state
     const selectedAddType = Writable.of<string>("");
     const trashExpanded = Writable.of(false);
@@ -2262,6 +2265,9 @@ const Record = pattern<RecordInput, RecordOutput>(
       title,
       subCharms,
       trashedSubCharms,
+      // Self-reference for sub-charms to access their parent Record
+      // Enables cleaner parent-child relationships than ContainerCoordinationContext
+      parentRecord: self,
       "#record": true,
       // LLM-callable streams for Omnibot integration
       // Omnibot can invoke these via: invoke({ "@link": "/of:record-id/getSummary" }, {})


### PR DESCRIPTION
## Summary

Adds a `parentRecord` field to the Record pattern using the new `SELF` symbol, enabling sub-charms to access their parent Record directly.

## Changes

- Import `SELF` symbol from commontools
- Add `parentRecord?: RecordOutput | null` to the `RecordOutput` interface
- Destructure `[SELF]: self` in the pattern function
- Export `parentRecord: self` in the pattern output

## Why

This provides a cleaner alternative to `ContainerCoordinationContext` for parent-child relationships:

- **Direct access**: Sub-charms can now read their parent Record directly via `parentRecord`
- **Reactive**: The reference is reactive - changes to the parent are reflected automatically
- **Persistent**: SELF serializes to `["resultRef"]`, so parent references survive across sessions

## Backwards Compatibility

This is an **additive change** - the existing `ContainerCoordinationContext` approach continues to work. Sub-charms that need to *modify* the parent still receive `Writable<>` cells as inputs (e.g., TypePicker receives `entries` and `trashedEntries`). The new `parentRecord` field provides *read-only* parent access.

## Testing

- Deployed Record pattern to local dev server
- Verified `parentRecord` field exists and is a self-reference
- Verified `parentRecord` is reactive (title changes reflected immediately)
- Tested Type Picker (uses ContainerCoordinationContext) - successfully applied Person template with 6 modules
- All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a parentRecord self-reference to the Record pattern using SELF, letting sub-charms read their parent Record directly and reactively. This is additive and read-only, persists across sessions, and keeps parent modifications via existing writable inputs.

<sup>Written for commit 8e86e16e6d64ad26dbc719af9d20ec058f679355. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

