### PR TITLE
Refactor: migrate standard decorators batch 1

### DIFF
--- a/packages/shell/src/components/Button.ts
+++ b/packages/shell/src/components/Button.ts
@@ -45,16 +45,16 @@ export class XButtonElement extends LitElement {
     }
   `;
   @property()
-  size: ButtonSize = "medium";
+  accessor size: ButtonSize = "medium";
 
   @property()
-  type: ButtonType = "text";
+  accessor type: ButtonType = "text";
 
   @property({ attribute: true })
-  disabled = false;
+  accessor disabled = false;
 
   @property({ attribute: true })
-  variant: VariantType = "none";
+  accessor variant: VariantType = "none";
 
   private onClick(e: Event) {
     // If this is a "submit" button, then we need

--- a/packages/shell/src/components/CFLogo.ts
+++ b/packages/shell/src/components/CFLogo.ts
@@ -79,19 +79,19 @@ export class CFLogo extends LitElement {
   `;
 
   @property()
-  width = 32;
+  accessor width = 32;
 
   @property()
-  height = 32;
+  accessor height = 32;
 
   @property({ attribute: "background-color" })
-  backgroundColor = "white";
+  accessor backgroundColor = "white";
 
   @property({ attribute: "shape-color" })
-  shapeColor = "#f9fafb";
+  accessor shapeColor = "#f9fafb";
 
   @property({ type: Boolean, reflect: true })
-  loading = false;
+  accessor loading = false;
 
   override render() {
     return html`

--- a/packages/shell/src/components/Flex.ts
+++ b/packages/shell/src/components/Flex.ts
@@ -30,10 +30,10 @@ export class XFlexElement extends LitElement {
   `;
 
   @property()
-  center = false;
+  accessor center = false;
 
   @property()
-  direction: FlexDirection = "horizontal";
+  accessor direction: FlexDirection = "horizontal";
 
   override render() {
     return html`
@@ -45,7 +45,7 @@ export class XFlexElement extends LitElement {
 
 export class HBoxElement extends LitElement {
   @property()
-  center = false;
+  accessor center = false;
 
   direction = "horizontal";
 

--- a/packages/ui/deno.json
+++ b/packages/ui/deno.json
@@ -5,7 +5,7 @@
   },
   "tasks": {
     "bundle": "../../scripts/bundle.ts src/index.ts",
-    "test": "deno test --no-check --allow-env --allow-ffi --allow-read --ignore=src/v2/components/cf-svg/sanitize-svg.test.ts && deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts src/v2/components/cf-svg/sanitize-svg.test.ts"
+    "test": "deno test --no-check --allow-env --allow-ffi --allow-read --allow-write --allow-run --ignore=src/v2/components/cf-svg/sanitize-svg.test.ts && deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts src/v2/components/cf-svg/sanitize-svg.test.ts"
   },
   "imports": {
     "@codemirror/commands": "npm:@codemirror/commands@^6.8.1",

--- a/packages/ui/src/v2/components/cf-attachments-bar/cf-attachments-bar.ts
+++ b/packages/ui/src/v2/components/cf-attachments-bar/cf-attachments-bar.ts
@@ -58,10 +58,10 @@ export class CFAttachmentsBar extends BaseElement {
   ];
 
   @property({ type: Array })
-  pinnedCells: Attachment[] = [];
+  accessor pinnedCells: Attachment[] = [];
 
   @property({ type: Boolean })
-  removable = false;
+  accessor removable = false;
 
   private _getVariant(type: string): "default" | "primary" | "accent" {
     switch (type) {

--- a/packages/ui/src/v2/components/cf-canvas/cf-canvas.ts
+++ b/packages/ui/src/v2/components/cf-canvas/cf-canvas.ts
@@ -5,9 +5,9 @@ import { BaseElement } from "../../core/base-element.ts";
 @customElement("cf-canvas")
 export class CFCanvas extends BaseElement {
   @property({ type: Number })
-  width = 800;
+  accessor width = 800;
   @property({ type: Number })
-  height = 600;
+  accessor height = 600;
 
   static override styles = css`
     :host {

--- a/packages/ui/src/v2/components/cf-chip/cf-chip.ts
+++ b/packages/ui/src/v2/components/cf-chip/cf-chip.ts
@@ -139,16 +139,16 @@ export class CFChip extends BaseElement {
     ];
 
     @property({ type: String })
-    label = "";
+    accessor label = "";
 
     @property({ type: String })
-    variant: "default" | "primary" | "accent" = "default";
+    accessor variant: "default" | "primary" | "accent" = "default";
 
     @property({ type: Boolean })
-    removable = false;
+    accessor removable = false;
 
     @property({ type: Boolean })
-    interactive = false;
+    accessor interactive = false;
 
     private _handleRemove(e: Event): void {
       e.stopPropagation();

--- a/packages/ui/src/v2/components/cf-router/cf-router.ts
+++ b/packages/ui/src/v2/components/cf-router/cf-router.ts
@@ -5,7 +5,7 @@ import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
 
 export class CFRouter extends BaseElement {
   @property({ attribute: false })
-  path: CellHandle<string> | string = "/";
+  accessor path: CellHandle<string> | string = "/";
 
   override connectedCallback(): void {
     super.connectedCallback();

--- a/packages/ui/src/v2/components/cf-tile/cf-tile.ts
+++ b/packages/ui/src/v2/components/cf-tile/cf-tile.ts
@@ -19,13 +19,13 @@ import { BaseElement } from "../../core/base-element.ts";
 
 export class CFTile extends BaseElement {
   @property()
-  item: { title: string; [key: string]: any } = { title: "" };
+  accessor item: { title: string; [key: string]: any } = { title: "" };
 
   @property()
-  summary: string = "";
+  accessor summary: string = "";
 
   @property()
-  clickable: boolean = true;
+  accessor clickable: boolean = true;
 
   static override styles = css`
     :host {

--- a/packages/ui/test/standard-decorators-batch1.test.ts
+++ b/packages/ui/test/standard-decorators-batch1.test.ts
@@ -1,7 +1,7 @@
 import { assert } from "@std/assert";
 import { join } from "@std/path";
 
-const ROOT = join(import.meta.dirname!, "..");
+const ROOT = join(import.meta.dirname!, "..", "..", "..");
 
 function decode(bytes: Uint8Array): string {
   return new TextDecoder().decode(bytes);

--- a/tests/standard_decorators_batch1_test.ts
+++ b/tests/standard_decorators_batch1_test.ts
@@ -1,0 +1,46 @@
+import { assert } from "@std/assert";
+import { join } from "@std/path";
+
+const ROOT = join(import.meta.dirname!, "..");
+
+function decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+Deno.test("batch 1 files type-check under standard decorators", async () => {
+  const rootConfigPath = join(ROOT, "deno.json");
+  const rootConfig = JSON.parse(await Deno.readTextFile(rootConfigPath));
+
+  rootConfig.compilerOptions ??= {};
+  rootConfig.compilerOptions.experimentalDecorators = false;
+
+  const tempConfig = join(ROOT, ".deno.standard-decorators.batch1.json");
+  await Deno.writeTextFile(tempConfig, JSON.stringify(rootConfig, null, 2));
+
+  const files = [
+    "packages/shell/src/components/Button.ts",
+    "packages/shell/src/components/CFLogo.ts",
+    "packages/shell/src/components/Flex.ts",
+    "packages/ui/src/v2/components/cf-attachments-bar/cf-attachments-bar.ts",
+    "packages/ui/src/v2/components/cf-canvas/cf-canvas.ts",
+    "packages/ui/src/v2/components/cf-chip/cf-chip.ts",
+    "packages/ui/src/v2/components/cf-router/cf-router.ts",
+    "packages/ui/src/v2/components/cf-tile/cf-tile.ts",
+  ];
+
+  const output = await new Deno.Command(Deno.execPath(), {
+    cwd: ROOT,
+    args: ["check", "--config", tempConfig, ...files],
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+
+  await Deno.remove(tempConfig);
+
+  if (!output.success) {
+    console.error(decode(output.stdout));
+    console.error(decode(output.stderr));
+  }
+
+  assert(output.success, "batch 1 files should pass under standard decorators");
+});


### PR DESCRIPTION
## Why
This is the first implementation batch from the standard decorators migration
plan.

The long-term goal is to remove the deprecated
`experimentalDecorators` compiler warning from the repo's root Deno config.
We cannot safely remove that flag yet, because many Lit and `@lit/context`
components still rely on legacy decorator syntax and semantics.

This PR starts the migration with the low-risk, pure-Lit subset.

## What This PR Does
- converts the Batch 1 decorator-backed components from legacy field decorators
  to `accessor` form
- adds a focused regression test that checks these files under a generated
  standard-decorators config
- keeps the root `experimentalDecorators` flag in place for now

## Scope
Touched components:
- `packages/shell/src/components/Button.ts`
- `packages/shell/src/components/CFLogo.ts`
- `packages/shell/src/components/Flex.ts`
- `packages/ui/src/v2/components/cf-attachments-bar/cf-attachments-bar.ts`
- `packages/ui/src/v2/components/cf-canvas/cf-canvas.ts`
- `packages/ui/src/v2/components/cf-chip/cf-chip.ts`
- `packages/ui/src/v2/components/cf-router/cf-router.ts`
- `packages/ui/src/v2/components/cf-tile/cf-tile.ts`

Guard test:
- `packages/ui/test/standard-decorators-batch1.test.ts`

Note: two files from the original Batch 1 candidate list were already using
static `properties` rather than decorators, so they are not part of this code
change.

## Validation
- `cd packages/ui && deno test --no-check --allow-env --allow-ffi --allow-read --allow-write --allow-run test/standard-decorators-batch1.test.ts`
- `deno check packages/shell/src/components/Button.ts packages/shell/src/components/CFLogo.ts packages/shell/src/components/Flex.ts packages/ui/src/v2/components/cf-attachments-bar/cf-attachments-bar.ts packages/ui/src/v2/components/cf-canvas/cf-canvas.ts packages/ui/src/v2/components/cf-chip/cf-chip.ts packages/ui/src/v2/components/cf-router/cf-router.ts packages/ui/src/v2/components/cf-tile/cf-tile.ts`

## Why This Batch Is Safe
- no `@lit/context` conversions
- no root config change
- no compiler/transformer changes
- no behavioral refactors beyond the decorator syntax migration
