### PR TITLE
feat(scripts): make ports configurable for local dev scripts

### DIFF
--- a/packages/shell/deno.json
+++ b/packages/shell/deno.json
@@ -6,7 +6,7 @@
     "production": "deno task clean && PRODUCTION=1 deno run -A ../felt/cli.ts build .",
     "serve": "deno run -A ../felt/cli.ts serve .",
     "dev": "deno task clean && API_URL=https://toolshed.saga-castor.ts.net deno run -A ../felt/cli.ts dev .",
-    "dev-local": "deno task clean && API_URL=http://localhost:8000 deno run -A ../felt/cli.ts dev .",
+    "dev-local": "deno task clean && API_URL=http://localhost:${TOOLSHED_PORT:-8000} deno run -A ../felt/cli.ts dev .",
     "dev-clusterduck": "deno task clean && API_URL='http://localhost:7001' deno run -A ../felt/cli.ts dev .",
     "integration": "LOG_LEVEL=warn deno test -A ./integration/*.test.ts",
     "test": "deno test test/*.test.ts"

--- a/packages/shell/felt.config.ts
+++ b/packages/shell/felt.config.ts
@@ -3,6 +3,8 @@ import { type Config } from "@commontools/felt";
 const PRODUCTION = !!Deno.env.get("PRODUCTION");
 const ENVIRONMENT = PRODUCTION ? "production" : "development";
 
+const SHELL_PORT = parseInt(Deno.env.get("SHELL_PORT") || "5173", 10);
+
 const config: Config = {
   entries: [
     { in: "src/index.ts", out: "scripts/index" },
@@ -13,7 +15,7 @@ const config: Config = {
   ],
   outDir: "dist",
   hostname: "127.0.0.1",
-  port: 5173,
+  port: SHELL_PORT,
   publicDir: "public",
   watchDir: "src",
   redirectToIndex: /^\/(?!((assets|scripts|styles|static)\/.*))/,

--- a/scripts/start-local-dev.sh
+++ b/scripts/start-local-dev.sh
@@ -6,6 +6,11 @@ cd "$SCRIPT_DIR/.."
 # Source shared utilities
 source "$SCRIPT_DIR/common/port-utils.sh"
 
+# Default ports and offset
+PORT_OFFSET=${PORT_OFFSET:-0}
+SHELL_PORT=${SHELL_PORT:-}
+TOOLSHED_PORT=${TOOLSHED_PORT:-}
+
 # Parse command line arguments
 FORCE=false
 while [[ $# -gt 0 ]]; do
@@ -14,11 +19,43 @@ while [[ $# -gt 0 ]]; do
             FORCE=true
             shift
             ;;
+        --port-offset)
+            PORT_OFFSET="$2"
+            shift 2
+            ;;
+        --port-offset=*)
+            PORT_OFFSET="${1#*=}"
+            shift
+            ;;
+        --shell-port)
+            SHELL_PORT="$2"
+            shift 2
+            ;;
+        --shell-port=*)
+            SHELL_PORT="${1#*=}"
+            shift
+            ;;
+        --toolshed-port)
+            TOOLSHED_PORT="$2"
+            shift 2
+            ;;
+        --toolshed-port=*)
+            TOOLSHED_PORT="${1#*=}"
+            shift
+            ;;
         *)
             shift
             ;;
     esac
 done
+
+# Apply offset to default ports if not explicitly set
+SHELL_PORT=${SHELL_PORT:-$((5173 + PORT_OFFSET))}
+TOOLSHED_PORT=${TOOLSHED_PORT:-$((8000 + PORT_OFFSET))}
+
+# Export for child processes
+export SHELL_PORT
+export TOOLSHED_PORT
 
 # Check if port is free; kill processes if --force, otherwise error
 check_port() {
@@ -45,8 +82,8 @@ check_port() {
     fi
 }
 
-check_port 8000
-check_port 5173
+check_port "$TOOLSHED_PORT"
+check_port "$SHELL_PORT"
 
 # Start shell dev server in background
 cd packages/shell
@@ -58,7 +95,7 @@ sleep 2
 
 # Start toolshed dev server in background
 cd ../toolshed
-SHELL_URL=http://localhost:5173 deno task dev > local-dev-toolshed.log 2>&1 &
+SHELL_URL="http://localhost:$SHELL_PORT" PORT="$TOOLSHED_PORT" deno task dev > local-dev-toolshed.log 2>&1 &
 TOOLSHED_PID=$!
 
 # # Function to cleanup background processes
@@ -75,6 +112,10 @@ sleep 3
 
 # Print the toolshed URL on success
 echo "Development servers started successfully!"
-echo "Toolshed URL: http://localhost:8000"
+echo "  Shell:    http://localhost:$SHELL_PORT"
+echo "  Toolshed: http://localhost:$TOOLSHED_PORT"
+if [[ "$PORT_OFFSET" -ne 0 ]]; then
+    echo "  Offset:   $PORT_OFFSET"
+fi
 echo "Shell log file: packages/shell/local-dev-shell.log"
 echo "Toolshed log file: packages/toolshed/local-dev-toolshed.log"

--- a/scripts/stop-local-dev.sh
+++ b/scripts/stop-local-dev.sh
@@ -1,7 +1,49 @@
 #!/usr/bin/env bash
-# Kill any deno process on ports 5173 and 8000
+# Kill any deno process on the specified ports
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPT_DIR/common/port-utils.sh"
+
+# Default ports and offset
+PORT_OFFSET=${PORT_OFFSET:-0}
+SHELL_PORT=${SHELL_PORT:-}
+TOOLSHED_PORT=${TOOLSHED_PORT:-}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --port-offset)
+            PORT_OFFSET="$2"
+            shift 2
+            ;;
+        --port-offset=*)
+            PORT_OFFSET="${1#*=}"
+            shift
+            ;;
+        --shell-port)
+            SHELL_PORT="$2"
+            shift 2
+            ;;
+        --shell-port=*)
+            SHELL_PORT="${1#*=}"
+            shift
+            ;;
+        --toolshed-port)
+            TOOLSHED_PORT="$2"
+            shift 2
+            ;;
+        --toolshed-port=*)
+            TOOLSHED_PORT="${1#*=}"
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+# Apply offset to default ports if not explicitly set
+SHELL_PORT=${SHELL_PORT:-$((5173 + PORT_OFFSET))}
+TOOLSHED_PORT=${TOOLSHED_PORT:-$((8000 + PORT_OFFSET))}
 
 # Kill deno processes listening on a specific port
 kill_deno_on_port() {
@@ -17,5 +59,5 @@ kill_deno_on_port() {
     done
 }
 
-kill_deno_on_port 5173
-kill_deno_on_port 8000
+kill_deno_on_port "$SHELL_PORT"
+kill_deno_on_port "$TOOLSHED_PORT"


### PR DESCRIPTION
## Summary
- Add `--port-offset`, `--shell-port`, and `--toolshed-port` flags to local dev scripts
- Enables running multiple dev instances simultaneously by offsetting ports
- Supports both command line arguments and environment variables

Motivation: Makes it easier to run multiple instances at the same time via PORT_OFFSET=N in the environment when running e.g. Claude Code.

## Usage
```bash
# Run second instance (shell=5174, toolshed=8001)
./scripts/start-local-dev.sh --port-offset 1

# Custom ports
./scripts/start-local-dev.sh --shell-port 3000 --toolshed-port 9000

# Via environment
SHELL_PORT=3000 TOOLSHED_PORT=9000 ./scripts/start-local-dev.sh
```

## Test plan
- [x] Run `./scripts/start-local-dev.sh` (default ports 5173/8000)
- [x] Run `./scripts/start-local-dev.sh --port-offset 1` (ports 5174/8001)
- [x] Verify both instances can run simultaneously
- [x] Test `./scripts/stop-local-dev.sh --port-offset 1` stops correct instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)