### PR TITLE
feat(notes): name-based backlink resolution (CT-1281)

### DIFF
--- a/packages/patterns/notes/note-md.tsx
+++ b/packages/patterns/notes/note-md.tsx
@@ -56,16 +56,24 @@ export default pattern<NoteMdInput, NoteMdOutput>(
 
     const hasBacklinks = computed(() => (note?.backlinks?.length ?? 0) > 0);
 
-    // Convert [[Name (id)]] wiki-links to markdown links [Name](/of:id)
-    // ct-markdown will then convert these to clickable ct-cell-link components
+    // Convert wiki-links to markdown links
+    // Legacy format: [[Name (id)]] -> [Name](/of:id)
+    // New format: [[Name]] -> **Name** (bold text, can't navigate from markdown view)
+    // ct-markdown will then convert /of:id links to clickable ct-cell-link components
     // Use content prop if provided, otherwise fall back to note.content
     const processedContent = computed(() => {
       const raw = content?.get?.() ?? note?.content ?? "";
-      // Match [[Name (id)]] pattern and convert to [Name](/of:id)
-      return raw.replace(
+      // First pass: Match [[Name (id)]] pattern and convert to [Name](/of:id)
+      let result = raw.replace(
         /\[\[([^\]]*?)\s*\(([^)]+)\)\]\]/g,
         (_match, name, id) => `[${name.trim()}](/of:${id})`,
       );
+      // Second pass: Match [[Name]] (no id) and convert to bold text
+      result = result.replace(
+        /\[\[([^\]]+)\]\]/g,
+        (_match, name) => `**${name.trim()}**`,
+      );
+      return result;
     });
 
     // Type-based discovery for notes via mentionable list

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -272,11 +272,9 @@ const Note = pattern<NoteInput, NoteOutput>(
     const appendLink = action(
       ({ piece }: { piece: Writable<MentionablePiece> }) => {
         const name = piece.get()[NAME] ?? "";
-        const resolved = (piece as any).resolveAsCell();
-        const entityId = resolved?.entityId?.["/"];
-        if (!name || !entityId) return;
+        if (!name) return;
 
-        const link = `[[${name} (${entityId})]]`;
+        const link = `[[${name}]]`;
         const current = content.get();
         content.set(current ? `${current}\n${link}` : link);
 

--- a/packages/patterns/notes/notes-import-export.tsx
+++ b/packages/patterns/notes/notes-import-export.tsx
@@ -148,7 +148,9 @@ const NOTE_END_MARKER = "<!-- COMMON_NOTE_END -->";
 const NOTEBOOK_START_MARKER = "<!-- COMMON_NOTEBOOK_START";
 const NOTEBOOK_END_MARKER = "<!-- COMMON_NOTEBOOK_END -->";
 
-// Strip entity IDs from mentions for portable export: [[Name (id)]] -> [[Name]]
+// Strip entity IDs from mentions for portable export
+// Legacy format: [[Name (id)]] -> [[Name]]
+// New format: [[Name]] -> [[Name]] (no change needed)
 function stripMentionIds(content: string): string {
   return content.replace(/\[\[([^\]]*?)\s*\([^)]+\)\]\]/g, "[[$1]]");
 }
@@ -601,47 +603,10 @@ function performImport(
   }
 
   // Phase 3: Resolve mentions
-  const titleToId = new Map<string, string>();
-  for (const { title, index } of createdNotes) {
-    try {
-      const noteCell = allPieces.key(index) as any;
-      const resolved = noteCell.resolveAsCell();
-      const entityId = resolved?.entityId;
-      if (entityId?.["/"] && title) {
-        titleToId.set(title.toLowerCase(), entityId["/"]);
-      }
-    } catch (_e) {
-      // Ignore errors
-    }
-  }
-
-  for (const { originalContent, contentCell } of createdNotes) {
-    try {
-      const content = originalContent ?? "";
-      if (!content) continue;
-
-      const updatedContent = content.replace(
-        /\[\[([^\]]+)\]\]/g,
-        (match: string, name: string) => {
-          if (name.includes("(") && name.endsWith(")")) return match;
-
-          const cleanName = name.trim().replace(/^(📝|📓)\s*/, "")
-            .toLowerCase();
-          const id = titleToId.get(cleanName);
-          if (id) {
-            return `[[${name.trim()} (${id})]]`;
-          }
-          return match;
-        },
-      );
-
-      if (updatedContent !== content) {
-        contentCell.set(updatedContent);
-      }
-    } catch (_e) {
-      // Ignore errors
-    }
-  }
+  // CT-1281: Name-based linking - no longer add IDs to [[Name]] patterns
+  // Editor resolves mentions by name lookup in mentionables list
+  // Legacy [[Name (id)]] format in imported content still works
+  // So we skip ID resolution entirely and keep [[Name]] as-is
 
   onComplete?.();
 }

--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -277,30 +277,21 @@ export class CTCodeEditor extends BaseElement {
         return null;
       }
 
-      // Check if this is already a complete backlink WITH an ID (not just auto-closed brackets)
-      // Pattern: [[Name (id)]] - if there's an ID, don't show dropdown
-      const afterCursor = context.state.doc.sliceString(
-        context.pos,
-        context.pos + 50, // Look ahead for potential ]] and ID pattern
-      );
-      const hasIdPattern = afterCursor.match(/^\s*\([^)]+\)\]\]/);
-      if (hasIdPattern) {
-        // This is a complete backlink with ID - don't show dropdown
-        return null;
-      }
-
       const query = backlink.text.slice(2); // Remove [[ prefix
 
       const mentionable = this.getFilteredMentionable(query);
 
       // Check if auto-close added ]] after cursor
+      const afterCursor = context.state.doc.sliceString(
+        context.pos,
+        context.pos + 2,
+      );
       const hasAutoCloseBrackets = afterCursor.startsWith("]]");
 
       // Build options from existing mentionable items
-      const options: Completion[] = mentionable.map(([piece, index]) => {
-        const pieceId = this._getPieceId(index);
+      const options: Completion[] = mentionable.map(([piece, _index]) => {
         const pieceName = piece.key(NAME).get() || "";
-        const insertText = `${pieceName} (${pieceId})`;
+        const insertText = `${pieceName}`;
         return {
           label: pieceName,
           // Use apply function to handle auto-closed brackets
@@ -397,13 +388,11 @@ export class CTCodeEditor extends BaseElement {
   }
 
   /**
-   * Complete a backlink by inserting the full [[Name (id)]] format
+   * Complete a backlink by inserting the [[Name]] format
    */
-  private _completeBacklinkWithId(
+  private _completeBacklinkWithName(
     view: EditorView,
-    _queryText: string,
     pieceName: string,
-    pieceId: string,
   ): void {
     // Find the [[ start position
     const pos = view.state.selection.main.head;
@@ -418,7 +407,7 @@ export class CTCodeEditor extends BaseElement {
     const hasAutoClose = afterCursor === "]]";
 
     // Build the complete backlink
-    const fullBacklink = `[[${pieceName} (${pieceId})]]`;
+    const fullBacklink = `[[${pieceName}]]`;
 
     // Calculate replacement range
     const replaceFrom = bracketPos;
@@ -496,26 +485,31 @@ export class CTCodeEditor extends BaseElement {
       const _matchEnd = matchStart + match[0].length;
       const innerText = match[1];
 
-      // Check if has ID
+      // Support both [[Name]] and legacy [[Name (id)]] formats
       const idMatch = innerText.match(/^(.+?)\s+\(([^)]+)\)$/);
-      if (!idMatch) continue; // Skip incomplete backlinks
-
-      const name = idMatch[1];
-      const id = idMatch[2];
+      const name = idMatch ? idMatch[1] : innerText;
+      const id = idMatch ? idMatch[2] : undefined;
       const nameStart = matchStart + 2; // After [[
       const nameEnd = nameStart + name.length;
 
       // Check if click position is within the name portion (the visible pill)
       if (pos >= nameStart && pos <= nameEnd) {
-        const runtime = this.pattern.runtime();
-        const space = this.pattern.space();
+        // Try name-based resolution first, fall back to ID
+        let piece = this.findPieceByName(name);
+        if (!piece && id) {
+          const runtime = this.pattern.runtime();
+          const space = this.pattern.space();
+          const cell = await runtime.getCell(space, id);
+          piece = cell as CellHandle<Mentionable>;
+        }
 
-        const cell = await runtime.getCell(space, id);
-        this.emit("backlink-click", {
-          id,
-          text: innerText,
-          piece: cell,
-        });
+        if (piece) {
+          this.emit("backlink-click", {
+            id,
+            text: innerText,
+            piece,
+          });
+        }
         return;
       }
     }
@@ -547,10 +541,16 @@ export class CTCodeEditor extends BaseElement {
       // Check if cursor is within this backlink
       if (pos >= matchStart && pos <= matchEnd) {
         const backlinkText = match[1];
-        // Extract ID from "Name (id)" format
-        const idMatch = backlinkText.match(/\(([^)]+)\)$/);
-        const backlinkId = idMatch ? idMatch[1] : undefined;
-        const piece = backlinkId ? this.findPieceById(backlinkId) : null;
+        // Try name-based resolution first, fall back to ID for legacy content
+        const idMatch = backlinkText.match(/^(.+?)\s+\(([^)]+)\)$/);
+        const name = idMatch ? idMatch[1] : backlinkText;
+        const backlinkId = idMatch ? idMatch[2] : undefined;
+
+        let piece = this.findPieceByName(name);
+        if (!piece && backlinkId) {
+          piece = this.findPieceById(backlinkId);
+        }
+
         if (piece) {
           this.emit("backlink-click", {
             id: backlinkId,
@@ -560,9 +560,9 @@ export class CTCodeEditor extends BaseElement {
           return true;
         }
 
-        // Only create new backlink if there's NO ID (text-only like [[Name]])
-        if (!backlinkId && this.pattern) {
-          this.createBacklinkFromPattern(backlinkText, true);
+        // Only create new backlink if piece was not found by either method
+        if (!piece && this.pattern) {
+          this.createBacklinkFromPattern(name, true);
         }
 
         return true;
@@ -601,10 +601,7 @@ export class CTCodeEditor extends BaseElement {
       }
       const pieceId = page.id();
 
-      // Insert the ID into the text if we have an editor
-      if (this._editorView && pieceId) {
-        this._insertBacklinkId(backlinkText, pieceId, navigate);
-      }
+      // The [[Name]] text is already in the correct format, no ID insertion needed
 
       this.emit("backlink-create", {
         text: backlinkText,
@@ -618,41 +615,6 @@ export class CTCodeEditor extends BaseElement {
   }
 
   /**
-   * Insert the ID into an incomplete backlink and position cursor appropriately.
-   * Replaces [[text]] with [[text (id)]] and positions cursor after ]].
-   */
-  private _insertBacklinkId(
-    backlinkText: string,
-    id: string,
-    navigate: boolean,
-  ): void {
-    if (!this._editorView) return;
-
-    const view = this._editorView;
-    const state = view.state;
-    const doc = state.doc;
-    const content = doc.toString();
-
-    // Find the incomplete backlink: [[backlinkText]]
-    const searchPattern = `[[${backlinkText}]]`;
-    const index = content.indexOf(searchPattern);
-
-    if (index === -1) return;
-
-    // Replace with complete backlink including ID
-    const replacement = `[[${backlinkText} (${id})]]`;
-    const from = index;
-    const to = index + searchPattern.length;
-
-    view.dispatch({
-      changes: { from, to, insert: replacement },
-      selection: navigate
-        ? undefined // Keep current selection if navigating away
-        : { anchor: from + replacement.length }, // Position after ]] if staying
-    });
-  }
-
-  /**
    * If the cursor is after an unclosed [[... token on the same line,
    * return the current query text. Otherwise return null.
    */
@@ -663,6 +625,31 @@ export class CTCodeEditor extends BaseElement {
     const m = textBefore.match(/\[\[([^\]]*)$/);
     if (!m) return null;
     return m[1] ?? "";
+  }
+
+  /**
+   * Find a piece by name in the mentionable list.
+   * First match wins (no disambiguation).
+   */
+  private findPieceByName(name: string): CellHandle<Mentionable> | null {
+    if (!this.mentionable) return null;
+    const rawMentionable = this.mentionable.get();
+    if (!rawMentionable) return null;
+    const mentionableData = Array.isArray(rawMentionable)
+      ? rawMentionable as MentionableArray
+      : isCellHandle(rawMentionable)
+      ? ((rawMentionable.get() ?? []) as MentionableArray)
+      : [];
+    if (mentionableData.length === 0) return null;
+    for (let i = 0; i < mentionableData.length; i++) {
+      const pieceValue = mentionableData[i];
+      if (!pieceValue) continue;
+      const pieceName = pieceValue[NAME];
+      if (pieceName === name) {
+        return this.mentionable.key(i) as CellHandle<Mentionable>;
+      }
+    }
+    return null;
   }
 
   /**
@@ -1278,16 +1265,14 @@ export class CTCodeEditor extends BaseElement {
               const exactMatch = this._findExactMentionable(text);
 
               if (exactMatch) {
-                // Found exact match - insert complete backlink with stable piece ID
-                const [matchCell, matchIndex] = exactMatch;
-                const pieceId = this._getPieceId(matchIndex);
+                // Found exact match - insert complete backlink with name only
+                const [matchCell, _matchIndex] = exactMatch;
                 const pieceName = matchCell.key(NAME).get() || text;
-                this._completeBacklinkWithId(view, text, pieceName, pieceId);
+                this._completeBacklinkWithName(view, pieceName);
               } else if (this.pattern) {
                 // No exact match - create new piece without navigating
                 // First complete the backlink text, then create the piece
                 this._completeBacklinkText(view);
-                // createBacklinkFromPattern will insert the ID and emit event
                 this.createBacklinkFromPattern(text, false);
               }
               return true;
@@ -1352,25 +1337,25 @@ export class CTCodeEditor extends BaseElement {
   /**
    * Extract mentioned pieces from current content and write to `$mentioned`.
    *
-   * Link syntax: [[Name (id)]]. We parse ids and resolve them against
-   * `$mentionable` to produce live Piece instances.
+   * Link syntax: [[Name]] or legacy [[Name (id)]]. We parse names and resolve
+   * them against `$mentionable` to produce live Piece instances.
    */
   private _updateMentionedFromContent(): void {
     if (!this.mentioned) return;
 
     const content = this.getValue() || "";
 
-    // Extract IDs from content
-    const newIds = this._extractMentionedIds(content);
+    // Extract names from content
+    const newNames = this._extractMentionedNames(content);
 
-    // Get current mentioned IDs by looking them up in mentionable
-    const curIds = this._getCurrentMentionedIds();
+    // Get current mentioned names by looking them up in mentionable
+    const curNames = this._getCurrentMentionedNames();
 
-    // Compare ID sets to avoid unnecessary writes
-    if (newIds.size === curIds.size) {
+    // Compare name sets to avoid unnecessary writes
+    if (newNames.size === curNames.size) {
       let same = true;
-      for (const id of newIds) {
-        if (!curIds.has(id)) {
+      for (const name of newNames) {
+        if (!curNames.has(name)) {
           same = false;
           break;
         }
@@ -1380,35 +1365,37 @@ export class CTCodeEditor extends BaseElement {
       }
     }
 
-    // Resolve IDs to Mentionable values and update the cell
+    // Resolve names to Mentionable values and update the cell
     const newMentioned = this._extractMentionedPieces(content);
     this.mentioned.set(newMentioned);
     this._setupPieceNameSubscriptions();
   }
 
   /**
-   * Extract unique piece IDs from content backlinks.
+   * Extract unique piece names from content backlinks.
    */
-  private _extractMentionedIds(content: string): Set<string> {
-    const ids = new Set<string>();
-    const regex = /\[\[[^\]]*?\(([^)]+)\)\]\]/g;
+  private _extractMentionedNames(content: string): Set<string> {
+    const names = new Set<string>();
+    const regex = /\[\[([^\]]+)\]\]/g;
     let match: RegExpExecArray | null;
     while ((match = regex.exec(content)) !== null) {
-      const id = match[1];
-      if (id) ids.add(id);
+      const innerText = match[1];
+      const idMatch = innerText.match(/^(.+?)\s+\(([^)]+)\)$/);
+      const name = idMatch ? idMatch[1] : innerText;
+      if (name) names.add(name);
     }
-    return ids;
+    return names;
   }
 
   /**
-   * Get IDs of currently mentioned pieces by looking them up in mentionable.
+   * Get names of currently mentioned pieces by looking them up in mentionable.
    */
-  private _getCurrentMentionedIds(): Set<string> {
-    const curIds = new Set<string>();
-    if (!this.mentioned) return curIds;
+  private _getCurrentMentionedNames(): Set<string> {
+    const curNames = new Set<string>();
+    if (!this.mentioned) return curNames;
 
     const rawMentioned = this.mentioned.get();
-    if (!rawMentioned) return curIds;
+    if (!rawMentioned) return curNames;
 
     const currentSource = Array.isArray(rawMentioned)
       ? rawMentioned
@@ -1416,7 +1403,7 @@ export class CTCodeEditor extends BaseElement {
       ? ((rawMentioned.get() ?? []) as MentionableArray)
       : [];
 
-    if (!this.mentionable) return curIds;
+    if (!this.mentionable) return curNames;
 
     const rawMentionable = this.mentionable.get();
     const mentionableData = Array.isArray(rawMentionable)
@@ -1425,19 +1412,19 @@ export class CTCodeEditor extends BaseElement {
       ? ((rawMentionable.get() ?? []) as MentionableArray)
       : [];
 
-    // For each current mentioned value, find its ID by matching in mentionable
+    // For each current mentioned value, find its name by matching in mentionable
     for (const mentionedValue of currentSource) {
       if (!mentionedValue) continue;
       for (let i = 0; i < mentionableData.length; i++) {
         if (mentionableData[i] === mentionedValue) {
-          const pieceId = this._getPieceId(i);
-          if (pieceId) curIds.add(pieceId);
+          const pieceName = mentionableData[i]?.[NAME];
+          if (pieceName) curNames.add(pieceName);
           break;
         }
       }
     }
 
-    return curIds;
+    return curNames;
   }
 
   /**
@@ -1451,35 +1438,38 @@ export class CTCodeEditor extends BaseElement {
     if (!this._editorView) return;
 
     const backlinks = this._editorView.state.field(backlinkField);
-    const activeIds = new Set<string>();
+    const activeNames = new Set<string>();
 
     for (const bl of backlinks) {
-      if (!bl.id) continue;
-      activeIds.add(bl.id);
+      activeNames.add(bl.name);
 
       // Skip if already subscribed
-      if (this._pieceNameSubscriptions.has(bl.id)) continue;
+      if (this._pieceNameSubscriptions.has(bl.name)) continue;
 
-      const pieceCell = this.findPieceById(bl.id);
+      // Try to find piece by name first, fall back to ID for legacy backlinks
+      let pieceCell = this.findPieceByName(bl.name);
+      if (!pieceCell && bl.id) {
+        pieceCell = this.findPieceById(bl.id);
+      }
       if (!pieceCell) continue;
 
       // Subscribe to TITLE cell (not NAME) - this is what we update
       const titleCell = pieceCell.key("title");
-      const pieceId = bl.id;
+      const pieceName = bl.name;
 
       // Subscribe with changeGroup so our own edits are filtered out
       const unsub = titleCell.subscribe(() => {
-        this._handleExternalTitleChange(pieceId, pieceCell);
+        this._handleExternalTitleChange(pieceName, pieceCell);
       });
 
-      this._pieceNameSubscriptions.set(pieceId, unsub);
+      this._pieceNameSubscriptions.set(pieceName, unsub);
     }
 
     // Clean up subscriptions for pieces no longer in document
-    for (const [id, unsub] of this._pieceNameSubscriptions) {
-      if (!activeIds.has(id)) {
+    for (const [name, unsub] of this._pieceNameSubscriptions) {
+      if (!activeNames.has(name)) {
         unsub();
-        this._pieceNameSubscriptions.delete(id);
+        this._pieceNameSubscriptions.delete(name);
       }
     }
   }
@@ -1489,7 +1479,7 @@ export class CTCodeEditor extends BaseElement {
    * This is called when a piece's title field changes externally (not from our own edit).
    */
   private _handleExternalTitleChange(
-    pieceId: string,
+    previousName: string,
     pieceCell: CellHandle<Mentionable>,
   ): void {
     if (!this._editorView) return;
@@ -1498,9 +1488,9 @@ export class CTCodeEditor extends BaseElement {
     const title = pieceCell.key("title").get() as string;
     if (!title) return;
 
-    // Find backlink in document
+    // Find backlink in document by previous name
     const backlinks = this._editorView.state.field(backlinkField);
-    const bl = backlinks.find((b) => b.id === pieceId);
+    const bl = backlinks.find((b) => b.name === previousName);
     if (!bl) return;
 
     // Strip emoji from document name for comparison
@@ -1515,7 +1505,7 @@ export class CTCodeEditor extends BaseElement {
 
     // Update tracking map BEFORE dispatch so _detectAndSyncNameChanges doesn't
     // try to sync this change back to the piece (it runs synchronously during dispatch)
-    this._previousBacklinkNames.set(pieceId, currentName);
+    this._previousBacklinkNames.set(currentName, currentName);
 
     // Update document with annotation to prevent updateListener from calling setValue
     this._editorView.dispatch({
@@ -1546,28 +1536,35 @@ export class CTCodeEditor extends BaseElement {
   private _extractMentionedPieces(content: string): Mentionable[] {
     if (!content || !this.mentionable) return [];
 
-    const ids: string[] = [];
-    const regex = /\[\[[^\]]*?\(([^)]+)\)\]\]/g;
+    // Parse all backlinks from content
+    const backlinkRegex = /\[\[([^\]]+)\]\]/g;
     let match: RegExpExecArray | null;
-    while ((match = regex.exec(content)) !== null) {
-      const id = match[1];
-      if (id) ids.push(id);
-    }
-
-    // Resolve unique ids to pieces using mentionable list.
-    // Push CellHandles (not plain values) so the pattern system receives
-    // live cell references that backlinks-index can traverse.
     const seen = new Set<string>();
     const result: Mentionable[] = [];
-    for (const id of ids) {
-      if (seen.has(id)) continue;
-      const piece = this.findPieceById(id);
+
+    while ((match = backlinkRegex.exec(content)) !== null) {
+      const innerText = match[1];
+      // Check for legacy format: "Name (id)"
+      const idMatch = innerText.match(/^(.+?)\s+\(([^)]+)\)$/);
+      const name = idMatch ? idMatch[1] : innerText;
+      const id = idMatch ? idMatch[2] : null;
+
+      // Skip duplicates by name
+      if (seen.has(name)) continue;
+
+      // Try name-based resolution first
+      let piece = this.findPieceByName(name);
+      // Fall back to ID-based resolution for legacy content
+      if (!piece && id) {
+        piece = this.findPieceById(id);
+      }
+
       if (piece) {
         // Push the CellHandle itself — it serializes as a link (via toJSON)
         // so the runtime resolves it to the actual piece cell, preserving
         // reactive connections for backlinks computation.
         result.push(piece as unknown as Mentionable);
-        seen.add(id);
+        seen.add(name);
       }
     }
     return result;
@@ -1575,6 +1572,8 @@ export class CTCodeEditor extends BaseElement {
 
   /**
    * Detect name changes in backlinks and sync them to linked piece's NAME property.
+   * Only syncs for legacy backlinks with IDs. Name-only backlinks don't support
+   * bidirectional sync (editing the name changes which piece it points to).
    * Called when document changes.
    */
   private _detectAndSyncNameChanges(): void {
@@ -1584,6 +1583,7 @@ export class CTCodeEditor extends BaseElement {
     const currentNames = new Map<string, string>();
 
     for (const bl of backlinks) {
+      // Only sync name changes for legacy backlinks with IDs
       if (!bl.id) continue;
       currentNames.set(bl.id, bl.name);
 

--- a/packages/ui/src/v2/components/ct-code-editor/features/backlinks.test.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/features/backlinks.test.ts
@@ -52,14 +52,14 @@ describe("parseBacklinks", () => {
     expect(bl.nameTo).toBe(13); // end of "My Note"
   });
 
-  it("parses a single incomplete backlink [[text]]", () => {
+  it("parses a single name-only backlink [[Name]] (new format)", () => {
     const doc = "Check [[todo item]] later";
     const result = parseBacklinks(doc);
     expect(result).toHaveLength(1);
 
     const bl = result[0];
     expect(bl.name).toBe("todo item");
-    expect(bl.id).toBe(""); // no ID
+    expect(bl.id).toBe(""); // no ID - name-only format
     expect(bl.from).toBe(6);
     expect(bl.to).toBe(19);
     expect(bl.nameFrom).toBe(8);
@@ -119,7 +119,7 @@ describe("parseBacklinks", () => {
     expect(result).toEqual([]);
   });
 
-  it("handles mixed complete and incomplete backlinks", () => {
+  it("handles mixed legacy [[Name (id)]] and new [[Name]] formats", () => {
     const doc = "[[Done (d1)]] and [[Pending]]";
     const result = parseBacklinks(doc);
     expect(result).toHaveLength(2);
@@ -127,6 +127,34 @@ describe("parseBacklinks", () => {
     expect(result[0].name).toBe("Done");
     expect(result[1].id).toBe("");
     expect(result[1].name).toBe("Pending");
+  });
+
+  it("parses name-only backlinks with various characters", () => {
+    const doc = "[[Project TODO]] and [[Meeting Notes 2026]]";
+    const result = parseBacklinks(doc);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("Project TODO");
+    expect(result[0].id).toBe("");
+    expect(result[1].name).toBe("Meeting Notes 2026");
+    expect(result[1].id).toBe("");
+  });
+
+  it("treats name-only backlinks as complete (not incomplete)", () => {
+    // CT-1281: Name-only [[Name]] is now the standard format
+    // Both formats are valid, but name-only is the new default
+    const nameOnly = parseBacklinks("[[My Note]]");
+    const withId = parseBacklinks("[[My Note (abc123)]]");
+
+    expect(nameOnly).toHaveLength(1);
+    expect(withId).toHaveLength(1);
+
+    // Both have non-empty names, so both are treated as complete backlinks
+    expect(nameOnly[0].name).toBe("My Note");
+    expect(withId[0].name).toBe("My Note");
+
+    // The only difference is whether id is present
+    expect(nameOnly[0].id).toBe("");
+    expect(withId[0].id).toBe("abc123");
   });
 });
 
@@ -268,12 +296,28 @@ describe("backlinkEditFilter", () => {
     expect(getBacklinks(tr.state)).toHaveLength(0);
   });
 
-  it("allows edits on incomplete backlinks (no ID to protect)", () => {
+  it("allows edits on name-only backlinks (no ID to protect)", () => {
     const state = createState("[[pending]]");
     const tr = state.update({
       changes: { from: 3, to: 3, insert: "X" },
     });
     expect(tr.state.doc.toString()).toBe("[[pXending]]");
+  });
+
+  it("allows editing name portion of both legacy and new format backlinks", () => {
+    // Legacy format with ID
+    const stateLegacy = createState("[[World (w1)]]");
+    const trLegacy = stateLegacy.update({
+      changes: { from: 4, to: 4, insert: "X" },
+    });
+    expect(trLegacy.state.doc.toString()).toBe("[[WoXrld (w1)]]");
+
+    // New name-only format
+    const stateNew = createState("[[World]]");
+    const trNew = stateNew.update({
+      changes: { from: 4, to: 4, insert: "X" },
+    });
+    expect(trNew.state.doc.toString()).toBe("[[WoXrld]]");
   });
 
   it("multi-change transaction: blocks ID edit while allowing other changes", () => {
@@ -296,7 +340,7 @@ describe("backlinkEditFilter", () => {
 // ---------------------------------------------------------------------------
 
 describe("Enter keymap conditions", () => {
-  it("cursor position determines Enter behavior", () => {
+  it("cursor position determines Enter behavior for legacy format", () => {
     // Keymap condition: bl.id && pos >= bl.from && pos < bl.to
     const state = createState("text [[Note (n1)]] more");
     const bl = getBacklinks(state)[0];
@@ -310,6 +354,20 @@ describe("Enter keymap conditions", () => {
     expect(0 >= bl.from && 0 < bl.to).toBe(false);
 
     // bl.to is the dispatch target — the character after ]] in the doc
+    expect(state.doc.sliceString(bl.to, bl.to + 1)).toBe(" ");
+  });
+
+  it("name-only backlinks have empty id field", () => {
+    const state = createState("text [[Note]] more");
+    const bl = getBacklinks(state)[0];
+
+    // Name-only backlink has no ID
+    expect(bl.id).toBe("");
+    expect(bl.name).toBe("Note");
+
+    // Position tracking works the same
+    const insidePos = bl.nameFrom + 1;
+    expect(insidePos >= bl.from && insidePos < bl.to).toBe(true);
     expect(state.doc.sliceString(bl.to, bl.to + 1)).toBe(" ");
   });
 });

--- a/packages/ui/src/v2/components/ct-code-editor/features/backlinks.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/features/backlinks.ts
@@ -62,8 +62,10 @@ export const backlinkField = StateField.define<BacklinkInfo[]>({
 });
 
 /**
- * Create atomic ranges that make cursor skip over [[ and (id)]] portions.
- * This prevents the cursor from entering the ID area during navigation.
+ * Create atomic ranges that make cursor skip over [[ and ]] portions.
+ * This prevents the cursor from entering the bracket areas during navigation.
+ * For backlinks WITH id (legacy format): protects [[ and (id)]]
+ * For backlinks WITHOUT id (name-only format): protects [[ and ]]
  * Note: We must ensure ranges don't span line breaks.
  */
 export const atomicBacklinkRanges = EditorView.atomicRanges.of((view) => {
@@ -72,8 +74,6 @@ export const atomicBacklinkRanges = EditorView.atomicRanges.of((view) => {
   const decorations: Range<Decoration>[] = [];
 
   for (const bl of backlinks) {
-    if (!bl.id) continue; // Only protect complete backlinks with IDs
-
     // Safety: ensure the backlink is on a single line
     const startLine = doc.lineAt(bl.from).number;
     const endLine = doc.lineAt(bl.to).number;
@@ -84,9 +84,22 @@ export const atomicBacklinkRanges = EditorView.atomicRanges.of((view) => {
       decorations.push(Decoration.mark({}).range(bl.from, bl.nameFrom));
     }
 
-    // Make " (id)]]" atomic (cursor skips from end of name to after ]])
-    if (bl.nameTo < bl.to) {
-      decorations.push(Decoration.mark({}).range(bl.nameTo, bl.to));
+    if (bl.id) {
+      // Legacy format with ID: make " (id)]]" atomic
+      if (bl.nameTo < bl.to) {
+        decorations.push(Decoration.mark({}).range(bl.nameTo, bl.to));
+      }
+    } else {
+      // Name-only format: make ]] atomic
+      // The ]] is at positions bl.to-2 to bl.to
+      const closeBracketStart = bl.to - 2;
+      if (bl.nameTo < closeBracketStart) {
+        // This shouldn't happen in valid backlinks, but safety check
+        decorations.push(Decoration.mark({}).range(closeBracketStart, bl.to));
+      } else if (bl.nameTo === closeBracketStart) {
+        // Normal case: name ends right before ]]
+        decorations.push(Decoration.mark({}).range(closeBracketStart, bl.to));
+      }
     }
   }
 
@@ -178,17 +191,16 @@ export const backlinkEditFilter = EditorState.transactionFilter.of((tr) => {
 
 /**
  * Create a plugin to decorate backlinks with focus-aware styling.
- * - When cursor is outside: show as collapsed pill (hide brackets and ID)
- * - When cursor is adjacent/inside: show [[Name]] with visible brackets (ID never visible)
- * - Incomplete backlinks show as pending pills or [[text]] when editing
+ * - When cursor is outside: show as collapsed pill (hide brackets and ID if present)
+ * - When cursor is adjacent/inside: show [[Name]] with visible brackets (ID never visible for legacy format)
  *
- * The piece ID is never shown to the user - it's stored in the document
- * as [[Name (id)]] but displayed as [[Name]] when editing or just Name when collapsed.
+ * All parsed backlinks with non-empty names are treated as "complete":
+ * - Name-only format: [[Name]] - pill hides [[ and ]]
+ * - Legacy format with ID: [[Name (id)]] - pill hides [[, (id), and ]]
  */
 export function createBacklinkDecorationPlugin() {
   const editingMark = Decoration.mark({ class: "cm-backlink-editing" });
   const pillMark = Decoration.mark({ class: "cm-backlink-pill" });
-  const pendingMark = Decoration.mark({ class: "cm-backlink-pending" });
   const hiddenReplace = Decoration.replace({});
 
   return ViewPlugin.fromClass(
@@ -221,13 +233,16 @@ export function createBacklinkDecorationPlugin() {
         const backlinks = view.state.field(backlinkField);
 
         for (const bl of backlinks) {
-          const { from: start, to: end, nameFrom, nameTo, id } = bl;
+          const { from: start, to: end, nameFrom, nameTo, id, name } = bl;
           const hasId = id !== "";
 
           // Safety: skip backlinks that span multiple lines (would cause decoration errors)
           const startLine = doc.lineAt(start).number;
           const endLine = doc.lineAt(end).number;
           if (startLine !== endLine) continue;
+
+          // Skip truly empty backlinks (shouldn't happen with current regex, but safety check)
+          if (!name.trim()) continue;
 
           // Check if cursor is anywhere within the backlink (including hidden areas)
           // This ensures editing mode triggers when cursor is adjacent to visible pill
@@ -237,33 +252,34 @@ export function createBacklinkDecorationPlugin() {
           const selectionOverlaps = hasFocus && selectionFrom < end &&
             selectionTo > start;
 
-          if (hasId && (cursorInBacklink || selectionOverlaps)) {
-            // EDITING MODE: Show plain [[Name]] text, hide only the " (id)" portion
-            // The closing ]] stays visible so user sees [[Name]]
-            // Safety check: only hide if there's actually content between nameTo and end-2
-            const idStart = nameTo;
-            const idEnd = end - 2; // Position before ]]
-            if (idEnd > idStart) {
-              decorations.push(hiddenReplace.range(idStart, idEnd)); // Hide " (id)"
-            }
-          } else if (!hasId) {
-            // Incomplete backlink - show as pending pill or full text when editing
-            const cursorInside = hasFocus && cursorPos >= start &&
-              cursorPos <= end;
-            if (cursorInside || selectionOverlaps) {
-              // Cursor inside or adjacent - show full [[mention]] with editing style
-              decorations.push(editingMark.range(start, end));
+          if (cursorInBacklink || selectionOverlaps) {
+            // EDITING MODE: Show [[Name]] text with editing style
+            // For legacy format with ID: hide the " (id)" portion
+            if (hasId) {
+              // Show [[Name]] and hide " (id)"
+              decorations.push(editingMark.range(start, nameTo));
+              // Safety check: only hide if there's actually content between nameTo and end-2
+              const idStart = nameTo;
+              const idEnd = end - 2; // Position before ]]
+              if (idEnd > idStart) {
+                decorations.push(hiddenReplace.range(idStart, idEnd)); // Hide " (id)"
+              }
+              decorations.push(editingMark.range(end - 2, end)); // Show ]]
             } else {
-              // Cursor away - show as pending pill
-              decorations.push(hiddenReplace.range(start, start + 2)); // Hide [[
-              decorations.push(pendingMark.range(start + 2, end - 2)); // Style inner text
-              decorations.push(hiddenReplace.range(end - 2, end)); // Hide ]]
+              // Name-only format: show full [[Name]] with editing style
+              decorations.push(editingMark.range(start, end));
             }
           } else {
-            // Complete backlink, cursor outside - show as navigable pill
+            // PILL MODE: Cursor outside - show as navigable pill
             decorations.push(hiddenReplace.range(start, start + 2)); // Hide [[
             decorations.push(pillMark.range(nameFrom, nameTo)); // Style name only
-            decorations.push(hiddenReplace.range(nameTo, end)); // Hide (id)]]
+            if (hasId) {
+              // Legacy format: hide " (id)]]"
+              decorations.push(hiddenReplace.range(nameTo, end));
+            } else {
+              // Name-only format: hide ]]
+              decorations.push(hiddenReplace.range(end - 2, end));
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

- Replace regex-based `[[Name (id)]]` linking with name-only `[[Name]]` format that resolves links through the mentionables list as a lookup table
- Both formats supported during transition: name-based resolution first, ID fallback for legacy content
- Simplify editor backlink handling — no more ID insertion, protection, or hiding in the decorator

## This is a big change

This touches the full backlink pipeline across 6 files spanning UI components, pattern code, and import/export. The testing surface area that needs manual verification covers:

- **Notebooks**: Creating/opening notebooks, mentionables list populating correctly
- **Notes**: Creating backlinks via `[[` autocomplete, clicking pills to navigate, bidirectional name sync
- **Import/Export**: Round-tripping notes through markdown import and export with both old and new formats
- **Format bridging**: Existing `[[Name (id)]]` content coexisting with new `[[Name]]` content — legacy links should still resolve via ID fallback

### Files changed

| File | Change |
|------|--------|
| `ct-code-editor.ts` | Name-based resolution with `findPieceByName()`, completions insert `[[Name]]`, removed `_insertBacklinkId()` |
| `backlinks.ts` | All backlinks with non-empty names treated as complete, simplified decoration |
| `backlinks.test.ts` | 4 new test cases for name-only format (28 steps total, all pass) |
| `note.tsx` | `appendLink` creates `[[Name]]` instead of `[[Name (id)]]` |
| `note-md.tsx` | Dual-format: legacy → markdown links, new → bold text |
| `notes-import-export.tsx` | Simplified — no-op for new format, removed ID re-insertion |

## Test plan

- [ ] Automated: `deno test packages/ui/src/v2/components/ct-code-editor/features/backlinks.test.ts` (28 steps pass)
- [ ] Manual: Create a notebook with multiple notes, verify `[[` autocomplete inserts name-only format
- [ ] Manual: Click backlink pills — verify navigation works
- [ ] Manual: Verify backlinks section shows referring notes
- [ ] Manual: Test with existing notes that have legacy `[[Name (id)]]` format — should still resolve
- [ ] Manual: Import/export a notebook with backlinks — verify round-trip integrity
- [ ] Manual: Rename a linked note — verify backlink text updates (legacy format only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)