### PR TITLE
Make `schemaWithProperties()` smarter about `boolean` and `undefined` base.

### DIFF
--- a/packages/data-model/schema-hash.ts
+++ b/packages/data-model/schema-hash.ts
@@ -322,7 +322,8 @@ export function findInternedSchema(
 /**
  * Indicates whether or not the given `schema` is already interned. This returns
  * `false` even if there is already a schema in the intern cache that is
- * equivalent to the given one.
+ * equivalent to the given one, unless `schema` is in fact the one that is in
+ * the cache.
  */
 export function isInternedSchema(schema: JSONSchema): boolean {
   if (typeof schema === "boolean") {

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -139,16 +139,33 @@ export function schemaWithProperties(
   schema: JSONSchema | undefined,
   overrides: JSONSchemaObj,
 ): JSONSchema {
-  if (schema === false) return false;
+  // Deal with `boolean`s and `undefined` values for the base `schema`. Since
+  // these count as interned schemas, "intern contagion" applies.
+  switch (typeof schema) {
+    case "boolean": {
+      // Since `true` counts as an interned schemas, "intern contagion" applies.
+      return schema
+        ? internSchema(overrides)
+        : false;
+    }
 
-  const base = (schema === undefined || schema === true)
-    ? emptySchemaObject()
-    : schema;
-  const result = { ...base, ...overrides };
+    case "undefined": {
+      // Since `undefined` counts as an interned schemas, "intern contagion"
+      // applies.
+      return internSchema(overrides);
+    }
 
-  return isInternedSchema(base)
-    ? internSchema(result)
-    : toDeepFrozenSchema(result, true);
+    case "object": {
+      const result = { ...schema, ...overrides };
+      return isInternedSchema(schema)
+        ? internSchema(result)
+        : toDeepFrozenSchema(result, true);
+    }
+
+    default: {
+      throw new Error(`Unrecognized schema value type: ${typeof schema}`);
+    }
+  }
 }
 
 /**

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -140,10 +140,6 @@ export function schemaWithProperties(
   schema: JSONSchema | undefined,
   overrides: JSONSchema,
 ): JSONSchema {
-  if (schema === undefined) {
-    schema = true;
-  }
-
   // Deals with `boolean`s values for either of the arguements. In both cases, a
   // `false` means the result is `false`, and a "truish" (`true` per se or
   // `undefined`) means that the result is the _other_ argument. Since these
@@ -175,7 +171,7 @@ export function schemaWithProperties(
     }
   };
 
-  const handledSchema = handleBooleanArgument(schema, overrides);
+  const handledSchema = handleBooleanArgument(schema ?? true, overrides);
   if (handledSchema !== undefined) {
     return handledSchema;
   }

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -176,18 +176,20 @@ export function schemaWithProperties(
     return handledSchema;
   }
 
-  const handledOverrides = handleBooleanArgument(overrides, schema);
+  // At this point, `schema` is an `object`s (but the type system can't figure
+  // that out.)
+  const schemaObj = schema as JSONSchemaObj;
+
+  const handledOverrides = handleBooleanArgument(overrides, schemaObj);
   if (handledOverrides !== undefined) {
     return handledOverrides;
   }
 
-  // At this point, both `schema` and `overrides` are `object`s (but the type
-  // system can't figure that out.)
-  const schemaObj = schema as JSONSchemaObj;
+  // Similar to above, for `overrides`.
   const overridesObj = overrides as JSONSchemaObj;
 
   const result = { ...schemaObj, ...overridesObj };
-  return isInternedSchema(schema)
+  return isInternedSchema(schemaObj)
     ? internSchema(result)
     : toDeepFrozenSchema(result, true);
 }

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -131,48 +131,56 @@ export function cloneSchemaMutable(
  * `schema` is interned, then the result of this function will also be interned.
  *
  * - `undefined` and `true` ("accept everything") are treated as an interned
- *   `{}` before applying overrides.
- * - `false` ("reject everything") short-circuits: no overrides can make a
- *   "never" schema accept anything, so `false` is returned as-is.
+ *   `{}`.
+ * - `false` ("reject everything"), whether in `schema` or `overrides`, results
+ *   in a `false` result. That is, adding properties to a "never" schema still
+ *   results in "never," and adding "never" to any schema makes it a "never."
  */
 export function schemaWithProperties(
   schema: JSONSchema | undefined,
-  overrides: JSONSchemaObj,
+  overrides: JSONSchema,
 ): JSONSchema {
-  switch (typeof schema) {
-    case "boolean":
-    case "undefined": {
-      // Deal with `boolean`s and `undefined` values for the base `schema`.
-      // Since these count as interned schemas, "intern contagion" applies.
-      if (schema === false) {
+  // Deals with `boolean`s and `undefined` values for either of the arguements.
+  // In both cases, a `false` means the result is `false`, and a "truish"
+  // (`true` per se or `undefined`) means that the result is the _other_
+  // argument. Since these (non-object) values count as interned schemas,
+  // "intern contagion" applies, so if handled the result is always an interned
+  // instance.
+  const handleBooleanArgument = (schemaToCheck, otherSchema) => {
+    switch (schemaToCheck) {
+      case false: {
         return false;
-      } else {
-        // `schema` is (effectively) `true`, so we return the interned reference
-        // to `overrides`. If `overrides` is already deep-frozen (which also
-        // means possibly already interned) we can call `internSchema()` on it
-        // directly. But if it's _not_ deep-frozen, then per function contract
-        // we have to do a shallow clone.
-        return isDeepFrozen(overrides)
-          ? internSchema(overrides)
-          : internSchema({ ...overrides });
-      }
-    }
-
-    case "object": {
-      if (schema === null) {
-        throw new Error("`null` is not a valid schema.");
       }
 
-      const result = { ...schema, ...overrides };
-      return isInternedSchema(schema)
-        ? internSchema(result)
-        : toDeepFrozenSchema(result, true);
-    }
+      case true:
+      case undefined: {
+        return isDeepFrozen(otherSchema)
+          ? internSchema(otherSchema)
+          : internSchema({ ...otherSchema });
+      }
 
-    default: {
-      throw new Error(`Unrecognized schema value type: ${typeof schema}`);
+      default: {
+        return undefined;
+      }
     }
+  };
+
+  const handledSchema = handleBooleanArgument(schema, overrides);
+  if (handledSchema !== undefined) {
+    return handledSchema;
   }
+
+  const handledOverrides = handleBooleanArgument(overrides, schema);
+  if (handledOverrides !== undefined) {
+    return handledOverrides;
+  }
+
+  // At this point, both `schema` and `overrides` are `object`s.
+
+  const result = { ...schema, ...overrides };
+  return isInternedSchema(schema)
+    ? internSchema(result)
+    : toDeepFrozenSchema(result, true);
 }
 
 /**

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -143,17 +143,21 @@ export function schemaWithProperties(
   // these count as interned schemas, "intern contagion" applies.
   switch (typeof schema) {
     case "boolean": {
-      // Since `true` counts as an interned schemas, "intern contagion" applies.
+      // Since `true` counts as an interned schema, "intern contagion" applies.
       return schema ? internSchema(overrides) : false;
     }
 
     case "undefined": {
-      // Since `undefined` counts as an interned schemas, "intern contagion"
+      // Since `undefined` counts as an interned schema, "intern contagion"
       // applies.
       return internSchema(overrides);
     }
 
     case "object": {
+      if (schema === null) {
+        throw new Error("`null` is not a valid schema.");
+      }
+
       const result = { ...schema, ...overrides };
       return isInternedSchema(schema)
         ? internSchema(result)

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -144,9 +144,7 @@ export function schemaWithProperties(
   switch (typeof schema) {
     case "boolean": {
       // Since `true` counts as an interned schemas, "intern contagion" applies.
-      return schema
-        ? internSchema(overrides)
-        : false;
+      return schema ? internSchema(overrides) : false;
     }
 
     case "undefined": {

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -139,12 +139,23 @@ export function schemaWithProperties(
   schema: JSONSchema | undefined,
   overrides: JSONSchemaObj,
 ): JSONSchema {
-  // Deal with `boolean`s and `undefined` values for the base `schema`. Since
-  // these count as interned schemas, "intern contagion" applies.
   switch (typeof schema) {
-    case "boolean": {
-      // Since `true` counts as an interned schema, "intern contagion" applies.
-      return schema ? internSchema(overrides) : false;
+    case "boolean":
+    case "undefined": {
+      // Deal with `boolean`s and `undefined` values for the base `schema`.
+      // Since these count as interned schemas, "intern contagion" applies.
+      if (schema === false) {
+        return false;
+      } else {
+        // `schema` is (effectively) `true`, so we return the interned reference
+        // to `overrides`. If `overrides` is already deep-frozen (which also
+        // means possibly already interned) we can call `internSchema()` on it
+        // directly. But if it's _not_ deep-frozen, then per function contract
+        // we have to do a shallow clone.
+        return isDeepFrozen(overrides)
+          ? internSchema(overrides)
+          : internSchema({ ...overrides });
+      }
     }
 
     case "undefined": {

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -140,13 +140,19 @@ export function schemaWithProperties(
   schema: JSONSchema | undefined,
   overrides: JSONSchema,
 ): JSONSchema {
-  // Deals with `boolean`s and `undefined` values for either of the arguements.
-  // In both cases, a `false` means the result is `false`, and a "truish"
-  // (`true` per se or `undefined`) means that the result is the _other_
-  // argument. Since these (non-object) values count as interned schemas,
-  // "intern contagion" applies, so if handled the result is always an interned
-  // instance.
-  const handleBooleanArgument = (schemaToCheck, otherSchema) => {
+  if (schema === undefined) {
+    schema = true;
+  }
+
+  // Deals with `boolean`s values for either of the arguements. In both cases, a
+  // `false` means the result is `false`, and a "truish" (`true` per se or
+  // `undefined`) means that the result is the _other_ argument. Since these
+  // (non-object) values count as interned schemas, "intern contagion" applies,
+  // so if handled the result is always an interned instance.
+  const handleBooleanArgument = (
+    schemaToCheck: JSONSchema,
+    otherSchema: JSONSchema,
+  ) => {
     switch (schemaToCheck) {
       case false: {
         return false;
@@ -154,6 +160,10 @@ export function schemaWithProperties(
 
       case true:
       case undefined: {
+        if (typeof otherSchema === "boolean") {
+          return otherSchema;
+        }
+
         return isDeepFrozen(otherSchema)
           ? internSchema(otherSchema)
           : internSchema({ ...otherSchema });
@@ -175,9 +185,12 @@ export function schemaWithProperties(
     return handledOverrides;
   }
 
-  // At this point, both `schema` and `overrides` are `object`s.
+  // At this point, both `schema` and `overrides` are `object`s (but the type
+  // system can't figure that out.)
+  const schemaObj = schema as JSONSchemaObj;
+  const overridesObj = overrides as JSONSchemaObj;
 
-  const result = { ...schema, ...overrides };
+  const result = { ...schemaObj, ...overridesObj };
   return isInternedSchema(schema)
     ? internSchema(result)
     : toDeepFrozenSchema(result, true);

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -158,12 +158,6 @@ export function schemaWithProperties(
       }
     }
 
-    case "undefined": {
-      // Since `undefined` counts as an interned schema, "intern contagion"
-      // applies.
-      return internSchema(overrides);
-    }
-
     case "object": {
       if (schema === null) {
         throw new Error("`null` is not a valid schema.");

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -626,25 +626,23 @@ describe("schemaWithProperties", () => {
     });
   }
 
-  for (const truish of [true, undefined]) {
-    describe(`for \`overrides = ${truish}\``, () => {
-      it("treats it as `{}` (any) and returns `schema`", () => {
-        const result = schemaWithProperties({ type: "string" }, truish);
-        assertEquals(result, { type: "string" });
-      });
-
-      it("returns an interned result", () => {
-        const result = schemaWithProperties({ type: "string" }, truish);
-        assert(isInternedSchema(result));
-      });
-
-      it("does not freeze `schema`", () => {
-        const schema: JSONSchemaObj = { type: "boolean" };
-        schemaWithProperties(schema, truish);
-        assert(!Object.isFrozen(schema));
-      });
+  describe("for `overrides = true`", () => {
+    it("treats it as `{}` (any) and returns `schema`", () => {
+      const result = schemaWithProperties({ type: "string" }, true);
+      assertEquals(result, { type: "string" });
     });
-  }
+
+    it("returns an interned result", () => {
+      const result = schemaWithProperties({ type: "string" }, true);
+      assert(isInternedSchema(result));
+    });
+
+    it("does not freeze `schema`", () => {
+      const schema: JSONSchemaObj = { type: "boolean" };
+      schemaWithProperties(schema, true);
+      assert(!Object.isFrozen(schema));
+    });
+  });
 
   describe("for `schema = false\`", () => {
     for (const overrides of [false, true, { type: "string" }]) {

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@std/assert";
 import type {
   FabricValue,
+  JSONSchema,
   JSONSchemaObj,
   JSONSchemaTypes,
 } from "@commonfabric/api";

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -606,24 +606,32 @@ describe("schemaWithProperties", () => {
     assert(!("description" in withoutOverride));
   });
 
-  it("treats undefined as {} and applies overrides", () => {
-    const result = schemaWithProperties(undefined, { type: "string" });
-    assertEquals(result, { type: "string" });
-    assert(Object.isFrozen(result));
-  });
+  for (const truish of [true, undefined]) {
+    describe(`for \`schema = ${truish}\``, () => {
+      it("treats it as `{}` (any) and returns `overrides`", () => {
+        const result = schemaWithProperties(truish, { type: "string" });
+        assertEquals(result, { type: "string" });
+      });
 
-  it("treats boolean true as {} and applies overrides", () => {
-    const result = schemaWithProperties(true, { type: "string" });
-    assertEquals(result, { type: "string" });
-    assert(Object.isFrozen(result));
-  });
+      it("returns an interned result", () => {
+        const result = schemaWithProperties(truish, { type: "string" });
+        assert(isInternedSchema(result));
+      });
+
+      it("does not freeze `overrides`", () => {
+        const overrides = { type: "boolean" };
+        const result = schemaWithProperties(truish, overrides);
+        assert(!Object.isFrozen(overrides));
+      });
+    });
+  }
 
   it("returns false as-is regardless of overrides", () => {
     const result = schemaWithProperties(false, { type: "string" });
     assertStrictEquals(result, false);
   });
 
-  describe("intern contagion", () => {
+  describe("intern contagion of `object`s", () => {
     it("result is interned when base schema is interned", () => {
       const base = internSchema({ type: "object" });
       const result = schemaWithProperties(base, {
@@ -640,16 +648,6 @@ describe("schemaWithProperties", () => {
       assert(!isInternedSchema(result));
       // But it should still be frozen.
       assert(Object.isFrozen(result));
-    });
-
-    it("result is interned when base is undefined (treated as interned {})", () => {
-      const result = schemaWithProperties(undefined, { type: "string" });
-      assert(isInternedSchema(result));
-    });
-
-    it("result is interned when base is true (treated as interned {})", () => {
-      const result = schemaWithProperties(true, { type: "string" });
-      assert(isInternedSchema(result));
     });
   });
 });

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -619,7 +619,7 @@ describe("schemaWithProperties", () => {
       });
 
       it("does not freeze `overrides`", () => {
-        const overrides = { type: "boolean" };
+        const overrides: JSONSchemaObj = { type: "boolean" };
         schemaWithProperties(truish, overrides);
         assert(!Object.isFrozen(overrides));
       });

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -626,9 +626,48 @@ describe("schemaWithProperties", () => {
     });
   }
 
-  it("returns false as-is regardless of overrides", () => {
-    const result = schemaWithProperties(false, { type: "string" });
-    assertStrictEquals(result, false);
+  for (const truish of [true, undefined]) {
+    describe(`for \`overrides = ${truish}\``, () => {
+      it("treats it as `{}` (any) and returns `schema`", () => {
+        const result = schemaWithProperties({ type: "string" }, truish);
+        assertEquals(result, { type: "string" });
+      });
+
+      it("returns an interned result", () => {
+        const result = schemaWithProperties({ type: "string" }, truish);
+        assert(isInternedSchema(result));
+      });
+
+      it("does not freeze `schema`", () => {
+        const schema: JSONSchemaObj = { type: "boolean" };
+        schemaWithProperties(schema, truish);
+        assert(!Object.isFrozen(schema));
+      });
+    });
+  }
+
+  describe("for `schema = false\`", () => {
+    for (const overrides of [false, true, { type: "string" }]) {
+      const label = (typeof overrides === "boolean")
+        ? `\`overrides = ${overrides}\``
+        : "`overrides` of type `object`";
+      it(`returns \`false\` given ${label}`, () => {
+        const result = schemaWithProperties(false, overrides);
+        assertStrictEquals(result, false);
+      });
+    }
+  });
+
+  describe("for `overrides = false\`", () => {
+    for (const schema of [false, true, { type: "string" }]) {
+      const label = (typeof schema === "boolean")
+        ? `\`schema = ${schema}\``
+        : "`schema` of type `object`";
+      it(`returns \`false\` given ${label}`, () => {
+        const result = schemaWithProperties(schema, false);
+        assertStrictEquals(result, false);
+      });
+    }
   });
 
   describe("intern contagion of `object`s", () => {

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -620,7 +620,7 @@ describe("schemaWithProperties", () => {
 
       it("does not freeze `overrides`", () => {
         const overrides = { type: "boolean" };
-        const result = schemaWithProperties(truish, overrides);
+        schemaWithProperties(truish, overrides);
         assert(!Object.isFrozen(overrides));
       });
     });

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -645,7 +645,7 @@ describe("schemaWithProperties", () => {
   });
 
   describe("for `schema = false\`", () => {
-    for (const overrides of [false, true, { type: "string" }]) {
+    for (const overrides of [false, true, { type: "string" } as JSONSchema]) {
       const label = (typeof overrides === "boolean")
         ? `\`overrides = ${overrides}\``
         : "`overrides` of type `object`";
@@ -657,7 +657,7 @@ describe("schemaWithProperties", () => {
   });
 
   describe("for `overrides = false\`", () => {
-    for (const schema of [false, true, { type: "string" }]) {
+    for (const schema of [false, true, { type: "string" } as JSONSchema]) {
       const label = (typeof schema === "boolean")
         ? `\`schema = ${schema}\``
         : "`schema` of type `object`";


### PR DESCRIPTION
This PR reworks `schemaWithProperties()` so it no longer makes gratuitous object copies when the given base `schema` is a `boolean` or `undefined`, and it also now accepts `boolean` arguments for `overrides`.