### PR TITLE
feat(ui): filter current note from mentions autocomplete

### DIFF
--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -416,6 +416,10 @@ const Note = pattern<Input, Output>(
       return custom || JSON.stringify(Note);
     });
 
+    // Get current charm's NAME for filtering from mentions dropdown
+    // Must use computed to avoid reactive context error
+    const selfName = computed(() => `📝 ${title}`);
+
     // Editor component - used in both full UI and embeddedUI
     const editorUI = (
       <ct-code-editor
@@ -423,6 +427,7 @@ const Note = pattern<Input, Output>(
         $mentionable={mentionable}
         $mentioned={mentioned}
         $pattern={patternJson}
+        data-self-name={selfName}
         onbacklink-click={handleCharmLinkClick({})}
         onbacklink-create={handleNewBacklink({ mentionable, allCharms })}
         language="text/markdown"

--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -306,6 +306,8 @@ export class CTCodeEditor extends BaseElement {
     mentionable: { type: Object },
     mentioned: { type: Array },
     pattern: { type: Object },
+    // NOTE: selfName is read from dataset.selfName (data-self-name attribute)
+    // to avoid JSX type changes that trigger TS2589 in CI
     // New editor configuration props
     wordWrap: { type: Boolean },
     lineNumbers: { type: Boolean },
@@ -328,6 +330,13 @@ export class CTCodeEditor extends BaseElement {
   declare mentionable?: CellHandle<MentionableArray> | null;
   declare mentioned?: CellHandle<MentionableArray>;
   declare pattern: CellHandle<string>;
+  /**
+   * Name of the current charm to exclude from mentionable dropdown.
+   * Read from data-self-name attribute via this.dataset.selfName.
+   */
+  private get selfName(): string | undefined {
+    return this.dataset.selfName;
+  }
   declare wordWrap: boolean;
   declare lineNumbers: boolean;
   declare maxLineWidth?: number;
@@ -481,12 +490,14 @@ export class CTCodeEditor extends BaseElement {
 
     for (let i = 0; i < mentionableData.length; i++) {
       const mention = mentionableData[i];
-      if (
-        mention &&
-        mention[NAME]
-          ?.toLowerCase()
-          ?.includes(queryLower)
-      ) {
+      const name = mention?.[NAME] ?? "";
+
+      // Skip the current charm by comparing NAME
+      if (this.selfName && name === this.selfName) {
+        continue;
+      }
+
+      if (name?.toLowerCase()?.includes(queryLower)) {
         matches.push(this.mentionable.key(i) as CellHandle<Mentionable>);
       }
     }


### PR DESCRIPTION
## Summary
Adds self-filtering to prevent the current note from appearing in its own [[mentions]] autocomplete dropdown.

## Implementation
- Added `selfName` getter to `CTCodeEditor` that reads from `data-self-name` attribute
- Modified `getFilteredMentionable()` to skip mentions matching the current note's NAME
- Used `computed()` in `note.tsx` to generate the self-name reactively

### Technical Notes
Uses `data-self-name` attribute instead of a typed JSX prop to avoid triggering TS2589 "Type instantiation excessively deep" error in CI when combined with the recursive `MentionableCharm` type.

## Test plan
- [ ] Open a note in the shell
- [ ] Type `[[` to open mentions dropdown
- [ ] Verify the current note does not appear in the autocomplete list
- [ ] Verify other notes still appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)