### PR TITLE
docs(patterns): warn against bound-control self-feedback

### DIFF
--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -77,6 +77,7 @@ Ternaries are valid in JSX. The transformer auto-converts them to `ifElse()`.
 | `value={title}` | `$value={title}` |
 | `$checked={item}` | `$checked={item.done}` |
 | wrong event name | Use `oncf-send`, `oncf-input`, or `oncf-change` |
+| `$value={status}` with `oncf-change` writing `status.set(...)` | Let the binding own the control value; use the handler only for dependent state or side effects |
 
 ### 6. Custom Component Props and Styling Affordances
 

--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -77,7 +77,7 @@ Ternaries are valid in JSX. The transformer auto-converts them to `ifElse()`.
 | `value={title}` | `$value={title}` |
 | `$checked={item}` | `$checked={item.done}` |
 | wrong event name | Use `oncf-send`, `oncf-input`, or `oncf-change` |
-| `$value={status}` with `oncf-change` writing `status.set(...)` | Let the binding own the control value; use the handler only for dependent state or side effects |
+| cell-bound control (for example `$value={status}`) with `oncf-change` writing `status.set(...)` | Let the binding own the control value; use the handler only for dependent state or side effects |
 
 ### 6. Custom Component Props and Styling Affordances
 

--- a/docs/common/ai/pattern-development-guide.md
+++ b/docs/common/ai/pattern-development-guide.md
@@ -249,9 +249,10 @@ Use `computed()` for derivation and `action()` for side effects.
 
 ### Bound Control Self-Feedback
 
-If a control already uses `$value` or `$checked`, treat that binding as the
-control's primary value path. Do not add `oncf-change` / `oncf-input` handlers
-that merely write the same value back into that same bound cell.
+If a control is already bound to a cell, usually via `$value` or `$checked`,
+treat that binding as the control's primary value path. Do not add
+`oncf-change` / `oncf-input` handlers that merely write the same value back
+into that same cell.
 
 ```tsx
 // Wrong

--- a/docs/common/ai/pattern-development-guide.md
+++ b/docs/common/ai/pattern-development-guide.md
@@ -247,6 +247,30 @@ const updateStatus = action(() => {
 
 Use `computed()` for derivation and `action()` for side effects.
 
+### Bound Control Self-Feedback
+
+If a control already uses `$value` or `$checked`, treat that binding as the
+control's primary value path. Do not add `oncf-change` / `oncf-input` handlers
+that merely write the same value back into that same bound cell.
+
+```tsx
+// Wrong
+<cf-select
+  $value={entryType}
+  items={typeItems}
+  oncf-change={(event) => entryType.set(event.detail.value)}
+/>
+
+// Right
+<cf-select
+  $value={entryType}
+  items={typeItems}
+  oncf-change={(event) => syncCategoryForType.send(event.detail.value)}
+/>
+```
+
+Use the handler only for dependent state updates or other side effects.
+
 ### Composition Contracts
 
 When one pattern feeds another, output field names and input field names must

--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -137,6 +137,11 @@ Uses `items` attribute with `{ label, value }` objects. **Do not use `<option>` 
 />
 ```
 
+When a select already uses `$value`, treat that binding as the primary value
+path. Avoid `oncf-change` handlers that simply write the same value back into
+the same bound cell. Use `oncf-change` only for dependent state updates or
+other side effects.
+
 ---
 
 ## cf-message-input

--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -8,7 +8,8 @@ Common Fabric UI components with bidirectional binding support.
 
 ## Bidirectional Binding
 
-Use `$` prefix for automatic two-way sync. No handler needed for simple updates.
+Use `$` prefix for explicit two-way sync. That is the normal authoring form for
+Common Fabric controls. No handler is needed for simple updates.
 
 ```tsx
 <cf-checkbox $checked={item.done} />    // Auto-syncs checkbox state
@@ -84,11 +85,13 @@ timestamp snapshot.
 // With placeholder
 <cf-input $value={searchQuery} placeholder="Search..." />
 
-// Manual handler for side effects
-<cf-input value={title} oncf-input={(e) => {
-  title.set(e.detail.value);
-  console.log("Changed:", e.detail.value);
-}} />
+// Binding plus side effect
+<cf-input
+  $value={title}
+  oncf-input={(e) => {
+    console.log("Changed:", e.detail.value);
+  }}
+/>
 ```
 
 ---
@@ -137,10 +140,10 @@ Uses `items` attribute with `{ label, value }` objects. **Do not use `<option>` 
 />
 ```
 
-When a select already uses `$value`, treat that binding as the primary value
-path. Avoid `oncf-change` handlers that simply write the same value back into
-the same bound cell. Use `oncf-change` only for dependent state updates or
-other side effects.
+When a control is already bound to a cell, usually via `$value`, treat that
+binding as the primary value path. Avoid `oncf-change` handlers that simply
+write the same value back into that same cell. Use `oncf-change` only for
+dependent state updates or other side effects.
 
 ---
 

--- a/docs/common/patterns/two-way-binding.md
+++ b/docs/common/patterns/two-way-binding.md
@@ -47,7 +47,12 @@ export default pattern<Input, Input>(({ items }) => ({
 
 **Key points:**
 - `$checked` automatically syncs - no handler needed
+- if a control already uses `$value` or `$checked`, do not add a change handler
+  that merely writes the same value back into that same bound cell
 - Inline handlers for add/remove operations
 - **Uses `equals()` for item identity**
 - Ternary in `style` attribute works fine
 - Type inference works in `.map()` - no annotations needed
+
+Use change handlers on bound controls only when they update dependent state or
+perform another side effect.

--- a/docs/common/patterns/two-way-binding.md
+++ b/docs/common/patterns/two-way-binding.md
@@ -47,12 +47,13 @@ export default pattern<Input, Input>(({ items }) => ({
 
 **Key points:**
 - `$checked` automatically syncs - no handler needed
-- if a control already uses `$value` or `$checked`, do not add a change handler
-  that merely writes the same value back into that same bound cell
+- if a control is already bound to a cell, usually via `$value` or
+  `$checked`, do not add a change handler that merely writes the same value
+  back into that same cell
 - Inline handlers for add/remove operations
 - **Uses `equals()` for item identity**
 - Ternary in `style` attribute works fine
 - Type inference works in `.map()` - no annotations needed
 
-Use change handlers on bound controls only when they update dependent state or
-perform another side effect.
+Use change handlers on cell-bound controls only when they update dependent state
+or perform another side effect.

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -12,10 +12,10 @@ Read that guide first. It is the canonical reference.
 Be explicit about SES and determinism issues: direct `Date.now()` or
 `Math.random()`, authored timers, and non-idempotent `computed()` use of
 `safeDateNow()` or `nonPrivateRandom()` should all be flagged. Also flag
-bound-control self-feedback: if a `cf-*` form control already uses `$value` or
-`$checked`, treat an event handler that writes the same value back into that
-same cell as a reactive-loop hazard unless it is clearly necessary and
-idempotent.
+bound-control self-feedback: if a `cf-*` form control is already bound to a
+cell, usually via `$value` or `$checked`, treat an event handler that writes the
+same value back into that same cell as a reactive-loop hazard unless it is
+clearly necessary and idempotent.
 
 Then use the detailed references already maintained in the repo for:
 

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -11,11 +11,11 @@ Read that guide first. It is the canonical reference.
 
 Be explicit about SES and determinism issues: direct `Date.now()` or
 `Math.random()`, authored timers, and non-idempotent `computed()` use of
-`safeDateNow()` or `nonPrivateRandom()` should all be flagged.
-Also flag bound-control self-feedback: if a `cf-*` form control already uses
-`$value` or `$checked`, treat an event handler that writes the same value back
-into that same cell as a reactive-loop hazard unless it is clearly necessary
-and idempotent.
+`safeDateNow()` or `nonPrivateRandom()` should all be flagged. Also flag
+bound-control self-feedback: if a `cf-*` form control already uses `$value` or
+`$checked`, treat an event handler that writes the same value back into that
+same cell as a reactive-loop hazard unless it is clearly necessary and
+idempotent.
 
 Then use the detailed references already maintained in the repo for:
 

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -12,6 +12,10 @@ Read that guide first. It is the canonical reference.
 Be explicit about SES and determinism issues: direct `Date.now()` or
 `Math.random()`, authored timers, and non-idempotent `computed()` use of
 `safeDateNow()` or `nonPrivateRandom()` should all be flagged.
+Also flag bound-control self-feedback: if a `cf-*` form control already uses
+`$value` or `$checked`, treat an event handler that writes the same value back
+into that same cell as a reactive-loop hazard unless it is clearly necessary
+and idempotent.
 
 Then use the detailed references already maintained in the repo for:
 

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -12,8 +12,8 @@ Read that guide first. It is the canonical reference.
 Pay special attention to its SES authoring section before adding module-scope
 setup, timers, or time/random helpers. The current authored escape hatches are
 `safeDateNow()` and `nonPrivateRandom()`. Also follow its binding guidance: when
-a control already uses `$value` or `$checked`, do not add a handler that simply
-writes the same value back into that same bound cell.
+a control is already bound to a cell, usually via `$value` or `$checked`, do not
+add a handler that simply writes the same value back into that same cell.
 
 Runtime notes:
 

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -12,6 +12,9 @@ Read that guide first. It is the canonical reference.
 Pay special attention to its SES authoring section before adding module-scope
 setup, timers, or time/random helpers. The current authored escape hatches are
 `safeDateNow()` and `nonPrivateRandom()`.
+Also follow its binding guidance: when a control already uses `$value` or
+`$checked`, do not add a handler that simply writes the same value back into
+that same bound cell.
 
 Runtime notes:
 

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -11,10 +11,9 @@ Read that guide first. It is the canonical reference.
 
 Pay special attention to its SES authoring section before adding module-scope
 setup, timers, or time/random helpers. The current authored escape hatches are
-`safeDateNow()` and `nonPrivateRandom()`.
-Also follow its binding guidance: when a control already uses `$value` or
-`$checked`, do not add a handler that simply writes the same value back into
-that same bound cell.
+`safeDateNow()` and `nonPrivateRandom()`. Also follow its binding guidance: when
+a control already uses `$value` or `$checked`, do not add a handler that simply
+writes the same value back into that same bound cell.
 
 Runtime notes:
 

--- a/skills/pattern-implement/SKILL.md
+++ b/skills/pattern-implement/SKILL.md
@@ -47,8 +47,9 @@ const submit = action(() => {
 
 Use `safeDateNow()` and `nonPrivateRandom()` instead of ambient `Date.now()` and
 `Math.random()` when a pattern needs explicit time or randomness. If a control
-already uses `$value` or `$checked`, let that binding own the control value. Use
-`oncf-change` / `oncf-input` only for dependent state or other side effects.
+is already bound to a cell, usually via `$value` or `$checked`, let that binding
+own the control value. Use `oncf-change` / `oncf-input` only for dependent state
+or other side effects.
 
 **handler()** - Reused with different bindings:
 

--- a/skills/pattern-implement/SKILL.md
+++ b/skills/pattern-implement/SKILL.md
@@ -46,10 +46,9 @@ const submit = action(() => {
 ```
 
 Use `safeDateNow()` and `nonPrivateRandom()` instead of ambient `Date.now()` and
-`Math.random()` when a pattern needs explicit time or randomness.
-If a control already uses `$value` or `$checked`, let that binding own the
-control value. Use `oncf-change` / `oncf-input` only for dependent state or
-other side effects.
+`Math.random()` when a pattern needs explicit time or randomness. If a control
+already uses `$value` or `$checked`, let that binding own the control value. Use
+`oncf-change` / `oncf-input` only for dependent state or other side effects.
 
 **handler()** - Reused with different bindings:
 

--- a/skills/pattern-implement/SKILL.md
+++ b/skills/pattern-implement/SKILL.md
@@ -47,6 +47,9 @@ const submit = action(() => {
 
 Use `safeDateNow()` and `nonPrivateRandom()` instead of ambient `Date.now()` and
 `Math.random()` when a pattern needs explicit time or randomness.
+If a control already uses `$value` or `$checked`, let that binding own the
+control value. Use `oncf-change` / `oncf-input` only for dependent state or
+other side effects.
 
 **handler()** - Reused with different bindings:
 

--- a/skills/pattern-ui/SKILL.md
+++ b/skills/pattern-ui/SKILL.md
@@ -57,9 +57,9 @@ Layout: `cf-screen`, `cf-vstack`, `cf-hstack` Input: `cf-input`, `cf-textarea`,
 <cf-checkbox $checked={done} />
 ```
 
-If a control already uses `$value` or `$checked`, do not add a change handler
-that simply writes the same value back into that same bound cell. Use handlers
-only for dependent state updates or other side effects.
+If a control is already bound to a cell, usually via `$value` or `$checked`, do
+not add a change handler that simply writes the same value back into that same
+cell. Use handlers only for dependent state updates or other side effects.
 
 **Layout structure:**
 

--- a/skills/pattern-ui/SKILL.md
+++ b/skills/pattern-ui/SKILL.md
@@ -57,6 +57,10 @@ Layout: `cf-screen`, `cf-vstack`, `cf-hstack` Input: `cf-input`, `cf-textarea`,
 <cf-checkbox $checked={done} />
 ```
 
+If a control already uses `$value` or `$checked`, do not add a change handler
+that simply writes the same value back into that same bound cell. Use handlers
+only for dependent state updates or other side effects.
+
 **Layout structure:**
 
 ```tsx


### PR DESCRIPTION
## Summary
- document that `$value` / `$checked` bindings are the primary value path for a control
- warn against `oncf-change` / `oncf-input` handlers that simply write the same value back into the same bound cell
- update the shared component docs, two-way-binding guidance, development/critique guides, and core pattern skills

## Why
During Pattern Factory runtime investigation, the strongest piece-local thrash repro came from a generated `cf-select` pattern that both bound `$value` and wrote the same value back into that same cell from `oncf-change`. A local validation patch that removed those obvious same-cell write-backs stopped reproducing the original thrash. This PR turns that lesson into shared authoring and critique guidance.