### PR TITLE
Spec: mark toJSON() as legacy, extend StorableNativeObject

### DIFF
--- a/docs/specs/space-model-formal-spec/1-storable-values.md
+++ b/docs/specs/space-model-formal-spec/1-storable-values.md
@@ -139,7 +139,7 @@ type StorableNativeObject =
   | Date
   | Uint8Array
   | Blob
-  | { toJSON(): string }; // Legacy — see below.
+  | { toJSON(): unknown }; // Legacy — see below.
 ```
 
 The `StorableNativeObject` type exists solely at function parameter/return
@@ -147,9 +147,9 @@ boundaries — for example, `toStorableValue()` accepts
 `StorableValue | StorableNativeObject` as input (Section 8). It is never a
 member of `StorableValue` or `StorableDatum`.
 
-> **Legacy: `{ toJSON(): string }` variant.** The `toJSON()` arm of
-> `StorableNativeObject` represents objects that provide a `toJSON()` method
-> returning a string. The conversion functions call `toJSON()` and process the
+> **Legacy: `{ toJSON(): unknown }` variant.** The `toJSON()` arm of
+> `StorableNativeObject` represents objects that provide a `toJSON()` method.
+> The conversion functions call `toJSON()` and process the
 > result (Section 8.2). This variant is **legacy and marked for removal** —
 > callers should migrate to the storable protocol
 > (`[DECONSTRUCT]`/`[RECONSTRUCT]`). See Section 7.1 for migration guidance.


### PR DESCRIPTION
## Summary

Mark `toJSON()` support as legacy in the formal spec and extend `StorableNativeObject` to include a `{ toJSON(): string }` variant, making the `canBeStored()` type predicate sound.

This addresses the soundness concern from comment `2829506961` on PR #2824: the `canBeStored()` type predicate narrows to `StorableValue | StorableNativeObject`, but the implementation also returns `true` for objects with a `toJSON()` method. Rather than just documenting the gap, we extend the type to include `toJSON` objects (with legacy labeling), making the predicate honest.

### Changes

- **Section 1.2 (`StorableNativeObject`):** Add `| { toJSON(): string }` to the union type, with a legacy explanatory blockquote.
- **Section 7.1:** Relabel existing `toJSON()` note with "Legacy:" prefix for consistency.
- **Section 8.2 (conversion rules):** Add legacy blockquote after the conversion rules table, noting `toJSON()` is a transitional mechanism.
- **Section 8.4 (`canBeStored()`):** Update the accepted-types enumeration to include `toJSON` objects; add note explaining the predicate is sound because `StorableNativeObject` includes the legacy variant.

## Test plan

- [ ] Verify spec renders correctly in Markdown preview
- [ ] Confirm all `toJSON()` mentions use consistent "Legacy" labeling
- [ ] Cross-references (Section 1.2, 7.1, 8.2) are accurate
- [ ] `StorableNativeObject` type definition includes the new variant

Co-Authored-By: spec-writer-sage (Claude Opus 4.6) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks toJSON() support as legacy and extends StorableNativeObject with a { toJSON(): unknown } variant so canBeStored() stays a sound type predicate. Consolidates legacy guidance to a single note in Section 1.2.

- **Spec Updates**
  - Add `{ toJSON(): unknown }` as a legacy arm of StorableNativeObject (Section 1.2) with a single annotation.
  - Update canBeStored() accepted types to include toJSON objects as part of StorableNativeObject (Section 8.4).
  - Remove scattered legacy notes and revert Section 7.1 wording.

- **Migration**
  - Migrate to the storable protocol (`[DECONSTRUCT]`/`[RECONSTRUCT]`); the toJSON() path will be removed.

<sup>Written for commit a091b29064036f16824683a124eb916c2ffc68b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

