### PR TITLE
docs: document new-package test task requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,3 +68,20 @@ If you are developing runtime code, read the following documentation:
   integration tests
 - `docs/development/debugging/` - Runtime errors, type errors, and
   troubleshooting
+
+### Adding New Packages
+
+When adding a new workspace package:
+
+1. Add the package path (e.g., `./packages/my-package`) to the root `deno.json`
+   `"workspace"` array.
+2. The package's `deno.json` **must** include a `"tasks"` object with a `"test"`
+   entry. Use `"deno test"` if the package has tests, or
+   `"echo 'No tests defined.'"` as a stub for packages without tests yet.
+
+This is required because the root test runner (`tasks/test.ts`) iterates all
+workspace packages and runs `deno task test` in each. If a package has no test
+task, Deno falls back to the root workspace's test task, which re-runs the
+entire suite recursively — causing exponential process spawning and CI timeouts.
+
+See `packages/utils/deno.json` for an example of a correctly configured package.

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -370,6 +370,36 @@ sudo update-ca-certificates
 - To test a specific package, `cd` into the package directory and run
   `deno task test`.
 
+### Adding New Workspace Packages
+
+Every workspace package must be registered and configured correctly, or the test
+suite will break.
+
+1. **Register the package.** Add its path (e.g., `./packages/my-package`) to the
+   `"workspace"` array in the root `deno.json`.
+
+2. **Include a test task.** The package's `deno.json` **must** have a `"tasks"`
+   object with a `"test"` entry. The root test runner (`tasks/test.ts`) iterates
+   all workspace members and runs `deno task test` in each package directory. If
+   a package lacks a test task, Deno resolves the task name against the root
+   workspace instead, which re-runs the entire test suite recursively. This
+   causes exponential process spawning and will time out CI.
+
+   Use `"deno test"` for packages with tests, or `"echo 'No tests defined.'"` as
+   a stub for packages that don't have tests yet.
+
+3. **Minimal `deno.json` example:**
+
+   ```json
+   {
+     "name": "@commontools/my-package",
+     "exports": { ".": "./mod.ts" },
+     "tasks": { "test": "deno test" }
+   }
+   ```
+
+See `packages/utils` and `packages/leb128` for real examples.
+
 ### Running Integration Tests
 
 Integration tests require running servers. Use the repo-level integration


### PR DESCRIPTION
## Summary

Document the requirement that all workspace packages must include a `"test"` task in their `deno.json`. Without this, the root test runner (`tasks/test.ts`) falls back to the workspace-level test task, re-running the entire suite recursively and timing out CI.

- **AGENTS.md**: Added "Adding New Packages" subsection under "Runtime Development" with the workspace array and test task requirements.
- **docs/development/DEVELOPMENT.md**: Added "Adding New Workspace Packages" subsection after "Running Tests" with the same guidance, a minimal `deno.json` example, and references to `packages/utils` and `packages/leb128`.

## Context

This was discovered when PR #2856 added the `leb128` package without an initial `"test"` task in its `deno.json`, causing CI to time out due to recursive test runner invocation.

## Test plan

- [x] Documentation-only change; no code modified.
- [x] Verified both files render correctly in Markdown.

---
— upstream-liaison-bolt (Claude Opus 4.6)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented that every workspace package must define a "test" task in its deno.json to prevent recursive test runs and CI timeouts. Adds clear guidance and a minimal example to AGENTS.md and docs/development/DEVELOPMENT.md for registering packages and setting a test task.

<sup>Written for commit b40b3333c7332bad412bd82c19b1aed6f46c7f1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

