### PR TITLE
docs(ts-transformers): sync specs with current behavior

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -217,9 +217,9 @@ Guards that skip validation:
 Diagnostics:
 
 - **Error** `schema:unknown-type-access`
-  - parameter is typed as `unknown`/`any` and the code accesses properties, OR
-    one or more accessed property heads resolve to `unknown`-typed members on
-    an otherwise concrete type
+  - parameter is typed as `unknown` and the code accesses properties, OR one or
+    more accessed property heads resolve to `unknown`-typed members on an
+    otherwise concrete type
   - message lists the accessed property heads and instructs the author to
     replace `unknown` with a concrete type
 - **Error** `schema:path-not-in-type`

--- a/docs/specs/ts-transformer/ts_transformers_design_deltas.md
+++ b/docs/specs/ts-transformer/ts_transformers_design_deltas.md
@@ -265,8 +265,10 @@ contract support).
 - When capability analysis detects property reads/writes and schema shrinking
   narrows the declared type, validate that all accessed top-level property
   heads are actually present in the result.
-- If the declared type is `unknown`/`any`, every property access is
-  unresolvable → hard error.
+- If the declared type is `unknown`, every property access is unresolvable →
+  hard error.
+- If the declared type is `any`, path validation is skipped because runtime
+  fetch is already full-shape.
 - If the declared type is concrete but missing accessed properties → hard error
   naming the missing paths.
 
@@ -307,7 +309,7 @@ contract support).
 
 **Diagnostic codes:**
 
-- `schema:unknown-type-access` — parameter typed `unknown`/`any` with property
+- `schema:unknown-type-access` — parameter typed `unknown` with property
   accesses, or concrete parameter with accessed `unknown`-typed property heads
 - `schema:path-not-in-type` — concrete type missing accessed properties
 

--- a/docs/specs/ts-transformer/ts_transformers_goals.md
+++ b/docs/specs/ts-transformer/ts_transformers_goals.md
@@ -209,9 +209,10 @@ inference creates unusable reactive types (for example `Cell.of([])` inferring
 
 When capability analysis detects that a callback reads specific properties, and
 schema shrinking attempts to narrow the declared type to those paths, the result
-must be validated. If the declared type is `unknown`/`any` (no structure) or is
+must be validated. If the declared type is `unknown` (no structure), or is
 concrete but missing accessed properties, the transformer must produce a hard
-error so authors fix their types before the pattern compiles. Silent fallback to
+error so authors fix their types before the pattern compiles. `any` remains the
+full-shape fallback and does not trigger this diagnostic. Silent fallback to
 unshrunk schemas hides type mismatches that cause runtime surprises. This
 includes declared members whose own type is `unknown`, not just top-level
 `unknown` parameters.
@@ -355,9 +356,9 @@ We are meeting goals when:
     enabled
 12. empty-array cell-factory fixtures fail with actionable diagnostics unless
     explicit element type arguments are provided
-13. schema shrink validation errors on `unknown`/`any` parameter types when
-    property accesses are detected, and on concrete types missing accessed
-    properties, with messages that name the missing paths and guide the fix
+13. schema shrink validation errors on `unknown` parameter types when property
+    accesses are detected, and on concrete types missing accessed properties,
+    with messages that name the missing paths and guide the fix
 
 ## 8. Policy For Future Changes
 


### PR DESCRIPTION
## Summary
- update the ts-transformer current-behavior spec to match the merged remove-opaque-ref work
- fold in later mainline contract changes after the last spec update, including call detection tightening, unknown-vs-any schema behavior, unknown-property validation, local reactive alias diagnostics, and array length shrinking
- align the design deltas and goals docs with the now-landed collection-method and schema behavior


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync `@commontools/ts-transformers` specs with current behavior and align design deltas/goals to March 17, 2026. Clarifies schema diagnostics to error on `unknown` access (including `unknown` members) but not on `any`.

- **Refactors**
  - Provenance-first CommonTools detection with alias following; narrow synthetic/ambient fallback; shadowed helpers not classified; builder-placement uses direct-call checks.
  - Reactive collections: rewrite `map`/`filter`/`flatMap` to `...WithPattern`; compute-context policy honored; local rewrap aliases in compute are eligible; helper-owned compute branches re-analyzed.
  - Validation/diagnostics: `.get()` allowed for cell/stream; structural reactive-origin tracing for opaque cases; new `compute-context:local-reactive-use`; standalone-function checks include collection methods.
  - Schema: distinguish `unknown` vs `any`; error on `unknown` access (including `unknown`-typed members), not on `any`; array-length-only access shrinks item type to `unknown`; preserve `unknown` in unions; drop `asOpaque`.
  - Inference/lowering: recover result types from object literals and direct projections; reuse types from local `lift`/`derive` aliases; derive callbacks recursively lowered with block-aware opaque-root detection; `.get()` path capture is precise and de-duplicates blanket reads.

<sup>Written for commit 2d166609bf0b765e4c6cbc9cb3aaa3fb2a32572a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



