### PR TITLE
fix(runtime-client): silence errors during worker teardown race

### DIFF
--- a/packages/runtime-client/backends/web-worker/index.ts
+++ b/packages/runtime-client/backends/web-worker/index.ts
@@ -40,7 +40,11 @@ self.addEventListener("message", async (event: MessageEvent) => {
       throw new Error("WorkerRuntime not initialized.");
     }
     if (worker.isDisposed()) {
-      throw new Error("WorkerRuntime is disposed.");
+      // After disposal, silently ack any late-arriving requests.
+      // Components may still be unsubscribing or finishing in-flight
+      // operations during teardown — no point erroring on these.
+      self.postMessage({ msgId });
+      return;
     }
 
     const response = await worker.handleRequest(request);


### PR DESCRIPTION
## Summary
- When navigating between spaces, the old runtime worker is disposed while Lit components are still tearing down
- Components trying to unsubscribe from cells on the disposed worker caused console errors: "WorkerRuntime is disposed" and "[RuntimeClient] Unsubscription failed"
- Fix at two layers:
  - **Worker**: silently ack late-arriving requests after disposal instead of throwing
  - **Connection**: skip IPC for unsubscribe/unmount/event calls after `dispose()` has been called

## Root Cause
`RootView` calls `previous.dispose()` as fire-and-forget (not awaited). The worker immediately sets `_isDisposed = true`. Meanwhile, Lit fires `disconnectedCallback` on old components which try to unsubscribe through the now-disposed connection. The disposal and component teardown are concurrent with no coordination.

## Test plan
- [ ] Navigate between spaces (home → other space → home)
- [ ] Check console for absence of "WorkerRuntime is disposed" errors
- [ ] Check console for absence of "[RuntimeClient] Unsubscription failed" errors
- [ ] Verify pieces render correctly after navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a teardown race between worker disposal and component unmounts when navigating between spaces. Stops “WorkerRuntime is disposed” and “[RuntimeClient] Unsubscription failed” console errors by acknowledging late messages and skipping post-dispose IPC.

- **Bug Fixes**
  - Worker: after disposal, silently ack late requests instead of throwing.
  - RuntimeConnection: add a disposed flag; no-op unsubscribe, VDOM events, and unmount after dispose(), and set the flag in dispose().

<sup>Written for commit 67534fe02fc2c1beba997ea843ee0c756f2f1b54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

