### PR TITLE
fix(runner): stop child pattern runs in map when list becomes undefined

### DIFF
--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -95,6 +95,9 @@ export function map(
     // distinguish empty inputs from undefined inputs?
     if (list === undefined) {
       resultWithLog.set([]);
+      for (const entry of elementRuns.values()) {
+        runtime.runner.stop(entry.resultCell);
+      }
       elementRuns.clear();
       return;
     }

--- a/packages/runner/test/patterns-dynamic.test.ts
+++ b/packages/runner/test/patterns-dynamic.test.ts
@@ -389,6 +389,54 @@ describe("Pattern Runner - Dynamic Patterns", () => {
     expect(result.key("doubled").get()).toEqual([10, 20, 10]);
   });
 
+  it("should clean up pattern runs when map list becomes undefined", async () => {
+    let runCount = 0;
+    const double = lift((x: number) => {
+      runCount++;
+      return x * 2;
+    });
+
+    const mapPattern = pattern<{ values: number[] }>(({ values }) => {
+      return { values, doubled: values.map((x) => double(x)) };
+    });
+
+    const resultCell = runtime.getCell<
+      { values: number[]; doubled: number[] }
+    >(
+      space,
+      "map-undef-cleanup",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, mapPattern, {
+      values: [1, 2, 3],
+    }, resultCell);
+    tx.commit();
+    tx = runtime.edit();
+
+    await result.pull();
+    expect(result.key("doubled").get()).toEqual([2, 4, 6]);
+    expect(runCount).toBe(3);
+
+    // Set list to undefined — should clean up and produce empty output
+    result.withTx(tx).key("values").set(undefined as any);
+    tx.commit();
+    tx = runtime.edit();
+
+    await result.pull();
+    expect(result.key("doubled").get()).toEqual([]);
+
+    // Restore list — runs must re-execute (old runs were stopped)
+    const runsBeforeRestore = runCount;
+    result.withTx(tx).key("values").set([4, 5]);
+    tx.commit();
+    tx = runtime.edit();
+
+    await result.pull();
+    expect(result.key("doubled").get()).toEqual([8, 10]);
+    expect(runCount - runsBeforeRestore).toBe(2);
+  });
+
   // ── filter builtin tests ──────────────────────────────────────────────
 
   it("should filter an array by predicate", async () => {


### PR DESCRIPTION
## Summary

- Fix leaked child pattern runs in `map.ts` when the input list becomes `undefined`
- The `list === undefined` branch called `elementRuns.clear()` without first stopping child runs via `runtime.runner.stop()`, leaking active executions in the reactive graph
- Matches the fix already applied to `filter` and `flatMap` in PR #2977

## Test plan

- [x] Added test: "should clean up pattern runs when map list becomes undefined"
- [x] All 204 runner tests pass

Fixes CT-1299

🤖 Generated with [Claude Code](https://claude.com/claude-code)