### PR TITLE
fix: harden agent bootstrap and secure-mode time handling (CT-1477)

### DIFF
--- a/packages/patterns/activity-log/activity-log.tsx
+++ b/packages/patterns/activity-log/activity-log.tsx
@@ -4,7 +4,9 @@ import {
   type Default,
   handler,
   NAME,
+  nonPrivateRandom,
   pattern,
+  safeDateNow,
   UI,
   type VNode,
   Writable,
@@ -53,11 +55,12 @@ const logEventHandler = handler<
   Omit<ActivityEvent, "id" | "timestamp">,
   { events: Writable<ActivityEvent[]>; mentioned: Writable<MentionablePiece[]> }
 >((args, { events, mentioned }) => {
+  const now = safeDateNow();
   events.push({
-    id: `${new Date().getTime().toString(36)}-${
-      Math.random().toString(36).slice(2, 11)
+    id: `${now.toString(36)}-${
+      nonPrivateRandom().toString(36).slice(2, 11)
     }`,
-    timestamp: new Date().toISOString(),
+    timestamp: new Date(now).toISOString(),
     ...args,
   });
   if (args.pieceRef) mentioned.push(args.pieceRef);

--- a/packages/patterns/activity-log/activity-log.tsx
+++ b/packages/patterns/activity-log/activity-log.tsx
@@ -57,9 +57,7 @@ const logEventHandler = handler<
 >((args, { events, mentioned }) => {
   const now = safeDateNow();
   events.push({
-    id: `${now.toString(36)}-${
-      nonPrivateRandom().toString(36).slice(2, 11)
-    }`,
+    id: `${now.toString(36)}-${nonPrivateRandom().toString(36).slice(2, 11)}`,
     timestamp: new Date(now).toISOString(),
     ...args,
   });

--- a/packages/patterns/agent/agent.tsx
+++ b/packages/patterns/agent/agent.tsx
@@ -6,6 +6,7 @@ import {
   handler,
   NAME,
   pattern,
+  safeDateNow,
   type Stream,
   UI,
   type VNode,
@@ -128,8 +129,9 @@ export default pattern<AgentInput, AgentOutput>(
         summary: string;
         learned?: string;
       }) => {
+        const nowIso = new Date(safeDateNow()).toISOString();
         status.set("idle");
-        lastRun.set(new Date().toISOString());
+        lastRun.set(nowIso);
         lastRunSummary.set(summary);
         if (learnedEntry) {
           const current = learned.get() || "";
@@ -147,8 +149,9 @@ export default pattern<AgentInput, AgentOutput>(
     );
 
     const markError = action(({ summary }: { summary: string }) => {
+      const nowIso = new Date(safeDateNow()).toISOString();
       status.set("error");
-      lastRun.set(new Date().toISOString());
+      lastRun.set(nowIso);
       lastRunSummary.set(`ERROR: ${summary}`);
       if (activityLog) {
         activityLog.logEvent.send({

--- a/scripts/agents/agent-bootstrap.md
+++ b/scripts/agents/agent-bootstrap.md
@@ -26,6 +26,10 @@ in the space. You will be told which agent piece is yours when you start.
 8. Call `markIdle.handler` with `--summary 'what you did'` when done
 
 Important filesystem discipline:
-- Only `[FS]` note pieces have `index.md`. Notebook / structured pieces usually do not.
-- If `index.md` is missing, inspect `result/summary`, `result.json`, or `input.json` instead of retrying the same path.
-- Before calling handlers, prefer reading `.handlers` or `--help` so you use the exact flag names the handler exposes.
+
+- Only `[FS]` note pieces have `index.md`. Notebook / structured pieces usually
+  do not.
+- If `index.md` is missing, inspect `result/summary`, `result.json`, or
+  `input.json` instead of retrying the same path.
+- Before calling handlers, prefer reading `.handlers` or `--help` so you use the
+  exact flag names the handler exposes.

--- a/scripts/agents/agent-bootstrap.md
+++ b/scripts/agents/agent-bootstrap.md
@@ -17,10 +17,15 @@ in the space. You will be told which agent piece is yours when you start.
 1. Load the `fuse-agent` skill — it contains the complete reference for
    deploying, activity logging, annotations, and agent lifecycle.
 2. Health check: `ls $MOUNT/` — if empty, remount with
-   `cf fuse mount $MOUNT --background && sleep 3`
+   `cd ~/code/labs && deno task cf fuse mount "$MOUNT" -s "$SPACE" --background && sleep 3`
 3. Read `pieces.json`: `cat "$MOUNT/$SPACE/pieces/pieces.json"`
 4. Find your agent piece by name and read your directive from `input/directive`
 5. Call `markRunning.handler` on your agent piece
 6. Execute your directive
 7. Use `appendLearned.handler` to record anything you learned during the run
 8. Call `markIdle.handler` with `--summary 'what you did'` when done
+
+Important filesystem discipline:
+- Only `[FS]` note pieces have `index.md`. Notebook / structured pieces usually do not.
+- If `index.md` is missing, inspect `result/summary`, `result.json`, or `input.json` instead of retrying the same path.
+- Before calling handlers, prefer reading `.handlers` or `--help` so you use the exact flag names the handler exposes.

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -169,6 +169,32 @@ See `docs/common/workflows/handlers-cli-testing.md` for the full workflow and
 | JSON parse error             | Check nested quotes, no trailing commas                                      |
 | Local servers not responding | `./scripts/check-local-dev.sh` then `./scripts/restart-local-dev.sh --force` |
 
+### FUSE mount wrapper mismatch
+
+On some local setups, the installed `cf` wrapper (for example `dist/cf`) can lag
+behind the source CLI and reject newer `fuse mount` flags such as `-s/--space`,
+even when `deno task cf fuse mount --help` supports them.
+
+**Symptom:**
+
+```bash
+cf fuse mount /tmp/cf -s my-space
+# error: Unknown option "-s"
+```
+
+**Fix:** use the source CLI through the repo task wrapper instead:
+
+```bash
+cd ~/code/labs
+export CF_IDENTITY=./shared.key
+export CF_API_URL=http://localhost:8000
+
+deno task cf fuse mount /tmp/cf -s my-space
+```
+
+This matters because preconnecting the space is required for writable FUSE
+mounts; auto-discovered spaces may appear writable but silently drop writes.
+
 ## References
 
 - `packages/patterns/system/default-app.tsx` - System pieces (allCharms list

--- a/skills/fuse-agent/SKILL.md
+++ b/skills/fuse-agent/SKILL.md
@@ -110,6 +110,33 @@ fail silently with a dead transport — the handler appears to execute but no
 state changes. If agents report "learned" entries that don't show up in
 `input/learned`, check the transport first.
 
+### Secure-mode time/random pitfalls in handlers
+
+Pattern handlers and actions may run under SES secure mode. Avoid raw zero-arg
+`new Date()` and `Math.random()` inside authored patterns — both can throw under
+secure mode.
+
+Use Common Fabric safe builtins instead:
+
+```ts
+import { safeDateNow, nonPrivateRandom } from "commonfabric";
+
+const now = safeDateNow();
+const iso = new Date(now).toISOString();
+const id = `${now.toString(36)}-${nonPrivateRandom().toString(36).slice(2, 11)}`;
+```
+
+This specifically matters for:
+- `activity-log.tsx` event creation / timestamps
+- `agent.tsx` lifecycle handlers (`markIdle`, `markError`)
+- any handler-generated IDs or timestamps in experiment support patterns
+
+If a handler fails with messages like:
+- `secure mode Calling new %SharedDate%() with no arguments throws`
+- `secure mode %SharedMath%.random() throws`
+
+check the pattern source before assuming the agent invoked it incorrectly.
+
 ---
 
 ## Activity Log Pattern
@@ -129,8 +156,12 @@ LOG_NAME=$(cat "MOUNT/SPACE/pieces/pieces.json" | python3 -c \
 "MOUNT/SPACE/pieces/$LOG_NAME/result/logEvent.handler" \
   --agent "deployer" \
   --action "deployed" \
-  --pieceName "Contact Book" \
+  --piece-name "Contact Book" \
   --note "Contacts mentioned in standup notes with no structured tracking"
+
+# Note: handler CLIs expose object fields as kebab-case flags (`piece-name`),
+# not camelCase (`pieceName`). `--help` on the handler shows the exact flags.
+# When in doubt, prefer `--json` / `--json-file` to avoid flag-name mismatches.
 
 # Re-read pieces.json after — name changes on every event
 ```

--- a/skills/fuse-agent/SKILL.md
+++ b/skills/fuse-agent/SKILL.md
@@ -119,19 +119,34 @@ secure mode.
 Use Common Fabric safe builtins instead:
 
 ```ts
-import { safeDateNow, nonPrivateRandom } from "commonfabric";
+import { nonPrivateRandom, safeDateNow } from "commonfabric";
 
 const now = safeDateNow();
 const iso = new Date(now).toISOString();
-const id = `${now.toString(36)}-${nonPrivateRandom().toString(36).slice(2, 11)}`;
+const id = `${now.toString(36)}-${
+  nonPrivateRandom().toString(36).slice(2, 11)
+}`;
 ```
 
 This specifically matters for:
+
 - `activity-log.tsx` event creation / timestamps
 - `agent.tsx` lifecycle handlers (`markIdle`, `markError`)
 - any handler-generated IDs or timestamps in experiment support patterns
 
+For event IDs in authored patterns, avoid `Math.random()` too. A safe pattern
+is:
+
+```ts
+const now = safeDateNow();
+const id = `${now.toString(36)}-${
+  nonPrivateRandom().toString(36).slice(2, 11)
+}`;
+const timestamp = new Date(now).toISOString();
+```
+
 If a handler fails with messages like:
+
 - `secure mode Calling new %SharedDate%() with no arguments throws`
 - `secure mode %SharedMath%.random() throws`
 


### PR DESCRIPTION
## Summary
- replace insecure zero-arg time calls in `activity-log` and `agent` patterns with secure-mode-safe builtins
- replace raw `Math.random()` in Activity Log event IDs with `nonPrivateRandom()`
- improve the run-14 agent bootstrap guidance for remounting, handler discovery, and non-`[FS]` piece reading
- document the local `cf` fuse-wrapper mismatch and the correct Activity Log handler flag naming in skills

## Context
- Fixes CT-1477
- Related investigation: CT-1476 tracks the deeper populated-space slowdown / startup-timeout issue

## Test Plan
- `deno task cf check packages/patterns/activity-log/activity-log.tsx --no-run`
- `deno task cf check packages/patterns/agent/agent.tsx --no-run`
- manually verified `Activity Log` handler invocation in a fresh scratch space after the safe time/random changes

## Notes
- This PR is intentionally scoped to the secure-mode/runtime-safety fixes and bootstrap refinements already identified during the run-14 investigation.
- It does not attempt to solve the deeper space slowdown / poisoned-space behavior.