### PR TITLE
fix(ts-transformer): Fix imported default union aliases

### DIFF
--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -316,7 +316,10 @@ export class UnionFormatter implements TypeFormatter {
     }
 
     const symbol = checker.getSymbolAtLocation(unwrapped.typeName);
-    const aliasDeclaration = symbol?.declarations?.find((
+    const resolvedSymbol = symbol && (symbol.flags & ts.SymbolFlags.Alias)
+      ? checker.getAliasedSymbol(symbol)
+      : symbol;
+    const aliasDeclaration = resolvedSymbol?.declarations?.find((
       declaration,
     ): declaration is ts.TypeAliasDeclaration =>
       ts.isTypeAliasDeclaration(declaration)

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -328,12 +328,21 @@ export class UnionFormatter implements TypeFormatter {
       return undefined;
     }
 
-    const aliasName = aliasDeclaration.name.text;
-    if (visited.has(aliasName)) {
-      throw new Error(`Circular type alias detected: ${aliasName}`);
+    const aliasKey = this.getTypeAliasDeclarationKey(aliasDeclaration);
+    if (visited.has(aliasKey)) {
+      throw new Error(
+        `Circular type alias detected: ${aliasDeclaration.name.text}`,
+      );
     }
-    visited.add(aliasName);
+    visited.add(aliasKey);
     return this.getUnionTypeNode(aliasDeclaration.type, checker, visited);
+  }
+
+  private getTypeAliasDeclarationKey(
+    declaration: ts.TypeAliasDeclaration,
+  ): string {
+    const sourceFile = declaration.getSourceFile();
+    return `${sourceFile.fileName}:${declaration.pos}:${declaration.end}`;
   }
 
   private getDefaultUnionEntry(

--- a/packages/schema-generator/test/schema/default-union.test.ts
+++ b/packages/schema-generator/test/schema/default-union.test.ts
@@ -81,6 +81,39 @@ describe("Schema: Default in unions", () => {
     });
   });
 
+  it("does not treat same-name imported aliases as circular", async () => {
+    const { type, checker } = await getTypeFromFiles(
+      {
+        "/base.ts": `
+        export interface Default<T, V extends T = T> {}
+        export type WithDefault = string | Default<"">;
+      `,
+        "/wrapper.ts": `
+        import type { WithDefault as ImportedWithDefault } from "./base.ts";
+        export type WithDefault = ImportedWithDefault;
+      `,
+        "/main.ts": `
+        import type { WithDefault } from "./wrapper.ts";
+        export interface X {
+          title: WithDefault;
+        }
+      `,
+      },
+      "/main.ts",
+      "X",
+    );
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker),
+    );
+
+    const title = result.properties?.title as any;
+    expect(title.$ref).toBe("#/$defs/WithDefault");
+    expect((result as any).$defs?.WithDefault).toEqual({
+      type: "string",
+      default: "",
+    });
+  });
+
   it("applies null defaults from T | Default<null>", async () => {
     const code = `
       interface Default<T, V extends T = T> {}

--- a/packages/schema-generator/test/schema/default-union.test.ts
+++ b/packages/schema-generator/test/schema/default-union.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSchemaTransformerV2 } from "../../src/plugin.ts";
-import { asObjectSchema, getTypeFromCode } from "../utils.ts";
+import { asObjectSchema, getTypeFromCode, getTypeFromFiles } from "../utils.ts";
 
 describe("Schema: Default in unions", () => {
   it("applies primitive defaults from T | Default<V>", async () => {
@@ -40,6 +40,35 @@ describe("Schema: Default in unions", () => {
       }
     `;
     const { type, checker } = await getTypeFromCode(code, "X");
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker),
+    );
+
+    const title = result.properties?.title as any;
+    expect(title.$ref).toBe("#/$defs/WithDefault");
+    expect((result as any).$defs?.WithDefault).toEqual({
+      type: "string",
+      default: "",
+    });
+  });
+
+  it("applies defaults through imported aliased union types", async () => {
+    const { type, checker } = await getTypeFromFiles(
+      {
+        "/types.ts": `
+        export interface Default<T, V extends T = T> {}
+        export type WithDefault = string | Default<"">;
+      `,
+        "/main.ts": `
+        import type { WithDefault } from "./types.ts";
+        export interface X {
+          title: WithDefault;
+        }
+      `,
+      },
+      "/main.ts",
+      "X",
+    );
     const result = asObjectSchema(
       createSchemaTransformerV2().generateSchema(type, checker),
     );

--- a/packages/schema-generator/test/utils.ts
+++ b/packages/schema-generator/test/utils.ts
@@ -47,6 +47,18 @@ async function getTypeScriptEnvironmentTypes(): Promise<
   return typeLibsCache;
 }
 
+function getLibSourceText(
+  name: string,
+  typeLibs: Record<string, string>,
+): string | undefined {
+  if (name === "lib.d.ts" || name.endsWith("/lib.d.ts")) {
+    return typeLibs.es2023;
+  }
+
+  const libName = name.toLowerCase().replace(".d.ts", "");
+  return typeLibs[libName];
+}
+
 export async function createTestProgram(
   code: string,
 ): Promise<
@@ -140,11 +152,110 @@ export async function createTestProgram(
   };
 }
 
+export async function createTestProgramFromFiles(
+  files: Record<string, string>,
+  entryFile: string,
+): Promise<
+  { program: ts.Program; checker: ts.TypeChecker; sourceFile: ts.SourceFile }
+> {
+  const normalizePath = (path: string) =>
+    path.startsWith("/") ? path : `/${path}`;
+  const normalizedEntry = normalizePath(entryFile);
+  const filesWithPrelude: Record<string, string> = {};
+  for (const [path, code] of Object.entries(files)) {
+    filesWithPrelude[normalizePath(path)] = `${CELL_BRAND_PRELUDE}\n${code}`;
+  }
+
+  const typeLibs = await getTypeScriptEnvironmentTypes();
+
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2023,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    allowImportingTsExtensions: true,
+    noEmit: true,
+    lib: ["ES2023", "DOM", "JSX"],
+    strict: true,
+    strictNullChecks: true,
+  };
+
+  const compilerHost: ts.CompilerHost = {
+    getSourceFile: (name) => {
+      const normalizedName = normalizePath(name);
+      const sourceText = filesWithPrelude[normalizedName] ??
+        getLibSourceText(name, typeLibs);
+      return sourceText === undefined ? undefined : ts.createSourceFile(
+        name,
+        sourceText,
+        compilerOptions.target!,
+        true,
+      );
+    },
+    writeFile: () => {},
+    getCurrentDirectory: () => "/",
+    getDirectories: () => [],
+    fileExists: (name) =>
+      filesWithPrelude[normalizePath(name)] !== undefined ||
+      getLibSourceText(name, typeLibs) !== undefined,
+    readFile: (name) =>
+      filesWithPrelude[normalizePath(name)] ?? getLibSourceText(name, typeLibs),
+    getCanonicalFileName: (f) => f,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    getDefaultLibFileName: () => "lib.d.ts",
+  };
+
+  const program = ts.createProgram(
+    Object.keys(filesWithPrelude),
+    compilerOptions,
+    compilerHost,
+  );
+  const sourceFile = program.getSourceFile(normalizedEntry);
+  if (!sourceFile) {
+    throw new Error(`Entry file ${entryFile} not found in test program`);
+  }
+
+  return {
+    program,
+    checker: program.getTypeChecker(),
+    sourceFile,
+  };
+}
+
 export async function getTypeFromCode(
   code: string,
   typeName: string,
 ): Promise<{ type: ts.Type; checker: ts.TypeChecker; typeNode?: ts.TypeNode }> {
   const { checker, sourceFile } = await createTestProgram(code);
+
+  let foundType: ts.Type | undefined;
+  let foundTypeNode: ts.TypeNode | undefined;
+
+  ts.forEachChild(sourceFile, (node) => {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === typeName) {
+      const symbol = checker.getSymbolAtLocation(node.name);
+      if (symbol) foundType = checker.getDeclaredTypeOfSymbol(symbol);
+    } else if (ts.isTypeAliasDeclaration(node) && node.name.text === typeName) {
+      foundType = checker.getTypeFromTypeNode(node.type);
+      foundTypeNode = node.type;
+    }
+  });
+
+  if (!foundType) throw new Error(`Type ${typeName} not found in code`);
+  return foundTypeNode
+    ? { type: foundType, checker, typeNode: foundTypeNode }
+    : { type: foundType, checker };
+}
+
+export async function getTypeFromFiles(
+  files: Record<string, string>,
+  entryFile: string,
+  typeName: string,
+): Promise<{ type: ts.Type; checker: ts.TypeChecker; typeNode?: ts.TypeNode }> {
+  const { checker, sourceFile } = await createTestProgramFromFiles(
+    files,
+    entryFile,
+  );
 
   let foundType: ts.Type | undefined;
   let foundTypeNode: ts.TypeNode | undefined;


### PR DESCRIPTION
## Summary

Fixes schema generation for imported aliases that wrap the new default-union syntax, for example:

```ts
import type { WithDefault } from "./types.ts";

interface X {
  title: WithDefault;
}
```

where `WithDefault` is defined in another file as `string | Default<"">`.

## Root Cause

`UnionFormatter.getUnionTypeNode()` only inspected the direct declarations returned by `checker.getSymbolAtLocation(...)`. For imported type aliases, that symbol is the import alias, so the formatter never reached the underlying `TypeAliasDeclaration` and fell back to formatting `Default<"">` as an empty object schema member.

## Changes

- Resolve TypeScript alias symbols with `checker.getAliasedSymbol(...)` before looking for the union type alias declaration.
- Add a cross-file schema-generator test for imported default-union aliases.
- Add a small multi-file TypeScript test-program helper for schema-generator tests.

## Validation

- Reproduced the failing imported-alias case before the fix.
- `deno test --allow-read --allow-write --allow-run --allow-env=API_URL,"TSC_*",NODE_INSPECTOR_IPC,VSCODE_INSPECTOR_OPTIONS,NODE_ENV test/schema/default-union.test.ts`
- `deno task test` in `packages/schema-generator`
- root `deno task check`
- root `deno task test`
- pre-commit `deno fmt` and `deno lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes schema generation for imported union aliases using Default<...> and improves cycle detection, so defaults resolve across files without empty object entries or false circular errors.

- **Bug Fixes**
  - Resolve import aliases with `checker.getAliasedSymbol(...)` before reading the underlying `TypeAliasDeclaration`.
  - Detect cycles by declaration (source file + span) instead of alias name to avoid cross-file false positives.
  - Add cross-file tests for imported `WithDefault = string | Default<"">` and same-name wrappers; add multi-file TS test helpers (`getTypeFromFiles`, `createTestProgramFromFiles`).

<sup>Written for commit 70652bdee0a6a2598dd23821539289194053e131. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

