### PR TITLE
add two fixtures to cover additional cases of recently fixed transformer bug

### DIFF
--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.tsx
@@ -1,10 +1,10 @@
 import * as __ctHelpers from "commontools";
 /**
- * Regression test: action() with explicit computed() in same ternary branch
+ * Regression test: action() referenced inside explicit computed() in JSX
  *
  * Variation where the pattern author uses computed() explicitly inside JSX
- * (not encouraged, but should still work). The action must be captured in
- * the derive wrapper created for the computed.
+ * (not encouraged, but should still work). The action is referenced INSIDE
+ * the computed expression, so it must be captured in the derive wrapper.
  */
 import { action, Cell, computed, pattern, UI } from "commontools";
 interface Card {
@@ -292,113 +292,82 @@ export default pattern(({ card }) => {
                     }
                 }
             }
-        } as const satisfies __ctHelpers.JSONSchema, isEditing, <div>Editing</div>, __ctHelpers.derive({
-            type: "object",
-            properties: {
-                card: {
-                    type: "object",
-                    properties: {
-                        title: {
-                            type: "string",
-                            asOpaque: true
-                        },
-                        description: {
-                            type: "string",
-                            asOpaque: true
-                        }
-                    },
-                    required: ["title", "description"]
-                },
-                startEditing: {
-                    type: "object",
-                    properties: {
-                        type: {
-                            "enum": ["ref", "javascript", "recipe", "raw", "isolated", "passthrough"]
-                        },
-                        "with": {
-                            asStream: true
-                        }
-                    },
-                    required: ["type", "with"]
-                }
-            },
-            required: ["card", "startEditing"]
-        } as const satisfies __ctHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                type: {
-                    type: "string",
-                    "enum": ["vnode"]
-                },
-                name: {
-                    type: "string"
-                },
-                props: {
-                    $ref: "#/$defs/Props"
-                },
-                children: {
-                    $ref: "#/$defs/RenderNode"
-                },
-                $UI: {
-                    $ref: "#/$defs/VNode"
-                }
-            },
-            required: ["type", "name", "props"],
-            $defs: {
-                VNode: {
-                    type: "object",
-                    properties: {
-                        type: {
-                            type: "string",
-                            "enum": ["vnode"]
-                        },
-                        name: {
-                            type: "string"
-                        },
-                        props: {
-                            $ref: "#/$defs/Props"
-                        },
-                        children: {
-                            $ref: "#/$defs/RenderNode"
-                        },
-                        $UI: {
-                            $ref: "#/$defs/VNode"
-                        }
-                    },
-                    required: ["type", "name", "props"]
-                },
-                RenderNode: {
-                    anyOf: [{
-                            type: "string"
-                        }, {
-                            type: "number"
-                        }, {
-                            type: "boolean",
-                            "enum": [false]
-                        }, {
-                            type: "boolean",
-                            "enum": [true]
-                        }, {
-                            $ref: "#/$defs/VNode"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }, {
-                            type: "array",
-                            items: {
-                                $ref: "#/$defs/RenderNode"
+        } as const satisfies __ctHelpers.JSONSchema, isEditing, <div>Editing</div>, <div>
+            <span>{card.title}</span>
+            {/* Explicit computed() wrapping JSX that references the action */}
+            {/* The action must be captured in the derive created for this computed */}
+            {__ctHelpers.derive({
+                type: "object",
+                properties: {
+                    card: {
+                        type: "object",
+                        properties: {
+                            description: {
+                                type: "string",
+                                asOpaque: true
                             }
-                        }, {
-                            type: "null"
-                        }]
+                        },
+                        required: ["description"]
+                    },
+                    startEditing: {
+                        type: "object",
+                        properties: {
+                            type: {
+                                "enum": ["ref", "javascript", "recipe", "raw", "isolated", "passthrough"]
+                            },
+                            "with": {
+                                asStream: true
+                            }
+                        },
+                        required: ["type", "with"]
+                    }
                 },
-                Props: {
-                    type: "object",
-                    properties: {},
-                    additionalProperties: {
+                required: ["card", "startEditing"]
+            } as const satisfies __ctHelpers.JSONSchema, {
+                type: "object",
+                properties: {
+                    type: {
+                        type: "string",
+                        "enum": ["vnode"]
+                    },
+                    name: {
+                        type: "string"
+                    },
+                    props: {
+                        $ref: "#/$defs/Props"
+                    },
+                    children: {
+                        $ref: "#/$defs/RenderNode"
+                    },
+                    $UI: {
+                        $ref: "#/$defs/VNode"
+                    }
+                },
+                required: ["type", "name", "props"],
+                $defs: {
+                    VNode: {
+                        type: "object",
+                        properties: {
+                            type: {
+                                type: "string",
+                                "enum": ["vnode"]
+                            },
+                            name: {
+                                type: "string"
+                            },
+                            props: {
+                                $ref: "#/$defs/Props"
+                            },
+                            children: {
+                                $ref: "#/$defs/RenderNode"
+                            },
+                            $UI: {
+                                $ref: "#/$defs/VNode"
+                            }
+                        },
+                        required: ["type", "name", "props"]
+                    },
+                    RenderNode: {
                         anyOf: [{
                                 type: "string"
                             }, {
@@ -410,241 +379,62 @@ export default pattern(({ card }) => {
                                 type: "boolean",
                                 "enum": [true]
                             }, {
-                                type: "object",
-                                additionalProperties: true
-                            }, {
-                                type: "array",
-                                items: true
-                            }, {
-                                asCell: true
-                            }, {
-                                asStream: true
-                            }, {
-                                type: "null"
-                            }]
-                    }
-                }
-            }
-        } as const satisfies __ctHelpers.JSONSchema, {
-            card: {
-                title: card.title,
-                description: card.description
-            },
-            startEditing: startEditing
-        }, ({ card, startEditing }) => (<div>
-            <span>{card.title}</span>
-            {/* Explicit computed() in JSX - not encouraged but should work */}
-            {__ctHelpers.ifElse({
-            type: "boolean"
-        } as const satisfies __ctHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                type: {
-                    type: "string"
-                },
-                name: {
-                    type: "string"
-                },
-                props: {
-                    $ref: "#/$defs/Props"
-                },
-                children: {
-                    $ref: "#/$defs/RenderNode"
-                },
-                $UI: {
-                    $ref: "#/$defs/VNode"
-                }
-            },
-            required: ["type", "name", "props"],
-            $defs: {
-                VNode: {
-                    type: "object",
-                    properties: {
-                        type: {
-                            type: "string"
-                        },
-                        name: {
-                            type: "string"
-                        },
-                        props: {
-                            $ref: "#/$defs/Props"
-                        },
-                        children: {
-                            $ref: "#/$defs/RenderNode"
-                        },
-                        $UI: {
-                            $ref: "#/$defs/VNode"
-                        }
-                    },
-                    required: ["type", "name", "props"]
-                },
-                RenderNode: {
-                    anyOf: [{
-                            type: "string"
-                        }, {
-                            type: "number"
-                        }, {
-                            type: "boolean"
-                        }, {
-                            $ref: "#/$defs/VNode"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }, {
-                            type: "array",
-                            items: {
-                                $ref: "#/$defs/RenderNode"
-                            }
-                        }, {
-                            type: "null"
-                        }]
-                },
-                Props: {
-                    type: "object",
-                    properties: {},
-                    additionalProperties: {
-                        anyOf: [{
-                                type: "string"
-                            }, {
-                                type: "number"
-                            }, {
-                                type: "boolean"
+                                $ref: "#/$defs/VNode"
                             }, {
                                 type: "object",
-                                additionalProperties: true
-                            }, {
-                                type: "array",
-                                items: true
-                            }, {}, {
-                                type: "null"
-                            }]
-                    }
-                }
-            }
-        } as const satisfies __ctHelpers.JSONSchema, {
-            type: "null"
-        } as const satisfies __ctHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "#/$defs/Element"
-                }, {
-                    type: "null"
-                }],
-            $defs: {
-                Element: {
-                    type: "object",
-                    properties: {
-                        type: {
-                            type: "string"
-                        },
-                        name: {
-                            type: "string"
-                        },
-                        props: {
-                            $ref: "#/$defs/Props"
-                        },
-                        children: {
-                            $ref: "#/$defs/RenderNode"
-                        },
-                        $UI: {
-                            $ref: "#/$defs/VNode"
-                        }
-                    },
-                    required: ["type", "name", "props"]
-                },
-                VNode: {
-                    type: "object",
-                    properties: {
-                        type: {
-                            type: "string"
-                        },
-                        name: {
-                            type: "string"
-                        },
-                        props: {
-                            $ref: "#/$defs/Props"
-                        },
-                        children: {
-                            $ref: "#/$defs/RenderNode"
-                        },
-                        $UI: {
-                            $ref: "#/$defs/VNode"
-                        }
-                    },
-                    required: ["type", "name", "props"]
-                },
-                RenderNode: {
-                    anyOf: [{
-                            type: "string"
-                        }, {
-                            type: "number"
-                        }, {
-                            type: "boolean"
-                        }, {
-                            $ref: "#/$defs/VNode"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }, {
-                            type: "array",
-                            items: {
-                                $ref: "#/$defs/RenderNode"
-                            }
-                        }, {
-                            type: "null"
-                        }]
-                },
-                Props: {
-                    type: "object",
-                    properties: {},
-                    additionalProperties: {
-                        anyOf: [{
-                                type: "string"
-                            }, {
-                                type: "number"
-                            }, {
-                                type: "boolean"
+                                properties: {}
                             }, {
                                 type: "object",
-                                additionalProperties: true
+                                properties: {}
                             }, {
                                 type: "array",
-                                items: true
-                            }, {}, {
-                                type: "null"
-                            }]
-                    }
-                }
-            }
-        } as const satisfies __ctHelpers.JSONSchema, __ctHelpers.derive({
-            type: "object",
-            properties: {
-                card: {
-                    type: "object",
-                    properties: {
-                        description: {
-                            type: "object",
-                            properties: {
-                                length: {
-                                    type: "number"
+                                items: {
+                                    $ref: "#/$defs/RenderNode"
                                 }
-                            },
-                            required: ["length"]
-                        }
+                            }, {
+                                type: "null"
+                            }]
                     },
-                    required: ["description"]
+                    Props: {
+                        type: "object",
+                        properties: {},
+                        additionalProperties: {
+                            anyOf: [{
+                                    type: "string"
+                                }, {
+                                    type: "number"
+                                }, {
+                                    type: "boolean",
+                                    "enum": [false]
+                                }, {
+                                    type: "boolean",
+                                    "enum": [true]
+                                }, {
+                                    type: "object",
+                                    additionalProperties: true
+                                }, {
+                                    type: "array",
+                                    items: true
+                                }, {
+                                    asStream: true
+                                }, {
+                                    asCell: true
+                                }, {
+                                    type: "null"
+                                }]
+                        }
+                    }
                 }
-            },
-            required: ["card"]
-        } as const satisfies __ctHelpers.JSONSchema, {
-            type: "boolean"
-        } as const satisfies __ctHelpers.JSONSchema, { card: {
-                description: {
-                    length: card.description.length
-                }
-            } }, ({ card }) => card.description.length > 0), <span>{card.description}</span>, null)}
-            {/* Action in SAME branch - must be captured */}
-            <ct-button onClick={startEditing}>Edit</ct-button>
-          </div>)))}
+            } as const satisfies __ctHelpers.JSONSchema, {
+                card: {
+                    description: card.description
+                },
+                startEditing: startEditing
+            }, ({ card, startEditing }) => (<div>
+                <span>{card.description}</span>
+                <ct-button onClick={startEditing}>Edit</ct-button>
+              </div>))}
+          </div>)}
       </ct-card>),
         card,
     };
@@ -788,9 +578,9 @@ export default pattern(({ card }) => {
                         type: "array",
                         items: true
                     }, {
-                        asCell: true
-                    }, {
                         asStream: true
+                    }, {
+                        asCell: true
                     }, {
                         type: "null"
                     }]

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.input.tsx
@@ -1,10 +1,10 @@
 /// <cts-enable />
 /**
- * Regression test: action() with explicit computed() in same ternary branch
+ * Regression test: action() referenced inside explicit computed() in JSX
  *
  * Variation where the pattern author uses computed() explicitly inside JSX
- * (not encouraged, but should still work). The action must be captured in
- * the derive wrapper created for the computed.
+ * (not encouraged, but should still work). The action is referenced INSIDE
+ * the computed expression, so it must be captured in the derive wrapper.
  */
 import { action, Cell, computed, pattern, UI } from "commontools";
 
@@ -32,12 +32,14 @@ export default pattern<Input>(({ card }) => {
         ) : (
           <div>
             <span>{card.title}</span>
-            {/* Explicit computed() in JSX - not encouraged but should work */}
-            {computed(() => card.description.length > 0) ? (
-              <span>{card.description}</span>
-            ) : null}
-            {/* Action in SAME branch - must be captured */}
-            <ct-button onClick={startEditing}>Edit</ct-button>
+            {/* Explicit computed() wrapping JSX that references the action */}
+            {/* The action must be captured in the derive created for this computed */}
+            {computed(() => (
+              <div>
+                <span>{card.description}</span>
+                <ct-button onClick={startEditing}>Edit</ct-button>
+              </div>
+            ))}
           </div>
         )}
       </ct-card>

--- a/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.tsx
@@ -1,11 +1,11 @@
 import * as __ctHelpers from "commontools";
 /**
- * Regression test: inline arrow function action in ternary branch with computed
+ * Regression test: inline arrow function inside explicit computed() in JSX
  *
- * Variation where the action is defined as an inline arrow function in the
- * onClick handler. The transformer will convert this to a handler, and the
- * Cell reference (state.isEditing) must be properly captured in the derive
- * wrapper alongside the computed value (hasDescription).
+ * Variation where an inline arrow function handler is wrapped inside an
+ * explicit computed() in JSX. The transformer will convert the arrow function
+ * to a handler, and the Cell reference (state.isEditing) must be properly
+ * captured in the derive wrapper created for the computed.
  */
 import { Cell, computed, pattern, UI } from "commontools";
 interface Card {
@@ -17,37 +17,6 @@ interface State {
     isEditing: Cell<boolean>;
 }
 export default pattern((state) => {
-    const hasDescription = __ctHelpers.derive({
-        type: "object",
-        properties: {
-            state: {
-                type: "object",
-                properties: {
-                    card: {
-                        type: "object",
-                        properties: {
-                            description: {
-                                type: "string",
-                                asOpaque: true
-                            }
-                        },
-                        required: ["description"]
-                    }
-                },
-                required: ["card"]
-            }
-        },
-        required: ["state"]
-    } as const satisfies __ctHelpers.JSONSchema, {
-        type: "boolean"
-    } as const satisfies __ctHelpers.JSONSchema, { state: {
-            card: {
-                description: state.card.description
-            }
-        } }, ({ state }) => {
-        const desc = state.card.description;
-        return desc && desc.length > 0;
-    });
     return {
         [UI]: (<ct-card>
         {__ctHelpers.ifElse({
@@ -308,115 +277,70 @@ export default pattern((state) => {
                     }
                 }
             }
-        } as const satisfies __ctHelpers.JSONSchema, state.isEditing, <div>Editing</div>, __ctHelpers.derive({
-            type: "object",
-            properties: {
-                state: {
-                    type: "object",
-                    properties: {
-                        card: {
-                            type: "object",
-                            properties: {
-                                title: {
-                                    type: "string",
-                                    asOpaque: true
-                                },
-                                description: {
-                                    type: "string",
-                                    asOpaque: true
-                                }
-                            },
-                            required: ["title", "description"]
-                        },
-                        isEditing: {
-                            type: "boolean",
-                            asCell: true
-                        }
-                    },
-                    required: ["card", "isEditing"]
-                },
-                hasDescription: {
-                    type: "boolean",
-                    asOpaque: true
-                }
-            },
-            required: ["state", "hasDescription"]
-        } as const satisfies __ctHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                type: {
-                    type: "string",
-                    "enum": ["vnode"]
-                },
-                name: {
-                    type: "string"
-                },
-                props: {
-                    $ref: "#/$defs/Props"
-                },
-                children: {
-                    $ref: "#/$defs/RenderNode"
-                },
-                $UI: {
-                    $ref: "#/$defs/VNode"
-                }
-            },
-            required: ["type", "name", "props"],
-            $defs: {
-                VNode: {
-                    type: "object",
-                    properties: {
-                        type: {
-                            type: "string",
-                            "enum": ["vnode"]
-                        },
-                        name: {
-                            type: "string"
-                        },
-                        props: {
-                            $ref: "#/$defs/Props"
-                        },
-                        children: {
-                            $ref: "#/$defs/RenderNode"
-                        },
-                        $UI: {
-                            $ref: "#/$defs/VNode"
-                        }
-                    },
-                    required: ["type", "name", "props"]
-                },
-                RenderNode: {
-                    anyOf: [{
-                            type: "string"
-                        }, {
-                            type: "number"
-                        }, {
-                            type: "boolean",
-                            "enum": [false]
-                        }, {
-                            type: "boolean",
-                            "enum": [true]
-                        }, {
-                            $ref: "#/$defs/VNode"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }, {
-                            type: "array",
-                            items: {
-                                $ref: "#/$defs/RenderNode"
+        } as const satisfies __ctHelpers.JSONSchema, state.isEditing, <div>Editing</div>, <div>
+            <span>{state.card.title}</span>
+            {/* Explicit computed() wrapping a button with inline handler */}
+            {/* The Cell ref in the handler must be captured in the derive */}
+            {__ctHelpers.derive({
+                type: "object",
+                properties: {
+                    state: {
+                        type: "object",
+                        properties: {
+                            isEditing: {
+                                type: "boolean",
+                                asCell: true
                             }
-                        }, {
-                            type: "null"
-                        }]
+                        },
+                        required: ["isEditing"]
+                    }
                 },
-                Props: {
-                    type: "object",
-                    properties: {},
-                    additionalProperties: {
+                required: ["state"]
+            } as const satisfies __ctHelpers.JSONSchema, {
+                type: "object",
+                properties: {
+                    type: {
+                        type: "string",
+                        "enum": ["vnode"]
+                    },
+                    name: {
+                        type: "string"
+                    },
+                    props: {
+                        $ref: "#/$defs/Props"
+                    },
+                    children: {
+                        $ref: "#/$defs/RenderNode"
+                    },
+                    $UI: {
+                        $ref: "#/$defs/VNode"
+                    }
+                },
+                required: ["type", "name", "props"],
+                $defs: {
+                    VNode: {
+                        type: "object",
+                        properties: {
+                            type: {
+                                type: "string",
+                                "enum": ["vnode"]
+                            },
+                            name: {
+                                type: "string"
+                            },
+                            props: {
+                                $ref: "#/$defs/Props"
+                            },
+                            children: {
+                                $ref: "#/$defs/RenderNode"
+                            },
+                            $UI: {
+                                $ref: "#/$defs/VNode"
+                            }
+                        },
+                        required: ["type", "name", "props"]
+                    },
+                    RenderNode: {
                         anyOf: [{
                                 type: "string"
                             }, {
@@ -428,238 +352,95 @@ export default pattern((state) => {
                                 type: "boolean",
                                 "enum": [true]
                             }, {
+                                $ref: "#/$defs/VNode"
+                            }, {
                                 type: "object",
-                                additionalProperties: true
+                                properties: {}
+                            }, {
+                                type: "object",
+                                properties: {}
                             }, {
                                 type: "array",
-                                items: true
+                                items: {
+                                    $ref: "#/$defs/RenderNode"
+                                }
                             }, {
+                                type: "null"
+                            }]
+                    },
+                    Props: {
+                        type: "object",
+                        properties: {},
+                        additionalProperties: {
+                            anyOf: [{
+                                    type: "string"
+                                }, {
+                                    type: "number"
+                                }, {
+                                    type: "boolean",
+                                    "enum": [false]
+                                }, {
+                                    type: "boolean",
+                                    "enum": [true]
+                                }, {
+                                    type: "object",
+                                    additionalProperties: true
+                                }, {
+                                    type: "array",
+                                    items: true
+                                }, {
+                                    asCell: true
+                                }, {
+                                    asStream: true
+                                }, {
+                                    type: "null"
+                                }]
+                        }
+                    }
+                }
+            } as const satisfies __ctHelpers.JSONSchema, { state: {
+                    isEditing: state.isEditing
+                } }, ({ state }) => (<ct-button onClick={__ctHelpers.handler(false as const satisfies __ctHelpers.JSONSchema, {
+                type: "object",
+                properties: {
+                    state: {
+                        type: "object",
+                        properties: {
+                            isEditing: {
+                                type: "boolean",
                                 asCell: true
-                            }, {
-                                asStream: true
-                            }, {
-                                type: "null"
-                            }]
-                    }
-                }
-            }
-        } as const satisfies __ctHelpers.JSONSchema, {
-            state: {
-                card: {
-                    title: state.card.title,
-                    description: state.card.description
-                },
-                isEditing: state.isEditing
-            },
-            hasDescription: hasDescription
-        }, ({ state, hasDescription }) => (<div>
-            <span>{state.card.title}</span>
-            {/* Nested ternary with computed - triggers derive wrapper */}
-            {__ctHelpers.ifElse({
-            type: "boolean"
-        } as const satisfies __ctHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                type: {
-                    type: "string"
-                },
-                name: {
-                    type: "string"
-                },
-                props: {
-                    $ref: "#/$defs/Props"
-                },
-                children: {
-                    $ref: "#/$defs/RenderNode"
-                },
-                $UI: {
-                    $ref: "#/$defs/VNode"
-                }
-            },
-            required: ["type", "name", "props"],
-            $defs: {
-                VNode: {
-                    type: "object",
-                    properties: {
-                        type: {
-                            type: "string"
-                        },
-                        name: {
-                            type: "string"
-                        },
-                        props: {
-                            $ref: "#/$defs/Props"
-                        },
-                        children: {
-                            $ref: "#/$defs/RenderNode"
-                        },
-                        $UI: {
-                            $ref: "#/$defs/VNode"
-                        }
-                    },
-                    required: ["type", "name", "props"]
-                },
-                RenderNode: {
-                    anyOf: [{
-                            type: "string"
-                        }, {
-                            type: "number"
-                        }, {
-                            type: "boolean"
-                        }, {
-                            $ref: "#/$defs/VNode"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }, {
-                            type: "array",
-                            items: {
-                                $ref: "#/$defs/RenderNode"
                             }
-                        }, {
-                            type: "null"
-                        }]
-                },
-                Props: {
-                    type: "object",
-                    properties: {},
-                    additionalProperties: {
-                        anyOf: [{
-                                type: "string"
-                            }, {
-                                type: "number"
-                            }, {
-                                type: "boolean"
-                            }, {
-                                type: "object",
-                                additionalProperties: true
-                            }, {
-                                type: "array",
-                                items: true
-                            }, {}, {
-                                type: "null"
-                            }]
+                        },
+                        required: ["isEditing"]
                     }
-                }
-            }
-        } as const satisfies __ctHelpers.JSONSchema, {
-            type: "null"
-        } as const satisfies __ctHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "#/$defs/Element"
-                }, {
-                    type: "null"
-                }],
-            $defs: {
-                Element: {
-                    type: "object",
-                    properties: {
-                        type: {
-                            type: "string"
-                        },
-                        name: {
-                            type: "string"
-                        },
-                        props: {
-                            $ref: "#/$defs/Props"
-                        },
-                        children: {
-                            $ref: "#/$defs/RenderNode"
-                        },
-                        $UI: {
-                            $ref: "#/$defs/VNode"
-                        }
-                    },
-                    required: ["type", "name", "props"]
                 },
-                VNode: {
-                    type: "object",
-                    properties: {
-                        type: {
-                            type: "string"
-                        },
-                        name: {
-                            type: "string"
-                        },
-                        props: {
-                            $ref: "#/$defs/Props"
-                        },
-                        children: {
-                            $ref: "#/$defs/RenderNode"
-                        },
-                        $UI: {
-                            $ref: "#/$defs/VNode"
-                        }
-                    },
-                    required: ["type", "name", "props"]
-                },
-                RenderNode: {
-                    anyOf: [{
-                            type: "string"
-                        }, {
-                            type: "number"
-                        }, {
-                            type: "boolean"
-                        }, {
-                            $ref: "#/$defs/VNode"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }, {
-                            type: "array",
-                            items: {
-                                $ref: "#/$defs/RenderNode"
+                required: ["state"]
+            } as const satisfies __ctHelpers.JSONSchema, (__ct_handler_event, { state }) => __ctHelpers.derive({
+                type: "object",
+                properties: {
+                    state: {
+                        type: "object",
+                        properties: {
+                            isEditing: {
+                                type: "boolean",
+                                asCell: true
                             }
-                        }, {
-                            type: "null"
-                        }]
-                },
-                Props: {
-                    type: "object",
-                    properties: {},
-                    additionalProperties: {
-                        anyOf: [{
-                                type: "string"
-                            }, {
-                                type: "number"
-                            }, {
-                                type: "boolean"
-                            }, {
-                                type: "object",
-                                additionalProperties: true
-                            }, {
-                                type: "array",
-                                items: true
-                            }, {}, {
-                                type: "null"
-                            }]
+                        },
+                        required: ["isEditing"]
                     }
-                }
-            }
-        } as const satisfies __ctHelpers.JSONSchema, hasDescription, <span>{state.card.description}</span>, null)}
-            {/* Inline arrow function - gets transformed to handler */}
-            {/* state.isEditing Cell must be captured in the derive for the branch */}
-            <ct-button onClick={__ctHelpers.handler(false as const satisfies __ctHelpers.JSONSchema, {
-            type: "object",
-            properties: {
+                },
+                required: ["state"]
+            } as const satisfies __ctHelpers.JSONSchema, {
+                type: "boolean",
+                asCell: true
+            } as const satisfies __ctHelpers.JSONSchema, { state: {
+                    isEditing: state.isEditing
+                } }, ({ state }) => state.isEditing.set(true)))({
                 state: {
-                    type: "object",
-                    properties: {
-                        isEditing: {
-                            type: "boolean",
-                            asCell: true
-                        }
-                    },
-                    required: ["isEditing"]
+                    isEditing: state.isEditing
                 }
-            },
-            required: ["state"]
-        } as const satisfies __ctHelpers.JSONSchema, (__ct_handler_event, { state }) => state.isEditing.set(true))({
-            state: {
-                isEditing: state.isEditing
-            }
-        })}>Edit</ct-button>
-          </div>)))}
+            })}>Edit</ct-button>))}
+          </div>)}
       </ct-card>),
         card: state.card,
     };

--- a/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.input.tsx
@@ -1,11 +1,11 @@
 /// <cts-enable />
 /**
- * Regression test: inline arrow function action in ternary branch with computed
+ * Regression test: inline arrow function inside explicit computed() in JSX
  *
- * Variation where the action is defined as an inline arrow function in the
- * onClick handler. The transformer will convert this to a handler, and the
- * Cell reference (state.isEditing) must be properly captured in the derive
- * wrapper alongside the computed value (hasDescription).
+ * Variation where an inline arrow function handler is wrapped inside an
+ * explicit computed() in JSX. The transformer will convert the arrow function
+ * to a handler, and the Cell reference (state.isEditing) must be properly
+ * captured in the derive wrapper created for the computed.
  */
 import { Cell, computed, pattern, UI } from "commontools";
 
@@ -20,11 +20,6 @@ interface State {
 }
 
 export default pattern<State>((state) => {
-  const hasDescription = computed(() => {
-    const desc = state.card.description;
-    return desc && desc.length > 0;
-  });
-
   return {
     [UI]: (
       <ct-card>
@@ -33,11 +28,11 @@ export default pattern<State>((state) => {
         ) : (
           <div>
             <span>{state.card.title}</span>
-            {/* Nested ternary with computed - triggers derive wrapper */}
-            {hasDescription ? <span>{state.card.description}</span> : null}
-            {/* Inline arrow function - gets transformed to handler */}
-            {/* state.isEditing Cell must be captured in the derive for the branch */}
-            <ct-button onClick={() => state.isEditing.set(true)}>Edit</ct-button>
+            {/* Explicit computed() wrapping a button with inline handler */}
+            {/* The Cell ref in the handler must be captured in the derive */}
+            {computed(() => (
+              <ct-button onClick={() => state.isEditing.set(true)}>Edit</ct-button>
+            ))}
           </div>
         )}
       </ct-card>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add two transformer test fixtures to verify actions and handlers inside ternary branches with computed values are correctly captured in derive wrappers. This improves regression coverage for the recent transformer bug fix.

- **Tests**
  - Action with explicit computed() in the same ternary branch; ensures the onClick handler is captured.
  - Inline arrow function action in a ternary branch with computed; ensures isEditing Cell reference is captured.

<sup>Written for commit ac9b20bedcdee5da6b7e1c133e02447ddac45fbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

