### PR TITLE
feat(api,runner): expose debug-stringifier helpers to patterns

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2121,6 +2121,11 @@ export interface PatternEnvironment {
 export type GetPatternEnvironmentFunction = () => PatternEnvironment;
 export type NonPrivateRandomFunction = () => number;
 export type SafeDateNowFunction = () => number;
+export type ToCompactDebugStringFunction = (
+  value: unknown,
+  maxLength?: number,
+) => string;
+export type ToIndentedDebugStringFunction = (value: unknown) => string;
 
 /**
  * Compare two cells or values for equality after resolving, i.e. after
@@ -2165,6 +2170,8 @@ export declare const byRef: ByRefFunction;
 export declare const getPatternEnvironment: GetPatternEnvironmentFunction;
 export declare const nonPrivateRandom: NonPrivateRandomFunction;
 export declare const safeDateNow: SafeDateNowFunction;
+export declare const toCompactDebugString: ToCompactDebugStringFunction;
+export declare const toIndentedDebugString: ToIndentedDebugStringFunction;
 
 export interface UiActionProps {
   readonly as?: string;

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -57,6 +57,10 @@ import {
   FabricEpochNsec,
 } from "@commonfabric/data-model/fabric-epoch";
 import { FabricHash } from "@commonfabric/data-model/fabric-hash";
+import {
+  toCompactDebugString,
+  toIndentedDebugString,
+} from "@commonfabric/data-model/value-debug";
 import { freezeVerifiedPlainData } from "../sandbox/plain-data.ts";
 import { nonPrivateRandom, safeDateNow } from "./safe-builtins.ts";
 import {
@@ -214,6 +218,10 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
     FabricEpochNsec,
     FabricEpochDays,
     FabricHash,
+
+    // Debug stringifiers (helpers exposed for pattern code)
+    toCompactDebugString,
+    toIndentedDebugString,
   } as BuilderFunctionsAndConstants & {
     __cfHelpers?: BuilderFunctionsAndConstants;
   };

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -349,6 +349,12 @@ export interface BuilderFunctionsAndConstants {
   FabricEpochDays:
     typeof import("@commonfabric/data-model/fabric-epoch").FabricEpochDays;
   FabricHash: typeof import("@commonfabric/data-model/fabric-hash").FabricHash;
+
+  // Debug stringifiers
+  toCompactDebugString:
+    typeof import("@commonfabric/data-model/value-debug").toCompactDebugString;
+  toIndentedDebugString:
+    typeof import("@commonfabric/data-model/value-debug").toIndentedDebugString;
 }
 
 // Runtime interface needed by createCell


### PR DESCRIPTION
Exposes two debug-stringifier helpers from `@commonfabric/data-model/value-debug` to pattern code via the synthetic `commonfabric` builder surface.

## What this PR exposes

Two helpers, available to pattern code via `import { ... } from "commonfabric"`:

- **`toCompactDebugString(value: unknown, maxLength?: number): string`** — single-line, length-bounded debug rendering (the `maxLength` parameter is per PR #3431).
- **`toIndentedDebugString(value: unknown): string`** — multi-line, indented debug rendering.

Both names are idiomatic with the rest of `value-debug.ts` and share the `unknown` input contract established in PR #3409 (helpers widened from `FabricValue` to `unknown` so pattern code can pass anything).

These are **debug-grade** stringifiers — outputs are not stable, not round-trippable, and not part of the JSON-encoding contract. They're for human-readable diagnostic output (logs, error messages, dev assertions). Pattern code that needs wire-format JSON should continue to use the existing JSON-encoding paths.

## Why now

Session 2026-065 migrated ~50 internal call sites from `JSON.stringify` to these helpers across `packages/runner`, `packages/memory`, and `packages/cli` (PRs #3411, #3416, #3426). The patterns-side of that migration was deferred because the synthetic `commonfabric` sandbox surface didn't expose the helpers — patterns can only import what `commonfabric` re-exports, and the helpers weren't there. This PR closes that gap so the pattern migration can proceed as a follow-up.

## Mechanism (three touch points, +21/-0 across 3 files)

1. **`packages/api/index.ts`** — adds `ToCompactDebugStringFunction` and `ToIndentedDebugStringFunction` type aliases plus matching `declare const` exports, next to `safeDateNow` / `nonPrivateRandom` / `byRef`. The `commonfabric.d.ts` consumed by the pattern compiler is a symlink to this file (`packages/static/assets/types/commonfabric.d.ts -> ../../../api/index.ts`), so edits here flow through `StaticCache.getText()` to the pattern-compilation pipeline automatically.

2. **`packages/runner/src/builder/types.ts`** — adds the two members to `BuilderFunctionsAndConstants` using the `typeof import(...)` form to match the immediately-adjacent `// Fabric value classes` block.

3. **`packages/runner/src/builder/factory.ts`** — named imports from `@commonfabric/data-model/value-debug`, wired into the `commonfabric` builder-functions object under a new `// Debug stringifiers (helpers exposed for pattern code)` comment.

## Form-choice rationale

Two different declaration conventions appear in two different files, each chosen by **immediate-context match**:

- **`api/index.ts`** uses the function-type-alias + `declare const` form, matching the `safeDateNow` / `nonPrivateRandom` / `byRef` precedent in this file. Required because `index.ts` cannot use relative imports (it's loaded as a flat type surface by the pattern compiler).
- **`runner/src/builder/types.ts`** uses the `typeof import(...)` form, matching the immediately-adjacent Fabric-value-classes block in the same interface.

Local consistency over codebase-wide consistency — calling this out here so reviewers don't have to ask.

## Scope-out

- **Patterns-side migration** — the actual `JSON.stringify` → debug-stringifier swap inside pattern code is a separate follow-up PR; this one only exposes the surface.
- **No semantic changes** to `toCompactDebugString` / `toIndentedDebugString` themselves; they're re-exported as-is from `@commonfabric/data-model/value-debug`.

## Validation

- `deno fmt --check`, `deno lint`, `deno task check` (full): clean.
- `deno task test` on `runner` (407/0) and `js-compiler` (3/0).
- Runtime smoke check: both helpers reachable on `createBuilder().commonfabric` and produce expected output with the 2-arg `maxLength` signature.
