### PR TITLE
fix(gmail-extractor): fix rawAnalyses filter crash in raw mode

### DIFF
--- a/packages/patterns/google/core/gmail-extractor.tsx
+++ b/packages/patterns/google/core/gmail-extractor.tsx
@@ -312,16 +312,27 @@ function interpolateTemplate(template: string, email: Email): string {
  * ```
  */
 export function trackAnalyses<T>(analyses: AnalysisItem<T>[]) {
-  const pendingCount = computed(
-    () => analyses?.filter((a) => a?.analysis?.pending)?.length || 0,
-  );
-  const completedCount = computed(
-    () =>
-      analyses?.filter(
-        (a) =>
-          a?.analysis?.pending === false && a?.analysis?.result !== undefined,
-      ).length || 0,
-  );
+  // Use index access since analyses may be a reactive mapped array
+  // (from .map() on a reactive cell) which doesn't support .filter()
+  const pendingCount = computed(() => {
+    const len = analyses?.length || 0;
+    let count = 0;
+    for (let i = 0; i < len; i++) {
+      if (analyses[i]?.analysis?.pending) count++;
+    }
+    return count;
+  });
+  const completedCount = computed(() => {
+    const len = analyses?.length || 0;
+    let count = 0;
+    for (let i = 0; i < len; i++) {
+      const a = analyses[i];
+      if (a?.analysis?.pending === false && a?.analysis?.result !== undefined) {
+        count++;
+      }
+    }
+    return count;
+  });
   return { pendingCount, completedCount };
 }
 
@@ -475,17 +486,29 @@ function GmailExtractor<T = unknown>(input: GmailExtractorInput) {
       error: unknown;
     }>);
 
-  // Compute pending/completed counts directly (rawAnalyses is a reactive mapped array)
-  const pendingCount = computed(
-    () => rawAnalyses?.filter((a) => a?.analysis?.pending)?.length || 0,
-  );
-  const completedCount = computed(
-    () =>
-      rawAnalyses?.filter(
-        (a) =>
-          a?.analysis?.pending === false && a?.analysis?.result !== undefined,
-      ).length || 0,
-  );
+  // Compute pending/completed counts using index access (rawAnalyses from .map()
+  // is a reactive mapped array that doesn't support .filter() directly)
+  const pendingCount = computed(() => {
+    if (!shouldRunAnalysis) return 0;
+    const len = rawAnalyses?.length || 0;
+    let count = 0;
+    for (let i = 0; i < len; i++) {
+      if (rawAnalyses[i]?.analysis?.pending) count++;
+    }
+    return count;
+  });
+  const completedCount = computed(() => {
+    if (!shouldRunAnalysis) return 0;
+    const len = rawAnalyses?.length || 0;
+    let count = 0;
+    for (let i = 0; i < len; i++) {
+      const a = rawAnalyses[i];
+      if (a?.analysis?.pending === false && a?.analysis?.result !== undefined) {
+        count++;
+      }
+    }
+    return count;
+  });
 
   // Note: Handler operations removed - they were unused and the authForHandlers wrapper
   // was an anti-pattern (Writable.of + computed side effect).


### PR DESCRIPTION
## Summary

- **Remove `computed()` wrapper from `shouldRunAnalysis`** — it returned a Cell object, which is always truthy in a plain JS ternary, so raw mode (no extraction config) always took the analysis branch
- **Replace `.filter()` with index-based iteration on `rawAnalyses` and `trackAnalyses`** — `emails.map()` returns a reactive mapped array (`OpaqueRef<S[]>`) that doesn't support `.filter()`; index access works correctly through the reactive proxy

## Root cause

Two bugs combined to produce `rawAnalyses?.filter is not a function`:

1. `shouldRunAnalysis` was wrapped in `computed()`, making it a Cell (always truthy). This caused the ternary at line 440 to always take the analysis branch, even when no extraction config was provided.

2. When analysis mode is active, `rawAnalyses = emails.map(...)` returns a reactive mapped array. Calling `.filter()` on this OpaqueRef fails because reactive mapped arrays don't expose native Array methods. Index-based access (`arr[i]`) works correctly through the proxy.

## Affected patterns

- **Raw mode (was crashing):** usps-informed-delivery, email-notes, email-task-engine, email-pattern-launcher, expect-response-followup, bam-school-dashboard
- **Analysis mode (filter fix):** email-ticket-finder, united-flight-tracker, berkeley-library, calendar-change-detector

## Test plan

- [x] Deployed `email-notes` (raw mode) to local dev server via `ct charm new`
- [x] Verified in Playwright: charm renders full UI ("Email Notes", note count, checkbox) with zero `filter is not a function` errors
- [x] `deno fmt` and `deno lint` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed raw mode crash in the Gmail extractor by properly detecting when analysis should run and iterating reactive arrays by index. Raw mode now loads without errors, and analysis counts compute correctly.

- **Bug Fixes**
  - Removed computed() from shouldRunAnalysis so the ternary respects missing extraction config.
  - Replaced .filter() with index-based loops for rawAnalyses and trackAnalyses (reactive arrays don’t expose Array methods).
  - Guarded pending/completed count computations when analysis is off.

<sup>Written for commit 82368c26de334f758e9be33e67e830dac6dd62c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

