### PR TITLE
Fix reflected XSS in Google OAuth callback HTML generation

### DIFF
--- a/packages/toolshed/routes/integrations/google-oauth/google-oauth.utils.ts
+++ b/packages/toolshed/routes/integrations/google-oauth/google-oauth.utils.ts
@@ -72,8 +72,26 @@ export const getBaseUrl = (url: string): string => {
   }
 };
 
+// Escape special HTML characters to prevent XSS when interpolating into HTML.
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 // Helper function to generate HTML for the callback page
 export function generateCallbackHtml(result: Record<string, unknown>): string {
+  // Escape user-controlled values before interpolation into HTML body.
+  const statusMessage = result.success
+    ? "You can close this window now."
+    : escapeHtml(String(result.error || "An error occurred"));
+
+  // Escape '<' in JSON to prevent </script> breakout in script context.
+  const safeJson = JSON.stringify(result).replace(/</g, "\\u003c");
+
   return `
     <!DOCTYPE html>
     <html>
@@ -99,19 +117,15 @@ export function generateCallbackHtml(result: Record<string, unknown>): string {
     result.success ? "Authentication Successful!" : "Authentication Failed"
   }
       </h1>
-      <p>${
-    result.success
-      ? "You can close this window now."
-      : result.error || "An error occurred"
-  }</p>
+      <p>${statusMessage}</p>
       <script>
         // Send message to opener and close window
         if (window.opener) {
           window.opener.postMessage({
             type: 'oauth-callback',
-            result: ${JSON.stringify(result)}
+            result: ${safeJson}
           }, window.location.origin);
-          
+
           // Close the window after a short delay
           setTimeout(() => window.close(), 2000);
         }


### PR DESCRIPTION
## Summary
- Fixes reflected XSS in Google OAuth callback HTML generation
- HTML-escapes error messages before interpolation into HTML body
- Escapes `<` in JSON.stringify output inside script tags to prevent script context breakout

Fixes CT-1286

## Test plan
- [ ] Verify OAuth callback still works correctly for success and error cases
- [ ] Verify error messages with HTML characters are properly escaped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reflected XSS in the Google OAuth callback by escaping user-controlled error messages and sanitizing JSON in the script block. Addresses CT-1286 and hardens the callback page without changing the success flow.

- **Bug Fixes**
  - HTML-escape error messages before rendering in the page.
  - Escape "<" in JSON used inside the script to prevent </script> breakout.

<sup>Written for commit fbf231ea93571ca49518acbf5c0b6c7f3649efb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

