### PR TITLE
Ct switch cell support

### DIFF
--- a/packages/ui/src/v2/components/ct-switch/ct-switch.ts
+++ b/packages/ui/src/v2/components/ct-switch/ct-switch.ts
@@ -272,6 +272,7 @@ export class CTSwitch extends BaseElement {
 
       // For plain boolean usage (no Cell), update the property directly
       this.checked = !oldChecked;
+      this.emit("ct-change", { checked: this.checked });
     }
 
     private _handleKeydown(event: KeyboardEvent) {


### PR DESCRIPTION
## Summary
ct-switch now supports $checked bidirectional binding with reactive Cells, matching ct-checkbox behavior. Uses createBooleanCellController for Cell subscription, value read/write, and change events.

## Steps to reproduce

Deploy this test pattern. When you toggle either the switch or the checkbox, the other control should also update and the Status label should update to match. Previously this did not work.

```ts
/// <cts-enable />
import { computed, Default, NAME, pattern, UI, Writable } from "commontools";

interface SwitchInput {
  on: Writable<Default<boolean, false>>;
}

interface SwitchOutput {
  on: boolean;
}

export default pattern<SwitchInput, SwitchOutput>(({ on }) => {
  const label = computed(() => (on.get() ? "On" : "Off"));

  return {
    [NAME]: "Toggle Switch",
    [UI]: (
      <div
        style={{
          padding: "1rem",
          display: "flex",
          flexDirection: "column",
          gap: "0.5rem",
        }}
      >
        <ct-switch $checked={on}>Toggle</ct-switch>
        <ct-checkbox $checked={on}>Toggle</ct-checkbox>
        <span>State: {label}</span>
      </div>
    ),
    on,
  };
});
```

## Demo

https://github.com/user-attachments/assets/7c6fa3a8-659c-489d-9b8b-f3ef11cfa4e2