### PR TITLE
Inject CT_API_URL into sandbox exec for toolshed access

### DIFF
--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -157,6 +157,10 @@ const EnvSchema = z.object({
   SANDBOX_SERVICE_URL: z.string().default(
     "https://sandbox.stage.commontools.dev",
   ),
+
+  // URL that sandboxes should use to reach the toolshed API (injected as
+  // CT_API_URL into every sandbox exec). Defaults to API_URL if not set.
+  SANDBOX_TOOLSHED_URL: z.string().optional(),
 });
 
 export type env = z.infer<typeof EnvSchema>;

--- a/packages/toolshed/routes/sandbox/exec/exec.handlers.ts
+++ b/packages/toolshed/routes/sandbox/exec/exec.handlers.ts
@@ -99,6 +99,13 @@ export const sandboxExec: AppRouteHandler<SandboxExecRoute> = async (c) => {
 
   logger.info({ sandboxId, command }, "Sandbox exec request");
 
+  // Inject CT_API_URL so `ct` inside sandboxes can reach the toolshed
+  const sandboxToolshedUrl = env.SANDBOX_TOOLSHED_URL || env.API_URL;
+  const mergedEnv: Record<string, string> = {
+    CT_API_URL: sandboxToolshedUrl,
+    ...(environment || {}),
+  };
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeout);
 
@@ -111,7 +118,7 @@ export const sandboxExec: AppRouteHandler<SandboxExecRoute> = async (c) => {
         sandboxId,
         command,
         workingDirectory,
-        environment,
+        mergedEnv,
         controller.signal,
       );
       logger.info(
@@ -131,7 +138,7 @@ export const sandboxExec: AppRouteHandler<SandboxExecRoute> = async (c) => {
           sandboxId,
           command,
           workingDirectory,
-          environment,
+          mergedEnv,
           controller.signal,
         );
         logger.info(


### PR DESCRIPTION
## Summary
- Adds `SANDBOX_TOOLSHED_URL` env var to toolshed config (optional, defaults to `API_URL`)
- Auto-injects `CT_API_URL` into every sandbox exec call so `ct` inside sandboxes can reach the toolshed API
- Covers both the initial exec path and the retry-after-reap path

## Deploy config
Set `SANDBOX_TOOLSHED_URL=http://10.138.0.12:8000` (direct IP) or `http://toolshed.internal:8000` (via `/etc/hosts` injected by common-cluster) in the toolshed deploy env.

## Test plan
- [ ] Deploy with `SANDBOX_TOOLSHED_URL` unset — verify `CT_API_URL` defaults to `API_URL`
- [ ] Deploy with `SANDBOX_TOOLSHED_URL=http://10.138.0.12:8000` — verify `echo $CT_API_URL` in sandbox shows the correct URL
- [ ] Run `ct piece list` inside a sandbox — verify it reaches toolshed and returns results
- [ ] Verify caller-provided env vars in exec still override defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects CT_API_URL into all sandbox exec calls so ct inside sandboxes can reach the toolshed API without manual setup. Adds SANDBOX_TOOLSHED_URL (defaults to API_URL) to control the URL used by sandboxes.

- **New Features**
  - Adds SANDBOX_TOOLSHED_URL env var (optional, falls back to API_URL).
  - Auto-injects CT_API_URL into initial and retry exec paths.
  - Caller-provided env still overrides defaults.

- **Migration**
  - Optionally set SANDBOX_TOOLSHED_URL to the internal toolshed URL (e.g., http://toolshed.internal:8000 or direct IP). If not set, API_URL is used.

<sup>Written for commit c982cd0b11edd82ad0c3678a8a605e8e06ef819e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

