### PR TITLE
perf(bench): remove 500-item array benchmark that takes ~17min

### DIFF
--- a/packages/runner/test/cell-set.bench.ts
+++ b/packages/runner/test/cell-set.bench.ts
@@ -605,31 +605,11 @@ Deno.bench({
   },
 });
 
-Deno.bench({
-  name: "Cell.set() - array: large (500 items)",
-  group: "array",
-  async fn() {
-    const { runtime, storageManager, tx } = setup();
-
-    const cell = runtime.getCell<any>(
-      space,
-      "bench-array-large",
-      undefined,
-      tx,
-    );
-
-    for (let i = 0; i < 100; i++) {
-      cell.set({
-        items: Array.from({ length: 500 }, (_, j) => ({
-          id: j,
-          value: `item-${i}-${j}`,
-        })),
-      });
-    }
-
-    await cleanup(runtime, storageManager, tx);
-  },
-});
+// NOTE: A "large (500 items)" array benchmark was removed because it took ~96s
+// per iteration. Profiling showed 95% of that time was spent in SQLite writes
+// during tx.commit() (~150-200K prepared statement executions for 50K changed
+// facts), not in Cell.set() itself (~3.4s for all 100 iterations). The benchmark
+// was measuring SQLite write throughput rather than Cell.set() performance.
 
 // =============================================================================
 // WRITE COUNT BENCHMARKS


### PR DESCRIPTION
## Summary

- Removes the `Cell.set() - array: large (500 items)` benchmark which took ~17 minutes per bench run (~96s avg per iteration × 11 iterations)
- This single benchmark consumed ~67% of the entire benchmark suite's runtime

## Profiling findings

We profiled why this benchmark was so slow. For 100 iterations of `cell.set({items: array_of_500_objects})`:

| Phase | Time | % |
|-------|------|---|
| 100 × `cell.set()` | 3.4s | 3.3% |
| `chronicle.commit()` (diff/refer) | 1.5s | 1.5% |
| SQLite writes in `swap()` | **~98s** | **95%** |
| **Total** | **~103s** | |

The bottleneck is SQLite — each of the ~50,001 changed facts goes through `swap()` which executes 3-4 prepared statements (`importDatum`, `importFact`, `importMemory`, `swap`), totaling ~150-200K individual SQLite operations.

`refer()` (merkle-reference hashing) accounts for only ~2.5s of the total — not the bottleneck.

The medium array benchmark (100 items) still covers array scaling behavior without the extreme SQLite overhead.

## Test plan

- [ ] `deno bench` passes without the removed benchmark
- [ ] CI benchmark suite completes in ~8min instead of ~25min

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "Cell.set() - array: large (500 items)" benchmark that took ~17 minutes per run and dominated the suite. It was measuring SQLite write throughput, not cell mutation performance.

- **Refactors**
  - Removed the large array case; the medium (100 items) benchmark still covers scaling.
  - Profiling: ~95% spent in SQLite writes (~150–200K statements); `cell.set()` ~3.4s total.
  - Expected suite runtime drops from ~25 minutes to ~8 minutes.

<sup>Written for commit a3126d38ee4735249b181e6aadff9a502a25f807. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

