### PR TITLE
Remove noisy console.log statements from journal.tsx

### DIFF
--- a/packages/patterns/system/journal.tsx
+++ b/packages/patterns/system/journal.tsx
@@ -84,14 +84,9 @@ export default pattern<Record<string, never>>((_) => {
     query: "#journal",
   });
 
-  // Debug: log raw result
+  // Debug: stringify raw result for the debug panel
   const debugRaw = computed(() => {
     const raw = journalResult.result;
-    console.log("[journal.tsx] raw journalResult.result:", raw);
-    console.log("[journal.tsx] type:", typeof raw);
-    if (Array.isArray(raw)) {
-      console.log("[journal.tsx] first entry:", raw[0]);
-    }
     return JSON.stringify(raw, null, 2);
   });
 


### PR DESCRIPTION
These debug logs were added during initial journal prototype development and are no longer needed. The debug panel UI is preserved for users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed noisy console.log statements from journal.tsx to reduce console spam sop output stays clean in dev and prod. The debug panel still shows the stringified journal result sop there are no user rustic changes.

<sup>Written for commit f5d6d02afab5de37333b29a50074524e1bd4faa1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

