### PR TITLE
fix(patterns): fix store-mapper aisle photo import rendering

### DIFF
--- a/packages/patterns/store-mapper.tsx
+++ b/packages/patterns/store-mapper.tsx
@@ -1555,10 +1555,12 @@ export default pattern<Input, Output>(
                               </ct-button>
                             </ct-hstack>
 
-                            {/* Status: pending / error / results
+                            {
+                              /* Status: pending / error / results
                                  Uses nested ifElse with static JSX branches.
                                  Note: computed() returning JSX does not render
-                                 inside ifElse branches within mapWithPattern. */}
+                                 inside ifElse branches within mapWithPattern. */
+                            }
                             {ifElse(
                               extraction.pending,
                               <div


### PR DESCRIPTION
## Summary
- Import canonical `ImageData` from `commontools` instead of local incomplete type
- Replace `computed()` returning JSX inside `ifElse` branches with nested `ifElse` using static JSX branches — `computed()` as a dynamic child inside `ifElse` branches within `mapWithPattern` does not render

## Context
The aisle photo import flow was broken by two issues:
1. **CellController.bind() schema divergence** — fixed in #3213 (merged)
2. **computed() inside ifElse branches in mapWithPattern** — this PR

The original code used `computed(() => { return <div>...</div>; })` as the false branch of a nested `ifElse` inside `.map()`. This pattern doesn't render because `ifElse` links to pre-compiled VNode templates and doesn't evaluate dynamic children within them. The fix restructures to use only static JSX with reactive property bindings in all `ifElse` branches.

## Test plan
- [x] `ct check` passes
- [x] Manually verified end-to-end: upload photo → AI detects aisles → "Add" button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)