### PR TITLE
Enhance reactivity log to allow references to metadata fields instead of only value fields

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -93,6 +93,7 @@ import {
 import type {
   ChangeGroup,
   IExtendedStorageTransaction,
+  IMemorySpaceAddress,
   IReadOptions,
 } from "./storage/interface.ts";
 import {
@@ -1401,7 +1402,7 @@ export class CellImpl<T extends FabricValue>
   getSourceCell(schema?: JSONSchema): Cell<any> | undefined {
     if (!this.synced) this.sync(); // No await, just kicking this off
     let sourceCellId = this.runtime.readTx(this.tx).readOrThrow(
-      { ...this.link, path: ["source"] },
+      { ...this.link, path: ["source"] } as IMemorySpaceAddress,
       {
         meta: { ...ignoreReadForScheduling, ...internalVerifierRead },
       },
@@ -1440,7 +1441,7 @@ export class CellImpl<T extends FabricValue>
     }
     // System-owned provenance metadata, not user-surface value data.
     this.tx.writeOrThrow(
-      { ...this.link, path: ["source"] },
+      { ...this.link, path: ["source"] } as IMemorySpaceAddress,
       // TODO(@ubik2): Transition source links to sigil links?
       { "/": fromURI(sourceLink.id) },
     );

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -5,6 +5,7 @@ import {
   type CellLink,
   type NormalizedFullLink,
   parseLink,
+  toMemorySpaceAddress,
 } from "./link-utils.ts";
 import type {
   IExtendedStorageTransaction,
@@ -97,10 +98,10 @@ export function resolveLink(
     let nextLink: NormalizedFullLink | undefined;
 
     // Sigil probe at full path
-    const sigilProbe = tx.read({
+    const sigilProbe = tx.read(toMemorySpaceAddress({
       ...link,
-      path: ["value", ...link.path, "/", LINK_V1_TAG],
-    });
+      path: [...link.path, "/", LINK_V1_TAG],
+    }));
     if (
       sigilProbe.ok &&
       isRecord(sigilProbe.ok.value) &&
@@ -137,10 +138,10 @@ export function resolveLink(
           }
         } else {
           // Check sigil at this parent, then legacy
-          const parentSigil = tx.read({
+          const parentSigil = tx.read(toMemorySpaceAddress({
             ...link,
-            path: ["value", ...lastValid, "/", LINK_V1_TAG],
-          });
+            path: [...lastValid, "/", LINK_V1_TAG],
+          }));
           if (parentSigil.ok && isRecord(parentSigil.ok.value)) {
             // Read the full value at the parent to ensure proper reactivity
             const whole = tx.readValueOrThrow({ ...link, path: lastValid });
@@ -214,10 +215,10 @@ function checkLegacyAt(
   atPath: readonly string[],
   onlyRedirects: boolean,
 ): NormalizedFullLink | undefined {
-  const aliasPath = tx.read({
+  const aliasPath = tx.read(toMemorySpaceAddress({
     ...link,
-    path: ["value", ...atPath, "$alias", "path"],
-  });
+    path: [...atPath, "$alias", "path"],
+  }));
   if (Array.isArray(aliasPath.ok?.value)) {
     return parseLink(
       tx.readValueOrThrow({ ...link, path: atPath }) as CellLink,
@@ -225,10 +226,10 @@ function checkLegacyAt(
     );
   }
   if (onlyRedirects) return undefined;
-  const legacyCell = tx.read({
+  const legacyCell = tx.read(toMemorySpaceAddress({
     ...link,
-    path: ["value", ...atPath, "cell", "/"],
-  });
+    path: [...atPath, "cell", "/"],
+  }));
   if (typeof legacyCell.ok?.value === "string") {
     return parseLink(
       tx.readValueOrThrow({ ...link, path: atPath }) as CellLink,

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -32,9 +32,23 @@ export type NormalizedLink = {
  * Full normalized link that from a complete link, i.e. with required id, space
  * and type. Gets created by parseLink if a base is provided.
  *
- * Any such link can be used as a memory address.
+ * Any such link can be used as a memory address
  */
 export type NormalizedFullLink = NormalizedLink & IMemorySpaceAddress;
+
+/**
+ * Convert a value-relative normalized link into a document-root memory address.
+ */
+export function toMemorySpaceAddress(
+  link: NormalizedFullLink,
+): IMemorySpaceAddress {
+  return {
+    space: link.space,
+    id: link.id,
+    type: link.type ?? "application/json",
+    path: ["value", ...link.path],
+  };
+}
 
 /**
  * Primitive cell link types that can be serialized.

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -29,23 +29,32 @@ export type NormalizedLink = {
 };
 
 /**
- * Full normalized link that from a complete link, i.e. with required id, space
- * and type. Gets created by parseLink if a base is provided.
+ * Full normalized link from a complete link, i.e. with required id, space and
+ * type. Gets created by parseLink if a base is provided.
  *
- * Any such link can be used as a memory address
+ * Normalized link paths are value-relative. Use `toMemorySpaceAddress` when a
+ * document-root memory address is required.
  */
-export type NormalizedFullLink = NormalizedLink & IMemorySpaceAddress;
+export type NormalizedFullLink = NormalizedLink & {
+  id: URI;
+  space: MemorySpace;
+  type: string; // just string, so we can't use it as an IMemorySpaceAddress
+};
 
+export type ValuePath = readonly ["value", ...string[]];
+export type IMemorySpaceValueAddress = IMemorySpaceAddress & {
+  path: ValuePath;
+};
 /**
  * Convert a value-relative normalized link into a document-root memory address.
  */
 export function toMemorySpaceAddress(
   link: NormalizedFullLink,
-): IMemorySpaceAddress {
+): IMemorySpaceValueAddress {
   return {
     space: link.space,
     id: link.id,
-    type: link.type ?? "application/json",
+    type: (link.type ?? "application/json") as IMemorySpaceValueAddress["type"],
     path: ["value", ...link.path],
   };
 }
@@ -221,8 +230,14 @@ export function areNormalizedLinksSame(
  * Serialize an address to a string key for use in Maps/Sets/memoization.
  * Includes space, id, type, and path — the same fields compared by
  * areNormalizedLinksSame.
+ *
+ * Because links are relative to "value", the IMemorySpaceAddress and
+ * NormalizedFullLink version of the same address will return different
+ * keys, so they should not be mixed up.
  */
-export function addressKey(addr: IMemorySpaceAddress): string {
+export function addressKey(
+  addr: IMemorySpaceAddress | NormalizedFullLink,
+): string {
   return JSON.stringify([addr.space, addr.id, addr.type, addr.path]);
 }
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -49,7 +49,6 @@ import type { SigilLink } from "./sigil-types.ts";
 import type { Runtime } from "./runtime.ts";
 import type {
   IExtendedStorageTransaction,
-  IMemorySpaceAddress,
   IStorageSubscription,
   MemorySpace,
   URI,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -49,6 +49,7 @@ import type { SigilLink } from "./sigil-types.ts";
 import type { Runtime } from "./runtime.ts";
 import type {
   IExtendedStorageTransaction,
+  IMemorySpaceAddress,
   IStorageSubscription,
   MemorySpace,
   URI,

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -24,6 +24,7 @@ import type {
 import {
   areNormalizedLinksSame,
   type NormalizedFullLink,
+  toMemorySpaceAddress,
 } from "./link-utils.ts";
 import type {
   ChangeGroup,
@@ -217,9 +218,10 @@ function addressMatchesLinkPrefix(
   address: IMemorySpaceAddress,
   link: NormalizedFullLink,
 ): boolean {
+  const documentAddress = toMemorySpaceAddress(link);
   return address.space === link.space &&
     address.id === link.id &&
-    arraysOverlap(link.path, address.path);
+    arraysOverlap(documentAddress.path, address.path);
 }
 
 function filterIgnoredAddresses(
@@ -686,28 +688,9 @@ export class Scheduler {
         }
         writeDetailsBySpace.set(write.space, details);
       }
-      writes.set(key, this.lookupComparableWriteValue(details, write));
-      if (!writes.has(key)) writes.set(key, undefined);
+      writes.set(key, details.has(key) ? details.get(key) : undefined);
     }
     return writes;
-  }
-
-  private lookupComparableWriteValue(
-    details: Map<string, unknown>,
-    write: IMemorySpaceAddress,
-  ): unknown {
-    const exactKey = this.makeAddressKey(write);
-    if (details.has(exactKey)) {
-      return details.get(exactKey);
-    }
-    const valueKey = this.makeAddressKey({
-      ...write,
-      path: ["value", ...write.path],
-    });
-    if (details.has(valueKey)) {
-      return details.get(valueKey);
-    }
-    return undefined;
   }
 
   private runIdempotencyRecheck(
@@ -937,7 +920,7 @@ export class Scheduler {
         this.setDependencies(action, {
           reads: [],
           shallowReads: [],
-          writes: declaredWrites,
+          writes: declaredWrites.map(toMemorySpaceAddress),
         });
       }
     }
@@ -1030,7 +1013,7 @@ export class Scheduler {
     // Only set if not already set (resubscribe can be called multiple times)
     this.registerParentChild(action, { allowExisting: false });
 
-    const { entities, pathsWithValuesByEntity } = this.addTriggerPaths(
+    const { entities, triggerPathsByEntity } = this.addTriggerPaths(
       action,
       reads,
       shallowReads,
@@ -1038,14 +1021,14 @@ export class Scheduler {
 
     logger.debug("schedule-resubscribe", () => [
       `Action: ${actionId}`,
-      `Entities: ${pathsWithValuesByEntity.size}`,
+      `Entities: ${triggerPathsByEntity.size}`,
       `Reads: ${reads.length}`,
     ]);
 
-    for (const [spaceAndURI, pathsWithValues] of pathsWithValuesByEntity) {
+    for (const [spaceAndURI, triggerPaths] of triggerPathsByEntity) {
       logger.debug("schedule-resubscribe-path", () => [
         `Registered action for ${spaceAndURI}`,
-        `Paths: ${pathsWithValues.map((p) => p.join("/")).join(", ")}`,
+        `Paths: ${triggerPaths.map((p) => p.join("/")).join(", ")}`,
       ]);
     }
 
@@ -1759,7 +1742,9 @@ export class Scheduler {
     );
     const declaredWrites = sortAndCompactPaths(
       filterIgnoredAddresses(
-        (action as Partial<TelemetryAnnotations>).writes,
+        ((action as Partial<TelemetryAnnotations>).writes ?? []).map(
+          toMemorySpaceAddress,
+        ),
         ignoredSchedulingWrites,
       ),
     );
@@ -1881,7 +1866,7 @@ export class Scheduler {
     shallowReads: IMemorySpaceAddress[],
   ): {
     entities: Set<SpaceAndURI>;
-    pathsWithValuesByEntity: Map<SpaceAndURI, SortedAndCompactPaths>;
+    triggerPathsByEntity: Map<SpaceAndURI, SortedAndCompactPaths>;
   } {
     this.clearActionTriggers(action);
     const pathsByEntity = addressesToPathByEntity(reads);
@@ -1889,7 +1874,7 @@ export class Scheduler {
       shallowReads,
     );
     const entities = new Set<SpaceAndURI>();
-    const pathsWithValuesByEntity = new Map<
+    const triggerPathsByEntity = new Map<
       SpaceAndURI,
       SortedAndCompactPaths
     >();
@@ -1899,30 +1884,18 @@ export class Scheduler {
       if (!this.triggers.has(spaceAndURI)) {
         this.triggers.set(spaceAndURI, new Map());
       }
-      const pathsWithValues = paths.map((path) =>
-        [
-          "value",
-          ...path,
-        ] as readonly MemoryAddressPathComponent[]
-      );
-      this.triggers.get(spaceAndURI)!.set(action, pathsWithValues);
-      pathsWithValuesByEntity.set(spaceAndURI, pathsWithValues);
+      this.triggers.get(spaceAndURI)!.set(action, paths);
+      triggerPathsByEntity.set(spaceAndURI, paths);
     }
     for (const [spaceAndURI, paths] of nonRecursivePathsByEntity) {
       entities.add(spaceAndURI);
       if (!this.nonRecursiveTriggers.has(spaceAndURI)) {
         this.nonRecursiveTriggers.set(spaceAndURI, new Map());
       }
-      const pathsWithValues = paths.map((path) =>
-        [
-          "value",
-          ...path,
-        ] as readonly MemoryAddressPathComponent[]
-      );
-      this.nonRecursiveTriggers.get(spaceAndURI)!.set(action, pathsWithValues);
+      this.nonRecursiveTriggers.get(spaceAndURI)!.set(action, paths);
     }
 
-    return { entities, pathsWithValuesByEntity };
+    return { entities, triggerPathsByEntity };
   }
 
   private clearActionTriggers(action: Action): void {
@@ -2116,13 +2089,10 @@ export class Scheduler {
   }
 
   private pathMatchesWrite(
-    pathWithValuePrefix: readonly MemoryAddressPathComponent[],
+    readPath: readonly MemoryAddressPathComponent[],
     writePath: readonly MemoryAddressPathComponent[],
     options: { nonRecursive?: boolean } = {},
   ): boolean {
-    const readPath = pathWithValuePrefix[0] === "value"
-      ? pathWithValuePrefix.slice(1)
-      : pathWithValuePrefix;
     return options.nonRecursive
       ? writePath.length <= readPath.length + 1 &&
         arraysOverlap(writePath, readPath)
@@ -3273,7 +3243,7 @@ export class Scheduler {
             space: read.space,
             id: read.id,
             type: read.type ?? "application/json",
-            path: ["value", ...read.path],
+            path: [...read.path],
           },
           { meta: ignoreReadForScheduling },
         );
@@ -3301,11 +3271,7 @@ export class Scheduler {
           }
           writeDetailsBySpace.set(write.space, details);
         }
-        writeValues.set(
-          key,
-          this.lookupComparableWriteValue(details, write),
-        );
-        if (!writeValues.has(key)) writeValues.set(key, undefined);
+        writeValues.set(key, details.has(key) ? details.get(key) : undefined);
       } catch {
         writeValues.set(key, "[write-error]");
       }

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -18,7 +18,10 @@ import { readMaybeLink, resolveLink } from "./link-resolution.ts";
 import { type IExtendedStorageTransaction } from "./storage/interface.ts";
 import { getTransactionForChildCells } from "./storage/extended-storage-transaction.ts";
 import { type Runtime } from "./runtime.ts";
-import { type NormalizedFullLink } from "./link-utils.ts";
+import {
+  type IMemorySpaceValueAddress,
+  type NormalizedFullLink,
+} from "./link-utils.ts";
 import {
   createQueryResultProxy,
   isCellResultForDereferencing,
@@ -26,7 +29,6 @@ import {
 import { toCell } from "./back-to-cell.ts";
 import {
   combineSchema,
-  IMemorySpaceValueAddress,
   IObjectCreator,
   mergeAnyOfMatches,
   mergeSchemaFlags,
@@ -34,6 +36,7 @@ import {
 } from "@commonfabric/runner/traverse";
 import { ignoreReadForScheduling } from "./scheduler.ts";
 import { internalVerifierRead } from "./storage/reactivity-log.ts";
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 
 const logger = getLogger("validateAndTransform", {
   enabled: true,
@@ -541,13 +544,7 @@ export function validateAndTransform(
   }
 
   // Link paths don't include value, but doc address should
-  const { space, id, type, path } = ref;
-  const address: IMemorySpaceValueAddress = {
-    space,
-    id,
-    type,
-    path: ["value", ...path],
-  };
+  const address: IMemorySpaceValueAddress = toMemorySpaceAddress(ref);
   // Get the full value without telling the scheduler. The traverse method will
   // notify the scheduler for shallow reads as they occur.
   const value = tx.readOrThrow(address, {

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -19,7 +19,6 @@ import type {
   ITransactionJournal,
   ITransactionReader,
   ITransactionWriter,
-  ITransactionWriteRequest,
   MemorySpace,
   ReaderError,
   ReadError,
@@ -43,6 +42,10 @@ import {
   reactivityLogFromActivities,
 } from "./reactivity-log.ts";
 
+import {
+  type NormalizedFullLink,
+  toMemorySpaceAddress,
+} from "../link-types.ts";
 import { ignoreReadForScheduling } from "../scheduler.ts";
 import {
   type AttemptedWrite,
@@ -327,13 +330,10 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   }
 
   readValueOrThrow(
-    address: IMemorySpaceAddress,
+    address: NormalizedFullLink,
     options?: IReadOptions,
   ): Immutable<FabricValue> {
-    return this.readOrThrow(
-      { ...address, path: ["value", ...address.path] },
-      options,
-    );
+    return this.readOrThrow(toMemorySpaceAddress(address), options);
   }
 
   writer(space: MemorySpace): Result<ITransactionWriter, WriterError> {
@@ -429,15 +429,15 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   }
 
   writeValueOrThrow(
-    address: IMemorySpaceAddress,
+    address: NormalizedFullLink,
     value: FabricValue,
   ): void {
     this.assertWritable("writeValueOrThrow()");
-    this.writeOrThrow({ ...address, path: ["value", ...address.path] }, value);
+    this.writeOrThrow(toMemorySpaceAddress(address), value);
   }
 
   writeValuesOrThrow(
-    writes: Iterable<ITransactionWriteRequest>,
+    writes: Iterable<{ address: NormalizedFullLink; value: FabricValue }>,
   ): void {
     this.assertWritable("writeValuesOrThrow()");
     if (this.tx.writeBatch) {
@@ -445,10 +445,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
         (function* () {
           for (const write of writes) {
             yield {
-              address: {
-                ...write.address,
-                path: ["value", ...write.address.path],
-              },
+              address: toMemorySpaceAddress(write.address),
               value: write.value,
             };
           }
@@ -777,7 +774,7 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
   }
 
   readValueOrThrow(
-    address: IMemorySpaceAddress,
+    address: NormalizedFullLink,
     options?: IReadOptions,
   ): FabricValue {
     return this.wrapped.readValueOrThrow(
@@ -805,14 +802,14 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
   }
 
   writeValueOrThrow(
-    address: IMemorySpaceAddress,
+    address: NormalizedFullLink,
     value: FabricValue,
   ): void {
     return this.wrapped.writeValueOrThrow(address, value);
   }
 
   writeValuesOrThrow(
-    writes: Iterable<ITransactionWriteRequest>,
+    writes: Iterable<{ address: NormalizedFullLink; value: FabricValue }>,
   ): void {
     if (this.wrapped.writeValuesOrThrow) {
       return this.wrapped.writeValuesOrThrow(writes);

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -39,6 +39,7 @@ import type {
   TrustSnapshot,
   WritePolicyInput,
 } from "../cfc/mod.ts";
+import type { NormalizedFullLink } from "../link-types.ts";
 
 export type {
   Assertion,
@@ -675,7 +676,7 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    * @returns The read value.
    */
   readValueOrThrow(
-    address: IMemorySpaceAddress,
+    address: NormalizedFullLink,
     options?: IReadOptions,
   ): FabricValue;
 
@@ -714,7 +715,7 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    * @param value - Value to write.
    */
   writeValueOrThrow(
-    address: IMemorySpaceAddress,
+    address: NormalizedFullLink,
     value: FabricValue,
   ): void;
 
@@ -723,7 +724,7 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    * `["value", ...path]` helper semantics on top of `writeBatch`.
    */
   writeValuesOrThrow?(
-    writes: Iterable<ITransactionWriteRequest>,
+    writes: Iterable<{ address: NormalizedFullLink; value: FabricValue }>,
   ): void;
 }
 

--- a/packages/runner/src/storage/reactivity-log.ts
+++ b/packages/runner/src/storage/reactivity-log.ts
@@ -56,8 +56,6 @@ export function isInternalVerifierRead(meta?: Metadata): boolean {
 export function reactivityLogFromActivities(
   activities: Iterable<Activity>,
 ): TransactionReactivityLog {
-  const normalizedPath = (path: readonly string[]): string[] =>
-    path[0] === "value" ? path.slice(1) : [...path];
   const log: TransactionReactivityLog = {
     reads: [],
     shallowReads: [],
@@ -72,7 +70,7 @@ export function reactivityLogFromActivities(
         space: activity.read.space,
         id: activity.read.id,
         type: activity.read.type,
-        path: normalizedPath(activity.read.path),
+        path: [...activity.read.path],
       };
       if (activity.read.nonRecursive === true) {
         log.shallowReads.push(address);
@@ -90,7 +88,7 @@ export function reactivityLogFromActivities(
         space: activity.write.space,
         id: activity.write.id,
         type: activity.write.type,
-        path: normalizedPath(activity.write.path),
+        path: [...activity.write.path],
       });
     }
   }

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -235,9 +235,6 @@ const collapseEmptyJsonDocumentEnvelope = (
 
 const EMPTY_META = Object.freeze({});
 
-const normalizeReactivityPath = (path: readonly string[]): string[] =>
-  path[0] === "value" ? [...path.slice(1)] : [...path];
-
 type PathInspection =
   | {
     kind: "ok";
@@ -1682,7 +1679,7 @@ export class V2StorageTransaction implements IStorageTransaction {
         space: read.space,
         id: read.id,
         type: read.type,
-        path: normalizeReactivityPath(read.path),
+        path: read.path,
       };
 
       if (read.nonRecursive === true) {
@@ -1725,7 +1722,7 @@ export class V2StorageTransaction implements IStorageTransaction {
             space,
             id,
             type,
-            path: normalizeReactivityPath(path),
+            path,
           });
         }
       }

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -64,8 +64,12 @@ import type {
 } from "./storage/interface.ts";
 import { createReadOnlyTransactionError } from "./storage/interface.ts";
 import { resolve } from "./storage/transaction/attestation.ts";
-import { isWriteRedirectLink } from "./link-types.ts";
-import { LastNode } from "./link-resolution.ts";
+import {
+  type IMemorySpaceValueAddress,
+  isWriteRedirectLink,
+  type ValuePath,
+} from "./link-types.ts";
+import type { LastNode } from "./link-resolution.ts";
 import type { IAttestation, IMemoryAddress } from "./storage/interface.ts";
 
 const logger = getLogger("traverse", { enabled: true, level: "warn" });
@@ -97,10 +101,6 @@ const enum TypeValidity {
   Unknown = 2,
 }
 
-type ValuePath = readonly ["value", ...string[]];
-export type IMemorySpaceValueAddress = IMemorySpaceAddress & {
-  path: ValuePath;
-};
 export type IMemorySpaceValueAttestation = IMemorySpaceAttestation & {
   address: IMemorySpaceValueAddress;
 };

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -9,7 +9,7 @@ import * as V2Storage from "../src/storage/v2.ts";
 import { raw } from "../src/module.ts";
 import { storedCfcMetadataAppliesToPath } from "../src/cfc/metadata.ts";
 import { Runtime } from "../src/runtime.ts";
-import { parseLink } from "../src/link-utils.ts";
+import { parseLink, toMemorySpaceAddress } from "../src/link-utils.ts";
 import {
   canonicalizeCfcMetadata,
   canonicalizePreparedDigestInput,
@@ -1400,12 +1400,9 @@ describe("ExtendedStorageTransaction CFC gate", () => {
 
       const link = cell.getAsNormalizedFullLink();
       const verify = runtime.edit();
-      const stored = verify.readOrThrow({
-        space: link.space,
-        id: link.id,
-        type: link.type,
-        path: [],
-      }) as { cfc?: unknown };
+      const stored = verify.readOrThrow(toMemorySpaceAddress(link)) as {
+        cfc?: unknown;
+      };
       expect(stored.cfc).toBeUndefined();
       expect(storedCfcMetadataAppliesToPath(verify, link)).toBe(false);
       verify.abort();

--- a/packages/runner/test/memory-v2-pull-reactivity.test.ts
+++ b/packages/runner/test/memory-v2-pull-reactivity.test.ts
@@ -9,6 +9,7 @@ import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import type { Action } from "../src/scheduler.ts";
 import type { URI } from "@commonfabric/memory/interface";
 import { createGraphFixture } from "./memory-v2-graph.fixture.ts";
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("memory-v2-pull-reactivity");
 const space = signer.did();
@@ -108,9 +109,9 @@ describe("Memory v2 pull reactivity", () => {
     runtime.scheduler.subscribe(
       computation,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [result.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(result.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -207,9 +208,9 @@ describe("Memory v2 pull reactivity", () => {
     runtime.scheduler.subscribe(
       computation,
       {
-        reads: [root.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(root.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [result.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(result.getAsNormalizedFullLink())],
       },
       {},
     );

--- a/packages/runner/test/runtime-v2-read-tx-fallback.test.ts
+++ b/packages/runner/test/runtime-v2-read-tx-fallback.test.ts
@@ -4,6 +4,7 @@ import { Identity } from "@commonfabric/identity";
 import { createQueryResultProxy } from "../src/query-result-proxy.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("runtime-v2-read-tx-fallback");
 const space = signer.did();
@@ -140,7 +141,12 @@ describe("Runtime v2 read transaction fallback", () => {
       expect(cell.withTx(readTx2).get()).toBe(3);
       expect(() => readTx1.writeValueOrThrow(cell.getAsNormalizedFullLink(), 4))
         .toThrow(/runtime\.edit\(\)/);
-      expect(() => readTx1.tx.write(cell.getAsNormalizedFullLink(), 4))
+      expect(() =>
+        readTx1.tx.write(
+          toMemorySpaceAddress(cell.getAsNormalizedFullLink()),
+          4,
+        )
+      )
         .toThrow(/runtime\.edit\(\)/);
       expect(() => readTx1.abort()).toThrow(/runtime\.edit\(\)/);
       await expect(readTx1.commit()).resolves.toEqual({ ok: {} });

--- a/packages/runner/test/scheduler-convergence.test.ts
+++ b/packages/runner/test/scheduler-convergence.test.ts
@@ -8,6 +8,7 @@ import { Runtime } from "../src/runtime.ts";
 import { type Action } from "../src/scheduler.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -180,9 +181,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       actionA,
       {
-        reads: [cellA.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cellA.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cellB.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cellB.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -190,9 +191,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       actionB,
       {
-        reads: [cellB.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cellB.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cellA.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cellA.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -201,9 +202,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       effect,
       {
-        reads: [cellB.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cellB.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [output.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );
@@ -252,9 +253,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       computation,
       {
-        reads: [counter.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(counter.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [doubled.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(doubled.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -272,9 +273,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       computation,
       {
-        reads: [counter.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(counter.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [doubled.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(doubled.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -339,9 +340,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       actionA,
       {
-        reads: [cellB.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cellB.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cellA.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cellA.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -349,9 +350,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       actionB,
       {
-        reads: [cellA.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cellA.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cellB.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cellB.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -360,9 +361,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       effect,
       {
-        reads: [cellB.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cellB.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [output.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );
@@ -415,9 +416,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       computation,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [result.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(result.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -435,9 +436,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       computation,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [result.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(result.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -499,9 +500,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       actionA,
       {
-        reads: [cellC.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cellC.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cellA.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cellA.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -510,9 +511,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       actionB,
       {
-        reads: [cellA.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cellA.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cellB.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cellB.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -521,9 +522,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       actionC,
       {
-        reads: [cellB.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cellB.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cellC.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cellC.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -729,9 +730,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       action,
       {
-        reads: [cell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cell.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -749,9 +750,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       action,
       {
-        reads: [cell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cell.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -826,9 +827,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       acyclicAction,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [computed.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(computed.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -837,9 +838,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       cycleActionA,
       {
-        reads: [cycleA.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cycleA.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cycleB.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cycleB.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -848,9 +849,9 @@ describe("cycle-aware convergence", () => {
     runtime.scheduler.subscribe(
       cycleActionB,
       {
-        reads: [cycleB.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cycleB.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cycleA.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cycleA.getAsNormalizedFullLink())],
       },
       {},
     );

--- a/packages/runner/test/scheduler-core.test.ts
+++ b/packages/runner/test/scheduler-core.test.ts
@@ -386,32 +386,13 @@ describe("scheduler", () => {
     expect(computeRuns.at(-1)?.declaredWrites[0]).toMatchObject({
       space,
       entityId: expect.stringMatching(/^of:/),
-      path: [],
+      path: ["value"],
     });
     expect(effectRuns.at(-1)?.declaredWrites[0]).toMatchObject({
       space,
       entityId: expect.stringMatching(/^of:/),
-      path: [],
+      path: ["value"],
     });
-  });
-
-  it("falls back to value-path write details for non-JSON diagnostics", () => {
-    const scheduler = runtime.scheduler as any;
-    const write = {
-      space,
-      id: "scheduler-non-json-value-fallback",
-      type: "text/plain",
-      path: ["body"],
-    };
-    const details = new Map<string, unknown>([[
-      scheduler.makeAddressKey({
-        ...write,
-        path: ["value", "body"],
-      }),
-      "hello",
-    ]]);
-
-    expect(scheduler.lookupComparableWriteValue(details, write)).toBe("hello");
   });
 
   it("should remove actions", async () => {
@@ -904,16 +885,22 @@ describe("scheduler", () => {
     // The "nested" path should appear in potentialWrites
     expect(log.potentialWrites).toBeDefined();
     expect(
-      log.potentialWrites!.some((addr) => addr.path[0] === "nested"),
+      log.potentialWrites!.some((addr) =>
+        addr.path[0] === "value" && addr.path[1] === "nested"
+      ),
     ).toBe(true);
 
     // Only `b` changed within nested, so nested.b should be in writes
     expect(
-      log.writes.some((w) => w.path[0] === "nested" && w.path[1] === "b"),
+      log.writes.some((w) =>
+        w.path[0] === "value" && w.path[1] === "nested" && w.path[2] === "b"
+      ),
     ).toBe(true);
     // nested.a should NOT be in writes (value didn't change)
     expect(
-      log.writes.some((w) => w.path[0] === "nested" && w.path[1] === "a"),
+      log.writes.some((w) =>
+        w.path[0] === "value" && w.path[1] === "nested" && w.path[2] === "a"
+      ),
     ).toBe(false);
 
     await setTx.commit();
@@ -942,17 +929,25 @@ describe("scheduler", () => {
     // The "data" path should be in potentialWrites because diffAndUpdate
     // reads the nested object to compare
     expect(log.potentialWrites).toBeDefined();
-    expect(log.potentialWrites!.some((addr) => addr.path[0] === "data")).toBe(
-      true,
-    );
+    expect(
+      log.potentialWrites!.some((addr) =>
+        addr.path[0] === "value" && addr.path[1] === "data"
+      ),
+    ).toBe(true);
 
     // Only changed property within data should be in writes
     expect(
-      log.writes.some((w) => w.path[0] === "data" && w.path[1] === "changed"),
+      log.writes.some((w) =>
+        w.path[0] === "value" && w.path[1] === "data" &&
+        w.path[2] === "changed"
+      ),
     ).toBe(true);
     // unchanged property should NOT be in writes (value didn't change)
     expect(
-      log.writes.some((w) => w.path[0] === "data" && w.path[1] === "unchanged"),
+      log.writes.some((w) =>
+        w.path[0] === "value" && w.path[1] === "data" &&
+        w.path[2] === "unchanged"
+      ),
     ).toBe(false);
 
     await setTx.commit();

--- a/packages/runner/test/scheduler-core.test.ts
+++ b/packages/runner/test/scheduler-core.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { assertSpyCall, assertSpyCalls, spy } from "@std/testing/mock";
+import { storedCfcMetadataAppliesToPath } from "../src/cfc/metadata.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { Runtime } from "../src/runtime.ts";
 import {
@@ -862,6 +863,171 @@ describe("scheduler", () => {
     // Still should not have run
     expect(actionRunCount).toBe(1);
     expect(resultCell.get()).toEqual({ count: 1, lastValue: { value: 1 } });
+  });
+
+  it("should not react to stored CFC metadata updates read through verifier helpers", async () => {
+    const sourceCell = runtime.getCell<{ secret: string }>(
+      space,
+      "source-cell-for-cfc-metadata-reactivity-test",
+      {
+        type: "object",
+        properties: {
+          secret: { type: "string" },
+        },
+        required: ["secret"],
+      },
+      tx,
+    );
+    sourceCell.set({ secret: "seed" });
+
+    const resultCell = runtime.getCell<{ count: number; applies: boolean }>(
+      space,
+      "result-cell-for-cfc-metadata-reactivity-test",
+      undefined,
+      tx,
+    );
+    resultCell.set({ count: 0, applies: false });
+    tx.commit();
+    tx = runtime.edit();
+
+    const secretLink = sourceCell.key("secret").getAsNormalizedFullLink();
+
+    let actionRunCount = 0;
+    let lastApplies = false;
+
+    const cfcMetadataReadAction: Action = (actionTx) => {
+      actionRunCount++;
+      lastApplies = storedCfcMetadataAppliesToPath(actionTx, secretLink);
+      resultCell.withTx(actionTx).set({
+        count: actionRunCount,
+        applies: lastApplies,
+      });
+    };
+
+    runtime.scheduler.subscribe(
+      cfcMetadataReadAction,
+      { reads: [], shallowReads: [], writes: [] },
+      {},
+    );
+    await resultCell.pull();
+
+    expect(actionRunCount).toBe(1);
+    expect(lastApplies).toBe(false);
+    expect(resultCell.get()).toEqual({ count: 1, applies: false });
+
+    tx.writeOrThrow(
+      {
+        space: secretLink.space,
+        id: secretLink.id,
+        type: secretLink.type as "application/json",
+        path: ["cfc"],
+      },
+      {
+        version: 1,
+        schemaHash: "cfc-reactivity-test-schema",
+        labelMap: {
+          version: 1,
+          entries: [{
+            path: ["secret"],
+            label: { confidentiality: ["secret"] },
+          }],
+        },
+      },
+    );
+    tx.commit();
+    tx = runtime.edit();
+    await resultCell.pull();
+
+    expect(actionRunCount).toBe(1);
+    expect(resultCell.get()).toEqual({ count: 1, applies: false });
+
+    const verifyTx = runtime.edit();
+    expect(storedCfcMetadataAppliesToPath(verifyTx, secretLink)).toBe(true);
+    await verifyTx.commit();
+  });
+
+  it("should react to direct reads of stored CFC metadata when the cfc field changes", async () => {
+    const sourceCell = runtime.getCell<{ secret: string }>(
+      space,
+      "source-cell-for-direct-cfc-read-reactivity-test",
+      {
+        type: "object",
+        properties: {
+          secret: { type: "string" },
+        },
+        required: ["secret"],
+      },
+      tx,
+    );
+    sourceCell.set({ secret: "seed" });
+
+    const resultCell = runtime.getCell<{ count: number; version: number }>(
+      space,
+      "result-cell-for-direct-cfc-read-reactivity-test",
+      undefined,
+      tx,
+    );
+    resultCell.set({ count: 0, version: 0 });
+    tx.commit();
+    tx = runtime.edit();
+
+    const sourceLink = sourceCell.getAsNormalizedFullLink();
+
+    let actionRunCount = 0;
+    let lastVersion = 0;
+
+    const directCfcReadAction: Action = (actionTx) => {
+      actionRunCount++;
+      const cfcDocument = actionTx.readOrThrow({
+        space: sourceLink.space,
+        id: sourceLink.id,
+        type: sourceLink.type as "application/json",
+        path: ["cfc"],
+      }) as { version?: number } | undefined;
+      lastVersion = cfcDocument?.version ?? 0;
+      resultCell.withTx(actionTx).set({
+        count: actionRunCount,
+        version: lastVersion,
+      });
+    };
+
+    runtime.scheduler.subscribe(
+      directCfcReadAction,
+      { reads: [], shallowReads: [], writes: [] },
+      {},
+    );
+    await resultCell.pull();
+
+    expect(actionRunCount).toBe(1);
+    expect(lastVersion).toBe(0);
+    expect(resultCell.get()).toEqual({ count: 1, version: 0 });
+
+    tx.writeOrThrow(
+      {
+        space: sourceLink.space,
+        id: sourceLink.id,
+        type: sourceLink.type as "application/json",
+        path: ["cfc"],
+      },
+      {
+        version: 1,
+        schemaHash: "cfc-direct-read-reactivity-test-schema",
+        labelMap: {
+          version: 1,
+          entries: [{
+            path: ["secret"],
+            label: { confidentiality: ["secret"] },
+          }],
+        },
+      },
+    );
+    tx.commit();
+    tx = runtime.edit();
+    await resultCell.pull();
+
+    expect(actionRunCount).toBe(2);
+    expect(lastVersion).toBe(1);
+    expect(resultCell.get()).toEqual({ count: 2, version: 1 });
   });
 
   it("should track potentialWrites via Cell.set on nested path", async () => {

--- a/packages/runner/test/scheduler-core.test.ts
+++ b/packages/runner/test/scheduler-core.test.ts
@@ -15,6 +15,7 @@ import {
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import type { Entity } from "@commonfabric/memory/interface";
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -123,11 +124,11 @@ describe("scheduler", () => {
     };
     runtime.scheduler.subscribe(adder, {
       reads: [
-        a.getAsNormalizedFullLink(),
-        b.getAsNormalizedFullLink(),
+        toMemorySpaceAddress(a.getAsNormalizedFullLink()),
+        toMemorySpaceAddress(b.getAsNormalizedFullLink()),
       ],
       shallowReads: [],
-      writes: [c.getAsNormalizedFullLink()],
+      writes: [toMemorySpaceAddress(c.getAsNormalizedFullLink())],
     }, {});
     expect(runCount).toBe(0);
     expect(c.get()).toBe(0);
@@ -170,7 +171,7 @@ describe("scheduler", () => {
     runtime.scheduler.subscribe(
       effect,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
         writes: [],
       },
@@ -246,18 +247,18 @@ describe("scheduler", () => {
     runtime.scheduler.subscribe(
       computeIntermediate,
       {
-        reads: [a.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(a.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [b.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(b.getAsNormalizedFullLink())],
       },
       { changeGroup: "compute-intermediate-change-group" },
     );
     runtime.scheduler.subscribe(
       effectSink,
       {
-        reads: [b.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(b.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [c.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(c.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );
@@ -338,17 +339,17 @@ describe("scheduler", () => {
     runtime.scheduler.subscribe(
       computeIntermediate,
       {
-        reads: [a.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(a.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [b.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(b.getAsNormalizedFullLink())],
       },
     );
     runtime.scheduler.subscribe(
       effectSink,
       {
-        reads: [b.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(b.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [c.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(c.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );
@@ -484,11 +485,11 @@ describe("scheduler", () => {
     };
     const cancel = runtime.scheduler.subscribe(adder, {
       reads: [
-        a.getAsNormalizedFullLink(),
-        b.getAsNormalizedFullLink(),
+        toMemorySpaceAddress(a.getAsNormalizedFullLink()),
+        toMemorySpaceAddress(b.getAsNormalizedFullLink()),
       ],
       shallowReads: [],
-      writes: [c.getAsNormalizedFullLink()],
+      writes: [toMemorySpaceAddress(c.getAsNormalizedFullLink())],
     }, {});
     expect(runCount).toBe(0);
     expect(c.get()).toBe(0);
@@ -755,11 +756,11 @@ describe("scheduler", () => {
       increment,
       {
         reads: [
-          counter.getAsNormalizedFullLink(),
-          step.getAsNormalizedFullLink(),
+          toMemorySpaceAddress(counter.getAsNormalizedFullLink()),
+          toMemorySpaceAddress(step.getAsNormalizedFullLink()),
         ],
         shallowReads: [],
-        writes: [counter.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(counter.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );
@@ -1019,12 +1020,7 @@ describe("scheduler", () => {
     tx = runtime.edit();
 
     const sourceLink = sourceCell.getAsNormalizedFullLink();
-    const sourceAddress = {
-      space: sourceLink.space,
-      id: sourceLink.id,
-      type: sourceLink.type,
-      path: ["value", ...sourceLink.path],
-    };
+    const sourceAddress = toMemorySpaceAddress(sourceLink);
 
     let actionRunCount = 0;
     const action: Action = (actionTx) => {
@@ -1703,18 +1699,20 @@ describe("reactive retries", () => {
       runtime.scheduler.subscribe(
         action1,
         {
-          reads: [source.getAsNormalizedFullLink()],
+          reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
           shallowReads: [],
-          writes: [intermediate.getAsNormalizedFullLink()],
+          writes: [
+            toMemorySpaceAddress(intermediate.getAsNormalizedFullLink()),
+          ],
         },
         {},
       );
       runtime.scheduler.subscribe(
         action2,
         {
-          reads: [intermediate.getAsNormalizedFullLink()],
+          reads: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
           shallowReads: [],
-          writes: [output.getAsNormalizedFullLink()],
+          writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
         },
         {},
       );

--- a/packages/runner/test/scheduler-effects.test.ts
+++ b/packages/runner/test/scheduler-effects.test.ts
@@ -9,6 +9,7 @@ import { Runtime } from "../src/runtime.ts";
 import { type Action } from "../src/scheduler.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { toMemorySpaceAddress } from "../src/link-types.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -336,7 +337,9 @@ describe("effect/computation tracking", () => {
       {
         reads: [],
         shallowReads: [],
-        writes: [data.key("foo").getAsNormalizedFullLink()],
+        writes: [
+          toMemorySpaceAddress(data.key("foo").getAsNormalizedFullLink()),
+        ],
       },
       {},
     );
@@ -373,7 +376,9 @@ describe("effect/computation tracking", () => {
       {
         reads: [],
         shallowReads: [],
-        writes: [data.key("foo").getAsNormalizedFullLink()],
+        writes: [
+          toMemorySpaceAddress(data.key("foo").getAsNormalizedFullLink()),
+        ],
       },
       {},
     );
@@ -385,8 +390,8 @@ describe("effect/computation tracking", () => {
       reads: [],
       shallowReads: [],
       writes: [
-        data.key("foo").getAsNormalizedFullLink(),
-        data.key("bar").getAsNormalizedFullLink(),
+        toMemorySpaceAddress(data.key("foo").getAsNormalizedFullLink()),
+        toMemorySpaceAddress(data.key("bar").getAsNormalizedFullLink()),
       ],
     });
 

--- a/packages/runner/test/scheduler-effects.test.ts
+++ b/packages/runner/test/scheduler-effects.test.ts
@@ -9,7 +9,7 @@ import { Runtime } from "../src/runtime.ts";
 import { type Action } from "../src/scheduler.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { toMemorySpaceAddress } from "../src/link-types.ts";
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -208,7 +208,7 @@ describe("effect/computation tracking", () => {
     };
 
     runtime.scheduler.subscribe(parentAction, {
-      reads: [sourceCell.getAsNormalizedFullLink()],
+      reads: [toMemorySpaceAddress(sourceCell.getAsNormalizedFullLink())],
       shallowReads: [],
       writes: [],
     }, { isEffect: true }); // Mark as effect so it runs in pull mode
@@ -284,9 +284,9 @@ describe("effect/computation tracking", () => {
     runtime.scheduler.subscribe(
       action1,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [intermediate.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -296,9 +296,9 @@ describe("effect/computation tracking", () => {
     runtime.scheduler.subscribe(
       action2,
       {
-        reads: [intermediate.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [output.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -436,7 +436,7 @@ describe("effect/computation tracking", () => {
       {
         reads: [],
         shallowReads: [],
-        writes: [output.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -491,7 +491,7 @@ describe("effect/computation tracking", () => {
       {
         reads: [],
         shallowReads: [],
-        writes: [cellA.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cellA.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -501,7 +501,7 @@ describe("effect/computation tracking", () => {
     runtime.scheduler.resubscribe(computation, {
       reads: [],
       shallowReads: [],
-      writes: [cellB.getAsNormalizedFullLink()],
+      writes: [toMemorySpaceAddress(cellB.getAsNormalizedFullLink())],
     });
 
     expect(runtime.scheduler.getDependents(computation).has(effect)).toBe(
@@ -534,7 +534,7 @@ describe("effect/computation tracking", () => {
       {
         reads: [],
         shallowReads: [],
-        writes: [output.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -543,7 +543,7 @@ describe("effect/computation tracking", () => {
       reads: [],
       shallowReads: [],
       writes: [],
-      potentialWrites: [output.getAsNormalizedFullLink()],
+      potentialWrites: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
     });
 
     expect(runtime.scheduler.getDependents(computation).has(effect)).toBe(true);

--- a/packages/runner/test/scheduler-ordering.test.ts
+++ b/packages/runner/test/scheduler-ordering.test.ts
@@ -7,7 +7,7 @@ import { Runtime } from "../src/runtime.ts";
 import { type Action } from "../src/scheduler.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { toMemorySpaceAddress } from "../src/link-types.ts";
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -53,7 +53,11 @@ describe("push-triggered filtering", () => {
     // Run action
     runtime.scheduler.subscribe(
       action,
-      { reads: [], shallowReads: [], writes: [cell.getAsNormalizedFullLink()] },
+      {
+        reads: [],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
+      },
       {},
     );
     await cell.pull();
@@ -135,7 +139,7 @@ describe("push-triggered filtering", () => {
       {
         reads: [],
         shallowReads: [],
-        writes: [cell1.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cell1.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -143,7 +147,7 @@ describe("push-triggered filtering", () => {
     runtime.scheduler.resubscribe(action, {
       reads: [],
       shallowReads: [],
-      writes: [cell2.getAsNormalizedFullLink()],
+      writes: [toMemorySpaceAddress(cell2.getAsNormalizedFullLink())],
     });
 
     expect(
@@ -175,7 +179,7 @@ describe("push-triggered filtering", () => {
       {
         reads: [],
         shallowReads: [],
-        writes: [declaredWrite],
+        writes: [toMemorySpaceAddress(declaredWrite)],
       },
       {},
     );
@@ -238,7 +242,11 @@ describe("push-triggered filtering", () => {
     // First run with default scheduling should work
     runtime.scheduler.subscribe(
       action,
-      { reads: [], shallowReads: [], writes: [cell.getAsNormalizedFullLink()] },
+      {
+        reads: [],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
+      },
       {},
     );
     await cell.pull();
@@ -273,9 +281,9 @@ describe("push-triggered filtering", () => {
     runtime.scheduler.subscribe(
       action,
       {
-        reads: [cell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cell.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );
@@ -320,7 +328,11 @@ describe("push-triggered filtering", () => {
     // Run once to establish mightWrite
     runtime.scheduler.subscribe(
       action,
-      { reads: [], shallowReads: [], writes: [cell.getAsNormalizedFullLink()] },
+      {
+        reads: [],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
+      },
       {},
     );
     await cell.pull();
@@ -331,7 +343,11 @@ describe("push-triggered filtering", () => {
     // Run again with default scheduling - should bypass filter
     runtime.scheduler.subscribe(
       action,
-      { reads: [], shallowReads: [], writes: [cell.getAsNormalizedFullLink()] },
+      {
+        reads: [],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
+      },
       {},
     );
     await cell.pull();
@@ -463,7 +479,7 @@ describe("parent-child action ordering", () => {
     runtime.scheduler.subscribe(
       parentAction,
       {
-        reads: [toggle.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(toggle.getAsNormalizedFullLink())],
         shallowReads: [],
         writes: [],
       },
@@ -637,7 +653,7 @@ describe("parent-child action ordering", () => {
         childCanceler = runtime.scheduler.subscribe(
           childAction,
           {
-            reads: [source.getAsNormalizedFullLink()],
+            reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
             shallowReads: [],
             writes: [],
           },
@@ -654,7 +670,7 @@ describe("parent-child action ordering", () => {
     const parentCanceler = runtime.scheduler.subscribe(
       parentAction,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
         writes: [],
       },

--- a/packages/runner/test/scheduler-ordering.test.ts
+++ b/packages/runner/test/scheduler-ordering.test.ts
@@ -7,6 +7,7 @@ import { Runtime } from "../src/runtime.ts";
 import { type Action } from "../src/scheduler.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { toMemorySpaceAddress } from "../src/link-types.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -77,23 +78,23 @@ describe("push-triggered filtering", () => {
       {
         reads: [],
         shallowReads: [],
-        writes: [cell1.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cell1.getAsNormalizedFullLink())],
       },
       {},
     );
 
     expect(runtime.scheduler.getMightWrite(action)).toEqual([
-      cell1.getAsNormalizedFullLink(),
+      toMemorySpaceAddress(cell1.getAsNormalizedFullLink()),
     ]);
 
     runtime.scheduler.resubscribe(action, {
       reads: [],
       shallowReads: [],
-      writes: [cell2.getAsNormalizedFullLink()],
+      writes: [toMemorySpaceAddress(cell2.getAsNormalizedFullLink())],
     });
 
     expect(runtime.scheduler.getMightWrite(action)).toEqual([
-      cell2.getAsNormalizedFullLink(),
+      toMemorySpaceAddress(cell2.getAsNormalizedFullLink()),
     ]);
   });
 
@@ -185,7 +186,9 @@ describe("push-triggered filtering", () => {
       writes: [],
     });
 
-    expect(runtime.scheduler.getMightWrite(action)).toEqual([declaredWrite]);
+    expect(runtime.scheduler.getMightWrite(action)).toEqual([
+      toMemorySpaceAddress(declaredWrite),
+    ]);
   });
 
   it("should track filter stats", async () => {

--- a/packages/runner/test/scheduler-pull-seeds.bench.ts
+++ b/packages/runner/test/scheduler-pull-seeds.bench.ts
@@ -3,6 +3,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import type { Action } from "../src/scheduler.ts";
 import { BENCH_MEMORY_VERSION } from "./bench-memory-version.ts";
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("bench operator");
 const space = signer.did();
@@ -61,9 +62,9 @@ async function setupSharedSeedGraph(effectCount: number) {
   runtime.scheduler.subscribe(
     computation,
     {
-      reads: [source.getAsNormalizedFullLink()],
+      reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
       shallowReads: [],
-      writes: [intermediate.getAsNormalizedFullLink()],
+      writes: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
     },
     {},
   );
@@ -77,9 +78,9 @@ async function setupSharedSeedGraph(effectCount: number) {
     runtime.scheduler.subscribe(
       effect,
       {
-        reads: [intermediate.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [output.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );

--- a/packages/runner/test/scheduler-pull.test.ts
+++ b/packages/runner/test/scheduler-pull.test.ts
@@ -9,6 +9,7 @@ import { type Action, type EventHandler } from "../src/scheduler.ts";
 import { type JSONSchema } from "../src/builder/types.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -118,9 +119,9 @@ describe("pull-based scheduling", () => {
     runtime.scheduler.subscribe(
       computation,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [result.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(result.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -175,7 +176,7 @@ describe("pull-based scheduling", () => {
       {
         reads: [],
         shallowReads: [],
-        writes: [target.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(target.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -242,9 +243,9 @@ describe("pull-based scheduling", () => {
     runtime.scheduler.subscribe(
       computation,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [intermediate.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -254,9 +255,9 @@ describe("pull-based scheduling", () => {
     runtime.scheduler.subscribe(
       effect,
       {
-        reads: [intermediate.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [effectResult.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(effectResult.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );
@@ -338,9 +339,9 @@ describe("pull-based scheduling", () => {
     runtime.scheduler.subscribe(
       computation,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [intermediate.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -348,9 +349,9 @@ describe("pull-based scheduling", () => {
     runtime.scheduler.subscribe(
       leftEffect,
       {
-        reads: [intermediate.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [leftResult.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(leftResult.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );
@@ -358,9 +359,9 @@ describe("pull-based scheduling", () => {
     runtime.scheduler.subscribe(
       rightEffect,
       {
-        reads: [intermediate.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [rightResult.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(rightResult.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );
@@ -479,9 +480,9 @@ describe("pull-based scheduling", () => {
     runtime.scheduler.subscribe(
       computation1,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [intermediate1.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(intermediate1.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -490,9 +491,9 @@ describe("pull-based scheduling", () => {
     runtime.scheduler.subscribe(
       computation2,
       {
-        reads: [intermediate1.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(intermediate1.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [intermediate2.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(intermediate2.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -501,9 +502,9 @@ describe("pull-based scheduling", () => {
     runtime.scheduler.subscribe(
       effect,
       {
-        reads: [intermediate2.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(intermediate2.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [effectResult.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(effectResult.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );
@@ -586,11 +587,11 @@ describe("pull-based scheduling", () => {
       computation,
       {
         reads: [
-          selector.getAsNormalizedFullLink(),
-          sourceA.getAsNormalizedFullLink(),
+          toMemorySpaceAddress(selector.getAsNormalizedFullLink()),
+          toMemorySpaceAddress(sourceA.getAsNormalizedFullLink()),
         ],
         shallowReads: [],
-        writes: [intermediate.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -599,9 +600,9 @@ describe("pull-based scheduling", () => {
     runtime.scheduler.subscribe(
       effect,
       {
-        reads: [intermediate.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [effectResult.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(effectResult.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );
@@ -660,7 +661,7 @@ describe("pull-based scheduling", () => {
     runtime.scheduler.subscribe(
       computation,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
         writes: [],
       },
@@ -798,9 +799,9 @@ describe("pull mode with references", () => {
     runtime.scheduler.subscribe(
       innerLift,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [innerOutput.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(innerOutput.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -809,9 +810,9 @@ describe("pull mode with references", () => {
     runtime.scheduler.subscribe(
       outerLift,
       {
-        reads: [innerOutput.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(innerOutput.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [outerOutput.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(outerOutput.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -820,9 +821,9 @@ describe("pull mode with references", () => {
     runtime.scheduler.subscribe(
       effect,
       {
-        reads: [outerOutput.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(outerOutput.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [effectResult.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(effectResult.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );
@@ -1012,9 +1013,11 @@ describe("handler dependency pulling", () => {
     runtime.scheduler.subscribe(
       computedAction,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [computedOutput.getAsNormalizedFullLink()],
+        writes: [
+          toMemorySpaceAddress(computedOutput.getAsNormalizedFullLink()),
+        ],
       },
       {},
     );
@@ -1181,9 +1184,11 @@ describe("handler dependency pulling", () => {
     runtime.scheduler.subscribe(
       computedAction,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [data.key("foo").getAsNormalizedFullLink()],
+        writes: [
+          toMemorySpaceAddress(data.key("foo").getAsNormalizedFullLink()),
+        ],
       },
       {},
     );
@@ -1294,9 +1299,9 @@ describe("handler dependency pulling", () => {
     runtime.scheduler.subscribe(
       computedAction1,
       {
-        reads: [source1.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source1.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [computed1.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(computed1.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -1304,9 +1309,9 @@ describe("handler dependency pulling", () => {
     runtime.scheduler.subscribe(
       computedAction2,
       {
-        reads: [source2.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source2.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [computed2.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(computed2.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -1432,9 +1437,9 @@ describe("handler dependency pulling", () => {
     runtime.scheduler.subscribe(
       computedAction1,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [computed1.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(computed1.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -1442,9 +1447,9 @@ describe("handler dependency pulling", () => {
     runtime.scheduler.subscribe(
       computedAction2,
       {
-        reads: [computed1.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(computed1.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [computed2.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(computed2.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -1547,9 +1552,9 @@ describe("handler dependency pulling", () => {
     runtime.scheduler.subscribe(
       computation,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [computed.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(computed.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -1632,9 +1637,9 @@ describe("handler dependency pulling", () => {
     runtime.scheduler.subscribe(
       computation,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [computed.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(computed.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -1748,9 +1753,9 @@ describe("handler dependency pulling", () => {
     // This tests that the lift is pulled when handler B needs it
     // Use resubscribe to set up triggers without scheduling immediate execution
     runtime.scheduler.resubscribe(liftAction, {
-      reads: [liftInput.getAsNormalizedFullLink()],
+      reads: [toMemorySpaceAddress(liftInput.getAsNormalizedFullLink())],
       shallowReads: [],
-      writes: [liftOutput.getAsNormalizedFullLink()],
+      writes: [toMemorySpaceAddress(liftOutput.getAsNormalizedFullLink())],
     });
 
     await runtime.idle();
@@ -1992,9 +1997,9 @@ describe("pull mode array reactivity", () => {
     runtime.scheduler.subscribe(
       filterAction,
       {
-        reads: [sourceArray.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(sourceArray.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [filteredCell.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(filteredCell.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -2062,9 +2067,9 @@ describe("pull mode array reactivity", () => {
     runtime.scheduler.subscribe(
       transformAction,
       {
-        reads: [sourceArray.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(sourceArray.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [computedCell.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(computedCell.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -2173,9 +2178,11 @@ describe("pull mode array reactivity", () => {
     runtime.scheduler.subscribe(
       computeVisiblePieces,
       {
-        reads: [allPiecesCell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(allPiecesCell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [visiblePiecesCell.getAsNormalizedFullLink()],
+        writes: [
+          toMemorySpaceAddress(visiblePiecesCell.getAsNormalizedFullLink()),
+        ],
       },
       {},
     );
@@ -2269,9 +2276,9 @@ describe("pull mode array reactivity", () => {
     runtime.scheduler.subscribe(
       countPieces,
       {
-        reads: [allPiecesCell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(allPiecesCell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [countCell.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(countCell.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -2366,9 +2373,11 @@ describe("pull mode array reactivity", () => {
     runtime.scheduler.subscribe(
       computeVisible,
       {
-        reads: [allPiecesCell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(allPiecesCell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [visiblePiecesCell.getAsNormalizedFullLink()],
+        writes: [
+          toMemorySpaceAddress(visiblePiecesCell.getAsNormalizedFullLink()),
+        ],
       },
       {},
     );
@@ -2467,9 +2476,11 @@ describe("pull mode array reactivity", () => {
     let cancelComputation = runtime.scheduler.subscribe(
       computeVisible,
       {
-        reads: [allPiecesCell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(allPiecesCell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [visiblePiecesCell.getAsNormalizedFullLink()],
+        writes: [
+          toMemorySpaceAddress(visiblePiecesCell.getAsNormalizedFullLink()),
+        ],
       },
       {},
     );
@@ -2500,9 +2511,11 @@ describe("pull mode array reactivity", () => {
     cancelComputation = runtime.scheduler.subscribe(
       computeVisible,
       {
-        reads: [allPiecesCell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(allPiecesCell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [visiblePiecesCell.getAsNormalizedFullLink()],
+        writes: [
+          toMemorySpaceAddress(visiblePiecesCell.getAsNormalizedFullLink()),
+        ],
       },
       {},
     );
@@ -2579,9 +2592,11 @@ describe("pull mode array reactivity", () => {
     let cancelComputation = runtime.scheduler.subscribe(
       computeVisible1,
       {
-        reads: [allPiecesCell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(allPiecesCell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [visiblePiecesCell.getAsNormalizedFullLink()],
+        writes: [
+          toMemorySpaceAddress(visiblePiecesCell.getAsNormalizedFullLink()),
+        ],
       },
       {},
     );
@@ -2617,9 +2632,11 @@ describe("pull mode array reactivity", () => {
     cancelComputation = runtime.scheduler.subscribe(
       computeVisible2,
       {
-        reads: [allPiecesCell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(allPiecesCell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [visiblePiecesCell.getAsNormalizedFullLink()],
+        writes: [
+          toMemorySpaceAddress(visiblePiecesCell.getAsNormalizedFullLink()),
+        ],
       },
       {},
     );

--- a/packages/runner/test/scheduler-timing.test.ts
+++ b/packages/runner/test/scheduler-timing.test.ts
@@ -8,6 +8,7 @@ import { Runtime } from "../src/runtime.ts";
 import { type Action } from "../src/scheduler.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -75,7 +76,11 @@ describe("debounce and throttling", () => {
     // Subscribe with proper writes for pull mode
     runtime.scheduler.subscribe(
       action,
-      { reads: [], shallowReads: [], writes: [cell.getAsNormalizedFullLink()] },
+      {
+        reads: [],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
+      },
       {},
     );
 
@@ -119,7 +124,7 @@ describe("debounce and throttling", () => {
         {
           reads: [],
           shallowReads: [],
-          writes: [cell.getAsNormalizedFullLink()],
+          writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
         },
         {},
       );
@@ -157,7 +162,11 @@ describe("debounce and throttling", () => {
     // Subscribe with debounce option (and proper writes for pull mode)
     runtime.scheduler.subscribe(
       action,
-      { reads: [], shallowReads: [], writes: [cell.getAsNormalizedFullLink()] },
+      {
+        reads: [],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
+      },
       { debounce: 50 },
     );
 
@@ -309,9 +318,9 @@ describe("debounce and throttling", () => {
     runtime.scheduler.subscribe(
       action,
       {
-        reads: [cell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cell.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -322,9 +331,9 @@ describe("debounce and throttling", () => {
       runtime.scheduler.subscribe(
         action,
         {
-          reads: [cell.getAsNormalizedFullLink()],
+          reads: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
           shallowReads: [],
-          writes: [cell.getAsNormalizedFullLink()],
+          writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
         },
         {},
       );
@@ -376,9 +385,9 @@ describe("debounce and throttling", () => {
     runtime.scheduler.subscribe(
       effect,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [result.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(result.getAsNormalizedFullLink())],
       },
       { isEffect: true },
     );
@@ -578,7 +587,11 @@ describe("debounce and throttling", () => {
 
     runtime.scheduler.subscribe(
       action,
-      { reads: [], shallowReads: [], writes: [cell.getAsNormalizedFullLink()] },
+      {
+        reads: [],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
+      },
       {},
     );
 
@@ -836,9 +849,9 @@ describe("throttle - staleness tolerance", () => {
     runtime.scheduler.subscribe(
       action,
       {
-        reads: [cell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cell.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -852,9 +865,9 @@ describe("throttle - staleness tolerance", () => {
     runtime.scheduler.subscribe(
       action,
       {
-        reads: [cell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cell.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -887,9 +900,9 @@ describe("throttle - staleness tolerance", () => {
     runtime.scheduler.subscribe(
       action,
       {
-        reads: [cell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cell.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -900,9 +913,9 @@ describe("throttle - staleness tolerance", () => {
     runtime.scheduler.subscribe(
       action,
       {
-        reads: [cell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cell.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -916,9 +929,9 @@ describe("throttle - staleness tolerance", () => {
     runtime.scheduler.subscribe(
       action,
       {
-        reads: [cell.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [cell.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -957,9 +970,9 @@ describe("throttle - staleness tolerance", () => {
     runtime.scheduler.subscribe(
       computation,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [result.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(result.getAsNormalizedFullLink())],
       },
       {},
     );
@@ -1013,9 +1026,9 @@ describe("throttle - staleness tolerance", () => {
     runtime.scheduler.subscribe(
       effect,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [result.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(result.getAsNormalizedFullLink())],
       },
       { throttle: 50, isEffect: true },
     );
@@ -1090,7 +1103,11 @@ describe("throttle - staleness tolerance", () => {
     // First run should still execute (no previous timestamp to throttle against)
     runtime.scheduler.subscribe(
       action,
-      { reads: [], shallowReads: [], writes: [cell.getAsNormalizedFullLink()] },
+      {
+        reads: [],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
+      },
       {},
     );
     await cell.pull();

--- a/packages/runner/test/scheduler.bench.ts
+++ b/packages/runner/test/scheduler.bench.ts
@@ -15,6 +15,7 @@ import {
   addressesToPathByEntity,
   sortAndCompactPaths,
 } from "../src/reactive-dependencies.ts";
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("bench operator");
 const space = signer.did();
@@ -87,9 +88,9 @@ Deno.bench(
       runtime.scheduler.subscribe(
         action,
         {
-          reads: [source.getAsNormalizedFullLink()],
+          reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
           shallowReads: [],
-          writes: [output.getAsNormalizedFullLink()],
+          writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
         },
         {},
       );
@@ -144,9 +145,9 @@ Deno.bench(
       runtime.scheduler.subscribe(
         action,
         {
-          reads: [input.getAsNormalizedFullLink()],
+          reads: [toMemorySpaceAddress(input.getAsNormalizedFullLink())],
           shallowReads: [],
-          writes: [output.getAsNormalizedFullLink()],
+          writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
         },
         {},
       );
@@ -202,9 +203,9 @@ Deno.bench(
       runtime.scheduler.subscribe(
         action,
         {
-          reads: [source.getAsNormalizedFullLink()],
+          reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
           shallowReads: [],
-          writes: [output.getAsNormalizedFullLink()],
+          writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
         },
         {},
       );
@@ -257,9 +258,9 @@ Deno.bench(
       runtime.scheduler.subscribe(
         action,
         {
-          reads: [source.getAsNormalizedFullLink()],
+          reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
           shallowReads: [],
-          writes: [output.getAsNormalizedFullLink()],
+          writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
         },
         {},
       );
@@ -307,9 +308,9 @@ Deno.bench(
       runtime.scheduler.subscribe(
         action,
         {
-          reads: [input.getAsNormalizedFullLink()],
+          reads: [toMemorySpaceAddress(input.getAsNormalizedFullLink())],
           shallowReads: [],
-          writes: [output.getAsNormalizedFullLink()],
+          writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
         },
         {},
       );
@@ -374,9 +375,9 @@ Deno.bench(
       runtime.scheduler.subscribe(
         actionAB,
         {
-          reads: [a.getAsNormalizedFullLink()],
+          reads: [toMemorySpaceAddress(a.getAsNormalizedFullLink())],
           shallowReads: [],
-          writes: [b.getAsNormalizedFullLink()],
+          writes: [toMemorySpaceAddress(b.getAsNormalizedFullLink())],
         },
         {},
       );
@@ -389,9 +390,9 @@ Deno.bench(
       runtime.scheduler.subscribe(
         actionAC,
         {
-          reads: [a.getAsNormalizedFullLink()],
+          reads: [toMemorySpaceAddress(a.getAsNormalizedFullLink())],
           shallowReads: [],
-          writes: [c.getAsNormalizedFullLink()],
+          writes: [toMemorySpaceAddress(c.getAsNormalizedFullLink())],
         },
         {},
       );
@@ -406,9 +407,12 @@ Deno.bench(
       runtime.scheduler.subscribe(
         actionBCD,
         {
-          reads: [b.getAsNormalizedFullLink(), c.getAsNormalizedFullLink()],
+          reads: [
+            toMemorySpaceAddress(b.getAsNormalizedFullLink()),
+            toMemorySpaceAddress(c.getAsNormalizedFullLink()),
+          ],
           shallowReads: [],
-          writes: [result.getAsNormalizedFullLink()],
+          writes: [toMemorySpaceAddress(result.getAsNormalizedFullLink())],
         },
         {},
       );
@@ -461,9 +465,9 @@ Deno.bench(
       runtime.scheduler.subscribe(
         action,
         {
-          reads: [input.getAsNormalizedFullLink()],
+          reads: [toMemorySpaceAddress(input.getAsNormalizedFullLink())],
           shallowReads: [],
-          writes: [output.getAsNormalizedFullLink()],
+          writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
         },
         {},
       );
@@ -520,9 +524,9 @@ Deno.bench(
     runtime.scheduler.subscribe(
       action,
       {
-        reads: [source.getAsNormalizedFullLink()],
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [output.getAsNormalizedFullLink()],
+        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
       },
       {},
     );

--- a/packages/runner/test/schema-examples.test.ts
+++ b/packages/runner/test/schema-examples.test.ts
@@ -394,14 +394,14 @@ describe("Schema - Examples", () => {
       expect(
         reads.some((r) =>
           r.id === toURI(docCell.entityId!) &&
-          r.path[0] === "current"
+          r.path[0] === "value" && r.path[1] === "current"
         ),
       ).toBe(true);
       // The initial entity is read via followPointer at the "foo" sub-path.
       expect(
         reads.some((r) =>
           r.id === toURI(initialEntityId) &&
-          r.path[0] === "foo"
+          r.path[0] === "value" && r.path[1] === "foo"
         ),
       ).toBe(true);
 

--- a/packages/runner/test/transaction-inspection.test.ts
+++ b/packages/runner/test/transaction-inspection.test.ts
@@ -77,7 +77,7 @@ describe("transaction inspection", () => {
     });
   });
 
-  it("preserves non-document-prefixed paths in derived reactivity logs", () => {
+  it("preserves document-root paths in derived reactivity logs", () => {
     assertEquals(
       reactivityLogFromActivities([
         {
@@ -119,7 +119,7 @@ describe("transaction inspection", () => {
           space: "did:key:test",
           id: "of:shallow",
           type: "application/json",
-          path: ["items"],
+          path: ["value", "items"],
         }],
         writes: [{
           space: "did:key:test",
@@ -158,7 +158,7 @@ describe("transaction inspection", () => {
           space,
           id,
           type: "application/json",
-          path: [],
+          path: ["value"],
         }],
         shallowReads: [],
         writes: [{
@@ -269,7 +269,7 @@ describe("transaction inspection", () => {
           space,
           id,
           type: "application/json",
-          path: [],
+          path: ["value"],
         }],
         shallowReads: [],
         writes: [{
@@ -491,17 +491,17 @@ describe("transaction inspection", () => {
           space,
           id,
           type: "application/json",
-          path: [],
+          path: ["value"],
         }, {
           space,
           id,
           type: "application/json",
-          path: ["profile"],
+          path: ["value", "profile"],
         }, {
           space,
           id,
           type: "application/json",
-          path: ["profile", "name"],
+          path: ["value", "profile", "name"],
         }],
       });
 
@@ -566,22 +566,22 @@ describe("transaction inspection", () => {
           space,
           id,
           type: "application/json",
-          path: [],
+          path: ["value"],
         }, {
           space,
           id,
           type: "application/json",
-          path: ["profile"],
+          path: ["value", "profile"],
         }, {
           space,
           id,
           type: "application/json",
-          path: ["profile", "age"],
+          path: ["value", "profile", "age"],
         }, {
           space,
           id,
           type: "application/json",
-          path: ["profile", "name"],
+          path: ["value", "profile", "name"],
         }],
       });
 
@@ -644,17 +644,17 @@ describe("transaction inspection", () => {
           space,
           id,
           type: "application/json",
-          path: ["tags"],
+          path: ["value", "tags"],
         }, {
           space,
           id,
           type: "application/json",
-          path: ["tags", "0"],
+          path: ["value", "tags", "0"],
         }, {
           space,
           id,
           type: "application/json",
-          path: ["tags", "length"],
+          path: ["value", "tags", "length"],
         }],
       });
     } finally {
@@ -695,7 +695,7 @@ describe("transaction inspection", () => {
           space,
           id,
           type: "application/json",
-          path: ["tags", "0"],
+          path: ["value", "tags", "0"],
         }],
       });
     } finally {


### PR DESCRIPTION
Change many of the underlying tracking structures, especially the ReactivityLog, to track with IMemorySpaceAddress objects instead of NormalizedFullLink. The former can reference meta fields, while the latter can only reference entries under the cell's "value".

~~I'm creating this as a PR to run the automation, but still want to follow up on the TelemetryAnnotations, which are still basic links.
I also need to add some unit tests showing reactivity of meta fields (specifically "source").~~

~~Need to follow up on the reads/writes attached to actions in runner.ts, as well as BoundNodeIO (these are the same ones in the TelemetryAnnotations).~~

I'm deferring potential changes to the reads/writes attached to actions for now, since the reactivity log changes are useful whether or not we change those.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized reactivity and scheduler tracking on document-root `IMemorySpaceAddress` and made `NormalizedFullLink` value-relative only. Added `toMemorySpaceAddress()` so meta fields (like "source") are reactive and stopped stripping `"value"` from reactivity logs; added tests for `cfc` path reactivity (helper vs direct read).

- **Refactors**
  - Added `toMemorySpaceAddress(link)` in `link-types` and moved `ValuePath`/`IMemorySpaceValueAddress` there.
  - `NormalizedFullLink` no longer implements `IMemorySpaceAddress`; doc-root ops now convert explicitly.
  - Reactivity logs (`v2-transaction`, `reactivity-log`) keep document-root paths (prefixed with `"value"`).
  - Scheduler converts annotated writes to doc-root addresses and registers triggers using doc-root paths; removed `lookupComparableWriteValue`.
  - `readValueOrThrow`, `writeValueOrThrow`, `writeValuesOrThrow` accept `NormalizedFullLink` and convert internally.
  - Updated `link-resolution`, `schema`, and `cell` to probe/read/write via doc-root addresses, including sigil/alias checks and meta `"source"`.
  - `addressKey` now accepts `IMemorySpaceAddress` or `NormalizedFullLink`; keys differ across domains.
  - Tests updated to wrap links with `toMemorySpaceAddress(...)` when passing scheduler addresses and to expect `"value"`-prefixed paths; added `cfc` metadata reactivity tests verifying helper-based checks bypass scheduling while direct `cfc` reads are reactive.

- **Migration**
  - When subscribing or passing addresses to low-level reads/writes, wrap links with `toMemorySpaceAddress(...)`.
  - Update tests/diagnostics to expect `["value", ...]` paths in reactivity logs.

<sup>Written for commit 7dec350b239bf0c53b6d8566b14947e1c18cc260. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





