### PR TITLE
More `content-hash` cleanup

### DIFF
--- a/packages/content-hash/src/InstancePool.ts
+++ b/packages/content-hash/src/InstancePool.ts
@@ -2,7 +2,6 @@
  * Pool of instances of some specific type, which can be `acquire()`d and
  * `release()`d, with support for recovering insstances which were never
  * `release()` before their owners got GCed.
- *
  */
 export class InstancePool<T extends WeakKey> {
   /** The instance pool. */

--- a/packages/content-hash/src/InstancePool.ts
+++ b/packages/content-hash/src/InstancePool.ts
@@ -1,0 +1,64 @@
+/**
+ * Pool of instances of some specific type, which can be `acquire()`d and
+ * `release()`d, with support for recovering insstances which were never
+ * `release()` before their owners got GCed.
+ *
+ */
+export class InstancePool<T extends WeakKey> {
+  /** The instance pool. */
+  #pool: T[] = [];
+
+  /** Finalization registry which repools "lost" instances. */
+  #repooler = new FinalizationRegistry((instance: T) => {
+    if (this.#pool.indexOf(instance) === -1) {
+      this.#pool.push(instance);
+    }
+  });
+
+  /**
+   * Gets a freshly-initialized instance, or throws an error indicating that
+   * no instance is available.
+   */
+  acquire(owner: WeakKey): T {
+    if (!this.canAcquire()) {
+      throw new Error("No instances available.");
+    }
+
+    const result = this.#pool.pop()!;
+    this._initInstance(result);
+
+    this.#repooler.register(owner, result, result);
+
+    return result;
+  }
+
+  /**
+   * Adds a new instance to the pool.
+   */
+  add(instance: T) {
+    this.#pool.push(instance);
+  }
+
+  /**
+   * Is there an instance available for acquisition?
+   */
+  canAcquire() {
+    return this.#pool.length !== 0;
+  }
+
+  /**
+   * Releases a previously-acquired instance.
+   */
+  release(instance: T) {
+    this.#repooler.unregister(instance);
+    this.#pool.push(instance);
+  }
+
+  /**
+   * Performs any necessary initialization of an instance. May be overridden
+   * by subclasses. Does nothing by default.
+   */
+  protected _initInstance(instance: T) {
+    // This space intentionally left blank.
+  }
+}

--- a/packages/content-hash/src/InstancePool.ts
+++ b/packages/content-hash/src/InstancePool.ts
@@ -57,7 +57,7 @@ export class InstancePool<T extends WeakKey> {
    * Performs any necessary initialization of an instance. May be overridden
    * by subclasses. Does nothing by default.
    */
-  protected _initInstance(instance: T) {
+  protected _initInstance(_instance: T) {
     // This space intentionally left blank.
   }
 }

--- a/packages/content-hash/src/sha256-deno.ts
+++ b/packages/content-hash/src/sha256-deno.ts
@@ -19,17 +19,20 @@ if (isDeno()) {
 }
 
 /**
- * Throws an error indicating that this module is not usable.
+ * Throws an error indicating that this module is not usable, if it is not in
+ * fact usable. Otherwise, does nothing.
  */
-function cantUse(): never {
-  throw new Error("Cannot use `sha256-deno` in this environment.");
+function assertUsable() {
+  if (crypto === null) {
+    throw new Error("Cannot use `sha256-deno` in this environment.");
+  }
 }
 
 /**
  * Deno-specific incremental hasher.
  */
 class DenoHasher extends BaseIncrementalHasher {
-  #hasher = (crypto === null) ? cantUse() : crypto.createHash("sha256");
+  #hasher = crypto!.createHash("sha256");
 
   _rawUpdate(data: Uint8Array) {
     this.#hasher.update(data);
@@ -67,14 +70,12 @@ export function canUseDeno() {
  * Performs a hash on a single array.
  */
 export function sha256Deno(payload: Uint8Array): Uint8Array {
-  if (crypto === null) {
-    cantUse();
-  }
+  assertUsable();
 
   // `node:crypto digest()` returns a `Buffer` (a `Uint8Array` subclass);
   // normalize it to plain `Uint8Array`, so downstream equality checks work
   // correctly.
-  const buf = crypto.createHash("sha256").update(payload).digest();
+  const buf = crypto!.createHash("sha256").update(payload).digest();
   return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
 }
 
@@ -82,5 +83,6 @@ export function sha256Deno(payload: Uint8Array): Uint8Array {
  * Creates an incremental hasher.
  */
 export function createHasherDeno(): IncrementalHasher {
+  assertUsable();
   return new DenoHasher();
 }

--- a/packages/content-hash/src/sha256-wasm.ts
+++ b/packages/content-hash/src/sha256-wasm.ts
@@ -7,6 +7,7 @@ import { BaseCollectingHasher } from "./BaseCollectingHasher.ts";
 import {
   BaseSmallChunkUpdatingHasher,
 } from "./BaseSmallChunkUpdatingHasher.ts";
+import { InstancePool } from "./InstancePool.ts";
 import type { IncrementalHasher } from "./interface.ts";
 
 /**
@@ -15,24 +16,20 @@ import type { IncrementalHasher } from "./interface.ts";
 const HASHER_POOL_SIZE = 5;
 
 /**
- * Pool of usable hasher instances. This array is populated at module init
- * time, a tactic that is necessary since this module exposes a synchronous
- * interface for actual hashing (once loaded), whereas `hash-wasm` only allows
+ * Pool of usable hasher instances. This is populated at module init time, a
+ * tactic that is necessary since this module exposes a synchronous interface
+ * for actual hashing (once loaded), whereas `hash-wasm` only allows
  * asynchronous hasher construction. Once constructed, though, hashers can be
  * used synchronously).
  */
-const theHashers: IHasher[] = [];
-
-/**
- * Finalization registry used to re-pool instances that were in use but whose
- * "public" facet (a `WasmUpdatingHasher`) never ended up releasing the
- * instance.
- */
-const hasherRepooler = new FinalizationRegistry((hasher: IHasher) => {
-  if (theHashers.indexOf(hasher) === -1) {
-    theHashers.push(hasher);
+class HasherPool extends InstancePool<IHasher> {
+  protected override _initInstance(instance: IHasher) {
+    instance.init();
   }
-});
+}
+
+/** Unique instance of `HasherPool`. */
+const hasherPool = new HasherPool();
 
 /**
  * A hasher instance which _isn't_ allowed to be acquired for concurrent use.
@@ -50,38 +47,6 @@ let initResult: Promise<boolean> | null = null;
  * Is this module actually usable?
  */
 let moduleIsUsable: boolean = false;
-
-/**
- * Is there an available hasher that could be acquired?
- */
-function canAcquireHasher(): boolean {
-  return theHashers.length !== 0;
-}
-
-/**
- * Gets a freshly-initialized hasher instance, or throws an error indicating
- * that this module is not usable.
- */
-function acquireHasher(owner: WasmUpdatingHasher): IHasher {
-  if (theHashers.length === 0) {
-    throw new Error("Too many concurrent hashers.");
-  }
-
-  const result = theHashers.pop()!;
-  result.init();
-
-  hasherRepooler.register(owner, result, result);
-
-  return result;
-}
-
-/**
- * Releases a previously-acquired hasher, or adds one to the pool.
- */
-function releaseHasher(hasher: IHasher) {
-  hasherRepooler.unregister(hasher);
-  theHashers.push(hasher);
-}
 
 /**
  * Gets and initializes the unique one-shot hasher instance.
@@ -112,15 +77,13 @@ export function initWasm() {
       try {
         theOneShotHasher.push(await createSHA256());
         for (let i = 0; i < HASHER_POOL_SIZE; i++) {
-          theHashers.push(await createSHA256());
+          hasherPool.add(await createSHA256());
         }
+        moduleIsUsable = true;
       } catch {
         // `hash-wasm` not available, or couldn't be fully initialized.
-        theOneShotHasher.length = 0;
-        theHashers.length = 0;
       }
 
-      moduleIsUsable = theHashers.length !== 0;
       return moduleIsUsable;
     })();
   }
@@ -152,7 +115,7 @@ class WasmCollectingHasher extends BaseCollectingHasher {
  * can `update()` it.
  */
 class WasmUpdatingHasher extends BaseSmallChunkUpdatingHasher {
-  #hasher: IHasher = acquireHasher(this);
+  #hasher: IHasher = hasherPool.acquire(this);
 
   protected _rawUpdate(data: Uint8Array) {
     this.#hasher.update(data);
@@ -162,7 +125,7 @@ class WasmUpdatingHasher extends BaseSmallChunkUpdatingHasher {
     const hasher = this.#hasher;
     const result: Uint8Array = hasher.digest("binary");
 
-    releaseHasher(hasher);
+    hasherPool.release(hasher);
     return result;
   }
 }
@@ -182,7 +145,7 @@ export function sha256Wasm(payload: Uint8Array): Uint8Array {
  */
 export function createHasherWasm(): IncrementalHasher {
   assertUsable();
-  return canAcquireHasher()
+  return hasherPool.canAcquire()
     ? new WasmUpdatingHasher()
     : new WasmCollectingHasher();
 }

--- a/packages/content-hash/src/sha256-wasm.ts
+++ b/packages/content-hash/src/sha256-wasm.ts
@@ -87,13 +87,19 @@ function releaseHasher(hasher: IHasher) {
  * Gets and initializes the unique one-shot hasher instance.
  */
 function getOneShotHasher(): IHasher {
-  if (!moduleIsUsable) {
-    throw new Error("Cannot use `sha256-wasm` in this environment.");
-  }
-
   const result = theOneShotHasher[0];
   result.init();
   return result;
+}
+
+/**
+ * Throws an error indicating that this module is not usable, if it is not in
+ * fact usable. Otherwise, does nothing.
+ */
+function assertUsable() {
+  if (!moduleIsUsable) {
+    throw new Error("Cannot use `sha256-wasm` in this environment.");
+  }
 }
 
 /**
@@ -175,6 +181,7 @@ export function sha256Wasm(payload: Uint8Array): Uint8Array {
  * Creates an incremental hasher.
  */
 export function createHasherWasm(): IncrementalHasher {
+  assertUsable();
   return canAcquireHasher()
     ? new WasmUpdatingHasher()
     : new WasmCollectingHasher();
@@ -188,5 +195,6 @@ export function createHasherWasm(): IncrementalHasher {
  * concurrency required by the test.)
  */
 export function createHasherWasmCollecting(): IncrementalHasher {
+  assertUsable();
   return new WasmCollectingHasher();
 }

--- a/packages/content-hash/src/sha256-wasm.ts
+++ b/packages/content-hash/src/sha256-wasm.ts
@@ -134,6 +134,7 @@ class WasmUpdatingHasher extends BaseSmallChunkUpdatingHasher {
  * Performs a hash on a single array.
  */
 export function sha256Wasm(payload: Uint8Array): Uint8Array {
+  assertUsable();
   const hasher = getOneShotHasher();
 
   hasher.update(payload);


### PR DESCRIPTION
This PR cleans up a bit more in `content-hash`:

* Made the "is this module usable?" checks more straightforward.
* Extracted `sha256-wasm`'s instance pooling facility into its own class, for both readability / understandability and for possible reuse.