### PR TITLE
Spec: Blob throws on synchronous conversion path

### DIFF
--- a/docs/specs/space-model-formal-spec/1-storable-values.md
+++ b/docs/specs/space-model-formal-spec/1-storable-values.md
@@ -98,6 +98,22 @@ type StorableValue =
   | { [key: string]: StorableValue };
 ```
 
+> **Excluded JS types.** The following JavaScript types are explicitly **not**
+> storable and cause rejection (thrown error) in `toStorableValueOrThrow()` and
+> `canBeStored()`:
+>
+> - `symbol` — Symbols are inherently local (not serializable across realms or
+>   processes). Symbol-keyed properties on objects are silently ignored; a bare
+>   `symbol` value is rejected outright.
+> - `function` — Functions are opaque closures with no portable representation.
+>   Objects with a `[DECONSTRUCT]` method are not functions in this sense — they
+>   are `StorableInstance`s.
+>
+> These are the two JS primitive types (`typeof` returns `"symbol"` or
+> `"function"`) that are absent from the `StorableValue` union. All other
+> `typeof` results (`"undefined"`, `"boolean"`, `"number"`, `"string"`,
+> `"bigint"`, `"object"`) have corresponding `StorableValue` arms.
+
 #### `StorableNativeObject`
 
 A separate type — **outside** the `StorableValue` hierarchy — defines the raw


### PR DESCRIPTION
## Summary

- `Blob` is already in `StorableNativeObject` (added in PR #2828), but the synchronous conversion path (`toStorableValue()`) cannot handle it -- `Blob` content is only accessible via async methods
- Added `Blob` row to conversion rules table (Section 8.2): documents that it **throws**, with guidance to convert to `Uint8Array` first
- Added "Asymmetry note" to the Blob rationale blockquote (Section 8.5): `Blob` is output-only from `nativeValueFromStorableValue()`; a future async conversion path may accept `Blob` directly

---
-- spec-writer-sage (Claude Opus 4.6)

Co-Authored-By: spec-writer-sage (Claude Opus 4.6) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the spec: Blob throws in the synchronous toStorableValue() path because its bytes are only accessible asynchronously. Adds a conversion-table row telling callers to convert Blob to Uint8Array first, an asymmetry note that Blob is output-only from nativeValueFromStorableValue(), and an “Excluded JS types” note that symbol and function are non-storable and rejected by toStorableValueOrThrow() and canBeStored().

<sup>Written for commit 75041985ccbfbe22dca18e016204859b056a7b3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

