### PR TITLE
feat(runtime-client): add resolveAsCell IPC for cell link resolution

### DIFF
--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -19,6 +19,7 @@ import {
 import {
   BooleanResponse,
   type CellGetRequest,
+  type CellResolveAsCellRequest,
   CellResponse,
   type CellSendRequest,
   type CellSetRequest,
@@ -285,6 +286,14 @@ export class RuntimeProcessor {
     return { value: false };
   }
 
+  handleCellResolveAsCell(request: CellResolveAsCellRequest): CellResponse {
+    const cell = getCell(this.runtime, request.cell);
+    const resolved = cell.resolveAsCell();
+    return {
+      cell: createCellRef(resolved),
+    };
+  }
+
   handleGetCell(request: GetCellRequest): CellResponse {
     const cell = this.runtime.getCell(
       request.space,
@@ -548,6 +557,8 @@ export class RuntimeProcessor {
         return this.handleCellSubscribe(request);
       case RequestType.CellUnsubscribe:
         return this.handleCellUnsubscribe(request);
+      case RequestType.CellResolveAsCell:
+        return this.handleCellResolveAsCell(request);
       case RequestType.GetCell:
         return this.handleGetCell(request);
       case RequestType.GetHomeSpaceCell:

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -222,6 +222,21 @@ export class CellHandle<T = unknown> {
     return this.#value;
   }
 
+  /**
+   * Resolve links in this cell to get the actual cell it points to.
+   * Returns a new CellHandle pointing to the resolved cell.
+   */
+  async resolveAsCell(): Promise<CellHandle<T>> {
+    const response = await this.#conn.request<
+      RequestType.CellResolveAsCell
+    >({
+      type: RequestType.CellResolveAsCell,
+      cell: this.ref(),
+    });
+
+    return new CellHandle<T>(this.#rt, response.cell);
+  }
+
   equals(other: unknown): boolean {
     if (this === other) return true;
     if (!isCellHandle(other)) return false;

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -28,6 +28,7 @@ export enum RequestType {
   CellSend = "cell:send",
   CellSubscribe = "cell:subscribe",
   CellUnsubscribe = "cell:unsubscribe",
+  CellResolveAsCell = "cell:resolveAsCell",
 
   // Runtime operations
   GetCell = "runtime:getCell",
@@ -127,6 +128,11 @@ export interface CellSubscribeRequest extends BaseRequest {
 
 export interface CellUnsubscribeRequest extends BaseRequest {
   type: RequestType.CellUnsubscribe;
+  cell: CellRef;
+}
+
+export interface CellResolveAsCellRequest extends BaseRequest {
+  type: RequestType.CellResolveAsCell;
   cell: CellRef;
 }
 
@@ -262,6 +268,7 @@ export type IPCClientRequest =
   | CellSendRequest
   | CellSubscribeRequest
   | CellUnsubscribeRequest
+  | CellResolveAsCellRequest
   | GetCellRequest
   | GetHomeSpaceCellRequest
   | EnsureHomePatternRunningRequest
@@ -425,6 +432,10 @@ export type Commands = {
   [RequestType.CellUnsubscribe]: {
     request: CellUnsubscribeRequest;
     response: BooleanResponse;
+  };
+  [RequestType.CellResolveAsCell]: {
+    request: CellResolveAsCellRequest;
+    response: CellResponse;
   };
   // Page requests
   [RequestType.PageCreate]: {

--- a/packages/ui/src/v2/components/ct-cell-link/ct-cell-link.ts
+++ b/packages/ui/src/v2/components/ct-cell-link/ct-cell-link.ts
@@ -109,9 +109,9 @@ export class CTCellLink extends BaseElement {
     }
   }
 
-  private _resolveCell() {
+  private async _resolveCell() {
     if (this.cell) {
-      this._resolvedCell = this.cell;
+      this._resolvedCell = await this.cell.resolveAsCell();
       return;
     }
 
@@ -124,9 +124,8 @@ export class CTCellLink extends BaseElement {
         if (!parsedLink.space) {
           throw new Error("Link missing space.");
         }
-        this._resolvedCell = this.runtime.getCellFromRef(
-          parsedLink as CellRef,
-        );
+        const cell = this.runtime.getCellFromRef(parsedLink as CellRef);
+        this._resolvedCell = await cell.resolveAsCell();
       } catch (e) {
         console.error("Failed to resolve link:", e);
         this._resolvedCell = undefined;


### PR DESCRIPTION
## Summary
- Adds `CellResolveAsCell` IPC request type that calls `cell.resolveAsCell()` in the worker
- Adds `resolveAsCell()` async method to `CellHandle` for resolving links from the main thread
- Updates `ct-cell-link` component to use `resolveAsCell()` for proper link resolution before navigation
- Adds integration test verifying the full IPC path

## Changes
- **protocol/types.ts**: Add `CellResolveAsCell` request type, interface, and command mapping
- **runtime-processor.ts**: Add `handleCellResolveAsCell()` handler
- **cell-handle.ts**: Add `resolveAsCell()` method
- **ct-cell-link.ts**: Make `_resolveCell()` async and use `resolveAsCell()`
- **client.test.ts**: Add integration test for `resolveAsCell()`

## Test plan
- [x] Integration test passes: `resolves cell links with resolveAsCell()`
- [x] All existing runtime-client integration tests pass (22 steps)
- [ ] Manual testing of ct-cell-link navigation in shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds resolveAsCell IPC and a CellHandle API to resolve cell links in the worker, and updates link navigation to use resolved, schema-aware cells for correct behavior.

- **New Features**
  - Added RequestType.CellResolveAsCell and handler to resolve links in the runtime worker.
  - Added CellHandle.resolveAsCell() to resolve links from the main thread.
  - Updated ct-cell-link to resolve links asynchronously before navigation.
  - Added integration test covering the full resolveAsCell IPC path.

- **Refactors**
  - CharmManager returns the result cell with schema and builds schema-preserving links without rewriting to resultRef.
  - Removed getCellForLinking and its test.
  - ct-cell-link now throws when attempting to navigate to a non-root cell.

<sup>Written for commit 4eaec525943fb1a95ea1adacc1823f7584a151e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

