### PR TITLE
bench: add hashOfModernAsString to object hashing benchmark

### DIFF
--- a/scripts/benchmark-object-hashing/main.ts
+++ b/scripts/benchmark-object-hashing/main.ts
@@ -11,6 +11,9 @@
  *   deno run --allow-net --allow-read --allow-env scripts/benchmark-object-hashing/main.ts
  */
 
+// Import our own hasher for comparison
+import { hashOfModernAsString } from "../../packages/data-model/value-hash-modern.ts";
+
 // Import libraries from esm.sh to avoid adding dependencies
 // @ts-ignore - dynamic import from esm.sh
 const MerkleReference = await import("https://esm.sh/merkle-reference@2.2.0");
@@ -912,6 +915,11 @@ async function createStrategies() {
     return cid.toString();
   };
 
+  // hashOfModernAsString (our own hasher)
+  strategies["hashOfModernAsString"] = (obj: any) => {
+    return hashOfModernAsString(obj);
+  };
+
   return strategies;
 }
 
@@ -1094,8 +1102,9 @@ async function main() {
             opsPerSec.toFixed(0)
           } ops/sec)`,
         );
-      } catch (err) {
-        console.log(`${strategyName.padEnd(40)} ERROR: ${err.message}`);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.log(`${strategyName.padEnd(40)} ERROR: ${message}`);
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds `hashOfModernAsString()` as a strategy in the object hashing benchmark suite (`scripts/benchmark-object-hashing/`), so we can compare our own hasher against the third-party alternatives.

Also fixes a pre-existing `TS18046` type error in the benchmark catch block.

## Results (Deno, ops/sec — higher is better)

```
                                    simple   nested   array    mixed    wide    deep    lrgArr  sparse   complex  simpComp form    dataTbl  dashbd   fullPg
                                    ------   ------   -----    -----    ----    ----    ------  ------   -------  -------- ----    ------   ------   ------
hashOfModernAsString                470.4K   593.9K   1.3M     359.3K   1.1K    21.6K   530     268.0K   1.5K     71.1K    2.7K    317      951      1.1K
merkle-reference[noble]             47.1K    50.6K    58.1K    23.6K    146     1.6K    29      N/A      146      7.4K     232     30       93       124
merkle-reference[node:crypto]       58.4K    61.6K    69.1K    23.6K    139     1.9K    57      N/A      181      9.0K     299     27       115      169
fast-stable-stringify+noble         484.3K   486.5K   556.8K   536.4K   6.4K    67.8K   2.2K    32.8K    8.0K     225.3K   15.1K   1.5K     4.7K     5.6K
safe-stable-stringify+node:crypto   638.4K   620.2K   663.1K   571.9K   8.5K    97.6K   5.0K    67.0K    16.1K    335.5K   26.9K   2.8K     8.2K     11.1K
dag-cbor+node:crypto                502.8K   485.9K   622.8K   416.3K   4.7K    37.2K   1.4K    N/A      5.7K     196.1K   10.7K   960      3.0K     3.9K
hash-it (non-crypto)                2.9M     2.4M     3.7M     1.9M     4.2K    52.5K   2.3K    16.7K    7.9K     418.5K   22.2K   1.8K     5.6K     6.3K
JSON.stringify+noble (UNSTABLE)     578.6K   580.0K   651.8K   632.7K   19.8K   148.7K  4.4K    47.4K    19.5K    336.0K   25.9K   2.8K     9.5K     11.3K
```

## Takeaways

- `hashOfModernAsString` is **~10x faster than merkle-reference** on small data, and crushes it on arrays (1.3M vs 58K).
- On small structures it is competitive with `fast-stable-stringify+noble`.
- On **large/complex structures** (wide, deep, largeArray, complex, vdom), it falls well behind the stringify approaches — roughly 3-10x slower. This is likely the cost of recursive `feedValue` traversal + per-node hasher updates vs. a single stringify + one hash call.
- It handles sparse arrays (268K) where both merkle-reference and dag-cbor return N/A.

## Test plan

- [x] Benchmark runs successfully with `hashOfModernAsString` included
- [x] Stability test confirms `hashOfModernAsString` is STABLE (property-order independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)