### PR TITLE
feat(ui): add fontSize to CTTheme and ct-code-editor

### DIFF
--- a/packages/ui/src/v2/components/ct-code-editor/styles.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/styles.ts
@@ -44,7 +44,7 @@ export const styles = css`
 
   /* Match v2 component theming */
   .cm-editor {
-    font-size: 0.875rem;
+    font-size: var(--ct-theme-font-size, 0.875rem);
     font-family: var(--ct-theme-mono-font-family, monospace);
   }
 
@@ -72,7 +72,7 @@ export const styles = css`
         sans-serif
       )
     );
-    font-size: 1rem;
+    font-size: var(--ct-theme-font-size, 1rem);
   }
 
   :host([mode="prose"]) .cm-editor.cm-focused {

--- a/packages/ui/src/v2/components/theme-context.ts
+++ b/packages/ui/src/v2/components/theme-context.ts
@@ -21,6 +21,8 @@ export interface CTTheme {
   fontFamily: string;
   /** Monospace font family for code */
   monoFontFamily: string;
+  /** Base font size for UI elements */
+  fontSize: string;
   /** Border radius for UI elements */
   borderRadius: string;
   /** Overall density/spacing preference */
@@ -157,6 +159,7 @@ export const defaultTheme: CTTheme = {
   fontFamily: "system-ui, -apple-system, sans-serif",
   monoFontFamily:
     "ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace",
+  fontSize: "1rem",
   borderRadius: "0.5rem",
   density: "comfortable",
   colorScheme: "light",
@@ -367,6 +370,10 @@ export function mergeWithDefaultTheme(
     mergedTheme.monoFontFamily = partialTheme.monoFontFamily;
   }
 
+  if (partialTheme.fontSize) {
+    mergedTheme.fontSize = partialTheme.fontSize;
+  }
+
   if (partialTheme.density) {
     mergedTheme.density = partialTheme.density;
   }
@@ -441,6 +448,7 @@ export function applyThemeToElement(
       "--ct-theme-mono-font-family",
       theme.monoFontFamily,
     );
+    element.style.setProperty("--ct-theme-font-size", theme.fontSize);
     element.style.setProperty("--ct-theme-border-radius", theme.borderRadius);
     element.style.setProperty(
       "--ct-theme-animation-duration",


### PR DESCRIPTION
## Summary
- Adds `fontSize` property to `CTTheme` interface (default `1rem`)
- Exposes `--ct-theme-font-size` CSS custom property via `applyThemeToElement()`
- `ct-code-editor` respects the theme font size with mode-specific fallbacks (0.875rem for code, 1rem for prose)

## Test plan
- [x] Deployed note pattern with `--ct-theme-font-size: 24px` and verified font size change in browser