### PR TITLE
fix(runner): handle inline objects with asCell in array traversal

### DIFF
--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1929,14 +1929,15 @@ export class SchemaObjectTraverser<V extends JSONValue>
         !this.traverseCells &&
         SchemaObjectTraverser.asCellOrStream(curSelector.schema)
       ) {
-        // For non-link values, we need to create a DataCellURI-style address
-        // with path: ["value"] so that getNextCellLink can generate a proper
-        // normalized link. We check item (not curDoc.value) because if item
-        // was a link, we've already followed it and curDoc.address has the
-        // correct target address - we don't want to overwrite it with a
-        // DataCellURI. This handles inline objects, primitives, arrays, null,
-        // and undefined.
-        if (!isPrimitiveCellLink(item)) {
+        // For values where curDoc.address.path doesn't start with "value",
+        // we need to create a DataCellURI-style address so that getNextCellLink
+        // can generate a proper normalized link via getNormalizedLink.
+        // This handles:
+        // 1. Inline objects/primitives (item was never a link)
+        // 2. Links that resolved to a doc whose path doesn't start with "value"
+        // We skip this when the path already starts with "value" to preserve
+        // the original link's identity.
+        if (curDoc.address.path[0] !== "value") {
           const elementLink: NormalizedFullLink = {
             space: curDoc.address.space,
             id: curDoc.address.id,


### PR DESCRIPTION
When traversing arrays with items marked as asCell, inline objects (not links) need a DataCellURI-style address with path: ["value"] before getNextCellLink can generate a proper normalized link.

Commit 231acd0c2 removed the isPrimitiveCellLink guard to respect asCell boundaries for inline objects, but didn't account for the case where curDoc.address.path doesn't start with "value" (e.g., VDOM children arrays have paths like ["$UI", "children", "0"]).

This fix creates the proper address for inline objects before calling getNextCellLink, preventing the "Unable to create link to non-value address" error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix array traversal for asCell items by wrapping elements whose address path doesn’t start with "value" in a DataCellURI before link resolution. Prevents "Unable to create link to non-value address" and restores link normalization for VDOM children and other non-"value" paths.

- **Bug Fixes**
  - If curDoc.address.path[0] !== "value", create a DataCellURI from the element, set path to ["value"], then call getNextCellLink (handles inline values and links resolving to non-value paths).
  - Skip wrapping when the path already starts with "value" to preserve existing link IDs.

<sup>Written for commit 68b04a9188298dc2c699e4e688a64f19c2d1ccac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

