### PR TITLE
feat: Re-enable mentions in ct-code-editor with CellHandles

### DIFF
--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -1,4 +1,4 @@
-import { env, waitFor } from "@commontools/integration";
+import { env, Page, waitFor } from "@commontools/integration";
 import { ShellIntegration } from "@commontools/integration/shell-utils";
 import { describe, it } from "@std/testing/bdd";
 import { Identity } from "@commontools/identity";
@@ -28,91 +28,30 @@ describe("default-app flow test", () => {
       identity,
     });
 
-    // Helper to find and click a button by text using piercing selectors
-    const clickButtonWithText = async (
-      searchText: string,
-    ): Promise<boolean> => {
-      try {
-        // Search ct-button, button, and a elements with piercing selector
-        const buttons = await page.$$("ct-button, button, a", {
-          strategy: "pierce",
-        });
-        for (const button of buttons) {
-          const text = await button.innerText();
-          if (text?.trim().includes(searchText)) {
-            await button.click();
-            return true;
-          }
-        }
-        // Also check x-charm-link elements
-        const links = await page.$$("x-charm-link", { strategy: "pierce" });
-        for (const link of links) {
-          const text = await link.innerText();
-          if (text?.trim().includes(searchText)) {
-            await link.click();
-            return true;
-          }
-        }
-        return false;
-      } catch (_) {
-        return false;
-      }
-    };
-
-    // Helper to check if text exists in the DOM using waitForFunction
-    const textExistsInDom = async (searchText: string): Promise<boolean> => {
-      try {
-        // Use page.evaluate to search text in shadow DOM
-        return await page.evaluate((text: string) => {
-          function searchShadowDom(root: Document | ShadowRoot): boolean {
-            const walker = document.createTreeWalker(
-              root,
-              NodeFilter.SHOW_TEXT,
-              null,
-            );
-            let node;
-            while ((node = walker.nextNode())) {
-              if (node.textContent?.includes(text)) {
-                return true;
-              }
-            }
-            const elements = root.querySelectorAll("*");
-            for (const el of elements) {
-              if (el.shadowRoot) {
-                if (searchShadowDom(el.shadowRoot)) {
-                  return true;
-                }
-              }
-            }
-            return false;
-          }
-          return searchShadowDom(document);
-        }, { args: [searchText] });
-      } catch (_) {
-        return false;
-      }
-    };
-
     // Wait for "Notes" dropdown button to appear and click it
+    console.log("Click notes drop down...");
     await waitFor(async () => {
-      return await clickButtonWithText("Notes");
+      return await clickButtonWithText(page, "Notes");
     });
 
     // Wait for dropdown to open and click "New Note"
+    console.log("Click 'New Note'...");
     await waitFor(async () => {
-      return await clickButtonWithText("New Note");
+      return await clickButtonWithText(page, "New Note");
     });
 
     // Wait for the note page to load by checking for the note title
+    console.log("Look for '📝 New Note'...");
     await waitFor(async () => {
-      return await textExistsInDom("📝 New Note");
+      return await textExistsInDom(page, "📝 New Note");
     });
 
     // Wait for the note to be fully persisted
     // Note: We don't have persistence hooks to wait on, so use a sleep
-    await sleep(3000);
+    await sleep(10000);
 
     // Navigate back to the space list
+    console.log("Navigate back to space...");
     await shell.goto({
       frontendUrl: FRONTEND_URL,
       view: { spaceName },
@@ -120,45 +59,116 @@ describe("default-app flow test", () => {
     });
 
     // Wait for the list content to fully load (look for Patterns heading)
+    console.log("Look for 'Patterns'...");
     await waitFor(async () => {
-      return await textExistsInDom("Patterns");
+      return await textExistsInDom(page, "Patterns");
     });
 
-    // Helper to find note in list using regex pattern
-    const findNoteInList = async (): Promise<boolean> => {
-      try {
-        return await page.evaluate(() => {
-          function search(root: Document | ShadowRoot): boolean {
-            const allElements = root.querySelectorAll("*");
-            for (const el of allElements) {
-              const text = el.textContent;
-              // Match pattern: emoji + "New Note #" + hash chars
-              if (text && /📝 New Note #[a-z0-9]+/.test(text)) {
-                return true;
-              }
-              if (el.shadowRoot) {
-                if (search(el.shadowRoot)) {
-                  return true;
-                }
-              }
-            }
-            return false;
-          }
-          return search(document);
-        });
-      } catch (_) {
-        return false;
-      }
-    };
-
+    console.log("Wait for note in list...");
     // Check that the list contains a note item
-    await waitFor(findNoteInList);
+    await waitFor(() => findNoteInList(page));
 
     // Final assertion using the same helper
-    const noteFound = await findNoteInList();
+    const noteFound = await findNoteInList(page);
     assert(
       noteFound,
       "List should contain '📝 New Note #<hash>' after creating a note",
     );
   });
 });
+
+// Helper to find and click a button by text using piercing selectors
+async function clickButtonWithText(
+  page: Page,
+  searchText: string,
+): Promise<boolean> {
+  try {
+    // Search ct-button, button, and a elements with piercing selector
+    const buttons = await page.$$("ct-button, button, a", {
+      strategy: "pierce",
+    });
+    for (const button of buttons) {
+      const text = await button.innerText();
+      if (text?.trim().includes(searchText)) {
+        await button.click();
+        return true;
+      }
+    }
+    // Also check x-charm-link elements
+    const links = await page.$$("x-charm-link", { strategy: "pierce" });
+    for (const link of links) {
+      const text = await link.innerText();
+      if (text?.trim().includes(searchText)) {
+        await link.click();
+        return true;
+      }
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
+
+// Helper to check if text exists in the DOM using waitForFunction
+async function textExistsInDom(
+  page: Page,
+  searchText: string,
+): Promise<boolean> {
+  try {
+    // Use page.evaluate to search text in shadow DOM
+    return await page.evaluate((text: string) => {
+      function searchShadowDom(root: Document | ShadowRoot): boolean {
+        const walker = document.createTreeWalker(
+          root,
+          NodeFilter.SHOW_TEXT,
+          null,
+        );
+        let node;
+        while ((node = walker.nextNode())) {
+          if (node.textContent?.includes(text)) {
+            return true;
+          }
+        }
+        const elements = root.querySelectorAll("*");
+        for (const el of elements) {
+          if (el.shadowRoot) {
+            if (searchShadowDom(el.shadowRoot)) {
+              return true;
+            }
+          }
+        }
+        return false;
+      }
+      return searchShadowDom(document);
+    }, { args: [searchText] });
+  } catch (_) {
+    return false;
+  }
+}
+
+// Helper to find note in list using regex pattern
+async function findNoteInList(page: Page): Promise<boolean> {
+  try {
+    return await page.evaluate(() => {
+      function search(root: Document | ShadowRoot): boolean {
+        const allElements = root.querySelectorAll("*");
+        for (const el of allElements) {
+          const text = el.textContent;
+          // Match pattern: emoji + "New Note #" + hash chars
+          if (text && /📝 New Note #[a-z0-9]+/.test(text)) {
+            return true;
+          }
+          if (el.shadowRoot) {
+            if (search(el.shadowRoot)) {
+              return true;
+            }
+          }
+        }
+        return false;
+      }
+      return search(document);
+    });
+  } catch (_) {
+    return false;
+  }
+}

--- a/packages/ui/src/v2/core/mentionable.ts
+++ b/packages/ui/src/v2/core/mentionable.ts
@@ -1,4 +1,4 @@
-import { NAME } from "@commontools/api";
+import { type JSONSchema, NAME } from "@commontools/runner/shared";
 
 export interface Mentionable {
   [NAME]: string;
@@ -6,3 +6,19 @@ export interface Mentionable {
 }
 
 export type MentionableArray = Mentionable[];
+
+export const MentionableSchema = {
+  type: "object",
+  properties: {
+    [NAME]: { type: "string" },
+  },
+  required: [NAME],
+  // While Mentionable may have extra properies on it,
+  // we don't need to sync them when using in UI code
+  // additionalProperties: true,
+} as const satisfies JSONSchema;
+
+export const MentionableArraySchema = {
+  type: "array",
+  items: MentionableSchema,
+} as const satisfies JSONSchema;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Re-enabled mentions in ct-code-editor using CellHandles and schema-aware bindings so the editor syncs its mentioned list from content and external updates reliably. Reduces unnecessary writes by comparing mentioned IDs before updating.

- **New Features**
  - Added MentionableSchema and MentionableArraySchema; coerces mentionable/mentioned in willUpdate.
  - Subscribed to mentionable and mentioned changes; re-syncs charm name subscriptions; added cleanup.
  - Parsed [[... (id)]] backlinks, resolved IDs against mentionable, and updated mentioned only when IDs change.
  - Removed _getMentionableCell; now use this.mentionable directly.

<sup>Written for commit e6ebcdd68b3b1c541d6a743792c620b38ad2cb07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

