### PR TITLE
Fix LLM tool definitions: inline $ref and strip internal markers

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -35,6 +35,7 @@ import {
   matchLLMFriendlyLink,
   parseLink,
   parseLLMFriendlyLink,
+  sanitizeSchemaForLinks,
 } from "../link-utils.ts";
 import {
   getCellOrThrow,
@@ -94,7 +95,93 @@ function normalizeInputSchema(schemaLike: unknown): JSONSchema {
     };
   }
   if (!isObject(inputSchema)) inputSchema = { type: "object" };
-  return stripInjectedResult(inputSchema) as JSONSchema;
+  const stripped = stripInjectedResult(inputSchema) as JSONSchema;
+  return prepareSchemaForLLM(stripped);
+}
+
+/**
+ * Inline all `$ref: "#/$defs/X"` references in a JSON schema, producing a
+ * self-contained schema with no `$ref` or `$defs`.
+ *
+ * Circular references are detected by tracking which definition names are
+ * currently being resolved on the active path. When a cycle is found (or
+ * `maxDepth` $ref resolutions are exceeded), the node is truncated to a
+ * permissive object.
+ *
+ * `refDepth` only increments when resolving a `$ref`, not when recursing into
+ * regular JSON properties, so deeply nested but non-recursive schemas pass
+ * through without truncation.
+ */
+function resolveRefsForLLM(
+  schema: JSONSchema,
+  maxDepth = 4,
+): JSONSchema {
+  if (typeof schema !== "object" || schema === null) return schema;
+
+  const defs = (schema as any).$defs ?? {};
+
+  function resolve(
+    node: any,
+    refDepth: number,
+    activeRefs: Set<string>,
+  ): any {
+    if (typeof node !== "object" || node === null) return node;
+
+    // Handle $ref
+    if (node.$ref && typeof node.$ref === "string") {
+      const match = node.$ref.match(/^#\/\$defs\/(.+)$/);
+      if (match) {
+        const defName = match[1];
+        if (activeRefs.has(defName) || refDepth >= maxDepth) {
+          // Circular or too deep — truncate
+          return { type: "object", additionalProperties: true };
+        }
+        const def = defs[defName];
+        if (def) {
+          const { $ref: _, ...rest } = node; // preserve sibling props
+          const newActiveRefs = new Set(activeRefs);
+          newActiveRefs.add(defName);
+          const resolved = resolve(def, refDepth + 1, newActiveRefs);
+          return Object.keys(rest).length > 0
+            ? { ...resolved, ...rest }
+            : resolved;
+        }
+      }
+      // Unresolvable ref — return as generic object
+      return { type: "object", additionalProperties: true };
+    }
+
+    // Recurse into object properties (does not increment refDepth)
+    const result: any = {};
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "$defs") continue; // strip $defs from output
+      if (Array.isArray(value)) {
+        result[key] = value.map((item) =>
+          typeof item === "object" && item !== null
+            ? resolve(item, refDepth, activeRefs)
+            : item
+        );
+      } else if (typeof value === "object" && value !== null) {
+        result[key] = resolve(value, refDepth, activeRefs);
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  return resolve(schema, 0, new Set());
+}
+
+/**
+ * Prepare a schema for use in LLM tool definitions by:
+ * 1. Stripping internal markers (asCell, asStream, asOpaque)
+ * 2. Inlining all $ref references
+ */
+function prepareSchemaForLLM(schema: JSONSchema): JSONSchema {
+  if (typeof schema !== "object" || schema === null) return schema;
+  const sanitized = sanitizeSchemaForLinks(schema);
+  return resolveRefsForLLM(sanitized);
 }
 
 /**
@@ -1391,6 +1478,8 @@ export const llmDialogTestHelpers = {
   hasValidContent,
   PRESENT_RESULT_TOOL_NAME,
   simplifySchemaForContext,
+  prepareSchemaForLLM,
+  resolveRefsForLLM,
 };
 
 /**
@@ -1407,6 +1496,7 @@ export const llmToolExecutionHelpers = {
   hasValidContent,
   buildAvailableCellsDocumentation,
   traverseAndCellify,
+  prepareSchemaForLLM,
 };
 
 /**
@@ -2149,7 +2239,9 @@ async function startRequest(
     toolCatalog.llmTools[PRESENT_RESULT_TOOL_NAME] = {
       description:
         "Call this tool to present a structured result. This stores the result for the caller.",
-      inputSchema: JSON.parse(JSON.stringify(userResultSchema)),
+      inputSchema: prepareSchemaForLLM(
+        JSON.parse(JSON.stringify(userResultSchema)),
+      ),
     };
   }
 

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -804,7 +804,9 @@ export function generateObject<T extends Record<string, unknown>>(
               [llmToolExecutionHelpers.PRESENT_RESULT_TOOL_NAME]: {
                 description:
                   "Call this tool with the final structured result matching the required schema. This should be your last action.",
-                inputSchema: JSON.parse(JSON.stringify(schema)),
+                inputSchema: llmToolExecutionHelpers.prepareSchemaForLLM(
+                  JSON.parse(JSON.stringify(schema)),
+                ),
               },
             },
           };
@@ -934,7 +936,9 @@ export function generateObject<T extends Record<string, unknown>>(
       const generateObjectParams: LLMGenerateObjectRequest = {
         messages: requestMessages,
         maxTokens: maxTokens ?? 8192,
-        schema: JSON.parse(JSON.stringify(schema)),
+        schema: llmToolExecutionHelpers.prepareSchemaForLLM(
+          JSON.parse(JSON.stringify(schema)),
+        ) as Record<string, unknown>,
         model: model ?? DEFAULT_GENERATE_OBJECT_MODELS,
         metadata: {
           ...readyMetadata,

--- a/packages/runner/test/llm-dialog-helpers.test.ts
+++ b/packages/runner/test/llm-dialog-helpers.test.ts
@@ -12,6 +12,8 @@ const {
   createToolResultMessages,
   hasValidContent,
   simplifySchemaForContext,
+  prepareSchemaForLLM,
+  resolveRefsForLLM,
 } = llmDialogTestHelpers;
 
 Deno.test("parseTargetString recognizes handle format", () => {
@@ -449,4 +451,208 @@ Deno.test("simplifySchemaForContext handles Stream with nested detail structure"
     result.properties?.editContent?.properties?.detail?.properties?.value?.type,
     "string",
   );
+});
+
+// Tests for resolveRefsForLLM
+
+Deno.test("resolveRefsForLLM resolves simple $ref", () => {
+  const schema: any = {
+    type: "object",
+    $defs: {
+      Name: { type: "string" },
+    },
+    properties: {
+      name: { $ref: "#/$defs/Name" },
+    },
+  };
+  const result = resolveRefsForLLM(schema) as any;
+  assertEquals(result.properties?.name, { type: "string" });
+  assertEquals(result.$defs, undefined);
+});
+
+Deno.test("resolveRefsForLLM resolves nested $ref chains", () => {
+  const schema: any = {
+    type: "object",
+    $defs: {
+      Inner: { type: "number" },
+      Outer: {
+        type: "object",
+        properties: {
+          value: { $ref: "#/$defs/Inner" },
+        },
+      },
+    },
+    properties: {
+      data: { $ref: "#/$defs/Outer" },
+    },
+  };
+  const result = resolveRefsForLLM(schema) as any;
+  assertEquals(result.properties?.data?.type, "object");
+  assertEquals(result.properties?.data?.properties?.value, { type: "number" });
+  assertEquals(result.$defs, undefined);
+});
+
+Deno.test("resolveRefsForLLM truncates circular $ref", () => {
+  const schema: any = {
+    type: "object",
+    $defs: {
+      Node: {
+        type: "object",
+        properties: {
+          child: { $ref: "#/$defs/Node" },
+          value: { type: "string" },
+        },
+      },
+    },
+    properties: {
+      root: { $ref: "#/$defs/Node" },
+    },
+  };
+  const result = resolveRefsForLLM(schema) as any;
+  // First level should be resolved
+  assertEquals(result.properties?.root?.type, "object");
+  assertEquals(result.properties?.root?.properties?.value, { type: "string" });
+  // Circular reference should be truncated
+  assertEquals(result.properties?.root?.properties?.child, {
+    type: "object",
+    additionalProperties: true,
+  });
+  assertEquals(result.$defs, undefined);
+});
+
+Deno.test("resolveRefsForLLM passes through schema with no $ref unchanged", () => {
+  const schema: any = {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      age: { type: "number" },
+    },
+    required: ["name"],
+  };
+  const result = resolveRefsForLLM(schema) as any;
+  assertEquals(result.type, "object");
+  assertEquals(result.properties?.name, { type: "string" });
+  assertEquals(result.properties?.age, { type: "number" });
+  assertEquals(result.required, ["name"]);
+});
+
+Deno.test("resolveRefsForLLM preserves sibling properties alongside $ref", () => {
+  const schema: any = {
+    type: "object",
+    $defs: {
+      Items: { type: "array", items: { type: "string" } },
+    },
+    properties: {
+      list: { $ref: "#/$defs/Items", default: [] },
+    },
+  };
+  const result = resolveRefsForLLM(schema) as any;
+  assertEquals(result.properties?.list?.type, "array");
+  assertEquals(result.properties?.list?.default, []);
+  assertEquals(result.properties?.list?.items, { type: "string" });
+});
+
+Deno.test("resolveRefsForLLM handles mutually recursive types", () => {
+  const schema: any = {
+    type: "object",
+    $defs: {
+      A: {
+        type: "object",
+        properties: { b: { $ref: "#/$defs/B" } },
+      },
+      B: {
+        type: "object",
+        properties: { a: { $ref: "#/$defs/A" } },
+      },
+    },
+    properties: {
+      start: { $ref: "#/$defs/A" },
+    },
+  };
+  const result = resolveRefsForLLM(schema) as any;
+  assertEquals(result.properties?.start?.type, "object");
+  // A resolved -> B resolved -> A is circular, truncated
+  assertEquals(result.properties?.start?.properties?.b?.type, "object");
+  assertEquals(
+    result.properties?.start?.properties?.b?.properties?.a,
+    { type: "object", additionalProperties: true },
+  );
+});
+
+// Tests for prepareSchemaForLLM
+
+Deno.test("prepareSchemaForLLM strips internal markers and resolves $ref", () => {
+  const schema: any = {
+    type: "object",
+    $defs: {
+      Item: { type: "string" },
+    },
+    properties: {
+      data: { $ref: "#/$defs/Item", asCell: true },
+      stream: { type: "number", asStream: true },
+      hidden: { type: "object", asOpaque: true },
+    },
+  };
+  const result = prepareSchemaForLLM(schema) as any;
+  // asCell, asStream, asOpaque should be stripped
+  assertEquals(result.properties?.data?.asCell, undefined);
+  assertEquals(result.properties?.stream?.asStream, undefined);
+  assertEquals(result.properties?.hidden?.asOpaque, undefined);
+  // $ref should be resolved
+  assertEquals(result.properties?.data?.type, "string");
+  assertEquals(result.$defs, undefined);
+});
+
+Deno.test("prepareSchemaForLLM handles recursive TodoItem schema", () => {
+  // This mirrors the writable-recursive-todoitem.expected.json fixture
+  const schema: any = {
+    $defs: {
+      AnonymousType_1: {
+        items: { $ref: "#/$defs/TodoItem" },
+        type: "array",
+      },
+      TodoItem: {
+        properties: {
+          done: { default: false, type: "boolean" },
+          items: { $ref: "#/$defs/AnonymousType_1", asCell: true, default: [] },
+          title: { type: "string" },
+        },
+        required: ["done", "items", "title"],
+        type: "object",
+      },
+    },
+    properties: {
+      todos: { $ref: "#/$defs/AnonymousType_1", default: [] },
+    },
+    required: ["todos"],
+    type: "object",
+  };
+  const result = prepareSchemaForLLM(schema) as any;
+
+  // No $defs or $ref in output
+  assertEquals(result.$defs, undefined);
+  assertEquals(JSON.stringify(result).includes("$ref"), false);
+
+  // No internal markers
+  assertEquals(JSON.stringify(result).includes("asCell"), false);
+
+  // Structure should be resolved
+  assertEquals(result.type, "object");
+  assertEquals(result.properties?.todos?.type, "array");
+  assertEquals(result.properties?.todos?.default, []);
+
+  // The items of todos should be resolved TodoItem objects
+  const todoItem = result.properties?.todos?.items;
+  assertEquals(todoItem?.type, "object");
+  assertEquals(todoItem?.properties?.title?.type, "string");
+  assertEquals(todoItem?.properties?.done?.type, "boolean");
+
+  // The nested items field (recursive) should be truncated
+  // since TodoItem -> AnonymousType_1 -> TodoItem is circular.
+  // When a circular $ref is detected, it's replaced with a permissive object.
+  const nestedItems = todoItem?.properties?.items;
+  assertEquals(nestedItems, {
+    type: "object",
+    additionalProperties: true,
+  });
 });


### PR DESCRIPTION
## Summary

- **Inline `$ref`/`$defs`** in tool `inputSchema` objects before sending to LLM providers (Anthropic, OpenAI). Most providers reject schemas with `$ref` references in tool definitions.
- **Strip internal markers** (`asCell`, `asStream`, `asOpaque`) which are Common Tools runtime internals that pollute tool schemas.
- Applied at all three sites where tool schemas are created: `normalizeInputSchema()`, `presentResult` tool in `llm-dialog.ts`, and both `generateObject()` paths in `llm.ts`.

## Details

Adds `resolveRefsForLLM(schema)` which recursively inlines `$ref` definitions with cycle detection (circular refs truncate to `{ type: "object", additionalProperties: true }`), and `prepareSchemaForLLM(schema)` which composes the existing `sanitizeSchemaForLinks()` with ref resolution.

This fixes tool call failures for patterns with complex/recursive types (e.g., do-list's `addItems` handler with `Writable<>` producing `asCell`, or recursive `TodoItem` schemas).

## Test plan

- [x] 8 new unit tests covering simple refs, nested chains, circular refs, sibling properties, mutually recursive types, passthrough, combined sanitize+resolve, and recursive TodoItem schemas
- [x] All 181 runner tests pass (0 failures)
- [x] `deno lint` and `deno fmt` clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)