### PR TITLE
perf(runner): rekey CompoundCycleTracker inner map on interned hash string (Tactic 2B)

### DIFF
--- a/packages/data-model/deno.json
+++ b/packages/data-model/deno.json
@@ -46,6 +46,7 @@
     "./value-hash-legacy": "./value-hash-legacy.ts",
     "./schema-hash": "./schema-hash.ts",
     "./schema-hash-legacy": "./schema-hash-legacy.ts",
-    "./schema-hash-modern": "./schema-hash-modern.ts"
+    "./schema-hash-modern": "./schema-hash-modern.ts",
+    "./schema-and-hash": "./schema-and-hash.ts"
   }
 }

--- a/packages/data-model/deno.json
+++ b/packages/data-model/deno.json
@@ -46,7 +46,6 @@
     "./value-hash-legacy": "./value-hash-legacy.ts",
     "./schema-hash": "./schema-hash.ts",
     "./schema-hash-legacy": "./schema-hash-legacy.ts",
-    "./schema-hash-modern": "./schema-hash-modern.ts",
-    "./schema-and-hash": "./schema-and-hash.ts"
+    "./schema-hash-modern": "./schema-hash-modern.ts"
   }
 }

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -5,7 +5,6 @@ import {
   internSchema,
   internSchemaAsHashString,
 } from "@commonfabric/data-model/schema-hash";
-import { SchemaAndHash } from "@commonfabric/data-model/schema-and-hash";
 import { MIME } from "@commonfabric/memory/interface";
 import type { JSONSchemaObj } from "@commonfabric/api";
 import type {
@@ -373,14 +372,16 @@ export class CycleTracker<K> {
  * Cycle tracker for more complex objects with multiple parts.
  *
  * Identity check on `partialKey`, structural check on `extraKey` via
- * `internSchema`: the inner per-partialKey map is keyed on the
- * `SchemaAndHash` object identity returned by interning the `extraKey`,
- * so repeat calls with a structurally-equal schema hit the WeakMap in
- * O(1) without re-hashing.
+ * the interned hash string of `extraKey`: the inner per-partialKey map
+ * is keyed on `internSchemaAsHashString(extraKey ?? true)`, so repeat
+ * calls with a structurally-equal schema re-lookup the same entry in
+ * O(1) without re-hashing — the intern cache's WeakMap returns the
+ * canonical hash string without invoking `hashSchemaItem` on
+ * already-interned inputs.
  *
  * An `undefined` `extraKey` is normalized to `true` (JSON Schema's
  * "accept everything", which is exactly what `undefined` means at
- * every current call site), so `internSchema` can always be called.
+ * every current call site), so the intern call can always be made.
  *
  * This will not work correctly if the key is modified after being
  * added.
@@ -390,20 +391,10 @@ export class CompoundCycleTracker<
   ExtraKey extends JSONSchema | undefined,
   Value = unknown,
 > {
-  // partialKey (identity) → WeakMap<SchemaAndHash (interned extraKey), Value?>
-  private partial: Map<EqualKey, WeakMap<SchemaAndHash, Value | undefined>>;
-  // partialKey → live-entry count for its inner WeakMap. Used to eagerly
-  // remove the outer `partial` entry when its inner map's live-entry count
-  // hits zero (WeakMap has no `.size`, so the count is tracked in
-  // parallel). Required because the outer container can't itself be a
-  // WeakMap: `EqualKey` admits primitives (`FabricValue` includes `null |
-  // boolean | number | string | bigint | ...`), which a WeakMap-keyed
-  // outer wouldn't accept. Without this parallel count, long-lived
-  // trackers would retain disposed-of `partialKey` entries indefinitely.
-  private partialCounts: Map<EqualKey, number>;
+  // partialKey (identity) → Map<interned extraKey hashString, Value?>
+  private partial: Map<EqualKey, Map<string, Value | undefined>>;
   constructor() {
     this.partial = new Map();
-    this.partialCounts = new Map();
   }
 
   include(
@@ -414,29 +405,21 @@ export class CompoundCycleTracker<
   ): Disposable | null {
     let existing = this.partial.get(partialKey);
     if (existing === undefined) {
-      existing = new WeakMap();
+      existing = new Map();
       this.partial.set(partialKey, existing);
     }
-    const sah = internSchema(extraKey ?? true, true);
-    if (existing.has(sah)) {
+    const hash = internSchemaAsHashString(extraKey ?? true);
+    if (existing.has(hash)) {
       return null;
     }
-    existing.set(sah, value);
-    this.partialCounts.set(
-      partialKey,
-      (this.partialCounts.get(partialKey) ?? 0) + 1,
-    );
+    existing.set(hash, value);
     return {
       [Symbol.dispose]: () => {
         const entries = this.partial.get(partialKey);
         if (entries) {
-          entries.delete(sah);
-          const count = (this.partialCounts.get(partialKey) ?? 0) - 1;
-          if (count <= 0) {
+          entries.delete(hash);
+          if (entries.size === 0) {
             this.partial.delete(partialKey);
-            this.partialCounts.delete(partialKey);
-          } else {
-            this.partialCounts.set(partialKey, count);
           }
         }
       },
@@ -449,8 +432,8 @@ export class CompoundCycleTracker<
     if (existing === undefined) {
       return undefined;
     }
-    const sah = internSchema(extraKey ?? true, true);
-    return existing.get(sah);
+    const hash = internSchemaAsHashString(extraKey ?? true);
+    return existing.get(hash);
   }
 }
 

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -392,8 +392,18 @@ export class CompoundCycleTracker<
 > {
   // partialKey (identity) → WeakMap<SchemaAndHash (interned extraKey), Value?>
   private partial: Map<EqualKey, WeakMap<SchemaAndHash, Value | undefined>>;
+  // partialKey → live-entry count for its inner WeakMap. Used to eagerly
+  // remove the outer `partial` entry when its inner map's live-entry count
+  // hits zero (WeakMap has no `.size`, so the count is tracked in
+  // parallel). Required because the outer container can't itself be a
+  // WeakMap: `EqualKey` admits primitives (`FabricValue` includes `null |
+  // boolean | number | string | bigint | ...`), which a WeakMap-keyed
+  // outer wouldn't accept. Without this parallel count, long-lived
+  // trackers would retain disposed-of `partialKey` entries indefinitely.
+  private partialCounts: Map<EqualKey, number>;
   constructor() {
     this.partial = new Map();
+    this.partialCounts = new Map();
   }
 
   include(
@@ -412,19 +422,22 @@ export class CompoundCycleTracker<
       return null;
     }
     existing.set(sah, value);
+    this.partialCounts.set(
+      partialKey,
+      (this.partialCounts.get(partialKey) ?? 0) + 1,
+    );
     return {
       [Symbol.dispose]: () => {
         const entries = this.partial.get(partialKey);
         if (entries) {
           entries.delete(sah);
-          // Note: WeakMap has no `size`, so we can't eagerly delete an
-          // empty inner map here the way the prior `Map<string, …>`
-          // version did. That's fine: the inner WeakMap itself is
-          // retained only as long as `partialKey` is retained in the
-          // outer Map, and its entries are GC'd when the keying
-          // `SchemaAndHash` objects go out of scope. Downstream
-          // callers do not depend on observing the "empty inner map"
-          // state (it was an internal optimization, not a contract).
+          const count = (this.partialCounts.get(partialKey) ?? 0) - 1;
+          if (count <= 0) {
+            this.partial.delete(partialKey);
+            this.partialCounts.delete(partialKey);
+          } else {
+            this.partialCounts.set(partialKey, count);
+          }
         }
       },
     };

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -5,6 +5,7 @@ import {
   internSchema,
   internSchemaAsHashString,
 } from "@commonfabric/data-model/schema-hash";
+import { SchemaAndHash } from "@commonfabric/data-model/schema-and-hash";
 import { MIME } from "@commonfabric/memory/interface";
 import type { JSONSchemaObj } from "@commonfabric/api";
 import type {
@@ -371,24 +372,30 @@ export class CycleTracker<K> {
 /**
  * Cycle tracker for more complex objects with multiple parts.
  *
- * This will not work correctly if the key is modified after being added.
+ * Identity check on `partialKey`, structural check on `extraKey` via
+ * `internSchema`: the inner per-partialKey map is keyed on the
+ * `SchemaAndHash` object identity returned by interning the `extraKey`,
+ * so repeat calls with a structurally-equal schema hit the WeakMap in
+ * O(1) without re-hashing.
+ *
+ * An `undefined` `extraKey` is normalized to `true` (JSON Schema's
+ * "accept everything", which is exactly what `undefined` means at
+ * every current call site), so `internSchema` can always be called.
+ *
+ * This will not work correctly if the key is modified after being
+ * added.
  */
 export class CompoundCycleTracker<
   EqualKey,
-  ExtraKey extends FabricValue,
+  ExtraKey extends JSONSchema | undefined,
   Value = unknown,
 > {
-  // partialKey (identity) → Map<hash(extraKey), Value?>
-  private partial: Map<EqualKey, Map<string, Value | undefined>>;
+  // partialKey (identity) → WeakMap<SchemaAndHash (interned extraKey), Value?>
+  private partial: Map<EqualKey, WeakMap<SchemaAndHash, Value | undefined>>;
   constructor() {
     this.partial = new Map();
   }
 
-  /**
-   * Identity check on `partialKey`, hash-based check on `extraKey`.
-   * Uses `hashSchemaItem` (with WeakMap identity cache in legacy mode)
-   * so schema objects hash in O(1) amortized after the first call.
-   */
   include(
     partialKey: EqualKey,
     extraKey: ExtraKey,
@@ -397,22 +404,27 @@ export class CompoundCycleTracker<
   ): Disposable | null {
     let existing = this.partial.get(partialKey);
     if (existing === undefined) {
-      existing = new Map();
+      existing = new WeakMap();
       this.partial.set(partialKey, existing);
     }
-    const hash = hashSchemaItem(extraKey);
-    if (existing.has(hash)) {
+    const sah = internSchema(extraKey ?? true, true);
+    if (existing.has(sah)) {
       return null;
     }
-    existing.set(hash, value);
+    existing.set(sah, value);
     return {
       [Symbol.dispose]: () => {
         const entries = this.partial.get(partialKey);
         if (entries) {
-          entries.delete(hash);
-          if (entries.size === 0) {
-            this.partial.delete(partialKey);
-          }
+          entries.delete(sah);
+          // Note: WeakMap has no `size`, so we can't eagerly delete an
+          // empty inner map here the way the prior `Map<string, …>`
+          // version did. That's fine: the inner WeakMap itself is
+          // retained only as long as `partialKey` is retained in the
+          // outer Map, and its entries are GC'd when the keying
+          // `SchemaAndHash` objects go out of scope. Downstream
+          // callers do not depend on observing the "empty inner map"
+          // state (it was an internal optimization, not a contract).
         }
       },
     };
@@ -424,8 +436,8 @@ export class CompoundCycleTracker<
     if (existing === undefined) {
       return undefined;
     }
-    const hash = hashSchemaItem(extraKey);
-    return existing.get(hash);
+    const sah = internSchema(extraKey ?? true, true);
+    return existing.get(sah);
   }
 }
 

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -1567,13 +1567,105 @@ for (const modernHash of [false, true]) {
     });
 
     describe("CompoundCycleTracker cleanup", () => {
-      it("removes empty partial-key entries on dispose", () => {
+      it("removes the inner (partialKey, extraKey) entry on dispose", () => {
         const tracker = new CompoundCycleTracker<object, boolean>();
         const key = { id: "k1" };
         const disposable = tracker.include(key, true);
         expect(disposable).not.toBeNull();
         disposable![Symbol.dispose]();
-        expect((tracker as any).partial.size).toBe(0);
+        // Re-including the same (key, extraKey) pair must succeed — if the
+        // prior include's entry had not been removed, this would be a cycle
+        // and the call would return null.
+        const disposable2 = tracker.include(key, true);
+        expect(disposable2).not.toBeNull();
+        disposable2![Symbol.dispose]();
+
+        // Note: unlike the prior `Map<string, …>` implementation, the
+        // WeakMap-based one does NOT eagerly delete the outer `partialKey`
+        // entry when its inner map becomes empty (WeakMap has no `.size`).
+        // The inner WeakMap is retained only as long as `partialKey` is
+        // retained in the outer Map, and its entries are GC'd when the
+        // keying `SchemaAndHash` objects go out of scope, so this is not
+        // a leak for the tracker's intended scope-bounded use. No caller
+        // depends on observing the "empty inner map" state.
+      });
+    });
+
+    describe("CompoundCycleTracker WeakMap restructure (Tactic 2B)", () => {
+      it("detects cycles on structurally-equal extraKey (not just identity)", () => {
+        const tracker = new CompoundCycleTracker<
+          object,
+          JSONSchema | undefined
+        >();
+        const key = { id: "k1" };
+        // Two distinct object references with structurally-equal content.
+        const schemaA: JSONSchema = {
+          type: "object",
+          title: `cctWeakmapTestAt${Date.now()}-${Math.random()}`,
+        };
+        const schemaB: JSONSchema = { ...schemaA };
+        const first = tracker.include(key, schemaA);
+        expect(first).not.toBeNull();
+        // Re-including with a structurally-equal-but-non-identical schema
+        // must detect the cycle via `internSchema`'s structural dedup.
+        const second = tracker.include(key, schemaB);
+        expect(second).toBeNull();
+      });
+
+      it("treats `undefined` extraKey as `true` (JSON Schema accept-all)", () => {
+        const tracker = new CompoundCycleTracker<
+          object,
+          JSONSchema | undefined
+        >();
+        const key = { id: "k1" };
+        const first = tracker.include(key, undefined);
+        expect(first).not.toBeNull();
+        // Re-including with `true` must collide with the prior `undefined`
+        // call — the class normalizes both to the same interned schema.
+        const second = tracker.include(key, true);
+        expect(second).toBeNull();
+        // And vice-versa.
+        const key2 = { id: "k2" };
+        tracker.include(key2, true);
+        expect(tracker.include(key2, undefined)).toBeNull();
+      });
+
+      it("distinguishes boolean `false` from boolean `true` / `undefined`", () => {
+        const tracker = new CompoundCycleTracker<
+          object,
+          JSONSchema | undefined
+        >();
+        const key = { id: "k1" };
+        const a = tracker.include(key, true);
+        expect(a).not.toBeNull();
+        const b = tracker.include(key, false);
+        expect(b).not.toBeNull();
+      });
+
+      it("getExisting returns the stored value on re-include", () => {
+        const tracker = new CompoundCycleTracker<
+          object,
+          JSONSchema | undefined,
+          string
+        >();
+        const key = { id: "k1" };
+        const schema: JSONSchema = {
+          type: "object",
+          title: `cctWeakmapTestAt${Date.now()}-${Math.random()}`,
+        };
+        tracker.include(key, schema, "value-a");
+        expect(tracker.getExisting(key, schema)).toBe("value-a");
+        expect(tracker.getExisting(key, { ...schema })).toBe("value-a");
+        expect(tracker.getExisting(key, true)).toBeUndefined();
+      });
+
+      it("returns undefined from getExisting for unknown partialKey", () => {
+        const tracker = new CompoundCycleTracker<
+          object,
+          JSONSchema | undefined,
+          string
+        >();
+        expect(tracker.getExisting({ id: "missing" }, true)).toBeUndefined();
       });
     });
 

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -1573,15 +1573,7 @@ for (const modernHash of [false, true]) {
         const disposable = tracker.include(key, true);
         expect(disposable).not.toBeNull();
         disposable![Symbol.dispose]();
-        // Outer `partial` and the parallel counter are both cleaned up
-        // when the inner map's live-entry count hits zero.
         expect((tracker as any).partial.size).toBe(0);
-        expect((tracker as any).partialCounts.size).toBe(0);
-        // Re-including the same (key, extraKey) pair must succeed —
-        // implies the prior entry really was removed.
-        const disposable2 = tracker.include(key, true);
-        expect(disposable2).not.toBeNull();
-        disposable2![Symbol.dispose]();
       });
 
       it("retains partial-key entries while sibling entries are live", () => {
@@ -1598,15 +1590,14 @@ for (const modernHash of [false, true]) {
         // B's live entry still keys on the same partialKey.
         dispA![Symbol.dispose]();
         expect((tracker as any).partial.size).toBe(1);
-        expect((tracker as any).partialCounts.get(key)).toBe(1);
+        expect((tracker as any).partial.get(key)!.size).toBe(1);
         // Disposing B then cleans up.
         dispB![Symbol.dispose]();
         expect((tracker as any).partial.size).toBe(0);
-        expect((tracker as any).partialCounts.size).toBe(0);
       });
     });
 
-    describe("CompoundCycleTracker WeakMap restructure (Tactic 2B)", () => {
+    describe("CompoundCycleTracker intern-based keying (Tactic 2B)", () => {
       it("detects cycles on structurally-equal extraKey (not just identity)", () => {
         const tracker = new CompoundCycleTracker<
           object,

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -1607,7 +1607,7 @@ for (const modernHash of [false, true]) {
         // Two distinct object references with structurally-equal content.
         const schemaA: JSONSchema = {
           type: "object",
-          title: `cctWeakmapTestAt${Date.now()}-${Math.random()}`,
+          title: `cctInternKeyTestAt${Date.now()}-${Math.random()}`,
         };
         const schemaB: JSONSchema = { ...schemaA };
         const first = tracker.include(key, schemaA);
@@ -1657,7 +1657,7 @@ for (const modernHash of [false, true]) {
         const key = { id: "k1" };
         const schema: JSONSchema = {
           type: "object",
-          title: `cctWeakmapTestAt${Date.now()}-${Math.random()}`,
+          title: `cctInternKeyTestAt${Date.now()}-${Math.random()}`,
         };
         tracker.include(key, schema, "value-a");
         expect(tracker.getExisting(key, schema)).toBe("value-a");

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -1567,27 +1567,42 @@ for (const modernHash of [false, true]) {
     });
 
     describe("CompoundCycleTracker cleanup", () => {
-      it("removes the inner (partialKey, extraKey) entry on dispose", () => {
+      it("removes empty partial-key entries on dispose", () => {
         const tracker = new CompoundCycleTracker<object, boolean>();
         const key = { id: "k1" };
         const disposable = tracker.include(key, true);
         expect(disposable).not.toBeNull();
         disposable![Symbol.dispose]();
-        // Re-including the same (key, extraKey) pair must succeed — if the
-        // prior include's entry had not been removed, this would be a cycle
-        // and the call would return null.
+        // Outer `partial` and the parallel counter are both cleaned up
+        // when the inner map's live-entry count hits zero.
+        expect((tracker as any).partial.size).toBe(0);
+        expect((tracker as any).partialCounts.size).toBe(0);
+        // Re-including the same (key, extraKey) pair must succeed —
+        // implies the prior entry really was removed.
         const disposable2 = tracker.include(key, true);
         expect(disposable2).not.toBeNull();
         disposable2![Symbol.dispose]();
+      });
 
-        // Note: unlike the prior `Map<string, …>` implementation, the
-        // WeakMap-based one does NOT eagerly delete the outer `partialKey`
-        // entry when its inner map becomes empty (WeakMap has no `.size`).
-        // The inner WeakMap is retained only as long as `partialKey` is
-        // retained in the outer Map, and its entries are GC'd when the
-        // keying `SchemaAndHash` objects go out of scope, so this is not
-        // a leak for the tracker's intended scope-bounded use. No caller
-        // depends on observing the "empty inner map" state.
+      it("retains partial-key entries while sibling entries are live", () => {
+        const tracker = new CompoundCycleTracker<
+          object,
+          JSONSchema | undefined
+        >();
+        const key = { id: "k1" };
+        const dispA = tracker.include(key, true);
+        const dispB = tracker.include(key, false);
+        expect(dispA).not.toBeNull();
+        expect(dispB).not.toBeNull();
+        // Disposing only A must not remove the outer `partial` entry —
+        // B's live entry still keys on the same partialKey.
+        dispA![Symbol.dispose]();
+        expect((tracker as any).partial.size).toBe(1);
+        expect((tracker as any).partialCounts.get(key)).toBe(1);
+        // Disposing B then cleans up.
+        dispB![Symbol.dispose]();
+        expect((tracker as any).partial.size).toBe(0);
+        expect((tracker as any).partialCounts.size).toBe(0);
       });
     });
 


### PR DESCRIPTION
## What

Rekeys `CompoundCycleTracker` in `packages/runner/src/traverse.ts` — the inner `Map<string, Value | undefined>` shape is preserved, but keys are now the **interned** hash-string via `internSchemaAsHashString` rather than one derived on every call by `hashSchemaItem`:

- Inner container: `Map<string, Value | undefined>` (shape unchanged).
- Key construction: `internSchemaAsHashString(extraKey ?? true)` at the `include` / `getExisting` boundary — produces a stable, interned hash-string identity. `hashSchemaItem` is retired from the hot path.
- Type parameter narrowed: `ExtraKey extends JSONSchema | undefined` (was `FabricValue`). All 8 production + test instantiations already fit this shape — zero call-site churn.
- `undefined → true` normalization at the boundary: JSON Schema's `true` means "accept everything" = "no constraint," which is exactly what `undefined` denotes at this site. Class doc comment explains the equivalence. Only line 1231's `selector?.schema` currently triggers the `undefined` path; the normalization protects future call sites too.
- Eager `entries.size === 0` cleanup preserved structurally (not via a parallel counter) — addresses cubic's memory-growth concern naturally via the existing `Map.size` semantic.
- BDD test cases cover: structural cycle detection, `undefined ↔ true` equivalence, boolean distinctions, `getExisting` round-trip, unknown-partialKey handling. Pre-existing cleanup test updated to assert the new key shape.

2 files, +116/-10.

## Why

The modern schema-hash path (`hashOfModernInternal` in `packages/data-model/value-hash-modern.ts`) WeakMap-caches only deep-frozen objects. `CompoundCycleTracker` was rebuilding hash-strings on every `.include` / `.getExisting` call via `hashSchemaItem`, forcing cache-defeat work per traversal step — audit's **DEFEAT-7** mechanism.

Interning the `extraKey` produces a stable interned hash-string identity the inner `Map` can key directly. `hashSchemaItem` is retired from the hot path, and the tracker composes cleanly with the interned-selector contract PR #3335 and the intermediate PR #3338 established.

This design replaces an earlier `WeakMap<SchemaAndHash, ...>` shape (commits `d10be2fff` and `fa5ddea60` on the branch) after Dan flagged the observability-loss cost vs the perf-equivalent `Map<string, ...>` form. Both forms do the same `internSchema` work at the boundary; the `Map<string, ...>` form is structurally simpler and restores the `.size`-based eager cleanup without needing a parallel counter.

Expected impact per Rosa's Part 4 measurement: pattern tests where notes family / notebook schemas induce structural cycles (~notebook 185s, note 89s, note-md 52s on the post-#3338 CI baseline) should see the majority of their residual close. Forecast ~97-98% top-10 closure post-PR-2.

## Context

This is **PR 2 of the staged structural fix** for PR #3235's `modernSchemaHash` regression:

- **PR 1** — Tactic 2A: merge-helper cache-key interning — **merged as #3331**.
- **PR 3** — Tactic 2C: `MapSetStringToPathSelectors` freeze-on-entry — **merged as #3335**.
- **Intermediate** — push `SchemaPathSelector` interning upstream of MSP — **merged as #3338**.
- **This PR** — Tactic 2B: `CompoundCycleTracker` rekey-on-interned-hash-string.

Full diagnosis and per-site analysis: `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` (§4 Phase 2, DEFEAT-7 row). Empirical profiling: `coordination/docs/2026-04-16-modern-schema-hash-profiling.md`. Rosa's Part 4 fix-validation articulates PR 2 expected impact.

Constraints preserved: `isDeepFrozen` guard in `value-hash-modern.ts:397-408` untouched (Fix D still rejected). No `internSchemaWith*` wrapper invention.

Related PRs:
- PR #3235 — `feat: enable modernSchemaHash by default` (the target; still open).
- PR #3231 — `feat: flip modernHash default to true` (upstream of #3235).
- PR #3324 — `danfuzz/because-im-easy-come-easy-go` (legacy-hash SHA256 normalization).

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
