### PR TITLE
Removed SchemaContext from the network protocol

### DIFF
--- a/packages/memory/consumer.ts
+++ b/packages/memory/consumer.ts
@@ -32,7 +32,6 @@ import type {
   Reference,
   Result,
   Revision,
-  SchemaContextPathSelector,
   SchemaPathSelector,
   SchemaQuery,
   SchemaQueryArgs,
@@ -385,12 +384,12 @@ class MemorySpaceConsumerSession<Space extends MemorySpace>
   private static asSelectSchema(queryArg: QueryArgs): SchemaQueryArgs {
     const selectSchema: Select<
       URI,
-      Select<MIME, Select<CauseString, SchemaContextPathSelector>>
+      Select<MIME, Select<CauseString, SchemaPathSelector>>
     > = {};
     for (const [of, attributes] of Object.entries(queryArg.select)) {
       const entityEntry: Select<
         MIME,
-        Select<CauseString, SchemaContextPathSelector>
+        Select<CauseString, SchemaPathSelector>
       > = {};
       selectSchema[of as URI | SelectAll] = entityEntry;
       let attrEntries = Object.entries(attributes);
@@ -399,19 +398,17 @@ class MemorySpaceConsumerSession<Space extends MemorySpace>
         attrEntries = [["_", {}]];
       }
       for (const [the, causes] of attrEntries) {
-        const attributeEntry: Select<CauseString, SchemaContextPathSelector> =
-          {};
+        const attributeEntry: Select<CauseString, SchemaPathSelector> = {};
         entityEntry[the as MIME | SelectAll] = attributeEntry;
         // A Selector may not have a cause, but SchemaSelector needs all three levels
         let causeEntries = Object.entries(causes);
         if (causeEntries.length === 0) {
           causeEntries = [["_", {}]];
         }
-        for (const [cause, selector] of causeEntries) {
-          const causeEntry: SchemaContextPathSelector = {
+        for (const [cause, _selector] of causeEntries) {
+          const causeEntry: SchemaPathSelector = {
             path: [],
-            schemaContext: { schema: false },
-            ...selector.is ? { is: selector.is } : {},
+            schema: false,
           };
           attributeEntry[cause as CauseString | SelectAll] = causeEntry;
         }
@@ -612,13 +609,13 @@ class QueryView<
     return subscription;
   }
 
-  // Get the schema context used to fetch the specified fact.
-  // If the fact was included from another fact, it will not have a schemaContext.
+  // Get the SchemaPathSelector used to fetch the specified fact.
+  // If the fact was included from another fact, it will not have a schema.
   getSchemaPathSelector(fact: Revision<Fact>): SchemaPathSelector | undefined {
     const factSelector = this.selector as SchemaSelector;
     const value = getSelectorRevision(factSelector, fact.of, fact.the);
     return value !== undefined
-      ? { path: value?.path, schema: value?.schemaContext.schema }
+      ? { path: value?.path, schema: value?.schema }
       : undefined;
   }
 }

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -854,23 +854,17 @@ export type SchemaQuery<Space extends MemorySpace = MemorySpace> = Invocation<
 //     "application/json": {
 //       _: {
 //         path: [],
-//         schemaContext: {
-//           schema: { "type": "object" },
-//           rootSchema: { "type": "object" }
-//         }
+//         schema: { "type": "object" },
 //       }
 //     }
 //   }
 // }
 
-export type SchemaContextPathSelector = {
-  path: readonly string[];
-  schemaContext: { schema: JSONSchema };
-};
-
+// The SchemaPathSelector objects contained by the SchemaSelector have their
+// path relative to fact.is.value, unlike standard SchemaPathSelectors.
 export type SchemaSelector = Select<
   URI,
-  Select<MIME, Select<CauseString, SchemaContextPathSelector>>
+  Select<MIME, Select<CauseString, SchemaPathSelector>>
 >;
 
 export type Operation =

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -176,7 +176,7 @@ export const selectSchema = <Space extends MemorySpace>(
   for (
     const selectorEntry of iterateSelector(
       selectSchema,
-      { path: [], schemaContext: { schema: true } },
+      { path: [], schema: true },
     )
   ) {
     const factSelector = {
@@ -193,7 +193,7 @@ export const selectSchema = <Space extends MemorySpace>(
       // to the value, but our traversal wants them to be relative to the
       // fact.is, so adjust the paths.
       const selector: SchemaPathSelector = {
-        schema: selectorEntry.value.schemaContext?.schema,
+        schema: selectorEntry.value.schema,
         path: ["value", ...selectorEntry.value.path],
       };
       // Then filter the facts by the associated schemas, which will dereference
@@ -247,7 +247,7 @@ export const selectSchema = <Space extends MemorySpace>(
   for (
     const factSelector of iterateSelector(
       selectSchema,
-      { path: [], schemaContext: { schema: true } },
+      { path: [], schema: true },
     )
   ) {
     if (

--- a/packages/memory/test/consumer-test.ts
+++ b/packages/memory/test/consumer-test.ts
@@ -346,7 +346,7 @@ test("list multiple facts using schema query", store, async (session) => {
     selectSchema: {
       _: {
         [the]: {
-          _: { path: [], schemaContext: { schema: true } },
+          _: { path: [], schema: true },
         },
       },
     },
@@ -775,7 +775,7 @@ test(
       selectSchema: {
         [doc]: {
           "application/json": {
-            _: { path: [], schemaContext: { schema: VersionSchema } },
+            _: { path: [], schema: VersionSchema },
           },
         },
       },
@@ -815,7 +815,7 @@ test(
       selectSchema: {
         [doc]: {
           "application/json": {
-            _: { path: [], schemaContext: { schema: VersionSchema } },
+            _: { path: [], schema: VersionSchema },
           },
         },
       },
@@ -924,7 +924,7 @@ test(
         [the]: {
           _: {
             path: ["offices", "main"],
-            schemaContext: { schema: AddressSchema },
+            schema: AddressSchema,
           },
         },
       },
@@ -1036,7 +1036,7 @@ test(
         [the]: {
           _: {
             path: ["offices", "main"],
-            schemaContext: { schema: AddressSchema },
+            schema: AddressSchema,
           },
         },
       },
@@ -1165,7 +1165,7 @@ test(
 
     const selector = {
       path: [],
-      schemaContext: { schema: VersionSchema },
+      schema: VersionSchema,
     };
 
     const v1 = Fact.assert({
@@ -1277,7 +1277,7 @@ test(
 
     const selector = {
       path: [],
-      schemaContext: { schema: VersionSchema },
+      schema: VersionSchema,
     };
 
     const v1 = Fact.assert({
@@ -1347,7 +1347,7 @@ test(
       selectSchema: {
         _: {
           [the]: {
-            _: { path: [], schemaContext: { schema: true } },
+            _: { path: [], schema: true },
           },
         },
       },
@@ -1366,7 +1366,7 @@ test(
       selectSchema: {
         _: {
           [the]: {
-            _: { path: [], schemaContext: { schema: true } },
+            _: { path: [], schema: true },
           },
         },
       },
@@ -1385,7 +1385,7 @@ test(
       selectSchema: {
         _: {
           [the]: {
-            _: { path: [], schemaContext: { schema: true } },
+            _: { path: [], schema: true },
           },
         },
       },

--- a/packages/memory/test/space-test.ts
+++ b/packages/memory/test/space-test.ts
@@ -1193,7 +1193,7 @@ test("list single fact with schema query", DB, async (session) => {
   const sampleSchemaSelector: SchemaSelector = {
     [doc]: {
       [the]: {
-        _: { path: ["v"], schemaContext: { schema: { "type": "number" } } },
+        _: { path: ["v"], schema: { "type": "number" } },
       },
     },
   };
@@ -1307,14 +1307,12 @@ test(
         [the]: {
           _: {
             path: ["address"],
-            schemaContext: {
-              schema: {
-                "type": "object",
-                "properties": {
-                  "name": { "type": "string" },
-                  "street": { "type": "string" },
-                  "city": { "type": "string" },
-                },
+            schema: {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "street": { "type": "string" },
+                "city": { "type": "string" },
               },
             },
           },
@@ -1436,15 +1434,13 @@ test(
         [the]: {
           _: {
             path: ["address"],
-            schemaContext: {
-              schema: {
-                "type": "object",
-                "properties": {
-                  "street": { "type": "string" },
-                  "city": { "type": "string" },
-                },
-                "additionalProperties": false,
+            schema: {
+              "type": "object",
+              "properties": {
+                "street": { "type": "string" },
+                "city": { "type": "string" },
               },
+              "additionalProperties": false,
             },
           },
         },
@@ -1575,7 +1571,7 @@ test(
         [the]: {
           _: {
             path: ["emergency_contacts", "0", "first"],
-            schemaContext: { schema: { "type": "string" } },
+            schema: { "type": "string" },
           },
         },
       },
@@ -1662,7 +1658,7 @@ test(
     const schemaSelector: SchemaSelector = {
       [doc2]: {
         [the]: {
-          _: { path: ["left"], schemaContext: { schema } },
+          _: { path: ["left"], schema },
         },
       },
     };
@@ -1747,7 +1743,7 @@ test(
     const schemaSelector: SchemaSelector = {
       [doc2]: {
         [the]: {
-          _: { path: ["left"], schemaContext: { schema } },
+          _: { path: ["left"], schema },
         },
       },
     };
@@ -1843,16 +1839,14 @@ test(
         [the]: {
           _: {
             path: ["offices", "main"],
-            schemaContext: {
-              schema: {
-                "type": "object",
-                "properties": {
-                  "name": { "type": "string" },
-                  "street": { "type": "string" },
-                  "city": { "type": "string" },
-                },
-                "required": ["name", "street", "city"],
+            schema: {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "street": { "type": "string" },
+                "city": { "type": "string" },
               },
+              "required": ["name", "street", "city"],
             },
           },
         },
@@ -1887,7 +1881,7 @@ test(
         selectSchema: {
           [doc]: {
             [the]: {
-              _: { path: [], schemaContext: { schema: {} } },
+              _: { path: [], schema: {} },
             },
           },
         },
@@ -2002,7 +1996,7 @@ test(
         [the]: {
           _: {
             path: [],
-            schemaContext: { schema: { "type": "object", "properties": {} } },
+            schema: { "type": "object", "properties": {} },
           },
         },
       },
@@ -2037,7 +2031,7 @@ test(
         selectSchema: {
           [doc1]: {
             [the]: {
-              _: { path: [], schemaContext: { schema: {} } },
+              _: { path: [], schema: {} },
             },
           },
         },
@@ -2066,9 +2060,7 @@ test(
             [the]: {
               _: {
                 path: [],
-                schemaContext: {
-                  schema: { type: "object", additionalProperties: true },
-                },
+                schema: { type: "object", additionalProperties: true },
               },
             },
           },
@@ -2154,7 +2146,7 @@ test(
     const schemaSelector: SchemaSelector = {
       [doc3]: {
         [the]: {
-          _: { path: [], schemaContext: { schema: pieceListSchema } },
+          _: { path: [], schema: pieceListSchema },
         },
       },
     };

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -688,9 +688,7 @@ export class Replica {
       //     [the]: {
       //       SelectAllString: {
       //         path: [],
-      //         schemaContext: {
-      //           schema: SchemaNone,
-      //         },
+      //         schema: SchemaNone,
       //       },
       //     },
       //   },
@@ -772,10 +770,7 @@ export class Replica {
       logger.debug("pull-doc", () => [`Pulling doc: ${address.id}`]);
 
       // If we don't have a schema, use SchemaNone, which will only fetch the specified object
-      setSelector(schemaSelector, address.id, address.type, "_", {
-        path: selector.path,
-        schemaContext: { schema: selector.schema },
-      });
+      setSelector(schemaSelector, address.id, address.type, "_", selector);
       // Since we're accessing the entire document, we should base our
       // classification on the fullSchema
       const fullSchema = selector.schema ?? false;
@@ -2232,7 +2227,7 @@ export const getChanges = (
   return changes;
 };
 
-// Given an Assert statement with labels, return a SchemaContext with the ifc tags
+// Given an Assert statement with labels, return a Schema with the ifc tags
 const _generateSchemaFromLabels = (
   change: Assert | Retract | Claim,
 ): JSONSchema | undefined => {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -172,7 +172,7 @@ export interface IStorageProvider {
    * Sync a value from storage. Use `get()` to retrieve the value.
    *
    * @param uri - uri of the entity to sync.
-   * @param selector - The SchemaPathSelector with the path and schemaContext that determines what to sync.
+   * @param selector - The SchemaPathSelector with the path and schema that determines what to sync.
    * @returns Promise that resolves when the value is synced.
    */
   sync(

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1497,9 +1497,9 @@ export class SchemaObjectTraverser<V extends JSONValue>
   // Traverse the specified doc with the selector.
   // The selector should have been re-rooted if needed to be relative to the
   // specified doc. This generally means that its path starts with value.
-  // The selector must have a valid (defined) schemaContext
+  // The selector must have a valid (defined) schema
   // Once we've gotten the path of our doc to match the path of our selector,
-  // we can call traverseWithSchemaContext instead.
+  // we can call traverseWithSchema instead.
   traverseWithSelector(
     doc: IMemorySpaceAttestation,
     selector: SchemaPathSelector,


### PR DESCRIPTION
- Removed SchemaContext from the network protocol
- Updated a few comments.
- Removed a misleading `is` prpoerty from SchemaPathSelector, since this isn't honored.

Possibly, I should use a different type for the SchemaPathSelectors rooted at fact.is and those rooted at fact.is.value to avoid confusion, but I may decide to switch over the traverse variants to root them at fact.is.value instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed SchemaContext from the network protocol and selector types. SchemaPathSelector now carries schema directly, simplifying requests and payloads.

- **Refactors**
  - Replaced SchemaContextPathSelector with SchemaPathSelector across memory, runner, and traverse.
  - In SchemaSelector, each contained SchemaPathSelector’s path is relative to fact.is.value; re-rooting handled in space-schema.
  - Removed unused is property from SchemaPathSelector.
  - Updated comments and tests to the new shape.

- **Migration**
  - Build selectors as { path: [...], schema: <JSONSchema|true|false> } (no schemaContext wrapper).
  - For SchemaSelector, provide paths relative to fact.is.value; standard SchemaPathSelector remains relative to fact.is.
  - Remove any is fields from selectors.
  - Update storage calls: sync(uri, selector) now expects schema instead of schemaContext.

<sup>Written for commit f1e750cbacdb55acd131808ee6b4d156da41911c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

