### PR TITLE
Extract shared SHA-256 module from reference.ts

### DIFF
--- a/packages/memory/hash-impl.ts
+++ b/packages/memory/hash-impl.ts
@@ -13,11 +13,6 @@ import { createSHA256, type IHasher } from "hash-wasm";
 import { sha256 as nobleSha256 } from "merkle-reference";
 
 /**
- * Which SHA-256 implementation is currently in use.
- */
-export type HashImplementation = "node:crypto" | "hash-wasm" | "noble";
-
-/**
  * Incremental SHA-256 hasher. Feed data via `update()`, finalize with
  * `digest()`. A hasher must not be reused after `digest()` is called.
  */
@@ -31,7 +26,6 @@ export interface IncrementalHasher {
  */
 export type Sha256Fn = (payload: Uint8Array) => Uint8Array;
 
-let activeHashImpl: HashImplementation = "noble";
 let sha256Fn: Sha256Fn = nobleSha256;
 let createHasher: () => IncrementalHasher;
 
@@ -45,7 +39,6 @@ if (isDeno()) {
     sha256Fn = (payload: Uint8Array): Uint8Array => {
       return nodeCrypto.createHash("sha256").update(payload).digest();
     };
-    activeHashImpl = "node:crypto";
   } catch {
     // node:crypto not available
   }
@@ -62,7 +55,6 @@ if (!nodeCrypto) {
       wasmHasher!.update(payload);
       return wasmHasher!.digest("binary");
     };
-    activeHashImpl = "hash-wasm";
   } catch {
     // hash-wasm not available
   }
@@ -127,13 +119,6 @@ if (nodeCrypto) {
       },
     };
   };
-}
-
-/**
- * Get the currently active SHA-256 implementation.
- */
-export function getHashImplementation(): HashImplementation {
-  return activeHashImpl;
 }
 
 /**

--- a/packages/memory/reference.ts
+++ b/packages/memory/reference.ts
@@ -1,13 +1,8 @@
 import * as Reference from "merkle-reference";
 import { LRUCache } from "@commontools/utils/cache";
 import { canonicalHash } from "./canonical-hash.ts";
-import {
-  getHashImplementation,
-  type HashImplementation,
-  sha256,
-} from "./hash-impl.ts";
+import { sha256 } from "./hash-impl.ts";
 export * from "merkle-reference";
-export type { HashImplementation };
 
 /**
  * Module-level flag for canonical hashing mode, set by the `Runtime`
@@ -143,8 +138,3 @@ export const refer = <T>(source: T): Reference.View<T> => {
 
   return referImpl(source);
 };
-
-/**
- * Get the currently active SHA-256 implementation.
- */
-export { getHashImplementation };


### PR DESCRIPTION
## Summary

Pure refactor: extract the SHA-256 environment detection and hash function selection from `reference.ts` into a new shared `hash-impl.ts` module.

- **New file `packages/memory/hash-impl.ts`**: Contains the SHA-256 fallback chain (node:crypto -> hash-wasm -> noble), the `sha256` all-at-once function, `getHashImplementation()`, and an `IncrementalHasher` interface with `createHasher` factory.
- **Modified `packages/memory/reference.ts`**: Now imports `sha256` and `getHashImplementation` from `hash-impl.ts` instead of defining them inline. The ~60-line environment detection block is replaced by a simple `Reference.Tree.createBuilder(sha256, wrappedNodeBuilder)` call.

### What this does NOT change

- **No behavioral change to `refer()`** or any other exported API.
- The SHA-256 fallback chain priority (node:crypto -> hash-wasm -> noble) is preserved exactly.
- The `canonicalHash` stub path is unchanged.
- The primitive cache, unclaimed-facts cache, and all other `reference.ts` internals are untouched.

### Why a separate PR

This extraction affects the non-experimental `refer()` code path used by all consumers. Splitting it from the experimental canonical hashing work in PR #2856 ensures it gets focused review.

### Verification

- **Dispatch parity verified** by `researcher-remy`: the fallback chain order, environment detection, and per-implementation hash function construction are all preserved. See the full parity report in the project coordination docs.
- `deno fmt --check` passes.
- `deno task test` passes (99 tests, 0 failures).

### New additions (inert)

The `IncrementalHasher` interface and `createHasher` factory are new additions that nothing in `main` uses yet. They are included here because they are part of the `hash-impl.ts` module and will be consumed by `canonical-hash.ts` in the follow-up PR (#2856). They have no effect on existing behavior.

---

Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.6) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted SHA-256 environment detection and hash selection into a shared hash-impl.ts module to simplify reference.ts and enable reuse. Behavior is unchanged; refer() still uses the same fallback order (node:crypto -> hash-wasm -> noble). Removed unused getHashImplementation() and HashImplementation type.

- **Refactors**
  - Added packages/memory/hash-impl.ts exposing sha256, IncrementalHasher, and createHasher.
  - Updated packages/memory/reference.ts to import sha256 and build the tree via Reference.Tree.createBuilder, removing inline env detection.
  - Removed getHashImplementation() and HashImplementation type (dead code).

<sup>Written for commit eeacc71bee89979c92ccb2a835946e356a64d016. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

