### PR TITLE
fix: resolve flaky note menu close test

### DIFF
--- a/packages/patterns/notes/note.test.tsx
+++ b/packages/patterns/notes/note.test.tsx
@@ -223,6 +223,10 @@ export default pattern(() => {
     () => note.menuOpen === false,
   );
 
+  const assert_menu_open_before_close = computed(
+    () => note.menuOpen === true,
+  );
+
   const assert_menu_closed_via_close = computed(
     () => note.menuOpen === false,
   );
@@ -308,6 +312,7 @@ export default pattern(() => {
       { action: action_toggle_menu_again },
       { assertion: assert_menu_closed_after_toggle },
       { action: action_toggle_menu_for_close },
+      { assertion: assert_menu_open_before_close },
       { action: action_close_menu },
       { assertion: assert_menu_closed_via_close },
 


### PR DESCRIPTION
## Summary
- Fixes flaky `assertion_24` failure in `packages/patterns/notes/note.test.tsx` (CI run 22636844871)
- Root cause: two consecutive actions (`toggleMenu` then `closeMenu`) could be batched by the reactive scheduler, causing out-of-order execution — `closeMenu` no-ops on the still-closed state, then `toggleMenu` opens it
- Adds a synchronization assertion (`assert_menu_open_before_close`) between the toggle and close actions, forcing the test runner to verify the menu opened before dispatching close

## Test plan
- [x] `deno task ct test packages/patterns/notes/note.test.tsx --verbose` passes locally (30/30 assertions)
- [x] CI Pattern Unit Tests job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)