### PR TITLE
Add EMPTY_RECONSTRUCTION_CONTEXT; make valueFromJson runtime arg optional

### DIFF
--- a/packages/data-model/empty-reconstruction-context.ts
+++ b/packages/data-model/empty-reconstruction-context.ts
@@ -1,0 +1,25 @@
+/**
+ * Empty `ReconstructionContext`: a singleton whose `getCell()` always throws.
+ * Useful as a default for decode paths that aren't expected to encounter
+ * `Cell` references (e.g. storage-boundary reads of values known to be
+ * structurally flat).
+ */
+
+import type { FabricInstance, ReconstructionContext } from "./interface.ts";
+
+/**
+ * Shared `ReconstructionContext` instance whose `getCell()` always throws.
+ * Pass this when a decoder wants a context object but isn't expected to need
+ * cell reconstruction; if a cell ref does turn up, the throw makes the
+ * unexpected reconstruction obvious instead of silent.
+ */
+export const EMPTY_RECONSTRUCTION_CONTEXT: ReconstructionContext = Object
+  .freeze({
+    getCell(
+      ref: { id: string; path: string[]; space: string },
+    ): FabricInstance {
+      throw new Error(
+        `Cannot reconstruct cell reference \`${ref.id}\`: no runtime context provided.`,
+      );
+    },
+  });

--- a/packages/data-model/json-encoding-modern.ts
+++ b/packages/data-model/json-encoding-modern.ts
@@ -4,6 +4,7 @@
 
 import type { FabricValue } from "./fabric-value.ts";
 import type { ReconstructionContext } from "./fabric-value.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "./empty-reconstruction-context.ts";
 import { JsonEncodingContext } from "./json-encoding-context.ts";
 
 /** Shared JSON encoding context. */
@@ -52,11 +53,17 @@ export function seemsLikeJsonEncodedFabricValueModern(value: string): boolean {
 }
 
 /**
- * Decodes a JSON string back into a fabric value.
+ * Decodes a JSON string back into a fabric value. If `runtime` is `undefined`,
+ * the shared `EMPTY_RECONSTRUCTION_CONTEXT` is used; that context throws on
+ * any `getCell()` call, so callers who pass `undefined` are implicitly
+ * asserting that the encoded value contains no cell references.
  */
 export function valueFromJsonModern(
   json: string,
-  runtime: ReconstructionContext,
+  runtime: ReconstructionContext | undefined,
 ): FabricValue {
-  return jsonEncodingContext.decode(json, runtime);
+  return jsonEncodingContext.decode(
+    json,
+    runtime ?? EMPTY_RECONSTRUCTION_CONTEXT,
+  );
 }

--- a/packages/data-model/json-encoding.ts
+++ b/packages/data-model/json-encoding.ts
@@ -80,11 +80,13 @@ export function seemsLikeJsonEncodedFabricValue(value: string): boolean {
 /**
  * Decodes a JSON string back into a fabric value. When unified JSON encoding is
  * ON, uses the modern JSON-based format. When OFF, equivalent to
- * `JSON.parse(json)`.
+ * `JSON.parse(json)`. The `runtime` argument is only consulted when the flag
+ * is ON; if omitted, the shared `EMPTY_RECONSTRUCTION_CONTEXT` is substituted,
+ * which throws if any cell reconstruction is needed.
  */
 export function valueFromJson(
   json: string,
-  runtime: ReconstructionContext,
+  runtime?: ReconstructionContext,
 ): FabricValue {
   if (jsonEncodingEnabled) {
     return valueFromJsonModern(json, runtime);

--- a/packages/data-model/test/empty-reconstruction-context.test.ts
+++ b/packages/data-model/test/empty-reconstruction-context.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "../empty-reconstruction-context.ts";
+
+describe("EMPTY_RECONSTRUCTION_CONTEXT", () => {
+  it("is a singleton (re-import yields the same instance)", async () => {
+    const reimported = (await import("../empty-reconstruction-context.ts"))
+      .EMPTY_RECONSTRUCTION_CONTEXT;
+    expect(reimported).toBe(EMPTY_RECONSTRUCTION_CONTEXT);
+  });
+
+  it("throws on getCell()", () => {
+    expect(() =>
+      EMPTY_RECONSTRUCTION_CONTEXT.getCell({
+        id: "of:bafyabc",
+        path: [],
+        space: "did:key:z1",
+      })
+    ).toThrow();
+  });
+
+  it("throw includes the requested ref id for debuggability", () => {
+    expect(() =>
+      EMPTY_RECONSTRUCTION_CONTEXT.getCell({
+        id: "of:bafySPECIFIC",
+        path: [],
+        space: "did:key:z1",
+      })
+    ).toThrow(/of:bafySPECIFIC/);
+  });
+
+  it("is frozen (cannot have getCell replaced)", () => {
+    expect(Object.isFrozen(EMPTY_RECONSTRUCTION_CONTEXT)).toBe(true);
+  });
+});

--- a/packages/data-model/test/json-encoding.test.ts
+++ b/packages/data-model/test/json-encoding.test.ts
@@ -396,4 +396,39 @@ describe("json-encoding", () => {
       expect(seemsLikeJsonEncodedFabricValue("NaN")).toBe(false);
     });
   });
+
+  // --------------------------------------------------------------------------
+  // valueFromJson with omitted runtime
+  // --------------------------------------------------------------------------
+
+  describe("valueFromJson without a runtime argument", () => {
+    it("decodes a plain object (flag OFF)", () => {
+      expect(valueFromJson('{"a":1}')).toEqual({ a: 1 });
+    });
+
+    it("decodes a plain object (flag ON)", () => {
+      setJsonEncodingConfig(true);
+      expect(valueFromJson('{"a":1}')).toEqual({ a: 1 });
+    });
+
+    it("decodes a primitive (flag OFF)", () => {
+      expect(valueFromJson("42")).toBe(42);
+    });
+
+    it("decodes a primitive (flag ON)", () => {
+      setJsonEncodingConfig(true);
+      expect(valueFromJson("42")).toBe(42);
+    });
+
+    it("decodes tagged values that don't need cell reconstruction (flag ON)", () => {
+      setJsonEncodingConfig(true);
+      expect(valueFromJson('{"\/Undefined@1":null}')).toBe(undefined);
+      expect(valueFromJson('{"\/BigInt@1":"Kg"}')).toBe(42n);
+    });
+
+    it("explicit `undefined` runtime is equivalent to omission", () => {
+      setJsonEncodingConfig(true);
+      expect(valueFromJson('{"a":1}', undefined)).toEqual({ a: 1 });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a shared `EMPTY_RECONSTRUCTION_CONTEXT` singleton (in a new `packages/data-model/empty-reconstruction-context.ts`) whose `getCell()` always throws — and includes the offending ref id in the error.
- Makes `runtime` optional in the public `valueFromJson()` and explicitly `| undefined` in `valueFromJsonModern()`; an omitted (or explicit `undefined`) runtime is substituted with `EMPTY_RECONSTRUCTION_CONTEXT`. `JsonEncodingContext.decode()` itself stays strict.

## Why

Several decode call sites read values that are known to be structurally flat (no `Cell` references) and currently hand-roll their own throw-on-`getCell` context, or skip the data-model decoder entirely and use raw `JSON.parse`. This PR gives them a canonical drop-in default so they can use `valueFromJson(json)` without manufacturing a runtime — and an unexpected cell ref turns into a clear, named-id error instead of a silent or generic one.

This is a no-op in `main` today (existing callers all pass an explicit `runtime`); it sets up follow-up PRs that migrate raw-`JSON.parse` reads in the memory layer onto `valueFromJson`.

## Test plan

- [x] `deno task test` in `packages/data-model` — 40 suites / 1318 steps, 0 failed
- [x] New `test/empty-reconstruction-context.test.ts`: singleton identity, `getCell` throws, error message includes the ref id, instance is frozen
- [x] New cases in `test/json-encoding.test.ts` under "valueFromJson without a runtime argument": plain object decode (flag OFF + ON), primitive decode (flag OFF + ON), tagged values that don't need cell reconstruction (flag ON), explicit `undefined` parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)
