### PR TITLE
Add fuse-workflow skill for hybrid workflows

### DIFF
--- a/.claude/skills/fuse-workflow/SKILL.md
+++ b/.claude/skills/fuse-workflow/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: fuse-workflow
+description: >
+  Guide for hybrid workflows using CT FUSE filesystem mounting alongside the
+  browser and CLI. Use when mounting spaces, editing cells via the filesystem,
+  developing patterns for filesystem interaction, running agents against mounted
+  spaces, or combining browser + filesystem + CLI workflows. Triggers include
+  "mount a space", "edit cells from filesystem", "use FUSE", "hybrid workflow",
+  "filesystem sync", or working with pieces across both browser and CLI.
+user-invocable: false
+---
+
+# FUSE Hybrid Workflows
+
+**This workflow is evolving.** As we discover new dynamics, update this skill
+to capture them. Offer to do so when patterns emerge that aren't documented here.
+
+## What CT FUSE Does
+
+Mounts a Common Tools space as a local filesystem. Cells become files and
+directories. Reads and writes are bidirectional — edit a file, the cell updates;
+change a cell in the browser, the file updates within ~1 second.
+
+## Quick Start
+
+```bash
+# Prerequisites
+brew install --cask fuse-t          # macOS only, requires sudo
+
+# Identity (reuse existing or create one)
+ls claude.key || deno run -A packages/cli/mod.ts id derive "implicit trust" > claude.key
+
+# Environment
+export CT_API_URL=http://localhost:8000
+export CT_IDENTITY=./claude.key
+
+# Mount
+deno task ct fuse mount /tmp/ct
+
+# Explore a space (connects on demand — any name works)
+ls /tmp/ct/home/pieces/
+ls /tmp/ct/my-space/pieces/
+
+# Unmount
+deno task ct fuse unmount /tmp/ct
+```
+
+## Filesystem Layout
+
+```
+/tmp/ct/
+  <space>/                        # connected on first access
+    pieces/
+      <piece-name>/
+        meta.json                 # read-only: id, entityId, name, patternName
+        input.json                # full input cell as JSON
+        input/                    # exploded input — each key is a file or dir
+          title                   # raw text (no quotes): "My Title"
+          count                   # raw text: "42"
+        result.json               # full result cell as JSON
+        result/
+          items/
+            0/
+              text                # raw text: "Buy milk"
+              done                # raw text: "false"
+            0.json                # atomic: {"text":"Buy milk","done":false}
+          addItem.handler         # write-only: send JSON to trigger handler
+      .index.json                 # name → entity ID mapping
+    entities/                     # access by entity ID (on demand)
+    space.json                    # { did, name }
+  .spaces.json                    # known spaces
+  .status                         # connection state
+```
+
+## Reading and Writing
+
+```bash
+# Read scalar
+cat pieces/my-note/input/title           # => My Title
+
+# Read JSON subtree
+cat pieces/my-note/input.json            # => full input as JSON
+cat pieces/my-note/result/items/0.json   # => single item as JSON
+
+# Write scalar (type auto-detected: number, boolean, null, or string)
+echo -n "New Title" > pieces/my-note/input/title
+
+# Write JSON (atomic multi-field update)
+echo '{"text":"Updated","done":true}' > pieces/my-note/result/items/0.json
+
+# Trigger handler
+echo '{"title":"New Item"}' > pieces/my-note/result/addItem.handler
+
+# Create field
+touch pieces/my-note/result/newField     # creates empty string
+mkdir pieces/my-note/result/metadata     # creates empty object
+
+# Delete field
+rm pieces/my-note/result/oldField
+rm -r pieces/my-note/result/items/0      # removes + re-indexes array
+```
+
+## The Hybrid Workflow
+
+The power is in combining FUSE, CLI, and browser simultaneously:
+
+### Deploy + Mount + Edit
+
+```bash
+# 1. Develop a pattern
+deno task ct check packages/patterns/my-app/main.tsx --no-run
+
+# 2. Deploy to a space
+deno task ct piece new packages/patterns/my-app/main.tsx -s my-space
+# => Created piece bafyreia...
+
+# 3. Mount and interact via filesystem
+deno task ct fuse mount /tmp/ct
+ls /tmp/ct/my-space/pieces/my-app/result/
+
+# 4. Edit cells from terminal while viewing in browser
+echo -n "Updated content" > /tmp/ct/my-space/pieces/my-app/input/title
+# => Browser shows the change within ~1 second
+
+# 5. Iterate on the pattern
+deno task ct piece setsrc packages/patterns/my-app/main.tsx --piece bafyreia...
+# => Result updates in both browser AND filesystem
+```
+
+### Cross-Space Operations
+
+```bash
+# Copy data between spaces
+cp /tmp/ct/space-a/pieces/notes/result/items.json /tmp/backup.json
+cat /tmp/backup.json | jq '.' > /tmp/ct/space-b/pieces/notes/input/items.json
+
+# Grep across an entire space
+grep -r "TODO" /tmp/ct/my-space/pieces/*/result/content
+
+# Diff two pieces
+diff /tmp/ct/my-space/pieces/note-1/result/content \
+     /tmp/ct/my-space/pieces/note-2/result/content
+```
+
+### Agent Workflows
+
+Multiple agents can read/write cells via the filesystem while a human works in
+the browser. Each agent sees the same live data:
+
+```bash
+# Agent reads a piece's state
+cat /tmp/ct/my-space/pieces/assistant/result.json | jq '.messages'
+
+# Agent writes to a handler
+echo '{"message":"Hello from agent"}' > \
+  /tmp/ct/my-space/pieces/assistant/result/sendMessage.handler
+
+# Agent monitors for changes (polling — fswatch may not work with FUSE-T)
+while true; do cat /tmp/ct/my-space/pieces/task/result/status; sleep 2; done
+```
+
+### Pattern Development Loop
+
+Combine pattern-dev with FUSE for a tight feedback loop:
+
+```bash
+# 1. Write pattern in packages/patterns/my-pattern/main.tsx
+# 2. Type check
+deno task ct check packages/patterns/my-pattern/main.tsx --no-run
+# 3. Deploy
+deno task ct piece new packages/patterns/my-pattern/main.tsx -s dev-space
+# 4. Mount
+deno task ct fuse mount /tmp/ct
+# 5. Set input via filesystem (faster than ct piece set for complex data)
+cat test-data.json > /tmp/ct/dev-space/pieces/my-pattern/input.json
+# 6. Read result
+cat /tmp/ct/dev-space/pieces/my-pattern/result.json | jq '.'
+# 7. Iterate: edit pattern → setsrc → result updates automatically
+```
+
+## Important Gotchas
+
+### Identity Mismatch
+
+The CLI identity key creates a *different space* than the browser. If you
+deploy with `claude.key` but browse with your browser identity, you'll see
+different spaces.
+
+**Fix:** Use the browser's space name when mounting:
+```bash
+# Find your browser space name from the URL or shell UI
+ls /tmp/ct/2026-03-09-ben/pieces/   # connects on demand
+```
+
+### No `step` Needed via FUSE
+
+Unlike `ct piece set` which requires `ct piece step` to trigger recomputation,
+FUSE writes go through `cell.set()` directly, which triggers reactive updates
+automatically.
+
+### Writes Are Fire-and-Forget
+
+FUSE returns success before the cell write completes. If toolshed is down,
+writes silently fail. Check the browser to confirm writes landed.
+
+### FUSE-T Cache TTL
+
+Changes from the browser appear in the filesystem within ~1 second (FUSE-T
+NFS cache). Not instant. If you need to force a re-read, `cat` the `.json`
+file (not the exploded directory).
+
+### Large Pieces
+
+Pieces with large `$UI` trees or complex schemas produce huge `result.json`
+files (100KB+). Reading them works but is slow. Prefer reading specific fields
+via the exploded directory: `cat result/title` instead of `cat result.json`.
+
+### Mount Stability
+
+The FUSE daemon can crash if patterns throw uncaught errors during reactive
+updates. If the mount stops responding but the process is still running:
+```bash
+pkill -f "packages/fuse/mod.ts"
+umount /tmp/ct 2>/dev/null
+# Remount
+deno task ct fuse mount /tmp/ct
+```
+
+### macOS Resource Forks
+
+Finder and some macOS tools create `._` resource fork files. The FUSE mount
+rejects these with EACCES. Use CLI tools, not Finder, to browse mounted spaces.
+
+## Reference
+
+- `packages/fuse/mod.ts` — FUSE daemon entry point
+- `packages/fuse/cell-bridge.ts` — cell-to-filesystem bridge
+- `packages/fuse/tree-builder.ts` — JSON-to-tree conversion
+- `docs/specs/fuse-filesystem/` — 7-part specification
+- Use `Skill("ct")` for CLI command reference
+- Use `Skill("pattern-dev")` for pattern development


### PR DESCRIPTION
## Summary

- New Claude Code skill documenting hybrid workflows that combine CT FUSE filesystem mounting with the browser UI and CLI
- Covers: mounting, filesystem layout, read/write operations, deploy+mount+edit loops, cross-space operations, agent workflows, pattern development loops
- Documents key gotchas: identity mismatch, fire-and-forget writes, FUSE-T cache TTL, mount stability, macOS resource forks
- Marked as evolving — should be updated as new dynamics emerge from experiments

## Test plan

- [x] Skill auto-discovered by Claude Code (visible in skills list after creating the directory)
- [x] Content validated against actual FUSE behavior from hands-on testing in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)