### PR TITLE
feat(patterns): enable debugMode for gmail-importer in all email patterns

### DIFF
--- a/packages/patterns/google/bam-school-dashboard.tsx
+++ b/packages/patterns/google/bam-school-dashboard.tsx
@@ -315,7 +315,7 @@ export default pattern<PatternInput, PatternOutput>(
         autoFetchOnAuth: true,
         resolveInlineImages: false,
         limit: 50,
-        debugMode: false,
+        debugMode: true,
       },
       linkedAuth,
     });

--- a/packages/patterns/google/berkeley-library.tsx
+++ b/packages/patterns/google/berkeley-library.tsx
@@ -549,7 +549,7 @@ export default pattern<PatternInput, PatternOutput>(
         autoFetchOnAuth: true,
         resolveInlineImages: false,
         limit: 50,
-        debugMode: false,
+        debugMode: true,
       },
       linkedAuth,
     });

--- a/packages/patterns/google/bofa-bill-tracker.tsx
+++ b/packages/patterns/google/bofa-bill-tracker.tsx
@@ -366,7 +366,7 @@ export default pattern<PatternInput, PatternOutput>(
         autoFetchOnAuth: true,
         resolveInlineImages: false,
         limit: 100,
-        debugMode: false,
+        debugMode: true,
       },
       linkedAuth,
     });

--- a/packages/patterns/google/calendar-change-detector.tsx
+++ b/packages/patterns/google/calendar-change-detector.tsx
@@ -232,7 +232,7 @@ export default pattern<PatternInput, PatternOutput>(({ linkedAuth }) => {
       autoFetchOnAuth: true,
       resolveInlineImages: false,
       limit: 50,
-      debugMode: false,
+      debugMode: true,
     },
     linkedAuth,
   });

--- a/packages/patterns/google/chase-bill-tracker.tsx
+++ b/packages/patterns/google/chase-bill-tracker.tsx
@@ -378,7 +378,7 @@ export default pattern<PatternInput, PatternOutput>(
         autoFetchOnAuth: true,
         resolveInlineImages: false,
         limit: 100,
-        debugMode: false,
+        debugMode: true,
       },
       linkedAuth,
     });

--- a/packages/patterns/google/email-notes.tsx
+++ b/packages/patterns/google/email-notes.tsx
@@ -274,7 +274,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
       autoFetchOnAuth: true,
       resolveInlineImages: false,
       limit: 50,
-      debugMode: DEBUG_NOTES,
+      debugMode: true,
     },
     linkedAuth: auth,
   });

--- a/packages/patterns/google/email-ticket-finder.tsx
+++ b/packages/patterns/google/email-ticket-finder.tsx
@@ -385,7 +385,7 @@ export default pattern<PatternInput, PatternOutput>(({ linkedAuth }) => {
       autoFetchOnAuth: true,
       resolveInlineImages: false,
       limit: 100,
-      debugMode: false,
+      debugMode: true,
     },
     linkedAuth,
   });

--- a/packages/patterns/google/united-flight-tracker.tsx
+++ b/packages/patterns/google/united-flight-tracker.tsx
@@ -460,7 +460,7 @@ export default pattern<PatternInput, PatternOutput>(({ linkedAuth }) => {
       autoFetchOnAuth: true,
       resolveInlineImages: false,
       limit: 100,
-      debugMode: false,
+      debugMode: true,
     },
     linkedAuth,
   });

--- a/packages/patterns/google/usps-informed-delivery.tsx
+++ b/packages/patterns/google/usps-informed-delivery.tsx
@@ -297,7 +297,7 @@ export default pattern<PatternInput, PatternOutput>(
         autoFetchOnAuth: true,
         resolveInlineImages: true,
         limit: 20,
-        debugMode: DEBUG_USPS,
+        debugMode: true,
       },
       linkedAuth, // Pass through from USPS input (user can link google-auth here)
     });


### PR DESCRIPTION
## Summary
- Enable `debugMode: true` for gmail-importer across all 9 email-based patterns
- This enables debug logging to help with development and troubleshooting of email fetching

## Patterns Updated
- `usps-informed-delivery.tsx`
- `berkeley-library.tsx`
- `chase-bill-tracker.tsx`
- `bam-school-dashboard.tsx`
- `bofa-bill-tracker.tsx`
- `email-ticket-finder.tsx`
- `calendar-change-detector.tsx`
- `email-notes.tsx`
- `united-flight-tracker.tsx`

## Test plan
- [x] Deployed email-pattern-dreamer locally and verified patterns load
- [x] `deno fmt` passes
- [x] `deno lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable gmail-importer debugMode across all nine email-based patterns to surface detailed logs for development and troubleshooting. This improves visibility into email fetching without changing user-facing behavior.

<sup>Written for commit 0145eaa6f839d94ba41da2178fe825999d525c57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

