### PR TITLE
fix schemas for generic interfaces. now always inline them unless the…

### DIFF
--- a/packages/schema-generator/test/fixtures/schema/cell-brand-variants.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/cell-brand-variants.expected.json
@@ -1,41 +1,24 @@
 {
-  "$defs": {
-    "MyComparableCell": {
+  "properties": {
+    "comparableValue": {
       "asCell": true,
       "type": "number"
     },
-    "MyOpaque": {
+    "opaqueValue": {
       "asOpaque": true,
       "type": "boolean"
     },
-    "MyReadonlyCell": {
+    "readonlyValue": {
       "asCell": true,
       "type": "string"
     },
-    "MyStream": {
+    "streamValue": {
       "asStream": true,
       "type": "number"
     },
-    "MyWriteonlyCell": {
+    "writeonlyValue": {
       "asCell": true,
       "type": "boolean"
-    }
-  },
-  "properties": {
-    "comparableValue": {
-      "$ref": "#/$defs/MyComparableCell"
-    },
-    "opaqueValue": {
-      "$ref": "#/$defs/MyOpaque"
-    },
-    "readonlyValue": {
-      "$ref": "#/$defs/MyReadonlyCell"
-    },
-    "streamValue": {
-      "$ref": "#/$defs/MyStream"
-    },
-    "writeonlyValue": {
-      "$ref": "#/$defs/MyWriteonlyCell"
     }
   },
   "required": [

--- a/packages/schema-generator/test/fixtures/schema/generic-interface-distinct.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/generic-interface-distinct.expected.json
@@ -1,0 +1,42 @@
+{
+  "type": "object",
+  "properties": {
+    "first": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        },
+        "extraParams": {
+          "type": "object",
+          "properties": {
+            "alpha": {
+              "type": "number"
+            }
+          },
+          "required": ["alpha"]
+        }
+      },
+      "required": ["data", "extraParams"]
+    },
+    "second": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string"
+        },
+        "extraParams": {
+          "type": "object",
+          "properties": {
+            "beta": {
+              "type": "string"
+            }
+          },
+          "required": ["beta"]
+        }
+      },
+      "required": ["data", "extraParams"]
+    }
+  },
+  "required": ["first", "second"]
+}

--- a/packages/schema-generator/test/fixtures/schema/generic-interface-distinct.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/generic-interface-distinct.input.ts
@@ -1,0 +1,15 @@
+// Test that generic interface instantiations with different type arguments
+// are NOT collapsed into a single shared $def.
+// This was a bug where PatternToolResult<{ mentionable: X }> and
+// PatternToolResult<{ recentCharms: Y }> were both mapped to the same
+// $ref: "#/$defs/PatternToolResult" definition.
+
+interface GenericResult<E> {
+  data: string;
+  extraParams: E;
+}
+
+interface SchemaRoot {
+  first: GenericResult<{ alpha: number }>;
+  second: GenericResult<{ beta: string }>;
+}

--- a/packages/schema-generator/test/schema-generator.test.ts
+++ b/packages/schema-generator/test/schema-generator.test.ts
@@ -230,4 +230,58 @@ interface HasImage {
       });
     });
   });
+
+  describe("non-serializable type rejection", () => {
+    it("throws error for Map type", async () => {
+      const generator = new SchemaGenerator();
+      const code = `
+interface HasMap {
+  data: Map<string, number>;
+}`;
+      const { type, checker } = await getTypeFromCode(code, "HasMap");
+
+      expect(() => generator.generateSchema(type, checker)).toThrow(
+        /Map cannot be used in pattern inputs\/outputs because it is not JSON-serializable/,
+      );
+    });
+
+    it("throws error for Set type", async () => {
+      const generator = new SchemaGenerator();
+      const code = `
+interface HasSet {
+  items: Set<string>;
+}`;
+      const { type, checker } = await getTypeFromCode(code, "HasSet");
+
+      expect(() => generator.generateSchema(type, checker)).toThrow(
+        /Set cannot be used in pattern inputs\/outputs because it is not JSON-serializable/,
+      );
+    });
+
+    it("throws error for WeakMap type", async () => {
+      const generator = new SchemaGenerator();
+      const code = `
+interface HasWeakMap {
+  cache: WeakMap<object, string>;
+}`;
+      const { type, checker } = await getTypeFromCode(code, "HasWeakMap");
+
+      expect(() => generator.generateSchema(type, checker)).toThrow(
+        /WeakMap cannot be used in pattern inputs\/outputs because it is not JSON-serializable/,
+      );
+    });
+
+    it("throws error for WeakSet type", async () => {
+      const generator = new SchemaGenerator();
+      const code = `
+interface HasWeakSet {
+  seen: WeakSet<object>;
+}`;
+      const { type, checker } = await getTypeFromCode(code, "HasWeakSet");
+
+      expect(() => generator.generateSchema(type, checker)).toThrow(
+        /WeakSet cannot be used in pattern inputs\/outputs because it is not JSON-serializable/,
+      );
+    });
+  });
 });

--- a/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.ts
+++ b/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.ts
@@ -2,11 +2,9 @@ import * as __ctHelpers from "commontools";
 import { handler, Cell } from "commontools";
 interface TimedEvent {
     timestamp: Date;
-    data: Map<string, number>;
 }
 interface TimedState {
     lastUpdate: Cell<Date>;
-    history: Cell<Map<string, Date>>;
 }
 const timedHandler = handler({
     type: "object",
@@ -14,23 +12,9 @@ const timedHandler = handler({
         timestamp: {
             type: "string",
             format: "date-time"
-        },
-        data: {
-            $ref: "#/$defs/Map"
         }
     },
-    required: ["timestamp", "data"],
-    $defs: {
-        Map: {
-            type: "object",
-            properties: {
-                size: {
-                    type: "number"
-                }
-            },
-            required: ["size"]
-        }
-    }
+    required: ["timestamp"]
 } as const satisfies __ctHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -38,29 +22,11 @@ const timedHandler = handler({
             type: "string",
             format: "date-time",
             asCell: true
-        },
-        history: {
-            $ref: "#/$defs/Map",
-            asCell: true
         }
     },
-    required: ["lastUpdate", "history"],
-    $defs: {
-        Map: {
-            type: "object",
-            properties: {
-                size: {
-                    type: "number"
-                }
-            },
-            required: ["size"]
-        }
-    }
+    required: ["lastUpdate"]
 } as const satisfies __ctHelpers.JSONSchema, (event, state) => {
     state.lastUpdate.set(event.timestamp);
-    event.data.forEach((_value, key) => {
-        state.history.get().set(key, new Date());
-    });
 });
 export { timedHandler };
 // @ts-ignore: Internals

--- a/packages/ts-transformers/test/fixtures/handler-schema/date-types.input.ts
+++ b/packages/ts-transformers/test/fixtures/handler-schema/date-types.input.ts
@@ -3,19 +3,14 @@ import { handler, Cell } from "commontools";
 
 interface TimedEvent {
   timestamp: Date;
-  data: Map<string, number>;
 }
 
 interface TimedState {
   lastUpdate: Cell<Date>;
-  history: Cell<Map<string, Date>>;
 }
 
 const timedHandler = handler<TimedEvent, TimedState>((event, state) => {
   state.lastUpdate.set(event.timestamp);
-  event.data.forEach((_value, key) => {
-    state.history.get().set(key, new Date());
-  });
 });
 
 export { timedHandler };


### PR DESCRIPTION
…y're cyclic in which case they get an anonymous type name. also, reject Map and Set as pattern input/output types

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix schema generation for generic interfaces to avoid collisions and simplify output. Generic interface/class instantiations are now inlined (cyclic ones get anonymous $defs), and Map/Set/WeakMap/WeakSet are rejected in pattern inputs/outputs as they aren’t JSON-serializable.

- **Bug Fixes**
  - Stop hoisting generic interface/class instantiations; GenericResult<X> and GenericResult<Y> now produce distinct, inlined schemas.
  - Inline branded wrappers (Cell/Stream/Opaque/etc.) instead of emitting separate $defs.

- **Migration**
  - Replace Map/WeakMap with Record<string, V> or Array<[K, V]>.
  - Replace Set/WeakSet with Array<T>.
  - Schema generation now throws if these types appear in pattern inputs/outputs.

<sup>Written for commit be791b83d43614b7605a6385abc01eff6b0511e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

