### PR TITLE
feat(fuse): support docker-readable linux mounts

### DIFF
--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -118,6 +118,10 @@ export const fuse = new Command()
   .option("--background", "Run in the background (detached).")
   .option("--debug", "Enable FUSE debug output.")
   .option(
+    "--allow-other",
+    "Linux only: export the mount to other users such as Docker daemon. Requires user_allow_other in /etc/fuse.conf.",
+  )
+  .option(
     "-s, --space <name:string>",
     "Space(s) to connect (repeatable, default: home).",
     { collect: true },
@@ -135,6 +139,12 @@ export const fuse = new Command()
   .example(
     cliText("cf fuse mount /tmp/cf-fuse --background"),
     cliText("Mount in background; use 'cf fuse status' to check."),
+  )
+  .example(
+    cliText("cf fuse mount /tmp/cf-fuse --allow-other"),
+    cliText(
+      "Linux only: export the mount to Docker or other users.",
+    ),
   )
   .action(async (options, mountpoint) => {
     // globalEnv merges CF_API_URL / CF_IDENTITY into options automatically
@@ -174,6 +184,7 @@ export const fuse = new Command()
       spawnArgs = ["fuse-daemon", absMountpoint];
       if (apiUrl) spawnArgs.push("--api-url", apiUrl);
       if (identity) spawnArgs.push("--identity", identity);
+      if (options.allowOther) spawnArgs.push("--allow-other");
       if (execCli) spawnArgs.push("--exec-cli", execCli);
       for (const s of options.space ?? []) spawnArgs.push("--space", s);
     } else {
@@ -185,6 +196,7 @@ export const fuse = new Command()
         apiUrl,
         identity,
         execCli,
+        allowOther: options.allowOther,
       });
       for (const s of options.space ?? []) spawnArgs.push("--space", s);
     }

--- a/packages/cli/lib/fuse.ts
+++ b/packages/cli/lib/fuse.ts
@@ -289,6 +289,7 @@ export function buildDenoArgs(opts: {
   identity: string;
   execCli: string;
   logFile?: string;
+  allowOther?: boolean;
 }): string[] {
   const args = [
     "run",
@@ -306,6 +307,7 @@ export function buildDenoArgs(opts: {
   if (opts.identity) args.push("--identity", opts.identity);
   if (opts.execCli) args.push("--exec-cli", opts.execCli);
   if (opts.logFile) args.push("--log-file", opts.logFile);
+  if (opts.allowOther) args.push("--allow-other");
 
   return args;
 }

--- a/packages/fuse/README.md
+++ b/packages/fuse/README.md
@@ -213,6 +213,9 @@ cf fuse mount /tmp/cf
 # Mount in background
 cf fuse mount /tmp/cf --background
 
+# Linux: export the mount so Docker/root can traverse it
+cf fuse mount /tmp/cf --allow-other
+
 # Check active mounts
 cf fuse status
 
@@ -227,6 +230,17 @@ cf exec /tmp/cf/home/pieces/todo-app/result/search.tool --help
 ```
 
 Environment variables `CF_API_URL` and `CF_IDENTITY` are also supported.
+
+### Linux: Docker / other-user access
+
+If you need Docker or another user to traverse a Linux FUSE mount, mount with:
+
+```bash
+cf fuse mount /tmp/cf --allow-other
+```
+
+This enables `allow_other` together with `default_permissions`. The host must
+also have `user_allow_other` enabled in `/etc/fuse.conf`.
 
 Handlers remain writable through the mounted `.handler` file. Both mounted
 `.handler` and `.tool` files can be executed directly or via `cf exec`.

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -161,7 +161,12 @@ export async function main(argv: string[] = Deno.args) {
       "cfc-mode",
       "cfc-writeback-state",
     ],
-    boolean: ["debug", "cfc-annotations", "cfc-writeback-xattrs"],
+    boolean: [
+      "debug",
+      "cfc-annotations",
+      "cfc-writeback-xattrs",
+      "allow-other",
+    ],
     collect: ["space"],
     default: {
       "api-url": Deno.env.get("CF_API_URL") ?? "",
@@ -175,6 +180,7 @@ export async function main(argv: string[] = Deno.args) {
       debug: false,
       "cfc-annotations": false,
       "cfc-writeback-xattrs": false,
+      "allow-other": false,
     },
   });
 
@@ -2673,9 +2679,13 @@ export async function main(argv: string[] = Deno.args) {
   setOp(OPS_OFFSETS.create, createCb);
 
   // --- Mount ---
-  const { argsBuf, argv: _argv, encodedArgs: _ea } = platform.createFuseArgs([
-    "fuse_ct",
-  ]);
+  const fuseArgs = ["fuse_ct"];
+  if (Deno.build.os === "linux" && args["allow-other"]) {
+    fuseArgs.push("-o", "allow_other", "-o", "default_permissions");
+  }
+  const { argsBuf, argv: _argv, encodedArgs: _ea } = platform.createFuseArgs(
+    fuseArgs,
+  );
 
   const mountpointBuf = encoder.encode(mountpoint + "\0");
 


### PR DESCRIPTION
## Summary
- add a Linux `--allow-other` flag to `cf fuse mount` so Docker and other users can traverse the host FUSE mount
- plumb the option through the CLI into the FUSE daemon and mount with `allow_other,default_permissions`
- document the Linux host requirement and usage in the FUSE README

## Testing
- deno fmt packages/cli/commands/fuse.ts packages/cli/lib/fuse.ts packages/fuse/mod.ts packages/fuse/README.md
- deno check packages/cli/commands/fuse.ts packages/cli/lib/fuse.ts packages/fuse/mod.ts