### PR TITLE
feat(patterns): add email-notes pattern for processing task-current notes

### DIFF
--- a/packages/patterns/google/email-notes.tsx
+++ b/packages/patterns/google/email-notes.tsx
@@ -210,6 +210,7 @@ interface PatternInput {
 interface PatternOutput {
   notes: Note[];
   noteCount: number;
+  previewUI: unknown;
 }
 
 export default pattern<PatternInput, PatternOutput>(() => {
@@ -308,10 +309,50 @@ export default pattern<PatternInput, PatternOutput>(() => {
 
   const noteCount = computed(() => notes?.length || 0);
 
+  // Preview UI for compact display
+  const previewUI = (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "12px",
+        padding: "8px 12px",
+      }}
+    >
+      <div
+        style={{
+          width: "36px",
+          height: "36px",
+          borderRadius: "8px",
+          backgroundColor: "#eff6ff",
+          border: "2px solid #3b82f6",
+          color: "#1d4ed8",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontWeight: "bold",
+          fontSize: "16px",
+        }}
+      >
+        {noteCount}
+      </div>
+      <div>
+        <div style={{ fontWeight: "600", fontSize: "14px" }}>Email Notes</div>
+        <div style={{ fontSize: "12px", color: "#6b7280" }}>
+          {computed(() => {
+            const count = noteCount;
+            return count === 1 ? "1 note" : `${count} notes`;
+          })}
+        </div>
+      </div>
+    </div>
+  );
+
   return {
     [NAME]: "Email Notes",
     notes,
     noteCount,
+    previewUI,
 
     [UI]: (
       <ct-screen>


### PR DESCRIPTION
## Summary

Adds a new pattern for managing quick notes sent to yourself via email. This is designed for the workflow:

1. **Send yourself a note** - Email yourself with no subject and the Gmail label `task-current`
2. **View notes** - This pattern fetches and displays all such emails
3. **Copy to another system** - Use the copy button to paste content (supports rich text formatting)
4. **Mark as done** - Click "Done" to remove the `task-current` label, archiving the note

## Features

- **Automatic Gmail integration** - Uses embedded gmail-importer with `label:task-current subject:""` filter
- **Rich text copying** - Copy button includes both plain text and HTML for pasting into rich editors
- **Mark as Done** - Removes the `task-current` label via Gmail API
- **Encoding fix** - Cleans up UTF-8 mojibake artifacts (Â characters) common in email content
- **Compact preview** - Includes `previewUI` for embedding in dashboards showing note count
- **Clean UI** - Status indicators only appear when there's a problem (not when everything is working)

## Use Case

This is for people who use Gmail's `task-current` label as an inbox for quick notes to themselves - things they want to process into another system (notes app, task manager, etc.) and then dismiss. The workflow is:

```
Phone → Quick email to self (no subject) → Apply task-current label
Later → Open this pattern → Copy content → Paste into destination → Click Done
```

## Test plan

- [ ] Deploy pattern and authenticate with Google
- [ ] Send yourself an email with no subject and apply `task-current` label
- [ ] Verify note appears in the pattern
- [ ] Copy content and paste into a rich text editor (verify formatting preserved)
- [ ] Click "Done" and verify the `task-current` label is removed from the email
- [ ] Verify note disappears from the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Email Notes pattern that pulls Gmail messages with the task-current label and no subject, so you can quickly copy content and mark notes done. Improves processing flow with rich-text copying, label management, and a compact preview.

- **New Features**
  - Preconfigured Gmail filter: label:task-current subject:""
  - Rich text copy via ct-copy-button (text/plain + text/html)
  - Done removes task-current label and hides the note
  - Auto-fetches label ID on auth; also provides a Load Labels button
  - Cleans common UTF-8 mojibake in email content
  - Preview UI with note count for dashboards

- **Bug Fixes**
  - Passes createGoogleAuth auth directly to GmailSendClient/GmailImporter
  - Uses Stream + computed for reliable label auto-fetch
  - Shows label status only when loading or missing

<sup>Written for commit 1ba3c4ed64a8b9a719313f090df12ca63ed955ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

