### PR TITLE
fix(runner): computed() nodes skipped by action validation (#CT-1192)

### DIFF
--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -333,9 +333,15 @@ export function derive<In, Out>(...args: any[]): OpaqueRef<any> {
   return lift(f)(input);
 }
 
-// unsafe closures: like derive, but doesn't need any arguments
+// unsafe closures: like derive, but doesn't need any arguments.
+// Uses argumentSchema: false to signal "takes no input" so the action
+// validation doesn't skip it due to undefined arguments.
 export const computed: <T>(fn: () => T) => OpaqueRef<T> = <T>(fn: () => T) =>
-  lift<any, T>(fn)(undefined);
+  createNodeFactory<any, T>({
+    type: "javascript",
+    implementation: fn,
+    argumentSchema: false,
+  })(undefined);
 
 /**
  * action: Creates a handler that doesn't use the state parameter.


### PR DESCRIPTION
## Summary

Fixes **CT-1192**: Cross-space Google Auth wish discovery broken — all auth patterns stuck.

The `computed()` function in the runner was delegating to `lift(fn)(undefined)`, which meant the resulting action had no explicit `argumentSchema`. During action validation, actions with `undefined` arguments and no schema were being **skipped** — they never executed, so any downstream logic depending on `computed()` values (like wish queries in GoogleAuthManager) silently failed.

### Root Cause

Action validation treats actions with `undefined` arguments as "not yet ready" unless the action's schema explicitly declares it takes no input. `computed()` actions by definition take no input, but the old implementation didn't signal this.

### Fix

- Changed `computed()` to use `createNodeFactory` directly with `argumentSchema: false`, which explicitly tells the validation layer "this action takes no input — always run it."
- Added a regression test that mimics the GoogleAuthManager pattern: uses `computed()` to build a wish query for `#googleAuth` hashtag discovery across spaces.

### Scope

As seefeldb noted: in the full CTS transformation pipeline, `computed()` gets converted to `derive`, so this fix is effectively a no-op in production. However, it corrects the semantics for direct runner usage and non-CTS code paths.

## Test plan

- [x] Regression test: `resolves hashtag using computed query (GoogleAuthManager pattern)`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
