### PR TITLE
[codex] Document SES pattern authoring guidance

### DIFF
--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -26,6 +26,8 @@ Check that these are not inside the pattern body:
 | `handler()` defined inside pattern | Move to module scope, or use `action()` instead |
 | `lift()` immediately invoked (`lift(...)(args)`) | Use `computed()` or define lift at module scope |
 | helper functions defined inside pattern | Move to module scope |
+| top-level `let`, `var`, or class | Convert to `const` plain data, or move stateful logic into actions, handlers, or helpers |
+| `setTimeout()` or `setInterval()` in authored pattern code | Use a reactive/runtime primitive instead; authored timers are not available yet |
 
 Allowed inside patterns:
 
@@ -44,6 +46,8 @@ Allowed inside patterns:
 | `.get()` on computed or lift result | Access directly; only `Writable` uses `.get()` |
 | `items.filter(...)` inline in JSX | Wrap in `computed()` outside JSX |
 | `items.sort(...)` inline in JSX | Wrap in `computed()` outside JSX |
+| `Date.now()` or `Math.random()` in authored pattern code | Use `safeDateNow()` or `nonPrivateRandom()` |
+| `safeDateNow()` or `nonPrivateRandom()` inside `computed()` or `derive()` without clear intent | Move the snapshot into `action()`, `handler()`, or one-time initialization |
 | nested computed with outer-scope reactive vars | Pre-compute with lift or an outer computed |
 | `lift()` closing over reactive deps | Pass dependencies as explicit parameters |
 | cells from composed patterns in `ifElse` | Wrap in a local `computed()` bridge |

--- a/docs/common/ai/pattern-development-guide.md
+++ b/docs/common/ai/pattern-development-guide.md
@@ -152,6 +152,45 @@ const List = pattern<ListInput, ListOutput>(({ items }) => ({
 }));
 ```
 
+## SES Authoring Limits and Escape Hatches
+
+Patterns now run inside a verified SES subset. The practical authoring rules
+are:
+
+- keep module scope declarative:
+  - use `const`
+  - define `pattern()`, `handler()`, `lift()`, schemas, and plain data
+  - avoid top-level `let`, `var`, classes, or ad hoc mutable caches
+- keep pattern-owned callback bodies straight-line:
+  - avoid `let`, `var`, reassignment, and loop statements
+  - prefer array methods, `computed()`, `derive()`, or a module-scope helper
+- do not rely on authored timers or proxies:
+  - `setTimeout()`, `setInterval()`, and `new Proxy()` are not part of the
+    authored runtime surface yet
+- use explicit time/random escape hatches only when needed:
+  - use `safeDateNow()` instead of `Date.now()`
+  - use `nonPrivateRandom()` instead of `Math.random()`
+  - prefer calling them from `action()`, `handler()`, or one-time
+    initialization rather than inside `computed()` or `derive()`
+
+The current exported helper names are `safeDateNow()` and
+`nonPrivateRandom()`. Older shorthand such as `dateNow` or `insecureRandom`
+does not match the current API.
+
+```tsx
+const createItem = action(() => {
+  items.push({
+    id: `item-${nonPrivateRandom().toString(36).slice(2, 8)}`,
+    createdAt: safeDateNow(),
+    title: title.get(),
+  });
+});
+```
+
+If a pattern needs richer time, scheduling, or entropy behavior, prefer an
+explicit runtime capability or service over hiding imperative state in authored
+callbacks.
+
 ## Common Pitfalls
 
 ### Conditional JSX

--- a/docs/common/ai/pattern-testing-guide.md
+++ b/docs/common/ai/pattern-testing-guide.md
@@ -80,6 +80,17 @@ export default pattern(() => {
 - test a sub-pattern before building the next dependent layer when that helps
   isolate failures
 
+## Testing Time and Randomness
+
+If a pattern uses `safeDateNow()` or `nonPrivateRandom()`, keep the assertions
+deterministic:
+
+- prefer asserting that a value was set, changed, or has the expected shape
+- avoid calling `safeDateNow()`, `nonPrivateRandom()`, `Date.now()`, or
+  `Math.random()` inside a test `computed()` assertion
+- if you need an exact value, capture it in the action under test and assert
+  against the captured result rather than recomputing it in the assertion
+
 ## Done When
 
 - the test file exists beside the pattern or in the expected local test layout

--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -43,10 +43,13 @@ Use camelCase for Common Fabric component properties. Kebab-case JSX attributes 
 // action() for more complex logic (preferred)
 const increment = action(() => {
   count.set(count.get() + 1);
-  lastUpdated.set(Date.now());
+  lastUpdated.set(safeDateNow());
 });
 <cf-button onClick={increment}>Increment</cf-button>
 ```
+
+Use `safeDateNow()` rather than `Date.now()` when authored pattern code needs a
+timestamp snapshot.
 
 ---
 

--- a/docs/common/concepts/action.md
+++ b/docs/common/concepts/action.md
@@ -63,6 +63,21 @@ const resetGame = action(() => {
 });
 ```
 
+## SES Notes
+
+Actions are still the default place for event-driven mutations, timestamps, and
+one-off IDs.
+
+- Keep action bodies simple and straight-line. Prefer `const` plus direct cell
+  operations over `let`, `var`, reassignment, or loops.
+- If the logic starts becoming imperative, move the heavy lifting into
+  `computed()`, `derive()`, or a module-scope helper and keep the action as the
+  trigger.
+- Use `safeDateNow()` and `nonPrivateRandom()` instead of `Date.now()` and
+  `Math.random()` in authored pattern code.
+- Prefer capturing time/random snapshots in the action itself rather than
+  inside a `computed()` that may re-run many times.
+
 ## When to Use `handler()` Instead
 
 Use `action()` for most cases. Switch to `handler()` when you need to:

--- a/docs/common/concepts/handler.md
+++ b/docs/common/concepts/handler.md
@@ -84,6 +84,23 @@ export default pattern(({ items }) => {
 
 **Why:** The CTS transformer processes patterns at compile time and cannot handle closures over pattern-scoped variables in handlers.
 
+Handlers also live on the verified SES module-scope surface. Define them once
+at the top level, then pass any changing state through the binding object
+instead of hiding it in module-scoped mutable variables.
+
+## SES-Friendly Handlers
+
+- Bind changing state explicitly. Avoid top-level mutable caches, counters, or
+  class instances.
+- Keep the handler callback direct and readable. If the body becomes too
+  imperative, push complex logic into a helper and keep the bound state
+  explicit.
+- Use `safeDateNow()` and `nonPrivateRandom()` instead of ambient
+  `Date.now()` and `Math.random()` when a handler needs a timestamp or random
+  ID.
+- Timers are not exposed inside authored modules yet, so do not rely on
+  `setTimeout()` or `setInterval()` in handler code.
+
 ## Exporting Handlers as Streams
 
 Bound handlers become `Stream<T>` and can be exported for other patterns to call:

--- a/docs/common/workflows/pattern-testing.md
+++ b/docs/common/workflows/pattern-testing.md
@@ -136,6 +136,11 @@ const assert_game_ready = computed(() => {
 });
 ```
 
+Keep assertions deterministic. Do not call `safeDateNow()`,
+`nonPrivateRandom()`, `Date.now()`, or `Math.random()` inside the assertion
+itself. If the pattern stamps a timestamp or random ID, assert that the value
+exists or changed in the expected place.
+
 ## Test Organization
 
 ### Naming Conventions

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -9,6 +9,10 @@ Start with the shared critique guidance in:
 
 Read that guide first. It is the canonical reference.
 
+Be explicit about SES and determinism issues: direct `Date.now()` or
+`Math.random()`, authored timers, and non-idempotent `computed()` use of
+`safeDateNow()` or `nonPrivateRandom()` should all be flagged.
+
 Then use the detailed references already maintained in the repo for:
 
 - `docs/development/debugging/README.md`

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -9,6 +9,10 @@ Start with the shared pattern development guidance in:
 
 Read that guide first. It is the canonical reference.
 
+Pay special attention to its SES authoring section before adding module-scope
+setup, timers, or time/random helpers. The current authored escape hatches are
+`safeDateNow()` and `nonPrivateRandom()`.
+
 Runtime notes:
 
 - Use the `cf` skill, or read `skills/cf/SKILL.md`, when you need CLI command

--- a/skills/pattern-implement/SKILL.md
+++ b/skills/pattern-implement/SKILL.md
@@ -25,6 +25,8 @@ testability.
 
 ## Read First
 
+- `docs/common/ai/pattern-development-guide.md` - especially the SES authoring
+  limits and escape-hatch guidance
 - `docs/common/patterns/` - especially `meta/` for generalizable idioms
 - `docs/common/concepts/action.md` - action() for local state
 - `docs/common/concepts/handler.md` - handler() for reusable logic
@@ -42,6 +44,9 @@ const submit = action(() => {
   inputValue.set("");
 });
 ```
+
+Use `safeDateNow()` and `nonPrivateRandom()` instead of ambient `Date.now()` and
+`Math.random()` when a pattern needs explicit time or randomness.
 
 **handler()** - Reused with different bindings:
 

--- a/skills/pattern-test/SKILL.md
+++ b/skills/pattern-test/SKILL.md
@@ -10,6 +10,9 @@ Start with the shared testing guidance in:
 
 Read that guide first. It is the canonical reference.
 
+For patterns that stamp timestamps or IDs, prefer deterministic assertions over
+recomputing time/random values inside the test itself.
+
 Runtime notes:
 
 - Use the `cf` skill, or read `skills/cf/SKILL.md`, when you need CLI command


### PR DESCRIPTION
## Summary

This PR updates the pattern-authoring documentation and skill entrypoints to reflect the new SES execution limits and the current escape hatches.

## What Changed

- added a dedicated SES authoring section to the canonical pattern development guide
- documented the current authored time/random helpers: `safeDateNow()` and `nonPrivateRandom()`
- clarified `action()` and `handler()` guidance around module-scope rules, straight-line callback bodies, and missing authored timers/proxies
- added testing guidance for deterministic assertions when patterns stamp timestamps or random IDs
- added critique guidance so reviewers flag direct `Date.now()` / `Math.random()`, authored timers, and non-idempotent `computed()` use of the escape hatches
- updated the component reference example to use `safeDateNow()` instead of `Date.now()`
- updated the `pattern-dev`, `pattern-test`, `pattern-critic`, and `pattern-implement` skills so agents see the SES guidance immediately

## Why

The SES runtime and verifier already enforce these rules, but the main pattern-facing docs and skills did not explain them clearly. That left a gap between the implementation and the guidance authors, reviewers, and agents actually start from.

## Impact

Pattern authors now get the right API names and constraints up front, especially around:

- module-scope restrictions
- explicit time/random escape hatches
- deterministic testing expectations
- reviewer checks for SES-related anti-patterns

## Validation

- pre-commit `deno fmt`
- pre-commit `deno lint`

No additional runtime tests were run because this is a docs/skills-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SES pattern authoring guidance across docs and skills. Documents `safeDateNow()`/`nonPrivateRandom()` (prefer in `action()`/`handler()`, not inside `computed()`/`derive()`), bans top‑level `let`/`var`/classes, clarifies authored timers and `Proxy` are unavailable, adds SES notes to `action()` and `handler()` docs, updates `COMPONENTS.md` to use `safeDateNow()`, and strengthens deterministic testing and critique checks.

<sup>Written for commit 4b4f6336d29722d19da70596216be7ea2ef9a5ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

