### PR TITLE
Fix commit.ts fid1: content ID parse failure

### DIFF
--- a/packages/memory/commit.ts
+++ b/packages/memory/commit.ts
@@ -10,7 +10,7 @@ import type {
 } from "./interface.ts";
 import type { ContentId } from "./reference.ts";
 import { assert } from "./fact.ts";
-import { fromString } from "merkle-reference";
+import { fromString } from "./reference.ts";
 
 export const COMMIT_LOG_TYPE = "application/commit+json" as const;
 export const create = <Space extends MemorySpace>({


### PR DESCRIPTION
## Summary

`commit.ts` imports `fromString` directly from `merkle-reference`, bypassing the flag-dispatched version in `./reference.ts`. When canonical hashing is enabled, `fid1:` content IDs crash with `ReferenceError: Invalid reference` because the upstream `merkle-reference` library only handles legacy ID formats.

This was a site missed by the earlier merkle-reference import audit (Phase 2, PR #2906).

## Changes

- `packages/memory/commit.ts` line 13: changed `import { fromString } from "merkle-reference"` to `import { fromString } from "./reference.ts"`

This routes `fromString` calls in `toRevision` and `toChanges` through the flag-dispatched wrapper, which correctly handles both legacy and `fid1:` content ID formats.

## Test plan

- [x] `deno fmt --check` passes on `packages/memory` (75 files checked)
- [x] `deno task test` passes on `packages/memory` (109/109 tests passed, 0 failed)
- [ ] Manual verification: start local dev servers with `EXPERIMENTAL_RICH_STORABLE_VALUES=true EXPERIMENTAL_CANONICAL_HASHING=true` and confirm pieces load without `ReferenceError`

--- upstream-liaison-bolt (Claude Opus 4.6)
