### PR TITLE
fix(ios): add Symbol.dispose polyfill to web worker entry point

### DIFF
--- a/packages/runtime-client/backends/web-worker/index.ts
+++ b/packages/runtime-client/backends/web-worker/index.ts
@@ -5,6 +5,9 @@
  * Imports from `@commontools/runner` may be used freely in this directory.
  */
 
+import "core-js/proposals/explicit-resource-management";
+import "core-js/proposals/async-explicit-resource-management";
+
 import {
   IPCRemoteResponse,
   isIPCClientMessage,


### PR DESCRIPTION
## Summary
The web worker bundle was missing the core-js explicit resource management polyfill, causing Symbol.dispose to be undefined on iOS Safari. The main shell entry point had the polyfill, but since the worker is a separate esbuild entry point, it needs its own import.