### PR TITLE
feat(patterns/google): direct GmailImporter instantiation in USPS pattern

### DIFF
--- a/packages/patterns/google/WIP/usps-informed-delivery.tsx
+++ b/packages/patterns/google/WIP/usps-informed-delivery.tsx
@@ -320,10 +320,17 @@ export default pattern<PatternInput, PatternOutput>(
       (emails: Email[]) => emails?.length || 0,
     );
 
-    // Check if auth is connected by checking if linkedAuth has a token
+    // Check if connected - either linkedAuth is provided or gmailImporter found auth via wish
+    // We check emailCount > 0 OR if the importer is actively fetching
     const isConnected = derive(
-      { linkedAuth },
-      ({ linkedAuth: la }) => !!(la?.token),
+      { linkedAuth, gmailImporter },
+      ({ linkedAuth: la, gmailImporter: gi }) => {
+        // If linkedAuth has a token, we're connected
+        if (la?.token) return true;
+        // Otherwise check if gmailImporter has found auth (emailCount will be defined, even if 0)
+        // The importer uses wish() internally to find favorited google-auth
+        return gi?.emailCount !== undefined;
+      },
     );
 
     // ==========================================================================


### PR DESCRIPTION
## Summary

- Refactors USPS Informed Delivery pattern to directly instantiate `GmailImporter` instead of using `wish()` to find a separate charm
- Simplifies user setup: link `google-auth/auth` directly instead of configuring a separate gmail-importer charm
- Fixes `isConnected` detection to properly detect wish-based auth inside the embedded GmailImporter

## Motivation

The previous architecture required users to:
1. Deploy a gmail-importer charm
2. Configure it with the specific USPS filter query
3. Enable auto-fetch on auth
4. Deploy the USPS pattern which would find the gmail-importer via `wish()`

The new approach embeds the GmailImporter directly with pre-configured USPS settings, reducing setup to:
1. Deploy a google-auth charm and complete OAuth
2. Deploy this pattern
3. Link: `ct charm link google-auth/auth usps/linkedAuth`

## Status

⚠️ **Note:** The behavior is still flaky, but this moves toward the architecture we want (explicit GmailImporter instantiation rather than wish-based discovery). Further work may be needed to stabilize the auth detection and email fetching flow.

## Changes

- `packages/patterns/google/WIP/usps-informed-delivery.tsx`: 
  - Replace `wish("#gmailEmails")` with direct `GmailImporter({...})` instantiation
  - Change input from `linkedEmails?: Email[]` to `linkedAuth?: Auth`
  - Update `isConnected` logic to check for `linkedAuth.token` or `gmailImporter.emailCount !== undefined`
  - Update UI instructions to reflect new linking approach

## Test plan

- [ ] Deploy google-auth charm and complete OAuth
- [ ] Deploy USPS pattern
- [ ] Link auth: `ct charm link google-auth/auth usps/linkedAuth`
- [ ] Verify USPS emails are fetched and displayed
- [ ] Verify LLM analysis runs on mail piece images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embed GmailImporter directly in the USPS Informed Delivery pattern, removing wish-based discovery and the separate gmail-importer charm. This reduces setup to linking a Google Auth charm and fixes auth detection for both linked and favorited auth.

- **Refactors**
  - Instantiate GmailImporter with the USPS filter and auto-fetch; no separate charm needed.
  - Replace linkedEmails with linkedAuth and pass auth to the embedded importer.
  - Update UI instructions to use: ct charm link google-auth/auth usps/linkedAuth.

- **Bug Fixes**
  - Correct isConnected to check linkedAuth.token.
  - Detect auth found by the embedded importer when a favorited google-auth exists.

<sup>Written for commit 11daaa0c2adafc5c95876da29e02f85b6e1f4b06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

