### PR TITLE
feat(backlinks-index): recursively collect nested mentionables

### DIFF
--- a/packages/patterns/examples/nested-mentionables.tsx
+++ b/packages/patterns/examples/nested-mentionables.tsx
@@ -1,0 +1,47 @@
+/// <cts-enable />
+import { computed, NAME, pattern, UI } from "commontools";
+
+interface Node {
+  label: string;
+  children: Node[];
+}
+
+const TREE: Node = {
+  label: "Root",
+  children: [
+    {
+      label: "A",
+      children: [
+        { label: "A.1", children: [] },
+        { label: "A.2", children: [{ label: "A.2.x", children: [] }] },
+      ],
+    },
+    {
+      label: "B",
+      children: [{ label: "B.1", children: [] }],
+    },
+  ],
+};
+
+function toMentionable(node: Node): any {
+  return {
+    [NAME]: node.label,
+    [UI]: <div>{node.label}</div>,
+    mentionable: computed(() => node.children.map(toMentionable)),
+  };
+}
+
+export default pattern<Record<string, never>>((_) => {
+  const mentionables = TREE.children.map(toMentionable);
+
+  return {
+    [NAME]: "Nested Mentionables Test",
+    [UI]: (
+      <div>
+        <p>This pattern exports a recursive mentionable tree:</p>
+        <pre>{JSON.stringify(TREE, null, 2)}</pre>
+      </div>
+    ),
+    mentionable: computed(() => mentionables),
+  };
+});

--- a/packages/patterns/system/backlinks-index.tsx
+++ b/packages/patterns/system/backlinks-index.tsx
@@ -75,33 +75,44 @@ const computeIndex = lift<
  * its `[NAME]`). This mirrors how existing note patterns identify notes when
  * computing backlinks locally.
  */
+const MAX_MENTIONABLE_DEPTH = 5;
+
 const computeMentionable = lift<
   { allPieces: MentionablePiece[] },
   MentionablePiece[]
 >(({ allPieces: pieceList }) => {
   const cs = pieceList ?? [];
   const out: MentionablePiece[] = [];
-  for (const c of cs) {
-    // Skip undefined/null entries that may exist in the array
-    if (!c) continue;
-    // Skip pieces explicitly marked as not mentionable (like note-md viewer pieces)
-    // Note: We check isMentionable === false, not isHidden, because notes in
-    // notebooks are hidden but should still be mentionable
-    if (c.isMentionable === false) continue;
-    out.push(c);
-    const exported = c.mentionable;
+
+  function isVisited(piece: MentionablePiece): boolean {
+    return out.some((other) => equals(piece, other));
+  }
+
+  function collect(piece: MentionablePiece, depth: number) {
+    if (!piece || piece.isMentionable === false) return;
+    if (isVisited(piece)) return;
+    out.push(piece);
+
+    if (depth >= MAX_MENTIONABLE_DEPTH) return;
+
+    const exported = piece.mentionable;
+    let items: MentionablePiece[] = [];
     if (Array.isArray(exported)) {
-      for (const m of exported) if (m && m.isMentionable !== false) out.push(m);
+      items = exported;
     } else if (exported && typeof (exported as any).get === "function") {
-      const arr = (exported as { get: () => MentionablePiece[] }).get() ??
-        [];
-      for (const m of arr) if (m && m.isMentionable !== false) out.push(m);
+      items = (exported as { get: () => MentionablePiece[] }).get() ?? [];
+    }
+
+    for (const m of items) {
+      collect(m, depth + 1);
     }
   }
-  // Deduplicate using equals()
-  return out.filter(
-    (item, index) => out.findIndex((other) => equals(item, other)) === index,
-  );
+
+  for (const c of cs) {
+    collect(c, 0);
+  }
+
+  return out;
 });
 
 const BacklinksIndex = pattern<Input, Output>(({ allPieces }) => {


### PR DESCRIPTION
Replace the flat one-level mentionable collection with a recursive
collect that descends into each piece's mentionable exports. Cycle
detection via equals() and a max depth of 5 prevent infinite loops.

Add nested-mentionables example pattern for testing.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backlinks index now recursively collects nested mentionables, so deeply nested lists are indexed. Addresses Linear CT-1210: recursively discover mentionable lists.

- **New Features**
  - Descends into each piece’s mentionable exports (not just one level).
  - Prevents cycles with equals() and limits depth to 5.
  - Adds nested-mentionables example pattern for testing.

<sup>Written for commit b9ade379018117b3894efde32d914dc5f7ff23d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

