### PR TITLE
refactor(runner): swap raw JSON.stringify for {Compact,Indented}DebugString in non-test DEBUG+DISPLAY sites

### DIFF
--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -1,3 +1,4 @@
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { isRecord } from "@commonfabric/utils/types";
 import {
   type Frame,
@@ -429,7 +430,7 @@ function formatStableCauseSegment(cause: unknown): string {
   }
 
   try {
-    return JSON.stringify(cause) ?? String(cause);
+    return toCompactDebugString(cause);
   } catch {
     return String(cause);
   }

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -1,4 +1,3 @@
-import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { isRecord } from "@commonfabric/utils/types";
 import {
   type Frame,
@@ -430,7 +429,7 @@ function formatStableCauseSegment(cause: unknown): string {
   }
 
   try {
-    return toCompactDebugString(cause);
+    return JSON.stringify(cause) ?? String(cause);
   } catch {
     return String(cause);
   }

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -13,6 +13,7 @@ import { type Runtime, spaceCellSchema } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { NAME, type Pattern, UI } from "../builder/types.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getPatternEnvironment } from "../env.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 
@@ -768,7 +769,7 @@ export function wish(
 
       if (query === undefined || query === null || query === "") {
         const errorMsg = `Wish target "${
-          JSON.stringify(targetValue)
+          toCompactDebugString(targetValue)
         }" has no query.`;
         wishFlowLogger.debug(`wish/error/${queryKey}`, () => [
           `[WISH ERROR] source=${sourceKey}`,
@@ -794,7 +795,7 @@ export function wish(
           `query=${query}`,
           `scope=${formatScope(scope)}`,
           `headless=${Boolean(headless)}`,
-          `path=${JSON.stringify(path ?? [])}`,
+          `path=${toCompactDebugString(path ?? [])}`,
           `parent=${describeCell(parentCell)}`,
         ]);
         wishFlowLogger.debug(

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -6,6 +6,7 @@ import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { CellKind, JSONSchema } from "./builder/types.ts";
 import { CycleTracker } from "./traverse.ts";
 import { isArrayIndexPropertyName } from "@commonfabric/data-model/fabric-value";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { rendererVDOMSchema, vnodeSchema } from "@commonfabric/runner/schemas";
 import { decodeJsonPointer } from "./link-types.ts";
 export { CFC_ATOM_TYPE, CFC_RUNTIME_SUBJECT, cfcAtom } from "./cfc/atoms.ts";
@@ -382,7 +383,7 @@ export class ContextualFlowControl {
     if (resolved === undefined) {
       const ref = "$ref" in schemaObj
         ? schemaObj.$ref
-        : JSON.stringify(schemaObj);
+        : toCompactDebugString(schemaObj);
       throw new Error(
         `Failed to resolve $ref: ${ref}. ` +
           (typeof ref === "string" && ref.startsWith("http")
@@ -390,7 +391,7 @@ export class ContextualFlowControl {
               `If you added a new native type to NATIVE_TYPE_SCHEMAS in ` +
               `packages/schema-generator/src/formatters/native-type-formatter.ts, ` +
               `add its schema to embeddedSchemas as well.`
-            : `Schema: ${JSON.stringify(schemaObj)}`),
+            : `Schema: ${toCompactDebugString(schemaObj)}`),
       );
     }
     return resolved;

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -5,6 +5,7 @@ import {
   isArrayIndexPropertyName,
   shallowFabricFromNativeValue,
 } from "@commonfabric/data-model/fabric-value";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
 import { ID, ID_FIELD, type JSONSchema } from "./builder/types.ts";
 import { createRef } from "./create-ref.ts";
@@ -213,7 +214,7 @@ export function diffAndUpdate(
   );
   diffLogger.debug(
     "diff",
-    () => `[diffAndUpdate] changes: ${JSON.stringify(changes)}`,
+    () => `[diffAndUpdate] changes: ${toCompactDebugString(changes)}`,
   );
   applyChangeSet(tx, changes);
   return changes.length > 0;
@@ -264,7 +265,7 @@ export function normalizeAndDiff(
     "diff",
     () =>
       `[DIFF_ENTER] path=${pathStr} type=${valueType} newValue=${
-        JSON.stringify(newValue as any)
+        toCompactDebugString(newValue)
       }`,
   );
 
@@ -461,7 +462,7 @@ export function normalizeAndDiff(
       "diff",
       () =>
         `[BRANCH_CELL_LINK] Processing cell link at path=${pathStr} link=${
-          JSON.stringify(newValue as any)
+          toCompactDebugString(newValue)
         }`,
     );
     const parsedLink = parseLink(newValue, link);

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -1,6 +1,7 @@
 import { isRecord } from "@commonfabric/utils/types";
 import { getLogger } from "@commonfabric/utils/logger";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { LINK_V1_TAG, type LinkV1Inner } from "./sigil-types.ts";
 import {
   type CellLink,
@@ -116,10 +117,10 @@ export function resolveLink(
     if (seen.has(key)) {
       logger.error(
         "link-res-error",
-        `Link cycle detected ${key} [${JSON.stringify([...seen])}]`,
+        `Link cycle detected ${key} [${toCompactDebugString([...seen])}]`,
       );
       throw new Error(
-        `Link cycle detected at ${key} [${JSON.stringify([...seen])}]`,
+        `Link cycle detected at ${key} [${toCompactDebugString([...seen])}]`,
       );
     }
     seen.add(key);

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -1,3 +1,4 @@
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { isRecord } from "@commonfabric/utils/types";
 import { type AnyCell, type JSONSchema } from "./builder/types.ts";
 import {
@@ -129,7 +130,9 @@ export function parseLinkOrThrow(
 ): NormalizedLink {
   const result = parseLink(value, baseCell);
   if (!result) {
-    throw new Error(`Cannot parse value as link: ${JSON.stringify(value)}`);
+    throw new Error(
+      `Cannot parse value as link: ${toCompactDebugString(value)}`,
+    );
   }
   return result;
 }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1741,7 +1741,7 @@ export class Runner {
     tx: IExtendedStorageTransaction,
   ): string {
     try {
-      return toCompactDebugString(inputsCell.getAsQueryResult([], tx));
+      return JSON.stringify(inputsCell.getAsQueryResult([], tx));
     } catch (_error) {
       return "(Can't serialize to JSON)";
     }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2,6 +2,10 @@ import {
   fabricFromNativeValue,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
+import {
+  toCompactDebugString,
+  toIndentedDebugString,
+} from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isRecord } from "@commonfabric/utils/types";
 import { rendererVDOMSchema } from "./schemas.ts";
@@ -1235,13 +1239,13 @@ export class Runner {
               () => [
                 "Error committing transaction",
                 "\nError:",
-                JSON.stringify(error, null, 2),
+                toIndentedDebugString(error),
                 error.name === "ConflictError"
                   ? [
                     "\nConflict details:",
-                    JSON.stringify(error.conflict, null, 2),
+                    toIndentedDebugString(error.conflict),
                     "\nTransaction:",
-                    JSON.stringify(error.transaction, null, 2),
+                    toIndentedDebugString(error.transaction),
                   ]
                   : [],
               ],
@@ -1592,7 +1596,7 @@ export class Runner {
     } else if (isWriteRedirectLink(module)) {
       // TODO(seefeld): Implement, a dynamic node
     } else {
-      throw new Error(`Unknown module: ${JSON.stringify(module)}`);
+      throw new Error(`Unknown module: ${toCompactDebugString(module)}`);
     }
   }
 
@@ -1737,7 +1741,7 @@ export class Runner {
     tx: IExtendedStorageTransaction,
   ): string {
     try {
-      return JSON.stringify(inputsCell.getAsQueryResult([], tx));
+      return toCompactDebugString(inputsCell.getAsQueryResult([], tx));
     } catch (_error) {
       return "(Can't serialize to JSON)";
     }

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -1,3 +1,4 @@
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isRecord } from "@commonfabric/utils/types";
@@ -1477,8 +1478,8 @@ export class Scheduler {
             triggerFlowLogger.debug("schedule-change", () => [
               `Change #${changeIndex}`,
               `Address: ${change.address.id}/${change.address.path.join("/")}`,
-              `Before: ${JSON.stringify(change.before)}`,
-              `After: ${JSON.stringify(change.after)}`,
+              `Before: ${toCompactDebugString(change.before)}`,
+              `After: ${toCompactDebugString(change.after)}`,
             ]);
             this.runtime.telemetry.submit({
               type: "cell.update",

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -1,5 +1,9 @@
 import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
 import { hashObjectFromString } from "@commonfabric/data-model/value-hash";
+import {
+  toCompactDebugString,
+  toIndentedDebugString,
+} from "@commonfabric/data-model/value-debug";
 import type { FabricValue } from "@commonfabric/memory/interface";
 import type {
   CauseString,
@@ -917,7 +921,7 @@ export class Replica {
               // Log actual content for each document
               for (const [contentType, data] of Object.entries(facts)) {
                 try {
-                  const dataStr = JSON.stringify(data);
+                  const dataStr = toCompactDebugString(data);
                   const preview = dataStr.length > 1000
                     ? dataStr.substring(0, 1000) + "..."
                     : dataStr;
@@ -1203,24 +1207,24 @@ export class Replica {
           () => [
             "Transaction failed (aready exists)",
             "\nError:",
-            JSON.stringify(result.error, null, 2),
+            toIndentedDebugString(result.error),
             "\nConflict details:",
-            JSON.stringify((result.error as any).conflict, null, 2),
+            toIndentedDebugString((result.error as any).conflict),
             "\nTransaction:",
-            JSON.stringify((result.error as any).transaction, null, 2),
+            toIndentedDebugString((result.error as any).transaction),
           ],
         );
       } else {
         logger.warn("push-error", () => [
           "Transaction failed",
           "\nError:",
-          JSON.stringify(result.error, null, 2),
+          toIndentedDebugString(result.error),
           result.error.name === "ConflictError"
             ? [
               "\nConflict details:",
-              JSON.stringify((result.error as any).conflict, null, 2),
+              toIndentedDebugString((result.error as any).conflict),
               "\nTransaction:",
-              JSON.stringify((result.error as any).transaction, null, 2),
+              toIndentedDebugString((result.error as any).transaction),
             ]
             : [],
         ]);

--- a/packages/runner/src/storage/transaction-summary.ts
+++ b/packages/runner/src/storage/transaction-summary.ts
@@ -5,6 +5,7 @@
  * into concise summaries suitable for LLMs to help humans debug software behavior.
  */
 
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
@@ -286,7 +287,7 @@ function truncateValue(value: unknown, maxLength: number): unknown {
   }
 
   if (typeof value === "object") {
-    const str = JSON.stringify(value);
+    const str = toCompactDebugString(value);
     return str.length > maxLength ? str.substring(0, maxLength) + "..." : value;
   }
 
@@ -351,7 +352,7 @@ function formatValueForSummary(value: unknown): string {
   if (typeof value === "number" || typeof value === "boolean") {
     return String(value);
   }
-  return JSON.stringify(value);
+  return toCompactDebugString(value);
 }
 
 /**

--- a/packages/runner/src/storage/transaction.ts
+++ b/packages/runner/src/storage/transaction.ts
@@ -1,5 +1,6 @@
 import { getLogger } from "@commonfabric/utils/logger";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import type {
   ChangeGroup,
   CommitError,
@@ -270,7 +271,7 @@ export const read = (
       logger.debug("storage-source-read", () => [
         `Read source path for ${address.id}`,
         `Value type: ${typeof value}`,
-        `Value: ${JSON.stringify(value)}`,
+        `Value: ${toCompactDebugString(value)}`,
       ]);
 
       if (typeof value === "string" && value.startsWith('{"/":')) {
@@ -284,7 +285,7 @@ export const read = (
           };
           logger.debug("storage-source-parse", () => [
             `Parsed JSON string to object`,
-            `Result: ${JSON.stringify(parsedValue)}`,
+            `Result: ${toCompactDebugString(parsedValue)}`,
           ]);
         } catch (e) {
           // If parsing fails, leave it as is

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -5,6 +5,7 @@ import {
   type FabricValue,
   isArrayIndexPropertyName,
 } from "@commonfabric/data-model/fabric-value";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import type {
   IAttestation,
   IInvalidDataURIError,
@@ -581,9 +582,9 @@ export const StateInconsistency = (source: {
     }"`,
     space ? ` in space "${space}"` : "",
     ` hash changed. Previously it used to be:\n `,
-    expected === undefined ? "undefined" : JSON.stringify(expected),
+    toCompactDebugString(expected),
     "\n and currently it is:\n ",
-    actual === undefined ? "undefined" : JSON.stringify(actual),
+    toCompactDebugString(actual),
   ].join("");
 
   return {

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1,4 +1,5 @@
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { toIndentedDebugString } from "@commonfabric/data-model/value-debug";
 import {
   hashSchema,
   hashSchemaItem,
@@ -2045,7 +2046,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
       logger.debug("traverse", () => [
         "Call to traverse failed validation",
         doc,
-        JSON.stringify(this.selector?.schema, undefined, 2),
+        toIndentedDebugString(this.selector?.schema),
         this.getDebugValue(doc),
       ]);
     }

--- a/packages/runner/src/uri-utils.ts
+++ b/packages/runner/src/uri-utils.ts
@@ -1,4 +1,5 @@
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { isRecord } from "@commonfabric/utils/types";
 import type { URI } from "./sigil-types.ts";
 
@@ -27,7 +28,9 @@ export function toURI(value: unknown): URI {
     }
   }
 
-  throw new Error(`Cannot convert value to URI: ${JSON.stringify(value)}`);
+  throw new Error(
+    `Cannot convert value to URI: ${toCompactDebugString(value)}`,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

First migration PR in the JSON.stringify → debug-stringifier arc. Swaps raw `JSON.stringify` for the new `toCompactDebugString` / `toIndentedDebugString` helpers (from PR #3409) at **32 non-test DEBUG-class sites in `packages/runner/src/`** across **13 files**.

> **Scope adjusted during review:** opened with 34 sites; Dan + Flux flagged 2 as mis-classified (function-name asserts a stable/parseable contract, sentinel output would silently break it). Both reverted in `149471e14`. See "Sites flagged during review and reverted" below.

References:
- Helpers + arc context: PR #3409 (merged earlier today, squash `5aeabba11`).
- Per-package classification + shape vocabulary: `coordination/docs/2026-04-28-json-stringify-classification.md` (Researcher-Remy's report).

## Sites migrated

Broken down by Remy's shape vocabulary:

### D1 — Error message text (11 sites)

`toCompactDebugString` for single-line error-message embeds:

- `link-resolution.ts:119, 122` (`Link cycle detected ...`)
- `uri-utils.ts:30` (`Cannot convert value to URI: ...`)
- `link-utils.ts:132` (`Cannot parse value as link: ...`)
- `runner.ts:1595` (`Unknown module: ...`)
- `cfc.ts:385, 393` (`Failed to resolve $ref: ...`, `Schema: ...`)
- `builtins/wish.ts:771` (`Wish target "..." has no query.`)
- `storage/transaction/attestation.ts:584, 586` (Transaction-consistency-violated; expected/actual blocks)

### D2 — Logger argument (19 sites)

`toIndentedDebugString` where the original passed `null, 2` (multi-line); `toCompactDebugString` otherwise:

- `data-updating.ts:216, 267, 464` (compact)
- `runner.ts:1238, 1242, 1244` (indented — three `JSON.stringify(error/conflict/transaction, null, 2)` in a `logger.warn` array)
- `scheduler.ts:1480, 1481` (compact `Before:` / `After:`)
- `traverse.ts:2048` (indented; was `JSON.stringify(..., undefined, 2)`)
- `builtins/wish.ts:797` (compact `path=...`)
- `storage/cache.ts:920` (compact `dataStr` for log preview)
- `storage/cache.ts:1206, 1208, 1210, 1217, 1221, 1223` (indented; six `null, 2` sites in two adjacent `logger.info`/`logger.warn` blocks)
- `storage/transaction.ts:273, 287` (compact `Value: ...`, `Result: ...`)

### D3 — Convention `toString` / format helper (2 sites)

- `storage/transaction-summary.ts:289, 354` (`formatValueForSummary` / `truncateValue`)

## Sites flagged during review and reverted (2)

Dan flagged two sites as incorrectly migrated; Flux concurred. Both reverted to raw `JSON.stringify` in `149471e14`. The category is **function-name-as-contract / consumer-shape-as-stable-identity**: the new helper's non-JSON sentinel output (`<bigint>n`, `<NaN>`, `<undefined>`, `function fn(...) {...}`, etc.) would silently break a stable/parseable output contract.

- **`builder/pattern.ts:432`** (`formatStableCauseSegment`): output flows into `getStableInternalPathSegment` → literal cell-path segment via `paths.set(top, ["internal", stableName ...])`. Format drift = identity drift across runs. The "Stable" in the function name is the signal. The `?? String(cause)` fallback was pulled back along with the revert.
- **`runner.ts:1740`** (`serializeQueryResult`): output flows through `logger.flag` named state → `logger.flags` getter → exposed across-package to the shell debugger UI via `getActiveFlags()`. Function name + field name (`queryResult: string`) read as an interface contract; current consumers are display-bound, but a future caller could silently break.

The remaining three small simplifications (one `=== undefined ? "undefined" : ...` drop in `attestation.ts:584/586`, two `as any` drops in `data-updating.ts:267, 464`) are kept — they're not tied to either reverted site.

Threads: [`#discussion_r3157421202`](https://github.com/commontoolsinc/labs/pull/3411#discussion_r3157421202) (pattern.ts), [`#discussion_r3157415536`](https://github.com/commontoolsinc/labs/pull/3411#discussion_r3157415536) (runner.ts).

### Sibling-scan after the reverts

Re-evaluated all 32 remaining migrated sites through the same lens (function-name asserting stable/parseable/canonical contract; consumer-shape feeding Map keys, comparators, hashes, persisted storage, or cross-API boundaries). **Zero other strict matches**, matching Flux's read.

**One borderline call** worth flagging: `transaction-summary.ts:289, 354` (`formatValueForSummary` / `truncateValue`). Function names contain "format" but the doc comment + consumers are LLM-prompt summaries — the LLM tolerates `42n` / `Symbol(...)` as text and the previous behavior threw on bigints, so migration is strictly better. Kept migrated; happy to revert if the conservative call is preferred.

## Sites left in place — flagged for visibility (3)

Three sites are *shape*-eligible (non-WIRE / non-cache-key) but were excluded from this pilot for substantive reasons:

- **`traverse.ts:3145`** (`getDebugValue`): uses `getCircularReplacer()` (defined at `traverse.ts:3399`) to emit `"[Circular]"` markers on cycles. The new helpers don't support cycle handling; migrating without preserving that guard would risk runtime throws on circular Cell graphs (a realistic input for this debug helper). **Suggested follow-up:** extend the helpers with a circular-replacer variant.
- **`builtins/llm-dialog.ts:1172`**: `valueJson` is embedded inside an LLM-prompt `` ```json `` code-fence, which signals to the LLM that the bytes are valid JSON. Migrating would inject bare `undefined` / `42n` / `Infinity` tokens that aren't valid JSON. An LLM-prompt-aware migration is a separate concern (and likely belongs to whichever PR migrates the broader D5 LLM-prompt category).
- **`scripts/profile-memory-regressions.ts:446`**: emits a benchmark report as machine-parseable JSON to stdout for tooling consumption. Not DEBUG-class; output stability for external consumers comes first.

## Sites correctly excluded as categorical mismatches

- **`builtins/wish.ts:279, 423`** (D7 substring search-text): the `tag` is consumed by `tagMatchesHashtag` regex matching. Migrating would change the consumer-visible text and break the search.

All other `JSON.stringify` sites in `packages/runner/{src,scripts}` are WIRE / cache-key / Map-key / deep-clone / sandbox-source — out of scope for any DEBUG-stringifier sweep.

## Local validation

- `deno fmt --check packages/runner/src/`: 143 files clean.
- `deno lint packages/runner/src/`: 140 files clean.
- `cd packages/runner && deno task test`: **400 passed (2790 steps), 0 failed.** Identical to the pre-migration baseline (verified both before the migration and after the post-review reverts).

## Test coverage

No new tests added — the migration is mechanical and the existing 400-test runner suite exercises every changed file. Coverage of the helpers themselves is in `packages/data-model/test/value-debug.test.ts` (39 cases — see PR #3409).

## Next

This is the **first migration PR** of a multi-PR arc. Subsequent PRs (Cedar + Colt parallel) will cover other packages. TEST-DEBUG sites across all packages are deferred to a later combined sweep per Dan's call.
