### PR TITLE
fix(html): handle non-array to array transitions in VdomChildNode

### DIFF
--- a/packages/html/src/render.ts
+++ b/packages/html/src/render.ts
@@ -316,6 +316,20 @@ class VdomChildNode {
     let cancel;
     if (isCellHandle(childValue)) {
       throw new Error("child node cell resolved to another cell.");
+    } else if (Array.isArray(childValue)) {
+      // Wrap array in synthetic VNode with display:contents so it's layout-invisible
+      const [childElement, childCancel] = renderNode(
+        {
+          type: "vnode",
+          name: "span",
+          props: { style: "display:contents" },
+          children: childValue,
+        },
+        this.options,
+        new Set(this.visited),
+      );
+      element = childElement;
+      cancel = childCancel;
     } else if (isVNodeish(childValue)) {
       // Create a fresh copy of visited for each effect invocation to avoid
       // false cycle detection when the same VNode structure is re-rendered.


### PR DESCRIPTION
## Summary
- Fix edge case where a child value transitions from non-array to array
- Previously, arrays fell through to `stringifyText()` and were converted to text (e.g., `["a", "b"]` → `"a,b"`)
- Now arrays are wrapped in a synthetic `<span style="display:contents">` VNode, reusing all existing rendering machinery

## Test plan
- [x] Run `deno test --allow-all test/render.test.ts` in packages/html - all 54 steps pass
- [x] Verify `display: contents` doesn't break existing layouts in manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix rendering when a child value switches from a non-array to an array. Arrays are now wrapped in a synthetic <span style="display:contents"> and rendered as real children, so they don’t get stringified (e.g., ["a","b"] → "a,b") and diffing works correctly.

<sup>Written for commit b219c771c04e7af47468fb12371198d4db948a94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

