### PR TITLE
feat(runner): enable logging for schema mismatch debugging

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -142,7 +142,7 @@ jobs:
       - name: 🧪 Run CLI integration tests
         working-directory: packages/cli
         run: |
-          LOG_TO_STDERR=1 API_URL=http://localhost:8000 ./integration/integration.sh
+          API_URL=http://localhost:8000 ./integration/integration.sh
 
   pattern-integration-test:
     name: "Pattern Integration Tests"

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -e
+
+# Redirect logs to stderr so they don't pollute stdout (used for machine-readable output)
+export LOG_TO_STDERR=1
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 error () {
   >&2 echo $1

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -134,8 +134,6 @@ async function runPackageIntegration(
   if (pkg === "cli") {
     // CLI uses a special shell script
     env.CT_CLI_INTEGRATION_USE_LOCAL = "1";
-    // Redirect logs to stderr so they don't pollute stdout (used for machine-readable output)
-    env.LOG_TO_STDERR = "1";
     result = await runCommand(
       ["bash", "./integration/integration.sh"],
       { cwd: packageDir, env, inheritStdio: true },


### PR DESCRIPTION
## Summary
- Enable runner logger with `info` level by default to surface schema mismatch issues
- Add detailed logging when action arguments are undefined (potential schema mismatch)
- Include JSON-serialized query result and inputsCell in logs for better debugging visibility

## Test plan
- [x] Deploy locally and trigger a schema mismatch scenario
- [x] Verify logs show the additional context (argument schema, raw data, serialized query result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables info-level runner logging with lifecycle visibility for schema mismatches and routes logs to stderr via LOG_TO_STDERR to keep CLI stdout clean. The integration script now sets LOG_TO_STDERR directly so CI and local runs behave the same.

- **New Features**
  - Enable runner logger by default (info level).
  - Structure schema-mismatch logs with named fields: schema, raw, asQueryResult (JSON fallback).
  - Log transitions from invalid to valid at info level to confirm recovery.
  - Set LOG_TO_STDERR=1 inside integration.sh to route logs to stderr consistently.

<sup>Written for commit fe35fe28c829f5bf68184347691fd8bf28d718c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

