### PR TITLE
Flip default memory version to v2

### DIFF
--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -12,7 +12,7 @@ export type { FabricValue };
 
 export type { JSONValue };
 export type MemoryVersion = "v1" | "v2";
-export const DEFAULT_MEMORY_VERSION: MemoryVersion = "v1";
+export const DEFAULT_MEMORY_VERSION: MemoryVersion = "v2";
 export const INTEGRATION_MEMORY_VERSION_ENV = "CT_INTEGRATION_MEMORY_VERSION";
 
 type MaybeDeno = {


### PR DESCRIPTION
## Summary
This follow-up flips the centralized default memory version from `v1` to `v2`.

The Memory v2 implementation has already landed in prior PRs; this change is the smaller follow-up that actually makes `v2` the default for call sites that rely on `DEFAULT_MEMORY_VERSION`.

## Change
- change `DEFAULT_MEMORY_VERSION` in `packages/memory/interface.ts` from `v1` to `v2`

## Verification
- `deno test -A packages/runner/test/memory-version.test.ts`
- `deno test -A packages/memory/test/v1-entrypoint-test.ts`
- `deno task check`
- `deno task test`
- `deno task integration`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set memory v2 as the default by updating `DEFAULT_MEMORY_VERSION` in `packages/memory/interface.ts`. This switches any call sites that use the centralized default from v1 to v2.

<sup>Written for commit 0d2675e12a61b572461f5b25969510563107972d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

