### PR TITLE
fix(tasks): typecheck google patterns individually to avoid TS exhaustion

### DIFF
--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -58,9 +58,6 @@ PATHS=(
   "packages/patterns/system"
   "packages/patterns/test"
   "packages/patterns/weekly-calendar"
-  "packages/patterns/google/google-*.ts*"
-  "packages/patterns/google/gmail-*.ts*"
-  "packages/patterns/google/!(google-*|gmail-*).ts*"
   "packages/patterns/google/util"
   "packages/patterns/google/integration"
 )
@@ -68,4 +65,13 @@ PATHS=(
 # Check each path separately
 for path in "${PATHS[@]}"; do
   check_path "$path"
+done
+
+# Google patterns are checked individually to avoid TypeScript exhaustion
+# due to their large file sizes
+echo "Checking google patterns individually..."
+for file in packages/patterns/google/*.ts packages/patterns/google/*.tsx; do
+  if [[ -f "$file" ]]; then
+    check_path "$file"
+  fi
 done


### PR DESCRIPTION
## Summary

- Modifies `tasks/check.sh` to typecheck patterns in `packages/patterns/google/` individually rather than in batches
- The large file sizes in the google folder (some over 100KB) were causing TypeScript to exhaust memory when checking multiple files together

## Changes

**Before:** Files were checked in 3 batches by glob pattern:
```bash
deno check packages/patterns/google/google-*.ts*
deno check packages/patterns/google/gmail-*.ts*
deno check packages/patterns/google/!(google-*|gmail-*).ts*
```

**After:** Each `.ts`/`.tsx` file is checked individually:
```bash
for file in packages/patterns/google/*.ts packages/patterns/google/*.tsx; do
  deno check "$file"
done
```

The `util/` and `integration/` subdirectories continue to be checked as grouped paths since they contain smaller files.

## Test plan

- [x] Verified script runs successfully with `deno task check`
- [x] Confirmed shell syntax is valid
- [x] Verified the same set of files are checked (just individually instead of batched)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typecheck Google pattern files one by one to prevent TypeScript OOM during deno task check. Stabilizes checks for large files in packages/patterns/google.

- **Bug Fixes**
  - Replaced batched globs with a per-file loop over .ts/.tsx, calling check_path for each file.
  - Kept grouped checks for google/util and google/integration.

<sup>Written for commit c95f185a43b2c64ca21210812abeefab6c1461df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

