### PR TITLE
Restrict cf-harness browser host commands

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -145,7 +145,9 @@ deno task run -- \
 The provisional browser profile is the only CLI-supported path to
 `bash-no-sandbox`. It gives the child a host shell so it can invoke
 `agent-browser`, while the parent still receives only the normal sanitized
-subagent result:
+subagent result. The host shell is policy-restricted to `agent-browser`,
+`agent-browser` discovery (`which agent-browser`, `command -v agent-browser`),
+`pwd`, `ls`, and bounded workspace-local `find` commands:
 
 ```bash
 deno task run -- \

--- a/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
@@ -214,6 +214,21 @@ Why:
 - child prompt explicitly labels host execution as outside the sandbox and
   orients browser-profile children toward `agent-browser`
 
+### Stage J: Browser host command policy
+
+- `bash-no-sandbox` is no longer an arbitrary host shell even inside the browser
+  profile
+- allowed host command shapes:
+  - `agent-browser ...` except host-mutating setup such as
+    `agent-browser install`
+  - `which agent-browser` and `command -v agent-browser`
+  - `pwd`
+  - `ls` with a small read-only flag set and workspace-relative paths
+  - `find` with workspace-relative paths, required bounded `-maxdepth`, and a
+    small read-only predicate set
+- denied host commands return a normal nonzero tool result without invoking the
+  host process runner, and diagnostics classify the denial as `tool_not_allowed`
+
 Why:
 
 - to keep the intended eventual `agent-browser` usage shape: agents invoke it

--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -8,6 +8,10 @@ import type {
 import type { HarnessPolicyEvent } from "./contracts/policy.ts";
 import type { ToolOutputId } from "./contracts/tool-result.ts";
 import type { BashToolInput, BashToolOutput } from "./tools/bash.ts";
+import {
+  BROWSER_HOST_COMMAND_DENIED_EXIT_CODE,
+  BROWSER_HOST_COMMAND_DENIED_PREFIX,
+} from "./tools/browser-host-command-policy.ts";
 import type { DelegateTaskToolOutput } from "./contracts/subagent.ts";
 import {
   isStructuredFileToolErrorOutput,
@@ -425,6 +429,22 @@ export const classifyBashToolFailure = (
   capabilitySnapshot?: HarnessCapabilitySnapshot,
   toolId = "bash",
 ): HarnessFailureRecord | undefined => {
+  if (
+    toolId === "bash-no-sandbox" &&
+    output.exitCode === BROWSER_HOST_COMMAND_DENIED_EXIT_CODE &&
+    output.stderr.startsWith(BROWSER_HOST_COMMAND_DENIED_PREFIX)
+  ) {
+    return createHarnessFailureRecord({
+      kind: "tool_not_allowed",
+      source: "tool_output",
+      detail: output.stderr,
+      at,
+      toolId,
+      outputId: output.outputId as ToolOutputId,
+      command: input.command,
+      exitCode: output.exitCode,
+    });
+  }
   if (output.exitCode !== 127) {
     return undefined;
   }

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -629,17 +629,58 @@ export class CfHarnessEngine {
     );
   }
 
-  async #isHostPathWithinWorkspace(path: string): Promise<boolean> {
+  async #isHostPathWithinWorkspace(
+    path: string,
+    options: { allowMissing?: boolean } = {},
+  ): Promise<boolean> {
     if (this.workspaceHostPath === undefined) {
       return false;
     }
+    const normalizedPath = normalizeHostPath(path);
     try {
       const hostRoot = await Deno.realPath(this.workspaceHostPath);
-      const hostPath = await Deno.realPath(path);
+      const hostPath = await Deno.realPath(normalizedPath);
       return isHostPathWithinRoot(hostRoot, hostPath);
+    } catch (error) {
+      if (!options.allowMissing || !(error instanceof Deno.errors.NotFound)) {
+        return false;
+      }
+      return await this.#missingHostPathCanResolveWithinWorkspace(
+        normalizedPath,
+      );
+    }
+  }
+
+  async #missingHostPathCanResolveWithinWorkspace(path: string): Promise<
+    boolean
+  > {
+    if (this.workspaceHostPath === undefined) {
+      return false;
+    }
+    const lexicalRoot = normalizeHostPath(this.workspaceHostPath);
+    let realRoot: string;
+    try {
+      realRoot = await Deno.realPath(this.workspaceHostPath);
     } catch {
       return false;
     }
+    let candidate = normalizeHostPath(path);
+    while (isHostPathWithinRoot(lexicalRoot, candidate)) {
+      try {
+        const realCandidate = await Deno.realPath(candidate);
+        return isHostPathWithinRoot(realRoot, realCandidate);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          return false;
+        }
+      }
+      const parent = dirname(candidate);
+      if (parent === candidate) {
+        return false;
+      }
+      candidate = parent;
+    }
+    return false;
   }
 
   #createToolContext() {
@@ -654,8 +695,10 @@ export class CfHarnessEngine {
       resolveHostPath: (path: string) => this.#resolveHostPath(path),
       hostPathToWorkspacePath: (path: string) =>
         this.#hostPathToWorkspacePath(path),
-      isHostPathWithinWorkspace: (path: string) =>
-        this.#isHostPathWithinWorkspace(path),
+      isHostPathWithinWorkspace: (
+        path: string,
+        options?: { allowMissing?: boolean },
+      ) => this.#isHostPathWithinWorkspace(path, options),
       setCurrentDir: (path: string) => {
         const resolved = this.sandbox.resolvePath(
           path,

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -629,6 +629,19 @@ export class CfHarnessEngine {
     );
   }
 
+  async #isHostPathWithinWorkspace(path: string): Promise<boolean> {
+    if (this.workspaceHostPath === undefined) {
+      return false;
+    }
+    try {
+      const hostRoot = await Deno.realPath(this.workspaceHostPath);
+      const hostPath = await Deno.realPath(path);
+      return isHostPathWithinRoot(hostRoot, hostPath);
+    } catch {
+      return false;
+    }
+  }
+
   #createToolContext() {
     return {
       runId: this.#runState.runId,
@@ -641,6 +654,8 @@ export class CfHarnessEngine {
       resolveHostPath: (path: string) => this.#resolveHostPath(path),
       hostPathToWorkspacePath: (path: string) =>
         this.#hostPathToWorkspacePath(path),
+      isHostPathWithinWorkspace: (path: string) =>
+        this.#isHostPathWithinWorkspace(path),
       setCurrentDir: (path: string) => {
         const resolved = this.sandbox.resolvePath(
           path,

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -45,6 +45,7 @@ import {
   type HarnessToolPolicyDecision,
 } from "./contracts/run-report.ts";
 import {
+  BROWSER_SUBAGENT_PROFILE,
   DEFAULT_SUBAGENT_PROFILE,
   type DelegateTaskToolInput,
   type DelegateTaskToolOutput,
@@ -530,6 +531,12 @@ const buildSubagentSystemPrompt = (
           profileConfig.hostToolIds.join(", ")
         }`,
         "Host execution is outside the sandbox. Use it only for the delegated task and prefer agent-browser commands when browser access is needed.",
+        ...(profileConfig.profile === BROWSER_SUBAGENT_PROFILE
+          ? [
+            "Browser profile host commands are restricted to agent-browser, agent-browser discovery, pwd, ls, and bounded workspace-local find commands.",
+            "Do not chain host shell commands; call the tool once per host command.",
+          ]
+          : []),
       ]
       : []),
     `Current sandbox directory: ${currentDir}`,

--- a/packages/cf-harness/src/tools/bash-no-sandbox.ts
+++ b/packages/cf-harness/src/tools/bash-no-sandbox.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema } from "@commonfabric/api";
+import { join, normalize } from "@std/path";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { BashToolInput, BashToolOutput } from "./bash.ts";
 import {
@@ -6,14 +7,11 @@ import {
   BROWSER_HOST_COMMAND_DENIED_PREFIX,
   validateBrowserHostCommand,
 } from "./browser-host-command-policy.ts";
-import {
-  commandWithFinalWorkingDirectoryMarker,
-  cwdMarkerForOutput,
-  extractFinalWorkingDirectory,
-} from "./shell-cwd.ts";
-import type { HarnessToolDefinition } from "./types.ts";
+import type { HarnessToolContext, HarnessToolDefinition } from "./types.ts";
 
-const CWD_MARKER_PREFIX = "__CF_HARNESS_HOST_CWD__";
+const DEFAULT_HOST_TIMEOUT_MS = 30_000;
+const MAX_HOST_TIMEOUT_MS = 120_000;
+const MAX_HOST_OUTPUT_CHARS = 20_000;
 
 export const bashNoSandboxToolDescriptor: HarnessToolDescriptor = {
   toolId: "bash-no-sandbox",
@@ -68,27 +66,80 @@ export const bashNoSandboxTool: HarnessToolDefinition<
       };
     }
     const hostCwd = context.resolveHostPath(commandCwd);
-    const cwdMarker = cwdMarkerForOutput(CWD_MARKER_PREFIX, outputId);
+    const plan = policyResult.plan;
+    if (plan === undefined || plan.argv.length === 0) {
+      context.setCurrentDir(commandCwd);
+      return {
+        outputId,
+        stdout: "",
+        stderr:
+          `${BROWSER_HOST_COMMAND_DENIED_PREFIX}: command did not produce an execution plan`,
+        exitCode: BROWSER_HOST_COMMAND_DENIED_EXIT_CODE,
+        cwd: commandCwd,
+      };
+    }
+    const hostPathFailure = await validateHostWorkspacePaths(
+      context,
+      hostCwd,
+      plan.workspacePathArgs,
+    );
+    if (hostPathFailure !== undefined) {
+      context.setCurrentDir(commandCwd);
+      return {
+        outputId,
+        stdout: "",
+        stderr: `${BROWSER_HOST_COMMAND_DENIED_PREFIX}: ${hostPathFailure}`,
+        exitCode: BROWSER_HOST_COMMAND_DENIED_EXIT_CODE,
+        cwd: commandCwd,
+      };
+    }
     const result = await context.hostProcessRunner.run({
-      command: "bash",
-      args: [
-        "-lc",
-        commandWithFinalWorkingDirectoryMarker(input.command, cwdMarker),
-      ],
+      command: plan.argv[0]!,
+      args: [...plan.argv.slice(1)],
       cwd: hostCwd,
-      timeoutMs: input.timeoutMs,
+      timeoutMs: resolveHostTimeoutMs(input.timeoutMs),
     });
-    const parsedResult = extractFinalWorkingDirectory(result.stdout, cwdMarker);
-    const nextCurrentDir = parsedResult.cwd === undefined
-      ? commandCwd
-      : context.hostPathToWorkspacePath(parsedResult.cwd) ?? commandCwd;
-    context.setCurrentDir(nextCurrentDir);
+    context.setCurrentDir(commandCwd);
     return {
       outputId,
-      stdout: parsedResult.stdout,
-      stderr: result.stderr,
+      stdout: truncateHostOutput(result.stdout, "stdout"),
+      stderr: truncateHostOutput(result.stderr, "stderr"),
       exitCode: result.exitCode,
-      cwd: nextCurrentDir,
+      cwd: commandCwd,
     };
   },
+};
+
+const resolveHostTimeoutMs = (timeoutMs: number | undefined): number => {
+  if (timeoutMs === undefined) {
+    return DEFAULT_HOST_TIMEOUT_MS;
+  }
+  return Math.min(Math.max(Math.floor(timeoutMs), 0), MAX_HOST_TIMEOUT_MS);
+};
+
+const truncateHostOutput = (output: string, label: string): string => {
+  if (output.length <= MAX_HOST_OUTPUT_CHARS) {
+    return output;
+  }
+  const omitted = output.length - MAX_HOST_OUTPUT_CHARS;
+  return `${
+    output.slice(0, MAX_HOST_OUTPUT_CHARS)
+  }\n[cf-harness truncated ${label}: ${omitted} chars omitted]`;
+};
+
+const validateHostWorkspacePaths = async (
+  context: HarnessToolContext,
+  hostCwd: string,
+  workspacePathArgs: readonly string[],
+): Promise<string | undefined> => {
+  if (!(await context.isHostPathWithinWorkspace(hostCwd))) {
+    return `cwd ${hostCwd} must resolve within the workspace`;
+  }
+  for (const pathArg of workspacePathArgs) {
+    const hostPath = normalize(join(hostCwd, pathArg));
+    if (!(await context.isHostPathWithinWorkspace(hostPath))) {
+      return `path ${pathArg} must resolve within the workspace`;
+    }
+  }
+  return undefined;
 };

--- a/packages/cf-harness/src/tools/bash-no-sandbox.ts
+++ b/packages/cf-harness/src/tools/bash-no-sandbox.ts
@@ -137,8 +137,12 @@ const validateHostWorkspacePaths = async (
   }
   for (const pathArg of workspacePathArgs) {
     const hostPath = normalize(join(hostCwd, pathArg));
-    if (!(await context.isHostPathWithinWorkspace(hostPath))) {
-      return `path ${pathArg} must resolve within the workspace`;
+    if (
+      !(await context.isHostPathWithinWorkspace(hostPath, {
+        allowMissing: true,
+      }))
+    ) {
+      return `path ${pathArg} must resolve within or below the workspace`;
     }
   }
   return undefined;

--- a/packages/cf-harness/src/tools/bash-no-sandbox.ts
+++ b/packages/cf-harness/src/tools/bash-no-sandbox.ts
@@ -2,6 +2,11 @@ import type { JSONSchema } from "@commonfabric/api";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { BashToolInput, BashToolOutput } from "./bash.ts";
 import {
+  BROWSER_HOST_COMMAND_DENIED_EXIT_CODE,
+  BROWSER_HOST_COMMAND_DENIED_PREFIX,
+  validateBrowserHostCommand,
+} from "./browser-host-command-policy.ts";
+import {
   commandWithFinalWorkingDirectoryMarker,
   cwdMarkerForOutput,
   extractFinalWorkingDirectory,
@@ -14,7 +19,7 @@ export const bashNoSandboxToolDescriptor: HarnessToolDescriptor = {
   toolId: "bash-no-sandbox",
   title: "Bash (No Sandbox)",
   description:
-    "PROVISIONAL HOST SHELL. Runs a bash command outside the sandbox on the host workspace. Intended only for the browser subagent profile, especially invoking agent-browser; do not use for normal repository work.",
+    "PROVISIONAL BROWSER HOST COMMAND TOOL. Runs policy-restricted commands outside the sandbox on the host workspace. Intended only for the browser subagent profile, especially invoking agent-browser; do not use for normal repository work.",
   effectClass: "side-effect",
   inputSchema: {
     type: "object",
@@ -51,6 +56,17 @@ export const bashNoSandboxTool: HarnessToolDefinition<
     const commandCwd = input.cwd !== undefined
       ? context.resolvePath(input.cwd)
       : context.currentDir;
+    const policyResult = validateBrowserHostCommand(input.command);
+    if (!policyResult.allowed) {
+      context.setCurrentDir(commandCwd);
+      return {
+        outputId,
+        stdout: "",
+        stderr: `${BROWSER_HOST_COMMAND_DENIED_PREFIX}: ${policyResult.reason}`,
+        exitCode: BROWSER_HOST_COMMAND_DENIED_EXIT_CODE,
+        cwd: commandCwd,
+      };
+    }
     const hostCwd = context.resolveHostPath(commandCwd);
     const cwdMarker = cwdMarkerForOutput(CWD_MARKER_PREFIX, outputId);
     const result = await context.hostProcessRunner.run({

--- a/packages/cf-harness/src/tools/browser-host-command-policy.ts
+++ b/packages/cf-harness/src/tools/browser-host-command-policy.ts
@@ -103,6 +103,7 @@ const DISALLOWED_AGENT_BROWSER_COMMANDS = new Set([
   "profiler",
   "record",
   "screenshot",
+  "state",
   "trace",
   "upload",
 ]);

--- a/packages/cf-harness/src/tools/browser-host-command-policy.ts
+++ b/packages/cf-harness/src/tools/browser-host-command-policy.ts
@@ -1,6 +1,12 @@
 export interface BrowserHostCommandPolicyResult {
   allowed: boolean;
   reason?: string;
+  plan?: BrowserHostCommandPlan;
+}
+
+export interface BrowserHostCommandPlan {
+  argv: readonly string[];
+  workspacePathArgs: readonly string[];
 }
 
 export const BROWSER_HOST_COMMAND_DENIED_EXIT_CODE = 126;
@@ -29,7 +35,7 @@ export const validateBrowserHostCommand = (
       return validateLsCommand(args);
     case "pwd":
       return args.length === 0
-        ? allow()
+        ? allow(["pwd"])
         : deny("pwd does not accept arguments in the browser host profile");
     case "which":
       return validateWhichCommand(args);
@@ -42,7 +48,16 @@ export const validateBrowserHostCommand = (
   }
 };
 
-const allow = (): BrowserHostCommandPolicyResult => ({ allowed: true });
+const allow = (
+  argv: readonly string[],
+  workspacePathArgs: readonly string[] = [],
+): BrowserHostCommandPolicyResult => ({
+  allowed: true,
+  plan: {
+    argv: [...argv],
+    workspacePathArgs: [...workspacePathArgs],
+  },
+});
 
 const deny = (reason: string): BrowserHostCommandPolicyResult => ({
   allowed: false,
@@ -52,29 +67,116 @@ const deny = (reason: string): BrowserHostCommandPolicyResult => ({
 const validateAgentBrowserCommand = (
   args: readonly string[],
 ): BrowserHostCommandPolicyResult => {
-  if (args[0] === "install") {
-    return deny("agent-browser install is not allowed from cf-harness");
+  for (const arg of args) {
+    const flag = normalizeLongFlag(arg);
+    if (
+      DISALLOWED_AGENT_BROWSER_FLAGS.has(flag) ||
+      isDisallowedAgentBrowserShortFlag(arg)
+    ) {
+      return deny(`agent-browser flag ${flag} is not allowed from cf-harness`);
+    }
   }
-  return allow();
+
+  const command = findAgentBrowserSubcommand(args);
+  if (command !== undefined) {
+    if (DISALLOWED_AGENT_BROWSER_COMMANDS.has(command.name)) {
+      return deny(
+        `agent-browser ${command.name} is not allowed from cf-harness`,
+      );
+    }
+    if (
+      command.name === "open" &&
+      args.slice(command.index + 1).some((arg) => /^file:/i.test(arg))
+    ) {
+      return deny("agent-browser open file: URLs are not allowed");
+    }
+  }
+  return allow([AGENT_BROWSER_COMMAND, ...args]);
+};
+
+const DISALLOWED_AGENT_BROWSER_COMMANDS = new Set([
+  "connect",
+  "download",
+  "eval",
+  "install",
+  "pdf",
+  "profiler",
+  "record",
+  "screenshot",
+  "trace",
+  "upload",
+]);
+
+const DISALLOWED_AGENT_BROWSER_FLAGS = new Set([
+  "--allow-file-access",
+  "--args",
+  "--auto-connect",
+  "--cdp",
+  "--config",
+  "--device",
+  "--executable-path",
+  "--extension",
+  "--headers",
+  "--ignore-https-errors",
+  "--profile",
+  "--provider",
+  "--proxy",
+  "--proxy-bypass",
+  "--state",
+  "--user-agent",
+]);
+
+const AGENT_BROWSER_VALUE_FLAGS = new Set([
+  "--session",
+  "--session-name",
+]);
+
+const normalizeLongFlag = (arg: string): string => {
+  if (!arg.startsWith("--")) {
+    return arg;
+  }
+  const equalsIndex = arg.indexOf("=");
+  return equalsIndex === -1 ? arg : arg.slice(0, equalsIndex);
+};
+
+const isDisallowedAgentBrowserShortFlag = (arg: string): boolean =>
+  arg === "-p" || arg.startsWith("-p=");
+
+const findAgentBrowserSubcommand = (
+  args: readonly string[],
+): { name: string; index: number } | undefined => {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (arg.startsWith("-")) {
+      const flag = normalizeLongFlag(arg);
+      if (AGENT_BROWSER_VALUE_FLAGS.has(flag) && !arg.includes("=")) {
+        index += 1;
+      }
+      continue;
+    }
+    return { name: arg, index };
+  }
+  return undefined;
 };
 
 const validateCommandBuiltin = (
   args: readonly string[],
 ): BrowserHostCommandPolicyResult =>
   args.length === 2 && args[0] === "-v" && args[1] === AGENT_BROWSER_COMMAND
-    ? allow()
+    ? allow(["which", AGENT_BROWSER_COMMAND])
     : deny("only command -v agent-browser is allowed");
 
 const validateWhichCommand = (
   args: readonly string[],
 ): BrowserHostCommandPolicyResult =>
   args.length === 1 && args[0] === AGENT_BROWSER_COMMAND
-    ? allow()
+    ? allow(["which", AGENT_BROWSER_COMMAND])
     : deny("only which agent-browser is allowed");
 
 const validateLsCommand = (
   args: readonly string[],
 ): BrowserHostCommandPolicyResult => {
+  const workspacePathArgs: string[] = [];
   for (const arg of args) {
     if (arg.startsWith("-")) {
       if (!/^-[alhF1d]+$/.test(arg)) {
@@ -85,8 +187,9 @@ const validateLsCommand = (
     if (!isSafeWorkspaceRelativePath(arg)) {
       return deny(`ls path ${arg} must stay within the workspace`);
     }
+    workspacePathArgs.push(arg);
   }
-  return allow();
+  return allow(["ls", ...args], workspacePathArgs);
 };
 
 const validateFindCommand = (
@@ -98,6 +201,7 @@ const validateFindCommand = (
   let sawSearchPath = false;
   let sawMaxDepth = false;
   let index = 0;
+  const workspacePathArgs: string[] = [];
   while (index < args.length) {
     const arg = args[index]!;
     if (!arg.startsWith("-")) {
@@ -107,6 +211,7 @@ const validateFindCommand = (
       if (!isSafeWorkspaceRelativePath(arg)) {
         return deny(`find path ${arg} must stay within the workspace`);
       }
+      workspacePathArgs.push(arg);
       sawSearchPath = true;
       index += 1;
       continue;
@@ -172,7 +277,7 @@ const validateFindCommand = (
   if (!sawMaxDepth) {
     return deny("find must include -maxdepth");
   }
-  return allow();
+  return allow(["find", ...args], workspacePathArgs);
 };
 
 const parseBoundedInteger = (input: string | undefined): number | undefined => {

--- a/packages/cf-harness/src/tools/browser-host-command-policy.ts
+++ b/packages/cf-harness/src/tools/browser-host-command-policy.ts
@@ -241,6 +241,12 @@ const parseSimpleShellCommand = (command: string): SimpleShellParseResult => {
       }
       continue;
     }
+    if (isDisallowedUnquotedShellExpansionSyntax(char)) {
+      return {
+        error:
+          "unquoted shell expansion syntax is not allowed; quote literal selectors, URLs, and patterns",
+      };
+    }
     if (isDisallowedShellSyntax(char)) {
       return {
         error:
@@ -263,6 +269,14 @@ const parseSimpleShellCommand = (command: string): SimpleShellParseResult => {
 
 const isDisallowedShellExpansionSyntax = (char: string): boolean =>
   char === "`" || char === "$" || char === "\\";
+
+const isDisallowedUnquotedShellExpansionSyntax = (char: string): boolean =>
+  char === "{" ||
+  char === "}" ||
+  char === "[" ||
+  char === "]" ||
+  char === "*" ||
+  char === "?";
 
 const isDisallowedShellSyntax = (char: string): boolean =>
   char === "|" ||

--- a/packages/cf-harness/src/tools/browser-host-command-policy.ts
+++ b/packages/cf-harness/src/tools/browser-host-command-policy.ts
@@ -1,0 +1,276 @@
+export interface BrowserHostCommandPolicyResult {
+  allowed: boolean;
+  reason?: string;
+}
+
+export const BROWSER_HOST_COMMAND_DENIED_EXIT_CODE = 126;
+export const BROWSER_HOST_COMMAND_DENIED_PREFIX =
+  "bash-no-sandbox command denied";
+
+const AGENT_BROWSER_COMMAND = "agent-browser";
+const MAX_FIND_DEPTH = 5;
+
+export const validateBrowserHostCommand = (
+  command: string,
+): BrowserHostCommandPolicyResult => {
+  const parsed = parseSimpleShellCommand(command);
+  if (parsed.error !== undefined) {
+    return deny(parsed.error);
+  }
+  const [commandName, ...args] = parsed.tokens;
+  switch (commandName) {
+    case AGENT_BROWSER_COMMAND:
+      return validateAgentBrowserCommand(args);
+    case "command":
+      return validateCommandBuiltin(args);
+    case "find":
+      return validateFindCommand(args);
+    case "ls":
+      return validateLsCommand(args);
+    case "pwd":
+      return args.length === 0
+        ? allow()
+        : deny("pwd does not accept arguments in the browser host profile");
+    case "which":
+      return validateWhichCommand(args);
+    default:
+      return deny(
+        `${
+          commandName ?? "empty command"
+        } is not allowed in the browser host profile`,
+      );
+  }
+};
+
+const allow = (): BrowserHostCommandPolicyResult => ({ allowed: true });
+
+const deny = (reason: string): BrowserHostCommandPolicyResult => ({
+  allowed: false,
+  reason,
+});
+
+const validateAgentBrowserCommand = (
+  args: readonly string[],
+): BrowserHostCommandPolicyResult => {
+  if (args[0] === "install") {
+    return deny("agent-browser install is not allowed from cf-harness");
+  }
+  return allow();
+};
+
+const validateCommandBuiltin = (
+  args: readonly string[],
+): BrowserHostCommandPolicyResult =>
+  args.length === 2 && args[0] === "-v" && args[1] === AGENT_BROWSER_COMMAND
+    ? allow()
+    : deny("only command -v agent-browser is allowed");
+
+const validateWhichCommand = (
+  args: readonly string[],
+): BrowserHostCommandPolicyResult =>
+  args.length === 1 && args[0] === AGENT_BROWSER_COMMAND
+    ? allow()
+    : deny("only which agent-browser is allowed");
+
+const validateLsCommand = (
+  args: readonly string[],
+): BrowserHostCommandPolicyResult => {
+  for (const arg of args) {
+    if (arg.startsWith("-")) {
+      if (!/^-[alhF1d]+$/.test(arg)) {
+        return deny(`ls flag ${arg} is not allowed`);
+      }
+      continue;
+    }
+    if (!isSafeWorkspaceRelativePath(arg)) {
+      return deny(`ls path ${arg} must stay within the workspace`);
+    }
+  }
+  return allow();
+};
+
+const validateFindCommand = (
+  args: readonly string[],
+): BrowserHostCommandPolicyResult => {
+  if (args.length === 0) {
+    return deny("find must include a workspace-relative search path");
+  }
+  let sawSearchPath = false;
+  let sawMaxDepth = false;
+  let index = 0;
+  while (index < args.length) {
+    const arg = args[index]!;
+    if (!arg.startsWith("-")) {
+      if (sawMaxDepth) {
+        return deny(`unexpected find argument ${arg}`);
+      }
+      if (!isSafeWorkspaceRelativePath(arg)) {
+        return deny(`find path ${arg} must stay within the workspace`);
+      }
+      sawSearchPath = true;
+      index += 1;
+      continue;
+    }
+    switch (arg) {
+      case "-maxdepth": {
+        const depth = parseBoundedInteger(args[index + 1]);
+        if (depth === undefined || depth > MAX_FIND_DEPTH) {
+          return deny(
+            `find -maxdepth must be an integer from 0 to ${MAX_FIND_DEPTH}`,
+          );
+        }
+        sawMaxDepth = true;
+        index += 2;
+        break;
+      }
+      case "-mindepth": {
+        const depth = parseBoundedInteger(args[index + 1]);
+        if (depth === undefined || depth > MAX_FIND_DEPTH) {
+          return deny(
+            `find -mindepth must be an integer from 0 to ${MAX_FIND_DEPTH}`,
+          );
+        }
+        index += 2;
+        break;
+      }
+      case "-type": {
+        const type = args[index + 1];
+        if (type !== "f" && type !== "d" && type !== "l") {
+          return deny("find -type must be one of f, d, or l");
+        }
+        index += 2;
+        break;
+      }
+      case "-name":
+      case "-iname": {
+        const pattern = args[index + 1];
+        if (pattern === undefined || pattern === "" || pattern.includes("/")) {
+          return deny(`${arg} must use a non-empty basename pattern`);
+        }
+        index += 2;
+        break;
+      }
+      case "-path":
+      case "-ipath": {
+        const pattern = args[index + 1];
+        if (pattern === undefined || !isSafeWorkspaceRelativePattern(pattern)) {
+          return deny(`${arg} pattern must stay within the workspace`);
+        }
+        index += 2;
+        break;
+      }
+      case "-print":
+        index += 1;
+        break;
+      default:
+        return deny(`find predicate ${arg} is not allowed`);
+    }
+  }
+  if (!sawSearchPath) {
+    return deny("find must include a workspace-relative search path");
+  }
+  if (!sawMaxDepth) {
+    return deny("find must include -maxdepth");
+  }
+  return allow();
+};
+
+const parseBoundedInteger = (input: string | undefined): number | undefined => {
+  if (input === undefined || !/^\d+$/.test(input)) {
+    return undefined;
+  }
+  return Number.parseInt(input, 10);
+};
+
+const isSafeWorkspaceRelativePattern = (pattern: string): boolean =>
+  pattern !== "" &&
+  !pattern.startsWith("/") &&
+  !pattern.startsWith("~") &&
+  !pathSegments(pattern).includes("..");
+
+const isSafeWorkspaceRelativePath = (path: string): boolean =>
+  path === "." || path === "./" ||
+  (path !== "" &&
+    !path.startsWith("-") &&
+    !path.startsWith("/") &&
+    !path.startsWith("~") &&
+    !path.includes("*") &&
+    !path.includes("?") &&
+    !pathSegments(path).includes(".."));
+
+const pathSegments = (path: string): string[] =>
+  path.split("/").filter((segment) => segment.length > 0);
+
+type SimpleShellParseResult =
+  | { tokens: string[]; error?: undefined }
+  | { tokens?: undefined; error: string };
+
+const parseSimpleShellCommand = (command: string): SimpleShellParseResult => {
+  const input = command.trim();
+  if (input === "") {
+    return { error: "empty commands are not allowed" };
+  }
+  if (/[\n\r\0]/.test(input)) {
+    return { error: "multi-line commands are not allowed" };
+  }
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index]!;
+    if (quote !== undefined) {
+      if (char === quote) {
+        quote = undefined;
+      } else if (isDisallowedShellExpansionSyntax(char)) {
+        return {
+          error: "shell substitutions and escaped commands are not allowed",
+        };
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current !== "") {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    if (isDisallowedShellSyntax(char)) {
+      return {
+        error:
+          "shell operators, substitutions, redirects, and escaped commands are not allowed",
+      };
+    }
+    current += char;
+  }
+  if (quote !== undefined) {
+    return { error: "unterminated quoted argument" };
+  }
+  if (current !== "") {
+    tokens.push(current);
+  }
+  if (tokens.length === 0) {
+    return { error: "empty commands are not allowed" };
+  }
+  return { tokens };
+};
+
+const isDisallowedShellExpansionSyntax = (char: string): boolean =>
+  char === "`" || char === "$" || char === "\\";
+
+const isDisallowedShellSyntax = (char: string): boolean =>
+  char === "|" ||
+  char === "&" ||
+  char === ";" ||
+  char === "<" ||
+  char === ">" ||
+  char === "(" ||
+  char === ")" ||
+  isDisallowedShellExpansionSyntax(char) ||
+  char === "#";

--- a/packages/cf-harness/src/tools/browser-host-command-policy.ts
+++ b/packages/cf-harness/src/tools/browser-host-command-policy.ts
@@ -140,7 +140,7 @@ const normalizeLongFlag = (arg: string): string => {
 };
 
 const isDisallowedAgentBrowserShortFlag = (arg: string): boolean =>
-  arg === "-p" || arg.startsWith("-p=");
+  arg === "-p" || arg.startsWith("-p=") || /^-p[^-]/.test(arg);
 
 const findAgentBrowserSubcommand = (
   args: readonly string[],

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -13,7 +13,10 @@ export interface HarnessToolContext {
   resolvePath(path: string): string;
   resolveHostPath(path: string): string;
   hostPathToWorkspacePath(path: string): string | undefined;
-  isHostPathWithinWorkspace(path: string): Promise<boolean>;
+  isHostPathWithinWorkspace(
+    path: string,
+    options?: { allowMissing?: boolean },
+  ): Promise<boolean>;
   setCurrentDir(path: string): void;
   nextOutputId(toolId: string): ToolOutputId;
 }

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -13,6 +13,7 @@ export interface HarnessToolContext {
   resolvePath(path: string): string;
   resolveHostPath(path: string): string;
   hostPathToWorkspacePath(path: string): string | undefined;
+  isHostPathWithinWorkspace(path: string): Promise<boolean>;
   setCurrentDir(path: string): void;
   nextOutputId(toolId: string): ToolOutputId;
 }

--- a/packages/cf-harness/test/browser-host-command-policy.test.ts
+++ b/packages/cf-harness/test/browser-host-command-policy.test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "@std/assert";
 import { validateBrowserHostCommand } from "../src/tools/browser-host-command-policy.ts";
 
 const assertAllowed = (command: string) => {
-  assertEquals(validateBrowserHostCommand(command), { allowed: true });
+  assertEquals(validateBrowserHostCommand(command).allowed, true);
 };
 
 const assertDenied = (command: string) => {
@@ -17,8 +17,20 @@ Deno.test("validateBrowserHostCommand allows agent-browser invocations", () => {
 });
 
 Deno.test("validateBrowserHostCommand allows agent-browser discovery", () => {
-  assertAllowed("which agent-browser");
-  assertAllowed("command -v agent-browser");
+  assertEquals(validateBrowserHostCommand("which agent-browser"), {
+    allowed: true,
+    plan: {
+      argv: ["which", "agent-browser"],
+      workspacePathArgs: [],
+    },
+  });
+  assertEquals(validateBrowserHostCommand("command -v agent-browser"), {
+    allowed: true,
+    plan: {
+      argv: ["which", "agent-browser"],
+      workspacePathArgs: [],
+    },
+  });
 });
 
 Deno.test("validateBrowserHostCommand allows minimal workspace read commands", () => {
@@ -69,4 +81,15 @@ Deno.test("validateBrowserHostCommand keeps ls and find within the workspace", (
 
 Deno.test("validateBrowserHostCommand rejects host-mutating agent-browser setup", () => {
   assertDenied("agent-browser install");
+});
+
+Deno.test("validateBrowserHostCommand rejects high-risk agent-browser host surfaces", () => {
+  assertDenied("agent-browser eval 'location.href'");
+  assertDenied("agent-browser upload '#file' ./secret.txt");
+  assertDenied("agent-browser screenshot page.png");
+  assertDenied("agent-browser open file:///etc/passwd");
+  assertDenied("agent-browser --cdp 9222 snapshot");
+  assertDenied("agent-browser --extension ./extension snapshot");
+  assertDenied("agent-browser -p ios snapshot");
+  assertDenied("agent-browser -p=ios snapshot");
 });

--- a/packages/cf-harness/test/browser-host-command-policy.test.ts
+++ b/packages/cf-harness/test/browser-host-command-policy.test.ts
@@ -1,0 +1,62 @@
+import { assertEquals } from "@std/assert";
+import { validateBrowserHostCommand } from "../src/tools/browser-host-command-policy.ts";
+
+const assertAllowed = (command: string) => {
+  assertEquals(validateBrowserHostCommand(command), { allowed: true });
+};
+
+const assertDenied = (command: string) => {
+  assertEquals(validateBrowserHostCommand(command).allowed, false);
+};
+
+Deno.test("validateBrowserHostCommand allows agent-browser invocations", () => {
+  assertAllowed("agent-browser --help");
+  assertAllowed('agent-browser open "https://example.com/?a=1&b=2"');
+  assertAllowed('agent-browser find role button click "Submit"');
+});
+
+Deno.test("validateBrowserHostCommand allows agent-browser discovery", () => {
+  assertAllowed("which agent-browser");
+  assertAllowed("command -v agent-browser");
+});
+
+Deno.test("validateBrowserHostCommand allows minimal workspace read commands", () => {
+  assertAllowed("pwd");
+  assertAllowed("ls -lah .");
+  assertAllowed("ls src/tools");
+  assertAllowed('find . -maxdepth 2 -type f -name "*.ts" -print');
+  assertAllowed("find src -maxdepth 3 -type d -print");
+});
+
+Deno.test("validateBrowserHostCommand rejects arbitrary shell commands", () => {
+  assertDenied("git status");
+  assertDenied("cat /etc/passwd");
+  assertDenied("env");
+  assertDenied("python -c 'print(1)'");
+});
+
+Deno.test("validateBrowserHostCommand rejects shell operators and substitutions", () => {
+  assertDenied("agent-browser open example.com && agent-browser snapshot");
+  assertDenied("agent-browser open $(cat url.txt)");
+  assertDenied('agent-browser open "$SECRET_URL"');
+  assertDenied("agent-browser open `cat url.txt`");
+  assertDenied("agent-browser snapshot > page.txt");
+  assertDenied("agent-browser snapshot\nls");
+});
+
+Deno.test("validateBrowserHostCommand keeps ls and find within the workspace", () => {
+  assertDenied("ls /tmp");
+  assertDenied("ls ../secrets");
+  assertDenied("ls ~/Desktop");
+  assertDenied("find /tmp -maxdepth 1 -type f -print");
+  assertDenied("find .. -maxdepth 1 -type f -print");
+  assertDenied("find . -type f -print");
+  assertDenied("find . -maxdepth 6 -type f -print");
+  assertDenied("find . -maxdepth 2 -delete");
+  assertDenied("find . -maxdepth 2 -exec cat {} ;");
+  assertDenied("ls -R .");
+});
+
+Deno.test("validateBrowserHostCommand rejects host-mutating agent-browser setup", () => {
+  assertDenied("agent-browser install");
+});

--- a/packages/cf-harness/test/browser-host-command-policy.test.ts
+++ b/packages/cf-harness/test/browser-host-command-policy.test.ts
@@ -13,6 +13,7 @@ Deno.test("validateBrowserHostCommand allows agent-browser invocations", () => {
   assertAllowed("agent-browser --help");
   assertAllowed('agent-browser open "https://example.com/?a=1&b=2"');
   assertAllowed('agent-browser find role button click "Submit"');
+  assertAllowed(`agent-browser click 'button[aria-label="Close"]'`);
 });
 
 Deno.test("validateBrowserHostCommand allows agent-browser discovery", () => {
@@ -42,6 +43,15 @@ Deno.test("validateBrowserHostCommand rejects shell operators and substitutions"
   assertDenied("agent-browser open `cat url.txt`");
   assertDenied("agent-browser snapshot > page.txt");
   assertDenied("agent-browser snapshot\nls");
+});
+
+Deno.test("validateBrowserHostCommand rejects unquoted shell expansion syntax", () => {
+  assertDenied("ls {.,..}");
+  assertDenied("ls [.][.]");
+  assertDenied("find {.,..} -maxdepth 1 -type d -print");
+  assertDenied("find . -maxdepth 2 -type f -name *.ts -print");
+  assertDenied("agent-browser open https://example.com/?a=1");
+  assertDenied("agent-browser click button[aria-label=Close]");
 });
 
 Deno.test("validateBrowserHostCommand keeps ls and find within the workspace", () => {

--- a/packages/cf-harness/test/browser-host-command-policy.test.ts
+++ b/packages/cf-harness/test/browser-host-command-policy.test.ts
@@ -92,4 +92,5 @@ Deno.test("validateBrowserHostCommand rejects high-risk agent-browser host surfa
   assertDenied("agent-browser --extension ./extension snapshot");
   assertDenied("agent-browser -p ios snapshot");
   assertDenied("agent-browser -p=ios snapshot");
+  assertDenied("agent-browser -pbrowserbase snapshot");
 });

--- a/packages/cf-harness/test/browser-host-command-policy.test.ts
+++ b/packages/cf-harness/test/browser-host-command-policy.test.ts
@@ -87,6 +87,8 @@ Deno.test("validateBrowserHostCommand rejects high-risk agent-browser host surfa
   assertDenied("agent-browser eval 'location.href'");
   assertDenied("agent-browser upload '#file' ./secret.txt");
   assertDenied("agent-browser screenshot page.png");
+  assertDenied("agent-browser state save ./browser-state.json");
+  assertDenied("agent-browser --session demo state load ./browser-state.json");
   assertDenied("agent-browser open file:///etc/passwd");
   assertDenied("agent-browser --cdp 9222 snapshot");
   assertDenied("agent-browser --extension ./extension snapshot");

--- a/packages/cf-harness/test/diagnostics.test.ts
+++ b/packages/cf-harness/test/diagnostics.test.ts
@@ -237,6 +237,35 @@ Deno.test("classifyBuiltinToolFailure records host shell failures without sandbo
   });
 });
 
+Deno.test("classifyBuiltinToolFailure records denied browser host commands", () => {
+  const failure = classifyBuiltinToolFailure(
+    "bash-no-sandbox",
+    { command: "git status" },
+    {
+      outputId: createToolOutputId("run-host", "bash-no-sandbox", 1),
+      stdout: "",
+      stderr:
+        "bash-no-sandbox command denied: git is not allowed in the browser host profile",
+      exitCode: 126,
+      cwd: "/workspace",
+    },
+    "2026-04-23T18:26:00.000Z",
+  );
+
+  assertEquals(failure, {
+    type: "cf-harness.failure-record",
+    kind: "tool_not_allowed",
+    source: "tool_output",
+    detail:
+      "bash-no-sandbox command denied: git is not allowed in the browser host profile",
+    at: "2026-04-23T18:26:00.000Z",
+    toolId: "bash-no-sandbox",
+    outputId: createToolOutputId("run-host", "bash-no-sandbox", 1),
+    command: "git status",
+    exitCode: 126,
+  });
+});
+
 Deno.test("classifyBuiltinToolFailure handles delegate_task outputs defensively", () => {
   assertEquals(
     classifyBuiltinToolFailure(

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -9,6 +9,11 @@ import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import type { HarnessRunState } from "../src/run-state.ts";
 import type {
+  ProcessRunner,
+  ProcessRunRequest,
+  ProcessRunResult,
+} from "../src/sandbox/process-runner.ts";
+import type {
   SandboxCommandRequest,
   SandboxCommandResult,
   SandboxRuntime,
@@ -66,6 +71,25 @@ class FakeSandboxRuntime implements SandboxRuntime {
   }
 }
 
+class FakeProcessRunner implements ProcessRunner {
+  readonly calls: ProcessRunRequest[] = [];
+
+  constructor(
+    private readonly results: ProcessRunResult[] = [{
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    }],
+  ) {}
+
+  run(request: ProcessRunRequest): Promise<ProcessRunResult> {
+    this.calls.push(request);
+    return Promise.resolve(
+      this.results.shift() ?? { stdout: "", stderr: "", exitCode: 0 },
+    );
+  }
+}
+
 Deno.test("CfHarnessEngine builds a default docker-runsc sandbox when given a workspace path", () => {
   const engine = new CfHarnessEngine({
     workspaceHostPath: "/host/project",
@@ -84,6 +108,80 @@ Deno.test("CfHarnessEngine builds a default docker-runsc sandbox when given a wo
     policyEvents: [],
     toolOutputs: [],
     failureRecords: [],
+  });
+});
+
+Deno.test("CfHarnessEngine lets bash-no-sandbox host commands handle missing workspace paths", async () => {
+  const workspaceHostPath = await Deno.makeTempDir({
+    prefix: "cf-harness-engine-missing-",
+  });
+  const runner = new FakeProcessRunner([{
+    stdout: "",
+    stderr: "ls: missing.txt: No such file or directory\n",
+    exitCode: 1,
+  }]);
+  const engine = new CfHarnessEngine({
+    runId: "run-1",
+    workspaceHostPath,
+    sandboxRuntime: new FakeSandboxRuntime(),
+    processRunner: runner,
+    cfcEnforcementMode: "observe",
+    now: () => "2026-04-29T23:20:00.000Z",
+  });
+
+  const result = await engine.invokeBuiltinTool("bash-no-sandbox", {
+    command: "ls missing.txt",
+  });
+
+  assertEquals(runner.calls, [{
+    command: "ls",
+    args: ["missing.txt"],
+    cwd: workspaceHostPath,
+    timeoutMs: 30_000,
+  }]);
+  assertEquals(result.output, {
+    outputId: "run-1:bash-no-sandbox:1",
+    stdout: "",
+    stderr: "ls: missing.txt: No such file or directory\n",
+    exitCode: 1,
+    cwd: "/workspace",
+  });
+});
+
+Deno.test("CfHarnessEngine denies bash-no-sandbox missing paths below escaping symlinks", async () => {
+  const workspaceHostPath = await Deno.makeTempDir({
+    prefix: "cf-harness-engine-workspace-",
+  });
+  const outsideHostPath = await Deno.makeTempDir({
+    prefix: "cf-harness-engine-outside-",
+  });
+  await Deno.symlink(
+    outsideHostPath,
+    `${workspaceHostPath}/outside-link`,
+    { type: "dir" },
+  );
+  const runner = new FakeProcessRunner();
+  const engine = new CfHarnessEngine({
+    runId: "run-1",
+    workspaceHostPath,
+    sandboxRuntime: new FakeSandboxRuntime(),
+    processRunner: runner,
+    cfcEnforcementMode: "observe",
+    now: () => "2026-04-29T23:20:00.000Z",
+  });
+
+  const result = await engine.invokeBuiltinTool("bash-no-sandbox", {
+    command: "ls outside-link/missing.txt",
+  });
+
+  assertEquals(runner.calls, []);
+  assertEquals(result.output, {
+    outputId: "run-1:bash-no-sandbox:1",
+    stdout: "",
+    stderr:
+      "bash-no-sandbox command denied: path outside-link/missing.txt must resolve within or below the workspace",
+    exitCode: 126,
+    cwd: "/workspace",
   });
 });
 

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -217,11 +217,35 @@ Deno.test("bash-no-sandbox keeps currentDir inside the workspace if the host com
     hostRunner,
   );
   const output = await bashNoSandboxTool.invoke(context, {
-    command: "cd /tmp/outside",
+    command: "agent-browser --help",
   });
 
   assertEquals(output.cwd, "/workspace/repo");
   assertEquals(context.currentDir, "/workspace/repo");
+});
+
+Deno.test("bash-no-sandbox denies host commands outside the browser policy", async () => {
+  const hostRunner = new FakeProcessRunner();
+  const context = createContext(
+    new FakeSandboxRuntime(),
+    "/workspace/repo",
+    hostRunner,
+  );
+  const output = await bashNoSandboxTool.invoke(context, {
+    command: "git status",
+    cwd: "browser",
+  });
+
+  assertEquals(hostRunner.calls, []);
+  assertEquals(output, {
+    outputId: "run-1:bash-no-sandbox:1",
+    stdout: "",
+    stderr:
+      "bash-no-sandbox command denied: git is not allowed in the browser host profile",
+    exitCode: 126,
+    cwd: "/workspace/repo/browser",
+  });
+  assertEquals(context.currentDir, "/workspace/repo/browser");
 });
 
 Deno.test("read_file tool resolves relative paths from the session currentDir", async () => {

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -294,6 +294,45 @@ Deno.test("bash-no-sandbox translates command -v agent-browser to direct argv", 
   }]);
 });
 
+Deno.test("bash-no-sandbox lets allowed host commands handle missing workspace paths", async () => {
+  const hostRunner = new FakeProcessRunner([{
+    stdout: "",
+    stderr: "ls: missing.txt: No such file or directory\n",
+    exitCode: 1,
+  }]);
+  const context = createContext(
+    new FakeSandboxRuntime(),
+    "/workspace/repo",
+    hostRunner,
+  );
+  context.isHostPathWithinWorkspace = (
+    path: string,
+    options?: { allowMissing?: boolean },
+  ) =>
+    Promise.resolve(
+      path === "/tmp/cf-harness-workspace/repo" ||
+        (path.endsWith("/missing.txt") && options?.allowMissing === true),
+    );
+
+  const output = await bashNoSandboxTool.invoke(context, {
+    command: "ls missing.txt",
+  });
+
+  assertEquals(hostRunner.calls, [{
+    command: "ls",
+    args: ["missing.txt"],
+    cwd: "/tmp/cf-harness-workspace/repo",
+    timeoutMs: 30_000,
+  }]);
+  assertEquals(output, {
+    outputId: "run-1:bash-no-sandbox:1",
+    stdout: "",
+    stderr: "ls: missing.txt: No such file or directory\n",
+    exitCode: 1,
+    cwd: "/workspace/repo",
+  });
+});
+
 Deno.test("bash-no-sandbox denies ls and find paths that realpath outside the workspace", async () => {
   const hostRunner = new FakeProcessRunner();
   const context = createContext(
@@ -313,7 +352,7 @@ Deno.test("bash-no-sandbox denies ls and find paths that realpath outside the wo
     outputId: "run-1:bash-no-sandbox:1",
     stdout: "",
     stderr:
-      "bash-no-sandbox command denied: path outside-link must resolve within the workspace",
+      "bash-no-sandbox command denied: path outside-link must resolve within or below the workspace",
     exitCode: 126,
     cwd: "/workspace/repo",
   });

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -114,6 +114,12 @@ const createContext = (
         ? workspaceHostPath
         : `${workspaceHostPath}${sandboxPath.slice("/workspace".length)}`;
     },
+    isHostPathWithinWorkspace(path: string) {
+      return Promise.resolve(
+        path === workspaceHostPath ||
+          path.startsWith(`${workspaceHostPath}/`),
+      );
+    },
     hostPathToWorkspacePath(path: string) {
       return path === workspaceHostPath
         ? "/workspace"
@@ -168,8 +174,7 @@ Deno.test("bash tool executes the command through the sandbox shell runtime", as
 
 Deno.test("bash-no-sandbox tool executes the command through the host process runner", async () => {
   const hostRunner = new FakeProcessRunner([{
-    stdout:
-      "host ok\n__CF_HARNESS_HOST_CWD__run-1:bash-no-sandbox:1__/tmp/cf-harness-workspace/browser",
+    stdout: "host ok\n",
     stderr: "",
     exitCode: 0,
   }]);
@@ -190,24 +195,65 @@ Deno.test("bash-no-sandbox tool executes the command through the host process ru
   });
   assertEquals(sandbox.calls, []);
   assertEquals(hostRunner.calls, [{
-    command: "bash",
-    args: [
-      "-lc",
-      [
-        '__cf_harness_cwd_marker="__CF_HARNESS_HOST_CWD__run-1:bash-no-sandbox:1__"',
-        'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
-        "agent-browser --help",
-      ].join("\n"),
-    ],
+    command: "agent-browser",
+    args: ["--help"],
     cwd: "/tmp/cf-harness-workspace/browser",
     timeoutMs: 1000,
   }]);
   assertEquals(context.currentDir, "/workspace/browser");
 });
 
-Deno.test("bash-no-sandbox keeps currentDir inside the workspace if the host command exits elsewhere", async () => {
+Deno.test("bash-no-sandbox defaults and caps host command timeouts", async () => {
+  const hostRunner = new FakeProcessRunner();
+  const context = createContext(
+    new FakeSandboxRuntime(),
+    "/workspace/repo",
+    hostRunner,
+  );
+
+  await bashNoSandboxTool.invoke(context, {
+    command: "agent-browser --help",
+  });
+  await bashNoSandboxTool.invoke(context, {
+    command: "agent-browser --help",
+    timeoutMs: 999_999,
+  });
+
+  assertEquals(hostRunner.calls.map((call) => call.timeoutMs), [
+    30_000,
+    120_000,
+  ]);
+});
+
+Deno.test("bash-no-sandbox caps returned host output", async () => {
   const hostRunner = new FakeProcessRunner([{
-    stdout: "__CF_HARNESS_HOST_CWD__run-1:bash-no-sandbox:1__/tmp/outside",
+    stdout: "x".repeat(20_010),
+    stderr: "y".repeat(20_001),
+    exitCode: 0,
+  }]);
+  const context = createContext(
+    new FakeSandboxRuntime(),
+    "/workspace/repo",
+    hostRunner,
+  );
+
+  const output = await bashNoSandboxTool.invoke(context, {
+    command: "agent-browser --help",
+  });
+
+  assertEquals(
+    output.stdout,
+    `${"x".repeat(20_000)}\n[cf-harness truncated stdout: 10 chars omitted]`,
+  );
+  assertEquals(
+    output.stderr,
+    `${"y".repeat(20_000)}\n[cf-harness truncated stderr: 1 chars omitted]`,
+  );
+});
+
+Deno.test("bash-no-sandbox keeps currentDir at the command cwd", async () => {
+  const hostRunner = new FakeProcessRunner([{
+    stdout: "",
     stderr: "",
     exitCode: 0,
   }]);
@@ -222,6 +268,55 @@ Deno.test("bash-no-sandbox keeps currentDir inside the workspace if the host com
 
   assertEquals(output.cwd, "/workspace/repo");
   assertEquals(context.currentDir, "/workspace/repo");
+});
+
+Deno.test("bash-no-sandbox translates command -v agent-browser to direct argv", async () => {
+  const hostRunner = new FakeProcessRunner([{
+    stdout: "/usr/local/bin/agent-browser\n",
+    stderr: "",
+    exitCode: 0,
+  }]);
+  const context = createContext(
+    new FakeSandboxRuntime(),
+    "/workspace/repo",
+    hostRunner,
+  );
+  const output = await bashNoSandboxTool.invoke(context, {
+    command: "command -v agent-browser",
+  });
+
+  assertEquals(output.stdout, "/usr/local/bin/agent-browser\n");
+  assertEquals(hostRunner.calls, [{
+    command: "which",
+    args: ["agent-browser"],
+    cwd: "/tmp/cf-harness-workspace/repo",
+    timeoutMs: 30_000,
+  }]);
+});
+
+Deno.test("bash-no-sandbox denies ls and find paths that realpath outside the workspace", async () => {
+  const hostRunner = new FakeProcessRunner();
+  const context = createContext(
+    new FakeSandboxRuntime(),
+    "/workspace/repo",
+    hostRunner,
+  );
+  context.isHostPathWithinWorkspace = (path: string) =>
+    Promise.resolve(!path.endsWith("/outside-link"));
+
+  const output = await bashNoSandboxTool.invoke(context, {
+    command: "ls outside-link",
+  });
+
+  assertEquals(hostRunner.calls, []);
+  assertEquals(output, {
+    outputId: "run-1:bash-no-sandbox:1",
+    stdout: "",
+    stderr:
+      "bash-no-sandbox command denied: path outside-link must resolve within the workspace",
+    exitCode: 126,
+    cwd: "/workspace/repo",
+  });
 });
 
 Deno.test("bash-no-sandbox denies host commands outside the browser policy", async () => {


### PR DESCRIPTION
## Summary
- add a browser host command policy for `bash-no-sandbox`
- allow `agent-browser ...`, agent-browser discovery, `pwd`, constrained `ls`, and bounded workspace-local `find`
- deny shell chaining/substitution/redirects/multi-line commands before invoking the host runner
- classify denied host commands as `tool_not_allowed` and update browser-profile guidance/docs

## Notes
This intentionally preserves the eventual usage shape where browser subagents invoke `agent-browser` through a shell command. The remaining broad surface is inside `agent-browser ...` itself; option/path-aware browser policy can be a later refinement.

## Test plan
- `deno test --allow-read --allow-write --allow-run packages/cf-harness/test/browser-host-command-policy.test.ts packages/cf-harness/test/tools-execution.test.ts packages/cf-harness/test/diagnostics.test.ts packages/cf-harness/test/prompt-loop.test.ts`
- `deno task test` from `packages/cf-harness`
- `deno task check` from `packages/cf-harness`
- `git diff --check`
