### PR TITLE
fix(ui): Remove flex-shrink: 0 from ct-hstack/ct-vstack slotted children

### DIFF
--- a/packages/ui/src/v2/components/ct-hstack/ct-hstack.ts
+++ b/packages/ui/src/v2/components/ct-hstack/ct-hstack.ts
@@ -164,9 +164,11 @@ export class CTHStack extends BaseElement {
       padding: 6rem;
     }
 
-    /* Direct children styling */
+    /* Allow children to shrink naturally (default flexbox behavior).
+       Use min-width: 0 to let text-based children truncate properly
+       instead of overflowing the container. */
     ::slotted(*) {
-      flex-shrink: 0;
+      min-width: 0;
     }
   `;
 

--- a/packages/ui/src/v2/components/ct-vstack/ct-vstack.ts
+++ b/packages/ui/src/v2/components/ct-vstack/ct-vstack.ts
@@ -155,9 +155,11 @@ export class CTVStack extends BaseElement {
       padding: 6rem;
     }
 
-    /* Direct children styling */
+    /* Allow children to shrink naturally (default flexbox behavior).
+       Use min-height: 0 to let children shrink properly instead of
+       overflowing the container. */
     ::slotted(*) {
-      flex-shrink: 0;
+      min-height: 0;
     }
   `;
 


### PR DESCRIPTION
## Summary

- **ct-hstack** and **ct-vstack** applied `flex-shrink: 0` to all slotted children via `::slotted(*)`, preventing any child from shrinking below its natural size
- This caused content overflow (clipped buttons, truncated text) especially with `justify="between"`, which pushes items to opposite container edges
- Multiple pattern factory runs and user reports hit this — it's the most common layout issue in generated patterns

## Change

Replace `flex-shrink: 0` with `min-width: 0` (hstack) / `min-height: 0` (vstack). This:

1. **Restores normal flexbox shrink behavior** — children can shrink proportionally when they exceed container width
2. **Fixes text truncation** — `min-width: 0` overrides the default `min-width: auto` on flex items, allowing text content to truncate with `overflow: hidden; text-overflow: ellipsis` when needed

## Scope

Only ct-hstack and ct-vstack (general-purpose layout primitives) are changed. ct-hgroup and ct-vgroup retain `flex-shrink: 0` — those are opinionated grouping components (button bars, form groups) where preventing shrink is reasonable.

## Test plan

- [ ] Verify existing patterns using `ct-hstack justify="between"` no longer clip rightmost children
- [ ] Verify `ct-hstack wrap` still works as expected
- [ ] Verify `ct-vstack` children can shrink vertically when constrained
- [ ] Check that no existing UI regresses (buttons, text, icons should still render at natural size when space is available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)