### PR TITLE
test(ts-transformers): add spread-outside-computed diagnostic test

### DIFF
--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -175,6 +175,41 @@ Deno.test("Pattern Context Validation - Restricted Contexts", async (t) => {
     },
   );
 
+  await t.step(
+    "errors on spread of pattern input outside computed()",
+    async () => {
+      const source = `/// <cts-enable />
+      import { pattern, h } from "commontools";
+
+      interface State {
+        name: string;
+        count: number;
+      }
+
+      export default pattern<State>((input) => {
+        return { ...input };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONTOOLS_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      const spreadErrors = errors.filter((error) =>
+        error.type === "pattern-context:computation"
+      );
+      assertGreater(
+        spreadErrors.length,
+        0,
+        "Spreading pattern input outside computed() should produce an error",
+      );
+      assertEquals(
+        spreadErrors[0]!.message.includes("computed"),
+        true,
+        "Error should suggest using computed()",
+      );
+    },
+  );
+
   await t.step("allows .get() calls inside JSX expressions", async () => {
     const source = `/// <cts-enable />
       import { pattern, Cell, h } from "commontools";


### PR DESCRIPTION
## Summary
- Adds a validation test confirming the transformer errors when a pattern input is spread outside `computed()`
- The diagnostic (`pattern-context:computation`) already existed in `capability-lowering.ts` but had no dedicated test coverage

## Test plan
- [x] New test passes: spreading pattern input outside `computed()` produces error with `computed()` suggestion
- [ ] Existing validation tests still pass (`deno task test` in `packages/ts-transformers`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a validation test to ensure spreading a pattern input outside `computed()` triggers the `pattern-context:computation` diagnostic with a `computed()` suggestion. This closes a gap in test coverage for the transformer.

<sup>Written for commit fae2815aec3eed99403e18072c751154d42cea89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

