### PR TITLE
perf(runner): memoize schemaHasIfc top-level calls

### DIFF
--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -9,6 +9,7 @@ import {
   cloneIfNecessary,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
+import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
   isNontrivialSchema,
   toDeepFrozenSchema,
@@ -93,6 +94,16 @@ export function resolveSchema(
     : undefined;
 }
 
+// Memo for `schemaHasIfc` top-level calls. Safe **only** because entries
+// are populated under an `isDeepFrozen` guard below: the predicate's
+// answer depends on the entire subtree's shape, so caching against a
+// merely-TS-`readonly` or shallow-frozen input would be unsound — a
+// future sub-schema swap would silently invalidate the cached answer.
+// A future contributor must not relax the populate guard to accept
+// non-deep-frozen inputs. `Object.isFrozen` is **not** sufficient; it
+// is shallow-only.
+const _hasIfcCache = new WeakMap<JSONSchemaObj, boolean>();
+
 export function schemaHasIfc(
   schema: JSONSchema | undefined,
   seen: Set<JSONSchema> = new Set(),
@@ -101,6 +112,29 @@ export function schemaHasIfc(
   if (schema === undefined || typeof schema === "boolean") {
     return false;
   }
+  // Top-level calls (the default entry from cell.ts / schema.ts) can
+  // consult the memo. Recursive calls carry caller-provided `seen` and
+  // `fullSchema`, which aren't captured in the cache key, so they must
+  // bypass.
+  const isTopLevel = seen.size === 0 && fullSchema === schema;
+  if (isTopLevel) {
+    const cached = _hasIfcCache.get(schema);
+    if (cached !== undefined) return cached;
+  }
+  const result = _schemaHasIfcUncached(schema, seen, fullSchema);
+  // Populate only under a deep-frozen guard. See the invariant comment
+  // above `_hasIfcCache`.
+  if (isTopLevel && isDeepFrozen(schema)) {
+    _hasIfcCache.set(schema, result);
+  }
+  return result;
+}
+
+function _schemaHasIfcUncached(
+  schema: JSONSchemaObj,
+  seen: Set<JSONSchema>,
+  fullSchema: JSONSchema | undefined,
+): boolean {
   if (seen.has(schema)) {
     return false;
   }


### PR DESCRIPTION
## What

Adds a WeakMap memo around top-level `schemaHasIfc` calls in `packages/runner/src/schema.ts`. First top-level call on a given schema computes and caches; subsequent top-level calls on the same schema reference return the cached result directly. Recursive inner calls are unaffected (they continue the existing traversal without touching the memo).

The memo is guarded by `isDeepFrozen` — only deep-frozen schemas are eligible to be cached, which is the required invariant for identity-based memoization of recursively-walked data structures. The WeakMap declaration carries an explicit doc comment noting that the `isDeepFrozen` guard is **load-bearing** and why, as a tripwire for future edits.

1 file, +34/-0.

## Why

`schemaHasIfc` is called twice per `cell.set()` / `Stream.send()` on a hot path. On compound schemas (reading-list / notes family) the repeated structural walk is material overhead per write. Remy's reading-list residual analysis named `schemaHasIfc` the primary perf target in the residual landscape — highest transferability (same schema shape reused across writes), lowest scope (single-file memo, one WeakMap).

The `isDeepFrozen` guard is what makes the memo safe: a deep-frozen schema is guaranteed not to mutate between calls, so the computed boolean `schemaHasIfc` result remains valid for the lifetime of that identity. Non-frozen schemas still take the unmemoized path, preserving correctness on any live-edited schema paths (none in production at present, but the guard future-proofs the contract).

Diagnosis: `coordination/docs/2026-04-22-reading-list-residual-analysis.md` §3 (per-call hot-path accounting) and §7 step 4 (landing order).

## Context

Scope of this PR is tight per Remy's staged landing order:
- Single site (`schemaHasIfc` top-level) only; no sibling `schemaHasAsCell` memoization, no shared `memoizedSchemaPredicate` helper extraction. Both deferred if post-landing data warrants.
- Does not bundle sibling-track items B (`storage/cache.ts` spread), A.edit2 (fresh anyOf wrapper), `resolveSchemaRefs` backlog, or the broader `JSON.stringify` sweep — each is its own PR.

Related PRs in the flight:
- PR #3348 — A.edit1 cfc subSchema interning safety fix (merged as `6aea35b6e`).
- PR #3235 — `feat: enable modernSchemaHash by default` (the target for the overall regression fix; still open; Dan resynced post-#3348 himself).
- PR #3231 — `feat: flip modernHash default to true` (upstream of #3235; Dan resynced too).
- PR #3324 — `danfuzz/because-im-easy-come-easy-go` (legacy-hash SHA256 normalization).

Post-merge plan: Rosa will queue multi-sample CI measurement per her §P5.9 multi-run discipline to quantify the effect on reading-list / notes family write throughput.

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
