### PR TITLE
Spec updates and type definitions for three-layer architecture

### DIFF
--- a/packages/memory/deno.json
+++ b/packages/memory/deno.json
@@ -43,7 +43,12 @@
     "./reference": "./reference.ts",
     "./rich-storable-value": "./rich-storable-value.ts",
     "./schema": "./schema.ts",
-    "./storable-value": "./storable-value.ts"
+    "./storable-value": "./storable-value.ts",
+    "./storable-protocol": "./storable-protocol.ts",
+    "./serialization-context": "./serialization-context.ts",
+    "./type-tags": "./type-tags.ts",
+    "./unknown-storable": "./unknown-storable.ts",
+    "./problematic-storable": "./problematic-storable.ts"
   },
   "imports": {
     "@db/sqlite": "jsr:@db/sqlite@^0.12.0",

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -60,6 +60,36 @@ export type StorableValueLayer =
   | unknown[]
   | Record<string, unknown>;
 
+/**
+ * Union of raw native JS **object** types that the storable type system can
+ * convert into `StorableInstance` wrappers. These are the inputs to the
+ * "sausage grinder" -- `toStorableValue()` accepts
+ * `StorableValue | StorableNativeObject`, meaning callers can pass in either
+ * already-storable data or raw native JS objects. The conversion produces
+ * `StorableInstance` wrappers (StorableError, StorableMap, etc.) that live
+ * inside `StorableValue` via the `StorableInstance` arm of `StorableDatum`.
+ *
+ * `Blob` is included because `StorableUint8Array.toNativeValue(true)` returns
+ * a `Blob` (immutable by nature) instead of a `Uint8Array`. The synchronous
+ * serialization path throws on `Blob` since its data access methods are async.
+ *
+ * The `{ toJSON(): unknown }` arm covers objects (and functions) that are
+ * convertible to storable form via their `toJSON()` method. This is a legacy
+ * conversion path but is included here so the `canBeStored()` type predicate
+ * (`value is StorableValue | StorableNativeObject`) remains sound.
+ *
+ * Note: `bigint` is NOT included here -- it is a primitive (like `undefined`)
+ * and belongs directly in `StorableDatum` without wrapping.
+ */
+export type StorableNativeObject =
+  | Error
+  | Map<unknown, unknown>
+  | Set<unknown>
+  | Date
+  | Uint8Array
+  | Blob
+  | { toJSON(): unknown };
+
 export interface Clock {
   now(): UTCUnixTimestampInSeconds;
 }

--- a/packages/memory/problematic-storable.ts
+++ b/packages/memory/problematic-storable.ts
@@ -1,0 +1,35 @@
+import type { StorableValue } from "./interface.ts";
+import {
+  DECONSTRUCT,
+  RECONSTRUCT,
+  type ReconstructionContext,
+  type StorableInstance,
+} from "./storable-protocol.ts";
+
+/**
+ * Holds a value whose deconstruction or reconstruction failed. Preserves the
+ * original tag and raw state for round-tripping and debugging. Used in lenient
+ * mode to allow graceful degradation rather than hard failures.
+ * See Section 3.4 of the formal spec.
+ */
+export class ProblematicStorable implements StorableInstance {
+  constructor(
+    /** The original type tag, e.g. `"MyType@1"`. */
+    readonly typeTag: string,
+    /** The raw state that could not be processed. */
+    readonly state: StorableValue,
+    /** A description of what went wrong. */
+    readonly error: string,
+  ) {}
+
+  [DECONSTRUCT](): StorableValue {
+    return { type: this.typeTag, state: this.state, error: this.error };
+  }
+
+  static [RECONSTRUCT](
+    state: { type: string; state: StorableValue; error: string },
+    _context: ReconstructionContext,
+  ): ProblematicStorable {
+    return new ProblematicStorable(state.type, state.state, state.error);
+  }
+}

--- a/packages/memory/serialization-context.ts
+++ b/packages/memory/serialization-context.ts
@@ -1,0 +1,33 @@
+import type { StorableClass, StorableInstance } from "./storable-protocol.ts";
+
+/**
+ * Maps between runtime types and wire format representations. Parameterized
+ * on `WireFormat` -- the type of the intermediate serialized representation.
+ * JSON contexts use `JsonWireValue` (an intermediate tree that `JSON.stringify`
+ * converts to bytes); future binary contexts would use `Uint8Array`.
+ * See Section 4.3 of the formal spec.
+ */
+export interface SerializationContext<WireFormat = unknown> {
+  /** Whether failed reconstructions produce `ProblematicStorable` instead of
+   *  throwing. @default false */
+  readonly lenient: boolean;
+
+  /** Get the wire format tag for a storable instance's type. */
+  getTagFor(value: StorableInstance): string;
+
+  /** Get the class that can reconstruct instances for a given tag. */
+  getClassFor(
+    tag: string,
+  ): StorableClass<StorableInstance> | undefined;
+
+  /** Encode a tag and state into the format's wire representation. */
+  encode(tag: string, state: WireFormat): WireFormat;
+
+  /**
+   * Decode a wire representation into tag and state, or `null` if not a
+   * tagged value.
+   */
+  decode(
+    data: WireFormat,
+  ): { tag: string; state: WireFormat } | null;
+}

--- a/packages/memory/storable-protocol.ts
+++ b/packages/memory/storable-protocol.ts
@@ -1,0 +1,83 @@
+import type { StorableValue } from "./interface.ts";
+
+/**
+ * Well-known symbol for deconstructing a storable instance into its essential
+ * state. The returned value may contain nested `StorableValue`s (including
+ * other `StorableInstance`s); the serialization system handles recursion.
+ * See Section 2.2 of the formal spec.
+ */
+export const DECONSTRUCT: unique symbol = Symbol.for("common.deconstruct");
+
+/**
+ * Well-known symbol for reconstructing a storable instance from its essential
+ * state. Static method on the class.
+ * See Section 2.2 of the formal spec.
+ */
+export const RECONSTRUCT: unique symbol = Symbol.for("common.reconstruct");
+
+/**
+ * A value that knows how to deconstruct itself into essential state for
+ * serialization. The presence of `[DECONSTRUCT]` serves as the brand -- no
+ * separate marker is needed. See Section 2.3 of the formal spec.
+ */
+export interface StorableInstance {
+  /**
+   * Returns the essential state of this instance as a `StorableValue`.
+   * Implementations must NOT recursively deconstruct nested values -- the
+   * serialization system handles that.
+   */
+  [DECONSTRUCT](): StorableValue;
+}
+
+/**
+ * A class that can reconstruct storable instances from essential state. The
+ * static `[RECONSTRUCT]` method is separate from the constructor to support
+ * reconstruction-specific context and instance interning.
+ * See Section 2.4 of the formal spec.
+ */
+export interface StorableClass<T extends StorableInstance> {
+  /**
+   * Reconstruct an instance from essential state. Nested values in `state`
+   * have already been reconstructed by the serialization system. May return
+   * an existing instance (interning) rather than creating a new one.
+   */
+  [RECONSTRUCT](state: StorableValue, context: ReconstructionContext): T;
+}
+
+/**
+ * A converter that can reconstruct arbitrary values (not necessarily
+ * `StorableInstance`s) from essential state. Used for built-in JS types like
+ * `Error` that participate in the serialization protocol but don't implement
+ * `StorableInstance`. See Section 1.4.1 of the formal spec.
+ */
+export interface StorableConverter<T> {
+  /**
+   * Reconstruct a value from essential state. Nested values in `state`
+   * have already been reconstructed by the serialization system.
+   */
+  [RECONSTRUCT](state: StorableValue, context: ReconstructionContext): T;
+}
+
+/**
+ * The minimal interface that `[RECONSTRUCT]` implementations may depend on.
+ * Provided by the `Runtime` in practice, but defined as an interface here to
+ * avoid a circular dependency between the storable protocol and the runner.
+ * See Section 2.5 of the formal spec.
+ */
+export interface ReconstructionContext {
+  /** Resolve a cell reference. Used by types that need to intern or look up
+   *  existing instances during reconstruction. */
+  getCell(
+    ref: { id: string; path: string[]; space: string },
+  ): StorableInstance;
+}
+
+/**
+ * Type guard: checks whether a value implements the storable protocol. The
+ * presence of `[DECONSTRUCT]` is the brand. See Section 2.6 of the formal spec.
+ */
+export function isStorableInstance(value: unknown): value is StorableInstance {
+  return value != null &&
+    typeof value === "object" &&
+    DECONSTRUCT in value;
+}

--- a/packages/memory/type-tags.ts
+++ b/packages/memory/type-tags.ts
@@ -1,0 +1,30 @@
+/**
+ * Canonical type tags for the `/<Type>@<Version>` wire format. Collected in a
+ * single frozen object so that use sites are type-checked for valid tag
+ * reference, and literal strings don't end up bit-rotting inadvertently.
+ *
+ * Constant names are un-versioned as a baseline. If and when we need to support
+ * multiple versions of a type, the current one stays unmarked and old versions
+ * get a `V1` suffix (or similar).
+ *
+ * See Section 5.2 of the formal spec.
+ */
+export const TAGS = Object.freeze(
+  {
+    // -- Instance types (deserialized via class registry) --
+    Error: "Error@1",
+    Map: "Map@1",
+    Set: "Set@1",
+    Date: "Date@1",
+    Bytes: "Bytes@1",
+
+    // -- Primitive type handlers --
+    BigInt: "BigInt@1",
+    Undefined: "Undefined@1",
+
+    // -- Structural / meta tags (serialization format) --
+    quote: "quote",
+    hole: "hole",
+    object: "object",
+  } as const,
+);

--- a/packages/memory/unknown-storable.ts
+++ b/packages/memory/unknown-storable.ts
@@ -1,0 +1,33 @@
+import type { StorableValue } from "./interface.ts";
+import {
+  DECONSTRUCT,
+  RECONSTRUCT,
+  type ReconstructionContext,
+  type StorableInstance,
+} from "./storable-protocol.ts";
+
+/**
+ * Holds an unrecognized type's data for round-tripping. When the serialization
+ * system encounters an unknown tag during deserialization, it wraps the tag and
+ * state here; on re-serialization, it uses the preserved `typeTag` to produce
+ * the original wire format. See Section 3.2 of the formal spec.
+ */
+export class UnknownStorable implements StorableInstance {
+  constructor(
+    /** The original type tag, e.g. `"FutureType@2"`. */
+    readonly typeTag: string,
+    /** The raw state, already recursively processed by the deserializer. */
+    readonly state: StorableValue,
+  ) {}
+
+  [DECONSTRUCT](): StorableValue {
+    return { type: this.typeTag, state: this.state };
+  }
+
+  static [RECONSTRUCT](
+    state: { type: string; state: StorableValue },
+    _context: ReconstructionContext,
+  ): UnknownStorable {
+    return new UnknownStorable(state.type, state.state);
+  }
+}


### PR DESCRIPTION
## Summary

Extract spec changes and type/interface definitions from PR #2818 (the large json-conversion PR) into a standalone, reviewable chunk. This is the first of several smaller PRs to land #2818 incrementally -- same pattern as the #2824 -> #2840 split.

### What's included

**Spec updates** (`docs/specs/space-model-formal-spec/1-storable-values.md`):
- Clarified `/quote` freeze semantics
- Renamed `/Hole@1` to `/hole`
- Updated for three-layer architecture (#2823)
- No extra properties on non-Error wrappers (#2827)
- Blob for frozen Uint8Array unwrapping (#2828)
- Blob throws on synchronous conversion path (#2830)
- PR #2824 review decisions (#2836)
- Marked `toJSON()` as legacy (#2837)
- Fixed Error@1 encoding comment
- Updated coordination doc reference

**New type/interface files** (all additive, nothing imports them yet):
- `storable-protocol.ts` -- `StorableInstance` interface, symbols, type guard
- `serialization-context.ts` -- `SerializationContext` interface
- `type-tags.ts` -- `TAGS` constant object
- `unknown-storable.ts` -- `UnknownStorable` class
- `problematic-storable.ts` -- `ProblematicStorable` class

**`interface.ts`**: Added `StorableNativeObject` type union (no changes to `StorableDatum`)

**`deno.json`**: Added export entries for the new modules

### What's NOT included

- No changes to `StorableDatum` (the `| StorableInstance` and `| bigint` additions depend on implementation code)
- No implementation files (`serialization.ts`, `json-encoding.ts`, etc.)
- No test files
- No changes to `rich-storable-value.ts`, `storable-value.ts`, or `runner.ts`

### Verification

- `deno fmt --check` passes
- `deno task test` passes (96 tests, 0 failures)
- All changes are additive; existing code is unaffected

---
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.6) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the storable-value spec for the new three-layer architecture and adds core type definitions to support upcoming serialization work. This is a spec/interfaces-only change; no implementation or tests are included.

- **New Features**
  - Documented three-layer model; raw native types are excluded from StorableValue and defined as StorableNativeObject.
  - Specified native object wrappers and immutability rules (deep-freeze on /quote); clarified Error state and renamed isStorable to isStorableInstance.
  - Updated tags: renamed Hole@1 to hole; added BigInt@1; introduced a TAGS constants module.
  - Added interfaces and classes: storable-protocol (symbols, guard), serialization-context, UnknownStorable, ProblematicStorable.
  - Exported new modules in deno.json and added StorableNativeObject to interface.ts; existing code paths are unaffected.

<sup>Written for commit 4caf83559ab56f2ebb74e2c9ca034a11dcdb581b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

