### PR TITLE
feat(shell): add Spaces tab to home view

### DIFF
--- a/packages/home-schemas/favorites.ts
+++ b/packages/home-schemas/favorites.ts
@@ -12,6 +12,8 @@ export const favoriteEntrySchema = {
     cell: { not: true, asCell: true },
     tag: { type: "string", default: "" },
     userTags: { type: "array", items: { type: "string" }, default: [] },
+    spaceName: { type: "string" },
+    spaceDid: { type: "string" },
   },
   required: ["cell"],
 } as const satisfies JSONSchema;

--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -2861,6 +2861,7 @@ type CtListItem = {
 
 interface CTOutlinerElement extends CTHTMLElement {}
 interface CTCellLinkElement extends CTHTMLElement {}
+interface CTSpaceLinkElement extends CTHTMLElement {}
 interface CTListElement extends CTHTMLElement {}
 interface CTListItemElement extends CTHTMLElement {}
 interface CTLoaderElement extends CTHTMLElement {}
@@ -3168,6 +3169,12 @@ interface CTOutlinerAttributes<T> extends CTHTMLAttributes<T> {
 interface CTCellLinkAttributes<T> extends CTHTMLAttributes<T> {
   "link"?: string;
   "$cell": CellLike<any>;
+}
+
+interface CTSpaceLinkAttributes<T> extends CTHTMLAttributes<T> {
+  "spaceName"?: string;
+  "spaceDid"?: string;
+  "label"?: string;
 }
 
 interface CTChatMessageAttributes<T> extends CTHTMLAttributes<T> {
@@ -4426,6 +4433,10 @@ declare global {
       "ct-cell-link": CTDOM.DetailedHTMLProps<
         CTCellLinkAttributes<CTCellLinkElement>,
         CTCellLinkElement
+      >;
+      "ct-space-link": CTDOM.DetailedHTMLProps<
+        CTSpaceLinkAttributes<CTSpaceLinkElement>,
+        CTSpaceLinkElement
       >;
       "ct-outliner": CTDOM.DetailedHTMLProps<
         CTOutlinerAttributes<CTOutlinerElement>,

--- a/packages/patterns/system/favorites-manager.tsx
+++ b/packages/patterns/system/favorites-manager.tsx
@@ -16,6 +16,8 @@ type Favorite = {
   cell: Writable<{ [NAME]?: string }>;
   tag: string;
   userTags: Writable<string[]>;
+  spaceName?: string;
+  spaceDid?: string;
 };
 
 const onRemoveFavorite = handler<

--- a/packages/runtime-client/favorites-manager.ts
+++ b/packages/runtime-client/favorites-manager.ts
@@ -35,11 +35,16 @@ export class FavoritesManager {
    * Add a charm to favorites.
    * @param charmId - The entity ID of the charm to add
    * @param tag - Optional tag/category for the favorite
+   * @param spaceName - Optional human-readable name of the space
    */
-  async addFavorite(charmId: string, tag?: string): Promise<void> {
+  async addFavorite(
+    charmId: string,
+    tag?: string,
+    spaceName?: string,
+  ): Promise<void> {
     const handler = await this.#getHandler("addFavorite");
     const charmCellRef = this.#createCharmRef(charmId);
-    await handler.send({ charm: charmCellRef, tag: tag || "" });
+    await handler.send({ charm: charmCellRef, tag: tag || "", spaceName });
   }
 
   /**

--- a/packages/shell/src/components/FavoriteButton.ts
+++ b/packages/shell/src/components/FavoriteButton.ts
@@ -127,7 +127,11 @@ export class XFavoriteButtonElement extends LitElement {
         await this.rt.favorites().removeFavorite(this.charmId);
         this._localIsFavorite = false;
       } else {
-        await this.rt.favorites().addFavorite(this.charmId);
+        await this.rt.favorites().addFavorite(
+          this.charmId,
+          undefined,
+          this.rt.spaceName(),
+        );
         this._localIsFavorite = true;
       }
       // Server state will update via subscription

--- a/packages/ui/src/v2/components/ct-space-link/ct-space-link.ts
+++ b/packages/ui/src/v2/components/ct-space-link/ct-space-link.ts
@@ -1,0 +1,90 @@
+import { css, html } from "lit";
+import { property } from "lit/decorators.js";
+import { BaseElement } from "../../core/base-element.ts";
+import "../ct-chip/ct-chip.ts";
+import type { DID } from "@commontools/identity";
+import { navigate } from "@commontools/shell/shared";
+
+/**
+ * CTSpaceLink - Renders a space as a clickable pill that navigates to the space
+ *
+ * @element ct-space-link
+ *
+ * @property {string} spaceName - The human-readable space name (optional)
+ * @property {DID} spaceDid - The space DID (required for navigation fallback)
+ * @property {string} label - Custom display text (optional)
+ *
+ * @example
+ * <ct-space-link spaceName="my-space"></ct-space-link>
+ * <ct-space-link spaceDid="did:key:z6Mk..."></ct-space-link>
+ * <ct-space-link spaceName="my-space" spaceDid="did:key:z6Mk..." label="My Space"></ct-space-link>
+ */
+export class CTSpaceLink extends BaseElement {
+  static override styles = [
+    BaseElement.baseStyles,
+    css`
+      :host {
+        display: inline-block;
+        vertical-align: middle;
+      }
+
+      ct-chip {
+        cursor: pointer;
+        max-width: 100%;
+      }
+    `,
+  ];
+
+  @property({ type: String })
+  spaceName?: string;
+
+  @property({ type: String })
+  spaceDid?: DID;
+
+  @property({ type: String })
+  label?: string;
+
+  private _truncateDid(did: string): string {
+    if (did.length <= 20) return did;
+    return `${did.slice(0, 10)}...${did.slice(-6)}`;
+  }
+
+  private _handleClick(e: Event) {
+    e.stopPropagation();
+
+    if (this.spaceName) {
+      navigate({ spaceName: this.spaceName });
+    } else if (this.spaceDid) {
+      navigate({ spaceDid: this.spaceDid });
+    }
+  }
+
+  override render() {
+    // Priority: label > spaceName > truncated spaceDid > "Unknown Space"
+    const displayText = this.label
+      ? this.label
+      : this.spaceName
+      ? this.spaceName
+      : this.spaceDid
+      ? this._truncateDid(this.spaceDid)
+      : "Unknown Space";
+
+    return html`
+      <ct-chip
+        variant="primary"
+        interactive
+        @click="${this._handleClick}"
+      >
+        ${displayText}
+      </ct-chip>
+    `;
+  }
+}
+
+globalThis.customElements.define("ct-space-link", CTSpaceLink);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ct-space-link": CTSpaceLink;
+  }
+}

--- a/packages/ui/src/v2/components/ct-space-link/index.ts
+++ b/packages/ui/src/v2/components/ct-space-link/index.ts
@@ -1,0 +1,1 @@
+export * from "./ct-space-link.ts";

--- a/packages/ui/src/v2/index.ts
+++ b/packages/ui/src/v2/index.ts
@@ -109,6 +109,7 @@ export * from "./components/ct-attachments-bar/ct-attachments-bar.ts";
 export * from "./components/ct-chip/ct-chip.ts";
 export * from "./components/ct-cell-link/index.ts";
 export * from "./components/ct-cell-context/index.ts";
+export * from "./components/ct-space-link/index.ts";
 export * from "./components/ct-drag-source/index.ts";
 export * from "./components/ct-drop-zone/index.ts";
 export * from "./components/ct-picker/index.ts";


### PR DESCRIPTION
Add a new "Spaces" tab in home.tsx that displays unique spaces from the
user's favorites. When a charm is favorited, the space name and DID are
now captured and stored with the favorite entry.

Changes:
- Add spaceName/spaceDid fields to favoriteEntrySchema
- Update FavoritesManager.addFavorite() to accept spaceName
- Pass rt.spaceName() when favoriting from FavoriteButton
- Create ct-space-link component for space navigation
- Add Spaces tab UI with computed unique spaces

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Spaces tab to Home that lists unique spaces from your favorites. Favorites now store the space name and DID, and you can navigate to a space via a new ct-space-link component.

- **New Features**
  - Store spaceName and spaceDid on favorite entries; FavoritesManager.addFavorite accepts spaceName; FavoriteButton passes rt.spaceName().
  - Compute unique spaces in Home and render a Spaces tab with clickable ct-space-link items and an empty state.
  - Add ct-space-link UI component, register its types in jsx.d.ts, and export from the UI package.

<sup>Written for commit 15b3604eaa94eb43056d71614a595f8f4dce2faf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

