### PR TITLE
feat(fuse): [FS] symbol — per-pattern filesystem projection CT-1417 CT-1420 CT-1421 CT-1418 CT-1419 CT-1403

### DIFF
--- a/docs/specs/fuse-filesystem/2-path-scheme.md
+++ b/docs/specs/fuse-filesystem/2-path-scheme.md
@@ -119,26 +119,110 @@ Each piece gets a directory named by its display name (if set) or a
 shortened entity ID. Name collisions are resolved by appending a numeric
 suffix: `todo-app`, `todo-app-2`, etc.
 
+### Default Layout
+
+When a pattern does not declare `[FS]`, the result cell is exploded into a
+directory tree:
+
 ```
 home/pieces/todo-app/
   input.json          # {"title": "My Todos", "maxItems": 100}
   input/
-    title             # file containing: My Todos
-    maxItems          # file containing: 100
+    title             # file: My Todos
+    maxItems          # file: 100
   result.json         # {"items": [...], "count": 3}
   result/
     items/
       0/
-        text          # file containing: Buy milk
-        done          # file containing: false
-      1/
-        text          # ...
-        done          # ...
-    count             # file containing: 3
-    addItem.handler   # readable+writable mounted handler
-    search.tool       # readable mounted pattern tool
-  meta.json           # {"id": "of:ba4j...", "patternName": "todo-app", ...}
+        text          # file: Buy milk
+        done          # file: false
+      0.json          # {"text":"Buy milk","done":false}
+    count             # file: 3
+    addItem.handler   # executable: invoke via ct exec or write JSON
+    search.tool       # executable: run via ct exec
+    $UI.json          # serialized VNode tree (not exploded)
+  meta.json           # {"id":"of:ba4j...","patternName":"todo-app",...}
+  .handlers           # hidden summary: one line per callable with type info
 ```
+
+### [FS] Projection Layout
+
+When a pattern declares `[FS]`, the result cell is replaced by a single
+projection file at the piece root. The `result/` directory is suppressed.
+Callable files move to the piece root:
+
+**Markdown projection** (`type: "text/markdown"`):
+
+```
+home/pieces/my-note/
+  index.md            # YAML frontmatter + markdown body
+  input.json
+  input/
+    title
+    content
+  addItem.handler     # callable at piece root
+  $UI.json            # serialized UI tree (single file)
+  meta.json
+  .handlers           # hidden callable summary
+```
+
+`index.md` looks like:
+
+```markdown
+---
+entityId: of:ba4jcbvpq3k5soo...
+title: My Note Title
+---
+
+The note body content goes here.
+```
+
+Primitive frontmatter fields appear in YAML. Complex values (arrays of
+entities, nested objects) become sibling directories alongside `index.md`,
+using the same directory-tree rules as the default layout.
+
+**JSON projection** (`type: "application/json"` or plain object):
+
+```
+home/pieces/my-widget/
+  index.json          # {"entityId":"of:ba4j...","field1":"value1",...}
+  input.json
+  input/...
+  doSomething.handler
+  meta.json
+  .handlers
+```
+
+### The `.handlers` File
+
+Every piece has a `.handlers` file (dot-prefixed, hidden from `ls`) at its
+root. It lists all callable entries with their TypeScript-ish input types:
+
+```
+editContent.handler  {
+  detail: {
+    value: string
+  }
+}
+setTitle.handler  string
+appendLink.handler  {
+  piece: MentionablePiece
+}
+createNewNote.handler  void
+toggleMenu.handler  void
+```
+
+Handlers that take no payload show `void`. Read with `cat .handlers`.
+
+### The `$UI.json` File
+
+Patterns that return a `[UI]` property (a VNode virtual DOM tree) have it
+serialized as a single `$UI.json` file rather than exploded into a recursive
+directory structure. This keeps the piece directory navigable and prevents
+`grep` from scanning thousands of VNode files.
+
+`$UI.json` lives in the `result/` directory (default layout) or at the piece
+root (`[FS]` layout).
 
 Only top-level callable children under `input/` and `result/` are surfaced as
 `*.handler` and `*.tool`. These callable files are readable; the first line is

--- a/docs/specs/fuse-filesystem/3-json-mapping.md
+++ b/docs/specs/fuse-filesystem/3-json-mapping.md
@@ -55,6 +55,39 @@ result/items/      # [{"text": "Buy milk"}, {"text": "Walk dog"}]
     text           # file: Walk dog
 ```
 
+## Special System Fields
+
+Patterns use symbol-keyed fields to declare metadata and capabilities. These
+fields begin with `$` and are treated specially by the filesystem projection.
+
+### `$NAME` — Piece Display Name
+
+`$NAME` is a string computed by the pattern used as the piece's filesystem
+directory name. It is not surfaced as a file in the piece directory.
+
+### `$UI` — UI Tree
+
+`$UI` holds a `VNode` — a virtual DOM tree potentially thousands of nodes
+deep. Exploding this into a directory tree would flood the filesystem with
+noise and make `grep` and `ls` unusable.
+
+Instead, `$UI` is serialized as a single `$UI.json` file. It is skipped
+during recursive directory expansion and written once as a compact JSON
+snapshot. It is readable but not writable (the UI is computed).
+
+### `$FS` — Filesystem Projection
+
+`$FS` declares how the pattern wants its result represented on disk. When
+present it is consumed entirely to produce `index.md` or `index.json` at
+the piece root; it does not appear as a file in the result tree.
+
+See [Filesystem Projections](./8-fs-projections.md) for full details.
+
+### `$TYPE` — Pattern Type Tag
+
+`$TYPE` is an internal tag used for type-based discovery. Not surfaced as a
+file.
+
 ## The `.json` Sibling Convention
 
 Every directory (object or array) has a corresponding `.json` file that provides
@@ -315,6 +348,19 @@ siblings for those directories:
 Mounted callable files are readable. Their content starts with a stable
 shebang whose first line is `#!... exec`, so `ct exec <mounted-callable-file>`
 can resolve the backing callable schema and execute it.
+
+Callable files also embed the handler's input schema as readable comments:
+
+```sh
+#!/path/to/ct-exec exec
+# schema: {"type":"string"}
+# input: string
+exec '/path/to/ct-exec' exec "$0" "$@"
+```
+
+Reading the file with `cat` or `head` reveals the expected input type before
+invoking. For compound types, `# input:` shows a TypeScript-ish shape such
+as `{ detail: { value: string } }`. Handlers with no payload show `void`.
 
 ---
 

--- a/docs/specs/fuse-filesystem/4-read-write.md
+++ b/docs/specs/fuse-filesystem/4-read-write.md
@@ -132,7 +132,9 @@ When a piece uses the `[FS]` projection, writing to `index.md` or
 
 **`index.json`**: Parsed as a JSON object.
 - Each key (except `entityId`) is written to `$FS.content.<key>`.
-- Invalid JSON is silently ignored.
+- Keys present in the cell but absent from the file are removed (deleted keys
+  are cleared).
+- Invalid JSON returns `EINVAL`.
 
 `entityId` is always read-only and cannot be changed by writing to either
 file.

--- a/docs/specs/fuse-filesystem/4-read-write.md
+++ b/docs/specs/fuse-filesystem/4-read-write.md
@@ -35,9 +35,11 @@ Always includes `.` and `..`.
 For object values: keys become entries, plus any `.json` siblings.
 For array values: indices become entries, plus `.json` sibling.
 
-Piece directories always contain: `input.json`, `input/`, `result.json`,
-`result/`, `meta.json`. Top-level callable children appear as `*.handler` or
-`*.tool` files under `input/` and `result/`.
+Piece directories always contain `input.json`, `input/`, and `meta.json`.
+For pieces without `[FS]`, they also contain `result.json` and `result/`;
+callable files appear under `result/`. For pieces with `[FS]`, `result/` is
+replaced by `index.md` or `index.json`, and callable files appear at the
+piece root. All pieces have a `.handlers` file at the piece root.
 
 ### `read`
 
@@ -116,6 +118,30 @@ target path parsing rules and examples.
 
 Handlers remain writable so legacy flows like
 `echo '{"message":"hi"}' > result/addItem.handler` keep working.
+
+### `write` to `index.md` or `index.json` (`[FS]` Projection)
+
+When a piece uses the `[FS]` projection, writing to `index.md` or
+`index.json` parses the content and writes back to the corresponding cells:
+
+**`index.md`**: The file is parsed as YAML frontmatter + markdown body.
+- Each frontmatter key (except `entityId`, which is read-only) is written to
+  its corresponding cell via the `$FS.frontmatter.<key>` path.
+- The body is written to the `$FS.content` cell.
+- Invalid YAML frontmatter is silently skipped.
+
+**`index.json`**: Parsed as a JSON object.
+- Each key (except `entityId`) is written to `$FS.content.<key>`.
+- Invalid JSON is silently ignored.
+
+`entityId` is always read-only and cannot be changed by writing to either
+file.
+
+### `read` from `.handlers`
+
+`.handlers` is a read-only dot file at the piece root. It is generated
+automatically when the piece is loaded and updated when the result cell
+changes. Writing to `.handlers` fails with `EACCES`.
 
 ### `write` to `.tool` File
 

--- a/docs/specs/fuse-filesystem/8-fs-projections.md
+++ b/docs/specs/fuse-filesystem/8-fs-projections.md
@@ -1,0 +1,224 @@
+# 8. Filesystem Projections (`[FS]`)
+
+## Overview
+
+By default, FUSE explodes a pattern's result cell into a recursive directory
+tree. This works well for structured data but is poor UX for patterns whose
+primary output is a document — you get dozens of nested directories instead
+of a readable file.
+
+The `[FS]` symbol lets a pattern declare its own on-disk representation.
+When a result cell includes `[FS]`, FUSE produces a single projection file
+(`index.md` or `index.json`) at the piece root instead of a `result/`
+directory.
+
+## Declaring a Projection
+
+Import `FS` and `FsProjection` from `commontools` and add `[FS]` to the
+pattern's return object:
+
+```tsx
+import { FS, type FsProjection, NAME, pattern, UI } from "commontools";
+
+const MyPattern = pattern<Input, Output>(({ title, content }) => {
+  // ...
+
+  return {
+    [NAME]: computed(() => `My Pattern`),
+    [UI]: myUI,
+    [FS]: {
+      type: "text/markdown",
+      frontmatter: { title },
+      content,
+    },
+    // other fields...
+  };
+});
+```
+
+## The `FsProjection` Type
+
+```ts
+type FsProjection =
+  | {
+      type: "text/markdown";
+      frontmatter?: Record<string, unknown>;
+      content: string;
+    }
+  | {
+      type: "application/json";
+      content: Record<string, unknown>;
+    }
+  | Record<string, unknown>; // plain object → default JSON projection
+```
+
+## Projection Variants
+
+### `text/markdown` — Markdown with YAML Frontmatter
+
+Produces `index.md` at the piece root:
+
+```markdown
+---
+entityId: of:ba4jcbvpq3k5soo...
+title: My Note Title
+---
+
+The note body content goes here.
+```
+
+- `entityId` is always injected first and is read-only.
+- Primitive `frontmatter` fields (string, number, boolean, null) become YAML
+  key-value pairs.
+- Complex `frontmatter` fields (arrays of entities, nested objects) cannot be
+  represented in YAML — they become sibling directories alongside `index.md`,
+  using the same directory-tree rules as the default result layout.
+- `content` becomes the markdown body after the closing `---`.
+
+### `application/json` — Explicit JSON
+
+Produces `index.json` at the piece root:
+
+```json
+{
+  "entityId": "of:ba4jcbvpq3k5soo...",
+  "field1": "value1",
+  "field2": 42
+}
+```
+
+`entityId` is always injected first. The `content` object's keys follow.
+
+### Plain Object (Default JSON Shorthand)
+
+Omitting `type` treats the entire `[FS]` value as the content of
+`index.json`. Equivalent to `{ type: "application/json", content: theObject }`:
+
+```tsx
+[FS]: { summary, count }  // → index.json with { entityId, summary, count }
+```
+
+## Write-Back
+
+`index.md` and `index.json` are writable. Edits are parsed and written back
+to the corresponding reactive cells.
+
+| File | Write-Back Behavior |
+|------|---------------------|
+| `index.md` | Parses YAML frontmatter → updates `$FS.frontmatter.<key>` cells; parses body → updates `$FS.content` cell |
+| `index.json` | Parses JSON → updates `$FS.content.<key>` cells |
+
+`entityId` is always skipped on write (read-only).
+
+## Callables and `.handlers`
+
+When `[FS]` is active, callable files (`.handler`, `.tool`) move from
+`result/` to the piece root, alongside `index.md` or `index.json`.
+
+The `.handlers` summary file is always at the piece root regardless of
+whether `[FS]` is used.
+
+## The `.handlers` File
+
+Every piece has a `.handlers` file at its root, generated automatically:
+
+```
+editContent.handler  {
+  detail: {
+    value: string
+  }
+}
+setTitle.handler  string
+appendLink.handler  {
+  piece: MentionablePiece
+}
+createNewNote.handler  void
+```
+
+- Dot-prefixed: hidden from `ls` but readable with `cat .handlers`
+- One entry per callable (handlers and tools)
+- Input type shown as a TypeScript-ish shape
+- Void handlers (no payload) show `void`
+
+## Callable Scripts
+
+Each `.handler` and `.tool` file embeds the input schema as readable comments:
+
+```sh
+#!/path/to/ct-exec exec
+# schema: {"type":"string"}
+# input: string
+exec '/path/to/ct-exec' exec "$0" "$@"
+```
+
+Use `cat setTitle.handler` or `head setTitle.handler` to see the expected
+input before invoking. Run with `--help` for full usage including all flags:
+
+```bash
+./setTitle.handler --help
+# Usage:
+#   ./setTitle.handler [invoke] --value <string>
+#   ...
+# Input type:
+#   string
+# Flags:
+#   --value <string>  Required.
+```
+
+Call with no arguments to see the expected type in the error:
+
+```bash
+./setTitle.handler
+# Handler requires input. Expected type: string
+# Run --help for full usage.
+```
+
+## Live Updates
+
+Projection files update reactively. When a cell changes, the FUSE daemon
+regenerates `index.md`/`index.json` in place and invalidates the kernel
+cache. Reads always see the current cell value.
+
+## Example: Note Pattern
+
+The `Note` pattern in `packages/patterns/notes/note.tsx` uses `[FS]`:
+
+```tsx
+return {
+  [NAME]: computed(() => `📝 ${title.get()}`),
+  [UI]: <ct-screen>...</ct-screen>,
+  [FS]: {
+    type: "text/markdown",
+    frontmatter: { title },
+    content,
+  },
+  title,
+  content,
+  editContent,
+  setTitle,
+  // ...
+};
+```
+
+Mounted result for a note piece:
+
+```
+home/pieces/📝 My Note/
+  index.md              # YAML frontmatter + note body
+  $UI.json              # serialized UI tree (single file, not exploded)
+  editContent.handler   # { detail: { value: string } }
+  setTitle.handler      # string
+  appendLink.handler    # { piece: MentionablePiece }
+  createNewNote.handler # void
+  toggleMenu.handler    # void
+  input.json
+  input/
+    title
+    content
+  meta.json
+  .handlers
+```
+
+---
+
+**Previous:** [Open Questions](./7-open-questions.md)

--- a/docs/specs/fuse-filesystem/README.md
+++ b/docs/specs/fuse-filesystem/README.md
@@ -15,3 +15,4 @@ Directory listings reflect space contents and JSON structure traversal.
 - [5. Architecture](./5-architecture.md)
 - [6. Reactivity and Caching](./6-reactivity.md)
 - [7. Open Questions](./7-open-questions.md)
+- [8. Filesystem Projections (`[FS]`)](./8-fs-projections.md)

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2165,4 +2165,4 @@ export type FsProjection =
     type: "application/json";
     content: Record<string, unknown>;
   }
-  | Record<string, unknown>;
+  | { type?: undefined; [key: string]: unknown };

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -153,6 +153,7 @@ export declare const ID_FIELD: unique symbol;
 export declare const TYPE: "$TYPE";
 export declare const NAME: "$NAME";
 export declare const UI: "$UI";
+export declare const FS: "$FS";
 
 // Symbol for accessing self-reference in patterns
 export declare const SELF: unique symbol;

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2144,3 +2144,25 @@ export type VNode = {
   children?: RenderNode | undefined;
   [UI]?: VNode;
 };
+
+/**
+ * Filesystem projection for a pattern result. Used with the [FS] symbol.
+ *
+ * - `type: "text/markdown"` — render as `index.md` with YAML frontmatter +
+ *   markdown body. Primitive frontmatter fields go into YAML; complex values
+ *   (arrays of entities, nested objects) become sibling directories.
+ * - `type: "application/json"` — render as `index.json` with `content`.
+ * - Plain object (no `type` field) — shorthand: the object itself becomes the
+ *   content of `index.json`.
+ */
+export type FsProjection =
+  | {
+    type: "text/markdown";
+    frontmatter?: Record<string, unknown>;
+    content: string;
+  }
+  | {
+    type: "application/json";
+    content: Record<string, unknown>;
+  }
+  | Record<string, unknown>;

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -68,7 +68,7 @@ function pieceCallRawArgs(tail: string[], literalArgs: string[]): string[] {
   }
 
   if (tail.length === 0) {
-    return ["--json"];
+    return [];
   }
 
   if (tail[0] === "--help") {

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -366,16 +366,11 @@ assert_json_eq \
 success "ct exec runs mounted tools without an explicit verb"
 
 LEGACY_COUNT_BEFORE_EXEC=$(read_piece_value_or_default "legacyCount" "0")
-NO_ARG_HANDLER_ERR=$(mktemp)
-if ct exec "$LEGACY_HANDLER_FILE" >/dev/null 2>"$NO_ARG_HANDLER_ERR"; then
-  error "Handlers without inputs should require invoke for no-arg execution."
-fi
-NO_ARG_HANDLER_ERROR=$(cat "$NO_ARG_HANDLER_ERR")
-rm -f "$NO_ARG_HANDLER_ERR"
-assert_contains "$NO_ARG_HANDLER_ERROR" "use invoke to call it without inputs" "No-arg handler error should explain the explicit invoke requirement."
-ct exec "$LEGACY_HANDLER_FILE" invoke
+ct exec "$LEGACY_HANDLER_FILE"
 wait_for_piece_value "legacyCount" "$((LEGACY_COUNT_BEFORE_EXEC + 1))"
-success "No-arg handlers require invoke, and invoke alone still works for optional-input handlers"
+ct exec "$LEGACY_HANDLER_FILE" invoke
+wait_for_piece_value "legacyCount" "$((LEGACY_COUNT_BEFORE_EXEC + 2))"
+success "Empty-object handlers run without an explicit verb, and invoke still works"
 
 COUNT_BEFORE_PIECES_SHARED=$(read_piece_value_or_default "messageCount" "0")
 ct exec "$HANDLER_FILE" --message "shared-message"

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -302,17 +302,17 @@ if [ "$RESULT" != '"piece-flags"' ]; then
   error "Flag-based handler call should update lastMessage, got: $RESULT"
 fi
 
-NO_ARG_HANDLER_ERR=$(mktemp)
-if ct piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyWrite > /dev/null 2>"$NO_ARG_HANDLER_ERR"; then
-  error "Bare no-arg handler calls should fail without explicit invoke"
+LEGACY_COUNT_BEFORE=$(ct piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyCount)
+ct piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyWrite
+RESULT=$(ct piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyCount)
+if [ "$RESULT" != "$((LEGACY_COUNT_BEFORE + 1))" ]; then
+  error "Bare no-arg handler call should increment legacyCount, got: $RESULT"
 fi
-grep -q "Expected JSON on stdin for --json" "$NO_ARG_HANDLER_ERR" ||
-  error "Bare no-arg handler call should explain that JSON input is required"
 
 ct piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyWrite -- invoke
 RESULT=$(ct piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyCount)
-if [ "$RESULT" != "1" ]; then
-  error "Explicit invoke should call a no-input handler, got legacyCount=$RESULT"
+if [ "$RESULT" != "$((LEGACY_COUNT_BEFORE + 2))" ]; then
+  error "Explicit invoke should still call an empty-object handler, got legacyCount=$RESULT"
 fi
 
 TOOL_RESULT=$(ct piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID search -- --query tea)

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -302,16 +302,15 @@ if [ "$RESULT" != '"piece-flags"' ]; then
   error "Flag-based handler call should update lastMessage, got: $RESULT"
 fi
 
-LEGACY_COUNT_BEFORE=$(ct piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyCount)
 ct piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyWrite
 RESULT=$(ct piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyCount)
-if [ "$RESULT" != "$((LEGACY_COUNT_BEFORE + 1))" ]; then
+if [ "$RESULT" != "1" ]; then
   error "Bare no-arg handler call should increment legacyCount, got: $RESULT"
 fi
 
 ct piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyWrite -- invoke
 RESULT=$(ct piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyCount)
-if [ "$RESULT" != "$((LEGACY_COUNT_BEFORE + 2))" ]; then
+if [ "$RESULT" != "2" ]; then
   error "Explicit invoke should still call an empty-object handler, got legacyCount=$RESULT"
 fi
 

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -119,6 +119,26 @@ test_value() {
   fi
 }
 
+read_piece_value_or_default() {
+  local piece_id="$1"
+  local path="$2"
+  local fallback="$3"
+  local actual
+
+  actual=$(ct piece get $SPACE_ARGS --piece "$piece_id" "$path" 2>/dev/null || true)
+  if [ -z "$actual" ]; then
+    printf '%s\n' "$fallback"
+    return 0
+  fi
+
+  if [[ ! "$actual" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$fallback"
+    return 0
+  fi
+
+  printf '%s\n' "$actual"
+}
+
 test_json_value() {
   local test_name="$1"
   local path="$2"
@@ -302,15 +322,16 @@ if [ "$RESULT" != '"piece-flags"' ]; then
   error "Flag-based handler call should update lastMessage, got: $RESULT"
 fi
 
+LEGACY_COUNT_BEFORE=$(read_piece_value_or_default "$CALLABLE_PIECE_ID" "legacyCount" "0")
 ct piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyWrite
 RESULT=$(ct piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyCount)
-if [ "$RESULT" != "1" ]; then
+if [ "$RESULT" != "$((LEGACY_COUNT_BEFORE + 1))" ]; then
   error "Bare no-arg handler call should increment legacyCount, got: $RESULT"
 fi
 
 ct piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyWrite -- invoke
 RESULT=$(ct piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyCount)
-if [ "$RESULT" != "2" ]; then
+if [ "$RESULT" != "$((LEGACY_COUNT_BEFORE + 2))" ]; then
   error "Explicit invoke should still call an empty-object handler, got legacyCount=$RESULT"
 fi
 

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -30,6 +30,7 @@ export interface ExecInputResolverDeps {
   readJsonInput?: () => Promise<unknown>;
   readTextInput?: () => Promise<string>;
   readTextFile?: (path: string) => Promise<string>;
+  isStdinTerminal?: () => boolean;
 }
 
 interface FlagDescriptor {
@@ -542,6 +543,51 @@ export async function resolveParsedExecInput(
   return parsed.input;
 }
 
+export async function resolveImplicitPipedHandlerInput(
+  spec: ExecCommandSpec,
+  rawArgs: string[],
+  deps: ExecInputResolverDeps = {},
+): Promise<{ parsed: ParsedExecArgs; input: unknown } | null> {
+  if (spec.callableKind !== "handler" || rawArgs.length > 0) {
+    return null;
+  }
+
+  const isTerminal = deps.isStdinTerminal?.() ?? Deno.stdin.isTerminal();
+  if (isTerminal) {
+    return null;
+  }
+
+  const text = await (deps.readTextInput ?? defaultReadTextInput)();
+  if (text.length === 0) {
+    return null;
+  }
+
+  const properties = objectProperties(spec.inputSchema);
+  const input = properties
+    ? parseJsonText(text, "stdin")
+    : parseValueForSchema(text, spec.inputSchema, "--value-file");
+
+  if (
+    properties &&
+    (typeof input !== "object" || input === null || Array.isArray(input))
+  ) {
+    throw new Error("Invalid JSON from stdin: expected object");
+  }
+
+  return {
+    parsed: {
+      verb: spec.defaultVerb,
+      input: properties ? input ?? {} : input,
+      showHelp: false,
+      showHelpJson: false,
+      readJsonFromStdin: false,
+      readTextFromStdin: false,
+      usedJsonInput: properties !== null,
+    },
+    input,
+  };
+}
+
 function schemaDescription(schema: JSONSchema): string | undefined {
   return isSchemaObject(schema) && typeof schema.description === "string"
     ? schema.description
@@ -859,12 +905,9 @@ export function parseExecArgs(
     }
   }
 
-  const props = objectProperties(spec.inputSchema);
-  const hasOptionalInputs = props !== null && Object.keys(props).length > 0 &&
-    requiredFlags(spec.inputSchema).size === 0;
   if (
     spec.callableKind === "handler" && !explicitVerb && args.length === 0 &&
-    !hasOptionalInputs
+    !handlerAllowsInvokeWithoutInputs(spec.inputSchema)
   ) {
     const typeShape = schemaShapeString(spec.inputSchema);
     throw new Error(

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -13,12 +13,23 @@ export interface ParsedExecArgs {
   showHelp: boolean;
   showHelpJson: boolean;
   readJsonFromStdin: boolean;
+  readTextFromStdin: boolean;
+  inputFile?: {
+    format: "json" | "text";
+    path: string;
+  };
   usedJsonInput: boolean;
 }
 
 export interface RenderExecHelpOptions {
   commandPrefix?: string;
   invocationStyle?: "ct" | "direct";
+}
+
+export interface ExecInputResolverDeps {
+  readJsonInput?: () => Promise<unknown>;
+  readTextInput?: () => Promise<string>;
+  readTextFile?: (path: string) => Promise<string>;
 }
 
 interface FlagDescriptor {
@@ -30,6 +41,11 @@ interface FlagDescriptor {
 interface ParsedInputMode {
   input: unknown;
   readJsonFromStdin: boolean;
+  readTextFromStdin: boolean;
+  inputFile?: {
+    format: "json" | "text";
+    path: string;
+  };
   usedJsonInput: boolean;
 }
 
@@ -102,6 +118,18 @@ function parseInlineOrStdinJson(
     throw new Error("--json cannot be combined with generated flags");
   }
   return { inlineValue: candidate, consumeNext: true };
+}
+
+function parseFilePathArg(
+  args: string[],
+  index: number,
+  flagName: string,
+): string {
+  const candidate = args[index + 1];
+  if (candidate === undefined || candidate.startsWith("--")) {
+    throw new Error(`Missing value for ${flagName}`);
+  }
+  return candidate;
 }
 
 function validateEnum(
@@ -182,6 +210,7 @@ function parseObjectInput(
   let usedJson = false;
   let usedGeneratedFlags = false;
   let readJsonFromStdin = false;
+  let inputFile: ParsedInputMode["inputFile"];
 
   for (let i = 0; i < args.length; i++) {
     const token = args[i];
@@ -214,6 +243,24 @@ function parseObjectInput(
       if (consumeNext) {
         i++;
       }
+      continue;
+    }
+
+    if (token === "--json-file") {
+      if (usedGeneratedFlags) {
+        throw new Error("--json-file cannot be combined with generated flags");
+      }
+      if (usedJson) {
+        throw new Error("--json can only be provided once");
+      }
+      usedJson = true;
+      const filePath = parseFilePathArg(args, i, "--json-file");
+      if (filePath === "-") {
+        readJsonFromStdin = true;
+      } else {
+        inputFile = { format: "json", path: filePath };
+      }
+      i++;
       continue;
     }
 
@@ -275,6 +322,17 @@ function parseObjectInput(
     return {
       input: undefined,
       readJsonFromStdin: true,
+      readTextFromStdin: false,
+      usedJsonInput: true,
+    };
+  }
+
+  if (inputFile) {
+    return {
+      input: undefined,
+      readJsonFromStdin: false,
+      readTextFromStdin: false,
+      inputFile,
       usedJsonInput: true,
     };
   }
@@ -292,6 +350,7 @@ function parseObjectInput(
   return {
     input,
     readJsonFromStdin: false,
+    readTextFromStdin: false,
     usedJsonInput: usedJson,
   };
 }
@@ -304,6 +363,7 @@ function parseNonObjectInput(
     return {
       input: undefined,
       readJsonFromStdin: false,
+      readTextFromStdin: false,
       usedJsonInput: false,
     };
   }
@@ -312,18 +372,56 @@ function parseNonObjectInput(
   }
 
   const [flag, rawValue] = args;
-  if (flag !== "--value" && flag !== "--json") {
+  if (
+    flag !== "--value" && flag !== "--json" && flag !== "--value-file" &&
+    flag !== "--json-file"
+  ) {
     throw new Error(`Unknown flag ${flag}`);
   }
   if (flag === "--json" && rawValue === undefined) {
     return {
       input: undefined,
       readJsonFromStdin: true,
+      readTextFromStdin: false,
       usedJsonInput: true,
     };
   }
   if (rawValue === undefined) {
     throw new Error(`Missing value for ${flag}`);
+  }
+  if (flag === "--json-file") {
+    if (rawValue === "-") {
+      return {
+        input: undefined,
+        readJsonFromStdin: true,
+        readTextFromStdin: false,
+        usedJsonInput: true,
+      };
+    }
+    return {
+      input: undefined,
+      readJsonFromStdin: false,
+      readTextFromStdin: false,
+      inputFile: { format: "json", path: rawValue },
+      usedJsonInput: true,
+    };
+  }
+  if (flag === "--value-file") {
+    if (rawValue === "-") {
+      return {
+        input: undefined,
+        readJsonFromStdin: false,
+        readTextFromStdin: true,
+        usedJsonInput: false,
+      };
+    }
+    return {
+      input: undefined,
+      readJsonFromStdin: false,
+      readTextFromStdin: false,
+      inputFile: { format: "text", path: rawValue },
+      usedJsonInput: false,
+    };
   }
   if (flag === "--json") {
     if (rawValue.startsWith("--")) {
@@ -332,12 +430,14 @@ function parseNonObjectInput(
     return {
       input: parseJson(rawValue, flag),
       readJsonFromStdin: false,
+      readTextFromStdin: false,
       usedJsonInput: true,
     };
   }
   return {
     input: parseValueForSchema(rawValue, schema, flag),
     readJsonFromStdin: false,
+    readTextFromStdin: false,
     usedJsonInput: false,
   };
 }
@@ -371,6 +471,75 @@ export function normalizeCallableInputForExecution(
     ...(input as Record<string, unknown>),
     help: "",
   };
+}
+
+async function defaultReadTextInput(): Promise<string> {
+  return await new Response(Deno.stdin.readable).text();
+}
+
+async function defaultReadTextFile(path: string): Promise<string> {
+  return await Deno.readTextFile(path);
+}
+
+function parseJsonText(text: string, source: string): unknown {
+  if (text.trim().length === 0) {
+    throw new Error(`Expected JSON from ${source}`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Invalid JSON from ${source}`);
+  }
+}
+
+export async function resolveParsedExecInput(
+  spec: ExecCommandSpec,
+  parsed: ParsedExecArgs,
+  deps: ExecInputResolverDeps = {},
+): Promise<unknown> {
+  if (parsed.readJsonFromStdin) {
+    if (deps.readJsonInput) {
+      return await deps.readJsonInput();
+    }
+    const text = await (deps.readTextInput ?? defaultReadTextInput)();
+    const value = parseJsonText(text, "stdin for --json");
+    if (
+      objectProperties(spec.inputSchema) &&
+      (typeof value !== "object" || value === null || Array.isArray(value))
+    ) {
+      throw new Error("Invalid JSON from stdin for --json: expected object");
+    }
+    return value;
+  }
+
+  if (parsed.readTextFromStdin) {
+    const text = await (deps.readTextInput ?? defaultReadTextInput)();
+    return parseValueForSchema(text, spec.inputSchema, "--value-file");
+  }
+
+  if (parsed.inputFile) {
+    const text = await (deps.readTextFile ?? defaultReadTextFile)(
+      parsed.inputFile.path,
+    );
+    if (parsed.inputFile.format === "json") {
+      const value = parseJsonText(
+        text,
+        `${parsed.inputFile.path} for --json-file`,
+      );
+      if (
+        objectProperties(spec.inputSchema) &&
+        (typeof value !== "object" || value === null || Array.isArray(value))
+      ) {
+        throw new Error(
+          `Invalid JSON from ${parsed.inputFile.path} for --json-file: expected object`,
+        );
+      }
+      return value;
+    }
+    return parseValueForSchema(text, spec.inputSchema, "--value-file");
+  }
+
+  return parsed.input;
 }
 
 function schemaDescription(schema: JSONSchema): string | undefined {
@@ -437,6 +606,9 @@ function specificFlagLines(schema: JSONSchema): string[] {
   if (!properties) {
     return [
       `  ${`--value ${valuePlaceholder(schema)}`.padEnd(20)}  Required.`,
+      `  ${
+        "--value-file <path>".padEnd(20)
+      }  Read the value from a UTF-8 file. Use - for stdin.`,
     ];
   }
 
@@ -488,12 +660,18 @@ function specificFlagLines(schema: JSONSchema): string[] {
 }
 
 function genericFlagLines(schema: JSONSchema): string[] {
-  const jsonLabel = objectProperties(schema) ? "--json" : "--json";
+  const jsonLabel = "--json";
   const jsonDescription = objectProperties(schema)
     ? "Read the full input object from stdin. Cannot be combined with other input flags."
     : "Read the full input value as JSON from stdin. Cannot be combined with other input flags.";
   const descriptors = [
     { usage: jsonLabel, detail: jsonDescription },
+    {
+      usage: "--json-file <path>",
+      detail: objectProperties(schema)
+        ? "Read the full input object from a JSON file. Use - for stdin."
+        : "Read the full input value as JSON from a file. Use - for stdin.",
+    },
     { usage: "--help", detail: "Show this help." },
     { usage: "--help --json", detail: "Show full schema details as JSON." },
   ];
@@ -588,9 +766,12 @@ function helpUsageLines(
     commandPrefix,
   );
   const verb = optionalVerbUsage(spec);
+  const properties = objectProperties(spec.inputSchema);
   return [
     `  ${usageLine(mountedFilePath, spec, invocationStyle, commandPrefix)}`,
+    ...(!properties ? [`  ${prefix} ${verb} --value-file <path>`] : []),
     `  ${prefix} ${verb} --json`,
+    `  ${prefix} ${verb} --json-file <path>`,
     `  ${prefix} ${verb} --help`,
     `  ${prefix} ${verb} --help --json`,
   ];
@@ -618,6 +799,7 @@ export function parseExecArgs(
         showHelp: true,
         showHelpJson: false,
         readJsonFromStdin: false,
+        readTextFromStdin: false,
         usedJsonInput: false,
       };
     }
@@ -628,6 +810,7 @@ export function parseExecArgs(
         showHelp: true,
         showHelpJson: true,
         readJsonFromStdin: false,
+        readTextFromStdin: false,
         usedJsonInput: false,
       };
     }
@@ -656,6 +839,7 @@ export function parseExecArgs(
         showHelp: true,
         showHelpJson: false,
         readJsonFromStdin: false,
+        readTextFromStdin: false,
         usedJsonInput: false,
       };
     }
@@ -666,6 +850,7 @@ export function parseExecArgs(
         showHelp: true,
         showHelpJson: true,
         readJsonFromStdin: false,
+        readTextFromStdin: false,
         usedJsonInput: false,
       };
     }
@@ -694,12 +879,15 @@ export function parseExecArgs(
 
   return {
     verb,
-    input: properties && !parsedInput.readJsonFromStdin
-      ? parsedInput.input ?? {}
-      : parsedInput.input,
+    input:
+      properties && !parsedInput.readJsonFromStdin && !parsedInput.inputFile
+        ? parsedInput.input ?? {}
+        : parsedInput.input,
     showHelp: false,
     showHelpJson: false,
     readJsonFromStdin: parsedInput.readJsonFromStdin,
+    readTextFromStdin: parsedInput.readTextFromStdin,
+    inputFile: parsedInput.inputFile,
     usedJsonInput: parsedInput.usedJsonInput,
   };
 }
@@ -838,17 +1026,20 @@ function pieceUsageLines(
   commandPrefix: string,
   spec: ExecCommandSpec,
 ): string[] {
+  const properties = objectProperties(spec.inputSchema);
   return [
     `  ${commandPrefix} --help`,
     `  ${commandPrefix} --help --json`,
     `  ${pieceJsonUsageLine(commandPrefix)}`,
+    `  ${commandPrefix} -- --json-file <path>`,
     `  ${pieceFlagUsageLine(commandPrefix, spec)}`,
+    ...(!properties ? [`  ${commandPrefix} -- --value-file <path>`] : []),
   ];
 }
 
 function pieceJsonInputLines(schema: JSONSchema): string[] {
   return [
-    "  Pass inline JSON as the next argument, or pipe JSON on stdin.",
+    "  Pass inline JSON as the next argument, use `-- --json-file <path>`, or pipe JSON on stdin with `-- --json`.",
     ...schemaShapeString(schema).split("\n").map((line) => `  ${line}`),
   ];
 }

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -33,6 +33,11 @@ export interface ExecInputResolverDeps {
   isStdinTerminal?: () => boolean;
 }
 
+export interface ResolvedExecInvocation {
+  parsed: ParsedExecArgs;
+  input?: unknown;
+}
+
 interface FlagDescriptor {
   key: string;
   flagName: string;
@@ -208,6 +213,7 @@ function parseObjectInput(
   }
 
   const input: Record<string, unknown> = {};
+  let directJsonInput: unknown;
   let usedJson = false;
   let usedGeneratedFlags = false;
   let readJsonFromStdin = false;
@@ -232,15 +238,7 @@ function parseObjectInput(
         readJsonFromStdin = true;
         continue;
       }
-      const parsed = parseJson(inlineValue, "--json");
-      if (
-        typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
-      ) {
-        throw new Error("Invalid JSON for --json: expected object");
-      }
-      // TODO(#3117): validate decoded --json input against the linked schema here so
-      // callers get field-level CLI errors before runner-side validation.
-      Object.assign(input, parsed as Record<string, unknown>);
+      directJsonInput = parseJson(inlineValue, "--json");
       if (consumeNext) {
         i++;
       }
@@ -349,7 +347,7 @@ function parseObjectInput(
   }
 
   return {
-    input,
+    input: usedJson ? directJsonInput : input,
     readJsonFromStdin: false,
     readTextFromStdin: false,
     usedJsonInput: usedJson,
@@ -503,14 +501,7 @@ export async function resolveParsedExecInput(
       return await deps.readJsonInput();
     }
     const text = await (deps.readTextInput ?? defaultReadTextInput)();
-    const value = parseJsonText(text, "stdin for --json");
-    if (
-      objectProperties(spec.inputSchema) &&
-      (typeof value !== "object" || value === null || Array.isArray(value))
-    ) {
-      throw new Error("Invalid JSON from stdin for --json: expected object");
-    }
-    return value;
+    return parseJsonText(text, "stdin for --json");
   }
 
   if (parsed.readTextFromStdin) {
@@ -523,19 +514,10 @@ export async function resolveParsedExecInput(
       parsed.inputFile.path,
     );
     if (parsed.inputFile.format === "json") {
-      const value = parseJsonText(
+      return parseJsonText(
         text,
         `${parsed.inputFile.path} for --json-file`,
       );
-      if (
-        objectProperties(spec.inputSchema) &&
-        (typeof value !== "object" || value === null || Array.isArray(value))
-      ) {
-        throw new Error(
-          `Invalid JSON from ${parsed.inputFile.path} for --json-file: expected object`,
-        );
-      }
-      return value;
     }
     return parseValueForSchema(text, spec.inputSchema, "--value-file");
   }
@@ -543,11 +525,11 @@ export async function resolveParsedExecInput(
   return parsed.input;
 }
 
-export async function resolveImplicitPipedHandlerInput(
+async function resolveImplicitPipedHandlerInput(
   spec: ExecCommandSpec,
   rawArgs: string[],
   deps: ExecInputResolverDeps = {},
-): Promise<{ parsed: ParsedExecArgs; input: unknown } | null> {
+): Promise<ResolvedExecInvocation | null> {
   if (spec.callableKind !== "handler" || rawArgs.length > 0) {
     return null;
   }
@@ -570,7 +552,7 @@ export async function resolveImplicitPipedHandlerInput(
   return {
     parsed: {
       verb: spec.defaultVerb,
-      input: properties ? input ?? {} : input,
+      input,
       showHelp: false,
       showHelpJson: false,
       readJsonFromStdin: false,
@@ -578,6 +560,27 @@ export async function resolveImplicitPipedHandlerInput(
       usedJsonInput: properties !== null,
     },
     input,
+  };
+}
+
+export async function resolveExecInvocation(
+  spec: ExecCommandSpec,
+  rawArgs: string[],
+  deps: ExecInputResolverDeps = {},
+): Promise<ResolvedExecInvocation> {
+  const implicit = await resolveImplicitPipedHandlerInput(spec, rawArgs, deps);
+  if (implicit) {
+    return implicit;
+  }
+
+  const parsed = parseExecArgs(spec, rawArgs);
+  if (parsed.showHelp) {
+    return { parsed };
+  }
+
+  return {
+    parsed,
+    input: await resolveParsedExecInput(spec, parsed, deps),
   };
 }
 
@@ -916,7 +919,8 @@ export function parseExecArgs(
   return {
     verb,
     input:
-      properties && !parsedInput.readJsonFromStdin && !parsedInput.inputFile
+      properties && !parsedInput.readJsonFromStdin && !parsedInput.inputFile &&
+        !parsedInput.usedJsonInput
         ? parsedInput.input ?? {}
         : parsedInput.input,
     showHelp: false,

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -675,8 +675,9 @@ export function parseExecArgs(
   }
 
   if (spec.callableKind === "handler" && !explicitVerb && args.length === 0) {
+    const typeShape = schemaShapeString(spec.inputSchema);
     throw new Error(
-      "Refusing to invoke handler with no inputs; use invoke to call it without inputs",
+      `Handler requires input. Expected type: ${typeShape}\nRun --help for full usage.`,
     );
   }
 
@@ -717,10 +718,14 @@ export function renderExecHelp(
   const invocationStyle = options.invocationStyle ?? "ct";
   const specificFlags = specificFlagLines(spec.inputSchema);
   const genericFlags = genericFlagLines(spec.inputSchema);
+  const typeShape = schemaShapeString(spec.inputSchema);
 
   const lines = [
     "Usage:",
     ...helpUsageLines(mountedFilePath, spec, invocationStyle, commandPrefix),
+    "",
+    "Input type:",
+    ...typeShape.split("\n").map((line) => `  ${line}`),
     "",
     "Flags:",
     ...specificFlags,

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -567,13 +567,6 @@ export async function resolveImplicitPipedHandlerInput(
     ? parseJsonText(text, "stdin")
     : parseValueForSchema(text, spec.inputSchema, "--value-file");
 
-  if (
-    properties &&
-    (typeof input !== "object" || input === null || Array.isArray(input))
-  ) {
-    throw new Error("Invalid JSON from stdin: expected object");
-  }
-
   return {
     parsed: {
       verb: spec.defaultVerb,

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -674,7 +674,13 @@ export function parseExecArgs(
     }
   }
 
-  if (spec.callableKind === "handler" && !explicitVerb && args.length === 0) {
+  const props = objectProperties(spec.inputSchema);
+  const hasOptionalInputs = props !== null && Object.keys(props).length > 0 &&
+    requiredFlags(spec.inputSchema).size === 0;
+  if (
+    spec.callableKind === "handler" && !explicitVerb && args.length === 0 &&
+    !hasOptionalInputs
+  ) {
     const typeShape = schemaShapeString(spec.inputSchema);
     throw new Error(
       `Handler requires input. Expected type: ${typeShape}\nRun --help for full usage.`,

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -12,6 +12,7 @@ import {
   parseExecArgs,
   renderExecHelp,
   renderExecHelpJson,
+  resolveImplicitPipedHandlerInput,
   resolveParsedExecInput,
 } from "./exec-schema.ts";
 import {
@@ -51,6 +52,7 @@ export interface ExecDependencies {
   readJsonInput?: () => Promise<unknown>;
   readTextInput?: () => Promise<string>;
   readTextFile?: (path: string) => Promise<string>;
+  isStdinTerminal?: () => boolean;
 }
 
 export interface ExecutedMountedCallableFile {
@@ -164,7 +166,13 @@ export async function executeMountedCallableFile(
   deps: ExecDependencies = {},
 ): Promise<ExecutedMountedCallableFile> {
   const resolved = await resolveMountedCallableFile(filePath, deps);
-  const parsed = parseExecArgs(resolved.commandSpec, rawArgs);
+  const implicitInput = await resolveImplicitPipedHandlerInput(
+    resolved.commandSpec,
+    rawArgs,
+    deps,
+  );
+  const parsed = implicitInput?.parsed ??
+    parseExecArgs(resolved.commandSpec, rawArgs);
   const invocationStyle = deps.invocationStyle ??
     (Deno.env.get("CT_EXEC_SHEBANG") === "1" ? "direct" : "ct");
 
@@ -180,11 +188,12 @@ export async function executeMountedCallableFile(
     };
   }
 
-  const input = await resolveParsedExecInput(
-    resolved.commandSpec,
-    parsed,
-    deps,
-  );
+  const input = implicitInput?.input ??
+    await resolveParsedExecInput(
+      resolved.commandSpec,
+      parsed,
+      deps,
+    );
   const executed = await executeResolvedCallable(
     {
       callableCell: resolved.callableCell,

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -12,6 +12,7 @@ import {
   parseExecArgs,
   renderExecHelp,
   renderExecHelpJson,
+  resolveParsedExecInput,
 } from "./exec-schema.ts";
 import {
   canonicalizeMountLookupPath,
@@ -48,6 +49,8 @@ export interface ExecDependencies {
   waitForResult?: (resultCell: any, timeoutMs: number) => Promise<unknown>;
   invocationStyle?: "ct" | "direct";
   readJsonInput?: () => Promise<unknown>;
+  readTextInput?: () => Promise<string>;
+  readTextFile?: (path: string) => Promise<string>;
 }
 
 export interface ExecutedMountedCallableFile {
@@ -104,19 +107,6 @@ async function assertMountedCallableFileExists(absPath: string): Promise<void> {
 
   if (!stat.isFile) {
     throw new Error(`Mounted callable file not found: ${absPath}`);
-  }
-}
-
-async function defaultReadJsonInput(): Promise<unknown> {
-  const text = await new Response(Deno.stdin.readable).text();
-  if (text.trim().length === 0) {
-    throw new Error("Expected JSON on stdin for --json");
-  }
-
-  try {
-    return JSON.parse(text);
-  } catch {
-    throw new Error("Invalid JSON on stdin for --json");
   }
 }
 
@@ -190,9 +180,11 @@ export async function executeMountedCallableFile(
     };
   }
 
-  const input = parsed.readJsonFromStdin
-    ? await (deps.readJsonInput ?? defaultReadJsonInput)()
-    : parsed.input;
+  const input = await resolveParsedExecInput(
+    resolved.commandSpec,
+    parsed,
+    deps,
+  );
   const executed = await executeResolvedCallable(
     {
       callableCell: resolved.callableCell,

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -9,11 +9,9 @@ import {
   type ExecCommandSpec,
   normalizeCallableInputForExecution,
   type ParsedExecArgs,
-  parseExecArgs,
   renderExecHelp,
   renderExecHelpJson,
-  resolveImplicitPipedHandlerInput,
-  resolveParsedExecInput,
+  resolveExecInvocation,
 } from "./exec-schema.ts";
 import {
   canonicalizeMountLookupPath,
@@ -166,13 +164,12 @@ export async function executeMountedCallableFile(
   deps: ExecDependencies = {},
 ): Promise<ExecutedMountedCallableFile> {
   const resolved = await resolveMountedCallableFile(filePath, deps);
-  const implicitInput = await resolveImplicitPipedHandlerInput(
+  const invocation = await resolveExecInvocation(
     resolved.commandSpec,
     rawArgs,
     deps,
   );
-  const parsed = implicitInput?.parsed ??
-    parseExecArgs(resolved.commandSpec, rawArgs);
+  const parsed = invocation.parsed;
   const invocationStyle = deps.invocationStyle ??
     (Deno.env.get("CT_EXEC_SHEBANG") === "1" ? "direct" : "ct");
 
@@ -188,12 +185,7 @@ export async function executeMountedCallableFile(
     };
   }
 
-  const input = implicitInput?.input ??
-    await resolveParsedExecInput(
-      resolved.commandSpec,
-      parsed,
-      deps,
-    );
+  const input = invocation.input;
   const executed = await executeResolvedCallable(
     {
       callableCell: resolved.callableCell,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -25,6 +25,7 @@ import {
   parseExecArgs,
   renderExecHelpJson,
   renderPieceCallHelp,
+  resolveImplicitPipedHandlerInput,
   resolveParsedExecInput,
 } from "./exec-schema.ts";
 
@@ -55,6 +56,7 @@ export interface PieceCallableDependencies extends CallableExecutionDeps {
   readJsonInput?: () => Promise<unknown>;
   readTextInput?: () => Promise<string>;
   readTextFile?: (path: string) => Promise<string>;
+  isStdinTerminal?: () => boolean;
 }
 
 export interface ExecutedPieceCallable {
@@ -445,7 +447,13 @@ export async function executePieceCallable(
   deps: PieceCallableDependencies = {},
 ): Promise<ExecutedPieceCallable> {
   const resolved = await resolvePieceCallable(config, callableName, deps);
-  const parsed = parseExecArgs(resolved.commandSpec, rawArgs);
+  const implicitInput = await resolveImplicitPipedHandlerInput(
+    resolved.commandSpec,
+    rawArgs,
+    deps,
+  );
+  const parsed = implicitInput?.parsed ??
+    parseExecArgs(resolved.commandSpec, rawArgs);
 
   if (parsed.showHelp) {
     return {
@@ -460,11 +468,12 @@ export async function executePieceCallable(
     };
   }
 
-  const input = await resolveParsedExecInput(
-    resolved.commandSpec,
-    parsed,
-    deps,
-  );
+  const input = implicitInput?.input ??
+    await resolveParsedExecInput(
+      resolved.commandSpec,
+      parsed,
+      deps,
+    );
   const executed = await executeResolvedCallable(
     resolved,
     parsed.usedJsonInput

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -25,6 +25,7 @@ import {
   parseExecArgs,
   renderExecHelpJson,
   renderPieceCallHelp,
+  resolveParsedExecInput,
 } from "./exec-schema.ts";
 
 export interface EntryConfig {
@@ -52,6 +53,8 @@ export interface PieceCallableDependencies extends CallableExecutionDeps {
   loadManager?: (config: SpaceConfig) => Promise<any>;
   loadPiece?: (manager: any, pieceId: string) => Promise<any>;
   readJsonInput?: () => Promise<unknown>;
+  readTextInput?: () => Promise<string>;
+  readTextFile?: (path: string) => Promise<string>;
 }
 
 export interface ExecutedPieceCallable {
@@ -262,19 +265,6 @@ export async function applyPieceInput(
   await piece.setInput(input);
 }
 
-async function defaultReadJsonInput(): Promise<unknown> {
-  const text = await new Response(Deno.stdin.readable).text();
-  if (text.trim().length === 0) {
-    throw new Error("Expected JSON on stdin for --json");
-  }
-
-  try {
-    return JSON.parse(text);
-  } catch {
-    throw new Error("Invalid JSON on stdin for --json");
-  }
-}
-
 function getCallableValue(rootValue: unknown, callableName: string): unknown {
   if (
     typeof rootValue !== "object" || rootValue === null ||
@@ -470,9 +460,11 @@ export async function executePieceCallable(
     };
   }
 
-  const input = parsed.readJsonFromStdin
-    ? await (deps.readJsonInput ?? defaultReadJsonInput)()
-    : parsed.input;
+  const input = await resolveParsedExecInput(
+    resolved.commandSpec,
+    parsed,
+    deps,
+  );
   const executed = await executeResolvedCallable(
     resolved,
     parsed.usedJsonInput

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -22,11 +22,9 @@ import {
   type ExecCommandSpec,
   normalizeCallableInputForExecution,
   type ParsedExecArgs,
-  parseExecArgs,
   renderExecHelpJson,
   renderPieceCallHelp,
-  resolveImplicitPipedHandlerInput,
-  resolveParsedExecInput,
+  resolveExecInvocation,
 } from "./exec-schema.ts";
 
 export interface EntryConfig {
@@ -447,13 +445,12 @@ export async function executePieceCallable(
   deps: PieceCallableDependencies = {},
 ): Promise<ExecutedPieceCallable> {
   const resolved = await resolvePieceCallable(config, callableName, deps);
-  const implicitInput = await resolveImplicitPipedHandlerInput(
+  const invocation = await resolveExecInvocation(
     resolved.commandSpec,
     rawArgs,
     deps,
   );
-  const parsed = implicitInput?.parsed ??
-    parseExecArgs(resolved.commandSpec, rawArgs);
+  const parsed = invocation.parsed;
 
   if (parsed.showHelp) {
     return {
@@ -468,12 +465,7 @@ export async function executePieceCallable(
     };
   }
 
-  const input = implicitInput?.input ??
-    await resolveParsedExecInput(
-      resolved.commandSpec,
-      parsed,
-      deps,
-    );
+  const input = invocation.input;
   const executed = await executeResolvedCallable(
     resolved,
     parsed.usedJsonInput

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -357,9 +357,9 @@ describe("resolveParsedExecInput", () => {
     const parsed = parseExecArgs(spec, ["--value-file", "/tmp/content.md"]);
 
     const input = await resolveParsedExecInput(spec, parsed, {
-      readTextFile: async (path) => {
+      readTextFile: (path) => {
         expect(path).toBe("/tmp/content.md");
-        return "# Title\n\nLine 2";
+        return Promise.resolve("# Title\n\nLine 2");
       },
     });
 
@@ -382,9 +382,11 @@ describe("resolveParsedExecInput", () => {
     const parsed = parseExecArgs(spec, ["--json-file", "/tmp/input.json"]);
 
     const input = await resolveParsedExecInput(spec, parsed, {
-      readTextFile: async (path) => {
+      readTextFile: (path) => {
         expect(path).toBe("/tmp/input.json");
-        return '{"detail":{"value":"Use `cat` to read files"}}';
+        return Promise.resolve(
+          '{"detail":{"value":"Use `cat` to read files"}}',
+        );
       },
     });
 

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -226,6 +226,22 @@ describe("parseExecArgs", () => {
     });
   });
 
+  it("preserves inline --json payloads for object schemas without CLI shape enforcement", () => {
+    const result = parseExecArgs(
+      makeSpec("handler", {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+      }),
+      ["--json", '["not-an-object"]'],
+    );
+
+    expect(result.usedJsonInput).toBe(true);
+    expect(result.input).toEqual(["not-an-object"]);
+  });
+
   it("treats bare --json as stdin input mode", () => {
     const result = parseExecArgs(
       makeSpec("tool", {
@@ -405,6 +421,43 @@ describe("resolveParsedExecInput", () => {
     expect(input).toEqual({
       detail: { value: "Use `cat` to read files" },
     });
+  });
+
+  it("reads --json stdin payloads for object inputs without CLI shape enforcement", async () => {
+    const spec = makeSpec("handler", {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+      required: ["query"],
+    });
+    const parsed = parseExecArgs(spec, ["--json"]);
+
+    const input = await resolveParsedExecInput(spec, parsed, {
+      readTextInput: () => Promise.resolve('["not-an-object"]'),
+    });
+
+    expect(input).toEqual(["not-an-object"]);
+  });
+
+  it("reads --json-file payloads for object inputs without CLI shape enforcement", async () => {
+    const spec = makeSpec("handler", {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+      required: ["query"],
+    });
+    const parsed = parseExecArgs(spec, ["--json-file", "/tmp/input.json"]);
+
+    const input = await resolveParsedExecInput(spec, parsed, {
+      readTextFile: (path) => {
+        expect(path).toBe("/tmp/input.json");
+        return Promise.resolve('["not-an-object"]');
+      },
+    });
+
+    expect(input).toEqual(["not-an-object"]);
   });
 });
 

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -260,7 +260,7 @@ describe("parseExecArgs", () => {
         [],
       )
     ).toThrow(
-      /Refusing to invoke handler with no inputs; use invoke to call it without inputs/i,
+      /Handler requires input/i,
     );
   });
 

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -9,6 +9,7 @@ import {
   renderExecHelp,
   renderExecHelpJson,
   renderPieceCallHelp,
+  resolveParsedExecInput,
 } from "../lib/exec-schema.ts";
 import {
   executeMountedCallableFile,
@@ -241,6 +242,45 @@ describe("parseExecArgs", () => {
     expect(result.input).toBeUndefined();
   });
 
+  it("supports file-based value and JSON input modes", () => {
+    const valueFile = parseExecArgs(
+      makeSpec("handler", { type: "string" }),
+      ["--value-file", "/tmp/content.md"],
+    );
+    const jsonFile = parseExecArgs(
+      makeSpec("tool", {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+      }),
+      ["--json-file", "/tmp/input.json"],
+    );
+
+    expect(valueFile.inputFile).toEqual({
+      format: "text",
+      path: "/tmp/content.md",
+    });
+    expect(valueFile.readTextFromStdin).toBe(false);
+    expect(jsonFile.inputFile).toEqual({
+      format: "json",
+      path: "/tmp/input.json",
+    });
+    expect(jsonFile.readJsonFromStdin).toBe(false);
+  });
+
+  it("supports reading primitive values from stdin via --value-file -", () => {
+    const result = parseExecArgs(
+      makeSpec("handler", { type: "string" }),
+      ["--value-file", "-"],
+    );
+
+    expect(result.readTextFromStdin).toBe(true);
+    expect(result.readJsonFromStdin).toBe(false);
+    expect(result.input).toBeUndefined();
+  });
+
   it("preserves omitted non-object inputs as undefined", () => {
     const primitive = parseExecArgs(
       makeSpec("handler", { type: "number" }),
@@ -311,6 +351,49 @@ describe("parseExecArgs", () => {
   });
 });
 
+describe("resolveParsedExecInput", () => {
+  it("reads text payloads from files for primitive inputs", async () => {
+    const spec = makeSpec("handler", { type: "string" });
+    const parsed = parseExecArgs(spec, ["--value-file", "/tmp/content.md"]);
+
+    const input = await resolveParsedExecInput(spec, parsed, {
+      readTextFile: async (path) => {
+        expect(path).toBe("/tmp/content.md");
+        return "# Title\n\nLine 2";
+      },
+    });
+
+    expect(input).toBe("# Title\n\nLine 2");
+  });
+
+  it("reads JSON payloads from files for object inputs", async () => {
+    const spec = makeSpec("tool", {
+      type: "object",
+      properties: {
+        detail: {
+          type: "object",
+          properties: {
+            value: { type: "string" },
+          },
+        },
+      },
+      required: ["detail"],
+    });
+    const parsed = parseExecArgs(spec, ["--json-file", "/tmp/input.json"]);
+
+    const input = await resolveParsedExecInput(spec, parsed, {
+      readTextFile: async (path) => {
+        expect(path).toBe("/tmp/input.json");
+        return '{"detail":{"value":"Use `cat` to read files"}}';
+      },
+    });
+
+    expect(input).toEqual({
+      detail: { value: "Use `cat` to read files" },
+    });
+  });
+});
+
 describe("renderExecHelp", () => {
   it("renders flag-first tool help without schema prose", () => {
     const help = renderExecHelp(
@@ -340,10 +423,12 @@ describe("renderExecHelp", () => {
     expect(help).toContain("Usage:");
     expect(help).toContain("ct exec /tmp/search.tool [run] --query <string>");
     expect(help).toContain("ct exec /tmp/search.tool [run] --json");
+    expect(help).toContain("ct exec /tmp/search.tool [run] --json-file <path>");
     expect(help).toContain("ct exec /tmp/search.tool [run] --help --json");
     expect(help).toContain("--query <string>");
     expect(help).toContain('Optional input field named "help".');
     expect(help).toContain("Read the full input object from stdin.");
+    expect(help).toContain("Read the full input object from a JSON file.");
     expect(help).toContain("Show full schema details as JSON.");
     expect(help).toContain("Output:");
     expect(help).toContain("JSON on success:");
@@ -418,9 +503,19 @@ describe("renderExecHelp", () => {
     expect(help).toContain(
       "ct exec /tmp/number.handler [invoke] --value <number>",
     );
+    expect(help).toContain(
+      "ct exec /tmp/number.handler [invoke] --value-file <path>",
+    );
     expect(help).toContain("ct exec /tmp/number.handler [invoke] --json");
+    expect(help).toContain(
+      "ct exec /tmp/number.handler [invoke] --json-file <path>",
+    );
     expect(help).toContain("--value <number>");
+    expect(help).toContain("--value-file <path>");
     expect(help).toContain("Read the full input value as JSON from stdin.");
+    expect(help).toContain(
+      "Read the value from a UTF-8 file. Use - for stdin.",
+    );
   });
 
   it("renders boolean help fields without colliding with command help", () => {

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -294,14 +294,26 @@ describe("parseExecArgs", () => {
     expect(() =>
       parseExecArgs(
         makeSpec("handler", {
-          type: "object",
-          properties: {},
+          type: "string",
         }),
         [],
       )
     ).toThrow(
       /Handler requires input/i,
     );
+  });
+
+  it("allows handlers with empty object inputs to invoke without arguments", () => {
+    const result = parseExecArgs(
+      makeSpec("handler", {
+        type: "object",
+        properties: {},
+      }),
+      [],
+    );
+
+    expect(result.verb).toBe("invoke");
+    expect(result.input).toEqual({});
   });
 
   it("allows invoke alone for handlers whose inputs are all optional", () => {
@@ -1161,6 +1173,43 @@ describe("mounted callable resolution and execution", () => {
         cellProp: "result",
         path: ["add"],
         value: { query: "milk" },
+      },
+    ]);
+  });
+
+  it("infers piped stdin for mounted primitive handlers when no args are provided", async () => {
+    const mountpoint = join(tmpDir, "mount");
+    const filePath = await createMountedFile(mountpoint, {
+      relativePath: "home/pieces/notes-2/result/add.handler",
+      pieceId: "of:piece-123",
+    });
+    const harness = createExecHarness({
+      callableKind: "handler",
+      cellProp: "result",
+      cellKey: "add",
+      pieceId: "of:piece-123",
+      inputSchema: { type: "string" },
+    });
+
+    await writeLiveMountState(stateDir, mountpoint);
+
+    await executeMountedCallableFile(
+      filePath,
+      [],
+      {
+        stateDir,
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        isStdinTerminal: () => false,
+        readTextInput: () => Promise.resolve("# Title\n\nLine 2"),
+      },
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["add"],
+        value: "# Title\n\nLine 2",
       },
     ]);
   });

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -1214,6 +1214,47 @@ describe("mounted callable resolution and execution", () => {
     ]);
   });
 
+  it("passes implicit piped JSON through for mounted object handlers without CLI shape enforcement", async () => {
+    const mountpoint = join(tmpDir, "mount");
+    const filePath = await createMountedFile(mountpoint, {
+      relativePath: "home/pieces/notes-2/result/add.handler",
+      pieceId: "of:piece-123",
+    });
+    const harness = createExecHarness({
+      callableKind: "handler",
+      cellProp: "result",
+      cellKey: "add",
+      pieceId: "of:piece-123",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+      },
+    });
+
+    await writeLiveMountState(stateDir, mountpoint);
+
+    await executeMountedCallableFile(
+      filePath,
+      [],
+      {
+        stateDir,
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        isStdinTerminal: () => false,
+        readTextInput: () => Promise.resolve('["not-an-object"]'),
+      },
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["add"],
+        value: ["not-an-object"],
+      },
+    ]);
+  });
+
   it("passes stdin --json through unchanged for mounted tools", async () => {
     const mountpoint = join(tmpDir, "mount");
     const filePath = await createMountedFile(mountpoint, {

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -190,6 +190,86 @@ describe("executePieceCallable", () => {
     ]);
   });
 
+  it("infers piped stdin for primitive handlers when no args are provided", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "editContent",
+      inputSchema: { type: "string" },
+    });
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "of:piece-123",
+        space: "home",
+      },
+      "editContent",
+      [],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        isStdinTerminal: () => false,
+        readTextInput: () => Promise.resolve("# Title\n\nLine 2"),
+      },
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["editContent"],
+        value: "# Title\n\nLine 2",
+      },
+    ]);
+  });
+
+  it("infers piped stdin for object handlers when no args are provided", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "editContent",
+      inputSchema: {
+        type: "object",
+        properties: {
+          detail: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+          },
+        },
+        required: ["detail"],
+      },
+    });
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "of:piece-123",
+        space: "home",
+      },
+      "editContent",
+      [],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        isStdinTerminal: () => false,
+        readTextInput: () =>
+          Promise.resolve('{"detail":{"value":"Use `cat` to read files"}}'),
+      },
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["editContent"],
+        value: {
+          detail: { value: "Use `cat` to read files" },
+        },
+      },
+    ]);
+  });
+
   it("renders piece-call help with the piece-call command prefix", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "tool",

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -110,6 +110,86 @@ describe("executePieceCallable", () => {
     });
   });
 
+  it("reads primitive handler input from --value-file", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "editContent",
+      inputSchema: { type: "string" },
+    });
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "of:piece-123",
+        space: "home",
+      },
+      "editContent",
+      ["--value-file", "/tmp/content.md"],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        readTextFile: () => Promise.resolve("# Title\n\nUse `cat` here"),
+      },
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["editContent"],
+        value: "# Title\n\nUse `cat` here",
+      },
+    ]);
+  });
+
+  it("reads object handler input from --json-file", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "editContent",
+      inputSchema: {
+        type: "object",
+        properties: {
+          detail: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+          },
+        },
+        required: ["detail"],
+      },
+    });
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "of:piece-123",
+        space: "home",
+      },
+      "editContent",
+      ["--json-file", "/tmp/input.json"],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        readTextFile: () =>
+          Promise.resolve(
+            '{"detail":{"value":"Use `cat` to read files"}}',
+          ),
+      },
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["editContent"],
+        value: {
+          detail: { value: "Use `cat` to read files" },
+        },
+      },
+    ]);
+  });
+
   it("renders piece-call help with the piece-call command prefix", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "tool",

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -270,6 +270,50 @@ describe("executePieceCallable", () => {
     ]);
   });
 
+  it("passes implicit piped JSON through for object handlers without CLI shape enforcement", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "editContent",
+      inputSchema: {
+        type: "object",
+        properties: {
+          detail: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+          },
+        },
+        required: ["detail"],
+      },
+    });
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "of:piece-123",
+        space: "home",
+      },
+      "editContent",
+      [],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        isStdinTerminal: () => false,
+        readTextInput: () => Promise.resolve('["not-an-object"]'),
+      },
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["editContent"],
+        value: ["not-an-object"],
+      },
+    ]);
+  });
+
   it("renders piece-call help with the piece-call command prefix", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "tool",

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -190,6 +190,49 @@ describe("executePieceCallable", () => {
     ]);
   });
 
+  it("passes --json-file payloads through for object handlers without CLI shape enforcement", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "editContent",
+      inputSchema: {
+        type: "object",
+        properties: {
+          detail: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+          },
+        },
+        required: ["detail"],
+      },
+    });
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "of:piece-123",
+        space: "home",
+      },
+      "editContent",
+      ["--json-file", "/tmp/input.json"],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        readTextFile: () => Promise.resolve('["not-an-object"]'),
+      },
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["editContent"],
+        value: ["not-an-object"],
+      },
+    ]);
+  });
+
   it("infers piped stdin for primitive handlers when no args are provided", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "handler",
@@ -302,6 +345,48 @@ describe("executePieceCallable", () => {
         loadPiece: () => Promise.resolve(harness.piece),
         isStdinTerminal: () => false,
         readTextInput: () => Promise.resolve('["not-an-object"]'),
+      },
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["editContent"],
+        value: ["not-an-object"],
+      },
+    ]);
+  });
+
+  it("passes inline --json through for object handlers without CLI shape enforcement", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "editContent",
+      inputSchema: {
+        type: "object",
+        properties: {
+          detail: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+          },
+        },
+        required: ["detail"],
+      },
+    });
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "of:piece-123",
+        space: "home",
+      },
+      "editContent",
+      ["--json", '["not-an-object"]'],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
       },
     );
 

--- a/packages/fuse/callables.ts
+++ b/packages/fuse/callables.ts
@@ -112,7 +112,9 @@ export function buildCallableScript(
   const schemaComment = schema !== undefined
     ? `# schema: ${JSON.stringify(schema)}\n`
     : "";
-  const typeComment = typeStr !== undefined ? `# input: ${typeStr}\n` : "";
+  const typeComment = typeStr !== undefined
+    ? `# input: ${typeStr.replaceAll("\n", "\n# ")}\n`
+    : "";
   return encoder.encode(
     `#!${shim} exec\n${schemaComment}${typeComment}exec ${
       shellQuote(shim)

--- a/packages/fuse/callables.ts
+++ b/packages/fuse/callables.ts
@@ -101,12 +101,22 @@ export function classifyCallableEntry(
   return null;
 }
 
-export function buildCallableScript(execCli: string): Uint8Array {
+export function buildCallableScript(
+  execCli: string,
+  schema?: JSONSchema,
+  typeStr?: string,
+): Uint8Array {
   const shim = execCli || "/usr/bin/false";
-  // Some environments fall back to running mounted files through the shell
-  // instead of honoring the nested shebang interpreter directly.
+  // Comments are readable via `cat` and `head`; ct exec handles --help and
+  // flag-based invocation (--value <x> for scalars, --flag <v> for objects).
+  const schemaComment = schema !== undefined
+    ? `# schema: ${JSON.stringify(schema)}\n`
+    : "";
+  const typeComment = typeStr !== undefined ? `# input: ${typeStr}\n` : "";
   return encoder.encode(
-    `#!${shim} exec\nexec ${shellQuote(shim)} exec "$0" "$@"\n`,
+    `#!${shim} exec\n${schemaComment}${typeComment}exec ${
+      shellQuote(shim)
+    } exec "$0" "$@"\n`,
   );
 }
 

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -152,6 +152,11 @@ type SubscribePiece = (
   spaceName: string,
 ) => Promise<Array<() => void>>;
 
+type WriteFsFile = (
+  writePath: unknown,
+  text: string,
+) => Promise<boolean>;
+
 // ---------------------------------------------------------------------------
 // Group 1: loadPieceTree — initial tree structure
 // ---------------------------------------------------------------------------
@@ -383,6 +388,80 @@ Deno.test("CellBridge.updateIndexJson writes .index.json mapping names to entity
 
   assertEquals(indexJson["Alpha"], "of:alpha");
   assertEquals(indexJson["Beta"], "of:beta");
+});
+
+Deno.test("CellBridge.writeFsFile writes markdown frontmatter and body to FS paths", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/ct-exec");
+  const writes: Array<{ path: (string | number)[]; value: unknown }> = [];
+
+  const ok = await (bridge as unknown as { writeFsFile: WriteFsFile })
+    .writeFsFile(
+      {
+        fsProjection: "markdown",
+        piece: {
+          result: {
+            set: (
+              value: unknown,
+              path?: (string | number)[],
+            ) => {
+              writes.push({ path: path ?? [], value });
+              return Promise.resolve();
+            },
+          },
+        },
+      },
+      "---\ntitle: Updated Title\n---\n\nUpdated body",
+    );
+
+  assertEquals(ok, true);
+  assertEquals(writes, [
+    { path: ["$FS", "frontmatter", "title"], value: "Updated Title" },
+    { path: ["$FS", "content"], value: "Updated body" },
+  ]);
+});
+
+Deno.test("CellBridge.writeFsFile removes deleted keys from application/json projections", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/ct-exec");
+  const writes: Array<{ path: (string | number)[]; value: unknown }> = [];
+
+  const ok = await (bridge as unknown as { writeFsFile: WriteFsFile })
+    .writeFsFile(
+      {
+        fsProjection: "json",
+        piece: {
+          result: {
+            get: (path?: (string | number)[]) => {
+              if (path?.join("/") === "$FS") {
+                return Promise.resolve({
+                  type: "application/json",
+                  content: { title: "Old", stale: true },
+                });
+              }
+              if (path?.join("/") === "$FS/content") {
+                return Promise.resolve({ title: "Old", stale: true });
+              }
+              return Promise.resolve(undefined);
+            },
+            set: (
+              value: unknown,
+              path?: (string | number)[],
+            ) => {
+              writes.push({ path: path ?? [], value });
+              return Promise.resolve();
+            },
+          },
+        },
+      },
+      '{"title":"New"}',
+    );
+
+  assertEquals(ok, true);
+  assertEquals(writes, [
+    { path: ["$FS", "content", "title"], value: "New" },
+    { path: ["$FS", "content", "stale"], value: undefined },
+  ]);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -110,6 +110,7 @@ function buildTestSpace(
     piecesIno,
     entitiesIno,
     pieceMap: new Map(),
+    pieceAliases: new Map(),
     pieceControllers: new Map(),
     pieceSubs: new Map(),
     did: "did:key:zTest",
@@ -634,9 +635,80 @@ Deno.test("CellBridge.subscribePiece renames directory when piece name changes",
     true,
     "New Name dir should exist after rename",
   );
+  const oldNameIno = tree.lookup(state.piecesIno, "Old Name");
+  assertEquals(oldNameIno !== undefined, true, "Old Name alias should remain");
+  const oldNameNode = tree.getNode(oldNameIno!);
   assertEquals(
-    tree.lookup(state.piecesIno, "Old Name"),
+    oldNameNode?.kind,
+    "symlink",
+    "Old Name should become a compatibility symlink after rename",
+  );
+  if (oldNameNode?.kind === "symlink") {
+    assertEquals(
+      oldNameNode.target,
+      "New Name",
+      "Compatibility symlink should point at the renamed piece",
+    );
+  }
+});
+
+Deno.test("CellBridge.subscribePiece keeps only the latest compatibility alias", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/ct-exec");
+  const state = buildTestSpace(bridge, "home", []);
+
+  let pieceName = "Reading List (0)";
+  const resultCell = new SinkableCell({});
+
+  const piece = {
+    id: "of:reading-list",
+    name: () => pieceName,
+    getPatternMeta: () => Promise.resolve({ patternName: "reading-list" }),
+    input: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+    result: {
+      getCell: () => Promise.resolve(resultCell as unknown as FakeCell),
+      get: () => Promise.resolve({}),
+    },
+  };
+
+  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
+    .addPieceToSpace.bind(bridge);
+  await addPiece(state, piece, "home");
+
+  const subs = await (bridge as unknown as { subscribePiece: SubscribePiece })
+    .subscribePiece.call(
+      bridge,
+      piece,
+      tree.lookup(state.piecesIno, "Reading List (0)")!,
+      "Reading List (0)",
+      "home",
+    );
+  state.pieceSubs.set("Reading List (0)", subs);
+
+  pieceName = "Reading List (1)";
+  resultCell.set({});
+  await new Promise((r) => setTimeout(r, 10));
+
+  pieceName = "Reading List (2)";
+  resultCell.set({});
+  await new Promise((r) => setTimeout(r, 10));
+
+  assertEquals(
+    tree.lookup(state.piecesIno, "Reading List (2)") !== undefined,
+    true,
+    "Latest canonical name should exist",
+  );
+  assertEquals(
+    tree.lookup(state.piecesIno, "Reading List (1)") !== undefined,
+    true,
+    "Most recent prior name should remain as a compatibility alias",
+  );
+  assertEquals(
+    tree.lookup(state.piecesIno, "Reading List (0)"),
     undefined,
-    "Old Name dir should be gone after rename",
+    "Older compatibility aliases should be discarded",
   );
 });

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -15,6 +15,7 @@ interface FakeCell {
   getRaw(): unknown;
   asSchemaFromLinks(): FakeCell;
   key(segment: string): FakeCell;
+  sink?: (fn: (v: unknown) => void) => () => void;
   isStream?: () => boolean;
 }
 
@@ -34,6 +35,7 @@ function makeCell(
     key(segment: string) {
       return children[segment] ?? makeCell(undefined, undefined);
     },
+    sink: () => () => {},
     isStream: options.isStream ? () => true : undefined,
   };
 }
@@ -45,20 +47,37 @@ class SinkableCell {
   _value: unknown;
   _sinks: Array<(v: unknown) => void> = [];
   schema = undefined;
+  private root: SinkableCell;
+  private path: string[];
 
-  constructor(value: unknown) {
+  constructor(value: unknown, root?: SinkableCell, path: string[] = []) {
     this._value = value;
+    this.root = root ?? this;
+    this.path = path;
   }
 
   get() {
-    return this._value;
+    let current = this.root._value;
+    for (const segment of this.path) {
+      if (
+        typeof current !== "object" || current === null ||
+        Array.isArray(current)
+      ) {
+        return undefined;
+      }
+      current = (current as Record<string, unknown>)[segment];
+    }
+    return current;
   }
 
   getRaw() {
-    return this._value;
+    return this.get();
   }
 
   set(v: unknown) {
+    if (this.root !== this) {
+      throw new Error("set() is only supported on the root SinkableCell");
+    }
     this._value = v;
     for (const fn of this._sinks) fn(v);
   }
@@ -67,11 +86,17 @@ class SinkableCell {
     return this as unknown as FakeCell;
   }
 
-  key(_s: string): FakeCell {
-    return this as unknown as FakeCell;
+  key(segment: string): FakeCell {
+    return new SinkableCell(undefined, this.root, [
+      ...this.path,
+      segment,
+    ]) as unknown as FakeCell;
   }
 
   sink(fn: (v: unknown) => void): () => void {
+    if (this.root !== this) {
+      return this.root.sink(() => fn(this.get()));
+    }
     this._sinks.push(fn);
     return () => {
       this._sinks = this._sinks.filter((s) => s !== fn);
@@ -110,7 +135,6 @@ function buildTestSpace(
     piecesIno,
     entitiesIno,
     pieceMap: new Map(),
-    pieceAliases: new Map(),
     pieceControllers: new Map(),
     pieceSubs: new Map(),
     did: "did:key:zTest",
@@ -422,6 +446,49 @@ Deno.test("CellBridge.writeFsFile writes markdown frontmatter and body to FS pat
   ]);
 });
 
+Deno.test("CellBridge.writeFsFile removes deleted markdown frontmatter keys and preserves scalar types", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/ct-exec");
+  const writes: Array<{ path: (string | number)[]; value: unknown }> = [];
+
+  const ok = await (bridge as unknown as { writeFsFile: WriteFsFile })
+    .writeFsFile(
+      {
+        fsProjection: "markdown",
+        piece: {
+          result: {
+            get: (path?: (string | number)[]) => {
+              if (path?.join("/") === "$FS/frontmatter") {
+                return Promise.resolve({
+                  title: "Old Title",
+                  stale: true,
+                });
+              }
+              return Promise.resolve(undefined);
+            },
+            set: (
+              value: unknown,
+              path?: (string | number)[],
+            ) => {
+              writes.push({ path: path ?? [], value });
+              return Promise.resolve();
+            },
+          },
+        },
+      },
+      "---\ntitle: Updated Title\ncount: 42\npublished: true\n---\n\nUpdated body",
+    );
+
+  assertEquals(ok, true);
+  assertEquals(writes, [
+    { path: ["$FS", "frontmatter", "title"], value: "Updated Title" },
+    { path: ["$FS", "frontmatter", "count"], value: 42 },
+    { path: ["$FS", "frontmatter", "published"], value: true },
+    { path: ["$FS", "frontmatter", "stale"], value: undefined },
+    { path: ["$FS", "content"], value: "Updated body" },
+  ]);
+});
+
 Deno.test("CellBridge.writeFsFile removes deleted keys from application/json projections", async () => {
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/ct-exec");
@@ -635,42 +702,42 @@ Deno.test("CellBridge.subscribePiece renames directory when piece name changes",
     true,
     "New Name dir should exist after rename",
   );
-  const oldNameIno = tree.lookup(state.piecesIno, "Old Name");
-  assertEquals(oldNameIno !== undefined, true, "Old Name alias should remain");
-  const oldNameNode = tree.getNode(oldNameIno!);
   assertEquals(
-    oldNameNode?.kind,
-    "symlink",
-    "Old Name should become a compatibility symlink after rename",
+    tree.lookup(state.piecesIno, "Old Name"),
+    undefined,
+    "Old Name dir should be gone after rename",
   );
-  if (oldNameNode?.kind === "symlink") {
-    assertEquals(
-      oldNameNode.target,
-      "New Name",
-      "Compatibility symlink should point at the renamed piece",
-    );
-  }
 });
 
-Deno.test("CellBridge.subscribePiece keeps only the latest compatibility alias", async () => {
+Deno.test("CellBridge.subscribePiece clears stale FS root entries when result switches to result/ tree", async () => {
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/ct-exec");
   const state = buildTestSpace(bridge, "home", []);
 
-  let pieceName = "Reading List (0)";
-  const resultCell = new SinkableCell({});
+  const inputCell = new SinkableCell({});
+  const resultCell = new SinkableCell({
+    $FS: {
+      type: "text/markdown",
+      content: "Hello",
+      frontmatter: {
+        meta: {
+          pinned: true,
+        },
+      },
+    },
+  });
 
   const piece = {
-    id: "of:reading-list",
-    name: () => pieceName,
-    getPatternMeta: () => Promise.resolve({ patternName: "reading-list" }),
+    id: "of:fs-piece",
+    name: () => "FS Piece",
+    getPatternMeta: () => Promise.resolve({ patternName: "note" }),
     input: {
-      getCell: () => Promise.resolve(makeCell({}, undefined)),
-      get: () => Promise.resolve({}),
+      getCell: () => Promise.resolve(inputCell as unknown as FakeCell),
+      get: () => Promise.resolve(inputCell.get()),
     },
     result: {
       getCell: () => Promise.resolve(resultCell as unknown as FakeCell),
-      get: () => Promise.resolve({}),
+      get: () => Promise.resolve(resultCell.get()),
     },
   };
 
@@ -678,37 +745,28 @@ Deno.test("CellBridge.subscribePiece keeps only the latest compatibility alias",
     .addPieceToSpace.bind(bridge);
   await addPiece(state, piece, "home");
 
-  const subs = await (bridge as unknown as { subscribePiece: SubscribePiece })
-    .subscribePiece.call(
-      bridge,
-      piece,
-      tree.lookup(state.piecesIno, "Reading List (0)")!,
-      "Reading List (0)",
-      "home",
-    );
-  state.pieceSubs.set("Reading List (0)", subs);
+  const pieceIno = tree.lookup(state.piecesIno, "FS Piece")!;
+  assertEquals(tree.lookup(pieceIno, "index.md") !== undefined, true);
+  assertEquals(tree.lookup(pieceIno, "meta") !== undefined, true);
+  assertEquals(tree.lookup(pieceIno, "result"), undefined);
 
-  pieceName = "Reading List (1)";
-  resultCell.set({});
+  resultCell.set({ content: "Now a regular result tree" });
   await new Promise((r) => setTimeout(r, 10));
 
-  pieceName = "Reading List (2)";
-  resultCell.set({});
-  await new Promise((r) => setTimeout(r, 10));
-
+  const resultIno = tree.lookup(pieceIno, "result");
+  assertEquals(resultIno !== undefined, true, "result/ dir should exist");
   assertEquals(
-    tree.lookup(state.piecesIno, "Reading List (2)") !== undefined,
-    true,
-    "Latest canonical name should exist",
-  );
-  assertEquals(
-    tree.lookup(state.piecesIno, "Reading List (1)") !== undefined,
-    true,
-    "Most recent prior name should remain as a compatibility alias",
-  );
-  assertEquals(
-    tree.lookup(state.piecesIno, "Reading List (0)"),
+    tree.lookup(pieceIno, "index.md"),
     undefined,
-    "Older compatibility aliases should be discarded",
+    "index.md should be removed when leaving FS projection mode",
+  );
+  assertEquals(
+    tree.lookup(pieceIno, "meta"),
+    undefined,
+    "Complex frontmatter dirs should be removed when leaving FS projection mode",
+  );
+  assertEquals(
+    resultIno !== undefined ? getFileContent(tree, resultIno, "content") : "",
+    "Now a regular result tree",
   );
 });

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -49,8 +49,8 @@ function getInputSchema(
  */
 function parseFrontmatter(
   text: string,
-): { frontmatter: Record<string, string>; body: string } {
-  const fm: Record<string, string> = {};
+): { frontmatter: Record<string, unknown>; body: string } {
+  const fm: Record<string, unknown> = {};
   if (!text.startsWith("---\n")) return { frontmatter: fm, body: text };
   const end = text.indexOf("\n---\n", 4);
   if (end === -1) return { frontmatter: fm, body: text };
@@ -62,7 +62,24 @@ function parseFrontmatter(
     if (colonIdx === -1) continue;
     const key = line.slice(0, colonIdx).trim();
     const val = line.slice(colonIdx + 1).trim();
-    if (key) fm[key] = val;
+    if (!key) continue;
+    if (val.length === 0) {
+      fm[key] = "";
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(val);
+      fm[key] = (
+          typeof parsed === "string" ||
+          typeof parsed === "number" ||
+          typeof parsed === "boolean" ||
+          parsed === null
+        )
+        ? parsed
+        : val;
+    } catch {
+      fm[key] = val;
+    }
   }
   return { frontmatter: fm, body };
 }
@@ -94,14 +111,12 @@ export interface SpaceState {
   piecesIno: bigint;
   entitiesIno: bigint;
   pieceMap: Map<string, string>; // name → entity ID
-  /** Last compatibility alias left behind for a renamed piece (piece ID → alias). */
-  pieceAliases: Map<string, string>;
   pieceControllers: Map<string, PieceController>; // name → controller
   /** Per-piece subscription cancellers, keyed by piece name. */
   pieceSubs: Map<string, Cancel[]>;
   did: string;
   unsubscribes: Cancel[];
-  /** Occupied names set for collision resolution, including compatibility aliases. */
+  /** Used names set for collision resolution. */
   usedNames: Set<string>;
 }
 
@@ -122,10 +137,10 @@ export class CellBridge {
   private syncAgain: Set<string> = new Set();
   private execCli: string;
   /**
-   * Tracks sibling directory names that were created by buildSubtree (complex
-   * frontmatter) for each piece inode. Used to clear stale dirs on rebuild.
+   * Tracks root-level entries created by [FS] projections so they can be
+   * cleared when the result switches back to the default result/ tree.
    */
-  private fsFrontmatterSiblings: Map<bigint, Set<string>> = new Map();
+  private fsProjectionEntries: Map<bigint, Set<string>> = new Map();
 
   private startedAt = new Date().toISOString();
   /** Inode of the .status file (created by initStatus). */
@@ -468,9 +483,34 @@ export class CellBridge {
   async writeFsFile(writePath: WritePath, text: string): Promise<boolean> {
     if (writePath.fsProjection === "markdown") {
       const { frontmatter, body } = parseFrontmatter(text);
+      let existingFrontmatter: Record<string, unknown> | null = null;
+      try {
+        const current = await writePath.piece.result.get([
+          "$FS",
+          "frontmatter",
+        ]);
+        if (
+          typeof current === "object" && current !== null &&
+          !Array.isArray(current)
+        ) {
+          existingFrontmatter = current as Record<string, unknown>;
+        }
+      } catch {
+        // Missing frontmatter is fine.
+      }
       for (const [key, val] of Object.entries(frontmatter)) {
         if (key === "entityId") continue;
         await writePath.piece.result.set(val, ["$FS", "frontmatter", key]);
+      }
+      if (existingFrontmatter) {
+        for (const key of Object.keys(existingFrontmatter)) {
+          if (key === "entityId" || key in frontmatter) continue;
+          await writePath.piece.result.set(undefined, [
+            "$FS",
+            "frontmatter",
+            key,
+          ]);
+        }
       }
       await writePath.piece.result.set(body, ["$FS", "content"]);
       return true;
@@ -571,7 +611,6 @@ export class CellBridge {
       piecesIno,
       entitiesIno,
       pieceMap: new Map(),
-      pieceAliases: new Map(),
       pieceControllers: new Map(),
       pieceSubs: new Map(),
       did: spaceDid,
@@ -732,6 +771,10 @@ export class CellBridge {
    */
   private removePieceFromSpace(state: SpaceState, name: string): void {
     const pieceId = state.pieceMap.get(name);
+    const pieceIno = this.tree.lookup(state.piecesIno, name);
+    if (pieceIno !== undefined) {
+      this.fsProjectionEntries.delete(pieceIno);
+    }
 
     // Cancel piece-level subscriptions
     const subs = state.pieceSubs.get(name);
@@ -745,7 +788,10 @@ export class CellBridge {
 
     // Clean up entity tree
     if (pieceId) {
-      this.clearPieceAlias(state, pieceId);
+      const entityIno = this.tree.lookup(state.entitiesIno, pieceId);
+      if (entityIno !== undefined) {
+        this.fsProjectionEntries.delete(entityIno);
+      }
       this.tree.removeChild(state.entitiesIno, pieceId);
       const entitySubsKey = `entity:${pieceId}`;
       const entitySubs = state.pieceSubs.get(entitySubsKey);
@@ -937,42 +983,6 @@ export class CellBridge {
     );
   }
 
-  private clearPieceAlias(
-    state: SpaceState,
-    pieceId: string,
-    preserveName?: string,
-  ): string | undefined {
-    const aliasName = state.pieceAliases.get(pieceId);
-    if (!aliasName) return undefined;
-
-    state.pieceAliases.delete(pieceId);
-    state.usedNames.delete(aliasName);
-
-    if (aliasName !== preserveName) {
-      const aliasIno = this.tree.lookup(state.piecesIno, aliasName);
-      if (aliasIno !== undefined) {
-        this.tree.clear(aliasIno);
-      }
-    }
-
-    return aliasName;
-  }
-
-  private installPieceAlias(
-    state: SpaceState,
-    pieceId: string,
-    aliasName: string,
-    targetName: string,
-  ): void {
-    const existingAliasIno = this.tree.lookup(state.piecesIno, aliasName);
-    if (existingAliasIno !== undefined) {
-      this.tree.clear(existingAliasIno);
-    }
-    this.tree.addSymlink(state.piecesIno, aliasName, targetName);
-    state.pieceAliases.set(pieceId, aliasName);
-    state.usedNames.add(aliasName);
-  }
-
   private updatePieceMetaName(parentIno: bigint, name: string): void {
     const metaIno = this.tree.lookup(parentIno, "meta.json");
     if (metaIno === undefined) return;
@@ -995,6 +1005,76 @@ export class CellBridge {
     } catch {
       // Ignore malformed synthetic metadata.
     }
+  }
+
+  private clearFsProjectionEntries(pieceIno: bigint): void {
+    const entries = this.fsProjectionEntries.get(pieceIno);
+    this.fsProjectionEntries.delete(pieceIno);
+
+    for (const name of ["index.md", "index.json"]) {
+      const ino = this.tree.lookup(pieceIno, name);
+      if (ino !== undefined) this.tree.clear(ino);
+    }
+
+    if (!entries) return;
+    for (const name of entries) {
+      const ino = this.tree.lookup(pieceIno, name);
+      if (ino !== undefined) this.tree.clear(ino);
+    }
+  }
+
+  private buildFsProjectionTree(
+    pieceIno: bigint,
+    pieceId: string,
+    fsValue: FsValue,
+    treeValue: unknown,
+    callables: Array<
+      { key: string; callableKind: CallableKind; schema?: JSONSchema }
+    >,
+    resolveLink: (value: unknown, depth: number) => string | null,
+    skipEntry: (value: unknown) => boolean,
+    classifyEntry: (key: string, value: unknown) => CallableKind | null,
+  ): "index.md" | "index.json" {
+    const entries = new Set<string>();
+    const indexName = fsValue.type === "text/markdown"
+      ? "index.md"
+      : "index.json";
+    entries.add(indexName);
+
+    buildFsProjection(
+      this.tree,
+      pieceIno,
+      fsValue,
+      pieceId,
+      (siblingParentIno, name, value) => {
+        if (siblingParentIno === pieceIno) {
+          entries.add(name);
+        }
+        this.makeFsSubtreeBuilder(
+          resolveLink,
+          skipEntry,
+          classifyEntry,
+        )(siblingParentIno, name, value);
+      },
+    );
+
+    this.addVNodeJsonFiles(pieceIno, treeValue);
+    if (
+      typeof treeValue === "object" && treeValue !== null &&
+      !Array.isArray(treeValue)
+    ) {
+      for (const [key, value] of Object.entries(treeValue)) {
+        if (isVNode(value)) entries.add(`${key}.json`);
+      }
+    }
+
+    this.addCallableFiles(pieceIno, callables, "result");
+    for (const { key, callableKind } of callables) {
+      entries.add(`${key}.${callableKind}`);
+    }
+
+    this.fsProjectionEntries.set(pieceIno, entries);
+    return indexName;
   }
 
   private discoverCallableEntries(
@@ -1373,59 +1453,41 @@ export class CellBridge {
               if (jsonIno !== undefined) {
                 this.tree.clear(jsonIno);
               }
+              if (propName === "result") {
+                this.clearFsProjectionEntries(pieceIno);
+              }
 
               // Rebuild
               const treeValue = this.materializeTreeValue(cell, newValue);
+              let callables: Array<
+                { key: string; callableKind: CallableKind; schema?: JSONSchema }
+              > = [];
               if (treeValue !== undefined && treeValue !== null) {
-                const { callables, classifyEntry, skipEntry } = this
+                const {
+                  callables: discoveredCallables,
+                  classifyEntry,
+                  skipEntry,
+                } = this
                   .discoverCallableEntries(
                     cell,
                     treeValue,
                   );
+                callables = discoveredCallables;
 
                 if (propName === "result") {
                   const fsValue = this.readFsValue(cell, treeValue);
                   if (fsValue !== null) {
-                    // [FS] projection: update index.md or index.json in place.
-                    // Clear both possible index files (handles type switching).
-                    for (const staleIndex of ["index.md", "index.json"]) {
-                      const staleIno = this.tree.lookup(pieceIno, staleIndex);
-                      if (staleIno !== undefined) this.tree.clear(staleIno);
-                    }
-                    // Clear stale complex frontmatter sibling dirs from prior render.
-                    const prevSiblings = this.fsFrontmatterSiblings.get(
+                    const indexName = this.buildFsProjectionTree(
                       pieceIno,
-                    );
-                    if (prevSiblings) {
-                      for (const name of prevSiblings) {
-                        const staleIno = this.tree.lookup(pieceIno, name);
-                        if (staleIno !== undefined) this.tree.clear(staleIno);
-                      }
-                    }
-                    // Track which sibling dirs this rebuild creates.
-                    const newSiblings = new Set<string>();
-                    buildFsProjection(
-                      this.tree,
-                      pieceIno,
-                      fsValue,
                       piece.id,
-                      (siblingParentIno, name, value) => {
-                        if (siblingParentIno === pieceIno) {
-                          newSiblings.add(name);
-                        }
-                        this.makeFsSubtreeBuilder(
-                          resolveLink,
-                          skipEntry,
-                          classifyEntry,
-                        )(siblingParentIno, name, value);
-                      },
+                      fsValue,
+                      treeValue,
+                      callables,
+                      resolveLink,
+                      skipEntry,
+                      classifyEntry,
                     );
-                    this.fsFrontmatterSiblings.set(pieceIno, newSiblings);
-                    this.addVNodeJsonFiles(pieceIno, treeValue);
                     this.buildHandlersFile(pieceIno, callables);
-                    const indexName = fsValue.type === "text/markdown"
-                      ? "index.md"
-                      : "index.json";
                     if (this.onInvalidate) {
                       this.onInvalidate(pieceIno, [indexName, ".handlers"]);
                     }
@@ -1447,8 +1509,10 @@ export class CellBridge {
                 this.addCallableFiles(propIno, callables, propName);
                 if (propName === "result") {
                   this.addVNodeJsonFiles(propIno, treeValue);
-                  this.buildHandlersFile(pieceIno, callables);
                 }
+              }
+              if (propName === "result") {
+                this.buildHandlersFile(pieceIno, callables);
               }
 
               // Invalidate kernel cache
@@ -1501,7 +1565,6 @@ export class CellBridge {
             if (currentName === undefined) return;
 
             const newRawName = piece.name() ?? piece.id;
-            const previousAlias = state.pieceAliases.get(piece.id);
 
             // Skip if the raw name hasn't changed.
             if (newRawName === currentName) return;
@@ -1511,13 +1574,12 @@ export class CellBridge {
             // must NOT mutate usedNames until after tree.rename() succeeds —
             // a thrown rename would otherwise leave tracking inconsistent.
             let newName = newRawName;
-            const isOccupied = (candidate: string) =>
-              state.usedNames.has(candidate) &&
-              candidate !== currentName &&
-              candidate !== previousAlias;
-            if (isOccupied(newName)) {
+            if (state.usedNames.has(newName) && newName !== currentName) {
               let suffix = 2;
-              while (isOccupied(`${newName}-${suffix}`)) suffix++;
+              while (
+                state.usedNames.has(`${newName}-${suffix}`) &&
+                `${newName}-${suffix}` !== currentName
+              ) suffix++;
               newName = `${newName}-${suffix}`;
             }
 
@@ -1537,12 +1599,6 @@ export class CellBridge {
               newName,
             );
 
-            const clearedAlias = this.clearPieceAlias(
-              state,
-              piece.id,
-              newName,
-            );
-
             // Tree rename succeeded — now update all four state maps atomically.
             state.usedNames.delete(currentName);
             state.usedNames.add(newName);
@@ -1556,7 +1612,6 @@ export class CellBridge {
             if (subs !== undefined) {
               state.pieceSubs.set(newName, subs);
             }
-            this.installPieceAlias(state, piece.id, currentName, newName);
 
             const renamedPieceIno = this.tree.lookup(state.piecesIno, newName);
             if (renamedPieceIno !== undefined) {
@@ -1574,11 +1629,6 @@ export class CellBridge {
             // Invalidate kernel cache.
             if (this.onInvalidate) {
               this.onInvalidate(state.piecesIno, [
-                ...(clearedAlias &&
-                    clearedAlias !== currentName &&
-                    clearedAlias !== newName
-                  ? [clearedAlias]
-                  : []),
                 currentName,
                 newName,
                 ".index.json",
@@ -1588,6 +1638,9 @@ export class CellBridge {
             }
             if (this.onInvalidateInode) {
               this.onInvalidateInode(state.piecesIno);
+              if (renamedPieceIno !== undefined) {
+                this.onInvalidateInode(renamedPieceIno);
+              }
             }
 
             console.log(
@@ -1748,15 +1801,16 @@ export class CellBridge {
         if (fsValue !== null) {
           // [FS] projection: index.md or index.json at piece root,
           // callable files also at piece root (no result/ dir)
-          buildFsProjection(
-            this.tree,
+          this.buildFsProjectionTree(
             pieceIno,
-            fsValue,
             piece.id,
-            this.makeFsSubtreeBuilder(resolveLink, skipEntry, classifyEntry),
+            fsValue,
+            result,
+            callables,
+            resolveLink,
+            skipEntry,
+            classifyEntry,
           );
-          this.addVNodeJsonFiles(pieceIno, result);
-          this.addCallableFiles(pieceIno, callables, "result");
         } else {
           // Default: exploded result/ directory
           const resultIno = buildJsonTree(

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -1128,6 +1128,19 @@ export class CellBridge {
 
     try {
       const fsCell = resultCell.key("$FS");
+      const fsRaw = fsCell.get();
+
+      // Plain-object shorthand: no `type` field → treat entire value as JSON content
+      if (
+        typeof fsRaw === "object" && fsRaw !== null &&
+        !("type" in (fsRaw as Record<string, unknown>))
+      ) {
+        return {
+          type: "application/json",
+          content: fsRaw as Record<string, unknown>,
+        };
+      }
+
       const type = String(fsCell.key("type").get() ?? "text/markdown") as
         | "text/markdown"
         | "application/json";

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -5,6 +5,7 @@
 // Subscribes to cell changes and rebuilds subtrees on updates.
 
 import type { Cell } from "@commontools/runner";
+import { schemaToTypeString } from "@commontools/runner";
 import { FsTree } from "./tree.ts";
 import {
   buildCallableScript,
@@ -13,12 +14,56 @@ import {
   isHandlerCell,
 } from "./callables.ts";
 import { parseMountedCallablePath } from "./callable-path.ts";
-import { buildJsonTree, isSigilLink } from "./tree-builder.ts";
+import {
+  buildFsProjection,
+  buildJsonTree,
+  type FsValue,
+  isSigilLink,
+} from "./tree-builder.ts";
+import type { JSONSchema } from "@commontools/api";
 import type { PieceManager } from "@commontools/piece";
 import type { PieceController, PiecesController } from "@commontools/piece/ops";
+
+/** Strip asStream/asCell markers from a schema for display as input schema. */
+function getInputSchema(
+  schema: JSONSchema | undefined,
+): JSONSchema | undefined {
+  if (typeof schema !== "object" || schema === null || Array.isArray(schema)) {
+    return undefined;
+  }
+  const { asStream: _s, asCell: _c, ...rest } = schema as Record<
+    string,
+    unknown
+  >;
+  return Object.keys(rest).length > 0 ? rest as JSONSchema : undefined;
+}
 // Lazy-imported in connectSpace() to avoid pulling in heavy CLI deps at import
 // time (breaks tests that only use CellBridge for tree/symlink logic).
 // import { loadManager } from "../cli/lib/piece.ts";
+
+/**
+ * Parse YAML frontmatter from a markdown string.
+ * Expects the format: ---\nkey: value\n---\n\nbody...
+ */
+function parseFrontmatter(
+  text: string,
+): { frontmatter: Record<string, string>; body: string } {
+  const fm: Record<string, string> = {};
+  if (!text.startsWith("---\n")) return { frontmatter: fm, body: text };
+  const end = text.indexOf("\n---\n", 4);
+  if (end === -1) return { frontmatter: fm, body: text };
+  const fmText = text.slice(4, end);
+  let body = text.slice(end + 5); // skip "\n---\n"
+  if (body.startsWith("\n")) body = body.slice(1); // strip blank separator line
+  for (const line of fmText.split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const val = line.slice(colonIdx + 1).trim();
+    if (key) fm[key] = val;
+  }
+  return { frontmatter: fm, body };
+}
 
 type Cancel = () => void;
 
@@ -30,6 +75,8 @@ export interface WritePath {
   jsonPath: (string | number)[];
   isJsonFile: boolean;
   piece: PieceController;
+  /** Set when the file is an [FS] projection index file. */
+  fsProjection?: "markdown" | "json";
 }
 
 /** Callback to invalidate kernel cache entries (by name under a parent). */
@@ -201,12 +248,37 @@ export class CellBridge {
     // Read-only files
     const cellSegment = segments[3];
     if (cellSegment === "meta.json") return null;
+    if (cellSegment === ".handlers") return null;
 
     // Find the space and piece controller
     const space = this.spaces.get(spaceName);
     if (!space) return null;
     const piece = space.pieceControllers.get(pieceName);
     if (!piece) return null;
+
+    // Handle [FS] projection index files
+    if (cellSegment === "index.md") {
+      return {
+        spaceName,
+        pieceName,
+        cell: "result",
+        jsonPath: [],
+        isJsonFile: false,
+        piece,
+        fsProjection: "markdown",
+      };
+    }
+    if (cellSegment === "index.json") {
+      return {
+        spaceName,
+        pieceName,
+        cell: "result",
+        jsonPath: [],
+        isJsonFile: false,
+        piece,
+        fsProjection: "json",
+      };
+    }
 
     // Handle .json sibling files: result.json, input.json, result/items.json
     let cell: "input" | "result";
@@ -371,6 +443,33 @@ export class CellBridge {
       value,
       writePath.jsonPath.length > 0 ? writePath.jsonPath : undefined,
     );
+  }
+
+  /**
+   * Write back an [FS] projection index file (index.md or index.json).
+   * Parses the content and writes each field to its corresponding cell path.
+   * entityId is always skipped (read-only).
+   */
+  async writeFsFile(writePath: WritePath, text: string): Promise<void> {
+    if (writePath.fsProjection === "markdown") {
+      const { frontmatter, body } = parseFrontmatter(text);
+      for (const [key, val] of Object.entries(frontmatter)) {
+        if (key === "entityId") continue;
+        await writePath.piece.result.set(val, ["$FS", "frontmatter", key]);
+      }
+      await writePath.piece.result.set(body, ["$FS", "content"]);
+    } else if (writePath.fsProjection === "json") {
+      let obj: Record<string, unknown>;
+      try {
+        obj = JSON.parse(text);
+      } catch {
+        return;
+      }
+      for (const [key, val] of Object.entries(obj)) {
+        if (key === "entityId") continue;
+        await writePath.piece.result.set(val, ["$FS", "content", key]);
+      }
+    }
   }
 
   /** Update the root .spaces.json file. */
@@ -788,7 +887,9 @@ export class CellBridge {
     rootCell: Cell<unknown>,
     value: unknown,
   ): {
-    callables: Array<{ key: string; callableKind: CallableKind }>;
+    callables: Array<
+      { key: string; callableKind: CallableKind; schema?: JSONSchema }
+    >;
     skipEntry: (value: unknown) => boolean;
     classifyEntry: (key: string, value: unknown) => CallableKind | null;
   } {
@@ -802,7 +903,9 @@ export class CellBridge {
 
     const callableValues = new WeakSet<object>();
     const callableKinds = new Map<string, CallableKind>();
-    const callables: Array<{ key: string; callableKind: CallableKind }> = [];
+    const callables: Array<
+      { key: string; callableKind: CallableKind; schema?: JSONSchema }
+    > = [];
     for (
       const [key, candidate] of Object.entries(
         value as Record<string, unknown>,
@@ -835,7 +938,11 @@ export class CellBridge {
 
       if (!callableKind) continue;
 
-      callables.push({ key, callableKind });
+      callables.push({
+        key,
+        callableKind,
+        schema: getInputSchema(childCell.schema),
+      });
       callableKinds.set(key, callableKind);
       if (typeof candidate === "object" && candidate !== null) {
         callableValues.add(candidate);
@@ -918,11 +1025,22 @@ export class CellBridge {
 
   private addCallableFiles(
     propIno: bigint,
-    callables: Array<{ key: string; callableKind: CallableKind }>,
+    callables: Array<
+      { key: string; callableKind: CallableKind; schema?: JSONSchema }
+    >,
     cellProp: "input" | "result",
   ): void {
-    const script = buildCallableScript(this.execCli);
-    for (const { key, callableKind } of callables) {
+    for (const { key, callableKind, schema } of callables) {
+      const defs =
+        schema && typeof schema === "object" && !Array.isArray(schema)
+          ? (schema as Record<string, unknown>).$defs as
+            | Record<string, JSONSchema>
+            | undefined
+          : undefined;
+      const typeStr = schema !== undefined
+        ? schemaToTypeString(schema, { defs, maxDepth: 3 })
+        : undefined;
+      const script = buildCallableScript(this.execCli, schema, typeStr);
       this.tree.addCallable(
         propIno,
         `${key}.${callableKind}`,
@@ -931,6 +1049,89 @@ export class CellBridge {
         cellProp,
         script,
       );
+    }
+  }
+
+  /**
+   * Generate a .handlers summary file at the piece root.
+   * One line per callable: "<name>.<handler|tool>  <input-schema-json>"
+   * Dot-prefixed so it's hidden from plain `ls` but readable with `cat`.
+   */
+  private buildHandlersFile(
+    pieceIno: bigint,
+    callables: Array<
+      { key: string; callableKind: CallableKind; schema?: JSONSchema }
+    >,
+  ): void {
+    const existingIno = this.tree.lookup(pieceIno, ".handlers");
+    if (existingIno !== undefined) this.tree.clear(existingIno);
+    if (callables.length === 0) return;
+    const lines = callables.map(({ key, callableKind, schema }) => {
+      const defs =
+        schema && typeof schema === "object" && !Array.isArray(schema)
+          ? (schema as Record<string, unknown>).$defs as
+            | Record<string, JSONSchema>
+            | undefined
+          : undefined;
+      const typeStr = schema !== undefined
+        ? schemaToTypeString(schema, { defs, maxDepth: 3 })
+        : "void";
+      return `${key}.${callableKind}  ${typeStr}`;
+    });
+    this.tree.addFile(
+      pieceIno,
+      ".handlers",
+      lines.join("\n") + "\n",
+      "string",
+    );
+  }
+
+  /**
+   * Read [FS] projection values from a result cell.
+   * Returns null if the result does not declare [FS].
+   */
+  private readFsValue(
+    resultCell: Cell<unknown>,
+    result: unknown,
+  ): FsValue | null {
+    if (
+      typeof result !== "object" || result === null ||
+      !("$FS" in (result as Record<string, unknown>))
+    ) {
+      return null;
+    }
+
+    try {
+      const fsCell = resultCell.key("$FS");
+      const type = String(fsCell.key("type").get() ?? "text/markdown") as
+        | "text/markdown"
+        | "application/json";
+      const content = fsCell.key("content").get();
+
+      if (type === "text/markdown") {
+        const contentStr = String(content ?? "");
+        const fmCell = fsCell.key("frontmatter");
+        const fmRaw = fmCell.get();
+        const frontmatter: Record<string, string> = {};
+        if (fmRaw && typeof fmRaw === "object" && !Array.isArray(fmRaw)) {
+          for (const key of Object.keys(fmRaw as Record<string, unknown>)) {
+            frontmatter[key] = String(fmCell.key(key).get() ?? "");
+          }
+        }
+        return { type, content: contentStr, frontmatter };
+      }
+
+      if (type === "application/json") {
+        const contentObj = content && typeof content === "object" &&
+            !Array.isArray(content)
+          ? content as Record<string, unknown>
+          : {};
+        return { type, content: contentObj };
+      }
+
+      return null;
+    } catch {
+      return null;
     }
   }
 
@@ -982,6 +1183,35 @@ export class CellBridge {
                     cell,
                     treeValue,
                   );
+
+                if (propName === "result") {
+                  const fsValue = this.readFsValue(cell, treeValue);
+                  if (fsValue !== null) {
+                    // [FS] projection: update index.md or index.json in place
+                    const indexName = fsValue.type === "text/markdown"
+                      ? "index.md"
+                      : "index.json";
+                    const existingIndexIno = this.tree.lookup(
+                      pieceIno,
+                      indexName,
+                    );
+                    if (existingIndexIno !== undefined) {
+                      this.tree.clear(existingIndexIno);
+                    }
+                    buildFsProjection(
+                      this.tree,
+                      pieceIno,
+                      fsValue,
+                      piece.id,
+                    );
+                    this.buildHandlersFile(pieceIno, callables);
+                    if (this.onInvalidate) {
+                      this.onInvalidate(pieceIno, [indexName, ".handlers"]);
+                    }
+                    return;
+                  }
+                }
+
                 const propIno = buildJsonTree(
                   this.tree,
                   pieceIno,
@@ -994,6 +1224,9 @@ export class CellBridge {
                   classifyEntry,
                 );
                 this.addCallableFiles(propIno, callables, propName);
+                if (propName === "result") {
+                  this.buildHandlersFile(pieceIno, callables);
+                }
               }
 
               // Invalidate kernel cache
@@ -1265,18 +1498,29 @@ export class CellBridge {
             resultCell,
             result,
           );
-        const resultIno = buildJsonTree(
-          this.tree,
-          pieceIno,
-          "result",
-          result,
-          undefined,
-          resolveLink,
-          0,
-          skipEntry,
-          classifyEntry,
-        );
-        this.addCallableFiles(resultIno, callables, "result");
+
+        const fsValue = this.readFsValue(resultCell, result);
+        if (fsValue !== null) {
+          // [FS] projection: index.md or index.json at piece root,
+          // callable files also at piece root (no result/ dir)
+          buildFsProjection(this.tree, pieceIno, fsValue, piece.id);
+          this.addCallableFiles(pieceIno, callables, "result");
+        } else {
+          // Default: exploded result/ directory
+          const resultIno = buildJsonTree(
+            this.tree,
+            pieceIno,
+            "result",
+            result,
+            undefined,
+            resolveLink,
+            0,
+            skipEntry,
+            classifyEntry,
+          );
+          this.addCallableFiles(resultIno, callables, "result");
+        }
+        this.buildHandlersFile(pieceIno, callables);
       }
     } catch (e) {
       console.error(`Error loading piece "${name}": ${e}`);

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -1087,6 +1087,31 @@ export class CellBridge {
   }
 
   /**
+   * Build a subtree callback for `buildFsProjection`.
+   * Complex frontmatter fields (arrays of entities, nested objects) are
+   * rendered as sibling directories using the standard `buildJsonTree` path.
+   */
+  private makeFsSubtreeBuilder(
+    resolveLink: (v: unknown, depth: number) => string | null,
+    skipEntry: (v: unknown) => boolean,
+    classifyEntry: (k: string, v: unknown) => CallableKind | null,
+  ): (parentIno: bigint, name: string, value: unknown) => void {
+    return (parentIno, name, value) => {
+      buildJsonTree(
+        this.tree,
+        parentIno,
+        name,
+        value,
+        undefined,
+        resolveLink,
+        0,
+        skipEntry,
+        classifyEntry,
+      );
+    };
+  }
+
+  /**
    * Read [FS] projection values from a result cell.
    * Returns null if the result does not declare [FS].
    */
@@ -1112,10 +1137,10 @@ export class CellBridge {
         const contentStr = String(content ?? "");
         const fmCell = fsCell.key("frontmatter");
         const fmRaw = fmCell.get();
-        const frontmatter: Record<string, string> = {};
+        const frontmatter: Record<string, unknown> = {};
         if (fmRaw && typeof fmRaw === "object" && !Array.isArray(fmRaw)) {
           for (const key of Object.keys(fmRaw as Record<string, unknown>)) {
-            frontmatter[key] = String(fmCell.key(key).get() ?? "");
+            frontmatter[key] = fmCell.key(key).get() ?? null;
           }
         }
         return { type, content: contentStr, frontmatter };
@@ -1203,6 +1228,11 @@ export class CellBridge {
                       pieceIno,
                       fsValue,
                       piece.id,
+                      this.makeFsSubtreeBuilder(
+                        resolveLink,
+                        skipEntry,
+                        classifyEntry,
+                      ),
                     );
                     this.buildHandlersFile(pieceIno, callables);
                     if (this.onInvalidate) {
@@ -1503,7 +1533,13 @@ export class CellBridge {
         if (fsValue !== null) {
           // [FS] projection: index.md or index.json at piece root,
           // callable files also at piece root (no result/ dir)
-          buildFsProjection(this.tree, pieceIno, fsValue, piece.id);
+          buildFsProjection(
+            this.tree,
+            pieceIno,
+            fsValue,
+            piece.id,
+            this.makeFsSubtreeBuilder(resolveLink, skipEntry, classifyEntry),
+          );
           this.addCallableFiles(pieceIno, callables, "result");
         } else {
           // Default: exploded result/ directory

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -19,6 +19,8 @@ import {
   buildJsonTree,
   type FsValue,
   isSigilLink,
+  isVNode,
+  safeStringify,
 } from "./tree-builder.ts";
 import type { JSONSchema } from "@commontools/api";
 import type { PieceManager } from "@commontools/piece";
@@ -952,8 +954,9 @@ export class CellBridge {
     return {
       callables,
       skipEntry: (candidate: unknown) =>
-        typeof candidate === "object" && candidate !== null &&
-        callableValues.has(candidate),
+        (typeof candidate === "object" && candidate !== null &&
+          callableValues.has(candidate)) ||
+        isVNode(candidate),
       classifyEntry: (key: string, candidate: unknown) =>
         typeof candidate === "object" && candidate !== null &&
           callableValues.has(candidate)
@@ -1049,6 +1052,29 @@ export class CellBridge {
         cellProp,
         script,
       );
+    }
+  }
+
+  /**
+   * For each VNode-typed property in `value`, add a `<key>.json` file under
+   * `parentIno`. This replaces the recursive directory explosion that
+   * buildJsonTree would otherwise produce for UI trees.
+   */
+  private addVNodeJsonFiles(parentIno: bigint, value: unknown): void {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      return;
+    }
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      if (isVNode(val)) {
+        const existing = this.tree.lookup(parentIno, `${key}.json`);
+        if (existing !== undefined) this.tree.clear(existing);
+        this.tree.addFile(
+          parentIno,
+          `${key}.json`,
+          safeStringify(val),
+          "object",
+        );
+      }
     }
   }
 
@@ -1247,6 +1273,7 @@ export class CellBridge {
                         classifyEntry,
                       ),
                     );
+                    this.addVNodeJsonFiles(pieceIno, treeValue);
                     this.buildHandlersFile(pieceIno, callables);
                     if (this.onInvalidate) {
                       this.onInvalidate(pieceIno, [indexName, ".handlers"]);
@@ -1268,6 +1295,7 @@ export class CellBridge {
                 );
                 this.addCallableFiles(propIno, callables, propName);
                 if (propName === "result") {
+                  this.addVNodeJsonFiles(propIno, treeValue);
                   this.buildHandlersFile(pieceIno, callables);
                 }
               }
@@ -1553,6 +1581,7 @@ export class CellBridge {
             piece.id,
             this.makeFsSubtreeBuilder(resolveLink, skipEntry, classifyEntry),
           );
+          this.addVNodeJsonFiles(pieceIno, result);
           this.addCallableFiles(pieceIno, callables, "result");
         } else {
           // Default: exploded result/ directory
@@ -1567,6 +1596,7 @@ export class CellBridge {
             skipEntry,
             classifyEntry,
           );
+          this.addVNodeJsonFiles(resultIno, result);
           this.addCallableFiles(resultIno, callables, "result");
         }
         this.buildHandlersFile(pieceIno, callables);

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -119,6 +119,11 @@ export class CellBridge {
   /** Flag: re-run sync after current pass completes. */
   private syncAgain: Set<string> = new Set();
   private execCli: string;
+  /**
+   * Tracks sibling directory names that were created by buildSubtree (complex
+   * frontmatter) for each piece inode. Used to clear stale dirs on rebuild.
+   */
+  private fsFrontmatterSiblings: Map<bigint, Set<string>> = new Map();
 
   private startedAt = new Date().toISOString();
   /** Inode of the .status file (created by initStatus). */
@@ -452,7 +457,7 @@ export class CellBridge {
    * Parses the content and writes each field to its corresponding cell path.
    * entityId is always skipped (read-only).
    */
-  async writeFsFile(writePath: WritePath, text: string): Promise<void> {
+  async writeFsFile(writePath: WritePath, text: string): Promise<boolean> {
     if (writePath.fsProjection === "markdown") {
       const { frontmatter, body } = parseFrontmatter(text);
       for (const [key, val] of Object.entries(frontmatter)) {
@@ -460,18 +465,60 @@ export class CellBridge {
         await writePath.piece.result.set(val, ["$FS", "frontmatter", key]);
       }
       await writePath.piece.result.set(body, ["$FS", "content"]);
+      return true;
     } else if (writePath.fsProjection === "json") {
       let obj: Record<string, unknown>;
       try {
         obj = JSON.parse(text);
       } catch {
-        return;
+        return false;
       }
+      if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+        return false;
+      }
+      // Detect whether this piece uses plain-object shorthand (no $FS.type/content
+      // wrapper) or explicit application/json (content is nested under $FS.content).
+      // Plain-object shorthand: $FS has no `type` field.
+      let isPlainObjectShorthand = false;
+      let existingContent: Record<string, unknown> | null = null;
+      try {
+        const fsRaw = await writePath.piece.result.get(["$FS"]);
+        isPlainObjectShorthand = typeof fsRaw === "object" && fsRaw !== null &&
+          !("type" in (fsRaw as Record<string, unknown>));
+        const contentRaw = isPlainObjectShorthand
+          ? fsRaw
+          : await writePath.piece.result.get(["$FS", "content"]);
+        if (
+          contentRaw && typeof contentRaw === "object" &&
+          !Array.isArray(contentRaw)
+        ) {
+          existingContent = contentRaw as Record<string, unknown>;
+        }
+      } catch {
+        // If we can't read, default to explicit form
+      }
+      const basePath = isPlainObjectShorthand ? ["$FS"] : ["$FS", "content"];
+
+      // Collect keys currently in the cell so we can remove deleted ones.
+      const existingKeys = new Set<string>(
+        existingContent ? Object.keys(existingContent) : [],
+      );
+
       for (const [key, val] of Object.entries(obj)) {
         if (key === "entityId") continue;
-        await writePath.piece.result.set(val, ["$FS", "content", key]);
+        await writePath.piece.result.set(val, [...basePath, key]);
+        existingKeys.delete(key);
       }
+
+      // Remove keys that were deleted from the file
+      for (const key of existingKeys) {
+        if (key === "entityId") continue;
+        await writePath.piece.result.set(undefined, [...basePath, key]);
+      }
+
+      return true;
     }
+    return false;
   }
 
   /** Update the root .spaces.json file. */
@@ -1059,21 +1106,44 @@ export class CellBridge {
    * For each VNode-typed property in `value`, add a `<key>.json` file under
    * `parentIno`. This replaces the recursive directory explosion that
    * buildJsonTree would otherwise produce for UI trees.
+   * Also removes any previously-projected `<key>.json` files for VNode
+   * properties that no longer exist in the current value.
    */
   private addVNodeJsonFiles(parentIno: bigint, value: unknown): void {
-    if (typeof value !== "object" || value === null || Array.isArray(value)) {
-      return;
+    const currentVNodeKeys = new Set<string>();
+
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      for (
+        const [key, val] of Object.entries(value as Record<string, unknown>)
+      ) {
+        if (isVNode(val)) {
+          currentVNodeKeys.add(key);
+          const existing = this.tree.lookup(parentIno, `${key}.json`);
+          if (existing !== undefined) this.tree.clear(existing);
+          this.tree.addFile(
+            parentIno,
+            `${key}.json`,
+            safeStringify(val),
+            "object",
+          );
+        }
+      }
     }
-    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
-      if (isVNode(val)) {
-        const existing = this.tree.lookup(parentIno, `${key}.json`);
-        if (existing !== undefined) this.tree.clear(existing);
-        this.tree.addFile(
-          parentIno,
-          `${key}.json`,
-          safeStringify(val),
-          "object",
-        );
+
+    // Remove stale VNode `.json` files from previous renders.
+    // We identify them by looking for `<key>.json` children whose key starts
+    // with "$" (VNode keys are always system-prefixed symbols like $UI).
+    for (const [name, ino] of this.tree.getChildren(parentIno)) {
+      if (
+        name.endsWith(".json") && name.startsWith("$") &&
+        !currentVNodeKeys.has(name.slice(0, -5))
+      ) {
+        // Check if this was a VNode file by seeing if the child was a file
+        // (not a directory — directories are never VNode projections).
+        const node = this.tree.getNode(ino);
+        if (node && node.kind === "file") {
+          this.tree.clear(ino);
+        }
       }
     }
   }
@@ -1251,30 +1321,46 @@ export class CellBridge {
                 if (propName === "result") {
                   const fsValue = this.readFsValue(cell, treeValue);
                   if (fsValue !== null) {
-                    // [FS] projection: update index.md or index.json in place
-                    const indexName = fsValue.type === "text/markdown"
-                      ? "index.md"
-                      : "index.json";
-                    const existingIndexIno = this.tree.lookup(
-                      pieceIno,
-                      indexName,
-                    );
-                    if (existingIndexIno !== undefined) {
-                      this.tree.clear(existingIndexIno);
+                    // [FS] projection: update index.md or index.json in place.
+                    // Clear both possible index files (handles type switching).
+                    for (const staleIndex of ["index.md", "index.json"]) {
+                      const staleIno = this.tree.lookup(pieceIno, staleIndex);
+                      if (staleIno !== undefined) this.tree.clear(staleIno);
                     }
+                    // Clear stale complex frontmatter sibling dirs from prior render.
+                    const prevSiblings = this.fsFrontmatterSiblings.get(
+                      pieceIno,
+                    );
+                    if (prevSiblings) {
+                      for (const name of prevSiblings) {
+                        const staleIno = this.tree.lookup(pieceIno, name);
+                        if (staleIno !== undefined) this.tree.clear(staleIno);
+                      }
+                    }
+                    // Track which sibling dirs this rebuild creates.
+                    const newSiblings = new Set<string>();
                     buildFsProjection(
                       this.tree,
                       pieceIno,
                       fsValue,
                       piece.id,
-                      this.makeFsSubtreeBuilder(
-                        resolveLink,
-                        skipEntry,
-                        classifyEntry,
-                      ),
+                      (siblingParentIno, name, value) => {
+                        if (siblingParentIno === pieceIno) {
+                          newSiblings.add(name);
+                        }
+                        this.makeFsSubtreeBuilder(
+                          resolveLink,
+                          skipEntry,
+                          classifyEntry,
+                        )(siblingParentIno, name, value);
+                      },
                     );
+                    this.fsFrontmatterSiblings.set(pieceIno, newSiblings);
                     this.addVNodeJsonFiles(pieceIno, treeValue);
                     this.buildHandlersFile(pieceIno, callables);
+                    const indexName = fsValue.type === "text/markdown"
+                      ? "index.md"
+                      : "index.json";
                     if (this.onInvalidate) {
                       this.onInvalidate(pieceIno, [indexName, ".handlers"]);
                     }

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -344,7 +344,13 @@ export class CellBridge {
     const piece = this.resolvePieceController(space, parsed);
     if (!piece) throw new Error(`Piece "${parsed.rootName}" not found`);
 
-    await piece[parsed.cellProp].set(value, [parsed.cellKey]);
+    const rootCell = await piece[parsed.cellProp].getCell();
+    const handlerCell = rootCell.key(parsed.cellKey as keyof unknown) as Cell<
+      unknown
+    >;
+    handlerCell.send(value);
+    await piece.manager().runtime.idle();
+    await piece.manager().synced();
   }
 
   private resolvePieceController(

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -476,9 +476,8 @@ export class CellBridge {
       if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
         return false;
       }
-      // Detect whether this piece uses plain-object shorthand (no $FS.type/content
-      // wrapper) or explicit application/json (content is nested under $FS.content).
-      // Plain-object shorthand: $FS has no `type` field.
+      // Plain-object shorthand stores keys directly under $FS instead of
+      // nesting them under $FS.content.
       let isPlainObjectShorthand = false;
       let existingContent: Record<string, unknown> | null = null;
       try {
@@ -495,27 +494,22 @@ export class CellBridge {
           existingContent = contentRaw as Record<string, unknown>;
         }
       } catch {
-        // If we can't read, default to explicit form
+        // If we can't read current state, default to the explicit content form.
       }
       const basePath = isPlainObjectShorthand ? ["$FS"] : ["$FS", "content"];
 
-      // Collect keys currently in the cell so we can remove deleted ones.
       const existingKeys = new Set<string>(
         existingContent ? Object.keys(existingContent) : [],
       );
-
       for (const [key, val] of Object.entries(obj)) {
         if (key === "entityId") continue;
         await writePath.piece.result.set(val, [...basePath, key]);
         existingKeys.delete(key);
       }
-
-      // Remove keys that were deleted from the file
       for (const key of existingKeys) {
         if (key === "entityId") continue;
         await writePath.piece.result.set(undefined, [...basePath, key]);
       }
-
       return true;
     }
     return false;

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -94,12 +94,14 @@ export interface SpaceState {
   piecesIno: bigint;
   entitiesIno: bigint;
   pieceMap: Map<string, string>; // name → entity ID
+  /** Last compatibility alias left behind for a renamed piece (piece ID → alias). */
+  pieceAliases: Map<string, string>;
   pieceControllers: Map<string, PieceController>; // name → controller
   /** Per-piece subscription cancellers, keyed by piece name. */
   pieceSubs: Map<string, Cancel[]>;
   did: string;
   unsubscribes: Cancel[];
-  /** Used names set for collision resolution. */
+  /** Occupied names set for collision resolution, including compatibility aliases. */
   usedNames: Set<string>;
 }
 
@@ -569,6 +571,7 @@ export class CellBridge {
       piecesIno,
       entitiesIno,
       pieceMap: new Map(),
+      pieceAliases: new Map(),
       pieceControllers: new Map(),
       pieceSubs: new Map(),
       did: spaceDid,
@@ -728,6 +731,8 @@ export class CellBridge {
    * Remove a piece from a space's tree and clean up subscriptions.
    */
   private removePieceFromSpace(state: SpaceState, name: string): void {
+    const pieceId = state.pieceMap.get(name);
+
     // Cancel piece-level subscriptions
     const subs = state.pieceSubs.get(name);
     if (subs) {
@@ -739,8 +744,8 @@ export class CellBridge {
     this.tree.removeChild(state.piecesIno, name);
 
     // Clean up entity tree
-    const pieceId = state.pieceMap.get(name);
     if (pieceId) {
+      this.clearPieceAlias(state, pieceId);
       this.tree.removeChild(state.entitiesIno, pieceId);
       const entitySubsKey = `entity:${pieceId}`;
       const entitySubs = state.pieceSubs.get(entitySubsKey);
@@ -930,6 +935,66 @@ export class CellBridge {
       JSON.stringify(indexObj, null, 2),
       "object",
     );
+  }
+
+  private clearPieceAlias(
+    state: SpaceState,
+    pieceId: string,
+    preserveName?: string,
+  ): string | undefined {
+    const aliasName = state.pieceAliases.get(pieceId);
+    if (!aliasName) return undefined;
+
+    state.pieceAliases.delete(pieceId);
+    state.usedNames.delete(aliasName);
+
+    if (aliasName !== preserveName) {
+      const aliasIno = this.tree.lookup(state.piecesIno, aliasName);
+      if (aliasIno !== undefined) {
+        this.tree.clear(aliasIno);
+      }
+    }
+
+    return aliasName;
+  }
+
+  private installPieceAlias(
+    state: SpaceState,
+    pieceId: string,
+    aliasName: string,
+    targetName: string,
+  ): void {
+    const existingAliasIno = this.tree.lookup(state.piecesIno, aliasName);
+    if (existingAliasIno !== undefined) {
+      this.tree.clear(existingAliasIno);
+    }
+    this.tree.addSymlink(state.piecesIno, aliasName, targetName);
+    state.pieceAliases.set(pieceId, aliasName);
+    state.usedNames.add(aliasName);
+  }
+
+  private updatePieceMetaName(parentIno: bigint, name: string): void {
+    const metaIno = this.tree.lookup(parentIno, "meta.json");
+    if (metaIno === undefined) return;
+
+    const metaNode = this.tree.getNode(metaIno);
+    if (!metaNode || metaNode.kind !== "file") return;
+
+    try {
+      const parsed = JSON.parse(new TextDecoder().decode(metaNode.content));
+      if (
+        typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
+      ) {
+        return;
+      }
+      this.tree.updateFile(
+        metaIno,
+        JSON.stringify({ ...parsed, name }, null, 2),
+        "object",
+      );
+    } catch {
+      // Ignore malformed synthetic metadata.
+    }
   }
 
   private discoverCallableEntries(
@@ -1436,6 +1501,7 @@ export class CellBridge {
             if (currentName === undefined) return;
 
             const newRawName = piece.name() ?? piece.id;
+            const previousAlias = state.pieceAliases.get(piece.id);
 
             // Skip if the raw name hasn't changed.
             if (newRawName === currentName) return;
@@ -1445,12 +1511,13 @@ export class CellBridge {
             // must NOT mutate usedNames until after tree.rename() succeeds —
             // a thrown rename would otherwise leave tracking inconsistent.
             let newName = newRawName;
-            if (state.usedNames.has(newName) && newName !== currentName) {
+            const isOccupied = (candidate: string) =>
+              state.usedNames.has(candidate) &&
+              candidate !== currentName &&
+              candidate !== previousAlias;
+            if (isOccupied(newName)) {
               let suffix = 2;
-              while (
-                state.usedNames.has(`${newName}-${suffix}`) &&
-                `${newName}-${suffix}` !== currentName
-              ) suffix++;
+              while (isOccupied(`${newName}-${suffix}`)) suffix++;
               newName = `${newName}-${suffix}`;
             }
 
@@ -1470,6 +1537,12 @@ export class CellBridge {
               newName,
             );
 
+            const clearedAlias = this.clearPieceAlias(
+              state,
+              piece.id,
+              newName,
+            );
+
             // Tree rename succeeded — now update all four state maps atomically.
             state.usedNames.delete(currentName);
             state.usedNames.add(newName);
@@ -1483,6 +1556,16 @@ export class CellBridge {
             if (subs !== undefined) {
               state.pieceSubs.set(newName, subs);
             }
+            this.installPieceAlias(state, piece.id, currentName, newName);
+
+            const renamedPieceIno = this.tree.lookup(state.piecesIno, newName);
+            if (renamedPieceIno !== undefined) {
+              this.updatePieceMetaName(renamedPieceIno, newName);
+            }
+            const entityIno = this.tree.lookup(state.entitiesIno, piece.id);
+            if (entityIno !== undefined) {
+              this.updatePieceMetaName(entityIno, newName);
+            }
 
             // Rebuild .index.json and pieces.json.
             this.updateIndexJson(state);
@@ -1491,6 +1574,11 @@ export class CellBridge {
             // Invalidate kernel cache.
             if (this.onInvalidate) {
               this.onInvalidate(state.piecesIno, [
+                ...(clearedAlias &&
+                    clearedAlias !== currentName &&
+                    clearedAlias !== newName
+                  ? [clearedAlias]
+                  : []),
                 currentName,
                 newName,
                 ".index.json",

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -606,7 +606,8 @@ export async function main(argv: string[] = Deno.args) {
 
       // [FS] projection index file: parse and write back to cells
       if (writePath.fsProjection) {
-        await bridge.writeFsFile(writePath, text);
+        const ok = await bridge.writeFsFile(writePath, text);
+        if (!ok) return EINVAL;
         if (handle.version === flushVersion) {
           handle.dirty = false;
         }

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -603,6 +603,24 @@ export async function main(argv: string[] = Deno.args) {
       if (!writePath) return EACCES;
 
       const text = new TextDecoder().decode(buffer);
+
+      // [FS] projection index file: parse and write back to cells
+      if (writePath.fsProjection) {
+        await bridge.writeFsFile(writePath, text);
+        if (handle.version === flushVersion) {
+          handle.dirty = false;
+        }
+        try {
+          const node = tree.getNode(handle.ino);
+          if (node && node.kind === "file") {
+            tree.updateFile(handle.ino, text);
+          }
+        } catch {
+          // Stale inode after subscription rebuild — ignore.
+        }
+        return 0;
+      }
+
       let value: unknown;
 
       if (writePath.isJsonFile) {

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -31,7 +31,7 @@ import {
   SYMLINK_MODE,
 } from "./platform.ts";
 import { FsTree } from "./tree.ts";
-import { HandleMap } from "./handles.ts";
+import { HandleMap, type HandleState } from "./handles.ts";
 
 const encoder = new TextEncoder();
 
@@ -116,6 +116,10 @@ export async function main(argv: string[] = Deno.args) {
   const tree = new FsTree();
 
   let bridge: CellBridge | null = null;
+  const scheduledFlushes = new WeakMap<
+    HandleState,
+    ReturnType<typeof setTimeout>
+  >();
 
   // Populate tree
   const apiUrl = args["api-url"];
@@ -692,6 +696,36 @@ export async function main(argv: string[] = Deno.args) {
     }
   }
 
+  function clearScheduledFlush(
+    handle: NonNullable<ReturnType<typeof handles.get>>,
+  ): void {
+    const timer = scheduledFlushes.get(handle);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      scheduledFlushes.delete(handle);
+    }
+  }
+
+  function scheduleFlush(
+    handle: NonNullable<ReturnType<typeof handles.get>>,
+    delayMs: number,
+  ): void {
+    clearScheduledFlush(handle);
+    const timer = setTimeout(() => {
+      scheduledFlushes.delete(handle);
+      if (handle.flushing) {
+        // A flush is already in flight; retry shortly so we commit the latest
+        // stable buffer rather than an intermediate chunk from a multi-write save.
+        scheduleFlush(handle, 10);
+        return;
+      }
+      flushHandle(handle).catch((e) => {
+        console.error(`[fuse] scheduled flush error: ${e}`);
+      });
+    }, delayMs);
+    scheduledFlushes.set(handle, timer);
+  }
+
   // write(req, ino, buf_ptr, size, offset, fi_ptr)
   const writeCb = new Deno.UnsafeCallback(
     {
@@ -753,9 +787,17 @@ export async function main(argv: string[] = Deno.args) {
       fuse.symbols.fuse_reply_err(req, 0);
 
       // Fire-and-forget the actual write to the cell
-      flushHandle(handle).catch((e) => {
-        console.error(`[fuse] flush write error: ${e}`);
-      });
+      const writePath = bridge?.resolveWritePath(handle.ino);
+      if (writePath?.fsProjection === "markdown") {
+        // Markdown saves often arrive as several small writes plus flushes.
+        // Delay slightly so we commit the settled buffer, not a truncated
+        // intermediate body that still parses as valid markdown.
+        scheduleFlush(handle, 25);
+      } else {
+        flushHandle(handle).catch((e) => {
+          console.error(`[fuse] flush write error: ${e}`);
+        });
+      }
     },
   );
   callbacks.push(flushCb);
@@ -830,10 +872,15 @@ export async function main(argv: string[] = Deno.args) {
 
       // Reply immediately and close the handle.
       // Fire-and-forget the write if dirty.
-      if (handle && handle.dirty && bridge && !handle.flushing) {
-        flushHandle(handle).catch((e) => {
-          console.error(`[fuse] release flush error: ${e}`);
-        });
+      if (handle && handle.dirty && bridge) {
+        const writePath = bridge.resolveWritePath(handle.ino);
+        if (writePath?.fsProjection === "markdown") {
+          scheduleFlush(handle, 0);
+        } else if (!handle.flushing) {
+          flushHandle(handle).catch((e) => {
+            console.error(`[fuse] release flush error: ${e}`);
+          });
+        }
       }
       handles.close(fh);
       fuse.symbols.fuse_reply_err(req, 0);

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -19,19 +19,16 @@ import {
   ENOTDIR,
   ERANGE,
   EXDEV,
-  FILE_MODE,
   FILE_MODE_RW,
-  FILE_MODE_RWX,
-  FILE_MODE_RX,
   FUSE_SET_ATTR_SIZE,
   getPlatform,
   O_RDWR,
   O_WRONLY,
   readCString,
-  SYMLINK_MODE,
 } from "./platform.ts";
 import { FsTree } from "./tree.ts";
 import { HandleMap, type HandleState } from "./handles.ts";
+import { buildNodeStat, getMountOwnership, nodeMode } from "./stat.ts";
 
 const encoder = new TextEncoder();
 
@@ -114,6 +111,7 @@ export async function main(argv: string[] = Deno.args) {
 
   // Create filesystem tree
   const tree = new FsTree();
+  const mountOwnership = getMountOwnership();
 
   let bridge: CellBridge | null = null;
   const scheduledFlushes = new WeakMap<
@@ -152,26 +150,14 @@ export async function main(argv: string[] = Deno.args) {
   // File handle tracking for write support
   const handles = new HandleMap();
 
-  function nodeMode(node: ReturnType<typeof tree.getNode>, ino?: bigint) {
-    if (!node) return 0;
-    if (node.kind === "dir") return DIR_MODE;
-    if (node.kind === "symlink") return SYMLINK_MODE;
-    if (node.kind === "callable") {
-      return node.callableKind === "handler" ? FILE_MODE_RWX : FILE_MODE_RX;
-    }
-    // Files in writable piece data get 644, others stay 444
-    if (bridge && ino !== undefined && bridge.resolveWritePath(ino)) {
-      return FILE_MODE_RW;
-    }
-    return FILE_MODE;
-  }
-
-  function nodeSize(node: ReturnType<typeof tree.getNode>) {
-    if (!node) return 0;
-    if (node.kind === "file") return node.content.length;
-    if (node.kind === "symlink") return node.target.length;
-    if (node.kind === "callable") return node.script.length;
-    return 0;
+  function buildStat(
+    node: NonNullable<ReturnType<typeof tree.getNode>>,
+    ino: bigint,
+  ) {
+    return buildNodeStat(node, ino, {
+      isWritable: Boolean(bridge?.resolveWritePath(ino)),
+      ownership: mountOwnership,
+    });
   }
 
   function replyEntry(
@@ -182,12 +168,7 @@ export async function main(argv: string[] = Deno.args) {
     const entryBuf = new ArrayBuffer(ENTRY_PARAM_SIZE);
     writeEntryParam(entryBuf, {
       ino,
-      attr: {
-        ino,
-        mode: nodeMode(node, ino),
-        nlink: node!.kind === "dir" ? 2 : 1,
-        size: nodeSize(node),
-      },
+      attr: buildStat(node!, ino),
       attrTimeout: 1.0,
       entryTimeout: 1.0,
     });
@@ -292,12 +273,7 @@ export async function main(argv: string[] = Deno.args) {
       }
 
       const statBuf = new ArrayBuffer(STAT_SIZE);
-      writeStat(statBuf, {
-        ino: inode,
-        mode: nodeMode(node, inode),
-        nlink: node.kind === "dir" ? 2 : 1,
-        size: nodeSize(node),
-      });
+      writeStat(statBuf, buildStat(node, inode));
 
       fuse.symbols.fuse_reply_attr(
         req,
@@ -525,7 +501,10 @@ export async function main(argv: string[] = Deno.args) {
         entries.push({
           name: childName,
           ino: childIno,
-          mode: nodeMode(childNode),
+          mode: nodeMode(
+            childNode,
+            Boolean(bridge?.resolveWritePath(childIno)),
+          ),
         });
       }
 
@@ -542,6 +521,8 @@ export async function main(argv: string[] = Deno.args) {
           mode: entry.mode,
           nlink: 1,
           size: 0,
+          uid: mountOwnership.uid,
+          gid: mountOwnership.gid,
         });
 
         const remaining = bufSize - pos;
@@ -847,12 +828,7 @@ export async function main(argv: string[] = Deno.args) {
 
       // Reply with current attrs (silently accept chmod/chown/times)
       const statBuf = new ArrayBuffer(STAT_SIZE);
-      writeStat(statBuf, {
-        ino: inode,
-        mode: nodeMode(node, inode),
-        nlink: node.kind === "dir" ? 2 : 1,
-        size: nodeSize(node),
-      });
+      writeStat(statBuf, buildStat(node, inode));
       fuse.symbols.fuse_reply_attr(
         req,
         Deno.UnsafePointer.of(new Uint8Array(statBuf)),
@@ -1044,6 +1020,8 @@ export async function main(argv: string[] = Deno.args) {
           mode: FILE_MODE_RW,
           nlink: 1,
           size: 0,
+          uid: mountOwnership.uid,
+          gid: mountOwnership.gid,
         },
         attrTimeout: 1.0,
         entryTimeout: 1.0,

--- a/packages/fuse/stat.test.ts
+++ b/packages/fuse/stat.test.ts
@@ -17,6 +17,20 @@ Deno.test("getMountOwnership falls back to root ids when unavailable", () => {
   assertEquals(getMountOwnership({}), { uid: 0, gid: 0 });
 });
 
+Deno.test("getMountOwnership falls back when uid/gid probes throw", () => {
+  assertEquals(
+    getMountOwnership({
+      uid: () => {
+        throw new Error("uid unavailable");
+      },
+      gid: () => {
+        throw new Error("gid unavailable");
+      },
+    }),
+    { uid: 0, gid: 0 },
+  );
+});
+
 Deno.test("buildNodeStat assigns mounted handler files to the current user", () => {
   const script = new TextEncoder().encode("#!/bin/sh\n");
   const node: FsNode = {

--- a/packages/fuse/stat.test.ts
+++ b/packages/fuse/stat.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals } from "@std/assert";
+import { FILE_MODE_RWX } from "./platform.ts";
+import { buildNodeStat, getMountOwnership } from "./stat.ts";
+import type { FsNode } from "./types.ts";
+
+Deno.test("getMountOwnership uses the current process ids when available", () => {
+  assertEquals(
+    getMountOwnership({
+      uid: () => 501,
+      gid: () => 20,
+    }),
+    { uid: 501, gid: 20 },
+  );
+});
+
+Deno.test("getMountOwnership falls back to root ids when unavailable", () => {
+  assertEquals(getMountOwnership({}), { uid: 0, gid: 0 });
+});
+
+Deno.test("buildNodeStat assigns mounted handler files to the current user", () => {
+  const script = new TextEncoder().encode("#!/bin/sh\n");
+  const node: FsNode = {
+    kind: "callable",
+    callableKind: "handler",
+    cellKey: "addItem",
+    cellProp: "result",
+    script,
+  };
+
+  assertEquals(
+    buildNodeStat(node, 7n, {
+      ownership: { uid: 501, gid: 20 },
+    }),
+    {
+      ino: 7n,
+      mode: FILE_MODE_RWX,
+      nlink: 1,
+      size: script.length,
+      uid: 501,
+      gid: 20,
+    },
+  );
+});

--- a/packages/fuse/stat.ts
+++ b/packages/fuse/stat.ts
@@ -1,0 +1,65 @@
+import {
+  DIR_MODE,
+  FILE_MODE,
+  FILE_MODE_RW,
+  FILE_MODE_RWX,
+  FILE_MODE_RX,
+  type StatOpts,
+  SYMLINK_MODE,
+} from "./platform.ts";
+import type { FsNode } from "./types.ts";
+
+export interface MountOwnership {
+  uid: number;
+  gid: number;
+}
+
+interface OwnershipProvider {
+  uid?: () => number | null;
+  gid?: () => number | null;
+}
+
+export function getMountOwnership(
+  provider: OwnershipProvider = Deno,
+): MountOwnership {
+  const uid = typeof provider.uid === "function" ? provider.uid() : null;
+  const gid = typeof provider.gid === "function" ? provider.gid() : null;
+  return {
+    uid: uid ?? 0,
+    gid: gid ?? 0,
+  };
+}
+
+export function nodeMode(node: FsNode, isWritable = false): number {
+  if (node.kind === "dir") return DIR_MODE;
+  if (node.kind === "symlink") return SYMLINK_MODE;
+  if (node.kind === "callable") {
+    return node.callableKind === "handler" ? FILE_MODE_RWX : FILE_MODE_RX;
+  }
+  return isWritable ? FILE_MODE_RW : FILE_MODE;
+}
+
+export function nodeSize(node: FsNode): number {
+  if (node.kind === "file") return node.content.length;
+  if (node.kind === "symlink") return node.target.length;
+  if (node.kind === "callable") return node.script.length;
+  return 0;
+}
+
+export function buildNodeStat(
+  node: FsNode,
+  ino: bigint,
+  options: {
+    isWritable?: boolean;
+    ownership: MountOwnership;
+  },
+): StatOpts {
+  return {
+    ino,
+    mode: nodeMode(node, options.isWritable ?? false),
+    nlink: node.kind === "dir" ? 2 : 1,
+    size: nodeSize(node),
+    uid: options.ownership.uid,
+    gid: options.ownership.gid,
+  };
+}

--- a/packages/fuse/stat.ts
+++ b/packages/fuse/stat.ts
@@ -19,11 +19,20 @@ interface OwnershipProvider {
   gid?: () => number | null;
 }
 
+function safeCall(fn: (() => number | null) | undefined): number | null {
+  if (typeof fn !== "function") return null;
+  try {
+    return fn();
+  } catch {
+    return null;
+  }
+}
+
 export function getMountOwnership(
   provider: OwnershipProvider = Deno,
 ): MountOwnership {
-  const uid = typeof provider.uid === "function" ? provider.uid() : null;
-  const gid = typeof provider.gid === "function" ? provider.gid() : null;
+  const uid = safeCall(provider.uid);
+  const gid = safeCall(provider.gid);
   return {
     uid: uid ?? 0,
     gid: gid ?? 0,

--- a/packages/fuse/tree-builder.test.ts
+++ b/packages/fuse/tree-builder.test.ts
@@ -692,20 +692,25 @@ Deno.test("CellBridge.sendToHandler resolves mounted callable paths under pieces
     path: (string | number)[] | undefined;
     value: unknown;
   }> = [];
+  const makeChannel = (channel: "input" | "result") => ({
+    key: (key: string) => ({
+      send: (value: unknown) => {
+        calls.push({ channel, value, path: [key] });
+      },
+    }),
+  });
   const piece = {
     id: "of:entity-123",
     input: {
-      set: (value: unknown, path?: (string | number)[]) => {
-        calls.push({ channel: "input", value, path });
-        return Promise.resolve();
-      },
+      getCell: () => Promise.resolve(makeChannel("input")),
     },
     result: {
-      set: (value: unknown, path?: (string | number)[]) => {
-        calls.push({ channel: "result", value, path });
-        return Promise.resolve();
-      },
+      getCell: () => Promise.resolve(makeChannel("result")),
     },
+    manager: () => ({
+      runtime: { idle: () => Promise.resolve() },
+      synced: () => Promise.resolve(),
+    }),
   };
 
   const spaceIno = tree.addDir(tree.rootIno, "home");

--- a/packages/fuse/tree-builder.test.ts
+++ b/packages/fuse/tree-builder.test.ts
@@ -746,6 +746,7 @@ Deno.test("CellBridge.sendToHandler resolves mounted callable paths under pieces
     piecesIno,
     entitiesIno,
     pieceMap: new Map([["notes", "of:entity-123"]]),
+    pieceAliases: new Map(),
     pieceControllers: new Map([["notes", piece as never]]),
     pieceSubs: new Map(),
     did: "did:key:home",

--- a/packages/fuse/tree-builder.test.ts
+++ b/packages/fuse/tree-builder.test.ts
@@ -746,7 +746,6 @@ Deno.test("CellBridge.sendToHandler resolves mounted callable paths under pieces
     piecesIno,
     entitiesIno,
     pieceMap: new Map([["notes", "of:entity-123"]]),
-    pieceAliases: new Map(),
     pieceControllers: new Map([["notes", piece as never]]),
     pieceSubs: new Map(),
     did: "did:key:home",

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -61,7 +61,11 @@ export function isSigilLink(v: unknown): boolean {
 
 export { isHandlerCell, isStreamValue } from "./callables.ts";
 
-/** Shape of the value a pattern returns under the [FS] key. */
+/**
+ * Resolved shape of a [FS] projection value, after reading from cells.
+ * Mirrors the FsProjection API type but with the plain-object case
+ * normalized into the explicit application/json form.
+ */
 export interface FsValue {
   type: "text/markdown" | "application/json";
   content: string | Record<string, unknown>;

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -61,6 +61,13 @@ export function isSigilLink(v: unknown): boolean {
 
 export { isHandlerCell, isStreamValue } from "./callables.ts";
 
+/** Returns true if the value is a VNode (virtual DOM element). */
+export function isVNode(value: unknown): boolean {
+  return typeof value === "object" && value !== null &&
+    !Array.isArray(value) &&
+    (value as Record<string, unknown>).type === "vnode";
+}
+
 /**
  * Resolved shape of a [FS] projection value, after reading from cells.
  * Mirrors the FsProjection API type but with the plain-object case

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -68,10 +68,18 @@ export interface FsValue {
   frontmatter?: Record<string, unknown>;
 }
 
+function isFrontmatterPrimitive(val: unknown): boolean {
+  return val === null || val === undefined || typeof val === "string" ||
+    typeof val === "number" || typeof val === "boolean";
+}
+
 /**
  * Build a single-file filesystem projection from a [FS] value.
  *
  * - text/markdown  → index.md  (YAML frontmatter + body)
+ *   Primitive frontmatter fields go into YAML.
+ *   Complex fields (objects, arrays of entities) become subdirectories
+ *   alongside index.md via `buildSubtree`.
  * - application/json → index.json (flat JSON object)
  *
  * `entityId` is always injected first (read-only field).
@@ -82,6 +90,7 @@ export function buildFsProjection(
   parentIno: bigint,
   fsValue: FsValue,
   entityId: string,
+  buildSubtree?: (parentIno: bigint, name: string, value: unknown) => void,
 ): bigint {
   if (fsValue.type === "text/markdown") {
     const fmLines: string[] = [`entityId: ${entityId}`];
@@ -89,7 +98,13 @@ export function buildFsProjection(
       for (const [key, val] of Object.entries(fsValue.frontmatter)) {
         // Skip entityId if pattern accidentally includes it
         if (key === "entityId") continue;
-        fmLines.push(`${key}: ${String(val ?? "")}`);
+        if (isFrontmatterPrimitive(val)) {
+          fmLines.push(`${key}: ${String(val ?? "")}`);
+        } else if (buildSubtree) {
+          // Arrays of entities or nested objects can't be expressed in YAML
+          // frontmatter — render as a sibling directory instead.
+          buildSubtree(parentIno, key, val);
+        }
       }
     }
     const body = String(fsValue.content ?? "");

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -61,6 +61,57 @@ export function isSigilLink(v: unknown): boolean {
 
 export { isHandlerCell, isStreamValue } from "./callables.ts";
 
+/** Shape of the value a pattern returns under the [FS] key. */
+export interface FsValue {
+  type: "text/markdown" | "application/json";
+  content: string | Record<string, unknown>;
+  frontmatter?: Record<string, unknown>;
+}
+
+/**
+ * Build a single-file filesystem projection from a [FS] value.
+ *
+ * - text/markdown  → index.md  (YAML frontmatter + body)
+ * - application/json → index.json (flat JSON object)
+ *
+ * `entityId` is always injected first (read-only field).
+ * Returns the inode of the created file.
+ */
+export function buildFsProjection(
+  tree: FsTree,
+  parentIno: bigint,
+  fsValue: FsValue,
+  entityId: string,
+): bigint {
+  if (fsValue.type === "text/markdown") {
+    const fmLines: string[] = [`entityId: ${entityId}`];
+    if (fsValue.frontmatter) {
+      for (const [key, val] of Object.entries(fsValue.frontmatter)) {
+        // Skip entityId if pattern accidentally includes it
+        if (key === "entityId") continue;
+        fmLines.push(`${key}: ${String(val ?? "")}`);
+      }
+    }
+    const body = String(fsValue.content ?? "");
+    const fileContent = `---\n${fmLines.join("\n")}\n---\n\n${body}`;
+    return tree.addFile(parentIno, "index.md", fileContent, "string");
+  }
+
+  if (fsValue.type === "application/json") {
+    const content = (fsValue.content ?? {}) as Record<string, unknown>;
+    const obj = { entityId, ...content };
+    return tree.addFile(parentIno, "index.json", safeStringify(obj), "object");
+  }
+
+  // Fallback: unknown type
+  return tree.addFile(
+    parentIno,
+    "index.txt",
+    safeStringify(fsValue),
+    "object",
+  );
+}
+
 /** Options for buildJsonTree beyond the required params. */
 export interface BuildJsonTreeOpts {
   seen?: WeakSet<object>;

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -73,11 +73,16 @@ export function isVNode(value: unknown): boolean {
  * Mirrors the FsProjection API type but with the plain-object case
  * normalized into the explicit application/json form.
  */
-export interface FsValue {
-  type: "text/markdown" | "application/json";
-  content: string | Record<string, unknown>;
-  frontmatter?: Record<string, unknown>;
-}
+export type FsValue =
+  | {
+    type: "text/markdown";
+    content: string;
+    frontmatter?: Record<string, unknown>;
+  }
+  | {
+    type: "application/json";
+    content: Record<string, unknown>;
+  };
 
 function isFrontmatterPrimitive(val: unknown): boolean {
   return val === null || val === undefined || typeof val === "string" ||
@@ -124,8 +129,8 @@ export function buildFsProjection(
   }
 
   if (fsValue.type === "application/json") {
-    const content = (fsValue.content ?? {}) as Record<string, unknown>;
-    const obj = { entityId, ...content };
+    const { entityId: _skipEntityId, ...safeContent } = fsValue.content ?? {};
+    const obj = { entityId, ...safeContent };
     return tree.addFile(parentIno, "index.json", safeStringify(obj), "object");
   }
 

--- a/packages/patterns/contacts/contact-book.tsx
+++ b/packages/patterns/contacts/contact-book.tsx
@@ -51,13 +51,16 @@ export default pattern<ContactBookInput, ContactBookOutput>(
 
     const summary = computed(() => {
       return contacts.get()
+        .filter((c): c is Contact => c != null)
         .map((c) => c.name || "(unnamed)")
         .join(", ");
     });
 
     const contactSelectItems = computed(
       () =>
-        contacts.map((c) => ({ label: c.name || "(unnamed)", value: c.name })),
+        contacts.get()
+          .filter((c): c is Contact => c != null)
+          .map((c) => ({ label: c.name || "(unnamed)", value: c.name })),
     );
 
     const onAddContact = action(() => {

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -4,6 +4,7 @@ import {
   computed,
   type Default,
   FS,
+  type FsProjection,
   generateText,
   handler,
   NAME,
@@ -35,7 +36,7 @@ export { NotePiece };
 interface NoteOutput extends NotePiece {
   [NAME]: string;
   [UI]: VNode;
-  [FS]: { type: string; content: string; frontmatter: Record<string, string> };
+  [FS]: FsProjection;
   title: string;
   content: string;
   summary: string;

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -3,6 +3,7 @@ import {
   action,
   computed,
   type Default,
+  FS,
   generateText,
   handler,
   NAME,
@@ -34,6 +35,7 @@ export { NotePiece };
 interface NoteOutput extends NotePiece {
   [NAME]: string;
   [UI]: VNode;
+  [FS]: { type: string; content: string; frontmatter: Record<string, string> };
   title: string;
   content: string;
   summary: string;
@@ -361,6 +363,11 @@ const Note = pattern<NoteInput, NoteOutput>(
 
     return {
       [NAME]: computed(() => `📝 ${title.get()}`),
+      [FS]: {
+        type: "text/markdown",
+        frontmatter: { title },
+        content,
+      },
       [UI]: (
         <ct-screen>
           <ct-vstack

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -13,6 +13,7 @@ import {
   AsStream,
   AsWriteonlyCell,
   AuthSchema,
+  FS,
   ID,
   ID_FIELD,
   isPattern,
@@ -145,6 +146,7 @@ export const createBuilder = (): {
       TYPE,
       NAME,
       UI,
+      FS,
 
       // Schema utilities
       schema,

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -67,6 +67,7 @@ export const ID_FIELD: typeof IDFieldSymbol = Symbol(
 export const TYPE = "$TYPE";
 export const NAME = "$NAME";
 export const UI = "$UI";
+export const FS = "$FS";
 
 // Symbol for accessing self-reference in patterns
 export const SELF: typeof SELFSymbol = Symbol("SELF") as any;
@@ -291,6 +292,7 @@ export interface BuilderFunctionsAndConstants {
   TYPE: typeof TYPE;
   NAME: typeof NAME;
   UI: typeof UI;
+  FS: typeof FS;
 
   // Schema utilities
   schema: typeof schema;

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -92,6 +92,7 @@ export type {
   Cell,
   CellKind,
   CellTypeConstructor,
+  FsProjection,
   Handler,
   HandlerFactory,
   HKT,

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -88,6 +88,7 @@ export {
   type Cell as BuilderCell,
   type Frame,
   FS,
+  type FsProjection,
   type HandlerFactory,
   ID,
   ID_FIELD,

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -87,6 +87,7 @@ export {
   AuthSchema,
   type Cell as BuilderCell,
   type Frame,
+  FS,
   type HandlerFactory,
   ID,
   ID_FIELD,
@@ -141,3 +142,5 @@ export {
 export { createJsonSchema } from "./builder/json-utils.ts";
 export { deepEqual } from "@commontools/utils/deep-equal";
 export { getValueAtPath, setValueAtPath } from "./path-utils.ts";
+export { schemaToTypeString } from "./schema-format.ts";
+export type { SchemaFormatOptions } from "./schema-format.ts";

--- a/packages/ts-transformers/src/closures/strategies/array-method-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-strategy.ts
@@ -399,7 +399,8 @@ function isKnownComputedKey(
 ): expression is ts.Identifier {
   return isCommonToolsKeyIdentifier(expression, context, "NAME") ||
     isCommonToolsKeyIdentifier(expression, context, "UI") ||
-    isCommonToolsKeyIdentifier(expression, context, "SELF");
+    isCommonToolsKeyIdentifier(expression, context, "SELF") ||
+    isCommonToolsKeyIdentifier(expression, context, "FS");
 }
 
 function lowerMapReceiverMemberAccess(

--- a/packages/ts-transformers/src/utils/reactive-keys.ts
+++ b/packages/ts-transformers/src/utils/reactive-keys.ts
@@ -6,7 +6,7 @@ import {
   type TransformationContext,
 } from "../core/mod.ts";
 
-type CommonToolsKeyName = "NAME" | "UI" | "SELF";
+type CommonToolsKeyName = "NAME" | "UI" | "SELF" | "FS";
 
 export function cloneKeyExpression(
   expr: ts.Expression,
@@ -74,7 +74,7 @@ export function getKnownComputedKeyExpression(
   expr: ts.Expression,
   context: TransformationContext,
 ): ts.Expression | undefined {
-  for (const name of ["NAME", "UI", "SELF"] as const) {
+  for (const name of ["NAME", "UI", "SELF", "FS"] as const) {
     if (
       isCommonToolsKeyIdentifier(expr, context, name) ||
       isCtHelpersKeyAccess(expr, name)

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -1,0 +1,86 @@
+import { assertEquals } from "@std/assert";
+import {
+  extractMetrics,
+  type Job,
+  type Step,
+  type WorkflowRun,
+} from "./perf-lib.ts";
+
+function makeRun(): WorkflowRun {
+  return {
+    id: 1,
+    html_url: "https://example.test/run/1",
+    head_sha: "deadbeef",
+    created_at: "2026-01-01T00:00:00Z",
+    conclusion: "success",
+    event: "push",
+  };
+}
+
+function makeStep(
+  name: string,
+  started_at: string,
+  completed_at: string,
+): Step {
+  return { name, started_at, completed_at };
+}
+
+function makeJob(
+  id: number,
+  name: string,
+  started_at: string,
+  completed_at: string,
+  steps: Step[],
+): Job {
+  return { id, name, started_at, completed_at, steps };
+}
+
+Deno.test("extractMetrics keeps CLI core and fuse timings separate", () => {
+  const metrics = extractMetrics(makeRun(), [
+    makeJob(
+      1,
+      "CLI Integration Tests (core)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:03:20Z",
+      [
+        makeStep(
+          "🧪 Run CLI integration suite",
+          "2026-01-01T00:01:00Z",
+          "2026-01-01T00:03:00Z",
+        ),
+      ],
+    ),
+    makeJob(
+      2,
+      "CLI Integration Tests (fuse)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:35Z",
+      [
+        makeStep(
+          "🧪 Run CLI FUSE integration suite",
+          "2026-01-01T00:01:00Z",
+          "2026-01-01T00:01:30Z",
+        ),
+      ],
+    ),
+  ]);
+
+  assertEquals(
+    metrics.get("job: CLI Integration Tests (core)")?.durationSeconds,
+    200,
+  );
+  assertEquals(
+    metrics.get("job: CLI Integration Tests (fuse)")?.durationSeconds,
+    95,
+  );
+  assertEquals(
+    metrics.get("step: CLI integration (core)")?.durationSeconds,
+    120,
+  );
+  assertEquals(
+    metrics.get("step: CLI integration (fuse)")?.durationSeconds,
+    30,
+  );
+  assertEquals(metrics.has("job: CLI Integration Tests"), false);
+  assertEquals(metrics.has("step: CLI integration"), false);
+});

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -561,6 +561,13 @@ export function extractMetrics(
     durationSeconds: duration,
   });
 
+  const setIfLonger = (name: string, sample: TimingSample) => {
+    const existing = metrics.get(name);
+    if (!existing || sample.durationSeconds > existing.durationSeconds) {
+      metrics.set(name, sample);
+    }
+  };
+
   for (const job of jobs) {
     const jobDuration = durationSeconds(job.started_at, job.completed_at);
     if (jobDuration <= 0) continue;
@@ -569,31 +576,31 @@ export function extractMetrics(
 
     for (const pattern of INTEGRATION_JOB_PATTERNS) {
       if (normalizedJobName.includes(pattern)) {
-        metrics.set(`job: ${pattern}`, makeSample(jobDuration));
+        setIfLonger(`job: ${pattern}`, makeSample(jobDuration));
       }
     }
 
     const unitMatch = PATTERN_UNIT_RE.exec(normalizedJobName);
     if (unitMatch) {
-      metrics.set(
+      setIfLonger(
         `job: Pattern Unit Tests (${unitMatch[1]}/${unitMatch[2]})`,
         makeSample(jobDuration),
       );
     }
 
     if (normalizedJobName.includes("Test and Build")) {
-      metrics.set("job: Test and Build", makeSample(jobDuration));
+      setIfLonger("job: Test and Build", makeSample(jobDuration));
     }
 
     // New parallelized job names (after CI restructure)
     if (normalizedJobName === "Build Binaries") {
-      metrics.set("job: Build Binaries", makeSample(jobDuration));
+      setIfLonger("job: Build Binaries", makeSample(jobDuration));
     }
     if (normalizedJobName === "Test") {
-      metrics.set("job: Test", makeSample(jobDuration));
+      setIfLonger("job: Test", makeSample(jobDuration));
     }
     if (normalizedJobName === "Check") {
-      metrics.set("job: Check", makeSample(jobDuration));
+      setIfLonger("job: Check", makeSample(jobDuration));
     }
 
     for (const step of job.steps) {
@@ -603,7 +610,7 @@ export function extractMetrics(
       const normalizedStepName = normalizeName(step.name).toLowerCase();
       for (const keyword of STEP_KEYWORDS) {
         if (normalizedStepName.includes(keyword.toLowerCase())) {
-          metrics.set(`step: ${keyword}`, makeSample(stepDuration));
+          setIfLonger(`step: ${keyword}`, makeSample(stepDuration));
         }
       }
     }

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -521,30 +521,96 @@ export function normalizeName(name: string): string {
     .trim();
 }
 
-/** Integration-test job name patterns to track. */
-export const INTEGRATION_JOB_PATTERNS = [
-  "Package Integration Tests",
-  "CLI Integration Tests",
-  "Pattern Integration Tests",
-  "Generated Patterns Integration Tests",
-];
+const JOB_METRIC_NAMES: Record<string, string> = {
+  "Package Integration Tests": "job: Package Integration Tests",
+  "CLI Integration Tests (core)": "job: CLI Integration Tests (core)",
+  "CLI Integration Tests (fuse)": "job: CLI Integration Tests (fuse)",
+  // Legacy pre-matrix job name retained for older baselines and overrides.
+  "CLI Integration Tests": "job: CLI Integration Tests",
+  "Pattern Integration Tests": "job: Pattern Integration Tests",
+  "Generated Patterns Integration Tests":
+    "job: Generated Patterns Integration Tests",
+  "Build Binaries": "job: Build Binaries",
+  "Test": "job: Test",
+  "Check": "job: Check",
+  "Test and Build": "job: Test and Build",
+};
 
 /** Pattern for matrix jobs like "Pattern Unit Tests (1/5)". */
 export const PATTERN_UNIT_RE = /Pattern Unit Tests\s*\((\d+)\/(\d+)\)/;
 
-/** Step name substrings to track within jobs. */
-export const STEP_KEYWORDS = [
-  "runner integration",
-  "runtime-client integration",
-  "shell integration",
-  "background worker integration",
-  "patterns integration",
-  "CLI integration",
-  "generated patterns integration",
-  "pattern unit tests",
-  "Type check",
-  "workspace tests",
-  "Build application",
+interface StepMetricMatcher {
+  jobName: string;
+  stepKeyword: string;
+  metricName: string;
+}
+
+const STEP_METRIC_MATCHERS: StepMetricMatcher[] = [
+  {
+    jobName: "Package Integration Tests",
+    stepKeyword: "runner integration",
+    metricName: "step: runner integration",
+  },
+  {
+    jobName: "Package Integration Tests",
+    stepKeyword: "runtime-client integration",
+    metricName: "step: runtime-client integration",
+  },
+  {
+    jobName: "Package Integration Tests",
+    stepKeyword: "shell integration",
+    metricName: "step: shell integration",
+  },
+  {
+    jobName: "Package Integration Tests",
+    stepKeyword: "background worker integration",
+    metricName: "step: background worker integration",
+  },
+  {
+    jobName: "Pattern Integration Tests",
+    stepKeyword: "patterns integration",
+    metricName: "step: patterns integration",
+  },
+  {
+    jobName: "Generated Patterns Integration Tests",
+    stepKeyword: "generated patterns integration",
+    metricName: "step: generated patterns integration",
+  },
+  {
+    jobName: "CLI Integration Tests (core)",
+    stepKeyword: "cli integration suite",
+    metricName: "step: CLI integration (core)",
+  },
+  {
+    jobName: "CLI Integration Tests (fuse)",
+    stepKeyword: "cli fuse integration suite",
+    metricName: "step: CLI integration (fuse)",
+  },
+  {
+    jobName: "CLI Integration Tests",
+    stepKeyword: "cli integration suite",
+    metricName: "step: CLI integration",
+  },
+  {
+    jobName: "Pattern Unit Tests",
+    stepKeyword: "pattern unit tests",
+    metricName: "step: pattern unit tests",
+  },
+  {
+    jobName: "Check",
+    stepKeyword: "type check",
+    metricName: "step: Type check",
+  },
+  {
+    jobName: "Test",
+    stepKeyword: "workspace tests",
+    metricName: "step: workspace tests",
+  },
+  {
+    jobName: "Build Binaries",
+    stepKeyword: "build application",
+    metricName: "step: Build application",
+  },
 ];
 
 export function extractMetrics(
@@ -561,46 +627,31 @@ export function extractMetrics(
     durationSeconds: duration,
   });
 
-  const setIfLonger = (name: string, sample: TimingSample) => {
-    const existing = metrics.get(name);
-    if (!existing || sample.durationSeconds > existing.durationSeconds) {
-      metrics.set(name, sample);
-    }
-  };
-
   for (const job of jobs) {
     const jobDuration = durationSeconds(job.started_at, job.completed_at);
     if (jobDuration <= 0) continue;
 
     const normalizedJobName = normalizeName(job.name);
 
-    for (const pattern of INTEGRATION_JOB_PATTERNS) {
-      if (normalizedJobName.includes(pattern)) {
-        setIfLonger(`job: ${pattern}`, makeSample(jobDuration));
-      }
+    const jobMetricName = JOB_METRIC_NAMES[normalizedJobName];
+    if (jobMetricName) {
+      metrics.set(jobMetricName, makeSample(jobDuration));
     }
+
+    const matcherJobName = normalizedJobName.startsWith("Pattern Unit Tests")
+      ? "Pattern Unit Tests"
+      : normalizedJobName;
 
     const unitMatch = PATTERN_UNIT_RE.exec(normalizedJobName);
     if (unitMatch) {
-      setIfLonger(
+      metrics.set(
         `job: Pattern Unit Tests (${unitMatch[1]}/${unitMatch[2]})`,
         makeSample(jobDuration),
       );
     }
 
     if (normalizedJobName.includes("Test and Build")) {
-      setIfLonger("job: Test and Build", makeSample(jobDuration));
-    }
-
-    // New parallelized job names (after CI restructure)
-    if (normalizedJobName === "Build Binaries") {
-      setIfLonger("job: Build Binaries", makeSample(jobDuration));
-    }
-    if (normalizedJobName === "Test") {
-      setIfLonger("job: Test", makeSample(jobDuration));
-    }
-    if (normalizedJobName === "Check") {
-      setIfLonger("job: Check", makeSample(jobDuration));
+      metrics.set("job: Test and Build", makeSample(jobDuration));
     }
 
     for (const step of job.steps) {
@@ -608,9 +659,12 @@ export function extractMetrics(
       if (stepDuration <= 0) continue;
 
       const normalizedStepName = normalizeName(step.name).toLowerCase();
-      for (const keyword of STEP_KEYWORDS) {
-        if (normalizedStepName.includes(keyword.toLowerCase())) {
-          setIfLonger(`step: ${keyword}`, makeSample(stepDuration));
+      for (const matcher of STEP_METRIC_MATCHERS) {
+        if (
+          matcher.jobName === matcherJobName &&
+          normalizedStepName.includes(matcher.stepKeyword)
+        ) {
+          metrics.set(matcher.metricName, makeSample(stepDuration));
         }
       }
     }


### PR DESCRIPTION
## Summary

- **`[FS]` symbol**: patterns can now declare their own on-disk representation via `[FS]: { type, content, frontmatter? }` in their return object. When present, FUSE renders a single `index.md` (YAML frontmatter + markdown body) or `index.json` at the piece root instead of an exploded `result/` directory.
- **Live write-back**: edits to `index.md`/`index.json` parse the content and update the corresponding reactive cells bidirectionally.
- **`.handlers` file**: every piece now gets a dot-prefixed `.handlers` file at its root listing all callables with TypeScript-ish input types (e.g. `setTitle.handler  string`, `createNewNote.handler  void`). Hidden from `ls`, readable with `cat`.
- **Callable scripts enriched**: each `.handler`/`.tool` script file now embeds `# schema:` and `# input:` comments so agents can discover the expected shape via `cat` or `head` without invoking.
- **`ct exec` UX**: `--help` output now includes an "Input type:" section showing the TypeScript-ish type shape; calling a handler with no args now shows the expected type in the error message.
- **`note.tsx`**: first pattern to adopt `[FS]`, exporting `title` and `content` cells through markdown projection.

## Test plan

- [x] `deno test --allow-all packages/fuse/` — all 69 tests pass
- [x] `deno test --allow-all packages/cli/test/exec.test.ts` — all tests pass
- [x] Mount a space with `ct fuse mount`, open a note piece → `index.md` at piece root, no `result/` dir
- [x] `cat pieces/<Note>/index.md` → YAML frontmatter with `entityId` + `title`, markdown body
- [x] Edit and save `index.md` → title/content cells update in browser UI
- [x] `cat pieces/<Note>/.handlers` → TypeScript-ish types for each handler
- [x] `cat pieces/<Note>/setTitle.handler` → shebang with `# schema:` and `# input: string` comments
- [x] `./setTitle.handler` (no args) → error showing `Handler requires input. Expected type: string`
- [x] `./setTitle.handler --help` → usage with "Input type: string" section
- [x] Non-FS pieces → `result/` dir still present; `.handlers` file present

🤖 Generated with [Claude Code](https://claude.com/claude-code)