### PR TITLE
feat(ts-transformer): Tighten handler identity schemas

### DIFF
--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -270,15 +270,10 @@ export class CommonFabricFormatter implements TypeFormatter {
 
     // Keep schema-hint propagation behavior aligned with type-based wrapper formatting.
     let childContext = context;
-    let isArrayPropertyOnlyAccess = false;
     if (context.schemaHints && context.typeNode) {
       const hint = context.schemaHints.get(context.typeNode);
       if (hint?.items === false) {
-        isArrayPropertyOnlyAccess = true;
-        const propertyValue = wrapperKindToBrand(wrapperKind);
-        const itemsOverride: JSONSchema = propertyValue
-          ? { type: "object", properties: {}, asCell: [propertyValue] }
-          : { type: "object", properties: {} };
+        const itemsOverride: JSONSchema = { type: "unknown" };
         childContext = { ...context, arrayItemsOverride: itemsOverride };
       }
     }
@@ -288,10 +283,6 @@ export class CommonFabricFormatter implements TypeFormatter {
       childContext,
       innerTypeNode,
     );
-
-    if (isArrayPropertyOnlyAccess) {
-      return innerSchema;
-    }
 
     if (wrapperKind === "Stream") {
       if (typeof innerSchema === "boolean") {
@@ -394,19 +385,14 @@ export class CommonFabricFormatter implements TypeFormatter {
     const shouldPassTypeNode = innerTypeNode && !innerTypeIsGeneric &&
       (!isSyntheticNode || syntheticNodeNeedsHelp);
 
-    // Check for schema hints on the current typeNode and propagate to child context
-    // This allows array-property-only access patterns (e.g., .length) to generate items: { not: true, asCell/asOpaque: true }
+    // Check for schema hints on the current typeNode and propagate to child context.
+    // This allows identity-only/property-only array access patterns to avoid
+    // materializing full item schemas while preserving the wrapper on the array.
     let childContext = context;
-    let isArrayPropertyOnlyAccess = false;
     if (context.schemaHints && context.typeNode) {
       const hint = context.schemaHints.get(context.typeNode);
       if (hint?.items === false) {
-        isArrayPropertyOnlyAccess = true;
-        // Build items override with object stub and the appropriate wrapper semantic
-        const propertyValue = wrapperKindToBrand(wrapperKind);
-        const itemsOverride: JSONSchema = propertyValue
-          ? { type: "unknown", asCell: [propertyValue] }
-          : { type: "unknown" };
+        const itemsOverride: JSONSchema = { type: "unknown" };
         childContext = { ...context, arrayItemsOverride: itemsOverride };
       }
     }
@@ -416,12 +402,6 @@ export class CommonFabricFormatter implements TypeFormatter {
       childContext,
       shouldPassTypeNode ? innerTypeNode : undefined,
     );
-
-    // For array-property-only access (e.g., .length), don't wrap the result -
-    // we need the array unwrapped so .length is accessible
-    if (isArrayPropertyOnlyAccess) {
-      return innerSchema;
-    }
 
     // Stream<T>: can also reflect inner Cell-ness
     if (wrapperKind === "Stream") {

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -9,7 +9,6 @@ import {
 } from "../typescript/cell-brand.ts";
 import { isDefaultAliasSymbol } from "../typescript/property-optionality.ts";
 import type {
-  JSONSchema,
   JSONSchemaMutable,
   JSONSchemaObjMutable,
 } from "@commonfabric/api";
@@ -17,6 +16,7 @@ import type { GenerationContext, TypeFormatter } from "../interface.ts";
 import type { SchemaGenerator } from "../schema-generator.ts";
 import {
   detectWrapperViaNode,
+  getArrayElementInfo,
   getPropertyNameText,
   resolveWrapperNode,
   type TypeWithInternals,
@@ -273,7 +273,11 @@ export class CommonFabricFormatter implements TypeFormatter {
     if (context.schemaHints && context.typeNode) {
       const hint = context.schemaHints.get(context.typeNode);
       if (hint?.items === false) {
-        const itemsOverride: JSONSchema = { type: "unknown" };
+        const itemsOverride = this.createArrayItemsOverride(
+          innerType,
+          innerTypeNode,
+          context,
+        );
         childContext = { ...context, arrayItemsOverride: itemsOverride };
       }
     }
@@ -392,7 +396,11 @@ export class CommonFabricFormatter implements TypeFormatter {
     if (context.schemaHints && context.typeNode) {
       const hint = context.schemaHints.get(context.typeNode);
       if (hint?.items === false) {
-        const itemsOverride: JSONSchema = { type: "unknown" };
+        const itemsOverride = this.createArrayItemsOverride(
+          innerType,
+          shouldPassTypeNode ? innerTypeNode : undefined,
+          context,
+        );
         childContext = { ...context, arrayItemsOverride: itemsOverride };
       }
     }
@@ -426,6 +434,32 @@ export class CommonFabricFormatter implements TypeFormatter {
 
     // Apply wrapper semantics (asCell/asOpaque) to the inner schema
     return this.applyWrapperSemantics(innerSchema, wrapperKind);
+  }
+
+  private createArrayItemsOverride(
+    arrayType: ts.Type,
+    arrayTypeNode: ts.TypeNode | undefined,
+    context: GenerationContext,
+  ): JSONSchemaMutable {
+    const base: JSONSchemaMutable = { type: "unknown" };
+    const elementInfo = getArrayElementInfo(
+      arrayType,
+      context.typeChecker,
+      arrayTypeNode,
+    );
+    if (!elementInfo) {
+      return base;
+    }
+
+    const resolvedElementWrapperKind = elementInfo.elementNode
+      ? resolveWrapperNode(elementInfo.elementNode, context.typeChecker)?.kind
+      : getCellWrapperInfo(elementInfo.elementType, context.typeChecker)?.kind;
+    const elementWrapperKind = resolvedElementWrapperKind === "Default"
+      ? undefined
+      : resolvedElementWrapperKind;
+    return elementWrapperKind
+      ? this.applyWrapperSemantics(base, elementWrapperKind)
+      : base;
   }
 
   private isUnusableInnerType(type: ts.Type): boolean {

--- a/packages/schema-generator/test/schema/capability-wrapper-types.test.ts
+++ b/packages/schema-generator/test/schema/capability-wrapper-types.test.ts
@@ -1,7 +1,44 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import ts from "typescript";
 import { createSchemaTransformerV2 } from "../../src/plugin.ts";
-import { asObjectSchema, getTypeFromCode } from "../utils.ts";
+import {
+  asObjectSchema,
+  createTestProgram,
+  getTypeFromCode,
+} from "../utils.ts";
+
+function findInterfaceMemberTypeNode(
+  sourceFile: ts.SourceFile,
+  interfaceName: string,
+  memberName: string,
+): ts.TypeNode {
+  let found: ts.TypeNode | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isInterfaceDeclaration(node) &&
+      node.name.text === interfaceName
+    ) {
+      for (const member of node.members) {
+        if (
+          ts.isPropertySignature(member) &&
+          member.type &&
+          ts.isIdentifier(member.name) &&
+          member.name.text === memberName
+        ) {
+          found = member.type;
+          return;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) {
+    throw new Error(`Member ${interfaceName}.${memberName} not found`);
+  }
+  return found;
+}
 
 describe("Schema: Capability wrapper types", () => {
   it("handles ReadonlyCell, WriteonlyCell, and OpaqueCell", async () => {
@@ -106,5 +143,75 @@ describe("Schema: Capability wrapper types", () => {
     const items = result.properties?.items as Record<string, any>;
     expect(items.type).toBe("array");
     expect(items.items).toEqual({ type: "unknown", asCell: ["cell"] });
+  });
+
+  it("array item hints preserve the outer cell wrapper without marking plain items as cells", async () => {
+    const code = `
+      interface X {
+        items: Writable<{ name: string }[]>;
+      }
+    `;
+    const { checker, sourceFile } = await createTestProgram(code);
+    const symbol = checker.getSymbolsInScope(
+      sourceFile,
+      ts.SymbolFlags.Interface,
+    ).find((candidate) => candidate.name === "X");
+    if (!symbol) throw new Error("Interface X not found");
+
+    const type = checker.getDeclaredTypeOfSymbol(symbol);
+    const itemsTypeNode = findInterfaceMemberTypeNode(
+      sourceFile,
+      "X",
+      "items",
+    );
+    const schemaHints = new WeakMap<ts.Node, { items?: unknown }>();
+    schemaHints.set(itemsTypeNode, { items: false });
+
+    const gen = createSchemaTransformerV2();
+    const result = asObjectSchema(
+      gen.generateSchema(type, checker, undefined, undefined, schemaHints),
+    );
+    const items = result.properties?.items as Record<string, any>;
+
+    expect(items).toEqual({
+      type: "array",
+      items: { type: "unknown" },
+      asCell: ["cell"],
+    });
+  });
+
+  it("array item hints preserve item-level cell wrappers when the element is a cell", async () => {
+    const code = `
+      interface X {
+        items: Writable<Array<Cell<{ name: string }>>>;
+      }
+    `;
+    const { checker, sourceFile } = await createTestProgram(code);
+    const symbol = checker.getSymbolsInScope(
+      sourceFile,
+      ts.SymbolFlags.Interface,
+    ).find((candidate) => candidate.name === "X");
+    if (!symbol) throw new Error("Interface X not found");
+
+    const type = checker.getDeclaredTypeOfSymbol(symbol);
+    const itemsTypeNode = findInterfaceMemberTypeNode(
+      sourceFile,
+      "X",
+      "items",
+    );
+    const schemaHints = new WeakMap<ts.Node, { items?: unknown }>();
+    schemaHints.set(itemsTypeNode, { items: false });
+
+    const gen = createSchemaTransformerV2();
+    const result = asObjectSchema(
+      gen.generateSchema(type, checker, undefined, undefined, schemaHints),
+    );
+    const items = result.properties?.items as Record<string, any>;
+
+    expect(items).toEqual({
+      type: "array",
+      items: { type: "unknown", asCell: ["cell"] },
+      asCell: ["cell"],
+    });
   });
 });

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -101,7 +101,8 @@ function extendSourceRef(
 const PARAMETER_SUMMARY_PREFIX = "__param";
 
 const WRITER_METHODS = new Set(["set", "update"]);
-const ARRAY_IDENTITY_WRITER_METHODS = new Set(["push"]);
+const ARRAY_IDENTITY_WRITER_METHODS = new Set(["push", "unshift", "splice"]);
+const ARRAY_IDENTITY_PRESERVING_CHAIN_METHODS = new Set(["slice"]);
 const READER_METHODS = new Set(["get"]);
 const FALLBACK_OPERATORS = new Set<ts.SyntaxKind>([
   ts.SyntaxKind.QuestionQuestionToken,
@@ -482,7 +483,22 @@ function isArrayIdentityWriterArgumentUsage(
         isLiteralElement(target.argumentExpression)
     ? getLiteralElementText(target.argumentExpression)
     : undefined;
-  return !!methodName && ARRAY_IDENTITY_WRITER_METHODS.has(methodName);
+  return isArrayIdentityWriterValueArgument(methodName, parent, usage);
+}
+
+function isArrayIdentityWriterValueArgument(
+  methodName: string | undefined,
+  call: ts.CallExpression,
+  usage: ts.Expression,
+): boolean {
+  if (!methodName || !ARRAY_IDENTITY_WRITER_METHODS.has(methodName)) {
+    return false;
+  }
+  const index = call.arguments.findIndex((argument) => argument === usage);
+  if (index < 0) {
+    return false;
+  }
+  return methodName === "splice" ? index >= 2 : true;
 }
 
 function isOptionalAliasInitializerMemberUsage(usage: ts.Expression): boolean {
@@ -571,6 +587,28 @@ function getIdentityArrayLocalNameForElementUsage(
   return undefined;
 }
 
+function getIdentityArrayLocalNameForWriterArgumentUsage(
+  usage: ts.Expression,
+): string | undefined {
+  const parent = usage.parent;
+  if (!parent || !ts.isCallExpression(parent)) {
+    return undefined;
+  }
+  const target = unwrapExpression(parent.expression);
+  const receiver = ts.isPropertyAccessExpression(target) ||
+      ts.isElementAccessExpression(target)
+    ? unwrapExpression(target.expression)
+    : undefined;
+  const methodName = getCallMethodNameFromExpression(parent.expression);
+  if (!receiver || !ts.isIdentifier(receiver)) {
+    return undefined;
+  }
+  if (!isArrayIdentityWriterValueArgument(methodName, parent, usage)) {
+    return undefined;
+  }
+  return receiver.text;
+}
+
 function collectArrayLocalsPassedToSet(
   body: ts.ConciseBody,
   checker?: ts.TypeChecker,
@@ -579,7 +617,7 @@ function collectArrayLocalsPassedToSet(
   const setArgumentLocals = new Set<string>();
   const structurallyAccessedArrayLocals = new Set<string>();
 
-  const expressionStartsWithArrayLiteral = (
+  const expressionIsIdentityArrayInitializer = (
     expression: ts.Expression,
   ): boolean => {
     const current = unwrapExpression(expression);
@@ -592,10 +630,24 @@ function collectArrayLocalsPassedToSet(
         ts.isPropertyAccessExpression(target) ||
         ts.isElementAccessExpression(target)
       ) {
-        return expressionStartsWithArrayLiteral(target.expression);
+        const methodName = getCallMethodNameFromExpression(current.expression);
+        return !!methodName &&
+          ARRAY_IDENTITY_PRESERVING_CHAIN_METHODS.has(methodName) &&
+          expressionIsIdentityArrayInitializer(target.expression);
       }
     }
     return false;
+  };
+
+  const isCallReceiverForMethod = (
+    node: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+    methods: ReadonlySet<string>,
+  ): boolean => {
+    const methodName = getCallMethodNameFromExpression(node);
+    return !!methodName &&
+      methods.has(methodName) &&
+      ts.isCallExpression(node.parent) &&
+      node.parent.expression === node;
   };
 
   const visit = (node: ts.Node): void => {
@@ -604,7 +656,7 @@ function collectArrayLocalsPassedToSet(
       ts.isIdentifier(node.name) &&
       node.initializer &&
       ts.isExpression(node.initializer) &&
-      expressionStartsWithArrayLiteral(node.initializer)
+      expressionIsIdentityArrayInitializer(node.initializer)
     ) {
       arrayInitializerLocals.add(node.name.text);
     }
@@ -630,7 +682,14 @@ function collectArrayLocalsPassedToSet(
       const isSetCallReceiver = node.name.text === "set" &&
         ts.isCallExpression(node.parent) &&
         node.parent.expression === node;
-      if (ts.isIdentifier(current) && !isSetCallReceiver) {
+      const isIdentityWriterReceiver = isCallReceiverForMethod(
+        node,
+        ARRAY_IDENTITY_WRITER_METHODS,
+      );
+      if (
+        ts.isIdentifier(current) && !isSetCallReceiver &&
+        !isIdentityWriterReceiver
+      ) {
         structurallyAccessedArrayLocals.add(current.text);
       }
     }
@@ -642,7 +701,14 @@ function collectArrayLocalsPassedToSet(
         getLiteralElementText(node.argumentExpression) === "set" &&
         ts.isCallExpression(node.parent) &&
         node.parent.expression === node;
-      if (ts.isIdentifier(current) && !isSetCallReceiver) {
+      const isIdentityWriterReceiver = isCallReceiverForMethod(
+        node,
+        ARRAY_IDENTITY_WRITER_METHODS,
+      );
+      if (
+        ts.isIdentifier(current) && !isSetCallReceiver &&
+        !isIdentityWriterReceiver
+      ) {
         structurallyAccessedArrayLocals.add(current.text);
       }
     }
@@ -1555,7 +1621,7 @@ export function analyzeFunctionCapabilities(
       }
     };
 
-    const recordLocalArrayPush = (
+    const recordLocalArrayIdentityWrite = (
       arrayName: string,
       args: readonly ts.Expression[],
     ): void => {
@@ -2031,9 +2097,17 @@ export function analyzeFunctionCapabilities(
                 getIdentityArrayLocalNameForElementUsage(usage);
               const identityOnlyArrayElementUse = !!identityArrayLocal &&
                 identityArrayLocals.has(identityArrayLocal);
+              const identityArrayWriterLocal =
+                getIdentityArrayLocalNameForWriterArgumentUsage(usage);
+              const identityOnlyArrayWriterArgumentUse =
+                !!identityArrayWriterLocal &&
+                identityArrayLocals.has(identityArrayWriterLocal);
               const arrayIdentityWriterArgumentUse =
                 isArrayIdentityWriterArgumentUsage(usage);
-              if (arrayIdentityWriterArgumentUse) {
+              if (
+                arrayIdentityWriterArgumentUse &&
+                !identityOnlyArrayWriterArgumentUse
+              ) {
                 if (
                   source.arrayElement &&
                   !resolvedSource.dynamic
@@ -2053,7 +2127,8 @@ export function analyzeFunctionCapabilities(
               } else if (
                 isCallOrNewArgumentUsage(usage) ||
                 isPassThroughIdentifierUsage(node) ||
-                identityOnlyArrayElementUse
+                identityOnlyArrayElementUse ||
+                identityOnlyArrayWriterArgumentUse
               ) {
                 if (
                   resolvedSource.path.length === 0 && !resolvedSource.dynamic
@@ -2076,11 +2151,13 @@ export function analyzeFunctionCapabilities(
                     cellLike: isCellLikeExpression(usage),
                   });
                 } else if (
-                  identityOnlyArrayElementUse &&
+                  (identityOnlyArrayElementUse ||
+                    identityOnlyArrayWriterArgumentUse) &&
                   !resolvedSource.dynamic
                 ) {
                   recordIdentityPath(resolvedSource.root, resolvedSource.path, {
-                    cellLike: isCellLikeExpression(usage),
+                    cellLike: isCellLikeExpression(usage) ||
+                      !isPrimitiveLikeExpression(usage),
                   });
                 } else {
                   trackReadRef(
@@ -2158,10 +2235,16 @@ export function analyzeFunctionCapabilities(
         const localMethodName = getCallMethodName(node.expression);
         if (
           localReceiverName &&
-          localMethodName === "push" &&
+          localMethodName &&
+          ARRAY_IDENTITY_WRITER_METHODS.has(localMethodName) &&
           node.arguments.length > 0
         ) {
-          recordLocalArrayPush(localReceiverName, node.arguments);
+          recordLocalArrayIdentityWrite(
+            localReceiverName,
+            localMethodName === "splice"
+              ? node.arguments.slice(2)
+              : node.arguments,
+          );
         } else if (localReceiverName && localMethodName === "set") {
           recordLocalMapSet(localReceiverName, node.arguments[1]);
         }

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -573,6 +573,7 @@ function getIdentityArrayLocalNameForElementUsage(
 
 function collectArrayLocalsPassedToSet(
   body: ts.ConciseBody,
+  checker?: ts.TypeChecker,
 ): ReadonlySet<string> {
   const arrayInitializerLocals = new Set<string>();
   const setArgumentLocals = new Set<string>();
@@ -610,7 +611,11 @@ function collectArrayLocalsPassedToSet(
 
     if (ts.isCallExpression(node)) {
       const methodName = getCallMethodNameFromExpression(node.expression);
-      if (methodName === "set") {
+      const receiver = getCallReceiverFromExpression(node.expression);
+      const receiverIsCellLike = !checker ||
+        (receiver &&
+          isCellLikeType(checker.getTypeAtLocation(receiver), checker));
+      if (methodName === "set" && receiverIsCellLike) {
         for (const argument of node.arguments) {
           const current = unwrapExpression(argument);
           if (ts.isIdentifier(current)) {
@@ -620,9 +625,24 @@ function collectArrayLocalsPassedToSet(
       }
     }
 
+    if (ts.isPropertyAccessExpression(node)) {
+      const current = unwrapExpression(node.expression);
+      const isSetCallReceiver = node.name.text === "set" &&
+        ts.isCallExpression(node.parent) &&
+        node.parent.expression === node;
+      if (ts.isIdentifier(current) && !isSetCallReceiver) {
+        structurallyAccessedArrayLocals.add(current.text);
+      }
+    }
+
     if (ts.isElementAccessExpression(node)) {
       const current = unwrapExpression(node.expression);
-      if (ts.isIdentifier(current)) {
+      const isSetCallReceiver = node.argumentExpression &&
+        isLiteralElement(node.argumentExpression) &&
+        getLiteralElementText(node.argumentExpression) === "set" &&
+        ts.isCallExpression(node.parent) &&
+        node.parent.expression === node;
+      if (ts.isIdentifier(current) && !isSetCallReceiver) {
         structurallyAccessedArrayLocals.add(current.text);
       }
     }
@@ -636,6 +656,19 @@ function collectArrayLocalsPassedToSet(
       setArgumentLocals.has(name) && !structurallyAccessedArrayLocals.has(name)
     ),
   );
+}
+
+function getCallReceiverFromExpression(
+  expression: ts.Expression,
+): ts.Expression | undefined {
+  const current = unwrapExpression(expression);
+  if (ts.isPropertyAccessExpression(current)) {
+    return current.expression;
+  }
+  if (ts.isElementAccessExpression(current)) {
+    return current.expression;
+  }
+  return undefined;
 }
 
 function getCallMethodNameFromExpression(
@@ -1125,7 +1158,7 @@ export function analyzeFunctionCapabilities(
     // encounters a synthetic identifier with no parent pointer, it can skip
     // the blanket read if the alias already has a more specific path.
     const aliasesWithSpecificPaths = new Set<string>();
-    const identityArrayLocals = collectArrayLocalsPassedToSet(fn.body);
+    const identityArrayLocals = collectArrayLocalsPassedToSet(fn.body, checker);
 
     const getIdentifierName = (
       expression: ts.Expression,

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -101,6 +101,7 @@ function extendSourceRef(
 const PARAMETER_SUMMARY_PREFIX = "__param";
 
 const WRITER_METHODS = new Set(["set", "update"]);
+const ARRAY_IDENTITY_WRITER_METHODS = new Set(["push"]);
 const READER_METHODS = new Set(["get"]);
 const FALLBACK_OPERATORS = new Set<ts.SyntaxKind>([
   ts.SyntaxKind.QuestionQuestionToken,
@@ -464,6 +465,196 @@ function isCallOrNewArgumentUsage(
   return false;
 }
 
+function isArrayIdentityWriterArgumentUsage(
+  usage: ts.Expression,
+): boolean {
+  const parent = usage.parent;
+  if (!parent || !ts.isCallExpression(parent)) {
+    return false;
+  }
+  if (!parent.arguments.includes(usage)) {
+    return false;
+  }
+  const target = unwrapExpression(parent.expression);
+  const methodName = ts.isPropertyAccessExpression(target)
+    ? target.name.text
+    : ts.isElementAccessExpression(target) && target.argumentExpression &&
+        isLiteralElement(target.argumentExpression)
+    ? getLiteralElementText(target.argumentExpression)
+    : undefined;
+  return !!methodName && ARRAY_IDENTITY_WRITER_METHODS.has(methodName);
+}
+
+function isOptionalAliasInitializerMemberUsage(usage: ts.Expression): boolean {
+  let current: ts.Expression = usage;
+  let sawOptionalMemberAccess = (ts.isPropertyAccessExpression(current) ||
+    ts.isElementAccessExpression(current)) && !!current.questionDotToken;
+  while (current.parent) {
+    const parent = current.parent;
+    if (
+      (ts.isPropertyAccessExpression(parent) ||
+        ts.isElementAccessExpression(parent)) &&
+      parent.expression === current
+    ) {
+      sawOptionalMemberAccess ||= !!parent.questionDotToken;
+      current = parent;
+      continue;
+    }
+    if (
+      (ts.isParenthesizedExpression(parent) ||
+        ts.isAsExpression(parent) ||
+        ts.isTypeAssertionExpression(parent) ||
+        ts.isSatisfiesExpression(parent) ||
+        ts.isNonNullExpression(parent)) &&
+      parent.expression === current
+    ) {
+      current = parent;
+      continue;
+    }
+    return sawOptionalMemberAccess && ts.isVariableDeclaration(parent) &&
+      parent.initializer === current;
+  }
+  return false;
+}
+
+function getIdentityArrayLocalNameForElementUsage(
+  usage: ts.Node,
+): string | undefined {
+  const parent = usage.parent;
+  if (!parent || !ts.isArrayLiteralExpression(parent)) {
+    return undefined;
+  }
+
+  let current: ts.Expression = parent;
+  while (current.parent) {
+    const parentNode = current.parent;
+    if (
+      (ts.isParenthesizedExpression(parentNode) ||
+        ts.isAsExpression(parentNode) ||
+        ts.isTypeAssertionExpression(parentNode) ||
+        ts.isSatisfiesExpression(parentNode) ||
+        ts.isNonNullExpression(parentNode)) &&
+      parentNode.expression === current
+    ) {
+      current = parentNode;
+      continue;
+    }
+
+    if (
+      (ts.isPropertyAccessExpression(parentNode) ||
+        ts.isElementAccessExpression(parentNode)) &&
+      parentNode.expression === current
+    ) {
+      current = parentNode;
+      continue;
+    }
+
+    if (
+      ts.isCallExpression(parentNode) &&
+      parentNode.expression === current
+    ) {
+      current = parentNode;
+      continue;
+    }
+
+    if (
+      ts.isVariableDeclaration(parentNode) &&
+      parentNode.initializer === current &&
+      ts.isIdentifier(parentNode.name)
+    ) {
+      return parentNode.name.text;
+    }
+
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function collectArrayLocalsPassedToSet(
+  body: ts.ConciseBody,
+): ReadonlySet<string> {
+  const arrayInitializerLocals = new Set<string>();
+  const setArgumentLocals = new Set<string>();
+  const structurallyAccessedArrayLocals = new Set<string>();
+
+  const expressionStartsWithArrayLiteral = (
+    expression: ts.Expression,
+  ): boolean => {
+    const current = unwrapExpression(expression);
+    if (ts.isArrayLiteralExpression(current)) {
+      return true;
+    }
+    if (ts.isCallExpression(current)) {
+      const target = unwrapExpression(current.expression);
+      if (
+        ts.isPropertyAccessExpression(target) ||
+        ts.isElementAccessExpression(target)
+      ) {
+        return expressionStartsWithArrayLiteral(target.expression);
+      }
+    }
+    return false;
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isExpression(node.initializer) &&
+      expressionStartsWithArrayLiteral(node.initializer)
+    ) {
+      arrayInitializerLocals.add(node.name.text);
+    }
+
+    if (ts.isCallExpression(node)) {
+      const methodName = getCallMethodNameFromExpression(node.expression);
+      if (methodName === "set") {
+        for (const argument of node.arguments) {
+          const current = unwrapExpression(argument);
+          if (ts.isIdentifier(current)) {
+            setArgumentLocals.add(current.text);
+          }
+        }
+      }
+    }
+
+    if (ts.isElementAccessExpression(node)) {
+      const current = unwrapExpression(node.expression);
+      if (ts.isIdentifier(current)) {
+        structurallyAccessedArrayLocals.add(current.text);
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(body);
+  return new Set(
+    [...arrayInitializerLocals].filter((name) =>
+      setArgumentLocals.has(name) && !structurallyAccessedArrayLocals.has(name)
+    ),
+  );
+}
+
+function getCallMethodNameFromExpression(
+  expression: ts.Expression,
+): string | undefined {
+  const current = unwrapExpression(expression);
+  if (ts.isPropertyAccessExpression(current)) {
+    return current.name.text;
+  }
+  if (
+    ts.isElementAccessExpression(current) &&
+    current.argumentExpression &&
+    isLiteralElement(current.argumentExpression)
+  ) {
+    return getLiteralElementText(current.argumentExpression);
+  }
+  return undefined;
+}
+
 function isKnownIdentityEqualsCallee(
   expr: ts.Expression,
   checker?: ts.TypeChecker,
@@ -506,6 +697,29 @@ function isKnownIdentityEqualsCall(
   checker?: ts.TypeChecker,
 ): boolean {
   return isKnownIdentityEqualsCallee(call.expression, checker);
+}
+
+function isKnownIdentityNavigationCallee(
+  expr: ts.Expression,
+  checker?: ts.TypeChecker,
+): boolean {
+  const current = unwrapExpression(expr);
+  if (!ts.isIdentifier(current) || current.text !== "navigateTo") {
+    return false;
+  }
+  if (!checker) {
+    return true;
+  }
+  const symbol = checker.getSymbolAtLocation(current);
+  return resolvesToCommonFabricSymbol(symbol, checker, "navigateTo");
+}
+
+function isKnownIdentityArgumentCall(
+  call: ts.CallExpression,
+  checker?: ts.TypeChecker,
+): boolean {
+  return isKnownIdentityEqualsCall(call, checker) ||
+    isKnownIdentityNavigationCallee(call.expression, checker);
 }
 
 function isAliasShape(binding: AliasBinding): binding is AliasShape {
@@ -737,6 +951,7 @@ export function analyzeFunctionCapabilities(
     const states = new Map<string, MutableCapabilityState>();
     const aliases = new Map<string, SourceRef>();
     const aliasShapes = new Map<string, AliasShape>();
+    const optionalPresenceAliases = new Set<string>();
     const localArrayElementBindings = new Map<string, AliasBinding>();
     const localMapValueBindings = new Map<string, AliasBinding>();
     const parameterStateKeys: string[] = [];
@@ -824,11 +1039,43 @@ export function analyzeFunctionCapabilities(
       state.hasIdentityUse = true;
     };
 
+    const hasRecordedIdentityPath = (
+      name: string,
+      path: readonly string[],
+    ): boolean => {
+      return ensureState(name).rawIdentityPaths.has(encodePath(path));
+    };
+
+    const hasRecordedIdentityUseRef = (ref: SourceRef): boolean => {
+      const materialized = materializeSourceRef(ref);
+      if (materialized.dynamic) {
+        return false;
+      }
+      return hasRecordedIdentityPath(materialized.root, materialized.path);
+    };
+
     const isCellLikeExpression = (expr: ts.Expression): boolean => {
       if (!checker) {
         return false;
       }
       return isCellLikeType(checker.getTypeAtLocation(expr), checker);
+    };
+
+    const isPrimitiveLikeExpression = (expr: ts.Expression): boolean => {
+      if (!checker) {
+        return false;
+      }
+      const type = checker.getTypeAtLocation(expr);
+      const flags = type.flags;
+      return !!(
+        flags &
+        (ts.TypeFlags.BooleanLike |
+          ts.TypeFlags.NumberLike |
+          ts.TypeFlags.StringLike |
+          ts.TypeFlags.BigIntLike |
+          ts.TypeFlags.ESSymbolLike |
+          ts.TypeFlags.EnumLike)
+      );
     };
 
     for (let index = 0; index < fn.parameters.length; index++) {
@@ -878,6 +1125,7 @@ export function analyzeFunctionCapabilities(
     // encounters a synthetic identifier with no parent pointer, it can skip
     // the blanket read if the alias already has a more specific path.
     const aliasesWithSpecificPaths = new Set<string>();
+    const identityArrayLocals = collectArrayLocalsPassedToSet(fn.body);
 
     const getIdentifierName = (
       expression: ts.Expression,
@@ -1451,7 +1699,9 @@ export function analyzeFunctionCapabilities(
       ref: SourceRef,
       expr?: ts.Expression,
     ): void => {
-      const cellLike = expr ? isCellLikeExpression(expr) : false;
+      const cellLike = expr
+        ? isCellLikeExpression(expr) || !isPrimitiveLikeExpression(expr)
+        : false;
       if (ref.dynamic) {
         markWildcard(ref.root);
       } else if (ref.path.length === 0) {
@@ -1460,6 +1710,15 @@ export function analyzeFunctionCapabilities(
       } else {
         recordIdentityPath(ref.root, ref.path, { cellLike });
       }
+    };
+
+    const markArrayItemIdentityUseRef = (ref: SourceRef): void => {
+      const materialized = materializeSourceRef(ref);
+      if (materialized.dynamic) {
+        markWildcard(materialized.root);
+        return;
+      }
+      recordIdentityPath(materialized.root, [...materialized.path, "0"]);
     };
 
     const resolveInterproceduralSummary = (
@@ -1487,6 +1746,7 @@ export function analyzeFunctionCapabilities(
     ): void => {
       const savedAliases = new Map(aliases);
       const savedAliasShapes = new Map(aliasShapes);
+      const savedOptionalPresenceAliases = new Set(optionalPresenceAliases);
       const savedSpecificPaths = new Set(aliasesWithSpecificPaths);
       const savedLocalArrayElementBindings = new Map(
         localArrayElementBindings,
@@ -1528,6 +1788,10 @@ export function analyzeFunctionCapabilities(
         aliasShapes.clear();
         for (const [name, shape] of savedAliasShapes) {
           aliasShapes.set(name, shape);
+        }
+        optionalPresenceAliases.clear();
+        for (const name of savedOptionalPresenceAliases) {
+          optionalPresenceAliases.add(name);
         }
         aliasesWithSpecificPaths.clear();
         for (const name of savedSpecificPaths) {
@@ -1695,6 +1959,15 @@ export function analyzeFunctionCapabilities(
               // Truthiness checks on array-element aliases (e.g. find() results)
               // don't require loading the element payload.
             } else if (
+              source.path.length > 0 &&
+              !source.dynamic &&
+              (optionalPresenceAliases.has(node.text) ||
+                !isPrimitiveLikeExpression(usage)) &&
+              isBooleanConditionUsage(usage)
+            ) {
+              // Truthiness checks on local aliases of source properties only
+              // require presence, not the aliased payload shape.
+            } else if (
               !(
                 parent &&
                 ts.isPropertyAccessExpression(parent) &&
@@ -1719,11 +1992,35 @@ export function analyzeFunctionCapabilities(
                 parent &&
                 ts.isCallExpression(parent) &&
                 parent.arguments.includes(usage) &&
-                isKnownIdentityEqualsCall(parent, checker)
+                isKnownIdentityArgumentCall(parent, checker)
               );
-              if (
+              const identityArrayLocal =
+                getIdentityArrayLocalNameForElementUsage(usage);
+              const identityOnlyArrayElementUse = !!identityArrayLocal &&
+                identityArrayLocals.has(identityArrayLocal);
+              const arrayIdentityWriterArgumentUse =
+                isArrayIdentityWriterArgumentUsage(usage);
+              if (arrayIdentityWriterArgumentUse) {
+                if (
+                  source.arrayElement &&
+                  !resolvedSource.dynamic
+                ) {
+                  trackReadRef(resolvedSource);
+                }
+                if (
+                  hasRecordedIdentityUseRef(source) &&
+                  !resolvedSource.dynamic
+                ) {
+                  recordIdentityPath(resolvedSource.root, resolvedSource.path, {
+                    cellLike: isCellLikeExpression(usage),
+                  });
+                } else {
+                  trackReadRef(resolvedSource);
+                }
+              } else if (
                 isCallOrNewArgumentUsage(usage) ||
-                isPassThroughIdentifierUsage(node)
+                isPassThroughIdentifierUsage(node) ||
+                identityOnlyArrayElementUse
               ) {
                 if (
                   resolvedSource.path.length === 0 && !resolvedSource.dynamic
@@ -1741,6 +2038,13 @@ export function analyzeFunctionCapabilities(
                   );
                 } else if (
                   identityOnlyArgumentUse && !resolvedSource.dynamic
+                ) {
+                  recordIdentityPath(resolvedSource.root, resolvedSource.path, {
+                    cellLike: isCellLikeExpression(usage),
+                  });
+                } else if (
+                  identityOnlyArrayElementUse &&
+                  !resolvedSource.dynamic
                 ) {
                   recordIdentityPath(resolvedSource.root, resolvedSource.path, {
                     cellLike: isCellLikeExpression(usage),
@@ -1769,7 +2073,8 @@ export function analyzeFunctionCapabilities(
           const parent = node.parent;
           if (
             !(parent && ts.isCallExpression(parent) &&
-              parent.expression === node)
+              parent.expression === node) &&
+            !isOptionalAliasInitializerMemberUsage(node)
           ) {
             const ref = resolveSourceRef(node);
             if (ref) {
@@ -1829,6 +2134,7 @@ export function analyzeFunctionCapabilities(
         }
 
         const identityEqualsCall = isKnownIdentityEqualsCall(node, checker);
+        const identityArgumentCall = isKnownIdentityArgumentCall(node, checker);
         const interproceduralHandledArgs = new Set<number>();
         const calleeSummary = resolveInterproceduralSummary(node);
         if (calleeSummary) {
@@ -1942,6 +2248,26 @@ export function analyzeFunctionCapabilities(
               markIdentityUseRef(receiver, node.expression.expression);
             } else if (WRITER_METHODS.has(methodName)) {
               trackWriteRef(receiver);
+            } else if (ARRAY_IDENTITY_WRITER_METHODS.has(methodName)) {
+              trackWriteRef(receiver);
+              let hasIdentityArgument = false;
+              for (const argument of node.arguments) {
+                const argumentRef = resolveSourceRef(argument);
+                const rawArgument = unwrapExpression(argument);
+                const rawAlias = ts.isIdentifier(rawArgument)
+                  ? aliases.get(rawArgument.text)
+                  : undefined;
+                if (rawAlias?.arrayElement || argumentRef?.arrayElement) {
+                  trackReadRef(materializeSourceRef(rawAlias ?? argumentRef!));
+                }
+                if (argumentRef && hasRecordedIdentityUseRef(argumentRef)) {
+                  hasIdentityArgument = true;
+                  markIdentityUseRef(argumentRef, argument);
+                }
+              }
+              if (hasIdentityArgument) {
+                markArrayItemIdentityUseRef(receiver);
+              }
             } else if (READER_METHODS.has(methodName)) {
               // If the .get() result was already resolved with a more specific
               // path by the member-access handler (e.g. notes.get().length →
@@ -1962,7 +2288,7 @@ export function analyzeFunctionCapabilities(
 
         // Passing a tracked root object into an opaque helper can conceal
         // indirect traversal/mutation; conservatively disable shrinking.
-        if (!identityEqualsCall) {
+        if (!identityArgumentCall) {
           for (let index = 0; index < node.arguments.length; index++) {
             if (interproceduralHandledArgs.has(index)) {
               continue;
@@ -1977,7 +2303,7 @@ export function analyzeFunctionCapabilities(
             markWildcard(source.root);
           }
         }
-        if (identityEqualsCall) {
+        if (identityArgumentCall) {
           for (const argument of node.arguments) {
             const source = resolveSourceRef(argument);
             if (source) {
@@ -2002,6 +2328,17 @@ export function analyzeFunctionCapabilities(
         const initRef = node.initializer && ts.isExpression(node.initializer)
           ? buildAliasBindingFromExpression(node.initializer)
           : undefined;
+        if (ts.isIdentifier(node.name)) {
+          if (
+            node.initializer &&
+            ts.isExpression(node.initializer) &&
+            isOptionalAliasInitializerMemberUsage(node.initializer)
+          ) {
+            optionalPresenceAliases.add(node.name.text);
+          } else {
+            optionalPresenceAliases.delete(node.name.text);
+          }
+        }
         assignBindingAlias(node.name, initRef);
       }
 
@@ -2017,10 +2354,27 @@ export function analyzeFunctionCapabilities(
         }
       }
 
-      if (
-        ts.isSpreadElement(node) ||
-        ts.isSpreadAssignment(node)
-      ) {
+      if (ts.isSpreadElement(node)) {
+        const spreadExpr = node.expression;
+        if (spreadExpr) {
+          const ref = resolveSourceRef(spreadExpr);
+          if (ref) {
+            trackReadRef(ref);
+            const identityArrayLocal = getIdentityArrayLocalNameForElementUsage(
+              node,
+            );
+            if (
+              identityArrayLocal && identityArrayLocals.has(identityArrayLocal)
+            ) {
+              markArrayItemIdentityUseRef(ref);
+            }
+          } else {
+            markWildcardFromExpression(spreadExpr);
+          }
+        }
+      }
+
+      if (ts.isSpreadAssignment(node)) {
         const spreadExpr = node.expression;
         if (spreadExpr) {
           markWildcardFromExpression(spreadExpr);
@@ -2057,6 +2411,7 @@ export function analyzeFunctionCapabilities(
 
         const savedAliases = new Map(aliases);
         const savedAliasShapes = new Map(aliasShapes);
+        const savedOptionalPresenceAliases = new Set(optionalPresenceAliases);
         const savedSpecificPaths = new Set(aliasesWithSpecificPaths);
         const savedLocalArrayElementBindings = new Map(
           localArrayElementBindings,
@@ -2087,6 +2442,10 @@ export function analyzeFunctionCapabilities(
           aliasShapes.clear();
           for (const [name, shape] of savedAliasShapes) {
             aliasShapes.set(name, shape);
+          }
+          optionalPresenceAliases.clear();
+          for (const name of savedOptionalPresenceAliases) {
+            optionalPresenceAliases.add(name);
           }
           aliasesWithSpecificPaths.clear();
           for (const name of savedSpecificPaths) {

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -77,12 +77,15 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
           ? { widenLiterals }
           : undefined;
 
-        // If Type resolved to 'any' and we have a synthetic TypeNode, use new method
+        // If Type resolved to 'any' or the synthetic TypeNode intentionally
+        // contains unknown, use the synthetic-node generator so the checker
+        // does not recover a wider semantic type from the original source.
         let schema: unknown;
         if (
-          (type.flags & ts.TypeFlags.Any) &&
-          typeArg.pos === -1 &&
-          typeArg.end === -1
+          ((typeArg.pos === -1 &&
+            typeArg.end === -1 &&
+            (type.flags & ts.TypeFlags.Any)) ||
+            containsAnyOrUnknownTypeNode(typeArg))
         ) {
           // Synthetic TypeNode path - use new method that shares context properly
           schema = schemaTransformer.generateSchemaFromSyntheticTypeNode(
@@ -448,6 +451,24 @@ function evaluateExpression(
 interface ToSchemaNode extends ts.CallExpression {
   typeArguments: ts.NodeArray<ts.TypeNode>;
 }
+
+function containsAnyOrUnknownTypeNode(node: ts.TypeNode): boolean {
+  let found = false;
+  const visit = (current: ts.Node): void => {
+    if (found) return;
+    if (
+      current.kind === ts.SyntaxKind.AnyKeyword ||
+      current.kind === ts.SyntaxKind.UnknownKeyword
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(current, visit);
+  };
+  visit(node);
+  return found;
+}
+
 function isToSchemaNode(node: ts.Node): node is ToSchemaNode {
   if (!ts.isCallExpression(node)) return false;
   const { typeArguments, expression } = node;

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -280,12 +280,10 @@ function applyCapabilitySummaryToParameter(
     fn,
     parameterIndex,
     capabilityRegistry,
-    parameterNode.pos < 0 || parameterNode.end < 0
-      ? {
-        checker,
-        includeNestedCallbacks: true,
-      }
-      : undefined,
+    {
+      checker,
+      includeNestedCallbacks: true,
+    },
   );
   if (!paramSummary) {
     return parameterNode;
@@ -761,7 +759,10 @@ function createSchemaCallWithRegistryTransfer(
 
   // Transfer TypeRegistry entry from source typeNode to schema call
   // This preserves type information for closure-captured variables
-  if (typeRegistry && emittedTypeNode === typeNode) {
+  if (
+    typeRegistry && emittedTypeNode === typeNode &&
+    !containsAnyOrUnknownTypeNode(emittedTypeNode)
+  ) {
     const typeFromRegistry = typeRegistry.get(typeNode);
     if (typeFromRegistry) {
       typeRegistry.set(schemaCall, typeFromRegistry);
@@ -769,6 +770,43 @@ function createSchemaCallWithRegistryTransfer(
   }
 
   return schemaCall;
+}
+
+function applyIdentityArrayItemSchemaHints(
+  typeNode: ts.TypeNode,
+  identityPaths: readonly (readonly string[])[],
+  context: TransformationContext,
+): void {
+  const schemaHints = context.options.schemaHints;
+  if (!schemaHints || identityPaths.length === 0) return;
+
+  const grouped = new Map<string, boolean>();
+  for (const path of identityPaths) {
+    const [head, second] = path;
+    if (head && second !== undefined && /^\d+$/.test(second)) {
+      grouped.set(head, true);
+    }
+  }
+  if (grouped.size === 0) return;
+
+  const visitObject = (node: ts.TypeNode): void => {
+    if (ts.isTypeLiteralNode(node)) {
+      for (const member of node.members) {
+        if (!ts.isPropertySignature(member) || !member.name || !member.type) {
+          continue;
+        }
+        const name = ts.isIdentifier(member.name) ||
+            ts.isStringLiteral(member.name)
+          ? member.name.text
+          : undefined;
+        if (name && grouped.has(name)) {
+          schemaHints.set(member.type, { items: false });
+        }
+      }
+    }
+  };
+
+  visitObject(typeNode);
 }
 
 function createRegisteredSchemaCallFromResolvedType(
@@ -2518,6 +2556,17 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
               context,
               handlerFn,
             ) ?? stateType;
+            const stateSummary = findCapabilitySummaryForParameter(
+              handlerFn,
+              1,
+              capabilityRegistry,
+              { checker, includeNestedCallbacks: true },
+            );
+            applyIdentityArrayItemSchemaHints(
+              stateTypeNode,
+              stateSummary?.identityPaths ?? [],
+              context,
+            );
           }
 
           const toSchemaEvent = createSchemaCallWithRegistryTransfer(
@@ -2608,6 +2657,17 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
               context,
               handlerFn,
             ) ?? stateTypeBase;
+            const stateSummary = findCapabilitySummaryForParameter(
+              handlerFn,
+              1,
+              capabilityRegistry,
+              { checker, includeNestedCallbacks: true },
+            );
+            applyIdentityArrayItemSchemaHints(
+              stateType,
+              stateSummary?.identityPaths ?? [],
+              context,
+            );
 
             // Always transform - generate schemas regardless of parameter presence
             const toSchemaEvent = createSchemaCallWithRegistryTransfer(

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -1813,7 +1813,10 @@ function applyIdentityOnlyPathsToTypeNode(
   }
   const resolvedSemanticType = semanticType ??
     resolveIdentitySemanticType(node, checker, typeRegistry);
-  if (normalized.some((path) => path.length === 0)) {
+  if (
+    normalized.some((path) => path.length === 0) &&
+    !normalized.some((path) => path.length > 0)
+  ) {
     return createIdentityOnlyRootTypeNode(
       node,
       resolvedSemanticType,
@@ -1862,7 +1865,6 @@ function applyIdentityOnlyPathsToTypeNode(
         return node;
       }
       const arrayNode = factory.updateArrayTypeNode(node, updated);
-      ensureTypeNodeRegistered(arrayNode, checker, typeRegistry);
       return arrayNode;
     }
 
@@ -1888,7 +1890,6 @@ function applyIdentityOnlyPathsToTypeNode(
         node,
         readonlyArray,
       );
-      ensureTypeNodeRegistered(readonlyNode, checker, typeRegistry);
       return readonlyNode;
     }
 
@@ -1916,7 +1917,6 @@ function applyIdentityOnlyPathsToTypeNode(
         node.typeName,
         factory.createNodeArray([updated]),
       );
-      ensureTypeNodeRegistered(arrayRef, checker, typeRegistry);
       return arrayRef;
     }
   }
@@ -1970,10 +1970,7 @@ function applyIdentityOnlyPathsToTypeNode(
     if (!changed) {
       return node;
     }
-    return createRegisteredTypeLiteral(
-      members,
-      { factory, checker, typeRegistry },
-    );
+    return factory.createTypeLiteralNode(members);
   }
 
   if (
@@ -1999,8 +1996,62 @@ function applyIdentityOnlyPathsToTypeNode(
       node.typeName,
       factory.createNodeArray([updated, ...rest]),
     );
-    ensureTypeNodeRegistered(cellNode, checker, typeRegistry);
     return cellNode;
+  }
+
+  if (ts.isTypeReferenceNode(node) && checker) {
+    const members = resolveTypeReferenceMembers(node, checker, typeRegistry);
+    if (members) {
+      const grouped = groupPathsByHead(normalized);
+      const cellLikeGrouped = groupPathsByHead(normalizedCellLikePaths);
+      let changed = false;
+      const updatedMembers = members.map((member) => {
+        if (!ts.isPropertySignature(member) || !member.type || !member.name) {
+          return member;
+        }
+        const propertyName = getRequestedPropertyNameText(member.name, checker);
+        if (!propertyName) {
+          return member;
+        }
+        const childPaths = grouped.get(propertyName);
+        if (!childPaths) {
+          return member;
+        }
+        const updated = applyIdentityOnlyPathsToTypeNode(
+          member.type,
+          childPaths,
+          cellLikeGrouped.get(propertyName) ?? [],
+          factory,
+          checker,
+          getIdentityChildSemanticType(
+            resolvedSemanticType,
+            propertyName,
+            member,
+            checker,
+          ),
+          typeRegistry,
+        );
+        if (updated === member.type) {
+          return member;
+        }
+        changed = true;
+        return factory.updatePropertySignature(
+          member,
+          member.modifiers,
+          member.name,
+          member.questionToken ??
+            (typeNodeIncludesUndefined(updated)
+              ? factory.createToken(ts.SyntaxKind.QuestionToken)
+              : undefined),
+          updated,
+        );
+      });
+
+      if (!changed) {
+        return node;
+      }
+      return factory.createTypeLiteralNode(updatedMembers);
+    }
   }
 
   if (ts.isUnionTypeNode(node)) {
@@ -2025,7 +2076,6 @@ function applyIdentityOnlyPathsToTypeNode(
       return node;
     }
     const unionNode = factory.createUnionTypeNode(members);
-    ensureTypeNodeRegistered(unionNode, checker, typeRegistry);
     return unionNode;
   }
 
@@ -2393,15 +2443,36 @@ export function applyShrinkAndWrap(
       baseType,
       context?.options.typeRegistry,
     )
+    : identityPaths.length > 0
+    ? applyIdentityOnlyPathsToTypeNode(
+      baseTypeNode,
+      identityPaths,
+      identityCellPaths,
+      factory,
+      checker,
+      baseType,
+      context?.options.typeRegistry,
+    )
     : baseTypeNode;
   let shrunk: ts.TypeNode | undefined;
+  const retainedPathsCoveredByIdentityContainers = identityPaths.length > 0 &&
+    retainedPaths.every((path) =>
+      identityPaths.some((identityPath) =>
+        identityPath.length > path.length &&
+        path.every((segment, index) => segment === identityPath[index])
+      )
+    );
   if (
     !identityOnlyRoot &&
     !paramSummary.wildcard &&
-    retainedPaths.length > 0
+    retainedPaths.length > 0 &&
+    !retainedPathsCoveredByIdentityContainers
   ) {
+    const shrinkBaseTypeNode = next;
     const hasDirectAccess = retainedPaths.some((path) => path.length === 0);
-    const preferTypeDriven = !!baseType && isSyntheticTypeNode(baseTypeNode);
+    const preferTypeDriven = !!baseType && isSyntheticTypeNode(
+      shrinkBaseTypeNode,
+    );
     if (preferTypeDriven) {
       // Synthetic inferred nodes can lose property precision in node-only mode.
       const typeDriven = buildShrunkTypeNodeFromType(
@@ -2414,7 +2485,7 @@ export function applyShrinkAndWrap(
         fullShapePaths,
       );
       const nodeDriven = buildShrunkTypeNodeFromTypeNode(
-        baseTypeNode,
+        shrinkBaseTypeNode,
         retainedPaths,
         factory,
         checker,
@@ -2425,7 +2496,7 @@ export function applyShrinkAndWrap(
         "type",
         nodeDriven,
         typeDriven,
-        baseTypeNode,
+        shrinkBaseTypeNode,
         retainedPaths,
         checker,
         hasDirectAccess,
@@ -2435,14 +2506,14 @@ export function applyShrinkAndWrap(
       // shrinking can still produce a better result for arrays and inferred
       // wrappers. Compute both and choose the more informative shrink.
       const nodeDriven = buildShrunkTypeNodeFromTypeNode(
-        baseTypeNode,
+        shrinkBaseTypeNode,
         retainedPaths,
         factory,
         checker,
         context?.options.typeRegistry,
         fullShapePaths,
       );
-      const typeDriven = baseType
+      const typeDriven = baseType && identityPaths.length === 0
         ? buildShrunkTypeNodeFromType(
           baseType,
           retainedPaths,
@@ -2457,7 +2528,7 @@ export function applyShrinkAndWrap(
         "node",
         nodeDriven,
         typeDriven,
-        baseTypeNode,
+        shrinkBaseTypeNode,
         retainedPaths,
         checker,
         hasDirectAccess,

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -2458,8 +2458,8 @@ export function applyShrinkAndWrap(
   const retainedPathsCoveredByIdentityContainers = identityPaths.length > 0 &&
     retainedPaths.every((path) =>
       identityPaths.some((identityPath) =>
-        identityPath.length > path.length &&
-        path.every((segment, index) => segment === identityPath[index])
+        identityPath.length <= path.length &&
+        identityPath.every((segment, index) => segment === path[index])
       )
     );
   if (

--- a/packages/ts-transformers/test/fixtures/closures/derive-all-literal-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-all-literal-types.expected.jsx
@@ -38,14 +38,11 @@ export default pattern(() => {
             floatLiteral: {
                 type: "number"
             },
-            boolLiteral: {
-                type: "boolean"
-            },
             strLiteral: {
                 type: "string"
             }
         },
-        required: ["value", "numLiteral", "floatLiteral", "boolLiteral", "strLiteral"]
+        required: ["value", "numLiteral", "floatLiteral", "strLiteral"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
@@ -24,7 +24,8 @@ const removeItem = handler({
         items: {
             type: "array",
             items: {
-                type: "unknown"
+                type: "unknown",
+                asCell: ["opaque"]
             },
             asCell: ["cell"]
         },

--- a/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
@@ -24,8 +24,7 @@ const removeItem = handler({
         items: {
             type: "array",
             items: {
-                type: "unknown",
-                asCell: ["opaque"]
+                type: "unknown"
             },
             asCell: ["cell"]
         },

--- a/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.jsx
@@ -53,6 +53,10 @@ const userHandler = handler({
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
+        count: {
+            type: "number",
+            asCell: ["cell"]
+        },
         users: {
             type: "array",
             items: {
@@ -72,16 +76,12 @@ const userHandler = handler({
             },
             asCell: ["cell"]
         },
-        count: {
-            type: "number",
-            asCell: ["cell"]
-        },
         lastAction: {
             type: "string",
             asCell: ["cell"]
         }
     },
-    required: ["users", "count", "lastAction"]
+    required: ["count", "users", "lastAction"]
 } as const satisfies __cfHelpers.JSONSchema, (event, state) => {
     if (event.action === "create") {
         state.users.push({

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
@@ -1,0 +1,83 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { equals, handler, Writable } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+type MentionablePiece = {
+    title?: string;
+    isHidden?: boolean;
+    mentioned?: MentionablePiece[];
+    backlinks?: MentionablePiece[];
+};
+const addPiece = handler({
+    type: "object",
+    properties: {
+        piece: {
+            type: "unknown",
+            asCell: ["opaque"]
+        }
+    },
+    required: ["piece"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        allPieces: {
+            type: "array",
+            items: {
+                type: "unknown"
+            },
+            asCell: ["cell"]
+        }
+    },
+    required: ["allPieces"]
+} as const satisfies __cfHelpers.JSONSchema, (event, { allPieces }) => {
+    const piece = event?.piece;
+    if (!piece)
+        return;
+    const current = allPieces.get();
+    if (!current.some((c) => equals(c, piece))) {
+        allPieces.push(piece);
+    }
+});
+const trackRecent = handler({
+    type: "object",
+    properties: {
+        piece: {
+            type: "unknown",
+            asCell: ["opaque"]
+        }
+    },
+    required: ["piece"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        recentPieces: {
+            type: "array",
+            items: {
+                type: "unknown"
+            },
+            asCell: ["cell"]
+        }
+    },
+    required: ["recentPieces"]
+} as const satisfies __cfHelpers.JSONSchema, ({ piece }, { recentPieces }) => {
+    const current = recentPieces.get();
+    const filtered = current.filter((c) => !equals(c, piece));
+    const updated = [piece, ...filtered].slice(0, 10);
+    recentPieces.set(updated);
+});
+// FIXTURE: identity-only-handler-payload
+// Verifies: handler payloads and array items used only for identity/passthrough
+// shrink to unknown instead of retaining full recursive structural schemas.
+export { addPiece, trackRecent };
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
@@ -32,7 +32,8 @@ const addPiece = handler({
         allPieces: {
             type: "array",
             items: {
-                type: "unknown"
+                type: "unknown",
+                asCell: ["opaque"]
             },
             asCell: ["cell"]
         }
@@ -62,7 +63,8 @@ const trackRecent = handler({
         recentPieces: {
             type: "array",
             items: {
-                type: "unknown"
+                type: "unknown",
+                asCell: ["opaque"]
             },
             asCell: ["cell"]
         }

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.input.tsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.input.tsx
@@ -1,0 +1,36 @@
+import { equals, handler, Writable } from "commonfabric";
+
+type MentionablePiece = {
+  title?: string;
+  isHidden?: boolean;
+  mentioned?: MentionablePiece[];
+  backlinks?: MentionablePiece[];
+};
+
+const addPiece = handler<
+  { piece: MentionablePiece },
+  { allPieces: Writable<MentionablePiece[]> }
+>((event, { allPieces }) => {
+  const piece = event?.piece;
+  if (!piece) return;
+
+  const current = allPieces.get();
+  if (!current.some((c) => equals(c, piece))) {
+    allPieces.push(piece);
+  }
+});
+
+const trackRecent = handler<
+  { piece: MentionablePiece },
+  { recentPieces: Writable<MentionablePiece[]> }
+>(({ piece }, { recentPieces }) => {
+  const current = recentPieces.get();
+  const filtered = current.filter((c) => !equals(c, piece));
+  const updated = [piece, ...filtered].slice(0, 10);
+  recentPieces.set(updated);
+});
+
+// FIXTURE: identity-only-handler-payload
+// Verifies: handler payloads and array items used only for identity/passthrough
+// shrink to unknown instead of retaining full recursive structural schemas.
+export { addPiece, trackRecent };

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
@@ -39,9 +39,6 @@ export default pattern((__cf_pattern_input) => {
         } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfHelpers.derive({
             type: "object",
             properties: {
-                showHistory: {
-                    type: "boolean"
-                },
                 messageCount: {
                     type: "number"
                 },
@@ -50,7 +47,7 @@ export default pattern((__cf_pattern_input) => {
                     asCell: ["cell"]
                 }
             },
-            required: ["showHistory", "messageCount", "dismissedIndex"]
+            required: ["messageCount", "dismissedIndex"]
         } as const satisfies __cfHelpers.JSONSchema, {
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
@@ -39,8 +39,6 @@ export default pattern(() => {
         required: ["result"]
     } as const satisfies __cfHelpers.JSONSchema, {
         anyOf: [{
-                type: "undefined"
-            }, {
                 type: "object",
                 properties: {
                     result: {
@@ -48,6 +46,8 @@ export default pattern(() => {
                     }
                 },
                 required: ["result"]
+            }, {
+                type: "undefined"
             }]
     } as const satisfies __cfHelpers.JSONSchema, __cfHelpers.derive({
         type: "object",
@@ -81,8 +81,6 @@ export default pattern(() => {
         type: "undefined"
     } as const satisfies __cfHelpers.JSONSchema, {
         anyOf: [{
-                type: "undefined"
-            }, {
                 type: "object",
                 properties: {
                     data: {
@@ -90,6 +88,8 @@ export default pattern(() => {
                     }
                 },
                 required: ["data"]
+            }, {
+                type: "undefined"
             }]
     } as const satisfies __cfHelpers.JSONSchema, __cfHelpers.derive({
         type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
@@ -131,7 +131,10 @@ const goToCharm = handler({
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
-        charm: true
+        charm: {
+            type: "unknown",
+            asCell: ["opaque"]
+        }
     },
     required: ["charm"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { charm }) => {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
@@ -69,14 +69,11 @@ export const ComputedLogicalAnd = pattern((__cf_pattern_input) => {
     return (<div>{__cfHelpers.derive({
         type: "object",
         properties: {
-            foo: {
-                type: "boolean"
-            },
             bar: {
                 type: "string"
             }
         },
-        required: ["foo", "bar"]
+        required: ["bar"]
     } as const satisfies __cfHelpers.JSONSchema, {
         anyOf: [{
                 type: "string"

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -739,6 +739,69 @@ Deno.test(
 );
 
 Deno.test(
+  "Capability analysis does not treat non-cell set calls as identity array sinks",
+  () => {
+    const { program, sourceFile } = createProgramWithSource(
+      `
+      class Map<K, V> {
+        set(key: K, value: V): this;
+      }
+
+      type Piece = { title: string; unused: string };
+
+      const fn = (input: { piece: Piece }) => {
+        const piece = input.piece;
+        const updated = [piece];
+        const cache = new Map<string, Piece[]>();
+        cache.set("items", updated);
+      };
+      `,
+    );
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const input = getPaths(summary, "input");
+
+    assertEquals(input.identityPaths.includes("piece"), false);
+    assert(input.readPaths.includes("piece"));
+  },
+);
+
+Deno.test(
+  "Capability analysis keeps array locals structural when methods inspect items before set",
+  () => {
+    const { program, sourceFile } = createProgramWithSource(
+      `
+      declare const state: {
+        items: {
+          set(value: unknown): void;
+        };
+      };
+
+      type Piece = { title: string; unused: string };
+
+      const fn = (input: { piece: Piece }) => {
+        const updated = [input.piece];
+        if (updated.length > 0) {
+          state.items.set(updated);
+        }
+      };
+      `,
+    );
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const input = getPaths(summary, "input");
+
+    assertEquals(input.identityPaths.includes("piece"), false);
+    assert(input.readPaths.includes("piece"));
+    assertEquals(input.readPaths.includes("piece.unused"), false);
+  },
+);
+
+Deno.test(
   "Capability analysis restores local array bindings after nested callbacks",
   () => {
     const { program, sourceFile } = createProgramWithSource(

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -802,6 +802,223 @@ Deno.test(
 );
 
 Deno.test(
+  "Capability analysis keeps array-literal map chains structural before set",
+  () => {
+    const { program, sourceFile } = createProgramWithSource(
+      `
+      declare const CELL_BRAND: unique symbol;
+
+      type Cell<T> = {
+        readonly [CELL_BRAND]: "cell";
+        set(value: T): void;
+      };
+
+      interface Array<T> {
+        map<U>(mapper: (value: T) => U): U[];
+      }
+
+      declare const state: { items: Cell<{ title: string }[]> };
+
+      type Piece = { title: string; unused: string };
+
+      const fn = (input: { piece?: Piece }) => {
+        const piece = input?.piece;
+        if (!piece) return;
+        const updated = [piece].map((p) => ({ title: p.title }));
+        state.items.set(updated);
+      };
+      `,
+    );
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const input = getPaths(summary, "input");
+
+    assertEquals(input.identityPaths.includes("piece"), false);
+    assert(
+      input.readPaths.includes("piece") ||
+        input.readPaths.includes("piece.title"),
+    );
+  },
+);
+
+Deno.test(
+  "Capability analysis treats direct local array set payloads as identity-only",
+  () => {
+    const { program, sourceFile } = createProgramWithSource(
+      `
+      declare const CELL_BRAND: unique symbol;
+
+      type Cell<T> = {
+        readonly [CELL_BRAND]: "cell";
+        set(value: T): void;
+      };
+
+      declare const state: { items: Cell<Piece[]> };
+
+      type Piece = { title: string; unused: string };
+
+      const fn = (input: { piece?: Piece }) => {
+        const piece = input?.piece;
+        if (!piece) return;
+        const updated = [piece];
+        state.items.set(updated);
+      };
+      `,
+    );
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const input = getPaths(summary, "input");
+
+    assert(input.identityPaths.includes("piece"));
+    assert(input.identityCellPaths.includes("piece"));
+    assertEquals(input.readPaths.includes("piece"), false);
+  },
+);
+
+Deno.test(
+  "Capability analysis treats local array push, unshift, and splice payloads as identity-only",
+  () => {
+    const { program, sourceFile } = createProgramWithSource(
+      `
+      declare const CELL_BRAND: unique symbol;
+
+      type Cell<T> = {
+        readonly [CELL_BRAND]: "cell";
+        set(value: T): void;
+      };
+
+      interface Array<T> {
+        push(...items: T[]): number;
+        unshift(...items: T[]): number;
+        splice(start: number, deleteCount: number, ...items: T[]): T[];
+      }
+
+      declare const state: { items: Cell<Piece[]> };
+
+      type Piece = { title: string; unused: string };
+
+      const fn = (input: { first?: Piece; second?: Piece; third?: Piece }) => {
+        const first = input?.first;
+        const second = input?.second;
+        const third = input?.third;
+        if (!first) return;
+        if (!second) return;
+        if (!third) return;
+        const updated: Piece[] = [];
+        updated.push(first);
+        updated.unshift(second);
+        updated.splice(1, 0, third);
+        state.items.set(updated);
+      };
+      `,
+    );
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const input = getPaths(summary, "input");
+
+    assert(input.identityPaths.includes("first"));
+    assert(input.identityPaths.includes("second"));
+    assert(input.identityPaths.includes("third"));
+    assert(input.identityCellPaths.includes("first"));
+    assert(input.identityCellPaths.includes("second"));
+    assert(input.identityCellPaths.includes("third"));
+    assertEquals(input.readPaths.includes("first"), false);
+    assertEquals(input.readPaths.includes("second"), false);
+    assertEquals(input.readPaths.includes("third"), false);
+  },
+);
+
+Deno.test(
+  "Capability analysis keeps splice control arguments structural",
+  () => {
+    const { program, sourceFile } = createProgramWithSource(
+      `
+      declare const CELL_BRAND: unique symbol;
+
+      type Cell<T> = {
+        readonly [CELL_BRAND]: "cell";
+        set(value: T): void;
+      };
+
+      interface Array<T> {
+        splice(start: number, deleteCount: number, ...items: T[]): T[];
+      }
+
+      declare const state: { items: Cell<Piece[]> };
+
+      type Piece = { title: string; unused: string };
+
+      const fn = (
+        input: { piece?: Piece; index: number; deleteCount: number },
+      ) => {
+        const piece = input?.piece;
+        if (!piece) return;
+        const updated: Piece[] = [];
+        updated.splice(input.index, input.deleteCount, piece);
+        state.items.set(updated);
+      };
+      `,
+    );
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const input = getPaths(summary, "input");
+
+    assert(input.identityPaths.includes("piece"));
+    assert(input.identityCellPaths.includes("piece"));
+    assert(input.readPaths.includes("index"));
+    assert(input.readPaths.includes("deleteCount"));
+    assertEquals(input.readPaths.includes("piece"), false);
+  },
+);
+
+Deno.test(
+  "Capability analysis keeps primitive local array writer payloads structural",
+  () => {
+    const { program, sourceFile } = createProgramWithSource(
+      `
+      declare const CELL_BRAND: unique symbol;
+
+      type Cell<T> = {
+        readonly [CELL_BRAND]: "cell";
+        set(value: T): void;
+      };
+
+      interface Array<T> {
+        push(...items: T[]): number;
+      }
+
+      declare const state: { items: Cell<string[]> };
+
+      type Piece = { title: string; unused: string };
+
+      const fn = (input: { piece: Piece }) => {
+        const updated: string[] = [];
+        updated.push(input.piece.title);
+        state.items.set(updated);
+      };
+      `,
+    );
+    const summary = analyzeFunctionCapabilities(
+      findArrowByVariableName(sourceFile, "fn"),
+      { checker: program.getTypeChecker() },
+    );
+    const input = getPaths(summary, "input");
+
+    assertEquals(input.identityPaths.includes("piece.title"), false);
+    assert(input.readPaths.includes("piece.title"));
+    assertEquals(input.readPaths.includes("piece.unused"), false);
+  },
+);
+
+Deno.test(
   "Capability analysis restores local array bindings after nested callbacks",
   () => {
     const { program, sourceFile } = createProgramWithSource(

--- a/packages/ts-transformers/test/type-shrinking.test.ts
+++ b/packages/ts-transformers/test/type-shrinking.test.ts
@@ -300,7 +300,7 @@ Deno.test("applyShrinkAndWrap turns identity-only wrapped inputs into OpaqueCell
       identityOnly: true,
       passthrough: true,
     }),
-    alias.type,
+    ts.factory.createTypeReferenceNode("Input"),
     baseType,
     true,
     checker,
@@ -356,7 +356,7 @@ Deno.test("applyShrinkAndWrap turns identity-only cell leaves into OpaqueCell<un
       identityPaths: [["left"], ["right"]],
       identityCellPaths: [["left"], ["right"]],
     }),
-    ts.factory.createTypeReferenceNode("Input"),
+    alias.type,
     baseType,
     false,
     checker,
@@ -369,6 +369,35 @@ Deno.test("applyShrinkAndWrap turns identity-only cell leaves into OpaqueCell<un
   assertStringIncludes(printed, "right: __cfHelpers.OpaqueCell<unknown>");
   assertEquals(printed.includes("name"), false);
   assertEquals(printed.includes("nested"), false);
+});
+
+Deno.test("applyShrinkAndWrap lets identity containers cover retained child paths", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = {
+      item: { active: boolean; name: string };
+      untouched: string;
+    };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      readPaths: [["item", "active"]],
+      identityPaths: [["item"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "item: unknown");
+  assertEquals(printed.includes("active"), false);
+  assertEquals(printed.includes("name"), false);
 });
 
 Deno.test("applyShrinkAndWrap shrinks direct array parameters to used item fields", () => {


### PR DESCRIPTION
## Summary

Tightens handler schema shrinking for identity-only payloads so recursive handler payload types do not leak full structural schemas when handlers only preserve identity.

- Treats handler payloads passed through identity-only array writes as `unknown`.
- Preserves writable array cell wrappers while shrinking array item schemas to `unknown`.
- Adds a red-green fixture covering `addPiece` and `trackRecent` style recursive payload handlers.

## Root Cause

The capability summary could identify some identity-only uses, but later shrinking and schema generation could recover the original recursive semantic type from registered type information. Array write paths also needed enough context to distinguish identity-only handler payload writes from local arrays that are later structurally inspected.

## Validation

- `FIXTURE=identity-only-handler-payload deno test -A test/fixture-based.test.ts`
- `deno test -A test/policy/capability-analysis.test.ts`
- `deno test -A test/type-shrinking.test.ts`
- `deno task cf check packages/patterns/system/default-app.tsx --show-transformed --no-run`
- pre-commit `deno fmt`
- pre-commit `deno lint`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens handler schema shrinking to stop recursive payloads from leaking when handlers only preserve identity. Identity-only payloads and array items now shrink to `unknown` while keeping array and element cell wrappers.

- **Bug Fixes**
  - Expands identity-only array detection to `push`, `unshift`, `splice` (value args only), `slice` chains, element spreads, and array‑literal locals passed to `.set`; only treats `.set` on cell-like receivers, ignores arrays inspected before `set`, and keeps primitive item writes structural.
  - Treats arguments to `equals` and `navigateTo` as identity-only; records identity without wildcarding and marks array item identity when identity args are written via array writers.
  - Injects item-level schema hints from capability summaries so formatters emit `items: { type: "unknown" }` and preserve outer and element cell wrappers.
  - Skips payload loading for truthiness checks on property aliases, including optional‑chained alias initializers and boolean conditions on local alias members.
  - Uses synthetic-node schema generation when type nodes contain `any`/`unknown` and avoids TypeRegistry transfer; improves shrinking for arrays/readonly arrays/unions/referenced types and skips shrinking when identity containers already cover retained paths.

<sup>Written for commit 8f60cf6a1a068a270527b0759d21f226ca2c80fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



NEW_PERF_BASELINE: subtest: pattern-unit-5/pattern-unit-tests > packages/patterns/simple-list/simple-list.test.tsx = 14s
