### PR TITLE
example(pattern): simple text-swapper that tests modals

### DIFF
--- a/packages/patterns/text-swapper.tsx
+++ b/packages/patterns/text-swapper.tsx
@@ -26,7 +26,7 @@ interface Output {
 const swapTexts = handler<
   unknown,
   { leftText: Writable<string>; rightText: Writable<string> }
-  >((_event, { leftText, rightText }) => {
+>((_event, { leftText, rightText }) => {
   const left = leftText.get();
   const right = rightText.get();
   console.log("swapTexts", { left, right });
@@ -42,7 +42,7 @@ const openEditLeft = handler<
     editValue: Writable<string>;
     showModal: Writable<boolean>;
   }
-  >((_event, { leftText, editingSide, editValue, showModal }) => {
+>((_event, { leftText, editingSide, editValue, showModal }) => {
   console.log("openEditLeft");
   editingSide.set("left");
   editValue.set(leftText.get());
@@ -57,7 +57,7 @@ const openEditRight = handler<
     editValue: Writable<string>;
     showModal: Writable<boolean>;
   }
-  >((_event, { rightText, editingSide, editValue, showModal }) => {
+>((_event, { rightText, editingSide, editValue, showModal }) => {
   console.log("openEditRight");
   editingSide.set("right");
   editValue.set(rightText.get());


### PR DESCRIPTION
Written by @tonyespinoza1 and Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a simple Text Swapper pattern with two labels, a swap button, and a modal to rename either label. Defaults to "Hello" and "World" and helps test modal open/save/cancel flows.

<sup>Written for commit f8ecba6dd617e64c68e48fb02ddaddf1cdb84fd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

