### PR TITLE
test(runner): add integration test for `@Error` wrapper in `fetchData`

### DIFF
--- a/packages/runner/test/fetch-data-mutex.test.ts
+++ b/packages/runner/test/fetch-data-mutex.test.ts
@@ -335,8 +335,13 @@ describe("fetch-data mutex mechanism", () => {
       pending?: boolean;
     };
 
-    // Should have an error
+    // Should have an error with proper @Error wrapper structure
     expect(data.error).toBeDefined();
+    expect(data.error).toHaveProperty("@Error");
+    const errorInfo =
+      (data.error as { "@Error": Record<string, unknown> })["@Error"];
+    expect(errorInfo.name).toBe("Error");
+    expect(errorInfo.message).toMatch(/HTTP 404/);
     expect(data.pending).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- Adds test assertions verifying that HTTP errors from `fetchData` are stored with the proper `@Error` wrapper structure

## Context

This is the remaining useful bit from the earlier abandoned PR #2455, whose main functionality (Error serialization via `@Error` wrapper) was reimplemented via a different approach in `value-codec.ts`.

The test ensures that error `name`, `message`, and other properties are preserved when `fetchData` encounters HTTP errors.

## Test plan

- [x] Existing tests pass
- [x] New assertions verify `@Error` wrapper structure in fetch error handling test

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an integration test to ensure fetchData stores HTTP errors using the @Error wrapper. It verifies the wrapper exists, preserves error name and message (e.g., HTTP 404), and sets pending to false.

<sup>Written for commit 2dd66c274ffb9a46b5143e4f6708b4ecd3d1f68b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

