### PR TITLE
fix(patterns): pass allCharms to NotesImportExport and make chips draggable

### DIFF
--- a/packages/patterns/system/default-app.tsx
+++ b/packages/patterns/system/default-app.tsx
@@ -145,7 +145,7 @@ const menuAllNotebooks = handler<
   if (existing) {
     return navigateTo(existing);
   }
-  return navigateTo(NotesImportExport({ importMarkdown: "" }));
+  return navigateTo(NotesImportExport({ importMarkdown: "", allCharms }));
 });
 
 // Handler: Add charm to allCharms if not already present
@@ -319,27 +319,16 @@ export default pattern<CharmsListInput, CharmsListOutput>((_) => {
                     return result;
                   });
 
-                  const dragHandle = (
-                    <ct-drag-source $cell={charm} type="note">
-                      <span
-                        style={{ cursor: "grab", padding: "4px", opacity: 0.5 }}
-                      >
-                        ⠿
-                      </span>
-                    </ct-drag-source>
-                  );
-
                   const link = (
-                    <ct-cell-context $cell={charm}>
-                      <ct-cell-link $cell={charm} />
-                    </ct-cell-context>
+                    <ct-drag-source $cell={charm} type="note">
+                      <ct-cell-context $cell={charm}>
+                        <ct-cell-link $cell={charm} />
+                      </ct-cell-context>
+                    </ct-drag-source>
                   );
 
                   return (
                     <tr>
-                      <td style={{ width: "24px", padding: "0 4px" }}>
-                        {dragHandle}
-                      </td>
                       <td>
                         {ifElse(
                           isNotebook,


### PR DESCRIPTION
## Summary
- Pass `allCharms` prop when creating NotesImportExport from default-app (fixes notes not appearing in All Notes view)
- Remove separate drag handle column and wrap `ct-cell-link` with `ct-drag-source` directly for cleaner UX

## Test plan
- [x] Create note via Notes dropdown, verify it appears in All Notes
- [x] Drag charm by its chip directly (no separate handle needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the All Notes view by passing allCharms to NotesImportExport. Simplifies drag behavior by making chips draggable directly and removing the separate drag handle.

- **Bug Fixes**
  - Pass allCharms to NotesImportExport so newly created notes show up in All Notes.

- **Refactors**
  - Wrap ct-cell-link in ct-drag-source and remove the drag handle column for cleaner, direct chip dragging.

<sup>Written for commit 1da0a39e6196cc17c8e3e2d9b510eb221397415f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

