### PR TITLE
fix(notebook): use .get() on Writable title in NAME computed

### DIFF
--- a/packages/patterns/notes/notebook.tsx
+++ b/packages/patterns/notes/notebook.tsx
@@ -921,7 +921,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
 
     return {
       // Include 📓 marker in NAME for reliable identification through proxy
-      [NAME]: computed(() => `📓 ${title} (${noteCount})`),
+      [NAME]: computed(() => `📓 ${title.get()} (${noteCount})`),
       isNotebook,
       isHidden,
       [UI]: (


### PR DESCRIPTION
## Summary
- The notebook `[NAME]` computed was interpolating `title` (a `Writable` cell) directly in a template literal, producing `📓 [object Object] (0)` instead of `📓 Notebook (0)`
- Added `.get()` to unwrap the Writable before string interpolation

## Test plan
- [x] Deployed to saga-castor toolshed and verified title renders correctly
- [x] `ct check --no-run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes notebook NAME display by unwrapping the Writable title with .get(), preventing "[object Object]" and showing the correct title (e.g., "📓 Notebook (0)").

<sup>Written for commit ad085196a38f53d4114666b71e5e6eab3af386d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

