### PR TITLE
Increase pattern test runner default timeout to 60s

### DIFF
--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -79,7 +79,7 @@ export async function runTestPattern(
   testPath: string,
   options: TestRunnerOptions = {},
 ): Promise<TestRunResult> {
-  const TIMEOUT = options.timeout ?? 5000;
+  const TIMEOUT = options.timeout ?? 60000;
   const startTime = performance.now();
 
   // 1. Create emulated runtime (same as piece step)


### PR DESCRIPTION
## Summary
- Increases the default timeout for pattern unit tests from 5s to 60s in the test runner
- Several tests (e.g. notebook) were known to need longer timeouts but relied on the 5s default

## Test plan
- [ ] Verify pattern tests pass with the new timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)