### PR TITLE
feat(patterns): add GitHub activity pattern

### DIFF
--- a/packages/patterns/github-activity/main.tsx
+++ b/packages/patterns/github-activity/main.tsx
@@ -145,6 +145,7 @@ export default pattern<{
                         <a
                           href={commit.html_url}
                           target="_blank"
+                          rel="noopener noreferrer"
                           style="font-size: 13px; color: #0969da;"
                         >
                           View commit →

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -1113,3 +1113,29 @@ type Input = {
 ```ts
 // Returns a 3-column grid view of pieces with live previews
 ```
+
+## `github-activity/main.tsx`
+
+Fetches recent commits from a GitHub repository via the public API, displays
+them as a clickable card list, and uses an LLM to generate a summary of recent
+development activity. Fully reactive — changing the repo URL re-fetches and
+re-summarizes.
+
+**Keywords:** github, commits, fetchData, generateText, LLM, summary, activity
+
+### Input Schema
+
+```ts
+type Input = {
+  repoUrl: Writable<
+    Default<string, "https://github.com/anthropics/claude-code">
+  >;
+};
+```
+
+### Output Schema
+
+```ts
+// Displays LLM-generated activity summary and scrollable commit list
+// with author, date, and clickable links to GitHub
+```


### PR DESCRIPTION
## Summary
- Adds a new pattern that fetches recent commits from any GitHub repo via the public API
- Displays commits as a clickable card list with author, date, and link to GitHub
- Uses `generateText` to produce an LLM-generated summary of recent development activity
- Fully reactive — changing the repo URL re-fetches and re-summarizes

## Test plan
- [x] `deno task ct check packages/patterns/github-activity/main.tsx`
- [x] Change the repo URL input and verify re-fetch
- [x] Click a commit link and verify it opens GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Activity pattern that fetches recent commits from a repo and generates a short summary of recent development. Displays commits as clickable cards; changing the repo URL re-fetches and re-summarizes.

- **New Features**
  - Parses owner/repo from a GitHub URL and fetches commits via the public API.
  - Shows up to 20 commits as cards with message, author, date, and a safe link to GitHub (rel=noopener noreferrer).
  - Generates a concise 2–3 sentence activity summary with loading state and empty-state handling; adds an index entry for the pattern.

<sup>Written for commit 0637fedc0ab34f1378c9d7489e702ed339e5f011. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

