### PR TITLE
Two more modern hash improvements

### DIFF
--- a/packages/data-model/test/value-hash-modern.test.ts
+++ b/packages/data-model/test/value-hash-modern.test.ts
@@ -402,9 +402,8 @@ describe("modernHash", () => {
     const error = new FabricError(new Error("test"));
     const enc = new TextEncoder();
 
-    // TAG_INSTANCE (0x12) + LEB128(typeTagLen) + typeTag UTF-8
-    const typeTagUtf8 = enc.encode("Error@1"); // 7 bytes
-    const stream: number[] = [0x12, typeTagUtf8.length, ...typeTagUtf8];
+    // TAG_INSTANCE (0x12)
+    const stream: number[] = [0x12];
 
     const pushShortString = (value: string) => {
       const encoded = enc.encode(value);
@@ -415,6 +414,9 @@ describe("modernHash", () => {
       const hashed = sha256(enc.encode(value));
       stream.push(0xf0, ...hashed);
     };
+
+    // Type tag.
+    pushShortString("Error@1");
 
     // Deconstructed state is an object with sorted keys.
     // FabricError.DECONSTRUCT() returns:
@@ -841,9 +843,10 @@ describe("modernHash", () => {
       new Uint8Array([0xDE, 0xAD, 0xBE, 0xEF]),
       "fid1",
     );
-    // Expected: TAG_CONTENT_ID(0x29), algTagLen(0x04), "fid1", hashLen(0x04), hash
+    // Expected: TAG_CONTENT_ID(0x29), "fid1" (encoded), hashLen(0x04), hash
     const expected = sha256([
       0x29,
+      0x24,
       0x04,
       0x66,
       0x69,

--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -146,6 +146,50 @@ function getStringRep(value: string) {
 }
 
 /**
+ * Compares strings by UTF-8 sort order.
+ *
+ * Note: Even though we could conceivably define the sort to be something
+ * easier to calculate in JS, (a) ultimately we want this implementation to be
+ * but one of several that aren't all written in JS, (b) those other languages
+ * don't necessarily have the same encoding bias as JS, and (c) we want to make
+ * the specification for hashing straightforward anyway (and are willing to pay
+ * a performance cost because of it).
+ */
+function compareStrings(a: string, b: string): number {
+  // Here's what's going on: JS native string sort and UTF-8 sort can differ
+  // only when at least one of the JS-form strings contains a codepoint for a
+  // surrogate-pair. As long as we don't run into one of those, we can just
+  // do a regular difference-based comparison. But if we _do_ run into one, then
+  // we have to do something extra, one way or another.
+
+  const isSurrogate = (c: number) => (c >= 0xd800) && (c <= 0xdfff);
+
+  const minCharLen = Math.min(a.length, b.length);
+
+  for (let i = 0; i < minCharLen; i++) {
+    const aChar = a.charCodeAt(i);
+    const bChar = b.charCodeAt(i);
+    if (aChar === bChar) {
+      continue;
+    } else if (!(isSurrogate(aChar) || isSurrogate(bChar))) {
+      return aChar - bChar;
+    } else {
+      // At least one is a surrogate. Use `codePointAt()` to decode whichever of
+      // the strings have surrogate characters. That method operates reasonably
+      // whether or not the code point is in the basic or astral plane, and it
+      // also returns a reasonable value given an invalid surrogate-pair
+      // sequence. Importantly, Unicode code-point order corresponds to UTF-8
+      // byte order.
+      const aPoint = a.codePointAt(i)!;
+      const bPoint = b.codePointAt(i)!;
+      return aPoint - bPoint;
+    }
+  }
+
+  return a.length - b.length;
+}
+
+/**
  * Updates an incremental hasher with a length value, using the standard
  * in-hash encoding for same.
  */
@@ -345,7 +389,7 @@ function feedPlainObject(
   hasher: IncrementalHasher,
   value: Record<string, unknown>,
 ): void {
-  const keys = Object.keys(value);
+  const keys = Object.keys(value).sort(compareStrings);
   // Sort keys by UTF-8 byte comparison.
   keys.sort((a, b) => {
     const aBytes = encoder.encode(a);

--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -146,6 +146,21 @@ function getStringRep(value: string) {
 }
 
 /**
+ * Helper for `compareStrings()`: Is the given character code a surrogate?
+ */
+function isSurrogateCharCode(c: number) {
+  return (c >= 0xd800) && (c <= 0xdfff);
+}
+
+/**
+ * Helper for `compareStrings()`: Does the given string contain any surrogate
+ * code points?
+ */
+function hasSurrogateCharCode(value: string) {
+  return /[\ud800-\udfff]/.test(value);
+}
+
+/**
  * Compares strings by UTF-8 sort order.
  *
  * Note: Even though we could conceivably define the sort to be something
@@ -156,22 +171,39 @@ function getStringRep(value: string) {
  * a performance cost because of it).
  */
 function compareStrings(a: string, b: string): number {
+  // Credit where due: Though this started out as an independent implementation
+  // of the key insight for fast sorting, this incorporates ideas from
+  // <https://github.com/rocicorp/compare-utf8>.
+
   // Here's what's going on: JS native string sort and UTF-8 sort can differ
   // only when at least one of the JS-form strings contains a codepoint for a
   // surrogate-pair. As long as we don't run into one of those, we can just
   // do a regular difference-based comparison. But if we _do_ run into one, then
   // we have to do something extra, one way or another.
 
-  const isSurrogate = (c: number) => (c >= 0xd800) && (c <= 0xdfff);
+  if (a === b) {
+    // Easy out!
+    return 0;
+  }
 
   const minCharLen = Math.min(a.length, b.length);
+
+  if (
+    (minCharLen >= 20) && !(hasSurrogateCharCode(a) || hasSurrogateCharCode(b))
+  ) {
+    // Strings are long enough that it's worth a preflight check for surrogate
+    // pairs, and it turns out that neither had them.
+    return (a < b) ? -1 : ((a > b) ? 1 : 0);
+  }
+
+  // No luck for us today. Gotta do it the hard way.
 
   for (let i = 0; i < minCharLen; i++) {
     const aChar = a.charCodeAt(i);
     const bChar = b.charCodeAt(i);
     if (aChar === bChar) {
       continue;
-    } else if (!(isSurrogate(aChar) || isSurrogate(bChar))) {
+    } else if (!(isSurrogateCharCode(aChar) || isSurrogateCharCode(bChar))) {
       return aChar - bChar;
     } else {
       // At least one is a surrogate. Use `codePointAt()` to decode whichever of

--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -422,16 +422,6 @@ function feedPlainObject(
   value: Record<string, unknown>,
 ): void {
   const keys = Object.keys(value).sort(compareStrings);
-  // Sort keys by UTF-8 byte comparison.
-  keys.sort((a, b) => {
-    const aBytes = encoder.encode(a);
-    const bBytes = encoder.encode(b);
-    const minLen = Math.min(aBytes.length, bBytes.length);
-    for (let j = 0; j < minLen; j++) {
-      if (aBytes[j] !== bBytes[j]) return aBytes[j] - bBytes[j];
-    }
-    return aBytes.length - bBytes.length;
-  });
 
   hasher.update(TAG_OBJECT_BYTES);
   for (const key of keys) {

--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -323,9 +323,7 @@ function feedObjectValue(
     case NATIVE_TAGS.ContentHash: {
       const cid = value as FabricHash;
       hasher.update(TAG_CONTENT_HASH_BYTES);
-      const algTagUtf8 = encoder.encode(cid.tag);
-      feedLength(hasher, algTagUtf8.length);
-      hasher.update(algTagUtf8);
+      hasher.update(getStringRep(cid.tag));
       // TODO(@danfuzz): Look into avoiding making a copy of bytes here.
       // This could be a performance issue.
       const cidBytes = cid.bytes;
@@ -359,9 +357,7 @@ function feedObjectValue(
           `hashOfModern: FabricInstance missing typeTag property`,
         );
       }
-      const typeTagUtf8 = encoder.encode(typeTag);
-      feedLength(hasher, typeTagUtf8.length);
-      hasher.update(typeTagUtf8);
+      hasher.update(getStringRep(typeTag));
       const state = (value as FabricInstance)[DECONSTRUCT]();
       feedValue(hasher, state);
       return;


### PR DESCRIPTION
This PR makes two more improvements to modern hashing:

* I'd made string hashing smarter in an earlier PR, but I missed two spots where encoded strings were being used. These now use the new form.
* Rewrote the string comparison function used for sorting object keys, so that it doesn't need to do encoding anymore.