### PR TITLE
Disable OpenTelemetry by default in toolshed

### DIFF
--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -32,7 +32,7 @@ const EnvSchema = z.object({
   // ===========================================================================
   // OpenTelemetry Configuration
   // ===========================================================================
-  OTEL_ENABLED: z.coerce.boolean().default(true),
+  OTEL_ENABLED: z.coerce.boolean().default(false),
   OTEL_SERVICE_NAME: z.string().default("toolshed"),
   OTEL_EXPORTER_OTLP_ENDPOINT: z.string().default("http://localhost:4318"),
   OTEL_TRACES_SAMPLER: z.string().default("always_on"),


### PR DESCRIPTION
## Summary
- Changes `OTEL_ENABLED` default from `true` to `false` in `packages/toolshed/env.ts`
- Most local dev setups don't run an OTEL collector on localhost:4318, so having it on by default just adds connection error noise
- Opt in with `OTEL_ENABLED=true` in your `.env` or environment

## Test plan
- [ ] Verify toolshed starts without OTEL errors when no collector is running
- [ ] Verify `OTEL_ENABLED=true` still enables telemetry when a collector is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)