### PR TITLE
docs: point component references to catalog.tsx

### DIFF
--- a/.agents/skills/pattern-dev/SKILL.md
+++ b/.agents/skills/pattern-dev/SKILL.md
@@ -223,5 +223,5 @@ Phase skills consult as needed:
 - Types: `docs/common/concepts/types-and-schemas/`
 - Actions/handlers: `docs/common/concepts/action.md`, `docs/common/concepts/handler.md`
 - Testing: `docs/common/workflows/pattern-testing.md`
-- Components: `docs/common/components/COMPONENTS.md`
+- Components: `packages/patterns/catalog/catalog.tsx` — the authoritative, type-checked component catalog. Story files in `packages/patterns/catalog/stories/` show live usage for each component. Also see `docs/common/components/COMPONENTS.md` for narrative docs.
 - Debugging: `docs/development/debugging/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,10 @@ If you are developing patterns, use Claude Skills (pattern-dev) to do the work.
 **Start here:**
 
 - `docs/common/INTRODUCTION.md` - Overview of the pattern system
-- `docs/common/components/COMPONENTS.md` - UI component reference with
+- `packages/patterns/catalog/catalog.tsx` - Authoritative, type-checked
+  component catalog; story files in `packages/patterns/catalog/stories/` show
+  live usage for each component
+- `docs/common/components/COMPONENTS.md` - UI component narrative reference with
   bidirectional binding and event handling
 
 **Core concepts:**

--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -2,6 +2,8 @@
 
 # UI Components Reference
 
+> **Living documentation:** [`packages/patterns/catalog/catalog.tsx`](../../../packages/patterns/catalog/catalog.tsx) is the authoritative, type-checked component catalog. Each component has a story file under [`packages/patterns/catalog/stories/`](../../../packages/patterns/catalog/stories/) showing usage. Refer to those files for the most accurate, up-to-date examples.
+
 CommonTools UI components with bidirectional binding support.
 
 ## Bidirectional Binding


### PR DESCRIPTION
## Summary

- Adds `packages/patterns/catalog/catalog.tsx` to `AGENTS.md` as the authoritative, type-checked component catalog
- Adds a callout at the top of `docs/common/components/COMPONENTS.md` pointing to catalog.tsx and its stories/
- Updates the pattern-dev skill's Documentation section to reference catalog.tsx first

Closes CT-1335

🤖 Generated with [Claude Code](https://claude.com/claude-code)