### PR TITLE
fix(shell): serve /fonts/ instead of SPA fallback

### DIFF
--- a/packages/shell/felt.config.ts
+++ b/packages/shell/felt.config.ts
@@ -21,7 +21,7 @@ const config: Config = {
   publicDir: "public",
   watchDir: "src",
   redirectToIndex:
-    /^\/(?!((assets|scripts|styles|static)\/.*|build-manifest\.json))/,
+    /^\/(?!((assets|scripts|styles|static|fonts)\/.*|build-manifest\.json))/,
   staticDirs: [
     { from: "../static/assets", to: "/static" },
   ],


### PR DESCRIPTION
## Summary
- The shell dev server's `redirectToIndex` regex was missing `/fonts/` from its exclusion list
- Requests to `/fonts/JetBrainsMono[wght].ttf` were being served as `index.html`, causing "Failed to decode downloaded font" browser console errors
- Added `fonts` to the exclusion list alongside `assets`, `scripts`, `styles`, and `static`

## Test plan
- [x] Restart local dev servers and verify no font decode errors in browser console
- [x] Verify JetBrainsMono renders correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)