### PR TITLE
fix(runner): guard broken cell links to prevent infinite error loop

### DIFF
--- a/packages/memory/provider.ts
+++ b/packages/memory/provider.ts
@@ -1397,15 +1397,22 @@ class MemoryProviderSession<
       const address = this.parseDocKey(docKey);
       if (address === undefined) continue;
       for (const schemaSelector of schemaSelectors) {
-        evaluateDocumentLinks(
-          spaceSession,
-          address,
-          schemaSelector,
-          classification,
-          this.sharedSchemaTracker,
-          sharedManager,
-          sharedMemo,
-        );
+        try {
+          evaluateDocumentLinks(
+            spaceSession,
+            address,
+            schemaSelector,
+            classification,
+            this.sharedSchemaTracker,
+            sharedManager,
+            sharedMemo,
+          );
+        } catch (error) {
+          logger.warn("incremental-update", () => [
+            `Error evaluating document links for ${docKey}, skipping`,
+            error,
+          ]);
+        }
       }
     }
 

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -719,9 +719,20 @@ export abstract class BaseObjectTraverser {
           const [linkDoc, _selector] = this.nextLink(redirDoc, redirSelector);
           // our item link should point one past the last redirect, but it may
           // be invalid (in which case, we should base the link on redirDoc).
-          arrayElementLink = getNormalizedLink(
-            linkDoc.value !== undefined ? linkDoc.address : redirDoc.address,
-          );
+          const linkAddress = linkDoc.value !== undefined
+            ? linkDoc.address
+            : redirDoc.address;
+          if (
+            linkAddress.path.length === 0 || linkAddress.path[0] !== "value"
+          ) {
+            logger.warn("traverse", () => [
+              "Broken cell link in array element, skipping",
+              { id: linkAddress.id, path: linkAddress.path },
+            ]);
+            newValue[index] = null;
+            return; // continue forEach
+          }
+          arrayElementLink = getNormalizedLink(linkAddress);
           // We can follow all the links, since we don't need to track cells
           const [valueDoc, _] = this.getDocAtPath(linkDoc, [], DefaultSelector);
           docItem = valueDoc;
@@ -793,6 +804,16 @@ export abstract class BaseObjectTraverser {
           return null;
         }
         // our item link should point to the target of the last redirect
+        if (
+          redirDoc.address.path.length === 0 ||
+          redirDoc.address.path[0] !== "value"
+        ) {
+          logger.warn("traverse", () => [
+            "Broken cell link in record value, skipping",
+            { id: redirDoc.address.id, path: redirDoc.address.path },
+          ]);
+          return null;
+        }
         itemLink = getNormalizedLink(redirDoc.address, true);
         // We can follow all the links, since we don't need to track cells
         const [valueDoc, _] = this.getDocAtPath(redirDoc, [], DefaultSelector);


### PR DESCRIPTION
## Summary

- Guard two `getNormalizedLink` call sites in `traverseDAG` (array element and record value cell links) against broken redirect chains — invalid links are treated as missing values instead of throwing
- Wrap `evaluateDocumentLinks` in `processIncrementalUpdate` with try/catch to prevent traversal errors from crashing the commit pipeline

When a cell link points to a non-existent document, `getNormalizedLink()` throws `"Unable to create link to non-value address"`. Because queries re-execute reactively, this fires many times per second and permanently bricks the affected space.

## Test plan

- [x] `deno task test` in `packages/runner` (205 passed)
- [x] `deno task test` in `packages/memory` (64 passed)
- [ ] Reproduce with a space containing a broken cell link, verify it no longer bricks

Fixes CT-1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)