### PR TITLE
perf: pool-based parallelism for pattern tests

### DIFF
--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -166,7 +166,7 @@ async function runPatternTests(
             ...ctCmd,
             "test",
             "--timeout",
-            "20000",
+            "60000",
             "--root",
             patternsDir,
             testFile,


### PR DESCRIPTION
## Summary
- Replace fixed batch-of-5 with a pool that always keeps 5 pattern tests in flight
- Previously the slowest test in each batch gated the next batch from starting
- Now a new test starts immediately whenever any one finishes, keeping utilization at max

## Test plan
- [x] Run `deno task integration pattern-tests` and verify all tests still pass
- [x] Observe that tests stream results as they complete rather than in batch groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch pattern tests from fixed batches to a pool that always keeps 5 tests running and starts a new one as soon as any finishes, streaming results to cut idle time and total runtime. Set a 60s per-test timeout to prevent CI flakiness on slower cases.

<sup>Written for commit d4c1359e3d6d8132bbd2f117834c6f64e5b644f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

