### PR TITLE
Added return type annotation to CellHandle.toJSON

### DIFF
--- a/packages/html/src/worker/keying.ts
+++ b/packages/html/src/worker/keying.ts
@@ -36,7 +36,7 @@ export function generateKey(node: unknown): string {
  */
 function cellReplacer(_key: string, value: unknown): unknown {
   if (isCell(value)) {
-    // Use getAsNormalizedFullLink which returns the same format as CellHandle.toJSON()
+    // Use getAsNormalizedFullLink
     return value.getAsNormalizedFullLink();
   }
   return value;

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -8,6 +8,7 @@ import {
   isSigilLink,
   type JSONSchema,
   LINK_V1_TAG,
+  type SigilLink,
   type URI,
 } from "@commontools/runner/shared";
 import { $conn, type RuntimeClient } from "./runtime-client.ts";
@@ -266,7 +267,7 @@ export class CellHandle<T = unknown> {
     };
   }
 
-  toJSON() {
+  toJSON(): SigilLink {
     // Wrap in sigil link format so the runtime recognizes this as a link
     // and dereferences it (e.g., when passed through event.detail.sourceCell)
     return {


### PR DESCRIPTION
Added return type annotation to CellHandle.toJSON  and removed portion of comment that was no longer accurate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an explicit SigilLink return type to CellHandle.toJSON for better type safety and clearer API contracts. Also remove an outdated reference in a comment in packages/html/src/worker/keying.ts.

<sup>Written for commit d1b7edf3463bbd0bbf50a6fb4e83d4a2aa8fbd06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

