### PR TITLE
feat(runner): add keepAsOpaque option to sanitizeSchemaForLinks

### DIFF
--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -996,6 +996,21 @@ describe("link-utils", () => {
       ).toBeDefined();
       expect(() => JSON.stringify(result)).not.toThrow();
     });
+
+    it("should handle keepAsOpaque option", () => {
+      const schema: any = {
+        type: "object",
+        asOpaque: true,
+      };
+
+      // By default, asOpaque should be removed
+      const resultDefault = sanitizeSchemaForLinks(schema);
+      expect((resultDefault as any).asOpaque).toBeUndefined();
+
+      // With keepAsOpaque: true, it should be preserved
+      const resultKept = sanitizeSchemaForLinks(schema, { keepAsOpaque: true });
+      expect((resultKept as any).asOpaque).toBe(true);
+    });
   });
 
   describe("createDataCellURI", () => {


### PR DESCRIPTION
This change adds support for preserving 'asOpaque' property in schemas when sanitizing them for links, controllable via a new option. Includes tests verifying this behavior.

While asOpaque is so far a no-op it's more like asCell in the future. For now a separate flag, and I expect we actually change the as* format soon anyway. For now, this means that links won't have extraneous asOpaque in them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds keepAsOpaque option to sanitizeSchemaForLinks to optionally preserve the asOpaque flag when preparing schemas for links. Also wires this option into createSigilLinkFromParsedLink.

- New Features
  - New SanitizeSchemaForLinksOptions: keepAsOpaque, keepAsCell, keepStreams (defaults strip all).
  - Sanitizer now respects these options when producing link-safe schemas.
  - createSigilLinkFromParsedLink accepts and forwards the options; tests added for keepAsOpaque behavior.

<sup>Written for commit 757e0d7d4aea1998b3c301f2447e03fd45c9ea4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

