### PR TITLE
fix(runner): add asStream to rendererVDOMSchema props

### DIFF
--- a/packages/runner/src/schemas.ts
+++ b/packages/runner/src/schemas.ts
@@ -52,6 +52,7 @@ export const rendererVDOMSchema = {
               items: { type: "null" }, // stop query from descending
             }, {
               asStream: true,
+              type: "unknown",
             }],
           },
           asCell: true,


### PR DESCRIPTION
## Summary
- Adds `{ asStream: true }` to `rendererVDOMSchema`'s props `additionalProperties` anyOf
- Without this, the traverser drops Stream-valued props (event handlers like `onct-send`) during `Cell<Props>` resolution, breaking all `handler()` bindings on VDOM elements
- The `vnodeSchema` already had this branch — this aligns `rendererVDOMSchema` to match
- Regression introduced by b7b4199a7 which moved `asCell` from `additionalProperties` to the props field level but didn't add `asStream`

## Test plan
- [x] Verify chatbot pattern's `ct-prompt-input` `onct-send` handler fires when sending a message
- [x] Verify do-list pattern's `ct-message-input` `onct-send` handler still works
- [x] Runner tests pass (196 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped event handler streams in Runner by adding asStream support (with type: unknown) to rendererVDOMSchema props. Restores onct-send and other handler() bindings on VDOM elements like ct-prompt-input.

- **Bug Fixes**
  - Added { asStream: true, type: "unknown" } to rendererVDOMSchema props additionalProperties anyOf so Stream-valued props survive Cell<Props> resolution.
  - Aligned rendererVDOMSchema with vnodeSchema to restore onct-send for ct-prompt-input and ct-message-input.

<sup>Written for commit 399c5d993fd0abaeb8f1667d2c1d5b1ed2b42b22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

