### PR TITLE
test(ts-transformers): regression tests for CT-1186 map-inside-computed

### DIFF
--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.tsx
@@ -1,0 +1,194 @@
+import * as __ctHelpers from "commontools";
+/**
+ * Regression: .map() on a destructured property from a computed result
+ * inside another computed() should NOT be transformed to .mapWithPattern().
+ *
+ * Inside a derive callback, OpaqueRef values are unwrapped to plain JS,
+ * so destructured `tasks` is a plain array.
+ */
+import { computed, recipe, UI } from "commontools";
+interface Item {
+    name: string;
+    done: boolean;
+}
+export default recipe({
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            }
+        }
+    },
+    required: ["items"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["name", "done"]
+        }
+    }
+} as const satisfies __ctHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $UI: {
+            $ref: "#/$defs/JSXElement"
+        }
+    },
+    required: ["$UI"],
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    type: "object",
+                    properties: {}
+                }, {
+                    $ref: "#/$defs/UIRenderable",
+                    asOpaque: true
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __ctHelpers.JSONSchema, ({ items }) => {
+    const result = __ctHelpers.derive({
+        type: "object",
+        properties: {
+            items: {
+                type: "array",
+                items: {
+                    $ref: "#/$defs/Item"
+                },
+                asOpaque: true
+            }
+        },
+        required: ["items"],
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    done: {
+                        type: "boolean"
+                    }
+                },
+                required: ["name", "done"]
+            }
+        }
+    } as const satisfies __ctHelpers.JSONSchema, {
+        type: "object",
+        properties: {
+            tasks: {
+                type: "array",
+                items: {
+                    $ref: "#/$defs/Item",
+                    asOpaque: true
+                }
+            },
+            view: {
+                type: "string"
+            }
+        },
+        required: ["tasks", "view"],
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    done: {
+                        type: "boolean"
+                    }
+                },
+                required: ["name", "done"]
+            }
+        }
+    } as const satisfies __ctHelpers.JSONSchema, { items: items }, ({ items }) => ({
+        tasks: items.filter((i) => !i.done),
+        view: "inbox",
+    }));
+    return {
+        [UI]: (<div>
+        {__ctHelpers.derive({
+                type: "object",
+                properties: {
+                    result: {
+                        type: "object",
+                        properties: {
+                            tasks: {
+                                type: "array",
+                                items: {
+                                    $ref: "#/$defs/Item",
+                                    asOpaque: true
+                                }
+                            },
+                            view: {
+                                type: "string"
+                            }
+                        },
+                        required: ["tasks", "view"],
+                        asOpaque: true
+                    }
+                },
+                required: ["result"],
+                $defs: {
+                    Item: {
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string"
+                            },
+                            done: {
+                                type: "boolean"
+                            }
+                        },
+                        required: ["name", "done"]
+                    }
+                }
+            } as const satisfies __ctHelpers.JSONSchema, {
+                type: "array",
+                items: {
+                    $ref: "#/$defs/UIRenderable"
+                },
+                asOpaque: true,
+                $defs: {
+                    UIRenderable: {
+                        type: "object",
+                        properties: {
+                            $UI: {
+                                $ref: "https://commonfabric.org/schemas/vnode.json"
+                            }
+                        },
+                        required: ["$UI"]
+                    }
+                }
+            } as const satisfies __ctHelpers.JSONSchema, { result: result }, ({ result }) => {
+                const { tasks } = result;
+                return tasks.map((task) => <li>{task.name}</li>);
+            })}
+      </div>),
+    };
+});
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.input.tsx
@@ -1,0 +1,32 @@
+/// <cts-enable />
+/**
+ * Regression: .map() on a destructured property from a computed result
+ * inside another computed() should NOT be transformed to .mapWithPattern().
+ *
+ * Inside a derive callback, OpaqueRef values are unwrapped to plain JS,
+ * so destructured `tasks` is a plain array.
+ */
+import { computed, recipe, UI } from "commontools";
+
+interface Item {
+  name: string;
+  done: boolean;
+}
+
+export default recipe<{ items: Item[] }>("ComputedDestructuredMap", ({ items }) => {
+  const result = computed(() => ({
+    tasks: items.filter((i) => !i.done),
+    view: "inbox",
+  }));
+
+  return {
+    [UI]: (
+      <div>
+        {computed(() => {
+          const { tasks } = result;
+          return tasks.map((task) => <li>{task.name}</li>);
+        })}
+      </div>
+    ),
+  };
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.tsx
@@ -1,0 +1,173 @@
+import * as __ctHelpers from "commontools";
+/**
+ * Regression: .map() on a computed result assigned to a local variable
+ * inside another computed() should NOT be transformed to .mapWithPattern().
+ *
+ * Inside a derive callback, OpaqueRef values are unwrapped to plain JS,
+ * so `localVar` is a plain array and .mapWithPattern() doesn't exist on it.
+ */
+import { computed, recipe, UI } from "commontools";
+interface Item {
+    name: string;
+    price: number;
+}
+export default recipe({
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            }
+        }
+    },
+    required: ["items"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                price: {
+                    type: "number"
+                }
+            },
+            required: ["name", "price"]
+        }
+    }
+} as const satisfies __ctHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $UI: {
+            $ref: "#/$defs/JSXElement"
+        }
+    },
+    required: ["$UI"],
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    type: "object",
+                    properties: {}
+                }, {
+                    $ref: "#/$defs/UIRenderable",
+                    asOpaque: true
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __ctHelpers.JSONSchema, ({ items }) => {
+    const filtered = __ctHelpers.derive({
+        type: "object",
+        properties: {
+            items: {
+                type: "array",
+                items: {
+                    $ref: "#/$defs/Item"
+                },
+                asOpaque: true
+            }
+        },
+        required: ["items"],
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    price: {
+                        type: "number"
+                    }
+                },
+                required: ["name", "price"]
+            }
+        }
+    } as const satisfies __ctHelpers.JSONSchema, {
+        type: "array",
+        items: {
+            $ref: "#/$defs/Item",
+            asOpaque: true
+        },
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    price: {
+                        type: "number"
+                    }
+                },
+                required: ["name", "price"]
+            }
+        }
+    } as const satisfies __ctHelpers.JSONSchema, { items: items }, ({ items }) => items.filter((i) => i.price > 100));
+    return {
+        [UI]: (<div>
+        {__ctHelpers.derive({
+                type: "object",
+                properties: {
+                    filtered: {
+                        type: "array",
+                        items: {
+                            $ref: "#/$defs/Item",
+                            asOpaque: true
+                        },
+                        asOpaque: true
+                    }
+                },
+                required: ["filtered"],
+                $defs: {
+                    Item: {
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string"
+                            },
+                            price: {
+                                type: "number"
+                            }
+                        },
+                        required: ["name", "price"]
+                    }
+                }
+            } as const satisfies __ctHelpers.JSONSchema, {
+                type: "array",
+                items: {
+                    $ref: "#/$defs/UIRenderable"
+                },
+                asOpaque: true,
+                $defs: {
+                    UIRenderable: {
+                        type: "object",
+                        properties: {
+                            $UI: {
+                                $ref: "https://commonfabric.org/schemas/vnode.json"
+                            }
+                        },
+                        required: ["$UI"]
+                    }
+                }
+            } as const satisfies __ctHelpers.JSONSchema, { filtered: filtered }, ({ filtered }) => {
+                const localVar = filtered;
+                return localVar.map((item) => <li>{item.name}</li>);
+            })}
+      </div>),
+    };
+});
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.input.tsx
@@ -1,0 +1,29 @@
+/// <cts-enable />
+/**
+ * Regression: .map() on a computed result assigned to a local variable
+ * inside another computed() should NOT be transformed to .mapWithPattern().
+ *
+ * Inside a derive callback, OpaqueRef values are unwrapped to plain JS,
+ * so `localVar` is a plain array and .mapWithPattern() doesn't exist on it.
+ */
+import { computed, recipe, UI } from "commontools";
+
+interface Item {
+  name: string;
+  price: number;
+}
+
+export default recipe<{ items: Item[] }>("ComputedLocalVarMap", ({ items }) => {
+  const filtered = computed(() => items.filter((i) => i.price > 100));
+
+  return {
+    [UI]: (
+      <div>
+        {computed(() => {
+          const localVar = filtered;
+          return localVar.map((item) => <li>{item.name}</li>);
+        })}
+      </div>
+    ),
+  };
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.tsx
@@ -1,0 +1,192 @@
+import * as __ctHelpers from "commontools";
+/**
+ * Regression: .map() on a property access of a computed result inside
+ * another computed() should NOT be transformed to .mapWithPattern().
+ *
+ * Inside a derive callback, OpaqueRef values are unwrapped to plain JS,
+ * so `result.tasks` is a plain array.
+ */
+import { computed, recipe, UI } from "commontools";
+interface Item {
+    name: string;
+    done: boolean;
+}
+export default recipe({
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            }
+        }
+    },
+    required: ["items"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["name", "done"]
+        }
+    }
+} as const satisfies __ctHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $UI: {
+            $ref: "#/$defs/JSXElement"
+        }
+    },
+    required: ["$UI"],
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    type: "object",
+                    properties: {}
+                }, {
+                    $ref: "#/$defs/UIRenderable",
+                    asOpaque: true
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __ctHelpers.JSONSchema, ({ items }) => {
+    const result = __ctHelpers.derive({
+        type: "object",
+        properties: {
+            items: {
+                type: "array",
+                items: {
+                    $ref: "#/$defs/Item"
+                },
+                asOpaque: true
+            }
+        },
+        required: ["items"],
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    done: {
+                        type: "boolean"
+                    }
+                },
+                required: ["name", "done"]
+            }
+        }
+    } as const satisfies __ctHelpers.JSONSchema, {
+        type: "object",
+        properties: {
+            tasks: {
+                type: "array",
+                items: {
+                    $ref: "#/$defs/Item",
+                    asOpaque: true
+                }
+            },
+            view: {
+                type: "string"
+            }
+        },
+        required: ["tasks", "view"],
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    done: {
+                        type: "boolean"
+                    }
+                },
+                required: ["name", "done"]
+            }
+        }
+    } as const satisfies __ctHelpers.JSONSchema, { items: items }, ({ items }) => ({
+        tasks: items.filter((i) => !i.done),
+        view: "inbox",
+    }));
+    return {
+        [UI]: (<div>
+        {__ctHelpers.derive({
+                type: "object",
+                properties: {
+                    result: {
+                        type: "object",
+                        properties: {
+                            tasks: {
+                                type: "array",
+                                items: {
+                                    $ref: "#/$defs/Item",
+                                    asOpaque: true
+                                },
+                                asOpaque: true
+                            }
+                        },
+                        required: ["tasks"]
+                    }
+                },
+                required: ["result"],
+                $defs: {
+                    Item: {
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string"
+                            },
+                            done: {
+                                type: "boolean"
+                            }
+                        },
+                        required: ["name", "done"]
+                    }
+                }
+            } as const satisfies __ctHelpers.JSONSchema, {
+                type: "array",
+                items: {
+                    $ref: "#/$defs/UIRenderable"
+                },
+                asOpaque: true,
+                $defs: {
+                    UIRenderable: {
+                        type: "object",
+                        properties: {
+                            $UI: {
+                                $ref: "https://commonfabric.org/schemas/vnode.json"
+                            }
+                        },
+                        required: ["$UI"]
+                    }
+                }
+            } as const satisfies __ctHelpers.JSONSchema, { result: {
+                    tasks: result.tasks
+                } }, ({ result }) => {
+                return result.tasks.map((task) => <li>{task.name}</li>);
+            })}
+      </div>),
+    };
+});
+// @ts-ignore: Internals
+function h(...args: any[]) { return __ctHelpers.h.apply(null, args); }
+// @ts-ignore: Internals
+h.fragment = __ctHelpers.h.fragment;

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.input.tsx
@@ -1,0 +1,31 @@
+/// <cts-enable />
+/**
+ * Regression: .map() on a property access of a computed result inside
+ * another computed() should NOT be transformed to .mapWithPattern().
+ *
+ * Inside a derive callback, OpaqueRef values are unwrapped to plain JS,
+ * so `result.tasks` is a plain array.
+ */
+import { computed, recipe, UI } from "commontools";
+
+interface Item {
+  name: string;
+  done: boolean;
+}
+
+export default recipe<{ items: Item[] }>("ComputedPropertyAccessMap", ({ items }) => {
+  const result = computed(() => ({
+    tasks: items.filter((i) => !i.done),
+    view: "inbox",
+  }));
+
+  return {
+    [UI]: (
+      <div>
+        {computed(() => {
+          return result.tasks.map((task) => <li>{task.name}</li>);
+        })}
+      </div>
+    ),
+  };
+});


### PR DESCRIPTION
## Summary

- Adds three regression test fixtures verifying that `.map()` on computed results inside another `computed()` is NOT incorrectly transformed to `.mapWithPattern()`
- Covers the three scenarios from [CT-1186](https://linear.app/common-tools/issue/CT-1186): local variable assignment, destructuring, and property access on computed results
- All three scenarios already produce correct output on main — this PR adds regression coverage to prevent future regressions

## Test plan

- [ ] `deno task test` passes in `packages/ts-transformers/` (39 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests to ensure .map() on computed results inside another computed is not transformed to .mapWithPattern(). Addresses CT-1186 and guards against future "mapWithPattern is not a function" regressions.

- **Test Coverage**
  - Adds 3 fixtures for CT-1186 scenarios: local variable assignment, destructuring, and property access on computed results.
  - Verified via deno task test in packages/ts-transformers (39 passed).

<sup>Written for commit aa349b61a0b72b279481d4ba3a898cbb26d8a262. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

