### PR TITLE
chore: add CLAUDE.local.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ ralph.yml
 .claude/blackboard.db-wal
 .commands
 tour-screenshots
+CLAUDE.local.md


### PR DESCRIPTION
## Summary
- Add `CLAUDE.local.md` to `.gitignore` to prevent local Claude Code instructions from being committed

## Test plan
- [x] Verify `CLAUDE.local.md` no longer shows in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)