### PR TITLE
[codex] Add stable causes for reactive cell values

### DIFF
--- a/packages/ts-transformers/src/cf-pipeline.ts
+++ b/packages/ts-transformers/src/cf-pipeline.ts
@@ -10,6 +10,7 @@ import {
   PatternCallbackLoweringTransformer,
   PatternContextValidationTransformer,
   PatternOwnedExpressionSiteLoweringTransformer,
+  ReactiveVariableForTransformer,
   SchemaGeneratorTransformer,
   SchemaInjectionTransformer,
 } from "./transformers/mod.ts";
@@ -67,6 +68,7 @@ export class CommonFabricTransformerPipeline extends Pipeline {
     transformers.push(
       new SchemaInjectionTransformer(sharedOps),
       new SchemaGeneratorTransformer(sharedOps),
+      new ReactiveVariableForTransformer(sharedOps),
       new ModuleScopeShadowingTransformer(sharedOps),
       new ModuleScopeCfDataTransformer(sharedOps),
       new ModuleScopeFunctionHardeningTransformer(sharedOps),

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -25,9 +25,13 @@ import {
   isJsxLocalRewriteContainer,
 } from "./expression-rewrite/emitters/compute-wrap-invariants.ts";
 import type { AnalyzeFn } from "./expression-rewrite/types.ts";
-import { isOpaqueRefType } from "./opaque-ref/opaque-ref.ts";
 import { classifyOpaquePathTerminalCall } from "./opaque-roots.ts";
 import type { ExpressionContainerKind } from "./expression-site-types.ts";
+import {
+  isPatternFactoryCalleeExpression,
+  isStructuralReactiveFactoryExpression,
+  returnsOpaqueRefResult,
+} from "./structural-reactive-factory.ts";
 
 interface ExpressionSiteCallRootPolicyInfo {
   readonly reactiveContext: ReactiveContextInfo;
@@ -209,179 +213,6 @@ function getLeftmostMemberBase(expression: ts.Expression): ts.Expression {
     current = current.expression;
   }
   return current;
-}
-
-function isPatternFactoryCalleeExpression(
-  expression: ts.Expression,
-  checker: ts.TypeChecker,
-): boolean {
-  const target = unwrapExpression(expression);
-
-  try {
-    const type = checker.getTypeAtLocation(target);
-    const signatures = checker.getSignaturesOfType(type, ts.SignatureKind.Call);
-    if (signatures.length === 0) {
-      return false;
-    }
-
-    const propertyNames = new Set(
-      type.getProperties().map((property) => property.getName()),
-    );
-    if (
-      !propertyNames.has("argumentSchema") ||
-      !propertyNames.has("resultSchema") ||
-      propertyNames.has("with")
-    ) {
-      return false;
-    }
-
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function returnsOpaqueRefResult(
-  expression: ts.CallExpression,
-  checker: ts.TypeChecker,
-): boolean {
-  try {
-    const type = checker.getTypeAtLocation(expression);
-    return isOpaqueRefType(type, checker);
-  } catch {
-    return false;
-  }
-}
-
-function getAliasedSymbol(
-  symbol: ts.Symbol,
-  checker: ts.TypeChecker,
-): ts.Symbol {
-  if (!(symbol.flags & ts.SymbolFlags.Alias)) {
-    return symbol;
-  }
-
-  try {
-    return checker.getAliasedSymbol(symbol);
-  } catch {
-    return symbol;
-  }
-}
-
-function getReturnedExpression(
-  declaration: ts.Declaration,
-): ts.Expression | undefined {
-  if (
-    ts.isFunctionDeclaration(declaration) ||
-    ts.isMethodDeclaration(declaration) ||
-    ts.isFunctionExpression(declaration) ||
-    ts.isArrowFunction(declaration)
-  ) {
-    if (!declaration.body) {
-      return undefined;
-    }
-    if (ts.isBlock(declaration.body)) {
-      if (declaration.body.statements.length !== 1) {
-        return undefined;
-      }
-      const [statement] = declaration.body.statements;
-      return ts.isReturnStatement(statement) ? statement.expression : undefined;
-    }
-    return declaration.body;
-  }
-
-  if (!ts.isVariableDeclaration(declaration) || !declaration.initializer) {
-    return undefined;
-  }
-
-  const initializer = unwrapExpression(declaration.initializer);
-  if (
-    ts.isArrowFunction(initializer) ||
-    ts.isFunctionExpression(initializer)
-  ) {
-    return getReturnedExpression(initializer);
-  }
-
-  if (
-    ts.isIdentifier(initializer) ||
-    ts.isCallExpression(initializer) ||
-    ts.isPropertyAccessExpression(initializer)
-  ) {
-    return initializer;
-  }
-
-  return undefined;
-}
-
-function isStructuralReactiveFactoryExpression(
-  expression: ts.Expression,
-  checker: ts.TypeChecker,
-  seenSymbols = new Set<ts.Symbol>(),
-): boolean {
-  const target = unwrapExpression(expression);
-
-  if (ts.isCallExpression(target)) {
-    if (returnsOpaqueRefResult(target, checker)) {
-      return true;
-    }
-
-    if (isPatternFactoryCalleeExpression(target.expression, checker)) {
-      return true;
-    }
-
-    const callKind = detectCallKind(target, checker);
-    if (callKind) {
-      switch (callKind.kind) {
-        case "builder":
-        case "derive":
-        case "cell-factory":
-        case "cell-for":
-        case "wish":
-        case "generate-text":
-        case "generate-object":
-        case "pattern-tool":
-        case "runtime-call":
-          return true;
-        default:
-          break;
-      }
-    }
-
-    return isStructuralReactiveFactoryExpression(
-      target.expression,
-      checker,
-      seenSymbols,
-    );
-  }
-
-  if (
-    !ts.isIdentifier(target) &&
-    !ts.isPropertyAccessExpression(target)
-  ) {
-    return false;
-  }
-
-  const symbol = checker.getSymbolAtLocation(target);
-  if (!symbol) {
-    return false;
-  }
-
-  const resolvedSymbol = getAliasedSymbol(symbol, checker);
-  if (seenSymbols.has(resolvedSymbol)) {
-    return false;
-  }
-  seenSymbols.add(resolvedSymbol);
-
-  const declarations = resolvedSymbol.getDeclarations() ?? [];
-  return declarations.some((declaration) => {
-    const returnedExpression = getReturnedExpression(declaration);
-    return !!returnedExpression &&
-      isStructuralReactiveFactoryExpression(
-        returnedExpression,
-        checker,
-        seenSymbols,
-      );
-  });
 }
 
 function classifyCallExpressionRoot(

--- a/packages/ts-transformers/src/transformers/mod.ts
+++ b/packages/ts-transformers/src/transformers/mod.ts
@@ -9,5 +9,6 @@ export { ModuleScopeShadowingTransformer } from "./module-scope-shadowing.ts";
 export { OpaqueGetValidationTransformer } from "./opaque-get-validation.ts";
 export { PatternContextValidationTransformer } from "./pattern-context-validation.ts";
 export { PatternOwnedExpressionSiteLoweringTransformer } from "./pattern-owned-expression-site-lowering.ts";
+export { ReactiveVariableForTransformer } from "./reactive-variable-for.ts";
 export { SchemaInjectionTransformer } from "./schema-injection.ts";
 export { SchemaGeneratorTransformer } from "./schema-generator.ts";

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -21,6 +21,29 @@ function createReactiveVariableForVisitor(
   context: TransformationContext,
 ): ts.Visitor {
   const visit: ts.Visitor = (node: ts.Node): ts.Node => {
+    if (ts.isPropertyAssignment(node)) {
+      const visited = ts.visitEachChild(
+        node,
+        visit,
+        context.tsContext,
+      ) as ts.PropertyAssignment;
+
+      const propertyName = getStablePropertyName(visited.name);
+      if (
+        !propertyName ||
+        isInternalSyntheticName(propertyName) ||
+        !shouldAddPropertyFor(visited.initializer, context)
+      ) {
+        return visited;
+      }
+
+      return context.factory.updatePropertyAssignment(
+        visited,
+        visited.name,
+        createForCall(visited.initializer, propertyName, context),
+      );
+    }
+
     if (!ts.isVariableDeclarationList(node)) {
       return ts.visitEachChild(node, visit, context.tsContext);
     }
@@ -75,6 +98,30 @@ function shouldAddVariableFor(
   initializer: ts.Expression,
   context: TransformationContext,
 ): boolean {
+  return shouldAddReactiveFor(initializer, context, {
+    includeRuntimeCalls: true,
+    useTypeFallback: true,
+  });
+}
+
+function shouldAddPropertyFor(
+  initializer: ts.Expression,
+  context: TransformationContext,
+): boolean {
+  return shouldAddReactiveFor(initializer, context, {
+    includeRuntimeCalls: false,
+    useTypeFallback: false,
+  });
+}
+
+function shouldAddReactiveFor(
+  initializer: ts.Expression,
+  context: TransformationContext,
+  options: {
+    includeRuntimeCalls: boolean;
+    useTypeFallback: boolean;
+  },
+): boolean {
   if (chainContainsForCall(initializer)) {
     return false;
   }
@@ -109,11 +156,15 @@ function shouldAddVariableFor(
       case "generate-object":
         return true;
       case "runtime-call":
-        return callKind.reactiveOrigin;
+        return options.includeRuntimeCalls && callKind.reactiveOrigin;
       case "cell-for":
       case "pattern-tool":
         return false;
     }
+  }
+
+  if (!options.useTypeFallback) {
+    return false;
   }
 
   const type = getTypeAtLocationWithFallback(
@@ -127,6 +178,31 @@ function shouldAddVariableFor(
 
 function isInternalSyntheticName(name: string): boolean {
   return name.startsWith("__cf");
+}
+
+function getStablePropertyName(name: ts.PropertyName): string | undefined {
+  if (
+    ts.isIdentifier(name) ||
+    ts.isStringLiteralLike(name) ||
+    ts.isNumericLiteral(name)
+  ) {
+    return name.text;
+  }
+
+  if (!ts.isComputedPropertyName(name)) {
+    return undefined;
+  }
+
+  const expression = unwrapExpression(name.expression);
+  if (
+    ts.isStringLiteralLike(expression) ||
+    ts.isNoSubstitutionTemplateLiteral(expression) ||
+    ts.isNumericLiteral(expression)
+  ) {
+    return expression.text;
+  }
+
+  return undefined;
 }
 
 function isReactiveBuilderResult(

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -282,6 +282,9 @@ function visitExpressionWithCausePath(
       context.tsContext,
     ) as ts.Expression;
   }
+  if (addRootFor && isTransparentExpressionWrapper(expression)) {
+    return createForCall(expression, causePath, context);
+  }
 
   const visited = visitExpressionChildrenWithCausePath(
     expression,
@@ -300,6 +303,15 @@ function visitExpressionWithCausePath(
   }
 
   return createForCall(visited, causePath, context);
+}
+
+function isTransparentExpressionWrapper(expression: ts.Expression): boolean {
+  return ts.isParenthesizedExpression(expression) ||
+    ts.isAsExpression(expression) ||
+    ts.isTypeAssertionExpression(expression) ||
+    ts.isSatisfiesExpression(expression) ||
+    ts.isNonNullExpression(expression) ||
+    ts.isPartiallyEmittedExpression(expression);
 }
 
 function visitExpressionChildrenWithCausePath(

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -10,6 +10,7 @@ import {
   getTypeAtLocationWithFallback,
   hasReactiveCollectionProvenance,
   isCellLikeType,
+  isReactiveValueExpression,
 } from "../ast/mod.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { unwrapExpression } from "../utils/expression.ts";
@@ -304,7 +305,10 @@ function visitExpressionChildrenWithCausePath(
   if (ts.isObjectLiteralExpression(expression)) {
     let changed = false;
     const properties = expression.properties.map((property) => {
-      if (!ts.isPropertyAssignment(property)) {
+      if (
+        !ts.isPropertyAssignment(property) &&
+        !ts.isShorthandPropertyAssignment(property)
+      ) {
         const visited = ts.visitEachChild(
           property,
           visit,
@@ -328,22 +332,28 @@ function visitExpressionChildrenWithCausePath(
         return visited;
       }
 
-      const initializer = visitExpressionWithCausePath(
-        property.initializer,
+      const initializerExpression = ts.isPropertyAssignment(property)
+        ? property.initializer
+        : property.name;
+      const initializer = visitObjectPropertyInitializerWithCausePath(
+        initializerExpression,
         [...causePath, propertyName],
         context,
         visit,
-        { includeRoot: true },
       );
-      if (initializer === property.initializer) {
+      if (initializer === initializerExpression) {
         return property;
       }
 
       changed = true;
-      return context.factory.updatePropertyAssignment(
-        property,
+      const updatedProperty = context.factory.createPropertyAssignment(
         property.name,
         initializer,
+      );
+      return context.cfHelpers.preserveNodeSourceMap(
+        updatedProperty,
+        property,
+        property,
       );
     });
 
@@ -463,17 +473,36 @@ function getCallArgumentCausePath(
   index: number,
   argumentCount: number,
 ): CausePath {
+  const unwrappedArgument = unwrapExpression(argument);
   if (
     argumentCount === 1 &&
     (
-      ts.isObjectLiteralExpression(argument) ||
-      ts.isArrayLiteralExpression(argument)
+      ts.isObjectLiteralExpression(unwrappedArgument) ||
+      ts.isArrayLiteralExpression(unwrappedArgument)
     )
   ) {
     return causePath;
   }
 
   return [...causePath, index];
+}
+
+function visitObjectPropertyInitializerWithCausePath(
+  expression: ts.Expression,
+  causePath: CausePath,
+  context: TransformationContext,
+  visit: ts.Visitor,
+): ts.Expression {
+  const visited = visitExpressionWithCausePath(
+    expression,
+    causePath,
+    context,
+    visit,
+    { includeRoot: true },
+  );
+  return shouldRetargetReactiveReference(visited, context)
+    ? createForCall(visited, causePath, context)
+    : visited;
 }
 
 function shouldAddVariableFor(
@@ -678,6 +707,15 @@ function isExplicitReactiveCall(
       includeRuntimeCalls: true,
       useTypeFallback: true,
     });
+}
+
+function shouldRetargetReactiveReference(
+  expression: ts.Expression,
+  context: TransformationContext,
+): boolean {
+  const target = unwrapExpression(expression);
+  return ts.isIdentifier(target) &&
+    isReactiveValueExpression(target, context.checker);
 }
 
 function chainContainsForCall(expression: ts.Expression): boolean {

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -14,6 +14,10 @@ import {
 } from "../ast/mod.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { unwrapExpression } from "../utils/expression.ts";
+import {
+  isPatternFactoryCalleeExpression,
+  isPatternFactoryHelperExpression,
+} from "./structural-reactive-factory.ts";
 
 type CausePathElement = string | number;
 type CausePath = readonly CausePathElement[];
@@ -579,7 +583,9 @@ function shouldAddReactiveFor(
     return false;
   }
 
-  if (isPatternFactoryCall(expression, context)) {
+  if (
+    isPatternFactoryCalleeExpression(expression.expression, context.checker)
+  ) {
     return false;
   }
 
@@ -708,32 +714,6 @@ function isReactiveArrayMethodCall(
   ) || isExplicitReactiveCall(target.expression, context);
 }
 
-function isPatternFactoryCall(
-  call: ts.CallExpression,
-  context: TransformationContext,
-): boolean {
-  const target = unwrapExpression(call.expression);
-  try {
-    const type = context.checker.getTypeAtLocation(target);
-    const signatures = context.checker.getSignaturesOfType(
-      type,
-      ts.SignatureKind.Call,
-    );
-    if (signatures.length === 0) {
-      return false;
-    }
-
-    const propertyNames = new Set(
-      type.getProperties().map((property) => property.getName()),
-    );
-    return propertyNames.has("argumentSchema") &&
-      propertyNames.has("resultSchema") &&
-      !propertyNames.has("with");
-  } catch {
-    return false;
-  }
-}
-
 function isExplicitReactiveCall(
   expression: ts.Expression,
   context: TransformationContext,
@@ -759,117 +739,8 @@ function shouldPreserveStructuralCallArgumentReferences(
   call: ts.CallExpression,
   context: TransformationContext,
 ): boolean {
-  return isPatternFactoryCall(call, context) ||
-    isStructuralPatternFactoryHelperExpression(
-      call.expression,
-      context,
-      new Set(),
-    );
-}
-
-function isStructuralPatternFactoryHelperExpression(
-  expression: ts.Expression,
-  context: TransformationContext,
-  seenSymbols: Set<ts.Symbol>,
-): boolean {
-  const target = unwrapExpression(expression);
-
-  if (ts.isCallExpression(target)) {
-    return isPatternFactoryCall(target, context) ||
-      isStructuralPatternFactoryHelperExpression(
-        target.expression,
-        context,
-        seenSymbols,
-      );
-  }
-
-  if (
-    !ts.isIdentifier(target) &&
-    !ts.isPropertyAccessExpression(target)
-  ) {
-    return false;
-  }
-
-  const symbol = context.checker.getSymbolAtLocation(target);
-  if (!symbol) {
-    return false;
-  }
-
-  const resolvedSymbol = getAliasedSymbol(symbol, context.checker);
-  if (seenSymbols.has(resolvedSymbol)) {
-    return false;
-  }
-  seenSymbols.add(resolvedSymbol);
-
-  return (resolvedSymbol.getDeclarations() ?? []).some((declaration) => {
-    const returnedExpression = getReturnedExpression(declaration);
-    return !!returnedExpression &&
-      isStructuralPatternFactoryHelperExpression(
-        returnedExpression,
-        context,
-        seenSymbols,
-      );
-  });
-}
-
-function getAliasedSymbol(
-  symbol: ts.Symbol,
-  checker: ts.TypeChecker,
-): ts.Symbol {
-  if (!(symbol.flags & ts.SymbolFlags.Alias)) {
-    return symbol;
-  }
-
-  try {
-    return checker.getAliasedSymbol(symbol);
-  } catch {
-    return symbol;
-  }
-}
-
-function getReturnedExpression(
-  declaration: ts.Declaration,
-): ts.Expression | undefined {
-  if (
-    ts.isFunctionDeclaration(declaration) ||
-    ts.isMethodDeclaration(declaration) ||
-    ts.isFunctionExpression(declaration) ||
-    ts.isArrowFunction(declaration)
-  ) {
-    if (!declaration.body) {
-      return undefined;
-    }
-    if (ts.isBlock(declaration.body)) {
-      if (declaration.body.statements.length !== 1) {
-        return undefined;
-      }
-      const [statement] = declaration.body.statements;
-      return ts.isReturnStatement(statement) ? statement.expression : undefined;
-    }
-    return declaration.body;
-  }
-
-  if (!ts.isVariableDeclaration(declaration) || !declaration.initializer) {
-    return undefined;
-  }
-
-  const initializer = unwrapExpression(declaration.initializer);
-  if (
-    ts.isArrowFunction(initializer) ||
-    ts.isFunctionExpression(initializer)
-  ) {
-    return getReturnedExpression(initializer);
-  }
-
-  if (
-    ts.isIdentifier(initializer) ||
-    ts.isCallExpression(initializer) ||
-    ts.isPropertyAccessExpression(initializer)
-  ) {
-    return initializer;
-  }
-
-  return undefined;
+  return isPatternFactoryCalleeExpression(call.expression, context.checker) ||
+    isPatternFactoryHelperExpression(call.expression, context.checker);
 }
 
 function chainContainsForCall(expression: ts.Expression): boolean {

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -39,6 +39,7 @@ function createReactiveVariableForVisitor(
     const declarations = visited.declarations.map((declaration) => {
       if (
         !ts.isIdentifier(declaration.name) ||
+        isInternalSyntheticName(declaration.name.text) ||
         !declaration.initializer ||
         !shouldAddVariableFor(declaration.initializer, context)
       ) {
@@ -122,6 +123,10 @@ function shouldAddVariableFor(
     context.options.logger,
   );
   return isCellLikeType(type, context.checker);
+}
+
+function isInternalSyntheticName(name: string): boolean {
+  return name.startsWith("__cf");
 }
 
 function isReactiveBuilderResult(

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -1,11 +1,14 @@
 import ts from "typescript";
 
 import {
+  classifyArrayMethodCall,
   classifyArrayMethodCallSite,
   detectCallKind,
   detectDirectBuilderCall,
+  getEnclosingFunctionLikeDeclaration,
   getPatternBuilderCallbackArgument,
   getTypeAtLocationWithFallback,
+  hasReactiveCollectionProvenance,
   isCellLikeType,
 } from "../ast/mod.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
@@ -35,35 +38,6 @@ function createReactiveVariableForVisitor(
       if (patternCallback) {
         return visitPatternCall(node, patternCallback, context, visit);
       }
-    }
-
-    if (ts.isPropertyAssignment(node)) {
-      const propertyName = getStablePropertyName(node.name);
-      if (
-        !propertyName ||
-        isInternalSyntheticName(propertyName)
-      ) {
-        const visited = ts.visitEachChild(
-          node,
-          visit,
-          context.tsContext,
-        ) as ts.PropertyAssignment;
-        return visited;
-      }
-
-      const visitedInitializer = visitExpressionWithCausePath(
-        node.initializer,
-        [propertyName],
-        context,
-        visit,
-        { includeRoot: true },
-      );
-
-      return context.factory.updatePropertyAssignment(
-        node,
-        node.name,
-        visitedInitializer,
-      );
     }
 
     if (!ts.isVariableDeclarationList(node)) {
@@ -447,6 +421,26 @@ function visitExpressionChildrenWithCausePath(
       : expression;
   }
 
+  if (
+    ts.isPropertyAccessExpression(expression) ||
+    ts.isElementAccessExpression(expression)
+  ) {
+    return ts.visitEachChild(
+      expression,
+      (child) =>
+        child === expression.expression
+          ? visitExpressionWithCausePath(
+            child as ts.Expression,
+            causePath,
+            context,
+            visit,
+            { includeRoot: false },
+          )
+          : visit(child),
+      context.tsContext,
+    ) as ts.Expression;
+  }
+
   return ts.visitEachChild(
     expression,
     (child) =>
@@ -516,6 +510,10 @@ function shouldAddReactiveFor(
 
   const expression = unwrapExpression(initializer);
   if (!ts.isCallExpression(expression)) {
+    return false;
+  }
+
+  if (isPatternFactoryCall(expression, context)) {
     return false;
   }
 
@@ -610,8 +608,76 @@ function isReactiveArrayMethodCall(
   call: ts.CallExpression,
   context: TransformationContext,
 ): boolean {
-  return classifyArrayMethodCallSite(call, context.checker)?.ownership ===
-    "reactive";
+  const access = classifyArrayMethodCall(call);
+  if (!access) {
+    return false;
+  }
+
+  const callSite = classifyArrayMethodCallSite(call, context.checker);
+  if (access.lowered && callSite?.ownership === "reactive") {
+    return true;
+  }
+
+  const target = unwrapExpression(call.expression);
+  if (
+    !ts.isPropertyAccessExpression(target) &&
+    !ts.isElementAccessExpression(target)
+  ) {
+    return false;
+  }
+
+  return hasReactiveCollectionProvenance(
+    target.expression,
+    context.checker,
+    {
+      allowTypeBasedRoot: false,
+      allowImplicitReactiveParameters: false,
+      allowReactiveArrayCallbackParameters: false,
+      sameScope: getEnclosingFunctionLikeDeclaration(call),
+      typeRegistry: context.options.typeRegistry,
+      syntheticReactiveCollectionRegistry:
+        context.options.syntheticReactiveCollectionRegistry,
+      logger: context.options.logger,
+    },
+  ) || isExplicitReactiveCall(target.expression, context);
+}
+
+function isPatternFactoryCall(
+  call: ts.CallExpression,
+  context: TransformationContext,
+): boolean {
+  const target = unwrapExpression(call.expression);
+  try {
+    const type = context.checker.getTypeAtLocation(target);
+    const signatures = context.checker.getSignaturesOfType(
+      type,
+      ts.SignatureKind.Call,
+    );
+    if (signatures.length === 0) {
+      return false;
+    }
+
+    const propertyNames = new Set(
+      type.getProperties().map((property) => property.getName()),
+    );
+    return propertyNames.has("argumentSchema") &&
+      propertyNames.has("resultSchema") &&
+      !propertyNames.has("with");
+  } catch {
+    return false;
+  }
+}
+
+function isExplicitReactiveCall(
+  expression: ts.Expression,
+  context: TransformationContext,
+): boolean {
+  const target = unwrapExpression(expression);
+  return ts.isCallExpression(target) &&
+    shouldAddReactiveFor(target, context, {
+      includeRuntimeCalls: true,
+      useTypeFallback: true,
+    });
 }
 
 function chainContainsForCall(expression: ts.Expression): boolean {

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -263,6 +263,7 @@ function visitExpressionWithCausePath(
   visit: ts.Visitor,
   options: {
     includeRoot: boolean;
+    allowReactiveIdentifierRetargeting?: boolean;
   },
 ): ts.Expression {
   const addRootFor = options.includeRoot &&
@@ -283,7 +284,11 @@ function visitExpressionWithCausePath(
     causePath,
     context,
     visit,
-    { skipCallArguments: addRootFor },
+    {
+      skipCallArguments: addRootFor,
+      allowReactiveIdentifierRetargeting:
+        options.allowReactiveIdentifierRetargeting ?? true,
+    },
   );
 
   if (!addRootFor) {
@@ -300,6 +305,7 @@ function visitExpressionChildrenWithCausePath(
   visit: ts.Visitor,
   options: {
     skipCallArguments: boolean;
+    allowReactiveIdentifierRetargeting: boolean;
   },
 ): ts.Expression {
   if (ts.isObjectLiteralExpression(expression)) {
@@ -340,6 +346,10 @@ function visitExpressionChildrenWithCausePath(
         [...causePath, propertyName],
         context,
         visit,
+        {
+          allowReactiveIdentifierRetargeting:
+            options.allowReactiveIdentifierRetargeting,
+        },
       );
       if (initializer === initializerExpression) {
         return property;
@@ -380,7 +390,11 @@ function visitExpressionChildrenWithCausePath(
         [...causePath, index],
         context,
         visit,
-        { includeRoot: true },
+        {
+          includeRoot: true,
+          allowReactiveIdentifierRetargeting:
+            options.allowReactiveIdentifierRetargeting,
+        },
       );
       changed ||= visited !== element;
       return visited;
@@ -397,6 +411,9 @@ function visitExpressionChildrenWithCausePath(
     }
 
     let changed = false;
+    const allowArgumentReactiveIdentifierRetargeting =
+      options.allowReactiveIdentifierRetargeting &&
+      !shouldPreserveStructuralCallArgumentReferences(expression, context);
     const callTarget = ts.visitNode(
       expression.expression,
       visit,
@@ -415,7 +432,11 @@ function visitExpressionChildrenWithCausePath(
         argumentPath,
         context,
         visit,
-        { includeRoot: true },
+        {
+          includeRoot: true,
+          allowReactiveIdentifierRetargeting:
+            allowArgumentReactiveIdentifierRetargeting,
+        },
       );
       changed ||= visited !== argument;
       return visited;
@@ -444,7 +465,11 @@ function visitExpressionChildrenWithCausePath(
             causePath,
             context,
             visit,
-            { includeRoot: false },
+            {
+              includeRoot: false,
+              allowReactiveIdentifierRetargeting:
+                options.allowReactiveIdentifierRetargeting,
+            },
           )
           : visit(child),
       context.tsContext,
@@ -460,7 +485,11 @@ function visitExpressionChildrenWithCausePath(
           causePath,
           context,
           visit,
-          { includeRoot: true },
+          {
+            includeRoot: true,
+            allowReactiveIdentifierRetargeting:
+              options.allowReactiveIdentifierRetargeting,
+          },
         )
         : visit(child),
     context.tsContext,
@@ -492,15 +521,23 @@ function visitObjectPropertyInitializerWithCausePath(
   causePath: CausePath,
   context: TransformationContext,
   visit: ts.Visitor,
+  options: {
+    allowReactiveIdentifierRetargeting: boolean;
+  },
 ): ts.Expression {
   const visited = visitExpressionWithCausePath(
     expression,
     causePath,
     context,
     visit,
-    { includeRoot: true },
+    {
+      includeRoot: true,
+      allowReactiveIdentifierRetargeting:
+        options.allowReactiveIdentifierRetargeting,
+    },
   );
-  return shouldRetargetReactiveReference(visited, context)
+  return options.allowReactiveIdentifierRetargeting &&
+      shouldRetargetReactiveReference(visited, context)
     ? createForCall(visited, causePath, context)
     : visited;
 }
@@ -716,6 +753,123 @@ function shouldRetargetReactiveReference(
   const target = unwrapExpression(expression);
   return ts.isIdentifier(target) &&
     isReactiveValueExpression(target, context.checker);
+}
+
+function shouldPreserveStructuralCallArgumentReferences(
+  call: ts.CallExpression,
+  context: TransformationContext,
+): boolean {
+  return isPatternFactoryCall(call, context) ||
+    isStructuralPatternFactoryHelperExpression(
+      call.expression,
+      context,
+      new Set(),
+    );
+}
+
+function isStructuralPatternFactoryHelperExpression(
+  expression: ts.Expression,
+  context: TransformationContext,
+  seenSymbols: Set<ts.Symbol>,
+): boolean {
+  const target = unwrapExpression(expression);
+
+  if (ts.isCallExpression(target)) {
+    return isPatternFactoryCall(target, context) ||
+      isStructuralPatternFactoryHelperExpression(
+        target.expression,
+        context,
+        seenSymbols,
+      );
+  }
+
+  if (
+    !ts.isIdentifier(target) &&
+    !ts.isPropertyAccessExpression(target)
+  ) {
+    return false;
+  }
+
+  const symbol = context.checker.getSymbolAtLocation(target);
+  if (!symbol) {
+    return false;
+  }
+
+  const resolvedSymbol = getAliasedSymbol(symbol, context.checker);
+  if (seenSymbols.has(resolvedSymbol)) {
+    return false;
+  }
+  seenSymbols.add(resolvedSymbol);
+
+  return (resolvedSymbol.getDeclarations() ?? []).some((declaration) => {
+    const returnedExpression = getReturnedExpression(declaration);
+    return !!returnedExpression &&
+      isStructuralPatternFactoryHelperExpression(
+        returnedExpression,
+        context,
+        seenSymbols,
+      );
+  });
+}
+
+function getAliasedSymbol(
+  symbol: ts.Symbol,
+  checker: ts.TypeChecker,
+): ts.Symbol {
+  if (!(symbol.flags & ts.SymbolFlags.Alias)) {
+    return symbol;
+  }
+
+  try {
+    return checker.getAliasedSymbol(symbol);
+  } catch {
+    return symbol;
+  }
+}
+
+function getReturnedExpression(
+  declaration: ts.Declaration,
+): ts.Expression | undefined {
+  if (
+    ts.isFunctionDeclaration(declaration) ||
+    ts.isMethodDeclaration(declaration) ||
+    ts.isFunctionExpression(declaration) ||
+    ts.isArrowFunction(declaration)
+  ) {
+    if (!declaration.body) {
+      return undefined;
+    }
+    if (ts.isBlock(declaration.body)) {
+      if (declaration.body.statements.length !== 1) {
+        return undefined;
+      }
+      const [statement] = declaration.body.statements;
+      return ts.isReturnStatement(statement) ? statement.expression : undefined;
+    }
+    return declaration.body;
+  }
+
+  if (!ts.isVariableDeclaration(declaration) || !declaration.initializer) {
+    return undefined;
+  }
+
+  const initializer = unwrapExpression(declaration.initializer);
+  if (
+    ts.isArrowFunction(initializer) ||
+    ts.isFunctionExpression(initializer)
+  ) {
+    return getReturnedExpression(initializer);
+  }
+
+  if (
+    ts.isIdentifier(initializer) ||
+    ts.isCallExpression(initializer) ||
+    ts.isPropertyAccessExpression(initializer)
+  ) {
+    return initializer;
+  }
+
+  return undefined;
 }
 
 function chainContainsForCall(expression: ts.Expression): boolean {

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -732,6 +732,7 @@ function shouldRetargetReactiveReference(
 ): boolean {
   const target = unwrapExpression(expression);
   return ts.isIdentifier(target) &&
+    !isPatternFactoryHelperExpression(target, context.checker) &&
     isReactiveValueExpression(target, context.checker);
 }
 

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -1,0 +1,205 @@
+import ts from "typescript";
+
+import {
+  classifyArrayMethodCallSite,
+  detectCallKind,
+  detectDirectBuilderCall,
+  getTypeAtLocationWithFallback,
+  isCellLikeType,
+} from "../ast/mod.ts";
+import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
+import { unwrapExpression } from "../utils/expression.ts";
+
+export class ReactiveVariableForTransformer extends HelpersOnlyTransformer {
+  override transform(context: TransformationContext): ts.SourceFile {
+    const visitor = createReactiveVariableForVisitor(context);
+    return ts.visitNode(context.sourceFile, visitor) as ts.SourceFile;
+  }
+}
+
+function createReactiveVariableForVisitor(
+  context: TransformationContext,
+): ts.Visitor {
+  const visit: ts.Visitor = (node: ts.Node): ts.Node => {
+    if (!ts.isVariableDeclarationList(node)) {
+      return ts.visitEachChild(node, visit, context.tsContext);
+    }
+
+    const visited = ts.visitEachChild(
+      node,
+      visit,
+      context.tsContext,
+    ) as ts.VariableDeclarationList;
+
+    if ((visited.flags & ts.NodeFlags.Const) === 0) {
+      return visited;
+    }
+
+    let changed = false;
+    const declarations = visited.declarations.map((declaration) => {
+      if (
+        !ts.isIdentifier(declaration.name) ||
+        !declaration.initializer ||
+        !shouldAddVariableFor(declaration.initializer, context)
+      ) {
+        return declaration;
+      }
+
+      changed = true;
+      return context.factory.updateVariableDeclaration(
+        declaration,
+        declaration.name,
+        declaration.exclamationToken,
+        declaration.type,
+        createForCall(
+          declaration.initializer,
+          declaration.name.text,
+          context,
+        ),
+      );
+    });
+
+    return changed
+      ? context.factory.updateVariableDeclarationList(
+        visited,
+        declarations,
+      )
+      : visited;
+  };
+
+  return visit;
+}
+
+function shouldAddVariableFor(
+  initializer: ts.Expression,
+  context: TransformationContext,
+): boolean {
+  if (chainContainsForCall(initializer)) {
+    return false;
+  }
+
+  const expression = unwrapExpression(initializer);
+  if (!ts.isCallExpression(expression)) {
+    return false;
+  }
+
+  if (isReactiveArrayMethodCall(expression, context)) {
+    return true;
+  }
+
+  const callKind = detectCallKind(expression, context.checker);
+  if (callKind) {
+    switch (callKind.kind) {
+      case "array-method":
+        return isReactiveArrayMethodCall(expression, context);
+      case "builder":
+        return isReactiveBuilderResult(
+          expression,
+          callKind.builderName,
+          context,
+        );
+      case "cell-factory":
+      case "derive":
+      case "ifElse":
+      case "when":
+      case "unless":
+      case "wish":
+      case "generate-text":
+      case "generate-object":
+        return true;
+      case "runtime-call":
+        return callKind.reactiveOrigin;
+      case "cell-for":
+      case "pattern-tool":
+        return false;
+    }
+  }
+
+  const type = getTypeAtLocationWithFallback(
+    expression,
+    context.checker,
+    context.options.typeRegistry,
+    context.options.logger,
+  );
+  return isCellLikeType(type, context.checker);
+}
+
+function isReactiveBuilderResult(
+  call: ts.CallExpression,
+  builderName: string,
+  context: TransformationContext,
+): boolean {
+  const direct = detectDirectBuilderCall(call, context.checker);
+  if (!direct) {
+    return true;
+  }
+
+  return builderName === "action" || builderName === "computed";
+}
+
+function isReactiveArrayMethodCall(
+  call: ts.CallExpression,
+  context: TransformationContext,
+): boolean {
+  return classifyArrayMethodCallSite(call, context.checker)?.ownership ===
+    "reactive";
+}
+
+function chainContainsForCall(expression: ts.Expression): boolean {
+  let current = unwrapExpression(expression);
+
+  while (ts.isCallExpression(current)) {
+    const target = unwrapExpression(current.expression);
+    if (isForAccess(target)) {
+      return true;
+    }
+    if (
+      ts.isPropertyAccessExpression(target) ||
+      ts.isElementAccessExpression(target)
+    ) {
+      current = unwrapExpression(target.expression);
+      continue;
+    }
+    break;
+  }
+
+  return false;
+}
+
+function isForAccess(expression: ts.Expression): boolean {
+  if (ts.isPropertyAccessExpression(expression)) {
+    return expression.name.text === "for";
+  }
+
+  if (!ts.isElementAccessExpression(expression)) {
+    return false;
+  }
+
+  const argument = expression.argumentExpression;
+  return !!argument &&
+    (
+      ts.isStringLiteralLike(argument) ||
+      ts.isNoSubstitutionTemplateLiteral(argument)
+    ) &&
+    argument.text === "for";
+}
+
+function createForCall(
+  initializer: ts.Expression,
+  variableName: string,
+  context: TransformationContext,
+): ts.Expression {
+  const call = context.factory.createCallExpression(
+    context.factory.createPropertyAccessExpression(initializer, "for"),
+    undefined,
+    [
+      context.factory.createStringLiteral(variableName),
+      context.factory.createTrue(),
+    ],
+  );
+  return context.cfHelpers.preserveNodeSourceMap(
+    call,
+    initializer,
+    initializer,
+  );
+}

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -4,11 +4,17 @@ import {
   classifyArrayMethodCallSite,
   detectCallKind,
   detectDirectBuilderCall,
+  getPatternBuilderCallbackArgument,
   getTypeAtLocationWithFallback,
   isCellLikeType,
 } from "../ast/mod.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { unwrapExpression } from "../utils/expression.ts";
+
+type CausePathElement = string | number;
+type CausePath = readonly CausePathElement[];
+
+const PATTERN_RESULT_CAUSE = "__patternResult";
 
 export class ReactiveVariableForTransformer extends HelpersOnlyTransformer {
   override transform(context: TransformationContext): ts.SourceFile {
@@ -21,26 +27,42 @@ function createReactiveVariableForVisitor(
   context: TransformationContext,
 ): ts.Visitor {
   const visit: ts.Visitor = (node: ts.Node): ts.Node => {
-    if (ts.isPropertyAssignment(node)) {
-      const visited = ts.visitEachChild(
+    if (ts.isCallExpression(node)) {
+      const patternCallback = getPatternBuilderCallbackArgument(
         node,
-        visit,
-        context.tsContext,
-      ) as ts.PropertyAssignment;
+        context.checker,
+      );
+      if (patternCallback) {
+        return visitPatternCall(node, patternCallback, context, visit);
+      }
+    }
 
-      const propertyName = getStablePropertyName(visited.name);
+    if (ts.isPropertyAssignment(node)) {
+      const propertyName = getStablePropertyName(node.name);
       if (
         !propertyName ||
-        isInternalSyntheticName(propertyName) ||
-        !shouldAddPropertyFor(visited.initializer, context)
+        isInternalSyntheticName(propertyName)
       ) {
+        const visited = ts.visitEachChild(
+          node,
+          visit,
+          context.tsContext,
+        ) as ts.PropertyAssignment;
         return visited;
       }
 
+      const visitedInitializer = visitExpressionWithCausePath(
+        node.initializer,
+        [propertyName],
+        context,
+        visit,
+        { includeRoot: true },
+      );
+
       return context.factory.updatePropertyAssignment(
-        visited,
-        visited.name,
-        createForCall(visited.initializer, propertyName, context),
+        node,
+        node.name,
+        visitedInitializer,
       );
     }
 
@@ -48,24 +70,43 @@ function createReactiveVariableForVisitor(
       return ts.visitEachChild(node, visit, context.tsContext);
     }
 
-    const visited = ts.visitEachChild(
-      node,
-      visit,
-      context.tsContext,
-    ) as ts.VariableDeclarationList;
-
-    if ((visited.flags & ts.NodeFlags.Const) === 0) {
-      return visited;
+    if ((node.flags & ts.NodeFlags.Const) === 0) {
+      return ts.visitEachChild(node, visit, context.tsContext);
     }
 
     let changed = false;
-    const declarations = visited.declarations.map((declaration) => {
+    const declarations = node.declarations.map((declaration) => {
       if (
         !ts.isIdentifier(declaration.name) ||
         isInternalSyntheticName(declaration.name.text) ||
-        !declaration.initializer ||
-        !shouldAddVariableFor(declaration.initializer, context)
+        !declaration.initializer
       ) {
+        const visited = ts.visitEachChild(
+          declaration,
+          visit,
+          context.tsContext,
+        ) as ts.VariableDeclaration;
+        changed ||= visited !== declaration;
+        return visited;
+      }
+
+      let initializer = visitExpressionWithCausePath(
+        declaration.initializer,
+        [declaration.name.text],
+        context,
+        visit,
+        { includeRoot: false },
+      );
+
+      if (shouldAddVariableFor(initializer, context)) {
+        initializer = createForCall(
+          initializer,
+          declaration.name.text,
+          context,
+        );
+      }
+
+      if (initializer === declaration.initializer) {
         return declaration;
       }
 
@@ -75,23 +116,370 @@ function createReactiveVariableForVisitor(
         declaration.name,
         declaration.exclamationToken,
         declaration.type,
-        createForCall(
-          declaration.initializer,
-          declaration.name.text,
-          context,
-        ),
+        initializer,
       );
     });
 
     return changed
       ? context.factory.updateVariableDeclarationList(
-        visited,
+        node,
         declarations,
       )
-      : visited;
+      : node;
   };
 
   return visit;
+}
+
+function visitPatternCall(
+  node: ts.CallExpression,
+  patternCallback: ts.ArrowFunction | ts.FunctionExpression,
+  context: TransformationContext,
+  visit: ts.Visitor,
+): ts.CallExpression {
+  let changed = false;
+  const callTarget = ts.visitNode(node.expression, visit) as ts.Expression;
+  changed ||= callTarget !== node.expression;
+
+  const args = node.arguments.map((argument) => {
+    const visited = visitPatternCallbackArgument(
+      argument,
+      patternCallback,
+      context,
+      visit,
+    );
+    changed ||= visited !== argument;
+    return visited;
+  });
+
+  return changed
+    ? context.factory.updateCallExpression(
+      node,
+      callTarget,
+      node.typeArguments,
+      args,
+    )
+    : node;
+}
+
+function visitPatternCallbackArgument(
+  argument: ts.Expression,
+  patternCallback: ts.ArrowFunction | ts.FunctionExpression,
+  context: TransformationContext,
+  visit: ts.Visitor,
+): ts.Expression {
+  if (argument === patternCallback) {
+    return visitPatternCallbackFunction(patternCallback, context, visit);
+  }
+
+  return ts.visitEachChild(
+    argument,
+    (child) =>
+      child === patternCallback
+        ? visitPatternCallbackFunction(patternCallback, context, visit)
+        : visit(child),
+    context.tsContext,
+  ) as ts.Expression;
+}
+
+function visitPatternCallbackFunction(
+  callback: ts.ArrowFunction | ts.FunctionExpression,
+  context: TransformationContext,
+  visit: ts.Visitor,
+): ts.ArrowFunction | ts.FunctionExpression {
+  if (ts.isArrowFunction(callback) && !ts.isBlock(callback.body)) {
+    const body = visitExpressionWithCausePath(
+      callback.body,
+      [PATTERN_RESULT_CAUSE],
+      context,
+      visit,
+      { includeRoot: true },
+    );
+    return context.factory.updateArrowFunction(
+      callback,
+      callback.modifiers,
+      callback.typeParameters,
+      callback.parameters,
+      callback.type,
+      callback.equalsGreaterThanToken,
+      body,
+    );
+  }
+
+  const body = ts.visitNode(
+    callback.body,
+    (node) => visitPatternCallbackBodyNode(node, context, visit),
+    ts.isBlock,
+  );
+  if (!body || body === callback.body) {
+    return callback;
+  }
+
+  return ts.isArrowFunction(callback)
+    ? context.factory.updateArrowFunction(
+      callback,
+      callback.modifiers,
+      callback.typeParameters,
+      callback.parameters,
+      callback.type,
+      callback.equalsGreaterThanToken,
+      body,
+    )
+    : context.factory.updateFunctionExpression(
+      callback,
+      callback.modifiers,
+      callback.asteriskToken,
+      callback.name,
+      callback.typeParameters,
+      callback.parameters,
+      callback.type,
+      body,
+    );
+}
+
+function visitPatternCallbackBodyNode(
+  node: ts.Node,
+  context: TransformationContext,
+  visit: ts.Visitor,
+): ts.Node {
+  if (
+    node !== undefined &&
+    (
+      ts.isArrowFunction(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isFunctionDeclaration(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node) ||
+      ts.isConstructorDeclaration(node)
+    )
+  ) {
+    return ts.visitEachChild(node, visit, context.tsContext);
+  }
+
+  if (ts.isReturnStatement(node) && node.expression) {
+    return context.factory.updateReturnStatement(
+      node,
+      visitExpressionWithCausePath(
+        node.expression,
+        [PATTERN_RESULT_CAUSE],
+        context,
+        visit,
+        { includeRoot: true },
+      ),
+    );
+  }
+
+  if (ts.isExpression(node) || ts.isVariableDeclarationList(node)) {
+    return visit(node) as ts.Node;
+  }
+
+  return ts.visitEachChild(
+    node,
+    (child) => visitPatternCallbackBodyNode(child, context, visit),
+    context.tsContext,
+  );
+}
+
+function visitExpressionWithCausePath(
+  expression: ts.Expression,
+  causePath: CausePath,
+  context: TransformationContext,
+  visit: ts.Visitor,
+  options: {
+    includeRoot: boolean;
+  },
+): ts.Expression {
+  const addRootFor = options.includeRoot &&
+    shouldAddPropertyFor(expression, context);
+  if (
+    ts.isArrowFunction(expression) ||
+    ts.isFunctionExpression(expression)
+  ) {
+    return ts.visitEachChild(
+      expression,
+      visit,
+      context.tsContext,
+    ) as ts.Expression;
+  }
+
+  const visited = visitExpressionChildrenWithCausePath(
+    expression,
+    causePath,
+    context,
+    visit,
+    { skipCallArguments: addRootFor },
+  );
+
+  if (!addRootFor) {
+    return visited;
+  }
+
+  return createForCall(visited, causePath, context);
+}
+
+function visitExpressionChildrenWithCausePath(
+  expression: ts.Expression,
+  causePath: CausePath,
+  context: TransformationContext,
+  visit: ts.Visitor,
+  options: {
+    skipCallArguments: boolean;
+  },
+): ts.Expression {
+  if (ts.isObjectLiteralExpression(expression)) {
+    let changed = false;
+    const properties = expression.properties.map((property) => {
+      if (!ts.isPropertyAssignment(property)) {
+        const visited = ts.visitEachChild(
+          property,
+          visit,
+          context.tsContext,
+        ) as ts.ObjectLiteralElementLike;
+        changed ||= visited !== property;
+        return visited;
+      }
+
+      const propertyName = getStablePropertyName(property.name);
+      if (
+        !propertyName ||
+        isInternalSyntheticName(propertyName)
+      ) {
+        const visited = ts.visitEachChild(
+          property,
+          visit,
+          context.tsContext,
+        ) as ts.PropertyAssignment;
+        changed ||= visited !== property;
+        return visited;
+      }
+
+      const initializer = visitExpressionWithCausePath(
+        property.initializer,
+        [...causePath, propertyName],
+        context,
+        visit,
+        { includeRoot: true },
+      );
+      if (initializer === property.initializer) {
+        return property;
+      }
+
+      changed = true;
+      return context.factory.updatePropertyAssignment(
+        property,
+        property.name,
+        initializer,
+      );
+    });
+
+    return changed
+      ? context.factory.updateObjectLiteralExpression(expression, properties)
+      : expression;
+  }
+
+  if (ts.isArrayLiteralExpression(expression)) {
+    let changed = false;
+    const elements = expression.elements.map((element, index) => {
+      if (ts.isOmittedExpression(element) || ts.isSpreadElement(element)) {
+        const visited = ts.visitEachChild(
+          element,
+          visit,
+          context.tsContext,
+        ) as ts.Expression;
+        changed ||= visited !== element;
+        return visited;
+      }
+
+      const visited = visitExpressionWithCausePath(
+        element,
+        [...causePath, index],
+        context,
+        visit,
+        { includeRoot: true },
+      );
+      changed ||= visited !== element;
+      return visited;
+    });
+
+    return changed
+      ? context.factory.updateArrayLiteralExpression(expression, elements)
+      : expression;
+  }
+
+  if (ts.isCallExpression(expression)) {
+    if (options.skipCallArguments) {
+      return expression;
+    }
+
+    let changed = false;
+    const callTarget = ts.visitNode(
+      expression.expression,
+      visit,
+    ) as ts.Expression;
+    changed ||= callTarget !== expression.expression;
+
+    const argumentsArray = expression.arguments.map((argument, index) => {
+      const argumentPath = getCallArgumentCausePath(
+        causePath,
+        argument,
+        index,
+        expression.arguments.length,
+      );
+      const visited = visitExpressionWithCausePath(
+        argument,
+        argumentPath,
+        context,
+        visit,
+        { includeRoot: true },
+      );
+      changed ||= visited !== argument;
+      return visited;
+    });
+
+    return changed
+      ? context.factory.updateCallExpression(
+        expression,
+        callTarget,
+        expression.typeArguments,
+        argumentsArray,
+      )
+      : expression;
+  }
+
+  return ts.visitEachChild(
+    expression,
+    (child) =>
+      ts.isExpression(child)
+        ? visitExpressionWithCausePath(
+          child,
+          causePath,
+          context,
+          visit,
+          { includeRoot: true },
+        )
+        : visit(child),
+    context.tsContext,
+  ) as ts.Expression;
+}
+
+function getCallArgumentCausePath(
+  causePath: CausePath,
+  argument: ts.Expression,
+  index: number,
+  argumentCount: number,
+): CausePath {
+  if (
+    argumentCount === 1 &&
+    (
+      ts.isObjectLiteralExpression(argument) ||
+      ts.isArrayLiteralExpression(argument)
+    )
+  ) {
+    return causePath;
+  }
+
+  return [...causePath, index];
 }
 
 function shouldAddVariableFor(
@@ -267,14 +655,14 @@ function isForAccess(expression: ts.Expression): boolean {
 
 function createForCall(
   initializer: ts.Expression,
-  variableName: string,
+  cause: string | CausePath,
   context: TransformationContext,
 ): ts.Expression {
   const call = context.factory.createCallExpression(
     context.factory.createPropertyAccessExpression(initializer, "for"),
     undefined,
     [
-      context.factory.createStringLiteral(variableName),
+      createCauseExpression(cause, context),
       context.factory.createTrue(),
     ],
   );
@@ -282,5 +670,27 @@ function createForCall(
     call,
     initializer,
     initializer,
+  );
+}
+
+function createCauseExpression(
+  cause: string | CausePath,
+  context: TransformationContext,
+): ts.Expression {
+  if (typeof cause === "string") {
+    return context.factory.createStringLiteral(cause);
+  }
+
+  if (cause.length === 1 && typeof cause[0] === "string") {
+    return context.factory.createStringLiteral(cause[0]);
+  }
+
+  return context.factory.createArrayLiteralExpression(
+    cause.map((part) =>
+      typeof part === "number"
+        ? context.factory.createNumericLiteral(part)
+        : context.factory.createStringLiteral(part)
+    ),
+    false,
   );
 }

--- a/packages/ts-transformers/src/transformers/structural-reactive-factory.ts
+++ b/packages/ts-transformers/src/transformers/structural-reactive-factory.ts
@@ -57,6 +57,7 @@ export function isPatternFactoryHelperExpression(
     (target, nextSeenSymbols) =>
       ts.isCallExpression(target) &&
       (
+        isPatternBuilderCall(target, checker) ||
         isPatternFactoryCalleeExpression(target.expression, checker) ||
         isPatternFactoryHelperExpression(
           target.expression,
@@ -66,6 +67,14 @@ export function isPatternFactoryHelperExpression(
       ),
     seenSymbols,
   );
+}
+
+function isPatternBuilderCall(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  const callKind = detectCallKind(call, checker);
+  return callKind?.kind === "builder" && callKind.builderName === "pattern";
 }
 
 export function isStructuralReactiveFactoryExpression(

--- a/packages/ts-transformers/src/transformers/structural-reactive-factory.ts
+++ b/packages/ts-transformers/src/transformers/structural-reactive-factory.ts
@@ -1,0 +1,222 @@
+import ts from "typescript";
+
+import { detectCallKind } from "../ast/mod.ts";
+import { unwrapExpression } from "../utils/expression.ts";
+import { isOpaqueRefType } from "./opaque-ref/opaque-ref.ts";
+
+export function isPatternFactoryCalleeExpression(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
+  const target = unwrapExpression(expression);
+
+  try {
+    const type = checker.getTypeAtLocation(target);
+    const signatures = checker.getSignaturesOfType(type, ts.SignatureKind.Call);
+    if (signatures.length === 0) {
+      return false;
+    }
+
+    const propertyNames = new Set(
+      type.getProperties().map((property) => property.getName()),
+    );
+    if (
+      !propertyNames.has("argumentSchema") ||
+      !propertyNames.has("resultSchema") ||
+      propertyNames.has("with")
+    ) {
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function returnsOpaqueRefResult(
+  expression: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  try {
+    const type = checker.getTypeAtLocation(expression);
+    return isOpaqueRefType(type, checker);
+  } catch {
+    return false;
+  }
+}
+
+export function isPatternFactoryHelperExpression(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  seenSymbols = new Set<ts.Symbol>(),
+): boolean {
+  return someResolvedHelperExpressionMatches(
+    expression,
+    checker,
+    (target, nextSeenSymbols) =>
+      ts.isCallExpression(target) &&
+      (
+        isPatternFactoryCalleeExpression(target.expression, checker) ||
+        isPatternFactoryHelperExpression(
+          target.expression,
+          checker,
+          nextSeenSymbols,
+        )
+      ),
+    seenSymbols,
+  );
+}
+
+export function isStructuralReactiveFactoryExpression(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  seenSymbols = new Set<ts.Symbol>(),
+): boolean {
+  return someResolvedHelperExpressionMatches(
+    expression,
+    checker,
+    (target, nextSeenSymbols) => {
+      if (!ts.isCallExpression(target)) {
+        return false;
+      }
+
+      if (returnsOpaqueRefResult(target, checker)) {
+        return true;
+      }
+
+      if (isPatternFactoryCalleeExpression(target.expression, checker)) {
+        return true;
+      }
+
+      const callKind = detectCallKind(target, checker);
+      if (callKind) {
+        switch (callKind.kind) {
+          case "builder":
+          case "derive":
+          case "cell-factory":
+          case "cell-for":
+          case "wish":
+          case "generate-text":
+          case "generate-object":
+          case "pattern-tool":
+          case "runtime-call":
+            return true;
+          default:
+            break;
+        }
+      }
+
+      return isStructuralReactiveFactoryExpression(
+        target.expression,
+        checker,
+        nextSeenSymbols,
+      );
+    },
+    seenSymbols,
+  );
+}
+
+function someResolvedHelperExpressionMatches(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  evaluateTarget: (
+    target: ts.Expression,
+    seenSymbols: Set<ts.Symbol>,
+  ) => boolean,
+  seenSymbols: Set<ts.Symbol>,
+): boolean {
+  const target = unwrapExpression(expression);
+  if (evaluateTarget(target, seenSymbols)) {
+    return true;
+  }
+
+  if (
+    !ts.isIdentifier(target) &&
+    !ts.isPropertyAccessExpression(target)
+  ) {
+    return false;
+  }
+
+  const symbol = checker.getSymbolAtLocation(target);
+  if (!symbol) {
+    return false;
+  }
+
+  const resolvedSymbol = getAliasedSymbol(symbol, checker);
+  if (seenSymbols.has(resolvedSymbol)) {
+    return false;
+  }
+  seenSymbols.add(resolvedSymbol);
+
+  return (resolvedSymbol.getDeclarations() ?? []).some((declaration) => {
+    const returnedExpression = getReturnedExpression(declaration);
+    return !!returnedExpression &&
+      someResolvedHelperExpressionMatches(
+        returnedExpression,
+        checker,
+        evaluateTarget,
+        seenSymbols,
+      );
+  });
+}
+
+function getAliasedSymbol(
+  symbol: ts.Symbol,
+  checker: ts.TypeChecker,
+): ts.Symbol {
+  if (!(symbol.flags & ts.SymbolFlags.Alias)) {
+    return symbol;
+  }
+
+  try {
+    return checker.getAliasedSymbol(symbol);
+  } catch {
+    return symbol;
+  }
+}
+
+function getReturnedExpression(
+  declaration: ts.Declaration,
+): ts.Expression | undefined {
+  if (
+    ts.isFunctionDeclaration(declaration) ||
+    ts.isMethodDeclaration(declaration) ||
+    ts.isFunctionExpression(declaration) ||
+    ts.isArrowFunction(declaration)
+  ) {
+    if (!declaration.body) {
+      return undefined;
+    }
+    if (ts.isBlock(declaration.body)) {
+      if (declaration.body.statements.length !== 1) {
+        return undefined;
+      }
+      const [statement] = declaration.body.statements;
+      return ts.isReturnStatement(statement) ? statement.expression : undefined;
+    }
+    return declaration.body;
+  }
+
+  if (!ts.isVariableDeclaration(declaration) || !declaration.initializer) {
+    return undefined;
+  }
+
+  const initializer = unwrapExpression(declaration.initializer);
+  if (
+    ts.isArrowFunction(initializer) ||
+    ts.isFunctionExpression(initializer)
+  ) {
+    return getReturnedExpression(initializer);
+  }
+
+  if (
+    ts.isIdentifier(initializer) ||
+    ts.isCallExpression(initializer) ||
+    ts.isPropertyAccessExpression(initializer)
+  ) {
+    return initializer;
+  }
+
+  return undefined;
+}

--- a/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
@@ -54,7 +54,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["count"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "number"
-        } as const satisfies __cfHelpers.JSONSchema, { count: count }, ({ count }) => count + 1), 0),
+        } as const satisfies __cfHelpers.JSONSchema, { count: count }, ({ count }) => count + 1), 0).for("value", true),
         cellValue: ifElse({
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {
@@ -74,7 +74,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["cell"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "number"
-        } as const satisfies __cfHelpers.JSONSchema, { cell: cell }, ({ cell }) => cell.get()), 0),
+        } as const satisfies __cfHelpers.JSONSchema, { cell: cell }, ({ cell }) => cell.get()), 0).for("cellValue", true),
         trimmed: ifElse({
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {
@@ -93,7 +93,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["name"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, { name: name }, ({ name }) => name.trim()), "fallback"),
+        } as const satisfies __cfHelpers.JSONSchema, { name: name }, ({ name }) => name.trim()), "fallback").for("trimmed", true),
         upper,
         upperDirect: __cfHelpers.derive({
             type: "object",
@@ -105,7 +105,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["name"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, { name: name }, ({ name }) => name.trim()),
+        } as const satisfies __cfHelpers.JSONSchema, { name: name }, ({ name }) => name.trim()).for("upperDirect", true),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
@@ -34,7 +34,7 @@ export default pattern((__cf_pattern_input) => {
         required: ["name"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema, { name: name }, ({ name }) => identity(name.trim()));
+    } as const satisfies __cfHelpers.JSONSchema, { name: name }, ({ name }) => identity(name.trim())).for("upper", true);
     return {
         value: ifElse({
             type: "boolean"

--- a/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
@@ -54,7 +54,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["count"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "number"
-        } as const satisfies __cfHelpers.JSONSchema, { count: count }, ({ count }) => count + 1), 0).for("value", true),
+        } as const satisfies __cfHelpers.JSONSchema, { count: count }, ({ count }) => count + 1), 0).for(["__patternResult", "value"], true),
         cellValue: ifElse({
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {
@@ -74,7 +74,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["cell"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "number"
-        } as const satisfies __cfHelpers.JSONSchema, { cell: cell }, ({ cell }) => cell.get()), 0).for("cellValue", true),
+        } as const satisfies __cfHelpers.JSONSchema, { cell: cell }, ({ cell }) => cell.get()), 0).for(["__patternResult", "cellValue"], true),
         trimmed: ifElse({
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {
@@ -93,7 +93,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["name"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, { name: name }, ({ name }) => name.trim()), "fallback").for("trimmed", true),
+        } as const satisfies __cfHelpers.JSONSchema, { name: name }, ({ name }) => name.trim()), "fallback").for(["__patternResult", "trimmed"], true),
         upper,
         upperDirect: __cfHelpers.derive({
             type: "object",
@@ -105,7 +105,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["name"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, { name: name }, ({ name }) => name.trim()).for("upperDirect", true),
+        } as const satisfies __cfHelpers.JSONSchema, { name: name }, ({ name }) => name.trim()).for(["__patternResult", "upperDirect"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/ast-transform/derive-object-literal-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/derive-object-literal-input.expected.jsx
@@ -11,45 +11,45 @@ import { cell, derive, lift } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const stage = cell<string>("initial", {
+const stage = __cfHelpers.__cf_data(cell<string>("initial", {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
-const attemptCount = cell<number>(0, {
+} as const satisfies __cfHelpers.JSONSchema).for("stage", true));
+const attemptCount = __cfHelpers.__cf_data(cell<number>(0, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
-const acceptedCount = cell<number>(0, {
+} as const satisfies __cfHelpers.JSONSchema).for("attemptCount", true));
+const acceptedCount = __cfHelpers.__cf_data(cell<number>(0, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
-const rejectedCount = cell<number>(0, {
+} as const satisfies __cfHelpers.JSONSchema).for("acceptedCount", true));
+const rejectedCount = __cfHelpers.__cf_data(cell<number>(0, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema).for("rejectedCount", true));
 // FIXTURE: derive-object-literal-input
 // Verifies: cell(), lift(), and derive() all get schemas injected from type annotations
 //   cell<string>("initial")             → cell<string>("initial", { type: "string" })
 //   lift((value: string) => value)      → lift(inputSchema, outputSchema, fn)
 //   derive({ stage, ... }, fn)          → derive(inputSchema, outputSchema, { stage, ... }, fn)
 // Context: No export default; first export-relevant statement is the cells/lifts/derive at top level
-const normalizedStage = lift({
+const normalizedStage = __cfHelpers.__cf_data(lift({
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, (value: string) => value)(stage);
-const attempts = lift({
+} as const satisfies __cfHelpers.JSONSchema, (value: string) => value)(stage).for("normalizedStage", true));
+const attempts = __cfHelpers.__cf_data(lift({
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (count: number) => count)(attemptCount);
-const accepted = lift({
+} as const satisfies __cfHelpers.JSONSchema, (count: number) => count)(attemptCount).for("attempts", true));
+const accepted = __cfHelpers.__cf_data(lift({
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (count: number) => count)(acceptedCount);
-const rejected = lift({
+} as const satisfies __cfHelpers.JSONSchema, (count: number) => count)(acceptedCount).for("accepted", true));
+const rejected = __cfHelpers.__cf_data(lift({
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (count: number) => count)(rejectedCount);
-const _summary = derive({
+} as const satisfies __cfHelpers.JSONSchema, (count: number) => count)(rejectedCount).for("rejected", true));
+const _summary = __cfHelpers.__cf_data(derive({
     type: "object",
     properties: {
         stage: {
@@ -74,7 +74,7 @@ const _summary = derive({
     accepted: accepted,
     rejected: rejected,
 }, (snapshot) => `stage:${snapshot.stage} attempts:${snapshot.attempts}` +
-    ` accepted:${snapshot.accepted} rejected:${snapshot.rejected}`);
+    ` accepted:${snapshot.accepted} rejected:${snapshot.rejected}`).for("_summary", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/derive-object-literal-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/derive-object-literal-input.expected.jsx
@@ -69,10 +69,10 @@ const _summary = __cfHelpers.__cf_data(derive({
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, {
-    stage: normalizedStage,
-    attempts: attempts,
-    accepted: accepted,
-    rejected: rejected,
+    stage: normalizedStage.for(["_summary", 2, "stage"], true),
+    attempts: attempts.for(["_summary", 2, "attempts"], true),
+    accepted: accepted.for(["_summary", 2, "accepted"], true),
+    rejected: rejected.for(["_summary", 2, "rejected"], true)
 }, (snapshot) => `stage:${snapshot.stage} attempts:${snapshot.attempts}` +
     ` accepted:${snapshot.accepted} rejected:${snapshot.rejected}`).for("_summary", true));
 // @ts-ignore: Internals

--- a/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.jsx
@@ -37,11 +37,11 @@ const myHandler = handler(false as const satisfies __cfHelpers.JSONSchema, {
 export default pattern((state) => {
     return {
         // Test case 1: Object literal with all properties from state
-        onClick1: myHandler({ value: state.key("value"), name: state.key("name") }).for("onClick1", true),
+        onClick1: myHandler({ value: state.key("value"), name: state.key("name") }).for(["__patternResult", "onClick1"], true),
         // Test case 2: Object literal with all properties (explicitly listed)
-        onClick2: myHandler({ value: state.key("value"), name: state.key("name") }).for("onClick2", true),
+        onClick2: myHandler({ value: state.key("value"), name: state.key("name") }).for(["__patternResult", "onClick2"], true),
         // Test case 3: Direct state passing (what we want to transform to)
-        onClick3: myHandler(state).for("onClick3", true),
+        onClick3: myHandler(state).for(["__patternResult", "onClick3"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.jsx
@@ -37,11 +37,11 @@ const myHandler = handler(false as const satisfies __cfHelpers.JSONSchema, {
 export default pattern((state) => {
     return {
         // Test case 1: Object literal with all properties from state
-        onClick1: myHandler({ value: state.key("value"), name: state.key("name") }),
+        onClick1: myHandler({ value: state.key("value"), name: state.key("name") }).for("onClick1", true),
         // Test case 2: Object literal with all properties (explicitly listed)
-        onClick2: myHandler({ value: state.key("value"), name: state.key("name") }),
+        onClick2: myHandler({ value: state.key("value"), name: state.key("name") }).for("onClick2", true),
         // Test case 3: Direct state passing (what we want to transform to)
-        onClick3: myHandler(state),
+        onClick3: myHandler(state).for("onClick3", true),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
@@ -56,7 +56,7 @@ export default pattern((state) => ({
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             wishes: state.key("wishes")
-        } }, ({ state }) => JSON.stringify(state.wishes[1])).for("serialized", true),
+        } }, ({ state }) => JSON.stringify(state.wishes[1])).for(["__patternResult", "serialized"], true),
     keys: __cfHelpers.derive({
         type: "object",
         properties: {
@@ -90,7 +90,7 @@ export default pattern((state) => ({
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             wishes: state.key("wishes")
-        } }, ({ state }) => Object.keys(state.wishes[1])).for("keys", true),
+        } }, ({ state }) => Object.keys(state.wishes[1])).for(["__patternResult", "keys"], true),
     values: __cfHelpers.derive({
         type: "object",
         properties: {
@@ -124,7 +124,7 @@ export default pattern((state) => ({
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             wishes: state.key("wishes")
-        } }, ({ state }) => Object.values(state.wishes[1])).for("values", true),
+        } }, ({ state }) => Object.values(state.wishes[1])).for(["__patternResult", "values"], true),
     entries: __cfHelpers.derive({
         type: "object",
         properties: {
@@ -161,7 +161,7 @@ export default pattern((state) => ({
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             wishes: state.key("wishes")
-        } }, ({ state }) => Object.entries(state.wishes[1])).for("entries", true),
+        } }, ({ state }) => Object.entries(state.wishes[1])).for(["__patternResult", "entries"], true)
 }), {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
@@ -56,7 +56,7 @@ export default pattern((state) => ({
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             wishes: state.key("wishes")
-        } }, ({ state }) => JSON.stringify(state.wishes[1])),
+        } }, ({ state }) => JSON.stringify(state.wishes[1])).for("serialized", true),
     keys: __cfHelpers.derive({
         type: "object",
         properties: {
@@ -90,7 +90,7 @@ export default pattern((state) => ({
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             wishes: state.key("wishes")
-        } }, ({ state }) => Object.keys(state.wishes[1])),
+        } }, ({ state }) => Object.keys(state.wishes[1])).for("keys", true),
     values: __cfHelpers.derive({
         type: "object",
         properties: {
@@ -124,7 +124,7 @@ export default pattern((state) => ({
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             wishes: state.key("wishes")
-        } }, ({ state }) => Object.values(state.wishes[1])),
+        } }, ({ state }) => Object.values(state.wishes[1])).for("values", true),
     entries: __cfHelpers.derive({
         type: "object",
         properties: {
@@ -161,7 +161,7 @@ export default pattern((state) => ({
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             wishes: state.key("wishes")
-        } }, ({ state }) => Object.entries(state.wishes[1])),
+        } }, ({ state }) => Object.entries(state.wishes[1])).for("entries", true),
 }), {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-arg-conditional.expected.jsx
@@ -36,7 +36,7 @@ export default pattern((state) => {
         "enum": ["Done", "Pending"]
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             done: state.key("done")
-        } }, ({ state }) => identity(state.done ? "Done" : "Pending"));
+        } }, ({ state }) => identity(state.done ? "Done" : "Pending")).for("label", true);
     return { label };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
@@ -37,7 +37,7 @@ export default pattern((state) => ({
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             count: state.key("count")
-        } }, ({ state }) => double(state.count + 1)).for("doubled", true),
+        } }, ({ state }) => double(state.count + 1)).for(["__patternResult", "doubled"], true)
 }), {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
@@ -37,7 +37,7 @@ export default pattern((state) => ({
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             count: state.key("count")
-        } }, ({ state }) => double(state.count + 1)),
+        } }, ({ state }) => double(state.count + 1)).for("doubled", true),
 }), {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-binary-add.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-binary-add.expected.jsx
@@ -36,7 +36,7 @@ export default pattern((state) => ({
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             count: state.key("count")
-        } }, ({ state }) => state.count + 1),
+        } }, ({ state }) => state.count + 1).for("next", true),
 }), {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-binary-add.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-binary-add.expected.jsx
@@ -36,7 +36,7 @@ export default pattern((state) => ({
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             count: state.key("count")
-        } }, ({ state }) => state.count + 1).for("next", true),
+        } }, ({ state }) => state.count + 1).for(["__patternResult", "next"], true)
 }), {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-logical-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-logical-or.expected.jsx
@@ -23,7 +23,7 @@ export default pattern((state) => ({
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema, state.key("label"), "Pending").for("label", true),
+    } as const satisfies __cfHelpers.JSONSchema, state.key("label"), "Pending").for(["__patternResult", "label"], true)
 }), {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-logical-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-logical-or.expected.jsx
@@ -23,7 +23,7 @@ export default pattern((state) => ({
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema, state.key("label"), "Pending"),
+    } as const satisfies __cfHelpers.JSONSchema, state.key("label"), "Pending").for("label", true),
 }), {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-prefix-not.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-prefix-not.expected.jsx
@@ -35,7 +35,7 @@ export default pattern((state) => ({
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             done: state.key("done")
-        } }, ({ state }) => !state.done),
+        } }, ({ state }) => !state.done).for("hidden", true),
 }), {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-prefix-not.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-prefix-not.expected.jsx
@@ -35,7 +35,7 @@ export default pattern((state) => ({
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             done: state.key("done")
-        } }, ({ state }) => !state.done).for("hidden", true),
+        } }, ({ state }) => !state.done).for(["__patternResult", "hidden"], true)
 }), {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
@@ -98,7 +98,7 @@ export default pattern((state) => {
         } as const satisfies __cfHelpers.JSONSchema, { state: {
                 a: state.key("a"),
                 b: state.key("b")
-            } }, ({ state }) => Math.max(state.a, state.b)).for("maxValue", true),
+            } }, ({ state }) => Math.max(state.a, state.b)).for(["__patternResult", "maxValue"], true),
         parsedValue: __cfHelpers.derive({
             type: "object",
             properties: {
@@ -117,7 +117,7 @@ export default pattern((state) => {
             type: "number"
         } as const satisfies __cfHelpers.JSONSchema, { state: {
                 float: state.key("float")
-            } }, ({ state }) => parseInt(state.float)).for("parsedValue", true),
+            } }, ({ state }) => parseInt(state.float)).for(["__patternResult", "parsedValue"], true),
         fallbackLabel: __cfHelpers.derive({
             type: "object",
             properties: {
@@ -135,8 +135,8 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, { state: {
                 label: state.key("label")
-            } }, ({ state }) => state.label ?? "Pending").for("fallbackLabel", true),
-        firstItem: state.key("items", "0"),
+            } }, ({ state }) => state.label ?? "Pending").for(["__patternResult", "fallbackLabel"], true),
+        firstItem: state.key("items", "0")
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
@@ -98,7 +98,7 @@ export default pattern((state) => {
         } as const satisfies __cfHelpers.JSONSchema, { state: {
                 a: state.key("a"),
                 b: state.key("b")
-            } }, ({ state }) => Math.max(state.a, state.b)),
+            } }, ({ state }) => Math.max(state.a, state.b)).for("maxValue", true),
         parsedValue: __cfHelpers.derive({
             type: "object",
             properties: {
@@ -117,7 +117,7 @@ export default pattern((state) => {
             type: "number"
         } as const satisfies __cfHelpers.JSONSchema, { state: {
                 float: state.key("float")
-            } }, ({ state }) => parseInt(state.float)),
+            } }, ({ state }) => parseInt(state.float)).for("parsedValue", true),
         fallbackLabel: __cfHelpers.derive({
             type: "object",
             properties: {
@@ -135,7 +135,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, { state: {
                 label: state.key("label")
-            } }, ({ state }) => state.label ?? "Pending"),
+            } }, ({ state }) => state.label ?? "Pending").for("fallbackLabel", true),
         firstItem: state.key("items", "0"),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
@@ -48,7 +48,7 @@ export default pattern((state) => {
             user: {
                 name: state.key("user", "name")
             }
-        } }, ({ state }) => identity(state.user.name));
+        } }, ({ state }) => identity(state.user.name)).for("label", true);
     const maybeLabel = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -72,7 +72,7 @@ export default pattern((state) => {
         type: ["string", "undefined"]
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             maybeUser: state.key("maybeUser")
-        } }, ({ state }) => identity(state.maybeUser?.name));
+        } }, ({ state }) => identity(state.maybeUser?.name)).for("maybeLabel", true);
     return {
         label,
         maybeLabel,

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
@@ -37,7 +37,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["count"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "number"
-        } as const satisfies __cfHelpers.JSONSchema, { count: count }, ({ count }) => count * 2)
+        } as const satisfies __cfHelpers.JSONSchema, { count: count }, ({ count }) => count * 2).for("doubled", true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
@@ -37,7 +37,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["count"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "number"
-        } as const satisfies __cfHelpers.JSONSchema, { count: count }, ({ count }) => count * 2).for("doubled", true)
+        } as const satisfies __cfHelpers.JSONSchema, { count: count }, ({ count }) => count * 2).for(["__patternResult", "doubled"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
@@ -39,7 +39,7 @@ export default pattern((input: MyInput) => {
             type: "number"
         } as const satisfies __cfHelpers.JSONSchema, { input: {
                 value: input.key("value")
-            } }, ({ input: input_1 }) => input.value * 2),
+            } }, ({ input: input_1 }) => input.value * 2).for("result", true),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
@@ -39,7 +39,7 @@ export default pattern((input: MyInput) => {
             type: "number"
         } as const satisfies __cfHelpers.JSONSchema, { input: {
                 value: input.key("value")
-            } }, ({ input: input_1 }) => input.value * 2).for("result", true),
+            } }, ({ input: input_1 }) => input.value * 2).for(["__patternResult", "result"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
@@ -39,7 +39,7 @@ export default pattern((input: MyInput) => {
             type: "number"
         } as const satisfies __cfHelpers.JSONSchema, { input: {
                 value: input.key("value")
-            } }, ({ input: input_1 }) => input.value * 2),
+            } }, ({ input: input_1 }) => input.value * 2).for("result", true),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
@@ -39,7 +39,7 @@ export default pattern((input: MyInput) => {
             type: "number"
         } as const satisfies __cfHelpers.JSONSchema, { input: {
                 value: input.key("value")
-            } }, ({ input: input_1 }) => input.value * 2).for("result", true),
+            } }, ({ input: input_1 }) => input.value * 2).for(["__patternResult", "result"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-alias.expected.jsx
@@ -22,7 +22,7 @@ declare const state: AliasInput;
 // Verifies: derive imported under an alias still gets schema injection
 //   deriveAlias<AliasInput, AliasResult>(state, fn) → deriveAlias(inputSchema, outputSchema, state, fn)
 // Context: Uses `import { derive as deriveAlias }` to test aliased import tracking
-export const textLength = deriveAlias({
+export const textLength = __cfHelpers.__cf_data(deriveAlias({
     type: "object",
     properties: {
         text: {
@@ -40,7 +40,7 @@ export const textLength = deriveAlias({
     required: ["length"]
 } as const satisfies __cfHelpers.JSONSchema, state, (value) => ({
     length: value.text.length,
-}));
+})).for("textLength", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-multiple-returns.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-multiple-returns.expected.jsx
@@ -17,7 +17,7 @@ declare const flag: boolean;
 //   derive(flag, fn) → derive({ type: "boolean" }, { enum: ["hello", 42] }, flag, fn)
 // Context: Callback has two return statements (string and number); output schema is an enum union
 // Function with multiple return statements - should infer string | number
-export const multiReturn = derive({
+export const multiReturn = __cfHelpers.__cf_data(derive({
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["hello", 42]
@@ -26,7 +26,7 @@ export const multiReturn = derive({
         return "hello";
     }
     return 42;
-});
+}).for("multiReturn", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-untyped.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive-untyped.expected.jsx
@@ -16,11 +16,11 @@ declare const total: number;
 // Verifies: derive() with no generic type args infers schemas from the declared source type
 //   derive(total, fn) → derive({ type: "number" }, { type: "number" }, total, fn)
 // Context: Input type comes from `declare const total: number`; output inferred from arrow body
-export const doubled = derive({
+export const doubled = __cfHelpers.__cf_data(derive({
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, total, (value) => value * 2);
+} as const satisfies __cfHelpers.JSONSchema, total, (value) => value * 2).for("doubled", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-derive.expected.jsx
@@ -21,7 +21,7 @@ declare const source: DeriveInput;
 // FIXTURE: schema-generation-derive
 // Verifies: derive() with generic type args generates input and output schemas
 //   derive<DeriveInput, DeriveResult>(source, fn) → derive(inputSchema, outputSchema, source, fn)
-export const doubledValue = derive({
+export const doubledValue = __cfHelpers.__cf_data(derive({
     type: "object",
     properties: {
         count: {
@@ -39,7 +39,7 @@ export const doubledValue = derive({
     required: ["doubled"]
 } as const satisfies __cfHelpers.JSONSchema, source, (input) => ({
     doubled: input.count * 2,
-}));
+})).for("doubledValue", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-injection-unless.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-injection-unless.expected.jsx
@@ -38,7 +38,7 @@ export default pattern((__cf_pattern_input) => {
             }, {
                 type: "null"
             }]
-    } as const satisfies __cfHelpers.JSONSchema, value, defaultValue);
+    } as const satisfies __cfHelpers.JSONSchema, value, defaultValue).for("result", true);
     return {
         [NAME]: "unless schema test",
         [UI]: <div>{result}</div>,

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-injection-when.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-injection-when.expected.jsx
@@ -30,7 +30,7 @@ export default pattern((__cf_pattern_input) => {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: ["boolean", "string"]
-    } as const satisfies __cfHelpers.JSONSchema, enabled, message);
+    } as const satisfies __cfHelpers.JSONSchema, enabled, message).for("result", true);
     return {
         [NAME]: "when schema test",
         [UI]: <div>{result}</div>,

--- a/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
@@ -31,7 +31,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["count"]
         } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => count.set(count.get() + 1))({
             count: count
-        }).for("inc", true),
+        }).for(["__patternResult", "inc"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
@@ -31,7 +31,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["count"]
         } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => count.set(count.get() + 1))({
             count: count
-        }),
+        }).for("inc", true),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
@@ -44,7 +44,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["value"]
         } as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data))({
             value: value
-        }).for("update", true),
+        }).for(["__patternResult", "update"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
@@ -44,7 +44,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["value"]
         } as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data))({
             value: value
-        }),
+        }).for("update", true),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
@@ -35,7 +35,7 @@ export default pattern((__cf_pattern_input) => {
     const card = __cf_pattern_input.key("card");
     const isEditing = Cell.of(false, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("isEditing", true);
     const startEditing = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
         type: "object",
         properties: {
@@ -49,7 +49,7 @@ export default pattern((__cf_pattern_input) => {
         isEditing.set(true);
     })({
         isEditing: isEditing
-    });
+    }).for("startEditing", true);
     const hasDescription = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -71,7 +71,7 @@ export default pattern((__cf_pattern_input) => {
         } }, ({ card }) => {
         const desc = card.description;
         return desc && desc.length > 0;
-    });
+    }).for("hasDescription", true);
     return {
         [UI]: (<cf-card>
         {__cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
@@ -34,7 +34,7 @@ export default pattern((__cf_pattern_input) => {
     const card = __cf_pattern_input.key("card");
     const isEditing = Cell.of(false, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("isEditing", true);
     const startEditing = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
         type: "object",
         properties: {
@@ -48,7 +48,7 @@ export default pattern((__cf_pattern_input) => {
         isEditing.set(true);
     })({
         isEditing: isEditing
-    });
+    }).for("startEditing", true);
     return {
         [UI]: (<cf-card>
         {__cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
@@ -35,7 +35,7 @@ export default pattern((__cf_pattern_input) => {
             }
         } as const satisfies __cfHelpers.JSONSchema, (_, { a }) => console.log(a))({
             a: a
-        }).for("readA", true),
+        }).for(["__patternResult", "readA"], true),
         readB: __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
             type: "object",
             properties: {
@@ -46,7 +46,7 @@ export default pattern((__cf_pattern_input) => {
             }
         } as const satisfies __cfHelpers.JSONSchema, (_, { b }) => console.log(b))({
             b: b
-        }).for("readB", true),
+        }).for(["__patternResult", "readB"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
@@ -35,7 +35,7 @@ export default pattern((__cf_pattern_input) => {
             }
         } as const satisfies __cfHelpers.JSONSchema, (_, { a }) => console.log(a))({
             a: a
-        }),
+        }).for("readA", true),
         readB: __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
             type: "object",
             properties: {
@@ -46,7 +46,7 @@ export default pattern((__cf_pattern_input) => {
             }
         } as const satisfies __cfHelpers.JSONSchema, (_, { b }) => console.log(b))({
             b: b
-        }),
+        }).for("readB", true),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
@@ -36,7 +36,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["a"]
         } as const satisfies __cfHelpers.JSONSchema, (_, { a }) => a.set("hello"))({
             a: a
-        }).for("setA", true),
+        }).for(["__patternResult", "setA"], true),
         setB: __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
             type: "object",
             properties: {
@@ -48,7 +48,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["b"]
         } as const satisfies __cfHelpers.JSONSchema, (_, { b }) => b.set(42))({
             b: b
-        }).for("setB", true),
+        }).for(["__patternResult", "setB"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
@@ -36,7 +36,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["a"]
         } as const satisfies __cfHelpers.JSONSchema, (_, { a }) => a.set("hello"))({
             a: a
-        }),
+        }).for("setA", true),
         setB: __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
             type: "object",
             properties: {
@@ -48,7 +48,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["b"]
         } as const satisfies __cfHelpers.JSONSchema, (_, { b }) => b.set(42))({
             b: b
-        }),
+        }).for("setB", true),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
@@ -62,7 +62,7 @@ export default pattern((__cf_pattern_input) => {
         <cf-button onClick={increment}>+</cf-button>
         <cf-button onClick={decrement}>-</cf-button>
       </div>),
-        count,
+        count: count.for(["__patternResult", "count"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
@@ -27,7 +27,7 @@ export default pattern((__cf_pattern_input) => {
     const label = __cf_pattern_input.key("label");
     const count = Writable.of(0, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("count", true);
     const increment = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
         type: "object",
         properties: {
@@ -41,7 +41,7 @@ export default pattern((__cf_pattern_input) => {
         count.set(count.get() + 1);
     })({
         count: count
-    });
+    }).for("increment", true);
     const decrement = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
         type: "object",
         properties: {
@@ -55,7 +55,7 @@ export default pattern((__cf_pattern_input) => {
         count.set(count.get() - 1);
     })({
         count: count
-    });
+    }).for("decrement", true);
     return {
         [UI]: (<div>
         <span>{label}: {count}</span>

--- a/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
@@ -31,7 +31,7 @@ export default pattern((__cf_pattern_input) => {
     const self = __cf_pattern_input[__cfHelpers.SELF];
     const count = Writable.of(0, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("count", true);
     // Action closing over `self` — works because all inputs use Default<>
     const showSelf = __cfHelpers.handler({
         type: "object",
@@ -57,7 +57,7 @@ export default pattern((__cf_pattern_input) => {
         self: {
             title: self.key("title")
         }
-    });
+    }).for("showSelf", true);
     // Action closing over both `self` and `count`
     const incrementWithSelf = __cfHelpers.handler({
         type: "object",
@@ -101,7 +101,7 @@ export default pattern((__cf_pattern_input) => {
     })({
         self: self,
         count: count
-    });
+    }).for("incrementWithSelf", true);
     return {
         [NAME]: "Action SELF Test",
         [UI]: (<div>

--- a/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
@@ -109,7 +109,7 @@ export default pattern((__cf_pattern_input) => {
           <cf-button onClick={incrementWithSelf}>Increment with Self</cf-button>
         </div>),
         title,
-        count,
+        count: count.for(["__patternResult", "count"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
@@ -43,7 +43,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["value"]
         } as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data))({
             value: value
-        }).for("update", true),
+        }).for(["__patternResult", "update"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
@@ -43,7 +43,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["value"]
         } as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data))({
             value: value
-        }),
+        }).for("update", true),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/cell-map-with-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/cell-map-with-captures.expected.jsx
@@ -54,7 +54,7 @@ export default pattern((state) => {
         items: {
             type: "number"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("typedValues", true);
     return {
         [UI]: (<div>
         {typedValues.mapWithPattern(__cfHelpers.pattern(__cfModuleCallback_1, {

--- a/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
@@ -18,10 +18,10 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const multiplier = Writable.of(2, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -40,7 +40,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         value: value,
         multiplier: multiplier
-    }, ({ value, multiplier }) => value.get() * multiplier.get());
+    }, ({ value, multiplier }) => value.get() * multiplier.get()).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
@@ -18,13 +18,13 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const a = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("a", true);
     const b = Writable.of(20, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("b", true);
     const c = Writable.of(5, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("c", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -48,7 +48,7 @@ export default pattern(() => {
         a: a,
         b: b,
         c: c
-    }, ({ a, b, c }) => (a.get() * b.get() + c.get()) / 2);
+    }, ({ a, b, c }) => (a.get() * b.get() + c.get()) / 2).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
@@ -18,16 +18,16 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const threshold = Writable.of(5, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("threshold", true);
     const a = Writable.of(100, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("a", true);
     const b = Writable.of(200, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("b", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -56,7 +56,7 @@ export default pattern(() => {
         threshold: threshold,
         a: a,
         b: b
-    }, ({ value, threshold, a, b }) => value.get() > threshold.get() ? a.get() : b.get());
+    }, ({ value, threshold, a, b }) => value.get() > threshold.get() ? a.get() : b.get()).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
@@ -78,7 +78,7 @@ export default pattern((__cf_pattern_input) => {
     } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => ({
         tasks: items.filter((i) => !i.done),
         view: "inbox",
-    }));
+    })).for("result", true);
     return {
         [UI]: (<div>
         {__cfHelpers.derive({

--- a/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
@@ -58,7 +58,7 @@ export default pattern((state) => {
         return state.preferences
             .filter((p) => p.preference === "liked")
             .map((p) => p.ingredient);
-    });
+    }).for("liked", true);
     return { liked };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
@@ -23,7 +23,7 @@ const __cfModuleCallback_1 = __cfHardenFn(() => {
             }
         },
         required: ["bar"]
-    } as const satisfies __cfHelpers.JSONSchema, {}, () => ({ bar: 1 }));
+    } as const satisfies __cfHelpers.JSONSchema, {}, () => ({ bar: 1 })).for("foo", true);
     return foo.bar;
 });
 // FIXTURE: computed-in-computed-property-access
@@ -39,7 +39,7 @@ export default pattern(() => {
         properties: {}
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema, {}, __cfModuleCallback_1);
+    } as const satisfies __cfHelpers.JSONSchema, {}, __cfModuleCallback_1).for("outer", true);
     return outer;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
@@ -25,7 +25,7 @@ const __cfModuleCallback_1 = __cfHardenFn(() => {
                 }
             },
             required: ["bar"]
-        } as const satisfies __cfHelpers.JSONSchema, {}, () => ({ bar: 1 }));
+        } as const satisfies __cfHelpers.JSONSchema, {}, () => ({ bar: 1 })).for("config", true);
         return config.bar;
     }
     return config.bar;
@@ -44,7 +44,7 @@ export default pattern(() => {
         properties: {}
     } as const satisfies __cfHelpers.JSONSchema, {
         type: ["number", "string"]
-    } as const satisfies __cfHelpers.JSONSchema, {}, __cfModuleCallback_1);
+    } as const satisfies __cfHelpers.JSONSchema, {}, __cfModuleCallback_1).for("outer", true);
     return outer;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "string"]

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
@@ -66,7 +66,7 @@ export default pattern((__cf_pattern_input) => {
                 required: ["name", "price"]
             }
         }
-    } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => items.filter((i) => i.price > 100));
+    } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => items.filter((i) => i.price > 100)).for("filtered", true);
     return {
         [UI]: (<div>
         {__cfHelpers.derive({

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
@@ -83,7 +83,7 @@ export default pattern((state) => {
                     type: "string"
                 } as const satisfies __cfHelpers.JSONSchema, {
                     "enum": ["Done", "Pending"]
-                } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending"));
+                } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for(["label", 0], true));
                 return <span>{label}</span>;
             }, {
                 type: "object",
@@ -125,7 +125,7 @@ export default pattern((state) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
@@ -70,7 +70,7 @@ export default pattern((state) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             items: state.key("items")
-        } }, ({ state }) => state.items);
+        } }, ({ state }) => state.items).for("rows", true);
     return {
         [UI]: (<div>
         {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
@@ -81,7 +81,7 @@ export default pattern((state) => {
                     type: "string"
                 } as const satisfies __cfHelpers.JSONSchema, {
                     "enum": [false, "Done"]
-                } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done"));
+                } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done").for(["label", 0], true));
                 return <span>{label}</span>;
             }, {
                 type: "object",
@@ -123,7 +123,7 @@ export default pattern((state) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
@@ -70,7 +70,7 @@ export default pattern((state) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             items: state.key("items")
-        } }, ({ state }) => state.items);
+        } }, ({ state }) => state.items).for("rows", true);
     return {
         [UI]: (<div>
         {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
@@ -83,7 +83,7 @@ export default pattern((state) => {
                 type: "string"
             } as const satisfies __cfHelpers.JSONSchema, {
                 "enum": ["Done", "Pending"]
-            } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending");
+            } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for("__patternResult", true);
         }, {
             type: "object",
             properties: {
@@ -106,7 +106,7 @@ export default pattern((state) => {
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Done", "Pending"]
         } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
@@ -70,7 +70,7 @@ export default pattern((state) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             items: state.key("items")
-        } }, ({ state }) => state.items);
+        } }, ({ state }) => state.items).for("rows", true);
     return {
         [UI]: (<div>
         {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
@@ -30,7 +30,7 @@ export default pattern((__cf_pattern_input) => {
     const people = __cf_pattern_input.key("people");
     const showAdmin = Writable.of(false, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("showAdmin", true);
     const adminData = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -76,7 +76,7 @@ export default pattern((__cf_pattern_input) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, { people: people }, ({ people }) => [...people.get()]
         .sort((a, b) => a.rank - b.rank)
-        .map((p) => ({ name: p.name, rank: p.rank, isFirst: p.rank === 1 })));
+        .map((p) => ({ name: p.name, rank: p.rank, isFirst: p.rank === 1 }))).for("adminData", true);
     const count = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -105,7 +105,7 @@ export default pattern((__cf_pattern_input) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema, { people: people }, ({ people }) => people.get().length);
+    } as const satisfies __cfHelpers.JSONSchema, { people: people }, ({ people }) => people.get().length).for("count", true);
     return {
         [UI]: (<div>
         {__cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
@@ -31,7 +31,7 @@ export default pattern((__cf_pattern_input) => {
     const people = __cf_pattern_input.key("people");
     const showAdmin = Writable.of(false, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("showAdmin", true);
     const adminData = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -77,7 +77,7 @@ export default pattern((__cf_pattern_input) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, { people: people }, ({ people }) => [...people.get()]
         .sort((a, b) => a.rank - b.rank)
-        .map((p) => ({ name: p.name, rank: p.rank, isFirst: p.rank === 1 })));
+        .map((p) => ({ name: p.name, rank: p.rank, isFirst: p.rank === 1 }))).for("adminData", true);
     const count = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -106,7 +106,7 @@ export default pattern((__cf_pattern_input) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema, { people: people }, ({ people }) => people.get().length);
+    } as const satisfies __cfHelpers.JSONSchema, { people: people }, ({ people }) => people.get().length).for("count", true);
     return {
         [UI]: (<div>
         {people.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
@@ -69,7 +69,7 @@ export default pattern((state) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             items: state.key("items")
-        } }, ({ state }) => state.items);
+        } }, ({ state }) => state.items).for("rows", true);
     return {
         [UI]: (<div>
         {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
@@ -82,7 +82,7 @@ export default pattern((state) => {
                         type: "string"
                     } as const satisfies __cfHelpers.JSONSchema, {
                         "enum": ["Done", "Pending"]
-                    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending")];
+                    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for(["view", 0], true)];
                 return <span>{__cfHelpers.derive({
                     type: "object",
                     properties: {
@@ -137,7 +137,7 @@ export default pattern((state) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
@@ -82,7 +82,7 @@ export default pattern((state) => {
                         type: "string"
                     } as const satisfies __cfHelpers.JSONSchema, {
                         "enum": ["Done", "Pending"]
-                    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending") };
+                    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for("status", true) };
                 return <span>{view.status}</span>;
             }, {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
@@ -82,7 +82,7 @@ export default pattern((state) => {
                         type: "string"
                     } as const satisfies __cfHelpers.JSONSchema, {
                         "enum": ["Done", "Pending"]
-                    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for("status", true) };
+                    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for(["view", "status"], true) };
                 return <span>{view.status}</span>;
             }, {
                 type: "object",
@@ -124,7 +124,7 @@ export default pattern((state) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
@@ -69,7 +69,7 @@ export default pattern((state) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             items: state.key("items")
-        } }, ({ state }) => state.items);
+        } }, ({ state }) => state.items).for("rows", true);
     return {
         [UI]: (<div>
         {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
@@ -80,7 +80,7 @@ export default pattern((state) => {
                         type: "string"
                     } as const satisfies __cfHelpers.JSONSchema, {
                         "enum": [true, "Pending"]
-                    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Pending") };
+                    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Pending").for("status", true) };
                 return <span>{view.status}</span>;
             }, {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
@@ -80,7 +80,7 @@ export default pattern((state) => {
                         type: "string"
                     } as const satisfies __cfHelpers.JSONSchema, {
                         "enum": [true, "Pending"]
-                    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Pending").for("status", true) };
+                    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Pending").for(["view", "status"], true) };
                 return <span>{view.status}</span>;
             }, {
                 type: "object",
@@ -122,7 +122,7 @@ export default pattern((state) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
@@ -69,7 +69,7 @@ export default pattern((state) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             items: state.key("items")
-        } }, ({ state }) => state.items);
+        } }, ({ state }) => state.items).for("rows", true);
     return {
         [UI]: (<div>
         {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
@@ -73,7 +73,7 @@ export default pattern((state) => {
                 type: "string"
             } as const satisfies __cfHelpers.JSONSchema, {
                 "enum": ["Done", "Pending"]
-            } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending");
+            } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for("__patternResult", true);
         }, {
             type: "object",
             properties: {
@@ -91,7 +91,7 @@ export default pattern((state) => {
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Done", "Pending"]
         } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
@@ -60,7 +60,7 @@ export default pattern((state) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             items: state.key("items")
-        } }, ({ state }) => state.items.map((item) => ({ done: item.done })));
+        } }, ({ state }) => state.items.map((item) => ({ done: item.done }))).for("rows", true);
     return {
         [UI]: (<div>
         {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
@@ -18,13 +18,13 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const a = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("a", true);
     const b = Writable.of(20, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("b", true);
     const c = Writable.of(30, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("c", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -51,7 +51,7 @@ export default pattern(() => {
     }, ({ a, b, c }) => {
         const sum = a.get() + b.get();
         return sum * c.get();
-    });
+    }).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
@@ -24,7 +24,7 @@ export default pattern(() => {
             }
         },
         required: ["count"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("counter", true);
     const doubled = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -45,7 +45,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, { counter: counter }, ({ counter }) => {
         const current = counter.get();
         return current.count * 2;
-    });
+    }).for("doubled", true);
     return doubled;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
@@ -20,10 +20,10 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const a = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("a", true);
     const b = Writable.of(20, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("b", true);
     const sum = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -42,7 +42,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         a: a,
         b: b
-    }, ({ a, b }) => a.get() + b.get());
+    }, ({ a, b }) => a.get() + b.get()).for("sum", true);
     const doubled = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -53,7 +53,7 @@ export default pattern(() => {
         required: ["sum"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema, { sum: sum }, ({ sum }) => sum * 2);
+    } as const satisfies __cfHelpers.JSONSchema, { sum: sum }, ({ sum }) => sum * 2).for("doubled", true);
     return doubled;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/computed-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-no-captures.expected.jsx
@@ -22,7 +22,7 @@ export default pattern(() => {
         properties: {}
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema, {}, () => 42);
+    } as const satisfies __cfHelpers.JSONSchema, {}, () => 42).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
@@ -55,7 +55,7 @@ export default pattern((_) => {
     } as const satisfies __cfHelpers.JSONSchema, {}, (): Question | null => {
         // In real code this would filter and return first match, or null
         return null;
-    });
+    }).for("topQuestion", true);
     return {
         [NAME]: "Computed Nullable Optional Chain",
         [UI]: (<div>

--- a/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
@@ -29,10 +29,10 @@ export default pattern(() => {
             }, {
                 type: "null"
             }]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("config", true);
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -60,7 +60,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         value: value,
         config: config
-    }, ({ value, config }) => value.get() * (config.get()?.multiplier ?? 1));
+    }, ({ value, config }) => value.get() * (config.get()?.multiplier ?? 1)).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
@@ -23,11 +23,11 @@ export default pattern((config: {
 }) => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const offset = 5; // non-cell local
     const threshold = Writable.of(15, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema); // cell local
+    } as const satisfies __cfHelpers.JSONSchema).for("threshold", true); // cell local
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -66,7 +66,7 @@ export default pattern((config: {
         },
         offset: offset,
         threshold: threshold
-    }, ({ value, config, offset, threshold }) => (value.get() + config.base + offset) * config.multiplier + threshold.get());
+    }, ({ value, config, offset, threshold }) => (value.get() + config.base + offset) * config.multiplier + threshold.get()).for("result", true);
     return result;
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
@@ -22,7 +22,7 @@ export default pattern((config: {
 }) => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -48,7 +48,7 @@ export default pattern((config: {
         config: {
             multiplier: config.key("multiplier")
         }
-    }, ({ value, config }) => value.get() * config.multiplier);
+    }, ({ value, config }) => value.get() * config.multiplier).for("result", true);
     return result;
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
@@ -21,7 +21,7 @@ export default pattern((__cf_pattern_input) => {
     const multiplier = __cf_pattern_input.key("multiplier");
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -39,7 +39,7 @@ export default pattern((__cf_pattern_input) => {
     } as const satisfies __cfHelpers.JSONSchema, {
         value: value,
         multiplier: multiplier
-    }, ({ value, multiplier }) => value.get() * multiplier);
+    }, ({ value, multiplier }) => value.get() * multiplier).for("result", true);
     return result;
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
@@ -79,7 +79,7 @@ export default pattern((__cf_pattern_input) => {
     } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => ({
         tasks: items.filter((i) => !i.done),
         view: "inbox",
-    }));
+    })).for("result", true);
     return {
         [UI]: (<div>
         {__cfHelpers.derive({

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
@@ -69,7 +69,7 @@ export default pattern((state) => {
         } }, ({ state }) => ({
         count: state.items.filter((i) => i.done).length,
         total: state.items.length,
-    }));
+    })).for("stats", true);
     return {
         [UI]: (<div>
         {__cfHelpers.derive({

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
@@ -48,7 +48,7 @@ export default pattern((state) => {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             items: state.key("items")
-        } }, ({ state }) => state.items.join(", "));
+        } }, ({ state }) => state.items.join(", ")).for("summary", true);
     return {
         summary,
         charCount: __cfHelpers.derive({

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
@@ -69,7 +69,7 @@ export default pattern((state) => {
             type: "number"
         } as const satisfies __cfHelpers.JSONSchema, { summary: {
                 length: summary.key("length")
-            } }, ({ summary }) => summary.length).for("charCount", true),
+            } }, ({ summary }) => summary.length).for(["__patternResult", "charCount"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
@@ -69,7 +69,7 @@ export default pattern((state) => {
             type: "number"
         } as const satisfies __cfHelpers.JSONSchema, { summary: {
                 length: summary.key("length")
-            } }, ({ summary }) => summary.length),
+            } }, ({ summary }) => summary.length).for("charCount", true),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-template-literal-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-template-literal-capture.expected.jsx
@@ -29,7 +29,7 @@ export default pattern((__cf_pattern_input: {
         required: ["token"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema, { token: token }, ({ token }) => `http://api.example.com?token=${token}`);
+    } as const satisfies __cfHelpers.JSONSchema, { token: token }, ({ token }) => `http://api.example.com?token=${token}`).for("url", true);
     const options = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -54,7 +54,7 @@ export default pattern((__cf_pattern_input: {
         required: ["headers"]
     } as const satisfies __cfHelpers.JSONSchema, { token: token }, ({ token }) => ({
         headers: { Authorization: `Bearer ${token}` },
-    }));
+    })).for("options", true);
     return { url, options };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
@@ -23,10 +23,10 @@ export default pattern(() => {
         items: {
             type: "number"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("numbers", true);
     const multiplier = Writable.of(2, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     // Inside computed, we close over numbers (a Cell)
     // The computed gets transformed to derive({}, () => numbers.map(...))
     // Inside a derive, .map on a closed-over Cell should STILL be transformed to mapWithPattern
@@ -81,7 +81,7 @@ export default pattern(() => {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema), {
         multiplier: multiplier
-    }));
+    })).for("doubled", true);
     return doubled;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "array",

--- a/packages/ts-transformers/test/fixtures/closures/derive-4arg-form.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-4arg-form.expected.jsx
@@ -40,7 +40,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         multiplier: multiplier
     }, ({ value: v, multiplier }) => v.get() * multiplier.get()).for("result", true);
     return result;

--- a/packages/ts-transformers/test/fixtures/closures/derive-4arg-form.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-4arg-form.expected.jsx
@@ -19,10 +19,10 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const multiplier = Writable.of(2, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     // Explicit 4-arg form with schemas - should still transform captures
     const result = __cfHelpers.derive({
         type: "object",
@@ -42,7 +42,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         value,
         multiplier: multiplier
-    }, ({ value: v, multiplier }) => v.get() * multiplier.get());
+    }, ({ value: v, multiplier }) => v.get() * multiplier.get()).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-all-literal-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-all-literal-types.expected.jsx
@@ -49,7 +49,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         numLiteral: numLiteral,
         floatLiteral: floatLiteral,
         boolLiteral: boolLiteral,

--- a/packages/ts-transformers/test/fixtures/closures/derive-all-literal-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-all-literal-types.expected.jsx
@@ -19,7 +19,7 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     // All literal types that should be widened
     const numLiteral = 42;
     const strLiteral = "hello";
@@ -58,7 +58,7 @@ export default pattern(() => {
         // Use all captured literals to ensure they're all widened
         const combined = v.get() + numLiteral + floatLiteral;
         return boolLiteral ? strLiteral + combined : "";
-    });
+    }).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "string"

--- a/packages/ts-transformers/test/fixtures/closures/derive-array-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-array-element-access.expected.jsx
@@ -18,7 +18,7 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const factors = [2, 3, 4];
     const result = __cfHelpers.derive({
         type: "object",
@@ -40,7 +40,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         value,
         factors: factors
-    }, ({ value: v, factors }) => v.get() * factors[1]!);
+    }, ({ value: v, factors }) => v.get() * factors[1]!).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-array-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-array-element-access.expected.jsx
@@ -38,7 +38,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         factors: factors
     }, ({ value: v, factors }) => v.get() * factors[1]!).for("result", true);
     return result;

--- a/packages/ts-transformers/test/fixtures/closures/derive-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-basic-capture.expected.jsx
@@ -17,10 +17,10 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const multiplier = Writable.of(2, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -39,7 +39,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         value,
         multiplier: multiplier
-    }, ({ value: v, multiplier }) => v.get() * multiplier.get());
+    }, ({ value: v, multiplier }) => v.get() * multiplier.get()).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-basic-capture.expected.jsx
@@ -37,7 +37,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         multiplier: multiplier
     }, ({ value: v, multiplier }) => v.get() * multiplier.get()).for("result", true);
     return result;

--- a/packages/ts-transformers/test/fixtures/closures/derive-collision-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-collision-property.expected.jsx
@@ -48,7 +48,7 @@ export default pattern(() => {
         },
         required: ["multiplier", "value"]
     } as const satisfies __cfHelpers.JSONSchema, {
-        multiplier,
+        multiplier: multiplier.for(["result", 2, "multiplier"], true),
         multiplier_1: multiplier
     }, ({ multiplier: m, multiplier_1 }) => ({
         multiplier: multiplier_1.get(),

--- a/packages/ts-transformers/test/fixtures/closures/derive-collision-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-collision-property.expected.jsx
@@ -19,7 +19,7 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const multiplier = Writable.of(2, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     // Input name 'multiplier' collides with captured variable 'multiplier'
     // The callback returns an object with a property named 'multiplier'
     // Only the variable reference should be renamed, NOT the property name
@@ -53,7 +53,7 @@ export default pattern(() => {
     }, ({ multiplier: m, multiplier_1 }) => ({
         multiplier: multiplier_1.get(),
         value: m.get() * 3,
-    }));
+    })).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/derive-collision-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-collision-shorthand.expected.jsx
@@ -19,7 +19,7 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const multiplier = Writable.of(2, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     // Input name 'multiplier' collides with captured variable 'multiplier'
     // The callback uses shorthand property { multiplier }
     // This should expand to { multiplier: multiplier_1 } after renaming
@@ -60,7 +60,7 @@ export default pattern(() => {
     }, ({ multiplier: m, multiplier_1 }) => ({
         value: m.get() * 3,
         data: { multiplier: multiplier_1 },
-    }));
+    })).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/derive-collision-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-collision-shorthand.expected.jsx
@@ -55,7 +55,7 @@ export default pattern(() => {
         },
         required: ["value", "data"]
     } as const satisfies __cfHelpers.JSONSchema, {
-        multiplier,
+        multiplier: multiplier.for(["result", 2, "multiplier"], true),
         multiplier_1: multiplier
     }, ({ multiplier: m, multiplier_1 }) => ({
         value: m.get() * 3,

--- a/packages/ts-transformers/test/fixtures/closures/derive-complex-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-complex-expression.expected.jsx
@@ -44,7 +44,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        a,
+        a: a.for(["result", 2, "a"], true),
         b: b,
         c: c
     }, ({ a: x, b, c }) => (x.get() * b.get() + c.get()) / 2).for("result", true);

--- a/packages/ts-transformers/test/fixtures/closures/derive-complex-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-complex-expression.expected.jsx
@@ -17,13 +17,13 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const a = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("a", true);
     const b = Writable.of(20, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("b", true);
     const c = Writable.of(30, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("c", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -47,7 +47,7 @@ export default pattern(() => {
         a,
         b: b,
         c: c
-    }, ({ a: x, b, c }) => (x.get() * b.get() + c.get()) / 2);
+    }, ({ a: x, b, c }) => (x.get() * b.get() + c.get()) / 2).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-computed-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-computed-property.expected.jsx
@@ -48,7 +48,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         config: config,
         key: key
     }, ({ value: v, config, key }) => v.get() * config[key]).for("result", true);

--- a/packages/ts-transformers/test/fixtures/closures/derive-computed-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-computed-property.expected.jsx
@@ -18,7 +18,7 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const config = { multiplier: 2, divisor: 5 };
     const key = "multiplier";
     const result = __cfHelpers.derive({
@@ -51,7 +51,7 @@ export default pattern(() => {
         value,
         config: config,
         key: key
-    }, ({ value: v, config, key }) => v.get() * config[key]);
+    }, ({ value: v, config, key }) => v.get() * config[key]).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-conditional-expression.expected.jsx
@@ -44,7 +44,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         threshold: threshold,
         multiplier: multiplier
     }, ({ value: v, threshold, multiplier }) => v.get() > threshold.get() ? v.get() * multiplier.get() : v.get()).for("result", true);

--- a/packages/ts-transformers/test/fixtures/closures/derive-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-conditional-expression.expected.jsx
@@ -17,13 +17,13 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const threshold = Writable.of(5, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("threshold", true);
     const multiplier = Writable.of(2, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -47,7 +47,7 @@ export default pattern(() => {
         value,
         threshold: threshold,
         multiplier: multiplier
-    }, ({ value: v, threshold, multiplier }) => v.get() > threshold.get() ? v.get() * multiplier.get() : v.get());
+    }, ({ value: v, threshold, multiplier }) => v.get() > threshold.get() ? v.get() * multiplier.get() : v.get()).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-destructured-param.expected.jsx
@@ -66,7 +66,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        point,
+        point: point.for(["result", 2, "point"], true),
         multiplier: multiplier
     }, ({ point: p, multiplier }) => {
         const { x, y } = p.get();

--- a/packages/ts-transformers/test/fixtures/closures/derive-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-destructured-param.expected.jsx
@@ -31,10 +31,10 @@ export default pattern(() => {
             }
         },
         required: ["x", "y"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("point", true);
     const multiplier = Writable.of(2, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     // Destructuring requires .get() first since derive doesn't unwrap Cell
     const result = __cfHelpers.derive({
         type: "object",
@@ -71,7 +71,7 @@ export default pattern(() => {
     }, ({ point: p, multiplier }) => {
         const { x, y } = p.get();
         return (x + y) * multiplier.get();
-    });
+    }).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-empty-input-no-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-empty-input-no-params.expected.jsx
@@ -18,10 +18,10 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const a = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("a", true);
     const b = Writable.of(20, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("b", true);
     // Zero-parameter callback that closes over a and b
     const result = __cfHelpers.derive({
         type: "object",
@@ -41,7 +41,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         a: a,
         b: b
-    }, ({ a, b }) => a.get() + b.get());
+    }, ({ a, b }) => a.get() + b.get()).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-filter-map-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-filter-map-chain.expected.jsx
@@ -64,7 +64,7 @@ export default pattern((state) => {
             .map((p) => p.ingredient)
             .join(", ");
         return `Pattern for ${food} with: ${liked}`;
-    });
+    }).for("wishQuery", true);
     return { wishQuery };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/derive-local-variable.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-local-variable.expected.jsx
@@ -18,13 +18,13 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const a = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("a", true);
     const b = Writable.of(20, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("b", true);
     const c = Writable.of(30, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("c", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -51,7 +51,7 @@ export default pattern(() => {
     }, ({ a: aVal, b, c }) => {
         const sum = aVal.get() + b.get();
         return sum * c.get();
-    });
+    }).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-local-variable.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-local-variable.expected.jsx
@@ -45,7 +45,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        a,
+        a: a.for(["result", 2, "a"], true),
         b: b,
         c: c
     }, ({ a: aVal, b, c }) => {

--- a/packages/ts-transformers/test/fixtures/closures/derive-map-input-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-map-input-no-captures.expected.jsx
@@ -72,7 +72,7 @@ export default pattern((__cf_pattern_input) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {}), (arr) => arr.length).for("count", true);
+    } as const satisfies __cfHelpers.JSONSchema), {}).for(["count", 2], true), (arr) => arr.length).for("count", true);
     return { count };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/derive-map-input-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-map-input-no-captures.expected.jsx
@@ -72,7 +72,7 @@ export default pattern((__cf_pattern_input) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {}), (arr) => arr.length);
+    } as const satisfies __cfHelpers.JSONSchema), {}), (arr) => arr.length).for("count", true);
     return { count };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/derive-map-union-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-map-union-return.expected.jsx
@@ -98,7 +98,7 @@ export default pattern((state) => {
             }
         }
         return null;
-    });
+    }).for("latestMessage", true);
     return {
         [UI]: (<div>
         <div>Latest: {latestMessage}</div>

--- a/packages/ts-transformers/test/fixtures/closures/derive-method-call-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-method-call-capture.expected.jsx
@@ -23,7 +23,7 @@ interface State {
 export default pattern((state: State) => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     // Capture property before method call
     const result = __cfHelpers.derive({
         type: "object",
@@ -58,7 +58,7 @@ export default pattern((state: State) => {
                 value: state.key("counter", "value")
             }
         }
-    }, ({ value: v, state }) => v.get() + state.counter.value);
+    }, ({ value: v, state }) => v.get() + state.counter.value).for("result", true);
     return result;
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/derive-method-call-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-method-call-capture.expected.jsx
@@ -52,7 +52,7 @@ export default pattern((state: State) => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         state: {
             counter: {
                 value: state.key("counter", "value")

--- a/packages/ts-transformers/test/fixtures/closures/derive-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-multiple-captures.expected.jsx
@@ -17,13 +17,13 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const multiplier = Writable.of(2, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     const offset = Writable.of(5, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("offset", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -47,7 +47,7 @@ export default pattern(() => {
         value,
         multiplier: multiplier,
         offset: offset
-    }, ({ value: v, multiplier, offset }) => (v.get() * multiplier.get()) + offset.get());
+    }, ({ value: v, multiplier, offset }) => (v.get() * multiplier.get()) + offset.get()).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-multiple-captures.expected.jsx
@@ -44,7 +44,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         multiplier: multiplier,
         offset: offset
     }, ({ value: v, multiplier, offset }) => (v.get() * multiplier.get()) + offset.get()).for("result", true);

--- a/packages/ts-transformers/test/fixtures/closures/derive-name-collision.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-name-collision.expected.jsx
@@ -18,7 +18,7 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const multiplier = Writable.of(2, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     // Input name collides with capture name
     // multiplier is both the input AND a captured variable (used via .get())
     const result = __cfHelpers.derive({
@@ -39,7 +39,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         multiplier,
         multiplier_1: multiplier
-    }, ({ multiplier: m, multiplier_1 }) => m.get() * 3 + multiplier_1.get());
+    }, ({ multiplier: m, multiplier_1 }) => m.get() * 3 + multiplier_1.get()).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-name-collision.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-name-collision.expected.jsx
@@ -37,7 +37,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        multiplier,
+        multiplier: multiplier.for(["result", 2, "multiplier"], true),
         multiplier_1: multiplier
     }, ({ multiplier: m, multiplier_1 }) => m.get() * 3 + multiplier_1.get()).for("result", true);
     return result;

--- a/packages/ts-transformers/test/fixtures/closures/derive-nested-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-nested-callback.expected.jsx
@@ -49,7 +49,7 @@ export default pattern(() => {
             type: "number"
         }
     } as const satisfies __cfHelpers.JSONSchema, {
-        numbers,
+        numbers: numbers.for(["result", 2, "numbers"], true),
         multiplier: multiplier
     }, ({ numbers: nums, multiplier }) => nums.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
         const n = __cf_pattern_input.key("element");

--- a/packages/ts-transformers/test/fixtures/closures/derive-nested-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-nested-callback.expected.jsx
@@ -22,10 +22,10 @@ export default pattern(() => {
         items: {
             type: "number"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("numbers", true);
     const multiplier = Writable.of(2, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     // Nested callback - inner array map should not capture outer multiplier
     const result = __cfHelpers.derive({
         type: "object",
@@ -77,7 +77,7 @@ export default pattern(() => {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema), {
         multiplier: multiplier
-    }));
+    })).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "array",

--- a/packages/ts-transformers/test/fixtures/closures/derive-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-nested-property.expected.jsx
@@ -23,7 +23,7 @@ interface State {
 export default pattern((state: State) => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -57,7 +57,7 @@ export default pattern((state: State) => {
                 multiplier: state.key("config", "multiplier")
             }
         }
-    }, ({ value: v, state }) => v.get() * state.config.multiplier);
+    }, ({ value: v, state }) => v.get() * state.config.multiplier).for("result", true);
     return result;
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/derive-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-nested-property.expected.jsx
@@ -51,7 +51,7 @@ export default pattern((state: State) => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         state: {
             config: {
                 multiplier: state.key("config", "multiplier")

--- a/packages/ts-transformers/test/fixtures/closures/derive-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-no-captures.expected.jsx
@@ -18,14 +18,14 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     // No captures - should not be transformed
     const result = derive({
         type: "number",
         asCell: ["cell"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema, value, (v) => v.get() * 2);
+    } as const satisfies __cfHelpers.JSONSchema, value, (v) => v.get() * 2).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-optional-chaining.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-optional-chaining.expected.jsx
@@ -42,7 +42,7 @@ export default pattern((config: Config) => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         config: {
             multiplier: config.key("multiplier")
         }

--- a/packages/ts-transformers/test/fixtures/closures/derive-optional-chaining.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-optional-chaining.expected.jsx
@@ -21,7 +21,7 @@ interface Config {
 export default pattern((config: Config) => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -46,7 +46,7 @@ export default pattern((config: Config) => {
         config: {
             multiplier: config.key("multiplier")
         }
-    }, ({ value: v, config }) => v.get() * (config.multiplier ?? 1));
+    }, ({ value: v, config }) => v.get() * (config.multiplier ?? 1)).for("result", true);
     return result;
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/derive-param-initializer.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-param-initializer.expected.jsx
@@ -19,7 +19,7 @@ export default pattern(() => {
     const value = 5;
     const multiplier = Writable.of(2, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     // Test parameter with default value
     const result = __cfHelpers.derive({
         type: "object",
@@ -38,7 +38,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         value,
         multiplier: multiplier
-    }, ({ value: v = 10, multiplier }) => v * multiplier.get());
+    }, ({ value: v = 10, multiplier }) => v * multiplier.get()).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-reserved-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-reserved-names.expected.jsx
@@ -17,7 +17,7 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     // Reserved JavaScript keyword as variable name (valid in TS with quotes)
     const __cf_reserved = Writable.of(2, {
         type: "number"
@@ -40,7 +40,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         value,
         __cf_reserved: __cf_reserved
-    }, ({ value: v, __cf_reserved }) => v.get() * __cf_reserved.get());
+    }, ({ value: v, __cf_reserved }) => v.get() * __cf_reserved.get()).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-reserved-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-reserved-names.expected.jsx
@@ -38,7 +38,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         __cf_reserved: __cf_reserved
     }, ({ value: v, __cf_reserved }) => v.get() * __cf_reserved.get()).for("result", true);
     return result;

--- a/packages/ts-transformers/test/fixtures/closures/derive-template-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-template-literal.expected.jsx
@@ -17,10 +17,10 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const prefix = Writable.of("Value: ", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("prefix", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -39,7 +39,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         value,
         prefix: prefix
-    }, ({ value: v, prefix }) => `${prefix.get()}${v}`);
+    }, ({ value: v, prefix }) => `${prefix.get()}${v}`).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "string"

--- a/packages/ts-transformers/test/fixtures/closures/derive-template-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-template-literal.expected.jsx
@@ -37,7 +37,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         prefix: prefix
     }, ({ value: v, prefix }) => `${prefix.get()}${v}`).for("result", true);
     return result;

--- a/packages/ts-transformers/test/fixtures/closures/derive-type-assertion.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-type-assertion.expected.jsx
@@ -38,7 +38,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         multiplier: multiplier
     }, ({ value: v, multiplier }) => (v.get() * multiplier.get()) as number).for("result", true);
     return result;

--- a/packages/ts-transformers/test/fixtures/closures/derive-type-assertion.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-type-assertion.expected.jsx
@@ -18,10 +18,10 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const multiplier = Writable.of(2, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -40,7 +40,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         value,
         multiplier: multiplier
-    }, ({ value: v, multiplier }) => (v.get() * multiplier.get()) as number);
+    }, ({ value: v, multiplier }) => (v.get() * multiplier.get()) as number).for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-union-undefined.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-union-undefined.expected.jsx
@@ -47,7 +47,7 @@ export default pattern((config: Config) => {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
-        value,
+        value: value.for(["result", 2, "value"], true),
         config: {
             required: config.key("required"),
             unionUndefined: config.key("unionUndefined")

--- a/packages/ts-transformers/test/fixtures/closures/derive-union-undefined.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-union-undefined.expected.jsx
@@ -22,7 +22,7 @@ interface Config {
 export default pattern((config: Config) => {
     const value = Writable.of(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("value", true);
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -52,7 +52,7 @@ export default pattern((config: Config) => {
             required: config.key("required"),
             unionUndefined: config.key("unionUndefined")
         }
-    }, ({ value: v, config }) => v.get() + config.required + (config.unionUndefined ?? 0));
+    }, ({ value: v, config }) => v.get() + config.required + (config.unionUndefined ?? 0)).for("result", true);
     return result;
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/filter-flatmap-fallback-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-flatmap-fallback-chain.expected.jsx
@@ -79,7 +79,7 @@ export default pattern((__cf_pattern_input) => {
                 }
             } as const satisfies __cfHelpers.JSONSchema, { item: {
                     tags: item.key("tags")
-                } }, ({ item }) => item.tags ?? []);
+                } }, ({ item }) => item.tags ?? []).for("__patternResult", true);
         }, {
             type: "object",
             properties: {
@@ -142,7 +142,7 @@ export default pattern((__cf_pattern_input) => {
                 }
             }
         } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
@@ -139,7 +139,7 @@ export default pattern((__cf_pattern_input) => {
             }
         } as const satisfies __cfHelpers.JSONSchema), {
             prefix: prefix
-        }),
+        }).for("labels", true),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
@@ -139,7 +139,7 @@ export default pattern((__cf_pattern_input) => {
             }
         } as const satisfies __cfHelpers.JSONSchema), {
             prefix: prefix
-        }).for("labels", true),
+        }).for(["__patternResult", "labels"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
@@ -50,7 +50,7 @@ export default pattern((state) => {
             },
             required: ["state"]
         } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state }) => {
-            const scaled = state.items.map((item) => item.value * state.multiplier).for("scaled", true);
+            const scaled = state.items.map((item) => item.value * state.multiplier);
             console.log(scaled);
         })({
             state: {
@@ -59,7 +59,7 @@ export default pattern((state) => {
             }
         })}>
         Compute
-      </button>)
+      </button>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
@@ -50,7 +50,7 @@ export default pattern((state) => {
             },
             required: ["state"]
         } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state }) => {
-            const scaled = state.items.map((item) => item.value * state.multiplier);
+            const scaled = state.items.map((item) => item.value * state.multiplier).for("scaled", true);
             console.log(scaled);
         })({
             state: {

--- a/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
@@ -59,7 +59,7 @@ export default pattern((state) => {
             }
         })}>
         Compute
-      </button>),
+      </button>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
@@ -116,7 +116,7 @@ export default pattern((__cf_pattern_input) => {
         savedContent: savedContent,
         onSaveFile: onSaveFile
     }).for("trigger", true);
-    return { trigger };
+    return { trigger: trigger.for(["__patternResult", "trigger"], true) };
 }, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
@@ -60,7 +60,7 @@ export default pattern((__cf_pattern_input) => {
             }, {
                 type: "null"
             }]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("timer", true);
     const trigger = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
         type: "object",
         properties: {
@@ -115,7 +115,7 @@ export default pattern((__cf_pattern_input) => {
         content: content,
         savedContent: savedContent,
         onSaveFile: onSaveFile
-    });
+    }).for("trigger", true);
     return { trigger };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
@@ -84,7 +84,7 @@ export default pattern((__cf_pattern_input) => {
                     anyOf: [{
                             type: "null"
                         }, {}]
-                } as const satisfies __cfHelpers.JSONSchema, moduleHasSettings({ piece: entry.key("piece") }), <span>settings</span>, null);
+                } as const satisfies __cfHelpers.JSONSchema, moduleHasSettings({ piece: entry.key("piece") }), <span>settings</span>, null).for("__patternResult", true);
             }, {
                 type: "object",
                 properties: {
@@ -164,7 +164,7 @@ export default pattern((__cf_pattern_input) => {
                         type: msg.key("type")
                     } }, ({ msg }) => msg.type === "system"), <span>{msg.key("id")}</span>, <button type="button" onClick={selectMessage({ selectedId, msgId: msg.key("id") })}>
                 open
-              </button>);
+              </button>).for("__patternResult", true);
             }, {
                 type: "object",
                 properties: {
@@ -217,7 +217,7 @@ export default pattern((__cf_pattern_input) => {
             } as const satisfies __cfHelpers.JSONSchema), {
                 selectedId: selectedId
             })}
-        </div>),
+        </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
@@ -66,7 +66,7 @@ export default pattern((__cf_pattern_input) => {
     const messages = __cf_pattern_input.key("messages");
     const selectedId = Writable.of("", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("selectedId", true);
     return {
         [UI]: (<div>
           {entries.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-fn.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-fn.expected.jsx
@@ -23,7 +23,7 @@ interface State {
 export default pattern((state) => {
     const count = cell(0, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("count", true);
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-of.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-of.expected.jsx
@@ -23,7 +23,7 @@ interface State {
 export default pattern((state) => {
     const counter = Cell.of(0, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("counter", true);
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.expected.jsx
@@ -27,7 +27,7 @@ export default pattern((state) => {
     const label = "Result";
     const limit = cell(100, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("limit", true);
     const derived = state.key("threshold");
     return {
         [UI]: (<div>

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
@@ -27,7 +27,7 @@ export default pattern((state) => {
             }, {
                 type: "null"
             }]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("selected", true);
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/map-cell-receiver-in-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-cell-receiver-in-lift.expected.jsx
@@ -20,7 +20,7 @@ const items = __cfHelpers.__cf_data(Cell.of<string[]>([], {
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema));
+} as const satisfies __cfHelpers.JSONSchema).for("items", true));
 export const fn = lift(false as const satisfies __cfHelpers.JSONSchema, {
     type: "array",
     items: {

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
@@ -42,7 +42,7 @@ export default pattern((state) => {
                 } as const satisfies __cfHelpers.JSONSchema, {
                     element: element,
                     __cf_amount_key: __cf_amount_key
-                }, ({ element, __cf_amount_key }) => element[__cf_amount_key]);
+                }, ({ element, __cf_amount_key }) => element[__cf_amount_key]).for("amount", true);
                 return (<span>{amount}</span>);
             }, {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
@@ -77,7 +77,7 @@ export default pattern((state) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-alias-with-plain-binding.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-alias-with-plain-binding.expected.jsx
@@ -26,7 +26,7 @@ const __cfModuleCallback_1 = __cfHardenFn(({ element, params: {} }) => {
     } as const satisfies __cfHelpers.JSONSchema, {
         element: element,
         __cf_val_key: __cf_val_key
-    }, ({ element, __cf_val_key }) => element[__cf_val_key]);
+    }, ({ element, __cf_val_key }) => element[__cf_val_key]).for("val", true);
     return (<span>{__cfHelpers.derive({
         type: "object",
         properties: {

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
@@ -77,7 +77,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 } as const satisfies __cfHelpers.JSONSchema, { msg: {
                         reactions: msg.key("reactions")
-                    } }, ({ msg }) => (msg.reactions ?? []) as Reaction[]);
+                    } }, ({ msg }) => (msg.reactions ?? []) as Reaction[]).for("messageReactions", true);
                 return (<div>
               {messageReactions.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                         const reaction = __cf_pattern_input.key("element");

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
@@ -200,7 +200,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
@@ -87,7 +87,7 @@ export default pattern((state) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
@@ -42,7 +42,7 @@ export default pattern((state) => {
                 } as const satisfies __cfHelpers.JSONSchema, {
                     element: element,
                     __cf_val_key: __cf_val_key
-                }, ({ element, __cf_val_key }) => element[__cf_val_key]);
+                }, ({ element, __cf_val_key }) => element[__cf_val_key]).for("val", true);
                 return (<span>{val}</span>);
             }, {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-local-helper-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-local-helper-call-root.expected.jsx
@@ -41,7 +41,7 @@ export default pattern((__cf_pattern_input) => {
         required: ["element"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {});
+    } as const satisfies __cfHelpers.JSONSchema), {}).for("__patternResult", true);
 }, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
@@ -73,7 +73,7 @@ export default pattern((state) => {
                         editingPersonName: state.key("editingPersonName")
                     },
                     personName: personName
-                }, ({ state, personName }) => state.editingPersonName === personName);
+                }, ({ state, personName }) => state.editingPersonName === personName).for("isEditing", true);
                 const isRemoveConfirm = __cfHelpers.derive({
                     type: "object",
                     properties: {
@@ -102,7 +102,7 @@ export default pattern((state) => {
                         removePersonConfirmTarget: state.key("removePersonConfirmTarget")
                     },
                     personName: personName
-                }, ({ state, personName }) => state.removePersonConfirmTarget === personName);
+                }, ({ state, personName }) => state.removePersonConfirmTarget === personName).for("isRemoveConfirm", true);
                 const activeSpotOpts = __cfHelpers.derive({
                     type: "object",
                     properties: {
@@ -153,7 +153,7 @@ export default pattern((state) => {
                     .map((s) => ({
                     label: "#" + s.spotNumber + (s.label ? " - " + s.label : ""),
                     value: s.spotNumber,
-                })));
+                }))).for("activeSpotOpts", true);
                 return (<section>
               <span>{personName}</span>
               <span>{email}</span>

--- a/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
@@ -442,7 +442,7 @@ export default pattern((state) => {
                     spots: state.key("spots")
                 }
             })}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
@@ -175,7 +175,7 @@ export default pattern((__cf_pattern_input) => {
             } as const satisfies __cfHelpers.JSONSchema), {
                 logs: logs,
                 todayDate: todayDate
-            })}</div>,
+            })}</div>
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
@@ -92,7 +92,7 @@ export default pattern((__cf_pattern_input) => {
                     return logList.some((log) => log.habitName === habit.name &&
                         log.date === todayDate &&
                         log.completed);
-                });
+                }).for("doneToday", true);
                 return <span>{__cfHelpers.ifElse({
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
@@ -172,7 +172,7 @@ export default pattern((__cf_pattern_input) => {
             } as const satisfies __cfHelpers.JSONSchema), {
                 logs: logs,
                 todayDate: todayDate
-            })}</div>,
+            })}</div>
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
@@ -89,7 +89,7 @@ export default pattern((__cf_pattern_input) => {
                     todayDate: todayDate
                 }, ({ logs, habit, todayDate }) => logs.get().some((log) => log.habitName === habit.name &&
                     log.date === todayDate &&
-                    log.completed));
+                    log.completed)).for("doneToday", true);
                 return <span>{__cfHelpers.ifElse({
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
@@ -94,7 +94,7 @@ export default pattern((state) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             items: state.key("items")
-        } }, ({ state }) => state.items);
+        } }, ({ state }) => state.items).for("inner", true);
     const fromComputed = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -128,7 +128,7 @@ export default pattern((state) => {
             items: {
                 type: "string"
             }
-        } as const satisfies __cfHelpers.JSONSchema, { inner: inner }, ({ inner }) => inner);
+        } as const satisfies __cfHelpers.JSONSchema, { inner: inner }, ({ inner }) => inner).for("foo", true);
         return foo.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
             const item = __cf_pattern_input.key("element");
             return item + "!";
@@ -143,7 +143,7 @@ export default pattern((state) => {
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema), {});
-    });
+    }).for("fromComputed", true);
     const fromLift = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -161,7 +161,7 @@ export default pattern((state) => {
             type: "string"
         }
     } as const satisfies __cfHelpers.JSONSchema, { inner: inner }, ({ inner }) => {
-        const foo = passthrough(inner);
+        const foo = passthrough(inner).for("foo", true);
         return foo.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
             const item = __cf_pattern_input.key("element");
             return item + "!";
@@ -176,7 +176,7 @@ export default pattern((state) => {
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema), {});
-    });
+    }).for("fromLift", true);
     const fromWish = __cfHelpers.derive({
         type: "object",
         properties: {}
@@ -185,7 +185,7 @@ export default pattern((state) => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema, {}, __cfModuleCallback_1);
+    } as const satisfies __cfHelpers.JSONSchema, {}, __cfModuleCallback_1).for("fromWish", true);
     const fromFiltered = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -219,7 +219,7 @@ export default pattern((state) => {
             items: {
                 type: "string"
             }
-        } as const satisfies __cfHelpers.JSONSchema, { inner: inner }, ({ inner }) => inner);
+        } as const satisfies __cfHelpers.JSONSchema, { inner: inner }, ({ inner }) => inner).for("foo", true);
         const filtered = foo.filterWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
             const item = __cf_pattern_input.key("element");
             return item.key("length") > 1;
@@ -233,7 +233,7 @@ export default pattern((state) => {
             required: ["element"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "boolean"
-        } as const satisfies __cfHelpers.JSONSchema), {});
+        } as const satisfies __cfHelpers.JSONSchema), {}).for("filtered", true);
         return filtered.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
             const item = __cf_pattern_input.key("element");
             return item + "!";
@@ -248,7 +248,7 @@ export default pattern((state) => {
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema), {});
-    });
+    }).for("fromFiltered", true);
     const fromFilteredReceiverMethod = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -282,7 +282,7 @@ export default pattern((state) => {
             items: {
                 type: "string"
             }
-        } as const satisfies __cfHelpers.JSONSchema, { inner: inner }, ({ inner }) => inner);
+        } as const satisfies __cfHelpers.JSONSchema, { inner: inner }, ({ inner }) => inner).for("foo", true);
         const filtered = foo.filterWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
             const item = __cf_pattern_input.key("element");
             return item.key("length") > 1;
@@ -296,7 +296,7 @@ export default pattern((state) => {
             required: ["element"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "boolean"
-        } as const satisfies __cfHelpers.JSONSchema), {});
+        } as const satisfies __cfHelpers.JSONSchema), {}).for("filtered", true);
         return filtered.mapWithPattern(__cfHelpers.pattern(__cfModuleCallback_2, {
             type: "object",
             properties: {
@@ -308,7 +308,7 @@ export default pattern((state) => {
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema), {});
-    });
+    }).for("fromFilteredReceiverMethod", true);
     return {
         fromComputed,
         fromLift,

--- a/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
@@ -19,7 +19,7 @@ const __cfModuleCallback_1 = __cfHardenFn(() => {
             type: "string"
         },
         "default": []
-    } as const satisfies __cfHelpers.JSONSchema).result!;
+    } as const satisfies __cfHelpers.JSONSchema).for("foo", true).result!;
     return foo.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
         const item = __cf_pattern_input.key("element");
         return item + "!";

--- a/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
@@ -19,7 +19,7 @@ const __cfModuleCallback_1 = __cfHardenFn(() => {
             type: "string"
         },
         "default": []
-    } as const satisfies __cfHelpers.JSONSchema).for("foo", true).result!;
+    } as const satisfies __cfHelpers.JSONSchema).result!;
     return foo.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
         const item = __cf_pattern_input.key("element");
         return item + "!";

--- a/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
@@ -87,7 +87,7 @@ export default pattern((__cf_pattern_input) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => items.get().length > 0);
+    } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => items.get().length > 0).for("hasItems", true);
     return {
         [UI]: (<div>
         {__cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
@@ -79,7 +79,7 @@ export default pattern((_) => {
                 required: ["name", "value"]
             }
         }
-    } as const satisfies __cfHelpers.JSONSchema).for("items", true).result!;
+    } as const satisfies __cfHelpers.JSONSchema).result!;
     return {
         [NAME]: "Test",
         [UI]: (<ul>

--- a/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
@@ -79,7 +79,7 @@ export default pattern((_) => {
                 required: ["name", "value"]
             }
         }
-    } as const satisfies __cfHelpers.JSONSchema).result!;
+    } as const satisfies __cfHelpers.JSONSchema).for("items", true).result!;
     return {
         [NAME]: "Test",
         [UI]: (<ul>

--- a/packages/ts-transformers/test/fixtures/closures/map-with-array-param-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-with-array-param-no-name.expected.jsx
@@ -22,7 +22,7 @@ export default pattern((_state: any) => {
         items: {
             type: "number"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     return {
         [UI]: (<div>
         {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/map-with-array-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-with-array-param.expected.jsx
@@ -22,7 +22,7 @@ export default pattern((_state) => {
         items: {
             type: "number"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     return {
         [UI]: (<div>
         {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
@@ -32,10 +32,10 @@ const __cfAmdHooks = undefined;
 export default pattern(() => {
     const showOuter = Writable.of(false, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("showOuter", true);
     const secondToggle = Writable.of(false, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("secondToggle", true);
     return {
         [UI]: (<div>
         {/* Case A: Top-level computed - always worked */}

--- a/packages/ts-transformers/test/fixtures/closures/pattern-computed-opaque-ref-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-computed-opaque-ref-map.expected.jsx
@@ -36,7 +36,7 @@ export default pattern((items) => {
         items: {
             type: "number"
         }
-    } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => items.map((n) => n * 2));
+    } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => items.map((n) => n * 2)).for("doubled", true);
     return doubled;
 }, {
     type: "array",

--- a/packages/ts-transformers/test/fixtures/closures/pattern-derive-opaque-ref-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-derive-opaque-ref-map.expected.jsx
@@ -36,7 +36,7 @@ export default pattern((items) => {
         items: {
             type: "number"
         }
-    } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => items.map((n) => n * 2));
+    } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => items.map((n) => n * 2)).for("doubled", true);
     return doubled;
 }, {
     type: "array",

--- a/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
@@ -88,7 +88,7 @@ export default pattern((__cf_pattern_input) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => items.get().length > 0);
+    } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => items.get().length > 0).for("hasItems", true);
     return {
         [UI]: (<div>
         {__cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
@@ -29,7 +29,7 @@ export default pattern((__cf_pattern_input) => {
         required: ["messages"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema, { messages: messages }, ({ messages }) => messages[0] ?? "");
+    } as const satisfies __cfHelpers.JSONSchema, { messages: messages }, ({ messages }) => messages[0] ?? "").for("preview", true);
     const __cf_destructure_1 = generateObject({
         prompt: preview,
         schema: {

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
@@ -44,9 +44,9 @@ const __cfModuleCallback_1 = __cfHardenFn(({ query, content }: {
         return content.split("\n").filter((c: string) => c.includes(query));
     });
 });
-const content = cell("Hello world\nGoodbye world", {
+const content = __cfHelpers.__cf_data(cell("Hello world\nGoodbye world", {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema).for("content", true));
 type Output = {
     grepTool: PatternToolResult<{
         content: string;

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
@@ -59,7 +59,7 @@ type Output = {
 // Context: Module-scoped `content` cell is referenced inside the patternTool
 //   callback. The transformer threads it through the existing extraParams object.
 export default pattern(() => {
-    const grepTool = patternTool(__cfModuleCallback_1, { content });
+    const grepTool = patternTool(__cfModuleCallback_1, { content: content.for(["grepTool", 1, "content"], true) });
     return { grepTool };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
@@ -26,7 +26,7 @@ const __cfModuleCallback_1 = __cfHardenFn(({ language, content }: {
             required: ["language"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, { language: language }, ({ language }) => `Translate to ${language}.`),
+        } as const satisfies __cfHelpers.JSONSchema, { language: language }, ({ language }) => `Translate to ${language}.`).for("system", true),
         prompt: __cfHelpers.derive({
             type: "object",
             properties: {
@@ -37,7 +37,7 @@ const __cfModuleCallback_1 = __cfHardenFn(({ language, content }: {
             required: ["content"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, { content: content }, ({ content }) => content),
+        } as const satisfies __cfHelpers.JSONSchema, { content: content }, ({ content }) => content).for("prompt", true),
     }).for("genResult", true);
     return __cfHelpers.derive({
         type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
@@ -38,7 +38,7 @@ const __cfModuleCallback_1 = __cfHardenFn(({ language, content }: {
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, { content: content }, ({ content }) => content),
-    });
+    }).for("genResult", true);
     return __cfHelpers.derive({
         type: "object",
         properties: {
@@ -69,7 +69,7 @@ const __cfModuleCallback_1 = __cfHardenFn(({ language, content }: {
 });
 const content = __cfHelpers.__cf_data(Writable.of("Hello world", {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema));
+} as const satisfies __cfHelpers.JSONSchema).for("content", true));
 type Output = {
     tool: PatternToolResult<{
         content: string;

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
@@ -26,7 +26,7 @@ const __cfModuleCallback_1 = __cfHardenFn(({ language, content }: {
             required: ["language"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, { language: language }, ({ language }) => `Translate to ${language}.`).for("system", true),
+        } as const satisfies __cfHelpers.JSONSchema, { language: language }, ({ language }) => `Translate to ${language}.`).for(["genResult", "system"], true),
         prompt: __cfHelpers.derive({
             type: "object",
             properties: {
@@ -37,7 +37,7 @@ const __cfModuleCallback_1 = __cfHardenFn(({ language, content }: {
             required: ["content"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        } as const satisfies __cfHelpers.JSONSchema, { content: content }, ({ content }) => content).for("prompt", true),
+        } as const satisfies __cfHelpers.JSONSchema, { content: content }, ({ content }) => content).for(["genResult", "prompt"], true)
     }).for("genResult", true);
     return __cfHelpers.derive({
         type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
@@ -86,7 +86,7 @@ type Output = {
 //   must not be hoisted into extraParams. Only module-scoped reactive bindings
 //   (here, `content` from Writable.of) should be captured.
 export default pattern(() => {
-    const tool = patternTool(__cfModuleCallback_1, { content });
+    const tool = patternTool(__cfModuleCallback_1, { content: content.for(["tool", 1, "content"], true) });
     return { tool };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
@@ -13,10 +13,10 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const multiplier = __cfHelpers.__cf_data(Writable.of(2, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema));
+} as const satisfies __cfHelpers.JSONSchema).for("multiplier", true));
 const prefix = __cfHelpers.__cf_data(Writable.of("Result: ", {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema));
+} as const satisfies __cfHelpers.JSONSchema).for("prefix", true));
 type Output = {
     tool: PatternToolResult<Record<string, never>>;
 };

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
@@ -11,12 +11,12 @@ import { cell, derive, pattern, patternTool, type PatternToolResult } from "comm
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const multiplier = cell(2, {
+const multiplier = __cfHelpers.__cf_data(cell(2, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
-const offset = cell(10, {
+} as const satisfies __cfHelpers.JSONSchema).for("multiplier", true));
+const offset = __cfHelpers.__cf_data(cell(10, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema).for("offset", true));
 type Output = {
     tool: PatternToolResult<{
         offset: number;

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
@@ -56,7 +56,7 @@ export default pattern(() => {
         });
     }, {
         multiplier: multiplier,
-        offset
+        offset: offset.for(["tool", 1, "offset"], true)
     });
     return { tool };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
@@ -32,10 +32,10 @@ export default pattern((__cf_pattern_input) => {
     const title = __cf_pattern_input.key("title");
     const counter = Writable.of(0, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("counter", true);
     const label = Writable.of("Count", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("label", true);
     const reset = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
         type: "object",
         properties: {
@@ -55,7 +55,7 @@ export default pattern((__cf_pattern_input) => {
     })({
         counter: counter,
         label: label
-    });
+    }).for("reset", true);
     return {
         [UI]: (<div>
         <span>{title} {label}: {counter}</span>

--- a/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
@@ -61,8 +61,8 @@ export default pattern((__cf_pattern_input) => {
         <span>{title} {label}: {counter}</span>
         <cf-button onClick={reset}>Reset</cf-button>
       </div>),
-        counter,
-        label,
+        counter: counter.for(["__patternResult", "counter"], true),
+        label: label.for(["__patternResult", "label"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/conditional-empty-check.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/conditional-empty-check.expected.jsx
@@ -21,7 +21,7 @@ export default pattern(() => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     return {
         [NAME]: "Conditional empty check",
         [UI]: (<div>

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
@@ -88,7 +88,7 @@ export default pattern((__cf_pattern_input) => {
     } as const satisfies __cfHelpers.JSONSchema, { items }, ({ items }) => items.map((item, idx) => ({
         aisle: `Aisle ${(idx % 3) + 1}`,
         item: item,
-    })));
+    }))).for("itemsWithAisles", true);
     // Group by aisle - returns Record<string, Assignment[]>
     const groupedByAisle = derive({
         type: "object",
@@ -170,7 +170,7 @@ export default pattern((__cf_pattern_input) => {
             groups[assignment.aisle]!.push(assignment);
         }
         return groups;
-    });
+    }).for("groupedByAisle", true);
     // Derive sorted aisle names from grouped object
     const aisleNames = derive({
         type: "object",
@@ -219,7 +219,7 @@ export default pattern((__cf_pattern_input) => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema, { groupedByAisle }, ({ groupedByAisle }) => Object.keys(groupedByAisle).sort());
+    } as const satisfies __cfHelpers.JSONSchema, { groupedByAisle }, ({ groupedByAisle }) => Object.keys(groupedByAisle).sort()).for("aisleNames", true);
     // The pattern from CT-1036:
     // - Map over derived keys (aisleNames)
     // - Access derived object with derived key (groupedByAisle[aisleName])

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-both-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-both-opaque.expected.jsx
@@ -20,10 +20,10 @@ export default pattern((_state) => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     const index = cell(1, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("index", true);
     return {
         [UI]: (<div>
         <h3>Element Access with Both OpaqueRefs</h3>

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
@@ -48,7 +48,7 @@ export default pattern((__cf_pattern_input) => {
                 type: "boolean"
             } as const satisfies __cfHelpers.JSONSchema, { file: {
                     type: file.key("type")
-                } }, ({ file }) => file.type === "folder");
+                } }, ({ file }) => file.type === "folder").for("isFolder", true);
             return isFolder;
         }, {
             type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
@@ -120,7 +120,7 @@ export default pattern((__cf_pattern_input) => {
                 }
             }
         } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/generate-text-local-ternary.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/generate-text-local-ternary.expected.jsx
@@ -18,7 +18,7 @@ const __cfAmdHooks = undefined;
 // input binding, so this exercises expression-site lowering on local reactive
 // aliases in JSX.
 export default pattern(() => {
-    const text = generateText({ prompt: "hi" });
+    const text = generateText({ prompt: "hi" }).for("text", true);
     return {
         [UI]: <div>{__cfHelpers.ifElse({
             type: "boolean"

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -101,7 +101,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []).for("p", true);
+                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()).for(["p", 3], true), []).for("p", true);
                 if (p.length === 0)
                     return null;
                 return <div>{__cfHelpers.derive({
@@ -150,7 +150,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []).for("p", true);
+                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()).for(["p", 3], true), []).for("p", true);
                 const visible = __cfHelpers.derive({
                     type: "object",
                     properties: {
@@ -294,7 +294,7 @@ export default pattern((__cf_pattern_input) => {
                     pushPath: pushPath
                 });
             })()}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -42,7 +42,7 @@ export default pattern((__cf_pattern_input) => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("path", true);
     const pushPath = __cfHelpers.handler({
         type: "object",
         properties: {
@@ -67,7 +67,7 @@ export default pattern((__cf_pattern_input) => {
         path.push(name);
     })({
         path: path
-    });
+    }).for("pushPath", true);
     return {
         [UI]: (<div>
         {(() => {
@@ -101,7 +101,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []);
+                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []).for("p", true);
                 if (p.length === 0)
                     return null;
                 return <div>{__cfHelpers.derive({
@@ -150,7 +150,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []);
+                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []).for("p", true);
                 const visible = __cfHelpers.derive({
                     type: "object",
                     properties: {
@@ -199,7 +199,7 @@ export default pattern((__cf_pattern_input) => {
                 } as const satisfies __cfHelpers.JSONSchema, {
                     entries: entries,
                     p: p
-                }, ({ entries, p }) => visibleEntries(entries, p[0] || ""));
+                }, ({ entries, p }) => visibleEntries(entries, p[0] || "")).for("visible", true);
                 return visible.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                     const entry = __cf_pattern_input.key("element");
                     const pushPath = __cf_pattern_input.key("params", "pushPath");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -119,7 +119,7 @@ export default pattern((__cf_pattern_input) => {
     return {
         [UI]: (<div>
         {(() => {
-                const tree = ((__cfHelpers.unless({
+                const tree = (__cfHelpers.unless({
                     $ref: "#/$defs/AnonymousType_1",
                     $defs: {
                         AnonymousType_1: {
@@ -184,8 +184,8 @@ export default pattern((__cf_pattern_input) => {
                             required: ["id", "name", "type"]
                         }
                     }
-                } as const satisfies __cfHelpers.JSONSchema, entries, [])) as Entry[]).for("tree", true);
-                const p = ((__cfHelpers.unless({
+                } as const satisfies __cfHelpers.JSONSchema, entries, []).for("tree", true)).for("tree", true) as Entry[];
+                const p = (__cfHelpers.unless({
                     type: "array",
                     items: {
                         type: "string"
@@ -215,7 +215,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), [])) as string[]).for("p", true);
+                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []).for("p", true)).for("p", true) as string[];
                 const unsorted = findChildren(tree, p) as Entry[];
                 const items = __cfHelpers.derive({
                     type: "object",
@@ -477,7 +477,7 @@ export default pattern((__cf_pattern_input) => {
                     handleOpenFile: handleOpenFile
                 });
             })()}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -184,7 +184,7 @@ export default pattern((__cf_pattern_input) => {
                             required: ["id", "name", "type"]
                         }
                     }
-                } as const satisfies __cfHelpers.JSONSchema, entries, []).for("tree", true)).for("tree", true) as Entry[];
+                } as const satisfies __cfHelpers.JSONSchema, entries, [])).for("tree", true) as Entry[];
                 const p = (__cfHelpers.unless({
                     type: "array",
                     items: {
@@ -215,7 +215,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []).for("p", true)).for("p", true) as string[];
+                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), [])).for("p", true) as string[];
                 const unsorted = findChildren(tree, p) as Entry[];
                 const items = __cfHelpers.derive({
                     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -50,7 +50,7 @@ export default pattern((__cf_pattern_input) => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("path", true);
     const handleNavigateInto = __cfHelpers.handler({
         type: "object",
         properties: {
@@ -75,7 +75,7 @@ export default pattern((__cf_pattern_input) => {
         path.push(name);
     })({
         path: path
-    });
+    }).for("handleNavigateInto", true);
     const handleOpenFile = __cfHelpers.handler({
         type: "object",
         properties: {
@@ -115,11 +115,11 @@ export default pattern((__cf_pattern_input) => {
         properties: {}
     } as const satisfies __cfHelpers.JSONSchema, ({ item }, __cf_action_params) => {
         void item;
-    })({});
+    })({}).for("handleOpenFile", true);
     return {
         [UI]: (<div>
         {(() => {
-                const tree = (__cfHelpers.unless({
+                const tree = ((__cfHelpers.unless({
                     $ref: "#/$defs/AnonymousType_1",
                     $defs: {
                         AnonymousType_1: {
@@ -184,8 +184,8 @@ export default pattern((__cf_pattern_input) => {
                             required: ["id", "name", "type"]
                         }
                     }
-                } as const satisfies __cfHelpers.JSONSchema, entries, [])) as Entry[];
-                const p = (__cfHelpers.unless({
+                } as const satisfies __cfHelpers.JSONSchema, entries, [])) as Entry[]).for("tree", true);
+                const p = ((__cfHelpers.unless({
                     type: "array",
                     items: {
                         type: "string"
@@ -215,7 +215,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), [])) as string[];
+                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), [])) as string[]).for("p", true);
                 const unsorted = findChildren(tree, p) as Entry[];
                 const items = __cfHelpers.derive({
                     type: "object",
@@ -289,7 +289,7 @@ export default pattern((__cf_pattern_input) => {
                     if (a.type === b.type)
                         return 0;
                     return a.type === "file" ? -1 : 1;
-                }));
+                })).for("items", true);
                 return items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                     const item = __cf_pattern_input.key("element");
                     const handleNavigateInto = __cf_pattern_input.key("params", "handleNavigateInto");
@@ -302,7 +302,7 @@ export default pattern((__cf_pattern_input) => {
                     } as const satisfies __cfHelpers.JSONSchema, {
                         type: "boolean"
                     } as const satisfies __cfHelpers.JSONSchema, !isFolder &&
-                        !!item.key("contentType"), item.key("contentType") !== "binary");
+                        !!item.key("contentType"), item.key("contentType") !== "binary").for("isOpenable", true);
                     return (<button type="button" onClick={isFolder
                             ? __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
                                 type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
@@ -37,10 +37,10 @@ export default pattern((__cf_pattern_input) => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("path", true);
     const labelPrefix = Writable.of("a", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("labelPrefix", true);
     return {
         [UI]: (<div>
         {(() => {
@@ -74,7 +74,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []);
+                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []).for("p", true);
                 const visible = __cfHelpers.derive({
                     type: "object",
                     properties: {
@@ -123,7 +123,7 @@ export default pattern((__cf_pattern_input) => {
                 } as const satisfies __cfHelpers.JSONSchema, {
                     entries: entries,
                     p: p
-                }, ({ entries, p }) => visibleEntries(entries, p[0] || ""));
+                }, ({ entries, p }) => visibleEntries(entries, p[0] || "")).for("visible", true);
                 const filtered = visible.filterWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                     const entry = __cf_pattern_input.key("element");
                     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
@@ -74,7 +74,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []).for("p", true);
+                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()).for(["p", 3], true), []).for("p", true);
                 const visible = __cfHelpers.derive({
                     type: "object",
                     properties: {
@@ -217,7 +217,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 } as const satisfies __cfHelpers.JSONSchema), {});
             })()}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
@@ -172,7 +172,7 @@ export default pattern((__cf_pattern_input) => {
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema), {
                     labelPrefix: labelPrefix
-                });
+                }).for("filtered", true);
                 return filtered.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                     const entry = __cf_pattern_input.key("element");
                     return <button type="button">{entry.key("name")}</button>;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
@@ -178,7 +178,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 } as const satisfies __cfHelpers.JSONSchema), {
                     labelPrefix: labelPrefix
-                });
+                }).for("labels", true);
                 return labels.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                     const label = __cf_pattern_input.key("element");
                     return <button type="button">{label}</button>;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
@@ -113,7 +113,7 @@ export default pattern((__cf_pattern_input) => {
                 } as const satisfies __cfHelpers.JSONSchema, {
                     entries: entries,
                     prefix: prefix
-                }, ({ entries, prefix }) => visibleEntries(entries, prefix)), []).for("visible", true);
+                }, ({ entries, prefix }) => visibleEntries(entries, prefix)).for(["visible", 3], true), []).for("visible", true);
                 const labels = visible.flatMapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                     const entry = __cf_pattern_input.key("element");
                     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
@@ -212,7 +212,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 } as const satisfies __cfHelpers.JSONSchema), {});
             })()}
-    </div>),
+    </div>)
     });
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
@@ -113,7 +113,7 @@ export default pattern((__cf_pattern_input) => {
                 } as const satisfies __cfHelpers.JSONSchema, {
                     entries: entries,
                     prefix: prefix
-                }, ({ entries, prefix }) => visibleEntries(entries, prefix)), []);
+                }, ({ entries, prefix }) => visibleEntries(entries, prefix)), []).for("visible", true);
                 const labels = visible.flatMapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                     const entry = __cf_pattern_input.key("element");
                     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
@@ -78,7 +78,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []).for("p", true);
+                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()).for(["p", 3], true), []).for("p", true);
                 const visible = __cfHelpers.derive({
                     type: "object",
                     properties: {
@@ -187,7 +187,7 @@ export default pattern((__cf_pattern_input) => {
                     labelPrefix: labelPrefix
                 });
             })()}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
@@ -41,10 +41,10 @@ export default pattern((__cf_pattern_input) => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("path", true);
     const labelPrefix = Writable.of("prefix:", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("labelPrefix", true);
     return {
         [UI]: (<div>
         {(() => {
@@ -78,7 +78,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []);
+                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []).for("p", true);
                 const visible = __cfHelpers.derive({
                     type: "object",
                     properties: {
@@ -127,7 +127,7 @@ export default pattern((__cf_pattern_input) => {
                 } as const satisfies __cfHelpers.JSONSchema, {
                     entries: entries,
                     p: p
-                }, ({ entries, p }) => visibleEntries(entries, p[0] || ""));
+                }, ({ entries, p }) => visibleEntries(entries, p[0] || "")).for("visible", true);
                 return visible.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                     const entry = __cf_pattern_input.key("element");
                     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
@@ -113,7 +113,7 @@ export default pattern((__cf_pattern_input) => {
                 } as const satisfies __cfHelpers.JSONSchema, {
                     entries: entries,
                     prefix: prefix
-                }, ({ entries, prefix }) => visibleEntries(entries, prefix)), []);
+                }, ({ entries, prefix }) => visibleEntries(entries, prefix)), []).for("visible", true);
                 return visible.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                     const entry = __cf_pattern_input.key("element");
                     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
@@ -113,7 +113,7 @@ export default pattern((__cf_pattern_input) => {
                 } as const satisfies __cfHelpers.JSONSchema, {
                     entries: entries,
                     prefix: prefix
-                }, ({ entries, prefix }) => visibleEntries(entries, prefix)), []).for("visible", true);
+                }, ({ entries, prefix }) => visibleEntries(entries, prefix)).for(["visible", 3], true), []).for("visible", true);
                 return visible.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                     const entry = __cf_pattern_input.key("element");
                     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
@@ -172,7 +172,7 @@ export default pattern((__cf_pattern_input) => {
                     labelPrefix: labelPrefix
                 });
             })()}
-    </div>),
+    </div>)
     });
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -50,7 +50,7 @@ export default pattern((__cf_pattern_input) => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("path", true);
     const pushPath = __cfHelpers.handler({
         type: "object",
         properties: {
@@ -75,7 +75,7 @@ export default pattern((__cf_pattern_input) => {
         path.push(name);
     })({
         path: path
-    });
+    }).for("pushPath", true);
     return {
         [UI]: (<div>
         {(() => {
@@ -110,7 +110,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []);
+                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []).for("p", true);
                 const unsorted = __cfHelpers.derive({
                     type: "object",
                     properties: {
@@ -186,7 +186,7 @@ export default pattern((__cf_pattern_input) => {
                 } as const satisfies __cfHelpers.JSONSchema, {
                     tree: tree,
                     p: p
-                }, ({ tree, p }) => findChildren(tree, p));
+                }, ({ tree, p }) => findChildren(tree, p)).for("unsorted", true);
                 const items = __cfHelpers.derive({
                     type: "object",
                     properties: {
@@ -252,7 +252,7 @@ export default pattern((__cf_pattern_input) => {
                             required: ["id", "name", "type"]
                         }
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { unsorted: unsorted }, ({ unsorted }) => [...unsorted].sort((a: Entry, b: Entry) => a.name.localeCompare(b.name)));
+                } as const satisfies __cfHelpers.JSONSchema, { unsorted: unsorted }, ({ unsorted }) => [...unsorted].sort((a: Entry, b: Entry) => a.name.localeCompare(b.name))).for("items", true);
                 return items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                     const item = __cf_pattern_input.key("element");
                     const pushPath = __cf_pattern_input.key("params", "pushPath");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -110,7 +110,7 @@ export default pattern((__cf_pattern_input) => {
                     items: {
                         type: "string"
                     }
-                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()), []).for("p", true);
+                } as const satisfies __cfHelpers.JSONSchema, { path: path }, ({ path }) => path.get()).for(["p", 3], true), []).for("p", true);
                 const unsorted = __cfHelpers.derive({
                     type: "object",
                     properties: {
@@ -362,7 +362,7 @@ export default pattern((__cf_pattern_input) => {
                     pushPath: pushPath
                 });
             })()}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
@@ -65,7 +65,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         pending: pending,
         result: result
-    }, ({ pending, result }) => pending || !result), undefined, { result });
+    }, ({ pending, result }) => pending || !result), undefined, { result }).for("output1", true);
     // Pattern 2: undefined as ifFalse (error state returns nothing)
     const output2 = ifElse({
         type: "boolean"
@@ -101,7 +101,7 @@ export default pattern(() => {
         required: ["result"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema, { result: result }, ({ result }) => !!result), { data: result }, undefined);
+    } as const satisfies __cfHelpers.JSONSchema, { result: result }, ({ result }) => !!result), { data: result }, undefined).for("output2", true);
     return {
         [UI]: (<div>
         <span>{output1}</span>

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
@@ -65,7 +65,7 @@ export default pattern(() => {
     } as const satisfies __cfHelpers.JSONSchema, {
         pending: pending,
         result: result
-    }, ({ pending, result }) => pending || !result), undefined, { result }).for("output1", true);
+    }, ({ pending, result }) => pending || !result).for(["output1", 4], true), undefined, { result }).for("output1", true);
     // Pattern 2: undefined as ifFalse (error state returns nothing)
     const output2 = ifElse({
         type: "boolean"
@@ -101,7 +101,7 @@ export default pattern(() => {
         required: ["result"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema, { result: result }, ({ result }) => !!result), { data: result }, undefined).for("output2", true);
+    } as const satisfies __cfHelpers.JSONSchema, { result: result }, ({ result }) => !!result).for(["output2", 4], true), { data: result }, undefined).for("output2", true);
     return {
         [UI]: (<div>
         <span>{output1}</span>

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
@@ -101,7 +101,7 @@ export default pattern(() => {
         required: ["result"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema, { result: result }, ({ result }) => !!result).for(["output2", 4], true), { data: result }, undefined).for("output2", true);
+    } as const satisfies __cfHelpers.JSONSchema, { result: result }, ({ result }) => !!result).for(["output2", 4], true), { data: result.for(["output2", 5, "data"], true) }, undefined).for("output2", true);
     return {
         [UI]: (<div>
         <span>{output1}</span>

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
@@ -298,7 +298,7 @@ export default pattern((state) => {
                             fontSize: state.key("config", "theme", "fontSize")
                         }
                     }
-                } }, ({ state }) => state.config.theme.fontSize + "px"),
+                } }, ({ state }) => state.config.theme.fontSize + "px").for("fontSize", true),
         }}>
           Styled text
         </p>
@@ -311,7 +311,7 @@ export default pattern((state) => {
                 type: "string"
             } as const satisfies __cfHelpers.JSONSchema, {
                 "enum": ["#333", "#fff"]
-            } as const satisfies __cfHelpers.JSONSchema, state.key("config", "features", "darkMode"), "#333", "#fff"),
+            } as const satisfies __cfHelpers.JSONSchema, state.key("config", "features", "darkMode"), "#333", "#fff").for("backgroundColor", true),
             borderColor: state.key("config", "theme", "secondaryColor"),
         }}>
           Theme-aware box

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
@@ -410,7 +410,7 @@ export default pattern((state) => {
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, state.key("config", "features", "beta"), state.key("config", "features", "darkMode")), "Yes", "No")}
         </p>
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
@@ -298,7 +298,7 @@ export default pattern((state) => {
                             fontSize: state.key("config", "theme", "fontSize")
                         }
                     }
-                } }, ({ state }) => state.config.theme.fontSize + "px").for("fontSize", true),
+                } }, ({ state }) => state.config.theme.fontSize + "px"),
         }}>
           Styled text
         </p>
@@ -311,7 +311,7 @@ export default pattern((state) => {
                 type: "string"
             } as const satisfies __cfHelpers.JSONSchema, {
                 "enum": ["#333", "#fff"]
-            } as const satisfies __cfHelpers.JSONSchema, state.key("config", "features", "darkMode"), "#333", "#fff").for("backgroundColor", true),
+            } as const satisfies __cfHelpers.JSONSchema, state.key("config", "features", "darkMode"), "#333", "#fff"),
             borderColor: state.key("config", "theme", "secondaryColor"),
         }}>
           Theme-aware box
@@ -410,7 +410,7 @@ export default pattern((state) => {
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, state.key("config", "features", "beta"), state.key("config", "features", "darkMode")), "Yes", "No")}
         </p>
-      </div>)
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-non-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-non-jsx.expected.jsx
@@ -31,7 +31,7 @@ export default pattern((_state) => {
             }
         },
         required: ["name", "age"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("user", true);
     return {
         [UI]: (<div>
         {/* Non-JSX right side: string template with complex expression */}

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-simple-ref.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-simple-ref.expected.jsx
@@ -18,10 +18,10 @@ const __cfAmdHooks = undefined;
 export default pattern((_state) => {
     const showPanel = cell(true, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("showPanel", true);
     const userName = cell("Alice", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("userName", true);
     return {
         [UI]: (<div>
         {/* Simple opaque ref with JSX on right - SHOULD use when for short-circuit optimization */}

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-complex-expressions.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-complex-expressions.expected.jsx
@@ -21,13 +21,13 @@ export default pattern((_state) => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     const isEnabled = cell(false, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("isEnabled", true);
     const count = cell(0, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("count", true);
     return {
         [UI]: (<div>
         {/* Nested && - both conditions reference opaque refs */}

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-mixed-and-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-mixed-and-or.expected.jsx
@@ -33,10 +33,10 @@ export default pattern((_state) => {
             }
         },
         required: ["name", "age"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("user", true);
     const defaultMessage = cell("Guest", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("defaultMessage", true);
     return {
         [UI]: (<div>
         {/* (condition && value) || fallback pattern */}

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-nullish-coalescing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-nullish-coalescing.expected.jsx
@@ -40,13 +40,13 @@ export default pattern((_state) => {
             }
         },
         required: ["timeout", "retries"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("config", true);
     const items = cell<string[]>([], {
         type: "array",
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     return {
         [UI]: (<div>
         {/* ?? followed by || - different semantics */}

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-or-unless.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-or-unless.expected.jsx
@@ -20,7 +20,7 @@ export default pattern((_state) => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     return {
         [UI]: (<div>
         {/* Pattern: falsy check || fallback */}

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-and-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-and-chain.expected.jsx
@@ -35,7 +35,7 @@ export default pattern((_state) => {
             }
         },
         required: ["active", "verified", "name"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("user", true);
     return {
         [UI]: (<div>
         {/* Triple && chain with complex conditions */}

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-or-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-or-chain.expected.jsx
@@ -19,16 +19,16 @@ const __cfAmdHooks = undefined;
 export default pattern((_state) => {
     const primary = cell("", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("primary", true);
     const secondary = cell("", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("secondary", true);
     const items = cell<string[]>([], {
         type: "array",
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     return {
         [UI]: (<div>
         {/* Triple || chain - first truthy wins */}

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
@@ -20,7 +20,7 @@ export default pattern((_state) => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("list", true);
     return {
         [UI]: (<div>
         {__cfHelpers.when({

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
@@ -98,7 +98,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
@@ -45,7 +45,7 @@ export default pattern((__cf_pattern_input) => {
                     required: ["kind"]
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, { kind: kind }, ({ kind }) => kind === "folder");
+                } as const satisfies __cfHelpers.JSONSchema, { kind: kind }, ({ kind }) => kind === "folder").for("isFolder", true);
                 return <span>{__cfHelpers.ifElse({
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
@@ -48,7 +48,7 @@ export default pattern((__cf_pattern_input) => {
                     required: ["kind"]
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, { kind: kind }, ({ kind }) => kind === "folder");
+                } as const satisfies __cfHelpers.JSONSchema, { kind: kind }, ({ kind }) => kind === "folder").for("isFolder", true);
                 return <span>{__cfHelpers.ifElse({
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
@@ -104,7 +104,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
@@ -91,7 +91,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
@@ -46,7 +46,7 @@ export default pattern((__cf_pattern_input) => {
                     required: ["kind"]
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, { kind: kind }, ({ kind }) => describeKind(kind));
+                } as const satisfies __cfHelpers.JSONSchema, { kind: kind }, ({ kind }) => describeKind(kind)).for("label", true);
                 return <span>{label}</span>;
             }, {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
@@ -78,7 +78,7 @@ export default pattern((__cf_pattern_input) => {
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, { file: {
                         contentType: file.key("contentType")
-                    } }, ({ file }) => file.contentType !== "binary")).for("isOpenable", true);
+                    } }, ({ file }) => file.contentType !== "binary").for(["isOpenable", 4], true)).for("isOpenable", true);
                 return <span>{__cfHelpers.ifElse({
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, {
@@ -134,7 +134,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
@@ -53,7 +53,7 @@ export default pattern((__cf_pattern_input) => {
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, { file: {
                         type: file.key("type")
-                    } }, ({ file }) => file.type === "folder");
+                    } }, ({ file }) => file.type === "folder").for("isFolder", true);
                 const isOpenable = __cfHelpers.unless({
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, {
@@ -78,7 +78,7 @@ export default pattern((__cf_pattern_input) => {
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, { file: {
                         contentType: file.key("contentType")
-                    } }, ({ file }) => file.contentType !== "binary"));
+                    } }, ({ file }) => file.contentType !== "binary")).for("isOpenable", true);
                 return <span>{__cfHelpers.ifElse({
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
@@ -53,7 +53,7 @@ export default pattern((__cf_pattern_input) => {
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, { meta: {
                         kind: meta.kind
-                    } }, ({ meta }) => meta.kind === "folder");
+                    } }, ({ meta }) => meta.kind === "folder").for("isFolder", true);
                 return <span>{__cfHelpers.ifElse({
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
@@ -106,7 +106,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
@@ -98,7 +98,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
@@ -45,7 +45,7 @@ export default pattern((__cf_pattern_input) => {
                     required: ["kind"]
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, { kind: kind }, ({ kind }) => kind === "folder");
+                } as const satisfies __cfHelpers.JSONSchema, { kind: kind }, ({ kind }) => kind === "folder").for("isFolder", true);
                 return <span>{__cfHelpers.ifElse({
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
@@ -101,7 +101,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 }
             } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
@@ -48,7 +48,7 @@ export default pattern((__cf_pattern_input) => {
                     required: ["info"]
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, { info: info }, ({ info }) => info[0] === "folder");
+                } as const satisfies __cfHelpers.JSONSchema, { info: info }, ({ info }) => info[0] === "folder").for("isFolder", true);
                 return <span>{__cfHelpers.ifElse({
                     type: "boolean"
                 } as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional-no-name.expected.jsx
@@ -27,10 +27,10 @@ export default pattern((_state: any) => {
             },
             required: ["name"]
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     const showList = cell(true, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("showList", true);
     return {
         [UI]: (<div>
         {__cfHelpers.when({

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional.expected.jsx
@@ -27,10 +27,10 @@ export default pattern((_state) => {
             },
             required: ["name"]
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     const showList = cell(true, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("showList", true);
     return {
         [UI]: (<div>
         {__cfHelpers.when({

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
@@ -33,7 +33,7 @@ export default pattern((_state: any) => {
             },
             required: ["id", "name"]
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("people", true);
     return {
         [UI]: (<div>
         {__cfHelpers.when({

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
@@ -33,7 +33,7 @@ export default pattern((_state) => {
             },
             required: ["id", "name"]
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("people", true);
     return {
         [UI]: (<div>
         {__cfHelpers.when({

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
@@ -188,7 +188,7 @@ export default pattern((state) => {
                 state: {
                     threshold: state.key("threshold")
                 }
-            }, ({ x, state }) => x > state.threshold);
+            }, ({ x, state }) => x > state.threshold).for("__patternResult", true);
         }, {
             type: "object",
             properties: {
@@ -915,7 +915,7 @@ export default pattern((state) => {
                 words: state.key("words"),
                 separator: state.key("separator")
             } }, ({ state }) => state.words.join(state.separator).toUpperCase())}</p>
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
@@ -151,8 +151,8 @@ export default pattern(() => {
     const { cellRef } = createCellRef({
         isInitialized: cell(false, {
             type: "boolean"
-        } as const satisfies __cfHelpers.JSONSchema),
-        storedCellRef: cell(),
+        } as const satisfies __cfHelpers.JSONSchema).for("isInitialized", true),
+        storedCellRef: cell().for("storedCellRef", true),
     }) as {
         cellRef: any[];
     };

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
@@ -119,9 +119,9 @@ const createSimplePattern = handler({
     // Create isInitialized cell for this charm addition
     const isInitialized = cell(false, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("isInitialized", true);
     // Create the charm
-    const charm = SimplePattern({});
+    const charm = SimplePattern({}).for("charm", true);
     // Store the charm in the array and navigate
     return addCharmAndNavigate({ charm, cellRef, isInitialized });
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
@@ -121,7 +121,7 @@ const createSimplePattern = handler({
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("isInitialized", true);
     // Create the charm
-    const charm = SimplePattern({}).for("charm", true);
+    const charm = SimplePattern({});
     // Store the charm in the array and navigate
     return addCharmAndNavigate({ charm, cellRef, isInitialized });
 });
@@ -151,8 +151,8 @@ export default pattern(() => {
     const { cellRef } = createCellRef({
         isInitialized: cell(false, {
             type: "boolean"
-        } as const satisfies __cfHelpers.JSONSchema).for("isInitialized", true),
-        storedCellRef: cell().for("storedCellRef", true),
+        } as const satisfies __cfHelpers.JSONSchema),
+        storedCellRef: cell(),
     }) as {
         cellRef: any[];
     };

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-operations.expected.jsx
@@ -19,10 +19,10 @@ const __cfAmdHooks = undefined;
 export default pattern((_state) => {
     const count = cell(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("count", true);
     const price = cell(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("price", true);
     return {
         [UI]: (<div>
         <p>Count: {count}</p>

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.jsx
@@ -25,7 +25,7 @@ export default pattern(() => {
                     type: "string"
                 }
             }]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("list", true);
     return {
         [NAME]: "Optional element access",
         [UI]: (<div>

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
@@ -38,7 +38,7 @@ type State = {
 export default pattern((state) => {
     const showList = Writable.of(true, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("showList", true);
     const sorted = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -91,7 +91,7 @@ export default pattern((state) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             items: state.key("items")
-        } }, ({ state }) => [...state.items].sort((a, b) => a.value - b.value));
+        } }, ({ state }) => [...state.items].sort((a, b) => a.value - b.value)).for("sorted", true);
     const count = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -118,7 +118,7 @@ export default pattern((state) => {
             items: {
                 length: state.key("items", "length")
             }
-        } }, ({ state }) => state.items.length);
+        } }, ({ state }) => state.items.length).for("count", true);
     return {
         [UI]: (<div>
         <p>{__cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
@@ -25,7 +25,7 @@ interface Item {
 export default pattern((state) => {
     const showList = Writable.of(true, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("showList", true);
     const sorted = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -78,7 +78,7 @@ export default pattern((state) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             items: state.key("items")
-        } }, ({ state }) => [...state.items].sort((a, b) => a.value - b.value));
+        } }, ({ state }) => [...state.items].sort((a, b) => a.value - b.value)).for("sorted", true);
     const count = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -105,7 +105,7 @@ export default pattern((state) => {
             items: {
                 length: state.key("items", "length")
             }
-        } }, ({ state }) => state.items.length);
+        } }, ({ state }) => state.items.length).for("count", true);
     return {
         [UI]: (<div>
         {__cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
@@ -355,7 +355,7 @@ export default pattern((__cf_pattern_input) => {
                         type: "string"
                     } as const satisfies __cfHelpers.JSONSchema, {
                         "enum": ["a", "b"]
-                    } as const satisfies __cfHelpers.JSONSchema, isPinned, "a", "b") }}>
+                    } as const satisfies __cfHelpers.JSONSchema, isPinned, "a", "b").for("background", true) }}>
                 expand
               </button>
               {__cfHelpers.when({

--- a/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
@@ -355,7 +355,7 @@ export default pattern((__cf_pattern_input) => {
                         type: "string"
                     } as const satisfies __cfHelpers.JSONSchema, {
                         "enum": ["a", "b"]
-                    } as const satisfies __cfHelpers.JSONSchema, isPinned, "a", "b").for("background", true) }}>
+                    } as const satisfies __cfHelpers.JSONSchema, isPinned, "a", "b") }}>
                 expand
               </button>
               {__cfHelpers.when({
@@ -391,7 +391,7 @@ export default pattern((__cf_pattern_input) => {
                     })}>
                   trash
                 </button>)}
-            </div>, null);
+            </div>, null).for("__patternResult", true);
             }, {
                 type: "object",
                 properties: {
@@ -499,7 +499,7 @@ export default pattern((__cf_pattern_input) => {
                 expandedIndex: expandedIndex,
                 trashedSubPieces: trashedSubPieces
             })}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
@@ -112,16 +112,16 @@ export default pattern((__cf_pattern_input) => {
     const trashedSubPieces = __cf_pattern_input.key("trashedSubPieces");
     const editingNoteIndex = Writable.of<number | undefined>(undefined, {
         type: ["number", "undefined"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("editingNoteIndex", true);
     const editingNoteText = Writable.of("", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("editingNoteText", true);
     const expandedIndex = Writable.of<number | undefined>(undefined, {
         type: ["number", "undefined"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("expandedIndex", true);
     const settingsModuleIndex = Writable.of<number | undefined>(undefined, {
         type: ["number", "undefined"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("settingsModuleIndex", true);
     const allEntries = __cfHelpers.derive({
         type: "object",
         properties: {
@@ -202,7 +202,7 @@ export default pattern((__cf_pattern_input) => {
         isExpanded: index === 0,
         isPinned: entry.pinned || false,
         allowMultiple: entry.allowMultiple,
-    })));
+    }))).for("allEntries", true);
     return {
         [UI]: (<div>
         {allEntries.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {

--- a/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
@@ -41,7 +41,7 @@ export default pattern((state) => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("fallbackMembers", true);
     // [TRANSFORM] computed() → derive(): captures state.showArchived, state.projects
     const visibleProjects = __cfHelpers.derive({
         type: "object",
@@ -120,7 +120,7 @@ export default pattern((state) => {
             projects: state.key("projects")
         } }, ({ state }) => state.showArchived
         ? state.projects
-        : state.projects.filter((project) => !project.archived));
+        : state.projects.filter((project) => !project.archived)).for("visibleProjects", true);
     // [TRANSFORM] computed() → derive(): captures visibleProjects (asOpaque), state.prefix, fallbackMembers (asCell — Writable)
     const rows = __cfHelpers.derive({
         type: "object",
@@ -341,7 +341,7 @@ export default pattern((state) => {
                     : member}
             </span>))}
         </div>);
-    }));
+    })).for("rows", true);
     return {
         [UI]: <div>{rows}</div>,
     };

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
@@ -83,8 +83,8 @@ export default pattern((state) => {
     // [TRANSFORM] Writable.of: schema arg injected; undefined default added for optional type
     const selectedCommentId = Writable.of<string | undefined>(undefined, {
         type: ["string", "undefined"]
-    } as const satisfies __cfHelpers.JSONSchema);
-    const laneLabels = passthroughLabels(["lane", "detail", "summary"]);
+    } as const satisfies __cfHelpers.JSONSchema).for("selectedCommentId", true);
+    const laneLabels = passthroughLabels(["lane", "detail", "summary"]).for("laneLabels", true);
     // [TRANSFORM] computed() → derive(): captures state.threads, state.showFlagged
     const visibleThreads = __cfHelpers.derive({
         type: "object",
@@ -225,7 +225,7 @@ export default pattern((state) => {
         visibleComments: state.showFlagged
             ? thread.comments.filter((comment) => comment.flagged)
             : thread.comments,
-    })));
+    }))).for("visibleThreads", true);
     // [TRANSFORM] computed() → derive(): captures visibleThreads (asOpaque), selectedCommentId (asCell — Writable), state.lane
     const threadRows = __cfHelpers.derive({
         type: "object",
@@ -333,7 +333,7 @@ export default pattern((state) => {
     visibleThreads.map(({ thread, outerIndex, visibleComments }) => {
         // [TRANSFORM] .map() stays plain: ["top","bottom"] is a literal array
         const plainSeparators = ["top", "bottom"].map((edge) => `${thread.title}-${edge}`);
-        const liftedSeparators = passthroughLabels(plainSeparators);
+        const liftedSeparators = passthroughLabels(plainSeparators).for("liftedSeparators", true);
         // [TRANSFORM] computed() → derive() (nested): captures visibleComments from outer derive scope
         const reboundComments = __cfHelpers.derive({
             type: "object",
@@ -397,7 +397,7 @@ export default pattern((state) => {
                     required: ["id", "text", "flagged", "reactions"]
                 }
             }
-        } as const satisfies __cfHelpers.JSONSchema, { visibleComments: visibleComments }, ({ visibleComments }) => visibleComments);
+        } as const satisfies __cfHelpers.JSONSchema, { visibleComments: visibleComments }, ({ visibleComments }) => visibleComments).for("reboundComments", true);
         return (<article>
           <h2>{thread.title}</h2>
           {/* [TRANSFORM] .map() stays plain: visibleComments is destructured from captured derive input */}
@@ -679,7 +679,7 @@ export default pattern((state) => {
           {/* [TRANSFORM] .map() stays plain: plainSeparators is a local literal array */}
           {plainSeparators.map((edge) => <small>{edge}</small>)}
         </article>);
-    }));
+    })).for("threadRows", true);
     return {
         [UI]: (<div>
         {/* [TRANSFORM] .map() → mapWithPattern: laneLabels is output of lift() in pattern context — reactive */}

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
@@ -223,7 +223,8 @@ export default pattern((state) => {
         thread,
         outerIndex,
         visibleComments: state.showFlagged
-            ? thread.comments.filter((comment) => comment.flagged).for("visibleComments", true) : thread.comments,
+            ? thread.comments.filter((comment) => comment.flagged)
+            : thread.comments,
     }))).for("visibleThreads", true);
     // [TRANSFORM] computed() → derive(): captures visibleThreads (asOpaque), selectedCommentId (asCell — Writable), state.lane
     const threadRows = __cfHelpers.derive({

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
@@ -223,8 +223,7 @@ export default pattern((state) => {
         thread,
         outerIndex,
         visibleComments: state.showFlagged
-            ? thread.comments.filter((comment) => comment.flagged)
-            : thread.comments,
+            ? thread.comments.filter((comment) => comment.flagged).for("visibleComments", true) : thread.comments,
     }))).for("visibleThreads", true);
     // [TRANSFORM] computed() → derive(): captures visibleThreads (asOpaque), selectedCommentId (asCell — Writable), state.lane
     const threadRows = __cfHelpers.derive({

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -68,11 +68,11 @@ export default pattern((state) => {
     // [TRANSFORM] Writable.of: schema arg injected; undefined default added for optional type
     const selectedTaskId = Writable.of<string | undefined>(undefined, {
         type: ["string", "undefined"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("selectedTaskId", true);
     // [TRANSFORM] Writable.of: schema arg injected; undefined default added for optional type
     const hoveredSectionId = Writable.of<string | undefined>(undefined, {
         type: ["string", "undefined"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("hoveredSectionId", true);
     // [TRANSFORM] computed() → derive(): captures state.sections (asCell — Writable<Section[]>)
     const hasSections = __cfHelpers.derive({
         type: "object",
@@ -96,7 +96,7 @@ export default pattern((state) => {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema, { state: {
             sections: state.key("sections")
-        } }, ({ state }) => state.sections.get().length > 0);
+        } }, ({ state }) => state.sections.get().length > 0).for("hasSections", true);
     return {
         [UI]: (<div>
         {/* [TRANSFORM] ifElse: schema-injected authored ifElse(hasSections, ..., ...) */}

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -132,7 +132,7 @@ export default pattern((state) => {
                         type: "string"
                     } as const satisfies __cfHelpers.JSONSchema, {
                         type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, section.key("accent"), section.key("accent"), state.key("globalAccent")).for("color", true),
+                    } as const satisfies __cfHelpers.JSONSchema, section.key("accent"), section.key("accent"), state.key("globalAccent")),
                 }}>
                   {section.key("title")}
                 </h2>
@@ -699,7 +699,7 @@ export default pattern((state) => {
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["No completed sections", "No sections"]
         } as const satisfies __cfHelpers.JSONSchema, state.key("showCompleted"), "No completed sections", "No sections")}</p>)}
-      </div>)
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -699,7 +699,7 @@ export default pattern((state) => {
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["No completed sections", "No sections"]
         } as const satisfies __cfHelpers.JSONSchema, state.key("showCompleted"), "No completed sections", "No sections")}</p>)}
-      </div>),
+      </div>)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -132,7 +132,7 @@ export default pattern((state) => {
                         type: "string"
                     } as const satisfies __cfHelpers.JSONSchema, {
                         type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, section.key("accent"), section.key("accent"), state.key("globalAccent")),
+                    } as const satisfies __cfHelpers.JSONSchema, section.key("accent"), section.key("accent"), state.key("globalAccent")).for("color", true),
                 }}>
                   {section.key("title")}
                 </h2>

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -32,7 +32,7 @@ const deriveInput = __cfHelpers.__cf_data({} as Writable<{
     foo: string;
     bar: string;
 }>);
-const deriveObserved = derive({
+const deriveObserved = __cfHelpers.__cf_data(derive({
     type: "object",
     properties: {
         foo: {
@@ -46,8 +46,8 @@ const deriveObserved = derive({
 } as const satisfies __cfHelpers.JSONSchema, deriveInput, (input: Writable<{
     foo: string;
     bar: string;
-}>) => input.key("foo").get());
-const deriveExplicit = derive({
+}>) => input.key("foo").get()).for("deriveObserved", true));
+const deriveExplicit = __cfHelpers.__cf_data(derive({
     type: "object",
     properties: {
         foo: {
@@ -58,7 +58,7 @@ const deriveExplicit = derive({
     asCell: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, deriveInput, (value) => value.key("foo").get());
+} as const satisfies __cfHelpers.JSONSchema, deriveInput, (value) => value.key("foo").get()).for("deriveExplicit", true));
 const handlerObserved = handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -173,7 +173,7 @@ const actionPattern = pattern((input: Writable<{
         required: ["input"]
     } as const satisfies __cfHelpers.JSONSchema, (_, { input }) => input.key("foo").get())({
         input: input
-    });
+    }).for("a", true);
     return a;
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/schema-injection/cell-like-classes.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/cell-like-classes.expected.jsx
@@ -21,19 +21,19 @@ export default function TestCellLikeClasses() {
     // Standalone cell() function
     const _standalone = cell(100, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_standalone", true);
     // ComparableCell.of()
     const _comparable = ComparableCell.of(200, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_comparable", true);
     // ReadonlyCell.of()
     const _readonly = ReadonlyCell.of(300, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_readonly", true);
     // WriteonlyCell.of()
     const _writeonly = WriteonlyCell.of(400, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_writeonly", true);
     return {
         standalone: _standalone,
         comparable: _comparable,

--- a/packages/ts-transformers/test/fixtures/schema-injection/cell-of-no-value.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/cell-of-no-value.expected.jsx
@@ -21,17 +21,17 @@ export default function TestCellOfNoValue() {
     // Cell.of with type argument but no value - should become Cell.of(undefined, schema)
     const _c1 = Cell.of<string>(undefined, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_c1", true);
     const _c2 = Cell.of<number>(undefined, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_c2", true);
     const _c3 = Cell.of<boolean>(undefined, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_c3", true);
     // cell() with type argument but no value - should become cell(undefined, schema)
     const _c4 = cell<string>(undefined, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_c4", true);
     // ComparableCell.of with type argument but no value
     const _c5 = ComparableCell.of<{
         name: string;
@@ -43,14 +43,14 @@ export default function TestCellOfNoValue() {
             }
         },
         required: ["name"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_c5", true);
     // Mixed - some with value, some without
     const _c6 = Cell.of<string>("hello", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema); // has value
+    } as const satisfies __cfHelpers.JSONSchema).for("_c6", true); // has value
     const _c7 = Cell.of<number>(undefined, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema); // no value
+    } as const satisfies __cfHelpers.JSONSchema).for("_c7", true); // no value
     return null;
 }
 __cfHardenFn(TestCellOfNoValue);

--- a/packages/ts-transformers/test/fixtures/schema-injection/cell-static-factories.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/cell-static-factories.expected.jsx
@@ -20,10 +20,10 @@ const __cfAmdHooks = undefined;
 export default function TestCellStaticFactories() {
     const explicitString = Cell.of<string>("hello", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("explicitString", true);
     const inferredNumber = Cell.of(123, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("inferredNumber", true);
     const explicitCause = Cell.for<string>("cause").asSchema({
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema);
@@ -32,10 +32,10 @@ export default function TestCellStaticFactories() {
     } as const satisfies __cfHelpers.JSONSchema);
     const opaque = OpaqueCell.of<boolean>(true, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("opaque", true);
     const stream = Stream.of<number>(1, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("stream", true);
     return {
         explicitString,
         inferredNumber,

--- a/packages/ts-transformers/test/fixtures/schema-injection/collections-array-of-objects.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/collections-array-of-objects.expected.jsx
@@ -37,7 +37,7 @@ export default function TestCollectionsArrayOfObjects() {
             },
             required: ["id", "name", "score"]
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_arrayOfObjects", true);
     return _arrayOfObjects;
 }
 __cfHardenFn(TestCollectionsArrayOfObjects);

--- a/packages/ts-transformers/test/fixtures/schema-injection/collections-empty.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/collections-empty.expected.jsx
@@ -29,8 +29,8 @@ export default pattern(() => {
         properties: {}
     } as const satisfies __cfHelpers.JSONSchema).for("_emptyObject", true);
     return {
-        emptyArray: _emptyArray,
-        emptyObject: _emptyObject,
+        emptyArray: _emptyArray.for(["__patternResult", "emptyArray"], true),
+        emptyObject: _emptyObject.for(["__patternResult", "emptyObject"], true)
     };
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/schema-injection/collections-empty.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/collections-empty.expected.jsx
@@ -22,12 +22,12 @@ export default pattern(() => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_emptyArray", true);
     // Empty object
     const _emptyObject = Writable.of({}, {
         type: "object",
         properties: {}
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_emptyObject", true);
     return {
         emptyArray: _emptyArray,
         emptyObject: _emptyObject,

--- a/packages/ts-transformers/test/fixtures/schema-injection/collections-nested-objects.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/collections-nested-objects.expected.jsx
@@ -58,7 +58,7 @@ export default function TestCollectionsNestedObjects() {
             }
         },
         required: ["user", "timestamp"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_nested", true);
     return _nested;
 }
 __cfHardenFn(TestCollectionsNestedObjects);

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
@@ -53,7 +53,7 @@ const liftSummary = lift({
 export default pattern((__cf_pattern_input) => {
     const primary = __cf_pattern_input.key("primary");
     const secondary = __cf_pattern_input.key("secondary");
-    const summary = liftSummary({ primary, secondary }).for("summary", true);
+    const summary = liftSummary({ primary: primary.for(["summary", "primary"], true), secondary: secondary.for(["summary", "secondary"], true) }).for("summary", true);
     const difference = derive({
         type: "object",
         properties: {

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
@@ -53,7 +53,7 @@ const liftSummary = lift({
 export default pattern((__cf_pattern_input) => {
     const primary = __cf_pattern_input.key("primary");
     const secondary = __cf_pattern_input.key("secondary");
-    const summary = liftSummary({ primary, secondary });
+    const summary = liftSummary({ primary, secondary }).for("summary", true);
     const difference = derive({
         type: "object",
         properties: {
@@ -64,7 +64,7 @@ export default pattern((__cf_pattern_input) => {
         required: ["difference"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema, summary, (snapshot) => snapshot.difference);
+    } as const satisfies __cfHelpers.JSONSchema, summary, (snapshot) => snapshot.difference).for("difference", true);
     return { difference };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
@@ -54,7 +54,7 @@ const liftSummary = lift({
 export default pattern((__cf_pattern_input) => {
     const primary = __cf_pattern_input.key("primary");
     const secondary = __cf_pattern_input.key("secondary");
-    const summary = liftSummary({ primary, secondary });
+    const summary = liftSummary({ primary, secondary }).for("summary", true);
     const difference = derive({
         type: "object",
         properties: {
@@ -65,7 +65,7 @@ export default pattern((__cf_pattern_input) => {
         required: ["difference"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema, summary, (snapshot) => snapshot.difference);
+    } as const satisfies __cfHelpers.JSONSchema, summary, (snapshot) => snapshot.difference).for("difference", true);
     return {
         summary,
         difference,

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
@@ -54,7 +54,7 @@ const liftSummary = lift({
 export default pattern((__cf_pattern_input) => {
     const primary = __cf_pattern_input.key("primary");
     const secondary = __cf_pattern_input.key("secondary");
-    const summary = liftSummary({ primary, secondary }).for("summary", true);
+    const summary = liftSummary({ primary: primary.for(["summary", "primary"], true), secondary: secondary.for(["summary", "secondary"], true) }).for("summary", true);
     const difference = derive({
         type: "object",
         properties: {

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-variations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-variations.expected.jsx
@@ -12,14 +12,14 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 // 1. Top-level
-const _topLevel = cell(10, {
+const _topLevel = __cfHelpers.__cf_data(cell(10, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema).for("_topLevel", true));
 // 2. Inside function
 function regularFunction() {
     const _inFunction = cell(20, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_inFunction", true);
     return _inFunction;
 }
 __cfHardenFn(regularFunction);
@@ -27,7 +27,7 @@ __cfHardenFn(regularFunction);
 const arrowFunction = __cfHardenFn(() => {
     const _inArrow = cell(30, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_inArrow", true);
     return _inArrow;
 });
 // 4. Inside class method
@@ -35,7 +35,7 @@ class TestClass {
     method() {
         const _inMethod = cell(40, {
             type: "number"
-        } as const satisfies __cfHelpers.JSONSchema);
+        } as const satisfies __cfHelpers.JSONSchema).for("_inMethod", true);
         return _inMethod;
     }
 }
@@ -43,7 +43,7 @@ class TestClass {
 const testPattern = pattern(() => {
     const _inPattern = cell(50, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_inPattern", true);
     return _inPattern;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number",
@@ -53,7 +53,7 @@ const testPattern = pattern(() => {
 const testHandler = handler(false as const satisfies __cfHelpers.JSONSchema, false as const satisfies __cfHelpers.JSONSchema, () => {
     const _inHandler = cell(60, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_inHandler", true);
     return _inHandler;
 });
 // FIXTURE: context-variations

--- a/packages/ts-transformers/test/fixtures/schema-injection/double-inject-already-has-schema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/double-inject-already-has-schema.expected.jsx
@@ -19,9 +19,9 @@ const existingSchema = __cfHelpers.__cf_data({ type: "number" } as const);
 // Context: negative test -- transformer must skip calls that already have two arguments
 export default function TestDoubleInjectAlreadyHasSchema() {
     // Should NOT transform - already has 2 arguments
-    const _c1 = cell(10, existingSchema);
-    const _c2 = cell("hello", { type: "string" });
-    const _c3 = cell(true, { type: "boolean" } as const);
+    const _c1 = cell(10, existingSchema).for("_c1", true);
+    const _c2 = cell("hello", { type: "string" }).for("_c2", true);
+    const _c3 = cell(true, { type: "boolean" } as const).for("_c3", true);
     return null;
 }
 __cfHardenFn(TestDoubleInjectAlreadyHasSchema);

--- a/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-array-elements.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-array-elements.expected.jsx
@@ -22,19 +22,19 @@ export default function TestLiteralWidenArrayElements() {
         items: {
             type: "number"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_arr1", true);
     const _arr2 = cell(["a", "b", "c"], {
         type: "array",
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_arr2", true);
     const _arr3 = cell([true, false], {
         type: "array",
         items: {
             type: "boolean"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_arr3", true);
     return null;
 }
 __cfHardenFn(TestLiteralWidenArrayElements);

--- a/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-bigint.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-bigint.expected.jsx
@@ -19,13 +19,13 @@ const __cfAmdHooks = undefined;
 export default function TestLiteralWidenBigInt() {
     const _bi1 = cell(123n, {
         type: "integer"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_bi1", true);
     const _bi2 = cell(0n, {
         type: "integer"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_bi2", true);
     const _bi3 = cell(-456n, {
         type: "integer"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_bi3", true);
     return null;
 }
 __cfHardenFn(TestLiteralWidenBigInt);

--- a/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-boolean.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-boolean.expected.jsx
@@ -18,10 +18,10 @@ const __cfAmdHooks = undefined;
 export default function TestLiteralWidenBoolean() {
     const _b1 = cell(true, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_b1", true);
     const _b2 = cell(false, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_b2", true);
     return null;
 }
 __cfHardenFn(TestLiteralWidenBoolean);

--- a/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-explicit-type-args.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-explicit-type-args.expected.jsx
@@ -19,13 +19,13 @@ const __cfAmdHooks = undefined;
 export default function TestLiteralWidenExplicitTypeArgs() {
     const _c1 = Cell.of<number>(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_c1", true);
     const _c2 = Cell.of<string>("hello", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_c2", true);
     const _c3 = Cell.of<boolean>(true, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_c3", true);
     return null;
 }
 __cfHardenFn(TestLiteralWidenExplicitTypeArgs);

--- a/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-mixed-values.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-mixed-values.expected.jsx
@@ -21,13 +21,13 @@ export default function TestLiteralWidenMixedValues() {
     const variable = 42;
     const _c1 = cell(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_c1", true);
     const _c2 = cell(variable, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_c2", true);
     const _c3 = cell(10 + 20, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_c3", true);
     return null;
 }
 __cfHardenFn(TestLiteralWidenMixedValues);

--- a/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-nested-structure.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-nested-structure.expected.jsx
@@ -47,7 +47,7 @@ export default function TestLiteralWidenNestedStructure() {
             }
         },
         required: ["users", "count"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_nested", true);
     return null;
 }
 __cfHardenFn(TestLiteralWidenNestedStructure);

--- a/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-null-undefined.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-null-undefined.expected.jsx
@@ -18,10 +18,10 @@ const __cfAmdHooks = undefined;
 export default function TestLiteralWidenNullUndefined() {
     const _c1 = cell(null, {
         type: "null"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_c1", true);
     const _c2 = cell(undefined, {
         type: "undefined"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_c2", true);
     return null;
 }
 __cfHardenFn(TestLiteralWidenNullUndefined);

--- a/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-number.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-number.expected.jsx
@@ -21,19 +21,19 @@ const __cfAmdHooks = undefined;
 export default function TestLiteralWidenNumber() {
     const _n1 = cell(10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_n1", true);
     const _n2 = cell(-5, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_n2", true);
     const _n3 = cell(3.14, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_n3", true);
     const _n4 = cell(1e10, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_n4", true);
     const _n5 = cell(0, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_n5", true);
     return null;
 }
 __cfHardenFn(TestLiteralWidenNumber);

--- a/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-object-properties.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-object-properties.expected.jsx
@@ -29,7 +29,7 @@ export default function TestLiteralWidenObjectProperties() {
             }
         },
         required: ["x", "y", "name"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_obj", true);
     return null;
 }
 __cfHardenFn(TestLiteralWidenObjectProperties);

--- a/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-string.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-string.expected.jsx
@@ -19,16 +19,16 @@ const __cfAmdHooks = undefined;
 export default function TestLiteralWidenString() {
     const _s1 = cell("hello", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_s1", true);
     const _s2 = cell("", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_s2", true);
     const _s3 = cell("hello\nworld", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_s3", true);
     const _s4 = cell("with spaces", {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("_s4", true);
     return null;
 }
 __cfHardenFn(TestLiteralWidenString);

--- a/packages/ts-transformers/test/fixtures/schema-injection/wish-and-generate-object-contextual.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/wish-and-generate-object-contextual.expected.jsx
@@ -26,7 +26,7 @@ const existingLabelSchema = __cfHelpers.__cf_data({
 export default function TestWishAndGenerateObjectContextual() {
     const explicitWish = wish<string>({ query: "#greeting" }, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("explicitWish", true);
     const contextualWish: WishState<{
         title: string;
     }> = wish({
@@ -65,7 +65,7 @@ export default function TestWishAndGenerateObjectContextual() {
             }
         },
         required: ["result", "candidates"]
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("contextualWish", true);
     const explicitObject = generateObject<{
         title: string;
     }>({
@@ -80,14 +80,14 @@ export default function TestWishAndGenerateObjectContextual() {
             },
             required: ["title"]
         } as const satisfies __cfHelpers.JSONSchema
-    });
+    }).for("explicitObject", true);
     const preSchemaObject = generateObject<{
         label: string;
     }>({
         model: "gpt-4o-mini",
         prompt: "Return a label",
         schema: existingLabelSchema,
-    });
+    }).for("preSchemaObject", true);
     return {
         explicitWish,
         contextualWish,

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-pattern-input-structure-recovery.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-pattern-input-structure-recovery.expected.jsx
@@ -20,7 +20,7 @@ export default pattern((state) => {
         items: {
             type: "number"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("typedValues", true);
     return { typedValues };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-pattern-input-structure-recovery.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-pattern-input-structure-recovery.expected.jsx
@@ -21,7 +21,7 @@ export default pattern((state) => {
             type: "number"
         }
     } as const satisfies __cfHelpers.JSONSchema).for("typedValues", true);
-    return { typedValues };
+    return { typedValues: typedValues.for(["__patternResult", "typedValues"], true) };
 }, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-value-any-recovery.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-value-any-recovery.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 declare function fetchAny(): any;
 // FIXTURE: cell-value-any-recovery
 // Verifies: direct `any` cell values emit a permissive `true` schema.
-export const value = cell(fetchAny(), true as const satisfies __cfHelpers.JSONSchema);
+export const value = __cfHelpers.__cf_data(cell(fetchAny(), true as const satisfies __cfHelpers.JSONSchema).for("value", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-value-unknown-recovery.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-value-unknown-recovery.expected.jsx
@@ -14,9 +14,9 @@ const __cfAmdHooks = undefined;
 declare function fetchUnknown(): unknown;
 // FIXTURE: cell-value-unknown-recovery
 // Verifies: direct `unknown` cell values emit an explicit `{ type: "unknown" }` schema.
-export const value = cell(fetchUnknown(), {
+export const value = __cfHelpers.__cf_data(cell(fetchUnknown(), {
     type: "unknown"
-} as const satisfies __cfHelpers.JSONSchema);
+} as const satisfies __cfHelpers.JSONSchema).for("value", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
@@ -82,7 +82,7 @@ export default pattern((__cf_pattern_input) => {
     const state = __cf_pattern_input.key("state");
     return {
         state,
-        increment: increment({ state }).for("increment", true),
+        increment: increment({ state }).for(["__patternResult", "increment"], true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
@@ -82,7 +82,7 @@ export default pattern((__cf_pattern_input) => {
     const state = __cf_pattern_input.key("state");
     return {
         state,
-        increment: increment({ state }),
+        increment: increment({ state }).for("increment", true),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/schema-transform/opaque-ref-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/opaque-ref-map.expected.jsx
@@ -50,7 +50,7 @@ export default pattern((__cf_pattern_input) => {
         }
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {});
+    } as const satisfies __cfHelpers.JSONSchema), {}).for("mapped", true);
     // This should also be transformed
     const filtered = items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
         const item = __cf_pattern_input.key("element");
@@ -99,7 +99,7 @@ export default pattern((__cf_pattern_input) => {
             }
         },
         required: ["title", "done", "position"]
-    } as const satisfies __cfHelpers.JSONSchema), {});
+    } as const satisfies __cfHelpers.JSONSchema), {}).for("filtered", true);
     return { mapped, filtered };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.jsx
@@ -47,7 +47,7 @@ export default pattern((input) => {
             }
         },
         required: ["bar", "foo"]
-    } as const satisfies __cfHelpers.JSONSchema, { input: input }, ({ input: input_1 }) => ({ ...input, bar: 123 }));
+    } as const satisfies __cfHelpers.JSONSchema, { input: input }, ({ input: input_1 }) => ({ ...input, bar: 123 })).for("__patternResult", true);
 }, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/schema-transform/reactive-array-element-access-schema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/reactive-array-element-access-schema.expected.jsx
@@ -20,10 +20,10 @@ export default pattern((_state) => {
         items: {
             type: "string"
         }
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     const index = cell(1, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema);
+    } as const satisfies __cfHelpers.JSONSchema).for("index", true);
     return {
         [UI]: <div>{__cfHelpers.derive({
             type: "object",

--- a/packages/ts-transformers/test/fixtures/schema-transform/with-opaque-ref.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/with-opaque-ref.expected.jsx
@@ -37,7 +37,7 @@ export default pattern((cell) => {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
-    } as const satisfies __cfHelpers.JSONSchema, cell.key("value"), (v: number) => v * 2);
+    } as const satisfies __cfHelpers.JSONSchema, cell.key("value"), (v: number) => v * 2).for("doubled", true);
     return {
         [UI]: (<div>
         <p>Value: {cell.key("value")}</p>

--- a/packages/ts-transformers/test/pipeline-regressions.test.ts
+++ b/packages/ts-transformers/test/pipeline-regressions.test.ts
@@ -517,7 +517,7 @@ export default pattern<{ values: string[] }>(({ values }) => {
 
     assertMatch(
       normalized,
-      /const result = derive\([\s\S]*, values, (?:__cfModuleCallback_\d+|\(entries\) => summarize\(entries\.get\(\)\))\);/,
+      /const result = derive\([\s\S]*, values, (?:__cfModuleCallback_\d+|\(entries\) => summarize\(entries\.get\(\)\))\)\.for\("result", true\);/,
     );
   },
 );

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -73,6 +73,70 @@ export default pattern<{ count: number }, { doubled: number }>((state) => ({
     assertNotMatch(main, /state\.key\("count"\)\.for/);
   });
 
+  it("adds stable nested causes to pattern result cells", async () => {
+    const source = `
+import { pattern, Writable } from "commonfabric";
+
+export default pattern<{ count: number }>((state) => ({
+  foo: state.count * 2,
+  nested: {
+    bar: Writable.of("bar"),
+  },
+  tuple: [Writable.of("tuple")],
+}));
+`;
+
+    const output = await transformFiles({
+      "/main.tsx": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.tsx"]!;
+
+    assertStringIncludes(main, '.for(["__patternResult", "foo"], true)');
+    assertStringIncludes(
+      main,
+      '.for(["__patternResult", "nested", "bar"], true)',
+    );
+    assertStringIncludes(
+      main,
+      '.for(["__patternResult", "tuple", 0], true)',
+    );
+    assertNotMatch(main, /state\.key\("count"\)\.for/);
+  });
+
+  it("adds stable nested causes to constructed variable values", async () => {
+    const source = `
+import { computed, Writable } from "commonfabric";
+
+declare function f(input: unknown): unknown;
+
+export function make() {
+  const foo = f({
+    param: Writable.of(1),
+    nested: {
+      result: computed(() => 2),
+    },
+    tuple: [Writable.of("tuple")],
+    already: Writable.of(3).for("manual"),
+  });
+  return foo;
+}
+`;
+
+    const output = await transformFiles({
+      "/main.ts": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.ts"]!;
+
+    assertStringIncludes(main, '.for(["foo", "param"], true)');
+    assertStringIncludes(main, '.for(["foo", "nested", "result"], true)');
+    assertStringIncludes(main, '.for(["foo", "tuple", 0], true)');
+    assert(!main.includes('.for(["foo", "already"], true)'));
+  });
+
   it("transforms by default and supports cf-disable-transform opt-out", async () => {
     const source = `
 import { computed } from "commonfabric";

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -192,6 +192,34 @@ export function make() {
     assert(!main.includes('.for(["foo", 0, "param"], true)'));
   });
 
+  it("does not duplicate stable causes on asserted reactive initializers", async () => {
+    const source = `
+import { Default, pattern } from "commonfabric";
+
+interface Entry {
+  id: string;
+}
+
+export default pattern<{ entries: Default<Entry[], []> }>(({ entries }) => {
+  const tree = (entries || []) as Entry[];
+  return { tree };
+});
+`;
+
+    const output = await transformFiles({
+      "/main.tsx": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.tsx"]!;
+
+    const treeCauseCount = main.match(/\.for\("tree", true\)/g)?.length ?? 0;
+    assert(
+      treeCauseCount === 1,
+      `expected one tree cause, found ${treeCauseCount}`,
+    );
+  });
+
   it("does not add causes to plain array methods in lift callbacks", async () => {
     const source = `
 import { lift } from "commonfabric";

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -6,6 +6,7 @@ import {
   assertStringIncludes,
 } from "@std/assert";
 import { transformFiles } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 
 const fixture = `
 import { toSchema } from "commonfabric";
@@ -22,6 +23,35 @@ export { configSchema };
 `;
 
 describe("CommonFabricTransformerPipeline", () => {
+  it("adds stable variable causes to fresh reactive initializers", async () => {
+    const source = `
+import { cell, computed, Writable } from "commonfabric";
+
+export function make() {
+  const foo = Writable.of(1);
+  const bar = computed(() => foo.get() + 1);
+  const baz = cell(["a"]).map((value) => value.toUpperCase());
+  const already = Writable.of(2).for("manual");
+  return { already, bar, baz, foo };
+}
+`;
+
+    const output = await transformFiles({
+      "/main.ts": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.ts"]!;
+
+    assertStringIncludes(
+      main,
+      'const foo = Writable.of(1, {\n        type: "number"\n    } as const satisfies __cfHelpers.JSONSchema).for("foo", true);',
+    );
+    assertStringIncludes(main, '.for("bar", true);');
+    assertStringIncludes(main, '.for("baz", true);');
+    assert(!main.includes('.for("already", true)'));
+  });
+
   it("transforms by default and supports cf-disable-transform opt-out", async () => {
     const source = `
 import { computed } from "commonfabric";

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -65,7 +65,7 @@ export { value };
     });
     assertStringIncludes(
       enabledByDefault["/main.ts"]!,
-      "const value = __cfHelpers.derive(",
+      "__cfHelpers.derive(",
     );
 
     const disabled = await transformFiles({

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -105,6 +105,37 @@ export default pattern<{ count: number }>((state) => ({
     assertNotMatch(main, /state\.key\("count"\)\.for/);
   });
 
+  it("re-roots reactive identifier members in pattern results", async () => {
+    const source = `
+import { pattern, Writable } from "commonfabric";
+
+export default pattern(() => {
+  const foo = Writable.of(1);
+  return {
+    foo,
+    explicit: foo,
+  };
+});
+`;
+
+    const output = await transformFiles({
+      "/main.tsx": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.tsx"]!;
+
+    assertStringIncludes(main, '.for("foo", true);');
+    assertStringIncludes(
+      main,
+      'foo: foo.for(["__patternResult", "foo"], true)',
+    );
+    assertStringIncludes(
+      main,
+      'explicit: foo.for(["__patternResult", "explicit"], true)',
+    );
+  });
+
   it("adds stable nested causes to constructed variable values", async () => {
     const source = `
 import { computed, Writable } from "commonfabric";
@@ -135,6 +166,30 @@ export function make() {
     assertStringIncludes(main, '.for(["foo", "nested", "result"], true)');
     assertStringIncludes(main, '.for(["foo", "tuple", 0], true)');
     assert(!main.includes('.for(["foo", "already"], true)'));
+  });
+
+  it("does not add positional cause segments for wrapped single object arguments", async () => {
+    const source = `
+import { Writable } from "commonfabric";
+
+declare function f<T>(arg: T): T;
+
+export function make() {
+  const param = Writable.of(1);
+  const foo = f(({ param }) as const);
+  return foo;
+}
+`;
+
+    const output = await transformFiles({
+      "/main.ts": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.ts"]!;
+
+    assertStringIncludes(main, '.for(["foo", "param"], true)');
+    assert(!main.includes('.for(["foo", 0, "param"], true)'));
   });
 
   it("does not add causes to plain array methods in lift callbacks", async () => {

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -52,6 +52,27 @@ export function make() {
     assert(!main.includes('.for("already", true)'));
   });
 
+  it("adds stable property causes to pattern-owned lowered derives", async () => {
+    const source = `
+import { pattern } from "commonfabric";
+
+export default pattern<{ count: number }, { doubled: number }>((state) => ({
+  doubled: state.count * 2,
+}));
+`;
+
+    const output = await transformFiles({
+      "/main.tsx": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.tsx"]!;
+
+    assertStringIncludes(main, "doubled: __cfHelpers.derive(");
+    assertStringIncludes(main, '.for("doubled", true)');
+    assertNotMatch(main, /state\.key\("count"\)\.for/);
+  });
+
   it("transforms by default and supports cf-disable-transform opt-out", async () => {
     const source = `
 import { computed } from "commonfabric";

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -303,6 +303,37 @@ export default pattern(() => {
     assertStringIncludes(main, '.for(["child", "value"], true)');
   });
 
+  it("does not re-root pattern factory identifiers in tool descriptors", async () => {
+    const source = `
+import { BuiltInLLMTool, pattern, patternTool } from "commonfabric";
+
+export const searchWeb = pattern<{ query: string }, { results: string[] }>(
+  ({ query }) => ({ results: [query] }),
+);
+
+export default pattern(() => {
+  const tools: Record<string, BuiltInLLMTool> = {
+    searchWeb: {
+      pattern: searchWeb,
+    },
+    wrappedSearch: patternTool(searchWeb),
+  };
+  return { tools };
+});
+`;
+
+    const output = await transformFiles({
+      "/main.tsx": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.tsx"]!;
+
+    assertStringIncludes(main, "pattern: searchWeb");
+    assertStringIncludes(main, "wrappedSearch: patternTool(searchWeb)");
+    assert(!main.includes("searchWeb.for("));
+  });
+
   it("does not add shared property causes inside dynamic array callbacks", async () => {
     const source = `
 import { lift, Writable } from "commonfabric";

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -69,7 +69,7 @@ export default pattern<{ count: number }, { doubled: number }>((state) => ({
     const main = output["/main.tsx"]!;
 
     assertStringIncludes(main, "doubled: __cfHelpers.derive(");
-    assertStringIncludes(main, '.for("doubled", true)');
+    assertStringIncludes(main, '.for(["__patternResult", "doubled"], true)');
     assertNotMatch(main, /state\.key\("count"\)\.for/);
   });
 

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -137,6 +137,138 @@ export function make() {
     assert(!main.includes('.for(["foo", "already"], true)'));
   });
 
+  it("does not add causes to plain array methods in lift callbacks", async () => {
+    const source = `
+import { lift } from "commonfabric";
+
+interface Summary {
+  label: string;
+  count: number;
+}
+
+export const summarize = lift((summaries: Summary[]) => {
+  const labels = summaries.map((summary) => summary.label);
+  const active = summaries.filter((summary) => summary.count > 0);
+  return {
+    labels: summaries.map((summary) => summary.label),
+    active,
+    label: labels.join(", "),
+  };
+});
+`;
+
+    const output = await transformFiles({
+      "/main.ts": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.ts"]!;
+
+    assert(!main.includes('.for("labels", true)'));
+    assert(!main.includes('.for("active", true)'));
+    assert(!main.includes('.for(["labels"], true)'));
+  });
+
+  it("does not add causes to plain array methods in lowered handler callbacks", async () => {
+    const source = `
+import { action, pattern, Stream } from "commonfabric";
+
+const Child = pattern<{}, { deleteHandlers: Stream<void>[] }>(() => {
+  return { deleteHandlers: [] as Stream<void>[] };
+});
+
+export default pattern(() => {
+  const subject = Child({});
+  const remove = action(() => {
+    const handlers = subject.deleteHandlers.filter(() => true);
+    handlers[0]?.send();
+  });
+  return { remove };
+});
+`;
+
+    const output = await transformFiles({
+      "/main.tsx": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.tsx"]!;
+
+    assert(!main.includes('.filter(() => true).for("handlers", true)'));
+  });
+
+  it("does not add causes to receiver calls in property access chains", async () => {
+    const source = `
+import { Default, pattern, wish, Writable } from "commonfabric";
+
+type MentionablePiece = { name: string };
+declare function make(input: unknown): { result: unknown };
+
+export default pattern(() => {
+  const mentionable =
+    wish<Default<MentionablePiece[], []>>({ query: "#mentionable" }).result;
+  const picked = make({ param: Writable.of(1) }).result;
+  return { mentionable, picked };
+});
+`;
+
+    const output = await transformFiles({
+      "/main.tsx": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.tsx"]!;
+
+    assert(!main.includes('.for("mentionable", true).result'));
+    assertStringIncludes(main, '.for(["picked", "param"], true)');
+  });
+
+  it("does not add root causes to pattern factory outputs", async () => {
+    const source = `
+import { pattern, Writable } from "commonfabric";
+
+const Child = pattern<{ value: number }>(() => {
+  return { value: Writable.of(1) };
+});
+
+export default pattern(() => {
+  const child = Child({ value: Writable.of(2) });
+  return { child };
+});
+`;
+
+    const output = await transformFiles({
+      "/main.tsx": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.tsx"]!;
+
+    assert(!main.includes('.for("child", true)'));
+    assertStringIncludes(main, '.for(["child", "value"], true)');
+  });
+
+  it("does not add shared property causes inside dynamic array callbacks", async () => {
+    const source = `
+import { lift, Writable } from "commonfabric";
+
+export const build = lift((values: number[]) =>
+  values.map((_value, index) => ({
+    token: Writable.of(index),
+  }))
+);
+`;
+
+    const output = await transformFiles({
+      "/main.ts": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.ts"]!;
+
+    assert(!main.includes('.for("token", true)'));
+  });
+
   it("transforms by default and supports cf-disable-transform opt-out", async () => {
     const source = `
 import { computed } from "commonfabric";


### PR DESCRIPTION
## Summary

- Add a late ts-transformer pass that appends `.for(name, true)` to fresh reactive or cell-like const initializers when the call chain does not already contain `.for(...)`.
- Extend stable causes through constructed object and tuple values, including variable call inputs like `.for(["foo", "param"], true)` and pattern results rooted at `.for(["__patternResult", ...], true)`.
- Preserve existing `.for(...)` chains, avoid internal `__cf...` temporaries, and keep generated capture plumbing such as `state.key(...)` unnamed.
- Refresh transformer golden fixtures for the new generated causes.

This should help stabilize setsrc quite a bit by giving generated reactive values stable, source-derived causes.

## Validation

- `deno check src/**/*.ts`
- `deno test --allow-read --allow-write --allow-env test/transform.test.ts`
- `UPDATE_GOLDENS=1 deno test --allow-read --allow-write --allow-env test/fixture-based.test.ts`
- `deno task test`