### PR TITLE
Retry ETXTBSY Astral browser launches

### DIFF
--- a/packages/deno-web-test/browser.ts
+++ b/packages/deno-web-test/browser.ts
@@ -1,16 +1,53 @@
-import { Browser, ConsoleEvent, launch, Page } from "@astral/astral";
+import {
+  Browser as AstralBrowser,
+  ConsoleEvent,
+  launch,
+  LaunchOptions,
+  Page,
+} from "@astral/astral";
 import { Manifest } from "./manifest.ts";
 import { tsToJs } from "./utils.ts";
 import { TestResult } from "./interface.ts";
 import { extractAstralConfig } from "./config.ts";
 import { sleep } from "@commonfabric/utils/sleep";
 
+const LAUNCH_RETRY_ATTEMPTS = 5;
+const LAUNCH_RETRYABLE_ETXTBSY = "Text file busy (os error 26)";
+
+type LaunchFn = (options: LaunchOptions) => Promise<AstralBrowser>;
+type SleepFn = (ms: number) => Promise<unknown>;
+
+export function isRetryableAstralLaunchError(error: unknown): boolean {
+  return String(error).includes(LAUNCH_RETRYABLE_ETXTBSY);
+}
+
+export async function launchWithRetry(
+  options: LaunchOptions,
+  launchImpl: LaunchFn = launch,
+  sleepImpl: SleepFn = sleep,
+): Promise<AstralBrowser> {
+  for (let attempt = 1; attempt <= LAUNCH_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await launchImpl(options);
+    } catch (error) {
+      if (
+        attempt === LAUNCH_RETRY_ATTEMPTS ||
+        !isRetryableAstralLaunchError(error)
+      ) {
+        throw error;
+      }
+      await sleepImpl(250 * 2 ** (attempt - 1));
+    }
+  }
+  throw new Error("unreachable");
+}
+
 export class BrowserController extends EventTarget {
   private static readonly HARNESS_READY_TIMEOUT_MS = 10_000;
   private static readonly HARNESS_READY_POLL_MS = 200;
   private manifest: Manifest;
   private page: Page | null;
-  private browser: Browser | null;
+  private browser: AstralBrowser | null;
   private serverPort: number;
 
   constructor(manifest: Manifest, serverPort: number) {
@@ -30,7 +67,7 @@ export class BrowserController extends EventTarget {
     if (this.page) {
       await this.page.goto(testUrl);
     } else {
-      this.browser = await launch(extractAstralConfig(config));
+      this.browser = await launchWithRetry(extractAstralConfig(config));
       this.page = await this.browser.newPage(testUrl);
       this.page.addEventListener("console", (e) => {
         // Not sure why this event needs reconstructed in order

--- a/packages/deno-web-test/test/browser.test.ts
+++ b/packages/deno-web-test/test/browser.test.ts
@@ -1,0 +1,92 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { isRetryableAstralLaunchError, launchWithRetry } from "../browser.ts";
+import type { Browser as AstralBrowser, LaunchOptions } from "@astral/astral";
+
+Deno.test("isRetryableAstralLaunchError matches ETXTBSY browser-launch failures", () => {
+  assertEquals(
+    isRetryableAstralLaunchError(
+      new Error("open '/tmp/chrome': Text file busy (os error 26)"),
+    ),
+    true,
+  );
+  assertEquals(
+    isRetryableAstralLaunchError(new Error("permission denied")),
+    false,
+  );
+});
+
+Deno.test("launchWithRetry retries retryable ETXTBSY launch failures", async () => {
+  const launchCalls: LaunchOptions[] = [];
+  const sleepCalls: number[] = [];
+  const browser = { close: async () => {} } as AstralBrowser;
+  let attempts = 0;
+
+  const launched = await launchWithRetry(
+    { headless: true },
+    (options) => {
+      launchCalls.push(options);
+      attempts += 1;
+      if (attempts < 3) {
+        return Promise.reject(
+          new Error(
+            "Could not load test/console.test.ts: Text file busy (os error 26)",
+          ),
+        );
+      }
+      return Promise.resolve(browser);
+    },
+    (ms) => {
+      sleepCalls.push(ms);
+      return Promise.resolve();
+    },
+  );
+
+  assertEquals(launched, browser);
+  assertEquals(launchCalls.length, 3);
+  assertEquals(sleepCalls, [250, 500]);
+});
+
+Deno.test("launchWithRetry does not retry non-retryable launch failures", async () => {
+  let attempts = 0;
+
+  await assertRejects(
+    () =>
+      launchWithRetry(
+        { headless: true },
+        () => {
+          attempts += 1;
+          return Promise.reject(new Error("permission denied"));
+        },
+        () => Promise.resolve(),
+      ),
+    Error,
+    "permission denied",
+  );
+
+  assertEquals(attempts, 1);
+});
+
+Deno.test("launchWithRetry rethrows ETXTBSY after exhausting retries", async () => {
+  let attempts = 0;
+  const sleepCalls: number[] = [];
+
+  await assertRejects(
+    () =>
+      launchWithRetry(
+        { headless: true },
+        () => {
+          attempts += 1;
+          return Promise.reject(new Error("Text file busy (os error 26)"));
+        },
+        (ms) => {
+          sleepCalls.push(ms);
+          return Promise.resolve();
+        },
+      ),
+    Error,
+    "Text file busy",
+  );
+
+  assertEquals(attempts, 5);
+  assertEquals(sleepCalls, [250, 500, 1000, 2000]);
+});


### PR DESCRIPTION
## Summary
- retry Astral browser launches in deno-web-test when Chrome is temporarily ETXTBSY in the shared cache
- add focused unit coverage for retryable ETXTBSY, non-retryable launch errors, and retry exhaustion
- keep the patch narrow to the launch path used by js-sandbox browser tests

## Context
This is intended to harden the Labs main failure from https://github.com/commontoolsinc/labs/actions/runs/24862286623 where js-sandbox failed with:

- `Text file busy (os error 26): open '/home/runner/.cache/astral/125.0.6400.0/chrome-linux64/chrome'`

## Testing
- `deno fmt packages/deno-web-test/browser.ts packages/deno-web-test/test/browser.test.ts`
- `deno lint packages/deno-web-test/browser.ts packages/deno-web-test/test/browser.test.ts`
- `cd packages/deno-web-test && deno test --allow-env --allow-read --allow-write --allow-run --allow-net test/browser.test.ts`
- `cd packages/deno-web-test && deno check cli.ts`

## Validation note
Broader local browser-test smoke coverage is not clean in this environment for unrelated reasons:
- `deno-web-test` smoke/config tests fail locally before exercising the new helper
- `packages/js-sandbox` browser-test hit a separate local bundling issue resolving `npm:typescript`

So CI is the real arbiter for whether this launch hardening resolves the observed race.
