### PR TITLE
fix(cli): fix silent error swallowing and piece start hang

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -266,9 +266,26 @@ export async function newPiece(
     "newPiece.getProgramFromFile",
     () => getProgramFromFile(manager, entry),
   );
+  const PIECE_START_TIMEOUT_MS = 30_000;
   const piece = await timeCliPhase(
     "newPiece.create",
-    () => pieces.create(program, options),
+    () => {
+      const createPromise = pieces.create(program, options);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new Error(
+              `Piece created but failed to start within ${PIECE_START_TIMEOUT_MS / 1000}s. ` +
+                `Check toolshed logs for runtime errors.`,
+            ),
+          );
+        }, PIECE_START_TIMEOUT_MS);
+      });
+      return Promise.race([createPromise, timeout]).finally(() =>
+        clearTimeout(timer)
+      );
+    },
   );
 
   // Explicitly add the piece to the space's allPieces list

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -266,7 +266,7 @@ export async function newPiece(
     "newPiece.getProgramFromFile",
     () => getProgramFromFile(manager, entry),
   );
-  const PIECE_START_TIMEOUT_MS = 30_000;
+  const PIECE_START_TIMEOUT_MS = 60_000;
   const piece = await timeCliPhase(
     "newPiece.create",
     () => {

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -62,7 +62,7 @@ export async function main(args: string[]) {
     if (e instanceof TransformerError || e instanceof CompilerError) {
       console.error(e.message);
     } else if (e instanceof Error) {
-      console.error(e.stack ?? e.message);
+      console.error(e.stack || e.message);
     } else {
       console.error(e);
     }


### PR DESCRIPTION
## Summary

Two fixes for CLI error reporting that were discovered while debugging loom deploy failures. The SES `Date` lockdown change caused `cf piece new` to fail silently — empty error output + infinite hang — making the root cause extremely difficult to find.

- **Fix empty error output on exit 1:** The catch block in `mod.ts` used `e.stack ?? e.message`. When `e.stack` is an empty string (which happens for several error types including SES lockdown errors), `??` treats it as non-nullish and prints nothing. Changed to `||` so empty strings fall through to `e.message`.

- **Fix `cf piece new` hanging when piece fails to start:** Added a 30-second timeout to the `pieces.create()` call in `newPiece`. Previously, if the piece failed to start (e.g., due to SES sandbox errors), the CLI would hang indefinitely waiting for `pull()` / `synced()` inside `startPiece`. Now it fails with: *"Piece created but failed to start within 30s. Check toolshed logs for runtime errors."*

## Test plan

- [ ] Verify `cf piece new` with a piece that triggers a runtime error shows the error message instead of blank output
- [ ] Verify `cf piece new` with a piece that fails to start times out after 30s with a clear message
- [ ] Verify normal `cf piece new` still works (timeout is not triggered for healthy pieces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)