### PR TITLE
Allow object styles on ct-* components in pattern critic

### DIFF
--- a/.claude/agents/pattern-critic.md
+++ b/.claude/agents/pattern-critic.md
@@ -19,7 +19,6 @@ Quickly scan for common mistakes. Focus on what breaks at runtime.
 2. **Reactivity** — `[NAME]: prop` without `computed()`? Reactive value in `Writable.of()`?
 3. **Conditionals** — Ternary for elements? Use `ifElse()` instead.
 4. **Binding** — Missing `$` prefix on `checked`/`value`?
-5. **Styles** — Object style on `ct-*` element? String style on `div`?
 
 ## Output
 
@@ -28,8 +27,8 @@ Just list what's wrong with line numbers and fixes:
 ```
 ## Issues in [filename]
 
-1. [Line 15] `handler()` inside pattern — move to module scope
-2. [Line 23] `{show ? <X/> : null}` — use `ifElse(show, <X/>, null)`
+1. [Line 10] Reactive [NAME], `Study: ${deck.name}`, should use computed — [NAME]: computed(() => `Study: ${deck.name}`),
+2. [Line 15] `handler()` inside pattern — move to module scope
 
 No issues found in categories: binding, styles, types
 ```

--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -74,16 +74,12 @@ Ternaries are valid in JSX. The transformer auto-converts them to `ifElse()`.
 | `$checked={item}` | `$checked={item.done}` |
 | wrong event name | Use `onct-send`, `onct-input`, or `onct-change` |
 
-### 6. Style Syntax
+### 6. Custom component props
 
-HTML elements require object style syntax. Custom `ct-*` elements require
-string style syntax. Also check that custom component props use the correct
-camelCase names.
+Check that custom component props use the correct camelCase names.
 
 | Violation | Fix |
 |-----------|-----|
-| string style on HTML | Convert to object syntax |
-| object style on `ct-*` | Convert to string syntax |
 | kebab-case props on `ct-*` | Use camelCase, for example `allowCustom` |
 
 ### 7. Handler Binding

--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -444,24 +444,6 @@ const mapData = {
 
 ---
 
-## Style Syntax
-
-| Element | Syntax | Example |
-|---------|--------|---------|
-| HTML (`div`, `span`) | Object, camelCase | `style={{ backgroundColor: "#fff" }}` |
-| Custom (`ct-*`) | String, kebab-case | `style="background-color: #fff;"` |
-
-```tsx
-// Mixed usage
-<div style={{ display: "flex", gap: "1rem" }}>
-  <ct-vstack style="flex: 1; padding: 1rem;">
-    <span style={{ color: "#333" }}>Label</span>
-  </ct-vstack>
-</div>
-```
-
----
-
 ## ct-chart
 
 SVG charting components. Compose mark elements inside a `ct-chart` container.

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -89,13 +89,3 @@ export default pattern<Input>(({ deck }) => ({
 return <>{showDetails ? <div>Details content</div> : null}</>;
 return <>{ifElse(showDetails, <div>Details content</div>, null)}</>;
 ```
-
-### Correct Style Syntax
-
-```typescript
-<div style={{ display: "flex", gap: "1rem" }}>
-  <ct-vstack style="flex: 1; padding: 1rem;">
-    Content
-  </ct-vstack>
-</div>;
-```


### PR DESCRIPTION
## Summary

Our pattern-critic skill, and related docs, recommend against using style objects on ct-* components in JSX, but it seems like object styles work on custom elements. I believe JSX should transform them to inline `style="..."` for all elements.

For example, I have the following code:

```tsx
<ct-tabs
  $value={activeTab}
  style={{
    display: "flex",
    flexDirection: "column",
    height: "100%",
  }}
>
```

And the styles get generated correctly:

<img width="479" height="156" alt="image" src="https://github.com/user-attachments/assets/861e2147-4c4b-481c-ac20-6652397794b9" />
