### PR TITLE
dev/2026 simplified docs refinements

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -13,6 +13,6 @@ When entries are added or modified, provenance can be found in this file's git h
 
 | Question | Answer Location | Last Updated |
 |----------|-----------------|--------------|
-| What type should handlers use in Output interfaces? | `docs/common/concepts/types-and-schemas.md` - Section "Handler Types in Output Interfaces". Use `Stream<T>` (not `OpaqueRef<T>`) for handlers in Output interfaces. `Stream<T>` represents a write-only channel that other charms can call via `.send()`. | 2026-01-09 |
+| What type should handlers use in Output interfaces? | `docs/common/concepts/types-and-schemas/exported-handler.md` - Section "Handler Types in Output Interfaces". Use `Stream<T>` (not `OpaqueRef<T>`) for handlers in Output interfaces. `Stream<T>` represents a write-only channel that other charms can call via `.send()`. | 2026-01-09 |
 | How do I run the ct command? | `.claude/skills/ct/SKILL.md` - Section "Running CT". Always use `deno task ct [command]`. There is no binary to build or verify for normal development - ct runs TypeScript directly via deno. | 2025-12-16 |
 | How do I compare objects for identity? Why does my custom `id` property not work? | `docs/common/concepts/identity.md` and `docs/development/debugging/gotchas/custom-id-property-pitfall.md`. Use `equals()` from commontools. Properties in `.map()` callbacks are Cells, not plain values. | 2026-01-13 |

--- a/docs/common/patterns/meta/drag-and-drop.md
+++ b/docs/common/patterns/meta/drag-and-drop.md
@@ -102,8 +102,7 @@ export default pattern<DragDropDemoInput, DragDropDemoOutput>(
           <ct-drop-zone
             accept="item"
             onct-drop={(e: { detail: { sourceCell: Writable<Item> } }) => {
-              const sourceItem = e.detail.sourceCell.get();
-              droppedItems.push(sourceItem);
+              droppedItems.push(e.detail.sourceCell);
             }}
           >
             <div

--- a/docs/common/workflows/pattern-testing.md
+++ b/docs/common/workflows/pattern-testing.md
@@ -177,12 +177,12 @@ deno task ct charm new ./main.test.tsx
 deno task ct charm inspect --charm <CHARM_ID>
 
 # Get specific values
-deno task ct charm get subject.items --charm <CHARM_ID>
+deno task ct charm get subject/items --charm <CHARM_ID>
 
 # Step through manually
-deno task ct charm call tests.0.action --charm <CHARM_ID>
+deno task ct charm call tests/0/action --charm <CHARM_ID>
 deno task ct charm step --charm <CHARM_ID>
-deno task ct charm get tests.1.assertion --charm <CHARM_ID>
+deno task ct charm get tests/1/assertion --charm <CHARM_ID>
 ```
 
 ### 3. Expose Debug Data

--- a/docs/development/debugging/workflow.md
+++ b/docs/development/debugging/workflow.md
@@ -15,7 +15,7 @@ Fix all type errors before deploying. Most issues are caught here.
 - **Type errors** - [@writeable](../../common/concepts/types-and-schemas/writeable.md)
 - **Reactivity issues** - [@reactivity](../../common/concepts/reactivity.md)
 - **Component questions** - [@COMPONENTS](../../common/components/COMPONENTS.md)
-- **Pattern examples** - [@INDEX](../../../packages/patterns/INDEX.md)
+- **Pattern examples** - [@index](../../../packages/patterns/index.md)
 
 ### 3. Inspect Cell Values
 

--- a/packages/cli/commands/charm.ts
+++ b/packages/cli/commands/charm.ts
@@ -147,7 +147,7 @@ export const charm = new Command()
     "Root directory for resolving imports. Allows imports from parent directories within this root.",
   )
   .action(async (options, main) => {
-    if (options.quiet) setQuietMode(true);
+    setQuietMode(!!options.quiet);
     const spaceConfig = parseSpaceOptions(options);
     const charmId = await newCharm(
       spaceConfig,
@@ -237,7 +237,7 @@ export const charm = new Command()
   )
   .arguments("<main:string>")
   .action(async (options, mainPath) => {
-    if (options.quiet) setQuietMode(true);
+    setQuietMode(!!options.quiet);
     const charmConfig = parseCharmOptions(options);
     await setCharmRecipe(charmConfig, {
       mainPath: absPath(mainPath),
@@ -438,7 +438,7 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
   )
   .arguments("<source:string> <target:string>")
   .action(async (options, sourceRef, targetRef) => {
-    if (options.quiet) setQuietMode(true);
+    setQuietMode(!!options.quiet);
     const spaceConfig = parseSpaceOptions(options);
 
     // Parse source and target references - handle both charmId/path and well-known IDs
@@ -521,7 +521,7 @@ JSON VALUES: Strings need quotes: echo '"hello"' | ct charm set ...`,
   .option("--input", "Write to the charm's input cell instead of result cell")
   .arguments("<path:string>")
   .action(async (options, pathString) => {
-    if (options.quiet) setQuietMode(true);
+    setQuietMode(!!options.quiet);
     const charmConfig = parseCharmOptions(options);
     const pathSegments = parsePath(pathString);
     const value = await drainStdin();
@@ -571,7 +571,7 @@ JSON VALUES: Strings need quotes: echo '"hello"' | ct charm set ...`,
   .option("-c,--charm <charm:string>", "The target charm ID.")
   .arguments("<handler:string> [args:string]")
   .action(async (options, handlerName, argsJson) => {
-    if (options.quiet) setQuietMode(true);
+    setQuietMode(!!options.quiet);
     const charmConfig = parseCharmOptions(options);
     const args = argsJson ? JSON.parse(argsJson) : await drainStdin();
     await callCharmHandler(charmConfig, handlerName, args);


### PR DESCRIPTION
- **Simplify and break apart monolithic docs (#2460)**
- **Decompose DEBUGGING.md (#2461)**
- **Typecheck concepts/ docs folder (#2462)**
- **Create drag-and-drop.md meta pattern (#2463)**
- **first rev of condensing pattern-dev skill for new structure**
- **feat(cli): enhance deno task ct --help with progressive disclosure**
- **midway on refactoring battleship and testing it**
- **midway on figuring out symbol issue**
- **docs: move symbol-repro investigation to docs/investigations**
- **Encourage usage of the new docs + fix stale filepaths**
- **docs: add guide for invoking handlers from outside a pattern (#2496)**
- **docs(skill): add UI component research step to pattern-dev**
- **docs(gotcha): add computed Cell [object Object] pitfall**
- **docs: add SELF reference and module-scope handler guidance (#2498)**
- **docs: add CLI testing workflow for handlers**
- **docs: update skill and handler docs to link CLI testing guide**
- **docs(gotcha): warn against custom id properties in patterns**
- **1. Structured Test Format (test-runner.ts)**
- **remove unneeded change**
- **back to required events**
- **change format for specifying tests**
- **Back to optional event parameter on send**
- **first rev of pattern testing docs**
- **remove asOpaque from kind**
- **switch from emphasizing handler to action**
- **update process docs to emphasize pattern testing**
- **doc updates to put equality and scoping up front in pattern-dev**
- **more emphasis on not using IDs**
- **even stronger**
- **new data modeling section**
- **another rev of no-id guidance**
- **oooops go back to simpler version**
- **temporarily delete kanban board**
- **docs: replace charm.md with pattern.md, add action vs handler guidance**
- **docs: integrate automated testing, add CLI guidance, warn about computed in JSX**
- **docs: update conditional.md - ternaries work in JSX**
- **docs: enforce sub-pattern decomposition, reorder layers for test-first**
- **docs: add Layer 3 interactive CLI verification step**
- **docs: strengthen sub-pattern decomposition with concrete example**
- **docs: clarify testing applies to each sub-pattern, not just main.tsx**
- **docs: enforce sequential sub-pattern development with passing tests**
- **docs: explain why computed() isn't needed in JSX (transformer handles it)**
- **guidance for Default**
- **more default guidance**
- **streamline now-bloated process guidance**
- **add line about when to have writable on types**
- **tell it to make final UI at the end**
- **very directive about testing flow**
- **new attempt to emphasize test processes**
- **more guidance about output types and actions**
- **warn against using existing patterns as templates**
- **docs: add navigateTo() guide and mark reading-list as canonical**
- **Action cubic feedback on docs**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified and reorganized docs into small, type-checked guides and added progressive CLI help to make development and debugging faster. Also updated the pattern test runner to a clearer step format and added an optional send() signature for streams.

- New Features
  - Docs: split into concepts, patterns, components, workflows, and debugging; added navigateTo, drag-and-drop, handler invocation, computed-in-JSX, SELF, identity, and gotchas.
  - Docs tooling: docs/check.sh to type-check code blocks (supports subtrees).
  - CLI: richer ct --help, contextual hints for charm commands, --quiet flag, improved dev help and path tips.
  - Testing: test runner now uses discriminated union steps ({ action } / { assertion}); added Pattern Testing guide.
  - API: Stream.send now accepts optional args with conditional types.
  - Patterns: added Battleship pass-and-play test; cleaned up multiplayer file names; marked reading-list as canonical list→detail example.

- Migration
  - Update .test.tsx files to return tests as an array of objects: { assertion: computed(() => ...) } and { action: action(() => ...) }.

<sup>Written for commit 8c5a2616109e405c89b1881845e5db56cdf50bfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

