### PR TITLE
Optimize schema traversal hot paths

### DIFF
--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -15,6 +15,42 @@ const embeddedSchemas: Record<string, JSONSchema> = {
   "https://commonfabric.org/schemas/vnode.json": vnodeSchema,
 };
 
+function schemaAtPathCacheToken(schema: JSONSchema): string {
+  if (schema === true) return "t";
+  if (schema === false) return "f";
+  if (
+    isObject(schema) &&
+    Object.keys(schema).length === 1 &&
+    typeof schema.$comment === "string"
+  ) {
+    return `$comment:${schema.$comment}`;
+  }
+  return JSON.stringify(schema);
+}
+
+function schemaAtPathCacheKey(
+  path: readonly string[],
+  extraClassifications: Set<string> | undefined,
+  defaultEmptyProperties: JSONSchema,
+  defaultMissingProperty: JSONSchema,
+): string {
+  const pathKey = path.join("\u001f");
+  const extraKey = extraClassifications === undefined
+    ? ""
+    : [...extraClassifications].sort().join("\u001f");
+  // Keep the common case cheap: most hot-path callers use the default behavior.
+  if (
+    extraKey === "" &&
+    defaultEmptyProperties === true &&
+    defaultMissingProperty === true
+  ) {
+    return pathKey;
+  }
+  return `${pathKey}|${extraKey}|${
+    schemaAtPathCacheToken(defaultEmptyProperties)
+  }|${schemaAtPathCacheToken(defaultMissingProperty)}`;
+}
+
 // I use these strings in other code, so make them available as
 // constants. These are just strings, and real meaning would be
 // up to implementation.
@@ -164,6 +200,7 @@ class KahnTopologicalSort {
 // These preferences are likely per user/space combination.
 export class ContextualFlowControl {
   private reachable: Map<string, Set<string>>;
+  private schemaAtPathCache = new WeakMap<object, Map<string, JSONSchema>>();
   constructor(
     private lattice: Map<string, string[]> = classificationLattice,
   ) {
@@ -616,12 +653,37 @@ export class ContextualFlowControl {
     defaultEmptyProperties: JSONSchema = true,
     defaultMissingProperty: JSONSchema = true,
   ): JSONSchema {
-    // Take defs from schema if available
-    const defs = isObject(schema) && schema.$defs ? schema.$defs : undefined;
+    if (isObject(schema)) {
+      const cacheKey = schemaAtPathCacheKey(
+        path,
+        extraClassifications,
+        defaultEmptyProperties,
+        defaultMissingProperty,
+      );
+      let cache = this.schemaAtPathCache.get(schema);
+      if (cache === undefined) {
+        cache = new Map();
+        this.schemaAtPathCache.set(schema, cache);
+      } else {
+        const cached = cache.get(cacheKey);
+        if (cached !== undefined) return cached;
+      }
+      const defs = schema.$defs;
+      const result = this.schemaAtPathInternal(
+        schema,
+        path,
+        defs,
+        extraClassifications,
+        defaultEmptyProperties,
+        defaultMissingProperty,
+      );
+      cache.set(cacheKey, result);
+      return result;
+    }
     return this.schemaAtPathInternal(
       schema,
       path,
-      defs,
+      undefined,
       extraClassifications,
       defaultEmptyProperties,
       defaultMissingProperty,
@@ -640,11 +702,8 @@ export class ContextualFlowControl {
       ? new Set<string>(extraClassifications)
       : new Set<string>();
     let cursor = schema;
-    for (
-      const [index, part] of path.map((value, index) =>
-        [index, value] as [number, string]
-      )
-    ) {
+    for (let index = 0; index < path.length; index++) {
+      const part = path[index];
       // If the cursor is a $ref, get the target location
       if (isObject(cursor) && "$ref" in cursor) {
         // Follow the reference
@@ -660,7 +719,7 @@ export class ContextualFlowControl {
       }
       if (isObject(cursor) && ("anyOf" in cursor || "oneOf" in cursor)) {
         const subSchemas: JSONSchema[] = [];
-        const subSchemaStrings: string[] = [];
+        const subSchemaStrings = new Set<string>();
         const options = (cursor.anyOf && cursor.oneOf)
           ? [...cursor.anyOf, ...cursor.oneOf]
           : cursor.anyOf ?? cursor.oneOf ?? [];
@@ -684,11 +743,11 @@ export class ContextualFlowControl {
             break;
           } else {
             const subSchemaString = JSON.stringify(subSchema);
-            if (subSchemaStrings.includes(subSchemaString)) {
+            if (subSchemaStrings.has(subSchemaString)) {
               continue;
             }
             subSchemas.push(subSchema as JSONSchema);
-            subSchemaStrings.push(subSchemaString);
+            subSchemaStrings.add(subSchemaString);
           }
         }
         // Only update cursor from subSchemas if the isTrueSchema branch

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -491,6 +491,7 @@ export function validateAndTransform(
 
 class TransformObjectCreator
   implements IObjectCreator<AnyCellWrapping<StorableDatum>> {
+  readonly allowMergedAnyOfObjectTraversal = true;
   constructor(
     private runtime: Runtime,
     private tx: IExtendedStorageTransaction,
@@ -598,22 +599,24 @@ class TransformObjectCreator
           string,
           JSONSchema,
         ][];
+        const valueObj = value as Record<string, any>;
         for (const [propName, propSchema] of propertyEntries) {
-          if (isObject(propSchema) && propSchema.default !== undefined) {
-            const valueObj = value as Record<string, any>;
-            if (valueObj[propName] === undefined) {
-              valueObj[propName] = processDefaultValue(
-                this.runtime,
-                this.tx,
-                {
-                  ...link,
-                  path: [...link.path, propName],
-                  schema: propSchema,
-                },
-                undefined,
-                this.synced,
-              );
-            }
+          if (
+            isObject(propSchema) &&
+            propSchema.default !== undefined &&
+            valueObj[propName] === undefined
+          ) {
+            valueObj[propName] = processDefaultValue(
+              this.runtime,
+              this.tx,
+              {
+                ...link,
+                path: [...link.path, propName],
+                schema: propSchema,
+              },
+              undefined,
+              this.synced,
+            );
           }
         }
       }

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -119,6 +119,15 @@ const _mergeSchemaOptionCache = new Map<string, JSONSchema>();
 const _combineSchemaCache = new Map<string, JSONSchema>();
 const _mergeSchemaFlagsCache = new Map<string, JSONSchema>();
 const _mergeAnyOfBranchCache = new Map<string, JSONSchema | null>();
+const _logicalBranchOrderCache = new WeakMap<object, JSONSchema[]>();
+
+const mergeableAnyOfObjectSchemaKeys = new Set([
+  "$defs",
+  "additionalProperties",
+  "properties",
+  "required",
+  "type",
+]);
 
 function internSet(
   cache: Map<string, JSONSchema>,
@@ -127,6 +136,24 @@ function internSet(
 ) {
   if (cache.size >= INTERN_CACHE_MAX) cache.clear();
   cache.set(key, value);
+}
+
+function prioritizeNonCellLogicalBranches(
+  options: readonly JSONSchema[],
+): JSONSchema[] {
+  const cached = _logicalBranchOrderCache.get(options);
+  if (cached !== undefined) return cached;
+
+  const prioritized = options.filter((option) =>
+    !SchemaObjectTraverser.asCellOrStream(option)
+  );
+  for (const option of options) {
+    if (SchemaObjectTraverser.asCellOrStream(option)) {
+      prioritized.push(option);
+    }
+  }
+  _logicalBranchOrderCache.set(options, prioritized);
+  return prioritized;
 }
 
 export function stableStringify(value: unknown): string {
@@ -467,6 +494,7 @@ export interface ObjectStorageManager {
 // I think this callback system is a bit of a kludge, but it lets me
 // use the core traversal together with different object types for the runner.
 export interface IObjectCreator<T> {
+  readonly allowMergedAnyOfObjectTraversal?: boolean;
   // When we have multiple matches, we may need to do something special to
   // combine them (for example, merging properties)
   mergeMatches(
@@ -505,6 +533,7 @@ export interface IObjectCreator<T> {
  * queries. We don't need to do anything special here.
  */
 class StandardObjectCreator implements IObjectCreator<StorableDatum> {
+  readonly allowMergedAnyOfObjectTraversal = false;
   mergeMatches(
     matches: StorableDatum[],
     _schema?: JSONSchema,
@@ -2022,19 +2051,13 @@ export class SchemaObjectTraverser<V extends StorableDatum>
       // a very limited set here, with no support for combinations.
       if (resolved.anyOf) {
         const { anyOf, ...restSchema } = resolved;
-        // Consider items without asCell or asStream first, since if we aren't
-        // traversing cells, we consider them a match.
-        const sortedAnyOf = [
-          ...anyOf.filter((option) =>
-            !SchemaObjectTraverser.asCellOrStream(option)
-          ),
-          ...anyOf.filter(SchemaObjectTraverser.asCellOrStream),
-        ];
-
-        // Branch-by-branch traversal; fast-reject after merge so canBranchMatch
-        // sees the full merged constraints (type/required from restSchema too).
         const matches: Immutable<StorableValue>[] = [];
-        for (const optionSchema of sortedAnyOf) {
+        const traversableBranches: Array<{
+          mergedSchema: JSONSchema;
+          optionSchema: JSONSchema;
+          useMergedObjectTraversal: boolean;
+        }> = [];
+        for (const optionSchema of prioritizeNonCellLogicalBranches(anyOf)) {
           this.anyOfBranches++;
           if (ContextualFlowControl.isFalseSchema(optionSchema)) {
             continue;
@@ -2044,18 +2067,107 @@ export class SchemaObjectTraverser<V extends StorableDatum>
             this.anyOfFastRejects++;
             continue;
           }
-          // TODO(@ubik2): do i need to merge the link schema?
-          const { ok: val, error } = this.traverseWithSchema(
-            doc,
+          traversableBranches.push({
             mergedSchema,
-            link,
+            optionSchema,
+            useMergedObjectTraversal: isMergeableAnyOfObjectSchema(
+              mergedSchema,
+            ),
+          });
+        }
+
+        if (
+          this.objectCreator.allowMergedAnyOfObjectTraversal === true &&
+          traversableBranches.length > 1
+        ) {
+          const mergeableBranches = traversableBranches.filter((branch) =>
+            branch.useMergedObjectTraversal
           );
-          if (error === undefined) {
-            // We may just have a cell match, so the first match is what we
-            // will return, but in this case, we still want to evaluate with
-            // all the schema options, so we know to include all the potential
-            // docs needed.
-            matches.push(val);
+          if (mergeableBranches.length > 1) {
+            const mergedObjectSchema = mergeAnyOfBranchSchemas(
+              mergeableBranches.map((branch) => branch.optionSchema),
+              restSchema,
+            );
+            if (mergedObjectSchema !== null) {
+              const { ok: val, error } = this.traverseWithSchema(
+                doc,
+                mergedObjectSchema,
+                link,
+              );
+              if (error === undefined) {
+                matches.push(val);
+                this.anyOfPropertyMerges += mergeableBranches.length;
+                const mergedOptions = new Set(
+                  mergeableBranches.map((branch) => branch.optionSchema),
+                );
+                for (const branch of traversableBranches) {
+                  if (mergedOptions.has(branch.optionSchema)) {
+                    continue;
+                  }
+                  const { ok: branchVal, error: branchError } = this
+                    .traverseWithSchema(
+                      doc,
+                      branch.mergedSchema,
+                      link,
+                    );
+                  if (branchError === undefined) {
+                    matches.push(branchVal);
+                  }
+                }
+              } else {
+                for (const branch of traversableBranches) {
+                  // TODO(@ubik2): do i need to merge the link schema?
+                  const { ok: branchVal, error: branchError } = this
+                    .traverseWithSchema(
+                      doc,
+                      branch.mergedSchema,
+                      link,
+                    );
+                  if (branchError === undefined) {
+                    matches.push(branchVal);
+                  }
+                }
+              }
+            } else {
+              for (const branch of traversableBranches) {
+                // TODO(@ubik2): do i need to merge the link schema?
+                const { ok: branchVal, error: branchError } = this
+                  .traverseWithSchema(
+                    doc,
+                    branch.mergedSchema,
+                    link,
+                  );
+                if (branchError === undefined) {
+                  matches.push(branchVal);
+                }
+              }
+            }
+          } else {
+            for (const branch of traversableBranches) {
+              // TODO(@ubik2): do i need to merge the link schema?
+              const { ok: branchVal, error: branchError } = this
+                .traverseWithSchema(
+                  doc,
+                  branch.mergedSchema,
+                  link,
+                );
+              if (branchError === undefined) {
+                matches.push(branchVal);
+              }
+            }
+          }
+        } else {
+          for (const branch of traversableBranches) {
+            // TODO(@ubik2): do i need to merge the link schema?
+            const { ok: branchVal, error: branchError } = this
+              .traverseWithSchema(
+                doc,
+                branch.mergedSchema,
+                link,
+              );
+            if (branchError === undefined) {
+              matches.push(branchVal);
+            }
           }
         }
         const merged = this.objectCreator.mergeMatches(
@@ -2071,24 +2183,16 @@ export class SchemaObjectTraverser<V extends StorableDatum>
           () => [
             "No matching anyOf",
             doc,
-            sortedAnyOf,
+            anyOf,
             this.getDebugValue(doc),
           ],
         );
         return { error: new Error("No matching anyOf") };
       } else if (resolved.oneOf) {
         const { oneOf, ...restSchema } = resolved;
-        // Consider items without asCell or asStream first, since if we aren't
-        // traversing cells, we consider them a match.
-        const sortedOneOf = [
-          ...oneOf.filter((option) =>
-            !SchemaObjectTraverser.asCellOrStream(option)
-          ),
-          ...oneOf.filter(SchemaObjectTraverser.asCellOrStream),
-        ];
         let matchCount = 0;
         let match: Immutable<StorableValue> | undefined = undefined;
-        for (const optionSchema of sortedOneOf) {
+        for (const optionSchema of prioritizeNonCellLogicalBranches(oneOf)) {
           if (ContextualFlowControl.isFalseSchema(optionSchema)) {
             continue;
           }
@@ -2113,7 +2217,7 @@ export class SchemaObjectTraverser<V extends StorableDatum>
             () => [
               "No matching oneOf",
               doc,
-              sortedOneOf,
+              oneOf,
               this.getDebugValue(doc),
             ],
           );
@@ -2124,7 +2228,7 @@ export class SchemaObjectTraverser<V extends StorableDatum>
           () => [
             "Multiple matching oneOf",
             doc,
-            sortedOneOf,
+            oneOf,
             this.getDebugValue(doc),
           ],
         );
@@ -2226,7 +2330,7 @@ export class SchemaObjectTraverser<V extends StorableDatum>
         return { error: new Error("Invalid type") };
       }
 
-      const newValue: Immutable<StorableValue>[] = [];
+      const newValue = new Array<Immutable<StorableValue>>(doc.value.length);
       // Our link is based on the last link in the chain and not the first.
       const newLink = link ?? getNormalizedLink(
         doc.address,
@@ -2241,14 +2345,15 @@ export class SchemaObjectTraverser<V extends StorableDatum>
       if (valid === TypeValidity.Unknown) {
         return { ok: this.objectCreator.createObject(newLink, undefined) };
       }
-      const entries = this.traverseArrayWithSchema(doc, schemaObj, newLink);
-      if (!Array.isArray(entries)) {
+      const validEntries = this.traverseArrayWithSchema(
+        doc,
+        schemaObj,
+        newValue,
+        newLink,
+      );
+      if (!validEntries) {
         return { error: new Error("Invalid array") };
       }
-      entries.forEach((item, i) => {
-        newValue[i] = item;
-      });
-      newValue.length = entries.length;
       return { ok: this.objectCreator.createObject(newLink, newValue) };
     } else if (isObject(doc.value)) {
       if (isPrimitiveCellLink(doc.value)) {
@@ -2273,12 +2378,14 @@ export class SchemaObjectTraverser<V extends StorableDatum>
         if (valid === TypeValidity.Unknown) {
           return { ok: this.objectCreator.createObject(newLink, undefined) };
         }
-        const entries = this.traverseObjectWithSchema(doc, schemaObj, newLink);
-        if (entries === undefined || entries === null) {
+        const validEntries = this.traverseObjectWithSchema(
+          doc,
+          schemaObj,
+          newValue,
+          newLink,
+        );
+        if (!validEntries) {
           return { error: new Error("Invalid object") };
-        }
-        for (const [k, v] of Object.entries(entries)) {
-          newValue[k] = v;
         }
         // TODO(@ubik2): We should be able to remove this cast when we make
         // our return types more correct (we can hold cells/functions).
@@ -2441,11 +2548,11 @@ export class SchemaObjectTraverser<V extends StorableDatum>
   private traverseArrayWithSchema(
     doc: IMemorySpaceValueAttestation,
     schema: JSONSchemaObj,
+    arrayObj: Immutable<StorableValue>[],
     _link?: NormalizedFullLink,
-  ): Immutable<StorableValue>[] | undefined {
+  ): boolean {
     this.traverseArrayCalls++;
     const docArray = doc.value as Immutable<StorableDatum>[];
-    const arrayObj = new Array<Immutable<StorableValue>>(docArray.length);
 
     // We use `every` here so if our input is a sparse array, so is our output.
     const valid = docArray.every((item, index) => {
@@ -2598,7 +2705,7 @@ export class SchemaObjectTraverser<V extends StorableDatum>
       }
       return true;
     });
-    return valid ? arrayObj : undefined;
+    return valid;
   }
 
   /**
@@ -2622,10 +2729,10 @@ export class SchemaObjectTraverser<V extends StorableDatum>
   private traverseObjectWithSchema(
     doc: IMemorySpaceValueAttestation,
     schema: JSONSchemaObj,
+    filteredObj: Record<string, Immutable<StorableValue>>,
     _link?: NormalizedFullLink,
-  ): Record<string, Immutable<StorableValue>> | undefined {
+  ): boolean {
     this.traverseObjectCalls++;
-    const filteredObj: Record<string, Immutable<StorableValue>> = {};
     for (const [propKey, propValue] of Object.entries(doc.value!)) {
       // We'll use marker schemas to detect some places where we want special
       // schema behavior
@@ -2744,12 +2851,12 @@ export class SchemaObjectTraverser<V extends StorableDatum>
               "with schema",
               schema,
             ]);
-            return undefined;
+            return false;
           }
         }
       }
     }
-    return filteredObj;
+    return true;
   }
 
   // This just has a schema, since the doc.address.path should match the
@@ -3002,6 +3109,21 @@ export function canBranchMatch(
   }
 
   return true;
+}
+
+function isMergeableAnyOfObjectSchema(
+  schema: JSONSchema,
+): schema is JSONSchemaObj {
+  if (!isObject(schema) || SchemaObjectTraverser.asCellOrStream(schema)) {
+    return false;
+  }
+  if (schema.type !== undefined) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (!types.includes("object")) return false;
+  }
+  return Object.keys(schema).every((key) =>
+    mergeableAnyOfObjectSchemaKeys.has(key)
+  );
 }
 
 /** Map JS typeof to JSON Schema type string, or null if unknown */

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -2097,6 +2097,54 @@ for (const canonicalHashing of [false, true]) {
         // string and null branches should be fast-rejected
         expect(traverser.anyOfFastRejects).toBeGreaterThanOrEqual(2);
       });
+
+      it("does not overmatch merged branches with distinct required keys", () => {
+        const store = new Map<string, Revision<State>>();
+        const type = "application/json" as const;
+        const docUri = "of:doc-required-anyof" as URI;
+        const docEntity = docUri as Entity;
+
+        const docValue = {};
+
+        const docRevision: Revision<State> = {
+          the: type,
+          of: docEntity,
+          is: { value: docValue },
+          cause: refer({ the: type, of: docEntity }),
+          since: 1,
+        };
+        store.set(`${docRevision.of}/${docRevision.the}`, docRevision);
+
+        const schema = {
+          anyOf: [
+            {
+              type: "object",
+              properties: { left: { type: "string" } },
+              required: ["left"],
+            },
+            {
+              type: "object",
+              properties: { right: { type: "string" } },
+              required: ["right"],
+            },
+          ],
+        } as JSONSchema;
+
+        const traverser = getTraverser(store, { path: ["value"], schema });
+
+        const { error } = traverser.traverse({
+          address: {
+            space: "did:null:null",
+            id: docUri,
+            type,
+            path: ["value"],
+          },
+          value: docValue,
+        });
+
+        expect(error).toBeDefined();
+        expect(traverser.anyOfFastRejects).toBe(2);
+      });
     });
 
     describe("anyOf fast-reject reactivity invariants (traverseCells)", () => {


### PR DESCRIPTION
## Summary
- memoize `ContextualFlowControl.schemaAtPath()` results by schema object and path
- cache logical branch ordering and merge compatible object `anyOf` branches for schema-backed traversal
- populate tracker-backed arrays and objects in place to avoid extra allocation and copy churn
- add a regression test covering merged `anyOf` branches with distinct required keys

## Performance
Measured against `origin/main` in a temporary worktree on the same machine (`Apple M3 Max`):
- `Cell complex - MentionablePiece graph (10 top-level, 20 linked each, 100x get)`
  - avg: `404.8ms -> 385.0ms` (`4.9%` faster)
  - max: `475.3ms -> 405.0ms` (`14.8%` lower)
- `Cell large - array with 1000 items (100x get)`
  - avg: `265.1ms -> 262.3ms` (`1.1%` faster)
  - max: `283.7ms -> 277.3ms` (`2.3%` lower)
- I also checked the dedicated `traverse-anyof` bench and a smaller schema-backed object `.get()` bench; those were neutral or noisy relative to `origin/main`, so I am not claiming them as wins here.

## Notes
- I investigated caching repeated schema-backed `.get()` results, but sampled pattern integration runs did not show reuse on the same cell+tx, so this PR stays focused on traversal hot paths instead.

## Testing
- `deno test --allow-env packages/runner/test/traverse.test.ts`
- `deno test --allow-env --allow-read --allow-ffi packages/runner/test/schema-basic.test.ts`
- `deno test --allow-env --allow-read --allow-ffi packages/runner/test/cell-hooks.test.ts`
- `deno bench packages/runner/test/traverse-anyof.bench.ts`
- `deno bench --allow-env --allow-read --allow-ffi --filter='MentionablePiece' packages/runner/test/cell.bench.ts`
- `deno bench --allow-env --allow-read --allow-ffi --filter='Cell large - array with 1000 items' packages/runner/test/cell.bench.ts`
