### PR TITLE
fix(patterns/google): fix type errors in agentic search tools

### DIFF
--- a/packages/patterns/google/gmail-agentic-search.tsx
+++ b/packages/patterns/google/gmail-agentic-search.tsx
@@ -101,7 +101,7 @@ type RefreshStreamType = Stream<Record<string, never>>;
 // Tool definition for additional tools
 export interface ToolDefinition {
   description: string;
-  handler: ReturnType<typeof handler>;
+  handler: Stream<any>;
 }
 
 // ============================================================================

--- a/packages/patterns/google/util/agentic-tools.ts
+++ b/packages/patterns/google/util/agentic-tools.ts
@@ -149,7 +149,7 @@ export function listTool<Fields extends string>(
     LIST_TOOL_STATE_SCHEMA,
     (input: Record<string, any>, state: {
       items: Writable<any[]>;
-      dedupeFields: string[];
+      dedupeFields: readonly string[];
       idPrefix: string;
       timestampField: string;
     }) => {


### PR DESCRIPTION
## Summary
- Fix `ToolDefinition.handler` type from `ReturnType<typeof handler>` to `Stream<any>` in gmail-agentic-search.tsx
- Fix `dedupeFields` type from `string[]` to `readonly string[]` in agentic-tools.ts to match const array usage

These changes fix compilation errors for hotel-membership-gmail-agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix type errors in Google agentic search tools to restore successful compilation for Gmail patterns.

- **Bug Fixes**
  - Set ToolDefinition.handler to Stream<any> in gmail-agentic-search.tsx.
  - Make dedupeFields readonly string[] in agentic-tools.ts to match const arrays.

<sup>Written for commit 52280d3024efa28801ba307cd165b2c5716296c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

