### PR TITLE
fix(html): prevent computed props from being sent as unresolved links

### DIFF
--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -671,7 +671,11 @@ export class WorkerReconciler {
     // Use convertCellsToLinks to handle Cells, circular refs, and non-JSON values.
     // Pass doNotConvertCellResults to prevent already-resolved values (from .sink())
     // from being converted back to links - we want the actual data for props.
-    return convertCellsToLinks(value, { doNotConvertCellResults: true });
+    return convertCellsToLinks(value, {
+      doNotConvertCellResults: true,
+      includeSchema: true,
+      keepStreams: true,
+    });
   }
 
   /**


### PR DESCRIPTION
Pass doNotConvertCellResults option to convertCellsToLinks in the worker
reconciler's transformPropValue method. This prevents already-resolved
values (which have [toCell] symbols from validateAndTransform) from being
converted back to link references when passed as props to custom elements.

Fixes issue where ct-google-oauth received scopes as { "/": { "v1": ... } }
instead of the actual array ["email", "profile", ...], causing 400 errors.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent computed props from being converted back to unresolved link references in the worker reconciler by passing doNotConvertCellResults and enabling keepStreams/includeSchema in convertCellsToLinks. Fixes ct-google-oauth scopes being sent as { "/": { "v1": ... } } instead of ["email", "profile", ...], avoiding 400 errors.

<sup>Written for commit 4fcfbfb2fff7e947076f33cd4d07064549d1b7ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

