### PR TITLE
chore: remove extraneous typescript dependency

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -124,7 +124,6 @@
     "npm:stoker@^1.4.2": "1.4.3_@hono+zod-openapi@0.18.4__hono@4.10.5__zod@3.25.76_hono@4.10.5_zod@3.25.76",
     "npm:turndown@^7.1.2": "7.2.2",
     "npm:typescript@*": "5.9.3",
-    "npm:typescript@5.4.5": "5.4.5",
     "npm:zod@^3.24.1": "3.25.76"
   },
   "jsr": {
@@ -1737,10 +1736,6 @@
       "dependencies": [
         "@mixmark-io/domino"
       ]
-    },
-    "typescript@5.4.5": {
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "bin": true
     },
     "typescript@5.9.3": {
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed a duplicate TypeScript dependency from deno.lock so we use a single version (5.9.3) across the project. This avoids conflicting resolutions and reduces lockfile churn.

<sup>Written for commit 2f862db9a67afb143e2d3f22328b612982906e62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

