### PR TITLE
feat(patterns/google): add calendar selection filter to Google Calendar Importer

### DIFF
--- a/packages/patterns/google/google-calendar-importer.tsx
+++ b/packages/patterns/google/google-calendar-importer.tsx
@@ -365,7 +365,9 @@ async function fetchCalendarEvents(state: FetchState): Promise<void> {
       calendars.some(
         (cal, i) =>
           existingCalendars[i]?.id !== cal.id ||
-          existingCalendars[i]?.summary !== cal.summary,
+          existingCalendars[i]?.summary !== cal.summary ||
+          existingCalendars[i]?.backgroundColor !== cal.backgroundColor ||
+          existingCalendars[i]?.foregroundColor !== cal.foregroundColor,
       );
     if (calendarsChanged) {
       debugLog(debugMode, "Calendar list changed, updating...");


### PR DESCRIPTION
## Summary

- **Add clickable calendar selection chips** - Users can now toggle individual calendars on/off to filter which events are imported
- **Add color-coded calendar tags** - Events in the list now show colored tags indicating which calendar they belong to
- **Add collapsible events list** - Events section can be expanded/collapsed for cleaner UI

## Features

### Calendar Selection Filter
- Calendars display as clickable chips with checkmarks (✓) when selected
- Deselected calendars are visually faded (opacity: 0.4) with strikethrough
- "Select All" and "Deselect All" convenience buttons
- Only selected calendars are fetched when importing events

### Color-Coded Calendar Tags  
- Each event shows a colored tag matching its source calendar
- Tags use the calendar's foreground/background colors from Google

### Collapsible Events List
- "Show Events" / "Hide Events" toggle button
- Defaults to hidden for cleaner initial state

## Bug Fixes

- **Fixed checkmark display reactivity bug** - Checkmarks now properly update when toggling calendar selection
  - Root cause: Wrapping JSX in `computed()` breaks reactive updates (JSX transformer skips reactive wrapping in computed context)
  - Fix: Use `computed()` inside `.map()` for per-item reactive state with `ifElse()` for conditionals

- **Fixed reactive loop causing 100% CPU** - Added change detection before `.set()` calls to prevent unnecessary re-renders when fetched data hasn't changed

## Test plan

- [ ] Deploy charm and authenticate with Google
- [ ] Click "Fetch Calendar Events" - all calendars selected by default
- [ ] Click a calendar chip to deselect - should fade out with strikethrough, checkmark disappears
- [ ] Click "Fetch Calendar Events" again - events from deselected calendar should not appear
- [ ] Verify "Select All" / "Deselect All" buttons work
- [ ] Verify colored tags appear on events matching their calendar colors
- [ ] Verify "Show Events" / "Hide Events" toggle works

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a calendar selection filter to the Google Calendar Importer with selectable chips and color-coded tags, plus a collapsible events list. Users can choose which calendars to import and scan events by source.

- **New Features**
  - Toggle calendars with chips; includes Select All/Deselect All and auto-selects all on first fetch.
  - Imports only from selected calendars.
  - Collapsible events list (hidden by default) with calendar-colored tags and event details.

- **Bug Fixes**
  - Fixed checkmarks not updating by moving per-item selection to computed values inside map.
  - Prevented reactive loops/CPU spikes by guarding state updates and only setting calendars when they change.

<sup>Written for commit 58862f7fe36fb3e5f0c3634577496d80f7d11a17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

