### PR TITLE
refactor(cli): swap raw JSON.stringify for {Compact,Indented}DebugString in non-test DEBUG+DISPLAY sites

### DIFF
--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema } from "@commonfabric/api";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { cliCommand } from "./cli-name.ts";
 
 export interface ExecCommandSpec {
@@ -607,14 +608,13 @@ function schemaDescription(schema: JSONSchema): string | undefined {
 
 function schemaEnumSummary(schema: JSONSchema): string | undefined {
   if (!isSchemaObject(schema) || !Array.isArray(schema.enum)) return undefined;
-  return (schema.enum as unknown[]).map((value) => JSON.stringify(value)).join(
-    " | ",
-  );
+  return (schema.enum as unknown[]).map((value) => toCompactDebugString(value))
+    .join(" | ");
 }
 
 function schemaDefaultSummary(schema: JSONSchema): string | undefined {
   if (!isSchemaObject(schema) || !("default" in schema)) return undefined;
-  return JSON.stringify(schema.default);
+  return toCompactDebugString(schema.default);
 }
 
 function valuePlaceholder(schema: JSONSchema): string {
@@ -1028,7 +1028,7 @@ function schemaShapeString(
   }
 
   if (Array.isArray(schema.enum)) {
-    return schema.enum.map((value) => JSON.stringify(value)).join(" | ");
+    return schema.enum.map((value) => toCompactDebugString(value)).join(" | ");
   }
 
   const unionSchemas = Array.isArray(schema.anyOf)

--- a/packages/cli/lib/render.ts
+++ b/packages/cli/lib/render.ts
@@ -1,5 +1,4 @@
 import { encode } from "@commonfabric/utils/encoding";
-import { toIndentedDebugString } from "@commonfabric/data-model/value-debug";
 
 function stringify(value: unknown): string {
   switch (typeof value) {
@@ -13,7 +12,7 @@ function stringify(value: unknown): string {
         throw new Error("Binary data could not be stringified");
       }
       try {
-        return toIndentedDebugString(value);
+        return JSON.stringify(value, null, 2);
         // deno-lint-ignore no-empty
       } catch (_) {}
       return value.toString();

--- a/packages/cli/lib/render.ts
+++ b/packages/cli/lib/render.ts
@@ -1,4 +1,5 @@
 import { encode } from "@commonfabric/utils/encoding";
+import { toIndentedDebugString } from "@commonfabric/data-model/value-debug";
 
 function stringify(value: unknown): string {
   switch (typeof value) {
@@ -12,7 +13,7 @@ function stringify(value: unknown): string {
         throw new Error("Binary data could not be stringified");
       }
       try {
-        return JSON.stringify(value, null, 2);
+        return toIndentedDebugString(value);
         // deno-lint-ignore no-empty
       } catch (_) {}
       return value.toString();

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -38,6 +38,7 @@ import type {
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { OpaqueRef } from "@commonfabric/api";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { basename } from "@std/path";
 import { timeout } from "@commonfabric/utils/sleep";
@@ -971,7 +972,7 @@ export async function runTestPattern(
     if (!Array.isArray(testSteps)) {
       throw new Error(
         "Test pattern must return { tests: TestStep[] }. Got: " +
-          JSON.stringify(typeof testSteps),
+          toCompactDebugString(typeof testSteps),
       );
     }
 
@@ -1083,7 +1084,7 @@ export async function runTestPattern(
       if (!isAction && !isAssertion) {
         throw new Error(
           `Test step at index ${i} must have either 'action' or 'assertion' key. Got: ${
-            JSON.stringify(Object.keys(stepValue))
+            toCompactDebugString(Object.keys(stepValue))
           }`,
         );
       }
@@ -1325,7 +1326,7 @@ export async function runTestPattern(
             }
             return {
               passed: false,
-              error: `Expected true, got ${JSON.stringify(value)}`,
+              error: `Expected true, got ${toCompactDebugString(value)}`,
             };
           } catch (err) {
             return {


### PR DESCRIPTION
## Summary

Third cadence PR in the JSON.stringify → debug-stringifier migration arc for session 2026-065. Mirrors the pilot template established in PR #3411 (runner, 32 sites) and continued by PR #3416 (memory, 13 sites). Migrates **6 swap-eligible non-test sites in `packages/cli`** to use `toCompactDebugString` from `@commonfabric/data-model/value-debug`.

`packages/cli` was sandbox-clean (no synthetic `commonfabric` import), so this PR is mechanically the simplest of the three so far — it's primarily about consumer-side classification discipline, not technical migration challenges.

## Scope discipline note

The original brief estimated 11 swap-eligible sites based on per-package shape tally. Pre-edit per-site survey reclassified **3 sites as WIRE** on contract grounds (each is reachable via a `--json`-flag-documented user-facing API contract). Post-review, Dan's review reverted **1 additional site** in `render.ts`, treating the file holistically rather than migrating one of its `JSON.stringify` calls in isolation. Final scope: **6 sites migrated, 7 WIRE excluded** (3 directly per Remy's classification + 3 reclassified during survey + 1 reverted post-review). The function-name-as-contract / consumer-shape-as-stable-identity lens caught what raw shape-tally counts missed — exactly the discipline this arc was designed to apply.

## Sites migrated

### D1 — Error message text (4 sites, compact)

- `lib/exec-schema.ts:1031` — `schemaShapeString` enum branch. The recursive `schemaShapeString` function is consumed by an `Error` throw (line 932): `Handler requires input. Expected type: ${typeShape}`. D1.
- `lib/test-runner.ts:975` — `Test pattern must return { tests: TestStep[] }. Got: ${...}` Error message.
- `lib/test-runner.ts:1087` — `Test step at index ${i} must have either 'action' or 'assertion' key. Got: ${...}` Error message.
- `lib/test-runner.ts:1329` — `error: \`Expected true, got ${...}\`` assertion failure message; consumer at line 1491 is `console.log(\`  ✗ Error: ${result.error}\`)`. D1.

### DISPLAY — `--help` text, compact (2 sites)

- `lib/exec-schema.ts:611` — `schemaEnumSummary` produces `"Allowed: x | y | z."` text in `cf X --help` output.
- `lib/exec-schema.ts:618` — `schemaDefaultSummary` produces `"Default: foo."` text in `cf X --help` output.

Both are descriptive prose embedded in help text — not parser-friendly format, no documented contract that they're machine-parseable. Output is identical for typical schema enum/default values (strings, numbers, bools); behavioral delta is only for special values (bigint/Symbol/etc.) which are uncommon in JSON Schema enums but render better through the new helpers.

## Sites left in place

### Direct exclusions (3 sites — JSON output contract)

- `lib/fuse.ts:104` — `Deno.writeTextFile(path, JSON.stringify(normalized, null, 2))` writing to `.json` mountstate file. Parsed back by `readMountState` (next function). Round-trip persistence.
- `commands/init.ts:118` — `Deno.writeTextFile(join(cwd, "tsconfig.json"), JSON.stringify(createTsConfig(), null, 2))`. Parsed by tsc.
- `lib/exec-schema.ts:966` — `renderExecHelpJson` function body. Function name asserts JSON output contract.

### Reclassified during survey (3 sites — `--json`-flag documented contracts)

- `lib/callable.ts:275` — `outputText: JSON.stringify(outputValue, null, 2)` returned in `ExecutedCallable` interface. The `cf piece call --json` flag help text says `"Input/output format (JSON is the only supported format; this flag is a no-op)"` — i.e. the JSON output contract is **unconditional**, not just `--json`-gated. API-boundary WIRE.
- `lib/render.ts:79` — `safeStringify` body, the implementation of `render(value, {json: true})` mode. Reachable via `--json` flag at `commands/piece.ts:182,351,441,472,733` with help text `"Output machine-readable JSON"`. Function name (`safeStringify`) + flag-documented JSON contract = WIRE.
- `commands/dev.ts:78` — `--pattern-json` mode body. Flag help (line 153): `"Print the evaluated pattern export as JSON."` Inline comment (line 66): `"Only print JSON output when --pattern-json is used"`. Documented JSON contract.

The `<max depth reached>` and `<circular reference>` literal sentinels in `safeStringify`, and the try/catch fallback to `.toString()` in `render.ts`, are valid-JSON strings (sentinels emitted as quoted strings) or error-recovery paths — not intentional truncation/redaction. Per the lens, intentional lossy mutation disqualifies a format claim; error-recovery does not.

### Reverted post-review (1 site — file-level rework deferred)

- `lib/render.ts:16` — `stringify()` helper for the non-JSON terminal output path. Initially migrated as D4-equivalent (terminal stdout for humans), but per Dan's review: "most of the `stringify()` stuff in `render.ts` was adjudicated as 'WIRE' and i think the best call for the one remaining place is to leave it as-is for now. that whole file ought to be properly reworked as a unit, so please revert it for now." Restored to `JSON.stringify(value, null, 2)`; the file is queued for a holistic rework pass in a future session.

## Validation

```
deno fmt --check packages/cli/   →  Checked 47 files (clean)
deno lint packages/cli/          →  Checked 45 files (clean)
deno check packages/cli/lib/{render,exec-schema,test-runner}.ts  →  clean
cd packages/cli && deno task test  →  19 passed (133 steps), 0 failed, 1 ignored
```

Re-validated after the post-review revert; all checks remain clean.

## Test plan

- [x] `deno fmt --check packages/cli/` clean
- [x] `deno lint packages/cli/` clean
- [x] `deno check` on edited files clean
- [x] `deno task test` in packages/cli — 19 passed, 0 failed
- [ ] Cubic / standard CI green on the PR
- [ ] Per-site detail review by `reviewer-flux` on the cadence six-point template

## Test coverage note

No new test coverage added. The helpers themselves (`toCompactDebugString` / `toIndentedDebugString`) are exhaustively covered by `packages/data-model/test/value-debug.test.ts` (39 tests landed with PR #3409, covering all special-value rendering: bigint, Symbol, function, NaN, ±Infinity, -0, undefined). Migration is pre-state-equivalent for plain JSON-y inputs; behavioral delta is strictly improvement for special values.

## References

- Pilot PR #3411 — `packages/runner` (32 sites), squash `fcf6f0ef1`.
- Sister PR #3416 — `packages/memory` (13 sites), squash `1665099f0`.
- Helper widening PR #3409 — `value-debug.ts` `unknown` parameter type + Symbol/function/NaN/±Inf/-0 support, squash `5aeabba11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
