### PR TITLE
fix(runner): detect stream values in query result proxy

### DIFF
--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -970,7 +970,9 @@ describe("Proxy", () => {
     streamCell.send({ $stream: true });
     await runtime.idle();
 
-    expect(c.get()).toStrictEqual({ stream: { $stream: true } });
+    // The stream property returns a Cell (stream kind) rather than raw { $stream: true }
+    // because createQueryResultProxy detects stream markers and returns stream cells
+    expect(c.get().stream).toHaveProperty("send");
     expect(eventCount).toBe(1);
     expect(lastEventSeen).toEqual({ $stream: true });
   });


### PR DESCRIPTION
When a pattern's Output type isn't explicitly specified, the capture schema loses asStream information (becomes `any` -> `true`). This caused .send() to be unavailable on handlers accessed via query result proxy.

Now createQueryResultProxy checks if the value is a stream marker ({ $stream: true }) and returns a stream Cell, enabling .send() calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix stream detection in the query result proxy so handlers expose .send() even when the Output type isn’t specified. Stream markers now return a stream Cell instead of the raw { $stream: true } object.

- **Bug Fixes**
  - createQueryResultProxy detects stream markers via isStreamValue and returns a stream Cell (kind "stream") to enable .send().
  - Updated tests to assert the stream property provides a Cell with .send().

<sup>Written for commit 6f14182e24fe30cee6b1d376ea442c73f5655db2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

