### PR TITLE
fix(runtime-client): fix start error

### DIFF
--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -33,7 +33,13 @@ export function cellRefToSigilLink(cell: CellRef): SigilLink {
 }
 
 export function createCellRef(cell: Cell<unknown>, schema?: unknown): CellRef {
-  const link = parseLink(cell.getAsLink());
+  const link = parseLink(
+    cell.getAsLink({
+      includeSchema: true,
+      keepAsCell: true,
+      keepStreams: true,
+    }),
+  );
   // Check before casting to a NormalizedFullLink
   if (!link.id || !link.space || !link.type) {
     throw new Error("Serialized links must contain id, space, type.");
@@ -47,7 +53,10 @@ export function createCellRef(cell: Cell<unknown>, schema?: unknown): CellRef {
   if (link.schema != null) cellRef.schema = link.schema;
   if (link.rootSchema != null) cellRef.rootSchema = link.rootSchema;
   if (link.overwrite != null) cellRef.overwrite = link.overwrite;
-  if (schema !== undefined) cellRef.schema = schema as JSONSchema;
+  if (schema !== undefined) {
+    cellRef.schema = schema as JSONSchema;
+    delete cellRef.rootSchema;
+  }
   return cellRef;
 }
 

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -232,8 +232,9 @@ export class CellHandle<T = unknown> {
    * Create a new CellHandle with a different schema.
    */
   asSchema<U = unknown>(schema: JSONSchema): CellHandle<U> {
+    const { schema: _schema, rootSchema: _rootSchema, ...rest } = this.#ref;
     const newCell = new CellHandle(this.#rt, {
-      ...this.#ref,
+      ...rest,
       schema,
     });
     newCell.#value = this.#value;


### PR DESCRIPTION
- make sure schemas are sent from worker side, which includes charm list schema
- make sure schema is never changed without resetting rootSchema

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a runtime-client start error by ensuring cells carry their schema from the worker and by resetting rootSchema whenever the schema changes.

- **Bug Fixes**
  - Send schema in cell links from the worker (including charm list) to prevent missing schema at startup.
  - Clear rootSchema whenever a new schema is set to avoid mismatches and start failures.

<sup>Written for commit 9a051719f1748946843d54edeab33066d80223ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

