### PR TITLE
fix(html): cancel child sinks when parent render tree is torn down

### DIFF
--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -755,6 +755,16 @@ export class WorkerReconciler {
       this.updateChildren(ctx, state, children, visited);
     }
 
+    // When this cancel is called, also cancel all current children.
+    // This ensures child sinks are cleaned up when the parent render tree
+    // is torn down (e.g., during reconcileIntoWrapper).
+    addCancel(() => {
+      for (const [, childState] of state.children) {
+        childState.cancel();
+      }
+      state.children.clear();
+    });
+
     return cancel;
   }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `bindChildren` in the reconciler did not connect static children's cancel functions to the parent cancel chain. When the render tree was torn down (e.g., during `reconcileIntoWrapper`), children's sink Actions were never unsubscribed from the scheduler.
- **Effect**: Leaked sink Actions accumulated in the scheduler's `triggers` map, causing unbounded re-execution on every storage notification (scheduler thrashing). Action count grew monotonically: 45 → 91 → 157 → 246 → 361 → 505 per swap click.
- **Fix**: Added a cleanup closure to `bindChildren`'s cancel group that cancels all children in `state.children` when the parent is torn down.

## Test plan

- [x] Manually verified with text-swapper pattern — no more thrashing after ~10 swap clicks
- [x] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel child sinks when a parent render tree is torn down to stop scheduler thrashing and action leaks. We now hook children into the parent cancel chain in bindChildren.

- **Bug Fixes**
  - Root cause: bindChildren didn’t cancel static children on parent teardown (e.g., reconcileIntoWrapper), leaving sink Actions subscribed.
  - Fix: add a cleanup to the parent cancel group that cancels all current children and clears state.children.
  - Result: prevents leaked Actions from piling up in the scheduler; manual swaps no longer trigger unbounded re-execution.

<sup>Written for commit 9e64b35baf1175786b72a2853fd5351203bb4934. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

