### PR TITLE
I decided that I'm wrong to have aborted on these facts with no value.

### DIFF
--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -472,8 +472,8 @@ function loadFactsForDoc(
     if (selector.schema !== false) {
       if (fact.address.path.length > 0) {
         throw new Error("Invalid fact.address.path (must be empty)");
-      } else if (!isObject(fact.value) || !("value" in fact.value)) {
-        throw new Error("Invalid fact.value with no value");
+      } else if (!("value" in fact.value)) {
+        return; // this doc lacks the portion that could be matched by a schema
       } else if (selector.path.length < 1 || selector.path[0] !== "value") {
         throw new Error("Invalid selector path with no value");
       }


### PR DESCRIPTION
Instead, just treat these docs as non-matching (will not even match schema true, since those are relative to value).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop aborting when a fact lacks a value during schema matching. We now skip those facts and treat the doc as non-matching (won’t match selectors with schema: true), preventing crashes on partial documents.

<sup>Written for commit 35cd2bc0f98282ded3e11f991f24e8ec52d0275e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

