### PR TITLE
fix(runner): prevent redundant updates when writing same WriteRedirectLink

### DIFF
--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -273,7 +273,10 @@ export function normalizeAndDiff(
   if (isWriteRedirectLink(newValue)) {
     if (
       isWriteRedirectLink(currentValue) &&
-      areNormalizedLinksSame(parseLink(currentValue, link), link)
+      areNormalizedLinksSame(
+        parseLink(currentValue, link),
+        parseLink(newValue, link),
+      )
     ) {
       diffLogger.debug(
         "diff",

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -365,6 +365,27 @@ describe("data-updating", () => {
       expect(changes[0].value).toBe(5);
     });
 
+    it("should no-op when writing the same write redirect alias twice", () => {
+      const testCell = runtime.getCell<{
+        alias: any;
+      }>(
+        space,
+        "normalizeAndDiff test duplicate same alias",
+        undefined,
+        tx,
+      );
+
+      const aliasLink = { $alias: { path: ["some_value"] } };
+      testCell.set({ alias: aliasLink });
+
+      const current = testCell.getAsNormalizedFullLink();
+      const changes = normalizeAndDiff(runtime, tx, current, {
+        alias: aliasLink,
+      });
+
+      expect(changes.length).toBe(0);
+    });
+
     it("should follow aliases", () => {
       const testCell = runtime.getCell<{
         value: number;


### PR DESCRIPTION
Fixes a bug where writing the exact same alias/WriteRedirectLink into a cell caused a redundant rewrite instead of a no-op due to a faulty equality check against the destination link instead of the new link value.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes redundant rewrites when writing the same WriteRedirectLink alias to a cell. `normalizeAndDiff` now treats identical alias writes as a no-op.

- **Bug Fixes**
  - Corrected equality check to compare `parseLink(currentValue, link)` with `parseLink(newValue, link)`.
  - Added a test to ensure writing the same alias twice results in no changes.

<sup>Written for commit e80d3a522383b3af80ee74815055752d44dbc6dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

