### PR TITLE
fix(test-runner): await storage sync before running test steps

### DIFF
--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -132,6 +132,11 @@ export async function runTestPattern(
 
     // Wait for initial setup to complete
     await runtime.idle();
+    // Also wait for all in-flight storage subscriptions to settle.
+    // replica.poll() fires without await during mount(), so subscription
+    // updates can arrive after idle() resolves, scheduling more work.
+    await storageManager.synced();
+    await runtime.idle();
 
     // Keep the pattern reactive - store cancel function for cleanup
     sinkCancel = patternResult.sink(() => {});


### PR DESCRIPTION
During pattern setup, Replica.poll() fires without await during Provider.mount(). Storage subscription updates travel through an async ReadableStream pipeline that runtime.idle() can't see, so they can arrive after idle() resolves. This causes the first action in a test to collide with late-arriving subscription work, making idle() never resolve (timeout).

Fix: after initial setup idle(), also await storageManager.synced() and a second idle() to drain all in-flight subscription pipelines before test steps begin.

This fixes notebook.test.tsx action_1 (setTitle) timeout without regressing notes-import-export.test.tsx.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the test runner waits for storage subscriptions to finish before executing test steps. This prevents idle() timeouts caused by late subscription work during pattern mount.

- **Bug Fixes**
  - After the initial idle(), also await storageManager.synced() and then a second idle() to drain in-flight updates.
  - Fixes notebook.test.tsx action_1 (setTitle) timeout; notes-import-export.test.tsx remains green.

<sup>Written for commit d9e91909cf0fc6c8640479c91bf4da7f128d5d69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

