### PR TITLE
cf-harness: default sandbox runs to the public kitchen-sink image

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -26,6 +26,9 @@ The current design direction is:
 What works today:
 
 - shell-centric execution against the local `runsc-cfc` sandbox path
+- default sandbox image aligned with the public CFC kitchen-sink image published
+  from the sibling `gvisor` repo:
+  - `us-docker.pkg.dev/commontools-core/common-fabric/sandbox-kitchensink:latest`
 - built-in tools:
   - `bash`
   - `read_file`
@@ -130,6 +133,8 @@ deno task test:integration
 ```
 
 The integration suite requires a working local Docker + `runsc-cfc` environment.
+By default it also uses the published kitchen-sink image above, unless you
+override `CF_HARNESS_INTEGRATION_IMAGE`.
 
 ## Related Docs
 

--- a/packages/cf-harness/integration/engine.integration.test.ts
+++ b/packages/cf-harness/integration/engine.integration.test.ts
@@ -1,12 +1,15 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { CfHarnessEngine } from "../src/engine.ts";
-import { resolveDockerRunscSandboxConfig } from "../src/sandbox/docker-runsc.ts";
+import {
+  DEFAULT_DOCKER_RUNSC_IMAGE,
+  resolveDockerRunscSandboxConfig,
+} from "../src/sandbox/docker-runsc.ts";
 
 const INTEGRATION = Deno.env.get("CF_HARNESS_INTEGRATION") === "1";
 const DOCKER_RUNTIME = Deno.env.get("CF_HARNESS_INTEGRATION_RUNTIME") ??
   "runsc-cfc";
 const DOCKER_IMAGE = Deno.env.get("CF_HARNESS_INTEGRATION_IMAGE") ??
-  "alpine:3.20";
+  DEFAULT_DOCKER_RUNSC_IMAGE;
 
 const assertRunscRuntimeAvailable = async () => {
   const result = await new Deno.Command("docker", {

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -17,17 +17,23 @@ export const DEFAULT_WORKSPACE_MOUNT_PATH = "/workspace";
 export const DEFAULT_SANDBOX_SHELL = "/bin/sh";
 export const DEFAULT_DOCKER_NETWORK_MODE = "none" as const;
 
+const readEnvVar = (name: string): string | undefined => {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    return undefined;
+  }
+};
+
 const resolveDefaultContainerUser = (): string | undefined => {
   if (Deno.build.os === "windows") {
     return undefined;
   }
-  try {
-    const uidFromEnv = Deno.env.get("UID");
-    const gidFromEnv = Deno.env.get("GID");
-    if (uidFromEnv !== undefined && gidFromEnv !== undefined) {
-      return `${uidFromEnv}:${gidFromEnv}`;
-    }
-  } catch {}
+  const uidFromEnv = readEnvVar("UID");
+  const gidFromEnv = readEnvVar("GID");
+  if (uidFromEnv !== undefined && gidFromEnv !== undefined) {
+    return `${uidFromEnv}:${gidFromEnv}`;
+  }
   try {
     const uid = Deno.uid();
     const gid = Deno.gid();

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -9,12 +9,54 @@ import type {
   SandboxShellRequest,
 } from "./types.ts";
 
-export const DEFAULT_DOCKER_RUNSC_IMAGE = "alpine:3.20";
+export const DEFAULT_DOCKER_RUNSC_IMAGE =
+  "us-docker.pkg.dev/commontools-core/common-fabric/sandbox-kitchensink:latest";
 export const DEFAULT_DOCKER_RUNTIME_NAME = "runsc-cfc";
 export const DEFAULT_DOCKER_BINARY = "docker";
 export const DEFAULT_WORKSPACE_MOUNT_PATH = "/workspace";
 export const DEFAULT_SANDBOX_SHELL = "/bin/sh";
 export const DEFAULT_DOCKER_NETWORK_MODE = "none" as const;
+
+const resolveDefaultContainerUser = (): string | undefined => {
+  if (Deno.build.os === "windows") {
+    return undefined;
+  }
+  try {
+    const uidFromEnv = Deno.env.get("UID");
+    const gidFromEnv = Deno.env.get("GID");
+    if (uidFromEnv !== undefined && gidFromEnv !== undefined) {
+      return `${uidFromEnv}:${gidFromEnv}`;
+    }
+  } catch {}
+  try {
+    const uid = Deno.uid();
+    const gid = Deno.gid();
+    return `${uid}:${gid}`;
+  } catch {
+    try {
+      const uidResult = new Deno.Command("id", {
+        args: ["-u"],
+        stdout: "piped",
+        stderr: "null",
+      }).outputSync();
+      const gidResult = new Deno.Command("id", {
+        args: ["-g"],
+        stdout: "piped",
+        stderr: "null",
+      }).outputSync();
+      if (uidResult.success && gidResult.success) {
+        const uid = new TextDecoder().decode(uidResult.stdout).trim();
+        const gid = new TextDecoder().decode(gidResult.stdout).trim();
+        if (uid.length > 0 && gid.length > 0) {
+          return `${uid}:${gid}`;
+        }
+      }
+    } catch {
+      return undefined;
+    }
+    return undefined;
+  }
+};
 
 const normalizeWorkspacePath = (path: string): string => {
   const normalized = normalize(path);
@@ -32,18 +74,22 @@ const isWithinRoot = (root: string, path: string): boolean => {
 
 export const resolveDockerRunscSandboxConfig = (
   options: ResolveDockerRunscSandboxConfigOptions,
-): DockerRunscSandboxConfig => ({
-  kind: "docker-runsc-cfc",
-  dockerBinary: options.dockerBinary ?? DEFAULT_DOCKER_BINARY,
-  runtimeName: options.runtimeName ?? DEFAULT_DOCKER_RUNTIME_NAME,
-  image: options.image ?? DEFAULT_DOCKER_RUNSC_IMAGE,
-  workspaceHostPath: options.workspaceHostPath,
-  workspaceMountPath: options.workspaceMountPath ??
-    DEFAULT_WORKSPACE_MOUNT_PATH,
-  shellPath: options.shellPath ?? DEFAULT_SANDBOX_SHELL,
-  dockerNetworkMode: options.dockerNetworkMode ?? DEFAULT_DOCKER_NETWORK_MODE,
-  extraDockerArgs: options.extraDockerArgs ?? [],
-});
+): DockerRunscSandboxConfig => {
+  const containerUser = options.containerUser ?? resolveDefaultContainerUser();
+  return {
+    kind: "docker-runsc-cfc",
+    dockerBinary: options.dockerBinary ?? DEFAULT_DOCKER_BINARY,
+    runtimeName: options.runtimeName ?? DEFAULT_DOCKER_RUNTIME_NAME,
+    image: options.image ?? DEFAULT_DOCKER_RUNSC_IMAGE,
+    ...(containerUser !== undefined ? { containerUser } : {}),
+    workspaceHostPath: options.workspaceHostPath,
+    workspaceMountPath: options.workspaceMountPath ??
+      DEFAULT_WORKSPACE_MOUNT_PATH,
+    shellPath: options.shellPath ?? DEFAULT_SANDBOX_SHELL,
+    dockerNetworkMode: options.dockerNetworkMode ?? DEFAULT_DOCKER_NETWORK_MODE,
+    extraDockerArgs: options.extraDockerArgs ?? [],
+  };
+};
 
 export class DockerRunscSandboxRuntime implements SandboxRuntime {
   readonly kind = "docker-runsc-cfc" as const;
@@ -80,6 +126,9 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
       this.config.runtimeName,
       "--network",
       this.config.dockerNetworkMode,
+      ...(this.config.containerUser !== undefined
+        ? ["--user", this.config.containerUser]
+        : []),
       "--mount",
       `type=bind,src=${this.config.workspaceHostPath},dst=${this.config.workspaceMountPath}`,
       "-w",

--- a/packages/cf-harness/src/sandbox/types.ts
+++ b/packages/cf-harness/src/sandbox/types.ts
@@ -7,6 +7,7 @@ export interface DockerRunscSandboxConfig {
   dockerBinary: string;
   runtimeName: string;
   image: string;
+  containerUser?: string;
   workspaceHostPath: string;
   workspaceMountPath: string;
   shellPath: string;
@@ -20,6 +21,7 @@ export interface ResolveDockerRunscSandboxConfigOptions {
   dockerBinary?: string;
   runtimeName?: string;
   image?: string;
+  containerUser?: string;
   workspaceHostPath: string;
   workspaceMountPath?: string;
   shellPath?: string;

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -44,11 +44,12 @@ Deno.test("DockerRunscSandboxRuntime builds a docker run invocation", async () =
     stderr: "",
     exitCode: 0,
   });
+  const config = resolveDockerRunscSandboxConfig({
+    workspaceHostPath: "/host/project",
+    image: "sandbox:latest",
+  });
   const runtime = new DockerRunscSandboxRuntime(
-    resolveDockerRunscSandboxConfig({
-      workspaceHostPath: "/host/project",
-      image: "sandbox:latest",
-    }),
+    config,
     runner,
   );
 
@@ -71,6 +72,9 @@ Deno.test("DockerRunscSandboxRuntime builds a docker run invocation", async () =
       "runsc-cfc",
       "--network",
       "none",
+      ...(config.containerUser !== undefined
+        ? ["--user", config.containerUser]
+        : []),
       "--mount",
       "type=bind,src=/host/project,dst=/workspace",
       "-w",

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import {
+  DEFAULT_DOCKER_RUNSC_IMAGE,
   DockerRunscSandboxRuntime,
   resolveDockerRunscSandboxConfig,
 } from "../src/sandbox/docker-runsc.ts";
@@ -27,7 +28,10 @@ Deno.test("resolveDockerRunscSandboxConfig fills the expected defaults", () => {
   assertEquals(config.kind, "docker-runsc-cfc");
   assertEquals(config.dockerBinary, "docker");
   assertEquals(config.runtimeName, "runsc-cfc");
-  assertEquals(config.image, "alpine:3.20");
+  assertEquals(
+    config.image,
+    "us-docker.pkg.dev/commontools-core/common-fabric/sandbox-kitchensink:latest",
+  );
   assertEquals(config.workspaceMountPath, "/workspace");
   assertEquals(config.shellPath, "/bin/sh");
   assertEquals(config.dockerNetworkMode, "none");
@@ -80,7 +84,7 @@ Deno.test("DockerRunscSandboxRuntime builds a docker run invocation", async () =
   });
 });
 
-Deno.test("DockerRunscSandboxRuntime runShell uses the configured shell and resolved cwd", async () => {
+Deno.test("DockerRunscSandboxRuntime runShell honors an explicit container user override", async () => {
   const runner = new FakeProcessRunner({
     stdout: "",
     stderr: "",
@@ -89,6 +93,7 @@ Deno.test("DockerRunscSandboxRuntime runShell uses the configured shell and reso
   const runtime = new DockerRunscSandboxRuntime(
     resolveDockerRunscSandboxConfig({
       workspaceHostPath: "/host/project",
+      containerUser: "1234:2345",
     }),
     runner,
   );
@@ -108,11 +113,13 @@ Deno.test("DockerRunscSandboxRuntime runShell uses the configured shell and reso
       "runsc-cfc",
       "--network",
       "none",
+      "--user",
+      "1234:2345",
       "--mount",
       "type=bind,src=/host/project,dst=/workspace",
       "-w",
       "/workspace/demo",
-      "alpine:3.20",
+      DEFAULT_DOCKER_RUNSC_IMAGE,
       "/bin/sh",
       "-lc",
       "pwd",


### PR DESCRIPTION
## Summary
- default `cf-harness` sandbox runs to `us-docker.pkg.dev/commontools-core/common-fabric/sandbox-kitchensink:latest`
- preserve host ownership for bind-mounted workspace writes by running the sandbox as the calling user's UID:GID
- document the new default image and the `CF_HARNESS_INTEGRATION_IMAGE` override

## Validation
- `deno test packages/cf-harness/test/docker-runsc-sandbox.test.ts packages/cf-harness/test/config.test.ts packages/cf-harness/test/engine.test.ts`
- `deno check packages/cf-harness/src/sandbox/docker-runsc.ts packages/cf-harness/src/sandbox/types.ts packages/cf-harness/integration/engine.integration.test.ts`
- `CF_HARNESS_INTEGRATION=1 deno test --allow-env --allow-read --allow-run --allow-write packages/cf-harness/integration/engine.integration.test.ts`

## Environment report
This report was captured by invoking the agent with:

```bash
deno task run -- \
  --workspace /tmp/cf-harness-manual-workspace \
  --artifact-root /tmp/cf-harness-artifacts \
  --allow-tool read_file \
  --allow-tool write_file \
  --allow-tool bash \
  --stream-events \
  --print-transcript \
  --max-model-turns 8 \
  --prompt "explore the container we are running in and tell me what packages and development tools are available.  store the result in an appropriate file in /workspace"
```

# Container Environment Report

Generated from direct inspection of the running container and `/workspace`.

## Summary
This container is running **Alpine Linux 3.20** and includes a solid set of development tools for **Python, Node.js, Deno, Go, Rust, C/C++**, plus common CLI utilities.

## Base OS
- Name: Alpine Linux
- Version: 3.20.9
- Pretty name: Alpine Linux v3.20

## Available shells
- `sh` → `/bin/sh`
- `bash` → `/bin/bash`
- `zsh` → `/bin/zsh`

## Languages and package managers
- Python: `python`, `python3` available
  - Version: **Python 3.12.12**
- Pip: `pip`, `pip3` available
  - Installed package: `py3-pip 24.0-r2`
- Node.js: `node` available
  - Version: **v20.15.1**
  - Installed package: `nodejs 20.15.1-r0`
- npm: `npm` available
  - Version: **10.9.1**
  - Installed package: `npm 10.9.1-r0`
- Deno: `deno` available
  - Installed package: `deno 1.43.5-r0`
- Go: `go` available
  - Version: **go1.22.10**
  - Installed package: `go 1.22.10-r0`
- Rust toolchain:
  - `rustc` version: **1.78.0**
  - `cargo` version: **1.78.0**
  - Installed packages: `rust 1.78.0-r1`, `cargo 1.78.0-r1`

## Compilers and build tools
- GCC: `gcc`
  - Version: **13.2.1**
- G++: `g++`
  - Installed package: `g++ 13.2.1_git20240309-r1`
- Clang: `clang`
  - Version: **17.0.6**
- Make: `make`
  - Installed package: `make 4.4.1-r2`
- CMake: `cmake`
  - Version: **3.29.3**
  - Installed package: `cmake 3.29.3-r0`

## Source control and developer utilities
- Git: `git`
  - Version: **2.45.4**
  - Installed packages: `git 2.45.4-r0`, `git-lfs 3.5.1-r4`
- SQLite CLI: `sqlite3`
  - Version: **3.45.3**
  - Installed package: `sqlite 3.45.3-r3`
- JSON/YAML tools:
  - `jq` version **1.7.1**
  - `yq` available (`yq-go 4.44.1-r2`)
- Terminal/editor tools:
  - `tmux` available (`3.4-r1`)
  - `vim` available (`9.1.0707-r0`)

## Not found during inspection
These common tools were checked but not found in `PATH`:
- `java`, `javac`
- `mvn`, `gradle`
- `yarn`, `pnpm`, `bun`
- `docker`, `podman`
- `kubectl`, `terraform`, `ansible`
- `psql`, `mysql`, `redis-server`, `redis-cli`
- `ninja`, `neovim`, `emacs`, `code`

## Notes
- This is an **Alpine** environment, so `dpkg`/APT are not used; package inspection is via `apk`.
- `/workspace` did not contain project manifest files such as `README.md`, `package.json`, or `pyproject.toml` at the top level.
- There was already an `ENVIRONMENT_REPORT.md` in `/workspace`; it has been replaced with this updated inventory based on the actual container state.