### PR TITLE
fix(runner): dedup cfc subSchemas via interned-schema identity (safety fix)

### DIFF
--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -2,6 +2,7 @@ import { type ImmutableJSONValue, JSONSchemaObj } from "@commonfabric/api";
 import { isRecord } from "@commonfabric/utils/types";
 import { getLogger } from "@commonfabric/utils/logger";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { internSchemaAsHashString } from "@commonfabric/data-model/schema-hash";
 import type { CellKind, JSONSchema } from "./builder/types.ts";
 import { CycleTracker } from "./traverse.ts";
 import { isArrayIndexPropertyName } from "@commonfabric/data-model/fabric-value";
@@ -482,7 +483,7 @@ export class ContextualFlowControl {
       }
       if (isRecord(cursor) && ("anyOf" in cursor || "oneOf" in cursor)) {
         const subSchemas: JSONSchema[] = [];
-        const subSchemaStrings: string[] = [];
+        const subSchemaHashes: string[] = [];
         const options = (cursor.anyOf && cursor.oneOf)
           ? [...cursor.anyOf, ...cursor.oneOf]
           : cursor.anyOf ?? cursor.oneOf ?? [];
@@ -505,12 +506,15 @@ export class ContextualFlowControl {
             cursor = true;
             break;
           } else {
-            const subSchemaString = JSON.stringify(subSchema);
-            if (subSchemaStrings.includes(subSchemaString)) {
+            // Safe against non-JSON-compatible `FabricValue`s (e.g.
+            // `FabricEpochNsec`, `FabricBytes`, `FabricHash`) that may
+            // appear in schema `default` fields.
+            const subSchemaHash = internSchemaAsHashString(subSchema);
+            if (subSchemaHashes.includes(subSchemaHash)) {
               continue;
             }
             subSchemas.push(subSchema as JSONSchema);
-            subSchemaStrings.push(subSchemaString);
+            subSchemaHashes.push(subSchemaHash);
           }
         }
         // Only update cursor from subSchemas if the isTrueSchema branch

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -483,7 +483,7 @@ export class ContextualFlowControl {
       }
       if (isRecord(cursor) && ("anyOf" in cursor || "oneOf" in cursor)) {
         const subSchemas: JSONSchema[] = [];
-        const subSchemaHashes: string[] = [];
+        const subSchemaHashes = new Set<string>();
         const options = (cursor.anyOf && cursor.oneOf)
           ? [...cursor.anyOf, ...cursor.oneOf]
           : cursor.anyOf ?? cursor.oneOf ?? [];
@@ -509,12 +509,11 @@ export class ContextualFlowControl {
             // Safe against non-JSON-compatible `FabricValue`s (e.g.
             // `FabricEpochNsec`, `FabricBytes`, `FabricHash`) that may
             // appear in schema `default` fields.
-            const subSchemaHash = internSchemaAsHashString(subSchema);
-            if (subSchemaHashes.includes(subSchemaHash)) {
-              continue;
+            const sizeBefore = subSchemaHashes.size;
+            subSchemaHashes.add(internSchemaAsHashString(subSchema));
+            if (subSchemaHashes.size !== sizeBefore) {
+              subSchemas.push(subSchema as JSONSchema);
             }
-            subSchemas.push(subSchema as JSONSchema);
-            subSchemaHashes.push(subSchemaHash);
           }
         }
         // Only update cursor from subSchemas if the isTrueSchema branch

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -482,8 +482,7 @@ export class ContextualFlowControl {
         }
       }
       if (isRecord(cursor) && ("anyOf" in cursor || "oneOf" in cursor)) {
-        const subSchemas: JSONSchema[] = [];
-        const seen = new Set<JSONSchema>();
+        const subSchemas = new Set<JSONSchema>();
         const options = (cursor.anyOf && cursor.oneOf)
           ? [...cursor.anyOf, ...cursor.oneOf]
           : cursor.anyOf ?? cursor.oneOf ?? [];
@@ -512,23 +511,19 @@ export class ContextualFlowControl {
             // `Set<JSONSchema>`, and correctly handles non-JSON-compatible
             // `FabricValue`s (e.g. `FabricEpochNsec`, `FabricBytes`,
             // `FabricHash`) that may appear in schema `default` fields.
-            const interned = internSchema(subSchema as JSONSchema);
-            const sizeBefore = seen.size;
-            seen.add(interned);
-            if (seen.size !== sizeBefore) {
-              subSchemas.push(interned);
-            }
+            subSchemas.add(internSchema(subSchema as JSONSchema));
           }
         }
         // Only update cursor from subSchemas if the isTrueSchema branch
         // didn't already set cursor = true and break out of the loop.
         if (cursor !== true) {
-          if (subSchemas.length === 0) {
+          const subSchemaArr = [...subSchemas];
+          if (subSchemaArr.length === 0) {
             cursor = false;
-          } else if (subSchemas.length === 1) {
-            cursor = subSchemas[0];
+          } else if (subSchemaArr.length === 1) {
+            cursor = subSchemaArr[0];
           } else {
-            cursor = { "anyOf": subSchemas };
+            cursor = { "anyOf": subSchemaArr };
           }
         }
         break;

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -2,7 +2,7 @@ import { type ImmutableJSONValue, JSONSchemaObj } from "@commonfabric/api";
 import { isRecord } from "@commonfabric/utils/types";
 import { getLogger } from "@commonfabric/utils/logger";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { internSchemaAsHashString } from "@commonfabric/data-model/schema-hash";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { CellKind, JSONSchema } from "./builder/types.ts";
 import { CycleTracker } from "./traverse.ts";
 import { isArrayIndexPropertyName } from "@commonfabric/data-model/fabric-value";
@@ -483,7 +483,7 @@ export class ContextualFlowControl {
       }
       if (isRecord(cursor) && ("anyOf" in cursor || "oneOf" in cursor)) {
         const subSchemas: JSONSchema[] = [];
-        const subSchemaHashes = new Set<string>();
+        const seen = new Set<JSONSchema>();
         const options = (cursor.anyOf && cursor.oneOf)
           ? [...cursor.anyOf, ...cursor.oneOf]
           : cursor.anyOf ?? cursor.oneOf ?? [];
@@ -506,13 +506,17 @@ export class ContextualFlowControl {
             cursor = true;
             break;
           } else {
-            // Safe against non-JSON-compatible `FabricValue`s (e.g.
-            // `FabricEpochNsec`, `FabricBytes`, `FabricHash`) that may
-            // appear in schema `default` fields.
-            const sizeBefore = subSchemaHashes.size;
-            subSchemaHashes.add(internSchemaAsHashString(subSchema));
-            if (subSchemaHashes.size !== sizeBefore) {
-              subSchemas.push(subSchema as JSONSchema);
+            // `internSchema()` returns the canonical (identity-unique)
+            // schema object, so structurally-equal schemas collapse to
+            // the same reference. That gives identity-based dedup via
+            // `Set<JSONSchema>`, and correctly handles non-JSON-compatible
+            // `FabricValue`s (e.g. `FabricEpochNsec`, `FabricBytes`,
+            // `FabricHash`) that may appear in schema `default` fields.
+            const interned = internSchema(subSchema as JSONSchema);
+            const sizeBefore = seen.size;
+            seen.add(interned);
+            if (seen.size !== sizeBefore) {
+              subSchemas.push(interned);
             }
           }
         }


### PR DESCRIPTION
## What

Fixes the `anyOf` / `oneOf` subSchema dedup logic in `packages/runner/src/cfc.ts` (inside `ContextualFlowControl.schemaAtPathInternal`) to use **interned-schema identity** instead of `JSON.stringify(subSchema)`:

- Replaces per-iteration `JSON.stringify(subSchema)` string keys with `internSchema(subSchema)`, which returns the **canonical (identity-unique) schema reference**. Structurally-equal schemas collapse to the same reference, giving identity-based dedup — no hash-string computation needed.
- Collapses the parallel `JSONSchema[]` + `string[]` into a single `Set<JSONSchema>` deduplicated on interned references. The loop body reduces to `subSchemas.add(internSchema(subSchema))`; the coda materializes the set with `[...subSchemas]` once. Set iteration order = insertion order, so original `anyOf` / `oneOf` entry ordering is preserved.
- `subSchemas` now holds the interned canonical references, a slight semantic tightening for downstream consumers.

1 file, +14/-12.

## Why

`JSON.stringify(subSchema)` is a **latent correctness bug** on schemas whose `default` fields contain non-JSON-compatible `FabricValue` instances (e.g., `FabricEpochNsec`, `FabricBytes`, `FabricHash`). `JSON.stringify` silently produces wrong or undefined output on those, so dedup can incorrectly collapse distinct schemas or incorrectly separate equivalent ones. `internSchema` is the authoritative canonical-schema-identity primitive — structurally-equivalent schemas share the same canonical reference regardless of any `FabricValue` in `default`.

Safety-first framing: this PR is about correctness; the incidental perf win (reference-identity dedup instead of per-call `JSON.stringify` + substring linear-search) is a bonus, not the motivation. No measurement gating.

The implementation evolved across review rounds with Dan's guidance: started with `internSchemaAsHashString` + string-keyed `Set`, simplified to `internSchema` canonical-reference dedup with `Set<JSONSchema>`, then dropped the redundant parallel `subSchemas` array in favor of materializing the set at the coda. This branch tip (`c073df806`) is the final shape.

## Context

Diagnosis and landing order come from Remy's reading-list residual analysis:
`coordination/docs/2026-04-22-reading-list-residual-analysis.md` §7 step 1 ("A.edit1"). Dan approved Remy's landing order; this is the first PR in that sequence.

Out of scope for this PR (follow-ups):
- Sibling `JSON.stringify` sites elsewhere in the codebase are **separate PR work** (Remy's §7 step 5), not bundled here.
- `stableHash()` stays untouched in any sweep — explicitly excluded.

Related work:
- PR #3235 — `feat: enable modernSchemaHash by default` (the target for the overall regression fix; still open).
- PR #3231 — `feat: flip modernHash default to true` (upstream of #3235).
- PR #3324 — `danfuzz/because-im-easy-come-easy-go` (legacy-hash SHA256 normalization).

Reviewer-flux APPROVED on earlier revisions; re-confirming on `c073df806`.

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
