### PR TITLE
docs: refresh ternary lowering guidance

### DIFF
--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -58,10 +58,9 @@ Allowed inside patterns:
 |-----------|-----|
 | `onClick` or conditional UI inside `computed()` | Move the interactive element outside and use direct JSX conditionals |
 
-Plain ternaries are valid across supported lowered value-expression sites. The
-main author-facing buckets are JSX expressions, lowerable top-level
-pattern-body value-expression sites, and callback-local values inside supported
-collection callbacks.
+Plain ternaries are generally valid in normal pattern code. Prefer direct
+authored expressions over helper-owned conditional workarounds unless a site
+has been explicitly verified as problematic.
 
 ### 4. Type System and Data Shape
 

--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -58,7 +58,9 @@ Allowed inside patterns:
 |-----------|-----|
 | `onClick` or conditional UI inside `computed()` | Move the interactive element outside and use direct JSX conditionals |
 
-Ternaries are valid in JSX. The transformer auto-converts them to `ifElse()`.
+Plain ternaries are valid across common JSX-facing expression positions. The
+transformer lowers them automatically in JSX children, prop values, style/object
+properties, and similar authored sites.
 
 ### 4. Type System and Data Shape
 

--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -58,9 +58,10 @@ Allowed inside patterns:
 |-----------|-----|
 | `onClick` or conditional UI inside `computed()` | Move the interactive element outside and use direct JSX conditionals |
 
-Plain ternaries are valid across common JSX-facing expression positions. The
-transformer lowers them automatically in JSX children, prop values, style/object
-properties, and similar authored sites.
+Plain ternaries are valid across supported lowered value-expression sites. The
+main author-facing buckets are JSX expressions, lowerable top-level
+pattern-body value-expression sites, and callback-local values inside supported
+collection callbacks.
 
 ### 4. Type System and Data Shape
 

--- a/docs/common/ai/pattern-development-guide.md
+++ b/docs/common/ai/pattern-development-guide.md
@@ -207,11 +207,15 @@ buckets:
 - top-level pattern-body value-expression sites, such as:
   - returned object property values
   - variable initializers
-  - call arguments
-  - array elements
   - return expressions
 - callback-local value-expression sites inside supported reactive collection
   callbacks
+
+Some call-argument and array-element sites are also lowerable, but those can
+still route through whole-site wrapping rather than direct inner `ifElse()`
+lowering. For unusual call-root shapes, inspect the emitted output with
+`cf check --show-transformed` instead of assuming the conditional itself will
+be rewritten.
 
 ```tsx
 // Wrong
@@ -231,9 +235,10 @@ truthy. That leads to subtle incorrect rendering because ternaries inside the
 `computed()` body are plain JS, not transformer-lowered conditionals.
 
 That distinction matters: explicit computation callbacks like `computed`,
-`derive`, `action`, `lift`, and `handler` are not blanket "rewrite everywhere"
-contexts. Inside those callback bodies, ternaries follow ordinary JavaScript
-rules unless they appear inside a nested supported lowered site such as JSX.
+`derive`, `action`, `lift`, and `handler` are preserved-JavaScript control-flow
+boundaries. Inside those callback bodies, ternaries and logical operators
+follow ordinary JavaScript rules even when nested inside returned JSX, local
+consts, or object literals.
 
 ### CORS and `fetchData`
 

--- a/docs/common/ai/pattern-development-guide.md
+++ b/docs/common/ai/pattern-development-guide.md
@@ -73,6 +73,8 @@ Use the runtime, not just static reasoning:
 
 - `deno task cf check <pattern>.tsx`
 - `deno task cf check <pattern>.tsx --no-run` for faster type validation
+- `deno task cf check <pattern>.tsx --show-transformed` when you need to
+  inspect how the transformer lowered a conditional or reactive expression site
 - `deno task cf test <pattern>.test.tsx` when tests are justified
 
 Primary verification is still runtime behavior. Tests are for logic that is
@@ -195,8 +197,18 @@ callbacks.
 
 ### Conditional JSX
 
-Do not use `computed()` to gate JSX sections. Use JSX conditionals directly.
-The JSX transformer handles ternaries correctly, including nested ternaries.
+Do not use `computed()` to gate JSX sections. Use plain authored ternaries
+instead.
+
+The transformer now lowers ternaries across many common authored expression
+sites that feed JSX or returned pattern values, including:
+
+- JSX children
+- prop values
+- inline text and template literals
+- style/object property values
+- local consts later consumed by JSX
+- returned object fields
 
 ```tsx
 // Wrong
@@ -212,7 +224,8 @@ The JSX transformer handles ternaries correctly, including nested ternaries.
 ```
 
 Inside `computed()`, a `Writable<boolean>` is just a JS object and therefore
-truthy. That leads to subtle incorrect rendering.
+truthy. That leads to subtle incorrect rendering because ternaries inside the
+`computed()` body are plain JS, not transformer-lowered conditionals.
 
 ### CORS and `fetchData`
 

--- a/docs/common/ai/pattern-development-guide.md
+++ b/docs/common/ai/pattern-development-guide.md
@@ -197,25 +197,13 @@ callbacks.
 
 ### Conditional JSX
 
-Do not use `computed()` to gate JSX sections. Use plain authored ternaries at
-supported lowered value-expression sites instead.
+Do not use `computed()` to gate JSX sections. Use direct authored expressions
+instead, usually plain ternaries.
 
-The transformer now lowers plain ternaries across three main author-facing
-buckets:
-
-- JSX expressions
-- top-level pattern-body value-expression sites, such as:
-  - returned object property values
-  - variable initializers
-  - return expressions
-- callback-local value-expression sites inside supported reactive collection
-  callbacks
-
-Some call-argument and array-element sites are also lowerable, but those can
-still route through whole-site wrapping rather than direct inner `ifElse()`
-lowering. For unusual call-root shapes, inspect the emitted output with
-`cf check --show-transformed` instead of assuming the conditional itself will
-be rewritten.
+Current main handles ordinary ternaries correctly in normal pattern code, not
+just in JSX children. If you're debugging a less common site, inspect the
+emitted output with `cf check --show-transformed` instead of reasoning from old
+transformer limitations.
 
 ```tsx
 // Wrong
@@ -234,11 +222,10 @@ Inside `computed()`, a `Writable<boolean>` is just a JS object and therefore
 truthy. That leads to subtle incorrect rendering because ternaries inside the
 `computed()` body are plain JS, not transformer-lowered conditionals.
 
-That distinction matters: explicit computation callbacks like `computed`,
-`derive`, `action`, `lift`, and `handler` are preserved-JavaScript control-flow
-boundaries. Inside those callback bodies, ternaries and logical operators
-follow ordinary JavaScript rules even when nested inside returned JSX, local
-consts, or object literals.
+That distinction matters because explicit computation callbacks like
+`computed`, `derive`, `action`, `lift`, and `handler` are preserved-JavaScript
+control-flow boundaries. Inside those callback bodies, use `.get()` when you
+need the raw boolean value.
 
 ### CORS and `fetchData`
 

--- a/docs/common/ai/pattern-development-guide.md
+++ b/docs/common/ai/pattern-development-guide.md
@@ -197,18 +197,21 @@ callbacks.
 
 ### Conditional JSX
 
-Do not use `computed()` to gate JSX sections. Use plain authored ternaries
-instead.
+Do not use `computed()` to gate JSX sections. Use plain authored ternaries at
+supported lowered value-expression sites instead.
 
-The transformer now lowers ternaries across many common authored expression
-sites that feed JSX or returned pattern values, including:
+The transformer now lowers plain ternaries across three main author-facing
+buckets:
 
-- JSX children
-- prop values
-- inline text and template literals
-- style/object property values
-- local consts later consumed by JSX
-- returned object fields
+- JSX expressions
+- top-level pattern-body value-expression sites, such as:
+  - returned object property values
+  - variable initializers
+  - call arguments
+  - array elements
+  - return expressions
+- callback-local value-expression sites inside supported reactive collection
+  callbacks
 
 ```tsx
 // Wrong
@@ -226,6 +229,11 @@ sites that feed JSX or returned pattern values, including:
 Inside `computed()`, a `Writable<boolean>` is just a JS object and therefore
 truthy. That leads to subtle incorrect rendering because ternaries inside the
 `computed()` body are plain JS, not transformer-lowered conditionals.
+
+That distinction matters: explicit computation callbacks like `computed`,
+`derive`, `action`, `lift`, and `handler` are not blanket "rewrite everywhere"
+contexts. Inside those callback bodies, ternaries follow ordinary JavaScript
+rules unless they appear inside a nested supported lowered site such as JSX.
 
 ### CORS and `fetchData`
 

--- a/docs/common/capabilities/llm.md
+++ b/docs/common/capabilities/llm.md
@@ -9,13 +9,11 @@ const response = generateText({
 });
 
 // Response: { result: string, error: string, pending: boolean }
-{ifElse(response.pending,
-  <span>Generating...</span>,
-  ifElse(response.error,
-    <span>Error: {response.error}</span>,
-    <div>{response.result}</div>
-  )
-)}
+{response.pending
+  ? <span>Generating...</span>
+  : response.error
+  ? <span>Error: {response.error}</span>
+  : <div>{response.result}</div>}
 ```
 
 ---
@@ -38,17 +36,17 @@ const idea = generateObject<ProductIdea>({
 });
 
 // Response: { result: ProductIdea, error: string, pending: boolean }
-{ifElse(idea.pending,
-  <span>Generating...</span>,
-  ifElse(idea.error,
-    <span>Error: {idea.error}</span>,
+{idea.pending
+  ? <span>Generating...</span>
+  : idea.error
+  ? <span>Error: {idea.error}</span>
+  : (
     <div>
       <h3>{idea.result?.name}</h3>
       <p>{idea.result?.description}</p>
       <p>${idea.result?.price}</p>
     </div>
-  )
-)}
+  )}
 ```
 
 ## Processing Arrays
@@ -66,10 +64,9 @@ const summaries = articles.map((article) => ({
 {summaries.map(({ article, summary }) => (
   <div>
     <h3>{article.title}</h3>
-    {ifElse(summary.pending,
-      <em>Summarizing...</em>,
-      <p>{summary.result}</p>
-    )}
+    {summary.pending
+      ? <em>Summarizing...</em>
+      : <p>{summary.result}</p>}
   </div>
 ))}
 ```

--- a/docs/common/concepts/computed/computed.md
+++ b/docs/common/concepts/computed/computed.md
@@ -71,13 +71,10 @@ export default pattern<Input>(({ deck }) => ({
 
 Static strings like `[NAME]: "My Pattern"` don't need `computed()`.
 
-**Never wrap JSX in `computed()`** — the transformer automatically handles
-reactivity in JSX expressions and in many supported lowered value-expression
-sites in pattern-owned code. Important non-JSX examples include returned object
-property values, variable initializers, call arguments, array elements, return
-expressions, and callback-local values inside supported collection callbacks.
-Nested ternaries work too. See
-`docs/common/patterns/conditional.md`.
+**Never wrap JSX in `computed()`** — normal pattern code already handles
+reactive expressions directly. In current main, plain ternaries usually work
+the way you want in ordinary authored pattern code, including nested ternaries.
+See `docs/common/patterns/conditional.md`.
 
 Inside a `computed()` body, ternaries are **not** transformed — they execute
 as plain JS where a `Writable<boolean>` object is always truthy. This is
@@ -125,9 +122,9 @@ callback bodies.
 ```
 
 **Rule of thumb:** `computed()` is for deriving data (strings, numbers,
-arrays, objects). For conditional rendering or simple conditional values at
-supported lowered value-expression sites, use plain ternaries. If you're unsure
-whether a site lowers, inspect it with
+arrays, objects). For conditional rendering or other simple conditional values
+in normal pattern code, use plain ternaries. If you're unsure whether a site
+lowers, inspect it with
 `deno task cf check <pattern>.tsx --show-transformed`.
 
 Example of correct usage:

--- a/docs/common/concepts/computed/computed.md
+++ b/docs/common/concepts/computed/computed.md
@@ -72,10 +72,11 @@ export default pattern<Input>(({ deck }) => ({
 Static strings like `[NAME]: "My Pattern"` don't need `computed()`.
 
 **Never wrap JSX in `computed()`** — the transformer automatically handles
-reactivity in JSX expressions. Ternaries in JSX children position are
-automatically converted to `ifElse()`, which correctly unwraps
-OpaqueRefs. Nested ternaries work too — a ternary inside the truthy branch of
-another ternary is also transformed. See `docs/common/patterns/conditional.md`.
+reactivity in JSX expressions and many adjacent authored expression sites that
+feed JSX or returned pattern values. Ternaries in JSX children, prop values,
+style/object properties, local JSX-facing aliases, and returned object fields
+are lowered automatically. Nested ternaries work too. See
+`docs/common/patterns/conditional.md`.
 
 Inside a `computed()` body, ternaries are **not** transformed — they execute
 as plain JS where a `Writable<boolean>` object is always truthy. This is
@@ -83,8 +84,8 @@ the most common source of "conditional section always renders" bugs.
 
 ```tsx
 // ❌ WRONG - computed() for conditional JSX. The ternary inside the
-// computed body is plain JS, not transformed to ifElse(). `showForm`
-// is a Writable object (always truthy), so the form always renders.
+// computed body is plain JS, not a transformer-lowered conditional.
+// `showForm` is a Writable object (always truthy), so the form always renders.
 {computed(() => {
   if (!adminMode.get()) return null;
   return (
@@ -104,12 +105,12 @@ the most common source of "conditional section always renders" bugs.
 // This "works" because .get() returns the actual boolean, but it's
 // still unnecessary — use a JSX ternary instead.
 
-// ✅ RIGHT - Use JSX ternaries. They nest correctly.
+// ✅ RIGHT - Use plain ternaries in authored expression positions.
 {adminMode
   ? (
     <>
       {showForm
-        ? <div>Form content — both ternaries get ifElse() transforms</div>
+        ? <div>Form content — both ternaries are lowered correctly</div>
         : null}
     </>
   )
@@ -117,7 +118,9 @@ the most common source of "conditional section always renders" bugs.
 ```
 
 **Rule of thumb:** `computed()` is for deriving data (strings, numbers,
-arrays, objects). For conditional rendering, use JSX ternaries.
+arrays, objects). For conditional rendering or simple conditional values that
+feed JSX, use plain ternaries. If you're unsure whether a site lowers, inspect
+it with `deno task cf check <pattern>.tsx --show-transformed`.
 
 Example of correct usage:
 

--- a/docs/common/concepts/computed/computed.md
+++ b/docs/common/concepts/computed/computed.md
@@ -83,6 +83,12 @@ Inside a `computed()` body, ternaries are **not** transformed — they execute
 as plain JS where a `Writable<boolean>` object is always truthy. This is
 the most common source of "conditional section always renders" bugs.
 
+That current-main behavior includes ternaries nested inside returned JSX,
+callback-local aliases, object properties, and logical `&&` / `||` forms. The
+recent recursive lowering work helps in pattern-owned sites and supported
+collection callbacks, but it does not currently rescue explicit compute
+callback bodies.
+
 ```tsx
 // ❌ WRONG - computed() for conditional JSX. The ternary inside the
 // computed body is plain JS, not a transformer-lowered conditional.

--- a/docs/common/concepts/computed/computed.md
+++ b/docs/common/concepts/computed/computed.md
@@ -72,10 +72,11 @@ export default pattern<Input>(({ deck }) => ({
 Static strings like `[NAME]: "My Pattern"` don't need `computed()`.
 
 **Never wrap JSX in `computed()`** — the transformer automatically handles
-reactivity in JSX expressions and many adjacent authored expression sites that
-feed JSX or returned pattern values. Ternaries in JSX children, prop values,
-style/object properties, local JSX-facing aliases, and returned object fields
-are lowered automatically. Nested ternaries work too. See
+reactivity in JSX expressions and in many supported lowered value-expression
+sites in pattern-owned code. Important non-JSX examples include returned object
+property values, variable initializers, call arguments, array elements, return
+expressions, and callback-local values inside supported collection callbacks.
+Nested ternaries work too. See
 `docs/common/patterns/conditional.md`.
 
 Inside a `computed()` body, ternaries are **not** transformed — they execute
@@ -105,7 +106,7 @@ the most common source of "conditional section always renders" bugs.
 // This "works" because .get() returns the actual boolean, but it's
 // still unnecessary — use a JSX ternary instead.
 
-// ✅ RIGHT - Use plain ternaries in authored expression positions.
+// ✅ RIGHT - Use plain ternaries at supported lowered sites.
 {adminMode
   ? (
     <>
@@ -118,9 +119,10 @@ the most common source of "conditional section always renders" bugs.
 ```
 
 **Rule of thumb:** `computed()` is for deriving data (strings, numbers,
-arrays, objects). For conditional rendering or simple conditional values that
-feed JSX, use plain ternaries. If you're unsure whether a site lowers, inspect
-it with `deno task cf check <pattern>.tsx --show-transformed`.
+arrays, objects). For conditional rendering or simple conditional values at
+supported lowered value-expression sites, use plain ternaries. If you're unsure
+whether a site lowers, inspect it with
+`deno task cf check <pattern>.tsx --show-transformed`.
 
 Example of correct usage:
 

--- a/docs/common/concepts/jsx.md
+++ b/docs/common/concepts/jsx.md
@@ -66,11 +66,13 @@ export default pattern<Input>(({ count, items, user }) => ({
 }));
 ```
 
-### Conditional Expressions in JSX-Adjacent Sites
+### Conditional Expressions And Other Lowered Value Sites
 
-Plain ternaries work in more than just top-level JSX children. The transformer
-also lowers common authored expression sites such as prop values, style/object
-properties, and local aliases later consumed by JSX.
+Plain ternaries work in more than just JSX children. The transformer also
+lowers other supported value-expression sites in pattern-owned code, including
+returned object property values, variable initializers, call arguments, array
+elements, return expressions, and callback-local values inside supported
+collection callbacks.
 
 ```tsx
 export default pattern<Input>(({ count, items, user }) => {

--- a/docs/common/concepts/jsx.md
+++ b/docs/common/concepts/jsx.md
@@ -65,3 +65,32 @@ export default pattern<Input>(({ count, items, user }) => ({
   ),
 }));
 ```
+
+### Conditional Expressions in JSX-Adjacent Sites
+
+Plain ternaries work in more than just top-level JSX children. The transformer
+also lowers common authored expression sites such as prop values, style/object
+properties, and local aliases later consumed by JSX.
+
+```tsx
+export default pattern<Input>(({ count, items, user }) => {
+  const badgeText = count > 10 ? "High" : "Low";
+
+  return {
+    [UI]: (
+      <div
+        style={{ opacity: count > 0 ? 1 : 0.5 }}
+        data-state={user.name ? "ready" : "empty"}
+      >
+        <button disabled={items.length === 0}>
+          {items.length === 0 ? "No items" : "Open list"}
+        </button>
+        <span>{badgeText}</span>
+      </div>
+    ),
+  };
+});
+```
+
+If you're debugging a less common expression site, inspect the emitted source
+with `deno task cf check <pattern>.tsx --show-transformed`.

--- a/docs/common/concepts/jsx.md
+++ b/docs/common/concepts/jsx.md
@@ -68,11 +68,9 @@ export default pattern<Input>(({ count, items, user }) => ({
 
 ### Conditional Expressions And Other Lowered Value Sites
 
-Plain ternaries work in more than just JSX children. The transformer also
-lowers other supported value-expression sites in pattern-owned code, including
-returned object property values, variable initializers, call arguments, array
-elements, return expressions, and callback-local values inside supported
-collection callbacks.
+Plain ternaries work in more than just JSX children. In current main, they
+also work across most ordinary value-expression positions in normal pattern
+code.
 
 ```tsx
 export default pattern<Input>(({ count, items, user }) => {
@@ -94,5 +92,5 @@ export default pattern<Input>(({ count, items, user }) => {
 });
 ```
 
-If you're debugging a less common expression site, inspect the emitted source
-with `deno task cf check <pattern>.tsx --show-transformed`.
+If you're debugging a less common site, inspect the emitted source with
+`deno task cf check <pattern>.tsx --show-transformed`.

--- a/docs/common/patterns/conditional.md
+++ b/docs/common/patterns/conditional.md
@@ -28,8 +28,6 @@ The main author-facing buckets are:
 - top-level pattern-body value-expression sites:
   - returned object property values
   - variable initializers
-  - call arguments
-  - array elements
   - return expressions
 - callback-local value-expression sites inside supported reactive collection
   callbacks
@@ -38,16 +36,22 @@ In transformer source terms, those correspond to the current container kinds
 `jsx-expression`, `return-expression`, `variable-initializer`,
 `call-argument`, `object-property`, and `array-element`.
 
+The last two container kinds are a little more nuanced in practice: some
+call-argument and array-element shapes lower by wrapping the containing
+expression rather than by rewriting the inner conditional directly. If the
+condition is an unusual cell-like value at one of those sites, inspect the
+transformed output before assuming `ifElse()` lowering.
+
 You usually do not need to author `ifElse()` directly for render-time
 conditionals or simple conditional values in those sites. Authored helper
 control flow remains supported when it is the clearest way to express the code.
 
 ## Keep `computed()` for Data, Not UI Gating
 
-Inside a `computed()` body, the callback body itself is not a blanket lowered
-value-expression site. Ternaries there are plain JavaScript unless they occur
-inside a nested supported lowered site such as JSX. That means
-`Writable<boolean>` values are just truthy objects there.
+Inside a `computed()` body, the callback body itself is not a lowered
+value-expression site. Ternaries and logical operators there stay plain
+JavaScript even when nested inside returned JSX. That means `Writable<boolean>`
+values are still just truthy objects there.
 
 Use plain ternaries at supported lowered value-expression sites instead of
 wrapping JSX in `computed()`. If you're unsure whether a site lowers the way

--- a/docs/common/patterns/conditional.md
+++ b/docs/common/patterns/conditional.md
@@ -1,7 +1,9 @@
 ## Prefer Plain Ternaries
 
-Use regular ternary operators at supported lowered value-expression sites. The
-transformer recognizes a shared set of authored container kinds, not just JSX.
+Use regular ternary operators directly in normal pattern code. On current main,
+the transformer handles ordinary authored ternaries in JSX and most other
+common value-expression positions, so you usually do not need to author
+`ifElse()` directly.
 
 ```tsx
 // JSX expressions
@@ -22,40 +24,21 @@ const modalTitle = editing ? "Edit Person" : "Add Person";
 {score >= 90 ? "A" : score >= 80 ? "B" : "C"}
 ```
 
-The main author-facing buckets are:
-
-- JSX expressions
-- top-level pattern-body value-expression sites:
-  - returned object property values
-  - variable initializers
-  - return expressions
-- callback-local value-expression sites inside supported reactive collection
-  callbacks
-
-In transformer source terms, those correspond to the current container kinds
-`jsx-expression`, `return-expression`, `variable-initializer`,
-`call-argument`, `object-property`, and `array-element`.
-
-The last two container kinds are a little more nuanced in practice: some
-call-argument and array-element shapes lower by wrapping the containing
-expression rather than by rewriting the inner conditional directly. If the
-condition is an unusual cell-like value at one of those sites, inspect the
-transformed output before assuming `ifElse()` lowering.
-
-You usually do not need to author `ifElse()` directly for render-time
-conditionals or simple conditional values in those sites. Authored helper
-control flow remains supported when it is the clearest way to express the code.
+This includes JSX expressions, common returned values, variable initializers,
+and many callback-local expressions. If you're debugging a less common site,
+inspect the emitted source with
+`deno task cf check <pattern>.tsx --show-transformed` rather than guessing
+about the lowering.
 
 ## Keep `computed()` for Data, Not UI Gating
 
-Inside a `computed()` body, the callback body itself is not a lowered
-value-expression site. Ternaries and logical operators there stay plain
-JavaScript even when nested inside returned JSX. That means `Writable<boolean>`
-values are still just truthy objects there.
+Inside a `computed()` body, ternaries and logical operators stay plain
+JavaScript even when nested inside returned JSX. That means
+`Writable<boolean>` values are still just truthy objects there.
 
-Use plain ternaries at supported lowered value-expression sites instead of
-wrapping JSX in `computed()`. If you're unsure whether a site lowers the way
-you expect, inspect it with
+Use plain ternaries in normal pattern code instead of wrapping JSX in
+`computed()`. If you're unsure whether a site lowers the way you expect,
+inspect it with
 `deno task cf check <pattern>.tsx --show-transformed`.
 
 ## See Also

--- a/docs/common/patterns/conditional.md
+++ b/docs/common/patterns/conditional.md
@@ -7,7 +7,7 @@ transformer recognizes a shared set of authored container kinds, not just JSX.
 // JSX expressions
 {show ? <div>Content</div> : null}
 
-// Returned object property values
+// JSX prop/text values
 <button disabled={loading}>
   {loading ? "Loading..." : "Load"}
 </button>

--- a/docs/common/patterns/conditional.md
+++ b/docs/common/patterns/conditional.md
@@ -1,39 +1,51 @@
-## Ternaries in JSX
+## Prefer Plain Ternaries
 
-Use regular ternary operators in JSX - the transformer automatically converts them to `ifElse()`:
+Use regular ternary operators in authored pattern code when the conditional
+result flows into JSX or returned pattern values. The transformer lowers many
+common expression sites automatically.
 
 ```tsx
-// ✅ Just use ternaries - they're transformed automatically
+// JSX children
 {show ? <div>Content</div> : null}
-{user.isActive ? "Active" : "Inactive"}
-{count > 10 ? "High" : "Low"}
 
-// ✅ Nested ternaries work too
+// Text labels and prop/style values
+<button disabled={loading}>
+  {loading ? "Loading..." : "Load"}
+</button>
+<div style={{ opacity: done ? 0.6 : 1 }}>
+  {done ? "Done" : "Todo"}
+</div>
+
+// Local aliases used by JSX
+const modalTitle = editing ? "Edit Person" : "Add Person";
+
+// Nested ternaries work too
 {score >= 90 ? "A" : score >= 80 ? "B" : "C"}
 ```
 
-You don't need to use `ifElse()` explicitly in JSX.
+Common lowered sites include:
 
-## Using ifElse() Directly
+- JSX children
+- prop values
+- inline text and template literals
+- style/object property values
+- local consts later consumed by JSX
+- returned object fields
 
-You can use `ifElse()` explicitly outside JSX when needed:
+You usually do not need to author `ifElse()` directly for render-time
+conditionals.
 
-```typescript
-const message = ifElse(
-  user.isLoggedIn,
-  str`Welcome back, ${user.name}!`,
-  "Please log in"
-);
+## Keep `computed()` for Data, Not UI Gating
 
-const processedItems = items.map(item =>
-  ifElse(
-    item.isValid,
-    () => processItem(item),
-    () => ({ ...item, error: "Invalid" })
-  )
-);
-```
+Inside a `computed()` body, ternaries are plain JavaScript, not transformer
+lowered conditionals. That means `Writable<boolean>` values are just truthy
+objects there.
+
+Use plain ternaries in authored expression positions instead of wrapping JSX in
+`computed()`. If you're unsure whether a site lowers the way you expect, inspect
+it with `deno task cf check <pattern>.tsx --show-transformed`.
 
 ## See Also
 
+- [computed()](../concepts/computed/computed.md) — when to derive data vs gate UI
 - [View Switching](./view-switching.md) — switching between entire sub-patterns or cell references

--- a/docs/common/patterns/conditional.md
+++ b/docs/common/patterns/conditional.md
@@ -1,14 +1,13 @@
 ## Prefer Plain Ternaries
 
-Use regular ternary operators in authored pattern code when the conditional
-result flows into JSX or returned pattern values. The transformer lowers many
-common expression sites automatically.
+Use regular ternary operators at supported lowered value-expression sites. The
+transformer recognizes a shared set of authored container kinds, not just JSX.
 
 ```tsx
-// JSX children
+// JSX expressions
 {show ? <div>Content</div> : null}
 
-// Text labels and prop/style values
+// Returned object property values
 <button disabled={loading}>
   {loading ? "Loading..." : "Load"}
 </button>
@@ -16,34 +15,44 @@ common expression sites automatically.
   {done ? "Done" : "Todo"}
 </div>
 
-// Local aliases used by JSX
+// Variable initializers
 const modalTitle = editing ? "Edit Person" : "Add Person";
 
 // Nested ternaries work too
 {score >= 90 ? "A" : score >= 80 ? "B" : "C"}
 ```
 
-Common lowered sites include:
+The main author-facing buckets are:
 
-- JSX children
-- prop values
-- inline text and template literals
-- style/object property values
-- local consts later consumed by JSX
-- returned object fields
+- JSX expressions
+- top-level pattern-body value-expression sites:
+  - returned object property values
+  - variable initializers
+  - call arguments
+  - array elements
+  - return expressions
+- callback-local value-expression sites inside supported reactive collection
+  callbacks
+
+In transformer source terms, those correspond to the current container kinds
+`jsx-expression`, `return-expression`, `variable-initializer`,
+`call-argument`, `object-property`, and `array-element`.
 
 You usually do not need to author `ifElse()` directly for render-time
-conditionals.
+conditionals or simple conditional values in those sites. Authored helper
+control flow remains supported when it is the clearest way to express the code.
 
 ## Keep `computed()` for Data, Not UI Gating
 
-Inside a `computed()` body, ternaries are plain JavaScript, not transformer
-lowered conditionals. That means `Writable<boolean>` values are just truthy
-objects there.
+Inside a `computed()` body, the callback body itself is not a blanket lowered
+value-expression site. Ternaries there are plain JavaScript unless they occur
+inside a nested supported lowered site such as JSX. That means
+`Writable<boolean>` values are just truthy objects there.
 
-Use plain ternaries in authored expression positions instead of wrapping JSX in
-`computed()`. If you're unsure whether a site lowers the way you expect, inspect
-it with `deno task cf check <pattern>.tsx --show-transformed`.
+Use plain ternaries at supported lowered value-expression sites instead of
+wrapping JSX in `computed()`. If you're unsure whether a site lowers the way
+you expect, inspect it with
+`deno task cf check <pattern>.tsx --show-transformed`.
 
 ## See Also
 

--- a/docs/common/patterns/navigation.md
+++ b/docs/common/patterns/navigation.md
@@ -83,5 +83,5 @@ See `packages/patterns/reading-list/` for a complete implementation:
 
 - [Writable Methods](../concepts/types-and-schemas/writable.md) - `.key()` and other methods
 - [Two-Way Binding](./two-way-binding.md) - `$value` binding syntax
-- [Conditional Rendering](./conditional.md) - Using ifElse for show/hide
+- [Conditional Rendering](./conditional.md) - Plain ternaries for show/hide
 - [View Switching](./view-switching.md) - Switching between views inline (without navigation)

--- a/docs/common/patterns/view-switching.md
+++ b/docs/common/patterns/view-switching.md
@@ -138,4 +138,4 @@ The `.for("activeTab")` call makes the tab state durable (persisted by key). See
 
 - [Pattern Composition](./composition.md) — embedding sub-patterns in the vdom
 - [Navigation](./navigation.md) — `navigateTo()` for drill-down to detail views
-- [Conditional Rendering](./conditional.md) — `ifElse` for show/hide
+- [Conditional Rendering](./conditional.md) — plain ternaries for show/hide

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -326,6 +326,38 @@ structurally representable.
 This inference runs through `collectFunctionSchemaTypeNodes` via
 `inferReturnType`, object-literal recovery, and direct projection recovery.
 
+### 6.7 Lowerable Expression-Site Categories
+
+The shared expression-site policy recognizes six authored container kinds via
+`getExpressionContainerKind`:
+
+- `jsx-expression`
+- `return-expression`
+- `variable-initializer`
+- `call-argument`
+- `object-property`
+- `array-element`
+
+Those container kinds are the raw building blocks for the author-facing buckets
+described in the target-language spec:
+
+- JSX expressions
+- top-level pattern-body value-expression sites
+- callback-local value-expression sites inside supported reactive collection
+  callbacks
+
+`findLowerableExpressionSite` walks outward through enclosing pattern-context
+containers until it finds the nearest lowerable site admitted by
+`classifyExpressionSiteHandling`.
+
+`findPreferredNestedLowerableExpressionSite` is narrower: it only picks nested
+structural sites with container kinds `call-argument`, `object-property`, or
+`array-element`.
+
+These categories do not mean "rewrite every descendant expression." Explicit
+computation callbacks still create their own ownership boundary, and every site
+must separately satisfy the shared handling policy.
+
 ## 7. JSX Expression Site Routing And Early Rewriting
 
 `JsxExpressionSiteRouterTransformer` runs only when helper import is present.

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -358,11 +358,11 @@ These categories do not mean "rewrite every descendant expression." Explicit
 computation callbacks still create their own ownership boundary, and every site
 must separately satisfy the shared handling policy.
 
-In particular, current-main explicit compute callbacks preserve authored
-JavaScript control flow even for nested JSX ternaries/logicals inside the
-callback body. The recent recursive lowering work applies to pattern-owned
-sites and supported collection callbacks, not to explicit compute callback
-bodies.
+In particular, explicit compute callbacks remain an ownership boundary for
+recursive lowering. That boundary does not disappear just because the callback
+returns JSX: ternaries and logical control flow inside the compute callback
+body stay authored JavaScript rather than recursively lowered helper control
+flow.
 
 ## 7. JSX Expression Site Routing And Early Rewriting
 

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -358,6 +358,12 @@ These categories do not mean "rewrite every descendant expression." Explicit
 computation callbacks still create their own ownership boundary, and every site
 must separately satisfy the shared handling policy.
 
+In particular, current-main explicit compute callbacks preserve authored
+JavaScript control flow even for nested JSX ternaries/logicals inside the
+callback body. The recent recursive lowering work applies to pattern-owned
+sites and supported collection callbacks, not to explicit compute callback
+bodies.
+
 ## 7. JSX Expression Site Routing And Early Rewriting
 
 `JsxExpressionSiteRouterTransformer` runs only when helper import is present.

--- a/docs/specs/ts-transformer/ts_transformers_lowering_contract.md
+++ b/docs/specs/ts-transformer/ts_transformers_lowering_contract.md
@@ -26,6 +26,9 @@ the divergence in descriptive docs rather than weakening the contract.
 This contract applies to lowering of supported reactive expression constructs,
 especially:
 
+- shared lowered value-expression sites (`jsx-expression`,
+  `return-expression`, `variable-initializer`, `call-argument`,
+  `object-property`, `array-element`)
 - reactive control flow
 - reactive collection operators
 - property/element access over reactive values

--- a/docs/specs/ts-transformer/ts_transformers_review_guide.md
+++ b/docs/specs/ts-transformer/ts_transformers_review_guide.md
@@ -44,8 +44,12 @@ for this PR is:
   - explicit computation callbacks (`computed`, `derive`, `action`, `lift`,
     `handler`)
   - supported reactive collection callbacks (`map` / `filter` / `flatMap`)
-  - top-level lowerable value expressions such as direct property access,
-    element access with representable keys, and direct receiver-method roots
+  - top-level pattern-body lowerable value-expression sites such as returned
+    object property values, variable initializers, call arguments, array
+    elements, return expressions, direct property/element access, and direct
+    receiver-method roots
+  - callback-local lowerable value-expression sites inside supported reactive
+    collection callbacks
   - JSX sink chains over structural array values, for example
     `.filter(...).join(", ")`
   - true-cell `.key(...)`, plus true-cell `.get()` only inside JSX, authored

--- a/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
@@ -30,7 +30,9 @@ not silently let implementation accident become language policy.
 
 This v1 draft focuses on the **reactive expression language inside patterns**:
 
-- JSX expression sites
+- supported lowered value-expression sites (`jsx-expression`,
+  `return-expression`, `variable-initializer`, `call-argument`,
+  `object-property`, `array-element`)
 - helper-owned control flow (`ifElse`, `when`, `unless`)
 - collection operators over reactive receivers
 - direct reactive property/element access
@@ -59,7 +61,8 @@ Each construct family is classified as one of:
 | --- | --- | --- |
 | Reactive property access in JSX or helper-owned expressions | Supported | Authored reactive reads like `state.user.name` should remain natural and lower to explicit reactive access as needed |
 | Reactive element access with static or known-symbol keys | Supported | Forms like `items[0]`, `item[NAME]`, `state["foo"]` should lower predictably when the access path is statically representable |
-| Reactive control flow in JSX (`?:`, `&&`, `||`, `??`) | Supported | Reactive conditions and branch values should preserve authored JavaScript control-flow meaning |
+| Reactive ternary control flow in supported lowered value-expression sites | Supported | Authored `cond ? x : y` should preserve JavaScript branch meaning in JSX, top-level pattern-body value sites, and callback-local values inside supported collection callbacks |
+| Reactive logical control flow in supported lowered pattern-owned expression sites (`&&`, `||`, `??`) | Supported | Reactive short-circuiting should preserve authored JavaScript meaning where the expression-site policy admits lowering |
 | Authored helper control flow (`ifElse`, `when`, `unless`) | Supported | These are first-class reactive control-flow forms, not mere implementation helpers |
 | `map` / `filter` / `flatMap` on reactive receivers in pattern-facing contexts | Supported | These operators are core language forms and may be structurally rewritten to explicit reactive collection operators |
 | Callback-local plain JS arrays in rewritten callbacks | Supported | Plain JS arrays inside callbacks stay plain; they are not implicitly promoted into pattern-owned array operators |
@@ -85,6 +88,32 @@ The matrix above is the policy summary. This section states the same boundary
 in author-facing terms: **what kinds of expressions belong in each authored
 context.**
 
+### Supported Lowered Value-Expression Sites
+
+The shared lowering model starts from a small set of recognized authored
+container kinds:
+
+- `jsx-expression`
+- `return-expression`
+- `variable-initializer`
+- `call-argument`
+- `object-property`
+- `array-element`
+
+Those container kinds appear to authors in three main buckets:
+
+1. JSX expressions
+2. top-level pattern-body value-expression sites such as returned object
+   property values, variable initializers, call arguments, array elements, and
+   direct function return expressions
+3. callback-local value-expression sites inside supported reactive collection
+   callbacks
+
+Explicit computation callbacks such as `computed`, `derive`, `action`, `lift`,
+and `handler` are important boundaries, but their bodies are **not** blanket
+"lower everything here" regions. Inner expressions lower only when they appear
+inside one of the supported container kinds above.
+
 ### Top-Level Pattern Body
 
 The top-level pattern body should stay declarative.
@@ -94,6 +123,7 @@ The top-level pattern body should stay declarative.
 ```ts
 pattern(({ items, show }) => ({
   upper: items[0].name.toUpperCase(),
+  title: show ? "Visible" : "Hidden",
   visibleCount: ifElse(show, items.length, 0),
   [UI]: <div>{items.map((item) => item.name)}</div>,
 }));
@@ -109,6 +139,8 @@ pattern(({ user, count }) => ({
 
 Why:
 
+- top-level pattern-body value-expression sites participate in the shared
+  lowering model
 - top-level helper control flow is part of the language
 - top-level receiver-method roots are supported at lowerable non-JSX
   expression sites
@@ -202,6 +234,7 @@ items.map((item) => <span>{item.name.toUpperCase()}</span>)
 Why:
 
 - the outer callback belongs to the supported reactive collection operator
+- callback-local value-expression sites participate in the shared lowering model
 - structural access, receiver-method value expressions, helper control flow,
   and nested JSX-local expressions are valid here
 - inner plain arrays stay plain JS and are not implicitly promoted into

--- a/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
@@ -111,8 +111,9 @@ Those container kinds appear to authors in three main buckets:
 
 Explicit computation callbacks such as `computed`, `derive`, `action`, `lift`,
 and `handler` are important boundaries, but their bodies are **not** blanket
-"lower everything here" regions. Inner expressions lower only when they appear
-inside one of the supported container kinds above.
+"lower everything here" regions. The shared container list above does not imply
+that nested compute-context JSX/control-flow receives pattern-context lowering;
+current-main behavior preserves authored JavaScript control flow there.
 
 ### Top-Level Pattern Body
 

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -90,9 +90,8 @@ export default pattern<Input>(({ deck }) => ({
 ### Correct Conditional Rendering
 
 ```typescript
-// Both are valid - ternaries auto-transform to ifElse()
+// Prefer plain ternaries in authored pattern code
 return <>{showDetails ? <div>Details content</div> : null}</>;
-return <>{ifElse(showDetails, <div>Details content</div>, null)}</>;
 ```
 
 ### Visual Review Reminder

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -90,7 +90,7 @@ export default pattern<Input>(({ deck }) => ({
 ### Correct Conditional Rendering
 
 ```typescript
-// Prefer plain ternaries at supported lowered value-expression sites
+// Prefer plain ternaries in normal pattern code
 return <>{showDetails ? <div>Details content</div> : null}</>;
 ```
 

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -90,7 +90,7 @@ export default pattern<Input>(({ deck }) => ({
 ### Correct Conditional Rendering
 
 ```typescript
-// Prefer plain ternaries in authored pattern code
+// Prefer plain ternaries at supported lowered value-expression sites
 return <>{showDetails ? <div>Details content</div> : null}</>;
 ```
 

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -9,6 +9,14 @@ Start with the shared pattern development guidance in:
 
 Read that guide first. It is the canonical reference.
 
+When you're unsure whether a reactive expression site lowers the way you expect,
+inspect the emitted source directly with:
+
+- `deno task cf check <pattern>.tsx --show-transformed`
+
+Current main lowers plain ternaries across many common authored expression
+sites, not just top-level JSX children.
+
 Pay special attention to its SES authoring section before adding module-scope
 setup, timers, or time/random helpers. The current authored escape hatches are
 `safeDateNow()` and `nonPrivateRandom()`.

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -14,8 +14,11 @@ inspect the emitted source directly with:
 
 - `deno task cf check <pattern>.tsx --show-transformed`
 
-Current main lowers plain ternaries across many common authored expression
-sites, not just top-level JSX children.
+Current main lowers plain ternaries across multiple supported lowered
+value-expression sites, not just JSX expressions. Important examples include
+top-level object-property values, variable initializers, call arguments, array
+elements, return expressions, and callback-local values inside supported
+collection callbacks.
 
 Pay special attention to its SES authoring section before adding module-scope
 setup, timers, or time/random helpers. The current authored escape hatches are

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -14,11 +14,9 @@ inspect the emitted source directly with:
 
 - `deno task cf check <pattern>.tsx --show-transformed`
 
-Current main lowers plain ternaries across multiple supported lowered
-value-expression sites, not just JSX expressions. Important examples include
-top-level object-property values, variable initializers, call arguments, array
-elements, return expressions, and callback-local values inside supported
-collection callbacks.
+Current main handles plain ternaries well in normal pattern code. Prefer direct
+authored expressions first; if an unusual site seems ambiguous, inspect the
+emitted source rather than guessing.
 
 Pay special attention to its SES authoring section before adding module-scope
 setup, timers, or time/random helpers. The current authored escape hatches are


### PR DESCRIPTION
## Summary
- update the `pattern-dev` and `pattern-critic` skills to point agents at `cf check --show-transformed` and to prefer plain ternaries at supported lowered value-expression sites
- refresh the main pattern-authoring docs (`pattern-development-guide`, `conditional`, `computed`, `jsx`) so they describe the shared expression-site model instead of framing ternaries as JSX-child-only
- extend the transformer spec docs (`target_pattern_language_spec`, `current_behavior_spec`, `lowering_contract`, `review_guide`) so the normative language now names the actual lowered container kinds and author-facing buckets
- pin an important current-main nuance: explicit compute callbacks still preserve authored JS control flow even for nested returned JSX ternaries/logicals, and call-argument / array-element sites can still be more nuanced than the highest-confidence direct JSX/object-property/local-const cases
- align adjacent docs/examples (`pattern-critique-guide`, plus the existing navigation/view-switching/llm updates in the branch) so they no longer present authored `ifElse(...)` or JSX-centric shorthand as the default mental model

## Validation
- `git diff --check`
- `rg -n "JSX-facing|feed JSX|top-level JSX children|JSX-adjacent|returned pattern values" docs skills`
- probe with `deno task cf check packages/patterns/gideon-tests/_tmp-computed-conditional-probe.tsx --show-transformed --no-run` before deleting the temp file, to verify current compute-callback ternary/logical behavior directly