### PR TITLE
Another couple promising schema-related tweaks

### DIFF
--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -1,4 +1,4 @@
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isRecord } from "@commonfabric/utils/types";
 import type { JSONSchema, JSONSchemaObj } from "../builder/types.ts";
@@ -281,7 +281,7 @@ const mergeSchemaNode = (
     mergedItems = right.items;
   }
 
-  const merged = {
+  return {
     ...left,
     ...right,
     ...(Object.keys(mergedProperties).length > 0
@@ -291,9 +291,7 @@ const mergeSchemaNode = (
     ifc: mergeIfc(left.ifc, right.ifc),
     required: mergeRequired(left.required, right.required, mergedProperties),
     default: mergeDefaults(left.default, right.default),
-  } satisfies JSONSchemaObj;
-
-  return toDeepFrozenSchema(merged, true);
+  };
 };
 
 export const mergeCfcSchemaEnvelopes = (
@@ -302,5 +300,5 @@ export const mergeCfcSchemaEnvelopes = (
 ): JSONSchema => {
   assertNoDivergentIfcBranches(existing);
   assertNoDivergentIfcBranches(candidate);
-  return mergeSchemaNode(existing, candidate);
+  return internSchema(mergeSchemaNode(existing, candidate));
 };

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -218,7 +218,10 @@ function _schemaHasIfcUncached(
   return false;
 }
 
-const _filterAsCellCache = new WeakMap<JSONSchemaObj, JSONSchema | "<undefined>">();
+const _filterAsCellCache = new WeakMap<
+  JSONSchemaObj,
+  JSONSchema | "<undefined>"
+>();
 
 function filterAsCell(schema: JSONSchema | undefined): JSONSchema | undefined {
   if (!isNontrivialSchema(schema)) {

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -218,14 +218,34 @@ function _schemaHasIfcUncached(
   return false;
 }
 
+const _filterAsCellCache = new WeakMap<JSONSchemaObj, JSONSchema | "<undefined>">();
+
 function filterAsCell(schema: JSONSchema | undefined): JSONSchema | undefined {
   if (!isNontrivialSchema(schema)) {
     return schema;
   }
-  const { asCell: _asCell, asStream: _asStream, ...restSchema } = schema;
-  return isNontrivialSchema(restSchema)
-    ? toDeepFrozenSchema(restSchema)
-    : undefined;
+
+  const makeRawResult = () => {
+    const { asCell: _asCell, asStream: _asStream, ...restSchema } = schema;
+    return isNontrivialSchema(restSchema) ? restSchema : undefined;
+  };
+
+  if (isDeepFrozen(schema)) {
+    // Note: We cache literal `<undefined>` when we are to return `undefined`,
+    // to disambiguate with no-entry.
+    const cached = _filterAsCellCache.get(schema);
+    if (cached) return (cached === "<undefined>") ? undefined : cached;
+    const result = makeRawResult();
+    if (result) {
+      _filterAsCellCache.set(schema, result);
+      return result;
+    } else {
+      _filterAsCellCache.set(schema, "<undefined>");
+      return undefined;
+    }
+  } else {
+    return makeRawResult();
+  }
 }
 
 /**


### PR DESCRIPTION
Two more schema-related tweaks:

* Intern on the way out of `mergeCfcSchemaEnvelopes()` instead of incrementally deep-freezing partial results, most of which will quickly become garbage.
* Cache the results of `filterAsCell()` on deep-frozen inputs.