### PR TITLE
Fix ct-prompt-input onct-send handler dropping

### DIFF
--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -3167,6 +3167,11 @@ interface CTPromptInputAttributes<T> extends CTHTMLAttributes<T> {
   "autoResize"?: boolean;
   "pending"?: boolean;
   "voice"?: boolean;
+  "onct-send"?: EventHandler<any>;
+  "onct-stop"?: EventHandler<any>;
+  "onct-input"?: EventHandler<any>;
+  "onct-attachment-add"?: EventHandler<any>;
+  "onct-attachment-remove"?: EventHandler<any>;
 }
 
 interface CTAttachmentsBarAttributes<T> extends CTHTMLAttributes<T> {

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -803,7 +803,8 @@ export class WorkerReconciler {
       }
 
       const props = resolvedProps as Record<string, unknown>;
-      const newKeys = new Set(Object.keys(props));
+      const allKeys = Object.keys(props);
+      const newKeys = new Set(allKeys);
 
       // Remove props that no longer exist
       for (const [key, propState] of state.propSubscriptions) {
@@ -854,9 +855,9 @@ export class WorkerReconciler {
           }
           if (existingState) existingState.cancel();
 
-          const handlerId = ctx.registerHandler((event: unknown) =>
-            resolvedTarget.send(event)
-          );
+          const handlerId = ctx.registerHandler((event: unknown) => {
+            resolvedTarget.send(event);
+          });
           state.eventHandlers.set(eventType, handlerId);
           this.queueOps([{
             op: "set-event",

--- a/packages/runner/src/schemas.ts
+++ b/packages/runner/src/schemas.ts
@@ -41,6 +41,10 @@ export const rendererVDOMSchema = {
             }, {
               type: "boolean",
             }, {
+              asCell: true,
+            }, {
+              asStream: true,
+            }, {
               type: "null",
             }, {
               type: "undefined",

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -2498,6 +2498,20 @@ export class SchemaObjectTraverser<V extends StorableDatum>
         const { ok: val, error } = this.traverseWithSchema(propDoc, propSchema);
         if (error === undefined) {
           filteredObj[propKey] = val;
+        } else if (propKey === "onct-send" || propKey.startsWith("onct-")) {
+          logger.info(
+            "traverse",
+            () => [
+              "Dropping event prop due to schema mismatch",
+              {
+                propKey,
+                valueType: typeof propValue,
+                isLink: isPrimitiveCellLink(propValue),
+                schema: propSchema,
+                error: error?.message,
+              },
+            ],
+          );
         }
       }
     }

--- a/packages/runner/test/vdom-schema-undefined.test.ts
+++ b/packages/runner/test/vdom-schema-undefined.test.ts
@@ -22,6 +22,23 @@ const anyOfIncludesUndefined = (schema: unknown): boolean => {
   return Array.isArray(anyOf) && anyOf.some((entry) => hasUndefinedType(entry));
 };
 
+const anyOfIncludesFlag = (
+  schema: unknown,
+  flag: "asCell" | "asStream",
+): boolean => {
+  if (!schema || typeof schema !== "object" || !("anyOf" in schema)) {
+    return false;
+  }
+  const anyOf = (schema as { anyOf: unknown[] }).anyOf;
+  return Array.isArray(anyOf) &&
+    anyOf.some((entry) =>
+      !!entry &&
+      typeof entry === "object" &&
+      flag in entry &&
+      (entry as Record<string, unknown>)[flag] === true
+    );
+};
+
 const getArrayVariant = (
   schema: unknown,
 ): Record<string, unknown> | undefined => {
@@ -137,6 +154,26 @@ Deno.test("debugVDOMSchema child arrays recurse through vdomRenderNode", () => {
     childItems.asCell,
     undefined,
     "debug children items should not include asCell",
+  );
+});
+
+Deno.test("rendererVDOMSchema props allow asCell/asStream", () => {
+  const defs = rendererVDOMSchema.$defs as Record<string, unknown>;
+  const vdomNode = defs.vdomNode as {
+    properties: Record<string, unknown>;
+  };
+  const propsSchema = vdomNode.properties.props as {
+    additionalProperties?: unknown;
+  };
+  const additional = propsSchema.additionalProperties;
+
+  assert(
+    anyOfIncludesFlag(additional, "asCell"),
+    "rendererVDOMSchema props should allow asCell values",
+  );
+  assert(
+    anyOfIncludesFlag(additional, "asStream"),
+    "rendererVDOMSchema props should allow asStream values",
   );
 });
 


### PR DESCRIPTION
## Summary
- allow asCell/asStream values in renderer VDOM props additionalProperties so event handler streams survive schema traversal
- add schema regression test and prompt-input event typings
- remove temporary DIAG logging in reconciler

## Why this works
The UI renderer builds props from a Cell<Props> filtered by rendererVDOMSchema. onct-send was a stream/link value, but the schema's additionalProperties anyOf did not permit asCell/asStream, so the prop was dropped before bindCellProps saw it. Allowing asCell/asStream keeps onct-send in resolved props, so bindCellProps resolves the stream and registers the handler as expected.

## Testing
- deno test packages/runner/test/vdom-schema-undefined.test.ts