### PR TITLE
test(patterns): add folksonomy aggregator tests and stress test

### DIFF
--- a/packages/patterns/experimental/folksonomy-aggregator.test.tsx
+++ b/packages/patterns/experimental/folksonomy-aggregator.test.tsx
@@ -1,0 +1,632 @@
+/// <cts-enable />
+/**
+ * Test Pattern: Folksonomy Aggregator
+ *
+ * Tests correctness of the folksonomy aggregator under load:
+ * - Basic event posting via stream
+ * - Multi-scope isolation
+ * - Preferential attachment (sort order by count)
+ * - Remove handling (count decrements, never negative)
+ * - Large batch loading (500 events)
+ * - Invalid event handling (graceful rejection)
+ * - Dense scope (100 unique tags in 1 scope)
+ *
+ * Run: deno task ct test packages/patterns/experimental/folksonomy-aggregator.test.tsx --verbose
+ *
+ * Note: Uses module-scoped handlers with explicit state parameters
+ * instead of action() closures to avoid "reactive reference outside
+ * reactive context" errors when accessing reactive proxy objects.
+ */
+import { Cell, computed, handler, pattern, Stream } from "commontools";
+import AggregatorPattern from "./folksonomy-aggregator.tsx";
+
+export interface TagEvent {
+  scope: string;
+  tag: string;
+  action: "add" | "use" | "remove";
+  timestamp: number;
+}
+
+export interface CommunityTagSuggestion {
+  tag: string;
+  count: number;
+}
+
+// ============================================================================
+// Test Data Generators
+// ============================================================================
+
+/** Multi-scope events: scope-a gets alpha(5) + beta(3), scope-b gets gamma(4) + delta(2) */
+function makeMultiScopeEvents(): TagEvent[] {
+  const events: TagEvent[] = [];
+  for (let i = 0; i < 5; i++) {
+    events.push({
+      scope: "scope-a",
+      tag: "alpha",
+      action: "add",
+      timestamp: i,
+    });
+  }
+  for (let i = 0; i < 3; i++) {
+    events.push({
+      scope: "scope-a",
+      tag: "beta",
+      action: "add",
+      timestamp: 10 + i,
+    });
+  }
+  for (let i = 0; i < 4; i++) {
+    events.push({
+      scope: "scope-b",
+      tag: "gamma",
+      action: "add",
+      timestamp: 20 + i,
+    });
+  }
+  for (let i = 0; i < 2; i++) {
+    events.push({
+      scope: "scope-b",
+      tag: "delta",
+      action: "add",
+      timestamp: 30 + i,
+    });
+  }
+  return events;
+}
+
+/** Preferential attachment: popular(10) vs rare(1) in same scope */
+function makePreferentialEvents(): TagEvent[] {
+  const events: TagEvent[] = [];
+  for (let i = 0; i < 10; i++) {
+    events.push({
+      scope: "scope-p",
+      tag: "popular",
+      action: "add",
+      timestamp: i,
+    });
+  }
+  events.push({ scope: "scope-p", tag: "rare", action: "add", timestamp: 100 });
+  return events;
+}
+
+/** Remove handling: add removable(5), remove removable(3), add permanent(1) */
+function makeRemoveEvents(): TagEvent[] {
+  const events: TagEvent[] = [];
+  for (let i = 0; i < 5; i++) {
+    events.push({
+      scope: "scope-r",
+      tag: "removable",
+      action: "add",
+      timestamp: i,
+    });
+  }
+  for (let i = 0; i < 3; i++) {
+    events.push({
+      scope: "scope-r",
+      tag: "removable",
+      action: "remove",
+      timestamp: 10 + i,
+    });
+  }
+  events.push({
+    scope: "scope-r",
+    tag: "permanent",
+    action: "add",
+    timestamp: 20,
+  });
+  return events;
+}
+
+const BATCH_SCOPES = [
+  "recipe-tracker",
+  "meal-planner",
+  "cookbook",
+  "food-blog",
+  "grocery-list",
+  "restaurant-reviews",
+  "wine-journal",
+  "kitchen-inventory",
+  "diet-log",
+  "cooking-class",
+];
+
+const BATCH_TAGS = [
+  "vegetarian",
+  "quick",
+  "easy",
+  "italian",
+  "mexican",
+  "breakfast",
+  "dessert",
+  "healthy",
+  "spicy",
+  "gluten-free",
+  "vegan",
+  "comfort-food",
+  "budget",
+  "meal-prep",
+  "one-pot",
+  "grilled",
+  "baked",
+  "seasonal",
+  "holiday",
+  "snack",
+];
+
+const DENSE_TAGS = [
+  "vegetarian",
+  "quick",
+  "easy",
+  "italian",
+  "mexican",
+  "breakfast",
+  "dessert",
+  "healthy",
+  "spicy",
+  "gluten-free",
+  "vegan",
+  "comfort-food",
+  "budget",
+  "meal-prep",
+  "one-pot",
+  "grilled",
+  "baked",
+  "seasonal",
+  "holiday",
+  "snack",
+  "appetizer",
+  "soup",
+  "salad",
+  "pasta",
+  "seafood",
+  "chicken",
+  "beef",
+  "pork",
+  "tofu",
+  "rice",
+  "noodles",
+  "curry",
+  "stir-fry",
+  "slow-cooker",
+  "instant-pot",
+  "fermented",
+  "pickled",
+  "smoked",
+  "roasted",
+  "steamed",
+  "raw",
+  "frozen",
+  "organic",
+  "local",
+  "farm-to-table",
+  "keto",
+  "paleo",
+  "mediterranean",
+  "asian",
+  "french",
+  "indian",
+  "thai",
+  "japanese",
+  "korean",
+  "middle-eastern",
+  "african",
+  "caribbean",
+  "southern",
+  "tex-mex",
+  "fusion",
+  "street-food",
+  "brunch",
+  "lunch",
+  "dinner",
+  "party",
+  "potluck",
+  "date-night",
+  "kids",
+  "beginner",
+  "advanced",
+  "under-30-min",
+  "under-15-min",
+  "overnight",
+  "no-cook",
+  "five-ingredient",
+  "dairy-free",
+  "nut-free",
+  "egg-free",
+  "soy-free",
+  "low-sodium",
+  "high-protein",
+  "low-carb",
+  "high-fiber",
+  "antioxidant",
+  "probiotic",
+  "immune-boost",
+  "energy",
+  "recovery",
+  "chocolate",
+  "vanilla",
+  "cinnamon",
+  "garlic",
+  "lemon",
+  "ginger",
+  "basil",
+  "cilantro",
+  "mint",
+  "rosemary",
+  "thyme",
+  "oregano",
+  "cumin",
+  "turmeric",
+];
+
+/** Large batch: 500 events across 10 scopes and 20 tags */
+function makeLargeBatchEvents(): TagEvent[] {
+  const events: TagEvent[] = [];
+  for (let i = 0; i < 500; i++) {
+    events.push({
+      scope: BATCH_SCOPES[i % 10],
+      tag: BATCH_TAGS[(i * 7) % 20], // Prime multiplier for even distribution
+      action: "add",
+      timestamp: i,
+    });
+  }
+  return events;
+}
+
+/** Dense scope: 100 unique tags in 1 scope, each with (index % 3 + 1) events */
+function makeDenseEvents(): TagEvent[] {
+  const events: TagEvent[] = [];
+  for (let t = 0; t < 100; t++) {
+    const count = (t % 3) + 1; // 1, 2, or 3 events per tag
+    for (let i = 0; i < count; i++) {
+      events.push({
+        scope: "cookbook",
+        tag: DENSE_TAGS[t],
+        action: "add",
+        timestamp: t * 10 + i,
+      });
+    }
+  }
+  return events;
+}
+
+// ============================================================================
+// Module-scope Handlers
+// ============================================================================
+
+/** Set events cell directly (for bulk loading and resetting) */
+const setEventsHandler = handler<
+  void,
+  { eventsCell: Cell<TagEvent[]>; newEvents: TagEvent[] }
+>((_event, { eventsCell, newEvents }) => {
+  eventsCell.set([...newEvents]);
+});
+
+/** Post a single event via the aggregator's postEvent stream */
+const postEventHandler = handler<
+  void,
+  { stream: Stream<TagEvent>; event: TagEvent }
+>((_event, { stream, event }) => {
+  stream.send(event);
+});
+
+// ============================================================================
+// Test Pattern
+// ============================================================================
+
+export default pattern(() => {
+  // Instantiate aggregator with a writable events cell
+  const eventsCell = Cell.of<TagEvent[]>([]);
+  const aggregator = AggregatorPattern({ events: eventsCell });
+
+  // ========================================================================
+  // Actions
+  // ========================================================================
+
+  // --- Test 1: Basic correctness ---
+  const action_post_basic_event = postEventHandler({
+    stream: aggregator.postEvent,
+    event: { scope: "basic", tag: "typescript", action: "add", timestamp: 1 },
+  });
+
+  // --- Test 2: Multi-scope isolation ---
+  const action_load_multiscope = setEventsHandler({
+    eventsCell,
+    newEvents: makeMultiScopeEvents(),
+  });
+
+  // --- Test 3: Preferential attachment ---
+  const action_load_preferential = setEventsHandler({
+    eventsCell,
+    newEvents: makePreferentialEvents(),
+  });
+
+  // --- Test 4: Remove handling ---
+  const action_load_remove = setEventsHandler({
+    eventsCell,
+    newEvents: makeRemoveEvents(),
+  });
+
+  // --- Test 5: Large batch ---
+  const action_load_large_batch = setEventsHandler({
+    eventsCell,
+    newEvents: makeLargeBatchEvents(),
+  });
+
+  // --- Test 6: Invalid events ---
+  const action_reset = setEventsHandler({
+    eventsCell,
+    newEvents: [],
+  });
+
+  const action_post_invalid_empty_scope = postEventHandler({
+    stream: aggregator.postEvent,
+    event: { scope: "", tag: "orphan", action: "add", timestamp: 1 },
+  });
+
+  const action_post_invalid_empty_tag = postEventHandler({
+    stream: aggregator.postEvent,
+    event: { scope: "invalid-test", tag: "", action: "add", timestamp: 2 },
+  });
+
+  const action_post_valid_after_invalid = postEventHandler({
+    stream: aggregator.postEvent,
+    event: { scope: "recovery", tag: "works", action: "add", timestamp: 3 },
+  });
+
+  // --- Test 7: Dense scope ---
+  const action_load_dense = setEventsHandler({
+    eventsCell,
+    newEvents: makeDenseEvents(),
+  });
+
+  // ========================================================================
+  // Assertions
+  // ========================================================================
+
+  // --- Initial state ---
+  const assert_initial_empty = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    // Either no keys or all values are empty arrays
+    for (const scopeSuggs of Object.values(suggs)) {
+      if (scopeSuggs.length > 0) return false;
+    }
+    return true;
+  });
+
+  // --- Test 1: Basic correctness ---
+  const assert_basic_has_typescript = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    const basicSuggs = suggs["basic"] || [];
+    return basicSuggs.some(
+      (s) => s.tag === "typescript" && s.count === 1,
+    );
+  });
+
+  // --- Test 2: Multi-scope isolation ---
+  const assert_scope_a_has_alpha = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    return (suggs["scope-a"] || []).some((s) => s.tag === "alpha");
+  });
+
+  const assert_scope_a_has_beta = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    return (suggs["scope-a"] || []).some((s) => s.tag === "beta");
+  });
+
+  const assert_scope_b_has_gamma = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    return (suggs["scope-b"] || []).some((s) => s.tag === "gamma");
+  });
+
+  const assert_scope_a_no_gamma = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    return !(suggs["scope-a"] || []).some((s) => s.tag === "gamma");
+  });
+
+  const assert_scope_b_no_alpha = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    return !(suggs["scope-b"] || []).some((s) => s.tag === "alpha");
+  });
+
+  const assert_scope_a_alpha_count_5 = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    const alpha = (suggs["scope-a"] || []).find((s) => s.tag === "alpha");
+    return alpha?.count === 5;
+  });
+
+  // --- Test 3: Preferential attachment ---
+  const assert_popular_first = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    const pSuggs = suggs["scope-p"] || [];
+    return pSuggs.length >= 2 && pSuggs[0].tag === "popular";
+  });
+
+  const assert_popular_count_higher = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    const pSuggs = suggs["scope-p"] || [];
+    const popular = pSuggs.find((s) => s.tag === "popular");
+    const rare = pSuggs.find((s) => s.tag === "rare");
+    return (popular?.count || 0) > (rare?.count || 0);
+  });
+
+  // --- Test 4: Remove handling ---
+  const assert_removable_count_2 = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    const removable = (suggs["scope-r"] || []).find(
+      (s) => s.tag === "removable",
+    );
+    return removable?.count === 2; // 5 adds - 3 removes = 2
+  });
+
+  const assert_permanent_count_1 = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    const permanent = (suggs["scope-r"] || []).find(
+      (s) => s.tag === "permanent",
+    );
+    return permanent?.count === 1;
+  });
+
+  // --- Test 5: Large batch ---
+  const assert_batch_multiple_scopes = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    let scopeCount = 0;
+    for (const key of Object.keys(suggs)) {
+      if (BATCH_SCOPES.includes(key) && suggs[key].length > 0) {
+        scopeCount++;
+      }
+    }
+    return scopeCount >= 5; // Should have all 10 batch scopes populated
+  });
+
+  const assert_batch_has_tags = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    const first = suggs["recipe-tracker"] || [];
+    return first.length > 0; // first scope should have suggestions
+  });
+
+  // --- Test 6: Invalid events ---
+  const assert_empty_after_invalid = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    for (const scopeSuggs of Object.values(suggs)) {
+      if (scopeSuggs.length > 0) return false;
+    }
+    return true;
+  });
+
+  const assert_recovery_after_invalid = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    return (suggs["recovery"] || []).some(
+      (s) => s.tag === "works" && s.count === 1,
+    );
+  });
+
+  // --- Test 7: Dense scope ---
+  const assert_dense_100_tags = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    return (suggs["cookbook"] || []).length === 100;
+  });
+
+  const assert_dense_sorted = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    const denseSuggs = suggs["cookbook"] || [];
+    if (denseSuggs.length < 2) return false;
+    // Verify descending sort by count
+    for (let i = 0; i < denseSuggs.length - 1; i++) {
+      if (denseSuggs[i].count < denseSuggs[i + 1].count) return false;
+    }
+    return true;
+  });
+
+  // ========================================================================
+  // Test Sequence
+  // ========================================================================
+
+  return {
+    tests: [
+      // === Initial state: empty ===
+      { assertion: assert_initial_empty },
+
+      // === Test 1: Basic correctness ===
+      // Post 1 event via stream, verify suggestions contain it
+      { action: action_post_basic_event },
+      { assertion: assert_basic_has_typescript },
+
+      // === Test 2: Multi-scope isolation ===
+      // Set events across 2 scopes, verify isolation
+      { action: action_load_multiscope },
+      { assertion: assert_scope_a_has_alpha },
+      { assertion: assert_scope_a_has_beta },
+      { assertion: assert_scope_b_has_gamma },
+      { assertion: assert_scope_a_no_gamma },
+      { assertion: assert_scope_b_no_alpha },
+      { assertion: assert_scope_a_alpha_count_5 },
+
+      // === Test 3: Preferential attachment ===
+      // popular(10) should sort before rare(1)
+      { action: action_load_preferential },
+      { assertion: assert_popular_first },
+      { assertion: assert_popular_count_higher },
+
+      // === Test 4: Remove handling ===
+      // 5 adds - 3 removes = count 2, permanent stays at 1
+      { action: action_load_remove },
+      { assertion: assert_removable_count_2 },
+      { assertion: assert_permanent_count_1 },
+
+      // === Test 5: Large batch ===
+      // 500 events across 10 scopes
+      { action: action_load_large_batch },
+      { assertion: assert_batch_multiple_scopes },
+      { assertion: assert_batch_has_tags },
+
+      // === Test 6: Invalid events ===
+      // Reset, post invalid events, verify rejection, then verify recovery
+      { action: action_reset },
+      { action: action_post_invalid_empty_scope },
+      { action: action_post_invalid_empty_tag },
+      { assertion: assert_empty_after_invalid },
+      { action: action_post_valid_after_invalid },
+      { assertion: assert_recovery_after_invalid },
+
+      // === Test 7: Dense scope ===
+      // 100 unique tags in 1 scope, all present and sorted
+      { action: action_load_dense },
+      { assertion: assert_dense_100_tags },
+      { assertion: assert_dense_sorted },
+    ],
+  };
+});

--- a/packages/patterns/experimental/folksonomy-stress-test.tsx
+++ b/packages/patterns/experimental/folksonomy-stress-test.tsx
@@ -1,0 +1,772 @@
+/// <cts-enable />
+/**
+ * Folksonomy Stress Test - Performance Testing at Scale
+ *
+ * Deployable pattern that pre-loads the aggregator with large event sets
+ * and lets you feel the typing latency firsthand, while displaying
+ * timing instrumentation.
+ *
+ * Deploy: deno task ct deploy packages/patterns/experimental/folksonomy-stress-test.tsx
+ *
+ * HOW TO USE:
+ * 1. Click a scale button (100, 500, 1K, 5K, 10K) to load synthetic events
+ * 2. Observe the generation and load timing
+ * 3. Type in the autocomplete below to feel suggestion latency
+ * 4. Compare latency across scales to identify performance cliffs
+ */
+import {
+  Cell,
+  computed,
+  handler,
+  NAME,
+  pattern,
+  UI,
+  Writable,
+} from "commontools";
+import AggregatorPattern from "./folksonomy-aggregator.tsx";
+import { FolksonomyTags } from "./folksonomy-tags.tsx";
+
+interface TagEvent {
+  scope: string;
+  tag: string;
+  action: "add" | "use" | "remove";
+  timestamp: number;
+}
+
+interface CommunityTagSuggestion {
+  tag: string;
+  count: number;
+}
+
+// Word pools for realistic synthetic data
+const TAG_WORDS = [
+  "vegetarian",
+  "quick",
+  "easy",
+  "italian",
+  "mexican",
+  "breakfast",
+  "dessert",
+  "healthy",
+  "spicy",
+  "gluten-free",
+  "vegan",
+  "comfort-food",
+  "budget",
+  "meal-prep",
+  "one-pot",
+  "grilled",
+  "baked",
+  "seasonal",
+  "holiday",
+  "snack",
+  "appetizer",
+  "soup",
+  "salad",
+  "pasta",
+  "seafood",
+  "chicken",
+  "beef",
+  "pork",
+  "tofu",
+  "rice",
+  "noodles",
+  "curry",
+  "stir-fry",
+  "slow-cooker",
+  "instant-pot",
+  "fermented",
+  "pickled",
+  "smoked",
+  "roasted",
+  "steamed",
+  "raw",
+  "frozen",
+  "organic",
+  "local",
+  "farm-to-table",
+  "keto",
+  "paleo",
+  "mediterranean",
+  "asian",
+  "french",
+  "indian",
+  "thai",
+  "japanese",
+  "korean",
+  "middle-eastern",
+  "african",
+  "caribbean",
+  "southern",
+  "tex-mex",
+  "fusion",
+  "street-food",
+  "brunch",
+  "lunch",
+  "dinner",
+  "party",
+  "potluck",
+  "date-night",
+  "kids",
+  "beginner",
+  "advanced",
+  "under-30-min",
+  "under-15-min",
+  "overnight",
+  "no-cook",
+  "five-ingredient",
+  "dairy-free",
+  "nut-free",
+  "egg-free",
+  "soy-free",
+  "low-sodium",
+  "high-protein",
+  "low-carb",
+  "high-fiber",
+  "antioxidant",
+  "probiotic",
+  "immune-boost",
+  "energy",
+  "recovery",
+  "chocolate",
+  "vanilla",
+  "cinnamon",
+  "garlic",
+  "lemon",
+  "ginger",
+  "basil",
+  "cilantro",
+  "mint",
+  "rosemary",
+  "thyme",
+  "oregano",
+  "cumin",
+  "turmeric",
+  "chili",
+  "honey",
+  "maple",
+  "coconut",
+  "avocado",
+  "sweet-potato",
+  "quinoa",
+  "lentils",
+  "chickpeas",
+  "black-beans",
+  "spinach",
+  "kale",
+  "broccoli",
+  "mushroom",
+  "tomato",
+  "onion",
+  "pepper",
+  "eggplant",
+  "zucchini",
+  "squash",
+  "cauliflower",
+  "cabbage",
+  "carrot",
+  "beet",
+  "corn",
+  "peas",
+  "artichoke",
+  "asparagus",
+  "celery",
+  "cucumber",
+  "radish",
+  "turnip",
+  "parsnip",
+  "fennel",
+  "leek",
+  "shallot",
+  "scallion",
+  "watercress",
+  "arugula",
+  "endive",
+  "radicchio",
+  "chard",
+  "collard",
+  "mustard-greens",
+  "bok-choy",
+  "napa-cabbage",
+  "daikon",
+  "jicama",
+  "plantain",
+  "yuca",
+  "taro",
+  "breadfruit",
+  "jackfruit",
+  "tempeh",
+  "seitan",
+  "miso",
+  "tahini",
+  "harissa",
+  "gochujang",
+  "sriracha",
+  "sambal",
+  "chimichurri",
+  "pesto",
+  "salsa-verde",
+  "romesco",
+  "aioli",
+  "tzatziki",
+  "hummus",
+  "guacamole",
+  "chutney",
+  "relish",
+  "compote",
+  "coulis",
+  "gastrique",
+  "demi-glace",
+  "bechamel",
+  "hollandaise",
+  "veloute",
+  "roux",
+  "fond",
+  "consomme",
+  "bisque",
+  "chowder",
+  "gumbo",
+  "stew",
+  "tagine",
+  "ragu",
+  "bolognese",
+  "carbonara",
+  "puttanesca",
+  "arrabiata",
+  "alfredo",
+  "primavera",
+  "risotto",
+  "polenta",
+  "gnocchi",
+  "ravioli",
+  "lasagna",
+  "macaroni",
+  "penne",
+];
+
+const SCOPE_WORDS = [
+  "recipe-tracker",
+  "meal-planner",
+  "cookbook",
+  "food-blog",
+  "grocery-list",
+  "restaurant-reviews",
+  "wine-journal",
+  "kitchen-inventory",
+  "diet-log",
+  "cooking-class",
+  "garden-planner",
+  "farmers-market",
+  "food-photography",
+  "nutrition-tracker",
+  "baking-journal",
+  "fermentation-log",
+  "spice-rack",
+  "tea-collection",
+  "coffee-notes",
+  "cocktail-recipes",
+  "canning-tracker",
+  "sourdough-log",
+  "bbq-journal",
+  "sushi-notes",
+  "pizza-diary",
+  "bread-baking",
+  "pastry-notes",
+  "cheese-journal",
+  "chocolate-tasting",
+  "olive-oil-notes",
+  "herb-garden",
+  "mushroom-foraging",
+  "fish-market",
+  "butcher-notes",
+  "deli-tracker",
+  "pantry-organizer",
+  "freezer-inventory",
+  "leftovers-log",
+  "potluck-planner",
+  "holiday-cooking",
+  "camping-meals",
+  "travel-eats",
+  "street-food-log",
+  "food-truck-finder",
+  "tasting-menu",
+  "supper-club",
+  "cooking-challenge",
+  "recipe-swap",
+  "ingredient-sourcing",
+  "kitchen-equipment",
+  "cookbook-collection",
+  "food-science",
+  "flavor-pairing",
+  "menu-planning",
+  "catering-notes",
+  "food-styling",
+  "recipe-development",
+  "taste-testing",
+  "food-preservation",
+  "dehydrator-log",
+  "smoker-journal",
+  "wok-cooking",
+  "cast-iron-care",
+  "knife-sharpening",
+  "sous-vide-log",
+  "pressure-cooking",
+  "air-fryer-notes",
+  "dutch-oven-recipes",
+  "griddle-cooking",
+  "plancha-notes",
+  "tandoor-journal",
+  "clay-pot-cooking",
+  "bamboo-steamer",
+  "mortar-pestle",
+  "mandoline-cuts",
+  "pasta-machine",
+  "ice-cream-maker",
+  "food-processor",
+  "stand-mixer",
+  "immersion-blender",
+  "thermometer-log",
+  "scale-measurements",
+  "timer-presets",
+  "oven-calibration",
+  "grill-temps",
+  "humidity-control",
+  "altitude-adjustments",
+  "water-quality",
+  "flour-types",
+  "sugar-varieties",
+  "salt-selection",
+  "oil-smoke-points",
+  "vinegar-notes",
+  "stock-making",
+  "bone-broth",
+  "dashi-notes",
+  "court-bouillon",
+  "fumet-log",
+  "reduction-notes",
+  "emulsion-tips",
+  "gelatin-work",
+  "agar-experiments",
+];
+
+/** Pick n items from a word pool, cycling if needed */
+function pickWords(pool: string[], n: number): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < n; i++) {
+    result.push(pool[i % pool.length]);
+  }
+  return result;
+}
+
+/**
+ * Generate synthetic tag events with Zipf-like tag popularity.
+ * Lower-index tags are more popular (quadratic distribution).
+ * Uses real words for tags and scopes.
+ */
+function generateEvents(
+  count: number,
+  scopeCount: number,
+  tagsPerScope: number,
+): TagEvent[] {
+  const events: TagEvent[] = [];
+  const scopes = pickWords(SCOPE_WORDS, scopeCount);
+  const tags = pickWords(TAG_WORDS, tagsPerScope);
+
+  for (let i = 0; i < count; i++) {
+    // Zipf-like: lower-index tags are much more likely
+    const tagIndex = Math.floor(Math.pow(Math.random(), 2) * tagsPerScope);
+    events.push({
+      scope: scopes[i % scopeCount],
+      tag: tags[tagIndex],
+      action: Math.random() > 0.1 ? "add" : "remove", // 90% adds
+      timestamp: Date.now() - (count - i) * 1000,
+    });
+  }
+  return events;
+}
+
+// Handler to load events at a specific scale
+const loadScale = handler<
+  void,
+  {
+    eventsCell: Cell<TagEvent[]>;
+    count: number;
+    scopeCount: number;
+    tagsPerScope: number;
+    statusText: Writable<string>;
+    genMs: Writable<number>;
+    loadMs: Writable<number>;
+    loadedCount: Writable<number>;
+    loadedScopes: Writable<number>;
+    loadedTags: Writable<number>;
+  }
+>(
+  (
+    _event,
+    {
+      eventsCell,
+      count,
+      scopeCount,
+      tagsPerScope,
+      statusText,
+      genMs,
+      loadMs,
+      loadedCount,
+      loadedScopes,
+      loadedTags,
+    },
+  ) => {
+    const t0 = Date.now();
+    const generated = generateEvents(count, scopeCount, tagsPerScope);
+    const t1 = Date.now();
+
+    eventsCell.set(generated);
+    const t2 = Date.now();
+
+    statusText.set(
+      `Loaded ${count.toLocaleString()} events (${scopeCount} scopes, ${tagsPerScope} tags/scope)`,
+    );
+    genMs.set(Math.round(t1 - t0));
+    loadMs.set(Math.round(t2 - t1));
+    loadedCount.set(count);
+    loadedScopes.set(scopeCount);
+    loadedTags.set(tagsPerScope);
+  },
+);
+
+// Handler to clear all events
+const clearAll = handler<
+  void,
+  {
+    eventsCell: Cell<TagEvent[]>;
+    statusText: Writable<string>;
+    genMs: Writable<number>;
+    loadMs: Writable<number>;
+    loadedCount: Writable<number>;
+  }
+>((_event, { eventsCell, statusText, genMs, loadMs, loadedCount }) => {
+  eventsCell.set([]);
+  statusText.set("Cleared");
+  genMs.set(0);
+  loadMs.set(0);
+  loadedCount.set(0);
+});
+
+export default pattern(() => {
+  // Core state
+  const eventsCell = Cell.of<TagEvent[]>([]);
+  const aggregator = AggregatorPattern({ events: eventsCell });
+
+  // Timing state
+  const statusText = Writable.of("Ready - click a scale button to load events");
+  const genMs = Writable.of(0);
+  const loadMs = Writable.of(0);
+  const loadedCount = Writable.of(0);
+  const loadedScopes = Writable.of(0);
+  const loadedTags = Writable.of(0);
+
+  // Suggestion statistics derived from aggregator output
+  const scopesWithSuggestions = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    return Object.keys(suggs).length;
+  });
+
+  const totalSuggestions = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    let total = 0;
+    for (const scopeSuggs of Object.values(suggs)) {
+      total += scopeSuggs.length;
+    }
+    return total;
+  });
+
+  const uniqueTagCount = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    const tags = new Set<string>();
+    for (const scopeSuggs of Object.values(suggs)) {
+      for (const s of scopeSuggs) tags.add(s.tag);
+    }
+    return tags.size;
+  });
+
+  const maxSuggestionsPerScope = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    let max = 0;
+    for (const scopeSuggs of Object.values(suggs)) {
+      if (scopeSuggs.length > max) max = scopeSuggs.length;
+    }
+    return max;
+  });
+
+  const avgSuggestionsPerScope = computed(() => {
+    const suggs = (aggregator.suggestions || {}) as Record<
+      string,
+      CommunityTagSuggestion[]
+    >;
+    const scopes = Object.keys(suggs);
+    if (scopes.length === 0) return 0;
+    let total = 0;
+    for (const scopeSuggs of Object.values(suggs)) {
+      total += scopeSuggs.length;
+    }
+    return Math.round(total / scopes.length);
+  });
+
+  // Interactive typing test - uses first scope which gets events in all scales
+  const testScope = Writable.of("recipe-tracker");
+  const testTags = Writable.of<string[]>([]);
+  const tagsInstance = FolksonomyTags({
+    scope: testScope,
+    tags: testTags,
+    aggregator,
+  });
+
+  // Scale configurations
+  const scales = [
+    { count: 100, scopeCount: 10, tagsPerScope: 20, label: "100" },
+    { count: 500, scopeCount: 10, tagsPerScope: 50, label: "500" },
+    { count: 1000, scopeCount: 20, tagsPerScope: 50, label: "1K" },
+    { count: 5000, scopeCount: 50, tagsPerScope: 100, label: "5K" },
+    { count: 10000, scopeCount: 100, tagsPerScope: 200, label: "10K" },
+  ];
+
+  // Create handler bindings for each scale
+  const loadActions = scales.map((s) =>
+    loadScale({
+      eventsCell,
+      count: s.count,
+      scopeCount: s.scopeCount,
+      tagsPerScope: s.tagsPerScope,
+      statusText,
+      genMs,
+      loadMs,
+      loadedCount,
+      loadedScopes,
+      loadedTags,
+    })
+  );
+
+  const clearAction = clearAll({
+    eventsCell,
+    statusText,
+    genMs,
+    loadMs,
+    loadedCount,
+  });
+
+  const metricStyle = {
+    padding: "12px",
+    background: "#f9fafb",
+    borderRadius: "8px",
+    flex: "1",
+    minWidth: "100px",
+  };
+  const metricValue = { fontSize: "20px", fontWeight: "bold" };
+  const metricLabel = { fontSize: "11px", color: "#6b7280" };
+
+  return {
+    [NAME]: "Folksonomy Stress Test",
+    [UI]: (
+      <ct-vstack gap="4" style={{ padding: "16px", maxWidth: "800px" }}>
+        <ct-vstack gap="1">
+          <h2 style={{ margin: "0" }}>Folksonomy Performance Test</h2>
+          <p style={{ color: "#6b7280", margin: "0", fontSize: "13px" }}>
+            Load synthetic events at scale and test typing latency in the
+            autocomplete below.
+          </p>
+        </ct-vstack>
+
+        {/* Scale buttons */}
+        <ct-vstack gap="2">
+          <span
+            style={{
+              fontWeight: "600",
+              fontSize: "13px",
+              textTransform: "uppercase",
+              color: "#6b7280",
+            }}
+          >
+            Load Scale
+          </span>
+          <ct-hstack gap="2" wrap>
+            {scales.map((s, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={loadActions[i]}
+                style={{
+                  padding: "8px 16px",
+                  borderRadius: "6px",
+                  border: "1px solid #d1d5db",
+                  background: "#f9fafb",
+                  cursor: "pointer",
+                  fontSize: "13px",
+                  fontWeight: "500",
+                }}
+              >
+                {s.label}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={clearAction}
+              style={{
+                padding: "8px 16px",
+                borderRadius: "6px",
+                border: "1px solid #fca5a5",
+                background: "#fef2f2",
+                cursor: "pointer",
+                fontSize: "13px",
+                color: "#991b1b",
+              }}
+            >
+              Clear
+            </button>
+          </ct-hstack>
+        </ct-vstack>
+
+        {/* Status + timing */}
+        <ct-vstack
+          gap="2"
+          style={{
+            padding: "12px",
+            background: "#f0f9ff",
+            borderRadius: "8px",
+          }}
+        >
+          <span style={{ fontWeight: "600", fontSize: "14px" }}>
+            {statusText}
+          </span>
+          <ct-hstack gap="3" wrap>
+            <ct-vstack style={metricStyle}>
+              <span style={metricValue}>
+                {genMs}
+                <span style={{ fontSize: "12px", fontWeight: "normal" }}>
+                  ms
+                </span>
+              </span>
+              <span style={metricLabel}>Event generation</span>
+            </ct-vstack>
+            <ct-vstack style={metricStyle}>
+              <span style={metricValue}>
+                {loadMs}
+                <span style={{ fontSize: "12px", fontWeight: "normal" }}>
+                  ms
+                </span>
+              </span>
+              <span style={metricLabel}>Cell set (load)</span>
+            </ct-vstack>
+            <ct-vstack style={metricStyle}>
+              <span style={metricValue}>{loadedCount}</span>
+              <span style={metricLabel}>Events loaded</span>
+            </ct-vstack>
+          </ct-hstack>
+        </ct-vstack>
+
+        {/* Aggregator output stats */}
+        <ct-vstack
+          gap="2"
+          style={{
+            padding: "12px",
+            background: "#f0fdf4",
+            borderRadius: "8px",
+          }}
+        >
+          <span
+            style={{
+              fontWeight: "600",
+              fontSize: "13px",
+              textTransform: "uppercase",
+              color: "#6b7280",
+            }}
+          >
+            Aggregator Output
+          </span>
+          <ct-hstack gap="3" wrap>
+            <ct-vstack style={metricStyle}>
+              <span style={metricValue}>{scopesWithSuggestions}</span>
+              <span style={metricLabel}>Scopes</span>
+            </ct-vstack>
+            <ct-vstack style={metricStyle}>
+              <span style={metricValue}>{totalSuggestions}</span>
+              <span style={metricLabel}>Total suggestions</span>
+            </ct-vstack>
+            <ct-vstack style={metricStyle}>
+              <span style={metricValue}>{uniqueTagCount}</span>
+              <span style={metricLabel}>Unique tags</span>
+            </ct-vstack>
+            <ct-vstack style={metricStyle}>
+              <span style={metricValue}>{maxSuggestionsPerScope}</span>
+              <span style={metricLabel}>Max / scope</span>
+            </ct-vstack>
+            <ct-vstack style={metricStyle}>
+              <span style={metricValue}>{avgSuggestionsPerScope}</span>
+              <span style={metricLabel}>Avg / scope</span>
+            </ct-vstack>
+          </ct-hstack>
+        </ct-vstack>
+
+        {/* Interactive typing test */}
+        <ct-vstack
+          gap="2"
+          style={{
+            padding: "12px",
+            background: "#faf5ff",
+            borderRadius: "8px",
+            border: "1px solid #e9d5ff",
+          }}
+        >
+          <span
+            style={{
+              fontWeight: "600",
+              fontSize: "13px",
+              textTransform: "uppercase",
+              color: "#6b7280",
+            }}
+          >
+            Try typing below (scope: recipe-tracker)
+          </span>
+          <p style={{ margin: "0", fontSize: "12px", color: "#9ca3af" }}>
+            Load events above, then type here to feel the autocomplete latency.
+            Community suggestions from the aggregator appear as you type.
+          </p>
+          <ct-render $cell={tagsInstance} />
+        </ct-vstack>
+
+        {/* Explanation */}
+        <div
+          style={{
+            padding: "12px",
+            background: "#fffbeb",
+            border: "1px solid #fef08a",
+            borderRadius: "8px",
+            fontSize: "12px",
+            color: "#92400e",
+          }}
+        >
+          <strong>What to look for:</strong>{" "}
+          Event generation and cell set times measure data loading overhead. The
+          real bottleneck is the O(n) suggestion recomputation in the
+          aggregator, which runs when events change. At 5K+ events, you may
+          notice lag when the autocomplete items list updates. The autocomplete
+          typing itself is purely internal Lit state and should remain fast.
+        </div>
+      </ct-vstack>
+    ),
+    loadedCount,
+    genMs,
+    loadMs,
+  };
+});


### PR DESCRIPTION
## Summary

- Add **folksonomy-aggregator.test.tsx** — a pattern test with 18 assertions across 7 test sections validating the folksonomy aggregator's correctness under load (basic posting, multi-scope isolation, preferential attachment sort order, remove handling, large batch of 500 events, invalid event rejection with recovery, dense scope with 100 unique tags)
- Add **folksonomy-stress-test.tsx** — a deployable performance test pattern with scale buttons (100/500/1K/5K/10K events), timing instrumentation, live aggregator output stats, and an interactive FolksonomyTags autocomplete instance for hands-on latency testing

Both files use realistic synthetic data (food/cooking vocabulary for tags and scopes) and follow the module-scope `handler()` pattern to avoid reactive context errors.

Follows up on the folksonomy tags system from #2785.

## Test plan

- [ ] `deno task ct test packages/patterns/experimental/folksonomy-aggregator.test.tsx --verbose` — all 18 assertions pass
- [ ] Deploy `folksonomy-stress-test.tsx`, click scale buttons, verify timing metrics populate and autocomplete suggestions appear with real words
- [ ] `deno fmt` and `deno lint` pass on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a correctness test suite and a deployable stress test for the folksonomy aggregator to validate behavior and measure performance from 100 to 10K events. This improves confidence in tag suggestions and makes latency profiling straightforward.

- **New Features**
  - Added folksonomy-aggregator.test.tsx with 18 assertions across 7 areas: basic posting, multi-scope isolation, sort by count, removes, 500-event batch, invalid event rejection with recovery, and a dense scope (100 tags).
  - Added folksonomy-stress-test.tsx with scale buttons (100/500/1K/5K/10K), timing metrics (generation and load), live aggregator stats, and an interactive FolksonomyTags autocomplete for hands-on latency testing.

<sup>Written for commit 3f91c32438bd8cb669d8ddeb35a74002562f5d8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

