### PR TITLE
docs(spec): document /quote-vs-/object encoder dispatch in §6 (best practice)

### DIFF
--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -202,8 +202,11 @@ deserialization.
 
 **When the serializer emits `/object`:** During serialization, if a plain object
 has any string key that starts with `/` — regardless of how many other keys the
-object has — the serializer wraps it in `/object`. This prevents the
-deserializer from treating the object as a reserved form.
+object has — the serializer wraps it in one of these escapes (either `/object`
+or `/quote`; see "Encoder dispatch" below). This prevents the deserializer from
+treating the object as a reserved form. `/object` is always a valid choice; the
+distinction between `/object` and `/quote` is a recommendation about which form
+makes the wire output most readable, not a correctness requirement.
 
 ### `/quote` — Fully Literal
 
@@ -237,6 +240,30 @@ Use cases:
 - `/object`: You have a plain object with a slash-prefixed key, but values
   should still be interpreted normally.
 - `/quote`: You want the entire subtree treated as literal JSON data.
+
+### Encoder Dispatch (Recommended Best Practice)
+
+When the encoder encounters a plain object that needs an escape (i.e., any plain
+object containing one or more `/`-prefixed keys), both `/object` and `/quote`
+are valid choices. The recommended best practice is:
+
+- If the entire subtree to be wrapped is fully literal — i.e., it contains no
+  values that would themselves need encoding as special types — emit `/quote`.
+- Otherwise (some descendant value still needs to be processed as a special
+  type during deserialization), emit `/object`.
+
+The motivation for the recommendation is wire-format readability and round-trip
+fidelity: a `/quote`-wrapped literal subtree appears in the wire format as
+itself, with no per-key escaping or restructuring, which is easier for humans to
+read and easier for tools to compare. Conversely, `/object` is required (not
+just preferred) whenever any descendant value still needs encoding, because
+`/quote` would suppress that encoding entirely.
+
+This is a **recommendation, not a requirement**. A conforming encoder may emit
+`/object` in either case; the wire format is unambiguous either way. **A
+conforming decoder must accept both forms.** See `1-fabric-values.md` Section
+2.9 (immutability) and the freeze guarantee under `/quote` above for the
+properties a decoder preserves regardless of which form it sees.
 
 ## 7. Serialization Context Responsibilities
 

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -294,10 +294,10 @@ The `/` prefix is wholly owned by the encoding system in the wire format. Any
 object containing **any** key that starts with `/` — regardless of how many
 other keys the object has — is a **reserved form** in the encoded
 representation. User-data plain objects may contain `/`-prefixed keys at the
-data level, but a conforming encoder always wraps them via `/object` (Section 6)
-before they reach the wire. The presence of a bare `/`-prefixed key in a
-wire-format object therefore always signals a tagged value, built-in escape, or
-encoding error — never a literal user-data key.
+data level, but a conforming encoder always wraps them via `/object` or `/quote`
+(Section 6) before they reach the wire. The presence of a bare `/`-prefixed key
+in a wire-format object therefore always signals a tagged value, built-in
+escape, or encoding error — never a literal user-data key.
 
 Specifically:
 


### PR DESCRIPTION
## Summary

Closes the spec-completeness gap surfaced in `reviewer-flux`'s Opus-4.7
re-review of session-064 PRs ("FU2"): the encoder algorithm introduced in
#3401 — emit `/quote` when the entire wrapped subtree is fully literal,
otherwise `/object` — was not described anywhere in the formal spec. Per
Dan's framing, the spec **recommends** the dispatch as best practice but
does **not** mandate it. A conforming encoder may emit `/object` in either
case; a conforming decoder must accept both forms. The wire format remains
unambiguous either way.

## Changes

All within `docs/specs/space-model-formal-spec/3-json-encoding.md` §6:

1. **Softened the existing "When the serializer emits `/object`"
   paragraph.** It previously claimed flatly that the serializer "wraps it
   in `/object`" for any plain object with a `/`-prefixed key, which is no
   longer accurate post-#3401. The paragraph now says the encoder wraps in
   "one of these escapes (either `/object` or `/quote`; see Encoder
   dispatch below)" and notes that `/object` is always a valid choice — the
   distinction is recommendation-only, not a correctness requirement.

2. **Added a new subsection "Encoder Dispatch (Recommended Best
   Practice)"** at the end of §6 (after "When to Use Which"). It states the
   recommended algorithm, the motivation (wire-format readability and
   round-trip fidelity, plus the hard reason `/object` is *required* when
   any descendant value still needs encoding because `/quote` would
   suppress that encoding entirely), and the explicit
   recommendation-not-requirement / decoder-symmetry MUST framing.

## Structural choice (open question from the original task)

The task framing left open whether to "extend §6 in place" vs. "add a new
short subsection §6.x". I chose **a new subsection within §6 at the same
level as the existing `/object`, `/quote`, and "When to Use Which"
subsections**, rather than promoting the dispatch material to a top-level
§6.x. The rationale: §6 is already organized as a sequence of subsections,
so adding a fourth one at that level matches the existing structural
pattern. Easy to reverse if you prefer the §6.x form — let me know.

## Testing

Docs-only change. No CI gate beyond the standard markdown formatting check
(the `docs/` directory is excluded from `deno fmt`, so no fmt step
applies). Manually verified all new lines fit within the 80-column wrap
convention used elsewhere in the file.

## References

- Flux's re-review report (FU2 finding):
  `coordination/docs/2026-04-28-session-064-rereview-flux.md`
- The dispatch algorithm landed in #3401 (`feat(data-model): emit /quote
  for literal-only /-keyed plain objects`).

Co-Authored-By: spec-writer-sage (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
