### PR TITLE
Decode storage values via valueFromJson consistently

### DIFF
--- a/packages/data-model/json-encoding.ts
+++ b/packages/data-model/json-encoding.ts
@@ -1,3 +1,4 @@
+import { isInstance } from "@commonfabric/utils/types";
 import type { FabricValue } from "./fabric-value.ts";
 import type { ReconstructionContext } from "./fabric-value.ts";
 import {
@@ -66,6 +67,31 @@ export function jsonFromValue(value: FabricValue): string {
 }
 
 /**
+ * Decodes a JSON string back into a fabric value which is expected to be a
+ * plain object. Throws if it turns out to be something else.
+ */
+export function plainObjectFromJson<T extends object = object>(
+  json: string,
+  runtime?: ReconstructionContext,
+): T {
+  const result = valueFromJson(json, runtime);
+
+  if ((result === null) || (typeof result !== "object")) {
+    throw new Error("plainObjectFromJson: Decoded to non-object");
+  } else if (Array.isArray(result)) {
+    throw new Error(
+      "plainObjectFromJson: Decoded to array (not a plain object)",
+    );
+  } else if (isInstance(result)) {
+    throw new Error(
+      "plainObjectFromJson: Decoded to instance (not a plain object)",
+    );
+  }
+
+  return result as T;
+}
+
+/**
  * Indicates if the given text has a "first-blush" appearance as valid encoded
  * JSON as defined by this module.
  */
@@ -86,7 +112,7 @@ export function seemsLikeJsonEncodedFabricValue(value: string): boolean {
  */
 export function valueFromJson(
   json: string,
-  runtime?: ReconstructionContext,
+  runtime?: ReconstructionContext | undefined,
 ): FabricValue {
   if (jsonEncodingEnabled) {
     return valueFromJsonModern(json, runtime);

--- a/packages/data-model/test/json-encoding.test.ts
+++ b/packages/data-model/test/json-encoding.test.ts
@@ -2,11 +2,13 @@ import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   jsonFromValue,
+  plainObjectFromJson,
   resetJsonEncodingConfig,
   seemsLikeJsonEncodedFabricValue,
   setJsonEncodingConfig,
   valueFromJson,
 } from "../json-encoding.ts";
+import { FabricError } from "../fabric-native-instances.ts";
 import type { ReconstructionContext } from "../fabric-value.ts";
 import type { FabricValue } from "../fabric-value.ts";
 
@@ -429,6 +431,41 @@ describe("json-encoding", () => {
     it("explicit `undefined` runtime is equivalent to omission", () => {
       setJsonEncodingConfig(true);
       expect(valueFromJson('{"a":1}', undefined)).toEqual({ a: 1 });
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // plainObjectFromJson
+  // --------------------------------------------------------------------------
+
+  describe("plainObjectFromJson", () => {
+    it("returns the decoded plain object (flag OFF)", () => {
+      expect(plainObjectFromJson('{"a":1,"b":"two"}'))
+        .toEqual({ a: 1, b: "two" });
+    });
+
+    it("returns the decoded plain object (flag ON)", () => {
+      setJsonEncodingConfig(true);
+      const json = jsonFromValue({ a: 1, b: 42n } as FabricValue);
+      const result = plainObjectFromJson<{ a: number; b: bigint }>(json);
+      expect(result.a).toBe(1);
+      expect(result.b).toBe(42n);
+    });
+
+    it("throws on null, primitives, and arrays", () => {
+      expect(() => plainObjectFromJson("null")).toThrow();
+      expect(() => plainObjectFromJson("42")).toThrow();
+      expect(() => plainObjectFromJson('"hello"')).toThrow();
+      expect(() => plainObjectFromJson("true")).toThrow();
+      expect(() => plainObjectFromJson("[]")).toThrow();
+      expect(() => plainObjectFromJson("[1,2,3]")).toThrow();
+    });
+
+    it("throws on a class instance (flag ON, FabricError)", () => {
+      setJsonEncodingConfig(true);
+      const err = new FabricError(new Error("test"));
+      const json = jsonFromValue(err as FabricValue);
+      expect(() => plainObjectFromJson(json)).toThrow(/instance/);
     });
   });
 });

--- a/packages/memory/space.ts
+++ b/packages/memory/space.ts
@@ -76,22 +76,7 @@ import {
   jsonFromValue,
   valueFromJson,
 } from "@commonfabric/data-model/json-encoding";
-import type { ReconstructionContext } from "@commonfabric/data-model/fabric-value";
 export type * from "./interface.ts";
-
-/**
- * Minimal reconstruction context for decoding values at the storage boundary.
- * Step 0 only handles types that don't require runtime context (undefined,
- * bigint, sparse arrays, etc.), so `getCell` is unimplemented. Future steps
- * that add Cell serialization will need to supply a real context.
- */
-const storageReconstructionContext: ReconstructionContext = {
-  getCell() {
-    throw new globalThis.Error(
-      "getCell is not available at the storage boundary (step 0)",
-    );
-  },
-};
 
 export const PREPARE = `
 BEGIN TRANSACTION;
@@ -576,10 +561,7 @@ const recall = <Space extends MemorySpace>(
       // dispatch, `JSON.parse` returned `any` which silently satisfied the
       // type; `valueFromJson` returns `FabricValue`, so we need a cast.
       // deno-lint-ignore no-explicit-any
-      (revision as any).is = valueFromJson(
-        row.is,
-        storageReconstructionContext,
-      );
+      (revision as any).is = valueFromJson(row.is);
     }
 
     return revision;
@@ -660,10 +642,7 @@ const getFact = <Space extends MemorySpace>(
   if (row.is) {
     // See comment in `recall` for why this cast is needed.
     // deno-lint-ignore no-explicit-any
-    (revision as any).is = valueFromJson(
-      row.is,
-      storageReconstructionContext,
-    );
+    (revision as any).is = valueFromJson(row.is);
   }
   return revision;
 };
@@ -721,9 +700,7 @@ const toFact = function (row: StateRow): SelectedFact {
     cause: row.cause
       ? row.cause as CauseString
       : unclaimedRef(row as FactAddress).toString() as CauseString,
-    is: row.is
-      ? valueFromJson(row.is, storageReconstructionContext) as FabricValue
-      : undefined,
+    is: row.is ? valueFromJson(row.is) as FabricValue : undefined,
     since: row.since,
   };
 };
@@ -971,7 +948,7 @@ const commit = <Space extends MemorySpace>(
   const row = stmt.get({ the, of }) as StateRow | undefined;
   const [since, cause] = row
     ? [
-      (JSON.parse(row.is as string) as CommitData).since + 1,
+      (valueFromJson(row.is as string) as unknown as CommitData).since + 1,
       hashObjectFromString(row.fact) as HashObject<Assertion>,
     ]
     : [0, unclaimedRef({ the, of }) as HashObject as HashObject<Assertion>];

--- a/packages/memory/space.ts
+++ b/packages/memory/space.ts
@@ -74,6 +74,7 @@ import { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { isRecord } from "../utils/src/types.ts";
 import {
   jsonFromValue,
+  plainObjectFromJson,
   valueFromJson,
 } from "@commonfabric/data-model/json-encoding";
 export type * from "./interface.ts";
@@ -948,7 +949,7 @@ const commit = <Space extends MemorySpace>(
   const row = stmt.get({ the, of }) as StateRow | undefined;
   const [since, cause] = row
     ? [
-      (valueFromJson(row.is as string) as unknown as CommitData).since + 1,
+      plainObjectFromJson<CommitData>(row.is as string).since + 1,
       hashObjectFromString(row.fact) as HashObject<Assertion>,
     ]
     : [0, unclaimedRef({ the, of }) as HashObject as HashObject<Assertion>];


### PR DESCRIPTION
## Summary

`packages/memory/space.ts` had three related shortcuts at its data-model boundary:

- A locally-rolled `storageReconstructionContext` whose `getCell()` threw — duplicating the `EMPTY_RECONSTRUCTION_CONTEXT` singleton from `data-model` (#3410).
- A lone `JSON.parse(row.is as string) as CommitData` in `commit()`, while every other read of the same column already used `valueFromJson()`.
- Once that lone read was migrated to `valueFromJson`, an `as unknown as CommitData` double-cast was needed, since `valueFromJson` returns `FabricValue`.

This PR:

- Deletes the local context and drops the now-redundant `runtime` argument from the existing `valueFromJson()` call sites (the dispatch wrapper substitutes `EMPTY_RECONSTRUCTION_CONTEXT` automatically).
- Migrates the lone `JSON.parse` site in `commit()` to use the new `plainObjectFromJson<T>()` helper, which decodes via `valueFromJson`, asserts the result is a plain (non-null, non-primitive, non-array, non-instance) object, and narrows the return type to `T`. No more double cast.
- Adds unit tests for `plainObjectFromJson()` covering happy paths under both flag states and rejection of null / primitives / arrays / class instances.

## Why

Behaviorally a no-op on `main` today: with the unified-JSON-encoding flag off, `valueFromJson` is exactly `JSON.parse`. The point is to harden the boundary so that when the modern encoding gains its `fvj1:` prefix, this read site stops being a hidden landmine — and to remove a stale duplicate now that a canonical empty context exists.

## Test plan

- [x] `deno task test` in `packages/data-model` — 40 suites / 1323 steps, 0 failed (4 new cases for `plainObjectFromJson`)
- [x] `deno task test` in `packages/memory` — 119 passed (164 steps), 0 failed
- [x] `deno task test` in `packages/runner` — 400 passed (2790 steps), 0 failed
- [x] `deno task test` in `packages/toolshed` — 32 passed (83 steps), 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
