### PR TITLE
fix(patterns): set parentNotebook at creation time in notebook.tsx

### DIFF
--- a/packages/patterns/notes/notebook.tsx
+++ b/packages/patterns/notes/notebook.tsx
@@ -118,6 +118,7 @@ const createNoteAndOpen = handler<
     notes: Writable<NoteCharm[]>;
     allCharms: Writable<NoteCharm[]>;
     usedCreateAnotherNote: Writable<boolean>;
+    self: any;
   }
 >((
   _,
@@ -127,6 +128,7 @@ const createNoteAndOpen = handler<
     notes,
     allCharms,
     usedCreateAnotherNote,
+    self,
   },
 ) => {
   const title = newNoteTitle.get() || "New Note";
@@ -135,6 +137,7 @@ const createNoteAndOpen = handler<
     content: "",
     isHidden: true,
     noteId: generateId(),
+    parentNotebook: self, // Set parent at creation for back navigation
   });
   allCharms.push(newNote as any); // Required for persistence
   notes.push(newNote);
@@ -454,6 +457,7 @@ const createNestedNotebookAndOpen = handler<
     notes: Writable<NoteCharm[]>;
     allCharms: Writable<NoteCharm[]>;
     usedCreateAnotherNotebook: Writable<boolean>;
+    self: any;
   }
 >((
   _,
@@ -463,14 +467,16 @@ const createNestedNotebookAndOpen = handler<
     notes,
     allCharms,
     usedCreateAnotherNotebook,
+    self,
   },
 ) => {
   const title = newNestedNotebookTitle.get() || "New Notebook";
-  // Pass isHidden: true and parentNotebook for navigation back
+  // Pass isHidden: true and parentNotebook: self at creation time for back navigation
   const nb = Notebook({
     title,
     notes: [],
     isHidden: true,
+    parentNotebook: self,
   });
   allCharms.push(nb);
   notes.push(nb);
@@ -1821,6 +1827,7 @@ const Notebook = pattern<Input, Output>(
                   notes,
                   allCharms,
                   usedCreateAnotherNote,
+                  self,
                 })}
               >
                 Create
@@ -1874,6 +1881,7 @@ const Notebook = pattern<Input, Output>(
                   notes,
                   allCharms,
                   usedCreateAnotherNotebook,
+                  self,
                 })}
               >
                 Create


### PR DESCRIPTION
## Summary
- When creating a new note or nested notebook, the "In: [Parent]" chip now appears immediately
- Previously, `parentNotebook` was set via `notes.key(index).key("parentNotebook").set(self)` after push, which didn't work due to cell identity mismatch
- Fix: Pass `parentNotebook: self` as an initial prop when creating the Note/Notebook

## Root Cause
When you push an item to a Writable array and then access it via `notes.key(index)`, you get a Cell pointing to the **stored link**, not the same cell identity that the pattern receives internally. Setting `parentNotebook` on that cell modifies storage, but the Note/Notebook pattern reads `(self as any).parentNotebook` from its own input resolution path, which doesn't see this write.

## Test plan
- [x] Deployed to test space 18jantEv2
- [ ] Create a notebook "Parent"
- [ ] Click "New Note" → Create a note → Verify "In: Parent" chip appears immediately
- [ ] Click the chip → navigates back to Parent
- [ ] Click "New Notebook" → Create nested notebook → Verify "In: Parent" chip appears
- [ ] Test "Create Another" flow

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set parentNotebook at creation time for new notes and nested notebooks so the parent chip shows immediately and back navigation works. Fixes a cell identity mismatch that broke parent resolution when setting it after push.

- **Bug Fixes**
  - Pass self to createNoteAndOpen and createNestedNotebookAndOpen.
  - Include parentNotebook: self in the initial Note/Notebook object.
  - Remove post-push parentNotebook writes via notes.key(index).

<sup>Written for commit 81b91fa463ff6a42482e2f9324cfc85de61de1db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

