### PR TITLE
Remove experimentalDecorators compiler flag

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -63,7 +63,6 @@
       "dom.asynciterable",
       "esnext"
     ],
-    "experimentalDecorators": true
   },
   "exclude": [
     "**/node_modules/",


### PR DESCRIPTION
## Summary

Remove `experimentalDecorators: true` from root `deno.json`. This flag enables TypeScript's legacy decorator implementation (2015 proposal). Deno has supported TC39 standard decorators natively since v1.40 (January 2024), and Lit 3.0+ supports both.

The flag was added in #1334 (July 2025, @jsantell) for the initial shell work. There was a previous removal attempt on July 28 2025 (@jakedahn, `9b5b5d95e`) that didn't land on main.

## Why now

- Deno emits `Warning: experimentalDecorators compiler option is deprecated and may be removed at any time` on every check/test/run
- The TC39 standard decorators are stable and supported everywhere
- 304 decorator sites across `packages/ui/`, `packages/shell/`, and `packages/iframe-sandbox/` — all Lit decorators (`@property`, `@state`, `@query`, etc.) which Lit handles transparently for both implementations

## What could break

The main semantic difference between legacy and standard decorators is class field initialization ordering. For Lit's simple `@property`/`@state` decorators this rarely matters, but worth testing the shell and UI packages.

## Test plan

- [ ] Shell builds and renders correctly
- [ ] UI components work (especially components with `@property`/`@state` decorators)
- [ ] `deno check` passes without the warning

Looking for feedback from @jsantell and anyone working on shell/UI.