### PR TITLE
chore: Fix race condition in default-app integration test

### DIFF
--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -152,9 +152,7 @@ export class XAppView extends BaseView {
         );
       }
       this.titleSubscription = undefined;
-      this.charmTitle = this.app && "spaceName" in this.app.view
-        ? this.app.view.spaceName
-        : "Common Tools";
+      this.charmTitle = "Untitled";
     } else {
       const cell = activeCharm.cell().key(NAME).asSchema<string>(stringSchema);
       if (

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -156,13 +156,15 @@ export class XHeaderView extends BaseView {
   override render() {
     const spaceLink = this.spaceName
       ? html`
-        <x-charm-link .spaceName="${this.spaceName}">${this
+        <x-charm-link id="header-space-link" .spaceName="${this.spaceName}"
+        >${this
           .spaceName}</x-charm-link>
       `
       : null;
     const charmLink = this.charmId && this.spaceName
       ? html`
         <x-charm-link
+          id="header-charm-link"
           .charmId="${this.charmId}"
           .spaceName="${this.spaceName}"
         >${this.charmTitle || this.charmId}</x-charm-link>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a race condition in the default-app integration test by waiting on a stable header link instead of arbitrary timers. Adds stable selectors in the header to make the test reliable.

- Bug Fixes
  - Test now waits for #header-charm-link text, removes the 10s sleep and shadow-DOM text search, and returns to the space page by clicking the space name.
  - Header adds id attributes for space/charm links and sets the fallback charm title to "Untitled" to prevent timing mismatches.

<sup>Written for commit 5af3067a649ecc62acebd06bb33497e270977fe6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

