### PR TITLE
cleanup: normalize style and local ternaries

### DIFF
--- a/packages/patterns/form-demo.tsx
+++ b/packages/patterns/form-demo.tsx
@@ -218,7 +218,7 @@ export default pattern<FormDemoInput, FormDemoOutput>(({ people }) => {
   // Computed values
   const peopleCount = computed(() => people.get().length);
   const isEditMode = computed(() => editing.get().editing !== null);
-  const modalTitle = ifElse(isEditMode, "Edit Person", "Add Person");
+  const modalTitle = isEditMode ? "Edit Person" : "Add Person";
 
   const showModal = computed(() => modalOpen.get());
 
@@ -271,15 +271,15 @@ export default pattern<FormDemoInput, FormDemoOutput>(({ people }) => {
                         fontSize: "0.75rem",
                         padding: "2px 8px",
                         borderRadius: "4px",
-                        background: ifElse(
-                          computed(() => person.role === "admin"),
-                          "var(--cf-color-blue-100)",
-                          "var(--cf-color-gray-100)",
+                        background: computed(() =>
+                          person.role === "admin"
+                            ? "var(--cf-color-blue-100)"
+                            : "var(--cf-color-gray-100)"
                         ),
-                        color: ifElse(
-                          computed(() => person.role === "admin"),
-                          "var(--cf-color-blue-700)",
-                          "var(--cf-color-gray-700)",
+                        color: computed(() =>
+                          person.role === "admin"
+                            ? "var(--cf-color-blue-700)"
+                            : "var(--cf-color-gray-700)"
                         ),
                         width: "fit-content",
                       }}

--- a/packages/patterns/form-demo.tsx
+++ b/packages/patterns/form-demo.tsx
@@ -271,16 +271,12 @@ export default pattern<FormDemoInput, FormDemoOutput>(({ people }) => {
                         fontSize: "0.75rem",
                         padding: "2px 8px",
                         borderRadius: "4px",
-                        background: computed(() =>
-                          person.role === "admin"
-                            ? "var(--cf-color-blue-100)"
-                            : "var(--cf-color-gray-100)"
-                        ),
-                        color: computed(() =>
-                          person.role === "admin"
-                            ? "var(--cf-color-blue-700)"
-                            : "var(--cf-color-gray-700)"
-                        ),
+                        background: person.role === "admin"
+                          ? "var(--cf-color-blue-100)"
+                          : "var(--cf-color-gray-100)",
+                        color: person.role === "admin"
+                          ? "var(--cf-color-blue-700)"
+                          : "var(--cf-color-gray-700)",
                         width: "fit-content",
                       }}
                     >

--- a/packages/patterns/google/core/google-calendar-importer.tsx
+++ b/packages/patterns/google/core/google-calendar-importer.tsx
@@ -849,12 +849,10 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
                           color: cal.foregroundColor,
                           fontSize: "12px",
                           cursor: "pointer",
-                          opacity: ifElse(calendarSelectionMap[cal.id], 1, 0.4),
-                          textDecoration: ifElse(
-                            calendarSelectionMap[cal.id],
-                            "none",
-                            "line-through",
-                          ),
+                          opacity: calendarSelectionMap[cal.id] ? 1 : 0.4,
+                          textDecoration: calendarSelectionMap[cal.id]
+                            ? "none"
+                            : "line-through",
                           transition: "opacity 0.15s, text-decoration 0.15s",
                         }}
                         onClick={toggleCalendarSelection({
@@ -902,7 +900,7 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
                   onClick={toggleShowEvents({ showEvents })}
                 >
                   <span style={{ fontSize: "14px" }}>
-                    {ifElse(showEvents, "▼", "▶")}
+                    {showEvents ? "▼" : "▶"}
                   </span>
                   <h4 style={{ fontSize: "16px", margin: 0 }}>
                     {derive(

--- a/packages/patterns/shopping-list.tsx
+++ b/packages/patterns/shopping-list.tsx
@@ -422,18 +422,14 @@ export default pattern<Input, Output>(({ items, storeLayout }) => {
               {statsText}
             </span>
             <cf-button
-              variant={computed(() =>
-                viewMode.get() === "quick" ? "primary" : "secondary"
-              )}
+              variant={viewMode.get() === "quick" ? "primary" : "secondary"}
               size="sm"
               onClick={() => viewMode.set("quick")}
             >
               Quick
             </cf-button>
             <cf-button
-              variant={computed(() =>
-                viewMode.get() === "sorted" ? "primary" : "secondary"
-              )}
+              variant={viewMode.get() === "sorted" ? "primary" : "secondary"}
               size="sm"
               onClick={() => viewMode.set("sorted")}
             >

--- a/packages/patterns/shopping-list.tsx
+++ b/packages/patterns/shopping-list.tsx
@@ -422,10 +422,8 @@ export default pattern<Input, Output>(({ items, storeLayout }) => {
               {statsText}
             </span>
             <cf-button
-              variant={ifElse(
-                computed(() => viewMode.get() === "quick"),
-                "primary",
-                "secondary",
+              variant={computed(() =>
+                viewMode.get() === "quick" ? "primary" : "secondary"
               )}
               size="sm"
               onClick={() => viewMode.set("quick")}
@@ -433,10 +431,8 @@ export default pattern<Input, Output>(({ items, storeLayout }) => {
               Quick
             </cf-button>
             <cf-button
-              variant={ifElse(
-                computed(() => viewMode.get() === "sorted"),
-                "primary",
-                "secondary",
+              variant={computed(() =>
+                viewMode.get() === "sorted" ? "primary" : "secondary"
               )}
               size="sm"
               onClick={() => viewMode.set("sorted")}
@@ -496,12 +492,8 @@ export default pattern<Input, Output>(({ items, storeLayout }) => {
                           flex: 1,
                           border: "none",
                           background: "transparent",
-                          textDecoration: ifElse(
-                            item.done,
-                            "line-through",
-                            "none",
-                          ),
-                          opacity: ifElse(item.done, 0.6, 1),
+                          textDecoration: item.done ? "line-through" : "none",
+                          opacity: item.done ? 0.6 : 1,
                         }}
                       />
                       <cf-button
@@ -550,12 +542,10 @@ export default pattern<Input, Output>(({ items, storeLayout }) => {
                         style={{
                           flex: 1,
                           color: "#111827",
-                          textDecoration: ifElse(
-                            itemWithAisle.item.done,
-                            "line-through",
-                            "none",
-                          ),
-                          opacity: ifElse(itemWithAisle.item.done, 0.6, 1),
+                          textDecoration: itemWithAisle.item.done
+                            ? "line-through"
+                            : "none",
+                          opacity: itemWithAisle.item.done ? 0.6 : 1,
                         }}
                       >
                         {itemWithAisle.item.title}


### PR DESCRIPTION
## Summary
- replace stale `ifElse(...)` helper use in local-const, prop-value, and style-object positions with plain ternaries at the now-supported lowered sites
- cover the high-confidence sites in `form-demo`, `shopping-list`, and `google-calendar-importer`, including the follow-up simplification of the `form-demo` badge style props and `shopping-list` `variant` props
- leave JSX-child control-flow and lower-confidence auth-source selector rewrites out of scope

## Validation
- `deno fmt packages/patterns/form-demo.tsx packages/patterns/shopping-list.tsx packages/patterns/google/core/google-calendar-importer.tsx`
- `deno lint packages/patterns/form-demo.tsx packages/patterns/shopping-list.tsx packages/patterns/google/core/google-calendar-importer.tsx`
- `deno task check packages/patterns/form-demo.tsx packages/patterns/shopping-list.tsx`
- `deno task cf check packages/patterns/form-demo.tsx packages/patterns/shopping-list.tsx packages/patterns/google/core/google-calendar-importer.tsx --no-run`
- `git diff --check`