### PR TITLE
fix(felt): skip SWC transpilation to fix standard decorators

### DIFF
--- a/packages/felt/builder.ts
+++ b/packages/felt/builder.ts
@@ -169,7 +169,7 @@ export async function build(
   config: Parameters<typeof esbuild.build>[0],
 ): Promise<ReturnType<typeof esbuild.build>> {
   const fullConfig = Object.assign({}, config, {
-    plugins: [textLoaderPlugin(), denoPlugin()],
+    plugins: [textLoaderPlugin(), denoPlugin({ noTranspile: true })],
     platform: "browser",
     bundle: true,
     format: "esm",


### PR DESCRIPTION
## Summary

- Pass `noTranspile: true` to `denoPlugin()` in felt's esbuild build pipeline
- Fixes runtime crash: `Unsupported decorator location: field` introduced by #3284's standard decorator cutover

## Root cause

The `@deno/esbuild-plugin` uses `@deno/loader`'s SWC transpiler to pre-process TypeScript before esbuild bundles it. SWC was stripping the `accessor` keyword from decorated fields, so esbuild's standard decorator transform received `kind: 'field'` instead of `kind: 'accessor'`. Lit's `@property()` rejects field decorators, causing the crash.

With `noTranspile: true`, the plugin still handles Deno module resolution (npm:, jsr:, import maps) but skips the redundant SWC transpilation, letting esbuild handle TypeScript natively — including proper `accessor` support.

## Test plan

- [x] `deno task build` succeeds in packages/shell
- [x] Bundle output uses esbuild's decorator helpers (`__decorateElement`) with `kind: 'accessor'`
- [x] Shell loads in browser without "Unsupported decorator location" error
- [x] Loom end-to-end: piece deploy and shell load verified against loom's vendor/labs
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)