### PR TITLE
fix(runner): optional chaining crash + wrong space in loadPattern

### DIFF
--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -389,7 +389,7 @@ export class PatternManager {
       patternMeta = metaCell.get();
     }
 
-    if (!patternMeta.src && !patternMeta.program) {
+    if (!patternMeta?.src && !patternMeta?.program) {
       throw new Error(`Pattern ${patternId} has no stored source`);
     }
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -481,7 +481,7 @@ export class Runner {
             // Async load for pattern change after initial start.
             // Errors are logged here since there's no caller to propagate to.
             this.runtime.patternManager
-              .loadPattern(newPatternId, resultCell.space)
+              .loadPattern(newPatternId, processCell.space)
               .then((loaded) => {
                 if (currentPatternId !== newPatternId) return;
 
@@ -627,7 +627,7 @@ export class Runner {
     if (!pattern) {
       return this.runtime.patternManager.loadPattern(
         patternId,
-        resultCell.space,
+        processCell.space,
       )
         .then((loaded) => {
           if (loaded) {

--- a/packages/runner/test/pattern-manager.test.ts
+++ b/packages/runner/test/pattern-manager.test.ts
@@ -114,6 +114,38 @@ describe("PatternManager program persistence", () => {
   });
 });
 
+describe("PatternManager.loadPattern error handling", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("throws descriptive error for missing pattern, not TypeError", async () => {
+    const bogusId = "nonexistent-pattern-id";
+    try {
+      await runtime.patternManager.loadPattern(bogusId, space);
+      throw new Error("should have thrown");
+    } catch (err) {
+      // Should throw the descriptive "has no stored source" error,
+      // NOT a TypeError about reading properties of undefined
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).not.toMatch(/Cannot read properties/);
+      expect((err as Error).message).toContain("has no stored source");
+    }
+  });
+});
+
 describe("PatternManager.compileOrGetPattern", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;


### PR DESCRIPTION
Bug 1: pattern-manager.ts:392 missing ?. after legacy fallback causes TypeError instead of descriptive "has no stored source" error when patternMeta is undefined.

Bug 2: setupTypeWatcher and doStart passed resultCell.space to loadPattern, but pattern metadata lives in the process cell's space. Changed to processCell.space to match the working path in ensure-piece-running.ts.

Adds regression test for Bug 1.