### PR TITLE
feat(cli): show env var status in help and add hidden deploy command

### DIFF
--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -7,6 +7,20 @@ import { piece } from "./piece.ts";
 import { identity } from "./identity.ts";
 import { test } from "./test.ts";
 
+function envStatus(): string {
+  const identity = Deno.env.get("CT_IDENTITY");
+  const apiUrl = Deno.env.get("CT_API_URL");
+  if (!identity && !apiUrl) return "";
+  const lines: string[] = ["", "ENVIRONMENT:"];
+  if (identity) {
+    lines.push(`  CT_IDENTITY = ${identity} (set, no need to pass --identity)`);
+  }
+  if (apiUrl) {
+    lines.push(`  CT_API_URL  = ${apiUrl} (set, no need to pass --api-url)`);
+  }
+  return lines.join("\n");
+}
+
 const mainDescription = `Tool for running programs on common fabric.
 
 QUICK START:
@@ -22,7 +36,7 @@ FIRST TIME SETUP:
 LOCAL DEVELOPMENT:
   ./scripts/start-local-dev.sh      # Start local servers
   ./scripts/stop-local-dev.sh       # Stop local servers
-
+${envStatus()}
 Run 'ct <command> --help' for command-specific help.`;
 
 export const main = new Command()
@@ -48,4 +62,15 @@ export const main = new Command()
   .command("dev", dev)
   .command("id", identity)
   .command("init", init)
-  .command("test", test);
+  .command("test", test)
+  .command(
+    "deploy",
+    new Command()
+      .description("Use 'ct piece new' instead.")
+      .hidden()
+      .action(() => {
+        console.log(
+          "The 'deploy' command does not exist. Use 'ct piece new' to deploy a pattern.",
+        );
+      }),
+  );

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -57,6 +57,24 @@ const EX_COMP = `--api-url ${RAW_EX_COMP.apiUrl} --space ${RAW_EX_COMP.space}`;
 const EX_COMP_PIECE = `${EX_COMP} --piece ${RAW_EX_COMP.piece!}`;
 
 // Enhanced description with workflow tips
+function pieceEnvStatus(): string {
+  const identity = Deno.env.get("CT_IDENTITY");
+  const apiUrl = Deno.env.get("CT_API_URL");
+  if (!identity && !apiUrl) return "";
+  const lines: string[] = ["", "ENVIRONMENT:"];
+  if (identity) {
+    lines.push(
+      `  CT_IDENTITY = ${identity} (set, no need to pass --identity)`,
+    );
+  }
+  if (apiUrl) {
+    lines.push(
+      `  CT_API_URL  = ${apiUrl} (set, no need to pass --api-url)`,
+    );
+  }
+  return lines.join("\n");
+}
+
 const pieceDescription = `Interact with pieces running on a server.
 
 COMMON WORKFLOWS:
@@ -64,7 +82,7 @@ COMMON WORKFLOWS:
   Update:    ct piece setsrc --piece <ID> ./pattern.tsx -i ./claude.key -a http://localhost:8000 -s my-space
   Test:      ct piece call --piece <ID> handlerName -i ./claude.key -a http://localhost:8000 -s my-space
   Inspect:   ct piece inspect --piece <ID> -i ./claude.key -a http://localhost:8000 -s my-space
-
+${pieceEnvStatus()}
 TIPS:
   • Use 'setsrc' for iteration, not repeated 'new' (avoids clutter)
   • After 'set', run 'step' to trigger computed value updates


### PR DESCRIPTION
## Summary
- When `CT_IDENTITY` or `CT_API_URL` env vars are set, `ct help` and `ct piece help` now display an ENVIRONMENT section showing their current values and noting they don't need to be passed as flags
- Adds a hidden `ct deploy` command that tells users to use `ct piece new` instead (not listed in `ct help` output)

## Test plan
- [x] `deno task test` passes
- [x] Verified `ct help` and `ct piece help` show env status when vars are set
- [x] Verified env section is omitted when vars are not set
- [x] Verified `ct deploy` prints redirect message
- [x] Verified `deploy` does not appear in `ct help` command list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated CLI help to show env var status for CT_IDENTITY and CT_API_URL, so users don’t pass duplicate flags. Added a hidden ct deploy command that guides users to use ct piece new.

- **New Features**
  - ct help and ct piece help show an ENVIRONMENT block when CT_IDENTITY or CT_API_URL are set, with current values and notes that flags aren’t needed.
  - Added hidden ct deploy that prints a redirect to ct piece new and does not appear in help.

<sup>Written for commit e66bb327526170c7d301a9fc692b415543acb9fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

