### PR TITLE
Add browser subagent host shell profile

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -31,13 +31,14 @@ What works today:
   - `us-docker.pkg.dev/commontools-core/common-fabric/sandbox-kitchensink:latest`
 - built-in tools:
   - `bash`
+  - `bash-no-sandbox` (provisional host shell for named subagent profiles only)
   - `read_file`
   - `write_file`
   - `delegate_task`
 - whole-file replace/create plus append writes
 - bounded OpenAI-compatible prompt/tool loop
-- single-child subagent delegation with fresh child prompt context, an explicit
-  default child profile, retained child run references, and a sanitized
+- single-child subagent delegation with fresh child prompt context, explicit
+  default/browser child profiles, retained child run references, and a sanitized
   summary/state return channel
 - persisted run state, transcript, Loom run manifests, capability snapshots, and
   tool outputs
@@ -61,8 +62,9 @@ What is not done yet:
 
 - real runner-driven CFC feedback integration
 - richer opaque-handle/pass-through behavior
-- additional subagent profiles, browser-mediated subagents, and parallel job
-  orchestration
+- first-class browser operation policy on top of the provisional browser
+  subagent profile
+- parallel child orchestration
 - app UI event provenance
 - streaming model responses
 - richer mid-turn resumability
@@ -138,6 +140,20 @@ deno task run -- \
   --allow-tool delegate_task \
   --allow-subagent-profile default \
   --prompt "Delegate a focused inspection and summarize the result."
+```
+
+The provisional browser profile is the only CLI-supported path to
+`bash-no-sandbox`. It gives the child a host shell so it can invoke
+`agent-browser`, while the parent still receives only the normal sanitized
+subagent result:
+
+```bash
+deno task run -- \
+  --workspace /path/to/workspace \
+  --gateway-auth-mode none \
+  --allow-tool delegate_task \
+  --allow-subagent-profile browser \
+  --prompt "Delegate browser inspection of the local app and summarize the result."
 ```
 
 Current caveat:

--- a/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
@@ -198,6 +198,31 @@ Why:
 - to make delegation a visible policy transition before adding higher-taint
   child capabilities such as `agent-browser`
 
+### Stage I: Browser subagent profile, provisional host shell
+
+- built-in `bash-no-sandbox` tool descriptor and implementation
+- parent/default prompt loops keep `bash-no-sandbox` unavailable unless a loop
+  is explicitly constructed with that tool
+- package CLI intentionally does not expose `bash-no-sandbox` as a parent
+  `--allow-tool`
+- named `browser` subagent profile limited to:
+  - `bash-no-sandbox`
+  - `read_file`
+  - `write_file`
+- subagent manifests record `hostToolIds` so host execution capability is
+  visible in retained provenance
+- child prompt explicitly labels host execution as outside the sandbox and
+  orients browser-profile children toward `agent-browser`
+
+Why:
+
+- to keep the intended eventual `agent-browser` usage shape: agents invoke it
+  through shell commands, not through a special-purpose harness tool
+- to put the high-taint browser capability behind an explicit delegation
+  transition before broader browser policy exists
+- to avoid silently making host execution part of the parent/default tool
+  surface
+
 ## Current Verified State
 
 At the current checkpoint, the package has:
@@ -308,12 +333,14 @@ Current resumability is transcript-based and useful, but still limited:
 
 The package now has a first minimal subagent path: a parent can delegate one
 focused child run through `delegate_task`, and the child receives a fresh prompt
-context plus the default shell/file tool set.
+context plus the selected profile's tool set. The default profile remains
+sandbox shell/file only; the provisional browser profile adds host shell access
+for `agent-browser`-style commands.
 
 The remaining subagent work is still substantial:
 
-- additional profile/policy selection beyond the single default child policy
-- browser-mediated subagents, expected to wrap `agent-browser`
+- first-class browser-mediated subagent policy on top of the provisional host
+  shell path
 - parallel child orchestration
 - richer orchestration resume for partially completed child runs
 

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -24,7 +24,10 @@ import {
   HARNESS_SUBAGENT_PROFILES,
   type HarnessSubagentProfile,
 } from "./contracts/subagent.ts";
-import type { BuiltinToolId } from "./contracts/tool-descriptor.ts";
+import {
+  type BuiltinToolId,
+  DEFAULT_PARENT_TOOL_IDS,
+} from "./contracts/tool-descriptor.ts";
 import type {
   HarnessTranscriptEvent,
   HarnessTranscriptMessage,
@@ -168,7 +171,7 @@ Options:
   --cwd <path>                  Initial working directory inside the workspace
   --focus-root <path>           Narrow exploration to a workspace subpath when possible
   --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | write_file | delegate_task)
-  --allow-subagent-profile <p>  Authorize delegate_task to spawn a profile (repeatable: default)
+  --allow-subagent-profile <p>  Authorize delegate_task to spawn a profile (repeatable: default | browser)
   --output-mode <mode>          operator | batch (default: operator)
   --stream-events               Print transcript events as they happen
   --prompt-slot-role <role>     direct-command | context | quote (default: direct-command)
@@ -210,12 +213,7 @@ const parsePositiveInteger = (
 };
 
 const PROMPT_SLOT_ROLES = ["direct-command", "context", "quote"] as const;
-const BUILTIN_TOOL_IDS = [
-  "bash",
-  "read_file",
-  "write_file",
-  "delegate_task",
-] as const;
+const CLI_PARENT_TOOL_IDS = DEFAULT_PARENT_TOOL_IDS;
 
 const parsePromptSlotRole = (
   input: string | undefined,
@@ -236,7 +234,7 @@ const parseCliOutputMode = (
 const parseBuiltinToolId = (
   input: string,
 ): BuiltinToolId | undefined =>
-  (BUILTIN_TOOL_IDS as readonly string[]).includes(input)
+  (CLI_PARENT_TOOL_IDS as readonly string[]).includes(input)
     ? input as BuiltinToolId
     : undefined;
 
@@ -253,7 +251,7 @@ const parseBuiltinToolIds = (
   const parsed = values.map((value) => parseBuiltinToolId(value));
   if (parsed.some((value) => value === undefined)) {
     throw new Error(
-      "allowed tools must be one or more of bash, read_file, write_file, delegate_task",
+      `allowed tools must be one or more of ${CLI_PARENT_TOOL_IDS.join(", ")}`,
     );
   }
   return [...new Set(parsed)] as readonly BuiltinToolId[];
@@ -278,7 +276,11 @@ const parseSubagentProfiles = (
   }
   const parsed = values.map((value) => parseSubagentProfile(value));
   if (parsed.some((value) => value === undefined)) {
-    throw new Error("allowed subagent profiles must be one or more of default");
+    throw new Error(
+      `allowed subagent profiles must be one or more of ${
+        HARNESS_SUBAGENT_PROFILES.join(", ")
+      }`,
+    );
   }
   return [...new Set(parsed)] as readonly HarnessSubagentProfile[];
 };
@@ -656,6 +658,7 @@ const summarizeToolCallArguments = (
     const parsed = JSON.parse(rawArguments) as Record<string, unknown>;
     switch (toolName) {
       case "bash":
+      case "bash-no-sandbox":
         return typeof parsed.command === "string"
           ? `command=${JSON.stringify(parsed.command)}`
           : undefined;

--- a/packages/cf-harness/src/contracts/subagent.ts
+++ b/packages/cf-harness/src/contracts/subagent.ts
@@ -3,6 +3,7 @@ import type { HarnessFailureRecord } from "../diagnostics.ts";
 import type { BuiltinToolId } from "./tool-descriptor.ts";
 
 export const DEFAULT_SUBAGENT_PROFILE = "default" as const;
+export const BROWSER_SUBAGENT_PROFILE = "browser" as const;
 export const DEFAULT_SUBAGENT_MAX_MODEL_TURNS = 8;
 export const MAX_SUBAGENT_MAX_MODEL_TURNS = 16;
 export const DEFAULT_SUBAGENT_RETURN_CHANNEL =
@@ -12,15 +13,25 @@ export const DEFAULT_SUBAGENT_ALLOWED_TOOL_IDS = [
   "read_file",
   "write_file",
 ] as const satisfies readonly BuiltinToolId[];
-
-export type HarnessSubagentProfile = typeof DEFAULT_SUBAGENT_PROFILE;
-export type HarnessSubagentRunStatus = "completed" | "failed";
-export type HarnessSubagentReturnChannel =
-  typeof DEFAULT_SUBAGENT_RETURN_CHANNEL;
+export const BROWSER_SUBAGENT_ALLOWED_TOOL_IDS = [
+  "bash-no-sandbox",
+  "read_file",
+  "write_file",
+] as const satisfies readonly BuiltinToolId[];
+export const NO_HOST_TOOL_IDS = [] as const satisfies readonly BuiltinToolId[];
+export const BROWSER_SUBAGENT_HOST_TOOL_IDS = [
+  "bash-no-sandbox",
+] as const satisfies readonly BuiltinToolId[];
 
 export const HARNESS_SUBAGENT_PROFILES = [
   DEFAULT_SUBAGENT_PROFILE,
-] as const satisfies readonly HarnessSubagentProfile[];
+  BROWSER_SUBAGENT_PROFILE,
+] as const;
+
+export type HarnessSubagentProfile = typeof HARNESS_SUBAGENT_PROFILES[number];
+export type HarnessSubagentRunStatus = "completed" | "failed";
+export type HarnessSubagentReturnChannel =
+  typeof DEFAULT_SUBAGENT_RETURN_CHANNEL;
 
 export interface HarnessSubagentReturnPolicy {
   type: "cf-harness.subagent-return-policy";
@@ -36,6 +47,7 @@ export interface HarnessSubagentProfileConfig {
   type: "cf-harness.subagent-profile-config";
   profile: HarnessSubagentProfile;
   allowedToolIds: readonly BuiltinToolId[];
+  hostToolIds: readonly BuiltinToolId[];
   maxModelTurns: number;
   returnPolicy: HarnessSubagentReturnPolicy;
 }
@@ -54,6 +66,16 @@ export const DEFAULT_SUBAGENT_PROFILE_CONFIG: HarnessSubagentProfileConfig = {
   type: "cf-harness.subagent-profile-config",
   profile: DEFAULT_SUBAGENT_PROFILE,
   allowedToolIds: DEFAULT_SUBAGENT_ALLOWED_TOOL_IDS,
+  hostToolIds: NO_HOST_TOOL_IDS,
+  maxModelTurns: DEFAULT_SUBAGENT_MAX_MODEL_TURNS,
+  returnPolicy: DEFAULT_SUBAGENT_RETURN_POLICY,
+};
+
+export const BROWSER_SUBAGENT_PROFILE_CONFIG: HarnessSubagentProfileConfig = {
+  type: "cf-harness.subagent-profile-config",
+  profile: BROWSER_SUBAGENT_PROFILE,
+  allowedToolIds: BROWSER_SUBAGENT_ALLOWED_TOOL_IDS,
+  hostToolIds: BROWSER_SUBAGENT_HOST_TOOL_IDS,
   maxModelTurns: DEFAULT_SUBAGENT_MAX_MODEL_TURNS,
   returnPolicy: DEFAULT_SUBAGENT_RETURN_POLICY,
 };
@@ -69,6 +91,8 @@ export const getHarnessSubagentProfileConfig = (
   switch (profile) {
     case DEFAULT_SUBAGENT_PROFILE:
       return DEFAULT_SUBAGENT_PROFILE_CONFIG;
+    case BROWSER_SUBAGENT_PROFILE:
+      return BROWSER_SUBAGENT_PROFILE_CONFIG;
   }
 };
 
@@ -91,6 +115,7 @@ export interface HarnessSubagentRunManifest {
   cfcEnforcementMode: CfcEnforcementMode;
   model: string;
   allowedToolIds: readonly BuiltinToolId[];
+  hostToolIds: readonly BuiltinToolId[];
   maxModelTurns: number;
   returnPolicy: HarnessSubagentReturnPolicy;
   createdAt: string;

--- a/packages/cf-harness/src/contracts/tool-descriptor.ts
+++ b/packages/cf-harness/src/contracts/tool-descriptor.ts
@@ -2,9 +2,17 @@ import type { JSONSchema } from "@commonfabric/api";
 
 export type BuiltinToolId =
   | "bash"
+  | "bash-no-sandbox"
   | "read_file"
   | "write_file"
   | "delegate_task";
+
+export const DEFAULT_PARENT_TOOL_IDS = [
+  "bash",
+  "read_file",
+  "write_file",
+  "delegate_task",
+] as const satisfies readonly BuiltinToolId[];
 
 export type HarnessToolEffectClass = "read" | "write" | "side-effect";
 

--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -399,7 +399,7 @@ const detailForMissingBinary = (
   capabilitySnapshot?: HarnessCapabilitySnapshot,
 ): string => {
   if (commandName === undefined) {
-    return "a shell command was not found in the sandbox";
+    return "a shell command was not found";
   }
   const capabilityCommand = capabilityCommandForName(commandName);
   const probe = capabilityCommand === undefined
@@ -422,6 +422,7 @@ export const classifyBashToolFailure = (
   output: BashToolOutput,
   at: string,
   capabilitySnapshot?: HarnessCapabilitySnapshot,
+  toolId = "bash",
 ): HarnessFailureRecord | undefined => {
   if (output.exitCode !== 127) {
     return undefined;
@@ -442,7 +443,7 @@ export const classifyBashToolFailure = (
     source: "tool_output",
     detail: detailForMissingBinary(commandName, capabilitySnapshot),
     at,
-    toolId: "bash",
+    toolId,
     outputId: output.outputId as ToolOutputId,
     command: input.command,
     ...(commandName !== undefined ? { commandName } : {}),
@@ -464,6 +465,15 @@ export const classifyBuiltinToolFailure = (
         output as BashToolOutput,
         at,
         capabilitySnapshot,
+        toolId,
+      );
+    case "bash-no-sandbox":
+      return classifyBashToolFailure(
+        input as BashToolInput,
+        output as BashToolOutput,
+        at,
+        undefined,
+        toolId,
       );
     case "read_file":
     case "write_file":

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -50,8 +50,17 @@ import {
   DockerRunscSandboxRuntime,
   resolveDockerRunscSandboxConfig,
 } from "./sandbox/docker-runsc.ts";
-import { dirname } from "@std/path";
-import type { ProcessRunner } from "./sandbox/process-runner.ts";
+import {
+  dirname,
+  join as joinHostPath,
+  normalize as normalizeHostPath,
+  relative as relativeHostPath,
+} from "@std/path";
+import { normalize as normalizeSandboxPath } from "@std/path/posix";
+import {
+  DenoProcessRunner,
+  type ProcessRunner,
+} from "./sandbox/process-runner.ts";
 import type { HarnessSandboxConfig, SandboxRuntime } from "./sandbox/types.ts";
 import { type BashToolInput, type BashToolOutput } from "./tools/bash.ts";
 import {
@@ -70,6 +79,7 @@ import { getBuiltinTool } from "./tools/registry.ts";
 
 export interface BuiltinToolInputMap {
   bash: BashToolInput;
+  "bash-no-sandbox": BashToolInput;
   read_file: ReadFileToolInput;
   write_file: WriteFileToolInput;
   delegate_task: DelegateTaskToolInput;
@@ -77,6 +87,7 @@ export interface BuiltinToolInputMap {
 
 export interface BuiltinToolOutputMap {
   bash: BashToolOutput;
+  "bash-no-sandbox": BashToolOutput;
   read_file: ReadFileToolOutput;
   write_file: WriteFileToolOutput;
   delegate_task: DelegateTaskToolOutput;
@@ -155,10 +166,29 @@ const resolveInitialCurrentDir = (
   return sandbox.defaultWorkingDirectory();
 };
 
+const normalizeSandboxRoot = (path: string): string => {
+  const normalized = normalizeSandboxPath(path);
+  return normalized.length > 1 && normalized.endsWith("/")
+    ? normalized.slice(0, -1)
+    : normalized;
+};
+
+const isHostPathWithinRoot = (root: string, path: string): boolean => {
+  const relativePath = relativeHostPath(
+    normalizeHostPath(root),
+    normalizeHostPath(path),
+  );
+  return relativePath === "" ||
+    (!relativePath.startsWith("..") && !relativePath.startsWith("/"));
+};
+
 export class CfHarnessEngine {
   readonly config: HarnessConfig;
   readonly sandbox: SandboxRuntime;
   readonly artifactStore?: HarnessArtifactStore;
+  readonly hostProcessRunner: ProcessRunner;
+  readonly workspaceHostPath?: string;
+  readonly workspaceMountPath: string;
 
   #runState: HarnessRunState;
   #outputSequence: number;
@@ -169,11 +199,18 @@ export class CfHarnessEngine {
     this.config = resolveHarnessConfig(options);
     const runId = options.runState?.runId ?? options.runId ??
       crypto.randomUUID();
+    const sandboxConfig = options.sandboxRuntime === undefined
+      ? resolveSandboxConfig(this.config, options.workspaceHostPath)
+      : this.config.sandbox;
+    this.hostProcessRunner = options.processRunner ?? new DenoProcessRunner();
     this.sandbox = options.sandboxRuntime ??
-      createSandboxRuntime(
-        resolveSandboxConfig(this.config, options.workspaceHostPath),
-        options.processRunner,
-      );
+      createSandboxRuntime(sandboxConfig!, options.processRunner);
+    this.workspaceHostPath = sandboxConfig?.workspaceHostPath ??
+      options.workspaceHostPath;
+    this.workspaceMountPath = normalizeSandboxRoot(
+      sandboxConfig?.workspaceMountPath ??
+        this.sandbox.defaultWorkingDirectory(),
+    );
     this.artifactStore = options.artifactStore ??
       ((this.config.artifactRoot ?? options.runState?.artifactRoot) !==
           undefined
@@ -517,14 +554,61 @@ export class CfHarnessEngine {
     };
   }
 
+  #resolveHostPath(path: string): string {
+    if (this.workspaceHostPath === undefined) {
+      throw new Error(
+        "bash-no-sandbox requires a workspace host path to map sandbox paths",
+      );
+    }
+    const sandboxPath = this.sandbox.resolvePath(
+      path,
+      this.#runState.currentDir,
+    );
+    const mountPath = this.workspaceMountPath;
+    if (sandboxPath === mountPath) {
+      return normalizeHostPath(this.workspaceHostPath);
+    }
+    if (!sandboxPath.startsWith(`${mountPath}/`)) {
+      throw new Error(`path escapes workspace root: ${path}`);
+    }
+    return normalizeHostPath(
+      joinHostPath(
+        this.workspaceHostPath,
+        sandboxPath.slice(mountPath.length + 1),
+      ),
+    );
+  }
+
+  #hostPathToWorkspacePath(path: string): string | undefined {
+    if (this.workspaceHostPath === undefined) {
+      return undefined;
+    }
+    const hostRoot = normalizeHostPath(this.workspaceHostPath);
+    const hostPath = normalizeHostPath(path);
+    if (!isHostPathWithinRoot(hostRoot, hostPath)) {
+      return undefined;
+    }
+    const relativePath = relativeHostPath(hostRoot, hostPath);
+    if (relativePath === "") {
+      return this.workspaceMountPath;
+    }
+    return normalizeSandboxPath(
+      `${this.workspaceMountPath}/${relativePath.replaceAll("\\", "/")}`,
+    );
+  }
+
   #createToolContext() {
     return {
       runId: this.#runState.runId,
       cfcEnforcementMode: this.#runState.cfcEnforcementMode,
       currentDir: this.#runState.currentDir,
       sandbox: this.sandbox,
+      hostProcessRunner: this.hostProcessRunner,
       resolvePath: (path: string) =>
         this.sandbox.resolvePath(path, this.#runState.currentDir),
+      resolveHostPath: (path: string) => this.#resolveHostPath(path),
+      hostPathToWorkspacePath: (path: string) =>
+        this.#hostPathToWorkspacePath(path),
       setCurrentDir: (path: string) => {
         const resolved = this.sandbox.resolvePath(
           path,

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -44,9 +44,11 @@ import {
   type DelegateTaskToolInput,
   type DelegateTaskToolOutput,
   getHarnessSubagentProfileConfig,
+  HARNESS_SUBAGENT_PROFILES,
   type HarnessSubagentFailureSummary,
   type HarnessSubagentInputSummary,
   type HarnessSubagentProfile,
+  type HarnessSubagentProfileConfig,
   type HarnessSubagentResult,
   type HarnessSubagentRunManifest,
   type HarnessSubagentRunStateSummary,
@@ -55,6 +57,7 @@ import {
 } from "./contracts/subagent.ts";
 import { BUILTIN_TOOLS, getBuiltinTool } from "./tools/registry.ts";
 import type { HarnessFailureRecord } from "./diagnostics.ts";
+import { DEFAULT_PARENT_TOOL_IDS as DEFAULT_PROMPT_LOOP_TOOL_IDS } from "./contracts/tool-descriptor.ts";
 
 const DEFAULT_MAX_MODEL_TURNS = 8;
 
@@ -150,21 +153,19 @@ const toOpenAIChatMessage = (
 };
 
 const toOpenAITools = (
-  allowedToolIds?: ReadonlySet<BuiltinToolId>,
+  allowedToolIds: ReadonlySet<BuiltinToolId>,
 ): OpenAIChatCompletionTool[] =>
-  BUILTIN_TOOLS.filter((tool) =>
-    allowedToolIds === undefined ||
-    allowedToolIds.has(tool.descriptor.toolId)
-  ).map((tool) => ({
-    type: "function",
-    function: {
-      name: tool.descriptor.toolId,
-      description: tool.descriptor.description,
-      parameters: typeof tool.descriptor.inputSchema === "boolean"
-        ? tool.descriptor.inputSchema
-        : { ...tool.descriptor.inputSchema },
-    },
-  }));
+  BUILTIN_TOOLS.filter((tool) => allowedToolIds.has(tool.descriptor.toolId))
+    .map((tool) => ({
+      type: "function",
+      function: {
+        name: tool.descriptor.toolId,
+        description: tool.descriptor.description,
+        parameters: typeof tool.descriptor.inputSchema === "boolean"
+          ? tool.descriptor.inputSchema
+          : { ...tool.descriptor.inputSchema },
+      },
+    }));
 
 const parseToolArguments = (
   toolCall: HarnessToolCall,
@@ -348,7 +349,8 @@ const summarizeToolInput = async (
   input: Record<string, unknown>,
 ): Promise<HarnessToolInputSummary> => {
   switch (toolId) {
-    case "bash": {
+    case "bash":
+    case "bash-no-sandbox": {
       const commandSummary = typeof input.command === "string"
         ? await summarizeSensitiveText(input.command)
         : undefined;
@@ -459,7 +461,9 @@ const parseDelegateTaskInput = (
     : undefined;
   if (profile === undefined) {
     throw new Error(
-      `delegate_task profile must be one of ${DEFAULT_SUBAGENT_PROFILE}`,
+      `delegate_task profile must be one of ${
+        HARNESS_SUBAGENT_PROFILES.join(", ")
+      }`,
     );
   }
   const maxModelTurns = input.maxModelTurns;
@@ -504,13 +508,25 @@ const createSubagentInputSummary = async (
   };
 };
 
-const buildSubagentSystemPrompt = (currentDir: string): string =>
+const buildSubagentSystemPrompt = (
+  currentDir: string,
+  profileConfig: HarnessSubagentProfileConfig,
+): string =>
   [
     "You are a focused cf-harness subagent working on one delegated task.",
     "You start with a fresh context and do not know the parent conversation.",
     "Use only the task and context provided in this child run.",
     "Do not ask the user follow-up questions.",
     "Do not attempt to delegate further; nested subagents are not available.",
+    `Subagent profile: ${profileConfig.profile}`,
+    ...(profileConfig.hostToolIds.length > 0
+      ? [
+        `Host execution tools available: ${
+          profileConfig.hostToolIds.join(", ")
+        }`,
+        "Host execution is outside the sandbox. Use it only for the delegated task and prefer agent-browser commands when browser access is needed.",
+      ]
+      : []),
     `Current sandbox directory: ${currentDir}`,
     "",
     "When finished, return a concise summary with:",
@@ -675,7 +691,7 @@ export class CfHarnessPromptLoop {
   readonly engine: CfHarnessEngine;
   readonly gatewayClient: OpenAICompatibleGatewayClient;
   readonly #maxModelTurns: number;
-  readonly #allowedToolIds?: ReadonlySet<BuiltinToolId>;
+  readonly #allowedToolIds: ReadonlySet<BuiltinToolId>;
   readonly #allowedSubagentProfiles: ReadonlySet<HarnessSubagentProfile>;
 
   constructor(options: CreateHarnessPromptLoopOptions = {}) {
@@ -689,9 +705,9 @@ export class CfHarnessPromptLoop {
         fetchFn: options.fetchFn,
       });
     this.#maxModelTurns = options.maxModelTurns ?? DEFAULT_MAX_MODEL_TURNS;
-    this.#allowedToolIds = options.allowedToolIds === undefined
-      ? undefined
-      : new Set(options.allowedToolIds);
+    this.#allowedToolIds = new Set(
+      options.allowedToolIds ?? DEFAULT_PROMPT_LOOP_TOOL_IDS,
+    );
     this.#allowedSubagentProfiles = new Set(
       options.allowedSubagentProfiles ??
         (options.allowedToolIds === undefined
@@ -911,10 +927,7 @@ export class CfHarnessPromptLoop {
       await this.engine.recordPolicyEvent(event);
       policyEventIndexes.push(index);
     };
-    if (
-      this.#allowedToolIds !== undefined &&
-      !this.#allowedToolIds.has(toolCall.function.name)
-    ) {
+    if (!this.#allowedToolIds.has(toolCall.function.name)) {
       const denial = makeObservationDenied("not-authorized", {
         detail: `${toolCall.function.name} is not allowed in this run`,
       });
@@ -1129,6 +1142,8 @@ export class CfHarnessPromptLoop {
     const childEngine = new CfHarnessEngine({
       runId: childRunId,
       sandboxRuntime: this.engine.sandbox,
+      workspaceHostPath: this.engine.workspaceHostPath,
+      processRunner: this.engine.hostProcessRunner,
       artifactRoot: this.engine.artifactStore?.artifactRoot,
       model: options.model,
       gatewayBaseUrl: this.engine.config.gatewayBaseUrl,
@@ -1148,6 +1163,7 @@ export class CfHarnessPromptLoop {
       cfcEnforcementMode: parentRunState.cfcEnforcementMode,
       model: options.model,
       allowedToolIds: [...profileConfig.allowedToolIds],
+      hostToolIds: [...profileConfig.hostToolIds],
       maxModelTurns,
       returnPolicy: profileConfig.returnPolicy,
       createdAt: childCreatedState.createdAt,
@@ -1167,6 +1183,7 @@ export class CfHarnessPromptLoop {
       const childResult = await childLoop.runPrompt({
         systemPrompt: buildSubagentSystemPrompt(
           childEngine.getRunState().currentDir,
+          profileConfig,
         ),
         prompt: buildSubagentUserPrompt(delegateInput),
         model: options.model,

--- a/packages/cf-harness/src/tools/bash-no-sandbox.ts
+++ b/packages/cf-harness/src/tools/bash-no-sandbox.ts
@@ -1,0 +1,92 @@
+import type { JSONSchema } from "@commonfabric/api";
+import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
+import type { BashToolInput, BashToolOutput } from "./bash.ts";
+import type { HarnessToolDefinition } from "./types.ts";
+
+const cwdMarkerForOutput = (outputId: string): string =>
+  `__CF_HARNESS_HOST_CWD__${outputId}__`;
+
+const extractFinalWorkingDirectory = (
+  stdout: string,
+  marker: string,
+): { stdout: string; cwd?: string } => {
+  const markerIndex = stdout.lastIndexOf(marker);
+  if (markerIndex === -1) {
+    return { stdout };
+  }
+  return {
+    stdout: stdout.slice(0, markerIndex),
+    cwd: stdout.slice(markerIndex + marker.length),
+  };
+};
+
+export const bashNoSandboxToolDescriptor: HarnessToolDescriptor = {
+  toolId: "bash-no-sandbox",
+  title: "Bash (No Sandbox)",
+  description:
+    "PROVISIONAL HOST SHELL. Runs a bash command outside the sandbox on the host workspace. Intended only for the browser subagent profile, especially invoking agent-browser; do not use for normal repository work.",
+  effectClass: "side-effect",
+  inputSchema: {
+    type: "object",
+    properties: {
+      command: { type: "string" },
+      cwd: { type: "string" },
+      timeoutMs: { type: "number", minimum: 0 },
+    },
+    required: ["command"],
+    additionalProperties: false,
+  } satisfies JSONSchema,
+  outputSchema: {
+    type: "object",
+    properties: {
+      outputId: { type: "string" },
+      stdout: { type: "string" },
+      stderr: { type: "string" },
+      exitCode: { type: "number" },
+      cwd: { type: "string" },
+    },
+    required: ["outputId", "stdout", "stderr", "exitCode", "cwd"],
+    additionalProperties: false,
+  } satisfies JSONSchema,
+  tags: ["shell", "host", "no-sandbox", "browser"],
+};
+
+export const bashNoSandboxTool: HarnessToolDefinition<
+  BashToolInput,
+  BashToolOutput
+> = {
+  descriptor: bashNoSandboxToolDescriptor,
+  async invoke(context, input) {
+    const outputId = context.nextOutputId("bash-no-sandbox");
+    const commandCwd = input.cwd !== undefined
+      ? context.resolvePath(input.cwd)
+      : context.currentDir;
+    const hostCwd = context.resolveHostPath(commandCwd);
+    const cwdMarker = cwdMarkerForOutput(outputId);
+    const result = await context.hostProcessRunner.run({
+      command: "bash",
+      args: [
+        "-lc",
+        [
+          `__cf_harness_cwd_marker=${JSON.stringify(cwdMarker)}`,
+          'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
+          input.command,
+        ].join("\n"),
+      ],
+      cwd: hostCwd,
+      timeoutMs: input.timeoutMs,
+    });
+    const parsedResult = extractFinalWorkingDirectory(result.stdout, cwdMarker);
+    const nextCurrentDir = parsedResult.cwd === undefined
+      ? commandCwd
+      : context.hostPathToWorkspacePath(parsedResult.cwd) ?? commandCwd;
+    context.setCurrentDir(nextCurrentDir);
+    return {
+      outputId,
+      stdout: parsedResult.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+      cwd: nextCurrentDir,
+    };
+  },
+};

--- a/packages/cf-harness/src/tools/delegate-task.ts
+++ b/packages/cf-harness/src/tools/delegate-task.ts
@@ -1,7 +1,9 @@
 import type {
   DelegateTaskToolInput,
   DelegateTaskToolOutput,
+  HarnessSubagentProfile,
 } from "../contracts/subagent.ts";
+import { HARNESS_SUBAGENT_PROFILES } from "../contracts/subagent.ts";
 import type { HarnessToolDefinition } from "./types.ts";
 import { createUnimplementedToolError } from "./types.ts";
 
@@ -27,7 +29,9 @@ export const delegateTaskTool: HarnessToolDefinition<
         },
         profile: {
           type: "string",
-          enum: ["default"],
+          enum: [
+            ...HARNESS_SUBAGENT_PROFILES,
+          ] satisfies HarnessSubagentProfile[],
           description:
             "Named subagent profile to spawn. Defaults to the harness default profile.",
         },

--- a/packages/cf-harness/src/tools/registry.ts
+++ b/packages/cf-harness/src/tools/registry.ts
@@ -1,5 +1,6 @@
 import type { BuiltinToolId } from "../contracts/tool-descriptor.ts";
 import { bashTool } from "./bash.ts";
+import { bashNoSandboxTool } from "./bash-no-sandbox.ts";
 import { delegateTaskTool } from "./delegate-task.ts";
 import { readFileTool } from "./read-file.ts";
 import { writeFileTool } from "./write-file.ts";
@@ -7,6 +8,7 @@ import type { HarnessToolDefinition } from "./types.ts";
 
 export const BUILTIN_TOOLS = [
   bashTool,
+  bashNoSandboxTool,
   readFileTool,
   writeFileTool,
   delegateTaskTool,

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -1,14 +1,18 @@
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { ToolOutputId } from "../contracts/tool-result.ts";
+import type { ProcessRunner } from "../sandbox/process-runner.ts";
 import type { SandboxRuntime } from "../sandbox/types.ts";
 
 export interface HarnessToolContext {
   runId: string;
   cfcEnforcementMode: CfcEnforcementMode;
   sandbox: SandboxRuntime;
+  hostProcessRunner: ProcessRunner;
   currentDir: string;
   resolvePath(path: string): string;
+  resolveHostPath(path: string): string;
+  hostPathToWorkspacePath(path: string): string | undefined;
   setCurrentDir(path: string): void;
   nextOutputId(toolId: string): ToolOutputId;
 }

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -575,6 +575,7 @@ Deno.test({
         "read_file",
         "write_file",
       ]);
+      assertEquals(subagentRun.manifest.hostToolIds, []);
       assertEquals(subagentRun.manifest.returnPolicy, {
         type: "cf-harness.subagent-return-policy",
         channel: "summary-and-sanitized-state",

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -231,6 +231,29 @@ Deno.test("parseCfHarnessCliArgs supports explicit subagent profile authorizatio
   assertEquals(parsed.allowedSubagentProfiles, ["default"]);
 });
 
+Deno.test("parseCfHarnessCliArgs supports explicit browser subagent profile authorization", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--prompt",
+      "hi",
+      "--allow-tool",
+      "delegate_task",
+      "--allow-subagent-profile",
+      "browser",
+    ],
+    {
+      cwd: "/tmp/project",
+      env: {},
+    },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.allowedToolIds, ["delegate_task"]);
+  assertEquals(parsed.allowedSubagentProfiles, ["browser"]);
+});
+
 Deno.test("parseCfHarnessCliArgs covers tool allowlist and subagent profile permutations", async () => {
   const cases = [
     {
@@ -244,6 +267,12 @@ Deno.test("parseCfHarnessCliArgs covers tool allowlist and subagent profile perm
       flags: ["--allow-subagent-profile", "default"],
       allowedToolIds: undefined,
       allowedSubagentProfiles: ["default"],
+    },
+    {
+      name: "explicit browser profile when parent tools are unrestricted",
+      flags: ["--allow-subagent-profile", "browser"],
+      allowedToolIds: undefined,
+      allowedSubagentProfiles: ["browser"],
     },
     {
       name: "delegate_task alone does not imply child profile authority",
@@ -290,6 +319,19 @@ Deno.test("parseCfHarnessCliArgs covers tool allowlist and subagent profile perm
       allowedToolIds: ["delegate_task"],
       allowedSubagentProfiles: ["default"],
     },
+    {
+      name: "default and browser profiles can both be preauthorized",
+      flags: [
+        "--allow-tool",
+        "delegate_task",
+        "--allow-subagent-profile",
+        "default",
+        "--allow-subagent-profile",
+        "browser",
+      ],
+      allowedToolIds: ["delegate_task"],
+      allowedSubagentProfiles: ["default", "browser"],
+    },
   ] as const;
 
   for (const testCase of cases) {
@@ -321,14 +363,29 @@ Deno.test("parseCfHarnessCliArgs rejects unknown subagent profiles", async () =>
   await assertRejects(
     () =>
       parseCfHarnessCliArgs(
-        ["--prompt", "hi", "--allow-subagent-profile", "browser"],
+        ["--prompt", "hi", "--allow-subagent-profile", "unknown"],
         {
           cwd: "/tmp/project",
           env: {},
         },
       ),
     Error,
-    "allowed subagent profiles must be one or more of default",
+    "allowed subagent profiles must be one or more of default, browser",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs rejects bash-no-sandbox as a parent allow-tool", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        ["--prompt", "hi", "--allow-tool", "bash-no-sandbox"],
+        {
+          cwd: "/tmp/project",
+          env: {},
+        },
+      ),
+    Error,
+    "allowed tools must be one or more of bash, read_file, write_file, delegate_task",
   );
 });
 
@@ -753,6 +810,17 @@ Deno.test("runCfHarnessCli passes tool and subagent profile allowlists", async (
       ],
       allowedToolIds: ["delegate_task"],
       allowedSubagentProfiles: ["default"],
+    },
+    {
+      name: "delegate_task with explicit browser profile authorization",
+      flags: [
+        "--allow-tool",
+        "delegate_task",
+        "--allow-subagent-profile",
+        "browser",
+      ],
+      allowedToolIds: ["delegate_task"],
+      allowedSubagentProfiles: ["browser"],
     },
   ] as const;
 

--- a/packages/cf-harness/test/diagnostics.test.ts
+++ b/packages/cf-harness/test/diagnostics.test.ts
@@ -209,6 +209,34 @@ Deno.test("classifyBashToolFailure prefers the missing subcommand from shell out
   });
 });
 
+Deno.test("classifyBuiltinToolFailure records host shell failures without sandbox capability claims", () => {
+  const failure = classifyBuiltinToolFailure(
+    "bash-no-sandbox",
+    { command: "agent-browser --help" },
+    {
+      outputId: createToolOutputId("run-host", "bash-no-sandbox", 1),
+      stdout: "",
+      stderr: "bash: agent-browser: command not found",
+      exitCode: 127,
+      cwd: "/workspace",
+    },
+    "2026-04-23T18:25:00.000Z",
+  );
+
+  assertEquals(failure, {
+    type: "cf-harness.failure-record",
+    kind: "missing_binary",
+    source: "tool_output",
+    detail: "agent-browser was not found while executing a shell command.",
+    at: "2026-04-23T18:25:00.000Z",
+    toolId: "bash-no-sandbox",
+    outputId: createToolOutputId("run-host", "bash-no-sandbox", 1),
+    command: "agent-browser --help",
+    commandName: "agent-browser",
+    exitCode: 127,
+  });
+});
+
 Deno.test("classifyBuiltinToolFailure handles delegate_task outputs defensively", () => {
   assertEquals(
     classifyBuiltinToolFailure(
@@ -254,6 +282,7 @@ Deno.test("classifyBuiltinToolFailure handles delegate_task outputs defensively"
             cfcEnforcementMode: "disabled",
             model: "gpt-5.4",
             allowedToolIds: ["bash", "read_file", "write_file"],
+            hostToolIds: [],
             maxModelTurns: 8,
             returnPolicy: {
               type: "cf-harness.subagent-return-policy",

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -514,9 +514,11 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
       summary: string;
       modelTurns: number;
       manifest: {
+        profile: string;
         parentRunId: string;
         parentToolCallId: string;
         allowedToolIds: string[];
+        hostToolIds: string[];
         returnPolicy: Record<string, unknown>;
         inputSummary: {
           goalBytes: number;
@@ -545,11 +547,13 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
   assertEquals(output.subagent.modelTurns, 1);
   assertEquals(output.subagent.manifest.parentRunId, "run-delegate");
   assertEquals(output.subagent.manifest.parentToolCallId, "call-delegate");
+  assertEquals(output.subagent.manifest.profile, "default");
   assertEquals(output.subagent.manifest.allowedToolIds, [
     "bash",
     "read_file",
     "write_file",
   ]);
+  assertEquals(output.subagent.manifest.hostToolIds, []);
   assertEquals(output.subagent.manifest.returnPolicy, {
     type: "cf-harness.subagent-return-policy",
     channel: "summary-and-sanitized-state",
@@ -662,6 +666,7 @@ Deno.test("CfHarnessPromptLoop lets an explicit subagent profile expand child to
       manifest: {
         profile: string;
         allowedToolIds: string[];
+        hostToolIds: string[];
       };
     };
   };
@@ -686,6 +691,263 @@ Deno.test("CfHarnessPromptLoop lets an explicit subagent profile expand child to
     "read_file",
     "write_file",
   ]);
+  assertEquals(output.subagent.manifest.hostToolIds, []);
+});
+
+Deno.test("CfHarnessPromptLoop keeps bash-no-sandbox unavailable to the parent by default", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      workspaceHostPath: "/tmp/project",
+      runId: "run-parent-host-tool-denied",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-host-tool",
+                type: "function",
+                function: {
+                  name: "bash-no-sandbox",
+                  arguments: JSON.stringify({
+                    command: "agent-browser --help",
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Host tool denied.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Try the host tool.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+  const firstRequest = JSON.parse(String(fetchCalls[0]?.body)) as {
+    tools: Array<{ function: { name: string } }>;
+  };
+  const toolMessage = result.transcript.at(-2);
+  if (toolMessage?.role !== "tool") {
+    throw new Error("expected host tool denial message");
+  }
+  const denied = JSON.parse(toolMessage.content) as { detail: string };
+
+  assertEquals(
+    firstRequest.tools.map((tool) => tool.function.name),
+    ["bash", "read_file", "write_file", "delegate_task"],
+  );
+  assertEquals(denied.detail, "bash-no-sandbox is not allowed in this run");
+  assertEquals(result.runState.toolOutputs, []);
+  assertEquals(result.runState.policyEvents[0]?.toolId, "bash-no-sandbox");
+  assertEquals(result.runState.primaryFailure?.kind, "tool_not_allowed");
+});
+
+Deno.test("CfHarnessPromptLoop gives bash-no-sandbox only to the authorized browser subagent profile", async () => {
+  const requestBodies: Array<{
+    messages: Array<{ role: string; content: string }>;
+    tools: Array<{ function: { name: string } }>;
+  }> = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    allowedToolIds: ["delegate_task"],
+    allowedSubagentProfiles: ["browser"],
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      workspaceHostPath: "/tmp/project",
+      runId: "run-delegate-browser-profile",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        messages: Array<{ role: string; content: string }>;
+        tools: Array<{ function: { name: string } }>;
+      };
+      requestBodies.push(body);
+      const payload = requestBodies.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-browser-profile",
+                type: "function",
+                function: {
+                  name: "delegate_task",
+                  arguments: JSON.stringify({
+                    goal: "Open the local app with agent-browser.",
+                    profile: "browser",
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : requestBodies.length === 2
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Browser-profile child completed.",
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Browser-profile parent completed.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Delegate browser work.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+  const toolMessage = result.transcript.at(-2);
+  if (toolMessage?.role !== "tool") {
+    throw new Error("expected delegate_task tool message");
+  }
+  const output = JSON.parse(toolMessage.content) as {
+    subagent: {
+      manifest: {
+        profile: string;
+        allowedToolIds: string[];
+        hostToolIds: string[];
+      };
+    };
+  };
+
+  assertEquals(
+    requestBodies[0].tools.map((tool) => tool.function.name),
+    ["delegate_task"],
+  );
+  assertEquals(
+    requestBodies[1].tools.map((tool) => tool.function.name),
+    ["bash-no-sandbox", "read_file", "write_file"],
+  );
+  assertEquals(
+    requestBodies[1].messages[0].content.includes(
+      "Host execution tools available: bash-no-sandbox",
+    ),
+    true,
+  );
+  assertEquals(output.subagent.manifest.profile, "browser");
+  assertEquals(output.subagent.manifest.allowedToolIds, [
+    "bash-no-sandbox",
+    "read_file",
+    "write_file",
+  ]);
+  assertEquals(output.subagent.manifest.hostToolIds, ["bash-no-sandbox"]);
+  assertEquals(result.finalAssistantText, "Browser-profile parent completed.");
+});
+
+Deno.test("CfHarnessPromptLoop does not authorize the browser profile by default", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      workspaceHostPath: "/tmp/project",
+      runId: "run-browser-profile-default-denied",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-browser-default-denied",
+                type: "function",
+                function: {
+                  name: "delegate_task",
+                  arguments: JSON.stringify({
+                    goal: "Use browser profile.",
+                    profile: "browser",
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Browser profile denied.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Try browser delegation.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+  const toolMessage = result.transcript.at(-2);
+  if (toolMessage?.role !== "tool") {
+    throw new Error("expected delegate_task denial message");
+  }
+  const denied = JSON.parse(toolMessage.content) as { detail: string };
+
+  assertEquals(
+    denied.detail,
+    'delegate_task profile "browser" is not allowed in this run',
+  );
+  assertEquals(result.runState.subagentRuns, undefined);
+  assertEquals(result.runState.toolOutputs, []);
+  assertEquals(result.runState.policyEvents[0]?.toolInputSummary, {
+    type: "cf-harness.tool-input-summary",
+    toolId: "delegate_task",
+    profile: "browser",
+    goalBytes: 20,
+    goalDigest:
+      "sha256:8175c86ebf4f98a6041f1eb335920800690b2de78acb76fb8962ea6bf5f99eed",
+  });
 });
 
 Deno.test("CfHarnessPromptLoop rejects invalid delegate_task inputs before creating a child run", async () => {
@@ -712,8 +974,8 @@ Deno.test("CfHarnessPromptLoop rejects invalid delegate_task inputs before creat
     },
     {
       name: "unknown profile",
-      arguments: { goal: "Inspect", profile: "browser" },
-      message: "delegate_task profile must be one of default",
+      arguments: { goal: "Inspect", profile: "unknown" },
+      message: "delegate_task profile must be one of default, browser",
     },
   ];
 
@@ -920,6 +1182,7 @@ Deno.test("CfHarnessPromptLoop continues subagent ids from retained run state", 
       cfcEnforcementMode: "disabled",
       model: "gpt-5.4",
       allowedToolIds: ["bash", "read_file", "write_file"],
+      hostToolIds: [],
       maxModelTurns: 8,
       returnPolicy: {
         type: "cf-harness.subagent-return-policy",

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -2,9 +2,15 @@ import { assertEquals, assertRejects } from "@std/assert";
 import { normalize } from "@std/path/posix";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
 import { bashTool } from "../src/tools/bash.ts";
+import { bashNoSandboxTool } from "../src/tools/bash-no-sandbox.ts";
 import { readFileTool } from "../src/tools/read-file.ts";
 import { writeFileTool } from "../src/tools/write-file.ts";
 import type { HarnessToolContext } from "../src/tools/types.ts";
+import type {
+  ProcessRunner,
+  ProcessRunRequest,
+  ProcessRunResult,
+} from "../src/sandbox/process-runner.ts";
 import type {
   SandboxCommandRequest,
   SandboxCommandResult,
@@ -64,12 +70,33 @@ class StrictFakeSandboxRuntime extends FakeSandboxRuntime {
   }
 }
 
+class FakeProcessRunner implements ProcessRunner {
+  readonly calls: ProcessRunRequest[] = [];
+
+  constructor(
+    private readonly results: ProcessRunResult[] = [{
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    }],
+  ) {}
+
+  run(request: ProcessRunRequest): Promise<ProcessRunResult> {
+    this.calls.push(request);
+    return Promise.resolve(
+      this.results.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+    );
+  }
+}
+
 const createContext = (
   sandbox: SandboxRuntime,
   initialCurrentDir = "/workspace",
+  hostProcessRunner: ProcessRunner = new FakeProcessRunner(),
 ): HarnessToolContext => {
   let currentDir = initialCurrentDir;
   let sequence = 0;
+  const workspaceHostPath = "/tmp/cf-harness-workspace";
   return {
     runId: "run-1",
     cfcEnforcementMode: "observe",
@@ -77,8 +104,22 @@ const createContext = (
       return currentDir;
     },
     sandbox,
+    hostProcessRunner,
     resolvePath(path: string) {
       return sandbox.resolvePath(path, currentDir);
+    },
+    resolveHostPath(path: string) {
+      const sandboxPath = sandbox.resolvePath(path, currentDir);
+      return sandboxPath === "/workspace"
+        ? workspaceHostPath
+        : `${workspaceHostPath}${sandboxPath.slice("/workspace".length)}`;
+    },
+    hostPathToWorkspacePath(path: string) {
+      return path === workspaceHostPath
+        ? "/workspace"
+        : path.startsWith(`${workspaceHostPath}/`)
+        ? `/workspace${path.slice(workspaceHostPath.length)}`
+        : undefined;
     },
     setCurrentDir(path: string) {
       currentDir = sandbox.resolvePath(path, currentDir);
@@ -122,6 +163,64 @@ Deno.test("bash tool executes the command through the sandbox shell runtime", as
       timeoutMs: 1000,
     },
   }]);
+  assertEquals(context.currentDir, "/workspace/repo");
+});
+
+Deno.test("bash-no-sandbox tool executes the command through the host process runner", async () => {
+  const hostRunner = new FakeProcessRunner([{
+    stdout:
+      "host ok\n__CF_HARNESS_HOST_CWD__run-1:bash-no-sandbox:1__/tmp/cf-harness-workspace/browser",
+    stderr: "",
+    exitCode: 0,
+  }]);
+  const sandbox = new FakeSandboxRuntime();
+  const context = createContext(sandbox, "/workspace", hostRunner);
+  const output = await bashNoSandboxTool.invoke(context, {
+    command: "agent-browser --help",
+    cwd: "browser",
+    timeoutMs: 1000,
+  });
+
+  assertEquals(output, {
+    outputId: "run-1:bash-no-sandbox:1",
+    stdout: "host ok\n",
+    stderr: "",
+    exitCode: 0,
+    cwd: "/workspace/browser",
+  });
+  assertEquals(sandbox.calls, []);
+  assertEquals(hostRunner.calls, [{
+    command: "bash",
+    args: [
+      "-lc",
+      [
+        '__cf_harness_cwd_marker="__CF_HARNESS_HOST_CWD__run-1:bash-no-sandbox:1__"',
+        'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
+        "agent-browser --help",
+      ].join("\n"),
+    ],
+    cwd: "/tmp/cf-harness-workspace/browser",
+    timeoutMs: 1000,
+  }]);
+  assertEquals(context.currentDir, "/workspace/browser");
+});
+
+Deno.test("bash-no-sandbox keeps currentDir inside the workspace if the host command exits elsewhere", async () => {
+  const hostRunner = new FakeProcessRunner([{
+    stdout: "__CF_HARNESS_HOST_CWD__run-1:bash-no-sandbox:1__/tmp/outside",
+    stderr: "",
+    exitCode: 0,
+  }]);
+  const context = createContext(
+    new FakeSandboxRuntime(),
+    "/workspace/repo",
+    hostRunner,
+  );
+  const output = await bashNoSandboxTool.invoke(context, {
+    command: "cd /tmp/outside",
+  });
+
+  assertEquals(output.cwd, "/workspace/repo");
   assertEquals(context.currentDir, "/workspace/repo");
 });
 

--- a/packages/cf-harness/test/tools-registry.test.ts
+++ b/packages/cf-harness/test/tools-registry.test.ts
@@ -1,5 +1,9 @@
 import { assert, assertEquals } from "@std/assert";
 import {
+  type BuiltinToolId,
+  DEFAULT_PARENT_TOOL_IDS,
+} from "../src/contracts/tool-descriptor.ts";
+import {
   BUILTIN_TOOL_REGISTRY,
   BUILTIN_TOOLS,
   getBuiltinTool,
@@ -9,11 +13,21 @@ import { WRITE_FILE_MODES } from "../src/tools/write-file.ts";
 Deno.test("builtin tool registry includes the agreed first-pass tool floor", () => {
   assertEquals(BUILTIN_TOOLS.map((tool) => tool.descriptor.toolId), [
     "bash",
+    "bash-no-sandbox",
     "read_file",
     "write_file",
     "delegate_task",
   ]);
-  assertEquals(BUILTIN_TOOL_REGISTRY.size, 4);
+  assertEquals(BUILTIN_TOOL_REGISTRY.size, 5);
+  assertEquals(
+    [...DEFAULT_PARENT_TOOL_IDS],
+    [
+      "bash",
+      "read_file",
+      "write_file",
+      "delegate_task",
+    ] satisfies BuiltinToolId[],
+  );
 });
 
 Deno.test("builtin tool registry exposes invoke functions for all built-ins", () => {

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -3,6 +3,7 @@ import {
   computeBaseline,
   extractMetrics,
   type Job,
+  readPRBodyFromEventPayload,
   type Step,
   type WorkflowRun,
 } from "./perf-lib.ts";
@@ -100,4 +101,27 @@ Deno.test("computeBaseline uses the 3 sigma threshold when it exceeds 15 percent
   assertEquals(baseline?.median, 100);
   assertAlmostEquals(baseline?.stddev ?? 0, 20, 1e-9);
   assertEquals(baseline?.threshold, 160);
+});
+
+Deno.test("readPRBodyFromEventPayload reads matching pull request bodies", async () => {
+  const eventPath = await Deno.makeTempFile();
+  try {
+    await Deno.writeTextFile(
+      eventPath,
+      JSON.stringify({
+        pull_request: {
+          number: 3427,
+          body: "NEW_PERF_BASELINE: job: Test = 300s",
+        },
+      }),
+    );
+
+    assertEquals(
+      await readPRBodyFromEventPayload(3427, eventPath),
+      "NEW_PERF_BASELINE: job: Test = 300s",
+    );
+    assertEquals(await readPRBodyFromEventPayload(1, eventPath), undefined);
+  } finally {
+    await Deno.remove(eventPath);
+  }
 });

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -148,6 +148,13 @@ export interface PRInfo {
   merged_at: string | null;
 }
 
+export interface PullRequestEventPayload {
+  pull_request?: {
+    number?: number;
+    body?: string | null;
+  };
+}
+
 export interface BaselineOverrides {
   /** Metric name -> value in the metric's native unit (seconds or nanoseconds). */
   metrics: Map<string, number>;
@@ -786,11 +793,37 @@ export async function fetchPRForCommit(
 }
 
 /** Fetch the full body of a PR by number. */
-export async function fetchPRBody(prNumber: number): Promise<string> {
+export async function fetchPRBody(
+  prNumber: number,
+  eventPath = Deno.env.get("GITHUB_EVENT_PATH"),
+): Promise<string> {
+  const bodyFromEvent = await readPRBodyFromEventPayload(prNumber, eventPath);
+  if (bodyFromEvent !== undefined) {
+    return bodyFromEvent;
+  }
   const pr = await githubGet<{ body: string | null }>(
     `/repos/${REPO}/pulls/${prNumber}`,
   );
   return pr.body ?? "";
+}
+
+export async function readPRBodyFromEventPayload(
+  prNumber: number,
+  eventPath: string | undefined,
+): Promise<string | undefined> {
+  if (eventPath === undefined || eventPath === "") {
+    return undefined;
+  }
+  try {
+    const payload = JSON.parse(
+      await Deno.readTextFile(eventPath),
+    ) as PullRequestEventPayload;
+    return payload.pull_request?.number === prNumber
+      ? payload.pull_request.body ?? ""
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
- add provisional bash-no-sandbox host shell tool for cf-harness
- add browser subagent profile that is the only CLI path to that host tool
- keep parent/default tool availability sandbox-only and record hostToolIds in subagent manifests
- expand CLI, prompt-loop, diagnostics, docs, and tests for the new boundaries

Verification:
- deno task test
- deno task check
- git diff --check