### PR TITLE
docs: compilation cache design spec

### DIFF
--- a/docs/specs/compilation-cache.md
+++ b/docs/specs/compilation-cache.md
@@ -196,6 +196,9 @@ This covers:
 - New untracked files → included in dirty hash → cache invalidated.
 - Deleted files → path included in hash → cache invalidated.
 - Clean working tree → fingerprint = hash(HEAD) → stable across restarts.
+- **Library dependencies**: `deno.lock` is committed to the repo, so any
+  dependency version change (add, update, or remove) changes either HEAD or the
+  dirty file set — no special handling needed.
 
 Computed once at process startup. Cost is negligible: one `git` invocation plus
 reading a handful of dirty files (typically 0-5 in practice).


### PR DESCRIPTION
## Summary

- Design spec for persistent caching of compiled pattern JS output to avoid redundant recompilation across page reloads and process restarts
- Covers invalidation strategy (fingerprint based on code changes), cache storage (IndexedDB for browser, filesystem for server), Engine refactor (split compile/evaluate), and observability via RuntimeTelemetry
- All design decisions documented; no open questions remain

## Key decisions

- **What to cache**: `JsScript` (compiled JS + source maps), not `Pattern` objects (which contain closures)
- **Invalidation**: Single policy — "did any code change?" Browser uses worker bundle hash; server uses `hash(git HEAD + dirty files)` (all files — including deno.lock, deno.json, etc.)
- **Disabling**: Don't construct `CachedCompiler` — its absence means no caching
- **Engine refactor**: Split `process()` into `compile()` + `evaluate()` to allow cache to intercept compilation
- **Build tool change**: Felt gains manifest generation for browser fingerprint (accepted tradeoff, documented)

## Test plan

- [x] Review design doc for completeness and correctness
- [x] Validate fingerprint strategy covers local dev and production scenarios
- [x] Confirm Engine refactor approach is safe (Engine is only Harness impl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)