### PR TITLE
Add unit tests that show the different behavior for array and object get responses

### DIFF
--- a/packages/runner/test/schema.test.ts
+++ b/packages/runner/test/schema.test.ts
@@ -3407,6 +3407,9 @@ describe("Schema Support", () => {
         outerLink.id,
       );
 
+      // Test that we have our object
+      expect(resultInnerContents!.test).toEqual({ foo: "bar" });
+
       // resultInnerContents was returned from outer's inner.get(), and
       // inner->redir->first are all writeRedirect, so its toCell() returns
       // the first cell.
@@ -4056,6 +4059,9 @@ describe("Schema Support", () => {
         .getAsNormalizedFullLink();
       expect(resultInnerContentsCellLink.id).toBe(secondCellLink.id);
       expect(resultInnerContentsCellLink.path).toEqual([]);
+
+      // Test that unknown type from object turns into undefined
+      expect(resultInnerContents!.test).toBeUndefined();
 
       // resultInnerContents was returned from outer's inner.get(), and
       // inner->redir->first are all writeRedirect, so its toCell() returns


### PR DESCRIPTION
Add some tests with type unknown
Demonstrate that arrays go one extra link
Fix a minor issue where the tests had one less write redirect link than intended.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests documenting how get/asCell resolves links for objects vs arrays when type is unknown, and fix a small test setup bug. Adds a few extra expects to verify resolved values and link targets.

- **New Features**
  - Tests: objects follow all redirects + 1 link; arrays follow + 2; unknown-from-object becomes undefined.
  - Extra asserts validate returned object data and toCell/normalized link IDs.

- **Bug Fixes**
  - Corrected a test to use inner.getAsWriteRedirectLink() to get the intended redirect chain.

<sup>Written for commit 21e1495d3bfe645c9aa7ea8f467af8eb452ec7bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

