### PR TITLE
perf(cli): emit cpu metrics for pattern tests

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to use for performance checks"
+        required: false
+        type: string
 
 # Define the list of binaries we're building
 # This makes it easy to add more binaries in the future
@@ -355,7 +361,7 @@ jobs:
 
       - name: 🧪 Run pattern unit tests
         env:
-          CF_INTEGRATION_PERF_JSON: ${{ github.event_name == 'pull_request' && '1' || '' }}
+          CF_INTEGRATION_PERF_JSON: ${{ (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.pr_number != '')) && '1' || '' }}
         run: |
           chmod +x ./common-binaries/cf
           mkdir -p test-results
@@ -376,7 +382,7 @@ jobs:
 
   perf-check:
     name: "Performance Check"
-    if: (github.event_name == 'pull_request') || (github.ref_name == 'main')
+    if: (github.event_name == 'pull_request') || (github.ref_name == 'main') || (github.event_name == 'workflow_dispatch' && inputs.pr_number != '')
     runs-on: ubuntu-latest
     needs:
       - check
@@ -404,7 +410,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_RUN_ID: ${{ github.run_id }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: deno run --allow-net --allow-env --allow-read --allow-run --allow-write tasks/perf-check.ts
 
   attest-binaries:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -354,6 +354,8 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: 🧪 Run pattern unit tests
+        env:
+          CF_INTEGRATION_PERF_JSON: ${{ github.event_name == 'pull_request' && '1' || '' }}
         run: |
           chmod +x ./common-binaries/cf
           mkdir -p test-results

--- a/deno.json
+++ b/deno.json
@@ -126,6 +126,8 @@
     ]
   },
   "imports": {
+    "@node/process": "node:process",
+    "node:process": "node:process",
     "commonfabric": "./packages/api/index.ts",
     "commonfabric/schema": "./packages/api/schema.ts",
     "core-js/proposals/explicit-resource-management": "https://esm.sh/core-js@3.46.0/proposals/explicit-resource-management",

--- a/packages/cli/commands/test.ts
+++ b/packages/cli/commands/test.ts
@@ -42,6 +42,10 @@ export const test = new Command()
     "Show detailed execution logs.",
   )
   .option(
+    "--perf-json",
+    "Emit one machine-readable JSON metrics line per test file.",
+  )
+  .option(
     "--root <dir:string>",
     "Root directory for resolving imports. Enables imports like '../shared/utils.tsx'.",
   )
@@ -163,6 +167,7 @@ export const test = new Command()
     const { failed } = await runTests(uniqueTestFiles, {
       timeout: options.timeout,
       verbose: options.verbose,
+      perfJson: options.perfJson,
       root,
       memoryVersion: options.memoryVersion,
       statsThreshold: options.statsThreshold,

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -38,8 +38,8 @@ import type {
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { OpaqueRef } from "@commonfabric/api";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import process from "@node/process";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
-import { cpuUsage, memoryUsage } from "node:process";
 import { basename } from "@std/path";
 import { timeout } from "@commonfabric/utils/sleep";
 import { experimentalOptionsFromEnv } from "./utils.ts";
@@ -257,10 +257,10 @@ function fmtMs(ms: number): string {
 }
 
 function collectCpuMetrics(
-  startCpu = cpuUsage(),
+  startCpu = process.cpuUsage(),
 ): TestRunCpuMetrics {
-  const cpu = cpuUsage(startCpu);
-  const memory = memoryUsage();
+  const cpu = process.cpuUsage(startCpu);
+  const memory = process.memoryUsage();
   return {
     userCpuMicros: cpu.user,
     systemCpuMicros: cpu.system,
@@ -837,7 +837,7 @@ export async function runTestPattern(
 ): Promise<TestRunResult> {
   const TIMEOUT = options.timeout ?? 60000;
   const startTime = performance.now();
-  const startCpu = cpuUsage();
+  const startCpu = process.cpuUsage();
   performance.clearMarks();
   performance.clearMeasures();
   resetAllLoggerCounts();

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -272,6 +272,13 @@ function collectCpuMetrics(
   };
 }
 
+export function testRunPassed(result: TestRunResult): boolean {
+  return !result.error &&
+    result.results.every((test) => test.skipped || test.passed) &&
+    (result.allowRuntimeErrors || result.runtimeErrors.length === 0) &&
+    (result.expectNonIdempotent || result.nonIdempotent.length === 0);
+}
+
 function printPerfJson(result: TestRunResult): void {
   console.log(JSON.stringify({
     kind: "cf-test-metrics",
@@ -279,7 +286,7 @@ function printPerfJson(result: TestRunResult): void {
     path: result.path,
     totalDurationMs: result.totalDurationMs,
     cpuMetrics: result.cpuMetrics,
-    passed: !result.error,
+    passed: testRunPassed(result),
   }));
 }
 

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -39,6 +39,7 @@ import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { OpaqueRef } from "@commonfabric/api";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { cpuUsage, memoryUsage } from "node:process";
 import { basename } from "@std/path";
 import { timeout } from "@commonfabric/utils/sleep";
 import { experimentalOptionsFromEnv } from "./utils.ts";
@@ -161,6 +162,7 @@ export interface TestRunResult {
   path: string;
   results: TestResult[];
   totalDurationMs: number;
+  cpuMetrics?: TestRunCpuMetrics;
   error?: string;
   /** Navigation events recorded during the test run */
   navigations: NavigationEvent[];
@@ -174,9 +176,21 @@ export interface TestRunResult {
   expectNonIdempotent?: boolean;
 }
 
+export interface TestRunCpuMetrics {
+  userCpuMicros: number;
+  systemCpuMicros: number;
+  totalCpuMicros: number;
+  rssBytes: number;
+  heapTotalBytes: number;
+  heapUsedBytes: number;
+  externalBytes: number;
+}
+
 export interface TestRunnerOptions {
   timeout?: number;
   verbose?: boolean;
+  /** Emit machine-readable CPU/resource metrics for each completed test file. */
+  perfJson?: boolean;
   /** Root directory for resolving imports. If not provided, uses the test file's directory. */
   root?: string;
   /** Force the storage/runtime memory implementation used by the test harness. */
@@ -240,6 +254,33 @@ function fmtMs(ms: number): string {
   if (ms >= 10) return `${Math.round(ms)}ms`;
   if (ms >= 1) return `${ms.toFixed(1)}ms`;
   return `${ms.toFixed(2)}ms`;
+}
+
+function collectCpuMetrics(
+  startCpu = cpuUsage(),
+): TestRunCpuMetrics {
+  const cpu = cpuUsage(startCpu);
+  const memory = memoryUsage();
+  return {
+    userCpuMicros: cpu.user,
+    systemCpuMicros: cpu.system,
+    totalCpuMicros: cpu.user + cpu.system,
+    rssBytes: memory.rss,
+    heapTotalBytes: memory.heapTotal,
+    heapUsedBytes: memory.heapUsed,
+    externalBytes: memory.external,
+  };
+}
+
+function printPerfJson(result: TestRunResult): void {
+  console.log(JSON.stringify({
+    kind: "cf-test-metrics",
+    version: 1,
+    path: result.path,
+    totalDurationMs: result.totalDurationMs,
+    cpuMetrics: result.cpuMetrics,
+    passed: !result.error,
+  }));
 }
 
 function printSettleStats(stats: SettleStats | null): void {
@@ -796,6 +837,7 @@ export async function runTestPattern(
 ): Promise<TestRunResult> {
   const TIMEOUT = options.timeout ?? 60000;
   const startTime = performance.now();
+  const startCpu = cpuUsage();
   performance.clearMarks();
   performance.clearMeasures();
   resetAllLoggerCounts();
@@ -1422,6 +1464,7 @@ export async function runTestPattern(
       path: testPath,
       results,
       totalDurationMs: performance.now() - startTime,
+      cpuMetrics: collectCpuMetrics(startCpu),
       navigations,
       runtimeErrors: errorMessages,
       allowRuntimeErrors,
@@ -1446,6 +1489,7 @@ export async function runTestPattern(
       path: testPath,
       results: [],
       totalDurationMs: performance.now() - startTime,
+      cpuMetrics: collectCpuMetrics(startCpu),
       navigations,
       runtimeErrors: errorMessages,
       nonIdempotent: [],
@@ -1486,6 +1530,10 @@ export async function runTests(
 
     const result = await runTestPattern(testPath, options);
     allResults.push(result);
+
+    if (options.perfJson && result.cpuMetrics) {
+      printPerfJson(result);
+    }
 
     if (result.error) {
       console.log(`  ✗ Error: ${result.error}`);

--- a/packages/cli/test/test-runner.test.ts
+++ b/packages/cli/test/test-runner.test.ts
@@ -1,0 +1,58 @@
+import { assertEquals } from "@std/assert";
+import { testRunPassed, type TestRunResult } from "../lib/test-runner.ts";
+
+function makeResult(
+  overrides: Partial<TestRunResult> = {},
+): TestRunResult {
+  return {
+    path: "packages/patterns/example.test.tsx",
+    results: [{
+      name: "assertion_1",
+      passed: true,
+      afterAction: null,
+      durationMs: 1,
+    }],
+    totalDurationMs: 1,
+    navigations: [],
+    runtimeErrors: [],
+    nonIdempotent: [],
+    ...overrides,
+  };
+}
+
+Deno.test("testRunPassed follows pattern test failure accounting", () => {
+  assertEquals(testRunPassed(makeResult()), true);
+  assertEquals(
+    testRunPassed(makeResult({
+      results: [{
+        name: "assertion_1",
+        passed: false,
+        afterAction: null,
+        durationMs: 1,
+      }],
+    })),
+    false,
+  );
+  assertEquals(
+    testRunPassed(makeResult({ runtimeErrors: ["boom"] })),
+    false,
+  );
+  assertEquals(
+    testRunPassed(makeResult({
+      runtimeErrors: ["expected"],
+      allowRuntimeErrors: true,
+    })),
+    true,
+  );
+  assertEquals(
+    testRunPassed(makeResult({ nonIdempotent: ["computed-value"] })),
+    false,
+  );
+  assertEquals(
+    testRunPassed(makeResult({
+      nonIdempotent: ["computed-value"],
+      expectNonIdempotent: true,
+    })),
+    true,
+  );
+});

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -19,6 +19,65 @@
 import * as path from "@std/path";
 import ports from "@commonfabric/ports" with { type: "json" };
 
+type PatternTestTiming = {
+  file: string;
+  durationMs: number;
+  passed: boolean;
+  cpuMetrics?: {
+    userCpuMicros: number;
+    systemCpuMicros: number;
+    totalCpuMicros: number;
+    rssBytes: number;
+    heapTotalBytes: number;
+    heapUsedBytes: number;
+    externalBytes: number;
+  };
+};
+
+type CfTestPerfJson = {
+  kind: "cf-test-metrics";
+  version: number;
+  path: string;
+  totalDurationMs: number;
+  cpuMetrics?: PatternTestTiming["cpuMetrics"];
+  passed: boolean;
+};
+
+function parseCfTestPerfJson(
+  stdout: string | undefined,
+): CfTestPerfJson | undefined {
+  if (!stdout) return undefined;
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{"kind":"cf-test-metrics"')) continue;
+    try {
+      return JSON.parse(trimmed) as CfTestPerfJson;
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+function buildPatternCpuMetricsJson(
+  timings: PatternTestTiming[],
+): string {
+  return JSON.stringify(
+    {
+      kind: "pattern-test-metrics",
+      version: 1,
+      metrics: timings.map((timing) => ({
+        file: timing.file,
+        durationMs: timing.durationMs,
+        passed: timing.passed,
+        cpuMetrics: timing.cpuMetrics,
+      })),
+    },
+    null,
+    2,
+  );
+}
+
 // Packages with integration tests that need a running server by default.
 const DEFAULT_PACKAGES_WITH_SERVER = [
   "runner",
@@ -198,6 +257,9 @@ async function runPatternTests(
   const testFiles = await findPatternTests(rootDir, patternsDir, filter);
   const memoryVersion = Deno.env.get("CF_TEST_MEMORY_VERSION") ??
     Deno.env.get("CF_INTEGRATION_MEMORY_VERSION");
+  const perfJsonEnabled = ["1", "true", "yes", "on"].includes(
+    (Deno.env.get("CF_INTEGRATION_PERF_JSON") ?? "").toLowerCase(),
+  );
 
   if (testFiles.length === 0) {
     console.log("No pattern test files found.");
@@ -213,8 +275,7 @@ async function runPatternTests(
   }
 
   const failed: string[] = [];
-  const testTimings: { file: string; durationMs: number; passed: boolean }[] =
-    [];
+  const testTimings: PatternTestTiming[] = [];
 
   // Run as a pool: always keep `concurrency` tests in flight
   let nextIndex = 0;
@@ -233,6 +294,7 @@ async function runPatternTests(
             "180000",
             "--root",
             patternsDir,
+            ...(perfJsonEnabled ? ["--perf-json"] : []),
             ...(memoryVersion === "v1" || memoryVersion === "v2"
               ? ["--memory-version", memoryVersion]
               : []),
@@ -241,11 +303,13 @@ async function runPatternTests(
           { cwd: rootDir },
         );
         const durationMs = performance.now() - startMs;
+        const perfMetrics = parseCfTestPerfJson(result.stdout);
 
         testTimings.push({
           file: testFile,
           durationMs,
           passed: result.success,
+          cpuMetrics: perfMetrics?.cpuMetrics,
         });
 
         if (result.success) {
@@ -260,6 +324,7 @@ async function runPatternTests(
         }
         if (result.stdout) {
           for (const line of result.stdout.trimEnd().split("\n")) {
+            if (line.trim().startsWith('{"kind":"cf-test-metrics"')) continue;
             console.log(`   ${line}`);
           }
         }
@@ -299,6 +364,15 @@ async function runPatternTests(
     const junitPath = path.join(junitDir, "pattern-unit-tests.xml");
     await Deno.writeTextFile(junitPath, xml);
     console.log(`Wrote JUnit timing to ${junitPath}`);
+
+    if (perfJsonEnabled) {
+      const perfJsonPath = path.join(junitDir, "pattern-unit-metrics.json");
+      await Deno.writeTextFile(
+        perfJsonPath,
+        buildPatternCpuMetricsJson(testTimings),
+      );
+      console.log(`Wrote pattern-unit metrics to ${perfJsonPath}`);
+    }
   }
 
   return failed.length === 0;

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -22,7 +22,9 @@ import {
   type BaselineOverrides,
   computeBaseline,
   downloadAndParseJUnit,
+  downloadAndParsePatternTestMetrics,
   extractMetrics,
+  extractPatternTestCpuMetrics,
   extractTestFileMetrics,
   fetchArtifactsForRun,
   fetchJobsForRun,
@@ -31,14 +33,18 @@ import {
   formatMetricValue,
   formatOverrideSuggestion,
   githubGet,
+  isPatternUnitWallMetric,
+  isVeryLargePatternUnitWallRegression,
   mapConcurrent,
   type MetricTimeline,
   MIN_ABSOLUTE_DELTA,
   MIN_REGRESSION_PCT,
   MIN_SAMPLES,
   parseBaselineOverrides,
+  patternUnitCpuMetricForWallMetric,
   type PRInfo,
   REPO,
+  shouldGatePatternUnitWallRegression,
   STDDEV_FACTOR,
   type TimingSample,
   TOKEN,
@@ -57,6 +63,7 @@ const BASELINE_RUNS = 20;
 const EXCLUDED_METRIC_PATTERNS = [
   /^job: Pattern Unit Tests/,
   /^step: pattern unit tests$/,
+  /^cpu: pattern-unit-\d+\/pattern-unit-tests/,
 ];
 
 // ---------------------------------------------------------------------------
@@ -117,14 +124,31 @@ async function main() {
       (a) => a.name.startsWith("test-timing-") && !a.expired,
     );
     for (const artifact of timingArtifacts) {
+      const artifactName = artifact.name.replace("test-timing-", "");
       const suites = await downloadAndParseJUnit(artifact.id);
       const testMetrics = extractTestFileMetrics(
         currentRunInfo,
-        artifact.name.replace("test-timing-", ""),
+        artifactName,
         suites,
       );
       for (const [name, sample] of testMetrics) {
         currentMetrics.set(name, sample);
+      }
+
+      if (artifactName.startsWith("pattern-unit-")) {
+        const patternMetricArtifacts = await downloadAndParsePatternTestMetrics(
+          artifact.id,
+        );
+        for (const patternMetricArtifact of patternMetricArtifacts) {
+          const cpuMetrics = extractPatternTestCpuMetrics(
+            currentRunInfo,
+            artifactName,
+            patternMetricArtifact,
+          );
+          for (const [name, sample] of cpuMetrics) {
+            currentMetrics.set(name, sample);
+          }
+        }
       }
     }
   } catch (e) {
@@ -181,15 +205,33 @@ async function main() {
         (a) => a.name.startsWith("test-timing-") && !a.expired,
       );
       for (const artifact of timingArtifacts) {
+        const artifactName = artifact.name.replace("test-timing-", "");
         const suites = await downloadAndParseJUnit(artifact.id);
         if (suites.length > 0) {
           const testMetrics = extractTestFileMetrics(
             run,
-            artifact.name.replace("test-timing-", ""),
+            artifactName,
             suites,
           );
           for (const [name, sample] of testMetrics) {
             addSample(timelines, name, sample);
+          }
+        }
+
+        if (artifactName.startsWith("pattern-unit-")) {
+          const patternMetricArtifacts =
+            await downloadAndParsePatternTestMetrics(
+              artifact.id,
+            );
+          for (const patternMetricArtifact of patternMetricArtifacts) {
+            const cpuMetrics = extractPatternTestCpuMetrics(
+              run,
+              artifactName,
+              patternMetricArtifact,
+            );
+            for (const [name, sample] of cpuMetrics) {
+              addSample(timelines, name, sample);
+            }
           }
         }
       }
@@ -220,7 +262,7 @@ async function main() {
   }
 
   // 5. Compare current metrics against baseline
-  type Status = "OVER" | "CLOSE" | "OK" | "ovrd" | "excl" | "n/a";
+  type Status = "OVER" | "WATCH" | "CLOSE" | "OK" | "ovrd" | "excl" | "n/a";
   interface Row {
     metric: string;
     status: Status;
@@ -236,12 +278,27 @@ async function main() {
      * as a percentage. 0% = at median; 100% = at threshold; >100% = over.
      */
     headroomPct?: number;
+    note?: string;
   }
 
-  const rows: Row[] = [];
-  const failures: Row[] = [];
+  interface MetricEvaluation {
+    current: number;
+    n: number;
+    baseline: ReturnType<typeof computeBaseline>;
+    stats?: {
+      median: number;
+      variance: number;
+      stddev: number;
+      threshold: number;
+      pctIncrease: number;
+      headroomPct: number;
+    };
+  }
 
-  for (const [metric, currentSample] of currentMetrics) {
+  const evaluateMetric = (
+    metric: string,
+    currentSample: TimingSample,
+  ): MetricEvaluation => {
     const current = currentSample.durationSeconds;
     const timeline = timelines.get(metric);
     const n = timeline?.samples.length ?? 0;
@@ -252,22 +309,39 @@ async function main() {
       )
       : null;
 
-    const stats = baseline && {
-      median: baseline.median,
-      variance: baseline.variance,
-      stddev: baseline.stddev,
-      threshold: baseline.threshold,
-      pctIncrease: ((current - baseline.median) / baseline.median) * 100,
-      headroomPct: baseline.threshold > baseline.median
-        ? ((current - baseline.median) /
-          (baseline.threshold - baseline.median)) * 100
-        : 0,
-    };
+    const stats = baseline
+      ? {
+        median: baseline.median,
+        variance: baseline.variance,
+        stddev: baseline.stddev,
+        threshold: baseline.threshold,
+        pctIncrease: ((current - baseline.median) / baseline.median) * 100,
+        headroomPct: baseline.threshold > baseline.median
+          ? ((current - baseline.median) /
+            (baseline.threshold - baseline.median)) * 100
+          : 0,
+      }
+      : undefined;
+
+    return { current, n, baseline, stats };
+  };
+
+  const rows: Row[] = [];
+  const failures: Row[] = [];
+
+  for (const [metric, currentSample] of currentMetrics) {
+    const { current, n, baseline, stats } = evaluateMetric(
+      metric,
+      currentSample,
+    );
 
     // Metrics whose aggregate values grow as tests are added — never fail,
     // but still shown so the log has full context.
     if (EXCLUDED_METRIC_PATTERNS.some((re) => re.test(metric))) {
-      rows.push({ metric, status: "excl", current, n, ...(stats ?? {}) });
+      const note = metric.startsWith("cpu: pattern-unit-")
+        ? "used to corroborate pattern-unit wall-clock outliers"
+        : undefined;
+      rows.push({ metric, status: "excl", current, n, ...(stats ?? {}), note });
       continue;
     }
 
@@ -288,6 +362,40 @@ async function main() {
 
     if (current > baseline.threshold) {
       const row: Row = { metric, status: "OVER", current, n, ...stats! };
+      if (isPatternUnitWallMetric(metric)) {
+        const cpuMetric = patternUnitCpuMetricForWallMetric(metric);
+        const cpuSample = cpuMetric ? currentMetrics.get(cpuMetric) : undefined;
+        const cpuEvaluation = cpuMetric && cpuSample
+          ? evaluateMetric(cpuMetric, cpuSample)
+          : undefined;
+        const cpuFailed = Boolean(
+          cpuEvaluation?.baseline &&
+            cpuEvaluation.current > cpuEvaluation.baseline.threshold,
+        );
+        const gatePatternWallMetric = shouldGatePatternUnitWallRegression({
+          wallFailed: true,
+          wallCurrentSeconds: current,
+          wallBaselineMedianSeconds: baseline.median,
+          cpuFailed,
+        });
+
+        if (!gatePatternWallMetric) {
+          rows.push({
+            ...row,
+            status: "WATCH",
+            note: cpuMetric
+              ? `wall-clock over threshold; ${cpuMetric} did not corroborate`
+              : "wall-clock over threshold; CPU metric unavailable",
+          });
+          continue;
+        }
+
+        row.note = cpuFailed && cpuMetric
+          ? `CPU corroborated by ${cpuMetric}`
+          : isVeryLargePatternUnitWallRegression(current, baseline.median)
+          ? "very large wall-clock regression"
+          : undefined;
+      }
       rows.push(row);
       failures.push(row);
     } else if ((stats!.headroomPct ?? 0) >= 50) {
@@ -307,17 +415,19 @@ async function main() {
       `\n!!! PERFORMANCE REGRESSION DETECTED in ${failures.length} metric(s) !!!\n`,
     );
     console.log(
-      "| Metric | Current | Baseline (median) | Threshold | Change |",
+      "| Metric | Current | Baseline (median) | Threshold | Change | Reason |",
     );
     console.log(
-      "|--------|---------|-------------------|-----------|--------|",
+      "|--------|---------|-------------------|-----------|--------|--------|",
     );
     for (const f of failures) {
       const fmt = (v: number) => formatMetricValue(f.metric, v);
       console.log(
         `| ${f.metric} | ${fmt(f.current)} | ${fmt(f.median!)} | ${
           fmt(f.threshold!)
-        } | +${f.pctIncrease!.toFixed(0)}% |`,
+        } | +${f.pctIncrease!.toFixed(0)}% | ${
+          f.note ?? "threshold exceeded"
+        } |`,
       );
     }
 
@@ -351,7 +461,7 @@ async function main() {
     }% (whichever is higher); non-bench metrics also require at least +${MIN_ABSOLUTE_DELTA}s.`,
   );
   console.log(
-    "Status key: OVER = over threshold (fails); CLOSE = ≥50% of margin consumed;",
+    "Status key: OVER = over threshold (fails); WATCH = over pattern-unit wall-clock threshold without CPU corroboration; CLOSE = ≥50% of margin consumed;",
   );
   console.log(
     "  OK = <50% consumed; ovrd = saved by a PR override; excl = metric excluded from the check;",
@@ -376,23 +486,33 @@ async function main() {
         return "Test files";
       case "subtest":
         return "Subtests";
+      case "cpu":
+        return "CPU";
       case "bench":
         return "Benchmarks";
       default:
         return prefix;
     }
   };
-  const KIND_ORDER = ["Jobs", "Steps", "Test files", "Subtests", "Benchmarks"];
+  const KIND_ORDER = [
+    "Jobs",
+    "Steps",
+    "Test files",
+    "Subtests",
+    "CPU",
+    "Benchmarks",
+  ];
   // Sort order within each kind: most at-risk of failing the check first.
   // `ovrd` sits below `OK` because an override-protected metric is at strictly
   // lower risk of tripping the check than an unguarded OK metric — the author
   // has already authorized its current level.
   const STATUS_ORDER: Record<Status, number> = {
     OVER: 5,
-    CLOSE: 4,
-    OK: 3,
-    ovrd: 2,
-    excl: 1,
+    WATCH: 4,
+    CLOSE: 3,
+    OK: 2,
+    ovrd: 1,
+    excl: 0,
     "n/a": 0,
   };
 
@@ -409,6 +529,7 @@ async function main() {
 
   const counts = {
     OVER: 0,
+    WATCH: 0,
     CLOSE: 0,
     OK: 0,
     ovrd: 0,
@@ -418,7 +539,7 @@ async function main() {
   for (const r of rows) counts[r.status]++;
 
   console.log(
-    `\n## All metrics checked  (${rows.length} total — OVER: ${counts.OVER}, CLOSE: ${counts.CLOSE}, OK: ${counts.OK}, ovrd: ${counts.ovrd}, excl: ${counts.excl}, n/a: ${
+    `\n## All metrics checked  (${rows.length} total — OVER: ${counts.OVER}, WATCH: ${counts.WATCH}, CLOSE: ${counts.CLOSE}, OK: ${counts.OK}, ovrd: ${counts.ovrd}, excl: ${counts.excl}, n/a: ${
       counts["n/a"]
     })`,
   );
@@ -432,9 +553,9 @@ async function main() {
     });
     console.log(`\n### ${kind}  (${rs.length})`);
     console.log(
-      "| status | head% | Δ% | current | baseline median | threshold | n | metric |",
+      "| status | head% | Δ% | current | baseline median | threshold | n | metric | note |",
     );
-    console.log("|:---|---:|---:|---:|---:|---:|---:|:--|");
+    console.log("|:---|---:|---:|---:|---:|---:|---:|:--|:--|");
     for (const r of rs) {
       const fmt = (v: number | undefined) =>
         v === undefined ? "—" : formatMetricValue(r.metric, v);
@@ -447,7 +568,7 @@ async function main() {
       console.log(
         `| ${r.status} | ${head} | ${pct} | ${fmt(r.current)} | ${
           fmt(r.median)
-        } | ${fmt(r.threshold)} | ${r.n} | ${r.metric} |`,
+        } | ${fmt(r.threshold)} | ${r.n} | ${r.metric} | ${r.note ?? ""} |`,
       );
     }
   }

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -34,6 +34,7 @@ import {
   formatOverrideSuggestion,
   githubGet,
   isPatternUnitWallMetric,
+  isTestMetricForPrefix,
   isVeryLargePatternUnitWallRegression,
   mapConcurrent,
   type MetricTimeline,
@@ -46,6 +47,7 @@ import {
   REPO,
   shouldGatePatternUnitWallRegression,
   STDDEV_FACTOR,
+  testMetricPrefixesForStepMetric,
   type TimingSample,
   TOKEN,
   WORKFLOW_FILE,
@@ -395,6 +397,37 @@ async function main() {
           : isVeryLargePatternUnitWallRegression(current, baseline.median)
           ? "very large wall-clock regression"
           : undefined;
+      } else {
+        const relatedPrefixes = testMetricPrefixesForStepMetric(metric);
+        if (relatedPrefixes.length > 0) {
+          const corroboratingMetrics = [...currentMetrics]
+            .filter(([candidate]) =>
+              relatedPrefixes.some((prefix) =>
+                isTestMetricForPrefix(candidate, prefix)
+              )
+            )
+            .filter(([candidate, sample]) => {
+              const candidateEvaluation = evaluateMetric(candidate, sample);
+              return Boolean(candidateEvaluation.baseline) &&
+                candidateEvaluation.current >
+                  candidateEvaluation.baseline!.threshold;
+            })
+            .map(([candidate]) => candidate);
+
+          if (corroboratingMetrics.length === 0) {
+            rows.push({
+              ...row,
+              status: "WATCH",
+              note:
+                "step wall-clock over threshold; related test timings did not corroborate",
+            });
+            continue;
+          }
+
+          row.note = `corroborated by ${
+            corroboratingMetrics.slice(0, 3).join(", ")
+          }`;
+        }
       }
       rows.push(row);
       failures.push(row);

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -3,12 +3,16 @@ import {
   computeBaseline,
   extractMetrics,
   extractPatternTestCpuMetrics,
+  extractTestFileMetrics,
   isPatternUnitWallMetric,
+  isTestMetricForPrefix,
   type Job,
+  parseJUnitXml,
   parsePatternTestMetricsJson,
   patternUnitCpuMetricForWallMetric,
   shouldGatePatternUnitWallRegression,
   type Step,
+  testMetricPrefixesForStepMetric,
   type WorkflowRun,
 } from "./perf-lib.ts";
 
@@ -105,6 +109,69 @@ Deno.test("computeBaseline uses the 3 sigma threshold when it exceeds 15 percent
   assertEquals(baseline?.median, 100);
   assertAlmostEquals(baseline?.stddev ?? 0, 20, 1e-9);
   assertEquals(baseline?.threshold, 160);
+});
+
+Deno.test("parseJUnitXml accepts Deno suites without suite-level time", () => {
+  const suites = parseJUnitXml(
+    `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="deno test" tests="2" failures="0" errors="0" time="1.500">
+  <testsuite name="./integration/shell.test.ts" tests="2" disabled="0" errors="0" failures="0">
+    <testcase name="shell tests" classname="./integration/shell.test.ts" time="1.250" line="1" col="1"></testcase>
+    <testcase name="shell tests &gt; opens menu" classname="ext:cli/40_test.js" time="0.250" line="2" col="1" />
+  </testsuite>
+</testsuites>`,
+    "shell",
+  );
+
+  assertEquals(suites.length, 1);
+  assertEquals(suites[0].name, "./integration/shell.test.ts");
+  assertEquals(suites[0].sourceLabel, "shell");
+  assertAlmostEquals(suites[0].time, 1.5, 1e-9);
+  assertEquals(suites[0].tests.length, 2);
+  assertEquals(suites[0].tests[1].name, "shell tests &gt; opens menu");
+});
+
+Deno.test("extractTestFileMetrics includes XML source label when present", () => {
+  const metrics = extractTestFileMetrics(makeRun(), "package-integration", [{
+    name: "./integration/shell.test.ts",
+    time: 1.5,
+    sourceLabel: "shell",
+    tests: [{ name: "shell tests", time: 1.25 }],
+  }]);
+
+  assertAlmostEquals(
+    metrics.get("test: package-integration/shell/./integration/shell.test.ts")
+      ?.durationSeconds ?? 0,
+    1.5,
+    1e-9,
+  );
+  assertAlmostEquals(
+    metrics.get(
+      "subtest: package-integration/shell/./integration/shell.test.ts > shell tests",
+    )?.durationSeconds ?? 0,
+    1.25,
+    1e-9,
+  );
+});
+
+Deno.test("step metrics map to related test metric prefixes", () => {
+  assertEquals(testMetricPrefixesForStepMetric("step: shell integration"), [
+    "package-integration/shell/",
+  ]);
+  assertEquals(
+    isTestMetricForPrefix(
+      "subtest: package-integration/shell/./integration/shell.test.ts > shell tests",
+      "package-integration/shell/",
+    ),
+    true,
+  );
+  assertEquals(
+    isTestMetricForPrefix(
+      "subtest: package-integration/runner/./integration/runner.test.ts > runner tests",
+      "package-integration/shell/",
+    ),
+    false,
+  );
 });
 
 Deno.test("parsePatternTestMetricsJson accepts pattern-unit CPU metrics", () => {

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -2,7 +2,12 @@ import { assertAlmostEquals, assertEquals } from "@std/assert";
 import {
   computeBaseline,
   extractMetrics,
+  extractPatternTestCpuMetrics,
+  isPatternUnitWallMetric,
   type Job,
+  parsePatternTestMetricsJson,
+  patternUnitCpuMetricForWallMetric,
+  shouldGatePatternUnitWallRegression,
   type Step,
   type WorkflowRun,
 } from "./perf-lib.ts";
@@ -100,4 +105,147 @@ Deno.test("computeBaseline uses the 3 sigma threshold when it exceeds 15 percent
   assertEquals(baseline?.median, 100);
   assertAlmostEquals(baseline?.stddev ?? 0, 20, 1e-9);
   assertEquals(baseline?.threshold, 160);
+});
+
+Deno.test("parsePatternTestMetricsJson accepts pattern-unit CPU metrics", () => {
+  const parsed = parsePatternTestMetricsJson(JSON.stringify({
+    kind: "pattern-test-metrics",
+    version: 1,
+    metrics: [
+      {
+        file: "packages/patterns/calendar/calendar.test.tsx",
+        durationMs: 12_500,
+        passed: true,
+        cpuMetrics: {
+          userCpuMicros: 2_000_000,
+          systemCpuMicros: 500_000,
+          totalCpuMicros: 2_500_000,
+          rssBytes: 400_000_000,
+          heapTotalBytes: 100_000_000,
+          heapUsedBytes: 80_000_000,
+          externalBytes: 10_000_000,
+        },
+      },
+    ],
+  }));
+
+  assertEquals(parsed?.kind, "pattern-test-metrics");
+  assertEquals(parsed?.metrics.length, 1);
+  assertEquals(parsed?.metrics[0].cpuMetrics?.totalCpuMicros, 2_500_000);
+});
+
+Deno.test("extractPatternTestCpuMetrics emits aggregate and per-file CPU seconds", () => {
+  const parsed = parsePatternTestMetricsJson(JSON.stringify({
+    kind: "pattern-test-metrics",
+    version: 1,
+    metrics: [
+      {
+        file: "packages/patterns/calendar/calendar.test.tsx",
+        durationMs: 12_500,
+        passed: true,
+        cpuMetrics: {
+          userCpuMicros: 2_000_000,
+          systemCpuMicros: 500_000,
+          totalCpuMicros: 2_500_000,
+          rssBytes: 400_000_000,
+          heapTotalBytes: 100_000_000,
+          heapUsedBytes: 80_000_000,
+          externalBytes: 10_000_000,
+        },
+      },
+      {
+        file: "packages/patterns/reading-list/reading-list.test.tsx",
+        durationMs: 8_000,
+        passed: true,
+        cpuMetrics: {
+          userCpuMicros: 3_000_000,
+          systemCpuMicros: 250_000,
+          totalCpuMicros: 3_250_000,
+          rssBytes: 410_000_000,
+          heapTotalBytes: 110_000_000,
+          heapUsedBytes: 85_000_000,
+          externalBytes: 11_000_000,
+        },
+      },
+    ],
+  }));
+  if (!parsed) throw new Error("expected valid pattern metrics JSON");
+
+  const metrics = extractPatternTestCpuMetrics(
+    makeRun(),
+    "pattern-unit-2",
+    parsed,
+  );
+
+  assertAlmostEquals(
+    metrics.get("cpu: pattern-unit-2/pattern-unit-tests")
+      ?.durationSeconds ?? 0,
+    5.75,
+    1e-9,
+  );
+  assertAlmostEquals(
+    metrics.get(
+      "cpu: pattern-unit-2/pattern-unit-tests > packages/patterns/calendar/calendar.test.tsx",
+    )?.durationSeconds ?? 0,
+    2.5,
+    1e-9,
+  );
+});
+
+Deno.test("pattern-unit wall metrics map to matching CPU metrics", () => {
+  assertEquals(
+    patternUnitCpuMetricForWallMetric(
+      "test: pattern-unit-1/pattern-unit-tests",
+    ),
+    "cpu: pattern-unit-1/pattern-unit-tests",
+  );
+  assertEquals(
+    patternUnitCpuMetricForWallMetric(
+      "subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/calendar/calendar.test.tsx",
+    ),
+    "cpu: pattern-unit-1/pattern-unit-tests > packages/patterns/calendar/calendar.test.tsx",
+  );
+  assertEquals(
+    isPatternUnitWallMetric("step: pattern unit tests"),
+    false,
+  );
+});
+
+Deno.test("shouldGatePatternUnitWallRegression requires CPU corroboration unless wall is very large", () => {
+  assertEquals(
+    shouldGatePatternUnitWallRegression({
+      wallFailed: true,
+      wallCurrentSeconds: 12,
+      wallBaselineMedianSeconds: 10,
+      cpuFailed: true,
+    }),
+    true,
+  );
+  assertEquals(
+    shouldGatePatternUnitWallRegression({
+      wallFailed: true,
+      wallCurrentSeconds: 13,
+      wallBaselineMedianSeconds: 10,
+      cpuFailed: false,
+    }),
+    false,
+  );
+  assertEquals(
+    shouldGatePatternUnitWallRegression({
+      wallFailed: true,
+      wallCurrentSeconds: 14.1,
+      wallBaselineMedianSeconds: 10,
+      cpuFailed: false,
+    }),
+    true,
+  );
+  assertEquals(
+    shouldGatePatternUnitWallRegression({
+      wallFailed: false,
+      wallCurrentSeconds: 14.1,
+      wallBaselineMedianSeconds: 10,
+      cpuFailed: true,
+    }),
+    false,
+  );
 });

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -113,6 +113,7 @@ export interface Regression {
 export interface JUnitTestSuite {
   name: string;
   time: number;
+  sourceLabel?: string;
   tests: { name: string; time: number }[];
 }
 
@@ -303,12 +304,20 @@ export async function downloadAndParseJUnit(
     const result = await unzip.output();
     if (!result.success) return [];
 
-    const suites: JUnitTestSuite[] = [];
+    const xmlEntries: string[] = [];
     for await (const entry of walkFiles(tmpDir)) {
       if (entry.endsWith(".xml")) {
-        const content = await Deno.readTextFile(entry);
-        suites.push(...parseJUnitXml(content));
+        xmlEntries.push(entry);
       }
+    }
+
+    const suites: JUnitTestSuite[] = [];
+    for (const entry of xmlEntries) {
+      const content = await Deno.readTextFile(entry);
+      const sourceLabel = xmlEntries.length > 1
+        ? junitSourceLabel(entry)
+        : undefined;
+      suites.push(...parseJUnitXml(content, sourceLabel));
     }
     return suites;
   } finally {
@@ -328,30 +337,59 @@ export async function* walkFiles(dir: string): AsyncGenerator<string> {
   }
 }
 
-export function parseJUnitXml(xml: string): JUnitTestSuite[] {
+function junitSourceLabel(filePath: string): string {
+  const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
+  return fileName.replace(/\.xml$/i, "");
+}
+
+function parseXmlAttributes(attrs: string): Map<string, string> {
+  const result = new Map<string, string>();
+  const attrRegex = /([:\w.-]+)="([^"]*)"/g;
+  let match;
+  while ((match = attrRegex.exec(attrs)) !== null) {
+    result.set(match[1], match[2]);
+  }
+  return result;
+}
+
+export function parseJUnitXml(
+  xml: string,
+  sourceLabel?: string,
+): JUnitTestSuite[] {
   const suites: JUnitTestSuite[] = [];
 
-  const suiteRegex =
-    /<testsuite\s[^>]*?name="([^"]*)"[^>]*?time="([^"]*)"[^>]*?>([\s\S]*?)<\/testsuite>/g;
-  const caseRegex =
-    /<testcase\s[^>]*?name="([^"]*)"[^>]*?time="([^"]*)"[^>]*?\/?>(?:<\/testcase>)?/g;
+  const suiteRegex = /<testsuite\b([^>]*)>([\s\S]*?)<\/testsuite>/g;
+  const caseRegex = /<testcase\b([^>]*?)(?:\/>|>[\s\S]*?<\/testcase>)/g;
 
   let suiteMatch;
   while ((suiteMatch = suiteRegex.exec(xml)) !== null) {
-    const [, suiteName, suiteTime, suiteBody] = suiteMatch;
+    const [, suiteAttrs, suiteBody] = suiteMatch;
+    const attrs = parseXmlAttributes(suiteAttrs);
+    const suiteName = attrs.get("name");
+    if (!suiteName) continue;
+
     const tests: { name: string; time: number }[] = [];
 
     let caseMatch;
     while ((caseMatch = caseRegex.exec(suiteBody)) !== null) {
+      const caseAttrs = parseXmlAttributes(caseMatch[1]);
+      const caseName = caseAttrs.get("name");
+      if (!caseName) continue;
       tests.push({
-        name: caseMatch[1],
-        time: parseFloat(caseMatch[2]) || 0,
+        name: caseName,
+        time: parseFloat(caseAttrs.get("time") ?? "0") || 0,
       });
     }
 
+    const suiteTime = parseFloat(attrs.get("time") ?? "");
+    const time = Number.isFinite(suiteTime)
+      ? suiteTime
+      : tests.reduce((sum, test) => sum + test.time, 0);
+
     suites.push({
       name: suiteName,
-      time: parseFloat(suiteTime) || 0,
+      time,
+      sourceLabel,
       tests,
     });
   }
@@ -835,12 +873,15 @@ export function extractTestFileMetrics(
 
   for (const suite of suites) {
     if (suite.time <= 0) continue;
-    const key = `test: ${artifactName}/${suite.name}`;
+    const metricBase = suite.sourceLabel
+      ? `${artifactName}/${suite.sourceLabel}`
+      : artifactName;
+    const key = `test: ${metricBase}/${suite.name}`;
     metrics.set(key, makeSample(suite.time));
 
     for (const test of suite.tests) {
       if (test.time <= 0) continue;
-      const testKey = `subtest: ${artifactName}/${suite.name} > ${test.name}`;
+      const testKey = `subtest: ${metricBase}/${suite.name} > ${test.name}`;
       metrics.set(testKey, makeSample(test.time));
     }
   }
@@ -877,6 +918,26 @@ export function patternUnitCpuMetricForWallMetric(
 
 export function isPatternUnitWallMetric(metric: string): boolean {
   return patternUnitCpuMetricForWallMetric(metric) !== null;
+}
+
+const STEP_TEST_METRIC_PREFIXES: Record<string, string[]> = {
+  "step: runner integration": ["package-integration/runner/"],
+  "step: runtime-client integration": ["package-integration/runtime-client/"],
+  "step: shell integration": ["package-integration/shell/"],
+  "step: background worker integration": [
+    "package-integration/background-charm-service/",
+  ],
+  "step: patterns integration": ["pattern-integration/"],
+  "step: generated patterns integration": ["generated-patterns/"],
+};
+
+export function testMetricPrefixesForStepMetric(metric: string): string[] {
+  return STEP_TEST_METRIC_PREFIXES[metric] ?? [];
+}
+
+export function isTestMetricForPrefix(metric: string, prefix: string): boolean {
+  return metric.startsWith(`test: ${prefix}`) ||
+    metric.startsWith(`subtest: ${prefix}`);
 }
 
 export function isVeryLargePatternUnitWallRegression(

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -116,6 +116,29 @@ export interface JUnitTestSuite {
   tests: { name: string; time: number }[];
 }
 
+export interface PatternTestCpuMetrics {
+  userCpuMicros: number;
+  systemCpuMicros: number;
+  totalCpuMicros: number;
+  rssBytes: number;
+  heapTotalBytes: number;
+  heapUsedBytes: number;
+  externalBytes: number;
+}
+
+export interface PatternTestMetric {
+  file: string;
+  durationMs: number;
+  passed: boolean;
+  cpuMetrics?: PatternTestCpuMetrics;
+}
+
+export interface PatternTestMetricsArtifact {
+  kind: "pattern-test-metrics";
+  version: number;
+  metrics: PatternTestMetric[];
+}
+
 /** Structured output from `deno bench --json`. */
 export interface DenoBenchResult {
   version: number;
@@ -291,7 +314,9 @@ export async function downloadAndParseJUnit(
   } finally {
     try {
       await Deno.remove(tmpDir, { recursive: true });
-    } catch { /* ignore cleanup errors */ }
+    } catch (error) {
+      console.warn(`Warning: could not remove ${tmpDir}: ${error}`);
+    }
   }
 }
 
@@ -332,6 +357,122 @@ export function parseJUnitXml(xml: string): JUnitTestSuite[] {
   }
 
   return suites;
+}
+
+export async function downloadAndParsePatternTestMetrics(
+  artifactId: number,
+): Promise<PatternTestMetricsArtifact[]> {
+  const resp = await fetch(
+    `https://api.github.com/repos/${REPO}/actions/artifacts/${artifactId}/zip`,
+    { headers: apiHeaders() },
+  );
+  if (!resp.ok) return [];
+
+  const tmpDir = await Deno.makeTempDir({ prefix: "perf-pattern-metrics-" });
+  const zipPath = `${tmpDir}/artifact.zip`;
+
+  try {
+    const data = new Uint8Array(await resp.arrayBuffer());
+    await Deno.writeFile(zipPath, data);
+
+    const unzip = new Deno.Command("unzip", {
+      args: ["-o", zipPath, "-d", tmpDir],
+      stdout: "null",
+      stderr: "null",
+    });
+    const result = await unzip.output();
+    if (!result.success) return [];
+
+    const artifacts: PatternTestMetricsArtifact[] = [];
+    for await (const entry of walkFiles(tmpDir)) {
+      if (!entry.endsWith("pattern-unit-metrics.json")) continue;
+      const content = await Deno.readTextFile(entry);
+      const parsed = parsePatternTestMetricsJson(content);
+      if (parsed) artifacts.push(parsed);
+    }
+    return artifacts;
+  } finally {
+    try {
+      await Deno.remove(tmpDir, { recursive: true });
+    } catch (error) {
+      console.warn(`Warning: could not remove ${tmpDir}: ${error}`);
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function numberField(
+  record: Record<string, unknown>,
+  key: string,
+): number | null {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parsePatternTestCpuMetrics(
+  value: unknown,
+): PatternTestCpuMetrics | undefined {
+  if (!isRecord(value)) return undefined;
+  const userCpuMicros = numberField(value, "userCpuMicros");
+  const systemCpuMicros = numberField(value, "systemCpuMicros");
+  const totalCpuMicros = numberField(value, "totalCpuMicros");
+  const rssBytes = numberField(value, "rssBytes");
+  const heapTotalBytes = numberField(value, "heapTotalBytes");
+  const heapUsedBytes = numberField(value, "heapUsedBytes");
+  const externalBytes = numberField(value, "externalBytes");
+  if (
+    userCpuMicros === null || systemCpuMicros === null ||
+    totalCpuMicros === null || rssBytes === null ||
+    heapTotalBytes === null || heapUsedBytes === null || externalBytes === null
+  ) {
+    return undefined;
+  }
+  return {
+    userCpuMicros,
+    systemCpuMicros,
+    totalCpuMicros,
+    rssBytes,
+    heapTotalBytes,
+    heapUsedBytes,
+    externalBytes,
+  };
+}
+
+export function parsePatternTestMetricsJson(
+  json: string,
+): PatternTestMetricsArtifact | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed)) return null;
+  if (parsed.kind !== "pattern-test-metrics") return null;
+  const version = numberField(parsed, "version");
+  if (version === null || !Array.isArray(parsed.metrics)) return null;
+
+  const metrics: PatternTestMetric[] = [];
+  for (const value of parsed.metrics) {
+    if (!isRecord(value)) continue;
+    const file = value.file;
+    const durationMs = numberField(value, "durationMs");
+    const passed = value.passed;
+    if (
+      typeof file !== "string" || durationMs === null ||
+      typeof passed !== "boolean"
+    ) {
+      continue;
+    }
+    const cpuMetrics = parsePatternTestCpuMetrics(value.cpuMetrics);
+    metrics.push({ file, durationMs, passed, cpuMetrics });
+  }
+
+  return { kind: "pattern-test-metrics", version, metrics };
 }
 
 // ---------------------------------------------------------------------------
@@ -702,6 +843,97 @@ export function extractTestFileMetrics(
       const testKey = `subtest: ${artifactName}/${suite.name} > ${test.name}`;
       metrics.set(testKey, makeSample(test.time));
     }
+  }
+
+  return metrics;
+}
+
+const PATTERN_UNIT_TEST_SUITE_NAME = "pattern-unit-tests";
+
+export const PATTERN_UNIT_LARGE_WALL_REGRESSION_PCT = 0.40;
+export const PATTERN_UNIT_LARGE_WALL_REGRESSION_SECONDS = 2;
+
+export function patternUnitCpuMetricForWallMetric(
+  metric: string,
+): string | null {
+  const aggregateMatch = metric.match(
+    /^test: (pattern-unit-\d+)\/pattern-unit-tests$/,
+  );
+  if (aggregateMatch) {
+    return `cpu: ${aggregateMatch[1]}/${PATTERN_UNIT_TEST_SUITE_NAME}`;
+  }
+
+  const fileMatch = metric.match(
+    /^subtest: (pattern-unit-\d+)\/pattern-unit-tests > (.+)$/,
+  );
+  if (fileMatch) {
+    return `cpu: ${fileMatch[1]}/${PATTERN_UNIT_TEST_SUITE_NAME} > ${
+      fileMatch[2]
+    }`;
+  }
+
+  return null;
+}
+
+export function isPatternUnitWallMetric(metric: string): boolean {
+  return patternUnitCpuMetricForWallMetric(metric) !== null;
+}
+
+export function isVeryLargePatternUnitWallRegression(
+  currentSeconds: number,
+  baselineMedianSeconds: number,
+): boolean {
+  return currentSeconds > Math.max(
+    baselineMedianSeconds * (1 + PATTERN_UNIT_LARGE_WALL_REGRESSION_PCT),
+    baselineMedianSeconds + PATTERN_UNIT_LARGE_WALL_REGRESSION_SECONDS,
+  );
+}
+
+export function shouldGatePatternUnitWallRegression(args: {
+  wallFailed: boolean;
+  wallCurrentSeconds: number;
+  wallBaselineMedianSeconds: number;
+  cpuFailed: boolean;
+}): boolean {
+  return args.wallFailed &&
+    (args.cpuFailed ||
+      isVeryLargePatternUnitWallRegression(
+        args.wallCurrentSeconds,
+        args.wallBaselineMedianSeconds,
+      ));
+}
+
+export function extractPatternTestCpuMetrics(
+  run: WorkflowRun,
+  artifactName: string,
+  artifact: PatternTestMetricsArtifact,
+): Map<string, TimingSample> {
+  const metrics = new Map<string, TimingSample>();
+
+  const makeSample = (totalCpuMicros: number): TimingSample => ({
+    runId: run.id,
+    runUrl: run.html_url,
+    sha: run.head_sha,
+    createdAt: run.created_at,
+    durationSeconds: totalCpuMicros / 1_000_000,
+  });
+
+  let aggregateCpuMicros = 0;
+  for (const metric of artifact.metrics) {
+    const totalCpuMicros = metric.cpuMetrics?.totalCpuMicros;
+    if (totalCpuMicros === undefined || totalCpuMicros <= 0) continue;
+    aggregateCpuMicros += totalCpuMicros;
+    metrics.set(
+      `cpu: ${artifactName}/${PATTERN_UNIT_TEST_SUITE_NAME} > ${metric.file}`,
+      makeSample(totalCpuMicros),
+    );
+  }
+
+  if (aggregateCpuMicros > 0) {
+    metrics.set(
+      `cpu: ${artifactName}/${PATTERN_UNIT_TEST_SUITE_NAME}`,
+      makeSample(aggregateCpuMicros),
+    );
   }
 
   return metrics;


### PR DESCRIPTION
## Summary
- add an opt-in `--perf-json` mode to `cf test` that emits one machine-readable metrics record per completed test file
- capture per-file CPU time (`cpuUsage`) plus memory snapshots in the pattern test harness
- extend `tasks/integration.ts` to collect those child-emitted metrics and write a sibling `pattern-unit-metrics.json` artifact next to the existing JUnit timing file
- parse Deno JUnit XML that omits suite-level `time` and label multi-XML artifacts so shell/package integration test timings are visible
- demote generic integration step wall-clock overages to `WATCH` unless related test/subtest timings corroborate the regression

## Why
The current perf gate includes wall-clock CI timings that are useful telemetry but can be too noisy to treat as benchmark-grade signal on their own. Repeated sampling showed flakiness in pattern-unit wall-clock subprocess timings and short browser integration steps. This PR adds CPU metrics for pattern tests and uses underlying JUnit test timings to corroborate step-level wall-clock outliers.

## Validation
- `deno task cf test --root packages/patterns packages/patterns/cfc-render-policy-demo/main.test.tsx --perf-json --memory-version v2`
- `CF_INTEGRATION_PERF_JSON=1 deno task integration --junit-dir=/tmp/pattern-metrics-check pattern-tests 1/5`
- `deno test --allow-env packages/cli/test/test-runner.test.ts`
- `deno test --allow-env tasks/perf-lib.test.ts`
- `deno task --cwd packages/cli test`
- `deno task check`
- replayed `tasks/perf-check.ts` against PR #3375 run `24971407249`; extracted 736 metrics and reported `OVER: 0`, `WATCH: 0`

## Notes
- cubic identified that `passed` in perf JSON was only checking `result.error`; this branch now uses the same failure accounting as the pattern test runner summary.