### PR TITLE
More tactical `schemaIntern()`ing.

### DIFF
--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -37,7 +37,7 @@ import type {
 } from "@commonfabric/runner";
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { OpaqueRef } from "@commonfabric/api";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { basename } from "@std/path";
 import { timeout } from "@commonfabric/utils/sleep";
@@ -104,7 +104,7 @@ type HarnessTestStepMeta = {
 
 type HarnessTestStepCell = Cell<unknown>;
 
-const testStepPeekSchema = toDeepFrozenSchema(
+const testStepPeekSchema = internSchema(
   {
     type: "object",
     properties: {
@@ -113,24 +113,21 @@ const testStepPeekSchema = toDeepFrozenSchema(
       skip: { type: "boolean" },
     },
   },
-  true,
 );
 
-const testStepEntrySchema = toDeepFrozenSchema(
+const testStepEntrySchema = internSchema(
   {
     type: "object",
     asCell: true,
   },
-  true,
 );
 
-const testStepListSchema = toDeepFrozenSchema(
+const testStepListSchema = internSchema(
   {
     type: "array",
     items: testStepEntrySchema,
     default: [],
   },
-  true,
 );
 
 function actionStreamForStep(stepCell: HarnessTestStepCell): Stream<unknown> {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -11,7 +11,6 @@ import {
   shallowFabricFromNativeValue,
 } from "@commonfabric/data-model/fabric-value";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import { getTopFrame, pattern } from "./builder/pattern.ts";
 import { createNodeFactory, lift } from "./builder/module.ts";
@@ -132,10 +131,7 @@ const recordSchemaWritePolicyInput = (
   if (resolvedSchema === undefined) {
     return;
   }
-  const schemaAndHash = internSchema(
-    toDeepFrozenSchema(resolvedSchema, true),
-    true,
-  );
+  const schemaAndHash = internSchema(resolvedSchema, true);
   tx.recordCfcWritePolicyInput({
     kind: "schema",
     target: {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -835,10 +835,7 @@ export const prepareBoundaryCommit = (
         continue;
       }
     }
-    const schemaAndHash = internSchema(
-      toDeepFrozenSchema(mergedSchema, true) as JSONSchema,
-      true,
-    );
+    const schemaAndHash = internSchema(mergedSchema, true);
     const mergedSchemaEntries = walkIfcSchema(mergedSchema);
     const mergedSchemaEntryLabels = new Map<string, IFCLabel>(
       mergedSchemaEntries.map((entry) => [


### PR DESCRIPTION
This fixes a few more use sites of `toDeepFrozenSchema()` to instead just use `internSchema()`.