### PR TITLE
feat: add intern contagion to schema copy helpers

### DIFF
--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -10,7 +10,7 @@ import type {
 } from "@commontools/api";
 import { deepFreeze, isDeepFrozen } from "./deep-freeze.ts";
 import { cloneIfNecessary } from "./fabric-value.ts";
-import { internSchema } from "./schema-hash.ts";
+import { internSchema, isInternedSchema } from "./schema-hash.ts";
 import { type FabricValue } from "./interface.ts";
 
 /**
@@ -60,8 +60,8 @@ export function toDeepFrozenSchema<T extends JSONSchema>(
   schema: T,
   canShare: boolean = false,
 ): T {
-  // Booleans are primitives — already immutable.
-  if (typeof schema === "boolean") {
+  // No need to do any work given an interned schema (including `boolean`s.)
+  if (isInternedSchema(schema)) {
     return schema;
   }
 
@@ -127,10 +127,11 @@ export function cloneSchemaMutable(
 
 /**
  * Return a deep-frozen shallow copy of a schema with the given property
- * overrides applied.
+ * overrides applied. This function provides "intern contagion:" If the given
+ * `schema` is interned, then the result of this function will also be interned.
  *
- * - `undefined` and `true` ("accept everything") are treated as `{}` before
- *   applying overrides.
+ * - `undefined` and `true` ("accept everything") are treated as an interned
+ *   `{}` before applying overrides.
  * - `false` ("reject everything") short-circuits: no overrides can make a
  *   "never" schema accept anything, so `false` is returned as-is.
  */
@@ -139,13 +140,21 @@ export function schemaWithProperties(
   overrides: JSONSchemaObj,
 ): JSONSchema {
   if (schema === false) return false;
-  const base = (schema === undefined || schema === true) ? {} : schema;
-  return toDeepFrozenSchema({ ...base, ...overrides }, true);
+
+  const base = (schema === undefined || schema === true)
+    ? emptySchemaObject()
+    : schema;
+  const result = { ...base, ...overrides };
+
+  return isInternedSchema(base)
+    ? internSchema(result)
+    : toDeepFrozenSchema(result, true);
 }
 
 /**
  * Return a deep-frozen shallow copy of a schema with the named properties
- * removed.
+ * removed. This function provides "intern contagion:" If the given
+ * `schema` is interned, then the result of this function will also be interned.
  *
  * `undefined` is treated as `true` (JSON Schema "accept everything").
  * Boolean schemas are returned as-is (no properties to remove).
@@ -169,11 +178,15 @@ export function schemaWithoutProperties(
     }
   }
 
-  // Note: Still have to deep-freeze in the `!copy` case, though it will be a
-  // no-op if `schema` was already deep-frozen.
-  return copy
-    ? toDeepFrozenSchema(copy as JSONSchemaObj, true)
-    : toDeepFrozenSchema(schema);
+  if (copy) {
+    return isInternedSchema(schema)
+      ? internSchema(copy)
+      : toDeepFrozenSchema(copy as JSONSchemaObj, true);
+  } else {
+    // Note: We still have to deep-freeze in the `!copy` case, though it will be
+    // a no-op if `schema` was already deep-frozen (including interned).
+    return toDeepFrozenSchema(schema);
+  }
 }
 
 /**

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -20,7 +20,7 @@ import {
   schemaWithProperties,
   toDeepFrozenSchema,
 } from "../schema-utils.ts";
-import { isInternedSchema } from "../schema-hash.ts";
+import { internSchema, isInternedSchema } from "../schema-hash.ts";
 
 describe("toDeepFrozenSchema", () => {
   describe("boolean schemas", () => {
@@ -216,6 +216,23 @@ describe("toDeepFrozenSchema", () => {
         },
         TypeError,
       );
+    });
+  });
+
+  describe("interned schema handling", () => {
+    it("returns an interned schema as-is", () => {
+      const schema = internSchema({ type: "string" });
+      const result = toDeepFrozenSchema(schema);
+      assertStrictEquals(result, schema);
+    });
+
+    it("returns an interned schema as-is even with canShare=false", () => {
+      const schema = internSchema({
+        type: "object",
+        properties: { x: { type: "number" } },
+      });
+      const result = toDeepFrozenSchema(schema, false);
+      assertStrictEquals(result, schema);
     });
   });
 
@@ -605,6 +622,36 @@ describe("schemaWithProperties", () => {
     const result = schemaWithProperties(false, { type: "string" });
     assertStrictEquals(result, false);
   });
+
+  describe("intern contagion", () => {
+    it("result is interned when base schema is interned", () => {
+      const base = internSchema({ type: "object" });
+      const result = schemaWithProperties(base, {
+        properties: { x: { type: "string" } },
+      });
+      assert(isInternedSchema(result));
+    });
+
+    it("result is not interned when base schema is not interned", () => {
+      const base: JSONSchemaObj = { type: "object" };
+      const result = schemaWithProperties(base, {
+        properties: { x: { type: "string" } },
+      });
+      assert(!isInternedSchema(result));
+      // But it should still be frozen.
+      assert(Object.isFrozen(result));
+    });
+
+    it("result is interned when base is undefined (treated as interned {})", () => {
+      const result = schemaWithProperties(undefined, { type: "string" });
+      assert(isInternedSchema(result));
+    });
+
+    it("result is interned when base is true (treated as interned {})", () => {
+      const result = schemaWithProperties(true, { type: "string" });
+      assert(isInternedSchema(result));
+    });
+  });
 });
 
 describe("schemaWithoutProperties", () => {
@@ -677,6 +724,29 @@ describe("schemaWithoutProperties", () => {
   it("returns boolean false as-is", () => {
     assertStrictEquals(schemaWithoutProperties(false, "asCell"), false);
   });
+
+  describe("intern contagion", () => {
+    it("result is interned when input schema is interned", () => {
+      const schema = internSchema({ type: "object", asCell: true });
+      const result = schemaWithoutProperties(schema, "asCell");
+      assert(isInternedSchema(result));
+    });
+
+    it("result is not interned when input schema is not interned", () => {
+      const schema: JSONSchemaObj = { type: "object", asCell: true };
+      const result = schemaWithoutProperties(schema, "asCell");
+      assert(!isInternedSchema(result));
+      // But it should still be frozen.
+      assert(Object.isFrozen(result));
+    });
+
+    it("no-op on interned schema preserves interned identity", () => {
+      const schema = internSchema({ type: "string" });
+      const result = schemaWithoutProperties(schema, "nonexistent");
+      assertStrictEquals(result, schema);
+      assert(isInternedSchema(result));
+    });
+  });
 });
 
 describe("schemaForValueType", () => {
@@ -689,15 +759,19 @@ describe("schemaForValueType", () => {
         assertEquals(schemaForValueType(example), { type: typeName });
       });
 
+      it("should return a frozen result", () => {
+        assert(isDeepFrozen(schemaForValueType(example)!));
+      });
+
       it("should return an interned result", () => {
+        assert(isInternedSchema(schemaForValueType(example)!));
+      });
+
+      it("should return the same result every time", () => {
         assertStrictEquals(
           schemaForValueType(example),
           schemaForValueType(example),
         );
-      });
-
-      it("should return a frozen result", () => {
-        assert(isDeepFrozen(schemaForValueType(example)));
       });
     });
   }

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -92,6 +92,7 @@ export type {
   Cell,
   CellKind,
   CellTypeConstructor,
+  FabricValue,
   FsProjection,
   Handler,
   HandlerFactory,


### PR DESCRIPTION
## Summary

Add "intern contagion" behavior to schema copy helpers: when the input schema is interned, the output is also interned. This preserves the interning invariant through schema transformations, avoiding redundant re-interning at call sites.

**Production changes in `packages/data-model/schema-utils.ts`:**

- **`toDeepFrozenSchema()`**: Now short-circuits on any interned schema (not just booleans). Since interned schemas are already deeply frozen, no work is needed.
- **`schemaWithProperties()`**: Uses `emptySchemaObject()` (interned `{}`) for `undefined`/`true` base schemas. When the base is interned, the result is interned via `internSchema()` rather than just frozen.
- **`schemaWithoutProperties()`**: Same contagion pattern -- when a property is removed from an interned schema, the result is also interned. No-op cases preserve the original interned identity.

**Type re-export in `packages/runner/src/builder/types.ts`:**

- `FabricValue` added to the re-export list.

**Test coverage in `packages/data-model/test/schema-utils.test.ts`:**

- New `interned schema handling` describe block for `toDeepFrozenSchema` (returns interned schemas as-is, including with `canShare=false`).
- New `intern contagion` describe blocks for both `schemaWithProperties` and `schemaWithoutProperties` (verifying interned/non-interned propagation, `undefined`/`true` base handling, no-op identity preservation).
- Minor test reordering in `schemaForValueType` tests (frozen before interned before identity).

### Performance Baseline

This accounts for spurious performance check failure: This PR adds code which very-nearly isn't called; there's an additional map-get in a couple places, which really can't account for this type of observed difference. Furthermore, this same code _passed_ the performance check in the PR it was split out of.

NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/factory-outputs/parking-coordinator/main.test.tsx = 142s
NEW_PERF_BASELINE: test: pattern-unit-2/pattern-unit-tests = 189s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/shopping-list.test.tsx = 16s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/notes/notebook.test.tsx = 76s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/notes/note.test.tsx = 54s

Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.6) <noreply@anthropic.com>
