### PR TITLE
finish the fix for action typing so that it returns Stream<void> inst…

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1567,6 +1567,9 @@ export type HandlerFunction = {
  * computed(() => expr) becomes derive({}, () => expr) with closure extraction.
  */
 export type ActionFunction = {
+  // Overload 1: Zero-parameter callback returns Stream<void>
+  (fn: () => void): Stream<void>;
+  // Overload 2: Parameterized callback returns Stream<T>
   <T>(fn: (event: T) => void): Stream<T>;
 };
 


### PR DESCRIPTION
…ead of Stream<unknown>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed ActionFunction typing so zero-parameter callbacks return Stream<void> instead of Stream<unknown>, improving type safety and avoiding unnecessary casts.

<sup>Written for commit 8feabb746b5b592e17efd0b3b5cda4ec658e7650. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

