### PR TITLE
fix(pattern): note.tsx no longer uses as any

### DIFF
--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -205,7 +205,7 @@ const createNewNote = handler<
 
   // Add to parent notebook using Cell.key() pattern
   if (notebook) {
-    const charmsList = allPieces.get();
+    const piecesList = allPieces.get();
     const nbName = notebook?.[NAME];
     const nbIndex = piecesList.findIndex((c: any) => c?.[NAME] === nbName);
     if (nbIndex >= 0) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed unsafe any casts in Note pattern and replaced them with proper typing and optional chaining to improve type safety without changing behavior.

- **Refactors**
  - Access notebook and self.parentNotebook via optional chaining instead of casting.
  - Return typed notebooks (NotebookCharm[]) and cast containingNotebookNames to string[] for includes checks.
  - Read linkPattern reactively via .get() when available.

<sup>Written for commit 87055f68366a20caf8acdd5990a2d58fcea857d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

