### PR TITLE
test: fix hash assertions for modern hash compatibility

### DIFF
--- a/packages/runner/test/doc-map.test.ts
+++ b/packages/runner/test/doc-map.test.ts
@@ -35,7 +35,7 @@ describe("hashOf", () => {
   it("should create a reference that is equal to another reference with the same source", () => {
     const ref = hashOf({ hello: "world" });
     const ref2 = hashOf({ hello: "world" });
-    expect(ref).toEqual(ref2);
+    expect(ref.toJSON!()).toEqual(ref2.toJSON!());
   });
 });
 
@@ -67,7 +67,7 @@ describe("cell-map", () => {
       const cause = "custom-cause";
       const ref = createRef(source, cause);
       const ref2 = createRef(source);
-      expect(ref).not.toEqual(ref2);
+      expect(ref.toJSON!()).not.toEqual(ref2.toJSON!());
     });
   });
 

--- a/packages/runner/test/schema-links.test.ts
+++ b/packages/runner/test/schema-links.test.ts
@@ -1384,7 +1384,7 @@ describe("Schema - Link Resolution", () => {
           "system": {
             "$alias": {
               "path": ["internal", "__#1"],
-              "cell": { "/": cellCLink.id.split(":")[1] },
+              "cell": { "/": cellCLink.id.replace(/^of:/, "") },
             },
           },
         },
@@ -1403,7 +1403,7 @@ describe("Schema - Link Resolution", () => {
               "$defs": {}, // the real case has a bunch here, but it doesn't matter
             },
             "cell": {
-              "/": cellBLink.id.split(":")[1],
+              "/": cellBLink.id.replace(/^of:/, ""),
             },
           },
         },


### PR DESCRIPTION
## Summary

Fix two test assertions that break under modern hashing, without flipping the `modernHash` default. These fixes make the tests work correctly regardless of which hashing mode is active.

- **`doc-map.test.ts`**: `FabricHash` objects produced by modern hashing have no enumerable properties, so Jest's `toEqual` sees them as empty objects. Fixed by comparing via `.toJSON!()`, which produces a serializable representation that works under both legacy and modern hashing.

- **`schema-links.test.ts`**: Modern hash URIs contain colons (e.g., `sha256-sri:base64data`), so `split(":")[1]` truncates the hash. Fixed by using `.replace(/^of:/, "")` to strip only the `of:` prefix, preserving the full hash string regardless of format.

### Performance Baseline

This addresses spurious performance check failures. This PR just makes small tweaks to unit tests.

NEW_PERF_BASELINE: job: Test = 171s
NEW_PERF_BASELINE: test: pattern-unit-5/pattern-unit-tests = 59s

Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.6) <noreply@anthropic.com>
