### PR TITLE
fix(runner): dedup llm tool-list change-detection by interned-schema identity

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -18,6 +18,7 @@ import {
   isNontrivialSchema,
   toDeepFrozenSchema,
 } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   LLMMessageSchema,
   LLMParamsSchema,
@@ -961,13 +962,20 @@ function _toolsHaveChanged(
     // Compare description
     if (newTool.description !== oldTool.description) return true;
 
-    // Compare inputSchema (safe to stringify as it's a JSON Schema)
+    // Compare inputSchema via interned-schema identity. `internSchema()`
+    // returns the canonical reference, so structurally-equal schemas
+    // collapse to `===`. Handles non-JSON-compatible `FabricValue`s in
+    // schema `default` fields correctly, unlike plain `JSON.stringify`
+    // (which silently mis-encodes them and could hide real changes).
     try {
-      const newSchema = JSON.stringify(newTool.inputSchema);
-      const oldSchema = JSON.stringify(oldTool.inputSchema);
-      if (newSchema !== oldSchema) return true;
+      if (
+        internSchema(newTool.inputSchema) !== internSchema(oldTool.inputSchema)
+      ) {
+        return true;
+      }
     } catch {
-      // If schema has circular refs (unlikely), consider it changed
+      // Defensive: preserve the prior try/catch shape in case of
+      // unexpected input. Treat any failure as "changed."
       return true;
     }
 


### PR DESCRIPTION
## What

Fixes the LLM tool-list change-detection dedup in `packages/runner/src/builtins/llm-dialog.ts` (at lines 966 and 967) to use **interned-schema identity** instead of `JSON.stringify(schema)`:

- Both sites swap `JSON.stringify(schema)` → `internSchema(schema)` for dedup identity.
- Keeps the surrounding `try/catch` semantics at lines 965-972 (project-convention guard).

1 file, +13/-5.

## Why

`JSON.stringify(schema)` silently mis-encodes schemas whose `default` fields contain non-JSON-compatible `FabricValue` instances (e.g., `FabricEpochNsec`, `FabricBytes`, `FabricHash`). In the LLM tool-list change-detection path that means tool schemas can be wrongly treated as unchanged-when-different or different-when-unchanged, affecting the "when does the tool list visibly change for the LLM" decision. `internSchema` returns the canonical identity for any structurally-equal schema, giving correct dedup regardless of `FabricValue` serialization quirks.

Same class of latent correctness bug as:
- **PR #3348** (A.edit1, cfc subSchema interning).
- **PR #3355** (JSON.stringify sibling sweep at cfc.ts:71, `joinSchema` cycle tracker).
- **PR #3357** (A1, `SelectorTracker.subsumes` spreads).

Safety-first framing: this PR is about correctness; any perf improvement is incidental. No measurement gating.

## Sweep audit trail (narrow slice)

Colt's sweep PR 1 is deliberately narrow — covers 2 of the 5 HIGH dedup-key sites identified in Remy's comprehensive `JSON.stringify(schema)` antipattern audit:

- **`llm-dialog.ts:966`, `llm-dialog.ts:967`** — LLM tool-list change-detection dedup. **In scope; fixed by this PR.**
- **2 schema-generator sites** (`packages/schema-generator/…`) — deferred. Pulling `@commonfabric/data-model/schema-hash` into schema-generator's strict tsconfig surfaces 15 pre-existing transitive-dep type errors in `content-hash` / `data-model` / `leb128` / `utils`. Resolving those needs a separate prep PR; not bundled here.
- **`llm-dialog.ts:909`** — explicitly **excluded**. Per Cedar's earlier finding, `normalizeSchemaForComparison(schema)` at that site produces output that is not JSONSchema-shaped (it's a deliberately-lossy comparison form), so `internSchema` would be an incorrect fit. Site is a dedup-key-adjacent context that warrants `JSON.stringify`.

Standing guardrail: `stableHash()` stays untouched until both hash flags are fully on. PR #3348's A.edit1 anyOf/oneOf sites, PR #3355's `joinSchema` cycle tracker, and PR #3357's `SelectorTracker.subsumes` spreads are already covered by prior PRs; not re-touched.

## Validation

`deno fmt --check`, `deno lint`, `deno check` all clean on the touched files. Runner tests 398/2767 pass. Flux reviewing concurrently.

## Context

Diagnosis: Remy's comprehensive `JSON.stringify(schema)` antipattern audit (coordination docs, 2026-04-22). Dan's session-close decisions approved landing the narrow 2-site slice as PR 1 and deferring the schema-generator sites to a separate prep-PR-first track.

Related PRs (merged this session):
- PR #3348 — A.edit1, cfc subSchema interning safety fix.
- PR #3349 — E, `schemaHasIfc` memo.
- PR #3355 — JSON.stringify sibling sweep at cfc.ts:71.
- PR #3356 — resolveLink-exit intern.
- PR #3357 — A1, `SelectorTracker.subsumes` spread intern.

Open related:
- PR #3235 — `feat: enable modernSchemaHash by default` (the target; still open).
- PR #3324 — `danfuzz/because-im-easy-come-easy-go` (legacy-hash SHA256 normalization).

Co-Authored-By: coder-colt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
