### PR TITLE
Fix OAuth state parameter forgery and PKCE bypass

### DIFF
--- a/packages/toolshed/routes/integrations/google-oauth/google-oauth.handlers.ts
+++ b/packages/toolshed/routes/integrations/google-oauth/google-oauth.handlers.ts
@@ -19,10 +19,12 @@ import {
   createOAuthClient,
   createRefreshErrorResponse,
   createRefreshSuccessResponse,
+  createSignedState,
   fetchUserInfo,
   getBaseUrl,
   persistTokens,
   tokenToAuthData,
+  verifySignedState,
 } from "./google-oauth.utils.ts";
 import { setBGCharm } from "@commontools/background-charm";
 import { runtime } from "@/index.ts";
@@ -59,13 +61,14 @@ export const login: AppRouteHandler<LoginRoute> = async (c) => {
       scope: scopeString,
     });
 
-    // Create state payload that includes the code verifier and scopes
-    const statePayload = btoa(JSON.stringify({
+    // Create HMAC-signed state payload; the code verifier is stored
+    // server-side and referenced by a random nonce in the state.
+    const statePayload = await createSignedState({
       authCellId: payload.authCellId,
       integrationPieceId: payload.integrationPieceId,
       codeVerifier: codeVerifier,
       scopes: payload.scopes,
-    }));
+    });
 
     // Add state parameter and other required params to the URL
     const authUrl = new URL(uri.toString());
@@ -124,39 +127,38 @@ export const callback: AppRouteHandler<CallbackRoute> = async (c) => {
       return createCallbackResponse(callbackResult);
     }
 
-    // Decode and parse the state parameter
+    // Verify the HMAC-signed state parameter and retrieve the server-side
+    // code verifier. This rejects forged, tampered, expired, or replayed
+    // state values.
     let decodedState: {
       authCellId: string;
       integrationPieceId: string;
-      codeVerifier: string;
+      codeVerifierNonce: string;
       scopes?: string[];
+      timestamp: number;
     };
+    let codeVerifier: string;
 
     try {
-      decodedState = JSON.parse(atob(state));
+      const verified = await verifySignedState(state);
+      decodedState = verified.payload;
+      codeVerifier = verified.codeVerifier;
       logger.info({
         decodedState: {
           authCellId: decodedState.authCellId,
           integrationPieceId: decodedState.integrationPieceId,
-          codeVerifier: decodedState.codeVerifier ? "present" : "missing",
+          codeVerifier: "present (server-side)",
           scopes: decodedState.scopes,
         },
-      }, "Decoded state parameter");
+      }, "Verified and decoded state parameter");
     } catch (error) {
-      logger.error({ state, error }, "Failed to decode state parameter");
+      const errorMsg = error instanceof Error
+        ? error.message
+        : "Invalid state parameter";
+      logger.error({ state, error }, "State parameter verification failed");
       const callbackResult: CallbackResult = {
         success: false,
-        error: "Invalid state parameter format",
-      };
-      return createCallbackResponse(callbackResult);
-    }
-
-    const codeVerifier = decodedState.codeVerifier;
-    if (!codeVerifier) {
-      logger.error("No code verifier found in state parameter");
-      const callbackResult: CallbackResult = {
-        success: false,
-        error: "Invalid state parameter: missing code verifier",
+        error: errorMsg,
       };
       return createCallbackResponse(callbackResult);
     }

--- a/packages/toolshed/routes/integrations/google-oauth/google-oauth.utils.ts
+++ b/packages/toolshed/routes/integrations/google-oauth/google-oauth.utils.ts
@@ -257,8 +257,186 @@ export function createCallbackResponse(
   });
 }
 
-// Store code verifiers (could be moved to a more persistent storage in production)
-export const codeVerifiers = new Map<string, string>();
+// ---------------------------------------------------------------------------
+// Server-side code verifier storage
+// Stores PKCE code verifiers keyed by a random nonce so they are never exposed
+// to the client. Entries are cleaned up on retrieval. This is an in-memory
+// store and will be lost on process restart, which is acceptable because OAuth
+// flows are short-lived (enforced by STATE_MAX_AGE_MS below).
+// ---------------------------------------------------------------------------
+export const codeVerifiers = new Map<
+  string,
+  { codeVerifier: string; createdAt: number }
+>();
+
+/** Maximum age of an OAuth state parameter (10 minutes). */
+const STATE_MAX_AGE_MS = 10 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// HMAC signing helpers for OAuth state parameters
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-process HMAC key used to sign OAuth state payloads. Generated once at
+ * startup via Web Crypto. A per-process secret is sufficient because OAuth
+ * flows complete within minutes — well within a single process lifetime.
+ */
+let _hmacKey: CryptoKey | null = null;
+
+async function getHmacKey(): Promise<CryptoKey> {
+  if (!_hmacKey) {
+    _hmacKey = await crypto.subtle.generateKey(
+      { name: "HMAC", hash: "SHA-256" },
+      false, // not extractable
+      ["sign", "verify"],
+    );
+  }
+  return _hmacKey;
+}
+
+function bufToHex(buf: ArrayBuffer): string {
+  return [...new Uint8Array(buf)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Timing-safe comparison of two hex strings. */
+function timingSafeEqual(a: string, b: string): boolean {
+  const bufA = new TextEncoder().encode(a);
+  const bufB = new TextEncoder().encode(b);
+  if (bufA.length !== bufB.length) return false;
+  let result = 0;
+  for (let i = 0; i < bufA.length; i++) {
+    result |= bufA[i] ^ bufB[i];
+  }
+  return result === 0;
+}
+
+export interface OAuthStatePayload {
+  authCellId: string;
+  integrationPieceId: string;
+  /** Random nonce used to look up the code verifier from server-side storage. */
+  codeVerifierNonce: string;
+  scopes?: string[];
+  /** Unix epoch ms when the state was created. */
+  timestamp: number;
+}
+
+/**
+ * Creates a signed OAuth state parameter.
+ *
+ * The code verifier is stored server-side keyed by a random nonce. The state
+ * payload is HMAC-SHA256 signed so it cannot be forged or tampered with.
+ *
+ * Returns a base64-encoded JSON string of `{ payload, signature }`.
+ */
+export async function createSignedState(params: {
+  authCellId: string;
+  integrationPieceId: string;
+  codeVerifier: string;
+  scopes?: string[];
+}): Promise<string> {
+  // Generate a random nonce for server-side code verifier storage
+  const nonce = crypto.randomUUID();
+
+  // Store code verifier server-side, keyed by nonce
+  codeVerifiers.set(nonce, {
+    codeVerifier: params.codeVerifier,
+    createdAt: Date.now(),
+  });
+
+  // Prune expired entries on every create to prevent unbounded growth
+  pruneExpiredCodeVerifiers();
+
+  const payload: OAuthStatePayload = {
+    authCellId: params.authCellId,
+    integrationPieceId: params.integrationPieceId,
+    codeVerifierNonce: nonce,
+    scopes: params.scopes,
+    timestamp: Date.now(),
+  };
+
+  const payloadJson = JSON.stringify(payload);
+  const key = await getHmacKey();
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(payloadJson),
+  );
+  const signature = bufToHex(sig);
+
+  return btoa(JSON.stringify({ payload, signature }));
+}
+
+/**
+ * Verifies and decodes a signed OAuth state parameter.
+ *
+ * Returns the payload and the server-side code verifier on success.
+ * Throws an error describing the failure on verification failure.
+ */
+export async function verifySignedState(state: string): Promise<{
+  payload: OAuthStatePayload;
+  codeVerifier: string;
+}> {
+  let parsed: { payload: OAuthStatePayload; signature: string };
+  try {
+    parsed = JSON.parse(atob(state));
+  } catch {
+    throw new Error("Invalid state parameter format");
+  }
+
+  if (!parsed.payload || !parsed.signature) {
+    throw new Error("Malformed state parameter: missing payload or signature");
+  }
+
+  // Verify HMAC signature
+  const key = await getHmacKey();
+  const payloadJson = JSON.stringify(parsed.payload);
+  const expectedSig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(payloadJson),
+  );
+  const expectedHex = bufToHex(expectedSig);
+
+  if (!timingSafeEqual(parsed.signature, expectedHex)) {
+    throw new Error("Invalid state parameter: signature verification failed");
+  }
+
+  // Check expiration
+  const age = Date.now() - parsed.payload.timestamp;
+  if (age > STATE_MAX_AGE_MS) {
+    throw new Error(
+      "OAuth state parameter has expired (older than 10 minutes)",
+    );
+  }
+
+  // Retrieve and consume the code verifier from server-side storage
+  const nonce = parsed.payload.codeVerifierNonce;
+  const stored = codeVerifiers.get(nonce);
+  if (!stored) {
+    throw new Error(
+      "Invalid state parameter: code verifier not found (may have expired or already been used)",
+    );
+  }
+  // Delete after retrieval so it cannot be reused
+  codeVerifiers.delete(nonce);
+
+  return {
+    payload: parsed.payload,
+    codeVerifier: stored.codeVerifier,
+  };
+}
+
+/** Remove expired entries from the code verifier store. */
+function pruneExpiredCodeVerifiers(): void {
+  const now = Date.now();
+  for (const [nonce, entry] of codeVerifiers) {
+    if (now - entry.createdAt > STATE_MAX_AGE_MS) {
+      codeVerifiers.delete(nonce);
+    }
+  }
+}
 
 // Type-safe response helpers for route handlers
 export function createLoginSuccessResponse(c: any, url: string) {


### PR DESCRIPTION
## Summary
- Fixes OAuth state parameter forgery by HMAC-signing the state payload
- Moves PKCE code verifier to server-side storage instead of embedding in client-visible state
- Adds 10-minute expiration to OAuth state parameters
- Uses timing-safe comparison for signature verification

Fixes CT-1288

## Test plan
- [ ] Verify Google OAuth login flow still works end-to-end
- [ ] Verify callback rejects tampered state parameters
- [ ] Verify callback rejects expired state parameters (>10 min)
- [ ] Verify PKCE code verifier is no longer visible in the state URL parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures the Google OAuth flow by HMAC-signing the state and moving the PKCE code verifier to server-side storage. Adds a 10-minute expiry and timing-safe checks to block forgery, replay, and PKCE bypass (CT-1288).

- **Bug Fixes**
  - HMAC-SHA256 signed state; rejects tampering.
  - PKCE code verifier stored server-side by random nonce and removed from URL; single-use retrieval on callback.
  - 10-minute state TTL with timing-safe signature check, plus auto-pruning of expired verifiers.

<sup>Written for commit db9c38de2c15594c23b15bc06bc25ec8bed3d55b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

