### PR TITLE
feat: add deno task for CLI profiling

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -37,14 +37,14 @@
   ],
   "tasks": {
     "check": "./tasks/check.sh",
-    "ct": "ROOT=$(pwd) && cd $INIT_CWD && deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/packages/cli/mod.ts\"",
+    "ct": "ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/packages/cli/mod.ts\"",
     "test": "./tasks/test.ts",
     "test-all": "echo \"Use 'deno task test' instead.\" && exit 1",
     "build-binaries": "./tasks/build-binaries.ts",
     "initialize-db": "./tasks/initialize-db.sh",
     "integration": "./tasks/integration.ts",
     "profile": "./scripts/restart-local-dev.sh --inspect-brk",
-    "ct-profile": "ROOT=$(pwd) && cd $INIT_CWD && deno run --inspect-brk --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/packages/cli/mod.ts\""
+    "ct-profile": "ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && deno run --inspect-brk --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/packages/cli/mod.ts\""
   },
   "compilerOptions": {
     "jsx": "react-jsx",


### PR DESCRIPTION
Adds a ct-profile task with --inspect-brk for Chrome DevTools profiling of CLI commands, mirroring the profile task from #3167.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `deno task ct-profile` to launch the `ct` CLI with `--inspect-brk`, so you can attach Chrome DevTools and profile CPU/memory for any subcommand. Mirrors the existing `profile` task but runs the CLI directly for easier local debugging, and quotes shell variables in `ct`/`ct-profile` to handle paths with spaces.

<sup>Written for commit 506102f677e4f61cf6890e87b84370c8ce430a94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

