### PR TITLE
test(runner): fix array_push integration path

### DIFF
--- a/packages/runner/integration/array_push.test.ts
+++ b/packages/runner/integration/array_push.test.ts
@@ -1,198 +1,175 @@
-#!/usr/bin/env -S deno run --allow-net --allow-env --allow-read
+#!/usr/bin/env -S deno run -A
 
 /**
- * as integration test, we make sure we can write 100 element array and get it back
- * as client performance test, we can use this script to create a piece and see how
- * fast the client can render 100 mapped elements, which often ends up creating a
- * lot of vdom nodes
+ * Integration test: verify writable-array `.push()` works against the real
+ * remote memory transport and toolshed app.
  */
-import { Identity, Session } from "@commonfabric/identity";
-import { env } from "@commonfabric/integration";
-import { StorageManager } from "../src/storage/cache.ts";
-import { Runtime, Stream } from "../src/index.ts";
-import { compilePattern, PieceManager } from "@commonfabric/piece";
+import app from "../../toolshed/app.ts";
+import { Identity } from "@commonfabric/identity";
+import { type JSONSchema, Runtime } from "../src/index.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 (Error as any).stackTraceLimit = 100;
 
-const { API_URL } = env;
-const MEMORY_WS_URL = `${
-  API_URL.replace("http://", "ws://")
-}/api/storage/memory`;
-const SPACE_NAME_PREFIX = "runner_integration";
+const TOTAL_COUNT = 20;
+const TIMEOUT_MS = 180000;
 
-const TOTAL_COUNT = 20; // how many elements we push to the array
-const TIMEOUT_MS = 180000; // timeout for the test in ms (3 minutes)
-
-console.log("Array Push Test");
-console.log(`Connecting to: ${MEMORY_WS_URL}`);
-console.log(`API URL: ${API_URL}`);
-
-// Main test function
-async function runTest() {
-  const account = await Identity.fromPassphrase("common user");
-  const spaceName = `${SPACE_NAME_PREFIX}-${crypto.randomUUID()}`;
-  const space_thingy = await account.derive(spaceName);
-  const space_thingy_space = space_thingy.did();
-  const session = {
-    isPrivate: false,
-    spaceName,
-    space: space_thingy_space,
-    as: space_thingy,
-  } as Session;
-
-  // Create storage manager
-  const storageManager = StorageManager.open({
-    as: session.as,
-    address: new URL("/api/storage/memory", API_URL),
-  });
-
-  // Create runtime
-  const runtime = new Runtime({
-    apiUrl: new URL(API_URL),
-    storageManager,
-  });
-
-  // Create piece manager for the specified space
-  const pieceManager = new PieceManager(session, runtime);
-  await pieceManager.ready;
-
-  // Read the pattern file content
-  const patternContent = await Deno.readTextFile(
-    "./integration/array_push.test.tsx",
-  );
-
-  // FIXME(@ellyse) use this instead of compile
-  // const { result } = compileAndRun({
-  //   files: [{ name: "/main.tsx", contents: state.code }],
-  //   main: "/main.tsx",
-  // });
-  const pattern = await compilePattern(
-    patternContent,
-    "pattern",
-    runtime,
-    space_thingy_space,
-  );
-  console.log("Pattern compiled successfully");
-
-  const piece = (await pieceManager.runPersistent(pattern, {})).asSchema({
-    type: "object",
-    properties: {
-      my_numbers_array: {
-        type: "array",
-        items: { type: "number" },
+const OutputSchema = {
+  type: "object",
+  properties: {
+    my_numbers_array: {
+      type: "array",
+      items: { type: "number" },
+    },
+    my_objects_array: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { count: { type: "number" } },
       },
-      my_objects_array: {
-        type: "array",
-        items: {
+    },
+    pushNumbersHandler: {
+      type: "object",
+      properties: { value: { type: "number" } },
+      asStream: true,
+    },
+    pushObjectsHandler: {
+      type: "object",
+      properties: {
+        value: {
           type: "object",
           properties: { count: { type: "number" } },
         },
       },
-      pushNumbersHandler: {
-        type: "object",
-        properties: { value: { type: "number" } },
-        asStream: true,
-      },
-      pushObjectsHandler: {
-        type: "object",
-        properties: {
-          value: { type: "object", properties: { count: { type: "number" } } },
-        },
-        asStream: true,
-      },
+      asStream: true,
     },
-    required: [
-      "my_numbers_array",
-      "my_objects_array",
-      "pushNumbersHandler",
-      "pushObjectsHandler",
-    ],
-  });
-  console.log("Result piece ID:", piece.entityId);
-  console.log("Result piece schema:", piece.schema);
-
-  // Wait so we can load the page on the browser
-  // await new Promise((resolve) => setTimeout(resolve, 10000));
-
-  // Get the handler stream and send some numbers
-  const pushNumbersHandlerStream = piece.key(
+  },
+  required: [
+    "my_numbers_array",
+    "my_objects_array",
     "pushNumbersHandler",
-  ) as unknown as Stream<{ value: number }>;
-  const pushObjectsHandlerStream = piece.key(
     "pushObjectsHandler",
-  ) as unknown as Stream<{ value: { count: number } }>;
+  ],
+} as const satisfies JSONSchema;
 
-  const expectedNumbers = [];
-  const expectedObjects = [];
-
-  let sendCount = 0;
-
-  // Loop, sending numbers one by one
-  for (let i = 0; i < TOTAL_COUNT; i++) {
-    console.log(`Sending value: ${i}`);
-    pushNumbersHandlerStream.send({ value: i });
-    pushObjectsHandlerStream.send({ value: { count: i } });
-    expectedNumbers.push(i);
-    expectedObjects.push({ count: i });
-    sendCount++;
-  }
-
-  console.log("Waiting for runtime to finish and storage to sync...");
-  await runtime.idle();
-  await runtime.storageManager.synced();
-  console.log("Storage synced");
-
-  // Now we should have all elements
-  const actualNumbersElements = piece.get().my_numbers_array.length;
-  const actualObjectsElements = piece.get().my_objects_array.length;
-  if (
-    actualNumbersElements === TOTAL_COUNT &&
-    actualObjectsElements === TOTAL_COUNT
-  ) {
-    console.log(`Test passed - all ${TOTAL_COUNT} elements received`);
-  } else {
-    console.error(
-      `Test failed - expected ${TOTAL_COUNT} but got ${actualNumbersElements} numbers and ${actualObjectsElements} objects`,
-    );
-    console.log("Array contents (numbers):", piece.get().my_numbers_array);
-    console.log("Array contents (objects):", piece.get().my_objects_array);
-    throw new Error(
-      `Expected ${TOTAL_COUNT} numbers and ${TOTAL_COUNT} objects but got ${actualNumbersElements} numbers and ${actualObjectsElements} objects`,
-    );
-  }
-
-  if (
-    JSON.stringify(piece.get().my_numbers_array) ===
-      JSON.stringify(expectedNumbers)
-  ) {
-    console.log("Numbers array is as expected");
-  } else {
-    console.log("Numbers array is not as expected");
-    console.log("Expected:", expectedNumbers);
-    console.log("Actual:", piece.get().my_numbers_array);
-    throw new Error("Numbers array is not as expected");
-  }
-  if (
-    JSON.stringify(piece.get().my_objects_array) ===
-      JSON.stringify(expectedObjects)
-  ) {
-    console.log("Objects array is as expected");
-  } else {
-    console.log("Objects array is not as expected");
-    console.log("Expected:", expectedObjects);
-    console.log("Actual:", piece.get().my_objects_array);
-    throw new Error("Objects array is not as expected");
-  }
-
-  // Clean up
-  await runtime.dispose();
-  await storageManager.close();
+function readExperimentalFlag(name: string): boolean | undefined {
+  const value = Deno.env.get(name);
+  if (value === undefined || value === "") return undefined;
+  return value === "true" || value === "1";
 }
 
-// Run the test with timeout
+function createRuntime(identity: Identity, base: URL): Runtime {
+  return new Runtime({
+    apiUrl: base,
+    storageManager: StorageManager.open({
+      as: identity,
+      address: new URL("/api/storage/memory", base),
+    }),
+    experimental: {
+      modernDataModel: readExperimentalFlag("EXPERIMENTAL_MODERN_DATA_MODEL"),
+      modernHash: readExperimentalFlag("EXPERIMENTAL_MODERN_HASH"),
+      modernSchemaHash: readExperimentalFlag("EXPERIMENTAL_MODERN_SCHEMA_HASH"),
+    },
+  });
+}
+
+async function runTest(base: URL) {
+  const account = await Identity.fromPassphrase(
+    `array-push-test-${crypto.randomUUID()}`,
+  );
+  const runtime = createRuntime(account, base);
+  const space = account.did();
+
+  try {
+    const patternSource = await Deno.readTextFile(
+      new URL("./array_push.test.tsx", import.meta.url),
+    );
+    const pattern = await runtime.patternManager.compilePattern(patternSource);
+    const patternId = runtime.patternManager.registerPattern(
+      pattern,
+      patternSource,
+    );
+    await runtime.patternManager.saveAndSyncPattern({ patternId, space });
+
+    const resultCell = runtime.getCell(
+      space,
+      `array-push-result-${crypto.randomUUID()}`,
+      pattern.resultSchema,
+    );
+    const result = await runtime.runSynced(resultCell, pattern, {});
+    const shaped = result.asSchema(OutputSchema);
+    const cancelSink = shaped.sink(() => {});
+
+    const expectedNumbers: number[] = [];
+    const expectedObjects: { count: number }[] = [];
+
+    for (let i = 0; i < TOTAL_COUNT; i++) {
+      await runtime.editWithRetry((tx) =>
+        shaped.key("pushNumbersHandler").withTx(tx).send({ value: i })
+      );
+      await runtime.editWithRetry((tx) =>
+        shaped.key("pushObjectsHandler").withTx(tx).send({
+          value: { count: i },
+        })
+      );
+      expectedNumbers.push(i);
+      expectedObjects.push({ count: i });
+    }
+
+    await runtime.idle();
+    await runtime.storageManager.synced();
+
+    const actualNumbers = await shaped.key("my_numbers_array").pull() as
+      | number[]
+      | undefined;
+    const actualObjects = await shaped.key("my_objects_array").pull() as
+      | { count: number }[]
+      | undefined;
+
+    if (!actualNumbers || !actualObjects) {
+      throw new Error("Pattern result did not materialize expected arrays");
+    }
+
+    if (actualNumbers.length !== TOTAL_COUNT) {
+      throw new Error(
+        `Expected ${TOTAL_COUNT} numbers but got ${actualNumbers.length}`,
+      );
+    }
+
+    if (actualObjects.length !== TOTAL_COUNT) {
+      throw new Error(
+        `Expected ${TOTAL_COUNT} objects but got ${actualObjects.length}`,
+      );
+    }
+
+    if (JSON.stringify(actualNumbers) !== JSON.stringify(expectedNumbers)) {
+      throw new Error(
+        `Numbers array mismatch\nExpected: ${
+          JSON.stringify(expectedNumbers)
+        }\nActual: ${JSON.stringify(actualNumbers)}`,
+      );
+    }
+
+    if (JSON.stringify(actualObjects) !== JSON.stringify(expectedObjects)) {
+      throw new Error(
+        `Objects array mismatch\nExpected: ${
+          JSON.stringify(expectedObjects)
+        }\nActual: ${JSON.stringify(actualObjects)}`,
+      );
+    }
+
+    cancelSink();
+  } finally {
+    await runtime.dispose();
+  }
+}
+
 Deno.test({
   name: "array push test",
   fn: async () => {
+    const server = Deno.serve({ port: 0 }, app.fetch);
+    const base = new URL(`http://${server.addr.hostname}:${server.addr.port}`);
+
     let timeoutHandle: number;
     const timeoutPromise = new Promise((_, reject) => {
       timeoutHandle = setTimeout(() => {
@@ -201,10 +178,10 @@ Deno.test({
     });
 
     try {
-      await Promise.race([runTest(), timeoutPromise]);
-      console.log("Test completed successfully within timeout");
+      await Promise.race([runTest(base), timeoutPromise]);
     } finally {
       clearTimeout(timeoutHandle!);
+      await server.shutdown();
     }
   },
   sanitizeResources: false,

--- a/skills/pattern-debug/SKILL.md
+++ b/skills/pattern-debug/SKILL.md
@@ -55,6 +55,15 @@ piece issues.
 - Ensure Output type includes action as Stream<void>
 - Use .send() not .get() to trigger
 
+**Browser UI stays stale after a write:**
+
+- Do not assume a documented primitive like `.push()` is broken just because
+  tests/CLI and browser behavior diverge
+- First inspect the actual cell values in browser/runtime tools to confirm
+  whether state changed
+- If state changed but the UI did not, isolate the rendering/reactivity issue
+  with a minimal repro before rewriting the mutation style
+
 **computed() wrapping JSX — conditional rendering broken:**
 
 - Inside `computed()` body, ternaries are plain JS (Writable objects always
@@ -93,6 +102,13 @@ agent-browser eval "(async () => {
 # Check for action schema mismatches (handlers doing nothing)
 agent-browser eval "JSON.stringify(commonfabric.getLoggerFlagsBreakdown())"
 ```
+
+When tests or CLI calls succeed but browser-visible UI stays stale:
+
+- inspect the live piece state first
+- confirm whether the handler actually wrote the expected value
+- only then decide whether the bug is in mutation semantics, rendering, or
+  browser harness behavior
 
 **In browser console** (for interactive debugging):
 


### PR DESCRIPTION
## Summary
- rewrite array_push.test.ts as a self-contained toolshed integration test
- verify writable-array .push() over the real remote memory transport instead of relying on piece creation side effects
- add pattern-debug guidance to inspect live state before blaming a documented primitive

## Verification
- deno fmt packages/runner/integration/array_push.test.ts skills/pattern-debug/SKILL.md
- deno test -A packages/runner/integration/array_push.test.ts

## Notes
The old test had multiple unrelated failure modes (bad websocket URL, cwd-sensitive source loading, and a piece lifecycle mismatch). This version keeps the scope on runner + toolshed behavior and proves .push() works on current main.