### PR TITLE
fix(ui): restore scroll for patterns inside ct-render

### DIFF
--- a/packages/ui/src/v2/components/ct-render/ct-render.ts
+++ b/packages/ui/src/v2/components/ct-render/ct-render.ts
@@ -89,6 +89,7 @@ export class CTRender extends BaseElement {
       flex-direction: column;
       width: 100%;
       height: 100%;
+      overflow: auto;
     }
 
     .loading-spinner {


### PR DESCRIPTION
## Summary

- The header dropdown redesign (#3132) added `overflow: hidden` to `ct-render`'s `:host` to fix a double scrollbar. This also prevented all pattern content from scrolling — the shadow DOM wrapper clipped content with no scroll escape.
- Adds `overflow: auto` to `.render-container` (inside the shadow DOM) instead. This avoids a browser quirk where `overflow: auto` on a custom element host reports inflated `scrollHeight` through shadow DOM boundaries, while correctly enabling scroll for overflowing pattern content.
- Patterns using `ct-screen` (e.g. component catalog) are unaffected — `ct-screen` fills the bounded container via `height: 100%` and handles its own internal scrolling, so `.render-container` sees no overflow.
- Patterns without `ct-screen` (e.g. Loom, which uses `min-height: 100vh`) now scroll within `.render-container` instead of being silently clipped.

## Test plan

- [x] Open the component catalog — verify sidebar and content scroll independently, controls stay pinned at bottom
- [x] Open an LLM-generated pattern with long content — verify the page scrolls
- [x] Check no double scrollbar appears on any pattern
- [x] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)