### PR TITLE
Minimal changes to restore llm tool calls

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -97,6 +97,30 @@ function normalizeInputSchema(schemaLike: unknown): JSONSchema {
 }
 
 /**
+ * Create a copy of a recipe with argumentSchema set to `true` on all node
+ * modules. This means we will always pass the argument validatio in
+ * instantiateJavaScriptNode that was introduced by the unified traversal
+ * (5d352fc09).
+ *
+ * This is needed for tool call patterns because iInternal builtin nodes
+ * have schema mismatches.
+ *
+ * Setting argumentSchema to true is safe here because this only affects the
+ * ephemeral recipe copy created for this tool call invocation.
+ */
+function prepareRecipeForToolCall(recipe: Readonly<Recipe>): Recipe {
+  return {
+    ...recipe,
+    nodes: recipe.nodes.map((node) => ({
+      ...node,
+      module: {
+        ...node.module,
+        argumentSchema: true as unknown as JSONSchema,
+      },
+    })),
+  };
+}
+/**
  * Resolve a piece's result schema similarly to PieceManager.#getResultSchema:
  * - Prefer a non-empty recipe.resultSchema if recipe is loaded
  * - Otherwise derive a simple object schema from the current value
@@ -1607,7 +1631,8 @@ async function handleInvoke(
     );
 
     if (pattern) {
-      runtime.run(tx, pattern, { ...input, ...extraParams }, result);
+      const toolPattern = prepareRecipeForToolCall(pattern);
+      runtime.run(tx, toolPattern, { ...input, ...extraParams }, result);
     } else if (handler) {
       handler.withTx(tx).send({
         ...input,


### PR DESCRIPTION
This is a minimal change to make those tool calls work.
I still need to handle the mismatching Required property on input fields, but until that happens, this should get things working.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores LLM tool calls by bypassing argument schema validation on a temporary recipe copy during tool invocation. Tool calls now run even with schema mismatches in internal nodes, without affecting saved recipes.

- **Bug Fixes**
  - Added prepareRecipeForToolCall to clone the pattern and set module.argumentSchema=true on all nodes.
  - Updated handleInvoke to run the cloned pattern; handler path unchanged.

<sup>Written for commit f869c54c501bd439605a9e3d675981a31d11aee4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

