### PR TITLE
More intern-related bits

### DIFF
--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1,5 +1,4 @@
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import type {
   FabricValue,
@@ -295,6 +294,9 @@ const storedMetadataFor = (
     : undefined;
 };
 
+/**
+ * This returns a map whose values are always interned schemas.
+ */
 const candidateSchemasByTarget = (
   inputs: readonly WritePolicyInput[],
   implementationIdentity?: ImplementationIdentity,
@@ -318,8 +320,8 @@ const candidateSchemasByTarget = (
     result.set(
       key,
       existing === undefined
-        ? candidate
-        : mergeCfcSchemaEnvelopes(existing, candidate),
+        ? internSchema(candidate)
+        : mergeCfcSchemaEnvelopes(existing, candidate), // Guaranteed interned.
     );
   }
   return result;
@@ -796,10 +798,9 @@ export const prepareBoundaryCommit = (
       URI,
       MediaType,
     ];
-    const frozen = toDeepFrozenSchema(schema, true) as JSONSchema;
 
     const target = { space, id, type };
-    const requirementFailure = verifyInputRequirements(tx, frozen, target);
+    const requirementFailure = verifyInputRequirements(tx, schema, target);
     if (requirementFailure) {
       reasons.push(requirementFailure);
       continue;
@@ -807,25 +808,25 @@ export const prepareBoundaryCommit = (
     const trustedEventFailure = verifyTrustedEventRequirements(
       tx,
       target,
-      frozen,
+      schema,
     );
     if (trustedEventFailure) {
       reasons.push(trustedEventFailure);
       continue;
     }
 
-    const exactCopyFailure = verifyExactCopyRequirements(tx, target, frozen);
+    const exactCopyFailure = verifyExactCopyRequirements(tx, target, schema);
     if (exactCopyFailure) {
       reasons.push(exactCopyFailure);
       continue;
     }
 
     const existing = storedMetadataFor(tx, space, id, type);
-    let mergedSchema = frozen;
+    let mergedSchema = schema;
     if (existing !== undefined) {
       try {
         const storedSchema = loadSchemaDocument(tx, space, existing.schemaHash);
-        mergedSchema = mergeCfcSchemaEnvelopes(storedSchema, frozen);
+        mergedSchema = mergeCfcSchemaEnvelopes(storedSchema, schema);
       } catch (error) {
         reasons.push(
           error instanceof Error
@@ -836,7 +837,7 @@ export const prepareBoundaryCommit = (
       }
     }
     const schemaAndHash = internSchema(mergedSchema, true);
-    const mergedSchemaEntries = walkIfcSchema(mergedSchema);
+    const mergedSchemaEntries = walkIfcSchema(schemaAndHash.schema);
     const mergedSchemaEntryLabels = new Map<string, IFCLabel>(
       mergedSchemaEntries.map((entry) => [
         canonicalizeLogicalPath(entry.path).join("\u0000"),

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1027,7 +1027,9 @@ export const prepareBoundaryCommit = (
   }
   const targetKeys = new Set([...candidates.keys(), ...linkWrites.keys()]);
   for (const key of targetKeys) {
-    const schema = candidates.get(key) ?? emptySchemaObject();
+    const candidateSchema = candidates.get(key);
+    const schema = candidateSchema ?? emptySchemaObject();
+    const undefinedCandidate = candidateSchema === undefined;
     const [space, id, type] = key.split("\u0000") as [
       MemorySpace,
       URI,
@@ -1038,7 +1040,7 @@ export const prepareBoundaryCommit = (
     const existing = storedMetadataFor(tx, space, id, type);
     let storedSchema: JSONSchema | undefined;
     let mergedSchema = schema;
-    if (existing !== undefined && schema === undefined) {
+    if (existing !== undefined && undefinedCandidate) {
       try {
         storedSchema = loadSchemaDocument(tx, space, existing.schemaHash);
         mergedSchema = storedSchema;
@@ -1067,7 +1069,7 @@ export const prepareBoundaryCommit = (
     const linkWriteInputs = linkWrites.get(key) ?? [];
     const verificationSchema = storedSchema !== undefined &&
         linkWriteInputs.length > 0
-      ? schema === undefined
+      ? undefinedCandidate
         ? storedSchemaClaimsForLinkWrites(storedSchema, linkWriteInputs)
         : mergeCfcSchemaEnvelopes(
           schema,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1,4 +1,5 @@
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { emptySchemaObject } from "@commonfabric/data-model/schema-utils";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import type {
   FabricValue,
@@ -1026,7 +1027,7 @@ export const prepareBoundaryCommit = (
   }
   const targetKeys = new Set([...candidates.keys(), ...linkWrites.keys()]);
   for (const key of targetKeys) {
-    const schema = candidates.get(key);
+    const schema = candidates.get(key) ?? emptySchemaObject();
     const [space, id, type] = key.split("\u0000") as [
       MemorySpace,
       URI,
@@ -1069,10 +1070,10 @@ export const prepareBoundaryCommit = (
       ? schema === undefined
         ? storedSchemaClaimsForLinkWrites(storedSchema, linkWriteInputs)
         : mergeCfcSchemaEnvelopes(
-          frozen,
+          schema,
           storedSchemaClaimsForLinkWrites(storedSchema, linkWriteInputs),
         )
-      : frozen;
+      : schema;
 
     const requirementFailure = verifyInputRequirements(
       tx,

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -13,6 +13,7 @@ import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   isNontrivialSchema,
+  schemaWithProperties,
   toDeepFrozenSchema,
 } from "@commonfabric/data-model/schema-utils";
 import { createCell, isCell } from "./cell.ts";
@@ -475,7 +476,7 @@ export function mergeDefaults(
     ? { ...base.default, ...defaultValue } as JSONValue
     : defaultValue as JSONValue;
 
-  return toDeepFrozenSchema({ ...base, default: mergedDefault }, true);
+  return schemaWithProperties(base, { default: mergedDefault });
 }
 
 /**

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -14,7 +14,6 @@ import { internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   isNontrivialSchema,
   schemaWithProperties,
-  toDeepFrozenSchema,
 } from "@commonfabric/data-model/schema-utils";
 import { createCell, isCell } from "./cell.ts";
 import { readMaybeLink, resolveLink } from "./link-resolution.ts";
@@ -877,7 +876,7 @@ export function generateHandlerSchema(
     Object.assign(mergedDefs, $defs);
     Object.assign(mergedDefinitions, definitions);
   }
-  return toDeepFrozenSchema({
+  return internSchema({
     type: "object",
     properties: {
       "$event": eventSchema ?? true,
@@ -887,7 +886,7 @@ export function generateHandlerSchema(
     ...(Object.keys(mergedDefs).length && { $defs: mergedDefs }),
     ...(Object.keys(mergedDefinitions).length &&
       { definitions: mergedDefinitions }),
-  }, true);
+  });
 }
 
 function unwrapAsCellSchema(schema: JSONSchemaObj): JSONSchemaObj {

--- a/packages/runner/test/merge-defaults.test.ts
+++ b/packages/runner/test/merge-defaults.test.ts
@@ -5,6 +5,10 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
+import {
+  internSchema,
+  isInternedSchema,
+} from "@commonfabric/data-model/schema-hash";
 import { isNontrivialSchema } from "@commonfabric/data-model/schema-utils";
 import { mergeDefaults } from "../src/schema.ts";
 import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
@@ -284,6 +288,20 @@ describe("mergeDefaults", () => {
       const result = mergeDefaults(schema, [1, 2, 3]);
       expect(isDeepFrozen(result)).toBe(true);
     });
+  });
+
+  describe("intern contagion", () => {
+    it("should return an interned result when the given `schema` is interned", () => {
+      const schema = internSchema({ type: "array", title: "muffins" });
+      const result = mergeDefaults(schema, ["blueberry", "corn"]);
+      expect(isInternedSchema(result)).toBe(true);
+    });
+  });
+
+  it("should return an uninterned result when the given `schema` is uninterned", () => {
+    const schema: JSONSchema = { type: "array", title: "muffins" };
+    const result = mergeDefaults(schema, ["blueberry", "corn"]);
+    expect(isInternedSchema(result)).toBe(false);
   });
 
   describe("edge cases", () => {


### PR DESCRIPTION
This PR adds another sprinkling of interning:

* Moved where `prepare.ts` does its interning to be further upstream, which also allows it to avoid double-interning sometimes.
* Made `mergeDefaults()` do "intern contagion."
* Made `generateHandlerSchema()` do `internSchema()` instead of `toDeepFrozenSchema()`.
