### PR TITLE
perf(runner): intern schema-hash cache keys to close modern-schema-hash regression

### DIFF
--- a/packages/data-model/schema-hash.ts
+++ b/packages/data-model/schema-hash.ts
@@ -333,8 +333,20 @@ export function isInternedSchema(schema: JSONSchema): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Interned cache-key helper
+// Interned cache-key helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Interns (and thus deep-freezes) the given schema, returning its hash
+ * string. Equivalent to `internSchema(schema, true).hashString`, but names
+ * the operation and avoids the non-obvious `true` (`wantSchemaAndHash`)
+ * argument at call sites. Intended for building stable cache-key strings
+ * that also benefit from `internSchema`'s identity-stable WeakMap
+ * fast-path on repeat lookups.
+ */
+export function internSchemaHashString(schema: JSONSchema): string {
+  return internSchema(schema, true).hashString;
+}
 
 /**
  * Returns a cache-key string for an ordered pair of schemas, each interned
@@ -351,7 +363,5 @@ export function isInternedSchema(schema: JSONSchema): boolean {
  * for the motivating regression.
  */
 export function internedPairKey(a: JSONSchema, b: JSONSchema): string {
-  return `${internSchema(a, true).hashString}|${
-    internSchema(b, true).hashString
-  }`;
+  return `${internSchemaHashString(a)}|${internSchemaHashString(b)}`;
 }

--- a/packages/data-model/schema-hash.ts
+++ b/packages/data-model/schema-hash.ts
@@ -342,8 +342,9 @@ export function isInternedSchema(schema: JSONSchema): boolean {
 /**
  * Returns a stable cache-key string for a schema, interning the schema (and
  * thus deep-freezing it) if it's an object. Boolean schemas map to sentinel
- * strings (`"T"`, `"F"`) that cannot overlap with any object-schema hash
- * string (which is base64url-encoded and always longer than one character).
+ * strings (`"<schema:true>"`, `"<schema:false>"`) that cannot overlap with
+ * any object-schema hash string (hash strings are base64url, so `<`, `>`,
+ * and `:` never appear in them).
  *
  * Intended for building cache keys at sites that would otherwise compute
  * `hashSchema(schema).toString()`. The interning step lets subsequent calls
@@ -353,7 +354,9 @@ export function isInternedSchema(schema: JSONSchema): boolean {
  * the motivating regression.
  */
 export function internSchemaKey(schema: JSONSchema): string {
-  if (typeof schema === "boolean") return schema ? "T" : "F";
+  if (typeof schema === "boolean") {
+    return schema ? "<schema:true>" : "<schema:false>";
+  }
   return internSchema(schema, true).hashString;
 }
 

--- a/packages/data-model/schema-hash.ts
+++ b/packages/data-model/schema-hash.ts
@@ -334,3 +334,40 @@ export function isInternedSchema(schema: JSONSchema): boolean {
 
   return schemaToSah.has(schema);
 }
+
+// ---------------------------------------------------------------------------
+// Interned cache-key helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a stable cache-key string for a schema, interning the schema (and
+ * thus deep-freezing it) if it's an object. Boolean schemas map to sentinel
+ * strings (`"T"`, `"F"`) that cannot overlap with any object-schema hash
+ * string (which is base64url-encoded and always longer than one character).
+ *
+ * Intended for building cache keys at sites that would otherwise compute
+ * `hashSchema(schema).toString()`. The interning step lets subsequent calls
+ * with the same (now-interned) object identity hit `internSchema`'s WeakMap
+ * in O(1) rather than re-hashing. See
+ * `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` §1 for
+ * the motivating regression.
+ */
+export function internSchemaKey(schema: JSONSchema): string {
+  if (typeof schema === "boolean") return schema ? "T" : "F";
+  return internSchema(schema, true).hashString;
+}
+
+/**
+ * Returns a cache-key string for an ordered pair of schemas, each interned
+ * via `internSchemaKey`. Equivalent to
+ * `${internSchemaKey(a)}|${internSchemaKey(b)}`. The `|` delimiter cannot
+ * appear in a base64url hash string and is distinct from the boolean
+ * sentinels, so the pair is unambiguously decodable (though callers only
+ * need it as an opaque key).
+ *
+ * Used at the handful of `traverse.ts` sites that key an intern cache on a
+ * merge operation's two input schemas.
+ */
+export function internedPairKey(a: JSONSchema, b: JSONSchema): string {
+  return `${internSchemaKey(a)}|${internSchemaKey(b)}`;
+}

--- a/packages/data-model/schema-hash.ts
+++ b/packages/data-model/schema-hash.ts
@@ -336,41 +336,25 @@ export function isInternedSchema(schema: JSONSchema): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Interned cache-key helpers
+// Interned cache-key helper
 // ---------------------------------------------------------------------------
 
 /**
- * Returns a stable cache-key string for a schema, interning the schema (and
- * thus deep-freezing it) if it's an object. Boolean schemas map to sentinel
- * strings (`"<schema:true>"`, `"<schema:false>"`) that cannot overlap with
- * any object-schema hash string (hash strings are base64url, so `<`, `>`,
- * and `:` never appear in them).
- *
- * Intended for building cache keys at sites that would otherwise compute
- * `hashSchema(schema).toString()`. The interning step lets subsequent calls
- * with the same (now-interned) object identity hit `internSchema`'s WeakMap
- * in O(1) rather than re-hashing. See
- * `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` §1 for
- * the motivating regression.
- */
-export function internSchemaKey(schema: JSONSchema): string {
-  if (typeof schema === "boolean") {
-    return schema ? "<schema:true>" : "<schema:false>";
-  }
-  return internSchema(schema, true).hashString;
-}
-
-/**
  * Returns a cache-key string for an ordered pair of schemas, each interned
- * via `internSchemaKey`. Equivalent to
- * `${internSchemaKey(a)}|${internSchemaKey(b)}`. The `|` delimiter cannot
- * appear in a base64url hash string and is distinct from the boolean
- * sentinels, so the pair is unambiguously decodable (though callers only
- * need it as an opaque key).
+ * (and thus deep-frozen) via `internSchema`. The `|` delimiter is outside
+ * the base64url alphabet used by hash strings, so the two halves cannot
+ * merge ambiguously.
  *
- * Used at the handful of `traverse.ts` sites that key an intern cache on a
- * merge operation's two input schemas.
+ * Used at the `traverse.ts` sites that key an intern cache on a merge
+ * operation's two input schemas. Interning the inputs stabilizes their
+ * identities in `internSchema`'s WeakMap, so subsequent calls with the
+ * same object references hit the hash-cache fast path in O(1) rather
+ * than re-hashing. See
+ * `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` §1
+ * for the motivating regression.
  */
 export function internedPairKey(a: JSONSchema, b: JSONSchema): string {
-  return `${internSchemaKey(a)}|${internSchemaKey(b)}`;
+  return `${internSchema(a, true).hashString}|${
+    internSchema(b, true).hashString
+  }`;
 }

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -317,12 +317,12 @@ describe("schema-hash dispatch", () => {
       });
 
       describe("internSchemaKey()", () => {
-        it('returns `"T"` for the `true` schema', () => {
-          assertStrictEquals(internSchemaKey(true), "T");
+        it('returns `"<schema:true>"` for the `true` schema', () => {
+          assertStrictEquals(internSchemaKey(true), "<schema:true>");
         });
 
-        it('returns `"F"` for the `false` schema', () => {
-          assertStrictEquals(internSchemaKey(false), "F");
+        it('returns `"<schema:false>"` for the `false` schema', () => {
+          assertStrictEquals(internSchemaKey(false), "<schema:false>");
         });
 
         it("returns the interned schema's `hashString` for objects", () => {
@@ -385,13 +385,16 @@ describe("schema-hash dispatch", () => {
           const obj: JSONSchema = { type: "number" };
           assertStrictEquals(
             internedPairKey(true, obj),
-            `T|${internSchemaKey(obj)}`,
+            `<schema:true>|${internSchemaKey(obj)}`,
           );
           assertStrictEquals(
             internedPairKey(obj, false),
-            `${internSchemaKey(obj)}|F`,
+            `${internSchemaKey(obj)}|<schema:false>`,
           );
-          assertStrictEquals(internedPairKey(true, false), "T|F");
+          assertStrictEquals(
+            internedPairKey(true, false),
+            "<schema:true>|<schema:false>",
+          );
         });
 
         it("is order-sensitive", () => {

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -12,6 +12,7 @@ import {
   hashSchemaItem,
   internedPairKey,
   internSchema,
+  internSchemaHashString,
   isInternedSchema,
   resetSchemaHashConfig,
   setSchemaHashConfig,
@@ -313,6 +314,65 @@ describe("schema-hash dispatch", () => {
             });
           });
         }
+      });
+
+      describe("internSchemaHashString()", () => {
+        it("returns the interned schema's hashString for an object", () => {
+          const schema: JSONSchema = { type: "number" };
+          const sah = internSchema(schema, true);
+          assertStrictEquals(internSchemaHashString(schema), sah.hashString);
+        });
+
+        it("returns the boolean schema's prefab hashString for `true`", () => {
+          const expected = internSchema(true, true).hashString;
+          assertStrictEquals(internSchemaHashString(true), expected);
+        });
+
+        it("returns the boolean schema's prefab hashString for `false`", () => {
+          const expected = internSchema(false, true).hashString;
+          assertStrictEquals(internSchemaHashString(false), expected);
+        });
+
+        it("produces matching strings for structurally-equal objects", () => {
+          const a: JSONSchema = {
+            type: "object",
+            properties: { x: { type: "string" } },
+          };
+          const b: JSONSchema = {
+            type: "object",
+            properties: { x: { type: "string" } },
+          };
+          assertStrictEquals(
+            internSchemaHashString(a),
+            internSchemaHashString(b),
+          );
+        });
+
+        it("produces different strings for different schemas", () => {
+          assertNotEquals(
+            internSchemaHashString({ type: "number" }),
+            internSchemaHashString({ type: "string" }),
+          );
+          assertNotEquals(
+            internSchemaHashString(true),
+            internSchemaHashString(false),
+          );
+        });
+
+        it("interns the input schema as a side effect", () => {
+          const schema: JSONSchemaObj = { type: "number" };
+          assertStrictEquals(isInternedSchema(schema), false);
+          internSchemaHashString(schema);
+          assertStrictEquals(isInternedSchema(schema), true);
+          assert(isDeepFrozen(schema));
+        });
+
+        it("is idempotent on already-interned schemas", () => {
+          const schema: JSONSchema = { type: "number" };
+          const first = internSchemaHashString(schema);
+          const second = internSchemaHashString(schema);
+          assertStrictEquals(first, second);
+        });
       });
 
       describe("internedPairKey()", () => {

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -360,7 +360,12 @@ describe("schema-hash dispatch", () => {
         });
 
         it("interns the input schema as a side effect", () => {
-          const schema: JSONSchemaObj = { type: "number" };
+          // Content-unique key guarantees no prior interning has seen this
+          // exact schema, so `isInternedSchema` reflects what THIS call did.
+          const schema: JSONSchemaObj = {
+            type: "number",
+            title: `schemaHashTestAt${Date.now()}-${Math.random()}`,
+          };
           assertStrictEquals(isInternedSchema(schema), false);
           internSchemaHashString(schema);
           assertStrictEquals(isInternedSchema(schema), true);
@@ -424,8 +429,18 @@ describe("schema-hash dispatch", () => {
         });
 
         it("interns both inputs as a side effect", () => {
-          const a: JSONSchemaObj = { type: "number" };
-          const b: JSONSchemaObj = { type: "string" };
+          // Content-unique keys guarantee no prior interning has seen
+          // these exact schemas, so `isInternedSchema` reflects what
+          // THIS call did.
+          const stamp = `${Date.now()}-${Math.random()}`;
+          const a: JSONSchemaObj = {
+            type: "number",
+            title: `schemaHashTestAt${stamp}-a`,
+          };
+          const b: JSONSchemaObj = {
+            type: "string",
+            title: `schemaHashTestAt${stamp}-b`,
+          };
           assertStrictEquals(isInternedSchema(a), false);
           assertStrictEquals(isInternedSchema(b), false);
           internedPairKey(a, b);

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -10,7 +10,9 @@ import {
   findInternedSchema,
   hashSchema,
   hashSchemaItem,
+  internedPairKey,
   internSchema,
+  internSchemaKey,
   isInternedSchema,
   resetSchemaHashConfig,
   setSchemaHashConfig,
@@ -312,6 +314,105 @@ describe("schema-hash dispatch", () => {
             });
           });
         }
+      });
+
+      describe("internSchemaKey()", () => {
+        it('returns `"T"` for the `true` schema', () => {
+          assertStrictEquals(internSchemaKey(true), "T");
+        });
+
+        it('returns `"F"` for the `false` schema', () => {
+          assertStrictEquals(internSchemaKey(false), "F");
+        });
+
+        it("returns the interned schema's `hashString` for objects", () => {
+          const schema: JSONSchema = { type: "number" };
+          const sah = internSchema(schema, true);
+          assertStrictEquals(internSchemaKey(schema), sah.hashString);
+        });
+
+        it("produces structurally-equal hash strings for equal objects", () => {
+          const a: JSONSchema = {
+            type: "object",
+            properties: { x: { type: "string" } },
+          };
+          const b: JSONSchema = {
+            type: "object",
+            properties: { x: { type: "string" } },
+          };
+          assertStrictEquals(internSchemaKey(a), internSchemaKey(b));
+        });
+
+        it("produces different strings for different schemas", () => {
+          assertNotEquals(
+            internSchemaKey({ type: "number" }),
+            internSchemaKey({ type: "string" }),
+          );
+          assertNotEquals(internSchemaKey(true), internSchemaKey(false));
+          assertNotEquals(
+            internSchemaKey(true),
+            internSchemaKey({ type: "number" }),
+          );
+        });
+
+        it("interns the input schema as a side effect", () => {
+          const schema: JSONSchemaObj = { type: "number" };
+          assertStrictEquals(isInternedSchema(schema), false);
+          internSchemaKey(schema);
+          assertStrictEquals(isInternedSchema(schema), true);
+          assert(isDeepFrozen(schema));
+        });
+
+        it("is idempotent on already-interned schemas", () => {
+          const schema: JSONSchema = { type: "number" };
+          const first = internSchemaKey(schema);
+          const second = internSchemaKey(schema);
+          assertStrictEquals(first, second);
+        });
+      });
+
+      describe("internedPairKey()", () => {
+        it("composes `internSchemaKey` for two objects with `|`", () => {
+          const a: JSONSchema = { type: "number" };
+          const b: JSONSchema = { type: "string" };
+          assertStrictEquals(
+            internedPairKey(a, b),
+            `${internSchemaKey(a)}|${internSchemaKey(b)}`,
+          );
+        });
+
+        it("handles boolean schemas on either side", () => {
+          const obj: JSONSchema = { type: "number" };
+          assertStrictEquals(
+            internedPairKey(true, obj),
+            `T|${internSchemaKey(obj)}`,
+          );
+          assertStrictEquals(
+            internedPairKey(obj, false),
+            `${internSchemaKey(obj)}|F`,
+          );
+          assertStrictEquals(internedPairKey(true, false), "T|F");
+        });
+
+        it("is order-sensitive", () => {
+          const a: JSONSchema = { type: "number" };
+          const b: JSONSchema = { type: "string" };
+          assertNotEquals(internedPairKey(a, b), internedPairKey(b, a));
+        });
+
+        it("matches for structurally-equal inputs", () => {
+          const a1: JSONSchema = {
+            type: "object",
+            properties: { x: { type: "string" } },
+          };
+          const a2: JSONSchema = {
+            type: "object",
+            properties: { x: { type: "string" } },
+          };
+          const b1: JSONSchema = { type: "array", items: { type: "number" } };
+          const b2: JSONSchema = { type: "array", items: { type: "number" } };
+          assertStrictEquals(internedPairKey(a1, b1), internedPairKey(a2, b2));
+        });
       });
     });
   }

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -12,7 +12,6 @@ import {
   hashSchemaItem,
   internedPairKey,
   internSchema,
-  internSchemaKey,
   isInternedSchema,
   resetSchemaHashConfig,
   setSchemaHashConfig,
@@ -316,84 +315,31 @@ describe("schema-hash dispatch", () => {
         }
       });
 
-      describe("internSchemaKey()", () => {
-        it('returns `"<schema:true>"` for the `true` schema', () => {
-          assertStrictEquals(internSchemaKey(true), "<schema:true>");
-        });
-
-        it('returns `"<schema:false>"` for the `false` schema', () => {
-          assertStrictEquals(internSchemaKey(false), "<schema:false>");
-        });
-
-        it("returns the interned schema's `hashString` for objects", () => {
-          const schema: JSONSchema = { type: "number" };
-          const sah = internSchema(schema, true);
-          assertStrictEquals(internSchemaKey(schema), sah.hashString);
-        });
-
-        it("produces structurally-equal hash strings for equal objects", () => {
-          const a: JSONSchema = {
-            type: "object",
-            properties: { x: { type: "string" } },
-          };
-          const b: JSONSchema = {
-            type: "object",
-            properties: { x: { type: "string" } },
-          };
-          assertStrictEquals(internSchemaKey(a), internSchemaKey(b));
-        });
-
-        it("produces different strings for different schemas", () => {
-          assertNotEquals(
-            internSchemaKey({ type: "number" }),
-            internSchemaKey({ type: "string" }),
-          );
-          assertNotEquals(internSchemaKey(true), internSchemaKey(false));
-          assertNotEquals(
-            internSchemaKey(true),
-            internSchemaKey({ type: "number" }),
-          );
-        });
-
-        it("interns the input schema as a side effect", () => {
-          const schema: JSONSchemaObj = { type: "number" };
-          assertStrictEquals(isInternedSchema(schema), false);
-          internSchemaKey(schema);
-          assertStrictEquals(isInternedSchema(schema), true);
-          assert(isDeepFrozen(schema));
-        });
-
-        it("is idempotent on already-interned schemas", () => {
-          const schema: JSONSchema = { type: "number" };
-          const first = internSchemaKey(schema);
-          const second = internSchemaKey(schema);
-          assertStrictEquals(first, second);
-        });
-      });
-
       describe("internedPairKey()", () => {
-        it("composes `internSchemaKey` for two objects with `|`", () => {
+        it("composes the two interned `hashString`s with `|`", () => {
           const a: JSONSchema = { type: "number" };
           const b: JSONSchema = { type: "string" };
-          assertStrictEquals(
-            internedPairKey(a, b),
-            `${internSchemaKey(a)}|${internSchemaKey(b)}`,
-          );
+          const aHash = internSchema(a, true).hashString;
+          const bHash = internSchema(b, true).hashString;
+          assertStrictEquals(internedPairKey(a, b), `${aHash}|${bHash}`);
         });
 
         it("handles boolean schemas on either side", () => {
           const obj: JSONSchema = { type: "number" };
+          const objHash = internSchema(obj, true).hashString;
+          const trueHash = internSchema(true, true).hashString;
+          const falseHash = internSchema(false, true).hashString;
           assertStrictEquals(
             internedPairKey(true, obj),
-            `<schema:true>|${internSchemaKey(obj)}`,
+            `${trueHash}|${objHash}`,
           );
           assertStrictEquals(
             internedPairKey(obj, false),
-            `${internSchemaKey(obj)}|<schema:false>`,
+            `${objHash}|${falseHash}`,
           );
           assertStrictEquals(
             internedPairKey(true, false),
-            "<schema:true>|<schema:false>",
+            `${trueHash}|${falseHash}`,
           );
         });
 
@@ -415,6 +361,18 @@ describe("schema-hash dispatch", () => {
           const b1: JSONSchema = { type: "array", items: { type: "number" } };
           const b2: JSONSchema = { type: "array", items: { type: "number" } };
           assertStrictEquals(internedPairKey(a1, b1), internedPairKey(a2, b2));
+        });
+
+        it("interns both inputs as a side effect", () => {
+          const a: JSONSchemaObj = { type: "number" };
+          const b: JSONSchemaObj = { type: "string" };
+          assertStrictEquals(isInternedSchema(a), false);
+          assertStrictEquals(isInternedSchema(b), false);
+          internedPairKey(a, b);
+          assertStrictEquals(isInternedSchema(a), true);
+          assertStrictEquals(isInternedSchema(b), true);
+          assert(isDeepFrozen(a));
+          assert(isDeepFrozen(b));
         });
       });
     });

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -4,6 +4,7 @@ import {
   hashSchemaItem,
   internedPairKey,
   internSchema,
+  internSchemaHashString,
 } from "@commonfabric/data-model/schema-hash";
 import { MIME } from "@commonfabric/memory/interface";
 import type { JSONSchemaObj } from "@commonfabric/api";
@@ -3251,8 +3252,8 @@ export function mergeAnyOfBranchSchemas(
   // Interning each input stabilizes its identity so downstream callers
   // hit the hash-cache fast path; `||` separates outer from branches,
   // `|` separates branches.
-  const key = `${internSchema(outerSchema, true).hashString}||` +
-    branches.map((b) => internSchema(b, true).hashString).join("|");
+  const key = `${internSchemaHashString(outerSchema)}||` +
+    branches.map(internSchemaHashString).join("|");
   const cached = _mergeAnyOfBranchCache.get(key);
   if (cached !== undefined) return cached;
 
@@ -3336,7 +3337,7 @@ function _mergeAnyOfBranchSchemasUncached(
     // identities for any downstream caller that re-hashes them.
     const uniqueHashes = new Map<string, JSONSchema>();
     for (const s of schemas) {
-      uniqueHashes.set(internSchema(s, true).hashString, s);
+      uniqueHashes.set(internSchemaHashString(s), s);
     }
     if (uniqueHashes.size === 1) {
       // All branches agree on this property's schema

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -4,7 +4,6 @@ import {
   hashSchemaItem,
   internedPairKey,
   internSchema,
-  internSchemaKey,
 } from "@commonfabric/data-model/schema-hash";
 import { MIME } from "@commonfabric/memory/interface";
 import type { JSONSchemaObj } from "@commonfabric/api";
@@ -111,9 +110,9 @@ const _hashCache = new WeakMap<object, string>();
 // Schema operation intern caches: memoize merge/combine results so
 // structurally-identical operations return the same object identity.
 // The cached value is run through `internSchema`, which deep-freezes and
-// dedups structurally-equal results — so downstream `hashSchema` /
-// `internSchemaKey` calls on the cached output hit `internSchema`'s
-// WeakMap in O(1) instead of re-walking the schema tree.
+// dedups structurally-equal results — so downstream `hashSchema` calls
+// on the cached output hit `internSchema`'s WeakMap in O(1) instead of
+// re-walking the schema tree.
 // Capped to prevent unbounded growth in long-running servers.
 const INTERN_CACHE_MAX = 10_000;
 const _mergeSchemaOptionCache = new Map<string, JSONSchema>();
@@ -3249,9 +3248,11 @@ export function mergeAnyOfBranchSchemas(
   if (branches.length < 2) return null;
 
   // Inline 1+N intern-based key: outer schema, then each branch.
-  // `||` separates outer from branches; `|` separates branches.
-  const key = `${internSchemaKey(outerSchema)}||` +
-    branches.map(internSchemaKey).join("|");
+  // Interning each input stabilizes its identity so downstream callers
+  // hit the hash-cache fast path; `||` separates outer from branches,
+  // `|` separates branches.
+  const key = `${internSchema(outerSchema, true).hashString}||` +
+    branches.map((b) => internSchema(b, true).hashString).join("|");
   const cached = _mergeAnyOfBranchCache.get(key);
   if (cached !== undefined) return cached;
 
@@ -3335,7 +3336,7 @@ function _mergeAnyOfBranchSchemasUncached(
     // identities for any downstream caller that re-hashes them.
     const uniqueHashes = new Map<string, JSONSchema>();
     for (const s of schemas) {
-      uniqueHashes.set(internSchemaKey(s), s);
+      uniqueHashes.set(internSchema(s, true).hashString, s);
     }
     if (uniqueHashes.size === 1) {
       // All branches agree on this property's schema

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -2,6 +2,9 @@ import { hashOf } from "@commonfabric/data-model/value-hash";
 import {
   hashSchema,
   hashSchemaItem,
+  internedPairKey,
+  internSchema,
+  internSchemaKey,
 } from "@commonfabric/data-model/schema-hash";
 import { MIME } from "@commonfabric/memory/interface";
 import type { JSONSchemaObj } from "@commonfabric/api";
@@ -28,10 +31,7 @@ import {
 } from "../../utils/src/types.ts";
 import { getLogger } from "../../utils/src/logger.ts";
 import { ContextualFlowControl } from "./cfc.ts";
-import {
-  schemaWithProperties,
-  toDeepFrozenSchema,
-} from "@commonfabric/data-model/schema-utils";
+import { schemaWithProperties } from "@commonfabric/data-model/schema-utils";
 import type { JSONObject, JSONSchema } from "./builder/types.ts";
 import {
   addressKey,
@@ -110,8 +110,10 @@ const _hashCache = new WeakMap<object, string>();
 
 // Schema operation intern caches: memoize merge/combine results so
 // structurally-identical operations return the same object identity.
-// This ensures downstream hashSchema hits the WeakMap cache
-// (O(1) identity lookup) instead of re-walking the schema tree.
+// The cached value is run through `internSchema`, which deep-freezes and
+// dedups structurally-equal results — so downstream `hashSchema` /
+// `internSchemaKey` calls on the cached output hit `internSchema`'s
+// WeakMap in O(1) instead of re-walking the schema tree.
 // Capped to prevent unbounded growth in long-running servers.
 const INTERN_CACHE_MAX = 10_000;
 const _mergeSchemaOptionCache = new Map<string, JSONSchema>();
@@ -126,7 +128,7 @@ function internSet(
 ): JSONSchema {
   if (cache.size >= INTERN_CACHE_MAX) cache.clear();
 
-  const result = toDeepFrozenSchema(value, true);
+  const result = internSchema(value);
   cache.set(key, result);
   return result;
 }
@@ -1435,8 +1437,7 @@ function combineOptionalSchema(
 
 // Merge any schema flags like asCell or asStream from flagSchema into schema.
 export function mergeSchemaFlags(flagSchema: JSONSchema, schema: JSONSchema) {
-  const key = hashSchema(flagSchema).toString() + "|" +
-    hashSchema(schema).toString();
+  const key = internedPairKey(flagSchema, schema);
   const cached = _mergeSchemaFlagsCache.get(key);
   if (cached !== undefined) return cached;
   const result = _mergeSchemaFlagsUncached(flagSchema, schema);
@@ -1484,8 +1485,7 @@ export function combineSchema(
   parentSchema: JSONSchema,
   linkSchema: JSONSchema,
 ): JSONSchema {
-  const key = hashSchema(parentSchema).toString() + "|" +
-    hashSchema(linkSchema).toString();
+  const key = internedPairKey(parentSchema, linkSchema);
   const cached = _combineSchemaCache.get(key);
   if (cached !== undefined) return cached;
   const result = _combineSchemaUncached(parentSchema, linkSchema);
@@ -3141,12 +3141,11 @@ function mergeSchemaOption(
   // JSONSchema rules should.
   // For example, `{type: "object", anyOf: [{type: "string"}]}` schema should
   // never match
-  const key = hashSchema(outerSchema).toString() + "|" +
-    hashSchema(innerSchema).toString();
+  const key = internedPairKey(outerSchema, innerSchema);
   const cached = _mergeSchemaOptionCache.get(key);
   if (cached !== undefined) return cached;
   const result = isRecord(innerSchema)
-    ? { ...outerSchema, ...innerSchema }
+    ? schemaWithProperties(outerSchema, innerSchema)
     : innerSchema
     ? outerSchema // innerSchema === true
     : false; // innerSchema === false
@@ -3249,18 +3248,20 @@ export function mergeAnyOfBranchSchemas(
 ): JSONSchema | null {
   if (branches.length < 2) return null;
 
-  const key = hashSchema(outerSchema).toString() + "||" +
-    branches.map((b) => hashSchema(b).toString()).join("|");
+  // Inline 1+N intern-based key: outer schema, then each branch.
+  // `||` separates outer from branches; `|` separates branches.
+  const key = `${internSchemaKey(outerSchema)}||` +
+    branches.map(internSchemaKey).join("|");
   const cached = _mergeAnyOfBranchCache.get(key);
   if (cached !== undefined) return cached;
 
   const result = _mergeAnyOfBranchSchemasUncached(branches, outerSchema);
-  const frozen = result !== null ? toDeepFrozenSchema(result, true) : null;
+  const interned = result !== null ? internSchema(result) : null;
   if (_mergeAnyOfBranchCache.size >= INTERN_CACHE_MAX) {
     _mergeAnyOfBranchCache.clear();
   }
-  _mergeAnyOfBranchCache.set(key, frozen);
-  return frozen;
+  _mergeAnyOfBranchCache.set(key, interned);
+  return interned;
 }
 
 function _mergeAnyOfBranchSchemasUncached(
@@ -3329,10 +3330,12 @@ function _mergeAnyOfBranchSchemasUncached(
   // Build merged properties
   const mergedProperties: Record<string, JSONSchema> = {};
   for (const [propKey, schemas] of allProps) {
-    // Deduplicate schemas using hashSchema
+    // Deduplicate structurally-equal property schemas across branches by
+    // keying on the interned hash; interning also stabilizes these schema
+    // identities for any downstream caller that re-hashes them.
     const uniqueHashes = new Map<string, JSONSchema>();
     for (const s of schemas) {
-      uniqueHashes.set(hashSchema(s).toString(), s);
+      uniqueHashes.set(internSchemaKey(s), s);
     }
     if (uniqueHashes.size === 1) {
       // All branches agree on this property's schema


### PR DESCRIPTION
## What

Adds a new `internedPairKey(a, b)` helper to `packages/data-model/schema-hash.ts` that composes two `internSchema(x, true).hashString`s with a `|` delimiter — producing a stable, base64url-collision-safe cache key from a pair of schemas.

Applies it at 5 merge-helper cache-key sites in `packages/runner/src/traverse.ts`:

- `mergeSchemaFlags` — `internedPairKey(flagSchema, schema)`.
- `combineSchema` — `internedPairKey(parentSchema, linkSchema)`.
- `mergeSchemaOption` — `internedPairKey(outerSchema, innerSchema)`.
- `mergeAnyOfBranchSchemas` — inline 1+N key (`${outerHashString}||${branches.map(…).join("|")}`) since it's a single site, not a recurring 2-arg pattern. Result is interned directly.
- anyOf property dedup — keys a `uniqueHashes` Map on `internSchema(s, true).hashString`.

Also upgrades the shared `internSet` helper from `toDeepFrozenSchema(value, true)` to `internSchema(value)` — a single-line change that retires "intern the merged result" guidance for three of the five sites at once while preserving the `INTERN_CACHE_MAX=10_000` cap and clear-on-overflow behavior.

## Why

The modern schema-hash path (`hashOfModernInternal` in `packages/data-model/value-hash-modern.ts`) WeakMap-caches only deep-frozen objects. Hot-path callers in `traverse.ts` construct fresh unfrozen spread objects every call, so they miss the modern cache entirely — producing the CI regression first observed on PR #3235 (parking-coordinator pattern test: ~78 min on the PR branch vs ~2 min on `main`).

Interning schemas produces stable, deep-frozen identities that are cache-friendly for the modern hash path, retiring 5 of the cache-defeat sites identified in the 2026-04-16 audit.

## Context

This is **PR 1 of a three-PR staged structural fix**:

- **PR 1 (this PR)** — Tactic 2A: intern schema-hash cache keys at the 5 merge-helper sites in `traverse.ts`.
- **PR 2** — Tactic 2B: `CompoundCycleTracker` restructure (tracked separately, lands independently).
- **PR 3** — Tactic 2C: `MapSetStringToPathSelectors` freeze (tracked separately, lands independently).

All three together are expected to close PR #3235's parking-coordinator regression. PR #3235 remains open as the final target; this PR unblocks it but does not close it.

Full diagnosis and per-site analysis: `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` (§4 Phase 2). Empirical profiling: `coordination/docs/2026-04-16-modern-schema-hash-profiling.md`. Test-surface triage: `coordination/docs/2026-04-16-modern-schema-hash-test-surface-triage.md`.

Related PRs:
- PR #3235 — `feat: enable modernSchemaHash by default` (the target; still open).
- PR #3231 — `coder-cedar/flip-modern-hash-default` (upstream of #3235).
- PR #3324 — `danfuzz/because-im-easy-come-easy-go` (legacy-hash SHA256 normalization; apples-to-apples comparison prep).

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
