### PR TITLE
ci: migrate GHA runners to labs runner group

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   benchmarks:
     name: "Run Benchmarks"
-    runs-on: ubuntu-24.04-64-core
+    runs-on:
+      group: labs
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -41,7 +41,8 @@ jobs:
 
   test:
     name: "Test"
-    runs-on: ubuntu-24.04-32-core
+    runs-on:
+      group: labs
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
@@ -70,7 +71,8 @@ jobs:
 
   build-binaries:
     name: "Build Binaries"
-    runs-on: ubuntu-24.04-32-core
+    runs-on:
+      group: labs
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
@@ -406,7 +408,8 @@ jobs:
   attest-binaries:
     name: "Attest and Upload Binaries"
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-24.04-32-core
+    runs-on:
+      group: labs
     needs:
       [
         "test",


### PR DESCRIPTION
## Summary
- Replaces specific runner labels (`ubuntu-24.04-64-core`, `ubuntu-24.04-32-core`) with the `labs` runner group across all workflows
- Affects `test`, `build-binaries`, and `attest-binaries` jobs in `deno.yml`, and `benchmarks` job in `benchmarks.yml`
- The old specific runner labels no longer exist after the runner infrastructure was reorganized

## Test plan
- [ ] Verify CI jobs pick up runners from the `labs` group
- [ ] Confirm all 4 affected jobs start and complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)