### PR TITLE
Change global / module schema constant definitions to use `internSchema()`.

### DIFF
--- a/packages/data-model/schema-hash.ts
+++ b/packages/data-model/schema-hash.ts
@@ -254,20 +254,20 @@ function internSchemaReturningSchemaAndHash(schema: JSONSchema): SchemaAndHash {
  * shallow-cloned as mutable, for the express purpose of tactical modification
  * and then immediately treated once again as deep-immutable.
  */
-export function internSchema(
-  schema: JSONSchema,
+export function internSchema<T extends JSONSchema>(
+  schema: T,
   wantSchemaAndHash?: false,
-): JSONSchema;
-export function internSchema(
-  schema: JSONSchema,
+): T;
+export function internSchema<T extends JSONSchema>(
+  schema: T,
   wantSchemaAndHash: true,
 ): SchemaAndHash;
-export function internSchema(
-  schema: JSONSchema,
+export function internSchema<T extends JSONSchema>(
+  schema: T,
   wantSchemaAndHash?: boolean,
 ): JSONSchema | SchemaAndHash;
-export function internSchema(
-  schema: JSONSchema,
+export function internSchema<T extends JSONSchema>(
+  schema: T,
   wantSchemaAndHash: boolean = false,
 ): JSONSchema | SchemaAndHash {
   const sahResult = internSchemaReturningSchemaAndHash(schema);

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -77,6 +77,10 @@ export function isNontrivialSchema(
  *
  * Boolean schemas (`true` / `false`) are primitives and therefore already
  * immutable — they are returned as-is regardless of `canShare`.
+ *
+ * Note: Use `internSchema()` in preference to this function, which can cost a
+ * little more to run but which will save both time and memory when the schema
+ * in question is reused.
  */
 export function toDeepFrozenSchema<T extends JSONSchema>(
   schema: T,

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -17,7 +17,7 @@ import {
   TYPE,
   URI,
 } from "@commonfabric/runner";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { type Session } from "@commonfabric/identity";
 import { isRecord } from "@commonfabric/utils/types";
 import { ensureNotRenderThread } from "@commonfabric/utils/env";
@@ -30,7 +30,7 @@ import {
 } from "@commonfabric/runner/schemas";
 ensureNotRenderThread();
 
-const PRIVILEGED_PIECE_LIST_SCHEMA = toDeepFrozenSchema({
+const PRIVILEGED_PIECE_LIST_SCHEMA = internSchema({
   ...pieceListSchema,
   ifc: { confidentiality: [cfcAtom.resource("PrivilegedPieceList")] },
 });

--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -1,5 +1,5 @@
 import { BuiltInLLMDialogState } from "@commonfabric/api";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { createNodeFactory, lift } from "./module.ts";
 import { pattern } from "./pattern.ts";
 import { isPattern } from "./types.ts";
@@ -32,7 +32,7 @@ import type {
 import { isRecord } from "@commonfabric/utils/types";
 import { isCell } from "../cell.ts";
 
-const WISH_ARGUMENT_SCHEMA = toDeepFrozenSchema({
+const WISH_ARGUMENT_SCHEMA = internSchema({
   type: "object",
   properties: {
     query: { type: "string" },

--- a/packages/runner/src/builder/schema-lib.ts
+++ b/packages/runner/src/builder/schema-lib.ts
@@ -1,10 +1,10 @@
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { cfcAtom } from "../cfc/atoms.ts";
 
 const credentialSecretAtom = cfcAtom.resource("CredentialSecret");
 
 // This is used by the various Google tokens created with tokenToAuthData
-export const AuthSchema = toDeepFrozenSchema(
+export const AuthSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -32,11 +32,10 @@ export const AuthSchema = toDeepFrozenSchema(
       },
     },
   },
-  true,
 );
 
 // More general OAuth2 Token (used by Airtable and future OAuth2 providers)
-export const OAuth2TokenSchema = toDeepFrozenSchema(
+export const OAuth2TokenSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -65,11 +64,10 @@ export const OAuth2TokenSchema = toDeepFrozenSchema(
     },
     required: ["accessToken", "tokenType"],
   },
-  true,
 );
 
 // Webhook confidential config: URL and bearer token written by toolshed
-export const WebhookConfigSchema = toDeepFrozenSchema(
+export const WebhookConfigSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -86,5 +84,4 @@ export const WebhookConfigSchema = toDeepFrozenSchema(
     },
     required: ["url", "secret"],
   },
-  true,
 );

--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -4,7 +4,7 @@ import type { Runtime } from "../runtime.ts";
 import { getPatternEnvironment } from "../builder/env.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import type { Schema } from "../builder/types.ts";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
 import {
@@ -26,7 +26,7 @@ type FetchDataInputs = {
  * which is `any`) lets cell.asSchema(schema).get() materialize nested
  * properties like options.headers as plain objects instead of proxies.
  */
-const fetchDataInputSchema = toDeepFrozenSchema(
+const fetchDataInputSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -45,7 +45,6 @@ const fetchDataInputSchema = toDeepFrozenSchema(
       },
     },
   },
-  true,
 );
 
 function snapshotFetchDataInputs(

--- a/packages/runner/src/builtins/fetch-program.ts
+++ b/packages/runner/src/builtins/fetch-program.ts
@@ -2,7 +2,7 @@ import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
 import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { HttpProgramResolver } from "@commonfabric/js-compiler";
 import { resolveProgram, TARGET } from "@commonfabric/js-compiler/typescript";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
@@ -29,14 +29,13 @@ interface FetchCacheEntry {
   state: FetchState;
 }
 
-const fetchProgramInputSchema = toDeepFrozenSchema(
+const fetchProgramInputSchema = internSchema(
   {
     type: "object",
     properties: {
       url: { type: "string" },
     },
   },
-  true,
 );
 
 function snapshotFetchProgramInputs(
@@ -50,7 +49,7 @@ function snapshotFetchProgramInputs(
 // Full schema for cache structure to ensure proper validation when reading back
 // from storage. Without this, nested arrays may have undefined elements due to
 // incomplete schema-based transformation.
-const cacheSchema = toDeepFrozenSchema(
+const cacheSchema = internSchema(
   {
     type: "object",
     default: {},
@@ -105,7 +104,6 @@ const cacheSchema = toDeepFrozenSchema(
       },
     },
   },
-  true,
 );
 
 /**

--- a/packages/runner/src/builtins/fetch-utils.ts
+++ b/packages/runner/src/builtins/fetch-utils.ts
@@ -4,11 +4,11 @@ import { type Cell } from "../cell.ts";
 import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import type { Schema } from "../builder/types.ts";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 
 export const REQUEST_TIMEOUT = 1000 * 5; // 5 seconds
 
-export const internalSchema = toDeepFrozenSchema(
+export const internalSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -19,7 +19,6 @@ export const internalSchema = toDeepFrozenSchema(
     default: {},
     required: ["requestId", "lastActivity", "inputHash"],
   },
-  true,
 );
 
 /**

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -1,7 +1,7 @@
 import type { Pattern } from "../builder/types.ts";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 
-const FILTER_INPUT_SCHEMA = toDeepFrozenSchema({
+const FILTER_INPUT_SCHEMA = internSchema({
   type: "object",
   properties: {
     list: { type: "array", items: { asCell: ["cell"], type: "unknown" } },

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -1,7 +1,7 @@
 import type { Pattern } from "../builder/types.ts";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 
-const FLATMAP_INPUT_SCHEMA = toDeepFrozenSchema({
+const FLATMAP_INPUT_SCHEMA = internSchema({
   type: "object",
   properties: {
     list: { type: "array", items: { asCell: ["cell"], type: "unknown" } },

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -14,10 +14,7 @@ import type {
   JSONSchema,
 } from "commonfabric";
 import type { Schema } from "@commonfabric/api/schema";
-import {
-  isNontrivialSchema,
-  toDeepFrozenSchema,
-} from "@commonfabric/data-model/schema-utils";
+import { isNontrivialSchema } from "@commonfabric/data-model/schema-utils";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   LLMMessageSchema,
@@ -541,7 +538,7 @@ function traverseAndCellify(
   return value;
 }
 
-const resultSchema = toDeepFrozenSchema(
+const resultSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -573,10 +570,9 @@ const resultSchema = toDeepFrozenSchema(
     },
     required: ["pending", "addMessage", "cancelGeneration"],
   } as const,
-  true,
 );
 
-const internalSchema = toDeepFrozenSchema(
+const internalSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -585,7 +581,6 @@ const internalSchema = toDeepFrozenSchema(
     },
     required: ["requestId", "lastActivity"],
   },
-  true,
 );
 
 type LegacyToolEntry = {
@@ -646,7 +641,7 @@ function collectToolEntries(
   return { legacy, pieces };
 }
 
-const TOOL_CATALOG_SCHEMA = toDeepFrozenSchema({
+const TOOL_CATALOG_SCHEMA = internSchema({
   type: "object",
   additionalProperties: LLMToolSchema,
 });
@@ -658,7 +653,7 @@ const UNPIN_TOOL_NAME = "unpin";
 const PRESENT_RESULT_TOOL_NAME = "presentResult";
 const UPDATE_ARGUMENT_TOOL_NAME = "updateArgument";
 
-const READ_INPUT_SCHEMA = toDeepFrozenSchema(
+const READ_INPUT_SCHEMA = internSchema(
   {
     type: "object",
     properties: {
@@ -675,10 +670,9 @@ const READ_INPUT_SCHEMA = toDeepFrozenSchema(
     required: ["path"],
     additionalProperties: false,
   },
-  true,
 );
 
-const INVOKE_INPUT_SCHEMA = toDeepFrozenSchema(
+const INVOKE_INPUT_SCHEMA = internSchema(
   {
     type: "object",
     properties: {
@@ -699,10 +693,9 @@ const INVOKE_INPUT_SCHEMA = toDeepFrozenSchema(
     required: ["path"],
     additionalProperties: true,
   },
-  true,
 );
 
-const SCHEMA_INPUT_SCHEMA = toDeepFrozenSchema(
+const SCHEMA_INPUT_SCHEMA = internSchema(
   {
     type: "object",
     properties: {
@@ -719,10 +712,9 @@ const SCHEMA_INPUT_SCHEMA = toDeepFrozenSchema(
     required: ["path"],
     additionalProperties: false,
   },
-  true,
 );
 
-const PIN_INPUT_SCHEMA = toDeepFrozenSchema(
+const PIN_INPUT_SCHEMA = internSchema(
   {
     type: "object",
     properties: {
@@ -743,10 +735,9 @@ const PIN_INPUT_SCHEMA = toDeepFrozenSchema(
     required: ["path", "name"],
     additionalProperties: false,
   },
-  true,
 );
 
-const UNPIN_INPUT_SCHEMA = toDeepFrozenSchema(
+const UNPIN_INPUT_SCHEMA = internSchema(
   {
     type: "object",
     properties: {
@@ -763,10 +754,9 @@ const UNPIN_INPUT_SCHEMA = toDeepFrozenSchema(
     required: ["path"],
     additionalProperties: false,
   },
-  true,
 );
 
-const UPDATE_ARGUMENT_INPUT_SCHEMA = toDeepFrozenSchema(
+const UPDATE_ARGUMENT_INPUT_SCHEMA = internSchema(
   {
     type: "object",
     properties: {
@@ -788,7 +778,6 @@ const UPDATE_ARGUMENT_INPUT_SCHEMA = toDeepFrozenSchema(
     required: ["path", "updates"],
     additionalProperties: false,
   },
-  true,
 );
 
 /**

--- a/packages/runner/src/builtins/llm-schemas.ts
+++ b/packages/runner/src/builtins/llm-schemas.ts
@@ -1,7 +1,7 @@
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 
 /** Runtime schema for {@link BuiltInLLMContent} (packages/api/index.ts). */
-export const LLMContentSchema = toDeepFrozenSchema(
+export const LLMContentSchema = internSchema(
   {
     anyOf: [
       { type: "string" },
@@ -28,11 +28,10 @@ export const LLMContentSchema = toDeepFrozenSchema(
       },
     ],
   },
-  true,
 );
 
 /** Runtime schema for {@link BuiltInLLMMessage} (packages/api/index.ts). */
-export const LLMMessageSchema = toDeepFrozenSchema(
+export const LLMMessageSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -41,11 +40,10 @@ export const LLMMessageSchema = toDeepFrozenSchema(
     },
     required: ["role", "content"],
   },
-  true,
 );
 
 /** Runtime schema for {@link BuiltInLLMTool} (packages/api/index.ts). */
-export const LLMToolSchema = toDeepFrozenSchema(
+export const LLMToolSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -75,11 +73,10 @@ export const LLMToolSchema = toDeepFrozenSchema(
     },
     required: [],
   } as const,
-  true,
 );
 
 /** Runtime schema for reduced tool info sent to the LLM provider. */
-export const LLMReducedToolSchema = toDeepFrozenSchema(
+export const LLMReducedToolSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -87,11 +84,10 @@ export const LLMReducedToolSchema = toDeepFrozenSchema(
       inputSchema: { type: "object" },
     },
   },
-  true,
 );
 
 /** Runtime schema for {@link BuiltInLLMParams} (packages/api/index.ts). */
-export const LLMParamsSchema = toDeepFrozenSchema(
+export const LLMParamsSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -114,11 +110,10 @@ export const LLMParamsSchema = toDeepFrozenSchema(
     },
     required: ["messages"],
   } as const,
-  true,
 );
 
 /** Runtime schema for {@link BuiltInGenerateTextParams} (packages/api/index.ts). */
-export const GenerateTextParamsSchema = toDeepFrozenSchema(
+export const GenerateTextParamsSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -139,11 +134,10 @@ export const GenerateTextParamsSchema = toDeepFrozenSchema(
       },
     },
   },
-  true,
 );
 
 /** Runtime schema for {@link BuiltInGenerateObjectParams} (packages/api/index.ts). */
-export const GenerateObjectParamsSchema = toDeepFrozenSchema(
+export const GenerateObjectParamsSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -164,11 +158,10 @@ export const GenerateObjectParamsSchema = toDeepFrozenSchema(
     },
     required: ["schema"],
   },
-  true,
 );
 
 /** Runtime schema for the result of the `llm` builtin. */
-export const LLMResultSchema = toDeepFrozenSchema(
+export const LLMResultSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -185,11 +178,10 @@ export const LLMResultSchema = toDeepFrozenSchema(
     },
     required: ["pending"],
   } as const,
-  true,
 );
 
 /** Runtime schema for the result of the `generateText` builtin. */
-export const GenerateTextResultSchema = toDeepFrozenSchema(
+export const GenerateTextResultSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -201,11 +193,10 @@ export const GenerateTextResultSchema = toDeepFrozenSchema(
     },
     required: ["pending"],
   } as const,
-  true,
 );
 
 /** Runtime schema for the result of the `generateObject` builtin. */
-export const GenerateObjectResultSchema = toDeepFrozenSchema(
+export const GenerateObjectResultSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -217,5 +208,4 @@ export const GenerateObjectResultSchema = toDeepFrozenSchema(
     },
     required: ["pending"],
   } as const,
-  true,
 );

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -1,7 +1,7 @@
 import { type Pattern } from "../builder/types.ts";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 
-const MAP_INPUT_SCHEMA = toDeepFrozenSchema({
+const MAP_INPUT_SCHEMA = internSchema({
   type: "object",
   properties: {
     // type: "unknown" is ignored by the asCell code path (no type validation)

--- a/packages/runner/src/builtins/stream-data.ts
+++ b/packages/runner/src/builtins/stream-data.ts
@@ -2,7 +2,7 @@ import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
 import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
@@ -226,7 +226,7 @@ type StreamDataInputs = {
   options?: { body?: any; method?: string; headers?: Record<string, string> };
 };
 
-const streamDataInputSchema = toDeepFrozenSchema(
+const streamDataInputSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -244,7 +244,6 @@ const streamDataInputSchema = toDeepFrozenSchema(
       },
     },
   },
-  true,
 );
 
 function snapshotStreamDataInputs(

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -12,7 +12,7 @@ import { type Action } from "../scheduler.ts";
 import { type Runtime, spaceCellSchema } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { NAME, type Pattern, UI } from "../builder/types.ts";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { getPatternEnvironment } from "../env.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 
@@ -26,12 +26,11 @@ const wishFlowLogger = getLogger("runner.wish-flow", {
 
 // Schema for mentionable array - items are cell references (asCell: true)
 // Don't restrict properties so .get() returns full cell data
-const mentionableListSchema = toDeepFrozenSchema(
+const mentionableListSchema = internSchema(
   {
     type: "array",
     items: { asCell: true },
   },
-  true,
 );
 
 class WishError extends Error {
@@ -617,7 +616,7 @@ function cellLinkUI(cell: Cell<unknown>): VNode {
   return h("cf-cell-link", { $cell: cell });
 }
 
-const TARGET_SCHEMA = toDeepFrozenSchema(
+const TARGET_SCHEMA = internSchema(
   {
     type: "object",
     properties: {
@@ -629,7 +628,6 @@ const TARGET_SCHEMA = toDeepFrozenSchema(
     },
     required: ["query"],
   },
-  true,
 );
 
 export function wish(

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -7,7 +7,7 @@ import {
   unsafe_originalPattern,
   unsafe_verifiedLoadId,
 } from "./builder/types.ts";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { Cell } from "./cell.ts";
 import type { MemorySpace, Runtime } from "./runtime.ts";
 import { createRef } from "./create-ref.ts";
@@ -25,7 +25,7 @@ const logger = getLogger("pattern-manager");
  */
 const MAX_PATTERN_CACHE_SIZE = 100;
 
-export const patternMetaSchema = toDeepFrozenSchema(
+export const patternMetaSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -57,7 +57,6 @@ export const patternMetaSchema = toDeepFrozenSchema(
     },
     required: ["id"],
   },
-  true,
 );
 
 export type PatternMeta = Schema<typeof patternMetaSchema>;

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -55,7 +55,7 @@ import {
   NormalizedLink,
   parseLink,
 } from "./link-utils.ts";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { type CfcEnforcementMode, type TrustSnapshot } from "./cfc/mod.ts";
 import { PatternManager } from "./pattern-manager.ts";
 import { ModuleRegistry } from "./module.ts";
@@ -215,7 +215,7 @@ const initialCfcRuntimeStats = (): CfcRuntimeStats => ({
  * reachable object from these pieces.
  * @see SchemaObjectTraverser.traverseObjectWithSchema for more detail.
  */
-export const spaceCellSchema: JSONSchema = toDeepFrozenSchema(
+export const spaceCellSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -247,7 +247,6 @@ export const spaceCellSchema: JSONSchema = toDeepFrozenSchema(
       },
     },
   },
-  true,
 );
 
 export interface SpaceCellContents {

--- a/packages/runner/src/schemas.ts
+++ b/packages/runner/src/schemas.ts
@@ -5,9 +5,9 @@
  */
 
 import { NAME, type Schema, TYPE, UI } from "./shared.ts";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 
-export const rendererVDOMSchema = toDeepFrozenSchema(
+export const rendererVDOMSchema = internSchema(
   {
     $id: "https://commonfabric.org/schemas/vdom.json",
     $defs: {
@@ -80,7 +80,6 @@ export const rendererVDOMSchema = toDeepFrozenSchema(
     },
     $ref: "#/$defs/vdomRenderNode",
   },
-  true,
 );
 
 /**
@@ -88,7 +87,7 @@ export const rendererVDOMSchema = toDeepFrozenSchema(
  * Children expand inline (no asCell) so the full tree is readable in one .get().
  * Props keep asCell since prop values can be large and aren't needed for structural debugging.
  */
-export const debugVDOMSchema = toDeepFrozenSchema(
+export const debugVDOMSchema = internSchema(
   {
     $id: "https://commonfabric.org/schemas/vdom-debug.json",
     $defs: {
@@ -125,10 +124,9 @@ export const debugVDOMSchema = toDeepFrozenSchema(
     },
     $ref: "#/$defs/vdomNode",
   },
-  true,
 );
 
-export const vnodeSchema = toDeepFrozenSchema(
+export const vnodeSchema = internSchema(
   {
     $id: "https://commonfabric.org/schemas/vnode.json",
     $ref: "#/$defs/VNode",
@@ -234,43 +232,39 @@ export const vnodeSchema = toDeepFrozenSchema(
       },
     },
   },
-  true,
 );
 
-export const nameSchema = toDeepFrozenSchema(
+export const nameSchema = internSchema(
   {
     type: "object",
     properties: { [NAME]: { type: "string" } },
     required: [NAME],
   },
-  true,
 );
 
 export type NameSchema = Schema<typeof nameSchema>;
 
-export const uiSchema = toDeepFrozenSchema(
+export const uiSchema = internSchema(
   {
     type: "object",
     properties: { [UI]: rendererVDOMSchema },
     required: [UI],
   },
-  true,
 );
 
 export type UISchema = Schema<typeof uiSchema>;
 
 // We specify type unknown for the items, since we don't want to recursively
 // load them
-export const pieceListSchema = toDeepFrozenSchema(
+export const pieceListSchema = internSchema(
   {
     type: "array",
     items: { type: "unknown", asCell: ["cell"] },
     default: [],
   },
-  true,
 );
 
-export const pieceLineageSchema = toDeepFrozenSchema(
+export const pieceLineageSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -280,11 +274,10 @@ export const pieceLineageSchema = toDeepFrozenSchema(
     },
     required: ["piece", "relation", "timestamp"],
   },
-  true,
 );
 export type PieceLineage = Schema<typeof pieceLineageSchema>;
 
-export const pieceSourceCellSchema = toDeepFrozenSchema(
+export const pieceSourceCellSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -298,10 +291,9 @@ export const pieceSourceCellSchema = toDeepFrozenSchema(
       llmRequestId: { type: "string" },
     },
   },
-  true,
 );
 
-export const processSchema = toDeepFrozenSchema(
+export const processSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -311,26 +303,21 @@ export const processSchema = toDeepFrozenSchema(
     },
     required: [TYPE],
   },
-  true,
 );
 
 // Primitive schemas for UI component cell bindings
-export const stringSchema = toDeepFrozenSchema(
+export const stringSchema = internSchema(
   { type: "string" },
-  true,
 );
-export const booleanSchema = toDeepFrozenSchema(
+export const booleanSchema = internSchema(
   { type: "boolean" },
-  true,
 );
-export const numberSchema = toDeepFrozenSchema(
+export const numberSchema = internSchema(
   { type: "number" },
-  true,
 );
-export const stringArraySchema = toDeepFrozenSchema(
+export const stringArraySchema = internSchema(
   {
     type: "array",
     items: { type: "string" },
   },
-  true,
 );


### PR DESCRIPTION
This PR changes global / module schema constant definitions to use `internSchema()` instead of `toDeepFrozenSchema()`. The original uses of `toDeepFrozenSchema()` in this context came from me, but in the meantime other uses have cropped up using the same pattern. However, my original changes predated the introduction (or at least the concerted effort to use) `internSchema()`. The new function is basically the same cost as the old one in this context, and it comes with the possibility of saving time and memory once the system is up and running.