### PR TITLE
Revert "Replace stableStringify() with canonicalHash()-based stableHash()"

### DIFF
--- a/packages/memory/deno.json
+++ b/packages/memory/deno.json
@@ -57,8 +57,7 @@
     "./frozen-builtins": "./frozen-builtins.ts",
     "./storable-native-instances": "./storable-native-instances.ts",
     "./special-primitive-value": "./special-primitive-value.ts",
-    "./storable-content-id": "./storable-content-id.ts",
-    "./canonical-hash": "./canonical-hash.ts"
+    "./storable-content-id": "./storable-content-id.ts"
   },
   "imports": {
     "@commontools/leb128": "jsr:@commontools/leb128",

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -38,7 +38,7 @@ import { isObject, isRecord } from "@commontools/utils/types";
 import type { JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import { deepEqual } from "@commontools/utils/deep-equal";
-import { BaseMemoryAddress, MapSet, stableHash } from "../traverse.ts";
+import { BaseMemoryAddress, MapSet, stableStringify } from "../traverse.ts";
 import { getJSONFromDataURI } from "../uri-utils.ts";
 import {
   isPrimitiveCellLink,
@@ -2241,7 +2241,7 @@ export class StorageManager implements IStorageManager {
   ): Promise<Cell<T>> {
     // Build cache key: data URI + schema hash + path + space
     const pathStr = JSON.stringify(cell.path);
-    const schemaStr = schema ? stableHash(schema) : "";
+    const schemaStr = schema ? stableStringify(schema) : "";
     const cacheKey = `${id}|${schemaStr}|${pathStr}|${space}`;
 
     const existing = _dataURISyncCache.get(cacheKey);

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1,6 +1,4 @@
 import { refer } from "@commontools/memory/reference";
-import { canonicalHash } from "@commontools/memory/canonical-hash";
-import { deepFreeze } from "@commontools/memory/deep-freeze";
 import { MIME } from "@commontools/memory/interface";
 import type { JSONSchemaObj } from "@commontools/api";
 import type {
@@ -85,61 +83,16 @@ const enum TypeValidity {
  * @template V The type of values stored in the sets
  */
 /**
- * Produces a canonical hash string for use as a cache/dedup key.
- * Delegates to `canonicalHash()` (SHA-256 based) with a WeakMap identity
- * cache so repeated hashing of the same object reference is O(1).
- *
- * Falls back to a deterministic JSON-like stringification for values that
- * `canonicalHash` rejects (NaN, Infinity, Date, RegExp). These don't
- * appear in normal JSON Schema data but may surface in edge-case tests.
+ * Produces a canonical string representation for use as a hash key.
+ * Object keys are sorted for deterministic output so structurally-equal
+ * objects always hash identically. Results are cached per object identity
+ * via WeakMap, so repeated hashing of the same schema object is O(1).
  */
-// TODO(danfuzz): Remove fallbacks once the data model covers NaN, Infinity,
-// Date, and RegExp directly.
-const _stableHashCache = new WeakMap<object, string>();
-
-export function stableHash(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    if (typeof value === "number" && !Number.isFinite(value)) {
-      return `h:num:${value}`;
-    }
-    return canonicalHash(value).toString();
-  }
-
-  const cached = _stableHashCache.get(value);
-  if (cached !== undefined) return cached;
-
-  let result: string;
-  try {
-    result = canonicalHash(value).toString();
-  } catch {
-    result = _legacyStringify(value);
-  }
-
-  _stableHashCache.set(value, result);
-  return result;
-}
-
-/** Deterministic string fallback for objects `canonicalHash` cannot handle. */
-function _legacyStringify(value: object): string {
-  if (Array.isArray(value)) {
-    return "[" + value.map(stableHash).join(",") + "]";
-  }
-  if (value instanceof Date) {
-    return `D${value.getTime()}`;
-  }
-  if (value instanceof RegExp) {
-    return `R${value.toString()}`;
-  }
-  const keys = Object.keys(value).sort();
-  return "{" +
-    keys.map((k) => k + ":" + stableHash((value as Record<string, unknown>)[k]))
-      .join(",") +
-    "}";
-}
+const _hashCache = new WeakMap<object, string>();
 
 // Schema operation intern caches: memoize merge/combine results so
 // structurally-identical operations return the same object identity.
-// This ensures downstream stableHash hits the _stableHashCache WeakMap
+// This ensures downstream stableStringify hits the _hashCache WeakMap
 // (O(1) identity lookup) instead of re-walking the schema tree.
 // Capped to prevent unbounded growth in long-running servers.
 const INTERN_CACHE_MAX = 10_000;
@@ -157,23 +110,55 @@ function internSet(
   cache.set(key, value);
 }
 
+export function stableStringify(value: unknown): string {
+  if (value === null) return "n";
+  if (value === undefined) return "u";
+  const t = typeof value;
+  if (t === "boolean") return value ? "T" : "F";
+  if (t === "number") return `#${value}`;
+  if (t === "string") return `s${(value as string).length}:${value}`;
+
+  const obj = value as object;
+  const cached = _hashCache.get(obj);
+  if (cached !== undefined) return cached;
+
+  let result: string;
+  if (Array.isArray(obj)) {
+    result = "[" + obj.map(stableStringify).join(",") + "]";
+  } else if (obj instanceof Date) {
+    result = `D${(obj as Date).getTime()}`;
+  } else if (obj instanceof RegExp) {
+    result = `R${(obj as RegExp).toString()}`;
+  } else {
+    const keys = Object.keys(obj).sort();
+    result = "{" +
+      keys.map((k) =>
+        k + ":" + stableStringify((obj as Record<string, unknown>)[k])
+      ).join(",") +
+      "}";
+  }
+
+  _hashCache.set(obj, result);
+  return result;
+}
+
 /**
  * A data structure that maps keys to sets of values, allowing multiple values
  * to be associated with a single key without duplication.
  *
- * When `useStableHash` is true, values are deduped using a canonical hash
- * (stableHash with WeakMap identity cache) for O(1) add/hasValue.
+ * When `useStableStringify` is true, values are deduped using a canonical hash
+ * (stableStringify with WeakMap identity cache) for O(1) add/hasValue.
  * The hash path uses sorted object keys, so structurally-equal values always
  * produce the same hash.
  *
- * When `useStableHash` is false, values are stored in a plain Set using
+ * When `useStableStringify` is false, values are stored in a plain Set using
  * reference equality.
  *
  * @template K The type of keys in the map
  * @template V The type of values stored in the sets
  */
 export class MapSet<K, V> {
-  // When useStableHash is true, use hash-based dedup: key → (hash → value)
+  // When useStableStringify is true, use hash-based dedup: key → (hash → value)
   // When false, use plain Set: key → Set<value>
   private hashMap?: Map<K, Map<string, V>>;
   private setMap?: Map<K, Set<V>>;
@@ -182,8 +167,8 @@ export class MapSet<K, V> {
   deepEqualCalls = 0;
   deepEqualMs = 0;
 
-  constructor(useStableHash = false) {
-    if (useStableHash) {
+  constructor(useStableStringify = false) {
+    if (useStableStringify) {
       this.hashMap = new Map();
     } else {
       this.setMap = new Map();
@@ -222,7 +207,7 @@ export class MapSet<K, V> {
         m = new Map<string, V>();
         this.hashMap.set(key, m);
       }
-      const hash = stableHash(value);
+      const hash = stableStringify(value);
       if (!m.has(hash)) {
         m.set(hash, value);
       }
@@ -246,7 +231,7 @@ export class MapSet<K, V> {
     if (this.hashMap) {
       const m = this.hashMap.get(key);
       if (!m) return false;
-      return m.has(stableHash(value));
+      return m.has(stableStringify(value));
     }
     const values = this.setMap!.get(key);
     return values !== undefined && values.has(value);
@@ -256,7 +241,7 @@ export class MapSet<K, V> {
     if (this.hashMap) {
       const m = this.hashMap.get(key);
       if (!m) return false;
-      const hash = stableHash(value);
+      const hash = stableStringify(value);
       const rv = m.delete(hash);
       if (m.size === 0) this.hashMap.delete(key);
       return rv;
@@ -337,7 +322,7 @@ export class CompoundCycleTracker<EqualKey, ExtraKey, Value = unknown> {
 
   /**
    * Identity check on `partialKey`, hash-based check on `extraKey`.
-   * Uses stableHash (with WeakMap identity cache) so schema objects
+   * Uses stableStringify (with WeakMap identity cache) so schema objects
    * hash in O(1) amortized after the first stringify.
    */
   include(
@@ -351,7 +336,7 @@ export class CompoundCycleTracker<EqualKey, ExtraKey, Value = unknown> {
       existing = new Map();
       this.partial.set(partialKey, existing);
     }
-    const hash = stableHash(extraKey);
+    const hash = stableStringify(extraKey);
     if (existing.has(hash)) {
       return null;
     }
@@ -375,7 +360,7 @@ export class CompoundCycleTracker<EqualKey, ExtraKey, Value = unknown> {
     if (existing === undefined) {
       return undefined;
     }
-    const hash = stableHash(extraKey);
+    const hash = stableStringify(extraKey);
     return existing.get(hash);
   }
 }
@@ -1300,10 +1285,10 @@ function combineOptionalSchema(
 
 // Merge any schema flags like asCell or asStream from flagSchema into schema.
 export function mergeSchemaFlags(flagSchema: JSONSchema, schema: JSONSchema) {
-  const key = stableHash(flagSchema) + "|" + stableHash(schema);
+  const key = stableStringify(flagSchema) + "|" + stableStringify(schema);
   const cached = _mergeSchemaFlagsCache.get(key);
   if (cached !== undefined) return cached;
-  const result = deepFreeze(_mergeSchemaFlagsUncached(flagSchema, schema));
+  const result = _mergeSchemaFlagsUncached(flagSchema, schema);
   internSet(_mergeSchemaFlagsCache, key, result);
   return result;
 }
@@ -1362,10 +1347,10 @@ export function combineSchema(
   parentSchema: JSONSchema,
   linkSchema: JSONSchema,
 ): JSONSchema {
-  const key = stableHash(parentSchema) + "|" + stableHash(linkSchema);
+  const key = stableStringify(parentSchema) + "|" + stableStringify(linkSchema);
   const cached = _combineSchemaCache.get(key);
   if (cached !== undefined) return cached;
-  const result = deepFreeze(_combineSchemaUncached(parentSchema, linkSchema));
+  const result = _combineSchemaUncached(parentSchema, linkSchema);
   internSet(_combineSchemaCache, key, result);
   return result;
 }
@@ -1897,7 +1882,6 @@ export class SchemaObjectTraverser<V extends StorableDatum>
     schema: JSONSchema,
     link?: NormalizedFullLink,
   ): TraverseResult<Immutable<StorableValue>> {
-    schema = deepFreeze(schema);
     this.traverseWithSchemaCalls++;
     this.currentDepth++;
     if (this.currentDepth > this.maxDepth) this.maxDepth = this.currentDepth;
@@ -1913,7 +1897,7 @@ export class SchemaObjectTraverser<V extends StorableDatum>
       if (this.traverseCells) {
         const memo = this.activeMemo;
         const memoKey = docId + "|" + doc.address.path.join("/") + "|" +
-          stableHash(schema);
+          stableStringify(schema);
         const cached = memo.get(memoKey);
         if (cached !== undefined) {
           this.schemaMemoHits++;
@@ -2838,16 +2822,14 @@ function mergeSchemaOption(
   // JSONSchema rules should.
   // For example, `{type: "object", anyOf: [{type: "string"}]}` schema should
   // never match
-  const key = stableHash(outerSchema) + "|" + stableHash(innerSchema);
+  const key = stableStringify(outerSchema) + "|" + stableStringify(innerSchema);
   const cached = _mergeSchemaOptionCache.get(key);
   if (cached !== undefined) return cached;
-  const result = deepFreeze(
-    isObject(innerSchema)
-      ? { ...outerSchema, ...innerSchema }
-      : innerSchema
-      ? outerSchema // innerSchema === true
-      : false, // innerSchema === false
-  );
+  const result = isObject(innerSchema)
+    ? { ...outerSchema, ...innerSchema }
+    : innerSchema
+    ? outerSchema // innerSchema === true
+    : false; // innerSchema === false
   internSet(_mergeSchemaOptionCache, key, result as JSONSchema);
   return result;
 }
@@ -2949,14 +2931,12 @@ export function mergeAnyOfBranchSchemas(
 ): JSONSchema | null {
   if (branches.length < 2) return null;
 
-  const key = stableHash(outerSchema) + "||" +
-    branches.map(stableHash).join("|");
+  const key = stableStringify(outerSchema) + "||" +
+    branches.map(stableStringify).join("|");
   const cached = _mergeAnyOfBranchCache.get(key);
   if (cached !== undefined) return cached;
 
-  const result = deepFreeze(
-    _mergeAnyOfBranchSchemasUncached(branches, outerSchema),
-  );
+  const result = _mergeAnyOfBranchSchemasUncached(branches, outerSchema);
   if (_mergeAnyOfBranchCache.size >= INTERN_CACHE_MAX) {
     _mergeAnyOfBranchCache.clear();
   }
@@ -3030,10 +3010,10 @@ function _mergeAnyOfBranchSchemasUncached(
   // Build merged properties
   const mergedProperties: Record<string, JSONSchema> = {};
   for (const [propKey, schemas] of allProps) {
-    // Deduplicate schemas using stableHash
+    // Deduplicate schemas using stableStringify
     const uniqueHashes = new Map<string, JSONSchema>();
     for (const s of schemas) {
-      uniqueHashes.set(stableHash(s), s);
+      uniqueHashes.set(stableStringify(s), s);
     }
     if (uniqueHashes.size === 1) {
       // All branches agree on this property's schema


### PR DESCRIPTION
Reverts commontoolsinc/labs#2996

It looks like something is wonky with this PR: The new canonical hashing that is done here is only supposed to have ephemeral local effects (not stored durably, not transmitted across the net), but with the PR in we are seeing the error indicative of conflicting hashing algorithms. Here is the text of the report we received:

> hosted deploy is failing. The error says "Sync timed out after 30s" with a possible EXPERIMENTAL_CANONICAL_HASHING mismatch between the local CLI and the hosted server. This is a labs repo config issue, not a problem with our dashboard code.

To be clear, though there's obviously a problem, it might not actually be the exact problem stated in the error.