### PR TITLE
chore(scripts): Keep local dev servers attached in Codex

### DIFF
--- a/scripts/start-local-dev.sh
+++ b/scripts/start-local-dev.sh
@@ -91,6 +91,11 @@ INSPECT_PORT=${INSPECT_PORT:-$((BASE_INSPECTOR_PORT + PORT_OFFSET))}
 export SHELL_PORT
 export TOOLSHED_PORT
 
+KEEP_ALIVE=false
+if [[ -n "${CODEX_SANDBOX:-}" ]]; then
+    KEEP_ALIVE=true
+fi
+
 # Check if port is free; kill processes if --force, otherwise error
 check_port() {
     local port=$1
@@ -232,4 +237,11 @@ if [[ "$BG_UPDATER" == "true" ]]; then
     fi
     echo "Shell log file: packages/shell/local-dev-shell.log"
     echo "Toolshed log file: packages/toolshed/local-dev-toolshed.log"
+fi
+
+if [[ "$KEEP_ALIVE" == "true" ]]; then
+    echo ""
+    echo "Codex detected; keeping this command attached so Codex does not clean up the dev servers."
+    echo "Stop this command or run ./scripts/stop-local-dev.sh from another shell to stop them."
+    wait "$SHELL_PID" "$TOOLSHED_PID"
 fi


### PR DESCRIPTION
## Summary

Keep `scripts/start-local-dev.sh` attached when it is running inside Codex so the Codex command runner does not clean up the background dev server process tree as soon as the startup script exits.

## Root Cause

The restart flow starts the shell and toolshed servers as background children and then returns. That works in a normal terminal, but Codex cleans up the process tree for a completed command, so the servers briefly start and then disappear.

## Changes

- Detect Codex via `CODEX_SANDBOX`.
- Preserve existing terminal behavior outside Codex.
- In Codex, wait on the shell and toolshed server PIDs after printing the URLs so the command session remains attached to the long-running servers.

## Validation

- `bash -n scripts/start-local-dev.sh`
- Commit hook ran `deno fmt` and `deno lint` successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep local dev servers running in Codex by keeping `scripts/start-local-dev.sh` attached after startup. Detect Codex via `CODEX_SANDBOX` and wait on the shell and toolshed server PIDs so Codex doesn’t clean them up; behavior outside Codex is unchanged.

<sup>Written for commit b6a17877981735b72c4d9be7950a589d0b21669d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-spec-gallery/main.test.tsx = 20s
NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/gideon-tests/test-reactivity-computed-derive-same/index.test.tsx = 10s
NEW_PERF_BASELINE: step: Type check = 62s

