### PR TITLE
[codex] Fix cf-harness gateway docs

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -105,11 +105,13 @@ deno task run -- \
 
 Current caveat:
 
-- the stage gateway at
+- the default gateway target is still the stage endpoint at
   [https://llm.stage.commontools.dev/](https://llm.stage.commontools.dev/)
-  currently answers `GET /v1/models` but fails `POST /v1/chat/completions` even
-  in no-auth mode; that is currently treated as a gateway-side issue rather than
-  a `cf-harness` request-shape issue
+- gateway auth defaults remain an ergonomics question:
+  - standalone `cf-harness` still defaults to `bearer`
+  - Loom's `cf-harness` adapter defaults to `none`
+- confirm the intended gateway/auth mode for the environment you are testing
+  against
 
 ## Testing
 

--- a/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
@@ -171,12 +171,13 @@ At the current checkpoint, the package has:
 - a local commit checkpoint on `codex/cf-harness-skeleton`:
   - `9208ac17a` `Add cf-harness policy and gateway controls`
 
-The stage gateway caveat is important:
+The earlier stage gateway caveat has been resolved, but one auth-defaulting
+question remains important:
 
-- unauthenticated `GET /v1/models` works
-- unauthenticated `POST /v1/chat/completions` currently fails
-- current evidence points to a gateway-side issue on chat completions rather
-  than a `cf-harness` request-shape bug
+- standalone `cf-harness` still defaults to `bearer`
+- Loom's `cf-harness` adapter defaults to `none`
+- that split is intentional for now, but it means operator behavior differs
+  between the package CLI and the Loom batch adapter
 
 ## What Comes Next
 


### PR DESCRIPTION
## Summary
- remove the stale claim that the stage gateway is known to fail chat completions
- document the real remaining caveat: auth-mode defaults differ between standalone `cf-harness` and the Loom adapter
- keep the docs aligned with the current Loom testing path

## Why
The current `cf-harness` docs still describe an older gateway failure diagnosis that is no longer the right operational guidance. That stale note makes Loom setup/debugging look blocked on gateway auth before the vendored package path is even in place.

## Validation
- `deno fmt packages/cf-harness/README.md packages/cf-harness/docs/IMPLEMENTATION_PLAN.md`
- `git diff --check`