### PR TITLE
fix(runner): Fix stream stable causes

### DIFF
--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -229,8 +229,8 @@ function factoryFromPattern<T, R>(
 
   const usedNames = new Set<string>();
   allCells.forEach((cell) => {
-    const existingName = cell.export().name;
-    if (existingName) usedNames.add(existingName);
+    const existingName = getStableInternalPathSegment(cell.export().name);
+    if (typeof existingName === "string") usedNames.add(existingName);
   });
 
   // First from results
@@ -297,6 +297,7 @@ function factoryFromPattern<T, R>(
     const { cell: top, path, value, name, external } = cell.export();
     if (!external) {
       if (!paths.has(top)) {
+        const stableName = getStableInternalPathSegment(name);
         // HACK(seefeld): For unnamed cells, we've run into an issue when the
         // order changes that a stream might clobber a previously used
         // non-stream, which means the default value won't be assigned and the
@@ -306,7 +307,7 @@ function factoryFromPattern<T, R>(
           : "";
         paths.set(top, [
           "internal",
-          name ?? `__#${count++}${streamMarker}`,
+          stableName ?? `__#${count++}${streamMarker}`,
         ]);
       }
       if (path.length) paths.set(cell, [...paths.get(top)!, ...path]);
@@ -395,6 +396,43 @@ function factoryFromPattern<T, R>(
   }, pattern) satisfies PatternFactory<T, R>;
 
   return patternFactory;
+}
+
+function getStableInternalPathSegment(cause: unknown): PropertyKey | undefined {
+  if (
+    typeof cause === "string" ||
+    typeof cause === "number" ||
+    typeof cause === "symbol"
+  ) {
+    return cause;
+  }
+
+  if (isRecord(cause) && "stream" in cause) {
+    return `stream:${formatStableCauseSegment(cause.stream)}`;
+  }
+
+  if (cause !== undefined) {
+    return formatStableCauseSegment(cause);
+  }
+
+  return undefined;
+}
+
+function formatStableCauseSegment(cause: unknown): string {
+  if (typeof cause === "string") return cause;
+  if (
+    typeof cause === "number" ||
+    typeof cause === "boolean" ||
+    cause === null
+  ) {
+    return String(cause);
+  }
+
+  try {
+    return JSON.stringify(cause) ?? String(cause);
+  } catch {
+    return String(cause);
+  }
 }
 
 const frames: Frame[] = [];

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -323,7 +323,7 @@ declare module "@commonfabric/api" {
       nodes: Set<NodeRef>;
       frame: Frame;
       value?: Opaque<T> | T;
-      name?: string;
+      name?: unknown;
       external?: unknown;
     };
     getAsOpaqueRefProxy(
@@ -1513,7 +1513,7 @@ export class CellImpl<T extends FabricValue>
     nodes: Set<NodeRef>;
     frame: Frame;
     value?: Opaque<T> | T;
-    name?: string;
+    name?: unknown;
     external?: unknown;
   } {
     if (!this._frame) {
@@ -1529,7 +1529,7 @@ export class CellImpl<T extends FabricValue>
       value: this._kind === "stream"
         ? { $stream: true } as unknown as T
         : this._initialValue,
-      name: this._causeContainer.cause as string | undefined,
+      name: this._causeContainer.cause,
       external: this._link.id
         ? this.getAsWriteRedirectLink({
           baseSpace: this._frame.space,

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../src/builder/module.ts";
 import { opaqueRef } from "../src/builder/opaque-ref.ts";
 import { pattern, popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { CellImpl } from "../src/cell.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 
@@ -201,6 +202,34 @@ describe("module", () => {
         $alias: {
           path: ["internal", "stream:click"],
           schema: true,
+        },
+      });
+    });
+
+    it("serializes array causes as stable internal path segments", () => {
+      const arrayCausePattern = pattern(() => {
+        const value = new CellImpl<number>(
+          runtime,
+          undefined,
+          { path: [], space },
+          false,
+        );
+        value.setInitialValue(1);
+        return {
+          value: value.for(["a", "b"], true),
+        };
+      });
+
+      expect(arrayCausePattern.result).toEqual({
+        value: {
+          $alias: {
+            path: ["internal", '["a","b"]'],
+          },
+        },
+      });
+      expect(arrayCausePattern.initial).toEqual({
+        internal: {
+          '["a","b"]': 1,
         },
       });
     });

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -22,7 +22,7 @@ import {
   resolveSourceLocationFromStack,
 } from "../src/builder/module.ts";
 import { opaqueRef } from "../src/builder/opaque-ref.ts";
-import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { pattern, popFrame, pushFrame } from "../src/builder/pattern.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 
@@ -164,6 +164,45 @@ describe("module", () => {
       expect(nodes.size).toBe(1);
       expect([...nodes][0].module).toMatchObject({ wrapper: "handler" });
       expect([...nodes][0].inputs.$event).toBe(stream);
+    });
+
+    it("serializes stream causes without losing the stream marker", () => {
+      const clickHandler = handler(
+        false,
+        false,
+        (_event: unknown, _state: unknown) => {},
+      );
+
+      const clickPattern = pattern(() => {
+        const click = clickHandler({} as never).for(
+          { stream: "click" },
+          true,
+        );
+        return { click };
+      });
+
+      expect(clickPattern.result).toEqual({
+        click: {
+          $alias: {
+            path: ["internal", "stream:click"],
+            schema: true,
+          },
+        },
+      });
+      expect(clickPattern.initial).toEqual({
+        internal: {
+          "stream:click": { $stream: true },
+        },
+      });
+      const handlerInputs = clickPattern.nodes[0].inputs as {
+        $event: unknown;
+      };
+      expect(handlerInputs.$event).toEqual({
+        $alias: {
+          path: ["internal", "stream:click"],
+          schema: true,
+        },
+      });
     });
 
     it("supports event and state schema validation", () => {

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -21,6 +21,7 @@ import {
 
 type CausePathElement = string | number;
 type CausePath = readonly CausePathElement[];
+type ForCause = string | CausePath | { readonly stream: string | CausePath };
 
 const PATTERN_RESULT_CAUSE = "__patternResult";
 
@@ -800,11 +801,14 @@ function createForCall(
   cause: string | CausePath,
   context: TransformationContext,
 ): ts.Expression {
+  const stableCause: ForCause = shouldUseStreamCause(initializer, context)
+    ? { stream: cause }
+    : cause;
   const call = context.factory.createCallExpression(
     context.factory.createPropertyAccessExpression(initializer, "for"),
     undefined,
     [
-      createCauseExpression(cause, context),
+      createCauseExpression(stableCause, context),
       context.factory.createTrue(),
     ],
   );
@@ -816,11 +820,20 @@ function createForCall(
 }
 
 function createCauseExpression(
-  cause: string | CausePath,
+  cause: ForCause,
   context: TransformationContext,
 ): ts.Expression {
   if (typeof cause === "string") {
     return context.factory.createStringLiteral(cause);
+  }
+
+  if (isStreamCause(cause)) {
+    return context.factory.createObjectLiteralExpression([
+      context.factory.createPropertyAssignment(
+        "stream",
+        createCauseExpression(cause.stream, context),
+      ),
+    ], false);
   }
 
   if (cause.length === 1 && typeof cause[0] === "string") {
@@ -835,4 +848,53 @@ function createCauseExpression(
     ),
     false,
   );
+}
+
+function isStreamCause(
+  cause: ForCause,
+): cause is { readonly stream: string | CausePath } {
+  return typeof cause === "object" && cause !== null &&
+    !Array.isArray(cause) && "stream" in cause;
+}
+
+function shouldUseStreamCause(
+  expression: ts.Expression,
+  context: TransformationContext,
+): boolean {
+  const target = unwrapExpression(expression);
+  if (ts.isCallExpression(target)) {
+    const callKind = detectCallKind(target, context.checker);
+    if (
+      callKind?.kind === "builder" &&
+      (callKind.builderName === "handler" || callKind.builderName === "action")
+    ) {
+      return true;
+    }
+  }
+
+  const type = getTypeAtLocationWithFallback(
+    target,
+    context.checker,
+    context.options.typeRegistry,
+    context.options.logger,
+  );
+  return isStreamLikeType(type, context.checker);
+}
+
+function isStreamLikeType(
+  type: ts.Type | undefined,
+  checker: ts.TypeChecker,
+): boolean {
+  if (!type) return false;
+
+  const parts = type.isUnionOrIntersection() ? type.types : [type];
+  return parts.some((part) => {
+    const symbols = [
+      part.aliasSymbol,
+      part.getSymbol(),
+      checker.getApparentType(part).aliasSymbol,
+      checker.getApparentType(part).getSymbol(),
+    ];
+    return symbols.some((symbol) => symbol?.getName() === "Stream");
+  });
 }

--- a/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.jsx
@@ -37,11 +37,11 @@ const myHandler = handler(false as const satisfies __cfHelpers.JSONSchema, {
 export default pattern((state) => {
     return {
         // Test case 1: Object literal with all properties from state
-        onClick1: myHandler({ value: state.key("value"), name: state.key("name") }).for(["__patternResult", "onClick1"], true),
+        onClick1: myHandler({ value: state.key("value"), name: state.key("name") }).for({ stream: ["__patternResult", "onClick1"] }, true),
         // Test case 2: Object literal with all properties (explicitly listed)
-        onClick2: myHandler({ value: state.key("value"), name: state.key("name") }).for(["__patternResult", "onClick2"], true),
+        onClick2: myHandler({ value: state.key("value"), name: state.key("name") }).for({ stream: ["__patternResult", "onClick2"] }, true),
         // Test case 3: Direct state passing (what we want to transform to)
-        onClick3: myHandler(state).for(["__patternResult", "onClick3"], true)
+        onClick3: myHandler(state).for({ stream: ["__patternResult", "onClick3"] }, true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
@@ -31,7 +31,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["count"]
         } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => count.set(count.get() + 1))({
             count: count
-        }).for(["__patternResult", "inc"], true)
+        }).for({ stream: ["__patternResult", "inc"] }, true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
@@ -44,7 +44,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["value"]
         } as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data))({
             value: value
-        }).for(["__patternResult", "update"], true)
+        }).for({ stream: ["__patternResult", "update"] }, true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
@@ -49,7 +49,7 @@ export default pattern((__cf_pattern_input) => {
         isEditing.set(true);
     })({
         isEditing: isEditing
-    }).for("startEditing", true);
+    }).for({ stream: "startEditing" }, true);
     const hasDescription = __cfHelpers.derive({
         type: "object",
         properties: {

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
@@ -48,7 +48,7 @@ export default pattern((__cf_pattern_input) => {
         isEditing.set(true);
     })({
         isEditing: isEditing
-    }).for("startEditing", true);
+    }).for({ stream: "startEditing" }, true);
     return {
         [UI]: (<cf-card>
         {__cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
@@ -35,7 +35,7 @@ export default pattern((__cf_pattern_input) => {
             }
         } as const satisfies __cfHelpers.JSONSchema, (_, { a }) => console.log(a))({
             a: a
-        }).for(["__patternResult", "readA"], true),
+        }).for({ stream: ["__patternResult", "readA"] }, true),
         readB: __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
             type: "object",
             properties: {
@@ -46,7 +46,7 @@ export default pattern((__cf_pattern_input) => {
             }
         } as const satisfies __cfHelpers.JSONSchema, (_, { b }) => console.log(b))({
             b: b
-        }).for(["__patternResult", "readB"], true)
+        }).for({ stream: ["__patternResult", "readB"] }, true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
@@ -36,7 +36,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["a"]
         } as const satisfies __cfHelpers.JSONSchema, (_, { a }) => a.set("hello"))({
             a: a
-        }).for(["__patternResult", "setA"], true),
+        }).for({ stream: ["__patternResult", "setA"] }, true),
         setB: __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
             type: "object",
             properties: {
@@ -48,7 +48,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["b"]
         } as const satisfies __cfHelpers.JSONSchema, (_, { b }) => b.set(42))({
             b: b
-        }).for(["__patternResult", "setB"], true)
+        }).for({ stream: ["__patternResult", "setB"] }, true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
@@ -41,7 +41,7 @@ export default pattern((__cf_pattern_input) => {
         count.set(count.get() + 1);
     })({
         count: count
-    }).for("increment", true);
+    }).for({ stream: "increment" }, true);
     const decrement = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
         type: "object",
         properties: {
@@ -55,7 +55,7 @@ export default pattern((__cf_pattern_input) => {
         count.set(count.get() - 1);
     })({
         count: count
-    }).for("decrement", true);
+    }).for({ stream: "decrement" }, true);
     return {
         [UI]: (<div>
         <span>{label}: {count}</span>

--- a/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
@@ -57,7 +57,7 @@ export default pattern((__cf_pattern_input) => {
         self: {
             title: self.key("title")
         }
-    }).for("showSelf", true);
+    }).for({ stream: "showSelf" }, true);
     // Action closing over both `self` and `count`
     const incrementWithSelf = __cfHelpers.handler({
         type: "object",
@@ -101,7 +101,7 @@ export default pattern((__cf_pattern_input) => {
     })({
         self: self,
         count: count
-    }).for("incrementWithSelf", true);
+    }).for({ stream: "incrementWithSelf" }, true);
     return {
         [NAME]: "Action SELF Test",
         [UI]: (<div>

--- a/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
@@ -43,7 +43,7 @@ export default pattern((__cf_pattern_input) => {
             required: ["value"]
         } as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data))({
             value: value
-        }).for(["__patternResult", "update"], true)
+        }).for({ stream: ["__patternResult", "update"] }, true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
@@ -115,8 +115,8 @@ export default pattern((__cf_pattern_input) => {
         content: content,
         savedContent: savedContent,
         onSaveFile: onSaveFile
-    }).for("trigger", true);
-    return { trigger: trigger.for(["__patternResult", "trigger"], true) };
+    }).for({ stream: "trigger" }, true);
+    return { trigger: trigger.for({ stream: ["__patternResult", "trigger"] }, true) };
 }, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
@@ -55,7 +55,7 @@ export default pattern((__cf_pattern_input) => {
     })({
         counter: counter,
         label: label
-    }).for("reset", true);
+    }).for({ stream: "reset" }, true);
     return {
         [UI]: (<div>
         <span>{title} {label}: {counter}</span>

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -67,7 +67,7 @@ export default pattern((__cf_pattern_input) => {
         path.push(name);
     })({
         path: path
-    }).for("pushPath", true);
+    }).for({ stream: "pushPath" }, true);
     return {
         [UI]: (<div>
         {(() => {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -75,7 +75,7 @@ export default pattern((__cf_pattern_input) => {
         path.push(name);
     })({
         path: path
-    }).for("handleNavigateInto", true);
+    }).for({ stream: "handleNavigateInto" }, true);
     const handleOpenFile = __cfHelpers.handler({
         type: "object",
         properties: {
@@ -115,7 +115,7 @@ export default pattern((__cf_pattern_input) => {
         properties: {}
     } as const satisfies __cfHelpers.JSONSchema, ({ item }, __cf_action_params) => {
         void item;
-    })({}).for("handleOpenFile", true);
+    })({}).for({ stream: "handleOpenFile" }, true);
     return {
         [UI]: (<div>
         {(() => {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -75,7 +75,7 @@ export default pattern((__cf_pattern_input) => {
         path.push(name);
     })({
         path: path
-    }).for("pushPath", true);
+    }).for({ stream: "pushPath" }, true);
     return {
         [UI]: (<div>
         {(() => {

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -173,7 +173,7 @@ const actionPattern = pattern((input: Writable<{
         required: ["input"]
     } as const satisfies __cfHelpers.JSONSchema, (_, { input }) => input.key("foo").get())({
         input: input
-    }).for("a", true);
+    }).for({ stream: "a" }, true);
     return a;
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
@@ -82,7 +82,7 @@ export default pattern((__cf_pattern_input) => {
     const state = __cf_pattern_input.key("state");
     return {
         state,
-        increment: increment({ state }).for(["__patternResult", "increment"], true)
+        increment: increment({ state }).for({ stream: ["__patternResult", "increment"] }, true)
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import {
   assert,
+  assertMatch,
   assertNotMatch,
   assertRejects,
   assertStringIncludes,
@@ -103,6 +104,42 @@ export default pattern<{ count: number }>((state) => ({
       '.for(["__patternResult", "tuple", 0], true)',
     );
     assertNotMatch(main, /state\.key\("count"\)\.for/);
+  });
+
+  it("uses stream-scoped causes for handler result streams", async () => {
+    const source = `
+import { handler, pattern } from "commonfabric";
+
+const saveHandler = handler(false, false, () => {});
+
+export default pattern(() => {
+  const save = saveHandler({});
+  return {
+    nested: {
+      cancel: saveHandler({}),
+    },
+    save,
+  };
+});
+`;
+
+    const output = await transformFiles({
+      "/main.tsx": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.tsx"]!;
+
+    assertMatch(main, /\.for\(\{\s*stream: "save"\s*\}, true\)/s);
+    assertMatch(
+      main,
+      /\.for\(\{\s*stream: \[\s*"__patternResult",\s*"nested",\s*"cancel"\s*\]\s*\}, true\)/s,
+    );
+    assertNotMatch(main, /\.for\("save", true\)/);
+    assertNotMatch(
+      main,
+      /\.for\(\["__patternResult", "nested", "cancel"\], true\)/,
+    );
   });
 
   it("re-roots reactive identifier members in pattern results", async () => {


### PR DESCRIPTION
## Summary
- Emit stream-specific stable causes for handler/action stream results, e.g. `.for({ stream: "name" }, true)`.
- Normalize non-primitive `.for(...)` causes before pattern serialization uses them as internal path segments.
- Preserve `{ $stream: true }` initial markers while avoiding object/array path segments that serialize inconsistently.

## Root Cause
Stream causes need their own namespace, but using object or array causes directly as internal pattern path segments made aliases and initial data disagree. Initial object writes coerced those keys through JavaScript property naming while aliases retained structured path segments.

## Validation
- `deno task test` in `packages/ts-transformers`
- `deno test -A packages/runner/test/module.test.ts`
- `deno task integration patterns`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make stream causes stable and namespaced to prevent collisions and alias/initial mismatches. Streams now serialize to deterministic internal path segments while preserving `$stream` markers.

- **Bug Fixes**
  - Emit stream-scoped causes for handler/action results and any Stream-like values as `.for({ stream: <cause> }, true)` in `packages/ts-transformers`.
  - Normalize non-primitive causes (arrays/objects) to stable string path segments; stream causes use `stream:<value>` and are used for internal name de-duping in `packages/runner`.
  - Preserve `{ $stream: true }` in initial state and keep aliases consistent; updated tests cover stream markers and array-cause paths in `packages/runner` and `packages/ts-transformers`.

<sup>Written for commit 0b6f83f27ff535dffa90e9a5cae0e38a725d8304. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/battleship/multiplayer/room.test.tsx = 21s
NEW_PERF_BASELINE: job: CLI Integration Tests (core) = 228s
NEW_PERF_BASELINE: step: CLI integration (core) = 191s

