### PR TITLE
Rename isStorable() to isStorableInstance()

### DIFF
--- a/packages/memory/storable-native-instances.ts
+++ b/packages/memory/storable-native-instances.ts
@@ -1,7 +1,7 @@
 import type { StorableValue } from "./interface.ts";
 import {
   DECONSTRUCT,
-  isStorable,
+  isStorableInstance,
   RECONSTRUCT,
   type ReconstructionContext,
   type StorableInstance,
@@ -530,7 +530,7 @@ export function deepNativeValueFromStorableValue(
   }
 
   // Other StorableInstance (Cell, Stream, UnknownStorable, etc.) -- pass through.
-  if (isStorable(value)) return value;
+  if (isStorableInstance(value)) return value;
 
   // Storable primitives (null, undefined, boolean, number, string, bigint)
   // pass through. Note: `symbol` and `function` are NOT storable and cannot

--- a/packages/memory/storable-protocol.ts
+++ b/packages/memory/storable-protocol.ts
@@ -76,7 +76,7 @@ export interface ReconstructionContext {
  * Type guard: checks whether a value implements the storable protocol. The
  * presence of `[DECONSTRUCT]` is the brand. See Section 2.6 of the formal spec.
  */
-export function isStorable(value: unknown): value is StorableInstance {
+export function isStorableInstance(value: unknown): value is StorableInstance {
   return value != null &&
     typeof value === "object" &&
     DECONSTRUCT in value;

--- a/packages/memory/test/serialization-test.ts
+++ b/packages/memory/test/serialization-test.ts
@@ -8,7 +8,11 @@ import {
 } from "../serialization.ts";
 import { JsonEncodingContext } from "../json-encoding.ts";
 import type { ReconstructionContext } from "../storable-protocol.ts";
-import { DECONSTRUCT, isStorable, RECONSTRUCT } from "../storable-protocol.ts";
+import {
+  DECONSTRUCT,
+  isStorableInstance,
+  RECONSTRUCT,
+} from "../storable-protocol.ts";
 import type { StorableClass, StorableInstance } from "../storable-protocol.ts";
 import type { StorableValue } from "../interface.ts";
 import type { SerializedForm } from "../json-serialization-context.ts";
@@ -823,37 +827,37 @@ describe("serialization", () => {
   });
 
   // --------------------------------------------------------------------------
-  // storable-protocol: isStorable type guard
+  // storable-protocol: isStorableInstance type guard
   // --------------------------------------------------------------------------
 
-  describe("isStorable type guard", () => {
+  describe("isStorableInstance type guard", () => {
     it("returns false for null", () => {
-      expect(isStorable(null)).toBe(false);
+      expect(isStorableInstance(null)).toBe(false);
     });
 
     it("returns false for undefined", () => {
-      expect(isStorable(undefined)).toBe(false);
+      expect(isStorableInstance(undefined)).toBe(false);
     });
 
     it("returns false for primitives", () => {
-      expect(isStorable(42)).toBe(false);
-      expect(isStorable("hello")).toBe(false);
-      expect(isStorable(true)).toBe(false);
+      expect(isStorableInstance(42)).toBe(false);
+      expect(isStorableInstance("hello")).toBe(false);
+      expect(isStorableInstance(true)).toBe(false);
     });
 
     it("returns false for plain objects", () => {
-      expect(isStorable({})).toBe(false);
-      expect(isStorable({ a: 1 })).toBe(false);
+      expect(isStorableInstance({})).toBe(false);
+      expect(isStorableInstance({ a: 1 })).toBe(false);
     });
 
     it("returns true for UnknownStorable", () => {
       const us = new UnknownStorable("Test@1", null);
-      expect(isStorable(us)).toBe(true);
+      expect(isStorableInstance(us)).toBe(true);
     });
 
     it("returns true for ProblematicStorable", () => {
       const ps = new ProblematicStorable("Test@1", null, "oops");
-      expect(isStorable(ps)).toBe(true);
+      expect(isStorableInstance(ps)).toBe(true);
     });
 
     it("returns true for custom StorableInstance", () => {
@@ -862,7 +866,7 @@ describe("serialization", () => {
           return { value: 42 };
         },
       };
-      expect(isStorable(instance)).toBe(true);
+      expect(isStorableInstance(instance)).toBe(true);
     });
   });
 

--- a/packages/memory/test/storable-native-instances-test.ts
+++ b/packages/memory/test/storable-native-instances-test.ts
@@ -1,6 +1,10 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { DECONSTRUCT, isStorable, RECONSTRUCT } from "../storable-protocol.ts";
+import {
+  DECONSTRUCT,
+  isStorableInstance,
+  RECONSTRUCT,
+} from "../storable-protocol.ts";
 import type { ReconstructionContext } from "../storable-protocol.ts";
 import type { StorableValue } from "../interface.ts";
 import {
@@ -34,9 +38,9 @@ describe("storable-native-instances", () => {
   // --------------------------------------------------------------------------
 
   describe("StorableError", () => {
-    it("implements StorableInstance (isStorable returns true)", () => {
+    it("implements StorableInstance (isStorableInstance returns true)", () => {
       const se = new StorableError(new Error("test"));
-      expect(isStorable(se)).toBe(true);
+      expect(isStorableInstance(se)).toBe(true);
     });
 
     it("has typeTag 'Error@1'", () => {
@@ -263,7 +267,7 @@ describe("storable-native-instances", () => {
   describe("stub wrappers", () => {
     it("StorableMap implements StorableInstance", () => {
       const sm = new StorableMap(new Map());
-      expect(isStorable(sm)).toBe(true);
+      expect(isStorableInstance(sm)).toBe(true);
       expect(sm.typeTag).toBe("Map@1");
     });
 
@@ -303,7 +307,7 @@ describe("storable-native-instances", () => {
 
     it("StorableSet implements StorableInstance", () => {
       const ss = new StorableSet(new Set());
-      expect(isStorable(ss)).toBe(true);
+      expect(isStorableInstance(ss)).toBe(true);
       expect(ss.typeTag).toBe("Set@1");
     });
 
@@ -332,7 +336,7 @@ describe("storable-native-instances", () => {
 
     it("StorableDate implements StorableInstance", () => {
       const sd = new StorableDate(new Date());
-      expect(isStorable(sd)).toBe(true);
+      expect(isStorableInstance(sd)).toBe(true);
       expect(sd.typeTag).toBe("Date@1");
     });
 
@@ -360,7 +364,7 @@ describe("storable-native-instances", () => {
 
     it("StorableUint8Array implements StorableInstance", () => {
       const su = new StorableUint8Array(new Uint8Array([1, 2, 3]));
-      expect(isStorable(su)).toBe(true);
+      expect(isStorableInstance(su)).toBe(true);
       expect(su.typeTag).toBe("Bytes@1");
     });
 

--- a/packages/memory/type-handlers.ts
+++ b/packages/memory/type-handlers.ts
@@ -1,7 +1,7 @@
 import type { StorableValue } from "./interface.ts";
 import {
   DECONSTRUCT,
-  isStorable,
+  isStorableInstance,
   RECONSTRUCT,
   type ReconstructionContext,
   type StorableConverter,
@@ -273,7 +273,7 @@ export const StorableInstanceHandler: TypeHandler = {
   tag: "",
 
   canSerialize(value: StorableValue): boolean {
-    return isStorable(value);
+    return isStorableInstance(value);
   },
 
   serialize(
@@ -321,7 +321,7 @@ export const StorableInstanceHandler: TypeHandler = {
  */
 export function createDefaultRegistry(): TypeHandlerRegistry {
   const registry = new TypeHandlerRegistry();
-  // StorableInstance first (most specific -- checked via isStorable brand).
+  // StorableInstance first (most specific -- checked via isStorableInstance brand).
   registry.register(StorableInstanceHandler);
   // Error before undefined (Error is a broader instanceof check).
   registry.register(ErrorHandler);


### PR DESCRIPTION
## Summary

- Rename `isStorable()` to `isStorableInstance()` across the `packages/memory/` codebase to align with the formal spec (Section 2.6), which already uses `isStorableInstance()`.
- This is a pure mechanical rename with no behavioral changes.
- Split out from Wiring PR #2824 for reviewability.

## Files changed

- `storable-protocol.ts` -- function definition
- `type-handlers.ts` -- import, usage, and comment
- `storable-native-instances.ts` -- import and usage
- `test/serialization-test.ts` -- import, test descriptions, and assertions
- `test/storable-native-instances-test.ts` -- import, test descriptions, and assertions

## Test plan

- [x] `deno fmt --check` passes
- [x] `deno task test` passes (98 tests, 359 steps, 0 failures)
- [x] `deno task check` has only pre-existing type errors (12 errors in `storable-native-instances-test.ts` from `StorableInstance` not yet in `StorableDatum` union -- same count on the base branch)

Co-Authored-By: coder-colt (Claude Opus 4.6) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed isStorable() to isStorableInstance() across the memory package to match the formal spec (Section 2.6). This is a mechanical rename with no behavior changes.

- **Refactors**
  - Updated storable-protocol.ts to export isStorableInstance() and adjusted imports/usages in type-handlers.ts and storable-native-instances.ts.
  - Updated tests to use isStorableInstance() and refreshed related comments.

- **Migration**
  - Replace isStorable(...) with isStorableInstance(...) in any downstream code.

<sup>Written for commit 4f4b7bdb7d07070972a2763a1156db2f691941cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

