### PR TITLE
Fix optional parentNotebook compile errors in note patterns

### DIFF
--- a/packages/patterns/notes/note-md.tsx
+++ b/packages/patterns/notes/note-md.tsx
@@ -156,7 +156,9 @@ export default pattern<NoteMdInput, NoteMdOutput>(
               Linked from:
             </span>
             <cf-hstack gap="2" wrap>
-              {note?.backlinks?.map((piece) => (
+              {(note?.backlinks as MentionablePiece[] | undefined)?.map((
+                piece,
+              ) => (
                 <cf-chip
                   label={piece?.[NAME] ?? "Untitled"}
                   interactive

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -142,9 +142,13 @@ const Note = pattern<NoteInput, NoteOutput>(
     content,
     isHidden,
     linkPattern,
-    parentNotebook,
+    parentNotebook: _parentNotebook,
     [SELF]: self,
   }) => {
+    // Ensure parentNotebook is always a Writable (input is optional)
+    const parentNotebook = _parentNotebook ??
+      Writable.of(null as NotebookPiece | null);
+
     // Type-based discovery for notebooks and "All Notes" piece
     const notebookWish = wish<NotebookPiece>({
       query: "#notebook",

--- a/packages/patterns/notes/notebook.tsx
+++ b/packages/patterns/notes/notebook.tsx
@@ -499,7 +499,19 @@ const toggleNoteCheckbox = handler<
 });
 
 const Notebook = pattern<NotebookInput, NotebookOutput>(
-  ({ title, notes, isNotebook, isHidden, parentNotebook, [SELF]: self }) => {
+  (
+    {
+      title,
+      notes,
+      isNotebook,
+      isHidden,
+      parentNotebook: _parentNotebook,
+      [SELF]: self,
+    },
+  ) => {
+    // Ensure parentNotebook is always a Writable (input is optional)
+    const parentNotebook = _parentNotebook ??
+      Writable.of(null as NotebookPiece | null);
     // Type-based discovery for notebooks and "All Notes" piece
     const notebookWish = wish<NotebookPiece>({
       query: "#notebook",


### PR DESCRIPTION
## Summary
- Default `parentNotebook` to `Writable.of(null)` when input is undefined in `note.tsx` and `notebook.tsx` — the input is optional but the pattern body and output type assume it's always present
- Cast `backlinks` array in `note-md.tsx` to fix `Default<>` union type making `.map()` uncallable

## Test plan
- [x] `cf check` passes on all three files
- [x] Deploy loom patterns without compile errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)