### PR TITLE
feat(patterns/google): enhance berkeley-library with bulk operations and reactivity fixes

### DIFF
--- a/packages/patterns/google/berkeley-library.tsx
+++ b/packages/patterns/google/berkeley-library.tsx
@@ -359,6 +359,7 @@ const markAsReturnedHandler = handler<
   }
 >(({ title }, { manuallyReturned, emailAnalyses }) => {
   const normalizedInput = title.toLowerCase().trim();
+  if (!normalizedInput) return; // Guard against empty input
 
   // Check if input is "Title by Author" format
   const byMatch = normalizedInput.match(/^(.+?)\s+by\s+(.+)$/);
@@ -415,6 +416,7 @@ const dismissHoldHandler = handler<
   }
 >(({ title }, { dismissedHolds, emailAnalyses }) => {
   const normalizedInput = title.toLowerCase().trim();
+  if (!normalizedInput) return; // Guard against empty input
 
   // Check if input is "Title by Author" format
   const byMatch = normalizedInput.match(/^(.+?)\s+by\s+(.+)$/);


### PR DESCRIPTION
## Summary

Major enhancements to the Berkeley Library pattern with new bulk operations, omnibot integration, and critical reactivity fixes.

### Features
- **Grouped due date view** - Items grouped by due date with bulk "Mark Returned" buttons
- **Bulk selection** - Checkboxes for selecting/deselecting items within each due date group
- **Manual due date override** - Set new due dates for selected items (useful after renewals)
- **Omnibot actions** - `markAsReturned` and `dismissHold` handlers for AI assistant integration
- **Hold dismissal** - "Picked Up" button to dismiss holds from the ready list

### Bug Fixes
- **Deduplication fix** - Now uses title+author only (not dueDate), so renewed books don't appear as duplicates
- **OpaqueRef fix** - Extract item keys before computed closures to avoid "reactive reference outside context" errors
- **PreviewUI fix** - Pre-compute `dueTomorrowCount` instead of comparing Cell object to number
- **Checkbox reactivity** - Use native `<input type="checkbox">` instead of `ct-checkbox` for computed bindings (ct-checkbox $checked tries to write to read-only computed cells)

### Technical Notes
- Selection logic inverted: tracks *deselected* items so items are selected by default for bulk operations
- All derived values (urgency, colors, formatted dates) pre-computed in `itemsByDueDate` to avoid OpaqueRef issues in JSX
- Handlers defined at module scope with proper typing

## Test plan
- [x] Deploy charm and verify emails load
- [x] Click checkbox - visual toggles and count updates
- [x] Click again - toggles back
- [x] Bulk "Mark Returned" button reflects selected count
- [x] Pattern-critic review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a grouped-by-due-date UI with bulk selection/returns, manual due date overrides, and omnibot actions for returning books and dismissing holds. Fixes deduplication and reactivity issues for a more accurate, stable experience.

- **New Features**
  - Group checked-out items by due date with per-item checkboxes and bulk “Mark Returned”.
  - Override due dates for selected items; items regroup automatically.
  - Omnibot actions: markAsReturned({ title }) and dismissHold({ title }).
  - Holds: “Picked Up” button and a Dismissed Holds section with undo.
  - New persisted state: manuallyReturned, dismissedHolds, selectedItems, dueDateOverrides; exposes markAsReturned and dismissHold streams.

- **Bug Fixes**
  - Deduplicate by title+author (ignore dueDate) to avoid duplicates after renewals.
  - Resolved OpaqueRef issues by precomputing derived values and extracting item keys before computed closures.
  - Fixed preview UI by precomputing dueTomorrowCount and using display bindings.
  - Replaced ct-checkbox with a native checkbox and inverted selection logic to track deselected keys.

<sup>Written for commit 9a96f1d825cc2de355cc20db50b1f59020da23ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

