### PR TITLE
cleanup: normalize simple text toggles

### DIFF
--- a/packages/patterns/airtable/airtable-importer.tsx
+++ b/packages/patterns/airtable/airtable-importer.tsx
@@ -349,7 +349,7 @@ export default pattern<Input, Output>(
                       fontSize: "14px",
                     }}
                   >
-                    {ifElse(loading, "Loading...", "Load Bases")}
+                    {loading ? "Loading..." : "Load Bases"}
                   </button>
                 </div>
 
@@ -436,7 +436,7 @@ export default pattern<Input, Output>(
                         fontSize: "14px",
                       }}
                     >
-                      {ifElse(loading, "Loading...", "Load Tables")}
+                      {loading ? "Loading..." : "Load Tables"}
                     </button>
                   </div>
 
@@ -525,7 +525,7 @@ export default pattern<Input, Output>(
                         fontSize: "14px",
                       }}
                     >
-                      {ifElse(loading, "Fetching...", "Fetch Records")}
+                      {loading ? "Fetching..." : "Fetch Records"}
                     </button>
                   </div>
 

--- a/packages/patterns/google/core/experimental/gmail-label-manager.tsx
+++ b/packages/patterns/google/core/experimental/gmail-label-manager.tsx
@@ -335,7 +335,7 @@ export default pattern<Input, Output>(
                   cursor: "pointer",
                 }}
               >
-                {ifElse(loadingLabels, "Loading...", "Refresh Labels")}
+                {loadingLabels ? "Loading..." : "Refresh Labels"}
               </button>
             </div>,
             null,
@@ -887,7 +887,7 @@ export default pattern<Input, Output>(
                       opacity: derive(processing, (p) => (p ? 0.7 : 1)),
                     }}
                   >
-                    {ifElse(processing, "Applying...", "Apply Changes")}
+                    {processing ? "Applying..." : "Apply Changes"}
                   </button>
                 </div>
               </div>

--- a/packages/patterns/google/core/experimental/gmail-sender.tsx
+++ b/packages/patterns/google/core/experimental/gmail-sender.tsx
@@ -671,7 +671,7 @@ export default pattern<Input, Output>(({ draft }) => {
                     opacity: computed(() => sending.get() ? 0.7 : 1),
                   }}
                 >
-                  {ifElse(sending, "Sending...", "Send Email")}
+                  {sending ? "Sending..." : "Send Email"}
                 </button>
               </div>
             </div>

--- a/packages/patterns/google/extractors/email-notes.tsx
+++ b/packages/patterns/google/extractors/email-notes.tsx
@@ -440,7 +440,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
                     fontWeight: "500",
                   }}
                 >
-                  {ifElse(loadingLabels, "Loading...", "Load Labels")}
+                  {loadingLabels ? "Loading..." : "Load Labels"}
                 </button>
               </div>,
               null,
@@ -552,7 +552,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
                               ),
                             }}
                           >
-                            {ifElse(isProcessing, "Processing...", "Done")}
+                            {isProcessing ? "Processing..." : "Done"}
                           </button>
                         </div>
                       </div>

--- a/packages/patterns/google/extractors/expect-response-followup.tsx
+++ b/packages/patterns/google/extractors/expect-response-followup.tsx
@@ -997,7 +997,7 @@ Write only the email body, no subject line or greeting line (the greeting will b
                     fontWeight: "500",
                   }}
                 >
-                  {ifElse(loadingLabels, "Loading...", "Load Labels")}
+                  {loadingLabels ? "Loading..." : "Load Labels"}
                 </button>
               </div>,
               null,
@@ -1193,7 +1193,7 @@ Write only the email body, no subject line or greeting line (the greeting will b
                               fontSize: "12px",
                             }}
                           >
-                            {ifElse(isExpanded, "Hide thread", "Show thread")}
+                            {isExpanded ? "Hide thread" : "Show thread"}
                           </button>
                         </div>
                       </div>

--- a/packages/patterns/record/extraction/extractor-module.tsx
+++ b/packages/patterns/record/extraction/extractor-module.tsx
@@ -2462,7 +2462,7 @@ export const ExtractorModule = pattern<
             }}
           >
             <span style={{ color: "#92400e", fontWeight: "500" }}>
-              {ifElse(isPreviewPhase, "Review Changes", "Select Sources")}
+              {isPreviewPhase ? "Review Changes" : "Select Sources"}
             </span>
             {ifElse(
               isExtractingPhase,
@@ -2517,11 +2517,9 @@ export const ExtractorModule = pattern<
                       color: "#6b7280",
                     }}
                   >
-                    {ifElse(
-                      hasNoUsableSources,
-                      "Add content to sources below:",
-                      "Select sources to extract from:",
-                    )}
+                    {hasNoUsableSources
+                      ? "Add content to sources below:"
+                      : "Select sources to extract from:"}
                   </div>
                   <div
                     style={{
@@ -2688,7 +2686,7 @@ export const ExtractorModule = pattern<
                       }}
                     >
                       Extract from {selectedSourceCount} source
-                      {ifElse(isSingleSource, "", "s")}
+                      {isSingleSource ? "" : "s"}
                     </button>
                   </div>
                 </div>,
@@ -2752,7 +2750,7 @@ export const ExtractorModule = pattern<
                     textDecoration: "underline",
                   }}
                 >
-                  {ifElse(showErrorDetails, "Hide details", "Show details")}
+                  {showErrorDetails ? "Hide details" : "Show details"}
                 </button>
                 {ifElse(
                   showErrorDetails,
@@ -3198,11 +3196,9 @@ export const ExtractorModule = pattern<
                             fontStyle: "italic",
                           }}
                         >
-                          {ifElse(
-                            cleanupDisabled,
-                            "Cleanup disabled - Notes will remain unchanged",
-                            "No changes needed to Notes content",
-                          )}
+                          {cleanupDisabled
+                            ? "Cleanup disabled - Notes will remain unchanged"
+                            : "No changes needed to Notes content"}
                         </div>,
                       )}
                     </div>,


### PR DESCRIPTION
## Summary
- replace simple authored `ifElse(cond, "A", "B")` text toggles with plain ternaries in importer/extractor-style patterns
- simplify a few equally mechanical extractor text labels and pluralization sites
- leave structural JSX-child `ifElse(...)` cases out of scope for later cleanup passes

## Validation
- `deno fmt packages/patterns/airtable/airtable-importer.tsx packages/patterns/google/extractors/email-notes.tsx packages/patterns/google/extractors/expect-response-followup.tsx packages/patterns/google/core/experimental/gmail-label-manager.tsx packages/patterns/google/core/experimental/gmail-sender.tsx packages/patterns/record/extraction/extractor-module.tsx`
- `deno lint packages/patterns/airtable/airtable-importer.tsx packages/patterns/google/extractors/email-notes.tsx packages/patterns/google/extractors/expect-response-followup.tsx packages/patterns/google/core/experimental/gmail-label-manager.tsx packages/patterns/google/core/experimental/gmail-sender.tsx packages/patterns/record/extraction/extractor-module.tsx`
- `deno check packages/patterns/airtable/airtable-importer.tsx packages/patterns/google/extractors/email-notes.tsx packages/patterns/google/extractors/expect-response-followup.tsx packages/patterns/google/core/experimental/gmail-label-manager.tsx packages/patterns/google/core/experimental/gmail-sender.tsx packages/patterns/record/extraction/extractor-module.tsx`
- `git diff --check`
- `deno task cf check packages/patterns/record/extraction/extractor-module.tsx --no-run`

## Notes
- A combined `deno task cf check ... --no-run` across all touched files still hits existing SES module-scope verifier failures in several importer/extractor patterns (`airtable-importer`, `email-notes`, `expect-response-followup`, `gmail-label-manager`, `gmail-sender`). Those failures were treated as pre-existing validation noise for this mechanical cleanup, so the PR relies on fmt/lint/typecheck plus the `extractor-module.tsx` transformer pass.