### PR TITLE
In setAtPath, don't delete undefined keys/array entries

### DIFF
--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -136,8 +136,8 @@ const setAtPath = (
     if (rest.length === 0) {
       if (root[index] === value) return { ok: root }; // noop
       const newArray = sparseArrayCopy(root);
-      // We delete elements from an array by setting the array
-      // to another array without those elements
+      // We just set the values here. If you need to delete elements from an
+      // array, set the array to another array without those elements.
       newArray[index] = value;
       return { ok: newArray };
     }
@@ -166,7 +166,8 @@ const setAtPath = (
   // Terminal case
   if (rest.length === 0) {
     if (obj[key] === value) return { ok: root }; // noop
-    // We delete keys by setting an object that lacks those keys
+    // We just set the values here. If you need to delete keys from an object,
+    // set the object to another object without those keys.
     return { ok: { ...obj, [key]: value } };
   }
 

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -136,11 +136,9 @@ const setAtPath = (
     if (rest.length === 0) {
       if (root[index] === value) return { ok: root }; // noop
       const newArray = sparseArrayCopy(root);
-      if (value === undefined) {
-        delete newArray[index]; // creates hole, not splice
-      } else {
-        newArray[index] = value;
-      }
+      // We delete elements from an array by setting the array
+      // to another array without those elements
+      newArray[index] = value;
       return { ok: newArray };
     }
 
@@ -168,11 +166,7 @@ const setAtPath = (
   // Terminal case
   if (rest.length === 0) {
     if (obj[key] === value) return { ok: root }; // noop
-    if (value === undefined) {
-      if (!(key in obj)) return { ok: root }; // delete non-existent = noop
-      const { [key]: _, ...without } = obj;
-      return { ok: without as StorableDatum };
-    }
+    // We delete keys by setting an object that lacks those keys
     return { ok: { ...obj, [key]: value } };
   }
 


### PR DESCRIPTION
Part of a larger set of changes to support undefined throughout the system
There will likely be downstream problems from these, since we were stripping undefined values with this logic, and now will end up trying (unsuccessfully) to send them as JSON across the wire

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop treating undefined as a delete signal in setAtPath. We now preserve undefined in arrays and objects, and comments clarify that deletion requires replacing the parent container.

- **Migration**
  - Replace setAtPath(..., undefined) delete calls by building a new object/array without that key/element and setting it at the parent path.
  - If you serialize to JSON, note that undefined object properties are dropped and undefined array entries become null; adjust callers if needed.

<sup>Written for commit 0430995e54eda2c34b4416d55c14f74706845f2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

