### PR TITLE
Retry cf-harness chat transport failures

### DIFF
--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -398,6 +398,27 @@ export const classifyHarnessRunError = (
   }
   const message = error instanceof Error ? error.message : String(error);
   const normalized = message.toLowerCase();
+  if (
+    normalized.includes("chat completion transport request failed") &&
+    (normalized.includes("timed out") ||
+      normalized.includes("timeout"))
+  ) {
+    return createHarnessFailureRecord({
+      kind: "timeout",
+      source: options.source ?? "run_error",
+      detail: message,
+      at: options.at,
+      ...(options.toolId !== undefined ? { toolId: options.toolId } : {}),
+      ...(options.toolCallId !== undefined
+        ? { toolCallId: options.toolCallId }
+        : {}),
+      ...(options.outputId !== undefined ? { outputId: options.outputId } : {}),
+      ...(options.command !== undefined ? { command: options.command } : {}),
+      ...(options.commandName !== undefined
+        ? { commandName: options.commandName }
+        : {}),
+    });
+  }
   if (normalized.includes("path escapes workspace root")) {
     return createHarnessFailureRecord({
       kind: "workspace_path_confusion",

--- a/packages/cf-harness/src/gateway/openai-client.ts
+++ b/packages/cf-harness/src/gateway/openai-client.ts
@@ -3,6 +3,8 @@ export interface OpenAICompatibleGatewayClientOptions {
   authMode?: "bearer" | "none";
   apiKey?: string;
   apiKeySource?: string;
+  chatCompletionTransportRetries?: number;
+  chatCompletionRetryDelayMs?: number;
   fetchFn?: typeof fetch;
 }
 
@@ -65,12 +67,44 @@ export interface OpenAIChatCompletionResponse {
   choices: readonly OpenAIChatCompletionChoice[];
 }
 
+const DEFAULT_CHAT_COMPLETION_TRANSPORT_RETRIES = 1;
+const DEFAULT_CHAT_COMPLETION_RETRY_DELAY_MS = 1_000;
+
+const nonNegativeIntegerOrDefault = (
+  input: number | undefined,
+  fallback: number,
+): number =>
+  input !== undefined && Number.isInteger(input) && input >= 0
+    ? input
+    : fallback;
+
+const sleep = (ms: number): Promise<void> =>
+  ms <= 0
+    ? Promise.resolve()
+    : new Promise((resolve) => setTimeout(resolve, ms));
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const transportErrorAfterRetries = (
+  endpoint: URL,
+  attempts: number,
+  error: unknown,
+): Error =>
+  new Error(
+    `chat completion transport request failed after ${attempts} ${
+      attempts === 1 ? "attempt" : "attempts"
+    } for ${endpoint.toString()}: ${errorMessage(error)}`,
+  );
+
 export class OpenAICompatibleGatewayClient {
   readonly baseUrl: URL;
   readonly authMode: "bearer" | "none";
   readonly apiKey?: string;
   readonly apiKeySource?: string;
   readonly #fetchFn: typeof fetch;
+  readonly #chatCompletionTransportRetries: number;
+  readonly #chatCompletionRetryDelayMs: number;
 
   constructor(options: OpenAICompatibleGatewayClientOptions) {
     this.baseUrl = new URL(options.baseUrl);
@@ -78,6 +112,14 @@ export class OpenAICompatibleGatewayClient {
     this.apiKey = options.apiKey;
     this.apiKeySource = options.apiKeySource;
     this.#fetchFn = options.fetchFn ?? fetch;
+    this.#chatCompletionTransportRetries = nonNegativeIntegerOrDefault(
+      options.chatCompletionTransportRetries,
+      DEFAULT_CHAT_COMPLETION_TRANSPORT_RETRIES,
+    );
+    this.#chatCompletionRetryDelayMs = nonNegativeIntegerOrDefault(
+      options.chatCompletionRetryDelayMs,
+      DEFAULT_CHAT_COMPLETION_RETRY_DELAY_MS,
+    );
   }
 
   #requireApiKey(): string {
@@ -122,11 +164,26 @@ export class OpenAICompatibleGatewayClient {
   async createChatCompletion(
     payload: OpenAIChatCompletionRequest,
   ): Promise<Response> {
-    return await this.#fetchFn(this.endpoint("/v1/chat/completions"), {
+    const endpoint = this.endpoint("/v1/chat/completions");
+    const init: RequestInit = {
       method: "POST",
       headers: this.headers(),
       body: JSON.stringify(payload),
-    });
+    };
+    const maxAttempts = this.#chatCompletionTransportRetries + 1;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        return await this.#fetchFn(endpoint, init);
+      } catch (error) {
+        lastError = error;
+        if (attempt >= maxAttempts) {
+          throw transportErrorAfterRetries(endpoint, attempt, error);
+        }
+        await sleep(this.#chatCompletionRetryDelayMs * attempt);
+      }
+    }
+    throw transportErrorAfterRetries(endpoint, maxAttempts, lastError);
   }
 
   async createChatCompletionJson(

--- a/packages/cf-harness/test/diagnostics.test.ts
+++ b/packages/cf-harness/test/diagnostics.test.ts
@@ -211,6 +211,17 @@ Deno.test("classifyHarnessRunError maps timeouts and path escapes deterministica
     ).kind,
     "workspace_path_confusion",
   );
+  assertEquals(
+    classifyHarnessRunError(
+      new Error(
+        "chat completion transport request failed after 2 attempts for https://llm.stage.commontools.dev/v1/chat/completions: error sending request from 100.87.21.105:52328 for https://llm.stage.commontools.dev/v1/chat/completions (10.128.15.193:443): client error (SendRequest): connection error: timed out",
+      ),
+      {
+        at: "2026-04-22T23:30:02.000Z",
+      },
+    ).kind,
+    "timeout",
+  );
 });
 
 Deno.test("selectPrimaryHarnessFailure prefers the highest-signal failure kind", () => {

--- a/packages/cf-harness/test/openai-client.test.ts
+++ b/packages/cf-harness/test/openai-client.test.ts
@@ -94,6 +94,64 @@ Deno.test("OpenAICompatibleGatewayClient parses successful chat completion JSON 
   assertEquals(response.choices[0]?.message.content, "ok");
 });
 
+Deno.test("OpenAICompatibleGatewayClient retries chat completion transport failures once by default", async () => {
+  let calls = 0;
+  const client = new OpenAICompatibleGatewayClient({
+    baseUrl: "https://llm.stage.commontools.dev/",
+    apiKey: "test-key",
+    chatCompletionRetryDelayMs: 0,
+    fetchFn: () => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.reject(new Error("connection error: timed out"));
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            choices: [{
+              index: 0,
+              message: { role: "assistant", content: "ok" },
+            }],
+          }),
+          { status: 200 },
+        ),
+      );
+    },
+  });
+
+  const response = await client.createChatCompletionJson({
+    model: "gpt-5.4",
+    messages: [],
+  });
+
+  assertEquals(calls, 2);
+  assertEquals(response.choices[0]?.message.content, "ok");
+});
+
+Deno.test("OpenAICompatibleGatewayClient surfaces exhausted chat completion transport retries", async () => {
+  let calls = 0;
+  const client = new OpenAICompatibleGatewayClient({
+    baseUrl: "https://llm.stage.commontools.dev/",
+    apiKey: "test-key",
+    chatCompletionRetryDelayMs: 0,
+    fetchFn: () => {
+      calls += 1;
+      return Promise.reject(new Error("connection error: timed out"));
+    },
+  });
+
+  await assertRejects(
+    () =>
+      client.createChatCompletionJson({
+        model: "gpt-5.4",
+        messages: [],
+      }),
+    Error,
+    "chat completion transport request failed after 2 attempts",
+  );
+  assertEquals(calls, 2);
+});
+
 Deno.test("OpenAICompatibleGatewayClient surfaces chat completion errors with response text", async () => {
   const client = new OpenAICompatibleGatewayClient({
     baseUrl: "https://llm.stage.commontools.dev/",


### PR DESCRIPTION
## Summary
- retry cf-harness chat completion transport failures once before failing the run
- keep HTTP response errors non-retried so auth/schema/upstream errors still surface immediately
- classify wrapped gateway timeout transport failures as timeout instead of unknown

## Tests
- deno fmt packages/cf-harness/src/gateway/openai-client.ts packages/cf-harness/src/diagnostics.ts packages/cf-harness/test/openai-client.test.ts packages/cf-harness/test/diagnostics.test.ts
- deno task test