### PR TITLE
fix(runner): do not overwrite other parameters when restarting patterns

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -26,7 +26,6 @@ import {
 } from "./builder/recipe.ts";
 import { type Cell, isCell } from "./cell.ts";
 import { type Action } from "./scheduler.ts";
-import { diffAndUpdate } from "./data-updating.ts";
 import {
   findAllWriteRedirectCells,
   unsafe_noteParentOnRecipes,


### PR DESCRIPTION
Matters especially for pattern instantiated patterns that pass inputs.

Ideally though we don't even overwrite these, since they are start values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented overwriting of other parameters when restarting patterns by updating only the argument field. Object arguments are merged via update; non-object or link values are set.

- **Bug Fixes**
  - When the recipe is unchanged, update the argument without stopping the process.
  - Use partial update for object arguments and set for links/primitives to avoid clobbering other parameters.

<sup>Written for commit 3602a60aa8a5353f2f7747ab437c2d61fb0808f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

