### PR TITLE
fix(llm): typed stream error propagation (split from #3359)

### DIFF
--- a/packages/llm/src/client.test.ts
+++ b/packages/llm/src/client.test.ts
@@ -8,12 +8,35 @@ import {
   disableMockMode,
   enableMockMode,
   LLMClient,
+  LLMStreamError,
   loadConversationFixture,
   resetMockMode,
 } from "./client.ts";
 
 const GUARD_MESSAGE =
   "LLMClient: live LLM calls are blocked in test environments.";
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+function runClientStream(client: LLMClient, chunks: string[]) {
+  return (client as unknown as {
+    stream(
+      body: ReadableStream<Uint8Array>,
+      id: string,
+      callback?: (text: string) => void,
+    ): Promise<unknown>;
+  }).stream(streamFromChunks(chunks), "trace-1", () => {});
+}
 
 describe("LLMClient test-environment guard", () => {
   const client = new LLMClient();
@@ -319,5 +342,59 @@ describe("LLMClient test-environment guard", () => {
         () => {},
       ),
     ).rejects.toThrow("not configured as a stream");
+  });
+
+  it("throws LLMStreamError for streamed error events mid-stream", async () => {
+    for (
+      const chunks of [
+        [
+          JSON.stringify({ type: "text-delta", textDelta: "hello" }) + "\n",
+          JSON.stringify({ type: "error", error: "boom" }) + "\n",
+        ],
+        [
+          JSON.stringify({ type: "text-delta", textDelta: "hello" }) + "\n",
+          JSON.stringify({ type: "error", error: "boom" }),
+        ],
+      ]
+    ) {
+      try {
+        await runClientStream(client, chunks);
+      } catch (error) {
+        expect(error).toBeInstanceOf(LLMStreamError);
+        expect((error as Error).message).toBe("boom");
+        continue;
+      }
+
+      throw new Error("Expected LLMStreamError");
+    }
+  });
+
+  it("logs and ignores garbage lines mid-stream", async () => {
+    const originalConsoleError = console.error;
+    const loggedErrors: unknown[][] = [];
+    console.error = (...args: unknown[]) => {
+      loggedErrors.push(args);
+    };
+
+    try {
+      const result = await runClientStream(client, [
+        JSON.stringify("hello") + "\n",
+        "not json\n",
+        "not final json",
+      ]);
+
+      expect(result).toEqual({
+        role: "assistant",
+        content: [{ type: "text", text: "hello" }],
+        id: "trace-1",
+      });
+      expect(loggedErrors.length).toBe(2);
+      expect(loggedErrors[0][0]).toBe("Failed to parse JSON line:");
+      expect(loggedErrors[0][1]).toBe("not json");
+      expect(loggedErrors[1][0]).toBe("Failed to parse final JSON line:");
+      expect(loggedErrors[1][1]).toBe("not final json");
+    } finally {
+      console.error = originalConsoleError;
+    }
   });
 });

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -9,6 +9,13 @@ import {
 
 type PartialCallback = (text: string) => void;
 
+export class LLMStreamError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LLMStreamError";
+  }
+}
+
 /**
  * Detect if we're running in a test environment.
  * Checks CI=true (CI runners) and ENV=test (set by deno task test).
@@ -617,8 +624,11 @@ export class LLMClient {
               } else if (event.type === "finish") {
                 // Stream finished
                 break;
+              } else if (event.type === "error") {
+                throw new LLMStreamError(event.error ?? "LLM stream error");
               }
             } catch (error) {
+              if (error instanceof LLMStreamError) throw error;
               console.error("Failed to parse JSON line:", line, error);
             }
           }
@@ -633,8 +643,11 @@ export class LLMClient {
         if (typeof event === "string") {
           text += event;
           if (callback) callback(text);
+        } else if (event.type === "error") {
+          throw new LLMStreamError(event.error ?? "LLM stream error");
         }
       } catch (error) {
+        if (error instanceof LLMStreamError) throw error;
         console.error("Failed to parse final JSON line:", buffer, error);
       }
     }


### PR DESCRIPTION
## Summary

Replaces the double-parse pattern in the LLM client's streaming response handler with a typed `LLMStreamError`. Extracted from #3359.

The original change in #3359 threw a generic `Error` from inside the streaming `try` when an `{type: "error"}` frame arrived, then in the surrounding `catch` re-parsed the same line/buffer to decide whether the throw was its own (propagate) or a JSON parse failure (log and continue). That works but is fragile — the second parse path uses `buffer.trim()`, which doesn't necessarily contain the same input that triggered the throw, and it parses garbage twice on the happy error path.

This PR introduces `class LLMStreamError extends Error` exported from `packages/llm/src/client.ts`. Both catch sites (SSE-line loop and trailing-buffer handler) now do `if (error instanceof LLMStreamError) throw error;` before logging — no JSON re-parsing.

## Test plan

- [x] `deno task test` in `packages/llm` (passing; new tests cover both code paths)
- [x] `deno task test` in `packages/runtime-client` (no regression)
- [ ] CI green

Tests landed in `packages/llm/src/client.test.ts` rather than `packages/runtime-client/integration/client.test.ts` because the runtime-client integration suite has no LLM endpoint mock harness — the new tests use a `ReadableStream`-based mock that wires directly to the client's private stream method. Two scenarios:
1. Mid-stream `{type: "error", error: "boom"}` frame (both with trailing newline and as the trailing buffer) → throws `LLMStreamError` with the server message.
2. Garbage / unparseable lines → logged via `console.error` and stream continues normally.

Split from #3359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a typed `LLMStreamError` in the LLM client’s streaming handler to propagate server error events cleanly. This removes fragile double-parsing and reduces noisy logs.

- **Bug Fixes**
  - Added exported `LLMStreamError` and throw it on `{type: "error"}` stream events.
  - Catch blocks rethrow typed errors and no longer re-parse the line/buffer.
  - Applies to both the SSE line loop and final-buffer handler; garbage lines still log and continue.

<sup>Written for commit c11b509b089d41c79187ac91add34e6b0483919d. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3418?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

