### PR TITLE
feat(patterns): add Bank of America bill tracker pattern

### DIFF
--- a/packages/patterns/google/bofa-bill-tracker.tsx
+++ b/packages/patterns/google/bofa-bill-tracker.tsx
@@ -8,8 +8,8 @@
  * Features:
  * - Embeds gmail-importer directly for BoA emails
  * - Extracts bill information using LLM from email markdown content
- * - Tracks payment confirmations to auto-mark bills as paid
  * - Supports manual "Mark as Paid" for local tracking
+ * - "Likely paid" heuristic for old bills (BoA doesn't send payment confirmations)
  * - Groups bills by account (last 4 digits)
  *
  * Usage:


### PR DESCRIPTION
## Summary

Adds a new pattern to track Bank of America credit card bills from email notifications, similar to the existing `chase-bill-tracker.tsx`.

## Features

- **Gmail Integration**: Searches multiple BoA email addresses:
  - `billpay@billpay.bankofamerica.com`
  - `onlinebanking@ealerts.bankofamerica.com`
  - `ealerts@ealerts.bankofamerica.com`
  - `alerts@bankofamerica.com`

- **LLM-Powered Analysis**: Uses Claude to extract bill information from email content:
  - Bill amounts and due dates
  - Account identifiers (last 4 digits)
  - Statement balances and minimum payments

- **Bill Tracking**:
  - Shows unpaid/overdue bills with visual alerts
  - Manual "Mark Paid" button for tracking payments
  - "Likely Paid" heuristic for bills >45 days overdue (since BoA doesn't send payment confirmation emails)
  - Paid bills history with undo option

- **Bank of America Branding**: Red accent color (#c9243f), BoA website link

## Key Difference from Chase Tracker

Bank of America does **not** send payment confirmation emails, so auto-detection of paid bills is not possible. The pattern relies on:
1. Manual "Mark Paid" clicks
2. The "likely paid" heuristic (bills >45 days overdue are assumed paid)

This is reflected in the simplified code - no payment confirmation detection logic.

## Usage

```bash
# Deploy google-auth first and complete OAuth
ct charm new google-auth.tsx --space my-space

# Deploy this pattern
ct charm new bofa-bill-tracker.tsx --space my-space

# Link the auth
ct charm link google-auth/auth bofa-bill-tracker/linkedAuth
```

## Test plan

- [x] Pattern compiles with `deno check`
- [x] Deployed and tested with Playwright
- [x] Found 23 BoA emails from connected Gmail account
- [x] LLM analysis correctly identified bill types and amounts
- [x] Unpaid/overdue bills display correctly with alerts
- [x] "Likely Paid" section shows old bills appropriately

## Screenshots

Pattern showing 3 unpaid bills (2 overdue) with $7,238.96 total:

![BoFA Bill Tracker](https://github.com/user-attachments/assets/bofa-tracker-screenshot.png)

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Bank of America bill tracker pattern that reads BoA Gmail notifications to surface due amounts, show unpaid/overdue bills, and track payments. Enables a Chase-like bill view for BoA with clear totals and simple paid workflows.

- **New Features**
  - Scans Gmail for BoA senders: billpay@billpay.bankofamerica.com, onlinebanking@ealerts.bankofamerica.com, ealerts@ealerts.bankofamerica.com, alerts@bankofamerica.com.
  - Parses email content to extract amount, due date, last 4 digits, statement balance, and minimum payment.
  - Groups by account and shows totals, unpaid, and overdue with alerts.
  - Paid tracking: “Mark Paid” and a “likely paid” rule for bills >45 days overdue.
  - Compact preview widget and BoA-styled UI with a link to bankofamerica.com.

- **Refactors**
  - Removed payment-confirmation detection and related code since BoA doesn’t send payment receipts.
  - Simplified analysis and bill-building logic to rely on manual marking and the likely-paid heuristic.

<sup>Written for commit 3469f9042651aba1d74fb3938505a8d4dcabfc12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

