### PR TITLE
fix(patterns): single timestamp for weekly rollup cutoff

### DIFF
--- a/packages/patterns/notes/daily-journal.tsx
+++ b/packages/patterns/notes/daily-journal.tsx
@@ -244,8 +244,9 @@ export default pattern<DailyJournalInput, DailyJournalOutput>(
 
     // Gather last 7 days of note content for the system prompt
     const recentNotesContext = computed(() => {
-      const today = new Date(safeDateNow());
-      const sevenDaysAgo = new Date(safeDateNow());
+      const now = safeDateNow();
+      const today = new Date(now);
+      const sevenDaysAgo = new Date(now);
       sevenDaysAgo.setDate(today.getDate() - 7);
       const cutoff = toLocalISODate(sevenDaysAgo);
 


### PR DESCRIPTION
## Summary

- Fix midnight/month-boundary bug in `recentNotesContext` where two separate `safeDateNow()` calls could straddle a month rollover, producing the wrong 7-day cutoff date and dropping notes from the weekly rollup
- Capture one timestamp and derive both `today` and `sevenDaysAgo` from it

## Test plan

- [ ] Verify daily-journal weekly rollup still includes notes from the past 7 days
- [ ] Confirm no other callers of `recentNotesContext` are affected

Addresses a late review comment on #3306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)