### PR TITLE
fix(gmail): proper UTF-8 decoding and email-notes result count

### DIFF
--- a/packages/patterns/google/gmail-importer.tsx
+++ b/packages/patterns/google/gmail-importer.tsx
@@ -254,12 +254,19 @@ const googleUpdater = handler<unknown, {
   },
 );
 
-// Helper function to decode base64 encoded email parts
-function decodeBase64(data: string) {
+// Helper function to decode base64 encoded email parts with proper UTF-8 handling
+function decodeBase64(data: string): string {
   // Replace URL-safe characters back to their original form
   const sanitized = data.replace(/-/g, "+").replace(/_/g, "/");
-  // Decode the base64 string
-  return atob(sanitized);
+  // Decode the base64 string to binary
+  const binaryString = atob(sanitized);
+  // Convert binary string to Uint8Array for proper UTF-8 decoding
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  // Use TextDecoder to properly decode UTF-8
+  return new TextDecoder("utf-8").decode(bytes);
 }
 
 // Helper function to extract email address from a header value


### PR DESCRIPTION
## Summary

Fixes two issues in the email-notes pattern:

### 1. Encoding Issue (mojibake)
- **Problem**: Smart quotes and other UTF-8 characters displayed as garbage (e.g., `'` instead of `'`)
- **Root cause**: `atob()` decodes Base64 to Latin-1, but email content is UTF-8 encoded. Multi-byte UTF-8 sequences get misinterpreted as multiple Latin-1 characters.
- **Fix**: Convert the binary string to `Uint8Array` and use `TextDecoder("utf-8")` for proper decoding

### 2. Result Count Issue
- **Problem**: Pattern showed 0 notes even when emails existed
- **Root cause**: Gmail API doesn't support `subject:""` as a search filter for empty subjects. The query `'label:task-current subject:""'` returned no results.
- **Fix**: Removed `subject:""` from the Gmail query, relying on the existing client-side filtering which already checks for empty subjects

## Changes

| File | Change |
|------|--------|
| `gmail-importer.tsx` | Fixed `decodeBase64()` to properly decode UTF-8 |
| `gmail-client.ts` | Added `decodeBase64Utf8()` method with proper UTF-8 handling |
| `email-notes.tsx` | Removed invalid `subject:""` filter, increased limit to 100, simplified `cleanContent()` |

## Test plan

- [x] Deployed pattern to test space via `ct charm new`
- [x] Verified 41 notes display (vs 0 before)
- [x] Verified proper character encoding (apostrophes, quotes display correctly)
- [x] Ran `deno fmt` and `deno lint` on changed files

## Notes

The pre-commit type check fails due to a pre-existing error on main (`TS2589: Type instantiation is excessively deep` in `gmail-agentic-search.tsx`), unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UTF-8 decoding for Gmail content and updates the email-notes query so notes appear correctly. Smart quotes and other characters now render properly, and the result count is accurate again.

- **Bug Fixes**
  - Decode Base64/Base64URL email parts as UTF-8 using TextDecoder and Uint8Array in gmail-importer and gmail-client.
  - Remove unsupported subject:"" from the Gmail query; rely on existing client-side empty-subject filter; raise fetch limit to 100 and disable debug.
  - Simplify cleanContent now that decoding is correct.

<sup>Written for commit 4c99a7fb4103f8a6f36793283177b46a5438928d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

