### PR TITLE
chore: small runtime fixes (split from #3359)

### DIFF
--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -292,6 +292,7 @@ function factoryFromPattern<T, R>(
   // Add paths for all the internal cells
   // TODO(seefeld): Infer more stable identifiers
   let count = 0;
+  const usedInternalPathSegments = new Set<string>();
   allCells.forEach((cell) => {
     if (paths.has(cell)) return;
     const { cell: top, path, value, name, external } = cell.export();
@@ -305,10 +306,16 @@ function factoryFromPattern<T, R>(
         const streamMarker = isRecord(value) && value.$stream === true
           ? "stream"
           : "";
-        paths.set(top, [
-          "internal",
-          stableName ?? `__#${count++}${streamMarker}`,
-        ]);
+        let internalPathSegment = stableName ??
+          `__#${count++}${streamMarker}`;
+        let internalPathKey = String(internalPathSegment);
+        while (usedInternalPathSegments.has(internalPathKey)) {
+          internalPathSegment =
+            `${internalPathKey}__#${count++}${streamMarker}`;
+          internalPathKey = String(internalPathSegment);
+        }
+        usedInternalPathSegments.add(internalPathKey);
+        paths.set(top, ["internal", internalPathSegment]);
       }
       if (path.length) paths.set(cell, [...paths.get(top)!, ...path]);
     }

--- a/packages/runner/src/builtins/list-op-argument-usage.ts
+++ b/packages/runner/src/builtins/list-op-argument-usage.ts
@@ -25,6 +25,17 @@ export function inferListOpArgumentUsage(
   const cached = usageCache.get(pattern as object);
   if (cached) return cached;
 
+  if (pattern.argumentSchema === undefined) {
+    const legacyUsage = {
+      usesElement: true,
+      usesIndex: true,
+      usesArray: true,
+      usesParams: true,
+    } satisfies ListOpArgumentUsage;
+    usageCache.set(pattern as object, legacyUsage);
+    return legacyUsage;
+  }
+
   const usage = {
     usesElement: hasArgumentSchema(cfc, pattern, ["element"]),
     usesIndex: hasArgumentSchema(cfc, pattern, ["index"]),

--- a/packages/runner/test/pattern.test.ts
+++ b/packages/runner/test/pattern.test.ts
@@ -75,6 +75,25 @@ describe("pattern", () => {
     });
   });
 
+  it("uniquifies repeated stable internal paths with schemas", () => {
+    const isPositive = lift(
+      { type: "number" } as const satisfies JSONSchema,
+      { type: "boolean" } as const satisfies JSONSchema,
+      (value: number) => value > 0,
+    );
+
+    const testPattern = pattern(() => {
+      const first = (isPositive(1) as any).for("isSelected", true);
+      const second = (isPositive(2) as any).for("isSelected", true);
+      return { first, second };
+    });
+
+    const firstPath = (testPattern.result as any).first.$alias.path;
+    const secondPath = (testPattern.result as any).second.$alias.path;
+    expect(firstPath).toEqual(["internal", "isSelected"]);
+    expect(secondPath).toEqual(["internal", "isSelected__#0"]);
+  });
+
   it("complex pattern has correct schema and nodes", () => {
     const doublePattern = pattern<{ x: number }>(({ x }) => {
       const double = lift<number>((x) => x * 2);

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -41,6 +41,7 @@ function fetchBuildHash(): Promise<string | undefined> {
       try {
         const resp = await fetch(
           new URL("/build-manifest.json", globalThis.location.origin),
+          { cache: "no-store" },
         );
         if (resp.ok) {
           const manifest = await resp.json();
@@ -357,18 +358,18 @@ export class RuntimeInternals extends EventTarget {
       })`,
     );
 
-    // Fetch build manifest (for compilation cache fingerprint) and
-    // connect worker transport in parallel — they're independent I/O.
+    // Fetch the build manifest first so the worker URL and compilation-cache
+    // fingerprint both point at the same worker bundle.
     // See docs/specs/compilation-cache.md Phase 3.
-    const [buildHash, transport] = await Promise.all([
-      COMPILATION_CACHE_CLIENT ? fetchBuildHash() : Promise.resolve(undefined),
-      WebWorkerRuntimeTransport.connect({
-        workerUrl: new URL(
-          "/scripts/worker-runtime.js",
-          globalThis.location.origin,
-        ),
-      }),
-    ]);
+    const buildHash = COMPILATION_CACHE_CLIENT
+      ? await fetchBuildHash()
+      : undefined;
+    const workerUrl = new URL(
+      "/scripts/worker-runtime.js",
+      globalThis.location.origin,
+    );
+    if (buildHash) workerUrl.searchParams.set("v", buildHash);
+    const transport = await WebWorkerRuntimeTransport.connect({ workerUrl });
     if (COMPILATION_CACHE_CLIENT) {
       console.log(
         buildHash

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -14,6 +14,7 @@ import {
 } from "../ast/mod.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { unwrapExpression } from "../utils/expression.ts";
+import { isOpaqueRefType } from "./opaque-ref/opaque-ref.ts";
 import {
   isPatternFactoryCalleeExpression,
   isPatternFactoryHelperExpression,
@@ -744,9 +745,25 @@ function shouldRetargetReactiveReference(
   context: TransformationContext,
 ): boolean {
   const target = unwrapExpression(expression);
-  return ts.isIdentifier(target) &&
-    !isPatternFactoryHelperExpression(target, context.checker) &&
-    isReactiveValueExpression(target, context.checker);
+  if (
+    !ts.isIdentifier(target) ||
+    isPatternFactoryHelperExpression(target, context.checker)
+  ) {
+    return false;
+  }
+
+  const type = getTypeAtLocationWithFallback(
+    target,
+    context.checker,
+    context.options.typeRegistry,
+    context.options.logger,
+  );
+  if (type) {
+    return isOpaqueRefType(type, context.checker) ||
+      isCellLikeType(type, context.checker);
+  }
+
+  return isReactiveValueExpression(target, context.checker);
 }
 
 function shouldPreserveStructuralCallArgumentReferences(

--- a/packages/ts-transformers/test/fixtures/ast-transform/derive-object-literal-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/derive-object-literal-input.expected.jsx
@@ -69,10 +69,10 @@ const _summary = __cfHelpers.__cf_data(derive({
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, {
-    stage: normalizedStage.for(["_summary", 2, "stage"], true),
-    attempts: attempts.for(["_summary", 2, "attempts"], true),
-    accepted: accepted.for(["_summary", 2, "accepted"], true),
-    rejected: rejected.for(["_summary", 2, "rejected"], true)
+    stage: normalizedStage,
+    attempts: attempts,
+    accepted: accepted,
+    rejected: rejected,
 }, (snapshot) => `stage:${snapshot.stage} attempts:${snapshot.attempts}` +
     ` accepted:${snapshot.accepted} rejected:${snapshot.rejected}`).for("_summary", true));
 // @ts-ignore: Internals

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
@@ -101,7 +101,7 @@ export default pattern(() => {
         required: ["result"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema, { result: result }, ({ result }) => !!result).for(["output2", 4], true), { data: result.for(["output2", 5, "data"], true) }, undefined).for("output2", true);
+    } as const satisfies __cfHelpers.JSONSchema, { result: result }, ({ result }) => !!result).for(["output2", 4], true), { data: result }, undefined).for("output2", true);
     return {
         [UI]: (<div>
         <span>{output1}</span>

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -229,6 +229,39 @@ export function make() {
     assert(!main.includes('.for(["foo", 0, "param"], true)'));
   });
 
+  it("does not retarget plain handler params inside local object initializers", async () => {
+    const source = `
+import { handler, type Stream } from "commonfabric";
+
+type Message = {
+  role: "user";
+  content: Array<{ type: "text"; text: string }>;
+};
+
+const runBoth = handler<void, { send: Stream<Message>; prompt: string }>(
+  (_, { send, prompt }) => {
+    const message = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: prompt }],
+    };
+    send.send(message);
+  },
+);
+
+export { runBoth };
+`;
+
+    const output = await transformFiles({
+      "/main.ts": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.ts"]!;
+
+    assertStringIncludes(main, "text: prompt");
+    assertNotMatch(main, /prompt\.for\(/);
+  });
+
   it("does not duplicate stable causes on asserted reactive initializers", async () => {
     const source = `
 import { Default, pattern } from "commonfabric";


### PR DESCRIPTION
## Summary

Carved out of #3359 so the pure-runtime fixes can land independently of the larger CFC observation-gating work. No shared-file coupling with the rest of that PR.

- `builder/pattern.ts` — uniquify duplicate internal schema paths (when two stable-named cells collide on a path segment, append `__#N`)
- `builtins/list-op-argument-usage.ts` — tolerate missing `argumentSchema` (assume all args used; legacy patterns)
- `ts-transformers/reactive-variable-for.ts` — skip retargeting for `OpaqueRef` / `Cell`-typed parameters (they're already reactive; double-wrap was producing spurious `.for(...)` calls)
- `shell/runtime.ts` — fetch build manifest with `no-store` and align worker bundle to manifest hash

## Test plan

- [x] `deno task test` in `packages/runner` (400 passed, 0 failed)
- [x] `deno task test` in `packages/ts-transformers` (254 passed, 0 failed)
- [x] `deno task test` in `packages/shell` (10 passed, 0 failed)
- [x] CI green

## Notes

Two fixture diffs (`derive-object-literal-input.expected.jsx`, `ifelse-undefined-value.expected.jsx`) reflect the transformer fix — `OpaqueRef` params no longer emit `.for(...)` retargeting calls. The `patternTool-*` fixture changes from #3359 are deferred to the observation-gating PR because they only encode a new API field (`useResultSchemaForObservation`) added there.

Split from #3359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several runtime edge cases to stabilize builds and transforms. Uniquifies internal schema paths, tolerates legacy list-op patterns, stops double-retargeting of reactive params, and aligns the worker bundle with the build manifest.

- Bug Fixes
  - `runner`: Uniquify duplicate internal schema path segments by appending `__#N`.
  - `runner`: Assume all list-op args are used when `argumentSchema` is missing (legacy support).
  - `ts-transformers`: Skip retargeting for `OpaqueRef`/`Cell` params to avoid spurious `.for(...)` calls.
  - `shell`: Fetch `/build-manifest.json` with `no-store` and version the worker URL with the manifest hash so cache fingerprints match.

<sup>Written for commit be6b096d4dcf467432a9a961b37c125e2825b97c. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3415?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/contacts/contact-book.test.tsx = 10s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-trusted-component-examples/main.test.tsx = 27s
NEW_PERF_BASELINE: test: pattern-unit-2/pattern-unit-tests = 132s

