### PR TITLE
Removed rootSchema from schema-generator and a bunch of tests, since it's no longer used.

### DIFF
--- a/packages/runner/test/data-uri-inlining.test.ts
+++ b/packages/runner/test/data-uri-inlining.test.ts
@@ -222,7 +222,6 @@ describe("data URI inlining", () => {
             id: dataURI,
             path: [],
             schema: { type: "number" },
-            rootSchema: { type: "number" },
           },
         },
       };
@@ -244,7 +243,6 @@ describe("data URI inlining", () => {
             id: dataURI,
             path: ["nested"],
             schema: { type: "object" },
-            rootSchema: { type: "object" },
           },
         },
       };
@@ -448,22 +446,6 @@ describe("data URI inlining", () => {
             id: linkedCell.entityId["/"],
             path: [],
             schema: {
-              type: "object",
-              properties: {
-                level1: {
-                  type: "object",
-                  properties: {
-                    level2: {
-                      type: "object",
-                      properties: {
-                        level3: { type: "string" },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-            rootSchema: {
               type: "object",
               properties: {
                 level1: {

--- a/packages/runner/test/link-resolution.test.ts
+++ b/packages/runner/test/link-resolution.test.ts
@@ -267,14 +267,12 @@ describe("link-resolution", () => {
 
     it("should preserve schema when available", () => {
       // Use a simple schema without $ref
-      const rootSchema = {
+      const schema = {
         type: "object",
         properties: {
           name: { type: "string" },
         },
       } as const;
-
-      const schema = rootSchema;
 
       const targetCell = runtime.getCell<any>(
         space,
@@ -284,7 +282,7 @@ describe("link-resolution", () => {
       );
       targetCell.set({ name: "Test User" });
 
-      // Create a link with setRaw to preserve rootSchema
+      // Create a link with setRaw to preserve schema
       const sourceCell = runtime.getCell<any>(
         space,
         "rootschema-source",
@@ -302,7 +300,7 @@ describe("link-resolution", () => {
 
       const link = parseLink(sourceCell.get().link, sourceCell)!;
       const resolved = resolveLink(runtime, tx, link);
-      expect(resolved.schema).toEqual(rootSchema);
+      expect(resolved.schema).toEqual(schema);
     });
 
     it("should handle schema through multiple link hops", () => {

--- a/packages/runner/test/opaque-ref-schema.test.ts
+++ b/packages/runner/test/opaque-ref-schema.test.ts
@@ -326,7 +326,7 @@ describe("OpaqueRef Schema Support", () => {
   });
 
   describe("Schema $ref and $defs Resolution", () => {
-    it("should preserve rootSchema with $defs when navigating with key()", () => {
+    it("should preserve schema with $defs when navigating with key()", () => {
       // Schema with $defs that needs to be preserved for nested $ref resolution
       const schema = {
         $defs: {
@@ -366,7 +366,7 @@ describe("OpaqueRef Schema Support", () => {
       const userRef = ref.key("user");
       const userExport = userRef.export();
 
-      // The rootSchema should be preserved (contains $defs)
+      // The schema should be preserved (contains $defs)
       expect(userExport.schema).toBeDefined();
       expect((userExport.schema as any).$defs).toBeDefined();
       expect((userExport.schema as any).$defs.Address).toBeDefined();
@@ -375,7 +375,7 @@ describe("OpaqueRef Schema Support", () => {
       const homeRef = userRef.key("home");
       const homeExport = homeRef.export();
 
-      // The rootSchema should still be preserved at this level
+      // The schema should still be preserved at this level
       expect(homeExport.schema).toBeDefined();
       expect((homeExport.schema as any).$defs).toBeDefined();
       expect((homeExport.schema as any).$defs.Address).toBeDefined();

--- a/packages/runner/test/schema-ref-default.test.ts
+++ b/packages/runner/test/schema-ref-default.test.ts
@@ -142,7 +142,7 @@ describe("$ref with default support", () => {
 
   describe("anyOf/oneOf with default", () => {
     it("should preserve default in anyOf options with refs", () => {
-      const rootSchema: JSONSchema = {
+      const schema: JSONSchema = {
         $defs: {
           String: { type: "string" },
           Number: { type: "number" },
@@ -154,12 +154,12 @@ describe("$ref with default support", () => {
       } as const satisfies JSONSchema;
 
       const s1 = {
-        ...(rootSchema.anyOf![0] as JSONSchemaObj),
-        $defs: rootSchema.$defs,
+        ...(schema.anyOf![0] as JSONSchemaObj),
+        $defs: schema.$defs,
       };
       const s2 = {
-        ...(rootSchema.anyOf![1] as JSONSchemaObj),
-        $defs: rootSchema.$defs,
+        ...(schema.anyOf![1] as JSONSchemaObj),
+        $defs: schema.$defs,
       };
       // This would be used in validateAndTransform's anyOf handling
       const option1 = resolveSchema(s1, false);
@@ -169,17 +169,17 @@ describe("$ref with default support", () => {
       expect(option1).toEqual({
         type: "string",
         default: "string-default",
-        $defs: rootSchema.$defs,
+        $defs: schema.$defs,
       });
       expect(option2).toEqual({
         type: "number",
         default: 42,
-        $defs: rootSchema.$defs,
+        $defs: schema.$defs,
       });
     });
 
     it("should apply ref site default to anyOf union as a whole", () => {
-      const rootSchema: JSONSchema = {
+      const schema: JSONSchema = {
         $defs: {
           StringOrNumber: {
             anyOf: [
@@ -192,10 +192,10 @@ describe("$ref with default support", () => {
         default: "override",
       };
 
-      const resolved = resolveSchema(rootSchema, false);
+      const resolved = resolveSchema(schema, false);
 
       expect(resolved).toEqual({
-        $defs: rootSchema.$defs,
+        $defs: schema.$defs,
         anyOf: [
           { type: "string", default: "str" },
           { type: "number", default: 42 },
@@ -205,7 +205,7 @@ describe("$ref with default support", () => {
     });
 
     it("should preserve asCell and default together in anyOf options", () => {
-      const rootSchema: JSONSchema = {
+      const schema: JSONSchema = {
         $defs: {
           StringCell: { type: "string" },
         },
@@ -216,13 +216,13 @@ describe("$ref with default support", () => {
       };
 
       const option1 = resolveSchema({
-        ...(rootSchema.anyOf![0] as JSONSchemaObj),
-        $defs: rootSchema.$defs,
+        ...(schema.anyOf![0] as JSONSchemaObj),
+        $defs: schema.$defs,
       }, false);
 
       // Resolve schema doesn't remove $defs
       expect(option1).toEqual({
-        $defs: rootSchema.$defs,
+        $defs: schema.$defs,
         type: "string",
         default: "cell-default",
         asCell: true,
@@ -232,7 +232,7 @@ describe("$ref with default support", () => {
 
   describe("edge cases", () => {
     it("should handle default with value of different types (number)", () => {
-      const rootSchema: JSONSchema = {
+      const schema: JSONSchema = {
         $defs: {
           Number: { type: "number" },
         },
@@ -240,16 +240,16 @@ describe("$ref with default support", () => {
         default: 42,
       };
 
-      const resolved = resolveSchema(rootSchema, false);
+      const resolved = resolveSchema(schema, false);
       expect(resolved).toEqual({
-        $defs: rootSchema.$defs,
+        $defs: schema.$defs,
         type: "number",
         default: 42,
       });
     });
 
     it("should handle default with value of null", () => {
-      const rootSchema: JSONSchema = {
+      const schema: JSONSchema = {
         $defs: {
           Nullable: { type: ["string", "null"] },
         },
@@ -257,16 +257,16 @@ describe("$ref with default support", () => {
         default: null,
       };
 
-      const resolved = resolveSchema(rootSchema, false);
+      const resolved = resolveSchema(schema, false);
       expect(resolved).toEqual({
-        $defs: rootSchema.$defs,
+        $defs: schema.$defs,
         type: ["string", "null"],
         default: null,
       });
     });
 
     it("should handle default with array value", () => {
-      const rootSchema: JSONSchema = {
+      const schema: JSONSchema = {
         $defs: {
           StringArray: { type: "array", items: { type: "string" } },
         },
@@ -274,9 +274,9 @@ describe("$ref with default support", () => {
         default: ["item1", "item2"],
       };
 
-      const resolved = resolveSchema(rootSchema, false);
+      const resolved = resolveSchema(schema, false);
       expect(resolved).toEqual({
-        $defs: rootSchema.$defs,
+        $defs: schema.$defs,
         type: "array",
         items: { type: "string" },
         default: ["item1", "item2"],
@@ -284,7 +284,7 @@ describe("$ref with default support", () => {
     });
 
     it("should handle default with object value", () => {
-      const rootSchema: JSONSchema = {
+      const schema: JSONSchema = {
         $defs: {
           Person: {
             type: "object",
@@ -298,9 +298,9 @@ describe("$ref with default support", () => {
         default: { name: "John", age: 30 },
       };
 
-      const resolved = resolveSchema(rootSchema, false);
+      const resolved = resolveSchema(schema, false);
       expect(resolved).toEqual({
-        $defs: rootSchema.$defs,
+        $defs: schema.$defs,
         type: "object",
         properties: {
           name: { type: "string" },
@@ -311,7 +311,7 @@ describe("$ref with default support", () => {
     });
 
     it("should not filter default when filterAsCell is true (unlike asCell)", () => {
-      const rootSchema: JSONSchema = {
+      const schema: JSONSchema = {
         $defs: {
           CellString: {
             type: "string",
@@ -324,7 +324,7 @@ describe("$ref with default support", () => {
         asCell: true,
       };
 
-      const resolved = resolveSchema(rootSchema, true);
+      const resolved = resolveSchema(schema, true);
 
       // asCell should be filtered out, but default should remain
       expect(resolved).not.toHaveProperty("asCell");
@@ -332,7 +332,7 @@ describe("$ref with default support", () => {
     });
 
     it("should handle ref with both asCell, asStream, and default", () => {
-      const rootSchema: JSONSchema = {
+      const schema: JSONSchema = {
         $defs: {
           StreamCell: { type: "string" },
         },
@@ -342,10 +342,10 @@ describe("$ref with default support", () => {
         asStream: true,
       };
 
-      const resolved = resolveSchema(rootSchema, false);
+      const resolved = resolveSchema(schema, false);
 
       expect(resolved).toEqual({
-        $defs: rootSchema.$defs,
+        $defs: schema.$defs,
         type: "string",
         default: "ref-default",
         asCell: true,

--- a/packages/runner/test/selector-tracker.test.ts
+++ b/packages/runner/test/selector-tracker.test.ts
@@ -129,7 +129,7 @@ describe("SelectorTracker", () => {
       expect(existingSelector2).toEqual(standardInitialSelector);
     });
 
-    it("should ignore rootSchema mismatches when schema has no $ref", () => {
+    it("should ignore schema mismatches when schema has no $ref", () => {
       const address: BaseMemoryAddress = {
         "id": "of:baeddoc",
         type: "application/json",

--- a/packages/runner/test/storage.test.ts
+++ b/packages/runner/test/storage.test.ts
@@ -171,7 +171,7 @@ describe("Storage", () => {
       let synced = false;
       const selector = {
         path: [],
-        schemaContext: { schema: true, rootSchema: true },
+        schemaContext: { schema: true },
       };
       const testCellURI = testCell.getAsNormalizedFullLink().id;
       storageManager.open(space).sync(testCellURI, selector)

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -552,7 +552,7 @@ describe("SchemaObjectTraverser array traversal", () => {
       };
       const docASelector = {
         path: ["value", "foo"],
-        schemaContext: { schema: true, rootSchema: true },
+        schemaContext: { schema: true },
       };
       const [curDoc, _selector1] = getAtPath(
         tx,
@@ -683,7 +683,7 @@ describe("SchemaObjectTraverser array traversal", () => {
       };
       const docASelector = {
         path: ["value", "current"],
-        schemaContext: { schema: true, rootSchema: true },
+        schemaContext: { schema: true },
       };
       const [curDoc, _selector1] = getAtPath(
         tx,

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -124,26 +124,26 @@ export class SchemaGenerator implements ISchemaGenerator {
     };
 
     // Auto-detect: Should we use node-based or type-based analysis?
-    let rootSchema: SchemaDefinition;
+    let schema: SchemaDefinition;
     if (this.shouldUseNodeBasedAnalysis(type, typeNode, checker)) {
       // Use node-based analysis (for synthetic nodes or when type is unreliable)
-      rootSchema = this.analyzeTypeNodeStructure(
+      schema = this.analyzeTypeNodeStructure(
         typeNode!,
         checker,
         context,
       );
       // Build final schema with $schema and $defs
-      return this.buildFinalSchemaForSynthetic(rootSchema, context);
+      return this.buildFinalSchemaForSynthetic(schema, context);
     }
 
     // Use type-based analysis (normal path)
-    rootSchema = this.formatType(type, context, true);
+    schema = this.formatType(type, context, true);
 
     // Attach root-level description from JSDoc if available
-    rootSchema = this.attachRootDescription(rootSchema, type, context);
+    schema = this.attachRootDescription(schema, type, context);
 
     // Build final schema with definitions if needed
-    return this.buildFinalSchema(rootSchema, type, context, typeNode);
+    return this.buildFinalSchema(schema, type, context, typeNode);
   }
 
   /**
@@ -410,7 +410,7 @@ export class SchemaGenerator implements ISchemaGenerator {
    * Build the final schema with definitions if needed
    */
   private buildFinalSchema(
-    rootSchema: SchemaDefinition,
+    schema: SchemaDefinition,
     type: ts.Type,
     context: GenerationContext,
     _typeNode?: ts.TypeNode,
@@ -419,7 +419,7 @@ export class SchemaGenerator implements ISchemaGenerator {
 
     // If no definitions were created or used, return simple schema without $schema
     if (Object.keys(definitions).length === 0 || emittedRefs.size === 0) {
-      return rootSchema;
+      return schema;
     }
 
     // Decide if we promote root to a $ref
@@ -431,11 +431,11 @@ export class SchemaGenerator implements ISchemaGenerator {
     if (shouldPromoteRoot && namedKey) {
       // Ensure root is present in definitions
       if (!definitions[namedKey]) {
-        definitions[namedKey] = rootSchema;
+        definitions[namedKey] = schema;
       }
       base = { $ref: `#/$defs/${namedKey}` } as SchemaDefinition;
     } else {
-      base = rootSchema;
+      base = schema;
     }
 
     // Handle boolean schemas (rare, but supported by JSON Schema)
@@ -739,25 +739,25 @@ export class SchemaGenerator implements ISchemaGenerator {
    * Build final schema for synthetic TypeNode with $schema and $defs
    */
   private buildFinalSchemaForSynthetic(
-    rootSchema: SchemaDefinition,
+    schema: SchemaDefinition,
     context: GenerationContext,
   ): SchemaDefinition {
     const { definitions, emittedRefs } = context;
 
     // Handle boolean schemas (rare, but supported by JSON Schema)
-    if (typeof rootSchema === "boolean") {
-      return rootSchema;
+    if (typeof schema === "boolean") {
+      return schema;
     }
 
     // If no definitions were created or used, return simple schema
     if (Object.keys(definitions).length === 0 || emittedRefs.size === 0) {
-      return rootSchema;
+      return schema;
     }
 
     // Object schema: attach only the definitions actually referenced
-    const filtered = this.collectReferencedDefinitions(rootSchema, definitions);
+    const filtered = this.collectReferencedDefinitions(schema, definitions);
     const out: Record<string, unknown> = {
-      ...(rootSchema as Record<string, unknown>),
+      ...(schema as Record<string, unknown>),
     };
     if (Object.keys(filtered).length > 0) out.$defs = filtered;
     return out as SchemaDefinition;


### PR DESCRIPTION
No significant changes, but removed the rootSchema from tests and schema-generator.ts variable name to make things less confusing for agents.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unused rootSchema across the schema generator and tests to simplify schema handling. Everything now relies on schema only with no behavior changes.

- **Refactors**
  - Renamed internal variables from rootSchema to schema in schema-generator and adjusted final schema builders.
  - Removed rootSchema from selector schemaContext and link exports in tests; updated expectations to use schema.
  - Kept $defs preservation intact through $ref resolution, anyOf/oneOf, and link hops; tests updated accordingly.

<sup>Written for commit e0577e851cca8877af92413b8703de1c212db361. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

