### PR TITLE
feat(patterns): inline pattern index into system prompt (CT-1078)

### DIFF
--- a/packages/patterns/system/omnibox-fab.tsx
+++ b/packages/patterns/system/omnibox-fab.tsx
@@ -1,6 +1,7 @@
 /// <cts-enable />
 import {
   computed,
+  fetchData,
   handler,
   ifElse,
   NAME,
@@ -19,7 +20,6 @@ import {
   calculator,
   fetchAndRunPattern,
   listMentionable,
-  listPatternIndex,
   listRecent,
   navigateToPattern,
   readWebpage,
@@ -127,6 +127,25 @@ export default pattern<OmniboxFABInput>(
 
     const profile = wish<string>({ query: "#profile" });
 
+    const patternIndexUrl = wish<{ url: Writable<string> }>({
+      query: "#pattern-index",
+    });
+    const resolvedPatternUrl = Writable.of<string>("/api/patterns/index.md");
+    computed(() => {
+      const urlRef = patternIndexUrl?.result?.url;
+      const urlValue = typeof urlRef?.get === "function"
+        ? urlRef.get()
+        : (typeof urlRef === "string" ? urlRef : undefined);
+      if (typeof urlValue === "string" && urlValue.length > 0) {
+        resolvedPatternUrl.set(urlValue);
+      }
+    });
+
+    const { result: patternIndex } = fetchData({
+      url: resolvedPatternUrl,
+      mode: "text",
+    });
+
     const profileContext = computed(() => {
       const profileText = profile.result;
       return profileText
@@ -136,11 +155,14 @@ export default pattern<OmniboxFABInput>(
 
     const systemPrompt = computed(() => {
       const profileSection = profileContext;
+      const indexText = patternIndex
+        ? `\n\n--- Available Patterns ---\n${patternIndex}\n---`
+        : "";
       return `You are a polite but efficient assistant. Think Star Trek computer - helpful and professional without unnecessary conversation. Let your actions speak for themselves.
-${profileSection}
+${profileSection}${indexText}
 Tool usage priority:
 - For finding content in the space: use searchSpace with a query to search across all piece summaries and names
-- For patterns: listPatternIndex first
+- For patterns: review the available patterns listed above, then use fetchAndRunPattern to instantiate one
 - For existing pages/notes/content: searchSpace first, then listRecent or listMentionable to identify what they're referencing
 - Attach relevant items to conversation after instantiation/retrieval if they support ongoing tasks
 - Remove attachments when no longer relevant
@@ -161,7 +183,6 @@ Be matter-of-fact. Prefer action to explanation.`;
         pattern: calculator,
       },
       fetchAndRunPattern: patternTool(fetchAndRunPattern),
-      listPatternIndex: patternTool(listPatternIndex),
       navigateTo: patternTool(navigateToPattern),
       wishAndNavigate: patternTool(wishTool),
       listMentionable: patternTool(listMentionable, { mentionable }),

--- a/packages/patterns/system/suggestion.tsx
+++ b/packages/patterns/system/suggestion.tsx
@@ -3,6 +3,7 @@ import {
   type BuiltInLLMMessage,
   computed,
   type Default,
+  fetchData,
   handler,
   ifElse,
   llmDialog,
@@ -20,7 +21,6 @@ import {
   bash,
   fetchAndRunPattern,
   listMentionable,
-  listPatternIndex,
   listRecent,
 } from "./common-tools.tsx";
 import {
@@ -117,6 +117,25 @@ export default pattern<
     entries: SummaryIndexEntry[];
   }>({ query: "#summaryIndex" }).result;
 
+  const patternIndexUrl = wish<{ url: Writable<string> }>({
+    query: "#pattern-index",
+  });
+  const resolvedPatternUrl = Writable.of<string>("/api/patterns/index.md");
+  computed(() => {
+    const urlRef = patternIndexUrl?.result?.url;
+    const urlValue = typeof urlRef?.get === "function"
+      ? urlRef.get()
+      : (typeof urlRef === "string" ? urlRef : undefined);
+    if (typeof urlValue === "string" && urlValue.length > 0) {
+      resolvedPatternUrl.set(urlValue);
+    }
+  });
+
+  const { result: patternIndex } = fetchData({
+    url: resolvedPatternUrl,
+    mode: "text",
+  });
+
   const profileContext = computed(() => {
     const profileText = profile.result;
     return profileText ? `\n\n--- User Context ---\n${profileText}\n---` : "";
@@ -128,17 +147,20 @@ export default pattern<
 
   const systemPrompt = computed(() => {
     const profileCtx = profileContext;
-    return `You help users by finding relevant content and patterns.${profileCtx}
+    const indexText = patternIndex
+      ? `\n\n--- Available Patterns ---\n${patternIndex}\n---`
+      : "";
+    return `You help users by finding relevant content and patterns.${profileCtx}${indexText}
 
 Your textual responses are invisible to the user — they can only see the presented result.
 
 Strategy:
 1. If the request is ambiguous or you need user preferences, call askUserQuestion first. After calling it, STOP — the user's answer will arrive as the next message. Then resume from step 2 with that context.
-2. Call listPatternIndex to see what patterns are available — do this on almost every request.
+2. Review the available patterns listed above to find the best match for the user's request.
 3. Search the space for existing relevant content using searchSpace.
 4. Decide: if an existing cell matches what the user needs, presentResult with it. Otherwise, use fetchAndRunPattern to instantiate a pattern from the index, optionally with existing data as context, then presentResult with the resulting cell link.
 
-The final result you present is almost always either an existing cell or a pattern instantiated from the index. Always gather the information you need (pattern index, search results, user clarification) before presenting a result.
+The final result you present is almost always either an existing cell or a pattern instantiated from the index. Always gather the information you need (search results, user clarification) before presenting a result.
 
 Use the user context above to personalize your suggestions when relevant.`;
   });
@@ -162,7 +184,6 @@ Use the user context above to personalize your suggestions when relevant.`;
     messages,
     tools: {
       fetchAndRunPattern: patternTool(fetchAndRunPattern),
-      listPatternIndex: patternTool(listPatternIndex),
       bash: patternTool(bash, { sandboxId }),
       searchSpace: patternTool(summarySearchPattern, {
         entries: summaryEntries,


### PR DESCRIPTION
## Summary

- Fetches the pattern index via `fetchData` upfront and inlines it into the system prompt in both `suggestion.tsx` and `omnibox-fab.tsx`
- Removes `listPatternIndex` as a tool, saving a tool call round-trip on every request
- Preserves `wish("#pattern-index")` URL override support for custom pattern lists

## Test plan

- [x] Deploy suggestion.tsx locally, trigger a suggestion — confirm the LLM references inlined patterns without calling listPatternIndex
- [x] Verify pattern index appears in system prompt via LLM logs
- [x] Test with a custom favorited `#pattern-index` URL to confirm override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)