### PR TITLE
fix(patterns): fix broken store-mapper outline tab

### DIFF
--- a/packages/patterns/store-mapper.tsx
+++ b/packages/patterns/store-mapper.tsx
@@ -1583,145 +1583,143 @@ export default pattern<Input, Output>(
                                   Error analyzing photo. Please try removing and
                                   re-uploading.
                                 </div>,
-                                derive(
-                                  extraction.extractedAisles,
-                                  (
-                                    extracted: { aisles: ExtractedAisle[] },
-                                  ) => {
-                                    const currentAisles = aisles.get();
-                                    if (
-                                      !extracted?.aisles ||
-                                      extracted.aisles.length === 0
-                                    ) {
-                                      return (
-                                        <div
-                                          style={{
-                                            fontSize: "12px",
-                                            color: "#999",
-                                          }}
-                                        >
-                                          No aisles detected in photo
-                                        </div>
-                                      );
-                                    }
-
-                                    // Helper function to check if aisle exists
-                                    // Uses .some() directly on currentAisles (works with reactive proxies)
-                                    const aisleExists = (name: string) => {
-                                      try {
-                                        return currentAisles.some(
-                                          (existing: Aisle) =>
-                                            existing?.name?.toLowerCase?.() ===
-                                              name.toLowerCase(),
-                                        );
-                                      } catch {
-                                        return false;
-                                      }
-                                    };
-
-                                    // Count new aisles
-                                    const newCount = extracted.aisles.filter(
-                                      (e) => !aisleExists(e.name),
-                                    ).length;
-
+                                computed(() => {
+                                  const extracted: {
+                                    aisles: ExtractedAisle[];
+                                  } = extraction.extractedAisles;
+                                  const currentAisles = aisles.get();
+                                  if (
+                                    !extracted?.aisles ||
+                                    extracted.aisles.length === 0
+                                  ) {
                                     return (
-                                      <ct-vstack gap="1">
-                                        {/* Batch add button */}
-                                        {newCount > 0 && (
-                                          <ct-button
-                                            size="sm"
-                                            variant="primary"
-                                            onClick={addAllExtractedAisles({
-                                              aisles,
-                                              extractedList: extracted.aisles,
-                                              hiddenPhotoIds,
-                                              photoId: extraction.photo.id,
-                                            })}
-                                            style="margin-bottom: 0.5rem;"
-                                          >
-                                            + Add All {newCount} New Aisles
-                                          </ct-button>
-                                        )}
+                                      <div
+                                        style={{
+                                          fontSize: "12px",
+                                          color: "#999",
+                                        }}
+                                      >
+                                        No aisles detected in photo
+                                      </div>
+                                    );
+                                  }
 
-                                        {/* Individual aisle results */}
-                                        {extracted.aisles.map(
-                                          (extractedAisle: ExtractedAisle) => {
-                                            const exists = aisleExists(
-                                              extractedAisle.name,
-                                            );
-                                            return (
-                                              <ct-hstack
-                                                gap="2"
-                                                align="center"
-                                                style={`padding: 0.5rem; background: ${
-                                                  exists ? "#fef3c7" : "#dcfce7"
-                                                }; border-radius: 4px;`}
-                                              >
-                                                <div style={{ flex: 1 }}>
-                                                  <strong>
-                                                    Aisle {extractedAisle.name}
-                                                  </strong>
-                                                  {exists && (
-                                                    <span
-                                                      style={{
-                                                        color: "#92400e",
-                                                        marginLeft: "0.5rem",
-                                                        fontSize: "11px",
-                                                      }}
-                                                    >
-                                                      (exists)
-                                                    </span>
-                                                  )}
-                                                  <div
+                                  // Helper function to check if aisle exists
+                                  // Uses .some() directly on currentAisles (works with reactive proxies)
+                                  const aisleExists = (name: string) => {
+                                    try {
+                                      return currentAisles.some(
+                                        (existing: Aisle) =>
+                                          existing?.name?.toLowerCase?.() ===
+                                            name.toLowerCase(),
+                                      );
+                                    } catch {
+                                      return false;
+                                    }
+                                  };
+
+                                  // Count new aisles
+                                  const newCount = extracted.aisles.filter(
+                                    (e) => !aisleExists(e.name),
+                                  ).length;
+
+                                  return (
+                                    <ct-vstack gap="1">
+                                      {/* Batch add button */}
+                                      {newCount > 0 && (
+                                        <ct-button
+                                          size="sm"
+                                          variant="primary"
+                                          onClick={addAllExtractedAisles({
+                                            aisles,
+                                            extractedList: extracted.aisles,
+                                            hiddenPhotoIds,
+                                            photoId: extraction.photo.id,
+                                          })}
+                                          style="margin-bottom: 0.5rem;"
+                                        >
+                                          + Add All {newCount} New Aisles
+                                        </ct-button>
+                                      )}
+
+                                      {/* Individual aisle results */}
+                                      {extracted.aisles.map(
+                                        (extractedAisle: ExtractedAisle) => {
+                                          const exists = aisleExists(
+                                            extractedAisle.name,
+                                          );
+                                          return (
+                                            <ct-hstack
+                                              gap="2"
+                                              align="center"
+                                              style={`padding: 0.5rem; background: ${
+                                                exists ? "#fef3c7" : "#dcfce7"
+                                              }; border-radius: 4px;`}
+                                            >
+                                              <div style={{ flex: 1 }}>
+                                                <strong>
+                                                  Aisle {extractedAisle.name}
+                                                </strong>
+                                                {exists && (
+                                                  <span
                                                     style={{
-                                                      fontSize: "12px",
-                                                      color: "#6b7280",
+                                                      color: "#92400e",
+                                                      marginLeft: "0.5rem",
+                                                      fontSize: "11px",
                                                     }}
                                                   >
-                                                    {(extractedAisle.products ||
-                                                      []).join(", ") ||
-                                                      "(no products)"}
-                                                  </div>
+                                                    (exists)
+                                                  </span>
+                                                )}
+                                                <div
+                                                  style={{
+                                                    fontSize: "12px",
+                                                    color: "#6b7280",
+                                                  }}
+                                                >
+                                                  {(extractedAisle.products ||
+                                                    []).join(", ") ||
+                                                    "(no products)"}
                                                 </div>
-                                                {exists
-                                                  ? (
-                                                    <ct-button
-                                                      size="sm"
-                                                      variant="secondary"
-                                                      onClick={mergeExtractedAisle(
-                                                        {
-                                                          aisles,
-                                                          extracted:
-                                                            extractedAisle,
-                                                        },
-                                                      )}
-                                                    >
-                                                      Merge
-                                                    </ct-button>
-                                                  )
-                                                  : (
-                                                    <ct-button
-                                                      size="sm"
-                                                      variant="primary"
-                                                      onClick={addExtractedAisle(
-                                                        {
-                                                          aisles,
-                                                          extracted:
-                                                            extractedAisle,
-                                                        },
-                                                      )}
-                                                    >
-                                                      Add
-                                                    </ct-button>
-                                                  )}
-                                              </ct-hstack>
-                                            );
-                                          },
-                                        )}
-                                      </ct-vstack>
-                                    );
-                                  },
-                                ),
+                                              </div>
+                                              {exists
+                                                ? (
+                                                  <ct-button
+                                                    size="sm"
+                                                    variant="secondary"
+                                                    onClick={mergeExtractedAisle(
+                                                      {
+                                                        aisles,
+                                                        extracted:
+                                                          extractedAisle,
+                                                      },
+                                                    )}
+                                                  >
+                                                    Merge
+                                                  </ct-button>
+                                                )
+                                                : (
+                                                  <ct-button
+                                                    size="sm"
+                                                    variant="primary"
+                                                    onClick={addExtractedAisle(
+                                                      {
+                                                        aisles,
+                                                        extracted:
+                                                          extractedAisle,
+                                                      },
+                                                    )}
+                                                  >
+                                                    Add
+                                                  </ct-button>
+                                                )}
+                                            </ct-hstack>
+                                          );
+                                        },
+                                      )}
+                                    </ct-vstack>
+                                  );
+                                }),
                               ),
                             )}
                           </div>,


### PR DESCRIPTION
## Summary

- The Outline tab in the store-mapper pattern was silently broken — it rendered an empty `<pre>` block instead of the store layout summary
- Root cause: `derive()` only accepts a single reactive input, but store-mapper was passing arrays of inputs (`derive([a, b, c], ([x, y, z]) => ...)`) — an unsupported calling convention that resolved to an empty `$alias`
- Converted the three broken `derive([...])` calls to idiomatic alternatives:
  1. **Outline generation** → `computed()` with `.get()` on each Writable cell
  2. **Header stats string** → `computed()` with template literal interpolation
  3. **Photo import aisle comparison** → single-input `derive()` with `.get()` for the second dependency

## Test plan

- [x] All 30 existing store-mapper tests pass (previously 4 outline assertions failed)
- [x] `deno fmt` and `deno lint` clean
- [x] No other patterns/recipes in the codebase use the broken `derive([...])` syntax
- [x] No new files created — single file change to `packages/patterns/store-mapper.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken Outline tab in store-mapper by replacing unsupported multi-input derive calls. The outline, header stats, and photo import results now update correctly.

- **Bug Fixes**
  - Rewrote outline generation using computed() with .get() reads.
  - Switched header stats to a computed() string for live counts.
  - Moved photo import aisle comparison to computed() to track both extractedAisles and aisles.

<sup>Written for commit 7fa4b91954ca66c24ef205321f1f31df8e34b515. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

