### PR TITLE
fix(check): increase V8 heap limit and allow Deno 2.6.9

### DIFF
--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -2,7 +2,7 @@
 set -e
 shopt -s extglob nullglob
 
-DENO_VERSIONS_ALLOWED=("2.5.2" "2.6.4")
+DENO_VERSIONS_ALLOWED=("2.5.2" "2.6.4" "2.6.9")
 # This is more portable than parsing `deno --version`
 DENO_VERSION=$(echo "console.log(Deno.version.deno)" | deno run -)
 if [[ ! " ${DENO_VERSIONS_ALLOWED[@]} " =~ " ${DENO_VERSION} " ]]; then
@@ -100,6 +100,6 @@ if [[ "${GITHUB_ACTION}" != '' ]]; then
     reloadArg=(--reload)
 fi
 
-deno check "${reloadArg[@]}" "${FILES_TO_CHECK[@]}"
+DENO_V8_FLAGS="--max-old-space-size=8192" deno check "${reloadArg[@]}" "${FILES_TO_CHECK[@]}"
 
 echo "Type check complete."


### PR DESCRIPTION
## Summary
- Increase V8 `--max-old-space-size` to 8GB for `deno check` to prevent OOM during pre-commit type checking
- Add Deno 2.6.9 to the allowed versions list in `check.sh`

## Context
Some people are hitting OOM during the git pre-commit hook when `deno check` type-checks the full workspace. The default V8 old-space heap limit (~1.7GB) is insufficient for the size of our type graph.

The fix uses `DENO_V8_FLAGS="--max-old-space-size=8192"` scoped to the `deno check` invocation. `--max-old-space-size` controls the V8 "old space" heap — where long-lived objects like ASTs, symbol tables, and type graphs accumulate during type checking. This is the standard knob for addressing OOM in Deno/Node. See [denoland/deno#18935](https://github.com/denoland/deno/issues/18935) for prior discussion of this issue.

## Test plan
- [ ] Run `deno task check` on a machine that was previously OOMing
- [ ] Verify Deno 2.6.9 passes the version check

🤖 Generated with [Claude Code](https://claude.com/claude-code)