### PR TITLE
Avoid a top level read in followPointer

### DIFF
--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -889,7 +889,7 @@ function getTrackerKey(
  * source docs as read if needed.
  *
  * I can't just use resolveLink, since I need to also track all the
- * intermediate docuemnts if we includeSource.
+ * intermediate documents if we includeSource.
  *
  * @param tx - IStorageTransaction that can be used to read data
  * @param doc - IAttestation for the current document
@@ -974,7 +974,7 @@ function followPointer(
     // If we had an unexpected error, or didn't find the doc at all, return.
     if (error.name === "NotFoundError" && error.path.length === 0) {
       // If the object we're pointing to is a retracted fact, just return undefined.
-      logger.warn(
+      logger.info(
         "traverse",
         () => ["followPointer found missing/retracted fact", valueEntry],
       );


### PR DESCRIPTION
Avoid a top level read in followPointer, since we don't want to taint the reactivity.

This means we attempt to read at the full depth, back out to the last valid read and try a getAtPath there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix followPointer reactivity by avoiding top-level reads. Traversal now reads at full depth, backs off to the last valid node, and continues without subscribing to unrelated cells.

- **Bug Fixes**
  - Read at the target path and back off to the last existing segment, then continue via getAtPath to avoid tainting reactive dependencies.
  - Track visited docs with a new trackVisitedDoc helper; load sources non-reactively when includeSource is true.
  - Improve link handling: prepend "value" to target link paths, re-root selectors correctly, and avoid double-prefixing.
  - Handle NotFound cases more precisely (missing doc vs missing path) and return notFound(target) with the correct address.
  - Fix redirect resolution: if the final link is invalid, base itemLink on the last valid redirect doc.

<sup>Written for commit e6683ca62c31af9bdc8023d3eccc5de724b1fd9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

