### PR TITLE
fix(cli): resolve path issues in dev command

### DIFF
--- a/packages/cli/commands/dev.ts
+++ b/packages/cli/commands/dev.ts
@@ -1,5 +1,5 @@
 import { Command } from "@cliffy/command";
-import { join } from "@std/path";
+import { isAbsolute, join } from "@std/path";
 import { render } from "../lib/render.ts";
 import { process } from "../lib/dev.ts";
 import { isRecord } from "@commontools/utils/types";
@@ -39,10 +39,11 @@ export const dev = new Command()
   )
   .arguments("<main:string>")
   .action(async (options, main) => {
-    const mainPath = join(Deno.cwd(), main);
+    const mainPath = isAbsolute(main) ? main : join(Deno.cwd(), main);
 
     const { main: exports } = await process({
       main: mainPath,
+      rootPath: Deno.cwd(),
       check: options.check,
       run: options.run,
       output: options.output,

--- a/packages/cli/lib/dev.ts
+++ b/packages/cli/lib/dev.ts
@@ -19,6 +19,7 @@ async function createRuntime() {
 
 export interface ProcessOptions {
   main: string;
+  rootPath?: string;
   run: boolean;
   check: boolean;
   output?: string;
@@ -37,7 +38,7 @@ export async function process(
     : undefined;
   const engine = new Engine(await createRuntime());
   const program = await engine.resolve(
-    new FileSystemProgramResolver(options.main),
+    new FileSystemProgramResolver(options.main, options.rootPath),
   );
   if (options.mainExport) {
     program.mainExport = options.mainExport;


### PR DESCRIPTION
## Summary
- Fix absolute paths being incorrectly prepended with cwd (e.g., `/cwd/Users/full/path/...`)
- Fix relative imports using `../` not resolving correctly when main file is in a subdirectory
- Pass cwd as `rootPath` to `FileSystemProgramResolver` to allow imports that traverse up directories

## Test plan
- [x] Verified `deno task ct dev system/default-app.tsx` works from `packages/patterns`
- [x] Verified `deno task ct dev /full/path/to/file.tsx` works correctly
- [x] All CLI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix path handling in the ct dev command. Absolute paths are no longer mangled, and ../ imports now resolve from the project root.

- **Bug Fixes**
  - Detect absolute main paths and avoid prefixing them with cwd.
  - Pass cwd as rootPath to FileSystemProgramResolver so ../ imports can traverse up directories.

<sup>Written for commit 16046500d0e62ad4c6c92b98f0de1f8cf1a654b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

