### PR TITLE
Make cf-harness subagent delegation profiles explicit

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -36,8 +36,9 @@ What works today:
   - `delegate_task`
 - whole-file replace/create plus append writes
 - bounded OpenAI-compatible prompt/tool loop
-- single-child subagent delegation with fresh child prompt context, a default
-  child tool policy, and retained child run references
+- single-child subagent delegation with fresh child prompt context, an explicit
+  default child profile, retained child run references, and a sanitized
+  summary/state return channel
 - persisted run state, transcript, Loom run manifests, capability snapshots, and
   tool outputs
 - transcript-based resumability
@@ -60,7 +61,8 @@ What is not done yet:
 
 - real runner-driven CFC feedback integration
 - richer opaque-handle/pass-through behavior
-- subagent profiles, browser-mediated subagents, and parallel job orchestration
+- additional subagent profiles, browser-mediated subagents, and parallel job
+  orchestration
 - app UI event provenance
 - streaming model responses
 - richer mid-turn resumability
@@ -124,6 +126,18 @@ deno task run -- \
   --gateway-auth-mode none \
   --run-manifest /path/to/loom-run-manifest.json \
   --prompt "Handle this Loom wish."
+```
+
+When constraining the parent tool surface to `delegate_task`, authorize the
+child profile separately so the delegation policy transition is explicit:
+
+```bash
+deno task run -- \
+  --workspace /path/to/workspace \
+  --gateway-auth-mode none \
+  --allow-tool delegate_task \
+  --allow-subagent-profile default \
+  --prompt "Delegate a focused inspection and summarize the result."
 ```
 
 Current caveat:

--- a/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
@@ -174,10 +174,17 @@ Why:
 - built-in `delegate_task` tool descriptor
 - prompt-loop orchestration for one focused child run at a time
 - fresh child prompt context with the delegated goal and optional context
-- default child tool policy limited to:
+- explicit default child profile limited to:
   - `bash`
   - `read_file`
   - `write_file`
+- parent delegation authority separated from direct parent tool allowlists:
+  - unconstrained runs allow the default profile
+  - runs with an explicit `--allow-tool` list require
+    `--allow-subagent-profile default` to spawn the default profile
+- named return policy that sends the parent a summary, manifest, and sanitized
+  run-state summary, while retaining raw child transcript/failure detail in
+  child artifacts
 - persisted parent references to child run ids, manifests, summaries, and run
   state snapshots
 - summary-only parent tool output, without exposing the child transcript back to
@@ -187,7 +194,9 @@ Why:
 
 - to introduce the core containment and provenance shape before browser access
 - to give Loom and Pattern Factory a native delegation primitive without adding
-  profiles, parallelism, or browser mediation in the first slice
+  additional profiles, parallelism, or browser mediation in the first slice
+- to make delegation a visible policy transition before adding higher-taint
+  child capabilities such as `agent-browser`
 
 ## Current Verified State
 
@@ -303,7 +312,7 @@ context plus the default shell/file tool set.
 
 The remaining subagent work is still substantial:
 
-- profile/policy selection beyond the single default child policy
+- additional profile/policy selection beyond the single default child policy
 - browser-mediated subagents, expected to wrap `agent-browser`
 - parallel child orchestration
 - richer orchestration resume for partially completed child runs

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -19,6 +19,11 @@ import {
   type HarnessRunManifest,
   parseLoomRunManifestJson,
 } from "./contracts/run-manifest.ts";
+import {
+  DEFAULT_SUBAGENT_PROFILE,
+  HARNESS_SUBAGENT_PROFILES,
+  type HarnessSubagentProfile,
+} from "./contracts/subagent.ts";
 import type { BuiltinToolId } from "./contracts/tool-descriptor.ts";
 import type {
   HarnessTranscriptEvent,
@@ -43,6 +48,7 @@ export interface CfHarnessCliConfig {
   cwd?: string;
   focusRoot?: string;
   allowedToolIds?: readonly BuiltinToolId[];
+  allowedSubagentProfiles: readonly HarnessSubagentProfile[];
   outputMode: CfHarnessCliOutputMode;
   streamEvents: boolean;
   promptSlotRole: PromptSlotRole;
@@ -162,6 +168,7 @@ Options:
   --cwd <path>                  Initial working directory inside the workspace
   --focus-root <path>           Narrow exploration to a workspace subpath when possible
   --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | write_file | delegate_task)
+  --allow-subagent-profile <p>  Authorize delegate_task to spawn a profile (repeatable: default)
   --output-mode <mode>          operator | batch (default: operator)
   --stream-events               Print transcript events as they happen
   --prompt-slot-role <role>     direct-command | context | quote (default: direct-command)
@@ -240,6 +247,9 @@ const parseBuiltinToolIds = (
     return undefined;
   }
   const values = Array.isArray(input) ? input : [input];
+  if (values.length === 0) {
+    return undefined;
+  }
   const parsed = values.map((value) => parseBuiltinToolId(value));
   if (parsed.some((value) => value === undefined)) {
     throw new Error(
@@ -248,6 +258,37 @@ const parseBuiltinToolIds = (
   }
   return [...new Set(parsed)] as readonly BuiltinToolId[];
 };
+
+const parseSubagentProfile = (
+  input: string,
+): HarnessSubagentProfile | undefined =>
+  (HARNESS_SUBAGENT_PROFILES as readonly string[]).includes(input)
+    ? input as HarnessSubagentProfile
+    : undefined;
+
+const parseSubagentProfiles = (
+  input: string | readonly string[] | undefined,
+): readonly HarnessSubagentProfile[] | undefined => {
+  if (input === undefined) {
+    return undefined;
+  }
+  const values = Array.isArray(input) ? input : [input];
+  if (values.length === 0) {
+    return undefined;
+  }
+  const parsed = values.map((value) => parseSubagentProfile(value));
+  if (parsed.some((value) => value === undefined)) {
+    throw new Error("allowed subagent profiles must be one or more of default");
+  }
+  return [...new Set(parsed)] as readonly HarnessSubagentProfile[];
+};
+
+const resolveAllowedSubagentProfiles = (
+  allowedToolIds: readonly BuiltinToolId[] | undefined,
+  allowedSubagentProfiles: readonly HarnessSubagentProfile[] | undefined,
+): readonly HarnessSubagentProfile[] =>
+  allowedSubagentProfiles ??
+    (allowedToolIds === undefined ? [DEFAULT_SUBAGENT_PROFILE] : []);
 
 const nonEmptyEnvValue = (input: string | undefined): string | undefined => {
   const trimmed = input?.trim();
@@ -310,6 +351,7 @@ export const parseCfHarnessCliArgs = async (
       "cwd",
       "focus-root",
       "allow-tool",
+      "allow-subagent-profile",
       "output-mode",
       "prompt-slot-role",
       "prompt",
@@ -326,7 +368,7 @@ export const parseCfHarnessCliArgs = async (
       "max-model-turns",
     ],
     boolean: ["help", "print-transcript", "stream-events"],
-    collect: ["allow-tool"],
+    collect: ["allow-tool", "allow-subagent-profile"],
     alias: {
       h: "help",
     },
@@ -354,6 +396,15 @@ export const parseCfHarnessCliArgs = async (
     : undefined;
   const allowedToolIds = parseBuiltinToolIds(
     args["allow-tool"] as string | readonly string[] | undefined,
+  );
+  const allowedSubagentProfiles = resolveAllowedSubagentProfiles(
+    allowedToolIds,
+    parseSubagentProfiles(
+      args["allow-subagent-profile"] as
+        | string
+        | readonly string[]
+        | undefined,
+    ),
   );
   const outputMode = parseCliOutputMode(
     typeof args["output-mode"] === "string" ? args["output-mode"] : undefined,
@@ -446,6 +497,7 @@ export const parseCfHarnessCliArgs = async (
     ...(initialCwd !== undefined ? { cwd: initialCwd } : {}),
     ...(focusRoot !== undefined ? { focusRoot } : {}),
     ...(allowedToolIds !== undefined ? { allowedToolIds } : {}),
+    allowedSubagentProfiles,
     outputMode: outputMode ?? "operator",
     streamEvents: Boolean(args["stream-events"]),
     promptSlotRole: promptSlotRole ?? "direct-command",
@@ -795,6 +847,7 @@ export const runCfHarnessCli = async (
         apiKey: parsed.apiKey,
         apiKeySource: parsed.apiKeySource,
         maxModelTurns: parsed.maxModelTurns,
+        allowedSubagentProfiles: parsed.allowedSubagentProfiles,
         ...(parsed.allowedToolIds !== undefined
           ? { allowedToolIds: parsed.allowedToolIds }
           : {}),
@@ -843,6 +896,7 @@ export const runCfHarnessCli = async (
           ? { runManifestPath: parsed.runManifestPath }
           : {}),
         maxModelTurns: parsed.maxModelTurns,
+        allowedSubagentProfiles: parsed.allowedSubagentProfiles,
         ...(parsed.allowedToolIds !== undefined
           ? { allowedToolIds: parsed.allowedToolIds }
           : {}),

--- a/packages/cf-harness/src/contracts/policy.ts
+++ b/packages/cf-harness/src/contracts/policy.ts
@@ -1,6 +1,7 @@
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { ObservationDenied } from "./observation.ts";
 import type { PromptSlotBinding } from "./prompt-slot.ts";
+import type { HarnessSubagentProfile } from "./subagent.ts";
 import type { BuiltinToolId } from "./tool-descriptor.ts";
 
 export type HarnessPolicyEventSeverity = "warning" | "denied";
@@ -34,6 +35,7 @@ export interface HarnessWriteFileToolInputSummary {
 export interface HarnessDelegateTaskToolInputSummary {
   type: "cf-harness.tool-input-summary";
   toolId: "delegate_task";
+  profile?: HarnessSubagentProfile;
   goalBytes?: number;
   goalDigest?: string;
   contextBytes?: number;

--- a/packages/cf-harness/src/contracts/subagent.ts
+++ b/packages/cf-harness/src/contracts/subagent.ts
@@ -5,6 +5,8 @@ import type { BuiltinToolId } from "./tool-descriptor.ts";
 export const DEFAULT_SUBAGENT_PROFILE = "default" as const;
 export const DEFAULT_SUBAGENT_MAX_MODEL_TURNS = 8;
 export const MAX_SUBAGENT_MAX_MODEL_TURNS = 16;
+export const DEFAULT_SUBAGENT_RETURN_CHANNEL =
+  "summary-and-sanitized-state" as const;
 export const DEFAULT_SUBAGENT_ALLOWED_TOOL_IDS = [
   "bash",
   "read_file",
@@ -13,6 +15,62 @@ export const DEFAULT_SUBAGENT_ALLOWED_TOOL_IDS = [
 
 export type HarnessSubagentProfile = typeof DEFAULT_SUBAGENT_PROFILE;
 export type HarnessSubagentRunStatus = "completed" | "failed";
+export type HarnessSubagentReturnChannel =
+  typeof DEFAULT_SUBAGENT_RETURN_CHANNEL;
+
+export const HARNESS_SUBAGENT_PROFILES = [
+  DEFAULT_SUBAGENT_PROFILE,
+] as const satisfies readonly HarnessSubagentProfile[];
+
+export interface HarnessSubagentReturnPolicy {
+  type: "cf-harness.subagent-return-policy";
+  channel: HarnessSubagentReturnChannel;
+  includeSummary: true;
+  includeSanitizedRunState: true;
+  includeManifest: true;
+  includeTranscript: false;
+  includeRawFailureRecords: false;
+}
+
+export interface HarnessSubagentProfileConfig {
+  type: "cf-harness.subagent-profile-config";
+  profile: HarnessSubagentProfile;
+  allowedToolIds: readonly BuiltinToolId[];
+  maxModelTurns: number;
+  returnPolicy: HarnessSubagentReturnPolicy;
+}
+
+export const DEFAULT_SUBAGENT_RETURN_POLICY: HarnessSubagentReturnPolicy = {
+  type: "cf-harness.subagent-return-policy",
+  channel: DEFAULT_SUBAGENT_RETURN_CHANNEL,
+  includeSummary: true,
+  includeSanitizedRunState: true,
+  includeManifest: true,
+  includeTranscript: false,
+  includeRawFailureRecords: false,
+};
+
+export const DEFAULT_SUBAGENT_PROFILE_CONFIG: HarnessSubagentProfileConfig = {
+  type: "cf-harness.subagent-profile-config",
+  profile: DEFAULT_SUBAGENT_PROFILE,
+  allowedToolIds: DEFAULT_SUBAGENT_ALLOWED_TOOL_IDS,
+  maxModelTurns: DEFAULT_SUBAGENT_MAX_MODEL_TURNS,
+  returnPolicy: DEFAULT_SUBAGENT_RETURN_POLICY,
+};
+
+export const isHarnessSubagentProfile = (
+  input: string,
+): input is HarnessSubagentProfile =>
+  (HARNESS_SUBAGENT_PROFILES as readonly string[]).includes(input);
+
+export const getHarnessSubagentProfileConfig = (
+  profile: HarnessSubagentProfile,
+): HarnessSubagentProfileConfig => {
+  switch (profile) {
+    case DEFAULT_SUBAGENT_PROFILE:
+      return DEFAULT_SUBAGENT_PROFILE_CONFIG;
+  }
+};
 
 export interface HarnessSubagentInputSummary {
   type: "cf-harness.subagent-input-summary";
@@ -34,6 +92,7 @@ export interface HarnessSubagentRunManifest {
   model: string;
   allowedToolIds: readonly BuiltinToolId[];
   maxModelTurns: number;
+  returnPolicy: HarnessSubagentReturnPolicy;
   createdAt: string;
   inputSummary: HarnessSubagentInputSummary;
 }
@@ -95,6 +154,7 @@ export interface HarnessSubagentRunRef {
 
 export interface DelegateTaskToolInput {
   goal: string;
+  profile: HarnessSubagentProfile;
   context?: string;
   maxModelTurns?: number;
 }

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -40,16 +40,17 @@ import {
   type HarnessToolPolicyDecision,
 } from "./contracts/run-report.ts";
 import {
-  DEFAULT_SUBAGENT_ALLOWED_TOOL_IDS,
-  DEFAULT_SUBAGENT_MAX_MODEL_TURNS,
   DEFAULT_SUBAGENT_PROFILE,
   type DelegateTaskToolInput,
   type DelegateTaskToolOutput,
+  getHarnessSubagentProfileConfig,
   type HarnessSubagentFailureSummary,
   type HarnessSubagentInputSummary,
+  type HarnessSubagentProfile,
   type HarnessSubagentResult,
   type HarnessSubagentRunManifest,
   type HarnessSubagentRunStateSummary,
+  isHarnessSubagentProfile,
   MAX_SUBAGENT_MAX_MODEL_TURNS,
 } from "./contracts/subagent.ts";
 import { BUILTIN_TOOLS, getBuiltinTool } from "./tools/registry.ts";
@@ -66,6 +67,7 @@ export interface CreateHarnessPromptLoopOptions
   fetchFn?: typeof fetch;
   maxModelTurns?: number;
   allowedToolIds?: readonly BuiltinToolId[];
+  allowedSubagentProfiles?: readonly HarnessSubagentProfile[];
 }
 
 export interface RunHarnessPromptOptions {
@@ -406,9 +408,16 @@ const summarizeToolInput = async (
       const contextSummary = typeof input.context === "string"
         ? await summarizeSensitiveText(input.context)
         : undefined;
+      const profile = input.profile === undefined
+        ? DEFAULT_SUBAGENT_PROFILE
+        : typeof input.profile === "string" &&
+            isHarnessSubagentProfile(input.profile)
+        ? input.profile
+        : undefined;
       return {
         type: "cf-harness.tool-input-summary",
         toolId,
+        ...(profile !== undefined ? { profile } : {}),
         ...(goalSummary !== undefined
           ? {
             goalBytes: goalSummary.bytes,
@@ -442,6 +451,17 @@ const parseDelegateTaskInput = (
   if (input.context !== undefined && typeof input.context !== "string") {
     throw new Error("delegate_task context must be a string when provided");
   }
+  const profile = input.profile === undefined
+    ? DEFAULT_SUBAGENT_PROFILE
+    : typeof input.profile === "string" &&
+        isHarnessSubagentProfile(input.profile)
+    ? input.profile
+    : undefined;
+  if (profile === undefined) {
+    throw new Error(
+      `delegate_task profile must be one of ${DEFAULT_SUBAGENT_PROFILE}`,
+    );
+  }
   const maxModelTurns = input.maxModelTurns;
   if (
     maxModelTurns !== undefined &&
@@ -456,6 +476,7 @@ const parseDelegateTaskInput = (
   }
   return {
     goal: input.goal,
+    profile,
     ...(typeof input.context === "string" && input.context.trim().length > 0
       ? { context: input.context }
       : {}),
@@ -655,6 +676,7 @@ export class CfHarnessPromptLoop {
   readonly gatewayClient: OpenAICompatibleGatewayClient;
   readonly #maxModelTurns: number;
   readonly #allowedToolIds?: ReadonlySet<BuiltinToolId>;
+  readonly #allowedSubagentProfiles: ReadonlySet<HarnessSubagentProfile>;
 
   constructor(options: CreateHarnessPromptLoopOptions = {}) {
     this.engine = options.engine ?? new CfHarnessEngine(options);
@@ -670,6 +692,12 @@ export class CfHarnessPromptLoop {
     this.#allowedToolIds = options.allowedToolIds === undefined
       ? undefined
       : new Set(options.allowedToolIds);
+    this.#allowedSubagentProfiles = new Set(
+      options.allowedSubagentProfiles ??
+        (options.allowedToolIds === undefined
+          ? [DEFAULT_SUBAGENT_PROFILE]
+          : []),
+    );
   }
 
   async runPrompt(
@@ -973,6 +1001,50 @@ export class CfHarnessPromptLoop {
         content: JSON.stringify(denial),
       };
     }
+    let delegateInput: DelegateTaskToolInput | undefined;
+    if (toolCall.function.name === "delegate_task") {
+      try {
+        delegateInput = parseDelegateTaskInput(input);
+      } catch (error) {
+        recordActivity({
+          type: "cf-harness.tool-activity",
+          ...baseActivity(policyDecision, "failed"),
+          toolInputSummary,
+          ...optionalPolicyEventIndexes(policyEventIndexes),
+          errorDetail: toErrorDetail(error),
+        });
+        throw error;
+      }
+      if (!this.#allowedSubagentProfiles.has(delegateInput.profile)) {
+        const detail =
+          `delegate_task profile "${delegateInput.profile}" is not allowed in this run`;
+        const denial = makeObservationDenied("not-authorized", { detail });
+        await recordPolicyEvent({
+          severity: "denied",
+          mode: this.engine.getRunState().cfcEnforcementMode,
+          toolId: toolCall.function.name,
+          toolCallId: toolCall.id,
+          ...(promptSlotBinding !== undefined
+            ? { promptSlot: promptSlotBinding }
+            : {}),
+          toolInputSummary,
+          detail,
+          observationDenied: denial,
+        });
+        recordActivity({
+          type: "cf-harness.tool-activity",
+          ...baseActivity("denied", "not-run"),
+          toolInputSummary,
+          ...optionalPolicyEventIndexes(policyEventIndexes),
+        });
+        return {
+          role: "tool",
+          toolCallId: toolCall.id,
+          toolName: toolCall.function.name,
+          content: JSON.stringify(denial),
+        };
+      }
+    }
     let result: {
       output: Awaited<
         ReturnType<CfHarnessEngine["invokeBuiltinTool"]>
@@ -983,7 +1055,7 @@ export class CfHarnessPromptLoop {
       result = toolCall.function.name === "delegate_task"
         ? await this.#invokeDelegateTaskTool({
           toolCall,
-          input,
+          input: delegateInput!,
           model,
           promptSlotBinding,
           sequence,
@@ -1037,7 +1109,7 @@ export class CfHarnessPromptLoop {
 
   async #invokeDelegateTaskTool(options: {
     toolCall: HarnessToolCall;
-    input: Record<string, unknown>;
+    input: DelegateTaskToolInput;
     model: string;
     promptSlotBinding?: PromptSlotBinding;
     sequence: number;
@@ -1045,9 +1117,12 @@ export class CfHarnessPromptLoop {
     output: DelegateTaskToolOutput;
     resultRef: ToolResultRef;
   }> {
-    const delegateInput = parseDelegateTaskInput(options.input);
+    const delegateInput = options.input;
+    const profileConfig = getHarnessSubagentProfileConfig(
+      delegateInput.profile,
+    );
     const maxModelTurns = delegateInput.maxModelTurns ??
-      DEFAULT_SUBAGENT_MAX_MODEL_TURNS;
+      profileConfig.maxModelTurns;
     const parentRunState = this.engine.getRunState();
     const subagentSequence = nextSubagentSequence(parentRunState);
     const childRunId = `${parentRunState.runId}.subagent.${subagentSequence}`;
@@ -1068,12 +1143,13 @@ export class CfHarnessPromptLoop {
       parentRunId: parentRunState.runId,
       parentToolCallId: options.toolCall.id,
       childRunId,
-      profile: DEFAULT_SUBAGENT_PROFILE,
+      profile: delegateInput.profile,
       depth: 1,
       cfcEnforcementMode: parentRunState.cfcEnforcementMode,
       model: options.model,
-      allowedToolIds: [...DEFAULT_SUBAGENT_ALLOWED_TOOL_IDS],
+      allowedToolIds: [...profileConfig.allowedToolIds],
       maxModelTurns,
+      returnPolicy: profileConfig.returnPolicy,
       createdAt: childCreatedState.createdAt,
       inputSummary: await createSubagentInputSummary(delegateInput),
     };
@@ -1081,7 +1157,8 @@ export class CfHarnessPromptLoop {
       engine: childEngine,
       gatewayClient: this.gatewayClient,
       maxModelTurns,
-      allowedToolIds: DEFAULT_SUBAGENT_ALLOWED_TOOL_IDS,
+      allowedToolIds: profileConfig.allowedToolIds,
+      allowedSubagentProfiles: [],
     });
     let subagentStatus: HarnessSubagentResult["status"] = "completed";
     let summary = "";

--- a/packages/cf-harness/src/tools/delegate-task.ts
+++ b/packages/cf-harness/src/tools/delegate-task.ts
@@ -25,6 +25,12 @@ export const delegateTaskTool: HarnessToolDefinition<
           description:
             "Specific task for the child run. Include all context the child needs; it will not see the parent transcript.",
         },
+        profile: {
+          type: "string",
+          enum: ["default"],
+          description:
+            "Named subagent profile to spawn. Defaults to the harness default profile.",
+        },
         context: {
           type: "string",
           description:

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -575,6 +575,15 @@ Deno.test({
         "read_file",
         "write_file",
       ]);
+      assertEquals(subagentRun.manifest.returnPolicy, {
+        type: "cf-harness.subagent-return-policy",
+        channel: "summary-and-sanitized-state",
+        includeSummary: true,
+        includeSanitizedRunState: true,
+        includeManifest: true,
+        includeTranscript: false,
+        includeRawFailureRecords: false,
+      });
       assertEquals(
         subagentRun.manifest.inputSummary.goalDigest.startsWith("sha256:"),
         true,

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -56,6 +56,7 @@ Deno.test("parseCfHarnessCliArgs resolves defaults from cwd and positional promp
   assertEquals(parsed.outputMode, "operator");
   assertEquals(parsed.streamEvents, false);
   assertEquals(parsed.promptSlotRole, "direct-command");
+  assertEquals(parsed.allowedSubagentProfiles, ["default"]);
   assertEquals(parsed.artifactRoot, "/tmp/project/.cf-harness-artifacts");
   assertEquals(parsed.maxModelTurns, 8);
   assertEquals(parsed.printTranscript, false);
@@ -203,7 +204,46 @@ Deno.test("parseCfHarnessCliArgs supports allowed tools and result json path", a
     throw new Error("expected config result");
   }
   assertEquals(parsed.allowedToolIds, ["read_file", "bash"]);
+  assertEquals(parsed.allowedSubagentProfiles, []);
   assertEquals(parsed.resultJsonPath, "/tmp/project/results/output.json");
+});
+
+Deno.test("parseCfHarnessCliArgs supports explicit subagent profile authorization", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--prompt",
+      "hi",
+      "--allow-tool",
+      "delegate_task",
+      "--allow-subagent-profile",
+      "default",
+    ],
+    {
+      cwd: "/tmp/project",
+      env: {},
+    },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.allowedToolIds, ["delegate_task"]);
+  assertEquals(parsed.allowedSubagentProfiles, ["default"]);
+});
+
+Deno.test("parseCfHarnessCliArgs rejects unknown subagent profiles", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        ["--prompt", "hi", "--allow-subagent-profile", "browser"],
+        {
+          cwd: "/tmp/project",
+          env: {},
+        },
+      ),
+    Error,
+    "allowed subagent profiles must be one or more of default",
+  );
 });
 
 Deno.test("parseCfHarnessCliArgs resolves focus-root relative to workspace", async () => {
@@ -535,6 +575,7 @@ Deno.test("runCfHarnessCli executes the prompt loop and prints result metadata",
   );
   assertEquals(createdOptions?.apiKey, "test-key");
   assertEquals(createdOptions?.apiKeySource, "CF_HARNESS_API_KEY");
+  assertEquals(createdOptions?.allowedSubagentProfiles, ["default"]);
   assertEquals(
     runPromptOptions?.systemPrompt,
     buildCfHarnessOperatorSystemPrompt({

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -231,6 +231,92 @@ Deno.test("parseCfHarnessCliArgs supports explicit subagent profile authorizatio
   assertEquals(parsed.allowedSubagentProfiles, ["default"]);
 });
 
+Deno.test("parseCfHarnessCliArgs covers tool allowlist and subagent profile permutations", async () => {
+  const cases = [
+    {
+      name: "implicit default profile when parent tools are unrestricted",
+      flags: [],
+      allowedToolIds: undefined,
+      allowedSubagentProfiles: ["default"],
+    },
+    {
+      name: "explicit default profile when parent tools are unrestricted",
+      flags: ["--allow-subagent-profile", "default"],
+      allowedToolIds: undefined,
+      allowedSubagentProfiles: ["default"],
+    },
+    {
+      name: "delegate_task alone does not imply child profile authority",
+      flags: ["--allow-tool", "delegate_task"],
+      allowedToolIds: ["delegate_task"],
+      allowedSubagentProfiles: [],
+    },
+    {
+      name: "delegate_task with explicit default profile authority",
+      flags: [
+        "--allow-tool",
+        "delegate_task",
+        "--allow-subagent-profile",
+        "default",
+      ],
+      allowedToolIds: ["delegate_task"],
+      allowedSubagentProfiles: ["default"],
+    },
+    {
+      name: "non-delegate parent tools can still preauthorize a profile",
+      flags: [
+        "--allow-tool",
+        "read_file",
+        "--allow-tool",
+        "bash",
+        "--allow-subagent-profile",
+        "default",
+      ],
+      allowedToolIds: ["read_file", "bash"],
+      allowedSubagentProfiles: ["default"],
+    },
+    {
+      name: "duplicate tool and profile flags are normalized",
+      flags: [
+        "--allow-tool",
+        "delegate_task",
+        "--allow-tool",
+        "delegate_task",
+        "--allow-subagent-profile",
+        "default",
+        "--allow-subagent-profile",
+        "default",
+      ],
+      allowedToolIds: ["delegate_task"],
+      allowedSubagentProfiles: ["default"],
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    const parsed = await parseCfHarnessCliArgs(
+      ["--prompt", "hi", ...testCase.flags],
+      {
+        cwd: "/tmp/project",
+        env: {},
+      },
+    );
+
+    if ("help" in parsed) {
+      throw new Error(`expected config result for ${testCase.name}`);
+    }
+    assertEquals(
+      parsed.allowedToolIds,
+      testCase.allowedToolIds,
+      testCase.name,
+    );
+    assertEquals(
+      parsed.allowedSubagentProfiles,
+      testCase.allowedSubagentProfiles,
+      testCase.name,
+    );
+  }
+});
+
 Deno.test("parseCfHarnessCliArgs rejects unknown subagent profiles", async () => {
   await assertRejects(
     () =>
@@ -243,6 +329,28 @@ Deno.test("parseCfHarnessCliArgs rejects unknown subagent profiles", async () =>
       ),
     Error,
     "allowed subagent profiles must be one or more of default",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs rejects unknown allowed tools before resolving profiles", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--prompt",
+          "hi",
+          "--allow-tool",
+          "agent-browser",
+          "--allow-subagent-profile",
+          "default",
+        ],
+        {
+          cwd: "/tmp/project",
+          env: {},
+        },
+      ),
+    Error,
+    "allowed tools must be one or more of bash, read_file, write_file, delegate_task",
   );
 });
 
@@ -625,6 +733,94 @@ Deno.test("runCfHarnessCli executes the prompt loop and prints result metadata",
     ],
   );
   assertEquals(stderr, []);
+});
+
+Deno.test("runCfHarnessCli passes tool and subagent profile allowlists", async () => {
+  const cases = [
+    {
+      name: "delegate_task without profile authorization",
+      flags: ["--allow-tool", "delegate_task"],
+      allowedToolIds: ["delegate_task"],
+      allowedSubagentProfiles: [],
+    },
+    {
+      name: "delegate_task with explicit profile authorization",
+      flags: [
+        "--allow-tool",
+        "delegate_task",
+        "--allow-subagent-profile",
+        "default",
+      ],
+      allowedToolIds: ["delegate_task"],
+      allowedSubagentProfiles: ["default"],
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    const { io, stdout, stderr } = createIoBuffers();
+    let createdOptions: Record<string, unknown> | undefined;
+    const exitCode = await runCfHarnessCli(
+      [
+        "--workspace",
+        "/tmp/project",
+        "--prompt",
+        `Delegate through ${testCase.name}.`,
+        "--gateway-auth-mode",
+        "none",
+        ...testCase.flags,
+      ],
+      {
+        io,
+        env: {},
+        createPromptLoop: (options) => {
+          createdOptions = options as Record<string, unknown>;
+          return {
+            runPrompt: () =>
+              Promise.resolve(
+                {
+                  model: "gpt-5.4",
+                  finalAssistantText: "Delegation configured.",
+                  transcript: [
+                    {
+                      role: "user",
+                      content: `Delegate through ${testCase.name}.`,
+                    },
+                    { role: "assistant", content: "Delegation configured." },
+                  ],
+                  modelTurns: 1,
+                  runState: {
+                    runId: "run-cli-profile-allowlist",
+                    status: "completed",
+                    createdAt: "2026-04-28T23:35:00.000Z",
+                    updatedAt: "2026-04-28T23:35:01.000Z",
+                    cfcEnforcementMode: "disabled",
+                    currentDir: "/workspace",
+                    policyEvents: [],
+                    toolOutputs: [],
+                  },
+                } satisfies HarnessPromptLoopResult,
+              ),
+            runTranscript: () =>
+              Promise.reject(new Error("unexpected resume path")),
+          };
+        },
+      },
+    );
+
+    assertEquals(exitCode, 0, testCase.name);
+    assertEquals(
+      createdOptions?.allowedToolIds,
+      testCase.allowedToolIds,
+      testCase.name,
+    );
+    assertEquals(
+      createdOptions?.allowedSubagentProfiles,
+      testCase.allowedSubagentProfiles,
+      testCase.name,
+    );
+    assertEquals(stdout.length, 1, testCase.name);
+    assertEquals(stderr, [], testCase.name);
+  }
 });
 
 Deno.test("runCfHarnessCli can override the prompt-slot role for testing", async () => {
@@ -1214,6 +1410,7 @@ Deno.test("runCfHarnessCli allows no-auth gateway mode without an API key", asyn
 
 Deno.test("runCfHarnessCli can resume from persisted run artifacts", async () => {
   const { io, stdout, stderr } = createIoBuffers();
+  let createdOptions: Record<string, unknown> | undefined;
   let runTranscriptOptions: RunHarnessTranscriptOptions | undefined;
   const promptSlotBinding = {
     type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
@@ -1225,7 +1422,14 @@ Deno.test("runCfHarnessCli can resume from persisted run artifacts", async () =>
     eventId: "event-original",
   } as const;
   const exitCode = await runCfHarnessCli(
-    ["--resume-run", "/tmp/project/.cf-harness-artifacts/run-1/run-state.json"],
+    [
+      "--resume-run",
+      "/tmp/project/.cf-harness-artifacts/run-1/run-state.json",
+      "--allow-tool",
+      "delegate_task",
+      "--allow-subagent-profile",
+      "default",
+    ],
     {
       io,
       env: { CF_HARNESS_API_KEY: "test-key" },
@@ -1260,42 +1464,47 @@ Deno.test("runCfHarnessCli can resume from persisted run artifacts", async () =>
           ],
         });
       },
-      createPromptLoop: () => ({
-        runPrompt: () => Promise.reject(new Error("unexpected prompt path")),
-        runTranscript: (options) => {
-          runTranscriptOptions = options;
-          const { transcript, model } = options;
-          return Promise.resolve(
-            ({
-              model: model ?? "gpt-5.4",
-              finalAssistantText: "Resumed.",
-              transcript: [
-                ...transcript,
-                { role: "assistant", content: "Resumed." },
-              ],
-              modelTurns: 1,
-              runState: {
-                runId: "run-1",
-                status: "completed",
-                createdAt: "2026-04-15T22:10:00.000Z",
-                updatedAt: "2026-04-15T22:10:02.000Z",
-                cfcEnforcementMode: "disabled",
-                currentDir: "/workspace",
-                model: "gpt-5.4",
-                artifactRoot: "/tmp/project/.cf-harness-artifacts/run-1",
-                transcriptPath:
-                  "/tmp/project/.cf-harness-artifacts/run-1/transcript.json",
-                policyEvents: [],
-                toolOutputs: [],
-              },
-            }) satisfies HarnessPromptLoopResult,
-          );
-        },
-      }),
+      createPromptLoop: (options) => {
+        createdOptions = options as Record<string, unknown>;
+        return {
+          runPrompt: () => Promise.reject(new Error("unexpected prompt path")),
+          runTranscript: (options) => {
+            runTranscriptOptions = options;
+            const { transcript, model } = options;
+            return Promise.resolve(
+              ({
+                model: model ?? "gpt-5.4",
+                finalAssistantText: "Resumed.",
+                transcript: [
+                  ...transcript,
+                  { role: "assistant", content: "Resumed." },
+                ],
+                modelTurns: 1,
+                runState: {
+                  runId: "run-1",
+                  status: "completed",
+                  createdAt: "2026-04-15T22:10:00.000Z",
+                  updatedAt: "2026-04-15T22:10:02.000Z",
+                  cfcEnforcementMode: "disabled",
+                  currentDir: "/workspace",
+                  model: "gpt-5.4",
+                  artifactRoot: "/tmp/project/.cf-harness-artifacts/run-1",
+                  transcriptPath:
+                    "/tmp/project/.cf-harness-artifacts/run-1/transcript.json",
+                  policyEvents: [],
+                  toolOutputs: [],
+                },
+              }) satisfies HarnessPromptLoopResult,
+            );
+          },
+        };
+      },
     },
   );
 
   assertEquals(exitCode, 0);
+  assertEquals(createdOptions?.allowedToolIds, ["delegate_task"]);
+  assertEquals(createdOptions?.allowedSubagentProfiles, ["default"]);
   assertEquals(runTranscriptOptions?.promptSlotBinding, promptSlotBinding);
   assertEquals(stdout, [
     formatCfHarnessCliResult({

--- a/packages/cf-harness/test/diagnostics.test.ts
+++ b/packages/cf-harness/test/diagnostics.test.ts
@@ -255,6 +255,15 @@ Deno.test("classifyBuiltinToolFailure handles delegate_task outputs defensively"
             model: "gpt-5.4",
             allowedToolIds: ["bash", "read_file", "write_file"],
             maxModelTurns: 8,
+            returnPolicy: {
+              type: "cf-harness.subagent-return-policy",
+              channel: "summary-and-sanitized-state",
+              includeSummary: true,
+              includeSanitizedRunState: true,
+              includeManifest: true,
+              includeTranscript: false,
+              includeRawFailureRecords: false,
+            },
             createdAt: "2026-04-23T18:30:00.000Z",
             inputSummary: {
               type: "cf-harness.subagent-input-summary",

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -517,6 +517,7 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
         parentRunId: string;
         parentToolCallId: string;
         allowedToolIds: string[];
+        returnPolicy: Record<string, unknown>;
         inputSummary: {
           goalBytes: number;
           goalDigest: string;
@@ -549,6 +550,15 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
     "read_file",
     "write_file",
   ]);
+  assertEquals(output.subagent.manifest.returnPolicy, {
+    type: "cf-harness.subagent-return-policy",
+    channel: "summary-and-sanitized-state",
+    includeSummary: true,
+    includeSanitizedRunState: true,
+    includeManifest: true,
+    includeTranscript: false,
+    includeRawFailureRecords: false,
+  });
   assertEquals(output.subagent.manifest.inputSummary.goalBytes, 22);
   assertEquals(output.subagent.manifest.inputSummary.contextBytes, 21);
   assertEquals(
@@ -568,6 +578,114 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
     result.runState.subagentRuns?.[0]?.summary,
     "Child inspected the file and found no issues.",
   );
+});
+
+Deno.test("CfHarnessPromptLoop lets an explicit subagent profile expand child tools", async () => {
+  const requestBodies: Array<{
+    messages: Array<{ role: string; content: string }>;
+    tools: Array<{ function: { name: string } }>;
+  }> = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    allowedToolIds: ["delegate_task"],
+    allowedSubagentProfiles: ["default"],
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-delegate-explicit-profile",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        messages: Array<{ role: string; content: string }>;
+        tools: Array<{ function: { name: string } }>;
+      };
+      requestBodies.push(body);
+      const payload = requestBodies.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-explicit-profile",
+                type: "function",
+                function: {
+                  name: "delegate_task",
+                  arguments: JSON.stringify({
+                    goal: "Inspect with explicit profile.",
+                    profile: "default",
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : requestBodies.length === 2
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Explicit-profile child completed.",
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Explicit-profile parent completed.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Delegate through the explicitly authorized profile.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+  const toolMessage = result.transcript.at(-2);
+  if (toolMessage?.role !== "tool") {
+    throw new Error("expected delegate_task tool message");
+  }
+  const output = JSON.parse(toolMessage.content) as {
+    subagent: {
+      childRunId: string;
+      status: string;
+      manifest: {
+        profile: string;
+        allowedToolIds: string[];
+      };
+    };
+  };
+
+  assertEquals(result.finalAssistantText, "Explicit-profile parent completed.");
+  assertEquals(
+    requestBodies[0].tools.map((tool) => tool.function.name),
+    ["delegate_task"],
+  );
+  assertEquals(
+    requestBodies[1].tools.map((tool) => tool.function.name),
+    ["bash", "read_file", "write_file"],
+  );
+  assertEquals(
+    output.subagent.childRunId,
+    "run-delegate-explicit-profile.subagent.1",
+  );
+  assertEquals(output.subagent.status, "completed");
+  assertEquals(output.subagent.manifest.profile, "default");
+  assertEquals(output.subagent.manifest.allowedToolIds, [
+    "bash",
+    "read_file",
+    "write_file",
+  ]);
 });
 
 Deno.test("CfHarnessPromptLoop rejects invalid delegate_task inputs before creating a child run", async () => {
@@ -591,6 +709,11 @@ Deno.test("CfHarnessPromptLoop rejects invalid delegate_task inputs before creat
       name: "too many turns",
       arguments: { goal: "Inspect", maxModelTurns: 17 },
       message: "delegate_task maxModelTurns must be an integer from 1 to 16",
+    },
+    {
+      name: "unknown profile",
+      arguments: { goal: "Inspect", profile: "browser" },
+      message: "delegate_task profile must be one of default",
     },
   ];
 
@@ -798,6 +921,15 @@ Deno.test("CfHarnessPromptLoop continues subagent ids from retained run state", 
       model: "gpt-5.4",
       allowedToolIds: ["bash", "read_file", "write_file"],
       maxModelTurns: 8,
+      returnPolicy: {
+        type: "cf-harness.subagent-return-policy",
+        channel: "summary-and-sanitized-state",
+        includeSummary: true,
+        includeSanitizedRunState: true,
+        includeManifest: true,
+        includeTranscript: false,
+        includeRawFailureRecords: false,
+      },
       createdAt: "2026-04-18T00:00:01.000Z",
       inputSummary: {
         type: "cf-harness.subagent-input-summary",
@@ -1103,6 +1235,7 @@ Deno.test("CfHarnessPromptLoop denies delegate_task without direct-command autho
     toolInputSummary: {
       type: "cf-harness.tool-input-summary",
       toolId: "delegate_task",
+      profile: "default",
       goalBytes: 34,
       goalDigest:
         "sha256:208d4a765f67911d464e8dd007c46edbac572beb839807a76ad7215b057e38cf",
@@ -1121,6 +1254,106 @@ Deno.test("CfHarnessPromptLoop denies delegate_task without direct-command autho
     JSON.stringify(result.runState.policyEvents[0]?.toolInputSummary)
       .includes("Inspect private delegated context."),
     false,
+  );
+  assertEquals(result.runState.primaryFailure?.kind, "tool_not_allowed");
+});
+
+Deno.test("CfHarnessPromptLoop denies delegate_task when the profile is not authorized", async () => {
+  const requestBodies: Array<{
+    messages: Array<{ role: string; content: string }>;
+    tools: Array<{ function: { name: string } }>;
+  }> = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    allowedToolIds: ["delegate_task"],
+    allowedSubagentProfiles: [],
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-delegate-profile-denied",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        messages: Array<{ role: string; content: string }>;
+        tools: Array<{ function: { name: string } }>;
+      };
+      requestBodies.push(body);
+      const payload = requestBodies.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-delegate-profile-denied",
+                type: "function",
+                function: {
+                  name: "delegate_task",
+                  arguments: JSON.stringify({
+                    goal: "Inspect private delegated context.",
+                    profile: "default",
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Profile denial observed.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Try a default-profile delegation.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+  const toolMessage = result.transcript.at(-2);
+  if (toolMessage?.role !== "tool") {
+    throw new Error("expected delegate_task tool message");
+  }
+  const denied = JSON.parse(toolMessage.content) as {
+    type: string;
+    reason: string;
+    detail: string;
+  };
+
+  assertEquals(result.finalAssistantText, "Profile denial observed.");
+  assertEquals(
+    requestBodies[0].tools.map((tool) => tool.function.name),
+    ["delegate_task"],
+  );
+  assertEquals(denied.type, "cf-harness.observation-denied");
+  assertEquals(denied.reason, "not-authorized");
+  assertEquals(
+    denied.detail,
+    'delegate_task profile "default" is not allowed in this run',
+  );
+  assertEquals(result.runState.subagentRuns, undefined);
+  assertEquals(result.runState.toolOutputs, []);
+  assertEquals(result.runState.policyEvents.length, 1);
+  assertEquals(result.runState.policyEvents[0]?.toolInputSummary, {
+    type: "cf-harness.tool-input-summary",
+    toolId: "delegate_task",
+    profile: "default",
+    goalBytes: 34,
+    goalDigest:
+      "sha256:208d4a765f67911d464e8dd007c46edbac572beb839807a76ad7215b057e38cf",
+  });
+  assertEquals(
+    result.runState.policyEvents[0]?.detail,
+    'delegate_task profile "default" is not allowed in this run',
   );
   assertEquals(result.runState.primaryFailure?.kind, "tool_not_allowed");
 });


### PR DESCRIPTION
## Summary
- add an explicit default subagent profile config and named summary/sanitized-state return policy
- add delegate_task profile input plus separate allowedSubagentProfiles authorization
- add CLI --allow-subagent-profile default for restricted parent tool allowlists
- document the explicit delegation transition and add positive/negative profile tests

## Verification
- deno fmt --check packages/cf-harness/src packages/cf-harness/test packages/cf-harness/README.md packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
- deno check packages/cf-harness/src/main.ts
- deno test --allow-read --allow-write --allow-run packages/cf-harness/test/prompt-loop.test.ts packages/cf-harness/test/artifacts.test.ts packages/cf-harness/test/cli.test.ts packages/cf-harness/test/diagnostics.test.ts packages/cf-harness/test/tools-registry.test.ts
- cd packages/cf-harness && deno task check
- cd packages/cf-harness && deno task test