### PR TITLE
Fix cf-harness Docker user default on macOS

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -136,6 +136,11 @@ The integration suite requires a working local Docker + `runsc-cfc` environment.
 By default it also uses the published kitchen-sink image above, unless you
 override `CF_HARNESS_INTEGRATION_IMAGE`.
 
+On Linux, Docker/runsc runs default to the host UID/GID. On macOS, the default
+omits `--user` because Docker Desktop bind mounts may expose host files as
+`root:root`, which prevents non-root container users from writing mounted Loom
+workspaces. An explicit `containerUser` still overrides the platform default.
+
 ## Related Docs
 
 - [IMPLEMENTATION_PLAN.md](docs/IMPLEMENTATION_PLAN.md)

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -25,8 +25,10 @@ const readEnvVar = (name: string): string | undefined => {
   }
 };
 
-const resolveDefaultContainerUser = (): string | undefined => {
-  if (Deno.build.os === "windows") {
+export const resolveDefaultContainerUser = (
+  hostOs: typeof Deno.build.os = Deno.build.os,
+): string | undefined => {
+  if (hostOs === "windows" || hostOs === "darwin") {
     return undefined;
   }
   const uidFromEnv = readEnvVar("UID");

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -1,7 +1,8 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertMatch, assertThrows } from "@std/assert";
 import {
   DEFAULT_DOCKER_RUNSC_IMAGE,
   DockerRunscSandboxRuntime,
+  resolveDefaultContainerUser,
   resolveDockerRunscSandboxConfig,
 } from "../src/sandbox/docker-runsc.ts";
 import type {
@@ -36,6 +37,18 @@ Deno.test("resolveDockerRunscSandboxConfig fills the expected defaults", () => {
   assertEquals(config.shellPath, "/bin/sh");
   assertEquals(config.dockerNetworkMode, "none");
   assertEquals(config.extraDockerArgs, []);
+});
+
+Deno.test("resolveDefaultContainerUser omits default --user on macOS", () => {
+  assertEquals(resolveDefaultContainerUser("darwin"), undefined);
+});
+
+Deno.test("resolveDefaultContainerUser keeps host UID/GID default on Linux", () => {
+  if (Deno.build.os === "windows") {
+    return;
+  }
+
+  assertMatch(resolveDefaultContainerUser("linux") ?? "", /^\d+:\d+$/);
 });
 
 Deno.test("DockerRunscSandboxRuntime builds a docker run invocation", async () => {


### PR DESCRIPTION
## Summary
- omit the default Docker/runsc --user flag on macOS so Docker Desktop bind mounts can be written when they appear root-owned in the container
- preserve host UID/GID defaults on Linux and explicit containerUser overrides on every platform\n- document the platform split in the cf-harness README

## Verification
- deno fmt packages/cf-harness/src/sandbox/docker-runsc.ts packages/cf-harness/test/docker-runsc-sandbox.test.ts packages/cf-harness/README.md
- deno test -A packages/cf-harness/test/docker-runsc-sandbox.test.ts
- deno task test (packages/cf-harness)
- deno task check (repo root)
- git diff --check

## Follow-up
- After merge/vendor bump, run a real local Loom gtd-ops write smoke on macOS to confirm Docker Desktop bind-mounted File Cabinet writes succeed.