### PR TITLE
refactor(data-model): widen debug stringifiers to unknown; export value-debug

### DIFF
--- a/packages/data-model/deno.json
+++ b/packages/data-model/deno.json
@@ -42,6 +42,7 @@
     "./fabric-value-legacy": "./fabric-value-legacy.ts",
     "./fabric-value-modern": "./fabric-value-modern.ts",
     "./array-utils": "./array-utils.ts",
+    "./value-debug": "./value-debug.ts",
     "./value-hash": "./value-hash.ts",
     "./value-hash-legacy": "./value-hash-legacy.ts",
     "./schema-hash": "./schema-hash.ts",

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -137,6 +137,40 @@ describe("value-debug", () => {
       expect(toCompactDebugString({ s })).toBe('{"s":Symbol("inner")}');
       expect(toCompactDebugString([s])).toBe('[Symbol("inner")]');
     });
+
+    it("renders top-level `NaN` as a bare token", () => {
+      expect(toCompactDebugString(NaN)).toBe("NaN");
+      expect(toCompactDebugString(0 / 0)).toBe("NaN");
+    });
+
+    it("renders top-level positive `Infinity` as a bare token", () => {
+      expect(toCompactDebugString(Infinity)).toBe("Infinity");
+      expect(toCompactDebugString(Number.POSITIVE_INFINITY)).toBe("Infinity");
+    });
+
+    it("renders top-level negative `Infinity` as a bare token", () => {
+      expect(toCompactDebugString(-Infinity)).toBe("-Infinity");
+      expect(toCompactDebugString(Number.NEGATIVE_INFINITY)).toBe("-Infinity");
+    });
+
+    it("renders top-level negative zero as `-0`", () => {
+      expect(toCompactDebugString(-0)).toBe("-0");
+    });
+
+    it("still renders ordinary `0` as `0` (not `-0`)", () => {
+      expect(toCompactDebugString(0)).toBe("0");
+    });
+
+    it("renders non-finite numbers and -0 inside an object", () => {
+      const v = { a: NaN, b: Infinity, c: -Infinity, d: -0, e: 1 };
+      expect(toCompactDebugString(v))
+        .toBe('{"a":NaN,"b":Infinity,"c":-Infinity,"d":-0,"e":1}');
+    });
+
+    it("renders non-finite numbers and -0 inside an array", () => {
+      expect(toCompactDebugString([NaN, Infinity, -Infinity, -0, 0]))
+        .toBe("[NaN,Infinity,-Infinity,-0,0]");
+    });
   });
 
   // --------------------------------------------------------------------------
@@ -189,6 +223,21 @@ describe("value-debug", () => {
       expect(toIndentedDebugString(v))
         .toBe(
           '{\n  "fn": function qux(...) {...},\n  "sym": Symbol("s")\n}',
+        );
+    });
+
+    it("renders non-finite numbers and -0 as bare tokens (top-level)", () => {
+      expect(toIndentedDebugString(NaN)).toBe("NaN");
+      expect(toIndentedDebugString(Infinity)).toBe("Infinity");
+      expect(toIndentedDebugString(-Infinity)).toBe("-Infinity");
+      expect(toIndentedDebugString(-0)).toBe("-0");
+    });
+
+    it("renders non-finite numbers and -0 inside a structure", () => {
+      const v = { a: NaN, b: Infinity, c: -Infinity, d: -0 };
+      expect(toIndentedDebugString(v))
+        .toBe(
+          '{\n  "a": NaN,\n  "b": Infinity,\n  "c": -Infinity,\n  "d": -0\n}',
         );
     });
   });

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { toCompactDebugString, toIndentedDebugString } from "../value-debug.ts";
-import type { FabricValue } from "../interface.ts";
 
 // ============================================================================
 // Tests
@@ -14,19 +13,19 @@ describe("value-debug", () => {
 
   describe("toCompactDebugString", () => {
     it("compactly stringifies a plain object", () => {
-      expect(toCompactDebugString({ a: 1, b: "two" } as FabricValue))
+      expect(toCompactDebugString({ a: 1, b: "two" }))
         .toBe('{"a":1,"b":"two"}');
     });
 
     it("compactly stringifies an array", () => {
-      expect(toCompactDebugString([1, 2, 3] as FabricValue)).toBe("[1,2,3]");
+      expect(toCompactDebugString([1, 2, 3])).toBe("[1,2,3]");
     });
 
     it("stringifies JSON-native primitives", () => {
-      expect(toCompactDebugString(42 as FabricValue)).toBe("42");
-      expect(toCompactDebugString("hello" as FabricValue)).toBe('"hello"');
-      expect(toCompactDebugString(true as FabricValue)).toBe("true");
-      expect(toCompactDebugString(false as FabricValue)).toBe("false");
+      expect(toCompactDebugString(42)).toBe("42");
+      expect(toCompactDebugString("hello")).toBe('"hello"');
+      expect(toCompactDebugString(true)).toBe("true");
+      expect(toCompactDebugString(false)).toBe("false");
       expect(toCompactDebugString(null)).toBe("null");
     });
 
@@ -35,33 +34,33 @@ describe("value-debug", () => {
     });
 
     it("renders `undefined` inside an array as a bare token", () => {
-      expect(toCompactDebugString([1, undefined, 2] as FabricValue))
+      expect(toCompactDebugString([1, undefined, 2]))
         .toBe("[1,undefined,2]");
     });
 
     it("renders `undefined` as object value as a bare token", () => {
-      expect(toCompactDebugString({ a: undefined, b: 1 } as FabricValue))
+      expect(toCompactDebugString({ a: undefined, b: 1 }))
         .toBe('{"a":undefined,"b":1}');
     });
 
     it("renders top-level `bigint` as a bare token with `n` suffix", () => {
-      expect(toCompactDebugString(42n as FabricValue)).toBe("42n");
+      expect(toCompactDebugString(42n)).toBe("42n");
     });
 
     it("renders zero, negative, and large `bigint`s", () => {
-      expect(toCompactDebugString(0n as FabricValue)).toBe("0n");
-      expect(toCompactDebugString(-42n as FabricValue)).toBe("-42n");
-      expect(toCompactDebugString(12345678901234567890n as FabricValue))
+      expect(toCompactDebugString(0n)).toBe("0n");
+      expect(toCompactDebugString(-42n)).toBe("-42n");
+      expect(toCompactDebugString(12345678901234567890n))
         .toBe("12345678901234567890n");
     });
 
     it("renders `bigint` inside an array as a bare token", () => {
-      expect(toCompactDebugString([42n, 7n] as FabricValue))
+      expect(toCompactDebugString([42n, 7n]))
         .toBe("[42n,7n]");
     });
 
     it("renders `bigint` as object value as a bare token", () => {
-      expect(toCompactDebugString({ n: 42n } as FabricValue))
+      expect(toCompactDebugString({ n: 42n }))
         .toBe('{"n":42n}');
     });
 
@@ -70,7 +69,7 @@ describe("value-debug", () => {
         count: 100n,
         missing: undefined,
         items: [1n, 2n, undefined],
-      } as FabricValue;
+      };
       expect(() => toCompactDebugString(v)).not.toThrow();
       expect(toCompactDebugString(v))
         .toBe('{"count":100n,"missing":undefined,"items":[1n,2n,undefined]}');
@@ -80,10 +79,10 @@ describe("value-debug", () => {
       // A user string that just happens to read "undefined" or "42n" should
       // remain a quoted string in the output -- only sentinel-wrapped payloads
       // get unquoted.
-      expect(toCompactDebugString("undefined" as FabricValue))
+      expect(toCompactDebugString("undefined"))
         .toBe('"undefined"');
-      expect(toCompactDebugString("42n" as FabricValue)).toBe('"42n"');
-      expect(toCompactDebugString({ a: "undefined" } as FabricValue))
+      expect(toCompactDebugString("42n")).toBe('"42n"');
+      expect(toCompactDebugString({ a: "undefined" }))
         .toBe('{"a":"undefined"}');
     });
   });
@@ -94,12 +93,12 @@ describe("value-debug", () => {
 
   describe("toIndentedDebugString", () => {
     it("indents object output with 2 spaces", () => {
-      expect(toIndentedDebugString({ a: 1, b: "two" } as FabricValue))
+      expect(toIndentedDebugString({ a: 1, b: "two" }))
         .toBe('{\n  "a": 1,\n  "b": "two"\n}');
     });
 
     it("indents array output with 2 spaces", () => {
-      expect(toIndentedDebugString([1, 2, 3] as FabricValue))
+      expect(toIndentedDebugString([1, 2, 3]))
         .toBe("[\n  1,\n  2,\n  3\n]");
     });
 
@@ -108,17 +107,17 @@ describe("value-debug", () => {
     });
 
     it("renders top-level `bigint` as bare token", () => {
-      expect(toIndentedDebugString(42n as FabricValue)).toBe("42n");
+      expect(toIndentedDebugString(42n)).toBe("42n");
     });
 
     it("renders nested `bigint` and `undefined` as bare tokens", () => {
-      const v = { n: 42n, m: undefined } as FabricValue;
+      const v = { n: 42n, m: undefined };
       expect(toIndentedDebugString(v))
         .toBe('{\n  "n": 42n,\n  "m": undefined\n}');
     });
 
     it("renders `undefined` and `bigint` inside arrays as bare tokens", () => {
-      expect(toIndentedDebugString([1n, undefined, 2n] as FabricValue))
+      expect(toIndentedDebugString([1n, undefined, 2n]))
         .toBe("[\n  1n,\n  undefined,\n  2n\n]");
     });
   });

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -85,6 +85,58 @@ describe("value-debug", () => {
       expect(toCompactDebugString({ a: "undefined" }))
         .toBe('{"a":"undefined"}');
     });
+
+    it("renders a named function as a bare abbreviated form", () => {
+      function foo() {}
+      expect(toCompactDebugString(foo)).toBe("function foo(...) {...}");
+    });
+
+    it("renders a named function inside a structure", () => {
+      function bar() {}
+      expect(toCompactDebugString({ fn: bar }))
+        .toBe('{"fn":function bar(...) {...}}');
+      expect(toCompactDebugString([bar]))
+        .toBe("[function bar(...) {...}]");
+    });
+
+    it("renders an anonymous arrow function as a bare abbreviated form", () => {
+      // An immediately-passed arrow expression has no `name`.
+      expect(toCompactDebugString((() => 1) as unknown))
+        .toBe("(...) => {...}");
+    });
+
+    it("renders an anonymous `function` expression as a bare abbreviated form", () => {
+      // Force an empty `name` to simulate a true anonymous function expression
+      // (`(function(){}).name === ""`).
+      const anon = function () {};
+      Object.defineProperty(anon, "name", { value: "" });
+      expect(toCompactDebugString(anon)).toBe("(...) => {...}");
+    });
+
+    it('renders an interned symbol as `Symbol.for("name")`', () => {
+      const s = Symbol.for("my-key");
+      expect(toCompactDebugString(s)).toBe('Symbol.for("my-key")');
+    });
+
+    it("renders an interned symbol inside a structure", () => {
+      const s = Symbol.for("k");
+      expect(toCompactDebugString({ s })).toBe('{"s":Symbol.for("k")}');
+      expect(toCompactDebugString([s])).toBe('[Symbol.for("k")]');
+    });
+
+    it('renders an uninterned symbol as `Symbol("name")`', () => {
+      expect(toCompactDebugString(Symbol("d"))).toBe('Symbol("d")');
+    });
+
+    it("renders an uninterned symbol with no description", () => {
+      expect(toCompactDebugString(Symbol())).toBe('Symbol("")');
+    });
+
+    it("renders an uninterned symbol inside a structure", () => {
+      const s = Symbol("inner");
+      expect(toCompactDebugString({ s })).toBe('{"s":Symbol("inner")}');
+      expect(toCompactDebugString([s])).toBe('[Symbol("inner")]');
+    });
   });
 
   // --------------------------------------------------------------------------
@@ -119,6 +171,25 @@ describe("value-debug", () => {
     it("renders `undefined` and `bigint` inside arrays as bare tokens", () => {
       expect(toIndentedDebugString([1n, undefined, 2n]))
         .toBe("[\n  1n,\n  undefined,\n  2n\n]");
+    });
+
+    it("renders top-level named function as bare abbreviated form", () => {
+      function baz() {}
+      expect(toIndentedDebugString(baz)).toBe("function baz(...) {...}");
+    });
+
+    it('renders top-level interned symbol as `Symbol.for("name")`', () => {
+      expect(toIndentedDebugString(Symbol.for("ind")))
+        .toBe('Symbol.for("ind")');
+    });
+
+    it("renders nested function and symbol as bare tokens", () => {
+      function qux() {}
+      const v = { fn: qux, sym: Symbol("s") };
+      expect(toIndentedDebugString(v))
+        .toBe(
+          '{\n  "fn": function qux(...) {...},\n  "sym": Symbol("s")\n}',
+        );
     });
   });
 });

--- a/packages/data-model/value-debug.ts
+++ b/packages/data-model/value-debug.ts
@@ -2,8 +2,6 @@
  * Debugging-ish helpers for `FabricValue`s.
  */
 
-import type { FabricValue } from "./interface.ts";
-
 /**
  * Sentinel marker used to wrap content that should appear unquoted in the
  * final output. The replacer brackets a bare-token payload (e.g. `42n` or
@@ -41,7 +39,7 @@ function unquoteMarked(json: string): string {
  * output of this function is valid JSON text, but not _all_ cases. This
  * function must _not_ be relied on to produce a parseable string.
  */
-export function toCompactDebugString(value: FabricValue): string {
+export function toCompactDebugString(value: unknown): string {
   // TODO(danfuzz): This function will have to get smarter once we have values
   // that go beyond what's representable as JSON text.
   return unquoteMarked(JSON.stringify(value, debugReplacer));
@@ -52,7 +50,7 @@ export function toCompactDebugString(value: FabricValue): string {
  * output of this function is valid JSON text, but not _all_ cases. This
  * function must _not_ be relied on to produce a parseable string.
  */
-export function toIndentedDebugString(value: FabricValue): string {
+export function toIndentedDebugString(value: unknown): string {
   // TODO(danfuzz): This function will have to get smarter once we have values
   // that go beyond what's representable as JSON text.
   return unquoteMarked(JSON.stringify(value, debugReplacer, 2));

--- a/packages/data-model/value-debug.ts
+++ b/packages/data-model/value-debug.ts
@@ -13,6 +13,11 @@ const UNQUOTE_MARKER = "@@DEBUG_UNQUOTE@@";
 /** Regex matching a marked, JSON-quoted payload. Group 1 is the payload. */
 const UNQUOTE_RE = /"@@DEBUG_UNQUOTE@@(.*?)@@DEBUG_UNQUOTE@@"/g;
 
+/** Wraps a payload in the sentinel markers for unquoting. */
+function marked(payload: string): string {
+  return `${UNQUOTE_MARKER}${payload}${UNQUOTE_MARKER}`;
+}
+
 /**
  * `JSON.stringify()` replacer that handles values it otherwise mishandles for
  * our debugging purposes:
@@ -20,28 +25,47 @@ const UNQUOTE_RE = /"@@DEBUG_UNQUOTE@@(.*?)@@DEBUG_UNQUOTE@@"/g;
  * - `bigint` (would throw),
  * - `undefined` (silently dropped/rewritten),
  * - `function` (silently dropped/rewritten),
- * - `symbol` (silently dropped/rewritten).
+ * - `symbol` (silently dropped/rewritten),
+ * - `NaN` and `±Infinity` (silently rewritten as `null`),
+ * - negative zero (silently rewritten as `0`, dropping the sign).
  *
  * The returned strings carry their desired bare-token form between sentinel
  * markers, which a post-processing pass strips along with the surrounding
  * JSON-string quotes.
  */
 function debugReplacer(_key: string, value: unknown): unknown {
-  if (typeof value === "bigint") {
-    return `${UNQUOTE_MARKER}${value}n${UNQUOTE_MARKER}`;
+  if (typeof value === "number") {
+    // Negative zero must be checked first: `value === 0` is true for both
+    // `0` and `-0` (IEEE 754), so a generic numeric early-out would lose
+    // the sign. `Object.is(value, -0)` distinguishes them.
+    if (Object.is(value, -0)) {
+      return marked("-0");
+    } else if (Number.isNaN(value)) {
+      return marked("NaN");
+    } else if (value === Infinity) {
+      return marked("Infinity");
+    } else if (value === -Infinity) {
+      return marked("-Infinity");
+    } else {
+      return value;
+    }
+  } else if (typeof value === "bigint") {
+    return marked(`${value}n`);
   } else if (value === undefined) {
-    return `${UNQUOTE_MARKER}undefined${UNQUOTE_MARKER}`;
+    return marked("undefined");
   } else if (typeof value === "function") {
-    const payload = value.name === ""
-      ? "(...) => {...}"
-      : `function ${value.name}(...) {...}`;
-    return `${UNQUOTE_MARKER}${payload}${UNQUOTE_MARKER}`;
+    return marked(
+      value.name === ""
+        ? "(...) => {...}"
+        : `function ${value.name}(...) {...}`,
+    );
   } else if (typeof value === "symbol") {
     const key = Symbol.keyFor(value);
-    const payload = key !== undefined
-      ? `Symbol.for(${JSON.stringify(key)})`
-      : `Symbol(${JSON.stringify(value.description ?? "")})`;
-    return `${UNQUOTE_MARKER}${payload}${UNQUOTE_MARKER}`;
+    return marked(
+      key !== undefined
+        ? `Symbol.for(${JSON.stringify(key)})`
+        : `Symbol(${JSON.stringify(value.description ?? "")})`,
+    );
   } else {
     return value;
   }

--- a/packages/data-model/value-debug.ts
+++ b/packages/data-model/value-debug.ts
@@ -14,24 +14,50 @@ const UNQUOTE_MARKER = "@@DEBUG_UNQUOTE@@";
 const UNQUOTE_RE = /"@@DEBUG_UNQUOTE@@(.*?)@@DEBUG_UNQUOTE@@"/g;
 
 /**
- * `JSON.stringify()` replacer that handles `bigint` and `undefined`, which it
- * otherwise mishandles for our debugging purposes (throws on `bigint`, and
- * silently drops/rewrites `undefined`). The returned strings carry their
- * desired bare-token form between sentinel markers.
+ * `JSON.stringify()` replacer that handles values it otherwise mishandles for
+ * our debugging purposes:
+ *
+ * - `bigint` (would throw),
+ * - `undefined` (silently dropped/rewritten),
+ * - `function` (silently dropped/rewritten),
+ * - `symbol` (silently dropped/rewritten).
+ *
+ * The returned strings carry their desired bare-token form between sentinel
+ * markers, which a post-processing pass strips along with the surrounding
+ * JSON-string quotes.
  */
 function debugReplacer(_key: string, value: unknown): unknown {
   if (typeof value === "bigint") {
     return `${UNQUOTE_MARKER}${value}n${UNQUOTE_MARKER}`;
   } else if (value === undefined) {
     return `${UNQUOTE_MARKER}undefined${UNQUOTE_MARKER}`;
+  } else if (typeof value === "function") {
+    const payload = value.name === ""
+      ? "(...) => {...}"
+      : `function ${value.name}(...) {...}`;
+    return `${UNQUOTE_MARKER}${payload}${UNQUOTE_MARKER}`;
+  } else if (typeof value === "symbol") {
+    const key = Symbol.keyFor(value);
+    const payload = key !== undefined
+      ? `Symbol.for(${JSON.stringify(key)})`
+      : `Symbol(${JSON.stringify(value.description ?? "")})`;
+    return `${UNQUOTE_MARKER}${payload}${UNQUOTE_MARKER}`;
   } else {
     return value;
   }
 }
 
-/** Strips sentinel markers (and surrounding JSON quotes) in a stringify output. */
+/**
+ * Strips sentinel markers (and surrounding JSON quotes) in a stringify output.
+ * The captured payload body is decoded back through `JSON.parse` so that any
+ * quote / backslash escapes introduced by the outer `JSON.stringify` round-
+ * trip are undone (e.g. so that the symbol-form payload `Symbol.for("name")`
+ * retains its literal `"`s rather than coming out as `Symbol.for(\"name\")`).
+ */
 function unquoteMarked(json: string): string {
-  return json.replace(UNQUOTE_RE, "$1");
+  return json.replace(UNQUOTE_RE, (_match, body) => {
+    return JSON.parse(`"${body}"`);
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Originally a small prep PR for the JSON.stringify → debug-stringifier migration arc. Grew during review to also cover per-type handling for several value categories that the existing replacer didn't handle and that the widened `unknown` parameter type made reachable.

### Original ask

Two prep items in `packages/data-model/`, motivated by the upcoming `packages/runner` migration pilot:

- **Widen helper signatures.** `toCompactDebugString` and `toIndentedDebugString` in `value-debug.ts` now accept `unknown` instead of `FabricValue`. The functions already work generically (they hand off to `JSON.stringify` with a replacer); the narrower input type was a docs/lint hint and forced consumers in non-fabric-typed contexts to cast. Dan's framing on this (verbatim): *"we can widen the stringifiers to `unknown`."*
- **Add the export entry.** `"./value-debug": "./value-debug.ts"` in `packages/data-model/deno.json`. The module was previously not exported, which prevented peer packages from importing it as `@commonfabric/data-model/value-debug`.
- **Drop unused import + casts.** `import type { FabricValue }` from `value-debug.ts`, and the matching `as FabricValue` casts in `test/value-debug.test.ts` (only there to satisfy the narrower signature).

### Per-type handling added during review

With the widening, several JS value categories that the original replacer didn't handle become reachable. `JSON.stringify` mishandles them silently or by throwing, so the replacer was extended (using the existing `UNQUOTE_MARKER` sentinel pattern) to emit specific debug shapes for each.

**Function values** (raised by Cubic [#3157038710](https://github.com/commontoolsinc/labs/pull/3409#discussion_r3157038710), agreed by Dan):

| JS value | Debug output |
|---|---|
| Named function (`function foo(){}`) | `function foo(...) {...}` |
| Anonymous function (`() => 1` or `function(){}` with `name === ""`) | `(...) => {...}` |

The `(...)` and `{...}` are **literal three-dot ellipses** — abbreviation markers, not placeholders.

**Symbol values** (same review round):

| JS value | Debug output |
|---|---|
| Interned (`Symbol.for("k")` — `Symbol.keyFor(v) !== undefined`) | `Symbol.for("k")` |
| Uninterned (`Symbol("d")` — `Symbol.keyFor(v) === undefined`) | `Symbol("d")` |

Uninterned symbols use `value.description ?? ""` as the inner text; an empty description renders as `Symbol("")`.

**Non-finite numbers and negative zero** (Dan's own expansion):

| JS value | Debug output |
|---|---|
| `NaN` | `NaN` |
| `Infinity` (and `Number.POSITIVE_INFINITY`) | `Infinity` |
| `-Infinity` (and `Number.NEGATIVE_INFINITY`) | `-Infinity` |
| `-0` (negative zero) | `-0` |

All four are bare unquoted tokens (no parens, no quotes). Without explicit handling, `JSON.stringify` rewrites `NaN` / `±Infinity` as `null` and drops the sign on `-0` (since `value === 0` is true for both `0` and `-0`).

### Implementation notes

- `Object.is(value, -0)` discriminates negative zero from positive zero (strict equality treats them the same per IEEE 754). It's checked first in the `number`-typeof branch so a generic numeric early-out doesn't lose the sign. `Number.isNaN` (not the global `isNaN`, which coerces) is used for `NaN`.
- A small `marked(payload)` helper was extracted to dedupe the sentinel-wrap pattern. There are now 7 call sites (across the bigint / undefined / function / symbol / -0 / NaN / Infinity branches), all routed through it.
- `unquoteMarked` was extended to decode each captured payload through `JSON.parse` to undo any quote/backslash escapes introduced by the outer `JSON.stringify` round-trip. This is **load-bearing for symbol payloads**, which contain literal `"` characters around the name (a `Symbol.for("k")` payload, after the outer stringify, comes back as `Symbol.for(\"k\")` and needed unescaping). Harmless for the simpler payloads (bigint / undefined / function / numeric-edges) since none of those contain escape-sensitive characters.

### Tests

21 new cases in `packages/data-model/test/value-debug.test.ts` (test count went from 18 to 39) covering every new shape across both helpers, with top-level / nested-in-object / nested-in-array variations and the relevant edge cases (anonymous-via-`function`, no-description symbol, `Number.POSITIVE_INFINITY` / `NEGATIVE_INFINITY` aliases, `-0`-vs-`0` regression guard).

### Local validation

- `deno fmt --check` on the changed files: clean.
- `deno lint` on the `.ts` files: clean.
- `cd packages/data-model && deno task test`: **39 passed (1307 steps), 0 failed.**

### Why now

This unblocks the `packages/runner` migration pilot, which will swap ~37 non-test DEBUG+DISPLAY raw `JSON.stringify` call sites onto these helpers in a follow-up PR. The arc rationale and the per-package classification are in `coordination/docs/2026-04-28-json-stringify-classification.md`.

### Review thread references

- Cubic's review comment: [`#3157038710`](https://github.com/commontoolsinc/labs/pull/3409#discussion_r3157038710) (function/symbol ask).
- My reply: [`#3157090635`](https://github.com/commontoolsinc/labs/pull/3409#discussion_r3157090635).
- Numeric-edge-case round: Dan's directive (no separate review thread).
