### PR TITLE
chore(gmail-extractor): remove transformer workarounds after PR #2654

### DIFF
--- a/packages/patterns/google/building-blocks/gmail-extractor.tsx
+++ b/packages/patterns/google/building-blocks/gmail-extractor.tsx
@@ -140,6 +140,7 @@ export interface GmailExtractorOutput<T = unknown> {
     emailId: string;
     emailDate: string;
     analysis: { pending?: boolean; result?: T; error?: unknown };
+    result?: T;
     pending: boolean;
     error: unknown;
   }>;
@@ -333,11 +334,11 @@ function GmailExtractor<T = unknown>(input: GmailExtractorInput) {
   });
 
   // Reactive LLM analysis - analyze each email (only if extraction is provided)
-  // Note: consumers access result via item.analysis.result (not item.result)
+  // Note: consumers can access result via item.analysis.result or item.result
   // Result type is inferred from extraction.schema by the runtime
   const rawAnalyses = shouldRunAnalysis
     ? emails.map((email: Email) => {
-      const analysis = generateObject({
+      const analysis = generateObject<T>({
         prompt: computed(() => {
           if (!email?.markdownContent) {
             return undefined;
@@ -359,6 +360,7 @@ function GmailExtractor<T = unknown>(input: GmailExtractorInput) {
         emailId: email.id,
         emailDate: email.date,
         analysis,
+        result: analysis.result,
         pending: analysis.pending,
         error: analysis.error,
       };
@@ -368,6 +370,7 @@ function GmailExtractor<T = unknown>(input: GmailExtractorInput) {
       emailId: string;
       emailDate: string;
       analysis: { pending?: boolean; result?: T; error?: unknown };
+      result?: T;
       pending: boolean;
       error: unknown;
     }>);


### PR DESCRIPTION
## Summary

Removes workarounds in GmailExtractor that were added to work around transformer bugs. These bugs were fixed in PR #2654 (`Fix/transformer bugs`):

- **Re-adds `<T>` type parameter** to `generateObject<T>()` - The capture-collector now correctly handles generic type parameters
- **Adds `result` property** to rawAnalyses return object - The schema-generator now handles `OpaqueRef<T | undefined>` correctly
- **Updates type definitions** in `GmailExtractorOutput` interface to include `result?: T`

### What stays

The hardcoded model string (`"anthropic:claude-sonnet-4-5"`) remains in place as CT-1182 (variables with fallbacks causing HTTP 400) is still unresolved.

## Test plan

- [x] `deno task check` passes
- [x] `deno fmt` - no changes needed
- [x] `deno lint` - passes
- [x] Deployed `pge-bill-tracker` pattern using GmailExtractor
- [x] Verified 35 emails fetched and all 35 LLM analyses completed successfully
- [x] Verified extracted data displays correctly (amounts, dates, account numbers)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes transformer workarounds in GmailExtractor after PR #2654 fixed the bugs. Restores proper generics and exposes analysis results directly for easier use.

- **Refactors**
  - Re-add <T> to generateObject<T>() for correct type inference.
  - Add result on each item (item.result mirrors item.analysis.result).
  - Update GmailExtractorOutput to include result?: T.
  - Keep hardcoded model string due to CT-1182 still open.

<sup>Written for commit 15927baaac255daceb2e719eaaf3439d38bbc9e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

