### PR TITLE
[codex] Align SES time and randomness examples

### DIFF
--- a/docs/common/concepts/computed/computed.md
+++ b/docs/common/concepts/computed/computed.md
@@ -166,7 +166,7 @@ const result = {
 If your `computed()` has side effects (like setting another cell), they should be idempotent. Non-idempotent side effects cause the scheduler to re-run repeatedly until it hits the 101-iteration limit.
 
 ```typescript
-import { computed, Writable } from 'commonfabric';
+import { computed, safeDateNow, Writable } from 'commonfabric';
 
 interface Item {}
 declare const items: Item[];
@@ -176,7 +176,7 @@ const cacheMap = Writable.of<Record<string, number>>({});
 // ❌ Non-idempotent - appends on every run
 const badComputed = computed(() => {
   const current = logArray.get();
-  logArray.set([...current, { timestamp: Date.now() }]);  // Grows forever
+  logArray.set([...current, { timestamp: safeDateNow() }]);  // Grows forever
   return items.length;
 });
 
@@ -185,11 +185,14 @@ const goodComputed = computed(() => {
   const current = cacheMap.get();
   const key = `items-${items.length}`;
   if (!(key in current)) {
-    cacheMap.set({ ...current, [key]: Date.now() });
+    cacheMap.set({ ...current, [key]: safeDateNow() });
   }
   return items.length;
 });
 ```
+
+These examples use `safeDateNow()` to stay within authored APIs. The bug is the
+non-idempotent write pattern inside `computed()`, not the helper choice.
 
 The scheduler re-runs computations when their dependencies change. If a computation modifies a cell it depends on, it triggers itself. With idempotent operations, the second run produces no change, so the system settles.
 

--- a/docs/common/concepts/computed/side-effects.md
+++ b/docs/common/concepts/computed/side-effects.md
@@ -4,7 +4,7 @@
 If your `computed()` has side effects (like setting another cell), they should be idempotent. Non-idempotent side effects cause the scheduler to re-run repeatedly until it hits the 101-iteration limit.
 
 ```typescript
-import { computed, pattern, Writable } from 'commonfabric';
+import { computed, pattern, safeDateNow, Writable } from 'commonfabric';
 
 interface Props {}
 
@@ -15,7 +15,7 @@ export default pattern<Props, Props>((_) => {
   // ❌ Non-idempotent - appends on every run
   const badComputed = computed(() => {
     const current = logArray.get();
-    logArray.set([...current, { timestamp: Date.now() }]);  // Grows forever
+    logArray.set([...current, { timestamp: safeDateNow() }]);  // Grows forever
     return logArray.get().length;
   });
   
@@ -24,7 +24,7 @@ export default pattern<Props, Props>((_) => {
     const current = cacheMap.get();
     const key = `items-${Object.keys(current).length}`;
     if (!(key in current)) {
-      cacheMap.set({ ...current, [key]: Date.now() });
+      cacheMap.set({ ...current, [key]: safeDateNow() });
     }
     return Object.values(cacheMap.get()).length;
   });
@@ -33,6 +33,9 @@ export default pattern<Props, Props>((_) => {
 })
 
 ```
+
+These examples use `safeDateNow()` to stay within authored APIs. The problem is
+still the side effect inside `computed()`, not the time helper itself.
 
 The scheduler re-runs computations when their dependencies change. If a computation modifies a cell it depends on, it triggers itself. With idempotent operations, the second run produces no change, so the system settles.
 

--- a/packages/fs-sync-example/src/todo-list-pattern.tsx
+++ b/packages/fs-sync-example/src/todo-list-pattern.tsx
@@ -14,8 +14,10 @@ import {
   handler,
   ifElse,
   NAME,
+  nonPrivateRandom,
   OpaqueRef,
   pattern,
+  safeDateNow,
   Stream,
   UI,
   Writable,
@@ -36,8 +38,8 @@ const onCreate = handler<
   const description = detail?.message?.trim();
   if (!description) return;
 
-  const pendingId = `pending-${Date.now()}-${
-    Math.random().toString(36).slice(2)
+  const pendingId = `pending-${safeDateNow()}-${
+    nonPrivateRandom().toString(36).slice(2)
   }`;
 
   // Optimistic: add to local state immediately

--- a/packages/patterns/activity-log/activity-log.tsx
+++ b/packages/patterns/activity-log/activity-log.tsx
@@ -4,7 +4,9 @@ import {
   type Default,
   handler,
   NAME,
+  nonPrivateRandom,
   pattern,
+  safeDateNow,
   UI,
   type VNode,
   Writable,
@@ -53,11 +55,10 @@ const logEventHandler = handler<
   Omit<ActivityEvent, "id" | "timestamp">,
   { events: Writable<ActivityEvent[]>; mentioned: Writable<MentionablePiece[]> }
 >((args, { events, mentioned }) => {
+  const now = safeDateNow();
   events.push({
-    id: `${new Date().getTime().toString(36)}-${
-      Math.random().toString(36).slice(2, 11)
-    }`,
-    timestamp: new Date().toISOString(),
+    id: `${now.toString(36)}-${nonPrivateRandom().toString(36).slice(2, 11)}`,
+    timestamp: new Date(now).toISOString(),
     ...args,
   });
   if (args.pieceRef) mentioned.push(args.pieceRef);


### PR DESCRIPTION
## Summary

This PR follows up on the SES authoring guidance work from [#3239](https://github.com/commontoolsinc/labs/pull/3239) by aligning a few lingering authored examples and pattern docs with the newer `safeDateNow()` / `nonPrivateRandom()` guidance.

## What Changed

- updated the fs-sync example handler to use `safeDateNow()` and `nonPrivateRandom()` for generated optimistic IDs
- updated the activity-log pattern handler to snapshot time with `safeDateNow()` and generate IDs with `nonPrivateRandom()`
- updated the computed side-effects docs to use `safeDateNow()` in the example snippets
- added clarifying notes in the computed docs that the anti-pattern being demonstrated is the non-idempotent side effect inside `computed()`, not the helper choice itself

## Why

PR #3239 corrected the canonical docs and skills, but a few active examples still taught the old ambient `Date.now()` / `Math.random()` pattern in authored code. That left the repo sending mixed signals immediately after the docs were updated.

## Impact

- active examples now match the current SES authoring guidance
- reviewers and authors are less likely to copy stale ambient time/random usage from example code
- computed-side-effect docs stay focused on idempotence while remaining consistent with the documented authored APIs

## Validation

- `deno fmt`
- `deno lint`
- `deno check packages/fs-sync-example/src/todo-list-pattern.tsx packages/patterns/activity-log/activity-log.tsx`
