### PR TITLE
fix(patterns): improve store-mapper department tab UX

### DIFF
--- a/packages/patterns/store-mapper.tsx
+++ b/packages/patterns/store-mapper.tsx
@@ -1743,16 +1743,16 @@ export default pattern<Input, Output>(
             <ct-tab-panel value="departments">
               <ct-vscroll flex showScrollbar fadeEdges>
                 <ct-vstack gap="2" style="padding: 1rem; max-width: 800px;">
-                  {/* Department list - sorted with unassigned first */}
-                  {derive(departments, (depts: Department[]) => {
+                  {/* Department list - unassigned shown first, assigned at bottom */}
+                  {computed(() => {
+                    const depts = departments.get();
                     // Sort: unassigned first, then assigned departments
-                    const sorted = [...depts].sort((a, b) => {
+                    return [...depts].sort((a, b) => {
                       const aAssigned = a.location !== "unassigned";
                       const bAssigned = b.location !== "unassigned";
                       if (aAssigned === bAssigned) return 0;
                       return aAssigned ? 1 : -1;
                     });
-                    return sorted;
                   }).map((dept) => (
                     <ct-card>
                       <ct-vstack gap="2">


### PR DESCRIPTION
## Summary

- Changed department location button labels from abbreviations (L/C/R/Fr/Bk) to full words (Left/Center/Right/Front/Back) for better clarity
- Renamed confusing "Center" button in Other section to "Normal Aisle" to distinguish it from wall-position center buttons
- Added reactive sorting so assigned departments move to the bottom of the list, keeping unassigned departments at the top for easier workflow

## Test plan

- [ ] Deploy store-mapper pattern and verify button labels show full words
- [ ] Assign a department to a location and verify it moves to the bottom of the list
- [ ] Verify "Normal Aisle" button correctly assigns in-aisle location

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Store Mapper departments tab for clearer controls and a smoother workflow. Replaces abbreviated location labels with full words and keeps unassigned departments at the top of the list.

- **New Features**
  - Use full labels: Left/Center/Right/Front/Back.
  - Rename “Center” in Other to “Normal Aisle” to avoid confusion with wall centers.
  - Reactively sort departments with computed(): unassigned first, assigned move to the bottom.

<sup>Written for commit 7965f4f48da78d2990ae344edd69ec765076bdf7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

