### PR TITLE
Ignore lockfiles in `.claude/`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ _deno.lock
 .pr-desc.tmp
 dist/
 .claude/settings.local.json
+.claude/*.lock
 .agents/settings.local.json
 # Current and legacy local CLI state
 .cf/


### PR DESCRIPTION
CC started dropping a file called `.claude/scheduled_tasks.lock` into the repo. I figure anything in `.claude` ending in `.lock` is best to be ignored.

## Performance baseline

This is one of the tests that was "on the edge" after my schema hash flag flip. It was green on that PR, but this PR got unlucky it seems.

NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/calendar/calendar.test.tsx = 16s
