### PR TITLE
feat(ui,patterns): enable checkbox toggle in markdown viewer

### DIFF
--- a/packages/patterns/notes/note-md.tsx
+++ b/packages/patterns/notes/note-md.tsx
@@ -9,6 +9,7 @@ import {
   UI,
   type VNode,
   wish,
+  Writable,
 } from "commontools";
 
 // Type for backlinks (same as note.tsx)
@@ -26,48 +27,51 @@ const handleBacklinkClick = (charm: MentionableCharm) => {
 
 // Handler for Edit button - go back to note editor (module scope)
 const goToEdit = handler<void, { sourceNote: any }>((_ev, { sourceNote }) => {
-  const noteRef = sourceNote?.get?.() ?? sourceNote;
-  if (noteRef) {
-    return navigateTo(noteRef);
+  console.log("goToEdit called, sourceNote:", sourceNote);
+  if (sourceNote) {
+    return navigateTo(sourceNote);
+  } else {
+    console.log("sourceNote is null/undefined, cannot navigate");
   }
 });
 
 // Handler for checkbox toggle in markdown
+// Uses properly typed Writable<string> for content updates
 const handleCheckboxToggle = handler<
   { detail: { index: number; checked: boolean } },
-  { sourceNote: any }
->((event, { sourceNote }) => {
-  if (!sourceNote) return;
-
-  // sourceNote is a cell reference from allCharms.find()
-  // Access content via the cell's property
-  const content = sourceNote?.content ?? "";
+  { content: Writable<string> }
+>((event, { content }) => {
+  const currentContent = content.get();
   const { index, checked } = event.detail;
+
+  console.log("Toggling checkbox", {
+    index,
+    checked,
+    contentLength: currentContent.length,
+  });
 
   // Find all checkbox patterns in the content
   const checkboxPattern = /- \[([ xX])\]/g;
   let match;
   let currentIndex = 0;
-  let result = content;
+  let result = currentContent;
 
-  // Need to reset lastIndex since we're reusing the regex
   checkboxPattern.lastIndex = 0;
 
-  while ((match = checkboxPattern.exec(content)) !== null) {
+  while ((match = checkboxPattern.exec(currentContent)) !== null) {
     if (currentIndex === index) {
-      // Found the checkbox to toggle
       const newCheckbox = checked ? "- [x]" : "- [ ]";
-      result = content.slice(0, match.index) +
+      result = currentContent.slice(0, match.index) +
         newCheckbox +
-        content.slice(match.index + match[0].length);
+        currentContent.slice(match.index + match[0].length);
       break;
     }
     currentIndex++;
   }
 
-  // Update the source note's content using .key() for write access
-  if (result !== content) {
-    sourceNote.key("content").set(result);
+  if (result !== currentContent) {
+    content.set(result);
+    console.log("Updated content via Writable.set()");
   }
 });
 
@@ -84,6 +88,10 @@ interface Input {
     NoteData,
     { title: ""; content: ""; backlinks: []; noteId: "" }
   >;
+  /** Direct reference to source note for Edit navigation */
+  sourceNoteRef?: any;
+  /** Writable content cell for checkbox updates */
+  content?: Writable<string>;
 }
 
 interface Output {
@@ -97,7 +105,7 @@ interface Output {
   embeddedUI: VNode;
 }
 
-export default pattern<Input, Output>(({ note }) => {
+export default pattern<Input, Output>(({ note, sourceNoteRef, content }) => {
   const displayName = computed(() => {
     const title = note?.title || "Untitled";
     return `📖 ${title}`;
@@ -107,8 +115,9 @@ export default pattern<Input, Output>(({ note }) => {
 
   // Convert [[Name (id)]] wiki-links to markdown links [Name](/of:id)
   // ct-markdown will then convert these to clickable ct-cell-link components
+  // Use content prop if provided, otherwise fall back to note.content
   const processedContent = computed(() => {
-    const raw = note?.content || "";
+    const raw = content?.get?.() ?? note?.content ?? "";
     // Match [[Name (id)]] pattern and convert to [Name](/of:id)
     return raw.replace(
       /\[\[([^\]]*?)\s*\(([^)]+)\)\]\]/g,
@@ -116,18 +125,23 @@ export default pattern<Input, Output>(({ note }) => {
     );
   });
 
-  // Find source note by noteId using wish()
+  // Get allCharms for noteId lookup fallback
   const { allCharms } = wish<{ allCharms: any[] }>("/");
+
+  // Use sourceNoteRef directly if provided, otherwise fall back to noteId lookup
   const sourceNote = computed(() => {
+    if (sourceNoteRef) {
+      console.log("Using sourceNoteRef directly");
+      return sourceNoteRef;
+    }
     const myNoteId = note?.noteId;
     if (!myNoteId) return null;
     return allCharms.find((charm: any) => charm?.noteId === myNoteId);
   });
 
-  // Bind checkbox toggle handler with sourceNote
-  const boundCheckboxToggle = handleCheckboxToggle({
-    sourceNote: sourceNote as any,
-  });
+  // Bind checkbox toggle handler with properly typed Writable<string>
+  // Content is required for checkbox updates to work
+  const boundCheckboxToggle = handleCheckboxToggle({ content: content! });
 
   // Scrollable content with markdown + backlinks (for print support)
   const markdownViewer = (

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -245,6 +245,7 @@ const goToViewer = handler<
     content: Writable<string>;
     backlinks: Writable<MentionableCharm[]>;
     noteId: Writable<string>;
+    self: any;
   }
 >((_, state) => {
   return navigateTo(
@@ -255,6 +256,10 @@ const goToViewer = handler<
         backlinks: state.backlinks,
         noteId: state.noteId,
       },
+      // Pass direct reference to source note for Edit button
+      sourceNoteRef: state.self,
+      // Pass content Writable for checkbox updates
+      content: state.content,
     }),
   );
 });
@@ -514,7 +519,13 @@ const Note = pattern<Input, Output>(
               {/* View Mode button */}
               <ct-button
                 variant="ghost"
-                onClick={goToViewer({ title, content, backlinks, noteId })}
+                onClick={goToViewer({
+                  title,
+                  content,
+                  backlinks,
+                  noteId,
+                  self,
+                })}
                 style={{
                   alignItems: "center",
                   padding: "6px 12px",


### PR DESCRIPTION
## Summary

- Adds interactive checkbox toggle support to `ct-markdown` component
- Enables toggling task list checkboxes in `note-md.tsx` (the markdown viewer) with changes persisting to the source note
- Key insight: proper `Writable<string>` type annotation in handler signatures preserves Cell methods through pattern composition

## Changes

### ct-markdown component
- Remove `disabled` attribute from task list checkboxes (marked library adds this by default)
- Fire `ct-checkbox-change` event with `{ index, checked }` detail
- Add `cursor: pointer` styling for checkboxes

### note-md.tsx
- Accept `content` as `Writable<string>` input prop
- Use proper type annotation to preserve Writable interface through handler binding
- Bind `handleCheckboxToggle` handler with typed content

### note.tsx
- Pass `sourceNoteRef` for Edit button navigation
- Pass `content` Writable for checkbox updates

## Test plan

- [ ] Navigate to a note with checkbox content
- [ ] Click "View" to open markdown viewer
- [ ] Click a checkbox - should toggle and update immediately
- [ ] Click "Edit" to return to editor - verify checkbox state persisted in raw markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable interactive task list checkboxes in the markdown viewer. Toggling a checkbox updates the note’s markdown immediately and persists when returning to edit mode.

- New Features
  - ct-markdown: enables checkbox clicks, removes disabled attribute, adds cursor pointer, and emits ct-checkbox-change with { index, checked }.
  - note-md.tsx: accepts a Writable<string> content prop, handles ct-checkbox-change, and updates content; supports sourceNoteRef for Edit navigation.
  - note.tsx: passes content (Writable) and self to the viewer to enable checkbox persistence and Edit navigation.

<sup>Written for commit 50b4f52164110c6d8fd1429703f10978e2eb2b7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

