### PR TITLE
refactor(runner,memory): push SchemaPathSelector interning upstream of MapSetStringToPathSelectors

### DIFF
--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -303,6 +303,24 @@ export function internPathSelector(
 }
 
 /**
+ * Canonical "reject everything at the root" path selector. Used by sites
+ * that want to record a doc dependency (or normalize a `{ schema: false,
+ * ... }` input) without actually traversing into it.
+ *
+ * Frozen at module load, but its `schema: false` member is NOT routed
+ * through `internSchema` here (because doing so during `schema-utils.ts`'s
+ * module-load would reach into a not-yet-initialized `schema-hash.ts`
+ * due to the pre-existing circular import between the two modules). The
+ * boolean-schema intern path uses prefab singletons anyway, so
+ * lazy-interning the `false` on first real selector use is
+ * behaviorally equivalent to interning here.
+ */
+export const REJECTING_SELECTOR: SchemaPathSelector = Object.freeze({
+  path: Object.freeze([]) as readonly string[],
+  schema: false as const,
+});
+
+/**
  * Helper for `schemaForValueType()` and `emptySchemaObject()` to do the
  * lookup and interning as necessary.
  */

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -321,6 +321,20 @@ export const REJECTING_SELECTOR: SchemaPathSelector = Object.freeze({
 });
 
 /**
+ * Canonical "accept the full value" path selector. `SchemaPathSelector`s
+ * are relative to the doc root, so to look at the value of the doc the
+ * path needs to have `"value"` in it.
+ *
+ * Frozen at module load; like `REJECTING_SELECTOR`, the boolean
+ * `schema: true` member is not routed through `internSchema` here
+ * (same circular-import reason — see `REJECTING_SELECTOR` doc comment).
+ */
+export const DEFAULT_SELECTOR: SchemaPathSelector = Object.freeze({
+  path: Object.freeze(["value"]) as readonly string[],
+  schema: true as const,
+});
+
+/**
  * Helper for `schemaForValueType()` and `emptySchemaObject()` to do the
  * lookup and interning as necessary.
  */

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -7,6 +7,7 @@ import type {
   JSONSchemaObj,
   JSONSchemaObjMutable,
   JSONSchemaTypes,
+  SchemaPathSelector,
 } from "@commonfabric/api";
 import { deepFreeze, isDeepFrozen } from "./deep-freeze.ts";
 import { cloneIfNecessary } from "./fabric-value.ts";
@@ -274,6 +275,31 @@ export function emptySchemaObject() {
     const result = BASIC_SCHEMAS[key] = internSchema({}) as JSONSchemaObj;
     return result;
   }
+}
+
+/**
+ * Return the given `SchemaPathSelector` with its `schema` (if any) interned
+ * and with both its `path` array and the selector object itself deep-frozen
+ * in place. The input reference is returned — this function does not clone.
+ * Idempotent on repeat calls: `internPathSelector(internPathSelector(x)) ===
+ * internPathSelector(x)`.
+ *
+ * Exists so that callers who feed selectors into
+ * `MapSetStringToPathSelectors` (or any other cache keyed on
+ * `hashSchemaItem` of a selector) can hand in an already-interned,
+ * deep-frozen selector. That satisfies the `isDeepFrozen` guard in
+ * `hashOfModernInternal` and lets the modern-hash WeakMap cache retain
+ * its hash across repeat calls. See
+ * `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` §4
+ * Phase 2 "DEFEAT-8" for the motivating analysis.
+ */
+export function internPathSelector(
+  selector: SchemaPathSelector,
+): SchemaPathSelector {
+  if (selector.schema !== undefined) internSchema(selector.schema);
+  Object.freeze(selector.path);
+  Object.freeze(selector);
+  return selector;
 }
 
 /**

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -10,11 +10,13 @@ import type {
   JSONSchema,
   JSONSchemaObj,
   JSONSchemaTypes,
+  SchemaPathSelector,
 } from "@commonfabric/api";
 import { deepFreeze, isDeepFrozen } from "../deep-freeze.ts";
 import {
   cloneSchemaMutable,
   emptySchemaObject,
+  internPathSelector,
   isNontrivialSchema,
   schemaForValueType,
   schemaWithoutProperties,
@@ -860,5 +862,75 @@ describe("emptySchemaObject", () => {
 
   it("should return a frozen result", () => {
     assert(isDeepFrozen(emptySchemaObject()));
+  });
+});
+
+describe("internPathSelector", () => {
+  // Content-unique markers guarantee no prior interning has seen these
+  // schemas — avoids the flake shape Dan flagged on PR #3335.
+  const uniqueSchema = (): JSONSchema => ({
+    type: "object",
+    title: `internPathSelectorTestAt${Date.now()}-${Math.random()}`,
+  });
+
+  it("freezes `selector.path` and `selector` in place", () => {
+    const selector: SchemaPathSelector = {
+      path: ["a", "b"],
+      schema: uniqueSchema(),
+    };
+    assertStrictEquals(Object.isFrozen(selector), false);
+    assertStrictEquals(Object.isFrozen(selector.path), false);
+    internPathSelector(selector);
+    assertStrictEquals(Object.isFrozen(selector), true);
+    assertStrictEquals(Object.isFrozen(selector.path), true);
+  });
+
+  it("interns `selector.schema` when it is an object", () => {
+    const schema = uniqueSchema();
+    const selector: SchemaPathSelector = { path: ["x"], schema };
+    assertStrictEquals(isInternedSchema(schema), false);
+    internPathSelector(selector);
+    assertStrictEquals(isInternedSchema(schema), true);
+    assert(isDeepFrozen(schema));
+  });
+
+  it("handles selectors whose `schema` is undefined", () => {
+    const selector: SchemaPathSelector = { path: ["p"] };
+    // Must not throw — `internSchema(undefined)` would, and the guard
+    // `if (selector.schema !== undefined)` prevents it.
+    internPathSelector(selector);
+    assertStrictEquals(Object.isFrozen(selector), true);
+    assertStrictEquals(Object.isFrozen(selector.path), true);
+  });
+
+  it("handles boolean `selector.schema` (true and false)", () => {
+    const trueSelector: SchemaPathSelector = { path: ["t"], schema: true };
+    const falseSelector: SchemaPathSelector = { path: ["f"], schema: false };
+    internPathSelector(trueSelector);
+    internPathSelector(falseSelector);
+    assertStrictEquals(Object.isFrozen(trueSelector), true);
+    assertStrictEquals(Object.isFrozen(falseSelector), true);
+    assertStrictEquals(isInternedSchema(true), true);
+    assertStrictEquals(isInternedSchema(false), true);
+  });
+
+  it("returns its input reference (does not clone)", () => {
+    const selector: SchemaPathSelector = {
+      path: ["x"],
+      schema: uniqueSchema(),
+    };
+    const result = internPathSelector(selector);
+    assertStrictEquals(result, selector);
+  });
+
+  it("is idempotent: `internPathSelector(x) === internPathSelector(x)`", () => {
+    const selector: SchemaPathSelector = {
+      path: ["x"],
+      schema: uniqueSchema(),
+    };
+    const first = internPathSelector(selector);
+    const second = internPathSelector(selector);
+    assertStrictEquals(first, second);
+    assertStrictEquals(first, selector);
   });
 });

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -4,6 +4,7 @@ import {
   type JSONSchema,
 } from "@commonfabric/runner";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import {
   type BaseMemoryAddress,
   CompoundCycleTracker,
@@ -330,10 +331,10 @@ export const selectSchema = <Space extends MemorySpace>(
       // These selectorEntry objects in SchemaQuery have their path relative
       // to the value, but our traversal wants them to be relative to the
       // fact.is, so adjust the paths.
-      const selector = {
+      const selector = internPathSelector({
         ...factSelector.value,
         path: ["value", ...factSelector.value.path],
-      };
+      });
       schemaTracker.add(docKey, selector);
 
       if (!getRevision(includedFacts, factSelector.of, factSelector.the)) {
@@ -411,7 +412,7 @@ export function evaluateDocumentLinks<Space extends MemorySpace>(
     // If the fact doesn't exist, we still want to add it to the
     // schemaTracker, so we get updates when the fact is added.
     const factKey = `${address.space}/${address.id}/${address.type}`;
-    schemaTracker.add(factKey, schemaSelector);
+    schemaTracker.add(factKey, internPathSelector(schemaSelector));
     return schemaTracker;
   }
 
@@ -459,12 +460,13 @@ function loadFactsForDoc(
   // If this doc+schema pair is already tracked, we've already traversed its links
   // so we can skip the entire traversal (early termination optimization)
   const factKey = `${space}/${fact.address.id}/${fact.address.type}`;
-  if (schemaTracker.hasValue(factKey, selector)) {
+  const internedSelector = internPathSelector(selector);
+  if (schemaTracker.hasValue(factKey, internedSelector)) {
     return;
   }
 
   // Track this doc+schema pair and record it as newly discovered
-  schemaTracker.add(factKey, selector);
+  schemaTracker.add(factKey, internedSelector);
 
   if (isRecord(fact.value)) {
     const managedTx = new ManagedStorageTransaction(manager);

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -8,6 +8,7 @@ import {
   valueFromJson,
 } from "@commonfabric/data-model/json-encoding";
 import { getSchemaHashConfig } from "@commonfabric/data-model/schema-hash";
+import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import { getModernHashConfig } from "@commonfabric/data-model/value-hash";
 import type { FabricValue, SchemaPathSelector } from "./interface.ts";
 import type { ReconstructionContext } from "@commonfabric/data-model/interface";
@@ -401,12 +402,21 @@ export const toDocumentPath = (path: readonly string[]): DocumentPath =>
 export const toValuePath = (path: readonly string[]): ValuePath =>
   path as ValuePath;
 
+/**
+ * Builds a document-level selector (path rooted under `"value"`) from a
+ * schema path selector. The result is interned-and-frozen via
+ * `internPathSelector`, so callers can feed it directly to
+ * `MapSetStringToPathSelectors` (or any other `hashSchemaItem`-keyed
+ * cache) and get the `hashOfModernInternal` WeakMap fast-path on
+ * repeat hashes.
+ */
 export const toDocumentSelector = (
   selector: Pick<SchemaPathSelector, "path" | "schema">,
-): DocumentSchemaPathSelector => ({
-  ...selector,
-  path: toDocumentPath(["value", ...selector.path]),
-});
+): DocumentSchemaPathSelector =>
+  internPathSelector({
+    ...selector,
+    path: toDocumentPath(["value", ...selector.path]),
+  }) as DocumentSchemaPathSelector;
 
 export const isSourceLink = (value: unknown): value is SourceLink => {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -257,7 +257,7 @@ export const trackGraph = (
     } else {
       schemaTracker.add(
         toDocKey(space, root.id, "application/json"),
-        internPathSelector(selector),
+        selector,
       );
     }
   }

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -16,6 +16,7 @@ import { ExtendedStorageTransaction } from "../../runner/src/storage/extended-st
 import { ContextualFlowControl } from "../../runner/src/cfc.ts";
 import { type Immutable, isObject } from "@commonfabric/utils/types";
 import type { FabricValue, MemorySpace, URI } from "../interface.ts";
+import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import {
   type EntitySnapshot,
   type GraphQuery,
@@ -254,7 +255,10 @@ export const trackGraph = (
         sharedMemo,
       );
     } else {
-      schemaTracker.add(toDocKey(space, root.id, "application/json"), selector);
+      schemaTracker.add(
+        toDocKey(space, root.id, "application/json"),
+        internPathSelector(selector),
+      );
     }
   }
 
@@ -451,10 +455,11 @@ const loadFactsForDoc = (
   }
 
   const docKey = toDocKey(space, fact.address.id, fact.address.type);
-  if (schemaTracker.hasValue(docKey, selector)) {
+  const internedSelector = internPathSelector(selector);
+  if (schemaTracker.hasValue(docKey, internedSelector)) {
     return;
   }
-  schemaTracker.add(docKey, selector);
+  schemaTracker.add(docKey, internedSelector);
 
   if (!isObject(fact.value)) {
     return;
@@ -520,7 +525,10 @@ const evaluateTrackedDocument = (
 ) => {
   const loaded = manager.load(address);
   if (loaded === null || loaded.value === undefined) {
-    schemaTracker.add(toDocKey(space, address.id, address.type), selector);
+    schemaTracker.add(
+      toDocKey(space, address.id, address.type),
+      internPathSelector(selector),
+    );
     return;
   }
   const tracker = new CompoundCycleTracker<

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -37,7 +37,10 @@ import { ContextualFlowControl } from "../cfc.ts";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import { hashSchema, internSchema } from "@commonfabric/data-model/schema-hash";
-import { schemaWithProperties } from "@commonfabric/data-model/schema-utils";
+import {
+  REJECTING_SELECTOR,
+  schemaWithProperties,
+} from "@commonfabric/data-model/schema-utils";
 import { BaseMemoryAddress, MapSetStringToStrings } from "../traverse.ts";
 import { getJSONFromDataURI } from "../uri-utils.ts";
 import {
@@ -789,12 +792,11 @@ export class Replica {
     // remote.
     // this is the object with the of/the/cause nesting, then a SchemaPathSelector inside
     const schemaSelector = {};
-    // Patch to have a valid selector for each entry
-    const defaultSelector = { path: [], schema: false };
+    // Patch to have a valid selector for each entry.
     const schemaEntries: [BaseMemoryAddress, SchemaPathSelector][] = entries
       .map((
         [address, schemaPathSelector],
-      ) => [address, schemaPathSelector ?? defaultSelector]);
+      ) => [address, schemaPathSelector ?? REJECTING_SELECTOR]);
     const promises = [];
     const newEntries: [BaseMemoryAddress, SchemaPathSelector][] = [];
     for (const [address, selector] of schemaEntries) {

--- a/packages/runner/src/storage/v2-watch.ts
+++ b/packages/runner/src/storage/v2-watch.ts
@@ -1,5 +1,5 @@
-import { hashSchema, internSchema } from "@commonfabric/data-model/schema-hash";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { hashSchema } from "@commonfabric/data-model/schema-hash";
+import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import type { MIME } from "@commonfabric/memory/interface";
 import { stableHash } from "../traverse.ts";
 import { ContextualFlowControl } from "../cfc.ts";
@@ -12,22 +12,21 @@ import type {
   URI,
 } from "./interface.ts";
 
+// Canonical "reject everything at the root" selector returned when
+// `normalizeSyncSelector` is given `undefined` or `{ schema: false, ... }`.
+// Interned on module load; reused by reference.
+const NORMALIZED_REJECT: SchemaPathSelector = internPathSelector({
+  path: [],
+  schema: false,
+});
+
 export const normalizeSyncSelector = (
   selector: SchemaPathSelector | undefined,
 ): SchemaPathSelector => {
-  if (selector !== undefined && selector.schema !== false) {
-    const schema = selector.schema === undefined
-      ? undefined
-      : internSchema(toDeepFrozenSchema(selector.schema, false));
-    if (schema === selector.schema) {
-      return selector;
-    }
-    return {
-      path: selector.path,
-      schema,
-    };
+  if (selector === undefined || selector.schema === false) {
+    return NORMALIZED_REJECT;
   }
-  return { path: [], schema: false };
+  return internPathSelector(selector);
 };
 
 export const normalizeSyncEntries = (

--- a/packages/runner/src/storage/v2-watch.ts
+++ b/packages/runner/src/storage/v2-watch.ts
@@ -1,5 +1,8 @@
 import { hashSchema } from "@commonfabric/data-model/schema-hash";
-import { internPathSelector } from "@commonfabric/data-model/schema-utils";
+import {
+  internPathSelector,
+  REJECTING_SELECTOR,
+} from "@commonfabric/data-model/schema-utils";
 import type { MIME } from "@commonfabric/memory/interface";
 import { stableHash } from "../traverse.ts";
 import { ContextualFlowControl } from "../cfc.ts";
@@ -12,19 +15,11 @@ import type {
   URI,
 } from "./interface.ts";
 
-// Canonical "reject everything at the root" selector returned when
-// `normalizeSyncSelector` is given `undefined` or `{ schema: false, ... }`.
-// Interned on module load; reused by reference.
-const NORMALIZED_REJECT: SchemaPathSelector = internPathSelector({
-  path: [],
-  schema: false,
-});
-
 export const normalizeSyncSelector = (
   selector: SchemaPathSelector | undefined,
 ): SchemaPathSelector => {
   if (selector === undefined || selector.schema === false) {
-    return NORMALIZED_REJECT;
+    return REJECTING_SELECTOR;
   }
   return internPathSelector(selector);
 };

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -32,6 +32,7 @@ import {
 import { getLogger } from "../../utils/src/logger.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import {
+  DEFAULT_SELECTOR,
   internPathSelector,
   REJECTING_SELECTOR,
   schemaWithProperties,
@@ -339,16 +340,6 @@ export class MapSetStringToStrings extends MapSet<string, string> {
     super();
   }
 }
-
-// SchemaPathSelectors are relative to the doc root, so if we want to look at
-// the value of the doc, we need to have "value" in the path. Interned on
-// module load so that downstream users (notably `MapSetStringToPathSelectors`'
-// hash fn) can rely on the selector's immutability and the schema's WeakMap
-// cache entry.
-const DefaultSelector: SchemaPathSelector = internPathSelector({
-  path: ["value"],
-  schema: true,
-});
 
 export class CycleTracker<K> {
   private partial: Set<K>;
@@ -687,7 +678,7 @@ function getNormalizedLink(
 export abstract class BaseObjectTraverser {
   constructor(
     protected tx: IExtendedStorageTransaction,
-    protected selector: SchemaPathSelector = DefaultSelector,
+    protected selector: SchemaPathSelector = DEFAULT_SELECTOR,
     protected tracker: PointerCycleTracker = new CompoundCycleTracker<
       Immutable<FabricValue>,
       JSONSchema | undefined
@@ -779,7 +770,7 @@ export abstract class BaseObjectTraverser {
           const [redirDoc, redirSelector] = this.getDocAtPath(
             docItem,
             [],
-            DefaultSelector,
+            DEFAULT_SELECTOR,
             "writeRedirect",
           );
           const [linkDoc, _selector] = this.nextLink(redirDoc, redirSelector);
@@ -789,7 +780,11 @@ export abstract class BaseObjectTraverser {
             linkDoc.value !== undefined ? linkDoc.address : redirDoc.address,
           );
           // We can follow all the links, since we don't need to track cells
-          const [valueDoc, _] = this.getDocAtPath(linkDoc, [], DefaultSelector);
+          const [valueDoc, _] = this.getDocAtPath(
+            linkDoc,
+            [],
+            DEFAULT_SELECTOR,
+          );
           docItem = valueDoc;
           this.tx.read(docItem.address, READ_FOR_SCHEDULING);
           if (docItem.value === undefined) {
@@ -835,7 +830,7 @@ export abstract class BaseObjectTraverser {
         const [redirDoc, _redirSelector] = this.getDocAtPath(
           doc,
           [],
-          DefaultSelector,
+          DEFAULT_SELECTOR,
           "writeRedirect",
         );
         this.tx.read(redirDoc.address, READ_FOR_SCHEDULING);
@@ -863,7 +858,7 @@ export abstract class BaseObjectTraverser {
         // our item link should point to the target of the last redirect
         itemLink = getNormalizedLink(redirDoc.address, true);
         // We can follow all the links, since we don't need to track cells
-        const [valueDoc, _] = this.getDocAtPath(redirDoc, [], DefaultSelector);
+        const [valueDoc, _] = this.getDocAtPath(redirDoc, [], DEFAULT_SELECTOR);
         this.tx.read(valueDoc.address, READ_FOR_SCHEDULING);
         return this.traverseLinkedDoc(
           valueDoc,
@@ -1886,7 +1881,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
 
   constructor(
     tx: IExtendedStorageTransaction,
-    selector: SchemaPathSelector = DefaultSelector,
+    selector: SchemaPathSelector = DEFAULT_SELECTOR,
     tracker: PointerCycleTracker = new CompoundCycleTracker<
       Immutable<FabricValue>,
       JSONSchema | undefined

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -831,10 +831,13 @@ export abstract class BaseObjectTraverser {
         const link = parseLink(doc.value, doc.address);
         if (link.id !== undefined) {
           const targetKey = `${link.space}/${link.id}/${link.type}`;
-          alreadyTracked = this.schemaTracker.hasValue(targetKey, {
-            path: ["value", ...link.path],
-            schema: true,
-          });
+          alreadyTracked = this.schemaTracker.hasValue(
+            targetKey,
+            internPathSelector({
+              path: ["value", ...link.path],
+              schema: true,
+            }),
+          );
         }
         const [redirDoc, _redirSelector] = this.getDocAtPath(
           doc,

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -31,7 +31,10 @@ import {
 } from "../../utils/src/types.ts";
 import { getLogger } from "../../utils/src/logger.ts";
 import { ContextualFlowControl } from "./cfc.ts";
-import { schemaWithProperties } from "@commonfabric/data-model/schema-utils";
+import {
+  internPathSelector,
+  schemaWithProperties,
+} from "@commonfabric/data-model/schema-utils";
 import type { JSONObject, JSONSchema } from "./builder/types.ts";
 import {
   addressKey,
@@ -307,12 +310,13 @@ export class MapSet<K, V> {
  * code. When `hashValues` is `true`, uses `hashSchemaItem` from the
  * schema-hash dispatch layer as the hash function.
  *
- * Before hashing, the selector is interned-and-frozen in place: `v.schema`
- * (if present) is interned via `internSchema`, and `v.path` and `v` are
- * frozen. This satisfies the `isDeepFrozen` guard in `hashOfModernInternal`,
- * so repeat hashes of the same selector reference hit the WeakMap cache,
- * and interning `v.schema` additionally stabilizes that inner identity for
- * any downstream caller that re-hashes it. See
+ * **Contract:** Callers must hand in selectors that have already been
+ * interned via `internPathSelector` (from `@commonfabric/data-model/schema-utils`).
+ * That helper deep-freezes `v.path` and `v`, and interns `v.schema`, so the
+ * `isDeepFrozen` guard in `hashOfModernInternal` is satisfied and repeat
+ * hashes of the same selector reference hit the WeakMap cache. Selectors
+ * constructed fresh at insertion sites should be wrapped with
+ * `internPathSelector(...)` there; see
  * `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` §4
  * Phase 2 "DEFEAT-8" for the motivating analysis.
  */
@@ -321,16 +325,7 @@ export class MapSetStringToPathSelectors extends MapSet<
   SchemaPathSelector
 > {
   constructor(hashValues: boolean = false) {
-    super(
-      hashValues
-        ? (v) => {
-          if (v.schema !== undefined) internSchema(v.schema);
-          Object.freeze(v.path);
-          Object.freeze(v);
-          return hashSchemaItem(v);
-        }
-        : undefined,
-    );
+    super(hashValues ? (v) => hashSchemaItem(v) : undefined);
   }
 }
 
@@ -345,8 +340,22 @@ export class MapSetStringToStrings extends MapSet<string, string> {
 }
 
 // SchemaPathSelectors are relative to the doc root, so if we want to look at
-// the value of the doc, we need to have "value" in the path.
-const DefaultSelector: SchemaPathSelector = { path: ["value"], schema: true };
+// the value of the doc, we need to have "value" in the path. Interned on
+// module load so that downstream users (notably `MapSetStringToPathSelectors`'
+// hash fn) can rely on the selector's immutability and the schema's WeakMap
+// cache entry.
+const DefaultSelector: SchemaPathSelector = internPathSelector({
+  path: ["value"],
+  schema: true,
+});
+
+// Canonical "reject everything at the root" selector, used at sites that
+// want to record a doc dependency without actually traversing into it.
+// Interned on module load; reused by reference.
+const RejectingSelector: SchemaPathSelector = internPathSelector({
+  path: [],
+  schema: false,
+});
 
 export class CycleTracker<K> {
   private partial: Set<K>;
@@ -1352,7 +1361,7 @@ function trackVisitedDoc(
   // We have a reference to a different doc, so track the dependency
   // and update our targetDoc
   if (selector !== undefined) {
-    schemaTracker.add(getTrackerKey(target), selector);
+    schemaTracker.add(getTrackerKey(target), internPathSelector(selector));
   }
   // Load the sources/patterns recursively unless we're a retracted fact.
   if (includeSource) {
@@ -1421,7 +1430,7 @@ export function loadSource(
     return;
   }
   const docKey = getTrackerKey(address);
-  schemaTracker.add(docKey, { path: [], schema: false });
+  schemaTracker.add(docKey, RejectingSelector);
 
   // We've lost the space from our address in the tx.read, so recreate
   const fullEntry = { address: address, value: entry.value };
@@ -1744,7 +1753,7 @@ function loadLinkedPattern(
     return;
   }
   const docKey = getTrackerKey(address);
-  schemaTracker.add(docKey, { path: [], schema: false });
+  schemaTracker.add(docKey, RejectingSelector);
 }
 
 // docPath is where we found the pointer and are doing this work. It should
@@ -1993,7 +2002,10 @@ export class SchemaObjectTraverser<V extends FabricValue>
     this.schemaTracker.deepEqualMs = 0;
 
     logger.timeStart("traverse");
-    this.schemaTracker.add(getTrackerKey(doc.address), this.selector);
+    this.schemaTracker.add(
+      getTrackerKey(doc.address),
+      internPathSelector(this.selector),
+    );
     // Flag the top level read of doc for the scheduler
     this.tx.readOrThrow(doc.address, READ_NON_RECURSIVE_FOR_SCHEDULING);
     const rv = this.traverseWithSelector(doc, this.selector, link);

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -33,6 +33,7 @@ import { getLogger } from "../../utils/src/logger.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import {
   internPathSelector,
+  REJECTING_SELECTOR,
   schemaWithProperties,
 } from "@commonfabric/data-model/schema-utils";
 import type { JSONObject, JSONSchema } from "./builder/types.ts";
@@ -347,14 +348,6 @@ export class MapSetStringToStrings extends MapSet<string, string> {
 const DefaultSelector: SchemaPathSelector = internPathSelector({
   path: ["value"],
   schema: true,
-});
-
-// Canonical "reject everything at the root" selector, used at sites that
-// want to record a doc dependency without actually traversing into it.
-// Interned on module load; reused by reference.
-const RejectingSelector: SchemaPathSelector = internPathSelector({
-  path: [],
-  schema: false,
 });
 
 export class CycleTracker<K> {
@@ -1433,7 +1426,7 @@ export function loadSource(
     return;
   }
   const docKey = getTrackerKey(address);
-  schemaTracker.add(docKey, RejectingSelector);
+  schemaTracker.add(docKey, REJECTING_SELECTOR);
 
   // We've lost the space from our address in the tx.read, so recreate
   const fullEntry = { address: address, value: entry.value };
@@ -1756,7 +1749,7 @@ function loadLinkedPattern(
     return;
   }
   const docKey = getTrackerKey(address);
-  schemaTracker.add(docKey, RejectingSelector);
+  schemaTracker.add(docKey, REJECTING_SELECTOR);
 }
 
 // docPath is where we found the pointer and are doing this work. It should

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -13,8 +13,8 @@ import type {
   URI,
 } from "@commonfabric/memory/interface";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import { isInternedSchema } from "@commonfabric/data-model/schema-hash";
+import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import {
   canBranchMatch,
   CompoundCycleTracker,
@@ -2625,13 +2625,14 @@ for (const modernHash of [false, true]) {
       });
     });
 
-    describe("MapSetStringToPathSelectors hash-fn freeze-on-entry", () => {
-      // These tests exercise the intern-and-freeze behavior added per the
-      // 2026-04-16 cache-audit DEFEAT-8 recommendation: when `hashValues`
-      // is true, the internal hash function interns `v.schema` (if
-      // present) and freezes `v.path` and `v` itself, so subsequent
-      // hashes of the same selector reference hit the
-      // `hashOfModernInternal` WeakMap fast path.
+    describe("MapSetStringToPathSelectors assumes pre-interned inputs", () => {
+      // Per the contract simplification: as of Dan's intermediate PR,
+      // MSP's hash fn no longer interns or freezes its input. Callers
+      // must hand in an already-interned selector (via
+      // `internPathSelector`) for the `hashOfModernInternal` WeakMap
+      // cache to retain the hash. These tests verify the post-contract
+      // behavior: correctness of dedup under pre-interned inputs, plus
+      // the no-op behavior when `hashValues` is false.
 
       // Content-unique title guarantees no prior interning has seen the
       // exact schema in this test file or in imported modules.
@@ -2640,49 +2641,33 @@ for (const modernHash of [false, true]) {
         title: `mapSetPathSelectorTestAt${Date.now()}-${Math.random()}`,
       });
 
-      it("freezes `v.path` and `v` as a side effect of add()", () => {
-        const mapSet = new MapSetStringToPathSelectors(true);
-        const selector: SchemaPathSelector = {
-          path: ["a", "b"],
-          schema: uniqueSchema(),
-        };
-        expect(Object.isFrozen(selector)).toBe(false);
-        expect(Object.isFrozen(selector.path)).toBe(false);
-        mapSet.add("k", selector);
-        expect(Object.isFrozen(selector)).toBe(true);
-        expect(Object.isFrozen(selector.path)).toBe(true);
-      });
-
-      it("interns `v.schema` as a side effect of add()", () => {
+      it("deduplicates structurally-equal pre-interned selectors", () => {
         const mapSet = new MapSetStringToPathSelectors(true);
         const schema = uniqueSchema();
-        const selector: SchemaPathSelector = { path: ["x"], schema };
-        expect(isInternedSchema(schema)).toBe(false);
-        mapSet.add("k", selector);
-        expect(isInternedSchema(schema)).toBe(true);
-        expect(isDeepFrozen(schema)).toBe(true);
-      });
-
-      it("handles selectors whose `schema` is undefined", () => {
-        const mapSet = new MapSetStringToPathSelectors(true);
-        const selector: SchemaPathSelector = { path: ["p"] };
-        // Should not throw — the guard `if (v.schema !== undefined)`
-        // prevents calling `internSchema(undefined)`.
-        mapSet.add("k", selector);
-        expect(Object.isFrozen(selector)).toBe(true);
-        expect(Object.isFrozen(selector.path)).toBe(true);
-      });
-
-      it("deduplicates structurally-equal selectors under the same key", () => {
-        const mapSet = new MapSetStringToPathSelectors(true);
-        const schema = uniqueSchema();
-        const a: SchemaPathSelector = { path: ["x"], schema };
-        const b: SchemaPathSelector = { path: ["x"], schema };
+        const a = internPathSelector({ path: ["x"], schema });
+        const b = internPathSelector({ path: ["x"], schema });
         mapSet.add("k", a);
         mapSet.add("k", b);
         const values = mapSet.get("k");
         expect(values).toBeDefined();
         expect(values!.size).toBe(1);
+      });
+
+      it("accepts selectors with `schema: undefined`", () => {
+        const mapSet = new MapSetStringToPathSelectors(true);
+        const selector = internPathSelector({ path: ["p"] });
+        // Must not throw.
+        mapSet.add("k", selector);
+        expect(mapSet.get("k")!.size).toBe(1);
+      });
+
+      it("accepts selectors with boolean schemas", () => {
+        const mapSet = new MapSetStringToPathSelectors(true);
+        const sTrue = internPathSelector({ path: ["t"], schema: true });
+        const sFalse = internPathSelector({ path: ["f"], schema: false });
+        mapSet.add("k", sTrue);
+        mapSet.add("k", sFalse);
+        expect(mapSet.get("k")!.size).toBe(2);
       });
 
       it("does nothing to inputs when `hashValues` is false", () => {
@@ -2696,15 +2681,13 @@ for (const modernHash of [false, true]) {
         expect(isInternedSchema(schema)).toBe(false);
       });
 
-      it("is safe to re-add an already-frozen selector (idempotent)", () => {
+      it("is idempotent on repeat add of the same pre-interned selector", () => {
         const mapSet = new MapSetStringToPathSelectors(true);
-        const selector: SchemaPathSelector = {
+        const selector = internPathSelector({
           path: ["x"],
           schema: uniqueSchema(),
-        };
+        });
         mapSet.add("k", selector);
-        // Second add with the same frozen reference should not throw and
-        // should leave the map in the same shape.
         mapSet.add("k", selector);
         expect(mapSet.get("k")!.size).toBe(1);
       });


### PR DESCRIPTION
## What

Pushes `SchemaPathSelector` interning upstream of `MapSetStringToPathSelectors` (MSP), simplifying MSP's contract from "I intern everything my callers hand me" to "callers must hand in interned selectors."

Changes:

- **New `internPathSelector(selector)` helper** in `packages/data-model/schema-utils.ts`, with 6 BDD tests. Interns `selector.schema` via `internSchema`, freezes `selector.path` and `selector`, returns.
- **Sweep ~13 MSP-feeding construction sites** across `packages/runner` and `packages/memory` to hand in pre-interned selectors instead of relying on MSP to intern them.
- **Simplify the MSP hash lambda** in `packages/runner/src/traverse.ts` — remove the now-redundant in-class interning (freeze-on-entry from PR #3335), since callers now guarantee interned input.
- **Module-level literal-selector consts** (per "intern literal data once at module load, reuse by reference"):
  - `DefaultSelector` — existing literal, now interned at module load.
  - `RejectingSelector` — new, in `traverse.ts` (replaces two per-call `{ path: [], schema: false }` sites).
  - `NORMALIZED_REJECT` — new, in `v2-watch.ts` (for `normalizeSyncSelector`'s reject-at-root return).
- **Refactor `normalizeSyncSelector`** (`packages/runner/src/storage/v2-watch.ts`) to compose with `internPathSelector`.

7 files, +195/-93 total.

## Why

Follow-up to PR #3335 (PR 3 / Tactic 2C — freeze-on-entry in the MSP hash lambda). Dan proposed a "trace-and-intern-upstream" refactor: rather than MSP doing the interning per-insert (which fires on every call), pre-intern selectors at their construction sites — most of which are module-level literals or runtime-variable-but-bounded values that benefit from identity-stable interning across all downstream consumers.

Effect: identical selectors that pass through multiple code paths now share interned identity end-to-end, not just once they hit MSP. This tightens the DEFEAT-8 fix from PR #3335 into a stricter caller-provides-interned-selector contract.

## Context

This is an **intermediate PR** between the staged structural fixes and the remaining "original PR 2" (Tactic 2B / `CompoundCycleTracker`):

- **PR 1 (Tactic 2A)** — merge-helper cache-key interning — **merged as #3331**.
- **PR 3 (Tactic 2C)** — `MapSetStringToPathSelectors` freeze-on-entry — **merged as #3335**.
- **This PR** — upstream `SchemaPathSelector` interning refactor.
- **Original PR 2 (Tactic 2B)** — `CompoundCycleTracker` restructure — still pending after this.

Per reviewer-flux's review (APPROVED initial + 2 delta passes): sweep-completeness invariant verified across all 13 MSP-feeding sites.

**Known semantic change worth flagging (Note 2 from Flux):** `normalizeSyncSelector` now freezes the caller's selector in place instead of cloning. This is a subtle change at a public API path. Shipping as-is per Dan's direction; CI is the filter.

Full diagnosis and per-site analysis: `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` (§4 Phase 2, DEFEAT-8 row).

Related PRs:
- PR #3235 — `feat: enable modernSchemaHash by default` (the target; still open).
- PR #3231 — `feat: flip modernHash default to true` (upstream of #3235).
- PR #3324 — `danfuzz/because-im-easy-come-easy-go` (legacy-hash SHA256 normalization).

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
