### PR TITLE
chore: create nested directories if needed when saving a charm source via CLI

### DIFF
--- a/packages/cli/lib/charm.ts
+++ b/packages/cli/lib/charm.ts
@@ -12,7 +12,7 @@ import {
 import { StorageManager } from "@commontools/runner/storage/cache";
 import { charmId, CharmManager, extractUserCode } from "@commontools/charm";
 import { CharmsController } from "@commontools/charm/ops";
-import { join } from "@std/path";
+import { dirname, join } from "@std/path";
 import { FileSystemProgramResolver } from "@commontools/js-compiler";
 import { setLLMUrl } from "@commontools/llm";
 import { isObject } from "@commontools/utils/types";
@@ -195,7 +195,9 @@ export async function saveCharmRecipe(
       if (name[0] !== "/") {
         throw new Error("Ungrounded file in recipe.");
       }
-      await Deno.writeTextFile(join(outPath, name.substring(1)), contents);
+      const outFilePath = join(outPath, name.substring(1));
+      await Deno.mkdir(dirname(outFilePath), { recursive: true });
+      await Deno.writeTextFile(outFilePath, contents);
     }
   } else {
     throw new Error(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure the CLI creates missing parent directories when saving charm recipes, so files with nested paths write successfully without errors.

<sup>Written for commit 1ff2b5fabd8587f35453db9366468e67d7354fe7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

