### PR TITLE
fix(runner): prevent Invalid recipe error when using subpatterns in .map()

### DIFF
--- a/packages/patterns/todo-list/todo-list.tsx
+++ b/packages/patterns/todo-list/todo-list.tsx
@@ -35,6 +35,33 @@ interface TodoListOutput {
 
 // ===== Pattern =====
 
+export const TodoItemPiece = pattern<
+  {
+    item: TodoItem;
+    removeItem: Stream<{ item: TodoItem }>;
+  },
+  { [UI]: VNode; [NAME]: string }
+>(({ item, removeItem }) => {
+  return {
+    [NAME]: "Todo Item",
+    [UI]: (
+      <ct-card>
+        <ct-hstack gap="2" align="center">
+          <ct-checkbox $checked={item.done} />
+          <ct-input
+            $value={item.title}
+            style="flex: 1;"
+            placeholder="Todo item..."
+          />
+          <ct-button variant="ghost" onClick={() => removeItem.send({ item })}>
+            x
+          </ct-button>
+        </ct-hstack>
+      </ct-card>
+    ),
+  };
+});
+
 export default pattern<TodoListInput, TodoListOutput>(({ items }) => {
   // Pattern-body actions - preferred for single-use handlers that close over
   // this pattern's state.
@@ -69,22 +96,7 @@ export default pattern<TodoListInput, TodoListOutput>(({ items }) => {
         <ct-vscroll flex showScrollbar fadeEdges>
           <ct-vstack gap="2" style="padding: 1rem;">
             {items.map((item) => (
-              <ct-card>
-                <ct-hstack gap="2" align="center">
-                  <ct-checkbox $checked={item.done} />
-                  <ct-input
-                    $value={item.title}
-                    style="flex: 1;"
-                    placeholder="Todo item..."
-                  />
-                  <ct-button
-                    variant="ghost"
-                    onClick={() => removeItem.send({ item })}
-                  >
-                    x
-                  </ct-button>
-                </ct-hstack>
-              </ct-card>
+              <TodoItemPiece item={item} removeItem={removeItem} />
             ))}
 
             {hasNoItems

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1683,9 +1683,14 @@ export class Runner {
       );
     }
 
+    // CT-1230: Pass bindRecipes: false to prevent premature alias binding in recipe
+    // arguments. When a subpattern is passed to map(), its aliases should not be
+    // bound to the current doc yet - they need to remain unbound until the recipe
+    // is actually instantiated for each mapped item.
     const mappedInputBindings = unwrapOneLevelAndBindtoDoc(
       inputBindings,
       processCell,
+      { bindRecipes: false },
     );
     const mappedOutputBindings = unwrapOneLevelAndBindtoDoc(
       outputBindings,


### PR DESCRIPTION
## Summary

- Fixes "Invalid recipe" error when using subpatterns (child patterns) inside `.map()` calls
- Adds defensive workarounds with detailed comments explaining the root cause and uncertainty
- Includes a regression test pattern (todo-list with TodoItemPiece subpattern)

## Problem

When a subpattern is passed to `.map()`, its `$alias` bindings were being bound to a specific doc too early (or re-used across runs). This caused handler `$event` aliases to point at stale docs, so the stream sentinel wasn't found and the handler was incorrectly treated as a lift.

## Solution

Three coordinated workarounds:

1. **moduleToJSON**: Preserve recipe structure using `toJSONWithLegacyAliases` instead of stringifying the factory function
2. **unwrapOneLevelAndBindtoDoc**: New `bindRecipes` option to skip/defer binding inside recipe values, plus rebinding logic for stale local aliases
3. **instantiateRawNode**: Pass `bindRecipes: false` to prevent premature alias binding in recipe arguments

All changes include comments noting we're not certain this is the correct architectural fix vs masking a deeper issue with how recipes capture execution context.

## Test plan

- [x] Type checks pass
- [x] All runner tests pass
- [x] Manual test: Deploy todo-list pattern, add items, verify no "Invalid recipe" error
- [x] Manual test: Verify subpattern handlers (like removeItem) work correctly

Fixes CT-1230

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes "Invalid recipe" errors when using subpatterns inside .map() by deferring $alias binding and preserving recipe structure during serialization. Addresses CT-1230; mapped subpattern handlers now work as expected.

- **Bug Fixes**
  - Serializer: moduleToJSON now preserves recipe structure with toJSONWithLegacyAliases instead of stringifying functions.
  - Binding: unwrapOneLevelAndBindtoDoc adds a bindRecipes flag to skip binding inside recipe values, rebinds local aliases if stale, and clears aliases when not binding.
  - Runner: passes bindRecipes: false when preparing map/raw node inputs to avoid premature alias binding.
  - Regression: todo-list now uses a TodoItemPiece subpattern to exercise the .map() path and verify no "Invalid recipe" error.

<sup>Written for commit bff8710ac29aedd6e7f1019e3b1f6a64e846eb6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

