### PR TITLE
test(patterns): accept mixed-case note handles in default-app flow

### DIFF
--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -1976,13 +1976,13 @@ async function collectNoteTitlesInList(page: Page): Promise<string[]> {
         const allElements = root.querySelectorAll("*");
         for (const el of allElements) {
           const text = el.textContent;
-          if (text) {
-            for (
-              const match of text.matchAll(/📝 New Note #[a-z0-9]+/g)
-            ) {
-              titles.add(match[0]);
+            if (text) {
+              for (
+                const match of text.matchAll(/📝 New Note #[A-Za-z0-9_-]+/g)
+              ) {
+                titles.add(match[0]);
+              }
             }
-          }
           if (el.shadowRoot) {
             search(el.shadowRoot);
           }

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -1976,13 +1976,13 @@ async function collectNoteTitlesInList(page: Page): Promise<string[]> {
         const allElements = root.querySelectorAll("*");
         for (const el of allElements) {
           const text = el.textContent;
-            if (text) {
-              for (
-                const match of text.matchAll(/📝 New Note #[A-Za-z0-9_-]+/g)
-              ) {
-                titles.add(match[0]);
-              }
+          if (text) {
+            for (
+              const match of text.matchAll(/📝 New Note #[A-Za-z0-9_-]+/g)
+            ) {
+              titles.add(match[0]);
             }
+          }
           if (el.shadowRoot) {
             search(el.shadowRoot);
           }


### PR DESCRIPTION
## Summary
- widen the `default-app` integration test matcher for generated note handles
- stop assuming the `#<suffix>` portion is lowercase-only
- keep the fix scoped to the test oracle; the product path is already rendering the note row correctly

## What was happening
This looked like a flaky reactivity bug at first because `packages/patterns/integration/default-app.test.ts` would sometimes time out while waiting for the new note to appear in the space list.

After tracing the full flow in a clean worktree, the underlying state and UI were actually fine on failing runs:
- the note row was present in the DOM
- `cf-cell-link` had resolved the cell
- the rendered label looked like `📝 New Note #PQsmc0`

The failure was the test matcher itself. It only accepted lowercase letters and digits:

```ts
/📝 New Note #[a-z0-9]+/
```

That means mixed-case handle suffixes were rejected even when the row was correctly rendered.

## Why now
The matcher was wrong from the day the test was added (`ebd249fd4`, 2026-01-12), but newer handle/ID paths now surface mixed-case suffixes often enough to make the bug visible in CI.

## Fix
Accept the actual rendered handle character set used in this UI path:

```ts
/📝 New Note #[A-Za-z0-9_-]+/
```

## Validation
Local validation against a clean local stack on `http://localhost:8041`:
- `HEADLESS=1 API_URL=http://localhost:8041/ deno test -A ./integration/default-app.test.ts`
- repeated 7 times
- result: 7 / 7 passed