### PR TITLE
Add unit test for combination of unknown with object with properties

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1650,7 +1650,7 @@ export type FetchDataFunction = <T>(
     options?: FetchOptions;
     result?: T;
   }>,
-) => OpaqueRef<{ pending: boolean; result: T | undefined; error?: any }>;
+) => OpaqueRef<{ pending: boolean; result: T; error?: any }>;
 
 export type FetchProgramFunction = (
   params: Opaque<{ url: string }>,
@@ -1669,7 +1669,7 @@ export type StreamDataFunction = <T>(
     options?: FetchOptions;
     result?: T;
   }>,
-) => OpaqueRef<{ pending: boolean; result: T | undefined; error?: any }>;
+) => OpaqueRef<{ pending: boolean; result: T; error?: any }>;
 
 export type CompileAndRunFunction = <T = any, S = any>(
   params: Opaque<BuiltInCompileAndRunParams<T>>,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added two unit tests to validate `anyOf` behavior when combining `unknown` with an object schema, ensuring object properties are preserved regardless of option order.

Tests live in `packages/runner/test/schema-anyof.test.ts` and cover both unknown-first and object-first cases.

<sup>Written for commit ded6f00e96c6b3355cff40de6a11517bf370af10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

