### PR TITLE
Some `data-model` utilities.

### DIFF
--- a/packages/data-model/json-encoding-legacy.ts
+++ b/packages/data-model/json-encoding-legacy.ts
@@ -22,6 +22,41 @@ export function jsonFromValueLegacy(value: FabricValue): string {
 }
 
 /**
+ * Indicates if the given text has a "first-blush" appearance as valid encoded
+ * JSON as defined by this module.
+ */
+export function seemsLikeJsonEncodedFabricValueLegacy(value: string): boolean {
+  switch (value) {
+    case "false":
+    case "true":
+    case "null": {
+      return true;
+    }
+  }
+
+  switch (value[0]) {
+    case "\"":
+    case "[":
+    case "{":
+    case "-":
+    case "0":
+    case "1":
+    case "2":
+    case "3":
+    case "4":
+    case "5":
+    case "6":
+    case "7":
+    case "8":
+    case "9": {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Decodes a legacy-format (plain) JSON string back into a fabric value.
  */
 export function valueFromJsonLegacy(json: string): FabricValue {

--- a/packages/data-model/json-encoding-legacy.ts
+++ b/packages/data-model/json-encoding-legacy.ts
@@ -35,7 +35,7 @@ export function seemsLikeJsonEncodedFabricValueLegacy(value: string): boolean {
   }
 
   switch (value[0]) {
-    case "\"":
+    case '"':
     case "[":
     case "{":
     case "-":

--- a/packages/data-model/json-encoding-modern.ts
+++ b/packages/data-model/json-encoding-modern.ts
@@ -17,6 +17,41 @@ export function jsonFromValueModern(value: FabricValue): string {
 }
 
 /**
+ * Indicates if the given text has a "first-blush" appearance as valid encoded
+ * JSON as defined by this module.
+ */
+export function seemsLikeJsonEncodedFabricValueModern(value: string): boolean {
+  switch (value) {
+    case "false":
+    case "true":
+    case "null": {
+      return true;
+    }
+  }
+
+  switch (value[0]) {
+    case "\"":
+    case "[":
+    case "{":
+    case "-":
+    case "0":
+    case "1":
+    case "2":
+    case "3":
+    case "4":
+    case "5":
+    case "6":
+    case "7":
+    case "8":
+    case "9": {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Decodes a JSON string back into a fabric value.
  */
 export function valueFromJsonModern(

--- a/packages/data-model/json-encoding-modern.ts
+++ b/packages/data-model/json-encoding-modern.ts
@@ -30,7 +30,7 @@ export function seemsLikeJsonEncodedFabricValueModern(value: string): boolean {
   }
 
   switch (value[0]) {
-    case "\"":
+    case '"':
     case "[":
     case "{":
     case "-":

--- a/packages/data-model/json-encoding.ts
+++ b/packages/data-model/json-encoding.ts
@@ -2,10 +2,12 @@ import type { FabricValue } from "./fabric-value.ts";
 import type { ReconstructionContext } from "./fabric-value.ts";
 import {
   jsonFromValueLegacy,
+  seemsLikeJsonEncodedFabricValueLegacy,
   valueFromJsonLegacy,
 } from "./json-encoding-legacy.ts";
 import {
   jsonFromValueModern,
+  seemsLikeJsonEncodedFabricValueModern,
   valueFromJsonModern,
 } from "./json-encoding-modern.ts";
 
@@ -60,6 +62,18 @@ export function jsonFromValue(value: FabricValue): string {
     return jsonFromValueModern(value);
   } else {
     return jsonFromValueLegacy(value);
+  }
+}
+
+/**
+ * Indicates if the given text has a "first-blush" appearance as valid encoded
+ * JSON as defined by this module.
+ */
+export function seemsLikeJsonEncodedFabricValue(value: string): boolean {
+  if (jsonEncodingEnabled) {
+    return seemsLikeJsonEncodedFabricValueModern(value);
+  } else {
+    return seemsLikeJsonEncodedFabricValueLegacy(value);
   }
 }
 

--- a/packages/data-model/test/json-encoding.test.ts
+++ b/packages/data-model/test/json-encoding.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import {
   jsonFromValue,
   resetJsonEncodingConfig,
+  seemsLikeJsonEncodedFabricValue,
   setJsonEncodingConfig,
   valueFromJson,
 } from "../json-encoding.ts";
@@ -316,6 +317,83 @@ describe("json-encoding", () => {
       // undefined stringifies to undefined (JSON.stringify returns undefined
       // for undefined input), so test with null instead.
       expect(jsonFromValue(null)).toBe("null");
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // seemsLikeJsonEncodedFabricValue
+  // --------------------------------------------------------------------------
+
+  describe("seemsLikeJsonEncodedFabricValue (flag OFF)", () => {
+    it("recognizes JSON keywords", () => {
+      expect(seemsLikeJsonEncodedFabricValue("true")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("false")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("null")).toBe(true);
+    });
+
+    it("recognizes strings starting with JSON delimiters", () => {
+      expect(seemsLikeJsonEncodedFabricValue('"hello"')).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("[]")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("[1,2,3]")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("{}")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue('{"a":1}')).toBe(true);
+    });
+
+    it("recognizes numeric-looking strings", () => {
+      expect(seemsLikeJsonEncodedFabricValue("0")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("42")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("3.14")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("-1")).toBe(true);
+    });
+
+    it("rejects empty string", () => {
+      expect(seemsLikeJsonEncodedFabricValue("")).toBe(false);
+    });
+
+    it("rejects bare identifiers and other non-JSON-looking strings", () => {
+      expect(seemsLikeJsonEncodedFabricValue("hello")).toBe(false);
+      expect(seemsLikeJsonEncodedFabricValue("undefined")).toBe(false);
+      expect(seemsLikeJsonEncodedFabricValue("True")).toBe(false);
+      expect(seemsLikeJsonEncodedFabricValue("NaN")).toBe(false);
+    });
+  });
+
+  describe("seemsLikeJsonEncodedFabricValue (flag ON)", () => {
+    it("recognizes JSON keywords", () => {
+      setJsonEncodingConfig(true);
+      expect(seemsLikeJsonEncodedFabricValue("true")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("false")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("null")).toBe(true);
+    });
+
+    it("recognizes strings starting with JSON delimiters", () => {
+      setJsonEncodingConfig(true);
+      expect(seemsLikeJsonEncodedFabricValue('"hello"')).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("[]")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("[1,2,3]")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("{}")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue('{"a":1}')).toBe(true);
+    });
+
+    it("recognizes numeric-looking strings", () => {
+      setJsonEncodingConfig(true);
+      expect(seemsLikeJsonEncodedFabricValue("0")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("42")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("3.14")).toBe(true);
+      expect(seemsLikeJsonEncodedFabricValue("-1")).toBe(true);
+    });
+
+    it("rejects empty string", () => {
+      setJsonEncodingConfig(true);
+      expect(seemsLikeJsonEncodedFabricValue("")).toBe(false);
+    });
+
+    it("rejects bare identifiers and other non-JSON-looking strings", () => {
+      setJsonEncodingConfig(true);
+      expect(seemsLikeJsonEncodedFabricValue("hello")).toBe(false);
+      expect(seemsLikeJsonEncodedFabricValue("undefined")).toBe(false);
+      expect(seemsLikeJsonEncodedFabricValue("True")).toBe(false);
+      expect(seemsLikeJsonEncodedFabricValue("NaN")).toBe(false);
     });
   });
 });

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -1,0 +1,125 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { toCompactDebugString, toIndentedDebugString } from "../value-debug.ts";
+import type { FabricValue } from "../interface.ts";
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("value-debug", () => {
+  // --------------------------------------------------------------------------
+  // toCompactDebugString
+  // --------------------------------------------------------------------------
+
+  describe("toCompactDebugString", () => {
+    it("compactly stringifies a plain object", () => {
+      expect(toCompactDebugString({ a: 1, b: "two" } as FabricValue))
+        .toBe('{"a":1,"b":"two"}');
+    });
+
+    it("compactly stringifies an array", () => {
+      expect(toCompactDebugString([1, 2, 3] as FabricValue)).toBe("[1,2,3]");
+    });
+
+    it("stringifies JSON-native primitives", () => {
+      expect(toCompactDebugString(42 as FabricValue)).toBe("42");
+      expect(toCompactDebugString("hello" as FabricValue)).toBe('"hello"');
+      expect(toCompactDebugString(true as FabricValue)).toBe("true");
+      expect(toCompactDebugString(false as FabricValue)).toBe("false");
+      expect(toCompactDebugString(null)).toBe("null");
+    });
+
+    it("renders top-level `undefined` as a bare token", () => {
+      expect(toCompactDebugString(undefined)).toBe("undefined");
+    });
+
+    it("renders `undefined` inside an array as a bare token", () => {
+      expect(toCompactDebugString([1, undefined, 2] as FabricValue))
+        .toBe("[1,undefined,2]");
+    });
+
+    it("renders `undefined` as object value as a bare token", () => {
+      expect(toCompactDebugString({ a: undefined, b: 1 } as FabricValue))
+        .toBe('{"a":undefined,"b":1}');
+    });
+
+    it("renders top-level `bigint` as a bare token with `n` suffix", () => {
+      expect(toCompactDebugString(42n as FabricValue)).toBe("42n");
+    });
+
+    it("renders zero, negative, and large `bigint`s", () => {
+      expect(toCompactDebugString(0n as FabricValue)).toBe("0n");
+      expect(toCompactDebugString(-42n as FabricValue)).toBe("-42n");
+      expect(toCompactDebugString(12345678901234567890n as FabricValue))
+        .toBe("12345678901234567890n");
+    });
+
+    it("renders `bigint` inside an array as a bare token", () => {
+      expect(toCompactDebugString([42n, 7n] as FabricValue))
+        .toBe("[42n,7n]");
+    });
+
+    it("renders `bigint` as object value as a bare token", () => {
+      expect(toCompactDebugString({ n: 42n } as FabricValue))
+        .toBe('{"n":42n}');
+    });
+
+    it("does not throw on mixed bigint/undefined values", () => {
+      const v = {
+        count: 100n,
+        missing: undefined,
+        items: [1n, 2n, undefined],
+      } as FabricValue;
+      expect(() => toCompactDebugString(v)).not.toThrow();
+      expect(toCompactDebugString(v))
+        .toBe('{"count":100n,"missing":undefined,"items":[1n,2n,undefined]}');
+    });
+
+    it("does not unquote ordinary string values that resemble bare tokens", () => {
+      // A user string that just happens to read "undefined" or "42n" should
+      // remain a quoted string in the output -- only sentinel-wrapped payloads
+      // get unquoted.
+      expect(toCompactDebugString("undefined" as FabricValue))
+        .toBe('"undefined"');
+      expect(toCompactDebugString("42n" as FabricValue)).toBe('"42n"');
+      expect(toCompactDebugString({ a: "undefined" } as FabricValue))
+        .toBe('{"a":"undefined"}');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // toIndentedDebugString
+  // --------------------------------------------------------------------------
+
+  describe("toIndentedDebugString", () => {
+    it("indents object output with 2 spaces", () => {
+      expect(toIndentedDebugString({ a: 1, b: "two" } as FabricValue))
+        .toBe('{\n  "a": 1,\n  "b": "two"\n}');
+    });
+
+    it("indents array output with 2 spaces", () => {
+      expect(toIndentedDebugString([1, 2, 3] as FabricValue))
+        .toBe("[\n  1,\n  2,\n  3\n]");
+    });
+
+    it("renders top-level `undefined` as bare token", () => {
+      expect(toIndentedDebugString(undefined)).toBe("undefined");
+    });
+
+    it("renders top-level `bigint` as bare token", () => {
+      expect(toIndentedDebugString(42n as FabricValue)).toBe("42n");
+    });
+
+    it("renders nested `bigint` and `undefined` as bare tokens", () => {
+      const v = { n: 42n, m: undefined } as FabricValue;
+      expect(toIndentedDebugString(v))
+        .toBe('{\n  "n": 42n,\n  "m": undefined\n}');
+    });
+
+    it("renders `undefined` and `bigint` inside arrays as bare tokens", () => {
+      expect(toIndentedDebugString([1n, undefined, 2n] as FabricValue))
+        .toBe("[\n  1n,\n  undefined,\n  2n\n]");
+    });
+  });
+});

--- a/packages/data-model/value-debug.ts
+++ b/packages/data-model/value-debug.ts
@@ -1,0 +1,59 @@
+/**
+ * Debugging-ish helpers for `FabricValue`s.
+ */
+
+import type { FabricValue } from "./interface.ts";
+
+/**
+ * Sentinel marker used to wrap content that should appear unquoted in the
+ * final output. The replacer brackets a bare-token payload (e.g. `42n` or
+ * `undefined`) with this marker; a post-processing pass then strips both the
+ * markers and the surrounding JSON-string quotes.
+ */
+const UNQUOTE_MARKER = "@@DEBUG_UNQUOTE@@";
+
+/** Regex matching a marked, JSON-quoted payload. Group 1 is the payload. */
+const UNQUOTE_RE = /"@@DEBUG_UNQUOTE@@(.*?)@@DEBUG_UNQUOTE@@"/g;
+
+/**
+ * `JSON.stringify()` replacer that handles `bigint` and `undefined`, which it
+ * otherwise mishandles for our debugging purposes (throws on `bigint`, and
+ * silently drops/rewrites `undefined`). The returned strings carry their
+ * desired bare-token form between sentinel markers.
+ */
+function debugReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === "bigint") {
+    return `${UNQUOTE_MARKER}${value}n${UNQUOTE_MARKER}`;
+  } else if (value === undefined) {
+    return `${UNQUOTE_MARKER}undefined${UNQUOTE_MARKER}`;
+  } else {
+    return value;
+  }
+}
+
+/** Strips sentinel markers (and surrounding JSON quotes) in a stringify output. */
+function unquoteMarked(json: string): string {
+  return json.replace(UNQUOTE_RE, "$1");
+}
+
+/**
+ * Produces a compact string representation of a value. In _many_ cases, the
+ * output of this function is valid JSON text, but not _all_ cases. This
+ * function must _not_ be relied on to produce a parseable string.
+ */
+export function toCompactDebugString(value: FabricValue): string {
+  // TODO(danfuzz): This function will have to get smarter once we have values
+  // that go beyond what's representable as JSON text.
+  return unquoteMarked(JSON.stringify(value, debugReplacer));
+}
+
+/**
+ * Produces an indented string representation of a value. In _many_ cases, the
+ * output of this function is valid JSON text, but not _all_ cases. This
+ * function must _not_ be relied on to produce a parseable string.
+ */
+export function toIndentedDebugString(value: FabricValue): string {
+  // TODO(danfuzz): This function will have to get smarter once we have values
+  // that go beyond what's representable as JSON text.
+  return unquoteMarked(JSON.stringify(value, debugReplacer, 2));
+}


### PR DESCRIPTION
This PR adds a small handful of utilities / helpers, for use in cleaning up the main codebase:

* `seemsLikeJsonEncodedFabricValue()` — does as it says on the tin. This is meant to be a quick "sniff test" for strings to see if they are likely to be encoded values from `data-model`. The twist: Though the two dispatched functions for this are identical right now, in the near future the one for the JSON flag-on case will become different (and much simpler).
* `toCompactDebugString()` and `toIndentedDebugString()` — These are meant to replace raw calls to `JSON.stringify()` in contexts where the output isn't meant for system reconsumption, and in fact you can't expect the output to even be reparsable as JSON. For example, this will plop the literal unquoted text `undefined` when an `undefined` is encountered, and it will represent bigints in JS syntax form (e.g., `42n` and not just `42` or quoted `"42n"`).