### PR TITLE
Fix `compiler.tsx` import so the example code compiles

### DIFF
--- a/packages/patterns/compiler.tsx
+++ b/packages/patterns/compiler.tsx
@@ -14,7 +14,7 @@ import {
 type Input = {
   code: Default<
     string,
-    '/// <cts-enable />\nimport { computed, Default, handler, NAME, pattern, UI } from "commontools";\n\ninterface Input {\n  value: Default<number, 0>;\n}\n\nconst increment = handler<unknown, { value: Writable<number> }>((_, state) => {\n  state.value.set(state.value.get() + 1);\n});\n\nconst decrement = handler<unknown, { value: Writable<number> }>((_, state) => {\n  state.value.set(state.value.get() - 1);\n});\n\nexport default pattern<Input>(({ value }) => {\n  return {\n    [NAME]: computed(() => `Simple counter: ${value}`),\n    [UI]: (\n      <div>\n        <ct-button onClick={decrement({ value })}>-</ct-button>\n        <b>{value}</b>\n        <ct-button onClick={increment({ value })}>+</ct-button>\n      </div>\n    ),\n    value,\n  };\n});\n'
+    '/// <cts-enable />\nimport { computed, Default, handler, NAME, pattern, UI, Writable } from "commontools";\n\ninterface Input {\n  value: Default<number, 0>;\n}\n\nconst increment = handler<unknown, { value: Writable<number> }>((_, state) => {\n  state.value.set(state.value.get() + 1);\n});\n\nconst decrement = handler<unknown, { value: Writable<number> }>((_, state) => {\n  state.value.set(state.value.get() - 1);\n});\n\nexport default pattern<Input>(({ value }) => {\n  return {\n    [NAME]: computed(() => `Simple counter: ${value}`),\n    [UI]: (\n      <div>\n        <ct-button onClick={decrement({ value })}>-</ct-button>\n        <b>{value}</b>\n        <ct-button onClick={increment({ value })}>+</ct-button>\n      </div>\n    ),\n    value,\n  };\n});\n'
   >;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added Writable to the commontools import in the embedded example in compiler.tsx, fixing the missing type so the counter example compiles without TypeScript errors.

<sup>Written for commit 3f8d647624b241ece4d96f9f590b58f3b4ae96f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

