### PR TITLE
Add CellHandle support to ct-switch component

### DIFF
--- a/packages/ui/src/v2/components/ct-switch/ct-switch.ts
+++ b/packages/ui/src/v2/components/ct-switch/ct-switch.ts
@@ -262,17 +262,16 @@ export class CTSwitch extends BaseElement {
         return;
       }
 
-      // Toggle checked state via cell controller
       const oldChecked = this.getChecked();
-      this.setChecked(!oldChecked);
 
-      // For plain boolean usage (no Cell), update the property directly
-      // so Lit re-renders and reflects the attribute
-      if (!this._checkedCellController.hasCell()) {
-        this.checked = !oldChecked;
+      // Toggle checked state via cell controller
+      if (this._checkedCellController.hasCell()) {
+        this.setChecked(!oldChecked);
+        return;
       }
 
-      // Note: ct-change event is emitted by the cell controller's onChange callback
+      // For plain boolean usage (no Cell), update the property directly
+      this.checked = !oldChecked;
     }
 
     private _handleKeydown(event: KeyboardEvent) {


### PR DESCRIPTION
## Summary
ct-switch now supports $checked bidirectional binding with reactive Cells, matching ct-checkbox behavior. Uses createBooleanCellController for Cell subscription, value read/write, and change events.

## Steps to reproduce

Deploy this test pattern. When you toggle either the switch or the checkbox, the other control should also update and the Status label should update to match. Previously this did not work.

```ts
/// <cts-enable />
import { computed, Default, NAME, pattern, UI, Writable } from "commontools";

interface SwitchInput {
  on: Writable<Default<boolean, false>>;
}

interface SwitchOutput {
  on: boolean;
}

export default pattern<SwitchInput, SwitchOutput>(({ on }) => {
  const label = computed(() => (on.get() ? "On" : "Off"));

  return {
    [NAME]: "Toggle Switch",
    [UI]: (
      <div
        style={{
          padding: "1rem",
          display: "flex",
          flexDirection: "column",
          gap: "0.5rem",
        }}
      >
        <ct-switch $checked={on}>Toggle</ct-switch>
        <ct-checkbox $checked={on}>Toggle</ct-checkbox>
        <span>State: {label}</span>
      </div>
    ),
    on,
  };
});
```

## Demo

https://github.com/user-attachments/assets/7c6fa3a8-659c-489d-9b8b-f3ef11cfa4e2


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CellHandle support to ct-switch so $checked can bind to reactive Cells, matching ct-checkbox. Fixes a regression so plain boolean checked values toggle and re-render correctly.

- **New Features**
  - checked accepts boolean or CellHandle<boolean>.
  - Uses createBooleanCellController for binding, read/write, and ct-change when bound to a Cell.
  - Binds in connectedCallback and rebinds in willUpdate when checked changes.
  - Host handles click/keydown; state drives aria-checked and input checked.

- **Bug Fixes**
  - Falls back to updating the checked property directly when no Cell is bound, ensuring plain booleans toggle and Lit re-renders.

<sup>Written for commit 242f55627b4f89ef41ccd6fe189bcb5bb2efd006. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

