### PR TITLE
feat: parallelize CI by splitting monolithic build job

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -17,8 +17,8 @@ jobs:
   # ---------------------------------------------------------------------------
   # Tier 0 – These jobs all start immediately with no dependencies
   # ---------------------------------------------------------------------------
-  lint-and-format:
-    name: "Lint and Format"
+  check:
+    name: "Check"
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
@@ -35,19 +35,6 @@ jobs:
 
       - name: 🧹 Lint codebase
         run: deno lint
-
-  type-check:
-    name: "Type Check"
-    runs-on: ubuntu-latest
-    steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
-
-      - name: 🦕 Setup Deno
-        uses: ./.github/actions/deno-setup
-
-      - name: 🔍 Verify lock file & install dependencies
-        run: deno install --frozen=true
 
       - name: 🔎 Type check codebase
         run: deno task check
@@ -319,8 +306,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs:
-      - lint-and-format
-      - type-check
+      - check
       - test
       - build-binaries
       - package-integration-test
@@ -355,8 +341,7 @@ jobs:
     needs:
       [
         "test",
-        "lint-and-format",
-        "type-check",
+        "check",
         "pattern-integration-test",
         "pattern-unit-test",
         "package-integration-test",
@@ -571,8 +556,7 @@ jobs:
     needs:
       [
         "test",
-        "lint-and-format",
-        "type-check",
+        "check",
         "pattern-integration-test",
         "pattern-unit-test",
         "package-integration-test",

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -592,11 +592,8 @@ export function extractMetrics(
     if (normalizedJobName === "Test") {
       metrics.set("job: Test", makeSample(jobDuration));
     }
-    if (normalizedJobName === "Type Check") {
-      metrics.set("job: Type Check", makeSample(jobDuration));
-    }
-    if (normalizedJobName === "Lint and Format") {
-      metrics.set("job: Lint and Format", makeSample(jobDuration));
+    if (normalizedJobName === "Check") {
+      metrics.set("job: Check", makeSample(jobDuration));
     }
 
     for (const step of job.steps) {


### PR DESCRIPTION
## Summary
- Split the monolithic "Test and Build" job (~4min sequential on 64-core) into 4 independent tier-0 jobs that all start immediately: `lint-and-format`, `type-check`, `test`, `build-binaries`
- Freed `generated-patterns-integration-test` from its unnecessary `build` dependency (it never used binaries)
- Updated perf tracking in `perf-lib.ts` to track the new job names alongside the old one for baseline continuity

## Before
```
build (64-core, ~4min sequential)
  → install → type-check → fmt → lint → tests → build-binaries → upload
    └── all integration tests wait here
```

## After
```
Tier 0 (all start immediately):
  ├── lint-and-format        (ubuntu-latest, ~30s)
  ├── type-check             (ubuntu-latest, ~1.5min)
  ├── test                   (64-core, ~2.5min)
  ├── build-binaries         (64-core, ~1min)
  └── generated-patterns-test (ubuntu-latest, ~3min, freed!)
Tier 1 (needs: build-binaries):
  └── integration tests (~2-3.5min)
```

Expected wall-clock: ~4-5min (down from ~7-8min).

NEW_PERF_BASELINE: job: Test and Build = 300s

## Test plan
- [ ] All tier-0 jobs start in parallel (visible in Actions graph)
- [ ] Integration tests start as soon as `build-binaries` completes
- [ ] `generated-patterns-integration-test` starts immediately
- [ ] Perf check passes (new job names tracked, old baseline override above)
- [ ] Attest and deploy jobs still gate on all required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelized CI by splitting the monolithic “Test and Build” into three tier-0 jobs (`Check`, `Test`, `Build Binaries`) and letting generated-patterns integration tests start immediately. This drops wall-clock to ~4–5 min while keeping perf tracking and gates intact.

- **Refactors**
  - Added tier-0 jobs: `Check` (fmt, lint, type-check on `ubuntu-latest`), `Test` and `Build Binaries` (both on `ubuntu-24.04-64-core`).
  - Updated integration/unit tests to depend only on `build-binaries`; `generated-patterns-integration-test` now has no build dependency.
  - Adjusted gates so `perf-check`, `attest`, and `deploy` wait on `check`, `test`, `build-binaries`, and integration suites.
  - Updated `tasks/perf-lib.ts` to record `job: Check`, `job: Test`, and `job: Build Binaries`, while preserving `job: Test and Build` for baseline continuity.

<sup>Written for commit 7e38ee230d34020af283417bcf90a65bbe27c279. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

