### PR TITLE
Add cf-harness CFC manifest intake

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -35,7 +35,8 @@ What works today:
   - `write_file`
 - whole-file replace/create plus append writes
 - bounded OpenAI-compatible prompt/tool loop
-- persisted run state, transcript, and tool outputs
+- persisted run state, transcript, Loom run manifests, capability snapshots, and
+  tool outputs
 - transcript-based resumability
 - package-local operator CLI
 - CFC mode plumbing with:
@@ -43,6 +44,10 @@ What works today:
   - `observe`
   - `enforce-explicit`
   - `enforce-strict`
+- default CFC mode aligned with the runner's permissive-if-absent
+  `enforce-explicit` rollout behavior
+- spec-aligned `PromptSlotBound` prompt-slot evidence
+- Loom run manifest intake through `--run-manifest`
 - first-pass policy events and deny/recovery behavior
 - configurable gateway auth mode:
   - `bearer`
@@ -68,9 +73,11 @@ What is not done yet:
 - [src/cli.ts](src/cli.ts)
   - package-local operator CLI
 - [src/artifacts.ts](src/artifacts.ts)
-  - persisted run state, transcript, and tool output storage
+  - persisted run state, run manifest, transcript, capability snapshot, and tool
+    output storage
 - [src/contracts/](src/contracts/)
-  - prompt-slot, observation, policy, transcript, and tool-result contracts
+  - prompt-slot, run-manifest, observation, policy, transcript, and tool-result
+    contracts
 - [integration/](integration/)
   - environment-gated real `runsc-cfc` integration tests
 
@@ -104,6 +111,16 @@ deno task run -- \
   --gateway-auth-mode none \
   --prompt "Summarize the cf-harness package structure." \
   --print-transcript
+```
+
+Loom-backed batch runs may also pass a retained manifest:
+
+```bash
+deno task run -- \
+  --workspace /path/to/workspace \
+  --gateway-auth-mode none \
+  --run-manifest /path/to/loom-run-manifest.json \
+  --prompt "Handle this Loom wish."
 ```
 
 Current caveat:

--- a/packages/cf-harness/deno.json
+++ b/packages/cf-harness/deno.json
@@ -15,6 +15,7 @@
     "./cli": "./src/cli.ts",
     "./gateway/openai-client": "./src/gateway/openai-client.ts",
     "./contracts/prompt-slot": "./src/contracts/prompt-slot.ts",
+    "./contracts/run-manifest": "./src/contracts/run-manifest.ts",
     "./contracts/observation": "./src/contracts/observation.ts",
     "./contracts/policy": "./src/contracts/policy.ts",
     "./contracts/run-report": "./src/contracts/run-report.ts",

--- a/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
@@ -84,6 +84,7 @@ The package already includes:
 - package exports and tasks in [deno.json](../deno.json)
 - initial contract surfaces:
   - [prompt-slot.ts](../src/contracts/prompt-slot.ts)
+  - [run-manifest.ts](../src/contracts/run-manifest.ts)
   - [observation.ts](../src/contracts/observation.ts)
   - [policy.ts](../src/contracts/policy.ts)
   - [transcript.ts](../src/contracts/transcript.ts)
@@ -119,6 +120,7 @@ Why:
 
 - artifact store in [artifacts.ts](../src/artifacts.ts)
 - run-state tracking in [run-state.ts](../src/run-state.ts)
+- retained Loom run manifest artifacts
 - transcript-based resume support in the prompt loop and CLI
 
 Why:
@@ -143,7 +145,12 @@ Why:
   - `observe`
   - `enforce-explicit`
   - `enforce-strict`
+- default CFC mode aligned with runner-style `enforce-explicit`
 - deny/recovery via JSON `ObservationDenied` tool messages
+- spec-aligned `PromptSlotBound` prompt-slot evidence
+- capability snapshots that record current CFC mode, manifest presence,
+  substrate absence behavior, sandbox CFC request hints, and expected protected
+  xattr visibility
 - CLI summaries of accumulated policy events
 
 Why:

--- a/packages/cf-harness/src/artifacts.ts
+++ b/packages/cf-harness/src/artifacts.ts
@@ -9,6 +9,7 @@ import {
 } from "@std/path";
 import type { HarnessRunState } from "./run-state.ts";
 import { createHarnessPolicyEvent } from "./contracts/policy.ts";
+import type { HarnessRunManifest } from "./contracts/run-manifest.ts";
 import type { HarnessRunReport } from "./contracts/run-report.ts";
 import type { HarnessTranscriptMessage } from "./contracts/transcript.ts";
 import type { ToolOutputId } from "./contracts/tool-result.ts";
@@ -67,6 +68,7 @@ export interface HarnessArtifactStore {
   persistRunReport(
     report: HarnessRunReport,
   ): Promise<string>;
+  persistRunManifest?(manifest: HarnessRunManifest): Promise<string>;
   persistToolOutput(
     toolId: string,
     outputId: ToolOutputId,
@@ -119,6 +121,13 @@ export class FileSystemHarnessArtifactStore implements HarnessArtifactStore {
     await ensureDir(this.runRoot);
     const path = join(this.runRoot, "run-report.json");
     await writeJsonFile(path, report);
+    return path;
+  }
+
+  async persistRunManifest(manifest: HarnessRunManifest): Promise<string> {
+    await ensureDir(this.runRoot);
+    const path = join(this.runRoot, "run-manifest.json");
+    await writeJsonFile(path, manifest);
     return path;
   }
 

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -15,6 +15,10 @@ import {
   createCliPromptSlotBinding,
   type PromptSlotRole,
 } from "./contracts/prompt-slot.ts";
+import {
+  type HarnessRunManifest,
+  parseLoomRunManifestJson,
+} from "./contracts/run-manifest.ts";
 import type { BuiltinToolId } from "./contracts/tool-descriptor.ts";
 import type {
   HarnessTranscriptEvent,
@@ -50,6 +54,7 @@ export interface CfHarnessCliConfig {
   gatewayAuthMode: HarnessGatewayAuthMode;
   artifactRoot: string;
   resultJsonPath?: string;
+  runManifestPath?: string;
   cfcEnforcementModeOverride?: CfcEnforcementMode;
   maxModelTurns: number;
   printTranscript: boolean;
@@ -169,6 +174,7 @@ Options:
   --gateway-auth-mode <mode>    bearer | none (default: bearer)
   --artifact-root <path>        Host-side artifact directory
   --result-json-path <path>     Optional structured result sidecar path
+  --run-manifest <path>         Optional Loom run manifest JSON path
   --cfc-enforcement-mode <mode> disabled | observe | enforce-explicit | enforce-strict
   --max-model-turns <n>         Maximum model turns before aborting
   --print-transcript            Print the final transcript JSON after the response
@@ -238,6 +244,11 @@ const parseBuiltinToolIds = (
   return [...new Set(parsed)] as readonly BuiltinToolId[];
 };
 
+const nonEmptyEnvValue = (input: string | undefined): string | undefined => {
+  const trimmed = input?.trim();
+  return trimmed === undefined || trimmed === "" ? undefined : trimmed;
+};
+
 const resolvePrompt = async (
   args: ReturnType<typeof parseArgs>,
   cwd: string,
@@ -305,6 +316,7 @@ export const parseCfHarnessCliArgs = async (
       "gateway-auth-mode",
       "artifact-root",
       "result-json-path",
+      "run-manifest",
       "cfc-enforcement-mode",
       "max-model-turns",
     ],
@@ -373,6 +385,9 @@ export const parseCfHarnessCliArgs = async (
   const resultJsonPath = typeof args["result-json-path"] === "string"
     ? resolve(cwd, args["result-json-path"])
     : undefined;
+  const runManifestPath = typeof args["run-manifest"] === "string"
+    ? resolve(cwd, args["run-manifest"])
+    : undefined;
   const gatewayBaseUrl = typeof args["gateway-base-url"] === "string"
     ? args["gateway-base-url"]
     : DEFAULT_GATEWAY_BASE_URL;
@@ -388,26 +403,33 @@ export const parseCfHarnessCliArgs = async (
     throw new Error("gateway auth mode must be one of bearer, none");
   }
   const gatewayAuthMode = parsedGatewayAuthMode ?? "bearer";
-  const cfcEnforcementModeOverride = parseCfcEnforcementMode(
-    typeof args["cfc-enforcement-mode"] === "string"
-      ? args["cfc-enforcement-mode"]
-      : undefined,
-  );
-  if (
-    args["cfc-enforcement-mode"] !== undefined &&
-    cfcEnforcementModeOverride === undefined
-  ) {
-    throw new Error(
-      "cfc enforcement mode must be one of disabled, observe, enforce-explicit, enforce-strict",
-    );
-  }
   const readTextFile = deps.readTextFile ?? Deno.readTextFile;
   const prompt = await resolvePrompt(args, cwd, readTextFile);
   const env = deps.env ??
     {
       CF_HARNESS_API_KEY: Deno.env.get("CF_HARNESS_API_KEY"),
       OPENAI_API_KEY: Deno.env.get("OPENAI_API_KEY"),
+      CF_HARNESS_CFC_ENFORCEMENT_MODE: Deno.env.get(
+        "CF_HARNESS_CFC_ENFORCEMENT_MODE",
+      ),
+      CF_CFC_MODE: Deno.env.get("CF_CFC_MODE"),
     };
+  const explicitCfcMode = typeof args["cfc-enforcement-mode"] === "string"
+    ? args["cfc-enforcement-mode"]
+    : undefined;
+  const envCfcMode = nonEmptyEnvValue(env.CF_HARNESS_CFC_ENFORCEMENT_MODE) ??
+    nonEmptyEnvValue(env.CF_CFC_MODE);
+  const cfcEnforcementModeOverride = parseCfcEnforcementMode(
+    explicitCfcMode ?? envCfcMode,
+  );
+  if (
+    (explicitCfcMode !== undefined || envCfcMode !== undefined) &&
+    cfcEnforcementModeOverride === undefined
+  ) {
+    throw new Error(
+      "cfc enforcement mode must be one of disabled, observe, enforce-explicit, enforce-strict",
+    );
+  }
   const apiKey = env.CF_HARNESS_API_KEY ?? env.OPENAI_API_KEY;
   const apiKeySource = env.CF_HARNESS_API_KEY !== undefined
     ? "CF_HARNESS_API_KEY"
@@ -436,6 +458,7 @@ export const parseCfHarnessCliArgs = async (
     gatewayAuthMode,
     artifactRoot,
     ...(resultJsonPath !== undefined ? { resultJsonPath } : {}),
+    ...(runManifestPath !== undefined ? { runManifestPath } : {}),
     ...(cfcEnforcementModeOverride !== undefined
       ? { cfcEnforcementModeOverride }
       : {}),
@@ -450,6 +473,14 @@ export const parseCfHarnessCliArgs = async (
     ...(apiKeySource !== undefined ? { apiKeySource } : {}),
   };
 };
+
+const readRunManifest = async (
+  path: string | undefined,
+  readTextFile: (path: string) => Promise<string>,
+): Promise<HarnessRunManifest | undefined> =>
+  path === undefined
+    ? undefined
+    : parseLoomRunManifestJson(await readTextFile(path));
 
 export const formatCfHarnessCliUsage = (): string => usage;
 
@@ -689,6 +720,7 @@ export const runCfHarnessCli = async (
       ((options: CreateHarnessPromptLoopOptions) =>
         new CfHarnessPromptLoop(options));
     const writeTextFile = deps.writeTextFile ?? Deno.writeTextFile;
+    const readTextFile = deps.readTextFile ?? Deno.readTextFile;
     if (parsed.gatewayAuthMode === "bearer" && parsed.apiKey === undefined) {
       throw new Error(
         "no API key configured; set CF_HARNESS_API_KEY or OPENAI_API_KEY",
@@ -696,11 +728,24 @@ export const runCfHarnessCli = async (
     }
     const startedAt = Date.now();
     let result: HarnessPromptLoopResult;
-    const promptSlotBinding = createCliPromptSlotBinding({
-      kernelName: "cf-harness",
-      role: parsed.promptSlotRole,
-      subject: parsed.resumeRun ?? parsed.workspace,
-    });
+    const runManifest = await readRunManifest(
+      parsed.runManifestPath,
+      readTextFile,
+    );
+    const promptSlotBinding = runManifest?.promptSlot ??
+      createCliPromptSlotBinding({
+        kernelName: "cf-harness",
+        ...(parsed.runManifestPath !== undefined
+          ? {
+            source: {
+              type: "cf-harness.loom-run-manifest-ref",
+              path: parsed.runManifestPath,
+            },
+          }
+          : {}),
+        role: parsed.promptSlotRole,
+        subject: parsed.resumeRun ?? parsed.workspace,
+      });
     const onTranscriptEvent = parsed.streamEvents
       ? (event: HarnessTranscriptEvent) => {
         const formatted = formatCfHarnessTranscriptEvent(event);
@@ -721,6 +766,10 @@ export const runCfHarnessCli = async (
         gatewayAuthMode: parsed.gatewayAuthMode,
         ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
         cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
+        ...(runManifest !== undefined ? { runManifest } : {}),
+        ...(parsed.runManifestPath !== undefined
+          ? { runManifestPath: parsed.runManifestPath }
+          : {}),
       });
       activateEngine(engine);
       const loop = createPromptLoop({
@@ -732,6 +781,10 @@ export const runCfHarnessCli = async (
         gatewayAuthMode: parsed.gatewayAuthMode,
         ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
         cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
+        ...(runManifest !== undefined ? { runManifest } : {}),
+        ...(parsed.runManifestPath !== undefined
+          ? { runManifestPath: parsed.runManifestPath }
+          : {}),
         apiKey: parsed.apiKey,
         apiKeySource: parsed.apiKeySource,
         maxModelTurns: parsed.maxModelTurns,
@@ -761,6 +814,10 @@ export const runCfHarnessCli = async (
         gatewayAuthMode: parsed.gatewayAuthMode,
         ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
         cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
+        ...(runManifest !== undefined ? { runManifest } : {}),
+        ...(parsed.runManifestPath !== undefined
+          ? { runManifestPath: parsed.runManifestPath }
+          : {}),
       });
       activateEngine(engine);
       const loop = createPromptLoop({
@@ -774,6 +831,10 @@ export const runCfHarnessCli = async (
         apiKey: parsed.apiKey,
         apiKeySource: parsed.apiKeySource,
         cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,
+        ...(runManifest !== undefined ? { runManifest } : {}),
+        ...(parsed.runManifestPath !== undefined
+          ? { runManifestPath: parsed.runManifestPath }
+          : {}),
         maxModelTurns: parsed.maxModelTurns,
         ...(parsed.allowedToolIds !== undefined
           ? { allowedToolIds: parsed.allowedToolIds }

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -1,10 +1,14 @@
-import type {
-  CfcEnforcementMode,
-  TrustSnapshot,
+import {
+  type CfcEnforcementMode,
+  isCfcEnforcementMode,
+  type TrustSnapshot,
 } from "@commonfabric/runner/cfc";
+import type { HarnessRunManifest } from "./contracts/run-manifest.ts";
 import type { HarnessSandboxConfig } from "./sandbox/types.ts";
 
 export const DEFAULT_GATEWAY_BASE_URL = "https://llm.stage.commontools.dev/";
+export const DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE =
+  "enforce-explicit" as const satisfies CfcEnforcementMode;
 export type HarnessGatewayAuthMode = "bearer" | "none";
 
 export interface HarnessConfig {
@@ -18,6 +22,8 @@ export interface HarnessConfig {
   cfcEnforcementMode: CfcEnforcementMode;
   trustSnapshot?: TrustSnapshot;
   sandbox?: HarnessSandboxConfig;
+  runManifest?: HarnessRunManifest;
+  runManifestPath?: string;
 }
 
 export interface ResolveHarnessConfigOptions {
@@ -34,24 +40,14 @@ export interface ResolveHarnessConfigOptions {
   cfcEnforcementModeOverride?: string | CfcEnforcementMode;
   trustSnapshot?: TrustSnapshot;
   sandbox?: HarnessSandboxConfig;
+  runManifest?: HarnessRunManifest;
+  runManifestPath?: string;
 }
 
-const CFC_ENFORCEMENT_MODES: readonly CfcEnforcementMode[] = [
-  "disabled",
-  "observe",
-  "enforce-explicit",
-  "enforce-strict",
-];
 const GATEWAY_AUTH_MODES: readonly HarnessGatewayAuthMode[] = [
   "bearer",
   "none",
 ];
-
-export const isCfcEnforcementMode = (
-  input: unknown,
-): input is CfcEnforcementMode =>
-  typeof input === "string" &&
-  CFC_ENFORCEMENT_MODES.includes(input as CfcEnforcementMode);
 
 export const parseCfcEnforcementMode = (
   input: string | null | undefined,
@@ -75,15 +71,20 @@ export const resolveCfcEnforcementMode = (
     | "cfcEnforcementModeOverride"
     | "cfcEnforcementMode"
     | "inheritedCfcEnforcementMode"
+    | "runManifest"
   >,
 ): CfcEnforcementMode => {
   const parsedOverride = typeof options.cfcEnforcementModeOverride === "string"
     ? parseCfcEnforcementMode(options.cfcEnforcementModeOverride)
     : options.cfcEnforcementModeOverride;
+  const parsedRunManifestMode = parseCfcEnforcementMode(
+    options.runManifest?.cfc?.enforcementMode,
+  );
   return parsedOverride ??
     options.cfcEnforcementMode ??
     options.inheritedCfcEnforcementMode ??
-    "disabled";
+    parsedRunManifestMode ??
+    DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE;
 };
 
 export const normalizeGatewayBaseUrl = (input: string): string =>
@@ -123,5 +124,11 @@ export const resolveHarnessConfig = (
     ? { trustSnapshot: options.trustSnapshot }
     : {}),
   ...(options.sandbox !== undefined ? { sandbox: options.sandbox } : {}),
+  ...(options.runManifest !== undefined
+    ? { runManifest: options.runManifest }
+    : {}),
+  ...(options.runManifestPath !== undefined
+    ? { runManifestPath: options.runManifestPath }
+    : {}),
   cfcEnforcementMode: resolveCfcEnforcementMode(options),
 });

--- a/packages/cf-harness/src/contracts/prompt-slot.ts
+++ b/packages/cf-harness/src/contracts/prompt-slot.ts
@@ -1,42 +1,181 @@
+import { isRecord } from "@commonfabric/utils/types";
+
 export type PromptSlotRole = "direct-command" | "context" | "quote";
 
+export const CFC_PROMPT_SLOT_BOUND_ATOM_TYPE =
+  "https://commonfabric.org/cfc/atom/PromptSlotBound" as const;
+
+export type PromptSlotReference = string | Record<string, unknown>;
+
+export interface PromptSlotRenderRef {
+  seq: number;
+  rootRef: PromptSlotReference;
+}
+
 export interface PromptSlotBinding {
-  type: "cf-harness.prompt-slot-binding";
+  type: typeof CFC_PROMPT_SLOT_BOUND_ATOM_TYPE;
+  source: PromptSlotReference;
   role: PromptSlotRole;
   kernelName: string;
   surface: string;
   subject?: string;
+  renderRef?: PromptSlotRenderRef;
   eventId?: string;
   valueDigest?: string;
   slotDigest?: string;
   snapshotDigest?: string;
   targetPath?: string;
-  sourceRef?: string;
 }
 
 export interface CreateCliPromptSlotBindingOptions {
   kernelName: string;
+  source?: PromptSlotReference;
   role?: PromptSlotRole;
   surface?: string;
   subject?: string;
+  renderRef?: PromptSlotRenderRef;
   eventId?: string;
   valueDigest?: string;
   slotDigest?: string;
+  snapshotDigest?: string;
+  targetPath?: string;
 }
+
+const PROMPT_SLOT_ROLES: readonly PromptSlotRole[] = [
+  "direct-command",
+  "context",
+  "quote",
+];
+
+const isJsonObject = (input: unknown): input is Record<string, unknown> =>
+  isRecord(input) && !Array.isArray(input);
+
+const isPromptSlotRole = (input: unknown): input is PromptSlotRole =>
+  typeof input === "string" &&
+  PROMPT_SLOT_ROLES.includes(input as PromptSlotRole);
+
+const isNonEmptyString = (input: unknown): input is string =>
+  typeof input === "string" && input.trim() !== "";
+
+const isPromptSlotReference = (
+  input: unknown,
+): input is PromptSlotReference =>
+  isNonEmptyString(input) ||
+  (isJsonObject(input) && Object.keys(input).length > 0);
+
+const optionalString = (
+  input: Record<string, unknown>,
+  field: keyof PromptSlotBinding,
+): string | undefined => {
+  const value = input[field];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`prompt slot ${String(field)} must be a string`);
+  }
+  return value;
+};
+
+const normalizePromptSlotRenderRef = (
+  input: unknown,
+): PromptSlotRenderRef | undefined => {
+  if (input === undefined) {
+    return undefined;
+  }
+  if (!isJsonObject(input)) {
+    throw new Error("prompt slot renderRef must be an object");
+  }
+  if (typeof input.seq !== "number" || !Number.isSafeInteger(input.seq)) {
+    throw new Error("prompt slot renderRef.seq must be a safe integer");
+  }
+  if (!isPromptSlotReference(input.rootRef)) {
+    throw new Error("prompt slot renderRef.rootRef must be a reference");
+  }
+  return {
+    seq: input.seq,
+    rootRef: input.rootRef,
+  };
+};
+
+export const normalizePromptSlotBinding = (
+  input: unknown,
+): PromptSlotBinding => {
+  if (!isJsonObject(input)) {
+    throw new Error("prompt slot binding must be a JSON object");
+  }
+  if (input.type !== CFC_PROMPT_SLOT_BOUND_ATOM_TYPE) {
+    throw new Error(
+      `unsupported prompt slot binding type: ${String(input.type)}`,
+    );
+  }
+  if (!isPromptSlotReference(input.source)) {
+    throw new Error("prompt slot source must be a reference");
+  }
+  if (!isPromptSlotRole(input.role)) {
+    throw new Error(
+      "prompt slot role must be one of direct-command, context, quote",
+    );
+  }
+  if (!isNonEmptyString(input.kernelName)) {
+    throw new Error("prompt slot kernelName must be a non-empty string");
+  }
+  if (!isNonEmptyString(input.surface)) {
+    throw new Error("prompt slot surface must be a non-empty string");
+  }
+
+  const renderRef = normalizePromptSlotRenderRef(input.renderRef);
+  const subject = optionalString(input, "subject");
+  const eventId = optionalString(input, "eventId");
+  const valueDigest = optionalString(input, "valueDigest");
+  const slotDigest = optionalString(input, "slotDigest");
+  const snapshotDigest = optionalString(input, "snapshotDigest");
+  const targetPath = optionalString(input, "targetPath");
+  return {
+    type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+    source: input.source,
+    role: input.role,
+    kernelName: input.kernelName,
+    surface: input.surface,
+    ...(subject !== undefined ? { subject } : {}),
+    ...(renderRef !== undefined ? { renderRef } : {}),
+    ...(eventId !== undefined ? { eventId } : {}),
+    ...(valueDigest !== undefined ? { valueDigest } : {}),
+    ...(slotDigest !== undefined ? { slotDigest } : {}),
+    ...(snapshotDigest !== undefined ? { snapshotDigest } : {}),
+    ...(targetPath !== undefined ? { targetPath } : {}),
+  };
+};
+
+const defaultCliPromptSource = (
+  options: Pick<CreateCliPromptSlotBindingOptions, "subject" | "surface">,
+): PromptSlotReference => ({
+  type: "cf-harness.cli-input",
+  surface: options.surface ?? "cli",
+  ...(options.subject !== undefined ? { subject: options.subject } : {}),
+});
 
 export const createCliPromptSlotBinding = (
   options: CreateCliPromptSlotBindingOptions,
 ): PromptSlotBinding => ({
-  type: "cf-harness.prompt-slot-binding",
+  type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+  source: options.source ?? defaultCliPromptSource(options),
   role: options.role ?? "direct-command",
   kernelName: options.kernelName,
   surface: options.surface ?? "cli",
   ...(options.subject !== undefined ? { subject: options.subject } : {}),
+  ...(options.renderRef !== undefined ? { renderRef: options.renderRef } : {}),
   ...(options.eventId !== undefined ? { eventId: options.eventId } : {}),
   ...(options.valueDigest !== undefined
     ? { valueDigest: options.valueDigest }
     : {}),
   ...(options.slotDigest !== undefined
     ? { slotDigest: options.slotDigest }
+    : {}),
+  ...(options.snapshotDigest !== undefined
+    ? { snapshotDigest: options.snapshotDigest }
+    : {}),
+  ...(options.targetPath !== undefined
+    ? { targetPath: options.targetPath }
     : {}),
 });

--- a/packages/cf-harness/src/contracts/run-manifest.ts
+++ b/packages/cf-harness/src/contracts/run-manifest.ts
@@ -1,0 +1,129 @@
+import {
+  type CfcEnforcementMode,
+  isCfcEnforcementMode,
+} from "@commonfabric/runner/cfc";
+import { isRecord } from "@commonfabric/utils/types";
+import {
+  normalizePromptSlotBinding,
+  type PromptSlotBinding,
+} from "./prompt-slot.ts";
+
+export const LOOM_RUN_MANIFEST_TYPE = "cf-harness.loom-run-manifest" as const;
+
+export interface LoomRunManifestWorkspace {
+  hostPath?: string;
+  sandboxPath?: string;
+  cwd?: string;
+}
+
+export interface LoomRunManifestCfc {
+  enforcementMode?: CfcEnforcementMode;
+  labelSource?: "loom-run-manifest";
+}
+
+export interface LoomRunManifest {
+  type: typeof LOOM_RUN_MANIFEST_TYPE;
+  version: 1;
+  source: "loom";
+  instanceId?: string;
+  wishId?: string;
+  parentWishId?: string;
+  dispatchClass?: string;
+  capabilityProfile?: string;
+  model?: string;
+  workspace?: LoomRunManifestWorkspace;
+  promptSlot?: PromptSlotBinding;
+  cfc?: LoomRunManifestCfc;
+  extra?: Record<string, unknown>;
+}
+
+export type HarnessRunManifest = LoomRunManifest;
+
+const isJsonObject = (input: unknown): input is Record<string, unknown> =>
+  isRecord(input) && !Array.isArray(input);
+
+const isLoomRunManifestType = (input: unknown): boolean =>
+  input === undefined || input === LOOM_RUN_MANIFEST_TYPE;
+
+const normalizeLoomRunManifestCfc = (
+  input: unknown,
+): LoomRunManifestCfc | undefined => {
+  if (input === undefined) {
+    return undefined;
+  }
+  if (!isJsonObject(input)) {
+    throw new Error("run manifest cfc must be a JSON object");
+  }
+  if (
+    input.enforcementMode !== undefined &&
+    !isCfcEnforcementMode(input.enforcementMode)
+  ) {
+    throw new Error(
+      `unsupported run manifest cfc.enforcementMode: ${
+        String(input.enforcementMode)
+      }`,
+    );
+  }
+  if (
+    input.labelSource !== undefined &&
+    input.labelSource !== "loom-run-manifest"
+  ) {
+    throw new Error(
+      `unsupported run manifest cfc.labelSource: ${String(input.labelSource)}`,
+    );
+  }
+  return {
+    ...(input.enforcementMode !== undefined
+      ? { enforcementMode: input.enforcementMode }
+      : {}),
+    ...(input.labelSource !== undefined
+      ? { labelSource: input.labelSource }
+      : {}),
+  };
+};
+
+export const normalizeLoomRunManifest = (
+  input: unknown,
+): LoomRunManifest => {
+  if (!isJsonObject(input)) {
+    throw new Error("run manifest must be a JSON object");
+  }
+  if (!isLoomRunManifestType(input.type)) {
+    throw new Error(
+      `unsupported run manifest type: ${String(input.type)}`,
+    );
+  }
+  if (input.version !== undefined && input.version !== 1) {
+    throw new Error(
+      `unsupported run manifest version: ${String(input.version)}`,
+    );
+  }
+  const promptSlot = input.promptSlot === undefined
+    ? undefined
+    : normalizePromptSlotBinding(input.promptSlot);
+  const cfc = normalizeLoomRunManifestCfc(input.cfc);
+  return {
+    ...input,
+    type: LOOM_RUN_MANIFEST_TYPE,
+    version: 1,
+    source: "loom",
+    ...(promptSlot !== undefined ? { promptSlot } : {}),
+    ...(cfc !== undefined ? { cfc } : {}),
+  } as LoomRunManifest;
+};
+
+export const parseLoomRunManifestJson = (
+  text: string,
+): LoomRunManifest => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `failed to parse run manifest JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  return normalizeLoomRunManifest(parsed);
+};

--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -1,5 +1,10 @@
+import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import type { HarnessRunManifest } from "./contracts/run-manifest.ts";
 import { ProcessTimeoutError } from "./sandbox/process-runner.ts";
-import type { SandboxRuntime } from "./sandbox/types.ts";
+import type {
+  SandboxRuntime,
+  SandboxRuntimeDescription,
+} from "./sandbox/types.ts";
 import type { HarnessPolicyEvent } from "./contracts/policy.ts";
 import type { ToolOutputId } from "./contracts/tool-result.ts";
 import type { BashToolInput, BashToolOutput } from "./tools/bash.ts";
@@ -31,6 +36,35 @@ export interface HarnessCapabilitySnapshot {
   type: "cf-harness.capability-snapshot";
   at: string;
   commands: Record<HarnessCapabilityCommand, HarnessCapabilityProbe>;
+  cfc: HarnessCfcCapabilitySnapshot;
+}
+
+export type HarnessCfcAbsenceBehavior =
+  | "not-required"
+  | "observe-only"
+  | "permissive-if-absent"
+  | "fail-closed-if-absent";
+
+export type HarnessCfcSubstrateStatus =
+  | "not-required"
+  | "manifest-present"
+  | "not-attested"
+  | "missing";
+
+export interface HarnessCfcCapabilitySnapshot {
+  enforcementMode: CfcEnforcementMode;
+  absenceBehavior: HarnessCfcAbsenceBehavior;
+  substrateStatus: HarnessCfcSubstrateStatus;
+  runManifest: {
+    present: boolean;
+    type?: string;
+    path?: string;
+  };
+  sandbox: SandboxRuntimeDescription;
+  protectedXattrs: {
+    expectedSandboxVisible: false;
+    sandboxVisibility: "not-probed";
+  };
 }
 
 export type HarnessFailureKind =
@@ -100,19 +134,22 @@ const isHarnessCapabilityCommand = (
 
 const createEmptyCapabilitySnapshot = (
   at: string,
+  cfc: HarnessCfcCapabilitySnapshot,
 ): HarnessCapabilitySnapshot => ({
   type: "cf-harness.capability-snapshot",
   at,
   commands: Object.fromEntries(
     HARNESS_CAPABILITY_COMMANDS.map((command) => [command, { present: false }]),
   ) as Record<HarnessCapabilityCommand, HarnessCapabilityProbe>,
+  cfc,
 });
 
 const parseCapabilityProbeOutput = (
   stdout: string,
   at: string,
+  cfc: HarnessCfcCapabilitySnapshot,
 ): HarnessCapabilitySnapshot => {
-  const snapshot = createEmptyCapabilitySnapshot(at);
+  const snapshot = createEmptyCapabilitySnapshot(at, cfc);
   for (const line of stdout.split("\n")) {
     if (line.trim() === "") {
       continue;
@@ -132,11 +169,90 @@ const parseCapabilityProbeOutput = (
   return snapshot;
 };
 
+const cfcAbsenceBehaviorForMode = (
+  mode: CfcEnforcementMode,
+): HarnessCfcAbsenceBehavior => {
+  switch (mode) {
+    case "disabled":
+      return "not-required";
+    case "observe":
+      return "observe-only";
+    case "enforce-explicit":
+      return "permissive-if-absent";
+    case "enforce-strict":
+      return "fail-closed-if-absent";
+  }
+};
+
+const cfcSubstrateStatusFor = (options: {
+  mode: CfcEnforcementMode;
+  runManifest?: HarnessRunManifest;
+}): HarnessCfcSubstrateStatus => {
+  if (options.mode === "disabled") {
+    return "not-required";
+  }
+  if (options.runManifest !== undefined) {
+    return "manifest-present";
+  }
+  return options.mode === "enforce-strict" ? "missing" : "not-attested";
+};
+
+const describeSandbox = (
+  sandbox: SandboxRuntime,
+  cwd: string,
+): SandboxRuntimeDescription =>
+  sandbox.describe?.() ?? {
+    kind: sandbox.kind,
+    defaultWorkingDirectory: sandbox.defaultWorkingDirectory(),
+    cfc: {
+      runtimeRequested: sandbox.kind === "docker-runsc-cfc",
+      workspaceMountPath: cwd,
+    },
+  };
+
+const createCfcCapabilitySnapshot = (
+  sandbox: SandboxRuntime,
+  cwd: string,
+  options: CollectHarnessCapabilitySnapshotOptions,
+): HarnessCfcCapabilitySnapshot => {
+  const mode = options.cfcEnforcementMode ?? "enforce-explicit";
+  return {
+    enforcementMode: mode,
+    absenceBehavior: cfcAbsenceBehaviorForMode(mode),
+    substrateStatus: cfcSubstrateStatusFor({
+      mode,
+      runManifest: options.runManifest,
+    }),
+    runManifest: {
+      present: options.runManifest !== undefined,
+      ...(options.runManifest !== undefined
+        ? { type: options.runManifest.type }
+        : {}),
+      ...(options.runManifestPath !== undefined
+        ? { path: options.runManifestPath }
+        : {}),
+    },
+    sandbox: describeSandbox(sandbox, cwd),
+    protectedXattrs: {
+      expectedSandboxVisible: false,
+      sandboxVisibility: "not-probed",
+    },
+  };
+};
+
+export interface CollectHarnessCapabilitySnapshotOptions {
+  cfcEnforcementMode?: CfcEnforcementMode;
+  runManifest?: HarnessRunManifest;
+  runManifestPath?: string;
+}
+
 export const collectHarnessCapabilitySnapshot = async (
   sandbox: SandboxRuntime,
   cwd: string,
   at = new Date().toISOString(),
+  options: CollectHarnessCapabilitySnapshotOptions = {},
 ): Promise<HarnessCapabilitySnapshot> => {
+  const cfc = createCfcCapabilitySnapshot(sandbox, cwd, options);
   const result = await sandbox.runShell({
     command: CAPABILITY_PROBE_SCRIPT,
     cwd,
@@ -148,7 +264,7 @@ export const collectHarnessCapabilitySnapshot = async (
       }`,
     );
   }
-  return parseCapabilityProbeOutput(result.stdout, at);
+  return parseCapabilityProbeOutput(result.stdout, at, cfc);
 };
 
 export const createHarnessFailureRecord = (

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -17,6 +17,7 @@ import {
   setHarnessCapabilitySnapshot,
   setHarnessPromptSlotBinding,
   setHarnessRunCurrentDir,
+  setHarnessRunManifestPath,
   setHarnessRunReportPath,
   setHarnessRunStatus,
   setHarnessTranscriptPath,
@@ -186,6 +187,8 @@ export class CfHarnessEngine {
         currentDir,
         model: this.config.model,
         artifactRoot: this.artifactStore?.runRoot,
+        runManifest: this.config.runManifest,
+        runManifestPath: this.config.runManifestPath,
         now: this.#now(),
       });
     this.#outputSequence = this.#runState.toolOutputs.length;
@@ -262,6 +265,24 @@ export class CfHarnessEngine {
     return await this.artifactStore?.persistRunState(this.#runState);
   }
 
+  async ensureRunManifestPersisted(): Promise<string | undefined> {
+    if (this.#runState.runManifest === undefined) {
+      return this.#runState.runManifestPath;
+    }
+    const manifestPath = await this.artifactStore?.persistRunManifest?.(
+      this.#runState.runManifest,
+    );
+    if (manifestPath !== undefined) {
+      this.#runState = setHarnessRunManifestPath(
+        this.#runState,
+        manifestPath,
+        this.#now(),
+      );
+      await this.persistRunState();
+    }
+    return manifestPath ?? this.#runState.runManifestPath;
+  }
+
   async terminalizeInterruptedRun(
     signalName: string,
   ): Promise<HarnessRunState> {
@@ -330,12 +351,18 @@ export class CfHarnessEngine {
     if (this.#runState.capabilitySnapshot !== undefined) {
       return this.getRunState();
     }
+    await this.ensureRunManifestPersisted();
     const now = this.#now();
     try {
       const capabilitySnapshot = await collectHarnessCapabilitySnapshot(
         this.sandbox,
         this.#runState.currentDir,
         now,
+        {
+          cfcEnforcementMode: this.#runState.cfcEnforcementMode,
+          runManifest: this.#runState.runManifest,
+          runManifestPath: this.#runState.runManifestPath,
+        },
       );
       let capabilitiesPath: string | undefined;
       try {

--- a/packages/cf-harness/src/index.ts
+++ b/packages/cf-harness/src/index.ts
@@ -6,6 +6,7 @@ export * from "./artifacts.ts";
 export * from "./cli.ts";
 export * from "./gateway/openai-client.ts";
 export * from "./contracts/prompt-slot.ts";
+export * from "./contracts/run-manifest.ts";
 export * from "./contracts/observation.ts";
 export * from "./contracts/policy.ts";
 export * from "./contracts/run-report.ts";

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -1,5 +1,6 @@
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { HarnessPolicyEvent } from "./contracts/policy.ts";
+import type { HarnessRunManifest } from "./contracts/run-manifest.ts";
 import type { PromptSlotBinding } from "./contracts/prompt-slot.ts";
 import type { ToolResultRef } from "./contracts/tool-result.ts";
 import type {
@@ -34,6 +35,8 @@ export interface HarnessRunState {
   currentDir: string;
   model?: string;
   artifactRoot?: string;
+  runManifest?: HarnessRunManifest;
+  runManifestPath?: string;
   transcriptPath?: string;
   runReportPath?: string;
   capabilitySnapshot?: HarnessCapabilitySnapshot;
@@ -54,6 +57,8 @@ export interface CreateHarnessRunStateOptions {
   currentDir: string;
   model?: string;
   artifactRoot?: string;
+  runManifest?: HarnessRunManifest;
+  runManifestPath?: string;
   transcriptPath?: string;
   runReportPath?: string;
   capabilitySnapshot?: HarnessCapabilitySnapshot;
@@ -84,6 +89,12 @@ export const createHarnessRunState = (
     ...(options.model !== undefined ? { model: options.model } : {}),
     ...(options.artifactRoot !== undefined
       ? { artifactRoot: options.artifactRoot }
+      : {}),
+    ...(options.runManifest !== undefined
+      ? { runManifest: options.runManifest }
+      : {}),
+    ...(options.runManifestPath !== undefined
+      ? { runManifestPath: options.runManifestPath }
       : {}),
     ...(options.transcriptPath !== undefined
       ? { transcriptPath: options.transcriptPath }
@@ -203,6 +214,16 @@ export const setHarnessRunReportPath = (
 ): HarnessRunState => ({
   ...state,
   runReportPath,
+  updatedAt: now,
+});
+
+export const setHarnessRunManifestPath = (
+  state: HarnessRunState,
+  runManifestPath: string,
+  now = new Date().toISOString(),
+): HarnessRunState => ({
+  ...state,
+  runManifestPath,
   updatedAt: now,
 });
 

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -6,6 +6,7 @@ import type {
   SandboxCommandRequest,
   SandboxCommandResult,
   SandboxRuntime,
+  SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "./types.ts";
 
@@ -109,6 +110,20 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
 
   defaultWorkingDirectory(): string {
     return normalizeWorkspacePath(this.config.workspaceMountPath);
+  }
+
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: this.kind,
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: {
+        runtimeRequested: true,
+        runtimeName: this.config.runtimeName,
+        workspaceMountPath: this.config.workspaceMountPath,
+        networkMode: this.config.dockerNetworkMode,
+        extraDockerArgsCount: this.config.extraDockerArgs.length,
+      },
+    };
   }
 
   isPathWithinWorkspace(path: string): boolean {

--- a/packages/cf-harness/src/sandbox/types.ts
+++ b/packages/cf-harness/src/sandbox/types.ts
@@ -50,8 +50,21 @@ export interface SandboxCommandResult {
   exitCode: number;
 }
 
+export interface SandboxRuntimeDescription {
+  kind: HarnessSandboxKind;
+  defaultWorkingDirectory: string;
+  cfc?: {
+    runtimeRequested: boolean;
+    runtimeName?: string;
+    workspaceMountPath?: string;
+    networkMode?: DockerNetworkMode;
+    extraDockerArgsCount?: number;
+  };
+}
+
 export interface SandboxRuntime {
   readonly kind: HarnessSandboxKind;
+  describe?(): SandboxRuntimeDescription;
   resolvePath(path: string, cwd?: string): string;
   isPathWithinWorkspace(path: string): boolean;
   defaultWorkingDirectory(): string;

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -8,6 +8,7 @@ import {
   readHarnessRunState,
   readHarnessTranscript,
 } from "../src/artifacts.ts";
+import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
@@ -138,6 +139,24 @@ Deno.test({
         capabilitySnapshot: {
           type: "cf-harness.capability-snapshot",
           at: "2026-04-15T21:00:01.000Z",
+          cfc: {
+            enforcementMode: "observe",
+            absenceBehavior: "observe-only",
+            substrateStatus: "not-attested",
+            runManifest: { present: false },
+            sandbox: {
+              kind: "docker-runsc-cfc",
+              defaultWorkingDirectory: "/workspace",
+              cfc: {
+                runtimeRequested: true,
+                workspaceMountPath: "/workspace",
+              },
+            },
+            protectedXattrs: {
+              expectedSandboxVisible: false,
+              sandboxVisibility: "not-probed",
+            },
+          },
           commands: {
             bash: {
               present: true,
@@ -173,6 +192,61 @@ Deno.test({
         toolOutputs: [result.resultRef],
         failureRecords: [],
       });
+    } finally {
+      await Deno.remove(artifactRoot, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "CfHarnessEngine persists Loom run manifest artifacts",
+  permissions: { read: true, write: true },
+  async fn() {
+    const artifactRoot = await Deno.makeTempDir({
+      prefix: "cf-harness-manifest-",
+    });
+    const runManifest = {
+      type: "cf-harness.loom-run-manifest" as const,
+      version: 1 as const,
+      source: "loom" as const,
+      wishId: "W-519",
+      cfc: { enforcementMode: "observe" as const },
+    };
+    try {
+      const engine = new CfHarnessEngine({
+        artifactRoot,
+        sandboxRuntime: new FakeSandboxRuntime([
+          { stdout: "ok\n", stderr: "", exitCode: 0 },
+        ]),
+        runId: "run-with-manifest",
+        runManifest,
+        runManifestPath: "/tmp/original-loom-run-manifest.json",
+      });
+
+      await engine.invokeBuiltinTool("bash", { command: "echo ok" });
+
+      const runRoot = join(artifactRoot, "run-with-manifest");
+      const manifestPath = join(runRoot, "run-manifest.json");
+      const persistedState = await readHarnessRunState(
+        join(runRoot, "run-state.json"),
+      );
+
+      assertEquals(
+        JSON.parse(await Deno.readTextFile(manifestPath)),
+        runManifest,
+      );
+      assertEquals(persistedState.cfcEnforcementMode, "observe");
+      assertEquals(persistedState.runManifest, runManifest);
+      assertEquals(persistedState.runManifestPath, manifestPath);
+      assertEquals(persistedState.capabilitySnapshot?.cfc.runManifest, {
+        present: true,
+        type: "cf-harness.loom-run-manifest",
+        path: manifestPath,
+      });
+      assertEquals(
+        persistedState.capabilitySnapshot?.cfc.substrateStatus,
+        "manifest-present",
+      );
     } finally {
       await Deno.remove(artifactRoot, { recursive: true });
     }
@@ -299,7 +373,7 @@ Deno.test({
         toolCallId: "call-1",
         toolId: "read_file",
         effectClass: "read",
-        cfcEnforcementMode: "disabled",
+        cfcEnforcementMode: "enforce-explicit",
         policyDecision: "allowed",
         executionStatus: "completed",
         toolInputSummary: {
@@ -370,7 +444,8 @@ Deno.test({
     });
     try {
       const promptSlotBinding = {
-        type: "cf-harness.prompt-slot-binding",
+        type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+        source: { type: "test.prompt-slot", subject: "artifact-test" },
         role: "direct-command",
         kernelName: "cf-harness",
         surface: "test",

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -13,6 +13,7 @@ import {
   runCfHarnessCli,
 } from "../src/cli.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
+import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
 import type {
   HarnessPromptLoopResult,
   RunHarnessPromptOptions,
@@ -88,6 +89,36 @@ Deno.test("parseCfHarnessCliArgs supports prompt files and mode overrides", asyn
   assertEquals(parsed.gatewayAuthMode, "bearer");
   assertEquals(parsed.cfcEnforcementModeOverride, "observe");
   assertEquals(parsed.maxModelTurns, 5);
+});
+
+Deno.test("parseCfHarnessCliArgs accepts CFC mode from environment", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    ["--prompt", "hi"],
+    {
+      cwd: "/tmp/project",
+      env: { CF_HARNESS_CFC_ENFORCEMENT_MODE: "enforce-strict" },
+    },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.cfcEnforcementModeOverride, "enforce-strict");
+});
+
+Deno.test("parseCfHarnessCliArgs resolves run manifest paths", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    ["--prompt", "hi", "--run-manifest", "loom-run.json"],
+    {
+      cwd: "/tmp/project",
+      env: {},
+    },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.runManifestPath, "/tmp/project/loom-run.json");
 });
 
 Deno.test("parseCfHarnessCliArgs rejects malformed max-model-turns values", async () => {
@@ -611,6 +642,88 @@ Deno.test("runCfHarnessCli can override the prompt-slot role for testing", async
   assertEquals(stdout.length, 1);
 });
 
+Deno.test("runCfHarnessCli passes a Loom run manifest and its prompt slot", async () => {
+  const { io, stdout, stderr } = createIoBuffers();
+  let createdOptions: Record<string, unknown> | undefined;
+  let runPromptOptions: RunHarnessPromptOptions | undefined;
+  const manifest = {
+    type: "cf-harness.loom-run-manifest",
+    version: 1,
+    source: "loom",
+    wishId: "W-519",
+    cfc: { enforcementMode: "observe" },
+    promptSlot: {
+      type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+      source: { type: "loom.wish", wishId: "W-519" },
+      role: "context",
+      kernelName: "cf-harness",
+      surface: "loom",
+      subject: "did:web:example.com#gideon",
+      slotDigest: "sha256:slot",
+    },
+  } as const;
+  const exitCode = await runCfHarnessCli(
+    [
+      "--workspace",
+      "/tmp/project",
+      "--prompt",
+      "Inspect the workspace",
+      "--gateway-auth-mode",
+      "none",
+      "--run-manifest",
+      "loom-run.json",
+    ],
+    {
+      io,
+      cwd: "/tmp/project",
+      env: {},
+      readTextFile: (path) => {
+        assertEquals(path, "/tmp/project/loom-run.json");
+        return Promise.resolve(JSON.stringify(manifest));
+      },
+      createPromptLoop: (options) => {
+        createdOptions = options as Record<string, unknown>;
+        return {
+          runPrompt: (options) => {
+            runPromptOptions = options;
+            return Promise.resolve(
+              {
+                model: "gpt-5.4",
+                finalAssistantText: "Manifest accepted.",
+                transcript: [
+                  { role: "user", content: "Inspect the workspace" },
+                  { role: "assistant", content: "Manifest accepted." },
+                ],
+                modelTurns: 1,
+                runState: {
+                  runId: "run-manifest",
+                  status: "completed",
+                  createdAt: "2026-04-27T21:00:00.000Z",
+                  updatedAt: "2026-04-27T21:00:01.000Z",
+                  cfcEnforcementMode: "observe",
+                  currentDir: "/workspace",
+                  policyEvents: [],
+                  toolOutputs: [],
+                },
+              } satisfies HarnessPromptLoopResult,
+            );
+          },
+          runTranscript: () =>
+            Promise.reject(new Error("unexpected resume path")),
+        };
+      },
+    },
+  );
+
+  const engine = createdOptions?.engine as CfHarnessEngine | undefined;
+  assertEquals(exitCode, 0);
+  assertEquals(engine?.getRunState().runManifest?.wishId, "W-519");
+  assertEquals(engine?.getRunState().cfcEnforcementMode, "observe");
+  assertEquals(runPromptOptions?.promptSlotBinding, manifest.promptSlot);
+  assertEquals(stderr, []);
+  assertEquals(stdout.length, 1);
+});
+
 Deno.test("runCfHarnessCli can stream transcript events as they happen", async () => {
   const { io, stdout, stderr } = createIoBuffers();
   const exitCode = await runCfHarnessCli(
@@ -1062,7 +1175,8 @@ Deno.test("runCfHarnessCli can resume from persisted run artifacts", async () =>
   const { io, stdout, stderr } = createIoBuffers();
   let runTranscriptOptions: RunHarnessTranscriptOptions | undefined;
   const promptSlotBinding = {
-    type: "cf-harness.prompt-slot-binding",
+    type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+    source: { type: "loom.run", runId: "run-1" },
     role: "context",
     kernelName: "cf-harness",
     surface: "loom",

--- a/packages/cf-harness/test/config.test.ts
+++ b/packages/cf-harness/test/config.test.ts
@@ -1,6 +1,8 @@
 import { assertEquals } from "@std/assert";
+import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import {
   DEFAULT_GATEWAY_BASE_URL,
+  DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE,
   parseCfcEnforcementMode,
   parseHarnessGatewayAuthMode,
   resolveCfcEnforcementMode,
@@ -49,7 +51,38 @@ Deno.test("resolveCfcEnforcementMode falls back through config and inherited val
     }),
     "observe",
   );
-  assertEquals(resolveCfcEnforcementMode({}), "disabled");
+  assertEquals(
+    resolveCfcEnforcementMode({}),
+    DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE,
+  );
+});
+
+Deno.test("resolveCfcEnforcementMode can inherit from a run manifest", () => {
+  assertEquals(
+    resolveCfcEnforcementMode({
+      runManifest: {
+        type: "cf-harness.loom-run-manifest",
+        version: 1,
+        source: "loom",
+        cfc: { enforcementMode: "observe" },
+      },
+    }),
+    "observe",
+  );
+});
+
+Deno.test("resolveCfcEnforcementMode ignores malformed in-memory run manifest modes", () => {
+  assertEquals(
+    resolveCfcEnforcementMode({
+      runManifest: {
+        type: "cf-harness.loom-run-manifest",
+        version: 1,
+        source: "loom",
+        cfc: { enforcementMode: "bogus" as CfcEnforcementMode },
+      },
+    }),
+    DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE,
+  );
 });
 
 Deno.test("resolveGatewayAuthMode prefers explicit override", () => {
@@ -72,7 +105,7 @@ Deno.test("resolveHarnessConfig normalizes the gateway base URL", () => {
   });
   assertEquals(config.gatewayBaseUrl, DEFAULT_GATEWAY_BASE_URL);
   assertEquals(config.gatewayAuthMode, "bearer");
-  assertEquals(config.cfcEnforcementMode, "disabled");
+  assertEquals(config.cfcEnforcementMode, DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE);
 });
 
 Deno.test("resolveHarnessConfig accepts an explicit mode override string", () => {

--- a/packages/cf-harness/test/diagnostics.test.ts
+++ b/packages/cf-harness/test/diagnostics.test.ts
@@ -67,6 +67,24 @@ Deno.test("collectHarnessCapabilitySnapshot captures fixed sandbox capabilities"
   assertEquals(snapshot, {
     type: "cf-harness.capability-snapshot",
     at: "2026-04-22T23:00:00.000Z",
+    cfc: {
+      enforcementMode: "enforce-explicit",
+      absenceBehavior: "permissive-if-absent",
+      substrateStatus: "not-attested",
+      runManifest: { present: false },
+      sandbox: {
+        kind: "docker-runsc-cfc",
+        defaultWorkingDirectory: "/workspace",
+        cfc: {
+          runtimeRequested: true,
+          workspaceMountPath: "/workspace",
+        },
+      },
+      protectedXattrs: {
+        expectedSandboxVisible: false,
+        sandboxVisibility: "not-probed",
+      },
+    },
     commands: {
       bash: {
         present: true,

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -101,6 +101,22 @@ Deno.test("DockerRunscSandboxRuntime builds a docker run invocation", async () =
   });
 });
 
+Deno.test("DockerRunscSandboxRuntime describe preserves custom CFC runtime aliases", () => {
+  const runtime = new DockerRunscSandboxRuntime(
+    resolveDockerRunscSandboxConfig({
+      workspaceHostPath: "/host/project",
+      runtimeName: "corp-runsc-prod",
+    }),
+  );
+  const description = runtime.describe();
+  if (description.cfc === undefined) {
+    throw new Error("expected CFC sandbox description");
+  }
+
+  assertEquals(description.cfc.runtimeRequested, true);
+  assertEquals(description.cfc.runtimeName, "corp-runsc-prod");
+});
+
 Deno.test("DockerRunscSandboxRuntime runShell honors an explicit container user override", async () => {
   const runner = new FakeProcessRunner({
     stdout: "",

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { normalize } from "@std/path/posix";
 import { createHarnessPolicyEvent } from "../src/contracts/policy.ts";
+import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
@@ -76,7 +77,7 @@ Deno.test("CfHarnessEngine builds a default docker-runsc sandbox when given a wo
     status: "pending",
     createdAt: "2026-04-15T19:00:00.000Z",
     updatedAt: "2026-04-15T19:00:00.000Z",
-    cfcEnforcementMode: "disabled",
+    cfcEnforcementMode: "enforce-explicit",
     currentDir: "/workspace",
     policyEvents: [],
     toolOutputs: [],
@@ -148,7 +149,8 @@ Deno.test("CfHarnessEngine records tool outputs into run state on success", asyn
 
 Deno.test("CfHarnessEngine records prompt slot binding into run state", () => {
   const promptSlotBinding = {
-    type: "cf-harness.prompt-slot-binding",
+    type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+    source: { type: "test.prompt-slot", subject: "engine-test" },
     role: "direct-command",
     kernelName: "cf-harness",
     surface: "test",

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -4,6 +4,10 @@ import type { HarnessArtifactStore } from "../src/artifacts.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
+import {
+  CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+  type PromptSlotBinding,
+} from "../src/contracts/prompt-slot.ts";
 import type {
   SandboxCommandRequest,
   SandboxCommandResult,
@@ -11,10 +15,10 @@ import type {
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
-import type { PromptSlotBinding } from "../src/contracts/prompt-slot.ts";
 
 const directPromptSlotBinding: PromptSlotBinding = {
-  type: "cf-harness.prompt-slot-binding",
+  type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+  source: { type: "test.prompt-slot", subject: "direct-test" },
   role: "direct-command",
   kernelName: "cf-harness",
   surface: "test",
@@ -23,7 +27,8 @@ const directPromptSlotBinding: PromptSlotBinding = {
 };
 
 const contextPromptSlotBinding: PromptSlotBinding = {
-  type: "cf-harness.prompt-slot-binding",
+  type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+  source: { type: "test.prompt-slot", subject: "context-test" },
   role: "context",
   kernelName: "cf-harness",
   surface: "test",

--- a/packages/cf-harness/test/run-manifest.test.ts
+++ b/packages/cf-harness/test/run-manifest.test.ts
@@ -1,0 +1,104 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
+import { parseLoomRunManifestJson } from "../src/contracts/run-manifest.ts";
+
+Deno.test("parseLoomRunManifestJson validates prompt-slot evidence", () => {
+  const manifest = parseLoomRunManifestJson(
+    JSON.stringify({
+      type: "cf-harness.loom-run-manifest",
+      version: 1,
+      source: "loom",
+      wishId: "W-519",
+      promptSlot: {
+        type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+        source: { type: "loom.wish", wishId: "W-519" },
+        role: "direct-command",
+        kernelName: "loom",
+        surface: "wish-dispatch",
+        subject: "W-519",
+      },
+    }),
+  );
+
+  assertEquals(manifest.promptSlot?.type, CFC_PROMPT_SLOT_BOUND_ATOM_TYPE);
+  assertEquals(manifest.promptSlot?.source, {
+    type: "loom.wish",
+    wishId: "W-519",
+  });
+});
+
+Deno.test("parseLoomRunManifestJson rejects malformed prompt-slot evidence", () => {
+  assertThrows(
+    () => parseLoomRunManifestJson(JSON.stringify([])),
+    Error,
+    "run manifest must be a JSON object",
+  );
+  assertThrows(
+    () =>
+      parseLoomRunManifestJson(
+        JSON.stringify({
+          type: "cf-harness.loom-run-manifest",
+          version: 1,
+          source: "loom",
+          promptSlot: [],
+        }),
+      ),
+    Error,
+    "prompt slot binding must be a JSON object",
+  );
+  assertThrows(
+    () =>
+      parseLoomRunManifestJson(
+        JSON.stringify({
+          type: "cf-harness.loom-run-manifest",
+          version: 1,
+          source: "loom",
+          promptSlot: { role: "direct-command" },
+        }),
+      ),
+    Error,
+    "unsupported prompt slot binding type",
+  );
+});
+
+Deno.test("parseLoomRunManifestJson rejects invalid CFC metadata", () => {
+  assertThrows(
+    () =>
+      parseLoomRunManifestJson(
+        JSON.stringify({
+          type: "cf-harness.loom-run-manifest",
+          version: 1,
+          source: "loom",
+          cfc: [],
+        }),
+      ),
+    Error,
+    "run manifest cfc must be a JSON object",
+  );
+  assertThrows(
+    () =>
+      parseLoomRunManifestJson(
+        JSON.stringify({
+          type: "cf-harness.loom-run-manifest",
+          version: 1,
+          source: "loom",
+          cfc: { enforcementMode: "bogus" },
+        }),
+      ),
+    Error,
+    "unsupported run manifest cfc.enforcementMode",
+  );
+  assertThrows(
+    () =>
+      parseLoomRunManifestJson(
+        JSON.stringify({
+          type: "cf-harness.loom-run-manifest",
+          version: 1,
+          source: "loom",
+          cfc: { enforcementMode: "" },
+        }),
+      ),
+    Error,
+    "unsupported run manifest cfc.enforcementMode",
+  );
+});

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -17,7 +17,11 @@ export type {
   TrustSnapshot,
   WritePolicyInput,
 } from "./types.ts";
-export { DEFAULT_CFC_ENFORCEMENT_MODE } from "./types.ts";
+export {
+  CFC_ENFORCEMENT_MODES,
+  DEFAULT_CFC_ENFORCEMENT_MODE,
+  isCfcEnforcementMode,
+} from "./types.ts";
 export {
   canonicalizeCfcMetadata,
   canonicalizeDereferenceTrace,

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -11,6 +11,19 @@ export type CfcEnforcementMode =
   | "enforce-explicit"
   | "enforce-strict";
 
+export const CFC_ENFORCEMENT_MODES = [
+  "disabled",
+  "observe",
+  "enforce-explicit",
+  "enforce-strict",
+] as const satisfies readonly CfcEnforcementMode[];
+
+export const isCfcEnforcementMode = (
+  input: unknown,
+): input is CfcEnforcementMode =>
+  typeof input === "string" &&
+  CFC_ENFORCEMENT_MODES.includes(input as CfcEnforcementMode);
+
 export const DEFAULT_CFC_ENFORCEMENT_MODE: CfcEnforcementMode = "disabled";
 
 export type IFCLabel = {


### PR DESCRIPTION
## Summary
- align cf-harness prompt-slot evidence with the CFC PromptSlotBound atom shape
- add Loom run manifest parsing, CLI intake, artifact retention, and run-state plumbing
- default cf-harness CFC mode to enforce-explicit with env overrides and add CFC substrate metadata to capability snapshots

## Verification
- deno task test (packages/cf-harness)
- deno task check (labs root)
- git diff --check