### PR TITLE
feat(ct-1378): use recorded space name when rendering favorite links

### DIFF
--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -3285,6 +3285,7 @@ interface CTOutlinerAttributes<T> extends CTHTMLAttributes<T> {
 interface CTCellLinkAttributes<T> extends CTHTMLAttributes<T> {
   "link"?: string;
   "$cell": CellLike<any>;
+  "spaceName"?: string;
 }
 
 interface CTSpaceLinkAttributes<T> extends CTHTMLAttributes<T> {

--- a/packages/patterns/system/favorites-manager.tsx
+++ b/packages/patterns/system/favorites-manager.tsx
@@ -49,7 +49,7 @@ export default pattern<Record<string, never>>((_) => {
           <ct-cell-context $cell={item.cell}>
             <ct-vstack gap="2">
               <ct-hstack gap="2" align="center">
-                <ct-cell-link $cell={item.cell} />
+                <ct-cell-link $cell={item.cell} spaceName={item.spaceName} />
                 <ct-button
                   variant="destructive"
                   size="sm"

--- a/packages/ui/src/v2/components/ct-cell-link/ct-cell-link.ts
+++ b/packages/ui/src/v2/components/ct-cell-link/ct-cell-link.ts
@@ -64,6 +64,9 @@ export class CTCellLink extends BaseElement {
   @property({ type: String })
   label?: string;
 
+  @property({ type: String })
+  spaceName?: string;
+
   @property({ attribute: false })
   cell?: CellHandle;
 
@@ -299,10 +302,12 @@ export class CTCellLink extends BaseElement {
       }
 
       // TODO(runtime-worker-refactor):
-      const view = {
-        spaceDid: this._resolvedCell.space(),
-        pieceId: this._resolvedCell.id(),
-      };
+      const view = this.spaceName
+        ? { spaceName: this.spaceName, pieceId: this._resolvedCell.id() }
+        : {
+          spaceDid: this._resolvedCell.space(),
+          pieceId: this._resolvedCell.id(),
+        };
 
       // Cmd (Mac) or Ctrl (Windows/Linux) opens in new tab
       if (e.metaKey || e.ctrlKey) {


### PR DESCRIPTION
## Summary

- Adds `spaceName` prop to `ct-cell-link`; when set, navigation uses `{ spaceName, pieceId }` instead of `{ spaceDid, pieceId }`, producing human-readable URLs like `/ben/of:bafy...`
- `favorites-manager.tsx` passes the already-stored `spaceName` from each favorite entry to `ct-cell-link`
- Adds `spaceName` to `CTCellLinkAttributes` in `jsx.d.ts` for JSX type safety

The full data pipeline (capturing spaceName at add-to-favorites time and storing it in the favorite entry) was already in place; this PR wires it up to the rendered link.

Closes CT-1378

## Test plan

- [x] Navigate to a named space, add a piece to favorites
- [x] Open Favorites tab in home — clicking the favorite should navigate to `/{spaceName}/{pieceId}` (readable URL)
- [x] Cmd/Ctrl+click should open in a new tab with the same readable URL
- [x] Favorites added from a DID-based URL fall back gracefully to `/{did}/{pieceId}`
- [x] `deno task check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)