### PR TITLE
Follow up memory v2 scope notes and review invariants

### DIFF
--- a/docs/specs/memory-v2/01-data-model.md
+++ b/docs/specs/memory-v2/01-data-model.md
@@ -75,10 +75,21 @@ conventions over that same stored document:
 **Deletion is explicit**: removing an entity is represented only by a `Delete`
 fact (section 2.2). A missing `value` field is NOT used as a tombstone in v2.
 Supporting a live "undefined" cell value is deferred; if we need it later, it
-should use an explicit sentinel rather than overloading deletion semantics. An
-empty JSON object `{}` is still an ordinary live value, not a delete. A marked
-document may also omit `value` entirely for metadata-only cases such as
-source-only documents; that is still not a tombstone.
+should use an explicit sentinel rather than overloading deletion semantics.
+There are two layers to keep separate here:
+
+- the logical cell value `{}` is stored as the document `{ value: {} }`
+- a stored document may omit `value` entirely for metadata-only cases, and even
+  the degenerate stored document `{}` is still a live document, not a tombstone
+
+Canonical examples:
+
+| Case | Stored representation | Meaning |
+| ---- | --------------------- | ------- |
+| Empty object payload | `{ value: {} }` | Live cell whose payload is the empty object |
+| Source-only / metadata-only document | `{ source: { "/": "abc123" } }` | Live document with no payload, but with metadata |
+| Empty document envelope | `{}` | Live document with no payload and no metadata set yet |
+| Explicit deletion | `Delete { type: "delete", id, parent }` | Tombstone; the entity is removed from the visible head |
 
 **Source links**: The `source` property uses the short-link form
 `{"/":"<short-id>"}`. The runtime resolves this to `of:<short-id>` in the same
@@ -290,6 +301,13 @@ A **blob** is immutable, write-once binary data identified by its content hash.
 Blobs are separate from entities — they never change after creation. They are
 used for storing images, files, compiled artifacts, or any data that is
 referenced by entities but should not be duplicated or versioned the same way.
+
+Current-pass scope: the rewrite only needs immutable content-addressed blob
+storage and reference plumbing so runner-facing entity history can point at
+large payloads without inlining them. Richer blob delivery, authenticated
+download/upload APIs, URL issuance, and product-facing policy are deferred to a
+later layer and are not part of the MVP acceptance bar for the core
+seq/revision rewrite.
 
 ```typescript
 interface Blob {

--- a/docs/specs/memory-v2/06-branching.md
+++ b/docs/specs/memory-v2/06-branching.md
@@ -282,6 +282,14 @@ Timeline:
 
 ## 6.7 Merging
 
+Status note: sections 6.1-6.6 describe the branch-scoped visibility model that
+the current rewrite relies on. The merge and lifecycle material from here down
+is target-design guidance, not the current-pass acceptance bar. Public branch
+lifecycle commands on the v2 wire, merge proposal generation/conflict workflow,
+and broader product-facing branch tooling remain deferred; see
+`10-implementation-guidance.md` and `implementation-plan.md` for the current
+implementation authority.
+
 Merging integrates changes from a source branch into a target branch. The merge
 operates at the **entity level** -- each entity is considered independently.
 

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -922,17 +922,11 @@ Deno.test("memory v2 server does not send watch effects after a connection close
   }
 });
 
-Deno.test("memory v2 server refreshes watched docs without rerunning full graph queries", async () => {
+Deno.test("memory v2 server refreshes watched docs by syncing only the touched entity", async () => {
   const server = createServer("memory://memory-v2-server-incremental-watch");
   const messages: ServerMessage[] = [];
   const connection = server.connect((message) => messages.push(message));
   const space = "did:key:z6Mk-memory-v2-server-incremental-watch";
-  const originalEvaluateGraphQuery = server.evaluateGraphQuery.bind(server);
-  const evaluatedRoots: string[][] = [];
-  server.evaluateGraphQuery = (async (...args) => {
-    evaluatedRoots.push(args[1].roots.map((root) => root.id));
-    return await originalEvaluateGraphQuery(...args);
-  }) as typeof server.evaluateGraphQuery;
 
   try {
     await connection.receive(encodeMemoryV2Boundary(HELLO));
@@ -1005,7 +999,6 @@ Deno.test("memory v2 server refreshes watched docs without rerunning full graph 
       assertResponse<any>(shiftMessage(messages)).requestId,
       "watch-1",
     );
-    evaluatedRoots.length = 0;
 
     await connection.receive(encodeMemoryV2Boundary({
       type: "transact",
@@ -1031,23 +1024,16 @@ Deno.test("memory v2 server refreshes watched docs without rerunning full graph 
     const effect = assertEffect(shiftMessage(messages));
     assertEquals(effect.effect.upserts.map((entry) => entry.id), ["of:doc:1"]);
     assertEquals(effect.effect.removes, []);
-    assertEquals(evaluatedRoots, []);
   } finally {
     await server.close();
   }
 });
 
-Deno.test("memory v2 server incrementally adds watches without rerunning full graph queries", async () => {
+Deno.test("memory v2 server watch.add bootstraps only the newly added watch", async () => {
   const server = createServer("memory://memory-v2-server-watch-add");
   const messages: ServerMessage[] = [];
   const connection = server.connect((message) => messages.push(message));
   const space = "did:key:z6Mk-memory-v2-server-watch-add";
-  const originalEvaluateGraphQuery = server.evaluateGraphQuery.bind(server);
-  const evaluatedRoots: string[][] = [];
-  server.evaluateGraphQuery = (async (...args) => {
-    evaluatedRoots.push(args[1].roots.map((root) => root.id));
-    return await originalEvaluateGraphQuery(...args);
-  }) as typeof server.evaluateGraphQuery;
 
   try {
     await connection.receive(encodeMemoryV2Boundary(HELLO));
@@ -1111,7 +1097,6 @@ Deno.test("memory v2 server incrementally adds watches without rerunning full gr
         "of:doc:1",
       ],
     );
-    evaluatedRoots.length = 0;
 
     await connection.receive(encodeMemoryV2Boundary({
       type: "session.watch.add",
@@ -1140,7 +1125,6 @@ Deno.test("memory v2 server incrementally adds watches without rerunning full gr
       ],
     );
     assertEquals(second.ok?.sync.removes, []);
-    assertEquals(evaluatedRoots, []);
   } finally {
     await server.close();
   }


### PR DESCRIPTION
## Summary
- add explicit entity-envelope worked examples for `{}` vs missing `value` vs explicit delete in the memory v2 data model spec
- mark blob delivery and merge/lifecycle sections more clearly as deferred next-layer scope rather than current-pass acceptance bar
- rewrite the v2 server watch tests to assert touched-entity semantics instead of pinning internal `evaluateGraphQuery` behavior

## Context
This PR addresses the remaining substantive Will Kelly feedback from #3083 after that PR merged into `main`.

## Validation
- `deno test -A packages/memory/test/v2-server-test.ts`
- `deno lint packages/memory/test/v2-server-test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Memory v2 semantics for empty payloads, missing `value`, and deletes, and explicitly defers richer blob delivery and merge/lifecycle to a later layer. Rewrites watch tests to assert touched-entity sync and that `session.watch.add` bootstraps only the new watch, without relying on internal query evaluation.

- **Refactors**
  - Docs: add canonical examples for `{ value: {} }`, missing `value`, metadata-only docs, and explicit `Delete`; scope notes: MVP includes content-addressed blob storage + refs only; merge/lifecycle is target guidance, not acceptance bar.
  - Tests: rename and simplify watch cases to drop `evaluateGraphQuery`; verify only the touched entity is synced on refresh and `session.watch.add` bootstraps only the newly added watch.

<sup>Written for commit 6ded46d67fafb07a2907402f40efd17157e10131. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

