### PR TITLE
feat(runner): make query result proxy read-only by default

### DIFF
--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -188,6 +188,7 @@ function handlerInternal<E, T>(
   stateSchema?: JSONSchema | { proxy: true },
   handler?: (event: E, props: T) => any,
 ): HandlerFactory<T, E> {
+  let writableProxy = false;
   if (typeof eventSchema === "function") {
     if (
       stateSchema && typeof stateSchema === "object" &&
@@ -195,6 +196,7 @@ function handlerInternal<E, T>(
     ) {
       handler = eventSchema;
       eventSchema = stateSchema = undefined;
+      writableProxy = true;
     } else {
       throw new Error(
         "Handler requires schemas or CTS transformer\n" +
@@ -236,6 +238,7 @@ function handlerInternal<E, T>(
     bind: (inputs: Opaque<StripCell<T>>) => factory(inputs),
     toJSON: () => moduleToJSON(module),
     ...(schema !== undefined ? { argumentSchema: schema } : {}),
+    ...(writableProxy ? { writableProxy: true } : {}),
   };
 
   const factory = Object.assign((props: Opaque<StripCell<T>>): Stream<E> => {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -158,6 +158,7 @@ declare module "@commontools/api" {
     getAsQueryResult<Path extends PropertyKey[]>(
       path?: Readonly<Path>,
       tx?: IExtendedStorageTransaction,
+      writable?: boolean,
     ): CellResult<DeepKeyLookup<T, Path>>;
     getAsNormalizedFullLink(): NormalizedFullLink;
     getAsLink(
@@ -1131,6 +1132,7 @@ export class CellImpl<T> implements ICell<T>, IStreamable<T> {
   getAsQueryResult<Path extends PropertyKey[]>(
     path?: Readonly<Path>,
     tx?: IExtendedStorageTransaction,
+    writable?: boolean,
   ): CellResult<DeepKeyLookup<T, Path>> {
     if (!this.synced) this.sync(); // No await, just kicking this off
     const subPath = path || [];
@@ -1141,6 +1143,8 @@ export class CellImpl<T> implements ICell<T>, IStreamable<T> {
         ...this.link,
         path: [...this.path, ...subPath.map((p) => p.toString())] as string[],
       },
+      0,
+      writable,
     );
   }
 

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -80,6 +80,7 @@ export function createQueryResultProxy<T>(
   tx: IExtendedStorageTransaction | undefined,
   link: NormalizedFullLink,
   depth: number = 0,
+  writable: boolean = false,
 ): T {
   // Check recursion depth
   if (depth > MAX_RECURSION_DEPTH) {
@@ -142,10 +143,16 @@ export function createQueryResultProxy<T>(
                 }) as number;
                 if (index < length) {
                   const result = {
-                    value: createQueryResultProxy(runtime, tx, {
-                      ...link,
-                      path: [...link.path, String(index)],
-                    }, depth + 1),
+                    value: createQueryResultProxy(
+                      runtime,
+                      tx,
+                      {
+                        ...link,
+                        path: [...link.path, String(index)],
+                      },
+                      depth + 1,
+                      writable,
+                    ),
                     done: false,
                   };
                   index++;
@@ -199,12 +206,19 @@ export function createQueryResultProxy<T>(
                 tx,
                 { ...link, path: [...link.path, String(i)] },
                 depth + 1,
+                writable,
               );
             }
 
             return method.apply(copy, args);
           }
           : (...args: any[]) => {
+            if (!writable) {
+              throw new Error(
+                "This value is read-only, declare type as Writable<..> instead to get a writable version",
+              );
+            }
+
             if (!tx) {
               throw new Error(
                 "Transaction required for mutation\n" +
@@ -225,6 +239,7 @@ export function createQueryResultProxy<T>(
                   tx,
                   index,
                   { ...link, path: [...link.path, String(index)] },
+                  writable,
                 )
               );
             }
@@ -284,7 +299,13 @@ export function createQueryResultProxy<T>(
 
               diffAndUpdate(runtime, tx, resultLink, result, cause);
 
-              result = createQueryResultProxy(runtime, tx, resultLink);
+              result = createQueryResultProxy(
+                runtime,
+                tx,
+                resultLink,
+                0,
+                writable,
+              );
             }
 
             return result;
@@ -296,10 +317,17 @@ export function createQueryResultProxy<T>(
         tx,
         { ...link, path: [...link.path, prop] },
         depth + 1,
+        writable,
       );
     },
     set: (_, prop, value) => {
       if (typeof prop === "symbol") return false;
+
+      if (!writable) {
+        throw new Error(
+          "This value is read-only, declare type as Writable<..> instead to get a writable version",
+        );
+      }
 
       if (isCellResult(value)) value = value[toCell]();
 
@@ -340,13 +368,14 @@ const createProxyForArrayValue = (
   tx: IExtendedStorageTransaction | undefined,
   source: number,
   link: NormalizedFullLink,
+  writable: boolean = false,
 ): { [originalIndex]: number } => {
   const target = {
     valueOf: function () {
-      return createQueryResultProxy(runtime, tx, link);
+      return createQueryResultProxy(runtime, tx, link, 0, writable);
     },
     toString: function () {
-      return String(createQueryResultProxy(runtime, tx, link));
+      return String(createQueryResultProxy(runtime, tx, link, 0, writable));
     },
     [originalIndex]: source,
   };

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1239,7 +1239,7 @@ export class Runner {
             unsafe_binding: {
               recipe,
               materialize: (path: readonly PropertyKey[]) =>
-                processCell.getAsQueryResult(path),
+                processCell.getAsQueryResult(path, tx),
               space: processCell.space,
               tx,
             },
@@ -1260,7 +1260,11 @@ export class Runner {
 
           const argument = module.argumentSchema
             ? inputsCell.asSchema(module.argumentSchema).get()
-            : inputsCell.getAsQueryResult([], tx);
+            : inputsCell.getAsQueryResult(
+              [],
+              tx,
+              (module as { writableProxy?: boolean }).writableProxy,
+            );
           const result = fn(argument);
 
           const postRun = (result: any) => {

--- a/packages/runner/test/cell.test.ts
+++ b/packages/runner/test/cell.test.ts
@@ -263,19 +263,6 @@ describe("Cell", () => {
     expect(proxy.y).toBe(2);
   });
 
-  it("should update cell value through proxy", () => {
-    const c = runtime.getCell<{ x: number; y: number }>(
-      space,
-      "should update cell value through proxy",
-      undefined,
-      tx,
-    );
-    c.set({ x: 1, y: 2 });
-    const proxy = c.getAsQueryResult();
-    proxy.x = 10;
-    expect(c.get()).toEqual({ x: 10, y: 2 });
-  });
-
   it("should get value at path", () => {
     const c = runtime.getCell<{ a: { b: { c: number } } }>(
       space,
@@ -285,18 +272,6 @@ describe("Cell", () => {
     );
     c.set({ a: { b: { c: 42 } } });
     expect(c.key("a").key("b").key("c").get()).toBe(42);
-  });
-
-  it("should set value at path", () => {
-    const c = runtime.getCell<{ a: { b: { c: number } } }>(
-      space,
-      "should set value at path",
-      undefined,
-      tx,
-    );
-    c.set({ a: { b: { c: 42 } } });
-    c.getAsQueryResult().a.b.c = 100;
-    expect(c.key("a").key("b").key("c").get()).toBe(100);
   });
 
   it("should get raw value using getRaw", () => {
@@ -625,19 +600,6 @@ describe("createProxy", () => {
     expect(proxy.a.b.c).toBe(42);
   });
 
-  it("should support regular assigments", () => {
-    const c = runtime.getCell<{ x: number }>(
-      space,
-      "should support regular assigments",
-      undefined,
-      tx,
-    );
-    c.set({ x: 1 });
-    const proxy = c.getAsQueryResult();
-    proxy.x = 2;
-    expect(c.get()).toStrictEqual({ x: 2 });
-  });
-
   it("should handle $alias in objects", () => {
     const c = runtime.getCell(
       space,
@@ -648,19 +610,6 @@ describe("createProxy", () => {
     c.setRaw({ x: { $alias: { path: ["y"] } }, y: 42 });
     const proxy = c.getAsQueryResult();
     expect(proxy.x).toBe(42);
-  });
-
-  it("should handle aliases when writing", () => {
-    const c = runtime.getCell<{ x: number; y: number }>(
-      space,
-      "should handle aliases when writing",
-      undefined,
-      tx,
-    );
-    c.setRaw({ x: { $alias: { path: ["y"] } }, y: 42 });
-    const proxy = c.getAsQueryResult();
-    proxy.x = 100;
-    expect(c.get().y).toBe(100);
   });
 
   it("should handle nested cells", () => {
@@ -679,34 +628,6 @@ describe("createProxy", () => {
     );
     outerCell.set({ x: innerCell });
     const proxy = outerCell.getAsQueryResult();
-    expect(proxy.x).toBe(42);
-  });
-
-  it("should handle cell references", () => {
-    const c = runtime.getCell<{ x: number; y?: any }>(
-      space,
-      "should handle cell references",
-      undefined,
-      tx,
-    );
-    c.set({ x: 42 });
-    const ref = c.key("x").getAsLink();
-    const proxy = c.getAsQueryResult();
-    proxy.y = ref;
-    expect(proxy.y).toBe(42);
-  });
-
-  it("should handle infinite loops in cell references", () => {
-    const c = runtime.getCell<{ x: number; y?: any }>(
-      space,
-      "should handle infinite loops in cell references",
-      undefined,
-      tx,
-    );
-    c.set({ x: 42 });
-    const ref = c.key("x").getAsLink();
-    const proxy = c.getAsQueryResult();
-    proxy.x = ref;
     expect(proxy.x).toBe(42);
   });
 
@@ -792,42 +713,6 @@ describe("createProxy", () => {
     expect(sliced.length).toBe(3);
     expect(sliced[0]).toBe(2);
     expect(sliced[2]).toBe(4);
-  });
-
-  it("should maintain reactivity with nested array operations", () => {
-    const c = runtime.getCell<{ nested: { arrays: number[][] } }>(
-      space,
-      "should maintain reactivity with nested array operations",
-      undefined,
-      tx,
-    );
-    c.set({ nested: { arrays: [[1, 2], [3, 4]] } });
-    const proxy = c.getAsQueryResult();
-
-    // Access a nested array through multiple levels
-    const firstInnerArray = proxy.nested.arrays[0];
-    expect(firstInnerArray).toEqual([1, 2]);
-    expect(isCellResult(firstInnerArray)).toBe(true);
-
-    // Modify the deeply nested array
-    firstInnerArray.push(3);
-    expect(firstInnerArray).toEqual([1, 2, 3]);
-
-    // Verify the change is reflected in the original data
-    expect(proxy.nested.arrays[0]).toEqual([1, 2, 3]);
-    expect(c.get().nested.arrays[0]).toEqual([1, 2, 3]);
-
-    // Create a flattened array using array methods
-    const flattened = proxy.nested.arrays.flat();
-    expect(flattened).toEqual([1, 2, 3, 3, 4]);
-    expect(isCellResult(flattened)).toBe(false);
-
-    // Modify the flattened result
-    flattened[0] = 10;
-    expect(flattened[0]).toBe(10);
-
-    // Original arrays should not be affected by modifying the flattened result
-    expect(proxy.nested.arrays[0][0]).toBe(1);
   });
 
   it("should support spreading array query results with for...of", () => {
@@ -1298,17 +1183,17 @@ describe("asCell", () => {
       values.push(value);
     });
     expect(values).toEqual([42]); // Initial call
-    c.withTx(tx).getAsQueryResult().d = 50;
+    c.withTx(tx).key("d").set(50);
     tx.commit();
     tx = runtime.edit();
-    c.withTx(tx).getAsQueryResult().a.c = 100;
+    c.withTx(tx).key("a").key("c").set(100);
     tx.commit();
     tx = runtime.edit();
-    c.withTx(tx).getAsQueryResult().a.b = 42;
+    c.withTx(tx).key("a").key("b").set(42);
     tx.commit();
     tx = runtime.edit();
     expect(values).toEqual([42]); // Didn't get called again
-    c.withTx(tx).getAsQueryResult().a.b = 300;
+    c.withTx(tx).key("a").key("b").set(300);
     tx.commit();
     await runtime.idle();
     expect(c.get()).toEqual({ a: { b: 300, c: 100 }, d: 50 });

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -653,7 +653,7 @@ describe("runRecipe", () => {
 
     // Now change the name
     const tx = runtime.edit();
-    resultCell.withTx(tx).getAsQueryResult()[NAME] = "my counter";
+    resultCell.withTx(tx).update({ [NAME]: "my counter" });
     await tx.commit();
 
     // Second run with same recipe but different argument


### PR DESCRIPTION
## Summary
- Query result proxies are now read-only by default, throwing a helpful error when writes are attempted
- Handlers with `{ proxy: true }` still get writable proxies for their state
- Tests updated to use Cell API instead of proxy writes

## Test plan
- [x] `deno test --allow-all test/cell.test.ts` passes (deleted 7 proxy write tests, converted 1)
- [x] `deno test --allow-all test/runner.test.ts` passes (converted 1 test)
- [x] `deno test --allow-all test/recipes.test.ts` passes (handlers with `{ proxy: true }` work)
- [x] Full test suite passes (129 tests, 3 pre-existing tsx import failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make query result proxies read-only by default to prevent accidental mutations. Handlers declared with { proxy: true } still get writable proxies; other writes should use the Cell API.

- **New Features**
  - Added a writable flag to createQueryResultProxy and Cell.getAsQueryResult (default: false).
  - Runner propagates writableProxy for handlers declared with { proxy: true }.
  - Read-only proxies throw a clear error on writes (property sets and array mutators).

- **Migration**
  - Replace proxy writes with the Cell API (key(...).set, update, withTx).
  - Only request writable proxies when needed: use { proxy: true } for handlers or pass writable: true to getAsQueryResult.
  - If your handler needs to mutate its argument, define it with { proxy: true } or use a Writable<T> type.

<sup>Written for commit e691f8a9c9f2ef9d4252dc16b8eae2063fbca6ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

