### PR TITLE
fix: prevent text selection in piece switcher items

### DIFF
--- a/packages/shell/src/views/QuickJumpView.ts
+++ b/packages/shell/src/views/QuickJumpView.ts
@@ -67,6 +67,7 @@ export class XQuickJumpView extends BaseView {
       display: flex;
       gap: 8px;
       align-items: baseline;
+      user-select: none;
     }
 
     .item[aria-selected="true"] {


### PR DESCRIPTION
## Summary

- Add `user-select: none` to `.item` CSS rule in `QuickJumpView`
- Prevents text cursor from appearing when hovering over piece switcher dropdown items
- Prevents accidental text selection when clicking items

Fixes CT-1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)