### PR TITLE
[codex] Add session cwd support to cf-harness

### DIFF
--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from "@std/cli/parse-args";
-import { dirname, join, resolve } from "@std/path";
+import { dirname, join, relative, resolve } from "@std/path";
 import { type CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import {
   DEFAULT_GATEWAY_BASE_URL,
@@ -36,6 +36,7 @@ export type CfHarnessCliOutputMode = (typeof CLI_OUTPUT_MODES)[number];
 
 export interface CfHarnessCliConfig {
   workspace: string;
+  cwd?: string;
   focusRoot?: string;
   allowedToolIds?: readonly BuiltinToolId[];
   outputMode: CfHarnessCliOutputMode;
@@ -82,6 +83,7 @@ const usage = `Usage: deno run -A src/main.ts [options] [prompt text]
 
 Options:
   --workspace <path>            Workspace host path (defaults to current directory)
+  --cwd <path>                  Initial working directory inside the workspace
   --focus-root <path>           Narrow exploration to a workspace subpath when possible
   --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | write_file)
   --output-mode <mode>          operator | batch (default: operator)
@@ -218,6 +220,7 @@ export const parseCfHarnessCliArgs = async (
   const args = parseArgs([...normalizedArgv], {
     string: [
       "workspace",
+      "cwd",
       "focus-root",
       "allow-tool",
       "output-mode",
@@ -252,6 +255,12 @@ export const parseCfHarnessCliArgs = async (
   const workspace = resolve(
     typeof args.workspace === "string" ? args.workspace : cwd,
   );
+  const initialCwd = typeof args.cwd === "string"
+    ? toWorkspaceSandboxPath(workspace, resolve(workspace, args.cwd), {
+      strict: true,
+      errorPrefix: "--cwd",
+    })
+    : undefined;
   const focusRoot = typeof args["focus-root"] === "string"
     ? resolve(workspace, args["focus-root"])
     : undefined;
@@ -336,6 +345,7 @@ export const parseCfHarnessCliArgs = async (
     : undefined;
   return {
     workspace,
+    ...(initialCwd !== undefined ? { cwd: initialCwd } : {}),
     ...(focusRoot !== undefined ? { focusRoot } : {}),
     ...(allowedToolIds !== undefined ? { allowedToolIds } : {}),
     outputMode: outputMode ?? "operator",
@@ -375,16 +385,21 @@ export const formatCfHarnessCliUsage = (): string => usage;
 const toWorkspaceSandboxPath = (
   workspaceHostPath: string,
   hostPath?: string,
+  options: { strict?: boolean; errorPrefix?: string } = {},
 ): string => {
   if (hostPath === undefined) {
     return "/workspace";
   }
-  const relativePath = hostPath.startsWith(`${workspaceHostPath}/`)
-    ? hostPath.slice(workspaceHostPath.length + 1)
-    : hostPath === workspaceHostPath
-    ? ""
-    : undefined;
-  if (relativePath === undefined) {
+  const relativePath = relative(workspaceHostPath, hostPath);
+  if (
+    relativePath === ".." ||
+    relativePath.startsWith("../")
+  ) {
+    if (options.strict) {
+      throw new Error(
+        `${options.errorPrefix ?? "path"} must stay within the workspace`,
+      );
+    }
     return "/workspace";
   }
   return relativePath.length > 0 ? `/workspace/${relativePath}` : "/workspace";
@@ -617,6 +632,7 @@ export const runCfHarnessCli = async (
           model: parsed.model ?? artifacts.runState.model,
           gatewayBaseUrl: parsed.gatewayBaseUrl,
           gatewayAuthMode: parsed.gatewayAuthMode,
+          ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
           cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
         }),
         apiKey: parsed.apiKey,
@@ -645,6 +661,7 @@ export const runCfHarnessCli = async (
         model: parsed.model,
         gatewayBaseUrl: parsed.gatewayBaseUrl,
         gatewayAuthMode: parsed.gatewayAuthMode,
+        ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
         apiKey: parsed.apiKey,
         apiKeySource: parsed.apiKeySource,
         cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -393,7 +393,8 @@ const toWorkspaceSandboxPath = (
   const relativePath = relative(workspaceHostPath, hostPath);
   if (
     relativePath === ".." ||
-    relativePath.startsWith("../")
+    relativePath.startsWith("../") ||
+    relativePath.startsWith("..\\")
   ) {
     if (options.strict) {
       throw new Error(

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -10,6 +10,7 @@ export type HarnessGatewayAuthMode = "bearer" | "none";
 export interface HarnessConfig {
   gatewayBaseUrl: string;
   gatewayAuthMode: HarnessGatewayAuthMode;
+  cwd?: string;
   model?: string;
   vmTarget?: string;
   skillsRoot?: string;
@@ -23,6 +24,7 @@ export interface ResolveHarnessConfigOptions {
   gatewayBaseUrl?: string;
   gatewayAuthMode?: HarnessGatewayAuthMode;
   gatewayAuthModeOverride?: string | HarnessGatewayAuthMode;
+  cwd?: string;
   model?: string;
   vmTarget?: string;
   skillsRoot?: string;
@@ -108,6 +110,7 @@ export const resolveHarnessConfig = (
     options.gatewayBaseUrl ?? DEFAULT_GATEWAY_BASE_URL,
   ),
   gatewayAuthMode: resolveGatewayAuthMode(options),
+  ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
   ...(options.model !== undefined ? { model: options.model } : {}),
   ...(options.vmTarget !== undefined ? { vmTarget: options.vmTarget } : {}),
   ...(options.skillsRoot !== undefined

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -12,6 +12,7 @@ import {
   appendHarnessToolOutput,
   createHarnessRunState,
   type HarnessRunState,
+  setHarnessRunCurrentDir,
   setHarnessRunStatus,
   setHarnessTranscriptPath,
 } from "./run-state.ts";
@@ -110,6 +111,25 @@ const createSandboxRuntime = (
   }
 };
 
+const resolveInitialCurrentDir = (
+  sandbox: SandboxRuntime,
+  config: HarnessConfig,
+  runState?: HarnessRunState,
+): string => {
+  if (runState !== undefined) {
+    if (runState.currentDir === undefined) {
+      throw new Error(
+        "run state is missing currentDir; older cf-harness runs cannot be resumed",
+      );
+    }
+    return runState.currentDir;
+  }
+  if (config.cwd !== undefined) {
+    return sandbox.resolvePath(config.cwd);
+  }
+  return sandbox.defaultWorkingDirectory();
+};
+
 export class CfHarnessEngine {
   readonly config: HarnessConfig;
   readonly sandbox: SandboxRuntime;
@@ -138,10 +158,16 @@ export class CfHarnessEngine {
           runId,
         })
         : undefined);
+    const currentDir = resolveInitialCurrentDir(
+      this.sandbox,
+      this.config,
+      options.runState,
+    );
     this.#runState = options.runState ??
       createHarnessRunState({
         runId,
         cfcEnforcementMode: this.config.cfcEnforcementMode,
+        currentDir,
         model: this.config.model,
         artifactRoot: this.artifactStore?.runRoot,
         now: this.#now(),
@@ -250,7 +276,21 @@ export class CfHarnessEngine {
     return {
       runId: this.#runState.runId,
       cfcEnforcementMode: this.#runState.cfcEnforcementMode,
+      currentDir: this.#runState.currentDir,
       sandbox: this.sandbox,
+      resolvePath: (path: string) =>
+        this.sandbox.resolvePath(path, this.#runState.currentDir),
+      setCurrentDir: (path: string) => {
+        const resolved = this.sandbox.resolvePath(
+          path,
+          this.#runState.currentDir,
+        );
+        this.#runState = setHarnessRunCurrentDir(
+          this.#runState,
+          resolved,
+          this.#now(),
+        );
+      },
       nextOutputId: (toolId: string) => {
         this.#outputSequence += 1;
         return `${this.#runState.runId}:${toolId}:${this.#outputSequence}` as ToolOutputId;

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -14,6 +14,7 @@ export interface HarnessRunState {
   createdAt: string;
   updatedAt: string;
   cfcEnforcementMode: CfcEnforcementMode;
+  currentDir: string;
   model?: string;
   artifactRoot?: string;
   transcriptPath?: string;
@@ -25,6 +26,7 @@ export interface CreateHarnessRunStateOptions {
   runId?: string;
   status?: HarnessRunStatus;
   cfcEnforcementMode: CfcEnforcementMode;
+  currentDir: string;
   model?: string;
   artifactRoot?: string;
   transcriptPath?: string;
@@ -41,6 +43,7 @@ export const createHarnessRunState = (
     createdAt: now,
     updatedAt: now,
     cfcEnforcementMode: options.cfcEnforcementMode,
+    currentDir: options.currentDir,
     ...(options.model !== undefined ? { model: options.model } : {}),
     ...(options.artifactRoot !== undefined
       ? { artifactRoot: options.artifactRoot }
@@ -81,6 +84,16 @@ export const appendHarnessPolicyEvent = (
   ...state,
   updatedAt: now,
   policyEvents: [...state.policyEvents, event],
+});
+
+export const setHarnessRunCurrentDir = (
+  state: HarnessRunState,
+  currentDir: string,
+  now = new Date().toISOString(),
+): HarnessRunState => ({
+  ...state,
+  currentDir,
+  updatedAt: now,
 });
 
 export const setHarnessTranscriptPath = (

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -16,6 +16,9 @@ export const DEFAULT_WORKSPACE_MOUNT_PATH = "/workspace";
 export const DEFAULT_SANDBOX_SHELL = "/bin/sh";
 export const DEFAULT_DOCKER_NETWORK_MODE = "none" as const;
 
+const isWithinRoot = (root: string, path: string): boolean =>
+  path === root || path.startsWith(`${root}/`);
+
 export const resolveDockerRunscSandboxConfig = (
   options: ResolveDockerRunscSandboxConfigOptions,
 ): DockerRunscSandboxConfig => ({
@@ -43,11 +46,21 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
     return this.config.workspaceMountPath;
   }
 
-  resolvePath(path: string): string {
-    if (isAbsolute(path)) {
-      return normalize(path);
+  isPathWithinWorkspace(path: string): boolean {
+    return isWithinRoot(
+      this.config.workspaceMountPath,
+      normalize(path),
+    );
+  }
+
+  resolvePath(path: string, cwd?: string): string {
+    const normalized = isAbsolute(path)
+      ? normalize(path)
+      : normalize(join(cwd ?? this.defaultWorkingDirectory(), path));
+    if (!this.isPathWithinWorkspace(normalized)) {
+      throw new Error(`path escapes workspace root: ${path}`);
     }
-    return normalize(join(this.config.workspaceMountPath, path));
+    return normalized;
   }
 
   run(request: SandboxCommandRequest): Promise<SandboxCommandResult> {

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -16,8 +16,19 @@ export const DEFAULT_WORKSPACE_MOUNT_PATH = "/workspace";
 export const DEFAULT_SANDBOX_SHELL = "/bin/sh";
 export const DEFAULT_DOCKER_NETWORK_MODE = "none" as const;
 
-const isWithinRoot = (root: string, path: string): boolean =>
-  path === root || path.startsWith(`${root}/`);
+const normalizeWorkspacePath = (path: string): string => {
+  const normalized = normalize(path);
+  return normalized.length > 1 && normalized.endsWith("/")
+    ? normalized.slice(0, -1)
+    : normalized;
+};
+
+const isWithinRoot = (root: string, path: string): boolean => {
+  const normalizedRoot = normalizeWorkspacePath(root);
+  const normalizedPath = normalizeWorkspacePath(path);
+  return normalizedPath === normalizedRoot ||
+    normalizedPath.startsWith(`${normalizedRoot}/`);
+};
 
 export const resolveDockerRunscSandboxConfig = (
   options: ResolveDockerRunscSandboxConfigOptions,
@@ -43,14 +54,11 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
   ) {}
 
   defaultWorkingDirectory(): string {
-    return this.config.workspaceMountPath;
+    return normalizeWorkspacePath(this.config.workspaceMountPath);
   }
 
   isPathWithinWorkspace(path: string): boolean {
-    return isWithinRoot(
-      this.config.workspaceMountPath,
-      normalize(path),
-    );
+    return isWithinRoot(this.config.workspaceMountPath, path);
   }
 
   resolvePath(path: string, cwd?: string): string {

--- a/packages/cf-harness/src/sandbox/types.ts
+++ b/packages/cf-harness/src/sandbox/types.ts
@@ -50,7 +50,8 @@ export interface SandboxCommandResult {
 
 export interface SandboxRuntime {
   readonly kind: HarnessSandboxKind;
-  resolvePath(path: string): string;
+  resolvePath(path: string, cwd?: string): string;
+  isPathWithinWorkspace(path: string): boolean;
   defaultWorkingDirectory(): string;
   run(request: SandboxCommandRequest): Promise<SandboxCommandResult>;
   runShell(request: SandboxShellRequest): Promise<SandboxCommandResult>;

--- a/packages/cf-harness/src/tools/bash.ts
+++ b/packages/cf-harness/src/tools/bash.ts
@@ -13,7 +13,25 @@ export interface BashToolOutput {
   stdout: string;
   stderr: string;
   exitCode: number;
+  cwd: string;
 }
+
+const cwdMarkerForOutput = (outputId: string): string =>
+  `__CF_HARNESS_CWD__${outputId}__`;
+
+const extractFinalWorkingDirectory = (
+  stdout: string,
+  marker: string,
+): { stdout: string; cwd?: string } => {
+  const markerIndex = stdout.lastIndexOf(marker);
+  if (markerIndex === -1) {
+    return { stdout };
+  }
+  return {
+    stdout: stdout.slice(0, markerIndex),
+    cwd: stdout.slice(markerIndex + marker.length),
+  };
+};
 
 export const bashToolDescriptor: HarnessToolDescriptor = {
   toolId: "bash",
@@ -38,8 +56,9 @@ export const bashToolDescriptor: HarnessToolDescriptor = {
       stdout: { type: "string" },
       stderr: { type: "string" },
       exitCode: { type: "number" },
+      cwd: { type: "string" },
     },
-    required: ["outputId", "stdout", "stderr", "exitCode"],
+    required: ["outputId", "stdout", "stderr", "exitCode", "cwd"],
     additionalProperties: false,
   } satisfies JSONSchema,
   tags: ["shell", "vm", "command"],
@@ -48,16 +67,32 @@ export const bashToolDescriptor: HarnessToolDescriptor = {
 export const bashTool: HarnessToolDefinition<BashToolInput, BashToolOutput> = {
   descriptor: bashToolDescriptor,
   async invoke(context, input) {
+    const outputId = context.nextOutputId("bash");
+    const commandCwd = input.cwd !== undefined
+      ? context.resolvePath(input.cwd)
+      : context.currentDir;
+    const cwdMarker = cwdMarkerForOutput(outputId);
     const result = await context.sandbox.runShell({
-      command: input.command,
-      cwd: input.cwd,
+      command: [
+        `__cf_harness_cwd_marker=${JSON.stringify(cwdMarker)}`,
+        'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
+        input.command,
+      ].join("\n"),
+      cwd: commandCwd,
       timeoutMs: input.timeoutMs,
     });
+    const parsedResult = extractFinalWorkingDirectory(result.stdout, cwdMarker);
+    const nextCurrentDir = parsedResult.cwd !== undefined &&
+        context.sandbox.isPathWithinWorkspace(parsedResult.cwd)
+      ? parsedResult.cwd
+      : commandCwd;
+    context.setCurrentDir(nextCurrentDir);
     return {
-      outputId: context.nextOutputId("bash"),
-      stdout: result.stdout,
+      outputId,
+      stdout: parsedResult.stdout,
       stderr: result.stderr,
       exitCode: result.exitCode,
+      cwd: nextCurrentDir,
     };
   },
 };

--- a/packages/cf-harness/src/tools/read-file.ts
+++ b/packages/cf-harness/src/tools/read-file.ts
@@ -55,7 +55,7 @@ export const readFileTool: HarnessToolDefinition<
     ) {
       throw new Error("read_file maxBytes must be a non-negative integer");
     }
-    const resolvedPath = context.sandbox.resolvePath(input.path);
+    const resolvedPath = context.resolvePath(input.path);
     const result = await context.sandbox.runShell({
       command: [
         "set -eu",

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -7,6 +7,9 @@ export interface HarnessToolContext {
   runId: string;
   cfcEnforcementMode: CfcEnforcementMode;
   sandbox: SandboxRuntime;
+  currentDir: string;
+  resolvePath(path: string): string;
+  setCurrentDir(path: string): void;
   nextOutputId(toolId: string): ToolOutputId;
 }
 

--- a/packages/cf-harness/src/tools/write-file.ts
+++ b/packages/cf-harness/src/tools/write-file.ts
@@ -58,7 +58,7 @@ export const writeFileTool: HarnessToolDefinition<
 > = {
   descriptor: writeFileToolDescriptor,
   async invoke(context, input) {
-    const resolvedPath = context.sandbox.resolvePath(input.path);
+    const resolvedPath = context.resolvePath(input.path);
     const mode = input.mode ?? "replace";
     await context.sandbox.runShell({
       command: [

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { join } from "@std/path";
+import { normalize } from "@std/path/posix";
 import {
   createFileSystemHarnessArtifactStore,
   readHarnessRunArtifacts,
@@ -24,8 +25,12 @@ class FakeSandboxRuntime implements SandboxRuntime {
     private readonly shellResults: SandboxCommandResult[] = [],
   ) {}
 
-  resolvePath(path: string): string {
-    return path.startsWith("/") ? path : `/workspace/${path}`;
+  resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
+    return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
   }
 
   defaultWorkingDirectory(): string {
@@ -93,6 +98,7 @@ Deno.test({
           stdout: "hello\n",
           stderr: "",
           exitCode: 0,
+          cwd: "/workspace",
         },
       );
       assertEquals(persistedState, {
@@ -101,6 +107,7 @@ Deno.test({
         createdAt: "2026-04-15T21:00:00.000Z",
         updatedAt: "2026-04-15T21:00:03.000Z",
         cfcEnforcementMode: "observe",
+        currentDir: "/workspace",
         artifactRoot: runRoot,
         policyEvents: [],
         toolOutputs: [result.resultRef],

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -213,6 +213,27 @@ Deno.test("parseCfHarnessCliArgs resolves an initial cwd within the workspace", 
   assertEquals(parsed.cwd, "/workspace/.ops");
 });
 
+Deno.test("parseCfHarnessCliArgs rejects an initial cwd outside the workspace", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--workspace",
+          "/tmp/project",
+          "--cwd",
+          "..",
+          "--prompt",
+          "hi",
+        ],
+        {
+          env: {},
+        },
+      ),
+    Error,
+    "--cwd must stay within the workspace",
+  );
+});
+
 Deno.test("parseCfHarnessCliArgs supports prompt-slot-role override", async () => {
   const parsed = await parseCfHarnessCliArgs(
     ["--prompt", "hi", "--prompt-slot-role", "context"],

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -192,6 +192,27 @@ Deno.test("parseCfHarnessCliArgs resolves focus-root relative to workspace", asy
   assertEquals(parsed.focusRoot, "/tmp/project/packages/cf-harness");
 });
 
+Deno.test("parseCfHarnessCliArgs resolves an initial cwd within the workspace", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--workspace",
+      "/tmp/project",
+      "--cwd",
+      ".ops",
+      "--prompt",
+      "hi",
+    ],
+    {
+      env: {},
+    },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.cwd, "/workspace/.ops");
+});
+
 Deno.test("parseCfHarnessCliArgs supports prompt-slot-role override", async () => {
   const parsed = await parseCfHarnessCliArgs(
     ["--prompt", "hi", "--prompt-slot-role", "context"],
@@ -311,6 +332,7 @@ Deno.test("runCfHarnessCli executes the prompt loop and prints result metadata",
                   createdAt: "2026-04-15T22:00:00.000Z",
                   updatedAt: "2026-04-15T22:00:01.000Z",
                   cfcEnforcementMode: "disabled",
+                  currentDir: "/workspace",
                   artifactRoot: "/tmp/project/.cf-harness-artifacts/run-cli",
                   transcriptPath:
                     "/tmp/project/.cf-harness-artifacts/run-cli/transcript.json",
@@ -361,6 +383,7 @@ Deno.test("runCfHarnessCli executes the prompt loop and prints result metadata",
           createdAt: "2026-04-15T22:00:00.000Z",
           updatedAt: "2026-04-15T22:00:01.000Z",
           cfcEnforcementMode: "disabled",
+          currentDir: "/workspace",
           artifactRoot: "/tmp/project/.cf-harness-artifacts/run-cli",
           transcriptPath:
             "/tmp/project/.cf-harness-artifacts/run-cli/transcript.json",
@@ -416,6 +439,7 @@ Deno.test("runCfHarnessCli can override the prompt-slot role for testing", async
                 createdAt: "2026-04-16T21:10:00.000Z",
                 updatedAt: "2026-04-16T21:10:01.000Z",
                 cfcEnforcementMode: "disabled",
+                currentDir: "/workspace",
                 artifactRoot:
                   "/tmp/project/.cf-harness-artifacts/run-cli-context",
                 transcriptPath:
@@ -501,6 +525,7 @@ Deno.test("runCfHarnessCli can stream transcript events as they happen", async (
               createdAt: "2026-04-16T22:40:00.000Z",
               updatedAt: "2026-04-16T22:40:01.000Z",
               cfcEnforcementMode: "disabled",
+              currentDir: "/workspace",
               policyEvents: [],
               toolOutputs: [],
             },
@@ -533,6 +558,7 @@ Deno.test("runCfHarnessCli can stream transcript events as they happen", async (
         createdAt: "2026-04-16T22:40:00.000Z",
         updatedAt: "2026-04-16T22:40:01.000Z",
         cfcEnforcementMode: "disabled",
+        currentDir: "/workspace",
         policyEvents: [],
         toolOutputs: [],
       },
@@ -577,6 +603,7 @@ Deno.test("runCfHarnessCli uses plain stdout and no operator guidance in batch m
                 createdAt: "2026-04-16T22:10:00.000Z",
                 updatedAt: "2026-04-16T22:10:01.000Z",
                 cfcEnforcementMode: "disabled",
+                currentDir: "/workspace",
                 policyEvents: [],
                 toolOutputs: [],
               },
@@ -635,6 +662,7 @@ Deno.test("runCfHarnessCli writes a structured batch result sidecar when request
                 createdAt: "2026-04-16T23:10:00.000Z",
                 updatedAt: "2026-04-16T23:10:02.000Z",
                 cfcEnforcementMode: "observe",
+                currentDir: "/workspace",
                 artifactRoot:
                   "/tmp/project/.cf-harness-artifacts/run-cli-batch-json",
                 transcriptPath:
@@ -679,6 +707,7 @@ Deno.test("runCfHarnessCli writes a structured batch result sidecar when request
         createdAt: "2026-04-16T23:10:00.000Z",
         updatedAt: "2026-04-16T23:10:02.000Z",
         cfcEnforcementMode: "observe",
+        currentDir: "/workspace",
         artifactRoot: "/tmp/project/.cf-harness-artifacts/run-cli-batch-json",
         transcriptPath:
           "/tmp/project/.cf-harness-artifacts/run-cli-batch-json/transcript.json",
@@ -836,6 +865,7 @@ Deno.test("runCfHarnessCli allows no-auth gateway mode without an API key", asyn
                   createdAt: "2026-04-16T00:00:00.000Z",
                   updatedAt: "2026-04-16T00:00:01.000Z",
                   cfcEnforcementMode: "disabled",
+                  currentDir: "/workspace",
                   policyEvents: [],
                   toolOutputs: [],
                 },
@@ -866,6 +896,7 @@ Deno.test("runCfHarnessCli allows no-auth gateway mode without an API key", asyn
         createdAt: "2026-04-16T00:00:00.000Z",
         updatedAt: "2026-04-16T00:00:01.000Z",
         cfcEnforcementMode: "disabled",
+        currentDir: "/workspace",
         policyEvents: [],
         toolOutputs: [],
       },
@@ -898,6 +929,7 @@ Deno.test("runCfHarnessCli can resume from persisted run artifacts", async () =>
             createdAt: "2026-04-15T22:10:00.000Z",
             updatedAt: "2026-04-15T22:10:01.000Z",
             cfcEnforcementMode: "disabled",
+            currentDir: "/workspace",
             model: "gpt-5.4",
             artifactRoot: "/tmp/project/.cf-harness-artifacts/run-1",
             transcriptPath:
@@ -928,6 +960,7 @@ Deno.test("runCfHarnessCli can resume from persisted run artifacts", async () =>
                 createdAt: "2026-04-15T22:10:00.000Z",
                 updatedAt: "2026-04-15T22:10:02.000Z",
                 cfcEnforcementMode: "disabled",
+                currentDir: "/workspace",
                 model: "gpt-5.4",
                 artifactRoot: "/tmp/project/.cf-harness-artifacts/run-1",
                 transcriptPath:
@@ -957,6 +990,7 @@ Deno.test("runCfHarnessCli can resume from persisted run artifacts", async () =>
         createdAt: "2026-04-15T22:10:00.000Z",
         updatedAt: "2026-04-15T22:10:02.000Z",
         cfcEnforcementMode: "disabled",
+        currentDir: "/workspace",
         model: "gpt-5.4",
         artifactRoot: "/tmp/project/.cf-harness-artifacts/run-1",
         transcriptPath:
@@ -981,6 +1015,7 @@ Deno.test("formatCfHarnessCliResult includes policy event summaries", () => {
       createdAt: "2026-04-15T22:20:00.000Z",
       updatedAt: "2026-04-15T22:20:01.000Z",
       cfcEnforcementMode: "observe",
+      currentDir: "/workspace",
       policyEvents: [{
         type: "cf-harness.policy-event",
         severity: "warning",
@@ -1022,6 +1057,7 @@ Deno.test("formatCfHarnessCliResult returns plain final text in batch mode", () 
         createdAt: "2026-04-16T22:30:00.000Z",
         updatedAt: "2026-04-16T22:30:01.000Z",
         cfcEnforcementMode: "disabled",
+        currentDir: "/workspace",
         policyEvents: [],
         toolOutputs: [],
       },

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -138,3 +138,22 @@ Deno.test("DockerRunscSandboxRuntime resolvePath rejects paths outside the works
     "path escapes workspace root",
   );
 });
+
+Deno.test("DockerRunscSandboxRuntime accepts workspace paths when the mount path has a trailing slash", () => {
+  const runtime = new DockerRunscSandboxRuntime(
+    resolveDockerRunscSandboxConfig({
+      workspaceHostPath: "/host/project",
+      workspaceMountPath: "/workspace/",
+    }),
+  );
+
+  assertEquals(runtime.defaultWorkingDirectory(), "/workspace");
+  assertEquals(
+    runtime.resolvePath("notes/todo.txt"),
+    "/workspace/notes/todo.txt",
+  );
+  assertEquals(
+    runtime.isPathWithinWorkspace("/workspace/notes/todo.txt"),
+    true,
+  );
+});

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import {
   DockerRunscSandboxRuntime,
   resolveDockerRunscSandboxConfig,
@@ -95,7 +95,7 @@ Deno.test("DockerRunscSandboxRuntime runShell uses the configured shell and reso
 
   await runtime.runShell({
     command: "pwd",
-    cwd: "/tmp/demo",
+    cwd: "/workspace/demo",
     args: ["arg-1", "arg-2"],
   });
 
@@ -111,7 +111,7 @@ Deno.test("DockerRunscSandboxRuntime runShell uses the configured shell and reso
       "--mount",
       "type=bind,src=/host/project,dst=/workspace",
       "-w",
-      "/tmp/demo",
+      "/workspace/demo",
       "alpine:3.20",
       "/bin/sh",
       "-lc",
@@ -123,4 +123,18 @@ Deno.test("DockerRunscSandboxRuntime runShell uses the configured shell and reso
     stdinText: undefined,
     timeoutMs: undefined,
   });
+});
+
+Deno.test("DockerRunscSandboxRuntime resolvePath rejects paths outside the workspace", () => {
+  const runtime = new DockerRunscSandboxRuntime(
+    resolveDockerRunscSandboxConfig({
+      workspaceHostPath: "/host/project",
+    }),
+  );
+
+  assertThrows(
+    () => runtime.resolvePath("../../escape", "/workspace/demo"),
+    Error,
+    "path escapes workspace root",
+  );
 });

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -1,7 +1,9 @@
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { normalize } from "@std/path/posix";
 import { createHarnessPolicyEvent } from "../src/contracts/policy.ts";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
+import type { HarnessRunState } from "../src/run-state.ts";
 import type {
   SandboxCommandRequest,
   SandboxCommandResult,
@@ -18,8 +20,12 @@ class FakeSandboxRuntime implements SandboxRuntime {
     private readonly shellError?: Error,
   ) {}
 
-  resolvePath(path: string): string {
-    return path.startsWith("/") ? path : `/workspace/${path}`;
+  resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
+    return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
   }
 
   defaultWorkingDirectory(): string {
@@ -55,6 +61,7 @@ Deno.test("CfHarnessEngine builds a default docker-runsc sandbox when given a wo
     createdAt: "2026-04-15T19:00:00.000Z",
     updatedAt: "2026-04-15T19:00:00.000Z",
     cfcEnforcementMode: "disabled",
+    currentDir: "/workspace",
     policyEvents: [],
     toolOutputs: [],
   });
@@ -104,6 +111,7 @@ Deno.test("CfHarnessEngine records tool outputs into run state on success", asyn
     createdAt: "2026-04-15T19:00:00.000Z",
     updatedAt: "2026-04-15T19:00:05.000Z",
     cfcEnforcementMode: "observe",
+    currentDir: "/workspace",
     policyEvents: [],
     toolOutputs: [first.resultRef, second.resultRef],
   });
@@ -135,6 +143,7 @@ Deno.test("CfHarnessEngine marks the run as failed when a tool invocation errors
     createdAt: "2026-04-15T19:10:00.000Z",
     updatedAt: "2026-04-15T19:10:02.000Z",
     cfcEnforcementMode: "observe",
+    currentDir: "/workspace",
     policyEvents: [],
     toolOutputs: [],
   });
@@ -149,6 +158,7 @@ Deno.test("CfHarnessEngine getRunState returns a deep clone", () => {
       createdAt: "2026-04-17T20:10:00.000Z",
       updatedAt: "2026-04-17T20:10:01.000Z",
       cfcEnforcementMode: "observe",
+      currentDir: "/workspace",
       policyEvents: [createHarnessPolicyEvent({
         severity: "warning",
         mode: "observe",
@@ -176,6 +186,7 @@ Deno.test("CfHarnessEngine getRunState returns a deep clone", () => {
     createdAt: "2026-04-17T20:10:00.000Z",
     updatedAt: "2026-04-17T20:10:01.000Z",
     cfcEnforcementMode: "observe",
+    currentDir: "/workspace",
     policyEvents: [createHarnessPolicyEvent({
       severity: "warning",
       mode: "observe",
@@ -191,4 +202,24 @@ Deno.test("CfHarnessEngine getRunState returns a deep clone", () => {
       artifactPath: "/tmp/original.json",
     }],
   });
+});
+
+Deno.test("CfHarnessEngine rejects legacy run state snapshots without currentDir", () => {
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runState: {
+          runId: "run-legacy",
+          status: "completed",
+          createdAt: "2026-04-20T00:00:00.000Z",
+          updatedAt: "2026-04-20T00:00:01.000Z",
+          cfcEnforcementMode: "observe",
+          policyEvents: [],
+          toolOutputs: [],
+        } as unknown as HarnessRunState,
+      }),
+    Error,
+    "older cf-harness runs cannot be resumed",
+  );
 });

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertRejects } from "@std/assert";
+import { normalize } from "@std/path/posix";
 import type { HarnessArtifactStore } from "../src/artifacts.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
@@ -19,8 +20,12 @@ class FakeSandboxRuntime implements SandboxRuntime {
     private readonly shellError?: Error,
   ) {}
 
-  resolvePath(path: string): string {
-    return path.startsWith("/") ? path : `/workspace/${path}`;
+  resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
+    return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
   }
 
   defaultWorkingDirectory(): string {
@@ -507,6 +512,7 @@ Deno.test("CfHarnessPromptLoop records observe-mode warnings and still executes 
         stdout: "warned\n",
         stderr: "",
         exitCode: 0,
+        cwd: "/workspace",
       }),
       resultRef: {
         type: "cf-harness.tool-result-ref",

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertRejects } from "@std/assert";
+import { normalize } from "@std/path/posix";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
 import { bashTool } from "../src/tools/bash.ts";
 import { readFileTool } from "../src/tools/read-file.ts";
@@ -19,15 +20,19 @@ class FakeSandboxRuntime implements SandboxRuntime {
   > = [];
 
   constructor(
-    private readonly shellResult: SandboxCommandResult = {
+    private readonly shellResults: SandboxCommandResult[] = [{
       stdout: "",
       stderr: "",
       exitCode: 0,
-    },
+    }],
   ) {}
 
-  resolvePath(path: string): string {
-    return path.startsWith("/") ? path : `/workspace/${path}`;
+  resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
+    return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
   }
 
   defaultWorkingDirectory(): string {
@@ -36,31 +41,53 @@ class FakeSandboxRuntime implements SandboxRuntime {
 
   run(request: SandboxCommandRequest): Promise<SandboxCommandResult> {
     this.calls.push({ type: "run", request });
-    return Promise.resolve(this.shellResult);
+    return Promise.resolve(
+      this.shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+    );
   }
 
   runShell(request: SandboxShellRequest): Promise<SandboxCommandResult> {
     this.calls.push({ type: "runShell", request });
-    return Promise.resolve(this.shellResult);
+    return Promise.resolve(
+      this.shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+    );
   }
 }
 
-const createContext = (sandbox: SandboxRuntime): HarnessToolContext => ({
-  runId: "run-1",
-  cfcEnforcementMode: "observe",
-  sandbox,
-  nextOutputId(toolId) {
-    return createToolOutputId("run-1", toolId, 1);
-  },
-});
+const createContext = (
+  sandbox: SandboxRuntime,
+  initialCurrentDir = "/workspace",
+): HarnessToolContext => {
+  let currentDir = initialCurrentDir;
+  let sequence = 0;
+  return {
+    runId: "run-1",
+    cfcEnforcementMode: "observe",
+    get currentDir() {
+      return currentDir;
+    },
+    sandbox,
+    resolvePath(path: string) {
+      return sandbox.resolvePath(path, currentDir);
+    },
+    setCurrentDir(path: string) {
+      currentDir = sandbox.resolvePath(path, currentDir);
+    },
+    nextOutputId(toolId) {
+      sequence += 1;
+      return createToolOutputId("run-1", toolId, sequence);
+    },
+  };
+};
 
 Deno.test("bash tool executes the command through the sandbox shell runtime", async () => {
-  const sandbox = new FakeSandboxRuntime({
+  const sandbox = new FakeSandboxRuntime([{
     stdout: "ok\n",
     stderr: "",
     exitCode: 0,
-  });
-  const output = await bashTool.invoke(createContext(sandbox), {
+  }]);
+  const context = createContext(sandbox);
+  const output = await bashTool.invoke(context, {
     command: "pwd",
     cwd: "repo",
     timeoutMs: 1000,
@@ -71,27 +98,36 @@ Deno.test("bash tool executes the command through the sandbox shell runtime", as
     stdout: "ok\n",
     stderr: "",
     exitCode: 0,
+    cwd: "/workspace/repo",
   });
   assertEquals(sandbox.calls, [{
     type: "runShell",
     request: {
-      command: "pwd",
-      cwd: "repo",
+      command: [
+        '__cf_harness_cwd_marker="__CF_HARNESS_CWD__run-1:bash:1__"',
+        'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
+        "pwd",
+      ].join("\n"),
+      cwd: "/workspace/repo",
       timeoutMs: 1000,
     },
   }]);
+  assertEquals(context.currentDir, "/workspace/repo");
 });
 
-Deno.test("read_file tool resolves relative paths into the sandbox workspace", async () => {
-  const sandbox = new FakeSandboxRuntime({
+Deno.test("read_file tool resolves relative paths from the session currentDir", async () => {
+  const sandbox = new FakeSandboxRuntime([{
     stdout: "hello",
     stderr: "",
     exitCode: 0,
-  });
-  const output = await readFileTool.invoke(createContext(sandbox), {
-    path: "notes/todo.txt",
-    maxBytes: 32,
-  });
+  }]);
+  const output = await readFileTool.invoke(
+    createContext(sandbox, "/workspace/.ops"),
+    {
+      path: "../notes/todo.txt",
+      maxBytes: 32,
+    },
+  );
 
   assertEquals(output, {
     outputId: "run-1:read_file:1",
@@ -172,6 +208,53 @@ Deno.test("write_file tool supports append mode and passes content over stdin", 
         "esac",
       ].join("\n"),
       args: ["/workspace/notes/log.txt", "append", "true"],
+      stdinText: "line one\n",
+    },
+  });
+});
+
+Deno.test("write_file uses the cwd established by an earlier bash call", async () => {
+  const sandbox = new FakeSandboxRuntime([
+    { stdout: "", stderr: "", exitCode: 0 },
+    { stdout: "", stderr: "", exitCode: 0 },
+  ]);
+  const context = createContext(sandbox);
+
+  await bashTool.invoke(context, {
+    command: "pwd",
+    cwd: "repo",
+  });
+  await writeFileTool.invoke(context, {
+    path: "notes/log.txt",
+    content: "line one\n",
+  });
+
+  assertEquals(context.currentDir, "/workspace/repo");
+  assertEquals(sandbox.calls[1], {
+    type: "runShell",
+    request: {
+      command: [
+        "set -eu",
+        'path="$1"',
+        'mode="$2"',
+        'create_parents="$3"',
+        'if [ "$create_parents" = "true" ]; then',
+        '  mkdir -p "$(dirname "$path")"',
+        "fi",
+        'case "$mode" in',
+        "  replace)",
+        '    cat > "$path"',
+        "    ;;",
+        "  append)",
+        '    cat >> "$path"',
+        "    ;;",
+        "  *)",
+        '    echo "unsupported write mode: $mode" >&2',
+        "    exit 2",
+        "    ;;",
+        "esac",
+      ].join("\n"),
+      args: ["/workspace/repo/notes/log.txt", "replace", "false"],
       stdinText: "line one\n",
     },
   });


### PR DESCRIPTION
## Summary
- add a session-scoped `currentDir` model to `cf-harness`
- make `bash`, `read_file`, and `write_file` share that cwd instead of mixing per-call shell cwd with workspace-root file resolution
- add CLI/config support for an initial cwd and reject legacy resumptions that lack `currentDir`

## Why
Loom `gtd-ops` assumes one coherent filesystem frame rooted at the workspace with execution beginning in `.ops`. Before this change, `bash` could start from a cwd but `read_file` and `write_file` always resolved relative paths from `/workspace`, which made the harness internally inconsistent and broke Loom-style relative path workflows.

## What changed
- threaded `currentDir` through run state and engine tool context
- extended sandbox path resolution to resolve against a provided cwd and reject paths that escape the workspace root
- updated `bash` to default to the session cwd, capture the final cwd, and persist it back into run state
- updated `read_file` and `write_file` to resolve relative paths from the session cwd
- added `--cwd` as the initial working-directory surface
- made pre-`currentDir` run states explicitly non-resumable

## Validation
- `deno fmt packages/cf-harness/src packages/cf-harness/test`
- `deno check packages/cf-harness/mod.ts`
- `ENV=test deno test --allow-read --allow-write packages/cf-harness/test`
- `git diff --check`

The `cf-harness` test suite is green: `77 passed, 0 failed`.
