### PR TITLE
feat(shell): make logo clickable to navigate home

### DIFF
--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -208,6 +208,12 @@ export class XHeaderView extends BaseView {
     }
   }
 
+  private handleLogoClick(e: Event) {
+    e.preventDefault();
+    e.stopPropagation();
+    globalThis.location.href = "/";
+  }
+
   private getConnectionStatus(): ConnectionStatus {
     return this.rt ? "connected" : "disconnected";
   }
@@ -257,7 +263,11 @@ export class XHeaderView extends BaseView {
     return html`
       <div id="header">
         <div class="left-section">
-          <ct-logo .backgroundColor="${connectionColor}"></ct-logo>
+          <ct-logo
+            .backgroundColor="${connectionColor}"
+            @click="${this.handleLogoClick}"
+            title="Go to home"
+          ></ct-logo>
           ${title} ${reloadIcon}
         </div>
         ${this.isLoggedIn


### PR DESCRIPTION
## Summary
- Clicking the Common Tools logo in the header now navigates to the root URL (home space)
- The logo already had `cursor: pointer` styling and hover effects, this adds the actual click handler

## Test plan
- [x] Integration tests pass
- [x] Manual: Click logo from any space/charm → should navigate to `/`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking the header logo now takes you to the home space (/). Added a click handler to ct-logo and a “Go to home” tooltip.

<sup>Written for commit a3a273bbef57dd4e7c2e81cbf68cf87a2a9609d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

