### PR TITLE
Improve /tour command reliability

### DIFF
--- a/.claude/commands/tour.md
+++ b/.claude/commands/tour.md
@@ -28,124 +28,11 @@ If no URL is provided, default to `http://localhost:8000`. Examples:
 
 5. **Navigate to the space.** Open `{base-url}/{space-slug}`. Take an initial snapshot and screenshot. Describe what you see.
 
-## The Tour
+## Shadow DOM Helpers
 
-Work through these steps in order. At each step:
-- Take a snapshot to discover interactive elements
-- Interact using refs from the snapshot — never hardcode selectors
-- After each major action, re-snapshot (refs are invalidated by DOM changes)
-- Take a screenshot and save it to the screenshot directory
-- **Narrate what you see** — describe the UI, what changed, anything surprising
-- If a step fails, note the failure, take a screenshot of the error state, and continue to the next step
+These reusable JS eval snippets help navigate shadow DOM. To avoid shell quoting issues with `agent-browser eval`, write JS to a temp file first, then run `agent-browser eval "$(cat /tmp/tour-helper.js)"`.
 
-### Step 0: Register / Login
-
-Fresh spaces require authentication. You will see "Register" and "Login" buttons on the landing page.
-
-- Click **Register** to create a new identity
-- Click **Generate Passphrase** on the next screen
-- Click **I've Saved It - Continue** to complete registration
-
-If the space is already authenticated (you see the Patterns view with a header toolbar), skip this step.
-
-### Step 1: Explore the Space Home
-
-You should now be on the authenticated space page. Describe the layout: the header breadcrumb, the "Patterns" heading, the "Notes" dropdown, any toolbar buttons, and the FAB (floating action button) in the bottom-right. Take a screenshot.
-
-### Step 2: Create a New Note
-
-Find the **"Notes ▾"** dropdown button in the content toolbar area. Click it to reveal a menu with options like "New Note", "New Notebook", "All Notes". Click **"New Note"**. After the note view loads, take a screenshot.
-
-### Step 3: Edit the Note
-
-The note has two parts to edit:
-
-**Title:** The title (e.g. "New Note") is displayed as a clickable text span inside the pattern, which is rendered inside multiple nested shadow DOM layers (`x-root-view` > `x-app-view` > `x-body-view` > iframe). It will NOT appear in the accessibility snapshot. To edit it, use coordinate-based clicking:
-1. Use `agent-browser eval` (or `browser_evaluate`) to walk the shadow DOM and find the title span's bounding box:
-   ```
-   const render = document.querySelector('x-root-view').shadowRoot
-     .querySelector('x-app-view').shadowRoot
-     .querySelector('x-body-view').shadowRoot
-     .querySelector('ct-render');
-   const iframe = render.shadowRoot.querySelector('iframe');
-   const span = iframe.contentDocument.querySelector('span');
-   const rect = span.getBoundingClientRect();
-   // Add iframe offset to get page-level coordinates
-   const iframeRect = iframe.getBoundingClientRect();
-   return { x: iframeRect.x + rect.x + rect.width/2, y: iframeRect.y + rect.y + rect.height/2, text: span.textContent };
-   ```
-2. Use `mouse move {x} {y}` then `mouse down left` + `mouse up left` to single-click it
-3. A `ct-input` will appear — find it the same way (query for `input` inside the iframe) and type the new title
-4. Press Enter to confirm
-
-**Body:** There is a textbox (code editor) for the note content. Click it and type a message like: "Hello from Claude's tour on {date}. This note was created during an automated platform walkthrough."
-
-Take a screenshot showing the edited note with the updated title in the breadcrumb.
-
-### Step 4: Return to Space Home
-
-Click the space name link in the breadcrumb (e.g. "2026-02-16-claude") to navigate back to the space home. Verify the note you created appears in the Patterns list with its title. The breadcrumb should show an updated item count. Take a screenshot.
-
-### Step 5: Open the Chat
-
-Find the **"Open" button** (the FAB) in the bottom-right corner of the page and click it. A chat panel will appear in the bottom-right with:
-- An input field: "Ask the LLM a question..."
-- A "Send" button
-- A model selector (defaults to Claude Opus)
-- "Tools" button showing available tool count
-- An "Expand" button to make the panel larger
-
-Click Expand for better visibility. Take a screenshot.
-
-### Step 6: Reference the Note in Chat
-
-1. Click into the chat input textbox
-2. Type `@` to trigger the mention autocomplete — a dropdown list will appear
-3. Find and click your note (e.g. "📝 2026-02-16") in the dropdown
-4. The mention will be inserted as a markdown link in the input
-5. Type after the mention: " What does this note say?"
-6. Click Send and wait ~15 seconds for the LLM to respond
-
-The LLM should use the `read` tool and quote the note's content back. Take a screenshot of the response.
-
-### Step 7: Ask for the Pattern Index
-
-In the chat, type: "Can you list the available patterns from the pattern index?" and send. Wait ~20 seconds. The LLM should use the `listPatternIndex` tool and return categorized lists of available patterns. Take a screenshot.
-
-### Step 8: Launch a Counter Pattern
-
-In the chat, type: "Please launch the counter pattern with an initial value of 5" and send. Wait ~25 seconds. The LLM should:
-1. Use `fetchAndRunPattern` to compile and run the counter
-2. Use `navigateTo` to navigate to the new pattern
-
-The counter view shows: a heading "Simple Counter", a large number (5), text like "Counter is the 5th number", and "- Decrement" / "+ Increment" buttons. Take a screenshot. Note: the counter pattern may not appear in `listPatternIndex`, but the LLM can still launch it via `fetchAndRunPattern` using the path `counter/counter.tsx`.
-
-**Testing interactivity:** The counter buttons are custom `ct-button` web components. Ref-based clicks (`agent-browser click @ref`) may hang on these elements. Use coordinate-based clicking instead:
-1. Use JS eval to walk the shadow DOM and find the button's bounding box
-2. Use `mouse move {x} {y}` + `mouse down left` + `mouse up left` to click
-3. Verify the counter value updates
-
-Take a screenshot showing the changed value.
-
-### Step 9: Add To-Do Items via Omnibot
-
-Navigate back to the space home by clicking the space name in the breadcrumb. The space home has a two-column layout: the **Do List** on the left and **Recent / Pieces** on the right.
-
-Open the Omnibot (click the FAB in the bottom-right). Send a message asking it to add four tasks to the do-list. Something like:
-
-> Please add these items to my to-do list:
-> 1. Plan a weekend camping trip
-> 2. Research the best noise-canceling headphones under $200
-> 3. Budget for a home office upgrade — $500 to spend
-> 4. Clone the https://github.com/commontoolsinc/labs repo and summarize the readme in a note
-
-Wait ~15-25 seconds for the LLM to use the `addDoItem` or `addDoItems` tools. The items appear in the do-list as soon as the tool executes — you don't need to wait for the LLM to finish its text summary. Once you see items in the list, click anywhere on the page to dismiss the omnibox and move on. Note: dismissing the omnibox eats the first click — it does NOT also interact with whatever is underneath. You'll need a second click to interact with elements like AI Suggestions disclosures.
-
-Verify the items appear in the do-list on the left side of the space home. Take a screenshot.
-
-### Step 10: Watch AI Suggestions Generate
-
-Each do-list item has a collapsible **"AI Suggestions"** section (a `<details>` disclosure element). These elements are inside nested shadow DOM and will NOT appear in accessibility snapshots. To find and click them, use JS eval to recursively search shadow roots:
+### Find Details Disclosures
 
 ```js
 (() => {
@@ -180,7 +67,238 @@ Each do-list item has a collapsible **"AI Suggestions"** section (a `<details>` 
 })()
 ```
 
-This returns an array of `{text, open, x, y}` objects — one per `<details>` element. Use coordinate-based clicking (`mouse move {x} {y}` + `mouse down left` + `mouse up left`) to toggle them open/closed. Re-run the JS eval after expanding to get updated positions, since expanding one item shifts the others down.
+### Find Cell Link Chips
+
+```js
+(() => {
+  function findCellLinks(node, depth) {
+    if (depth > 10) return [];
+    const results = [];
+    if (node.shadowRoot) {
+      const links = node.shadowRoot.querySelectorAll("ct-cell-link");
+      links.forEach((l) => {
+        const rect = l.getBoundingClientRect();
+        if (rect.width > 0 && rect.height > 0) {
+          const inner = l.shadowRoot ? l.shadowRoot.textContent.trim().substring(0, 60) : l.textContent.trim().substring(0, 60);
+          results.push({ text: inner, x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 });
+        }
+      });
+      node.shadowRoot.querySelectorAll("*").forEach((child) => {
+        results.push(...findCellLinks(child, depth + 1));
+      });
+    }
+    return results;
+  }
+  const all = [];
+  document.querySelectorAll("*").forEach((el) => { all.push(...findCellLinks(el, 0)); });
+  return all;
+})()
+```
+
+### Find Shadow DOM Buttons
+
+Replace `BUTTON_TEXT` with the target text (e.g. "+").
+
+```js
+(() => {
+  function findButtons(node, depth) {
+    if (depth > 12) return [];
+    const results = [];
+    if (node.shadowRoot) {
+      node.shadowRoot.querySelectorAll("button").forEach((b) => {
+        if (b.textContent.trim() === "BUTTON_TEXT") {
+          const rect = b.getBoundingClientRect();
+          if (rect.width > 0 && rect.y > 0 && rect.y < 800)
+            results.push({ text: b.textContent.trim(), x: rect.x + rect.width/2, y: rect.y + rect.height/2 });
+        }
+      });
+      node.shadowRoot.querySelectorAll("*").forEach((child) => { results.push(...findButtons(child, depth + 1)); });
+    }
+    return results;
+  }
+  const all = [];
+  document.querySelectorAll("*").forEach((el) => { all.push(...findButtons(el, 0)); });
+  return all;
+})()
+```
+
+### Scroll Content Area
+
+```js
+(() => {
+  function findScrollable(node, depth) {
+    if (depth > 8) return [];
+    const results = [];
+    if (node.shadowRoot) {
+      for (const el of node.shadowRoot.querySelectorAll('*')) {
+        if (el.scrollHeight > el.clientHeight + 50) {
+          el.scrollBy(0, 400);
+          results.push({ tag: el.tagName, scrollH: el.scrollHeight, clientH: el.clientHeight });
+        }
+        results.push(...findScrollable(el, depth + 1));
+      }
+    }
+    return results;
+  }
+  const all = [];
+  document.querySelectorAll('*').forEach(el => all.push(...findScrollable(el, 0)));
+  return all.filter(r => r.scrollH > r.clientH + 50);
+})()
+```
+
+### Scroll Content Area Up
+
+Same as above but use `el.scrollBy(0, -400)` instead of `el.scrollBy(0, 400)`.
+
+## The Tour
+
+Work through these steps in order. At each step:
+- Take a snapshot to discover interactive elements
+- Interact using refs from the snapshot — never hardcode selectors
+- After each major action, re-snapshot (refs are invalidated by DOM changes)
+- Take a screenshot and save it to the screenshot directory
+- **Narrate what you see** — describe the UI, what changed, anything surprising
+- If a step fails, note the failure, take a screenshot of the error state, and continue to the next step
+
+### Step 0: Register / Login
+
+Fresh spaces require authentication. You will see "Register" and "Login" buttons on the landing page.
+
+- Click **Register** to create a new identity
+- Click **Generate Passphrase** on the next screen
+- Click **I've Saved It - Continue** to complete registration
+
+If the space is already authenticated (you see the Patterns view with a header toolbar), skip this step.
+
+### Step 1: Explore the Space Home
+
+You should now be on the authenticated space page. Describe the layout: the header breadcrumb, the "Patterns" heading, the "Notes" dropdown, any toolbar buttons, and the FAB (floating action button) in the bottom-right. Take a screenshot.
+
+### Step 2: Create a New Note
+
+Find the **"Notes ▾"** dropdown button in the content toolbar area. Click it to reveal a menu with options like "New Note", "New Notebook", "All Notes". Click **"New Note"**. After the note view loads, take a screenshot.
+
+### Step 3: Edit the Note
+
+The note has two parts to edit:
+
+**Title:** The title is inside nested shadow DOM: `x-root-view > shadowRoot > x-app-view > shadowRoot > x-body-view > shadowRoot > ct-render > shadowRoot > div > ct-screen > ct-vstack`. It will NOT appear in accessibility snapshots.
+
+1. Write a JS eval to find the title span:
+```js
+(() => {
+  const rv = document.querySelector("x-root-view");
+  const av = rv.shadowRoot.querySelector("x-app-view");
+  const bv = av.shadowRoot.querySelector("x-body-view");
+  const cr = bv.shadowRoot.querySelector("ct-render");
+  const spans = cr.shadowRoot.querySelectorAll("span");
+  for (const span of spans) {
+    if (span.textContent.trim() === "New Note") {
+      const rect = span.getBoundingClientRect();
+      return { x: rect.x + rect.width/2, y: rect.y + rect.height/2, text: span.textContent };
+    }
+  }
+  return "title span not found";
+})()
+```
+2. Click at the returned coordinates to activate edit mode
+3. A `ct-input` appears. Find the input inside it:
+```js
+(() => {
+  const rv = document.querySelector("x-root-view");
+  const av = rv.shadowRoot.querySelector("x-app-view");
+  const bv = av.shadowRoot.querySelector("x-body-view");
+  const cr = bv.shadowRoot.querySelector("ct-render");
+  const ctInput = cr.shadowRoot.querySelector("ct-input");
+  const input = ctInput.shadowRoot.querySelector("input");
+  input.focus();
+  input.value = "YOUR TITLE HERE";
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+  return "set title: " + input.value;
+})()
+```
+4. Press Enter to confirm
+
+**Body:** The body textbox (code editor) IS accessible via snapshot. Use `agent-browser snapshot -i` to find it, then `agent-browser type @ref "your text"`. If the ref is ambiguous (matches multiple), use the textbox that doesn't have `"Note title..."` as placeholder.
+
+Take a screenshot showing the edited note with the updated title in the breadcrumb.
+
+### Step 4: Return to Space Home
+
+Click the space name link in the breadcrumb (e.g. "2026-02-16-claude") to navigate back to the space home. Verify the note you created appears in the Patterns list with its title. The breadcrumb should show an updated item count. Take a screenshot.
+
+### Step 5: Open the Chat
+
+Find the **"Open" button** (the FAB) in the bottom-right corner of the page and click it. A chat panel will appear in the bottom-right with:
+- An input field: "Ask the LLM a question..."
+- A "Send" button
+- A model selector (defaults may vary — typically Claude Sonnet 4.5 or Opus 4.1)
+- "Tools" button showing available tool count
+- An "Expand" button to make the panel larger
+
+Click Expand for better visibility. Take a screenshot.
+
+### Step 6: Reference the Note in Chat
+
+1. Click into the chat input textbox
+2. Type `@` to trigger the mention autocomplete — a dropdown list will appear
+3. Find and click your note (e.g. "📝 2026-02-16") in the dropdown
+4. The mention will be inserted as a markdown link in the input
+5. Type after the mention: " What does this note say?"
+6. Click Send and wait ~15 seconds for the LLM to respond
+
+The LLM should use the `read` tool and quote the note's content back. Take a screenshot of the response.
+
+### Step 7: Ask for the Pattern Index
+
+In the chat, type: "Can you list the available patterns from the pattern index?" and send. Wait ~20 seconds. The LLM should use the `listPatternIndex` tool and return categorized lists of available patterns. Take a screenshot.
+
+### Step 8: Launch a Counter Pattern
+
+In the chat, type: "Please launch the counter pattern with an initial value of 5" and send. Wait ~25 seconds. The LLM should:
+1. Use `fetchAndRunPattern` to compile and run the counter
+2. Use `navigateTo` to navigate to the new pattern
+
+The counter view shows: a heading "Simple Counter", a large number (5), text like "Counter is the 5th number", and "- Decrement" / "+ Increment" buttons. Take a screenshot. Note: the counter pattern may not appear in `listPatternIndex`, but the LLM can still launch it via `fetchAndRunPattern` using the path `counter/counter.tsx`.
+
+**Testing interactivity:** The `ct-button` component wraps a native `<button>` inside its shadow root. Use this approach:
+```js
+(() => {
+  const rv = document.querySelector("x-root-view");
+  const av = rv.shadowRoot.querySelector("x-app-view");
+  const bv = av.shadowRoot.querySelector("x-body-view");
+  const cr = bv.shadowRoot.querySelector("ct-render");
+  const buttons = cr.shadowRoot.querySelectorAll("ct-button");
+  return Array.from(buttons).map(b => {
+    const rect = b.getBoundingClientRect();
+    return { x: rect.x + rect.width/2, y: rect.y + rect.height/2, w: rect.width };
+  });
+})()
+```
+The first button is Decrement, the second is Increment. Click at the coordinates and verify the counter value updates.
+
+Take a screenshot showing the changed value.
+
+### Step 9: Add To-Do Items via Omnibot
+
+Navigate back to the space home by clicking the space name in the breadcrumb. The space home has a two-column layout: the **Do List** on the left and **Recent / Pieces** on the right.
+
+Open the Omnibot (click the FAB in the bottom-right). Send a message asking it to add four tasks to the do-list. Something like:
+
+> Please add these items to my to-do list:
+> 1. Plan a weekend camping trip
+> 2. Research the best noise-canceling headphones under $200
+> 3. Budget for a home office upgrade — $500 to spend
+> 4. Clone the https://github.com/commontoolsinc/labs repo and summarize the readme in a note
+
+Wait ~15-25 seconds for the LLM to use the `addDoItem` or `addDoItems` tools. The items appear in the do-list as soon as the tool executes — you don't need to wait for the LLM to finish its text summary. Once you see items in the list, click anywhere on the page to dismiss the omnibox and move on. Note: dismissing the omnibox eats the first click — it does NOT also interact with whatever is underneath. You'll need a second click to interact with elements like AI Suggestions disclosures.
+
+Verify the items appear in the do-list on the left side of the space home. Take a screenshot.
+
+### Step 10: Watch AI Suggestions Generate
+
+Each do-list item has a collapsible **"AI Suggestions"** section (a `<details>` disclosure element). These elements are inside nested shadow DOM and will NOT appear in accessibility snapshots. Use the **Find Details Disclosures** helper from the Shadow DOM Helpers section. This returns an array of `{text, open, x, y}` objects — one per `<details>` element. Use coordinate-based clicking (`mouse move {x} {y}` + `mouse down left` + `mouse up left`) to toggle them open/closed. Re-run the JS eval after expanding to get updated positions, since expanding one item shifts the others down.
 
 Click the disclosure summary on one of the items (e.g. "Plan a weekend camping trip") to expand it.
 
@@ -195,13 +313,13 @@ Expand the AI Suggestions on a second item too (e.g. "Research the best noise-ca
 
 ### Step 11: Click Suggestions and Explore Results
 
-Click the `ct-cell-link` chip on a completed suggestion to navigate to the resulting piece. Describe what the piece looks like — it could be a note with content, a web search result, a pattern output, etc.
+Use the **Find Cell Link Chips** helper to locate `ct-cell-link` chips. The `text` field from the helper shows the chip's display name. Click the `ct-cell-link` chip on a completed suggestion to navigate to the resulting piece. Describe what the piece looks like — it could be a note with content, a web search result, a pattern output, etc.
 
 Navigate back to the space home (breadcrumb). Check the **Recent** section in the right column — the piece you just visited should now appear there at the top of the list. Take a screenshot showing the recent list with the new piece.
 
 ### Step 12: View the Grid View
 
-On the space home, find the `ct-cell-link` chip next to the **"Recent"** heading. Click it to navigate to the **PieceGrid** — a thumbnail grid view.
+On the space home, use the **Find Cell Link Chips** helper to locate the chip next to the **"Recent"** heading. The `text` field from the helper shows the chip's display name. Click it to navigate to the **PieceGrid** — a thumbnail grid view.
 
 The grid shows a 3-column layout where each piece is rendered as a live scaled-down preview (40% scale) with a clickable name chip below. Describe what you see — the thumbnails should show miniature versions of each piece's actual UI. Take a screenshot.
 
@@ -209,7 +327,9 @@ Navigate back to the space home.
 
 ### Step 13: Suggestion Refinement / Follow-up
 
-Back on the space home, find a do-list item with a completed suggestion (expand it if collapsed). The **"Refine suggestion..."** input is hidden by default. To reveal it, click the **"+"** button on the `ct-message-beads` widget (the row of colored dots at the bottom of the suggestion). This toggles the `ct-prompt-input` visible, which allows you to continue the conversation with the suggestion LLM.
+Back on the space home, find a do-list item with a completed suggestion (expand it if collapsed). The **"Refine suggestion..."** input is hidden by default. To reveal it, click the **"+"** button on the `ct-message-beads` widget (the row of colored dots at the bottom of the suggestion). Use the **Find Shadow DOM Buttons** helper (searching for '+') to locate the button coordinates. This toggles the `ct-prompt-input` visible, which allows you to continue the conversation with the suggestion LLM.
+
+The refinement input and Send button appear in the accessibility snapshot after clicking '+'. Use refs to interact with them.
 
 For the **budget item**, type a refinement like:
 > Actually I need to include a standing desk — reallocate the budget to fit one in under $500
@@ -230,7 +350,7 @@ Navigate back to the space home. Open the Omnibot (FAB). Ask it to rearrange the
 
 > Make "Research the best noise-canceling headphones under $200" a subtask of "Budget for a home office upgrade"
 
-Wait for the LLM to use the `updateDoItem` tool (setting `indent`). The do-list supports indentation levels: 0 = root task, 1 = subtask, 2 = sub-subtask. Verify the item now appears indented under its parent in the do-list. Take a screenshot.
+Wait for the LLM to use the `updateDoItem` tool (setting `indent`). The do-list supports indentation levels: 0 = root task, 1 = subtask, 2 = sub-subtask. Complex operations (remove + re-add with indent) can take 30-60 seconds. If the LLM times out, the partial results (e.g. marking done, removing item) will still be visible. Try simpler operations first: 'Mark the camping trip as done' before attempting subtask nesting. Verify the item now appears indented under its parent in the do-list. Take a screenshot.
 
 Try another rearrangement — ask Omnibot to mark one item as done, or to add a new subtask under an existing item.
 
@@ -321,41 +441,24 @@ These are persistent platform/tooling quirks that affect multiple steps. Step-sp
 
 1. **Font warnings in console.** JetBrainsMono font OTS parsing warnings are cosmetic — not errors. Ignore them when reviewing console output.
 
-2. **Content area scrolling requires shadow DOM traversal.** The space home content (do-list, pieces) is inside a scrollable container within shadow DOM. `window.scrollBy()` does NOT work. Use JS eval to find and scroll the container:
-    ```js
-    (() => {
-      function findScrollable(node, depth) {
-        if (depth > 8) return [];
-        const results = [];
-        if (node.shadowRoot) {
-          for (const el of node.shadowRoot.querySelectorAll('*')) {
-            if (el.scrollHeight > el.clientHeight + 50) {
-              el.scrollBy(0, 400);
-              results.push({ tag: el.tagName, scrollH: el.scrollHeight, clientH: el.clientHeight });
-            }
-            results.push(...findScrollable(el, depth + 1));
-          }
-        }
-        return results;
-      }
-      const all = [];
-      document.querySelectorAll('*').forEach(el => all.push(...findScrollable(el, 0)));
-      return all.filter(r => r.scrollH > r.clientH + 50);
-    })()
-    ```
+2. **Newlines in `agent-browser type` trigger Enter/submit.** Never include newlines in typed text — the chat input interprets them as send. Write everything on one line.
 
-3. **Newlines in `agent-browser type` trigger Enter/submit.** Never include newlines in typed text — the chat input interprets them as send. Write everything on one line.
+3. **Shell quoting with `agent-browser eval`.** Inline JS with quotes gets mangled by the shell. Always write JS to a temp file first: `cat > /tmp/tour-helper.js <<'EOF' ... EOF` then run `agent-browser eval "$(cat /tmp/tour-helper.js)"`. See the Shadow DOM Helpers section.
+
+4. **Do NOT use Playwright MCP alongside `agent-browser`.** They operate on separate page contexts. Playwright MCP's page will be `about:blank` while `agent-browser` has the actual page. Pick one and stick with it.
 
 ## Rules
 
 - **Prefer `agent-browser`, fall back to Playwright MCP.** Check availability at startup and adapt.
 - **Always snapshot before interacting.** Never assume element refs from a previous snapshot are still valid.
+- **Use `snapshot -i` for interactive refs.** The `-i` flag returns only interactive elements with unique refs, avoiding the duplicate-ref problem that occurs with full snapshots.
+- **Use coordinate-based clicks for ALL shadow DOM custom elements.** This includes `ct-button`, `ct-cell-link`, `ct-input`, `<details>` summaries, and `ct-message-beads`. Ref-based clicks may hang or fail on these.
+- **Write JS eval snippets to temp files.** See Known Gotchas for details.
 - **Be descriptive.** The user is watching — narrate what you see, what you're clicking, and what happened.
 - **Don't block on failures.** If a step fails, document it and move on. The tour is about coverage, not perfection.
 - **No hardcoded selectors.** Discover elements from snapshots. The UI may change — the Known Gotchas describe interaction patterns, not specific refs.
 - **Show the browser.** Use headed/visible mode so the user can watch the tour happen in real time.
 - **This is exploratory, not a snapshot test.** The descriptions are high-level guides. You are free to explore beyond the prescribed steps and adapt to what you find.
-- **Use coordinate-based clicks for custom web components.** When `agent-browser click @ref` hangs, fall back to finding the element via JS eval and clicking at its coordinates.
 
 ## Self-Improvement
 
@@ -376,3 +479,5 @@ This tour is designed to improve itself. When something goes wrong during a run:
    - The file should get *better*, not *longer*.
 
 4. **Only document what you've actually hit.** Don't add speculative advice. Every change should come from a real failure in a real tour run.
+
+5. **Extract reusable helpers.** If a step requires JS eval for shadow DOM navigation, consider whether the snippet should be a helper in the Shadow DOM Helpers section. Parameterize where possible (e.g. 'find button by text' instead of 'find + button').


### PR DESCRIPTION
## Summary
- Fix Step 3 shadow DOM instructions (was referencing iframes that don't exist — actual structure is nested shadow DOM via `ct-render`)
- Add reusable Shadow DOM Helpers section with JS eval snippets for finding details disclosures, cell link chips, buttons, and scrolling
- Update steps 8, 10-13 to reference helpers instead of inlining fragile JS
- Add gotchas for shell quoting (`agent-browser eval` + temp files) and Playwright MCP (separate page context)
- Add rules for `snapshot -i`, coordinate-based clicks on custom elements, temp file usage

## Test plan
- [ ] Run `/tour` on a local dev server and verify Steps 3, 8, 10-13 work without manual DOM exploration
- [ ] Confirm shadow DOM helper snippets produce correct coordinates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the /tour command reliability by correcting shadow DOM paths and adding reusable helpers for interacting with custom elements. Updated steps and rules to favor snapshot -i and coordinate clicks, reducing flaky interactions and shell quoting issues.

- **New Features**
  - Shadow DOM Helpers for details disclosures, cell-link chips, buttons, and scroll (up/down).
  - Rules: use snapshot -i, coordinate-based clicks for custom elements, and temp-file JS eval to avoid shell quoting.
  - Guidance on Omnibot timing/dismissal and not mixing Playwright MCP with agent-browser (separate page contexts).
  - Self-improving process: fix steps directly, keep gotchas only for structural quirks.

- **Bug Fixes**
  - Corrected Step 3 to use the real nested shadow DOM path and a reliable title editing flow.
  - Updated Steps 8, 10–13 to use helpers instead of fragile inline JS; stabilized ct-button and <details> interactions.
  - Clarified counter launch via fetchAndRunPattern (counter/counter.tsx) and using snapshot refs for the body textbox.
  - Consolidated redundant gotchas and noted cosmetic font warnings.

<sup>Written for commit aaa60af83c112f5f2a2a5dbbf7f19510419887de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

