### PR TITLE
fix(patterns): restore reactive rendering in omnibox-fab

### DIFF
--- a/packages/patterns/system/omnibox-fab.tsx
+++ b/packages/patterns/system/omnibox-fab.tsx
@@ -156,7 +156,8 @@ export default pattern<OmniboxFABInput>(
           onct-fab-escape={closeFab({ fabExpanded })}
           onClick={toggle({ value: fabExpanded })}
         >
-          {fabExpanded.get() && (
+          {ifElse(
+            fabExpanded,
             <div style="width: 100%; display: flex; flex-direction: column; max-height: 580px;">
               {/* Chevron at top - the "handle" for the drawer */}
               <div style="border-bottom: 1px solid #e5e5e5; flex-shrink: 0;">
@@ -168,9 +169,18 @@ export default pattern<OmniboxFABInput>(
               </div>
 
               <div
-                style={showHistory.get()
-                  ? "flex: 1; min-height: 0; display: flex; flex-direction: column; opacity: 1; max-height: 480px; overflow: hidden; transition: opacity 300ms ease, max-height 400ms cubic-bezier(0.34, 1.56, 0.64, 1), flex 400ms cubic-bezier(0.34, 1.56, 0.64, 1); pointer-events: auto"
-                  : "flex: 0; min-height: 0; display: flex; flex-direction: column; opacity: 0; max-height: 0; overflow: hidden; transition: opacity 300ms ease, max-height 400ms cubic-bezier(0.34, 1.56, 0.64, 1), flex 400ms cubic-bezier(0.34, 1.56, 0.64, 1); pointer-events: none"}
+                style={computed(() => {
+                  const show = showHistory.get();
+                  return `flex: ${
+                    show ? "1" : "0"
+                  }; min-height: 0; display: flex; flex-direction: column; opacity: ${
+                    show ? "1" : "0"
+                  }; max-height: ${
+                    show ? "480px" : "0"
+                  }; overflow: hidden; transition: opacity 300ms ease, max-height 400ms cubic-bezier(0.34, 1.56, 0.64, 1), flex 400ms cubic-bezier(0.34, 1.56, 0.64, 1); pointer-events: ${
+                    show ? "auto" : "none"
+                  };`;
+                })}
               >
                 <div style="padding: .25rem; flex-shrink: 0;">
                   {omnibot.ui.attachmentsAndTools}
@@ -223,7 +233,8 @@ export default pattern<OmniboxFABInput>(
               <div style="padding: 0.5rem; flex-shrink: 0;">
                 {omnibot.ui.promptInput}
               </div>
-            </div>
+            </div>,
+            null,
           )}
         </ct-fab>
       ),


### PR DESCRIPTION
The lazy rendering optimization in f943c134d broke reactivity by using
non-reactive patterns:
- `fabExpanded.get() && (...)` doesn't create subscriptions
- `showHistory.get() ? "..." : "..."` in style is non-reactive

Fix by using proper reactive helpers:
- Use `ifElse(fabExpanded, ..., null)` for conditional rendering
- Wrap style ternary in `computed()` for reactive updates

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken reactivity in the omnibox FAB so the drawer and history panel update correctly when state changes. Restores proper reactive subscriptions and style updates for a smooth expand/collapse experience.

- **Bug Fixes**
  - Replace fabExpanded.get() conditional with ifElse(fabExpanded, ..., null) to restore reactive rendering.
  - Wrap the style ternary in computed() so layout and visibility react to showHistory changes.

<sup>Written for commit bb381c94a5edd81484d97c66e63fc33565e6aa5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

