### PR TITLE
feat(toolshed): autodiscover LLM models from AI gateway

### DIFF
--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -53,6 +53,7 @@ const EnvSchema = z.object({
   CTTS_AI_LLM_GOOGLE_VERTEX_PROJECT: z.string().default(""),
   CTTS_AI_LLM_GOOGLE_VERTEX_LOCATION: z.string().default(""),
   CTTS_AI_LLM_XAI_API_KEY: z.string().default(""),
+  CTTS_AI_LLM_GATEWAY_URL: z.string().default(""),
 
   // LLM Observability Tool
   CTTS_AI_LLM_PHOENIX_PROJECT: z.string().default(""),

--- a/packages/toolshed/routes/ai/llm/models.ts
+++ b/packages/toolshed/routes/ai/llm/models.ts
@@ -389,6 +389,38 @@ if (env.CTTS_AI_LLM_GOOGLE_APPLICATION_CREDENTIALS) {
   });
 }
 
+if (env.CTTS_AI_LLM_GATEWAY_URL) {
+  try {
+    const gatewayUrl = env.CTTS_AI_LLM_GATEWAY_URL;
+    const res = await fetch(`${gatewayUrl}/v1/models`);
+    const data = await res.json();
+
+    const gatewayProvider = createOpenAI({
+      baseURL: `${gatewayUrl}/v1`,
+      apiKey: "gateway",
+    });
+    console.log(" Adding 🤖 gateway");
+
+    for (const model of data.data) {
+      const modelId = model.id;
+      const capabilities = model.capabilities;
+      if (!capabilities) {
+        console.warn(`  Skipping gateway model ${modelId}: no capabilities`);
+        continue;
+      }
+
+      addModel({
+        provider: gatewayProvider,
+        name: `gateway:${modelId}`,
+        aliases: [modelId],
+        capabilities,
+      });
+    }
+  } catch (err) {
+    console.error(" Failed to discover gateway models:", err);
+  }
+}
+
 export const findModel = (name: string) => {
   return MODELS[name];
 };


### PR DESCRIPTION
## Summary

- Adds `CTTS_AI_LLM_GATEWAY_URL` env var to toolshed
- When set, fetches `${GATEWAY_URL}/v1/models` at startup and registers all models with their capabilities
- Uses a single `createOpenAI` provider pointed at the gateway (which handles auth/routing)
- Models registered as `gateway:${modelId}` with the bare model ID as an alias
- Wrapped in try/catch so gateway being down doesn't prevent toolshed from starting

Companion PR in `infra`: https://github.com/commontoolsinc/infra/pull/20

## Test plan

- [ ] Set `CTTS_AI_LLM_GATEWAY_URL=http://10.128.15.193` and start toolshed
- [ ] Confirm gateway models appear in startup logs ("Adding 🤖 gateway")
- [ ] Verify models available at `/api/ai/llm/models`
- [ ] Test without the env var — no gateway models, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-discovers and registers LLM models from the gateway at startup when CTTS_AI_LLM_GATEWAY_URL is set. Falls back cleanly if the gateway is unreachable.

- **New Features**
  - Adds CTTS_AI_LLM_GATEWAY_URL env var.
  - Fetches {GATEWAY_URL}/v1/models and registers each model as gateway:{id} with alias {id} and its capabilities.
  - Uses a single OpenAI-compatible provider pointed at the gateway; no local auth needed.

- **Migration**
  - Set CTTS_AI_LLM_GATEWAY_URL to your gateway base URL (e.g., http://host).
  - Verify models at /api/ai/llm/models; leave unset to disable.

<sup>Written for commit ff45feb147d10cb921c5e07c39becfbd6ce0de94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

