### PR TITLE
fix(piece): provide default cause in setupPersistent to avoid createRef warning

### DIFF
--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -809,7 +809,7 @@ export class PieceManager {
     await this.runtime.idle();
     const piece = this.runtime.getCell<T>(
       this.space,
-      cause,
+      cause ?? { space: this.space, random: crypto.randomUUID() },
       pattern.resultSchema,
     );
     this.runtime.setup(undefined, pattern, inputs ?? {}, piece);


### PR DESCRIPTION
## Summary
- When creating a new piece via `setupPersistent`, no causal reference was passed to `createRef`, triggering a noisy `[createRef] NO CAUSE — falling back to randomUUID` warning with a full stack trace
- Now generates a cause from `{ space: this.space, random: crypto.randomUUID() }` when none is provided — same outcome (unique piece per call), no warning

## Test plan
- [x] Deployed counter pattern to a fresh space via `ct piece new` — no createRef warning in output
- [ ] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provide a default cause in setupPersistent to prevent the noisy createRef warning while keeping each piece creation unique. If no cause is passed, we now use { space: this.space, random: crypto.randomUUID() }.

- **Bug Fixes**
  - Eliminates the "[createRef] NO CAUSE — falling back to randomUUID" warning and stack trace when creating a new piece.

<sup>Written for commit 3e63218604ce3e0d100c69407235925113c321e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

