### PR TITLE
fix(ui): use MentionableAsCellsArraySchema for correct charm IDs

### DIFF
--- a/packages/ui/src/v2/core/mention-controller.ts
+++ b/packages/ui/src/v2/core/mention-controller.ts
@@ -8,6 +8,7 @@ import {
   type Mentionable,
   type MentionableArray,
   MentionableAsCellsArraySchema,
+  type MentionableCellsArray,
 } from "./mentionable.ts";
 
 /**
@@ -88,8 +89,8 @@ export class MentionController implements ReactiveController {
     selectedIndex: 0,
   };
 
-  // Mentionable items
-  private _mentionable: CellHandle<MentionableArray> | null = null;
+  // Mentionable items - typed for schema-converted cell where .get() returns CellHandle[]
+  private _mentionable: CellHandle<MentionableCellsArray> | null = null;
   private _mentionableUnsubscribe: (() => void) | null = null;
 
   constructor(
@@ -120,8 +121,9 @@ export class MentionController implements ReactiveController {
    */
   setMentionable(mentionable: CellHandle<MentionableArray> | null): void {
     this._cleanupMentionableSubscription();
-    this._mentionable = mentionable?.asSchema(MentionableAsCellsArraySchema) ??
-      null;
+    this._mentionable = mentionable?.asSchema<MentionableCellsArray>(
+      MentionableAsCellsArraySchema,
+    ) ?? null;
 
     // Set up new subscription
     this._setupMentionableSubscription();
@@ -145,17 +147,10 @@ export class MentionController implements ReactiveController {
 
   /**
    * Get filtered mentions based on current query.
-   * With MentionableAsCellsArraySchema, .get() returns CellHandle[] directly.
+   * Uses _mentionable which has proper typing from asSchema<MentionableCellsArray>.
    */
   getFilteredMentions(): CellHandle<Mentionable>[] {
-    if (!this._mentionable) {
-      return [];
-    }
-
-    // With MentionableAsCellsArraySchema, .get() returns an array of CellHandles
-    const mentionableCells = this._mentionable.get() as unknown as
-      | CellHandle<Mentionable>[]
-      | null;
+    const mentionableCells = this._mentionable?.get();
     if (!mentionableCells || mentionableCells.length === 0) {
       return [];
     }
@@ -337,17 +332,10 @@ export class MentionController implements ReactiveController {
 
   /**
    * Read all mentionable items as CellHandles.
-   * With MentionableAsCellsArraySchema, .get() returns CellHandle[] directly.
+   * Uses _mentionable which has proper typing from asSchema<MentionableCellsArray>.
    */
   private readMentionables(): CellHandle<Mentionable>[] {
-    if (!this._mentionable) {
-      return [];
-    }
-
-    // With MentionableAsCellsArraySchema, .get() returns an array of CellHandles
-    const mentionableCells = this._mentionable.get() as unknown as
-      | CellHandle<Mentionable>[]
-      | null;
+    const mentionableCells = this._mentionable?.get();
     if (!mentionableCells || mentionableCells.length === 0) {
       return [];
     }

--- a/packages/ui/src/v2/core/mentionable.ts
+++ b/packages/ui/src/v2/core/mentionable.ts
@@ -1,3 +1,4 @@
+import { type CellHandle } from "@commontools/runtime-client";
 import { type JSONSchema, NAME } from "@commontools/runner/shared";
 
 export interface Mentionable {
@@ -6,6 +7,12 @@ export interface Mentionable {
 }
 
 export type MentionableArray = Mentionable[];
+
+/**
+ * Type for a CellHandle after applying MentionableAsCellsArraySchema.
+ * When .get() is called, returns CellHandle<Mentionable>[] instead of Mentionable[].
+ */
+export type MentionableCellsArray = CellHandle<Mentionable>[];
 
 export const MentionableSchema = {
   type: "object",


### PR DESCRIPTION
## Summary

- Fix bug where `.key(i)` returned wrong cell IDs when iterating over mentionable arrays
- Add `MentionableAsCellsArraySchema` with `asCell: true` so `.get()` returns `CellHandle[]` with correct IDs
- Update `ct-code-editor` and `mention-controller` to iterate over CellHandles directly
- Components using MentionController (ct-prompt-input, ct-outliner) automatically benefit

## Test plan

- [ ] Verify backlink autocomplete in ct-code-editor shows correct charm names
- [ ] Verify selecting a backlink inserts the correct charm ID
- [ ] Verify @-mentions in ct-prompt-input and ct-outliner work correctly
- [ ] Run existing integration tests for mentionables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect charm IDs in mentionables by returning CellHandle[] via a new schema. Autocomplete, insertions, and @-mentions now resolve the right IDs in ct-code-editor and components using MentionController.

- **Bug Fixes**
  - Added MentionableAsCellsArraySchema (asCell: true) so .get() returns CellHandle[] with the correct id().
  - Updated ct-code-editor and MentionController to iterate CellHandles and read names via key(NAME).
  - Corrected find-by-id and current mentioned ID computation to use cell.id().
  - ct-prompt-input and ct-outliner benefit automatically through MentionController.

<sup>Written for commit d5bbc9248165b8c9b3816152fb5dca5b05c4df8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

