### PR TITLE
[codex] carry fuse follow-ups onto posix-agent

### DIFF
--- a/packages/cli/lib/fuse.ts
+++ b/packages/cli/lib/fuse.ts
@@ -214,7 +214,13 @@ export function isAlive(pid: number): boolean {
     // stopped processes. We just need to check if the process exists.
     Deno.kill(pid, "SIGURG");
     return true;
-  } catch {
+  } catch (error) {
+    // EPERM means the process exists, but the caller cannot signal it.
+    // This happens when a sandboxed caller probes a live daemon started
+    // outside that sandbox.
+    if (error instanceof Deno.errors.PermissionDenied) {
+      return true;
+    }
     return false;
   }
 }

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { basename, join, resolve, toFileUrl } from "@std/path";
+import { stub } from "@std/testing/mock";
 import {
   awaitBackgroundMountStartup,
   awaitForegroundMountExit,
@@ -491,6 +492,18 @@ describe("fuse help", () => {
 describe("isAlive", () => {
   it("returns true for the current process", () => {
     expect(isAlive(Deno.pid)).toBe(true);
+  });
+
+  it("returns true when signaling is denied", () => {
+    const killStub = stub(Deno, "kill", () => {
+      throw new Deno.errors.PermissionDenied("EPERM: Operation not permitted");
+    });
+
+    try {
+      expect(isAlive(18871)).toBe(true);
+    } finally {
+      killStub.restore();
+    }
   });
 
   it("returns false for a bogus PID", () => {

--- a/scripts/brighid-docker-cfc-host-mount.sh
+++ b/scripts/brighid-docker-cfc-host-mount.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+ACTION="${1:-restart}"
+MOUNT_NAME="${MOUNT_NAME:-ct-fuse-brighid-docker-cfc}"
+MOUNTPOINT="${MOUNTPOINT:-/tmp/$MOUNT_NAME}"
+IDENTITY="${IDENTITY:-/tmp/$MOUNT_NAME.id}"
+API_URL="${API_URL:-https://toolshed.saga-castor.ts.net}"
+DOCKER_RUNTIME="${BRIGHID_DOCKER_RUNTIME:-runsc-cfc}"
+
+ensure_safe_mountpoint() {
+  case "$MOUNTPOINT" in
+    /tmp/*) ;;
+    *)
+      echo "error: refusing to reset non-/tmp mountpoint: $MOUNTPOINT" >&2
+      exit 1
+      ;;
+  esac
+}
+
+print_env() {
+  cat <<EOF
+BRIGHID_FABRIC_HOST_PATH=$MOUNTPOINT
+BRIGHID_SANDBOX_RUNTIME=docker-cfc
+BRIGHID_DOCKER_RUNTIME=$DOCKER_RUNTIME
+EOF
+}
+
+ensure_identity() {
+  if [[ -s "$IDENTITY" ]]; then
+    return
+  fi
+
+  (
+    cd "$REPO_ROOT"
+    deno task cf id new > "$IDENTITY"
+  )
+  chmod 600 "$IDENTITY"
+}
+
+force_cleanup() {
+  ensure_safe_mountpoint
+
+  (
+    cd "$REPO_ROOT"
+    deno task cf fuse unmount "$MOUNTPOINT" >/dev/null 2>&1 || true
+  )
+
+  if mount | grep -F " on $MOUNTPOINT " >/dev/null 2>&1; then
+    umount "$MOUNTPOINT" >/dev/null 2>&1 || true
+  fi
+
+  if mount | grep -F " on $MOUNTPOINT " >/dev/null 2>&1 && command -v diskutil >/dev/null 2>&1; then
+    diskutil unmount force "$MOUNTPOINT" >/dev/null 2>&1 || true
+  fi
+
+  rm -rf "$MOUNTPOINT"
+  mkdir -p "$MOUNTPOINT"
+}
+
+restart_mount() {
+  ensure_identity
+  force_cleanup
+
+  (
+    cd "$REPO_ROOT"
+    deno task cf fuse mount "$MOUNTPOINT" \
+      --api-url="$API_URL" \
+      --identity="$IDENTITY" \
+      --allow-root \
+      --background
+  )
+
+  echo
+  print_env
+}
+
+case "$ACTION" in
+  restart|start)
+    restart_mount
+    ;;
+  stop)
+    force_cleanup
+    ;;
+  status)
+    (
+      cd "$REPO_ROOT"
+      deno task cf fuse status
+    )
+    ;;
+  env)
+    print_env
+    ;;
+  *)
+    echo "usage: $(basename "$0") [restart|start|stop|status|env]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- treat `EPERM` from `Deno.kill(..., "SIGURG")` as "alive" in `packages/cli/lib/fuse.ts` so `cf fuse status` does not misclassify a live daemon started outside the current sandbox
- add a focused regression test covering the `PermissionDenied` case
- add `scripts/brighid-docker-cfc-host-mount.sh` as a small wrapper around the standard `cf fuse mount --background` flow for restarting a host mount outside Codex

## Why
We confirmed that the macOS Docker + gVisor + cf-fuse path works when the standard background mount is launched from a normal terminal outside Codex and then reused from inside Codex. Two small follow-ups were still missing from current `posix-agent`:
- the fuse status liveness check treated `EPERM` as dead, so live outside-terminal daemons were hidden from `cf fuse status`
- restarting that standard mount path manually was repetitive enough to warrant a tiny wrapper script

## Validation
- `deno test --config deno.json --allow-env --allow-read --allow-write --allow-run packages/cli/test/fuse.test.ts`
- `bash -n scripts/brighid-docker-cfc-host-mount.sh`