### PR TITLE
fix(ui): call onChange callback when cell values change from backend

### DIFF
--- a/packages/patterns/gideon-tests/select-initial-value-repro.tsx
+++ b/packages/patterns/gideon-tests/select-initial-value-repro.tsx
@@ -1,0 +1,88 @@
+/// <cts-enable />
+import { NAME, pattern, UI, Writable } from "commontools";
+
+/**
+ * Reproduction case for ct-select not displaying initial values from backend.
+ *
+ * Bug: When a ct-select is bound to a cell via $value, the dropdown would show
+ * the placeholder "-" instead of the actual cell value on initial page load.
+ * The value was present in the cell, but the component's onChange callback
+ * wasn't being called when the subscription received backend updates.
+ *
+ * Root cause: CellController._setupCellSubscription() only called
+ * host.requestUpdate() when cell values changed, but didn't call the onChange
+ * callback. Components like ct-select rely on onChange to sync their DOM state.
+ *
+ * Fix: In cell-controller.ts, the subscription callback now calls onChange
+ * when the cell value changes from the backend.
+ *
+ * To test:
+ * 1. Deploy this pattern with `charm new`
+ * 2. Use CLI to set values: echo '"video"' | ct charm set --charm ID type ...
+ * 3. Refresh the page - the dropdown should show "🎬 Video", not "-"
+ * 4. The "Current value" text should also display "video"
+ */
+
+interface Output {
+  [NAME]: string;
+  type: string;
+  status: string;
+}
+
+export default pattern<Record<string, never>, Output>(() => {
+  const type = Writable.of<string>("article");
+  const status = Writable.of<string>("want");
+
+  return {
+    [NAME]: "Select Initial Value Repro",
+    [UI]: (
+      <ct-screen>
+        <ct-vstack gap="4" style="padding: 1rem;">
+          <ct-card>
+            <ct-vstack gap="2">
+              <ct-heading level={4}>Type Select</ct-heading>
+              <ct-select
+                $value={type}
+                items={[
+                  { label: "📄 Article", value: "article" },
+                  { label: "📚 Book", value: "book" },
+                  { label: "📑 Paper", value: "paper" },
+                  { label: "🎬 Video", value: "video" },
+                ]}
+              />
+              <p>
+                <strong>Current value:</strong> {type}
+              </p>
+            </ct-vstack>
+          </ct-card>
+
+          <ct-card>
+            <ct-vstack gap="2">
+              <ct-heading level={4}>Status Select</ct-heading>
+              <ct-select
+                $value={status}
+                items={[
+                  { label: "Want to read", value: "want" },
+                  { label: "Reading", value: "reading" },
+                  { label: "Finished", value: "finished" },
+                  { label: "Abandoned", value: "abandoned" },
+                ]}
+              />
+              <p>
+                <strong>Current value:</strong> {status}
+              </p>
+            </ct-vstack>
+          </ct-card>
+
+          <p style="color: gray; font-size: 0.875rem;">
+            If either dropdown shows "-" instead of its value on page load, the
+            bug is present. Both dropdowns should show their selected values
+            immediately.
+          </p>
+        </ct-vstack>
+      </ct-screen>
+    ),
+    type,
+    status,
+  };
+});

--- a/packages/ui/src/v2/core/cell-controller.ts
+++ b/packages/ui/src/v2/core/cell-controller.ts
@@ -282,7 +282,18 @@ export class CellController<T> implements ReactiveController {
 
   private _setupCellSubscription(): void {
     if (isCellHandle(this._currentValue)) {
-      this._cellUnsubscribe = this._currentValue.subscribe(() => {
+      let previousValue: T | undefined;
+      this._cellUnsubscribe = this._currentValue.subscribe((newValue) => {
+        // Call onChange when the cell value changes from the backend
+        // This ensures components like ct-select can update their DOM state
+        const typedNewValue = newValue as T | undefined;
+        if (typedNewValue !== previousValue) {
+          const oldValue = previousValue;
+          previousValue = typedNewValue;
+          if (oldValue !== undefined || typedNewValue !== undefined) {
+            this.options.onChange(typedNewValue as T, oldValue as T);
+          }
+        }
         if (this.options.triggerUpdate) {
           this.host.requestUpdate();
         }


### PR DESCRIPTION
CellController's _setupCellSubscription() only triggered host.requestUpdate() when cell values changed from the backend, but didn't call the onChange callback. This caused components like ct-select to fail to sync their DOM state when receiving initial values from persisted charms.

The fix tracks the previous value and calls onChange when values change, ensuring components can properly update their DOM (e.g., applyValueToDom() in ct-select) when backend values arrive.

Bug symptoms:
- ct-select dropdowns showing "-" instead of actual value on page load
- Values present in cell but not reflected in UI until user interaction

Includes reproduction pattern: gideon-tests/select-initial-value-repro.tsx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Calls onChange when cell values update from the backend so bound components (like ct-select) sync on initial load. Fixes selects showing "-" despite a value being present.

- **Bug Fixes**
  - Track previous value in CellController subscription and invoke onChange with new and old values.
  - Keep host.requestUpdate() when triggerUpdate is enabled.
  - Add reproduction: gideon-tests/select-initial-value-repro.tsx to verify ct-select initial value sync.

<sup>Written for commit 14b4993a1a832a1480c2f7372fb2ba446fc6617e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

