### PR TITLE
refactor(ui): shared pill geometry tokens (CT-1501)

### DIFF
--- a/packages/patterns/catalog/stories/cf-button-story.tsx
+++ b/packages/patterns/catalog/stories/cf-button-story.tsx
@@ -17,11 +17,17 @@ interface ButtonStoryOutput {
 
 export default pattern<ButtonStoryInput, ButtonStoryOutput>(() => {
   const variant = Writable.of<
-    "primary" | "secondary" | "destructive" | "ghost"
+    | "primary"
+    | "secondary"
+    | "destructive"
+    | "outline"
+    | "ghost"
+    | "link"
+    | "pill"
   >("primary");
   const disabled = Writable.of(false);
   const label = Writable.of("Click me");
-  const size = Writable.of<"default" | "sm" | "lg" | "icon">("default");
+  const size = Writable.of<"xs" | "sm" | "md" | "lg" | "xl" | "icon">("md");
   const clickCount = Writable.of(0);
 
   const handleClick = action(() => {
@@ -67,18 +73,23 @@ export default pattern<ButtonStoryInput, ButtonStoryOutput>(() => {
               { label: "Primary", value: "primary" },
               { label: "Secondary", value: "secondary" },
               { label: "Destructive", value: "destructive" },
+              { label: "Outline", value: "outline" },
               { label: "Ghost", value: "ghost" },
+              { label: "Link", value: "link" },
+              { label: "Pill", value: "pill" },
             ]}
           />
           <SelectControl
             label="size"
             description="Size of the button"
-            defaultValue="default"
+            defaultValue="md"
             value={size}
             items={[
-              { label: "Default", value: "default" },
+              { label: "Extra Small", value: "xs" },
               { label: "Small", value: "sm" },
+              { label: "Medium", value: "md" },
               { label: "Large", value: "lg" },
+              { label: "Extra Large", value: "xl" },
               { label: "Icon", value: "icon" },
             ]}
           />

--- a/packages/ui/src/v2/components/cf-badge/cf-badge.ts
+++ b/packages/ui/src/v2/components/cf-badge/cf-badge.ts
@@ -24,6 +24,31 @@ export type BadgeVariant = "default" | "secondary" | "destructive" | "outline";
 export class CFBadge extends BaseElement {
   static override styles = css`
     :host {
+      --cf-badge-border-radius: var(
+        --cf-pill-border-radius,
+        var(--cf-border-radius-full, 9999px)
+      );
+      --cf-badge-min-height: var(
+        --cf-pill-sm-min-height,
+        var(--cf-size-sm-height)
+      );
+      --cf-badge-padding-h: var(
+        --cf-pill-sm-padding-h,
+        var(--cf-size-sm-padding-h)
+      );
+      --cf-badge-padding-v: var(
+        --cf-pill-sm-padding-v,
+        var(--cf-size-sm-padding-v)
+      );
+      --cf-badge-gap: var(--cf-pill-sm-gap, var(--cf-size-sm-spacing));
+      --cf-badge-font-size: var(
+        --cf-pill-sm-font-size,
+        var(--cf-size-sm-font-size)
+      );
+      --cf-badge-line-height: var(
+        --cf-pill-sm-line-height,
+        var(--cf-size-sm-line-height)
+      );
       --cf-badge-color-primary: var(
         --cf-theme-color-primary,
         hsl(212, 100%, 47%)
@@ -65,44 +90,53 @@ export class CFBadge extends BaseElement {
     .badge {
       display: inline-flex;
       align-items: center;
-      gap: var(--cf-size-sm-spacing);
-      padding: var(--cf-size-sm-padding-v) var(--cf-size-sm-padding-h);
-      font-size: var(--cf-size-sm-font-size);
+      min-height: var(--cf-badge-min-height);
+      gap: var(--cf-badge-gap);
+      padding: var(--cf-badge-padding-v) var(--cf-badge-padding-h);
+      font-size: var(--cf-badge-font-size);
       font-weight: 600;
-      line-height: var(--cf-size-sm-line-height);
-      border-radius: 9999px;
+      line-height: var(--cf-badge-line-height);
+      border-radius: var(--cf-badge-border-radius);
       border: 1px solid transparent;
       transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
     }
 
     :host([size="xs"]) .badge {
-      padding: var(--cf-size-xs-padding-v) var(--cf-size-xs-padding-h);
-      font-size: var(--cf-size-xs-font-size);
-      line-height: var(--cf-size-xs-line-height);
-      gap: var(--cf-size-xs-spacing);
+      min-height: var(--cf-pill-xs-min-height, var(--cf-size-xs-height));
+      padding: var(--cf-pill-xs-padding-v, var(--cf-size-xs-padding-v))
+        var(--cf-pill-xs-padding-h, var(--cf-size-xs-padding-h));
+      font-size: var(--cf-pill-xs-font-size, var(--cf-size-xs-font-size));
+      line-height: var(--cf-pill-xs-line-height, var(--cf-size-xs-line-height));
+      gap: var(--cf-pill-xs-gap, var(--cf-size-xs-spacing));
     }
 
     /* sm is default — no override needed */
 
     :host([size="md"]) .badge {
-      padding: var(--cf-size-md-padding-v) var(--cf-size-md-padding-h);
-      font-size: var(--cf-size-md-font-size);
-      line-height: var(--cf-size-md-line-height);
-      gap: var(--cf-size-md-spacing);
+      min-height: var(--cf-pill-md-min-height, var(--cf-size-md-height));
+      padding: var(--cf-pill-md-padding-v, var(--cf-size-md-padding-v))
+        var(--cf-pill-md-padding-h, var(--cf-size-md-padding-h));
+      font-size: var(--cf-pill-md-font-size, var(--cf-size-md-font-size));
+      line-height: var(--cf-pill-md-line-height, var(--cf-size-md-line-height));
+      gap: var(--cf-pill-md-gap, var(--cf-size-md-spacing));
     }
 
     :host([size="lg"]) .badge {
-      padding: var(--cf-size-lg-padding-v) var(--cf-size-lg-padding-h);
-      font-size: var(--cf-size-lg-font-size);
-      line-height: var(--cf-size-lg-line-height);
-      gap: var(--cf-size-lg-spacing);
+      min-height: var(--cf-pill-lg-min-height, var(--cf-size-lg-height));
+      padding: var(--cf-pill-lg-padding-v, var(--cf-size-lg-padding-v))
+        var(--cf-pill-lg-padding-h, var(--cf-size-lg-padding-h));
+      font-size: var(--cf-pill-lg-font-size, var(--cf-size-lg-font-size));
+      line-height: var(--cf-pill-lg-line-height, var(--cf-size-lg-line-height));
+      gap: var(--cf-pill-lg-gap, var(--cf-size-lg-spacing));
     }
 
     :host([size="xl"]) .badge {
-      padding: var(--cf-size-xl-padding-v) var(--cf-size-xl-padding-h);
-      font-size: var(--cf-size-xl-font-size);
-      line-height: var(--cf-size-xl-line-height);
-      gap: var(--cf-size-xl-spacing);
+      min-height: var(--cf-pill-xl-min-height, var(--cf-size-xl-height));
+      padding: var(--cf-pill-xl-padding-v, var(--cf-size-xl-padding-v))
+        var(--cf-pill-xl-padding-h, var(--cf-size-xl-padding-h));
+      font-size: var(--cf-pill-xl-font-size, var(--cf-size-xl-font-size));
+      line-height: var(--cf-pill-xl-line-height, var(--cf-size-xl-line-height));
+      gap: var(--cf-pill-xl-gap, var(--cf-size-xl-spacing));
     }
 
     /* Variant styles */

--- a/packages/ui/src/v2/components/cf-button/styles.ts
+++ b/packages/ui/src/v2/components/cf-button/styles.ts
@@ -319,6 +319,17 @@ export const styles = css`
     );
   }
 
+  :host([size="xs"]) .button.pill,
+  :host([size="sm"]) .button.pill,
+  :host([size="lg"]) .button.pill,
+  :host([size="xl"]) .button.pill {
+    height: auto;
+    border-radius: var(
+      --cf-pill-border-radius,
+      var(--cf-button-border-radius-full, var(--cf-border-radius-full, 9999px))
+    );
+  }
+
   :host([size="xs"]) .button.pill {
     min-height: var(--cf-pill-xs-min-height, var(--cf-size-xs-height, 16px));
     padding: var(--cf-pill-xs-padding-v, var(--cf-size-xs-padding-v, 2px))

--- a/packages/ui/src/v2/components/cf-button/styles.ts
+++ b/packages/ui/src/v2/components/cf-button/styles.ts
@@ -293,13 +293,23 @@ export const styles = css`
     border: 1px solid
       var(--cf-button-color-border, var(--cf-colors-gray-300, #d5d7dd));
     border-radius: var(
-      --cf-button-border-radius-full,
-      var(--cf-radius-full, 9999px)
+      --cf-pill-border-radius,
+      var(--cf-button-border-radius-full, var(--cf-border-radius-full, 9999px))
     );
+    width: auto;
     height: auto;
-    padding: 0.25rem 0.625rem;
-    font-size: 0.8125rem;
-    line-height: 1;
+    min-height: var(--cf-pill-md-min-height, var(--cf-size-md-height, 2rem));
+    padding: var(--cf-pill-md-padding-v, var(--cf-size-md-padding-v, 8px))
+      var(--cf-pill-md-padding-h, var(--cf-size-md-padding-h, 8px));
+    font-size: var(
+      --cf-pill-md-font-size,
+      var(--cf-size-md-font-size, 0.75rem)
+    );
+    line-height: var(
+      --cf-pill-md-line-height,
+      var(--cf-size-md-line-height, 1rem)
+    );
+    gap: var(--cf-pill-md-gap, var(--cf-size-md-spacing, 8px));
   }
 
   .button.pill:hover:not(:disabled) {
@@ -307,5 +317,53 @@ export const styles = css`
       --cf-button-color-surface-hover,
       var(--cf-colors-gray-200, #eceef1)
     );
+  }
+
+  :host([size="xs"]) .button.pill {
+    min-height: var(--cf-pill-xs-min-height, var(--cf-size-xs-height, 16px));
+    padding: var(--cf-pill-xs-padding-v, var(--cf-size-xs-padding-v, 2px))
+      var(--cf-pill-xs-padding-h, var(--cf-size-xs-padding-h, 4px));
+    font-size: var(--cf-pill-xs-font-size, var(--cf-size-xs-font-size, 9px));
+    line-height: var(
+      --cf-pill-xs-line-height,
+      var(--cf-size-xs-line-height, 12px)
+    );
+    gap: var(--cf-pill-xs-gap, var(--cf-size-xs-spacing, 2px));
+  }
+
+  :host([size="sm"]) .button.pill {
+    min-height: var(--cf-pill-sm-min-height, var(--cf-size-sm-height, 24px));
+    padding: var(--cf-pill-sm-padding-v, var(--cf-size-sm-padding-v, 4px))
+      var(--cf-pill-sm-padding-h, var(--cf-size-sm-padding-h, 6px));
+    font-size: var(--cf-pill-sm-font-size, var(--cf-size-sm-font-size, 11px));
+    line-height: var(
+      --cf-pill-sm-line-height,
+      var(--cf-size-sm-line-height, 16px)
+    );
+    gap: var(--cf-pill-sm-gap, var(--cf-size-sm-spacing, 4px));
+  }
+
+  :host([size="lg"]) .button.pill {
+    min-height: var(--cf-pill-lg-min-height, var(--cf-size-lg-height, 40px));
+    padding: var(--cf-pill-lg-padding-v, var(--cf-size-lg-padding-v, 8px))
+      var(--cf-pill-lg-padding-h, var(--cf-size-lg-padding-h, 12px));
+    font-size: var(--cf-pill-lg-font-size, var(--cf-size-lg-font-size, 16px));
+    line-height: var(
+      --cf-pill-lg-line-height,
+      var(--cf-size-lg-line-height, 20px)
+    );
+    gap: var(--cf-pill-lg-gap, var(--cf-size-lg-spacing, 12px));
+  }
+
+  :host([size="xl"]) .button.pill {
+    min-height: var(--cf-pill-xl-min-height, var(--cf-size-xl-height, 48px));
+    padding: var(--cf-pill-xl-padding-v, var(--cf-size-xl-padding-v, 12px))
+      var(--cf-pill-xl-padding-h, var(--cf-size-xl-padding-h, 16px));
+    font-size: var(--cf-pill-xl-font-size, var(--cf-size-xl-font-size, 18px));
+    line-height: var(
+      --cf-pill-xl-line-height,
+      var(--cf-size-xl-line-height, 24px)
+    );
+    gap: var(--cf-pill-xl-gap, var(--cf-size-xl-spacing, 16px));
   }
 `;

--- a/packages/ui/src/v2/components/cf-chip/cf-chip.ts
+++ b/packages/ui/src/v2/components/cf-chip/cf-chip.ts
@@ -55,6 +55,13 @@ export class CFChip extends BaseElement {
           var(--cf-size-sm-line-height)
         );
         display: inline-block;
+        box-sizing: border-box;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: inherit;
       }
 
       .chip {

--- a/packages/ui/src/v2/components/cf-chip/cf-chip.ts
+++ b/packages/ui/src/v2/components/cf-chip/cf-chip.ts
@@ -29,14 +29,40 @@ export class CFChip extends BaseElement {
     BaseElement.baseStyles,
     css`
       :host {
+        --cf-chip-border-radius: var(
+          --cf-pill-border-radius,
+          var(--cf-border-radius-full, 9999px)
+        );
+        --cf-chip-min-height: var(
+          --cf-pill-sm-min-height,
+          var(--cf-size-sm-height)
+        );
+        --cf-chip-padding-h: var(
+          --cf-pill-sm-padding-h,
+          var(--cf-size-sm-padding-h)
+        );
+        --cf-chip-padding-v: var(
+          --cf-pill-sm-padding-v,
+          var(--cf-size-sm-padding-v)
+        );
+        --cf-chip-gap: var(--cf-pill-sm-gap, var(--cf-size-sm-spacing));
+        --cf-chip-font-size: var(
+          --cf-pill-sm-font-size,
+          var(--cf-size-sm-font-size)
+        );
+        --cf-chip-line-height: var(
+          --cf-pill-sm-line-height,
+          var(--cf-size-sm-line-height)
+        );
         display: inline-block;
       }
 
       .chip {
         display: inline-flex;
         align-items: center;
-        gap: var(--cf-size-sm-spacing);
-        padding: var(--cf-size-sm-padding-v) var(--cf-size-sm-padding-h);
+        min-height: var(--cf-chip-min-height);
+        gap: var(--cf-chip-gap);
+        padding: var(--cf-chip-padding-v) var(--cf-chip-padding-h);
         background: var(
           --cf-chip-background,
           var(
@@ -60,11 +86,11 @@ export class CFChip extends BaseElement {
             )
           );
         border-radius: var(
-          --cf-theme-border-radius,
+          --cf-chip-border-radius,
           var(--cf-border-radius-full, 9999px)
         );
-        font-size: var(--cf-size-sm-font-size);
-        line-height: var(--cf-size-sm-line-height);
+        font-size: var(--cf-chip-font-size);
+        line-height: var(--cf-chip-line-height);
         user-select: none;
         transition:
           background-color var(--cf-theme-animation-duration, 200ms) ease,
@@ -72,33 +98,41 @@ export class CFChip extends BaseElement {
         }
 
         :host([size="xs"]) .chip {
-          padding: var(--cf-size-xs-padding-v) var(--cf-size-xs-padding-h);
-          font-size: var(--cf-size-xs-font-size);
-          line-height: var(--cf-size-xs-line-height);
-          gap: var(--cf-size-xs-spacing);
+          min-height: var(--cf-pill-xs-min-height, var(--cf-size-xs-height));
+          padding: var(--cf-pill-xs-padding-v, var(--cf-size-xs-padding-v))
+            var(--cf-pill-xs-padding-h, var(--cf-size-xs-padding-h));
+          font-size: var(--cf-pill-xs-font-size, var(--cf-size-xs-font-size));
+          line-height: var(--cf-pill-xs-line-height, var(--cf-size-xs-line-height));
+          gap: var(--cf-pill-xs-gap, var(--cf-size-xs-spacing));
         }
 
         /* sm is default — no override needed */
 
         :host([size="md"]) .chip {
-          padding: var(--cf-size-md-padding-v) var(--cf-size-md-padding-h);
-          font-size: var(--cf-size-md-font-size);
-          line-height: var(--cf-size-md-line-height);
-          gap: var(--cf-size-md-spacing);
+          min-height: var(--cf-pill-md-min-height, var(--cf-size-md-height));
+          padding: var(--cf-pill-md-padding-v, var(--cf-size-md-padding-v))
+            var(--cf-pill-md-padding-h, var(--cf-size-md-padding-h));
+          font-size: var(--cf-pill-md-font-size, var(--cf-size-md-font-size));
+          line-height: var(--cf-pill-md-line-height, var(--cf-size-md-line-height));
+          gap: var(--cf-pill-md-gap, var(--cf-size-md-spacing));
         }
 
         :host([size="lg"]) .chip {
-          padding: var(--cf-size-lg-padding-v) var(--cf-size-lg-padding-h);
-          font-size: var(--cf-size-lg-font-size);
-          line-height: var(--cf-size-lg-line-height);
-          gap: var(--cf-size-lg-spacing);
+          min-height: var(--cf-pill-lg-min-height, var(--cf-size-lg-height));
+          padding: var(--cf-pill-lg-padding-v, var(--cf-size-lg-padding-v))
+            var(--cf-pill-lg-padding-h, var(--cf-size-lg-padding-h));
+          font-size: var(--cf-pill-lg-font-size, var(--cf-size-lg-font-size));
+          line-height: var(--cf-pill-lg-line-height, var(--cf-size-lg-line-height));
+          gap: var(--cf-pill-lg-gap, var(--cf-size-lg-spacing));
         }
 
         :host([size="xl"]) .chip {
-          padding: var(--cf-size-xl-padding-v) var(--cf-size-xl-padding-h);
-          font-size: var(--cf-size-xl-font-size);
-          line-height: var(--cf-size-xl-line-height);
-          gap: var(--cf-size-xl-spacing);
+          min-height: var(--cf-pill-xl-min-height, var(--cf-size-xl-height));
+          padding: var(--cf-pill-xl-padding-v, var(--cf-size-xl-padding-v))
+            var(--cf-pill-xl-padding-h, var(--cf-size-xl-padding-h));
+          font-size: var(--cf-pill-xl-font-size, var(--cf-size-xl-font-size));
+          line-height: var(--cf-pill-xl-line-height, var(--cf-size-xl-line-height));
+          gap: var(--cf-pill-xl-gap, var(--cf-size-xl-spacing));
         }
 
         .chip.interactive {

--- a/packages/ui/src/v2/styles/variables.ts
+++ b/packages/ui/src/v2/styles/variables.ts
@@ -215,6 +215,50 @@ export const variablesCSS = `
   --cf-size-xl-font-size: 18px;
   --cf-size-xl-line-height: 24px;
 
+  /*
+   * Shared pill geometry
+   * Badge, chip, and button[variant="pill"] keep separate semantics and
+   * colors, but they should share the same compact rounded size contract.
+   */
+  --cf-pill-border-radius: var(
+    --cf-theme-border-radius-full,
+    var(--cf-border-radius-full, 9999px)
+  );
+  --cf-pill-xs-min-height: var(--cf-size-xs-height);
+  --cf-pill-xs-padding-h: var(--cf-size-xs-padding-h);
+  --cf-pill-xs-padding-v: var(--cf-size-xs-padding-v);
+  --cf-pill-xs-gap: var(--cf-size-xs-spacing);
+  --cf-pill-xs-font-size: var(--cf-size-xs-font-size);
+  --cf-pill-xs-line-height: var(--cf-size-xs-line-height);
+
+  --cf-pill-sm-min-height: var(--cf-size-sm-height);
+  --cf-pill-sm-padding-h: var(--cf-size-sm-padding-h);
+  --cf-pill-sm-padding-v: var(--cf-size-sm-padding-v);
+  --cf-pill-sm-gap: var(--cf-size-sm-spacing);
+  --cf-pill-sm-font-size: var(--cf-size-sm-font-size);
+  --cf-pill-sm-line-height: var(--cf-size-sm-line-height);
+
+  --cf-pill-md-min-height: var(--cf-size-md-height);
+  --cf-pill-md-padding-h: var(--cf-size-md-padding-h);
+  --cf-pill-md-padding-v: var(--cf-size-md-padding-v);
+  --cf-pill-md-gap: var(--cf-size-md-spacing);
+  --cf-pill-md-font-size: var(--cf-size-md-font-size);
+  --cf-pill-md-line-height: var(--cf-size-md-line-height);
+
+  --cf-pill-lg-min-height: var(--cf-size-lg-height);
+  --cf-pill-lg-padding-h: var(--cf-size-lg-padding-h);
+  --cf-pill-lg-padding-v: var(--cf-size-lg-padding-v);
+  --cf-pill-lg-gap: var(--cf-size-lg-spacing);
+  --cf-pill-lg-font-size: var(--cf-size-lg-font-size);
+  --cf-pill-lg-line-height: var(--cf-size-lg-line-height);
+
+  --cf-pill-xl-min-height: var(--cf-size-xl-height);
+  --cf-pill-xl-padding-h: var(--cf-size-xl-padding-h);
+  --cf-pill-xl-padding-v: var(--cf-size-xl-padding-v);
+  --cf-pill-xl-gap: var(--cf-size-xl-spacing);
+  --cf-pill-xl-font-size: var(--cf-size-xl-font-size);
+  --cf-pill-xl-line-height: var(--cf-size-xl-line-height);
+
   /* Shadows */
   --cf-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   --cf-shadow-base: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
## Summary

- Defines shared `--cf-pill-*` geometry contract in `variables.ts` (border-radius, min-height, padding, gap, font-size, line-height across xs/sm/md/lg/xl sizes)
- Migrates `cf-badge`, `cf-chip`, and `cf-button[variant="pill"]` onto shared tokens — colors and interactivity stay component-specific (Option B)
- Fixes `--cf-radius-full` typo in button pill styles → canonical `--cf-pill-border-radius`
- Updates button story with pill variant coverage and correct size values (`xs/sm/md/lg/xl/icon`)

Closes CT-1501 (Bucket 4 of the design token alignment work under CT-1497).

## Test plan

- [ ] All three pill-like components reference `--cf-pill-*` tokens for geometry
- [ ] Visual spot-check of badge, chip, and button-pill at different sizes
- [ ] `deno task test` in `packages/ui` passes (77 passed per Codex run)
- [ ] Button story pill variant renders correctly in catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)