### PR TITLE
fix(patterns): default all scopes to checked in google-auth wrappers

### DIFF
--- a/packages/patterns/google/core/google-auth-personal.tsx
+++ b/packages/patterns/google/core/google-auth-personal.tsx
@@ -19,13 +19,13 @@ import GoogleAuth, {
 interface Input {
   selectedScopes: Default<SelectedScopes, {
     gmail: true;
-    gmailSend: false;
-    gmailModify: false;
+    gmailSend: true;
+    gmailModify: true;
     calendar: true;
-    calendarWrite: false;
-    drive: false;
-    docs: false;
-    contacts: false;
+    calendarWrite: true;
+    drive: true;
+    docs: true;
+    contacts: true;
   }>;
   auth: Default<
     Auth,

--- a/packages/patterns/google/core/google-auth-work.tsx
+++ b/packages/patterns/google/core/google-auth-work.tsx
@@ -19,13 +19,13 @@ import GoogleAuth, {
 interface Input {
   selectedScopes: Default<SelectedScopes, {
     gmail: true;
-    gmailSend: false;
-    gmailModify: false;
+    gmailSend: true;
+    gmailModify: true;
     calendar: true;
-    calendarWrite: false;
-    drive: false;
-    docs: false;
-    contacts: false;
+    calendarWrite: true;
+    drive: true;
+    docs: true;
+    contacts: true;
   }>;
   auth: Default<
     Auth,


### PR DESCRIPTION
## Summary

- The base `google-auth.tsx` pattern defaults all 8 OAuth scopes to `true`, but the `google-auth-personal.tsx` and `google-auth-work.tsx` wrapper patterns only defaulted `gmail` and `calendar` to `true`
- This caused users to see most scope checkboxes unchecked on first load when using the personal/work wrappers, which is unexpected
- Aligns both wrappers to default all scopes to `true`, matching the base pattern behavior

## Changes

Only the `Default<SelectedScopes, ...>` type annotations in two files — changing `false` to `true` for these scopes:
- `gmailSend`
- `gmailModify`
- `calendarWrite`
- `drive`
- `docs`
- `contacts`

No logic, UI, or runtime changes.

## Test plan

- [ ] Deploy `google-auth-personal` and confirm all 8 scope checkboxes are checked on first load
- [ ] Deploy `google-auth-work` and confirm all 8 scope checkboxes are checked on first load
- [ ] Verify existing pieces with saved scope preferences are not affected (persisted cell values take precedence over defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default all 8 Google OAuth scopes to checked in google-auth-personal and google-auth-work wrappers to match the base google-auth pattern. This prevents confusing unchecked boxes on first load.

- **Bug Fixes**
  - Set gmailSend, gmailModify, calendarWrite, drive, docs, contacts to true in Default<SelectedScopes> for both wrappers.
  - No logic, UI, or runtime changes; saved scope preferences still take precedence.

<sup>Written for commit af039d41cebdf14b7e3580e658637bdbfc651a3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

