### PR TITLE
fix(scripts): separate cache clearing from database clearing

### DIFF
--- a/docs/development/LOCAL_DEV_SERVERS.md
+++ b/docs/development/LOCAL_DEV_SERVERS.md
@@ -11,7 +11,8 @@
 ./scripts/stop-local-dev.sh           # Stop both servers
 ./scripts/restart-local-dev.sh        # Restart both
 ./scripts/restart-local-dev.sh --force       # Force kill first
-./scripts/restart-local-dev.sh --clear-cache # Clear cache on restart
+./scripts/restart-local-dev.sh --clear-cache # Clear disposable caches (preserves spaces)
+./scripts/restart-local-dev.sh --dangerously-clear-all-spaces # Clear databases/spaces
 ```
 
 **URLs:**
@@ -84,7 +85,7 @@ curl -s -o /dev/null -w "%{http_code}" http://localhost:5173          # Shell
 | Commands hang/timeout | Servers not running | Run `./scripts/restart-local-dev.sh` |
 | Space shows errors | Only one server running | Ensure BOTH are running |
 | Port already in use | Previous server didn't stop | Use `--force` flag |
-| Stale data | Cache issues | Use `--clear-cache` flag |
+| Stale data | Cache issues | Use `--clear-cache` flag (or `--dangerously-clear-all-spaces` for database issues) |
 | `*.ts.net` URLs hang | Not on Tailscale | Connect to CT network via Tailscale |
 | OAuth error: `Unexpected token '<'` | Fetching from wrong port | Use port 8000 for API calls ([see below](#oauth-returns-html-instead-of-json)) |
 | UI component changes not appearing | Shell doesn't watch packages/ui | Restart local dev server |

--- a/scripts/restart-local-dev.sh
+++ b/scripts/restart-local-dev.sh
@@ -5,11 +5,16 @@ cd "$SCRIPT_DIR/.."
 
 # Parse command line arguments
 CLEAR_CACHE=false
+CLEAR_ALL_SPACES=false
 FORCE=false
 while [[ $# -gt 0 ]]; do
     case $1 in
         --clear-cache)
             CLEAR_CACHE=true
+            shift
+            ;;
+        --dangerously-clear-all-spaces)
+            CLEAR_ALL_SPACES=true
             shift
             ;;
         --force)
@@ -18,7 +23,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 [--clear-cache] [--force]"
+            echo "Usage: $0 [--clear-cache] [--dangerously-clear-all-spaces] [--force]"
             exit 1
             ;;
     esac
@@ -27,10 +32,25 @@ done
 echo "Stopping local dev servers..."
 ./scripts/stop-local-dev.sh
 
+CACHE_DIR="packages/toolshed/cache"
+
 if [[ "$CLEAR_CACHE" == "true" ]]; then
-    echo "Clearing cache..."
-    rm -rf packages/toolshed/cache/*
-    echo "Cache cleared."
+    echo "Clearing disposable caches (preserving spaces/databases)..."
+    # Clear all cache subdirectories except 'memory' which contains databases
+    if [[ -d "$CACHE_DIR" ]]; then
+        find "$CACHE_DIR" -mindepth 1 -maxdepth 1 -type d ! -name 'memory' -exec rm -rf {} +
+        # Also remove any loose files in cache root
+        find "$CACHE_DIR" -maxdepth 1 -type f -delete
+    fi
+    echo "Disposable caches cleared."
+fi
+
+if [[ "$CLEAR_ALL_SPACES" == "true" ]]; then
+    echo "WARNING: Clearing all spaces/databases..."
+    if [[ -d "$CACHE_DIR/memory" ]]; then
+        rm -rf "$CACHE_DIR/memory"
+    fi
+    echo "Spaces/databases cleared."
 fi
 
 echo "Starting local dev servers..."


### PR DESCRIPTION
The --clear-cache flag previously deleted everything in the cache
folder including the memory subfolder which contains user databases.

Now --clear-cache only clears disposable caches (LLM responses, web
reader cache, images, etc.) while preserving the memory folder.

Added --dangerously-clear-all-spaces flag for when you actually want
to clear the databases.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separated disposable cache clearing from persistent spaces/databases in restart-local-dev.sh to prevent accidental data loss. Added a dedicated flag to fully reset spaces when needed and updated docs.

- **New Features**
  - --clear-cache now removes LLM/web/image caches and keeps memory/.
  - --dangerously-clear-all-spaces deletes packages/toolshed/cache/memory.
  - Docs updated with flag usage and troubleshooting notes.

<sup>Written for commit e6421cb1fac69cada64ac9df2f49ffd3a9946b3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

