### PR TITLE
Share cf-harness shell cwd parsing

### DIFF
--- a/packages/cf-harness/src/tools/bash-no-sandbox.ts
+++ b/packages/cf-harness/src/tools/bash-no-sandbox.ts
@@ -1,24 +1,14 @@
 import type { JSONSchema } from "@commonfabric/api";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { BashToolInput, BashToolOutput } from "./bash.ts";
+import {
+  commandWithFinalWorkingDirectoryMarker,
+  cwdMarkerForOutput,
+  extractFinalWorkingDirectory,
+} from "./shell-cwd.ts";
 import type { HarnessToolDefinition } from "./types.ts";
 
-const cwdMarkerForOutput = (outputId: string): string =>
-  `__CF_HARNESS_HOST_CWD__${outputId}__`;
-
-const extractFinalWorkingDirectory = (
-  stdout: string,
-  marker: string,
-): { stdout: string; cwd?: string } => {
-  const markerIndex = stdout.lastIndexOf(marker);
-  if (markerIndex === -1) {
-    return { stdout };
-  }
-  return {
-    stdout: stdout.slice(0, markerIndex),
-    cwd: stdout.slice(markerIndex + marker.length),
-  };
-};
+const CWD_MARKER_PREFIX = "__CF_HARNESS_HOST_CWD__";
 
 export const bashNoSandboxToolDescriptor: HarnessToolDescriptor = {
   toolId: "bash-no-sandbox",
@@ -62,16 +52,12 @@ export const bashNoSandboxTool: HarnessToolDefinition<
       ? context.resolvePath(input.cwd)
       : context.currentDir;
     const hostCwd = context.resolveHostPath(commandCwd);
-    const cwdMarker = cwdMarkerForOutput(outputId);
+    const cwdMarker = cwdMarkerForOutput(CWD_MARKER_PREFIX, outputId);
     const result = await context.hostProcessRunner.run({
       command: "bash",
       args: [
         "-lc",
-        [
-          `__cf_harness_cwd_marker=${JSON.stringify(cwdMarker)}`,
-          'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
-          input.command,
-        ].join("\n"),
+        commandWithFinalWorkingDirectoryMarker(input.command, cwdMarker),
       ],
       cwd: hostCwd,
       timeoutMs: input.timeoutMs,

--- a/packages/cf-harness/src/tools/bash.ts
+++ b/packages/cf-harness/src/tools/bash.ts
@@ -1,5 +1,10 @@
 import type { JSONSchema } from "@commonfabric/api";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
+import {
+  commandWithFinalWorkingDirectoryMarker,
+  cwdMarkerForOutput,
+  extractFinalWorkingDirectory,
+} from "./shell-cwd.ts";
 import type { HarnessToolDefinition } from "./types.ts";
 
 export interface BashToolInput {
@@ -16,22 +21,7 @@ export interface BashToolOutput {
   cwd: string;
 }
 
-const cwdMarkerForOutput = (outputId: string): string =>
-  `__CF_HARNESS_CWD__${outputId}__`;
-
-const extractFinalWorkingDirectory = (
-  stdout: string,
-  marker: string,
-): { stdout: string; cwd?: string } => {
-  const markerIndex = stdout.lastIndexOf(marker);
-  if (markerIndex === -1) {
-    return { stdout };
-  }
-  return {
-    stdout: stdout.slice(0, markerIndex),
-    cwd: stdout.slice(markerIndex + marker.length),
-  };
-};
+const CWD_MARKER_PREFIX = "__CF_HARNESS_CWD__";
 
 export const bashToolDescriptor: HarnessToolDescriptor = {
   toolId: "bash",
@@ -71,13 +61,12 @@ export const bashTool: HarnessToolDefinition<BashToolInput, BashToolOutput> = {
     const commandCwd = input.cwd !== undefined
       ? context.resolvePath(input.cwd)
       : context.currentDir;
-    const cwdMarker = cwdMarkerForOutput(outputId);
+    const cwdMarker = cwdMarkerForOutput(CWD_MARKER_PREFIX, outputId);
     const result = await context.sandbox.runShell({
-      command: [
-        `__cf_harness_cwd_marker=${JSON.stringify(cwdMarker)}`,
-        'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
+      command: commandWithFinalWorkingDirectoryMarker(
         input.command,
-      ].join("\n"),
+        cwdMarker,
+      ),
       cwd: commandCwd,
       timeoutMs: input.timeoutMs,
     });

--- a/packages/cf-harness/src/tools/shell-cwd.ts
+++ b/packages/cf-harness/src/tools/shell-cwd.ts
@@ -1,0 +1,33 @@
+export interface FinalWorkingDirectoryParseResult {
+  stdout: string;
+  cwd?: string;
+}
+
+export const cwdMarkerForOutput = (
+  markerPrefix: string,
+  outputId: string,
+): string => `${markerPrefix}${outputId}__`;
+
+export const commandWithFinalWorkingDirectoryMarker = (
+  command: string,
+  cwdMarker: string,
+): string =>
+  [
+    `__cf_harness_cwd_marker=${JSON.stringify(cwdMarker)}`,
+    'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
+    command,
+  ].join("\n");
+
+export const extractFinalWorkingDirectory = (
+  stdout: string,
+  marker: string,
+): FinalWorkingDirectoryParseResult => {
+  const markerIndex = stdout.lastIndexOf(marker);
+  if (markerIndex === -1) {
+    return { stdout };
+  }
+  return {
+    stdout: stdout.slice(0, markerIndex),
+    cwd: stdout.slice(markerIndex + marker.length),
+  };
+};

--- a/packages/cf-harness/test/shell-cwd.test.ts
+++ b/packages/cf-harness/test/shell-cwd.test.ts
@@ -1,0 +1,44 @@
+import { assertEquals } from "@std/assert";
+import {
+  commandWithFinalWorkingDirectoryMarker,
+  cwdMarkerForOutput,
+  extractFinalWorkingDirectory,
+} from "../src/tools/shell-cwd.ts";
+
+Deno.test("cwdMarkerForOutput builds namespaced output markers", () => {
+  assertEquals(
+    cwdMarkerForOutput("__CF_HARNESS_CWD__", "run-1:bash:1"),
+    "__CF_HARNESS_CWD__run-1:bash:1__",
+  );
+});
+
+Deno.test("commandWithFinalWorkingDirectoryMarker wraps commands with a cwd trap", () => {
+  assertEquals(
+    commandWithFinalWorkingDirectoryMarker("pwd", "__MARKER__"),
+    [
+      '__cf_harness_cwd_marker="__MARKER__"',
+      'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
+      "pwd",
+    ].join("\n"),
+  );
+});
+
+Deno.test("extractFinalWorkingDirectory leaves stdout untouched without a marker", () => {
+  assertEquals(
+    extractFinalWorkingDirectory("plain output\n", "__MARKER__"),
+    { stdout: "plain output\n" },
+  );
+});
+
+Deno.test("extractFinalWorkingDirectory uses the last marker occurrence", () => {
+  assertEquals(
+    extractFinalWorkingDirectory(
+      "user output __MARKER__ still output\n__MARKER__/workspace/repo",
+      "__MARKER__",
+    ),
+    {
+      stdout: "user output __MARKER__ still output\n",
+      cwd: "/workspace/repo",
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- address the cubic review finding from #3427 by extracting shared shell CWD marker/parsing helpers
- update both bash tools to use the shared helper while preserving their distinct marker prefixes
- add direct helper coverage for marker construction, command wrapping, missing markers, and repeated markers

## Test plan
- deno test --allow-read --allow-write --allow-run packages/cf-harness/test/tools-execution.test.ts packages/cf-harness/test/shell-cwd.test.ts
- deno task check (from packages/cf-harness)
- deno task test (from packages/cf-harness)
- git diff --check