### PR TITLE
(fix/runner): sync linked cells inside data: URI cells

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -95,7 +95,7 @@ import { getLogger } from "@commontools/utils/logger";
 import { ensureNotRenderThread } from "@commontools/utils/env";
 ensureNotRenderThread();
 
-const logger = getLogger("cell");
+const logger = getLogger("cell", { level: "warn" });
 
 type SinkOptions = {
   changeGroup?: ChangeGroup;
@@ -1087,9 +1087,6 @@ export class CellImpl<T extends StorableValue>
   sync(): Promise<Cell<T>> | Cell<T> {
     this.synced = true;
     logger.info("sync", this.link);
-    if (this.link.id.startsWith("data:")) {
-      return this as unknown as Cell<T>;
-    }
     return this.runtime.storageManager.syncCell<T>(this as unknown as Cell<T>);
   }
 

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -38,7 +38,13 @@ import { isObject, isRecord } from "@commontools/utils/types";
 import type { JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import { deepEqual } from "@commontools/utils/deep-equal";
-import { BaseMemoryAddress, MapSet } from "../traverse.ts";
+import { BaseMemoryAddress, MapSet, stableStringify } from "../traverse.ts";
+import { getJSONFromDataURI } from "../uri-utils.ts";
+import {
+  isPrimitiveCellLink,
+  type NormalizedLink,
+  parseLinkPrimitive,
+} from "../link-types.ts";
 import type {
   Assert,
   Claim,
@@ -128,6 +134,10 @@ const logger = getLogger("storage.cache", {
   level: "error",
   logCountEvery: 0, // Disable auto-logging of counts
 });
+
+// Module-level cache: data URI + schema hash + path + space → Promise
+const DATA_URI_SYNC_CACHE_MAX = 10_000;
+const _dataURISyncCache = new Map<string, Promise<Cell<any>>>();
 
 interface NotFoundError extends Error {
   name: "NotFound";
@@ -2194,6 +2204,11 @@ export class StorageManager implements IStorageManager {
   ): Promise<Cell<T>> {
     const { space, id, schema } = cell.getAsNormalizedFullLink();
     if (!space) throw new Error("No space set");
+
+    if (id.startsWith("data:")) {
+      return this.syncDataURICell(cell, space, id, schema);
+    }
+
     const storageProvider = this.open(space);
 
     const selector = {
@@ -2203,6 +2218,131 @@ export class StorageManager implements IStorageManager {
 
     await storageProvider.sync(id, selector);
     return cell;
+  }
+
+  private syncDataURICell<T>(
+    cell: Cell<T>,
+    space: MemorySpace,
+    id: string,
+    schema: JSONSchema | undefined,
+  ): Promise<Cell<T>> {
+    // Build cache key: data URI + schema hash + path + space
+    const pathStr = JSON.stringify(cell.path);
+    const schemaStr = schema ? stableStringify(schema) : "";
+    const cacheKey = `${id}|${schemaStr}|${pathStr}|${space}`;
+
+    const existing = _dataURISyncCache.get(cacheKey);
+    if (existing) return existing as Promise<Cell<T>>;
+
+    const promise = this.syncDataURICellUncached(cell, space, id, schema);
+    if (_dataURISyncCache.size >= DATA_URI_SYNC_CACHE_MAX) {
+      _dataURISyncCache.clear();
+    }
+    _dataURISyncCache.set(cacheKey, promise);
+    return promise;
+  }
+
+  private async syncDataURICellUncached<T>(
+    cell: Cell<T>,
+    space: MemorySpace,
+    id: string,
+    schema: JSONSchema | undefined,
+  ): Promise<Cell<T>> {
+    // 1. Decode the data: URI
+    const json = getJSONFromDataURI(id);
+    if (!isRecord(json)) return cell;
+    let value = json["value"];
+
+    // 2. Walk the cell's path into the value
+    const path = [...cell.path.map(String)];
+    for (const segment of path) {
+      if (!isRecord(value) && !Array.isArray(value)) return cell;
+      value = (value as any)[segment];
+    }
+
+    // 3. Walk the resolved value, find links, sync them
+    //    Use a base link for resolving relative references (provides space)
+    const base: NormalizedLink = {
+      space,
+      id: id as any,
+      path: [],
+      type: "application/json",
+    };
+    const promises: Promise<any>[] = [];
+    const cfc = new ContextualFlowControl();
+
+    this.collectLinkedCellSyncs(value, base, schema, cfc, promises, new Set());
+
+    if (promises.length > 0) {
+      await Promise.all(promises);
+    }
+    return cell;
+  }
+
+  private collectLinkedCellSyncs(
+    value: any,
+    base: NormalizedLink,
+    schema: JSONSchema | undefined,
+    cfc: ContextualFlowControl,
+    promises: Promise<any>[],
+    seen: Set<any>,
+  ): void {
+    if (value === null || value === undefined || seen.has(value)) return;
+    if (typeof value !== "object") return;
+    seen.add(value);
+
+    if (isPrimitiveCellLink(value)) {
+      // Found a link — resolve it with base (for space) and sync
+      const link = parseLinkPrimitive(value, base);
+      if (link.id && !link.id.startsWith("data:")) {
+        const linkSchema = link.schema ?? schema;
+        const storageProvider = this.open(link.space ?? base.space!);
+        const selector = {
+          path: link.path.map(String),
+          schema: linkSchema ?? false,
+        };
+        const p = storageProvider.sync(link.id, selector);
+        promises.push(p);
+      }
+      return;
+    }
+
+    // Recurse into object/array
+    if (Array.isArray(value)) {
+      const itemSchema = schema && isObject(schema) && schema.items
+        ? schema.items as JSONSchema
+        : undefined;
+      for (const item of value) {
+        this.collectLinkedCellSyncs(
+          item,
+          base,
+          itemSchema,
+          cfc,
+          promises,
+          seen,
+        );
+      }
+    } else if (isRecord(value)) {
+      for (const key of Object.keys(value)) {
+        const child = value[key];
+        if (
+          child === null || child === undefined || typeof child !== "object"
+        ) {
+          continue;
+        }
+        const childSchema = schema
+          ? cfc.getSchemaAtPath(schema, [key])
+          : undefined;
+        this.collectLinkedCellSyncs(
+          child,
+          base,
+          childSchema,
+          cfc,
+          promises,
+          seen,
+        );
+      }
+    }
   }
 }
 

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -102,7 +102,7 @@ function internSet(
   cache.set(key, value);
 }
 
-function stableStringify(value: unknown): string {
+export function stableStringify(value: unknown): string {
   if (value === null) return "n";
   if (value === undefined) return "u";
   const t = typeof value;

--- a/packages/runner/test/data-uri-sync.test.ts
+++ b/packages/runner/test/data-uri-sync.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commontools/identity";
+import { StorageManager } from "@commontools/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createDataCellURI } from "../src/link-utils.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+describe("data URI sync", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("sync on a data: URI cell with no links resolves without error", async () => {
+    const dataURI = createDataCellURI({ simple: "value" });
+    const cell = runtime.getCellFromEntityId(
+      space,
+      dataURI,
+      [],
+      undefined,
+      tx,
+    );
+    const result = await cell.sync();
+    expect(result).toBeDefined();
+  });
+
+  it("sync on a data: URI cell containing a sigil link calls sync on the linked cell", async () => {
+    // Create a real cell that we expect to be synced
+    const linkedCell = runtime.getCell(space, "linked-target", undefined, tx);
+    linkedCell.set({ value: "target data" });
+    const linkedId = linkedCell.getAsNormalizedFullLink().id;
+
+    // Build a sigil link pointing at the real cell
+    const sigilLink = {
+      "/": {
+        [LINK_V1_TAG]: {
+          id: linkedId,
+          path: [],
+        },
+      },
+    };
+
+    // Create a data: URI whose value contains that link
+    const dataURI = createDataCellURI({ ref: sigilLink });
+    const dataCell = runtime.getCellFromEntityId(
+      space,
+      dataURI,
+      [],
+      undefined,
+      tx,
+    );
+
+    // Spy on the storage provider's sync method
+    const provider = storageManager.open(space);
+    const originalSync = provider.sync.bind(provider);
+    const syncedIds: string[] = [];
+    provider.sync = (id: any, selector?: any) => {
+      syncedIds.push(id);
+      return originalSync(id, selector);
+    };
+
+    await dataCell.sync();
+
+    // The linked cell's id should have been synced
+    expect(syncedIds).toContain(linkedId);
+  });
+
+  it("sync on a data: URI cell with multiple links syncs all of them", async () => {
+    const cell1 = runtime.getCell(space, "multi-1", undefined, tx);
+    cell1.set("first");
+    const cell2 = runtime.getCell(space, "multi-2", undefined, tx);
+    cell2.set("second");
+
+    const id1 = cell1.getAsNormalizedFullLink().id;
+    const id2 = cell2.getAsNormalizedFullLink().id;
+
+    const dataURI = createDataCellURI({
+      a: {
+        "/": {
+          [LINK_V1_TAG]: { id: id1, path: [] },
+        },
+      },
+      b: {
+        "/": {
+          [LINK_V1_TAG]: { id: id2, path: [] },
+        },
+      },
+    });
+
+    const dataCell = runtime.getCellFromEntityId(
+      space,
+      dataURI,
+      [],
+      undefined,
+      tx,
+    );
+
+    const provider = storageManager.open(space);
+    const originalSync = provider.sync.bind(provider);
+    const syncedIds: string[] = [];
+    provider.sync = (id: any, selector?: any) => {
+      syncedIds.push(id);
+      return originalSync(id, selector);
+    };
+
+    await dataCell.sync();
+
+    expect(syncedIds).toContain(id1);
+    expect(syncedIds).toContain(id2);
+  });
+
+  it("sync on a data: URI cell with links in arrays syncs them", async () => {
+    const cell1 = runtime.getCell(space, "arr-1", undefined, tx);
+    cell1.set("item1");
+    const cell2 = runtime.getCell(space, "arr-2", undefined, tx);
+    cell2.set("item2");
+
+    const id1 = cell1.getAsNormalizedFullLink().id;
+    const id2 = cell2.getAsNormalizedFullLink().id;
+
+    const dataURI = createDataCellURI([
+      { "/": { [LINK_V1_TAG]: { id: id1, path: [] } } },
+      { "/": { [LINK_V1_TAG]: { id: id2, path: [] } } },
+    ]);
+
+    const dataCell = runtime.getCellFromEntityId(
+      space,
+      dataURI,
+      [],
+      undefined,
+      tx,
+    );
+
+    const provider = storageManager.open(space);
+    const originalSync = provider.sync.bind(provider);
+    const syncedIds: string[] = [];
+    provider.sync = (id: any, selector?: any) => {
+      syncedIds.push(id);
+      return originalSync(id, selector);
+    };
+
+    await dataCell.sync();
+
+    expect(syncedIds).toContain(id1);
+    expect(syncedIds).toContain(id2);
+  });
+
+  it("sync on a data: URI cell with no links does not call provider.sync", async () => {
+    const dataURI = createDataCellURI({ plain: "data", count: 42 });
+    const dataCell = runtime.getCellFromEntityId(
+      space,
+      dataURI,
+      [],
+      undefined,
+      tx,
+    );
+
+    const provider = storageManager.open(space);
+    const originalSync = provider.sync.bind(provider);
+    const syncedIds: string[] = [];
+    provider.sync = (id: any, selector?: any) => {
+      syncedIds.push(id);
+      return originalSync(id, selector);
+    };
+
+    await dataCell.sync();
+
+    expect(syncedIds).toEqual([]);
+  });
+
+  it("sync uses cache — repeated calls share the same promise", async () => {
+    const linkedCell = runtime.getCell(space, "cache-target", undefined, tx);
+    linkedCell.set("cached");
+    const linkedId = linkedCell.getAsNormalizedFullLink().id;
+
+    const dataURI = createDataCellURI({
+      ref: { "/": { [LINK_V1_TAG]: { id: linkedId, path: [] } } },
+    });
+
+    const dataCell = runtime.getCellFromEntityId(
+      space,
+      dataURI,
+      [],
+      undefined,
+      tx,
+    );
+
+    const provider = storageManager.open(space);
+    const originalSync = provider.sync.bind(provider);
+    let syncCount = 0;
+    provider.sync = (id: any, selector?: any) => {
+      syncCount++;
+      return originalSync(id, selector);
+    };
+
+    // Call sync twice concurrently — the cache should deduplicate
+    const [r1, r2] = await Promise.all([dataCell.sync(), dataCell.sync()]);
+    expect(r1).toBeDefined();
+    expect(r2).toBeDefined();
+
+    // The linked cell should have been synced at most once
+    expect(syncCount).toBeLessThanOrEqual(1);
+  });
+
+  it("sync on a data: URI cell with nested data: URI links does not crash", async () => {
+    // A data URI containing another data URI link — the inner data: link
+    // should be skipped (not synced as a storage cell)
+    const innerDataURI = createDataCellURI("inner");
+    const dataURI = createDataCellURI({
+      nested: { "/": { [LINK_V1_TAG]: { id: innerDataURI, path: [] } } },
+    });
+
+    const dataCell = runtime.getCellFromEntityId(
+      space,
+      dataURI,
+      [],
+      undefined,
+      tx,
+    );
+
+    // Should resolve without throwing
+    const result = await dataCell.sync();
+    expect(result).toBeDefined();
+  });
+
+  it("sync walks into the cell path before scanning for links", async () => {
+    const linkedCell = runtime.getCell(space, "deep-target", undefined, tx);
+    linkedCell.set("deep");
+    const linkedId = linkedCell.getAsNormalizedFullLink().id;
+
+    // The link is nested under "level1" > "level2"
+    const dataURI = createDataCellURI({
+      level1: {
+        level2: {
+          ref: {
+            "/": { [LINK_V1_TAG]: { id: linkedId, path: [] } },
+          },
+        },
+      },
+    });
+
+    // Cell with path ["level1", "level2"] — sync should walk into the
+    // value at that path and find the link there
+    const dataCell = runtime.getCellFromEntityId(
+      space,
+      dataURI,
+      ["level1", "level2"],
+      undefined,
+      tx,
+    );
+
+    const provider = storageManager.open(space);
+    const originalSync = provider.sync.bind(provider);
+    const syncedIds: string[] = [];
+    provider.sync = (id: any, selector?: any) => {
+      syncedIds.push(id);
+      return originalSync(id, selector);
+    };
+
+    await dataCell.sync();
+
+    expect(syncedIds).toContain(linkedId);
+  });
+});


### PR DESCRIPTION
## Summary

- `Cell.sync()` previously short-circuited for `data:` URI cells, returning `this` without syncing. But data URIs can encode inline JSON containing sigil links to real storage cells that need to be synced from the network.
- Moves data: URI link-walking into `StorageManager.syncCell()` so linked cells are discovered and synced, with a promise cache to avoid redundant work on re-entrant calls.
- Adds 8 test cases covering: single/multiple/array links, cache deduplication, nested data URIs, path walking, and no-op for plain data.

## Test plan

- [x] All 183 existing runner tests pass
- [x] New `data-uri-sync.test.ts` tests pass (8 cases)
- [x] Manual verification with patterns using data: URI cells containing links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing sync for data: URI cells by decoding their JSON and syncing any linked storage cells. Also dedupes re-entrant syncs and reduces cell logger noise.

- **Bug Fixes**
  - Handle data: URIs in StorageManager.syncCell: walk the cell path, find sigil links, and sync their targets; skip nested data: URIs.
  - Add a promise cache keyed by data URI + schema + path + space to avoid duplicate syncs.
  - Remove the Cell.sync short-circuit for data: URIs, export stableStringify, add 8 tests (links, arrays, nested URIs, path walking, cache), and set the cell logger to warn.

<sup>Written for commit 4092e4b603a14e8fedd39f01f849f2d53d144539. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

