### PR TITLE
Add cf-harness run diagnostics foundation

### DIFF
--- a/packages/cf-harness/deno.json
+++ b/packages/cf-harness/deno.json
@@ -3,7 +3,7 @@
   "tasks": {
     "run": "deno run -A src/main.ts",
     "help": "deno run -A src/main.ts --help",
-    "test": "ENV=test deno test --allow-read --allow-write test",
+    "test": "ENV=test deno test --allow-read --allow-write --allow-run test",
     "test:integration": "CF_HARNESS_INTEGRATION=1 deno test -A integration"
   },
   "exports": {

--- a/packages/cf-harness/src/artifacts.ts
+++ b/packages/cf-harness/src/artifacts.ts
@@ -11,6 +11,7 @@ import type { HarnessRunState } from "./run-state.ts";
 import { createHarnessPolicyEvent } from "./contracts/policy.ts";
 import type { HarnessTranscriptMessage } from "./contracts/transcript.ts";
 import type { ToolOutputId } from "./contracts/tool-result.ts";
+import type { HarnessCapabilitySnapshot } from "./diagnostics.ts";
 
 const sanitizeArtifactName = (input: string): string =>
   input.replace(/[^A-Za-z0-9._-]+/g, "_");
@@ -59,6 +60,9 @@ export interface HarnessArtifactStore {
   persistTranscript(
     transcript: readonly HarnessTranscriptMessage[],
   ): Promise<string>;
+  persistCapabilitySnapshot(
+    snapshot: HarnessCapabilitySnapshot,
+  ): Promise<string>;
   persistToolOutput(
     toolId: string,
     outputId: ToolOutputId,
@@ -96,6 +100,15 @@ export class FileSystemHarnessArtifactStore implements HarnessArtifactStore {
     return path;
   }
 
+  async persistCapabilitySnapshot(
+    snapshot: HarnessCapabilitySnapshot,
+  ): Promise<string> {
+    await ensureDir(this.runRoot);
+    const path = join(this.runRoot, "capabilities.json");
+    await writeJsonFile(path, snapshot);
+    return path;
+  }
+
   async persistToolOutput(
     toolId: string,
     outputId: ToolOutputId,
@@ -127,6 +140,7 @@ const normalizeHarnessRunState = (
       : createHarnessPolicyEvent(event)
   ),
   toolOutputs: [...(state.toolOutputs ?? [])],
+  failureRecords: [...(state.failureRecords ?? [])],
 });
 
 export const readHarnessRunState = async (

--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -1,0 +1,388 @@
+import { ProcessTimeoutError } from "./sandbox/process-runner.ts";
+import type { SandboxRuntime } from "./sandbox/types.ts";
+import type { HarnessPolicyEvent } from "./contracts/policy.ts";
+import type { ToolOutputId } from "./contracts/tool-result.ts";
+import type { BashToolInput, BashToolOutput } from "./tools/bash.ts";
+
+export const HARNESS_CAPABILITY_COMMANDS = [
+  "bash",
+  "sh",
+  "node",
+  "deno",
+  "python",
+  "python3",
+  "git",
+] as const;
+
+export type HarnessCapabilityCommand =
+  typeof HARNESS_CAPABILITY_COMMANDS[number];
+
+export interface HarnessCapabilityProbe {
+  present: boolean;
+  path?: string;
+  version?: string;
+}
+
+export interface HarnessCapabilitySnapshot {
+  type: "cf-harness.capability-snapshot";
+  at: string;
+  commands: Record<HarnessCapabilityCommand, HarnessCapabilityProbe>;
+}
+
+export type HarnessFailureKind =
+  | "missing_binary"
+  | "tool_not_allowed"
+  | "workspace_path_confusion"
+  | "timeout"
+  | "sandbox_exec_mismatch"
+  | "harness_error"
+  | "unknown";
+
+export type HarnessFailureSource =
+  | "capability_snapshot"
+  | "policy_event"
+  | "tool_output"
+  | "run_error";
+
+export interface HarnessFailureRecord {
+  type: "cf-harness.failure-record";
+  kind: HarnessFailureKind;
+  source: HarnessFailureSource;
+  detail: string;
+  at: string;
+  toolId?: string;
+  toolCallId?: string;
+  outputId?: ToolOutputId;
+  command?: string;
+  commandName?: string;
+  exitCode?: number;
+}
+
+export interface ClassifyHarnessRunErrorOptions {
+  at: string;
+  source?: HarnessFailureSource;
+  toolId?: string;
+  toolCallId?: string;
+  outputId?: ToolOutputId;
+  command?: string;
+  commandName?: string;
+}
+
+export const CAPABILITY_PROBE_SENTINEL = "__CF_HARNESS_CAPABILITY_PROBE__";
+
+const CAPABILITY_PROBE_SCRIPT = [
+  `# ${CAPABILITY_PROBE_SENTINEL}`,
+  "set +e",
+  "probe() {",
+  '  name="$1"',
+  '  if command -v "$name" >/dev/null 2>&1; then',
+  "    path=\"$(command -v \"$name\" 2>/dev/null | head -n 1 | tr '\\t' ' ')\"",
+  "    version=\"$($name --version 2>/dev/null | head -n 1 | tr '\\t' ' ' || true)\"",
+  '    printf "%s\\tpresent\\t%s\\t%s\\n" "$name" "$path" "$version"',
+  "  else",
+  '    printf "%s\\tmissing\\t\\t\\n" "$name"',
+  "  fi",
+  "}",
+  ...HARNESS_CAPABILITY_COMMANDS.map((command) => `probe ${command}`),
+].join("\n");
+
+const isHarnessCapabilityCommand = (
+  input: string,
+): input is HarnessCapabilityCommand =>
+  HARNESS_CAPABILITY_COMMANDS.includes(input as HarnessCapabilityCommand);
+
+const createEmptyCapabilitySnapshot = (
+  at: string,
+): HarnessCapabilitySnapshot => ({
+  type: "cf-harness.capability-snapshot",
+  at,
+  commands: Object.fromEntries(
+    HARNESS_CAPABILITY_COMMANDS.map((command) => [command, { present: false }]),
+  ) as Record<HarnessCapabilityCommand, HarnessCapabilityProbe>,
+});
+
+const parseCapabilityProbeOutput = (
+  stdout: string,
+  at: string,
+): HarnessCapabilitySnapshot => {
+  const snapshot = createEmptyCapabilitySnapshot(at);
+  for (const line of stdout.split("\n")) {
+    if (line.trim() === "") {
+      continue;
+    }
+    const [command, status, path = "", version = ""] = line.split("\t");
+    if (!isHarnessCapabilityCommand(command)) {
+      continue;
+    }
+    snapshot.commands[command] = status === "present"
+      ? {
+        present: true,
+        ...(path !== "" ? { path } : {}),
+        ...(version !== "" ? { version } : {}),
+      }
+      : { present: false };
+  }
+  return snapshot;
+};
+
+export const collectHarnessCapabilitySnapshot = async (
+  sandbox: SandboxRuntime,
+  cwd: string,
+  at = new Date().toISOString(),
+): Promise<HarnessCapabilitySnapshot> => {
+  const result = await sandbox.runShell({
+    command: CAPABILITY_PROBE_SCRIPT,
+    cwd,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `capability probe failed with exit ${result.exitCode}: ${
+        result.stderr || result.stdout || "no error detail"
+      }`,
+    );
+  }
+  return parseCapabilityProbeOutput(result.stdout, at);
+};
+
+export const createHarnessFailureRecord = (
+  input: Omit<HarnessFailureRecord, "type">,
+): HarnessFailureRecord => ({
+  type: "cf-harness.failure-record",
+  ...input,
+});
+
+export const classifyHarnessPolicyEventFailure = (
+  event: HarnessPolicyEvent,
+): HarnessFailureRecord | undefined =>
+  event.severity === "denied"
+    ? createHarnessFailureRecord({
+      kind: "tool_not_allowed",
+      source: "policy_event",
+      detail: event.detail,
+      at: event.at,
+      toolId: event.toolId,
+      ...(event.toolCallId !== undefined
+        ? { toolCallId: event.toolCallId }
+        : {}),
+    })
+    : undefined;
+
+const MISSING_COMMAND_PATTERNS = [
+  "command not found",
+  "not found",
+  "not recognized",
+  "no such file or directory",
+];
+
+const SHELL_KEYWORDS = new Set([
+  "if",
+  "then",
+  "else",
+  "elif",
+  "fi",
+  "for",
+  "while",
+  "do",
+  "done",
+  "case",
+  "esac",
+  "function",
+  "{",
+  "}",
+]);
+
+const extractLeadingCommandName = (command: string): string | undefined => {
+  for (const rawLine of command.split("\n")) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) {
+      continue;
+    }
+    const tokens = line.split(/\s+/).filter((token) => token.length > 0);
+    let index = 0;
+    while (
+      index < tokens.length &&
+      /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[index]!)
+    ) {
+      index += 1;
+    }
+    let token = tokens[index];
+    if (token === undefined || SHELL_KEYWORDS.has(token)) {
+      continue;
+    }
+    if (token === "exec") {
+      token = tokens[index + 1];
+    }
+    if (token === undefined) {
+      return undefined;
+    }
+    return token.replace(/^['"]|['"]$/g, "");
+  }
+  return undefined;
+};
+
+const capabilityCommandForName = (
+  input: string | undefined,
+): HarnessCapabilityCommand | undefined =>
+  input !== undefined && isHarnessCapabilityCommand(input) ? input : undefined;
+
+const detailForMissingBinary = (
+  commandName: string | undefined,
+  capabilitySnapshot?: HarnessCapabilitySnapshot,
+): string => {
+  if (commandName === undefined) {
+    return "a shell command was not found in the sandbox";
+  }
+  const capabilityCommand = capabilityCommandForName(commandName);
+  const probe = capabilityCommand === undefined
+    ? undefined
+    : capabilitySnapshot?.commands[capabilityCommand];
+  const aliasHint = commandName === "python" &&
+      capabilitySnapshot?.commands.python3.present === true
+    ? " python3 is available."
+    : commandName === "python3" &&
+        capabilitySnapshot?.commands.python.present === true
+    ? " python is available."
+    : "";
+  return probe?.present === false
+    ? `${commandName} is not available in the sandbox.${aliasHint}`
+    : `${commandName} was not found while executing a shell command.${aliasHint}`;
+};
+
+export const classifyBashToolFailure = (
+  input: BashToolInput,
+  output: BashToolOutput,
+  at: string,
+  capabilitySnapshot?: HarnessCapabilitySnapshot,
+): HarnessFailureRecord | undefined => {
+  if (output.exitCode !== 127) {
+    return undefined;
+  }
+  const combinedOutput = `${output.stdout}\n${output.stderr}`.toLowerCase();
+  if (
+    !MISSING_COMMAND_PATTERNS.some((pattern) =>
+      combinedOutput.includes(pattern)
+    )
+  ) {
+    return undefined;
+  }
+  const commandName = extractLeadingCommandName(input.command);
+  return createHarnessFailureRecord({
+    kind: "missing_binary",
+    source: "tool_output",
+    detail: detailForMissingBinary(commandName, capabilitySnapshot),
+    at,
+    toolId: "bash",
+    outputId: output.outputId as ToolOutputId,
+    command: input.command,
+    ...(commandName !== undefined ? { commandName } : {}),
+    exitCode: output.exitCode,
+  });
+};
+
+export const classifyBuiltinToolFailure = (
+  toolId: string,
+  input: unknown,
+  output: unknown,
+  at: string,
+  capabilitySnapshot?: HarnessCapabilitySnapshot,
+): HarnessFailureRecord | undefined => {
+  switch (toolId) {
+    case "bash":
+      return classifyBashToolFailure(
+        input as BashToolInput,
+        output as BashToolOutput,
+        at,
+        capabilitySnapshot,
+      );
+    default:
+      return undefined;
+  }
+};
+
+export const classifyHarnessRunError = (
+  error: unknown,
+  options: ClassifyHarnessRunErrorOptions,
+): HarnessFailureRecord => {
+  if (error instanceof ProcessTimeoutError) {
+    return createHarnessFailureRecord({
+      kind: "timeout",
+      source: options.source ?? "run_error",
+      detail: error.message,
+      at: options.at,
+      ...(options.toolId !== undefined ? { toolId: options.toolId } : {}),
+      ...(options.toolCallId !== undefined
+        ? { toolCallId: options.toolCallId }
+        : {}),
+      ...(options.outputId !== undefined ? { outputId: options.outputId } : {}),
+      ...(options.command !== undefined ? { command: options.command } : {}),
+      ...(options.commandName !== undefined
+        ? { commandName: options.commandName }
+        : {}),
+    });
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+  if (normalized.includes("path escapes workspace root")) {
+    return createHarnessFailureRecord({
+      kind: "workspace_path_confusion",
+      source: options.source ?? "run_error",
+      detail: message,
+      at: options.at,
+      ...(options.toolId !== undefined ? { toolId: options.toolId } : {}),
+      ...(options.toolCallId !== undefined
+        ? { toolCallId: options.toolCallId }
+        : {}),
+      ...(options.outputId !== undefined ? { outputId: options.outputId } : {}),
+      ...(options.command !== undefined ? { command: options.command } : {}),
+      ...(options.commandName !== undefined
+        ? { commandName: options.commandName }
+        : {}),
+    });
+  }
+  const kind = normalized.includes("unknown builtin tool") ||
+      normalized.includes("did not return an outputid") ||
+      normalized.includes("failed to parse tool arguments") ||
+      normalized.includes("chat completion response did not include a message")
+    ? "harness_error"
+    : "unknown";
+  return createHarnessFailureRecord({
+    kind,
+    source: options.source ?? "run_error",
+    detail: message,
+    at: options.at,
+    ...(options.toolId !== undefined ? { toolId: options.toolId } : {}),
+    ...(options.toolCallId !== undefined
+      ? { toolCallId: options.toolCallId }
+      : {}),
+    ...(options.outputId !== undefined ? { outputId: options.outputId } : {}),
+    ...(options.command !== undefined ? { command: options.command } : {}),
+    ...(options.commandName !== undefined
+      ? { commandName: options.commandName }
+      : {}),
+  });
+};
+
+const FAILURE_PRIORITY: Record<HarnessFailureKind, number> = {
+  tool_not_allowed: 60,
+  timeout: 50,
+  workspace_path_confusion: 40,
+  missing_binary: 30,
+  sandbox_exec_mismatch: 20,
+  harness_error: 10,
+  unknown: 0,
+};
+
+export const selectPrimaryHarnessFailure = (
+  failures: readonly HarnessFailureRecord[],
+): HarnessFailureRecord | undefined => {
+  let best: HarnessFailureRecord | undefined;
+  for (const failure of failures) {
+    if (
+      best === undefined ||
+      FAILURE_PRIORITY[failure.kind] > FAILURE_PRIORITY[best.kind]
+    ) {
+      best = failure;
+    }
+  }
+  return best;
+};

--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -220,6 +220,32 @@ const extractLeadingCommandName = (command: string): string | undefined => {
   return undefined;
 };
 
+const MISSING_COMMAND_CAPTURE_PATTERNS = [
+  /(?:^|:\s*)["']?([^"' \t:]+)["']?:\s*command not found$/i,
+  /(?:^|:\s*)["']?([^"' \t:]+)["']?:\s*not found$/i,
+  /(?:^|:\s*)["']?([^"' \t:]+)["']?:\s*no such file or directory$/i,
+  /["']?([^"' \t]+)["']?\s+is not recognized as an internal or external command\b/i,
+];
+
+const extractMissingCommandNameFromText = (
+  text: string,
+): string | undefined => {
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (line === "") {
+      continue;
+    }
+    for (const pattern of MISSING_COMMAND_CAPTURE_PATTERNS) {
+      const match = line.match(pattern);
+      const commandName = match?.[1]?.trim();
+      if (commandName !== undefined && commandName !== "") {
+        return commandName;
+      }
+    }
+  }
+  return undefined;
+};
+
 const capabilityCommandForName = (
   input: string | undefined,
 ): HarnessCapabilityCommand | undefined =>
@@ -265,7 +291,9 @@ export const classifyBashToolFailure = (
   ) {
     return undefined;
   }
-  const commandName = extractLeadingCommandName(input.command);
+  const commandName =
+    extractMissingCommandNameFromText(`${output.stderr}\n${output.stdout}`) ??
+      extractLeadingCommandName(input.command);
   return createHarnessFailureRecord({
     kind: "missing_binary",
     source: "tool_output",

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -8,14 +8,24 @@ import {
   type HarnessArtifactStore,
 } from "./artifacts.ts";
 import {
+  appendHarnessFailureRecord,
   appendHarnessPolicyEvent,
   appendHarnessToolOutput,
   createHarnessRunState,
   type HarnessRunState,
+  setHarnessCapabilitySnapshot,
   setHarnessRunCurrentDir,
   setHarnessRunStatus,
   setHarnessTranscriptPath,
 } from "./run-state.ts";
+import {
+  classifyBuiltinToolFailure,
+  classifyHarnessPolicyEventFailure,
+  classifyHarnessRunError,
+  type ClassifyHarnessRunErrorOptions,
+  collectHarnessCapabilitySnapshot,
+  type HarnessFailureRecord,
+} from "./diagnostics.ts";
 import {
   createHarnessPolicyEvent,
   type HarnessPolicyEvent,
@@ -179,6 +189,27 @@ export class CfHarnessEngine {
     return structuredClone(this.#runState);
   }
 
+  appendFailureRecord(failure: HarnessFailureRecord): HarnessRunState {
+    this.#runState = appendHarnessFailureRecord(
+      this.#runState,
+      failure,
+      this.#now(),
+    );
+    return this.getRunState();
+  }
+
+  appendFailureFromError(
+    error: unknown,
+    options: Omit<ClassifyHarnessRunErrorOptions, "at"> = {},
+  ): HarnessRunState {
+    return this.appendFailureRecord(
+      classifyHarnessRunError(error, {
+        ...options,
+        at: this.#now(),
+      }),
+    );
+  }
+
   setRunStatus(status: HarnessRunState["status"]): HarnessRunState {
     this.#runState = setHarnessRunStatus(this.#runState, status, this.#now());
     return this.getRunState();
@@ -188,11 +219,16 @@ export class CfHarnessEngine {
     event: Omit<HarnessPolicyEvent, "type" | "at">,
   ): Promise<HarnessRunState> {
     const now = this.#now();
+    const policyEvent = createHarnessPolicyEvent({ ...event, at: now });
     this.#runState = appendHarnessPolicyEvent(
       this.#runState,
-      createHarnessPolicyEvent({ ...event, at: now }),
+      policyEvent,
       now,
     );
+    const failure = classifyHarnessPolicyEventFailure(policyEvent);
+    if (failure !== undefined) {
+      this.#runState = appendHarnessFailureRecord(this.#runState, failure, now);
+    }
     await this.persistRunState();
     return this.getRunState();
   }
@@ -218,6 +254,51 @@ export class CfHarnessEngine {
     return transcriptPath;
   }
 
+  async ensureDiagnosticsInitialized(): Promise<HarnessRunState> {
+    if (this.#runState.capabilitySnapshot !== undefined) {
+      return this.getRunState();
+    }
+    const now = this.#now();
+    try {
+      const capabilitySnapshot = await collectHarnessCapabilitySnapshot(
+        this.sandbox,
+        this.#runState.currentDir,
+        now,
+      );
+      let capabilitiesPath: string | undefined;
+      try {
+        capabilitiesPath = await this.artifactStore?.persistCapabilitySnapshot(
+          capabilitySnapshot,
+        );
+      } catch (error) {
+        this.#runState = appendHarnessFailureRecord(
+          this.#runState,
+          classifyHarnessRunError(error, {
+            at: this.#now(),
+            source: "capability_snapshot",
+          }),
+          this.#now(),
+        );
+      }
+      this.#runState = setHarnessCapabilitySnapshot(
+        this.#runState,
+        capabilitySnapshot,
+        capabilitiesPath,
+        this.#now(),
+      );
+    } catch (error) {
+      this.#runState = appendHarnessFailureRecord(
+        this.#runState,
+        classifyHarnessRunError(error, {
+          at: now,
+          source: "capability_snapshot",
+        }),
+        now,
+      );
+    }
+    return this.getRunState();
+  }
+
   async invokeBuiltinTool<TToolId extends BuiltinToolId>(
     toolId: TToolId,
     input: BuiltinToolInputMap[TToolId],
@@ -226,6 +307,7 @@ export class CfHarnessEngine {
     if (tool === undefined) {
       throw new Error(`unknown builtin tool: ${toolId}`);
     }
+    await this.ensureDiagnosticsInitialized();
     this.#runState = setHarnessRunStatus(
       this.#runState,
       "running",
@@ -250,11 +332,26 @@ export class CfHarnessEngine {
         this.#runState.runId,
         artifactPath,
       );
+      const completionTime = this.#now();
       this.#runState = appendHarnessToolOutput(
-        setHarnessRunStatus(this.#runState, "completed", this.#now()),
+        setHarnessRunStatus(this.#runState, "completed", completionTime),
         resultRef,
-        this.#now(),
+        completionTime,
       );
+      const failure = classifyBuiltinToolFailure(
+        toolId,
+        input,
+        output,
+        completionTime,
+        this.#runState.capabilitySnapshot,
+      );
+      if (failure !== undefined) {
+        this.#runState = appendHarnessFailureRecord(
+          this.#runState,
+          failure,
+          completionTime,
+        );
+      }
       await this.persistRunState();
       return {
         output,
@@ -262,10 +359,20 @@ export class CfHarnessEngine {
         runState: this.getRunState(),
       };
     } catch (error) {
+      const failureTime = this.#now();
       this.#runState = setHarnessRunStatus(
         this.#runState,
         "failed",
-        this.#now(),
+        failureTime,
+      );
+      this.#runState = appendHarnessFailureRecord(
+        this.#runState,
+        classifyHarnessRunError(error, {
+          at: failureTime,
+          toolId,
+          source: "run_error",
+        }),
+        failureTime,
       );
       await this.persistRunState();
       throw error;

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -13,6 +13,7 @@ import {
   appendHarnessToolOutput,
   createHarnessRunState,
   type HarnessRunState,
+  type HarnessRunTerminalReason,
   setHarnessCapabilitySnapshot,
   setHarnessRunCurrentDir,
   setHarnessRunStatus,
@@ -210,8 +211,16 @@ export class CfHarnessEngine {
     );
   }
 
-  setRunStatus(status: HarnessRunState["status"]): HarnessRunState {
-    this.#runState = setHarnessRunStatus(this.#runState, status, this.#now());
+  setRunStatus(
+    status: HarnessRunState["status"],
+    terminalReason?: HarnessRunTerminalReason,
+  ): HarnessRunState {
+    this.#runState = setHarnessRunStatus(
+      this.#runState,
+      status,
+      this.#now(),
+      terminalReason,
+    );
     return this.getRunState();
   }
 
@@ -334,7 +343,12 @@ export class CfHarnessEngine {
       );
       const completionTime = this.#now();
       this.#runState = appendHarnessToolOutput(
-        setHarnessRunStatus(this.#runState, "completed", completionTime),
+        setHarnessRunStatus(
+          this.#runState,
+          "completed",
+          completionTime,
+          "tool_completed",
+        ),
         resultRef,
         completionTime,
       );
@@ -364,6 +378,7 @@ export class CfHarnessEngine {
         this.#runState,
         "failed",
         failureTime,
+        "tool_error",
       );
       this.#runState = appendHarnessFailureRecord(
         this.#runState,

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -344,7 +344,7 @@ export class CfHarnessPromptLoop {
         });
         const toolCalls = assistantMessage.toolCalls ?? [];
         if (toolCalls.length === 0) {
-          this.engine.setRunStatus("completed");
+          this.engine.setRunStatus("completed", "assistant_completed");
           await this.engine.persistRunState();
           return {
             model,
@@ -369,7 +369,7 @@ export class CfHarnessPromptLoop {
       }
     } catch (error) {
       this.engine.appendFailureFromError(error);
-      this.engine.setRunStatus("failed");
+      this.engine.setRunStatus("failed", "prompt_loop_error");
       try {
         await this.engine.persistRunState();
         await this.engine.persistTranscript(transcript);
@@ -382,7 +382,7 @@ export class CfHarnessPromptLoop {
       `prompt loop exceeded max model turns (${maxModelTurns}) without a final assistant response`,
     );
     this.engine.appendFailureFromError(turnLimitError);
-    this.engine.setRunStatus("failed");
+    this.engine.setRunStatus("failed", "max_model_turns");
     await this.engine.persistRunState();
     await this.engine.persistTranscript(transcript);
     throw turnLimitError;

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -322,6 +322,7 @@ export class CfHarnessPromptLoop {
     const transcript: HarnessTranscriptMessage[] = [...options.transcript];
     const maxModelTurns = options.maxModelTurns ?? this.#maxModelTurns;
     let modelTurns = 0;
+    await this.engine.ensureDiagnosticsInitialized();
     this.engine.setRunStatus("running");
     await this.engine.persistRunState();
     await this.engine.persistTranscript(transcript);
@@ -367,6 +368,7 @@ export class CfHarnessPromptLoop {
         }
       }
     } catch (error) {
+      this.engine.appendFailureFromError(error);
       this.engine.setRunStatus("failed");
       try {
         await this.engine.persistRunState();
@@ -376,12 +378,14 @@ export class CfHarnessPromptLoop {
       }
       throw error;
     }
+    const turnLimitError = new Error(
+      `prompt loop exceeded max model turns (${maxModelTurns}) without a final assistant response`,
+    );
+    this.engine.appendFailureFromError(turnLimitError);
     this.engine.setRunStatus("failed");
     await this.engine.persistRunState();
     await this.engine.persistTranscript(transcript);
-    throw new Error(
-      `prompt loop exceeded max model turns (${maxModelTurns}) without a final assistant response`,
-    );
+    throw turnLimitError;
   }
 
   #buildChatCompletionRequest(

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -13,11 +13,20 @@ export type HarnessRunStatus =
   | "completed"
   | "failed";
 
+export type HarnessRunTerminalReason =
+  | "assistant_completed"
+  | "tool_completed"
+  | "tool_error"
+  | "max_model_turns"
+  | "prompt_loop_error";
+
 export interface HarnessRunState {
   runId: string;
   status: HarnessRunStatus;
   createdAt: string;
   updatedAt: string;
+  endedAt?: string;
+  terminalReason?: HarnessRunTerminalReason;
   cfcEnforcementMode: CfcEnforcementMode;
   currentDir: string;
   model?: string;
@@ -34,6 +43,8 @@ export interface HarnessRunState {
 export interface CreateHarnessRunStateOptions {
   runId?: string;
   status?: HarnessRunStatus;
+  endedAt?: string;
+  terminalReason?: HarnessRunTerminalReason;
   cfcEnforcementMode: CfcEnforcementMode;
   currentDir: string;
   model?: string;
@@ -55,6 +66,10 @@ export const createHarnessRunState = (
     status: options.status ?? "pending",
     createdAt: now,
     updatedAt: now,
+    ...(options.endedAt !== undefined ? { endedAt: options.endedAt } : {}),
+    ...(options.terminalReason !== undefined
+      ? { terminalReason: options.terminalReason }
+      : {}),
     cfcEnforcementMode: options.cfcEnforcementMode,
     currentDir: options.currentDir,
     ...(options.model !== undefined ? { model: options.model } : {}),
@@ -83,11 +98,26 @@ export const setHarnessRunStatus = (
   state: HarnessRunState,
   status: HarnessRunStatus,
   now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  status,
-  updatedAt: now,
-});
+  terminalReason?: HarnessRunTerminalReason,
+): HarnessRunState => {
+  const base = {
+    ...state,
+    status,
+    updatedAt: now,
+  };
+  if (status === "completed" || status === "failed") {
+    return {
+      ...base,
+      endedAt: now,
+      ...(terminalReason !== undefined ? { terminalReason } : {}),
+    };
+  }
+  const { endedAt: _endedAt, terminalReason: _terminalReason, ...nonTerminal } =
+    base;
+  return {
+    ...nonTerminal,
+  };
+};
 
 export const appendHarnessToolOutput = (
   state: HarnessRunState,

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -1,6 +1,11 @@
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { HarnessPolicyEvent } from "./contracts/policy.ts";
 import type { ToolResultRef } from "./contracts/tool-result.ts";
+import type {
+  HarnessCapabilitySnapshot,
+  HarnessFailureRecord,
+} from "./diagnostics.ts";
+import { selectPrimaryHarnessFailure } from "./diagnostics.ts";
 
 export type HarnessRunStatus =
   | "pending"
@@ -18,8 +23,12 @@ export interface HarnessRunState {
   model?: string;
   artifactRoot?: string;
   transcriptPath?: string;
+  capabilitySnapshot?: HarnessCapabilitySnapshot;
+  capabilitiesPath?: string;
   policyEvents: HarnessPolicyEvent[];
   toolOutputs: ToolResultRef[];
+  failureRecords?: HarnessFailureRecord[];
+  primaryFailure?: HarnessFailureRecord;
 }
 
 export interface CreateHarnessRunStateOptions {
@@ -30,6 +39,10 @@ export interface CreateHarnessRunStateOptions {
   model?: string;
   artifactRoot?: string;
   transcriptPath?: string;
+  capabilitySnapshot?: HarnessCapabilitySnapshot;
+  capabilitiesPath?: string;
+  failureRecords?: HarnessFailureRecord[];
+  primaryFailure?: HarnessFailureRecord;
   now?: string;
 }
 
@@ -51,8 +64,18 @@ export const createHarnessRunState = (
     ...(options.transcriptPath !== undefined
       ? { transcriptPath: options.transcriptPath }
       : {}),
+    ...(options.capabilitySnapshot !== undefined
+      ? { capabilitySnapshot: options.capabilitySnapshot }
+      : {}),
+    ...(options.capabilitiesPath !== undefined
+      ? { capabilitiesPath: options.capabilitiesPath }
+      : {}),
     policyEvents: [],
     toolOutputs: [],
+    failureRecords: [...(options.failureRecords ?? [])],
+    ...(options.primaryFailure !== undefined
+      ? { primaryFailure: options.primaryFailure }
+      : {}),
   };
 };
 
@@ -86,6 +109,21 @@ export const appendHarnessPolicyEvent = (
   policyEvents: [...state.policyEvents, event],
 });
 
+export const appendHarnessFailureRecord = (
+  state: HarnessRunState,
+  failure: HarnessFailureRecord,
+  now = new Date().toISOString(),
+): HarnessRunState => {
+  const failureRecords = [...(state.failureRecords ?? []), failure];
+  const primaryFailure = selectPrimaryHarnessFailure(failureRecords);
+  return {
+    ...state,
+    updatedAt: now,
+    failureRecords,
+    ...(primaryFailure !== undefined ? { primaryFailure } : {}),
+  };
+};
+
 export const setHarnessRunCurrentDir = (
   state: HarnessRunState,
   currentDir: string,
@@ -103,5 +141,17 @@ export const setHarnessTranscriptPath = (
 ): HarnessRunState => ({
   ...state,
   transcriptPath,
+  updatedAt: now,
+});
+
+export const setHarnessCapabilitySnapshot = (
+  state: HarnessRunState,
+  capabilitySnapshot: HarnessCapabilitySnapshot,
+  capabilitiesPath?: string,
+  now = new Date().toISOString(),
+): HarnessRunState => ({
+  ...state,
+  capabilitySnapshot,
+  ...(capabilitiesPath !== undefined ? { capabilitiesPath } : {}),
   updatedAt: now,
 });

--- a/packages/cf-harness/src/sandbox/process-runner.ts
+++ b/packages/cf-harness/src/sandbox/process-runner.ts
@@ -42,8 +42,12 @@ const readStreamText = async (
 export class DenoProcessRunner implements ProcessRunner {
   async run(request: ProcessRunRequest): Promise<ProcessRunResult> {
     const controller = new AbortController();
+    let timeoutTriggered = false;
     const timeoutId = request.timeoutMs !== undefined
-      ? setTimeout(() => controller.abort(), request.timeoutMs)
+      ? setTimeout(() => {
+        timeoutTriggered = true;
+        controller.abort();
+      }, request.timeoutMs)
       : undefined;
     try {
       const child = new Deno.Command(request.command, {
@@ -73,6 +77,13 @@ export class DenoProcessRunner implements ProcessRunner {
         readStreamText(child.stderr),
         writeInput(),
       ]);
+
+      if (timeoutTriggered && status.code !== 0) {
+        throw new ProcessTimeoutError(
+          [request.command, ...request.args].join(" "),
+          request.timeoutMs ?? 0,
+        );
+      }
 
       return {
         stdout,

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -8,6 +8,7 @@ import {
   readHarnessTranscript,
 } from "../src/artifacts.ts";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
+import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
 import type {
@@ -43,6 +44,21 @@ class FakeSandboxRuntime implements SandboxRuntime {
 
   runShell(request: SandboxShellRequest): Promise<SandboxCommandResult> {
     this.shellRequests.push(request);
+    if (request.command.includes(CAPABILITY_PROBE_SENTINEL)) {
+      return Promise.resolve({
+        stdout: [
+          "bash\tpresent\t/bin/bash\tGNU bash, version 5.2.26(1)-release",
+          "sh\tpresent\t/bin/sh\tBusyBox v1.36.1",
+          "node\tmissing\t\t",
+          "deno\tpresent\t/usr/local/bin/deno\tdeno 2.2.0",
+          "python\tmissing\t\t",
+          "python3\tpresent\t/usr/bin/python3\tPython 3.11.9",
+          "git\tpresent\t/usr/bin/git\tgit version 2.45.1",
+        ].join("\n"),
+        stderr: "",
+        exitCode: 0,
+      });
+    }
     return Promise.resolve(
       this.shellResults.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
     );
@@ -70,8 +86,10 @@ Deno.test({
             "2026-04-15T21:00:00.000Z",
             "2026-04-15T21:00:01.000Z",
             "2026-04-15T21:00:02.000Z",
+            "2026-04-15T21:00:03.000Z",
+            "2026-04-15T21:00:04.000Z",
           ];
-          return () => timestamps.shift() ?? "2026-04-15T21:00:03.000Z";
+          return () => timestamps.shift() ?? "2026-04-15T21:00:05.000Z";
         })(),
       });
 
@@ -82,6 +100,7 @@ Deno.test({
       const persistedState = await readHarnessRunState(
         join(runRoot, "run-state.json"),
       );
+      const capabilitySnapshotPath = join(runRoot, "capabilities.json");
 
       assertEquals(
         result.resultRef.artifactPath,
@@ -101,16 +120,55 @@ Deno.test({
           cwd: "/workspace",
         },
       );
+      assertEquals(
+        JSON.parse(await Deno.readTextFile(capabilitySnapshotPath)),
+        persistedState.capabilitySnapshot,
+      );
       assertEquals(persistedState, {
         runId: "run-artifacts",
         status: "completed",
         createdAt: "2026-04-15T21:00:00.000Z",
-        updatedAt: "2026-04-15T21:00:03.000Z",
+        updatedAt: "2026-04-15T21:00:05.000Z",
         cfcEnforcementMode: "observe",
         currentDir: "/workspace",
         artifactRoot: runRoot,
+        capabilitySnapshot: {
+          type: "cf-harness.capability-snapshot",
+          at: "2026-04-15T21:00:01.000Z",
+          commands: {
+            bash: {
+              present: true,
+              path: "/bin/bash",
+              version: "GNU bash, version 5.2.26(1)-release",
+            },
+            sh: {
+              present: true,
+              path: "/bin/sh",
+              version: "BusyBox v1.36.1",
+            },
+            node: { present: false },
+            deno: {
+              present: true,
+              path: "/usr/local/bin/deno",
+              version: "deno 2.2.0",
+            },
+            python: { present: false },
+            python3: {
+              present: true,
+              path: "/usr/bin/python3",
+              version: "Python 3.11.9",
+            },
+            git: {
+              present: true,
+              path: "/usr/bin/git",
+              version: "git version 2.45.1",
+            },
+          },
+        },
+        capabilitiesPath: capabilitySnapshotPath,
         policyEvents: [],
         toolOutputs: [result.resultRef],
+        failureRecords: [],
       });
     } finally {
       await Deno.remove(artifactRoot, { recursive: true });
@@ -206,6 +264,11 @@ Deno.test({
       assertEquals(persistedState.transcriptPath, transcriptPath);
       assertEquals(persistedState.artifactRoot, runRoot);
       assertEquals(persistedState.policyEvents, []);
+      assertEquals(persistedState.failureRecords, []);
+      assertEquals(
+        persistedState.capabilitySnapshot?.commands.python3.present,
+        true,
+      );
     } finally {
       await Deno.remove(artifactRoot, { recursive: true });
     }
@@ -249,6 +312,7 @@ Deno.test({
           transcriptPath: outsideTranscriptPath,
           policyEvents: [],
           toolOutputs: [],
+          failureRecords: [],
         }),
       );
       await Deno.writeTextFile(

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -129,6 +129,8 @@ Deno.test({
         status: "completed",
         createdAt: "2026-04-15T21:00:00.000Z",
         updatedAt: "2026-04-15T21:00:05.000Z",
+        endedAt: "2026-04-15T21:00:05.000Z",
+        terminalReason: "tool_completed",
         cfcEnforcementMode: "observe",
         currentDir: "/workspace",
         artifactRoot: runRoot,
@@ -263,6 +265,8 @@ Deno.test({
       );
       assertEquals(persistedState.transcriptPath, transcriptPath);
       assertEquals(persistedState.artifactRoot, runRoot);
+      assertEquals(persistedState.endedAt, "2026-04-15T21:10:07.000Z");
+      assertEquals(persistedState.terminalReason, "assistant_completed");
       assertEquals(persistedState.policyEvents, []);
       assertEquals(persistedState.failureRecords, []);
       assertEquals(

--- a/packages/cf-harness/test/diagnostics.test.ts
+++ b/packages/cf-harness/test/diagnostics.test.ts
@@ -156,6 +156,40 @@ Deno.test("classifyBashToolFailure uses the capability snapshot to explain missi
   });
 });
 
+Deno.test("classifyBashToolFailure prefers the missing subcommand from shell output", async () => {
+  const snapshot = await collectHarnessCapabilitySnapshot(
+    new FakeSandboxRuntime(),
+    "/workspace",
+    "2026-04-23T18:20:00.000Z",
+  );
+
+  const failure = classifyBashToolFailure(
+    { command: "echo ok && python script.py" },
+    {
+      outputId: createToolOutputId("run-2", "bash", 1),
+      stdout: "ok",
+      stderr: "/bin/sh: python: command not found",
+      exitCode: 127,
+      cwd: "/workspace",
+    },
+    "2026-04-23T18:20:01.000Z",
+    snapshot,
+  );
+
+  assertEquals(failure, {
+    type: "cf-harness.failure-record",
+    kind: "missing_binary",
+    source: "tool_output",
+    detail: "python is not available in the sandbox. python3 is available.",
+    at: "2026-04-23T18:20:01.000Z",
+    toolId: "bash",
+    outputId: createToolOutputId("run-2", "bash", 1),
+    command: "echo ok && python script.py",
+    commandName: "python",
+    exitCode: 127,
+  });
+});
+
 Deno.test("classifyHarnessRunError maps timeouts and path escapes deterministically", () => {
   assertEquals(
     classifyHarnessRunError(

--- a/packages/cf-harness/test/diagnostics.test.ts
+++ b/packages/cf-harness/test/diagnostics.test.ts
@@ -1,0 +1,207 @@
+import { assertEquals } from "@std/assert";
+import { createToolOutputId } from "../src/contracts/tool-result.ts";
+import {
+  CAPABILITY_PROBE_SENTINEL,
+  classifyBashToolFailure,
+  classifyHarnessPolicyEventFailure,
+  classifyHarnessRunError,
+  collectHarnessCapabilitySnapshot,
+  createHarnessFailureRecord,
+  selectPrimaryHarnessFailure,
+} from "../src/diagnostics.ts";
+import { createHarnessPolicyEvent } from "../src/contracts/policy.ts";
+import { ProcessTimeoutError } from "../src/sandbox/process-runner.ts";
+import type {
+  SandboxCommandRequest,
+  SandboxCommandResult,
+  SandboxRuntime,
+  SandboxShellRequest,
+} from "../src/sandbox/types.ts";
+
+class FakeSandboxRuntime implements SandboxRuntime {
+  readonly kind = "docker-runsc-cfc" as const;
+
+  resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
+    return path.startsWith("/") ? path : `${cwd}/${path}`;
+  }
+
+  isPathWithinWorkspace(path: string): boolean {
+    return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  defaultWorkingDirectory(): string {
+    return "/workspace";
+  }
+
+  run(_request: SandboxCommandRequest): Promise<SandboxCommandResult> {
+    return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+  }
+
+  runShell(request: SandboxShellRequest): Promise<SandboxCommandResult> {
+    if (!request.command.includes(CAPABILITY_PROBE_SENTINEL)) {
+      throw new Error("unexpected shell request");
+    }
+    return Promise.resolve({
+      stdout: [
+        "bash\tpresent\t/bin/bash\tGNU bash, version 5.2.26(1)-release",
+        "sh\tpresent\t/bin/sh\tBusyBox v1.36.1",
+        "node\tmissing\t\t",
+        "deno\tpresent\t/usr/local/bin/deno\tdeno 2.2.0",
+        "python\tmissing\t\t",
+        "python3\tpresent\t/usr/bin/python3\tPython 3.11.9",
+        "git\tpresent\t/usr/bin/git\tgit version 2.45.1",
+      ].join("\n"),
+      stderr: "",
+      exitCode: 0,
+    });
+  }
+}
+
+Deno.test("collectHarnessCapabilitySnapshot captures fixed sandbox capabilities", async () => {
+  const snapshot = await collectHarnessCapabilitySnapshot(
+    new FakeSandboxRuntime(),
+    "/workspace",
+    "2026-04-22T23:00:00.000Z",
+  );
+
+  assertEquals(snapshot, {
+    type: "cf-harness.capability-snapshot",
+    at: "2026-04-22T23:00:00.000Z",
+    commands: {
+      bash: {
+        present: true,
+        path: "/bin/bash",
+        version: "GNU bash, version 5.2.26(1)-release",
+      },
+      sh: {
+        present: true,
+        path: "/bin/sh",
+        version: "BusyBox v1.36.1",
+      },
+      node: { present: false },
+      deno: {
+        present: true,
+        path: "/usr/local/bin/deno",
+        version: "deno 2.2.0",
+      },
+      python: { present: false },
+      python3: {
+        present: true,
+        path: "/usr/bin/python3",
+        version: "Python 3.11.9",
+      },
+      git: {
+        present: true,
+        path: "/usr/bin/git",
+        version: "git version 2.45.1",
+      },
+    },
+  });
+});
+
+Deno.test("classifyHarnessPolicyEventFailure records denied tool usage", () => {
+  const failure = classifyHarnessPolicyEventFailure(
+    createHarnessPolicyEvent({
+      severity: "denied",
+      mode: "enforce-explicit",
+      toolId: "write_file",
+      toolCallId: "call-1",
+      detail: "write_file requires direct-command authorization",
+      at: "2026-04-22T23:10:00.000Z",
+    }),
+  );
+
+  assertEquals(failure, {
+    type: "cf-harness.failure-record",
+    kind: "tool_not_allowed",
+    source: "policy_event",
+    detail: "write_file requires direct-command authorization",
+    at: "2026-04-22T23:10:00.000Z",
+    toolId: "write_file",
+    toolCallId: "call-1",
+  });
+});
+
+Deno.test("classifyBashToolFailure uses the capability snapshot to explain missing python", async () => {
+  const snapshot = await collectHarnessCapabilitySnapshot(
+    new FakeSandboxRuntime(),
+    "/workspace",
+    "2026-04-22T23:20:00.000Z",
+  );
+
+  const failure = classifyBashToolFailure(
+    { command: "python script.py" },
+    {
+      outputId: createToolOutputId("run-1", "bash", 1),
+      stdout: "",
+      stderr: "/bin/sh: python: command not found",
+      exitCode: 127,
+      cwd: "/workspace",
+    },
+    "2026-04-22T23:20:01.000Z",
+    snapshot,
+  );
+
+  assertEquals(failure, {
+    type: "cf-harness.failure-record",
+    kind: "missing_binary",
+    source: "tool_output",
+    detail: "python is not available in the sandbox. python3 is available.",
+    at: "2026-04-22T23:20:01.000Z",
+    toolId: "bash",
+    outputId: createToolOutputId("run-1", "bash", 1),
+    command: "python script.py",
+    commandName: "python",
+    exitCode: 127,
+  });
+});
+
+Deno.test("classifyHarnessRunError maps timeouts and path escapes deterministically", () => {
+  assertEquals(
+    classifyHarnessRunError(
+      new ProcessTimeoutError("docker run ...", 5000),
+      {
+        at: "2026-04-22T23:30:00.000Z",
+        toolId: "bash",
+      },
+    ).kind,
+    "timeout",
+  );
+  assertEquals(
+    classifyHarnessRunError(
+      new Error("path escapes workspace root: ../../etc/passwd"),
+      {
+        at: "2026-04-22T23:30:01.000Z",
+        toolId: "read_file",
+      },
+    ).kind,
+    "workspace_path_confusion",
+  );
+});
+
+Deno.test("selectPrimaryHarnessFailure prefers the highest-signal failure kind", () => {
+  const primary = selectPrimaryHarnessFailure([
+    createHarnessFailureRecord({
+      kind: "unknown",
+      source: "run_error",
+      detail: "gateway boom",
+      at: "2026-04-22T23:40:00.000Z",
+    }),
+    createHarnessFailureRecord({
+      kind: "missing_binary",
+      source: "tool_output",
+      detail: "python is not available in the sandbox",
+      at: "2026-04-22T23:40:01.000Z",
+      toolId: "bash",
+    }),
+    createHarnessFailureRecord({
+      kind: "tool_not_allowed",
+      source: "policy_event",
+      detail: "write_file requires direct-command authorization",
+      at: "2026-04-22T23:40:02.000Z",
+      toolId: "write_file",
+    }),
+  ]);
+
+  assertEquals(primary?.kind, "tool_not_allowed");
+});

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { normalize } from "@std/path/posix";
 import { createHarnessPolicyEvent } from "../src/contracts/policy.ts";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
+import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import type { HarnessRunState } from "../src/run-state.ts";
 import type {
@@ -38,6 +39,21 @@ class FakeSandboxRuntime implements SandboxRuntime {
 
   runShell(request: SandboxShellRequest): Promise<SandboxCommandResult> {
     this.shellRequests.push(request);
+    if (request.command.includes(CAPABILITY_PROBE_SENTINEL)) {
+      return Promise.resolve({
+        stdout: [
+          "bash\tpresent\t/bin/bash\tGNU bash, version 5.2.26(1)-release",
+          "sh\tpresent\t/bin/sh\tBusyBox v1.36.1",
+          "node\tmissing\t\t",
+          "deno\tpresent\t/usr/local/bin/deno\tdeno 2.2.0",
+          "python\tmissing\t\t",
+          "python3\tpresent\t/usr/bin/python3\tPython 3.11.9",
+          "git\tpresent\t/usr/bin/git\tgit version 2.45.1",
+        ].join("\n"),
+        stderr: "",
+        exitCode: 0,
+      });
+    }
     if (this.shellError) {
       return Promise.reject(this.shellError);
     }
@@ -64,6 +80,7 @@ Deno.test("CfHarnessEngine builds a default docker-runsc sandbox when given a wo
     currentDir: "/workspace",
     policyEvents: [],
     toolOutputs: [],
+    failureRecords: [],
   });
 });
 
@@ -105,16 +122,26 @@ Deno.test("CfHarnessEngine records tool outputs into run state on success", asyn
     toolId: "bash",
     runId: "run-1",
   });
-  assertEquals(engine.getRunState(), {
-    runId: "run-1",
-    status: "completed",
-    createdAt: "2026-04-15T19:00:00.000Z",
-    updatedAt: "2026-04-15T19:00:05.000Z",
-    cfcEnforcementMode: "observe",
-    currentDir: "/workspace",
-    policyEvents: [],
-    toolOutputs: [first.resultRef, second.resultRef],
-  });
+  assertEquals(engine.getRunState().runId, "run-1");
+  assertEquals(engine.getRunState().status, "completed");
+  assertEquals(engine.getRunState().createdAt, "2026-04-15T19:00:00.000Z");
+  assertEquals(engine.getRunState().updatedAt, "2026-04-15T19:00:05.000Z");
+  assertEquals(engine.getRunState().cfcEnforcementMode, "observe");
+  assertEquals(engine.getRunState().currentDir, "/workspace");
+  assertEquals(engine.getRunState().policyEvents, []);
+  assertEquals(engine.getRunState().toolOutputs, [
+    first.resultRef,
+    second.resultRef,
+  ]);
+  assertEquals(engine.getRunState().failureRecords, []);
+  assertEquals(
+    engine.getRunState().capabilitySnapshot?.commands.python.present,
+    false,
+  );
+  assertEquals(
+    engine.getRunState().capabilitySnapshot?.commands.python3.path,
+    "/usr/bin/python3",
+  );
 });
 
 Deno.test("CfHarnessEngine marks the run as failed when a tool invocation errors", async () => {
@@ -137,16 +164,16 @@ Deno.test("CfHarnessEngine marks the run as failed when a tool invocation errors
     "sandbox boom",
   );
 
-  assertEquals(engine.getRunState(), {
-    runId: "run-fail",
-    status: "failed",
-    createdAt: "2026-04-15T19:10:00.000Z",
-    updatedAt: "2026-04-15T19:10:02.000Z",
-    cfcEnforcementMode: "observe",
-    currentDir: "/workspace",
-    policyEvents: [],
-    toolOutputs: [],
-  });
+  assertEquals(engine.getRunState().runId, "run-fail");
+  assertEquals(engine.getRunState().status, "failed");
+  assertEquals(engine.getRunState().createdAt, "2026-04-15T19:10:00.000Z");
+  assertEquals(engine.getRunState().updatedAt, "2026-04-15T19:10:02.000Z");
+  assertEquals(engine.getRunState().cfcEnforcementMode, "observe");
+  assertEquals(engine.getRunState().currentDir, "/workspace");
+  assertEquals(engine.getRunState().policyEvents, []);
+  assertEquals(engine.getRunState().toolOutputs, []);
+  assertEquals(engine.getRunState().failureRecords?.length, 1);
+  assertEquals(engine.getRunState().primaryFailure?.kind, "unknown");
 });
 
 Deno.test("CfHarnessEngine getRunState returns a deep clone", () => {
@@ -173,6 +200,7 @@ Deno.test("CfHarnessEngine getRunState returns a deep clone", () => {
         runId: "run-clone",
         artifactPath: "/tmp/original.json",
       }],
+      failureRecords: [],
     },
   });
 
@@ -201,6 +229,7 @@ Deno.test("CfHarnessEngine getRunState returns a deep clone", () => {
       runId: "run-clone",
       artifactPath: "/tmp/original.json",
     }],
+    failureRecords: [],
   });
 });
 
@@ -217,6 +246,7 @@ Deno.test("CfHarnessEngine rejects legacy run state snapshots without currentDir
           cfcEnforcementMode: "observe",
           policyEvents: [],
           toolOutputs: [],
+          failureRecords: [],
         } as unknown as HarnessRunState,
       }),
     Error,

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -126,6 +126,8 @@ Deno.test("CfHarnessEngine records tool outputs into run state on success", asyn
   assertEquals(engine.getRunState().status, "completed");
   assertEquals(engine.getRunState().createdAt, "2026-04-15T19:00:00.000Z");
   assertEquals(engine.getRunState().updatedAt, "2026-04-15T19:00:05.000Z");
+  assertEquals(engine.getRunState().endedAt, "2026-04-15T19:00:05.000Z");
+  assertEquals(engine.getRunState().terminalReason, "tool_completed");
   assertEquals(engine.getRunState().cfcEnforcementMode, "observe");
   assertEquals(engine.getRunState().currentDir, "/workspace");
   assertEquals(engine.getRunState().policyEvents, []);
@@ -168,6 +170,8 @@ Deno.test("CfHarnessEngine marks the run as failed when a tool invocation errors
   assertEquals(engine.getRunState().status, "failed");
   assertEquals(engine.getRunState().createdAt, "2026-04-15T19:10:00.000Z");
   assertEquals(engine.getRunState().updatedAt, "2026-04-15T19:10:02.000Z");
+  assertEquals(engine.getRunState().endedAt, "2026-04-15T19:10:02.000Z");
+  assertEquals(engine.getRunState().terminalReason, "tool_error");
   assertEquals(engine.getRunState().cfcEnforcementMode, "observe");
   assertEquals(engine.getRunState().currentDir, "/workspace");
   assertEquals(engine.getRunState().policyEvents, []);
@@ -184,6 +188,8 @@ Deno.test("CfHarnessEngine getRunState returns a deep clone", () => {
       status: "completed",
       createdAt: "2026-04-17T20:10:00.000Z",
       updatedAt: "2026-04-17T20:10:01.000Z",
+      endedAt: "2026-04-17T20:10:01.000Z",
+      terminalReason: "tool_completed",
       cfcEnforcementMode: "observe",
       currentDir: "/workspace",
       policyEvents: [createHarnessPolicyEvent({
@@ -213,6 +219,8 @@ Deno.test("CfHarnessEngine getRunState returns a deep clone", () => {
     status: "completed",
     createdAt: "2026-04-17T20:10:00.000Z",
     updatedAt: "2026-04-17T20:10:01.000Z",
+    endedAt: "2026-04-17T20:10:01.000Z",
+    terminalReason: "tool_completed",
     cfcEnforcementMode: "observe",
     currentDir: "/workspace",
     policyEvents: [createHarnessPolicyEvent({

--- a/packages/cf-harness/test/process-runner.test.ts
+++ b/packages/cf-harness/test/process-runner.test.ts
@@ -1,0 +1,20 @@
+import { assertRejects } from "@std/assert";
+import {
+  DenoProcessRunner,
+  ProcessTimeoutError,
+} from "../src/sandbox/process-runner.ts";
+
+Deno.test("DenoProcessRunner surfaces killed timeout exits as ProcessTimeoutError", async () => {
+  const runner = new DenoProcessRunner();
+
+  await assertRejects(
+    () =>
+      runner.run({
+        command: "/bin/sh",
+        args: ["-lc", "sleep 5"],
+        timeoutMs: 100,
+      }),
+    ProcessTimeoutError,
+    "process timed out after 100ms",
+  );
+});

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { normalize } from "@std/path/posix";
 import type { HarnessArtifactStore } from "../src/artifacts.ts";
+import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
 import type {
@@ -38,6 +39,21 @@ class FakeSandboxRuntime implements SandboxRuntime {
 
   runShell(request: SandboxShellRequest): Promise<SandboxCommandResult> {
     this.shellRequests.push(request);
+    if (request.command.includes(CAPABILITY_PROBE_SENTINEL)) {
+      return Promise.resolve({
+        stdout: [
+          "bash\tpresent\t/bin/bash\tGNU bash, version 5.2.26(1)-release",
+          "sh\tpresent\t/bin/sh\tBusyBox v1.36.1",
+          "node\tmissing\t\t",
+          "deno\tpresent\t/usr/local/bin/deno\tdeno 2.2.0",
+          "python\tmissing\t\t",
+          "python3\tpresent\t/usr/bin/python3\tPython 3.11.9",
+          "git\tpresent\t/usr/bin/git\tgit version 2.45.1",
+        ].join("\n"),
+        stderr: "",
+        exitCode: 0,
+      });
+    }
     if (this.shellError) {
       return Promise.reject(this.shellError);
     }
@@ -62,6 +78,10 @@ class FailingArtifactStore implements HarnessArtifactStore {
 
   persistTranscript(): Promise<string> {
     return Promise.resolve(`${this.runRoot}/transcript.json`);
+  }
+
+  persistCapabilitySnapshot(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/capabilities.json`);
   }
 
   persistToolOutput(): Promise<string> {
@@ -499,8 +519,9 @@ Deno.test("CfHarnessPromptLoop records observe-mode warnings and still executes 
     toolId: "bash",
     toolCallId: "call-observe",
     detail: "bash would require direct-command authorization in enforce modes",
-    at: "2026-04-15T22:30:02.000Z",
+    at: "2026-04-15T22:30:04.000Z",
   }]);
+  assertEquals(result.runState.failureRecords, []);
   assertEquals(
     result.transcript.at(-2),
     {
@@ -606,8 +627,9 @@ Deno.test("CfHarnessPromptLoop returns observation-denied tool content in enforc
       detail:
         "write_file requires direct-command authorization in enforce-explicit",
     },
-    at: "2026-04-15T22:40:02.000Z",
+    at: "2026-04-15T22:40:04.000Z",
   }]);
+  assertEquals(result.runState.primaryFailure?.kind, "tool_not_allowed");
   assertEquals(
     result.transcript.at(-2),
     {
@@ -700,8 +722,9 @@ Deno.test("CfHarnessPromptLoop denies tool calls outside the configured allowlis
       reason: "not-authorized",
       detail: "bash is not allowed in this run",
     },
-    at: "2026-04-16T23:20:02.000Z",
+    at: "2026-04-16T23:20:04.000Z",
   }]);
+  assertEquals(result.runState.primaryFailure?.kind, "tool_not_allowed");
   assertEquals(
     result.transcript.at(-2),
     {

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -156,6 +156,8 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
     "The todo file says hello from file.",
   );
   assertEquals(result.modelTurns, 2);
+  assertEquals(result.runState.endedAt, "2026-04-15T20:00:06.000Z");
+  assertEquals(result.runState.terminalReason, "assistant_completed");
   assertEquals(result.transcript, [
     { role: "system", content: "You are a test harness." },
     { role: "user", content: "Read the todo file and summarize it." },
@@ -345,6 +347,7 @@ Deno.test("CfHarnessPromptLoop fails when the model exceeds the configured turn 
     "prompt loop exceeded max model turns (1)",
   );
   assertEquals(loop.engine.getRunState().status, "failed");
+  assertEquals(loop.engine.getRunState().terminalReason, "max_model_turns");
   assertEquals(loop.engine.getRunState().policyEvents, []);
 });
 


### PR DESCRIPTION
## Summary
- add deterministic per-run capability snapshots and persisted `capabilities.json` artifacts for cf-harness runs
- add normalized high-confidence failure records and primary-failure plumbing for missing binaries, policy denials, timeouts, path confusion, harness errors, and unknown failures
- fix timeout detection in `DenoProcessRunner` so Docker/runsc timeouts that surface as exit 143 are classified as `timeout`

## Validation
- deno test --allow-run packages/cf-harness/test/process-runner.test.ts
- deno test --allow-env --allow-read --allow-write --allow-run packages/cf-harness/test/*.ts
- real Docker/runsc success smoke (`pwd`) with artifact inspection
- real Docker/runsc missing-binary smoke (`python -V`) with `primaryFailure.kind = "missing_binary"`
- real Docker/runsc timeout smoke (`sleep 5`, `timeoutMs: 100`) before and after the timeout fix with `primaryFailure.kind = "timeout"`

## Notes
- The real smoke environment is sparse: `sh` present; `bash`, `node`, `deno`, `python`, `python3`, and `git` absent in the default probe environment.
- This PR intentionally stops at diagnostics and artifact improvements; Loom-side offline review is follow-up work.