### PR TITLE
Add docs for addPiece handler pattern, deprecate direct allPieces.push()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ If you are developing patterns, use Claude Skills (pattern-dev) to do the work.
   troubleshooting
 - `docs/common/capabilities/llm.md` - Using generateText and generateObject for
   LLM integration
+- `docs/common/conventions/adding-pieces.md` - How to add pieces (use addPiece
+  handler, not allPieces.push)
 
 **Reference:**
 

--- a/docs/common/conventions/adding-pieces.md
+++ b/docs/common/conventions/adding-pieces.md
@@ -1,0 +1,175 @@
+# Adding Pieces
+
+To add a new piece to the space's piece list, use the `addPiece` handler
+exported by the default app pattern. **Never** push to `allPieces` directly.
+
+## Why
+
+- **Type safety** — no `as any` casts needed
+- **Deduplication** — `addPiece` checks for duplicates before adding
+- **Transaction semantics** — proper commit/retry via the handler system
+- **Encapsulation** — patterns don't depend on the internal shape of the default
+  app's state
+
+## Usage in an `action()`
+
+The most common case — creating a piece in response to a user interaction:
+
+```tsx
+import { action, pattern, wish, Stream, UI } from "commontools";
+import { MentionablePiece } from "@commontools/piece";
+
+// Wish for the addPiece handler at pattern body level
+const defaultApp = wish<{ addPiece: Stream<{ piece: MentionablePiece }> }>({
+  query: "#default",
+});
+
+const createNote = action(() => {
+  const note = Note({ title: "New Note", content: "", noteId: generateId() });
+  defaultApp.result.addPiece.send({ piece: note });
+  return navigateTo(note);
+});
+
+return {
+  [UI]: <ct-button onClick={createNote}>New Note</ct-button>,
+};
+```
+
+## Usage in a `handler()`
+
+When you need reusable logic that can be bound to different state:
+
+```tsx
+import { handler, Stream } from "commontools";
+import { MentionablePiece } from "@commontools/piece";
+
+// Define at module scope
+const createNoteHandler = handler<
+  { title: string; content: string },
+  { addPiece: Stream<{ piece: MentionablePiece }> }
+>(({ title, content }, { addPiece }) => {
+  const note = Note({ title, content, noteId: generateId() });
+  addPiece.send({ piece: note });
+  return note;
+});
+
+// Inside pattern body — bind with the wished stream
+const defaultApp = wish<{ addPiece: Stream<{ piece: MentionablePiece }> }>({
+  query: "#default",
+});
+
+return {
+  createNote: createNoteHandler({ addPiece: defaultApp.result.addPiece }),
+};
+```
+
+## Anti-patterns
+
+### Direct mutation
+
+```tsx
+// BAD — direct mutation, no deduplication
+const { allPieces } =
+  wish<{ allPieces: Writable<NotePiece[]> }>({ query: "#default" }).result;
+allPieces.push(newNote);
+```
+
+### Type hack
+
+```tsx
+// WORSE — hides type errors behind `as any`
+allPieces.push(note as any);
+(allPieces as any).push(note);
+```
+
+### Wishing for `allPieces` as Writable
+
+```tsx
+// BAD — exposes internal implementation of default-app
+wish<{ allPieces: Writable<MinimalPiece[]> }>({ query: "#default" });
+```
+
+Instead, wish only for the `addPiece` stream:
+
+```tsx
+// GOOD — depends on the handler contract, not internal state
+wish<{ addPiece: Stream<{ piece: MentionablePiece }> }>({
+  query: "#default",
+});
+```
+
+## Migration examples
+
+### From action with `allPieces.push()`
+
+Before:
+
+```tsx
+const { allPieces } =
+  wish<{ allPieces: Writable<MinimalPiece[]> }>({ query: "#default" }).result;
+
+const createNewNote = action(() => {
+  const note = Note({ title: "New Note", content: "", noteId: generateId() });
+  allPieces.push(note as any);
+  return navigateTo(note);
+});
+```
+
+After:
+
+```tsx
+const defaultApp = wish<{ addPiece: Stream<{ piece: MentionablePiece }> }>({
+  query: "#default",
+});
+
+const createNewNote = action(() => {
+  const note = Note({ title: "New Note", content: "", noteId: generateId() });
+  defaultApp.result.addPiece.send({ piece: note });
+  return navigateTo(note);
+});
+```
+
+### From handler with `allPieces` in state
+
+Before:
+
+```tsx
+const createNoteHandler = handler<
+  { title: string; content: string },
+  { allPieces: Writable<MentionablePiece[]> }
+>(({ title, content }, { allPieces }) => {
+  const note = Note({ title, content, noteId: generateId() });
+  allPieces.push(note as any);
+  return note;
+});
+
+// Bound as:
+createNoteHandler({ allPieces });
+```
+
+After:
+
+```tsx
+const createNoteHandler = handler<
+  { title: string; content: string },
+  { addPiece: Stream<{ piece: MentionablePiece }> }
+>(({ title, content }, { addPiece }) => {
+  const note = Note({ title, content, noteId: generateId() });
+  addPiece.send({ piece: note });
+  return note;
+});
+
+// Bound as:
+createNoteHandler({ addPiece: defaultApp.result.addPiece });
+```
+
+## How it works
+
+The `addPiece` handler is defined in `default-app.tsx` and exported as a
+`Stream<{ piece: MentionablePiece }>`. Internally it checks for duplicates
+and pushes to the owned `allPieces` Writable. The runtime infrastructure
+(`PieceManager.add()`) also uses this handler — patterns should follow the
+same approach.
+
+See [handler()](../concepts/handler.md) for handler mechanics and
+[wish()](wish.md) for wish usage.

--- a/docs/common/conventions/mentionable.md
+++ b/docs/common/conventions/mentionable.md
@@ -38,7 +38,9 @@ return {
 
 **Notes:**
 - Exported mentionables appear in autocomplete but NOT in the sidebar piece list
-- Use this instead of writing to `allPieces` directly
+- This is for mentionables within your pattern's own scope — to add pieces to the
+  global piece list, use the `addPiece` handler via `wish("#default")`.
+  See [Adding Pieces](adding-pieces.md).
 
 ## Wishing for Mentionables
 

--- a/docs/common/conventions/wish.md
+++ b/docs/common/conventions/wish.md
@@ -132,3 +132,17 @@ This ensures the wish is established once. Conditional logic belongs in how you
 
 Keep a handle to important information in a piece, e.g. google auth, user
 preferences/biography, cross-cutting data (calendar).
+
+### Adding Pieces via `#default`
+
+To add new pieces to the space, wish for the `addPiece` handler as a `Stream`:
+
+```tsx
+const defaultApp = wish<{ addPiece: Stream<{ piece: MentionablePiece }> }>({
+  query: "#default",
+});
+defaultApp.result.addPiece.send({ piece: newPiece });
+```
+
+Do **not** wish for `allPieces` as a `Writable` — see
+[Adding Pieces](adding-pieces.md).


### PR DESCRIPTION
Document the intended pattern for adding pieces: always use the addPiece
handler via wish("#default") instead of pushing to allPieces directly.
Includes migration examples, anti-patterns, and cross-references from
mentionable.md and wish.md.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
