### PR TITLE
Sync source chain before CFC label lookup

### DIFF
--- a/packages/runner/src/ensure-piece-running.ts
+++ b/packages/runner/src/ensure-piece-running.ts
@@ -3,6 +3,7 @@ import { TYPE } from "./builder/types.ts";
 import type { Cell } from "./cell.ts";
 import { type NormalizedFullLink, parseLink } from "./link-utils.ts";
 import type { Runtime } from "./runtime.ts";
+import { syncSourceCellChain } from "./source-cell.ts";
 
 const logger = getLogger("ensure-piece-running", {
   enabled: false,
@@ -41,27 +42,14 @@ export async function ensurePieceRunning(
 
     try {
       // Get the cell at the event link location
-      let currentCell: Cell<any> | undefined = runtime.getCellFromLink(
+      const rootCell: Cell<any> = runtime.getCellFromLink(
         // We'll find the piece information at the root of what could be the
         // process cell already, hence remove the path:
         { ...cellLink, path: [] },
         undefined,
         tx,
       );
-      await currentCell.sync();
-
-      // Traverse up the source cell chain
-      // This follows links from derived cells back to the process cell
-      let sourceCell = currentCell.getSourceCell();
-      while (sourceCell) {
-        await sourceCell.sync();
-        logger.debug("ensure-piece", () => [
-          `Following source cell from ${currentCell?.getAsNormalizedFullLink().id} to ${sourceCell?.getAsNormalizedFullLink().id}`,
-        ]);
-        currentCell = sourceCell;
-        sourceCell = currentCell.getSourceCell();
-      }
-      await currentCell.sync();
+      const currentCell = await syncSourceCellChain(rootCell) ?? rootCell;
 
       // currentCell is now the process cell (or the original cell if no sources)
       // Check if it has a resultRef and a TYPE (indicating it's a process cell)

--- a/packages/runner/src/source-cell.ts
+++ b/packages/runner/src/source-cell.ts
@@ -1,0 +1,35 @@
+import { getLogger } from "@commonfabric/utils/logger";
+import type { Cell } from "./cell.ts";
+
+const logger = getLogger("source-cell", {
+  enabled: false,
+  level: "debug",
+});
+
+/**
+ * Sync a root cell and each source cell reachable from it.
+ *
+ * Callers that need a transactional root cell can create it first and pass it.
+ * Returns the last followed source cell, or undefined if the root has no source.
+ */
+export async function syncSourceCellChain(
+  rootCell: Cell<unknown>,
+): Promise<Cell<unknown> | undefined> {
+  await rootCell.sync();
+
+  let currentCell = rootCell;
+  let lastSourceCell: Cell<unknown> | undefined;
+  let sourceCell = currentCell.getSourceCell();
+  while (sourceCell) {
+    const nextCell = sourceCell;
+    await nextCell.sync();
+    logger.debug("follow-source", () => [
+      `Following source cell from ${currentCell.getAsNormalizedFullLink().id} to ${nextCell.getAsNormalizedFullLink().id}`,
+    ]);
+    lastSourceCell = nextCell;
+    currentCell = nextCell;
+    sourceCell = currentCell.getSourceCell();
+  }
+
+  return lastSourceCell;
+}

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -381,7 +381,7 @@ describe("RuntimeProcessor diagnosis helpers", () => {
 });
 
 describe("RuntimeProcessor CFC label IPC", () => {
-  it("returns a label view for a cell ref", () => {
+  it("returns a label view for a cell ref", async () => {
     const ref: CellRef = {
       id: "of:cfc-label-cell" as CellRef["id"],
       space: "did:key:test" as CellRef["space"],
@@ -410,16 +410,18 @@ describe("RuntimeProcessor CFC label IPC", () => {
             }),
           },
           getAsNormalizedFullLink: () => ref,
+          getSourceCell: () => undefined,
+          sync: () => Promise.resolve(),
         }),
       },
     } as unknown as RuntimeProcessor;
 
-    expect(
+    await expect(
       RuntimeProcessor.prototype.handleCellGetCfcLabel.call(processor, {
         type: RequestType.CellGetCfcLabel,
         cell: ref,
       }),
-    ).toEqual({
+    ).resolves.toEqual({
       cfcLabel: {
         version: 1,
         entries: [{
@@ -428,6 +430,81 @@ describe("RuntimeProcessor CFC label IPC", () => {
         }],
       },
     });
+  });
+
+  it("syncs a result cell before looking up CFC from its source", async () => {
+    const resultRef: CellRef = {
+      id: "of:cfc-label-result" as CellRef["id"],
+      space: "did:key:test" as CellRef["space"],
+      type: "application/json",
+      path: [],
+    };
+    const sourceRef: CellRef = {
+      id: "of:cfc-label-source" as CellRef["id"],
+      space: "did:key:test" as CellRef["space"],
+      type: "application/json",
+      path: [],
+    };
+    let resultSynced = false;
+    let sourceSynced = false;
+    const runtime = {
+      readTx: () => ({
+        readOrThrow: (address: { id: string }) =>
+          address.id === sourceRef.id
+            ? {
+              value: "process cell",
+              cfc: {
+                version: 1,
+                schemaHash: "test-schema",
+                labelMap: {
+                  version: 1,
+                  entries: [{
+                    path: [],
+                    label: { confidentiality: ["source-label"] },
+                  }],
+                },
+              },
+            }
+            : { value: "result cell" },
+      }),
+      getCellFromLink: () => resultCell,
+    };
+    const sourceCell = {
+      runtime,
+      getAsNormalizedFullLink: () => sourceRef,
+      getSourceCell: () => undefined,
+      sync: () => {
+        sourceSynced = true;
+        return Promise.resolve();
+      },
+    };
+    const resultCell = {
+      runtime,
+      getAsNormalizedFullLink: () => resultRef,
+      getSourceCell: () => resultSynced ? sourceCell : undefined,
+      sync: () => {
+        resultSynced = true;
+        return Promise.resolve();
+      },
+    };
+    const processor = { runtime } as unknown as RuntimeProcessor;
+
+    await expect(Promise.resolve(
+      RuntimeProcessor.prototype.handleCellGetCfcLabel.call(processor, {
+        type: RequestType.CellGetCfcLabel,
+        cell: resultRef,
+      }),
+    )).resolves.toEqual({
+      cfcLabel: {
+        version: 1,
+        entries: [{
+          path: [],
+          label: { confidentiality: ["source-label"] },
+        }],
+      },
+    });
+    expect(resultSynced).toBe(true);
+    expect(sourceSynced).toBe(true);
   });
 });
 

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -33,6 +33,7 @@ import {
   type NormalizedFullLink,
   parseLink,
 } from "../../runner/src/link-utils.ts";
+import { syncSourceCellChain } from "../../runner/src/source-cell.ts";
 import {
   type ActionRunTraceResponse,
   BooleanResponse,
@@ -543,10 +544,16 @@ export class RuntimeProcessor {
     };
   }
 
-  handleCellGetCfcLabel(
+  async handleCellGetCfcLabel(
     request: CellGetCfcLabelRequest,
-  ): CfcLabelViewResponse {
+  ): Promise<CfcLabelViewResponse> {
     const cell = getCell(this.runtime, request.cell);
+    const rootCell = this.runtime.getCellFromLink({
+      ...cell.getAsNormalizedFullLink(),
+      path: [],
+    });
+    await syncSourceCellChain(rootCell);
+    await cell.sync();
     return {
       cfcLabel: cfcLabelViewForCell(cell),
     };
@@ -921,7 +928,7 @@ export class RuntimeProcessor {
       case RequestType.CellResolveAsCell:
         return this.handleCellResolveAsCell(request);
       case RequestType.CellGetCfcLabel:
-        return this.handleCellGetCfcLabel(request);
+        return await this.handleCellGetCfcLabel(request);
       case RequestType.GetCell:
         return this.handleGetCell(request);
       case RequestType.GetHomeSpaceCell:


### PR DESCRIPTION
One of the cfc integration tests was failing when I made unrelated changes. It looks like those happen because of a timing issue with setting up the cfc and reading the source. Since the runtime-client assumes only watches value changes, it doesn't re-evaluate when the cfc becomes defined later.

This PR changes that by recursively syncing the source cells and awaiting the results when we attempt to get the cfc label.

---

Factor the source-cell traversal used by ensurePieceRunning into a shared runner helper that syncs the root cell and each source cell in the chain. Use that helper from the runtime-client CFC label IPC path before computing the label view, so direct label lookups have the same source metadata available as query/subscription-backed paths.

Add coverage for the case where a result cell only exposes its source after syncing and the CFC label must be read from that source cell.

---
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/battleship/multiplayer/lobby.test.tsx = 15s

Slower performance may be justified, since we weren't waiting for cfc data before.

I'm not certain this is the right overall approach for synchronization between the runtime-client, and the storage system. The storage system should have access to all the chained sources already, from the query system.

I'm planning on a slightly broader enhancement to this in a later PR, where I subscribe to metadata changes. The Cell.sink system only watches `value` changes, but changes to `cfc`, `source`, and other similar metadata fields should also have a way to subscribe to updates. That approach would solve this problem, since the `source.sync` would trigger an update when the source is resolved. However, since we're already in an async function, it seems reasonable to just await the sync in this particular case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the source cell chain before CFC label lookups so label views use source metadata reliably. Extracted traversal into `syncSourceCellChain` and used it in the CFC label IPC path and `ensurePieceRunning`.

- **Bug Fixes**
  - CFC label IPC now syncs the root and each source cell before computing the label.
  - Handles result cells that reveal a source only after sync; reads the label from the source. Adds tests.

- **Refactors**
  - Added `packages/runner/src/source-cell.ts` with `syncSourceCellChain`.
  - Reused the helper in `ensurePieceRunning` to remove duplicate traversal logic.

<sup>Written for commit 6e7631310249edb1f98596154355d933e7d1cf2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

