### PR TITLE
perf(runner): intern schema at resolveLink exit

### DIFF
--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@commonfabric/utils/types";
 import { getLogger } from "@commonfabric/utils/logger";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { LINK_V1_TAG, type LinkV1Inner } from "./sigil-types.ts";
 import {
   type CellLink,
@@ -197,6 +198,16 @@ export function resolveLink(
   }
 
   const result = { ...link } satisfies NormalizedFullLink;
+
+  // Intern the schema at this single link-resolution exit so downstream
+  // consumers see an identity-canonical, deep-frozen schema reference.
+  // `getSchemaAtPath` (called within the loop above) can emit freshly-
+  // constructed schemas; interning here collapses structurally-equal
+  // outputs to the same `===` reference across calls, letting
+  // identity-based caches downstream hit rather than miss.
+  if (result.schema !== undefined) {
+    result.schema = internSchema(result.schema);
+  }
 
   // Remove overwrite field, i.e. when the last followed link was a write
   // redirect. The idea is that this is a link pointing to the final value, it


### PR DESCRIPTION
## What

Interns `result.schema` at the single `resolveLink` exit point in `packages/runner/src/link-resolution.ts`, guarded by `schema !== undefined`. Downstream consumers of `resolveLink` now receive canonical-identity schemas whose `===` comparisons match across calls, allowing identity-based caches to hit instead of missing on every fresh call.

Single file, +11/-0.

## Why

`resolveLink` calls `getSchemaAtPath` inside its loop, which emits **freshly-constructed** sub-schemas on each traversal — structurally equal but reference-different. Interning at the single resolveLink exit collapses those back to the canonical identity, so J5 hot-path consumers that key on schema identity finally get cache hits for cell-sourced schemas.

This covers the case that construction-site interning can't reach: `getSchemaAtPath` mints schemas in-function, so the only place to catch them on a single well-defined boundary is at `resolveLink`'s exit. Same class of canonicalization-via-interning as the prior `JSONSchema` work in PRs #3348, #3349, and #3355 — just applied at a different pinch point.

Expected impact (per Remy's trace §J5): calendar and related tests that repeatedly resolve the same cell schemas should see residual hash-work drop. No measurement gating; Rosa is on standby for post-merge measurement.

## Context

Remy's upstream trace `coordination/docs/2026-04-22-joinSchema-upstream-trace.md` established the pinch-point analysis. The initial 3-site proposal in `cell.ts` + `traverse.ts` was **reconciled mid-flight** to this single-site `resolveLink` exit after Remy's follow-up sizing surfaced it as the dominant J5 contributor (task #31). Dan's "go for it!" approval opened the landing.

Explicit scope-out:
- **Not** the broader "intern everywhere" cascade — just the J5 pinch point.
- **Not** the original 3-site cell.ts + traverse.ts proposal — superseded by Remy's reconciled verdict.
- Types unchanged; no API surface change.

## Correctness

- Guarded by `schema !== undefined` — no no-op cost when absent.
- `{...link}` spread clones the link record before intern, so interning doesn't mutate the caller's input.
- Boolean schemas route through `internSchema`'s `booleanInterns.true` / `.false` prefab singletons — no special-case branch needed.
- Single exit point in `resolveLink`; verified via function-structure check.
- Shallow-spread-freeze-side-effect is safe per Flux's review: `NormalizedFullLink.schema` typing + project convention that link records are treated as transient-by-construction + zero identity-assertion greps across the codebase.

## Validation

fmt / lint / type-check clean. Runner tests 398/2766 pass. HTML tests 27/200 pass. Memory tests 122/152 pass. Flux approved one-pass.

Related work:
- PR #3348 — A.edit1, cfc subSchema interning safety fix (merged).
- PR #3349 — E, `schemaHasIfc` memo (merged).
- PR #3355 — JSON.stringify sibling sweep at cfc.ts:71 (merged).
- PR #3235 — `feat: enable modernSchemaHash by default` (the target; still open).
- PR #3324 — `danfuzz/because-im-easy-come-easy-go` (legacy-hash SHA256 normalization).

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
