### PR TITLE
fix(ui): set up slotchange listener before initial tab selection

### DIFF
--- a/packages/ui/src/v2/components/ct-tabs/ct-tabs.ts
+++ b/packages/ui/src/v2/components/ct-tabs/ct-tabs.ts
@@ -133,7 +133,7 @@ export class CTTabs extends BaseElement {
     // Initialize cell controller binding
     this._cellController.bind(this.value, stringSchema);
 
-    // Set up slotchange listener FIRST to catch any pending events
+    // Set up slotchange listener to handle dynamically added content
     const slot = this.shadowRoot?.querySelector("slot");
     if (slot) {
       slot.addEventListener("slotchange", this.handleSlotChange);
@@ -183,10 +183,26 @@ export class CTTabs extends BaseElement {
     return this.querySelectorAll("ct-tab-panel");
   }
 
+  private _pendingRetry: number | null = null;
+
   private updateTabSelection(): void {
     const tabs = this.getTabs();
     const panels = this.getTabPanels();
     const currentValue = this._cellController.getValue();
+
+    // When tabs exist in DOM but the VDOM framework hasn't set their properties yet,
+    // defer selection until the next frame when properties will be available.
+    // This handles the timing gap between DOM element creation and property assignment.
+    if (tabs.length > 0 && (tabs[0] as CTTab).value === undefined) {
+      if (this._pendingRetry !== null) {
+        cancelAnimationFrame(this._pendingRetry);
+      }
+      this._pendingRetry = requestAnimationFrame(() => {
+        this._pendingRetry = null;
+        this.updateTabSelection();
+      });
+      return;
+    }
 
     // Track if any tab matches the current value
     let hasMatch = false;
@@ -229,10 +245,51 @@ export class CTTabs extends BaseElement {
   }
 
   private handleSlotChange = () => {
-    // When slot content changes, re-run tab selection
-    // This handles the case where tabs are added after initial render
+    // Set up listener on ct-tab-list's internal slot when it appears.
+    // ct-tab elements are nested inside ct-tab-list (not direct children of ct-tabs),
+    // so we need to listen to the inner slot to detect when tabs are added.
+    this.setupTabListSlotListener();
+
     this.updateTabSelection();
   };
+
+  private _tabListSlotListenerSetup = false;
+
+  /**
+   * Sets up a slotchange listener on ct-tab-list's internal slot.
+   * This is necessary because ct-tab elements are slotted into ct-tab-list,
+   * not directly into ct-tabs. Without this listener, we wouldn't know when
+   * tabs are actually added to the DOM.
+   */
+  private setupTabListSlotListener(): void {
+    if (this._tabListSlotListenerSetup) return;
+
+    const tabList = this.querySelector("ct-tab-list") as
+      | (Element & { updateComplete?: Promise<boolean> })
+      | null;
+    if (!tabList) return;
+
+    // Wait for ct-tab-list to have its shadow DOM ready
+    const tabListSlot = tabList.shadowRoot?.querySelector("slot");
+    if (!tabListSlot) {
+      // ct-tab-list hasn't rendered yet, retry after it updates
+      tabList.updateComplete?.then(() => {
+        this.setupTabListSlotListener();
+      });
+      return;
+    }
+
+    this._tabListSlotListenerSetup = true;
+
+    tabListSlot.addEventListener("slotchange", () => {
+      this.updateTabSelection();
+    });
+
+    // Check if tabs are already present (slotchange may have already fired)
+    if (tabListSlot.assignedElements().length > 0) {
+      this.updateTabSelection();
+    }
+  }
 
   private handleTabClick = (event: CustomEvent<{ tab: Element }>) => {
     const tab = event.detail.tab as CTTab;
@@ -321,9 +378,10 @@ export class CTTabs extends BaseElement {
   selectFirst(): void {
     const tabs = this.getTabs();
     // Use property access instead of getAttribute because JSX sets properties
-    const firstEnabledTab = Array.from(tabs).find((tab) =>
-      !(tab as CTTab).disabled
+    const firstEnabledTab = Array.from(tabs).find(
+      (tab) => !(tab as CTTab).disabled,
     ) as CTTab | undefined;
+
     if (firstEnabledTab?.value) {
       this._cellController.setValue(firstEnabledTab.value);
     }


### PR DESCRIPTION
## Summary
- Fix timing race condition in `ct-tabs` where `updateTabSelection()` was called before the slotchange listener was set up
- When children weren't in the DOM yet and slotchange fired before the listener existed, the event was missed
- This caused no tab to appear selected on initial load in home.tsx

## Test plan
- [ ] Load home.tsx pattern
- [ ] Verify journal tab is selected on initial load
- [ ] Verify clicking favorites tab works immediately

Fixes CT-1179

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ct-tabs init races by listening for slot changes (including ct-tab-list’s inner slot) before selection and deferring until tab values exist. Fixes initial load where no tab was selected in home.tsx (CT-1179).

<sup>Written for commit f12e65da51f6773dfdfe20b2ee3cfc476ec3a330. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

