### PR TITLE
Add cf CLI space root recreation command

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -14,6 +14,7 @@ import {
   MapFormat,
   newPiece,
   PieceConfig,
+  recreateSpaceRootPattern,
   removePiece,
   resetHomePattern,
   savePiecePattern,
@@ -780,22 +781,45 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
     await removePiece(pieceConfig);
     render(`Removed piece ${pieceConfig.piece}`);
   })
+  /* piece recreate-root */
+  .command(
+    "recreate-root",
+    "Recreate the root pattern for the explicitly targeted space.",
+  )
+  .usage(spaceUsage)
+  .example(
+    cliText(`cf piece recreate-root ${EX_ID} ${EX_COMP}`),
+    `Recreate the root pattern for "${RAW_EX_COMP.space}".`,
+  )
+  .example(
+    cliText(`cf piece recreate-root ${EX_ID} ${EX_URL}`),
+    `Recreate the root pattern for "${RAW_EX_COMP.space}".`,
+  )
+  .action(async (options) => {
+    setQuietMode(!!options.quiet);
+    const spaceConfig = parseSpaceOptions(options);
+    const pieceId = await recreateSpaceRootPattern(spaceConfig);
+    render(pieceId);
+    hint(cliText(`NEXT STEPS:
+  → Open space in browser: ${spaceConfig.apiUrl}/${spaceConfig.space}/${pieceId}
+  → Inspect state:         cf piece inspect --piece ${pieceId} ...`));
+  })
   /* piece set-home */
   .command(
     "set-home",
-    "Deploy a custom home pattern or reset to system default.",
+    "Deploy a custom home-space pattern or reset the identity's home space to system default.",
   )
   .example(
     cliText(
       `cf piece set-home ${EX_ID} -a http://localhost:${ports.toolshed} ./my-home.tsx`,
     ),
-    `Deploy a custom home pattern.`,
+    `Deploy a custom pattern to the identity's home space.`,
   )
   .example(
     cliText(
       `cf piece set-home ${EX_ID} -a http://localhost:${ports.toolshed} --reset`,
     ),
-    `Reset to the system default home pattern.`,
+    `Reset the identity's home space to the system default pattern.`,
   )
   .option("--reset", "Reset to the system default home pattern")
   .option(

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -988,6 +988,29 @@ export async function removePiece(config: PieceConfig): Promise<void> {
   }
 }
 
+interface RootPatternController {
+  recreateDefaultPattern(): Promise<{ id: string }>;
+}
+
+interface RootPatternDeps {
+  loadManager?: typeof loadManager;
+  createController?: (manager: PieceManager) => RootPatternController;
+}
+
+/**
+ * Recreate the default/root pattern for an explicitly targeted space.
+ */
+export async function recreateSpaceRootPattern(
+  config: SpaceConfig,
+  deps: RootPatternDeps = {},
+): Promise<string> {
+  const manager = await (deps.loadManager ?? loadManager)(config);
+  const pieces = deps.createController?.(manager) ??
+    new PiecesController(manager);
+  const piece = await pieces.recreateDefaultPattern();
+  return piece.id;
+}
+
 function isVNodeLike(value: unknown): value is VNode {
   const visited = new Set<object>();
   while (isRecord(value) && UI in value) {

--- a/packages/cli/test/charm.test.ts
+++ b/packages/cli/test/charm.test.ts
@@ -1,5 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { cf, checkStderr } from "./utils.ts";
+import { recreateSpaceRootPattern, type SpaceConfig } from "../lib/piece.ts";
 import {
   parseLink,
   parsePieceOptions,
@@ -157,6 +159,46 @@ describe("cli piece parsing", () => {
         piece: PIECE,
       })
     ).toThrow();
+  });
+
+  it("recreateSpaceRootPattern() targets the explicit space", async () => {
+    const seen: { config?: SpaceConfig; manager?: object } = {};
+    const pieceId = await recreateSpaceRootPattern({
+      apiUrl: API_URL,
+      space: SPACE,
+      identity: ID,
+    }, {
+      loadManager: async (config) => {
+        seen.config = config;
+        const manager = {};
+        seen.manager = manager;
+        return manager as any;
+      },
+      createController: (manager) => {
+        expect(manager).toBe(seen.manager);
+        return {
+          recreateDefaultPattern: async () => ({ id: PIECE }),
+        };
+      },
+    });
+
+    expect(seen.config).toEqual({
+      apiUrl: API_URL,
+      space: SPACE,
+      identity: ID,
+    });
+    expect(pieceId).toBe(PIECE);
+  });
+
+  it("shows recreate-root as a space-scoped command", async () => {
+    const { code, stdout, stderr } = await cf("piece recreate-root --help");
+    checkStderr(stderr);
+    const output = stdout.join("\n");
+    expect(output).toContain(
+      "Recreate the root pattern for the explicitly targeted space.",
+    );
+    expect(output).toContain("--space <space>");
+    expect(code).toBe(0);
   });
 
   describe("parseLink", () => {

--- a/packages/cli/test/charm.test.ts
+++ b/packages/cli/test/charm.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { cf, checkStderr } from "./utils.ts";
+import { cf, checkStderr, stripAnsi } from "./utils.ts";
 import { recreateSpaceRootPattern, type SpaceConfig } from "../lib/piece.ts";
 import {
   parseLink,
@@ -193,7 +193,7 @@ describe("cli piece parsing", () => {
   it("shows recreate-root as a space-scoped command", async () => {
     const { code, stdout, stderr } = await cf("piece recreate-root --help");
     checkStderr(stderr);
-    const output = stdout.join("\n");
+    const output = stripAnsi(stdout.join("\n"));
     expect(output).toContain(
       "Recreate the root pattern for the explicitly targeted space.",
     );

--- a/packages/cli/test/charm.test.ts
+++ b/packages/cli/test/charm.test.ts
@@ -168,16 +168,16 @@ describe("cli piece parsing", () => {
       space: SPACE,
       identity: ID,
     }, {
-      loadManager: async (config) => {
+      loadManager: (config) => {
         seen.config = config;
         const manager = {};
         seen.manager = manager;
-        return manager as any;
+        return Promise.resolve(manager as any);
       },
       createController: (manager) => {
         expect(manager).toBe(seen.manager);
         return {
-          recreateDefaultPattern: async () => ({ id: PIECE }),
+          recreateDefaultPattern: () => Promise.resolve({ id: PIECE }),
         };
       },
     });

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -10,8 +10,12 @@ export function bytesToLines(stream: Uint8Array): string[] {
 // deno-lint-ignore no-control-regex
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
 
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, "");
+}
+
 export function isIgnorableDenoWarningLine(line: string): boolean {
-  const trimmed = line.replace(ANSI_RE, "").trimStart();
+  const trimmed = stripAnsi(line).trimStart();
   return trimmed.startsWith(
     "Warning The following peer dependency issues were found:",
   ) ||


### PR DESCRIPTION
## Summary
- add `cf piece recreate-root` for explicitly targeted non-home spaces
- expose a thin CLI/lib helper over `PiecesController.recreateDefaultPattern()`
- clarify that `cf piece set-home` targets the identity's home space

## Why
- `cf piece set-home` always rewrites the identity's home space, so it is the wrong tool for repairing an arbitrary space's stale root/default pattern
- Shell already exposes this operation through `recreateSpaceRootPattern()`; the CF CLI did not
- this gives Loom operators a direct per-space repair command without overloading `set-home`

## Verification
- `deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env packages/cli/test/charm.test.ts`
- `deno check packages/cli/mod.ts`
- `git diff --check`
