### PR TITLE
fix(fuse): prevent daemon crash on uncaught cell link errors

### DIFF
--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -687,43 +687,49 @@ export class CellBridge {
           // the tree and calling notify_inval_entry from inside a FUSE
           // callback crashes FUSE-T and invalidates inodes mid-operation.
           setTimeout(() => {
-            // Clear existing subtree for this prop
-            const existingIno = this.tree.lookup(pieceIno, propName);
-            if (existingIno !== undefined) {
-              this.tree.clear(existingIno);
-            }
-            // Also clear the .json sibling
-            const jsonIno = this.tree.lookup(
-              pieceIno,
-              `${propName}.json`,
-            );
-            if (jsonIno !== undefined) {
-              this.tree.clear(jsonIno);
-            }
-
-            // Rebuild
-            if (newValue !== undefined && newValue !== null) {
-              const propIno = buildJsonTree(
-                this.tree,
+            try {
+              // Clear existing subtree for this prop
+              const existingIno = this.tree.lookup(pieceIno, propName);
+              if (existingIno !== undefined) {
+                this.tree.clear(existingIno);
+              }
+              // Also clear the .json sibling
+              const jsonIno = this.tree.lookup(
                 pieceIno,
-                propName,
-                newValue,
-                undefined,
-                resolveLink,
-                0,
-                skipEntry,
+                `${propName}.json`,
               );
-              this.addHandlerFiles(propIno, newValue, propName);
-            }
+              if (jsonIno !== undefined) {
+                this.tree.clear(jsonIno);
+              }
 
-            // Invalidate kernel cache
-            if (this.onInvalidate) {
-              this.onInvalidate(pieceIno, [propName, `${propName}.json`]);
-            }
+              // Rebuild
+              if (newValue !== undefined && newValue !== null) {
+                const propIno = buildJsonTree(
+                  this.tree,
+                  pieceIno,
+                  propName,
+                  newValue,
+                  undefined,
+                  resolveLink,
+                  0,
+                  skipEntry,
+                );
+                this.addHandlerFiles(propIno, newValue, propName);
+              }
 
-            console.log(
-              `[${spaceName}] Updated ${pieceName}/${propName}`,
-            );
+              // Invalidate kernel cache
+              if (this.onInvalidate) {
+                this.onInvalidate(pieceIno, [propName, `${propName}.json`]);
+              }
+
+              console.log(
+                `[${spaceName}] Updated ${pieceName}/${propName}`,
+              );
+            } catch (e) {
+              console.error(
+                `[${spaceName}] Error rebuilding ${pieceName}/${propName}: ${e}`,
+              );
+            }
           }, 0);
         });
         cancels.push(cancel);

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -45,6 +45,20 @@ import { HandleMap } from "./handles.ts";
 
 const encoder = new TextEncoder();
 
+// Prevent uncaught errors from crashing the FUSE daemon.
+// Pattern recomputation and cell operations can throw from setTimeout
+// callbacks (e.g. "Cannot create cell link - space required"). These
+// errors should be logged, not fatal.
+globalThis.addEventListener("unhandledrejection", (e) => {
+  console.error("[FUSE] Unhandled promise rejection:", e.reason);
+  e.preventDefault();
+});
+
+globalThis.addEventListener("error", (e) => {
+  console.error("[FUSE] Uncaught error:", e.error ?? e.message);
+  e.preventDefault();
+});
+
 async function main() {
   const args = parseArgs(Deno.args, {
     string: ["api-url", "space", "identity"],
@@ -633,7 +647,7 @@ async function main() {
       }
 
       handles.write(fh, data, off);
-      fuse.symbols.fuse_reply_write(req, sz);
+      fuse.symbols.fuse_reply_write(req, BigInt(sz));
     },
   );
   callbacks.push(writeCb);


### PR DESCRIPTION
## Summary

- Fix FUSE daemon crashing when pattern recomputation throws uncaught "Cannot create cell link - space required" errors from setTimeout callbacks
- Add try/catch in cell-bridge reactive update callback + global error handlers in mod.ts as safety net
- Fix pre-existing type error: `fuse_reply_write` expects `bigint` (usize) but was receiving `number`

Fixes CT-1315

## Test plan

- [x] Mount FUSE filesystem with `ct fuse mount`
- [x] Connect to a space with complex pieces (GMail Importer, patterns with cell links)
- [x] Write to a cell via the filesystem and verify the daemon survives the reactive update
- [x] Confirm errors are logged (not fatal): `[FUSE] Uncaught error: Cannot create cell link...`
- [x] Verify mount remains stable through repeated reads/writes of large pieces (565KB+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)