### PR TITLE
perf(runner): intern subsumes-local spreads for cross-call standardizedSchemaCache hits

### DIFF
--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -40,7 +40,6 @@ import { hashSchema, internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   REJECTING_SELECTOR,
   schemaWithProperties,
-  toDeepFrozenSchema,
 } from "@commonfabric/data-model/schema-utils";
 import { BaseMemoryAddress, MapSetStringToStrings } from "../traverse.ts";
 import { getJSONFromDataURI } from "../uri-utils.ts";
@@ -488,22 +487,20 @@ export class SelectorTracker<T = Result<Unit, Error>> {
             newSchemaObj && sortedSubSchemaObj &&
             newSchemaRefs.size == 0
           ) {
-            // `{ ...x }` produces fresh (non-frozen) objects, but
-            // `getStandardSchema` only populates its cache for
-            // deep-frozen inputs. Freeze these locally-owned spreads
-            // in place (`canShare: true`) so repeat calls across
-            // reactive updates hit the cache instead of re-traversing.
+            // `{ ...x }` produces fresh (non-frozen) objects that would
+            // miss `getStandardSchema`'s `isDeepFrozen`-gated cache on
+            // every call. Intern the spreads so structurally-equal
+            // variants collapse to the same canonical reference across
+            // reactive updates — `internSchema` deep-freezes in place
+            // (via `toDeepFrozenSchema(_, true)`) and then returns the
+            // canonical entry from the intern cache, so the downstream
+            // `standardizedSchemaCache` identity-key actually hits on
+            // repeat calls with structurally-equal inputs.
             const { $defs: _defs1, ...newSchemaNoDefsSpread } = newSchemaObj;
             const { $defs: _defs2, ...subSchemaNoDefsSpread } =
               sortedSubSchemaObj;
-            const newSchemaNoDefs = toDeepFrozenSchema(
-              newSchemaNoDefsSpread,
-              true,
-            );
-            const subSchemaNoDefs = toDeepFrozenSchema(
-              subSchemaNoDefsSpread,
-              true,
-            );
+            const newSchemaNoDefs = internSchema(newSchemaNoDefsSpread);
+            const subSchemaNoDefs = internSchema(subSchemaNoDefsSpread);
             if (
               hashSchema(
                 SelectorTracker.getStandardSchema(subSchemaNoDefs),

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -40,6 +40,7 @@ import { hashSchema, internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   REJECTING_SELECTOR,
   schemaWithProperties,
+  toDeepFrozenSchema,
 } from "@commonfabric/data-model/schema-utils";
 import { BaseMemoryAddress, MapSetStringToStrings } from "../traverse.ts";
 import { getJSONFromDataURI } from "../uri-utils.ts";
@@ -487,8 +488,22 @@ export class SelectorTracker<T = Result<Unit, Error>> {
             newSchemaObj && sortedSubSchemaObj &&
             newSchemaRefs.size == 0
           ) {
-            const { $defs: _defs1, ...newSchemaNoDefs } = newSchemaObj;
-            const { $defs: _defs2, ...subSchemaNoDefs } = sortedSubSchemaObj;
+            // `{ ...x }` produces fresh (non-frozen) objects, but
+            // `getStandardSchema` only populates its cache for
+            // deep-frozen inputs. Freeze these locally-owned spreads
+            // in place (`canShare: true`) so repeat calls across
+            // reactive updates hit the cache instead of re-traversing.
+            const { $defs: _defs1, ...newSchemaNoDefsSpread } = newSchemaObj;
+            const { $defs: _defs2, ...subSchemaNoDefsSpread } =
+              sortedSubSchemaObj;
+            const newSchemaNoDefs = toDeepFrozenSchema(
+              newSchemaNoDefsSpread,
+              true,
+            );
+            const subSchemaNoDefs = toDeepFrozenSchema(
+              subSchemaNoDefsSpread,
+              true,
+            );
             if (
               hashSchema(
                 SelectorTracker.getStandardSchema(subSchemaNoDefs),


### PR DESCRIPTION
## What

Interns two locally-owned spread objects in `SelectorTracker.subsumes` (`packages/runner/src/storage/cache.ts`) before they're handed to `getStandardSchema`. Spreads are wrapped in `internSchema(spread)` at construction, collapsing structurally-equal spreads across calls to the same canonical `===` reference.

1 file, +14/-2.

## Why

`SelectorTracker.subsumes` constructs **fresh spread objects on every subsumes-check**. `getStandardSchema`'s `standardizedSchemaCache` is keyed on schema **identity** (WeakMap on the object reference), so a fresh spread each call produces a new key — each subsumes-check populates a cache slot that's then orphaned for the next call with a structurally-equal-but-reference-different spread.

`internSchema` returns the canonical reference for any structurally-equal schema, which is exactly what cross-call cache hits require: two subsumes-checks on the same schema shape now hand `getStandardSchema` the **same** object reference, and the `standardizedSchemaCache` hits instead of mints-and-orphans.

This is the mechanism Flux called out in Note 1 on the prior revision — the cache needs identity-canonical collapse, not just deep-frozen inputs. Earlier revision used `toDeepFrozenSchema(spread, true)`, which made the spread cacheable but didn't give it a canonical identity across calls. `internSchema` does both (it internally deep-freezes and then dedups to canonical).

`subsumes` fires on every reactive subscription update, so the per-call cache miss is paid per-reactive-update on every subscription-heavy path. Same class of cache-defeat as **DEFEAT-1 / -3 / -4** in the 2026-04-16 cache audit, and matches Remy's §4 Candidate B in the reading-list residual follow-up — cross-shape uniformity of the 8-test cluster's +15-29% regression is consistent with a per-call cost that doesn't depend on schema complexity.

## Correctness

- Both spread objects are **locally owned** inside the `else` branch — no external references.
- `internSchema` returns a deep-frozen canonical reference. Safe because:
  - the spreads were never shared before this call,
  - canonicalization doesn't mutate input,
  - downstream `getStandardSchema` already expects deep-frozen inputs (its `isDeepFrozen`-gated cache path).
- `internSchema` is generic-preserving — no type churn at the call sites.
- No caller-contract change; `subsumes` still returns the same sense of "did I already have a superset for this?".

Revision history on this branch:
- `bcbe8476b` — used `toDeepFrozenSchema(spread, true)`. Made spreads cacheable but not canonical; Dan asked why this vs intern. No good answer.
- `47d2d55a6` (current) — swaps to `internSchema(spread)` for canonical-reference collapse. Dropped the now-unused `toDeepFrozenSchema` import. Net −3 lines.

Validation at current tip: `deno fmt --check`, `deno lint`, `deno check` all clean; runner 398/2767 pass.

## Scope

- Single file, single function. No broader `storage/cache.ts` refactoring bundled.
- `stableHash()` untouched per Dan's standing rule.
- No API-surface change.

## Context

Session-close tactical round. Task #33 per `coordination/tasks.md`. Based on Remy's residual-analysis follow-up §4 Candidate B; ranks above retired B2 (isInternedSchema short-circuit at resolveLink — retired as no-cost-win) and B3 (normalizeSyncSelector identity-safety — retired via caller-identity grep).

Related work this session:
- PR #3348 — A.edit1, cfc subSchema interning safety fix (merged).
- PR #3349 — E, `schemaHasIfc` memo (merged).
- PR #3355 — JSON.stringify sibling sweep at cfc.ts:71 (merged).
- PR #3356 — resolveLink-exit intern (merged).
- PR #3235 — `feat: enable modernSchemaHash by default` (the target; still open with Rosa Part 10 pending).
- PR #3324 — `danfuzz/because-im-easy-come-easy-go` (legacy-hash SHA256 normalization).

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
