### PR TITLE
[codex] Raise perf regression thresholds

### DIFF
--- a/docs/development/PERFORMANCE_PROGRAM.md
+++ b/docs/development/PERFORMANCE_PROGRAM.md
@@ -56,7 +56,7 @@ step, and we'll ratchet targets down as we improve.
 - 14 micro-benchmark files across runner, memory, utils
 - CI benchmarks on every push to main (64-core runner), JSON artifacts with
   90-day retention
-- Regression detector every 4 hours (median + 2σ, auto-creates GitHub issues)
+- Regression detector every 4 hours (median + 3σ or +15%, auto-creates GitHub issues)
 - Recent wins: compilation cache (~100-500ms saved), schema freeze caching,
   LLM queue batching, scheduler debouncing, refer() caching (~2x)
 

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -1,5 +1,6 @@
-import { assertEquals } from "@std/assert";
+import { assertAlmostEquals, assertEquals } from "@std/assert";
 import {
+  computeBaseline,
   extractMetrics,
   type Job,
   type Step,
@@ -83,4 +84,20 @@ Deno.test("extractMetrics keeps CLI core and fuse timings separate", () => {
   );
   assertEquals(metrics.has("job: CLI Integration Tests"), false);
   assertEquals(metrics.has("step: CLI integration"), false);
+});
+
+Deno.test("computeBaseline enforces the 15 percent floor for low-variance samples", () => {
+  const baseline = computeBaseline([100, 100, 100, 100, 100]);
+
+  assertEquals(baseline?.median, 100);
+  assertEquals(baseline?.stddev, 0);
+  assertAlmostEquals(baseline?.threshold ?? 0, 115, 1e-9);
+});
+
+Deno.test("computeBaseline uses the 3 sigma threshold when it exceeds 15 percent", () => {
+  const baseline = computeBaseline([100, 100, 100, 100, 150]);
+
+  assertEquals(baseline?.median, 100);
+  assertAlmostEquals(baseline?.stddev ?? 0, 20, 1e-9);
+  assertEquals(baseline?.threshold, 160);
 });

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -24,10 +24,10 @@ export const RECENT_WINDOW = 3;
 export const RECENT_THRESHOLD = 2;
 
 /** Standard deviations above the median to flag a regression. */
-export const STDDEV_FACTOR = 2;
+export const STDDEV_FACTOR = 3;
 
 /** Minimum percentage increase over median to flag a regression. */
-export const MIN_REGRESSION_PCT = 0.10;
+export const MIN_REGRESSION_PCT = 0.15;
 
 /** Minimum absolute increase (in seconds) over median for non-bench metrics. */
 export const MIN_ABSOLUTE_DELTA = 2;


### PR DESCRIPTION
## What changed
- raised the shared CI performance regression thresholds from `median + 2σ` / `+10%` to `median + 3σ` / `+15%`
- added focused `computeBaseline()` tests that pin both the 15% floor and the 3σ path
- updated the performance program doc to match the new detector behavior

## Why
The CI action was triggering on smaller regressions than intended. This change makes both the per-PR performance gate and the scheduled regression detector only fire for materially larger degradations.

## Impact
Both `tasks/perf-check.ts` and `tasks/perf-regression.ts` consume the shared thresholds from `tasks/perf-lib.ts`, so this updates the PR gate and the scheduled issue-opening detector together.

## Validation
- `deno test --allow-env tasks/perf-lib.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise CI performance regression thresholds to median + 3σ or +15% so only material regressions trigger. Adds `computeBaseline()` tests and updates docs; affects both `tasks/perf-check.ts` and `tasks/perf-regression.ts` via shared thresholds.

<sup>Written for commit 014566da3b4ec36ca26c6e0cd5553684548ae3b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

