### PR TITLE
Update deno.yml

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: "Test and Build"
-    runs-on: ubuntu-24.04-32-core
+    runs-on: ubuntu-24.04-64-core
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the CI “Test and Build” job to the ubuntu-24.04-64-core runner (from 32-core) to speed up Deno tests and builds. Expect shorter run times and more headroom for parallel tasks.

<sup>Written for commit 9b379a818203137dc3eea6efb0643e6ee9088fb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

