### PR TITLE
test(runner): add integration test for recipe and data persistence

### DIFF
--- a/packages/runner/integration/recipe-and-data-persistence.test.ts
+++ b/packages/runner/integration/recipe-and-data-persistence.test.ts
@@ -63,14 +63,14 @@ const recipeProgram: RuntimeProgram = {
   ],
 };
 
-const inputDataSchema = {
+const inputDataSchema: JSONSchema = {
   type: "object",
   properties: {
     values: { type: "array", items: { type: "number" } },
     label: { type: "string" },
   },
   required: ["values", "label"],
-} as const satisfies JSONSchema;
+};
 
 async function testRecipeAndDataPersistence() {
   console.log("\n=== TEST: Recipe and Data Persistence ===");


### PR DESCRIPTION
## Summary

- Adds a new integration test demonstrating the full layered persistence model
- Recipe source code and precious data both stored in the datum table
- Fresh runtime instances load both from storage and react correctly

The test has three phases:
1. **Phase 1**: Save recipe and data (runtime 1)
2. **Phase 2**: Load from storage with fresh runtime, verify computed values (runtime 2)
3. **Phase 3**: Reload again, observe values before update, update data, verify reactivity (runtime 3)

## Test plan

- [x] Test passes locally with `deno test --allow-all packages/runner/integration/recipe-and-data-persistence.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an integration test that verifies full layered persistence: recipe source and precious data are stored in the datum table, then loaded by fresh runtimes that compute and react correctly. Covers saving, reloading in a new runtime to validate results, and reloading again to confirm reactivity after updating data.

<sup>Written for commit f30e7056a793f5f7e1f99ee36b0cc236d5b3afc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

