### PR TITLE
test: add standard decorators prep guards

### DIFF
--- a/packages/js-compiler/test/typescript.compiler.test.ts
+++ b/packages/js-compiler/test/typescript.compiler.test.ts
@@ -104,6 +104,48 @@ describe("TypeScriptCompiler", () => {
     await compiler.resolveAndCompile(program);
   });
 
+  it("Compiles TSX with standard-decorator accessor fields", async () => {
+    const compiler = new TypeScriptCompiler(types);
+    const program = new InMemoryProgram("/main.tsx", {
+      "/main.tsx": `
+function tracked(
+  _value: ClassAccessorDecoratorTarget<Counter, number>,
+  _context: ClassAccessorDecoratorContext<Counter, number>,
+) {
+  return {
+    init(value: number) {
+      return value;
+    },
+  };
+}
+
+declare namespace JSX {
+  interface IntrinsicElements {
+    div: {};
+  }
+}
+
+declare function h(
+  tag: string,
+  props: Record<string, unknown> | null,
+  ...children: unknown[]
+): unknown;
+
+class Counter {
+  @tracked accessor count = 1;
+}
+
+export default <div>{new Counter().count}</div>;
+`,
+    });
+
+    const compiled = await compiler.resolveAndCompile(program, {
+      filename: "standard-decorators.js",
+    });
+    expect(compiled.filename).toBe("standard-decorators.js");
+    expect(compiled.sourceMap).toBeDefined();
+  });
+
   it("Inlines errors", async () => {
     const compiler = new TypeScriptCompiler(types);
     const program = new InMemoryProgram("/main.tsx", {

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -151,6 +151,49 @@ Deno.test("Capability analysis tracks alias assignment chains", () => {
   assert(input.readPaths.includes("user.name"));
 });
 
+Deno.test("TypeScript exposes accessor fields as property declarations", () => {
+  const file = ts.createSourceFile(
+    "/test.ts",
+    `
+function tracked(
+  _value: undefined,
+  _context: ClassAccessorDecoratorContext<Example, number>,
+) {}
+
+class Example {
+  @tracked accessor count = 1;
+}
+`,
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  let property: ts.PropertyDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (property) return;
+    if (ts.isPropertyDeclaration(node)) {
+      property = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
+
+  assert(property);
+  assertEquals(property.name.getText(file), "count");
+  assert(
+    property.modifiers?.some((modifier) =>
+      modifier.kind === ts.SyntaxKind.AccessorKeyword
+    ),
+  );
+  assert(
+    property.modifiers?.some((modifier) =>
+      modifier.kind === ts.SyntaxKind.Decorator
+    ),
+  );
+});
+
 Deno.test("Capability analysis tracks object destructure aliases", () => {
   const fn = parseFirstCallback(
     `const fn = (input) => {


### PR DESCRIPTION
## Summary
- add a js-compiler guard that compiles a TSX input using a standard-decorator accessor field
- add a ts-transformers guard that verifies accessor fields still appear as PropertyDeclaration nodes with an AccessorKeyword
- keep this as prep only for the coordinated standard-decorators migration, not the migration itself

## Why
We now know the real migration cannot land incrementally before the root `experimentalDecorators` flag flip. These tests make two key assumptions executable before the actual cutover work starts.

## Validation
- `cd packages/js-compiler && deno test --allow-read --allow-write --allow-run --allow-env=UPDATE_GOLDENS,API_URL,"TSC_*",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV test/typescript.compiler.test.ts`
- `cd packages/ts-transformers && deno test --allow-read --allow-write --allow-env test/policy/capability-analysis.test.ts`