### PR TITLE
Encode memory v2 wire payloads via the proper boundary helper in runner tests

### DIFF
--- a/packages/runner/test/memory-v2-reconnect-race.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-race.test.ts
@@ -1,7 +1,12 @@
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import type { MIME, URI } from "@commonfabric/memory/interface";
-import { type EntityDocument, getMemoryV2Flags } from "@commonfabric/memory/v2";
+import {
+  decodeMemoryV2Boundary,
+  encodeMemoryV2Boundary,
+  type EntityDocument,
+  getMemoryV2Flags,
+} from "@commonfabric/memory/v2";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { StorageManager as CutoverStorageManager } from "../src/storage/cache.deno.ts";
@@ -64,7 +69,7 @@ class SabotagedReconnectTransport implements MemoryV2Client.Transport {
   }
 
   async send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type?: string;
       commit?: { localSeq?: number };
     };
@@ -107,7 +112,7 @@ class SabotagedReconnectTransport implements MemoryV2Client.Transport {
       this.connectionCount++;
       this.#connection = this.server.connect((message) => {
         if (!this.#dropResponses) {
-          this.#receiver(JSON.stringify(message));
+          this.#receiver(encodeMemoryV2Boundary(message));
         }
       });
     }
@@ -128,7 +133,7 @@ class RejectThenSucceedTransport implements MemoryV2Client.Transport {
   }
 
   async send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type: string;
       requestId?: string;
       commit?: { localSeq?: number };
@@ -216,7 +221,7 @@ class RejectThenSucceedTransport implements MemoryV2Client.Transport {
   }
 
   #respond(message: unknown): void {
-    this.#receiver(JSON.stringify(message));
+    this.#receiver(encodeMemoryV2Boundary(message));
   }
 }
 

--- a/packages/runner/test/memory-v2-watch-refresh-race.test.ts
+++ b/packages/runner/test/memory-v2-watch-refresh-race.test.ts
@@ -4,6 +4,8 @@ import { Identity } from "@commonfabric/identity";
 import type { URI } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import {
+  decodeMemoryV2Boundary,
+  encodeMemoryV2Boundary,
   type EntityDocument,
   getMemoryV2Flags,
   type SessionSync,
@@ -47,7 +49,7 @@ class CountingWatchSetTransport implements MemoryV2Client.Transport {
   }
 
   send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type: string;
       requestId?: string;
       watches?: Array<{
@@ -118,7 +120,7 @@ class CountingWatchSetTransport implements MemoryV2Client.Transport {
   }
 
   #respond(message: unknown): void {
-    this.#receiver(JSON.stringify(message));
+    this.#receiver(encodeMemoryV2Boundary(message));
   }
 }
 
@@ -141,7 +143,7 @@ class DelayedWatchAddTransport implements MemoryV2Client.Transport {
   }
 
   send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type: string;
       requestId?: string;
       watches?: Array<{
@@ -221,7 +223,7 @@ class DelayedWatchAddTransport implements MemoryV2Client.Transport {
   }
 
   #respond(message: unknown): void {
-    this.#receiver(JSON.stringify(message));
+    this.#receiver(encodeMemoryV2Boundary(message));
   }
 }
 
@@ -244,7 +246,7 @@ class IncrementalEffectTransport implements MemoryV2Client.Transport {
   }
 
   send(payload: string): Promise<void> {
-    const message = JSON.parse(payload) as {
+    const message = decodeMemoryV2Boundary(payload) as {
       type: string;
       requestId?: string;
       watches?: Array<{
@@ -313,7 +315,7 @@ class IncrementalEffectTransport implements MemoryV2Client.Transport {
   }
 
   #respond(message: unknown): void {
-    this.#receiver(JSON.stringify(message));
+    this.#receiver(encodeMemoryV2Boundary(message));
   }
 }
 


### PR DESCRIPTION
## Summary

Continues the cascade started in #3414 / #3417, now in `packages/runner/test/`. The test transports in `memory-v2-reconnect-race.test.ts` and `memory-v2-watch-refresh-race.test.ts` were framing wire payloads with `JSON.parse(payload)` on send and `JSON.stringify(message)` on respond. Switches both sides to `decodeMemoryV2Boundary` / `encodeMemoryV2Boundary` so the runner test transports stay aligned with how the production wire format is actually framed.

The 3 `JSON.stringify(change.after) === JSON.stringify({...})` sites in `memory-v2-reconnect-race.test.ts` are intentionally left alone — they compare reactive change values, not wire payloads.

## Why

Behaviorally a no-op on `main` today: with the unified-JSON-encoding flag off, `encodeMemoryV2Boundary` reduces to `JSON.stringify` and `decodeMemoryV2Boundary` reduces to `JSON.parse`. The change just removes a hidden landmine for the in-flight encoding work — discovered by running the prefix branch's full suite, where these were the only remaining wire-framing chokepoints in the runner package after #3417.

## Test plan

- [x] `deno task test` in `packages/runner` — 400 passed, 0 failed (no regression on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
