### PR TITLE
fix(pre-commit): exclude schema-generator fixture inputs from type check

### DIFF
--- a/.agents/scripts/pre-commit.ts
+++ b/.agents/scripts/pre-commit.ts
@@ -127,13 +127,17 @@ if (safeToRestage.length > 0) {
   }).output();
 }
 
+// Schema-generator fixture inputs use bare Cell/Stream/Writable types that are
+// injected at runtime by a custom TypeScript compiler host (see
+// schema-generator/test/utils.ts CELL_BRAND_PRELUDE). They can't pass deno check.
+function isSchemaFixtureInput(path: string): boolean {
+  return path.includes("schema-generator/test/fixtures/") &&
+    path.endsWith(".input.ts");
+}
+
 // 2. Lint and type-check can run in parallel (both read-only)
-// Exclude schema-generator test fixture inputs from type checking — they use
-// bare Cell/Stream/Writable types that are injected at runtime by a custom
-// TypeScript compiler host (see schema-generator/test/utils.ts CELL_BRAND_PRELUDE).
 const tsFiles = files.filter((f) =>
-  /\.(ts|tsx)$/.test(f) &&
-  !(f.includes("schema-generator/test/fixtures/") && f.endsWith(".input.ts"))
+  /\.(ts|tsx)$/.test(f) && !isSchemaFixtureInput(f)
 );
 
 const errors = [


### PR DESCRIPTION
## Summary
- Excludes `schema-generator/test/fixtures/schema/*.input.ts` files from `deno check` in the pre-commit hook
- These fixture files use bare `Cell`/`Stream`/`Writable` types that are injected at test time via a `CELL_BRAND_PRELUDE` by a custom TypeScript compiler host (`schema-generator/test/utils.ts`), so they intentionally don't import these types and produce 32 false-positive TS2304 errors under `deno check`

## Test plan
- [x] Verify fixtures are excluded from type checking in pre-commit
- [x] `deno check` still catches real errors in schema-generator source and test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)