### PR TITLE
[codex] remove legacy shell env experimental aliases

### DIFF
--- a/packages/shell/src/lib/env.ts
+++ b/packages/shell/src/lib/env.ts
@@ -6,12 +6,9 @@ declare global {
   var $COMMIT_SHA: string | undefined;
   var $MEMORY_VERSION: string | undefined;
   var $EXPERIMENTAL_MODERN_DATA_MODEL: string | undefined;
-  var $EXPERIMENTAL_RICH_STORABLE_VALUES: string | undefined;
-  var $EXPERIMENTAL_STORABLE_PROTOCOL: string | undefined;
   var $EXPERIMENTAL_UNIFIED_JSON_ENCODING: string | undefined;
   var $EXPERIMENTAL_MODERN_SCHEMA_HASH: string | undefined;
   var $EXPERIMENTAL_MODERN_HASH: string | undefined;
-  var $EXPERIMENTAL_CANONICAL_HASHING: string | undefined;
   var $COMPILATION_CACHE_CLIENT: string | undefined;
 }
 
@@ -29,14 +26,6 @@ const EXPERIMENTAL_MODERN_DATA_MODEL_DEFINE =
   typeof $EXPERIMENTAL_MODERN_DATA_MODEL === "string"
     ? $EXPERIMENTAL_MODERN_DATA_MODEL
     : undefined;
-const EXPERIMENTAL_RICH_STORABLE_VALUES_DEFINE =
-  typeof $EXPERIMENTAL_RICH_STORABLE_VALUES === "string"
-    ? $EXPERIMENTAL_RICH_STORABLE_VALUES
-    : undefined;
-const EXPERIMENTAL_STORABLE_PROTOCOL_DEFINE =
-  typeof $EXPERIMENTAL_STORABLE_PROTOCOL === "string"
-    ? $EXPERIMENTAL_STORABLE_PROTOCOL
-    : undefined;
 const EXPERIMENTAL_UNIFIED_JSON_ENCODING_DEFINE =
   typeof $EXPERIMENTAL_UNIFIED_JSON_ENCODING === "string"
     ? $EXPERIMENTAL_UNIFIED_JSON_ENCODING
@@ -48,10 +37,6 @@ const EXPERIMENTAL_MODERN_SCHEMA_HASH_DEFINE =
 const EXPERIMENTAL_MODERN_HASH_DEFINE =
   typeof $EXPERIMENTAL_MODERN_HASH === "string"
     ? $EXPERIMENTAL_MODERN_HASH
-    : undefined;
-const EXPERIMENTAL_CANONICAL_HASHING_DEFINE =
-  typeof $EXPERIMENTAL_CANONICAL_HASHING === "string"
-    ? $EXPERIMENTAL_CANONICAL_HASHING
     : undefined;
 const COMPILATION_CACHE_CLIENT_DEFINE =
   typeof $COMPILATION_CACHE_CLIENT === "string"
@@ -82,12 +67,9 @@ function flagValue(flag: string | undefined): boolean | undefined {
 /** Build-time experimental flags, injected via felt.config.ts defines. */
 export const EXPERIMENTAL = {
   modernDataModel: flagValue(EXPERIMENTAL_MODERN_DATA_MODEL_DEFINE),
-  richStorableValues: flagValue(EXPERIMENTAL_RICH_STORABLE_VALUES_DEFINE),
-  storableProtocol: flagValue(EXPERIMENTAL_STORABLE_PROTOCOL_DEFINE),
   unifiedJsonEncoding: flagValue(EXPERIMENTAL_UNIFIED_JSON_ENCODING_DEFINE),
   modernHash: flagValue(EXPERIMENTAL_MODERN_HASH_DEFINE),
   modernSchemaHash: flagValue(EXPERIMENTAL_MODERN_SCHEMA_HASH_DEFINE),
-  canonicalHashing: flagValue(EXPERIMENTAL_CANONICAL_HASHING_DEFINE),
 };
 
 export const COMPILATION_CACHE_CLIENT =

--- a/packages/shell/test/env.test.ts
+++ b/packages/shell/test/env.test.ts
@@ -1,0 +1,76 @@
+import { expect } from "@std/expect";
+
+type ShellEnvGlobals = typeof globalThis & Record<string, string | undefined>;
+
+function importFreshEnvModule() {
+  return import(
+    new URL(`../src/lib/env.ts?case=${crypto.randomUUID()}`, import.meta.url)
+      .href
+  );
+}
+
+function withPatchedGlobals<T>(
+  globals: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const env = globalThis as ShellEnvGlobals;
+  const original = Object.fromEntries(
+    Object.keys(globals).map((key) => [key, env[key]]),
+  );
+  for (const [key, value] of Object.entries(globals)) {
+    env[key] = value;
+  }
+  return fn().finally(() => {
+    for (const [key, value] of Object.entries(original)) {
+      env[key] = value;
+    }
+  });
+}
+
+Deno.test({
+  name: "shell env reads the modern experimental globals",
+  permissions: { read: true },
+  async fn() {
+    const mod = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_MODERN_DATA_MODEL: "true",
+      $EXPERIMENTAL_UNIFIED_JSON_ENCODING: "false",
+      $EXPERIMENTAL_MODERN_HASH: "true",
+      $EXPERIMENTAL_MODERN_SCHEMA_HASH: "false",
+      $EXPERIMENTAL_RICH_STORABLE_VALUES: undefined,
+      $EXPERIMENTAL_STORABLE_PROTOCOL: undefined,
+      $EXPERIMENTAL_CANONICAL_HASHING: undefined,
+    }, importFreshEnvModule);
+
+    expect(mod.EXPERIMENTAL).toEqual({
+      modernDataModel: true,
+      unifiedJsonEncoding: false,
+      modernHash: true,
+      modernSchemaHash: false,
+    });
+  },
+});
+
+Deno.test({
+  name: "shell env ignores defunct legacy experimental globals",
+  permissions: { read: true },
+  async fn() {
+    const mod = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_MODERN_DATA_MODEL: undefined,
+      $EXPERIMENTAL_UNIFIED_JSON_ENCODING: undefined,
+      $EXPERIMENTAL_MODERN_HASH: undefined,
+      $EXPERIMENTAL_MODERN_SCHEMA_HASH: undefined,
+      $EXPERIMENTAL_RICH_STORABLE_VALUES: "true",
+      $EXPERIMENTAL_STORABLE_PROTOCOL: "true",
+      $EXPERIMENTAL_CANONICAL_HASHING: "true",
+    }, importFreshEnvModule);
+
+    expect(mod.EXPERIMENTAL).toEqual({
+      modernDataModel: undefined,
+      unifiedJsonEncoding: undefined,
+      modernHash: undefined,
+      modernSchemaHash: undefined,
+    });
+  },
+});

--- a/packages/shell/test/runtime-navigation.test.ts
+++ b/packages/shell/test/runtime-navigation.test.ts
@@ -36,10 +36,10 @@ describe("RuntimeInternals navigation", () => {
       $ENVIRONMENT?: string;
       $COMMIT_SHA?: string;
       $MEMORY_VERSION?: string;
-      $EXPERIMENTAL_RICH_STORABLE_VALUES?: string;
-      $EXPERIMENTAL_STORABLE_PROTOCOL?: string;
+      $EXPERIMENTAL_MODERN_DATA_MODEL?: string;
       $EXPERIMENTAL_UNIFIED_JSON_ENCODING?: string;
-      $EXPERIMENTAL_CANONICAL_HASHING?: string;
+      $EXPERIMENTAL_MODERN_SCHEMA_HASH?: string;
+      $EXPERIMENTAL_MODERN_HASH?: string;
       $COMPILATION_CACHE_CLIENT?: string;
     };
     const originalEnv = {
@@ -47,22 +47,21 @@ describe("RuntimeInternals navigation", () => {
       $ENVIRONMENT: env.$ENVIRONMENT,
       $COMMIT_SHA: env.$COMMIT_SHA,
       $MEMORY_VERSION: env.$MEMORY_VERSION,
-      $EXPERIMENTAL_RICH_STORABLE_VALUES:
-        env.$EXPERIMENTAL_RICH_STORABLE_VALUES,
-      $EXPERIMENTAL_STORABLE_PROTOCOL: env.$EXPERIMENTAL_STORABLE_PROTOCOL,
+      $EXPERIMENTAL_MODERN_DATA_MODEL: env.$EXPERIMENTAL_MODERN_DATA_MODEL,
       $EXPERIMENTAL_UNIFIED_JSON_ENCODING:
         env.$EXPERIMENTAL_UNIFIED_JSON_ENCODING,
-      $EXPERIMENTAL_CANONICAL_HASHING: env.$EXPERIMENTAL_CANONICAL_HASHING,
+      $EXPERIMENTAL_MODERN_SCHEMA_HASH: env.$EXPERIMENTAL_MODERN_SCHEMA_HASH,
+      $EXPERIMENTAL_MODERN_HASH: env.$EXPERIMENTAL_MODERN_HASH,
       $COMPILATION_CACHE_CLIENT: env.$COMPILATION_CACHE_CLIENT,
     };
     env.$API_URL = "http://shell.test/";
     env.$ENVIRONMENT = "development";
     env.$COMMIT_SHA = undefined;
     env.$MEMORY_VERSION = undefined;
-    env.$EXPERIMENTAL_RICH_STORABLE_VALUES = undefined;
-    env.$EXPERIMENTAL_STORABLE_PROTOCOL = undefined;
+    env.$EXPERIMENTAL_MODERN_DATA_MODEL = undefined;
     env.$EXPERIMENTAL_UNIFIED_JSON_ENCODING = undefined;
-    env.$EXPERIMENTAL_CANONICAL_HASHING = undefined;
+    env.$EXPERIMENTAL_MODERN_SCHEMA_HASH = undefined;
+    env.$EXPERIMENTAL_MODERN_HASH = undefined;
     env.$COMPILATION_CACHE_CLIENT = undefined;
 
     const { RuntimeInternals } = await import("../src/lib/runtime.ts");
@@ -115,14 +114,13 @@ describe("RuntimeInternals navigation", () => {
       env.$ENVIRONMENT = originalEnv.$ENVIRONMENT;
       env.$COMMIT_SHA = originalEnv.$COMMIT_SHA;
       env.$MEMORY_VERSION = originalEnv.$MEMORY_VERSION;
-      env.$EXPERIMENTAL_RICH_STORABLE_VALUES =
-        originalEnv.$EXPERIMENTAL_RICH_STORABLE_VALUES;
-      env.$EXPERIMENTAL_STORABLE_PROTOCOL =
-        originalEnv.$EXPERIMENTAL_STORABLE_PROTOCOL;
+      env.$EXPERIMENTAL_MODERN_DATA_MODEL =
+        originalEnv.$EXPERIMENTAL_MODERN_DATA_MODEL;
       env.$EXPERIMENTAL_UNIFIED_JSON_ENCODING =
         originalEnv.$EXPERIMENTAL_UNIFIED_JSON_ENCODING;
-      env.$EXPERIMENTAL_CANONICAL_HASHING =
-        originalEnv.$EXPERIMENTAL_CANONICAL_HASHING;
+      env.$EXPERIMENTAL_MODERN_SCHEMA_HASH =
+        originalEnv.$EXPERIMENTAL_MODERN_SCHEMA_HASH;
+      env.$EXPERIMENTAL_MODERN_HASH = originalEnv.$EXPERIMENTAL_MODERN_HASH;
       env.$COMPILATION_CACHE_CLIENT = originalEnv.$COMPILATION_CACHE_CLIENT;
       await runtime.dispose();
     }
@@ -134,10 +132,10 @@ describe("RuntimeInternals navigation", () => {
       $ENVIRONMENT?: string;
       $COMMIT_SHA?: string;
       $MEMORY_VERSION?: string;
-      $EXPERIMENTAL_RICH_STORABLE_VALUES?: string;
-      $EXPERIMENTAL_STORABLE_PROTOCOL?: string;
+      $EXPERIMENTAL_MODERN_DATA_MODEL?: string;
       $EXPERIMENTAL_UNIFIED_JSON_ENCODING?: string;
-      $EXPERIMENTAL_CANONICAL_HASHING?: string;
+      $EXPERIMENTAL_MODERN_SCHEMA_HASH?: string;
+      $EXPERIMENTAL_MODERN_HASH?: string;
       $COMPILATION_CACHE_CLIENT?: string;
     };
     const originalEnv = {
@@ -145,22 +143,21 @@ describe("RuntimeInternals navigation", () => {
       $ENVIRONMENT: env.$ENVIRONMENT,
       $COMMIT_SHA: env.$COMMIT_SHA,
       $MEMORY_VERSION: env.$MEMORY_VERSION,
-      $EXPERIMENTAL_RICH_STORABLE_VALUES:
-        env.$EXPERIMENTAL_RICH_STORABLE_VALUES,
-      $EXPERIMENTAL_STORABLE_PROTOCOL: env.$EXPERIMENTAL_STORABLE_PROTOCOL,
+      $EXPERIMENTAL_MODERN_DATA_MODEL: env.$EXPERIMENTAL_MODERN_DATA_MODEL,
       $EXPERIMENTAL_UNIFIED_JSON_ENCODING:
         env.$EXPERIMENTAL_UNIFIED_JSON_ENCODING,
-      $EXPERIMENTAL_CANONICAL_HASHING: env.$EXPERIMENTAL_CANONICAL_HASHING,
+      $EXPERIMENTAL_MODERN_SCHEMA_HASH: env.$EXPERIMENTAL_MODERN_SCHEMA_HASH,
+      $EXPERIMENTAL_MODERN_HASH: env.$EXPERIMENTAL_MODERN_HASH,
       $COMPILATION_CACHE_CLIENT: env.$COMPILATION_CACHE_CLIENT,
     };
     env.$API_URL = "http://shell.test/";
     env.$ENVIRONMENT = "development";
     env.$COMMIT_SHA = undefined;
     env.$MEMORY_VERSION = undefined;
-    env.$EXPERIMENTAL_RICH_STORABLE_VALUES = undefined;
-    env.$EXPERIMENTAL_STORABLE_PROTOCOL = undefined;
+    env.$EXPERIMENTAL_MODERN_DATA_MODEL = undefined;
     env.$EXPERIMENTAL_UNIFIED_JSON_ENCODING = undefined;
-    env.$EXPERIMENTAL_CANONICAL_HASHING = undefined;
+    env.$EXPERIMENTAL_MODERN_SCHEMA_HASH = undefined;
+    env.$EXPERIMENTAL_MODERN_HASH = undefined;
     env.$COMPILATION_CACHE_CLIENT = undefined;
 
     const { RuntimeInternals } = await import("../src/lib/runtime.ts");
@@ -209,14 +206,13 @@ describe("RuntimeInternals navigation", () => {
       env.$ENVIRONMENT = originalEnv.$ENVIRONMENT;
       env.$COMMIT_SHA = originalEnv.$COMMIT_SHA;
       env.$MEMORY_VERSION = originalEnv.$MEMORY_VERSION;
-      env.$EXPERIMENTAL_RICH_STORABLE_VALUES =
-        originalEnv.$EXPERIMENTAL_RICH_STORABLE_VALUES;
-      env.$EXPERIMENTAL_STORABLE_PROTOCOL =
-        originalEnv.$EXPERIMENTAL_STORABLE_PROTOCOL;
+      env.$EXPERIMENTAL_MODERN_DATA_MODEL =
+        originalEnv.$EXPERIMENTAL_MODERN_DATA_MODEL;
       env.$EXPERIMENTAL_UNIFIED_JSON_ENCODING =
         originalEnv.$EXPERIMENTAL_UNIFIED_JSON_ENCODING;
-      env.$EXPERIMENTAL_CANONICAL_HASHING =
-        originalEnv.$EXPERIMENTAL_CANONICAL_HASHING;
+      env.$EXPERIMENTAL_MODERN_SCHEMA_HASH =
+        originalEnv.$EXPERIMENTAL_MODERN_SCHEMA_HASH;
+      env.$EXPERIMENTAL_MODERN_HASH = originalEnv.$EXPERIMENTAL_MODERN_HASH;
       env.$COMPILATION_CACHE_CLIENT = originalEnv.$COMPILATION_CACHE_CLIENT;
       await runtime.dispose();
     }


### PR DESCRIPTION
## Summary
- remove legacy shell experimental globals and alias fields from `packages/shell/src/lib/env.ts`
- update the shell navigation tests to preserve the modern globals instead of the old aliases
- add a focused shell env test that proves the modern globals are honored and the old globals are ignored

## Why
`labs#3272` narrows the shell build-time define surface back to the documented modern env vars. While investigating that change, I found that `packages/shell/src/lib/env.ts` was still reading and exporting the old alias globals:
- `EXPERIMENTAL_RICH_STORABLE_VALUES`
- `EXPERIMENTAL_STORABLE_PROTOCOL`
- `EXPERIMENTAL_CANONICAL_HASHING`

In the shell itself, those names were no longer real inputs. The only shell-side references left were:
- `env.ts` itself
- `runtime-navigation.test.ts`, which was preserving those globals in test setup

The downstream runtime path already treats `modernDataModel` / `modernHash` as the primary contract, with the old names only retained as runner-side backward-compat aliases. So this follow-up removes the dead shell-side compatibility layer and adds a targeted regression test for the modern contract.

`EXPERIMENTAL_STORABLE_PROTOCOL` in particular appears fully defunct here, matching Dan's note that it never got wired up.

## Validation
- `cd packages/shell && deno task test`

## Notes
- This overlaps slightly with `labs#3272` on the shell test-task permissions: the new focused env test needs `--allow-read` for fresh module imports. If `#3272` lands first, that part should collapse cleanly on rebase.