### PR TITLE
feat(patterns): only render omnibox-fab content when expanded

### DIFF
--- a/packages/patterns/system/omnibox-fab.tsx
+++ b/packages/patterns/system/omnibox-fab.tsx
@@ -156,7 +156,7 @@ export default pattern<OmniboxFABInput>(
           onct-fab-escape={closeFab({ fabExpanded })}
           onClick={toggle({ value: fabExpanded })}
         >
-          {fabExpanded && (
+          {fabExpanded.get() && (
             <div style="width: 100%; display: flex; flex-direction: column; max-height: 580px;">
               {/* Chevron at top - the "handle" for the drawer */}
               <div style="border-bottom: 1px solid #e5e5e5; flex-shrink: 0;">
@@ -168,7 +168,7 @@ export default pattern<OmniboxFABInput>(
               </div>
 
               <div
-                style={showHistory
+                style={showHistory.get()
                   ? "flex: 1; min-height: 0; display: flex; flex-direction: column; opacity: 1; max-height: 480px; overflow: hidden; transition: opacity 300ms ease, max-height 400ms cubic-bezier(0.34, 1.56, 0.64, 1), flex 400ms cubic-bezier(0.34, 1.56, 0.64, 1); pointer-events: auto"
                   : "flex: 0; min-height: 0; display: flex; flex-direction: column; opacity: 0; max-height: 0; overflow: hidden; transition: opacity 300ms ease, max-height 400ms cubic-bezier(0.34, 1.56, 0.64, 1), flex 400ms cubic-bezier(0.34, 1.56, 0.64, 1); pointer-events: none"}
               >


### PR DESCRIPTION
## Summary
- Only renders the omnibot panel content when the FAB is expanded, avoiding unnecessary DOM elements on initial page load
- Simplifies computed expressions by using direct cell references where possible

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the omnibot panel only when the FAB is expanded to reduce initial DOM and improve page load. Simplifies reactive bindings by using direct cell references instead of computed expressions where possible.

- **Refactors**
  - Pass fabExpanded directly to ct-fab expanded.
  - Use showHistory directly for chevron state and style toggles.
  - Conditionally render panel content with fabExpanded to avoid mounting until open.

<sup>Written for commit 3b7764d9079ccd69fe1918271c16dbea34bc9889. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

