### PR TITLE
Add cf-harness run reports

### DIFF
--- a/packages/cf-harness/deno.json
+++ b/packages/cf-harness/deno.json
@@ -17,6 +17,7 @@
     "./contracts/prompt-slot": "./src/contracts/prompt-slot.ts",
     "./contracts/observation": "./src/contracts/observation.ts",
     "./contracts/policy": "./src/contracts/policy.ts",
+    "./contracts/run-report": "./src/contracts/run-report.ts",
     "./contracts/tool-result": "./src/contracts/tool-result.ts",
     "./contracts/tool-descriptor": "./src/contracts/tool-descriptor.ts",
     "./contracts/transcript": "./src/contracts/transcript.ts",

--- a/packages/cf-harness/src/artifacts.ts
+++ b/packages/cf-harness/src/artifacts.ts
@@ -9,6 +9,7 @@ import {
 } from "@std/path";
 import type { HarnessRunState } from "./run-state.ts";
 import { createHarnessPolicyEvent } from "./contracts/policy.ts";
+import type { HarnessRunReport } from "./contracts/run-report.ts";
 import type { HarnessTranscriptMessage } from "./contracts/transcript.ts";
 import type { ToolOutputId } from "./contracts/tool-result.ts";
 import type { HarnessCapabilitySnapshot } from "./diagnostics.ts";
@@ -63,6 +64,9 @@ export interface HarnessArtifactStore {
   persistCapabilitySnapshot(
     snapshot: HarnessCapabilitySnapshot,
   ): Promise<string>;
+  persistRunReport(
+    report: HarnessRunReport,
+  ): Promise<string>;
   persistToolOutput(
     toolId: string,
     outputId: ToolOutputId,
@@ -106,6 +110,15 @@ export class FileSystemHarnessArtifactStore implements HarnessArtifactStore {
     await ensureDir(this.runRoot);
     const path = join(this.runRoot, "capabilities.json");
     await writeJsonFile(path, snapshot);
+    return path;
+  }
+
+  async persistRunReport(
+    report: HarnessRunReport,
+  ): Promise<string> {
+    await ensureDir(this.runRoot);
+    const path = join(this.runRoot, "run-report.json");
+    await writeJsonFile(path, report);
     return path;
   }
 
@@ -154,6 +167,11 @@ export const readHarnessTranscript = async (
   path: string,
 ): Promise<HarnessTranscriptMessage[]> =>
   JSON.parse(await Deno.readTextFile(path)) as HarnessTranscriptMessage[];
+
+export const readHarnessRunReport = async (
+  path: string,
+): Promise<HarnessRunReport> =>
+  JSON.parse(await Deno.readTextFile(path)) as HarnessRunReport;
 
 export interface HarnessRunArtifacts {
   runRoot: string;

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -515,6 +515,7 @@ export interface CfHarnessBatchResult {
   model: string;
   artifact_root?: string;
   transcript_path?: string;
+  run_report_path?: string;
 }
 
 export const createCfHarnessBatchResult = (
@@ -535,6 +536,9 @@ export const createCfHarnessBatchResult = (
     : {}),
   ...(result.runState.transcriptPath !== undefined
     ? { transcript_path: result.runState.transcriptPath }
+    : {}),
+  ...(result.runState.runReportPath !== undefined
+    ? { run_report_path: result.runState.runReportPath }
     : {}),
 });
 
@@ -647,6 +651,9 @@ export const formatCfHarnessCliResult = (
   if (result.runState.transcriptPath !== undefined) {
     lines.push(`transcriptPath: ${result.runState.transcriptPath}`);
   }
+  if (result.runState.runReportPath !== undefined) {
+    lines.push(`runReportPath: ${result.runState.runReportPath}`);
+  }
   if (result.runState.policyEvents.length > 0) {
     lines.push(`policyEvents: ${result.runState.policyEvents.length}`);
     for (const event of result.runState.policyEvents) {
@@ -741,7 +748,8 @@ export const runCfHarnessCli = async (
         transcript: artifacts.transcript,
         model: parsed.model ?? artifacts.runState.model,
         maxModelTurns: parsed.maxModelTurns,
-        promptSlotBinding,
+        promptSlotBinding: artifacts.runState.promptSlotBinding ??
+          promptSlotBinding,
         onTranscriptEvent,
       });
     } else {

--- a/packages/cf-harness/src/contracts/policy.ts
+++ b/packages/cf-harness/src/contracts/policy.ts
@@ -1,7 +1,44 @@
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { ObservationDenied } from "./observation.ts";
+import type { PromptSlotBinding } from "./prompt-slot.ts";
+import type { BuiltinToolId } from "./tool-descriptor.ts";
 
 export type HarnessPolicyEventSeverity = "warning" | "denied";
+
+export interface HarnessBashToolInputSummary {
+  type: "cf-harness.tool-input-summary";
+  toolId: "bash";
+  cwd?: string;
+  timeoutMs?: number;
+  commandBytes?: number;
+  commandDigest?: string;
+}
+
+export interface HarnessReadFileToolInputSummary {
+  type: "cf-harness.tool-input-summary";
+  toolId: "read_file";
+  path?: string;
+  maxBytes?: number;
+}
+
+export interface HarnessWriteFileToolInputSummary {
+  type: "cf-harness.tool-input-summary";
+  toolId: "write_file";
+  path?: string;
+  mode?: "replace" | "append";
+  createParents?: boolean;
+  contentBytes?: number;
+  contentDigest?: string;
+}
+
+export type HarnessToolInputSummary =
+  | HarnessBashToolInputSummary
+  | HarnessReadFileToolInputSummary
+  | HarnessWriteFileToolInputSummary
+  | {
+    type: "cf-harness.tool-input-summary";
+    toolId: BuiltinToolId;
+  };
 
 export interface HarnessPolicyEvent {
   type: "cf-harness.policy-event";
@@ -11,6 +48,8 @@ export interface HarnessPolicyEvent {
   detail: string;
   at: string;
   toolCallId?: string;
+  promptSlot?: PromptSlotBinding;
+  toolInputSummary?: HarnessToolInputSummary;
   observationDenied?: ObservationDenied;
 }
 

--- a/packages/cf-harness/src/contracts/run-report.ts
+++ b/packages/cf-harness/src/contracts/run-report.ts
@@ -1,0 +1,266 @@
+import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import type { HarnessFailureRecord } from "../diagnostics.ts";
+import type { HarnessPolicyEvent, HarnessToolInputSummary } from "./policy.ts";
+import type { PromptSlotBinding } from "./prompt-slot.ts";
+import type { HarnessToolEffectClass } from "./tool-descriptor.ts";
+import type { HarnessTranscriptMessage } from "./transcript.ts";
+import type { ToolResultRef } from "./tool-result.ts";
+
+export type HarnessToolPolicyDecision = "allowed" | "warned" | "denied";
+export type HarnessToolExecutionStatus = "completed" | "failed" | "not-run";
+export type HarnessRunTimelineKind =
+  | "run_started"
+  | "transcript_message"
+  | "tool_activity"
+  | "policy_event"
+  | "failure_record"
+  | "run_finished";
+
+export interface HarnessToolActivity {
+  type: "cf-harness.tool-activity";
+  runId: string;
+  sequence: number;
+  startedAt: string;
+  endedAt: string;
+  toolCallId: string;
+  toolId: string;
+  effectClass: HarnessToolEffectClass;
+  cfcEnforcementMode: CfcEnforcementMode;
+  policyDecision: HarnessToolPolicyDecision;
+  executionStatus: HarnessToolExecutionStatus;
+  promptSlot?: PromptSlotBinding;
+  toolInputSummary?: HarnessToolInputSummary;
+  policyEventIndexes?: number[];
+  resultRef?: ToolResultRef;
+  errorDetail?: string;
+}
+
+export interface HarnessRunTimelineEntry {
+  type: "cf-harness.timeline-entry";
+  sequence: number;
+  at: string;
+  kind: HarnessRunTimelineKind;
+  endedAt?: string;
+  status?: string;
+  terminalReason?: string;
+  transcriptIndex?: number;
+  role?: HarnessTranscriptMessage["role"];
+  modelTurn?: number;
+  toolCallIds?: string[];
+  toolCallId?: string;
+  toolId?: string;
+  toolActivitySequence?: number;
+  policyDecision?: HarnessToolPolicyDecision;
+  executionStatus?: HarnessToolExecutionStatus;
+  policyEventIndex?: number;
+  severity?: HarnessPolicyEvent["severity"];
+  failureRecordIndex?: number;
+  failureKind?: string;
+  source?: string;
+}
+
+export type HarnessRunTimelineEntryInput = Omit<
+  HarnessRunTimelineEntry,
+  "type" | "sequence"
+>;
+
+export interface HarnessRunReport {
+  type: "cf-harness.run-report";
+  runId: string;
+  generatedAt: string;
+  status: string;
+  model: string;
+  modelTurns: number;
+  cfcEnforcementMode: CfcEnforcementMode;
+  createdAt?: string;
+  updatedAt?: string;
+  endedAt?: string;
+  terminalReason?: string;
+  finalAssistantText?: string;
+  artifactRoot?: string;
+  transcriptPath?: string;
+  promptSlotBinding?: PromptSlotBinding;
+  primaryFailure?: HarnessFailureRecord;
+  failureRecords?: HarnessFailureRecord[];
+  policyEventCounts: {
+    total: number;
+    warnings: number;
+    denied: number;
+  };
+  policyEvents: HarnessPolicyEvent[];
+  timeline: HarnessRunTimelineEntry[];
+  toolActivity: HarnessToolActivity[];
+  toolOutputs: ToolResultRef[];
+}
+
+export interface CreateHarnessRunReportOptions {
+  runState: {
+    runId: string;
+    status: string;
+    createdAt?: string;
+    updatedAt: string;
+    endedAt?: string;
+    terminalReason?: string;
+    cfcEnforcementMode: CfcEnforcementMode;
+    artifactRoot?: string;
+    transcriptPath?: string;
+    promptSlotBinding?: PromptSlotBinding;
+    primaryFailure?: HarnessFailureRecord;
+    failureRecords?: HarnessFailureRecord[];
+    policyEvents: HarnessPolicyEvent[];
+    toolOutputs: ToolResultRef[];
+  };
+  model: string;
+  modelTurns: number;
+  finalAssistantText?: string;
+  timeline?: readonly HarnessRunTimelineEntryInput[];
+  toolActivity: readonly HarnessToolActivity[];
+}
+
+export const createHarnessRunTimeline = (
+  options: Pick<CreateHarnessRunReportOptions, "runState" | "toolActivity"> & {
+    timeline?: readonly HarnessRunTimelineEntryInput[];
+  },
+): HarnessRunTimelineEntry[] => {
+  let insertionOrder = 0;
+  const entries: Array<HarnessRunTimelineEntryInput & { order: number }> = [];
+  const push = (entry: HarnessRunTimelineEntryInput): void => {
+    if (!entry.at) {
+      return;
+    }
+    insertionOrder += 1;
+    entries.push({ ...entry, order: insertionOrder });
+  };
+
+  if (options.runState.createdAt !== undefined) {
+    push({
+      kind: "run_started",
+      at: options.runState.createdAt,
+      status: "created",
+    });
+  }
+  for (const entry of options.timeline ?? []) {
+    push(entry);
+  }
+  for (const activity of options.toolActivity) {
+    push({
+      kind: "tool_activity",
+      at: activity.startedAt,
+      endedAt: activity.endedAt,
+      toolActivitySequence: activity.sequence,
+      toolCallId: activity.toolCallId,
+      toolId: activity.toolId,
+      policyDecision: activity.policyDecision,
+      executionStatus: activity.executionStatus,
+    });
+  }
+  for (
+    const [policyEventIndex, event] of options.runState.policyEvents.entries()
+  ) {
+    push({
+      kind: "policy_event",
+      at: event.at,
+      policyEventIndex,
+      severity: event.severity,
+      toolCallId: event.toolCallId,
+      toolId: event.toolId,
+    });
+  }
+  for (
+    const [failureRecordIndex, failure]
+      of (options.runState.failureRecords ?? []).entries()
+  ) {
+    push({
+      kind: "failure_record",
+      at: failure.at,
+      failureRecordIndex,
+      failureKind: failure.kind,
+      source: failure.source,
+      toolId: failure.toolId,
+    });
+  }
+  if (options.runState.endedAt !== undefined) {
+    push({
+      kind: "run_finished",
+      at: options.runState.endedAt,
+      status: options.runState.status,
+      ...(options.runState.terminalReason !== undefined
+        ? { terminalReason: options.runState.terminalReason }
+        : {}),
+    });
+  }
+
+  return entries
+    .sort((left, right) =>
+      left.at === right.at ? left.order - right.order : left.at.localeCompare(
+        right.at,
+      )
+    )
+    .map(({ order: _order, ...entry }, index) => ({
+      type: "cf-harness.timeline-entry",
+      sequence: index + 1,
+      ...entry,
+    }));
+};
+
+export const createHarnessRunReport = (
+  options: CreateHarnessRunReportOptions,
+): HarnessRunReport => {
+  const warnings =
+    options.runState.policyEvents.filter((event) =>
+      event.severity === "warning"
+    ).length;
+  const denied =
+    options.runState.policyEvents.filter((event) => event.severity === "denied")
+      .length;
+  return {
+    type: "cf-harness.run-report",
+    runId: options.runState.runId,
+    generatedAt: options.runState.updatedAt,
+    status: options.runState.status,
+    model: options.model,
+    modelTurns: options.modelTurns,
+    cfcEnforcementMode: options.runState.cfcEnforcementMode,
+    ...(options.runState.createdAt !== undefined
+      ? { createdAt: options.runState.createdAt }
+      : {}),
+    updatedAt: options.runState.updatedAt,
+    ...(options.runState.endedAt !== undefined
+      ? { endedAt: options.runState.endedAt }
+      : {}),
+    ...(options.runState.terminalReason !== undefined
+      ? { terminalReason: options.runState.terminalReason }
+      : {}),
+    ...(options.finalAssistantText !== undefined
+      ? { finalAssistantText: options.finalAssistantText }
+      : {}),
+    ...(options.runState.artifactRoot !== undefined
+      ? { artifactRoot: options.runState.artifactRoot }
+      : {}),
+    ...(options.runState.transcriptPath !== undefined
+      ? { transcriptPath: options.runState.transcriptPath }
+      : {}),
+    ...(options.runState.promptSlotBinding !== undefined
+      ? { promptSlotBinding: options.runState.promptSlotBinding }
+      : {}),
+    ...(options.runState.primaryFailure !== undefined
+      ? { primaryFailure: options.runState.primaryFailure }
+      : {}),
+    ...(options.runState.failureRecords !== undefined
+      ? { failureRecords: options.runState.failureRecords }
+      : {}),
+    policyEventCounts: {
+      total: options.runState.policyEvents.length,
+      warnings,
+      denied,
+    },
+    policyEvents: [...options.runState.policyEvents],
+    timeline: createHarnessRunTimeline({
+      runState: options.runState,
+      timeline: options.timeline,
+      toolActivity: options.toolActivity,
+    }),
+    toolActivity: [...options.toolActivity],
+    toolOutputs: [...options.runState.toolOutputs],
+  };
+};

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -15,7 +15,9 @@ import {
   type HarnessRunState,
   type HarnessRunTerminalReason,
   setHarnessCapabilitySnapshot,
+  setHarnessPromptSlotBinding,
   setHarnessRunCurrentDir,
+  setHarnessRunReportPath,
   setHarnessRunStatus,
   setHarnessTranscriptPath,
 } from "./run-state.ts";
@@ -32,6 +34,8 @@ import {
   createHarnessPolicyEvent,
   type HarnessPolicyEvent,
 } from "./contracts/policy.ts";
+import type { PromptSlotBinding } from "./contracts/prompt-slot.ts";
+import type { HarnessRunReport } from "./contracts/run-report.ts";
 import {
   createToolResultRef,
   type ToolOutputId,
@@ -225,6 +229,17 @@ export class CfHarnessEngine {
     return this.getRunState();
   }
 
+  setPromptSlotBinding(
+    promptSlotBinding: PromptSlotBinding,
+  ): HarnessRunState {
+    this.#runState = setHarnessPromptSlotBinding(
+      this.#runState,
+      promptSlotBinding,
+      this.#now(),
+    );
+    return this.getRunState();
+  }
+
   async recordPolicyEvent(
     event: Omit<HarnessPolicyEvent, "type" | "at">,
   ): Promise<HarnessRunState> {
@@ -294,6 +309,21 @@ export class CfHarnessEngine {
       await this.persistRunState();
     }
     return transcriptPath;
+  }
+
+  async persistRunReport(
+    report: HarnessRunReport,
+  ): Promise<string | undefined> {
+    const runReportPath = await this.artifactStore?.persistRunReport(report);
+    if (runReportPath !== undefined) {
+      this.#runState = setHarnessRunReportPath(
+        this.#runState,
+        runReportPath,
+        this.#now(),
+      );
+      await this.persistRunState();
+    }
+    return runReportPath;
   }
 
   async ensureDiagnosticsInitialized(): Promise<HarnessRunState> {

--- a/packages/cf-harness/src/index.ts
+++ b/packages/cf-harness/src/index.ts
@@ -8,6 +8,7 @@ export * from "./gateway/openai-client.ts";
 export * from "./contracts/prompt-slot.ts";
 export * from "./contracts/observation.ts";
 export * from "./contracts/policy.ts";
+export * from "./contracts/run-report.ts";
 export * from "./contracts/tool-result.ts";
 export * from "./contracts/tool-descriptor.ts";
 export * from "./contracts/transcript.ts";

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -32,6 +32,13 @@ import type {
   BuiltinToolId,
   HarnessToolDescriptor,
 } from "./contracts/tool-descriptor.ts";
+import type { HarnessToolInputSummary } from "./contracts/policy.ts";
+import {
+  createHarnessRunReport,
+  type HarnessRunTimelineEntryInput,
+  type HarnessToolActivity,
+  type HarnessToolPolicyDecision,
+} from "./contracts/run-report.ts";
 import { BUILTIN_TOOLS, getBuiltinTool } from "./tools/registry.ts";
 
 const DEFAULT_MAX_MODEL_TURNS = 8;
@@ -162,6 +169,139 @@ const parseToolArguments = (
     );
   }
   return parsed as Record<string, unknown>;
+};
+
+const tryParseToolArguments = (
+  toolCall: HarnessToolCall,
+): Record<string, unknown> | undefined => {
+  try {
+    return parseToolArguments(toolCall);
+  } catch {
+    return undefined;
+  }
+};
+
+const textBytes = (input: string): Uint8Array =>
+  new TextEncoder().encode(input);
+
+const sha256Digest = async (input: Uint8Array): Promise<string> => {
+  const digestInput = input.buffer.slice(
+    input.byteOffset,
+    input.byteOffset + input.byteLength,
+  ) as ArrayBuffer;
+  const digest = await crypto.subtle.digest("SHA-256", digestInput);
+  return `sha256:${
+    [...new Uint8Array(digest)].map((byte) =>
+      byte.toString(16).padStart(2, "0")
+    ).join("")
+  }`;
+};
+
+const summarizeSensitiveText = async (
+  input: string,
+): Promise<{ bytes: number; digest: string }> => {
+  const bytes = textBytes(input);
+  return {
+    bytes: bytes.byteLength,
+    digest: await sha256Digest(bytes),
+  };
+};
+
+const isSafeNonNegativeInteger = (value: unknown): value is number =>
+  typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+
+const optionalPolicyEventIndexes = (
+  policyEventIndexes: readonly number[],
+): { policyEventIndexes?: number[] } =>
+  policyEventIndexes.length > 0
+    ? { policyEventIndexes: [...policyEventIndexes] }
+    : {};
+
+const transcriptTimelineEntry = (
+  message: HarnessTranscriptMessage,
+  transcriptIndex: number,
+  at: string,
+  modelTurn?: number,
+): HarnessRunTimelineEntryInput => ({
+  kind: "transcript_message",
+  at,
+  transcriptIndex,
+  role: message.role,
+  ...(modelTurn !== undefined ? { modelTurn } : {}),
+  ...(message.role === "assistant" && message.toolCalls !== undefined
+    ? { toolCallIds: message.toolCalls.map((toolCall) => toolCall.id) }
+    : {}),
+  ...(message.role === "tool"
+    ? { toolCallId: message.toolCallId, toolId: message.toolName }
+    : {}),
+});
+
+const toErrorDetail = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const summarizeToolInput = async (
+  toolId: BuiltinToolId,
+  input: Record<string, unknown>,
+): Promise<HarnessToolInputSummary> => {
+  switch (toolId) {
+    case "bash": {
+      const commandSummary = typeof input.command === "string"
+        ? await summarizeSensitiveText(input.command)
+        : undefined;
+      return {
+        type: "cf-harness.tool-input-summary",
+        toolId,
+        ...(typeof input.cwd === "string" ? { cwd: input.cwd } : {}),
+        ...(isSafeNonNegativeInteger(input.timeoutMs)
+          ? { timeoutMs: input.timeoutMs }
+          : {}),
+        ...(commandSummary !== undefined
+          ? {
+            commandBytes: commandSummary.bytes,
+            commandDigest: commandSummary.digest,
+          }
+          : {}),
+      };
+    }
+    case "read_file":
+      return {
+        type: "cf-harness.tool-input-summary",
+        toolId,
+        ...(typeof input.path === "string" ? { path: input.path } : {}),
+        ...(isSafeNonNegativeInteger(input.maxBytes)
+          ? { maxBytes: input.maxBytes }
+          : {}),
+      };
+    case "write_file": {
+      const contentSummary = typeof input.content === "string"
+        ? await summarizeSensitiveText(input.content)
+        : undefined;
+      const mode = input.mode === "append" || input.mode === "replace"
+        ? input.mode
+        : input.mode === undefined
+        ? "replace"
+        : undefined;
+      return {
+        type: "cf-harness.tool-input-summary",
+        toolId,
+        ...(typeof input.path === "string" ? { path: input.path } : {}),
+        ...(mode !== undefined ? { mode } : {}),
+        ...(typeof input.createParents === "boolean"
+          ? { createParents: input.createParents }
+          : {}),
+        ...(contentSummary !== undefined
+          ? {
+            contentBytes: contentSummary.bytes,
+            contentDigest: contentSummary.digest,
+          }
+          : {}),
+      };
+    }
+  }
+  return {
+    type: "cf-harness.tool-input-summary",
+    toolId,
+  };
 };
 
 const createAssistantTranscriptMessage = (
@@ -312,8 +452,11 @@ export class CfHarnessPromptLoop {
   async runTranscript(
     options: RunHarnessTranscriptOptions,
   ): Promise<HarnessPromptLoopResult> {
-    const model = options.model ?? this.engine.getRunState().model ??
+    const initialRunState = this.engine.getRunState();
+    const model = options.model ?? initialRunState.model ??
       this.engine.config.model;
+    const promptSlotBinding = options.promptSlotBinding ??
+      initialRunState.promptSlotBinding;
     if (model === undefined) {
       throw new Error(
         "a model must be configured before running the prompt loop",
@@ -321,11 +464,38 @@ export class CfHarnessPromptLoop {
     }
     const transcript: HarnessTranscriptMessage[] = [...options.transcript];
     const maxModelTurns = options.maxModelTurns ?? this.#maxModelTurns;
+    const toolActivity: HarnessToolActivity[] = [];
+    const reportTimeline: HarnessRunTimelineEntryInput[] = [];
     let modelTurns = 0;
+    const persistRunReport = async (
+      finalAssistantText?: string,
+    ): Promise<void> => {
+      await this.engine.persistRunReport(
+        createHarnessRunReport({
+          runState: this.engine.getRunState(),
+          model,
+          modelTurns,
+          ...(finalAssistantText !== undefined ? { finalAssistantText } : {}),
+          timeline: reportTimeline,
+          toolActivity,
+        }),
+      );
+    };
     await this.engine.ensureDiagnosticsInitialized();
     this.engine.setRunStatus("running");
+    if (options.promptSlotBinding !== undefined) {
+      this.engine.setPromptSlotBinding(options.promptSlotBinding);
+    }
     await this.engine.persistRunState();
     await this.engine.persistTranscript(transcript);
+    const initialTranscriptAt = this.engine.getRunState().updatedAt;
+    for (const [index, message] of transcript.entries()) {
+      reportTimeline.push(transcriptTimelineEntry(
+        message,
+        index,
+        initialTranscriptAt,
+      ));
+    }
     for (const message of transcript) {
       await options.onTranscriptEvent?.({ message, transcript });
     }
@@ -338,6 +508,12 @@ export class CfHarnessPromptLoop {
         const assistantMessage = createAssistantTranscriptMessage(response);
         transcript.push(assistantMessage);
         await this.engine.persistTranscript(transcript);
+        reportTimeline.push(transcriptTimelineEntry(
+          assistantMessage,
+          transcript.length - 1,
+          this.engine.getRunState().updatedAt,
+          modelTurns,
+        ));
         await options.onTranscriptEvent?.({
           message: assistantMessage,
           transcript,
@@ -346,6 +522,7 @@ export class CfHarnessPromptLoop {
         if (toolCalls.length === 0) {
           this.engine.setRunStatus("completed", "assistant_completed");
           await this.engine.persistRunState();
+          await persistRunReport(assistantMessage.content);
           return {
             model,
             finalAssistantText: assistantMessage.content,
@@ -357,10 +534,18 @@ export class CfHarnessPromptLoop {
         for (const toolCall of toolCalls) {
           const toolMessage = await this.#invokeToolCall(
             toolCall,
-            options.promptSlotBinding,
+            promptSlotBinding,
+            toolActivity.length + 1,
+            (activity) => toolActivity.push(activity),
           );
           transcript.push(toolMessage);
           await this.engine.persistTranscript(transcript);
+          reportTimeline.push(transcriptTimelineEntry(
+            toolMessage,
+            transcript.length - 1,
+            this.engine.getRunState().updatedAt,
+            modelTurns,
+          ));
           await options.onTranscriptEvent?.({
             message: toolMessage,
             transcript,
@@ -373,6 +558,7 @@ export class CfHarnessPromptLoop {
       try {
         await this.engine.persistRunState();
         await this.engine.persistTranscript(transcript);
+        await persistRunReport();
       } catch {
         // Preserve the original model/tool failure when cleanup persistence also fails.
       }
@@ -385,6 +571,7 @@ export class CfHarnessPromptLoop {
     this.engine.setRunStatus("failed", "max_model_turns");
     await this.engine.persistRunState();
     await this.engine.persistTranscript(transcript);
+    await persistRunReport();
     throw turnLimitError;
   }
 
@@ -403,6 +590,8 @@ export class CfHarnessPromptLoop {
   async #invokeToolCall(
     toolCall: HarnessToolCall,
     promptSlotBinding?: PromptSlotBinding,
+    sequence = 1,
+    recordActivity: (activity: HarnessToolActivity) => void = () => {},
   ): Promise<HarnessToolTranscriptMessage> {
     if (!isBuiltinToolId(toolCall.function.name)) {
       throw new Error(
@@ -415,6 +604,41 @@ export class CfHarnessPromptLoop {
         `unknown builtin tool requested: ${toolCall.function.name}`,
       );
     }
+    const parsedInputForDeniedTool = tryParseToolArguments(toolCall);
+    const deniedToolInputSummary = parsedInputForDeniedTool === undefined
+      ? undefined
+      : await summarizeToolInput(
+        toolCall.function.name,
+        parsedInputForDeniedTool,
+      );
+    const policyEventIndexes: number[] = [];
+    const activityStartedAt = this.engine.getRunState().updatedAt;
+    const activityEndedAt = (): string => this.engine.getRunState().updatedAt;
+    const baseActivity = (
+      policyDecision: HarnessToolPolicyDecision,
+      executionStatus: HarnessToolActivity["executionStatus"],
+    ): Omit<HarnessToolActivity, "type"> => ({
+      runId: this.engine.getRunState().runId,
+      sequence,
+      startedAt: activityStartedAt,
+      endedAt: activityEndedAt(),
+      toolCallId: toolCall.id,
+      toolId: toolCall.function.name,
+      effectClass: tool.descriptor.effectClass,
+      cfcEnforcementMode: this.engine.getRunState().cfcEnforcementMode,
+      policyDecision,
+      executionStatus,
+      ...(promptSlotBinding !== undefined
+        ? { promptSlot: promptSlotBinding }
+        : {}),
+    });
+    const recordPolicyEvent = async (
+      event: Parameters<CfHarnessEngine["recordPolicyEvent"]>[0],
+    ): Promise<void> => {
+      const index = this.engine.getRunState().policyEvents.length;
+      await this.engine.recordPolicyEvent(event);
+      policyEventIndexes.push(index);
+    };
     if (
       this.#allowedToolIds !== undefined &&
       !this.#allowedToolIds.has(toolCall.function.name)
@@ -422,13 +646,27 @@ export class CfHarnessPromptLoop {
       const denial = makeObservationDenied("not-authorized", {
         detail: `${toolCall.function.name} is not allowed in this run`,
       });
-      await this.engine.recordPolicyEvent({
+      await recordPolicyEvent({
         severity: "denied",
         mode: this.engine.getRunState().cfcEnforcementMode,
         toolId: toolCall.function.name,
         toolCallId: toolCall.id,
+        ...(promptSlotBinding !== undefined
+          ? { promptSlot: promptSlotBinding }
+          : {}),
+        ...(deniedToolInputSummary !== undefined
+          ? { toolInputSummary: deniedToolInputSummary }
+          : {}),
         detail: denial.detail ?? `${toolCall.function.name} is not allowed`,
         observationDenied: denial,
+      });
+      recordActivity({
+        type: "cf-harness.tool-activity",
+        ...baseActivity("denied", "not-run"),
+        ...(deniedToolInputSummary !== undefined
+          ? { toolInputSummary: deniedToolInputSummary }
+          : {}),
+        ...optionalPolicyEventIndexes(policyEventIndexes),
       });
       return {
         role: "tool",
@@ -437,34 +675,52 @@ export class CfHarnessPromptLoop {
         content: JSON.stringify(denial),
       };
     }
-    const input = parseToolArguments(toolCall);
+    const input = parsedInputForDeniedTool ?? parseToolArguments(toolCall);
+    const toolInputSummary = deniedToolInputSummary ??
+      await summarizeToolInput(toolCall.function.name, input);
     const decision = evaluateToolPolicy(
       this.engine.getRunState().cfcEnforcementMode,
       tool.descriptor,
       promptSlotBinding,
       input,
     );
+    let policyDecision: HarnessToolPolicyDecision = "allowed";
     if (decision.warningDetail !== undefined) {
-      await this.engine.recordPolicyEvent({
+      await recordPolicyEvent({
         severity: "warning",
         mode: this.engine.getRunState().cfcEnforcementMode,
         toolId: toolCall.function.name,
         toolCallId: toolCall.id,
+        ...(promptSlotBinding !== undefined
+          ? { promptSlot: promptSlotBinding }
+          : {}),
+        toolInputSummary,
         detail: decision.warningDetail,
       });
+      policyDecision = "warned";
     }
     if (!decision.allowed) {
       const denial = decision.denial ??
         makeObservationDenied("not-authorized", {
           detail: `${toolCall.function.name} was denied`,
         });
-      await this.engine.recordPolicyEvent({
+      await recordPolicyEvent({
         severity: "denied",
         mode: this.engine.getRunState().cfcEnforcementMode,
         toolId: toolCall.function.name,
         toolCallId: toolCall.id,
+        ...(promptSlotBinding !== undefined
+          ? { promptSlot: promptSlotBinding }
+          : {}),
+        toolInputSummary,
         detail: denial.detail ?? `${toolCall.function.name} was denied`,
         observationDenied: denial,
+      });
+      recordActivity({
+        type: "cf-harness.tool-activity",
+        ...baseActivity("denied", "not-run"),
+        toolInputSummary,
+        ...optionalPolicyEventIndexes(policyEventIndexes),
       });
       return {
         role: "tool",
@@ -473,10 +729,34 @@ export class CfHarnessPromptLoop {
         content: JSON.stringify(denial),
       };
     }
-    const result = await this.#invokeBuiltinTool(
-      toolCall.function.name,
-      input,
-    );
+    let result: {
+      output: Awaited<
+        ReturnType<CfHarnessEngine["invokeBuiltinTool"]>
+      >["output"];
+      resultRef: ToolResultRef;
+    };
+    try {
+      result = await this.#invokeBuiltinTool(
+        toolCall.function.name,
+        input,
+      );
+    } catch (error) {
+      recordActivity({
+        type: "cf-harness.tool-activity",
+        ...baseActivity(policyDecision, "failed"),
+        toolInputSummary,
+        ...optionalPolicyEventIndexes(policyEventIndexes),
+        errorDetail: toErrorDetail(error),
+      });
+      throw error;
+    }
+    recordActivity({
+      type: "cf-harness.tool-activity",
+      ...baseActivity(policyDecision, "completed"),
+      toolInputSummary,
+      ...optionalPolicyEventIndexes(policyEventIndexes),
+      resultRef: result.resultRef,
+    });
     return {
       role: "tool",
       toolCallId: toolCall.id,

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -1,5 +1,6 @@
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { HarnessPolicyEvent } from "./contracts/policy.ts";
+import type { PromptSlotBinding } from "./contracts/prompt-slot.ts";
 import type { ToolResultRef } from "./contracts/tool-result.ts";
 import type {
   HarnessCapabilitySnapshot,
@@ -29,10 +30,12 @@ export interface HarnessRunState {
   endedAt?: string;
   terminalReason?: HarnessRunTerminalReason;
   cfcEnforcementMode: CfcEnforcementMode;
+  promptSlotBinding?: PromptSlotBinding;
   currentDir: string;
   model?: string;
   artifactRoot?: string;
   transcriptPath?: string;
+  runReportPath?: string;
   capabilitySnapshot?: HarnessCapabilitySnapshot;
   capabilitiesPath?: string;
   policyEvents: HarnessPolicyEvent[];
@@ -47,10 +50,12 @@ export interface CreateHarnessRunStateOptions {
   endedAt?: string;
   terminalReason?: HarnessRunTerminalReason;
   cfcEnforcementMode: CfcEnforcementMode;
+  promptSlotBinding?: PromptSlotBinding;
   currentDir: string;
   model?: string;
   artifactRoot?: string;
   transcriptPath?: string;
+  runReportPath?: string;
   capabilitySnapshot?: HarnessCapabilitySnapshot;
   capabilitiesPath?: string;
   failureRecords?: HarnessFailureRecord[];
@@ -72,6 +77,9 @@ export const createHarnessRunState = (
       ? { terminalReason: options.terminalReason }
       : {}),
     cfcEnforcementMode: options.cfcEnforcementMode,
+    ...(options.promptSlotBinding !== undefined
+      ? { promptSlotBinding: options.promptSlotBinding }
+      : {}),
     currentDir: options.currentDir,
     ...(options.model !== undefined ? { model: options.model } : {}),
     ...(options.artifactRoot !== undefined
@@ -79,6 +87,9 @@ export const createHarnessRunState = (
       : {}),
     ...(options.transcriptPath !== undefined
       ? { transcriptPath: options.transcriptPath }
+      : {}),
+    ...(options.runReportPath !== undefined
+      ? { runReportPath: options.runReportPath }
       : {}),
     ...(options.capabilitySnapshot !== undefined
       ? { capabilitySnapshot: options.capabilitySnapshot }
@@ -140,6 +151,16 @@ export const appendHarnessPolicyEvent = (
   policyEvents: [...state.policyEvents, event],
 });
 
+export const setHarnessPromptSlotBinding = (
+  state: HarnessRunState,
+  promptSlotBinding: PromptSlotBinding,
+  now = new Date().toISOString(),
+): HarnessRunState => ({
+  ...state,
+  promptSlotBinding,
+  updatedAt: now,
+});
+
 export const appendHarnessFailureRecord = (
   state: HarnessRunState,
   failure: HarnessFailureRecord,
@@ -172,6 +193,16 @@ export const setHarnessTranscriptPath = (
 ): HarnessRunState => ({
   ...state,
   transcriptPath,
+  updatedAt: now,
+});
+
+export const setHarnessRunReportPath = (
+  state: HarnessRunState,
+  runReportPath: string,
+  now = new Date().toISOString(),
+): HarnessRunState => ({
+  ...state,
+  runReportPath,
   updatedAt: now,
 });
 

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -4,6 +4,7 @@ import { normalize } from "@std/path/posix";
 import {
   createFileSystemHarnessArtifactStore,
   readHarnessRunArtifacts,
+  readHarnessRunReport,
   readHarnessRunState,
   readHarnessTranscript,
 } from "../src/artifacts.ts";
@@ -254,16 +255,20 @@ Deno.test({
 
       const runRoot = join(artifactRoot, "run-loop-persisted");
       const transcriptPath = join(runRoot, "transcript.json");
+      const runReportPath = join(runRoot, "run-report.json");
       const persistedState = await readHarnessRunState(
         join(runRoot, "run-state.json"),
       );
+      const persistedReport = await readHarnessRunReport(runReportPath);
 
       assertEquals(result.runState.transcriptPath, transcriptPath);
+      assertEquals(result.runState.runReportPath, runReportPath);
       assertEquals(
         await readHarnessTranscript(transcriptPath),
         result.transcript,
       );
       assertEquals(persistedState.transcriptPath, transcriptPath);
+      assertEquals(persistedState.runReportPath, runReportPath);
       assertEquals(persistedState.artifactRoot, runRoot);
       assertEquals(persistedState.endedAt, "2026-04-15T21:10:07.000Z");
       assertEquals(persistedState.terminalReason, "assistant_completed");
@@ -273,6 +278,292 @@ Deno.test({
         persistedState.capabilitySnapshot?.commands.python3.present,
         true,
       );
+      assertEquals(persistedReport.type, "cf-harness.run-report");
+      assertEquals(persistedReport.runId, "run-loop-persisted");
+      assertEquals(persistedReport.status, "completed");
+      assertEquals(persistedReport.model, "gpt-5.4");
+      assertEquals(persistedReport.modelTurns, 2);
+      assertEquals(persistedReport.finalAssistantText, "Persisted summary.");
+      assertEquals(persistedReport.policyEventCounts, {
+        total: 0,
+        warnings: 0,
+        denied: 0,
+      });
+      assertEquals(persistedReport.toolActivity.length, 1);
+      assertEquals(persistedReport.toolActivity[0], {
+        type: "cf-harness.tool-activity",
+        runId: "run-loop-persisted",
+        sequence: 1,
+        startedAt: "2026-04-15T21:10:05.000Z",
+        endedAt: "2026-04-15T21:10:07.000Z",
+        toolCallId: "call-1",
+        toolId: "read_file",
+        effectClass: "read",
+        cfcEnforcementMode: "disabled",
+        policyDecision: "allowed",
+        executionStatus: "completed",
+        toolInputSummary: {
+          type: "cf-harness.tool-input-summary",
+          toolId: "read_file",
+          path: "notes/todo.txt",
+        },
+        resultRef: result.runState.toolOutputs[0],
+      });
+      assertEquals(
+        persistedReport.timeline.map((entry) => entry.kind),
+        [
+          "run_started",
+          "transcript_message",
+          "transcript_message",
+          "tool_activity",
+          "transcript_message",
+          "transcript_message",
+          "run_finished",
+        ],
+      );
+      assertEquals(
+        persistedReport.timeline
+          .filter((entry) => entry.kind === "transcript_message")
+          .map((entry) => entry.role),
+        ["user", "assistant", "tool", "assistant"],
+      );
+      assertEquals(
+        persistedReport.timeline.find((entry) =>
+          entry.kind === "tool_activity"
+        ),
+        {
+          type: "cf-harness.timeline-entry",
+          sequence: 4,
+          kind: "tool_activity",
+          at: "2026-04-15T21:10:05.000Z",
+          endedAt: "2026-04-15T21:10:07.000Z",
+          toolActivitySequence: 1,
+          toolCallId: "call-1",
+          toolId: "read_file",
+          policyDecision: "allowed",
+          executionStatus: "completed",
+        },
+      );
+      assertEquals(
+        persistedReport.timeline[persistedReport.timeline.length - 1],
+        {
+          type: "cf-harness.timeline-entry",
+          sequence: 7,
+          kind: "run_finished",
+          at: "2026-04-15T21:10:07.000Z",
+          status: "completed",
+          terminalReason: "assistant_completed",
+        },
+      );
+    } finally {
+      await Deno.remove(artifactRoot, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "CfHarnessEngine persists prompt slot binding in run state artifacts",
+  permissions: { read: true, write: true },
+  async fn() {
+    const artifactRoot = await Deno.makeTempDir({
+      prefix: "cf-harness-prompt-slot-",
+    });
+    try {
+      const promptSlotBinding = {
+        type: "cf-harness.prompt-slot-binding",
+        role: "direct-command",
+        kernelName: "cf-harness",
+        surface: "test",
+        subject: "artifact-test",
+        eventId: "event-artifact",
+      } as const;
+      const engine = new CfHarnessEngine({
+        artifactRoot,
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runId: "run-prompt-slot",
+        cfcEnforcementMode: "observe",
+      });
+
+      engine.setPromptSlotBinding(promptSlotBinding);
+      await engine.persistRunState();
+
+      const persistedState = await readHarnessRunState(
+        join(artifactRoot, "run-prompt-slot", "run-state.json"),
+      );
+      assertEquals(persistedState.promptSlotBinding, promptSlotBinding);
+    } finally {
+      await Deno.remove(artifactRoot, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "CfHarnessPromptLoop persists denied tool activity in the run report",
+  permissions: { read: true, write: true },
+  async fn() {
+    const artifactRoot = await Deno.makeTempDir({
+      prefix: "cf-harness-denied-report-",
+    });
+    try {
+      const loop = new CfHarnessPromptLoop({
+        apiKey: "test-key",
+        engine: new CfHarnessEngine({
+          artifactRoot,
+          sandboxRuntime: new FakeSandboxRuntime(),
+          runId: "run-denied-report",
+          model: "gpt-5.4",
+          cfcEnforcementMode: "enforce-explicit",
+          now: (() => {
+            const timestamps = [
+              "2026-04-15T21:20:00.000Z",
+              "2026-04-15T21:20:01.000Z",
+              "2026-04-15T21:20:02.000Z",
+              "2026-04-15T21:20:03.000Z",
+              "2026-04-15T21:20:04.000Z",
+              "2026-04-15T21:20:05.000Z",
+              "2026-04-15T21:20:06.000Z",
+              "2026-04-15T21:20:07.000Z",
+              "2026-04-15T21:20:08.000Z",
+              "2026-04-15T21:20:09.000Z",
+            ];
+            return () => timestamps.shift() ?? "2026-04-15T21:20:10.000Z";
+          })(),
+        }),
+        fetchFn: (_input, init) => {
+          const body = JSON.parse(String(init?.body)) as {
+            messages: Array<{ role: string }>;
+          };
+          const payload = body.messages.some((message) =>
+              message.role === "tool"
+            )
+            ? {
+              choices: [{
+                index: 0,
+                message: {
+                  role: "assistant",
+                  content: "Write was denied.",
+                },
+              }],
+            }
+            : {
+              choices: [{
+                index: 0,
+                message: {
+                  role: "assistant",
+                  content: "",
+                  tool_calls: [{
+                    id: "call-denied-report",
+                    type: "function",
+                    function: {
+                      name: "write_file",
+                      arguments: JSON.stringify({
+                        path: "notes/out.txt",
+                        content: "nope",
+                      }),
+                    },
+                  }],
+                },
+              }],
+            };
+          return Promise.resolve(
+            new Response(JSON.stringify(payload), { status: 200 }),
+          );
+        },
+      });
+
+      const result = await loop.runPrompt({
+        prompt: "Write the output file.",
+      });
+
+      const runReport = await readHarnessRunReport(
+        join(artifactRoot, "run-denied-report", "run-report.json"),
+      );
+
+      assertEquals(result.runState.toolOutputs, []);
+      assertEquals(runReport.policyEventCounts, {
+        total: 1,
+        warnings: 0,
+        denied: 1,
+      });
+      assertEquals(runReport.toolActivity, [{
+        type: "cf-harness.tool-activity",
+        runId: "run-denied-report",
+        sequence: 1,
+        startedAt: "2026-04-15T21:20:05.000Z",
+        endedAt: "2026-04-15T21:20:06.000Z",
+        toolCallId: "call-denied-report",
+        toolId: "write_file",
+        effectClass: "write",
+        cfcEnforcementMode: "enforce-explicit",
+        policyDecision: "denied",
+        executionStatus: "not-run",
+        toolInputSummary: {
+          type: "cf-harness.tool-input-summary",
+          toolId: "write_file",
+          path: "notes/out.txt",
+          mode: "replace",
+          contentBytes: 4,
+          contentDigest:
+            "sha256:ca3704aa0b06f5954c79ee837faa152d84d6b2d42838f0637a15eda8337dbdce",
+        },
+        policyEventIndexes: [0],
+      }]);
+      assertEquals(
+        runReport.timeline.map((entry) => entry.kind),
+        [
+          "run_started",
+          "transcript_message",
+          "transcript_message",
+          "tool_activity",
+          "policy_event",
+          "failure_record",
+          "transcript_message",
+          "transcript_message",
+          "run_finished",
+        ],
+      );
+      assertEquals(
+        runReport.timeline.find((entry) => entry.kind === "policy_event"),
+        {
+          type: "cf-harness.timeline-entry",
+          sequence: 5,
+          kind: "policy_event",
+          at: "2026-04-15T21:20:06.000Z",
+          policyEventIndex: 0,
+          severity: "denied",
+          toolCallId: "call-denied-report",
+          toolId: "write_file",
+        },
+      );
+      assertEquals(
+        runReport.timeline.find((entry) => entry.kind === "tool_activity"),
+        {
+          type: "cf-harness.timeline-entry",
+          sequence: 4,
+          kind: "tool_activity",
+          at: "2026-04-15T21:20:05.000Z",
+          endedAt: "2026-04-15T21:20:06.000Z",
+          toolActivitySequence: 1,
+          toolCallId: "call-denied-report",
+          toolId: "write_file",
+          policyDecision: "denied",
+          executionStatus: "not-run",
+        },
+      );
+      assertEquals(
+        runReport.timeline.find((entry) => entry.kind === "failure_record"),
+        {
+          type: "cf-harness.timeline-entry",
+          sequence: 6,
+          kind: "failure_record",
+          at: "2026-04-15T21:20:06.000Z",
+          failureRecordIndex: 0,
+          failureKind: "tool_not_allowed",
+          source: "policy_event",
+          toolId: "write_file",
+        },
+      );
+      assertEquals(JSON.stringify(runReport).includes("nope"), false);
     } finally {
       await Deno.remove(artifactRoot, { recursive: true });
     }

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -16,6 +16,7 @@ import { CfHarnessEngine } from "../src/engine.ts";
 import type {
   HarnessPromptLoopResult,
   RunHarnessPromptOptions,
+  RunHarnessTranscriptOptions,
 } from "../src/prompt-loop.ts";
 
 const createIoBuffers = (): {
@@ -480,6 +481,8 @@ Deno.test("runCfHarnessCli executes the prompt loop and prints result metadata",
                   artifactRoot: "/tmp/project/.cf-harness-artifacts/run-cli",
                   transcriptPath:
                     "/tmp/project/.cf-harness-artifacts/run-cli/transcript.json",
+                  runReportPath:
+                    "/tmp/project/.cf-harness-artifacts/run-cli/run-report.json",
                   policyEvents: [],
                   toolOutputs: [],
                 },
@@ -531,6 +534,8 @@ Deno.test("runCfHarnessCli executes the prompt loop and prints result metadata",
           artifactRoot: "/tmp/project/.cf-harness-artifacts/run-cli",
           transcriptPath:
             "/tmp/project/.cf-harness-artifacts/run-cli/transcript.json",
+          runReportPath:
+            "/tmp/project/.cf-harness-artifacts/run-cli/run-report.json",
           policyEvents: [],
           toolOutputs: [],
         },
@@ -811,6 +816,8 @@ Deno.test("runCfHarnessCli writes a structured batch result sidecar when request
                   "/tmp/project/.cf-harness-artifacts/run-cli-batch-json",
                 transcriptPath:
                   "/tmp/project/.cf-harness-artifacts/run-cli-batch-json/transcript.json",
+                runReportPath:
+                  "/tmp/project/.cf-harness-artifacts/run-cli-batch-json/run-report.json",
                 policyEvents: [{
                   type: "cf-harness.policy-event",
                   severity: "denied",
@@ -855,6 +862,8 @@ Deno.test("runCfHarnessCli writes a structured batch result sidecar when request
         artifactRoot: "/tmp/project/.cf-harness-artifacts/run-cli-batch-json",
         transcriptPath:
           "/tmp/project/.cf-harness-artifacts/run-cli-batch-json/transcript.json",
+        runReportPath:
+          "/tmp/project/.cf-harness-artifacts/run-cli-batch-json/run-report.json",
         policyEvents: [{
           type: "cf-harness.policy-event",
           severity: "denied",
@@ -1051,6 +1060,15 @@ Deno.test("runCfHarnessCli allows no-auth gateway mode without an API key", asyn
 
 Deno.test("runCfHarnessCli can resume from persisted run artifacts", async () => {
   const { io, stdout, stderr } = createIoBuffers();
+  let runTranscriptOptions: RunHarnessTranscriptOptions | undefined;
+  const promptSlotBinding = {
+    type: "cf-harness.prompt-slot-binding",
+    role: "context",
+    kernelName: "cf-harness",
+    surface: "loom",
+    subject: "original-run",
+    eventId: "event-original",
+  } as const;
   const exitCode = await runCfHarnessCli(
     ["--resume-run", "/tmp/project/.cf-harness-artifacts/run-1/run-state.json"],
     {
@@ -1073,6 +1091,7 @@ Deno.test("runCfHarnessCli can resume from persisted run artifacts", async () =>
             createdAt: "2026-04-15T22:10:00.000Z",
             updatedAt: "2026-04-15T22:10:01.000Z",
             cfcEnforcementMode: "disabled",
+            promptSlotBinding,
             currentDir: "/workspace",
             model: "gpt-5.4",
             artifactRoot: "/tmp/project/.cf-harness-artifacts/run-1",
@@ -1088,8 +1107,10 @@ Deno.test("runCfHarnessCli can resume from persisted run artifacts", async () =>
       },
       createPromptLoop: () => ({
         runPrompt: () => Promise.reject(new Error("unexpected prompt path")),
-        runTranscript: ({ transcript, model }) =>
-          Promise.resolve(
+        runTranscript: (options) => {
+          runTranscriptOptions = options;
+          const { transcript, model } = options;
+          return Promise.resolve(
             ({
               model: model ?? "gpt-5.4",
               finalAssistantText: "Resumed.",
@@ -1113,12 +1134,14 @@ Deno.test("runCfHarnessCli can resume from persisted run artifacts", async () =>
                 toolOutputs: [],
               },
             }) satisfies HarnessPromptLoopResult,
-          ),
+          );
+        },
       }),
     },
   );
 
   assertEquals(exitCode, 0);
+  assertEquals(runTranscriptOptions?.promptSlotBinding, promptSlotBinding);
   assertEquals(stdout, [
     formatCfHarnessCliResult({
       model: "gpt-5.4",

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -146,6 +146,34 @@ Deno.test("CfHarnessEngine records tool outputs into run state on success", asyn
   );
 });
 
+Deno.test("CfHarnessEngine records prompt slot binding into run state", () => {
+  const promptSlotBinding = {
+    type: "cf-harness.prompt-slot-binding",
+    role: "direct-command",
+    kernelName: "cf-harness",
+    surface: "test",
+    subject: "engine-test",
+    eventId: "event-engine",
+  } as const;
+  const engine = new CfHarnessEngine({
+    sandboxRuntime: new FakeSandboxRuntime(),
+    runId: "run-prompt-slot",
+    cfcEnforcementMode: "observe",
+    now: (() => {
+      const timestamps = [
+        "2026-04-17T19:00:00.000Z",
+        "2026-04-17T19:00:01.000Z",
+      ];
+      return () => timestamps.shift() ?? "2026-04-17T19:00:02.000Z";
+    })(),
+  });
+
+  engine.setPromptSlotBinding(promptSlotBinding);
+
+  assertEquals(engine.getRunState().promptSlotBinding, promptSlotBinding);
+  assertEquals(engine.getRunState().updatedAt, "2026-04-17T19:00:01.000Z");
+});
+
 Deno.test("CfHarnessEngine marks the run as failed when a tool invocation errors", async () => {
   const engine = new CfHarnessEngine({
     sandboxRuntime: new FakeSandboxRuntime([], new Error("sandbox boom")),

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -11,6 +11,25 @@ import type {
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
+import type { PromptSlotBinding } from "../src/contracts/prompt-slot.ts";
+
+const directPromptSlotBinding: PromptSlotBinding = {
+  type: "cf-harness.prompt-slot-binding",
+  role: "direct-command",
+  kernelName: "cf-harness",
+  surface: "test",
+  subject: "direct-test",
+  eventId: "event-direct",
+};
+
+const contextPromptSlotBinding: PromptSlotBinding = {
+  type: "cf-harness.prompt-slot-binding",
+  role: "context",
+  kernelName: "cf-harness",
+  surface: "test",
+  subject: "context-test",
+  eventId: "event-context",
+};
 
 class FakeSandboxRuntime implements SandboxRuntime {
   readonly kind = "docker-runsc-cfc" as const;
@@ -82,6 +101,10 @@ class FailingArtifactStore implements HarnessArtifactStore {
 
   persistCapabilitySnapshot(): Promise<string> {
     return Promise.resolve(`${this.runRoot}/capabilities.json`);
+  }
+
+  persistRunReport(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/run-report.json`);
   }
 
   persistToolOutput(): Promise<string> {
@@ -414,9 +437,11 @@ Deno.test("CfHarnessPromptLoop completes a direct assistant response without too
 
   const result = await loop.runPrompt({
     prompt: "Say hi.",
+    promptSlotBinding: directPromptSlotBinding,
   });
 
   assertEquals(result.finalAssistantText, "No tool call needed.");
+  assertEquals(result.runState.promptSlotBinding, directPromptSlotBinding);
   assertEquals(result.runState.status, "completed");
   assertEquals(result.runState.policyEvents, []);
   assertEquals(result.runState.toolOutputs, []);
@@ -638,9 +663,21 @@ Deno.test("CfHarnessPromptLoop records observe-mode warnings and still executes 
     mode: "observe",
     toolId: "bash",
     toolCallId: "call-observe",
+    toolInputSummary: {
+      type: "cf-harness.tool-input-summary",
+      toolId: "bash",
+      commandBytes: 11,
+      commandDigest:
+        "sha256:17bc0d7e89ddefaf38bce5f3bedcd6309b9453c5d85dafd24d1243bb1e505e8c",
+    },
     detail: "bash would require direct-command authorization in enforce modes",
     at: "2026-04-15T22:30:04.000Z",
   }]);
+  assertEquals(
+    JSON.stringify(result.runState.policyEvents[0]?.toolInputSummary)
+      .includes("echo warned"),
+    false,
+  );
   assertEquals(result.runState.failureRecords, []);
   assertEquals(
     result.transcript.at(-2),
@@ -739,6 +776,15 @@ Deno.test("CfHarnessPromptLoop returns observation-denied tool content in enforc
     mode: "enforce-explicit",
     toolId: "write_file",
     toolCallId: "call-denied",
+    toolInputSummary: {
+      type: "cf-harness.tool-input-summary",
+      toolId: "write_file",
+      path: "notes/out.txt",
+      mode: "replace",
+      contentBytes: 4,
+      contentDigest:
+        "sha256:ca3704aa0b06f5954c79ee837faa152d84d6b2d42838f0637a15eda8337dbdce",
+    },
     detail:
       "write_file requires direct-command authorization in enforce-explicit",
     observationDenied: {
@@ -749,6 +795,11 @@ Deno.test("CfHarnessPromptLoop returns observation-denied tool content in enforc
     },
     at: "2026-04-15T22:40:04.000Z",
   }]);
+  assertEquals(
+    JSON.stringify(result.runState.policyEvents[0]?.toolInputSummary)
+      .includes("nope"),
+    false,
+  );
   assertEquals(result.runState.primaryFailure?.kind, "tool_not_allowed");
   assertEquals(
     result.transcript.at(-2),
@@ -836,6 +887,13 @@ Deno.test("CfHarnessPromptLoop denies tool calls outside the configured allowlis
     mode: "disabled",
     toolId: "bash",
     toolCallId: "call-bash-denied",
+    toolInputSummary: {
+      type: "cf-harness.tool-input-summary",
+      toolId: "bash",
+      commandBytes: 3,
+      commandDigest:
+        "sha256:a1159e9df3670d549d04524532629f5477ceb7deec9b45e47e8c009506ecb2c8",
+    },
     detail: "bash is not allowed in this run",
     observationDenied: {
       type: "cf-harness.observation-denied",
@@ -857,5 +915,145 @@ Deno.test("CfHarnessPromptLoop denies tool calls outside the configured allowlis
         detail: "bash is not allowed in this run",
       }),
     },
+  );
+});
+
+Deno.test("CfHarnessPromptLoop includes read_file input summaries on strict-mode denials", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-read-file-strict",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-strict",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-read-denied",
+                type: "function",
+                function: {
+                  name: "read_file",
+                  arguments: JSON.stringify({
+                    path: "notes/private.txt",
+                    maxBytes: 512,
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Read denied.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Read the private note.",
+  });
+
+  assertEquals(result.finalAssistantText, "Read denied.");
+  assertEquals(result.runState.toolOutputs, []);
+  assertEquals(result.runState.policyEvents[0]?.toolInputSummary, {
+    type: "cf-harness.tool-input-summary",
+    toolId: "read_file",
+    path: "notes/private.txt",
+    maxBytes: 512,
+  });
+  assertEquals(
+    result.runState.policyEvents[0]?.detail,
+    "read_file requires direct-command authorization in enforce-strict",
+  );
+});
+
+Deno.test("CfHarnessPromptLoop includes prompt slot context on policy events", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-policy-context",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-policy-context",
+                type: "function",
+                function: {
+                  name: "write_file",
+                  arguments: JSON.stringify({
+                    path: "notes/out.txt",
+                    content: "nope",
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Denied with context.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Write the output file.",
+    promptSlotBinding: contextPromptSlotBinding,
+  });
+
+  assertEquals(result.finalAssistantText, "Denied with context.");
+  assertEquals(result.runState.promptSlotBinding, contextPromptSlotBinding);
+  assertEquals(
+    result.runState.policyEvents[0]?.promptSlot,
+    contextPromptSlotBinding,
+  );
+  assertEquals(result.runState.policyEvents[0]?.toolInputSummary, {
+    type: "cf-harness.tool-input-summary",
+    toolId: "write_file",
+    path: "notes/out.txt",
+    mode: "replace",
+    contentBytes: 4,
+    contentDigest:
+      "sha256:ca3704aa0b06f5954c79ee837faa152d84d6b2d42838f0637a15eda8337dbdce",
+  });
+  assertEquals(
+    result.runState.policyEvents[0]?.detail,
+    "write_file requires direct-command authorization in enforce-explicit",
   );
 });


### PR DESCRIPTION
## Summary
- persist `run-report.json` alongside cf-harness run artifacts
- include run summary, policy event counts, policy events, tool outputs, tool activity, and compact timeline entries
- add provenance context for prompt slots and redacted tool input summaries in policy/audit output

## Tests
- `deno task test` in `packages/cf-harness`
- `deno fmt --check` on touched cf-harness files
