### PR TITLE
Encode memory v2 wire payloads via the proper boundary helper in tests

### DIFF
--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -3,6 +3,7 @@ import { FakeTime } from "@std/testing/time";
 import { Server, SessionRegistry } from "../v2/server.ts";
 import {
   decodeMemoryV2Boundary,
+  encodeMemoryV2Boundary,
   type EntitySnapshot,
   getMemoryV2Flags,
   MEMORY_V2_PROTOCOL,
@@ -422,7 +423,7 @@ class ReconnectableLoopbackTransport implements Transport {
     if (this.#connection === null) {
       this.connectionCount++;
       this.#connection = this.server.connect((message) => {
-        this.#receiver(JSON.stringify(message));
+        this.#receiver(encodeMemoryV2Boundary(message));
       });
     }
     return this.#connection;
@@ -524,7 +525,7 @@ class ScriptedReconnectTransport implements Transport {
   }
 
   #respond(message: unknown): void {
-    this.#receiver(JSON.stringify(message));
+    this.#receiver(encodeMemoryV2Boundary(message));
   }
 }
 
@@ -608,7 +609,7 @@ class DelayedTransactTransport implements Transport {
   }
 
   #respond(message: unknown): void {
-    this.#receiver(JSON.stringify(message));
+    this.#receiver(encodeMemoryV2Boundary(message));
   }
 }
 
@@ -684,7 +685,7 @@ class AckCountingTransport implements Transport {
   }
 
   #respond(message: unknown): void {
-    this.#receiver(JSON.stringify(message));
+    this.#receiver(encodeMemoryV2Boundary(message));
   }
 }
 
@@ -753,7 +754,7 @@ class HangingAckTransport implements Transport {
   }
 
   #respond(message: unknown): void {
-    this.#receiver(JSON.stringify(message));
+    this.#receiver(encodeMemoryV2Boundary(message));
   }
 }
 
@@ -796,10 +797,10 @@ class ControlledReconnectTransport implements Transport {
           queueMicrotask(() => this.#closeReceiver(new Error("offline")));
           return Promise.resolve();
         }
-        this.#receiver(JSON.stringify(HELLO_OK));
+        this.#receiver(encodeMemoryV2Boundary(HELLO_OK));
         return Promise.resolve();
       case "session.open":
-        this.#receiver(JSON.stringify({
+        this.#receiver(encodeMemoryV2Boundary({
           type: "response",
           requestId: message.requestId!,
           ok: {
@@ -839,7 +840,7 @@ class CloseOnSessionOpenTransport implements Transport {
     };
 
     if (message.type === "hello") {
-      this.#receiver(JSON.stringify(HELLO_OK));
+      this.#receiver(encodeMemoryV2Boundary(HELLO_OK));
       return Promise.resolve();
     }
 
@@ -880,10 +881,10 @@ class CloseOnAppliedCommitTransport implements Transport {
 
     switch (message.type) {
       case "hello":
-        this.#receiver(JSON.stringify(HELLO_OK));
+        this.#receiver(encodeMemoryV2Boundary(HELLO_OK));
         return Promise.resolve();
       case "session.open":
-        this.#receiver(JSON.stringify({
+        this.#receiver(encodeMemoryV2Boundary({
           type: "response",
           requestId: message.requestId!,
           ok: {
@@ -893,7 +894,7 @@ class CloseOnAppliedCommitTransport implements Transport {
         }));
         return Promise.resolve();
       case "session.ack":
-        this.#receiver(JSON.stringify({
+        this.#receiver(encodeMemoryV2Boundary({
           type: "response",
           requestId: message.requestId!,
           ok: {
@@ -902,7 +903,7 @@ class CloseOnAppliedCommitTransport implements Transport {
         }));
         return Promise.resolve();
       case "transact":
-        this.#receiver(JSON.stringify({
+        this.#receiver(encodeMemoryV2Boundary({
           type: "response",
           requestId: message.requestId!,
           ok: {
@@ -1500,7 +1501,7 @@ Deno.test("memory v2 client rejects hello.ok when flags disagree", async () => {
     send(payload): Promise<void> {
       const message = decodeMemoryV2Boundary(payload) as { type?: string };
       if (message.type === "hello") {
-        receiver(JSON.stringify({
+        receiver(encodeMemoryV2Boundary({
           type: "hello.ok",
           protocol: MEMORY_V2_PROTOCOL,
           flags: {
@@ -1667,7 +1668,7 @@ class DisconnectableAckTransport implements Transport {
   }
 
   #respond(message: unknown): void {
-    this.#receiver(JSON.stringify(message));
+    this.#receiver(encodeMemoryV2Boundary(message));
   }
 }
 
@@ -1751,7 +1752,7 @@ class SessionChangingTransport implements Transport {
 
     switch (message.type) {
       case "hello":
-        this.#receiver(JSON.stringify(HELLO_OK));
+        this.#receiver(encodeMemoryV2Boundary(HELLO_OK));
         return Promise.resolve();
       case "session.open": {
         this.sessionOpenCount++;
@@ -1759,7 +1760,7 @@ class SessionChangingTransport implements Transport {
         const sessionId = this.sessionOpenCount === 1
           ? "session-A"
           : "session-B";
-        this.#receiver(JSON.stringify({
+        this.#receiver(encodeMemoryV2Boundary({
           type: "response",
           requestId: message.requestId!,
           ok: {
@@ -1778,7 +1779,7 @@ class SessionChangingTransport implements Transport {
           return Promise.resolve();
         }
         // If we get here, a transact was sent with new session — this is the bug
-        this.#receiver(JSON.stringify({
+        this.#receiver(encodeMemoryV2Boundary({
           type: "response",
           requestId: message.requestId!,
           ok: { seq: this.transactCount },
@@ -1786,7 +1787,7 @@ class SessionChangingTransport implements Transport {
         return Promise.resolve();
       }
       case "session.ack":
-        this.#receiver(JSON.stringify({
+        this.#receiver(encodeMemoryV2Boundary({
           type: "response",
           requestId: message.requestId!,
           ok: { serverSeq: 0 },

--- a/packages/memory/test/v2-restore-flush-test.ts
+++ b/packages/memory/test/v2-restore-flush-test.ts
@@ -1,7 +1,7 @@
 import { assert, assertEquals } from "@std/assert";
 import { Server } from "../v2/server.ts";
 import { connect, type Transport } from "../v2/client.ts";
-import { decodeMemoryV2Boundary } from "../v2.ts";
+import { decodeMemoryV2Boundary, encodeMemoryV2Boundary } from "../v2.ts";
 
 const SPACE = "did:key:z6Mk-restore-flush-test";
 
@@ -106,7 +106,7 @@ class ReconnectableTransport implements Transport {
         const localSeq = typeof requestId === "string"
           ? this.#transactRequestLocalSeqById.get(requestId)
           : undefined;
-        const payload = JSON.stringify(message);
+        const payload = encodeMemoryV2Boundary(message);
         if (
           this.#delayTransacts &&
           typeof requestId === "string" &&

--- a/packages/memory/test/v2-watch-sync-test.ts
+++ b/packages/memory/test/v2-watch-sync-test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { Server } from "../v2/server.ts";
 import {
+  encodeMemoryV2Boundary,
   getMemoryV2Flags,
   MEMORY_V2_PROTOCOL,
   type ResponseMessage,
@@ -45,12 +46,12 @@ Deno.test("memory v2 server replaces watch sets and emits session sync effects",
 
   try {
     for (const connection of [writer, watcher]) {
-      await connection.receive(JSON.stringify(HELLO));
+      await connection.receive(encodeMemoryV2Boundary(HELLO));
     }
     shiftMessage(writerMessages);
     shiftMessage(watcherMessages);
 
-    await writer.receive(JSON.stringify({
+    await writer.receive(encodeMemoryV2Boundary({
       type: "session.open",
       requestId: "writer-open",
       space,
@@ -60,7 +61,7 @@ Deno.test("memory v2 server replaces watch sets and emits session sync effects",
       shiftMessage(writerMessages),
     );
 
-    await watcher.receive(JSON.stringify({
+    await watcher.receive(encodeMemoryV2Boundary({
       type: "session.open",
       requestId: "watcher-open",
       space,
@@ -74,7 +75,7 @@ Deno.test("memory v2 server replaces watch sets and emits session sync effects",
     const writerSessionId = writerOpen.ok!.sessionId;
     const watcherSessionId = watcherOpen.ok!.sessionId;
 
-    await writer.receive(JSON.stringify({
+    await writer.receive(encodeMemoryV2Boundary({
       type: "transact",
       requestId: "tx-1",
       space,
@@ -111,7 +112,7 @@ Deno.test("memory v2 server replaces watch sets and emits session sync effects",
       }],
     });
 
-    await watcher.receive(JSON.stringify({
+    await watcher.receive(encodeMemoryV2Boundary({
       type: "session.watch.set",
       requestId: "watch-1",
       space,
@@ -159,7 +160,7 @@ Deno.test("memory v2 server replaces watch sets and emits session sync effects",
     }]);
     assertEquals(watchResponse.ok?.sync.removes, []);
 
-    await writer.receive(JSON.stringify({
+    await writer.receive(encodeMemoryV2Boundary({
       type: "transact",
       requestId: "tx-2",
       space,


### PR DESCRIPTION
## Summary

Symmetric counterpart to #3414. The test transports in `packages/memory/test/v2-client-test.ts`, `v2-restore-flush-test.ts`, and `v2-watch-sync-test.ts` were producing wire payloads with `JSON.stringify(...)` while their receivers (post-#3414) read them via `decodeMemoryV2Boundary`. Switches the producing side to `encodeMemoryV2Boundary(...)` so test transports stay aligned with how the production wire format is actually framed.

Two debug-format sites in `v2-client-test.ts` (assertion failure messages) intentionally keep `JSON.stringify`, since they format arbitrary debug values (including `undefined`) rather than wire payloads.

## Why

Behaviorally a no-op on `main` today: with the unified-JSON-encoding flag off, `encodeMemoryV2Boundary` reduces to `JSON.stringify`. The change just removes a hidden landmine for the in-flight encoding work — completes the cascade started in #3412 and #3414 so test transports use the symmetric wire-format helpers on both ends.

## Test plan

- [x] `deno task test` in `packages/memory` — 119 passed (164 steps), 0 failed (no regression on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
