### PR TITLE
fix: replace empty-schema subscription hack with diagnostic, quiet noisy loggers

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -95,7 +95,7 @@ import { getLogger } from "@commontools/utils/logger";
 import { ensureNotRenderThread } from "@commontools/utils/env";
 ensureNotRenderThread();
 
-const logger = getLogger("cell");
+const logger = getLogger("cell", { level: "warn" });
 
 type SinkOptions = {
   changeGroup?: ChangeGroup;

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -64,7 +64,7 @@ import { isRawBuiltinResult, type RawBuiltinReturnType } from "./module.ts";
 import "./builtins/index.ts";
 import { isCellResult } from "./query-result-proxy.ts";
 
-const logger = getLogger("runner", { enabled: true, level: "info" });
+const logger = getLogger("runner", { enabled: true, level: "warn" });
 
 export class Runner {
   readonly cancels = new Map<`${MemorySpace}/${URI}`, Cancel>();

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -418,38 +418,20 @@ export class RuntimeProcessor {
     const cell = getCell(this.runtime, request.cell);
 
     const cancel = cell.sink((value) => {
-      // If the value is a CellResult proxy (from a cell with no/empty schema),
-      // convert it to a link immediately rather than walking into it.
-      // This prevents deep proxy traversal that can exceed
-      // MAX_RECURSION_DEPTH when VNode trees reference other pieces.
-      // Only apply this for cells without a meaningful schema — cells with
-      // schemas produce resolved plain objects from validateAndTransform.
-      // TODO(CT-1273): Once all pattern callsites produce real result schemas
-      // (CTS now errors on `any`/`unknown` inference), remove this guard and
-      // replace with a console.error — hitting this path would then indicate
-      // a bug rather than a known limitation.
+      // Log empty-schema subscriptions that produce CellResult proxies.
+      // These are the call sites that need real schemas added.
       const hasSchema = request.cell.schema &&
         typeof request.cell.schema === "object" &&
         Object.keys(request.cell.schema).length > 0;
       if (!hasSchema && isCellResult(value)) {
-        console.warn(
-          `[handleCellSubscribe] Cell subscription without schema produced ` +
-            `CellResult proxy — converting to link. This may indicate a ` +
-            `missing schema declaration. cell=${request.cell.id.slice(-20)} ` +
-            `path=${request.cell.path.join("/")}`,
+        console.error(
+          `[handleCellSubscribe] EMPTY SCHEMA SUBSCRIPTION producing ` +
+            `CellResult proxy. Add a schema to this subscription site!\n` +
+            `  cell: ${request.cell.id}\n` +
+            `  path: ${JSON.stringify(request.cell.path)}\n` +
+            `  space: ${request.cell.space}\n` +
+            `  schema: ${JSON.stringify(request.cell.schema)}`,
         );
-        const converted = getCellOrThrow(value).getAsLink({
-          includeSchema: true,
-          keepAsCell: true,
-        });
-        queueMicrotask(() =>
-          self.postMessage({
-            type: NotificationType.CellUpdate,
-            cell: request.cell,
-            value: converted,
-          })
-        );
-        return;
       }
       const converted = convertCellsToLinks(value, {
         includeSchema: true,


### PR DESCRIPTION
## Summary

- **Replace the CellResult-to-link hack** in `handleCellSubscribe` (runtime-processor.ts) with a `console.error` diagnostic. The hack (CT-1261/CT-1273) was converting CellResult proxy values to links when subscriptions had empty schemas, which prevented mentionables and other binding props from resolving correctly. Now the normal `convertCellsToLinks` path always runs, and empty-schema subscriptions are logged as errors to surface call sites that still need real schemas.

- **Set logger level to `"warn"`** for the `cell` and `runner` modules, suppressing high-volume `info`-level output in the console. This matches the existing convention in `traverse.ts` which already uses `level: "warn"`.

## Context

This was investigated alongside #2930 (Ben's mentionables fix) and #2899 (Berni's VDOM per-prop subscriptions). The hack was originally added to prevent deep proxy traversal when VNode trees had empty schemas, but it masked the real problem — sigil links stored without schema information causing `resolveLink()` to fall back to wrong VDOM schemas. With #2899 and #2930 now landed, the proper fix is in place and this hack can be replaced with a diagnostic.

## Test plan

- [x] Verified mentionables work correctly with #2899 + #2930 + this change
- [x] Console no longer spammed with `[INFO][cell::...]` and `[INFO][runner::...]` messages
- [x] Empty-schema subscription sites are logged as `console.error` for visibility


🤖 Generated with [Claude Code](https://claude.com/claude-code)