### PR TITLE
Fix path traversal vulnerability in pattern file server

### DIFF
--- a/packages/toolshed/routes/patterns/patterns-server.ts
+++ b/packages/toolshed/routes/patterns/patterns-server.ts
@@ -33,6 +33,13 @@ export class PatternsServer {
   async get(filename: string): Promise<Uint8Array> {
     const url = new URL(filename, this.baseUrl);
 
+    // Security: verify the resolved URL stays within the patterns directory.
+    // This prevents path traversal via encoded sequences (e.g. %2e%2e) that
+    // bypass string-level checks but are decoded during URL resolution.
+    if (!url.href.startsWith(this.baseUrl.href)) {
+      throw new Error("Path traversal detected");
+    }
+
     try {
       return await Deno.readFile(url);
     } catch (error) {

--- a/packages/toolshed/routes/patterns/patterns.handlers.ts
+++ b/packages/toolshed/routes/patterns/patterns.handlers.ts
@@ -15,13 +15,15 @@ export const getPattern = async (
 
   try {
     // Security: validate filename doesn't contain path traversal
+    // Decode first to catch encoded traversal sequences (e.g. %2e%2e)
     // Block .. sequences that could escape the patterns directory
     // Block leading / which would create absolute paths in URL resolution
     // Block : to prevent URL scheme injection (e.g., file:///etc/passwd)
     // Allow internal / for subdirectory access (e.g., record/registry.ts)
+    const decoded = decodeURIComponent(filename);
     if (
-      filename.includes("..") || filename.startsWith("/") ||
-      filename.includes(":")
+      decoded.includes("..") || decoded.startsWith("/") ||
+      decoded.includes(":")
     ) {
       return c.json(
         { error: "Invalid file path" },


### PR DESCRIPTION
## Summary
- Fixes path traversal vulnerability in pattern file server
- Adds post-resolution containment check to verify resolved URLs stay within patterns directory
- Adds defense-in-depth URL decoding before traversal string checks

Fixes CT-1287

## Test plan
- [ ] Verify normal pattern file serving still works
- [ ] Verify `..` sequences are blocked (literal and encoded)
- [ ] Verify double-encoded traversal attempts are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a path traversal vulnerability in the pattern file server to prevent reading files outside the patterns directory. Blocks literal, encoded, and double-encoded traversal attempts. Addresses CT-1287.

- **Bug Fixes**
  - Added a post-resolution containment check in PatternsServer.get() to ensure the resolved URL stays within the patterns base URL.
  - Decoded the filename before validation in getPattern and now reject "..", leading "/", and ":" to catch encoded traversal and scheme injection.

<sup>Written for commit 1ba994b1a518cd21f2b6da7f4595bf63dbaf37d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

