### PR TITLE
Run the performance checker on `main`

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -403,6 +403,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
         run: deno run --allow-net --allow-env --allow-read --allow-run --allow-write tasks/perf-check.ts
 
   attest-binaries:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -403,7 +403,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
         run: deno run --allow-net --allow-env --allow-read --allow-run --allow-write tasks/perf-check.ts
 
   attest-binaries:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -403,7 +403,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          TEST_OF_UNDEFINED_GH_VAR: ${{ github.event.zonk_boop.beep }}
           IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
         run: deno run --allow-net --allow-env --allow-read --allow-run --allow-write tasks/perf-check.ts
 

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -403,6 +403,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          TEST_OF_UNDEFINED_GH_VAR: ${{ github.event.zonk_boop.beep }}
           IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
         run: deno run --allow-net --allow-env --allow-read --allow-run --allow-write tasks/perf-check.ts
 

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -374,7 +374,7 @@ jobs:
 
   perf-check:
     name: "Performance Check"
-    if: github.event_name == 'pull_request'
+    if: (github.event_name == 'pull_request') || (github.ref_name == 'main')
     runs-on: ubuntu-latest
     needs:
       - check

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -65,16 +65,14 @@ const EXCLUDED_METRIC_PATTERNS = [
 
 async function main() {
   const runId = Deno.env.get("GITHUB_RUN_ID");
-  const prNumber = Deno.env.get("PR_NUMBER");
+  const rawPrNumber = Deno.env.get("PR_NUMBER");
   const isPullRequest = Deno.env.get("IS_PULL_REQUEST") !== "false";
+
   const informationalOnly = !isPullRequest;
 
   // For testing.
-  const zonk = Deno.env.get("TEST_OF_UNDEFINED_GH_VAR");
-  console.log("####### PR NUMBER", prNumber);
-  console.log("####### IS PULL REQUEST", isPullRequest);
-  console.log("####### TEST %o", zonk);
-  if (Math.random() !== -10) Deno.exit(1);
+  const prNumber = (rawPrNumber === "never123") ? rawPrNumber : null;
+  //const prNumber = (rawPrNumber === "") ? null : rawPrNumber;
 
   if (!TOKEN) {
     console.error("GITHUB_TOKEN is required.");
@@ -85,7 +83,7 @@ async function main() {
     Deno.exit(1);
   }
 
-  // 1. Check PR description for overrides
+  // 1. Check PR description for overrides, if there's a PR to check.
   let prOverrides;
   if (prNumber) {
     console.log(`Fetching PR #${prNumber} description...`);

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -66,6 +66,11 @@ const EXCLUDED_METRIC_PATTERNS = [
 async function main() {
   const runId = Deno.env.get("GITHUB_RUN_ID");
   const prNumber = Deno.env.get("PR_NUMBER");
+  const isPullRequest = Deno.env.get("IS_PULL_REQUEST");
+
+  console.log("####### PR NUMBER", prNumber);
+  console.log("####### IS PULL REQUEST", isPullRequest);
+  Deno.exit(1);
 
   if (!TOKEN) {
     console.error("GITHUB_TOKEN is required.");

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -69,13 +69,12 @@ async function main() {
   const isPullRequest = Deno.env.get("IS_PULL_REQUEST") !== "false";
   const informationalOnly = !isPullRequest;
 
-
   // For testing.
-  const zonk = Deno.env.get("TEST_OF_UNDEFINED_GH_VAR")
+  const zonk = Deno.env.get("TEST_OF_UNDEFINED_GH_VAR");
   console.log("####### PR NUMBER", prNumber);
   console.log("####### IS PULL REQUEST", isPullRequest);
   console.log("####### TEST %o", zonk);
-  if (Math.random() !== -10) { Deno.exit(1); }
+  if (Math.random() !== -10) Deno.exit(1);
 
   if (!TOKEN) {
     console.error("GITHUB_TOKEN is required.");

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -71,7 +71,7 @@ async function main() {
   const prNumber = (rawPrNumber === "never123") ? rawPrNumber : null;
   //const prNumber = (rawPrNumber === "") ? null : rawPrNumber;
 
-  const informationalOnly = (prNumber === null);
+  const informationalOnly = prNumber === null;
 
   if (!TOKEN) {
     console.error("GITHUB_TOKEN is required.");

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -66,13 +66,12 @@ const EXCLUDED_METRIC_PATTERNS = [
 async function main() {
   const runId = Deno.env.get("GITHUB_RUN_ID");
   const rawPrNumber = Deno.env.get("PR_NUMBER");
-  const isPullRequest = Deno.env.get("IS_PULL_REQUEST") !== "false";
-
-  const informationalOnly = !isPullRequest;
 
   // For testing.
   const prNumber = (rawPrNumber === "never123") ? rawPrNumber : null;
   //const prNumber = (rawPrNumber === "") ? null : rawPrNumber;
+
+  const informationalOnly = (prNumber === null);
 
   if (!TOKEN) {
     console.error("GITHUB_TOKEN is required.");
@@ -458,6 +457,10 @@ async function main() {
   }
 
   // 6c. Pass/fail outcome + override copy-paste block pinned at the bottom.
+  if (informationalOnly) {
+    console.log("\nInformational Only:");
+  }
+
   if (failures.length === 0) {
     console.log("\nAll metrics within normal range.");
     Deno.exit(0);

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -66,11 +66,7 @@ const EXCLUDED_METRIC_PATTERNS = [
 async function main() {
   const runId = Deno.env.get("GITHUB_RUN_ID");
   const rawPrNumber = Deno.env.get("PR_NUMBER");
-
-  // For testing.
-  const prNumber = (rawPrNumber === "never123") ? rawPrNumber : null;
-  //const prNumber = (rawPrNumber === "") ? null : rawPrNumber;
-
+  const prNumber = (rawPrNumber === "") ? null : rawPrNumber;
   const informationalOnly = prNumber === null;
 
   if (!TOKEN) {

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -70,7 +70,7 @@ async function main() {
 
   console.log("####### PR NUMBER", prNumber);
   console.log("####### IS PULL REQUEST", isPullRequest);
-  Deno.exit(1);
+  if (Math.random() !== -10) Deno.exit(1);
 
   if (!TOKEN) {
     console.error("GITHUB_TOKEN is required.");

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -67,6 +67,7 @@ async function main() {
   const runId = Deno.env.get("GITHUB_RUN_ID");
   const prNumber = Deno.env.get("PR_NUMBER");
   const isPullRequest = Deno.env.get("IS_PULL_REQUEST");
+  const informationalOnly = !isPullRequest;
 
   console.log("####### PR NUMBER", prNumber);
   console.log("####### IS PULL REQUEST", isPullRequest);
@@ -457,6 +458,10 @@ async function main() {
   // 6c. Pass/fail outcome + override copy-paste block pinned at the bottom.
   if (failures.length === 0) {
     console.log("\nAll metrics within normal range.");
+    Deno.exit(0);
+  } else if (informationalOnly) {
+    console.log("\nOne or more metrics are out-of-range.");
+    console.log("This build would fail if it were a PR.");
     Deno.exit(0);
   }
 

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -66,12 +66,16 @@ const EXCLUDED_METRIC_PATTERNS = [
 async function main() {
   const runId = Deno.env.get("GITHUB_RUN_ID");
   const prNumber = Deno.env.get("PR_NUMBER");
-  const isPullRequest = Deno.env.get("IS_PULL_REQUEST");
+  const isPullRequest = Deno.env.get("IS_PULL_REQUEST") !== "false";
   const informationalOnly = !isPullRequest;
 
+
+  // For testing.
+  const zonk = Deno.env.get("TEST_OF_UNDEFINED_GH_VAR")
   console.log("####### PR NUMBER", prNumber);
   console.log("####### IS PULL REQUEST", isPullRequest);
-  if (Math.random() !== -10) Deno.exit(1);
+  console.log("####### TEST %o", zonk);
+  if (Math.random() !== -10) { Deno.exit(1); }
 
   if (!TOKEN) {
     console.error("GITHUB_TOKEN is required.");
@@ -81,15 +85,16 @@ async function main() {
     console.error("GITHUB_RUN_ID is required.");
     Deno.exit(1);
   }
-  if (!prNumber) {
-    console.error("PR_NUMBER is required.");
-    Deno.exit(1);
-  }
 
   // 1. Check PR description for overrides
-  console.log(`Fetching PR #${prNumber} description...`);
-  const prBody = await fetchPRBody(parseInt(prNumber));
-  const prOverrides = parseBaselineOverrides(prBody);
+  let prOverrides;
+  if (prNumber) {
+    console.log(`Fetching PR #${prNumber} description...`);
+    const prBody = await fetchPRBody(parseInt(prNumber));
+    prOverrides = parseBaselineOverrides(prBody);
+  } else {
+    prOverrides = { metrics: new Map() };
+  }
 
   if (prOverrides.metrics.size > 0) {
     console.log(


### PR DESCRIPTION
In order to have a basis for performance comparison, this PR starts running the "Performance Check" CI job on `deno` workflows that are targeting `main`, but in an "information-only" mode, never actually failing.