### PR TITLE
fix(runner): copy-before-freeze in schema merge pass-through paths

### DIFF
--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1,5 +1,6 @@
 import { refer } from "@commontools/memory/reference";
 import { canonicalHash } from "@commontools/memory/canonical-hash";
+import { deepFreeze, isDeepFrozen } from "@commontools/memory/deep-freeze";
 import { MIME } from "@commontools/memory/interface";
 import type { JSONSchemaObj } from "@commontools/api";
 import type {
@@ -1351,7 +1352,7 @@ export function mergeSchemaFlags(flagSchema: JSONSchema, schema: JSONSchema) {
   const key = stableHash(flagSchema) + "|" + stableHash(schema);
   const cached = _mergeSchemaFlagsCache.get(key);
   if (cached !== undefined) return cached;
-  const result = _mergeSchemaFlagsUncached(flagSchema, schema);
+  const result = deepFreeze(_mergeSchemaFlagsUncached(flagSchema, schema));
   internSet(_mergeSchemaFlagsCache, key, result);
   return result;
 }
@@ -1382,7 +1383,8 @@ function _mergeSchemaFlagsUncached(
       }
     }
   }
-  return schema;
+  // Shallow copy to avoid freezing the caller's input.
+  return isObject(schema) ? { ...schema } : schema;
 }
 
 /**
@@ -1413,7 +1415,7 @@ export function combineSchema(
   const key = stableHash(parentSchema) + "|" + stableHash(linkSchema);
   const cached = _combineSchemaCache.get(key);
   if (cached !== undefined) return cached;
-  const result = _combineSchemaUncached(parentSchema, linkSchema);
+  const result = deepFreeze(_combineSchemaUncached(parentSchema, linkSchema));
   internSet(_combineSchemaCache, key, result);
   return result;
 }
@@ -1543,9 +1545,9 @@ function _combineSchemaUncached(
     (isObject(parentSchema) && parentSchema.type === "array")
   ) {
     if (parentSchema.items === undefined) {
-      return linkSchema;
+      return { ...linkSchema };
     } else if (linkSchema.items === undefined) {
-      return parentSchema;
+      return { ...parentSchema };
     }
     const mergedDefs = { ...linkSchema.$defs, ...parentSchema.$defs };
     const mergedSchemaItems = combineSchema(
@@ -1570,7 +1572,8 @@ function _combineSchemaUncached(
       ...(Object.keys(mergedDefs).length && { $defs: mergedDefs }),
     });
   }
-  return linkSchema;
+  // Shallow copy to avoid freezing the caller's input.
+  return isObject(linkSchema) ? { ...linkSchema } : linkSchema;
 }
 
 // Load the linked pattern from the doc ()
@@ -1954,6 +1957,9 @@ export class SchemaObjectTraverser<V extends StorableDatum>
     schema: JSONSchema,
     link?: NormalizedFullLink,
   ): TraverseResult<Immutable<StorableValue>> {
+    if (!isDeepFrozen(schema)) {
+      schema = deepFreeze(structuredClone(schema));
+    }
     this.traverseWithSchemaCalls++;
     this.currentDepth++;
     if (this.currentDepth > this.maxDepth) this.maxDepth = this.currentDepth;
@@ -2918,11 +2924,13 @@ function mergeSchemaOption(
   const key = stableHash(outerSchema) + "|" + stableHash(innerSchema);
   const cached = _mergeSchemaOptionCache.get(key);
   if (cached !== undefined) return cached;
-  const result = isObject(innerSchema)
-    ? { ...outerSchema, ...innerSchema }
-    : innerSchema
-    ? outerSchema // innerSchema === true
-    : false; // innerSchema === false
+  const result = deepFreeze(
+    isObject(innerSchema)
+      ? { ...outerSchema, ...innerSchema }
+      : innerSchema
+      ? { ...outerSchema } // copy to avoid freezing input
+      : false, // innerSchema === false
+  );
   internSet(_mergeSchemaOptionCache, key, result as JSONSchema);
   return result;
 }
@@ -3029,7 +3037,9 @@ export function mergeAnyOfBranchSchemas(
   const cached = _mergeAnyOfBranchCache.get(key);
   if (cached !== undefined) return cached;
 
-  const result = _mergeAnyOfBranchSchemasUncached(branches, outerSchema);
+  const result = deepFreeze(
+    _mergeAnyOfBranchSchemasUncached(branches, outerSchema),
+  );
   if (_mergeAnyOfBranchCache.size >= INTERN_CACHE_MAX) {
     _mergeAnyOfBranchCache.clear();
   }

--- a/packages/runner/test/schema-freeze-regression.test.ts
+++ b/packages/runner/test/schema-freeze-regression.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  combineSchema,
+  mergeAnyOfBranchSchemas,
+  mergeSchemaFlags,
+} from "../src/traverse.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { JSONSchemaObj } from "@commontools/api";
+
+describe("schema merge/combine must not freeze input schemas", () => {
+  it("mergeSchemaFlags does not freeze input when no flags to merge", () => {
+    const flagSchema: JSONSchema = { type: "object" };
+    const schema: JSONSchema = { type: "string" };
+    mergeSchemaFlags(flagSchema, schema);
+    expect(Object.isFrozen(flagSchema)).toBe(false);
+    expect(Object.isFrozen(schema)).toBe(false);
+    (schema as Record<string, unknown>).description = "still mutable";
+    expect((schema as Record<string, unknown>).description).toBe(
+      "still mutable",
+    );
+  });
+
+  it("mergeSchemaFlags does not freeze input when flags are merged", () => {
+    const flagSchema: JSONSchema = { type: "object", asCell: true };
+    const schema: JSONSchema = { type: "string" };
+    const result = mergeSchemaFlags(flagSchema, schema);
+    expect(Object.isFrozen(flagSchema)).toBe(false);
+    expect(Object.isFrozen(schema)).toBe(false);
+    // Result IS frozen (it's cached).
+    expect(Object.isFrozen(result)).toBe(true);
+  });
+
+  it("combineSchema does not freeze input on array pass-through", () => {
+    const parentSchema: JSONSchema = {
+      type: "array",
+      items: { type: "string" },
+    };
+    const linkSchema: JSONSchema = { type: "array" }; // no items -> pass-through
+    combineSchema(parentSchema, linkSchema);
+    expect(Object.isFrozen(parentSchema)).toBe(false);
+    expect(Object.isFrozen(linkSchema)).toBe(false);
+    (parentSchema as Record<string, unknown>).description = "still mutable";
+    expect((parentSchema as Record<string, unknown>).description).toBe(
+      "still mutable",
+    );
+  });
+
+  it("combineSchema does not freeze input on fallback path", () => {
+    // Both non-boolean, non-object-type, non-array-type -> fallback returns linkSchema copy
+    const parentSchema: JSONSchema = { type: "string" };
+    const linkSchema: JSONSchema = { type: "number" };
+    combineSchema(parentSchema, linkSchema);
+    expect(Object.isFrozen(parentSchema)).toBe(false);
+    expect(Object.isFrozen(linkSchema)).toBe(false);
+  });
+
+  it("mergeAnyOfBranchSchemas does not freeze inputs", () => {
+    const outerSchema: JSONSchemaObj = {
+      type: "object",
+      properties: { name: { type: "string" } },
+    };
+    const branches: JSONSchema[] = [
+      { properties: { name: { type: "string" }, age: { type: "number" } } },
+      { properties: { name: { type: "string" }, email: { type: "string" } } },
+    ];
+    mergeAnyOfBranchSchemas(branches, outerSchema);
+    expect(Object.isFrozen(outerSchema)).toBe(false);
+    expect(Object.isFrozen(branches[0])).toBe(false);
+    expect(Object.isFrozen(branches[1])).toBe(false);
+  });
+
+  it("merge results ARE frozen", () => {
+    const flagSchema: JSONSchema = { type: "object", asCell: true };
+    const schema: JSONSchema = { type: "string" };
+    const result = mergeSchemaFlags(flagSchema, schema);
+    expect(Object.isFrozen(result)).toBe(true);
+
+    const parentSchema: JSONSchema = { type: "string" };
+    const linkSchema: JSONSchema = { type: "number" };
+    const combined = combineSchema(parentSchema, linkSchema);
+    expect(Object.isFrozen(combined)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Wraps `mergeSchemaFlags`, `combineSchema`, `mergeSchemaOption`, and `mergeAnyOfBranchSchemas` cache results in `deepFreeze()` so `canonicalHash()`'s internal `frozenObjectHashCache` can cache them
- Shallow-copies in pass-through paths (where uncached functions return their input unchanged) to avoid freezing the caller's mutable schema objects
- Adds `structuredClone` + `deepFreeze` guard at `traverseWithSchema` entry for external schemas
- Adds 6 regression tests verifying inputs are not frozen while results are

Fixes the root cause of PR #2996's production failure: `deepFreeze()` was freezing shared schemas through pass-through paths in `_mergeSchemaFlagsUncached` and `_combineSchemaUncached`, where `return schema` / `return linkSchema` / `return parentSchema` returned the caller's original object directly. Subsequent `deepFreeze()` on the cached result would freeze the original in-place, causing `TypeError` in strict mode.

## Test plan

- [x] New regression tests pass (6 steps in `schema-freeze-regression.test.ts`)
- [x] Existing traverse tests pass (186 steps)
- [ ] CI green
