### PR TITLE
feat: Do not stream telemetry markers when debugger tools are not opened

### DIFF
--- a/packages/runtime-client/client/connection.ts
+++ b/packages/runtime-client/client/connection.ts
@@ -104,7 +104,10 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
 
     this.#pendingRequests.set(msgId, pending as PendingRequest);
     if (DEBUG_IPC) {
-      console.log("[RuntimeClient->]", message);
+      console.log(
+        `[IPC(\x1B[1m${message.msgId}\x1B[0m)\x1B[96m=>\x1B[0m]`,
+        message.data,
+      );
     }
     this.#transport.send(message);
 
@@ -175,15 +178,17 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
   }
 
   private _handleMessage = (message: IPCRemoteMessage): void => {
-    if (DEBUG_IPC) {
-      console.log("[RuntimeClient<-]", message);
-    }
-
     if (isIPCRemoteNotification(message)) {
+      if (isTelemetryNotification(message)) {
+        this.emit("telemetry", message);
+        // Do not log telemetry events when DEBUG_IPC is enabled
+        return;
+      }
+      if (DEBUG_IPC) {
+        console.log(`[IPC\x1B[92m<=\x1B[0m]`, message);
+      }
       if (isCellUpdateNotification(message)) {
         this._handleCellUpdate(message);
-      } else if (isTelemetryNotification(message)) {
-        this.emit("telemetry", message);
       } else if (isConsoleNotification(message)) {
         this.emit("console", message);
       } else if (isNavigateRequestNotification(message)) {
@@ -213,9 +218,22 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
     this.#pendingRequests.delete(msgId);
 
     if ("error" in message && message.error) {
+      if (DEBUG_IPC) {
+        console.log(
+          `[IPC(\x1B[1m${msgId}\x1B[0m)\x1B[91m<=\x1B[0m]`,
+          message.error,
+        );
+      }
       pending.deferred.reject(new Error(message.error));
     } else {
-      pending.deferred.resolve("data" in message ? message.data : undefined);
+      const data = "data" in message ? message.data : undefined;
+      if (DEBUG_IPC) {
+        console.log(
+          `[IPC(\x1B[1m${msgId}\x1B[0m)\x1B[92m<=\x1B[0m]`,
+          data,
+        );
+      }
+      pending.deferred.resolve(data);
     }
   };
 

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -40,6 +40,7 @@ export enum RequestType {
   GetLoggerCounts = "runtime:getLoggerCounts",
   SetLoggerLevel = "runtime:setLoggerLevel",
   SetLoggerEnabled = "runtime:setLoggerEnabled",
+  SetTelemetryEnabled = "runtime:setTelemetryEnabled",
 
   // Page operations (main -> worker)
   GetSpaceRootPattern = "pattern:getSpaceRoot",
@@ -185,6 +186,11 @@ export interface SetLoggerEnabledRequest extends BaseRequest {
   enabled: boolean;
 }
 
+export interface SetTelemetryEnabledRequest extends BaseRequest {
+  type: RequestType.SetTelemetryEnabled;
+  enabled: boolean;
+}
+
 // Logger count types for IPC (matches @commontools/utils/logger types)
 export interface LogCounts {
   debug: number;
@@ -277,6 +283,7 @@ export type IPCClientRequest =
   | GetLoggerCountsRequest
   | SetLoggerLevelRequest
   | SetLoggerEnabledRequest
+  | SetTelemetryEnabledRequest
   | IdleRequest
   | PageCreateRequest
   | PageGetSpaceDefault
@@ -410,6 +417,10 @@ export type Commands = {
   };
   [RequestType.SetLoggerEnabled]: {
     request: SetLoggerEnabledRequest;
+    response: EmptyResponse;
+  };
+  [RequestType.SetTelemetryEnabled]: {
+    request: SetTelemetryEnabledRequest;
     response: EmptyResponse;
   };
   // Cell requests

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -274,6 +274,18 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     });
   }
 
+  /**
+   * Enable or disable telemetry data emission from the worker.
+   * When disabled, telemetry events will not be sent over IPC.
+   * @param enabled - Whether to enable or disable telemetry
+   */
+  async setTelemetryEnabled(enabled: boolean): Promise<void> {
+    await this.#conn.request<RequestType.SetTelemetryEnabled>({
+      type: RequestType.SetTelemetryEnabled,
+      enabled,
+    });
+  }
+
   async dispose(): Promise<void> {
     await this.#conn.dispose();
   }

--- a/packages/shell/src/lib/debugger-controller.ts
+++ b/packages/shell/src/lib/debugger-controller.ts
@@ -121,6 +121,15 @@ export class DebuggerController implements ReactiveController {
         this.handleTelemetryUpdate,
       );
 
+      // Enable/disable telemetry based on current visibility
+      const rt = this.runtime.runtime();
+      rt.setTelemetryEnabled(this.visible).catch((e) => {
+        console.error(
+          "[DebuggerController] Failed to set telemetry enabled:",
+          e,
+        );
+      });
+
       // Load existing telemetry markers
       this.telemetryMarkers = this.runtime.telemetry().slice(
         -MAX_TELEMETRY_EVENTS,
@@ -166,6 +175,18 @@ export class DebuggerController implements ReactiveController {
 
     this.visible = visible;
     localStorage.setItem(STORAGE_KEY, String(visible));
+
+    // Toggle telemetry in the worker based on visibility
+    const rt = this.runtime?.runtime();
+    if (rt) {
+      rt.setTelemetryEnabled(visible).catch((e) => {
+        console.error(
+          "[DebuggerController] Failed to set telemetry enabled:",
+          e,
+        );
+      });
+    }
+
     this.host.requestUpdate();
   }
 


### PR DESCRIPTION
Heap growth of creating a new note decreased from ~50MB to ~1MB

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop streaming telemetry markers when the debugger is closed. This reduces heap growth when creating a new note from ~50MB to ~1MB and cuts unnecessary IPC traffic.

- **New Features**
  - Added SetTelemetryEnabled to the runtime protocol and client API.
  - Runtime processor gates telemetry emission; disabled by default.
  - DebuggerController toggles telemetry based on debugger visibility.
  - IPC debug logs improved; telemetry notifications are not logged when DEBUG_IPC is on.

<sup>Written for commit bd2050cfa232a986f4dc0af8fbee61e26667107b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

