### PR TITLE
fix(schema-generator): resolve orphaned $ref for recursive types with…

### DIFF
--- a/packages/schema-generator/test/fixtures/schema/writable-recursive-todoitem.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/writable-recursive-todoitem.expected.json
@@ -1,0 +1,42 @@
+{
+  "$defs": {
+    "AnonymousType_1": {
+      "items": {
+        "$ref": "#/$defs/TodoItem"
+      },
+      "type": "array"
+    },
+    "TodoItem": {
+      "properties": {
+        "done": {
+          "default": false,
+          "type": "boolean"
+        },
+        "items": {
+          "$ref": "#/$defs/AnonymousType_1",
+          "asCell": true,
+          "default": []
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "done",
+        "items",
+        "title"
+      ],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "todos": {
+      "$ref": "#/$defs/AnonymousType_1",
+      "default": []
+    }
+  },
+  "required": [
+    "todos"
+  ],
+  "type": "object"
+}

--- a/packages/schema-generator/test/fixtures/schema/writable-recursive-todoitem.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/writable-recursive-todoitem.input.ts
@@ -1,0 +1,14 @@
+// CT-1215: Recursive type with Writable<> wrapper creates orphaned $ref
+// Uses the real Cell/Writable branded interface (provided by test prelude)
+
+type Default<T, V extends T = T> = T;
+
+export interface TodoItem {
+  title: string;
+  done: Default<boolean, false>;
+  items: Writable<Default<TodoItem[], []>>;
+}
+
+interface SchemaRoot {
+  todos: Default<TodoItem[], []>;
+}


### PR DESCRIPTION
… Cell-like wrappers [CT-1215]

- Fix orphaned $ref when recursive types use Writable<>/Cell<> wrappers (e.g. items: Writable<Default<TodoItem[], []>> inside TodoItem)                   
  - Add regression test fixture (writable-recursive-todoitem)                      
                                                                                                                                                            
  Problem                                                                          

  When a type recursively references itself through a Cell-like wrapper, TypeScript reuses the same Cell<TodoItem[]> type object for every occurrence of
  that instantiation. The schema generator's identity-based cycle detector (definitionStack) catches this at the wrapper level, where isWrapperContext=true
  suppresses definition storage. Result: $ref: "#/$defs/AnonymousType_1" is emitted but AnonymousType_1 is never added to $defs.

  Fix

  Extend createStackKey() to give Cell-like wrappers (Cell, Writable, Stream, OpaqueRef) position-unique stack keys — the same treatment Default already
  had. This prevents cycle detection from firing at the wrapper level, allowing it to fire at the inner type level (e.g. the named TodoItem type) where it
  resolves correctly.

  Test plan

  - New fixture writable-recursive-todoitem reproduces the exact pattern from the issue
  - All 157 existing test steps pass with no regressions
  - deno task ct check on a real pattern with Writable<Default<TodoItem[], []>> passes cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes orphaned $ref in the schema generator when recursive types use Cell-like wrappers, so referenced types are properly emitted in $defs. Addresses CT-1215.

- **Bug Fixes**
  - Assign position-unique stack keys to Cell-like wrappers (Cell, Writable, Stream, OpaqueRef) in createStackKey to push cycle detection to the inner named type.
  - Add regression fixture: writable-recursive-todoitem.
  - Verified no regressions; existing tests pass.

<sup>Written for commit 0d142d4241bc46de4177ea30b90dc496c8256049. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

