### PR TITLE
Add test of traversal with createDataCellURI links

### DIFF
--- a/packages/runner/test/schema.test.ts
+++ b/packages/runner/test/schema.test.ts
@@ -3830,7 +3830,7 @@ describe("Schema Support", () => {
       expect(cellALink.path).toEqual(["baz", "bar"]);
     });
 
-    it("with data cell: validates contents", () => {
+    it("with data cell: validates contents", async () => {
       const cellASchema = {
         type: "object",
         properties: { system: { type: "string" } },
@@ -3912,7 +3912,7 @@ describe("Schema Support", () => {
         cellASchema,
       );
 
-      tx.commit();
+      await tx.commit();
       tx = runtime.edit();
 
       const cellAContents = cellA.asSchema({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added an async test for traversal with createDataCellURI links. It aliases through another cell to a source string, validates the resolved value, and awaits tx.commit to persist writes.

<sup>Written for commit 4f94baa6fcd844b8c4e5bdcee10bba9905564149. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

