### PR TITLE
fix(shell): load worker from shell origin, not API_URL

### DIFF
--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -12,7 +12,6 @@ import {
 import { WebWorkerRuntimeTransport } from "@commontools/runtime-client/transports/web-worker";
 import { getLogger } from "@commontools/utils/logger";
 import { AppView, navigate } from "../../shared/mod.ts";
-import { API_URL } from "./env.ts";
 
 const logger = getLogger("shell.runtime", {
   enabled: false,
@@ -221,8 +220,13 @@ export class RuntimeInternals extends EventTarget {
       })`,
     );
 
+    // Worker script is bundled with shell assets, so load from shell origin
+    // (not apiUrl which points to the backend/router)
     const transport = await WebWorkerRuntimeTransport.connect({
-      workerUrl: new URL("./scripts/worker-runtime.js", API_URL),
+      workerUrl: new URL(
+        "/scripts/worker-runtime.js",
+        globalThis.location.origin,
+      ),
     });
     const client = await RuntimeClient.initialize(transport, {
       apiUrl,


### PR DESCRIPTION
## Summary

Fixes the shell failing to initialize in ClusterDuck staging/production environments where the shell and router are hosted on different domains.

- **Shell served from**: `https://staging.commontools.dev` (GCS bucket via CDN)
- **API/Router at**: `https://router.stage.commontools.dev` (ClusterDuck router)

## The Problem

PR #2245 moved the runtime to a web worker. The worker URL was constructed as:

```typescript
workerUrl: new URL("./scripts/worker-runtime.js", API_URL)
```

This resolves to `https://router.stage.commontools.dev/scripts/worker-runtime.js`, but:

1. The router only handles `/spaces/{spaceId}/...` routes
2. The router returns **503** for `/scripts/worker-runtime.js`
3. The Worker fails to load
4. RuntimeClient never initializes
5. **No WebSocket connections are ever attempted**

The worker script is actually bundled with shell assets at `https://staging.commontools.dev/scripts/worker-runtime.js`.

## The Fix

Use `globalThis.location.origin` (the shell's origin) instead of `API_URL` for loading the worker:

```typescript
workerUrl: new URL("/scripts/worker-runtime.js", globalThis.location.origin)
```

## Why This Matters for ClusterDuck

ClusterDuck separates concerns:
- **Shell**: Static frontend served from GCS bucket via Cloud CDN
- **Router**: API gateway that proxies requests to space instances

When these are on different hosts (as they are in staging/prod), the shell must load its bundled assets from its own origin, not the API URL.

## Verification

Before fix:
```bash
curl -sk 'https://router.stage.commontools.dev/scripts/worker-runtime.js' -w '%{http_code}'
# 503
```

After fix, shell loads worker from:
```bash
curl -sk 'https://staging.commontools.dev/scripts/worker-runtime.js' -w '%{http_code}'
# 200
```

## Test plan

- [ ] Shell loads successfully on staging.commontools.dev
- [ ] Worker initializes (check browser console for "READY" message)
- [ ] WebSocket connections are established to router
- [ ] Charms render and sync properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load the runtime web worker from the shell origin instead of API_URL to fix shell startup when the shell and router are on different domains in ClusterDuck environments. The worker now loads from /scripts/worker-runtime.js, so RuntimeClient initializes and WebSocket connections are established.

<sup>Written for commit 63ef1ca6263aa4b5d46eb7521d2b5560c9c2333f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

