### PR TITLE
feat(hooks): add confirmation prompt before deleting spaces

### DIFF
--- a/.claude/scripts/ask-before-delete-spaces.ts
+++ b/.claude/scripts/ask-before-delete-spaces.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env -S deno run --allow-read
+/**
+ * .claude/scripts/ask-before-delete-spaces.ts
+ *
+ * Claude Code Pre-Tool hook.
+ * - Forces user confirmation when `--dangerously-clear-all-spaces` is detected
+ * - Allows all other commands through
+ */
+
+const rawInput = await new Response(Deno.stdin.readable).text();
+
+let cmd = "";
+try {
+  const payload = JSON.parse(rawInput);
+  cmd = payload?.tool_input?.command ?? "";
+} catch {
+  Deno.exit(0);
+}
+
+if (/--dangerously-clear-all-spaces/.test(cmd)) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason:
+        "WARNING: This will permanently delete all spaces/databases in packages/toolshed/cache/memory. Are you sure?",
+    },
+  };
+  console.log(JSON.stringify(output));
+}
+
+Deno.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,10 @@
           {
             "type": "command",
             "command": "deno run --allow-read \"$CLAUDE_PROJECT_DIR/.claude/scripts/deno-test-filter.ts\""
+          },
+          {
+            "type": "command",
+            "command": "deno run --allow-read \"$CLAUDE_PROJECT_DIR/.claude/scripts/ask-before-delete-spaces.ts\""
           }
         ]
       },


### PR DESCRIPTION
Adds a PreToolUse hook that detects `--dangerously-clear-all-spaces` in
bash commands and forces user confirmation with a warning before
execution, preventing accidental deletion of spaces/databases.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PreToolUse hook that prompts before running commands with --dangerously-clear-all-spaces. This prevents accidental deletion of spaces/databases.

- **New Features**
  - Detects the flag in tool_input.command and returns a permissionDecision of "ask" with a clear warning.
  - Hook added to .claude/settings.json; all other commands pass through unchanged.

<sup>Written for commit 8a9b8eb9de156b148bfa5903740a314724eb0b8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

