### PR TITLE
fix(default-app): guard charm[NAME] here as well

### DIFF
--- a/packages/patterns/system/default-app.tsx
+++ b/packages/patterns/system/default-app.tsx
@@ -313,7 +313,7 @@ export default pattern<CharmsListInput, CharmsListOutput>((_) => {
                 {visibleCharms.map((charm) => {
                   // Check if charm is a notebook by NAME prefix (isNotebook prop not reliable through proxy)
                   const isNotebook = computed(() => {
-                    const name = charm[NAME];
+                    const name = charm?.[NAME];
                     const result = typeof name === "string" &&
                       name.startsWith("📓");
                     return result;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevented a runtime error in the default app by safely reading the charm NAME during notebook detection. Uses optional chaining (charm?.[NAME]) to handle undefined charms.

<sup>Written for commit 1aed743e6063b7b7411a4ea21651b5357a3bd1df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

