### PR TITLE
feat(patterns): add knowledge graph pattern with base graph from backlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ PROMPT.md
 ralph.yml
 .claude/blackboard.db-shm
 .claude/blackboard.db-wal
+.commands
+tour-screenshots

--- a/packages/patterns/system/default-app.tsx
+++ b/packages/patterns/system/default-app.tsx
@@ -22,6 +22,7 @@ const MAX_RECENT_CHARMS = 10;
 
 import BacklinksIndex, { type MentionablePiece } from "./backlinks-index.tsx";
 import SummaryIndex from "./summary-index.tsx";
+import KnowledgeGraph from "./knowledge-graph.tsx";
 import OmniboxFAB from "./omnibox-fab.tsx";
 import DoList from "../do-list/do-list.tsx";
 import Notebook from "../notes/notebook.tsx";
@@ -212,6 +213,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
 
   const index = BacklinksIndex({ allPieces: allPiecesWithSystem });
   const summaryIdx = SummaryIndex({});
+  const knowledgeGraph = KnowledgeGraph({});
 
   const fab = OmniboxFAB({
     mentionable: index.mentionable,
@@ -230,6 +232,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
   return {
     backlinksIndex: index,
     summaryIndex: summaryIdx,
+    knowledgeGraph,
     [NAME]: computed(() => `Space Home (${visiblePieces.length})`),
     [UI]: (
       <ct-screen>
@@ -273,6 +276,18 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
             }}
           >
             Search
+          </ct-cell-link>
+          <ct-cell-link
+            $cell={knowledgeGraph}
+            slot="end"
+            style={{
+              fontSize: "14px",
+              padding: "6px 12px",
+              textDecoration: "none",
+              color: "var(--ct-color-text-secondary)",
+            }}
+          >
+            Graph
           </ct-cell-link>
           <div slot="end">
             <ct-button

--- a/packages/patterns/system/knowledge-graph.tsx
+++ b/packages/patterns/system/knowledge-graph.tsx
@@ -1,0 +1,215 @@
+/// <cts-enable />
+import {
+  computed,
+  type Default,
+  equals,
+  NAME,
+  pattern,
+  patternTool,
+  type PatternToolResult,
+  UI,
+  wish,
+  Writable,
+} from "commontools";
+import { type MentionablePiece } from "./backlinks-index.tsx";
+
+export type GraphEdge = {
+  from: Writable<MentionablePiece>;
+  to: Writable<MentionablePiece>;
+  fromName: string;
+  toName: string;
+  description: string;
+};
+
+export type CompoundNode = {
+  [NAME]: string;
+  linkedPieces: Writable<MentionablePiece>[];
+  summary: string;
+};
+
+type Input = Record<string, never>;
+
+type Output = {
+  edges: GraphEdge[];
+  compoundNodes: CompoundNode[];
+  findIncoming: PatternToolResult<{ edges: GraphEdge[] }>;
+  findOutgoing: PatternToolResult<{ edges: GraphEdge[] }>;
+  searchGraph: PatternToolResult<{
+    edges: GraphEdge[];
+    compoundNodes: CompoundNode[];
+  }>;
+};
+
+/** Query result type for LLM consumption — names for readability, refs for identity. */
+type EdgeResult = {
+  from: Writable<MentionablePiece>;
+  to: Writable<MentionablePiece>;
+  fromName: string;
+  toName: string;
+  description: string;
+};
+
+/** Query sub-pattern: finds incoming edges to an entity. */
+export const findIncomingPattern = pattern<
+  { entity: Writable<MentionablePiece>; edges: GraphEdge[] },
+  { result: EdgeResult[] }
+>(({ entity, edges }) => {
+  const result = computed(() => {
+    return edges
+      .filter((edge) => equals(edge.to, entity))
+      .map((edge) => ({
+        from: edge.from,
+        to: edge.to,
+        fromName: edge.fromName,
+        toName: edge.toName,
+        description: edge.description,
+      }));
+  });
+
+  return { result };
+});
+
+/** Query sub-pattern: finds outgoing edges from an entity. */
+export const findOutgoingPattern = pattern<
+  { entity: Writable<MentionablePiece>; edges: GraphEdge[] },
+  { result: EdgeResult[] }
+>(({ entity, edges }) => {
+  const result = computed(() => {
+    return edges
+      .filter((edge) => equals(edge.from, entity))
+      .map((edge) => ({
+        from: edge.from,
+        to: edge.to,
+        fromName: edge.fromName,
+        toName: edge.toName,
+        description: edge.description,
+      }));
+  });
+
+  return { result };
+});
+
+/** Query sub-pattern: searches graph by text query. */
+export const searchGraphPattern = pattern<
+  { query: string; edges: GraphEdge[]; compoundNodes: CompoundNode[] },
+  { edges: EdgeResult[]; compoundNodes: CompoundNode[] }
+>(({ query, edges, compoundNodes }) => {
+  const filteredEdges = computed(() => {
+    const matching = !query || query.trim() === "" ? edges : (() => {
+      const lowerQuery = query.toLowerCase().trim();
+      return edges.filter((edge) =>
+        edge.fromName.toLowerCase().includes(lowerQuery) ||
+        edge.toName.toLowerCase().includes(lowerQuery) ||
+        edge.description.toLowerCase().includes(lowerQuery)
+      );
+    })();
+    return matching.map((edge) => ({
+      from: edge.from,
+      to: edge.to,
+      fromName: edge.fromName,
+      toName: edge.toName,
+      description: edge.description,
+    }));
+  });
+
+  const filteredNodes = computed(() => {
+    if (!query || query.trim() === "") return compoundNodes;
+    const lowerQuery = query.toLowerCase().trim();
+    return compoundNodes.filter((node) => {
+      const name = (node[NAME] ?? "").toString().toLowerCase();
+      const summary = node.summary.toLowerCase();
+      return name.includes(lowerQuery) || summary.includes(lowerQuery);
+    });
+  });
+
+  return { edges: filteredEdges, compoundNodes: filteredNodes };
+});
+
+const KnowledgeGraph = pattern<Input, Output>(() => {
+  const mentionable = wish<Default<Writable<MentionablePiece>[], []>>({
+    query: "#mentionable",
+  }).result;
+
+  const baseEdges = computed(() => {
+    const result: GraphEdge[] = [];
+    for (const piece of mentionable ?? []) {
+      if (!piece) continue;
+      const pieceName = (piece.get()[NAME] ?? "").toString();
+      // Access mentioned via .key() for reactive tracking
+      const mentioned = piece.key("mentioned").get() ?? [];
+      for (const mentionedItem of mentioned) {
+        if (!mentionedItem) continue;
+        const mentionedName = (mentionedItem[NAME] ?? "").toString();
+        result.push({
+          from: piece,
+          to: mentionedItem as Writable<MentionablePiece>,
+          fromName: pieceName,
+          toName: mentionedName,
+          description: "mentions",
+        });
+      }
+    }
+    return result;
+  });
+
+  const agentEdges = Writable.of<GraphEdge[]>([]);
+  const compoundNodes = Writable.of<CompoundNode[]>([]);
+
+  const allEdges = computed(() => [...baseEdges, ...agentEdges.get()]);
+
+  const edgeCount = computed(() => allEdges.length);
+
+  return {
+    [NAME]: computed(() => `Knowledge Graph (${edgeCount} links)`),
+    [UI]: (
+      <ct-screen>
+        <ct-toolbar slot="header" sticky>
+          <h2 style={{ margin: 0, fontSize: "18px" }}>Knowledge Graph</h2>
+        </ct-toolbar>
+        <ct-vstack gap="4" padding="6">
+          <span
+            style={{
+              fontSize: "13px",
+              color: "var(--ct-color-text-secondary)",
+            }}
+          >
+            {edgeCount} links
+          </span>
+          <ct-table full-width>
+            <tbody>
+              {allEdges.map((edge) => (
+                <tr>
+                  <td style={{ fontWeight: "500", whiteSpace: "nowrap" }}>
+                    <ct-cell-link $cell={edge.from} />
+                  </td>
+                  <td
+                    style={{
+                      fontSize: "13px",
+                      color: "var(--ct-color-text-secondary)",
+                      textAlign: "center",
+                    }}
+                  >
+                    {edge.description}
+                  </td>
+                  <td style={{ fontWeight: "500", whiteSpace: "nowrap" }}>
+                    <ct-cell-link $cell={edge.to} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </ct-table>
+        </ct-vstack>
+      </ct-screen>
+    ),
+    edges: allEdges,
+    compoundNodes,
+    findIncoming: patternTool(findIncomingPattern, { edges: allEdges }),
+    findOutgoing: patternTool(findOutgoingPattern, { edges: allEdges }),
+    searchGraph: patternTool(searchGraphPattern, {
+      edges: allEdges,
+      compoundNodes,
+    }),
+  };
+});
+
+export default KnowledgeGraph;

--- a/packages/patterns/system/omnibox-fab.tsx
+++ b/packages/patterns/system/omnibox-fab.tsx
@@ -29,6 +29,11 @@ import {
   searchPattern as summarySearchPattern,
   type SummaryIndexEntry,
 } from "./summary-index.tsx";
+import {
+  findIncomingPattern,
+  findOutgoingPattern,
+  type GraphEdge,
+} from "./knowledge-graph.tsx";
 
 interface DoListTools {
   addItem: Stream<{ title: string; indent?: number }>;
@@ -168,6 +173,9 @@ export default pattern<OmniboxFABInput>(
     const { entries: summaryEntries } = wish<{
       entries: SummaryIndexEntry[];
     }>({ query: "#summaryIndex" }).result;
+    const { edges: graphEdges } = wish<{
+      edges: GraphEdge[];
+    }>({ query: "#knowledgeGraph" }).result;
 
     const sandboxId = Writable.of(
       `omnibot-${Math.random().toString(36).slice(2, 10)}`,
@@ -188,6 +196,7 @@ export default pattern<OmniboxFABInput>(
 ${profileSection}
 Tool usage priority:
 - For finding content in the space: use searchSpace with a query to search across all piece summaries and names
+- For finding relationships between pieces: use findIncomingLinks/findOutgoingLinks with an entity reference, or searchGraph with a text query
 - For patterns: listPatternIndex first
 - For existing pages/notes/content: searchSpace first, then listRecent or listMentionable to identify what they're referencing
 - Attach relevant items to conversation after instantiation/retrieval if they support ongoing tasks
@@ -249,6 +258,12 @@ Be matter-of-fact. Prefer action to explanation.`;
         }),
         searchSpace: patternTool(summarySearchPattern, {
           entries: summaryEntries,
+        }),
+        findIncomingLinks: patternTool(findIncomingPattern, {
+          edges: graphEdges,
+        }),
+        findOutgoingLinks: patternTool(findOutgoingPattern, {
+          edges: graphEdges,
         }),
       },
     });

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -402,6 +402,7 @@ function resolveSpaceTarget(
     "#default": ["defaultPattern"],
     "#mentionable": ["defaultPattern", "backlinksIndex", "mentionable"],
     "#summaryIndex": ["defaultPattern", "summaryIndex"],
+    "#knowledgeGraph": ["defaultPattern", "knowledgeGraph"],
     "#allPieces": ["defaultPattern", "allPieces"],
     "#recent": ["defaultPattern", "recentPieces"],
   };


### PR DESCRIPTION
Introduces a knowledge graph system pattern that builds a reactive graph
from the existing backlinks/mentioned relationships between pieces. Exposes
findIncomingLinks and findOutgoingLinks tools to the omnibox agent for
graph traversal. Phase 2 will add an LLM agent layer for higher-level
annotations (compound nodes, relationship descriptions).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reactive knowledge graph from existing backlinks and integrates traversal tools into the omnibox for quick relationship lookup. Progresses CT-1263 by providing a simple graph index and a UI entry point.

- **New Features**
  - KnowledgeGraph pattern builds edges from “mentioned” relationships and shows a simple graph screen with link count and edge table.
  - Omnibox tools: findIncomingLinks and findOutgoingLinks powered by graph edges; prompt updated with relationship guidance.
  - App integration: registers knowledgeGraph in default-app, adds a “Graph” link in Space Home, and adds #knowledgeGraph to wish resolver.
  - Housekeeping: added .commands and tour-screenshots to .gitignore.

<sup>Written for commit 125319ec6d6748d681311ba20474c323d63e3bea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

