### PR TITLE
docs(spec): update formal spec for StorableInstance, dispatch consolidation, and related changes

### DIFF
--- a/docs/specs/space-model-formal-spec/1-storable-values.md
+++ b/docs/specs/space-model-formal-spec/1-storable-values.md
@@ -2686,7 +2686,7 @@ spec from being implementable.
   `Date`, `RegExp`, `Map`, `Set`, or `Uint8Array` through these methods.
   Formalizing this contract (e.g., refining the type parameter `T` of
   `IAnyCell` to `extends StorableValue`) would make the implicit expectation
-  explicit without breaking any current caller. The `fromStorable()` /
-  `toStorable()` dispatch in these methods (Section 4.9) is correct but
+  explicit without breaking any current caller. The `nativeFromStorableValue()` /
+  `storableFromNativeValue()` dispatch in these methods (Section 4.9) is correct but
   forward-looking: it will become load-bearing when user-facing patterns
   start storing rich types through the schema-aware `set()` path.


### PR DESCRIPTION
## Summary

Updates the formal spec (`1-storable-values.md`) to reflect recent implementation changes:

- **StorableInstance**: Interface replaced with abstract base class providing `shallowClone()` and `shallowUnfrozenClone()` methods (Section 2.3). `isStorableInstance()` now uses `instanceof` instead of property-brand check (Section 2.6).
- **StorableNativeWrapper\<T\>**: New abstract base class for native object wrappers with `toNativeValue()` freeze-state dispatch (Section 1.4.1). All native wrappers extend it.
- **Dispatch consolidation** (PR #3041): `storable-value-dispatch.ts` -> `storable-value.ts` with legacy/modern split (Section 4.9).
- **tagFromNativeValue()**: O(1) constructor-based dispatch (Section 8.2 note).
- **shallowCloneIfNecessary()**: Centralized freeze-clone utility (Section 8.2).
- **deepFreeze copy-before-freeze** at schema merge/combine sites (Section 8.2).
- **getRaw/setRaw contract**: Middle-layer open question documented (Appendix A).
- File path references corrected (`packages/common/` -> `packages/memory/`).
- Temperature example updated to extend StorableInstance (Section 2.7).

Single file, 285 insertions, 97 deletions.

## Test plan

- [ ] Spec review by Dan

Co-Authored-By: spec-writer-sage (Claude Opus 4.6) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.6) <noreply@anthropic.com>