### PR TITLE
Separate out `json-encoding-{legacy,modern}.ts`.

### DIFF
--- a/packages/data-model/json-encoding-legacy.ts
+++ b/packages/data-model/json-encoding-legacy.ts
@@ -1,0 +1,29 @@
+/**
+ * Legacy JSON encoding system.
+ */
+
+import type { FabricValue } from "./fabric-value.ts";
+
+/**
+ * Encodes a fabric value to a JSON string, using the legacy (plain JSON)
+ * encoding.
+ */
+export function jsonFromValueLegacy(value: FabricValue): string {
+  try {
+    const result = JSON.stringify(value);
+    if (result !== undefined) {
+      return result;
+    }
+  } catch {
+    // Ignore. Fall through to more apt `throw` immediately below.
+  }
+
+  throw new Error("jsonFromValueLegacy: Cannot stringify given value.");
+}
+
+/**
+ * Decodes a legacy-format (plain) JSON string back into a fabric value.
+ */
+export function valueFromJsonLegacy(json: string): FabricValue {
+  return JSON.parse(json);
+}

--- a/packages/data-model/json-encoding-modern.ts
+++ b/packages/data-model/json-encoding-modern.ts
@@ -1,0 +1,31 @@
+/**
+ * Modern JSON encoding system.
+ */
+
+import type { FabricValue } from "./fabric-value.ts";
+import type { ReconstructionContext } from "./fabric-value.ts";
+import { JsonEncodingContext } from "./json-encoding-context.ts";
+
+/** Shared JSON encoding context. */
+const jsonEncodingContext = new JsonEncodingContext();
+
+/**
+ * Encodes a fabric value to a JSON string. When unified JSON encoding is ON,
+ * uses the modern JSON-based format. When OFF, equivalent to
+ * `JSON.stringify(value)`.
+ */
+export function jsonFromValueModern(value: FabricValue): string {
+  return jsonEncodingContext.encode(value);
+}
+
+/**
+ * Decodes a JSON string back into a fabric value. When unified JSON encoding is
+ * ON, uses the modern JSON-based format. When OFF, equivalent to
+ * `JSON.parse(json)`.
+ */
+export function valueFromJsonModern(
+  json: string,
+  runtime: ReconstructionContext,
+): FabricValue {
+  return jsonEncodingContext.decode(json, runtime);
+}

--- a/packages/data-model/json-encoding-modern.ts
+++ b/packages/data-model/json-encoding-modern.ts
@@ -10,18 +10,14 @@ import { JsonEncodingContext } from "./json-encoding-context.ts";
 const jsonEncodingContext = new JsonEncodingContext();
 
 /**
- * Encodes a fabric value to a JSON string. When unified JSON encoding is ON,
- * uses the modern JSON-based format. When OFF, equivalent to
- * `JSON.stringify(value)`.
+ * Encodes a fabric value to a JSON string.
  */
 export function jsonFromValueModern(value: FabricValue): string {
   return jsonEncodingContext.encode(value);
 }
 
 /**
- * Decodes a JSON string back into a fabric value. When unified JSON encoding is
- * ON, uses the modern JSON-based format. When OFF, equivalent to
- * `JSON.parse(json)`.
+ * Decodes a JSON string back into a fabric value.
  */
 export function valueFromJsonModern(
   json: string,

--- a/packages/data-model/json-encoding.ts
+++ b/packages/data-model/json-encoding.ts
@@ -1,6 +1,9 @@
 import type { FabricValue } from "./fabric-value.ts";
 import type { ReconstructionContext } from "./fabric-value.ts";
-import { JsonEncodingContext } from "./json-encoding-context.ts";
+import {
+  jsonFromValueModern,
+  valueFromJsonModern,
+} from "./json-encoding-modern.ts";
 
 // ---------------------------------------------------------------------------
 // Unified JSON encoding flag and dispatch configuration
@@ -43,8 +46,6 @@ export function resetJsonEncodingConfig(): void {
 // Flag-dispatched public API
 // ---------------------------------------------------------------------------
 
-const jsonEncodingContext = new JsonEncodingContext();
-
 /**
  * Encodes a fabric value to a JSON string. When unified JSON encoding is ON,
  * uses the modern JSON-based format. When OFF, equivalent to
@@ -52,7 +53,7 @@ const jsonEncodingContext = new JsonEncodingContext();
  */
 export function jsonFromValue(value: FabricValue): string {
   if (jsonEncodingEnabled) {
-    return jsonEncodingContext.encode(value);
+    return jsonFromValueModern(value);
   } else {
     try {
       const result = JSON.stringify(value);
@@ -77,7 +78,7 @@ export function valueFromJson(
   runtime: ReconstructionContext,
 ): FabricValue {
   if (jsonEncodingEnabled) {
-    return jsonEncodingContext.decode(json, runtime);
+    return valueFromJsonModern(json, runtime);
   } else {
     return JSON.parse(json);
   }

--- a/packages/data-model/json-encoding.ts
+++ b/packages/data-model/json-encoding.ts
@@ -1,6 +1,10 @@
 import type { FabricValue } from "./fabric-value.ts";
 import type { ReconstructionContext } from "./fabric-value.ts";
 import {
+  jsonFromValueLegacy,
+  valueFromJsonLegacy,
+} from "./json-encoding-legacy.ts";
+import {
   jsonFromValueModern,
   valueFromJsonModern,
 } from "./json-encoding-modern.ts";
@@ -55,16 +59,7 @@ export function jsonFromValue(value: FabricValue): string {
   if (jsonEncodingEnabled) {
     return jsonFromValueModern(value);
   } else {
-    try {
-      const result = JSON.stringify(value);
-      if (result !== undefined) {
-        return result;
-      }
-    } catch {
-      // Ignore. Fall through to more apt `throw` immediately below.
-    }
-
-    throw new Error("jsonFromValue (legacy): Cannot stringify given value.");
+    return jsonFromValueLegacy(value);
   }
 }
 
@@ -80,6 +75,6 @@ export function valueFromJson(
   if (jsonEncodingEnabled) {
     return valueFromJsonModern(json, runtime);
   } else {
-    return JSON.parse(json);
+    return valueFromJsonLegacy(json);
   }
 }


### PR DESCRIPTION
This PR separates out two dispatched-to files for the JSON-based encoder, `json-encoding-legacy.ts` and `json-encoding-modern.ts`, in a parallel structure to how `value-hash*` and other dispatched submodules are arranged in `data-model`. These are pretty small now, but they'll probably be growing some additional functions soon.