### PR TITLE
feat(integration): add PIPE_CONSOLE env var to forward browser console output

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -170,6 +170,18 @@ describe("shadow DOM component test", () => {
 4. **Use pierce strategy consistently**: It works for both finding and
    interacting with elements
 
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `HEADLESS` | Set to `true` or `1` to run browser headlessly (default: visible) |
+| `PIPE_CONSOLE` | Set to `true` or `1` to forward browser console output to the test runner |
+| `API_URL` | Server URL (default: `http://localhost:8000`) |
+| `FRONTEND_URL` | Frontend URL (default: `API_URL`) |
+| `SPACE_NAME` | Target a specific space (default: random UUID) |
+
+Example: `PIPE_CONSOLE=1 deno task integration`
+
 ## Debugging Tips
 
 If pierce strategy isn't finding your element:

--- a/packages/integration/env.ts
+++ b/packages/integration/env.ts
@@ -13,6 +13,9 @@ export const FRONTEND_URL = ensureTrailing(
 
 export const HEADLESS = envToBool(Deno.env.get("HEADLESS"));
 
+// Pipe browser console output to the test runner's console.
+export const PIPE_CONSOLE = envToBool(Deno.env.get("PIPE_CONSOLE"));
+
 // Some tests take a SPACE_NAME, targeting a specific space.
 // If not defined, uses a random UUID.
 export const SPACE_NAME = Deno.env.get("SPACE_NAME") ??

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -66,7 +66,9 @@ export class ShellIntegration {
   #config: ShellIntegrationConfig;
 
   constructor(config: ShellIntegrationConfig = {}) {
-    this.#config = config;
+    this.#config = {
+      pipeConsole: config.pipeConsole ?? env.PIPE_CONSOLE,
+    };
   }
 
   bindLifecycle() {


### PR DESCRIPTION
## Summary
- Adds `PIPE_CONSOLE` env var (`true`/`1`) that enables forwarding browser console output to the test runner in integration tests
- `ShellIntegration` reads the env var as a default, so no test code changes needed
- Documents all integration test env vars in `UI_TESTING.md`

## Test plan
- [x] Run `PIPE_CONSOLE=1 deno task integration` in `packages/shell` and verify browser logs appear
- [x] Run `PIPE_CONSOLE=1 deno task integration` in `packages/patterns` and verify browser logs appear
- [x] Run without `PIPE_CONSOLE` and verify no browser logs appear (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PIPE_CONSOLE env var to forward browser console output to the test runner in integration tests. ShellIntegration reads it by default, and docs now list all integration test env vars.

- **New Features**
  - Supports PIPE_CONSOLE=true/1 to pipe browser console to the test runner.
  - ShellIntegration uses the env value unless pipeConsole is set in config.

- **Migration**
  - Enable with: PIPE_CONSOLE=1 deno task integration.
  - Leave unset to keep current behavior (no browser logs).

<sup>Written for commit ef92482c99bc99347b7b3b4a0b43fd09e3da29e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

