### PR TITLE
fix for computed array bug

### DIFF
--- a/packages/patterns/gideon-tests/computed-array-repro.tsx
+++ b/packages/patterns/gideon-tests/computed-array-repro.tsx
@@ -1,0 +1,103 @@
+/// <cts-enable />
+import {
+  computed,
+  Default,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+  Writable,
+} from "commontools";
+
+/**
+ * MINIMAL BUG REPRODUCTION
+ *
+ * Bug: computed() returning array with onClick handler "sticks" empty
+ *
+ * Root cause: When computed() returns JSX array containing onClick handlers,
+ * and the array becomes empty (e.g. filtering to no results), the UI
+ * permanently shows empty even when the computed should return items again.
+ *
+ * To reproduce:
+ * 1. Add some "Pending" items
+ * 2. Switch to "Done" tab (shows empty - no done items)
+ * 3. Switch back to "All" or "Pending" tab
+ * 4. BUG: Items don't reappear!
+ *
+ * Workaround: Use items.map() with computed style to hide/show instead of
+ * computed() returning filtered array.
+ */
+
+type Status = "pending" | "done";
+
+interface Item {
+  name: string;
+  status: Status;
+}
+
+interface Input {
+  items?: Writable<Default<Item[], []>>;
+}
+
+interface Output {
+  [NAME]: string;
+  [UI]: VNode;
+  items: Item[];
+}
+
+export default pattern<Input, Output>(({ items }) => {
+  const filter = Writable.of<Status | "all">("all");
+  const counter = Writable.of(1);
+
+  return {
+    [NAME]: "Computed Array Bug",
+    [UI]: (
+      <ct-screen>
+        <ct-vstack slot="header" gap="2">
+          <ct-tabs $value={filter}>
+            <ct-tab-list>
+              <ct-tab value="all">All</ct-tab>
+              <ct-tab value="pending">Pending</ct-tab>
+              <ct-tab value="done">Done</ct-tab>
+            </ct-tab-list>
+          </ct-tabs>
+        </ct-vstack>
+
+        <ct-vscroll flex>
+          <ct-vstack gap="2" style="padding: 1rem;">
+            <ct-button
+              variant="secondary"
+              onClick={() => {
+                const c = counter.get();
+                items.push({ name: `Item ${c}`, status: "pending" });
+                counter.set(c + 1);
+              }}
+            >
+              Add Pending Item
+            </ct-button>
+
+            <p>
+              Filter: {filter} | Total: {computed(() => items.get().length)}
+            </p>
+
+            {/* BUG: This breaks after visiting empty tab */}
+            {computed(() =>
+              (filter.get() === "all"
+                ? items.get().filter((i) => i != null)
+                : items.get().filter((i) => i && i.status === filter.get()))
+                .map((item) => (
+                  <div style="padding: 0.5rem; background: #eee; border-radius: 4px;">
+                    {item.name}
+                    <button type="button" onClick={() => console.log(item)}>
+                      log
+                    </button>
+                  </div>
+                ))
+            )}
+          </ct-vstack>
+        </ct-vscroll>
+      </ct-screen>
+    ),
+    items,
+  };
+});


### PR DESCRIPTION
Problem                                                                                                                                              
                                                                                                                                                       
  When a computed() function returns an array of JSX elements containing onClick handlers, and the array becomes empty (e.g., filtering to no results), the UI permanently shows empty even when the computed should return items again.                                                                    
                                                                                                                                                       
  Root Cause                                                                                                                                           
                                                                                                                                                       
  In runner.ts, when a computed function returns a result with opaque refs (like JSX with onClick handlers), it creates a result recipe and caches it. 
  
  The caching logic had a bug:                                                                                                                         
                                                                                                                                                       
  1. First render with items: Creates result recipe, caches it, writes a link to the result cell into the output binding                               
  2. Filter to empty: Returns [] with no opaque refs, so it takes a different code path and writes [] directly to the output binding (overwriting the link)                                                                                                                                                
  3. Filter back to items: Creates result recipe, finds cache hit, early returns without updating anything - leaving [] in the output                  
                                                                                                                                                       
  Fix                                                                                                                                                  
                                                                                                                                                       
  Always write the result cell link to the output binding, even when the recipe hasn't changed. The early return optimization was skipping this write, but a previous run may have overwritten the output with a plain value.                                                                               
                                                                                                                                                       
  Test                                                                                                                                                 
                                                                                                                                                       
  The included computed-array-repro.tsx pattern reproduces the bug:                                                                                    
  1. Add some "Pending" items                                                                                                                          
  2. Switch to "Done" tab (shows empty)                                                                                                                
  3. Switch back to "All" or "Pending" tab                                                                                                             
  4. Before fix: items don't reappear. After fix: items reappear correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a caching bug where computed() arrays with onClick handlers could get stuck empty after filtering. The runner now always writes the result cell link to the output, so items reappear when the computed returns data again.

- **Bug Fixes**
  - Updated runner to always write the result cell link even when the recipe is unchanged, preventing stale [] from overwriting the binding.
  - Added computed-array-repro.tsx to reproduce and verify the fix (switching tabs no longer leaves the list empty).

<sup>Written for commit be8663d268436f111e527ff246f858088825a553. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

