### PR TITLE
feat(ui): add Cmd/Ctrl+click to open ct-cell-link in new tab

### DIFF
--- a/packages/ui/src/v2/components/ct-cell-link/ct-cell-link.ts
+++ b/packages/ui/src/v2/components/ct-cell-link/ct-cell-link.ts
@@ -12,7 +12,7 @@ import {
 } from "@commontools/runtime-client";
 import type { DID } from "@commontools/identity";
 import { runtimeContext, spaceContext } from "../../runtime-context.ts";
-import { navigate } from "@commontools/shell/shared";
+import { appViewToUrlPath, navigate } from "@commontools/shell/shared";
 
 /**
  * CTCellLink - Renders a link or cell as a clickable pill
@@ -175,14 +175,22 @@ export class CTCellLink extends BaseElement {
     }
   }
 
-  private _handleClick(e: Event) {
+  private _handleClick(e: MouseEvent) {
     e.stopPropagation();
     // @TODO(runtime-worker-refactor)
     if (this._resolvedCell) {
-      navigate({
+      const view = {
         spaceDid: this._resolvedCell.space(),
         charmId: this._resolvedCell.id(),
-      });
+      };
+
+      // Cmd (Mac) or Ctrl (Windows/Linux) opens in new tab
+      if (e.metaKey || e.ctrlKey) {
+        const url = appViewToUrlPath(view);
+        globalThis.open(url, "_blank");
+      } else {
+        navigate(view);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds support for Cmd+click (Mac) or Ctrl+click (Windows/Linux) on `ct-cell-link` to open the link in a new browser tab
- Normal clicks continue to navigate in the same tab
- Matches standard browser link behavior users expect

## Test plan
- [ ] Click a ct-cell-link normally → navigates in same tab
- [ ] Cmd+click (Mac) or Ctrl+click (Windows/Linux) on a ct-cell-link → opens in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Cmd/Ctrl+click on ct-cell-link to open the target view in a new tab, matching standard browser link behavior. Normal clicks are unchanged and continue to navigate in the same tab.

<sup>Written for commit cb8f2cb077f93dc81453d98e0449c248d71ae09f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

