### PR TITLE
Fix callback-local ordinary call-root lowering ownership

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -583,17 +583,17 @@ Current-main behavior distinguishes three buckets for non-JSX authored sites:
    - inside those callbacks, authored conditionals stay authored JS inside the
      callback body rather than being rewritten to helper control flow
 3. **supported collection-callback locals**
-   - callback-local structural sites such as `call-argument`,
-     `object-property`, `array-element`, and plain conditional
-     `variable-initializer` expressions prefer direct inner control-flow
-     lowering (for example `?:` to `ifElse(...)`)
-   - direct callback `return-expression` ordinary call roots still join the
-     shared ordinary-call slice and lower as whole callback-local
-     `derive(...)` wrappers
+   - callback-local **ordinary call roots** now join the shared ordinary-call
+     slice across `variable-initializer`, `object-property`, `array-element`,
+     and direct `return-expression` sites, so the whole call lowers as a
+     callback-local `derive(...)`
+   - callback-local **plain structural control-flow sites** that are not under
+     an owning ordinary call root still lower directly (for example bare
+     conditional `object-property` / `array-element` / `variable-initializer`
+     expressions lowering to `ifElse(...)`)
 
-In other words, the current split is closer to **call-root vs nested structural
-site ownership** than to a fixed per-container rule, with the main callback
-exception being direct return-expression call roots.
+In other words, the split is now explicitly **call-root vs nested structural
+site ownership** rather than a special-case callback return-expression rule.
 
 ## 10. Schema Injection
 

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -566,6 +566,35 @@ Primary behaviors:
 - registers capability summaries for transformed callbacks/builders for
   downstream schema shrinking/wrapping
 
+#### 9.7.1 Current non-JSX expression-site split
+
+Current-main behavior distinguishes three buckets for non-JSX authored sites:
+
+1. **top-level pattern-owned ordinary call roots**
+   - when the authored site root is an ordinary call (for example
+     `identity(state.done ? "Done" : "Pending")`), the shared expression-site
+     path whole-wraps that call in `derive(...)`
+   - this applies across non-JSX container kinds such as
+     `variable-initializer`, `object-property`, `array-element`, and
+     `return-expression`
+2. **explicit compute callbacks**
+   - `computed` / `derive` / `action` / `lift` / `handler` callbacks remain the
+     explicit reactive boundary
+   - inside those callbacks, authored conditionals stay authored JS inside the
+     callback body rather than being rewritten to helper control flow
+3. **supported collection-callback locals**
+   - callback-local structural sites such as `call-argument`,
+     `object-property`, `array-element`, and plain conditional
+     `variable-initializer` expressions prefer direct inner control-flow
+     lowering (for example `?:` to `ifElse(...)`)
+   - direct callback `return-expression` ordinary call roots still join the
+     shared ordinary-call slice and lower as whole callback-local
+     `derive(...)` wrappers
+
+In other words, the current split is closer to **call-root vs nested structural
+site ownership** than to a fixed per-container rule, with the main callback
+exception being direct return-expression call roots.
+
 ## 10. Schema Injection
 
 `SchemaInjectionTransformer` runs only when helper import is present. It injects

--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -15,6 +15,7 @@ import {
   getExpressionContainerKind,
   isControlFlowRewriteExpression,
   isDirectArrayMethodRootExpression,
+  shouldPreferArrayMethodSharedCallRootSite,
 } from "./expression-site-policy.ts";
 import { rewriteExpression } from "./expression-rewrite/mod.ts";
 import {
@@ -722,6 +723,7 @@ export function rewriteArrayMethodCallbackExpressionSites(
     }
 
     if (
+      !shouldPreferArrayMethodSharedCallRootSite(expression, context, analyze) &&
       findPreferredNestedLowerableExpressionSite(expression, context, analyze)
     ) {
       return undefined;

--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -723,7 +723,11 @@ export function rewriteArrayMethodCallbackExpressionSites(
     }
 
     if (
-      !shouldPreferArrayMethodSharedCallRootSite(expression, context, analyze) &&
+      !shouldPreferArrayMethodSharedCallRootSite(
+        expression,
+        context,
+        analyze,
+      ) &&
       findPreferredNestedLowerableExpressionSite(expression, context, analyze)
     ) {
       return undefined;

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -312,6 +312,60 @@ function isSharedPostClosureCallRootKind(
   return kind === "ordinary-call" || kind === "parameterized-inline-call";
 }
 
+const STRUCTURAL_NESTED_CONTAINER_KINDS = new Set<ExpressionContainerKind>([
+  "call-argument",
+  "object-property",
+  "array-element",
+]);
+
+const ARRAY_METHOD_SHARED_CALL_ROOT_CONTAINER_KINDS = new Set<
+  ExpressionContainerKind
+>([
+  "return-expression",
+  "object-property",
+  "array-element",
+]);
+
+export function shouldPreferArrayMethodSharedCallRootSite(
+  expression: ts.Expression,
+  context: TransformationContext,
+  analyze: AnalyzeFn,
+): boolean {
+  const siteInfo = getExpressionSiteCallRootPolicyInfo(
+    expression,
+    context,
+    analyze,
+  );
+  return siteInfo.arrayMethodOwned &&
+    isSharedPostClosureCallRootKind(siteInfo.callRootKind) &&
+    !isControlFlowRewriteExpression(expression);
+}
+
+function hasEnclosingArrayMethodSharedCallRootOwner(
+  expression: ts.Expression,
+  context: TransformationContext,
+  analyze: AnalyzeFn,
+): boolean {
+  let current: ts.Node | undefined = expression.parent;
+
+  while (current) {
+    if (ts.isFunctionLike(current)) {
+      return false;
+    }
+
+    if (
+      ts.isCallExpression(current) &&
+      shouldPreferArrayMethodSharedCallRootSite(current, context, analyze)
+    ) {
+      return true;
+    }
+
+    current = current.parent;
+  }
+
+  return false;
+}
+
 function isEligiblePatternOwnedWrapperCallbackSite(
   expression: ts.Expression,
   context: TransformationContext,
@@ -887,6 +941,13 @@ export function classifyExpressionSiteHandling(
     return { kind: "skip", reason: "non-pattern-context" };
   }
 
+  if (
+    STRUCTURAL_NESTED_CONTAINER_KINDS.has(containerKind) &&
+    hasEnclosingArrayMethodSharedCallRootOwner(expression, context, analyze)
+  ) {
+    return { kind: "skip", reason: "not-lowerable" };
+  }
+
   if (containerKind === "jsx-expression") {
     if (siteInfo.arrayMethodOwned) {
       return ownedDecision(
@@ -979,10 +1040,8 @@ export function classifyExpressionSiteHandling(
   }
 
   if (
-    siteInfo.arrayMethodOwned &&
-    isSharedPostClosureCallRootKind(siteInfo.callRootKind) &&
-    !siteInfo.controlFlowRewriteRoot &&
-    containerKind === "return-expression"
+    ARRAY_METHOD_SHARED_CALL_ROOT_CONTAINER_KINDS.has(containerKind) &&
+    shouldPreferArrayMethodSharedCallRootSite(expression, context, analyze)
   ) {
     return sharedDecision();
   }
@@ -1099,6 +1158,17 @@ export function findLowerableExpressionSite(
             containerKind: site.containerKind,
           };
         }
+
+        if (
+          decision.kind === "skip" &&
+          containerKind === "variable-initializer" &&
+          shouldPreferArrayMethodSharedCallRootSite(current, context, analyze)
+        ) {
+          return {
+            expression: current,
+            containerKind,
+          };
+        }
       }
     }
 
@@ -1107,12 +1177,6 @@ export function findLowerableExpressionSite(
 
   return deferredArrayMethodReceiverSite;
 }
-
-const STRUCTURAL_NESTED_CONTAINER_KINDS = new Set<ExpressionContainerKind>([
-  "call-argument",
-  "object-property",
-  "array-element",
-]);
 
 export function findPreferredNestedLowerableExpressionSite(
   expression: ts.Expression,

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
@@ -42,7 +42,7 @@ export const objectAndArray = pattern((state) => {
             "enum": ["Done", "Pending"]
         } as const satisfies __cfHelpers.JSONSchema, { state: {
                 done: state.key("done")
-            } }, ({ state }) => identity(state.done ? "Done" : "Pending")),
+            } }, ({ state }) => identity(state.done ? "Done" : "Pending")).for(["view", "value"], true),
         list: [__cfHelpers.derive({
                 type: "object",
                 properties: {
@@ -61,7 +61,7 @@ export const objectAndArray = pattern((state) => {
                 "enum": ["Done", "Pending"]
             } as const satisfies __cfHelpers.JSONSchema, { state: {
                     done: state.key("done")
-                } }, ({ state }) => identity(state.done ? "Done" : "Pending"))],
+                } }, ({ state }) => identity(state.done ? "Done" : "Pending")).for(["view", "list", 0], true)]
     };
     return view;
 }, {
@@ -105,7 +105,7 @@ export default pattern((state) => __cfHelpers.derive({
     "enum": ["Done", "Pending"]
 } as const satisfies __cfHelpers.JSONSchema, { state: {
         done: state.key("done")
-    } }, ({ state }) => identity(state.done ? "Done" : "Pending")), {
+    } }, ({ state }) => identity(state.done ? "Done" : "Pending")).for("__patternResult", true), {
     type: "object",
     properties: {
         done: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
@@ -1,0 +1,121 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { pattern } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+const identity = __cfHardenFn(<T,>(value: T) => value);
+// FIXTURE: pattern-call-root-containers
+// Verifies: top-level ordinary call roots whole-wrap consistently across
+//   non-JSX container kinds instead of lowering only their nested conditional
+//   arguments.
+//   { value: identity(state.done ? "Done" : "Pending") }
+//   → { value: derive(..., ({ state }) => identity(state.done ? "Done" : "Pending")) }
+//   [identity(state.done ? "Done" : "Pending")]
+//   → [derive(..., ({ state }) => identity(state.done ? "Done" : "Pending"))]
+//   return identity(state.done ? "Done" : "Pending")
+//   → return derive(..., ({ state }) => identity(state.done ? "Done" : "Pending"))
+export const objectAndArray = pattern((state) => {
+    const view = {
+        value: __cfHelpers.derive({
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        done: {
+                            type: "boolean"
+                        }
+                    },
+                    required: ["done"]
+                }
+            },
+            required: ["state"]
+        } as const satisfies __cfHelpers.JSONSchema, {
+            "enum": ["Done", "Pending"]
+        } as const satisfies __cfHelpers.JSONSchema, { state: {
+                done: state.key("done")
+            } }, ({ state }) => identity(state.done ? "Done" : "Pending")),
+        list: [__cfHelpers.derive({
+                type: "object",
+                properties: {
+                    state: {
+                        type: "object",
+                        properties: {
+                            done: {
+                                type: "boolean"
+                            }
+                        },
+                        required: ["done"]
+                    }
+                },
+                required: ["state"]
+            } as const satisfies __cfHelpers.JSONSchema, {
+                "enum": ["Done", "Pending"]
+            } as const satisfies __cfHelpers.JSONSchema, { state: {
+                    done: state.key("done")
+                } }, ({ state }) => identity(state.done ? "Done" : "Pending"))],
+    };
+    return view;
+}, {
+    type: "object",
+    properties: {
+        done: {
+            type: "boolean"
+        }
+    },
+    required: ["done"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        value: {
+            type: "string"
+        },
+        list: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        }
+    },
+    required: ["value", "list"]
+} as const satisfies __cfHelpers.JSONSchema);
+export default pattern((state) => __cfHelpers.derive({
+    type: "object",
+    properties: {
+        state: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    },
+    required: ["state"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    "enum": ["Done", "Pending"]
+} as const satisfies __cfHelpers.JSONSchema, { state: {
+        done: state.key("done")
+    } }, ({ state }) => identity(state.done ? "Done" : "Pending")), {
+    type: "object",
+    properties: {
+        done: {
+            type: "boolean"
+        }
+    },
+    required: ["done"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.input.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.input.tsx
@@ -1,0 +1,26 @@
+import { pattern } from "commonfabric";
+
+const identity = <T,>(value: T) => value;
+
+// FIXTURE: pattern-call-root-containers
+// Verifies: top-level ordinary call roots whole-wrap consistently across
+//   non-JSX container kinds instead of lowering only their nested conditional
+//   arguments.
+//   { value: identity(state.done ? "Done" : "Pending") }
+//   → { value: derive(..., ({ state }) => identity(state.done ? "Done" : "Pending")) }
+//   [identity(state.done ? "Done" : "Pending")]
+//   → [derive(..., ({ state }) => identity(state.done ? "Done" : "Pending"))]
+//   return identity(state.done ? "Done" : "Pending")
+//   → return derive(..., ({ state }) => identity(state.done ? "Done" : "Pending"))
+export const objectAndArray = pattern<{ done: boolean }>((state) => {
+  const view = {
+    value: identity(state.done ? "Done" : "Pending"),
+    list: [identity(state.done ? "Done" : "Pending")],
+  };
+
+  return view;
+});
+
+export default pattern<{ done: boolean }, string>((state) =>
+  identity(state.done ? "Done" : "Pending")
+);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
@@ -19,10 +19,11 @@ interface State {
     items: Item[];
 }
 // FIXTURE: computed-map-call-arg-conditional
-// Verifies: nested ternary inside a callback-local call argument within a
-//   computed-array .map() callback is lowered to ifElse().
+// Verifies: callback-local ordinary call roots within a computed-array .map()
+//   callback whole-wrap as callback-local derives rather than lowering only
+//   the nested ternary argument site.
 //   const label = identity(row.done ? "Done" : "Pending")
-//   → const label = identity(ifElse(row.done, "Done", "Pending"))
+//   → const label = derive(..., ({ row }) => identity(row.done ? "Done" : "Pending"))
 export default pattern((state) => {
     const rows = __cfHelpers.derive({
         type: "object",
@@ -75,15 +76,25 @@ export default pattern((state) => {
         [UI]: (<div>
         {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                 const row = __cf_pattern_input.key("element");
-                const label = identity(__cfHelpers.ifElse({
-                    type: "boolean"
+                const label = __cfHelpers.derive({
+                    type: "object",
+                    properties: {
+                        row: {
+                            type: "object",
+                            properties: {
+                                done: {
+                                    type: "boolean"
+                                }
+                            },
+                            required: ["done"]
+                        }
+                    },
+                    required: ["row"]
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    "enum": ["Done", "Pending"]
-                } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for(["label", 0], true));
+                } as const satisfies __cfHelpers.JSONSchema, { row: {
+                        done: row.key("done")
+                    } }, ({ row }) => identity(row.done ? "Done" : "Pending")).for("label", true);
                 return <span>{label}</span>;
             }, {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.input.tsx
@@ -11,10 +11,11 @@ interface State {
 }
 
 // FIXTURE: computed-map-call-arg-conditional
-// Verifies: nested ternary inside a callback-local call argument within a
-//   computed-array .map() callback is lowered to ifElse().
+// Verifies: callback-local ordinary call roots within a computed-array .map()
+//   callback whole-wrap as callback-local derives rather than lowering only
+//   the nested ternary argument site.
 //   const label = identity(row.done ? "Done" : "Pending")
-//   → const label = identity(ifElse(row.done, "Done", "Pending"))
+//   → const label = derive(..., ({ row }) => identity(row.done ? "Done" : "Pending"))
 export default pattern<State>((state) => {
   const rows = computed(() => state.items);
 

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
@@ -19,10 +19,11 @@ interface State {
     items: Item[];
 }
 // FIXTURE: computed-map-call-arg-logical-and
-// Verifies: nested && inside a callback-local call argument within a
-//   computed-array .map() callback is lowered to when().
+// Verifies: callback-local ordinary call roots within a computed-array .map()
+//   callback whole-wrap as callback-local derives rather than lowering only
+//   the nested && argument site.
 //   const label = identity(row.done && "Done")
-//   → const label = identity(when(row.done, "Done"))
+//   → const label = derive(..., ({ row }) => identity(row.done && "Done"))
 export default pattern((state) => {
     const rows = __cfHelpers.derive({
         type: "object",
@@ -75,13 +76,25 @@ export default pattern((state) => {
         [UI]: (<div>
         {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                 const row = __cf_pattern_input.key("element");
-                const label = identity(__cfHelpers.when({
-                    type: "boolean"
+                const label = __cfHelpers.derive({
+                    type: "object",
+                    properties: {
+                        row: {
+                            type: "object",
+                            properties: {
+                                done: {
+                                    type: "boolean"
+                                }
+                            },
+                            required: ["done"]
+                        }
+                    },
+                    required: ["row"]
                 } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    "enum": [false, "Done"]
-                } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done").for(["label", 0], true));
+                    type: "unknown"
+                } as const satisfies __cfHelpers.JSONSchema, { row: {
+                        done: row.key("done")
+                    } }, ({ row }) => identity(row.done && "Done")).for("label", true);
                 return <span>{label}</span>;
             }, {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.input.tsx
@@ -11,10 +11,11 @@ interface State {
 }
 
 // FIXTURE: computed-map-call-arg-logical-and
-// Verifies: nested && inside a callback-local call argument within a
-//   computed-array .map() callback is lowered to when().
+// Verifies: callback-local ordinary call roots within a computed-array .map()
+//   callback whole-wrap as callback-local derives rather than lowering only
+//   the nested && argument site.
 //   const label = identity(row.done && "Done")
-//   → const label = identity(when(row.done, "Done"))
+//   → const label = derive(..., ({ row }) => identity(row.done && "Done"))
 export default pattern<State>((state) => {
   const rows = computed(() => state.items);
 

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
@@ -1,0 +1,227 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { computed, pattern } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+const __cfModuleCallback_1 = __cfHardenFn(({ element: row, params: {} }) => __cfHelpers.derive({
+    type: "object",
+    properties: {
+        row: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    },
+    required: ["row"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema, { row: {
+        done: row.done
+    } }, ({ row }) => identity(row.done ? "Done" : "Pending")));
+const identity = __cfHardenFn((value: string) => value);
+interface Item {
+    done: boolean;
+}
+interface State {
+    items: Item[];
+}
+// FIXTURE: computed-map-call-root-containers
+// Verifies: inside a computed-array .map() callback, nested structural sites
+//   still lower inner conditionals directly, while a direct callback
+//   return-expression ordinary call root lowers as a whole callback-local
+//   derive.
+//   ({ value: identity(row.done ? "Done" : "Pending") })
+//   → ({ value: identity(ifElse(row.done, "Done", "Pending")) })
+//   [identity(row.done ? "Done" : "Pending")]
+//   → [identity(ifElse(row.done, "Done", "Pending"))]
+//   row => identity(row.done ? "Done" : "Pending")
+//   → row => derive(..., ({ row }) => identity(row.done ? "Done" : "Pending"))
+export default pattern((state) => {
+    const rows = __cfHelpers.derive({
+        type: "object",
+        properties: {
+            state: {
+                type: "object",
+                properties: {
+                    items: {
+                        type: "array",
+                        items: {
+                            $ref: "#/$defs/Item"
+                        }
+                    }
+                },
+                required: ["items"]
+            }
+        },
+        required: ["state"],
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    done: {
+                        type: "boolean"
+                    }
+                },
+                required: ["done"]
+            }
+        }
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "array",
+        items: {
+            $ref: "#/$defs/Item"
+        },
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    done: {
+                        type: "boolean"
+                    }
+                },
+                required: ["done"]
+            }
+        }
+    } as const satisfies __cfHelpers.JSONSchema, { state: {
+            items: state.key("items")
+        } }, ({ state }) => state.items);
+    const views = rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
+        const row = __cf_pattern_input.key("element");
+        return ({
+            value: identity(__cfHelpers.ifElse({
+                type: "boolean"
+            } as const satisfies __cfHelpers.JSONSchema, {
+                type: "string"
+            } as const satisfies __cfHelpers.JSONSchema, {
+                type: "string"
+            } as const satisfies __cfHelpers.JSONSchema, {
+                "enum": ["Done", "Pending"]
+            } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending")),
+            list: [identity(__cfHelpers.ifElse({
+                    type: "boolean"
+                } as const satisfies __cfHelpers.JSONSchema, {
+                    type: "string"
+                } as const satisfies __cfHelpers.JSONSchema, {
+                    type: "string"
+                } as const satisfies __cfHelpers.JSONSchema, {
+                    "enum": ["Done", "Pending"]
+                } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending"))],
+        });
+    }, {
+        type: "object",
+        properties: {
+            element: {
+                $ref: "#/$defs/Item"
+            }
+        },
+        required: ["element"],
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    done: {
+                        type: "boolean"
+                    }
+                },
+                required: ["done"]
+            }
+        }
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "object",
+        properties: {
+            value: {
+                type: "string"
+            },
+            list: {
+                type: "array",
+                items: {
+                    type: "string"
+                }
+            }
+        },
+        required: ["value", "list"]
+    } as const satisfies __cfHelpers.JSONSchema), {});
+    const labels = rows.mapWithPattern(__cfHelpers.pattern(__cfModuleCallback_1, {
+        type: "object",
+        properties: {
+            element: {
+                type: "object",
+                properties: {
+                    done: {
+                        type: "boolean"
+                    }
+                },
+                required: ["done"]
+            }
+        },
+        required: ["element"]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema), {});
+    return { views, labels };
+}, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            }
+        }
+    },
+    required: ["items"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        views: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    value: {
+                        type: "string"
+                    },
+                    list: {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        }
+                    }
+                },
+                required: ["value", "list"]
+            }
+        },
+        labels: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        }
+    },
+    required: ["views", "labels"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
@@ -11,7 +11,47 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfModuleCallback_1 = __cfHardenFn(({ element: row, params: {} }) => __cfHelpers.derive({
+const __cfModuleCallback_1 = __cfHardenFn(({ element: row, params: {} }) => ({
+    value: __cfHelpers.derive({
+        type: "object",
+        properties: {
+            row: {
+                type: "object",
+                properties: {
+                    done: {
+                        type: "boolean"
+                    }
+                },
+                required: ["done"]
+            }
+        },
+        required: ["row"]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, { row: {
+            done: row.done
+        } }, ({ row }) => identity(row.done ? "Done" : "Pending")),
+    list: [__cfHelpers.derive({
+            type: "object",
+            properties: {
+                row: {
+                    type: "object",
+                    properties: {
+                        done: {
+                            type: "boolean"
+                        }
+                    },
+                    required: ["done"]
+                }
+            },
+            required: ["row"]
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, { row: {
+                done: row.done
+            } }, ({ row }) => identity(row.done ? "Done" : "Pending"))],
+}));
+const __cfModuleCallback_2 = __cfHardenFn(({ element: row, params: {} }) => __cfHelpers.derive({
     type: "object",
     properties: {
         row: {
@@ -38,14 +78,13 @@ interface State {
     items: Item[];
 }
 // FIXTURE: computed-map-call-root-containers
-// Verifies: inside a computed-array .map() callback, nested structural sites
-//   still lower inner conditionals directly, while a direct callback
-//   return-expression ordinary call root lowers as a whole callback-local
-//   derive.
+// Verifies: inside a computed-array .map() callback, callback-local ordinary
+//   call roots whole-wrap as callback-local derives across object-property,
+//   array-element, and direct return-expression sites.
 //   ({ value: identity(row.done ? "Done" : "Pending") })
-//   → ({ value: identity(ifElse(row.done, "Done", "Pending")) })
+//   → ({ value: derive(..., ({ row }) => identity(row.done ? "Done" : "Pending")) })
 //   [identity(row.done ? "Done" : "Pending")]
-//   → [identity(ifElse(row.done, "Done", "Pending"))]
+//   → [derive(..., ({ row }) => identity(row.done ? "Done" : "Pending"))]
 //   row => identity(row.done ? "Done" : "Pending")
 //   → row => derive(..., ({ row }) => identity(row.done ? "Done" : "Pending"))
 export default pattern((state) => {
@@ -95,39 +134,11 @@ export default pattern((state) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             items: state.key("items")
-        } }, ({ state }) => state.items);
-    const views = rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const row = __cf_pattern_input.key("element");
-        return ({
-            value: identity(__cfHelpers.ifElse({
-                type: "boolean"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                "enum": ["Done", "Pending"]
-            } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending")),
-            list: [identity(__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    "enum": ["Done", "Pending"]
-                } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending"))],
-        });
-    }, {
+        } }, ({ state }) => state.items).for("rows", true);
+    const views = rows.mapWithPattern(__cfHelpers.pattern(__cfModuleCallback_1, {
         type: "object",
         properties: {
             element: {
-                $ref: "#/$defs/Item"
-            }
-        },
-        required: ["element"],
-        $defs: {
-            Item: {
                 type: "object",
                 properties: {
                     done: {
@@ -136,7 +147,8 @@ export default pattern((state) => {
                 },
                 required: ["done"]
             }
-        }
+        },
+        required: ["element"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "object",
         properties: {
@@ -151,8 +163,8 @@ export default pattern((state) => {
             }
         },
         required: ["value", "list"]
-    } as const satisfies __cfHelpers.JSONSchema), {});
-    const labels = rows.mapWithPattern(__cfHelpers.pattern(__cfModuleCallback_1, {
+    } as const satisfies __cfHelpers.JSONSchema), {}).for("views", true);
+    const labels = rows.mapWithPattern(__cfHelpers.pattern(__cfModuleCallback_2, {
         type: "object",
         properties: {
             element: {
@@ -168,7 +180,7 @@ export default pattern((state) => {
         required: ["element"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {});
+    } as const satisfies __cfHelpers.JSONSchema), {}).for("labels", true);
     return { views, labels };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.input.tsx
@@ -1,0 +1,40 @@
+import { computed, pattern } from "commonfabric";
+
+const identity = (value: string) => value;
+
+interface Item {
+  done: boolean;
+}
+
+interface State {
+  items: Item[];
+}
+
+// FIXTURE: computed-map-call-root-containers
+// Verifies: inside a computed-array .map() callback, nested structural sites
+//   still lower inner conditionals directly, while a direct callback
+//   return-expression ordinary call root lowers as a whole callback-local
+//   derive.
+//   ({ value: identity(row.done ? "Done" : "Pending") })
+//   → ({ value: identity(ifElse(row.done, "Done", "Pending")) })
+//   [identity(row.done ? "Done" : "Pending")]
+//   → [identity(ifElse(row.done, "Done", "Pending"))]
+//   row => identity(row.done ? "Done" : "Pending")
+//   → row => derive(..., ({ row }) => identity(row.done ? "Done" : "Pending"))
+export default pattern<
+  State,
+  { views: { value: string; list: string[] }[]; labels: string[] }
+>((state) => {
+  const rows = computed(() => state.items);
+
+  const views = rows.map((row) => ({
+    value: identity(row.done ? "Done" : "Pending"),
+    list: [identity(row.done ? "Done" : "Pending")],
+  }));
+
+  const labels = rows.map((row) =>
+    identity(row.done ? "Done" : "Pending")
+  );
+
+  return { views, labels };
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.input.tsx
@@ -11,14 +11,13 @@ interface State {
 }
 
 // FIXTURE: computed-map-call-root-containers
-// Verifies: inside a computed-array .map() callback, nested structural sites
-//   still lower inner conditionals directly, while a direct callback
-//   return-expression ordinary call root lowers as a whole callback-local
-//   derive.
+// Verifies: inside a computed-array .map() callback, callback-local ordinary
+//   call roots whole-wrap as callback-local derives across object-property,
+//   array-element, and direct return-expression sites.
 //   ({ value: identity(row.done ? "Done" : "Pending") })
-//   → ({ value: identity(ifElse(row.done, "Done", "Pending")) })
+//   → ({ value: derive(..., ({ row }) => identity(row.done ? "Done" : "Pending")) })
 //   [identity(row.done ? "Done" : "Pending")]
-//   → [identity(ifElse(row.done, "Done", "Pending"))]
+//   → [derive(..., ({ row }) => identity(row.done ? "Done" : "Pending"))]
 //   row => identity(row.done ? "Done" : "Pending")
 //   → row => derive(..., ({ row }) => identity(row.done ? "Done" : "Pending"))
 export default pattern<

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
@@ -1,0 +1,156 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { computed, pattern } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+const identity = __cfHardenFn((value: string) => value);
+interface Item {
+    done: boolean;
+}
+interface State {
+    items: Item[];
+}
+// FIXTURE: computed-map-local-call-root
+// Verifies: callback-local ordinary call roots in a computed-array .map()
+//   callback whole-wrap as callback-local derives even when introduced through
+//   a local variable initializer in non-JSX output code.
+//   const label = identity(row.done ? "Done" : "Pending")
+//   → const label = derive(..., ({ row }) => identity(row.done ? "Done" : "Pending"))
+export default pattern((state) => {
+    const rows = __cfHelpers.derive({
+        type: "object",
+        properties: {
+            state: {
+                type: "object",
+                properties: {
+                    items: {
+                        type: "array",
+                        items: {
+                            $ref: "#/$defs/Item"
+                        }
+                    }
+                },
+                required: ["items"]
+            }
+        },
+        required: ["state"],
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    done: {
+                        type: "boolean"
+                    }
+                },
+                required: ["done"]
+            }
+        }
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "array",
+        items: {
+            $ref: "#/$defs/Item"
+        },
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    done: {
+                        type: "boolean"
+                    }
+                },
+                required: ["done"]
+            }
+        }
+    } as const satisfies __cfHelpers.JSONSchema, { state: {
+            items: state.key("items")
+        } }, ({ state }) => state.items).for("rows", true);
+    const labels = rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
+        const row = __cf_pattern_input.key("element");
+        const label = __cfHelpers.derive({
+            type: "object",
+            properties: {
+                row: {
+                    type: "object",
+                    properties: {
+                        done: {
+                            type: "boolean"
+                        }
+                    },
+                    required: ["done"]
+                }
+            },
+            required: ["row"]
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, { row: {
+                done: row.key("done")
+            } }, ({ row }) => identity(row.done ? "Done" : "Pending")).for("label", true);
+        return label;
+    }, {
+        type: "object",
+        properties: {
+            element: {
+                $ref: "#/$defs/Item"
+            }
+        },
+        required: ["element"],
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    done: {
+                        type: "boolean"
+                    }
+                },
+                required: ["done"]
+            }
+        }
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema), {}).for("labels", true);
+    return { labels };
+}, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            }
+        }
+    },
+    required: ["items"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        labels: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        }
+    },
+    required: ["labels"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.input.tsx
@@ -1,0 +1,28 @@
+import { computed, pattern } from "commonfabric";
+
+const identity = (value: string) => value;
+
+interface Item {
+  done: boolean;
+}
+
+interface State {
+  items: Item[];
+}
+
+// FIXTURE: computed-map-local-call-root
+// Verifies: callback-local ordinary call roots in a computed-array .map()
+//   callback whole-wrap as callback-local derives even when introduced through
+//   a local variable initializer in non-JSX output code.
+//   const label = identity(row.done ? "Done" : "Pending")
+//   → const label = derive(..., ({ row }) => identity(row.done ? "Done" : "Pending"))
+export default pattern<State, { labels: string[] }>((state) => {
+  const rows = computed(() => state.items);
+
+  const labels = rows.map((row) => {
+    const label = identity(row.done ? "Done" : "Pending");
+    return label;
+  });
+
+  return { labels };
+});

--- a/packages/ts-transformers/test/policy/expression-site-lowering.test.ts
+++ b/packages/ts-transformers/test/policy/expression-site-lowering.test.ts
@@ -289,7 +289,7 @@ function assertJsxRouteCase(testCase: JsxRouteCase): void {
 }
 
 Deno.test(
-  "Expression site policy: array-method callback call arguments are tracked separately from helper-owned branches",
+  "Expression site policy: array-method callback call arguments under local helper roots defer to the enclosing call root",
   () => {
     const { sourceFile, checker, context } = createProgramAndContext(`
       declare function identity<T>(value: T): T;
@@ -308,6 +308,13 @@ Deno.test(
     context.markAsArrayMethodCallback(callback);
 
     const conditional = findFirstNode(sourceFile, ts.isConditionalExpression);
+    const helperCall = findFirstNode(
+      sourceFile,
+      (node): node is ts.CallExpression =>
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "identity",
+    );
     const analyze = createDataFlowAnalyzer(checker);
     assertEquals(
       canRewriteExpressionSite(
@@ -316,7 +323,7 @@ Deno.test(
         context,
         analyze,
       ),
-      true,
+      false,
     );
     assertEquals(
       canRewriteHelperOwnedExpressionSite(
@@ -327,6 +334,15 @@ Deno.test(
       ),
       false,
     );
+
+    const lowerableSite = findLowerableExpressionSite(
+      conditional,
+      context,
+      analyze,
+    );
+    assert(lowerableSite);
+    assert(lowerableSite.expression === helperCall);
+    assertEquals(lowerableSite.containerKind, "variable-initializer");
   },
 );
 


### PR DESCRIPTION
## Summary
- fix callback-local ordinary call roots inside supported collection callbacks so the outer call owns lowering instead of leaking a lowered inner `ifElse(...)` into helper arguments
- whole-wrap callback-local ordinary call roots across `variable-initializer`, `object-property`, `array-element`, and direct `return-expression` sites while keeping plain structural sites without an owning call root on the direct-lowering path
- update and add closure fixtures to pin the semantics-preserving behavior, and refresh the current-behavior spec to describe the resulting ownership rule

## Root Cause
The previous callback-local policy let nested structural sites such as `call-argument`, `object-property`, and `array-element` lower directly even when they were nested under an ordinary helper call. That produced shapes like `helper(ifElse(...))`, which are semantically unsafe because `ifElse(...)` yields an `OpaqueRef` rather than the authored plain value the helper expects.

## Impact
This makes callback-local lowering easier to reason about and preserves call semantics for ordinary helpers in supported collection callbacks. The direct-lowering behavior remains for plain structural sites that are not enclosed by an owning ordinary call root.

## Validation
- `UPDATE_GOLDENS=1 FIXTURE_PATTERN='computed-map-call-arg-conditional|computed-map-call-root-containers|computed-map-local-call-root' deno test --allow-read --allow-write --allow-env test/fixture-based.test.ts`
- `FIXTURE_PATTERN='computed-map-call-arg-conditional|computed-map-call-root-containers|computed-map-local-call-root|computed-map-local-array-conditional' deno test --allow-read --allow-write --allow-env test/fixture-based.test.ts`
