### PR TITLE
Add canonical hash byte-level spec and update formal spec

### DIFF
--- a/docs/specs/space-model-formal-spec/1-storable-values.md
+++ b/docs/specs/space-model-formal-spec/1-storable-values.md
@@ -203,9 +203,10 @@ Because each wrapper genuinely implements `StorableInstance` (with real
 `[DECONSTRUCT]` and `[RECONSTRUCT]` methods), the serialization system
 processes them through the same uniform `StorableInstance` path — no special
 cases needed in the serializer. The hashing system also uses the standard
-`TAG_STORABLE` path for most wrappers, but optimizes `StorableDate` and
-`StorableUint8Array` with dedicated `TAG_DATE` and `TAG_BYTES` tags for
-content-level identity (see Section 6.3).
+`TAG_INSTANCE` path for most wrappers, but optimizes `StorableUint8Array`
+with a dedicated `TAG_BYTES` tag for content-level identity (see
+Section 6.3). `StorableDate` is hashed via `TAG_INSTANCE` through its
+`[DECONSTRUCT]` method, like other `StorableInstance`s.
 
 #### 1.4.1 Wrapper Class Summary
 
@@ -697,6 +698,15 @@ class Temperature implements StorableInstance {
   }
 }
 ```
+
+> **Runtime validation in `[RECONSTRUCT]`.** The `Temperature[RECONSTRUCT]`
+> example above uses `state as { value: number; unit: TemperatureUnit }` — a
+> bare type cast with no runtime validation. This is acceptable in a short
+> illustrative example, but **production `[RECONSTRUCT]` implementations must
+> validate the shape of `state` at runtime** before using it. The `state`
+> parameter has been through serialization and deserialization; it may not
+> conform to the expected TypeScript type. See Section 7.4 for the full
+> rationale.
 
 **Why the protocol matters.** Without `StorableInstance`, the serialization
 system would see a `Temperature` as an opaque object and either reject it or
@@ -1321,7 +1331,8 @@ round-trip correctly.
 > rather than throwing or silently producing garbage. This principle applies to
 > all type handlers, not just `BigInt@1`: `Date@1` should validate its ISO 8601
 > string, `Bytes@1` should validate its base64 string, and so on. Wire data is
-> untrusted input.
+> untrusted input. See Section 7.4 for the broader principle that applies to all
+> code consuming deserialized values.
 
 > **Sparse array encoding in JSON.** Even when an array contains holes, it is
 > serialized as a JSON array. Runs of consecutive holes are represented by
@@ -1454,7 +1465,50 @@ tree construction.
 - The hash reflects the logical content, not any particular encoding or
   intermediate representation.
 
-### 6.3 Hashing Algorithm
+### 6.3 Suggested Tag Bytes
+
+The following single-byte type tags are used by the canonical hash byte format
+and are recommended for any binary encoding of `StorableValue`s. They are
+organized into three categories by high nibble:
+
+**Meta tags (`0x0N`)** — structural markers that are not themselves value types:
+
+| Tag               | Hex    | Decimal | Used for                        |
+|:------------------|:-------|:--------|:--------------------------------|
+| `TAG_END`         | `0x00` | 0       | end-of-sequence sentinel         |
+| `TAG_HOLE`        | `0x01` | 1       | sparse array holes (run-length) |
+
+**Compound tags (`0x1N`)** — containers whose children are tagged values:
+
+| Tag               | Hex    | Decimal | Used for                        |
+|:------------------|:-------|:--------|:--------------------------------|
+| `TAG_ARRAY`       | `0x10` | 16      | plain arrays                    |
+| `TAG_OBJECT`      | `0x11` | 17      | plain objects                   |
+| `TAG_INSTANCE`    | `0x12` | 18      | `StorableInstance` (general)    |
+
+**Primitive tags (`0x2N`)** — leaf value types:
+
+| Tag               | Hex    | Decimal | Used for                        |
+|:------------------|:-------|:--------|:--------------------------------|
+| `TAG_NULL`        | `0x20` | 32      | `null`                          |
+| `TAG_BOOLEAN`     | `0x21` | 33      | `boolean`                       |
+| `TAG_NUMBER`      | `0x22` | 34      | `number` (finite, non-NaN)      |
+| `TAG_STRING`      | `0x23` | 35      | `string`                        |
+| `TAG_BIGINT`      | `0x24` | 36      | `bigint`                        |
+| `TAG_UNDEFINED`   | `0x25` | 37      | `undefined`                     |
+| `TAG_BYTES`       | `0x26` | 38      | `StorableUint8Array`            |
+
+All unassigned values are reserved for future use. The category structure
+(meta/compound/primitive) is a convention for readability and is not enforced by
+the encoding — a decoder should handle any tag byte it encounters regardless of
+nibble range.
+
+> **Scope.** These tag bytes are defined here for use by any wire format that
+> needs to distinguish `StorableValue` types at the byte level. The canonical
+> hash byte format (`2-canonical-hash-byte-format.md`) is the first consumer;
+> future binary serialization formats may reuse the same tag assignments.
+
+### 6.4 Hashing Algorithm
 
 ```typescript
 // file: packages/common/canonical-hash.ts (stub)
@@ -1482,48 +1536,34 @@ export function canonicalHash(
   value: StorableValue,
   algorithm?: 'sha256' | 'blake2b',
 ): string {
-  // Type tag bytes (single-byte prefixes to prevent cross-type collisions):
+  // Type tag bytes — see Section 6.3 for the full table.
+  // Tag categories: meta (0x0N), compound (0x1N), primitive (0x2N).
   //
-  // TAG_NULL       = 0x00
-  // TAG_BOOL       = 0x01
-  // TAG_NUMBER     = 0x02
-  // TAG_STRING     = 0x03
-  // TAG_BIGINT     = 0x04
-  // TAG_UNDEFINED  = 0x05
-  // TAG_BYTES      = 0x06
-  // TAG_DATE       = 0x07
-  // TAG_ARRAY      = 0x08
-  // TAG_OBJECT     = 0x09
-  // TAG_STORABLE   = 0x0A
-  // TAG_HOLE       = 0x0B
-  //
-  // Implementation feeds type-tagged data into the hasher:
+  // Implementation feeds type-tagged data into the hasher.
+  // Byte-length prefixes for raw payloads use unsigned LEB128.
+  // Compound types (array, object) use TAG_END instead of a count prefix.
   //
   // - `null`:              hash(TAG_NULL)
-  // - `boolean`:           hash(TAG_BOOL, boolByte)
+  // - `boolean`:           hash(TAG_BOOLEAN, boolByte)
   // - `number`:            hash(TAG_NUMBER, ieee754Float64Bytes)
-  // - `string`:            hash(TAG_STRING, utf16CodeUnits)
-  // - `bigint`:            hash(TAG_BIGINT, signedTwosComplementBytes)
+  // - `string`:            hash(TAG_STRING, leb128(utf8ByteLen), utf8Bytes)
+  // - `bigint`:            hash(TAG_BIGINT, leb128(byteLen), signedTwosComplementBytes)
   // - `undefined`:         hash(TAG_UNDEFINED)
-  // - `StorableUint8Array`: hash(TAG_BYTES, rawBytes)
+  // - `StorableUint8Array`: hash(TAG_BYTES, leb128(byteLen), rawBytes)
   //                        (hashes the underlying byte content)
-  // - `StorableDate`:      hash(TAG_DATE, int64MillisSinceEpoch)
-  //                        (hashes the underlying timestamp)
-  // - array:               hash(TAG_ARRAY, length, ...elementHash)
-  //                        where `length` is the logical array length
-  //                        (uint32 big-endian) and elements are hashed
-  //                        in order:
+  // - array:               hash(TAG_ARRAY, ...elements, TAG_END)
+  //                        Elements are hashed in index order:
   //                          if `i in array`: canonicalHash(array[i])
-  //                          else (hole run): hash(TAG_HOLE, uint32(N))
+  //                          else (hole run): hash(TAG_HOLE, leb128(N))
+  //                        TAG_END marks the end of the element sequence.
   //                        (order-preserving)
   //
   //                        Holes use run-length encoding in the hash
   //                        stream, matching the wire format: a maximal
   //                        run of N consecutive holes is hashed as a
-  //                        single `TAG_HOLE` followed by the run length.
-  //                        The run length is encoded as uint32
-  //                        big-endian (4 bytes). A single hole is
-  //                        `hash(TAG_HOLE, uint32(1))`.
+  //                        single `TAG_HOLE` followed by the run length
+  //                        (unsigned LEB128). A single hole is
+  //                        `hash(TAG_HOLE, leb128(1))`.
   //
   //                        Runs MUST be maximal — consecutive holes are
   //                        always coalesced into a single TAG_HOLE entry
@@ -1534,34 +1574,37 @@ export function canonicalHash(
   //
   //                        When hashing from the wire format, each
   //                        `hole` entry maps directly to one
-  //                        `TAG_HOLE + uint32(N)` in the hash (since
+  //                        `TAG_HOLE + leb128(N)` in the hash (since
   //                        the wire format also uses maximal runs).
   //                        When hashing from an in-memory array, the
   //                        implementation must count consecutive absent
   //                        indices to form maximal runs.
-  // - object:              hash(TAG_OBJECT, sortedKeys, ...canonicalHash(value))
-  //                        (keys sorted lexicographically by UTF-8)
-  // - `StorableInstance`:  hash(TAG_STORABLE, typeTag, canonicalHash(deconstructedState))
+  // - object:              hash(TAG_OBJECT, ...sortedKeyValuePairs, TAG_END)
+  //                        Keys sorted lexicographically by UTF-8.
+  //                        Each pair: TAG_STRING key + tagged value.
+  //                        TAG_END marks the end of the pair sequence.
+  // - `StorableInstance`:  hash(TAG_INSTANCE, leb128(typeTagLen), typeTag,
+  //                              canonicalHash(deconstructedState))
   //
   // The native object wrappers are hashed as follows:
   //
-  // - `StorableError`, `StorableMap`, `StorableSet`, and other
-  //   `StorableInstance`s with recursively-processable deconstructed state
-  //   are hashed via TAG_STORABLE:
-  //     hash(TAG_STORABLE, typeTag, canonicalHash(deconstructedState))
+  // - `StorableError`, `StorableMap`, `StorableSet`, `StorableDate`, and
+  //   other `StorableInstance`s with recursively-processable deconstructed
+  //   state are hashed via TAG_INSTANCE:
+  //     hash(TAG_INSTANCE, leb128(typeTagLen), typeTag,
+  //          canonicalHash(deconstructedState))
   //
-  // - `StorableDate` and `StorableUint8Array` are special-cased: they use
-  //   TAG_DATE and TAG_BYTES respectively, matching their logical content
-  //   type rather than going through TAG_STORABLE with a string payload.
+  // - `StorableUint8Array` is special-cased: it uses TAG_BYTES, matching
+  //   its logical content type rather than going through TAG_INSTANCE.
   //
   // Examples:
-  // - `StorableError`:      hash(TAG_STORABLE, "Error@1", canonicalHash(errorState))
-  // - `StorableMap`:        hash(TAG_STORABLE, "Map@1", canonicalHash(entries))
+  // - `StorableError`:      hash(TAG_INSTANCE, ..., "Error@1", canonicalHash(errorState))
+  // - `StorableMap`:        hash(TAG_INSTANCE, ..., "Map@1", canonicalHash(entries))
   //                         where entries are hashed in insertion order
-  // - `StorableSet`:        hash(TAG_STORABLE, "Set@1", canonicalHash(elements))
+  // - `StorableSet`:        hash(TAG_INSTANCE, ..., "Set@1", canonicalHash(elements))
   //                         where elements are hashed in insertion order
-  // - `StorableDate`:       hash(TAG_DATE, int64MillisSinceEpoch)
-  // - `StorableUint8Array`: hash(TAG_BYTES, rawBytes)
+  // - `StorableDate`:       hash(TAG_INSTANCE, ..., "Date@1", canonicalHash(dateState))
+  // - `StorableUint8Array`: hash(TAG_BYTES, leb128(byteLen), rawBytes)
   //
   // Each type is tagged to prevent collisions between types with
   // identical content representations. In particular, holes (TAG_HOLE),
@@ -1577,12 +1620,9 @@ export function canonicalHash(
 }
 ```
 
-> **String encoding for hashing.** Strings are hashed as a sequence of UTF-16
-> code units (two bytes per code unit, in platform byte order). This matches the
-> native string encoding in JavaScript contexts, which are often on one or both
-> sides of the serialization boundaries this spec defines. Future performance
-> characterization may lead to a switch to UTF-8 encoding if the overhead of
-> UTF-16 proves significant for non-BMP-heavy workloads.
+> **String encoding for hashing.** Strings are hashed as UTF-8 byte sequences,
+> prefixed by their byte length (unsigned LEB128). See the byte-level spec
+> (`2-canonical-hash-byte-format.md`, Section 4.4) for the precise encoding.
 
 > **Map/Set ordering in hashing.** Canonical hashing preserves insertion order
 > for `StorableMap` entries and `StorableSet` elements, matching the serialized
@@ -1593,7 +1633,7 @@ export function canonicalHash(
 > contrast, plain objects are hashed with sorted keys, matching the existing
 > convention that plain-object key order is not semantically significant.)
 
-### 6.4 Relationship to Late Serialization
+### 6.5 Relationship to Late Serialization
 
 Canonical hashing operates on `StorableValue` directly, using deconstructed
 state for `StorableInstance`s (including the native object wrappers) and
@@ -1601,7 +1641,7 @@ type-specific handling for primitives and containers. This makes identity
 hashing independent of any particular wire encoding — the same hash whether
 later serialized to JSON, CBOR, or Automerge.
 
-### 6.5 Use Cases
+### 6.6 Use Cases
 
 Canonical hashing is used for:
 - Pattern ID generation (derived from pattern definition)
@@ -1674,6 +1714,41 @@ The canonical hashing approach (Section 6) replaces `merkle-reference` /
 CID-based hashing. Since the system does not participate in the IPFS network,
 CID formatting adds overhead without interoperability benefit. The canonical
 hash operates on the logical data structure directly.
+
+### 7.4 Untrusted Deserialized Input
+
+**Deserialized values must not be trusted for type safety.** After
+serialization and deserialization, a value may not conform to the TypeScript
+type that code assumes — the wire format carries no type guarantees, and a
+round-trip through JSON (or any other encoding) can silently produce values
+whose runtime shape does not match their static type.
+
+This applies at every point where deserialized data is consumed:
+
+- **`[RECONSTRUCT]` implementations** (Section 2.4) receive `state:
+  StorableValue`. The state has been deserialized by the serialization system,
+  but its internal structure is determined by whatever was on the wire.
+  Implementations must validate the shape of `state` at runtime — checking
+  property existence, types, and constraints — rather than relying on a type
+  cast (e.g., `state as { value: number }`). See the note in Section 2.7 for a
+  concrete example.
+
+- **JSON type handlers** (Section 5.3) must validate the format of their state
+  before processing. Malformed input should produce a `ProblematicStorable`
+  rather than throwing or silently producing garbage.
+
+- **Canonical hashing** (Section 6.3) may operate on values that have been
+  through a deserialization round-trip. Code that extracts properties from
+  `StorableInstance` values (e.g., casting to `{ typeTag: string }`) must
+  validate those properties at runtime.
+
+- **Application code** that reads values from cells, IPC messages, or any other
+  boundary listed in Section 4.7 should treat the values as untrusted until
+  validated.
+
+The general principle: a type cast (`as T`) is a compile-time assertion with no
+runtime effect. After a serialization boundary, the only reliable way to
+confirm a value's shape is runtime checking.
 
 ---
 
@@ -2089,13 +2164,10 @@ spec from being implementable.
   deconstructed state. How does this integrate with the schema language?
   Currently out of scope (schemas are listed as out-of-scope for this spec).
 
-- **Exact canonical hash specification**: Precise byte-level specification of
-  the hash algorithm (type tags, encoding of each type, handling of special
-  cases like `-0` normalization). This should be specified as a separate
-  document or appendix before the hashing implementation begins. (Note:
-  `TAG_HOLE`'s run-length count encoding is now specified as uint32 big-endian;
-  see Section 6.3. Consider unsigned LEB128 as a future optimization once
-  measurement data is available to assess its impact.)
+- **Exact canonical hash specification**: The precise byte-level format is
+  defined in `2-canonical-hash-byte-format.md`. All lengths and counts use
+  unsigned LEB128 encoding; see that document for the complete specification
+  of type tags, encoding per type, and illustrative examples.
 
 - **Migration path**: Out of scope for this spec. The detailed migration plan
   (sequencing of flag introductions, criteria for graduating each flag to

--- a/docs/specs/space-model-formal-spec/2-canonical-hash-byte-format.md
+++ b/docs/specs/space-model-formal-spec/2-canonical-hash-byte-format.md
@@ -1,0 +1,484 @@
+# Canonical Hash Byte Format
+
+This document specifies the precise byte-level format for canonical hashing of
+`StorableValue`s. It is the implementation-ready companion to Section 6.4 of the
+formal spec (`1-storable-values.md`), which defines the algorithm at the
+pseudocode level. The tag byte assignments used here are defined in formal spec
+Section 6.3.
+
+An implementer can work from this document alone to produce a byte-for-byte
+compatible canonical hasher. All encodings are deterministic; two conforming
+implementations must produce identical byte streams (and therefore identical
+hashes) for any given `StorableValue`.
+
+## Status
+
+Draft byte-level spec — extracted from the formal spec Section 6.3 and the
+implementation plan Phase 6.1.
+
+---
+
+## 1. Digest Algorithm
+
+The hash function is **SHA-256** (FIPS 180-4). All byte sequences described in
+this document are fed to a SHA-256 context in the order specified.
+
+The output is **32 raw bytes** (256 bits). String encoding of the output (e.g.,
+base64) is a separate concern at the call site and is not part of this
+specification.
+
+> **Future addition.** BLAKE2b is listed as a recommended second algorithm in
+> the formal spec. When added, it will use the same byte-level input format
+> defined here; only the digest function changes.
+
+---
+
+## 2. Type Tag Bytes
+
+Every value fed to the hasher begins with a single-byte type tag. The tag
+prevents cross-type collisions (e.g., the number `0` and the boolean `false`
+produce different hashes even though both could be represented as a zero byte).
+
+The authoritative tag assignments are in formal spec Section 6.3. Tags are
+organized into three categories by high nibble: **meta** (`0x0N`) for structural
+markers like `TAG_END` and `TAG_HOLE`, **compound** (`0x1N`) for containers
+whose children are tagged values, and **primitive** (`0x2N`) for leaf value
+types. All unassigned values are reserved for future use.
+
+---
+
+## 3. Encoding Conventions
+
+- **Unsigned LEB128** — variable-length encoding for non-negative integers. Each
+  byte uses 7 data bits (bits 0--6) and 1 continuation bit (bit 7). If the
+  continuation bit is `1`, another byte follows; if `0`, the encoding is
+  complete. Bytes are emitted in little-endian order (least significant group
+  first). Used for byte-length prefixes on raw payloads (strings, bigints, byte
+  arrays) and hole run counts.
+
+  Examples: `0` encodes as `0x00` (1 byte); `5` as `0x05` (1 byte); `127` as
+  `0x7F` (1 byte); `128` as `0x80 0x01` (2 bytes); `300` as `0xAC 0x02`
+  (2 bytes).
+
+- **`TAG_END` sentinel** — compound types (arrays and objects) use `TAG_END`
+  (`0x00`) to mark the end of their element or key-value sequence, instead of
+  encoding a count prefix. This is unambiguous because `TAG_END` is not a valid
+  value type tag — it cannot appear as the start of a child element.
+
+---
+
+## 4. Encoding Per Type
+
+For each type, the subsections below specify the exact byte sequence fed to the
+SHA-256 context. "Feed" means the bytes are appended to the running hash state
+in order; the overall hash is finalized only after the entire value tree has been
+traversed.
+
+### 4.1 `null`
+
+```
+Bytes: TAG_NULL
+       0x20
+```
+
+Total: 1 byte. No payload.
+
+### 4.2 `boolean`
+
+```
+Bytes: TAG_BOOLEAN  PAYLOAD
+       0x21         0x01   (true)
+       0x21         0x00   (false)
+```
+
+Total: 2 bytes.
+
+### 4.3 `number`
+
+```
+Bytes: TAG_NUMBER  IEEE_754_FLOAT64_BE
+       0x22        <8 bytes>
+```
+
+Total: 9 bytes.
+
+The payload is the IEEE 754 binary64 representation of the number, in
+big-endian byte order.
+
+**Normalization rules:**
+
+- **Negative zero (`-0`)** must be normalized to positive zero (`+0`) before
+  encoding. That is, the 8-byte payload for `-0` is
+  `00 00 00 00 00 00 00 00`, not `80 00 00 00 00 00 00 00`. This ensures `-0`
+  and `+0` produce identical hashes, matching JavaScript semantics where
+  `-0 === 0` is `true`.
+
+- **`NaN`** must not appear. `toStorableValue()` rejects `NaN` values; a
+  conforming hasher may assume `NaN` is never encountered. If a hasher does
+  encounter `NaN`, it should throw rather than produce a hash.
+
+- **`Infinity` / `-Infinity`** must not appear. Like `NaN`, these are rejected
+  by `toStorableValue()`. A conforming hasher should throw if encountered.
+
+### 4.4 `string`
+
+```
+Bytes: TAG_STRING  LENGTH_LEB128  UTF8_BYTES
+       0x23        <1+ bytes>     <length bytes>
+```
+
+Total: 1 + len(LEB128) + N bytes, where N is the byte length of the UTF-8
+encoding.
+
+- **Length**: The number of bytes in the UTF-8 encoding of the string, encoded
+  as unsigned LEB128.
+- **Payload**: The string encoded as UTF-8 bytes. Characters in the Basic
+  Multilingual Plane (U+0000--U+FFFF) use 1--3 bytes; supplementary characters
+  (U+10000 and above) use 4 bytes.
+
+Empty string (`""`) is encoded as `0x23 0x00` — the tag plus a zero-length
+prefix and no payload bytes.
+
+### 4.5 `bigint`
+
+```
+Bytes: TAG_BIGINT  LENGTH_LEB128  TWO_COMP_BYTES
+       0x24        <1+ bytes>     <length bytes>
+```
+
+Total: 1 + len(LEB128) + N bytes, where N is the minimal encoding length.
+
+- **Length**: The number of bytes in the two's-complement representation,
+  encoded as unsigned LEB128.
+- **Payload**: The value encoded as a signed two's-complement integer in
+  big-endian byte order, using the **minimal** number of bytes. Minimal means:
+  - The value `0n` is encoded as a single byte `0x00` (length = 1).
+  - Positive values use the fewest bytes such that the high bit of the first
+    byte is `0` (to distinguish from negative values). For example, `127n` is
+    `0x7F` (1 byte), but `128n` is `0x00 0x80` (2 bytes, because `0x80` alone
+    would be interpreted as `-128`).
+  - Negative values use the fewest bytes such that the high bit of the first
+    byte is `1`. For example, `-1n` is `0xFF` (1 byte), `-128n` is `0x80`
+    (1 byte), and `-129n` is `0xFF 0x7F` (2 bytes).
+
+### 4.6 `undefined`
+
+```
+Bytes: TAG_UNDEFINED
+       0x25
+```
+
+Total: 1 byte. No payload.
+
+### 4.7 `StorableUint8Array` (bytes)
+
+```
+Bytes: TAG_BYTES  LENGTH_LEB128  RAW_BYTES
+       0x26       <1+ bytes>     <length bytes>
+```
+
+Total: 1 + len(LEB128) + N bytes, where N is the byte array length.
+
+- **Length**: The number of bytes in the array, encoded as unsigned LEB128.
+- **Payload**: The raw bytes of the underlying `Uint8Array`, in order.
+
+Empty byte array is encoded as `0x26 0x00` — the tag plus a zero-length prefix
+and no payload bytes.
+
+### 4.8 Array
+
+```
+Bytes: TAG_ARRAY  ELEMENT_0  ELEMENT_1  ...  ELEMENT_N-1  TAG_END
+       0x10       <varies>   <varies>        <varies>      0x00
+```
+
+- **Elements**: Each element is hashed recursively in index order (0, 1, 2,
+  ...). Present elements are fed to the hasher as complete tagged values
+  (starting with their own type tag). Holes are encoded using run-length
+  encoding (see Section 4.11).
+- **Terminator**: `TAG_END` (`0x00`) marks the end of the element sequence.
+  This is unambiguous because `TAG_END` cannot appear as the start of any
+  element value.
+
+Empty array (`[]`) is encoded as `0x10 0x00` — the tag immediately followed by
+`TAG_END`.
+
+### 4.9 Object
+
+```
+Bytes: TAG_OBJECT  KEY_0  VALUE_0  KEY_1  VALUE_1  ...  TAG_END
+       0x11        <var>  <var>    <var>  <var>          0x00
+```
+
+- **Key-value pairs**: Emitted in **sorted order**. Keys are sorted
+  lexicographically by their UTF-8 byte representation (see Section 5). For each
+  key-value pair:
+  - The **key** is encoded as a `TAG_STRING`-style value: `TAG_STRING` +
+    LEB128 byte length + UTF-8 bytes (same format as Section 4.4).
+  - The **value** is hashed recursively as a complete tagged value.
+- **Terminator**: `TAG_END` (`0x00`) marks the end of the key-value sequence.
+
+Empty object (`{}`) is encoded as `0x11 0x00` — the tag immediately followed by
+`TAG_END`.
+
+### 4.10 `StorableInstance`
+
+```
+Bytes: TAG_INSTANCE  TYPE_TAG_LEN_LEB128  TYPE_TAG_UTF8  STATE_HASH
+       0x12          <1+ bytes>           <varies>       <recursive>
+```
+
+- **Type tag length**: The byte length of the type tag string in UTF-8,
+  encoded as unsigned LEB128.
+- **Type tag**: The `StorableInstance`'s type tag string (e.g., `"Error@1"`,
+  `"Map@1"`, `"Set@1"`), encoded as raw UTF-8 bytes.
+- **Deconstructed state**: The value returned by `[DECONSTRUCT]()`, hashed
+  recursively as a complete tagged value.
+
+> **Note on `StorableUint8Array`.** `StorableUint8Array` is **not** hashed via
+> `TAG_INSTANCE`. It has a dedicated type tag (`TAG_BYTES`) and is hashed using
+> its raw byte content directly (see Section 4.7). This reflects its nature as
+> a fundamental data type rather than a general storable instance.
+>
+> **Note on `StorableDate`.** `StorableDate` does not have a dedicated type tag.
+> It is hashed via `TAG_INSTANCE` through its `[DECONSTRUCT]` method, like any
+> other `StorableInstance`.
+
+### 4.11 Holes (sparse array elements)
+
+```
+Bytes: TAG_HOLE  RUN_COUNT_LEB128
+       0x01      <1+ bytes>
+```
+
+Total: 1 + len(LEB128) bytes per run (typically 2 bytes for small runs).
+
+Holes appear only within array encodings (Section 4.8). Consecutive holes are
+**always coalesced** into maximal runs:
+
+- A single hole at index `i` with present elements at `i-1` and `i+1` is
+  encoded as `TAG_HOLE` + LEB128 `1`.
+- Three consecutive holes starting at index `i` are encoded as `TAG_HOLE` +
+  LEB128 `3` (not three separate `TAG_HOLE` + `1` entries).
+- Runs **must** be maximal: an implementation must not split a run of N
+  consecutive holes into smaller runs. Doing so would produce a different byte
+  stream and therefore a different hash.
+
+> **Distinction.** `TAG_HOLE` (`0x01`), `TAG_UNDEFINED` (`0x25`), and `TAG_NULL`
+> (`0x20`) are all distinct. The arrays `[1, , 3]`, `[1, undefined, 3]`, and
+> `[1, null, 3]` produce three different hashes.
+
+---
+
+## 5. Object Key Sorting
+
+Object keys are sorted by their **UTF-8 byte representation**, using the
+following comparison:
+
+1. Compare byte-by-byte, treating each byte as an unsigned integer (0--255).
+2. At each position, the byte with the smaller unsigned value comes first.
+3. If one key is a prefix of another (all bytes match up to the shorter key's
+   length), the shorter key comes first.
+
+This is equivalent to the standard lexicographic ordering on byte sequences and
+matches the behavior of `Uint8Array` comparison or C's `memcmp` with a
+length tie-breaker.
+
+Since all string data in the hash stream uses UTF-8 encoding (Section 4.4),
+the sort order and the hash encoding use the same byte representation.
+
+> **UTF-8 byte sort vs. JavaScript string comparison.** JavaScript's native
+> string comparison (`<`, `>`, `localeCompare` with no locale) compares by
+> UTF-16 code units. This is **not** the same ordering as UTF-8 byte sort when
+> supplementary characters (U+10000 and above) are involved:
+>
+> - In UTF-16, supplementary characters are encoded as surrogate pairs
+>   (0xD800--0xDFFF), which sort between BMP characters U+D7FF and U+E000.
+> - In UTF-8, supplementary characters have a leading byte of 0xF0 or higher,
+>   which sorts after all BMP characters (whose maximum leading byte is 0xEF,
+>   for U+FFFF).
+>
+> For example, U+10000 (UTF-16: `D800 DC00`; UTF-8: `F0 90 80 80`) sorts
+> *before* U+E000 (UTF-16: `E000`; UTF-8: `EE 80 80`) in UTF-16 code unit
+> order, but *after* it in UTF-8 byte order.
+>
+> For strings containing only BMP characters (U+0000--U+FFFF) — the practical
+> common case for object keys — the two orderings are equivalent. An
+> implementation that needs to match the canonical hash sort order must sort by
+> UTF-8 bytes (or equivalently, by Unicode code point), not by JavaScript's
+> default string comparison, if supplementary characters may appear in keys.
+
+---
+
+## 6. Traversal Order
+
+The overall traversal is depth-first, left-to-right:
+
+1. Feed the type tag byte.
+2. For primitive types with variable-length payloads (string, bigint, bytes),
+   feed the LEB128 byte-length prefix, then the payload.
+3. For compound types (array, object), recursively hash each child, then feed
+   `TAG_END`. Each child's bytes (starting with its own type tag) are fed to
+   the **same** hasher — there is no per-child sub-hash.
+4. The entire value tree is serialized into one contiguous byte stream, then
+   digested once.
+
+The type tags, length prefixes, and `TAG_END` sentinels provide unambiguous
+framing.
+
+---
+
+## 7. Illustrative Examples
+
+The following examples show the exact byte stream fed to SHA-256 for several
+representative values. Bytes are shown in hexadecimal.
+
+### 7.1 `null`
+
+```
+20
+```
+
+### 7.2 `true`
+
+```
+21 01
+```
+
+### 7.3 `false`
+
+```
+21 00
+```
+
+### 7.4 `42` (number)
+
+```
+22  40 45 00 00 00 00 00 00
+```
+
+IEEE 754 binary64 for `42.0` is `0x4045000000000000`.
+
+### 7.5 `0` (number)
+
+```
+22  00 00 00 00 00 00 00 00
+```
+
+Note: `-0` produces the same byte stream (normalized to `+0`).
+
+### 7.6 `"hello"` (string)
+
+`"hello"` is 5 bytes in UTF-8: `0x68`, `0x65`, `0x6C`, `0x6C`, `0x6F`.
+Length 5 in LEB128 is `0x05`.
+
+```
+23  05  68 65 6C 6C 6F
+```
+
+### 7.7 `""` (empty string)
+
+```
+23  00
+```
+
+### 7.8 `undefined`
+
+```
+25
+```
+
+### 7.9 `[1, , 3]` (sparse array)
+
+Three elements: number `1`, one hole, number `3`. Terminated by `TAG_END`.
+
+- Tag: `10`
+- Element 0 (`1`): `22 3F F0 00 00 00 00 00 00` (IEEE 754 for `1.0`)
+- Element 1 (hole, run of 1): `01 01`
+- Element 2 (`3`): `22 40 08 00 00 00 00 00 00` (IEEE 754 for `3.0`)
+- End: `00`
+
+Full byte stream:
+```
+10
+22 3F F0 00 00 00 00 00 00
+01 01
+22 40 08 00 00 00 00 00 00
+00
+```
+
+### 7.10 `[]` (empty array)
+
+```
+10 00
+```
+
+`TAG_ARRAY` immediately followed by `TAG_END`.
+
+### 7.11 `{ a: 1, b: 2 }` (object)
+
+Two keys. UTF-8 sort order: `"a"` (0x61) < `"b"` (0x62). Terminated by
+`TAG_END`.
+
+- Tag: `11`
+- Key `"a"` (1 byte in UTF-8): `23 01 61`
+- Value `1`: `22 3F F0 00 00 00 00 00 00`
+- Key `"b"` (1 byte in UTF-8): `23 01 62`
+- Value `2`: `22 40 00 00 00 00 00 00 00` (IEEE 754 for `2.0`)
+- End: `00`
+
+Full byte stream:
+```
+11
+23 01 61
+22 3F F0 00 00 00 00 00 00
+23 01 62
+22 40 00 00 00 00 00 00 00
+00
+```
+
+### 7.12 `{}` (empty object)
+
+```
+11 00
+```
+
+`TAG_OBJECT` immediately followed by `TAG_END`.
+
+### 7.13 `[1, undefined, 3]` vs. `[1, , 3]` vs. `[1, null, 3]`
+
+These three arrays produce different byte streams at the middle element:
+
+- `[1, undefined, 3]`: middle element is `25` (`TAG_UNDEFINED`)
+- `[1, , 3]`: middle element is `01 01` (`TAG_HOLE` + run of 1)
+- `[1, null, 3]`: middle element is `20` (`TAG_NULL`)
+
+---
+
+## 8. Rejected Values
+
+The following JavaScript values are rejected by `toStorableValue()` and must
+never be passed to the canonical hasher:
+
+- `NaN`
+- `Infinity`
+- `-Infinity`
+- `Symbol` values
+- `Function` values
+
+A conforming implementation should throw an error if it encounters any of these
+rather than producing a hash.
+
+---
+
+## 9. Summary of Framing Mechanisms
+
+| Context                           | Mechanism       | Details                          |
+|:----------------------------------|:----------------|:---------------------------------|
+| String byte length                | unsigned LEB128 | Byte count of UTF-8 payload      |
+| Bigint payload bytes              | unsigned LEB128 | Byte count of two's complement   |
+| Byte array (`StorableUint8Array`) | unsigned LEB128 | Byte count of raw payload        |
+| `StorableInstance` type tag       | unsigned LEB128 | Byte count of type tag UTF-8     |
+| Hole run count                    | unsigned LEB128 | Number of consecutive holes      |
+| Array elements                    | `TAG_END`       | Sentinel after last element      |
+| Object key-value pairs            | `TAG_END`       | Sentinel after last pair         |


### PR DESCRIPTION
## Summary

Split the spec changes out of PR #2856 (canonical hashing implementation) into
a standalone PR, following the same pattern as PR #2863 (hash module
extraction).

### Changes

**`docs/specs/space-model-formal-spec/1-storable-values.md`** (modified):

- **New Section 6.3** — Suggested Tag Bytes: three-category tag organization
  (meta `0x0N`, compound `0x1N`, primitive `0x2N`) with full tag table.
- **Updated Section 6.4** (was 6.3) — Hashing Algorithm pseudocode updated for
  `TAG_END` sentinels (replacing count prefixes for arrays/objects), unsigned
  LEB128 lengths, `TAG_INSTANCE` (replacing `TAG_STORABLE`), UTF-8 string
  encoding, and `StorableDate` hashed via `TAG_INSTANCE`.
- **New Section 7.4** — Untrusted Deserialized Input: guidance on runtime
  validation after serialization boundaries.
- Updated cross-references, `[RECONSTRUCT]` validation note, and synchronized
  open-questions section.

**`docs/specs/space-model-formal-spec/2-canonical-hash-byte-format.md`** (new):

- Complete byte-level specification for the canonical hash format.
- Covers: digest algorithm (SHA-256), type tag bytes, encoding conventions
  (unsigned LEB128, `TAG_END` sentinel), encoding per type (all 12 types),
  traversal order, and conformance requirements.
- Includes illustrative examples for key types.

### Context

These spec changes went through three rounds of review on PR #2856. The
versions here are taken from `danfuzz/canonical-hashing` at commit `07c88b464`
(the reviewed and approved state). No code changes are included — this PR is
spec-only.

--- upstream-liaison-bolt (Claude Opus 4.6)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a precise byte-level spec for canonical hashing and aligns the formal spec with the approved design. Defines tag bytes, UTF-8 + LEB128 payloads, TAG_END framing for arrays/objects, and TAG_INSTANCE for storable types.

- **New Features**
  - Added 2-canonical-hash-byte-format.md: SHA-256 digest, type tags, per-type encoding (including hole runs and UTF-8 key sorting), traversal order, and examples.
  - Updated formal spec: new tag table (Section 6.3), revised hashing pseudocode (TAG_END, unsigned LEB128, UTF-8 strings, TAG_INSTANCE with Bytes special-cased), new guidance on untrusted deserialized input (Section 7.4), and synced cross-references.

<sup>Written for commit 4b8e27284e1d4d28d4edda41eeb58b6c23ef32fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

