### PR TITLE
[codex] cleanup: normalize auth-family conditionals

### DIFF
--- a/packages/patterns/airtable/core/airtable-auth.tsx
+++ b/packages/patterns/airtable/core/airtable-auth.tsx
@@ -2,7 +2,6 @@ import {
   computed,
   Default,
   handler,
-  ifElse,
   NAME,
   pattern,
   safeDateNow,
@@ -467,23 +466,25 @@ export default pattern<Input, Output>(
             }}
           >
             <h3 style={{ fontSize: "16px", marginTop: "0" }}>
-              Status: {ifElse(loggedIn, "Authenticated", "Not Authenticated")}
+              Status: {loggedIn ? "Authenticated" : "Not Authenticated"}
             </h3>
 
-            {ifElse(
-              loggedIn,
-              <div>
-                <p style={{ margin: "8px 0" }}>
-                  <strong>Email:</strong> {auth.user.email}
+            {loggedIn
+              ? (
+                <div>
+                  <p style={{ margin: "8px 0" }}>
+                    <strong>Email:</strong> {auth.user.email}
+                  </p>
+                  <p style={{ margin: "8px 0" }}>
+                    <strong>Name:</strong> {auth.user.name}
+                  </p>
+                </div>
+              )
+              : (
+                <p style={{ color: "#666" }}>
+                  Select permissions below and authenticate with Airtable
                 </p>
-                <p style={{ margin: "8px 0" }}>
-                  <strong>Name:</strong> {auth.user.name}
-                </p>
-              </div>,
-              <p style={{ color: "#666" }}>
-                Select permissions below and authenticate with Airtable
-              </p>,
-            )}
+              )}
           </div>
 
           {/* Permissions checkboxes */}
@@ -498,20 +499,20 @@ export default pattern<Input, Output>(
           >
             <h4 style={{ marginTop: "0", marginBottom: "12px" }}>
               Permissions
-              {ifElse(
-                loggedIn,
-                <span
-                  style={{
-                    fontWeight: "normal",
-                    fontSize: "12px",
-                    color: "#6b7280",
-                    marginLeft: "8px",
-                  }}
-                >
-                  (locked while authenticated)
-                </span>,
-                null,
-              )}
+              {loggedIn
+                ? (
+                  <span
+                    style={{
+                      fontWeight: "normal",
+                      fontSize: "12px",
+                      color: "#6b7280",
+                      marginLeft: "8px",
+                    }}
+                  >
+                    (locked while authenticated)
+                  </span>
+                )
+                : null}
             </h4>
             <div
               style={{ display: "flex", flexDirection: "column", gap: "10px" }}
@@ -538,123 +539,123 @@ export default pattern<Input, Output>(
           </div>
 
           {/* Re-auth warning */}
-          {ifElse(
-            needsReauth,
-            <div
-              style={{
-                padding: "12px",
-                backgroundColor: "#fff3cd",
-                borderRadius: "8px",
-                border: "1px solid #ffc107",
-                fontSize: "14px",
-              }}
-            >
-              <strong>Note:</strong>{" "}
-              You've selected new permissions. Click "Authenticate with
-              Airtable" below to grant access.
-            </div>,
-            null,
-          )}
+          {needsReauth
+            ? (
+              <div
+                style={{
+                  padding: "12px",
+                  backgroundColor: "#fff3cd",
+                  borderRadius: "8px",
+                  border: "1px solid #ffc107",
+                  fontSize: "14px",
+                }}
+              >
+                <strong>Note:</strong>{" "}
+                You've selected new permissions. Click "Authenticate with
+                Airtable" below to grant access.
+              </div>
+            )
+            : null}
 
           {/* Favorite reminder */}
-          {ifElse(
-            loggedIn,
-            <div
-              style={{
-                padding: "15px",
-                backgroundColor: "#d4edda",
-                borderRadius: "8px",
-                border: "1px solid #28a745",
-                fontSize: "14px",
-              }}
-            >
-              <strong>Tip:</strong>{" "}
-              Favorite this piece to share your Airtable auth across all your
-              patterns. Any pattern using{" "}
-              <code>wish({"{"} query: "#airtableAuth" {"}"})</code>{" "}
-              will automatically find and use it.
-            </div>,
-            null,
-          )}
+          {loggedIn
+            ? (
+              <div
+                style={{
+                  padding: "15px",
+                  backgroundColor: "#d4edda",
+                  borderRadius: "8px",
+                  border: "1px solid #28a745",
+                  fontSize: "14px",
+                }}
+              >
+                <strong>Tip:</strong>{" "}
+                Favorite this piece to share your Airtable auth across all your
+                patterns. Any pattern using{" "}
+                <code>wish({"{"} query: "#airtableAuth" {"}"})</code>{" "}
+                will automatically find and use it.
+              </div>
+            )
+            : null}
 
           {/* Show selected scopes */}
-          {ifElse(
-            notLoggedInWithScopes,
-            <div style={{ fontSize: "14px", color: "#666" }}>
-              Will request: {scopesDisplay}
-            </div>,
-            null,
-          )}
+          {notLoggedInWithScopes
+            ? (
+              <div style={{ fontSize: "14px", color: "#666" }}>
+                Will request: {scopesDisplay}
+              </div>
+            )
+            : null}
 
           {/* Token expired warning */}
-          {ifElse(
-            isTokenExpired,
-            <div
-              style={{
-                padding: "16px",
-                backgroundColor: "#fee2e2",
-                borderRadius: "8px",
-                border: "1px solid #ef4444",
-                marginBottom: "15px",
-              }}
-            >
-              <h4
+          {isTokenExpired
+            ? (
+              <div
                 style={{
-                  margin: "0 0 8px 0",
-                  color: "#dc2626",
-                  fontSize: "14px",
+                  padding: "16px",
+                  backgroundColor: "#fee2e2",
+                  borderRadius: "8px",
+                  border: "1px solid #ef4444",
+                  marginBottom: "15px",
                 }}
               >
-                Session Expired
-              </h4>
-              <p
-                style={{
-                  margin: "0 0 12px 0",
-                  fontSize: "13px",
-                  color: "#4b5563",
-                }}
-              >
-                Your Airtable token has expired. Click below to refresh it.
-              </p>
-              <button
-                type="button"
-                onClick={handleRefresh({
-                  auth,
-                  refreshInProgress,
-                  refreshing,
-                  refreshFailed,
-                })}
-                disabled={refreshing}
-                style={{
-                  padding: "10px 20px",
-                  backgroundColor: refreshing ? "#93c5fd" : "#3b82f6",
-                  color: "white",
-                  border: "none",
-                  borderRadius: "6px",
-                  cursor: refreshing ? "not-allowed" : "pointer",
-                  fontWeight: "500",
-                  fontSize: "14px",
-                }}
-              >
-                {ifElse(refreshing, "Refreshing...", "Refresh Token")}
-              </button>
-              {ifElse(
-                refreshFailed,
-                <p
+                <h4
                   style={{
-                    margin: "8px 0 0 0",
-                    fontSize: "13px",
+                    margin: "0 0 8px 0",
                     color: "#dc2626",
-                    fontWeight: "500",
+                    fontSize: "14px",
                   }}
                 >
-                  Refresh failed — try signing in again below.
-                </p>,
-                null,
-              )}
-            </div>,
-            null,
-          )}
+                  Session Expired
+                </h4>
+                <p
+                  style={{
+                    margin: "0 0 12px 0",
+                    fontSize: "13px",
+                    color: "#4b5563",
+                  }}
+                >
+                  Your Airtable token has expired. Click below to refresh it.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleRefresh({
+                    auth,
+                    refreshInProgress,
+                    refreshing,
+                    refreshFailed,
+                  })}
+                  disabled={refreshing}
+                  style={{
+                    padding: "10px 20px",
+                    backgroundColor: refreshing ? "#93c5fd" : "#3b82f6",
+                    color: "white",
+                    border: "none",
+                    borderRadius: "6px",
+                    cursor: refreshing ? "not-allowed" : "pointer",
+                    fontWeight: "500",
+                    fontSize: "14px",
+                  }}
+                >
+                  {refreshing ? "Refreshing..." : "Refresh Token"}
+                </button>
+                {refreshFailed
+                  ? (
+                    <p
+                      style={{
+                        margin: "8px 0 0 0",
+                        fontSize: "13px",
+                        color: "#dc2626",
+                        fontWeight: "500",
+                      }}
+                    >
+                      Refresh failed — try signing in again below.
+                    </p>
+                  )
+                  : null}
+              </div>
+            )
+            : null}
 
           <cf-oauth
             $auth={auth}
@@ -667,90 +668,90 @@ export default pattern<Input, Output>(
           />
 
           {/* Show granted scopes */}
-          {ifElse(
-            loggedIn,
-            <div
-              style={{
-                padding: "15px",
-                backgroundColor: "#e3f2fd",
-                borderRadius: "8px",
-                fontSize: "14px",
-              }}
-            >
-              <strong>Granted Scopes:</strong>
-              <ul style={{ margin: "8px 0 0 0", paddingLeft: "20px" }}>
-                {grantedScopesList.map((scope) => <li>{scope}</li>)}
-              </ul>
-            </div>,
-            null,
-          )}
-
-          {/* Token status when authenticated and NOT expired */}
-          {ifElse(
-            showTokenStatus,
-            <div
-              style={{
-                padding: "16px",
-                backgroundColor: "#f0f9ff",
-                borderRadius: "8px",
-                border: "1px solid #0ea5e9",
-              }}
-            >
+          {loggedIn
+            ? (
               <div
                 style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                  flexWrap: "wrap",
-                  gap: "12px",
+                  padding: "15px",
+                  backgroundColor: "#e3f2fd",
+                  borderRadius: "8px",
+                  fontSize: "14px",
                 }}
               >
-                <div>
-                  <h4
-                    style={{
-                      margin: "0 0 4px 0",
-                      fontSize: "14px",
-                      color: "#0369a1",
-                    }}
-                  >
-                    Token Status
-                  </h4>
-                  <p
-                    style={{
-                      margin: "0",
-                      fontSize: "13px",
-                      color: "#4b5563",
-                    }}
-                  >
-                    Expires in: <strong>{tokenExpiryDisplay}</strong>
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={handleRefresh({
-                    auth,
-                    refreshInProgress,
-                    refreshing,
-                    refreshFailed,
-                  })}
-                  disabled={refreshing}
+                <strong>Granted Scopes:</strong>
+                <ul style={{ margin: "8px 0 0 0", paddingLeft: "20px" }}>
+                  {grantedScopesList.map((scope) => <li>{scope}</li>)}
+                </ul>
+              </div>
+            )
+            : null}
+
+          {/* Token status when authenticated and NOT expired */}
+          {showTokenStatus
+            ? (
+              <div
+                style={{
+                  padding: "16px",
+                  backgroundColor: "#f0f9ff",
+                  borderRadius: "8px",
+                  border: "1px solid #0ea5e9",
+                }}
+              >
+                <div
                   style={{
-                    padding: "8px 16px",
-                    backgroundColor: refreshing ? "#7dd3fc" : "#0ea5e9",
-                    color: "white",
-                    border: "none",
-                    borderRadius: "6px",
-                    cursor: refreshing ? "not-allowed" : "pointer",
-                    fontWeight: "500",
-                    fontSize: "13px",
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    flexWrap: "wrap",
+                    gap: "12px",
                   }}
                 >
-                  {ifElse(refreshing, "Refreshing...", "Refresh Now")}
-                </button>
+                  <div>
+                    <h4
+                      style={{
+                        margin: "0 0 4px 0",
+                        fontSize: "14px",
+                        color: "#0369a1",
+                      }}
+                    >
+                      Token Status
+                    </h4>
+                    <p
+                      style={{
+                        margin: "0",
+                        fontSize: "13px",
+                        color: "#4b5563",
+                      }}
+                    >
+                      Expires in: <strong>{tokenExpiryDisplay}</strong>
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleRefresh({
+                      auth,
+                      refreshInProgress,
+                      refreshing,
+                      refreshFailed,
+                    })}
+                    disabled={refreshing}
+                    style={{
+                      padding: "8px 16px",
+                      backgroundColor: refreshing ? "#7dd3fc" : "#0ea5e9",
+                      color: "white",
+                      border: "none",
+                      borderRadius: "6px",
+                      cursor: refreshing ? "not-allowed" : "pointer",
+                      fontWeight: "500",
+                      fontSize: "13px",
+                    }}
+                  >
+                    {refreshing ? "Refreshing..." : "Refresh Now"}
+                  </button>
+                </div>
               </div>
-            </div>,
-            null,
-          )}
+            )
+            : null}
 
           <div
             style={{
@@ -770,44 +771,46 @@ export default pattern<Input, Output>(
       auth,
       scopes,
       selectedScopes,
-      userChip: ifElse(
-        hasEmail,
-        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-          <span
-            style={{
-              width: "24px",
-              height: "24px",
-              borderRadius: "50%",
-              backgroundColor: "#18BFFF",
-              display: "inline-block",
-            }}
-          />
-          <div>
-            <div style={{ fontWeight: 500, fontSize: "14px" }}>
-              {ifElse(hasUserName, auth.user.name, auth.user.email)}
+      userChip: hasEmail
+        ? (
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <span
+              style={{
+                width: "24px",
+                height: "24px",
+                borderRadius: "50%",
+                backgroundColor: "#18BFFF",
+                display: "inline-block",
+              }}
+            />
+            <div>
+              <div style={{ fontWeight: 500, fontSize: "14px" }}>
+                {hasUserName ? auth.user.name : auth.user.email}
+              </div>
+              {hasUserName
+                ? (
+                  <div style={{ fontSize: "12px", color: "#6b7280" }}>
+                    {auth.user.email}
+                  </div>
+                )
+                : null}
             </div>
-            {ifElse(
-              hasUserName,
-              <div style={{ fontSize: "12px", color: "#6b7280" }}>
-                {auth.user.email}
-              </div>,
-              null,
-            )}
           </div>
-        </div>,
-        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-          <span
-            style={{
-              width: "24px",
-              height: "24px",
-              borderRadius: "50%",
-              backgroundColor: "#e5e7eb",
-              display: "inline-block",
-            }}
-          />
-          <span style={{ color: "#6b7280" }}>Not signed in</span>
-        </div>,
-      ),
+        )
+        : (
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <span
+              style={{
+                width: "24px",
+                height: "24px",
+                borderRadius: "50%",
+                backgroundColor: "#e5e7eb",
+                display: "inline-block",
+              }}
+            />
+            <span style={{ color: "#6b7280" }}>Not signed in</span>
+          </div>
+        ),
       previewUI: (
         <div
           style={{
@@ -833,19 +836,19 @@ export default pattern<Input, Output>(
                 justifyContent: "center",
               }}
             >
-              {ifElse(
-                previewState.isAuthenticated,
-                <span
-                  style={{
-                    color: "white",
-                    fontSize: "14px",
-                    fontWeight: "600",
-                  }}
-                >
-                  {previewState.initial}
-                </span>,
-                null,
-              )}
+              {previewState.isAuthenticated
+                ? (
+                  <span
+                    style={{
+                      color: "white",
+                      fontSize: "14px",
+                      fontWeight: "600",
+                    }}
+                  >
+                    {previewState.initial}
+                  </span>
+                )
+                : null}
             </div>
             <div
               style={{
@@ -862,33 +865,31 @@ export default pattern<Input, Output>(
           </div>
           <div style={{ flex: 1, minWidth: 0 }}>
             <div style={{ fontWeight: 500, fontSize: "14px" }}>
-              {ifElse(
-                previewState.isAuthenticated,
-                <span>{previewState.name || previewState.email}</span>,
-                <span>Sign in required</span>,
-              )}
+              {previewState.isAuthenticated
+                ? <span>{previewState.name || previewState.email}</span>
+                : <span>Sign in required</span>}
             </div>
-            {ifElse(
-              previewState.isAuthenticated && !!previewState.name &&
-                !!previewState.email,
-              <div style={{ fontSize: "12px", color: "#6b7280" }}>
-                {previewState.email}
-              </div>,
-              null,
-            )}
-            {ifElse(
-              !!previewState.scopeSummary,
-              <div
-                style={{
-                  fontSize: "12px",
-                  color: "#6b7280",
-                  marginTop: "2px",
-                }}
-              >
-                {previewState.scopeSummary}
-              </div>,
-              null,
-            )}
+            {previewState.isAuthenticated && !!previewState.name &&
+                !!previewState.email
+              ? (
+                <div style={{ fontSize: "12px", color: "#6b7280" }}>
+                  {previewState.email}
+                </div>
+              )
+              : null}
+            {!!previewState.scopeSummary
+              ? (
+                <div
+                  style={{
+                    fontSize: "12px",
+                    color: "#6b7280",
+                    marginTop: "2px",
+                  }}
+                >
+                  {previewState.scopeSummary}
+                </div>
+              )
+              : null}
           </div>
         </div>
       ),

--- a/packages/patterns/airtable/core/airtable-auth.tsx
+++ b/packages/patterns/airtable/core/airtable-auth.tsx
@@ -877,7 +877,7 @@ export default pattern<Input, Output>(
                 </div>
               )
               : null}
-            {!!previewState.scopeSummary
+            {previewState.scopeSummary
               ? (
                 <div
                   style={{

--- a/packages/patterns/auth/create-auth-manager.tsx
+++ b/packages/patterns/auth/create-auth-manager.tsx
@@ -18,7 +18,6 @@ import {
   computed,
   Default,
   handler,
-  ifElse,
   lift,
   navigateTo,
   pattern,
@@ -422,41 +421,41 @@ export function createAuthManager<T, R>(
             fontSize: "14px",
           }}
         >
-          {ifElse(
-            authState.showAvatar,
-            <img
-              src={authState.avatarUrl}
-              alt=""
-              style={{ width: "20px", height: "20px", borderRadius: "50%" }}
-            />,
-            <span
-              style={{
-                width: "10px",
-                height: "10px",
-                borderRadius: "50%",
-                backgroundColor: ifElse(
-                  computed(() => currentState === "ready"),
-                  descriptor.brandColor,
-                  authState.statusDotColor,
-                ),
-              }}
-            />,
-          )}
+          {authState.showAvatar
+            ? (
+              <img
+                src={authState.avatarUrl}
+                alt=""
+                style={{ width: "20px", height: "20px", borderRadius: "50%" }}
+              />
+            )
+            : (
+              <span
+                style={{
+                  width: "10px",
+                  height: "10px",
+                  borderRadius: "50%",
+                  backgroundColor: currentState === "ready"
+                    ? descriptor.brandColor
+                    : authState.statusDotColor,
+                }}
+              />
+            )}
           <span>{authState.statusText}</span>
-          {ifElse(
-            authState.showExpiryInStatus,
-            <span
-              style={{
-                marginLeft: "4px",
-                fontSize: "12px",
-                color: authState.expiryHintColor,
-                fontWeight: authState.expiryHintWeight,
-              }}
-            >
-              • {tokenExpiryDisplay}
-            </span>,
-            null,
-          )}
+          {authState.showExpiryInStatus
+            ? (
+              <span
+                style={{
+                  marginLeft: "4px",
+                  fontSize: "12px",
+                  color: authState.expiryHintColor,
+                  fontWeight: authState.expiryHintWeight,
+                }}
+              >
+                • {tokenExpiryDisplay}
+              </span>
+            )
+            : null}
         </div>
       );
 
@@ -680,15 +679,15 @@ export function createAuthManager<T, R>(
                   fontSize: "14px",
                 }}
               >
-                {ifElse(isRefreshing, "Refreshing...", "Refresh Session")}
+                {isRefreshing ? "Refreshing..." : "Refresh Session"}
               </button>
-              {ifElse(
-                refreshFailed,
-                <span style={{ fontSize: "13px", color: "#dc2626" }}>
-                  Refresh failed — try signing in again below.
-                </span>,
-                null,
-              )}
+              {refreshFailed
+                ? (
+                  <span style={{ fontSize: "13px", color: "#dc2626" }}>
+                    Refresh failed — try signing in again below.
+                  </span>
+                )
+                : null}
             </div>
           </div>
           {pickerUI}
@@ -740,13 +739,13 @@ export function createAuthManager<T, R>(
                 gap: "12px",
               }}
             >
-              {ifElse(
-                showExpiryInReady,
-                <span style={{ fontSize: "12px", color: "#059669" }}>
-                  {tokenExpiryDisplay}
-                </span>,
-                null,
-              )}
+              {showExpiryInReady
+                ? (
+                  <span style={{ fontSize: "12px", color: "#059669" }}>
+                    {tokenExpiryDisplay}
+                  </span>
+                )
+                : null}
               <button
                 type="button"
                 onClick={reauthenticate}
@@ -779,23 +778,23 @@ export function createAuthManager<T, R>(
               </button>
             </div>
           </div>
-          {ifElse(
-            showTokenWarning,
-            <div
-              style={{
-                padding: "8px 16px",
-                backgroundColor: "#fef3c7",
-                borderRadius: "0 0 8px 8px",
-                border: "1px solid #f59e0b",
-                borderTop: "none",
-                fontSize: "13px",
-                color: "#b45309",
-              }}
-            >
-              Token expires soon. You may need to re-authenticate shortly.
-            </div>,
-            null,
-          )}
+          {showTokenWarning
+            ? (
+              <div
+                style={{
+                  padding: "8px 16px",
+                  backgroundColor: "#fef3c7",
+                  borderRadius: "0 0 8px 8px",
+                  border: "1px solid #f59e0b",
+                  borderTop: "none",
+                  fontSize: "13px",
+                  color: "#b45309",
+                }}
+              >
+                Token expires soon. You may need to re-authenticate shortly.
+              </div>
+            )
+            : null}
         </div>
       );
 
@@ -819,24 +818,14 @@ export function createAuthManager<T, R>(
         </div>
       );
 
-      // Compose fullUI via chained ifElse
-      const loginOrLoad = ifElse(
-        authState.isNeedsLogin,
-        needsLoginUI,
-        loadingUI,
-      );
-      const scopesOrPrev = ifElse(
-        isMissingScopes,
-        missingScopesUI,
-        loginOrLoad,
-      );
-      const expiredOrPrev = ifElse(
-        authState.isTokenExpiredState,
-        tokenExpiredUI,
-        scopesOrPrev,
-      );
-      const refreshOrPrev = ifElse(isRefreshing, refreshingUI, expiredOrPrev);
-      const fullUI = ifElse(authState.isReadyState, readyUI, refreshOrPrev);
+      // Compose fullUI via nested ternaries
+      const loginOrLoad = authState.isNeedsLogin ? needsLoginUI : loadingUI;
+      const scopesOrPrev = isMissingScopes ? missingScopesUI : loginOrLoad;
+      const expiredOrPrev = authState.isTokenExpiredState
+        ? tokenExpiredUI
+        : scopesOrPrev;
+      const refreshOrPrev = isRefreshing ? refreshingUI : expiredOrPrev;
+      const fullUI = authState.isReadyState ? readyUI : refreshOrPrev;
 
       // ====================================================================
       // RETURN

--- a/packages/patterns/google/core/google-auth.tsx
+++ b/packages/patterns/google/core/google-auth.tsx
@@ -3,7 +3,6 @@ import {
   computed,
   Default,
   handler,
-  ifElse,
   NAME,
   pattern,
   safeDateNow,
@@ -446,56 +445,60 @@ export default pattern<Input, Output>(
     const hasPicture = computed(() => !!auth?.user?.picture);
     const hasUserName = computed(() => !!auth?.user?.name);
 
-    const userChipAvatar = ifElse(
-      hasPicture,
-      <img
-        src={auth.user.picture}
-        alt=""
-        style={{ width: "24px", height: "24px", borderRadius: "50%" }}
-      />,
-      <span
-        style={{
-          width: "24px",
-          height: "24px",
-          borderRadius: "50%",
-          backgroundColor: "#10b981",
-          display: "inline-block",
-        }}
-      />,
-    );
-
-    const userChipEmailLine = ifElse(
-      hasUserName,
-      <div style={{ fontSize: "12px", color: "#6b7280" }}>
-        {auth.user.email}
-      </div>,
-      null,
-    );
-
-    const userChip = ifElse(
-      hasEmail,
-      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-        {userChipAvatar}
-        <div>
-          <div style={{ fontWeight: 500, fontSize: "14px" }}>
-            {auth.user.name || auth.user.email}
-          </div>
-          {userChipEmailLine}
-        </div>
-      </div>,
-      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+    const userChipAvatar = hasPicture
+      ? (
+        <img
+          src={auth.user.picture}
+          alt=""
+          style={{ width: "24px", height: "24px", borderRadius: "50%" }}
+        />
+      )
+      : (
         <span
           style={{
             width: "24px",
             height: "24px",
             borderRadius: "50%",
-            backgroundColor: "#e5e7eb",
+            backgroundColor: "#10b981",
             display: "inline-block",
           }}
         />
-        <span style={{ color: "#6b7280" }}>Not signed in</span>
-      </div>,
-    );
+      );
+
+    const userChipEmailLine = hasUserName
+      ? (
+        <div style={{ fontSize: "12px", color: "#6b7280" }}>
+          {auth.user.email}
+        </div>
+      )
+      : null;
+
+    const userChip = hasEmail
+      ? (
+        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          {userChipAvatar}
+          <div>
+            <div style={{ fontWeight: 500, fontSize: "14px" }}>
+              {auth.user.name || auth.user.email}
+            </div>
+            {userChipEmailLine}
+          </div>
+        </div>
+      )
+      : (
+        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <span
+            style={{
+              width: "24px",
+              height: "24px",
+              borderRadius: "50%",
+              backgroundColor: "#e5e7eb",
+              display: "inline-block",
+            }}
+          />
+          <span style={{ color: "#6b7280" }}>Not signed in</span>
+        </div>
+      );
 
     // Minimal preview chip for picker display using shared helper
     const previewUI = computed(() =>
@@ -513,7 +516,7 @@ export default pattern<Input, Output>(
 
     const loggedIn = computed(() => !!auth?.user?.email);
 
-    // Compound conditions for ifElse in JSX
+    // Compound conditions for conditional UI
     const showScopePreview = computed(() => !loggedIn && hasSelectedScopes);
     const showTokenStatus = computed(() =>
       !!auth?.user?.email && !isTokenExpired
@@ -562,23 +565,25 @@ export default pattern<Input, Output>(
             }}
           >
             <h3 style={{ fontSize: "16px", marginTop: "0" }}>
-              Status: {ifElse(loggedIn, "Authenticated", "Not Authenticated")}
+              Status: {loggedIn ? "Authenticated" : "Not Authenticated"}
             </h3>
 
-            {ifElse(
-              loggedIn,
-              <div>
-                <p style={{ margin: "8px 0" }}>
-                  <strong>Email:</strong> {auth.user.email}
+            {loggedIn
+              ? (
+                <div>
+                  <p style={{ margin: "8px 0" }}>
+                    <strong>Email:</strong> {auth.user.email}
+                  </p>
+                  <p style={{ margin: "8px 0" }}>
+                    <strong>Name:</strong> {auth.user.name}
+                  </p>
+                </div>
+              )
+              : (
+                <p style={{ color: "#666" }}>
+                  Select permissions below and authenticate with Google
                 </p>
-                <p style={{ margin: "8px 0" }}>
-                  <strong>Name:</strong> {auth.user.name}
-                </p>
-              </div>,
-              <p style={{ color: "#666" }}>
-                Select permissions below and authenticate with Google
-              </p>,
-            )}
+              )}
           </div>
 
           {/* Permissions checkboxes */}
@@ -593,20 +598,20 @@ export default pattern<Input, Output>(
           >
             <h4 style={{ marginTop: "0", marginBottom: "12px" }}>
               Permissions
-              {ifElse(
-                loggedIn,
-                <span
-                  style={{
-                    fontWeight: "normal",
-                    fontSize: "12px",
-                    color: "#6b7280",
-                    marginLeft: "8px",
-                  }}
-                >
-                  (locked while authenticated)
-                </span>,
-                null,
-              )}
+              {loggedIn
+                ? (
+                  <span
+                    style={{
+                      fontWeight: "normal",
+                      fontSize: "12px",
+                      color: "#6b7280",
+                      marginLeft: "8px",
+                    }}
+                  >
+                    (locked while authenticated)
+                  </span>
+                )
+                : null}
             </h4>
             <div
               style={{ display: "flex", flexDirection: "column", gap: "10px" }}
@@ -633,187 +638,85 @@ export default pattern<Input, Output>(
           </div>
 
           {/* Re-auth warning */}
-          {ifElse(
-            needsReauth,
-            <div
-              style={{
-                padding: "12px",
-                backgroundColor: "#fff3cd",
-                borderRadius: "8px",
-                border: "1px solid #ffc107",
-                fontSize: "14px",
-              }}
-            >
-              <strong>Note:</strong>{" "}
-              You've selected new permissions. Click "Sign in with Google" below
-              to grant access.
-            </div>,
-            null,
-          )}
-
-          {/* Favorite reminder */}
-          {ifElse(
-            loggedIn,
-            <div
-              style={{
-                padding: "15px",
-                backgroundColor: "#d4edda",
-                borderRadius: "8px",
-                border: "1px solid #28a745",
-                fontSize: "14px",
-              }}
-            >
-              <strong>Tip:</strong>{" "}
-              Favorite this piece (click ⭐) to share your Google auth across
-              all your patterns. Any pattern using{" "}
-              <code>wish({"{"} query: "#googleAuth" {"}"})</code>{" "}
-              will automatically find and use it.
-            </div>,
-            null,
-          )}
-
-          {/* Show selected scopes if no auth yet */}
-          {ifElse(
-            showScopePreview,
-            <div style={{ fontSize: "14px", color: "#666" }}>
-              Will request: {scopesDisplay}
-            </div>,
-            null,
-          )}
-
-          {/* Token expired warning with refresh button */}
-          {ifElse(
-            isTokenExpired,
-            <div
-              style={{
-                padding: "16px",
-                backgroundColor: "#fee2e2",
-                borderRadius: "8px",
-                border: "1px solid #ef4444",
-                marginBottom: "15px",
-              }}
-            >
-              <h4
-                style={{
-                  margin: "0 0 8px 0",
-                  color: "#dc2626",
-                  fontSize: "14px",
-                }}
-              >
-                Session Expired
-              </h4>
-              <p
-                style={{
-                  margin: "0 0 12px 0",
-                  fontSize: "13px",
-                  color: "#4b5563",
-                }}
-              >
-                Your Google token has expired. Click below to refresh it
-                automatically.
-              </p>
-              <button
-                type="button"
-                onClick={handleRefresh({
-                  auth,
-                  refreshInProgress,
-                  refreshing,
-                  refreshFailed,
-                })}
-                disabled={refreshing}
-                style={{
-                  padding: "10px 20px",
-                  backgroundColor: refreshing ? "#93c5fd" : "#3b82f6",
-                  color: "white",
-                  border: "none",
-                  borderRadius: "6px",
-                  cursor: refreshing ? "not-allowed" : "pointer",
-                  fontWeight: "500",
-                  fontSize: "14px",
-                }}
-              >
-                {ifElse(refreshing, "Refreshing...", "Refresh Token")}
-              </button>
-              {ifElse(
-                refreshFailed,
-                <p
-                  style={{
-                    margin: "8px 0 0 0",
-                    fontSize: "13px",
-                    color: "#dc2626",
-                    fontWeight: "500",
-                  }}
-                >
-                  Refresh failed — try signing in again below.
-                </p>,
-                null,
-              )}
-            </div>,
-            null,
-          )}
-
-          <cf-google-oauth
-            $auth={auth}
-            scopes={scopes}
-          />
-
-          {/* Show granted scopes if authenticated */}
-          {ifElse(
-            loggedIn,
-            <div
-              style={{
-                padding: "15px",
-                backgroundColor: "#e3f2fd",
-                borderRadius: "8px",
-                fontSize: "14px",
-              }}
-            >
-              <strong>Granted Scopes:</strong>
-              {grantedScopesUI}
-            </div>,
-            null,
-          )}
-
-          {/* Manual token refresh section - visible when authenticated and NOT expired */}
-          {ifElse(
-            showTokenStatus,
-            <div
-              style={{
-                padding: "16px",
-                backgroundColor: "#f0f9ff",
-                borderRadius: "8px",
-                border: "1px solid #0ea5e9",
-              }}
-            >
+          {needsReauth
+            ? (
               <div
                 style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                  flexWrap: "wrap",
-                  gap: "12px",
+                  padding: "12px",
+                  backgroundColor: "#fff3cd",
+                  borderRadius: "8px",
+                  border: "1px solid #ffc107",
+                  fontSize: "14px",
                 }}
               >
-                <div>
-                  <h4
-                    style={{
-                      margin: "0 0 4px 0",
-                      fontSize: "14px",
-                      color: "#0369a1",
-                    }}
-                  >
-                    Token Status
-                  </h4>
-                  <p
-                    style={{
-                      margin: "0",
-                      fontSize: "13px",
-                      color: "#4b5563",
-                    }}
-                  >
-                    Expires in: <strong>{tokenExpiryDisplay}</strong>
-                  </p>
-                </div>
+                <strong>Note:</strong>{" "}
+                You've selected new permissions. Click "Sign in with Google"
+                below to grant access.
+              </div>
+            )
+            : null}
+
+          {/* Favorite reminder */}
+          {loggedIn
+            ? (
+              <div
+                style={{
+                  padding: "15px",
+                  backgroundColor: "#d4edda",
+                  borderRadius: "8px",
+                  border: "1px solid #28a745",
+                  fontSize: "14px",
+                }}
+              >
+                <strong>Tip:</strong>{" "}
+                Favorite this piece (click ⭐) to share your Google auth across
+                all your patterns. Any pattern using{" "}
+                <code>wish({"{"} query: "#googleAuth" {"}"})</code>{" "}
+                will automatically find and use it.
+              </div>
+            )
+            : null}
+
+          {/* Show selected scopes if no auth yet */}
+          {showScopePreview
+            ? (
+              <div style={{ fontSize: "14px", color: "#666" }}>
+                Will request: {scopesDisplay}
+              </div>
+            )
+            : null}
+
+          {/* Token expired warning with refresh button */}
+          {isTokenExpired
+            ? (
+              <div
+                style={{
+                  padding: "16px",
+                  backgroundColor: "#fee2e2",
+                  borderRadius: "8px",
+                  border: "1px solid #ef4444",
+                  marginBottom: "15px",
+                }}
+              >
+                <h4
+                  style={{
+                    margin: "0 0 8px 0",
+                    color: "#dc2626",
+                    fontSize: "14px",
+                  }}
+                >
+                  Session Expired
+                </h4>
+                <p
+                  style={{
+                    margin: "0 0 12px 0",
+                    fontSize: "13px",
+                    color: "#4b5563",
+                  }}
+                >
+                  Your Google token has expired. Click below to refresh it
+                  automatically.
+                </p>
                 <button
                   type="button"
                   onClick={handleRefresh({
@@ -824,22 +727,124 @@ export default pattern<Input, Output>(
                   })}
                   disabled={refreshing}
                   style={{
-                    padding: "8px 16px",
-                    backgroundColor: refreshing ? "#7dd3fc" : "#0ea5e9",
+                    padding: "10px 20px",
+                    backgroundColor: refreshing ? "#93c5fd" : "#3b82f6",
                     color: "white",
                     border: "none",
                     borderRadius: "6px",
                     cursor: refreshing ? "not-allowed" : "pointer",
                     fontWeight: "500",
-                    fontSize: "13px",
+                    fontSize: "14px",
                   }}
                 >
-                  {ifElse(refreshing, "Refreshing...", "Refresh Now")}
+                  {refreshing ? "Refreshing..." : "Refresh Token"}
                 </button>
+                {refreshFailed
+                  ? (
+                    <p
+                      style={{
+                        margin: "8px 0 0 0",
+                        fontSize: "13px",
+                        color: "#dc2626",
+                        fontWeight: "500",
+                      }}
+                    >
+                      Refresh failed — try signing in again below.
+                    </p>
+                  )
+                  : null}
               </div>
-            </div>,
-            null,
-          )}
+            )
+            : null}
+
+          <cf-google-oauth
+            $auth={auth}
+            scopes={scopes}
+          />
+
+          {/* Show granted scopes if authenticated */}
+          {loggedIn
+            ? (
+              <div
+                style={{
+                  padding: "15px",
+                  backgroundColor: "#e3f2fd",
+                  borderRadius: "8px",
+                  fontSize: "14px",
+                }}
+              >
+                <strong>Granted Scopes:</strong>
+                {grantedScopesUI}
+              </div>
+            )
+            : null}
+
+          {/* Manual token refresh section - visible when authenticated and NOT expired */}
+          {showTokenStatus
+            ? (
+              <div
+                style={{
+                  padding: "16px",
+                  backgroundColor: "#f0f9ff",
+                  borderRadius: "8px",
+                  border: "1px solid #0ea5e9",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    flexWrap: "wrap",
+                    gap: "12px",
+                  }}
+                >
+                  <div>
+                    <h4
+                      style={{
+                        margin: "0 0 4px 0",
+                        fontSize: "14px",
+                        color: "#0369a1",
+                      }}
+                    >
+                      Token Status
+                    </h4>
+                    <p
+                      style={{
+                        margin: "0",
+                        fontSize: "13px",
+                        color: "#4b5563",
+                      }}
+                    >
+                      Expires in: <strong>{tokenExpiryDisplay}</strong>
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleRefresh({
+                      auth,
+                      refreshInProgress,
+                      refreshing,
+                      refreshFailed,
+                    })}
+                    disabled={refreshing}
+                    style={{
+                      padding: "8px 16px",
+                      backgroundColor: refreshing ? "#7dd3fc" : "#0ea5e9",
+                      color: "white",
+                      border: "none",
+                      borderRadius: "6px",
+                      cursor: refreshing ? "not-allowed" : "pointer",
+                      fontWeight: "500",
+                      fontSize: "13px",
+                    }}
+                  >
+                    {refreshing ? "Refreshing..." : "Refresh Now"}
+                  </button>
+                </div>
+              </div>
+            )
+            : null}
 
           <div
             style={{


### PR DESCRIPTION
## Summary
- replace authored `ifElse(...)` conditionals with plain ternaries across the mirrored auth-family UIs
- normalize JSX-child control flow, inline labels, local JSX/string aliases, returned `userChip` fields, and the shared auth-manager `fullUI` composition
- update the stale auth-manager comment so it describes the current nested-ternary composition rather than chained `ifElse(...)`

## Why
Current transformer behavior already lowers these ternary forms correctly in all of the positions used here. These auth files were still carrying older helper-oriented style that is no longer necessary.

## Scope
- `packages/patterns/google/core/google-auth.tsx`
- `packages/patterns/airtable/core/airtable-auth.tsx`
- `packages/patterns/auth/create-auth-manager.tsx`

## Validation
- `deno fmt packages/patterns/google/core/google-auth.tsx packages/patterns/airtable/core/airtable-auth.tsx packages/patterns/auth/create-auth-manager.tsx`
- `deno task cf check packages/patterns/google/core/google-auth.tsx packages/patterns/airtable/core/airtable-auth.tsx --no-run`
- `deno check packages/patterns/auth/create-auth-manager.tsx`
- `git diff --check`
