### PR TITLE
refactor(ui): shared spacing contract for layout primitives (CT-1499)

### DIFF
--- a/packages/ui/src/v2/components/cf-grid/cf-grid.ts
+++ b/packages/ui/src/v2/components/cf-grid/cf-grid.ts
@@ -1,6 +1,7 @@
 import { css, html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { BaseElement } from "../../core/base-element.ts";
+import { layoutSpacingUtilityStyles } from "../../styles/layout-spacing.ts";
 
 // TODO(v2-token-migration): Migrate this component to component-level tokens,
 // matching the prior phase-1 token migration pattern.
@@ -31,283 +32,138 @@ import { BaseElement } from "../../core/base-element.ts";
  * </cf-grid>
  */
 export class CFGrid extends BaseElement {
-  static override styles = css`
-    :host {
-      display: block;
-      container-type: inline-size;
-    }
+  static override styles = [
+    layoutSpacingUtilityStyles,
+    css`
+      :host {
+        display: block;
+        container-type: inline-size;
+      }
 
-    .grid {
-      display: grid;
-      box-sizing: border-box;
-    }
+      .grid {
+        display: grid;
+        box-sizing: border-box;
+      }
 
-    /* Gap utilities */
-    .gap-0 {
-      gap: 0;
-    }
-    .gap-1 {
-      gap: 0.25rem;
-    }
-    .gap-2 {
-      gap: 0.5rem;
-    }
-    .gap-3 {
-      gap: 0.75rem;
-    }
-    .gap-4 {
-      gap: 1rem;
-    }
-    .gap-5 {
-      gap: 1.25rem;
-    }
-    .gap-6 {
-      gap: 1.5rem;
-    }
-    .gap-8 {
-      gap: 2rem;
-    }
-    .gap-10 {
-      gap: 2.5rem;
-    }
-    .gap-12 {
-      gap: 3rem;
-    }
-    .gap-16 {
-      gap: 4rem;
-    }
-    .gap-20 {
-      gap: 5rem;
-    }
-    .gap-24 {
-      gap: 6rem;
-    }
+      /* Alignment */
+      .align-start {
+        align-items: start;
+      }
+      .align-center {
+        align-items: center;
+      }
+      .align-end {
+        align-items: end;
+      }
+      .align-stretch {
+        align-items: stretch;
+      }
 
-    /* Row gap utilities */
-    .row-gap-0 {
-      row-gap: 0;
-    }
-    .row-gap-1 {
-      row-gap: 0.25rem;
-    }
-    .row-gap-2 {
-      row-gap: 0.5rem;
-    }
-    .row-gap-3 {
-      row-gap: 0.75rem;
-    }
-    .row-gap-4 {
-      row-gap: 1rem;
-    }
-    .row-gap-5 {
-      row-gap: 1.25rem;
-    }
-    .row-gap-6 {
-      row-gap: 1.5rem;
-    }
-    .row-gap-8 {
-      row-gap: 2rem;
-    }
-    .row-gap-10 {
-      row-gap: 2.5rem;
-    }
-    .row-gap-12 {
-      row-gap: 3rem;
-    }
-    .row-gap-16 {
-      row-gap: 4rem;
-    }
+      /* Justification */
+      .justify-start {
+        justify-items: start;
+      }
+      .justify-center {
+        justify-items: center;
+      }
+      .justify-end {
+        justify-items: end;
+      }
+      .justify-stretch {
+        justify-items: stretch;
+      }
 
-    /* Column gap utilities */
-    .col-gap-0 {
-      column-gap: 0;
-    }
-    .col-gap-1 {
-      column-gap: 0.25rem;
-    }
-    .col-gap-2 {
-      column-gap: 0.5rem;
-    }
-    .col-gap-3 {
-      column-gap: 0.75rem;
-    }
-    .col-gap-4 {
-      column-gap: 1rem;
-    }
-    .col-gap-5 {
-      column-gap: 1.25rem;
-    }
-    .col-gap-6 {
-      column-gap: 1.5rem;
-    }
-    .col-gap-8 {
-      column-gap: 2rem;
-    }
-    .col-gap-10 {
-      column-gap: 2.5rem;
-    }
-    .col-gap-12 {
-      column-gap: 3rem;
-    }
-    .col-gap-16 {
-      column-gap: 4rem;
-    }
+      /* Place items */
+      .place-start {
+        place-items: start;
+      }
+      .place-center {
+        place-items: center;
+      }
+      .place-end {
+        place-items: end;
+      }
+      .place-stretch {
+        place-items: stretch;
+      }
 
-    /* Alignment */
-    .align-start {
-      align-items: start;
-    }
-    .align-center {
-      align-items: center;
-    }
-    .align-end {
-      align-items: end;
-    }
-    .align-stretch {
-      align-items: stretch;
-    }
+      /* Grid flow */
+      .flow-row {
+        grid-auto-flow: row;
+      }
+      .flow-column {
+        grid-auto-flow: column;
+      }
+      .flow-dense {
+        grid-auto-flow: dense;
+      }
+      .flow-row-dense {
+        grid-auto-flow: row dense;
+      }
+      .flow-column-dense {
+        grid-auto-flow: column dense;
+      }
 
-    /* Justification */
-    .justify-start {
-      justify-items: start;
-    }
-    .justify-center {
-      justify-items: center;
-    }
-    .justify-end {
-      justify-items: end;
-    }
-    .justify-stretch {
-      justify-items: stretch;
-    }
+      /*
+      * Grid container breakpoints remain local for now.
+      * They are intentionally documented here until we introduce a shared
+      * responsive contract for container-query thresholds.
+      */
+      @container (min-width: 640px) {
+        .grid-sm-1 {
+          grid-template-columns: repeat(1, minmax(0, 1fr));
+        }
+        .grid-sm-2 {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+        .grid-sm-3 {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+        .grid-sm-4 {
+          grid-template-columns: repeat(4, minmax(0, 1fr));
+        }
+        .grid-sm-6 {
+          grid-template-columns: repeat(6, minmax(0, 1fr));
+        }
+      }
 
-    /* Place items */
-    .place-start {
-      place-items: start;
-    }
-    .place-center {
-      place-items: center;
-    }
-    .place-end {
-      place-items: end;
-    }
-    .place-stretch {
-      place-items: stretch;
-    }
+      @container (min-width: 768px) {
+        .grid-md-1 {
+          grid-template-columns: repeat(1, minmax(0, 1fr));
+        }
+        .grid-md-2 {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+        .grid-md-3 {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+        .grid-md-4 {
+          grid-template-columns: repeat(4, minmax(0, 1fr));
+        }
+        .grid-md-6 {
+          grid-template-columns: repeat(6, minmax(0, 1fr));
+        }
+      }
 
-    /* Grid flow */
-    .flow-row {
-      grid-auto-flow: row;
-    }
-    .flow-column {
-      grid-auto-flow: column;
-    }
-    .flow-dense {
-      grid-auto-flow: dense;
-    }
-    .flow-row-dense {
-      grid-auto-flow: row dense;
-    }
-    .flow-column-dense {
-      grid-auto-flow: column dense;
-    }
-
-    /* Padding utilities */
-    .p-0 {
-      padding: 0;
-    }
-    .p-1 {
-      padding: 0.25rem;
-    }
-    .p-2 {
-      padding: 0.5rem;
-    }
-    .p-3 {
-      padding: 0.75rem;
-    }
-    .p-4 {
-      padding: 1rem;
-    }
-    .p-5 {
-      padding: 1.25rem;
-    }
-    .p-6 {
-      padding: 1.5rem;
-    }
-    .p-8 {
-      padding: 2rem;
-    }
-    .p-10 {
-      padding: 2.5rem;
-    }
-    .p-12 {
-      padding: 3rem;
-    }
-    .p-16 {
-      padding: 4rem;
-    }
-    .p-20 {
-      padding: 5rem;
-    }
-    .p-24 {
-      padding: 6rem;
-    }
-
-    /* Responsive grid columns */
-    @container (min-width: 640px) {
-      .grid-sm-1 {
-        grid-template-columns: repeat(1, minmax(0, 1fr));
+      @container (min-width: 1024px) {
+        .grid-lg-1 {
+          grid-template-columns: repeat(1, minmax(0, 1fr));
+        }
+        .grid-lg-2 {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+        .grid-lg-3 {
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+        .grid-lg-4 {
+          grid-template-columns: repeat(4, minmax(0, 1fr));
+        }
+        .grid-lg-6 {
+          grid-template-columns: repeat(6, minmax(0, 1fr));
+        }
       }
-      .grid-sm-2 {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
-      .grid-sm-3 {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-      }
-      .grid-sm-4 {
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-      }
-      .grid-sm-6 {
-        grid-template-columns: repeat(6, minmax(0, 1fr));
-      }
-    }
-
-    @container (min-width: 768px) {
-      .grid-md-1 {
-        grid-template-columns: repeat(1, minmax(0, 1fr));
-      }
-      .grid-md-2 {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
-      .grid-md-3 {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-      }
-      .grid-md-4 {
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-      }
-      .grid-md-6 {
-        grid-template-columns: repeat(6, minmax(0, 1fr));
-      }
-    }
-
-    @container (min-width: 1024px) {
-      .grid-lg-1 {
-        grid-template-columns: repeat(1, minmax(0, 1fr));
-      }
-      .grid-lg-2 {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
-      .grid-lg-3 {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-      }
-      .grid-lg-4 {
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-      }
-      .grid-lg-6 {
-        grid-template-columns: repeat(6, minmax(0, 1fr));
-      }
-    }
-  `;
+    `,
+  ];
 
   static override properties = {
     columns: { type: String },

--- a/packages/ui/src/v2/components/cf-hscroll/cf-hscroll.ts
+++ b/packages/ui/src/v2/components/cf-hscroll/cf-hscroll.ts
@@ -1,6 +1,7 @@
 import { css, html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { BaseElement } from "../../core/base-element.ts";
+import { layoutSpacingUtilityStyles } from "../../styles/layout-spacing.ts";
 
 /**
  * CFHScroll - Horizontal scroll container
@@ -40,134 +41,111 @@ export class CFHScroll extends BaseElement {
   declare _atStart: boolean;
   declare _atEnd: boolean;
 
-  static override styles = css`
-    :host {
-      --cf-hscroll-color-surface: var(--cf-theme-color-surface, #f1f5f9);
-      --cf-hscroll-color-thumb: var(--cf-theme-color-text-muted, #64748b);
-      --cf-hscroll-color-thumb-hover: var(--cf-theme-color-text, #475569);
-      --cf-hscroll-color-background: var(--cf-theme-color-background, #ffffff);
+  static override styles = [
+    layoutSpacingUtilityStyles,
+    css`
+      :host {
+        --cf-hscroll-color-surface: var(--cf-theme-color-surface, #f1f5f9);
+        --cf-hscroll-color-thumb: var(--cf-theme-color-text-muted, #64748b);
+        --cf-hscroll-color-thumb-hover: var(--cf-theme-color-text, #475569);
+        --cf-hscroll-color-background: var(--cf-theme-color-background, #ffffff);
 
-      display: block;
-      position: relative;
-      overflow: hidden;
-    }
+        display: block;
+        position: relative;
+        overflow: hidden;
+      }
 
-    .scroll-wrapper {
-      position: relative;
-      width: 100%;
-      height: 100%;
-    }
+      .scroll-wrapper {
+        position: relative;
+        width: 100%;
+        height: 100%;
+      }
 
-    .scroll-container {
-      overflow-x: auto;
-      overflow-y: hidden;
-      width: 100%;
-      height: 100%;
-      -webkit-overflow-scrolling: touch;
-      scrollbar-width: thin;
-    }
+      .scroll-container {
+        overflow-x: auto;
+        overflow-y: hidden;
+        width: 100%;
+        height: 100%;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: thin;
+      }
 
-    /* Hide scrollbar by default */
-    :host(:not([show-scrollbar])) .scroll-container {
-      scrollbar-width: none;
-      -ms-overflow-style: none;
-    }
+      /* Hide scrollbar by default */
+      :host(:not([show-scrollbar])) .scroll-container {
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+      }
 
-    :host(:not([show-scrollbar])) .scroll-container::-webkit-scrollbar {
-      display: none;
-    }
+      :host(:not([show-scrollbar])) .scroll-container::-webkit-scrollbar {
+        display: none;
+      }
 
-    /* Scrollbar styling when visible */
-    .scroll-container::-webkit-scrollbar {
-      height: 8px;
-    }
+      /* Scrollbar styling when visible */
+      .scroll-container::-webkit-scrollbar {
+        height: 8px;
+      }
 
-    .scroll-container::-webkit-scrollbar-track {
-      background: var(--cf-hscroll-color-surface, #f1f5f9);
-      border-radius: 4px;
-    }
+      .scroll-container::-webkit-scrollbar-track {
+        background: var(--cf-hscroll-color-surface, #f1f5f9);
+        border-radius: 4px;
+      }
 
-    .scroll-container::-webkit-scrollbar-thumb {
-      background: var(--cf-hscroll-color-thumb, #64748b);
-      border-radius: 4px;
-    }
+      .scroll-container::-webkit-scrollbar-thumb {
+        background: var(--cf-hscroll-color-thumb, #64748b);
+        border-radius: 4px;
+      }
 
-    .scroll-container::-webkit-scrollbar-thumb:hover {
-      background: var(--cf-hscroll-color-thumb-hover, #475569);
-    }
+      .scroll-container::-webkit-scrollbar-thumb:hover {
+        background: var(--cf-hscroll-color-thumb-hover, #475569);
+      }
 
-    /* Padding utilities */
-    .p-0 {
-      padding: 0;
-    }
-    .p-1 {
-      padding: 0.25rem;
-    }
-    .p-2 {
-      padding: 0.5rem;
-    }
-    .p-3 {
-      padding: 0.75rem;
-    }
-    .p-4 {
-      padding: 1rem;
-    }
-    .p-5 {
-      padding: 1.25rem;
-    }
-    .p-6 {
-      padding: 1.5rem;
-    }
-    .p-8 {
-      padding: 2rem;
-    }
+      /* Fade edges */
+      :host([fade-edges]) .scroll-wrapper::before,
+      :host([fade-edges]) .scroll-wrapper::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 2rem;
+        pointer-events: none;
+        z-index: 1;
+        transition: opacity 0.2s;
+      }
 
-    /* Fade edges */
-    :host([fade-edges]) .scroll-wrapper::before,
-    :host([fade-edges]) .scroll-wrapper::after {
-      content: "";
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      width: 2rem;
-      pointer-events: none;
-      z-index: 1;
-      transition: opacity 0.2s;
-    }
+      :host([fade-edges]) .scroll-wrapper::before {
+        left: 0;
+        background: linear-gradient(
+          to right,
+          var(--cf-hscroll-color-background, white),
+          transparent
+        );
+        opacity: 0;
+      }
 
-    :host([fade-edges]) .scroll-wrapper::before {
-      left: 0;
-      background: linear-gradient(
-        to right,
-        var(--cf-hscroll-color-background, white),
-        transparent
-      );
-      opacity: 0;
-    }
+      :host([fade-edges]) .scroll-wrapper::after {
+        right: 0;
+        background: linear-gradient(
+          to left,
+          var(--cf-hscroll-color-background, white),
+          transparent
+        );
+        opacity: 0;
+      }
 
-    :host([fade-edges]) .scroll-wrapper::after {
-      right: 0;
-      background: linear-gradient(
-        to left,
-        var(--cf-hscroll-color-background, white),
-        transparent
-      );
-      opacity: 0;
-    }
+      :host([fade-edges]) .scroll-wrapper:not(.at-start)::before {
+        opacity: 1;
+      }
 
-    :host([fade-edges]) .scroll-wrapper:not(.at-start)::before {
-      opacity: 1;
-    }
+      :host([fade-edges]) .scroll-wrapper:not(.at-end)::after {
+        opacity: 1;
+      }
 
-    :host([fade-edges]) .scroll-wrapper:not(.at-end)::after {
-      opacity: 1;
-    }
-
-    /* Ensure content doesn't wrap */
-    ::slotted(*) {
-      flex-shrink: 0;
-    }
-  `;
+      /* Ensure content doesn't wrap */
+      ::slotted(*) {
+        flex-shrink: 0;
+      }
+    `,
+  ];
 
   private _scrollContainer: HTMLElement | null = null;
 

--- a/packages/ui/src/v2/components/cf-hstack/cf-hstack.ts
+++ b/packages/ui/src/v2/components/cf-hstack/cf-hstack.ts
@@ -1,6 +1,7 @@
 import { css, html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { BaseElement } from "../../core/base-element.ts";
+import { layoutSpacingUtilityStyles } from "../../styles/layout-spacing.ts";
 
 /**
  * CFHStack - Horizontal stack layout component using flexbox
@@ -23,211 +24,75 @@ import { BaseElement } from "../../core/base-element.ts";
  * </cf-hstack>
  */
 export class CFHStack extends BaseElement {
-  static override styles = css`
-    :host {
-      --cf-hstack-gap-0: 0;
-      --cf-hstack-gap-1: 0.25rem;
-      --cf-hstack-gap-2: 0.5rem;
-      --cf-hstack-gap-3: 0.75rem;
-      --cf-hstack-gap-4: 1rem;
-      --cf-hstack-gap-5: 1.25rem;
-      --cf-hstack-gap-6: 1.5rem;
-      --cf-hstack-gap-8: 2rem;
-      --cf-hstack-gap-10: 2.5rem;
-      --cf-hstack-gap-12: 3rem;
-      --cf-hstack-gap-16: 4rem;
-      --cf-hstack-gap-20: 5rem;
-      --cf-hstack-gap-24: 6rem;
-      --cf-hstack-padding-0: 0;
-      --cf-hstack-padding-1: 0.25rem;
-      --cf-hstack-padding-2: 0.5rem;
-      --cf-hstack-padding-3: 0.75rem;
-      --cf-hstack-padding-4: 1rem;
-      --cf-hstack-padding-5: 1.25rem;
-      --cf-hstack-padding-6: 1.5rem;
-      --cf-hstack-padding-8: 2rem;
-      --cf-hstack-padding-10: 2.5rem;
-      --cf-hstack-padding-12: 3rem;
-      --cf-hstack-padding-16: 4rem;
-      --cf-hstack-padding-20: 5rem;
-      --cf-hstack-padding-24: 6rem;
+  static override styles = [
+    layoutSpacingUtilityStyles,
+    css`
+      :host {
+        display: block;
+        overflow: hidden;
+      }
 
-      display: block;
-      overflow: hidden;
-    }
+      .stack {
+        display: flex;
+        flex-direction: row;
+        box-sizing: border-box;
+        height: 100%;
+      }
 
-    .stack {
-      display: flex;
-      flex-direction: row;
-      box-sizing: border-box;
-      height: 100%;
-    }
+      /* Alignment */
+      .align-start {
+        align-items: flex-start;
+      }
+      .align-center {
+        align-items: center;
+      }
+      .align-end {
+        align-items: flex-end;
+      }
+      .align-stretch {
+        align-items: stretch;
+      }
+      .align-baseline {
+        align-items: baseline;
+      }
 
-    /* Gap utilities */
-    .gap-0 {
-      gap: var(--cf-hstack-gap-0);
-    }
-    .gap-1 {
-      gap: var(--cf-hstack-gap-1);
-    }
-    .gap-2 {
-      gap: var(--cf-hstack-gap-2);
-    }
-    .gap-3 {
-      gap: var(--cf-hstack-gap-3);
-    }
-    .gap-4 {
-      gap: var(--cf-hstack-gap-4);
-    }
-    .gap-5 {
-      gap: var(--cf-hstack-gap-5);
-    }
-    .gap-6 {
-      gap: var(--cf-hstack-gap-6);
-    }
-    .gap-8 {
-      gap: var(--cf-hstack-gap-8);
-    }
-    .gap-10 {
-      gap: var(--cf-hstack-gap-10);
-    }
-    .gap-12 {
-      gap: var(--cf-hstack-gap-12);
-    }
-    .gap-16 {
-      gap: var(--cf-hstack-gap-16);
-    }
-    .gap-20 {
-      gap: var(--cf-hstack-gap-20);
-    }
-    .gap-24 {
-      gap: var(--cf-hstack-gap-24);
-    }
-    .gap-xs {
-      gap: var(--cf-size-xs-spacing, 2px);
-    }
-    .gap-sm {
-      gap: var(--cf-size-sm-spacing, 4px);
-    }
-    .gap-md {
-      gap: var(--cf-size-md-spacing, 8px);
-    }
-    .gap-lg {
-      gap: var(--cf-size-lg-spacing, 12px);
-    }
-    .gap-xl {
-      gap: var(--cf-size-xl-spacing, 16px);
-    }
+      /* Justification */
+      .justify-start {
+        justify-content: flex-start;
+      }
+      .justify-center {
+        justify-content: center;
+      }
+      .justify-end {
+        justify-content: flex-end;
+      }
+      .justify-between {
+        justify-content: space-between;
+      }
+      .justify-around {
+        justify-content: space-around;
+      }
+      .justify-evenly {
+        justify-content: space-evenly;
+      }
 
-    /* Alignment */
-    .align-start {
-      align-items: flex-start;
-    }
-    .align-center {
-      align-items: center;
-    }
-    .align-end {
-      align-items: flex-end;
-    }
-    .align-stretch {
-      align-items: stretch;
-    }
-    .align-baseline {
-      align-items: baseline;
-    }
+      /* Wrap */
+      .wrap {
+        flex-wrap: wrap;
+      }
 
-    /* Justification */
-    .justify-start {
-      justify-content: flex-start;
-    }
-    .justify-center {
-      justify-content: center;
-    }
-    .justify-end {
-      justify-content: flex-end;
-    }
-    .justify-between {
-      justify-content: space-between;
-    }
-    .justify-around {
-      justify-content: space-around;
-    }
-    .justify-evenly {
-      justify-content: space-evenly;
-    }
+      /* Reverse */
+      .reverse {
+        flex-direction: row-reverse;
+      }
 
-    /* Wrap */
-    .wrap {
-      flex-wrap: wrap;
-    }
-
-    /* Reverse */
-    .reverse {
-      flex-direction: row-reverse;
-    }
-
-    /* Padding utilities */
-    .p-0 {
-      padding: var(--cf-hstack-padding-0);
-    }
-    .p-1 {
-      padding: var(--cf-hstack-padding-1);
-    }
-    .p-2 {
-      padding: var(--cf-hstack-padding-2);
-    }
-    .p-3 {
-      padding: var(--cf-hstack-padding-3);
-    }
-    .p-4 {
-      padding: var(--cf-hstack-padding-4);
-    }
-    .p-5 {
-      padding: var(--cf-hstack-padding-5);
-    }
-    .p-6 {
-      padding: var(--cf-hstack-padding-6);
-    }
-    .p-8 {
-      padding: var(--cf-hstack-padding-8);
-    }
-    .p-10 {
-      padding: var(--cf-hstack-padding-10);
-    }
-    .p-12 {
-      padding: var(--cf-hstack-padding-12);
-    }
-    .p-16 {
-      padding: var(--cf-hstack-padding-16);
-    }
-    .p-20 {
-      padding: var(--cf-hstack-padding-20);
-    }
-    .p-24 {
-      padding: var(--cf-hstack-padding-24);
-    }
-    .p-xs {
-      padding: var(--cf-size-xs-spacing, 2px);
-    }
-    .p-sm {
-      padding: var(--cf-size-sm-spacing, 4px);
-    }
-    .p-md {
-      padding: var(--cf-size-md-spacing, 8px);
-    }
-    .p-lg {
-      padding: var(--cf-size-lg-spacing, 12px);
-    }
-    .p-xl {
-      padding: var(--cf-size-xl-spacing, 16px);
-    }
-
-    /* Direct children styling - allow flex children to shrink by default
-      so scroll containers like cf-vscroll can be height-constrained */
-    ::slotted(*) {
-      min-height: 0;
-    }
-  `;
+      /* Direct children styling - allow flex children to shrink by default
+        so scroll containers like cf-vscroll can be height-constrained */
+      ::slotted(*) {
+        min-height: 0;
+      }
+    `,
+  ];
 
   static override properties = {
     gap: { type: String },

--- a/packages/ui/src/v2/components/cf-vscroll/cf-vscroll.ts
+++ b/packages/ui/src/v2/components/cf-vscroll/cf-vscroll.ts
@@ -2,6 +2,7 @@ import { css, html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { BaseElement } from "../../core/base-element.ts";
+import { layoutSpacingUtilityStyles } from "../../styles/layout-spacing.ts";
 
 /**
  * CFVScroll - Vertical scroll container
@@ -41,134 +42,111 @@ export class CFVScroll extends BaseElement {
     _atEnd: { type: Boolean, state: true },
   };
 
-  static override styles = css`
-    :host {
-      --cf-vscroll-color-surface: var(--cf-theme-color-surface, #f1f5f9);
-      --cf-vscroll-color-thumb: var(--cf-theme-color-text-muted, #64748b);
-      --cf-vscroll-color-thumb-hover: var(--cf-theme-color-text, #475569);
-      --cf-vscroll-color-background: var(--cf-theme-color-background, #ffffff);
+  static override styles = [
+    layoutSpacingUtilityStyles,
+    css`
+      :host {
+        --cf-vscroll-color-surface: var(--cf-theme-color-surface, #f1f5f9);
+        --cf-vscroll-color-thumb: var(--cf-theme-color-text-muted, #64748b);
+        --cf-vscroll-color-thumb-hover: var(--cf-theme-color-text, #475569);
+        --cf-vscroll-color-background: var(--cf-theme-color-background, #ffffff);
 
-      display: block;
-      position: relative;
-      overflow: hidden;
-      min-height: 0;
-    }
+        display: block;
+        position: relative;
+        overflow: hidden;
+        min-height: 0;
+      }
 
-    :host([flex]) {
-      flex: 1;
-    }
+      :host([flex]) {
+        flex: 1;
+      }
 
-    .scroll-wrapper {
-      position: relative;
-      overflow: hidden;
-      width: 100%;
-      height: 100%;
-    }
+      .scroll-wrapper {
+        position: relative;
+        overflow: hidden;
+        width: 100%;
+        height: 100%;
+      }
 
-    .scroll-container {
-      overflow-y: auto;
-      overflow-x: hidden;
-      width: 100%;
-      -webkit-overflow-scrolling: touch;
-      scrollbar-width: thin;
-    }
+      .scroll-container {
+        overflow-y: auto;
+        overflow-x: hidden;
+        width: 100%;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: thin;
+      }
 
-    /* Hide scrollbar by default */
-    :host(:not([show-scrollbar])) .scroll-container {
-      scrollbar-width: none;
-      -ms-overflow-style: none;
-    }
+      /* Hide scrollbar by default */
+      :host(:not([show-scrollbar])) .scroll-container {
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+      }
 
-    :host(:not([show-scrollbar])) .scroll-container::-webkit-scrollbar {
-      display: none;
-    }
+      :host(:not([show-scrollbar])) .scroll-container::-webkit-scrollbar {
+        display: none;
+      }
 
-    /* Scrollbar styling when visible */
-    .scroll-container::-webkit-scrollbar {
-      width: 8px;
-    }
+      /* Scrollbar styling when visible */
+      .scroll-container::-webkit-scrollbar {
+        width: 8px;
+      }
 
-    .scroll-container::-webkit-scrollbar-track {
-      background: var(--cf-vscroll-color-surface, #f1f5f9);
-      border-radius: 4px;
-    }
+      .scroll-container::-webkit-scrollbar-track {
+        background: var(--cf-vscroll-color-surface, #f1f5f9);
+        border-radius: 4px;
+      }
 
-    .scroll-container::-webkit-scrollbar-thumb {
-      background: var(--cf-vscroll-color-thumb, #64748b);
-      border-radius: 4px;
-    }
+      .scroll-container::-webkit-scrollbar-thumb {
+        background: var(--cf-vscroll-color-thumb, #64748b);
+        border-radius: 4px;
+      }
 
-    .scroll-container::-webkit-scrollbar-thumb:hover {
-      background: var(--cf-vscroll-color-thumb-hover, #475569);
-    }
+      .scroll-container::-webkit-scrollbar-thumb:hover {
+        background: var(--cf-vscroll-color-thumb-hover, #475569);
+      }
 
-    /* Padding utilities */
-    .p-0 {
-      padding: 0;
-    }
-    .p-1 {
-      padding: 0.25rem;
-    }
-    .p-2 {
-      padding: 0.5rem;
-    }
-    .p-3 {
-      padding: 0.75rem;
-    }
-    .p-4 {
-      padding: 1rem;
-    }
-    .p-5 {
-      padding: 1.25rem;
-    }
-    .p-6 {
-      padding: 1.5rem;
-    }
-    .p-8 {
-      padding: 2rem;
-    }
+      /* Fade edges */
+      :host([fade-edges]) .scroll-wrapper::before,
+      :host([fade-edges]) .scroll-wrapper::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        right: 0;
+        height: 2rem;
+        pointer-events: none;
+        z-index: 1;
+        transition: opacity 0.2s;
+      }
 
-    /* Fade edges */
-    :host([fade-edges]) .scroll-wrapper::before,
-    :host([fade-edges]) .scroll-wrapper::after {
-      content: "";
-      position: absolute;
-      left: 0;
-      right: 0;
-      height: 2rem;
-      pointer-events: none;
-      z-index: 1;
-      transition: opacity 0.2s;
-    }
+      :host([fade-edges]) .scroll-wrapper::before {
+        top: 0;
+        background: linear-gradient(
+          to bottom,
+          var(--cf-vscroll-color-background, white),
+          transparent
+        );
+        opacity: 0;
+      }
 
-    :host([fade-edges]) .scroll-wrapper::before {
-      top: 0;
-      background: linear-gradient(
-        to bottom,
-        var(--cf-vscroll-color-background, white),
-        transparent
-      );
-      opacity: 0;
-    }
+      :host([fade-edges]) .scroll-wrapper::after {
+        bottom: 0;
+        background: linear-gradient(
+          to top,
+          var(--cf-vscroll-color-background, white),
+          transparent
+        );
+        opacity: 0;
+      }
 
-    :host([fade-edges]) .scroll-wrapper::after {
-      bottom: 0;
-      background: linear-gradient(
-        to top,
-        var(--cf-vscroll-color-background, white),
-        transparent
-      );
-      opacity: 0;
-    }
+      :host([fade-edges]) .scroll-wrapper:not(.at-start)::before {
+        opacity: 1;
+      }
 
-    :host([fade-edges]) .scroll-wrapper:not(.at-start)::before {
-      opacity: 1;
-    }
-
-    :host([fade-edges]) .scroll-wrapper:not(.at-end)::after {
-      opacity: 1;
-    }
-  `;
+      :host([fade-edges]) .scroll-wrapper:not(.at-end)::after {
+        opacity: 1;
+      }
+    `,
+  ];
 
   declare showScrollbar: boolean;
   declare fadeEdges: boolean;

--- a/packages/ui/src/v2/components/cf-vstack/cf-vstack.ts
+++ b/packages/ui/src/v2/components/cf-vstack/cf-vstack.ts
@@ -1,6 +1,7 @@
 import { css, html } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { BaseElement } from "../../core/base-element.ts";
+import { layoutSpacingUtilityStyles } from "../../styles/layout-spacing.ts";
 
 /**
  * CFVStack - Vertical stack layout component using flexbox
@@ -22,202 +23,66 @@ import { BaseElement } from "../../core/base-element.ts";
  * </cf-vstack>
  */
 export class CFVStack extends BaseElement {
-  static override styles = css`
-    :host {
-      --cf-vstack-gap-0: 0;
-      --cf-vstack-gap-1: 0.25rem;
-      --cf-vstack-gap-2: 0.5rem;
-      --cf-vstack-gap-3: 0.75rem;
-      --cf-vstack-gap-4: 1rem;
-      --cf-vstack-gap-5: 1.25rem;
-      --cf-vstack-gap-6: 1.5rem;
-      --cf-vstack-gap-8: 2rem;
-      --cf-vstack-gap-10: 2.5rem;
-      --cf-vstack-gap-12: 3rem;
-      --cf-vstack-gap-16: 4rem;
-      --cf-vstack-gap-20: 5rem;
-      --cf-vstack-gap-24: 6rem;
-      --cf-vstack-padding-0: 0;
-      --cf-vstack-padding-1: 0.25rem;
-      --cf-vstack-padding-2: 0.5rem;
-      --cf-vstack-padding-3: 0.75rem;
-      --cf-vstack-padding-4: 1rem;
-      --cf-vstack-padding-5: 1.25rem;
-      --cf-vstack-padding-6: 1.5rem;
-      --cf-vstack-padding-8: 2rem;
-      --cf-vstack-padding-10: 2.5rem;
-      --cf-vstack-padding-12: 3rem;
-      --cf-vstack-padding-16: 4rem;
-      --cf-vstack-padding-20: 5rem;
-      --cf-vstack-padding-24: 6rem;
+  static override styles = [
+    layoutSpacingUtilityStyles,
+    css`
+      :host {
+        display: block;
+      }
 
-      display: block;
-    }
+      .stack {
+        display: flex;
+        flex-direction: column;
+        box-sizing: border-box;
+        height: 100%;
+        width: 100%;
+      }
 
-    .stack {
-      display: flex;
-      flex-direction: column;
-      box-sizing: border-box;
-      height: 100%;
-      width: 100%;
-    }
+      /* Alignment */
+      .align-start {
+        align-items: flex-start;
+      }
+      .align-center {
+        align-items: center;
+      }
+      .align-end {
+        align-items: flex-end;
+      }
+      .align-stretch {
+        align-items: stretch;
+      }
 
-    /* Gap utilities */
-    .gap-0 {
-      gap: var(--cf-vstack-gap-0);
-    }
-    .gap-1 {
-      gap: var(--cf-vstack-gap-1);
-    }
-    .gap-2 {
-      gap: var(--cf-vstack-gap-2);
-    }
-    .gap-3 {
-      gap: var(--cf-vstack-gap-3);
-    }
-    .gap-4 {
-      gap: var(--cf-vstack-gap-4);
-    }
-    .gap-5 {
-      gap: var(--cf-vstack-gap-5);
-    }
-    .gap-6 {
-      gap: var(--cf-vstack-gap-6);
-    }
-    .gap-8 {
-      gap: var(--cf-vstack-gap-8);
-    }
-    .gap-10 {
-      gap: var(--cf-vstack-gap-10);
-    }
-    .gap-12 {
-      gap: var(--cf-vstack-gap-12);
-    }
-    .gap-16 {
-      gap: var(--cf-vstack-gap-16);
-    }
-    .gap-20 {
-      gap: var(--cf-vstack-gap-20);
-    }
-    .gap-24 {
-      gap: var(--cf-vstack-gap-24);
-    }
-    .gap-xs {
-      gap: var(--cf-size-xs-spacing, 2px);
-    }
-    .gap-sm {
-      gap: var(--cf-size-sm-spacing, 4px);
-    }
-    .gap-md {
-      gap: var(--cf-size-md-spacing, 8px);
-    }
-    .gap-lg {
-      gap: var(--cf-size-lg-spacing, 12px);
-    }
-    .gap-xl {
-      gap: var(--cf-size-xl-spacing, 16px);
-    }
+      /* Justification */
+      .justify-start {
+        justify-content: flex-start;
+      }
+      .justify-center {
+        justify-content: center;
+      }
+      .justify-end {
+        justify-content: flex-end;
+      }
+      .justify-between {
+        justify-content: space-between;
+      }
+      .justify-around {
+        justify-content: space-around;
+      }
+      .justify-evenly {
+        justify-content: space-evenly;
+      }
 
-    /* Alignment */
-    .align-start {
-      align-items: flex-start;
-    }
-    .align-center {
-      align-items: center;
-    }
-    .align-end {
-      align-items: flex-end;
-    }
-    .align-stretch {
-      align-items: stretch;
-    }
+      /* Reverse */
+      .reverse {
+        flex-direction: column-reverse;
+      }
 
-    /* Justification */
-    .justify-start {
-      justify-content: flex-start;
-    }
-    .justify-center {
-      justify-content: center;
-    }
-    .justify-end {
-      justify-content: flex-end;
-    }
-    .justify-between {
-      justify-content: space-between;
-    }
-    .justify-around {
-      justify-content: space-around;
-    }
-    .justify-evenly {
-      justify-content: space-evenly;
-    }
-
-    /* Reverse */
-    .reverse {
-      flex-direction: column-reverse;
-    }
-
-    /* Padding utilities */
-    .p-0 {
-      padding: var(--cf-vstack-padding-0);
-    }
-    .p-1 {
-      padding: var(--cf-vstack-padding-1);
-    }
-    .p-2 {
-      padding: var(--cf-vstack-padding-2);
-    }
-    .p-3 {
-      padding: var(--cf-vstack-padding-3);
-    }
-    .p-4 {
-      padding: var(--cf-vstack-padding-4);
-    }
-    .p-5 {
-      padding: var(--cf-vstack-padding-5);
-    }
-    .p-6 {
-      padding: var(--cf-vstack-padding-6);
-    }
-    .p-8 {
-      padding: var(--cf-vstack-padding-8);
-    }
-    .p-10 {
-      padding: var(--cf-vstack-padding-10);
-    }
-    .p-12 {
-      padding: var(--cf-vstack-padding-12);
-    }
-    .p-16 {
-      padding: var(--cf-vstack-padding-16);
-    }
-    .p-20 {
-      padding: var(--cf-vstack-padding-20);
-    }
-    .p-24 {
-      padding: var(--cf-vstack-padding-24);
-    }
-    .p-xs {
-      padding: var(--cf-size-xs-spacing, 2px);
-    }
-    .p-sm {
-      padding: var(--cf-size-sm-spacing, 4px);
-    }
-    .p-md {
-      padding: var(--cf-size-md-spacing, 8px);
-    }
-    .p-lg {
-      padding: var(--cf-size-lg-spacing, 12px);
-    }
-    .p-xl {
-      padding: var(--cf-size-xl-spacing, 16px);
-    }
-
-    /* Direct children styling */
-    ::slotted(*) {
-      flex-shrink: 0;
-    }
-  `;
+      /* Direct children styling */
+      ::slotted(*) {
+        flex-shrink: 0;
+      }
+    `,
+  ];
 
   static override properties = {
     gap: { type: String },

--- a/packages/ui/src/v2/styles/layout-spacing.ts
+++ b/packages/ui/src/v2/styles/layout-spacing.ts
@@ -1,0 +1,203 @@
+import { css } from "lit";
+
+export const layoutSpacingUtilityStyles = css`
+  /*
+  * Layout utility props map to the shared --cf-spacing-* namespace.
+  * Numeric values keep the existing 0/1/2/.../24 contract.
+  * T-shirt aliases are shared aliases within the same spacing namespace.
+  */
+
+  /* Gap utilities */
+  .gap-0 {
+    gap: var(--cf-spacing-0, 0);
+  }
+  .gap-1 {
+    gap: var(--cf-spacing-1, 0.25rem);
+  }
+  .gap-2 {
+    gap: var(--cf-spacing-2, 0.5rem);
+  }
+  .gap-3 {
+    gap: var(--cf-spacing-3, 0.75rem);
+  }
+  .gap-4 {
+    gap: var(--cf-spacing-4, 1rem);
+  }
+  .gap-5 {
+    gap: var(--cf-spacing-5, 1.25rem);
+  }
+  .gap-6 {
+    gap: var(--cf-spacing-6, 1.5rem);
+  }
+  .gap-8 {
+    gap: var(--cf-spacing-8, 2rem);
+  }
+  .gap-10 {
+    gap: var(--cf-spacing-10, 2.5rem);
+  }
+  .gap-12 {
+    gap: var(--cf-spacing-12, 3rem);
+  }
+  .gap-16 {
+    gap: var(--cf-spacing-16, 4rem);
+  }
+  .gap-20 {
+    gap: var(--cf-spacing-20, 5rem);
+  }
+  .gap-24 {
+    gap: var(--cf-spacing-24, 6rem);
+  }
+  .gap-xs {
+    gap: var(--cf-spacing-xs, 0.125rem);
+  }
+  .gap-sm {
+    gap: var(--cf-spacing-sm, 0.25rem);
+  }
+  .gap-md {
+    gap: var(--cf-spacing-md, 0.5rem);
+  }
+  .gap-lg {
+    gap: var(--cf-spacing-lg, 0.75rem);
+  }
+  .gap-xl {
+    gap: var(--cf-spacing-xl, 1rem);
+  }
+
+  /* Row gap utilities */
+  .row-gap-0 {
+    row-gap: var(--cf-spacing-0, 0);
+  }
+  .row-gap-1 {
+    row-gap: var(--cf-spacing-1, 0.25rem);
+  }
+  .row-gap-2 {
+    row-gap: var(--cf-spacing-2, 0.5rem);
+  }
+  .row-gap-3 {
+    row-gap: var(--cf-spacing-3, 0.75rem);
+  }
+  .row-gap-4 {
+    row-gap: var(--cf-spacing-4, 1rem);
+  }
+  .row-gap-5 {
+    row-gap: var(--cf-spacing-5, 1.25rem);
+  }
+  .row-gap-6 {
+    row-gap: var(--cf-spacing-6, 1.5rem);
+  }
+  .row-gap-8 {
+    row-gap: var(--cf-spacing-8, 2rem);
+  }
+  .row-gap-10 {
+    row-gap: var(--cf-spacing-10, 2.5rem);
+  }
+  .row-gap-12 {
+    row-gap: var(--cf-spacing-12, 3rem);
+  }
+  .row-gap-16 {
+    row-gap: var(--cf-spacing-16, 4rem);
+  }
+  .row-gap-20 {
+    row-gap: var(--cf-spacing-20, 5rem);
+  }
+  .row-gap-24 {
+    row-gap: var(--cf-spacing-24, 6rem);
+  }
+
+  /* Column gap utilities */
+  .col-gap-0 {
+    column-gap: var(--cf-spacing-0, 0);
+  }
+  .col-gap-1 {
+    column-gap: var(--cf-spacing-1, 0.25rem);
+  }
+  .col-gap-2 {
+    column-gap: var(--cf-spacing-2, 0.5rem);
+  }
+  .col-gap-3 {
+    column-gap: var(--cf-spacing-3, 0.75rem);
+  }
+  .col-gap-4 {
+    column-gap: var(--cf-spacing-4, 1rem);
+  }
+  .col-gap-5 {
+    column-gap: var(--cf-spacing-5, 1.25rem);
+  }
+  .col-gap-6 {
+    column-gap: var(--cf-spacing-6, 1.5rem);
+  }
+  .col-gap-8 {
+    column-gap: var(--cf-spacing-8, 2rem);
+  }
+  .col-gap-10 {
+    column-gap: var(--cf-spacing-10, 2.5rem);
+  }
+  .col-gap-12 {
+    column-gap: var(--cf-spacing-12, 3rem);
+  }
+  .col-gap-16 {
+    column-gap: var(--cf-spacing-16, 4rem);
+  }
+  .col-gap-20 {
+    column-gap: var(--cf-spacing-20, 5rem);
+  }
+  .col-gap-24 {
+    column-gap: var(--cf-spacing-24, 6rem);
+  }
+
+  /* Padding utilities */
+  .p-0 {
+    padding: var(--cf-spacing-0, 0);
+  }
+  .p-1 {
+    padding: var(--cf-spacing-1, 0.25rem);
+  }
+  .p-2 {
+    padding: var(--cf-spacing-2, 0.5rem);
+  }
+  .p-3 {
+    padding: var(--cf-spacing-3, 0.75rem);
+  }
+  .p-4 {
+    padding: var(--cf-spacing-4, 1rem);
+  }
+  .p-5 {
+    padding: var(--cf-spacing-5, 1.25rem);
+  }
+  .p-6 {
+    padding: var(--cf-spacing-6, 1.5rem);
+  }
+  .p-8 {
+    padding: var(--cf-spacing-8, 2rem);
+  }
+  .p-10 {
+    padding: var(--cf-spacing-10, 2.5rem);
+  }
+  .p-12 {
+    padding: var(--cf-spacing-12, 3rem);
+  }
+  .p-16 {
+    padding: var(--cf-spacing-16, 4rem);
+  }
+  .p-20 {
+    padding: var(--cf-spacing-20, 5rem);
+  }
+  .p-24 {
+    padding: var(--cf-spacing-24, 6rem);
+  }
+  .p-xs {
+    padding: var(--cf-spacing-xs, 0.125rem);
+  }
+  .p-sm {
+    padding: var(--cf-spacing-sm, 0.25rem);
+  }
+  .p-md {
+    padding: var(--cf-spacing-md, 0.5rem);
+  }
+  .p-lg {
+    padding: var(--cf-spacing-lg, 0.75rem);
+  }
+  .p-xl {
+    padding: var(--cf-spacing-xl, 1rem);
+  }
+`;

--- a/packages/ui/src/v2/styles/variables.ts
+++ b/packages/ui/src/v2/styles/variables.ts
@@ -124,7 +124,11 @@ export const variablesCSS = `
   --cf-line-height-relaxed: 1.625;
   --cf-line-height-loose: 2;
 
-  /* Spacing */
+  /*
+   * Spacing
+   * Layout utility props like gap="4" and padding="2" map directly to
+   * this shared spacing namespace.
+   */
   --cf-spacing-0: 0;
   --cf-spacing-1: 0.25rem;
   --cf-spacing-2: 0.5rem;
@@ -138,6 +142,11 @@ export const variablesCSS = `
   --cf-spacing-16: 4rem;
   --cf-spacing-20: 5rem;
   --cf-spacing-24: 6rem;
+  --cf-spacing-xs: 0.125rem;
+  --cf-spacing-sm: var(--cf-spacing-1);
+  --cf-spacing-md: var(--cf-spacing-2);
+  --cf-spacing-lg: var(--cf-spacing-3);
+  --cf-spacing-xl: var(--cf-spacing-4);
 
   /* Border Radius */
   --cf-border-radius-none: 0;


### PR DESCRIPTION
## Summary

- Extracts per-component gap/padding ladders from cf-vstack, cf-hstack, cf-grid, cf-vscroll, and cf-hscroll into a shared `layout-spacing.ts` utility stylesheet
- All layout primitives now consume `--cf-spacing-*` tokens instead of component-local variables (`--cf-vstack-gap-*`, etc.)
- Adds t-shirt spacing aliases (`--cf-spacing-xs` through `--cf-spacing-xl`) to `variables.ts`
- Documents the `gap="4"` → `--cf-spacing-4` mapping in `variables.ts`
- Grid container-query breakpoints (`640px`, `768px`, `1024px`) documented as intentionally local

Net -246 lines from the layout primitives.

Closes CT-1499 (Bucket 2 of the design token alignment work under CT-1497).

## Test plan

- [x] Zero `--cf-vstack-gap-*` / `--cf-hstack-gap-*` etc. spacing ladders remain in layout components
- [x] All 5 layout primitives import `layoutSpacingUtilityStyles`
- [x] Visual spot-check of vstack/hstack/grid usage in catalog stories — spacing should be identical
- [x] `deno task test` in `packages/ui` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 133s
---END COPY-PASTE---