### PR TITLE
feat(patterns): add Gmail expect-response follow-up pattern

### DIFF
--- a/packages/patterns/google/core/experimental/gmail-sender.tsx
+++ b/packages/patterns/google/core/experimental/gmail-sender.tsx
@@ -28,6 +28,7 @@ import {
   NAME,
   pattern,
   UI,
+  type VNode,
   Writable,
 } from "commontools";
 import { GmailSendClient } from "../util/gmail-send-client.ts";
@@ -80,6 +81,7 @@ interface Input {
 
 /** Gmail email sender with confirmation dialog. #gmailSender */
 interface Output {
+  [UI]: VNode;
   draft: EmailDraft;
   result: SendResult | null;
 }


### PR DESCRIPTION
## Summary

- Adds a new **expect-response-followup** pattern that monitors Gmail threads labeled `expect-response`, shows a dashboard of threads awaiting responses, uses LLM to draft polite follow-up pings, and allows sending via Gmail
- Sends email through the embedded **gmail-sender** sub-pattern, which acts as a security declassification gate — the user must see the exact To/Subject/Body and explicitly confirm before any email is sent
- Tracks ping counts per thread, suggests giving up after configurable max pings, and supports removing the label to stop tracking

### Key design decisions

- **gmail-sender as trusted send gate**: Rather than calling `GmailSendClient.sendEmail()` directly, the pattern composes `gmail-sender.tsx` as a sub-pattern. Clicking "Send Follow-up" populates the sender's draft input, and the user goes through gmail-sender's full "Review & Send" → confirmation dialog flow
- **Thread context types**: Supports personal/business/urgent contexts with different day-counting (business days vs calendar days) and configurable thresholds
- **LLM draft generation**: Uses `generateText` with a single reactive computed prompt — only calls the LLM when a thread is selected for drafting
- **Sub-pattern composition**: Added `[UI]: VNode` to gmail-sender's Output type to enable embedding via the pattern composition system

### Files changed

| File | Change |
|------|--------|
| `packages/patterns/google/extractors/expect-response-followup.tsx` | New pattern (1619 lines) |
| `packages/patterns/google/core/experimental/gmail-sender.tsx` | Added `[UI]: VNode` to Output type for sub-pattern composition |

## Test plan

- [x] `deno task ct check` passes with no type errors
- [x] `deno fmt` and `deno lint` clean
- [x] Deployed and tested in browser:
  - [x] Pattern loads, authenticates via Google Auth wish system
  - [x] Threads with `expect-response` label appear after Refresh
  - [x] LLM draft generation produces reasonable follow-up text
  - [x] "Send Follow-up" opens gmail-sender compose form with pre-filled To/Subject/Body
  - [x] All fields are editable in the compose form
  - [x] "Review & Send" shows confirmation dialog with exact email content
  - [x] "Send Email" sends the email, increments ping count, clears draft
  - [x] Cancel flows work (both inner confirmation cancel and outer cancel back to draft editing)
  - [x] End-to-end send verified with real email delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Gmail expect-response follow-up pattern that tracks labeled threads, drafts polite follow-ups, and sends via a reviewed gmail-sender flow. Also exposes gmail-sender’s UI for embedding to support this composition.

- **New Features**
  - New expect-response-followup pattern: monitors label:expect-response, shows due threads, and tracks ping counts.
  - Context-aware thresholds (personal, business with business days, urgent); suggests giving up after max pings; supports removing the label.
  - On-demand draft generation; send through embedded gmail-sender with Review & Send confirmation.

- **Refactors**
  - gmail-sender Output now exposes [UI]: VNode to enable sub-pattern embedding.

<sup>Written for commit 4689ec8a0ed1594bc93829c950491f021e2a1143. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

