### PR TITLE
docs: clarify Writable input coercion and test instantiation

### DIFF
--- a/docs/common/concepts/types-and-schemas/writable.md
+++ b/docs/common/concepts/types-and-schemas/writable.md
@@ -35,9 +35,9 @@ With `Writable<T>` in your signature:
 
 Without `Writable<>`, you can still display values in JSX, pass to `computed()`, and map over arrays - all reactively. Note: filtering and transformations must be done in `computed()` outside JSX, then the result can be mapped inside JSX.
 
-### Passing Values to Writable Inputs
+### Passing Values to Pattern Inputs
 
-When calling a pattern that expects `Writable<T>`, you have two options:
+When calling a pattern, you have two options for providing input values:
 
 **Plain values** create independent state for each pattern instance:
 
@@ -50,10 +50,12 @@ const counter2 = Counter({ count: 0 });
 **Cell references** share state across pattern instances:
 
 ```typescript
-const sharedCount = Cell.of(0);
+const sharedCount = Writable.of(0);
 const counter1 = Counter({ count: sharedCount });
 const counter2 = Counter({ count: sharedCount });
 // counter1 and counter2 share state - incrementing one affects both
 ```
 
-For most cases, pass plain values. Use `Cell.of()` when you intentionally want multiple patterns to share the same underlying state.
+For most cases, pass plain values. Use `Writable.of()` when you intentionally want multiple patterns to share the same underlying state.
+
+Note: The `Writable<T>` annotation in a pattern's type signature indicates write intent within that pattern, but doesn't affect how input values are coerced. Plain values always become owned state that the pattern can modify—the pattern can pass these to handlers with `Writable<>` inputs, making them effectively writable regardless of the signature.

--- a/docs/common/workflows/pattern-testing.md
+++ b/docs/common/workflows/pattern-testing.md
@@ -43,7 +43,7 @@ export default pattern(() => {
 });
 ```
 
-**Note:** Pass plain values when instantiating patterns in tests. The runtime creates independent writable cells automatically. Use `Cell.of()` only when you need to test shared state behavior. See [Writable](../concepts/types-and-schemas/writable.md#passing-values-to-writable-inputs) for details.
+**Note:** Pass plain values when instantiating patterns in tests. The runtime creates independent writable cells automatically. Use `Writable.of()` only when you need to test shared state behavior. See [Writable](../concepts/types-and-schemas/writable.md#passing-values-to-pattern-inputs) for details.
 
 ## Running Tests
 


### PR DESCRIPTION
Document the semantic distinction when passing values to patterns expecting Writable<T> inputs:

- Plain values create independent state per pattern instance
- Cell.of() references share state across instances

Update pattern-testing.md to recommend plain values for test instantiation (most common case) and link to the new documentation.

This addresses a documentation gap discovered while investigating agent-generated pattern code that was using Cell.of() unnecessarily.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how Writable<T> inputs are handled: plain values create independent state per pattern instance, while Writable.of() shares state across instances. Updates pattern-testing.md to recommend plain values in tests and links to the new guidance to avoid unintended shared state.

<sup>Written for commit 43f82f32e4d237d9b73dfd86663cafd289458eb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

