### PR TITLE
feat(patterns): add demo mode toggle and power-law distribution to bill trackers

### DIFF
--- a/packages/patterns/google/bofa-bill-tracker.tsx
+++ b/packages/patterns/google/bofa-bill-tracker.tsx
@@ -94,12 +94,6 @@ interface TrackedBill {
 // =============================================================================
 
 /**
- * DEMO_MODE: When true, all dollar amounts are hashed to fake values
- * for privacy during demos. This ensures no real financial data is shown.
- */
-const DEMO_MODE = false;
-
-/**
  * Bills older than this threshold (in days overdue) are assumed "likely paid"
  * when no payment confirmation was detected. This avoids false positives from
  * missing payment emails (e.g., account number changed, payment made differently).
@@ -295,10 +289,10 @@ function getAccountColor(last4: string | undefined): string {
 
 /**
  * In demo mode, hash any price to a deterministic value $0-$5000.
- * Uses a simple string hash on the input to ensure same input = same output.
+ * Uses power-law distribution for more realistic bill amounts.
  */
-function demoPrice(amount: number): number {
-  if (!DEMO_MODE) return amount;
+function demoPrice(amount: number, isDemoMode: boolean): number {
+  if (!isDemoMode) return amount;
   // Handle NaN/undefined/invalid amounts
   if (!Number.isFinite(amount)) return 0;
   // Hash the amount to get deterministic pseudo-random value
@@ -307,8 +301,12 @@ function demoPrice(amount: number): number {
   for (const char of str) {
     hash = ((hash << 5) - hash + char.charCodeAt(0)) | 0;
   }
-  // Map to 0-5000 range
-  return Math.abs(hash % 500000) / 100; // 0.00 to 4999.99
+  // Normalize to 0-1 range using unsigned conversion
+  const normalized = (hash >>> 0) / 0xFFFFFFFF;
+  // Power-law: x^2 clusters values toward lower end
+  const powerLaw = Math.pow(normalized, 2);
+  // Scale to 0-5000 range, round to cents
+  return Math.round(powerLaw * 500000) / 100;
 }
 
 // =============================================================================
@@ -345,6 +343,7 @@ const unmarkAsPaid = handler<
 interface PatternInput {
   linkedAuth?: Auth;
   manuallyPaid: Writable<Default<string[], []>>;
+  demoMode: Writable<Default<boolean, true>>;
 }
 
 /** Bank of America bill tracker. #bofaBills */
@@ -358,7 +357,7 @@ interface PatternOutput {
 }
 
 export default pattern<PatternInput, PatternOutput>(
-  ({ linkedAuth, manuallyPaid }) => {
+  ({ linkedAuth, manuallyPaid, demoMode }) => {
     // Directly instantiate GmailImporter with BoA-specific settings
     const gmailImporter = GmailImporter({
       settings: {
@@ -545,7 +544,7 @@ Extract:
         const trackedBill: TrackedBill = {
           key,
           accountLast4: result.accountLast4,
-          amount: demoPrice(billAmount),
+          amount: demoPrice(billAmount, demoMode.get()),
           dueDate: result.dueDate,
           status,
           isPaid,
@@ -1381,7 +1380,10 @@ Extract:
                                 <strong>Amount:</strong> {computed(() =>
                                   formatCurrency(
                                     analysis.result?.amount !== undefined
-                                      ? demoPrice(analysis.result.amount)
+                                      ? demoPrice(
+                                        analysis.result.amount,
+                                        demoMode.get(),
+                                      )
                                       : undefined,
                                   )
                                 )}
@@ -1432,21 +1434,24 @@ Extract:
                 </a>
               </div>
 
-              {/* Demo Mode Indicator */}
-              {DEMO_MODE && (
-                <div
-                  style={{
-                    fontSize: "11px",
-                    color: "#9ca3af",
-                    cursor: "help",
-                    textAlign: "center",
-                    marginTop: "8px",
-                  }}
+              {/* Demo Mode Toggle */}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: "6px",
+                  marginTop: "8px",
+                }}
+              >
+                <ct-checkbox $checked={demoMode} />
+                <span
+                  style={{ fontSize: "11px", color: "#9ca3af" }}
                   title="Uses fake numbers for privacy"
                 >
-                  ⚠️ Demo Mode
-                </div>
-              )}
+                  Demo mode
+                </span>
+              </div>
             </ct-vstack>
           </ct-vscroll>
         </ct-screen>

--- a/packages/patterns/google/pge-bill-tracker.tsx
+++ b/packages/patterns/google/pge-bill-tracker.tsx
@@ -94,12 +94,6 @@ interface TrackedBill {
 // =============================================================================
 
 /**
- * DEMO_MODE: When true, all dollar amounts are hashed to fake values
- * for privacy during demos. This ensures no real financial data is shown.
- */
-const DEMO_MODE = true;
-
-/**
  * Bills older than this threshold (in days overdue) are assumed "likely paid"
  * when no payment confirmation was detected. This avoids false positives from
  * missing payment emails (e.g., account number changed, payment made differently).
@@ -302,10 +296,10 @@ function getAccountColor(accountId: string | undefined): string {
 
 /**
  * In demo mode, hash any price to a deterministic value $0-$5000.
- * Uses a simple string hash on the input to ensure same input = same output.
+ * Uses power-law distribution for more realistic bill amounts.
  */
-function demoPrice(amount: number): number {
-  if (!DEMO_MODE) return amount;
+function demoPrice(amount: number, isDemoMode: boolean): number {
+  if (!isDemoMode) return amount;
   // Handle NaN/undefined/invalid amounts
   if (!Number.isFinite(amount)) return 0;
   // Hash the amount to get deterministic pseudo-random value
@@ -314,8 +308,12 @@ function demoPrice(amount: number): number {
   for (const char of str) {
     hash = ((hash << 5) - hash + char.charCodeAt(0)) | 0;
   }
-  // Map to 0-5000 range
-  return Math.abs(hash % 500000) / 100; // 0.00 to 4999.99
+  // Normalize to 0-1 range using unsigned conversion
+  const normalized = (hash >>> 0) / 0xFFFFFFFF;
+  // Power-law: x^2 clusters values toward lower end
+  const powerLaw = Math.pow(normalized, 2);
+  // Scale to 0-5000 range, round to cents
+  return Math.round(powerLaw * 500000) / 100;
 }
 
 // =============================================================================
@@ -352,6 +350,7 @@ const unmarkAsPaid = handler<
 interface PatternInput {
   linkedAuth?: Auth;
   manuallyPaid: Writable<Default<string[], []>>;
+  demoMode: Writable<Default<boolean, true>>;
 }
 
 /** PGE utility bill tracker. #pgeBills */
@@ -365,7 +364,7 @@ interface PatternOutput {
 }
 
 export default pattern<PatternInput, PatternOutput>(
-  ({ linkedAuth, manuallyPaid }) => {
+  ({ linkedAuth, manuallyPaid, demoMode }) => {
     // Directly instantiate GmailImporter with PGE-specific settings
     const gmailImporter = GmailImporter({
       settings: {
@@ -605,7 +604,7 @@ Extract:
         const trackedBill: TrackedBill = {
           key,
           accountId: result.accountId,
-          amount: demoPrice(billAmount),
+          amount: demoPrice(billAmount, demoMode.get()),
           dueDate: result.dueDate,
           status,
           isPaid,
@@ -1434,7 +1433,10 @@ Extract:
                                 <strong>Amount:</strong> {computed(() =>
                                   formatCurrency(
                                     analysis.result?.amount !== undefined
-                                      ? demoPrice(analysis.result.amount)
+                                      ? demoPrice(
+                                        analysis.result.amount,
+                                        demoMode.get(),
+                                      )
                                       : undefined,
                                   )
                                 )}
@@ -1483,21 +1485,24 @@ Extract:
                 </a>
               </div>
 
-              {/* Demo Mode Indicator */}
-              {DEMO_MODE && (
-                <div
-                  style={{
-                    fontSize: "11px",
-                    color: "#9ca3af",
-                    cursor: "help",
-                    textAlign: "center",
-                    marginTop: "8px",
-                  }}
+              {/* Demo Mode Toggle */}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: "6px",
+                  marginTop: "8px",
+                }}
+              >
+                <ct-checkbox $checked={demoMode} />
+                <span
+                  style={{ fontSize: "11px", color: "#9ca3af" }}
                   title="Uses fake numbers for privacy"
                 >
-                  ⚠️ Demo Mode
-                </div>
-              )}
+                  Demo mode
+                </span>
+              </div>
             </ct-vstack>
           </ct-vscroll>
         </ct-screen>


### PR DESCRIPTION
## Summary

This PR adds two improvements to the bill tracker patterns (Chase, PGE, Bank of America):

1. **Runtime demo mode toggle** - Replaces the compile-time `DEMO_MODE` constant with a reactive checkbox that allows toggling demo mode on/off at runtime
2. **Power-law price distribution** - Changes the demo price hashing from linear to power-law distribution for more realistic bill amounts

## Changes

### Demo Mode Toggle
- Added `demoMode: Writable<Default<boolean, true>>` to `PatternInput` for all three patterns
- Replaced static "⚠️ Demo Mode" indicator with a subtle checkbox toggle
- Demo mode defaults to ON for privacy during demos

### Power-Law Distribution
The previous linear distribution (`hash % 500000`) produced uniformly distributed values. The new power-law distribution clusters values toward the lower end, which is more realistic for bill amounts:

```typescript
const normalized = (hash >>> 0) / 0xFFFFFFFF;
const powerLaw = Math.pow(normalized, 2);
return Math.round(powerLaw * 500000) / 100;
```

Distribution characteristics:
- ~50% of values fall under $1,250
- ~75% of values fall under $2,812
- Maximum remains $5,000

## Files Modified

- `packages/patterns/google/chase-bill-tracker.tsx`
- `packages/patterns/google/pge-bill-tracker.tsx`
- `packages/patterns/google/bofa-bill-tracker.tsx`

## Testing

- [x] All patterns pass `ct check`
- [x] Deployed chase-bill-tracker to playwright test space
- [x] Verified demo mode toggle appears and works
- [x] Confirmed amounts change when toggling (demo: $29.72 ↔ real: $4,061.32)
- [x] Verified checkbox state persists

## Test plan

- [ ] Deploy any bill tracker pattern
- [ ] Verify "Demo mode" checkbox appears at the bottom of the UI
- [ ] Toggle checkbox off - amounts should show real values
- [ ] Toggle checkbox on - amounts should show hashed demo values
- [ ] Verify the demo prices are reasonable (mostly smaller bills due to power-law)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runtime “Demo mode” toggle and power-law demo pricing to the Chase, PGE, and BofA bill trackers. You can now switch between real and demo amounts without rebuilding.

- **New Features**
  - Replaced compile-time DEMO_MODE with demoMode: Writable<Default<boolean, true>>.
  - Added a checkbox toggle in the UI; defaults to ON for privacy.
  - demoPrice(amount, isDemoMode) now uses a power-law (x^2) distribution normalized to $0–$5,000, with ~50% under $1,250 and ~75% under $2,812.
  - Applied to chase-bill-tracker, pge-bill-tracker, and bofa-bill-tracker.

- **Migration**
  - If you instantiate patterns programmatically, provide a demoMode writable (defaults to true). No changes needed for UI-only usage.

<sup>Written for commit d68c6ca81ee01f81809160f5f7b50d8157959d5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

