### PR TITLE
feat(debugger): add Data pending tab for actions with invalid inputs

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1256,6 +1256,36 @@ export class Runner {
           const isValidArgument = module.argumentSchema === false ||
             argument !== undefined;
 
+          // Set/clear the invalid input flag for stream handlers
+          if (name) {
+            if (!isValidArgument) {
+              let queryResult: string;
+              try {
+                queryResult = JSON.stringify(
+                  inputsCell.getAsQueryResult([], tx),
+                );
+              } catch (_e) {
+                queryResult = "(Can't serialize to JSON)";
+              }
+              logger.flag(
+                "action invalid input",
+                `action:${name}`,
+                true,
+                {
+                  schema: module.argumentSchema,
+                  raw: inputsCell.getRaw(),
+                  queryResult,
+                },
+              );
+            } else {
+              logger.flag(
+                "action invalid input",
+                `action:${name}`,
+                false,
+              );
+            }
+          }
+
           if (!isValidArgument) {
             logger.error(
               "stream",
@@ -1444,6 +1474,36 @@ export class Runner {
           // If we have a schema of false, we don't use our argument, so undefined is ok
           const isValidArgument = module.argumentSchema === false ||
             argument !== undefined;
+
+          // Set/clear the invalid input flag (always, not just on transitions)
+          if (name) {
+            if (!isValidArgument) {
+              let queryResult: string;
+              try {
+                queryResult = JSON.stringify(
+                  inputsCell.getAsQueryResult([], tx),
+                );
+              } catch (_e) {
+                queryResult = "(Can't serialize to JSON)";
+              }
+              logger.flag(
+                "action invalid input",
+                `action:${name}`,
+                true,
+                {
+                  schema: module.argumentSchema,
+                  raw: inputsCell.getRaw(),
+                  queryResult,
+                },
+              );
+            } else {
+              logger.flag(
+                "action invalid input",
+                `action:${name}`,
+                false,
+              );
+            }
+          }
 
           if (!isValidArgument || previouslyInvalidArgument) {
             logger.info(

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -3,6 +3,7 @@ import { PieceManager } from "@commontools/piece";
 import { PiecesController } from "@commontools/piece/ops";
 import {
   getLoggerCountsBreakdown,
+  getLoggerFlagsBreakdown,
   getTimingStatsBreakdown,
   Logger,
   resetAllCountBaselines,
@@ -632,7 +633,8 @@ export class RuntimeProcessor {
     const counts = getLoggerCountsBreakdown();
     const metadata = this.#getLoggerMetadata();
     const timing = getTimingStatsBreakdown();
-    return { counts, metadata, timing };
+    const flags = getLoggerFlagsBreakdown();
+    return { counts, metadata, timing, flags };
   }
 
   #getLoggerMetadata(): LoggerMetadata {

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -253,6 +253,11 @@ export type LoggerTimingData = Record<
   Record<string, TimingStats>
 >;
 
+export type LoggerFlagsData = Record<
+  string,
+  Record<string, Record<string, Record<string, unknown> | null>>
+>;
+
 export interface PageCreateRequest extends BaseRequest {
   type: RequestType.PageCreate;
   source: {
@@ -440,6 +445,7 @@ export interface LoggerCountsResponse {
   counts: LoggerCountsData;
   metadata: LoggerMetadata;
   timing: LoggerTimingData;
+  flags: LoggerFlagsData;
 }
 
 export interface CellUpdateNotification {

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -20,6 +20,7 @@ import {
   InitializationData,
   JSONValue,
   type LoggerCountsData,
+  type LoggerFlagsData,
   type LoggerMetadata,
   type LoggerTimingData,
   type LogLevel,
@@ -243,11 +244,17 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     counts: LoggerCountsData;
     metadata: LoggerMetadata;
     timing: LoggerTimingData;
+    flags: LoggerFlagsData;
   }> {
     const res = await this.#conn.request<RequestType.GetLoggerCounts>({
       type: RequestType.GetLoggerCounts,
     });
-    return { counts: res.counts, metadata: res.metadata, timing: res.timing };
+    return {
+      counts: res.counts,
+      metadata: res.metadata,
+      timing: res.timing,
+      flags: res.flags,
+    };
   }
 
   /**

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -1464,6 +1464,10 @@ export class XDebuggerView extends LitElement {
     try {
       const result = await rt.getLoggerCounts();
       this.workerLoggerMetadata = result.metadata;
+      // Also push flags to the debugger controller (piggyback on existing IPC call)
+      if (result.flags && this.debuggerController) {
+        this.debuggerController.updateFlags(result.flags);
+      }
       return { counts: result.counts, timing: result.timing };
     } catch {
       return { counts: null, timing: null };


### PR DESCRIPTION
## Summary

- Adds a **logger flag facility** (`Logger.flag()`) that tracks named boolean state per ID with optional metadata — a general-purpose mechanism for surfacing runtime conditions in the debugger
- **Runner** sets `"action invalid input"` flags when actions fail schema validation, capturing diagnostic metadata (schema, raw value, query result)
- Plumbs flags through **IPC** (`LoggerFlagsData` type, `LoggerCountsResponse.flags`) from worker to main thread
- Adds a **"Data pending" tab** in the scheduler area of the debugger that lists all actions with invalid inputs, with click-to-select showing full diagnostics (schema, raw value, query result) in the detail pane

## Test plan

- [x] Start local dev (`dev-local`)
- [x] Load a pattern that has schema mismatches (e.g. one with an argumentSchema that doesn't match its initial inputs)
- [x] Open debugger (Ctrl+D or equivalent)
- [x] Go to Scheduler tab → click "Data pending" toggle
- [x] Verify flagged actions appear with warning icon, type badge, label, and "invalid input" tag
- [x] Click an action → detail pane shows Invalid Input Diagnostics section with Schema, Raw Value, Query Result
- [x] When the pattern's data becomes valid, click Snapshot to refresh → the action should disappear from the list
- [x] Verify Graph and Table views still work correctly
- [x] Run `deno task check` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Data pending” tab in the debugger to show actions with invalid inputs and provide quick diagnostics. Built on a new logger flag system and IPC plumbing to surface schema mismatches.

- **New Features**
  - Logger: `flag(name, id, value, metadata?)` to track named boolean state per ID; `getLoggerFlagsBreakdown()` for aggregation.
  - Runner: sets “action invalid input” flags when argument schema validation fails, capturing schema, raw value, and query result.
  - IPC: adds `LoggerFlagsData` and includes `flags` in `GetLoggerCounts` response; runtime client/controller fetch and store flags.
  - Debugger UI: new “Data pending” view listing flagged actions, highlighting matched vs. not-in-graph, with click-to-select diagnostics in the detail pane.

<sup>Written for commit 9d4123cfa11681d758edf1607a5598a13c69a5c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

