### PR TITLE
feat(data-model): emit /quote for literal-only /-keyed plain objects

### DIFF
--- a/packages/data-model/json-encoding-modern.ts
+++ b/packages/data-model/json-encoding-modern.ts
@@ -36,9 +36,10 @@ function isEncodedInstance(v: JsonWireValue): boolean {
 }
 
 /**
- * Returns true if a serialized value `v` is quote-safe: it either needs no
- * decoding (primitive or plain object/array free of tag-wrapped forms), or it
- * is itself a /quote-wrapped literal that can be collapsed into a parent /quote.
+ * Returns true if the already-serialized wire value `v` can be embedded
+ * inside a /quote wrap without inner deserialization: primitives, plain
+ * objects/arrays free of non-/quote encoded instances, and /quote-wrapped
+ * values (which unquote() can collapse).
  */
 function isQuoteSafe(v: JsonWireValue): boolean {
   if (v === null || typeof v !== "object") return true;
@@ -46,14 +47,13 @@ function isQuoteSafe(v: JsonWireValue): boolean {
   if (!isEncodedInstance(v)) {
     return Object.values(v).every((item) => isQuoteSafe(item as JsonWireValue));
   }
-  // It is an encoded instance: safe only if it is a /quote wrapper.
   return Object.keys(v)[0] === "/quote";
 }
 
 /**
- * Recursively unwrap any /quote-wrapped values inside a serialized result,
- * restoring the original literal subtree so it can be re-wrapped by a parent
- * /quote without nesting.
+ * Recursively unwraps /quote forms so they can be embedded inside a parent
+ * /quote without double-wrapping. Non-/quote encoded instances are left as-is
+ * (they should not appear after an isQuoteSafe check passes).
  */
 function unquote(v: JsonWireValue): JsonWireValue {
   if (v === null || typeof v !== "object") return v;
@@ -318,17 +318,15 @@ export class JsonEncodingContext implements SerializationContext<string> {
     ) {
       result[key] = this.serialize(val, seen, registry);
     }
-
     seen.delete(value as object);
 
-    // Apply escaping per Section 5.6 for any plain object with a /-prefixed key.
-    // Use /quote when all serialized values are quote-safe (primitives, plain
-    // objects/arrays, or /quote-wrapped literals that can be collapsed); use
-    // /object otherwise.
+    // Apply escaping per Section 5.6 for plain objects with /-prefixed keys.
+    // Serialize all values first (post-pass), then check if all are quote-safe.
+    // If so, unwrap any /quote children and wrap the whole object with /quote.
+    // Otherwise wrap with /object so the decoder deserializes entries.
     const keys = Object.keys(result);
     if (keys.some((k) => k.startsWith("/"))) {
-      const allQuoteSafe = Object.values(result).every((v) => isQuoteSafe(v));
-      if (allQuoteSafe) {
+      if (Object.values(result).every((v) => isQuoteSafe(v))) {
         return this.wrapTag(TAGS.quote, unquote(result)) as JsonWireValue;
       }
       return this.wrapTag(TAGS.object, result) as JsonWireValue;

--- a/packages/data-model/json-encoding-modern.ts
+++ b/packages/data-model/json-encoding-modern.ts
@@ -181,16 +181,11 @@ export class JsonEncodingContext implements SerializationContext<string> {
       return null;
     }
 
-    const keys = Object.keys(data);
-    if (keys.length !== 1) {
+    if (!isEncodedInstance(data)) {
       return null;
     }
 
-    const key = keys[0];
-    if (!key.startsWith("/")) {
-      return null;
-    }
-
+    const key = Object.keys(data)[0];
     const tag = key.slice(1);
     const state = (data as Record<string, JsonWireValue>)[key];
     return { tag, state };

--- a/packages/data-model/json-encoding-modern.ts
+++ b/packages/data-model/json-encoding-modern.ts
@@ -51,15 +51,15 @@ function isQuoteSafe(v: JsonWireValue): boolean {
 }
 
 /**
- * Recursively unwraps /quote forms so they can be embedded inside a parent
- * /quote without double-wrapping. Non-/quote encoded instances are left as-is
- * (they should not appear after an isQuoteSafe check passes).
+ * Unwraps /quote forms one level so their literal content can be embedded
+ * directly inside a parent /quote. The inner content of a /quote is already
+ * literal and must not be recursed into.
  */
 function unquote(v: JsonWireValue): JsonWireValue {
   if (v === null || typeof v !== "object") return v;
   if (Array.isArray(v)) return v.map(unquote) as JsonWireValue;
   if (isEncodedInstance(v) && Object.keys(v)[0] === "/quote") {
-    return unquote((v as Record<string, JsonWireValue>)["/quote"]);
+    return (v as Record<string, JsonWireValue>)["/quote"];
   }
   return Object.fromEntries(
     Object.entries(v).map(([k, val]) => [k, unquote(val as JsonWireValue)]),
@@ -327,7 +327,10 @@ export class JsonEncodingContext implements SerializationContext<string> {
     const keys = Object.keys(result);
     if (keys.some((k) => k.startsWith("/"))) {
       if (Object.values(result).every((v) => isQuoteSafe(v))) {
-        return this.wrapTag(TAGS.quote, unquote(result)) as JsonWireValue;
+        const unquoted = Object.fromEntries(
+          Object.entries(result).map(([k, v]) => [k, unquote(v)]),
+        );
+        return this.wrapTag(TAGS.quote, unquoted) as JsonWireValue;
       }
       return this.wrapTag(TAGS.object, result) as JsonWireValue;
     }

--- a/packages/data-model/json-encoding-modern.ts
+++ b/packages/data-model/json-encoding-modern.ts
@@ -27,6 +27,26 @@ import { TAGS } from "./fabric-type-tags.ts";
 /** Shared default handler registry, created once. */
 const defaultRegistry: TypeHandlerRegistry = createDefaultRegistry();
 
+/** Returns true if `v` is a single-key object whose key starts with `/` —
+ * the wire form of an encoded instance (tag-wrapped value). */
+function isEncodedInstance(v: JsonWireValue): boolean {
+  if (v === null || typeof v !== "object" || Array.isArray(v)) return false;
+  const keys = Object.keys(v);
+  return keys.length === 1 && keys[0].startsWith("/");
+}
+
+/**
+ * Returns true if `v` contains no encoded instances anywhere in its subtree,
+ * meaning it is safe to embed directly inside a `/quote` wrapper without any
+ * further decoding by the deserializer.
+ */
+function isQuoteSafe(v: JsonWireValue): boolean {
+  if (v === null || typeof v !== "object") return true;
+  if (Array.isArray(v)) return v.every((item) => isQuoteSafe(item));
+  if (isEncodedInstance(v)) return false;
+  return Object.values(v).every((item) => isQuoteSafe(item as JsonWireValue));
+}
+
 /**
  * JSON encoding context implementing the `/<Type>@<Version>` wire format
  * from the formal spec (Section 5).
@@ -287,11 +307,16 @@ export class JsonEncodingContext implements SerializationContext<string> {
 
     seen.delete(value as object);
 
-    // Apply `TAGS.object` escaping per Section 5.6: wrap any plain object
-    // that has at least one /-prefixed key, not just single-key objects.
+    // Apply escaping per Section 5.6 for any plain object with a /-prefixed key.
+    // Use /quote when all serialized values are quote-safe (no tag-wrapped forms
+    // anywhere in their subtree); use /object when any value required encoding.
     const keys = Object.keys(result);
     if (keys.some((k) => k.startsWith("/"))) {
-      return this.wrapTag(TAGS.object, result) as JsonWireValue;
+      const allQuoteSafe = Object.values(result).every((v) => isQuoteSafe(v));
+      return this.wrapTag(
+        allQuoteSafe ? TAGS.quote : TAGS.object,
+        result,
+      ) as JsonWireValue;
     }
 
     return result as JsonWireValue;

--- a/packages/data-model/json-encoding-modern.ts
+++ b/packages/data-model/json-encoding-modern.ts
@@ -36,15 +36,34 @@ function isEncodedInstance(v: JsonWireValue): boolean {
 }
 
 /**
- * Returns true if `v` contains no encoded instances anywhere in its subtree,
- * meaning it is safe to embed directly inside a `/quote` wrapper without any
- * further decoding by the deserializer.
+ * Returns true if a serialized value `v` is quote-safe: it either needs no
+ * decoding (primitive or plain object/array free of tag-wrapped forms), or it
+ * is itself a /quote-wrapped literal that can be collapsed into a parent /quote.
  */
 function isQuoteSafe(v: JsonWireValue): boolean {
   if (v === null || typeof v !== "object") return true;
   if (Array.isArray(v)) return v.every((item) => isQuoteSafe(item));
-  if (isEncodedInstance(v)) return false;
-  return Object.values(v).every((item) => isQuoteSafe(item as JsonWireValue));
+  if (!isEncodedInstance(v)) {
+    return Object.values(v).every((item) => isQuoteSafe(item as JsonWireValue));
+  }
+  // It is an encoded instance: safe only if it is a /quote wrapper.
+  return Object.keys(v)[0] === "/quote";
+}
+
+/**
+ * Recursively unwrap any /quote-wrapped values inside a serialized result,
+ * restoring the original literal subtree so it can be re-wrapped by a parent
+ * /quote without nesting.
+ */
+function unquote(v: JsonWireValue): JsonWireValue {
+  if (v === null || typeof v !== "object") return v;
+  if (Array.isArray(v)) return v.map(unquote) as JsonWireValue;
+  if (isEncodedInstance(v) && Object.keys(v)[0] === "/quote") {
+    return unquote((v as Record<string, JsonWireValue>)["/quote"]);
+  }
+  return Object.fromEntries(
+    Object.entries(v).map(([k, val]) => [k, unquote(val as JsonWireValue)]),
+  ) as JsonWireValue;
 }
 
 /**
@@ -303,15 +322,16 @@ export class JsonEncodingContext implements SerializationContext<string> {
     seen.delete(value as object);
 
     // Apply escaping per Section 5.6 for any plain object with a /-prefixed key.
-    // Use /quote when all serialized values are quote-safe (no tag-wrapped forms
-    // anywhere in their subtree); use /object when any value required encoding.
+    // Use /quote when all serialized values are quote-safe (primitives, plain
+    // objects/arrays, or /quote-wrapped literals that can be collapsed); use
+    // /object otherwise.
     const keys = Object.keys(result);
     if (keys.some((k) => k.startsWith("/"))) {
       const allQuoteSafe = Object.values(result).every((v) => isQuoteSafe(v));
-      return this.wrapTag(
-        allQuoteSafe ? TAGS.quote : TAGS.object,
-        result,
-      ) as JsonWireValue;
+      if (allQuoteSafe) {
+        return this.wrapTag(TAGS.quote, unquote(result)) as JsonWireValue;
+      }
+      return this.wrapTag(TAGS.object, result) as JsonWireValue;
     }
 
     return result as JsonWireValue;

--- a/packages/data-model/test/json-encoding-modern.test.ts
+++ b/packages/data-model/test/json-encoding-modern.test.ts
@@ -1015,6 +1015,22 @@ describe("json encoding", () => {
       expect(result["/x"]["/y"]).toBe(123);
     });
 
+    it("boundary contrast: literal subtree uses /quote, Fabric type uses /object", () => {
+      // All-literal: single /quote wraps the whole structure.
+      const literal = { "/x": { "/y": 123 } } as unknown as FabricValue;
+      expect(toWireFormat(literal)).toEqual({
+        "/quote": { "/x": { "/y": 123 } },
+      });
+
+      // Fabric type as value: /object with the epoch encoded as its tagged form.
+      const withEpoch = {
+        "/x": new FabricEpochDays(42n),
+      } as unknown as FabricValue;
+      expect(toWireFormat(withEpoch)).toEqual({
+        "/object": { "/x": { "/EpochDays@1": expect.anything() } },
+      });
+    });
+
     it("emits /object for /-keyed object with FabricError value", () => {
       const err = new FabricError(new TypeError("eep!"));
       const obj = { "/x": err } as unknown as FabricValue;

--- a/packages/data-model/test/json-encoding-modern.test.ts
+++ b/packages/data-model/test/json-encoding-modern.test.ts
@@ -1115,6 +1115,27 @@ describe("json encoding", () => {
       expect(result).toBeInstanceOf(UnknownValue);
       expect((result as unknown as UnknownValue).typeTag).toBe("Future@7");
     });
+
+    it("unquote strips exactly one /quote layer — inner /quote is preserved as literal", () => {
+      // Wire form { "/quote": { "/quote": "x" } } is a /quote-wrapped literal
+      // whose content happens to be { "/quote": "x" }. Decoding must return
+      // { "/quote": "x" } as a frozen plain object — NOT recurse into it and
+      // return just "x".
+      const wire = { "/quote": { "/quote": "x" } } as JsonWireValue;
+      const result = fromWireFormat(wire) as Record<string, FabricValue>;
+      expect(result["/quote"]).toBe("x");
+    });
+
+    it("round-trips object whose value is a /quote-keyed literal", () => {
+      // { "/x": { "/quote": "inner" } } — the value at "/x" is user data that
+      // happens to have a /quote key. Must survive encode→decode intact.
+      const obj = { "/x": { "/quote": "inner" } } as unknown as FabricValue;
+      const result = roundTrip(obj) as Record<
+        string,
+        Record<string, FabricValue>
+      >;
+      expect(result["/x"]["/quote"]).toBe("inner");
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/packages/data-model/test/json-encoding-modern.test.ts
+++ b/packages/data-model/test/json-encoding-modern.test.ts
@@ -1001,13 +1001,12 @@ describe("json encoding", () => {
 
     // --- /object: any value requires encoding ---
 
-    it("emits /object for doubly-nested /-prefixed object (inner needs encoding)", () => {
+    it("emits /quote for doubly-nested /-prefixed literal object (whole subtree is literal)", () => {
       const obj = { "/x": { "/y": 123 } } as unknown as FabricValue;
       const wire = toWireFormat(obj);
-      // inner { "/y": 123 } is itself literal, so it emits /quote; outer has
-      // a /quote-wrapped value → not a plain literal → outer emits /object.
+      // Whole subtree is deep-literal → single /quote wrap of original structure.
       expect(wire).toEqual({
-        "/object": { "/x": { "/quote": { "/y": 123 } } },
+        "/quote": { "/x": { "/y": 123 } },
       });
       const result = roundTrip(obj) as Record<
         string,

--- a/packages/data-model/test/json-encoding-modern.test.ts
+++ b/packages/data-model/test/json-encoding-modern.test.ts
@@ -934,12 +934,11 @@ describe("json encoding", () => {
   // --------------------------------------------------------------------------
 
   describe("/object escaping", () => {
-    it("wraps single-key object with /-prefixed key", () => {
+    // --- /quote: literal-only /-keyed objects ---
+
+    it("emits /quote for single-key literal /-prefixed object", () => {
       const obj = { "/myKey": "val" } as unknown as FabricValue;
-      const result = toWireFormat(obj);
-      expect(result).toEqual({
-        "/object": { "/myKey": "val" },
-      });
+      expect(toWireFormat(obj)).toEqual({ "/quote": { "/myKey": "val" } });
     });
 
     it("round-trips {'/myKey': 'val'}", () => {
@@ -948,12 +947,9 @@ describe("json encoding", () => {
       expect(result["/myKey"]).toBe("val");
     });
 
-    it("wraps {'/Link@1': 'fake'} (looks like tag but is user data)", () => {
+    it("emits /quote for {'/Link@1': 'fake'} (looks like tag but is literal user data)", () => {
       const obj = { "/Link@1": "fake" } as unknown as FabricValue;
-      const result = toWireFormat(obj);
-      expect(result).toEqual({
-        "/object": { "/Link@1": "fake" },
-      });
+      expect(toWireFormat(obj)).toEqual({ "/quote": { "/Link@1": "fake" } });
     });
 
     it("round-trips {'/Link@1': 'fake'}", () => {
@@ -962,26 +958,26 @@ describe("json encoding", () => {
       expect(result["/Link@1"]).toBe("fake");
     });
 
-    it("wraps multi-key object with one /-prefixed key", () => {
+    it("emits /quote for multi-key literal object with one /-prefixed key", () => {
       const obj = { a: 1, "/b": 2 } as unknown as FabricValue;
-      const result = toWireFormat(obj);
-      expect(result).toEqual({ "/object": { a: 1, "/b": 2 } });
+      expect(toWireFormat(obj)).toEqual({ "/quote": { a: 1, "/b": 2 } });
     });
 
-    it("round-trips multi-key object with one /-prefixed key", () => {
+    it("round-trips multi-key literal object with one /-prefixed key", () => {
       const obj = { a: 1, "/b": 2 } as unknown as FabricValue;
       const result = roundTrip(obj) as Record<string, FabricValue>;
       expect(result["a"]).toBe(1);
       expect(result["/b"]).toBe(2);
     });
 
-    it("wraps multi-key object with multiple /-prefixed keys", () => {
+    it("emits /quote for multi-key literal object with multiple /-prefixed keys", () => {
       const obj = { "/a": 1, "/b": 2, c: 3 } as unknown as FabricValue;
-      const result = toWireFormat(obj);
-      expect(result).toEqual({ "/object": { "/a": 1, "/b": 2, c: 3 } });
+      expect(toWireFormat(obj)).toEqual({
+        "/quote": { "/a": 1, "/b": 2, c: 3 },
+      });
     });
 
-    it("round-trips multi-key object with multiple /-prefixed keys", () => {
+    it("round-trips multi-key literal object with multiple /-prefixed keys", () => {
       const obj = { "/a": 1, "/b": 2, c: 3 } as unknown as FabricValue;
       const result = roundTrip(obj) as Record<string, FabricValue>;
       expect(result["/a"]).toBe(1);
@@ -989,49 +985,42 @@ describe("json encoding", () => {
       expect(result["c"]).toBe(3);
     });
 
-    it("malformed wire: multi-key object with /-prefixed key produces ProblematicValue", () => {
-      // Wire data that was NOT encoded by this encoder (no /object wrapper) —
-      // the decoder must not silently round-trip it as a plain object.
-      const data = { a: 1, "/b": 2 } as JsonWireValue;
-      const result = fromWireFormat(data);
-      expect(result).toBeInstanceOf(ProblematicValue);
+    it("emits /quote when value is a plain nested object (no /-keys inside)", () => {
+      const obj = { "/x": { a: 1 } } as unknown as FabricValue;
+      expect(toWireFormat(obj)).toEqual({ "/quote": { "/x": { a: 1 } } });
     });
 
-    it("does not wrap plain object with no /-prefixed keys", () => {
-      const obj = { a: 1, b: 2 } as unknown as FabricValue;
-      const result = toWireFormat(obj);
-      expect(result).toEqual({ a: 1, b: 2 });
-    });
-
-    it("/object-wrapped multi-key object with /-prefixed key deserializes correctly", () => {
-      const data = { "/object": { a: 1, "/b": 2 } } as JsonWireValue;
-      const result = fromWireFormat(data) as Record<string, FabricValue>;
-      expect(result["a"]).toBe(1);
-      expect(result["/b"]).toBe(2);
-    });
-
-    it("round-trips nested object containing /-prefixed key", () => {
-      const obj = { outer: { "/inner": 1 } } as unknown as FabricValue;
+    it("round-trips /-keyed object whose value is a plain nested object", () => {
+      const obj = { "/x": { a: 1 } } as unknown as FabricValue;
       const result = roundTrip(obj) as Record<
         string,
         Record<string, FabricValue>
       >;
-      expect(result["outer"]["/inner"]).toBe(1);
+      expect(result["/x"]["a"]).toBe(1);
     });
 
-    it("round-trips doubly-nested /-prefixed object", () => {
-      // Outer { "/x": inner } wraps outer as /object; inner { "/y": 123 } must
-      // also be encoded as /object (recursive encoding of values).
+    // --- /object: any value requires encoding ---
+
+    it("emits /object for doubly-nested /-prefixed object (inner needs encoding)", () => {
       const obj = { "/x": { "/y": 123 } } as unknown as FabricValue;
       const wire = toWireFormat(obj);
+      // inner { "/y": 123 } is itself literal, so it emits /quote; outer has
+      // a /quote-wrapped value → not a plain literal → outer emits /object.
       expect(wire).toEqual({
-        "/object": { "/x": { "/object": { "/y": 123 } } },
+        "/object": { "/x": { "/quote": { "/y": 123 } } },
       });
       const result = roundTrip(obj) as Record<
         string,
         Record<string, FabricValue>
       >;
       expect(result["/x"]["/y"]).toBe(123);
+    });
+
+    it("emits /object for /-keyed object with FabricError value", () => {
+      const err = new FabricError(new TypeError("eep!"));
+      const obj = { "/x": err } as unknown as FabricValue;
+      const wire = toWireFormat(obj);
+      expect(Object.keys(wire as object)).toEqual(["/object"]);
     });
 
     it("round-trips FabricError as value inside /-prefixed key object", () => {
@@ -1050,6 +1039,56 @@ describe("json encoding", () => {
       const result = roundTrip(obj) as Record<string, FabricValue>;
       expect(result["/x"]).toBeInstanceOf(FabricEpochDays);
       expect((result["/x"] as unknown as FabricEpochDays).value).toBe(42n);
+    });
+
+    it("emits /object for mixed: literal and encoded values", () => {
+      const obj = {
+        "/a": "literal",
+        "/b": new FabricError(new Error("oops")),
+      } as unknown as FabricValue;
+      const wire = toWireFormat(obj);
+      expect(Object.keys(wire as object)).toEqual(["/object"]);
+    });
+
+    it("round-trips mixed literal+encoded /-keyed object", () => {
+      const obj = {
+        "/a": "literal",
+        "/b": new FabricError(new Error("oops")),
+      } as unknown as FabricValue;
+      const result = roundTrip(obj) as Record<string, FabricValue>;
+      expect(result["/a"]).toBe("literal");
+      expect(result["/b"]).toBeInstanceOf(FabricError);
+    });
+
+    // --- General ---
+
+    it("malformed wire: multi-key object with /-prefixed key produces ProblematicValue", () => {
+      // Wire data without /quote or /object wrapper — decoder must not silently
+      // round-trip it as a plain object.
+      const data = { a: 1, "/b": 2 } as JsonWireValue;
+      const result = fromWireFormat(data);
+      expect(result).toBeInstanceOf(ProblematicValue);
+    });
+
+    it("does not wrap plain object with no /-prefixed keys", () => {
+      const obj = { a: 1, b: 2 } as unknown as FabricValue;
+      expect(toWireFormat(obj)).toEqual({ a: 1, b: 2 });
+    });
+
+    it("/object-wrapped multi-key object with /-prefixed key deserializes correctly", () => {
+      const data = { "/object": { a: 1, "/b": 2 } } as JsonWireValue;
+      const result = fromWireFormat(data) as Record<string, FabricValue>;
+      expect(result["a"]).toBe(1);
+      expect(result["/b"]).toBe(2);
+    });
+
+    it("round-trips nested object containing /-prefixed key", () => {
+      const obj = { outer: { "/inner": 1 } } as unknown as FabricValue;
+      const result = roundTrip(obj) as Record<
+        string,
+        Record<string, FabricValue>
+      >;
+      expect(result["outer"]["/inner"]).toBe(1);
     });
 
     it("single-key /-prefixed object still routes through unwrapTag (no regression)", () => {


### PR DESCRIPTION
## What

The encoder previously always wrapped plain objects with `/`-prefixed keys using `/object`. This PR teaches it to use `/quote` instead when the entire value subtree is literal (numbers, strings, booleans, null, and plain nested objects — no registered Fabric types).

`/quote` is the more compact form and correctly signals "this is verbatim user data". When any value in the subtree requires encoding (FabricError, FabricEpochDays, etc.), `/object` is used and values are recursively encoded as before.

## Implementation

Uses a post-serialization `isQuoteSafe` check plus an `unquote()` pass to collapse inner `/quote` wrappers, yielding a single outer `/quote` wrap for the whole literal subtree. Includes `isEncodedInstance` helper refactor in `unwrapTag`.

## Tests

Covers: literal-only `/quote` emission, encoded-value `/object` path, doubly-nested literal case, FabricEpochDays boundary contrast, mixed literal+encoded, and round-trips.

## References

- `coordination/docs/2026-04-27-unified-json-encoding-readiness.md`

## Review

Reviewed and approved by reviewer-flux (Claude Sonnet 4.6), session 2026-064.

Co-Authored-By: coder-cedar (Claude Sonnet 4.6) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Sonnet 4.6) <noreply@anthropic.com>
