### PR TITLE
feat(cli): validate piece/path existence in ct piece link

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -9,6 +9,7 @@ import {
   getPieceView,
   inspectPiece,
   linkPieces,
+  LinkValidationError,
   listPieces,
   loadManager,
   MapFormat,
@@ -464,6 +465,10 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
   )
   .arguments("<source:string> <target:string>")
   .option("--no-start", "Only link without starting the pieces")
+  .option(
+    "--allow-non-existing",
+    "Allow linking to/from pieces or paths that don't exist yet",
+  )
   .action(async (options, sourceRef, targetRef) => {
     setQuietMode(!!options.quiet);
     const spaceConfig = parseSpaceOptions(options);
@@ -484,14 +489,24 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
       );
     }
 
-    await linkPieces(
-      spaceConfig,
-      source.pieceId,
-      source.path || [], // Empty path for well-known IDs
-      target.pieceId,
-      target.path,
-      { start: options.start },
-    );
+    try {
+      await linkPieces(
+        spaceConfig,
+        source.pieceId,
+        source.path || [], // Empty path for well-known IDs
+        target.pieceId,
+        target.path,
+        {
+          start: options.start,
+          allowNonExisting: !!(options as any).allowNonExisting,
+        },
+      );
+    } catch (error) {
+      if (error instanceof LinkValidationError) {
+        throw new ValidationError(error.message, { exitCode: 1 });
+      }
+      throw error;
+    }
 
     render(`Linked ${sourceRef} to ${targetRef}`);
     hint(`NEXT STEPS:

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -188,6 +188,16 @@ if [ "$RESULT" != "0" ]; then
   error "Piece2 value should be 0 before linking, got: $RESULT"
 fi
 
+# Linking from a nonexistent source path should fail
+if ct piece link $SPACE_ARGS $PIECE_ID/nonexistent $PIECE_ID2/value 2>/dev/null; then
+  error "Linking from nonexistent source path should have failed"
+fi
+
+# Linking to a nonexistent target path should fail
+if ct piece link $SPACE_ARGS $PIECE_ID/value $PIECE_ID2/nonexistent 2>/dev/null; then
+  error "Linking to nonexistent target path should have failed"
+fi
+
 # Link piece1's output value to piece2's input value
 ct piece link $SPACE_ARGS $PIECE_ID/value $PIECE_ID2/value
 
@@ -228,7 +238,13 @@ echo '42' | ct piece set $SPACE_ARGS --piece $INVENTED_ID value
 PIECE_ID3=$(ct piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS $PATTERN_SRC)
 echo "Created third piece: $PIECE_ID3"
 
-ct piece link $SPACE_ARGS $INVENTED_ID/value $PIECE_ID3/value
+# Linking from invented piece should fail without --allow-non-existing
+if ct piece link $SPACE_ARGS $INVENTED_ID/value $PIECE_ID3/value 2>/dev/null; then
+  error "Linking from invented piece should have failed without --allow-non-existing"
+fi
+
+# Now link with --allow-non-existing
+ct piece link $SPACE_ARGS --allow-non-existing $INVENTED_ID/value $PIECE_ID3/value
 
 # Read back piece3's input value - should be 42 from the invented piece
 RESULT=$(ct piece get $SPACE_ARGS --piece $PIECE_ID3 value --input)

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -241,13 +241,14 @@ export async function linkPieces(
   sourcePath: (string | number)[],
   targetPieceId: string,
   targetPath: (string | number)[],
-  options?: { start?: boolean },
+  options?: { start?: boolean; allowNonExisting?: boolean },
 ): Promise<void> {
   const manager = await loadManager(config);
 
   // Ensure default pattern exists (best effort)
+  let pieces: PiecesController;
   try {
-    const pieces = new PiecesController(manager);
+    pieces = new PiecesController(manager);
     await pieces.ensureDefaultPattern();
   } catch (error) {
     // Non-fatal, log and continue
@@ -256,6 +257,80 @@ export async function linkPieces(
         error instanceof Error ? error.message : String(error)
       }`,
     );
+    pieces = new PiecesController(manager);
+  }
+
+  // Validate that source and target pieces/paths exist by reading them
+  if (!options?.allowNonExisting) {
+    const errors: string[] = [];
+
+    // Check source piece exists by verifying it has a source/process cell
+    // (i.e., was created via ct piece new, not just written to with ct piece set)
+    const sourcePiece = await pieces.get(sourcePieceId, false);
+    const sourceHasProcess =
+      sourcePiece.getCell().getSourceCell() !== undefined;
+    if (!sourceHasProcess) {
+      errors.push(`Source piece ${sourcePieceId} does not exist`);
+    } else if (sourcePath.length > 0) {
+      const sourceData = await sourcePiece.result.get();
+      // Check source path resolves
+      let current: any = sourceData;
+      for (const segment of sourcePath) {
+        if (current == null || typeof current !== "object") {
+          errors.push(
+            `Source path "${
+              sourcePath.join("/")
+            }" does not exist on piece ${sourcePieceId}`,
+          );
+          break;
+        }
+        current = current[segment];
+      }
+      if (current === undefined) {
+        errors.push(
+          `Source path "${
+            sourcePath.join("/")
+          }" does not exist on piece ${sourcePieceId}`,
+        );
+      }
+    }
+
+    // Check target piece exists by verifying it has a source/process cell
+    const targetPiece = await pieces.get(targetPieceId, false);
+    const targetHasProcess =
+      targetPiece.getCell().getSourceCell() !== undefined;
+    if (!targetHasProcess) {
+      errors.push(`Target piece ${targetPieceId} does not exist`);
+    } else if (targetPath.length > 0) {
+      // Check target path resolves on the input cell
+      const targetData = await targetPiece.input.get();
+      let current: any = targetData;
+      for (const segment of targetPath) {
+        if (current == null || typeof current !== "object") {
+          errors.push(
+            `Target path "${
+              targetPath.join("/")
+            }" does not exist on piece ${targetPieceId}`,
+          );
+          break;
+        }
+        current = current[segment];
+      }
+      if (current === undefined) {
+        errors.push(
+          `Target path "${
+            targetPath.join("/")
+          }" does not exist on piece ${targetPieceId}`,
+        );
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new LinkValidationError(
+        errors.join("\n") +
+          "\n\nUse --allow-non-existing to link anyway.",
+      );
+    }
   }
 
   await manager.link(
@@ -265,6 +340,13 @@ export async function linkPieces(
     targetPath,
     options,
   );
+}
+
+export class LinkValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LinkValidationError";
+  }
 }
 
 // Constants for piece mapping


### PR DESCRIPTION
## Summary
- `ct piece link` now errors when the source piece, source path, or target piece doesn't exist
- Add `--allow-non-existing` flag to bypass validation for linking to arbitrary cell IDs or not-yet-created pieces
- Validation checks the source piece against the space's piece list, traverses the source path to verify it resolves, and confirms the target piece exists

## Test plan
- [x] `deno task integration cli` passes — includes tests for rejected invented IDs, rejected nonexistent paths, and `--allow-non-existing` bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`ct piece link` now validates that the source piece, target piece, and both paths exist before linking, failing fast with clear errors. Added `--allow-non-existing` to bypass checks for advanced links.

- **New Features**
  - Verify source and target pieces were created via `ct piece new` (have a process cell); reject invented IDs.
  - Ensure the source path resolves on the result cell and the target path resolves on the input cell; reject nonexistent paths.
  - Map `LinkValidationError` to CLI `ValidationError` with a message suggesting `--allow-non-existing`.

- **Migration**
  - Linking to non-existing pieces or paths now fails by default.
  - Use `--allow-non-existing` to link to arbitrary cell IDs or not-yet-created pieces.

<sup>Written for commit bc06b94efa79307b65aafe7dfc532a303117d657. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

