### PR TITLE
fix(runtime-client): wrap CellHandle.toJSON() in sigil link format

### DIFF
--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -266,8 +266,14 @@ export class CellHandle<T = unknown> {
     };
   }
 
-  toJSON(): CellRef {
-    return { ...this.ref() };
+  toJSON() {
+    // Wrap in sigil link format so the runtime recognizes this as a link
+    // and dereferences it (e.g., when passed through event.detail.sourceCell)
+    return {
+      "/": {
+        [LINK_V1_TAG]: { ...this.ref() },
+      },
+    };
   }
 
   // Called when cell has been updated from the backend with


### PR DESCRIPTION
CellHandle.toJSON() was returning a raw CellRef object, but the runtime only auto-dereferences links in sigil format ({"/": {"link@1": ...}}).

This caused event.detail.sourceCell.get() to return undefined when using ct-drag-source and ct-drop-zone for drag-and-drop, because the CellRef was treated as raw data instead of being resolved to the actual cell value.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wraps CellHandle.toJSON() in sigil link format so the runtime auto-dereferences links. Fixes ct-drag-source/ct-drop-zone where event.detail.sourceCell.get() returned undefined; it now resolves to the cell value.

<sup>Written for commit 900a62dd0b94a9939dab3fa7040d0ac237302df0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

