### PR TITLE
docs(patterns): update index.md with corrected paths and curated pattern set

### DIFF
--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -3,7 +3,9 @@
 Prefix the URLs with
 `https://raw.githubusercontent.com/commontoolsinc/labs/refs/heads/main/packages/patterns/`
 
-## `counter.tsx`
+---
+
+## `counter/counter.tsx`
 
 A simple counter demo.
 
@@ -11,31 +13,25 @@ A simple counter demo.
 
 ```ts
 interface CounterInput {
-  value: number;
+  value?: Writable<Default<number, 0>>;
 }
 ```
 
-### Result Schema
+### Output Schema
 
 ```ts
 interface CounterOutput {
-  value?: number;
+  value: number;
   increment: Stream<void>;
   decrement: Stream<void>;
 }
 ```
 
-## `todo-list.tsx`
+## `todo-list/todo-list.tsx`
 
 A todo list with AI suggestions.
 
 ### Input Schema
-
-```ts
-interface Input {}
-```
-
-### Result Schema
 
 ```ts
 interface TodoItem {
@@ -43,140 +39,107 @@ interface TodoItem {
   done: Default<boolean, false>;
 }
 
+interface TodoListInput {
+  items?: Writable<Default<TodoItem[], []>>;
+}
+```
+
+### Output Schema
+
+```ts
+interface TodoListOutput {
+  items: TodoItem[];
+  itemCount: number;
+  addItem: Stream<{ title: string }>;
+  removeItem: Stream<{ item: TodoItem }>;
+}
+```
+
+## `simple-list/simple-list.tsx`
+
+A checklist with indent support. Works standalone or embedded in Record
+containers.
+
+**Keywords:** checklist, indentation, composable
+
+### Input Schema
+
+```ts
+interface SimpleListItem {
+  text: string;
+  indented: Default<boolean, false>;
+  done: Default<boolean, false>;
+}
+
+interface SimpleListInput {
+  items?: Writable<Default<SimpleListItem[], []>>;
+}
+```
+
+### Output Schema
+
+```ts
+interface SimpleListOutput {
+  items: SimpleListItem[];
+  addItem: Stream<{ text: string }>;
+  deleteItem: Stream<{ index: number }>;
+  toggleIndent: Stream<{ index: number }>;
+}
+```
+
+## `shopping-list.tsx`
+
+Shopping list with AI-powered aisle sorting. Pair with `store-mapper.tsx` for
+store-specific layouts.
+
+**Keywords:** shopping, groceries, AI-sorting, generateObject
+
+### Input Schema
+
+```ts
+interface ShoppingItem {
+  title: string;
+  done: Default<boolean, false>;
+  aisleSeed: Default<number, 0>;
+  aisleOverride: Default<string, "">;
+}
+
+interface Input {
+  items: Writable<Default<ShoppingItem[], []>>;
+  storeLayout: Writable<Default<string, "">>;
+}
+```
+
+### Output Schema
+
+```ts
 interface Output {
-  items: Writable<TodoItem[]>;
+  items: ShoppingItem[];
+  totalCount: number;
+  doneCount: number;
+  remainingCount: number;
+  storeLayout: string;
+  addItem: OpaqueRef<Stream<{ detail: { message: string } }>>;
+  addItems: OpaqueRef<Stream<{ itemNames: string[] }>>;
 }
 ```
 
 ## `notes/note.tsx`
 
-A note demo.
+A note with wiki-links, backlinks, and embedding support. Managed by
+`notes/notebook.tsx`.
 
-### Input Schema
-
-```ts
-type NoteInput = {
-  /** The title of the note */
-  title: string;
-  /** The content of the note */
-  content: string;
-};
-```
-
-### Result Schema
-
-```ts
-type NoteOutput = {
-  /** The content of the note */
-  content: string;
-  grep: Stream<{ query: string }>;
-  translate: Stream<{ language: string }>;
-  editContent: Stream<{ detail: { value: string } }>;
-};
-```
-
-## `gpa-stats-source.tsx`
-
-Source piece for piece linking example. Computes statistics from GPA data and
-exposes them for other pieces to consume.
-
-**Keywords:** piece-linking, source, lift, computed-stats
-
-### Input Schema
-
-```ts
-interface Input {
-  name: Default<string, "gpa-source-v1">;
-  rawData: Default<string, "">;
-}
-```
-
-### Output Schema
-
-```ts
-interface Stats {
-  average: number;
-  count: number;
-  min: number;
-  max: number;
-}
-
-interface Output {
-  name: string;
-  rawData: string;
-  gpaStats: Stats | null; // Exposed for linking
-}
-```
-
-## `gpa-stats-reader.tsx`
-
-Consumer piece for piece linking example. Receives linked statistics from
-gpa-stats-source and displays them.
-
-**Keywords:** piece-linking, consumer, Default-null
-
-### Input Schema
-
-```ts
-interface Stats {
-  average: number;
-  count: number;
-  min: number;
-  max: number;
-}
-
-interface Input {
-  name: Default<string, "gpa-reader-v1">;
-  gpaStats: Default<Stats | null, null>; // null until linked
-}
-```
-
-## `chatbot.tsx`
-
-Full-featured AI chat assistant with tool support, model selection, and
-mentionables. Deploy this to have a conversational AI interface.
-
-**Keywords:** llm, chat, tools, llmDialog, generateObject
-
-### Input Schema
-
-```ts
-type ChatInput = {
-  messages?: Writable<Default<Array<BuiltInLLMMessage>, []>>;
-  tools?: any;
-  theme?: any;
-  system?: string;
-};
-```
-
-### Output Schema
-
-```ts
-type ChatOutput = {
-  messages: Array<BuiltInLLMMessage>;
-  pending: boolean | undefined;
-  addMessage: Stream<BuiltInLLMMessage>;
-  clearChat: Stream<void>;
-  cancelGeneration: Stream<void>;
-  title?: string;
-  pinnedCells: Array<PromptAttachment>;
-  tools: any;
-};
-```
-
-## `examples/profile-aware-writer.tsx`
-
-Example pattern demonstrating how to use the `#profile` wish to personalize LLM
-output. Fetches the user's profile summary and injects it into the system prompt
-for personalized text generation.
-
-**Keywords:** profile, wish, generateText, llm, personalization
+**Keywords:** note, wiki-links, backlinks, embedding
 
 ### Input Schema
 
 ```ts
 type Input = {
-  topic?: Writable<Default<string, "">>;
+  title?: Writable<Default<string, "Untitled Note">>;
+  content?: Writable<Default<string, "">>;
+  isHidden?: Default<boolean, false>;
+  noteId?: Default<string, "">;
+  parentNotebook?: any;
 };
 ```
 
@@ -184,9 +147,53 @@ type Input = {
 
 ```ts
 type Output = {
-  topic: string;
-  response: BuiltInLLMContent;
+  content: string;
+  isHidden: boolean;
+  noteId: string;
+  backlinks: MentionablePiece[];
+  grep: PatternToolResult<{ content: string }>;
+  translate: PatternToolResult<{ content: string }>;
+  editContent: Stream<{ detail: { value: string } }>;
 };
+```
+
+## `notes/notebook.tsx`
+
+Notebook pattern managing notes and nested notebooks. Creates and organizes
+`notes/note.tsx` pieces.
+
+**Keywords:** notebook, notes, nested, navigateTo
+
+### Input Schema
+
+```ts
+interface Input {
+  title?: Default<string, "Notebook">;
+  notes?: Writable<Default<NotePiece[], []>>;
+  isNotebook?: Default<boolean, true>;
+  isHidden?: Default<boolean, false>;
+  parentNotebook?: any;
+}
+```
+
+### Output Schema
+
+```ts
+interface Output {
+  title: string;
+  notes: NotePiece[];
+  noteCount: number;
+  isNotebook: boolean;
+  isHidden: boolean;
+  backlinks: MentionablePiece[];
+  createNote: Stream<{ title: string; content: string }>;
+  createNotes: Stream<{ notesData: Array<{ title: string; content: string }> }>;
+  setTitle: Stream<{ newTitle: string }>;
+  createNotebook: Stream<{
+    title: string;
+    notesData?: Array<{ title: string; content: string }>;
+  }>;
+}
 ```
 
 ## `notes/voice-note.tsx`
@@ -222,88 +229,69 @@ type Output = {
 };
 ```
 
-## `image-analysis.tsx`
+## `calendar/calendar.tsx`
 
-Upload images and get AI-powered analysis and descriptions. Supports multiple
-images with customizable prompts.
+Calendar for managing events with date and time. Events are sorted by date with
+today highlighted.
 
-**Keywords:** vision, image, generateText, ct-image-input
-
-### Input Schema
-
-```ts
-type ImageChatInput = {
-  systemPrompt?: string;
-  model?: string;
-};
-```
-
-### Output Schema
-
-```ts
-type ImageChatOutput = {
-  images: Writable<ImageData[]>;
-  prompt: Writable<string>;
-  response: string | undefined;
-  pending: boolean | undefined;
-};
-```
-
-## `scrabble/scrabble.tsx`
-
-Free-for-all multiplayer Scrabble game with lobby, tile bag, game board, and
-scoring. Two players can join and play simultaneously.
-
-**Keywords:** game, multiplayer, scrabble, navigateTo
+**Keywords:** calendar, events, dates, navigateTo
 
 ### Input Schema
 
 ```ts
-interface LobbyInput {
-  gameName: Default<string, "Scrabble Match">;
-  boardJson: Writable<Default<string, "">>;
-  bagJson: Writable<Default<string, "">>;
-  bagIndex: Writable<Default<number, 0>>;
-  playersJson: Writable<Default<string, "[]">>;
-  gameEventsJson: Writable<Default<string, "[]">>;
-  allRacksJson: Writable<Default<string, "{}">>;
-  allPlacedJson: Writable<Default<string, "{}">>;
+interface CalendarInput {
+  events?: Writable<Default<EventPiece[], []>>;
 }
 ```
 
 ### Output Schema
 
 ```ts
-interface LobbyOutput {
-  gameName: string;
-  boardJson: string;
-  bagJson: string;
-  bagIndex: number;
-  playersJson: string;
-  gameEventsJson: string;
-  allRacksJson: string;
-  allPlacedJson: string;
+interface CalendarOutput {
+  events: EventPiece[];
+  sortedEvents: EventPiece[];
+  todayDate: string;
+  addEvent: Stream<{ title: string; date: string; time: string }>;
+  removeEvent: Stream<{ event: EventPiece }>;
 }
 ```
 
-## `system/favorites-manager.tsx`
+## `weekly-calendar/weekly-calendar.tsx`
 
-View and manage favorited pieces with tags. Uses the wish system to query
-`#favorites` and allows removing items.
+Weekly calendar with drag-and-drop event creation and resizing. Manages
+`weekly-calendar/event.tsx` pieces.
 
-**Keywords:** favorites, wish, ct-cell-link
+**Keywords:** weekly, calendar, drag-drop, events, navigateTo
 
 ### Input Schema
 
 ```ts
-type Input = Record<string, never>;
+interface Input {
+  title?: Default<string, "Weekly Calendar">;
+  events: Writable<Default<EventPiece[], []>>;
+  isCalendar?: Default<boolean, true>;
+  isHidden?: Default<boolean, false>;
+}
 ```
 
 ### Output Schema
 
 ```ts
-// Uses wish<Array<Favorite>>({ query: "#favorites" }) internally
-// Displays favorited pieces with remove functionality
+interface Output {
+  title: string;
+  events: EventPiece[];
+  eventCount: number;
+  isCalendar: boolean;
+  isHidden: boolean;
+  backlinks: MentionablePiece[];
+  createEvent: Stream<{
+    title: string;
+    date: string;
+    startTime: string;
+    endTime: string;
+  }>;
+  setTitle: Stream<{ newTitle: string }>;
+}
 ```
 
 ## `contacts/contact-book.tsx`
@@ -332,7 +320,7 @@ interface Relationship {
   label: Default<string, "">;
 }
 
-interface Input {
+interface ContactBookInput {
   contacts: Writable<Default<Contact[], []>>;
   relationships: Writable<Default<Relationship[], []>>;
 }
@@ -341,13 +329,14 @@ interface Input {
 ### Output Schema
 
 ```ts
-interface Output {
+interface ContactBookOutput {
   contacts: Contact[];
   relationships: Relationship[];
+  onAddContact: Stream<void>;
 }
 ```
 
-## `habit-tracker.tsx`
+## `habit-tracker/habit-tracker.tsx`
 
 Track daily habits with streak counting and 7-day history visualization. Mark
 habits complete for today and see your progress over time.
@@ -369,7 +358,7 @@ interface HabitLog {
   completed: boolean;
 }
 
-interface Input {
+interface HabitTrackerInput {
   habits: Writable<Default<Habit[], []>>;
   logs: Writable<Default<HabitLog[], []>>;
 }
@@ -378,45 +367,17 @@ interface Input {
 ### Output Schema
 
 ```ts
-interface Output {
+interface HabitTrackerOutput {
   habits: Habit[];
   logs: HabitLog[];
   todayDate: string;
+  toggleHabit: Stream<{ habitName: string }>;
+  addHabit: Stream<{ name: string; icon: string }>;
+  deleteHabit: Stream<{ habit: Habit }>;
 }
 ```
 
-## `calendar.tsx`
-
-Minimal calendar for managing events with date and time. Events are grouped by
-date with today highlighted.
-
-**Keywords:** calendar, events, dates, lift
-
-### Input Schema
-
-```ts
-interface Event {
-  title: string;
-  date: string; // YYYY-MM-DD
-  time: Default<string, "">; // HH:MM or empty for all-day
-  notes: Default<string, "">;
-}
-
-interface Input {
-  events: Writable<Default<Event[], []>>;
-}
-```
-
-### Output Schema
-
-```ts
-interface Output {
-  events: Event[];
-  todayDate: string;
-}
-```
-
-## `reading-list.tsx`
+## `reading-list/reading-list.tsx`
 
 **Canonical list-detail example.** Track books, articles, papers, and videos.
 Demonstrates: footer forms, `navigateTo()` for details, `lift()` for filtering.
@@ -429,20 +390,57 @@ Demonstrates: footer forms, `navigateTo()` for details, `lift()` for filtering.
 type ItemType = "book" | "article" | "paper" | "video";
 type ItemStatus = "want" | "reading" | "finished" | "abandoned";
 
-interface ReadingItem {
-  title: string;
-  author: Default<string, "">;
-  url: Default<string, "">;
-  type: Default<ItemType, "article">;
-  status: Default<ItemStatus, "want">;
-  rating: Default<number | null, null>; // 1-5 stars
-  notes: Default<string, "">;
-  addedAt: number;
-  finishedAt: Default<number | null, null>;
+interface ReadingListInput {
+  items?: Writable<Default<ReadingItemPiece[], []>>;
+}
+```
+
+### Output Schema
+
+```ts
+interface ReadingListOutput {
+  items: ReadingItemPiece[];
+  totalCount: number;
+  currentFilter: ItemStatus | "all";
+  filteredItems: ReadingItemPiece[];
+  filteredCount: number;
+  addItem: Stream<{ title: string; author: string; type: ItemType }>;
+  removeItem: Stream<{ item: ReadingItemPiece }>;
+  setFilter: Stream<{ status: ItemStatus | "all" }>;
+  updateItem: Stream<{
+    item: ReadingItemPiece;
+    status?: ItemStatus;
+    rating?: number | null;
+    notes?: string;
+  }>;
+}
+```
+
+## `budget-tracker/main.tsx`
+
+Track expenses by category with budget limits and spending visualization.
+Multi-file pattern using sub-patterns for the form and data views.
+
+**Keywords:** budget, expenses, categories, sub-patterns
+
+### Input Schema
+
+```ts
+interface Expense {
+  description: string;
+  amount: number;
+  category: Default<string, "Other">;
+  date: string; // YYYY-MM-DD
+}
+
+interface CategoryBudget {
+  category: string;
+  limit: number;
 }
 
 interface Input {
-  items: Writable<Default<ReadingItem[], []>>;
+  expenses: Writable<Default<Expense[], []>>;
+  budgets: Writable<Default<CategoryBudget[], []>>;
 }
 ```
 
@@ -450,62 +448,130 @@ interface Input {
 
 ```ts
 interface Output {
-  items: ReadingItem[];
+  expenses: Expense[];
+  budgets: CategoryBudget[];
 }
 ```
 
-## `contacts/contact-detail.tsx`
+## `chatbot.tsx`
 
-Detail/edit view for a single contact. Use with `navigateTo()` from contact-book
-or as a standalone contact editor.
+Full-featured AI chat assistant with tool support, model selection, and
+mentionables. Deploy this to have a conversational AI interface.
 
-**Keywords:** contact, detail, edit, form, navigateTo
+**Keywords:** llm, chat, tools, llmDialog, generateObject
 
 ### Input Schema
 
 ```ts
-interface Contact {
+type ChatInput = {
+  messages?: Writable<Default<Array<BuiltInLLMMessage>, []>>;
+  tools?: any;
+  theme?: any;
+  system?: string;
+};
+```
+
+### Output Schema
+
+```ts
+type ChatOutput = {
+  messages: Array<BuiltInLLMMessage>;
+  pending: boolean | undefined;
+  addMessage: Stream<BuiltInLLMMessage>;
+  clearChat: Stream<void>;
+  cancelGeneration: Stream<void>;
+  title?: string;
+  pinnedCells: Array<{ path: string; name: string }>;
+  tools: any;
+};
+```
+
+## `group-chat-lobby.tsx`
+
+Multiplayer group chat lobby where users join, pick colors, and enter a shared
+chat room. Uses `navigateTo()` to transition into `group-chat-room.tsx`.
+
+**Keywords:** multiplayer, chat, lobby, navigateTo
+
+### Input Schema
+
+```ts
+interface Message {
+  id: string;
+  author: string;
+  content: string;
+  timestamp: number;
+  type: "chat" | "system" | "image";
+  imageUrl?: string;
+  reactions: Reaction[];
+}
+
+interface User {
   name: string;
-  email: Default<string, "">;
-  phone: Default<string, "">;
-  company: Default<string, "">;
-  tags: Default<string[], []>;
-  notes: Default<string, "">;
-  createdAt: number;
+  joinedAt: number;
+  color: string;
+  avatarImage?: { url: string };
 }
 
-interface Input {
-  contact: Contact;
+interface LobbyInput {
+  chatName: Default<string, "Group Chat">;
+  messages: Writable<Default<Message[], []>>;
+  users: Writable<Default<User[], []>>;
+  sessionId: Writable<Default<string, "">>;
 }
 ```
 
 ### Output Schema
 
 ```ts
-interface Output {
-  contact: Contact;
+interface LobbyOutput {
+  chatName: string;
+  messages: Message[];
+  users: User[];
+  sessionId: string;
 }
 ```
 
-## `event-detail.tsx`
+## `store-mapper.tsx`
 
-Detail/edit view for a single calendar event. Use with `navigateTo()` from
-calendar or as a standalone event editor.
+Capture grocery store layouts through manual aisle entry, perimeter department
+positioning, and item location corrections. Generates layout data used by
+`shopping-list.tsx` for AI-powered aisle sorting.
 
-**Keywords:** event, detail, edit, form, navigateTo
+**Keywords:** store-layout, grocery, aisles, generateObject
 
 ### Input Schema
 
 ```ts
-interface Event {
-  title: string;
-  date: string;
-  time: Default<string, "">;
-  notes: Default<string, "">;
+interface Aisle {
+  name: string;
+  description: Default<string, "">;
+}
+
+interface Department {
+  name: string;
+  icon: string;
+  location: Default<WallPosition, "unassigned">;
+  description: Default<string, "">;
+}
+
+interface Entrance {
+  position: WallPosition;
+}
+
+interface ItemLocation {
+  itemName: string;
+  correctAisle: string;
+  incorrectAisle: Default<string, "">;
+  timestamp: number;
 }
 
 interface Input {
-  event: Event;
+  storeName: Writable<Default<string, "My Store">>;
+  aisles: Writable<Default<Aisle[], []>>;
+  departments: Writable<Default<Department[], []>>;
+  entrances: Writable<Default<Entrance[], []>>;
+  itemLocations: Writable<Default<ItemLocation[], []>>;
 }
 ```
 
@@ -513,47 +579,18 @@ interface Input {
 
 ```ts
 interface Output {
-  event: Event;
+  storeName: string;
+  aisles: Aisle[];
+  departments: Department[];
+  entrances: Entrance[];
+  itemLocations: ItemLocation[];
+  storeLayout: string; // Generated markdown layout description
 }
 ```
 
-## `reading-item-detail.tsx`
+---
 
-Detail/edit view for a single reading list item. Use with `navigateTo()` from
-reading-list or as a standalone item editor.
-
-**Keywords:** reading, book, article, detail, edit, form, navigateTo
-
-### Input Schema
-
-```ts
-type ItemType = "book" | "article" | "paper" | "video";
-type ItemStatus = "want" | "reading" | "finished" | "abandoned";
-
-interface ReadingItem {
-  title: string;
-  author: Default<string, "">;
-  url: Default<string, "">;
-  type: Default<ItemType, "article">;
-  status: Default<ItemStatus, "want">;
-  rating: Default<number | null, null>;
-  notes: Default<string, "">;
-  addedAt: number;
-  finishedAt: Default<number | null, null>;
-}
-
-interface Input {
-  item: ReadingItem;
-}
-```
-
-### Output Schema
-
-```ts
-interface Output {
-  item: ReadingItem;
-}
-```
+# AI & Capability Demos
 
 ## `deep-research.tsx`
 
@@ -588,386 +625,199 @@ type Output = {
   question: string;
   result: Writable<ResearchResult | undefined>;
   pending: boolean;
-  error: string | undefined;
+  error: unknown;
 };
 ```
 
-## `record.tsx`
+## `image-analysis.tsx`
 
-Flexible container pattern for structured records with composable field modules.
-Supports dynamic type selection, soft-delete with restore, and LLM-powered data
-extraction. Used for contacts, businesses, places, and other structured data.
+Upload images and get AI-powered analysis and descriptions. Supports multiple
+images with customizable prompts.
 
-**Keywords:** record, container, sub-pieces, type-picker, modules, composable
+**Keywords:** vision, image, generateText, ct-image-input
 
 ### Input Schema
 
 ```ts
-interface Input {
-  title?: Default<string, "">;
+type ImageChatInput = {
+  systemPrompt?: string;
+  model?: string;
+};
+```
+
+### Output Schema
+
+```ts
+type ImageChatOutput = {
+  images: Writable<ImageData[]>;
+  prompt: Writable<string>;
+  response: string | undefined;
+  pending: boolean | undefined;
+};
+```
+
+## `examples/profile-aware-writer.tsx`
+
+Example pattern demonstrating how to use the `#profile` wish to personalize LLM
+output. Fetches the user's profile summary and injects it into the system prompt
+for personalized text generation.
+
+**Keywords:** profile, wish, generateText, llm, personalization
+
+### Input Schema
+
+```ts
+type Input = {
+  title?: Default<string, "Profile-Aware Writer">;
+};
+```
+
+### Output Schema
+
+```ts
+type Output = {
+  topic: Writable<string>;
+  response: string | undefined;
+};
+```
+
+---
+
+# Detail Views
+
+These patterns are used with `navigateTo()` from their parent patterns and can
+also work standalone.
+
+## `calendar/event-detail.tsx`
+
+Detail/edit view for a single calendar event.
+
+**Keywords:** event, detail, edit, form, navigateTo
+
+### Input Schema
+
+```ts
+interface EventDetailInput {
+  title?: Writable<Default<string, "">>;
+  date?: Writable<Default<string, "">>;
+  time?: Writable<Default<string, "">>;
+  notes?: Writable<Default<string, "">>;
 }
 ```
 
 ### Output Schema
 
 ```ts
-interface SubCharmEntry {
-  type: string;
-  piece: unknown;
-}
-
-interface Output {
+interface EventDetailOutput {
   title: string;
-  subCharms: SubCharmEntry[];
+  date: string;
+  time: string;
+  notes: string;
+  setTitle: Stream<{ title: string }>;
+  setDate: Stream<{ date: string }>;
+  setTime: Stream<{ time: string }>;
+  setNotes: Stream<{ notes: string }>;
 }
 ```
 
----
+## `contacts/contact-detail.tsx`
 
-# Record Field Modules
+Detail/edit view for a single contact. Use with `navigateTo()` from contact-book
+or as a standalone contact editor.
 
-These patterns are composable field modules designed to work with `record.tsx`
-but can also be used standalone. Each exports `MODULE_METADATA` for
-self-description.
-
-## `birthday.tsx`
-
-Birthday/date of birth tracking with optional birth year.
-
-**Keywords:** birthday, date, record-module
-
-### Schema
-
-```ts
-interface BirthdayModuleInput {
-  birthDate: Default<string, "">;
-  birthYear: Default<number | null, null>;
-}
-```
-
-## `rating.tsx`
-
-Star rating (1-5) with visual star display.
-
-**Keywords:** rating, stars, record-module
-
-### Schema
-
-```ts
-interface RatingModuleInput {
-  rating: Default<number | null, null>;
-}
-```
-
-## `tags.tsx`
-
-Comma-separated tags/labels.
-
-**Keywords:** tags, labels, record-module
-
-### Schema
-
-```ts
-interface TagsModuleInput {
-  tags: Default<string[], []>;
-}
-```
-
-## `status.tsx`
-
-Status tracking with customizable options (active, inactive, pending, etc.).
-
-**Keywords:** status, state, record-module
-
-### Schema
-
-```ts
-interface StatusModuleInput {
-  status: Default<string, "">;
-}
-```
-
-## `address.tsx`
-
-Physical address with street, city, state, postal code, and country.
-
-**Keywords:** address, location, record-module
-
-### Schema
-
-```ts
-interface AddressModuleInput {
-  street: Default<string, "">;
-  city: Default<string, "">;
-  state: Default<string, "">;
-  postalCode: Default<string, "">;
-  country: Default<string, "">;
-}
-```
-
-## `timeline.tsx`
-
-Key dates tracking (met, started, ended, etc.).
-
-**Keywords:** dates, timeline, history, record-module
-
-### Schema
-
-```ts
-interface TimelineModuleInput {
-  metDate: Default<string, "">;
-  startDate: Default<string, "">;
-  endDate: Default<string, "">;
-}
-```
-
-## `social.tsx`
-
-Social media profile (platform, handle, URL).
-
-**Keywords:** social, twitter, linkedin, github, record-module
-
-### Schema
-
-```ts
-interface SocialModuleInput {
-  platform: Default<string, "">;
-  handle: Default<string, "">;
-  url: Default<string, "">;
-}
-```
-
-## `link.tsx`
-
-URL/link with optional title.
-
-**Keywords:** link, url, web, record-module
-
-### Schema
-
-```ts
-interface LinkModuleInput {
-  url: Default<string, "">;
-  title: Default<string, "">;
-}
-```
-
-## `location.tsx`
-
-Geographic coordinates (latitude, longitude) with optional label.
-
-**Keywords:** location, coordinates, geo, record-module
-
-### Schema
-
-```ts
-interface LocationModuleInput {
-  latitude: Default<number | null, null>;
-  longitude: Default<number | null, null>;
-  label: Default<string, "">;
-}
-```
-
-## `relationship.tsx`
-
-Relationship to another entity with type and notes.
-
-**Keywords:** relationship, connection, record-module
-
-### Schema
-
-```ts
-interface RelationshipModuleInput {
-  relationshipType: Default<string, "">;
-  relatedTo: Default<string, "">;
-  notes: Default<string, "">;
-}
-```
-
-## `giftprefs.tsx`
-
-Gift preferences and ideas.
-
-**Keywords:** gifts, preferences, record-module
-
-### Schema
-
-```ts
-interface GiftPrefsModuleInput {
-  likes: Default<string, "">;
-  dislikes: Default<string, "">;
-  giftIdeas: Default<string[], []>;
-}
-```
-
-## `timing.tsx`
-
-Best times to contact (morning, afternoon, evening, etc.).
-
-**Keywords:** timing, availability, schedule, record-module
-
-### Schema
-
-```ts
-interface TimingModuleInput {
-  bestTime: Default<string, "">;
-  timezone: Default<string, "">;
-}
-```
-
-## `type-picker.tsx`
-
-Controller module for selecting record type. Internal use only - applies
-templates to parent container and then removes itself.
-
-**Keywords:** type-picker, controller, internal, record-module
-
-### Schema
-
-```ts
-interface TypePickerInput {
-  context: ContainerCoordinationContext<SubCharmEntry>;
-  dismissed?: Default<boolean, false>;
-}
-```
-
-## `age-category.tsx`
-
-Age categorization with two-tier selection: Adult/Child groups with specific
-subcategories (Senior, Young Adult, Teenager, etc.).
-
-**Keywords:** age, category, adult, child, record-module
-
-### Schema
-
-```ts
-type AgeCategory =
-  | "adult"
-  | "child"
-  | "senior"
-  | "adult-specific"
-  | "young-adult"
-  | "teenager"
-  | "school-age"
-  | "toddler"
-  | "baby";
-
-interface AgeCategoryModuleInput {
-  ageCategory: Default<AgeCategory, "adult">;
-}
-```
-
-## `dietary-restrictions.tsx`
-
-Comprehensive dietary restriction tracking with severity levels. Handles
-allergies, intolerances, and lifestyle diets (vegetarian, vegan, halal, kosher,
-keto, etc.) with automatic expansion of diet groups to specific food items.
-
-**Keywords:** dietary, allergies, diet, vegan, vegetarian, record-module
-
-### Schema
-
-```ts
-type RestrictionLevel = "flexible" | "prefer" | "strict" | "absolute";
-
-interface RestrictionEntry {
-  name: string;
-  level: RestrictionLevel;
-}
-
-interface DietaryRestrictionsInput {
-  restrictions: Default<RestrictionEntry[], []>;
-}
-```
-
-## `email.tsx`
-
-Email address with customizable label. Supports multiple instances per Record
-with smart default labels (Personal, Work, School, Other).
-
-**Keywords:** email, contact, record-module, multi-instance
-
-### Schema
-
-```ts
-interface EmailModuleInput {
-  label: Default<string, "Personal">;
-  address: Default<string, "">;
-}
-```
-
-## `phone.tsx`
-
-Phone number with customizable label. Supports multiple instances per Record
-with smart default labels (Mobile, Home, Work, Other).
-
-**Keywords:** phone, contact, record-module, multi-instance
-
-### Schema
-
-```ts
-interface PhoneModuleInput {
-  label: Default<string, "Mobile">;
-  number: Default<string, "">;
-}
-```
-
----
-
-# Utility Patterns
-
-## `record-backup.tsx`
-
-Import/export utility for Records. Exports all Records in a space to JSON and
-imports them back. Designed for data survival after server wipes.
-
-**Keywords:** backup, export, import, records, data-migration
+**Keywords:** contact, detail, edit, form, navigateTo
 
 ### Input Schema
 
 ```ts
-interface Input {
-  importJson: Default<string, "">;
+interface Contact {
+  name: string;
+  email: Default<string, "">;
+  phone: Default<string, "">;
+  company: Default<string, "">;
+  tags: Default<string[], []>;
+  notes: Default<string, "">;
+  createdAt: number;
+}
+
+interface ContactDetailInput {
+  contact: Writable<Contact>;
 }
 ```
 
 ### Output Schema
 
 ```ts
-interface Output {
-  exportedJson: string;
-  importJson: string;
-  recordCount: number;
-  importResult: ImportResult | null;
+interface ContactDetailOutput {
+  contact: Contact;
+}
+```
+
+## `reading-list/reading-item-detail.tsx`
+
+Detail/edit view for a single reading list item. Use with `navigateTo()` from
+reading-list or as a standalone item editor.
+
+**Keywords:** reading, book, article, detail, edit, form, navigateTo
+
+### Input Schema
+
+```ts
+type ItemType = "book" | "article" | "paper" | "video";
+type ItemStatus = "want" | "reading" | "finished" | "abandoned";
+
+interface ReadingItemDetailInput {
+  title?: Writable<Default<string, "">>;
+  author?: Writable<Default<string, "">>;
+  url?: Writable<Default<string, "">>;
+  type?: Writable<Default<ItemType, "article">>;
+  status?: Writable<Default<ItemStatus, "want">>;
+  rating?: Writable<Default<number | null, null>>;
+  notes?: Writable<Default<string, "">>;
+  addedAt?: Default<number, 0>;
+  finishedAt?: Default<number | null, null>;
+}
+```
+
+### Output Schema
+
+```ts
+interface ReadingItemDetailOutput {
+  title: string;
+  author: string;
+  url: string;
+  type: ItemType;
+  status: ItemStatus;
+  rating: number | null;
+  notes: string;
+  addedAt: number;
+  finishedAt: number | null;
+  setStatus: Stream<{ status: ItemStatus }>;
+  setRating: Stream<{ rating: number | null }>;
+  setNotes: Stream<{ notes: string }>;
 }
 ```
 
 ---
 
-# Protocol Types
+# System Patterns
 
-## `container-protocol.ts`
+## `system/favorites-manager.tsx`
 
-Protocol definitions for controller patterns that coordinate with parent
-containers.
+View and manage favorited pieces with tags. Uses the wish system to query
+`#favorites` and allows removing items.
 
-**Keywords:** protocol, container, coordination, types
+**Keywords:** favorites, wish, ct-cell-link
 
-### Types
+### Input Schema
 
 ```ts
-interface ContainerCoordinationContext<TEntry = unknown> {
-  entries: Writable<TEntry[]>;
-  trashedEntries: Writable<(TEntry & { trashedAt: string })[]>;
-  createModule: (type: string) => unknown;
-}
+type Input = Record<string, never>;
+```
 
-interface ModuleMetadata {
-  type: string;
-  label: string;
-  icon: string;
-  internal?: boolean;
-  schema?: Record<string, unknown>;
-  fieldMapping?: string[];
-}
+### Output Schema
+
+```ts
+// Uses wish<Array<Favorite>>({ query: "#favorites" }) internally
+// Displays favorited pieces with remove functionality
 ```


### PR DESCRIPTION
Fix stale paths (counter, todo-list, calendar, habit-tracker, reading-list,
event-detail, reading-item-detail all moved into subdirectories), remove
deleted patterns (gpa-stats-source/reader), drop record module system, and
add new user-facing patterns (simple-list, shopping-list, notebook,
weekly-calendar, budget-tracker, group-chat, store-mapper).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the patterns index to match the current repo: fixes moved paths, removes deprecated record modules and deleted patterns, and adds new user-facing patterns. Also standardizes schemas and reorganizes sections for clarity.

- New Features
  - Documented: simple-list, shopping-list + store-mapper, notes/notebook, weekly-calendar, budget-tracker, group-chat lobby.

- Migration
  - Update links to moved patterns now in subdirectories: counter/, todo-list/, calendar/, habit-tracker/, reading-list/, calendar/event-detail.tsx, reading-list/reading-item-detail.tsx.
  - Remove references to gpa-stats-source/reader and the entire record module system (all module docs dropped).
  - "Result Schema" is now "Output Schema" throughout.

<sup>Written for commit 824366cefff5bb148b1ae7eccea3a99bb490575d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

