### PR TITLE
Fix unresolved $ref warnings in anyOf branch matching

### DIFF
--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1946,7 +1946,7 @@ export class SchemaObjectTraverser<V extends StorableDatum>
           if (ContextualFlowControl.isFalseSchema(optionSchema)) {
             continue;
           }
-          if (!canBranchMatch(optionSchema, doc.value)) {
+          if (!canBranchMatch(optionSchema, doc.value, restSchema)) {
             this.anyOfFastRejects++;
             continue;
           }
@@ -2771,6 +2771,7 @@ function mergeSchemaOption(
 export function canBranchMatch(
   branch: JSONSchema,
   value: unknown,
+  outerSchema?: JSONSchemaObj,
 ): boolean {
   // Boolean schemas: true matches everything, false matches nothing
   if (!isObject(branch)) return branch !== false;
@@ -2785,10 +2786,17 @@ export function canBranchMatch(
     return true;
   }
 
-  // Resolve top-level $ref if present
+  // Resolve top-level $ref if present. When an outerSchema is provided (e.g.
+  // the restSchema from anyOf destructuring), merge first so that $defs are
+  // available for resolution. mergeSchemaOption is cached, so the later merge
+  // in the traversal loop will hit the cache.
   let resolved: JSONSchema | undefined = branch;
   if ("$ref" in branch) {
-    resolved = ContextualFlowControl.resolveSchemaRefs(branch);
+    const toResolve = outerSchema
+      ? mergeSchemaOption(outerSchema, branch)
+      : branch;
+    if (!isObject(toResolve)) return toResolve !== false;
+    resolved = ContextualFlowControl.resolveSchemaRefs(toResolve);
     if (resolved === undefined || !isObject(resolved)) return true;
   }
 


### PR DESCRIPTION
## Summary
- `canBranchMatch` was resolving `$ref` against the raw anyOf branch option, which lacks `$defs` (they live in the parent schema after destructuring). This produced noisy "Unresolved $ref in schema" warnings.
- Pass the outer `restSchema` into `canBranchMatch` and merge via `mergeSchemaOption` before resolving, so `$defs` are available for `$ref` resolution.
- `mergeSchemaOption` is keyed by `stableStringify` (which itself has a `WeakMap` identity cache), so the subsequent merge call in the traversal loop hits the cache — no duplicate work.

## Test plan
- [x] Existing `canBranchMatch` tests pass (signature is backwards-compatible via optional param)
- [x] Full runner test suite passes
- [ ] Verify "Unresolved $ref in schema" warnings are eliminated at runtime with schemas that use `$defs` + `anyOf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes “Unresolved $ref in schema” warnings when matching anyOf branches by merging the parent schema before resolving refs so $defs are available. Merge is cached, so no extra work.

- **Bug Fixes**
  - Pass restSchema into canBranchMatch and merge via mergeSchemaOption before resolving top-level $ref.
  - Keep canBranchMatch backward compatible with an optional outerSchema param.
  - Cached merge ensures the later traversal merge reuses the result.

<sup>Written for commit d23bb1889764e9653f4b834ea06f60d4eaa5b760. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

