### PR TITLE
fix(ts-transformers): keep callable closure captures lexical

### DIFF
--- a/packages/ts-transformers/src/cf-pipeline.ts
+++ b/packages/ts-transformers/src/cf-pipeline.ts
@@ -113,6 +113,7 @@ export class CommonFabricTransformerPipeline extends Pipeline {
     const ops: TransformationOptions = {
       typeRegistry: new WeakMap(),
       mapCallbackRegistry: new WeakSet(),
+      nonHoistableCallbackRegistry: new WeakSet(),
       syntheticComputeCallbackRegistry: new WeakSet(),
       syntheticComputeOwnedNodeRegistry: new WeakSet(),
       syntheticReactiveCollectionRegistry: new WeakSet(),

--- a/packages/ts-transformers/src/closures/module-scope-callback-hoisting.ts
+++ b/packages/ts-transformers/src/closures/module-scope-callback-hoisting.ts
@@ -38,6 +38,7 @@ export function hoistModuleScopedBuilderCallbacks(
       }
       if (
         !isFunctionLikeExpression(argument) ||
+        context.isNonHoistableCallback(argument) ||
         !isNestedWithinFunction(argument) ||
         !callbackCanBeHoisted(argument, context.checker)
       ) {
@@ -150,10 +151,6 @@ function callbackCanBeHoisted(
       node !== callback &&
       isFunctionLikeDeclaration(node)
     ) {
-      if (nestedFunctionCapturesEnclosingBindings(node, callback, checker)) {
-        capturesEnclosingBindings = true;
-        return true;
-      }
       return false;
     }
 
@@ -181,35 +178,6 @@ function callbackCanBeHoisted(
   }
 
   return usesModuleScopedReferences && !capturesEnclosingBindings;
-}
-
-function nestedFunctionCapturesEnclosingBindings(
-  nested: ts.FunctionLikeDeclaration,
-  callback: ts.FunctionLikeDeclaration,
-  checker: ts.TypeChecker,
-): boolean {
-  const visit = (node: ts.Node): boolean => {
-    if (node !== nested && isFunctionLikeDeclaration(node)) {
-      return false;
-    }
-
-    if (
-      ts.isIdentifier(node) &&
-      getReferenceScope(node, callback, checker) === "enclosing"
-    ) {
-      return true;
-    }
-
-    return ts.forEachChild(node, (child) => visit(child)) ?? false;
-  };
-
-  for (const parameter of nested.parameters) {
-    if (parameter.initializer && visit(parameter.initializer)) {
-      return true;
-    }
-  }
-
-  return nested.body ? visit(nested.body) : false;
 }
 
 type ReferenceScope = "local" | "module" | "enclosing" | "other";

--- a/packages/ts-transformers/src/closures/module-scope-callback-hoisting.ts
+++ b/packages/ts-transformers/src/closures/module-scope-callback-hoisting.ts
@@ -150,6 +150,10 @@ function callbackCanBeHoisted(
       node !== callback &&
       isFunctionLikeDeclaration(node)
     ) {
+      if (nestedFunctionCapturesEnclosingBindings(node, callback, checker)) {
+        capturesEnclosingBindings = true;
+        return true;
+      }
       return false;
     }
 
@@ -177,6 +181,35 @@ function callbackCanBeHoisted(
   }
 
   return usesModuleScopedReferences && !capturesEnclosingBindings;
+}
+
+function nestedFunctionCapturesEnclosingBindings(
+  nested: ts.FunctionLikeDeclaration,
+  callback: ts.FunctionLikeDeclaration,
+  checker: ts.TypeChecker,
+): boolean {
+  const visit = (node: ts.Node): boolean => {
+    if (node !== nested && isFunctionLikeDeclaration(node)) {
+      return false;
+    }
+
+    if (
+      ts.isIdentifier(node) &&
+      getReferenceScope(node, callback, checker) === "enclosing"
+    ) {
+      return true;
+    }
+
+    return ts.forEachChild(node, (child) => visit(child)) ?? false;
+  };
+
+  for (const parameter of nested.parameters) {
+    if (parameter.initializer && visit(parameter.initializer)) {
+      return true;
+    }
+  }
+
+  return nested.body ? visit(nested.body) : false;
 }
 
 type ReferenceScope = "local" | "module" | "enclosing" | "other";

--- a/packages/ts-transformers/src/closures/strategies/action-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/action-strategy.ts
@@ -6,6 +6,7 @@ import { CaptureCollector } from "../capture-collector.ts";
 import { SchemaFactory } from "../utils/schema-factory.ts";
 import { unwrapArrowFunction } from "../utils/ast-helpers.ts";
 import { buildCapturedHandlerClosureCall } from "../utils/capture-scaffold.ts";
+import type { CaptureTreeNode } from "../../utils/capture-tree.ts";
 
 /**
  * ActionStrategy transforms action() calls to handler() calls with explicit closures.
@@ -114,6 +115,10 @@ function transformActionCall(
   // Collect captures
   const collector = new CaptureCollector(checker);
   const { captureTree } = collector.analyze(callback);
+  const explicitCaptureTree = filterDirectCallableActionCaptures(
+    captureTree,
+    checker,
+  );
 
   // Determine event parameter name:
   // - If callback has an event param, preserve its name
@@ -135,7 +140,7 @@ function transformActionCall(
 
   // State schema is based on captures
   const stateTypeNode = schemaFactory.createHandlerStateSchema(
-    captureTree,
+    explicitCaptureTree,
     undefined, // no explicit state parameter in action
   );
 
@@ -143,7 +148,7 @@ function transformActionCall(
     actionCall,
     callback,
     transformedBody,
-    captureTree,
+    explicitCaptureTree,
     eventTypeNode,
     stateTypeNode,
     context,
@@ -176,4 +181,32 @@ function transformActionCall(
   }
 
   return finalCall;
+}
+
+function filterDirectCallableActionCaptures(
+  captureTree: Map<string, CaptureTreeNode>,
+  checker: ts.TypeChecker,
+): Map<string, CaptureTreeNode> {
+  const filtered = new Map<string, CaptureTreeNode>();
+
+  for (const [name, node] of captureTree) {
+    if (isDirectCallableActionCapture(node, checker)) {
+      continue;
+    }
+    filtered.set(name, node);
+  }
+
+  return filtered;
+}
+
+function isDirectCallableActionCapture(
+  node: CaptureTreeNode,
+  checker: ts.TypeChecker,
+): boolean {
+  if (!node.expression || node.path.length !== 0 || node.properties.size !== 0) {
+    return false;
+  }
+
+  const type = checker.getTypeAtLocation(node.expression);
+  return type.getCallSignatures().length > 0;
 }

--- a/packages/ts-transformers/src/closures/strategies/action-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/action-strategy.ts
@@ -10,15 +10,17 @@ import { filterDirectCallableCaptures } from "../utils/callable-capture-filter.t
 import { markCallbackAndAncestorsNonHoistable } from "../utils/non-hoistable-callbacks.ts";
 
 /**
- * ActionStrategy transforms action() calls to handler() calls with explicit closures.
+ * ActionStrategy transforms action() calls to handler() calls with explicit
+ * closure state where that transport is supported.
  *
  * This is to handler as computed is to lift/derive:
  * - Input: action(() => count.set(count.get() + 1))
  * - Output: handler((_, { count }) => count.set(count.get() + 1))({ count })
  *
- * The action callback takes zero or one parameters (optional event) and closes
- * over scope variables. The transformer extracts these closures and makes them
- * explicit as handler params.
+ * The action callback takes zero or one parameters (optional event) and may
+ * close over outer scope values. Most captures become explicit handler state,
+ * but direct callable root captures stay lexical because generated closure
+ * state/params objects cannot faithfully transport them today.
  *
  * Examples:
  * - action(() => doSomething())           → no event, schema is false
@@ -90,7 +92,9 @@ function extractActionCallback(
 }
 
 /**
- * Transform an action call to a handler call with explicit closures.
+ * Transform an action call to a handler call with explicit closure state where
+ * supported.
+ *
  * Converts: action(() => count.set(count.get() + 1))
  * To: handler((_, { count }) => count.set(count.get() + 1))({ count })
  */

--- a/packages/ts-transformers/src/closures/strategies/action-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/action-strategy.ts
@@ -6,7 +6,8 @@ import { CaptureCollector } from "../capture-collector.ts";
 import { SchemaFactory } from "../utils/schema-factory.ts";
 import { unwrapArrowFunction } from "../utils/ast-helpers.ts";
 import { buildCapturedHandlerClosureCall } from "../utils/capture-scaffold.ts";
-import type { CaptureTreeNode } from "../../utils/capture-tree.ts";
+import { filterDirectCallableCaptures } from "../utils/callable-capture-filter.ts";
+import { markCallbackAndAncestorsNonHoistable } from "../utils/non-hoistable-callbacks.ts";
 
 /**
  * ActionStrategy transforms action() calls to handler() calls with explicit closures.
@@ -115,10 +116,13 @@ function transformActionCall(
   // Collect captures
   const collector = new CaptureCollector(checker);
   const { captureTree } = collector.analyze(callback);
-  const explicitCaptureTree = filterDirectCallableActionCaptures(
+  const explicitCaptureTree = filterDirectCallableCaptures(
     captureTree,
     checker,
   );
+  if (explicitCaptureTree.size !== captureTree.size) {
+    markCallbackAndAncestorsNonHoistable(callback, context);
+  }
 
   // Determine event parameter name:
   // - If callback has an event param, preserve its name
@@ -181,32 +185,4 @@ function transformActionCall(
   }
 
   return finalCall;
-}
-
-function filterDirectCallableActionCaptures(
-  captureTree: Map<string, CaptureTreeNode>,
-  checker: ts.TypeChecker,
-): Map<string, CaptureTreeNode> {
-  const filtered = new Map<string, CaptureTreeNode>();
-
-  for (const [name, node] of captureTree) {
-    if (isDirectCallableActionCapture(node, checker)) {
-      continue;
-    }
-    filtered.set(name, node);
-  }
-
-  return filtered;
-}
-
-function isDirectCallableActionCapture(
-  node: CaptureTreeNode,
-  checker: ts.TypeChecker,
-): boolean {
-  if (!node.expression || node.path.length !== 0 || node.properties.size !== 0) {
-    return false;
-  }
-
-  const type = checker.getTypeAtLocation(node.expression);
-  return type.getCallSignatures().length > 0;
 }

--- a/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
@@ -22,6 +22,8 @@ import { CaptureCollector } from "../capture-collector.ts";
 import { buildCaptureParamsObject } from "../utils/capture-scaffold.ts";
 import { PatternBuilder } from "../utils/pattern-builder.ts";
 import { SchemaFactory } from "../utils/schema-factory.ts";
+import { filterDirectCallableCaptures } from "../utils/callable-capture-filter.ts";
+import { markCallbackAndAncestorsNonHoistable } from "../utils/non-hoistable-callbacks.ts";
 import {
   analyzeElementBinding,
   rewriteCallbackBody,
@@ -107,6 +109,7 @@ function createPatternCallWithParams(
   indexParam: ts.ParameterDeclaration | undefined,
   arrayParam: ts.ParameterDeclaration | undefined,
   captureTree: Map<string, CaptureTreeNode>,
+  containsLexicalCallableCaptures: boolean,
   context: TransformationContext,
   visitor: ts.Visitor,
   options: ArrayMethodCallbackTransformOptions,
@@ -189,6 +192,9 @@ function createPatternCallWithParams(
 
   const newCallback = builder.buildCallback(callback, rewrittenBody, "params");
   context.markAsArrayMethodCallback(newCallback);
+  if (containsLexicalCallableCaptures) {
+    context.markAsNonHoistableCallback(newCallback);
+  }
 
   const schemaFactory = new SchemaFactory(context);
   const callbackParamTypeNode = schemaFactory.createArrayMethodCallbackSchema(
@@ -322,6 +328,12 @@ export function transformArrayMethodCallback(
 
   const collector = new CaptureCollector(checker);
   const { captureTree } = collector.analyzeCurrentAndOriginal(callback);
+  const explicitCaptureTree = filterDirectCallableCaptures(captureTree, checker);
+  const containsLexicalCallableCaptures =
+    explicitCaptureTree.size !== captureTree.size;
+  if (containsLexicalCallableCaptures) {
+    markCallbackAndAncestorsNonHoistable(callback, context);
+  }
 
   const originalParams = callback.parameters;
   const elemParam = originalParams[0];
@@ -340,7 +352,8 @@ export function transformArrayMethodCallback(
     elemParam,
     indexParam,
     arrayParam,
-    captureTree,
+    explicitCaptureTree,
+    containsLexicalCallableCaptures,
     context,
     visitor,
     options,

--- a/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
@@ -328,7 +328,10 @@ export function transformArrayMethodCallback(
 
   const collector = new CaptureCollector(checker);
   const { captureTree } = collector.analyzeCurrentAndOriginal(callback);
-  const explicitCaptureTree = filterDirectCallableCaptures(captureTree, checker);
+  const explicitCaptureTree = filterDirectCallableCaptures(
+    captureTree,
+    checker,
+  );
   const containsLexicalCallableCaptures =
     explicitCaptureTree.size !== captureTree.size;
   if (containsLexicalCallableCaptures) {

--- a/packages/ts-transformers/src/closures/strategies/derive-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/derive-strategy.ts
@@ -327,7 +327,10 @@ export function transformDeriveCall(
   const { captures: captureExpressions, captureTree } = collector.analyze(
     callback,
   );
-  const explicitCaptureTree = filterDirectCallableCaptures(captureTree, checker);
+  const explicitCaptureTree = filterDirectCallableCaptures(
+    captureTree,
+    checker,
+  );
   if (explicitCaptureTree.size !== captureTree.size) {
     markCallbackAndAncestorsNonHoistable(callback, context);
   }

--- a/packages/ts-transformers/src/closures/strategies/derive-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/derive-strategy.ts
@@ -17,6 +17,8 @@ import {
 import { CaptureCollector } from "../capture-collector.ts";
 import { PatternBuilder } from "../utils/pattern-builder.ts";
 import { SchemaFactory } from "../utils/schema-factory.ts";
+import { filterDirectCallableCaptures } from "../utils/callable-capture-filter.ts";
+import { markCallbackAndAncestorsNonHoistable } from "../utils/non-hoistable-callbacks.ts";
 
 /**
  * Pre-register unwrapped types for captured identifiers in a callback body.
@@ -325,7 +327,11 @@ export function transformDeriveCall(
   const { captures: captureExpressions, captureTree } = collector.analyze(
     callback,
   );
-  if (captureExpressions.size === 0) {
+  const explicitCaptureTree = filterDirectCallableCaptures(captureTree, checker);
+  if (explicitCaptureTree.size !== captureTree.size) {
+    markCallbackAndAncestorsNonHoistable(callback, context);
+  }
+  if (explicitCaptureTree.size === 0) {
     // No captures - no transformation needed
     return undefined;
   }
@@ -361,14 +367,14 @@ export function transformDeriveCall(
   // Resolve capture name collisions with the original input parameter name
   const captureNameMap = resolveDeriveCaptureNameCollisions(
     hadZeroParameters ? "" : originalInputParamName,
-    captureTree,
+    explicitCaptureTree,
   );
 
   // Build merged input object
   const mergedInput = buildDeriveInputObject(
     originalInput,
     originalInputParamName,
-    captureTree,
+    explicitCaptureTree,
     captureNameMap,
     factory,
     hadZeroParameters,
@@ -387,7 +393,7 @@ export function transformDeriveCall(
 
   // Initialize PatternBuilder
   const builder = new PatternBuilder(context);
-  builder.setCaptureTree(captureTree);
+  builder.setCaptureTree(explicitCaptureTree);
   builder.setCaptureRenames(captureNameMap);
 
   // Register used names (original input param name)
@@ -459,7 +465,7 @@ export function transformDeriveCall(
   const inputTypeNode = schemaFactory.createDeriveInputSchema(
     originalInputParamName,
     originalInput,
-    captureTree,
+    explicitCaptureTree,
     captureNameMap,
     hadZeroParameters,
   );

--- a/packages/ts-transformers/src/closures/strategies/handler-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/handler-strategy.ts
@@ -6,6 +6,8 @@ import { CaptureCollector } from "../capture-collector.ts";
 import { unwrapArrowFunction } from "../utils/ast-helpers.ts";
 import { SchemaFactory } from "../utils/schema-factory.ts";
 import { buildCapturedHandlerClosureCall } from "../utils/capture-scaffold.ts";
+import { filterDirectCallableCaptures } from "../utils/callable-capture-filter.ts";
+import { markCallbackAndAncestorsNonHoistable } from "../utils/non-hoistable-callbacks.ts";
 
 export class HandlerStrategy implements ClosureTransformationStrategy {
   canTransform(
@@ -57,13 +59,20 @@ export function transformHandlerJsxAttribute(
 
   const collector = new CaptureCollector(context.checker);
   const { captureTree } = collector.analyze(callback);
+  const explicitCaptureTree = filterDirectCallableCaptures(
+    captureTree,
+    context.checker,
+  );
+  if (explicitCaptureTree.size !== captureTree.size) {
+    markCallbackAndAncestorsNonHoistable(callback, context);
+  }
   const { factory } = context;
 
   // Build type information for handler params using SchemaFactory
   const schemaFactory = new SchemaFactory(context);
   const eventTypeNode = schemaFactory.createHandlerEventSchema(callback);
   const stateTypeNode = schemaFactory.createHandlerStateSchema(
-    captureTree,
+    explicitCaptureTree,
     callback.parameters[1] as ts.ParameterDeclaration | undefined,
   );
 
@@ -71,7 +80,7 @@ export function transformHandlerJsxAttribute(
     expression,
     callback,
     transformedBody,
-    captureTree,
+    explicitCaptureTree,
     eventTypeNode,
     stateTypeNode,
     context,

--- a/packages/ts-transformers/src/closures/utils/callable-capture-filter.ts
+++ b/packages/ts-transformers/src/closures/utils/callable-capture-filter.ts
@@ -1,0 +1,35 @@
+import ts from "typescript";
+import type { CaptureTreeNode } from "../../utils/capture-tree.ts";
+
+/**
+ * Explicit closure state/params cannot faithfully transport plain callable
+ * captures today. Keep direct callable root captures lexical instead of routing
+ * them through generated handler/derive/map params objects.
+ */
+export function filterDirectCallableCaptures(
+  captureTree: Map<string, CaptureTreeNode>,
+  checker: ts.TypeChecker,
+): Map<string, CaptureTreeNode> {
+  const filtered = new Map<string, CaptureTreeNode>();
+
+  for (const [name, node] of captureTree) {
+    if (isDirectCallableCapture(node, checker)) {
+      continue;
+    }
+    filtered.set(name, node);
+  }
+
+  return filtered;
+}
+
+function isDirectCallableCapture(
+  node: CaptureTreeNode,
+  checker: ts.TypeChecker,
+): boolean {
+  if (!node.expression || node.path.length !== 0 || node.properties.size !== 0) {
+    return false;
+  }
+
+  const type = checker.getTypeAtLocation(node.expression);
+  return type.getCallSignatures().length > 0;
+}

--- a/packages/ts-transformers/src/closures/utils/callable-capture-filter.ts
+++ b/packages/ts-transformers/src/closures/utils/callable-capture-filter.ts
@@ -26,7 +26,9 @@ function isDirectCallableCapture(
   node: CaptureTreeNode,
   checker: ts.TypeChecker,
 ): boolean {
-  if (!node.expression || node.path.length !== 0 || node.properties.size !== 0) {
+  if (
+    !node.expression || node.path.length !== 0 || node.properties.size !== 0
+  ) {
     return false;
   }
 

--- a/packages/ts-transformers/src/closures/utils/capture-scaffold.ts
+++ b/packages/ts-transformers/src/closures/utils/capture-scaffold.ts
@@ -17,6 +17,12 @@ export function buildCaptureParamsObject(
   );
 }
 
+/**
+ * Build the shared `handler(...)(captures)` scaffold for closure strategies.
+ *
+ * Callers are responsible for filtering out any captures that must remain
+ * lexical, such as direct callable root captures.
+ */
 export function buildCapturedHandlerClosureCall(
   originalNode: ts.Node,
   callback: ts.ArrowFunction,

--- a/packages/ts-transformers/src/closures/utils/non-hoistable-callbacks.ts
+++ b/packages/ts-transformers/src/closures/utils/non-hoistable-callbacks.ts
@@ -1,0 +1,18 @@
+import ts from "typescript";
+import type { TransformationContext } from "../../core/mod.ts";
+
+export function markCallbackAndAncestorsNonHoistable(
+  node: ts.Node,
+  context: TransformationContext,
+): void {
+  let current: ts.Node | undefined = node;
+  while (current) {
+    if (ts.isFunctionLike(current)) {
+      context.markAsNonHoistableCallback(current);
+    }
+    if (ts.isSourceFile(current)) {
+      return;
+    }
+    current = current.parent;
+  }
+}

--- a/packages/ts-transformers/src/core/context.ts
+++ b/packages/ts-transformers/src/core/context.ts
@@ -152,6 +152,24 @@ export class TransformationContext {
     );
   }
 
+  markAsNonHoistableCallback(node: ts.Node): void {
+    if (this.options.nonHoistableCallbackRegistry) {
+      this.options.nonHoistableCallbackRegistry.add(node);
+    }
+  }
+
+  isNonHoistableCallback(node: ts.Node): boolean {
+    if (this.options.nonHoistableCallbackRegistry?.has(node)) {
+      return true;
+    }
+    const original = ts.getOriginalNode(node);
+    return !!(
+      original &&
+      original !== node &&
+      this.options.nonHoistableCallbackRegistry?.has(original)
+    );
+  }
+
   /**
    * Mark a synthetic callback introduced by a compute wrapper so later phases
    * can classify its contents as compute-owned even when they originate from

--- a/packages/ts-transformers/src/core/mod.ts
+++ b/packages/ts-transformers/src/core/mod.ts
@@ -21,6 +21,13 @@
  *   Readers: context.isArrayMethodCallback() (called by pattern-callback lowering,
  *            reactive-context classifier)
  *
+ * nonHoistableCallbackRegistry (WeakSet<ts.Node>)
+ *   Marks callbacks that must stay lexical because a closure strategy left
+ *   callable captures in surrounding JS scope instead of routing them through
+ *   explicit closure params/state.
+ *   Writers: closure strategies that filter direct callable captures
+ *   Readers: module-scope callback hoisting
+ *
  * syntheticComputeCallbackRegistry (WeakSet<ts.Node>)
  *   Marks callbacks introduced by synthetic compute wrappers (e.g. JSX branch
  *   wrapping) so later phases can treat reused authored nodes as compute-owned.

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -71,6 +71,7 @@ export interface TransformationOptions {
   readonly logger?: (message: string) => void;
   readonly typeRegistry?: TypeRegistry;
   readonly mapCallbackRegistry?: WeakSet<ts.Node>;
+  readonly nonHoistableCallbackRegistry?: WeakSet<ts.Node>;
   readonly syntheticComputeCallbackRegistry?: WeakSet<ts.Node>;
   readonly syntheticComputeOwnedNodeRegistry?: WeakSet<ts.Node>;
   readonly syntheticReactiveCollectionRegistry?:

--- a/packages/ts-transformers/test/closures/module-scope-helper-hoisting.test.ts
+++ b/packages/ts-transformers/test/closures/module-scope-helper-hoisting.test.ts
@@ -79,3 +79,26 @@ Deno.test("Closure Transformer does not hoist nested handler callbacks that also
     /const makeHandler = .*handler\(.*\(event: \{ status\?: string; \} \| undefined\) => \{.*allowed\.includes\(status\)/,
   );
 });
+
+Deno.test("Closure Transformer does not hoist pattern callbacks whose nested actions capture enclosing callables", async () => {
+  const source = `    import { action, pattern } from "commonfabric";
+
+    export const makePattern = (helper: (value: string) => string) =>
+      pattern(() => {
+        const go = action(() => helper("x"));
+        return { go };
+      });
+`;
+
+  const output = await transformSource(source, options);
+  const normalized = output.replace(/\s+/g, " ");
+
+  assertNotMatch(
+    normalized,
+    /const \S+ = __cfHardenFn\(\(\) => \{ const go = __cfHelpers\.handler\(false as const satisfies __cfHelpers\.JSONSchema, \{ type: "object", properties: \{\} \} as const satisfies __cfHelpers\.JSONSchema, \(_, __cf_action_params\) => \{ return helper\("x"\); \}\)\(\{\}\)\.for\(\{ stream: "go" \}, true\); return \{ go \}; \}\);/,
+  );
+  assertMatch(
+    normalized,
+    /const makePattern = .*pattern\(\(\) => \{ .*helper\("x"\).*\}, false as const satisfies __cfHelpers\.JSONSchema,/,
+  );
+});

--- a/packages/ts-transformers/test/fixtures/closures/action-captured-callable-export-binding.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-captured-callable-export-binding.expected.jsx
@@ -1,0 +1,34 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { action } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+// FIXTURE: action-captured-callable-export-binding
+// Verifies: action() should not route captured plain callables through handler state
+//   makeAction(helper) where helper is a closed-over callable should preserve lexical helper
+//   access in the handler body instead of destructuring/passing helper through handler params.
+// Context: the exported action binding form is later rejected by the plain-data/SES path, but
+// this fixture isolates the earlier closure-transform shape in --show-transformed output.
+function makeAction(helper: (value: string) => string) {
+    return __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+        type: "object",
+        properties: {}
+    } as const satisfies __cfHelpers.JSONSchema, (_, __cf_action_params) => {
+        return helper("x");
+    })({});
+}
+__cfHardenFn(makeAction);
+const helper = __cfHardenFn((value: string) => value.toUpperCase());
+const myAction = __cfHelpers.__cf_data(makeAction(helper).for({ stream: "myAction" }, true));
+export default myAction;
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/action-captured-callable-export-binding.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-captured-callable-export-binding.input.tsx
@@ -1,0 +1,18 @@
+import { action } from "commonfabric";
+
+// FIXTURE: action-captured-callable-export-binding
+// Verifies: action() should not route captured plain callables through handler state
+//   makeAction(helper) where helper is a closed-over callable should preserve lexical helper
+//   access in the handler body instead of destructuring/passing helper through handler params.
+// Context: the exported action binding form is later rejected by the plain-data/SES path, but
+// this fixture isolates the earlier closure-transform shape in --show-transformed output.
+function makeAction(helper: (value: string) => string) {
+  return action(() => {
+    return helper("x");
+  });
+}
+
+const helper = (value: string) => value.toUpperCase();
+const myAction = makeAction(helper);
+
+export default myAction;

--- a/packages/ts-transformers/test/fixtures/closures/derive-captured-callable-export-binding.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-captured-callable-export-binding.expected.jsx
@@ -1,0 +1,40 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { derive, pattern } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+// FIXTURE: derive-captured-callable-export-binding
+// Verifies: derive() should treat captured plain callables like no explicit
+// captures and leave the helper lexical rather than merging it into the derive input.
+function makePattern(helper: (value: string) => string) {
+    return pattern(() => {
+        return {
+            label: derive(false as const satisfies __cfHelpers.JSONSchema, {
+                type: "string"
+            } as const satisfies __cfHelpers.JSONSchema, "x", () => helper("x")).for(["__patternResult", "label"], true)
+        };
+    }, false as const satisfies __cfHelpers.JSONSchema, {
+        type: "object",
+        properties: {
+            label: {
+                type: "string"
+            }
+        },
+        required: ["label"]
+    } as const satisfies __cfHelpers.JSONSchema);
+}
+__cfHardenFn(makePattern);
+const helper = __cfHardenFn((value: string) => value.toUpperCase());
+const myPattern = __cfHelpers.__cf_data(makePattern(helper));
+export default myPattern;
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/derive-captured-callable-export-binding.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-captured-callable-export-binding.input.tsx
@@ -1,0 +1,17 @@
+import { derive, pattern } from "commonfabric";
+
+// FIXTURE: derive-captured-callable-export-binding
+// Verifies: derive() should treat captured plain callables like no explicit
+// captures and leave the helper lexical rather than merging it into the derive input.
+function makePattern(helper: (value: string) => string) {
+  return pattern(() => {
+    return {
+      label: derive("x", () => helper("x")),
+    };
+  });
+}
+
+const helper = (value: string) => value.toUpperCase();
+const myPattern = makePattern(helper);
+
+export default myPattern;

--- a/packages/ts-transformers/test/fixtures/closures/handler-captured-callable-export-binding.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-captured-callable-export-binding.expected.jsx
@@ -1,0 +1,62 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { pattern, UI } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+// FIXTURE: handler-captured-callable-export-binding
+// Verifies: inline JSX handlers should not route captured plain callables through
+// explicit handler state. The helper should remain lexical in the callback body.
+function makePattern(helper: (value: string) => string) {
+    return pattern(() => {
+        return {
+            [UI]: <cf-button onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+                type: "object",
+                properties: {}
+            } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, __cf_handler_params) => helper("x"))({})}>Go</cf-button>,
+        };
+    }, false as const satisfies __cfHelpers.JSONSchema, {
+        type: "object",
+        properties: {
+            $UI: {
+                $ref: "#/$defs/JSXElement"
+            }
+        },
+        required: ["$UI"],
+        $defs: {
+            JSXElement: {
+                anyOf: [{
+                        $ref: "https://commonfabric.org/schemas/vnode.json"
+                    }, {
+                        $ref: "#/$defs/UIRenderable"
+                    }, {
+                        type: "object",
+                        properties: {}
+                    }]
+            },
+            UIRenderable: {
+                type: "object",
+                properties: {
+                    $UI: {
+                        $ref: "https://commonfabric.org/schemas/vnode.json"
+                    }
+                },
+                required: ["$UI"]
+            }
+        }
+    } as const satisfies __cfHelpers.JSONSchema);
+}
+__cfHardenFn(makePattern);
+const helper = __cfHardenFn((value: string) => value.toUpperCase());
+const myPattern = __cfHelpers.__cf_data(makePattern(helper));
+export default myPattern;
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/handler-captured-callable-export-binding.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-captured-callable-export-binding.input.tsx
@@ -1,0 +1,17 @@
+import { pattern, UI } from "commonfabric";
+
+// FIXTURE: handler-captured-callable-export-binding
+// Verifies: inline JSX handlers should not route captured plain callables through
+// explicit handler state. The helper should remain lexical in the callback body.
+function makePattern(helper: (value: string) => string) {
+  return pattern(() => {
+    return {
+      [UI]: <cf-button onClick={() => helper("x")}>Go</cf-button>,
+    };
+  });
+}
+
+const helper = (value: string) => value.toUpperCase();
+const myPattern = makePattern(helper);
+
+export default myPattern;

--- a/packages/ts-transformers/test/fixtures/closures/map-captured-callable-export-binding.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-captured-callable-export-binding.expected.jsx
@@ -1,0 +1,117 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { pattern, UI } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Input {
+    items: string[];
+}
+// FIXTURE: map-captured-callable-export-binding
+// Verifies: array-method callback lowering should not route captured plain
+// callables through callback params/state. The helper should remain lexical.
+function makePattern(helper: (value: string) => string) {
+    return pattern((__cf_pattern_input) => {
+        const items = __cf_pattern_input.key("items");
+        return {
+            [UI]: (<div>
+          {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
+                const item = __cf_pattern_input.key("element");
+                return <span>{__cfHelpers.derive({
+                    type: "object",
+                    properties: {
+                        item: {
+                            type: "string"
+                        }
+                    },
+                    required: ["item"]
+                } as const satisfies __cfHelpers.JSONSchema, {
+                    type: "string"
+                } as const satisfies __cfHelpers.JSONSchema, { item: item }, ({ item }) => helper(item))}</span>;
+            }, {
+                type: "object",
+                properties: {
+                    element: {
+                        type: "string"
+                    }
+                },
+                required: ["element"]
+            } as const satisfies __cfHelpers.JSONSchema, {
+                anyOf: [{
+                        $ref: "https://commonfabric.org/schemas/vnode.json"
+                    }, {
+                        $ref: "#/$defs/UIRenderable"
+                    }, {
+                        type: "object",
+                        properties: {}
+                    }],
+                $defs: {
+                    UIRenderable: {
+                        type: "object",
+                        properties: {
+                            $UI: {
+                                $ref: "https://commonfabric.org/schemas/vnode.json"
+                            }
+                        },
+                        required: ["$UI"]
+                    }
+                }
+            } as const satisfies __cfHelpers.JSONSchema), {})}
+        </div>),
+        };
+    }, {
+        type: "object",
+        properties: {
+            items: {
+                type: "array",
+                items: {
+                    type: "string"
+                }
+            }
+        },
+        required: ["items"]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "object",
+        properties: {
+            $UI: {
+                $ref: "#/$defs/JSXElement"
+            }
+        },
+        required: ["$UI"],
+        $defs: {
+            JSXElement: {
+                anyOf: [{
+                        $ref: "https://commonfabric.org/schemas/vnode.json"
+                    }, {
+                        $ref: "#/$defs/UIRenderable"
+                    }, {
+                        type: "object",
+                        properties: {}
+                    }]
+            },
+            UIRenderable: {
+                type: "object",
+                properties: {
+                    $UI: {
+                        $ref: "https://commonfabric.org/schemas/vnode.json"
+                    }
+                },
+                required: ["$UI"]
+            }
+        }
+    } as const satisfies __cfHelpers.JSONSchema);
+}
+__cfHardenFn(makePattern);
+const helper = __cfHardenFn((value: string) => value.toUpperCase());
+const myPattern = __cfHelpers.__cf_data(makePattern(helper));
+export default myPattern;
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-captured-callable-export-binding.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-captured-callable-export-binding.input.tsx
@@ -1,0 +1,25 @@
+import { pattern, UI } from "commonfabric";
+
+interface Input {
+  items: string[];
+}
+
+// FIXTURE: map-captured-callable-export-binding
+// Verifies: array-method callback lowering should not route captured plain
+// callables through callback params/state. The helper should remain lexical.
+function makePattern(helper: (value: string) => string) {
+  return pattern<Input>(({ items }) => {
+    return {
+      [UI]: (
+        <div>
+          {items.map((item) => <span>{helper(item)}</span>)}
+        </div>
+      ),
+    };
+  });
+}
+
+const helper = (value: string) => value.toUpperCase();
+const myPattern = makePattern(helper);
+
+export default myPattern;


### PR DESCRIPTION
# Handover note (from Gideon + Claude review session, 2026-05-13)

This PR is in draft because the scope needs to change. The bug class it targets is real and still present on main today, but Berni has proposed a different fix direction for part of it. This note captures the empirical findings and the agreed-on split so this can be picked back up cleanly.

## 1. The bug class is real and still on main today

Verified empirically by extracting each fixture's `.input.tsx` from this branch, placing it on current `main`, and running `deno task cf check --show-transformed --no-run`. All four fixtures (`action-`, `derive-`, `handler-`, `map-captured-callable-export-binding`) produce the same broken shape on main: the captured callable is routed through an explicit `inputs`/`state` object that has an **empty schema** (no slot for the callable), yet the callback destructures the same name and the call site populates it. The runtime cannot faithfully transport a callable through that path.

### Concrete example — the `action` fixture

**Input:**

```tsx
import { action } from "commonfabric";

function makeAction(helper: (value: string) => string) {
  return action(() => {
    return helper("x");
  });
}

const helper = (value: string) => value.toUpperCase();
const myAction = makeAction(helper);

export default myAction;
```

**On main today** (the bug):

```ts
function makeAction(helper: (value: string) => string) {
    return __cfHelpers.handler(
        false as const satisfies __cfHelpers.JSONSchema,
        {
            type: "object",
            properties: {}                 // ← empty schema, no slot for `helper`
        } as const satisfies __cfHelpers.JSONSchema,
        (_, { helper }) => {               // ← destructures `helper` anyway
            return helper("x");
        }
    )({
        helper: helper                     // ← passes via state, which the schema doesn't permit
    });
}
```

**On this branch** (codex's fix):

```ts
function makeAction(helper: (value: string) => string) {
    return __cfHelpers.handler(
        false as const satisfies __cfHelpers.JSONSchema,
        {
            type: "object",
            properties: {}
        } as const satisfies __cfHelpers.JSONSchema,
        (_, __cf_action_params) => {       // ← anonymous placeholder, doesn't touch helper
            return helper("x");             // ← helper resolves lexically to outer parameter
        }
    )({});                                 // ← empty inputs, matches the empty schema
}
```

### Same bug, `derive` fixture

**Input:**

```tsx
import { derive, pattern } from "commonfabric";

function makePattern(helper: (value: string) => string) {
  return pattern(() => {
    return {
      label: derive("x", () => helper("x")),
    };
  });
}

const helper = (value: string) => value.toUpperCase();
const myPattern = makePattern(helper);

export default myPattern;
```

**On main today** (the bug):

```ts
function makePattern(helper: (value: string) => string) {
    return pattern(() => {
        return {
            label: __cfHelpers.derive(
                { type: "object", properties: {} } as const ...,    // ← empty schema
                { type: "string" } as const ...,
                { helper: helper },                                  // ← but inputs has helper
                ({ helper }) => helper("x")                          // ← destructured anyway
            ).for(["__patternResult", "label"], true)
        };
    }, ...);
}
```

**On this branch** (codex's fix): `helper` left lexical inside the derive callback; inputs argument dropped; schema stays `properties: {}` consistently.

The `handler-` and `map-` fixtures exhibit the same shape inconsistency on main (verified for `action-` and `derive-`; not individually re-run for the other two, but the structural pattern is identical).

## 2. Berni's proposed direction changes the scope

Per discussion with Berni (2026-05-13): we should add a **compile-time placement validator** for `action()` requiring it to appear only in allowed contexts (pattern body, computed body, handler body, map callback). This is in addition to the existing `lift()`/`handler()` placement validator in `packages/ts-transformers/src/transformers/pattern-context-validation.ts:583` (`validateBuilderPlacement`), which already rejects direct `lift()`/`handler()` calls inside restricted reactive contexts.

The existing validator does NOT today reject:

- `action()` placement (no validator for `action()` yet — this is what Berni wants added).
- The codex `action` fixture's shape: `function makeAction(helper) { return action(() => …) }` — `action()` at the top of a plain function, not in a restricted context. Confirmed empirically: main passes type check on this input, then emits the bad transform.

Once the new validator lands:

- **The `action-captured-callable-export-binding` fixture becomes a compile error** at validation time. The action-strategy's callable-capture filter never runs on it. → Action piece of this branch becomes dead code.
- **The `handler-captured-callable-export-binding` fixture (uses inline JSX `onClick`) may or may not be rejected**, depending on how the validator treats inline JSX event handlers (which lower into `handler()` but aren't direct calls). Needs a focused experiment.
- **The `derive-` and `map-captured-callable-export-binding` fixtures are NOT rejected.** Their placement is fine (`derive`/`.map()` inside a pattern body is an allowed context). The bug is in *what the callback captures*, not where it's placed. → Derive and map pieces of this branch are still needed.

## 3. Recommended split

This PR's contents should split into three:

### Keep (pick up here)

The **derive-strategy and array-method-transform changes** plus their fixtures (`derive-captured-callable-export-binding`, `map-captured-callable-export-binding`). These solve a real bug class that survives Berni's proposed validator.

The supporting machinery these depend on:

- `packages/ts-transformers/src/closures/utils/callable-capture-filter.ts` — keep.
- `packages/ts-transformers/src/closures/utils/non-hoistable-callbacks.ts` — keep; the hoisting registry is still load-bearing for the surviving paths (a callback that legitimately captures a callable from its enclosing scope cannot be hoisted to module scope without breaking the reference).
- `packages/ts-transformers/src/closures/module-scope-callback-hoisting.ts` — the recursive `nestedFunctionCapturesEnclosingBindings` descent is still needed.

### Drop (made redundant by the validator)

- The **action-strategy changes** (`packages/ts-transformers/src/closures/strategies/action-strategy.ts`).
- The **action fixture** (`action-captured-callable-export-binding.input.tsx` + golden).
- Possibly the **handler-strategy changes** and **handler fixture** — see #4 below.

### Validator work (new territory — does NOT reuse this branch)

Extend `packages/ts-transformers/src/transformers/pattern-context-validation.ts` to:

- Add an `action()` placement rule. Allowed contexts: pattern body, computed body, handler body, map callback. Anything else → diagnostic.
- Modeled on the existing `validateBuilderPlacement` (line 583) for `lift()`/`handler()`.

## 4. Open question on the handler-strategy piece

The `handler-captured-callable-export-binding` fixture uses an inline JSX event handler (`<cf-button onClick={() => helper("x")}>` inside a `pattern()` body). This isn't a direct `handler()` call site that the existing or proposed validator would catch — it lowers into `handler()` machinery, but the source-side construct is JSX-bound.

Open question: should the validator extend to inline JSX handler bodies, or are those a legitimate context for callable captures? Needs a focused experiment:

1. Construct an inline JSX `onClick={() => helper(...)}` shape inside a placement context that *is* allowed by the validator.
2. Run through main; see whether the bug still surfaces.
3. If yes → keep the handler-strategy piece of this branch.
4. If no (or if Berni decides inline JSX handlers should be banned in this shape) → drop the handler piece too.

## 5. What's been verified so far

- All four fixture inputs reproduce the bug on current `main` (transformer emits inconsistent empty-schema-but-populated-state output).
- The full ts-transformers suite passes on this branch's own state (255/0).
- This branch does NOT cleanly rebase onto current main — there's a conflict in `packages/ts-transformers/src/closures/module-scope-callback-hoisting.ts` with PR #3550's debug-only `non-hoistable-callback` diagnostic. The two changes touch the same lines of the `visit` function but aren't logically contradictory: codex's recursive nested-function descent and #3550's diagnostic should coexist (the diagnostic just observes what the hoist check decided). Manual rebase needed.

## 6. Test verification (originally from the PR description)

- `deno test -A test/closures/module-scope-helper-hoisting.test.ts`
- `env FIXTURE_PATTERN=captured-callable-export-binding deno test -A test/fixture-based.test.ts`
- `deno test -A test/fixture-based.test.ts`
- `git diff --check`

---

# Original PR description below

## Problem
- closure strategies were rewriting direct callable captures into generated closure state or params
- those generated transport objects do not faithfully carry plain callables today
- the rewritten callback could therefore shadow a valid lexical helper with an undefined generated binding

## Approach
- keep direct callable root captures lexical instead of routing them through generated closure state or params
- apply that rule across `action`, JSX `handler`, `derive`, and reactive array-method callback lowering
- mark callbacks and enclosing callbacks non-hoistable when they rely on those lexical callable captures
- add targeted fixtures for each affected strategy plus a hoisting regression

## Why The Hoisting Change Is Here
Once a closure strategy leaves callable captures lexical, module-scope callback hoisting must not pull those callbacks away from the enclosing bindings they still depend on. The new non-hoistable callback registry is the coordination seam for that rule.

## Out Of Scope
This PR does not change the separate SES or plain-data behavior for exported actions or dynamic pattern creation. It only fixes the earlier transformer-side bad shape.

## Verification
- `deno test -A test/closures/module-scope-helper-hoisting.test.ts`
- `env FIXTURE_PATTERN=captured-callable-export-binding deno test -A test/fixture-based.test.ts`
- `deno test -A test/fixture-based.test.ts`
- `git diff --check`
