### PR TITLE
fix(html): cancel rendered content when cell child is torn down

### DIFF
--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -988,6 +988,17 @@ export class WorkerReconciler {
       }),
     );
 
+    // When the cancel group fires (parent teardown), also cancel the current
+    // rendered content. Without this, deeper sinks (e.g. children/props of the
+    // rendered content) leak because currentCancel is only called on re-fire
+    // inside the sink callback, not on teardown.
+    addCancel(() => {
+      if (currentCancel) {
+        currentCancel();
+        currentCancel = undefined;
+      }
+    });
+
     return childState;
   }
 


### PR DESCRIPTION
## Summary
- `renderCellChild` stored the rendered content's cancel (`newState.cancel`) in a local `currentCancel` variable
- This cancel was only invoked on sink **re-fire** (line 942), not when the cancel group was torn down by a parent
- When a parent cancelled the cell child (e.g., `reconcileIntoWrapper` teardown), the `cell.sink()` was cancelled but **deeper sinks** (children, props of the rendered content) were never cleaned up
- These leaked actions accumulated in the scheduler's `triggers` map, causing linearly growing work per change event (47 subscribes vs 46 unsubscribes per click per sink)
- Fix: add a cleanup function to the cancel group that calls `currentCancel` on teardown

## Test plan
- [x] Verify registered action count stays constant across repeated clicks (no accumulation)
- [x] Run existing test suite
- [x] Test text-swapper pattern for reduced scheduler thrashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a leak in renderCellChild by canceling the current rendered content when the parent cancel group tears down. Prevents accumulating scheduler work and keeps per-change cost stable.

- **Bug Fixes**
  - Added cancel group cleanup that calls currentCancel on teardown (not only on sink re-fire).
  - Stops leaking child/prop sinks and avoids growing entries in the scheduler’s triggers map.

<sup>Written for commit 9bcfda9e31b7d6bad4e24e6cd30c6c212b549ef7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

