### PR TITLE
fix(ui): guard ct-select against non-array items

### DIFF
--- a/packages/ui/src/v2/components/ct-select/ct-select.ts
+++ b/packages/ui/src/v2/components/ct-select/ct-select.ts
@@ -269,7 +269,8 @@ export class CTSelect extends BaseElement {
     }
 
     private _renderOptions() {
-      if (!this.items?.length) return nothing;
+      // Guard against non-array items (e.g., reactive proxy not yet resolved)
+      if (!Array.isArray(this.items) || !this.items.length) return nothing;
 
       // Group items by `group` key
       const groups = new Map<string | undefined, SelectItem[]>();
@@ -360,7 +361,9 @@ export class CTSelect extends BaseElement {
 
     private _buildKeyMap() {
       this._keyMap.clear();
-      this.items?.forEach((item, index) => {
+      // Guard against non-array items (e.g., reactive proxy not yet resolved)
+      if (!Array.isArray(this.items)) return;
+      this.items.forEach((item, index) => {
         if (!item) return;
         this._keyMap.set(this._makeKey(item, index), item);
       });


### PR DESCRIPTION
Add Array.isArray() checks in _buildKeyMap and _renderOptions to prevent TypeError when items is a reactive proxy that hasn't resolved to an array yet.

Fixes: "this.items?.forEach is not a function" error on page load.

NB: this is speculative, not intending to merge yet, leaving it up here to experiment with during notes/notebooks refactor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard CTSelect against non-array items to prevent a page-load error when items hasn’t resolved to an array.
Adds Array.isArray checks in _renderOptions and _buildKeyMap, fixing "this.items?.forEach is not a function".

<sup>Written for commit a83ca3b0f5629d277cee295281995445b8625945. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

