### PR TITLE
fix(shell): use Deno-compatible env var syntax in dev-local task

### DIFF
--- a/packages/shell/deno.json
+++ b/packages/shell/deno.json
@@ -6,7 +6,7 @@
     "production": "deno task clean && PRODUCTION=1 deno run -A ../felt/cli.ts build .",
     "serve": "deno run -A ../felt/cli.ts serve .",
     "dev": "deno task clean && API_URL=https://toolshed.saga-castor.ts.net deno run -A ../felt/cli.ts dev .",
-    "dev-local": "deno task clean && API_URL=http://localhost:${TOOLSHED_PORT:-8000} deno run -A ../felt/cli.ts dev .",
+    "dev-local": "deno task clean && API_URL=http://localhost:$TOOLSHED_PORT deno run -A ../felt/cli.ts dev .",
     "dev-clusterduck": "deno task clean && API_URL='http://localhost:7001' deno run -A ../felt/cli.ts dev .",
     "integration": "LOG_LEVEL=warn deno test -A ./integration/*.test.ts",
     "test": "deno test test/*.test.ts"

--- a/scripts/start-local-dev.sh
+++ b/scripts/start-local-dev.sh
@@ -87,7 +87,7 @@ check_port "$SHELL_PORT"
 
 # Start shell dev server in background
 cd packages/shell
-deno task dev-local > local-dev-shell.log 2>&1 &
+TOOLSHED_PORT="$TOOLSHED_PORT" deno task dev-local > local-dev-shell.log 2>&1 &
 SHELL_PID=$!
 
 # Wait a moment for shell to start


### PR DESCRIPTION
Deno's task runner uses a cross-platform shell that doesn't support bash-style parameter expansion like ${VAR:-default}.

Changes:
- Use simple $TOOLSHED_PORT syntax in dev-local task
- Explicitly pass TOOLSHED_PORT env var in start-local-dev.sh

The start script already sets TOOLSHED_PORT with a default of 8000, so this maintains the same behavior while fixing the parsing error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix dev-local task to use Deno-compatible env var syntax and remove parsing errors. Use $TOOLSHED_PORT in deno.json and pass it from start-local-dev.sh, preserving the 8000 default.

<sup>Written for commit bffe0232d76337b7e052af621504fc51f47fa2dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

