### PR TITLE
Improve ct-code-editor prose mode and maxLineWidth flexibility

### DIFF
--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -3770,7 +3770,7 @@ interface CTCodeEditorAttributes<T> extends CTHTMLAttributes<T> {
   "pattern"?: any;
   "wordWrap"?: boolean;
   "lineNumbers"?: boolean;
-  "maxLineWidth"?: number;
+  "maxLineWidth"?: number | string;
   "tabSize"?: number;
   "tabIndent"?: boolean;
   "theme"?: "light" | "dark";

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -352,6 +352,7 @@ const Note = pattern<NoteInput, NoteOutput>(
         mode="prose"
         wordWrap
         tabIndent
+        placeholder="Start writing..."
       />
     );
 

--- a/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
+++ b/packages/ui/src/v2/components/ct-code-editor/ct-code-editor.ts
@@ -135,8 +135,9 @@ const getLangExtFromMimeType = (mime: MimeType) => {
  * @attr {Array} mentioned - Optional Cell of live Pieces mentioned in content
  * @attr {boolean} wordWrap - Enable soft line wrapping (default: true)
  * @attr {boolean} lineNumbers - Show line numbers gutter (default: false)
- * @attr {number} maxLineWidth - Optional max line width in ch units
- *   (default: undefined)
+ * @attr {number|string} maxLineWidth - Optional max line width. Numbers are
+ *   treated as ch units (e.g. 80 → "80ch"), strings are used as-is
+ *   (e.g. "700px", "50rem"). Default: undefined
  * @attr {number} tabSize - Tab size (spaces shown for a tab, default: 2)
  * @attr {boolean} tabIndent - Indent on Tab key (default: true)
  * @attr {"light"|"dark"} theme - Editor theme mode; "dark" enables oneDark.
@@ -169,7 +170,18 @@ export class CTCodeEditor extends BaseElement {
     // New editor configuration props
     wordWrap: { type: Boolean },
     lineNumbers: { type: Boolean },
-    maxLineWidth: { type: Number },
+    maxLineWidth: {
+      converter: {
+        fromAttribute(value: string | null) {
+          if (value === null) return undefined;
+          const num = Number(value);
+          return Number.isNaN(num) ? value : num;
+        },
+        toAttribute(value: number | string | undefined) {
+          return value?.toString() ?? null;
+        },
+      },
+    },
     tabSize: { type: Number },
     tabIndent: { type: Boolean },
     theme: { type: String, reflect: true },
@@ -191,7 +203,7 @@ export class CTCodeEditor extends BaseElement {
   declare pattern: CellHandle<string>;
   declare wordWrap: boolean;
   declare lineNumbers: boolean;
-  declare maxLineWidth?: number;
+  declare maxLineWidth?: number | string;
   declare tabSize: number;
   declare tabIndent: boolean;
   declare theme: "light" | "dark";
@@ -982,9 +994,12 @@ export class CTCodeEditor extends BaseElement {
     // Update max line width theme
     if (changedProperties.has("maxLineWidth") && this._editorView) {
       const n = this.maxLineWidth;
-      const ext = typeof n === "number" && n > 0
+      const maxWidth = typeof n === "number"
+        ? (n > 0 ? `${n}ch` : undefined)
+        : n;
+      const ext = maxWidth
         ? EditorView.theme({
-          ".cm-content": { maxWidth: `${n}ch` },
+          ".cm-content": { maxWidth },
         })
         : [] as unknown as Extension;
       this._editorView.dispatch({
@@ -1117,13 +1132,14 @@ export class CTCodeEditor extends BaseElement {
   private _getModeExtension(): Extension {
     if (this.mode !== "prose") return [];
 
+    const hasCustomWidth = this.maxLineWidth !== undefined;
     return [
       EditorView.theme({
         ".cm-content": {
-          fontFamily: "inherit",
+          fontFamily: "var(--ct-theme-font-family, var(--ct-font-family-sans))",
           lineHeight: "1.6",
           padding: "8px 0",
-          maxWidth: "700px",
+          ...(!hasCustomWidth && { maxWidth: "700px" }),
           margin: "0 auto",
         },
         ".cm-line": {
@@ -1166,13 +1182,17 @@ export class CTCodeEditor extends BaseElement {
       this._indentUnitComp.of(
         indentUnit.of(" ".repeat(this.tabSize ?? 2)),
       ),
-      // Optional max line width (in ch)
+      // Optional max line width (number → ch, string → as-is)
       this._maxLineWidthComp.of(
-        typeof this.maxLineWidth === "number" && this.maxLineWidth > 0
-          ? EditorView.theme({
-            ".cm-content": { maxWidth: `${this.maxLineWidth}ch` },
-          })
-          : [] as unknown as Extension,
+        (() => {
+          const n = this.maxLineWidth;
+          const maxWidth = typeof n === "number"
+            ? (n > 0 ? `${n}ch` : undefined)
+            : n;
+          return maxWidth
+            ? EditorView.theme({ ".cm-content": { maxWidth } })
+            : [] as unknown as Extension;
+        })(),
       ),
       // Theme (dark -> oneDark)
       this._themeComp.of(this.theme === "dark" ? oneDark : []),


### PR DESCRIPTION
## Summary
This PR extends the existing `maxLineWidth` property on `ct-code-editor` so it can be used to override the width in prose mode (previously it only worked in code mode).

The `maxLineWidth` originally only accepted a number which it would convert to ch units. This makes sense if you're thinking in terms of an IDE, but not if you're trying to fit a text editor into a predefined, pixel-sized region of the page. Now it can accept either a number _or_ a string

```html
maxLineWidth={80} // 80 ch
maxLineWidth="300px"  // 300px
maxLineWidth="35rem"  // 35rem
```

I chose this approach because maxLineWidth already exists on ct-code-editor and I didn't want to invent two ways of setting the same value. But I think there's a longer term cleanup of ct-code-editor that could happen to move everything to CSS vars.

This PR also fixes the broken font family in prose mode and adds placeholder copy so users don't see a blank page when they create a new note.

## Changes in this PR
- Allow `maxLineWidth` to accept string values (e.g. `"700px"`, `"50rem"`) in addition to numbers (interpreted as `ch` units)
- Use CSS variable `--ct-theme-font-family` for prose mode font-family instead of `inherit`
- Avoid overriding `maxWidth` in prose mode when a custom width is already set
- Add `"Start writing..."` placeholder to the note pattern

## Test plan
- [x] Verify prose mode renders correctly with default 700px max width
- [x] Verify `maxLineWidth` works with number values (e.g. `80` → `80ch`)
- [x] Verify `maxLineWidth` works with string values (e.g. `"700px"`, `"50rem"`)
- [x] Verify note pattern shows placeholder text when empty

## Related issues
- https://linear.app/common-tools/issue/CT-1302/ct-code-editor-prose-mode-allow-overriding-hardcoded-700px-max-width
- https://linear.app/common-tools/issue/CT-1292/700px-notes-column-creates-a-lot-of-whitespace-on-the-sides