### PR TITLE
fix(ts-transformers): preserve nullability with optional chaining in …

### DIFF
--- a/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.tsx
@@ -1,0 +1,329 @@
+import * as __ctHelpers from "commontools";
+import { computed, pattern, UI, NAME } from "commontools";
+// Represents a question that may or may not exist
+type Question = {
+    question: string;
+    category: string;
+    priority: number;
+};
+export default pattern((_) => {
+    // This computed can return null - simulates finding a question from a list
+    const topQuestion = __ctHelpers.derive({
+        type: "object",
+        properties: {}
+    } as const satisfies __ctHelpers.JSONSchema, {
+        anyOf: [{
+                $ref: "#/$defs/Question"
+            }, {
+                type: "null"
+            }],
+        $defs: {
+            Question: {
+                type: "object",
+                properties: {
+                    question: {
+                        type: "string"
+                    },
+                    category: {
+                        type: "string"
+                    },
+                    priority: {
+                        type: "number"
+                    }
+                },
+                required: ["question", "category", "priority"]
+            }
+        }
+    } as const satisfies __ctHelpers.JSONSchema, {}, (): Question | null => {
+        // In real code this would filter and return first match, or null
+        return null;
+    });
+    return {
+        [NAME]: "Computed Nullable Optional Chain",
+        [UI]: (<div>
+        {/* BUG CASE: Optional chaining loses nullability in schema inference */}
+        {/* The input schema should have topQuestion as anyOf [Question, null] */}
+        {/* but instead infers topQuestion as object with required "question" */}
+        <p>Optional chaining: {__ctHelpers.derive({
+            type: "object",
+            properties: {
+                topQuestion: {
+                    anyOf: [{
+                            $ref: "#/$defs/Question"
+                        }, {
+                            type: "null"
+                        }],
+                    asOpaque: true
+                }
+            },
+            required: ["topQuestion"],
+            $defs: {
+                Question: {
+                    type: "object",
+                    properties: {
+                        question: {
+                            type: "string"
+                        },
+                        category: {
+                            type: "string"
+                        },
+                        priority: {
+                            type: "number"
+                        }
+                    },
+                    required: ["question", "category", "priority"]
+                }
+            }
+        } as const satisfies __ctHelpers.JSONSchema, {
+            anyOf: [{
+                    type: "string",
+                    asOpaque: true
+                }, {
+                    type: "string",
+                    "enum": [""]
+                }]
+        } as const satisfies __ctHelpers.JSONSchema, { topQuestion: topQuestion }, ({ topQuestion }) => topQuestion?.question || "")}</p>
+
+        {/* WORKAROUND: Explicit null check preserves nullability */}
+        {/* This correctly generates anyOf [Question, null] in the schema */}
+        <p>Explicit check: {__ctHelpers.derive({
+            type: "object",
+            properties: {
+                topQuestion: {
+                    anyOf: [{
+                            $ref: "#/$defs/Question"
+                        }, {
+                            type: "null"
+                        }],
+                    asOpaque: true
+                }
+            },
+            required: ["topQuestion"],
+            $defs: {
+                Question: {
+                    type: "object",
+                    properties: {
+                        question: {
+                            type: "string"
+                        },
+                        category: {
+                            type: "string"
+                        },
+                        priority: {
+                            type: "number"
+                        }
+                    },
+                    required: ["question", "category", "priority"]
+                }
+            }
+        } as const satisfies __ctHelpers.JSONSchema, {
+            anyOf: [{
+                    type: "string",
+                    asOpaque: true
+                }, {
+                    type: "string",
+                    "enum": [""]
+                }]
+        } as const satisfies __ctHelpers.JSONSchema, { topQuestion: topQuestion }, ({ topQuestion }) => topQuestion === null ? "" : topQuestion.question)}</p>
+
+        {/* Same issue with category field */}
+        <span>Category (buggy): {__ctHelpers.derive({
+            type: "object",
+            properties: {
+                topQuestion: {
+                    anyOf: [{
+                            $ref: "#/$defs/Question"
+                        }, {
+                            type: "null"
+                        }],
+                    asOpaque: true
+                }
+            },
+            required: ["topQuestion"],
+            $defs: {
+                Question: {
+                    type: "object",
+                    properties: {
+                        question: {
+                            type: "string"
+                        },
+                        category: {
+                            type: "string"
+                        },
+                        priority: {
+                            type: "number"
+                        }
+                    },
+                    required: ["question", "category", "priority"]
+                }
+            }
+        } as const satisfies __ctHelpers.JSONSchema, {
+            anyOf: [{
+                    type: "string",
+                    asOpaque: true
+                }, {
+                    type: "string",
+                    "enum": [""]
+                }]
+        } as const satisfies __ctHelpers.JSONSchema, { topQuestion: topQuestion }, ({ topQuestion }) => topQuestion?.category || "")}</span>
+        <span>Category (works): {__ctHelpers.derive({
+            type: "object",
+            properties: {
+                topQuestion: {
+                    anyOf: [{
+                            $ref: "#/$defs/Question"
+                        }, {
+                            type: "null"
+                        }],
+                    asOpaque: true
+                }
+            },
+            required: ["topQuestion"],
+            $defs: {
+                Question: {
+                    type: "object",
+                    properties: {
+                        question: {
+                            type: "string"
+                        },
+                        category: {
+                            type: "string"
+                        },
+                        priority: {
+                            type: "number"
+                        }
+                    },
+                    required: ["question", "category", "priority"]
+                }
+            }
+        } as const satisfies __ctHelpers.JSONSchema, {
+            anyOf: [{
+                    type: "string",
+                    asOpaque: true
+                }, {
+                    type: "string",
+                    "enum": [""]
+                }]
+        } as const satisfies __ctHelpers.JSONSchema, { topQuestion: topQuestion }, ({ topQuestion }) => topQuestion === null ? "" : topQuestion.category)}</span>
+      </div>),
+    };
+}, false as const satisfies __ctHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $NAME: {
+            type: "string"
+        },
+        $UI: {
+            $ref: "#/$defs/JSXElement"
+        }
+    },
+    required: ["$NAME", "$UI"],
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "#/$defs/VNode"
+                }, {
+                    type: "object",
+                    properties: {}
+                }, {
+                    $ref: "#/$defs/UIRenderable",
+                    asOpaque: true
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "#/$defs/VNode"
+                }
+            },
+            required: ["$UI"]
+        },
+        VNode: {
+            type: "object",
+            properties: {
+                type: {
+                    type: "string",
+                    "enum": ["vnode"]
+                },
+                name: {
+                    type: "string"
+                },
+                props: {
+                    $ref: "#/$defs/Props"
+                },
+                children: {
+                    $ref: "#/$defs/RenderNode"
+                },
+                $UI: {
+                    $ref: "#/$defs/VNode"
+                }
+            },
+            required: ["type", "name", "props"]
+        },
+        RenderNode: {
+            anyOf: [{
+                    type: "string"
+                }, {
+                    type: "number"
+                }, {
+                    type: "boolean",
+                    "enum": [false]
+                }, {
+                    type: "boolean",
+                    "enum": [true]
+                }, {
+                    $ref: "#/$defs/VNode"
+                }, {
+                    type: "object",
+                    properties: {}
+                }, {
+                    $ref: "#/$defs/UIRenderable",
+                    asOpaque: true
+                }, {
+                    type: "object",
+                    properties: {}
+                }, {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/RenderNode"
+                    }
+                }, {
+                    type: "null"
+                }]
+        },
+        Props: {
+            type: "object",
+            properties: {},
+            additionalProperties: {
+                anyOf: [{
+                        type: "string"
+                    }, {
+                        type: "number"
+                    }, {
+                        type: "boolean",
+                        "enum": [false]
+                    }, {
+                        type: "boolean",
+                        "enum": [true]
+                    }, {
+                        type: "object",
+                        additionalProperties: true
+                    }, {
+                        type: "array",
+                        items: true
+                    }, {
+                        asCell: true
+                    }, {
+                        asStream: true
+                    }, {
+                        type: "null"
+                    }]
+            }
+        }
+    }
+} as const satisfies __ctHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.input.tsx
@@ -1,0 +1,37 @@
+/// <cts-enable />
+import { computed, pattern, UI, NAME } from "commontools";
+
+// Represents a question that may or may not exist
+type Question = {
+  question: string;
+  category: string;
+  priority: number;
+};
+
+export default pattern((_) => {
+  // This computed can return null - simulates finding a question from a list
+  const topQuestion = computed((): Question | null => {
+    // In real code this would filter and return first match, or null
+    return null;
+  });
+
+  return {
+    [NAME]: "Computed Nullable Optional Chain",
+    [UI]: (
+      <div>
+        {/* BUG CASE: Optional chaining loses nullability in schema inference */}
+        {/* The input schema should have topQuestion as anyOf [Question, null] */}
+        {/* but instead infers topQuestion as object with required "question" */}
+        <p>Optional chaining: {computed(() => topQuestion?.question || "")}</p>
+
+        {/* WORKAROUND: Explicit null check preserves nullability */}
+        {/* This correctly generates anyOf [Question, null] in the schema */}
+        <p>Explicit check: {computed(() => topQuestion === null ? "" : topQuestion.question)}</p>
+
+        {/* Same issue with category field */}
+        <span>Category (buggy): {computed(() => topQuestion?.category || "")}</span>
+        <span>Category (works): {computed(() => topQuestion === null ? "" : topQuestion.category)}</span>
+      </div>
+    ),
+  };
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.tsx
@@ -432,21 +432,15 @@ export default recipe(false as const satisfies __ctHelpers.JSONSchema, {
             type: "object",
             properties: {
                 typedCellRef: {
-                    type: "object",
-                    properties: {
-                        length: {
-                            type: "number"
-                        }
-                    },
-                    required: ["length"]
+                    type: "array",
+                    items: true,
+                    asOpaque: true
                 }
             },
             required: ["typedCellRef"]
         } as const satisfies __ctHelpers.JSONSchema, {
             type: "boolean"
-        } as const satisfies __ctHelpers.JSONSchema, { typedCellRef: {
-                length: typedCellRef?.length
-            } }, ({ typedCellRef }) => !typedCellRef?.length), <div>No charms created yet</div>, <ul>
+        } as const satisfies __ctHelpers.JSONSchema, { typedCellRef: typedCellRef }, ({ typedCellRef }) => !typedCellRef?.length), <div>No charms created yet</div>, <ul>
             {typedCellRef.mapWithPattern(__ctHelpers.recipe({
                 type: "object",
                 properties: {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-captures.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-captures.expected.tsx
@@ -304,10 +304,11 @@ export default recipe({
                                 type: "object",
                                 properties: {
                                     value: {
-                                        type: "number",
-                                        asOpaque: true
+                                        type: "number"
                                     }
-                                }
+                                },
+                                required: ["value"],
+                                asOpaque: true
                             }
                         }
                     }
@@ -322,9 +323,7 @@ export default recipe({
                         asOpaque: true
                     }]
             } as const satisfies __ctHelpers.JSONSchema, { item: {
-                    maybe: {
-                        value: item.maybe?.value
-                    }
+                    maybe: item.maybe
                 } }, ({ item }) => item.maybe?.value ?? 0)}</span>)), {})}
       </div>),
     };


### PR DESCRIPTION
…schema inference

When using optional chaining (e.g., `topQuestion?.question`) in a computed, the schema inference was incorrectly descending into the property and losing nullability information. This caused the input schema to require the object to exist, even though optional chaining explicitly handles the null case.

The fix detects optional chaining in `parseCaptureExpression()` and stops at the expression before the `?.` operator, preserving the full nullable type (e.g., `anyOf [Question, null]`) in the generated schema.

Before: `topQuestion?.question` generated schema requiring `topQuestion.question`
After: `topQuestion?.question` generates schema allowing `topQuestion` to be null

This matches the behavior of explicit null checks like: `topQuestion === null ? "" : topQuestion.question`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix schema inference to preserve nullability when optional chaining is used (e.g., topQuestion?.question), so inputs no longer require the object to exist when the chain handles null.

- **Bug Fixes**
  - Detect optional chaining in parseCaptureExpression and stop at the expression before ?. 
  - Preserve nullable types in generated schemas (e.g., anyOf [Question, null]) to match explicit null checks.
  - Update JSX fixtures to capture the parent object instead of descending into properties when using optional chaining.

- **Tests**
  - Add computed-nullable-optional-chain fixture to validate nullable optional chains in computed expressions.
  - Adjust expected outputs for opaque-ref-cell-map and optional-chain-captures to reflect the new capture behavior.

<sup>Written for commit c3b45d46c09132529e3f1e2a728ee543fb738a5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

