### PR TITLE
fix(ui): resolve type errors in ct-render and ct-select tests

### DIFF
--- a/packages/ui/src/v2/components/ct-render/ct-render.test.ts
+++ b/packages/ui/src/v2/components/ct-render/ct-render.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
+import type { CellHandle } from "@commontools/runtime-client";
 import { CTRender } from "./ct-render.ts";
 
 // NOTE: Full rendering lifecycle tests (cell swap cleanup, subscription
@@ -37,7 +38,7 @@ describe("CTRender", () => {
   it("should accept a CellHandle as cell property", () => {
     const element = new CTRender();
     const cell = createMockCellHandle({ ui: "some-vnode" });
-    element.cell = cell;
+    element.cell = cell as CellHandle;
     expect(element.cell).toBe(cell);
   });
 });
@@ -78,7 +79,7 @@ describe("CTRender disconnectedCallback", () => {
   it("should reset state on disconnect", () => {
     const element = new CTRender();
     const cell = createMockCellHandle({ name: "test" });
-    element.cell = cell;
+    element.cell = cell as CellHandle;
     element.variant = "preview";
 
     // disconnectedCallback should clean up internal state without throwing

--- a/packages/ui/src/v2/components/ct-select/ct-select.test.ts
+++ b/packages/ui/src/v2/components/ct-select/ct-select.test.ts
@@ -107,6 +107,6 @@ describe("CTSelect", () => {
 
     // Should accept items with groups
     expect(element.items.length).toBe(4);
-    expect(element.items.every((item) => item.group)).toBe(true);
+    expect(element.items.every((item) => item?.group)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- `ct-render.test.ts`: cast mock `CellHandle<{ui: string}>` to `CellHandle` to fix variance mismatch with `CellHandle<unknown>`
- `ct-select.test.ts`: use optional chaining (`item?.group`) since `items` array type allows `undefined` elements

## Test plan
- [x] `deno check packages/ui/src/v2/components/ct-render/ct-render.test.ts packages/ui/src/v2/components/ct-select/ct-select.test.ts` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)