### PR TITLE
fix(ts-transformers): reject same-callback local reactive uses

### DIFF
--- a/packages/ts-transformers/src/transformers/capability-lowering.ts
+++ b/packages/ts-transformers/src/transformers/capability-lowering.ts
@@ -16,7 +16,6 @@ import { analyzeFunctionCapabilities } from "../policy/mod.ts";
 import { unwrapExpression } from "../utils/expression.ts";
 import {
   cloneKeyExpression,
-  getKnownComputedKeyExpression,
   isCommonToolsKeyExpression,
 } from "../utils/reactive-keys.ts";
 import {
@@ -31,6 +30,14 @@ import {
   createComputedCallForExpression,
   filterRelevantDataFlows,
 } from "./opaque-ref/helpers.ts";
+import {
+  addBindingTargetSymbols,
+  collectLocalOpaqueRootSymbols,
+  getOpaqueAccessInfo,
+  isOpaqueRootInfo,
+  isOpaqueSourceExpression,
+  isTopmostMemberAccess,
+} from "./opaque-roots.ts";
 import {
   assertValidComputeWrapCandidate,
   findPendingComputeWrapCandidate,
@@ -57,94 +64,6 @@ function isSelfPathSegment(
     (
       isCommonToolsKeyExpression(segment, context, "SELF")
     );
-}
-
-function getAccessInfo(
-  expr: ts.Expression,
-  context: TransformationContext,
-): {
-  root?: string;
-  rootIdentifier?: ts.Identifier;
-  path: PathSegment[];
-  dynamic: boolean;
-} {
-  const path: PathSegment[] = [];
-  let current: ts.Expression = expr;
-  let dynamic = false;
-
-  while (true) {
-    if (ts.isParenthesizedExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isAsExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isTypeAssertionExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isSatisfiesExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isNonNullExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isPartiallyEmittedExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-
-    if (ts.isPropertyAccessExpression(current)) {
-      path.unshift(current.name.text);
-      current = current.expression;
-      continue;
-    }
-
-    if (ts.isElementAccessExpression(current)) {
-      const arg = current.argumentExpression;
-      if (
-        arg &&
-        (ts.isStringLiteral(arg) ||
-          ts.isNumericLiteral(arg) ||
-          ts.isNoSubstitutionTemplateLiteral(arg))
-      ) {
-        path.unshift(arg.text);
-      } else if (arg) {
-        const knownKeyExpression = getKnownComputedKeyExpression(arg, context);
-        if (knownKeyExpression) {
-          path.unshift(knownKeyExpression);
-        } else {
-          dynamic = true;
-        }
-      } else {
-        dynamic = true;
-      }
-      current = current.expression;
-      continue;
-    }
-
-    break;
-  }
-
-  if (ts.isIdentifier(current)) {
-    return { root: current.text, rootIdentifier: current, path, dynamic };
-  }
-
-  return { path, dynamic };
-}
-
-function isTopmostMemberAccess(node: ts.Node): boolean {
-  const parent = node.parent;
-  if (!parent) return true;
-  return !(
-    (ts.isPropertyAccessExpression(parent) ||
-      ts.isElementAccessExpression(parent)) &&
-    parent.expression === node
-  );
 }
 
 function registerReplacementType(
@@ -229,96 +148,6 @@ function reportComputationError(
     message,
     node,
   });
-}
-
-function isOpaqueOriginCall(
-  expression: ts.CallExpression,
-  context: TransformationContext,
-): boolean {
-  const kind = detectCallKind(expression, context.checker);
-  if (!kind) return false;
-
-  switch (kind.kind) {
-    case "builder":
-    case "cell-factory":
-    case "cell-for":
-    case "derive":
-    case "wish":
-    case "generate-object":
-    case "pattern-tool":
-      return true;
-    default:
-      return false;
-  }
-}
-
-function isOpaqueSourceExpression(
-  expression: ts.Expression,
-  opaqueRoots: ReadonlySet<string>,
-  opaqueRootSymbols: ReadonlySet<ts.Symbol>,
-  context: TransformationContext,
-): boolean {
-  const current = unwrapExpression(expression);
-  const info = getAccessInfo(current, context);
-  if (isOpaqueRootInfo(info, opaqueRoots, opaqueRootSymbols, context)) {
-    return true;
-  }
-
-  if (ts.isCallExpression(current)) {
-    if (isOpaqueOriginCall(current, context)) {
-      return true;
-    }
-
-    if (ts.isPropertyAccessExpression(current.expression)) {
-      const methodName = current.expression.name.text;
-      if (methodName === "key" || methodName === "get") {
-        return isOpaqueSourceExpression(
-          current.expression.expression,
-          opaqueRoots,
-          opaqueRootSymbols,
-          context,
-        );
-      }
-    }
-  }
-
-  return false;
-}
-
-function isOpaqueRootInfo(
-  info: ReturnType<typeof getAccessInfo>,
-  opaqueRoots: ReadonlySet<string>,
-  opaqueRootSymbols: ReadonlySet<ts.Symbol>,
-  context: TransformationContext,
-): boolean {
-  const rootIdentifier = info.rootIdentifier;
-  if (rootIdentifier) {
-    const symbol = context.checker.getSymbolAtLocation(rootIdentifier);
-    if (symbol) {
-      if (opaqueRootSymbols.has(symbol)) return true;
-    }
-  }
-
-  return !!info.root && opaqueRoots.has(info.root);
-}
-
-function addBindingTargetSymbols(
-  name: ts.BindingName,
-  bucket: Set<ts.Symbol>,
-  checker: ts.TypeChecker,
-): void {
-  if (ts.isIdentifier(name)) {
-    const symbol = checker.getSymbolAtLocation(name);
-    if (symbol) {
-      bucket.add(symbol);
-    }
-    return;
-  }
-
-  for (const element of name.elements) {
-    if (ts.isOmittedExpression(element)) continue;
-    addBindingTargetSymbols(element.name, bucket, checker);
-  }
 }
 
 function reportOptionalError(
@@ -418,7 +247,7 @@ function rewritePatternBody(
           ts.isElementAccessExpression(node)) &&
         isTopmostMemberAccess(node)
       ) {
-        const info = getAccessInfo(node, context);
+        const info = getOpaqueAccessInfo(node, context);
         if (
           info.dynamic &&
           isOpaqueRootInfo(
@@ -560,7 +389,7 @@ function rewritePatternBody(
         ts.isElementAccessExpression(visited)) &&
       isTopmostMemberAccess(visited)
     ) {
-      const info = getAccessInfo(visited, context);
+      const info = getOpaqueAccessInfo(visited, context);
       if (
         !info.root ||
         !isOpaqueRootInfo(
@@ -667,7 +496,7 @@ function rewritePatternBody(
 
     if (ts.isCallExpression(visited)) {
       if (visited.questionDotToken) {
-        const info = getAccessInfo(visited.expression, context);
+        const info = getOpaqueAccessInfo(visited.expression, context);
         if (
           isOpaqueRootInfo(
             info,
@@ -692,7 +521,7 @@ function rewritePatternBody(
       ) {
         const firstArg = visited.arguments[0];
         if (firstArg) {
-          const info = getAccessInfo(firstArg, context);
+          const info = getOpaqueAccessInfo(firstArg, context);
           if (
             isOpaqueRootInfo(
               info,
@@ -718,7 +547,7 @@ function rewritePatternBody(
       ) {
         const firstArg = visited.arguments[0];
         if (firstArg) {
-          const info = getAccessInfo(firstArg, context);
+          const info = getOpaqueAccessInfo(firstArg, context);
           if (
             isOpaqueRootInfo(
               info,
@@ -738,7 +567,7 @@ function rewritePatternBody(
     }
 
     if (ts.isSpreadElement(visited) || ts.isSpreadAssignment(visited)) {
-      const info = getAccessInfo(visited.expression, context);
+      const info = getOpaqueAccessInfo(visited.expression, context);
       if (
         isOpaqueRootInfo(
           info,
@@ -756,7 +585,7 @@ function rewritePatternBody(
     }
 
     if (ts.isForInStatement(visited)) {
-      const info = getAccessInfo(visited.expression, context);
+      const info = getOpaqueAccessInfo(visited.expression, context);
       if (
         isOpaqueRootInfo(
           info,
@@ -837,26 +666,10 @@ function rewriteDeriveCallbackBodies(
     // by rewritePatternBody's own setBindingOpaqueState as it walks declarations.
     // We walk the full AST (stopping at nested function boundaries) so
     // declarations inside if/else/loops are also discovered.
-    const localOpaqueRootSymbols = new Set<ts.Symbol>();
-    const scanForOpaqueDecls = (node: ts.Node): void => {
-      if (ts.isFunctionLike(node)) return; // don't cross function boundaries
-      if (
-        ts.isVariableDeclaration(node) &&
-        node.initializer &&
-        ts.isIdentifier(node.name) &&
-        isOpaqueSourceExpression(
-          node.initializer,
-          new Set(),
-          localOpaqueRootSymbols,
-          context,
-        )
-      ) {
-        const sym = context.checker.getSymbolAtLocation(node.name);
-        if (sym) localOpaqueRootSymbols.add(sym);
-      }
-      ts.forEachChild(node, scanForOpaqueDecls);
-    };
-    scanForOpaqueDecls(processedBody);
+    const localOpaqueRootSymbols = collectLocalOpaqueRootSymbols(
+      processedBody,
+      context,
+    );
 
     // Rewrite property accesses on local OpaqueRef variables.
     // Pass empty name set — rewritePatternBody will populate activeOpaqueRoots

--- a/packages/ts-transformers/src/transformers/opaque-roots.ts
+++ b/packages/ts-transformers/src/transformers/opaque-roots.ts
@@ -1,0 +1,219 @@
+import ts from "typescript";
+
+import { detectCallKind } from "../ast/mod.ts";
+import type { TransformationContext } from "../core/mod.ts";
+import { unwrapExpression } from "../utils/expression.ts";
+import { getKnownComputedKeyExpression } from "../utils/reactive-keys.ts";
+import type { PathSegment } from "./destructuring-lowering.ts";
+
+export interface OpaqueAccessInfo {
+  root?: string;
+  rootIdentifier?: ts.Identifier;
+  path: PathSegment[];
+  dynamic: boolean;
+}
+
+export function getOpaqueAccessInfo(
+  expr: ts.Expression,
+  context: TransformationContext,
+): OpaqueAccessInfo {
+  const path: PathSegment[] = [];
+  let current: ts.Expression = expr;
+  let dynamic = false;
+
+  while (true) {
+    if (ts.isParenthesizedExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+    if (ts.isAsExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+    if (ts.isTypeAssertionExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+    if (ts.isSatisfiesExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+    if (ts.isNonNullExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+    if (ts.isPartiallyEmittedExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+
+    if (ts.isPropertyAccessExpression(current)) {
+      path.unshift(current.name.text);
+      current = current.expression;
+      continue;
+    }
+
+    if (ts.isElementAccessExpression(current)) {
+      const arg = current.argumentExpression;
+      if (
+        arg &&
+        (ts.isStringLiteral(arg) ||
+          ts.isNumericLiteral(arg) ||
+          ts.isNoSubstitutionTemplateLiteral(arg))
+      ) {
+        path.unshift(arg.text);
+      } else if (arg) {
+        const knownKeyExpression = getKnownComputedKeyExpression(arg, context);
+        if (knownKeyExpression) {
+          path.unshift(knownKeyExpression);
+        } else {
+          dynamic = true;
+        }
+      } else {
+        dynamic = true;
+      }
+      current = current.expression;
+      continue;
+    }
+
+    break;
+  }
+
+  if (ts.isIdentifier(current)) {
+    return { root: current.text, rootIdentifier: current, path, dynamic };
+  }
+
+  return { path, dynamic };
+}
+
+export function isTopmostMemberAccess(node: ts.Node): boolean {
+  const parent = node.parent;
+  if (!parent) return true;
+  return !(
+    (ts.isPropertyAccessExpression(parent) ||
+      ts.isElementAccessExpression(parent)) &&
+    parent.expression === node
+  );
+}
+
+export function isOpaqueOriginCall(
+  expression: ts.CallExpression,
+  context: TransformationContext,
+): boolean {
+  const kind = detectCallKind(expression, context.checker);
+  if (!kind) return false;
+
+  switch (kind.kind) {
+    case "builder":
+    case "cell-factory":
+    case "cell-for":
+    case "derive":
+    case "wish":
+    case "generate-object":
+    case "pattern-tool":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function isOpaqueRootInfo(
+  info: OpaqueAccessInfo,
+  opaqueRoots: ReadonlySet<string>,
+  opaqueRootSymbols: ReadonlySet<ts.Symbol>,
+  context: TransformationContext,
+): boolean {
+  const rootIdentifier = info.rootIdentifier;
+  if (rootIdentifier) {
+    const symbol = context.checker.getSymbolAtLocation(rootIdentifier);
+    if (symbol && opaqueRootSymbols.has(symbol)) {
+      return true;
+    }
+  }
+
+  return !!info.root && opaqueRoots.has(info.root);
+}
+
+export function isOpaqueSourceExpression(
+  expression: ts.Expression,
+  opaqueRoots: ReadonlySet<string>,
+  opaqueRootSymbols: ReadonlySet<ts.Symbol>,
+  context: TransformationContext,
+): boolean {
+  const current = unwrapExpression(expression);
+  const info = getOpaqueAccessInfo(current, context);
+  if (isOpaqueRootInfo(info, opaqueRoots, opaqueRootSymbols, context)) {
+    return true;
+  }
+
+  if (ts.isCallExpression(current)) {
+    if (isOpaqueOriginCall(current, context)) {
+      return true;
+    }
+
+    if (ts.isPropertyAccessExpression(current.expression)) {
+      const methodName = current.expression.name.text;
+      if (methodName === "key" || methodName === "get") {
+        return isOpaqueSourceExpression(
+          current.expression.expression,
+          opaqueRoots,
+          opaqueRootSymbols,
+          context,
+        );
+      }
+    }
+  }
+
+  return false;
+}
+
+export function addBindingTargetSymbols(
+  name: ts.BindingName,
+  bucket: Set<ts.Symbol>,
+  checker: ts.TypeChecker,
+): void {
+  if (ts.isIdentifier(name)) {
+    const symbol = checker.getSymbolAtLocation(name);
+    if (symbol) {
+      bucket.add(symbol);
+    }
+    return;
+  }
+
+  for (const element of name.elements) {
+    if (ts.isOmittedExpression(element)) continue;
+    addBindingTargetSymbols(element.name, bucket, checker);
+  }
+}
+
+export function collectLocalOpaqueRootSymbols(
+  body: ts.Node,
+  context: TransformationContext,
+): Set<ts.Symbol> {
+  const localOpaqueRootSymbols = new Set<ts.Symbol>();
+  const scan = (node: ts.Node): void => {
+    if (ts.isFunctionLike(node)) return;
+
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.initializer &&
+      isOpaqueSourceExpression(
+        node.initializer,
+        new Set(),
+        localOpaqueRootSymbols,
+        context,
+      )
+    ) {
+      addBindingTargetSymbols(
+        node.name,
+        localOpaqueRootSymbols,
+        context.checker,
+      );
+    }
+
+    ts.forEachChild(node, scan);
+  };
+
+  scan(body);
+  return localOpaqueRootSymbols;
+}

--- a/packages/ts-transformers/src/transformers/pattern-context-validation.ts
+++ b/packages/ts-transformers/src/transformers/pattern-context-validation.ts
@@ -16,6 +16,9 @@
  *   - lift()
  *   - handler()
  *   - JSX expressions (handled by OpaqueRefJSXTransformer)
+ * - Local values created by computed()/derive() inside the current
+ *   computed()/derive() callback remain reactive and cannot be used as plain
+ *   values until a nested computed()/derive() consumes them.
  *
  * - Function creation is NOT allowed in pattern context (must be at module scope)
  * - lift() and handler() must be defined at module scope, not inside patterns
@@ -27,6 +30,8 @@
  * - Function creation in pattern context: ERROR (move to module scope)
  * - lift()/handler() inside pattern: ERROR (move to module scope)
  * - .map() on fallback expression (x ?? [] or x || []): ERROR (use direct property access)
+ * - Local computed()/derive() aliases used as plain values in the same
+ *   callback: ERROR (use a nested computed()/derive())
  */
 import ts from "typescript";
 import { TransformationContext, Transformer } from "../core/mod.ts";
@@ -39,6 +44,13 @@ import {
   isStandaloneFunctionDefinition,
 } from "../ast/mod.ts";
 import { isOpaqueRefType } from "./opaque-ref/opaque-ref.ts";
+import {
+  collectLocalOpaqueRootSymbols,
+  isOpaqueSourceExpression,
+  isTopmostMemberAccess,
+} from "./opaque-roots.ts";
+
+const EMPTY_OPAQUE_ROOTS = new Set<string>();
 
 export class PatternContextValidationTransformer extends Transformer {
   transform(context: TransformationContext): ts.SourceFile {
@@ -62,6 +74,13 @@ export class PatternContextValidationTransformer extends Transformer {
         // Check for reactive operations in standalone functions
         if (isStandaloneFunctionDefinition(node)) {
           this.validateStandaloneFunction(node, context, checker);
+        }
+
+        if (
+          (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) &&
+          this.isComputedLikeCallback(node, checker)
+        ) {
+          this.validateLocalReactiveAliasUsage(node, context);
         }
       }
 
@@ -238,6 +257,135 @@ export class PatternContextValidationTransformer extends Transformer {
     return result;
   }
 
+  private validateLocalReactiveAliasUsage(
+    func: ts.ArrowFunction | ts.FunctionExpression,
+    context: TransformationContext,
+  ): void {
+    const localOpaqueRootSymbols = collectLocalOpaqueRootSymbols(
+      func.body,
+      context,
+    );
+    if (localOpaqueRootSymbols.size === 0) {
+      return;
+    }
+
+    const diagnosticsSeen = new Set<number>();
+
+    const findProblematicUse = (
+      expression: ts.Expression,
+    ): ts.Expression | undefined => {
+      let culprit: ts.Expression | undefined;
+
+      const visit = (node: ts.Node): void => {
+        if (culprit) return;
+        if (node !== expression && ts.isFunctionLike(node)) return;
+
+        if (
+          ts.isCallExpression(node) &&
+          isOpaqueSourceExpression(
+            node,
+            EMPTY_OPAQUE_ROOTS,
+            localOpaqueRootSymbols,
+            context,
+          )
+        ) {
+          culprit = node;
+          return;
+        }
+
+        if (
+          (ts.isPropertyAccessExpression(node) ||
+            ts.isElementAccessExpression(node)) &&
+          isTopmostMemberAccess(node) &&
+          isOpaqueSourceExpression(
+            node,
+            EMPTY_OPAQUE_ROOTS,
+            localOpaqueRootSymbols,
+            context,
+          )
+        ) {
+          culprit = node;
+          return;
+        }
+
+        if (
+          ts.isIdentifier(node) &&
+          !this.isMemberAccessBase(node) &&
+          isOpaqueSourceExpression(
+            node,
+            EMPTY_OPAQUE_ROOTS,
+            localOpaqueRootSymbols,
+            context,
+          )
+        ) {
+          culprit = node;
+          return;
+        }
+
+        ts.forEachChild(node, visit);
+      };
+
+      visit(expression);
+      return culprit;
+    };
+
+    const report = (culprit: ts.Expression): void => {
+      const key = culprit.getStart(context.sourceFile);
+      if (diagnosticsSeen.has(key)) return;
+      diagnosticsSeen.add(key);
+
+      context.reportDiagnostic({
+        severity: "error",
+        type: "compute-context:local-reactive-use",
+        message: `Reactive value '${culprit.getText()}' is created in this ` +
+          `computed()/derive() callback and cannot be used as a plain value ` +
+          `here. Move this use into a nested computed(() => ...) or ` +
+          `derive(() => ...) callback.`,
+        node: culprit,
+      });
+    };
+
+    const checkExpression = (expression: ts.Expression | undefined): void => {
+      if (!expression) return;
+      const culprit = findProblematicUse(expression);
+      if (culprit) {
+        report(culprit);
+      }
+    };
+
+    const visitBody = (node: ts.Node): void => {
+      if (node !== func.body && ts.isFunctionLike(node)) {
+        return;
+      }
+
+      if (ts.isIfStatement(node)) {
+        checkExpression(node.expression);
+      } else if (ts.isWhileStatement(node) || ts.isDoStatement(node)) {
+        checkExpression(node.expression);
+      } else if (ts.isForStatement(node)) {
+        checkExpression(node.condition);
+      } else if (ts.isSwitchStatement(node)) {
+        checkExpression(node.expression);
+      } else if (this.isComputationExpression(node)) {
+        checkExpression(node as ts.Expression);
+      }
+
+      ts.forEachChild(node, visitBody);
+    };
+
+    visitBody(func.body);
+  }
+
+  private isMemberAccessBase(node: ts.Identifier): boolean {
+    const parent = node.parent;
+    return !!parent &&
+      (
+        (ts.isPropertyAccessExpression(parent) ||
+          ts.isElementAccessExpression(parent)) &&
+        parent.expression === node
+      );
+  }
+
   /**
    * Validates that functions are not created directly in pattern context.
    * Functions inside safe wrappers (computed, action, derive, lift, handler)
@@ -313,6 +461,21 @@ export class PatternContextValidationTransformer extends Transformer {
     }
 
     return false;
+  }
+
+  private isComputedLikeCallback(
+    node: ts.ArrowFunction | ts.FunctionExpression,
+    checker: ts.TypeChecker,
+  ): boolean {
+    const parent = node.parent;
+    if (!parent || !ts.isCallExpression(parent)) return false;
+    if (!parent.arguments.includes(node)) return false;
+
+    const callKind = detectCallKind(parent, checker);
+    if (!callKind) return false;
+
+    return callKind.kind === "derive" ||
+      (callKind.kind === "builder" && callKind.builderName === "computed");
   }
 
   /**

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -478,6 +478,104 @@ Deno.test("Pattern Context Validation - Safe Wrappers", async (t) => {
   );
 });
 
+Deno.test("Computed/derive local reactive alias validation", async (t) => {
+  await t.step(
+    "errors on truthiness checks of locally created computed results",
+    async () => {
+      const source = `/// <cts-enable />
+      import { computed, pattern } from "commontools";
+
+      export default pattern(() => {
+        const outer = computed(() => {
+          const foo = computed(() => true);
+          if (foo) {
+            return 1;
+          }
+          return 0;
+        });
+
+        return outer;
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONTOOLS_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertEquals(errors[0]!.type, "compute-context:local-reactive-use");
+    },
+  );
+
+  await t.step(
+    "errors on arithmetic using a locally created computed result",
+    async () => {
+      const source = `/// <cts-enable />
+      import { computed, pattern } from "commontools";
+
+      export default pattern(() => {
+        const outer = computed(() => {
+          const foo = computed(() => 21);
+          return foo * 2;
+        });
+
+        return outer;
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONTOOLS_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertEquals(errors[0]!.type, "compute-context:local-reactive-use");
+    },
+  );
+
+  await t.step(
+    "allows nested computed callbacks to use locally created computed results",
+    async () => {
+      const source = `/// <cts-enable />
+      import { computed, pattern } from "commontools";
+
+      export default pattern(() => {
+        const outer = computed(() => {
+          const foo = computed(() => 21);
+          const doubled = computed(() => foo * 2);
+          return doubled;
+        });
+
+        return outer;
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONTOOLS_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(errors.length, 0);
+    },
+  );
+
+  await t.step(
+    "allows later computed callbacks to use outer computed results",
+    async () => {
+      const source = `/// <cts-enable />
+      import { computed, pattern } from "commontools";
+
+      export default pattern(() => {
+        const foo = computed(() => 21);
+        const outer = computed(() => foo * 2);
+
+        return outer;
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONTOOLS_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(errors.length, 0);
+    },
+  );
+});
+
 Deno.test("Diagnostic output format", async (t) => {
   await t.step("includes source location information", async () => {
     const source = `


### PR DESCRIPTION
## Summary
- extract the local opaque-root detection used by capability lowering into a shared helper
- error when a computed/derive callback uses a locally-created reactive alias as a plain value in the same callback
- keep nested computed/derive callbacks and existing local property-access rewriting working

## Testing
- deno fmt packages/ts-transformers/src/transformers/opaque-roots.ts packages/ts-transformers/src/transformers/capability-lowering.ts packages/ts-transformers/src/transformers/pattern-context-validation.ts packages/ts-transformers/test/validation.test.ts
- deno lint packages/ts-transformers/src/transformers/opaque-roots.ts packages/ts-transformers/src/transformers/capability-lowering.ts packages/ts-transformers/src/transformers/pattern-context-validation.ts packages/ts-transformers/test/validation.test.ts
- deno task check
- deno test --allow-read --allow-write --allow-env test/validation.test.ts
- env FIXTURE=computed-in-computed-property-access deno test --allow-read --allow-write --allow-env test/fixture-based.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects using locally created reactive aliases as plain values inside the same `computed()`/`derive()` callback, preventing invalid reads. Centralizes opaque root analysis into a shared helper and updates capability lowering to use it.

- **Bug Fixes**
  - Error when a `computed()`/`derive()` callback uses its own locally created reactive alias as a plain value (`compute-context:local-reactive-use`).
  - Nested `computed()`/`derive()` calls can still consume those aliases.
  - Preserves existing local property-access rewriting.

- **Refactors**
  - Extracted opaque root analysis to `packages/ts-transformers/src/transformers/opaque-roots.ts` (e.g., `getOpaqueAccessInfo`, `isTopmostMemberAccess`, `isOpaqueSourceExpression`).
  - Updated `capability-lowering` to use shared helpers and added `collectLocalOpaqueRootSymbols` for callback-scoped scans.

<sup>Written for commit e81d7967d4fe0c8386eda2fa1eb91bd306ecf5e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

