### PR TITLE
fix(deps): pin core-js version to avoid esm.sh resolution failures

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -111,8 +111,8 @@
   "imports": {
     "commontools": "./packages/api/index.ts",
     "commontools/schema": "./packages/api/schema.ts",
-    "core-js/proposals/explicit-resource-management": "https://esm.sh/core-js/proposals/explicit-resource-management",
-    "core-js/proposals/async-explicit-resource-management": "https://esm.sh/core-js/proposals/async-explicit-resource-management",
+    "core-js/proposals/explicit-resource-management": "https://esm.sh/core-js@3.46.0/proposals/explicit-resource-management",
+    "core-js/proposals/async-explicit-resource-management": "https://esm.sh/core-js@3.46.0/proposals/async-explicit-resource-management",
     "@astral/astral": "./packages/vendor-astral/mod.ts",
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.8",
     "@std/assert": "jsr:@std/assert@^1",

--- a/deno.lock
+++ b/deno.lock
@@ -1785,9 +1785,7 @@
     }
   },
   "redirects": {
-    "https://esm.sh/@types/dagre@~0.7.53/index.d.ts": "https://esm.sh/@types/dagre@0.7.53/index.d.ts",
-    "https://esm.sh/core-js/proposals/async-explicit-resource-management": "https://esm.sh/core-js@3.46.0/proposals/async-explicit-resource-management",
-    "https://esm.sh/core-js/proposals/explicit-resource-management": "https://esm.sh/core-js@3.46.0/proposals/explicit-resource-management"
+    "https://esm.sh/@types/dagre@~0.7.53/index.d.ts": "https://esm.sh/@types/dagre@0.7.53/index.d.ts"
   },
   "remote": {
     "https://esm.sh/core-js@3.46.0/denonext/proposals/async-explicit-resource-management.mjs": "d75be20fbac6aec6a9c3f5f920641d135a9ece80b474fd17ff282e1288043d76",


### PR DESCRIPTION
Pin core-js imports to @3.46.0 to prevent transient 500 errors from esm.sh when resolving unversioned URLs. Remove redirect entries from lock file since versioned URLs don't need redirects.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin core-js proposal imports to v3.46.0 to stop intermittent esm.sh 500s and stabilize builds. Removed now-unneeded redirects from the lock file.

- **Dependencies**
  - Versioned imports for core-js/proposals/explicit-resource-management and async-explicit-resource-management to @3.46.0 in deno.json.
  - Removed related redirect entries from deno.lock.

<sup>Written for commit ad6c891b9d8c6c6f72bd03746ab493fcc2b37775. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

