### PR TITLE
Increase the stddev factor to 3σ

### DIFF
--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -24,7 +24,7 @@ export const RECENT_WINDOW = 3;
 export const RECENT_THRESHOLD = 2;
 
 /** Standard deviations above the median to flag a regression. */
-export const STDDEV_FACTOR = 2;
+export const STDDEV_FACTOR = 3;
 
 /** Multiplier on the median as an alternative threshold. */
 export const MEDIAN_MULTIPLIER = 2;


### PR DESCRIPTION
This takes the false positive rate from 1/40 to 1/740 (we only care about outliers on the high end).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the regression threshold from 2σ to 3σ in `tasks/perf-lib.ts` to cut false positives from ~1/20 to ~1/300.

<sup>Written for commit 34e4089b78e829232f8f2ce46b5d3ed2e97984d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

