### PR TITLE
feat(ui): add sheet presentation mode to cf-modal

### DIFF
--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -3517,6 +3517,9 @@ interface CFModalAttributes<T> extends CFHTMLAttributes<T> {
   "$open"?: CellLike<boolean> | boolean;
   "dismissable"?: boolean;
   "size"?: "sm" | "md" | "lg" | "full";
+  "presentation"?: "dialog" | "sheet";
+  "grabber"?: boolean;
+  "detent"?: "auto" | "half" | "full";
   "prevent-scroll"?: boolean;
   "label"?: string;
   "oncf-modal-open"?: EventHandler<void>;

--- a/packages/patterns/catalog/stories/cf-modal-story.tsx
+++ b/packages/patterns/catalog/stories/cf-modal-story.tsx
@@ -18,6 +18,9 @@ export default pattern<ModalStoryInput, ModalStoryOutput>(() => {
   const open = Writable.of(false);
   const size = Writable.of<"sm" | "md" | "lg" | "full">("md");
   const dismissable = Writable.of(true);
+  const presentation = Writable.of<"dialog" | "sheet">("dialog");
+  const grabber = Writable.of(false);
+  const detent = Writable.of<"auto" | "half" | "full">("auto");
 
   const showModal = action(() => open.set(true));
   const closeModal = action(() => open.set(false));
@@ -30,7 +33,14 @@ export default pattern<ModalStoryInput, ModalStoryOutput>(() => {
           Open Modal
         </cf-button>
 
-        <cf-modal $open={open} size={size} dismissable={dismissable}>
+        <cf-modal
+          $open={open}
+          size={size}
+          dismissable={dismissable}
+          presentation={presentation}
+          grabber={grabber}
+          detent={detent}
+        >
           <div slot="header">
             <cf-heading level={4}>Modal Title</cf-heading>
           </div>
@@ -57,8 +67,18 @@ export default pattern<ModalStoryInput, ModalStoryOutput>(() => {
       <Controls>
         <>
           <SelectControl
+            label="presentation"
+            description="Layout mode: centered dialog or bottom sheet"
+            defaultValue="dialog"
+            value={presentation}
+            items={[
+              { label: "Dialog", value: "dialog" },
+              { label: "Sheet", value: "sheet" },
+            ]}
+          />
+          <SelectControl
             label="size"
-            description="Modal width preset"
+            description="Modal width preset (dialog mode only)"
             defaultValue="md"
             value={size}
             items={[
@@ -67,6 +87,23 @@ export default pattern<ModalStoryInput, ModalStoryOutput>(() => {
               { label: "Large", value: "lg" },
               { label: "Full", value: "full" },
             ]}
+          />
+          <SelectControl
+            label="detent"
+            description="Sheet max height (sheet mode only)"
+            defaultValue="auto"
+            value={detent}
+            items={[
+              { label: "Auto", value: "auto" },
+              { label: "Half", value: "half" },
+              { label: "Full", value: "full" },
+            ]}
+          />
+          <SwitchControl
+            label="grabber"
+            description="Show drag-handle indicator (sheet mode only)"
+            defaultValue="false"
+            checked={grabber}
           />
           <SwitchControl
             label="dismissable"

--- a/packages/ui/src/v2/components/cf-modal/cf-modal.ts
+++ b/packages/ui/src/v2/components/cf-modal/cf-modal.ts
@@ -86,6 +86,18 @@ export class CFModal extends BaseElement {
   @property({ type: String })
   accessor label: string | undefined = undefined;
 
+  /** Controls layout and animation: centered dialog vs. bottom sheet */
+  @property({ type: String, reflect: true })
+  accessor presentation: "dialog" | "sheet" = "dialog";
+
+  /** Show the drag-handle indicator (only visible in sheet mode) */
+  @property({ type: Boolean, reflect: true })
+  accessor grabber = false;
+
+  /** Sheet snap height: content-sized, half-screen, or near-full-screen */
+  @property({ type: String, reflect: true })
+  accessor detent: "auto" | "half" | "full" = "auto";
+
   /** Modal manager from context (optional - works standalone too) */
   @consume({ context: modalContext, subscribe: false })
   private accessor _manager: ModalManager | undefined = undefined;
@@ -122,6 +134,9 @@ export class CFModal extends BaseElement {
     this.dismissable = true;
     this.size = "md";
     this.preventScroll = true;
+    this.presentation = "dialog";
+    this.grabber = false;
+    this.detent = "auto";
   }
 
   /**
@@ -429,6 +444,7 @@ export class CFModal extends BaseElement {
           aria-modal="true"
           aria-label="${this.label || nothing}"
         >
+          <div class="grabber" part="grabber" aria-hidden="true"></div>
           <div
             class="header ${this._headerHasContent ? "" : "empty"}"
             part="header"

--- a/packages/ui/src/v2/components/cf-modal/styles.ts
+++ b/packages/ui/src/v2/components/cf-modal/styles.ts
@@ -186,56 +186,126 @@ export const modalStyles = css`
       width: 100%;
     }
 
-    /* ===== Mobile Bottom Sheet Transformation ===== */
-    @media (max-width: 480px) {
-      .container {
-        align-items: flex-end;
-        padding: 0;
+    /* ===== Sheet Presentation Mode ===== */
+
+    /* Grabber: hidden by default */
+    .grabber {
+      display: none;
+    }
+
+    /* Grabber visible when both presentation=sheet and grabber attr */
+    :host([presentation="sheet"][grabber]) .grabber {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 8px 0 4px;
+      flex-shrink: 0;
+    }
+
+    :host([presentation="sheet"][grabber]) .grabber::after {
+      content: "";
+      display: block;
+      width: 36px;
+      height: 4px;
+      border-radius: 2px;
+      background: var(--cf-modal-color-border, #e5e7eb);
+    }
+
+    /* Sheet container: bottom-aligned */
+    :host([presentation="sheet"]) .container {
+      align-items: flex-end;
+      padding: 0;
+    }
+
+    /* Sheet dialog: full-width, top-only border-radius */
+    :host([presentation="sheet"]) .dialog {
+      width: 100%;
+      border-radius: var(--_border-radius) var(--_border-radius) 0 0;
+      box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.15);
+
+      /* Sheet animation: slide up instead of scale */
+      transform: translateY(100%);
+      opacity: 1;
+      transition: transform var(--_animation-duration)
+        cubic-bezier(0.32, 0.72, 0, 1);
       }
 
-      .dialog {
-        width: 100%;
-        max-height: 85vh;
-        border-radius: var(--_border-radius) var(--_border-radius) 0 0;
-
-        /* Mobile: slide up animation instead of scale */
-        transform: translateY(100%);
+      :host([presentation="sheet"][open]) .dialog {
+        transform: translateY(0);
         opacity: 1;
       }
 
-      :host([open]) .dialog {
-        transform: translateY(0);
+      /* Sheet detent variants */
+      :host([presentation="sheet"][detent="auto"]) .dialog,
+      :host([presentation="sheet"]:not([detent])) .dialog {
+        max-height: 90vh;
       }
 
-      /* Drag handle indicator for sheet */
-      .dialog::before {
-        content: "";
-        display: block;
-        width: 36px;
-        height: 4px;
-        background: var(--cf-modal-color-border, #e5e7eb);
-        border-radius: 2px;
-        margin: 8px auto 0;
+      :host([presentation="sheet"][detent="half"]) .dialog {
+        max-height: 50vh;
       }
 
-      /* Adjust header for sheet layout */
-      .header {
-        padding-top: 8px;
+      :host([presentation="sheet"][detent="full"]) .dialog {
+        max-height: 92vh;
       }
 
-      /* Full width for size variants on mobile */
-      :host([size="sm"]) .dialog,
-      :host([size="md"]) .dialog,
-      :host([size="lg"]) .dialog {
+      /* Sheet overrides size variants */
+      :host([presentation="sheet"][size="sm"]) .dialog,
+      :host([presentation="sheet"][size="md"]) .dialog,
+      :host([presentation="sheet"][size="lg"]) .dialog {
         width: 100%;
       }
-    }
 
-    /* ===== Reduced Motion ===== */
-    @media (prefers-reduced-motion: reduce) {
-      .backdrop,
-      .dialog {
-        transition: none;
+      /* ===== Mobile Bottom Sheet Transformation ===== */
+      @media (max-width: 480px) {
+        .container {
+          align-items: flex-end;
+          padding: 0;
+        }
+
+        .dialog {
+          width: 100%;
+          max-height: 85vh;
+          border-radius: var(--_border-radius) var(--_border-radius) 0 0;
+
+          /* Mobile: slide up animation instead of scale */
+          transform: translateY(100%);
+          opacity: 1;
+        }
+
+        :host([open]) .dialog {
+          transform: translateY(0);
+        }
+
+        /* Drag handle indicator for sheet */
+        .dialog::before {
+          content: "";
+          display: block;
+          width: 36px;
+          height: 4px;
+          background: var(--cf-modal-color-border, #e5e7eb);
+          border-radius: 2px;
+          margin: 8px auto 0;
+        }
+
+        /* Adjust header for sheet layout */
+        .header {
+          padding-top: 8px;
+        }
+
+        /* Full width for size variants on mobile */
+        :host([size="sm"]) .dialog,
+        :host([size="md"]) .dialog,
+        :host([size="lg"]) .dialog {
+          width: 100%;
+        }
       }
-    }
-  `;
+
+      /* ===== Reduced Motion ===== */
+      @media (prefers-reduced-motion: reduce) {
+        .backdrop,
+        .dialog {
+          transition: none;
+        }
+      }
+    `;


### PR DESCRIPTION
## Summary
- Adds `presentation="sheet"` attribute to `cf-modal` for bottom-anchored sheet layout with iOS-style slide-up animation (`cubic-bezier(0.32, 0.72, 0, 1)`)
- `grabber` boolean attribute for decorative drag-handle indicator
- `detent` attribute (`"auto"` | `"half"` | `"full"`) for sheet max-height control
- Updated catalog story with interactive controls for all new properties

## Spec
See `docs/specs/cf-modal-sheet-presentation.md`

## Test plan
- [ ] Open modal story in catalog, toggle presentation to "sheet" — verify bottom-anchored slide-up
- [ ] Toggle grabber on/off — verify pill handle appears/disappears
- [ ] Switch detent between auto/half/full — verify height changes
- [ ] Confirm dialog mode is unchanged (no regressions)
- [ ] Verify Escape and backdrop dismiss work in sheet mode
- [ ] Check reduced-motion media query disables animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)