### PR TITLE
docs(skills): replace legacy ct-color token examples

### DIFF
--- a/.agents/skills/lit-component/SKILL.md
+++ b/.agents/skills/lit-component/SKILL.md
@@ -153,7 +153,7 @@ Then use theme CSS variables with fallbacks:
 .button {
   background-color: var(
     --ct-theme-color-primary,
-    var(--ct-color-primary, #3b82f6)
+    var(--ct-colors-primary-500, #3b82f6)
   );
   border-radius: var(
     --ct-theme-border-radius,

--- a/.agents/skills/lit-component/references/theme-system.md
+++ b/.agents/skills/lit-component/references/theme-system.md
@@ -166,7 +166,7 @@ Always provide fallbacks to base CSS variables for components that may be used w
 .button {
   background-color: var(
     --ct-theme-color-primary,
-    var(--ct-color-primary, #3b82f6)
+    var(--ct-colors-primary-500, #3b82f6)
   );
   font-family: var(--ct-theme-font-family, inherit);
   border-radius: var(


### PR DESCRIPTION
## Summary

update lit-component skill example fallback token from legacy `--ct-color-primary` to `--ct-colors-primary-500`. `--ct-color-primary` doesn't exist in the system—seems like it might be legacy code