### PR TITLE
feat(transformer): Support default union schema syntax

### DIFF
--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -66,7 +66,7 @@ has been explicitly verified as problematic.
 
 | Violation | Fix |
 |-----------|-----|
-| array without `Default<T[], []>` where undefined would be invalid | Add a sensible default |
+| array without `T[] | Default<[]>` where undefined would be invalid | Add a sensible default |
 | missing `Writable<>` wrapper on values later mutated | Add `Writable<T>` to the relevant type |
 | `Map` or `Set` in serialized cell data | Use plain objects or arrays |
 | custom identity field where `equals()` is intended | Use `equals()` instead of ad hoc identity |

--- a/docs/common/concepts/computed/computed.md
+++ b/docs/common/concepts/computed/computed.md
@@ -5,12 +5,12 @@ import { computed, Default, NAME, pattern, UI } from "commonfabric";
 
 interface Item {
   title: string;
-  done: Default<boolean, false>;
-  category: Default<string, "Other">;
+  done: boolean | Default<false>;
+  category: string | Default<"Other">;
 }
 
 interface Input {
-  items: Default<Item[], []>;
+  items: Item[] | Default<[]>;
 }
 
 export default pattern<Input, Input>(({ items }) => {

--- a/docs/common/concepts/pattern.md
+++ b/docs/common/concepts/pattern.md
@@ -21,8 +21,8 @@ The type declares what data it expects and _how_ it is accessed.
 
 ```typescript
 interface TodoInput {
-  items?: Writable<Default<Todo[], []>>;
-  title?: Writable<Default<string, "untitled">>;
+  items?: Writable<Todo[] | Default<[]>>;
+  title?: Writable<string | Default<"untitled">>;
 }
 
 interface TodoOutput {
@@ -52,7 +52,7 @@ interface MyInput {
 **Guideline:**
 
 - Use `Writable<>` when you want to call .set(), .push(), .update(), etc on it. Use plain types otherwise. It's explicitly ok to pass a plain type to a pattern that requests Writable<>, the framework will handle write intent transparently.
-- Add `Default<Type, Value>` with a reasonable initial state for most inputs, unless it really makes no sense to use the pattern without that value being passed in.
+- Add `Type | Default<Value>` with a reasonable initial state for most inputs, unless it really makes no sense to use the pattern without that value being passed in.
 
 ### Output Types
 

--- a/docs/common/concepts/reactivity.md
+++ b/docs/common/concepts/reactivity.md
@@ -14,7 +14,7 @@ interface Item {}
 
 // ✅ Read-only - No Writable<> needed (still reactive!)
 interface ReadOnlyInput {
-  count: Default<number, 0>;         // Just display it (defaults to 0)
+  count: number | Default<0>;         // Just display it (defaults to 0)
   items: Item[];                     // Just map/display
   userName: string;                  // Just show it
 }
@@ -33,7 +33,7 @@ export const ReadOnly = pattern<ReadOnlyInput>(({ count, items, userName }) => {
 
 // ✅ Write access - Writable<> required
 interface WritableInput {
-  count: Writable<Default<number, 0>>;  // Will call count.set()
+  count: Writable<number | Default<0>>;  // Will call count.set()
   items: Writable<Item[]>;              // Will call items.push()
   title: Writable<string>;              // Will call title.set()
 }

--- a/docs/common/concepts/self-reference.md
+++ b/docs/common/concepts/self-reference.md
@@ -53,14 +53,14 @@ const createChild = action(() => {
 interface Input { title?: string; }
 
 // GOOD: Default<> ensures a value always exists
-interface Input { title: Default<string, "Untitled">; }
+interface Input { title: string | Default<"Untitled">; }
 ```
 
 ## Key Rules
 
 - **Both type params required:** Use `pattern<Input, Output>()` - single param `pattern<Input>()` will error if you access SELF
 - **`self` is typed as the output** - the instantiated piece itself, enabling recursive structures
-- **Inputs need defaults:** If an input feeds into the output, use `Default<T, V>` so `self` can bind
+- **Inputs need defaults:** If an input feeds into the output, use `T | Default<V>` so `self` can bind
 
 ## See Also
 

--- a/docs/common/concepts/types-and-schemas/contextual-types.md
+++ b/docs/common/concepts/types-and-schemas/contextual-types.md
@@ -9,12 +9,12 @@ import { Default, Writable, pattern, UI } from 'commonfabric';
 
 interface ShoppingItem {
   title: string;
-  done: Default<boolean, false>;
+  done: boolean | Default<false>;
 }
 
 // Context 1: Schema definition
 interface Input {
-  items: Default<ShoppingItem[], []>;
+  items: ShoppingItem[] | Default<[]>;
 }
 
 // Context 2: Pattern parameter (with Writable<> for write access)

--- a/docs/common/concepts/types-and-schemas/default.md
+++ b/docs/common/concepts/types-and-schemas/default.md
@@ -1,36 +1,68 @@
-## Default<T, Value>
+## Defaults
 
 **Use `Default<>` for any field that will be displayed in UI or used in computations.** Without a default, fields are `undefined` at runtime until data is explicitly set—causing errors like `Cannot read properties of undefined` when your pattern tries to render or compute.
 
 Specify default values in schemas:
 
 ```typescript
-import { Default } from 'commonfabric';
+import { Default } from "commonfabric";
 
 interface TodoItem {
   title: string;                      // Required
-  done: Default<boolean, false>;      // Defaults to false
-  category: Default<string, "Other">; // Defaults to "Other"
+  done: boolean | Default<false>;      // Defaults to false
+  category: string | Default<"Other">; // Defaults to "Other"
 }
 
 interface Input {
-  items: Default<TodoItem[], []>;     // Defaults to empty array
+  items: TodoItem[] | Default<[]>;     // Defaults to empty array
+}
+```
+
+Use `T | Default<Value>` when the default value is narrower than the runtime type:
+
+```typescript
+interface ProfileInput {
+  displayName: string | Default<"">;
+  avatarUrl: string | null | Default<null>;
+}
+```
+
+For object defaults, use `T | Default<Value>` when the default value is a valid
+`T`. Use `T | DeepDefault<Value>` when you only want to list part of an object
+and have defaults applied recursively to the listed properties:
+
+```typescript
+import { DeepDefault } from "commonfabric";
+
+interface Settings {
+  theme: string;
+  profile: {
+    displayName: string;
+    email: string;
+  };
+}
+
+interface SettingsInput {
+  settings: Settings | DeepDefault<{
+    theme: "light";
+    profile: { displayName: "" };
+  }>;
 }
 ```
 
 ### Writable<> with Default<>
 
-When you need **both** a default value **and** write access (`.push()`, `.set()`, `.get()`), wrap `Default<>` inside `Writable<>`:
+When you need **both** a default value **and** write access (`.push()`, `.set()`, `.get()`), wrap the defaulted type inside `Writable<>`:
 
 ```typescript
-import { Default, Writable } from 'commonfabric';
+import { Default, Writable } from "commonfabric";
 
 interface Board {
-  title: Default<string, "My Board">;
+  title: string | Default<"My Board">;
   // ❌ Writable<Column[]> - no default, will be undefined at runtime
-  // ❌ Default<Column[], []> - has default but no .push()/.set() methods
-  // ✅ Writable<Default<...>> - has both default AND write methods
-  columns: Writable<Default<Column[], []>>;
+  // ❌ Column[] | Default<[]> - has default but no .push()/.set() methods
+  // ✅ Writable<Column[] | Default<[]>> - has both default AND write methods
+  columns: Writable<Column[] | Default<[]>>;
 }
 ```
 

--- a/docs/common/conventions/wish.md
+++ b/docs/common/conventions/wish.md
@@ -56,7 +56,7 @@ Decorate your schema with a jsdoc comment containing a `#tag`:
 ```tsx
 /** Represents a small #note a user took to remember some text. */
 type Output = {
-  content: Default<string, "">;
+  content: string | Default<"">;
 };
 ```
 

--- a/docs/common/patterns/meta/drag-and-drop.md
+++ b/docs/common/patterns/meta/drag-and-drop.md
@@ -48,7 +48,7 @@ interface Item {
 }
 
 interface DragDropDemoInput {
-  availableItems: Default<Item[], [{ title: "Item A" }, { title: "Item B" }, { title: "Item C" }]>;
+  availableItems: Item[] | Default<[{ title: "Item A" }, { title: "Item B" }, { title: "Item C" }]>;
   droppedItems: Writable<Item[]>;
 }
 

--- a/docs/common/patterns/two-way-binding.md
+++ b/docs/common/patterns/two-way-binding.md
@@ -7,7 +7,7 @@ import { Default, NAME, pattern, UI, Writable, equals } from "commonfabric";
 
 interface Item {
   title: string;
-  done: Default<boolean, false>;
+  done: boolean | Default<false>;
 }
 
 interface Input {

--- a/docs/development/debugging/gotchas/filter-map-find-not-a-function.md
+++ b/docs/development/debugging/gotchas/filter-map-find-not-a-function.md
@@ -5,14 +5,14 @@
 **Tempting but wrong diagnosis:** "I need to unwrap with `.get()`"
 
 **Actual cause:** The value isn't an array (yet). This usually means:
-1. The array hasn't been initialized (missing `Default<T[], []>`)
+1. The array hasn't been initialized (missing `T[] | Default<[]>`)
 2. You're accessing a nested property that doesn't exist
 3. A computed is returning the wrong type
 
 ```typescript
 // CORRECT - Ensure array has a default value
 interface Input {
-  items: Default<Item[], []>;  // Defaults to empty array
+  items: Item[] | Default<[]>;  // Defaults to empty array
 }
 
 // CORRECT - Inside computed(), just use the value directly
@@ -30,7 +30,7 @@ const handleClear = handler<never, { items: Writable<Item[]> }>(
 **Diagnostic questions:**
 1. Is the source a `Writable<>`? -> Use `.get()` to read the value
 2. Is it a `computed()` or `lift()` result? -> Access directly, no `.get()`
-3. Is the value possibly undefined? -> Add `Default<T[], []>` to the interface
+3. Is the value possibly undefined? -> Add `T[] | Default<[]>` to the interface
 
 ## See Also
 

--- a/docs/features/CANONICAL_BASE_PATTERNS.md
+++ b/docs/features/CANONICAL_BASE_PATTERNS.md
@@ -684,7 +684,7 @@ export interface Contact extends PersonLike {
   phone?: string;
 }
 
-export default pattern<{ contact: Writable<Default<Contact, { name: "" }>> }, { contact: Contact }>(({ contact }) => {
+export default pattern<{ contact: Writable<Contact | Default<{ name: "" }>> }, { contact: Contact }>(({ contact }) => {
   return {
     [NAME]: computed(() => contact.name || "Contact"),
     [UI]: (
@@ -719,7 +719,7 @@ export interface FamilyMember extends PersonLike {
   giftPreferences?: string[];     // Added: for gift giving
 }
 
-export default pattern<{ member: Writable<Default<FamilyMember, { name: "", relationship: "" }>> }, { member: FamilyMember }>(({ member }) => {
+export default pattern<{ member: Writable<FamilyMember | Default<{ name: "", relationship: "" }>> }, { member: FamilyMember }>(({ member }) => {
   return {
     [NAME]: computed(() => member.name || "Family Member"),
     [UI]: (

--- a/docs/specs/PATTERN_TESTING_SPEC.md
+++ b/docs/specs/PATTERN_TESTING_SPEC.md
@@ -508,7 +508,7 @@ const decrement = handler<void, { value: Cell<number> }>(
   (_, { value }) => value.set(value.get() - 1)
 );
 
-interface Input { value: Default<number, 0>; }
+interface Input { value: number | Default<0>; }
 interface Output { value: number; increment: Stream<void>; decrement: Stream<void>; }
 
 export default pattern<Input, Output>(({ value }) => ({

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1912,12 +1912,17 @@ export type CreateNodeFactoryFunction = <T = any, R = any>(
 // This is a compile-time-only brand; at runtime Default<> is just T.
 export declare const DEFAULT_MARKER: unique symbol;
 
+type DefaultMarker<T> = { readonly [DEFAULT_MARKER]: T };
+
 // Default type for specifying default values in type definitions.
 // The DEFAULT_MARKER brand enables RequireDefaults<T> to detect which fields
 // have runtime-provided defaults and make them non-optional in pattern bodies.
 // Detection uses conditional type inference (not keyof) for performance.
+// Nullish-only defaults need a standalone marker because `null & Brand` and
+// `undefined & Brand` collapse to `never`.
 export type Default<T, V extends T = T> =
-  | (T & { readonly [DEFAULT_MARKER]: T })
+  | ([T] extends [null | undefined] ? DefaultMarker<T>
+    : T & DefaultMarker<T>)
   | T;
 
 /** Detect if T is `any` (used to avoid false positives in brand detection). */

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1977,6 +1977,34 @@ export type StripDefaultBrand<T> = Exclude<
   { readonly [DEFAULT_MARKER]: any }
 >;
 
+type RemoveRedundantUnionMembers<T, All = T> = T extends any
+  ? [Exclude<All, T>] extends [never] ? T
+  : T extends Exclude<All, T> ? never
+  : T
+  : never;
+
+type StripDefaultUnion<T> = RemoveRedundantUnionMembers<StripDefaultBrand<T>>;
+
+/**
+ * Cell-aware default stripping for pattern input normalization. The public
+ * StripDefaultBrand<T> intentionally stays shallow because it is used by cell
+ * interfaces in variance-sensitive positions.
+ */
+type StripDefaultField<T> = IsAny<T> extends true ? T
+  : StripDefaultFieldInner<StripDefaultUnion<T>>;
+
+type StripDefaultFieldInner<T> = T extends Cell<infer U>
+  ? Cell<StripDefaultUnion<U>>
+  : T extends OpaqueCell<infer U> ? OpaqueCell<StripDefaultUnion<U>>
+  : T extends Stream<infer U> ? Stream<StripDefaultUnion<U>>
+  : T extends ComparableCell<infer U> ? ComparableCell<StripDefaultUnion<U>>
+  : T extends ReadonlyCell<infer U> ? ReadonlyCell<StripDefaultUnion<U>>
+  : T extends WriteonlyCell<infer U> ? WriteonlyCell<StripDefaultUnion<U>>
+  : T extends AnyCell<infer U> ? AnyCell<StripDefaultUnion<U>>
+  : T extends AnyBrandedCell<infer U, infer Kind>
+    ? AnyBrandedCell<StripDefaultUnion<U>, Kind>
+  : T;
+
 /**
  * Maps a type T so that any fields carrying the DEFAULT_MARKER brand become required
  * (removing `?`) and have their brand stripped, while all other fields are left
@@ -1996,7 +2024,7 @@ export type RequireDefaults<T> =
   // `Default<X,V> | undefined`. In a non-distributive conditional context, `boolean extends true`
   // is `false`, but `true extends boolean` is `true` — correctly triggering the true branch.
   & {
-    [K in keyof T]: true extends IsDefaultField<T[K]> ? StripDefaultBrand<T[K]>
+    [K in keyof T]: true extends IsDefaultField<T[K]> ? StripDefaultField<T[K]>
       : T[K];
   }
   // Refinement: remove `?` from keys that carry the Default brand.
@@ -2007,7 +2035,7 @@ export type RequireDefaults<T> =
   // possibly-undefined in the pattern body despite being required.
   & {
     [K in keyof T as true extends IsDefaultField<T[K]> ? K : never]-?:
-      StripDefaultBrand<Exclude<T[K], undefined>>;
+      StripDefaultField<Exclude<T[K], undefined>>;
   };
 
 // Internal-only way to instantiate internal modules

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1925,6 +1925,14 @@ export type Default<T, V extends T = T> =
     : T & DefaultMarker<T>)
   | T;
 
+/**
+ * Marker for partial, recursive object defaults in `T | DeepDefault<V>` schema
+ * declarations. It is stripped from pattern body types by RequireDefaults<T>;
+ * schema generation reads `V` from the AST and applies it as object/property
+ * defaults.
+ */
+export type DeepDefault<V> = DefaultMarker<V>;
+
 /** Detect if T is `any` (used to avoid false positives in brand detection). */
 type IsAny<T> = 0 extends 1 & T ? true : false;
 

--- a/packages/patterns/activity-log/activity-log.tsx
+++ b/packages/patterns/activity-log/activity-log.tsx
@@ -36,8 +36,8 @@ export interface ActivityEvent {
 }
 
 interface ActivityLogInput {
-  events?: Writable<Default<ActivityEvent[], []>>;
-  mentioned?: Writable<Default<MentionablePiece[], []>>;
+  events?: Writable<ActivityEvent[] | Default<[]>>;
+  mentioned?: Writable<MentionablePiece[] | Default<[]>>;
 }
 
 /** An #activity-log for recording structured agent events. */

--- a/packages/patterns/address.tsx
+++ b/packages/patterns/address.tsx
@@ -36,15 +36,15 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface AddressModuleInput {
   /** Label for this address (Home, Work, Billing, etc.) */
-  label: Default<string, "Home">;
+  label: string | Default<"Home">;
   /** Street address */
-  street: Default<string, "">;
+  street: string | Default<"">;
   /** City */
-  city: Default<string, "">;
+  city: string | Default<"">;
   /** State/Province */
-  state: Default<string, "">;
+  state: string | Default<"">;
   /** ZIP/Postal code */
-  zip: Default<string, "">;
+  zip: string | Default<"">;
 }
 
 // ===== The Pattern =====

--- a/packages/patterns/age-category.tsx
+++ b/packages/patterns/age-category.tsx
@@ -91,7 +91,7 @@ export const MODULE_METADATA: ModuleMetadata = {
 
 // ===== Interface =====
 export interface AgeCategoryModuleInput {
-  ageCategory: Default<AgeCategory, "adult">;
+  ageCategory: AgeCategory | Default<"adult">;
 }
 
 // ===== Constants =====

--- a/packages/patterns/agent/agent.tsx
+++ b/packages/patterns/agent/agent.tsx
@@ -20,14 +20,14 @@ export type { AgentPiece };
 // ===== Types =====
 
 interface AgentInput {
-  agentName?: Writable<Default<string, "Unnamed Agent">>;
-  directive?: Writable<Default<string, "">>;
-  enabled?: Writable<Default<boolean, true>>;
-  learned?: Writable<Default<string, "">>;
-  status?: Writable<Default<AgentStatus, "idle">>;
-  lastRun?: Writable<Default<string, "">>;
-  lastRunSummary?: Writable<Default<string, "">>;
-  isAgent?: Default<boolean, true>;
+  agentName?: Writable<string | Default<"Unnamed Agent">>;
+  directive?: Writable<string | Default<"">>;
+  enabled?: Writable<boolean | Default<true>>;
+  learned?: Writable<string | Default<"">>;
+  status?: Writable<AgentStatus | Default<"idle">>;
+  lastRun?: Writable<string | Default<"">>;
+  lastRunSummary?: Writable<string | Default<"">>;
+  isAgent?: boolean | Default<true>;
 }
 
 /** An #agent piece — autonomous worker with directive, learned state, and status. */

--- a/packages/patterns/airtable/airtable-importer.tsx
+++ b/packages/patterns/airtable/airtable-importer.tsx
@@ -31,8 +31,8 @@ type BaseInfo = { id: string; name: string };
 type TableInfo = { id: string; name: string };
 
 interface Input {
-  selectedBaseId: Default<string, "">;
-  selectedTableId: Default<string, "">;
+  selectedBaseId: string | Default<"">;
+  selectedTableId: string | Default<"">;
 }
 
 /** Import records from an Airtable base. #airtableImporter */

--- a/packages/patterns/airtable/core/airtable-auth.tsx
+++ b/packages/patterns/airtable/core/airtable-auth.tsx
@@ -161,49 +161,53 @@ export function createPreviewUI(
  * Use direct property access: `airtableAuthPiece.auth`
  */
 export type AirtableAuth = {
-  accessToken: Default<Secret<string>, "">;
-  tokenType: Default<string, "">;
-  scope: Default<string[], []>;
-  expiresIn: Default<number, 0>;
-  expiresAt: Default<number, 0>;
-  refreshToken: Default<Secret<string>, "">;
-  user: Default<{
+  accessToken: Secret<string> | Default<"">;
+  tokenType: string | Default<"">;
+  scope: string[] | Default<[]>;
+  expiresIn: number | Default<0>;
+  expiresAt: number | Default<0>;
+  refreshToken: Secret<string> | Default<"">;
+  user: {
     email: string;
     name: string;
     picture: string;
-  }, { email: ""; name: ""; picture: "" }>;
+  } | Default<{ email: ""; name: ""; picture: "" }>;
 };
 
 // Selected scopes configuration
 export type SelectedScopes = {
-  "data.records:read": Default<boolean, true>;
-  "data.records:write": Default<boolean, false>;
-  "data.recordComments:read": Default<boolean, false>;
-  "data.recordComments:write": Default<boolean, false>;
-  "schema.bases:read": Default<boolean, true>;
-  "schema.bases:write": Default<boolean, false>;
-  "webhook:manage": Default<boolean, false>;
+  "data.records:read": boolean | Default<true>;
+  "data.records:write": boolean | Default<false>;
+  "data.recordComments:read": boolean | Default<false>;
+  "data.recordComments:write": boolean | Default<false>;
+  "schema.bases:read": boolean | Default<true>;
+  "schema.bases:write": boolean | Default<false>;
+  "webhook:manage": boolean | Default<false>;
 };
 
 interface Input {
-  selectedScopes: Default<SelectedScopes, {
-    "data.records:read": true;
-    "data.records:write": false;
-    "data.recordComments:read": false;
-    "data.recordComments:write": false;
-    "schema.bases:read": true;
-    "schema.bases:write": false;
-    "webhook:manage": false;
-  }>;
-  auth: Default<AirtableAuth, {
-    accessToken: "";
-    tokenType: "";
-    scope: [];
-    expiresIn: 0;
-    expiresAt: 0;
-    refreshToken: "";
-    user: { email: ""; name: ""; picture: "" };
-  }>;
+  selectedScopes:
+    | SelectedScopes
+    | Default<{
+      "data.records:read": true;
+      "data.records:write": false;
+      "data.recordComments:read": false;
+      "data.recordComments:write": false;
+      "schema.bases:read": true;
+      "schema.bases:write": false;
+      "webhook:manage": false;
+    }>;
+  auth:
+    | AirtableAuth
+    | Default<{
+      accessToken: "";
+      tokenType: "";
+      scope: [];
+      expiresIn: 0;
+      expiresAt: 0;
+      refreshToken: "";
+      user: { email: ""; name: ""; picture: "" };
+    }>;
 }
 
 /** Airtable OAuth authentication for Airtable APIs. #airtableAuth */

--- a/packages/patterns/annotation.tsx
+++ b/packages/patterns/annotation.tsx
@@ -48,13 +48,13 @@ export interface AnnotationPiece {
 }
 
 export interface AnnotationInput {
-  content: Writable<Default<string, "">>;
-  kind: Writable<Default<AnnotationKind, "note">>;
-  status: Writable<Default<AnnotationStatus, "open">>;
-  targetPiece: Writable<Default<MentionablePiece | null, null>>;
-  blockedBy: Writable<Default<AnnotationPiece[], []>>;
-  isAnnotation: Default<boolean, true>;
-  isHidden: Default<boolean, false>;
+  content: Writable<string | Default<"">>;
+  kind: Writable<AnnotationKind | Default<"note">>;
+  status: Writable<AnnotationStatus | Default<"open">>;
+  targetPiece: Writable<MentionablePiece | null | Default<null>>;
+  blockedBy: Writable<AnnotationPiece[] | Default<[]>>;
+  isAnnotation: boolean | Default<true>;
+  isHidden: boolean | Default<false>;
 }
 
 /** An #annotation pointing at an existing cell, optionally blocked by other annotations. */

--- a/packages/patterns/auth/create-auth-manager.tsx
+++ b/packages/patterns/auth/create-auth-manager.tsx
@@ -45,9 +45,9 @@ export type { AuthInfo, AuthState, TokenExpiryWarning };
 // =============================================================================
 
 export interface AuthManagerInput {
-  requiredScopes?: Default<string[], []>;
-  accountType?: Default<"default" | "personal" | "work", "default">;
-  debugMode?: Default<boolean, false>;
+  requiredScopes?: string[] | Default<[]>;
+  accountType?: "default" | "personal" | "work" | Default<"default">;
+  debugMode?: boolean | Default<false>;
 }
 
 export interface AuthManagerOutput {

--- a/packages/patterns/base/contact-types.tsx
+++ b/packages/patterns/base/contact-types.tsx
@@ -27,17 +27,17 @@ export interface PersonLike {
 // ============================================================================
 
 export interface Address {
-  label: Default<string, "">; // "Home", "Work", etc.
-  street: Default<string, "">;
-  city: Default<string, "">;
-  state: Default<string, "">;
-  zip: Default<string, "">;
-  country: Default<string, "">;
+  label: string | Default<"">; // "Home", "Work", etc.
+  street: string | Default<"">;
+  city: string | Default<"">;
+  state: string | Default<"">;
+  zip: string | Default<"">;
+  country: string | Default<"">;
 }
 
 export interface SocialProfile {
-  platform: Default<string, "">; // "LinkedIn", "Twitter", etc.
-  url: Default<string, "">;
+  platform: string | Default<"">; // "LinkedIn", "Twitter", etc.
+  url: string | Default<"">;
 }
 
 // ============================================================================
@@ -45,9 +45,9 @@ export interface SocialProfile {
 // ============================================================================
 
 export interface Birthday {
-  month: Default<number, 0>; // 1-12, 0 = unset
-  day: Default<number, 0>; // 1-31, 0 = unset
-  year: Default<number, 0>; // 4-digit year, 0 = unknown
+  month: number | Default<0>; // 1-12, 0 = unset
+  day: number | Default<0>; // 1-31, 0 = unset
+  year: number | Default<0>; // 4-digit year, 0 = unknown
 }
 
 // ============================================================================
@@ -58,21 +58,21 @@ export interface Person extends PersonLike {
   firstName: string;
   lastName: string;
   // Name extensions
-  middleName: Default<string, "">;
-  nickname: Default<string, "">; // preferred name / what they go by
-  prefix: Default<string, "">; // Dr., Mr., Prof.
-  suffix: Default<string, "">; // Jr., III, Ph.D.
+  middleName: string | Default<"">;
+  nickname: string | Default<"">; // preferred name / what they go by
+  prefix: string | Default<"">; // Dr., Mr., Prof.
+  suffix: string | Default<"">; // Jr., III, Ph.D.
   // Identity metadata
-  pronouns: Default<string, "">; // freeform: "he/him", "they/them"
-  birthday: Default<Birthday, { month: 0; day: 0; year: 0 }>;
-  photo: Default<string, "">; // URL or data reference
+  pronouns: string | Default<"">; // freeform: "he/him", "they/them"
+  birthday: Birthday | Default<{ month: 0; day: 0; year: 0 }>;
+  photo: string | Default<"">; // URL or data reference
   // Contact fields
-  email: Default<string, "">;
-  phone: Default<string, "">;
-  notes: Default<string, "">;
-  tags: Default<string[], []>;
-  addresses: Default<Address[], []>;
-  socialProfiles: Default<SocialProfile[], []>;
+  email: string | Default<"">;
+  phone: string | Default<"">;
+  notes: string | Default<"">;
+  tags: string[] | Default<[]>;
+  addresses: Address[] | Default<[]>;
+  socialProfiles: SocialProfile[] | Default<[]>;
 }
 
 // ============================================================================
@@ -82,13 +82,13 @@ export interface Person extends PersonLike {
 export interface FamilyMember extends PersonLike {
   firstName: string;
   lastName: string;
-  relationship: Default<string, "">;
-  birthday: Default<string, "">; // ISO date string (YYYY-MM-DD)
-  dietaryRestrictions: Default<string[], []>;
-  notes: Default<string, "">;
-  tags: Default<string[], []>;
-  allergies: Default<string[], []>;
-  giftIdeas: Default<string[], []>;
+  relationship: string | Default<"">;
+  birthday: string | Default<"">; // ISO date string (YYYY-MM-DD)
+  dietaryRestrictions: string[] | Default<[]>;
+  notes: string | Default<"">;
+  tags: string[] | Default<[]>;
+  allergies: string[] | Default<[]>;
+  giftIdeas: string[] | Default<[]>;
 }
 
 // ============================================================================
@@ -111,7 +111,7 @@ export interface ContactPiece {
 
 export interface ContactGroup {
   name: string;
-  contactIndices: Default<number[], []>; // indices into contacts[]
+  contactIndices: number[] | Default<[]>; // indices into contacts[]
 }
 
 // Default export required by cf check infrastructure

--- a/packages/patterns/base/contacts.tsx
+++ b/packages/patterns/base/contacts.tsx
@@ -41,8 +41,8 @@ import FamilyMemberPattern from "./family-member.tsx";
 
 interface Input {
   // Store piece results, not raw data
-  contacts: Writable<Default<ContactPiece[], []>>;
-  groups: Writable<Default<ContactGroup[], []>>;
+  contacts: Writable<ContactPiece[] | Default<[]>>;
+  groups: Writable<ContactGroup[] | Default<[]>>;
 }
 
 interface Output {

--- a/packages/patterns/base/family-member.tsx
+++ b/packages/patterns/base/family-member.tsx
@@ -55,20 +55,18 @@ const RELATIONSHIP_OPTIONS = [
 
 interface Input {
   member: Writable<
-    Default<
-      FamilyMember,
-      {
-        firstName: "";
-        lastName: "";
-        relationship: "";
-        birthday: "";
-        dietaryRestrictions: [];
-        notes: "";
-        tags: [];
-        allergies: [];
-        giftIdeas: [];
-      }
-    >
+    | FamilyMember
+    | Default<{
+      firstName: "";
+      lastName: "";
+      relationship: "";
+      birthday: "";
+      dietaryRestrictions: [];
+      notes: "";
+      tags: [];
+      allergies: [];
+      giftIdeas: [];
+    }>
   >;
   // Optional: reactive source of sibling contacts for sameAs linking.
   sameAs?: Writable<ContactPiece[]>;

--- a/packages/patterns/base/person.tsx
+++ b/packages/patterns/base/person.tsx
@@ -182,26 +182,24 @@ const removeSocialProfile = handler<
 
 interface Input {
   person: Writable<
-    Default<
-      Person,
-      {
-        firstName: "";
-        lastName: "";
-        middleName: "";
-        nickname: "";
-        prefix: "";
-        suffix: "";
-        pronouns: "";
-        birthday: { month: 0; day: 0; year: 0 };
-        photo: "";
-        email: "";
-        phone: "";
-        notes: "";
-        tags: [];
-        addresses: [];
-        socialProfiles: [];
-      }
-    >
+    | Person
+    | Default<{
+      firstName: "";
+      lastName: "";
+      middleName: "";
+      nickname: "";
+      prefix: "";
+      suffix: "";
+      pronouns: "";
+      birthday: { month: 0; day: 0; year: 0 };
+      photo: "";
+      email: "";
+      phone: "";
+      notes: "";
+      tags: [];
+      addresses: [];
+      socialProfiles: [];
+    }>
   >;
   // Optional: reactive source of sibling contacts for sameAs linking.
   sameAs?: Writable<ContactPiece[]>;

--- a/packages/patterns/battleship/multiplayer/repro-minimal.tsx
+++ b/packages/patterns/battleship/multiplayer/repro-minimal.tsx
@@ -18,7 +18,7 @@
  * - otherData.items[0]?.id: 10
  *
  * KEY CONDITIONS TO TRIGGER:
- * 1. Parent pattern owns cells with Writable<Default<T | null, null>>
+ * 1. Parent pattern owns cells with Writable<T | null | Default<null>>
  * 2. Child pattern receives cells as Writable<T | null> (no Default wrapper)
  * 3. Cell data is SET by one browser session (piece instance)
  * 4. Cell data is READ by a DIFFERENT browser session (piece instance)
@@ -159,12 +159,12 @@ const Child = pattern<ChildInput, object>(
 // ============================================================================
 
 /**
- * Parent uses Writable<Default<T>> but child receives Writable<T>.
+ * Parent uses Writable<T | Default<...>> but child receives Writable<T>.
  * This type mismatch may be related to the bug.
  */
 interface ParentInput {
-  data1: Writable<Default<Container | null, null>>;
-  data2: Writable<Default<Container | null, null>>;
+  data1: Writable<Container | null | Default<null>>;
+  data2: Writable<Container | null | Default<null>>;
 }
 
 let nav:

--- a/packages/patterns/battleship/multiplayer/schemas.tsx
+++ b/packages/patterns/battleship/multiplayer/schemas.tsx
@@ -103,18 +103,15 @@ export function createInitialShots(): ShotsState {
  * to provide initial values for the complex state objects.
  */
 export interface LobbyState {
-  gameName: Default<string, "Battleship">;
-  player1: Writable<Default<PlayerData | null, null>>;
-  player2: Writable<Default<PlayerData | null, null>>;
+  gameName: string | Default<"Battleship">;
+  player1: Writable<PlayerData | null | Default<null>>;
+  player2: Writable<PlayerData | null | Default<null>>;
   shots: Writable<
-    Default<
-      ShotsState,
-      { 1: []; 2: [] }
-    >
+    ShotsState | Default<{ 1: []; 2: [] }>
   >;
   gameState: Writable<
-    Default<
-      GameState,
+    | GameState
+    | Default<
       { phase: "waiting"; currentTurn: 1; winner: null; lastMessage: "" }
     >
   >;

--- a/packages/patterns/birthday.tsx
+++ b/packages/patterns/birthday.tsx
@@ -75,11 +75,11 @@ const getMonthName = (month: string): string => {
 // ===== Types =====
 export interface BirthdayModuleInput {
   /** Birth month (1-12 as string) */
-  birthMonth: Default<string, "">;
+  birthMonth: string | Default<"">;
   /** Birth day (1-31 as string) */
-  birthDay: Default<string, "">;
+  birthDay: string | Default<"">;
   /** Birth year (e.g., "1990") */
-  birthYear: Default<string, "">;
+  birthYear: string | Default<"">;
 }
 
 // ===== The Pattern =====

--- a/packages/patterns/bookmarks.tsx
+++ b/packages/patterns/bookmarks.tsx
@@ -21,12 +21,12 @@ import {
 // ===== Types =====
 interface Bookmark {
   url: string;
-  title: Default<string, "">;
-  description: Default<string, "">;
+  title: string | Default<"">;
+  description: string | Default<"">;
 }
 
 interface BookmarksInput {
-  bookmarks?: Writable<Default<Bookmark[], []>>;
+  bookmarks?: Writable<Bookmark[] | Default<[]>>;
 }
 
 interface BookmarksOutput {

--- a/packages/patterns/budget-tracker/main.tsx
+++ b/packages/patterns/budget-tracker/main.tsx
@@ -5,8 +5,8 @@ import ExpenseForm from "./expense-form.tsx";
 
 // Use SINGLE type parameter to avoid conflict bug with sub-pattern rendering
 interface State {
-  expenses: Writable<Default<Expense[], []>>;
-  budgets: Writable<Default<CategoryBudget[], []>>;
+  expenses: Writable<Expense[] | Default<[]>>;
+  budgets: Writable<CategoryBudget[] | Default<[]>>;
 }
 
 export default pattern<State>(({ expenses, budgets }) => {

--- a/packages/patterns/budget-tracker/schemas.tsx
+++ b/packages/patterns/budget-tracker/schemas.tsx
@@ -10,7 +10,7 @@ import { Default } from "commonfabric";
 export interface Expense {
   description: string;
   amount: number;
-  category: Default<string, "Other">;
+  category: string | Default<"Other">;
   date: string; // YYYY-MM-DD
 }
 

--- a/packages/patterns/calendar/calendar.tsx
+++ b/packages/patterns/calendar/calendar.tsx
@@ -19,7 +19,7 @@ import EventDetail, { type EventPiece } from "./event-detail.tsx";
 export type { EventPiece };
 
 interface CalendarInput {
-  events?: Writable<Default<EventPiece[], []>>;
+  events?: Writable<EventPiece[] | Default<[]>>;
 }
 
 interface CalendarOutput {

--- a/packages/patterns/calendar/event-detail.tsx
+++ b/packages/patterns/calendar/event-detail.tsx
@@ -12,10 +12,10 @@ import {
 
 /** Input for creating a new event detail piece */
 interface EventDetailInput {
-  title?: Writable<Default<string, "">>;
-  date?: Writable<Default<string, "">>;
-  time?: Writable<Default<string, "">>;
-  notes?: Writable<Default<string, "">>;
+  title?: Writable<string | Default<"">>;
+  date?: Writable<string | Default<"">>;
+  time?: Writable<string | Default<"">>;
+  notes?: Writable<string | Default<"">>;
 }
 
 /**

--- a/packages/patterns/card-piles/main.tsx
+++ b/packages/patterns/card-piles/main.tsx
@@ -49,8 +49,8 @@ export const defaultPile2: Card[] = [
 ];
 
 interface CardPilesInput {
-  pile1: Writable<Default<Card[], typeof defaultPile1>>;
-  pile2: Writable<Default<Card[], typeof defaultPile2>>;
+  pile1: Writable<Card[] | Default<typeof defaultPile1>>;
+  pile2: Writable<Card[] | Default<typeof defaultPile2>>;
 }
 
 interface CardPilesOutput {

--- a/packages/patterns/catalog/catalog.tsx
+++ b/packages/patterns/catalog/catalog.tsx
@@ -22,95 +22,97 @@ export interface Category {
   items: CategoryItem[];
 }
 interface CatalogInput {
-  selectedStory?: Writable<Default<string, "button">>;
-  categories?: Default<Category[], [
-    {
-      name: "Overview";
-      items: [{ id: "kitchen-sink"; label: "Kitchen Sink" }];
-    },
-    {
-      name: "Inputs";
-      items: [
-        { id: "button"; label: "Button" },
-        { id: "checkbox"; label: "Checkbox" },
-        { id: "code-editor"; label: "Code Editor" },
-        { id: "input"; label: "Input" },
-        { id: "picker"; label: "Picker" },
-        { id: "textarea"; label: "Textarea" },
-        { id: "select"; label: "Select" },
-        { id: "slider"; label: "Slider" },
-        { id: "switch"; label: "Switch" },
-        { id: "toggle"; label: "Toggle" },
-        { id: "toggle-group"; label: "Toggle Group" },
-        { id: "message-input"; label: "Message Input" },
-        { id: "calendar"; label: "Calendar" },
-        { id: "radio"; label: "Radio" },
-        { id: "autocomplete"; label: "Autocomplete" },
-        { id: "tags"; label: "Tags" },
-        { id: "fab"; label: "FAB" },
-      ];
-    },
-    {
-      name: "Layout";
-      items: [
-        { id: "card"; label: "Card" },
-        { id: "modal"; label: "Modal" },
-        { id: "toolbar"; label: "Toolbar" },
-        { id: "vstack"; label: "VStack" },
-        { id: "hstack"; label: "HStack" },
-        { id: "vgroup"; label: "VGroup" },
-        { id: "hgroup"; label: "HGroup" },
-        { id: "vscroll"; label: "VScroll" },
-        { id: "hscroll"; label: "HScroll" },
-        { id: "grid"; label: "Grid" },
-      ];
-    },
-    {
-      name: "Display";
-      items: [
-        { id: "heading"; label: "Heading" },
-        { id: "label"; label: "Label" },
-        { id: "chip"; label: "Chip" },
-        { id: "badge"; label: "Badge" },
-        { id: "separator"; label: "Separator" },
-        { id: "markdown"; label: "Markdown" },
-        { id: "svg"; label: "SVG" },
-        { id: "kbd"; label: "Kbd" },
-        { id: "code-editor"; label: "Code Editor" },
-        { id: "copy-button"; label: "Copy Button" },
-      ];
-    },
-    {
-      name: "Feedback";
-      items: [
-        { id: "progress"; label: "Progress" },
-        { id: "loader"; label: "Loader" },
-        { id: "skeleton"; label: "Skeleton" },
-        { id: "alert"; label: "Alert" },
-      ];
-    },
-    {
-      name: "Interactive";
-      items: [
-        { id: "collapsible"; label: "Collapsible" },
-        { id: "tab-list"; label: "Tab List" },
-        { id: "tabs"; label: "Tabs" },
-        { id: "table"; label: "Table" },
-      ];
-    },
-    {
-      name: "Data Visualization";
-      items: [{ id: "chart"; label: "Chart" }];
-    },
-    {
-      name: "Patterns";
-      items: [
-        { id: "note"; label: "Note" },
-        { id: "vignette-recipe"; label: "Vignette: Recipe" },
-        { id: "vignette-finance"; label: "Vignette: Finance" },
-      ];
-    },
-  ]>;
+  selectedStory?: Writable<string | Default<"button">>;
+  categories?:
+    | Category[]
+    | Default<[
+      {
+        name: "Overview";
+        items: [{ id: "kitchen-sink"; label: "Kitchen Sink" }];
+      },
+      {
+        name: "Inputs";
+        items: [
+          { id: "button"; label: "Button" },
+          { id: "checkbox"; label: "Checkbox" },
+          { id: "code-editor"; label: "Code Editor" },
+          { id: "input"; label: "Input" },
+          { id: "picker"; label: "Picker" },
+          { id: "textarea"; label: "Textarea" },
+          { id: "select"; label: "Select" },
+          { id: "slider"; label: "Slider" },
+          { id: "switch"; label: "Switch" },
+          { id: "toggle"; label: "Toggle" },
+          { id: "toggle-group"; label: "Toggle Group" },
+          { id: "message-input"; label: "Message Input" },
+          { id: "calendar"; label: "Calendar" },
+          { id: "radio"; label: "Radio" },
+          { id: "autocomplete"; label: "Autocomplete" },
+          { id: "tags"; label: "Tags" },
+          { id: "fab"; label: "FAB" },
+        ];
+      },
+      {
+        name: "Layout";
+        items: [
+          { id: "card"; label: "Card" },
+          { id: "modal"; label: "Modal" },
+          { id: "toolbar"; label: "Toolbar" },
+          { id: "vstack"; label: "VStack" },
+          { id: "hstack"; label: "HStack" },
+          { id: "vgroup"; label: "VGroup" },
+          { id: "hgroup"; label: "HGroup" },
+          { id: "vscroll"; label: "VScroll" },
+          { id: "hscroll"; label: "HScroll" },
+          { id: "grid"; label: "Grid" },
+        ];
+      },
+      {
+        name: "Display";
+        items: [
+          { id: "heading"; label: "Heading" },
+          { id: "label"; label: "Label" },
+          { id: "chip"; label: "Chip" },
+          { id: "badge"; label: "Badge" },
+          { id: "separator"; label: "Separator" },
+          { id: "markdown"; label: "Markdown" },
+          { id: "svg"; label: "SVG" },
+          { id: "kbd"; label: "Kbd" },
+          { id: "code-editor"; label: "Code Editor" },
+          { id: "copy-button"; label: "Copy Button" },
+        ];
+      },
+      {
+        name: "Feedback";
+        items: [
+          { id: "progress"; label: "Progress" },
+          { id: "loader"; label: "Loader" },
+          { id: "skeleton"; label: "Skeleton" },
+          { id: "alert"; label: "Alert" },
+        ];
+      },
+      {
+        name: "Interactive";
+        items: [
+          { id: "collapsible"; label: "Collapsible" },
+          { id: "tab-list"; label: "Tab List" },
+          { id: "tabs"; label: "Tabs" },
+          { id: "table"; label: "Table" },
+        ];
+      },
+      {
+        name: "Data Visualization";
+        items: [{ id: "chart"; label: "Chart" }];
+      },
+      {
+        name: "Patterns";
+        items: [
+          { id: "note"; label: "Note" },
+          { id: "vignette-recipe"; label: "Vignette: Recipe" },
+          { id: "vignette-finance"; label: "Vignette: Finance" },
+        ];
+      },
+    ]>;
 }
 
 interface CatalogOutput {

--- a/packages/patterns/cell-link.tsx
+++ b/packages/patterns/cell-link.tsx
@@ -1,7 +1,7 @@
 import { Default, NAME, pattern, UI } from "commonfabric";
 import Note from "./notes/note.tsx";
 
-export default pattern<{ title: Default<string, "Suggestion Tester"> }>(
+export default pattern<{ title: string | Default<"Suggestion Tester"> }>(
   ({ title }) => {
     const note = Note({
       title: "Demo",

--- a/packages/patterns/chatbot.tsx
+++ b/packages/patterns/chatbot.tsx
@@ -62,7 +62,7 @@ const clearChat = handler(
 );
 
 type ChatInput = {
-  messages?: Writable<Default<Array<BuiltInLLMMessage>, []>>;
+  messages?: Writable<Array<BuiltInLLMMessage> | Default<[]>>;
   tools?: any;
   theme?: any;
   system?: string;

--- a/packages/patterns/compiler.tsx
+++ b/packages/patterns/compiler.tsx
@@ -11,10 +11,11 @@ import {
 } from "commonfabric";
 
 type Input = {
-  code: Default<
-    string,
-    'import { computed, Default, handler, NAME, pattern, UI, Writable } from "commonfabric";\n\ninterface Input {\n  value: Default<number, 0>;\n}\n\nconst increment = handler<unknown, { value: Writable<number> }>((_, state) => {\n  state.value.set(state.value.get() + 1);\n});\n\nconst decrement = handler<unknown, { value: Writable<number> }>((_, state) => {\n  state.value.set(state.value.get() - 1);\n});\n\nexport default pattern<Input>(({ value }) => {\n  return {\n    [NAME]: computed(() => `Simple counter: ${value}`),\n    [UI]: (\n      <div>\n        <cf-button onClick={decrement({ value })}>-</cf-button>\n        <b>{value}</b>\n        <cf-button onClick={increment({ value })}>+</cf-button>\n      </div>\n    ),\n    value,\n  };\n});\n'
-  >;
+  code:
+    | string
+    | Default<
+      'import { computed, Default, handler, NAME, pattern, UI, Writable } from "commonfabric";\n\ninterface Input {\n  value: number | Default<0>;\n}\n\nconst increment = handler<unknown, { value: Writable<number> }>((_, state) => {\n  state.value.set(state.value.get() + 1);\n});\n\nconst decrement = handler<unknown, { value: Writable<number> }>((_, state) => {\n  state.value.set(state.value.get() - 1);\n});\n\nexport default pattern<Input>(({ value }) => {\n  return {\n    [NAME]: computed(() => `Simple counter: ${value}`),\n    [UI]: (\n      <div>\n        <cf-button onClick={decrement({ value })}>-</cf-button>\n        <b>{value}</b>\n        <cf-button onClick={increment({ value })}>+</cf-button>\n      </div>\n    ),\n    value,\n  };\n});\n'
+    >;
 };
 
 const updateCode = handler<

--- a/packages/patterns/contacts/contact-book.tsx
+++ b/packages/patterns/contacts/contact-book.tsx
@@ -27,12 +27,12 @@ export const matchesSearch = (contact: Contact, query: string): boolean => {
 interface Relationship {
   fromName: string;
   toName: string;
-  label: Default<string, "">;
+  label: string | Default<"">;
 }
 
 interface ContactBookInput {
-  contacts: Writable<Default<Contact[], []>>;
-  relationships: Writable<Default<Relationship[], []>>;
+  contacts: Writable<Contact[] | Default<[]>>;
+  relationships: Writable<Relationship[] | Default<[]>>;
 }
 
 interface ContactBookOutput {

--- a/packages/patterns/contacts/contact-detail.tsx
+++ b/packages/patterns/contacts/contact-detail.tsx
@@ -3,11 +3,11 @@ import { computed, Default, NAME, pattern, UI, Writable } from "commonfabric";
 /** Raw data shape - use in collection patterns */
 export interface Contact {
   name: string;
-  email: Default<string, "">;
-  phone: Default<string, "">;
-  company: Default<string, "">;
-  tags: Default<string[], []>;
-  notes: Default<string, "">;
+  email: string | Default<"">;
+  phone: string | Default<"">;
+  company: string | Default<"">;
+  tags: string[] | Default<[]>;
+  notes: string | Default<"">;
   createdAt: number;
 }
 

--- a/packages/patterns/counter/counter.tsx
+++ b/packages/patterns/counter/counter.tsx
@@ -14,7 +14,7 @@ import {
 // ===== Types =====
 
 interface CounterInput {
-  value?: Writable<Default<number, 0>>;
+  value?: Writable<number | Default<0>>;
 }
 
 interface CounterOutput {

--- a/packages/patterns/custom-field.tsx
+++ b/packages/patterns/custom-field.tsx
@@ -84,11 +84,11 @@ export const MODULE_METADATA: ModuleMetadata = {
 
 export interface CustomFieldModuleInput {
   /** Field name (e.g., "Employee ID", "SKU") */
-  name: Default<string, "">;
+  name: string | Default<"">;
   /** Field value (stored as string, parsed by UI) */
-  value: Default<string, "">;
+  value: string | Default<"">;
   /** Value type determines input UI */
-  valueType: Default<CustomFieldValueType, "text">;
+  valueType: CustomFieldValueType | Default<"text">;
 }
 
 // Output interface with unknown for UI properties to prevent OOM (CT-1148)

--- a/packages/patterns/deep-research.tsx
+++ b/packages/patterns/deep-research.tsx
@@ -61,11 +61,10 @@ const showRefineInput = handler<unknown, { showRefine: Writable<boolean> }>(
 
 export default pattern<
   {
-    situation: Default<
-      string,
-      "What are the latest developments in AI agents?"
-    >;
-    messages?: Writable<Default<Array<BuiltInLLMMessage>, []>>;
+    situation:
+      | string
+      | Default<"What are the latest developments in AI agents?">;
+    messages?: Writable<Array<BuiltInLLMMessage> | Default<[]>>;
     context?: { [id: string]: any };
   },
   { result: any; [UI]: VNode }

--- a/packages/patterns/deprecated/array-in-cell-ast-nocomponents.tsx
+++ b/packages/patterns/deprecated/array-in-cell-ast-nocomponents.tsx
@@ -1,12 +1,12 @@
 import { Default, handler, NAME, pattern, UI, Writable } from "commonfabric";
 
 interface Item {
-  text: Default<string, "">;
+  text: string | Default<"">;
 }
 
 interface InputSchema {
-  title: Default<string, "untitled">;
-  items: Default<Item[], []>;
+  title: string | Default<"untitled">;
+  items: Item[] | Default<[]>;
 }
 
 type InputEventType = {

--- a/packages/patterns/deprecated/array-in-cell-with-remove-ast-nocomponents.tsx
+++ b/packages/patterns/deprecated/array-in-cell-with-remove-ast-nocomponents.tsx
@@ -1,12 +1,12 @@
 import { Default, handler, NAME, pattern, UI, Writable } from "commonfabric";
 
 interface Item {
-  text: Default<string, "">;
+  text: string | Default<"">;
 }
 
 interface InputSchema {
-  title: Default<string, "untitled">;
-  items: Default<Item[], []>;
+  title: string | Default<"untitled">;
+  items: Item[] | Default<[]>;
 }
 
 type InputEventType = {

--- a/packages/patterns/deprecated/calendar-v512.tsx
+++ b/packages/patterns/deprecated/calendar-v512.tsx
@@ -53,7 +53,7 @@ interface SeriesOverride {
 
 interface DayEntry {
   date: string; // ISO date string (YYYY-MM-DD)
-  notes: Default<Note[], []>;
+  notes: Note[] | Default<[]>;
 }
 
 interface TimeLabel {
@@ -62,18 +62,19 @@ interface TimeLabel {
 }
 
 interface Input {
-  entries: Default<DayEntry[], []>;
-  recurringSeries: Default<RecurringSeries[], []>;
-  seriesOverrides: Default<SeriesOverride[], []>;
-  name: Default<string, "calendar-v512">;
-  customTimeLabels: Default<
-    TimeLabel[],
-    [{ label: "Morning"; time: "09:00" }, { label: "Evening"; time: "18:00" }]
-  >;
-  startTime: Default<number, 7>; // Start hour in 24-hour format (7 = 7 AM)
-  endTime: Default<number, 19>; // End hour in 24-hour format (19 = 7 PM)
-  timeInterval: Default<30 | 60, 60>; // Time slot interval in minutes
-  showMonthView: Default<boolean, true>; // Show/hide month calendar view
+  entries: DayEntry[] | Default<[]>;
+  recurringSeries: RecurringSeries[] | Default<[]>;
+  seriesOverrides: SeriesOverride[] | Default<[]>;
+  name: string | Default<"calendar-v512">;
+  customTimeLabels:
+    | TimeLabel[]
+    | Default<
+      [{ label: "Morning"; time: "09:00" }, { label: "Evening"; time: "18:00" }]
+    >;
+  startTime: number | Default<7>; // Start hour in 24-hour format (7 = 7 AM)
+  endTime: number | Default<19>; // End hour in 24-hour format (19 = 7 PM)
+  timeInterval: 30 | 60 | Default<60>; // Time slot interval in minutes
+  showMonthView: boolean | Default<true>; // Show/hide month calendar view
 }
 
 interface Output {

--- a/packages/patterns/deprecated/cf-checkbox-handler.tsx
+++ b/packages/patterns/deprecated/cf-checkbox-handler.tsx
@@ -1,7 +1,7 @@
 import { Default, ifElse, NAME, pattern, UI, Writable } from "commonfabric";
 
 interface CheckboxSimpleInput {
-  enabled: Writable<Default<boolean, false>>;
+  enabled: Writable<boolean | Default<false>>;
 }
 
 interface CheckboxSimpleOutput extends CheckboxSimpleInput {}

--- a/packages/patterns/deprecated/charm-ref-in-cell.tsx
+++ b/packages/patterns/deprecated/charm-ref-in-cell.tsx
@@ -25,7 +25,7 @@ const PatternStateSchema = toSchema<PatternState>();
 // instead of storing the piece directly. This avoids a "pointer of pointers"
 // error that occurs when a Cell directly contains another Cell/piece reference.
 type PatternInOutput = {
-  cellRef: Default<{ piece: any }, { piece: null }>;
+  cellRef: { piece: any } | Default<{ piece: null }>;
 };
 
 // the simple piece (to which we'll store a reference within a cell)

--- a/packages/patterns/deprecated/charms-ref-in-cell.tsx
+++ b/packages/patterns/deprecated/charms-ref-in-cell.tsx
@@ -81,7 +81,7 @@ const goToPiece = handler<unknown, { piece: Piece }>(
 
 // Pattern input/output type
 type PatternInOutput = {
-  cellRef: Default<Piece[], []>;
+  cellRef: Piece[] | Default<[]>;
 };
 
 // Main pattern that manages an array of piece references

--- a/packages/patterns/deprecated/linkedlist-in-cell.tsx
+++ b/packages/patterns/deprecated/linkedlist-in-cell.tsx
@@ -14,7 +14,7 @@ interface LinkedList {
 }
 
 interface InputSchema {
-  title: Default<string, "untitled">;
+  title: string | Default<"untitled">;
 }
 
 type InputEventType = {

--- a/packages/patterns/deprecated/list-operations.tsx
+++ b/packages/patterns/deprecated/list-operations.tsx
@@ -20,7 +20,7 @@ interface Item {
 }
 
 interface ListInput {
-  items: Writable<Default<Item[], []>>;
+  items: Writable<Item[] | Default<[]>>;
 }
 
 interface ListOutput extends ListInput {}

--- a/packages/patterns/deprecated/voice-note-simple.tsx
+++ b/packages/patterns/deprecated/voice-note-simple.tsx
@@ -23,11 +23,11 @@ interface TranscriptionData {
 }
 
 type Input = {
-  title?: Writable<Default<string, "Voice Note Test">>;
+  title?: Writable<string | Default<"Voice Note Test">>;
 };
 
 type Output = {
-  transcription: Default<TranscriptionData | null, null>;
+  transcription: TranscriptionData | null | Default<null>;
 };
 
 const VoiceNoteSimple = pattern<Input, Output>(

--- a/packages/patterns/dice-handlers.ts
+++ b/packages/patterns/dice-handlers.ts
@@ -1,7 +1,7 @@
 import { Default, handler, nonPrivateRandom, Writable } from "commonfabric";
 
 export const roll = handler<
-  { sides?: Default<number, 6> },
+  { sides?: number | Default<6> },
   { value: Writable<number> }
 >(
   (args, state) => {

--- a/packages/patterns/dice.tsx
+++ b/packages/patterns/dice.tsx
@@ -2,7 +2,7 @@ import { Default, NAME, pattern, Stream, UI } from "commonfabric";
 import { getValue, roll } from "./dice-handlers.ts";
 
 interface PatternState {
-  value: Default<number, 1>;
+  value: number | Default<1>;
 }
 
 interface PatternOutput {

--- a/packages/patterns/dietary-restrictions.tsx
+++ b/packages/patterns/dietary-restrictions.tsx
@@ -78,7 +78,7 @@ export interface RestrictionEntry {
 export type RestrictionInput = string | RestrictionEntry;
 
 export interface DietaryRestrictionsInput {
-  restrictions: Default<RestrictionInput[], []>;
+  restrictions: RestrictionInput[] | Default<[]>;
 }
 
 // ===== Restriction Categories =====

--- a/packages/patterns/do-list/do-list.tsx
+++ b/packages/patterns/do-list/do-list.tsx
@@ -19,14 +19,14 @@ import Suggestion from "../system/suggestion.tsx";
 /** A #do item — a task that may do itself */
 export interface DoItem {
   title: string;
-  done: Default<boolean, false>;
-  indent: Default<number, 0>; // 0 = root, 1 = child, 2 = grandchild...
-  aiEnabled: Default<boolean, false>; // future: flag for AI auto-completion
-  attachments: Default<Writable<any>[], []>;
+  done: boolean | Default<false>;
+  indent: number | Default<0>; // 0 = root, 1 = child, 2 = grandchild...
+  aiEnabled: boolean | Default<false>; // future: flag for AI auto-completion
+  attachments: Writable<any>[] | Default<[]>;
 }
 
 interface DoListInput {
-  items?: Writable<Default<DoItem[], []>>;
+  items?: Writable<DoItem[] | Default<[]>>;
 }
 
 interface DoListOutput {

--- a/packages/patterns/email.tsx
+++ b/packages/patterns/email.tsx
@@ -33,9 +33,9 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface EmailModuleInput {
   /** Label for this email (Personal, Work, School, etc.) */
-  label: Default<string, "Personal">;
+  label: string | Default<"Personal">;
   /** Email address */
-  address: Default<string, "">;
+  address: string | Default<"">;
 }
 
 // ===== The Pattern =====

--- a/packages/patterns/emoji-picker.tsx
+++ b/packages/patterns/emoji-picker.tsx
@@ -29,7 +29,7 @@ export const MODULE_METADATA: ModuleMetadata = {
 
 // ===== Types =====
 export interface EmojiPickerInput {
-  selectedEmoji: Default<string, "">;
+  selectedEmoji: string | Default<"">;
 }
 
 interface AutocompleteItem {

--- a/packages/patterns/examples/array-in-cell-with-remove-editable.tsx
+++ b/packages/patterns/examples/array-in-cell-with-remove-editable.tsx
@@ -1,12 +1,12 @@
 import { Default, handler, NAME, pattern, UI, Writable } from "commonfabric";
 
 interface Item {
-  text: Default<string, "">;
+  text: string | Default<"">;
 }
 
 interface InputSchema {
-  title: Default<string, "untitled">;
-  items: Default<Item[], []>;
+  title: string | Default<"untitled">;
+  items: Item[] | Default<[]>;
 }
 
 type InputEventType = {

--- a/packages/patterns/examples/cf-checkbox-cell.tsx
+++ b/packages/patterns/examples/cf-checkbox-cell.tsx
@@ -9,8 +9,8 @@ import {
 } from "commonfabric";
 
 interface CheckboxDemoInput {
-  simpleEnabled: Writable<Default<boolean, false>>;
-  trackedEnabled: Writable<Default<boolean, false>>;
+  simpleEnabled: Writable<boolean | Default<false>>;
+  trackedEnabled: Writable<boolean | Default<false>>;
 }
 
 interface CheckboxDemoOutput extends CheckboxDemoInput {}

--- a/packages/patterns/examples/cf-code-editor-cell.tsx
+++ b/packages/patterns/examples/cf-code-editor-cell.tsx
@@ -5,7 +5,7 @@
 import { Default, NAME, pattern, UI } from "commonfabric";
 
 interface Input {
-  content: Default<string, "">;
+  content: string | Default<"">;
 }
 
 export default pattern<Input>(({ content }) => {

--- a/packages/patterns/examples/cf-render-subpath.tsx
+++ b/packages/patterns/examples/cf-render-subpath.tsx
@@ -13,7 +13,7 @@
 import { computed, Default, NAME, pattern, UI } from "commonfabric";
 
 interface State {
-  title: Default<string, "Test Pattern">;
+  title: string | Default<"Test Pattern">;
 }
 
 export default pattern<State>((state) => {

--- a/packages/patterns/examples/cf-render.tsx
+++ b/packages/patterns/examples/cf-render.tsx
@@ -9,7 +9,7 @@ import {
 } from "commonfabric";
 
 interface PatternState {
-  value: Default<number, 0>;
+  value: number | Default<0>;
 }
 
 // In this case we do not have to type our event parameter because it is not used in the body.

--- a/packages/patterns/examples/cf-tags.tsx
+++ b/packages/patterns/examples/cf-tags.tsx
@@ -5,7 +5,7 @@ type Input = {
 };
 
 type Result = {
-  tags: Default<string[], []>;
+  tags: string[] | Default<[]>;
 };
 
 const updateTags = handler<

--- a/packages/patterns/examples/drag-drop-demo.tsx
+++ b/packages/patterns/examples/drag-drop-demo.tsx
@@ -17,8 +17,8 @@ interface Item {
 }
 
 interface DragDropDemoInput {
-  availableItems: Default<Item[], []>;
-  droppedItems: Default<Item[], []>;
+  availableItems: Item[] | Default<[]>;
+  droppedItems: Item[] | Default<[]>;
 }
 
 interface DragDropDemoOutput {

--- a/packages/patterns/examples/fetch-data.tsx
+++ b/packages/patterns/examples/fetch-data.tsx
@@ -150,7 +150,7 @@ function parseUrl(url: string): { org: string; user: string } {
 }
 
 export default pattern<
-  { repoUrl: Writable<Default<string, "https://github.com/vercel/next.js">> }
+  { repoUrl: Writable<string | Default<"https://github.com/vercel/next.js">> }
 >((state) => {
   // Parse URL and create API endpoint
   const output = computed(() => parseUrl(state.repoUrl.get()));

--- a/packages/patterns/examples/instantiate-pattern.tsx
+++ b/packages/patterns/examples/instantiate-pattern.tsx
@@ -11,7 +11,7 @@ import {
 } from "commonfabric";
 
 interface PatternState {
-  value: Default<number, 0>;
+  value: number | Default<0>;
 }
 
 const increment = handler<unknown, { value: Writable<number> }>((_, state) => {
@@ -61,7 +61,7 @@ export const Counter = pattern<PatternState>((state) => {
 
 interface FactoryInput {
   // Provided by the shell; not used directly here
-  allPieces: Default<unknown[], []>;
+  allPieces: unknown[] | Default<[]>;
 }
 
 // No additional outputs beyond name and UI

--- a/packages/patterns/examples/llm.tsx
+++ b/packages/patterns/examples/llm.tsx
@@ -11,7 +11,7 @@ import {
 } from "commonfabric";
 
 type LLMTestInput = {
-  title: Default<string, "LLM Test">;
+  title: string | Default<"LLM Test">;
 };
 
 type LLMTestResult = {

--- a/packages/patterns/examples/multi-option-selection.tsx
+++ b/packages/patterns/examples/multi-option-selection.tsx
@@ -1,10 +1,10 @@
 import { Default, NAME, pattern, UI, Writable } from "commonfabric";
 
 type Input = {
-  selected: Writable<Default<string, "opt_1">>;
-  numericChoice: Writable<Default<number, 1>>;
-  category: Writable<Default<string, "Other">>;
-  activeTab: Writable<Default<string, "tab1">>;
+  selected: Writable<string | Default<"opt_1">>;
+  numericChoice: Writable<number | Default<1>>;
+  category: Writable<string | Default<"Other">>;
+  activeTab: Writable<string | Default<"tab1">>;
 };
 
 type Result = {

--- a/packages/patterns/examples/nested-counter.tsx
+++ b/packages/patterns/examples/nested-counter.tsx
@@ -11,7 +11,7 @@ import {
 // ===== Types =====
 
 interface CounterInput {
-  value: Writable<Default<number, 0>>;
+  value: Writable<number | Default<0>>;
 }
 
 // ===== Handlers at module scope =====

--- a/packages/patterns/examples/output_schema.tsx
+++ b/packages/patterns/examples/output_schema.tsx
@@ -13,7 +13,7 @@ const increment = handler<unknown, { value: Writable<number> }>((_, state) => {
 });
 
 interface Input {
-  value: Default<number, 0>;
+  value: number | Default<0>;
 }
 interface Output {
   value: number;

--- a/packages/patterns/examples/profile-aware-writer.tsx
+++ b/packages/patterns/examples/profile-aware-writer.tsx
@@ -13,7 +13,7 @@ import {
 } from "commonfabric";
 
 type Input = {
-  title?: Default<string, "Profile-Aware Writer">;
+  title?: string | Default<"Profile-Aware Writer">;
 };
 
 const handleSend = handler<

--- a/packages/patterns/examples/queue-test.tsx
+++ b/packages/patterns/examples/queue-test.tsx
@@ -8,7 +8,7 @@ import {
 } from "commonfabric";
 
 type QueueTestInput = {
-  title: Default<string, "Queue Test">;
+  title: string | Default<"Queue Test">;
 };
 
 /**

--- a/packages/patterns/examples/suggestion-test.tsx
+++ b/packages/patterns/examples/suggestion-test.tsx
@@ -8,7 +8,7 @@ import BudgetPlanner from "../suggestable/budget-planner.tsx";
 import PeopleList from "../suggestable/people-list.tsx";
 import EventList from "../suggestable/event-list.tsx";
 
-export default pattern<{ title: Default<string, "Suggestion Tester"> }>(
+export default pattern<{ title: string | Default<"Suggestion Tester"> }>(
   ({ title }) => {
     const suggestion = Suggestion({
       situation: "gimme counter plz",

--- a/packages/patterns/examples/write-and-run.tsx
+++ b/packages/patterns/examples/write-and-run.tsx
@@ -17,7 +17,7 @@ const TEMPLATE =
   `import { computed, handler, Default, NAME, pattern, UI } from "commonfabric";
 
 interface Input {
-  value: Default<number, 0>;
+  value: number | Default<0>;
 }
 
 const increment = handler<unknown, { value: Writable<number> }>(
@@ -61,7 +61,7 @@ ${TEMPLATE}
 Generate ONLY the TypeScript code, no explanations or markdown.`;
 
 interface Input {
-  prompt: Default<string, "Create a simple counter">;
+  prompt: string | Default<"Create a simple counter">;
 }
 
 interface Output {

--- a/packages/patterns/experimental/chat-note.tsx
+++ b/packages/patterns/experimental/chat-note.tsx
@@ -40,16 +40,16 @@ const MODELS = [
 ] as const;
 
 type Input = {
-  title?: Writable<Default<string, "Chat Note">>;
-  content?: Writable<Default<string, "">>;
-  isHidden?: Default<boolean, false>;
-  noteId?: Default<string, "">;
+  title?: Writable<string | Default<"Chat Note">>;
+  content?: Writable<string | Default<"">>;
+  isHidden?: boolean | Default<false>;
+  noteId?: string | Default<"">;
   /** Pattern JSON for [[wiki-links]]. Defaults to creating new ChatNotes. */
-  linkPattern?: Writable<Default<string, "">>;
+  linkPattern?: Writable<string | Default<"">>;
   /** Parent notebook reference (passed via SELF from notebook.tsx) */
   parentNotebook?: any;
   /** Selected model for generation. Defaults to Sonnet 4.5 */
-  model?: Writable<Default<string, "anthropic:claude-sonnet-4-5">>;
+  model?: Writable<string | Default<"anthropic:claude-sonnet-4-5">>;
 };
 
 type LLMMessage = {
@@ -61,12 +61,12 @@ type LLMMessage = {
 type Output = {
   [NAME]?: string;
   [UI]: VNode;
-  mentioned: Default<Array<MentionablePiece>, []>;
+  mentioned: Array<MentionablePiece> | Default<[]>;
   backlinks: MentionablePiece[];
   parentNotebook: any;
-  content: Default<string, "">;
-  isHidden: Default<boolean, false>;
-  noteId: Default<string, "">;
+  content: string | Default<"">;
+  isHidden: boolean | Default<false>;
+  noteId: string | Default<"">;
   isGenerating: boolean;
   editContent: Stream<{ detail: { value: string } }>;
 };
@@ -348,8 +348,8 @@ const ChatNote = pattern<Input, Output>(
     [SELF]: self,
   }) => {
     const { allPieces } =
-      wish<{ allPieces: Default<MinimalPiece[], []> }>({ query: "/" }).result;
-    const { result: mentionable } = wish<Default<MentionablePiece[], []>>({
+      wish<{ allPieces: MinimalPiece[] | Default<[]> }>({ query: "/" }).result;
+    const { result: mentionable } = wish<MentionablePiece[] | Default<[]>>({
       query: "#mentionable",
     });
     const mentioned = Writable.of<MentionablePiece[]>([]);

--- a/packages/patterns/experimental/email-task-engine.tsx
+++ b/packages/patterns/experimental/email-task-engine.tsx
@@ -271,7 +271,7 @@ const executeCreateNote = handler<
     taskCurrentLabelId: Writable<string>;
     hiddenTasks: Writable<string[]>;
     processingTasks: Writable<string[]>;
-    allPieces: Writable<Default<NotePiece[], []>>;
+    allPieces: Writable<NotePiece[] | Default<[]>>;
   }
 >(
   (

--- a/packages/patterns/experimental/folksonomy-aggregator.tsx
+++ b/packages/patterns/experimental/folksonomy-aggregator.tsx
@@ -53,7 +53,7 @@ interface CommunityTagSuggestion {
 }
 
 interface Input {
-  events: Default<TagEvent[], []>;
+  events: TagEvent[] | Default<[]>;
 }
 
 /**

--- a/packages/patterns/experimental/folksonomy-demo.tsx
+++ b/packages/patterns/experimental/folksonomy-demo.tsx
@@ -33,13 +33,13 @@ import { FolksonomyTags } from "./folksonomy-tags.tsx";
 
 interface Input {
   /** Tags for item A (scope: demo-shared) */
-  itemATags: Default<string[], []>;
+  itemATags: string[] | Default<[]>;
   /** Tags for item B (scope: demo-shared - same as A) */
-  itemBTags: Default<string[], []>;
+  itemBTags: string[] | Default<[]>;
   /** Tags for item C (scope: demo-isolated - different scope) */
-  itemCTags: Default<string[], []>;
+  itemCTags: string[] | Default<[]>;
   /** Custom scope name */
-  customScope: Default<string, "demo-shared">;
+  customScope: string | Default<"demo-shared">;
 }
 
 interface Output {

--- a/packages/patterns/experimental/folksonomy-tags.tsx
+++ b/packages/patterns/experimental/folksonomy-tags.tsx
@@ -72,9 +72,9 @@ interface AggregatorCharm {
 
 interface FolksonomyTagsInput {
   /** Namespace key (e.g., GitHub URL of the pattern using it) */
-  scope: Writable<Default<string, "">>;
+  scope: Writable<string | Default<"">>;
   /** User's tags for this scope - bidirectional binding */
-  tags: Writable<Default<string[], []>>;
+  tags: Writable<string[] | Default<[]>>;
   /** Optional: Direct reference to aggregator (bypasses wish() discovery) */
   aggregator?: AggregatorCharm;
 }

--- a/packages/patterns/factory-outputs/parking-coordinator/main.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.tsx
@@ -52,7 +52,8 @@ export interface SpotRequest {
 
 export interface ParkingCoordinatorInput {
   spots: Writable<
-    Default<ParkingSpot[], [
+    | ParkingSpot[]
+    | Default<[
       { spotNumber: "1"; label: "Near entrance"; notes: ""; active: true },
       { spotNumber: "5"; label: ""; notes: ""; active: true },
       {
@@ -63,8 +64,8 @@ export interface ParkingCoordinatorInput {
       },
     ]>
   >;
-  people: Writable<Default<Person[], []>>;
-  requests: Writable<Default<SpotRequest[], []>>;
+  people: Writable<Person[] | Default<[]>>;
+  requests: Writable<SpotRequest[] | Default<[]>>;
 }
 
 export interface ParkingCoordinatorOutput {

--- a/packages/patterns/factory-outputs/parking-coordinator/summary.md
+++ b/packages/patterns/factory-outputs/parking-coordinator/summary.md
@@ -207,7 +207,7 @@ Manual test verified all 16 acceptance criteria except DEFAULT_SPOTS:
 Orchestrator invoked pattern-maker to fix both issues:
 
 1. **DEFAULT_SPOTS fix**: Inlined the three default spot values directly as
-   type-level literal in Default<ParkingSpot[], [{spotNumber: "1", label: "Near
+   type-level literal in ParkingSpot[] | Default<[{spotNumber: "1", label: "Near
    entrance", ...}, {spotNumber: "5", ...}, {spotNumber: "12", label: "Compact
    only", ...}]>. (Default<> second parameter must be a type literal, so const
    reference cannot be used.)

--- a/packages/patterns/form-demo.tsx
+++ b/packages/patterns/form-demo.tsx
@@ -27,11 +27,11 @@ import {
 export interface Person {
   name: string;
   email: string;
-  role: Default<"user" | "admin", "user">;
+  role: "user" | "admin" | Default<"user">;
 }
 
 interface FormDemoInput {
-  people: Writable<Default<Person[], []>>;
+  people: Writable<Person[] | Default<[]>>;
 }
 
 interface FormDemoOutput {

--- a/packages/patterns/gender.tsx
+++ b/packages/patterns/gender.tsx
@@ -42,7 +42,7 @@ type GenderValue =
 
 export interface GenderModuleInput {
   /** Gender identity - Writable<> required for setGender handler to call .set() */
-  gender: Writable<Default<GenderValue | "", "">>;
+  gender: Writable<GenderValue | "" | Default<"">>;
 }
 
 // ===== Constants =====

--- a/packages/patterns/gideon-tests/array-length-repro.tsx
+++ b/packages/patterns/gideon-tests/array-length-repro.tsx
@@ -23,7 +23,7 @@ interface Item {
 }
 
 interface Input {
-  items: Writable<Default<Item[], []>>;
+  items: Writable<Item[] | Default<[]>>;
 }
 
 interface Output {

--- a/packages/patterns/gideon-tests/computed-array-repro.tsx
+++ b/packages/patterns/gideon-tests/computed-array-repro.tsx
@@ -35,7 +35,7 @@ interface Item {
 }
 
 interface Input {
-  items?: Writable<Default<Item[], []>>;
+  items?: Writable<Item[] | Default<[]>>;
 }
 
 interface Output {

--- a/packages/patterns/gideon-tests/proxy-length-repro.tsx
+++ b/packages/patterns/gideon-tests/proxy-length-repro.tsx
@@ -20,7 +20,7 @@ interface Item {
 }
 
 interface Input {
-  items: Writable<Default<Item[], []>>;
+  items: Writable<Item[] | Default<[]>>;
 }
 
 interface Output {

--- a/packages/patterns/gideon-tests/test-30-fetchdata-dynamic-instantiation.tsx
+++ b/packages/patterns/gideon-tests/test-30-fetchdata-dynamic-instantiation.tsx
@@ -21,11 +21,13 @@ interface Repo {
 }
 
 interface InputSchema {
-  repos: Default<Repo[], [
-    { id: "1"; name: "react" },
-    { id: "2"; name: "vue" },
-    { id: "3"; name: "angular" },
-  ]>;
+  repos:
+    | Repo[]
+    | Default<[
+      { id: "1"; name: "react" },
+      { id: "2"; name: "vue" },
+      { id: "3"; name: "angular" },
+    ]>;
 }
 
 interface Input {

--- a/packages/patterns/gideon-tests/test-33-computed-projection-writability.tsx
+++ b/packages/patterns/gideon-tests/test-33-computed-projection-writability.tsx
@@ -34,10 +34,12 @@ interface Source {
 
 // Schema definition for default value
 interface InputSchema {
-  source: Default<Source, {
-    auth: { token: "initial-token"; expiresAt: 0; refreshCount: 0 };
-    name: "Test Source";
-  }>;
+  source:
+    | Source
+    | Default<{
+      auth: { token: "initial-token"; expiresAt: 0; refreshCount: 0 };
+      name: "Test Source";
+    }>;
 }
 
 // Pattern output type - describes the inner value, not the cell wrapper

--- a/packages/patterns/gideon-tests/test-await-in-handler.tsx
+++ b/packages/patterns/gideon-tests/test-await-in-handler.tsx
@@ -121,16 +121,16 @@ const resetAll = handler<
 
 interface PatternState {
   // State for await test
-  awaitStatus: Default<string, "Ready">;
-  awaitResult: Default<string, "">;
-  awaitCount: Default<number, 0>;
+  awaitStatus: string | Default<"Ready">;
+  awaitResult: string | Default<"">;
+  awaitCount: number | Default<0>;
 
   // State for reactive/fetchData test
-  fetchTrigger: Default<number, 0>;
-  fetchCount: Default<number, 0>;
+  fetchTrigger: number | Default<0>;
+  fetchCount: number | Default<0>;
 
   // Interactive counter to test responsiveness
-  counter: Default<number, 0>;
+  counter: number | Default<0>;
 }
 
 export default pattern<PatternState>((state) => {

--- a/packages/patterns/gideon-tests/test-background-manual-trigger.tsx
+++ b/packages/patterns/gideon-tests/test-background-manual-trigger.tsx
@@ -41,8 +41,8 @@ import {
 } from "commonfabric";
 
 interface Input {
-  runCount: Default<number, 0>;
-  logs: Default<string[], []>;
+  runCount: number | Default<0>;
+  logs: string[] | Default<[]>;
 }
 
 // Browser-triggered handler - explicitly marks source as BROWSER

--- a/packages/patterns/gideon-tests/test-cell-equals-diagnostic.tsx
+++ b/packages/patterns/gideon-tests/test-cell-equals-diagnostic.tsx
@@ -23,9 +23,9 @@ interface Item {
 }
 
 interface DiagInput {
-  items: Default<Item[], []>;
-  selectedItem: Default<Item | null, null>;
-  log: Default<string[], []>;
+  items: Item[] | Default<[]>;
+  selectedItem: Item | null | Default<null>;
+  log: string[] | Default<[]>;
 }
 
 // Add item handler

--- a/packages/patterns/gideon-tests/test-checkbox-computed.tsx
+++ b/packages/patterns/gideon-tests/test-checkbox-computed.tsx
@@ -11,16 +11,18 @@ import { computed, Default, NAME, pattern, UI } from "commonfabric";
 interface Item {
   id: string;
   title: string;
-  done: Default<boolean, false>;
-  active: Default<boolean, true>;
+  done: boolean | Default<false>;
+  active: boolean | Default<true>;
 }
 
 interface Input {
-  items: Default<Item[], [
-    { id: "1"; title: "Task A"; done: false; active: true },
-    { id: "2"; title: "Task B"; done: true; active: true },
-    { id: "3"; title: "Task C"; done: false; active: false },
-  ]>;
+  items:
+    | Item[]
+    | Default<[
+      { id: "1"; title: "Task A"; done: false; active: true },
+      { id: "2"; title: "Task B"; done: true; active: true },
+      { id: "3"; title: "Task C"; done: false; active: false },
+    ]>;
 }
 
 export default pattern<Input>(({ items }) => {

--- a/packages/patterns/gideon-tests/test-cross-charm-client.tsx
+++ b/packages/patterns/gideon-tests/test-cross-charm-client.tsx
@@ -37,13 +37,13 @@ import {
 
 interface Input {
   // Toggle between Mode A (wish only) and Mode B (wish + <cf-render>)
-  useCfRender: Default<boolean, false>;
+  useCfRender: boolean | Default<false>;
 
   // Track last invocation result
-  lastInvocationStatus: Default<string, "Not invoked yet">;
+  lastInvocationStatus: string | Default<"Not invoked yet">;
 
   // Track invocation count
-  invocationCount: Default<number, 0>;
+  invocationCount: number | Default<0>;
 }
 
 interface Output {

--- a/packages/patterns/gideon-tests/test-cross-charm-server.tsx
+++ b/packages/patterns/gideon-tests/test-cross-charm-server.tsx
@@ -21,10 +21,10 @@ import {
 
 interface Input {
   // Counter value that increments each time the stream is invoked
-  counter: Default<number, 0>;
+  counter: number | Default<0>;
 
   // Log of invocation timestamps
-  invocationLog: Default<string[], []>;
+  invocationLog: string[] | Default<[]>;
 }
 
 /** A #cross-piece-test-server that exposes a stream for testing cross-piece invocation. */

--- a/packages/patterns/gideon-tests/test-generateobject-error-handling.tsx
+++ b/packages/patterns/gideon-tests/test-generateobject-error-handling.tsx
@@ -36,7 +36,7 @@ interface ProductIdea {
 }
 
 interface Input {
-  userInput: Default<string, "a self-watering plant pot">;
+  userInput: string | Default<"a self-watering plant pot">;
 }
 
 export default pattern<Input, Input>(({ userInput }) => {

--- a/packages/patterns/gideon-tests/test-handler-capture-key-equals.tsx
+++ b/packages/patterns/gideon-tests/test-handler-capture-key-equals.tsx
@@ -13,7 +13,7 @@ export interface InboxItem {
 }
 
 interface InboxListInput {
-  inboxItems: Default<InboxItem[], []>;
+  inboxItems: InboxItem[] | Default<[]>;
 }
 
 interface InboxListOutput {

--- a/packages/patterns/gideon-tests/test-helper-owned-handler-nested-captures.tsx
+++ b/packages/patterns/gideon-tests/test-helper-owned-handler-nested-captures.tsx
@@ -15,9 +15,9 @@
 import { action, Default, pattern, Stream, Writable } from "commonfabric";
 
 function flushLater(
-  fileId: Writable<Default<string, "">>,
-  content: Writable<Default<string, "">>,
-  savedContent: Writable<Default<string, "">>,
+  fileId: Writable<string | Default<"">>,
+  content: Writable<string | Default<"">>,
+  savedContent: Writable<string | Default<"">>,
   onSaveFile: Stream<{ fileId: string; content: string }>,
 ): void {
   const nextContent = content.get();
@@ -28,9 +28,9 @@ function flushLater(
 }
 
 interface Input {
-  fileId: Writable<Default<string, "">>;
-  content: Writable<Default<string, "">>;
-  savedContent: Writable<Default<string, "">>;
+  fileId: Writable<string | Default<"">>;
+  content: Writable<string | Default<"">>;
+  savedContent: Writable<string | Default<"">>;
   onSaveFile: Stream<{ fileId: string; content: string }>;
 }
 

--- a/packages/patterns/gideon-tests/test-helper-owned-jsx-iife-captures.tsx
+++ b/packages/patterns/gideon-tests/test-helper-owned-jsx-iife-captures.tsx
@@ -20,7 +20,7 @@ interface Entry {
 }
 
 interface Input {
-  entries: Writable<Default<Entry[], []>>;
+  entries: Writable<Entry[] | Default<[]>>;
 }
 
 interface Output {
@@ -28,7 +28,7 @@ interface Output {
 }
 
 function visibleEntries(
-  entries: Writable<Default<Entry[], []>>,
+  entries: Writable<Entry[] | Default<[]>>,
   prefix: string,
 ): Entry[] {
   const list = entries.get();

--- a/packages/patterns/gideon-tests/test-idempotent-side-effects.tsx
+++ b/packages/patterns/gideon-tests/test-idempotent-side-effects.tsx
@@ -37,7 +37,7 @@ import {
 
 interface TestInput {
   // Trigger value that we can change to force re-computation
-  triggerCount: Default<number, 0>;
+  triggerCount: number | Default<0>;
 }
 
 interface TestOutput {

--- a/packages/patterns/gideon-tests/test-ifelse-both-branches.tsx
+++ b/packages/patterns/gideon-tests/test-ifelse-both-branches.tsx
@@ -35,8 +35,8 @@ import {
 } from "commonfabric";
 
 interface Input {
-  condition: Default<boolean, true>;
-  toggleCount: Default<number, 0>;
+  condition: boolean | Default<true>;
+  toggleCount: number | Default<0>;
 }
 
 interface Output {

--- a/packages/patterns/gideon-tests/test-llm-derive-template-strings.tsx
+++ b/packages/patterns/gideon-tests/test-llm-derive-template-strings.tsx
@@ -51,7 +51,7 @@ interface Summary {
 }
 
 interface Input {
-  articles: Default<Article[], []>;
+  articles: Article[] | Default<[]>;
 }
 
 const addArticle = handler<

--- a/packages/patterns/gideon-tests/test-llm-dumb-map-generateobject.tsx
+++ b/packages/patterns/gideon-tests/test-llm-dumb-map-generateobject.tsx
@@ -54,7 +54,7 @@ interface Sentiment {
 }
 
 interface Input {
-  items: Default<Item[], []>;
+  items: Item[] | Default<[]>;
 }
 
 const addItem = handler<

--- a/packages/patterns/gideon-tests/test-onclick-ifelse-simple-cell-working.tsx
+++ b/packages/patterns/gideon-tests/test-onclick-ifelse-simple-cell-working.tsx
@@ -49,8 +49,8 @@ import {
 } from "commonfabric";
 
 interface State {
-  count: Default<number, 0>;
-  showButton: Default<boolean, true>;
+  count: number | Default<0>;
+  showButton: boolean | Default<true>;
 }
 
 const incrementHandler = handler<unknown, { count: Writable<number> }>(

--- a/packages/patterns/gideon-tests/test-onclick-inside-derive-broken.tsx
+++ b/packages/patterns/gideon-tests/test-onclick-inside-derive-broken.tsx
@@ -26,7 +26,7 @@ import {
 } from "commonfabric";
 
 interface State {
-  count: Default<number, 0>;
+  count: number | Default<0>;
 }
 
 const incrementHandler = handler<unknown, { count: Writable<number> }>(

--- a/packages/patterns/gideon-tests/test-onclick-toplevel-disabled-working.tsx
+++ b/packages/patterns/gideon-tests/test-onclick-toplevel-disabled-working.tsx
@@ -45,9 +45,9 @@ import {
 } from "commonfabric";
 
 interface State {
-  count: Default<number, 0>;
-  pending: Default<boolean, false>;
-  isProcessing: Default<boolean, false>;
+  count: number | Default<0>;
+  pending: boolean | Default<false>;
+  isProcessing: boolean | Default<false>;
 }
 
 const incrementHandler = handler<

--- a/packages/patterns/gideon-tests/test-pattern-composition-index-based.tsx
+++ b/packages/patterns/gideon-tests/test-pattern-composition-index-based.tsx
@@ -21,8 +21,8 @@ import {
 
 interface ShoppingItem {
   title: string;
-  done: Default<boolean, false>;
-  category: Default<string, "Uncategorized">;
+  done: boolean | Default<false>;
+  category: string | Default<"Uncategorized">;
 }
 
 // INDEX-BASED removal handler - no .equals() needed
@@ -175,14 +175,13 @@ const CategoryList = pattern<CategoryListInput>(({ items }) => {
 
 // Main pattern
 interface ComposedInput {
-  items: Default<
-    ShoppingItem[],
-    [
+  items:
+    | ShoppingItem[]
+    | Default<[
       { title: "Milk"; done: false; category: "Dairy" },
       { title: "Bread"; done: false; category: "Bakery" },
       { title: "Cheese"; done: true; category: "Dairy" },
-    ]
-  >;
+    ]>;
 }
 
 export default pattern<ComposedInput>(({ items }) => {

--- a/packages/patterns/gideon-tests/test-pattern-composition-shared-cells.tsx
+++ b/packages/patterns/gideon-tests/test-pattern-composition-shared-cells.tsx
@@ -39,8 +39,8 @@ import {
 
 interface ShoppingItem {
   title: string;
-  done: Default<boolean, false>;
-  category: Default<string, "Uncategorized">;
+  done: boolean | Default<false>;
+  category: string | Default<"Uncategorized">;
 }
 
 // Handlers at module scope
@@ -193,14 +193,13 @@ const CategoryList = pattern<CategoryListInput>(({ items }) => {
 
 // Main pattern: Compose both views with shared cell
 interface ComposedInput {
-  items: Default<
-    ShoppingItem[],
-    [
+  items:
+    | ShoppingItem[]
+    | Default<[
       { title: "Milk"; done: false; category: "Dairy" },
       { title: "Bread"; done: false; category: "Bakery" },
       { title: "Cheese"; done: true; category: "Dairy" },
-    ]
-  >;
+    ]>;
 }
 
 export default pattern<ComposedInput>(({ items }) => {

--- a/packages/patterns/gideon-tests/test-reactivity-computed-derive-same/index.tsx
+++ b/packages/patterns/gideon-tests/test-reactivity-computed-derive-same/index.tsx
@@ -43,9 +43,9 @@ import {
 } from "commonfabric";
 
 interface TestInput {
-  firstName: Default<string, "John">;
-  lastName: Default<string, "Doe">;
-  age: Default<number, 30>;
+  firstName: string | Default<"John">;
+  lastName: string | Default<"Doe">;
+  age: number | Default<30>;
 }
 
 const updateNames = handler<

--- a/packages/patterns/gideon-tests/test-reactivity-jsx-automatic.tsx
+++ b/packages/patterns/gideon-tests/test-reactivity-jsx-automatic.tsx
@@ -36,12 +36,11 @@ interface User {
 }
 
 interface TestInput {
-  count: Default<number, 0>;
-  user: Default<User, { name: "Alice"; age: 30 }>;
-  items: Default<
-    Item[],
-    [{ title: "Item 1" }, { title: "Item 2" }, { title: "Item 3" }]
-  >;
+  count: number | Default<0>;
+  user: User | Default<{ name: "Alice"; age: 30 }>;
+  items:
+    | Item[]
+    | Default<[{ title: "Item 1" }, { title: "Item 2" }, { title: "Item 3" }]>;
 }
 
 const updateAllValues = handler<

--- a/packages/patterns/gideon-tests/test-record-key-set-56.tsx
+++ b/packages/patterns/gideon-tests/test-record-key-set-56.tsx
@@ -17,13 +17,12 @@ interface Item {
 
 interface Input {
   // Empty record to test creating new keys
-  emptyRecord: Default<Record<string, Item>, Record<PropertyKey, never>>;
+  emptyRecord: Record<string, Item> | Default<Record<PropertyKey, never>>;
   // Pre-populated record to test updating existing keys
-  populatedRecord: Default<
-    Record<string, Item>,
-    { existing: { value: "preset"; count: 0 } }
-  >;
-  logs: Default<string[], []>;
+  populatedRecord:
+    | Record<string, Item>
+    | Default<{ existing: { value: "preset"; count: 0 } }>;
+  logs: string[] | Default<[]>;
 }
 
 // ============================================================

--- a/packages/patterns/giftprefs.tsx
+++ b/packages/patterns/giftprefs.tsx
@@ -47,11 +47,11 @@ type GiftTier = "always" | "occasions" | "reciprocal" | "none";
 
 export interface GiftPrefsModuleInput {
   /** Gift giving tier */
-  giftTier: Default<GiftTier | "", "">;
+  giftTier: GiftTier | "" | Default<"">;
   /** Favorite things (interests, hobbies, brands) */
-  favorites: Default<string[], []>;
+  favorites: string[] | Default<[]>;
   /** Things to avoid (allergies, dislikes) */
-  avoid: Default<string[], []>;
+  avoid: string[] | Default<[]>;
 }
 
 // ===== Constants =====

--- a/packages/patterns/github-activity/main.tsx
+++ b/packages/patterns/github-activity/main.tsx
@@ -32,7 +32,7 @@ function parseUrl(url: string): { owner: string; repo: string } {
 
 export default pattern<{
   repoUrl: Writable<
-    Default<string, "https://github.com/anthropics/claude-code">
+    string | Default<"https://github.com/anthropics/claude-code">
   >;
 }>((state) => {
   // Parse URL and create API endpoint

--- a/packages/patterns/google/WIP/google-docs-importer.tsx
+++ b/packages/patterns/google/WIP/google-docs-importer.tsx
@@ -56,13 +56,13 @@ import Note from "../../notes/note.tsx";
 // =============================================================================
 
 interface Input {
-  docUrl?: Cell<Default<string, "">>;
-  markdown?: Cell<Default<string, "">>;
-  docTitle?: Cell<Default<string, "">>;
-  isFetching?: Cell<Default<boolean, false>>;
-  lastError?: Cell<Default<string | null, null>>;
-  includeComments?: Cell<Default<boolean, true>>;
-  embedImages?: Cell<Default<boolean, false>>;
+  docUrl?: Cell<string | Default<"">>;
+  markdown?: Cell<string | Default<"">>;
+  docTitle?: Cell<string | Default<"">>;
+  isFetching?: Cell<boolean | Default<false>>;
+  lastError?: Cell<string | null | Default<null>>;
+  includeComments?: Cell<boolean | Default<true>>;
+  embedImages?: Cell<boolean | Default<false>>;
 }
 
 /** Google Docs Markdown Importer. Import Google Docs as Markdown with comments. #googleDocsImporter */

--- a/packages/patterns/google/core/bill-extractor/index.tsx
+++ b/packages/patterns/google/core/bill-extractor/index.tsx
@@ -130,7 +130,7 @@ export interface BillExtractorInput {
   shortName: string;
 
   /** Brand color for website button (hex) */
-  brandColor?: Default<string, "#3b82f6">;
+  brandColor?: string | Default<"#3b82f6">;
 
   /** Provider website URL */
   websiteUrl?: string;
@@ -139,20 +139,20 @@ export interface BillExtractorInput {
   overrideAuth?: Auth;
 
   /** State for persistence - which bills user manually marked as paid */
-  manuallyPaid?: Writable<Default<string[], []>>;
+  manuallyPaid?: Writable<string[] | Default<[]>>;
 
   /** Whether to show fake amounts for privacy (demo mode) */
-  demoMode?: Writable<Default<boolean, true>>;
+  demoMode?: Writable<boolean | Default<true>>;
 
   /** Maximum number of emails to fetch */
-  limit?: Default<number, 100>;
+  limit?: number | Default<100>;
 
   /**
    * Whether this provider sends payment confirmation emails.
    * When false, shows a banner explaining manual tracking is required.
    * Defaults to true.
    */
-  supportsAutoDetect?: Default<boolean, true>;
+  supportsAutoDetect?: boolean | Default<true>;
 }
 
 /**

--- a/packages/patterns/google/core/experimental/calendar-event-manager.tsx
+++ b/packages/patterns/google/core/experimental/calendar-event-manager.tsx
@@ -49,19 +49,19 @@ type CalendarOperation = "create" | "update" | "delete" | "rsvp";
 
 type EventDraft = {
   /** Event title/summary */
-  summary: Default<string, "">;
+  summary: string | Default<"">;
   /** Start datetime (ISO or datetime-local format) */
-  start: Default<string, "">;
+  start: string | Default<"">;
   /** End datetime (ISO or datetime-local format) */
-  end: Default<string, "">;
+  end: string | Default<"">;
   /** Calendar ID (primary for main calendar) */
-  calendarId: Default<string, "primary">;
+  calendarId: string | Default<"primary">;
   /** Event description */
-  description: Default<string, "">;
+  description: string | Default<"">;
   /** Event location */
-  location: Default<string, "">;
+  location: string | Default<"">;
   /** Attendee emails (comma-separated) */
-  attendeesText: Default<string, "">;
+  attendeesText: string | Default<"">;
 };
 
 type ExistingEvent = {
@@ -98,9 +98,9 @@ type OperationResult = {
 
 interface Input {
   /** Event draft for creating/editing */
-  draft: Default<
-    EventDraft,
-    {
+  draft:
+    | EventDraft
+    | Default<{
       summary: "";
       start: "";
       end: "";
@@ -108,10 +108,9 @@ interface Input {
       description: "";
       location: "";
       attendeesText: "";
-    }
-  >;
+    }>;
   /** Existing event for update/delete/rsvp operations */
-  existingEvent: Default<ExistingEvent, null>;
+  existingEvent: ExistingEvent | Default<null>;
 }
 
 /** Google Calendar event manager for creating/editing/deleting events. #calendarManager */

--- a/packages/patterns/google/core/experimental/calendar-viewer.tsx
+++ b/packages/patterns/google/core/experimental/calendar-viewer.tsx
@@ -107,7 +107,7 @@ const toggleCalendar = handler<
 });
 
 export default pattern<{
-  events: Default<Confidential<CalendarEvent[]>, []>;
+  events: Confidential<CalendarEvent[]> | Default<[]>;
 }>(({ events }) => {
   const hiddenCalendars = Writable.of<string[]>([]);
 

--- a/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
+++ b/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
@@ -144,61 +144,64 @@ export interface PendingSubmission {
 
 export interface GmailAgenticSearchInput {
   // Agent configuration - the main prompt/goal (can be reactive Cell)
-  agentGoal?: Default<string, "">;
+  agentGoal?: string | Default<"">;
 
   // Additional system context
-  systemPrompt?: Default<string, "">;
+  systemPrompt?: string | Default<"">;
 
   // Suggested queries for the agent to try
-  suggestedQueries?: Default<string[], []>;
+  suggestedQueries?: string[] | Default<[]>;
 
   // JSON schema for agent's structured output
-  resultSchema?: Default<object, Record<string, never>>;
+  resultSchema?: object | Default<Record<string, never>>;
 
   // Account type for multi-account support
   // "default" = any #googleAuth, "personal" = #googleAuthPersonal, "work" = #googleAuthWork
-  accountType?: Default<"default" | "personal" | "work", "default">;
+  accountType?: "default" | "personal" | "work" | Default<"default">;
 
   // Additional tools beyond searchGmail
-  additionalTools?: Default<
-    Record<string, ToolDefinition>,
-    Record<string, never>
-  >;
+  additionalTools?:
+    | Record<string, ToolDefinition>
+    | Default<Record<string, never>>;
 
   // UI customization
-  title?: Default<string, "Gmail Agentic Search">;
-  scanButtonLabel?: Default<string, "Scan">;
+  title?: string | Default<"Gmail Agentic Search">;
+  scanButtonLabel?: string | Default<"Scan">;
 
   // Limits
-  maxSearches?: Default<number, 0>; // 0 = unlimited
+  maxSearches?: number | Default<0>; // 0 = unlimited
 
   // State persistence
-  isScanning?: Default<boolean, false>;
-  lastScanAt?: Default<number, 0>;
+  isScanning?: boolean | Default<false>;
+  lastScanAt?: number | Default<0>;
 
   // Progress state - can be passed in for parent pattern coordination
-  searchProgress?: Default<SearchProgress, {
-    currentQuery: "";
-    completedQueries: [];
-    status: "idle";
-    searchCount: 0;
-  }>;
+  searchProgress?:
+    | SearchProgress
+    | Default<{
+      currentQuery: "";
+      completedQueries: [];
+      status: "idle";
+      searchCount: 0;
+    }>;
 
   // Debug log - tracks agent activity for debugging
-  debugLog?: Default<DebugLogEntry[], []>;
+  debugLog?: DebugLogEntry[] | Default<[]>;
 
   // WORKAROUND (CT-1085): Accept auth as direct input since favorites don't persist.
   // Users can manually link gmail-auth's auth output to this input.
   // If provided, this takes precedence over wish-based auth.
-  auth?: Default<Auth, {
-    token: "";
-    tokenType: "";
-    scope: [];
-    expiresIn: 0;
-    expiresAt: 0;
-    refreshToken: "";
-    user: { email: ""; name: ""; picture: "" };
-  }>;
+  auth?:
+    | Auth
+    | Default<{
+      token: "";
+      tokenType: "";
+      scope: [];
+      expiresIn: 0;
+      expiresAt: 0;
+      refreshToken: "";
+      user: { email: ""; name: ""; picture: "" };
+    }>;
 
   // ========================================================================
   // SHARED SEARCH STRINGS SUPPORT
@@ -206,25 +209,25 @@ export interface GmailAgenticSearchInput {
 
   // GitHub raw URL to identify this agent type for community query sharing
   // Example: "https://raw.githubusercontent.com/anthropics/community-patterns/main/patterns/jkomoros/hotel-membership-gmail-agent.tsx"
-  agentTypeUrl?: Default<string, "">;
+  agentTypeUrl?: string | Default<"">;
 
   // Local queries saved by this agent instance
-  localQueries?: Default<LocalQuery[], []>;
+  localQueries?: LocalQuery[] | Default<[]>;
 
   // Queries pending user review before community submission
-  pendingSubmissions?: Default<PendingSubmission[], []>;
+  pendingSubmissions?: PendingSubmission[] | Default<[]>;
 
   // Whether to fetch and use community queries (requires registry setup)
-  enableCommunityQueries?: Default<boolean, true>;
+  enableCommunityQueries?: boolean | Default<true>;
 
   // When true, only show queries in "My Saved Queries" that have found target items
   // (via itemFoundSignal). Default false shows all queries that found emails.
-  onlySaveQueriesWithItems?: Default<boolean, false>;
+  onlySaveQueriesWithItems?: boolean | Default<false>;
 
   // Optional signal cell for consuming patterns to indicate "found an item"
   // When this value increases, marks the most recent query as having found items
   // Create with Writable.of<number>(0) and pass in - both patterns share the same cell
-  itemFoundSignal?: Default<number, 0>;
+  itemFoundSignal?: number | Default<0>;
 }
 
 /** Reusable Gmail agentic search base pattern. #gmailAgenticSearch */
@@ -285,7 +288,7 @@ export interface GmailAgenticSearchOutput {
 
   // Cell that consuming patterns can increment to signal "found an item"
   // When this value increases, the base pattern marks the most recent query as having found items
-  // Note: This is an input cell (Default<number, 0>) exposed for external access
+  // Note: This is an input cell (number | Default<0>) exposed for external access
   itemFoundSignal: number;
 }
 
@@ -370,8 +373,8 @@ const setAccountTypeHandler = handler<
 const stopScanHandler = handler<
   unknown,
   {
-    lastScanAt: Writable<Default<number, 0>>;
-    isScanning: Writable<Default<boolean, false>>;
+    lastScanAt: Writable<number | Default<0>>;
+    isScanning: Writable<boolean | Default<false>>;
   }
 >((_, state) => {
   state.lastScanAt.set(safeDateNow());
@@ -385,8 +388,8 @@ const stopScanHandler = handler<
 const completeScanHandler = handler<
   unknown,
   {
-    lastScanAt: Writable<Default<number, 0>>;
-    isScanning: Writable<Default<boolean, false>>;
+    lastScanAt: Writable<number | Default<0>>;
+    isScanning: Writable<boolean | Default<false>>;
   }
 >((_, state) => {
   state.lastScanAt.set(safeDateNow());
@@ -433,7 +436,7 @@ const searchGmailHandler = handler<
     // Stream<T> in signature lets framework unwrap opaque stream from wished pieces
     authRefreshStream: RefreshStreamType | null;
     progress: Writable<SearchProgress>;
-    maxSearches: Writable<Default<number, 0>>;
+    maxSearches: Writable<number | Default<0>>;
     debugLog: Writable<DebugLogEntry[]>;
     localQueries: Writable<LocalQuery[]>;
     communityQueryRefs: Writable<CommunityQueryRef[]>;
@@ -726,7 +729,7 @@ const searchGmailHandler = handler<
 const startScanHandler = handler<
   unknown,
   {
-    isScanning: Writable<Default<boolean, false>>;
+    isScanning: Writable<boolean | Default<false>>;
     isAuthenticated: Writable<boolean>;
     progress: Writable<SearchProgress>;
     auth: Writable<Auth>;
@@ -1024,7 +1027,7 @@ const GmailAgenticSearch = pattern<
     // ========================================================================
     // Use input cells directly - Default<> types handle writability and defaults.
     // Cannot call .get() on input cells at build time (causes "space is required" error).
-    // Input cells from Default<T[], D> are OpaqueCell types that have writable methods at runtime.
+    // Input cells from T[] | Default<D> are OpaqueCell types that have writable methods at runtime.
     // Use 'any' to avoid double-casting (as unknown as) which is disallowed by the compiler.
     // See: patterns/jkomoros/util/agentic-tools.ts for similar pattern
     const localQueries: any = localQueriesInput;
@@ -1033,7 +1036,7 @@ const GmailAgenticSearch = pattern<
     // ========================================================================
     // QUERY TRACKING (for foundItems feature)
     // ========================================================================
-    // Use the input signal cell directly - Default<number, 0> provides the default
+    // Use the input signal cell directly - number | Default<0> provides the default
     // This follows the "share cells by making them inputs" pattern
     // See: community-docs/superstitions/2025-12-04-share-cells-between-composed-patterns.md
     const itemFoundSignal = itemFoundSignalInput;
@@ -1186,7 +1189,7 @@ const GmailAgenticSearch = pattern<
     const GMAIL_SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
 
     const hasGmailScope = derive(auth, (a: Auth) => {
-      const scopes = a?.scope || [];
+      const scopes = (a?.scope || []) as string[];
       return scopes.includes(GMAIL_SCOPE);
     });
 

--- a/packages/patterns/google/core/experimental/gmail-label-manager.tsx
+++ b/packages/patterns/google/core/experimental/gmail-label-manager.tsx
@@ -69,11 +69,11 @@ type OperationResult = {
 
 interface Input {
   /** Message ID(s) to manage labels for - can be single string or array */
-  messageIds: Default<string[], []>;
+  messageIds: string[] | Default<[]>;
   /** Labels to add (by ID) */
-  labelsToAdd: Default<string[], []>;
+  labelsToAdd: string[] | Default<[]>;
   /** Labels to remove (by ID) */
-  labelsToRemove: Default<string[], []>;
+  labelsToRemove: string[] | Default<[]>;
 }
 
 /** Gmail label manager with confirmation. #gmailLabelManager */

--- a/packages/patterns/google/core/experimental/gmail-search-registry.tsx
+++ b/packages/patterns/google/core/experimental/gmail-search-registry.tsx
@@ -60,7 +60,7 @@ export interface AgentTypeRegistry {
 
 export interface GmailSearchRegistryInput {
   // Flat array of all queries (workaround for CLI display bug CT-1104)
-  queries?: Default<SharedQuery[], []>;
+  queries?: SharedQuery[] | Default<[]>;
 }
 
 /** Community registry for shared Gmail search queries. #gmailSearchRegistry */

--- a/packages/patterns/google/core/experimental/gmail-sender.tsx
+++ b/packages/patterns/google/core/experimental/gmail-sender.tsx
@@ -39,19 +39,19 @@ import { type Auth, createGoogleAuth } from "../util/google-auth-manager.tsx";
 
 type EmailDraft = {
   /** Recipient email address */
-  to: Default<string, "">;
+  to: string | Default<"">;
   /** Email subject line */
-  subject: Default<string, "">;
+  subject: string | Default<"">;
   /** Plain text body */
-  body: Default<string, "">;
+  body: string | Default<"">;
   /** CC recipients (comma-separated) */
-  cc: Default<string, "">;
+  cc: string | Default<"">;
   /** BCC recipients (comma-separated) */
-  bcc: Default<string, "">;
+  bcc: string | Default<"">;
   /** Message ID to reply to (for threading) */
-  replyToMessageId: Default<string, "">;
+  replyToMessageId: string | Default<"">;
   /** Thread ID to reply to (for threading) */
-  replyToThreadId: Default<string, "">;
+  replyToThreadId: string | Default<"">;
 };
 
 type SendResult = {
@@ -64,9 +64,9 @@ type SendResult = {
 
 interface Input {
   /** Email draft to compose/send */
-  draft: Default<
-    EmailDraft,
-    {
+  draft:
+    | EmailDraft
+    | Default<{
       to: "";
       subject: "";
       body: "";
@@ -74,8 +74,7 @@ interface Input {
       bcc: "";
       replyToMessageId: "";
       replyToThreadId: "";
-    }
-  >;
+    }>;
 }
 
 /** Gmail email sender with confirmation dialog. #gmailSender */

--- a/packages/patterns/google/core/experimental/google-auth-switcher.tsx
+++ b/packages/patterns/google/core/experimental/google-auth-switcher.tsx
@@ -24,20 +24,20 @@ import GoogleAuthWork from "../google-auth-work.tsx";
 
 // Same selected scopes type as base GoogleAuth
 type SelectedScopes = {
-  gmail: Default<boolean, false>;
-  gmailSend: Default<boolean, false>;
-  gmailModify: Default<boolean, false>;
-  calendar: Default<boolean, false>;
-  calendarWrite: Default<boolean, false>;
-  drive: Default<boolean, false>;
-  docs: Default<boolean, false>;
-  contacts: Default<boolean, false>;
+  gmail: boolean | Default<false>;
+  gmailSend: boolean | Default<false>;
+  gmailModify: boolean | Default<false>;
+  calendar: boolean | Default<false>;
+  calendarWrite: boolean | Default<false>;
+  drive: boolean | Default<false>;
+  docs: boolean | Default<false>;
+  contacts: boolean | Default<false>;
 };
 
 interface Input {
-  selectedScopes: Default<
-    SelectedScopes,
-    {
+  selectedScopes:
+    | SelectedScopes
+    | Default<{
       gmail: true;
       gmailSend: false;
       gmailModify: false;
@@ -46,11 +46,10 @@ interface Input {
       drive: false;
       docs: false;
       contacts: false;
-    }
-  >;
-  auth: Default<
-    Auth,
-    {
+    }>;
+  auth:
+    | Auth
+    | Default<{
       token: "";
       tokenType: "";
       scope: [];
@@ -58,8 +57,7 @@ interface Input {
       expiresAt: 0;
       refreshToken: "";
       user: { email: ""; name: ""; picture: "" };
-    }
-  >;
+    }>;
 }
 
 /** Google account switcher for choosing personal/work accounts. #googleAuthSwitcher */

--- a/packages/patterns/google/core/experimental/google-docs-comment-confirm.ts
+++ b/packages/patterns/google/core/experimental/google-docs-comment-confirm.ts
@@ -22,17 +22,17 @@ type Secret<T> = T;
 // =============================================================================
 
 export type Auth = {
-  token: Default<Secret<string>, "">;
-  tokenType: Default<string, "">;
-  scope: Default<string[], []>;
-  expiresIn: Default<number, 0>;
-  expiresAt: Default<number, 0>;
-  refreshToken: Default<Secret<string>, "">;
-  user: Default<{
+  token: Secret<string> | Default<"">;
+  tokenType: string | Default<"">;
+  scope: string[] | Default<[]>;
+  expiresIn: number | Default<0>;
+  expiresAt: number | Default<0>;
+  refreshToken: Secret<string> | Default<"">;
+  user: {
     email: string;
     name: string;
     picture: string;
-  }, { email: ""; name: ""; picture: "" }>;
+  } | Default<{ email: ""; name: ""; picture: "" }>;
 };
 
 export interface GoogleComment {

--- a/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.tsx
+++ b/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.tsx
@@ -99,17 +99,17 @@ interface GoogleComment {
 // =============================================================================
 
 type Auth = {
-  token: Default<Secret<string>, "">;
-  tokenType: Default<string, "">;
-  scope: Default<string[], []>;
-  expiresIn: Default<number, 0>;
-  expiresAt: Default<number, 0>;
-  refreshToken: Default<Secret<string>, "">;
-  user: Default<{
+  token: Secret<string> | Default<"">;
+  tokenType: string | Default<"">;
+  scope: string[] | Default<[]>;
+  expiresIn: number | Default<0>;
+  expiresAt: number | Default<0>;
+  refreshToken: Secret<string> | Default<"">;
+  user: {
     email: string;
     name: string;
     picture: string;
-  }, { email: ""; name: ""; picture: "" }>;
+  } | Default<{ email: ""; name: ""; picture: "" }>;
 };
 
 // =============================================================================
@@ -137,27 +137,27 @@ interface AIResponseSuggestion {
 
 interface Input {
   // Config
-  docUrl?: Writable<Default<string, "">>;
-  globalPrompt?: Writable<Default<string, "">>;
+  docUrl?: Writable<string | Default<"">>;
+  globalPrompt?: Writable<string | Default<"">>;
 
   // Fetched data
-  comments?: Writable<Default<GoogleComment[], []>>;
-  docContent?: Writable<Default<string, "">>;
+  comments?: Writable<GoogleComment[] | Default<[]>>;
+  docContent?: Writable<string | Default<"">>;
 
   // Per-comment state (keyed by comment ID)
   commentStates?: Writable<
-    Default<Record<string, CommentState>, Record<string, never>>
+    Record<string, CommentState> | Default<Record<string, never>>
   >;
 
   // UI state
-  expandedCommentId?: Writable<Default<string | null, null>>;
-  isFetching?: Writable<Default<boolean, false>>;
-  showGlobalPrompt?: Writable<Default<boolean, false>>;
-  lastError?: Writable<Default<string | null, null>>;
+  expandedCommentId?: Writable<string | null | Default<null>>;
+  isFetching?: Writable<boolean | Default<false>>;
+  showGlobalPrompt?: Writable<boolean | Default<false>>;
+  lastError?: Writable<string | null | Default<null>>;
 
   // Pending action for trusted confirmation
-  pendingAction?: Writable<Default<PendingCommentAction | null, null>>;
-  isExecuting?: Writable<Default<boolean, false>>;
+  pendingAction?: Writable<PendingCommentAction | null | Default<null>>;
+  isExecuting?: Writable<boolean | Default<false>>;
 }
 
 /** Google Docs Comment Orchestrator. AI-powered comment responses. #googleDocsComments */

--- a/packages/patterns/google/core/gmail-extractor.tsx
+++ b/packages/patterns/google/core/gmail-extractor.tsx
@@ -115,13 +115,13 @@ export interface GmailExtractorInput {
   };
 
   /** Display title for the extractor (shown in UI) */
-  title?: Default<string, "Email Items">;
+  title?: string | Default<"Email Items">;
 
   /** Whether to resolve inline images (cid: references) to base64 */
-  resolveInlineImages?: Default<boolean, false>;
+  resolveInlineImages?: boolean | Default<false>;
 
   /** Maximum number of emails to fetch */
-  limit?: Default<number, 100>;
+  limit?: number | Default<100>;
 
   // Note: model parameter removed - hardcoded to fix HTTP 400 errors
   // when passing variables through building block input.

--- a/packages/patterns/google/core/gmail-importer.tsx
+++ b/packages/patterns/google/core/gmail-importer.tsx
@@ -43,20 +43,17 @@ type SyncableWritable<T> = Writable<T> & {
  * See: community-docs/superstitions/2025-12-03-derive-creates-readonly-cells-use-property-access.md
  */
 export type Auth = {
-  token: Default<Secret<string>, "">;
-  tokenType: Default<string, "">;
-  scope: Default<string[], []>;
-  expiresIn: Default<number, 0>;
-  expiresAt: Default<number, 0>;
-  refreshToken: Default<Secret<string>, "">;
-  user: Default<
-    {
-      email: string;
-      name: string;
-      picture: string;
-    },
-    { email: ""; name: ""; picture: "" }
-  >;
+  token: Secret<string> | Default<"">;
+  tokenType: string | Default<"">;
+  scope: string[] | Default<[]>;
+  expiresIn: number | Default<0>;
+  expiresAt: number | Default<0>;
+  refreshToken: Secret<string> | Default<"">;
+  user: {
+    email: string;
+    name: string;
+    picture: string;
+  } | Default<{ email: ""; name: ""; picture: "" }>;
 };
 
 function htmlToMarkdown(htmlContent: string): string {
@@ -83,7 +80,7 @@ export type Email = {
   // Identifier for the email thread
   threadId: string;
   // Labels assigned to the email
-  labelIds: Default<string[], []>;
+  labelIds: string[] | Default<[]>;
   // Brief preview of the email content
   snippet: string;
   // Email subject line
@@ -101,22 +98,22 @@ export type Email = {
   // Email content converted to Markdown format. Often best for processing email contents.
   markdownContent: string;
   // Summary for search indexing
-  summary: Default<string, "">;
+  summary: string | Default<"">;
 };
 
 type Settings = {
   // Gmail filter query to use for fetching emails
-  gmailFilterQuery: Default<string, "in:INBOX">;
+  gmailFilterQuery: string | Default<"in:INBOX">;
   // Maximum number of emails to fetch
-  limit: Default<number, 10>;
+  limit: number | Default<10>;
   // Enable verbose console logging for debugging
-  debugMode: Default<boolean, false>;
+  debugMode: boolean | Default<false>;
   // Automatically fetch emails when auth becomes valid (opt-in)
-  autoFetchOnAuth: Default<boolean, false>;
+  autoFetchOnAuth: boolean | Default<false>;
   // Resolve inline image attachments (cid: references) to base64 data URLs
   // Enable this for emails with embedded images (e.g., USPS Informed Delivery)
   // Note: This fetches additional attachment data which may be slower
-  resolveInlineImages: Default<boolean, false>;
+  resolveInlineImages: boolean | Default<false>;
 };
 
 /** Gmail email importer for fetching and viewing emails. #gmailEmails */
@@ -171,16 +168,14 @@ const googleUpdater = handler<
     emails: SyncableWritable<Array<Writable<Email>>>;
     auth: SyncableWritable<Auth>;
     settings: SyncableWritable<
-      Default<
-        Settings,
-        {
-          gmailFilterQuery: "in:INBOX";
-          limit: 10;
-          debugMode: false;
-          autoFetchOnAuth: false;
-          resolveInlineImages: false;
-        }
-      >
+      | Settings
+      | Default<{
+        gmailFilterQuery: "in:INBOX";
+        limit: 10;
+        debugMode: false;
+        autoFetchOnAuth: false;
+        resolveInlineImages: false;
+      }>
     >;
     historyId: SyncableWritable<string>;
     fetching?: Writable<boolean>;
@@ -1090,16 +1085,15 @@ const EmailCard = pattern<
 
 export default pattern<
   {
-    settings: Default<
-      Settings,
-      {
+    settings:
+      | Settings
+      | Default<{
         gmailFilterQuery: "in:INBOX";
         limit: 10;
         debugMode: false;
         autoFetchOnAuth: false;
         resolveInlineImages: false;
-      }
-    >;
+      }>;
     // Optional: Link auth directly from a Google Auth piece when wish() is unavailable
     // Use: cf piece link googleAuthPiece/auth gmailImporterPiece/overrideAuth
     overrideAuth?: Auth;

--- a/packages/patterns/google/core/google-auth-personal.tsx
+++ b/packages/patterns/google/core/google-auth-personal.tsx
@@ -16,19 +16,21 @@ import GoogleAuth, {
 } from "./google-auth.tsx";
 
 interface Input {
-  selectedScopes: Default<SelectedScopes, {
-    gmail: true;
-    gmailSend: true;
-    gmailModify: true;
-    calendar: true;
-    calendarWrite: true;
-    drive: true;
-    docs: true;
-    contacts: true;
-  }>;
-  auth: Default<
-    Auth,
-    {
+  selectedScopes:
+    | SelectedScopes
+    | Default<{
+      gmail: true;
+      gmailSend: true;
+      gmailModify: true;
+      calendar: true;
+      calendarWrite: true;
+      drive: true;
+      docs: true;
+      contacts: true;
+    }>;
+  auth:
+    | Auth
+    | Default<{
       token: "";
       tokenType: "";
       scope: [];
@@ -36,8 +38,7 @@ interface Input {
       expiresAt: 0;
       refreshToken: "";
       user: { email: ""; name: ""; picture: "" };
-    }
-  >;
+    }>;
 }
 
 /** Personal Google account. #googleAuth #googleAuthPersonal */

--- a/packages/patterns/google/core/google-auth-work.tsx
+++ b/packages/patterns/google/core/google-auth-work.tsx
@@ -16,19 +16,21 @@ import GoogleAuth, {
 } from "./google-auth.tsx";
 
 interface Input {
-  selectedScopes: Default<SelectedScopes, {
-    gmail: true;
-    gmailSend: true;
-    gmailModify: true;
-    calendar: true;
-    calendarWrite: true;
-    drive: true;
-    docs: true;
-    contacts: true;
-  }>;
-  auth: Default<
-    Auth,
-    {
+  selectedScopes:
+    | SelectedScopes
+    | Default<{
+      gmail: true;
+      gmailSend: true;
+      gmailModify: true;
+      calendar: true;
+      calendarWrite: true;
+      drive: true;
+      docs: true;
+      contacts: true;
+    }>;
+  auth:
+    | Auth
+    | Default<{
       token: "";
       tokenType: "";
       scope: [];
@@ -36,8 +38,7 @@ interface Input {
       expiresAt: 0;
       refreshToken: "";
       user: { email: ""; name: ""; picture: "" };
-    }
-  >;
+    }>;
 }
 
 /** Work Google account. #googleAuth #googleAuthWork */

--- a/packages/patterns/google/core/google-auth.tsx
+++ b/packages/patterns/google/core/google-auth.tsx
@@ -218,51 +218,55 @@ export function createPreviewUI(
  * Use direct property access: `googleAuthPiece.auth`
  */
 export type Auth = {
-  token: Default<Secret<string>, "">;
-  tokenType: Default<string, "">;
-  scope: Default<string[], []>;
-  expiresIn: Default<number, 0>;
-  expiresAt: Default<number, 0>;
-  refreshToken: Default<Secret<string>, "">;
-  user: Default<{
+  token: Secret<string> | Default<"">;
+  tokenType: string | Default<"">;
+  scope: string[] | Default<[]>;
+  expiresIn: number | Default<0>;
+  expiresAt: number | Default<0>;
+  refreshToken: Secret<string> | Default<"">;
+  user: {
     email: string;
     name: string;
     picture: string;
-  }, { email: ""; name: ""; picture: "" }>;
+  } | Default<{ email: ""; name: ""; picture: "" }>;
 };
 
 // Selected scopes configuration - exported for wrapper patterns
 export type SelectedScopes = {
-  gmail: Default<boolean, false>;
-  gmailSend: Default<boolean, false>;
-  gmailModify: Default<boolean, false>;
-  calendar: Default<boolean, false>;
-  calendarWrite: Default<boolean, false>;
-  drive: Default<boolean, false>;
-  docs: Default<boolean, false>;
-  contacts: Default<boolean, false>;
+  gmail: boolean | Default<false>;
+  gmailSend: boolean | Default<false>;
+  gmailModify: boolean | Default<false>;
+  calendar: boolean | Default<false>;
+  calendarWrite: boolean | Default<false>;
+  drive: boolean | Default<false>;
+  docs: boolean | Default<false>;
+  contacts: boolean | Default<false>;
 };
 
 interface Input {
-  selectedScopes: Default<SelectedScopes, {
-    gmail: true;
-    gmailSend: true;
-    gmailModify: true;
-    calendar: true;
-    calendarWrite: true;
-    drive: true;
-    docs: true;
-    contacts: true;
-  }>;
-  auth: Default<Auth, {
-    token: "";
-    tokenType: "";
-    scope: [];
-    expiresIn: 0;
-    expiresAt: 0;
-    refreshToken: "";
-    user: { email: ""; name: ""; picture: "" };
-  }>;
+  selectedScopes:
+    | SelectedScopes
+    | Default<{
+      gmail: true;
+      gmailSend: true;
+      gmailModify: true;
+      calendar: true;
+      calendarWrite: true;
+      drive: true;
+      docs: true;
+      contacts: true;
+    }>;
+  auth:
+    | Auth
+    | Default<{
+      token: "";
+      tokenType: "";
+      scope: [];
+      expiresIn: 0;
+      expiresAt: 0;
+      refreshToken: "";
+      user: { email: ""; name: ""; picture: "" };
+    }>;
 }
 
 /** Google OAuth authentication for Google APIs. #googleAuth */

--- a/packages/patterns/google/core/google-calendar-importer.tsx
+++ b/packages/patterns/google/core/google-calendar-importer.tsx
@@ -23,17 +23,17 @@ import {
 
 // This is used by the various Google tokens created with tokenToAuthData
 export type Auth = {
-  token: Default<Secret<string>, "">;
-  tokenType: Default<string, "">;
-  scope: Default<string[], []>;
-  expiresIn: Default<number, 0>;
-  expiresAt: Default<number, 0>;
-  refreshToken: Default<Secret<string>, "">;
-  user: Default<{
+  token: Secret<string> | Default<"">;
+  tokenType: string | Default<"">;
+  scope: string[] | Default<[]>;
+  expiresIn: number | Default<0>;
+  expiresAt: number | Default<0>;
+  refreshToken: Secret<string> | Default<"">;
+  user: {
     email: string;
     name: string;
     picture: string;
-  }, { email: ""; name: ""; picture: "" }>;
+  } | Default<{ email: ""; name: ""; picture: "" }>;
 };
 
 export type CalendarEvent = {
@@ -50,10 +50,9 @@ export type CalendarEvent = {
   htmlLink: string;
   calendarId: string;
   calendarName: string;
-  attendees: Default<
-    { email: string; displayName: string; responseStatus: string }[],
-    []
-  >;
+  attendees:
+    | { email: string; displayName: string; responseStatus: string }[]
+    | Default<[]>;
   organizer: { email: string; displayName: string };
 };
 
@@ -68,13 +67,13 @@ export type Calendar = {
 
 type Settings = {
   // Number of days in the past to fetch
-  daysBack: Default<number, 7>;
+  daysBack: number | Default<7>;
   // Number of days in the future to fetch
-  daysForward: Default<number, 30>;
+  daysForward: number | Default<30>;
   // Maximum number of events to fetch per calendar
-  maxResults: Default<number, 100>;
+  maxResults: number | Default<100>;
   // Enable verbose console logging for debugging
-  debugMode: Default<boolean, false>;
+  debugMode: boolean | Default<false>;
 };
 
 // Debug logging helpers
@@ -503,12 +502,14 @@ function formatEventDate(
 }
 
 interface GoogleCalendarImporterInput {
-  settings?: Default<Settings, {
-    daysBack: 7;
-    daysForward: 30;
-    maxResults: 100;
-    debugMode: false;
-  }>;
+  settings?:
+    | Settings
+    | Default<{
+      daysBack: 7;
+      daysForward: 30;
+      maxResults: 100;
+      debugMode: false;
+    }>;
   // Optional: Link auth directly from a Google Auth piece when wish() is unavailable
   // Use: cf piece link googleAuthPiece/auth calendarImporterPiece/overrideAuth
   overrideAuth?: Auth;

--- a/packages/patterns/google/core/imported-calendar.tsx
+++ b/packages/patterns/google/core/imported-calendar.tsx
@@ -58,8 +58,8 @@ type LocalEvent = {
 };
 
 interface Input {
-  title?: Default<string, "Imported Calendar">;
-  localEvents?: Writable<Default<LocalEvent[], []>>;
+  title?: string | Default<"Imported Calendar">;
+  localEvents?: Writable<LocalEvent[] | Default<[]>>;
 }
 
 interface Output {

--- a/packages/patterns/google/extractors/bam-school-dashboard.tsx
+++ b/packages/patterns/google/extractors/bam-school-dashboard.tsx
@@ -37,10 +37,10 @@ import ProcessingStatus from "../core/processing-status.tsx";
 // =============================================================================
 
 interface SchoolSettings {
-  childName: Default<string, "Adeline Komoroske">;
-  schoolName: Default<string, "Berkeley Arts Magnet">;
-  grade: Default<string, "Kindergarten">;
-  teacher: Default<string, "Mr. Zaragoza">;
+  childName: string | Default<"Adeline Komoroske">;
+  schoolName: string | Default<"Berkeley Arts Magnet">;
+  grade: string | Default<"Kindergarten">;
+  teacher: string | Default<"Mr. Zaragoza">;
 }
 
 type EventCategory =
@@ -278,16 +278,15 @@ const restoreEvent = handler<
 // =============================================================================
 
 interface PatternInput {
-  settings?: Default<
-    SchoolSettings,
-    {
+  settings?:
+    | SchoolSettings
+    | Default<{
       childName: "Adeline Komoroske";
       schoolName: "Berkeley Arts Magnet";
       grade: "Kindergarten";
       teacher: "Mr. Zaragoza";
-    }
-  >;
-  dismissedIds?: Writable<Default<string[], []>>;
+    }>;
+  dismissedIds?: Writable<string[] | Default<[]>>;
   overrideAuth?: Auth;
 }
 

--- a/packages/patterns/google/extractors/berkeley-library.tsx
+++ b/packages/patterns/google/extractors/berkeley-library.tsx
@@ -356,11 +356,11 @@ const toggleItemSelection = handler<
   unknown,
   {
     item: TrackedItem;
-    selectedItems: Writable<Default<string[], []>>;
+    selectedItems: Writable<string[] | Default<[]>>;
   }
 >((_, { item, selectedItems }) => {
   const key = item.key; // Access key inside handler context
-  const current = selectedItems.get() || [];
+  const current = (selectedItems.get() || []) as string[];
   const idx = current.indexOf(key);
   if (idx >= 0) {
     selectedItems.set(current.filter((k: string) => k !== key));
@@ -379,7 +379,7 @@ const toggleItemSelection = handler<
 const markAsReturnedHandler = handler<
   { title: string },
   {
-    manuallyReturned: Writable<Default<string[], []>>;
+    manuallyReturned: Writable<string[] | Default<[]>>;
     rawAnalyses: Array<{
       analysis?: { result?: LibraryEmailAnalysis };
     }>;
@@ -393,7 +393,7 @@ const markAsReturnedHandler = handler<
   const searchTitle = byMatch ? byMatch[1].trim() : normalizedInput;
   const searchAuthor = byMatch ? byMatch[2].trim() : "";
 
-  const current = manuallyReturned.get() || [];
+  const current = (manuallyReturned.get() || []) as string[];
   const keysToAdd: string[] = [];
 
   // Search through all analyzed emails for matching items
@@ -437,7 +437,7 @@ const markAsReturnedHandler = handler<
 const dismissHoldHandler = handler<
   { title: string },
   {
-    dismissedHolds: Writable<Default<string[], []>>;
+    dismissedHolds: Writable<string[] | Default<[]>>;
     rawAnalyses: Array<{
       analysis?: { result?: LibraryEmailAnalysis };
     }>;
@@ -451,7 +451,7 @@ const dismissHoldHandler = handler<
   const searchTitle = byMatch ? byMatch[1].trim() : normalizedInput;
   const searchAuthor = byMatch ? byMatch[2].trim() : "";
 
-  const current = dismissedHolds.get() || [];
+  const current = (dismissedHolds.get() || []) as string[];
   const keysToAdd: string[] = [];
 
   // Search through all analyzed emails for matching holds
@@ -492,9 +492,9 @@ const setDueDateForGroup = handler<
   unknown,
   {
     groupItems: TrackedItem[];
-    selectedItems: Writable<Default<string[], []>>;
+    selectedItems: Writable<string[] | Default<[]>>;
     dueDateOverrides: Writable<
-      Default<Record<string, string>, Record<string, never>>
+      Record<string, string> | Default<Record<string, never>>
     >;
   }
 >((event, { groupItems, selectedItems, dueDateOverrides }) => {
@@ -503,7 +503,7 @@ const setDueDateForGroup = handler<
   if (!newDueDate) return;
 
   // Get selected items in this group (not in deselected list = selected)
-  const deselectedKeys = selectedItems.get() || [];
+  const deselectedKeys = (selectedItems.get() || []) as string[];
   const selectedInThisGroup = groupItems.filter(
     (item: TrackedItem) => !deselectedKeys.includes(item.key),
   );
@@ -537,14 +537,14 @@ interface PatternInput {
   // Use: cf piece link googleAuthPiece/auth berkeleyLibraryPiece/overrideAuth
   overrideAuth?: Auth;
   // Track items manually marked as returned (persisted)
-  manuallyReturned?: Writable<Default<string[], []>>;
+  manuallyReturned?: Writable<string[] | Default<[]>>;
   // Track holds manually dismissed (persisted)
-  dismissedHolds?: Writable<Default<string[], []>>;
+  dismissedHolds?: Writable<string[] | Default<[]>>;
   // Track selected items for bulk operations (per-group checkboxes)
-  selectedItems?: Writable<Default<string[], []>>;
+  selectedItems?: Writable<string[] | Default<[]>>;
   // Track manual due date overrides (persisted)
   dueDateOverrides?: Writable<
-    Default<Record<string, string>, Record<string, never>>
+    Record<string, string> | Default<Record<string, never>>
   >;
 }
 

--- a/packages/patterns/google/extractors/bofa-bill-tracker.tsx
+++ b/packages/patterns/google/extractors/bofa-bill-tracker.tsx
@@ -100,8 +100,8 @@ const unmarkAsPaid = handler<
 
 interface PatternInput {
   overrideAuth?: Auth;
-  manuallyPaid?: Writable<Default<string[], []>>;
-  demoMode?: Writable<Default<boolean, true>>;
+  manuallyPaid?: Writable<string[] | Default<[]>>;
+  demoMode?: Writable<boolean | Default<true>>;
 }
 
 export default pattern<PatternInput>(

--- a/packages/patterns/google/extractors/chase-bill-tracker.tsx
+++ b/packages/patterns/google/extractors/chase-bill-tracker.tsx
@@ -100,8 +100,8 @@ const unmarkAsPaid = handler<
 
 interface PatternInput {
   overrideAuth?: Auth;
-  manuallyPaid?: Writable<Default<string[], []>>;
-  demoMode?: Writable<Default<boolean, true>>;
+  manuallyPaid?: Writable<string[] | Default<[]>>;
+  demoMode?: Writable<boolean | Default<true>>;
 }
 
 export default pattern<PatternInput>(

--- a/packages/patterns/google/extractors/favorite-foods-gmail-agent.tsx
+++ b/packages/patterns/google/extractors/favorite-foods-gmail-agent.tsx
@@ -74,10 +74,10 @@ type FoodPreference = InferItem<typeof FoodSchema> & { extractedAt: number };
 // PATTERN INPUT/OUTPUT
 // ============================================================================
 interface FavoriteFoodsInput {
-  foods?: Default<FoodPreference[], []>;
-  lastScanAt?: Default<number, 0>;
-  isScanning?: Default<boolean, false>;
-  maxSearches?: Default<number, 5>;
+  foods?: FoodPreference[] | Default<[]>;
+  lastScanAt?: number | Default<0>;
+  isScanning?: boolean | Default<false>;
+  maxSearches?: number | Default<5>;
 }
 
 /** Favorite foods extractor from Gmail. #favoriteFoods */

--- a/packages/patterns/google/extractors/hotel-membership-gmail-agent.tsx
+++ b/packages/patterns/google/extractors/hotel-membership-gmail-agent.tsx
@@ -98,21 +98,23 @@ type MembershipRecord = InferItem<typeof MembershipSchema> & {
 };
 
 interface HotelMembershipInput {
-  memberships?: Default<MembershipRecord[], []>;
-  lastScanAt?: Default<number, 0>;
-  isScanning?: Default<boolean, false>;
-  maxSearches?: Default<number, 0>; // 0 = unlimited, >0 = limit searches
+  memberships?: MembershipRecord[] | Default<[]>;
+  lastScanAt?: number | Default<0>;
+  isScanning?: boolean | Default<false>;
+  maxSearches?: number | Default<0>; // 0 = unlimited, >0 = limit searches
   // Current scan mode - persisted to know if last scan was full or recent
-  currentScanMode?: Default<ScanMode, "full">;
+  currentScanMode?: ScanMode | Default<"full">;
   // Multi-account support: which Google account to use
-  accountType?: Default<"default" | "personal" | "work", "default">;
+  accountType?: "default" | "personal" | "work" | Default<"default">;
   // Shared with base pattern for coordinating progress UI
-  searchProgress?: Default<SearchProgress, {
-    currentQuery: "";
-    completedQueries: [];
-    status: "idle";
-    searchCount: 0;
-  }>;
+  searchProgress?:
+    | SearchProgress
+    | Default<{
+      currentQuery: "";
+      completedQueries: [];
+      status: "idle";
+      searchCount: 0;
+    }>;
 }
 
 /** Hotel loyalty membership extractor from Gmail. #hotelMemberships */
@@ -176,9 +178,9 @@ const startScan = handler<
   {
     mode: ScanMode;
     searchLimit: number; // 0 = unlimited, >0 = limit
-    currentScanMode: Writable<Default<ScanMode, "full">>;
-    maxSearches: Writable<Default<number, 0>>;
-    isScanning: Writable<Default<boolean, false>>;
+    currentScanMode: Writable<ScanMode | Default<"full">>;
+    maxSearches: Writable<number | Default<0>>;
+    isScanning: Writable<boolean | Default<false>>;
     searchProgress: Writable<SearchProgress>;
   }
 >((_, state) => {

--- a/packages/patterns/google/extractors/pge-bill-tracker.tsx
+++ b/packages/patterns/google/extractors/pge-bill-tracker.tsx
@@ -99,8 +99,8 @@ const unmarkAsPaid = handler<
 
 interface PatternInput {
   overrideAuth?: Auth;
-  manuallyPaid?: Writable<Default<string[], []>>;
-  demoMode?: Writable<Default<boolean, true>>;
+  manuallyPaid?: Writable<string[] | Default<[]>>;
+  demoMode?: Writable<boolean | Default<true>>;
 }
 
 export default pattern<PatternInput>(

--- a/packages/patterns/google/extractors/usps-informed-delivery.tsx
+++ b/packages/patterns/google/extractors/usps-informed-delivery.tsx
@@ -262,7 +262,7 @@ const deleteMember = handler<
 // =============================================================================
 
 interface PatternInput {
-  householdMembers?: Default<HouseholdMember[], []>;
+  householdMembers?: HouseholdMember[] | Default<[]>;
   // Optional: Link auth directly from a Google Auth piece
   // Use: cf piece link googleAuthPiece/auth uspsPiece/overrideAuth
   overrideAuth?: Auth;

--- a/packages/patterns/group-chat-lobby.tsx
+++ b/packages/patterns/group-chat-lobby.tsx
@@ -21,17 +21,17 @@ import GroupChatRoom, { Message, User } from "./group-chat-room.tsx";
  */
 
 interface LobbyInput {
-  chatName: Default<string, "Group Chat">;
-  messages: Writable<Default<Message[], []>>;
-  users: Writable<Default<User[], []>>;
-  sessionId: Writable<Default<string, "">>;
+  chatName: string | Default<"Group Chat">;
+  messages: Writable<Message[] | Default<[]>>;
+  users: Writable<User[] | Default<[]>>;
+  sessionId: Writable<string | Default<"">>;
 }
 
 interface LobbyOutput {
-  chatName: Default<string, "Group Chat">;
-  messages: Writable<Default<Message[], []>>;
-  users: Writable<Default<User[], []>>;
-  sessionId: Writable<Default<string, "">>;
+  chatName: string | Default<"Group Chat">;
+  messages: Writable<Message[] | Default<[]>>;
+  users: Writable<User[] | Default<[]>>;
+  sessionId: Writable<string | Default<"">>;
 }
 
 // Random color selection from a pool of distinct colors

--- a/packages/patterns/group-chat-room.tsx
+++ b/packages/patterns/group-chat-room.tsx
@@ -45,15 +45,15 @@ export interface User {
 }
 
 interface RoomInput {
-  messages: Writable<Default<Message[], []>>;
-  users: Writable<Default<User[], []>>;
-  myName: Default<string, "">;
-  mySessionId: Default<string, "">;
-  currentSessionId: Writable<Default<string, "">>;
+  messages: Writable<Message[] | Default<[]>>;
+  users: Writable<User[] | Default<[]>>;
+  myName: string | Default<"">;
+  mySessionId: string | Default<"">;
+  currentSessionId: Writable<string | Default<"">>;
 }
 
 interface RoomOutput {
-  myName: Default<string, "">;
+  myName: string | Default<"">;
 }
 
 // Common reaction emojis

--- a/packages/patterns/habit-tracker/schemas.tsx
+++ b/packages/patterns/habit-tracker/schemas.tsx
@@ -4,8 +4,8 @@ import { Default, NAME, Stream, UI, type VNode, Writable } from "commonfabric";
 
 export interface Habit {
   name: string;
-  icon: Default<string, "✓">;
-  color: Default<string, "#3b82f6">;
+  icon: string | Default<"✓">;
+  color: string | Default<"#3b82f6">;
 }
 
 export interface HabitLog {
@@ -17,8 +17,8 @@ export interface HabitLog {
 // === Pattern Types ===
 
 export interface HabitTrackerInput {
-  habits: Writable<Default<Habit[], []>>;
-  logs: Writable<Default<HabitLog[], []>>;
+  habits: Writable<Habit[] | Default<[]>>;
+  logs: Writable<HabitLog[] | Default<[]>>;
 }
 
 export interface HabitTrackerOutput {

--- a/packages/patterns/image.tsx
+++ b/packages/patterns/image.tsx
@@ -8,8 +8,8 @@ import {
 } from "commonfabric";
 
 type ImageInput = {
-  url: Default<string, "">;
-  caption: Default<string, "">;
+  url: string | Default<"">;
+  caption: string | Default<"">;
 };
 
 type ImageOutput = {

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -22,13 +22,13 @@ type AnnotationKind = "note" | "todo" | "wish";
 type AnnotationStatus = "open" | "in-progress" | "resolved" | "dismissed";
 
 interface AnnotationInput {
-  content: Writable<Default<string, "">>;
-  kind: Writable<Default<AnnotationKind, "note">>;
-  status: Writable<Default<AnnotationStatus, "open">>;
-  targetPiece: Writable<Default<MentionablePiece | null, null>>;
-  blockedBy: Writable<Default<AnnotationPiece[], []>>;
-  isAnnotation: Default<boolean, true>;
-  isHidden: Default<boolean, false>;
+  content: Writable<string | Default<"">>;
+  kind: Writable<AnnotationKind | Default<"note">>;
+  status: Writable<AnnotationStatus | Default<"open">>;
+  targetPiece: Writable<MentionablePiece | null | Default<null>>;
+  blockedBy: Writable<AnnotationPiece[] | Default<[]>>;
+  isAnnotation: boolean | Default<true>;
+  isHidden: boolean | Default<false>;
 }
 ```
 
@@ -84,14 +84,14 @@ worker, bot, automation
 type AgentStatus = "idle" | "running" | "error";
 
 interface AgentInput {
-  agentName?: Writable<Default<string, "Unnamed Agent">>;
-  directive?: Writable<Default<string, "">>;
-  enabled?: Writable<Default<boolean, true>>;
-  learned?: Writable<Default<string, "">>;
-  status?: Writable<Default<AgentStatus, "idle">>;
-  lastRun?: Writable<Default<string, "">>;
-  lastRunSummary?: Writable<Default<string, "">>;
-  isAgent?: Default<boolean, true>;
+  agentName?: Writable<string | Default<"Unnamed Agent">>;
+  directive?: Writable<string | Default<"">>;
+  enabled?: Writable<boolean | Default<true>>;
+  learned?: Writable<string | Default<"">>;
+  status?: Writable<AgentStatus | Default<"idle">>;
+  lastRun?: Writable<string | Default<"">>;
+  lastRunSummary?: Writable<string | Default<"">>;
+  isAgent?: boolean | Default<true>;
 }
 ```
 
@@ -148,7 +148,7 @@ A simple counter demo.
 
 ```ts
 interface CounterInput {
-  value?: Writable<Default<number, 0>>;
+  value?: Writable<number | Default<0>>;
 }
 ```
 
@@ -174,13 +174,13 @@ LLM-friendly title-based handlers.
 ```ts
 interface DoItem {
   title: string;
-  done: Default<boolean, false>;
-  indent: Default<number, 0>;
-  aiEnabled: Default<boolean, false>;
+  done: boolean | Default<false>;
+  indent: number | Default<0>;
+  aiEnabled: boolean | Default<false>;
 }
 
 interface DoListInput {
-  items?: Writable<Default<DoItem[], []>>;
+  items?: Writable<DoItem[] | Default<[]>>;
 }
 ```
 
@@ -215,11 +215,11 @@ A todo list with AI suggestions.
 ```ts
 interface TodoItem {
   title: string;
-  done: Default<boolean, false>;
+  done: boolean | Default<false>;
 }
 
 interface TodoListInput {
-  items?: Writable<Default<TodoItem[], []>>;
+  items?: Writable<TodoItem[] | Default<[]>>;
 }
 ```
 
@@ -246,12 +246,12 @@ containers.
 ```ts
 interface SimpleListItem {
   text: string;
-  indented: Default<boolean, false>;
-  done: Default<boolean, false>;
+  indented: boolean | Default<false>;
+  done: boolean | Default<false>;
 }
 
 interface SimpleListInput {
-  items?: Writable<Default<SimpleListItem[], []>>;
+  items?: Writable<SimpleListItem[] | Default<[]>>;
 }
 ```
 
@@ -278,14 +278,14 @@ store-specific layouts.
 ```ts
 interface ShoppingItem {
   title: string;
-  done: Default<boolean, false>;
-  aisleSeed: Default<number, 0>;
-  aisleOverride: Default<string, "">;
+  done: boolean | Default<false>;
+  aisleSeed: number | Default<0>;
+  aisleOverride: string | Default<"">;
 }
 
 interface Input {
-  items: Writable<Default<ShoppingItem[], []>>;
-  storeLayout: Writable<Default<string, "">>;
+  items: Writable<ShoppingItem[] | Default<[]>>;
+  storeLayout: Writable<string | Default<"">>;
 }
 ```
 
@@ -314,10 +314,10 @@ A note with wiki-links, backlinks, and embedding support. Managed by
 
 ```ts
 type Input = {
-  title?: Writable<Default<string, "Untitled Note">>;
-  content?: Writable<Default<string, "">>;
-  isHidden?: Default<boolean, false>;
-  noteId?: Default<string, "">;
+  title?: Writable<string | Default<"Untitled Note">>;
+  content?: Writable<string | Default<"">>;
+  isHidden?: boolean | Default<false>;
+  noteId?: string | Default<"">;
   parentNotebook?: any;
 };
 ```
@@ -347,10 +347,10 @@ Notebook pattern managing notes and nested notebooks. Creates and organizes
 
 ```ts
 interface Input {
-  title?: Default<string, "Notebook">;
-  notes?: Writable<Default<NotePiece[], []>>;
-  isNotebook?: Default<boolean, true>;
-  isHidden?: Default<boolean, false>;
+  title?: string | Default<"Notebook">;
+  notes?: Writable<NotePiece[] | Default<[]>>;
+  isNotebook?: boolean | Default<true>;
+  isHidden?: boolean | Default<false>;
   parentNotebook?: any;
 }
 ```
@@ -386,7 +386,7 @@ microphone button to record, release to transcribe.
 
 ```ts
 type Input = {
-  title?: Writable<Default<string, "Voice Note">>;
+  title?: Writable<string | Default<"Voice Note">>;
 };
 ```
 
@@ -403,8 +403,8 @@ interface TranscriptionData {
 }
 
 type Output = {
-  transcription: Default<TranscriptionData | null, null>;
-  notes: Default<TranscriptionData[], []>;
+  transcription: TranscriptionData | null | Default<null>;
+  notes: TranscriptionData[] | Default<[]>;
 };
 ```
 
@@ -419,7 +419,7 @@ today highlighted.
 
 ```ts
 interface CalendarInput {
-  events?: Writable<Default<EventPiece[], []>>;
+  events?: Writable<EventPiece[] | Default<[]>>;
 }
 ```
 
@@ -446,10 +446,10 @@ Weekly calendar with drag-and-drop event creation and resizing. Manages
 
 ```ts
 interface Input {
-  title?: Default<string, "Weekly Calendar">;
-  events: Writable<Default<EventPiece[], []>>;
-  isCalendar?: Default<boolean, true>;
-  isHidden?: Default<boolean, false>;
+  title?: string | Default<"Weekly Calendar">;
+  events: Writable<EventPiece[] | Default<[]>>;
+  isCalendar?: boolean | Default<true>;
+  isHidden?: boolean | Default<false>;
 }
 ```
 
@@ -485,23 +485,23 @@ can be linked together with labels (friend, spouse, colleague, etc.).
 ```ts
 interface Contact {
   name: string;
-  email: Default<string, "">;
-  phone: Default<string, "">;
-  company: Default<string, "">;
-  tags: Default<string[], []>;
-  notes: Default<string, "">;
+  email: string | Default<"">;
+  phone: string | Default<"">;
+  company: string | Default<"">;
+  tags: string[] | Default<[]>;
+  notes: string | Default<"">;
   createdAt: number;
 }
 
 interface Relationship {
   fromName: string;
   toName: string;
-  label: Default<string, "">;
+  label: string | Default<"">;
 }
 
 interface ContactBookInput {
-  contacts: Writable<Default<Contact[], []>>;
-  relationships: Writable<Default<Relationship[], []>>;
+  contacts: Writable<Contact[] | Default<[]>>;
+  relationships: Writable<Relationship[] | Default<[]>>;
 }
 ```
 
@@ -527,8 +527,8 @@ habits complete for today and see your progress over time.
 ```ts
 interface Habit {
   name: string;
-  icon: Default<string, "✓">;
-  color: Default<string, "#3b82f6">;
+  icon: string | Default<"✓">;
+  color: string | Default<"#3b82f6">;
 }
 
 interface HabitLog {
@@ -538,8 +538,8 @@ interface HabitLog {
 }
 
 interface HabitTrackerInput {
-  habits: Writable<Default<Habit[], []>>;
-  logs: Writable<Default<HabitLog[], []>>;
+  habits: Writable<Habit[] | Default<[]>>;
+  logs: Writable<HabitLog[] | Default<[]>>;
 }
 ```
 
@@ -570,7 +570,7 @@ type ItemType = "book" | "article" | "paper" | "video";
 type ItemStatus = "want" | "reading" | "finished" | "abandoned";
 
 interface ReadingListInput {
-  items?: Writable<Default<ReadingItemPiece[], []>>;
+  items?: Writable<ReadingItemPiece[] | Default<[]>>;
 }
 ```
 
@@ -608,7 +608,7 @@ Multi-file pattern using sub-patterns for the form and data views.
 interface Expense {
   description: string;
   amount: number;
-  category: Default<string, "Other">;
+  category: string | Default<"Other">;
   date: string; // YYYY-MM-DD
 }
 
@@ -618,8 +618,8 @@ interface CategoryBudget {
 }
 
 interface Input {
-  expenses: Writable<Default<Expense[], []>>;
-  budgets: Writable<Default<CategoryBudget[], []>>;
+  expenses: Writable<Expense[] | Default<[]>>;
+  budgets: Writable<CategoryBudget[] | Default<[]>>;
 }
 ```
 
@@ -643,7 +643,7 @@ mentionables. Deploy this to have a conversational AI interface.
 
 ```ts
 type ChatInput = {
-  messages?: Writable<Default<Array<BuiltInLLMMessage>, []>>;
+  messages?: Writable<Array<BuiltInLLMMessage> | Default<[]>>;
   tools?: any;
   theme?: any;
   system?: string;
@@ -693,10 +693,10 @@ interface User {
 }
 
 interface LobbyInput {
-  chatName: Default<string, "Group Chat">;
-  messages: Writable<Default<Message[], []>>;
-  users: Writable<Default<User[], []>>;
-  sessionId: Writable<Default<string, "">>;
+  chatName: string | Default<"Group Chat">;
+  messages: Writable<Message[] | Default<[]>>;
+  users: Writable<User[] | Default<[]>>;
+  sessionId: Writable<string | Default<"">>;
 }
 ```
 
@@ -724,14 +724,14 @@ positioning, and item location corrections. Generates layout data used by
 ```ts
 interface Aisle {
   name: string;
-  description: Default<string, "">;
+  description: string | Default<"">;
 }
 
 interface Department {
   name: string;
   icon: string;
-  location: Default<WallPosition, "unassigned">;
-  description: Default<string, "">;
+  location: WallPosition | Default<"unassigned">;
+  description: string | Default<"">;
 }
 
 interface Entrance {
@@ -741,16 +741,16 @@ interface Entrance {
 interface ItemLocation {
   itemName: string;
   correctAisle: string;
-  incorrectAisle: Default<string, "">;
+  incorrectAisle: string | Default<"">;
   timestamp: number;
 }
 
 interface Input {
-  storeName: Writable<Default<string, "My Store">>;
-  aisles: Writable<Default<Aisle[], []>>;
-  departments: Writable<Default<Department[], []>>;
-  entrances: Writable<Default<Entrance[], []>>;
-  itemLocations: Writable<Default<ItemLocation[], []>>;
+  storeName: Writable<string | Default<"My Store">>;
+  aisles: Writable<Aisle[] | Default<[]>>;
+  departments: Writable<Department[] | Default<[]>>;
+  entrances: Writable<Entrance[] | Default<[]>>;
+  itemLocations: Writable<ItemLocation[] | Default<[]>>;
 }
 ```
 
@@ -778,8 +778,8 @@ rendering images when an LLM has a URL to display.
 
 ```ts
 interface ImageInput {
-  url?: Default<string, "">;
-  caption?: Default<string, "">;
+  url?: string | Default<"">;
+  caption?: string | Default<"">;
 }
 ```
 
@@ -809,9 +809,9 @@ result with summary, confidence, and sources. Supports follow-up refinement.
 ```ts
 type Input = {
   /** The research question to investigate */
-  situation: Default<string, "What are the latest developments in AI agents?">;
+  situation: string | Default<"What are the latest developments in AI agents?">;
   /** Message history (managed by llmDialog) */
-  messages?: Writable<Default<Array<BuiltInLLMMessage>, []>>;
+  messages?: Writable<Array<BuiltInLLMMessage> | Default<[]>>;
   /** Optional context cells to provide to the agent */
   context?: { [id: string]: any };
 };
@@ -871,7 +871,7 @@ for personalized text generation.
 
 ```ts
 type Input = {
-  title?: Default<string, "Profile-Aware Writer">;
+  title?: string | Default<"Profile-Aware Writer">;
 };
 ```
 
@@ -901,10 +901,10 @@ Detail/edit view for a single calendar event.
 
 ```ts
 interface EventDetailInput {
-  title?: Writable<Default<string, "">>;
-  date?: Writable<Default<string, "">>;
-  time?: Writable<Default<string, "">>;
-  notes?: Writable<Default<string, "">>;
+  title?: Writable<string | Default<"">>;
+  date?: Writable<string | Default<"">>;
+  time?: Writable<string | Default<"">>;
+  notes?: Writable<string | Default<"">>;
 }
 ```
 
@@ -935,11 +935,11 @@ or as a standalone contact editor.
 ```ts
 interface Contact {
   name: string;
-  email: Default<string, "">;
-  phone: Default<string, "">;
-  company: Default<string, "">;
-  tags: Default<string[], []>;
-  notes: Default<string, "">;
+  email: string | Default<"">;
+  phone: string | Default<"">;
+  company: string | Default<"">;
+  tags: string[] | Default<[]>;
+  notes: string | Default<"">;
   createdAt: number;
 }
 
@@ -970,15 +970,15 @@ type ItemType = "book" | "article" | "paper" | "video";
 type ItemStatus = "want" | "reading" | "finished" | "abandoned";
 
 interface ReadingItemDetailInput {
-  title?: Writable<Default<string, "">>;
-  author?: Writable<Default<string, "">>;
-  url?: Writable<Default<string, "">>;
-  type?: Writable<Default<ItemType, "article">>;
-  status?: Writable<Default<ItemStatus, "want">>;
-  rating?: Writable<Default<number | null, null>>;
-  notes?: Writable<Default<string, "">>;
-  addedAt?: Default<number, 0>;
-  finishedAt?: Default<number | null, null>;
+  title?: Writable<string | Default<"">>;
+  author?: Writable<string | Default<"">>;
+  url?: Writable<string | Default<"">>;
+  type?: Writable<ItemType | Default<"article">>;
+  status?: Writable<ItemStatus | Default<"want">>;
+  rating?: Writable<number | null | Default<null>>;
+  notes?: Writable<string | Default<"">>;
+  addedAt?: number | Default<0>;
+  finishedAt?: number | null | Default<null>;
 }
 ```
 
@@ -1019,8 +1019,8 @@ Generates a concise summary of provided context using an LLM.
 
 ```ts
 type SummaryInput = {
-  topic?: Default<string, "">;
-  context?: Default<Record<string, any>, Record<string, never>>;
+  topic?: string | Default<"">;
+  context?: Record<string, any> | Default<Record<string, never>>;
 };
 ```
 
@@ -1044,8 +1044,8 @@ Generates a checklist of actionable steps from a topic and context.
 
 ```ts
 type ChecklistInput = {
-  topic?: Default<string, "">;
-  context?: Default<Record<string, any>, Record<string, never>>;
+  topic?: string | Default<"">;
+  context?: Record<string, any> | Default<Record<string, never>>;
 };
 ```
 
@@ -1054,7 +1054,7 @@ type ChecklistInput = {
 ```ts
 type ChecklistItem = {
   label: string;
-  done: Default<boolean, false>;
+  done: boolean | Default<false>;
 };
 
 type ChecklistOutput = {
@@ -1074,8 +1074,8 @@ Generates a clarifying question with optional multiple-choice options.
 
 ```ts
 type QuestionInput = {
-  topic?: Default<string, "">;
-  context?: Default<Record<string, any>, Record<string, never>>;
+  topic?: string | Default<"">;
+  context?: Record<string, any> | Default<Record<string, never>>;
 };
 ```
 
@@ -1102,8 +1102,8 @@ Rendered in a `<pre>` tag with monospace styling.
 
 ```ts
 type DiagramInput = {
-  topic?: Default<string, "">;
-  context?: Default<Record<string, any>, Record<string, never>>;
+  topic?: string | Default<"">;
+  context?: Record<string, any> | Default<Record<string, never>>;
 };
 ```
 
@@ -1128,8 +1128,8 @@ Rendered via `<cf-svg>` web component for scalable vector output.
 
 ```ts
 type SvgDiagramInput = {
-  topic?: Default<string, "">;
-  context?: Default<Record<string, any>, Record<string, never>>;
+  topic?: string | Default<"">;
+  context?: Record<string, any> | Default<Record<string, never>>;
 };
 ```
 
@@ -1154,9 +1154,9 @@ suggests spending categories that sum to the given budget ceiling.
 
 ```ts
 type BudgetInput = {
-  topic?: Default<string, "">;
-  context?: Default<Record<string, any>, Record<string, never>>;
-  maxAmount?: Default<number, 1000>;
+  topic?: string | Default<"">;
+  context?: Record<string, any> | Default<Record<string, never>>;
+  maxAmount?: number | Default<1000>;
 };
 ```
 
@@ -1165,7 +1165,7 @@ type BudgetInput = {
 ```ts
 type BudgetItem = {
   name: string;
-  amount: Default<number, 0>;
+  amount: number | Default<0>;
 };
 
 type BudgetOutput = {
@@ -1195,7 +1195,7 @@ type PersonListInput = Record<string, never>;
 type Person = {
   contact: {
     name: string;
-    email: Default<string, "">;
+    email: string | Default<"">;
   };
 };
 
@@ -1289,7 +1289,7 @@ re-summarizes.
 ```ts
 type Input = {
   repoUrl: Writable<
-    Default<string, "https://github.com/anthropics/claude-code">
+    string | Default<"https://github.com/anthropics/claude-code">
   >;
 };
 ```
@@ -1316,12 +1316,12 @@ cf-link-preview, cf-grid
 ```ts
 interface Bookmark {
   url: string;
-  title: Default<string, "">;
-  description: Default<string, "">;
+  title: string | Default<"">;
+  description: string | Default<"">;
 }
 
 interface BookmarksInput {
-  bookmarks?: Writable<Default<Bookmark[], []>>;
+  bookmarks?: Writable<Bookmark[] | Default<[]>>;
 }
 ```
 
@@ -1346,7 +1346,7 @@ metadata and screenshot.
 
 ```ts
 interface LinkPreviewInput {
-  url: Default<string, "https://github.com">;
+  url: string | Default<"https://github.com">;
 }
 ```
 

--- a/packages/patterns/link-preview.tsx
+++ b/packages/patterns/link-preview.tsx
@@ -1,7 +1,7 @@
 import { computed, type Default, NAME, pattern, UI } from "commonfabric";
 
 interface LinkPreviewInput {
-  url: Default<string, "https://github.com">;
+  url: string | Default<"https://github.com">;
 }
 
 export const LinkPreview = pattern<LinkPreviewInput, LinkPreviewInput>(

--- a/packages/patterns/link.tsx
+++ b/packages/patterns/link.tsx
@@ -23,11 +23,11 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface LinkModuleInput {
   /** URL */
-  url: Default<string, "">;
+  url: string | Default<"">;
   /** Link title */
-  linkTitle: Default<string, "">;
+  linkTitle: string | Default<"">;
   /** Description */
-  description: Default<string, "">;
+  description: string | Default<"">;
 }
 
 // ===== The Pattern =====

--- a/packages/patterns/location-track.tsx
+++ b/packages/patterns/location-track.tsx
@@ -81,9 +81,9 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Module Input Type =====
 export interface LocationTrackModuleInput {
   /** Array of captured location points */
-  locations: Default<LocationPoint[], []>;
+  locations: LocationPoint[] | Default<[]>;
   /** Optional label for this track (e.g., "Morning run", "Commute") */
-  label: Default<string, "">;
+  label: string | Default<"">;
 }
 
 // ===== Handlers =====

--- a/packages/patterns/location.tsx
+++ b/packages/patterns/location.tsx
@@ -23,11 +23,11 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface LocationModuleInput {
   /** Location name (e.g., venue, landmark) */
-  locationName: Default<string, "">;
+  locationName: string | Default<"">;
   /** Full address */
-  locationAddress: Default<string, "">;
+  locationAddress: string | Default<"">;
   /** Coordinates in lat,lng format */
-  coordinates: Default<string, "">;
+  coordinates: string | Default<"">;
 }
 
 // ===== The Pattern =====

--- a/packages/patterns/map-demo.tsx
+++ b/packages/patterns/map-demo.tsx
@@ -30,29 +30,29 @@ interface LatLng {
 interface TripStop {
   position: LatLng;
   title: string;
-  description: Default<string, "">;
-  icon: Default<string, "pin">;
-  draggable: Default<boolean, false>;
+  description: string | Default<"">;
+  icon: string | Default<"pin">;
+  draggable: boolean | Default<false>;
 }
 
 interface AreaOfInterest {
   center: LatLng;
   radius: number; // meters
   title: string;
-  description: Default<string, "">;
-  color: Default<string, "#3b82f6">;
+  description: string | Default<"">;
+  color: string | Default<"#3b82f6">;
 }
 
 interface Input {
-  tripName: Default<string, "My Bay Area Trip">;
-  stops: Cell<Default<TripStop[], []>>;
-  areasOfInterest: Cell<Default<AreaOfInterest[], []>>;
-  showRoute: Cell<Default<boolean, true>>;
-  center: Cell<Default<LatLng | null, null>>;
-  zoom: Cell<Default<number, 9>>;
-  selectedStopIndex: Cell<Default<number | null, null>>;
-  fitBoundsTrigger: Cell<Default<number, 0>>;
-  initialized: Cell<Default<boolean, false>>;
+  tripName: string | Default<"My Bay Area Trip">;
+  stops: Cell<TripStop[] | Default<[]>>;
+  areasOfInterest: Cell<AreaOfInterest[] | Default<[]>>;
+  showRoute: Cell<boolean | Default<true>>;
+  center: Cell<LatLng | null | Default<null>>;
+  zoom: Cell<number | Default<9>>;
+  selectedStopIndex: Cell<number | null | Default<null>>;
+  fitBoundsTrigger: Cell<number | Default<0>>;
+  initialized: Cell<boolean | Default<false>>;
 }
 
 interface Output {

--- a/packages/patterns/nested-map-ifelse-test.tsx
+++ b/packages/patterns/nested-map-ifelse-test.tsx
@@ -26,17 +26,19 @@ import {
 
 interface Item {
   title: string;
-  done: Default<boolean, false>;
-  category: Default<string, "Uncategorized">;
+  done: boolean | Default<false>;
+  category: string | Default<"Uncategorized">;
 }
 
 interface Input {
-  items: Default<Item[], [
-    { title: "Milk"; done: false; category: "Dairy" },
-    { title: "Bread"; done: false; category: "Bakery" },
-    { title: "Cheese"; done: true; category: "Dairy" },
-  ]>;
-  log: Default<string[], []>;
+  items:
+    | Item[]
+    | Default<[
+      { title: "Milk"; done: false; category: "Dairy" },
+      { title: "Bread"; done: false; category: "Bakery" },
+      { title: "Cheese"; done: true; category: "Dairy" },
+    ]>;
+  log: string[] | Default<[]>;
 }
 
 // Handler to run the exact repro sequence (moved to module scope)

--- a/packages/patterns/nickname.tsx
+++ b/packages/patterns/nickname.tsx
@@ -23,7 +23,7 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface NicknameModuleInput {
   /** Nickname or alias */
-  nickname: Default<string, "">;
+  nickname: string | Default<"">;
 }
 
 // ===== The Pattern =====

--- a/packages/patterns/notes/daily-journal.tsx
+++ b/packages/patterns/notes/daily-journal.tsx
@@ -160,9 +160,9 @@ const triggerRollup = handler<
 // ===== Input / Output types =====
 
 interface DailyJournalInput {
-  title?: Writable<Default<string, "Daily Journal">>;
-  entries?: Writable<Default<NotePiece[], []>>;
-  template?: Writable<Default<string, "">>;
+  title?: Writable<string | Default<"Daily Journal">>;
+  entries?: Writable<NotePiece[] | Default<[]>>;
+  template?: Writable<string | Default<"">>;
 }
 
 interface DailyJournalOutput {

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -40,7 +40,7 @@ interface NoteOutput extends NotePiece {
   title: string;
   content: string;
   summary: string;
-  mentioned: Default<MentionablePiece[], []>;
+  mentioned: MentionablePiece[] | Default<[]>;
   backlinks: MentionablePiece[];
   isHidden: boolean;
   grep: PatternToolResult<{ content: string }>;
@@ -165,7 +165,7 @@ const Note = pattern<NoteInput, NoteOutput>(
     const { allPieces } = wish<{ allPieces: Writable<MinimalPiece[]> }>(
       { query: "#default", headless: true },
     ).result!;
-    const mentionable = wish<Default<MentionablePiece[], []>>(
+    const mentionable = wish<MentionablePiece[] | Default<[]>>(
       { query: "#mentionable", headless: true },
     ).result;
     const _recentPieces = wish<MinimalPiece[]>(

--- a/packages/patterns/notes/notebook.tsx
+++ b/packages/patterns/notes/notebook.tsx
@@ -264,7 +264,7 @@ const deleteSelectedNotes = handler<
   {
     notes: Writable<NotePiece[]>;
     selectedNoteIndices: Writable<number[]>;
-    allPieces: Writable<Default<NotePiece[], []>>;
+    allPieces: Writable<NotePiece[] | Default<[]>>;
     notebooks: Writable<NotebookPiece[]>;
   }
 >((_, { notes, selectedNoteIndices, allPieces, notebooks }) => {

--- a/packages/patterns/notes/schemas.tsx
+++ b/packages/patterns/notes/schemas.tsx
@@ -101,30 +101,27 @@ export interface DailyJournalPiece {
 // ===== Input Types =====
 
 export interface NoteInput {
-  title?: Writable<Default<string, "Untitled Note">>;
-  content?: Writable<Default<string, "">>;
-  isHidden?: Default<boolean, false>;
+  title?: Writable<string | Default<"Untitled Note">>;
+  content?: Writable<string | Default<"">>;
+  isHidden?: boolean | Default<false>;
   /** Pattern JSON for [[wiki-links]]. Defaults to creating new Notes. */
-  linkPattern?: Writable<Default<string, "">>;
+  linkPattern?: Writable<string | Default<"">>;
   /** Parent notebook reference. Set at creation, can be updated for moves. */
-  parentNotebook?: Writable<Default<NotebookPiece | null, null>>;
+  parentNotebook?: Writable<NotebookPiece | null | Default<null>>;
 }
 
 export interface NotebookInput {
-  title?: Writable<Default<string, "Notebook">>;
-  notes?: Writable<Default<NotePiece[], []>>;
-  isNotebook?: Default<boolean, true>;
-  isHidden?: Default<boolean, false>;
+  title?: Writable<string | Default<"Notebook">>;
+  notes?: Writable<NotePiece[] | Default<[]>>;
+  isNotebook?: boolean | Default<true>;
+  isHidden?: boolean | Default<false>;
   /** Parent notebook reference. Set at creation, can be updated for moves. */
-  parentNotebook?: Writable<Default<NotebookPiece | null, null>>;
+  parentNotebook?: Writable<NotebookPiece | null | Default<null>>;
 }
 
 export interface NoteMdInput {
   /** Cell reference to note data (title + content + backlinks) */
-  note?: Default<
-    NotePiece,
-    { title: ""; content: ""; backlinks: [] }
-  >;
+  note?: NotePiece | Default<{ title: ""; content: ""; backlinks: [] }>;
   /** Direct reference to source note for Edit navigation */
   sourceNoteRef?: NotePiece;
   /** Writable content cell for checkbox updates */

--- a/packages/patterns/notes/voice-note.tsx
+++ b/packages/patterns/notes/voice-note.tsx
@@ -25,12 +25,12 @@ interface TranscriptionData {
 }
 
 type Input = {
-  title?: Writable<Default<string, "Voice Note">>;
+  title?: Writable<string | Default<"Voice Note">>;
 };
 
 type Output = {
-  transcription: Default<TranscriptionData | null, null>;
-  notes: Default<TranscriptionData[], []>;
+  transcription: TranscriptionData | null | Default<null>;
+  notes: TranscriptionData[] | Default<[]>;
 };
 
 const handleDeleteNote = handler<

--- a/packages/patterns/occurrence-tracker.tsx
+++ b/packages/patterns/occurrence-tracker.tsx
@@ -45,12 +45,12 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 interface Occurrence {
   timestamp: string; // ISO 8601
-  note: Default<string, "">;
+  note: string | Default<"">;
 }
 
 export interface OccurrenceTrackerInput {
-  label: Default<string, "">;
-  occurrences: Writable<Default<Occurrence[], []>>;
+  label: string | Default<"">;
+  occurrences: Writable<Occurrence[] | Default<[]>>;
 }
 
 // ===== Helper Functions =====

--- a/packages/patterns/pattern-index.tsx
+++ b/packages/patterns/pattern-index.tsx
@@ -1,6 +1,6 @@
 import { computed, type Default, NAME, pattern, UI } from "commonfabric";
 
-type Input = { url: Default<string, "/api/patterns/index.md"> };
+type Input = { url: string | Default<"/api/patterns/index.md"> };
 
 /** A URL to a #pattern-index */
 type Output = { url: string };

--- a/packages/patterns/phone.tsx
+++ b/packages/patterns/phone.tsx
@@ -33,9 +33,9 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface PhoneModuleInput {
   /** Label for this phone (Mobile, Home, Work, etc.) */
-  label: Default<string, "Mobile">;
+  label: string | Default<"Mobile">;
   /** Phone number (preserve original formatting) */
-  number: Default<string, "">;
+  number: string | Default<"">;
 }
 
 // ===== The Pattern =====

--- a/packages/patterns/photo.tsx
+++ b/packages/patterns/photo.tsx
@@ -36,9 +36,9 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface PhotoModuleInput {
   /** The uploaded image data (null if no image) */
-  image: Default<ImageData | null, null>;
+  image: ImageData | null | Default<null>;
   /** User-defined label for the photo */
-  label: Default<string, "">;
+  label: string | Default<"">;
 }
 
 // Output interface with unknown for UI properties to prevent OOM (CT-1148)

--- a/packages/patterns/profile.tsx
+++ b/packages/patterns/profile.tsx
@@ -89,8 +89,8 @@ export interface Membership {
 
 export interface Bank {
   name: string;
-  hasCheckingAccount: Default<boolean, false>;
-  hasCreditCard: Default<boolean, false>;
+  hasCheckingAccount: boolean | Default<false>;
+  hasCreditCard: boolean | Default<false>;
   notes: string;
 }
 
@@ -188,18 +188,18 @@ const EMPTY_EMPLOYMENT: Employment = {
 // ============================================================================
 
 interface ProfileInput {
-  self?: Writable<Default<Person, typeof EMPTY_PERSON>>;
-  partner?: Writable<Default<Person, typeof EMPTY_PERSON>>;
-  children?: Writable<Default<Person[], []>>;
-  parents?: Writable<Default<Person[], []>>;
-  inlaws?: Writable<Default<Person[], []>>;
-  addresses?: Writable<Default<Address[], []>>;
-  vehicles?: Writable<Default<Vehicle[], []>>;
-  memberships?: Writable<Default<Membership[], []>>;
-  banks?: Writable<Default<Bank[], []>>;
-  employment?: Writable<Default<Employment, typeof EMPTY_EMPLOYMENT>>;
-  notes?: Writable<Default<string, "">>;
-  learned?: Writable<Default<LearnedSection, typeof EMPTY_LEARNED>>;
+  self?: Writable<Person | Default<typeof EMPTY_PERSON>>;
+  partner?: Writable<Person | Default<typeof EMPTY_PERSON>>;
+  children?: Writable<Person[] | Default<[]>>;
+  parents?: Writable<Person[] | Default<[]>>;
+  inlaws?: Writable<Person[] | Default<[]>>;
+  addresses?: Writable<Address[] | Default<[]>>;
+  vehicles?: Writable<Vehicle[] | Default<[]>>;
+  memberships?: Writable<Membership[] | Default<[]>>;
+  banks?: Writable<Bank[] | Default<[]>>;
+  employment?: Writable<Employment | Default<typeof EMPTY_EMPLOYMENT>>;
+  notes?: Writable<string | Default<"">>;
+  learned?: Writable<LearnedSection | Default<typeof EMPTY_LEARNED>>;
 }
 
 /** Profile blackboard for personal data coordination. #profile */

--- a/packages/patterns/rating.tsx
+++ b/packages/patterns/rating.tsx
@@ -34,7 +34,7 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface RatingModuleInput {
   /** Rating from 1-5 stars */
-  rating: Writable<Default<number | null, null>>;
+  rating: Writable<number | null | Default<null>>;
 }
 
 // ===== Handlers =====

--- a/packages/patterns/reading-list/reading-item-detail.tsx
+++ b/packages/patterns/reading-list/reading-item-detail.tsx
@@ -15,15 +15,15 @@ export type ItemStatus = "want" | "reading" | "finished" | "abandoned";
 
 /** Input for creating a new reading item detail piece */
 interface ReadingItemDetailInput {
-  title?: Writable<Default<string, "">>;
-  author?: Writable<Default<string, "">>;
-  url?: Writable<Default<string, "">>;
-  type?: Writable<Default<ItemType, "article">>;
-  status?: Writable<Default<ItemStatus, "want">>;
-  rating?: Writable<Default<number | null, null>>;
-  notes?: Writable<Default<string, "">>;
-  addedAt?: Default<number, 0>;
-  finishedAt?: Default<number | null, null>;
+  title?: Writable<string | Default<"">>;
+  author?: Writable<string | Default<"">>;
+  url?: Writable<string | Default<"">>;
+  type?: Writable<ItemType | Default<"article">>;
+  status?: Writable<ItemStatus | Default<"want">>;
+  rating?: Writable<number | null | Default<null>>;
+  notes?: Writable<string | Default<"">>;
+  addedAt?: number | Default<0>;
+  finishedAt?: number | null | Default<null>;
 }
 
 /** Output shape of the reading item piece - this is what gets stored in lists

--- a/packages/patterns/reading-list/reading-list.tsx
+++ b/packages/patterns/reading-list/reading-list.tsx
@@ -23,7 +23,7 @@ import ReadingItemDetail, {
 export type { ItemStatus, ItemType, ReadingItemPiece };
 
 interface ReadingListInput {
-  items?: Writable<Default<ReadingItemPiece[], []>>;
+  items?: Writable<ReadingItemPiece[] | Default<[]>>;
 }
 
 interface ReadingListOutput {

--- a/packages/patterns/record-backup.tsx
+++ b/packages/patterns/record-backup.tsx
@@ -74,7 +74,7 @@ interface ImportResult {
 // ===== Pattern Input/Output =====
 
 interface Input {
-  importJson: Default<string, "">;
+  importJson: string | Default<"">;
 }
 
 interface Output {

--- a/packages/patterns/record-icon.tsx
+++ b/packages/patterns/record-icon.tsx
@@ -26,7 +26,7 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface RecordIconModuleInput {
   /** Custom emoji/icon */
-  icon: Default<string, "">;
+  icon: string | Default<"">;
 }
 
 // ===== The Pattern =====

--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -81,15 +81,15 @@ function getNextUnusedLabel(
 // ===== Types =====
 
 interface RecordInput {
-  title?: Default<string, "">;
-  subPieces?: Default<SubPieceEntry[], []>;
-  trashedSubPieces?: Default<TrashedSubPieceEntry[], []>;
+  title?: string | Default<"">;
+  subPieces?: SubPieceEntry[] | Default<[]>;
+  trashedSubPieces?: TrashedSubPieceEntry[] | Default<[]>;
 }
 
 interface RecordOutput {
-  title?: Default<string, "">;
-  subPieces?: Default<SubPieceEntry[], []>;
-  trashedSubPieces?: Default<TrashedSubPieceEntry[], []>;
+  title?: string | Default<"">;
+  subPieces?: SubPieceEntry[] | Default<[]>;
+  trashedSubPieces?: TrashedSubPieceEntry[] | Default<[]>;
   /** Self-reference for sub-pieces to access their parent Record */
   parentRecord?: RecordOutput | null;
 }

--- a/packages/patterns/record/extraction/extractor-module.tsx
+++ b/packages/patterns/record/extraction/extractor-module.tsx
@@ -60,52 +60,58 @@ interface ExtractorModuleInput {
   parentTitle: Writable<string>;
   // Source selection state (index -> selected, default true)
   sourceSelections: Writable<
-    Default<Record<number, boolean>, Record<number, never>>
+    Record<number, boolean> | Default<Record<number, never>>
   >;
   // Trash selection state (index -> should trash, default false)
   trashSelections: Writable<
-    Default<Record<number, boolean>, Record<number, never>>
+    Record<number, boolean> | Default<Record<number, never>>
   >;
   // Field selections for preview
-  selections: Writable<Default<Record<string, boolean>, Record<string, never>>>;
+  selections: Writable<
+    Record<string, boolean> | Default<Record<string, never>>
+  >;
   // Extraction phase
   extractPhase: Writable<
-    Default<"select" | "extracting" | "preview", "select">
+    "select" | "extracting" | "preview" | Default<"select">
   >;
   // Combined content for extraction (built from sources)
-  extractionPrompt: Writable<Default<string, "">>;
+  extractionPrompt: Writable<string | Default<"">>;
   // Notes cleanup state
-  cleanupNotesEnabled: Writable<Default<boolean, true>>;
+  cleanupNotesEnabled: Writable<boolean | Default<true>>;
   // Snapshot of Notes content at extraction start (for cleanup comparison)
   // Map of subPiece index (as string) -> original content for ALL selected Notes modules
   // NOTE: Uses string keys to avoid Cell coercing numeric keys to array indices
   notesContentSnapshot: Writable<
-    Default<Record<string, string>, Record<string, never>>
+    Record<string, string> | Default<Record<string, never>>
   >;
   // Cleanup application status tracking
   cleanupApplyStatus: Writable<
-    Default<"pending" | "success" | "failed" | "skipped", "pending">
+    "pending" | "success" | "failed" | "skipped" | Default<"pending">
   >;
   // Apply in progress guard (prevents double-click race condition)
-  applyInProgress: Writable<Default<boolean, false>>;
+  applyInProgress: Writable<boolean | Default<false>>;
   // Error details expanded state (for showing full error in UI)
-  errorDetailsExpanded: Writable<Default<boolean, false>>;
+  errorDetailsExpanded: Writable<boolean | Default<false>>;
 }
 
 interface ExtractorModuleOutput {
-  sourceSelections?: Default<Record<number, boolean>, Record<number, never>>;
-  trashSelections?: Default<Record<number, boolean>, Record<number, never>>;
-  selections?: Default<Record<string, boolean>, Record<string, never>>;
-  extractPhase?: Default<"select" | "extracting" | "preview", "select">;
-  extractionPrompt?: Default<string, "">;
-  cleanupNotesEnabled?: Default<boolean, true>;
-  notesContentSnapshot?: Default<Record<string, string>, Record<string, never>>;
-  cleanupApplyStatus?: Default<
-    "pending" | "success" | "failed" | "skipped",
-    "pending"
-  >;
-  applyInProgress?: Default<boolean, false>;
-  errorDetailsExpanded?: Default<boolean, false>;
+  sourceSelections?: Record<number, boolean> | Default<Record<number, never>>;
+  trashSelections?: Record<number, boolean> | Default<Record<number, never>>;
+  selections?: Record<string, boolean> | Default<Record<string, never>>;
+  extractPhase?: "select" | "extracting" | "preview" | Default<"select">;
+  extractionPrompt?: string | Default<"">;
+  cleanupNotesEnabled?: boolean | Default<true>;
+  notesContentSnapshot?:
+    | Record<string, string>
+    | Default<Record<string, never>>;
+  cleanupApplyStatus?:
+    | "pending"
+    | "success"
+    | "failed"
+    | "skipped"
+    | Default<"pending">;
+  applyInProgress?: boolean | Default<false>;
+  errorDetailsExpanded?: boolean | Default<false>;
 }
 
 // ===== Constants =====
@@ -953,7 +959,7 @@ const toggleSourceHandler = handler<
   {
     index: number;
     sourceSelectionsCell: Writable<
-      Default<Record<number, boolean>, Record<number, never>>
+      Record<number, boolean> | Default<Record<number, never>>
     >;
   }
 >((_event, { index, sourceSelectionsCell }) => {
@@ -974,7 +980,7 @@ const toggleTrashHandler = handler<
   {
     index: number;
     trashSelectionsCell: Writable<
-      Default<Record<number, boolean>, Record<number, never>>
+      Record<number, boolean> | Default<Record<number, never>>
     >;
   }
 >((_event, { index, trashSelectionsCell }) => {
@@ -995,7 +1001,7 @@ const toggleFieldHandler = handler<
   {
     fieldKey: string;
     selectionsCell: Writable<
-      Default<Record<string, boolean>, Record<string, never>>
+      Record<string, boolean> | Default<Record<string, never>>
     >;
     defaultSelected: boolean;
   }
@@ -1022,14 +1028,14 @@ const startExtraction = handler<
   unknown,
   {
     sourceSelectionsCell: Writable<
-      Default<Record<number, boolean>, Record<number, never>>
+      Record<number, boolean> | Default<Record<number, never>>
     >;
     parentSubPiecesCell: Writable<SubPieceEntry[]>;
     extractPhaseCell: Writable<
-      Default<"select" | "extracting" | "preview", "select">
+      "select" | "extracting" | "preview" | Default<"select">
     >;
     notesContentSnapshotCell: Writable<
-      Default<Record<number, string>, Record<number, never>>
+      Record<number, string> | Default<Record<number, never>>
     >;
   }
 >(
@@ -1209,7 +1215,7 @@ interface NotesCleanupParams {
   cleanedNotesValue: string;
   notesSnapshotMapValue: Record<string, string>;
   cleanupApplyStatusCell: Writable<
-    Default<"pending" | "success" | "failed" | "skipped", "pending">
+    "pending" | "success" | "failed" | "skipped" | Default<"pending">
   >;
 }
 
@@ -1376,19 +1382,19 @@ const applySelected = handler<
       { confidence: number; explanation: string; sourceExcerpt?: string }
     >;
     selectionsCell: Writable<
-      Default<Record<string, boolean>, Record<string, never>>
+      Record<string, boolean> | Default<Record<string, never>>
     >;
     trashSelectionsCell: Writable<
-      Default<Record<number, boolean>, Record<number, never>>
+      Record<number, boolean> | Default<Record<number, never>>
     >;
     cleanupEnabledValue: boolean;
     cleanedNotesValue: string;
     // Dereferenced value from notesContentSnapshot Cell (map of Notes module index as string -> original content)
     notesSnapshotMapValue: Record<string, string>;
     cleanupApplyStatusCell: Writable<
-      Default<"pending" | "success" | "failed" | "skipped", "pending">
+      "pending" | "success" | "failed" | "skipped" | Default<"pending">
     >;
-    applyInProgressCell: Writable<Default<boolean, false>>;
+    applyInProgressCell: Writable<boolean | Default<false>>;
   }
 >(
   (

--- a/packages/patterns/relationship.tsx
+++ b/packages/patterns/relationship.tsx
@@ -44,13 +44,13 @@ type ClosenessLevel = "intimate" | "close" | "casual" | "distant";
 
 export interface RelationshipModuleInput {
   /** Relationship types (e.g., friend, family, colleague) */
-  relationTypes: Default<string[], []>;
+  relationTypes: string[] | Default<[]>;
   /** Closeness level */
-  closeness: Default<ClosenessLevel | "", "">;
+  closeness: ClosenessLevel | "" | Default<"">;
   /** How we met */
-  howWeMet: Default<string, "">;
+  howWeMet: string | Default<"">;
   /** Inner circle member */
-  innerCircle: Default<boolean, false>;
+  innerCircle: boolean | Default<false>;
 }
 
 // ===== Constants =====

--- a/packages/patterns/render-test.tsx
+++ b/packages/patterns/render-test.tsx
@@ -2,19 +2,19 @@ import { Cell, Default, handler, NAME, pattern, UI } from "commonfabric";
 
 interface SubItem {
   label: string;
-  count: Default<number, 0>;
+  count: number | Default<0>;
 }
 
 interface Item {
   name: string;
-  value: Default<number, 0>;
-  subItems: Default<SubItem[], []>;
+  value: number | Default<0>;
+  subItems: SubItem[] | Default<[]>;
 }
 
 interface Input {
-  title: Default<string, "Render Test">;
-  globalCounter: Default<number, 0>;
-  items: Default<Item[], []>;
+  title: string | Default<"Render Test">;
+  globalCounter: number | Default<0>;
+  items: Item[] | Default<[]>;
 }
 
 // Root level: increment global counter

--- a/packages/patterns/scrabble/scrabble-game.tsx
+++ b/packages/patterns/scrabble/scrabble-game.tsx
@@ -1166,15 +1166,15 @@ const getBagCount = lift<{ bagJson: string; bagIndex: number }, number>(
 // =============================================================================
 
 interface GameInput {
-  gameName: Default<string, "Scrabble Match">;
-  boardJson: Writable<Default<string, "">>; // JSON string of PlacedTile[]
-  bagJson: Writable<Default<string, "">>;
-  bagIndex: Writable<Default<number, 0>>;
-  playersJson: Writable<Default<string, "[]">>; // JSON string of Player[]
-  gameEventsJson: Writable<Default<string, "[]">>; // JSON string of GameEvent[]
-  allRacksJson: Writable<Default<string, "{}">>; // JSON string of AllRacks
-  allPlacedJson: Writable<Default<string, "{}">>; // JSON string of AllPlaced
-  myName: Default<string, "">;
+  gameName: string | Default<"Scrabble Match">;
+  boardJson: Writable<string | Default<"">>; // JSON string of PlacedTile[]
+  bagJson: Writable<string | Default<"">>;
+  bagIndex: Writable<number | Default<0>>;
+  playersJson: Writable<string | Default<"[]">>; // JSON string of Player[]
+  gameEventsJson: Writable<string | Default<"[]">>; // JSON string of GameEvent[]
+  allRacksJson: Writable<string | Default<"{}">>; // JSON string of AllRacks
+  allPlacedJson: Writable<string | Default<"{}">>; // JSON string of AllPlaced
+  myName: string | Default<"">;
 }
 
 interface GameOutput {

--- a/packages/patterns/scrabble/scrabble.tsx
+++ b/packages/patterns/scrabble/scrabble.tsx
@@ -38,14 +38,14 @@ import ScrabbleGame, {
 // =============================================================================
 
 interface LobbyInput {
-  gameName: Default<string, "Scrabble Match">;
-  boardJson: Writable<Default<string, "">>; // JSON string of PlacedTile[]
-  bagJson: Writable<Default<string, "">>;
-  bagIndex: Writable<Default<number, 0>>;
-  playersJson: Writable<Default<string, "[]">>; // JSON string of Player[]
-  gameEventsJson: Writable<Default<string, "[]">>; // JSON string of GameEvent[]
-  allRacksJson: Writable<Default<string, "{}">>; // JSON string of AllRacks
-  allPlacedJson: Writable<Default<string, "{}">>; // JSON string of AllPlaced
+  gameName: string | Default<"Scrabble Match">;
+  boardJson: Writable<string | Default<"">>; // JSON string of PlacedTile[]
+  bagJson: Writable<string | Default<"">>;
+  bagIndex: Writable<number | Default<0>>;
+  playersJson: Writable<string | Default<"[]">>; // JSON string of Player[]
+  gameEventsJson: Writable<string | Default<"[]">>; // JSON string of GameEvent[]
+  allRacksJson: Writable<string | Default<"{}">>; // JSON string of AllRacks
+  allPlacedJson: Writable<string | Default<"{}">>; // JSON string of AllPlaced
 }
 
 interface LobbyOutput {

--- a/packages/patterns/self-improving-classifier.tsx
+++ b/packages/patterns/self-improving-classifier.tsx
@@ -147,16 +147,16 @@ const DEFAULT_CONFIG: ClassifierConfig = {
 // =============================================================================
 
 interface ClassifierInput {
-  config: Writable<Default<ClassifierConfig, typeof DEFAULT_CONFIG>>;
-  examples: Writable<Default<LabeledExample[], []>>;
-  rules: Writable<Default<ClassificationRule[], []>>;
+  config: Writable<ClassifierConfig | Default<typeof DEFAULT_CONFIG>>;
+  examples: Writable<LabeledExample[] | Default<[]>>;
+  rules: Writable<ClassificationRule[] | Default<[]>>;
   // NOTE: pendingClassifications is reserved for future batch processing API.
   // Currently items flow through currentItem → LLM → user confirmation → examples.
   // External systems could use this queue for bulk submissions in the future.
-  pendingClassifications: Writable<Default<PendingClassification[], []>>;
+  pendingClassifications: Writable<PendingClassification[] | Default<[]>>;
   // The item currently being classified (null when idle)
   // Only one item can be classified at a time
-  currentItem: Writable<Default<ClassifiableInput | null, null>>;
+  currentItem: Writable<ClassifiableInput | null | Default<null>>;
 }
 
 /** Self-improving binary classifier with LLM + regex rules. #classifier #learning */

--- a/packages/patterns/self-reference-test.tsx
+++ b/packages/patterns/self-reference-test.tsx
@@ -1,9 +1,9 @@
 import { Default, pattern, SELF, UI, Writable } from "commonfabric";
 
 interface Input {
-  label: Default<string, "Untitled">;
-  parent: Default<Output | null, null>;
-  registry: Writable<Default<Output[], []>>;
+  label: string | Default<"Untitled">;
+  parent: Output | null | Default<null>;
+  registry: Writable<Output[] | Default<[]>>;
 }
 interface Output {
   label: string;

--- a/packages/patterns/shopping-list.tsx
+++ b/packages/patterns/shopping-list.tsx
@@ -29,9 +29,9 @@ import StoreMapper from "./store-mapper.tsx";
 // Item with optional aisle override for manual corrections
 interface ShoppingItem {
   title: string;
-  done: Default<boolean, false>;
-  aisleSeed: Default<number, 0>;
-  aisleOverride: Default<string, "">; // User's manual aisle selection
+  done: boolean | Default<false>;
+  aisleSeed: number | Default<0>;
+  aisleOverride: string | Default<"">; // User's manual aisle selection
 }
 
 // AI categorization result
@@ -40,8 +40,8 @@ interface AisleResult {
 }
 
 interface Input {
-  items: Writable<Default<ShoppingItem[], []>>;
-  storeLayout: Writable<Default<string, "">>; // Markdown store layout from Store Mapper
+  items: Writable<ShoppingItem[] | Default<[]>>;
+  storeLayout: Writable<string | Default<"">>; // Markdown store layout from Store Mapper
 }
 
 /** Shopping list with AI-powered aisle sorting. #shoppingList */

--- a/packages/patterns/simple-list/simple-list.tsx
+++ b/packages/patterns/simple-list/simple-list.tsx
@@ -46,12 +46,12 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface SimpleListItem {
   text: string;
-  indented: Default<boolean, false>;
-  done: Default<boolean, false>;
+  indented: boolean | Default<false>;
+  done: boolean | Default<false>;
 }
 
 export interface SimpleListInput {
-  items?: Writable<Default<SimpleListItem[], []>>;
+  items?: Writable<SimpleListItem[] | Default<[]>>;
 }
 
 interface SimpleListOutput {

--- a/packages/patterns/social.tsx
+++ b/packages/patterns/social.tsx
@@ -50,11 +50,11 @@ type SocialPlatform =
 
 export interface SocialModuleInput {
   /** Social platform (normalize: Insta→instagram, X→twitter) */
-  platform: Default<SocialPlatform | "", "">;
+  platform: SocialPlatform | "" | Default<"">;
   /** Username/handle without @ prefix */
-  handle: Default<string, "">;
+  handle: string | Default<"">;
   /** Profile URL */
-  profileUrl: Default<string, "">;
+  profileUrl: string | Default<"">;
 }
 
 // ===== Constants =====

--- a/packages/patterns/status.tsx
+++ b/packages/patterns/status.tsx
@@ -29,7 +29,7 @@ type StatusValue = "planned" | "active" | "blocked" | "done" | "archived";
 
 export interface StatusModuleInput {
   /** Project status */
-  status: Default<StatusValue | "", "">;
+  status: StatusValue | "" | Default<"">;
 }
 
 // ===== Constants =====

--- a/packages/patterns/store-mapper.tsx
+++ b/packages/patterns/store-mapper.tsx
@@ -44,14 +44,14 @@ type WallPosition =
 
 interface Aisle {
   name: string; // Just the number, e.g., "1", "2", "5A"
-  description: Default<string, "">;
+  description: string | Default<"">;
 }
 
 interface Department {
   name: string;
   icon: string;
-  location: Default<WallPosition, "unassigned">;
-  description: Default<string, "">;
+  location: WallPosition | Default<"unassigned">;
+  description: string | Default<"">;
 }
 
 interface Entrance {
@@ -61,16 +61,16 @@ interface Entrance {
 interface ItemLocation {
   itemName: string;
   correctAisle: string;
-  incorrectAisle: Default<string, "">;
+  incorrectAisle: string | Default<"">;
   timestamp: number;
 }
 
 interface Input {
-  storeName: Writable<Default<string, "My Store">>;
-  aisles: Writable<Default<Aisle[], []>>;
-  departments: Writable<Default<Department[], []>>;
-  entrances: Writable<Default<Entrance[], []>>;
-  itemLocations: Writable<Default<ItemLocation[], []>>;
+  storeName: Writable<string | Default<"My Store">>;
+  aisles: Writable<Aisle[] | Default<[]>>;
+  departments: Writable<Department[] | Default<[]>>;
+  entrances: Writable<Entrance[] | Default<[]>>;
+  itemLocations: Writable<ItemLocation[] | Default<[]>>;
 }
 
 interface Output {

--- a/packages/patterns/suggestable/budget-planner.tsx
+++ b/packages/patterns/suggestable/budget-planner.tsx
@@ -12,14 +12,14 @@ import {
 // ===== Types =====
 
 type BudgetInput = {
-  topic?: Default<string, "">;
-  context?: Default<Record<string, any>, Record<string, never>>;
-  maxAmount?: Default<number, 1000>;
+  topic?: string | Default<"">;
+  context?: Record<string, any> | Default<Record<string, never>>;
+  maxAmount?: number | Default<1000>;
 };
 
 type BudgetItem = {
   name: string;
-  amount: Default<number, 0>;
+  amount: number | Default<0>;
 };
 
 type BudgetOutput = {

--- a/packages/patterns/suggestable/checklist.tsx
+++ b/packages/patterns/suggestable/checklist.tsx
@@ -12,13 +12,13 @@ import {
 // ===== Types =====
 
 type ChecklistInput = {
-  topic?: Default<string, "">;
-  context?: Default<Record<string, any>, Record<string, never>>;
+  topic?: string | Default<"">;
+  context?: Record<string, any> | Default<Record<string, never>>;
 };
 
 type ChecklistItem = {
   label: string;
-  done: Default<boolean, false>;
+  done: boolean | Default<false>;
 };
 
 type ChecklistOutput = {

--- a/packages/patterns/suggestable/diagram.tsx
+++ b/packages/patterns/suggestable/diagram.tsx
@@ -12,8 +12,8 @@ import {
 // ===== Types =====
 
 type DiagramInput = {
-  topic?: Default<string, "">;
-  context?: Default<Record<string, any>, Record<string, never>>;
+  topic?: string | Default<"">;
+  context?: Record<string, any> | Default<Record<string, never>>;
 };
 
 type DiagramOutput = {

--- a/packages/patterns/suggestable/people-list.tsx
+++ b/packages/patterns/suggestable/people-list.tsx
@@ -15,7 +15,7 @@ type PersonListInput = Record<string, never>;
 type Person = {
   contact: {
     name: string;
-    email: Default<string, "">;
+    email: string | Default<"">;
   };
 };
 

--- a/packages/patterns/suggestable/question.tsx
+++ b/packages/patterns/suggestable/question.tsx
@@ -14,8 +14,8 @@ import {
 // ===== Types =====
 
 type QuestionInput = {
-  topic?: Default<string, "">;
-  context?: Default<Record<string, any>, Record<string, never>>;
+  topic?: string | Default<"">;
+  context?: Record<string, any> | Default<Record<string, never>>;
 };
 
 type QuestionOutput = {

--- a/packages/patterns/suggestable/summary.tsx
+++ b/packages/patterns/suggestable/summary.tsx
@@ -12,8 +12,8 @@ import {
 // ===== Types =====
 
 type SummaryInput = {
-  topic?: Default<string, "">;
-  context?: Default<Record<string, any>, Record<string, never>>;
+  topic?: string | Default<"">;
+  context?: Record<string, any> | Default<Record<string, never>>;
 };
 
 type SummaryOutput = {

--- a/packages/patterns/suggestable/svg-diagram.tsx
+++ b/packages/patterns/suggestable/svg-diagram.tsx
@@ -12,8 +12,8 @@ import {
 // ===== Types =====
 
 type SvgDiagramInput = {
-  topic?: Default<string, "">;
-  context?: Default<Record<string, any>, Record<string, never>>;
+  topic?: string | Default<"">;
+  context?: Record<string, any> | Default<Record<string, never>>;
 };
 
 type SvgDiagramOutput = {

--- a/packages/patterns/system/favorites-manager.tsx
+++ b/packages/patterns/system/favorites-manager.tsx
@@ -21,7 +21,10 @@ type Favorite = {
 
 const onRemoveFavorite = handler<
   Record<string, never>,
-  { favorites: Writable<Default<Array<Favorite>, []>>; item: Writable<unknown> }
+  {
+    favorites: Writable<Array<Favorite> | Default<[]>>;
+    item: Writable<unknown>;
+  }
 >((_, { favorites, item }) => {
   const favorite = favorites.get().find((f: Favorite) => f.cell.equals(item));
   if (favorite) favorites.remove(favorite);
@@ -36,7 +39,7 @@ const onUpdateUserTags = handler<
 
 export default pattern<Record<string, never>>((_) => {
   // Use wish() to access favorites from home.tsx via defaultPattern
-  const { result: favorites } = wish<Default<Array<Favorite>, []>>({
+  const { result: favorites } = wish<Array<Favorite> | Default<[]>>({
     query: "#favorites",
   });
 

--- a/packages/patterns/system/knowledge-graph.tsx
+++ b/packages/patterns/system/knowledge-graph.tsx
@@ -173,7 +173,7 @@ const listPiecesPattern = pattern<
 // --- Main pattern ---
 
 const KnowledgeGraph = pattern<Input>(() => {
-  const mentionable = wish<Default<Writable<MentionablePiece>[], []>>({
+  const mentionable = wish<Writable<MentionablePiece>[] | Default<[]>>({
     query: "#mentionable",
   }).result;
 

--- a/packages/patterns/system/mentionables-inspector.tsx
+++ b/packages/patterns/system/mentionables-inspector.tsx
@@ -1,9 +1,11 @@
 import { Default, NAME, pattern, UI, wish } from "commonfabric";
 
 export default pattern<Record<string, never>>((_) => {
-  const { result: mentionable } = wish<Default<Array<{ [NAME]: string }>, []>>({
-    query: "#mentionable",
-  });
+  const { result: mentionable } = wish<Array<{ [NAME]: string }> | Default<[]>>(
+    {
+      query: "#mentionable",
+    },
+  );
 
   return {
     [NAME]: "Mentionable Inspector",

--- a/packages/patterns/system/suggestion-history.tsx
+++ b/packages/patterns/system/suggestion-history.tsx
@@ -58,7 +58,7 @@ export const searchPattern = pattern<
 });
 
 const SuggestionHistory = pattern<Input, Output>(() => {
-  const { result: entries } = wish<Default<SuggestionHistoryEntry[], []>>({
+  const { result: entries } = wish<SuggestionHistoryEntry[] | Default<[]>>({
     query: "#suggestions",
   });
   const allEntries = computed(() => entries ?? []);

--- a/packages/patterns/system/suggestion.tsx
+++ b/packages/patterns/system/suggestion.tsx
@@ -87,7 +87,7 @@ export default pattern<
   {
     situation: string;
     context: { [id: string]: any };
-    initialResults: Default<Writable<unknown>[], []>;
+    initialResults: Writable<unknown>[] | Default<[]>;
   },
   WishState<Writable<any>> & { [UI]: VNode }
 >(({ situation, context, initialResults }) => {

--- a/packages/patterns/system/summary-index.tsx
+++ b/packages/patterns/system/summary-index.tsx
@@ -61,7 +61,7 @@ export const searchPattern = pattern<
 });
 
 const SummaryIndex = pattern<Input, Output>(() => {
-  const mentionable = wish<Default<Writable<SummarizablePiece>[], []>>({
+  const mentionable = wish<Writable<SummarizablePiece>[] | Default<[]>>({
     query: "#mentionable",
   }).result;
 

--- a/packages/patterns/tags.tsx
+++ b/packages/patterns/tags.tsx
@@ -29,7 +29,7 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface TagsModuleInput {
   /** Tags or labels */
-  tags: Default<string[], []>;
+  tags: string[] | Default<[]>;
 }
 
 // ===== Handlers =====

--- a/packages/patterns/test/autosave-test.tsx
+++ b/packages/patterns/test/autosave-test.tsx
@@ -9,13 +9,13 @@ import {
 } from "commonfabric";
 
 interface State {
-  data: Default<string, "Initial test data">;
-  counter: Default<number, 0>;
+  data: string | Default<"Initial test data">;
+  counter: number | Default<0>;
 }
 
 interface WritableState {
-  data: Writable<Default<string, "Initial test data">>;
-  counter: Writable<Default<number, 0>>;
+  data: Writable<string | Default<"Initial test data">>;
+  counter: Writable<number | Default<0>>;
 }
 
 interface Output {

--- a/packages/patterns/test/data-model-test.tsx
+++ b/packages/patterns/test/data-model-test.tsx
@@ -39,10 +39,10 @@ function nowTimestamp(): string {
 }
 
 interface Input {
-  value: Writable<Default<any, null>>;
-  inputText: Writable<Default<string, "">>;
-  errorMsg: Writable<Default<string, "">>;
-  evalTime: Writable<Default<string, "(never)">>;
+  value: Writable<any | Default<null>>;
+  inputText: Writable<string | Default<"">>;
+  errorMsg: Writable<string | Default<"">>;
+  evalTime: Writable<string | Default<"(never)">>;
 }
 
 interface Output {

--- a/packages/patterns/test/non-idempotent/accumulator.tsx
+++ b/packages/patterns/test/non-idempotent/accumulator.tsx
@@ -4,7 +4,7 @@
 import { computed, Default, pattern, UI, Writable } from "commonfabric";
 
 export default pattern<{
-  value: Writable<Default<string, "hello">>;
+  value: Writable<string | Default<"hello">>;
 }>(({ value }) => {
   // Anti-pattern: Appending to an array instead of replacing — grows infinitely
   const log = Writable.of<string[]>([]);

--- a/packages/patterns/test/non-idempotent/set-to-array.tsx
+++ b/packages/patterns/test/non-idempotent/set-to-array.tsx
@@ -27,7 +27,7 @@ const preset: Item[] = [
 ];
 
 export default pattern<{
-  items: Writable<Default<Item[], typeof preset>>;
+  items: Writable<Item[] | Default<typeof preset>>;
 }>(({ items }) => {
   // Anti-pattern: Random sort before Set insertion changes iteration order
   const uniqueTags = Writable.of<string[]>([]);

--- a/packages/patterns/test/non-idempotent/shuffle.tsx
+++ b/packages/patterns/test/non-idempotent/shuffle.tsx
@@ -12,7 +12,7 @@ import {
 
 export default pattern<{
   items: Writable<
-    Default<string[], ["alpha", "bravo", "charlie", "delta", "echo"]>
+    string[] | Default<["alpha", "bravo", "charlie", "delta", "echo"]>
   >;
 }>(({ items }) => {
   // Anti-pattern: nonPrivateRandom() inside computed() produces different output each run

--- a/packages/patterns/test/non-idempotent/timestamp.tsx
+++ b/packages/patterns/test/non-idempotent/timestamp.tsx
@@ -26,7 +26,7 @@ const preset: Item[] = [
 ];
 
 export default pattern<{
-  items: Writable<Default<Item[], typeof preset>>;
+  items: Writable<Item[] | Default<typeof preset>>;
 }>(({ items }) => {
   // Anti-pattern: safeDateNow() in computed() — every run produces different timestamps
   const processed = Writable.of<ProcessedItem[]>([]);

--- a/packages/patterns/test/silent-computed-crash.tsx
+++ b/packages/patterns/test/silent-computed-crash.tsx
@@ -1,6 +1,6 @@
 import { computed, Default, pattern, UI } from "commonfabric";
 
-export default pattern<{ value?: Default<string, "hello"> }>(({ value }) => {
+export default pattern<{ value?: string | Default<"hello"> }>(({ value }) => {
   // This computed throws; current runner surfaces the failure via scheduler
   // error reporting and blanks the poisoned output path.
   const poisoned = computed(() => {

--- a/packages/patterns/test/webhook-test.tsx
+++ b/packages/patterns/test/webhook-test.tsx
@@ -18,7 +18,7 @@ interface WebhookConfig {
 }
 
 interface WebhookPatternInput {
-  webhookConfig: Writable<Default<WebhookConfig | null, null>>;
+  webhookConfig: Writable<WebhookConfig | null | Default<null>>;
 }
 
 interface WebhookPatternOutput {

--- a/packages/patterns/text-import.tsx
+++ b/packages/patterns/text-import.tsx
@@ -35,9 +35,9 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface TextImportModuleInput {
   /** The text content from the uploaded file */
-  content: Default<string, "">;
+  content: string | Default<"">;
   /** The original filename */
-  filename: Default<string, "">;
+  filename: string | Default<"">;
 }
 
 // Output interface with unknown for UI properties to prevent OOM (CT-1148)

--- a/packages/patterns/text-swapper.tsx
+++ b/packages/patterns/text-swapper.tsx
@@ -11,8 +11,8 @@ import { Default, handler, pattern, UI, Writable } from "commonfabric";
 type EditingSide = "left" | "right" | null;
 
 interface Input {
-  leftText: Writable<Default<string, "Hello">>;
-  rightText: Writable<Default<string, "World">>;
+  leftText: Writable<string | Default<"Hello">>;
+  rightText: Writable<string | Default<"World">>;
 }
 
 interface Output {

--- a/packages/patterns/timeline.tsx
+++ b/packages/patterns/timeline.tsx
@@ -31,11 +31,11 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface TimelineModuleInput {
   /** Start date (ISO format YYYY-MM-DD) */
-  startDate: Default<string, "">;
+  startDate: string | Default<"">;
   /** Target completion date (ISO format YYYY-MM-DD) */
-  targetDate: Default<string, "">;
+  targetDate: string | Default<"">;
   /** Actual completion date (ISO format YYYY-MM-DD) */
-  completedDate: Default<string, "">;
+  completedDate: string | Default<"">;
 }
 
 // ===== The Pattern =====

--- a/packages/patterns/timing.tsx
+++ b/packages/patterns/timing.tsx
@@ -23,11 +23,11 @@ export const MODULE_METADATA: ModuleMetadata = {
 // ===== Types =====
 export interface TimingModuleInput {
   /** Prep time in minutes */
-  prepTime: Default<number | null, null>;
+  prepTime: number | null | Default<null>;
   /** Cook time in minutes */
-  cookTime: Default<number | null, null>;
+  cookTime: number | null | Default<null>;
   /** Rest time in minutes */
-  restTime: Default<number | null, null>;
+  restTime: number | null | Default<null>;
 }
 
 // ===== Helpers =====

--- a/packages/patterns/todo-list/todo-list.tsx
+++ b/packages/patterns/todo-list/todo-list.tsx
@@ -16,11 +16,11 @@ import {
 /** A #todo item */
 export interface TodoItem {
   title: string;
-  done: Default<boolean, false>;
+  done: boolean | Default<false>;
 }
 
 interface TodoListInput {
-  items?: Writable<Default<TodoItem[], []>>;
+  items?: Writable<TodoItem[] | Default<[]>>;
 }
 
 interface TodoListOutput {

--- a/packages/patterns/tools/importer-prompt.ts
+++ b/packages/patterns/tools/importer-prompt.ts
@@ -220,32 +220,32 @@ export function createPreviewUI(
  * Use direct property access: \`airtableAuthPiece.auth\`
  */
 export type AirtableAuth = {
-  accessToken: Default<Secret<string>, "">;
-  tokenType: Default<string, "">;
-  scope: Default<string[], []>;
-  expiresIn: Default<number, 0>;
-  expiresAt: Default<number, 0>;
-  refreshToken: Default<Secret<string>, "">;
-  user: Default<{
+  accessToken: Secret<string> | Default<"">;
+  tokenType: string | Default<"">;
+  scope: string[] | Default<[]>;
+  expiresIn: number | Default<0>;
+  expiresAt: number | Default<0>;
+  refreshToken: Secret<string> | Default<"">;
+  user: {
     email: string;
     name: string;
     picture: string;
-  }, { email: ""; name: ""; picture: "" }>;
+  } | Default<{ email: ""; name: ""; picture: "" }>;
 };
 
 // Selected scopes configuration
 export type SelectedScopes = {
-  "data.records:read": Default<boolean, true>;
-  "data.records:write": Default<boolean, false>;
-  "data.recordComments:read": Default<boolean, false>;
-  "data.recordComments:write": Default<boolean, false>;
-  "schema.bases:read": Default<boolean, true>;
-  "schema.bases:write": Default<boolean, false>;
-  "webhook:manage": Default<boolean, false>;
+  "data.records:read": boolean | Default<true>;
+  "data.records:write": boolean | Default<false>;
+  "data.recordComments:read": boolean | Default<false>;
+  "data.recordComments:write": boolean | Default<false>;
+  "schema.bases:read": boolean | Default<true>;
+  "schema.bases:write": boolean | Default<false>;
+  "webhook:manage": boolean | Default<false>;
 };
 
 interface Input {
-  selectedScopes: Default<SelectedScopes, {
+  selectedScopes: SelectedScopes | Default<{
     "data.records:read": true;
     "data.records:write": false;
     "data.recordComments:read": false;
@@ -254,7 +254,7 @@ interface Input {
     "schema.bases:write": false;
     "webhook:manage": false;
   }>;
-  auth: Default<AirtableAuth, {
+  auth: AirtableAuth | Default<{
     accessToken: "";
     tokenType: "";
     scope: [];
@@ -1382,8 +1382,8 @@ type BaseInfo = { id: string; name: string };
 type TableInfo = { id: string; name: string };
 
 interface Input {
-  selectedBaseId: Default<string, "">;
-  selectedTableId: Default<string, "">;
+  selectedBaseId: string | Default<"">;
+  selectedTableId: string | Default<"">;
 }
 
 /** Import records from an Airtable base. #airtableImporter */
@@ -2081,8 +2081,10 @@ Import only what you need from the above list. Define \`type Secret<T> = T;\` lo
 - **\`navigateTo(piece)\`** — Navigate to another piece.
 - **\`[NAME]\`** — Special symbol for the piece's display name.
 - **\`[UI]\`** — Special symbol for the piece's rendered UI.
-- **\`Default<T, D>\`** — Type with a default value. For mutable arrays in schemas,
-  the standard pattern is \`Writable<Default<T[], []>>\`.
+- **\`T | Default<D>\`** — Type with a default value. For mutable arrays in schemas,
+  the standard pattern is \`Writable<T[] | Default<[]>>\`.
+- **\`T | DeepDefault<D>\`** — Object type with a partial recursive default.
+  Use this when the default lists only some nested object properties.
 - **\`Secret<T>\`** — Local no-op type alias (\`type Secret<T> = T;\`) for marking sensitive fields.
 - **\`Stream<T>\`** — Stateless channel. Written via \`.send()\`. Used for handlers
   that can be called from other pieces.
@@ -2276,13 +2278,13 @@ from \`../../auth/\` (auth-refresh, auth-reactive, auth-types, auth-ui-helpers):
 
 - CTS transforms are enabled by default; do not add \`/// <cf-disable-transform />\`
 - Export a type \`${pascalName}Auth\` with fields:
-  - \`accessToken: Default<Secret<string>, "">\`  (or \`token\` if the provider uses that convention)
-  - \`tokenType: Default<string, "">\`
-  - \`scope: Default<string[], []>\`
-  - \`expiresIn: Default<number, 0>\`
-  - \`expiresAt: Default<number, 0>\`
-  - \`refreshToken: Default<Secret<string>, "">\`
-  - \`user: Default<{ email: string; name: string; picture: string }, { email: ""; name: ""; picture: "" }>\`
+  - \`accessToken: Secret<string> | Default<"">\`  (or \`token\` if the provider uses that convention)
+  - \`tokenType: string | Default<"">\`
+  - \`scope: string[] | Default<[]>\`
+  - \`expiresIn: number | Default<0>\`
+  - \`expiresAt: number | Default<0>\`
+  - \`refreshToken: Secret<string> | Default<"">\`
+  - \`user: { email: string; name: string; picture: string } | Default<{ email: ""; name: ""; picture: "" }>\`
 - Use the \`#${
     hashTag.slice(1)
   }\` tag in the Output interface JSDoc comment for wish() discovery

--- a/packages/patterns/type-picker.tsx
+++ b/packages/patterns/type-picker.tsx
@@ -55,11 +55,11 @@ interface TypePickerInput {
   trashedEntries: Writable<TrashedSubPieceEntry[]>;
   linkPatternJson?: string;
   // Internal state
-  dismissed?: Default<boolean, false>;
+  dismissed?: boolean | Default<false>;
 }
 
 interface TypePickerOutput {
-  dismissed?: Default<boolean, false>;
+  dismissed?: boolean | Default<false>;
 }
 
 // ===== Handlers =====

--- a/packages/patterns/weekly-calendar/event.tsx
+++ b/packages/patterns/weekly-calendar/event.tsx
@@ -44,14 +44,14 @@ type MentionablePiece = {
 };
 
 interface Input {
-  title?: Writable<Default<string, "Untitled Event">>;
-  date?: Writable<Default<string, "">>; // YYYY-MM-DD
-  startTime?: Writable<Default<string, "09:00">>; // HH:MM
-  endTime?: Writable<Default<string, "10:00">>; // HH:MM
-  color?: Writable<Default<string, "#fef08a">>;
-  notes?: Writable<Default<string, "">>;
-  isHidden?: Default<boolean, false>;
-  eventId?: Default<string, "">;
+  title?: Writable<string | Default<"Untitled Event">>;
+  date?: Writable<string | Default<"">>; // YYYY-MM-DD
+  startTime?: Writable<string | Default<"09:00">>; // HH:MM
+  endTime?: Writable<string | Default<"10:00">>; // HH:MM
+  color?: Writable<string | Default<"#fef08a">>;
+  notes?: Writable<string | Default<"">>;
+  isHidden?: boolean | Default<false>;
+  eventId?: string | Default<"">;
 }
 
 /** Represents a calendar event with a date, time, and notes. */

--- a/packages/patterns/weekly-calendar/weekly-calendar.tsx
+++ b/packages/patterns/weekly-calendar/weekly-calendar.tsx
@@ -59,10 +59,10 @@ type MentionablePiece = {
 };
 
 interface Input {
-  title?: Default<string, "Weekly Calendar">;
-  events: Writable<Default<EventPiece[], []>>;
-  isCalendar?: Default<boolean, true>; // Marker for identification
-  isHidden?: Default<boolean, false>;
+  title?: string | Default<"Weekly Calendar">;
+  events: Writable<EventPiece[] | Default<[]>>;
+  isCalendar?: boolean | Default<true>; // Marker for identification
+  isHidden?: boolean | Default<false>;
 }
 
 interface Output {

--- a/packages/runner/test/require-defaults.test.ts
+++ b/packages/runner/test/require-defaults.test.ts
@@ -73,6 +73,14 @@ const _stripDefaultBoolean: MustBeTrue<
   AssertEqual<StripDefaultBrand<Default<boolean, true>>, boolean>
 > = true;
 
+const _stripDefaultNull: MustBeTrue<
+  AssertEqual<StripDefaultBrand<Default<null>>, null>
+> = true;
+
+const _stripUnionDefaultNull: MustBeTrue<
+  AssertEqual<StripDefaultBrand<string | Default<null>>, string | null>
+> = true;
+
 // Default<T|undefined, V> strips to T|undefined (brand removed, undefined kept)
 const _stripDefaultWithUndefined: MustBeTrue<
   AssertEqual<
@@ -182,6 +190,20 @@ const _unionDefault: MustBeTrue<
   AssertEqual<
     Simplify<RequireDefaults<{ value?: Default<string, "x"> | number }>>,
     { value: string | number }
+  >
+> = true;
+
+const _unionNullDefault: MustBeTrue<
+  AssertEqual<
+    Simplify<RequireDefaults<{ value?: string | Default<null> }>>,
+    { value: string | null }
+  >
+> = true;
+
+const _nullDefaultRequired: MustBeTrue<
+  AssertEqual<
+    Simplify<RequireDefaults<{ value?: Default<null> }>>,
+    { value: null }
   >
 > = true;
 

--- a/packages/runner/test/require-defaults.test.ts
+++ b/packages/runner/test/require-defaults.test.ts
@@ -200,6 +200,27 @@ const _unionNullDefault: MustBeTrue<
   >
 > = true;
 
+const _cellUnionNullDefaultRequired: MustBeTrue<
+  AssertEqual<
+    Simplify<RequireDefaults<{ value?: Cell<string | Default<null>> }>>,
+    { value: Cell<string | null> }
+  >
+> = true;
+
+const _arrayUnionEmptyDefaultRequired: MustBeTrue<
+  AssertEqual<
+    Simplify<RequireDefaults<{ items?: string[] | Default<[]> }>>,
+    { items: string[] }
+  >
+> = true;
+
+const _cellArrayUnionEmptyDefaultRequired: MustBeTrue<
+  AssertEqual<
+    Simplify<RequireDefaults<{ items?: Cell<string[] | Default<[]>> }>>,
+    { items: Cell<string[]> }
+  >
+> = true;
+
 const _nullDefaultRequired: MustBeTrue<
   AssertEqual<
     Simplify<RequireDefaults<{ value?: Default<null> }>>,

--- a/packages/runner/test/require-defaults.test.ts
+++ b/packages/runner/test/require-defaults.test.ts
@@ -11,7 +11,7 @@ import type {
   RequireDefaults,
   StripDefaultBrand,
 } from "../src/builder/types.ts";
-import type { Default } from "@commonfabric/api";
+import type { DeepDefault, Default } from "@commonfabric/api";
 import type { Cell } from "@commonfabric/runner";
 
 // ============================================================================
@@ -204,6 +204,22 @@ const _nullDefaultRequired: MustBeTrue<
   AssertEqual<
     Simplify<RequireDefaults<{ value?: Default<null> }>>,
     { value: null }
+  >
+> = true;
+
+type DeepDefaultConfig = {
+  theme: string;
+  retries: number;
+};
+
+const _deepDefaultUnion: MustBeTrue<
+  AssertEqual<
+    Simplify<
+      RequireDefaults<
+        { config?: DeepDefaultConfig | DeepDefault<{ theme: "dark" }> }
+      >
+    >,
+    { config: DeepDefaultConfig }
   >
 > = true;
 

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -636,15 +636,23 @@ export class CommonFabricFormatter implements TypeFormatter {
     context: GenerationContext,
   ): JSONSchemaMutable {
     const typeArgs = typeRefNode.typeArguments;
-    if (!typeArgs || typeArgs.length < 2) {
-      throw new Error("Default<T,V> requires exactly 2 type arguments");
+    if (!typeArgs || typeArgs.length < 1 || typeArgs.length > 2) {
+      throw new Error("Default<T,V> requires 1 or 2 type arguments");
     }
 
     const valueTypeNode = typeArgs[0];
-    const defaultTypeNode = typeArgs[1];
+    const defaultTypeNode = typeArgs[1] ?? valueTypeNode;
 
     if (!valueTypeNode || !defaultTypeNode) {
       throw new Error("Default<T,V> type arguments cannot be undefined");
+    }
+    if (
+      typeArgs.length === 1 &&
+      valueTypeNode.kind === ts.SyntaxKind.UndefinedKeyword
+    ) {
+      throw new Error(
+        "Default<undefined> is unsupported; use an optional field or a JSON value default.",
+      );
     }
 
     // Get the value type from the type nodes

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -646,17 +646,13 @@ export class CommonFabricFormatter implements TypeFormatter {
     if (!valueTypeNode || !defaultTypeNode) {
       throw new Error("Default<T,V> type arguments cannot be undefined");
     }
-    if (
-      typeArgs.length === 1 &&
-      valueTypeNode.kind === ts.SyntaxKind.UndefinedKeyword
-    ) {
+    // Get the value type from the type nodes
+    const valueType = context.typeChecker.getTypeFromTypeNode(valueTypeNode);
+    if (typeArgs.length === 1 && this.isUndefinedType(valueType)) {
       throw new Error(
         "Default<undefined> is unsupported; use an optional field or a JSON value default.",
       );
     }
-
-    // Get the value type from the type nodes
-    const valueType = context.typeChecker.getTypeFromTypeNode(valueTypeNode);
 
     // Generate schema for the value type
     const valueSchema = this.schemaGenerator.formatChildType(

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -435,7 +435,7 @@ export class UnionFormatter implements TypeFormatter {
     }
 
     throw new Error(
-      "Default object union member is not assignable to the existing object type. Use Default<T, V> for full defaults or DeepDefault<V> for partial object defaults.",
+      "Default object union member is not assignable to the existing object type. Use T | Default<V> for full defaults or T | DeepDefault<V> for partial object defaults.",
     );
   }
 

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -816,8 +816,8 @@ export class UnionFormatter implements TypeFormatter {
             );
           }
         } else if (ts.isShorthandPropertyAssignment(property)) {
-          obj[property.name.text] = this.extractValueFromExpression(
-            property.name,
+          obj[property.name.text] = this.extractValueFromShorthandProperty(
+            property,
             context,
           );
         }
@@ -832,6 +832,21 @@ export class UnionFormatter implements TypeFormatter {
     if (expr.kind === ts.SyntaxKind.NullKeyword) return null;
 
     return undefined;
+  }
+
+  private extractValueFromShorthandProperty(
+    property: ts.ShorthandPropertyAssignment,
+    context: GenerationContext,
+  ): unknown {
+    const checker = context.typeChecker as ts.TypeChecker & {
+      getShorthandAssignmentValueSymbol?: (
+        node: ts.ShorthandPropertyAssignment,
+      ) => ts.Symbol | undefined;
+    };
+    const symbol = checker.getShorthandAssignmentValueSymbol?.(property) ??
+      context.typeChecker.getSymbolAtLocation(property.name);
+
+    return symbol ? this.extractValueFromSymbol(symbol, context) : undefined;
   }
 
   private isUndefinedType(type: ts.Type): boolean {

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -254,13 +254,19 @@ export class UnionFormatter implements TypeFormatter {
       schemas.push(this.formatTypeNodeMember(node, context));
     }
 
-    if (
-      !this.isDefaultCoveredByUnion(
-        defaultEntry.entry,
-        nonDefaultNodes,
-        context.typeChecker,
-      )
-    ) {
+    const isCovered = this.isDefaultCoveredByUnion(
+      defaultEntry.entry,
+      nonDefaultNodes,
+      context.typeChecker,
+    );
+    this.assertDefaultObjectDoesNotWidenExistingObject(
+      defaultEntry.entry,
+      nonDefaultNodes,
+      isCovered,
+      context.typeChecker,
+    );
+
+    if (!isCovered) {
       schemas.push(
         this.formatTypeNodeMember(defaultEntry.entry.valueTypeNode, context),
       );
@@ -339,6 +345,44 @@ export class UnionFormatter implements TypeFormatter {
         memberType,
       );
     });
+  }
+
+  private assertDefaultObjectDoesNotWidenExistingObject(
+    defaultEntry: DefaultUnionEntry,
+    nonDefaultNodes: readonly ts.TypeNode[],
+    isCovered: boolean,
+    checker: ts.TypeChecker,
+  ): void {
+    if (
+      isCovered || !this.isPlainObjectType(defaultEntry.defaultType, checker)
+    ) {
+      return;
+    }
+
+    const hasObjectTarget = nonDefaultNodes.some((node) =>
+      this.isPlainObjectType(checker.getTypeFromTypeNode(node), checker)
+    );
+    if (!hasObjectTarget) {
+      return;
+    }
+
+    throw new Error(
+      "Default object union member is not assignable to the existing object type. Use Default<T, V> for full defaults or DeepDefault<T, V> for partial object defaults.",
+    );
+  }
+
+  private isPlainObjectType(
+    type: ts.Type,
+    checker: ts.TypeChecker,
+  ): boolean {
+    if ((type.flags & ts.TypeFlags.Object) === 0) {
+      return false;
+    }
+    if (checker.isArrayType(type) || checker.isTupleType(type)) {
+      return false;
+    }
+    const symbolName = type.getSymbol()?.getName();
+    return symbolName !== "Array" && symbolName !== "ReadonlyArray";
   }
 
   private formatTypeNodeMember(

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -18,7 +18,10 @@ import { isRecord } from "@commonfabric/utils/types";
 // Simple primitive schemas only have these keys (possibly just one)
 const PRIMITIVE_SCHEMA_KEY_SET = new Set(["type", "enum"]);
 
+type DefaultUnionKind = "Default" | "DeepDefault";
+
 interface DefaultUnionEntry {
+  readonly kind: DefaultUnionKind;
   readonly valueTypeNode: ts.TypeNode;
   readonly defaultTypeNode: ts.TypeNode;
   readonly valueType: ts.Type;
@@ -254,6 +257,18 @@ export class UnionFormatter implements TypeFormatter {
       schemas.push(this.formatTypeNodeMember(node, context));
     }
 
+    if (defaultEntry.entry.kind === "DeepDefault") {
+      this.assertDeepDefaultHasObjectTarget(
+        defaultEntry.entry,
+        nonDefaultNodes,
+        context.typeChecker,
+      );
+      return this.applyDeepDefaultToSchema(
+        this.combineUnionSchemas(schemas, context),
+        defaultEntry.entry.defaultValue,
+      );
+    }
+
     const isCovered = this.isDefaultCoveredByUnion(
       defaultEntry.entry,
       nonDefaultNodes,
@@ -272,23 +287,10 @@ export class UnionFormatter implements TypeFormatter {
       );
     }
 
-    const combined = this.combineUnionSchemas(schemas, context);
-    if (defaultEntry.entry.defaultValue === undefined) {
-      return combined;
-    }
-    const defaultValue = defaultEntry.entry
-      .defaultValue as NonNullable<JSONSchemaObjMutable["default"]>;
-
-    if (typeof combined === "boolean") {
-      return combined === false
-        ? { not: true, default: defaultValue }
-        : { default: defaultValue };
-    }
-
-    return {
-      ...combined,
-      default: defaultValue,
-    };
+    return this.applySchemaDefault(
+      this.combineUnionSchemas(schemas, context),
+      defaultEntry.entry.defaultValue,
+    );
   }
 
   private getDefaultUnionEntry(
@@ -299,11 +301,30 @@ export class UnionFormatter implements TypeFormatter {
       return undefined;
     }
 
+    const directName = this.getTypeReferenceName(memberNode);
+    if (directName === "DeepDefault") {
+      const typeArgs = memberNode.typeArguments;
+      if (!typeArgs || typeArgs.length !== 1 || !typeArgs[0]) {
+        throw new Error("DeepDefault<V> requires exactly 1 type argument");
+      }
+      const valueTypeNode = typeArgs[0];
+      return {
+        kind: "DeepDefault",
+        valueTypeNode,
+        defaultTypeNode: valueTypeNode,
+        valueType: context.typeChecker.getTypeFromTypeNode(valueTypeNode),
+        defaultType: context.typeChecker.getTypeFromTypeNode(valueTypeNode),
+        defaultValue: this.extractDefaultValueFromNode(
+          valueTypeNode,
+          context,
+        ),
+      };
+    }
+
     const resolved = resolveWrapperNode(memberNode, context.typeChecker);
     if (resolved?.kind !== "Default") {
       return undefined;
     }
-
     const defaultNode = memberNode.typeArguments ? memberNode : resolved.node;
     const typeArgs = defaultNode.typeArguments;
     if (!typeArgs || typeArgs.length < 1 || typeArgs.length > 2) {
@@ -325,12 +346,18 @@ export class UnionFormatter implements TypeFormatter {
     }
 
     return {
+      kind: "Default",
       valueTypeNode,
       defaultTypeNode,
       valueType: context.typeChecker.getTypeFromTypeNode(valueTypeNode),
       defaultType: context.typeChecker.getTypeFromTypeNode(defaultTypeNode),
       defaultValue: this.extractDefaultValueFromNode(defaultTypeNode, context),
     };
+  }
+
+  private getTypeReferenceName(typeNode: ts.TypeReferenceNode): string {
+    const typeName = typeNode.typeName;
+    return ts.isIdentifier(typeName) ? typeName.text : typeName.right.text;
   }
 
   private isDefaultCoveredByUnion(
@@ -367,7 +394,27 @@ export class UnionFormatter implements TypeFormatter {
     }
 
     throw new Error(
-      "Default object union member is not assignable to the existing object type. Use Default<T, V> for full defaults or DeepDefault<T, V> for partial object defaults.",
+      "Default object union member is not assignable to the existing object type. Use Default<T, V> for full defaults or DeepDefault<V> for partial object defaults.",
+    );
+  }
+
+  private assertDeepDefaultHasObjectTarget(
+    defaultEntry: DefaultUnionEntry,
+    nonDefaultNodes: readonly ts.TypeNode[],
+    checker: ts.TypeChecker,
+  ): void {
+    const hasObjectTarget = nonDefaultNodes.some((node) =>
+      this.isPlainObjectType(checker.getTypeFromTypeNode(node), checker)
+    );
+    if (
+      hasObjectTarget &&
+      this.isPlainObjectType(defaultEntry.defaultType, checker)
+    ) {
+      return;
+    }
+
+    throw new Error(
+      "DeepDefault must be unioned with an object type and must provide an object default.",
     );
   }
 
@@ -438,6 +485,76 @@ export class UnionFormatter implements TypeFormatter {
     }
 
     return { anyOf };
+  }
+
+  private applySchemaDefault(
+    schema: JSONSchemaMutable,
+    defaultValue: unknown,
+  ): JSONSchemaMutable {
+    if (defaultValue === undefined) {
+      return schema;
+    }
+    const value = defaultValue as NonNullable<JSONSchemaObjMutable["default"]>;
+
+    if (typeof schema === "boolean") {
+      return schema === false
+        ? { not: true, default: value }
+        : { default: value };
+    }
+
+    return {
+      ...schema,
+      default: value,
+    };
+  }
+
+  private applyDeepDefaultToSchema(
+    schema: JSONSchemaMutable,
+    defaultValue: unknown,
+  ): JSONSchemaMutable {
+    const withDefault = this.applySchemaDefault(schema, defaultValue);
+    if (!this.isDefaultObject(defaultValue) || !isRecord(withDefault)) {
+      return withDefault;
+    }
+
+    return this.applyObjectPropertyDefaults(withDefault, defaultValue);
+  }
+
+  private applyObjectPropertyDefaults(
+    schema: JSONSchemaObjMutable,
+    defaults: Record<string, unknown>,
+  ): JSONSchemaObjMutable {
+    const properties = isRecord(schema.properties)
+      ? { ...schema.properties }
+      : {};
+
+    for (const [name, value] of Object.entries(defaults)) {
+      properties[name] = this.applyDeepDefaultToProperty(
+        properties[name] as JSONSchemaMutable | undefined,
+        value,
+      );
+    }
+
+    return {
+      ...schema,
+      properties,
+    };
+  }
+
+  private applyDeepDefaultToProperty(
+    schema: JSONSchemaMutable | undefined,
+    defaultValue: unknown,
+  ): JSONSchemaMutable {
+    const withDefault = this.applySchemaDefault(schema ?? true, defaultValue);
+    if (!this.isDefaultObject(defaultValue) || !isRecord(withDefault)) {
+      return withDefault;
+    }
+
+    return this.applyObjectPropertyDefaults(withDefault, defaultValue);
+  }
+
+  private isDefaultObject(value: unknown): value is Record<string, unknown> {
+    return isRecord(value) && !Array.isArray(value);
   }
 
   private extractDefaultValueFromNode(

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -632,14 +632,40 @@ export class UnionFormatter implements TypeFormatter {
   private getObjectTargetProperties(
     schema: JSONSchemaObjMutable,
     rootDefs?: Record<string, unknown>,
+    seen = new Set<JSONSchemaObjMutable>(),
   ): Record<string, unknown> | undefined {
+    if (seen.has(schema)) {
+      return undefined;
+    }
+    seen.add(schema);
+
     if (isRecord(schema.properties)) {
       return schema.properties;
     }
 
     const refSchema = this.resolveLocalRefSchema(schema, rootDefs);
-    if (refSchema && isRecord(refSchema.properties)) {
-      return refSchema.properties;
+    if (refSchema) {
+      return this.getObjectTargetProperties(refSchema, rootDefs, seen);
+    }
+
+    if (Array.isArray(schema.anyOf)) {
+      const candidates = schema.anyOf
+        .map((option) =>
+          isRecord(option)
+            ? this.getObjectTargetProperties(
+              option as JSONSchemaObjMutable,
+              rootDefs,
+              new Set(seen),
+            )
+            : undefined
+        )
+        .filter((properties): properties is Record<string, unknown> =>
+          properties !== undefined
+        );
+
+      if (candidates.length === 1) {
+        return candidates[0];
+      }
     }
 
     return undefined;

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -9,12 +9,22 @@ import {
   cloneSchemaDefinition,
   detectWrapperViaNode,
   getNativeTypeSchema,
+  getPropertyNameText,
+  resolveWrapperNode,
   TypeWithInternals,
 } from "../type-utils.ts";
 import { isRecord } from "@commonfabric/utils/types";
 
 // Simple primitive schemas only have these keys (possibly just one)
 const PRIMITIVE_SCHEMA_KEY_SET = new Set(["type", "enum"]);
+
+interface DefaultUnionEntry {
+  readonly valueTypeNode: ts.TypeNode;
+  readonly defaultTypeNode: ts.TypeNode;
+  readonly valueType: ts.Type;
+  readonly defaultType: ts.Type;
+  readonly defaultValue: unknown;
+}
 
 function getTypeNodeMemberType(
   node: ts.TypeNode,
@@ -92,6 +102,13 @@ export class UnionFormatter implements TypeFormatter {
 
     if (members.length === 0) {
       throw new Error("UnionFormatter received empty union type");
+    }
+
+    const defaultUnionSchema = memberNodes
+      ? this.tryFormatDefaultUnion(memberNodes, context)
+      : undefined;
+    if (defaultUnionSchema) {
+      return defaultUnionSchema;
     }
 
     // Detect presence of null
@@ -200,6 +217,247 @@ export class UnionFormatter implements TypeFormatter {
     }
 
     return { anyOf };
+  }
+
+  private tryFormatDefaultUnion(
+    memberNodes: readonly ts.TypeNode[],
+    context: GenerationContext,
+  ): JSONSchemaMutable | undefined {
+    const defaultEntries = memberNodes
+      .map((node, index) => ({
+        index,
+        node,
+        entry: this.getDefaultUnionEntry(node, context),
+      }))
+      .filter((item): item is {
+        index: number;
+        node: ts.TypeNode;
+        entry: DefaultUnionEntry;
+      } => item.entry !== undefined);
+
+    if (defaultEntries.length === 0) {
+      return undefined;
+    }
+    if (defaultEntries.length > 1) {
+      throw new Error(
+        "Union types may contain at most one Default<> member.",
+      );
+    }
+
+    const defaultEntry = defaultEntries[0]!;
+    const nonDefaultNodes = memberNodes.filter((_, index) =>
+      index !== defaultEntry.index
+    );
+
+    const schemas: JSONSchemaMutable[] = [];
+    for (const node of nonDefaultNodes) {
+      schemas.push(this.formatTypeNodeMember(node, context));
+    }
+
+    if (
+      !this.isDefaultCoveredByUnion(
+        defaultEntry.entry,
+        nonDefaultNodes,
+        context.typeChecker,
+      )
+    ) {
+      schemas.push(
+        this.formatTypeNodeMember(defaultEntry.entry.valueTypeNode, context),
+      );
+    }
+
+    const combined = this.combineUnionSchemas(schemas, context);
+    if (defaultEntry.entry.defaultValue === undefined) {
+      return combined;
+    }
+    const defaultValue = defaultEntry.entry
+      .defaultValue as NonNullable<JSONSchemaObjMutable["default"]>;
+
+    if (typeof combined === "boolean") {
+      return combined === false
+        ? { not: true, default: defaultValue }
+        : { default: defaultValue };
+    }
+
+    return {
+      ...combined,
+      default: defaultValue,
+    };
+  }
+
+  private getDefaultUnionEntry(
+    memberNode: ts.TypeNode,
+    context: GenerationContext,
+  ): DefaultUnionEntry | undefined {
+    if (!ts.isTypeReferenceNode(memberNode)) {
+      return undefined;
+    }
+
+    const resolved = resolveWrapperNode(memberNode, context.typeChecker);
+    if (resolved?.kind !== "Default") {
+      return undefined;
+    }
+
+    const defaultNode = memberNode.typeArguments ? memberNode : resolved.node;
+    const typeArgs = defaultNode.typeArguments;
+    if (!typeArgs || typeArgs.length < 1 || typeArgs.length > 2) {
+      throw new Error("Default<T,V> requires 1 or 2 type arguments");
+    }
+
+    const valueTypeNode = typeArgs[0];
+    const defaultTypeNode = typeArgs[1] ?? valueTypeNode;
+    if (!valueTypeNode || !defaultTypeNode) {
+      throw new Error("Default<T,V> type arguments cannot be undefined");
+    }
+    if (
+      typeArgs.length === 1 &&
+      valueTypeNode.kind === ts.SyntaxKind.UndefinedKeyword
+    ) {
+      throw new Error(
+        "Default<undefined> is unsupported; use an optional field or a JSON value default.",
+      );
+    }
+
+    return {
+      valueTypeNode,
+      defaultTypeNode,
+      valueType: context.typeChecker.getTypeFromTypeNode(valueTypeNode),
+      defaultType: context.typeChecker.getTypeFromTypeNode(defaultTypeNode),
+      defaultValue: this.extractDefaultValueFromNode(defaultTypeNode, context),
+    };
+  }
+
+  private isDefaultCoveredByUnion(
+    defaultEntry: DefaultUnionEntry,
+    nonDefaultNodes: readonly ts.TypeNode[],
+    checker: ts.TypeChecker,
+  ): boolean {
+    return nonDefaultNodes.some((node) => {
+      const memberType = checker.getTypeFromTypeNode(node);
+      return checker.isTypeAssignableTo(
+        defaultEntry.defaultType,
+        memberType,
+      );
+    });
+  }
+
+  private formatTypeNodeMember(
+    typeNode: ts.TypeNode,
+    context: GenerationContext,
+  ): JSONSchemaMutable {
+    const type = context.typeChecker.getTypeFromTypeNode(typeNode);
+    const native = detectWrapperViaNode(typeNode, context.typeChecker) ===
+        undefined
+      ? getNativeTypeSchema(type, context.typeChecker)
+      : undefined;
+    if (native !== undefined) {
+      return cloneSchemaDefinition(native);
+    }
+    return this.schemaGenerator.formatChildType(type, context, typeNode);
+  }
+
+  private combineUnionSchemas(
+    schemas: JSONSchemaMutable[],
+    context: GenerationContext,
+  ): JSONSchemaMutable {
+    if (schemas.length === 0) {
+      return true;
+    }
+    if (schemas.length === 1) {
+      return schemas[0]!;
+    }
+    const nullSchema = schemas.find((schema) =>
+      isRecord(schema) && schema.type === "null"
+    );
+    const nonNullSchemas = schemas.filter((schema) => schema !== nullSchema);
+    if (nullSchema && nonNullSchemas.length === 1) {
+      return { anyOf: [nonNullSchemas[0]!, nullSchema] };
+    }
+
+    let unionOptions = schemas;
+    if (context.widenLiterals && unionOptions.length > 1) {
+      unionOptions = this.mergeIdenticalSchemas(unionOptions);
+    }
+
+    const anyOf: JSONSchemaObjMutable[] = [];
+    for (const option of unionOptions) {
+      if (this.mergePrimitiveSchemaIntoAnyOf(anyOf, option)) {
+        return true;
+      }
+    }
+
+    if (anyOf.length === 0) {
+      return false;
+    }
+    if (anyOf.length === 1) {
+      return anyOf[0]!;
+    }
+
+    return { anyOf };
+  }
+
+  private extractDefaultValueFromNode(
+    typeNode: ts.TypeNode,
+    context: GenerationContext,
+  ): unknown {
+    if (ts.isLiteralTypeNode(typeNode)) {
+      const literal = typeNode.literal;
+      if (ts.isStringLiteral(literal)) return literal.text;
+      if (ts.isNumericLiteral(literal)) return Number(literal.text);
+      if (literal.kind === ts.SyntaxKind.TrueKeyword) return true;
+      if (literal.kind === ts.SyntaxKind.FalseKeyword) return false;
+      if (literal.kind === ts.SyntaxKind.NullKeyword) return null;
+    }
+
+    if (ts.isTupleTypeNode(typeNode)) {
+      return typeNode.elements.map((element) =>
+        this.extractDefaultValueFromNode(element, context)
+      );
+    }
+
+    if (ts.isTypeLiteralNode(typeNode)) {
+      const obj: Record<string, unknown> = {};
+      for (const member of typeNode.members) {
+        if (!ts.isPropertySignature(member) || !member.name || !member.type) {
+          continue;
+        }
+        const propName = getPropertyNameText(member.name, context.typeChecker);
+        if (!propName) {
+          continue;
+        }
+        obj[propName] = this.extractDefaultValueFromNode(
+          member.type,
+          context,
+        );
+      }
+      return obj;
+    }
+
+    if (typeNode.kind === ts.SyntaxKind.NullKeyword) return null;
+    if (typeNode.kind === ts.SyntaxKind.UndefinedKeyword) return undefined;
+
+    return this.extractDefaultValue(
+      context.typeChecker.getTypeFromTypeNode(typeNode),
+    );
+  }
+
+  private extractDefaultValue(type: ts.Type): unknown {
+    if (type.flags & ts.TypeFlags.StringLiteral) {
+      return (type as ts.StringLiteralType).value;
+    }
+    if (type.flags & ts.TypeFlags.NumberLiteral) {
+      return (type as ts.NumberLiteralType).value;
+    }
+    if (type.flags & ts.TypeFlags.BooleanLiteral) {
+      return (type as TypeWithInternals).intrinsicName === "true";
+    }
+    if (type.flags & ts.TypeFlags.Null) {
+      return null;
+    }
+    if (type.flags & ts.TypeFlags.Undefined) {
+      return undefined;
+    }
+    return undefined;
   }
 
   /**

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -88,13 +88,11 @@ export class UnionFormatter implements TypeFormatter {
   ): JSONSchemaMutable {
     const union = type as ts.UnionType;
     const members = union.types ?? [];
-    const unionNode = context.typeNode &&
-        ts.isParenthesizedTypeNode(context.typeNode)
-      ? context.typeNode.type
-      : context.typeNode;
-    const memberNodes = unionNode && ts.isUnionTypeNode(unionNode)
-      ? unionNode.types
-      : undefined;
+    const unionNode = this.getUnionTypeNode(
+      context.typeNode,
+      context.typeChecker,
+    );
+    const memberNodes = unionNode ? unionNode.types : undefined;
     const orderedMemberNodes = memberNodes
       ? orderMemberNodesBySemanticType(
         members,
@@ -110,7 +108,7 @@ export class UnionFormatter implements TypeFormatter {
     const defaultUnionSchema = memberNodes
       ? this.tryFormatDefaultUnion(memberNodes, context)
       : undefined;
-    if (defaultUnionSchema) {
+    if (defaultUnionSchema !== undefined) {
       return defaultUnionSchema;
     }
 
@@ -266,6 +264,7 @@ export class UnionFormatter implements TypeFormatter {
       return this.applyDeepDefaultToSchema(
         this.combineUnionSchemas(schemas, context),
         defaultEntry.entry.defaultValue,
+        context.definitions,
       );
     }
 
@@ -291,6 +290,47 @@ export class UnionFormatter implements TypeFormatter {
       this.combineUnionSchemas(schemas, context),
       defaultEntry.entry.defaultValue,
     );
+  }
+
+  private getUnionTypeNode(
+    typeNode: ts.TypeNode | undefined,
+    checker: ts.TypeChecker,
+    visited = new Set<string>(),
+  ): ts.UnionTypeNode | undefined {
+    if (!typeNode) {
+      return undefined;
+    }
+
+    const unwrapped = ts.isParenthesizedTypeNode(typeNode)
+      ? typeNode.type
+      : typeNode;
+    if (ts.isUnionTypeNode(unwrapped)) {
+      return unwrapped;
+    }
+    if (
+      !ts.isTypeReferenceNode(unwrapped) ||
+      !ts.isIdentifier(unwrapped.typeName) ||
+      unwrapped.typeArguments?.length
+    ) {
+      return undefined;
+    }
+
+    const symbol = checker.getSymbolAtLocation(unwrapped.typeName);
+    const aliasDeclaration = symbol?.declarations?.find((
+      declaration,
+    ): declaration is ts.TypeAliasDeclaration =>
+      ts.isTypeAliasDeclaration(declaration)
+    );
+    if (!aliasDeclaration || aliasDeclaration.typeParameters?.length) {
+      return undefined;
+    }
+
+    const aliasName = aliasDeclaration.name.text;
+    if (visited.has(aliasName)) {
+      throw new Error(`Circular type alias detected: ${aliasName}`);
+    }
+    visited.add(aliasName);
+    return this.getUnionTypeNode(aliasDeclaration.type, checker, visited);
   }
 
   private getDefaultUnionEntry(
@@ -336,10 +376,11 @@ export class UnionFormatter implements TypeFormatter {
     if (!valueTypeNode || !defaultTypeNode) {
       throw new Error("Default<T,V> type arguments cannot be undefined");
     }
-    if (
-      typeArgs.length === 1 &&
-      valueTypeNode.kind === ts.SyntaxKind.UndefinedKeyword
-    ) {
+    const valueType = context.typeChecker.getTypeFromTypeNode(valueTypeNode);
+    const defaultType = context.typeChecker.getTypeFromTypeNode(
+      defaultTypeNode,
+    );
+    if (typeArgs.length === 1 && this.isUndefinedType(valueType)) {
       throw new Error(
         "Default<undefined> is unsupported; use an optional field or a JSON value default.",
       );
@@ -349,8 +390,8 @@ export class UnionFormatter implements TypeFormatter {
       kind: "Default",
       valueTypeNode,
       defaultTypeNode,
-      valueType: context.typeChecker.getTypeFromTypeNode(valueTypeNode),
-      defaultType: context.typeChecker.getTypeFromTypeNode(defaultTypeNode),
+      valueType,
+      defaultType,
       defaultValue: this.extractDefaultValueFromNode(defaultTypeNode, context),
     };
   }
@@ -511,27 +552,53 @@ export class UnionFormatter implements TypeFormatter {
   private applyDeepDefaultToSchema(
     schema: JSONSchemaMutable,
     defaultValue: unknown,
+    rootDefs?: Record<string, unknown>,
   ): JSONSchemaMutable {
     const withDefault = this.applySchemaDefault(schema, defaultValue);
     if (!this.isDefaultObject(defaultValue) || !isRecord(withDefault)) {
       return withDefault;
     }
 
-    return this.applyObjectPropertyDefaults(withDefault, defaultValue);
+    return this.applyObjectPropertyDefaults(
+      withDefault,
+      defaultValue,
+      [],
+      this.getSchemaDefs(withDefault) ?? rootDefs,
+    );
   }
 
   private applyObjectPropertyDefaults(
     schema: JSONSchemaObjMutable,
     defaults: Record<string, unknown>,
+    path: string[] = [],
+    rootDefs?: Record<string, unknown>,
+    targetSchema?: JSONSchemaMutable,
   ): JSONSchemaObjMutable {
     const properties = isRecord(schema.properties)
       ? { ...schema.properties }
       : {};
+    const targetProperties = this.getObjectTargetProperties(
+      isRecord(targetSchema) ? targetSchema : schema,
+      rootDefs,
+    );
 
     for (const [name, value] of Object.entries(defaults)) {
+      const fullPath = [...path, name];
+      const targetExisting = (properties[name] ??
+        targetProperties?.[name]) as JSONSchemaMutable | undefined;
+      if (targetExisting === undefined) {
+        throw new Error(
+          `DeepDefault key "${
+            fullPath.join(".")
+          }" does not exist on the target object type.`,
+        );
+      }
       properties[name] = this.applyDeepDefaultToProperty(
         properties[name] as JSONSchemaMutable | undefined,
         value,
+        fullPath,
+        rootDefs,
+        targetExisting,
       );
     }
 
@@ -544,13 +611,64 @@ export class UnionFormatter implements TypeFormatter {
   private applyDeepDefaultToProperty(
     schema: JSONSchemaMutable | undefined,
     defaultValue: unknown,
+    path: string[] = [],
+    rootDefs?: Record<string, unknown>,
+    targetSchema?: JSONSchemaMutable,
   ): JSONSchemaMutable {
     const withDefault = this.applySchemaDefault(schema ?? true, defaultValue);
     if (!this.isDefaultObject(defaultValue) || !isRecord(withDefault)) {
       return withDefault;
     }
 
-    return this.applyObjectPropertyDefaults(withDefault, defaultValue);
+    return this.applyObjectPropertyDefaults(
+      withDefault,
+      defaultValue,
+      path,
+      rootDefs,
+      targetSchema,
+    );
+  }
+
+  private getObjectTargetProperties(
+    schema: JSONSchemaObjMutable,
+    rootDefs?: Record<string, unknown>,
+  ): Record<string, unknown> | undefined {
+    if (isRecord(schema.properties)) {
+      return schema.properties;
+    }
+
+    const refSchema = this.resolveLocalRefSchema(schema, rootDefs);
+    if (refSchema && isRecord(refSchema.properties)) {
+      return refSchema.properties;
+    }
+
+    return undefined;
+  }
+
+  private resolveLocalRefSchema(
+    schema: JSONSchemaObjMutable,
+    rootDefs?: Record<string, unknown>,
+  ): JSONSchemaObjMutable | undefined {
+    if (typeof schema.$ref !== "string") {
+      return undefined;
+    }
+    const prefix = "#/$defs/";
+    if (!schema.$ref.startsWith(prefix)) {
+      return undefined;
+    }
+
+    const defs = this.getSchemaDefs(schema) ?? rootDefs;
+    const resolved = defs?.[schema.$ref.slice(prefix.length)];
+    return isRecord(resolved) ? resolved as JSONSchemaObjMutable : undefined;
+  }
+
+  private getSchemaDefs(
+    schema: JSONSchemaObjMutable,
+  ): Record<string, unknown> | undefined {
+    if (isRecord(schema.$defs)) {
+      return schema.$defs;
+    }
+    return isRecord(schema.definitions) ? schema.definitions : undefined;
   }
 
   private isDefaultObject(value: unknown): value is Record<string, unknown> {
@@ -561,6 +679,10 @@ export class UnionFormatter implements TypeFormatter {
     typeNode: ts.TypeNode,
     context: GenerationContext,
   ): unknown {
+    if (ts.isTypeQueryNode(typeNode)) {
+      return this.extractValueFromTypeQuery(typeNode, context);
+    }
+
     if (ts.isLiteralTypeNode(typeNode)) {
       const literal = typeNode.literal;
       if (ts.isStringLiteral(literal)) return literal.text;
@@ -599,10 +721,14 @@ export class UnionFormatter implements TypeFormatter {
 
     return this.extractDefaultValue(
       context.typeChecker.getTypeFromTypeNode(typeNode),
+      context,
     );
   }
 
-  private extractDefaultValue(type: ts.Type): unknown {
+  private extractDefaultValue(
+    type: ts.Type,
+    context: GenerationContext,
+  ): unknown {
     if (type.flags & ts.TypeFlags.StringLiteral) {
       return (type as ts.StringLiteralType).value;
     }
@@ -618,7 +744,98 @@ export class UnionFormatter implements TypeFormatter {
     if (type.flags & ts.TypeFlags.Undefined) {
       return undefined;
     }
+
+    const symbol = type.getSymbol();
+    if (symbol?.valueDeclaration) {
+      return this.extractValueFromSymbol(symbol, context);
+    }
+
     return undefined;
+  }
+
+  private extractValueFromTypeQuery(
+    typeQueryNode: ts.TypeQueryNode,
+    context: GenerationContext,
+  ): unknown {
+    const symbol = context.typeChecker.getSymbolAtLocation(
+      typeQueryNode.exprName,
+    );
+    return symbol ? this.extractValueFromSymbol(symbol, context) : undefined;
+  }
+
+  private extractValueFromSymbol(
+    symbol: ts.Symbol,
+    context: GenerationContext,
+  ): unknown {
+    const valueDeclaration = symbol.valueDeclaration;
+    if (
+      valueDeclaration &&
+      ts.isVariableDeclaration(valueDeclaration) &&
+      valueDeclaration.initializer
+    ) {
+      return this.extractValueFromExpression(
+        valueDeclaration.initializer,
+        context,
+      );
+    }
+
+    return undefined;
+  }
+
+  private extractValueFromExpression(
+    expr: ts.Expression,
+    context: GenerationContext,
+  ): unknown {
+    if (
+      ts.isAsExpression(expr) ||
+      ts.isTypeAssertionExpression(expr) ||
+      ts.isSatisfiesExpression(expr) ||
+      ts.isParenthesizedExpression(expr)
+    ) {
+      return this.extractValueFromExpression(expr.expression, context);
+    }
+
+    if (ts.isArrayLiteralExpression(expr)) {
+      return expr.elements.map((element) =>
+        this.extractValueFromExpression(element, context)
+      );
+    }
+
+    if (ts.isObjectLiteralExpression(expr)) {
+      const obj: Record<string, unknown> = {};
+      for (const property of expr.properties) {
+        if (ts.isPropertyAssignment(property)) {
+          const propName = getPropertyNameText(
+            property.name,
+            context.typeChecker,
+          );
+          if (propName) {
+            obj[propName] = this.extractValueFromExpression(
+              property.initializer,
+              context,
+            );
+          }
+        } else if (ts.isShorthandPropertyAssignment(property)) {
+          obj[property.name.text] = this.extractValueFromExpression(
+            property.name,
+            context,
+          );
+        }
+      }
+      return obj;
+    }
+
+    if (ts.isStringLiteral(expr)) return expr.text;
+    if (ts.isNumericLiteral(expr)) return Number(expr.text);
+    if (expr.kind === ts.SyntaxKind.TrueKeyword) return true;
+    if (expr.kind === ts.SyntaxKind.FalseKeyword) return false;
+    if (expr.kind === ts.SyntaxKind.NullKeyword) return null;
+
+    return undefined;
+  }
+
+  private isUndefinedType(type: ts.Type): boolean {
+    return (type.flags & ts.TypeFlags.Undefined) !== 0;
   }
 
   /**

--- a/packages/schema-generator/test/fixtures/schema/default-syntax-comparison.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/default-syntax-comparison.expected.json
@@ -1,0 +1,245 @@
+{
+  "$defs": {
+    "Preferences": {
+      "properties": {
+        "profile": {
+          "properties": {
+            "email": {
+              "type": "string"
+            },
+            "flags": {
+              "properties": {
+                "marketing": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "marketing"
+              ],
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "email",
+            "flags",
+            "name"
+          ],
+          "type": "object"
+        },
+        "retries": {
+          "type": "number"
+        },
+        "theme": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "profile",
+        "retries",
+        "theme"
+      ],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "deep": {
+      "properties": {
+        "preferences": {
+          "$ref": "#/$defs/Preferences",
+          "default": {
+            "profile": {
+              "flags": {
+                "marketing": false
+              },
+              "name": "Ada"
+            },
+            "theme": "dark"
+          },
+          "properties": {
+            "profile": {
+              "default": {
+                "flags": {
+                  "marketing": false
+                },
+                "name": "Ada"
+              },
+              "properties": {
+                "flags": {
+                  "default": {
+                    "marketing": false
+                  },
+                  "properties": {
+                    "marketing": {
+                      "default": false
+                    }
+                  }
+                },
+                "name": {
+                  "default": "Ada"
+                }
+              }
+            },
+            "theme": {
+              "default": "dark"
+            }
+          }
+        }
+      },
+      "required": [
+        "preferences"
+      ],
+      "type": "object"
+    },
+    "legacy": {
+      "properties": {
+        "count": {
+          "default": 0,
+          "type": "number"
+        },
+        "enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "nullable": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": null
+        },
+        "preferences": {
+          "$ref": "#/$defs/Preferences",
+          "default": {
+            "profile": {
+              "email": "",
+              "flags": {
+                "marketing": false
+              },
+              "name": "Ada"
+            },
+            "retries": 3,
+            "theme": "dark"
+          }
+        },
+        "tags": {
+          "default": [
+            "default",
+            "tags"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "default": "",
+          "type": "string"
+        },
+        "writableTags": {
+          "asCell": [
+            "cell"
+          ],
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "count",
+        "enabled",
+        "nullable",
+        "preferences",
+        "tags",
+        "title",
+        "writableTags"
+      ],
+      "type": "object"
+    },
+    "shorthand": {
+      "properties": {
+        "count": {
+          "default": 0,
+          "type": "number"
+        },
+        "enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "nullable": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": null
+        },
+        "preferences": {
+          "$ref": "#/$defs/Preferences",
+          "default": {
+            "profile": {
+              "email": "",
+              "flags": {
+                "marketing": false
+              },
+              "name": "Ada"
+            },
+            "retries": 3,
+            "theme": "dark"
+          }
+        },
+        "tags": {
+          "default": [
+            "default",
+            "tags"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "default": "",
+          "type": "string"
+        },
+        "writableTags": {
+          "asCell": [
+            "cell"
+          ],
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "count",
+        "enabled",
+        "nullable",
+        "preferences",
+        "tags",
+        "title",
+        "writableTags"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "deep",
+    "legacy",
+    "shorthand"
+  ],
+  "type": "object"
+}

--- a/packages/schema-generator/test/fixtures/schema/default-syntax-comparison.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/default-syntax-comparison.input.ts
@@ -1,0 +1,80 @@
+declare const DEFAULT_MARKER: unique symbol;
+
+interface Default<T, V extends T = T> {
+  readonly [DEFAULT_MARKER]?: [T, V];
+}
+
+interface DeepDefault<V> {
+  readonly [DEFAULT_MARKER]?: V;
+}
+
+interface Preferences {
+  theme: string;
+  retries: number;
+  profile: {
+    name: string;
+    email: string;
+    flags: {
+      marketing: boolean;
+    };
+  };
+}
+
+interface SchemaRoot {
+  legacy: {
+    title: Default<string, "">;
+    count: Default<number, 0>;
+    enabled: Default<boolean, false>;
+    nullable: Default<string | null, null>;
+    tags: Default<string[], ["default", "tags"]>;
+    preferences: Default<
+      Preferences,
+      {
+        theme: "dark";
+        retries: 3;
+        profile: {
+          name: "Ada";
+          email: "";
+          flags: {
+            marketing: false;
+          };
+        };
+      }
+    >;
+    writableTags: Writable<Default<string[], []>>;
+  };
+  shorthand: {
+    title: string | Default<"">;
+    count: number | Default<0>;
+    enabled: boolean | Default<false>;
+    nullable: string | null | Default<null>;
+    tags: string[] | Default<["default", "tags"]>;
+    preferences: Preferences | Default<
+      {
+        theme: "dark";
+        retries: 3;
+        profile: {
+          name: "Ada";
+          email: "";
+          flags: {
+            marketing: false;
+          };
+        };
+      }
+    >;
+    writableTags: Writable<string[] | Default<[]>>;
+  };
+  deep: {
+    preferences: Preferences | DeepDefault<
+      {
+        theme: "dark";
+        profile: {
+          name: "Ada";
+          flags: {
+            marketing: false;
+          };
+        };
+      }
+    >;
+  };
+}

--- a/packages/schema-generator/test/schema/default-type.test.ts
+++ b/packages/schema-generator/test/schema/default-type.test.ts
@@ -51,6 +51,20 @@ describe("Schema: Default<T,V>", () => {
     );
   });
 
+  it("rejects one-argument Default with aliased undefined", async () => {
+    const code = `
+      interface Default<T, V extends T = T> {}
+      type U = undefined;
+      type T = Default<U>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const gen = createSchemaTransformerV2();
+
+    expect(() => gen.generateSchema(type, checker, typeNode)).toThrow(
+      "Default<undefined> is unsupported",
+    );
+  });
+
   it("applies default for primitive value", async () => {
     const code = `
       interface Default<T, V> {}

--- a/packages/schema-generator/test/schema/default-type.test.ts
+++ b/packages/schema-generator/test/schema/default-type.test.ts
@@ -4,6 +4,53 @@ import { createSchemaTransformerV2 } from "../../src/plugin.ts";
 import { asObjectSchema, getTypeFromCode } from "../utils.ts";
 
 describe("Schema: Default<T,V>", () => {
+  it("applies default when Default has one type argument", async () => {
+    const code = `
+      interface Default<T, V extends T = T> {}
+      interface X {
+        text: Default<"">;
+        count: Default<0>;
+        enabled: Default<false>;
+        missing: Default<null>;
+      }
+    `;
+    const { type, checker } = await getTypeFromCode(code, "X");
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker),
+    );
+
+    expect(result.required).toEqual(["text", "count", "enabled", "missing"]);
+
+    const text = result.properties?.text as any;
+    expect(text.enum).toEqual([""]);
+    expect(text.default).toBe("");
+
+    const count = result.properties?.count as any;
+    expect(count.enum).toEqual([0]);
+    expect(count.default).toBe(0);
+
+    const enabled = result.properties?.enabled as any;
+    expect(enabled.enum).toEqual([false]);
+    expect(enabled.default).toBe(false);
+
+    const missing = result.properties?.missing as any;
+    expect(missing.type).toBe("null");
+    expect(missing.default).toBe(null);
+  });
+
+  it("rejects one-argument Default<undefined>", async () => {
+    const code = `
+      interface Default<T, V extends T = T> {}
+      type T = Default<undefined>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const gen = createSchemaTransformerV2();
+
+    expect(() => gen.generateSchema(type, checker, typeNode)).toThrow(
+      "Default<undefined> is unsupported",
+    );
+  });
+
   it("applies default for primitive value", async () => {
     const code = `
       interface Default<T, V> {}

--- a/packages/schema-generator/test/schema/default-union.test.ts
+++ b/packages/schema-generator/test/schema/default-union.test.ts
@@ -1,0 +1,86 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSchemaTransformerV2 } from "../../src/plugin.ts";
+import { asObjectSchema, getTypeFromCode } from "../utils.ts";
+
+describe("Schema: Default in unions", () => {
+  it("applies primitive defaults from T | Default<V>", async () => {
+    const code = `
+      interface Default<T, V extends T = T> {}
+      interface X {
+        title: string | Default<"">;
+        count: number | Default<0>;
+        enabled: boolean | Default<false>;
+      }
+    `;
+    const { type, checker } = await getTypeFromCode(code, "X");
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker),
+    );
+
+    const title = result.properties?.title as any;
+    expect(title.type).toBe("string");
+    expect(title.default).toBe("");
+
+    const count = result.properties?.count as any;
+    expect(count.type).toBe("number");
+    expect(count.default).toBe(0);
+
+    const enabled = result.properties?.enabled as any;
+    expect(enabled.type).toBe("boolean");
+    expect(enabled.default).toBe(false);
+  });
+
+  it("applies null defaults from T | Default<null>", async () => {
+    const code = `
+      interface Default<T, V extends T = T> {}
+      type T = string | Default<null>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker, typeNode),
+    );
+
+    expect(result.anyOf).toEqual(expect.arrayContaining([
+      { type: "string" },
+      { type: "null" },
+    ]));
+    expect(result.default).toBe(null);
+  });
+
+  it("applies array defaults from T[] | Default<[...]>", async () => {
+    const code = `
+      interface Default<T, V extends T = T> {}
+      type T = string[] | Default<["a", "b"]>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker, typeNode),
+    );
+
+    expect(result.type).toBe("array");
+    expect((result.items as any)?.type).toBe("string");
+    expect(result.default).toEqual(["a", "b"]);
+  });
+
+  it("applies object defaults from T | Default<V>", async () => {
+    const code = `
+      interface Default<T, V extends T = T> {}
+      interface Config {
+        theme: string;
+      }
+      type T = Config | Default<{ theme: "dark" }>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker, typeNode),
+    );
+
+    expect(result.$ref).toBe("#/$defs/Config");
+    const config = (result as any).$defs?.Config;
+    expect(config.type).toBe("object");
+    expect(config.properties?.theme).toEqual({ type: "string" });
+    expect(config.required).toEqual(["theme"]);
+    expect(result.default).toEqual({ theme: "dark" });
+  });
+});

--- a/packages/schema-generator/test/schema/default-union.test.ts
+++ b/packages/schema-generator/test/schema/default-union.test.ts
@@ -216,6 +216,44 @@ describe("Schema: Default in unions", () => {
     expect(profile.properties?.email).toBeUndefined();
   });
 
+  it("applies recursive object defaults to nullable object unions", async () => {
+    const code = `
+      interface DeepDefault<V> {}
+      interface Config {
+        theme: string;
+        profile: {
+          name: string;
+          email: string;
+        } | null;
+      }
+      type T = Config | null | DeepDefault<{
+        theme: "dark";
+        profile: {
+          name: "Ada";
+        };
+      }>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker, typeNode),
+    );
+
+    expect(result.anyOf).toEqual(expect.arrayContaining([
+      { "$ref": "#/$defs/Config" },
+      { type: "null" },
+    ]));
+    expect(result.default).toEqual({
+      theme: "dark",
+      profile: { name: "Ada" },
+    });
+    expect((result.properties?.theme as any)?.default).toBe("dark");
+
+    const profile = result.properties?.profile as any;
+    expect(profile.default).toEqual({ name: "Ada" });
+    expect(profile.properties?.name?.default).toBe("Ada");
+    expect(profile.properties?.email).toBeUndefined();
+  });
+
   it("rejects unknown keys in DeepDefault object defaults", async () => {
     const code = `
       interface DeepDefault<V> {}

--- a/packages/schema-generator/test/schema/default-union.test.ts
+++ b/packages/schema-generator/test/schema/default-union.test.ts
@@ -124,6 +124,27 @@ describe("Schema: Default in unions", () => {
     expect(result.default).toEqual({ theme: "dark", retries: 3 });
   });
 
+  it("applies object defaults from typeof values with shorthand properties", async () => {
+    const code = `
+      interface Default<T, V extends T = T> {}
+      const theme = "dark" as const;
+      const retries = 3 as const;
+      const DEFAULT_CONFIG = { theme, retries } as const;
+      interface Config {
+        theme: string;
+        retries: number;
+      }
+      type T = Config | Default<typeof DEFAULT_CONFIG>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker, typeNode),
+    );
+
+    expect(result.$ref).toBe("#/$defs/Config");
+    expect(result.default).toEqual({ theme: "dark", retries: 3 });
+  });
+
   it("rejects object defaults that would widen an existing object member", async () => {
     const code = `
       interface Default<T, V extends T = T> {}

--- a/packages/schema-generator/test/schema/default-union.test.ts
+++ b/packages/schema-generator/test/schema/default-union.test.ts
@@ -119,4 +119,52 @@ describe("Schema: Default in unions", () => {
       "Default object union member is not assignable",
     );
   });
+
+  it("applies recursive object defaults from T | DeepDefault<V>", async () => {
+    const code = `
+      interface DeepDefault<V> {}
+      interface Config {
+        theme: string;
+        profile: {
+          name: string;
+          email: string;
+        };
+      }
+      type T = Config | DeepDefault<{
+        theme: "dark";
+        profile: {
+          name: "Ada";
+        };
+      }>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker, typeNode),
+    );
+
+    expect(result.$ref).toBe("#/$defs/Config");
+    expect(result.default).toEqual({
+      theme: "dark",
+      profile: { name: "Ada" },
+    });
+    expect((result.properties?.theme as any)?.default).toBe("dark");
+
+    const profile = result.properties?.profile as any;
+    expect(profile.default).toEqual({ name: "Ada" });
+    expect(profile.properties?.name?.default).toBe("Ada");
+    expect(profile.properties?.email).toBeUndefined();
+  });
+
+  it("rejects DeepDefault without an existing object member", async () => {
+    const code = `
+      interface DeepDefault<V> {}
+      type T = string | DeepDefault<{ theme: "dark" }>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const gen = createSchemaTransformerV2();
+
+    expect(() => gen.generateSchema(type, checker, typeNode)).toThrow(
+      "DeepDefault must be unioned with an object type",
+    );
+  });
 });

--- a/packages/schema-generator/test/schema/default-union.test.ts
+++ b/packages/schema-generator/test/schema/default-union.test.ts
@@ -31,6 +31,27 @@ describe("Schema: Default in unions", () => {
     expect(enabled.default).toBe(false);
   });
 
+  it("applies defaults through aliased union types", async () => {
+    const code = `
+      interface Default<T, V extends T = T> {}
+      type WithDefault = string | Default<"">;
+      interface X {
+        title: WithDefault;
+      }
+    `;
+    const { type, checker } = await getTypeFromCode(code, "X");
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker),
+    );
+
+    const title = result.properties?.title as any;
+    expect(title.$ref).toBe("#/$defs/WithDefault");
+    expect((result as any).$defs?.WithDefault).toEqual({
+      type: "string",
+      default: "",
+    });
+  });
+
   it("applies null defaults from T | Default<null>", async () => {
     const code = `
       interface Default<T, V extends T = T> {}
@@ -82,6 +103,25 @@ describe("Schema: Default in unions", () => {
     expect(config.properties?.theme).toEqual({ type: "string" });
     expect(config.required).toEqual(["theme"]);
     expect(result.default).toEqual({ theme: "dark" });
+  });
+
+  it("applies object defaults from typeof values in T | Default<V>", async () => {
+    const code = `
+      interface Default<T, V extends T = T> {}
+      const DEFAULT_CONFIG = { theme: "dark", retries: 3 } as const;
+      interface Config {
+        theme: string;
+        retries: number;
+      }
+      type T = Config | Default<typeof DEFAULT_CONFIG>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker, typeNode),
+    );
+
+    expect(result.$ref).toBe("#/$defs/Config");
+    expect(result.default).toEqual({ theme: "dark", retries: 3 });
   });
 
   it("rejects object defaults that would widen an existing object member", async () => {
@@ -155,6 +195,44 @@ describe("Schema: Default in unions", () => {
     expect(profile.properties?.email).toBeUndefined();
   });
 
+  it("rejects unknown keys in DeepDefault object defaults", async () => {
+    const code = `
+      interface DeepDefault<V> {}
+      interface Config {
+        theme: string;
+      }
+      type T = Config | DeepDefault<{ typo: "x" }>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const gen = createSchemaTransformerV2();
+
+    expect(() => gen.generateSchema(type, checker, typeNode)).toThrow(
+      'DeepDefault key "typo" does not exist',
+    );
+  });
+
+  it("rejects unknown nested keys in DeepDefault object defaults", async () => {
+    const code = `
+      interface DeepDefault<V> {}
+      interface Config {
+        profile: {
+          name: string;
+        };
+      }
+      type T = Config | DeepDefault<{
+        profile: {
+          typo: "x";
+        };
+      }>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const gen = createSchemaTransformerV2();
+
+    expect(() => gen.generateSchema(type, checker, typeNode)).toThrow(
+      'DeepDefault key "profile.typo" does not exist',
+    );
+  });
+
   it("rejects DeepDefault without an existing object member", async () => {
     const code = `
       interface DeepDefault<V> {}
@@ -165,6 +243,20 @@ describe("Schema: Default in unions", () => {
 
     expect(() => gen.generateSchema(type, checker, typeNode)).toThrow(
       "DeepDefault must be unioned with an object type",
+    );
+  });
+
+  it("rejects one-argument Default with aliased undefined in unions", async () => {
+    const code = `
+      interface Default<T, V extends T = T> {}
+      type U = undefined;
+      type T = string | Default<U>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const gen = createSchemaTransformerV2();
+
+    expect(() => gen.generateSchema(type, checker, typeNode)).toThrow(
+      "Default<undefined> is unsupported",
     );
   });
 });

--- a/packages/schema-generator/test/schema/default-union.test.ts
+++ b/packages/schema-generator/test/schema/default-union.test.ts
@@ -83,4 +83,40 @@ describe("Schema: Default in unions", () => {
     expect(config.required).toEqual(["theme"]);
     expect(result.default).toEqual({ theme: "dark" });
   });
+
+  it("rejects object defaults that would widen an existing object member", async () => {
+    const code = `
+      interface Default<T, V extends T = T> {}
+      interface Config {
+        theme: string;
+        retries: number;
+      }
+      type T = Config | Default<{ theme: "dark" }>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const gen = createSchemaTransformerV2();
+
+    expect(() => gen.generateSchema(type, checker, typeNode)).toThrow(
+      "Default object union member is not assignable",
+    );
+  });
+
+  it("rejects nested object defaults that would widen an existing object member", async () => {
+    const code = `
+      interface Default<T, V extends T = T> {}
+      interface Config {
+        profile: {
+          name: string;
+          email: string;
+        };
+      }
+      type T = Config | Default<{ profile: { name: "Ada" } }>;
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const gen = createSchemaTransformerV2();
+
+    expect(() => gen.generateSchema(type, checker, typeNode)).toThrow(
+      "Default object union member is not assignable",
+    );
+  });
 });

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
@@ -83,26 +83,12 @@ export default pattern((__cf_pattern_input) => {
             people: {
                 type: "array",
                 items: {
-                    $ref: "#/$defs/Person"
+                    type: "unknown"
                 },
                 asCell: ["cell"]
             }
         },
-        required: ["people"],
-        $defs: {
-            Person: {
-                type: "object",
-                properties: {
-                    name: {
-                        type: "string"
-                    },
-                    rank: {
-                        type: "number"
-                    }
-                },
-                required: ["name", "rank"]
-            }
-        }
+        required: ["people"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, { people: people }, ({ people }) => people.get().length).for("count", true);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
@@ -84,26 +84,12 @@ export default pattern((__cf_pattern_input) => {
             people: {
                 type: "array",
                 items: {
-                    $ref: "#/$defs/Person"
+                    type: "unknown"
                 },
                 asCell: ["cell"]
             }
         },
-        required: ["people"],
-        $defs: {
-            Person: {
-                type: "object",
-                properties: {
-                    name: {
-                        type: "string"
-                    },
-                    rank: {
-                        type: "number"
-                    }
-                },
-                required: ["name", "rank"]
-            }
-        }
+        required: ["people"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, { people: people }, ({ people }) => people.get().length).for("count", true);

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
@@ -74,17 +74,14 @@ export default pattern((__cf_pattern_input) => {
             },
             fileId: {
                 type: "string",
-                "default": "",
                 asCell: ["cell"]
             },
             content: {
                 type: "string",
-                "default": "",
                 asCell: ["cell"]
             },
             savedContent: {
                 type: "string",
-                "default": "",
                 asCell: ["cell"]
             },
             onSaveFile: {

--- a/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
@@ -50,41 +50,12 @@ export default pattern((__cf_pattern_input) => {
             items: {
                 type: "array",
                 items: {
-                    $ref: "#/$defs/Item"
+                    type: "unknown"
                 },
                 asCell: ["cell"]
             }
         },
-        required: ["items"],
-        $defs: {
-            Item: {
-                type: "object",
-                properties: {
-                    label: {
-                        type: "string"
-                    },
-                    tags: {
-                        type: "array",
-                        items: {
-                            $ref: "#/$defs/Tag"
-                        }
-                    }
-                },
-                required: ["label", "tags"]
-            },
-            Tag: {
-                type: "object",
-                properties: {
-                    name: {
-                        type: "string"
-                    },
-                    active: {
-                        type: "boolean"
-                    }
-                },
-                required: ["name", "active"]
-            }
-        }
+        required: ["items"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => items.get().length > 0).for("hasItems", true);
@@ -102,11 +73,11 @@ export default pattern((__cf_pattern_input) => {
                 }]
         } as const satisfies __cfHelpers.JSONSchema, {
             anyOf: [{}, {
-                    type: "object",
-                    properties: {}
-                }, {
                     type: "array",
                     items: {}
+                }, {
+                    type: "object",
+                    properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, hasItems, items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
             const item = __cf_pattern_input.key("element");

--- a/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
@@ -51,41 +51,12 @@ export default pattern((__cf_pattern_input) => {
             items: {
                 type: "array",
                 items: {
-                    $ref: "#/$defs/Item"
+                    type: "unknown"
                 },
                 asCell: ["cell"]
             }
         },
-        required: ["items"],
-        $defs: {
-            Item: {
-                type: "object",
-                properties: {
-                    label: {
-                        type: "string"
-                    },
-                    tags: {
-                        type: "array",
-                        items: {
-                            $ref: "#/$defs/Tag"
-                        }
-                    },
-                    selectedIndex: {
-                        type: "number"
-                    }
-                },
-                required: ["label", "tags", "selectedIndex"]
-            },
-            Tag: {
-                type: "object",
-                properties: {
-                    name: {
-                        type: "string"
-                    }
-                },
-                required: ["name"]
-            }
-        }
+        required: ["items"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema, { items: items }, ({ items }) => items.get().length > 0).for("hasItems", true);
@@ -103,11 +74,11 @@ export default pattern((__cf_pattern_input) => {
                 }]
         } as const satisfies __cfHelpers.JSONSchema, {
             anyOf: [{}, {
-                    type: "object",
-                    properties: {}
-                }, {
                     type: "array",
                     items: {}
+                }, {
+                    type: "object",
+                    properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, hasItems, items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
             const item = __cf_pattern_input.key("element");

--- a/packages/ts-transformers/test/fixtures/schema-transform/default-union-syntax.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/default-union-syntax.expected.jsx
@@ -1,0 +1,220 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { DeepDefault, Default, NAME, pattern, toSchema, } from "commonfabric";
+import "commonfabric/schema";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Options {
+    theme: string;
+    profile: {
+        name: string;
+        email: string;
+    };
+}
+interface Input {
+    title: string | Default<"">;
+    subtitle: string | Default<null>;
+    options: Options | DeepDefault<{
+        theme: "dark";
+        profile: {
+            name: "Ada";
+        };
+    }>;
+}
+const inputSchema = __cfHelpers.__cf_data({
+    type: "object",
+    properties: {
+        title: {
+            type: "string",
+            "default": ""
+        },
+        subtitle: {
+            anyOf: [{
+                    type: "string"
+                }, {
+                    type: "null"
+                }],
+            "default": null
+        },
+        options: {
+            $ref: "#/$defs/Options",
+            "default": {
+                theme: "dark",
+                profile: {
+                    name: "Ada"
+                }
+            },
+            properties: {
+                theme: {
+                    "default": "dark"
+                },
+                profile: {
+                    "default": {
+                        name: "Ada"
+                    },
+                    properties: {
+                        name: {
+                            "default": "Ada"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    required: ["title", "subtitle", "options"],
+    $defs: {
+        Options: {
+            type: "object",
+            properties: {
+                theme: {
+                    type: "string"
+                },
+                profile: {
+                    type: "object",
+                    properties: {
+                        name: {
+                            type: "string"
+                        },
+                        email: {
+                            type: "string"
+                        }
+                    },
+                    required: ["name", "email"]
+                }
+            },
+            required: ["theme", "profile"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// FIXTURE: default-union-syntax
+// Verifies: union Default and DeepDefault syntax is preserved through schema-transform fixtures
+export default pattern((__cf_pattern_input) => {
+    const title = __cf_pattern_input.key("title");
+    const subtitle = __cf_pattern_input.key("subtitle");
+    const options = __cf_pattern_input.key("options");
+    return ({
+        [NAME]: title,
+        title,
+        subtitle,
+        options,
+    });
+}, {
+    type: "object",
+    properties: {
+        title: {
+            type: "string",
+            "default": ""
+        },
+        subtitle: {
+            anyOf: [{
+                    type: "string"
+                }, {
+                    type: "null"
+                }],
+            "default": null
+        },
+        options: {
+            $ref: "#/$defs/Options",
+            "default": {
+                theme: "dark",
+                profile: {
+                    name: "Ada"
+                }
+            },
+            properties: {
+                theme: {
+                    "default": "dark"
+                },
+                profile: {
+                    "default": {
+                        name: "Ada"
+                    },
+                    properties: {
+                        name: {
+                            "default": "Ada"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    required: ["title", "subtitle", "options"],
+    $defs: {
+        Options: {
+            type: "object",
+            properties: {
+                theme: {
+                    type: "string"
+                },
+                profile: {
+                    type: "object",
+                    properties: {
+                        name: {
+                            type: "string"
+                        },
+                        email: {
+                            type: "string"
+                        }
+                    },
+                    required: ["name", "email"]
+                }
+            },
+            required: ["theme", "profile"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $NAME: {
+            type: "string"
+        },
+        title: {
+            type: "string"
+        },
+        subtitle: {
+            anyOf: [{
+                    type: "string"
+                }, {
+                    type: "null"
+                }]
+        },
+        options: {
+            $ref: "#/$defs/Options"
+        }
+    },
+    required: ["$NAME", "title", "subtitle", "options"],
+    $defs: {
+        Options: {
+            type: "object",
+            properties: {
+                theme: {
+                    type: "string"
+                },
+                profile: {
+                    type: "object",
+                    properties: {
+                        name: {
+                            type: "string"
+                        },
+                        email: {
+                            type: "string"
+                        }
+                    },
+                    required: ["name", "email"]
+                }
+            },
+            required: ["theme", "profile"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/default-union-syntax.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/default-union-syntax.input.tsx
@@ -1,0 +1,38 @@
+import {
+  DeepDefault,
+  Default,
+  NAME,
+  pattern,
+  toSchema,
+} from "commonfabric";
+import "commonfabric/schema";
+
+interface Options {
+  theme: string;
+  profile: {
+    name: string;
+    email: string;
+  };
+}
+
+interface Input {
+  title: string | Default<"">;
+  subtitle: string | Default<null>;
+  options: Options | DeepDefault<{
+    theme: "dark";
+    profile: {
+      name: "Ada";
+    };
+  }>;
+}
+
+const inputSchema = toSchema<Input>();
+
+// FIXTURE: default-union-syntax
+// Verifies: union Default and DeepDefault syntax is preserved through schema-transform fixtures
+export default pattern<Input>(({ title, subtitle, options }) => ({
+  [NAME]: title,
+  title,
+  subtitle,
+  options,
+}), inputSchema);


### PR DESCRIPTION
## Summary

Adds schema generation support for the newer default syntax forms:

- one-argument `Default<V>` in addition to existing `Default<T, V>`
- union-level defaults such as `T | Default<V>` and `T | Default<null>`
- array and object defaults in union position
- recursive object defaults via `T | DeepDefault<V>`
- diagnostics for partial object defaults that should use `DeepDefault`

The API marker types were adjusted so null defaults retain their intended TypeScript surface instead of collapsing through intersections.

## Validation

- `deno task check`
- `deno task --cwd packages/schema-generator test`
- `deno check packages/schema-generator/src/**/*.ts`
- `deno check packages/api/index.ts`
- `ENV=test deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git packages/runner/test/require-defaults.test.ts`
- `FIXTURE=default-union-syntax deno task --cwd packages/ts-transformers test`
- `deno task --cwd packages/ts-transformers check`
- `deno task --cwd packages/ts-transformers test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for union-level defaults with `Default` and `DeepDefault`, normalizes default unions in API input types (including inside cells/streams), and fixes applying deep defaults through nullable unions. Docs, patterns, and tests now prefer the `T | Default<V>` syntax for clearer schemas and better tooling.

- **New Features**
  - Support `Default<V>` in addition to `Default<T, V>`.
  - Union defaults: `T | Default<V>` and `T | Default<null>`; works with arrays/objects, aliases, and through cell/stream wrappers.
  - `DeepDefault<V>` for recursive object defaults; applies object and property defaults in the generated schema.
  - Preserve `null` defaults via an internal brand; improve default extraction from literals, tuples, objects/arrays, and `typeof` constants.
  - Normalize pattern inputs by stripping default markers and removing redundant union members, producing clean runtime types.
  - Update docs/examples to prefer `T | Default<V>` and clarify `Writable<... | Default<...>>` usage.
  - Add test coverage for default syntax variants.

- **Migration**
  - Use `DeepDefault<V>` for partial object defaults in a union; object defaults that would widen the target are rejected.
  - Unions may contain at most one `Default<>`/`DeepDefault<>`.
  - `Default<undefined>` (single-arg) is not supported.
  - `DeepDefault` must be unioned with an object type, and all keys must exist on the target object type.
  - Import `DeepDefault` and `Default` from `commonfabric` (re-exported by `@commonfabric/api`).

<sup>Written for commit 77cf91f3ba77cefc6f5e9b5cf338cd4eff1c6ed9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/card-piles/main.test.tsx = 17s

