### PR TITLE
fix(fuse): sync .src/ pattern source writes to server (CT-1471)

### DIFF
--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -716,20 +716,50 @@ export async function main(argv: string[] = Deno.args) {
           return EACCES;
         }
 
-        if (!meta?.program) {
+        // Normalise to a files array, mirroring buildSourceTree:
+        // multi-file programs use program.files, single-file use meta.src.
+        let baseMain: string;
+        let baseMainExport: string | undefined;
+        let baseFiles: { name: string; contents: string }[];
+        if (meta?.program?.files?.length) {
+          baseMain = meta.program.main;
+          baseMainExport = meta.program.mainExport;
+          baseFiles = meta.program.files;
+        } else if (meta?.src) {
+          baseMain = "/main.tsx";
+          baseMainExport = undefined;
+          baseFiles = [{ name: "/main.tsx", contents: meta.src }];
+        } else {
+          console.error(
+            `[source] No program or src in pattern meta for ${relPath}`,
+          );
           return EACCES;
         }
 
         // Replace the written file's content in the files array
-        const updatedFiles = meta.program.files.map((f) => {
+        let matched = false;
+        const updatedFiles = baseFiles.map((f) => {
           const fRelPath = f.name.startsWith("/") ? f.name.slice(1) : f.name;
-          return fRelPath === relPath ? { ...f, contents: text } : f;
+          if (fRelPath === relPath) {
+            matched = true;
+            return { ...f, contents: text };
+          }
+          return f;
         });
+
+        if (!matched) {
+          console.error(
+            `[source] File "${relPath}" not found in pattern files: [${
+              baseFiles.map((f) => f.name).join(", ")
+            }]`,
+          );
+          return EACCES;
+        }
 
         try {
           await piece.setPattern({
-            main: meta.program.main,
-            mainExport: meta.program.mainExport,
+            main: baseMain,
+            mainExport: baseMainExport,
             files: updatedFiles,
           });
           // Clear error.log on success


### PR DESCRIPTION
## Summary

- Fix FUSE `.src/` pattern source writes silently failing to sync to the server
- Handle legacy single-file patterns (`meta.src`) in addition to multi-file (`meta.program.files`)
- Add error logging for file-not-found and missing-metadata failure paths

**Root cause:** `flushHandle` in `packages/fuse/mod.ts` only handled multi-file patterns and silently returned `EACCES` for single-file patterns. Additionally, if a written file path didn't match any existing file, `setPattern` was called with unchanged data — a silent no-op.

**Fix:** Normalise to a files array mirroring `buildSourceTree`, track whether a file matched during the map, and log errors for all failure paths.

## Test plan

- [x] Deploy single-file pattern, edit `.src/main.tsx` via FUSE, verify `cf piece getsrc` shows updated source
- [x] Deploy multi-file pattern, edit `main.tsx` via FUSE, verify server sync
- [x] Edit `helpers.ts` in multi-file pattern, verify server sync
- [x] Rapid re-edit of same file, verify latest content on server
- [x] Verify previous file edits preserved across writes to other files
- [x] Verify no errors in `error.log` or FUSE log
- [x] Verify cell writes (non-source) still work (regression)
- [x] `deno check packages/fuse/mod.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Linear: CT-1471