### PR TITLE
feat(patterns): add sort toggle to email-notes pattern

### DIFF
--- a/packages/patterns/google/email-notes.tsx
+++ b/packages/patterns/google/email-notes.tsx
@@ -220,6 +220,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
   const loadingLabels = Writable.of(false).for("loadingLabels");
   const hiddenNotes = Writable.of<string[]>([]).for("hiddenNotes");
   const processingNotes = Writable.of<string[]>([]).for("processingNotes");
+  const sortNewestFirst = Writable.of(true).for("sortNewestFirst");
 
   // Use createGoogleAuth for scopes that include gmailModify
   // Note: We use auth directly (not wrapped in ifElse) because GmailSendClient
@@ -305,7 +306,12 @@ export default pattern<PatternInput, PatternOutput>(() => {
         ),
         date: email.date,
         snippet: email.snippet,
-      }));
+      }))
+      .sort((a, b) => {
+        const dateA = new Date(a.date).getTime();
+        const dateB = new Date(b.date).getTime();
+        return sortNewestFirst.get() ? dateB - dateA : dateA - dateB;
+      });
   });
 
   const noteCount = computed(() => notes?.length || 0);
@@ -373,6 +379,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
             <span style={{ color: "#6b7280", fontSize: "14px" }}>
               ({noteCount} notes)
             </span>
+            <ct-checkbox $checked={sortNewestFirst}>Newest first</ct-checkbox>
           </ct-hstack>
         </div>
 


### PR DESCRIPTION
## Summary

Adds a toggle to the email-notes pattern that allows switching between newest-first (default) and oldest-first ordering of notes.

- Adds `sortNewestFirst` writable state (defaults to `true` for newest-first)
- Sorts notes by date based on the toggle preference  
- Adds a checkbox toggle in the header next to the note count

## Changes

**packages/patterns/google/email-notes.tsx**
- Line 223: Add `sortNewestFirst` Writable state
- Lines 310-314: Add `.sort()` after `.map()` to order notes by date
- Line 382: Add `<ct-checkbox>` toggle in header

## Test plan

- [x] Type check passes (`deno check`)
- [x] Linting passes (`deno lint`)
- [x] Formatting passes (`deno fmt`)
- [x] Deployed and tested in Playwright:
  - Toggle appears in header next to "(N notes)"
  - Default is newest-first (checkbox checked)
  - Unchecking shows oldest emails first
  - Notes re-sort reactively when toggling

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Newest first” toggle to email-notes so users can switch between newest-first (default) and oldest-first ordering. Notes re-sort instantly without reload.

- New Features
  - Added sortNewestFirst state (default true).
  - Sort notes by date based on the toggle.
  - Checkbox in header next to the note count.

<sup>Written for commit d0bf5e6bf8871fe01a20fc5725bdcfa6c14a9078. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

