### PR TITLE
fix: remove per-package compilerOptions from ts-transformers

### DIFF
--- a/packages/ts-transformers/deno.json
+++ b/packages/ts-transformers/deno.json
@@ -22,18 +22,5 @@
       "./test/fixtures/**/*.expected.ts",
       "./test/fixtures/**/*.expected.tsx"
     ]
-  },
-  "compilerOptions": {
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictBindCallApply": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true
   }
 }


### PR DESCRIPTION
## Summary
- Removes the per-package `compilerOptions` from `packages/ts-transformers/deno.json` so it inherits the root workspace config
- The ts-transformers package had `strict: true`, `noUncheckedIndexedAccess: true`, etc. which caused `deno check` on fixture files to fail — the strict settings propagated to transitive deps (runner, memory, js-compiler) that weren't written with those constraints
- The package's own `check` task only covers `src/**/*.ts`, so these settings were never needed for fixtures, and inheriting root config is the correct behavior

## Test plan
- [x] `deno task test` in ts-transformers: all 126 tests pass
- [x] `deno check` on fixture files no longer produces spurious errors from transitive deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)