### PR TITLE
Return recoverable file tool errors

### DIFF
--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -3,6 +3,10 @@ import type { SandboxRuntime } from "./sandbox/types.ts";
 import type { HarnessPolicyEvent } from "./contracts/policy.ts";
 import type { ToolOutputId } from "./contracts/tool-result.ts";
 import type { BashToolInput, BashToolOutput } from "./tools/bash.ts";
+import {
+  isStructuredFileToolErrorOutput,
+  type StructuredFileToolErrorCode,
+} from "./tools/file-errors.ts";
 
 export const HARNESS_CAPABILITY_COMMANDS = [
   "bash",
@@ -30,7 +34,10 @@ export interface HarnessCapabilitySnapshot {
 }
 
 export type HarnessFailureKind =
+  | "file_not_found"
   | "missing_binary"
+  | "not_a_file"
+  | "permission_denied"
   | "tool_not_allowed"
   | "workspace_path_confusion"
   | "timeout"
@@ -322,9 +329,50 @@ export const classifyBuiltinToolFailure = (
         at,
         capabilitySnapshot,
       );
+    case "read_file":
+    case "write_file":
+      return classifyStructuredFileToolFailure(toolId, output, at);
     default:
       return undefined;
   }
+};
+
+const fileFailureKindForCode = (
+  code: StructuredFileToolErrorCode,
+): HarnessFailureKind => {
+  switch (code) {
+    case "file_not_found":
+      return "file_not_found";
+    case "not_a_file":
+      return "not_a_file";
+    case "permission_denied":
+      return "permission_denied";
+    case "path_outside_workspace":
+      return "workspace_path_confusion";
+    case "unknown":
+      return "unknown";
+  }
+};
+
+const classifyStructuredFileToolFailure = (
+  toolId: "read_file" | "write_file",
+  output: unknown,
+  at: string,
+): HarnessFailureRecord | undefined => {
+  if (!isStructuredFileToolErrorOutput(output)) {
+    return undefined;
+  }
+  return createHarnessFailureRecord({
+    kind: fileFailureKindForCode(output.error.code),
+    source: "tool_output",
+    detail: output.error.message,
+    at,
+    toolId,
+    outputId: output.outputId as ToolOutputId,
+    ...(output.error.exitCode !== undefined
+      ? { exitCode: output.error.exitCode }
+      : {}),
+  });
 };
 
 export const classifyHarnessRunError = (
@@ -394,7 +442,10 @@ const FAILURE_PRIORITY: Record<HarnessFailureKind, number> = {
   tool_not_allowed: 60,
   timeout: 50,
   workspace_path_confusion: 40,
+  permission_denied: 35,
   missing_binary: 30,
+  not_a_file: 25,
+  file_not_found: 25,
   sandbox_exec_mismatch: 20,
   harness_error: 10,
   unknown: 0,

--- a/packages/cf-harness/src/index.ts
+++ b/packages/cf-harness/src/index.ts
@@ -17,5 +17,6 @@ export * from "./sandbox/process-runner.ts";
 export * from "./sandbox/docker-runsc.ts";
 export * from "./tools/registry.ts";
 export * from "./tools/bash.ts";
+export * from "./tools/file-errors.ts";
 export * from "./tools/read-file.ts";
 export * from "./tools/write-file.ts";

--- a/packages/cf-harness/src/tools/file-errors.ts
+++ b/packages/cf-harness/src/tools/file-errors.ts
@@ -1,0 +1,167 @@
+import type { JSONSchema } from "@commonfabric/api";
+import type { HarnessToolContext } from "./types.ts";
+
+export const STRUCTURED_FILE_TOOL_ERROR_CODES = [
+  "file_not_found",
+  "not_a_file",
+  "permission_denied",
+  "path_outside_workspace",
+  "unknown",
+] as const;
+
+export type StructuredFileToolErrorCode =
+  typeof STRUCTURED_FILE_TOOL_ERROR_CODES[number];
+
+export interface StructuredFileToolError {
+  type: "cf-harness.structured-file-tool-error";
+  code: StructuredFileToolErrorCode;
+  message: string;
+  path: string;
+  detail?: string;
+  exitCode?: number;
+}
+
+export interface StructuredFileToolErrorOutput {
+  outputId: string;
+  path: string;
+  ok: false;
+  error: StructuredFileToolError;
+}
+
+export const structuredFileToolErrorSchema = {
+  type: "object",
+  properties: {
+    type: {
+      type: "string",
+      const: "cf-harness.structured-file-tool-error",
+    },
+    code: {
+      type: "string",
+      enum: [...STRUCTURED_FILE_TOOL_ERROR_CODES],
+    },
+    message: { type: "string" },
+    path: { type: "string" },
+    detail: { type: "string" },
+    exitCode: { type: "integer" },
+  },
+  required: ["type", "code", "message", "path"],
+  additionalProperties: false,
+} satisfies JSONSchema;
+
+export const structuredFileToolErrorOutputSchema = {
+  type: "object",
+  properties: {
+    outputId: { type: "string" },
+    path: { type: "string" },
+    ok: { type: "boolean", const: false },
+    error: structuredFileToolErrorSchema,
+  },
+  required: ["outputId", "path", "ok", "error"],
+  additionalProperties: false,
+} satisfies JSONSchema;
+
+export const isStructuredFileToolErrorOutput = (
+  output: unknown,
+): output is StructuredFileToolErrorOutput =>
+  typeof output === "object" &&
+  output !== null &&
+  "ok" in output &&
+  output.ok === false &&
+  "error" in output &&
+  typeof output.error === "object" &&
+  output.error !== null &&
+  "type" in output.error &&
+  output.error.type === "cf-harness.structured-file-tool-error";
+
+const messageForFileToolError = (
+  code: StructuredFileToolErrorCode,
+  path: string,
+  detail?: string,
+): string => {
+  switch (code) {
+    case "file_not_found":
+      return `file not found: ${path}`;
+    case "not_a_file":
+      return `not a file: ${path}`;
+    case "permission_denied":
+      return `permission denied: ${path}`;
+    case "path_outside_workspace":
+      return `path outside workspace: ${path}`;
+    case "unknown":
+      return detail !== undefined && detail !== ""
+        ? `file tool failed for ${path}: ${detail}`
+        : `file tool failed for ${path}`;
+  }
+};
+
+export const createStructuredFileToolErrorOutput = (
+  context: HarnessToolContext,
+  toolId: "read_file" | "write_file",
+  options: {
+    path: string;
+    code: StructuredFileToolErrorCode;
+    detail?: string;
+    exitCode?: number;
+  },
+): StructuredFileToolErrorOutput => ({
+  outputId: context.nextOutputId(toolId),
+  path: options.path,
+  ok: false,
+  error: {
+    type: "cf-harness.structured-file-tool-error",
+    code: options.code,
+    message: messageForFileToolError(
+      options.code,
+      options.path,
+      options.detail,
+    ),
+    path: options.path,
+    ...(options.detail !== undefined && options.detail !== ""
+      ? { detail: options.detail }
+      : {}),
+    ...(options.exitCode !== undefined ? { exitCode: options.exitCode } : {}),
+  },
+});
+
+export const detailFromShellFailure = (
+  result: { stdout: string; stderr: string; exitCode: number },
+): string =>
+  result.stderr.trim() || result.stdout.trim() ||
+  `shell exited with code ${result.exitCode}`;
+
+export const classifyFileToolShellFailure = (
+  result: { stdout: string; stderr: string; exitCode: number },
+): StructuredFileToolErrorCode => {
+  const combined = `${result.stderr}\n${result.stdout}`.toLowerCase();
+  if (
+    result.exitCode === 10 ||
+    combined.includes("file not found") ||
+    combined.includes("no such file or directory")
+  ) {
+    return "file_not_found";
+  }
+  if (
+    result.exitCode === 11 ||
+    combined.includes("not a file") ||
+    combined.includes("is a directory") ||
+    combined.includes("not a directory")
+  ) {
+    return "not_a_file";
+  }
+  if (result.exitCode === 13 || combined.includes("permission denied")) {
+    return "permission_denied";
+  }
+  return "unknown";
+};
+
+export const classifyPathResolutionError = (
+  error: unknown,
+): StructuredFileToolErrorCode => {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.toLowerCase().includes("path escapes workspace root")
+    ? "path_outside_workspace"
+    : "unknown";
+};
+
+export const detailFromUnknownError = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);

--- a/packages/cf-harness/src/tools/read-file.ts
+++ b/packages/cf-harness/src/tools/read-file.ts
@@ -1,6 +1,15 @@
 import type { JSONSchema } from "@commonfabric/api";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { HarnessToolDefinition } from "./types.ts";
+import {
+  classifyFileToolShellFailure,
+  classifyPathResolutionError,
+  createStructuredFileToolErrorOutput,
+  detailFromShellFailure,
+  detailFromUnknownError,
+  type StructuredFileToolErrorOutput,
+  structuredFileToolErrorOutputSchema,
+} from "./file-errors.ts";
 
 export interface ReadFileToolInput {
   path: string;
@@ -8,11 +17,15 @@ export interface ReadFileToolInput {
   maxBytes?: number;
 }
 
-export interface ReadFileToolOutput {
+export interface ReadFileToolSuccessOutput {
   outputId: string;
   path: string;
   content: string;
 }
+
+export type ReadFileToolOutput =
+  | ReadFileToolSuccessOutput
+  | StructuredFileToolErrorOutput;
 
 export const readFileToolDescriptor: HarnessToolDescriptor = {
   toolId: "read_file",
@@ -31,14 +44,16 @@ export const readFileToolDescriptor: HarnessToolDescriptor = {
     additionalProperties: false,
   } satisfies JSONSchema,
   outputSchema: {
-    type: "object",
-    properties: {
-      outputId: { type: "string" },
-      path: { type: "string" },
-      content: { type: "string" },
-    },
-    required: ["outputId", "path", "content"],
-    additionalProperties: false,
+    oneOf: [{
+      type: "object",
+      properties: {
+        outputId: { type: "string" },
+        path: { type: "string" },
+        content: { type: "string" },
+      },
+      required: ["outputId", "path", "content"],
+      additionalProperties: false,
+    }, structuredFileToolErrorOutputSchema],
   } satisfies JSONSchema,
   tags: ["file", "read", "vm"],
 };
@@ -55,13 +70,26 @@ export const readFileTool: HarnessToolDefinition<
     ) {
       throw new Error("read_file maxBytes must be a non-negative integer");
     }
-    const resolvedPath = context.resolvePath(input.path);
+    let resolvedPath: string;
+    try {
+      resolvedPath = context.resolvePath(input.path);
+    } catch (error) {
+      return createStructuredFileToolErrorOutput(context, "read_file", {
+        path: input.path,
+        code: classifyPathResolutionError(error),
+        detail: detailFromUnknownError(error),
+      });
+    }
     const result = await context.sandbox.runShell({
       command: [
         "set -eu",
-        'if [ ! -f "$1" ]; then',
+        'if [ ! -e "$1" ]; then',
         '  echo "file not found: $1" >&2',
-        "  exit 1",
+        "  exit 10",
+        "fi",
+        'if [ ! -f "$1" ]; then',
+        '  echo "not a file: $1" >&2',
+        "  exit 11",
         "fi",
         'if [ -n "$2" ]; then',
         '  exec head -c "$2" "$1"',
@@ -74,9 +102,12 @@ export const readFileTool: HarnessToolDefinition<
       ],
     });
     if (result.exitCode !== 0) {
-      const detail = result.stderr.trim() || result.stdout.trim() ||
-        `shell exited with code ${result.exitCode}`;
-      throw new Error(`read_file failed for ${resolvedPath}: ${detail}`);
+      return createStructuredFileToolErrorOutput(context, "read_file", {
+        path: resolvedPath,
+        code: classifyFileToolShellFailure(result),
+        detail: detailFromShellFailure(result),
+        exitCode: result.exitCode,
+      });
     }
     return {
       outputId: context.nextOutputId("read_file"),

--- a/packages/cf-harness/src/tools/write-file.ts
+++ b/packages/cf-harness/src/tools/write-file.ts
@@ -1,6 +1,15 @@
 import type { JSONSchema } from "@commonfabric/api";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { HarnessToolDefinition } from "./types.ts";
+import {
+  classifyFileToolShellFailure,
+  classifyPathResolutionError,
+  createStructuredFileToolErrorOutput,
+  detailFromShellFailure,
+  detailFromUnknownError,
+  type StructuredFileToolErrorOutput,
+  structuredFileToolErrorOutputSchema,
+} from "./file-errors.ts";
 
 export type WriteFileMode = "replace" | "append";
 
@@ -11,11 +20,15 @@ export interface WriteFileToolInput {
   createParents?: boolean;
 }
 
-export interface WriteFileToolOutput {
+export interface WriteFileToolSuccessOutput {
   outputId: string;
   path: string;
   mode: WriteFileMode;
 }
+
+export type WriteFileToolOutput =
+  | WriteFileToolSuccessOutput
+  | StructuredFileToolErrorOutput;
 
 export const WRITE_FILE_MODES: readonly WriteFileMode[] = [
   "replace",
@@ -40,14 +53,16 @@ export const writeFileToolDescriptor: HarnessToolDescriptor = {
     additionalProperties: false,
   } satisfies JSONSchema,
   outputSchema: {
-    type: "object",
-    properties: {
-      outputId: { type: "string" },
-      path: { type: "string" },
-      mode: { type: "string", enum: [...WRITE_FILE_MODES] },
-    },
-    required: ["outputId", "path", "mode"],
-    additionalProperties: false,
+    oneOf: [{
+      type: "object",
+      properties: {
+        outputId: { type: "string" },
+        path: { type: "string" },
+        mode: { type: "string", enum: [...WRITE_FILE_MODES] },
+      },
+      required: ["outputId", "path", "mode"],
+      additionalProperties: false,
+    }, structuredFileToolErrorOutputSchema],
   } satisfies JSONSchema,
   tags: ["file", "write", "vm"],
 };
@@ -58,7 +73,16 @@ export const writeFileTool: HarnessToolDefinition<
 > = {
   descriptor: writeFileToolDescriptor,
   async invoke(context, input) {
-    const resolvedPath = context.resolvePath(input.path);
+    let resolvedPath: string;
+    try {
+      resolvedPath = context.resolvePath(input.path);
+    } catch (error) {
+      return createStructuredFileToolErrorOutput(context, "write_file", {
+        path: input.path,
+        code: classifyPathResolutionError(error),
+        detail: detailFromUnknownError(error),
+      });
+    }
     const mode = input.mode ?? "replace";
     const result = await context.sandbox.runShell({
       command: [
@@ -66,8 +90,16 @@ export const writeFileTool: HarnessToolDefinition<
         'path="$1"',
         'mode="$2"',
         'create_parents="$3"',
+        'parent="$(dirname "$path")"',
         'if [ "$create_parents" = "true" ]; then',
-        '  mkdir -p "$(dirname "$path")"',
+        '  mkdir -p "$parent"',
+        'elif [ ! -d "$parent" ]; then',
+        '  echo "file not found: parent directory $parent" >&2',
+        "  exit 10",
+        "fi",
+        'if [ -e "$path" ] && [ ! -f "$path" ]; then',
+        '  echo "not a file: $path" >&2',
+        "  exit 11",
         "fi",
         'case "$mode" in',
         "  replace)",
@@ -78,7 +110,7 @@ export const writeFileTool: HarnessToolDefinition<
         "    ;;",
         "  *)",
         '    echo "unsupported write mode: $mode" >&2',
-        "    exit 2",
+        "    exit 12",
         "    ;;",
         "esac",
       ].join("\n"),
@@ -86,9 +118,12 @@ export const writeFileTool: HarnessToolDefinition<
       stdinText: input.content,
     });
     if (result.exitCode !== 0) {
-      const detail = result.stderr.trim() || result.stdout.trim() ||
-        `shell exited with code ${result.exitCode}`;
-      throw new Error(`write_file failed for ${resolvedPath}: ${detail}`);
+      return createStructuredFileToolErrorOutput(context, "write_file", {
+        path: resolvedPath,
+        code: classifyFileToolShellFailure(result),
+        detail: detailFromShellFailure(result),
+        exitCode: result.exitCode,
+      });
     }
     return {
       outputId: context.nextOutputId("write_file"),

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -180,6 +180,61 @@ Deno.test("CfHarnessEngine marks the run as failed when a tool invocation errors
   assertEquals(engine.getRunState().primaryFailure?.kind, "unknown");
 });
 
+Deno.test("CfHarnessEngine records recoverable file-tool failures without failing the run", async () => {
+  const engine = new CfHarnessEngine({
+    sandboxRuntime: new FakeSandboxRuntime([{
+      stdout: "",
+      stderr: "file not found: /workspace/notes/missing.txt",
+      exitCode: 10,
+    }]),
+    runId: "run-file-missing",
+    cfcEnforcementMode: "observe",
+    now: (() => {
+      const timestamps = [
+        "2026-04-15T19:15:00.000Z",
+        "2026-04-15T19:15:01.000Z",
+        "2026-04-15T19:15:02.000Z",
+        "2026-04-15T19:15:03.000Z",
+        "2026-04-15T19:15:04.000Z",
+      ];
+      return () => timestamps.shift() ?? "2026-04-15T19:15:05.000Z";
+    })(),
+  });
+
+  const result = await engine.invokeBuiltinTool("read_file", {
+    path: "notes/missing.txt",
+  });
+
+  assertEquals(result.output, {
+    outputId: createToolOutputId("run-file-missing", "read_file", 1),
+    path: "/workspace/notes/missing.txt",
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "file_not_found",
+      message: "file not found: /workspace/notes/missing.txt",
+      path: "/workspace/notes/missing.txt",
+      detail: "file not found: /workspace/notes/missing.txt",
+      exitCode: 10,
+    },
+  });
+  assertEquals(engine.getRunState().status, "completed");
+  assertEquals(engine.getRunState().terminalReason, "tool_completed");
+  assertEquals(engine.getRunState().toolOutputs, [result.resultRef]);
+  assertEquals(engine.getRunState().failureRecords?.length, 1);
+  assertEquals(
+    engine.getRunState().failureRecords?.[0]?.kind,
+    "file_not_found",
+  );
+  assertEquals(engine.getRunState().failureRecords?.[0]?.source, "tool_output");
+  assertEquals(engine.getRunState().failureRecords?.[0]?.toolId, "read_file");
+  assertEquals(
+    engine.getRunState().failureRecords?.[0]?.outputId,
+    createToolOutputId("run-file-missing", "read_file", 1),
+  );
+  assertEquals(engine.getRunState().primaryFailure?.kind, "file_not_found");
+});
+
 Deno.test("CfHarnessEngine terminalizes interrupted runs even after an intermediate tool completion", async () => {
   const engine = new CfHarnessEngine({
     sandboxRuntime: new FakeSandboxRuntime([

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -222,6 +222,123 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
   );
 });
 
+Deno.test("CfHarnessPromptLoop surfaces recoverable file-tool failures to the model", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        {
+          stdout: "",
+          stderr: "file not found: /workspace/notes/missing.txt",
+          exitCode: 10,
+        },
+      ]),
+      runId: "run-recoverable-file-error",
+      model: "gpt-5.4",
+      now: (() => {
+        const timestamps = [
+          "2026-04-15T20:05:00.000Z",
+          "2026-04-15T20:05:01.000Z",
+          "2026-04-15T20:05:02.000Z",
+          "2026-04-15T20:05:03.000Z",
+          "2026-04-15T20:05:04.000Z",
+          "2026-04-15T20:05:05.000Z",
+        ];
+        return () => timestamps.shift() ?? "2026-04-15T20:05:06.000Z";
+      })(),
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-missing",
+                type: "function",
+                function: {
+                  name: "read_file",
+                  arguments: JSON.stringify({
+                    path: "notes/missing.txt",
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "The file is not present.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Read the missing file and tell me what happened.",
+  });
+
+  const recoverableOutput = {
+    outputId: createToolOutputId(
+      "run-recoverable-file-error",
+      "read_file",
+      1,
+    ),
+    path: "/workspace/notes/missing.txt",
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "file_not_found",
+      message: "file not found: /workspace/notes/missing.txt",
+      path: "/workspace/notes/missing.txt",
+      detail: "file not found: /workspace/notes/missing.txt",
+      exitCode: 10,
+    },
+  };
+
+  assertEquals(result.finalAssistantText, "The file is not present.");
+  assertEquals(result.modelTurns, 2);
+  assertEquals(result.runState.status, "completed");
+  assertEquals(result.runState.terminalReason, "assistant_completed");
+  assertEquals(result.runState.primaryFailure?.kind, "file_not_found");
+  assertEquals(result.transcript.at(-2), {
+    role: "tool",
+    toolCallId: "call-missing",
+    toolName: "read_file",
+    content: JSON.stringify(recoverableOutput),
+    resultRef: {
+      type: "cf-harness.tool-result-ref",
+      outputId: createToolOutputId(
+        "run-recoverable-file-error",
+        "read_file",
+        1,
+      ),
+      toolId: "read_file",
+      runId: "run-recoverable-file-error",
+    },
+  });
+
+  const secondRequest = JSON.parse(String(fetchCalls[1]?.body)) as {
+    messages: Array<{ role: string; tool_call_id?: string; content: string }>;
+  };
+  assertEquals(secondRequest.messages.at(-1), {
+    role: "tool",
+    tool_call_id: "call-missing",
+    content: JSON.stringify(recoverableOutput),
+  });
+});
+
 Deno.test("CfHarnessPromptLoop only advertises allowed tools when a tool allowlist is configured", async () => {
   const fetchCalls: RequestInit[] = [];
   const loop = new CfHarnessPromptLoop({

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -54,6 +54,16 @@ class FakeSandboxRuntime implements SandboxRuntime {
   }
 }
 
+class StrictFakeSandboxRuntime extends FakeSandboxRuntime {
+  override resolvePath(path: string, cwd = this.defaultWorkingDirectory()) {
+    const resolved = super.resolvePath(path, cwd);
+    if (!this.isPathWithinWorkspace(resolved)) {
+      throw new Error(`path escapes workspace root: ${resolved}`);
+    }
+    return resolved;
+  }
+}
+
 const createContext = (
   sandbox: SandboxRuntime,
   initialCurrentDir = "/workspace",
@@ -139,9 +149,13 @@ Deno.test("read_file tool resolves relative paths from the session currentDir", 
     request: {
       command: [
         "set -eu",
-        'if [ ! -f "$1" ]; then',
+        'if [ ! -e "$1" ]; then',
         '  echo "file not found: $1" >&2',
-        "  exit 1",
+        "  exit 10",
+        "fi",
+        'if [ ! -f "$1" ]; then',
+        '  echo "not a file: $1" >&2',
+        "  exit 11",
         "fi",
         'if [ -n "$2" ]; then',
         '  exec head -c "$2" "$1"',
@@ -169,21 +183,78 @@ Deno.test("read_file tool rejects non-integer maxBytes", async () => {
   assertEquals(sandbox.calls, []);
 });
 
-Deno.test("read_file tool rejects missing files instead of returning empty content", async () => {
+Deno.test("read_file tool returns a recoverable file_not_found result", async () => {
   const sandbox = new FakeSandboxRuntime([{
     stdout: "",
     stderr: "file not found: /workspace/notes/missing.txt",
-    exitCode: 1,
+    exitCode: 10,
   }]);
 
-  await assertRejects(
-    () =>
-      readFileTool.invoke(createContext(sandbox), {
-        path: "notes/missing.txt",
-      }),
-    Error,
-    "read_file failed for /workspace/notes/missing.txt: file not found: /workspace/notes/missing.txt",
-  );
+  const output = await readFileTool.invoke(createContext(sandbox), {
+    path: "notes/missing.txt",
+  });
+
+  assertEquals(output, {
+    outputId: "run-1:read_file:1",
+    path: "/workspace/notes/missing.txt",
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "file_not_found",
+      message: "file not found: /workspace/notes/missing.txt",
+      path: "/workspace/notes/missing.txt",
+      detail: "file not found: /workspace/notes/missing.txt",
+      exitCode: 10,
+    },
+  });
+});
+
+Deno.test("read_file tool returns a recoverable not_a_file result", async () => {
+  const sandbox = new FakeSandboxRuntime([{
+    stdout: "",
+    stderr: "not a file: /workspace/notes",
+    exitCode: 11,
+  }]);
+
+  const output = await readFileTool.invoke(createContext(sandbox), {
+    path: "notes",
+  });
+
+  assertEquals(output, {
+    outputId: "run-1:read_file:1",
+    path: "/workspace/notes",
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "not_a_file",
+      message: "not a file: /workspace/notes",
+      path: "/workspace/notes",
+      detail: "not a file: /workspace/notes",
+      exitCode: 11,
+    },
+  });
+});
+
+Deno.test("read_file tool returns a recoverable path_outside_workspace result", async () => {
+  const sandbox = new StrictFakeSandboxRuntime();
+
+  const output = await readFileTool.invoke(createContext(sandbox), {
+    path: "../outside.txt",
+  });
+
+  assertEquals(output, {
+    outputId: "run-1:read_file:1",
+    path: "../outside.txt",
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "path_outside_workspace",
+      message: "path outside workspace: ../outside.txt",
+      path: "../outside.txt",
+      detail: "path escapes workspace root: /outside.txt",
+    },
+  });
+  assertEquals(sandbox.calls, []);
 });
 
 Deno.test("write_file tool supports append mode and passes content over stdin", async () => {
@@ -208,8 +279,16 @@ Deno.test("write_file tool supports append mode and passes content over stdin", 
         'path="$1"',
         'mode="$2"',
         'create_parents="$3"',
+        'parent="$(dirname "$path")"',
         'if [ "$create_parents" = "true" ]; then',
-        '  mkdir -p "$(dirname "$path")"',
+        '  mkdir -p "$parent"',
+        'elif [ ! -d "$parent" ]; then',
+        '  echo "file not found: parent directory $parent" >&2',
+        "  exit 10",
+        "fi",
+        'if [ -e "$path" ] && [ ! -f "$path" ]; then',
+        '  echo "not a file: $path" >&2',
+        "  exit 11",
         "fi",
         'case "$mode" in',
         "  replace)",
@@ -220,7 +299,7 @@ Deno.test("write_file tool supports append mode and passes content over stdin", 
         "    ;;",
         "  *)",
         '    echo "unsupported write mode: $mode" >&2',
-        "    exit 2",
+        "    exit 12",
         "    ;;",
         "esac",
       ].join("\n"),
@@ -255,8 +334,16 @@ Deno.test("write_file uses the cwd established by an earlier bash call", async (
         'path="$1"',
         'mode="$2"',
         'create_parents="$3"',
+        'parent="$(dirname "$path")"',
         'if [ "$create_parents" = "true" ]; then',
-        '  mkdir -p "$(dirname "$path")"',
+        '  mkdir -p "$parent"',
+        'elif [ ! -d "$parent" ]; then',
+        '  echo "file not found: parent directory $parent" >&2',
+        "  exit 10",
+        "fi",
+        'if [ -e "$path" ] && [ ! -f "$path" ]; then',
+        '  echo "not a file: $path" >&2',
+        "  exit 11",
         "fi",
         'case "$mode" in',
         "  replace)",
@@ -267,7 +354,7 @@ Deno.test("write_file uses the cwd established by an earlier bash call", async (
         "    ;;",
         "  *)",
         '    echo "unsupported write mode: $mode" >&2',
-        "    exit 2",
+        "    exit 12",
         "    ;;",
         "esac",
       ].join("\n"),
@@ -277,20 +364,52 @@ Deno.test("write_file uses the cwd established by an earlier bash call", async (
   });
 });
 
-Deno.test("write_file tool rejects nonzero shell exits", async () => {
+Deno.test("write_file tool returns a recoverable permission_denied result", async () => {
   const sandbox = new FakeSandboxRuntime([{
     stdout: "",
     stderr: "permission denied",
     exitCode: 13,
   }]);
 
-  await assertRejects(
-    () =>
-      writeFileTool.invoke(createContext(sandbox), {
-        path: "notes/log.txt",
-        content: "line one\n",
-      }),
-    Error,
-    "write_file failed for /workspace/notes/log.txt: permission denied",
-  );
+  const output = await writeFileTool.invoke(createContext(sandbox), {
+    path: "notes/log.txt",
+    content: "line one\n",
+  });
+
+  assertEquals(output, {
+    outputId: "run-1:write_file:1",
+    path: "/workspace/notes/log.txt",
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "permission_denied",
+      message: "permission denied: /workspace/notes/log.txt",
+      path: "/workspace/notes/log.txt",
+      detail: "permission denied",
+      exitCode: 13,
+    },
+  });
+});
+
+Deno.test("write_file tool returns a recoverable path_outside_workspace result", async () => {
+  const sandbox = new StrictFakeSandboxRuntime();
+
+  const output = await writeFileTool.invoke(createContext(sandbox), {
+    path: "../outside.txt",
+    content: "line one\n",
+  });
+
+  assertEquals(output, {
+    outputId: "run-1:write_file:1",
+    path: "../outside.txt",
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "path_outside_workspace",
+      message: "path outside workspace: ../outside.txt",
+      path: "../outside.txt",
+      detail: "path escapes workspace root: /outside.txt",
+    },
+  });
+  assertEquals(sandbox.calls, []);
 });


### PR DESCRIPTION
## Summary
- return typed recoverable error outputs from `read_file` and `write_file` for operational file-system failures
- classify those structured file-tool errors into deterministic failure records without aborting the prompt loop
- cover direct tool behavior, engine diagnostics, and prompt-loop continuation after a recoverable file-tool error

## Stack
- Stacked on #3385 (`codex/cf-harness-terminalize-interrupted-runs`)
- After #3385 lands, this PR can be retargeted/rebased onto `main`

## Validation
- `deno fmt --check packages/cf-harness/src/tools/file-errors.ts packages/cf-harness/src/tools/read-file.ts packages/cf-harness/src/tools/write-file.ts packages/cf-harness/src/diagnostics.ts packages/cf-harness/src/index.ts packages/cf-harness/test/tools-execution.test.ts packages/cf-harness/test/engine.test.ts packages/cf-harness/test/prompt-loop.test.ts`
- `deno lint packages/cf-harness/src/tools/file-errors.ts packages/cf-harness/src/tools/read-file.ts packages/cf-harness/src/tools/write-file.ts packages/cf-harness/src/diagnostics.ts packages/cf-harness/src/index.ts packages/cf-harness/test/tools-execution.test.ts packages/cf-harness/test/engine.test.ts packages/cf-harness/test/prompt-loop.test.ts`
- `deno test --allow-read --allow-write --allow-run packages/cf-harness/test/tools-execution.test.ts packages/cf-harness/test/engine.test.ts packages/cf-harness/test/prompt-loop.test.ts packages/cf-harness/test/diagnostics.test.ts`
- `deno task test` from `packages/cf-harness` (`96 passed | 0 failed`)
- `git diff --check`
