### PR TITLE
Improve local dev health check diagnostics

### DIFF
--- a/scripts/check-local-dev.sh
+++ b/scripts/check-local-dev.sh
@@ -9,6 +9,7 @@ read_base_ports
 PORT_OFFSET=${PORT_OFFSET:-0}
 SHELL_PORT=${SHELL_PORT:-}
 TOOLSHED_PORT=${TOOLSHED_PORT:-}
+HEALTH_CHECK_TIMEOUT=${HEALTH_CHECK_TIMEOUT:-10}
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -65,15 +66,43 @@ check_server() {
         return
     fi
 
-    local status
-    status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "$url" 2>/dev/null)
+    local curl_output=""
+    local curl_exit=0
+    local status=""
+    local total_time=""
+    local metrics_file=""
+    local error_file=""
 
-    if [[ "$status" == "200" ]]; then
-        echo "  $name: ok ($url)"
+    metrics_file=$(mktemp)
+    error_file=$(mktemp)
+
+    if curl -sS -o /dev/null -w "%{http_code} %{time_total}" --max-time "$HEALTH_CHECK_TIMEOUT" "$url" >"$metrics_file" 2>"$error_file"; then
+        curl_output="$(cat "$metrics_file")"
     else
-        echo "  $name: process on port $port but HTTP status $status ($url)"
-        ALL_OK=false
+        curl_exit=$?
+        curl_output="$(cat "$error_file")"
     fi
+
+    rm -f "$metrics_file" "$error_file"
+
+    if [[ "$curl_exit" -eq 0 ]]; then
+        status="${curl_output%% *}"
+        total_time="${curl_output#* }"
+        if [[ "$status" == "200" ]]; then
+            echo "  $name: ok ($url, ${total_time}s)"
+            return
+        fi
+
+        echo "  $name: process on port $port but HTTP status $status after ${total_time}s ($url)"
+        ALL_OK=false
+        return
+    fi
+
+    echo "  $name: process on port $port but curl failed with exit $curl_exit ($url)"
+    if [[ -n "$curl_output" ]]; then
+        echo "    curl: $curl_output"
+    fi
+    ALL_OK=false
 }
 
 check_server "Toolshed" "http://localhost:$TOOLSHED_PORT/_health" "$TOOLSHED_PORT"


### PR DESCRIPTION
## Summary
- let local-dev health checks honor a configurable timeout instead of hard-coding 5 seconds
- report curl transport failures separately from non-200 HTTP responses
- include response timing in successful and unsuccessful health output

## Why
Pattern Factory's local-dev supervisor now wants to distinguish "process is down" from "process is up but too busy to answer health in time." The existing health script collapsed those cases and always used a 5-second curl timeout, which made supervisor diagnostics less precise.

This keeps the script small, but makes downstream restart logic much easier to reason about.

## Validation
- `bash -n scripts/check-local-dev.sh`
- `git diff --check`
