### PR TITLE
feat: add --inspect-brk support and deno task profile

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -42,7 +42,8 @@
     "test-all": "echo \"Use 'deno task test' instead.\" && exit 1",
     "build-binaries": "./tasks/build-binaries.ts",
     "initialize-db": "./tasks/initialize-db.sh",
-    "integration": "./tasks/integration.ts"
+    "integration": "./tasks/integration.ts",
+    "profile": "./scripts/restart-local-dev.sh --inspect-brk"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/scripts/restart-local-dev.sh
+++ b/scripts/restart-local-dev.sh
@@ -8,6 +8,7 @@ PORT_OFFSET=${PORT_OFFSET:-0}
 SHELL_PORT=${SHELL_PORT:-}
 TOOLSHED_PORT=${TOOLSHED_PORT:-}
 INSPECT=false
+INSPECT_BRK=false
 INSPECT_PORT=${INSPECT_PORT:-}
 
 # Parse command line arguments
@@ -40,6 +41,11 @@ while [[ $# -gt 0 ]]; do
             ;;
         --inspect)
             INSPECT=true
+            shift
+            ;;
+        --inspect-brk)
+            INSPECT=true
+            INSPECT_BRK=true
             shift
             ;;
         --inspect-port)
@@ -78,7 +84,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 [--clear-cache] [--dangerously-clear-all-spaces] [--force] [--watch] [--bg-updater] [--inspect] [--inspect-port PORT] [--port-offset N] [--shell-port PORT] [--toolshed-port PORT]"
+            echo "Usage: $0 [--clear-cache] [--dangerously-clear-all-spaces] [--force] [--watch] [--bg-updater] [--inspect] [--inspect-brk] [--inspect-port PORT] [--port-offset N] [--shell-port PORT] [--toolshed-port PORT]"
             exit 1
             ;;
     esac
@@ -129,7 +135,11 @@ if [[ "$BG_UPDATER" == "true" ]]; then
     START_ARGS="$START_ARGS --bg-updater"
 fi
 if [[ "$INSPECT" == "true" ]]; then
-    START_ARGS="$START_ARGS --inspect"
+    if [[ "$INSPECT_BRK" == "true" ]]; then
+        START_ARGS="$START_ARGS --inspect-brk"
+    else
+        START_ARGS="$START_ARGS --inspect"
+    fi
     if [[ -n "$INSPECT_PORT" ]]; then
         START_ARGS="$START_ARGS --inspect-port $INSPECT_PORT"
     fi

--- a/scripts/start-local-dev.sh
+++ b/scripts/start-local-dev.sh
@@ -11,6 +11,7 @@ PORT_OFFSET=${PORT_OFFSET:-0}
 SHELL_PORT=${SHELL_PORT:-}
 TOOLSHED_PORT=${TOOLSHED_PORT:-}
 INSPECT=false
+INSPECT_BRK=false
 INSPECT_PORT=${INSPECT_PORT:-}
 
 # Parse command line arguments
@@ -33,6 +34,11 @@ while [[ $# -gt 0 ]]; do
             ;;
         --inspect)
             INSPECT=true
+            shift
+            ;;
+        --inspect-brk)
+            INSPECT=true
+            INSPECT_BRK=true
             shift
             ;;
         --inspect-port)
@@ -129,7 +135,11 @@ if [[ "$WATCH" == "true" ]]; then
 fi
 INSPECT_FLAG=""
 if [[ "$INSPECT" == "true" ]]; then
-    INSPECT_FLAG="--inspect=127.0.0.1:$INSPECT_PORT"
+    if [[ "$INSPECT_BRK" == "true" ]]; then
+        INSPECT_FLAG="--inspect-brk=127.0.0.1:$INSPECT_PORT"
+    else
+        INSPECT_FLAG="--inspect=127.0.0.1:$INSPECT_PORT"
+    fi
 fi
 SHELL_URL="http://localhost:$SHELL_PORT" \
     deno run --unstable-otel -A $INSPECT_FLAG $WATCH_FLAG --env-file=.env index.ts --port="$TOOLSHED_PORT" > local-dev-toolshed.log 2>&1 &


### PR DESCRIPTION
## Summary
- Adds `--inspect-brk` flag to `start-local-dev.sh` and `restart-local-dev.sh`, passing `--inspect-brk=127.0.0.1:PORT` to toolshed's deno process (pauses at startup for debugger attach)
- Adds `deno task profile` convenience task that restarts with `--inspect-brk`
- Existing `--inspect` behavior is unchanged

## Usage
```bash
deno task profile                                        # quick restart with profiling
./scripts/restart-local-dev.sh --inspect-brk             # same, with other flags available
./scripts/restart-local-dev.sh --inspect-brk --inspect-port 9230  # custom port
./scripts/restart-local-dev.sh                           # restart normally when done
```

Then open `chrome://inspect` to attach DevTools and profile.

## Test plan
- [x] `deno task profile` stops existing servers and restarts toolshed with `--inspect-brk`
- [x] `chrome://inspect` shows the paused toolshed process
- [x] `./scripts/restart-local-dev.sh` restarts normally (no inspect)
- [x] `--inspect` (without brk) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)