### PR TITLE
Three interning-related bits

### DIFF
--- a/docs/plans/runner_cfc_implementation.md
+++ b/docs/plans/runner_cfc_implementation.md
@@ -309,9 +309,14 @@ JSON Pointer string derived from the segment array.
 
 ### Schema Hash and Frozen Schema
 
-Use the existing frozen-schema pipeline for canonical schema identity:
-`toDeepFrozenSchema()` for canonical deep-frozen form and
-`internSchema(..., true)` for `SchemaAndHash`.
+Use the existing frozen-schema pipeline for canonical schema identity. Prefer
+interning _unless_ there is strong evidence that it causes performance problems.
+`internSchema(...)` returns an interned value, and `internSchema(..., true)`
+returns a `SchemaAndHash` with both the interned value and its hash. If not
+interning, deep-freezing via `toDeepFrozenSchema()` is the best fallback choice.
+**Note:** There is never a need to pre-freeze the input to `internSchema()`, as
+it will do the freezing step itself; it is documented to "take ownership" of
+its argument and will freeze it directly.
 
 `schemaHash` is the persisted `SchemaAndHash.hashString` for the canonical
 merged schema envelope for the entity, not the hash of any one effective
@@ -346,9 +351,8 @@ Phase-1 merge rules:
   valid
 - a merge may add a required field only when the merged schema also provides a
   default that preserves validity/materialization for existing documents
-- every merged result is canonicalized with `toDeepFrozenSchema()` and
-  `internSchema(..., true)` before persistence to its `cid:<hash>` schema
-  document
+- every merged result is canonicalized with `internSchema(..., true)` before
+  persistence to its `cid:<hash>` schema document
 
 Phase-1 behavior:
 

--- a/packages/piece/src/iterate.ts
+++ b/packages/piece/src/iterate.ts
@@ -256,10 +256,10 @@ export function scrub(data: unknown): unknown {
       if (isObject(value)) {
         // Generate a new schema for all properties except $UI and $NAME and streams
         const scrubbedProperties = Object.fromEntries(
-          Object.keys(value).filter(([key, value]) =>
+          Object.entries(value).filter(([key, value]) =>
             !key.startsWith("$") && !isStream(value)
           ).map(
-            (key) => [key, {}],
+            ([key]) => [key, {}],
           ),
         );
         if (Object.keys(scrubbedProperties).length > 0) {

--- a/packages/piece/src/iterate.ts
+++ b/packages/piece/src/iterate.ts
@@ -1,8 +1,6 @@
 import { isObject, isRecord, Mutable } from "@commonfabric/utils/types";
-import {
-  cloneSchemaMutable,
-  toDeepFrozenSchema,
-} from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { cloneSchemaMutable } from "@commonfabric/data-model/schema-utils";
 import {
   type Cell,
   createJsonSchema,
@@ -257,24 +255,25 @@ export function scrub(data: unknown): unknown {
       const value = data.asSchema().get();
       if (isObject(value)) {
         // Generate a new schema for all properties except $UI and $NAME and streams
-        const scrubbed = toDeepFrozenSchema(
-          {
-            type: "object",
-            properties: Object.fromEntries(
-              Object.keys(value).filter(([key, value]) =>
-                !key.startsWith("$") && !isStream(value)
-              ).map(
-                (key) => [key, {}],
-              ),
-            ),
-            additionalProperties: false,
-          },
+        const scrubbedProperties = Object.fromEntries(
+          Object.keys(value).filter(([key, value]) =>
+            !key.startsWith("$") && !isStream(value)
+          ).map(
+            (key) => [key, {}],
+          ),
         );
-        console.log("scrubbed generated schema", scrubbed);
-        // Only if we found any properties, return the scrubbed schema
-        return Object.keys(scrubbed).length > 0
-          ? data.asSchema(scrubbed)
-          : data;
+        if (Object.keys(scrubbedProperties).length > 0) {
+          const scrubbed = internSchema({
+            type: "object",
+            properties: scrubbedProperties,
+            additionalProperties: false,
+          });
+          console.log("scrubbed generated schema", scrubbed);
+          return data.asSchema(scrubbed);
+        } else {
+          console.log("scrubbed generated schema: <no properties>");
+          return data;
+        }
       } else return data;
     }
   } else if (Array.isArray(data)) {

--- a/packages/runner/src/cfc/flow-precision.ts
+++ b/packages/runner/src/cfc/flow-precision.ts
@@ -1,4 +1,4 @@
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { JSONSchema } from "../builder/types.ts";
 import type { ImplementationIdentity } from "./types.ts";
 
@@ -16,8 +16,11 @@ type FlowPrecisionClaim = {
   claims: Array<{ type: FlowPrecisionClaimType }>;
 };
 
+const BUILTIN_IDS = ["map", "filter", "flatMap"] as const;
+type BuiltinId = (typeof BUILTIN_IDS)[number];
+
 const claimForBuiltin = (
-  builtinId: string,
+  builtinId: BuiltinId,
 ): FlowPrecisionClaim | undefined => {
   switch (builtinId) {
     case "map":
@@ -44,25 +47,30 @@ const claimForBuiltin = (
           { type: "StableRelativeOrder" },
         ],
       };
-    default:
-      return undefined;
   }
 };
 
-export const flowPrecisionSchemaForBuiltin = (
-  builtinId: string,
-): JSONSchema | undefined => {
+const internFlowPrecisionSchema = (builtinId: BuiltinId): JSONSchema => {
   const claim = claimForBuiltin(builtinId);
-  if (!claim) {
-    return undefined;
-  }
 
-  return toDeepFrozenSchema({
+  // Note: `as JSONSchema` required since `ifc.flowPrecisionClaim` is not
+  // defined as a property of `JSONSchema`.
+  return internSchema({
     type: "array",
     ifc: {
       flowPrecisionClaim: claim,
     },
-  } as JSONSchema, true);
+  } as JSONSchema);
+};
+
+const FLOW_PRECISION_SCHEMAS = new Map<string, JSONSchema>(
+  BUILTIN_IDS.map((id) => [id, internFlowPrecisionSchema(id)]),
+);
+
+export const flowPrecisionSchemaForBuiltin = (
+  builtinId: string,
+): JSONSchema | undefined => {
+  return FLOW_PRECISION_SCHEMAS.get(builtinId);
 };
 
 export const trustedFlowPrecisionSchemaForBuiltin = (


### PR DESCRIPTION
This PR does three intern-related things:

* Updates the advice in `runner_cfc_implementation.md` to steer towards using `schemaIntern()` over simply deep-freezing schemas.
* Precomputes and interns the three constant schemas in `flow-precision.ts` instead of constructing-and-freezing them fresh with every call.
* Fixes a bug in `piece/src/iterate.ts` which made it fail to correctly do-nothing when given a schema that got reduced to having no `properties`. Also, made it intern the "interesting" results instead of just deep-freezing them.