### PR TITLE
fix(scheduler): increase push-mode settle iterations to match pull-mode

### DIFF
--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -2185,7 +2185,7 @@ export class Scheduler {
     // First iteration processes initial seeds + their dirty deps.
     // Subsequent iterations process new subscriptions and re-collect dirty deps.
     logger.timeStart("scheduler", "execute", "settle");
-    const maxSettleIterations = this.pullMode ? 10 : 1;
+    const maxSettleIterations = this.pullMode ? 10 : 10;
     const EARLY_ITERATION_THRESHOLD = 5;
     const earlyIterationComputations = new Set<Action>(); // Track computations in first N iterations
     let lastWorkSet: Set<Action> = new Set();


### PR DESCRIPTION
## Summary

- Push mode was limited to 1 settle iteration per `execute()` cycle while pull mode allowed 10
- This caused reactive cascades to not converge when sub-patterns subscribe to `allPieces` (via `wish`) and are then pushed into it, creating feedback loops that require multiple iterations
- The settle loop already has early-exit logic (`settledEarly`) that breaks when no new work is produced, so this change has no performance impact for simple cases — only cascades that genuinely need multiple iterations will use them

## Reproducer

`notes-import-export.test.tsx` actions 31/37 (`importSkipDuplicates`, `importAllAsCopies`) which batch-add Note/Notebook sub-patterns to `allPieces`. Each sub-pattern subscribes to `allPieces` via `wish("#default")`, and pushing them into `allPieces` triggers subscription updates that require additional settle iterations.

## Test plan

- [ ] Existing CI tests pass (no behavioral change for 1-iteration cases due to early exit)
- [ ] Pattern tests that batch-add sub-patterns no longer timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase push-mode settle iterations from 1 to 10 to match pull-mode, allowing reactive cascades (e.g., allPieces subscriptions) to fully converge and preventing batch-add timeouts. No performance impact for simple cases due to existing early-exit in the settle loop.

<sup>Written for commit 307e7f5c3aaf244cdf51525c6aeb8fb6044ec55b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

