### PR TITLE
fix(runner): Restore stream markers during setup

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -122,6 +122,38 @@ const processCellSetupSchema = (pattern: Pattern): JSONSchema => ({
   required: [TYPE] as const,
 });
 
+function restoreStreamMarkers(
+  target: FabricValue,
+  source: FabricValue,
+): boolean {
+  if (!isRecord(target) || !isRecord(source)) return false;
+
+  let restored = false;
+  for (const [key, value] of Object.entries(source)) {
+    if (isStreamValue(value)) {
+      target[key] = cellAwareDeepCopy(value);
+      restored = true;
+      continue;
+    }
+
+    if (!isRecord(value)) continue;
+
+    const targetValue = target[key];
+    const nextTarget = isRecord(targetValue)
+      ? targetValue
+      : Array.isArray(value)
+      ? []
+      : {};
+
+    if (restoreStreamMarkers(nextTarget as FabricValue, value as FabricValue)) {
+      target[key] = nextTarget;
+      restored = true;
+    }
+  }
+
+  return restored;
+}
+
 const recordOutputSchemaPolicyInputs = (
   tx: IExtendedStorageTransaction,
   runtime: Runtime,
@@ -549,18 +581,20 @@ export class Runner {
       meta: ignoreReadForScheduling,
       frozen: false,
     });
+    const initialInternal = cellAwareDeepCopy(
+      isRecord(pattern.initial) && isRecord(pattern.initial.internal)
+        ? pattern.initial.internal
+        : {},
+    );
     const internal = Object.assign(
       {},
       cellAwareDeepCopy(
         (defaults as unknown as { internal: FabricValue })?.internal,
       ),
-      cellAwareDeepCopy(
-        isRecord(pattern.initial) && isRecord(pattern.initial.internal)
-          ? pattern.initial.internal
-          : {},
-      ),
+      initialInternal,
       isRecord(previousInternal) ? previousInternal : {},
     ) as FabricValue;
+    restoreStreamMarkers(internal, initialInternal);
 
     let nextArgument = argument;
     if (

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -206,6 +206,46 @@ describe("module", () => {
       });
     });
 
+    it("serializes array stream causes as one stable internal path segment", () => {
+      const clickHandler = handler(
+        false,
+        false,
+        (_event: unknown, _state: unknown) => {},
+      );
+
+      const clickPattern = pattern(() => {
+        const click = clickHandler({} as never).for(
+          { stream: ["__patternResult", "click"] },
+          true,
+        );
+        return { click };
+      });
+
+      const streamKey = 'stream:["__patternResult","click"]';
+      expect(clickPattern.result).toEqual({
+        click: {
+          $alias: {
+            path: ["internal", streamKey],
+            schema: true,
+          },
+        },
+      });
+      expect(clickPattern.initial).toEqual({
+        internal: {
+          [streamKey]: { $stream: true },
+        },
+      });
+      const handlerInputs = clickPattern.nodes[0].inputs as {
+        $event: unknown;
+      };
+      expect(handlerInputs.$event).toEqual({
+        $alias: {
+          path: ["internal", streamKey],
+          schema: true,
+        },
+      });
+    });
+
     it("serializes array causes as stable internal path segments", () => {
       const arrayCausePattern = pattern(() => {
         const value = new CellImpl<number>(

--- a/packages/runner/test/patterns-handlers.test.ts
+++ b/packages/runner/test/patterns-handlers.test.ts
@@ -87,6 +87,82 @@ describe("Pattern Runner - Handlers", () => {
     expect(value).toMatchObject({ counter: { value: 3 } });
   });
 
+  it("restores nested stream markers when rerunning with previous internal state", async () => {
+    const incHandler = handler<
+      { amount: number },
+      { counter: { value: number } }
+    >(
+      ({ amount }, { counter }) => {
+        counter.value += amount;
+      },
+      { proxy: true },
+    );
+
+    const incPattern = pattern<{ counter: { value: number } }>(
+      ({ counter }) => {
+        const stream = incHandler({ counter }).for(
+          { stream: "increment" },
+          true,
+        );
+        return { counter, stream };
+      },
+    );
+    const streamPath = ["internal", "group", "stream:increment"];
+    const streamAlias = () => ({
+      $alias: { path: [...streamPath], schema: true },
+    });
+    (incPattern.result as any).stream = streamAlias();
+    const handlerNode = incPattern.nodes.find((node) =>
+      typeof node.inputs === "object" &&
+      node.inputs !== null &&
+      "$event" in node.inputs
+    );
+    expect(handlerNode).toBeDefined();
+    (handlerNode!.inputs as any).$event = streamAlias();
+    (incPattern.initial as any).internal = {
+      group: {
+        "stream:increment": { $stream: true },
+        stableState: "initial",
+      },
+    };
+
+    const resultCell = runtime.getCell<
+      { counter: { value: number }; stream: any }
+    >(space, "restores nested stream markers", undefined, tx);
+    const result = runtime.run(tx, incPattern, {
+      counter: { value: 0 },
+    }, resultCell);
+    await tx.commit();
+    await result.pull();
+
+    tx = runtime.edit();
+    runtime.runner.stop(resultCell);
+    const processCell = result.withTx(tx).getSourceCell();
+    expect(processCell).toBeDefined();
+    processCell!.key("internal").key("group").setRawUntyped({
+      stableState: "preserved",
+    });
+    await tx.commit();
+
+    tx = runtime.edit();
+    expect(() =>
+      runtime.run(tx, incPattern, {
+        counter: { value: 0 },
+      }, resultCell.withTx(tx))
+    ).not.toThrow();
+    await tx.commit();
+
+    tx = runtime.edit();
+    const restoredGroup = resultCell.withTx(tx).getSourceCell()!
+      .key("internal")
+      .key("group")
+      .getRawUntyped();
+    expect(restoredGroup).toEqual({
+      "stream:increment": { $stream: true },
+      stableState: "preserved",
+    });
+  });
+
   it("defers handler registration for retryable setup transactions until commit", async () => {
     const addEventHandlerSpy = spy(runtime.scheduler, "addEventHandler");
 


### PR DESCRIPTION
## Summary

- Recursively restore `$stream: true` markers from the pattern initial internal state after setup merges preserved internal state.
- Add a regression covering rerunning a handler pattern when preserved nested internal state would otherwise drop a stream marker.
- Add coverage that array stream causes serialize as one stable internal path segment.

## Root Cause

`applySetupState` merged `pattern.initial.internal` and preserved `previousInternal` with a shallow `Object.assign`. If preserved state replaced a parent internal object, nested stream sentinels from the current pattern initial state could be omitted before handler startup. Handler detection then read a non-stream or missing value and treated the handler as a lift, producing the `$stream: true` overwritten error.

## Validation

- `deno test -A packages/runner/test/module.test.ts packages/runner/test/patterns-handlers.test.ts`
- `deno task integration patterns`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `$stream: true` markers during runner setup so handler streams survive state merges. Fixes misclassification of handlers as lifts and eliminates the “$stream: true overwritten” error.

- **Bug Fixes**
  - Added `restoreStreamMarkers()` to recursively reapply stream sentinels from `pattern.initial.internal` after merging defaults and preserved state.
  - Deep-copied `initialInternal`, merged with previous internal, then restored markers to keep nested streams intact.
  - Added tests for reruns with preserved nested internal state and for serializing array stream causes into a single stable internal path key.

<sup>Written for commit 89f969dfaf0ee5b9a0a926e0126e53ebf68d97ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

