### PR TITLE
Terminalize interrupted cf-harness runs

### DIFF
--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -62,6 +62,12 @@ export interface CfHarnessCliIO {
   stderr(text: string): void;
 }
 
+export type CfHarnessCliSignal = "SIGINT" | "SIGTERM";
+
+export type CfHarnessCliSignalHandler = (
+  signal: CfHarnessCliSignal,
+) => void | Promise<void>;
+
 export interface RunCfHarnessCliDependencies {
   cwd?: string;
   env?: Record<string, string | undefined>;
@@ -72,12 +78,77 @@ export interface RunCfHarnessCliDependencies {
   createPromptLoop?: (
     options: CreateHarnessPromptLoopOptions,
   ) => Pick<CfHarnessPromptLoop, "runPrompt" | "runTranscript">;
+  registerSignalHandler?: (
+    signals: readonly CfHarnessCliSignal[],
+    handler: CfHarnessCliSignalHandler,
+  ) => () => void;
+  exit?: (code: number) => never | void;
 }
 
 const defaultCliIo = (): CfHarnessCliIO => ({
   stdout: (text) => Deno.stdout.writeSync(new TextEncoder().encode(text)),
   stderr: (text) => Deno.stderr.writeSync(new TextEncoder().encode(text)),
 });
+
+const signalExitCode = (signal: CfHarnessCliSignal): number =>
+  signal === "SIGINT" ? 130 : 143;
+
+const defaultRegisterSignalHandler = (
+  signals: readonly CfHarnessCliSignal[],
+  handler: CfHarnessCliSignalHandler,
+): () => void => {
+  const listeners = signals.map((signal) => {
+    const listener = () => {
+      void handler(signal);
+    };
+    Deno.addSignalListener(signal, listener);
+    return { signal, listener };
+  });
+  let disposed = false;
+  return () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    for (const { signal, listener } of listeners) {
+      Deno.removeSignalListener(signal, listener);
+    }
+  };
+};
+
+export const installCfHarnessSignalHandlers = (
+  getEngine: () => CfHarnessEngine | undefined,
+  deps: Pick<
+    RunCfHarnessCliDependencies,
+    "registerSignalHandler" | "exit"
+  > = {},
+): () => void => {
+  const registerSignalHandler = deps.registerSignalHandler ??
+    defaultRegisterSignalHandler;
+  const exit = deps.exit ?? ((code: number): never => Deno.exit(code));
+  let handlingSignal = false;
+  let cleanup = () => {};
+  let disposed = false;
+  cleanup = registerSignalHandler(["SIGINT", "SIGTERM"], async (signal) => {
+    if (handlingSignal) {
+      return;
+    }
+    handlingSignal = true;
+    cleanup();
+    try {
+      await getEngine()?.terminalizeInterruptedRun(signal);
+    } finally {
+      exit(signalExitCode(signal));
+    }
+  });
+  return () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    cleanup();
+  };
+};
 
 const usage = `Usage: deno run -A src/main.ts [options] [prompt text]
 
@@ -592,6 +663,15 @@ export const runCfHarnessCli = async (
   deps: RunCfHarnessCliDependencies = {},
 ): Promise<number> => {
   const io = deps.io ?? defaultCliIo();
+  let activeEngine: CfHarnessEngine | undefined;
+  let signalCleanup: (() => void) | undefined;
+  const activateEngine = (engine: CfHarnessEngine) => {
+    activeEngine = engine;
+    signalCleanup ??= installCfHarnessSignalHandlers(
+      () => activeEngine,
+      deps,
+    );
+  };
   try {
     const parsed = await parseCfHarnessCliArgs(argv, deps);
     if ("help" in parsed) {
@@ -625,17 +705,26 @@ export const runCfHarnessCli = async (
     if (parsed.resumeRun !== undefined) {
       const readRunArtifacts = deps.readRunArtifacts ?? readHarnessRunArtifacts;
       const artifacts = await readRunArtifacts(parsed.resumeRun);
+      const engine = new CfHarnessEngine({
+        runState: artifacts.runState,
+        artifactRoot: parsed.artifactRoot,
+        workspaceHostPath: parsed.workspace,
+        model: parsed.model ?? artifacts.runState.model,
+        gatewayBaseUrl: parsed.gatewayBaseUrl,
+        gatewayAuthMode: parsed.gatewayAuthMode,
+        ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
+        cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
+      });
+      activateEngine(engine);
       const loop = createPromptLoop({
-        engine: new CfHarnessEngine({
-          runState: artifacts.runState,
-          artifactRoot: parsed.artifactRoot,
-          workspaceHostPath: parsed.workspace,
-          model: parsed.model ?? artifacts.runState.model,
-          gatewayBaseUrl: parsed.gatewayBaseUrl,
-          gatewayAuthMode: parsed.gatewayAuthMode,
-          ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
-          cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
-        }),
+        engine,
+        workspaceHostPath: parsed.workspace,
+        artifactRoot: parsed.artifactRoot,
+        model: parsed.model ?? artifacts.runState.model,
+        gatewayBaseUrl: parsed.gatewayBaseUrl,
+        gatewayAuthMode: parsed.gatewayAuthMode,
+        ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
+        cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
         apiKey: parsed.apiKey,
         apiKeySource: parsed.apiKeySource,
         maxModelTurns: parsed.maxModelTurns,
@@ -656,7 +745,18 @@ export const runCfHarnessCli = async (
         onTranscriptEvent,
       });
     } else {
+      const engine = new CfHarnessEngine({
+        workspaceHostPath: parsed.workspace,
+        artifactRoot: parsed.artifactRoot,
+        model: parsed.model,
+        gatewayBaseUrl: parsed.gatewayBaseUrl,
+        gatewayAuthMode: parsed.gatewayAuthMode,
+        ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
+        cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
+      });
+      activateEngine(engine);
       const loop = createPromptLoop({
+        engine,
         workspaceHostPath: parsed.workspace,
         artifactRoot: parsed.artifactRoot,
         model: parsed.model,
@@ -701,5 +801,7 @@ export const runCfHarnessCli = async (
   } catch (error) {
     io.stderr(`${error instanceof Error ? error.message : String(error)}\n`);
     return 1;
+  } finally {
+    signalCleanup?.();
   }
 };

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -25,6 +25,7 @@ import {
   classifyHarnessRunError,
   type ClassifyHarnessRunErrorOptions,
   collectHarnessCapabilitySnapshot,
+  createHarnessFailureRecord,
   type HarnessFailureRecord,
 } from "./diagnostics.ts";
 import {
@@ -244,6 +245,38 @@ export class CfHarnessEngine {
 
   async persistRunState(): Promise<string | undefined> {
     return await this.artifactStore?.persistRunState(this.#runState);
+  }
+
+  async terminalizeInterruptedRun(
+    signalName: string,
+  ): Promise<HarnessRunState> {
+    const currentState = this.#runState;
+    if (
+      currentState.status === "failed" ||
+      currentState.terminalReason === "assistant_completed"
+    ) {
+      return this.getRunState();
+    }
+    const now = this.#now();
+    this.#runState = appendHarnessFailureRecord(
+      this.#runState,
+      createHarnessFailureRecord({
+        kind: "harness_error",
+        source: "run_error",
+        detail:
+          `process received ${signalName} before the prompt loop completed`,
+        at: now,
+      }),
+      now,
+    );
+    this.#runState = setHarnessRunStatus(
+      this.#runState,
+      "failed",
+      now,
+      "process_interrupted",
+    );
+    await this.persistRunState();
+    return this.getRunState();
   }
 
   async persistTranscript(

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -18,7 +18,8 @@ export type HarnessRunTerminalReason =
   | "tool_completed"
   | "tool_error"
   | "max_model_turns"
-  | "prompt_loop_error";
+  | "prompt_loop_error"
+  | "process_interrupted";
 
 export interface HarnessRunState {
   runId: string;

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -2,14 +2,17 @@ import { assertEquals, assertRejects } from "@std/assert";
 import {
   buildCfHarnessOperatorSystemPrompt,
   type CfHarnessCliIO,
+  type CfHarnessCliSignalHandler,
   createCfHarnessBatchResult,
   formatCfHarnessCliResult,
   formatCfHarnessCliUsage,
   formatCfHarnessTranscriptEvent,
+  installCfHarnessSignalHandlers,
   parseCfHarnessCliArgs,
   resolveCfHarnessCliSystemPrompt,
   runCfHarnessCli,
 } from "../src/cli.ts";
+import { CfHarnessEngine } from "../src/engine.ts";
 import type {
   HarnessPromptLoopResult,
   RunHarnessPromptOptions,
@@ -312,6 +315,126 @@ Deno.test("runCfHarnessCli prints usage for help", async () => {
   assertEquals(exitCode, 0);
   assertEquals(stdout, [formatCfHarnessCliUsage()]);
   assertEquals(stderr, []);
+});
+
+Deno.test("installCfHarnessSignalHandlers terminalizes the active run before exiting", async () => {
+  const engine = new CfHarnessEngine({
+    workspaceHostPath: "/tmp/project",
+    runId: "run-signal",
+    now: (() => {
+      const timestamps = [
+        "2026-04-16T20:00:00.000Z",
+        "2026-04-16T20:00:01.000Z",
+      ];
+      return () => timestamps.shift() ?? "2026-04-16T20:00:02.000Z";
+    })(),
+  });
+  engine.setRunStatus("running");
+  let handler: CfHarnessCliSignalHandler | undefined;
+  let disposed = false;
+  let exitCode: number | undefined;
+
+  const cleanup = installCfHarnessSignalHandlers(() => engine, {
+    registerSignalHandler: (signals, registeredHandler) => {
+      assertEquals(signals, ["SIGINT", "SIGTERM"]);
+      handler = registeredHandler;
+      return () => {
+        disposed = true;
+      };
+    },
+    exit: (code) => {
+      exitCode = code;
+      throw new Error("exit");
+    },
+  });
+
+  await assertRejects(
+    () => Promise.resolve(handler?.("SIGTERM")),
+    Error,
+    "exit",
+  );
+  cleanup();
+
+  assertEquals(disposed, true);
+  assertEquals(exitCode, 143);
+  assertEquals(engine.getRunState().status, "failed");
+  assertEquals(engine.getRunState().terminalReason, "process_interrupted");
+  assertEquals(engine.getRunState().endedAt, "2026-04-16T20:00:02.000Z");
+  assertEquals(
+    engine.getRunState().failureRecords?.at(-1)?.detail,
+    "process received SIGTERM before the prompt loop completed",
+  );
+});
+
+Deno.test("runCfHarnessCli registers and disposes signal handlers around a run", async () => {
+  const { io, stdout, stderr } = createIoBuffers();
+  let registeredSignals: readonly string[] = [];
+  let disposed = false;
+  const exitCode = await runCfHarnessCli(
+    ["--prompt", "hello", "--gateway-auth-mode", "none"],
+    {
+      io,
+      env: {},
+      registerSignalHandler: (signals) => {
+        registeredSignals = signals;
+        return () => {
+          disposed = true;
+        };
+      },
+      createPromptLoop: () => ({
+        runPrompt: () =>
+          Promise.resolve(
+            ({
+              model: "gpt-5.4",
+              finalAssistantText: "Done.",
+              transcript: [
+                { role: "user", content: "hello" },
+                { role: "assistant", content: "Done." },
+              ],
+              modelTurns: 1,
+              runState: {
+                runId: "run-signal-cleanup",
+                status: "completed",
+                createdAt: "2026-04-16T20:10:00.000Z",
+                updatedAt: "2026-04-16T20:10:01.000Z",
+                cfcEnforcementMode: "disabled",
+                currentDir: "/workspace",
+                policyEvents: [],
+                toolOutputs: [],
+              },
+            }) satisfies HarnessPromptLoopResult,
+          ),
+        runTranscript: () =>
+          Promise.reject(new Error("unexpected resume path")),
+      }),
+    },
+  );
+
+  assertEquals(exitCode, 0);
+  assertEquals(registeredSignals, ["SIGINT", "SIGTERM"]);
+  assertEquals(disposed, true);
+  assertEquals(stderr, []);
+  assertEquals(stdout, [
+    formatCfHarnessCliResult({
+      model: "gpt-5.4",
+      finalAssistantText: "Done.",
+      transcript: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "Done." },
+      ],
+      modelTurns: 1,
+      runState: {
+        runId: "run-signal-cleanup",
+        status: "completed",
+        createdAt: "2026-04-16T20:10:00.000Z",
+        updatedAt: "2026-04-16T20:10:01.000Z",
+        cfcEnforcementMode: "disabled",
+        currentDir: "/workspace",
+        policyEvents: [],
+        toolOutputs: [],
+      },
+    }),
+  ]);
 });
 
 Deno.test("runCfHarnessCli executes the prompt loop and prints result metadata", async () => {

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -180,6 +180,44 @@ Deno.test("CfHarnessEngine marks the run as failed when a tool invocation errors
   assertEquals(engine.getRunState().primaryFailure?.kind, "unknown");
 });
 
+Deno.test("CfHarnessEngine terminalizes interrupted runs even after an intermediate tool completion", async () => {
+  const engine = new CfHarnessEngine({
+    sandboxRuntime: new FakeSandboxRuntime([
+      { stdout: "done\n", stderr: "", exitCode: 0 },
+    ]),
+    runId: "run-interrupted",
+    cfcEnforcementMode: "observe",
+    now: (() => {
+      const timestamps = [
+        "2026-04-15T19:20:00.000Z",
+        "2026-04-15T19:20:01.000Z",
+        "2026-04-15T19:20:02.000Z",
+        "2026-04-15T19:20:03.000Z",
+      ];
+      return () => timestamps.shift() ?? "2026-04-15T19:20:04.000Z";
+    })(),
+  });
+
+  await engine.invokeBuiltinTool("bash", { command: "echo done" });
+  assertEquals(engine.getRunState().status, "completed");
+  assertEquals(engine.getRunState().terminalReason, "tool_completed");
+
+  await engine.terminalizeInterruptedRun("SIGTERM");
+
+  assertEquals(engine.getRunState().status, "failed");
+  assertEquals(engine.getRunState().updatedAt, "2026-04-15T19:20:04.000Z");
+  assertEquals(engine.getRunState().endedAt, "2026-04-15T19:20:04.000Z");
+  assertEquals(engine.getRunState().terminalReason, "process_interrupted");
+  assertEquals(engine.getRunState().failureRecords?.at(-1), {
+    type: "cf-harness.failure-record",
+    kind: "harness_error",
+    source: "run_error",
+    detail: "process received SIGTERM before the prompt loop completed",
+    at: "2026-04-15T19:20:04.000Z",
+  });
+  assertEquals(engine.getRunState().primaryFailure?.kind, "harness_error");
+});
+
 Deno.test("CfHarnessEngine getRunState returns a deep clone", () => {
   const engine = new CfHarnessEngine({
     sandboxRuntime: new FakeSandboxRuntime(),


### PR DESCRIPTION
## Summary
- add explicit `process_interrupted` terminal reason for cf-harness run-state
- persist failed terminal state when CLI receives SIGINT/SIGTERM before prompt-loop completion
- keep `assistant_completed` as the successful no-op case while allowing intermediate `tool_completed` states to be marked interrupted

## Validation
- `deno fmt --check packages/cf-harness/src/run-state.ts packages/cf-harness/src/engine.ts packages/cf-harness/src/cli.ts packages/cf-harness/test/engine.test.ts packages/cf-harness/test/cli.test.ts`
- `deno test --allow-read --allow-write --allow-run packages/cf-harness/test/engine.test.ts packages/cf-harness/test/cli.test.ts`
- `deno task test` from `packages/cf-harness` (`91 passed | 0 failed`)
- `git diff --check`
