### PR TITLE
fix(shell): clean dist before build to prevent stale worker bundles

### DIFF
--- a/packages/shell/deno.json
+++ b/packages/shell/deno.json
@@ -1,12 +1,13 @@
 {
   "name": "@commontools/shell",
   "tasks": {
-    "build": "deno run -A ../felt/cli.ts build .",
-    "production": "PRODUCTION=1 deno run -A ../felt/cli.ts build .",
+    "clean": "rm -rf dist",
+    "build": "deno task clean && deno run -A ../felt/cli.ts build .",
+    "production": "deno task clean && PRODUCTION=1 deno run -A ../felt/cli.ts build .",
     "serve": "deno run -A ../felt/cli.ts serve .",
-    "dev": "API_URL=https://toolshed.saga-castor.ts.net deno run -A ../felt/cli.ts dev .",
-    "dev-local": "API_URL=http://localhost:8000 deno run -A ../felt/cli.ts dev .",
-    "dev-clusterduck": "API_URL='http://localhost:7001'  deno run -A ../felt/cli.ts dev .",
+    "dev": "deno task clean && API_URL=https://toolshed.saga-castor.ts.net deno run -A ../felt/cli.ts dev .",
+    "dev-local": "deno task clean && API_URL=http://localhost:8000 deno run -A ../felt/cli.ts dev .",
+    "dev-clusterduck": "deno task clean && API_URL='http://localhost:7001' deno run -A ../felt/cli.ts dev .",
     "integration": "LOG_LEVEL=warn deno test -A ./integration/*.test.ts",
     "test": "deno test test/*.test.ts"
   },


### PR DESCRIPTION
The felt build system doesn't watch runtime-client for changes, so
when pulling new code that modifies the worker entry point's dependencies
(like RequestType enum), the worker bundle can become stale. This caused
"Invalid IPC request" errors for new message types like vdom:mount.

Adding a clean step before each build/dev task ensures fresh builds.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clean dist before every build and dev task to prevent stale worker bundles. Adds a clean task and runs it before build/dev/production to avoid "Invalid IPC request" errors when runtime-client changes (e.g., new RequestType like vdom:mount) are pulled.

<sup>Written for commit 028da9ed47e0c8384855b3437a2ce4737a384123. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

