### PR TITLE
fix(ui): add undefined guards to ct-progress component

### DIFF
--- a/packages/ui/src/v2/components/ct-progress/ct-progress.ts
+++ b/packages/ui/src/v2/components/ct-progress/ct-progress.ts
@@ -75,7 +75,10 @@ export class CTProgress extends BaseElement {
   override willUpdate(changedProperties: PropertyValues) {
     // Clamp value within bounds
     if (changedProperties.has("value") || changedProperties.has("max")) {
-      const clampedValue = Math.max(0, Math.min(this.value, this.max));
+      const clampedValue = Math.max(
+        0,
+        Math.min(this.value ?? 0, this.max ?? 100),
+      );
       if (this.value !== clampedValue) {
         this.value = clampedValue;
       }
@@ -124,10 +127,10 @@ export class CTProgress extends BaseElement {
   }
 
   private updateAriaAttributes(): void {
-    this.setAttribute("aria-valuemax", this.max.toString());
+    this.setAttribute("aria-valuemax", this.max?.toString() ?? "100");
 
     if (!this.indeterminate) {
-      this.setAttribute("aria-valuenow", this.value.toString());
+      this.setAttribute("aria-valuenow", this.value?.toString() ?? "0");
       const percentage = this.getPercentage();
       this.setAttribute("aria-valuetext", `${Math.round(percentage)}%`);
     } else {
@@ -137,8 +140,8 @@ export class CTProgress extends BaseElement {
   }
 
   private getPercentage(): number {
-    if (this.max === 0) return 0;
-    return (this.value / this.max) * 100;
+    if (this.max === 0 || !Number.isFinite(this.max)) return 0;
+    return ((this.value ?? 0) / this.max) * 100;
   }
 
   private updateProgress(): void {
@@ -171,7 +174,7 @@ export class CTProgress extends BaseElement {
    * Check if progress is complete
    */
   isComplete(): boolean {
-    return !this.indeterminate && this.value >= this.max;
+    return !this.indeterminate && (this.value ?? 0) >= (this.max ?? 100);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add nullish coalescing guards to `ct-progress` component to prevent NaN values when `value` or `max` properties are undefined
- Guards added in `willUpdate`, `getPercentage`, `updateAriaAttributes`, and `isComplete` methods
- Also adds `Number.isFinite` check for `max` in `getPercentage`

## Test plan
- [ ] Verify ct-progress renders correctly with normal values
- [ ] Verify ct-progress handles undefined value/max gracefully
- [ ] Verify indeterminate state still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ct-progress to handle undefined value and max without producing NaN or invalid ARIA. Adds safe defaults and guards so the component renders and announces correctly, including in indeterminate mode.

- **Bug Fixes**
  - Clamp value with defaults (value: 0, max: 100) in willUpdate.
  - Safe ARIA: aria-valuemax defaults to 100, aria-valuenow to 0; percentage returns 0 if max is 0 or not finite.
  - isComplete compares using the same defaults to avoid undefined cases.

<sup>Written for commit 62c2742f1adb3d0a0a1135351245afbf34c9cfda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

