### PR TITLE
fix: ct-hstack height chain so ct-vscroll children can scroll

### DIFF
--- a/packages/ui/src/v2/components/ct-hstack/ct-hstack.ts
+++ b/packages/ui/src/v2/components/ct-hstack/ct-hstack.ts
@@ -53,12 +53,14 @@ export class CTHStack extends BaseElement {
       --ct-hstack-padding-24: 6rem;
 
       display: block;
+      overflow: hidden;
     }
 
     .stack {
       display: flex;
       flex-direction: row;
       box-sizing: border-box;
+      height: 100%;
     }
 
     /* Gap utilities */
@@ -190,9 +192,10 @@ export class CTHStack extends BaseElement {
       padding: var(--ct-hstack-padding-24);
     }
 
-    /* Direct children styling */
+    /* Direct children styling - allow flex children to shrink by default
+      so scroll containers like ct-vscroll can be height-constrained */
     ::slotted(*) {
-      flex-shrink: 0;
+      min-height: 0;
     }
   `;
 

--- a/packages/ui/src/v2/components/ct-vscroll/ct-vscroll.ts
+++ b/packages/ui/src/v2/components/ct-vscroll/ct-vscroll.ts
@@ -51,15 +51,16 @@ export class CTVScroll extends BaseElement {
       display: block;
       position: relative;
       overflow: hidden;
+      min-height: 0;
     }
 
     :host([flex]) {
       flex: 1;
-      min-height: 0;
     }
 
     .scroll-wrapper {
       position: relative;
+      overflow: hidden;
       width: 100%;
       height: 100%;
     }


### PR DESCRIPTION
## Summary
- The inner `.stack` div in `ct-hstack` had no height constraint, so it will grow to its content height even when the host is constrained. This broke `ct-vscroll` children — their `overflow-y: auto` had nothing to clip against.
- Added `overflow: hidden` and `height: 100%` to the `.stack` wrapper, replaced `flex-shrink: 0` with `min-height: 0` on `::slotted(*)`, and hardened `ct-vscroll` to work as a flex child without the `flex` attribute.

## Test plan
- [x] Verify the sidebar does NOT scroll (its content fits within the viewport)
- [x] Check ct-hstack story in the catalog still renders correctly

## Linear issue
https://linear.app/common-tools/issue/CT-1386/published-folders-from-fabric-local-do-not-scroll