### PR TITLE
feat(ui): add autofocus and cursorPosition to cf-code-editor (CT-1506)

### DIFF
--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -3968,6 +3968,8 @@ interface CFCodeEditorAttributes<T> extends CFHTMLAttributes<T> {
   "tabIndent"?: boolean;
   "theme"?: "light" | "dark";
   "mode"?: "code" | "prose";
+  "autofocus"?: boolean;
+  "cursorPosition"?: "start" | "end";
   "oncf-change"?: any;
   "oncf-focus"?: any;
   "oncf-blur"?: any;

--- a/packages/patterns/catalog/stories/cf-code-editor-story.tsx
+++ b/packages/patterns/catalog/stories/cf-code-editor-story.tsx
@@ -39,6 +39,8 @@ export default pattern<CodeEditorStoryInput, CodeEditorStoryOutput>(() => {
   const tabIndent = Writable.of(true);
   const theme = Writable.of<"light" | "dark">("light");
   const mode = Writable.of<"code" | "prose">("prose");
+  const autofocus = Writable.of(false);
+  const cursorPosition = Writable.of<"start" | "end">("start");
   const pattern = Writable.of("catalog");
   const mentionableData = [
     { [NAME]: "Design System" },
@@ -92,6 +94,8 @@ export default pattern<CodeEditorStoryInput, CodeEditorStoryOutput>(() => {
             tabIndent={tabIndent}
             theme={theme}
             mode={mode}
+            autofocus={autofocus}
+            cursorPosition={cursorPosition}
             style="height: 100%;"
           />
         </div>
@@ -251,6 +255,22 @@ export default pattern<CodeEditorStoryInput, CodeEditorStoryOutput>(() => {
             description="Indent using Tab key"
             defaultValue="true"
             checked={tabIndent}
+          />
+          <SwitchControl
+            label="autofocus"
+            description="Auto-focus editor on mount"
+            defaultValue="false"
+            checked={autofocus}
+          />
+          <SelectControl
+            label="cursorPosition"
+            description="Initial cursor position"
+            defaultValue="start"
+            value={cursorPosition}
+            items={[
+              { label: "Start", value: "start" },
+              { label: "End", value: "end" },
+            ]}
           />
         </>
       </Controls>

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
@@ -17,6 +17,8 @@ describe("CFCodeEditor", () => {
     expect(element.placeholder).toBe("");
     expect(element.timingStrategy).toBe("debounce");
     expect(element.timingDelay).toBe(500);
+    expect(element.autofocus).toBe(false);
+    expect(element.cursorPosition).toBe("start");
   });
 
   it("should have MimeType constants", () => {
@@ -42,5 +44,14 @@ describe("CFCodeEditor", () => {
     expect(element.readonly).toBe(true);
     expect(element.timingStrategy).toBe("immediate");
     expect(element.timingDelay).toBe(100);
+  });
+
+  it("should allow setting autofocus and cursorPosition", () => {
+    const element = new CFCodeEditor();
+    element.autofocus = true;
+    element.cursorPosition = "end";
+
+    expect(element.autofocus).toBe(true);
+    expect(element.cursorPosition).toBe("end");
   });
 });

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -129,6 +129,8 @@ const getLangExtFromMimeType = (mime: MimeType) => {
  * @attr {boolean} disabled - Whether the editor is disabled
  * @attr {boolean} readonly - Whether the editor is read-only
  * @attr {string} placeholder - Placeholder text when empty
+ * @attr {boolean} autofocus - Auto-focus the editor after initialization (default: false)
+ * @attr {"start"|"end"} cursorPosition - Initial cursor position (default: "start")
  * @attr {string} timingStrategy - Input timing strategy: "immediate" | "debounce" | "throttle" | "blur"
  * @attr {number} timingDelay - Delay in milliseconds for debounce/throttle (default: 500)
  * @attr {CellHandle<MentionableArray>} mentionable - Cell of mentionable items for @/@[[ completion
@@ -188,6 +190,8 @@ export class CFCodeEditor extends BaseElement {
     tabIndent: { type: Boolean },
     theme: { type: String, reflect: true },
     mode: { type: String, reflect: true },
+    autofocus: { type: Boolean },
+    cursorPosition: { type: String },
   };
 
   declare value: CellHandle<string> | string;
@@ -210,6 +214,8 @@ export class CFCodeEditor extends BaseElement {
   declare tabIndent: boolean;
   declare theme: "light" | "dark";
   declare mode: "code" | "prose";
+  declare autofocus: boolean;
+  declare cursorPosition: "start" | "end";
 
   private _editorView: EditorView | undefined;
   private _lang = new Compartment();
@@ -275,6 +281,8 @@ export class CFCodeEditor extends BaseElement {
     this.tabIndent = true;
     this.theme = "light";
     this.mode = "code";
+    this.autofocus = false;
+    this.cursorPosition = "start";
     this.mentionable = null;
   }
 
@@ -1069,6 +1077,10 @@ export class CFCodeEditor extends BaseElement {
 
     // Set up subscriptions for bidirectional NAME sync
     this._setupPieceNameSubscriptions();
+
+    if (this.autofocus) {
+      this._editorView?.focus();
+    }
   }
 
   /**
@@ -1323,9 +1335,11 @@ export class CFCodeEditor extends BaseElement {
     }
 
     // Create editor state
+    const doc = this.getValue() ?? "";
     const state = EditorState.create({
-      doc: this.getValue() ?? "",
+      doc,
       extensions,
+      selection: { anchor: this.cursorPosition === "end" ? doc.length : 0 },
     });
 
     // Create editor view


### PR DESCRIPTION
## Summary

- Add `autofocus` (boolean) property to auto-focus the editor after initialization
- Add `cursorPosition` (`"start" | "end"`) property to control initial cursor placement via EditorState selection
- Update JSX type definitions, unit tests, and catalog story

## Test plan

- [x] Unit tests pass (`deno test` in `packages/ui/`)
- [ ] Manual: open cf-code-editor story, toggle autofocus and cursorPosition controls
- [ ] Manual: `<cf-code-editor autofocus cursorPosition="end" value="hello">` focuses with cursor at end

Linear-issue: CT-1506

🤖 Generated with [Claude Code](https://claude.com/claude-code)