### PR TITLE
fix(cli): replace --start with --no-start for charm new command

### DIFF
--- a/packages/cli/commands/charm.ts
+++ b/packages/cli/commands/charm.ts
@@ -137,7 +137,7 @@ export const charm = new Command()
     `Create a charm that can import from parent directories within ./patterns.`,
   )
   .arguments("<main:string>")
-  .option("--start", "Start the charm after creation for one step")
+  .option("--no-start", "Only set up the charm without starting it")
   .option(
     "--main-export <export:string>",
     'Named export from entry for recipe definition. Defaults to "default".',


### PR DESCRIPTION
## Summary
- Replace redundant `--start` flag with `--no-start` for `ct charm new` command
- The `--start` flag was a no-op since charms already start by default (via `?? true` fallback in CharmsController)
- `--no-start` gives users the option to only set up a charm without starting it (calls `runner.setup` but not `runner.start`)

## Test plan
- [ ] Run `deno task ct charm new ./pattern.tsx ...` - should start charm by default
- [ ] Run `deno task ct charm new --no-start ./pattern.tsx ...` - should only set up charm without starting


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the redundant --start flag with --no-start for ct charm new. Charms still start by default; use --no-start to set up the charm without starting it.

<sup>Written for commit cb4f551271c9b2d52c1fd5b1d885d69bec600a7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

