### PR TITLE
Fail structured file tools on shell errors

### DIFF
--- a/packages/cf-harness/src/tools/read-file.ts
+++ b/packages/cf-harness/src/tools/read-file.ts
@@ -73,6 +73,11 @@ export const readFileTool: HarnessToolDefinition<
         input.maxBytes !== undefined ? String(input.maxBytes) : "",
       ],
     });
+    if (result.exitCode !== 0) {
+      const detail = result.stderr.trim() || result.stdout.trim() ||
+        `shell exited with code ${result.exitCode}`;
+      throw new Error(`read_file failed for ${resolvedPath}: ${detail}`);
+    }
     return {
       outputId: context.nextOutputId("read_file"),
       path: resolvedPath,

--- a/packages/cf-harness/src/tools/write-file.ts
+++ b/packages/cf-harness/src/tools/write-file.ts
@@ -60,7 +60,7 @@ export const writeFileTool: HarnessToolDefinition<
   async invoke(context, input) {
     const resolvedPath = context.resolvePath(input.path);
     const mode = input.mode ?? "replace";
-    await context.sandbox.runShell({
+    const result = await context.sandbox.runShell({
       command: [
         "set -eu",
         'path="$1"',
@@ -85,6 +85,11 @@ export const writeFileTool: HarnessToolDefinition<
       args: [resolvedPath, mode, String(input.createParents ?? false)],
       stdinText: input.content,
     });
+    if (result.exitCode !== 0) {
+      const detail = result.stderr.trim() || result.stdout.trim() ||
+        `shell exited with code ${result.exitCode}`;
+      throw new Error(`write_file failed for ${resolvedPath}: ${detail}`);
+    }
     return {
       outputId: context.nextOutputId("write_file"),
       path: resolvedPath,

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -169,6 +169,23 @@ Deno.test("read_file tool rejects non-integer maxBytes", async () => {
   assertEquals(sandbox.calls, []);
 });
 
+Deno.test("read_file tool rejects missing files instead of returning empty content", async () => {
+  const sandbox = new FakeSandboxRuntime([{
+    stdout: "",
+    stderr: "file not found: /workspace/notes/missing.txt",
+    exitCode: 1,
+  }]);
+
+  await assertRejects(
+    () =>
+      readFileTool.invoke(createContext(sandbox), {
+        path: "notes/missing.txt",
+      }),
+    Error,
+    "read_file failed for /workspace/notes/missing.txt: file not found: /workspace/notes/missing.txt",
+  );
+});
+
 Deno.test("write_file tool supports append mode and passes content over stdin", async () => {
   const sandbox = new FakeSandboxRuntime();
   const output = await writeFileTool.invoke(createContext(sandbox), {
@@ -258,4 +275,22 @@ Deno.test("write_file uses the cwd established by an earlier bash call", async (
       stdinText: "line one\n",
     },
   });
+});
+
+Deno.test("write_file tool rejects nonzero shell exits", async () => {
+  const sandbox = new FakeSandboxRuntime([{
+    stdout: "",
+    stderr: "permission denied",
+    exitCode: 13,
+  }]);
+
+  await assertRejects(
+    () =>
+      writeFileTool.invoke(createContext(sandbox), {
+        path: "notes/log.txt",
+        content: "line one\n",
+      }),
+    Error,
+    "write_file failed for /workspace/notes/log.txt: permission denied",
+  );
 });


### PR DESCRIPTION
Summary:
- make read_file reject nonzero shell exits instead of returning empty content
- make write_file reject nonzero shell exits instead of silently succeeding
- add regression tests for missing-file and failed-write behavior

Why:
The W-519 analysis showed that a bad file path inside cf-harness could collapse into an empty read_file result instead of a clear tool failure. That made the run look like it was missing content instead of pointing to the actual path problem. Structured file tools should not silently treat nonzero shell exits as success.

Verification:
- deno fmt packages/cf-harness/src/tools/read-file.ts packages/cf-harness/src/tools/write-file.ts packages/cf-harness/test/tools-execution.test.ts
- deno lint packages/cf-harness/src/tools/read-file.ts packages/cf-harness/src/tools/write-file.ts packages/cf-harness/test/tools-execution.test.ts
- deno test --allow-read --allow-write --allow-run packages/cf-harness/test/tools-execution.test.ts
- cd packages/cf-harness && deno task test