### PR TITLE
Cache of encoded small lengths for hashing

### DIFF
--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -125,15 +125,12 @@ function getStringRep(value: string) {
   let result;
 
   if (utf8Length <= MAX_DIRECT_STRING_LENGTH) {
-    const lengthBuf = encodeULEB128(utf8Length);
-    const lengthLength = lengthBuf.length;
-
     // Contents are: tag + utf8Length + utf8.
-    const totalLength = 1 + lengthLength + utf8Length;
+    const totalLength = 2 + utf8Length;
     result = new Uint8Array(totalLength);
     result[0] = TAG_STRING;
-    result.set(lengthBuf, 1); // After the tag.
-    result.set(utf8Buf, 1 + lengthLength); // After the length.
+    result[1] = utf8Length; // Always fits in a byte!
+    result.set(utf8Buf, 2); // After the tag and length.
   } else {
     const hashBuf = sha256(utf8Buf);
 

--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -76,6 +76,13 @@ const TAG_CONTENT_HASH_BYTES = new Uint8Array([TAG_CONTENT_HASH]);
 // Core: recursive value feeding
 // ---------------------------------------------------------------------------
 
+/**
+ * Maximum encoded length of a string which is represented in just-encoded form.
+ * Longer strings are represented in a hash feed as the hash of the string (in
+ * Merkle-ish fashion).
+ */
+const MAX_DIRECT_STRING_LENGTH = 64;
+
 /** Shared TextEncoder for UTF-8 string encoding. */
 const encoder = new TextEncoder();
 
@@ -87,13 +94,6 @@ const f64View = new DataView(f64Buf);
 
 /** Byte-array "view" of `f64Buf`. */
 const f64Bytes = new Uint8Array(f64Buf);
-
-/**
- * Maximum encoded length of a string which is represented in just-encoded form.
- * Longer strings are represented in a hash feed as the hash of the string (in
- * Merkle-ish fashion).
- */
-const MAX_DIRECT_STRING_LENGTH = 64;
 
 /** LRU cache for string representations. */
 const stringRepCache = new LRUCache<string, Uint8Array>({

--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -83,6 +83,11 @@ const TAG_CONTENT_HASH_BYTES = new Uint8Array([TAG_CONTENT_HASH]);
  */
 const MAX_DIRECT_STRING_LENGTH = 64;
 
+/**
+ * Maximum value (inclusive) of the small-length-number cache.
+ */
+const MAX_CACHED_SMALL_LENGTH = 500;
+
 /** Shared TextEncoder for UTF-8 string encoding. */
 const encoder = new TextEncoder();
 
@@ -99,6 +104,9 @@ const f64Bytes = new Uint8Array(f64Buf);
 const stringRepCache = new LRUCache<string, Uint8Array>({
   capacity: 50_000,
 });
+
+/** Cache of encoded small length numbers. */
+const smallLengthCache: Uint8Array[] = [];
 
 /**
  * Gets the bytes needed to represent the given string, either by computing it
@@ -142,7 +150,15 @@ function getStringRep(value: string) {
  * in-hash encoding for same.
  */
 function feedLength(hasher: IncrementalHasher, value: number): void {
-  hasher.update(encodeULEB128(value));
+  let valueBuf = smallLengthCache[value];
+  if (valueBuf === undefined) {
+    valueBuf = encodeULEB128(value);
+    if (value <= MAX_CACHED_SMALL_LENGTH) {
+      smallLengthCache[value] = valueBuf;
+    }
+  }
+
+  hasher.update(valueBuf);
 }
 
 /**

--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -105,9 +105,10 @@ const stringRepCache = new LRUCache<string, Uint8Array>({
   capacity: 50_000,
 });
 
-/** Cache of encoded small-length numbers. */
-const smallLengthCache: Uint8Array[] = Array(MAX_CACHED_SMALL_LENGTH + 1).fill(
-  undefined,
+/** Prepopulated cache of encoded small-length numbers. */
+const smallLengthCache: Uint8Array[] = Array.from(
+  { length: MAX_CACHED_SMALL_LENGTH + 1 },
+  (_, i) => encodeULEB128(i),
 );
 
 /**
@@ -152,13 +153,9 @@ function getStringRep(value: string) {
  * in-hash encoding for same.
  */
 function feedLength(hasher: IncrementalHasher, value: number): void {
-  let valueBuf = smallLengthCache[value];
-  if (valueBuf === undefined) {
-    valueBuf = encodeULEB128(value);
-    if (value <= MAX_CACHED_SMALL_LENGTH) {
-      smallLengthCache[value] = valueBuf;
-    }
-  }
+  const valueBuf = (value <= MAX_CACHED_SMALL_LENGTH)
+    ? smallLengthCache[value]
+    : encodeULEB128(value);
 
   hasher.update(valueBuf);
 }

--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -105,8 +105,10 @@ const stringRepCache = new LRUCache<string, Uint8Array>({
   capacity: 50_000,
 });
 
-/** Cache of encoded small length numbers. */
-const smallLengthCache: Uint8Array[] = [];
+/** Cache of encoded small-length numbers. */
+const smallLengthCache: Uint8Array[] = Array(MAX_CACHED_SMALL_LENGTH + 1).fill(
+  undefined,
+);
 
 /**
  * Gets the bytes needed to represent the given string, either by computing it

--- a/scripts/benchmark-object-hashing/main.ts
+++ b/scripts/benchmark-object-hashing/main.ts
@@ -1072,7 +1072,7 @@ async function main() {
       category: "vdom",
       name: "fullPage",
       data: testData.vdom.fullPageApp,
-      iterations: 50,
+      iterations: 100,
     },
   ];
 


### PR DESCRIPTION
This PR is another turn of the crank on performance in the modern hasher:

* It adds a prepopulated cache of small encoded length values, avoiding the encoding cost for a bunch of common cases.
* It fixes an avoidable inefficiency in small-string hashing that was in the previous PR due to "cargo-culting" part of the original implementation.

Benchmarking indicates that this is a decent win in realistic use case scenarios.