### PR TITLE
Fix iOS zooming and ct-vstack sizing

### DIFF
--- a/packages/shell/public/index.html
+++ b/packages/shell/public/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/assets/ct.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0"
+    />
     <title>Common Tools</title>
     <link rel="stylesheet" href="/styles/index.css" />
   </head>

--- a/packages/ui/src/v2/components/ct-vstack/ct-vstack.ts
+++ b/packages/ui/src/v2/components/ct-vstack/ct-vstack.ts
@@ -58,6 +58,8 @@ export class CTVStack extends BaseElement {
       display: flex;
       flex-direction: column;
       box-sizing: border-box;
+      height: 100%;
+      width: 100%;
     }
 
     /* Gap utilities */


### PR DESCRIPTION
## Summary

- Adds a temporary hack to the mobile viewport to disable zooming. This is because our ct-* inputs' font-size is less than 16px so when you interact with them on a phone, iOS will zoom the screen. This is a pretty old and well known iOS gotcha on mobile web. Disabling zooming is a quick way to fix the issue but it's generally bad for accessibility so we should work on improving the font size of our elements on mobile
- Updates the `.stack` child inside of `ct-vstack` to match the dimensions of the `:host`. Previously if you set `ct-vstack`'s height to 100% then the .stack child in the shadow root would not scale up to match it (it would only match the intrinsic size of its content).

NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/calendar/event-detail.test.tsx = 11s