### PR TITLE
docs: sweep internal Common Fabric naming

### DIFF
--- a/.claude/agents/manual-tester.md
+++ b/.claude/agents/manual-tester.md
@@ -29,7 +29,7 @@ You may also be told:
 
 Load these skills at the start of your workflow:
 
-1. `Skill("ct")` — for deploying, inspecting, and calling handlers
+1. `Skill("cf")` — for deploying, inspecting, and calling handlers
 2. `Skill("agent-browser")` — for browser-based UI testing
 
 Also read:

--- a/.claude/agents/pattern-user.md
+++ b/.claude/agents/pattern-user.md
@@ -1,6 +1,6 @@
 ---
 name: pattern-user
-description: Deploys patterns and debugs running pieces via ct CLI.
+description: Deploys patterns and debugs running pieces via cf CLI.
 tools: Skill, Bash, Glob, Grep, Read, Edit, Write, AskUserQuestion
 model: sonnet
 hooks:
@@ -11,7 +11,7 @@ hooks:
           command: "$CLAUDE_PROJECT_DIR/.claude/scripts/pattern-user-post-bash.ts"
 ---
 
-Load `Skill("ct")` first for ct CLI documentation.
+Load `Skill("cf")` first for cf CLI documentation.
 
 **When confused, search `docs/` first.** Key reference: `docs/development/debugging/`
 
@@ -22,7 +22,7 @@ Load `Skill("ct")` first for ct CLI documentation.
 2. API URL (e.g., `https://toolshed.saga-castor.ts.net`)
 3. Operator/space (optional)
 
-**Do not run any ct commands until you have these values.**
+**Do not run any cf commands until you have these values.**
 
 ## Key Commands
 

--- a/.claude/commands/logs.md
+++ b/.claude/commands/logs.md
@@ -40,7 +40,7 @@ the logs of past sessions in this repository are stored in `~/.claude/projects/`
    rg "interrupt|distract|confused|forgot" logs/*.jsonl
    
    # Find specific feature work
-   rg "ct-render|ct-outliner" logs/*.jsonl
+   rg "cf-render|cf-message-beads" logs/*.jsonl
    
    # Extract conversation summary
    jq -r '.message.content | if type == "string" then . else .[0].text // "" end' file.jsonl | head -20

--- a/.claude/commands/tour.md
+++ b/.claude/commands/tour.md
@@ -1,6 +1,6 @@
 # Platform Tour
 
-Interactively tour the Common Tools platform as a user, exercising core workflows through browser automation. You are LARPing as a curious user exploring the platform. Narrate what you see as you go — the user is watching.
+Interactively tour the Common Fabric platform as a user, exercising core workflows through browser automation. You are LARPing as a curious user exploring the platform. Narrate what you see as you go — the user is watching.
 
 ## Usage
 
@@ -75,7 +75,7 @@ These reusable JS eval snippets help navigate shadow DOM. To avoid shell quoting
     if (depth > 10) return [];
     const results = [];
     if (node.shadowRoot) {
-      const links = node.shadowRoot.querySelectorAll("ct-cell-link");
+      const links = node.shadowRoot.querySelectorAll("cf-cell-link");
       links.forEach((l) => {
         const rect = l.getBoundingClientRect();
         if (rect.width > 0 && rect.height > 0) {
@@ -182,7 +182,7 @@ Find the **"Notes ▾"** dropdown button in the content toolbar area. Click it t
 
 The note has two parts to edit:
 
-**Title:** The title is inside nested shadow DOM: `x-root-view > shadowRoot > x-app-view > shadowRoot > x-body-view > shadowRoot > ct-render > shadowRoot > div > ct-screen > ct-vstack`. It will NOT appear in accessibility snapshots.
+**Title:** The title is inside nested shadow DOM: `x-root-view > shadowRoot > x-app-view > shadowRoot > x-body-view > shadowRoot > cf-render > shadowRoot > div > cf-screen > cf-vstack`. It will NOT appear in accessibility snapshots.
 
 1. Write a JS eval to find the title span:
 ```js
@@ -190,7 +190,7 @@ The note has two parts to edit:
   const rv = document.querySelector("x-root-view");
   const av = rv.shadowRoot.querySelector("x-app-view");
   const bv = av.shadowRoot.querySelector("x-body-view");
-  const cr = bv.shadowRoot.querySelector("ct-render");
+  const cr = bv.shadowRoot.querySelector("cf-render");
   const spans = cr.shadowRoot.querySelectorAll("span");
   for (const span of spans) {
     if (span.textContent.trim() === "New Note") {
@@ -202,15 +202,15 @@ The note has two parts to edit:
 })()
 ```
 2. Click at the returned coordinates to activate edit mode
-3. A `ct-input` appears. Find the input inside it:
+3. A `cf-input` appears. Find the input inside it:
 ```js
 (() => {
   const rv = document.querySelector("x-root-view");
   const av = rv.shadowRoot.querySelector("x-app-view");
   const bv = av.shadowRoot.querySelector("x-body-view");
-  const cr = bv.shadowRoot.querySelector("ct-render");
-  const ctInput = cr.shadowRoot.querySelector("ct-input");
-  const input = ctInput.shadowRoot.querySelector("input");
+  const cr = bv.shadowRoot.querySelector("cf-render");
+  const cfInput = cr.shadowRoot.querySelector("cf-input");
+  const input = cfInput.shadowRoot.querySelector("input");
   input.focus();
   input.value = "YOUR TITLE HERE";
   input.dispatchEvent(new Event("input", { bubbles: true }));
@@ -272,14 +272,14 @@ In the chat, type: "Please launch the counter pattern with an initial value of 5
 
 The counter view shows: a heading "Simple Counter", a large number (5), text like "Counter is the 5th number", and "- Decrement" / "+ Increment" buttons. Take a screenshot. Note: the counter pattern may not appear in `listPatternIndex`, but the LLM can still launch it via `fetchAndRunPattern` using the path `counter/counter.tsx`.
 
-**Testing interactivity:** The `ct-button` component wraps a native `<button>` inside its shadow root. Use this approach:
+**Testing interactivity:** The `cf-button` component wraps a native `<button>` inside its shadow root. Use this approach:
 ```js
 (() => {
   const rv = document.querySelector("x-root-view");
   const av = rv.shadowRoot.querySelector("x-app-view");
   const bv = av.shadowRoot.querySelector("x-body-view");
-  const cr = bv.shadowRoot.querySelector("ct-render");
-  const buttons = cr.shadowRoot.querySelectorAll("ct-button");
+  const cr = bv.shadowRoot.querySelector("cf-render");
+  const buttons = cr.shadowRoot.querySelectorAll("cf-button");
   return Array.from(buttons).map(b => {
     const rect = b.getBoundingClientRect();
     return { x: rect.x + rect.width/2, y: rect.y + rect.height/2, w: rect.width };
@@ -313,9 +313,9 @@ Each do-list item has a collapsible **"AI Suggestions"** section (a `<details>` 
 Click the disclosure summary on one of the items (e.g. "Plan a weekend camping trip") to expand it.
 
 A Suggestion pattern will activate and begin generating. Watch for:
-- **`ct-message-beads`** — colored dots representing the LLM conversation. A spinning gray dot means the LLM is working. Blue = user, green = assistant text, amber = assistant tool calls, purple = tool results.
+- **`cf-message-beads`** — colored dots representing the LLM conversation. A spinning gray dot means the LLM is working. Blue = user, green = assistant text, amber = assistant tool calls, purple = tool results.
 - The LLM (Claude Sonnet) will call tools like `listPatternIndex`, `fetchAndRunPattern`, or `bash` to find/create a relevant result.
-- When done, a **`ct-cell-link`** chip (pill) appears showing the resulting piece.
+- When done, a **`cf-cell-link`** chip (pill) appears showing the resulting piece.
 
 Narrate the bead activity as it happens — describe what tools are being called and what's appearing. Wait for the suggestion to complete. Take a screenshot.
 
@@ -323,7 +323,7 @@ Expand the AI Suggestions on a second item too (e.g. "Research the best noise-ca
 
 ### Step 12: Click Suggestions and Explore Results
 
-Use the **Find Cell Link Chips** helper to locate `ct-cell-link` chips. The `text` field from the helper shows the chip's display name. Click the `ct-cell-link` chip on a completed suggestion to navigate to the resulting piece. Describe what the piece looks like — it could be a note with content, a web search result, a pattern output, etc.
+Use the **Find Cell Link Chips** helper to locate `cf-cell-link` chips. The `text` field from the helper shows the chip's display name. Click the `cf-cell-link` chip on a completed suggestion to navigate to the resulting piece. Describe what the piece looks like — it could be a note with content, a web search result, a pattern output, etc.
 
 Navigate back to the space home (breadcrumb). Check the **Recent** section in the right column — the piece you just visited should now appear there at the top of the list. Take a screenshot showing the recent list with the new piece.
 
@@ -337,7 +337,7 @@ Navigate back to the space home.
 
 ### Step 14: Suggestion Refinement / Follow-up
 
-Back on the space home, find a do-list item with a completed suggestion (expand it if collapsed). The **"Refine suggestion..."** input is hidden by default. To reveal it, click the **"+"** button on the `ct-message-beads` widget (the row of colored dots at the bottom of the suggestion). Use the **Find Shadow DOM Buttons** helper (searching for '+') to locate the button coordinates. This toggles the `ct-prompt-input` visible, which allows you to continue the conversation with the suggestion LLM.
+Back on the space home, find a do-list item with a completed suggestion (expand it if collapsed). The **"Refine suggestion..."** input is hidden by default. To reveal it, click the **"+"** button on the `cf-message-beads` widget (the row of colored dots at the bottom of the suggestion). Use the **Find Shadow DOM Buttons** helper (searching for '+') to locate the button coordinates. This toggles the `cf-prompt-input` visible, which allows you to continue the conversation with the suggestion LLM.
 
 The refinement input and Send button appear in the accessibility snapshot after clicking '+'. Use refs to interact with them.
 
@@ -381,7 +381,7 @@ Spend 2-3 minutes freely exploring the platform. This is intentionally unstructu
 - Open more AI Suggestions on do-list items you haven't expanded yet
 - Send more refinement messages on existing suggestions
 - Ask Omnibot to do other things with the do-list: mark items done, remove items, add new ones
-- Navigate between pieces using breadcrumbs and `ct-cell-link` chips
+- Navigate between pieces using breadcrumbs and `cf-cell-link` chips
 - Check if any suggestion results have their own interactive elements
 - Try creating another note or pattern from the Omnibot
 - Hover over the message beads in suggestions to see conversation details
@@ -463,7 +463,7 @@ These are persistent platform/tooling quirks that affect multiple steps. Step-sp
 - **Prefer `agent-browser`, fall back to Playwright MCP.** Check availability at startup and adapt.
 - **Always snapshot before interacting.** Never assume element refs from a previous snapshot are still valid.
 - **Use `snapshot -i` for interactive refs.** The `-i` flag returns only interactive elements with unique refs, avoiding the duplicate-ref problem that occurs with full snapshots.
-- **Use coordinate-based clicks for ALL shadow DOM custom elements.** This includes `ct-button`, `ct-cell-link`, `ct-input`, `<details>` summaries, and `ct-message-beads`. Ref-based clicks may hang or fail on these.
+- **Use coordinate-based clicks for ALL shadow DOM custom elements.** This includes `cf-button`, `cf-cell-link`, `cf-input`, `<details>` summaries, and `cf-message-beads`. Ref-based clicks may hang or fail on these.
 - **Write JS eval snippets to temp files.** See Known Gotchas for details.
 - **Be descriptive.** The user is watching — narrate what you see, what you're clicking, and what happened.
 - **Don't block on failures.** If a step fails, document it and move on. The tour is about coverage, not perfection.

--- a/docs/development/debugging/cli-debugging.md
+++ b/docs/development/debugging/cli-debugging.md
@@ -35,11 +35,11 @@ deno task cf piece get --piece ID totalSpent ...  # Now correct
 
 ## Inspect Transformed Output
 
-When the question is "what did the compiler emit?", use `ct check` with
+When the question is "what did the compiler emit?", use `cf check` with
 `--show-transformed` instead of reaching for ad hoc test harness code.
 
 ```bash
-deno task ct check ./packages/patterns/my-pattern.tsx --root $(pwd) --show-transformed
+deno task cf check ./packages/patterns/my-pattern.tsx --root $(pwd) --show-transformed
 ```
 
 This is the fastest way to inspect how `ts-transformers` rewrote:
@@ -52,7 +52,7 @@ This is the fastest way to inspect how `ts-transformers` rewrote:
 It also works on fixture inputs while debugging the compiler itself:
 
 ```bash
-deno task ct check \
+deno task cf check \
   packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.input.tsx \
   --root $(pwd) \
   --show-transformed

--- a/docs/specs/data-model/sigil.md
+++ b/docs/specs/data-model/sigil.md
@@ -4,11 +4,11 @@
 
 ## Editors
 
-- [Irakli Gozalishvili], [Common Tools]
+- [Irakli Gozalishvili], [Common Fabric]
 
 ## Authors
 
-- [Bernhard Seefeld], [Common Tools]
+- [Bernhard Seefeld], [Common Fabric]
 
 ## Abstract
 
@@ -634,7 +634,7 @@ backward-compatible evolution:
 3. **Migration tools**: Implementations SHOULD provide utilities for upgrading
    sigil versions
 
-[Common Tools]: https://common.tools/
+[Common Fabric]: https://common.tools/
 [Irakli Gozalishvili]: https://github.com/gozala
 [Memory Protocol]: ./memory.md
 [Binary Data Support]: ./memory-blobs.md

--- a/docs/specs/fuse-filesystem/2-path-scheme.md
+++ b/docs/specs/fuse-filesystem/2-path-scheme.md
@@ -138,8 +138,8 @@ home/pieces/todo-app/
         done          # file: false
       0.json          # {"text":"Buy milk","done":false}
     count             # file: 3
-    addItem.handler   # executable: invoke via ct exec or write JSON
-    search.tool       # executable: run via ct exec
+    addItem.handler   # executable: invoke via cf exec or write JSON
+    search.tool       # executable: run via cf exec
     $UI.json          # serialized VNode tree (not exploded)
   meta.json           # {"id":"of:ba4j...","patternName":"todo-app",...}
   .handlers           # hidden summary: one line per callable with type info

--- a/docs/specs/fuse-filesystem/3-json-mapping.md
+++ b/docs/specs/fuse-filesystem/3-json-mapping.md
@@ -352,10 +352,10 @@ can resolve the backing callable schema and execute it.
 Callable files also embed the handler's input schema as readable comments:
 
 ```sh
-#!/path/to/ct-exec exec
+#!/path/to/cf-exec exec
 # schema: {"type":"string"}
 # input: string
-exec '/path/to/ct-exec' exec "$0" "$@"
+exec '/path/to/cf-exec' exec "$0" "$@"
 ```
 
 Reading the file with `cat` or `head` reveals the expected input type before

--- a/docs/specs/fuse-filesystem/5-architecture.md
+++ b/docs/specs/fuse-filesystem/5-architecture.md
@@ -214,7 +214,7 @@ packages/
 
 ## CLI Integration
 
-The FUSE filesystem is accessed via the existing `ct` CLI:
+The FUSE filesystem is accessed via the existing `cf` CLI:
 
 ```bash
 cf fuse mount <mountpoint> [options]

--- a/docs/specs/fuse-filesystem/8-fs-projections.md
+++ b/docs/specs/fuse-filesystem/8-fs-projections.md
@@ -145,10 +145,10 @@ createNewNote.handler  void
 Each `.handler` and `.tool` file embeds the input schema as readable comments:
 
 ```sh
-#!/path/to/ct-exec exec
+#!/path/to/cf-exec exec
 # schema: {"type":"string"}
 # input: string
-exec '/path/to/ct-exec' exec "$0" "$@"
+exec '/path/to/cf-exec' exec "$0" "$@"
 ```
 
 Use `cat setTitle.handler` or `head setTitle.handler` to see the expected

--- a/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
+++ b/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
@@ -858,6 +858,9 @@ In the current implementation, the trusted runtime module identifiers are:
 - `commonfabric`
 - `commonfabric/schema`
 - `turndown`
+- `@commonfabric/html`
+- `@commonfabric/builder`
+- `@commonfabric/runner`
 
 These runtime modules may export:
 
@@ -1895,7 +1898,7 @@ module fallback.
 
 #### 3.3 Minimal globals plus trusted runtime modules (Priority: Medium)
 
-Keep ambient Compartment globals intentionally narrow and supply Common Tools
+Keep ambient Compartment globals intentionally narrow and supply Common Fabric
 capabilities through trusted runtime modules registered via `runtimeDeps`.
 Future reintroduction of time/network/randomness helpers for authored code
 remains a separate scoped decision.

--- a/docs/specs/ts-transformer/ts_transformers_type_driven_behavior_inventory.md
+++ b/docs/specs/ts-transformer/ts_transformers_type_driven_behavior_inventory.md
@@ -30,7 +30,7 @@ It does not list pure schema-generation/type-emission code unless that code exis
   - cell/stream receivers that still require rewrite
 
 - `src/ast/dataflow.ts`
-  The dataflow analyzer uses `checker.getTypeAtLocation(...)`, `isOpaqueRefType(...)`, `isReactiveValueExpression(...)`, and `symbolDeclaresCommonToolsDefault(...)` to decide:
+  The dataflow analyzer uses `checker.getTypeAtLocation(...)`, `isOpaqueRefType(...)`, `isReactiveValueExpression(...)`, and `symbolDeclaresCommonFabricDefault(...)` to decide:
   - `containsOpaqueRef`
   - `requiresRewrite`
   - which expressions become explicit dependencies

--- a/skills/fuse-agent/SKILL.md
+++ b/skills/fuse-agent/SKILL.md
@@ -22,14 +22,14 @@ cd ~/code/labs
 export CT_IDENTITY=./shared.key CT_API_URL=http://localhost:8000
 
 # 1. Deploy and capture piece ID
-ID=$(ct piece new packages/patterns/<path>.tsx \
+ID=$(cf piece new packages/patterns/<path>.tsx \
   --space SPACE --root packages/patterns 2>/dev/null | head -1)
 
 # 2. Set title
-ct piece call --quiet --piece $ID --space SPACE setTitle -- --value "My Title"
+cf piece call --quiet --piece $ID --space SPACE setTitle -- --value "My Title"
 
 # 3. Step to materialise
-ct piece step --piece $ID --space SPACE
+cf piece step --piece $ID --space SPACE
 
 # 4. Re-read pieces.json immediately — stale after deploy
 cat "MOUNT/SPACE/pieces/pieces.json"
@@ -63,17 +63,17 @@ cat "MOUNT/SPACE/pieces/pieces.json" | python3 -c \
   "import json,sys; p=json.load(sys.stdin); print(next(x['name'] for x in p if 'Reading' in x['name']))"
 ```
 
-### When to run `ct piece step`
+### When to run `cf piece step`
 
 | Operation                     | Step needed?                               |
 | ----------------------------- | ------------------------------------------ |
-| `ct piece call` (CLI)         | Always                                     |
-| `ct piece set` (CLI)          | Always                                     |
+| `cf piece call` (CLI)         | Always                                     |
+| `cf piece set` (CLI)          | Always                                     |
 | FUSE handler invocation       | Sometimes — if count suffix doesn't update |
 | Read/Write/Edit on `index.md` | Never                                      |
 
 When in doubt after a FUSE handler call: run
-`ct piece step --piece $ID --space SPACE`, then re-read `pieces.json`.
+`cf piece step --piece $ID --space SPACE`, then re-read `pieces.json`.
 
 ### NFS timeout and remount
 
@@ -82,10 +82,10 @@ load. Reads stall during the window.
 
 ```bash
 # Detect: mount is stale if this hangs or returns empty
-ls /tmp/ct-mount/
+ls /tmp/cf-mount/
 
 # Remount:
-ct fuse mount /tmp/ct-mount --background && sleep 3
+cf fuse mount /tmp/cf-mount --background && sleep 3
 ```
 
 Add `sleep 2` before verification reads if you see repeated stalls.
@@ -138,15 +138,15 @@ cat "MOUNT/SPACE/pieces/Activity Log (N)/result/summary"
 Annotations (`annotation.tsx`) are pieces that record observations, flags, and
 wishes. Use them to leave notes about things noticed without necessarily acting.
 
-**Deploy and configure via CT CLI:**
+**Deploy and configure via CF CLI:**
 
 ```bash
-ID=$(ct piece new packages/patterns/annotation.tsx \
+ID=$(cf piece new packages/patterns/annotation.tsx \
   --space SPACE --root packages/patterns 2>/dev/null | head -1)
 echo '"Standup notes mention 5 people with no structured contact list"' \
-  | ct piece set --piece $ID content --space SPACE
-echo '"wish"' | ct piece set --piece $ID kind --space SPACE
-ct piece step --piece $ID --space SPACE
+  | cf piece set --piece $ID content --space SPACE
+echo '"wish"' | cf piece set --piece $ID kind --space SPACE
+cf piece step --piece $ID --space SPACE
 # Re-read pieces.json — name now reflects content: "Standup notes mention..."
 ```
 
@@ -166,8 +166,8 @@ ct piece step --piece $ID --space SPACE
 **Mark a wish resolved** (when fulfilling another agent's annotation):
 
 ```bash
-echo '"resolved"' | ct piece set --piece $WISH_ID status --space SPACE
-ct piece step --piece $WISH_ID --space SPACE
+echo '"resolved"' | cf piece set --piece $WISH_ID status --space SPACE
+cf piece step --piece $WISH_ID --space SPACE
 ```
 
 **Discover open annotations** — deploy `annotation-manager.tsx` for an
@@ -188,7 +188,7 @@ for x in p:
 ## Cleanup
 
 ```bash
-ct piece rm --piece $ID --space SPACE
+cf piece rm --piece $ID --space SPACE
 ```
 
 Use this to clean up duplicate pieces deployed by accident (no `--confirm`

--- a/skills/fuse-workflow/SKILL.md
+++ b/skills/fuse-workflow/SKILL.md
@@ -335,7 +335,7 @@ path = "MOUNT/SPACE/pieces/My Piece/.src/main.tsx"
 src = open(path).read()
 # ... modify src ...
 open(path, "w").write(modified_src)
-# Write triggers setsrc automatically — no ct piece setsrc needed
+# Write triggers setsrc automatically — no cf piece setsrc needed
 ```
 
 **Check for errors after modifying:**

--- a/skills/lit-component/SKILL.md
+++ b/skills/lit-component/SKILL.md
@@ -383,7 +383,7 @@ Load these references as needed for detailed guidance:
 2. **Include box-sizing reset** - Ensures consistent layout behavior
 3. **Use `attribute: false`** for objects/arrays/Cells - Prevents serialization
    errors
-4. **Prefix custom events with `ct-`** - Namespace convention
+4. **Prefix custom events with `cf-`** - Namespace convention
 5. **Export types separately** - Use `export type { ... }`
 6. **Clean up subscriptions** - Always unsubscribe in `disconnectedCallback()`
 7. **Use transactions for Cell mutations** - Never mutate cells directly

--- a/tools/ralph/PROMPT.md
+++ b/tools/ralph/PROMPT.md
@@ -58,7 +58,7 @@ Steps:
        parameters
        ```tsx
        items.map((item, index) => (
-         <ct-button onClick={removeItem({ items, index })}>Remove</ct-button>
+         <cf-button onClick={removeItem({ items, index })}>Remove</cf-button>
        ));
        ```
 

--- a/tools/ralph/SMOKETEST_PROMPT.md
+++ b/tools/ralph/SMOKETEST_PROMPT.md
@@ -14,8 +14,8 @@ Goal: implement the task below
 
 2. Format with `deno fmt` for the changed files.
 
-3. Once tests pass, deploy it locally using the repo-local `ct` skill at
-   `skills/ct/` for deployment commands. It should deploy to
+3. Once tests pass, deploy it locally using the repo-local `cf` skill at
+   `skills/cf/` for deployment commands. It should deploy to
    http://localhost:8000. Servers are already running.
 
    Remember to use space name "ralph${RALPH_ID}" when deploying.

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -11,4 +11,4 @@ npm run dev
 
 TODO:
 * Add document on how Input and Output schemas work for Patterns
-* Chapter on basic UI and existing ct components
+* Chapter on basic UI and existing cf components


### PR DESCRIPTION
## Summary
- update internal docs, prompts, and specs from stale Common Tools/ct naming to Common Fabric/cf naming
- align browser-debug and UI-tag references with the post-cutover console API and cf-* custom elements
- leave live infra/org names and historical plan files alone

## Testing
- deno fmt <touched docs files>
- git diff --check
- rg audit across .claude/ skills/ tools/ tutorials/ docs
