### PR TITLE
Small `content-hash` cleanup

### DIFF
--- a/packages/content-hash/src/BaseIncrementalHasher.ts
+++ b/packages/content-hash/src/BaseIncrementalHasher.ts
@@ -1,0 +1,28 @@
+import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
+import type { IncrementalHasher } from "./interface.ts";
+
+/**
+ * Base implementation for the `IncrementalHasher` interface.
+ */
+export abstract class BaseIncrementalHasher implements IncrementalHasher {
+  digest(): Uint8Array;
+  digest(encoding: "base64url"): string;
+  digest(encoding?: string): Uint8Array | string {
+    const result = this._rawDigest();
+
+    switch (encoding) {
+      case "base64url": {
+        return toUnpaddedBase64url(result);
+      }
+      case undefined: {
+        return result;
+      }
+      default: {
+        throw new Error(`Unknown encoding: ${encoding}`);
+      }
+    }
+  }
+
+  abstract update(data: Uint8Array): void;
+  protected abstract _rawDigest(): Uint8Array;
+}

--- a/packages/content-hash/src/sha256-noble.ts
+++ b/packages/content-hash/src/sha256-noble.ts
@@ -3,38 +3,22 @@
  */
 
 import { sha256 } from "@noble/hashes/sha2.js";
-import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
+import { BaseIncrementalHasher } from "./BaseIncrementalHasher.ts";
 import type { IncrementalHasher } from "./interface.ts";
-
-export type { IncrementalHasher, Sha256Fn } from "./interface.ts";
 
 /**
  * Noble-specific incremental hasher. Noble notably only has a one-shot digest
  * function.
  */
-class NobleHasher implements IncrementalHasher {
+class NobleHasher extends BaseIncrementalHasher {
   #hasher = sha256.create();
 
   update(data: Uint8Array) {
     this.#hasher.update(data);
   }
 
-  digest(): Uint8Array;
-  digest(encoding: "base64url"): string;
-  digest(encoding?: string): Uint8Array | string {
-    const result = this.#hasher.digest();
-
-    switch (encoding) {
-      case "base64url": {
-        return toUnpaddedBase64url(result);
-      }
-      case undefined: {
-        return result;
-      }
-      default: {
-        throw new Error(`Unknown encoding: ${encoding}`);
-      }
-    }
+  protected _rawDigest(): Uint8Array {
+    return this.#hasher.digest();
   }
 }
 

--- a/packages/content-hash/src/sha256-wasm.ts
+++ b/packages/content-hash/src/sha256-wasm.ts
@@ -3,7 +3,7 @@
  */
 
 import { createSHA256, type IHasher } from "hash-wasm";
-import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
+import { BaseIncrementalHasher } from "./BaseIncrementalHasher.ts";
 import type { IncrementalHasher } from "./interface.ts";
 
 /**
@@ -131,36 +131,10 @@ export function initWasm() {
 }
 
 /**
- * Base for WASM-specific incremental hashers.
- */
-abstract class BaseWasmHasher implements IncrementalHasher {
-  digest(): Uint8Array;
-  digest(encoding: "base64url"): string;
-  digest(encoding?: string): Uint8Array | string {
-    const result = this._rawDigest();
-
-    switch (encoding) {
-      case "base64url": {
-        return toUnpaddedBase64url(result);
-      }
-      case undefined: {
-        return result;
-      }
-      default: {
-        throw new Error(`Unknown encoding: ${encoding}`);
-      }
-    }
-  }
-
-  abstract update(data: Uint8Array): void;
-  protected abstract _rawDigest(): Uint8Array;
-}
-
-/**
  * WASM-specific incremental hasher which collects chunks and performs a
  * one-shot digest at the end of processing.
  */
-class WasmCollectingHasher extends BaseWasmHasher {
+class WasmCollectingHasher extends BaseIncrementalHasher {
   /** Finalized chunks. */
   #chunks: Uint8Array[] = [];
 
@@ -240,7 +214,7 @@ class WasmCollectingHasher extends BaseWasmHasher {
  * WASM-specific incremental hasher which has a direct hasher instance and
  * can `update()` it.
  */
-class WasmUpdatingHasher extends BaseWasmHasher {
+class WasmUpdatingHasher extends BaseIncrementalHasher {
   #hasher: IHasher | null = acquireHasher(this);
 
   update(data: Uint8Array) {


### PR DESCRIPTION
This small PR just cleans up the `content-hash` implementation a little by DRYing out commonality between the Noble and WASM versions.

## Performance Baseline

This PR does not change anything beyond factoring out common code and can reasonably be expected to run exactly the same as the pre-PR version, especially in that the one place that might have a tiny difference isn't even code that's run at all. So, the following accounts for a spurious performance check failure.

NEW_PERF_BASELINE: job: Package Integration Tests = 175s
