### PR TITLE
Add SHA-256 benchmarks to `content-hash` package

### DIFF
--- a/packages/content-hash/bench/sha256.bench.ts
+++ b/packages/content-hash/bench/sha256.bench.ts
@@ -1,0 +1,91 @@
+/**
+ * Benchmarks comparing the three SHA-256 implementations across all fixtures
+ * and three call styles:
+ *
+ * * `sha256()` -- all-at-once function.
+ * * `createHasher()` one-shot -- a single `update()` then `digest()`.
+ * * `createHasher()` multi-byte variety -- many `update()` calls with
+ *   pseudo-randomly varying chunk sizes (mirrors the unit test of the same
+ *   name).
+ *
+ * Benchmarks are grouped by implementation (`sha256Deno`, `sha256Noble`,
+ * `sha256Wasm`).
+ */
+
+import { createHasherDeno, sha256Deno } from "../src/sha256-deno.ts";
+import { createHasherNoble, sha256Noble } from "../src/sha256-noble.ts";
+import { createHasherWasm, initWasm, sha256Wasm } from "../src/sha256-wasm.ts";
+import type { IncrementalHasher, Sha256Fn } from "../src/interface.ts";
+import { FIXTURES } from "../test/fixtures.ts";
+
+await initWasm();
+
+type CreateHasherFn = () => IncrementalHasher;
+
+interface Impl {
+  name: string;
+  sha256: Sha256Fn;
+  createHasher: CreateHasherFn;
+}
+
+const IMPLS: readonly Impl[] = [
+  { name: "sha256Deno", sha256: sha256Deno, createHasher: createHasherDeno },
+  { name: "sha256Noble", sha256: sha256Noble, createHasher: createHasherNoble },
+  { name: "sha256Wasm", sha256: sha256Wasm, createHasher: createHasherWasm },
+];
+
+/**
+ * Incremental hashing with varying chunk sizes, matching the "multi-byte
+ * variety" unit test.
+ */
+function hashMultiVariety(
+  createHasher: CreateHasherFn,
+  bytes: Uint8Array,
+  startingChunk: number,
+): Uint8Array {
+  const hasher = createHasher();
+  let oneLength = startingChunk;
+  let i = 0;
+  while (i < bytes.length) {
+    const someBytes = bytes.subarray(i, i + oneLength);
+    hasher.update(someBytes);
+    i += someBytes.length;
+    oneLength = ((oneLength + 7) * 1123) % (bytes.length - i + 1) + 1;
+  }
+  return hasher.digest();
+}
+
+for (const impl of IMPLS) {
+  let fixtureId = 0;
+  for (const { bytes } of FIXTURES) {
+    const id = fixtureId++;
+    const sizeLabel = `${bytes.length}B`;
+    const fixtureLabel = `#${String(id).padStart(2, "0")} (${sizeLabel})`;
+
+    Deno.bench({
+      name: `${fixtureLabel} sha256()`,
+      group: impl.name,
+      fn: () => {
+        impl.sha256(bytes);
+      },
+    });
+
+    Deno.bench({
+      name: `${fixtureLabel} createHasher() one-shot`,
+      group: impl.name,
+      fn: () => {
+        const hasher = impl.createHasher();
+        hasher.update(bytes);
+        hasher.digest();
+      },
+    });
+
+    Deno.bench({
+      name: `${fixtureLabel} createHasher() multi-variety`,
+      group: impl.name,
+      fn: () => {
+        hashMultiVariety(impl.createHasher, bytes, 10);
+      },
+    });
+  }
+}

--- a/packages/content-hash/deno.json
+++ b/packages/content-hash/deno.json
@@ -12,6 +12,10 @@
         "check",
         "just-test"
       ]
+    },
+    "bench": {
+      "description": "Run SHA-256 implementation benchmarks",
+      "command": "deno bench --allow-read"
     }
   },
   "test": {


### PR DESCRIPTION
## Summary

Adapts the `content-hash` unit test fixtures into a `deno bench` suite
that compares `sha256Deno`, `sha256Noble`, and `sha256Wasm` across three
call styles:

- `sha256()` — all-at-once function.
- `createHasher()` one-shot — a single `update()` then `digest()`.
- `createHasher()` multi-byte variety — many `update()` calls with
  pseudo-randomly varying chunk sizes (mirrors the unit test of the same
  name).

Benchmarks are grouped by implementation so Deno's baseline comparison
shows the three call styles side-by-side per group. Also wires up a
`bench` task in `packages/content-hash/deno.json`.

Run with:

```
cd packages/content-hash
deno task bench
```

## Benchmark findings

Captured locally on an Apple M5 Pro, Deno 2.7.8.

### Crossover by payload size

| Payload | Fastest |
|---|---|
| ≤ ~10 B | **Wasm** wins (lowest per-call overhead, ~280 ns for `sha256()`) |
| ~100 B | Wasm / Deno tied |
| ≥ ~235 B | **Deno** wins decisively |
| ≥ 1 KB | Deno is 3–11× faster than the others |

### Large-payload throughput (`sha256()`)

- Deno (`node:crypto` / OpenSSL): **~3.3 GB/s**
- Wasm (`hash-wasm`): ~490 MB/s
- Noble (pure JS): ~300 MB/s

### Call-style differences within an implementation

- `sha256()` vs. `createHasher()` one-shot: essentially identical for
  Deno; Noble and Wasm show a small penalty for the hasher path on tiny
  inputs.
- Multi-variety costs roughly 1.5–2× the one-shot on small inputs
  (chunking overhead), but collapses to near-zero extra on ≥10 KB where
  the actual hashing dominates.

### Takeaways

- Current priority order (Deno → Wasm → Noble) is correct for typical /
  large payloads.
- For tiny payloads (<100 B), Wasm actually beats Deno by ~1.4×, but
  this is unlikely to matter in practice.
- Noble is materially slower everywhere; it earns its place only as a
  last-resort fallback.

## Test plan

- [x] `deno task test` (in `packages/content-hash`) — 553 steps, 0 failed
- [x] `deno task bench` (in `packages/content-hash`) — produces the data above

## Performance Baseline

This PR just adds a benchmark, so the following accounts for a spurious performance check failure:

NEW_PERF_BASELINE: step: Build application = 21s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
