### PR TITLE
More efficient hashing for (a) re-encountered strings, and especially (b) re-encountered _long_ strings.

### DIFF
--- a/packages/data-model/test/value-hash-modern.test.ts
+++ b/packages/data-model/test/value-hash-modern.test.ts
@@ -409,12 +409,12 @@ describe("modernHash", () => {
     const pushShortString = (value: string) => {
       const encoded = enc.encode(value);
       stream.push(0x24, encoded.length, ...encoded);
-    }
+    };
 
     const pushLongString = (value: string) => {
       const hashed = sha256(enc.encode(value));
       stream.push(0xf0, ...hashed);
-    }
+    };
 
     // Deconstructed state is an object with sorted keys.
     // FabricError.DECONSTRUCT() returns:

--- a/packages/data-model/test/value-hash-modern.test.ts
+++ b/packages/data-model/test/value-hash-modern.test.ts
@@ -4,6 +4,7 @@ import {
   hashOfModern as modernHashRaw,
   hashOfModernAsString,
 } from "../value-hash-modern.ts";
+import { encodeULEB128 } from "@commonfabric/leb128";
 import { createHasher } from "@commonfabric/content-hash";
 import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
 import { FabricHash } from "../fabric-hash.ts";
@@ -18,7 +19,7 @@ const nodeCrypto = await import("node:crypto");
  * Compute the SHA-256 hash of a raw byte sequence (for verifying against
  * byte-level spec examples).
  */
-function sha256(bytes: number[]): Uint8Array {
+function sha256(bytes: number[] | Uint8Array): Uint8Array {
   // node:crypto digest() returns Buffer; normalize to plain Uint8Array so
   // expect comparisons against production code (which also normalizes)
   // work correctly.
@@ -406,6 +407,16 @@ describe("modernHash", () => {
     const typeTagUtf8 = enc.encode("Error@1"); // 7 bytes
     const stream: number[] = [0x12, typeTagUtf8.length, ...typeTagUtf8];
 
+    const pushShortString = (value: string) => {
+      const encoded = enc.encode(value);
+      stream.push(0x24, encoded.length, ...encoded);
+    }
+
+    const pushLongString = (value: string) => {
+      const hashed = sha256(enc.encode(value));
+      stream.push(0xf0, ...hashed);
+    }
+
     // Deconstructed state is an object with sorted keys.
     // FabricError.DECONSTRUCT() returns:
     //   { type: "Error", name: null, message: "test", stack: <string> }
@@ -413,40 +424,20 @@ describe("modernHash", () => {
     stream.push(0x11); // TAG_OBJECT
 
     // Key "message" + value "test"
-    const messageKey = enc.encode("message");
-    stream.push(0x24, messageKey.length, ...messageKey);
-    const messageVal = enc.encode("test");
-    stream.push(0x24, messageVal.length, ...messageVal);
+    pushShortString("message");
+    pushShortString("test");
 
     // Key "name" + value null (name === type for Error, so null)
-    const nameKey = enc.encode("name");
-    stream.push(0x24, nameKey.length, ...nameKey);
+    pushShortString("name");
     stream.push(0x20); // TAG_NULL
 
     // Key "stack" + value (the actual stack string)
-    const stackKey = enc.encode("stack");
-    stream.push(0x24, stackKey.length, ...stackKey);
-    const stackUtf8 = enc.encode(error.error.stack!);
-    // LEB128 encode the stack length
-    let stackLen = stackUtf8.length;
-    const stackLenBytes: number[] = [];
-    if (stackLen === 0) {
-      stackLenBytes.push(0);
-    } else {
-      while (stackLen > 0) {
-        let byte = stackLen & 0x7f;
-        stackLen >>>= 7;
-        if (stackLen > 0) byte |= 0x80;
-        stackLenBytes.push(byte);
-      }
-    }
-    stream.push(0x24, ...stackLenBytes, ...stackUtf8);
+    pushShortString("stack");
+    pushLongString(error.error.stack!);
 
     // Key "type" + value "Error"
-    const typeKey = enc.encode("type");
-    stream.push(0x24, typeKey.length, ...typeKey);
-    const typeVal = enc.encode("Error");
-    stream.push(0x24, typeVal.length, ...typeVal);
+    pushShortString("type");
+    pushShortString("Error");
 
     // TAG_END for the object
     stream.push(0x00);

--- a/packages/data-model/test/value-hash-modern.test.ts
+++ b/packages/data-model/test/value-hash-modern.test.ts
@@ -4,7 +4,6 @@ import {
   hashOfModern as modernHashRaw,
   hashOfModernAsString,
 } from "../value-hash-modern.ts";
-import { encodeULEB128 } from "@commonfabric/leb128";
 import { createHasher } from "@commonfabric/content-hash";
 import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
 import { FabricHash } from "../fabric-hash.ts";

--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -66,7 +66,6 @@ const TAG_UNDEFINED_BYTES = new Uint8Array([TAG_UNDEFINED]);
 const TAG_BOOLEAN_TRUE_BYTES = new Uint8Array([TAG_BOOLEAN, 0x01]);
 const TAG_BOOLEAN_FALSE_BYTES = new Uint8Array([TAG_BOOLEAN, 0x00]);
 const TAG_NUMBER_BYTES = new Uint8Array([TAG_NUMBER]);
-const TAG_STRING_BYTES = new Uint8Array([TAG_STRING]);
 const TAG_BYTES_BYTES = new Uint8Array([TAG_BYTES]);
 const TAG_BIGINT_BYTES = new Uint8Array([TAG_BIGINT]);
 const TAG_EPOCH_NSEC_BYTES = new Uint8Array([TAG_EPOCH_NSEC]);

--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -70,32 +70,31 @@ const TAG_EPOCH_DAYS_BYTES = new Uint8Array([TAG_EPOCH_DAYS]);
 const TAG_CONTENT_HASH_BYTES = new Uint8Array([TAG_CONTENT_HASH]);
 
 // ---------------------------------------------------------------------------
-// Shared scratch buffer (safe in single-threaded synchronous JS -- see
-// async safety analysis in PR #2856 review round 2)
+// Core: recursive value feeding
 // ---------------------------------------------------------------------------
-
-/** Reusable 8-byte buffer for float64 encoding. */
-const f64Buf = new ArrayBuffer(8);
-const f64View = new DataView(f64Buf);
-const f64Bytes = new Uint8Array(f64Buf);
 
 /** Shared TextEncoder for UTF-8 string encoding. */
 const encoder = new TextEncoder();
 
-// ---------------------------------------------------------------------------
-// Helper: feed an unsigned LEB128 length prefix
-// ---------------------------------------------------------------------------
+/** Reusable 8-byte buffer for float64 encoding. */
+const f64Buf = new ArrayBuffer(8);
 
+/** Float64 "view" of `f64Buf`. */
+const f64View = new DataView(f64Buf);
+
+/** Byte-array "view" of `f64Buf`. */
+const f64Bytes = new Uint8Array(f64Buf);
+
+/**
+ * Updates an incremental hasher with a length value, using the standard
+ * in-hash encoding for same.
+ */
 function feedLength(hasher: IncrementalHasher, value: number): void {
   hasher.update(encodeULEB128(value));
 }
 
-// ---------------------------------------------------------------------------
-// Core: recursive value feeding
-// ---------------------------------------------------------------------------
-
 /**
- * Feed a single `FabricValue` into the hasher, using the type-tagged
+ * Feeds a single `FabricValue` into the hasher, using the type-tagged
  * byte format from the byte-level spec.
  */
 function feedValue(hasher: IncrementalHasher, value: unknown): void {

--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -12,6 +12,7 @@
 import {
   createHasher,
   type IncrementalHasher,
+  sha256,
 } from "@commonfabric/content-hash";
 import { isDeepFrozen } from "./deep-freeze.ts";
 import { FabricHash } from "./fabric-hash.ts";
@@ -47,6 +48,9 @@ const TAG_BIGINT = 0x26;
 const TAG_EPOCH_NSEC = 0x27;
 const TAG_EPOCH_DAYS = 0x28;
 const TAG_CONTENT_HASH = 0x29;
+
+// Special for hashing:
+const TAG_STRING_HASH = 0xf0;
 
 // ---------------------------------------------------------------------------
 // Pre-allocated tag byte arrays (avoids per-call allocation)
@@ -86,6 +90,55 @@ const f64View = new DataView(f64Buf);
 const f64Bytes = new Uint8Array(f64Buf);
 
 /**
+ * Maximum encoded length of a string which is represented in just-encoded form.
+ * Longer strings are represented in a hash feed as the hash of the string (in
+ * Merkle-ish fashion).
+ */
+const MAX_DIRECT_STRING_LENGTH = 64;
+
+/** LRU cache for string representations. */
+const stringRepCache = new LRUCache<string, Uint8Array>({
+  capacity: 50_000,
+});
+
+/**
+ * Gets the bytes needed to represent the given string, either by computing it
+ * or retrieving a previously-computed result from the cache.
+ */
+function getStringRep(value: string) {
+  const cached = stringRepCache.get(value);
+  if (cached !== undefined) return cached;
+
+  const utf8Buf = encoder.encode(value);
+  const utf8Length = utf8Buf.length;
+
+  let result;
+
+  if (utf8Length <= MAX_DIRECT_STRING_LENGTH) {
+    const lengthBuf = encodeULEB128(utf8Length);
+    const lengthLength = lengthBuf.length;
+
+    // Contents are: tag + utf8Length + utf8.
+    const totalLength = 1 + lengthLength + utf8Length;
+    result = new Uint8Array(totalLength);
+    result[0] = TAG_STRING;
+    result.set(lengthBuf, 1); // After the tag.
+    result.set(utf8Buf, 1 + lengthLength); // After the length.
+  } else {
+    const hashBuf = sha256(utf8Buf);
+
+    // Contents are: tag + hash.
+    const totalLength = 1 + hashBuf.length;
+    result = new Uint8Array(totalLength);
+    result[0] = TAG_STRING_HASH;
+    result.set(hashBuf, 1); // After the tag.
+  }
+
+  stringRepCache.put(value, result);
+  return result;
+}
+
+/**
  * Updates an incremental hasher with a length value, using the standard
  * in-hash encoding for same.
  */
@@ -116,10 +169,7 @@ function feedValue(hasher: IncrementalHasher, value: unknown): void {
       break;
 
     case "string": {
-      hasher.update(TAG_STRING_BYTES);
-      const utf8 = encoder.encode(value);
-      feedLength(hasher, utf8.length);
-      hasher.update(utf8);
+      hasher.update(getStringRep(value));
       break;
     }
 

--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -348,12 +348,9 @@ function feedPlainObject(
 
   hasher.update(TAG_OBJECT_BYTES);
   for (const key of keys) {
-    // Keys are encoded as TAG_STRING-style values (same format as strings).
-    hasher.update(TAG_STRING_BYTES);
-    const keyUtf8 = encoder.encode(key);
-    feedLength(hasher, keyUtf8.length);
-    hasher.update(keyUtf8);
-    // Value is hashed recursively.
+    // Keys are encoded in the same format as strings, and values are hashed
+    // recursively.
+    hasher.update(getStringRep(key));
     feedValue(hasher, value[key]);
   }
   hasher.update(TAG_END_BYTES);


### PR DESCRIPTION
This PR introduces a Merkle-ish tactic when hashing long strings, either standalone or as part of structured values. In particular, when the UTF-8 encoding of a string is longer than a particular threshold (currently defined as `64` but perhaps worth adjusting), the encoded form of the string that gets hashed isn't the length+encoding of the string per se but is instead just the hash of that string.

And in both short and long string cases, the encoding-to-be-hashed is now kept in an LRU cache, to amortize the cost of encoding.

The upshot of this is that: In all cases, a string that is encountered more than once will hash faster (because re-encoding is avoided). And for re-encountered long strings in particular, hashing is faster because the (outer) hash will only ever have to be fed a tag byte and the (inner) string hash instead of the entire encoded string length plus the encoded long string.

Benchmarking indicates that this is a pretty good win in realistic use case scenarios.