### PR TITLE
More `schema` related cleanup

### DIFF
--- a/packages/data-model/schema-hash.ts
+++ b/packages/data-model/schema-hash.ts
@@ -190,40 +190,6 @@ function resetInternCache(): void {
 seedBooleanInterns();
 
 /**
- * Intern a schema: Freeze it, compute its hash, and cache the bidirectional
- * mapping. Returns the actual interned schema object or, optionally, the full
- * `SchemaAndHash`. The returned schema object is the same as (`===` to) the
- * given `schema` only if an identical schema was not already interned.
- *
- * If given a non-deep-frozen `schema`, this function will _always_ make it
- * deep-frozen as a side effect. Callers must be okay with this! This design is
- * motivated by the desire to minimize unnecessary cloning of objects, colored
- * by the observation that most mutable schemas are built by starting with an
- * effectively -- if not actually -- deep-immutable schema and selectively
- * shallow-cloned as mutable, for the express purpose of tactical modification
- * and then immediately treated once again as deep-immutable.
- */
-export function internSchema(
-  schema: JSONSchema,
-  wantSchemaAndHash?: false,
-): JSONSchema;
-export function internSchema(
-  schema: JSONSchema,
-  wantSchemaAndHash: true,
-): SchemaAndHash;
-export function internSchema(
-  schema: JSONSchema,
-  wantSchemaAndHash?: boolean,
-): JSONSchema | SchemaAndHash;
-export function internSchema(
-  schema: JSONSchema,
-  wantSchemaAndHash: boolean = false,
-): JSONSchema | SchemaAndHash {
-  const sahResult = internSchemaReturningSchemaAndHash(schema);
-  return wantSchemaAndHash ? sahResult : sahResult.schema;
-}
-
-/**
  * Helper for `internSchema()` which always returns a `SchemaAndHash`.
  */
 function internSchemaReturningSchemaAndHash(schema: JSONSchema): SchemaAndHash {
@@ -272,6 +238,40 @@ function internSchemaReturningSchemaAndHash(schema: JSONSchema): SchemaAndHash {
   schemaFinalizer.register(frozen, hashStr);
 
   return sah;
+}
+
+/**
+ * Intern a schema: Freeze it, compute its hash, and cache the bidirectional
+ * mapping. Returns the actual interned schema object or, optionally, the full
+ * `SchemaAndHash`. The returned schema object is the same as (`===` to) the
+ * given `schema` only if an identical schema was not already interned.
+ *
+ * If given a non-deep-frozen `schema`, this function will _always_ make it
+ * deep-frozen as a side effect. Callers must be okay with this! This design is
+ * motivated by the desire to minimize unnecessary cloning of objects, colored
+ * by the observation that most mutable schemas are built by starting with an
+ * effectively -- if not actually -- deep-immutable schema and selectively
+ * shallow-cloned as mutable, for the express purpose of tactical modification
+ * and then immediately treated once again as deep-immutable.
+ */
+export function internSchema(
+  schema: JSONSchema,
+  wantSchemaAndHash?: false,
+): JSONSchema;
+export function internSchema(
+  schema: JSONSchema,
+  wantSchemaAndHash: true,
+): SchemaAndHash;
+export function internSchema(
+  schema: JSONSchema,
+  wantSchemaAndHash?: boolean,
+): JSONSchema | SchemaAndHash;
+export function internSchema(
+  schema: JSONSchema,
+  wantSchemaAndHash: boolean = false,
+): JSONSchema | SchemaAndHash {
+  const sahResult = internSchemaReturningSchemaAndHash(schema);
+  return wantSchemaAndHash ? sahResult : sahResult.schema;
 }
 
 /**
@@ -329,36 +329,12 @@ export function isInternedSchema(schema: JSONSchema): boolean {
   return schemaToSah.has(schema);
 }
 
-// ---------------------------------------------------------------------------
-// Interned cache-key helpers
-// ---------------------------------------------------------------------------
-
 /**
  * Interns (and thus deep-freezes) the given schema, returning its hash
  * string. Equivalent to `internSchema(schema, true).hashString`, but names
  * the operation and avoids the non-obvious `true` (`wantSchemaAndHash`)
- * argument at call sites. Intended for building stable cache-key strings
- * that also benefit from `internSchema`'s identity-stable WeakMap
- * fast-path on repeat lookups.
+ * argument at call sites.
  */
 export function internSchemaAsHashString(schema: JSONSchema): string {
   return internSchema(schema, true).hashString;
-}
-
-/**
- * Returns a cache-key string for an ordered pair of schemas, each interned
- * (and thus deep-frozen) via `internSchema`. The `|` delimiter is outside
- * the base64url alphabet used by hash strings, so the two halves cannot
- * merge ambiguously.
- *
- * Used at the `traverse.ts` sites that key an intern cache on a merge
- * operation's two input schemas. Interning the inputs stabilizes their
- * identities in `internSchema`'s WeakMap, so subsequent calls with the
- * same object references hit the hash-cache fast path in O(1) rather
- * than re-hashing. See
- * `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` §1
- * for the motivating regression.
- */
-export function internedPairKey(a: JSONSchema, b: JSONSchema): string {
-  return `${internSchemaAsHashString(a)}|${internSchemaAsHashString(b)}`;
 }

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -369,6 +369,6 @@ export const DEFAULT_SELECTOR: SchemaPathSelector = Object.freeze({
  * `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` §1
  * for the motivating regression.
  */
-export function internedPairKey(a: JSONSchema, b: JSONSchema): string {
+export function internSchemaPairAsKey(a: JSONSchema, b: JSONSchema): string {
   return `${internSchemaAsHashString(a)}|${internSchemaAsHashString(b)}`;
 }

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -11,7 +11,11 @@ import type {
 } from "@commonfabric/api";
 import { deepFreeze, isDeepFrozen } from "./deep-freeze.ts";
 import { cloneIfNecessary } from "./fabric-value.ts";
-import { internSchema, isInternedSchema } from "./schema-hash.ts";
+import {
+  internSchema,
+  internSchemaAsHashString,
+  isInternedSchema,
+} from "./schema-hash.ts";
 import { type FabricValue } from "./interface.ts";
 
 /**
@@ -19,6 +23,23 @@ import { type FabricValue } from "./interface.ts";
  * interned schemas. Populated lazily.
  */
 const BASIC_SCHEMAS: Record<string, JSONSchemaObj> = {};
+
+/**
+ * Helper for `schemaForValueType()` and `emptySchemaObject()` to do the
+ * lookup and interning as necessary.
+ */
+function getBasicSchema(key: string) {
+  const found = BASIC_SCHEMAS[key];
+
+  if (found) {
+    return found;
+  } else {
+    const result = BASIC_SCHEMAS[key] = internSchema({
+      type: key as JSONSchemaTypes,
+    }) as JSONSchemaObj;
+    return result;
+  }
+}
 
 /**
  * Indicates if the given (nullable) schema is in fact a non-trivial schema. A
@@ -335,18 +356,19 @@ export const DEFAULT_SELECTOR: SchemaPathSelector = Object.freeze({
 });
 
 /**
- * Helper for `schemaForValueType()` and `emptySchemaObject()` to do the
- * lookup and interning as necessary.
+ * Returns a cache-key string for an ordered pair of schemas, each interned
+ * (and thus deep-frozen) via `internSchema`. The `|` delimiter is outside
+ * the base64url alphabet used by hash strings, so the two halves cannot
+ * merge ambiguously.
+ *
+ * Used at the `traverse.ts` sites that key an intern cache on a merge
+ * operation's two input schemas. Interning the inputs stabilizes their
+ * identities in `internSchema`'s WeakMap, so subsequent calls with the
+ * same object references hit the hash-cache fast path in O(1) rather
+ * than re-hashing. See
+ * `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` §1
+ * for the motivating regression.
  */
-function getBasicSchema(key: string) {
-  const found = BASIC_SCHEMAS[key];
-
-  if (found) {
-    return found;
-  } else {
-    const result = BASIC_SCHEMAS[key] = internSchema({
-      type: key as JSONSchemaTypes,
-    }) as JSONSchemaObj;
-    return result;
-  }
+export function internedPairKey(a: JSONSchema, b: JSONSchema): string {
+  return `${internSchemaAsHashString(a)}|${internSchemaAsHashString(b)}`;
 }

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -11,7 +11,6 @@ import {
   hashSchema,
   hashSchemaItem,
   hashSchemaItemAsFabricHash,
-  internedPairKey,
   internSchema,
   internSchemaAsHashString,
   isInternedSchema,
@@ -431,77 +430,6 @@ describe("schema-hash dispatch", () => {
           const first = internSchemaAsHashString(schema);
           const second = internSchemaAsHashString(schema);
           assertStrictEquals(first, second);
-        });
-      });
-
-      describe("internedPairKey()", () => {
-        it("composes the two interned `hashString`s with `|`", () => {
-          const a: JSONSchema = { type: "number" };
-          const b: JSONSchema = { type: "string" };
-          const aHash = internSchema(a, true).hashString;
-          const bHash = internSchema(b, true).hashString;
-          assertStrictEquals(internedPairKey(a, b), `${aHash}|${bHash}`);
-        });
-
-        it("handles boolean schemas on either side", () => {
-          const obj: JSONSchema = { type: "number" };
-          const objHash = internSchema(obj, true).hashString;
-          const trueHash = internSchema(true, true).hashString;
-          const falseHash = internSchema(false, true).hashString;
-          assertStrictEquals(
-            internedPairKey(true, obj),
-            `${trueHash}|${objHash}`,
-          );
-          assertStrictEquals(
-            internedPairKey(obj, false),
-            `${objHash}|${falseHash}`,
-          );
-          assertStrictEquals(
-            internedPairKey(true, false),
-            `${trueHash}|${falseHash}`,
-          );
-        });
-
-        it("is order-sensitive", () => {
-          const a: JSONSchema = { type: "number" };
-          const b: JSONSchema = { type: "string" };
-          assertNotEquals(internedPairKey(a, b), internedPairKey(b, a));
-        });
-
-        it("matches for structurally-equal inputs", () => {
-          const a1: JSONSchema = {
-            type: "object",
-            properties: { x: { type: "string" } },
-          };
-          const a2: JSONSchema = {
-            type: "object",
-            properties: { x: { type: "string" } },
-          };
-          const b1: JSONSchema = { type: "array", items: { type: "number" } };
-          const b2: JSONSchema = { type: "array", items: { type: "number" } };
-          assertStrictEquals(internedPairKey(a1, b1), internedPairKey(a2, b2));
-        });
-
-        it("interns both inputs as a side effect", () => {
-          // Content-unique keys guarantee no prior interning has seen
-          // these exact schemas, so `isInternedSchema` reflects what
-          // THIS call did.
-          const stamp = `${Date.now()}-${Math.random()}`;
-          const a: JSONSchemaObj = {
-            type: "number",
-            title: `schemaHashTestAt${stamp}-a`,
-          };
-          const b: JSONSchemaObj = {
-            type: "string",
-            title: `schemaHashTestAt${stamp}-b`,
-          };
-          assertStrictEquals(isInternedSchema(a), false);
-          assertStrictEquals(isInternedSchema(b), false);
-          internedPairKey(a, b);
-          assertStrictEquals(isInternedSchema(a), true);
-          assertStrictEquals(isInternedSchema(b), true);
-          assert(isDeepFrozen(a));
-          assert(isDeepFrozen(b));
         });
       });
     });

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -17,7 +17,7 @@ import { deepFreeze, isDeepFrozen } from "../deep-freeze.ts";
 import {
   cloneSchemaMutable,
   emptySchemaObject,
-  internedPairKey,
+  internSchemaPairAsKey,
   internPathSelector,
   isNontrivialSchema,
   schemaForValueType,
@@ -867,13 +867,13 @@ describe("emptySchemaObject", () => {
   });
 });
 
-describe("internedPairKey()", () => {
+describe("internSchemaPairAsKey()", () => {
   it("composes the two interned `hashString`s with `|`", () => {
     const a: JSONSchema = { type: "number" };
     const b: JSONSchema = { type: "string" };
     const aHash = internSchema(a, true).hashString;
     const bHash = internSchema(b, true).hashString;
-    assertStrictEquals(internedPairKey(a, b), `${aHash}|${bHash}`);
+    assertStrictEquals(internSchemaPairAsKey(a, b), `${aHash}|${bHash}`);
   });
 
   it("handles boolean schemas on either side", () => {
@@ -882,15 +882,15 @@ describe("internedPairKey()", () => {
     const trueHash = internSchema(true, true).hashString;
     const falseHash = internSchema(false, true).hashString;
     assertStrictEquals(
-      internedPairKey(true, obj),
+      internSchemaPairAsKey(true, obj),
       `${trueHash}|${objHash}`,
     );
     assertStrictEquals(
-      internedPairKey(obj, false),
+      internSchemaPairAsKey(obj, false),
       `${objHash}|${falseHash}`,
     );
     assertStrictEquals(
-      internedPairKey(true, false),
+      internSchemaPairAsKey(true, false),
       `${trueHash}|${falseHash}`,
     );
   });
@@ -898,7 +898,7 @@ describe("internedPairKey()", () => {
   it("is order-sensitive", () => {
     const a: JSONSchema = { type: "number" };
     const b: JSONSchema = { type: "string" };
-    assertNotEquals(internedPairKey(a, b), internedPairKey(b, a));
+    assertNotEquals(internSchemaPairAsKey(a, b), internSchemaPairAsKey(b, a));
   });
 
   it("matches for structurally-equal inputs", () => {
@@ -912,7 +912,7 @@ describe("internedPairKey()", () => {
     };
     const b1: JSONSchema = { type: "array", items: { type: "number" } };
     const b2: JSONSchema = { type: "array", items: { type: "number" } };
-    assertStrictEquals(internedPairKey(a1, b1), internedPairKey(a2, b2));
+    assertStrictEquals(internSchemaPairAsKey(a1, b1), internSchemaPairAsKey(a2, b2));
   });
 
   it("interns both inputs as a side effect", () => {
@@ -930,7 +930,7 @@ describe("internedPairKey()", () => {
     };
     assertStrictEquals(isInternedSchema(a), false);
     assertStrictEquals(isInternedSchema(b), false);
-    internedPairKey(a, b);
+    internSchemaPairAsKey(a, b);
     assertStrictEquals(isInternedSchema(a), true);
     assertStrictEquals(isInternedSchema(b), true);
     assert(isDeepFrozen(a));

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import {
   assert,
   assertEquals,
+  assertNotEquals,
   assertStrictEquals,
   assertThrows,
 } from "@std/assert";
@@ -16,6 +17,7 @@ import { deepFreeze, isDeepFrozen } from "../deep-freeze.ts";
 import {
   cloneSchemaMutable,
   emptySchemaObject,
+  internedPairKey,
   internPathSelector,
   isNontrivialSchema,
   schemaForValueType,
@@ -862,6 +864,77 @@ describe("emptySchemaObject", () => {
 
   it("should return a frozen result", () => {
     assert(isDeepFrozen(emptySchemaObject()));
+  });
+});
+
+describe("internedPairKey()", () => {
+  it("composes the two interned `hashString`s with `|`", () => {
+    const a: JSONSchema = { type: "number" };
+    const b: JSONSchema = { type: "string" };
+    const aHash = internSchema(a, true).hashString;
+    const bHash = internSchema(b, true).hashString;
+    assertStrictEquals(internedPairKey(a, b), `${aHash}|${bHash}`);
+  });
+
+  it("handles boolean schemas on either side", () => {
+    const obj: JSONSchema = { type: "number" };
+    const objHash = internSchema(obj, true).hashString;
+    const trueHash = internSchema(true, true).hashString;
+    const falseHash = internSchema(false, true).hashString;
+    assertStrictEquals(
+      internedPairKey(true, obj),
+      `${trueHash}|${objHash}`,
+    );
+    assertStrictEquals(
+      internedPairKey(obj, false),
+      `${objHash}|${falseHash}`,
+    );
+    assertStrictEquals(
+      internedPairKey(true, false),
+      `${trueHash}|${falseHash}`,
+    );
+  });
+
+  it("is order-sensitive", () => {
+    const a: JSONSchema = { type: "number" };
+    const b: JSONSchema = { type: "string" };
+    assertNotEquals(internedPairKey(a, b), internedPairKey(b, a));
+  });
+
+  it("matches for structurally-equal inputs", () => {
+    const a1: JSONSchema = {
+      type: "object",
+      properties: { x: { type: "string" } },
+    };
+    const a2: JSONSchema = {
+      type: "object",
+      properties: { x: { type: "string" } },
+    };
+    const b1: JSONSchema = { type: "array", items: { type: "number" } };
+    const b2: JSONSchema = { type: "array", items: { type: "number" } };
+    assertStrictEquals(internedPairKey(a1, b1), internedPairKey(a2, b2));
+  });
+
+  it("interns both inputs as a side effect", () => {
+    // Content-unique keys guarantee no prior interning has seen
+    // these exact schemas, so `isInternedSchema` reflects what
+    // THIS call did.
+    const stamp = `${Date.now()}-${Math.random()}`;
+    const a: JSONSchemaObj = {
+      type: "number",
+      title: `schemaHashTestAt${stamp}-a`,
+    };
+    const b: JSONSchemaObj = {
+      type: "string",
+      title: `schemaHashTestAt${stamp}-b`,
+    };
+    assertStrictEquals(isInternedSchema(a), false);
+    assertStrictEquals(isInternedSchema(b), false);
+    internedPairKey(a, b);
+    assertStrictEquals(isInternedSchema(a), true);
+    assertStrictEquals(isInternedSchema(b), true);
+    assert(isDeepFrozen(a));
+    assert(isDeepFrozen(b));
   });
 });
 

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -17,8 +17,8 @@ import { deepFreeze, isDeepFrozen } from "../deep-freeze.ts";
 import {
   cloneSchemaMutable,
   emptySchemaObject,
-  internSchemaPairAsKey,
   internPathSelector,
+  internSchemaPairAsKey,
   isNontrivialSchema,
   schemaForValueType,
   schemaWithoutProperties,
@@ -912,7 +912,10 @@ describe("internSchemaPairAsKey()", () => {
     };
     const b1: JSONSchema = { type: "array", items: { type: "number" } };
     const b2: JSONSchema = { type: "array", items: { type: "number" } };
-    assertStrictEquals(internSchemaPairAsKey(a1, b1), internSchemaPairAsKey(a2, b2));
+    assertStrictEquals(
+      internSchemaPairAsKey(a1, b1),
+      internSchemaPairAsKey(a2, b2),
+    );
   });
 
   it("interns both inputs as a side effect", () => {

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -2,7 +2,6 @@ import { hashOf } from "@commonfabric/data-model/value-hash";
 import {
   hashSchema,
   hashSchemaItem,
-  internedPairKey,
   internSchema,
   internSchemaAsHashString,
 } from "@commonfabric/data-model/schema-hash";
@@ -34,6 +33,7 @@ import { ContextualFlowControl } from "./cfc.ts";
 import {
   DEFAULT_SELECTOR,
   internPathSelector,
+  internedPairKey,
   REJECTING_SELECTOR,
   schemaWithProperties,
 } from "@commonfabric/data-model/schema-utils";

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -33,7 +33,7 @@ import { ContextualFlowControl } from "./cfc.ts";
 import {
   DEFAULT_SELECTOR,
   internPathSelector,
-  internedPairKey,
+  internSchemaPairAsKey,
   REJECTING_SELECTOR,
   schemaWithProperties,
 } from "@commonfabric/data-model/schema-utils";
@@ -1455,7 +1455,7 @@ function combineOptionalSchema(
 
 // Merge any schema flags like asCell or asStream from flagSchema into schema.
 export function mergeSchemaFlags(flagSchema: JSONSchema, schema: JSONSchema) {
-  const key = internedPairKey(flagSchema, schema);
+  const key = internSchemaPairAsKey(flagSchema, schema);
   const cached = _mergeSchemaFlagsCache.get(key);
   if (cached !== undefined) return cached;
   const result = _mergeSchemaFlagsUncached(flagSchema, schema);
@@ -1503,7 +1503,7 @@ export function combineSchema(
   parentSchema: JSONSchema,
   linkSchema: JSONSchema,
 ): JSONSchema {
-  const key = internedPairKey(parentSchema, linkSchema);
+  const key = internSchemaPairAsKey(parentSchema, linkSchema);
   const cached = _combineSchemaCache.get(key);
   if (cached !== undefined) return cached;
   const result = _combineSchemaUncached(parentSchema, linkSchema);
@@ -3162,7 +3162,7 @@ function mergeSchemaOption(
   // JSONSchema rules should.
   // For example, `{type: "object", anyOf: [{type: "string"}]}` schema should
   // never match
-  const key = internedPairKey(outerSchema, innerSchema);
+  const key = internSchemaPairAsKey(outerSchema, innerSchema);
   const cached = _mergeSchemaOptionCache.get(key);
   if (cached !== undefined) return cached;
   const result = schemaWithProperties(outerSchema, innerSchema);


### PR DESCRIPTION
This reorgs `schema-hash.ts` and `schema-utils.ts` a bit, including moving and renaming `internedPairKey()` -> `internSchemaPairAsKey()`.