### PR TITLE
chore(runner): refactor runner internals

### DIFF
--- a/packages/runner/src/runner-utils.ts
+++ b/packages/runner/src/runner-utils.ts
@@ -1,13 +1,70 @@
 import { type FabricValue } from "@commonfabric/data-model/fabric-value";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { isRecord, type Mutable } from "@commonfabric/utils/types";
-import { isOpaqueRef, type JSONSchema } from "./builder/types.ts";
+import {
+  isModule,
+  isOpaqueRef,
+  type JSONSchema,
+  type Module,
+  type Pattern,
+} from "./builder/types.ts";
 import { isCellLink } from "./link-utils.ts";
 import { LINK_V1_TAG, type SigilLink } from "./sigil-types.ts";
+
+export function setRunnableName<T extends object & { src?: string }>(
+  target: T,
+  name: string,
+  options: { setSrc?: boolean } = {},
+): void {
+  Object.defineProperty(target, "name", {
+    value: name,
+    configurable: true,
+  });
+
+  if (options.setSrc) {
+    target.src = name;
+  }
+}
+
+export function sanitizeDebugLabel(label?: string): string | undefined {
+  if (!label) return undefined;
+  return label.replace(/^async\s+/, "").trim() || undefined;
+}
 
 export function getSpellLink(patternId: string): SigilLink {
   const id = hashOf({ causal: { patternId, type: "pattern" } }).toJSON()["/"];
   return { "/": { [LINK_V1_TAG]: { id: `of:${id}` } } };
+}
+
+export function describePatternOrModule(
+  patternOrModule: Pattern | Module | undefined,
+): string {
+  if (!patternOrModule) return "undefined";
+  if (isModule(patternOrModule)) {
+    if (
+      patternOrModule.type === "ref" &&
+      typeof patternOrModule.implementation === "string"
+    ) {
+      return `module:ref:${patternOrModule.implementation}`;
+    }
+
+    if (typeof patternOrModule.implementation === "function") {
+      const impl = patternOrModule.implementation as {
+        debugName?: string;
+        src?: string;
+        name?: string;
+      };
+      const name = sanitizeDebugLabel(impl.debugName) ??
+        sanitizeDebugLabel(impl.src) ??
+        sanitizeDebugLabel(impl.name) ??
+        "anonymous";
+      return `module:${patternOrModule.type}:${name}`;
+    }
+
+    return `module:${patternOrModule.type}`;
+  }
+
+  return `pattern:nodes=${patternOrModule.nodes.length}`;
 }
 
 /**

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -63,9 +63,12 @@ import "./builtins/index.ts";
 import { isCellResult } from "./query-result-proxy.ts";
 import {
   cellAwareDeepCopy,
+  describePatternOrModule,
   extractDefaultValues,
   getSpellLink,
   mergeObjects,
+  sanitizeDebugLabel,
+  setRunnableName,
   validateAndCheckOpaqueRefs,
 } from "./runner-utils.ts";
 import { setVerifiedFunctionRegistrar } from "./sandbox/function-hardening.ts";
@@ -126,21 +129,6 @@ type JavaScriptNodeContext = BoundNodeIO & {
   name: string | undefined;
   verifiedLoadId: string | undefined;
 };
-
-function setRunnableName<T extends object & { src?: string }>(
-  target: T,
-  name: string,
-  options: { setSrc?: boolean } = {},
-): void {
-  Object.defineProperty(target, "name", {
-    value: name,
-    configurable: true,
-  });
-
-  if (options.setSrc) {
-    target.src = name;
-  }
-}
 
 export class Runner {
   readonly cancels = new Map<`${MemorySpace}/${URI}`, Cancel>();
@@ -2329,44 +2317,8 @@ export class Runner {
   }
 }
 
-function sanitizeDebugLabel(label?: string): string | undefined {
-  if (!label) return undefined;
-  return label.replace(/^async\s+/, "").trim() || undefined;
-}
-
 function getTxDebugActionId(
   tx?: IExtendedStorageTransaction,
 ): string | undefined {
   return tx ? (tx.tx as { debugActionId?: string }).debugActionId : undefined;
-}
-
-function describePatternOrModule(
-  patternOrModule: Pattern | Module | undefined,
-): string {
-  if (!patternOrModule) return "undefined";
-  if (isModule(patternOrModule)) {
-    if (
-      patternOrModule.type === "ref" &&
-      typeof patternOrModule.implementation === "string"
-    ) {
-      return `module:ref:${patternOrModule.implementation}`;
-    }
-
-    if (typeof patternOrModule.implementation === "function") {
-      const impl = patternOrModule.implementation as {
-        debugName?: string;
-        src?: string;
-        name?: string;
-      };
-      const name = sanitizeDebugLabel(impl.debugName) ??
-        sanitizeDebugLabel(impl.src) ??
-        sanitizeDebugLabel(impl.name) ??
-        "anonymous";
-      return `module:${patternOrModule.type}:${name}`;
-    }
-
-    return `module:${patternOrModule.type}`;
-  }
-
-  return `pattern:nodes=${patternOrModule.nodes.length}`;
 }


### PR DESCRIPTION
## Summary
- split large runner helpers into smaller private methods for setup/start and JavaScript node execution paths
- move pure runner utility exports into `packages/runner/src/runner-utils.ts` and re-export them from `runner.ts`
- keep runtime behavior unchanged while reducing duplication and tightening internal responsibilities

## Testing
- deno check packages/runner/src/runner.ts
- deno test -A packages/runner/test/runner.test.ts packages/runner/test/action-result-validation.test.ts packages/runner/test/patterns-derive-return-pattern.test.ts packages/runner/test/ensure-piece-running.test.ts
- deno task test
- deno task integration

## Perf
This seems just noisy:

NEW_PERF_BASELINE: job: Package Integration Tests = 150s
NEW_PERF_BASELINE: step: runtime-client integration = 40s
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/battleship/multiplayer/room.test.tsx = 24s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored runner internals to break setup and JavaScript execution into focused helpers, extracted debug helpers, and moved pure utilities to `packages/runner/src/runner-utils.ts`. Runtime behavior and public API remain unchanged.

- **Refactors**
  - Moved helpers (`getSpellLink`, `validateAndCheckOpaqueRefs`, `cellAwareDeepCopy`, `extractDefaultValues`, `mergeObjects`) to `packages/runner/src/runner-utils.ts`; re-exported common ones from `runner.ts`.
  - Extracted debug helpers (`sanitizeDebugLabel`, `describePatternOrModule`) and applied `setRunnableName` to actions, handlers, and raw nodes for clearer logs and scheduler labels.
  - Split setup into small methods (process cell creation/reuse, pattern resolve/register, argument merge with schema defaults, result projection, materializer wiring).
  - Factored JS node execution into cohesive helpers (IO binding, function resolution/caching, stream handler vs. action paths, input validation/flags, dependency population, error framing, and result writing/sub-pattern handling).

- **Bug Fixes**
  - Fixed runner lint issues post-refactor.
  - Fixed typecheck helper typing.

<sup>Written for commit 1b202dd70a895be7ceebd8a2d6d6dc322d478462. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



