### PR TITLE
refactor(runner): type-narrow NormalizedLink.schema to ImmutableJSONSchema

### DIFF
--- a/packages/runner/src/builder/opaque-ref.ts
+++ b/packages/runner/src/builder/opaque-ref.ts
@@ -8,6 +8,7 @@ import {
 } from "./types.ts";
 import { getTopFrame } from "./pattern.ts";
 import { createCell } from "../cell.ts";
+import { asImmutableJSONSchema } from "../link-types.ts";
 
 /**
  * Implementation of opaqueRef that creates actual Cells.
@@ -46,7 +47,7 @@ function opaqueRefWithCell<T>(
     frame.runtime,
     {
       path: [],
-      ...(schema !== undefined && { schema }),
+      ...(schema !== undefined && { schema: asImmutableJSONSchema(schema) }),
       ...(frame.space && { space: frame.space }),
     },
     frame.tx,

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -73,6 +73,7 @@ import {
 import type { Runtime } from "./runtime.ts";
 import {
   areLinksSame,
+  asImmutableJSONSchema,
   createDataCellURI,
   createSigilLinkFromParsedLink,
   findAndInlineDataURILinks,
@@ -999,7 +1000,9 @@ export class CellImpl<T extends StorableValue>
       currentLink = {
         ...currentLink,
         path: [...currentLink.path, key.toString()] as string[],
-        schema: childSchema,
+        schema: childSchema !== undefined
+          ? asImmutableJSONSchema(childSchema)
+          : undefined,
       };
     }
 
@@ -1034,7 +1037,7 @@ export class CellImpl<T extends StorableValue>
     // Create a new link with modified schema
     const siblingLink: NormalizedLink = {
       ...this._link,
-      schema: schema,
+      schema: schema !== undefined ? asImmutableJSONSchema(schema) : undefined,
     };
 
     return new CellImpl(
@@ -1291,7 +1294,7 @@ export class CellImpl<T extends StorableValue>
       path: [],
       id: toURI(sourceCellId),
       type: "application/json",
-      schema: schema,
+      schema: schema !== undefined ? asImmutableJSONSchema(schema) : undefined,
     }, this.tx) as Cell<any>;
   }
 
@@ -1344,7 +1347,7 @@ export class CellImpl<T extends StorableValue>
       );
     }
     // Since we don't have a cause yet, we can modify the link's schema
-    this._link = { ...this._link, schema: newSchema };
+    this._link = { ...this._link, schema: asImmutableJSONSchema(newSchema) };
   }
 
   /**
@@ -2189,7 +2192,9 @@ export function cellConstructorFactory<Wrap extends HKT>(kind: CellKind) {
         frame.runtime,
         {
           path: [],
-          ...(schema !== undefined && { schema }),
+          ...(schema !== undefined && {
+            schema: asImmutableJSONSchema(schema),
+          }),
           ...(frame.space && { space: frame.space }),
         },
         frame.tx,

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -2,6 +2,10 @@ import { JSONSchemaObj } from "@commontools/api";
 import { isObject, isRecord } from "@commontools/utils/types";
 import { getLogger } from "@commontools/utils/logger";
 import type { JSONSchema } from "./builder/types.ts";
+import {
+  asImmutableJSONSchema,
+  type ImmutableJSONSchema,
+} from "./link-types.ts";
 import { CycleTracker } from "./traverse.ts";
 import { isArrayIndexPropertyName } from "@commontools/memory/storable-value";
 import { rendererVDOMSchema, vnodeSchema } from "@commontools/runner/schemas";
@@ -574,12 +578,16 @@ export class ContextualFlowControl {
     schema: JSONSchema | undefined,
     path: string[],
     extraClassifications?: Set<string>,
-  ): JSONSchema | undefined {
+  ): ImmutableJSONSchema | undefined {
     if (schema === undefined) {
       return undefined;
     }
     const result = this.schemaAtPath(schema, path, extraClassifications);
-    return result === false ? undefined : result === true ? {} : result;
+    return result === false
+      ? undefined
+      : result === true
+      ? asImmutableJSONSchema({})
+      : result;
   }
 
   /**
@@ -615,17 +623,17 @@ export class ContextualFlowControl {
     extraClassifications?: Set<string>,
     defaultEmptyProperties: JSONSchema = true,
     defaultMissingProperty: JSONSchema = true,
-  ): JSONSchema {
+  ): ImmutableJSONSchema {
     // Take defs from schema if available
     const defs = isObject(schema) && schema.$defs ? schema.$defs : undefined;
-    return this.schemaAtPathInternal(
+    return asImmutableJSONSchema(this.schemaAtPathInternal(
       schema,
       path,
       defs,
       extraClassifications,
       defaultEmptyProperties,
       defaultMissingProperty,
-    );
+    ));
   }
 
   private schemaAtPathInternal(

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -16,6 +16,7 @@ import {
   areLinksSame,
   areMaybeLinkAndNormalizedLinkSame,
   areNormalizedLinksSame,
+  asImmutableJSONSchema,
   createSigilLinkFromParsedLink,
   findAndInlineDataURILinks,
   isCellLink,
@@ -523,7 +524,7 @@ export function normalizeAndDiff(
         location: {
           ...link,
           path: [...link.path, "length"],
-          schema: childSchema,
+          schema: asImmutableJSONSchema(childSchema),
         },
         value: newValue.length,
       });

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -1,5 +1,6 @@
 import { isObject, isRecord } from "@commontools/utils/types";
 import { type JSONSchema } from "./builder/types.ts";
+import { type JSONSchemaObj } from "@commontools/api";
 import { type MemorySpace } from "./cell.ts";
 import {
   type LegacyAlias,
@@ -16,6 +17,36 @@ import type {
   MemoryAddressPathComponent,
 } from "./storage/interface.ts";
 
+declare const IMMUTABLE_JSON_SCHEMA_BRAND: unique symbol;
+
+/**
+ * A `JSONSchemaObj` that is known to be deeply immutable at runtime (e.g.,
+ * deep-frozen or produced by a cache that returns frozen objects).
+ */
+type ImmutableJSONSchemaObj = JSONSchemaObj & {
+  readonly [IMMUTABLE_JSON_SCHEMA_BRAND]: true;
+};
+
+/**
+ * A `JSONSchema` that is known to be deeply immutable at runtime.
+ *
+ * Implemented as a branded subtype of `JSONSchema`: it is assignable anywhere
+ * `JSONSchema` is accepted, but plain `JSONSchema` cannot be assigned to it
+ * without an explicit coercion via {@link asImmutableJSONSchema}. The brand is
+ * applied only to the object branch (`JSONSchemaObj`) so that the `boolean`
+ * branch (`true`/`false`) retains its normal narrowing behavior.
+ */
+export type ImmutableJSONSchema = ImmutableJSONSchemaObj | boolean;
+
+/**
+ * Mark a `JSONSchema` as deeply immutable. Use only at production sites where
+ * the schema is known to be frozen (e.g., after `deepFreeze`,
+ * `structuredClone` + `deepFreeze`, or retrieval from a frozen cache).
+ */
+export function asImmutableJSONSchema(s: JSONSchema): ImmutableJSONSchema {
+  return s as ImmutableJSONSchema;
+}
+
 /**
  * Normalized link structure returned by parsers
  */
@@ -24,7 +55,7 @@ export type NormalizedLink = {
   path: readonly MemoryAddressPathComponent[];
   space?: MemorySpace;
   type?: string; // Default is "application/json"
-  schema?: JSONSchema;
+  schema?: ImmutableJSONSchema;
   overwrite?: "redirect"; // "this" gets normalized away to undefined
 };
 
@@ -158,7 +189,9 @@ export function parseLinkPrimitive(
       path: path.map((p) => p.toString()),
       ...(resolvedSpace && { space: resolvedSpace }),
       type: "application/json",
-      ...(link.schema !== undefined && { schema: link.schema }),
+      ...(link.schema !== undefined && {
+        schema: asImmutableJSONSchema(link.schema),
+      }),
       ...(link.overwrite === "redirect" && { overwrite: "redirect" }),
     };
   } else if (isLegacyAlias(value)) {
@@ -184,7 +217,9 @@ export function parseLinkPrimitive(
         : [],
       ...(base?.space && { space: base.space }),
       type: "application/json",
-      ...(alias.schema !== undefined && { schema: alias.schema }),
+      ...(alias.schema !== undefined && {
+        schema: asImmutableJSONSchema(alias.schema),
+      }),
       overwrite: "redirect",
     };
   }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -41,6 +41,7 @@ import { createRef, EntityId } from "./create-ref.ts";
 import { Action, Scheduler } from "./scheduler.ts";
 import { Engine } from "./harness/index.ts";
 import {
+  asImmutableJSONSchema,
   CellLink,
   isCellLink,
   isNormalizedFullLink,
@@ -556,7 +557,9 @@ export class Runtime {
       ? cellLink
       : undefined;
     if (!link) throw new Error("Invalid cell link");
-    if (schema !== undefined) link = { ...link, schema };
+    if (schema !== undefined) {
+      link = { ...link, schema: asImmutableJSONSchema(schema) };
+    }
     return createCell(this, link as NormalizedFullLink, tx);
   }
 
@@ -586,7 +589,7 @@ export class Runtime {
       path: [],
       id: asDataURI,
       type: "application/json",
-      schema,
+      ...(schema !== undefined && { schema: asImmutableJSONSchema(schema) }),
     }, tx);
   }
 

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -15,7 +15,11 @@ import { readMaybeLink, resolveLink } from "./link-resolution.ts";
 import { type IExtendedStorageTransaction } from "./storage/interface.ts";
 import { getTransactionForChildCells } from "./storage/extended-storage-transaction.ts";
 import { type Runtime } from "./runtime.ts";
-import { type NormalizedFullLink } from "./link-utils.ts";
+import {
+  asImmutableJSONSchema,
+  type ImmutableJSONSchema,
+  type NormalizedFullLink,
+} from "./link-utils.ts";
 import {
   createQueryResultProxy,
   isCellResultForDereferencing,
@@ -61,7 +65,7 @@ const logger = getLogger("validateAndTransform", {
 export function resolveSchema(
   schema: JSONSchema | undefined,
   filterAsCell = false,
-): JSONSchema | undefined {
+): ImmutableJSONSchema | undefined {
   // Treat undefined/null/{} or any other non-object as no schema
   // We don't use ContextualFlowControl.isTrueSchema here, since we want to
   // handle flags like default or ifc
@@ -105,18 +109,20 @@ export function resolveSchema(
     return undefined;
   }
 
-  return resolvedSchema;
+  return asImmutableJSONSchema(resolvedSchema);
 }
 
-function filterAsCell(schema: JSONSchema | undefined): JSONSchema | undefined {
+function filterAsCell(
+  schema: JSONSchema | undefined,
+): ImmutableJSONSchema | undefined {
   if (typeof schema !== "object") {
-    return schema;
+    return schema as ImmutableJSONSchema | undefined;
   }
   const { asCell: _asCell, asStream: _asStream, ...restSchema } = schema;
   if (restSchema === undefined || Object.keys(restSchema).length === 0) {
     return undefined;
   }
-  return restSchema;
+  return asImmutableJSONSchema(restSchema);
 }
 
 /**
@@ -191,8 +197,9 @@ export function processDefaultValue(
     // Process properties defined in both the schema and default value
     if (resolvedSchema?.properties) {
       for (
-        const [key, propSchema] of Object.entries(resolvedSchema.properties)
+        const [key, rawPropSchema] of Object.entries(resolvedSchema.properties)
       ) {
+        const propSchema = asImmutableJSONSchema(rawPropSchema);
         if (key in defaultValue) {
           result[key] = processDefaultValue(
             runtime,
@@ -240,7 +247,7 @@ export function processDefaultValue(
     if (resolvedSchema.additionalProperties) {
       const additionalPropertiesSchema =
         typeof resolvedSchema.additionalProperties === "object"
-          ? resolvedSchema.additionalProperties
+          ? asImmutableJSONSchema(resolvedSchema.additionalProperties)
           : undefined;
 
       for (const key in defaultValue) {
@@ -271,10 +278,10 @@ export function processDefaultValue(
     resolvedSchema.items
   ) {
     // Handle boolean items values
-    let itemSchema: JSONSchema;
+    let itemSchema: ImmutableJSONSchema;
     if (resolvedSchema.items === true) {
       // items: true means allow any item type
-      itemSchema = {};
+      itemSchema = asImmutableJSONSchema({});
     } else if ((resolvedSchema.items as any) === false) {
       // items: false means no additional items allowed (empty arrays only)
       // For default value processing, we'll treat this as an error
@@ -284,7 +291,7 @@ export function processDefaultValue(
       );
     } else {
       // items is a JSONSchema object
-      itemSchema = resolvedSchema.items as JSONSchema;
+      itemSchema = asImmutableJSONSchema(resolvedSchema.items as JSONSchema);
     }
 
     const result = defaultValue.map((item, i) =>
@@ -310,7 +317,7 @@ export function processDefaultValue(
 function mergeDefaults(
   schema: JSONSchema | undefined,
   defaultValue: Readonly<StorableDatum>,
-): JSONSchema {
+): ImmutableJSONSchema {
   const result: JSONSchemaMutable = {
     ...(isObject(schema) ? structuredClone(schema) as JSONSchemaMutable : {}),
   };
@@ -327,7 +334,7 @@ function mergeDefaults(
     } as JSONValue;
   } else result.default = defaultValue as JSONValue;
 
-  return result;
+  return asImmutableJSONSchema(result);
 }
 
 function annotateWithBackToCellSymbols(
@@ -608,7 +615,7 @@ class TransformObjectCreator
                 {
                   ...link,
                   path: [...link.path, propName],
-                  schema: propSchema,
+                  schema: asImmutableJSONSchema(propSchema),
                 },
                 undefined,
                 this.synced,

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -5,6 +5,7 @@
  */
 
 export {
+  asImmutableJSONSchema,
   isLegacyAlias,
   isSigilLink,
   type NormalizedFullLink,

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -26,7 +26,9 @@ import { ContextualFlowControl } from "./cfc.ts";
 import type { JSONObject, JSONSchema } from "./builder/types.ts";
 import {
   addressKey,
+  asImmutableJSONSchema,
   createDataCellURI,
+  type ImmutableJSONSchema,
   isPrimitiveCellLink,
   NormalizedFullLink,
   parseLink,
@@ -599,7 +601,7 @@ function getNormalizedLink(
     id,
     type,
     path: path.slice(1),
-    ...(schema !== undefined && { schema }),
+    ...(schema !== undefined && { schema: asImmutableJSONSchema(schema) }),
   };
 }
 
@@ -1363,13 +1365,16 @@ function combineOptionalSchema(
 }
 
 // Merge any schema flags like asCell or asStream from flagSchema into schema.
-export function mergeSchemaFlags(flagSchema: JSONSchema, schema: JSONSchema) {
+export function mergeSchemaFlags(
+  flagSchema: JSONSchema,
+  schema: JSONSchema,
+): ImmutableJSONSchema {
   const key = stableStringify(flagSchema) + "|" + stableStringify(schema);
   const cached = _mergeSchemaFlagsCache.get(key);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) return asImmutableJSONSchema(cached);
   const result = _mergeSchemaFlagsUncached(flagSchema, schema);
   internSet(_mergeSchemaFlagsCache, key, result);
-  return result;
+  return asImmutableJSONSchema(result);
 }
 
 function _mergeSchemaFlagsUncached(
@@ -1425,13 +1430,13 @@ function _mergeSchemaFlagsUncached(
 export function combineSchema(
   parentSchema: JSONSchema,
   linkSchema: JSONSchema,
-): JSONSchema {
+): ImmutableJSONSchema {
   const key = stableStringify(parentSchema) + "|" + stableStringify(linkSchema);
   const cached = _combineSchemaCache.get(key);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) return asImmutableJSONSchema(cached);
   const result = _combineSchemaUncached(parentSchema, linkSchema);
   internSet(_combineSchemaCache, key, result);
-  return result;
+  return asImmutableJSONSchema(result);
 }
 
 function _combineSchemaUncached(

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   areLinksSame,
+  asImmutableJSONSchema,
   createDataCellURI,
   createLLMFriendlyLink,
   createSigilLinkFromParsedLink,
@@ -487,7 +488,7 @@ describe("link-utils", () => {
         id: "of:test",
         path: ["nested", "value"],
         space: space,
-        schema: { type: "number" },
+        schema: asImmutableJSONSchema({ type: "number" }),
       };
 
       const result = createSigilLinkFromParsedLink(normalizedLink, {

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  asImmutableJSONSchema,
   type Cancel,
   isLegacyAlias,
   isSigilLink,
@@ -251,7 +252,7 @@ export class CellHandle<T = unknown> {
     const { schema: _schema, ...rest } = this.#ref;
     const newCell = new CellHandle(this.#rt, {
       ...rest,
-      schema,
+      schema: asImmutableJSONSchema(schema),
     });
     newCell.#value = this.#value;
     return newCell as CellHandle<U>;
@@ -484,7 +485,9 @@ function parseAsCellRef(
       space: linkData.space ?? from.space,
       path: (linkData.path ?? []).map((p) => p.toString()),
       type: "application/json",
-      ...(linkData.schema !== undefined && { schema: linkData.schema }),
+      ...(linkData.schema !== undefined && {
+        schema: asImmutableJSONSchema(linkData.schema),
+      }),
     };
   } else if (isLegacyAlias(value)) {
     const alias = value.$alias;
@@ -503,7 +506,9 @@ function parseAsCellRef(
       space: from.space,
       path: aliasPath,
       type: "application/json",
-      ...(alias.schema !== undefined && { schema: alias.schema }),
+      ...(alias.schema !== undefined && {
+        schema: asImmutableJSONSchema(alias.schema),
+      }),
     };
   }
 }


### PR DESCRIPTION
## Summary

Type-narrow `NormalizedLink.schema` from `JSONSchema` to `ImmutableJSONSchema`,
a branded subtype that communicates the schema is not mutated downstream. This
is a purely type-level change with no behavioral impact.

- Define `ImmutableJSONSchema` as a branded subtype of `JSONSchema` in
  `link-types.ts` (brand only on the object branch to preserve boolean
  narrowing)
- Propagate the type through return types of key functions: `schemaAtPath()`,
  `getSchemaAtPath()`, `combineSchema()`, `mergeSchemaFlags()`,
  `resolveSchema()`, `filterAsCell()`, `mergeDefaults()`
- Wrap remaining production sites with `asImmutableJSONSchema()` where plain
  `JSONSchema` values enter `NormalizedLink.schema`

## Motivation

Investigation confirmed all 26 downstream sites that consume
`NormalizedLink.schema` are read-only — zero shared-reference mutation, zero
incidental mutation. With `ImmutableJSONSchema` types in place, we can arrange
`Object.freeze()` calls at sites that are type-structurally known to be safe,
enabling freeze patterns that avoid the per-traversal `deepFreeze` overhead.

## Files changed (11)

link-types.ts, cfc.ts, cell.ts, runtime.ts, opaque-ref.ts, data-updating.ts,
schema.ts, traverse.ts, shared.ts, cell-handle.ts, link-utils.test.ts

---

Co-Authored-By: coder-cedar (Claude Opus 4.6) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.6) <noreply@anthropic.com>
