### PR TITLE
feat: Introduce LRUCache for common cache scenarios, backed by a linked list implementation

### DIFF
--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -1,10 +1,8 @@
 import { SourceMap } from "./interface.ts";
 import { MappedPosition, SourceMapConsumer } from "source-map-js";
+import { LRUCache } from "@commontools/utils/cache";
 
 export type { MappedPosition };
-import { getLogger } from "@commontools/utils/logger";
-
-const logger = getLogger("source-map");
 
 /**
  * Maximum number of source maps to cache in memory.
@@ -31,58 +29,13 @@ const CT_INTERNAL = `    at <CT_INTERNAL>`;
 const UNMAPPED = `    at <UNMAPPED>`;
 
 export class SourceMapParser {
-  private sourceMaps = new Map<string, SourceMap>();
-  private consumers = new Map<string, SourceMapConsumer>();
-
-  /**
-   * Evict oldest source maps if cache exceeds MAX_SOURCE_MAP_CACHE_SIZE.
-   * Uses Map insertion order for LRU - oldest entries are first.
-   */
-  private evictIfNeeded(): void {
-    while (this.sourceMaps.size > MAX_SOURCE_MAP_CACHE_SIZE) {
-      const oldestFilename = this.sourceMaps.keys().next().value;
-      if (oldestFilename === undefined) break;
-
-      // Remove from both caches
-      this.sourceMaps.delete(oldestFilename);
-      this.consumers.delete(oldestFilename);
-
-      logger.debug(
-        "source-map",
-        `Evicted source map ${oldestFilename} (cache size: ${this.sourceMaps.size})`,
-      );
-    }
-  }
-
-  /**
-   * Touch a source map to mark it as recently used (moves to end of Map).
-   * Call this on cache hits to maintain LRU order.
-   */
-  private touch(filename: string): void {
-    // Re-insert sourceMaps entry to move to end
-    const sourceMap = this.sourceMaps.get(filename);
-    if (sourceMap) {
-      this.sourceMaps.delete(filename);
-      this.sourceMaps.set(filename, sourceMap);
-    }
-
-    // Re-insert consumers entry to move to end (if exists)
-    const consumer = this.consumers.get(filename);
-    if (consumer) {
-      this.consumers.delete(filename);
-      this.consumers.set(filename, consumer);
-    }
-  }
+  private sourceMaps = new LRUCache<string, SourceMap>({
+    capacity: MAX_SOURCE_MAP_CACHE_SIZE,
+  });
+  private consumers = new WeakMap<SourceMap, SourceMapConsumer>();
 
   load(filename: string, sourceMap: SourceMap) {
-    // If already exists, touch to mark as recently used
-    if (this.sourceMaps.has(filename)) {
-      this.touch(filename);
-      return;
-    }
-
-    this.sourceMaps.set(filename, sourceMap);
-    this.evictIfNeeded();
+    this.sourceMaps.put(filename, sourceMap);
   }
 
   /**
@@ -91,14 +44,6 @@ export class SourceMapParser {
    */
   clear(): void {
     this.sourceMaps.clear();
-    this.consumers.clear();
-  }
-
-  /**
-   * Get the number of loaded source maps (for diagnostics/testing).
-   */
-  get size(): number {
-    return this.sourceMaps.size;
   }
 
   // Fixes stack traces to use source map from eval. Strangely, both Deno and
@@ -116,16 +61,14 @@ export class SourceMapParser {
       const lineNum = parseInt(match[3], 10);
       const columnNum = parseInt(match[4], 10);
 
-      if (!this.sourceMaps.has(filename)) return line;
-
-      // Touch to mark as recently used for LRU
-      this.touch(filename);
+      const sourceMap = this.sourceMaps.get(filename);
+      if (!sourceMap) return line;
 
       if (/AMDLoader/.test(fnName) && lineNum === 1) {
         return CT_INTERNAL;
       }
 
-      const consumer = this.getConsumer(filename);
+      const consumer = this.getConsumer(sourceMap);
       const originalPosition = consumer.originalPositionFor({
         line: lineNum,
         column: columnNum,
@@ -150,24 +93,21 @@ export class SourceMapParser {
     line: number,
     column: number,
   ): MappedPosition | null {
-    if (!this.sourceMaps.has(filename)) return null;
-
-    this.touch(filename);
-    const consumer = this.getConsumer(filename);
+    const sourceMap = this.sourceMaps.get(filename);
+    if (!sourceMap) return null;
+    const consumer = this.getConsumer(sourceMap);
     const pos = consumer.originalPositionFor({ line, column });
-
     return mapIsEmpty(pos) ? null : pos;
   }
 
-  private getConsumer(filename: string): SourceMapConsumer {
-    if (!this.consumers.has(filename)) {
-      this.consumers.set(
-        filename,
-        new SourceMapConsumer(this.sourceMaps.get(filename)!),
-      );
+  private getConsumer(sourceMap: SourceMap): SourceMapConsumer {
+    let consumer = this.consumers.get(sourceMap);
+    if (consumer) {
+      return consumer;
     }
-
-    return this.consumers.get(filename)!;
+    consumer = new SourceMapConsumer(sourceMap);
+    this.consumers.set(sourceMap, consumer);
+    return consumer;
   }
 }
 

--- a/packages/utils/deno.json
+++ b/packages/utils/deno.json
@@ -5,6 +5,7 @@
   },
   "exports": {
     ".": "./src/index.ts",
+    "./cache": "./src/cache.ts",
     "./defer": "./src/defer.ts",
     "./encoding": "./src/encoding.ts",
     "./env": "./src/env.ts",

--- a/packages/utils/src/cache.bench.ts
+++ b/packages/utils/src/cache.bench.ts
@@ -1,0 +1,234 @@
+import { Cache, CacheOptions, LRUCache, LRUCacheNaive } from "./cache.ts";
+
+const CACHE_SIZE = 1000;
+const OPERATIONS = 10000;
+
+function createCache<K, V>(
+  Ctor: new (options: CacheOptions) => Cache<K, V>,
+): Cache<K, V> {
+  return new Ctor({ capacity: CACHE_SIZE });
+}
+
+function fillCache(cache: Cache<number, number>, count: number): void {
+  for (let i = 0; i < count; i++) {
+    cache.put(i, i);
+  }
+}
+
+Deno.bench({
+  name: "LRUCache (linked list) - sequential put",
+  fn() {
+    const cache = createCache<number, number>(LRUCache);
+    for (let i = 0; i < OPERATIONS; i++) {
+      cache.put(i, i);
+    }
+  },
+});
+
+Deno.bench({
+  name: "LRUCacheNaive (map) - sequential put",
+  fn() {
+    const cache = createCache<number, number>(LRUCacheNaive);
+    for (let i = 0; i < OPERATIONS; i++) {
+      cache.put(i, i);
+    }
+  },
+});
+
+Deno.bench({
+  name: "LRUCache (linked list) - sequential get (hit)",
+  group: "get-hit",
+  baseline: true,
+  fn(b) {
+    const cache = createCache<number, number>(LRUCache);
+    fillCache(cache, CACHE_SIZE);
+    b.start();
+    for (let i = 0; i < OPERATIONS; i++) {
+      cache.get(i % CACHE_SIZE);
+    }
+    b.end();
+  },
+});
+
+Deno.bench({
+  name: "LRUCacheNaive (map) - sequential get (hit)",
+  group: "get-hit",
+  fn(b) {
+    const cache = createCache<number, number>(LRUCacheNaive);
+    fillCache(cache, CACHE_SIZE);
+    b.start();
+    for (let i = 0; i < OPERATIONS; i++) {
+      cache.get(i % CACHE_SIZE);
+    }
+    b.end();
+  },
+});
+
+Deno.bench({
+  name: "LRUCache (linked list) - sequential get (miss)",
+  group: "get-miss",
+  baseline: true,
+  fn(b) {
+    const cache = createCache<number, number>(LRUCache);
+    fillCache(cache, CACHE_SIZE);
+    b.start();
+    for (let i = 0; i < OPERATIONS; i++) {
+      cache.get(i + CACHE_SIZE);
+    }
+    b.end();
+  },
+});
+
+Deno.bench({
+  name: "LRUCacheNaive (map) - sequential get (miss)",
+  group: "get-miss",
+  fn(b) {
+    const cache = createCache<number, number>(LRUCacheNaive);
+    fillCache(cache, CACHE_SIZE);
+    b.start();
+    for (let i = 0; i < OPERATIONS; i++) {
+      cache.get(i + CACHE_SIZE);
+    }
+    b.end();
+  },
+});
+
+Deno.bench({
+  name: "LRUCache (linked list) - mixed put/get with eviction",
+  group: "mixed-eviction",
+  baseline: true,
+  fn(b) {
+    const cache = createCache<number, number>(LRUCache);
+    fillCache(cache, CACHE_SIZE);
+    b.start();
+    for (let i = 0; i < OPERATIONS; i++) {
+      if (i % 2 === 0) {
+        cache.put(i + CACHE_SIZE, i);
+      } else {
+        cache.get(i % CACHE_SIZE);
+      }
+    }
+    b.end();
+  },
+});
+
+Deno.bench({
+  name: "LRUCacheNaive (map) - mixed put/get with eviction",
+  group: "mixed-eviction",
+  fn(b) {
+    const cache = createCache<number, number>(LRUCacheNaive);
+    fillCache(cache, CACHE_SIZE);
+    b.start();
+    for (let i = 0; i < OPERATIONS; i++) {
+      if (i % 2 === 0) {
+        cache.put(i + CACHE_SIZE, i);
+      } else {
+        cache.get(i % CACHE_SIZE);
+      }
+    }
+    b.end();
+  },
+});
+
+Deno.bench({
+  name: "LRUCache (linked list) - update existing keys",
+  group: "update",
+  baseline: true,
+  fn(b) {
+    const cache = createCache<number, number>(LRUCache);
+    fillCache(cache, CACHE_SIZE);
+    b.start();
+    for (let i = 0; i < OPERATIONS; i++) {
+      cache.put(i % CACHE_SIZE, i);
+    }
+    b.end();
+  },
+});
+
+Deno.bench({
+  name: "LRUCacheNaive (map) - update existing keys",
+  group: "update",
+  fn(b) {
+    const cache = createCache<number, number>(LRUCacheNaive);
+    fillCache(cache, CACHE_SIZE);
+    b.start();
+    for (let i = 0; i < OPERATIONS; i++) {
+      cache.put(i % CACHE_SIZE, i);
+    }
+    b.end();
+  },
+});
+
+Deno.bench({
+  name: "LRUCache (linked list) - delete",
+  group: "delete",
+  baseline: true,
+  fn(b) {
+    const cache = createCache<number, number>(LRUCache);
+    fillCache(cache, CACHE_SIZE);
+    b.start();
+    for (let i = 0; i < CACHE_SIZE; i++) {
+      cache.delete(i);
+    }
+    b.end();
+  },
+});
+
+Deno.bench({
+  name: "LRUCacheNaive (map) - delete",
+  group: "delete",
+  fn(b) {
+    const cache = createCache<number, number>(LRUCacheNaive);
+    fillCache(cache, CACHE_SIZE);
+    b.start();
+    for (let i = 0; i < CACHE_SIZE; i++) {
+      cache.delete(i);
+    }
+    b.end();
+  },
+});
+
+Deno.bench({
+  name: "LRUCache (linked list) - random access pattern",
+  group: "random",
+  baseline: true,
+  fn(b) {
+    const cache = createCache<number, number>(LRUCache);
+    fillCache(cache, CACHE_SIZE);
+    const keys = Array.from(
+      { length: OPERATIONS },
+      () => Math.floor(Math.random() * CACHE_SIZE * 2),
+    );
+    b.start();
+    for (const key of keys) {
+      if (cache.has(key)) {
+        cache.get(key);
+      } else {
+        cache.put(key, key);
+      }
+    }
+    b.end();
+  },
+});
+
+Deno.bench({
+  name: "LRUCacheNaive (map) - random access pattern",
+  group: "random",
+  fn(b) {
+    const cache = createCache<number, number>(LRUCacheNaive);
+    fillCache(cache, CACHE_SIZE);
+    const keys = Array.from(
+      { length: OPERATIONS },
+      () => Math.floor(Math.random() * CACHE_SIZE * 2),
+    );
+    b.start();
+    for (const key of keys) {
+      if (cache.has(key)) {
+        cache.get(key);
+      } else {
+        cache.put(key, key);
+      }
+    }
+    b.end();
+  },
+});

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -1,0 +1,172 @@
+export interface CacheOptions {
+  capacity?: number;
+}
+
+export interface Cache<K, V> {
+  readonly size: number;
+  has(key: K): boolean;
+  get(key: K): V | undefined;
+  put(key: K, value: V): void;
+  delete(key: K): boolean;
+  clear(): void;
+}
+
+export class LRUCacheNaive<K, V> implements Cache<K, V> {
+  #map = new Map<K, V>();
+  #capacity: number;
+
+  constructor(options: CacheOptions = {}) {
+    this.#capacity = Math.max(options.capacity ?? 1000, 1);
+  }
+
+  get size(): number {
+    return this.#map.size;
+  }
+
+  has(key: K): boolean {
+    return this.#map.has(key);
+  }
+
+  get(key: K): V | undefined {
+    const value = this.#map.get(key);
+    if (value !== undefined) {
+      this.#map.delete(key);
+      this.#map.set(key, value);
+    }
+    return value;
+  }
+
+  put(key: K, value: V): void {
+    if (this.#map.has(key)) {
+      this.#map.delete(key);
+      this.#map.set(key, value);
+      return;
+    }
+    if (this.#map.size >= this.#capacity) {
+      const oldestKey = this.#map.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.#map.delete(oldestKey);
+      }
+    }
+    this.#map.set(key, value);
+  }
+
+  delete(key: K): boolean {
+    return this.#map.delete(key);
+  }
+
+  clear(): void {
+    this.#map.clear();
+  }
+}
+
+interface LRUNode<K, V> {
+  key: K;
+  value: V;
+  prev: LRUNode<K, V> | null;
+  next: LRUNode<K, V> | null;
+}
+
+export class LRUCache<K, V> implements Cache<K, V> {
+  #map = new Map<K, LRUNode<K, V>>();
+  #head: LRUNode<K, V> | null = null;
+  #tail: LRUNode<K, V> | null = null;
+  #capacity: number;
+
+  constructor(options: CacheOptions = {}) {
+    this.#capacity = Math.max(options.capacity ?? 1000, 1);
+  }
+
+  get size(): number {
+    return this.#map.size;
+  }
+
+  has(key: K): boolean {
+    return this.#map.has(key);
+  }
+
+  get(key: K): V | undefined {
+    const node = this.#map.get(key);
+    if (node === undefined) {
+      return undefined;
+    }
+    this.#moveToTail(node);
+    return node.value;
+  }
+
+  put(key: K, value: V): void {
+    const existingNode = this.#map.get(key);
+    if (existingNode !== undefined) {
+      existingNode.value = value;
+      this.#moveToTail(existingNode);
+      return;
+    }
+
+    if (this.#map.size >= this.#capacity) {
+      this.#evictHead();
+    }
+
+    const node: LRUNode<K, V> = { key, value, prev: null, next: null };
+    this.#map.set(key, node);
+    this.#addToTail(node);
+  }
+
+  delete(key: K): boolean {
+    const node = this.#map.get(key);
+    if (node === undefined) {
+      return false;
+    }
+    this.#map.delete(key);
+    this.#removeNode(node);
+    return true;
+  }
+
+  clear(): void {
+    this.#map.clear();
+    this.#head = null;
+    this.#tail = null;
+  }
+
+  #removeNode(node: LRUNode<K, V>): void {
+    if (node.prev !== null) {
+      node.prev.next = node.next;
+    } else {
+      this.#head = node.next;
+    }
+    if (node.next !== null) {
+      node.next.prev = node.prev;
+    } else {
+      this.#tail = node.prev;
+    }
+    node.prev = null;
+    node.next = null;
+  }
+
+  #addToTail(node: LRUNode<K, V>): void {
+    if (this.#tail === null) {
+      this.#head = node;
+      this.#tail = node;
+    } else {
+      node.prev = this.#tail;
+      this.#tail.next = node;
+      this.#tail = node;
+    }
+  }
+
+  #moveToTail(node: LRUNode<K, V>): void {
+    if (node === this.#tail) {
+      return;
+    }
+    this.#removeNode(node);
+    this.#addToTail(node);
+  }
+
+  #evictHead(): void {
+    if (this.#head === null) {
+      return;
+    }
+    const node = this.#head;
+    this.#map.delete(node.key);
+    this.#removeNode(node);
+  }
+}

--- a/packages/utils/test/cache.test.ts
+++ b/packages/utils/test/cache.test.ts
@@ -1,0 +1,174 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { LRUCache } from "@commontools/utils/cache";
+
+describe("LRUCache", () => {
+  describe("basic operations", () => {
+    it("stores and retrieves values", () => {
+      const cache = new LRUCache<string, number>();
+      cache.put("a", 1);
+      cache.put("b", 2);
+      expect(cache.get("a")).toBe(1);
+      expect(cache.get("b")).toBe(2);
+    });
+
+    it("returns undefined for missing keys", () => {
+      const cache = new LRUCache<string, number>();
+      expect(cache.get("missing")).toBe(undefined);
+    });
+
+    it("tracks size correctly", () => {
+      const cache = new LRUCache<string, number>();
+      expect(cache.size).toBe(0);
+      cache.put("a", 1);
+      expect(cache.size).toBe(1);
+      cache.put("b", 2);
+      expect(cache.size).toBe(2);
+    });
+
+    it("has() returns correct membership", () => {
+      const cache = new LRUCache<string, number>();
+      cache.put("a", 1);
+      expect(cache.has("a")).toBe(true);
+      expect(cache.has("b")).toBe(false);
+    });
+
+    it("updates existing keys", () => {
+      const cache = new LRUCache<string, number>();
+      cache.put("a", 1);
+      cache.put("a", 2);
+      expect(cache.get("a")).toBe(2);
+      expect(cache.size).toBe(1);
+    });
+
+    it("deletes keys", () => {
+      const cache = new LRUCache<string, number>();
+      cache.put("a", 1);
+      expect(cache.delete("a")).toBe(true);
+      expect(cache.has("a")).toBe(false);
+      expect(cache.size).toBe(0);
+    });
+
+    it("delete returns false for missing keys", () => {
+      const cache = new LRUCache<string, number>();
+      expect(cache.delete("missing")).toBe(false);
+    });
+
+    it("clears all entries", () => {
+      const cache = new LRUCache<string, number>();
+      cache.put("a", 1);
+      cache.put("b", 2);
+      cache.clear();
+      expect(cache.size).toBe(0);
+      expect(cache.has("a")).toBe(false);
+      expect(cache.has("b")).toBe(false);
+    });
+  });
+
+  describe("eviction", () => {
+    it("evicts least recently used on capacity overflow", () => {
+      const cache = new LRUCache<string, number>({ capacity: 3 });
+      cache.put("a", 1);
+      cache.put("b", 2);
+      cache.put("c", 3);
+      cache.put("d", 4);
+      expect(cache.has("a")).toBe(false);
+      expect(cache.has("b")).toBe(true);
+      expect(cache.has("c")).toBe(true);
+      expect(cache.has("d")).toBe(true);
+      expect(cache.size).toBe(3);
+    });
+
+    it("get() promotes item to most recently used", () => {
+      const cache = new LRUCache<string, number>({ capacity: 3 });
+      cache.put("a", 1);
+      cache.put("b", 2);
+      cache.put("c", 3);
+      cache.get("a");
+      cache.put("d", 4);
+      expect(cache.has("a")).toBe(true);
+      expect(cache.has("b")).toBe(false);
+      expect(cache.has("c")).toBe(true);
+      expect(cache.has("d")).toBe(true);
+    });
+
+    it("put() on existing key promotes to most recently used", () => {
+      const cache = new LRUCache<string, number>({ capacity: 3 });
+      cache.put("a", 1);
+      cache.put("b", 2);
+      cache.put("c", 3);
+      cache.put("a", 10);
+      cache.put("d", 4);
+      expect(cache.has("a")).toBe(true);
+      expect(cache.get("a")).toBe(10);
+      expect(cache.has("b")).toBe(false);
+    });
+
+    it("handles capacity of 1", () => {
+      const cache = new LRUCache<string, number>({ capacity: 1 });
+      cache.put("a", 1);
+      cache.put("b", 2);
+      expect(cache.size).toBe(1);
+      expect(cache.has("a")).toBe(false);
+      expect(cache.get("b")).toBe(2);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("works with various key types", () => {
+      const cache = new LRUCache<number, string>();
+      cache.put(1, "one");
+      cache.put(2, "two");
+      expect(cache.get(1)).toBe("one");
+      expect(cache.get(2)).toBe("two");
+    });
+
+    it("handles delete of head node", () => {
+      const cache = new LRUCache<string, number>({ capacity: 3 });
+      cache.put("a", 1);
+      cache.put("b", 2);
+      cache.put("c", 3);
+      cache.delete("a");
+      cache.put("d", 4);
+      cache.put("e", 5);
+      expect(cache.size).toBe(3);
+      expect(cache.has("b")).toBe(false);
+    });
+
+    it("handles delete of tail node", () => {
+      const cache = new LRUCache<string, number>({ capacity: 3 });
+      cache.put("a", 1);
+      cache.put("b", 2);
+      cache.put("c", 3);
+      cache.delete("c");
+      expect(cache.size).toBe(2);
+      cache.put("d", 4);
+      cache.put("e", 5);
+      expect(cache.has("a")).toBe(false);
+    });
+
+    it("handles delete of middle node", () => {
+      const cache = new LRUCache<string, number>({ capacity: 3 });
+      cache.put("a", 1);
+      cache.put("b", 2);
+      cache.put("c", 3);
+      cache.delete("b");
+      expect(cache.size).toBe(2);
+      expect(cache.get("a")).toBe(1);
+      expect(cache.get("c")).toBe(3);
+    });
+
+    it("get on tail node does not break list", () => {
+      const cache = new LRUCache<string, number>({ capacity: 3 });
+      cache.put("a", 1);
+      cache.put("b", 2);
+      cache.put("c", 3);
+      cache.get("c");
+      cache.put("d", 4);
+      expect(cache.has("a")).toBe(false);
+      expect(cache.has("b")).toBe(true);
+      expect(cache.has("c")).toBe(true);
+      expect(cache.has("d")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a shared LRUCache in utils with O(1) get/put and predictable eviction, then replace ad-hoc Map-based caches across the codebase to improve performance and memory behavior.

- **New Features**
  - Added utils/cache with LRUCache (linked-list), Cache interface, and a naive Map-based LRU for comparison. Exported as @commontools/utils/cache.
  - Added Deno benchmarks to compare linked-list LRU vs naive Map LRU under common access patterns.

- **Refactors**
  - js-compiler/source-map: Replaced Map caches with LRUCache; switched consumers to a WeakMap keyed by SourceMap to avoid leaks; removed custom LRU logic.
  - memory/reference: Replaced unclaimed pattern cache with LRUCache (capacity 50,000) and simplified put/get handling.
  - runner/attestation: Replaced data URI cache with LRUCache (capacity 1,000) and simplified eviction.

<sup>Written for commit 1eb5f8fe67ad14de4b9f177f210dc21ac5d5854f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->




| benchmark                                              | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
| ------------------------------------------------------ | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
| LRUCache (linked list) - sequential put                |        429.6 µs |         2,328 | (381.9 µs …   2.0 ms) | 429.1 µs | 872.7 µs | 905.3 µs |
| LRUCacheNaive (map) - sequential put                   |          2.8 ms |         363.5 | (  2.6 ms …   4.5 ms) |   2.7 ms |   3.8 ms |   4.5 ms |

| benchmark                                              | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
| ------------------------------------------------------ | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
| LRUCache (linked list) - sequential get (hit)          |         77.3 µs |        12,940 | ( 72.8 µs … 675.7 µs) |  76.4 µs |  97.1 µs | 127.6 µs |
| LRUCacheNaive (map) - sequential get (hit)             |        253.7 µs |         3,942 | (235.1 µs …   2.1 ms) | 253.1 µs | 326.4 µs | 337.3 µs |

summary
  LRUCache (linked list) - sequential get (hit)
     3.28x faster than LRUCacheNaive (map) - sequential get (hit)

| benchmark                                              | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
| ------------------------------------------------------ | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
| LRUCache (linked list) - sequential get (miss)         |         35.4 µs |        28,290 | ( 34.3 µs … 358.1 µs) |  35.1 µs |  43.0 µs |  46.9 µs |
| LRUCacheNaive (map) - sequential get (miss)            |         35.9 µs |        27,890 | ( 35.3 µs … 114.8 µs) |  35.9 µs |  41.6 µs |  43.9 µs |

summary
  LRUCache (linked list) - sequential get (miss)
     1.01x faster than LRUCacheNaive (map) - sequential get (miss)

| benchmark                                              | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
| ------------------------------------------------------ | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
| LRUCache (linked list) - mixed put/get with eviction   |        244.8 µs |         4,085 | (178.4 µs … 637.6 µs) | 252.1 µs | 523.4 µs | 545.9 µs |
| LRUCacheNaive (map) - mixed put/get with eviction      |          1.7 ms |         590.7 | (  1.6 ms …   2.5 ms) |   1.7 ms |   1.9 ms |   2.5 ms |

summary
  LRUCache (linked list) - mixed put/get with eviction
     6.92x faster than LRUCacheNaive (map) - mixed put/get with eviction

| benchmark                                              | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
| ------------------------------------------------------ | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
| LRUCache (linked list) - update existing keys          |         77.6 µs |        12,890 | ( 73.3 µs … 685.9 µs) |  77.6 µs |  87.0 µs |  92.6 µs |
| LRUCacheNaive (map) - update existing keys             |        252.5 µs |         3,960 | (232.2 µs …   1.7 ms) | 251.8 µs | 324.3 µs | 333.4 µs |

summary
  LRUCache (linked list) - update existing keys
     3.25x faster than LRUCacheNaive (map) - update existing keys

| benchmark                                              | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
| ------------------------------------------------------ | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
| LRUCache (linked list) - delete                        |         14.8 µs |        67,470 | ( 13.6 µs … 156.1 µs) |  14.8 µs |  20.2 µs |  21.1 µs |
| LRUCacheNaive (map) - delete                           |          9.8 µs |       101,600 | (  9.0 µs …  83.8 µs) |   9.9 µs |  14.3 µs |  15.6 µs |

summary
  LRUCache (linked list) - delete
     1.51x slower than LRUCacheNaive (map) - delete

| benchmark                                              | time/iter (avg) |        iter/s |      (min … max)      |      p75 |      p99 |     p995 |
| ------------------------------------------------------ | --------------- | ------------- | --------------------- | -------- | -------- | -------- |
| LRUCache (linked list) - random access pattern         |        448.0 µs |         2,232 | (415.9 µs … 704.8 µs) | 470.2 µs | 578.0 µs | 588.4 µs |
| LRUCacheNaive (map) - random access pattern            |          1.4 ms |         718.1 | (  1.3 ms …   1.6 ms) |   1.4 ms |   1.5 ms |   1.6 ms |

summary
  LRUCache (linked list) - random access pattern
     3.11x faster than LRUCacheNaive (map) - random access pattern



