### PR TITLE
refactor(memory): swap raw JSON.stringify for {Compact,Indented}DebugString in non-test DEBUG+DISPLAY sites

### DIFF
--- a/packages/memory/consumer.ts
+++ b/packages/memory/consumer.ts
@@ -48,6 +48,7 @@ import type {
   UTCUnixTimestampInSeconds,
 } from "./interface.ts";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import {
   type HashObject,
   hashObjectFromJson,
@@ -203,7 +204,7 @@ class MemoryConsumerSession<
           );
           logger.error(
             "stream-error",
-            () => ["Failed command:", JSON.stringify(command)],
+            () => ["Failed command:", toCompactDebugString(command)],
           );
           throw error;
         }

--- a/packages/memory/entity.ts
+++ b/packages/memory/entity.ts
@@ -2,6 +2,7 @@ import {
   hashObjectFromJson,
   hashOf,
 } from "@commonfabric/data-model/value-hash";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 
 export interface Entity<T extends null | NonNullable<unknown>> {
   "@": ToString<Entity<T>>;
@@ -28,9 +29,7 @@ export const fromString = <T extends null | NonNullable<unknown>>(
   if (!source.startsWith("@")) {
     throw new TypeError(
       `Expected formatted entity which starts with @ character instead got ${
-        JSON.stringify(
-          source,
-        )
+        toCompactDebugString(source)
       }`,
     );
   } else {

--- a/packages/memory/error.ts
+++ b/packages/memory/error.ts
@@ -14,6 +14,7 @@ import type {
 } from "./interface.ts";
 import { MemorySpace } from "./interface.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 
 export const unauthorized = (
   message: string,
@@ -134,7 +135,9 @@ export class TheQueryError extends Error implements QueryError {
     public override cause: SystemError,
   ) {
     super(
-      `Query ${JSON.stringify(selector)} in ${space} failed: ${cause.message}`,
+      `Query ${
+        toCompactDebugString(selector)
+      } in ${space} failed: ${cause.message}`,
     );
   }
   toJSON(): QueryError {

--- a/packages/memory/provider.ts
+++ b/packages/memory/provider.ts
@@ -34,6 +34,10 @@ import {
   UCAN,
 } from "./interface.ts";
 import { FabricValue } from "@commonfabric/data-model/fabric-value";
+import {
+  toCompactDebugString,
+  toIndentedDebugString,
+} from "@commonfabric/data-model/value-debug";
 import * as SelectionBuilder from "./selection.ts";
 import * as Memory from "./memory.ts";
 import {
@@ -184,7 +188,7 @@ function recordSlowQuery(entry: SlowQuery) {
           `sharedMemo=${entry.sharedMemoSize}`,
         ]
         : []),
-      `selector=${JSON.stringify(entry.selector)}`,
+      `selector=${toCompactDebugString(entry.selector)}`,
     ],
   );
 }
@@ -412,7 +416,7 @@ class MemoryProviderSession<
           );
           logger.error(
             "stream-error",
-            () => ["Failed command:", JSON.stringify(command)],
+            () => ["Failed command:", toCompactDebugString(command)],
           );
           throw error;
         }
@@ -746,7 +750,7 @@ class MemoryProviderSession<
             () => [
               `space=${invocation.sub}`,
               `elapsed=${txElapsed?.toFixed(1)}ms`,
-              JSON.stringify(result.error, null, 2),
+              toIndentedDebugString(result.error),
             ],
           );
         } else {

--- a/packages/memory/space-schema.ts
+++ b/packages/memory/space-schema.ts
@@ -5,6 +5,7 @@ import {
 } from "@commonfabric/runner";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { internPathSelector } from "@commonfabric/data-model/schema-utils";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import {
   type BaseMemoryAddress,
   CompoundCycleTracker,
@@ -274,7 +275,7 @@ export const selectSchema = <Space extends MemorySpace>(
           `sqliteReads=${manager.sqliteReads}`,
           `sqliteMs=${manager.sqliteTotalMs.toFixed(1)}`,
           `sqliteCacheHits=${manager.sqliteCacheHits}`,
-          `schemaPath=${JSON.stringify(selectorEntry.value.path)}`,
+          `schemaPath=${toCompactDebugString(selectorEntry.value.path)}`,
         ]);
       }
 
@@ -368,7 +369,7 @@ export const selectSchema = <Space extends MemorySpace>(
       `sqliteMs=${manager.sqliteTotalMs.toFixed(1)}`,
       `sqliteCacheHits=${manager.sqliteCacheHits}`,
       `sharedMemo=${sharedMemo.size}`,
-      `selectors=${JSON.stringify(selectSchema)}`,
+      `selectors=${toCompactDebugString(selectSchema)}`,
     ]);
   }
 

--- a/packages/memory/space.ts
+++ b/packages/memory/space.ts
@@ -71,6 +71,7 @@ export type {
   SelectSchemaStats,
 } from "./space-schema.ts";
 import { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { isRecord } from "../utils/src/types.ts";
 import {
   jsonFromValue,
@@ -1106,7 +1107,7 @@ export const querySchema = <Space extends MemorySpace>(
       span.setAttribute("querySchema.has_selector", true);
       span.setAttribute(
         "querySchema.selectSchema",
-        JSON.stringify(command.args.selectSchema),
+        toCompactDebugString(command.args.selectSchema),
       );
     }
     if (command.args?.since !== undefined) {

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -21,6 +21,7 @@ import {
 } from "../v2.ts";
 import type { Server } from "./server.ts";
 import type { AppliedCommit } from "./engine.ts";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 
 export interface Transport {
   send(payload: string): Promise<void>;
@@ -202,8 +203,8 @@ export class Client {
         if (!sameMemoryV2Flags(message.flags, expectedFlags)) {
           const error = new Error(
             `memory/v2 flag mismatch: client=${
-              JSON.stringify(expectedFlags)
-            } server=${JSON.stringify(message.flags)}`,
+              toCompactDebugString(expectedFlags)
+            } server=${toCompactDebugString(message.flags)}`,
           );
           error.name = "ProtocolError";
           this.#helloPending.reject(error);

--- a/packages/memory/v2/handshake.ts
+++ b/packages/memory/v2/handshake.ts
@@ -5,6 +5,7 @@ import {
   sameMemoryV2Flags,
   type ServerMessage,
 } from "../v2.ts";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 
 type TypedError = {
   name: string;
@@ -35,8 +36,8 @@ export const respondToHello = (message: HelloMessage): ServerMessage => {
       error: toError(
         "ProtocolError",
         `memory/v2 flag mismatch: client=${
-          JSON.stringify(message.flags)
-        } server=${JSON.stringify(expectedFlags)}`,
+          toCompactDebugString(message.flags)
+        } server=${toCompactDebugString(expectedFlags)}`,
       ),
     };
   }


### PR DESCRIPTION
## Summary

Cadence migration in the `JSON.stringify` → debug-stringifier arc. Swaps raw `JSON.stringify` for the new `toCompactDebugString` / `toIndentedDebugString` helpers (from PR #3409) at **13 non-test DEBUG+DISPLAY sites in `packages/memory/`** across **8 files**.

References:
- Helpers + arc context: PR #3409 (squash `5aeabba11`).
- Pilot idiom: PR #3411 (squash `fcf6f0ef1`).
- Per-package classification + shape vocabulary: `coordination/docs/2026-04-28-json-stringify-classification.md` (Researcher-Remy's report).

Mirrors the idiom established in PR #3411: `toCompactDebugString` for single-line embeds in error messages and most logger array arguments; `toIndentedDebugString` only where the original passed `null, 2` (multi-line). No test files touched (test-file sites are deferred to a later combined sweep per Dan's call).

## Sites migrated

Broken down by Remy's shape vocabulary (line numbers are post-migration in this branch):

### D1 — Error message text (8 sites)

`toCompactDebugString` for single-line error-message embeds:

- `entity.ts:30` — `fromString` `TypeError`: `Expected formatted entity which starts with @ character instead got ...`.
- `error.ts:138-140` — `TheQueryError.constructor` `super()`: `Query ${selector} in ${space} failed: ...`.
- `v2/client.ts:206-207` — `memory/v2 flag mismatch: client=${...} server=${...}` (two `JSON.stringify` calls in one error template).
- `v2/handshake.ts:39-40` — same flag-mismatch shape, server-side path (two calls).

### D2 — Logger argument (5 sites compact + 1 indented)

`toCompactDebugString` for single-line embeds in `logger.{warn,error}` array arguments (5 sites):

- `consumer.ts:206` — `logger.error(["Failed command:", ...])` in `MemoryConsumerSession` transform stream.
- `provider.ts:188` — `selector=...` in `recordSlowQuery` `logger.warn` array.
- `provider.ts:418` — `logger.error(["Failed command:", ...])` in `MemoryProviderSession` writable stream.
- `space-schema.ts:278` — `schemaPath=...` in slow-doc `logger.warn` array.
- `space-schema.ts:372` — `selectors=...` in slow-`selectSchema` `logger.warn` array.

`toIndentedDebugString` for the one site whose original passed `null, 2` (1 site):

- `provider.ts:753` — `logger.warn` `transact-error` array; original was `JSON.stringify(result.error, null, 2)`.

### D6 — DISPLAY telemetry / OpenTelemetry span attribute (1 site)

`toCompactDebugString` for the OpenTelemetry attribute write (1 site):

- `space.ts:1110` — `span.setAttribute("querySchema.selectSchema", ...)` in `querySchema` `traceSync` block.

Per Remy's R3, OpenTelemetry attribute sites are a clear win for a richer formatter (`BigInt` rendering as `42n` rather than `JSON.stringify` throwing; etc.).

## Sites carefully classified — DISPLAY confirmed via consumer trace

The `space.ts:1110` DISPLAY site warranted explicit consumer-trace before migration, since OpenTelemetry attributes can in principle flow into automated alerting / SLO machinery (which would make them WIRE-class):

- **Producer:** `space.ts:1107-1110` is the only place `querySchema.selectSchema` (and the related `querySchema.has_selector`) is set. Span comes from `traceSync(...)` in `packages/memory/telemetry.ts` (a thin OpenTelemetry tracer wrapper).
- **Repo-wide grep for `querySchema.selectSchema` / `querySchema.has_selector`:** zero non-producer hits — no code anywhere in `packages/**` reads, parses, or asserts on the attribute.
- **Repo-wide config grep** (`*.json`, `*.yaml`, `*.yml`, `*.tf`, `*.md`): zero references — no alerting rule, SLO config, or dashboard config in the repo consumes it.
- **Telemetry pipeline:** OpenTelemetry attributes are emitted via OTLP to a backend (Grafana / Datadog / etc.), where they're displayed as opaque strings in trace UI.

Pure observability surface; no parser downstream. Classification confirmed DISPLAY; migration is safe and produces strictly more useful trace data than `JSON.stringify`'s silent-mangling for `BigInt` / `Map` / `Set` / etc.

## Sites correctly excluded as categorical mismatches

All 8 remaining `JSON.stringify` sites in non-test `packages/memory/` are confirmed WIRE and left in place (matches Remy's per-package count: 8 WIRE / 13 swap-eligible / 21 total non-test):

- `bytes.ts:29` — `Bytes.toString` companion of `Bytes.fromJSON` (W12 wire helper, currently dead/placeholder per Dan's note in Remy's report).
- `consumer.ts:906` — `JSON.parse(JSON.stringify(item.cause))` deep-clone idiom (W6).
- `provider.ts:1668` — `new Response(JSON.stringify(body), { ... })` (W1 HTTP body).
- `receipt.ts:12` — exported `toString` wire helper (W12).
- `ucan.ts:45` — `Codec.UCAN.toString`, sent over websocket via `runner/storage/cache.ts:1612` (W12).
- `space.ts:1243` — `ofs: JSON.stringify(ofs)` SQL prepared-statement parameter (W7).
- `v2/server-sync.ts:91, 100` — watch-identity Map-key / Set-key strings (W4).

## Lens findings

Three-step classification lens applied per site (lossy-body check → name-asserted-contract → consumer trace):

- **Step 1 (lossy-body):** No migrated function does truncation, ellipsis, or redaction; all are direct embeds.
- **Step 2 (name-asserted-contract):** No migrated site sits inside a function whose name asserts a stable/canonical/parseable contract (`serialize*`, `format*Stable*`, `format*Canonical*`, `canonical*`, `*ToString` feeding identity). The closest neighbor — `entity.ts:fromString` — only stringifies inside the error-template path, not in the success path that yields the `@`-prefixed identity string; the success path doesn't touch `JSON.stringify` at all.
- **Step 3 (consumer trace):** No migrated output flows into Map/Set keys, hashes, persisted storage, structured log fields, or cross-package API boundaries. The DISPLAY telemetry site (`space.ts:1110`) was given an explicit consumer trace (above) to confirm.

## Note on per-shape placement

Three sites Remy's per-package count tallied as DEBUG, but his per-shape D2 list didn't enumerate by line: `provider.ts:188` (`recordSlowQuery` `selector=` log line), `space-schema.ts:278` (`schemaPath=` log line), `space-schema.ts:372` (`selectors=` log line). All three are inside `logger.warn(...)` array arguments — D2-shaped placement is consistent with Remy's D2 examples (`consumer.ts:206`, `provider.ts:415, 749`). No category-bending reclassification, just per-site placement in the D2-logger bucket.

## Local validation

- `deno fmt --check packages/memory/`: 72 files clean.
- `deno lint packages/memory/`: 67 files clean.
- `cd packages/memory && deno task test`: **119 passed (164 steps), 0 failed.** Identical to pre-migration baseline (verified both before the migration and after a merge-sync of `origin/main`).

## Test coverage

No new tests added — the migration is mechanical and the existing `packages/memory` test suite exercises every changed file. Coverage of the helpers themselves is in `packages/data-model/test/value-debug.test.ts` (see PR #3409).

## Branch sync note

Branch was sync-merged with `origin/main` mid-PR-prep to incorporate PR #3414 ("Decode memory v2 wire payloads via the proper boundary helper in tests") which had landed during this work. The merge is a clean ort-strategy merge of test-file changes only; the migration commit `990cb6b93` is unaffected.

Co-Authored-By: coder-colt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
