### PR TITLE
chore: Only apply classes to ct-button types if non-empty strings

### DIFF
--- a/packages/ui/src/v2/components/ct-button/ct-button.ts
+++ b/packages/ui/src/v2/components/ct-button/ct-button.ts
@@ -332,11 +332,13 @@ export class CTButton extends BaseElement {
     }
 
     override render() {
-      const classes = {
+      const classes: { [key: string]: true } = {
         button: true,
-        [this.variant]: true,
-        [this.size]: true,
       };
+      if (typeof this.variant === "string" && this.variant) {
+        classes[this.variant] = true;
+      }
+      if (typeof this.size === "string" && this.size) classes[this.size] = true;
 
       return html`
         <button


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Apply ct-button variant and size classes only when they are non-empty strings. This avoids invalid class names (like undefined or empty) and prevents styling glitches.

<sup>Written for commit 11a2c7998aaf16f63ff137b6d33377ef4884d22c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

