### PR TITLE
fix(shell): settle navigation side effects before same-space routing

### DIFF
--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -246,6 +246,13 @@ export class RuntimeInternals extends EventTarget {
     }
   }
 
+  async #settleNavigationSideEffects(): Promise<void> {
+    this.#check();
+    await this.#client.idle();
+    await this.#client.synced();
+    await this.#client.idle();
+  }
+
   #onConsole = (e: RuntimeClientEvents["console"][0]) => {
     const { metadata, method, args } = e;
     if (metadata?.pieceId) {
@@ -266,10 +273,10 @@ export class RuntimeInternals extends EventTarget {
       const sameSpace = cell.space() === this.#space;
 
       if (sameSpace) {
-        void this.registerNavigatedPiece(cell);
+        await this.registerNavigatedPiece(cell);
+        await this.#settleNavigationSideEffects();
       } else {
-        await this.#client.idle();
-        await this.#client.synced();
+        await this.#settleNavigationSideEffects();
       }
 
       if (sameSpace && this.#spaceName) {

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -246,11 +246,10 @@ export class RuntimeInternals extends EventTarget {
     }
   }
 
-  async #settleNavigationSideEffects(): Promise<void> {
+  async #waitForNavigationConvergence(): Promise<void> {
     this.#check();
     await this.#client.idle();
     await this.#client.synced();
-    await this.#client.idle();
   }
 
   #onConsole = (e: RuntimeClientEvents["console"][0]) => {
@@ -274,9 +273,9 @@ export class RuntimeInternals extends EventTarget {
 
       if (sameSpace) {
         await this.registerNavigatedPiece(cell);
-        await this.#settleNavigationSideEffects();
+        await this.#waitForNavigationConvergence();
       } else {
-        await this.#settleNavigationSideEffects();
+        await this.#waitForNavigationConvergence();
       }
 
       if (sameSpace && this.#spaceName) {

--- a/packages/shell/test/runtime-navigation.test.ts
+++ b/packages/shell/test/runtime-navigation.test.ts
@@ -29,11 +29,26 @@ class MockRuntimeClient extends EventEmitter<MockRuntimeClientEvents> {
   }
 }
 
-async function flushMicrotasks(count = 4): Promise<void> {
-  for (let i = 0; i < count; i += 1) {
-    await Promise.resolve();
-  }
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
+
+type NavigationDetail = {
+  spaceDid: DID;
+  pieceId: string;
+};
 
 describe("RuntimeInternals navigation", () => {
   it("waits for same-space registration and convergence before navigating", async () => {
@@ -82,22 +97,19 @@ describe("RuntimeInternals navigation", () => {
     );
 
     let registrations = 0;
-    let releaseRegistration: (() => void) | undefined;
-    runtime.registerNavigatedPiece = () => {
+    const registrationStarted = deferred<void>();
+    const registrationReleased = deferred<void>();
+    runtime.registerNavigatedPiece = async () => {
       registrations += 1;
-      return new Promise<void>((resolve) => {
-        releaseRegistration = resolve;
-      });
+      registrationStarted.resolve();
+      await registrationReleased.promise;
     };
 
-    let navigation:
-      | {
-        spaceDid: DID;
-        pieceId: string;
-      }
-      | undefined;
+    let navigation: NavigationDetail | undefined;
+    const navigationReceived = deferred<NavigationDetail>();
     const onNavigate = (event: Event) => {
       navigation = (event as CustomEvent<typeof navigation>).detail;
+      navigationReceived.resolve(navigation!);
     };
     globalThis.addEventListener("cf-navigate", onNavigate);
 
@@ -109,17 +121,17 @@ describe("RuntimeInternals navigation", () => {
         },
       });
 
-      await flushMicrotasks();
+      await registrationStarted.promise;
 
       expect(registrations).toBe(1);
       expect(client.idleCalls).toBe(0);
       expect(client.syncedCalls).toBe(0);
       expect(navigation).toBeUndefined();
 
-      releaseRegistration?.();
-      await flushMicrotasks();
+      registrationReleased.resolve();
+      await navigationReceived.promise;
 
-      expect(client.idleCalls).toBe(2);
+      expect(client.idleCalls).toBe(1);
       expect(client.syncedCalls).toBe(1);
       expect(navigation).toEqual({
         spaceDid,
@@ -189,14 +201,11 @@ describe("RuntimeInternals navigation", () => {
       currentSpace,
     );
 
-    let navigation:
-      | {
-        spaceDid: DID;
-        pieceId: string;
-      }
-      | undefined;
+    let navigation: NavigationDetail | undefined;
+    const navigationReceived = deferred<NavigationDetail>();
     const onNavigate = (event: Event) => {
       navigation = (event as CustomEvent<typeof navigation>).detail;
+      navigationReceived.resolve(navigation!);
     };
     globalThis.addEventListener("cf-navigate", onNavigate);
 
@@ -208,9 +217,9 @@ describe("RuntimeInternals navigation", () => {
         },
       });
 
-      await flushMicrotasks();
+      await navigationReceived.promise;
 
-      expect(client.idleCalls).toBe(2);
+      expect(client.idleCalls).toBe(1);
       expect(client.syncedCalls).toBe(1);
       expect(navigation).toEqual({
         spaceDid: nextSpace,

--- a/packages/shell/test/runtime-navigation.test.ts
+++ b/packages/shell/test/runtime-navigation.test.ts
@@ -29,8 +29,14 @@ class MockRuntimeClient extends EventEmitter<MockRuntimeClientEvents> {
   }
 }
 
+async function flushMicrotasks(count = 4): Promise<void> {
+  for (let i = 0; i < count; i += 1) {
+    await Promise.resolve();
+  }
+}
+
 describe("RuntimeInternals navigation", () => {
-  it("registers same-space navigations when the active view is keyed by DID", async () => {
+  it("waits for same-space registration and convergence before navigating", async () => {
     const env = globalThis as typeof globalThis & {
       $API_URL?: string;
       $ENVIRONMENT?: string;
@@ -76,8 +82,12 @@ describe("RuntimeInternals navigation", () => {
     );
 
     let registrations = 0;
+    let releaseRegistration: (() => void) | undefined;
     runtime.registerNavigatedPiece = () => {
       registrations += 1;
+      return new Promise<void>((resolve) => {
+        releaseRegistration = resolve;
+      });
     };
 
     let navigation:
@@ -99,11 +109,18 @@ describe("RuntimeInternals navigation", () => {
         },
       });
 
-      await Promise.resolve();
+      await flushMicrotasks();
 
       expect(registrations).toBe(1);
       expect(client.idleCalls).toBe(0);
       expect(client.syncedCalls).toBe(0);
+      expect(navigation).toBeUndefined();
+
+      releaseRegistration?.();
+      await flushMicrotasks();
+
+      expect(client.idleCalls).toBe(2);
+      expect(client.syncedCalls).toBe(1);
       expect(navigation).toEqual({
         spaceDid,
         pieceId: "piece-123",
@@ -191,10 +208,9 @@ describe("RuntimeInternals navigation", () => {
         },
       });
 
-      await Promise.resolve();
-      await Promise.resolve();
+      await flushMicrotasks();
 
-      expect(client.idleCalls).toBe(1);
+      expect(client.idleCalls).toBe(2);
       expect(client.syncedCalls).toBe(1);
       expect(navigation).toEqual({
         spaceDid: nextSpace,


### PR DESCRIPTION
## Summary
- wait for runtime-emitted same-space navigation to finish piece registration before switching the shell route
- keep the shell-side convergence wait focused on `idle()` + `synced()` instead of a broader reactive settle claim
- tighten the regression test so it waits on explicit promise milestones rather than microtask counting

## Scope of this PR
This PR is intentionally narrow.

It addresses one concrete race we found in the shell:
- `RuntimeInternals.#onNavigateRequest()` could fire same-space routing before `registerNavigatedPiece(cell)` had completed.

It does **not** claim to fully resolve the remaining `default-app` / `Pattern Integration Tests` flake. The current CI evidence suggests there is still a broader shell-readiness or render-readiness issue after returning to the space root, and that follow-up investigation should happen separately so this PR stays focused.

## Investigation
We started from GitHub Actions reruns where `Pattern Integration Tests` would fail and later reruns could succeed for the same workflow run.

The repeated symptom was:
- `packages/patterns/integration/default-app.test.ts`
- timeout while waiting for note count to increase after navigating back to the space page

During that investigation we found a separate shell race that looked real regardless of the deeper flake:
- `globalThis.commonfabric.rt.idle()` is only worker/runtime scheduler idleness
- same-space navigation in `packages/shell/src/lib/runtime.ts` was doing `registerNavigatedPiece(cell)` as fire-and-forget and then routing immediately

That meant the shell could route to the new same-space piece before the registration side effect had even been acknowledged across IPC.

## Why this fix
This PR keeps the fix narrowly scoped to the race above.

For runtime-emitted same-space navigation, we now:
1. `await registerNavigatedPiece(cell)`
2. `await idle()`
3. `await synced()`
4. route

Cross-space navigation uses the same `idle()` + `synced()` convergence helper for consistency.

After review, I simplified the first version of this PR by:
- removing the extra trailing `idle()`
- rewriting the regression test to wait on explicit deferred milestones instead of `flushMicrotasks()` bookkeeping

That keeps the PR focused on the race we actually found, without overfitting the test to internal await counts.

## What remains for follow-up
The current failing `default-app` integration case appears to be a different boundary:
- route state can be correct before the shell has fully rebound/resolved/rendered the space-root pattern
- that likely needs a follow-up fix around shell/AppView readiness or integration wait semantics, not more ordering changes in `RuntimeInternals.#onNavigateRequest()`

## Validation
Local validation run for this PR:
- `deno check packages/shell/src/lib/runtime.ts`
- `deno test --allow-read --allow-write --allow-run --allow-env packages/shell/test/runtime-navigation.test.ts`
- `deno task test` in `packages/shell`

## Reviewer context
I’d especially appreciate confirmation that this narrow shell race fix is desirable on its own, even if the broader `default-app` readiness issue still needs a separate follow-up.