### PR TITLE
chore(runner): only log >50ms get instead of >10ms for now

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -573,7 +573,7 @@ export class CellImpl<T> implements ICell<T>, IStreamable<T> {
       options,
     );
     const elapsed = performance.now() - begin;
-    if (elapsed > 10) {
+    if (elapsed > 50) {
       logger.warn(
         `get >${Math.floor(elapsed - (elapsed % 10))}ms`,
         `get() took ${Math.floor(elapsed)}ms`,


### PR DESCRIPTION
logs got too noisy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise get() slow-call log threshold from 10ms to 50ms to cut noise in runner logs. This keeps warnings for genuinely slow calls while avoiding spam during normal performance.

<sup>Written for commit e76427dd628af26ab9cb7044e98fe7dd9644ca19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

