### PR TITLE
Decode memory v2 wire payloads via the proper boundary helper in tests

### DIFF
--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import { FakeTime } from "@std/testing/time";
 import { Server, SessionRegistry } from "../v2/server.ts";
 import {
+  decodeMemoryV2Boundary,
   type EntitySnapshot,
   getMemoryV2Flags,
   MEMORY_V2_PROTOCOL,
@@ -391,7 +392,7 @@ class ReconnectableLoopbackTransport implements Transport {
   constructor(private readonly server: Server) {}
 
   async send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as { type?: string };
+    const message = decodeMemoryV2Boundary(payload) as { type?: string };
     await this.connection().receive(payload);
     if (message.type === "session.watch.set") {
       this.watchSetCount++;
@@ -452,7 +453,7 @@ class ScriptedReconnectTransport implements Transport {
       this.connectionCount++;
     }
 
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type: string;
       requestId?: string;
       commit?: { localSeq?: number };
@@ -539,7 +540,7 @@ class DelayedTransactTransport implements Transport {
   setCloseReceiver(): void {}
 
   send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type: string;
       requestId?: string;
       commit?: { localSeq?: number };
@@ -626,7 +627,7 @@ class AckCountingTransport implements Transport {
   }
 
   send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type: string;
       requestId?: string;
     };
@@ -702,7 +703,7 @@ class HangingAckTransport implements Transport {
   }
 
   send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type: string;
       requestId?: string;
     };
@@ -783,7 +784,7 @@ class ControlledReconnectTransport implements Transport {
   }
 
   send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type: string;
       requestId?: string;
     };
@@ -832,7 +833,7 @@ class CloseOnSessionOpenTransport implements Transport {
   }
 
   send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type: string;
       requestId?: string;
     };
@@ -871,7 +872,7 @@ class CloseOnAppliedCommitTransport implements Transport {
   }
 
   send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type: string;
       requestId?: string;
       commit?: { localSeq?: number };
@@ -1497,7 +1498,7 @@ Deno.test("memory v2 client rejects hello.ok when flags disagree", async () => {
   let receiver = (_payload: string) => {};
   const transport: Transport = {
     send(payload): Promise<void> {
-      const message = JSON.parse(payload) as { type?: string };
+      const message = decodeMemoryV2Boundary(payload) as { type?: string };
       if (message.type === "hello") {
         receiver(JSON.stringify({
           type: "hello.ok",
@@ -1606,7 +1607,7 @@ class DisconnectableAckTransport implements Transport {
   }
 
   send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type: string;
       requestId?: string;
     };
@@ -1741,7 +1742,7 @@ class SessionChangingTransport implements Transport {
   }
 
   send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type: string;
       requestId?: string;
       sessionId?: string;

--- a/packages/memory/test/v2-restore-flush-test.ts
+++ b/packages/memory/test/v2-restore-flush-test.ts
@@ -1,6 +1,7 @@
 import { assert, assertEquals } from "@std/assert";
 import { Server } from "../v2/server.ts";
 import { connect, type Transport } from "../v2/client.ts";
+import { decodeMemoryV2Boundary } from "../v2.ts";
 
 const SPACE = "did:key:z6Mk-restore-flush-test";
 
@@ -25,7 +26,7 @@ class ReconnectableTransport implements Transport {
   constructor(private readonly server: Server) {}
 
   async send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type?: string;
       requestId?: string;
       commit?: { localSeq?: number };
@@ -87,7 +88,9 @@ class ReconnectableTransport implements Transport {
   }
 
   async #deliver(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as { commit?: { localSeq?: number } };
+    const message = decodeMemoryV2Boundary(payload) as {
+      commit?: { localSeq?: number };
+    };
     if (typeof message.commit?.localSeq === "number") {
       this.#deliveredTransactLocalSeqs.push(message.commit.localSeq);
     }


### PR DESCRIPTION
## Summary

The test transports in `packages/memory/test/v2-client-test.ts` and `packages/memory/test/v2-restore-flush-test.ts` were inspecting intercepted wire messages with `JSON.parse(payload) as ...`. But `payload` is what `encodeMemoryV2Boundary()` produced — which is `jsonFromValue` underneath, so anything richer than legacy JSON (tagged values, the upcoming `fvj1:` prefix) breaks the raw parse.

Switches all 13 sites across the two test files to `decodeMemoryV2Boundary(payload) as ...`, which is the symmetric counterpart of the encoder used on the producing side.

## Why

Behaviorally a no-op on `main` today: with the unified-JSON-encoding flag off, `decodeMemoryV2Boundary` reduces to `JSON.parse`. The change just removes a hidden landmine for the in-flight encoding work — the prefix branch's full-suite run revealed that these test sites were the lone remaining JSON.parse choke point in the cascade (production code is already clean post-#3412).

## Test plan

- [x] `deno task test` in `packages/memory` — 119 passed (164 steps), 0 failed (no regression on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
