### PR TITLE
Patterns/rewrite habit tracker

### DIFF
--- a/packages/patterns/habit-tracker.test.tsx
+++ b/packages/patterns/habit-tracker.test.tsx
@@ -1,0 +1,186 @@
+/// <cts-enable />
+/**
+ * Test Pattern: Habit Tracker
+ *
+ * Tests the core functionality of the habit-tracker pattern:
+ * - Initial state (no habits, no logs)
+ * - Adding habits
+ * - Toggling habit completion (creates log)
+ * - Toggling habit again (uncompletes)
+ * - Deleting habits
+ *
+ * Run: deno task ct test packages/patterns/habit-tracker.test.tsx --verbose
+ */
+import { action, computed, pattern } from "commontools";
+import HabitTracker, { type Habit } from "./habit-tracker.tsx";
+
+// Module-level type for habit log
+interface HabitLog {
+  habitName: string;
+  date: string;
+  completed: boolean;
+}
+
+export default pattern(() => {
+  // Instantiate the habit tracker pattern with empty initial state
+  // Pass plain values - runtime creates writable cells automatically
+  const subject = HabitTracker({ habits: [], logs: [] });
+
+  // ==========================================================================
+  // Actions - using action() to trigger stream sends
+  // ==========================================================================
+
+  // Add a habit
+  const action_add_habit = action(() => {
+    subject.addHabit.send({ name: "Exercise", icon: "🏃" });
+  });
+
+  // Add a second habit for deletion test
+  const action_add_second_habit = action(() => {
+    subject.addHabit.send({ name: "Read", icon: "📚" });
+  });
+
+  // Toggle habit completion (marks as complete)
+  const action_toggle_habit_complete = action(() => {
+    subject.toggleHabit.send({ habitName: "Exercise" });
+  });
+
+  // Toggle habit again (should uncomplete)
+  const action_toggle_habit_uncomplete = action(() => {
+    subject.toggleHabit.send({ habitName: "Exercise" });
+  });
+
+  // Delete the second habit by name
+  const action_delete_habit = action(() => {
+    subject.deleteHabit.send({
+      habit: { name: "Read", icon: "📚", color: "#3b82f6" },
+    });
+  });
+
+  // ==========================================================================
+  // Assertions - computed booleans
+  // ==========================================================================
+
+  // Test 1: Initial state - no habits
+  // Note: Using filter().length for proper reactivity tracking
+  const assert_initial_no_habits = computed(() => {
+    return subject.habits.filter(() => true).length === 0;
+  });
+
+  // Test 1: Initial state - no logs
+  const assert_initial_no_logs = computed(() => {
+    return subject.logs.filter(() => true).length === 0;
+  });
+
+  // Test 2: After adding first habit
+  // Note: Using filter().length instead of direct .length for better reactivity
+  const assert_has_one_habit = computed(() => {
+    const habits = subject.habits.filter(() => true);
+    return habits.length === 1;
+  });
+
+  const assert_habit_name_correct = computed(
+    () => subject.habits[0]?.name === "Exercise",
+  );
+
+  const assert_habit_icon_correct = computed(
+    () => subject.habits[0]?.icon === "🏃",
+  );
+
+  // Test 3: After toggling habit (completion creates log)
+  const assert_log_created = computed(() => {
+    return subject.logs.filter(() => true).length === 1;
+  });
+
+  const assert_log_completed_true = computed(() => {
+    const log = subject.logs.find(
+      (l: HabitLog) => l.habitName === "Exercise",
+    );
+    return log?.completed === true;
+  });
+
+  const assert_log_habitName_correct = computed(() => {
+    const log = subject.logs[0];
+    return log?.habitName === "Exercise";
+  });
+
+  const assert_log_date_is_today = computed(() => {
+    const log = subject.logs[0];
+    return log?.date === subject.todayDate;
+  });
+
+  // Test 4: After toggling again (should uncomplete - toggle existing log)
+  const assert_log_completed_false = computed(() => {
+    const log = subject.logs.find(
+      (l: HabitLog) => l.habitName === "Exercise",
+    );
+    return log?.completed === false;
+  });
+
+  // Still only one log (toggling updates existing, doesn't create new)
+  const assert_still_one_log = computed(() => {
+    return subject.logs.filter(() => true).length === 1;
+  });
+
+  // Test 5: After adding second habit
+  const assert_has_two_habits = computed(() => {
+    return subject.habits.filter(() => true).length === 2;
+  });
+
+  const assert_second_habit_exists = computed(() => {
+    return subject.habits.some((h: Habit) => h.name === "Read");
+  });
+
+  // Test 5: After deleting second habit
+  const assert_back_to_one_habit = computed(() => {
+    return subject.habits.filter(() => true).length === 1;
+  });
+
+  const assert_read_habit_deleted = computed(() => {
+    return !subject.habits.some((h: Habit) => h.name === "Read");
+  });
+
+  const assert_exercise_habit_remains = computed(() => {
+    return subject.habits.some((h: Habit) => h.name === "Exercise");
+  });
+
+  // ==========================================================================
+  // Test Sequence
+  // ==========================================================================
+  return {
+    tests: [
+      // === Test 1: Initial state - no habits, no logs ===
+      { assertion: assert_initial_no_habits },
+      { assertion: assert_initial_no_logs },
+
+      // === Test 2: Add habit - verify habit count increases ===
+      { action: action_add_habit },
+      { assertion: assert_has_one_habit },
+      { assertion: assert_habit_name_correct },
+      { assertion: assert_habit_icon_correct },
+
+      // === Test 3: Toggle habit completion - verify log is created ===
+      { action: action_toggle_habit_complete },
+      { assertion: assert_log_created },
+      { assertion: assert_log_completed_true },
+      { assertion: assert_log_habitName_correct },
+      { assertion: assert_log_date_is_today },
+
+      // === Test 4: Toggle habit uncomplete - verify completion toggles off ===
+      { action: action_toggle_habit_uncomplete },
+      { assertion: assert_still_one_log },
+      { assertion: assert_log_completed_false },
+
+      // === Test 5: Delete habit - verify habit count decreases ===
+      { action: action_add_second_habit },
+      { assertion: assert_has_two_habits },
+      { assertion: assert_second_habit_exists },
+      { action: action_delete_habit },
+      { assertion: assert_back_to_one_habit },
+      { assertion: assert_read_habit_deleted },
+      { assertion: assert_exercise_habit_remains },
+    ],
+    // Expose subject for debugging
+    subject,
+  };
+});

--- a/packages/patterns/habit-tracker.tsx
+++ b/packages/patterns/habit-tracker.tsx
@@ -2,16 +2,16 @@
 import {
   computed,
   Default,
-  equals,
-  ifElse,
-  lift,
+  handler,
   NAME,
   pattern,
+  Stream,
   UI,
+  type VNode,
   Writable,
 } from "commontools";
 
-interface Habit {
+export interface Habit {
   name: string;
   icon: Default<string, "✓">;
   color: Default<string, "#3b82f6">;
@@ -23,15 +23,28 @@ interface HabitLog {
   completed: boolean;
 }
 
+// Pre-computed habit data for rendering (avoids closure issues in .map())
+interface HabitDisplayData {
+  habit: Habit;
+  isCompletedToday: boolean;
+  streak: number;
+  last7Days: { date: string; dayLabel: string; completed: boolean }[];
+}
+
 interface Input {
   habits: Writable<Default<Habit[], []>>;
   logs: Writable<Default<HabitLog[], []>>;
 }
 
 interface Output {
+  [NAME]: string;
+  [UI]: VNode;
   habits: Habit[];
   logs: HabitLog[];
   todayDate: string;
+  toggleHabit: Stream<{ habitName: string }>;
+  addHabit: Stream<{ name: string; icon: string }>;
+  deleteHabit: Stream<{ habit: Habit }>;
 }
 
 // Get today's date as YYYY-MM-DD
@@ -47,19 +60,19 @@ const getDateDaysAgo = (daysAgo: number): string => {
   return date.toISOString().split("T")[0];
 };
 
-// Pure functions wrapped with lift() - use object arg for multiple params
-const checkCompleted = lift(
-  (args: { logs: HabitLog[]; name: string; date: string }): boolean => {
-    const { logs, name, date } = args;
-    if (!Array.isArray(logs)) return false;
-    return logs.some(
-      (log) => log.habitName === name && log.date === date && log.completed,
-    );
-  },
-);
+// Pure helper functions (not lifted - used inside computed())
+const checkCompletedPure = (
+  logs: readonly HabitLog[],
+  name: string,
+  date: string,
+): boolean => {
+  if (!Array.isArray(logs)) return false;
+  return logs.some(
+    (log) => log.habitName === name && log.date === date && log.completed,
+  );
+};
 
-const calcStreak = lift((args: { logs: HabitLog[]; name: string }): number => {
-  const { logs, name } = args;
+const calcStreakPure = (logs: readonly HabitLog[], name: string): number => {
   if (!Array.isArray(logs)) return 0;
 
   let streak = 0;
@@ -83,6 +96,61 @@ const calcStreak = lift((args: { logs: HabitLog[]; name: string }): number => {
   }
 
   return streak;
+};
+
+// ===== Handlers at module scope =====
+// First type param is the args (Stream type), second is the bound context
+
+const toggleHabit = handler<
+  { habitName: string },
+  { logs: Writable<HabitLog[]>; todayDate: string }
+>(({ habitName }, { logs, todayDate }) => {
+  const currentLogs = logs.get();
+  const existingIdx = currentLogs.findIndex(
+    (log) => log.habitName === habitName && log.date === todayDate,
+  );
+
+  if (existingIdx >= 0) {
+    // Toggle existing
+    const updated = currentLogs.map((log, i) =>
+      i === existingIdx ? { ...log, completed: !log.completed } : log
+    );
+    logs.set(updated);
+  } else {
+    // Create new
+    logs.push({
+      habitName,
+      date: todayDate,
+      completed: true,
+    });
+  }
+});
+
+const deleteHabit = handler<
+  { habit: Habit },
+  { habits: Writable<Habit[]> }
+>(({ habit }, { habits }) => {
+  const current = habits.get();
+  // Find by name since full object equality may fail due to metadata differences
+  const idx = current.findIndex((h) => h.name === habit.name);
+  if (idx >= 0) {
+    habits.set(current.toSpliced(idx, 1));
+  }
+});
+
+const addHabit = handler<
+  { name: string; icon: string },
+  { habits: Writable<Habit[]>; newHabitName: Writable<string> }
+>(({ name, icon }, { habits, newHabitName }) => {
+  const trimmedName = name.trim();
+  if (trimmedName) {
+    habits.push({
+      name: trimmedName,
+      icon: icon || "✓",
+      color: "#3b82f6",
+    });
+    newHabitName.set("");
+  }
 });
 
 export default pattern<Input, Output>(({ habits, logs }) => {
@@ -91,6 +159,34 @@ export default pattern<Input, Output>(({ habits, logs }) => {
   const newHabitIcon = Writable.of("✓");
 
   const habitCount = computed(() => habits.get().length);
+  const hasNoHabits = computed(() => habits.get().length === 0);
+
+  // Bind handlers at pattern level (before JSX) to avoid closure issues in .map()
+  const boundToggleHabit = toggleHabit({ logs, todayDate });
+  const boundDeleteHabit = deleteHabit({ habits });
+  const boundAddHabit = addHabit({ habits, newHabitName });
+
+  // WORKAROUND: Pre-compute habit display data outside the map callback
+  // This avoids the "Cannot create cell link - space required" error
+  // that occurs when closing over cells inside .map() callbacks
+  const habitDisplayData = computed((): HabitDisplayData[] => {
+    const habitList = habits.get();
+    const logList = logs.get();
+
+    return habitList.map((habit) => ({
+      habit,
+      isCompletedToday: checkCompletedPure(logList, habit.name, todayDate),
+      streak: calcStreakPure(logList, habit.name),
+      last7Days: [6, 5, 4, 3, 2, 1, 0].map((daysAgo) => {
+        const date = getDateDaysAgo(daysAgo);
+        return {
+          date,
+          dayLabel: date.slice(-2),
+          completed: checkCompletedPure(logList, habit.name, date),
+        };
+      }),
+    }));
+  });
 
   return {
     [NAME]: "Habit Tracker",
@@ -107,120 +203,67 @@ export default pattern<Input, Output>(({ habits, logs }) => {
 
         <ct-vscroll flex showScrollbar fadeEdges>
           <ct-vstack gap="2" style="padding: 1rem;">
-            {habits.map((habit) => {
-              // Use lift() - just call with reactive args in an object
-              const isCompletedToday = checkCompleted({
-                logs,
-                name: habit.name,
-                date: todayDate,
-              });
-              const streak = calcStreak({ logs, name: habit.name });
+            {habitDisplayData.map((data) => (
+              <ct-card>
+                <ct-hstack gap="2" align="center">
+                  <span style="font-size: 1.5rem;">{data.habit.icon}</span>
+                  <ct-vstack gap="0" style="flex: 1;">
+                    <span style="font-weight: 500;">
+                      {data.habit.name || "(unnamed)"}
+                    </span>
+                    <span style="font-size: 0.75rem; color: var(--ct-color-gray-500);">
+                      Streak: {data.streak} days
+                    </span>
+                  </ct-vstack>
+                  <ct-button
+                    variant={data.isCompletedToday ? "primary" : "secondary"}
+                    onClick={() =>
+                      boundToggleHabit.send({ habitName: data.habit.name })}
+                  >
+                    {data.isCompletedToday ? "✓" : "○"}
+                  </ct-button>
+                  <ct-button
+                    variant="ghost"
+                    onClick={() => boundDeleteHabit.send({ habit: data.habit })}
+                  >
+                    ×
+                  </ct-button>
+                </ct-hstack>
 
-              return (
-                <ct-card>
-                  <ct-hstack gap="2" align="center">
-                    <span style="font-size: 1.5rem;">{habit.icon}</span>
-                    <ct-vstack gap="0" style="flex: 1;">
-                      <span style="font-weight: 500;">
-                        {habit.name || "(unnamed)"}
-                      </span>
-                      <span style="font-size: 0.75rem; color: var(--ct-color-gray-500);">
-                        Streak: {streak} days
-                      </span>
-                    </ct-vstack>
-                    <ct-button
-                      variant={ifElse(isCompletedToday, "primary", "secondary")}
-                      onClick={() => {
-                        const habitName = habit.name;
-                        const currentLogs = logs.get();
-                        const existingIdx = currentLogs.findIndex(
-                          (log) =>
-                            log.habitName === habitName &&
-                            log.date === todayDate,
-                        );
-
-                        if (existingIdx >= 0) {
-                          // Toggle existing
-                          const updated = currentLogs.map((log, i) =>
-                            i === existingIdx
-                              ? { ...log, completed: !log.completed }
-                              : log
-                          );
-                          logs.set(updated);
-                        } else {
-                          // Create new
-                          logs.push({
-                            habitName,
-                            date: todayDate,
-                            completed: true,
-                          });
-                        }
+                {/* Last 7 days indicator */}
+                <ct-hstack gap="1" style="margin-top: 0.5rem;">
+                  {data.last7Days.map((day) => (
+                    <div
+                      style={{
+                        width: "24px",
+                        height: "24px",
+                        borderRadius: "4px",
+                        backgroundColor: day.completed
+                          ? data.habit.color
+                          : "var(--ct-color-gray-200)",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        fontSize: "0.625rem",
+                        color: day.completed
+                          ? "white"
+                          : "var(--ct-color-gray-400)",
                       }}
                     >
-                      {ifElse(isCompletedToday, "✓", "○")}
-                    </ct-button>
-                    <ct-button
-                      variant="ghost"
-                      onClick={() => {
-                        const current = habits.get();
-                        const idx = current.findIndex((h) => equals(habit, h));
-                        if (idx >= 0) {
-                          habits.set(current.toSpliced(idx, 1));
-                        }
-                      }}
-                    >
-                      ×
-                    </ct-button>
-                  </ct-hstack>
+                      {day.dayLabel}
+                    </div>
+                  ))}
+                </ct-hstack>
+              </ct-card>
+            ))}
 
-                  {/* Last 7 days indicator */}
-                  <ct-hstack gap="1" style="margin-top: 0.5rem;">
-                    {[6, 5, 4, 3, 2, 1, 0].map((daysAgo) => {
-                      const dateStr = getDateDaysAgo(daysAgo);
-                      const wasCompleted = checkCompleted({
-                        logs,
-                        name: habit.name,
-                        date: dateStr,
-                      });
-
-                      return (
-                        <div
-                          style={{
-                            width: "24px",
-                            height: "24px",
-                            borderRadius: "4px",
-                            backgroundColor: ifElse(
-                              wasCompleted,
-                              habit.color,
-                              "var(--ct-color-gray-200)",
-                            ),
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            fontSize: "0.625rem",
-                            color: ifElse(
-                              wasCompleted,
-                              "white",
-                              "var(--ct-color-gray-400)",
-                            ),
-                          }}
-                        >
-                          {dateStr.slice(-2)}
-                        </div>
-                      );
-                    })}
-                  </ct-hstack>
-                </ct-card>
-              );
-            })}
-
-            {ifElse(
-              computed(() => habits.get().length === 0),
-              <div style="text-align: center; color: var(--ct-color-gray-500); padding: 2rem;">
-                No habits yet. Add one below!
-              </div>,
-              null,
-            )}
+            {hasNoHabits
+              ? (
+                <div style="text-align: center; color: var(--ct-color-gray-500); padding: 2rem;">
+                  No habits yet. Add one below!
+                </div>
+              )
+              : null}
           </ct-vstack>
         </ct-vscroll>
 
@@ -237,17 +280,11 @@ export default pattern<Input, Output>(({ habits, logs }) => {
           />
           <ct-button
             variant="primary"
-            onClick={() => {
-              const name = newHabitName.get().trim();
-              if (name) {
-                habits.push({
-                  name,
-                  icon: newHabitIcon.get() || "✓",
-                  color: "#3b82f6",
-                });
-                newHabitName.set("");
-              }
-            }}
+            onClick={() =>
+              boundAddHabit.send({
+                name: newHabitName.get(),
+                icon: newHabitIcon.get(),
+              })}
           >
             Add Habit
           </ct-button>
@@ -257,5 +294,8 @@ export default pattern<Input, Output>(({ habits, logs }) => {
     habits,
     logs,
     todayDate,
+    toggleHabit: boundToggleHabit,
+    addHabit: boundAddHabit,
+    deleteHabit: boundDeleteHabit,
   };
 });


### PR DESCRIPTION
Rewrite habit tracker pattern

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernized the Habit Tracker to the new handler/stream pattern API and precomputed display data to improve rendering stability. Added a full test suite.

- **New Features**
  - Exported streams: toggleHabit, addHabit, deleteHabit.
  - Added CT test with 16 assertions for add/toggle/delete flows.

- **Migration**
  - Use Writable.of() for new writable cells.
  - Bind handler() at module scope and trigger actions via subject.toggleHabit.send(...), subject.addHabit.send(...), subject.deleteHabit.send(...).
  - Precompute habit display with computed() to avoid map/closure issues.
  - Replace ifElse() and lift() with ternaries and simple helper functions.

<sup>Written for commit 80eabae47a2672ca8125d901f10794b699143ccc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

