### PR TITLE
Add CORS, reactive cycle, and cross-pattern gotchas to pattern-dev skill

### DIFF
--- a/.agents/skills/pattern-dev/SKILL.md
+++ b/.agents/skills/pattern-dev/SKILL.md
@@ -203,7 +203,7 @@ const sorted = computed(() => {
 });
 
 // ✅ RIGHT - computed for derivation, action for side-effects
-const sorted = computed(() => allItems.get().sort(compareFn));
+const sorted = computed(() => [...allItems.get()].sort(compareFn));
 const updateStatus = action(() => statusMessage.set(`${allItems.get().length} items`));
 ```
 


### PR DESCRIPTION
## Summary

Upstreams three lessons learned from factory runs into the `pattern-dev` skill so both factory agents and human developers benefit:

- **CORS on `fetchData` URLs**: Patterns run in the browser — URLs must respond with `Access-Control-Allow-Origin: *`. RSS feeds and many `.xml` endpoints don't. Prefer public JSON APIs.
- **`.set()` in `computed()` causes reactive cycles**: Writing to upstream cells inside a `computed()` triggers the 101-iteration cap. Split into `computed()` for derivation + `action()` for side-effects.
- **Cross-pattern field name matching**: When patterns compose, output/input field names must match exactly — no automatic mapping.

Addresses [CT-1324](https://linear.app/common-tools/issue/CT-1324/pattern-factory-post-run-retrospective-improvements) (quick-win skill updates).

## Test plan

- [ ] Verify `pattern-dev` skill loads correctly (no syntax issues in the markdown)
- [ ] Run a factory brief that uses `fetchData` — maker should avoid non-CORS URLs
- [ ] Run a factory brief with computed derivations — maker should not `.set()` upstream cells in computeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)