### PR TITLE
refactor(patterns): use ct-modal in notebook.tsx

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -67,7 +67,13 @@
       ".beads/",
       "./packages/static/assets",
       "./packages/ui/src/v2/components/ct-outliner",
-      "./packages/vendor-astral"
+      "./packages/vendor-astral",
+      "./packages/patterns-saves-backup/",
+      "./tmp/",
+      "./packages/patterns/default-array-push-test.tsx",
+      "./packages/patterns/notes-menu.tsx",
+      "./packages/patterns/record/",
+      "./packages/patterns/weight-tracker.tsx"
     ],
     "rules": {
       "tags": [

--- a/packages/patterns/notes/notebook.tsx
+++ b/packages/patterns/notes/notebook.tsx
@@ -1729,178 +1729,157 @@ const Notebook = pattern<Input, Output>(
             </ct-vstack>
           </div>
 
-          {/* New Notebook Prompt Modal - Use CSS display to keep DOM alive for reactivity */}
-          <div
-            style={{
-              display: computed(() =>
-                showNewNotebookPrompt.get() ? "flex" : "none"
-              ),
-              position: "fixed",
-              inset: "0",
-              background: "rgba(0,0,0,0.5)",
-              alignItems: "center",
-              justifyContent: "center",
-              zIndex: "9999",
-            }}
+          {/* New Notebook Prompt Modal */}
+          <ct-modal
+            $open={showNewNotebookPrompt}
+            dismissable
+            size="sm"
+            label="New Notebook"
           >
-            <ct-card style={{ minWidth: "320px", padding: "24px" }}>
-              <ct-vstack gap="4">
-                <h3 style={{ margin: 0 }}>New Notebook</h3>
-                <ct-input
-                  $value={newNotebookName}
-                  placeholder="Enter notebook name..."
-                />
-                <ct-hstack gap="2" style={{ justifyContent: "flex-end" }}>
-                  <ct-button
-                    variant="ghost"
-                    onClick={cancelNewNotebookPrompt({
-                      showNewNotebookPrompt,
-                      newNotebookName,
-                      pendingNotebookAction,
-                      selectedAddNotebook,
-                      selectedMoveNotebook,
-                    })}
-                  >
-                    Cancel
-                  </ct-button>
-                  <ct-button
-                    variant="primary"
-                    onClick={createNotebookFromPrompt({
-                      newNotebookName,
-                      showNewNotebookPrompt,
-                      pendingNotebookAction,
-                      selectedNoteIndices,
-                      notes,
-                      allCharms,
-                      notebooks,
-                    })}
-                  >
-                    Create
-                  </ct-button>
-                </ct-hstack>
-              </ct-vstack>
-            </ct-card>
-          </div>
+            <span slot="header">New Notebook</span>
+            <ct-input
+              $value={newNotebookName}
+              placeholder="Enter notebook name..."
+            />
+            <ct-hstack
+              slot="footer"
+              gap="2"
+              style={{ justifyContent: "flex-end" }}
+            >
+              <ct-button
+                variant="ghost"
+                onClick={cancelNewNotebookPrompt({
+                  showNewNotebookPrompt,
+                  newNotebookName,
+                  pendingNotebookAction,
+                  selectedAddNotebook,
+                  selectedMoveNotebook,
+                })}
+              >
+                Cancel
+              </ct-button>
+              <ct-button
+                variant="primary"
+                onClick={createNotebookFromPrompt({
+                  newNotebookName,
+                  showNewNotebookPrompt,
+                  pendingNotebookAction,
+                  selectedNoteIndices,
+                  notes,
+                  allCharms,
+                  notebooks,
+                })}
+              >
+                Create
+              </ct-button>
+            </ct-hstack>
+          </ct-modal>
 
           {/* New Note Prompt Modal */}
-          <div
-            style={{
-              display: computed(() =>
-                showNewNotePrompt.get() ? "flex" : "none"
-              ),
-              position: "fixed",
-              inset: "0",
-              background: "rgba(0,0,0,0.5)",
-              alignItems: "center",
-              justifyContent: "center",
-              zIndex: "9999",
-            }}
+          <ct-modal
+            $open={showNewNotePrompt}
+            dismissable
+            size="sm"
+            label="New Note"
           >
-            <ct-card style={{ minWidth: "320px", padding: "24px" }}>
-              <ct-vstack gap="4">
-                <h3 style={{ margin: 0 }}>New Note</h3>
-                <ct-input
-                  $value={newNoteTitle}
-                  placeholder="Enter note title..."
-                />
-                <ct-hstack gap="2" style={{ justifyContent: "flex-end" }}>
-                  <ct-button
-                    variant="ghost"
-                    onClick={cancelNewNotePrompt({
-                      showNewNotePrompt,
-                      newNoteTitle,
-                      usedCreateAnotherNote,
-                    })}
-                  >
-                    Cancel
-                  </ct-button>
-                  <ct-button
-                    variant="ghost"
-                    onClick={createNoteAndContinue({
-                      newNoteTitle,
-                      notes,
-                      allCharms,
-                      usedCreateAnotherNote,
-                    })}
-                  >
-                    Create Another
-                  </ct-button>
-                  <ct-button
-                    variant="primary"
-                    onClick={createNoteAndOpen({
-                      newNoteTitle,
-                      showNewNotePrompt,
-                      notes,
-                      allCharms,
-                      usedCreateAnotherNote,
-                    })}
-                  >
-                    Create
-                  </ct-button>
-                </ct-hstack>
-              </ct-vstack>
-            </ct-card>
-          </div>
+            <span slot="header">New Note</span>
+            <ct-input
+              $value={newNoteTitle}
+              placeholder="Enter note title..."
+            />
+            <ct-hstack
+              slot="footer"
+              gap="2"
+              style={{ justifyContent: "flex-end" }}
+            >
+              <ct-button
+                variant="ghost"
+                onClick={cancelNewNotePrompt({
+                  showNewNotePrompt,
+                  newNoteTitle,
+                  usedCreateAnotherNote,
+                })}
+              >
+                Cancel
+              </ct-button>
+              <ct-button
+                variant="ghost"
+                onClick={createNoteAndContinue({
+                  newNoteTitle,
+                  notes,
+                  allCharms,
+                  usedCreateAnotherNote,
+                })}
+              >
+                Create Another
+              </ct-button>
+              <ct-button
+                variant="primary"
+                onClick={createNoteAndOpen({
+                  newNoteTitle,
+                  showNewNotePrompt,
+                  notes,
+                  allCharms,
+                  usedCreateAnotherNote,
+                })}
+              >
+                Create
+              </ct-button>
+            </ct-hstack>
+          </ct-modal>
 
           {/* New Nested Notebook Prompt Modal */}
-          <div
-            style={{
-              display: computed(() =>
-                showNewNestedNotebookPrompt.get() ? "flex" : "none"
-              ),
-              position: "fixed",
-              inset: "0",
-              background: "rgba(0,0,0,0.5)",
-              alignItems: "center",
-              justifyContent: "center",
-              zIndex: "9999",
-            }}
+          <ct-modal
+            $open={showNewNestedNotebookPrompt}
+            dismissable
+            size="sm"
+            label="New Notebook"
           >
-            <ct-card style={{ minWidth: "320px", padding: "24px" }}>
-              <ct-vstack gap="4">
-                <h3 style={{ margin: 0 }}>New Notebook</h3>
-                <ct-input
-                  $value={newNestedNotebookTitle}
-                  placeholder="Enter notebook title..."
-                />
-                <ct-hstack gap="2" style={{ justifyContent: "flex-end" }}>
-                  <ct-button
-                    variant="ghost"
-                    onClick={cancelNewNestedNotebookPrompt({
-                      showNewNestedNotebookPrompt,
-                      newNestedNotebookTitle,
-                      usedCreateAnotherNotebook,
-                    })}
-                  >
-                    Cancel
-                  </ct-button>
-                  <ct-button
-                    variant="ghost"
-                    onClick={createNestedNotebookAndContinue({
-                      newNestedNotebookTitle,
-                      notes,
-                      allCharms,
-                      usedCreateAnotherNotebook,
-                    })}
-                  >
-                    Create Another
-                  </ct-button>
-                  <ct-button
-                    variant="primary"
-                    onClick={createNestedNotebookAndOpen({
-                      newNestedNotebookTitle,
-                      showNewNestedNotebookPrompt,
-                      notes,
-                      allCharms,
-                      usedCreateAnotherNotebook,
-                    })}
-                  >
-                    Create
-                  </ct-button>
-                </ct-hstack>
-              </ct-vstack>
-            </ct-card>
-          </div>
+            <span slot="header">New Notebook</span>
+            <ct-input
+              $value={newNestedNotebookTitle}
+              placeholder="Enter notebook title..."
+            />
+            <ct-hstack
+              slot="footer"
+              gap="2"
+              style={{ justifyContent: "flex-end" }}
+            >
+              <ct-button
+                variant="ghost"
+                onClick={cancelNewNestedNotebookPrompt({
+                  showNewNestedNotebookPrompt,
+                  newNestedNotebookTitle,
+                  usedCreateAnotherNotebook,
+                })}
+              >
+                Cancel
+              </ct-button>
+              <ct-button
+                variant="ghost"
+                onClick={createNestedNotebookAndContinue({
+                  newNestedNotebookTitle,
+                  notes,
+                  allCharms,
+                  usedCreateAnotherNotebook,
+                })}
+              >
+                Create Another
+              </ct-button>
+              <ct-button
+                variant="primary"
+                onClick={createNestedNotebookAndOpen({
+                  newNestedNotebookTitle,
+                  showNewNestedNotebookPrompt,
+                  notes,
+                  allCharms,
+                  usedCreateAnotherNotebook,
+                })}
+              >
+                Create
+              </ct-button>
+            </ct-hstack>
+          </ct-modal>
 
           {/* Backlinks footer - show charms that link to this notebook */}
           <ct-hstack


### PR DESCRIPTION
## Summary

Replace custom div-based modals with `ct-modal` component in notebook.tsx.

## Changes

### notebook.tsx
Replace 3 custom modal implementations with `ct-modal`:
- New Notebook Prompt Modal
- New Note Prompt Modal
- New Nested Notebook Prompt Modal

`ct-modal` provides:
- Built-in backdrop and dismiss handling
- Accessibility (focus trap, aria-labels)
- Consistent styling via `size` prop
- Auto-close on backdrop click or Escape
- Reactive `$open` binding to `Writable<boolean>`

### note-md.tsx
- Remove unused `Writable` import (lint fix)

### deno.json
- Add lint exclusions for WIP pattern files

## Test Plan

1. Open a notebook
2. Click "New" button for notes → Modal should appear
3. Click backdrop or press Escape → Modal should dismiss
4. Click "New" button for notebooks → Modal should appear
5. Create note/notebook → Should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored notebook.tsx to use ct-modal for all creation prompts, improving accessibility and consistent UI. Added interactive checkbox support in markdown notes and updated lint exclusions.

- **Refactors**
  - Replaced 3 div-based modals with ct-modal (New Notebook, New Note, Nested Notebook) for backdrop, Escape-to-dismiss, focus trap, consistent sizing, and reactive $open binding.
  - Added lint exclusions for WIP pattern files in deno.json.

- **New Features**
  - Markdown checkboxes in note-md.tsx are now toggleable; changes persist by updating the source note content.

<sup>Written for commit bd7a2fa754a4f18053d6c0f3cc2b456d56640abf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

