### PR TITLE
fix(ts-transformers): capture action() results in ternary branch derives

### DIFF
--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.tsx
@@ -1,0 +1,807 @@
+import * as __ctHelpers from "commontools";
+/**
+ * Regression test: action() result used in same ternary branch as computed()
+ *
+ * When a ternary branch contains both a computed() value and an action() reference,
+ * the action must be captured in the derive wrapper along with the computed value.
+ * Previously, action() results were incorrectly classified as "function declarations"
+ * and skipped by CaptureCollector.
+ */
+import { action, Cell, computed, pattern, UI } from "commontools";
+interface Card {
+    title: string;
+    description: string;
+}
+interface Input {
+    card: Card;
+}
+export default pattern(({ card }) => {
+    const isEditing = Cell.of(false, {
+        type: "boolean"
+    } as const satisfies __ctHelpers.JSONSchema);
+    const startEditing = __ctHelpers.handler(false as const satisfies __ctHelpers.JSONSchema, {
+        type: "object",
+        properties: {
+            isEditing: {
+                type: "boolean",
+                asCell: true
+            }
+        },
+        required: ["isEditing"]
+    } as const satisfies __ctHelpers.JSONSchema, (_, { isEditing }) => {
+        isEditing.set(true);
+    })({
+        isEditing: isEditing
+    });
+    const hasDescription = __ctHelpers.derive({
+        type: "object",
+        properties: {
+            card: {
+                type: "object",
+                properties: {
+                    description: {
+                        type: "string",
+                        asOpaque: true
+                    }
+                },
+                required: ["description"]
+            }
+        },
+        required: ["card"]
+    } as const satisfies __ctHelpers.JSONSchema, {
+        type: "boolean"
+    } as const satisfies __ctHelpers.JSONSchema, { card: {
+            description: card.description
+        } }, ({ card }) => {
+        const desc = card.description;
+        return desc && desc.length > 0;
+    });
+    return {
+        [UI]: (<ct-card>
+        {__ctHelpers.ifElse({
+            type: "boolean",
+            asCell: true
+        } as const satisfies __ctHelpers.JSONSchema, {
+            type: "object",
+            properties: {
+                type: {
+                    type: "string"
+                },
+                name: {
+                    type: "string"
+                },
+                props: {
+                    $ref: "#/$defs/Props"
+                },
+                children: {
+                    $ref: "#/$defs/RenderNode"
+                },
+                $UI: {
+                    $ref: "#/$defs/VNode"
+                }
+            },
+            required: ["type", "name", "props"],
+            $defs: {
+                VNode: {
+                    type: "object",
+                    properties: {
+                        type: {
+                            type: "string"
+                        },
+                        name: {
+                            type: "string"
+                        },
+                        props: {
+                            $ref: "#/$defs/Props"
+                        },
+                        children: {
+                            $ref: "#/$defs/RenderNode"
+                        },
+                        $UI: {
+                            $ref: "#/$defs/VNode"
+                        }
+                    },
+                    required: ["type", "name", "props"]
+                },
+                RenderNode: {
+                    anyOf: [{
+                            type: "string"
+                        }, {
+                            type: "number"
+                        }, {
+                            type: "boolean"
+                        }, {
+                            $ref: "#/$defs/VNode"
+                        }, {
+                            type: "object",
+                            properties: {}
+                        }, {
+                            type: "array",
+                            items: {
+                                $ref: "#/$defs/RenderNode"
+                            }
+                        }, {
+                            type: "null"
+                        }]
+                },
+                Props: {
+                    type: "object",
+                    properties: {},
+                    additionalProperties: {
+                        anyOf: [{
+                                type: "string"
+                            }, {
+                                type: "number"
+                            }, {
+                                type: "boolean"
+                            }, {
+                                type: "object",
+                                additionalProperties: true
+                            }, {
+                                type: "array",
+                                items: true
+                            }, {}, {
+                                type: "null"
+                            }]
+                    }
+                }
+            }
+        } as const satisfies __ctHelpers.JSONSchema, {
+            type: "object",
+            properties: {
+                type: {
+                    type: "string"
+                },
+                name: {
+                    type: "string"
+                },
+                props: {
+                    $ref: "#/$defs/Props"
+                },
+                children: {
+                    $ref: "#/$defs/RenderNode"
+                },
+                $UI: {
+                    $ref: "#/$defs/VNode"
+                }
+            },
+            required: ["type", "name", "props"],
+            $defs: {
+                VNode: {
+                    type: "object",
+                    properties: {
+                        type: {
+                            type: "string"
+                        },
+                        name: {
+                            type: "string"
+                        },
+                        props: {
+                            $ref: "#/$defs/Props"
+                        },
+                        children: {
+                            $ref: "#/$defs/RenderNode"
+                        },
+                        $UI: {
+                            $ref: "#/$defs/VNode"
+                        }
+                    },
+                    required: ["type", "name", "props"]
+                },
+                RenderNode: {
+                    anyOf: [{
+                            type: "string"
+                        }, {
+                            type: "number"
+                        }, {
+                            type: "boolean"
+                        }, {
+                            $ref: "#/$defs/VNode"
+                        }, {
+                            type: "object",
+                            properties: {}
+                        }, {
+                            type: "array",
+                            items: {
+                                $ref: "#/$defs/RenderNode"
+                            }
+                        }, {
+                            type: "null"
+                        }]
+                },
+                Props: {
+                    type: "object",
+                    properties: {},
+                    additionalProperties: {
+                        anyOf: [{
+                                type: "string"
+                            }, {
+                                type: "number"
+                            }, {
+                                type: "boolean"
+                            }, {
+                                type: "object",
+                                additionalProperties: true
+                            }, {
+                                type: "array",
+                                items: true
+                            }, {}, {
+                                type: "null"
+                            }]
+                    }
+                }
+            }
+        } as const satisfies __ctHelpers.JSONSchema, {
+            type: "object",
+            properties: {
+                type: {
+                    type: "string"
+                },
+                name: {
+                    type: "string"
+                },
+                props: {
+                    $ref: "#/$defs/Props"
+                },
+                children: {
+                    $ref: "#/$defs/RenderNode"
+                },
+                $UI: {
+                    $ref: "#/$defs/VNode"
+                }
+            },
+            required: ["type", "name", "props"],
+            $defs: {
+                VNode: {
+                    type: "object",
+                    properties: {
+                        type: {
+                            type: "string"
+                        },
+                        name: {
+                            type: "string"
+                        },
+                        props: {
+                            $ref: "#/$defs/Props"
+                        },
+                        children: {
+                            $ref: "#/$defs/RenderNode"
+                        },
+                        $UI: {
+                            $ref: "#/$defs/VNode"
+                        }
+                    },
+                    required: ["type", "name", "props"]
+                },
+                RenderNode: {
+                    anyOf: [{
+                            type: "string"
+                        }, {
+                            type: "number"
+                        }, {
+                            type: "boolean"
+                        }, {
+                            $ref: "#/$defs/VNode"
+                        }, {
+                            type: "object",
+                            properties: {}
+                        }, {
+                            type: "array",
+                            items: {
+                                $ref: "#/$defs/RenderNode"
+                            }
+                        }, {
+                            type: "null"
+                        }]
+                },
+                Props: {
+                    type: "object",
+                    properties: {},
+                    additionalProperties: {
+                        anyOf: [{
+                                type: "string"
+                            }, {
+                                type: "number"
+                            }, {
+                                type: "boolean"
+                            }, {
+                                type: "object",
+                                additionalProperties: true
+                            }, {
+                                type: "array",
+                                items: true
+                            }, {}, {
+                                type: "null"
+                            }]
+                    }
+                }
+            }
+        } as const satisfies __ctHelpers.JSONSchema, isEditing, <div>Editing</div>, __ctHelpers.derive({
+            type: "object",
+            properties: {
+                card: {
+                    type: "object",
+                    properties: {
+                        title: {
+                            type: "string",
+                            asOpaque: true
+                        },
+                        description: {
+                            type: "string",
+                            asOpaque: true
+                        }
+                    },
+                    required: ["title", "description"]
+                },
+                hasDescription: {
+                    type: "boolean",
+                    asOpaque: true
+                },
+                startEditing: {
+                    type: "object",
+                    properties: {
+                        type: {
+                            "enum": ["ref", "javascript", "recipe", "raw", "isolated", "passthrough"]
+                        },
+                        "with": {
+                            asStream: true
+                        }
+                    },
+                    required: ["type", "with"]
+                }
+            },
+            required: ["card", "hasDescription", "startEditing"]
+        } as const satisfies __ctHelpers.JSONSchema, {
+            type: "object",
+            properties: {
+                type: {
+                    type: "string",
+                    "enum": ["vnode"]
+                },
+                name: {
+                    type: "string"
+                },
+                props: {
+                    $ref: "#/$defs/Props"
+                },
+                children: {
+                    $ref: "#/$defs/RenderNode"
+                },
+                $UI: {
+                    $ref: "#/$defs/VNode"
+                }
+            },
+            required: ["type", "name", "props"],
+            $defs: {
+                VNode: {
+                    type: "object",
+                    properties: {
+                        type: {
+                            type: "string",
+                            "enum": ["vnode"]
+                        },
+                        name: {
+                            type: "string"
+                        },
+                        props: {
+                            $ref: "#/$defs/Props"
+                        },
+                        children: {
+                            $ref: "#/$defs/RenderNode"
+                        },
+                        $UI: {
+                            $ref: "#/$defs/VNode"
+                        }
+                    },
+                    required: ["type", "name", "props"]
+                },
+                RenderNode: {
+                    anyOf: [{
+                            type: "string"
+                        }, {
+                            type: "number"
+                        }, {
+                            type: "boolean",
+                            "enum": [false]
+                        }, {
+                            type: "boolean",
+                            "enum": [true]
+                        }, {
+                            $ref: "#/$defs/VNode"
+                        }, {
+                            type: "object",
+                            properties: {}
+                        }, {
+                            type: "object",
+                            properties: {}
+                        }, {
+                            type: "array",
+                            items: {
+                                $ref: "#/$defs/RenderNode"
+                            }
+                        }, {
+                            type: "null"
+                        }]
+                },
+                Props: {
+                    type: "object",
+                    properties: {},
+                    additionalProperties: {
+                        anyOf: [{
+                                type: "string"
+                            }, {
+                                type: "number"
+                            }, {
+                                type: "boolean",
+                                "enum": [false]
+                            }, {
+                                type: "boolean",
+                                "enum": [true]
+                            }, {
+                                type: "object",
+                                additionalProperties: true
+                            }, {
+                                type: "array",
+                                items: true
+                            }, {
+                                asCell: true
+                            }, {
+                                asStream: true
+                            }, {
+                                type: "null"
+                            }]
+                    }
+                }
+            }
+        } as const satisfies __ctHelpers.JSONSchema, {
+            card: {
+                title: card.title,
+                description: card.description
+            },
+            hasDescription: hasDescription,
+            startEditing: startEditing
+        }, ({ card, hasDescription, startEditing }) => (<div>
+            <span>{card.title}</span>
+            {/* Nested ternary with computed - triggers derive wrapper */}
+            {__ctHelpers.ifElse({
+            type: "boolean"
+        } as const satisfies __ctHelpers.JSONSchema, {
+            type: "object",
+            properties: {
+                type: {
+                    type: "string"
+                },
+                name: {
+                    type: "string"
+                },
+                props: {
+                    $ref: "#/$defs/Props"
+                },
+                children: {
+                    $ref: "#/$defs/RenderNode"
+                },
+                $UI: {
+                    $ref: "#/$defs/VNode"
+                }
+            },
+            required: ["type", "name", "props"],
+            $defs: {
+                VNode: {
+                    type: "object",
+                    properties: {
+                        type: {
+                            type: "string"
+                        },
+                        name: {
+                            type: "string"
+                        },
+                        props: {
+                            $ref: "#/$defs/Props"
+                        },
+                        children: {
+                            $ref: "#/$defs/RenderNode"
+                        },
+                        $UI: {
+                            $ref: "#/$defs/VNode"
+                        }
+                    },
+                    required: ["type", "name", "props"]
+                },
+                RenderNode: {
+                    anyOf: [{
+                            type: "string"
+                        }, {
+                            type: "number"
+                        }, {
+                            type: "boolean"
+                        }, {
+                            $ref: "#/$defs/VNode"
+                        }, {
+                            type: "object",
+                            properties: {}
+                        }, {
+                            type: "array",
+                            items: {
+                                $ref: "#/$defs/RenderNode"
+                            }
+                        }, {
+                            type: "null"
+                        }]
+                },
+                Props: {
+                    type: "object",
+                    properties: {},
+                    additionalProperties: {
+                        anyOf: [{
+                                type: "string"
+                            }, {
+                                type: "number"
+                            }, {
+                                type: "boolean"
+                            }, {
+                                type: "object",
+                                additionalProperties: true
+                            }, {
+                                type: "array",
+                                items: true
+                            }, {}, {
+                                type: "null"
+                            }]
+                    }
+                }
+            }
+        } as const satisfies __ctHelpers.JSONSchema, {
+            type: "null"
+        } as const satisfies __ctHelpers.JSONSchema, {
+            anyOf: [{
+                    $ref: "#/$defs/Element"
+                }, {
+                    type: "null"
+                }],
+            $defs: {
+                Element: {
+                    type: "object",
+                    properties: {
+                        type: {
+                            type: "string"
+                        },
+                        name: {
+                            type: "string"
+                        },
+                        props: {
+                            $ref: "#/$defs/Props"
+                        },
+                        children: {
+                            $ref: "#/$defs/RenderNode"
+                        },
+                        $UI: {
+                            $ref: "#/$defs/VNode"
+                        }
+                    },
+                    required: ["type", "name", "props"]
+                },
+                VNode: {
+                    type: "object",
+                    properties: {
+                        type: {
+                            type: "string"
+                        },
+                        name: {
+                            type: "string"
+                        },
+                        props: {
+                            $ref: "#/$defs/Props"
+                        },
+                        children: {
+                            $ref: "#/$defs/RenderNode"
+                        },
+                        $UI: {
+                            $ref: "#/$defs/VNode"
+                        }
+                    },
+                    required: ["type", "name", "props"]
+                },
+                RenderNode: {
+                    anyOf: [{
+                            type: "string"
+                        }, {
+                            type: "number"
+                        }, {
+                            type: "boolean"
+                        }, {
+                            $ref: "#/$defs/VNode"
+                        }, {
+                            type: "object",
+                            properties: {}
+                        }, {
+                            type: "array",
+                            items: {
+                                $ref: "#/$defs/RenderNode"
+                            }
+                        }, {
+                            type: "null"
+                        }]
+                },
+                Props: {
+                    type: "object",
+                    properties: {},
+                    additionalProperties: {
+                        anyOf: [{
+                                type: "string"
+                            }, {
+                                type: "number"
+                            }, {
+                                type: "boolean"
+                            }, {
+                                type: "object",
+                                additionalProperties: true
+                            }, {
+                                type: "array",
+                                items: true
+                            }, {}, {
+                                type: "null"
+                            }]
+                    }
+                }
+            }
+        } as const satisfies __ctHelpers.JSONSchema, hasDescription, <span>{card.description}</span>, null)}
+            {/* Action in SAME branch - must be captured by the derive! */}
+            <ct-button onClick={startEditing}>Edit</ct-button>
+          </div>)))}
+      </ct-card>),
+        card,
+    };
+}, {
+    type: "object",
+    properties: {
+        card: {
+            $ref: "#/$defs/Card"
+        }
+    },
+    required: ["card"],
+    $defs: {
+        Card: {
+            type: "object",
+            properties: {
+                title: {
+                    type: "string"
+                },
+                description: {
+                    type: "string"
+                }
+            },
+            required: ["title", "description"]
+        }
+    }
+} as const satisfies __ctHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $UI: {
+            $ref: "#/$defs/Element"
+        },
+        card: {
+            $ref: "#/$defs/Card",
+            asOpaque: true
+        }
+    },
+    required: ["$UI", "card"],
+    $defs: {
+        Card: {
+            type: "object",
+            properties: {
+                title: {
+                    type: "string"
+                },
+                description: {
+                    type: "string"
+                }
+            },
+            required: ["title", "description"]
+        },
+        Element: {
+            type: "object",
+            properties: {
+                type: {
+                    type: "string",
+                    "enum": ["vnode"]
+                },
+                name: {
+                    type: "string"
+                },
+                props: {
+                    $ref: "#/$defs/Props"
+                },
+                children: {
+                    $ref: "#/$defs/RenderNode"
+                },
+                $UI: {
+                    $ref: "#/$defs/VNode"
+                }
+            },
+            required: ["type", "name", "props"]
+        },
+        VNode: {
+            type: "object",
+            properties: {
+                type: {
+                    type: "string",
+                    "enum": ["vnode"]
+                },
+                name: {
+                    type: "string"
+                },
+                props: {
+                    $ref: "#/$defs/Props"
+                },
+                children: {
+                    $ref: "#/$defs/RenderNode"
+                },
+                $UI: {
+                    $ref: "#/$defs/VNode"
+                }
+            },
+            required: ["type", "name", "props"]
+        },
+        RenderNode: {
+            anyOf: [{
+                    type: "string"
+                }, {
+                    type: "number"
+                }, {
+                    type: "boolean",
+                    "enum": [false]
+                }, {
+                    type: "boolean",
+                    "enum": [true]
+                }, {
+                    $ref: "#/$defs/VNode"
+                }, {
+                    type: "object",
+                    properties: {}
+                }, {
+                    type: "object",
+                    properties: {}
+                }, {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/RenderNode"
+                    }
+                }, {
+                    type: "null"
+                }]
+        },
+        Props: {
+            type: "object",
+            properties: {},
+            additionalProperties: {
+                anyOf: [{
+                        type: "string"
+                    }, {
+                        type: "number"
+                    }, {
+                        type: "boolean",
+                        "enum": [false]
+                    }, {
+                        type: "boolean",
+                        "enum": [true]
+                    }, {
+                        type: "object",
+                        additionalProperties: true
+                    }, {
+                        type: "array",
+                        items: true
+                    }, {
+                        asCell: true
+                    }, {
+                        asStream: true
+                    }, {
+                        type: "null"
+                    }]
+            }
+        }
+    }
+} as const satisfies __ctHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.input.tsx
@@ -1,0 +1,51 @@
+/// <cts-enable />
+/**
+ * Regression test: action() result used in same ternary branch as computed()
+ *
+ * When a ternary branch contains both a computed() value and an action() reference,
+ * the action must be captured in the derive wrapper along with the computed value.
+ * Previously, action() results were incorrectly classified as "function declarations"
+ * and skipped by CaptureCollector.
+ */
+import { action, Cell, computed, pattern, UI } from "commontools";
+
+interface Card {
+  title: string;
+  description: string;
+}
+
+interface Input {
+  card: Card;
+}
+
+export default pattern<Input>(({ card }) => {
+  const isEditing = Cell.of(false);
+
+  const startEditing = action(() => {
+    isEditing.set(true);
+  });
+
+  const hasDescription = computed(() => {
+    const desc = card.description;
+    return desc && desc.length > 0;
+  });
+
+  return {
+    [UI]: (
+      <ct-card>
+        {isEditing ? (
+          <div>Editing</div>
+        ) : (
+          <div>
+            <span>{card.title}</span>
+            {/* Nested ternary with computed - triggers derive wrapper */}
+            {hasDescription ? <span>{card.description}</span> : null}
+            {/* Action in SAME branch - must be captured by the derive! */}
+            <ct-button onClick={startEditing}>Edit</ct-button>
+          </div>
+        )}
+      </ct-card>
+    ),
+    card,
+  };
+});


### PR DESCRIPTION
  When a ternary branch contains both a computed() value and an action()
  reference, the transformer wraps the branch in derive() to capture the
  computed. Previously, the action reference was not included in the
  derive's input object, causing a runtime error:

    'Cell with parent cell not found in current frame.
     Likely a closure that should have been transformed.'

  Root cause: CaptureCollector uses isFunctionDeclaration() to skip
  function declarations (which can't be serialized). However, this
  function treated ANY call expression returning a callable type as a
  'function declaration' - including action() results, which return
  HandlerFactory (a callable factory type).

  The fix adds a check for CommonTools builder calls (action, handler,
  computed, etc.) before the callable-type check. Builder results are
  reactive values that should be captured, not skipped.

  Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix transformer logic so action results are captured when used with computed in a ternary branch. Prevents runtime closure errors and keeps reactive behavior correct in derive wrappers.

- **Bug Fixes**
  - Updated isFunctionDeclaration to recognize CommonTools builder calls (action, handler, computed) and treat their results as reactive values to capture, not plain functions to skip.
  - Added a regression test covering action used in the same ternary branch as computed, ensuring the action is included in the derive input and no runtime error occurs.

<sup>Written for commit dc039d6515d6297ef695c8c7011903c532c50745. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

