### PR TITLE
Remove in-repo ct CLI aliasing

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -37,10 +37,9 @@ jobs:
         run: |
           deno task build-binaries --cli-only
 
-      - name: 🔎 Smoke CLI aliases
+      - name: 🔎 Smoke CLI
         run: |
           ./dist/cf --help
-          ./dist/ct --help
 
       - name: 📤 Upload CLI
         uses: actions/upload-artifact@v4
@@ -48,4 +47,3 @@ jobs:
           name: macos-cli
           path: |
             ./dist/cf
-            ./dist/ct

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -97,7 +97,6 @@ jobs:
             ./dist/toolshed
             ./dist/bg-charm-service
             ./dist/cf
-            ./dist/ct
 
   generated-patterns-integration-test:
     name: "Generated Patterns Integration Tests"
@@ -241,7 +240,6 @@ jobs:
           TOOLSHED_URL: http://localhost:${{ matrix.toolshed_port }}
         run: |
           chmod +x ./common-binaries/cf
-          chmod +x ./common-binaries/ct
           chmod +x ./common-binaries/toolshed
           # Set tools to path
           # Integration script needs `cf`

--- a/deno.json
+++ b/deno.json
@@ -39,7 +39,6 @@
   "tasks": {
     "check": "./tasks/check.sh",
     "cf": "bash -lc 'ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && CF_CLI_NAME=cf deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/packages/cli/mod.ts\" \"$@\"' --",
-    "ct": "bash -lc 'ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && CF_CLI_NAME=ct deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/packages/cli/mod.ts\" \"$@\"' --",
     "test": "./tasks/test.ts",
     "test-all": "echo \"Use 'deno task test' instead.\" && exit 1",
     "build-binaries": "./tasks/build-binaries.ts",
@@ -48,7 +47,6 @@
     "integration": "./tasks/integration.ts",
     "profile": "./scripts/restart-local-dev.sh --inspect-brk",
     "cf-profile": "bash -lc 'ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && CF_CLI_NAME=cf deno run --inspect-brk --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/packages/cli/mod.ts\" \"$@\"' --",
-    "ct-profile": "ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && deno run -A \"$ROOT/scripts/ct-profile.ts\"",
     "cf-profile-brk": "bash -lc 'ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && CF_CLI_NAME=cf deno run --inspect-brk --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/packages/cli/mod.ts\" \"$@\"' --"
   },
   "compilerOptions": {

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -2,9 +2,7 @@
   "name": "@commonfabric/cli",
   "tasks": {
     "cli": "bash -lc 'ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && CF_CLI_NAME=cf deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/mod.ts\" \"$@\"' --",
-    "ct": "bash -lc 'ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && CF_CLI_NAME=ct deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/mod.ts\" \"$@\"' --",
     "cli-no-pwd-override": "CF_CLI_NAME=cf deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run ./mod.ts",
-    "ct-no-pwd-override": "CF_CLI_NAME=ct deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run ./mod.ts",
     "test": "deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env test/*.test.ts",
     "integration": "CF_CLI_INTEGRATION_USE_LOCAL=1 CF_LOG_LEVEL=error ./integration/integration.sh",
     "fuse-integration": "CF_CLI_INTEGRATION_USE_LOCAL=1 CF_LOG_LEVEL=error ./integration/fuse-exec.sh",

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -30,44 +30,18 @@ replace () {
   fi
 }
 
-if [ -n "${CF_CLI_INTEGRATION_USE_LOCAL:-}" ] || [ -n "${CT_CLI_INTEGRATION_USE_LOCAL:-}" ]; then
- ct_impl() {
-   deno task ct "$@"
- }
-
+if [ -n "${CF_CLI_INTEGRATION_USE_LOCAL:-}" ]; then
  cf_impl() {
    deno task cli "$@"
  }
 else
- ct_impl() {
-   command ct "$@"
- }
-
  cf_impl() {
    command cf "$@"
  }
- ct() {
-   deno task ct "$@"
- }
 fi
 
-ct() {
-  if [ -z "$CT_CLI_INTEGRATION_TIMINGS" ]; then
-    ct_impl "$@"
-    return $?
-  fi
-
-  local start_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
-  ct_impl "$@"
-  local status=$?
-  local end_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
-  local elapsed_ms=$((end_ms - start_ms))
-  >&2 echo "[cf-timing] ${elapsed_ms}ms :: ct $*"
-  return $status
-}
-
 cf() {
-  if [ -z "$CT_CLI_INTEGRATION_TIMINGS" ]; then
+  if [ -z "$CF_CLI_INTEGRATION_TIMINGS" ]; then
     cf_impl "$@"
     return $?
   fi
@@ -289,10 +263,10 @@ fi
 
 # Call increment handler on piece2 — since its value is linked to piece1's
 # output cell, this should update piece1's value too
-ct piece call $SPACE_ARGS --piece $PIECE_ID2 increment '{}'
+cf piece call $SPACE_ARGS --piece $PIECE_ID2 increment '{}'
 
 # Verify piece1's value is now 11 (was 10, incremented via piece2's handler)
-RESULT=$(ct piece get $SPACE_ARGS --piece $PIECE_ID value)
+RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID value)
 if [ "$RESULT" != "11" ]; then
   error "After calling increment on piece2, piece1's value should be 11, got: $RESULT"
 fi
@@ -333,9 +307,9 @@ if [ "$RESULT" != "42" ]; then
 fi
 
 # Call increment on piece3 and verify the invented piece's value updates
-ct piece call $SPACE_ARGS --piece $PIECE_ID3 increment '{}'
+cf piece call $SPACE_ARGS --piece $PIECE_ID3 increment '{}'
 
-RESULT=$(ct piece get $SPACE_ARGS --piece $INVENTED_ID value)
+RESULT=$(cf piece get $SPACE_ARGS --piece $INVENTED_ID value)
 if [ "$RESULT" != "43" ]; then
   error "After calling increment on piece3, invented piece's value should be 43, got: $RESULT"
 fi

--- a/packages/cli/lib/cli-name.ts
+++ b/packages/cli/lib/cli-name.ts
@@ -2,11 +2,8 @@ import { basename } from "@std/path";
 
 function normalizeCliName(
   name: string | undefined | null,
-): "cf" | "ct" | undefined {
+): "cf" | undefined {
   const normalized = name?.trim().toLowerCase();
-  if (normalized === "ct" || normalized === "ct.exe") {
-    return "ct";
-  }
   if (normalized === "cf" || normalized === "cf.exe") {
     return "cf";
   }
@@ -15,7 +12,7 @@ function normalizeCliName(
 
 export function cliName(
   options: { envName?: string | undefined; execPath?: string | undefined } = {},
-): "cf" | "ct" {
+): "cf" {
   const envName = normalizeCliName(
     options.envName ?? Deno.env.get("CF_CLI_NAME"),
   );

--- a/packages/cli/test/alias.test.ts
+++ b/packages/cli/test/alias.test.ts
@@ -1,38 +1,37 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { cliName } from "../lib/cli-name.ts";
-import { checkStderr, ct } from "./utils.ts";
+import { cf, checkStderr } from "./utils.ts";
 
-describe("ct compatibility alias", () => {
-  it("shows ct in top-level help", async () => {
-    const { code, stdout, stderr } = await ct("--help");
+describe("CLI naming", () => {
+  it("shows cf in top-level help", async () => {
+    const { code, stdout, stderr } = await cf("--help");
     const help = stdout.join("\n");
 
     expect(code).toBe(0);
     checkStderr(stderr);
-    expect(help).toContain("ct check ./pattern.tsx");
+    expect(help).toContain("cf check ./pattern.tsx");
     expect(help).toContain(
-      "Run 'ct <command> --help' for command-specific help.",
+      "Run 'cf <command> --help' for command-specific help.",
     );
-    expect(help).not.toContain("Run 'cf <command> --help'");
   });
 
-  it("shows ct in exec help examples", async () => {
-    const { code, stdout, stderr } = await ct("help exec");
+  it("shows cf in exec help examples", async () => {
+    const { code, stdout, stderr } = await cf("help exec");
     const help = stdout.join("\n");
 
     expect(code).toBe(0);
     checkStderr(stderr);
     expect(help).toContain(
-      "ct exec /tmp/cf/home/pieces/notes/result/add.handler invoke --query milk",
+      "cf exec /tmp/cf/home/pieces/notes/result/add.handler invoke --query milk",
     );
     expect(help).toContain(
-      "ct exec /tmp/cf/home/pieces/notes/result/search.tool --query milk",
+      "cf exec /tmp/cf/home/pieces/notes/result/search.tool --query milk",
     );
   });
 
   it("ignores unsupported CF_CLI_NAME values", () => {
-    expect(cliName({ envName: " ct " })).toBe("ct");
+    expect(cliName({ envName: " ct " })).toBe("cf");
     expect(cliName({ envName: "cf.exe" })).toBe("cf");
     expect(cliName({ envName: "$(touch /tmp/pwned)" })).toBe("cf");
     expect(cliName({ envName: "`touch /tmp/pwned`" })).toBe("cf");

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../lib/exec.ts";
 import { writeMountState } from "../lib/fuse.ts";
 import { CF_RUNTIME_ERROR_LOG } from "../lib/callable.ts";
-import { cf, withEnv } from "./utils.ts";
+import { cf } from "./utils.ts";
 
 function makeSpec(
   callableKind: "handler" | "tool",
@@ -535,24 +535,6 @@ describe("renderExecHelp", () => {
     expect(help).toContain(
       "Alternatively, write JSON to this file to invoke the handler.",
     );
-  });
-
-  it("renders ct exec help when the compatibility alias is active", async () => {
-    await withEnv("CF_CLI_NAME", "ct", () => {
-      const help = renderExecHelp(
-        "/tmp/search.tool",
-        makeSpec("tool", {
-          type: "object",
-          properties: {
-            query: { type: "string" },
-          },
-          required: ["query"],
-        }),
-      );
-
-      expect(help).toContain("ct exec /tmp/search.tool [run] --query <string>");
-      expect(help).not.toContain("cf exec /tmp/search.tool [run]");
-    });
   });
 
   it("mentions explicit invoke for handlers whose inputs are all optional", () => {

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -334,16 +334,14 @@ describe("mount state operations", () => {
     let shimPath = "";
     let shim = "";
 
-    await withEnv("CF_CLI_NAME", "ct", async () => {
-      shimPath = await ensureExecShim(stateDir, importMetaUrl);
-      shim = await Deno.readTextFile(shimPath);
-    });
+    shimPath = await ensureExecShim(stateDir, importMetaUrl);
+    shim = await Deno.readTextFile(shimPath);
 
     expect(shimPath).toBe(join(repoRoot, ".cf", "fuse", "cf-exec"));
     expect(shimPath).not.toBe(join(stateDir, "cf-exec"));
     expect(shim).toContain("#!/usr/bin/env bash");
     expect(shim).toContain("export CF_EXEC_SHEBANG=1");
-    expect(shim).toContain("export CF_CLI_NAME=ct");
+    expect(shim).toContain("export CF_CLI_NAME=cf");
     expect(shim).toContain('" run --allow-net');
     expect(shim).toContain(join(repoRoot, "packages/cli/mod.ts"));
     expect(shim).toContain('"$@"');

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -3,7 +3,6 @@ import { expect } from "@std/expect";
 import type { JSONSchema } from "@commonfabric/api";
 import { CF_RUNTIME_ERROR_LOG } from "../lib/callable.ts";
 import { executePieceCallable } from "../lib/piece.ts";
-import { withEnv } from "./utils.ts";
 
 describe("executePieceCallable", () => {
   it("invokes handlers from schema-derived flags", async () => {
@@ -457,48 +456,6 @@ describe("executePieceCallable", () => {
     expect(result.helpText).not.toContain("cf exec");
   });
 
-  it("renders ct piece-call help when the compatibility alias is active", async () => {
-    const harness = createPieceCallableHarness({
-      callableKind: "tool",
-      cellKey: "search",
-      inputSchema: {
-        type: "object",
-        properties: {
-          query: { type: "string" },
-        },
-        required: ["query"],
-      },
-      pattern: {
-        argumentSchema: {
-          type: "object",
-          properties: {
-            query: { type: "string" },
-          },
-          required: ["query"],
-        },
-      },
-    });
-
-    await withEnv("CF_CLI_NAME", "ct", async () => {
-      const result = await executePieceCallable(
-        {
-          apiUrl: "http://localhost:8000",
-          identity: "/tmp/test-identity.pem",
-          piece: "of:piece-123",
-          space: "home",
-        },
-        "search",
-        ["--help"],
-        {
-          loadManager: () => Promise.resolve(harness.manager),
-          loadPiece: () => Promise.resolve(harness.piece),
-        },
-      );
-
-      expect(result.helpText).toContain("ct piece call ... search --help");
-      expect(result.helpText).not.toContain("cf piece call ... search --help");
-    });
-  });
   it("surfaces handler transaction failures as errors", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "handler",

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -19,7 +19,7 @@ export function checkStderr(stderr: string[]) {
 }
 
 async function runCliTask(
-  task: "cli-no-pwd-override" | "ct-no-pwd-override",
+  task: "cli-no-pwd-override",
   command: string,
 ): Promise<{ code: number; stdout: string[]; stderr: string[] }> {
   // Use a regex to split up spaces outside of quotes.
@@ -56,12 +56,6 @@ export async function cf(
   command: string,
 ): Promise<{ code: number; stdout: string[]; stderr: string[] }> {
   return await runCliTask("cli-no-pwd-override", command);
-}
-
-export async function ct(
-  command: string,
-): Promise<{ code: number; stdout: string[]; stderr: string[] }> {
-  return await runCliTask("ct-no-pwd-override", command);
 }
 
 export async function withEnv(

--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -314,9 +314,6 @@ async function buildCli(config: BuildConfig): Promise<void> {
     console.error("Failed to build background charm service binary");
     Deno.exit(1);
   }
-  await Deno.remove(config.distPath("ct")).catch(() => undefined);
-  await Deno.copyFile(config.distPath("cf"), config.distPath("ct"));
-  await Deno.chmod(config.distPath("ct"), 0o755).catch(() => undefined);
   console.log("CLI binary built successfully");
 }
 


### PR DESCRIPTION
## Summary
- remove the in-repo `ct` CLI alias tasks and name normalization
- stop generating a local `dist/ct` binary in the build task
- drop alias-specific CLI tests and examples so Labs speaks `cf` consistently in code and local CI

## Validation
- deno fmt
- deno lint
- targeted CLI tests passed earlier in this stack:
  - `packages/cli/test/alias.test.ts`
  - `packages/cli/test/exec.test.ts`
  - `packages/cli/test/fuse.test.ts`
  - `packages/cli/test/piece-call.test.ts`
- git diff --check

## Notes
- this PR intentionally leaves deploy/bastion compatibility and integration env naming for a follow-up stacked PR
- specifically, `/opt/ct`, `~/.ct`, release-bundle `dist/ct`, and `CT_*_MEMORY_VERSION` are handled separately
