### PR TITLE
Update formal spec for serialization rework and dispatch modules

### DIFF
--- a/docs/specs/space-model-formal-spec/1-storable-values.md
+++ b/docs/specs/space-model-formal-spec/1-storable-values.md
@@ -1402,9 +1402,13 @@ The dispatch is configured by `setJsonEncodingConfig(enabled)` /
 `resetJsonEncodingConfig()`, called from the `Runtime` constructor and
 `Runtime.dispose()` respectively:
 
-- **Flag OFF (default):** `jsonFromValue` = `JSON.stringify`,
-  `valueFromJson` = `JSON.parse`. This is the legacy path — the storage layer
-  sees plain JSON values with no tagged types.
+- **Flag OFF (default):** `jsonFromValue` wraps `JSON.stringify` with a
+  defensive guard that throws if the result is `undefined` — this can happen
+  when the input is `undefined` (a first-class `StorableValue` per Section
+  1.3), since `JSON.stringify(undefined)` returns `undefined` rather than a
+  string. The guard ensures `jsonFromValue` always returns a `string` as its
+  type signature promises. `valueFromJson` = `JSON.parse`. This is the legacy
+  path — the storage layer sees plain JSON values with no tagged types.
 - **Flag ON:** `jsonFromValue` routes through `JsonEncodingContext.encode()`,
   `valueFromJson` routes through `JsonEncodingContext.decode()`. Rich types
   are preserved across the storage boundary.


### PR DESCRIPTION
## Summary

- Rewrites Section 4 (Serialization Contexts) of the formal spec to reflect the session 2026-042 structural changes
- Replaces old 4-method `SerializationContext` interface with the new parameterized `SerializationContext<SerializedForm>` (just `encode`/`decode` + `lenient`)
- Replaces ~250 lines of standalone `serialize()`/`deserialize()` pseudocode with documentation of `TypeHandler`/`TypeHandlerCodec` interfaces and the five built-in handlers
- Adds new Section 4.8: JSON encoding dispatch (`jsonFromValue`/`valueFromJson` wired into `space.ts`)
- Adds new Section 4.9: Storable value dispatch (`toStorable`/`fromStorable` wired into `Cell.getRaw`/`Cell.setRaw`)

## Context

Reflects PRs #2970 (infrastructure refactoring), #2971 (storage boundary wiring), and #2975 (storable-value-dispatch chokepoint).

## Test plan

- [ ] Review spec sections for accuracy against merged code
- [ ] Verify no stale references to removed interfaces (`TagCodec`, `ByteTagCodec`, `SerializedForm`)

Co-Authored-By: spec-writer-sage (Claude Opus 4.6) <noreply@anthropic.com>
Co-Authored-By: foreman-rail (Claude Opus 4.6) <noreply@anthropic.com>
