### PR TITLE
feat: wire up EXPERIMENTAL_MODERN_SCHEMA_HASH env var

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -12,6 +12,7 @@ affecting users who haven't opted in.
 | `modernDataModel` | `EXPERIMENTAL_MODERN_DATA_MODEL` | Enables the new fabric value type system (`bigint`, `Map`, `Set`, `Uint8Array`, `Date`, `FabricInstance`). |
 | `unifiedJsonEncoding` | `EXPERIMENTAL_UNIFIED_JSON_ENCODING` | Enables a unified JSON encoding scheme for all fabric values. |
 | `modernHash` | `EXPERIMENTAL_MODERN_HASH` | Enables canonical hashing, replacing merkle-reference CID-based hashing (see Section 6 of the formal spec). |
+| `modernSchemaHash` | `EXPERIMENTAL_MODERN_SCHEMA_HASH` | Enables modern schema hashing, replacing stableStringify-based schema hashing. |
 
 All flags default to `false`. Setting any flag to `true` activates the
 corresponding experimental behavior.
@@ -63,6 +64,7 @@ Server Process (Deno)
   +-- toolshed/index.ts      --> new Runtime({ experimental: { ... } })
                                     +-- setDataModelConfig(...)
                                     +-- setModernHashConfig(...)
+                                    +-- setSchemaHashConfig(...)
 ```
 
 ### Browser-side (build-time injection)
@@ -96,8 +98,11 @@ Browser Web Worker
               |    +-- modernDataModelEnabled = true
               |         +-- fabricFromNativeValue() checks modernDataModelEnabled
               +-- setModernHashConfig(...)
-                   +-- modernHashEnabled = true
-                        +-- hashOf() dispatches to hashOfModern()
+              |    +-- modernHashEnabled = true
+              |         +-- hashOf() dispatches to hashOfModern()
+              +-- setSchemaHashConfig(...)
+                   +-- modernSchemaHashEnabled = true
+                        +-- schemaHashOf() dispatches to modern path
 ```
 
 Key points:
@@ -136,7 +141,7 @@ When any experimental flags are enabled, the `Runtime` constructor logs them on
 startup. Look for a line like:
 
 ```
-Experimental flags enabled: modernDataModel, unifiedJsonEncoding, modernHash
+Experimental flags enabled: modernDataModel, unifiedJsonEncoding, modernHash, modernSchemaHash
 ```
 
 - **Server-side (toolshed):** Check `packages/toolshed/local-dev-toolshed.log`.
@@ -168,8 +173,10 @@ with defaults (all `false`) and stores the resolved result as
 
 The memory layer uses module-level ambient config variables:
 `modernDataModelEnabled` in `packages/data-model/fabric-value.ts` (set by
-`setDataModelConfig()`) and `modernHashEnabled` in
-`packages/data-model/value-hash.ts` (set by `setModernHashConfig()`). This means:
+`setDataModelConfig()`), `modernHashEnabled` in
+`packages/data-model/value-hash.ts` (set by `setModernHashConfig()`), and
+`modernSchemaHashEnabled` in `packages/data-model/schema-hash.ts` (set by
+`setSchemaHashConfig()`). This means:
 
 - Only one set of experimental flags is active per JavaScript context at a time.
 - In the browser, the Web Worker is a separate JS context, so its flags are

--- a/docs/development/LOCAL_DEV_SERVERS.md
+++ b/docs/development/LOCAL_DEV_SERVERS.md
@@ -28,6 +28,7 @@
 experiments on both servers:
 ```bash
 EXPERIMENTAL_MODERN_HASH=true \
+EXPERIMENTAL_MODERN_SCHEMA_HASH=true \
 EXPERIMENTAL_MODERN_DATA_MODEL=true \
 ./scripts/restart-local-dev.sh --force --dangerously-clear-all-spaces
 ```

--- a/packages/background-charm-service/src/env.ts
+++ b/packages/background-charm-service/src/env.ts
@@ -36,6 +36,9 @@ const envSchema = z.object({
   EXPERIMENTAL_MODERN_HASH: z.string().default("false").transform((
     v,
   ) => v === "true"),
+  EXPERIMENTAL_MODERN_SCHEMA_HASH: z.string().default("false").transform((
+    v,
+  ) => v === "true"),
   // Background Charm Service: default is public space "toolshed-system"
   //SERVICE_DID: z.string().default(
   //  "did:key:z6Mkfuw7h6jDwqVb6wimYGys14JFcyTem4Kqvdj9DjpFhY88",

--- a/packages/background-charm-service/src/main.ts
+++ b/packages/background-charm-service/src/main.ts
@@ -35,6 +35,7 @@ const runtime = new Runtime({
     modernDataModel: env.EXPERIMENTAL_MODERN_DATA_MODEL,
     unifiedJsonEncoding: env.EXPERIMENTAL_UNIFIED_JSON_ENCODING,
     modernHash: env.EXPERIMENTAL_MODERN_HASH,
+    modernSchemaHash: env.EXPERIMENTAL_MODERN_SCHEMA_HASH,
   },
 });
 const service = new BackgroundCharmService({

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -21,6 +21,7 @@ export function experimentalOptionsFromEnv(): ExperimentalOptions {
     modernDataModel: read("EXPERIMENTAL_MODERN_DATA_MODEL"),
     unifiedJsonEncoding: read("EXPERIMENTAL_UNIFIED_JSON_ENCODING"),
     modernHash: read("EXPERIMENTAL_MODERN_HASH"),
+    modernSchemaHash: read("EXPERIMENTAL_MODERN_SCHEMA_HASH"),
   };
   const active = Object.entries(opts).filter(([, v]) => v);
   if (active.length > 0) {

--- a/packages/shell/felt.config.ts
+++ b/packages/shell/felt.config.ts
@@ -50,6 +50,9 @@ const config: Config = {
       "$EXPERIMENTAL_MODERN_HASH": Deno.env.get(
         "EXPERIMENTAL_MODERN_HASH",
       ),
+      "$EXPERIMENTAL_MODERN_SCHEMA_HASH": Deno.env.get(
+        "EXPERIMENTAL_MODERN_SCHEMA_HASH",
+      ),
       "$COMPILATION_CACHE_CLIENT": Deno.env.get(
         "COMPILATION_CACHE_CLIENT",
       ) ?? "true",

--- a/packages/shell/src/lib/env.ts
+++ b/packages/shell/src/lib/env.ts
@@ -5,6 +5,7 @@ declare global {
   var $EXPERIMENTAL_MODERN_DATA_MODEL: string | undefined;
   var $EXPERIMENTAL_UNIFIED_JSON_ENCODING: string | undefined;
   var $EXPERIMENTAL_MODERN_HASH: string | undefined;
+  var $EXPERIMENTAL_MODERN_SCHEMA_HASH: string | undefined;
   var $COMPILATION_CACHE_CLIENT: string | undefined;
 }
 
@@ -23,6 +24,7 @@ export const EXPERIMENTAL = {
   modernDataModel: $EXPERIMENTAL_MODERN_DATA_MODEL === "true",
   unifiedJsonEncoding: $EXPERIMENTAL_UNIFIED_JSON_ENCODING === "true",
   modernHash: $EXPERIMENTAL_MODERN_HASH === "true",
+  modernSchemaHash: $EXPERIMENTAL_MODERN_SCHEMA_HASH === "true",
 };
 
 export const COMPILATION_CACHE_CLIENT = $COMPILATION_CACHE_CLIENT === "true";

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -196,6 +196,9 @@ const EnvSchema = z.object({
   EXPERIMENTAL_MODERN_HASH: z.string().default("false").transform((
     v,
   ) => v === "true"),
+  EXPERIMENTAL_MODERN_SCHEMA_HASH: z.string().default("false").transform((
+    v,
+  ) => v === "true"),
 
   // ===========================================================================
   // Compilation cache flags (see docs/specs/compilation-cache.md)

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -53,6 +53,7 @@ const initializeRuntime = async () => {
         modernDataModel: env.EXPERIMENTAL_MODERN_DATA_MODEL,
         unifiedJsonEncoding: env.EXPERIMENTAL_UNIFIED_JSON_ENCODING,
         modernHash: env.EXPERIMENTAL_MODERN_HASH,
+        modernSchemaHash: env.EXPERIMENTAL_MODERN_SCHEMA_HASH,
       },
       cachedCompiler,
     });


### PR DESCRIPTION
## Summary

The `modernSchemaHash` flag already existed in `ExperimentalOptions` and
`Runtime` (runtime.ts) and was consumed by the data-model layer
(schema-hash.ts), but had no env var plumbing. This PR adds
`EXPERIMENTAL_MODERN_SCHEMA_HASH` env var support across all entry points,
following the exact same pattern as the other three experimental flags
(`EXPERIMENTAL_MODERN_DATA_MODEL`, `EXPERIMENTAL_UNIFIED_JSON_ENCODING`,
`EXPERIMENTAL_MODERN_HASH`).

### Changes

- **Toolshed** (`packages/toolshed/env.ts`, `packages/toolshed/index.ts`):
  Zod env schema + Runtime wiring.
- **Shell** (`packages/shell/felt.config.ts`, `packages/shell/src/lib/env.ts`):
  Build-time injection via felt config + global declaration + EXPERIMENTAL
  object.
- **Background charm service**
  (`packages/background-charm-service/src/env.ts`,
  `packages/background-charm-service/src/main.ts`): Zod env schema + Runtime
  wiring.
- **CT CLI** (`packages/cli/lib/utils.ts`): `experimentalOptionsFromEnv()`
  helper.
- **Documentation** (`docs/development/EXPERIMENTAL_OPTIONS.md`,
  `docs/development/LOCAL_DEV_SERVERS.md`): Updated reference table, flow
  diagrams, example commands, and ambient config description.

Co-Authored-By: coder-cedar (Claude Opus 4.6) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.6) <noreply@anthropic.com>
