### PR TITLE
removed stale todo comment

### DIFF
--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -817,8 +817,6 @@ export function generateHandlerSchema(
     Object.assign(mergedDefs, $defs);
     Object.assign(mergedDefinitions, definitions);
   }
-  // TODO(@ubik2): Defaults here should be true, but I haven't changed the JSONSchema type
-  // to allow that yet
   return {
     type: "object",
     properties: {


### PR DESCRIPTION
Tiny edit sitting in a stale branch

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed a stale TODO comment in `packages/runner/src/schema.ts` to clean up the `generateHandlerSchema` code and reduce noise.

<sup>Written for commit 5ea23b1763cadd07f189229c57929b33755e0855. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

