### PR TITLE
fix(data-model): produce ProblematicValue for bare "/"-keyed wire objects

### DIFF
--- a/packages/data-model/json-encoding-context.ts
+++ b/packages/data-model/json-encoding-context.ts
@@ -355,6 +355,18 @@ export class JsonEncodingContext implements SerializationContext<string> {
     if (decoded !== null) {
       const { tag, state } = decoded;
 
+      // A bare `"/"` key (empty tag after stripping the leading slash) is
+      // always an encoding error per spec §9 — no valid tag has an empty
+      // name. Produce a ProblematicValue rather than an UnknownValue with
+      // an empty tag.
+      if (tag === "") {
+        return new ProblematicValue(
+          tag,
+          state as unknown as FabricValue,
+          `object has bare "/" key`,
+        ) as unknown as FabricValue;
+      }
+
       // `TAGS.object` unwrapping (Section 5.6).
       if (tag === TAGS.object) {
         const inner = state as Record<string, JsonWireValue>;

--- a/packages/data-model/test/json-encoding-modern.test.ts
+++ b/packages/data-model/test/json-encoding-modern.test.ts
@@ -1085,6 +1085,15 @@ describe("json encoding", () => {
       expect(result).toBeInstanceOf(ProblematicValue);
     });
 
+    it("malformed wire: bare /-keyed object produces ProblematicValue", () => {
+      // Per spec §9, a single-key object whose key is bare "/" (empty tag
+      // after stripping the leading slash) is an encoding error. Decoding must
+      // produce a ProblematicValue, not an UnknownValue with an empty tag.
+      const data = { "/": "x" } as JsonWireValue;
+      const result = fromWireFormat(data);
+      expect(result).toBeInstanceOf(ProblematicValue);
+    });
+
     it("does not wrap plain object with no /-prefixed keys", () => {
       const obj = { a: 1, b: 2 } as unknown as FabricValue;
       expect(toWireFormat(obj)).toEqual({ a: 1, b: 2 });
@@ -1116,7 +1125,7 @@ describe("json encoding", () => {
       expect((result as unknown as UnknownValue).typeTag).toBe("Future@7");
     });
 
-    it("unquote strips exactly one /quote layer — inner /quote is preserved as literal", () => {
+    it("decoder strips exactly one /quote layer — inner /quote is preserved literally", () => {
       // Wire form { "/quote": { "/quote": "x" } } is a /quote-wrapped literal
       // whose content happens to be { "/quote": "x" }. Decoding must return
       // { "/quote": "x" } as a frozen plain object — NOT recurse into it and


### PR DESCRIPTION
## Summary

- Decoder bug fix: wire form `{ "/": x }` (single-key object whose sole key is bare `"/"`) was decoding to `UnknownValue("", x)` — an `UnknownValue` with an empty type tag. Per spec §9 ("`/`-Key Reservation Rule", bullet 1), bare `"/"` is always an encoding error: no valid tag has an empty name. The decoder now produces `ProblematicValue` instead.
- Test rename NIT: the test at `packages/data-model/test/json-encoding-modern.test.ts:1119` was named `"unquote strips exactly one /quote layer …"` but actually exercises the *decoder's* one-level behavior on wire form `{"/quote": {"/quote": "x"}}`, not the `unquote()` helper. Renamed to `"decoder strips exactly one /quote layer — inner /quote is preserved literally"`.
- Source: Flux's session-064 re-review report (`coordination/docs/2026-04-28-session-064-rereview-flux.md` in the project-coordination repo). Two scope items in one PR per Dan's "let's get the unit test gap fixed" + "might as well get the NIT fixed too".

The fix is a 9-line early-return in `JsonEncodingContext.deserialize()` right after `unwrapTag()` decodes, before any tag dispatch. Total diff: +22/-1 across `packages/data-model/json-encoding-context.ts` and `packages/data-model/test/json-encoding-modern.test.ts`.

## Test plan

- [x] Wrote BDD test first (`malformed wire: bare /-keyed object produces ProblematicValue`); confirmed red against pre-fix code (asserted `ProblematicValue`, got `UnknownValue("", "x")`).
- [x] Applied 9-line fix; test now green.
- [x] `deno fmt --check` clean.
- [x] `deno lint` clean.
- [x] `packages/data-model` test suite: 38 passed (1254 steps; +1 from new test), 0 failed.
- [x] `packages/memory` test suite (codec consumer): 119 passed, 0 failed.
- [x] No regression: existing single-key `/Future@7` test still produces `UnknownValue` (unrecognized tag), confirming the new check fires only on bare-empty-tag.

## Notes

- Independent of #3391 (the `unifiedJsonEncoding` flip). Lands on its own merits.
- Spec citation `§9` is the authoritative reference. My first comment draft cited `§5.4` by mistake; fixed before commit.
