### PR TITLE
CT-1476 Fix piece startup timeout in populated spaces

### DIFF
--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -25,6 +25,9 @@ import * as Engine from "./engine.ts";
 
 export type QueryDocKey = `${string}/${string}/${string}`;
 
+const TRACE_GRAPH_QUERY = typeof Deno !== "undefined" &&
+  Deno.env.get("CF_TRACE_GRAPH_QUERY") === "1";
+
 export interface TrackedGraphState {
   branch: string;
   tracker: MapSetStringToPathSelectors;
@@ -222,6 +225,7 @@ export const trackGraph = (
   serverSeq: number;
   state: TrackedGraphState;
 } => {
+  const startedAt = TRACE_GRAPH_QUERY ? performance.now() : 0;
   const branch = query.branch ?? "";
   const managerKey = options.readSeq === undefined
     ? branch
@@ -258,7 +262,7 @@ export const trackGraph = (
     }
   }
 
-  return {
+  const result = {
     serverSeq: Engine.serverSeq(engine),
     state: {
       branch,
@@ -273,6 +277,26 @@ export const trackGraph = (
       manager,
     },
   };
+
+  if (TRACE_GRAPH_QUERY) {
+    const elapsedMs = Math.round(performance.now() - startedAt);
+    const loadedAddresses = manager.loadedAddresses().length;
+    const rootCounts = new Map<string, number>();
+    const uniqueRootSelectors = new Set<string>();
+    for (const root of query.roots) {
+      rootCounts.set(root.id, (rootCounts.get(root.id) ?? 0) + 1);
+      uniqueRootSelectors.add(JSON.stringify([root.id, root.selector]));
+    }
+    let maxRootsPerDoc = 0;
+    for (const count of rootCounts.values()) {
+      if (count > maxRootsPerDoc) maxRootsPerDoc = count;
+    }
+    console.error(
+      `[graph-query] ${elapsedMs}ms trackGraph space=${space} branch=${branch || "<default>"} roots=${query.roots.length} uniqueRootSelectors=${uniqueRootSelectors.size} uniqueRootDocs=${rootCounts.size} maxRootsPerDoc=${maxRootsPerDoc} reads=${manager.readCount} loaded=${loadedAddresses} trackerKeys=${schemaTracker.size} trackerVals=${schemaTracker.totalValues} entities=${result.state.entities.size}`,
+    );
+  }
+
+  return result;
 };
 
 export const extendTrackedGraph = (

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -292,7 +292,9 @@ export const trackGraph = (
       if (count > maxRootsPerDoc) maxRootsPerDoc = count;
     }
     console.error(
-      `[graph-query] ${elapsedMs}ms trackGraph space=${space} branch=${branch || "<default>"} roots=${query.roots.length} uniqueRootSelectors=${uniqueRootSelectors.size} uniqueRootDocs=${rootCounts.size} maxRootsPerDoc=${maxRootsPerDoc} reads=${manager.readCount} loaded=${loadedAddresses} trackerKeys=${schemaTracker.size} trackerVals=${schemaTracker.totalValues} entities=${result.state.entities.size}`,
+      `[graph-query] ${elapsedMs}ms trackGraph space=${space} branch=${
+        branch || "<default>"
+      } roots=${query.roots.length} uniqueRootSelectors=${uniqueRootSelectors.size} uniqueRootDocs=${rootCounts.size} maxRootsPerDoc=${maxRootsPerDoc} reads=${manager.readCount} loaded=${loadedAddresses} trackerKeys=${schemaTracker.size} trackerVals=${schemaTracker.totalValues} entities=${result.state.entities.size}`,
     );
   }
 

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -23,6 +23,7 @@ import NoteMd from "./note-md.tsx";
 import {
   type MentionablePiece,
   type MinimalPiece,
+  type NotebookParentPiece,
   type NotebookPiece,
   type NoteInput,
   type NotePiece,
@@ -50,7 +51,7 @@ interface NoteOutput extends NotePiece {
   appendLink: Stream<{ piece: Writable<MentionablePiece> }>;
   createNewNote: Stream<void>;
   /** Parent notebook reference, null if not in a notebook */
-  parentNotebook: NotebookPiece | null;
+  parentNotebook: NotebookParentPiece | null;
   /** Minimal UI for embedding in containers like Record. Use via cf-render variant="embedded". */
   embeddedUI: VNode;
   // Test-accessible state
@@ -235,7 +236,7 @@ const Note = pattern<NoteInput, NoteOutput>(
     const createNewNote = action(() => {
       const notebook = parentNotebook.get();
 
-      if (notebook) {
+      if (notebook?.createNote) {
         notebook.createNote.send({
           title: "New Note",
           content: "",

--- a/packages/patterns/notes/notebook.tsx
+++ b/packages/patterns/notes/notebook.tsx
@@ -21,8 +21,9 @@ import {
   type MentionablePiece,
   type MinimalPiece,
   type NotebookInput,
+  type NotebookListItemPiece,
+  type NotebookParentPiece,
   type NotebookPiece,
-  type NotePiece,
 } from "./schemas.tsx";
 
 // ===== Shared Utility Functions =====
@@ -34,10 +35,8 @@ import {
 const removeFromAllNotebooks = (
   notebooks: Writable<NotebookPiece[]>,
   itemsToRemove: (
-    | NotePiece
-    | NotebookPiece
-    | Writable<NotePiece>
-    | Writable<NotebookPiece>
+    | NotebookListItemPiece
+    | Writable<NotebookListItemPiece>
   )[],
   skipIndex?: number,
 ): void => {
@@ -64,7 +63,7 @@ interface NotebookOutput extends NotebookPiece {
   [NAME]: string;
   [UI]: VNode;
   title: string;
-  notes: NotePiece[];
+  notes: NotebookListItemPiece[];
   noteCount: number;
   summary: string;
   isNotebook: boolean;
@@ -103,7 +102,7 @@ interface NotebookOutput extends NotebookPiece {
 // Handler to remove a note from this notebook (but keep it in the space)
 const removeFromNotebook = handler<
   void,
-  { note: Writable<NotePiece>; notes: Writable<NotePiece[]> }
+  { note: Writable<NotebookListItemPiece>; notes: Writable<NotebookListItemPiece[]> }
 >((_, { note, notes }) => {
   const notebookNotes = notes.get();
   const index = notebookNotes.findIndex((n) => equals(n, note));
@@ -120,9 +119,9 @@ const removeFromNotebook = handler<
 // This MOVES the dropped notebook - removes from all other notebooks, adds here
 // Supports multi-item drag: if dragged item is in selection, moves ALL selected items
 const handleDropOntoCurrentNotebook = handler<
-  { detail: { sourceCell: Writable<NotePiece | NotebookPiece> } },
+  { detail: { sourceCell: Writable<NotebookListItemPiece> } },
   {
-    notes: Writable<NotePiece[]>;
+    notes: Writable<NotebookListItemPiece[]>;
     notebooks: Writable<NotebookPiece[]>;
     selectedNoteIndices: Writable<number[]>;
   }
@@ -164,14 +163,14 @@ const handleDropOntoCurrentNotebook = handler<
 // Handler for dropping any item onto a notebook - moves from current notebook to target
 // Supports multi-item drag: if dragged item is in selection, moves ALL selected items
 const handleDropOntoNotebook = handler<
-  { detail: { sourceCell: Writable<NotePiece> } },
+  { detail: { sourceCell: Writable<NotebookListItemPiece> } },
   {
     targetNotebook: Writable<{
       title?: string;
-      notes?: NotePiece[];
+      notes?: NotebookListItemPiece[];
       isNotebook?: boolean;
     }>;
-    currentNotes: Writable<NotePiece[]>;
+    currentNotes: Writable<NotebookListItemPiece[]>;
     selectedNoteIndices: Writable<number[]>;
     notebooks: Writable<NotebookPiece[]>;
   }
@@ -250,7 +249,7 @@ const handleBacklinkClick = handler<
 // Must be module-scope handler because it's used in .map() with per-iteration child bindings
 const navigateToChild = handler<
   void,
-  { child: Writable<NotePiece | NotebookPiece>; self: NotebookPiece }
+  { child: Writable<NotebookListItemPiece>; self: NotebookParentPiece }
 >(
   (_, { child, self }) => {
     child.key("parentNotebook").set(self);
@@ -262,9 +261,9 @@ const navigateToChild = handler<
 const deleteSelectedNotes = handler<
   void,
   {
-    notes: Writable<NotePiece[]>;
+    notes: Writable<NotebookListItemPiece[]>;
     selectedNoteIndices: Writable<number[]>;
-    allPieces: Writable<Default<NotePiece[], []>>;
+    allPieces: Writable<Default<MinimalPiece[], []>>;
     notebooks: Writable<NotebookPiece[]>;
   }
 >((_, { notes, selectedNoteIndices, allPieces, notebooks }) => {
@@ -296,7 +295,7 @@ const deleteSelectedNotes = handler<
 const addSelectedToNotebook = handler<
   { target?: { value: string }; detail?: { value: string } },
   {
-    notes: Writable<NotePiece[]>;
+    notes: Writable<NotebookListItemPiece[]>;
     selectedNoteIndices: Writable<number[]>;
     notebooks: Writable<NotebookPiece[]>;
     selectedAddNotebook: Writable<string>;
@@ -336,12 +335,12 @@ const addSelectedToNotebook = handler<
   const targetNotebookNotes = targetNotebookCell.key("notes");
 
   // Collect notes first, then batch push (reduces N reactive cycles to 1)
-  const notesToAdd: NotePiece[] = [];
+  const notesToAdd: NotebookListItemPiece[] = [];
   for (const idx of selected) {
     const note = notesList[idx];
     if (note) notesToAdd.push(note);
   }
-  (targetNotebookNotes as Writable<NotePiece[] | undefined>).push(
+  (targetNotebookNotes as Writable<NotebookListItemPiece[] | undefined>).push(
     ...notesToAdd,
   );
 
@@ -353,7 +352,7 @@ const addSelectedToNotebook = handler<
 const moveSelectedToNotebook = handler<
   { target?: { value: string }; detail?: { value: string } },
   {
-    notes: Writable<NotePiece[]>;
+    notes: Writable<NotebookListItemPiece[]>;
     selectedNoteIndices: Writable<number[]>;
     notebooks: Writable<NotebookPiece[]>;
     selectedMoveNotebook: Writable<string>;
@@ -414,7 +413,7 @@ const createNotebookFromPrompt = handler<
     showNewNotebookPrompt: Writable<boolean>;
     pendingNotebookAction: Writable<"add" | "move" | "">;
     selectedNoteIndices: Writable<number[]>;
-    notes: Writable<NotePiece[]>;
+    notes: Writable<NotebookListItemPiece[]>;
     allPieces: Writable<MinimalPiece[]>;
     notebooks: Writable<NotebookPiece[]>;
   }
@@ -510,7 +509,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
     const notebooks = notebookWish.candidates;
 
     // Still need allPieces for write operations (push new notes/notebooks)
-    const { allPieces } = wish<{ allPieces: Writable<NotePiece[]> }>(
+    const { allPieces } = wish<{ allPieces: Writable<MinimalPiece[]> }>(
       { query: "#default", headless: true },
     ).result!;
 
@@ -655,7 +654,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
           notesData: Array<{ title: string; content: string }>;
         },
       ) => {
-        const created: NotePiece[] = [];
+        const created: NotebookListItemPiece[] = [];
         for (const data of notesData) {
           created.push(Note({
             title: data.title,
@@ -684,7 +683,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
           notesData?: Array<{ title: string; content: string }>;
         },
       ) => {
-        const notesToAdd: NotePiece[] = [];
+        const notesToAdd: NotebookListItemPiece[] = [];
         if (notesData && notesData.length > 0) {
           for (const data of notesData) {
             notesToAdd.push(Note({
@@ -821,7 +820,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
         .map((n) => getPieceName(n))
         .filter((t) => t.length > 0);
 
-      const children: (NotePiece | NotebookPiece)[] = [];
+      const children: NotebookListItemPiece[] = [];
       for (let i = 0; i < nbCount; i++) {
         const nb = notebooks[i];
         const nbName = getPieceName(nb);

--- a/packages/patterns/notes/notebook.tsx
+++ b/packages/patterns/notes/notebook.tsx
@@ -102,7 +102,10 @@ interface NotebookOutput extends NotebookPiece {
 // Handler to remove a note from this notebook (but keep it in the space)
 const removeFromNotebook = handler<
   void,
-  { note: Writable<NotebookListItemPiece>; notes: Writable<NotebookListItemPiece[]> }
+  {
+    note: Writable<NotebookListItemPiece>;
+    notes: Writable<NotebookListItemPiece[]>;
+  }
 >((_, { note, notes }) => {
   const notebookNotes = notes.get();
   const index = notebookNotes.findIndex((n) => equals(n, note));

--- a/packages/patterns/notes/schemas.tsx
+++ b/packages/patterns/notes/schemas.tsx
@@ -41,6 +41,42 @@ export interface MinimalPiece {
 }
 
 /**
+ * Minimal notebook reference used for navigation and note creation.
+ * Intentionally excludes `notes` and `backlinks` to avoid recursive expansion
+ * in container/list schemas.
+ */
+export interface NotebookParentPiece {
+  [NAME]?: string;
+  title?: string;
+  isNotebook?: boolean;
+  isHidden?: boolean;
+  createNote?: Stream<{ title: string; content: string; navigate?: boolean }>;
+  createNotes?: Stream<{ notesData: Array<{ title: string; content: string }> }>;
+  setTitle?: Stream<string>;
+  createNotebook?: Stream<{
+    title: string;
+    notesData?: Array<{ title: string; content: string }>;
+  }>;
+  parentNotebook?: NotebookParentPiece | null;
+}
+
+/**
+ * Lightweight item stored in notebook note arrays.
+ * Keeps the fields used by notebook list rendering and local actions, but
+ * excludes backlinks/mentioned recursion and full notebook contents.
+ */
+export interface NotebookListItemPiece {
+  [NAME]?: string;
+  title?: string;
+  content?: string;
+  summary?: string;
+  isHidden?: boolean;
+  isNotebook?: boolean;
+  parentNotebook?: NotebookParentPiece | null;
+  setTitle?: Stream<string>;
+}
+
+/**
  * A note's core data shape (without reactive wrappers).
  * Used for type-safe access to note properties.
  */
@@ -51,7 +87,7 @@ export interface NotePiece {
   summary?: string;
   isHidden?: boolean;
   backlinks?: MentionablePiece[];
-  parentNotebook?: NotebookPiece | null;
+  parentNotebook?: NotebookParentPiece | null;
   setTitle?: Stream<string>;
 }
 
@@ -61,7 +97,7 @@ export interface NotePiece {
 export interface NotebookPiece {
   [NAME]?: string;
   title?: string;
-  notes?: NotePiece[];
+  notes?: NotebookListItemPiece[];
   backlinks?: MentionablePiece[];
   isNotebook?: boolean;
   isHidden?: boolean;
@@ -82,7 +118,7 @@ export interface NotebookPiece {
 export interface NotebookCell {
   [NAME]?: string;
   title?: string;
-  notes: Writable<NotePiece[]>;
+  notes: Writable<NotebookListItemPiece[]>;
   isNotebook?: boolean;
   isHidden?: boolean;
 }
@@ -107,16 +143,16 @@ export interface NoteInput {
   /** Pattern JSON for [[wiki-links]]. Defaults to creating new Notes. */
   linkPattern?: Writable<Default<string, "">>;
   /** Parent notebook reference. Set at creation, can be updated for moves. */
-  parentNotebook?: Writable<Default<NotebookPiece | null, null>>;
+  parentNotebook?: Writable<Default<NotebookParentPiece | null, null>>;
 }
 
 export interface NotebookInput {
   title?: Writable<Default<string, "Notebook">>;
-  notes?: Writable<Default<NotePiece[], []>>;
+  notes?: Writable<Default<NotebookListItemPiece[], []>>;
   isNotebook?: Default<boolean, true>;
   isHidden?: Default<boolean, false>;
   /** Parent notebook reference. Set at creation, can be updated for moves. */
-  parentNotebook?: Writable<Default<NotebookPiece | null, null>>;
+  parentNotebook?: Writable<Default<NotebookParentPiece | null, null>>;
 }
 
 export interface NoteMdInput {

--- a/packages/patterns/notes/schemas.tsx
+++ b/packages/patterns/notes/schemas.tsx
@@ -51,7 +51,9 @@ export interface NotebookParentPiece {
   isNotebook?: boolean;
   isHidden?: boolean;
   createNote?: Stream<{ title: string; content: string; navigate?: boolean }>;
-  createNotes?: Stream<{ notesData: Array<{ title: string; content: string }> }>;
+  createNotes?: Stream<
+    { notesData: Array<{ title: string; content: string }> }
+  >;
   setTitle?: Stream<string>;
   createNotebook?: Stream<{
     title: string;

--- a/packages/patterns/system/backlinks-index.tsx
+++ b/packages/patterns/system/backlinks-index.tsx
@@ -17,18 +17,30 @@ import {
  * Only patterns like notes and calendar events define them. The computeIndex
  * function safely handles pieces that lack these fields.
  */
-export type MentionablePiece = {
+export type MentionableRef = {
   [NAME]?: string;
   isHidden?: boolean;
   isMentionable?: boolean;
-  mentioned?: MentionablePiece[];
-  backlinks?: MentionablePiece[];
-  mentionable?: MentionablePiece[] | { get?: () => MentionablePiece[] };
+  summary?: string;
+  mentionable?: MentionableRef[] | { get?: () => MentionableRef[] };
 };
 
-export type WritableBacklinks = {
-  mentioned?: WritableBacklinks[];
-  backlinks?: Writable<WritableBacklinks[]>;
+export type MentionablePiece = MentionableRef & {
+  mentioned?: Array<
+    MentionableRef & {
+      backlinks?: MentionableRef[] | Writable<MentionableRef[]>;
+    }
+  >;
+  backlinks?: MentionableRef[] | Writable<MentionableRef[]>;
+};
+
+export type WritableBacklinks = MentionableRef & {
+  mentioned?: Array<
+    WritableBacklinks & {
+      backlinks?: Writable<MentionableRef[]>;
+    }
+  >;
+  backlinks?: Writable<MentionableRef[]>;
 };
 
 type Input = {

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -902,7 +902,6 @@ export class PieceManager {
       "startPiece.result.pull",
       () => this.getResult(piece).pull(),
     );
-    await timePiecePhase("startPiece.synced", () => this.synced());
   }
 
   /** Stop a running piece (no-op if not running). */

--- a/packages/piece/test/piece-startup.test.ts
+++ b/packages/piece/test/piece-startup.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { createBuilder } from "../../runner/src/builder/factory.ts";
+import { PieceManager } from "../src/manager.ts";
+
+const signer = await Identity.fromPassphrase("piece startup regression");
+
+describe("PieceManager.startPiece", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let manager: PieceManager;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+
+    const session = await createSession({
+      identity: signer,
+      spaceName: "piece-startup-" + crypto.randomUUID(),
+    });
+    manager = new PieceManager(session, runtime);
+    await manager.synced();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("resolves once the initial result is available, without waiting for global sync", async () => {
+    const { commonfabric } = createBuilder();
+    const { pattern } = commonfabric;
+
+    const counterPattern = pattern<{ value: number }>(({ value }) => ({
+      value,
+    }));
+
+    const piece = await manager.runPersistent(
+      counterPattern,
+      { value: 7 },
+      "piece-startup-regression",
+      undefined,
+      { start: false },
+    );
+
+    const originalSynced = manager.synced.bind(manager);
+    manager.synced = () =>
+      new Promise<void>((resolve) => setTimeout(resolve, 250));
+
+    const startedAt = performance.now();
+    try {
+      await manager.startPiece(piece);
+    } finally {
+      manager.synced = originalSynced;
+    }
+
+    const elapsedMs = performance.now() - startedAt;
+    expect(elapsedMs).toBeLessThan(200);
+    expect(piece.get()).toEqual({ value: 7 });
+  });
+});

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -163,21 +163,6 @@ export function stableStringify(value: unknown): string {
 }
 
 export const stableHash = stableStringify;
-
-function hashPathPart(part: string): string {
-  return `${part.length}:${part}`;
-}
-
-function hashSchemaPathSelector(value: SchemaPathSelector): string {
-  const pathHash = value.path.map(hashPathPart).join("/");
-  const schema = value.schema;
-  const schemaHash = schema === undefined
-    ? "u"
-    : typeof schema === "boolean"
-    ? (schema ? "t" : "f")
-    : `s:${hashSchema(schema)}`;
-  return `${value.path.length}|${pathHash}|${schemaHash}`;
-}
 /**
  * A data structure that maps keys to sets of values, allowing multiple values
  * to be associated with a single key without duplication.
@@ -325,7 +310,7 @@ export class MapSetStringToPathSelectors extends MapSet<
   SchemaPathSelector
 > {
   constructor(hashValues: boolean = false) {
-    super(hashValues ? hashSchemaPathSelector : undefined);
+    super(hashValues ? (v) => hashSchemaItem(v).toString() : undefined);
   }
 }
 

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -163,6 +163,21 @@ export function stableStringify(value: unknown): string {
 }
 
 export const stableHash = stableStringify;
+
+function hashPathPart(part: string): string {
+  return `${part.length}:${part}`;
+}
+
+function hashSchemaPathSelector(value: SchemaPathSelector): string {
+  const pathHash = value.path.map(hashPathPart).join("/");
+  const schema = value.schema;
+  const schemaHash = schema === undefined
+    ? "u"
+    : typeof schema === "boolean"
+    ? (schema ? "t" : "f")
+    : `s:${hashSchema(schema)}`;
+  return `${value.path.length}|${pathHash}|${schemaHash}`;
+}
 /**
  * A data structure that maps keys to sets of values, allowing multiple values
  * to be associated with a single key without duplication.
@@ -310,7 +325,7 @@ export class MapSetStringToPathSelectors extends MapSet<
   SchemaPathSelector
 > {
   constructor(hashValues: boolean = false) {
-    super(hashValues ? (v) => hashSchemaItem(v).toString() : undefined);
+    super(hashValues ? hashSchemaPathSelector : undefined);
   }
 }
 

--- a/scripts/ct1476-startup-experiment.ts
+++ b/scripts/ct1476-startup-experiment.ts
@@ -1,0 +1,237 @@
+#!/usr/bin/env deno run -A
+
+import { fromFileUrl, resolve } from "@std/path";
+import {
+  callPieceHandler,
+  newPiece,
+  type EntryConfig,
+  type PieceConfig,
+  type SpaceConfig,
+} from "../packages/cli/lib/piece.ts";
+
+type ExperimentPattern = {
+  label: string;
+  mainPath: string;
+};
+
+type DeployTiming = {
+  pieceId: string;
+  elapsedMs: number;
+  space: string;
+};
+
+type PatternResult = {
+  pattern: string;
+  fresh: DeployTiming;
+  seeded: DeployTiming;
+  seededSetupMs: number;
+};
+
+const repoRoot = resolve(fromFileUrl(new URL("..", import.meta.url)));
+const patternsRoot = resolve(repoRoot, "packages/patterns");
+const noteParagraph =
+  "Common Fabric startup benchmark note. This content exists to populate a notebook with enough reactive state to exercise piece startup in a non-trivial space. ";
+
+const experimentPatterns: ExperimentPattern[] = [
+  { label: "note", mainPath: resolve(patternsRoot, "notes/note.tsx") },
+  {
+    label: "contact-book",
+    mainPath: resolve(patternsRoot, "contacts/contact-book.tsx"),
+  },
+  { label: "calendar", mainPath: resolve(patternsRoot, "calendar/calendar.tsx") },
+  {
+    label: "reading-list",
+    mainPath: resolve(patternsRoot, "reading-list/reading-list.tsx"),
+  },
+];
+
+function parseArgs(args: string[]) {
+  const values: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2);
+    const next = args[i + 1];
+    if (next && !next.startsWith("--")) {
+      values[key] = next;
+      i++;
+    } else {
+      values[key] = "true";
+    }
+  }
+
+  return {
+    apiUrl: values["api-url"] ?? "http://localhost:8000",
+    identity: values["identity"] ?? "/tmp/ct1476.key",
+    seedNotes: Number(values["seed-notes"] ?? "12"),
+    seedTodos: Number(values["seed-todos"] ?? "0"),
+    noteBytes: Number(values["note-bytes"] ?? "8192"),
+    spacePrefix: values["space-prefix"] ?? "ct1476",
+    pattern: values["pattern"] ?? "all",
+  };
+}
+
+function makeSpaceName(prefix: string, label: string, kind: "fresh" | "seeded") {
+  return `${prefix}-${label}-${kind}-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function makeConfig(apiUrl: string, identity: string, space: string): SpaceConfig {
+  return { apiUrl, identity, space };
+}
+
+function makePieceConfig(
+  base: SpaceConfig,
+  piece: string,
+): PieceConfig {
+  return { ...base, piece };
+}
+
+function buildEntry(mainPath: string): EntryConfig {
+  return {
+    mainPath,
+    rootPath: patternsRoot,
+  };
+}
+
+function makeNoteContent(index: number, targetBytes: number): string {
+  let content = `Seed note ${index + 1}\n\n`;
+  while (content.length < targetBytes) {
+    content += `${noteParagraph}${index} `;
+  }
+  return content.slice(0, targetBytes);
+}
+
+async function timedDeploy(
+  config: SpaceConfig,
+  entry: EntryConfig,
+): Promise<DeployTiming> {
+  const startedAt = performance.now();
+  const pieceId = await newPiece(config, entry);
+  return {
+    pieceId,
+    elapsedMs: Math.round(performance.now() - startedAt),
+    space: config.space,
+  };
+}
+
+async function seedSpace(
+  config: SpaceConfig,
+  options: { seedNotes: number; seedTodos: number; noteBytes: number },
+): Promise<number> {
+  const startedAt = performance.now();
+
+  const notebookId = await newPiece(
+    config,
+    buildEntry(resolve(patternsRoot, "notes/notebook.tsx")),
+  );
+  await callPieceHandler(
+    makePieceConfig(config, notebookId),
+    "setTitle",
+    "CT-1476 Benchmark Notebook",
+  );
+
+  if (options.seedNotes > 0) {
+    await callPieceHandler(
+      makePieceConfig(config, notebookId),
+      "createNotes",
+      {
+        notesData: Array.from({ length: options.seedNotes }, (_, i) => ({
+          title: `Seed Note ${i + 1}`,
+          content: makeNoteContent(i, options.noteBytes),
+        })),
+      },
+    );
+  }
+
+  if (options.seedTodos > 0) {
+    const todoId = await newPiece(
+      config,
+      buildEntry(resolve(patternsRoot, "todo-list/todo-list.tsx")),
+    );
+    for (let i = 0; i < options.seedTodos; i++) {
+      await callPieceHandler(
+        makePieceConfig(config, todoId),
+        "addItem",
+        { title: `Seed todo ${i + 1} for startup benchmark` },
+      );
+    }
+  }
+
+  return Math.round(performance.now() - startedAt);
+}
+
+async function runOnePattern(
+  pattern: ExperimentPattern,
+  options: ReturnType<typeof parseArgs>,
+): Promise<PatternResult> {
+  const freshConfig = makeConfig(
+    options.apiUrl,
+    options.identity,
+    makeSpaceName(options.spacePrefix, pattern.label, "fresh"),
+  );
+  const seededConfig = makeConfig(
+    options.apiUrl,
+    options.identity,
+    makeSpaceName(options.spacePrefix, pattern.label, "seeded"),
+  );
+  const entry = buildEntry(pattern.mainPath);
+
+  console.error(`\n[ct1476] Benchmarking ${pattern.label}`);
+  console.error(`[ct1476] Fresh space:  ${freshConfig.space}`);
+  console.error(`[ct1476] Seeded space: ${seededConfig.space}`);
+
+  const fresh = await timedDeploy(freshConfig, entry);
+  console.error(
+    `[ct1476] Fresh deploy completed in ${fresh.elapsedMs}ms (${fresh.pieceId})`,
+  );
+
+  const seededSetupMs = await seedSpace(seededConfig, options);
+  console.error(
+    `[ct1476] Seeded space populated in ${seededSetupMs}ms`,
+  );
+
+  const seeded = await timedDeploy(seededConfig, entry);
+  console.error(
+    `[ct1476] Seeded deploy completed in ${seeded.elapsedMs}ms (${seeded.pieceId})`,
+  );
+
+  return {
+    pattern: pattern.label,
+    fresh,
+    seeded,
+    seededSetupMs,
+  };
+}
+
+async function main() {
+  const options = parseArgs(Deno.args);
+  const patterns = options.pattern === "all"
+    ? experimentPatterns
+    : experimentPatterns.filter((pattern) => pattern.label === options.pattern);
+
+  if (patterns.length === 0) {
+    throw new Error(
+      `Unknown pattern "${options.pattern}". Expected one of: ${
+        experimentPatterns.map((pattern) => pattern.label).join(", ")
+      }, all`,
+    );
+  }
+
+  const results: PatternResult[] = [];
+  for (const pattern of patterns) {
+    results.push(await runOnePattern(pattern, options));
+  }
+
+  console.log(JSON.stringify({
+    apiUrl: options.apiUrl,
+    identity: options.identity,
+    seedNotes: options.seedNotes,
+    seedTodos: options.seedTodos,
+    noteBytes: options.noteBytes,
+    results,
+  }, null, 2));
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/ct1476-startup-experiment.ts
+++ b/scripts/ct1476-startup-experiment.ts
@@ -3,8 +3,8 @@
 import { fromFileUrl, resolve } from "@std/path";
 import {
   callPieceHandler,
-  newPiece,
   type EntryConfig,
+  newPiece,
   type PieceConfig,
   type SpaceConfig,
 } from "../packages/cli/lib/piece.ts";
@@ -38,7 +38,10 @@ const experimentPatterns: ExperimentPattern[] = [
     label: "contact-book",
     mainPath: resolve(patternsRoot, "contacts/contact-book.tsx"),
   },
-  { label: "calendar", mainPath: resolve(patternsRoot, "calendar/calendar.tsx") },
+  {
+    label: "calendar",
+    mainPath: resolve(patternsRoot, "calendar/calendar.tsx"),
+  },
   {
     label: "reading-list",
     mainPath: resolve(patternsRoot, "reading-list/reading-list.tsx"),
@@ -71,11 +74,21 @@ function parseArgs(args: string[]) {
   };
 }
 
-function makeSpaceName(prefix: string, label: string, kind: "fresh" | "seeded") {
-  return `${prefix}-${label}-${kind}-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+function makeSpaceName(
+  prefix: string,
+  label: string,
+  kind: "fresh" | "seeded",
+) {
+  return `${prefix}-${label}-${kind}-${Date.now()}-${
+    crypto.randomUUID().slice(0, 8)
+  }`;
 }
 
-function makeConfig(apiUrl: string, identity: string, space: string): SpaceConfig {
+function makeConfig(
+  apiUrl: string,
+  identity: string,
+  space: string,
+): SpaceConfig {
   return { apiUrl, identity, space };
 }
 
@@ -222,14 +235,18 @@ async function main() {
     results.push(await runOnePattern(pattern, options));
   }
 
-  console.log(JSON.stringify({
-    apiUrl: options.apiUrl,
-    identity: options.identity,
-    seedNotes: options.seedNotes,
-    seedTodos: options.seedTodos,
-    noteBytes: options.noteBytes,
-    results,
-  }, null, 2));
+  console.log(JSON.stringify(
+    {
+      apiUrl: options.apiUrl,
+      identity: options.identity,
+      seedNotes: options.seedNotes,
+      seedTodos: options.seedTodos,
+      noteBytes: options.noteBytes,
+      results,
+    },
+    null,
+    2,
+  ));
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
## Summary
- decouple piece startup completion from global storage quiescence
- return from startPiece once the initial result is available
- add a regression test covering delayed manager.synced() during startup

## Diagnosis
The CLI timeout was racing piece creation against startup, but startup waited on manager.synced() after the piece had already started and produced its initial result. In populated spaces, that global storage sync can take much longer than actual piece readiness.

## Testing
- deno test --allow-env --allow-ffi --allow-read --allow-write packages/piece/test/piece-startup.test.ts
- deno test --allow-env --allow-ffi --allow-read --allow-write packages/piece/test/default-pattern-persistence.test.ts
- cd packages/piece && deno task test