### PR TITLE
Add cf-harness CFC policy trace artifacts

### DIFF
--- a/packages/cf-harness/src/artifacts.ts
+++ b/packages/cf-harness/src/artifacts.ts
@@ -9,6 +9,7 @@ import {
 } from "@std/path";
 import type { HarnessRunState } from "./run-state.ts";
 import type { HarnessCfcPolicySnapshot } from "./contracts/cfc-policy-snapshot.ts";
+import type { HarnessPolicyTrace } from "./contracts/policy-trace.ts";
 import { createHarnessPolicyEvent } from "./contracts/policy.ts";
 import type { HarnessRunManifest } from "./contracts/run-manifest.ts";
 import type { HarnessRunReport } from "./contracts/run-report.ts";
@@ -69,6 +70,9 @@ export interface HarnessArtifactStore {
   persistCfcPolicySnapshot(
     snapshot: HarnessCfcPolicySnapshot,
   ): Promise<string>;
+  persistPolicyTrace?(
+    trace: HarnessPolicyTrace,
+  ): Promise<string>;
   persistRunReport(
     report: HarnessRunReport,
   ): Promise<string>;
@@ -128,6 +132,15 @@ export class FileSystemHarnessArtifactStore implements HarnessArtifactStore {
     return path;
   }
 
+  async persistPolicyTrace(
+    trace: HarnessPolicyTrace,
+  ): Promise<string> {
+    await ensureDir(this.runRoot);
+    const path = join(this.runRoot, "policy-trace.json");
+    await writeJsonFile(path, trace);
+    return path;
+  }
+
   async persistRunReport(
     report: HarnessRunReport,
   ): Promise<string> {
@@ -175,6 +188,9 @@ const normalizeHarnessRunState = (
       : createHarnessPolicyEvent(event)
   ),
   toolOutputs: [...(state.toolOutputs ?? [])],
+  ...(state.policyDecisions !== undefined
+    ? { policyDecisions: [...state.policyDecisions] }
+    : {}),
   ...(state.subagentRuns !== undefined
     ? { subagentRuns: [...state.subagentRuns] }
     : {}),

--- a/packages/cf-harness/src/contracts/policy-trace.ts
+++ b/packages/cf-harness/src/contracts/policy-trace.ts
@@ -1,0 +1,144 @@
+import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import type { PromptSlotBinding } from "./prompt-slot.ts";
+import type { HarnessToolEffectClass } from "./tool-descriptor.ts";
+import type { HarnessToolInputSummary } from "./policy.ts";
+import type { HarnessToolPolicyDecision } from "./run-report.ts";
+
+export type HarnessPolicyDecisionReasonCode =
+  | "tool_not_allowed"
+  | "cfc_disabled"
+  | "cfc_observe_read"
+  | "cfc_observe_direct_command"
+  | "cfc_observe_requires_direct_command"
+  | "cfc_enforce_explicit_read"
+  | "cfc_enforce_explicit_direct_command"
+  | "cfc_enforce_explicit_requires_direct_command"
+  | "cfc_enforce_strict_direct_command"
+  | "cfc_enforce_strict_requires_direct_command"
+  | "write_file_disabled"
+  | "write_file_observe_direct_command"
+  | "write_file_observe_requires_direct_command"
+  | "write_file_enforce_explicit_direct_command"
+  | "write_file_enforce_explicit_requires_direct_command"
+  | "write_file_enforce_strict_direct_command"
+  | "write_file_enforce_strict_requires_direct_command"
+  | "subagent_profile_allowed"
+  | "subagent_profile_not_allowed";
+
+export interface HarnessPolicyDecisionRecord {
+  type: "cf-harness.policy-decision";
+  sequence: number;
+  runId: string;
+  at: string;
+  toolActivitySequence: number;
+  toolCallId: string;
+  toolId: string;
+  effectClass?: HarnessToolEffectClass;
+  cfcEnforcementMode: CfcEnforcementMode;
+  decision: HarnessToolPolicyDecision;
+  reasonCodes: readonly HarnessPolicyDecisionReasonCode[];
+  detail?: string;
+  promptSlot?: PromptSlotBinding;
+  toolInputSummary?: HarnessToolInputSummary;
+  policyEventIndexes?: readonly number[];
+  subagentProfile?: string;
+}
+
+export interface HarnessPolicyDecisionCounts {
+  total: number;
+  allowed: number;
+  warned: number;
+  denied: number;
+}
+
+export interface HarnessPolicyTrace {
+  type: "cf-harness.policy-trace";
+  version: 1;
+  generatedAt: string;
+  runId: string;
+  cfcEnforcementMode: CfcEnforcementMode;
+  cfcPolicySnapshotPath?: string;
+  cfcPolicySnapshotDigest?: string;
+  decisionCounts: HarnessPolicyDecisionCounts;
+  decisions: readonly HarnessPolicyDecisionRecord[];
+}
+
+export interface CreateHarnessPolicyDecisionRecordOptions
+  extends Omit<HarnessPolicyDecisionRecord, "type" | "sequence" | "runId"> {
+  sequence: number;
+  runId: string;
+}
+
+export interface CreateHarnessPolicyTraceOptions {
+  generatedAt: string;
+  runId: string;
+  cfcEnforcementMode: CfcEnforcementMode;
+  cfcPolicySnapshotPath?: string;
+  cfcPolicySnapshotDigest?: string;
+  decisions?: readonly HarnessPolicyDecisionRecord[];
+}
+
+export const createHarnessPolicyDecisionRecord = (
+  options: CreateHarnessPolicyDecisionRecordOptions,
+): HarnessPolicyDecisionRecord => ({
+  type: "cf-harness.policy-decision",
+  sequence: options.sequence,
+  runId: options.runId,
+  at: options.at,
+  toolActivitySequence: options.toolActivitySequence,
+  toolCallId: options.toolCallId,
+  toolId: options.toolId,
+  ...(options.effectClass !== undefined
+    ? { effectClass: options.effectClass }
+    : {}),
+  cfcEnforcementMode: options.cfcEnforcementMode,
+  decision: options.decision,
+  reasonCodes: [...options.reasonCodes],
+  ...(options.detail !== undefined ? { detail: options.detail } : {}),
+  ...(options.promptSlot !== undefined
+    ? { promptSlot: options.promptSlot }
+    : {}),
+  ...(options.toolInputSummary !== undefined
+    ? { toolInputSummary: options.toolInputSummary }
+    : {}),
+  ...(options.policyEventIndexes !== undefined &&
+      options.policyEventIndexes.length > 0
+    ? { policyEventIndexes: [...options.policyEventIndexes] }
+    : {}),
+  ...(options.subagentProfile !== undefined
+    ? { subagentProfile: options.subagentProfile }
+    : {}),
+});
+
+export const countHarnessPolicyDecisions = (
+  decisions: readonly HarnessPolicyDecisionRecord[] = [],
+): HarnessPolicyDecisionCounts => ({
+  total: decisions.length,
+  allowed: decisions.filter((decision) => decision.decision === "allowed")
+    .length,
+  warned: decisions.filter((decision) => decision.decision === "warned")
+    .length,
+  denied: decisions.filter((decision) => decision.decision === "denied")
+    .length,
+});
+
+export const createHarnessPolicyTrace = (
+  options: CreateHarnessPolicyTraceOptions,
+): HarnessPolicyTrace => {
+  const decisions = [...(options.decisions ?? [])];
+  return {
+    type: "cf-harness.policy-trace",
+    version: 1,
+    generatedAt: options.generatedAt,
+    runId: options.runId,
+    cfcEnforcementMode: options.cfcEnforcementMode,
+    ...(options.cfcPolicySnapshotPath !== undefined
+      ? { cfcPolicySnapshotPath: options.cfcPolicySnapshotPath }
+      : {}),
+    ...(options.cfcPolicySnapshotDigest !== undefined
+      ? { cfcPolicySnapshotDigest: options.cfcPolicySnapshotDigest }
+      : {}),
+    decisionCounts: countHarnessPolicyDecisions(decisions),
+    decisions,
+  };
+};

--- a/packages/cf-harness/src/contracts/run-report.ts
+++ b/packages/cf-harness/src/contracts/run-report.ts
@@ -2,6 +2,12 @@ import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { HarnessCfcPolicySnapshot } from "./cfc-policy-snapshot.ts";
 import type { HarnessFailureRecord } from "../diagnostics.ts";
 import type { HarnessPolicyEvent, HarnessToolInputSummary } from "./policy.ts";
+import type {
+  HarnessPolicyDecisionCounts,
+  HarnessPolicyDecisionRecord,
+  HarnessPolicyTrace,
+} from "./policy-trace.ts";
+import { countHarnessPolicyDecisions } from "./policy-trace.ts";
 import type { PromptSlotBinding } from "./prompt-slot.ts";
 import type { HarnessSubagentRunRef } from "./subagent.ts";
 import type { HarnessToolEffectClass } from "./tool-descriptor.ts";
@@ -86,6 +92,8 @@ export interface HarnessRunReport {
   transcriptPath?: string;
   promptSlotBinding?: PromptSlotBinding;
   cfcPolicySnapshot?: HarnessCfcPolicySnapshot;
+  policyTrace?: HarnessPolicyTrace;
+  policyTracePath?: string;
   primaryFailure?: HarnessFailureRecord;
   failureRecords?: HarnessFailureRecord[];
   policyEventCounts: {
@@ -93,7 +101,9 @@ export interface HarnessRunReport {
     warnings: number;
     denied: number;
   };
+  policyDecisionCounts: HarnessPolicyDecisionCounts;
   policyEvents: HarnessPolicyEvent[];
+  policyDecisions: HarnessPolicyDecisionRecord[];
   timeline: HarnessRunTimelineEntry[];
   toolActivity: HarnessToolActivity[];
   toolOutputs: ToolResultRef[];
@@ -113,9 +123,12 @@ export interface CreateHarnessRunReportOptions {
     transcriptPath?: string;
     promptSlotBinding?: PromptSlotBinding;
     cfcPolicySnapshot?: HarnessCfcPolicySnapshot;
+    policyTrace?: HarnessPolicyTrace;
+    policyTracePath?: string;
     primaryFailure?: HarnessFailureRecord;
     failureRecords?: HarnessFailureRecord[];
     policyEvents: HarnessPolicyEvent[];
+    policyDecisions?: HarnessPolicyDecisionRecord[];
     toolOutputs: ToolResultRef[];
     subagentRuns?: HarnessSubagentRunRef[];
   };
@@ -234,6 +247,7 @@ export const createHarnessRunReport = (
   const denied =
     options.runState.policyEvents.filter((event) => event.severity === "denied")
       .length;
+  const policyDecisions = [...(options.runState.policyDecisions ?? [])];
   return {
     type: "cf-harness.run-report",
     runId: options.runState.runId,
@@ -267,6 +281,12 @@ export const createHarnessRunReport = (
     ...(options.runState.cfcPolicySnapshot !== undefined
       ? { cfcPolicySnapshot: options.runState.cfcPolicySnapshot }
       : {}),
+    ...(options.runState.policyTrace !== undefined
+      ? { policyTrace: options.runState.policyTrace }
+      : {}),
+    ...(options.runState.policyTracePath !== undefined
+      ? { policyTracePath: options.runState.policyTracePath }
+      : {}),
     ...(options.runState.primaryFailure !== undefined
       ? { primaryFailure: options.runState.primaryFailure }
       : {}),
@@ -278,7 +298,9 @@ export const createHarnessRunReport = (
       warnings,
       denied,
     },
+    policyDecisionCounts: countHarnessPolicyDecisions(policyDecisions),
     policyEvents: [...options.runState.policyEvents],
+    policyDecisions,
     timeline: createHarnessRunTimeline({
       runState: options.runState,
       timeline: options.timeline,

--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -83,6 +83,7 @@ export type HarnessFailureKind =
 export type HarnessFailureSource =
   | "capability_snapshot"
   | "policy_snapshot"
+  | "policy_trace"
   | "policy_event"
   | "tool_output"
   | "run_error";

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -9,6 +9,7 @@ import {
 } from "./artifacts.ts";
 import {
   appendHarnessFailureRecord,
+  appendHarnessPolicyDecision,
   appendHarnessPolicyEvent,
   appendHarnessSubagentRun,
   appendHarnessToolOutput,
@@ -17,6 +18,7 @@ import {
   type HarnessRunTerminalReason,
   setHarnessCapabilitySnapshot,
   setHarnessCfcPolicySnapshot,
+  setHarnessPolicyTrace,
   setHarnessPromptSlotBinding,
   setHarnessRunCurrentDir,
   setHarnessRunManifestPath,
@@ -38,6 +40,11 @@ import {
   type HarnessPolicyEvent,
 } from "./contracts/policy.ts";
 import type { HarnessCfcPolicySnapshot } from "./contracts/cfc-policy-snapshot.ts";
+import {
+  createHarnessPolicyDecisionRecord,
+  type HarnessPolicyDecisionRecord,
+  type HarnessPolicyTrace,
+} from "./contracts/policy-trace.ts";
 import type { PromptSlotBinding } from "./contracts/prompt-slot.ts";
 import type { HarnessRunReport } from "./contracts/run-report.ts";
 import type { HarnessSubagentRunRef } from "./contracts/subagent.ts";
@@ -308,6 +315,28 @@ export class CfHarnessEngine {
     return this.getRunState();
   }
 
+  async recordPolicyDecision(
+    decision: Omit<
+      HarnessPolicyDecisionRecord,
+      "type" | "sequence" | "runId" | "at"
+    >,
+  ): Promise<HarnessRunState> {
+    const now = this.#now();
+    const policyDecision = createHarnessPolicyDecisionRecord({
+      ...decision,
+      runId: this.#runState.runId,
+      sequence: (this.#runState.policyDecisions ?? []).length + 1,
+      at: now,
+    });
+    this.#runState = appendHarnessPolicyDecision(
+      this.#runState,
+      policyDecision,
+      now,
+    );
+    await this.persistRunState();
+    return this.getRunState();
+  }
+
   async persistRunState(): Promise<string | undefined> {
     return await this.artifactStore?.persistRunState(this.#runState);
   }
@@ -439,6 +468,33 @@ export class CfHarnessEngine {
     );
     await this.persistRunState();
     return cfcPolicySnapshotPath;
+  }
+
+  async persistPolicyTrace(
+    trace: HarnessPolicyTrace,
+  ): Promise<string | undefined> {
+    let policyTracePath: string | undefined;
+    try {
+      policyTracePath = await this.artifactStore?.persistPolicyTrace?.(trace);
+    } catch (error) {
+      const now = this.#now();
+      this.#runState = appendHarnessFailureRecord(
+        this.#runState,
+        classifyHarnessRunError(error, {
+          at: now,
+          source: "policy_trace",
+        }),
+        now,
+      );
+    }
+    this.#runState = setHarnessPolicyTrace(
+      this.#runState,
+      trace,
+      policyTracePath,
+      this.#now(),
+    );
+    await this.persistRunState();
+    return policyTracePath;
   }
 
   async ensureDiagnosticsInitialized(): Promise<HarnessRunState> {

--- a/packages/cf-harness/src/index.ts
+++ b/packages/cf-harness/src/index.ts
@@ -10,6 +10,7 @@ export * from "./contracts/cfc-policy-snapshot.ts";
 export * from "./contracts/run-manifest.ts";
 export * from "./contracts/observation.ts";
 export * from "./contracts/policy.ts";
+export * from "./contracts/policy-trace.ts";
 export * from "./contracts/run-report.ts";
 export * from "./contracts/subagent.ts";
 export * from "./contracts/tool-result.ts";

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -39,6 +39,10 @@ import type {
 } from "./contracts/tool-descriptor.ts";
 import type { HarnessToolInputSummary } from "./contracts/policy.ts";
 import {
+  createHarnessPolicyTrace,
+  type HarnessPolicyDecisionReasonCode,
+} from "./contracts/policy-trace.ts";
+import {
   createHarnessRunReport,
   type HarnessRunTimelineEntryInput,
   type HarnessToolActivity,
@@ -228,6 +232,9 @@ const summarizeSensitiveText = async (
     digest: await sha256Digest(bytes),
   };
 };
+
+const digestJsonValue = async (input: unknown): Promise<string> =>
+  await sha256Digest(textBytes(JSON.stringify(input)));
 
 const isSafeNonNegativeInteger = (value: unknown): value is number =>
   typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
@@ -614,6 +621,7 @@ const createAssistantTranscriptMessage = (
 
 interface ToolPolicyDecision {
   allowed: boolean;
+  reasonCodes: readonly HarnessPolicyDecisionReasonCode[];
   warningDetail?: string;
   denial?: ObservationDenied;
 }
@@ -641,15 +649,31 @@ const evaluateToolPolicy = (
       path: typeof input?.path === "string" ? input.path : "unknown",
       mode: input?.mode === "append" ? "append" : "replace",
     });
+    const writeReasonCode: HarnessPolicyDecisionReasonCode =
+      cfcEnforcementMode === "disabled"
+        ? "write_file_disabled"
+        : cfcEnforcementMode === "observe"
+        ? directCommand
+          ? "write_file_observe_direct_command"
+          : "write_file_observe_requires_direct_command"
+        : cfcEnforcementMode === "enforce-explicit"
+        ? directCommand
+          ? "write_file_enforce_explicit_direct_command"
+          : "write_file_enforce_explicit_requires_direct_command"
+        : directCommand
+        ? "write_file_enforce_strict_direct_command"
+        : "write_file_enforce_strict_requires_direct_command";
     return decision.allowed
       ? {
         allowed: true,
+        reasonCodes: [writeReasonCode],
         ...(decision.warningDetail !== undefined
           ? { warningDetail: decision.warningDetail }
           : {}),
       }
       : {
         allowed: false,
+        reasonCodes: [writeReasonCode],
         denial: makeObservationDenied("not-authorized", {
           detail: decision.denialDetail ?? "write_file was denied",
         }),
@@ -657,22 +681,38 @@ const evaluateToolPolicy = (
   }
   switch (cfcEnforcementMode) {
     case "disabled":
-      return { allowed: true };
+      return { allowed: true, reasonCodes: ["cfc_disabled"] };
     case "observe":
       if (!directCommand && descriptor.effectClass !== "read") {
         return {
           allowed: true,
+          reasonCodes: ["cfc_observe_requires_direct_command"],
           warningDetail:
             `${descriptor.toolId} would require direct-command authorization in enforce modes`,
         };
       }
-      return { allowed: true };
+      return {
+        allowed: true,
+        reasonCodes: [
+          descriptor.effectClass === "read"
+            ? "cfc_observe_read"
+            : "cfc_observe_direct_command",
+        ],
+      };
     case "enforce-explicit":
       if (descriptor.effectClass === "read" || directCommand) {
-        return { allowed: true };
+        return {
+          allowed: true,
+          reasonCodes: [
+            descriptor.effectClass === "read"
+              ? "cfc_enforce_explicit_read"
+              : "cfc_enforce_explicit_direct_command",
+          ],
+        };
       }
       return {
         allowed: false,
+        reasonCodes: ["cfc_enforce_explicit_requires_direct_command"],
         denial: makeObservationDenied("not-authorized", {
           detail:
             `${descriptor.toolId} requires direct-command authorization in enforce-explicit`,
@@ -680,10 +720,14 @@ const evaluateToolPolicy = (
       };
     case "enforce-strict":
       if (directCommand) {
-        return { allowed: true };
+        return {
+          allowed: true,
+          reasonCodes: ["cfc_enforce_strict_direct_command"],
+        };
       }
       return {
         allowed: false,
+        reasonCodes: ["cfc_enforce_strict_requires_direct_command"],
         denial: makeObservationDenied("not-authorized", {
           detail:
             `${descriptor.toolId} requires direct-command authorization in enforce-strict`,
@@ -817,9 +861,28 @@ export class CfHarnessPromptLoop {
     const toolActivity: HarnessToolActivity[] = [];
     const reportTimeline: HarnessRunTimelineEntryInput[] = [];
     let modelTurns = 0;
+    const buildPolicyTrace = async () => {
+      const runState = this.engine.getRunState();
+      const cfcPolicySnapshotDigest = runState.cfcPolicySnapshot === undefined
+        ? undefined
+        : await digestJsonValue(runState.cfcPolicySnapshot);
+      return createHarnessPolicyTrace({
+        runId: runState.runId,
+        generatedAt: runState.updatedAt,
+        cfcEnforcementMode: runState.cfcEnforcementMode,
+        ...(runState.cfcPolicySnapshotPath !== undefined
+          ? { cfcPolicySnapshotPath: runState.cfcPolicySnapshotPath }
+          : {}),
+        ...(cfcPolicySnapshotDigest !== undefined
+          ? { cfcPolicySnapshotDigest }
+          : {}),
+        decisions: runState.policyDecisions ?? [],
+      });
+    };
     const persistRunReport = async (
       finalAssistantText?: string,
     ): Promise<void> => {
+      await this.engine.persistPolicyTrace(await buildPolicyTrace());
       await this.engine.persistRunReport(
         createHarnessRunReport({
           runState: this.engine.getRunState(),
@@ -1023,6 +1086,23 @@ export class CfHarnessPromptLoop {
           : {}),
         ...optionalPolicyEventIndexes(policyEventIndexes),
       });
+      await this.engine.recordPolicyDecision({
+        toolActivitySequence: sequence,
+        toolCallId: toolCall.id,
+        toolId: toolCall.function.name,
+        effectClass: tool.descriptor.effectClass,
+        cfcEnforcementMode: this.engine.getRunState().cfcEnforcementMode,
+        decision: "denied",
+        reasonCodes: ["tool_not_allowed"],
+        detail: denial.detail ?? `${toolCall.function.name} is not allowed`,
+        ...(promptSlotBinding !== undefined
+          ? { promptSlot: promptSlotBinding }
+          : {}),
+        ...(deniedToolInputSummary !== undefined
+          ? { toolInputSummary: deniedToolInputSummary }
+          : {}),
+        ...optionalPolicyEventIndexes(policyEventIndexes),
+      });
       return {
         role: "tool",
         toolCallId: toolCall.id,
@@ -1040,6 +1120,8 @@ export class CfHarnessPromptLoop {
       input,
     );
     let policyDecision: HarnessToolPolicyDecision = "allowed";
+    const policyDecisionReasonCodes = [...decision.reasonCodes];
+    let policyDecisionDetail: string | undefined;
     if (decision.warningDetail !== undefined) {
       await recordPolicyEvent({
         severity: "warning",
@@ -1053,6 +1135,7 @@ export class CfHarnessPromptLoop {
         detail: decision.warningDetail,
       });
       policyDecision = "warned";
+      policyDecisionDetail = decision.warningDetail;
     }
     if (!decision.allowed) {
       const denial = decision.denial ??
@@ -1077,6 +1160,21 @@ export class CfHarnessPromptLoop {
         toolInputSummary,
         ...optionalPolicyEventIndexes(policyEventIndexes),
       });
+      await this.engine.recordPolicyDecision({
+        toolActivitySequence: sequence,
+        toolCallId: toolCall.id,
+        toolId: toolCall.function.name,
+        effectClass: tool.descriptor.effectClass,
+        cfcEnforcementMode: this.engine.getRunState().cfcEnforcementMode,
+        decision: "denied",
+        reasonCodes: policyDecisionReasonCodes,
+        detail: denial.detail ?? `${toolCall.function.name} was denied`,
+        ...(promptSlotBinding !== undefined
+          ? { promptSlot: promptSlotBinding }
+          : {}),
+        toolInputSummary,
+        ...optionalPolicyEventIndexes(policyEventIndexes),
+      });
       return {
         role: "tool",
         toolCallId: toolCall.id,
@@ -1095,6 +1193,23 @@ export class CfHarnessPromptLoop {
           toolInputSummary,
           ...optionalPolicyEventIndexes(policyEventIndexes),
           errorDetail: toErrorDetail(error),
+        });
+        await this.engine.recordPolicyDecision({
+          toolActivitySequence: sequence,
+          toolCallId: toolCall.id,
+          toolId: toolCall.function.name,
+          effectClass: tool.descriptor.effectClass,
+          cfcEnforcementMode: this.engine.getRunState().cfcEnforcementMode,
+          decision: policyDecision,
+          reasonCodes: policyDecisionReasonCodes,
+          ...(policyDecisionDetail !== undefined
+            ? { detail: policyDecisionDetail }
+            : {}),
+          ...(promptSlotBinding !== undefined
+            ? { promptSlot: promptSlotBinding }
+            : {}),
+          toolInputSummary,
+          ...optionalPolicyEventIndexes(policyEventIndexes),
         });
         throw error;
       }
@@ -1120,6 +1235,25 @@ export class CfHarnessPromptLoop {
           toolInputSummary,
           ...optionalPolicyEventIndexes(policyEventIndexes),
         });
+        await this.engine.recordPolicyDecision({
+          toolActivitySequence: sequence,
+          toolCallId: toolCall.id,
+          toolId: toolCall.function.name,
+          effectClass: tool.descriptor.effectClass,
+          cfcEnforcementMode: this.engine.getRunState().cfcEnforcementMode,
+          decision: "denied",
+          reasonCodes: [
+            ...policyDecisionReasonCodes,
+            "subagent_profile_not_allowed",
+          ],
+          detail,
+          ...(promptSlotBinding !== undefined
+            ? { promptSlot: promptSlotBinding }
+            : {}),
+          toolInputSummary,
+          subagentProfile: delegateInput.profile,
+          ...optionalPolicyEventIndexes(policyEventIndexes),
+        });
         return {
           role: "tool",
           toolCallId: toolCall.id,
@@ -1127,7 +1261,28 @@ export class CfHarnessPromptLoop {
           content: JSON.stringify(denial),
         };
       }
+      policyDecisionReasonCodes.push("subagent_profile_allowed");
     }
+    await this.engine.recordPolicyDecision({
+      toolActivitySequence: sequence,
+      toolCallId: toolCall.id,
+      toolId: toolCall.function.name,
+      effectClass: tool.descriptor.effectClass,
+      cfcEnforcementMode: this.engine.getRunState().cfcEnforcementMode,
+      decision: policyDecision,
+      reasonCodes: policyDecisionReasonCodes,
+      ...(policyDecisionDetail !== undefined
+        ? { detail: policyDecisionDetail }
+        : {}),
+      ...(promptSlotBinding !== undefined
+        ? { promptSlot: promptSlotBinding }
+        : {}),
+      toolInputSummary,
+      ...(delegateInput !== undefined
+        ? { subagentProfile: delegateInput.profile }
+        : {}),
+      ...optionalPolicyEventIndexes(policyEventIndexes),
+    });
     let result: {
       output: Awaited<
         ReturnType<CfHarnessEngine["invokeBuiltinTool"]>

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -1,6 +1,10 @@
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { HarnessCfcPolicySnapshot } from "./contracts/cfc-policy-snapshot.ts";
 import type { HarnessPolicyEvent } from "./contracts/policy.ts";
+import type {
+  HarnessPolicyDecisionRecord,
+  HarnessPolicyTrace,
+} from "./contracts/policy-trace.ts";
 import type { HarnessRunManifest } from "./contracts/run-manifest.ts";
 import type { PromptSlotBinding } from "./contracts/prompt-slot.ts";
 import type { HarnessSubagentRunRef } from "./contracts/subagent.ts";
@@ -45,7 +49,10 @@ export interface HarnessRunState {
   capabilitiesPath?: string;
   cfcPolicySnapshot?: HarnessCfcPolicySnapshot;
   cfcPolicySnapshotPath?: string;
+  policyTrace?: HarnessPolicyTrace;
+  policyTracePath?: string;
   policyEvents: HarnessPolicyEvent[];
+  policyDecisions?: HarnessPolicyDecisionRecord[];
   toolOutputs: ToolResultRef[];
   subagentRuns?: HarnessSubagentRunRef[];
   failureRecords?: HarnessFailureRecord[];
@@ -70,6 +77,9 @@ export interface CreateHarnessRunStateOptions {
   capabilitiesPath?: string;
   cfcPolicySnapshot?: HarnessCfcPolicySnapshot;
   cfcPolicySnapshotPath?: string;
+  policyTrace?: HarnessPolicyTrace;
+  policyTracePath?: string;
+  policyDecisions?: HarnessPolicyDecisionRecord[];
   subagentRuns?: HarnessSubagentRunRef[];
   failureRecords?: HarnessFailureRecord[];
   primaryFailure?: HarnessFailureRecord;
@@ -122,7 +132,16 @@ export const createHarnessRunState = (
     ...(options.cfcPolicySnapshotPath !== undefined
       ? { cfcPolicySnapshotPath: options.cfcPolicySnapshotPath }
       : {}),
+    ...(options.policyTrace !== undefined
+      ? { policyTrace: options.policyTrace }
+      : {}),
+    ...(options.policyTracePath !== undefined
+      ? { policyTracePath: options.policyTracePath }
+      : {}),
     policyEvents: [],
+    ...(options.policyDecisions !== undefined
+      ? { policyDecisions: [...options.policyDecisions] }
+      : {}),
     toolOutputs: [],
     ...(options.subagentRuns !== undefined
       ? { subagentRuns: [...options.subagentRuns] }
@@ -177,6 +196,16 @@ export const appendHarnessPolicyEvent = (
   ...state,
   updatedAt: now,
   policyEvents: [...state.policyEvents, event],
+});
+
+export const appendHarnessPolicyDecision = (
+  state: HarnessRunState,
+  decision: HarnessPolicyDecisionRecord,
+  now = new Date().toISOString(),
+): HarnessRunState => ({
+  ...state,
+  updatedAt: now,
+  policyDecisions: [...(state.policyDecisions ?? []), decision],
 });
 
 export const appendHarnessSubagentRun = (
@@ -275,5 +304,17 @@ export const setHarnessCfcPolicySnapshot = (
   ...state,
   cfcPolicySnapshot,
   ...(cfcPolicySnapshotPath !== undefined ? { cfcPolicySnapshotPath } : {}),
+  updatedAt: now,
+});
+
+export const setHarnessPolicyTrace = (
+  state: HarnessRunState,
+  policyTrace: HarnessPolicyTrace,
+  policyTracePath?: string,
+  now = new Date().toISOString(),
+): HarnessRunState => ({
+  ...state,
+  policyTrace,
+  ...(policyTracePath !== undefined ? { policyTracePath } : {}),
   updatedAt: now,
 });

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -330,6 +330,7 @@ Deno.test({
       const runRoot = join(artifactRoot, "run-loop-persisted");
       const transcriptPath = join(runRoot, "transcript.json");
       const policySnapshotPath = join(runRoot, "policy-snapshot.json");
+      const policyTracePath = join(runRoot, "policy-trace.json");
       const runReportPath = join(runRoot, "run-report.json");
       const persistedState = await readHarnessRunState(
         join(runRoot, "run-state.json"),
@@ -337,10 +338,14 @@ Deno.test({
       const persistedPolicySnapshot = JSON.parse(
         await Deno.readTextFile(policySnapshotPath),
       );
+      const persistedPolicyTrace = JSON.parse(
+        await Deno.readTextFile(policyTracePath),
+      );
       const persistedReport = await readHarnessRunReport(runReportPath);
 
       assertEquals(result.runState.transcriptPath, transcriptPath);
       assertEquals(result.runState.cfcPolicySnapshotPath, policySnapshotPath);
+      assertEquals(result.runState.policyTracePath, policyTracePath);
       assertEquals(result.runState.runReportPath, runReportPath);
       assertEquals(
         await readHarnessTranscript(transcriptPath),
@@ -349,6 +354,8 @@ Deno.test({
       assertEquals(persistedState.transcriptPath, transcriptPath);
       assertEquals(persistedState.cfcPolicySnapshotPath, policySnapshotPath);
       assertEquals(persistedState.cfcPolicySnapshot, persistedPolicySnapshot);
+      assertEquals(persistedState.policyTracePath, policyTracePath);
+      assertEquals(persistedState.policyTrace, persistedPolicyTrace);
       assertEquals(persistedState.runReportPath, runReportPath);
       assertEquals(persistedState.artifactRoot, runRoot);
       assertEquals(persistedState.endedAt, "2026-04-15T21:10:07.000Z");
@@ -394,6 +401,41 @@ Deno.test({
         persistedPolicySnapshot.substrate?.sandbox?.kind,
         "docker-runsc-cfc",
       );
+      assertEquals(persistedPolicyTrace.type, "cf-harness.policy-trace");
+      assertEquals(persistedPolicyTrace.version, 1);
+      assertEquals(persistedPolicyTrace.runId, "run-loop-persisted");
+      assertEquals(
+        persistedPolicyTrace.cfcPolicySnapshotPath,
+        policySnapshotPath,
+      );
+      assertEquals(
+        persistedPolicyTrace.cfcPolicySnapshotDigest.startsWith("sha256:"),
+        true,
+      );
+      assertEquals(persistedPolicyTrace.decisionCounts, {
+        total: 1,
+        allowed: 1,
+        warned: 0,
+        denied: 0,
+      });
+      assertEquals(persistedPolicyTrace.decisions[0], {
+        type: "cf-harness.policy-decision",
+        sequence: 1,
+        runId: "run-loop-persisted",
+        at: "2026-04-15T21:10:07.000Z",
+        toolActivitySequence: 1,
+        toolCallId: "call-1",
+        toolId: "read_file",
+        effectClass: "read",
+        cfcEnforcementMode: "enforce-explicit",
+        decision: "allowed",
+        reasonCodes: ["cfc_enforce_explicit_read"],
+        toolInputSummary: {
+          type: "cf-harness.tool-input-summary",
+          toolId: "read_file",
+          path: "notes/todo.txt",
+        },
+      });
       assertEquals(persistedReport.type, "cf-harness.run-report");
       assertEquals(persistedReport.runId, "run-loop-persisted");
       assertEquals(persistedReport.status, "completed");
@@ -401,6 +443,17 @@ Deno.test({
       assertEquals(persistedReport.modelTurns, 2);
       assertEquals(persistedReport.finalAssistantText, "Persisted summary.");
       assertEquals(persistedReport.cfcPolicySnapshot, persistedPolicySnapshot);
+      assertEquals(persistedReport.policyTracePath, policyTracePath);
+      assertEquals(persistedReport.policyTrace, persistedPolicyTrace);
+      assertEquals(persistedReport.policyDecisionCounts, {
+        total: 1,
+        allowed: 1,
+        warned: 0,
+        denied: 0,
+      });
+      assertEquals(persistedReport.policyDecisions, [
+        persistedPolicyTrace.decisions[0],
+      ]);
       assertEquals(persistedReport.policyEventCounts, {
         total: 0,
         warnings: 0,
@@ -1004,8 +1057,28 @@ Deno.test({
       const runReport = await readHarnessRunReport(
         join(artifactRoot, "run-denied-report", "run-report.json"),
       );
+      const policyTrace = JSON.parse(
+        await Deno.readTextFile(
+          join(artifactRoot, "run-denied-report", "policy-trace.json"),
+        ),
+      );
 
       assertEquals(result.runState.toolOutputs, []);
+      assertEquals(policyTrace.decisionCounts, {
+        total: 1,
+        allowed: 0,
+        warned: 0,
+        denied: 1,
+      });
+      assertEquals(policyTrace.decisions[0].decision, "denied");
+      assertEquals(policyTrace.decisions[0].reasonCodes, [
+        "write_file_enforce_explicit_requires_direct_command",
+      ]);
+      assertEquals(policyTrace.decisions[0].policyEventIndexes, [0]);
+      assertEquals(
+        policyTrace.decisions[0].detail,
+        "write_file requires direct-command authorization in enforce-explicit",
+      );
       assertEquals(runReport.policyEventCounts, {
         total: 1,
         warnings: 0,
@@ -1090,6 +1163,7 @@ Deno.test({
         },
       );
       assertEquals(JSON.stringify(runReport).includes("nope"), false);
+      assertEquals(JSON.stringify(policyTrace).includes("nope"), false);
     } finally {
       await Deno.remove(artifactRoot, { recursive: true });
     }

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -197,6 +197,9 @@ Deno.test("CfHarnessEngine stamps policy snapshot state changes with mutation ti
     persistCfcPolicySnapshot() {
       return Promise.reject(new Error("snapshot persist boom"));
     },
+    persistPolicyTrace() {
+      return Promise.resolve(`${runRoot}/policy-trace.json`);
+    },
     persistRunReport() {
       return Promise.resolve(`${runRoot}/run-report.json`);
     },

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -113,6 +113,10 @@ class FailingArtifactStore implements HarnessArtifactStore {
     return Promise.resolve(`${this.runRoot}/policy-snapshot.json`);
   }
 
+  persistPolicyTrace(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/policy-trace.json`);
+  }
+
   persistRunReport(): Promise<string> {
     return Promise.resolve(`${this.runRoot}/run-report.json`);
   }


### PR DESCRIPTION
## Summary
- add a deterministic cf-harness policy trace contract and persisted policy-trace.json artifact
- record one policy decision per tool call with stable reason codes, tool activity links, policy event links, prompt-slot context, and summarized tool input
- embed/link policy trace data from run-state and run-report without exposing raw sensitive payloads

## Verification
- deno check packages/cf-harness/src/index.ts
- deno test -A packages/cf-harness/test/artifacts.test.ts
- cd packages/cf-harness && deno task test