### PR TITLE
feat(runner): Accumulate CFC labels on traversed cells

### DIFF
--- a/packages/patterns/integration/cfc-authorship-chat.test.ts
+++ b/packages/patterns/integration/cfc-authorship-chat.test.ts
@@ -91,7 +91,7 @@ async function waitForAuthorshipStates(
           !host.lightText.includes("Imported ticket thread")
         )
       );
-    }, { timeout: 15_000 });
+    });
   } catch (cause) {
     throw new Error(
       `Timed out waiting for CFC authorship states. Last probe: ${

--- a/packages/patterns/integration/cfc-spec-gallery.test.ts
+++ b/packages/patterns/integration/cfc-spec-gallery.test.ts
@@ -143,7 +143,7 @@ async function waitForCfcLabelText(page: Page, expected: string[]) {
       return expected.every((label) =>
         labels.some((rendered) => rendered.includes(label))
       );
-    }, { timeout: 15_000 });
+    });
   } catch (cause) {
     throw new Error(
       `Timed out waiting for CFC labels. Last probe: ${

--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -23,6 +23,7 @@
     "./storage/cache": "./src/storage/cache.ts",
     "./storage/cache.deno": "./src/storage/cache.deno.ts",
     "./cfc": "./src/cfc/mod.ts",
+    "./cfc/label-view-core": "./src/cfc/label-view-core.ts",
     "./compilation-cache": "./src/compilation-cache/mod.ts"
   }
 }

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2357,15 +2357,17 @@ async function handleInvoke(
 
   // Patterns always write to the result cell, so always return the link
   if (pattern) {
+    const concreteResult = result.resolveAsCell();
+    const concreteResultSchema = getCellSchema(concreteResult) ?? resultSchema;
     const serialized = serializeForLLMObservation({
-      value: result.get(),
-      schema: resultSchema,
+      value: concreteResult.get(),
+      schema: concreteResultSchema,
       seen: new Set(),
       contextSpace: space,
-      rootLink: result.getAsNormalizedFullLink(),
+      rootLink: concreteResult.getAsNormalizedFullLink(),
       labelView: useResultSchemaForObservation
         ? undefined
-        : cfcLabelViewForCell(result),
+        : cfcLabelViewForCell(concreteResult),
       observationMaxConfidentiality,
     });
     return {
@@ -2374,7 +2376,7 @@ async function handleInvoke(
         value: {
           "@resultLocation": resultLink,
           result: serialized.value,
-          schema: resultSchema,
+          schema: concreteResultSchema,
         },
       },
       observedConfidentiality: serialized.observedConfidentiality,

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -47,6 +47,7 @@ import {
 } from "../query-result-proxy.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import { type CfcLabelView, cfcLabelViewForCell } from "../cfc/label-view.ts";
+import { cfcLabelPathPrefixMatches } from "../cfc/label-view-core.ts";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
@@ -402,14 +403,6 @@ function simplifySchemaForContext(
   return simplified as JSONSchema;
 }
 
-function isPathPrefix(
-  prefix: readonly string[],
-  path: readonly string[],
-): boolean {
-  return prefix.length <= path.length &&
-    prefix.every((segment, index) => segment === path[index]);
-}
-
 function joinObservedConfidentiality(
   parts: Iterable<readonly unknown[] | undefined>,
 ): readonly unknown[] {
@@ -436,7 +429,7 @@ function confidentialityForCurrentNode(
 
   if (labelView !== undefined) {
     for (const entry of labelView.entries) {
-      if (!isPathPrefix(entry.path, logicalPath)) {
+      if (!cfcLabelPathPrefixMatches(entry.path, logicalPath)) {
         continue;
       }
       joined.push(...(entry.label.confidentiality ?? []));
@@ -2358,10 +2351,6 @@ async function handleInvoke(
   // Patterns always write to the result cell, so always return the link
   if (pattern) {
     const concreteResult = result.resolveAsCell();
-    const concreteResultLink = createLLMFriendlyLink(
-      concreteResult.getAsNormalizedFullLink(),
-      space,
-    );
     const concreteResultSchema = getCellSchema(concreteResult) ?? resultSchema;
     const serialized = serializeForLLMObservation({
       value: concreteResult.get(),
@@ -2378,7 +2367,7 @@ async function handleInvoke(
       result: {
         type: "json",
         value: {
-          "@resultLocation": concreteResultLink,
+          "@resultLocation": resultLink,
           result: serialized.value,
           schema: concreteResultSchema,
         },

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2358,6 +2358,10 @@ async function handleInvoke(
   // Patterns always write to the result cell, so always return the link
   if (pattern) {
     const concreteResult = result.resolveAsCell();
+    const concreteResultLink = createLLMFriendlyLink(
+      concreteResult.getAsNormalizedFullLink(),
+      space,
+    );
     const concreteResultSchema = getCellSchema(concreteResult) ?? resultSchema;
     const serialized = serializeForLLMObservation({
       value: concreteResult.get(),
@@ -2374,7 +2378,7 @@ async function handleInvoke(
       result: {
         type: "json",
         value: {
-          "@resultLocation": resultLink,
+          "@resultLocation": concreteResultLink,
           result: serialized.value,
           schema: concreteResultSchema,
         },

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -85,7 +85,7 @@ function summarizeGenerateObjectRequest(details: {
 }
 
 function collectCellConfidentiality(cell: Cell<any>): readonly unknown[] {
-  const labelView = cfcLabelViewForCell(cell);
+  const labelView = cfcLabelViewForCell(cell.resolveAsCell());
   if (labelView === undefined) {
     return [];
   }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -101,6 +101,15 @@ import {
 } from "./storage/extended-storage-transaction.ts";
 import { fromURI } from "./uri-utils.ts";
 import { ContextualFlowControl } from "./cfc.ts";
+import {
+  type CfcLabelView,
+  cfcLabelViewForDereferenceTraces,
+  cfcLabelViewSymbol,
+  cloneCfcLabelView,
+  getCarriedCfcLabelView,
+  mergeCfcLabelViews,
+  rebaseCfcLabelView,
+} from "./cfc/label-view-state.ts";
 import { flowPrecisionSchemaForBuiltin } from "./cfc/flow-precision.ts";
 import { propagateRendererTrustedEvent } from "./cfc/ui-contract.ts";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -415,6 +424,7 @@ export function createCell<T>(
   tx?: IExtendedStorageTransaction,
   synced = false,
   kind?: CellKind,
+  cfcLabelView?: CfcLabelView,
 ): Cell<T> {
   return new CellImpl(
     runtime,
@@ -423,6 +433,7 @@ export function createCell<T>(
     synced,
     undefined, // No shared causeContainer
     kind,
+    cfcLabelView,
   ) as unknown as Cell<T>; // Cast to set brand
 }
 
@@ -476,6 +487,7 @@ export class CellImpl<T extends FabricValue>
     private synced: boolean = false,
     causeContainer?: CauseContainer,
     kind?: CellKind,
+    private _cfcLabelView?: CfcLabelView,
   ) {
     this._frame = getTopFrame();
 
@@ -495,6 +507,11 @@ export class CellImpl<T extends FabricValue>
     };
 
     this._kind = kind ?? "cell";
+    this._cfcLabelView = cloneCfcLabelView(_cfcLabelView);
+  }
+
+  [cfcLabelViewSymbol](): CfcLabelView | undefined {
+    return cloneCfcLabelView(this._cfcLabelView);
   }
 
   /**
@@ -678,7 +695,7 @@ export class CellImpl<T extends FabricValue>
       this.tx,
       this.link,
       [],
-      { ...options, synced: this.synced },
+      { ...options, synced: this.synced, cfcLabelView: this._cfcLabelView },
     );
     const elapsed = logger.timeEnd("cell", "get")!;
     if (elapsed > 50) {
@@ -708,7 +725,9 @@ export class CellImpl<T extends FabricValue>
     const readTx = this.runtime.readTx(this.tx);
     const nonReactiveTx = createNonReactiveTransaction(readTx);
 
-    return validateAndTransform(this.runtime, nonReactiveTx, this.link);
+    return validateAndTransform(this.runtime, nonReactiveTx, this.link, [], {
+      cfcLabelView: this._cfcLabelView,
+    });
   }
 
   /**
@@ -752,7 +771,9 @@ export class CellImpl<T extends FabricValue>
 
       const action: Action = (tx) => {
         // Read the value inside the effect - this ensures dependencies are pulled
-        result = validateAndTransform(this.runtime, tx, this.link);
+        result = validateAndTransform(this.runtime, tx, this.link, [], {
+          cfcLabelView: this._cfcLabelView,
+        });
 
         // If no schema or TrueSchema, traverse the result to register all
         // nested values as read dependencies.
@@ -1108,6 +1129,7 @@ export class CellImpl<T extends FabricValue>
   key(...keys: PropertyKey[]): Cell<any> {
     let currentLink = this._link;
     let childSchema: JSONSchema | undefined;
+    const childPath = keys.map((key) => key.toString());
 
     for (const key of keys) {
       // Get child schema if we have one
@@ -1142,6 +1164,7 @@ export class CellImpl<T extends FabricValue>
       this.synced,
       this._causeContainer,
       kind,
+      rebaseCfcLabelView(this._cfcLabelView, childPath),
     ) as unknown as Cell<any>;
   }
 
@@ -1166,6 +1189,7 @@ export class CellImpl<T extends FabricValue>
       false, // Reset synced flag, since schema is changing
       this._causeContainer, // Share the causeContainer with siblings
       this._kind,
+      this._cfcLabelView,
     ) as unknown as Cell<any>;
   }
 
@@ -1215,6 +1239,7 @@ export class CellImpl<T extends FabricValue>
       false, // Reset synced flag, since schema is changing
       this._causeContainer, // Share the causeContainer with siblings
       this._kind,
+      this._cfcLabelView,
     ) as unknown as Cell<T>;
   }
 
@@ -1228,6 +1253,7 @@ export class CellImpl<T extends FabricValue>
       this.synced,
       this._causeContainer, // Share the causeContainer with siblings
       this._kind,
+      this._cfcLabelView,
     ) as unknown as Cell<T>;
   }
 
@@ -1265,14 +1291,26 @@ export class CellImpl<T extends FabricValue>
 
   resolveAsCell(): Cell<T> {
     const readTx = this.runtime.readTx(this.tx);
+    const tracesBefore = readTx.getCfcState().dereferenceTraces.length;
     let link: NormalizedFullLink = resolveLink(
       this.runtime,
       readTx,
       this.link,
     );
+    const dereferenceView = cfcLabelViewForDereferenceTraces(
+      readTx,
+      readTx.getCfcState().dereferenceTraces.slice(tracesBefore),
+    );
     const nonReactiveTx = createNonReactiveTransaction(readTx);
     link = maybeConvertArrayPathToDataURILink(nonReactiveTx, link);
-    return createCell(this.runtime, link, this.tx, this.synced);
+    return createCell(
+      this.runtime,
+      link,
+      this.tx,
+      this.synced,
+      undefined,
+      mergeCfcLabelViews([this._cfcLabelView, dereferenceView]),
+    );
   }
 
   getAsQueryResult<Path extends PropertyKey[]>(
@@ -1291,6 +1329,10 @@ export class CellImpl<T extends FabricValue>
       },
       0,
       writable,
+      rebaseCfcLabelView(
+        this._cfcLabelView,
+        subPath.map((p) => p.toString()),
+      ),
     );
   }
 
@@ -2246,6 +2288,7 @@ export function convertCellsToLinks(
   options: {
     includeSchema?: boolean;
     doNotConvertCellResults?: boolean;
+    includeCfcLabelView?: boolean;
   } & SanitizeSchemaForLinksOptions = {},
   path: string[] = [],
   seen: Map<any, string[]> = new Map(),
@@ -2260,9 +2303,26 @@ export function convertCellsToLinks(
 
   // Early-return cases
   if (!options.doNotConvertCellResults && isCellResultForDereferencing(value)) {
-    return getCellOrThrow(value).getAsLink(options);
+    const cell = getCellOrThrow(value);
+    const link = cell.getAsLink(options);
+    if (options.includeCfcLabelView) {
+      const cfcLabelView = getCarriedCfcLabelView(cell);
+      if (cfcLabelView) {
+        (link["/"][LINK_V1_TAG] as { cfcLabelView?: CfcLabelView })
+          .cfcLabelView = cfcLabelView;
+      }
+    }
+    return link;
   } else if (isCell(value)) {
-    return value.getAsLink(options);
+    const link = value.getAsLink(options);
+    if (options.includeCfcLabelView) {
+      const cfcLabelView = getCarriedCfcLabelView(value);
+      if (cfcLabelView) {
+        (link["/"][LINK_V1_TAG] as { cfcLabelView?: CfcLabelView })
+          .cfcLabelView = cfcLabelView;
+      }
+    }
+    return link;
   } else if (!(isRecord(value) || isFunction(value))) {
     return value;
   }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -61,6 +61,7 @@ import {
 import { internalVerifierRead } from "./storage/reactivity-log.ts";
 import { type Cancel, isCancel, useCancelGroup } from "./cancel.ts";
 import {
+  type CellViewRef,
   processDefaultValue,
   resolveSchema,
   schemaHasIfc,
@@ -537,6 +538,13 @@ export class CellImpl<T extends FabricValue>
     return this._link as NormalizedFullLink;
   }
 
+  private get viewRef(): CellViewRef {
+    return {
+      link: this.link,
+      cfcLabelView: this._cfcLabelView,
+    };
+  }
+
   /**
    * Check if this cell has a full link (with id and space)
    */
@@ -693,9 +701,9 @@ export class CellImpl<T extends FabricValue>
     const value = validateAndTransform(
       this.runtime,
       this.tx,
-      this.link,
+      this.viewRef,
       [],
-      { ...options, synced: this.synced, cfcLabelView: this._cfcLabelView },
+      { ...options, synced: this.synced },
     );
     const elapsed = logger.timeEnd("cell", "get")!;
     if (elapsed > 50) {
@@ -725,9 +733,7 @@ export class CellImpl<T extends FabricValue>
     const readTx = this.runtime.readTx(this.tx);
     const nonReactiveTx = createNonReactiveTransaction(readTx);
 
-    return validateAndTransform(this.runtime, nonReactiveTx, this.link, [], {
-      cfcLabelView: this._cfcLabelView,
-    });
+    return validateAndTransform(this.runtime, nonReactiveTx, this.viewRef);
   }
 
   /**
@@ -771,9 +777,7 @@ export class CellImpl<T extends FabricValue>
 
       const action: Action = (tx) => {
         // Read the value inside the effect - this ensures dependencies are pulled
-        result = validateAndTransform(this.runtime, tx, this.link, [], {
-          cfcLabelView: this._cfcLabelView,
-        });
+        result = validateAndTransform(this.runtime, tx, this.viewRef);
 
         // If no schema or TrueSchema, traverse the result to register all
         // nested values as read dependencies.
@@ -1277,7 +1281,7 @@ export class CellImpl<T extends FabricValue>
       return subscribeToReferencedDocs(
         callback,
         this.runtime,
-        this.link,
+        this.viewRef,
         options,
       );
     }
@@ -1915,10 +1919,11 @@ export class CellImpl<T extends FabricValue>
 function subscribeToReferencedDocs<T>(
   callback: (value: T) => Cancel | undefined | void,
   runtime: Runtime,
-  link: NormalizedFullLink,
+  ref: CellViewRef,
   options: SinkOptions = {},
 ): Cancel {
   let cleanup: Cancel | undefined | void;
+  const link = ref.link;
 
   const action: Action = (tx) => {
     if (isCancel(cleanup)) cleanup();
@@ -1932,7 +1937,7 @@ function subscribeToReferencedDocs<T>(
     const schema = link.schema;
     const needsTraversal = schema === undefined ||
       ContextualFlowControl.isTrueSchema(schema);
-    const newValue = validateAndTransform(runtime, wrappedTx, link);
+    const newValue = validateAndTransform(runtime, wrappedTx, ref);
     if (needsTraversal && newValue !== undefined && newValue !== null) {
       deepTraverse(newValue);
     }

--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -10,6 +10,7 @@ import type {
   PreparedDigestInput,
   WritePolicyInput,
 } from "./types.ts";
+import { cloneCfcLabelView } from "./label-view-core.ts";
 
 export const canonicalizeLogicalPath = (path: readonly string[]): string[] =>
   path[0] === "value" ? [...path.slice(1)] : [...path];
@@ -65,12 +66,15 @@ export const canonicalizeWritePolicyInput = (
       };
     case "trusted-event":
       return { ...input, target: canonicalizeAttemptedWrite(input.target) };
-    case "link-write":
+    case "link-write": {
+      const cfcLabelView = cloneCfcLabelView(input.cfcLabelView);
       return {
         ...input,
         target: canonicalizeAttemptedWrite(input.target),
         source: canonicalizeAttemptedWrite(input.source),
+        ...(cfcLabelView !== undefined && { cfcLabelView }),
       };
+    }
     case "custom":
       return input.target === undefined
         ? input

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -31,7 +31,7 @@ export const cfcLabelViewPathKey = (path: readonly string[]): string => {
   }`;
 };
 
-const isPrefix = (
+export const cfcLabelPathPrefixMatches = (
   prefix: readonly string[],
   path: readonly string[],
 ): boolean =>
@@ -39,6 +39,13 @@ const isPrefix = (
   prefix.every((segment, index) =>
     segment === path[index] || segment === "*" || path[index] === "*"
   );
+
+export const cfcLabelPathsOverlap = (
+  left: readonly string[],
+  right: readonly string[],
+): boolean =>
+  cfcLabelPathPrefixMatches(left, right) ||
+  cfcLabelPathPrefixMatches(right, left);
 
 export const cloneCfcLabel = (label: IFCLabel): IFCLabel => {
   const cloned: IFCLabel = {};
@@ -130,7 +137,7 @@ export const rebaseCfcLabelView = (
   const entries: CfcLabelViewEntry[] = [];
   for (const entry of view.entries) {
     const entryPath = canonicalizeCfcLogicalPath(entry.path);
-    if (isPrefix(logicalPath, entryPath)) {
+    if (cfcLabelPathPrefixMatches(logicalPath, entryPath)) {
       const label = cloneCfcLabel(entry.label);
       if (hasCfcLabelValues(label)) {
         entries.push({
@@ -138,7 +145,7 @@ export const rebaseCfcLabelView = (
           label,
         });
       }
-    } else if (isPrefix(entryPath, logicalPath)) {
+    } else if (cfcLabelPathPrefixMatches(entryPath, logicalPath)) {
       const label = cloneCfcLabel(entry.label);
       if (hasCfcLabelValues(label)) {
         entries.push({ path: [], label });

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -1,0 +1,162 @@
+export type IFCLabel = {
+  confidentiality?: unknown[];
+  integrity?: unknown[];
+};
+
+export type CfcLabelViewEntry = {
+  path: string[];
+  label: IFCLabel;
+};
+
+export type CfcLabelView = {
+  version: 1;
+  entries: CfcLabelViewEntry[];
+};
+
+const LABEL_KEYS = [
+  "confidentiality",
+  "integrity",
+] as const satisfies readonly (keyof IFCLabel)[];
+
+export const canonicalizeCfcLogicalPath = (
+  path: readonly string[],
+): string[] => path[0] === "value" ? [...path.slice(1)] : [...path];
+
+export const cfcLabelViewPathKey = (path: readonly string[]): string => {
+  const logicalPath = canonicalizeCfcLogicalPath(path);
+  return logicalPath.length === 0 ? "" : `/${
+    logicalPath
+      .map((segment) => segment.replaceAll("~", "~0").replaceAll("/", "~1"))
+      .join("/")
+  }`;
+};
+
+const isPrefix = (
+  prefix: readonly string[],
+  path: readonly string[],
+): boolean =>
+  prefix.length <= path.length &&
+  prefix.every((segment, index) =>
+    segment === path[index] || segment === "*" || path[index] === "*"
+  );
+
+export const cloneCfcLabel = (label: IFCLabel): IFCLabel => {
+  const cloned: IFCLabel = {};
+  for (const key of LABEL_KEYS) {
+    const value = label[key];
+    if (Array.isArray(value) && value.length > 0) {
+      cloned[key] = [...value];
+    }
+  }
+  return cloned;
+};
+
+export const hasCfcLabelValues = (label: IFCLabel): boolean =>
+  LABEL_KEYS.some((key) => Array.isArray(label[key]) && label[key]!.length > 0);
+
+const sortEntries = (entries: CfcLabelViewEntry[]): CfcLabelViewEntry[] =>
+  entries.sort((left, right) =>
+    cfcLabelViewPathKey(left.path).localeCompare(
+      cfcLabelViewPathKey(right.path),
+    )
+  );
+
+const mergeLabel = (
+  left: IFCLabel | undefined,
+  right: IFCLabel,
+): IFCLabel => {
+  const merged: IFCLabel = {};
+  for (const key of LABEL_KEYS) {
+    const values = [
+      ...(Array.isArray(left?.[key]) ? left[key] : []),
+      ...(Array.isArray(right[key]) ? right[key] : []),
+    ];
+    const unique = [...new Set(values)];
+    if (unique.length > 0) {
+      merged[key] = unique;
+    }
+  }
+  return merged;
+};
+
+export const cloneCfcLabelView = (
+  view: CfcLabelView | undefined,
+): CfcLabelView | undefined => {
+  if (view === undefined) {
+    return undefined;
+  }
+  const entries = sortEntries(
+    view.entries.map((entry) => ({
+      path: canonicalizeCfcLogicalPath(entry.path),
+      label: cloneCfcLabel(entry.label),
+    })).filter((entry) => hasCfcLabelValues(entry.label)),
+  );
+  return entries.length > 0 ? { version: 1, entries } : undefined;
+};
+
+export const mergeCfcLabelViews = (
+  views: Array<CfcLabelView | undefined>,
+): CfcLabelView | undefined => {
+  const byPath = new Map<string, CfcLabelViewEntry>();
+  for (const view of views) {
+    if (!view) {
+      continue;
+    }
+    for (const entry of view.entries) {
+      const path = canonicalizeCfcLogicalPath(entry.path);
+      const key = cfcLabelViewPathKey(path);
+      const existing = byPath.get(key);
+      byPath.set(key, {
+        path,
+        label: mergeLabel(existing?.label, entry.label),
+      });
+    }
+  }
+  const entries = sortEntries(
+    [...byPath.values()].filter((entry) => hasCfcLabelValues(entry.label)),
+  );
+  return entries.length > 0 ? { version: 1, entries } : undefined;
+};
+
+export const rebaseCfcLabelView = (
+  view: CfcLabelView | undefined,
+  path: readonly string[],
+): CfcLabelView | undefined => {
+  if (!view) {
+    return undefined;
+  }
+
+  const logicalPath = canonicalizeCfcLogicalPath(path);
+  const entries: CfcLabelViewEntry[] = [];
+  for (const entry of view.entries) {
+    const entryPath = canonicalizeCfcLogicalPath(entry.path);
+    if (isPrefix(logicalPath, entryPath)) {
+      const label = cloneCfcLabel(entry.label);
+      if (hasCfcLabelValues(label)) {
+        entries.push({
+          path: entryPath.slice(logicalPath.length),
+          label,
+        });
+      }
+    } else if (isPrefix(entryPath, logicalPath)) {
+      const label = cloneCfcLabel(entry.label);
+      if (hasCfcLabelValues(label)) {
+        entries.push({ path: [], label });
+      }
+    }
+  }
+
+  return mergeCfcLabelViews([
+    entries.length > 0 ? { version: 1, entries } : undefined,
+  ]);
+};
+
+export const cfcLabelViewsEqual = (
+  left: CfcLabelView | undefined,
+  right: CfcLabelView | undefined,
+): boolean => {
+  if (left === right) return true;
+  if (left === undefined || right === undefined) return false;
+  return JSON.stringify(cloneCfcLabelView(left)) ===
+    JSON.stringify(cloneCfcLabelView(right));
+};

--- a/packages/runner/src/cfc/label-view-state.ts
+++ b/packages/runner/src/cfc/label-view-state.ts
@@ -1,152 +1,34 @@
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import { canonicalizeLogicalPath, logicalPathToPointer } from "./canonical.ts";
 import { readStoredCfcMetadata } from "./metadata.ts";
-import type {
-  CfcAddress,
-  CfcDereferenceTrace,
-  CfcMetadata,
+import type { CfcAddress, CfcDereferenceTrace, CfcMetadata } from "./types.ts";
+import {
+  canonicalizeCfcLogicalPath,
+  type CfcLabelView,
+  cloneCfcLabelView,
+  mergeCfcLabelViews,
+  rebaseCfcLabelView,
+} from "./label-view-core.ts";
+
+export type {
+  CfcLabelView,
+  CfcLabelViewEntry,
   IFCLabel,
-} from "./types.ts";
-
-export type CfcLabelViewEntry = {
-  path: string[];
-  label: IFCLabel;
-};
-
-export type CfcLabelView = {
-  version: 1;
-  entries: CfcLabelViewEntry[];
-};
+} from "./label-view-core.ts";
+export {
+  canonicalizeCfcLogicalPath,
+  cfcLabelViewPathKey,
+  cfcLabelViewsEqual,
+  cloneCfcLabel,
+  cloneCfcLabelView,
+  hasCfcLabelValues,
+  mergeCfcLabelViews,
+  rebaseCfcLabelView,
+} from "./label-view-core.ts";
 
 export const cfcLabelViewSymbol: unique symbol = Symbol("cfcLabelView");
 
 type CfcLabelCarrier = {
   [cfcLabelViewSymbol]?(): CfcLabelView | undefined;
-};
-
-const LABEL_KEYS = [
-  "confidentiality",
-  "integrity",
-] as const satisfies readonly (keyof IFCLabel)[];
-
-const isPrefix = (
-  prefix: readonly string[],
-  path: readonly string[],
-): boolean =>
-  prefix.length <= path.length &&
-  prefix.every((segment, index) =>
-    segment === path[index] || segment === "*" || path[index] === "*"
-  );
-
-export const cloneCfcLabel = (label: IFCLabel): IFCLabel => {
-  const cloned: IFCLabel = {};
-  for (const key of LABEL_KEYS) {
-    const value = label[key];
-    if (Array.isArray(value) && value.length > 0) {
-      cloned[key] = [...value];
-    }
-  }
-  return cloned;
-};
-
-export const hasCfcLabelValues = (label: IFCLabel): boolean =>
-  LABEL_KEYS.some((key) => Array.isArray(label[key]) && label[key]!.length > 0);
-
-const sortEntries = (entries: CfcLabelViewEntry[]): CfcLabelViewEntry[] =>
-  entries.sort((left, right) =>
-    logicalPathToPointer(left.path).localeCompare(
-      logicalPathToPointer(right.path),
-    )
-  );
-
-const mergeLabel = (
-  left: IFCLabel | undefined,
-  right: IFCLabel,
-): IFCLabel => {
-  const merged: IFCLabel = {};
-  for (const key of LABEL_KEYS) {
-    const values = [
-      ...(Array.isArray(left?.[key]) ? left[key] : []),
-      ...(Array.isArray(right[key]) ? right[key] : []),
-    ];
-    const unique = [...new Set(values)];
-    if (unique.length > 0) {
-      merged[key] = unique;
-    }
-  }
-  return merged;
-};
-
-export const cloneCfcLabelView = (
-  view: CfcLabelView | undefined,
-): CfcLabelView | undefined => {
-  if (view === undefined) {
-    return undefined;
-  }
-  const entries = sortEntries(
-    view.entries.map((entry) => ({
-      path: canonicalizeLogicalPath(entry.path),
-      label: cloneCfcLabel(entry.label),
-    })).filter((entry) => hasCfcLabelValues(entry.label)),
-  );
-  return entries.length > 0 ? { version: 1, entries } : undefined;
-};
-
-export const mergeCfcLabelViews = (
-  views: Array<CfcLabelView | undefined>,
-): CfcLabelView | undefined => {
-  const byPath = new Map<string, CfcLabelViewEntry>();
-  for (const view of views) {
-    if (!view) {
-      continue;
-    }
-    for (const entry of view.entries) {
-      const path = canonicalizeLogicalPath(entry.path);
-      const key = logicalPathToPointer(path);
-      const existing = byPath.get(key);
-      byPath.set(key, {
-        path,
-        label: mergeLabel(existing?.label, entry.label),
-      });
-    }
-  }
-  const entries = sortEntries(
-    [...byPath.values()].filter((entry) => hasCfcLabelValues(entry.label)),
-  );
-  return entries.length > 0 ? { version: 1, entries } : undefined;
-};
-
-export const rebaseCfcLabelView = (
-  view: CfcLabelView | undefined,
-  path: readonly string[],
-): CfcLabelView | undefined => {
-  if (!view) {
-    return undefined;
-  }
-
-  const logicalPath = canonicalizeLogicalPath(path);
-  const entries: CfcLabelViewEntry[] = [];
-  for (const entry of view.entries) {
-    const entryPath = canonicalizeLogicalPath(entry.path);
-    if (isPrefix(logicalPath, entryPath)) {
-      const label = cloneCfcLabel(entry.label);
-      if (hasCfcLabelValues(label)) {
-        entries.push({
-          path: entryPath.slice(logicalPath.length),
-          label,
-        });
-      }
-    } else if (isPrefix(entryPath, logicalPath)) {
-      const label = cloneCfcLabel(entry.label);
-      if (hasCfcLabelValues(label)) {
-        entries.push({ path: [], label });
-      }
-    }
-  }
-
-  return mergeCfcLabelViews([
-    entries.length > 0 ? { version: 1, entries } : undefined,
-  ]);
 };
 
 export const cfcLabelViewFromMetadata = (
@@ -176,7 +58,7 @@ const cfcLabelViewForAddress = (
   try {
     return cfcLabelViewFromMetadata(
       readStoredCfcMetadata(tx, address),
-      canonicalizeLogicalPath(address.path),
+      canonicalizeCfcLogicalPath(address.path),
     );
   } catch {
     return undefined;

--- a/packages/runner/src/cfc/label-view-state.ts
+++ b/packages/runner/src/cfc/label-view-state.ts
@@ -34,7 +34,9 @@ const isPrefix = (
   path: readonly string[],
 ): boolean =>
   prefix.length <= path.length &&
-  prefix.every((segment, index) => segment === path[index]);
+  prefix.every((segment, index) =>
+    segment === path[index] || segment === "*" || path[index] === "*"
+  );
 
 export const cloneCfcLabel = (label: IFCLabel): IFCLabel => {
   const cloned: IFCLabel = {};

--- a/packages/runner/src/cfc/label-view-state.ts
+++ b/packages/runner/src/cfc/label-view-state.ts
@@ -1,0 +1,212 @@
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import { canonicalizeLogicalPath, logicalPathToPointer } from "./canonical.ts";
+import { readStoredCfcMetadata } from "./metadata.ts";
+import type {
+  CfcAddress,
+  CfcDereferenceTrace,
+  CfcMetadata,
+  IFCLabel,
+} from "./types.ts";
+
+export type CfcLabelViewEntry = {
+  path: string[];
+  label: IFCLabel;
+};
+
+export type CfcLabelView = {
+  version: 1;
+  entries: CfcLabelViewEntry[];
+};
+
+export const cfcLabelViewSymbol: unique symbol = Symbol("cfcLabelView");
+
+type CfcLabelCarrier = {
+  [cfcLabelViewSymbol]?(): CfcLabelView | undefined;
+};
+
+const LABEL_KEYS = [
+  "confidentiality",
+  "integrity",
+] as const satisfies readonly (keyof IFCLabel)[];
+
+const isPrefix = (
+  prefix: readonly string[],
+  path: readonly string[],
+): boolean =>
+  prefix.length <= path.length &&
+  prefix.every((segment, index) => segment === path[index]);
+
+export const cloneCfcLabel = (label: IFCLabel): IFCLabel => {
+  const cloned: IFCLabel = {};
+  for (const key of LABEL_KEYS) {
+    const value = label[key];
+    if (Array.isArray(value) && value.length > 0) {
+      cloned[key] = [...value];
+    }
+  }
+  return cloned;
+};
+
+export const hasCfcLabelValues = (label: IFCLabel): boolean =>
+  LABEL_KEYS.some((key) => Array.isArray(label[key]) && label[key]!.length > 0);
+
+const sortEntries = (entries: CfcLabelViewEntry[]): CfcLabelViewEntry[] =>
+  entries.sort((left, right) =>
+    logicalPathToPointer(left.path).localeCompare(
+      logicalPathToPointer(right.path),
+    )
+  );
+
+const mergeLabel = (
+  left: IFCLabel | undefined,
+  right: IFCLabel,
+): IFCLabel => {
+  const merged: IFCLabel = {};
+  for (const key of LABEL_KEYS) {
+    const values = [
+      ...(Array.isArray(left?.[key]) ? left[key] : []),
+      ...(Array.isArray(right[key]) ? right[key] : []),
+    ];
+    const unique = [...new Set(values)];
+    if (unique.length > 0) {
+      merged[key] = unique;
+    }
+  }
+  return merged;
+};
+
+export const cloneCfcLabelView = (
+  view: CfcLabelView | undefined,
+): CfcLabelView | undefined => {
+  if (view === undefined) {
+    return undefined;
+  }
+  const entries = sortEntries(
+    view.entries.map((entry) => ({
+      path: canonicalizeLogicalPath(entry.path),
+      label: cloneCfcLabel(entry.label),
+    })).filter((entry) => hasCfcLabelValues(entry.label)),
+  );
+  return entries.length > 0 ? { version: 1, entries } : undefined;
+};
+
+export const mergeCfcLabelViews = (
+  views: Array<CfcLabelView | undefined>,
+): CfcLabelView | undefined => {
+  const byPath = new Map<string, CfcLabelViewEntry>();
+  for (const view of views) {
+    if (!view) {
+      continue;
+    }
+    for (const entry of view.entries) {
+      const path = canonicalizeLogicalPath(entry.path);
+      const key = logicalPathToPointer(path);
+      const existing = byPath.get(key);
+      byPath.set(key, {
+        path,
+        label: mergeLabel(existing?.label, entry.label),
+      });
+    }
+  }
+  const entries = sortEntries(
+    [...byPath.values()].filter((entry) => hasCfcLabelValues(entry.label)),
+  );
+  return entries.length > 0 ? { version: 1, entries } : undefined;
+};
+
+export const rebaseCfcLabelView = (
+  view: CfcLabelView | undefined,
+  path: readonly string[],
+): CfcLabelView | undefined => {
+  if (!view) {
+    return undefined;
+  }
+
+  const logicalPath = canonicalizeLogicalPath(path);
+  const entries: CfcLabelViewEntry[] = [];
+  for (const entry of view.entries) {
+    const entryPath = canonicalizeLogicalPath(entry.path);
+    if (isPrefix(logicalPath, entryPath)) {
+      const label = cloneCfcLabel(entry.label);
+      if (hasCfcLabelValues(label)) {
+        entries.push({
+          path: entryPath.slice(logicalPath.length),
+          label,
+        });
+      }
+    } else if (isPrefix(entryPath, logicalPath)) {
+      const label = cloneCfcLabel(entry.label);
+      if (hasCfcLabelValues(label)) {
+        entries.push({ path: [], label });
+      }
+    }
+  }
+
+  return mergeCfcLabelViews([
+    entries.length > 0 ? { version: 1, entries } : undefined,
+  ]);
+};
+
+export const cfcLabelViewFromMetadata = (
+  metadata: CfcMetadata | undefined,
+  path: readonly string[],
+): CfcLabelView | undefined => {
+  if (!metadata) {
+    return undefined;
+  }
+
+  return rebaseCfcLabelView(
+    {
+      version: 1,
+      entries: metadata.labelMap.entries.map((entry) => ({
+        path: entry.path,
+        label: entry.label,
+      })),
+    },
+    path,
+  );
+};
+
+const cfcLabelViewForAddress = (
+  tx: IExtendedStorageTransaction,
+  address: CfcAddress,
+): CfcLabelView | undefined => {
+  try {
+    return cfcLabelViewFromMetadata(
+      readStoredCfcMetadata(tx, address),
+      canonicalizeLogicalPath(address.path),
+    );
+  } catch {
+    return undefined;
+  }
+};
+
+export const cfcLabelViewForDereference = (
+  tx: IExtendedStorageTransaction,
+  source: CfcAddress,
+  target: CfcAddress,
+): CfcLabelView | undefined =>
+  mergeCfcLabelViews([
+    cfcLabelViewForAddress(tx, source),
+    cfcLabelViewForAddress(tx, target),
+  ]);
+
+export const cfcLabelViewForDereferenceTraces = (
+  tx: IExtendedStorageTransaction,
+  traces: readonly CfcDereferenceTrace[],
+): CfcLabelView | undefined =>
+  mergeCfcLabelViews(
+    traces.map((trace) =>
+      cfcLabelViewForDereference(tx, trace.source, trace.target)
+    ),
+  );
+
+export const getCarriedCfcLabelView = (
+  value: unknown,
+): CfcLabelView | undefined => {
+  const carrier = value as Partial<CfcLabelCarrier> | undefined;
+  if (typeof carrier?.[cfcLabelViewSymbol] !== "function") {
+    return undefined;
+  }
+  return cloneCfcLabelView(carrier[cfcLabelViewSymbol]());
+};

--- a/packages/runner/src/cfc/label-view.ts
+++ b/packages/runner/src/cfc/label-view.ts
@@ -5,94 +5,31 @@ import type {
 } from "../storage/interface.ts";
 import type { NormalizedFullLink } from "../link-utils.ts";
 import type { Runtime } from "../runtime.ts";
-import { canonicalizeLogicalPath, logicalPathToPointer } from "./canonical.ts";
 import { readStoredCfcMetadata } from "./metadata.ts";
-import type { CfcMetadata, IFCLabel } from "./types.ts";
-import { isInternalVerifierRead } from "../storage/reactivity-log.ts";
+import type { CfcMetadata } from "./types.ts";
+import {
+  type CfcLabelView,
+  type CfcLabelViewEntry,
+  cfcLabelViewFromMetadata,
+  getCarriedCfcLabelView,
+  mergeCfcLabelViews,
+} from "./label-view-state.ts";
 
-export type CfcLabelViewEntry = {
-  path: string[];
-  label: IFCLabel;
-};
-
-export type CfcLabelView = {
-  version: 1;
-  entries: CfcLabelViewEntry[];
-};
+export type { CfcLabelView, CfcLabelViewEntry };
+export {
+  cfcLabelViewForDereference,
+  cfcLabelViewForDereferenceTraces,
+  cfcLabelViewFromMetadata,
+  cloneCfcLabelView,
+  getCarriedCfcLabelView,
+  mergeCfcLabelViews,
+  rebaseCfcLabelView,
+} from "./label-view-state.ts";
 
 type LabelQueryableCell = {
   getAsNormalizedFullLink(): NormalizedFullLink;
-  get?(options?: { traverseCells?: boolean }): unknown;
-  getSourceCell?(): LabelQueryableCell | undefined;
-  withTx?(tx: IExtendedStorageTransaction): LabelQueryableCell;
   runtime?: Runtime;
   tx?: IExtendedStorageTransaction;
-};
-
-const LABEL_KEYS = [
-  "confidentiality",
-  "integrity",
-] as const satisfies readonly (keyof IFCLabel)[];
-
-const isPrefix = (
-  prefix: readonly string[],
-  path: readonly string[],
-): boolean =>
-  prefix.length <= path.length &&
-  prefix.every((segment, index) => segment === path[index]);
-
-const cloneLabel = (label: IFCLabel): IFCLabel => {
-  const cloned: IFCLabel = {};
-  for (const key of LABEL_KEYS) {
-    const value = label[key];
-    if (Array.isArray(value) && value.length > 0) {
-      cloned[key] = [...value];
-    }
-  }
-  return cloned;
-};
-
-const hasLabelValues = (label: IFCLabel): boolean =>
-  LABEL_KEYS.some((key) => Array.isArray(label[key]) && label[key]!.length > 0);
-
-const sortEntries = (entries: CfcLabelViewEntry[]): CfcLabelViewEntry[] =>
-  entries.sort((left, right) =>
-    logicalPathToPointer(left.path).localeCompare(
-      logicalPathToPointer(right.path),
-    )
-  );
-
-export const cfcLabelViewFromMetadata = (
-  metadata: CfcMetadata | undefined,
-  path: readonly string[],
-): CfcLabelView | undefined => {
-  if (!metadata) {
-    return undefined;
-  }
-
-  const logicalPath = canonicalizeLogicalPath(path);
-  const entries: CfcLabelViewEntry[] = [];
-  for (const entry of metadata.labelMap.entries) {
-    const entryPath = canonicalizeLogicalPath(entry.path);
-    if (isPrefix(logicalPath, entryPath)) {
-      const label = cloneLabel(entry.label);
-      if (hasLabelValues(label)) {
-        entries.push({
-          path: entryPath.slice(logicalPath.length),
-          label,
-        });
-      }
-    } else if (isPrefix(entryPath, logicalPath)) {
-      const label = cloneLabel(entry.label);
-      if (hasLabelValues(label)) {
-        entries.push({ path: [], label });
-      }
-    }
-  }
-
-  return entries.length > 0
-    ? { version: 1, entries: sortEntries(entries) }
-    : undefined;
 };
 
 const storedMetadataForCell = (
@@ -116,90 +53,6 @@ const storedMetadataForCell = (
   }
 };
 
-const mergeLabel = (left: IFCLabel | undefined, right: IFCLabel): IFCLabel => {
-  const merged: IFCLabel = {};
-  for (const key of LABEL_KEYS) {
-    const values = [
-      ...(Array.isArray(left?.[key]) ? left[key] : []),
-      ...(Array.isArray(right[key]) ? right[key] : []),
-    ];
-    const unique = [...new Set(values)];
-    if (unique.length > 0) {
-      merged[key] = unique;
-    }
-  }
-  return merged;
-};
-
-const mergeViews = (
-  views: Array<CfcLabelView | undefined>,
-): CfcLabelView | undefined => {
-  const byPath = new Map<string, CfcLabelViewEntry>();
-  for (const view of views) {
-    if (!view) {
-      continue;
-    }
-    for (const entry of view.entries) {
-      const path = canonicalizeLogicalPath(entry.path);
-      const key = logicalPathToPointer(path);
-      const existing = byPath.get(key);
-      byPath.set(key, {
-        path,
-        label: mergeLabel(existing?.label, entry.label),
-      });
-    }
-  }
-  const entries = sortEntries(
-    [...byPath.values()].filter((entry) => hasLabelValues(entry.label)),
-  );
-  return entries.length > 0 ? { version: 1, entries } : undefined;
-};
-
-const readLabelViewForCell = (
-  cell: LabelQueryableCell,
-): CfcLabelView | undefined => {
-  if (!cell.runtime || typeof cell.withTx !== "function") {
-    return undefined;
-  }
-
-  const tx = cell.runtime.readTx();
-  try {
-    const readCell = cell.withTx(tx);
-    if (typeof readCell.get === "function") {
-      readCell.get({ traverseCells: true });
-    } else {
-      const link = readCell.getAsNormalizedFullLink();
-      tx.readValueOrThrow(link);
-    }
-  } catch {
-    return undefined;
-  }
-
-  const reads = [...(tx.getReadActivities?.() ?? [])];
-  const views = reads.flatMap((read) => {
-    if (isInternalVerifierRead(read.meta)) {
-      return [];
-    }
-    return cfcLabelViewFromMetadata(
-      readStoredCfcMetadata(tx, read),
-      canonicalizeLogicalPath(read.path),
-    );
-  });
-  views.push(
-    ...tx.getCfcState().dereferenceTraces.flatMap((trace) => [
-      cfcLabelViewFromMetadata(
-        readStoredCfcMetadata(tx, trace.source),
-        canonicalizeLogicalPath(trace.source.path),
-      ),
-      cfcLabelViewFromMetadata(
-        readStoredCfcMetadata(tx, trace.target),
-        canonicalizeLogicalPath(trace.target.path),
-      ),
-    ]),
-  );
-  return mergeViews(views);
-};
-
 export const cfcLabelViewForCell = (
   cell: unknown,
 ): CfcLabelView | undefined => {
@@ -207,14 +60,14 @@ export const cfcLabelViewForCell = (
     !isRecord(cell) ||
     typeof cell.getAsNormalizedFullLink !== "function"
   ) {
-    return undefined;
+    return getCarriedCfcLabelView(cell);
   }
 
   let link: NormalizedFullLink;
   try {
     link = (cell as LabelQueryableCell).getAsNormalizedFullLink();
   } catch {
-    return undefined;
+    return getCarriedCfcLabelView(cell);
   }
 
   const metadataView = cfcLabelViewFromMetadata(
@@ -222,19 +75,8 @@ export const cfcLabelViewForCell = (
     link.path,
   );
 
-  const sourceCell = (cell as LabelQueryableCell).getSourceCell?.();
-  let sourceMetadataView: CfcLabelView | undefined;
-  if (sourceCell !== undefined) {
-    const sourceLink = sourceCell.getAsNormalizedFullLink();
-    sourceMetadataView = cfcLabelViewFromMetadata(
-      storedMetadataForCell(sourceCell, sourceLink),
-      link.path,
-    );
-  }
-
-  return mergeViews([
+  return mergeCfcLabelViews([
     metadataView,
-    sourceMetadataView,
-    readLabelViewForCell(cell as LabelQueryableCell),
+    getCarriedCfcLabelView(cell),
   ]);
 };

--- a/packages/runner/src/cfc/metadata.ts
+++ b/packages/runner/src/cfc/metadata.ts
@@ -1,7 +1,6 @@
 import { isRecord } from "@commonfabric/utils/types";
 import type { URI } from "@commonfabric/memory/interface";
 import type { NormalizedFullLink } from "../link-utils.ts";
-import { ignoreReadForScheduling } from "../scheduler.ts";
 import type {
   IExtendedStorageTransaction,
   MediaType,
@@ -12,7 +11,6 @@ import { canonicalizeLogicalPath } from "./canonical.ts";
 import type { CfcMetadata } from "./types.ts";
 
 const INTERNAL_VERIFIER_META = {
-  ...ignoreReadForScheduling,
   ...internalVerifierRead,
 };
 
@@ -22,6 +20,10 @@ const isPrefix = (
 ): boolean =>
   left.length <= right.length &&
   left.every((segment, index) => segment === right[index]);
+
+const isCfcMetadata = (value: unknown): value is CfcMetadata =>
+  isRecord(value) && value.version === 1 && isRecord(value.labelMap) &&
+  Array.isArray(value.labelMap.entries);
 
 export const readStoredCfcMetadata = (
   tx: IExtendedStorageTransaction,
@@ -35,12 +37,15 @@ export const readStoredCfcMetadata = (
     space: target.space,
     id: target.id as URI,
     type: target.type as MediaType,
-    path: [],
+    path: ["cfc"],
   }, {
     meta: INTERNAL_VERIFIER_META,
   });
-  return isRecord(document) && isRecord(document.cfc)
-    ? document.cfc as CfcMetadata
+  if (isCfcMetadata(document)) {
+    return document;
+  }
+  return isRecord(document) && isCfcMetadata(document.cfc)
+    ? document.cfc
     : undefined;
 };
 

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -1,5 +1,14 @@
 export type { CfcLabelView, CfcLabelViewEntry } from "./label-view.ts";
-export { cfcLabelViewForCell, cfcLabelViewFromMetadata } from "./label-view.ts";
+export {
+  cfcLabelViewForCell,
+  cfcLabelViewForDereference,
+  cfcLabelViewForDereferenceTraces,
+  cfcLabelViewFromMetadata,
+  cloneCfcLabelView,
+  getCarriedCfcLabelView,
+  mergeCfcLabelViews,
+  rebaseCfcLabelView,
+} from "./label-view.ts";
 export type {
   AttemptedWrite,
   CfcAddress,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -923,15 +923,24 @@ const derivePersistedLinkLabel = (
     )
     : undefined;
   const linkSchemaLabel = rootLabelFromSchema(input.linkSchema);
+  const hasCarriedLabel =
+    input.cfcLabelView?.entries.some((entry) => hasLabelValues(entry.label)) ??
+      false;
   if (
     sourceMetadata === undefined && pendingSourceLabel === undefined &&
-    !hasLabelValues(linkSchemaLabel)
+    !hasLabelValues(linkSchemaLabel) && !hasCarriedLabel
   ) {
     return {
       reason: `missing link source metadata for ${input.target.id} at /${
         input.target.path.join("/")
       }`,
     };
+  }
+  if (
+    sourceMetadata === undefined && pendingSourceLabel === undefined &&
+    !hasLabelValues(linkSchemaLabel) && hasCarriedLabel
+  ) {
+    return {};
   }
   const sourceLabel = mergeLabels(
     sourceMetadata === undefined ? undefined : labelAtPath(
@@ -960,6 +969,24 @@ const cloneLabel = (label: IFCLabel): IFCLabel => ({
     : {}),
   ...(label.integrity !== undefined ? { integrity: [...label.integrity] } : {}),
 });
+
+const coalesceLabelEntries = (
+  entries: Array<{ path: string[]; label: IFCLabel }>,
+): Array<{ path: string[]; label: IFCLabel }> => {
+  const byPath = new Map<string, { path: string[]; label: IFCLabel }>();
+  for (const entry of entries) {
+    const path = [...entry.path];
+    const key = pathKey(path);
+    const existing = byPath.get(key);
+    byPath.set(key, {
+      path,
+      label: mergeLabels(existing?.label, cloneLabel(entry.label)),
+    });
+  }
+  return [...byPath.values()].sort((left, right) =>
+    pathKey(left.path).localeCompare(pathKey(right.path))
+  );
+};
 
 const ensureSchemaDocument = (
   tx: IExtendedStorageTransaction,
@@ -1181,9 +1208,24 @@ export const prepareBoundaryCommit = (
           label: result.label,
         });
       }
+      const targetPath = canonicalizeLogicalPath(input.target.path);
+      for (const entry of input.cfcLabelView?.entries ?? []) {
+        if (!hasLabelValues(entry.label)) {
+          continue;
+        }
+        persistedLabelEntries.push({
+          path: [
+            ...targetPath,
+            ...canonicalizeLogicalPath(entry.path),
+          ],
+          label: cloneLabel(entry.label),
+        });
+      }
     }
 
-    if (persistedLabelEntries.length === 0) {
+    const coalescedLabelEntries = coalesceLabelEntries(persistedLabelEntries);
+
+    if (coalescedLabelEntries.length === 0) {
       continue;
     }
 
@@ -1198,7 +1240,7 @@ export const prepareBoundaryCommit = (
       schemaHash: schemaAndHash.hashString,
       labelMap: {
         version: 1,
-        entries: persistedLabelEntries,
+        entries: coalescedLabelEntries,
       },
     };
 

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -1,6 +1,9 @@
 import type { JSONSchema } from "../builder/types.ts";
 import type { FabricValue, MemorySpace } from "@commonfabric/memory/interface";
 import type { Metadata } from "../storage/interface.ts";
+import type { IFCLabel } from "./label-view-core.ts";
+
+export type { IFCLabel } from "./label-view-core.ts";
 
 export const CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION =
   "runtime.setup.result-projection";
@@ -25,11 +28,6 @@ export const isCfcEnforcementMode = (
   CFC_ENFORCEMENT_MODES.includes(input as CfcEnforcementMode);
 
 export const DEFAULT_CFC_ENFORCEMENT_MODE: CfcEnforcementMode = "disabled";
-
-export type IFCLabel = {
-  confidentiality?: unknown[];
-  integrity?: unknown[];
-};
 
 export type CfcSandboxJsonValue =
   | null

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -1,9 +1,9 @@
 import type { JSONSchema } from "../builder/types.ts";
 import type { FabricValue, MemorySpace } from "@commonfabric/memory/interface";
 import type { Metadata } from "../storage/interface.ts";
-import type { IFCLabel } from "./label-view-core.ts";
+import type { CfcLabelView, IFCLabel } from "./label-view-core.ts";
 
-export type { IFCLabel } from "./label-view-core.ts";
+export type { CfcLabelView, IFCLabel } from "./label-view-core.ts";
 
 export const CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION =
   "runtime.setup.result-projection";
@@ -182,6 +182,7 @@ export type WritePolicyInput =
     target: CfcAddress;
     source: CfcAddress;
     linkSchema?: JSONSchema;
+    cfcLabelView?: CfcLabelView;
   }
   | {
     kind: "sink-request";

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -18,11 +18,15 @@ import {
   findAndInlineDataURILinks,
   isCellLink,
   isPrimitiveCellLink,
+  isSigilLink,
   isWriteRedirectLink,
   type NormalizedFullLink,
   parseLink,
 } from "./link-utils.ts";
-import { isCellResultForDereferencing } from "./query-result-proxy.ts";
+import {
+  getCellOrThrow,
+  isCellResultForDereferencing,
+} from "./query-result-proxy.ts";
 import type {
   IExtendedStorageTransaction,
   IReadOptions,
@@ -38,7 +42,13 @@ import {
   storedCfcMetadataAppliesToPath,
 } from "./cfc/metadata.ts";
 import { canonicalizeLogicalPath } from "./cfc/canonical.ts";
+import {
+  type CfcLabelView,
+  cloneCfcLabelView,
+  getCarriedCfcLabelView,
+} from "./cfc/label-view-state.ts";
 import type { CfcAddress } from "./cfc/types.ts";
+import { LINK_V1_TAG } from "./sigil-types.ts";
 
 const diffLogger = getLogger("normalizeAndDiff", {
   enabled: false,
@@ -90,6 +100,9 @@ const labelHasValues = (
 ): boolean =>
   (label.confidentiality?.length ?? 0) > 0 ||
   (label.integrity?.length ?? 0) > 0;
+
+const cfcLabelViewHasValues = (view: CfcLabelView | undefined): boolean =>
+  view?.entries.some((entry) => labelHasValues(entry.label)) ?? false;
 
 const schemaIfcOverlapsPath = (
   schema: JSONSchema | undefined,
@@ -151,14 +164,17 @@ const recordLinkWritePolicyInput = (
   tx: IExtendedStorageTransaction,
   target: NormalizedFullLink,
   source: NormalizedFullLink,
+  cfcLabelView?: CfcLabelView,
 ): void => {
   if (tx.getCfcState().enforcementMode === "disabled") {
     return;
   }
+  const carriedCfcLabelView = cloneCfcLabelView(cfcLabelView);
   const sourceMetadata = readStoredCfcMetadata(tx, source);
   const sourceRelevant = schemaIfcOverlapsPath(source.schema, [], []) ||
     sourceMetadata !== undefined ||
-    hasPendingSchemaPolicyInput(tx, source);
+    hasPendingSchemaPolicyInput(tx, source) ||
+    cfcLabelViewHasValues(carriedCfcLabelView);
   const targetRelevant = storedCfcMetadataAppliesToPath(tx, target) ||
     hasPendingSchemaPolicyInput(tx, target);
   if (!sourceRelevant && !targetRelevant) {
@@ -171,7 +187,58 @@ const recordLinkWritePolicyInput = (
     target: cfcAddressFromLink(target),
     source: cfcAddressFromLink(source),
     ...(source.schema !== undefined && { linkSchema: source.schema }),
+    ...(carriedCfcLabelView !== undefined && {
+      cfcLabelView: carriedCfcLabelView,
+    }),
   });
+};
+
+const cfcLabelViewForPrimitiveLink = (
+  value: unknown,
+): CfcLabelView | undefined => {
+  if (!isSigilLink(value)) {
+    return undefined;
+  }
+  return cloneCfcLabelView(
+    (value["/"][LINK_V1_TAG] as { cfcLabelView?: CfcLabelView })
+      .cfcLabelView,
+  );
+};
+
+const attachCfcLabelViewToSigilLink = (
+  value: unknown,
+  cfcLabelView: CfcLabelView | undefined,
+): unknown => {
+  const clonedView = cloneCfcLabelView(cfcLabelView);
+  if (!clonedView || !isSigilLink(value)) {
+    return value;
+  }
+  return {
+    "/": {
+      [LINK_V1_TAG]: {
+        ...value["/"][LINK_V1_TAG],
+        cfcLabelView: clonedView,
+      },
+    },
+  };
+};
+
+const stripCfcLabelViewFromPrimitiveLink = (value: unknown): unknown => {
+  if (!isSigilLink(value)) {
+    return value;
+  }
+  const inner = value["/"][LINK_V1_TAG] as
+    & Record<string, unknown>
+    & { cfcLabelView?: CfcLabelView };
+  if (inner.cfcLabelView === undefined) {
+    return value;
+  }
+  const { cfcLabelView: _cfcLabelView, ...cleanInner } = inner;
+  return {
+    "/": {
+      [LINK_V1_TAG]: cleanInner,
+    },
+  };
 };
 
 /**
@@ -350,8 +417,14 @@ export function normalizeAndDiff(
 
   // Unwrap proxies and handle special types
   if (isCellResultForDereferencing(newValue)) {
+    const carriedCfcLabelView = getCarriedCfcLabelView(
+      getCellOrThrow(newValue),
+    );
     const parsedLink = parseLink(newValue);
-    const sigilLink = createSigilLinkFromParsedLink(parsedLink);
+    const sigilLink = attachCfcLabelViewToSigilLink(
+      createSigilLinkFromParsedLink(parsedLink),
+      carriedCfcLabelView,
+    );
     diffLogger.debug(
       "diff",
       () =>
@@ -372,7 +445,11 @@ export function normalizeAndDiff(
       () => `[BRANCH_CELL] Converting cell to link at path=${pathStr}`,
     );
     linkOriginFromCell = true;
-    newValue = newValue.getAsLink();
+    const carriedCfcLabelView = getCarriedCfcLabelView(newValue);
+    newValue = attachCfcLabelViewToSigilLink(
+      newValue.getAsLink(),
+      carriedCfcLabelView,
+    );
   }
 
   // Check for links that are data: URIs and inline them, by calling
@@ -408,6 +485,7 @@ export function normalizeAndDiff(
 
   // A new alias can overwrite a previous alias. No-op if the same.
   if (isWriteRedirectLink(newValue)) {
+    const carriedCfcLabelView = cfcLabelViewForPrimitiveLink(newValue);
     const parsedLink = parseLink(newValue, link);
     if (
       isWriteRedirectLink(currentValue) &&
@@ -420,6 +498,9 @@ export function normalizeAndDiff(
         "diff",
         () => `[BRANCH_WRITE_REDIRECT] Same redirect, no-op at path=${pathStr}`,
       );
+      if (cfcLabelViewHasValues(carriedCfcLabelView)) {
+        recordLinkWritePolicyInput(tx, link, parsedLink, carriedCfcLabelView);
+      }
       return [];
     } else {
       diffLogger.debug(
@@ -427,8 +508,11 @@ export function normalizeAndDiff(
         () =>
           `[BRANCH_WRITE_REDIRECT] Different redirect, updating at path=${pathStr}`,
       );
-      recordLinkWritePolicyInput(tx, link, parsedLink);
-      changes.push({ location: link, value: newValue as FabricValue });
+      recordLinkWritePolicyInput(tx, link, parsedLink, carriedCfcLabelView);
+      changes.push({
+        location: link,
+        value: stripCfcLabelViewFromPrimitiveLink(newValue) as FabricValue,
+      });
       return changes;
     }
   }
@@ -466,6 +550,7 @@ export function normalizeAndDiff(
           JSON.stringify(newValue as any)
         }`,
     );
+    const carriedCfcLabelView = cfcLabelViewForPrimitiveLink(newValue);
     const parsedLink = parseLink(newValue, link);
 
     // Collapse same-document self/parent links created by query-result dereferencing.
@@ -504,6 +589,9 @@ export function normalizeAndDiff(
         "diff",
         () => `[BRANCH_CELL_LINK] Same cell link, no-op at path=${pathStr}`,
       );
+      if (cfcLabelViewHasValues(carriedCfcLabelView)) {
+        recordLinkWritePolicyInput(tx, link, parsedLink, carriedCfcLabelView);
+      }
       return [];
     } else {
       diffLogger.debug(
@@ -511,10 +599,13 @@ export function normalizeAndDiff(
         () =>
           `[BRANCH_CELL_LINK] Different cell link, updating at path=${pathStr}`,
       );
-      recordLinkWritePolicyInput(tx, link, parsedLink);
+      recordLinkWritePolicyInput(tx, link, parsedLink, carriedCfcLabelView);
       return [
         // TODO(seefeld): Normalize the link to a sigil link?
-        { location: link, value: newValue as FabricValue },
+        {
+          location: link,
+          value: stripCfcLabelViewFromPrimitiveLink(newValue) as FabricValue,
+        },
       ];
     }
   }

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -10,6 +10,13 @@ import { type Cell, createCell, recursivelyAddIDIfNeeded } from "./cell.ts";
 import { type Runtime } from "./runtime.ts";
 import { type IExtendedStorageTransaction } from "./storage/interface.ts";
 import { toURI } from "./uri-utils.ts";
+import {
+  type CfcLabelView,
+  cfcLabelViewForDereferenceTraces,
+  cloneCfcLabelView,
+  mergeCfcLabelViews,
+  rebaseCfcLabelView,
+} from "./cfc/label-view-state.ts";
 
 // Maximum recursion depth to prevent infinite loops
 const MAX_RECURSION_DEPTH = 100;
@@ -45,6 +52,7 @@ const getProxyCache = (
 const proxyCacheKey = (
   link: NormalizedFullLink,
   writable: boolean,
+  cfcLabelView: CfcLabelView | undefined,
 ): string =>
   JSON.stringify([
     writable,
@@ -52,7 +60,13 @@ const proxyCacheKey = (
     link.id,
     link.type,
     link.path,
+    cfcLabelView ?? null,
   ]);
+
+const childLabelView = (
+  cfcLabelView: CfcLabelView | undefined,
+  segment: string,
+): CfcLabelView | undefined => rebaseCfcLabelView(cfcLabelView, [segment]);
 
 // Array.prototype's entries, and whether they modify the array
 enum ArrayMethodType {
@@ -113,6 +127,7 @@ export function createQueryResultProxy<T>(
   link: NormalizedFullLink,
   depth: number = 0,
   writable: boolean = false,
+  cfcLabelView?: CfcLabelView,
 ): T {
   // Check recursion depth
   if (depth > MAX_RECURSION_DEPTH) {
@@ -124,7 +139,15 @@ export function createQueryResultProxy<T>(
   // Resolve path and follow links to actual value.
   const readTx = tx === undefined ? runtime.edit() : runtime.readTx(tx);
   const proxyTx = tx ?? readTx;
+  const traceStart = readTx.getCfcState().dereferenceTraces.length;
   link = resolveLink(runtime, readTx, link);
+  cfcLabelView = mergeCfcLabelViews([
+    cloneCfcLabelView(cfcLabelView),
+    cfcLabelViewForDereferenceTraces(
+      readTx,
+      readTx.getCfcState().dereferenceTraces.slice(traceStart),
+    ),
+  ]);
   const value = readTx.readValueOrThrow(link) as any;
 
   // If the value is a stream marker ({ $stream: true }), return a Cell with
@@ -132,7 +155,7 @@ export function createQueryResultProxy<T>(
   // pattern's Output type wasn't explicitly specified, causing the capture
   // schema to lose the asStream information.
   if (isStreamValue(value)) {
-    return createCell(runtime, link, tx, false, "stream") as T;
+    return createCell(runtime, link, tx, false, "stream", cfcLabelView) as T;
   }
 
   if (!isRecord(value)) return value;
@@ -171,13 +194,13 @@ export function createQueryResultProxy<T>(
 
   // Get the appropriate cache index by log
   const txCache = getProxyCache(tx);
-  const cacheKey = proxyCacheKey(link, writable);
+  const cacheKey = proxyCacheKey(link, writable, cfcLabelView);
 
   // Check if we already have a proxy for this target in the cache.
   // The cache key is the original `value` (not the stub), ensuring that
   // the same frozen object always maps to the same proxy instance.
   const existingProxy = txCache.byLink.get(cacheKey) ??
-    txCache.byValue.get(value);
+    (cfcLabelView === undefined ? txCache.byValue.get(value) : undefined);
   if (existingProxy) return existingProxy;
 
   const proxy = new Proxy(proxyTarget as object, {
@@ -197,7 +220,8 @@ export function createQueryResultProxy<T>(
 
       if (typeof prop === "symbol") {
         if (prop === toCell) {
-          return () => createCell(runtime, link, tx);
+          return () =>
+            createCell(runtime, link, tx, false, undefined, cfcLabelView);
         } else if (prop === Symbol.iterator && Array.isArray(value)) {
           return function () {
             let index = 0;
@@ -219,6 +243,7 @@ export function createQueryResultProxy<T>(
                       },
                       depth + 1,
                       writable,
+                      childLabelView(cfcLabelView, String(index)),
                     ),
                     done: false,
                   };
@@ -276,6 +301,7 @@ export function createQueryResultProxy<T>(
                 { ...link, path: [...link.path, String(i)] },
                 depth + 1,
                 writable,
+                childLabelView(cfcLabelView, String(i)),
               );
             }
 
@@ -315,6 +341,7 @@ export function createQueryResultProxy<T>(
                   index,
                   { ...link, path: [...link.path, String(index)] },
                   writable,
+                  childLabelView(cfcLabelView, String(index)),
                 )
               );
             }
@@ -398,6 +425,7 @@ export function createQueryResultProxy<T>(
         { ...link, path: [...link.path, prop] },
         depth + 1,
         writable,
+        childLabelView(cfcLabelView, String(prop)),
       );
     },
     set: (_, prop, value) => {
@@ -470,6 +498,7 @@ export function createQueryResultProxy<T>(
             { ...link, path: [...link.path, prop as string] },
             depth + 1,
             writable,
+            childLabelView(cfcLabelView, String(prop)),
           ),
         };
       }
@@ -490,7 +519,9 @@ export function createQueryResultProxy<T>(
 
   // Cache the proxy in the appropriate cache before returning
   txCache.byLink.set(cacheKey, proxy);
-  txCache.byValue.set(value, proxy);
+  if (cfcLabelView === undefined) {
+    txCache.byValue.set(value, proxy);
+  }
   return proxy;
 }
 
@@ -509,13 +540,23 @@ const createProxyForArrayValue = (
   source: number,
   link: NormalizedFullLink,
   writable: boolean = false,
+  cfcLabelView?: CfcLabelView,
 ): { [originalIndex]: number } => {
   const target = {
     valueOf: function () {
-      return createQueryResultProxy(runtime, tx, link, 0, writable);
+      return createQueryResultProxy(
+        runtime,
+        tx,
+        link,
+        0,
+        writable,
+        cfcLabelView,
+      );
     },
     toString: function () {
-      return String(createQueryResultProxy(runtime, tx, link, 0, writable));
+      return String(
+        createQueryResultProxy(runtime, tx, link, 0, writable, cfcLabelView),
+      );
     },
     [originalIndex]: source,
   };

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -52,7 +52,11 @@ import {
   parseLink,
 } from "./link-utils.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { type CfcEnforcementMode, type TrustSnapshot } from "./cfc/mod.ts";
+import {
+  type CfcEnforcementMode,
+  type CfcLabelView,
+  type TrustSnapshot,
+} from "./cfc/mod.ts";
 import { PatternManager } from "./pattern-manager.ts";
 import { ModuleRegistry } from "./module.ts";
 import { Runner } from "./runner.ts";
@@ -800,16 +804,19 @@ export class Runtime {
     cellLink: CellLink | NormalizedLink | AnyCell<unknown>,
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
+    cfcLabelView?: CfcLabelView,
   ): Cell<T>;
   getCellFromLink<S extends JSONSchema = JSONSchema>(
     cellLink: CellLink | NormalizedLink | AnyCell<unknown>,
     schema: S,
     tx?: IExtendedStorageTransaction,
+    cfcLabelView?: CfcLabelView,
   ): Cell<Schema<S>>;
   getCellFromLink(
     cellLink: CellLink | NormalizedLink | AnyCell<unknown>,
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
+    cfcLabelView?: CfcLabelView,
   ): Cell<any> {
     let link = isCellLink(cellLink)
       ? parseLink(cellLink)
@@ -817,8 +824,23 @@ export class Runtime {
       ? cellLink
       : undefined;
     if (!link) throw new Error("Invalid cell link");
+    const carriedLabelView =
+      (link as NormalizedLink & { cfcLabelView?: CfcLabelView }).cfcLabelView;
+    if ("cfcLabelView" in link) {
+      const { cfcLabelView: _cfcLabelView, ...cleanLink } = link as
+        & NormalizedLink
+        & { cfcLabelView?: CfcLabelView };
+      link = cleanLink;
+    }
     if (schema !== undefined) link = { ...link, schema };
-    return createCell(this, link as NormalizedFullLink, tx);
+    return createCell(
+      this,
+      link as NormalizedFullLink,
+      tx,
+      false,
+      undefined,
+      cfcLabelView ?? carriedLabelView,
+    );
   }
 
   getImmutableCell<T>(
@@ -826,29 +848,39 @@ export class Runtime {
     data: T,
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
+    cfcLabelView?: CfcLabelView,
   ): Cell<T>;
   getImmutableCell<S extends JSONSchema = JSONSchema>(
     space: MemorySpace,
     data: any,
     schema: S,
     tx?: IExtendedStorageTransaction,
+    cfcLabelView?: CfcLabelView,
   ): Cell<Schema<S>>;
   getImmutableCell(
     space: MemorySpace,
     data: any,
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
+    cfcLabelView?: CfcLabelView,
   ): Cell<any> {
     const asDataURI = `data:application/json,${
       encodeURIComponent(JSON.stringify({ value: data }))
     }` as const as `${string}:${string}`;
-    return createCell(this, {
-      space,
-      path: [],
-      id: asDataURI,
-      type: "application/json",
-      schema,
-    }, tx);
+    return createCell(
+      this,
+      {
+        space,
+        path: [],
+        id: asDataURI,
+        type: "application/json",
+        schema,
+      },
+      tx,
+      false,
+      undefined,
+      cfcLabelView,
+    );
   }
 
   getHomeSpaceCell(

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -47,10 +47,12 @@ import {
   CellLink,
   isCellLink,
   isNormalizedFullLink,
+  isSigilLink,
   type NormalizedFullLink,
   NormalizedLink,
   parseLink,
 } from "./link-utils.ts";
+import { LINK_V1_TAG } from "./sigil-types.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   type CfcEnforcementMode,
@@ -818,14 +820,20 @@ export class Runtime {
     tx?: IExtendedStorageTransaction,
     cfcLabelView?: CfcLabelView,
   ): Cell<any> {
+    const carriedLabelView = cfcLabelView ??
+      (isSigilLink(cellLink)
+        ? (cellLink["/"][LINK_V1_TAG] as { cfcLabelView?: CfcLabelView })
+          .cfcLabelView
+        : isNormalizedFullLink(cellLink)
+        ? (cellLink as NormalizedLink & { cfcLabelView?: CfcLabelView })
+          .cfcLabelView
+        : undefined);
     let link = isCellLink(cellLink)
       ? parseLink(cellLink)
       : isNormalizedFullLink(cellLink)
       ? cellLink
       : undefined;
     if (!link) throw new Error("Invalid cell link");
-    const carriedLabelView =
-      (link as NormalizedLink & { cfcLabelView?: CfcLabelView }).cfcLabelView;
     if ("cfcLabelView" in link) {
       const { cfcLabelView: _cfcLabelView, ...cleanLink } = link as
         & NormalizedLink
@@ -839,7 +847,7 @@ export class Runtime {
       tx,
       false,
       undefined,
-      cfcLabelView ?? carriedLabelView,
+      carriedLabelView,
     );
   }
 

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -90,7 +90,7 @@ const labelViewForLink = (
   ) {
     return rebaseCfcLabelView(baseView, link.path.slice(baseLink.path.length));
   }
-  return cloneCfcLabelView(baseView);
+  return rebaseCfcLabelView(baseView, link.path);
 };
 
 /**
@@ -719,7 +719,7 @@ export function validateAndTransform(
       tx.getCfcState().dereferenceTraces.slice(valueTraceStart),
     ),
   ]);
-  objectCreator.setBase(link, cfcLabelView);
+  objectCreator.setBase(resolvedValueLink, cfcLabelView);
 
   // If our link is asCell/asStream, and we don't have any path portions, we
   // can just create the cell and mostly skip reading the value and traversal.

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -61,6 +61,15 @@ const cfcAddressFromLink = (link: NormalizedFullLink): CfcAddress => ({
   path: [...link.path],
 });
 
+export type CellViewRef = {
+  link: NormalizedFullLink;
+  cfcLabelView?: CfcLabelView;
+};
+
+const isCellViewRef = (
+  ref: NormalizedFullLink | CellViewRef,
+): ref is CellViewRef => isRecord(ref) && "link" in ref;
+
 const isPrefix = (
   prefix: readonly string[],
   path: readonly string[],
@@ -607,14 +616,12 @@ export interface ValidateAndTransformOptions {
   traverseCells?: boolean;
   /** When true, cells created during traversal are marked as already synced */
   synced?: boolean;
-  /** Labels accumulated by following links before this read. */
-  cfcLabelView?: CfcLabelView;
 }
 
 export function validateAndTransform(
   runtime: Runtime,
   tx: IExtendedStorageTransaction | undefined,
-  link: NormalizedFullLink,
+  sourceRef: NormalizedFullLink | CellViewRef,
   _seen?: Array<[string, any]>,
   options?: ValidateAndTransformOptions,
 ): any {
@@ -624,9 +631,12 @@ export function validateAndTransform(
   tx = runtime.readTx(tx);
 
   // Reconstruct doc, path, schema from link and runtime
+  let link = isCellViewRef(sourceRef) ? sourceRef.link : sourceRef;
   const schema = link.schema;
   const resolvedSchema = resolveSchema(schema);
-  let cfcLabelView = cloneCfcLabelView(options?.cfcLabelView);
+  let cfcLabelView = cloneCfcLabelView(
+    isCellViewRef(sourceRef) ? sourceRef.cfcLabelView : undefined,
+  );
 
   // For opaque cells, create the cell directly from the current link.
   // We intentionally avoid traversing redirect chains or reading through the
@@ -701,7 +711,7 @@ export function validateAndTransform(
   // We'll use this for the value, and potentially merge the schema
   // This gets me the result of following all the links, so I can get the value
   const valueTraceStart = tx.getCfcState().dereferenceTraces.length;
-  const ref = resolveLink(runtime, tx, link);
+  const resolvedValueLink = resolveLink(runtime, tx, link);
   cfcLabelView = mergeCfcLabelViews([
     cfcLabelView,
     cfcLabelViewForDereferenceTraces(
@@ -741,15 +751,20 @@ export function validateAndTransform(
     // This will overwrite any schema that we got from the first non-redirect
     // link, but this one should be more accurate
     // Otherwise, we won't return a cell like we are supposed to.
-    if (ref.schema !== undefined) {
-      link.schema = mergeSchemaFlags(effectiveSchema!, ref.schema);
+    if (resolvedValueLink.schema !== undefined) {
+      link.schema = mergeSchemaFlags(
+        effectiveSchema!,
+        resolvedValueLink.schema,
+      );
     }
     objectCreator.setBase(link, cfcLabelView);
     return objectCreator.createObject(link, undefined);
   }
 
   // Link paths don't include value, but doc address should
-  const address: IMemorySpaceValueAddress = toMemorySpaceAddress(ref);
+  const address: IMemorySpaceValueAddress = toMemorySpaceAddress(
+    resolvedValueLink,
+  );
   // Get the full value without telling the scheduler. The traverse method will
   // notify the scheduler for shallow reads as they occur.
   const value = tx.readOrThrow(address, {
@@ -759,7 +774,7 @@ export function validateAndTransform(
   // If we have a ref with a schema, use that; otherwise, use the link's schema
   const selector = {
     path: doc.address.path,
-    schema: ref.schema ?? link.schema!,
+    schema: resolvedValueLink.schema ?? link.schema!,
   };
   // TODO(@ubik2): these constructor parameters are complex enough that we should
   // use an options struct

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -39,11 +39,50 @@ import {
 import { ignoreReadForScheduling } from "./scheduler.ts";
 import { internalVerifierRead } from "./storage/reactivity-log.ts";
 import { toMemorySpaceAddress } from "../src/link-utils.ts";
+import {
+  type CfcLabelView,
+  cfcLabelViewForDereference,
+  cfcLabelViewForDereferenceTraces,
+  cloneCfcLabelView,
+  mergeCfcLabelViews,
+  rebaseCfcLabelView,
+} from "./cfc/label-view-state.ts";
+import type { CfcAddress } from "./cfc/types.ts";
 
 const logger = getLogger("validateAndTransform", {
   enabled: true,
   level: "debug",
 });
+
+const cfcAddressFromLink = (link: NormalizedFullLink): CfcAddress => ({
+  space: link.space,
+  id: link.id,
+  type: link.type,
+  path: [...link.path],
+});
+
+const isPrefix = (
+  prefix: readonly string[],
+  path: readonly string[],
+): boolean =>
+  prefix.length <= path.length &&
+  prefix.every((segment, index) => segment === path[index]);
+
+const labelViewForLink = (
+  baseLink: NormalizedFullLink,
+  baseView: CfcLabelView | undefined,
+  link: NormalizedFullLink,
+): CfcLabelView | undefined => {
+  if (
+    baseLink.space === link.space &&
+    baseLink.id === link.id &&
+    baseLink.type === link.type &&
+    isPrefix(baseLink.path, link.path)
+  ) {
+    return rebaseCfcLabelView(baseView, link.path.slice(baseLink.path.length));
+  }
+  return cloneCfcLabelView(baseView);
+};
 
 /**
  * Schemas are mostly a subset of JSONSchema.
@@ -264,6 +303,7 @@ export function processDefaultValue(
   link: NormalizedFullLink,
   defaultValue: any,
   synced = false,
+  cfcLabelView?: CfcLabelView,
 ): any {
   const schema = link.schema;
   if (!schema) return defaultValue;
@@ -277,6 +317,7 @@ export function processDefaultValue(
       link,
       tx,
       synced,
+      cfcLabelView,
     );
   }
 
@@ -297,6 +338,7 @@ export function processDefaultValue(
         { $stream: true },
         resolvedSchema,
         tx,
+        cfcLabelView,
       );
     } else {
       // If schema indicates this should be some sort of a cell
@@ -310,6 +352,7 @@ export function processDefaultValue(
           resolvedSchema.default,
           resolvedSchema,
           tx,
+          cfcLabelView,
         );
       } else {
         return createCell(
@@ -321,6 +364,7 @@ export function processDefaultValue(
           getTransactionForChildCells(tx),
           synced,
           asCellValues.at(0),
+          cfcLabelView,
         );
       }
     }
@@ -352,6 +396,7 @@ export function processDefaultValue(
             { ...link, schema: propSchema, path: [...link.path, key] },
             defaultValue[key as keyof typeof defaultValue],
             synced,
+            rebaseCfcLabelView(cfcLabelView, [key]),
           );
           processedKeys.add(key);
         } else if (isRecord(propSchema)) {
@@ -366,6 +411,7 @@ export function processDefaultValue(
               { ...link, schema: propSchema, path: [...link.path, key] },
               undefined,
               synced,
+              rebaseCfcLabelView(cfcLabelView, [key]),
             );
           } else if (propSchema.default !== undefined) {
             result[key] = processDefaultValue(
@@ -374,6 +420,7 @@ export function processDefaultValue(
               { ...link, schema: propSchema, path: [...link.path, key] },
               propSchema.default,
               synced,
+              rebaseCfcLabelView(cfcLabelView, [key]),
             );
           } else if (
             resolvedSchema?.required?.includes(key) &&
@@ -385,6 +432,7 @@ export function processDefaultValue(
               { ...link, schema: propSchema, path: [...link.path, key] },
               propSchema.type === "object" ? {} : [],
               synced,
+              rebaseCfcLabelView(cfcLabelView, [key]),
             );
           }
         }
@@ -411,12 +459,20 @@ export function processDefaultValue(
             },
             defaultValue[key as keyof typeof defaultValue],
             synced,
+            rebaseCfcLabelView(cfcLabelView, [key]),
           );
         }
       }
     }
 
-    return annotateWithBackToCellSymbols(result, runtime, link, tx, synced);
+    return annotateWithBackToCellSymbols(
+      result,
+      runtime,
+      link,
+      tx,
+      synced,
+      cfcLabelView,
+    );
   }
 
   // Handle array type defaults
@@ -453,13 +509,28 @@ export function processDefaultValue(
         },
         item,
         synced,
+        rebaseCfcLabelView(cfcLabelView, [String(i)]),
       )
     );
-    return annotateWithBackToCellSymbols(result, runtime, link, tx, synced);
+    return annotateWithBackToCellSymbols(
+      result,
+      runtime,
+      link,
+      tx,
+      synced,
+      cfcLabelView,
+    );
   }
 
   // For primitive types, return as is
-  return annotateWithBackToCellSymbols(defaultValue, runtime, link, tx, synced);
+  return annotateWithBackToCellSymbols(
+    defaultValue,
+    runtime,
+    link,
+    tx,
+    synced,
+    cfcLabelView,
+  );
 }
 
 /** @internal Exported for testing only. */
@@ -494,6 +565,7 @@ function annotateWithBackToCellSymbols(
   link: NormalizedFullLink,
   tx: IExtendedStorageTransaction | undefined,
   synced = false,
+  cfcLabelView?: CfcLabelView,
 ) {
   if (!isRecord(value) || isCell(value)) {
     // We only possibly annotate objects or arrays that _aren't_ cells.
@@ -515,7 +587,14 @@ function annotateWithBackToCellSymbols(
     // Use getTransactionForChildCells so that if this was called from sample(),
     // the resulting cell is still reactive
     value: () =>
-      createCell(runtime, link, getTransactionForChildCells(tx), synced),
+      createCell(
+        runtime,
+        link,
+        getTransactionForChildCells(tx),
+        synced,
+        undefined,
+        cfcLabelView,
+      ),
     enumerable: false,
   });
 
@@ -528,6 +607,8 @@ export interface ValidateAndTransformOptions {
   traverseCells?: boolean;
   /** When true, cells created during traversal are marked as already synced */
   synced?: boolean;
+  /** Labels accumulated by following links before this read. */
+  cfcLabelView?: CfcLabelView;
 }
 
 export function validateAndTransform(
@@ -545,12 +626,7 @@ export function validateAndTransform(
   // Reconstruct doc, path, schema from link and runtime
   const schema = link.schema;
   const resolvedSchema = resolveSchema(schema);
-
-  const objectCreator = new TransformObjectCreator(
-    runtime,
-    tx!,
-    options?.synced ?? false,
-  );
+  let cfcLabelView = cloneCfcLabelView(options?.cfcLabelView);
 
   // For opaque cells, create the cell directly from the current link.
   // We intentionally avoid traversing redirect chains or reading through the
@@ -558,7 +634,13 @@ export function validateAndTransform(
   // the pointed-to value.
   const asCellValues = ContextualFlowControl.getAsCellValues(resolvedSchema);
   if (asCellValues.at(0) === "opaque") {
-    return objectCreator.createObject(
+    return new TransformObjectCreator(
+      runtime,
+      tx!,
+      options?.synced ?? false,
+      link,
+      cfcLabelView,
+    ).createObject(
       { ...link, schema: resolvedSchema },
       undefined,
     );
@@ -567,7 +649,15 @@ export function validateAndTransform(
   // Follow aliases, etc. to last element on path + just aliases on that last one
   // When we generate cells below, we want them to be based off this value, as that
   // is what a setter would change when they update a value or reference.
+  const writeRedirectTraceStart = tx.getCfcState().dereferenceTraces.length;
   const resolvedLink = resolveLink(runtime, tx, link, "writeRedirect");
+  cfcLabelView = mergeCfcLabelViews([
+    cfcLabelView,
+    cfcLabelViewForDereferenceTraces(
+      tx,
+      tx.getCfcState().dereferenceTraces.slice(writeRedirectTraceStart),
+    ),
+  ]);
 
   const resolvedLinkSchema = resolveSchema(resolvedLink.schema);
   const effectiveSchema = resolvedSchema !== undefined
@@ -588,6 +678,13 @@ export function validateAndTransform(
     ...resolvedLink,
     ...(effectiveSchema !== undefined && { schema: effectiveSchema }),
   };
+  const objectCreator = new TransformObjectCreator(
+    runtime,
+    tx!,
+    options?.synced ?? false,
+    link,
+    cfcLabelView,
+  );
 
   // If we don't have a schema, and we aren't asCell/asStream, use a proxy
   if (
@@ -597,13 +694,22 @@ export function validateAndTransform(
     ) &&
     filteredSchema === undefined
   ) {
-    return createQueryResultProxy(runtime, tx, link);
+    return createQueryResultProxy(runtime, tx, link, 0, false, cfcLabelView);
   }
 
   // Now resolve further links until we get the actual value.
   // We'll use this for the value, and potentially merge the schema
   // This gets me the result of following all the links, so I can get the value
+  const valueTraceStart = tx.getCfcState().dereferenceTraces.length;
   const ref = resolveLink(runtime, tx, link);
+  cfcLabelView = mergeCfcLabelViews([
+    cfcLabelView,
+    cfcLabelViewForDereferenceTraces(
+      tx,
+      tx.getCfcState().dereferenceTraces.slice(valueTraceStart),
+    ),
+  ]);
+  objectCreator.setBase(link, cfcLabelView);
 
   // If our link is asCell/asStream, and we don't have any path portions, we
   // can just create the cell and mostly skip reading the value and traversal.
@@ -616,6 +722,14 @@ export function validateAndTransform(
     // but x.foo is link to y.baz, we really want y.baz.bar.
     // I'm not currently handling this, because it doesn't come up.
     if (next !== undefined) {
+      cfcLabelView = mergeCfcLabelViews([
+        cfcLabelView,
+        cfcLabelViewForDereference(
+          tx,
+          cfcAddressFromLink(link),
+          cfcAddressFromLink(next),
+        ),
+      ]);
       // We leave the asCell/asStream in the schema, so that createObject
       // knows to create a cell
       const mergedSchema = (next.schema !== undefined)
@@ -630,6 +744,7 @@ export function validateAndTransform(
     if (ref.schema !== undefined) {
       link.schema = mergeSchemaFlags(effectiveSchema!, ref.schema);
     }
+    objectCreator.setBase(link, cfcLabelView);
     return objectCreator.createObject(link, undefined);
   }
 
@@ -670,7 +785,21 @@ class TransformObjectCreator
     private runtime: Runtime,
     private tx: IExtendedStorageTransaction,
     private synced: boolean,
+    private baseLink: NormalizedFullLink,
+    private cfcLabelView: CfcLabelView | undefined,
   ) {
+  }
+
+  setBase(
+    baseLink: NormalizedFullLink,
+    cfcLabelView: CfcLabelView | undefined,
+  ): void {
+    this.baseLink = baseLink;
+    this.cfcLabelView = cloneCfcLabelView(cfcLabelView);
+  }
+
+  private labelViewFor(link: NormalizedFullLink): CfcLabelView | undefined {
+    return labelViewForLink(this.baseLink, this.cfcLabelView, link);
   }
 
   /**
@@ -743,7 +872,14 @@ class TransformObjectCreator
     link: NormalizedFullLink,
     value: T | undefined,
   ): T | undefined {
-    return processDefaultValue(this.runtime, this.tx, link, value, this.synced);
+    return processDefaultValue(
+      this.runtime,
+      this.tx,
+      link,
+      value,
+      this.synced,
+      this.labelViewFor(link),
+    );
   }
 
   // This is an early pass to see if we should just create a proxy or cell
@@ -758,7 +894,14 @@ class TransformObjectCreator
     // If we have a schema without asCell or asStream, we should annotate the
     // object so we can get back to the cell if needed.
     if (link.schema === undefined || link.schema === true) {
-      return createQueryResultProxy(this.runtime, this.tx, link);
+      return createQueryResultProxy(
+        this.runtime,
+        this.tx,
+        link,
+        0,
+        false,
+        this.labelViewFor(link),
+      );
     } else if (isRecord(link.schema)) {
       const { asCell: _c, asStream: _s, ...restSchema } = link.schema;
       const asCellValues = ContextualFlowControl.getAsCellValues(link.schema);
@@ -779,12 +922,20 @@ class TransformObjectCreator
           getTransactionForChildCells(this.tx),
           this.synced,
           cellKind,
+          this.labelViewFor(link),
         ) as AnyCellWrapping<FabricValue>;
       }
       // If it's not a cell/stream, but the schema is true-ish, use a
       // QueryResultProxy
       if (ContextualFlowControl.isTrueSchema(link.schema)) {
-        return createQueryResultProxy(this.runtime, this.tx, link);
+        return createQueryResultProxy(
+          this.runtime,
+          this.tx,
+          link,
+          0,
+          false,
+          this.labelViewFor(link),
+        );
       }
       // link.schema is not true, and not asCell/asStream
       // If we're undefined, check for a default and apply that
@@ -796,6 +947,7 @@ class TransformObjectCreator
           link,
           link.schema.default,
           this.synced,
+          this.labelViewFor(link),
         );
       }
       // If we're an object, we may be missing some properties that have a
@@ -830,6 +982,7 @@ class TransformObjectCreator
                 },
                 undefined,
                 this.synced,
+                rebaseCfcLabelView(this.labelViewFor(link), [propName]),
               );
             }
           }
@@ -844,6 +997,7 @@ class TransformObjectCreator
       link,
       this.tx,
       this.synced,
+      this.labelViewFor(link),
     );
   }
 }

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -20,6 +20,7 @@ import {
 import { flowPrecisionSchemaForBuiltin } from "../src/cfc/flow-precision.ts";
 import { CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION } from "../src/cfc/types.ts";
 import type { JSONSchema, Pattern } from "../src/builder/types.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-boundary-tests");
 
@@ -1185,7 +1186,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       }).getReadActivities()];
       expect(readActivities).toContainEqual(
         expect.objectContaining({
-          path: [],
+          path: ["cfc"],
         }),
       );
 
@@ -1779,6 +1780,76 @@ describe("ExtendedStorageTransaction CFC gate", () => {
                 }),
               ]),
             }),
+          }),
+        ]),
+      );
+      verify.abort();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("persists carried link labels without storing transient label views", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const seed = runtime.edit();
+      seed.setCfcEnforcementMode("enforce-explicit");
+      const source = runtime.getCell(
+        signer.did(),
+        "cfc-link-carried-only-source",
+        undefined,
+        seed,
+      );
+      source.set({ title: "plain source" });
+      seed.prepareCfc();
+      expect((await seed.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      const link = source.getAsLink() as any;
+      link["/"][LINK_V1_TAG].cfcLabelView = {
+        version: 1,
+        entries: [{
+          path: [],
+          label: { integrity: ["selected-by-alice"] },
+        }, {
+          path: ["title"],
+          label: { confidentiality: ["selected-title"] },
+        }],
+      };
+      const target = runtime.getCell(
+        signer.did(),
+        "cfc-link-carried-only-target",
+        undefined,
+        tx,
+      );
+      target.set(link);
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const verify = runtime.edit();
+      const stored = verify.readOrThrow({
+        space: signer.did(),
+        id: target.getAsNormalizedFullLink().id,
+        type: "application/json",
+        path: [],
+      }) as {
+        value?: { "/": { [LINK_V1_TAG]: { cfcLabelView?: unknown } } };
+        cfc?: { labelMap?: { entries?: unknown[] } };
+      };
+      expect(stored.value?.["/"][LINK_V1_TAG]).not.toHaveProperty(
+        "cfcLabelView",
+      );
+      expect(stored.cfc?.labelMap?.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: [],
+            label: { integrity: ["selected-by-alice"] },
+          }),
+          expect.objectContaining({
+            path: ["title"],
+            label: { confidentiality: ["selected-title"] },
           }),
         ]),
       );

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -9,6 +9,9 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import { parseLink } from "../src/link-utils.ts";
+import { toCell } from "../src/back-to-cell.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { UI } from "../src/builder/types.ts";
 
 describe("CFC label view helpers", () => {
   it("collects labels that apply to a logical value path", () => {
@@ -68,7 +71,23 @@ describe("CFC label view helpers", () => {
     expect(cfcLabelViewForCell(cell)).toBeUndefined();
   });
 
-  it("joins labels from the runtime read behind a linked cell", async () => {
+  it("does not ask source cells for label display", () => {
+    const cell = {
+      getAsNormalizedFullLink: () => ({
+        id: "of:labelled-result-cell",
+        space: "did:key:test",
+        type: "application/json",
+        path: [],
+      }),
+      getSourceCell: () => {
+        throw new Error("source cell should not be consulted");
+      },
+    };
+
+    expect(cfcLabelViewForCell(cell)).toBeUndefined();
+  });
+
+  it("does not synthesize runtime reads for linked cells", async () => {
     const signer = await Identity.fromPassphrase("cfc label view linked read");
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({
@@ -113,13 +132,7 @@ describe("CFC label view helpers", () => {
       target.set(source);
       await tx.commit();
 
-      expect(cfcLabelViewForCell(target)).toEqual({
-        version: 1,
-        entries: [{
-          path: [],
-          label: { confidentiality: ["prompt-influence"] },
-        }],
-      });
+      expect(cfcLabelViewForCell(target)).toBeUndefined();
     } finally {
       await runtime.dispose();
       await storageManager.close();
@@ -235,12 +248,669 @@ describe("CFC label view helpers", () => {
         entries: [{
           path: [],
           label: {
-            confidentiality: ["personal-space", "shared-space"],
-            integrity: ["selected-by-alice", "authored-by-bob"],
+            confidentiality: ["personal-space"],
+            integrity: ["selected-by-alice"],
+          },
+        }],
+      });
+
+      const resolvedTarget = target.resolveAsCell();
+      expect(cfcLabelViewForCell(resolvedTarget)).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: {
+            confidentiality: expect.arrayContaining([
+              "personal-space",
+              "shared-space",
+            ]),
+            integrity: expect.arrayContaining([
+              "selected-by-alice",
+              "authored-by-bob",
+            ]),
           },
         }, {
           path: ["details"],
           label: { confidentiality: ["target-detail"] },
+        }],
+      });
+
+      expect(cfcLabelViewForCell(resolvedTarget.asSchema({
+        type: "object",
+        properties: { details: { type: "string" } },
+      }))).toEqual(cfcLabelViewForCell(resolvedTarget));
+      const siblingTx = runtime.edit();
+      expect(cfcLabelViewForCell(resolvedTarget.withTx(siblingTx)))
+        .toEqual(cfcLabelViewForCell(resolvedTarget));
+      siblingTx.abort();
+
+      expect(cfcLabelViewForCell(resolvedTarget.key("details"))).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: {
+            confidentiality: expect.arrayContaining([
+              "personal-space",
+              "shared-space",
+              "target-detail",
+            ]),
+            integrity: expect.arrayContaining([
+              "selected-by-alice",
+              "authored-by-bob",
+            ]),
+          },
+        }],
+      });
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps accumulated link labels on cells recovered from query results", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cfc label view query result to cell",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-query-source",
+        undefined,
+        tx,
+      );
+      const sourceLink = parseLink(source.getAsLink());
+      tx.writeOrThrow({
+        space: signer.did(),
+        id: sourceLink.id!,
+        type: "application/json",
+        path: [],
+      }, {
+        value: { title: "shared" },
+        cfc: {
+          version: 1,
+          schemaHash: "source-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: [],
+              label: { integrity: ["authored-by-bob"] },
+            }],
+          },
+        },
+      });
+
+      const target = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-query-target",
+        undefined,
+        tx,
+      );
+      const targetLink = parseLink(target.getAsLink());
+      tx.writeOrThrow({
+        space: signer.did(),
+        id: targetLink.id!,
+        type: "application/json",
+        path: [],
+      }, {
+        value: source.getAsLink(),
+        cfc: {
+          version: 1,
+          schemaHash: "target-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: [],
+              label: { integrity: ["selected-by-alice"] },
+            }],
+          },
+        },
+      });
+      await tx.commit();
+
+      const value = target.get();
+      const recovered = (value as { [toCell]: () => unknown })[toCell]();
+      expect(cfcLabelViewForCell(recovered)).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: {
+            integrity: expect.arrayContaining([
+              "selected-by-alice",
+              "authored-by-bob",
+            ]),
+          },
+        }],
+      });
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps accumulated link labels on schema asCell materialization", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cfc label view schema asCell",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-as-cell-source",
+        undefined,
+        tx,
+      );
+      const sourceLink = parseLink(source.getAsLink());
+      tx.writeOrThrow({
+        space: signer.did(),
+        id: sourceLink.id!,
+        type: "application/json",
+        path: [],
+      }, {
+        value: { title: "as cell" },
+        cfc: {
+          version: 1,
+          schemaHash: "source-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: [],
+              label: { integrity: ["authored-by-bob"] },
+            }],
+          },
+        },
+      });
+
+      const target = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-as-cell-target",
+        {
+          asCell: ["cell"],
+          type: "object",
+          properties: { title: { type: "string" } },
+        },
+        tx,
+      );
+      const targetLink = parseLink(target.getAsLink());
+      tx.writeOrThrow({
+        space: signer.did(),
+        id: targetLink.id!,
+        type: "application/json",
+        path: [],
+      }, {
+        value: source.getAsLink(),
+        cfc: {
+          version: 1,
+          schemaHash: "target-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: [],
+              label: { integrity: ["selected-by-alice"] },
+            }],
+          },
+        },
+      });
+      await tx.commit();
+
+      const recovered = target.get();
+      expect(cfcLabelViewForCell(recovered)).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: {
+            integrity: expect.arrayContaining([
+              "selected-by-alice",
+              "authored-by-bob",
+            ]),
+          },
+        }],
+      });
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps accumulated link labels on default-created asCell values", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cfc label view default asCell",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-default-source",
+        undefined,
+        tx,
+      );
+      const sourceLink = parseLink(source.getAsLink());
+      tx.writeOrThrow({
+        space: signer.did(),
+        id: sourceLink.id!,
+        type: "application/json",
+        path: [],
+      }, {
+        value: {},
+        cfc: {
+          version: 1,
+          schemaHash: "source-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: [],
+              label: { integrity: ["authored-by-bob"] },
+            }],
+          },
+        },
+      });
+
+      const target = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-default-target",
+        {
+          type: "object",
+          properties: {
+            item: {
+              asCell: ["cell"],
+              type: "object",
+              default: { title: "fallback" },
+              properties: { title: { type: "string" } },
+            },
+          },
+        },
+        tx,
+      );
+      const targetLink = parseLink(target.getAsLink());
+      tx.writeOrThrow({
+        space: signer.did(),
+        id: targetLink.id!,
+        type: "application/json",
+        path: [],
+      }, {
+        value: source.getAsLink(),
+        cfc: {
+          version: 1,
+          schemaHash: "target-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: [],
+              label: { integrity: ["selected-by-alice"] },
+            }],
+          },
+        },
+      });
+      await tx.commit();
+
+      const recovered = target.get() as { item: unknown };
+      expect(cfcLabelViewForCell(recovered.item)).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: {
+            integrity: expect.arrayContaining([
+              "selected-by-alice",
+              "authored-by-bob",
+            ]),
+          },
+        }],
+      });
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps per-element labels through native array map proxies", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cfc label view array map proxies",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const tx = runtime.edit();
+      const first = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-array-first",
+        undefined,
+        tx,
+      );
+      const second = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-array-second",
+        undefined,
+        tx,
+      );
+      const firstLink = parseLink(first.getAsLink());
+      const secondLink = parseLink(second.getAsLink());
+      for (
+        const [link, value, integrity] of [
+          [firstLink, { title: "first" }, "authored-first"],
+          [secondLink, { title: "second" }, "authored-second"],
+        ] as const
+      ) {
+        tx.writeOrThrow({
+          space: signer.did(),
+          id: link.id!,
+          type: "application/json",
+          path: [],
+        }, {
+          value,
+          cfc: {
+            version: 1,
+            schemaHash: "item-schema",
+            labelMap: {
+              version: 1,
+              entries: [{
+                path: [],
+                label: { integrity: [integrity] },
+              }],
+            },
+          },
+        });
+      }
+
+      const list = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-array-list",
+        undefined,
+        tx,
+      );
+      const listLink = parseLink(list.getAsLink());
+      tx.writeOrThrow({
+        space: signer.did(),
+        id: listLink.id!,
+        type: "application/json",
+        path: [],
+      }, {
+        value: [first.getAsLink(), second.getAsLink()],
+        cfc: {
+          version: 1,
+          schemaHash: "list-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: ["0"],
+              label: { integrity: ["selected-first"] },
+            }, {
+              path: ["1"],
+              label: { integrity: ["selected-second"] },
+            }],
+          },
+        },
+      });
+      await tx.commit();
+
+      const recovered = (list.get() as unknown[]).map((item) =>
+        (item as { [toCell]: () => unknown })[toCell]()
+      );
+      expect(cfcLabelViewForCell(recovered[0])).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: {
+            integrity: expect.arrayContaining([
+              "selected-first",
+              "authored-first",
+            ]),
+          },
+        }],
+      });
+      expect(cfcLabelViewForCell(recovered[1])).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: {
+            integrity: expect.arrayContaining([
+              "selected-second",
+              "authored-second",
+            ]),
+          },
+        }],
+      });
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("does not reuse query proxies across different carried label views", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cfc label view query proxy cache",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-cache-source",
+        undefined,
+        tx,
+      );
+      const sourceLink = parseLink(source.getAsLink());
+      tx.writeOrThrow({
+        space: signer.did(),
+        id: sourceLink.id!,
+        type: "application/json",
+        path: [],
+      }, {
+        value: { title: "shared" },
+        cfc: {
+          version: 1,
+          schemaHash: "source-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: [],
+              label: { integrity: ["authored-shared"] },
+            }],
+          },
+        },
+      });
+
+      const list = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-cache-list",
+        undefined,
+        tx,
+      );
+      const listLink = parseLink(list.getAsLink());
+      tx.writeOrThrow({
+        space: signer.did(),
+        id: listLink.id!,
+        type: "application/json",
+        path: [],
+      }, {
+        value: [source.getAsLink(), source.getAsLink()],
+        cfc: {
+          version: 1,
+          schemaHash: "list-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: ["0"],
+              label: { integrity: ["selected-first"] },
+            }, {
+              path: ["1"],
+              label: { integrity: ["selected-second"] },
+            }],
+          },
+        },
+      });
+      await tx.commit();
+
+      const recovered = (list.get() as unknown[]).map((item) =>
+        (item as { [toCell]: () => unknown })[toCell]()
+      );
+      expect(cfcLabelViewForCell(recovered[0])).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: {
+            integrity: expect.arrayContaining([
+              "selected-first",
+              "authored-shared",
+            ]),
+          },
+        }],
+      });
+      expect(cfcLabelViewForCell(recovered[1])).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: {
+            integrity: expect.arrayContaining([
+              "selected-second",
+              "authored-shared",
+            ]),
+          },
+        }],
+      });
+      expect(
+        cfcLabelViewForCell(recovered[1])?.entries[0].label.integrity,
+      ).not.toContain("selected-first");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("recovers per-item integrity from mapped VDOM output cells", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cfc label view pattern map vdom",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const tx = runtime.edit();
+      const first = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-pattern-first",
+        undefined,
+        tx,
+      );
+      const second = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-pattern-second",
+        undefined,
+        tx,
+      );
+      for (
+        const [cell, value, integrity] of [
+          [first, { title: "First" }, "item-integrity-first"],
+          [second, { title: "Second" }, "item-integrity-second"],
+        ] as const
+      ) {
+        const link = parseLink(cell.getAsLink());
+        tx.writeOrThrow({
+          space: signer.did(),
+          id: link.id!,
+          type: "application/json",
+          path: [],
+        }, {
+          value,
+          cfc: {
+            version: 1,
+            schemaHash: "item-schema",
+            labelMap: {
+              version: 1,
+              entries: [{
+                path: [],
+                label: { integrity: [integrity] },
+              }],
+            },
+          },
+        });
+      }
+
+      const { commonfabric } = createTrustedBuilder(runtime);
+      const { pattern } = commonfabric;
+      const renderLabels = pattern<{ items: unknown[] }>(({ items }) => {
+        const rendered = items.map((item) => ({
+          [UI]: {
+            type: "vnode" as const,
+            name: "cf-cfc-label",
+            props: { value: item },
+            children: [],
+          },
+        }));
+        return { rendered };
+      });
+
+      const resultCell = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-pattern-result",
+        undefined,
+        tx,
+      );
+      const result = runtime.run(
+        tx,
+        renderLabels,
+        { items: [first, second] },
+        resultCell,
+      );
+      await tx.commit();
+      await result.pull();
+
+      const firstValue = result
+        .key("rendered")
+        .key("0")
+        .key(UI)
+        .key("props")
+        .key("value")
+        .resolveAsCell();
+      const secondValue = result
+        .key("rendered")
+        .key("1")
+        .key(UI)
+        .key("props")
+        .key("value")
+        .resolveAsCell();
+
+      expect(cfcLabelViewForCell(firstValue)).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: { integrity: ["item-integrity-first"] },
+        }],
+      });
+      expect(cfcLabelViewForCell(secondValue)).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: { integrity: ["item-integrity-second"] },
         }],
       });
     } finally {
@@ -285,7 +955,7 @@ describe("CFC label view helpers", () => {
     });
   });
 
-  it("reads source-cell metadata for result-cell internal paths", () => {
+  it("skips source-cell metadata for result-cell internal paths", () => {
     const sourceCell = {
       getAsNormalizedFullLink: () => ({
         id: "of:source-cell",
@@ -331,17 +1001,6 @@ describe("CFC label view helpers", () => {
       getSourceCell: () => sourceCell,
     };
 
-    expect(cfcLabelViewForCell(resultCell)).toEqual({
-      version: 1,
-      entries: [{
-        path: [],
-        label: {
-          integrity: [{
-            kind: "authored-by",
-            subject: "alice",
-          }],
-        },
-      }],
-    });
+    expect(cfcLabelViewForCell(resultCell)).toBeUndefined();
   });
 });

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -569,6 +569,84 @@ describe("CFC label view helpers", () => {
     }
   });
 
+  it("does not leak sibling labels on cross-document schema asCell children", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cfc label view cross doc sibling labels",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-sibling-source",
+        undefined,
+        tx,
+      );
+      const sourceLink = parseLink(source.getAsLink());
+      tx.writeOrThrow({
+        space: signer.did(),
+        id: sourceLink.id!,
+        type: "application/json",
+        path: [],
+      }, {
+        value: { a: "first", b: "second" },
+        cfc: {
+          version: 1,
+          schemaHash: "source-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: ["a"],
+              label: { integrity: ["source-a"] },
+            }, {
+              path: ["b"],
+              label: { integrity: ["source-b"] },
+            }],
+          },
+        },
+      });
+
+      const target = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-sibling-target",
+        {
+          type: "object",
+          properties: {
+            a: { type: "string", asCell: true },
+            b: { type: "string", asCell: true },
+          },
+        },
+        tx,
+      );
+      target.set(source);
+      await tx.commit();
+
+      const recovered = target.get() as { a: unknown; b: unknown };
+      expect(cfcLabelViewForCell(recovered.a)).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: { integrity: ["source-a"] },
+        }],
+      });
+      expect(cfcLabelViewForCell(recovered.b)).toEqual({
+        version: 1,
+        entries: [{
+          path: [],
+          label: { integrity: ["source-b"] },
+        }],
+      });
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("keeps accumulated link labels on default-created asCell values", async () => {
     const signer = await Identity.fromPassphrase(
       "cfc label view default asCell",

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -12,6 +12,7 @@ import { parseLink } from "../src/link-utils.ts";
 import { toCell } from "../src/back-to-cell.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { UI } from "../src/builder/types.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
 
 describe("CFC label view helpers", () => {
   it("collects labels that apply to a logical value path", () => {
@@ -47,6 +48,54 @@ describe("CFC label view helpers", () => {
         {
           path: ["summary"],
           label: { integrity: ["summarized-by-trusted-pattern"] },
+        },
+      ],
+    });
+  });
+
+  it("rebases wildcard label paths onto concrete array item paths", () => {
+    const metadata: CfcMetadata = {
+      version: 1,
+      schemaHash: "hash",
+      labelMap: {
+        version: 1,
+        entries: [
+          {
+            path: ["value", "*"],
+            label: { integrity: ["trusted-item"] },
+          },
+          {
+            path: ["value", "*", "title"],
+            label: { integrity: ["trusted-title"] },
+          },
+        ],
+      },
+    };
+
+    expect(cfcLabelViewFromMetadata(metadata, ["0"])).toEqual({
+      version: 1,
+      entries: [
+        {
+          path: [],
+          label: { integrity: ["trusted-item"] },
+        },
+        {
+          path: ["title"],
+          label: { integrity: ["trusted-title"] },
+        },
+      ],
+    });
+    expect(cfcLabelViewFromMetadata(metadata, ["0", "title"])).toEqual({
+      version: 1,
+      entries: [
+        {
+          path: [],
+          label: {
+            integrity: expect.arrayContaining([
+              "trusted-item",
+              "trusted-title",
+            ]),
+          },
         },
       ],
     });
@@ -133,6 +182,42 @@ describe("CFC label view helpers", () => {
       await tx.commit();
 
       expect(cfcLabelViewForCell(target)).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("preserves ref-carried label views when creating cells from sigil links", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cfc label view sigil carried state",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const view = {
+        version: 1,
+        entries: [{
+          path: [],
+          label: { integrity: ["carried-through-sigil"] },
+        }],
+      } as const;
+      const cell = runtime.getCell(
+        signer.did(),
+        "cfc-label-view-carried-sigil",
+      );
+      const link = cell.getAsLink() as any;
+      link["/"][LINK_V1_TAG].cfcLabelView = view;
+
+      const recovered = runtime.getCellFromLink(link);
+      expect(cfcLabelViewForCell(recovered)).toEqual(view);
+      expect(recovered.getAsLink()["/"][LINK_V1_TAG]).not.toHaveProperty(
+        "cfcLabelView",
+      );
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/test/generate-object-tools.test.ts
+++ b/packages/runner/test/generate-object-tools.test.ts
@@ -1893,13 +1893,14 @@ describe("generateObject with tools", () => {
 
       const liveResult = generatedResult.withTx();
       await liveResult.sync();
-      expect(liveResult.key("result").get()).toEqual({
+      const resolvedResult = liveResult.key("result").resolveAsCell();
+      expect(resolvedResult.get()).toEqual({
         action: "reject",
         approved: false,
         confidence: 0.91,
         reasoning: "The briefing was not approved.",
       });
-      expect(cfcLabelViewForCell(liveResult.key("result"))).toMatchObject({
+      expect(cfcLabelViewForCell(resolvedResult)).toMatchObject({
         entries: expect.arrayContaining([
           {
             path: ["action"],

--- a/packages/runner/test/generate-object-tools.test.ts
+++ b/packages/runner/test/generate-object-tools.test.ts
@@ -24,6 +24,7 @@ import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
 import { INJECTION_SAFE_ATOM } from "../src/cfc/schema-sanitization.ts";
+import { llmToolExecutionHelpers } from "../src/builtins/llm-dialog.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { parseLink } from "../src/link-utils.ts";
@@ -78,6 +79,35 @@ describe("generateObject with tools", () => {
     await runtime.idle();
     await runtime?.dispose();
     await storageManager?.close();
+  });
+
+  it("redacts wildcard label paths during LLM observation serialization", () => {
+    const rootLink = {
+      id: "of:llm-wildcard-label-root",
+      space,
+      type: "application/json",
+      path: [],
+    } as const;
+    const serialized = llmToolExecutionHelpers.serializeForLLMObservation({
+      value: [{ body: "do not inline" }],
+      contextSpace: space,
+      rootLink,
+      labelView: {
+        version: 1,
+        entries: [{
+          path: ["*", "body"],
+          label: { confidentiality: ["secret"] },
+        }],
+      },
+      observationMaxConfidentiality: ["public"],
+    });
+
+    expect(serialized.value).toEqual([{
+      body: {
+        "@link": "/of:llm-wildcard-label-root/0/body",
+      },
+    }]);
+    expect(serialized.observedConfidentiality).toEqual([]);
   });
 
   it("should add presentResult tool to catalog and extract structured result", async () => {
@@ -978,6 +1008,91 @@ describe("generateObject with tools", () => {
       analysis: "Data contains 5 numeric values",
       total: 5,
     });
+  });
+
+  it("keeps pattern tool resultLocation on the tool result cell when result is a link", async () => {
+    const linkedCell = runtime.getCell(
+      space,
+      "generateObject-pattern-tool-linked-result",
+      undefined,
+      tx,
+    );
+    linkedCell.set({ message: "linked" });
+    const linkedLocation = `/${linkedCell.getAsNormalizedFullLink().id}`;
+    let toolResultLocation: unknown;
+
+    addMockResponse(
+      (req) =>
+        req.messages.some((message) =>
+          typeof message.content === "string" &&
+          message.content.includes("test-pattern-tool-result-location-link")
+        ) &&
+        req.tools?.["returnLinked"] !== undefined &&
+        req.tools?.["presentResult"] !== undefined,
+      {
+        role: "assistant",
+        content: [{
+          type: "tool-call",
+          toolCallId: "call_returnLinked_1",
+          toolName: "returnLinked",
+          input: {},
+        }],
+        id: "return-linked-1",
+      },
+    );
+    addMockResponse(
+      (req) => {
+        const toolMessage = req.messages.find((message) =>
+          message.role === "tool"
+        ) as BuiltInLLMMessage | undefined;
+        const content = Array.isArray(toolMessage?.content)
+          ? toolMessage.content[0] as any
+          : undefined;
+        toolResultLocation = content?.output?.value?.["@resultLocation"];
+        return toolResultLocation !== undefined;
+      },
+      {
+        role: "assistant",
+        content: [{
+          type: "tool-call",
+          toolCallId: "call_present_link_result",
+          toolName: "presentResult",
+          input: { ok: true },
+        }],
+        id: "return-linked-2",
+      },
+    );
+
+    const resultSchema: JSONSchema = {
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+      required: ["ok"],
+    };
+    const returnLinked = pattern<Record<string, never>>(() => linkedCell);
+    const testPattern = pattern<Record<string, never>>(() =>
+      generateObject({
+        prompt: "test-pattern-tool-result-location-link",
+        schema: resultSchema,
+        tools: {
+          returnLinked: patternTool(returnLinked) as unknown as BuiltInLLMTool,
+        },
+      })
+    );
+
+    const resultCell = runtime.getCell(
+      space,
+      "generateObject-pattern-tool-result-location",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    tx.commit();
+
+    await expect(waitForPendingToBecomeFalse(result)).resolves.toBeUndefined();
+    await runtime.idle();
+
+    expect(result.key("result").get()).toEqual({ ok: true });
+    expect(toolResultLocation).not.toBe(linkedLocation);
   });
 
   it("should handle parallel tool calls before presentResult", async () => {

--- a/packages/runner/test/scheduler-core.test.ts
+++ b/packages/runner/test/scheduler-core.test.ts
@@ -865,7 +865,7 @@ describe("scheduler", () => {
     expect(resultCell.get()).toEqual({ count: 1, lastValue: { value: 1 } });
   });
 
-  it("should not react to stored CFC metadata updates read through verifier helpers", async () => {
+  it("should react to stored CFC metadata updates read through verifier helpers", async () => {
     const sourceCell = runtime.getCell<{ secret: string }>(
       space,
       "source-cell-for-cfc-metadata-reactivity-test",
@@ -938,8 +938,8 @@ describe("scheduler", () => {
     tx = runtime.edit();
     await resultCell.pull();
 
-    expect(actionRunCount).toBe(1);
-    expect(resultCell.get()).toEqual({ count: 1, applies: false });
+    expect(actionRunCount).toBe(2);
+    expect(resultCell.get()).toEqual({ count: 2, applies: true });
 
     const verifyTx = runtime.edit();
     expect(storedCfcMetadataAppliesToPath(verifyTx, secretLink)).toBe(true);

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -432,7 +432,72 @@ describe("RuntimeProcessor CFC label IPC", () => {
     });
   });
 
-  it("syncs a result cell before looking up CFC from its source", async () => {
+  it("returns label views on resolved cell refs", () => {
+    const sourceRef: CellRef = {
+      id: "of:cfc-label-source" as CellRef["id"],
+      space: "did:key:test" as CellRef["space"],
+      type: "application/json",
+      path: [],
+    };
+    const resolvedRef: CellRef = {
+      id: "of:cfc-label-resolved" as CellRef["id"],
+      space: "did:key:test" as CellRef["space"],
+      type: "application/json",
+      path: [],
+    };
+    const resolvedCell = {
+      getAsLink: () => ({
+        "/": {
+          "link@1": resolvedRef,
+        },
+      }),
+      getAsNormalizedFullLink: () => resolvedRef,
+      runtime: {
+        readTx: () => ({
+          readOrThrow: () => ({
+            value: "resolved value",
+            cfc: {
+              version: 1,
+              schemaHash: "test-schema",
+              labelMap: {
+                version: 1,
+                entries: [{
+                  path: [],
+                  label: { integrity: ["authored-by-bob"] },
+                }],
+              },
+            },
+          }),
+        }),
+      },
+    };
+    const sourceCell = {
+      resolveAsCell: () => resolvedCell,
+    };
+    const processor = {
+      runtime: {
+        getCellFromLink: () => sourceCell,
+      },
+    } as unknown as RuntimeProcessor;
+
+    expect(RuntimeProcessor.prototype.handleCellResolveAsCell.call(processor, {
+      type: RequestType.CellResolveAsCell,
+      cell: sourceRef,
+    })).toEqual({
+      cell: {
+        ...resolvedRef,
+        cfcLabelView: {
+          version: 1,
+          entries: [{
+            path: [],
+            label: { integrity: ["authored-by-bob"] },
+          }],
+        },
+      },
+    });
+  });
+
+  it("does not look up CFC labels from a result cell source", async () => {
     const resultRef: CellRef = {
       id: "of:cfc-label-result" as CellRef["id"],
       space: "did:key:test" as CellRef["space"],
@@ -495,13 +560,7 @@ describe("RuntimeProcessor CFC label IPC", () => {
         cell: resultRef,
       }),
     )).resolves.toEqual({
-      cfcLabel: {
-        version: 1,
-        entries: [{
-          path: [],
-          label: { confidentiality: ["source-label"] },
-        }],
-      },
+      cfcLabel: undefined,
     });
     expect(resultSynced).toBe(true);
     expect(sourceSynced).toBe(true);

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -5,7 +5,12 @@ import {
   RuntimeProcessor,
   sanitizeForPostMessage,
 } from "./runtime-processor.ts";
-import { type CellRef, RequestType } from "../protocol/mod.ts";
+import {
+  type CellRef,
+  type CfcLabelView,
+  RequestType,
+} from "../protocol/mod.ts";
+import { cellRefToSigilLink } from "./utils.ts";
 
 describe("sanitizeForPostMessage", () => {
   describe("primitives", () => {
@@ -634,6 +639,37 @@ describe("RuntimeProcessor CFC commit preparation", () => {
       type: RequestType.CellSend,
       cell: ref,
       event: "new value",
+    });
+  });
+});
+
+describe("runtime-client CellRef conversion", () => {
+  it("preserves carried label views in transient sigil links", () => {
+    const cfcLabelView: CfcLabelView = {
+      version: 1,
+      entries: [{
+        path: [],
+        label: { integrity: ["selected-by-alice"] },
+      }],
+    };
+    const ref: CellRef = {
+      id: "of:cfc-label-cell" as CellRef["id"],
+      space: "did:key:z6MkrX123abc" as CellRef["space"],
+      type: "application/json",
+      path: ["value"],
+      cfcLabelView,
+    };
+
+    expect(cellRefToSigilLink(ref)).toEqual({
+      "/": {
+        "link@1": {
+          id: ref.id,
+          space: ref.space,
+          type: ref.type,
+          path: ref.path,
+          cfcLabelView,
+        },
+      },
     });
   });
 });

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -453,6 +453,7 @@ export class RuntimeProcessor {
       includeSchema: true,
       keepAsCell: true,
       doNotConvertCellResults: true,
+      includeCfcLabelView: true,
     });
     return { value: converted };
   }
@@ -507,6 +508,7 @@ export class RuntimeProcessor {
         includeSchema: true,
         keepAsCell: true,
         doNotConvertCellResults: true,
+        includeCfcLabelView: true,
       });
 
       // `.sink` fires synchronously on invocation. Trigger the notification

--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -35,6 +35,9 @@ export function cellRefToSigilLink(cell: CellRef): SigilLink {
         type: cell.type,
         ...(cell.schema !== undefined && { schema: cell.schema }),
         ...(cell.overwrite !== undefined && { overwrite: cell.overwrite }),
+        ...(cell.cfcLabelView !== undefined && {
+          cfcLabelView: cell.cfcLabelView,
+        }),
       } as never,
     },
   };

--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -1,4 +1,5 @@
 import { Cell, JSONSchema, parseLink, SigilLink } from "@commonfabric/runner";
+import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
 import { CellRef, PageRef } from "../protocol/types.ts";
 import { Runtime } from "@commonfabric/runner";
 import { LINK_V1_TAG } from "@commonfabric/runner/shared";
@@ -27,7 +28,14 @@ export function mapCellRefsToSigilLinks(value: unknown): any {
 export function cellRefToSigilLink(cell: CellRef): SigilLink {
   return {
     "/": {
-      [LINK_V1_TAG]: cell,
+      [LINK_V1_TAG]: {
+        id: cell.id,
+        space: cell.space,
+        path: cell.path,
+        type: cell.type,
+        ...(cell.schema !== undefined && { schema: cell.schema }),
+        ...(cell.overwrite !== undefined && { overwrite: cell.overwrite }),
+      } as never,
     },
   };
 }
@@ -54,6 +62,10 @@ export function createCellRef(cell: Cell<unknown>, schema?: unknown): CellRef {
   if (schema !== undefined) {
     cellRef.schema = schema as JSONSchema;
   }
+  const cfcLabelView = cfcLabelViewForCell(cell);
+  if (cfcLabelView !== undefined) {
+    cellRef.cfcLabelView = cfcLabelView;
+  }
   return cellRef;
 }
 
@@ -67,5 +79,5 @@ export function getCell(runtime: Runtime, ref: CellRef): Cell<unknown> {
   // We explicitly do not pass in `schema`, as this function applies
   // the schema to `schema`, and cell refs already contain all this
   // information. Maybe the upstream function should change.
-  return runtime.getCellFromLink(ref);
+  return runtime.getCellFromLink(ref, undefined, undefined, ref.cfcLabelView);
 }

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -43,4 +43,91 @@ describe("CellHandle CFC label IPC", () => {
       cell: ref,
     }]);
   });
+
+  it("rebases ref-carried label views when creating child handles", async () => {
+    const requests: unknown[] = [];
+    const runtime = {
+      [$conn]: () => ({
+        request: (request: unknown) => {
+          requests.push(request);
+          return Promise.resolve({ cfcLabel: undefined });
+        },
+        subscribe: () => Promise.resolve(),
+        unsubscribe: () => Promise.resolve(),
+      }),
+    } as unknown as RuntimeClient;
+    const ref = {
+      id: "of:cfc-label-cell" as CellRef["id"],
+      space: "did:key:test" as CellRef["space"],
+      type: "application/json",
+      path: [],
+      cfcLabelView: {
+        version: 1 as const,
+        entries: [{
+          path: [],
+          label: { integrity: ["selected-by-alice"] },
+        }, {
+          path: ["details"],
+          label: { integrity: ["authored-by-bob"] },
+        }],
+      },
+    } as CellRef;
+
+    const child = new CellHandle<{ details: string }>(runtime, ref)
+      .key("details");
+    await child.getCfcLabel();
+
+    expect(requests).toEqual([{
+      type: RequestType.CellGetCfcLabel,
+      cell: {
+        id: ref.id,
+        space: ref.space,
+        type: ref.type,
+        path: ["details"],
+        cfcLabelView: {
+          version: 1,
+          entries: [{
+            path: [],
+            label: {
+              integrity: ["selected-by-alice", "authored-by-bob"],
+            },
+          }],
+        },
+      },
+    }]);
+  });
+
+  it("does not serialize ref-carried label views into sigil links", () => {
+    const runtime = {
+      [$conn]: () => ({
+        request: () => Promise.resolve({}),
+        subscribe: () => Promise.resolve(),
+        unsubscribe: () => Promise.resolve(),
+      }),
+    } as unknown as RuntimeClient;
+    const cell = new CellHandle(runtime, {
+      id: "of:cfc-label-cell" as CellRef["id"],
+      space: "did:key:test" as CellRef["space"],
+      type: "application/json",
+      path: ["value"],
+      cfcLabelView: {
+        version: 1 as const,
+        entries: [{
+          path: [],
+          label: { integrity: ["selected-by-alice"] },
+        }],
+      },
+    } as CellRef);
+
+    expect(cell.toJSON()).toEqual({
+      "/": {
+        "link@1": {
+          id: "of:cfc-label-cell",
+          space: "did:key:test",
+          type: "application/json",
+          path: ["value"],
+        },
+      },
+    });
+  });
 });

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   $conn,
+  $onCellUpdate,
   CellHandle,
   type CellRef,
   RequestType,
@@ -129,5 +130,80 @@ describe("CellHandle CFC label IPC", () => {
         },
       },
     });
+  });
+
+  it("refreshes reused cell refs when carried label views change", async () => {
+    const requests: unknown[] = [];
+    const runtime = {
+      [$conn]: () => ({
+        request: (request: unknown) => {
+          requests.push(request);
+          return Promise.resolve({ cfcLabel: undefined });
+        },
+        subscribe: () => Promise.resolve(),
+        unsubscribe: () => Promise.resolve(),
+      }),
+    } as unknown as RuntimeClient;
+    const baseRef: CellRef = {
+      id: "of:cfc-label-parent" as CellRef["id"],
+      space: "did:key:test" as CellRef["space"],
+      type: "application/json",
+      path: [],
+      schema: true,
+    };
+    const childRef = {
+      id: "of:cfc-label-child",
+      space: "did:key:test",
+      type: "application/json",
+      path: [],
+    };
+    const firstLabel = {
+      version: 1 as const,
+      entries: [{
+        path: [],
+        label: { integrity: ["selected-first"] },
+      }],
+    };
+    const secondLabel = {
+      version: 1 as const,
+      entries: [{
+        path: [],
+        label: { integrity: ["selected-second"] },
+      }],
+    };
+    const linkWithLabel = (cfcLabelView: typeof firstLabel) => ({
+      "/": {
+        "link@1": {
+          ...childRef,
+          cfcLabelView,
+        },
+      },
+    });
+
+    const parent = new CellHandle<{ item: CellHandle }>(runtime, baseRef);
+    parent[$onCellUpdate]({ item: linkWithLabel(firstLabel) });
+    const firstChild = parent.get()!.item;
+    await firstChild.getCfcLabel();
+
+    parent[$onCellUpdate]({ item: linkWithLabel(secondLabel) });
+    const secondChild = parent.get()!.item;
+    await secondChild.getCfcLabel();
+
+    expect(secondChild).not.toBe(firstChild);
+    expect(requests).toEqual([{
+      type: RequestType.CellGetCfcLabel,
+      cell: {
+        ...childRef,
+        path: [],
+        cfcLabelView: firstLabel,
+      },
+    }, {
+      type: RequestType.CellGetCfcLabel,
+      cell: {
+        ...childRef,
+        path: [],
+        cfcLabelView: secondLabel,
+      },
+    }]);
   });
 });

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -8,6 +8,7 @@ import {
   RequestType,
   type RuntimeClient,
 } from "./mod.ts";
+import { cellRefToKey } from "./shared/utils.ts";
 
 describe("CellHandle CFC label IPC", () => {
   it("queries the runtime for the label view behind a cell", async () => {
@@ -98,7 +99,7 @@ describe("CellHandle CFC label IPC", () => {
     }]);
   });
 
-  it("does not serialize ref-carried label views into sigil links", () => {
+  it("serializes ref-carried label views into transient sigil links", () => {
     const runtime = {
       [$conn]: () => ({
         request: () => Promise.resolve({}),
@@ -127,9 +128,44 @@ describe("CellHandle CFC label IPC", () => {
           space: "did:key:test",
           type: "application/json",
           path: ["value"],
+          cfcLabelView: {
+            version: 1,
+            entries: [{
+              path: [],
+              label: { integrity: ["selected-by-alice"] },
+            }],
+          },
         },
       },
     });
+  });
+
+  it("uses carried label views in subscription keys", () => {
+    const first: CellRef = {
+      id: "of:cfc-label-cell" as CellRef["id"],
+      space: "did:key:test" as CellRef["space"],
+      type: "application/json",
+      path: [],
+      cfcLabelView: {
+        version: 1 as const,
+        entries: [{
+          path: [],
+          label: { integrity: ["selected-first"] },
+        }],
+      },
+    };
+    const second: CellRef = {
+      ...first,
+      cfcLabelView: {
+        version: 1 as const,
+        entries: [{
+          path: [],
+          label: { integrity: ["selected-second"] },
+        }],
+      },
+    };
+
+    expect(cellRefToKey(first)).not.toEqual(cellRefToKey(second));
   });
 
   it("refreshes reused cell refs when carried label views change", async () => {

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -11,6 +11,10 @@ import {
   type SigilLink,
   type URI,
 } from "@commonfabric/runner/shared";
+import {
+  cfcLabelViewsEqual,
+  rebaseCfcLabelView,
+} from "@commonfabric/runner/cfc/label-view-core";
 import { $conn, type RuntimeClient } from "./runtime-client.ts";
 import {
   type CellRef,
@@ -280,7 +284,7 @@ export class CellHandle<T = unknown> {
       type: this.#ref.type,
       // Child schema is unknown, so we don't include it
       ...(this.#ref.cfcLabelView !== undefined && {
-        cfcLabelView: rebaseClientCfcLabelView(this.#ref.cfcLabelView, [key]),
+        cfcLabelView: rebaseCfcLabelView(this.#ref.cfcLabelView, [key]),
       }),
     };
   }
@@ -457,128 +461,6 @@ function cellRefsEqual(a: CellRef, b: CellRef): boolean {
   }
   if (!cfcLabelViewsEqual(a.cfcLabelView, b.cfcLabelView)) return false;
   return true;
-}
-
-function cfcLabelViewsEqual(
-  a: CfcLabelView | undefined,
-  b: CfcLabelView | undefined,
-): boolean {
-  if (a === b) return true;
-  if (a === undefined || b === undefined) return false;
-  return JSON.stringify(a) === JSON.stringify(b);
-}
-
-const CFC_LABEL_KEYS = ["confidentiality", "integrity"] as const;
-
-function canonicalizeCfcLogicalPath(path: readonly string[]): string[] {
-  return path[0] === "value" ? [...path.slice(1)] : [...path];
-}
-
-function isCfcPathPrefix(
-  prefix: readonly string[],
-  path: readonly string[],
-): boolean {
-  return prefix.length <= path.length &&
-    prefix.every((segment, index) => segment === path[index]);
-}
-
-function cloneClientCfcLabel(
-  label: CfcLabelView["entries"][number]["label"],
-): CfcLabelView["entries"][number]["label"] {
-  const cloned: CfcLabelView["entries"][number]["label"] = {};
-  for (const key of CFC_LABEL_KEYS) {
-    const value = label[key];
-    if (Array.isArray(value) && value.length > 0) {
-      cloned[key] = [...value];
-    }
-  }
-  return cloned;
-}
-
-function hasClientCfcLabelValues(
-  label: CfcLabelView["entries"][number]["label"],
-): boolean {
-  return CFC_LABEL_KEYS.some((key) =>
-    Array.isArray(label[key]) && label[key]!.length > 0
-  );
-}
-
-function mergeClientCfcLabels(
-  left: CfcLabelView["entries"][number]["label"] | undefined,
-  right: CfcLabelView["entries"][number]["label"],
-): CfcLabelView["entries"][number]["label"] {
-  const merged: CfcLabelView["entries"][number]["label"] = {};
-  for (const key of CFC_LABEL_KEYS) {
-    const values = [
-      ...(Array.isArray(left?.[key]) ? left[key]! : []),
-      ...(Array.isArray(right[key]) ? right[key]! : []),
-    ];
-    const unique = [...new Set(values)];
-    if (unique.length > 0) {
-      merged[key] = unique;
-    }
-  }
-  return merged;
-}
-
-function cfcPathKey(path: readonly string[]): string {
-  const logicalPath = canonicalizeCfcLogicalPath(path);
-  return logicalPath.length === 0 ? "" : `/${
-    logicalPath
-      .map((segment) => segment.replaceAll("~", "~0").replaceAll("/", "~1"))
-      .join("/")
-  }`;
-}
-
-function normalizeClientCfcLabelView(
-  entries: CfcLabelView["entries"],
-): CfcLabelView | undefined {
-  const byPath = new Map<string, CfcLabelView["entries"][number]>();
-  for (const entry of entries) {
-    const path = canonicalizeCfcLogicalPath(entry.path);
-    const label = cloneClientCfcLabel(entry.label);
-    if (!hasClientCfcLabelValues(label)) continue;
-
-    const key = cfcPathKey(path);
-    const existing = byPath.get(key);
-    byPath.set(key, {
-      path,
-      label: mergeClientCfcLabels(existing?.label, label),
-    });
-  }
-
-  const normalized = [...byPath.values()].sort((left, right) =>
-    cfcPathKey(left.path).localeCompare(cfcPathKey(right.path))
-  );
-  return normalized.length > 0
-    ? { version: 1, entries: normalized }
-    : undefined;
-}
-
-function rebaseClientCfcLabelView(
-  view: CfcLabelView | undefined,
-  path: readonly string[],
-): CfcLabelView | undefined {
-  if (!view) return undefined;
-
-  const logicalPath = canonicalizeCfcLogicalPath(path);
-  const entries: CfcLabelView["entries"] = [];
-  for (const entry of view.entries) {
-    const entryPath = canonicalizeCfcLogicalPath(entry.path);
-    const label = cloneClientCfcLabel(entry.label);
-    if (!hasClientCfcLabelValues(label)) continue;
-
-    if (isCfcPathPrefix(logicalPath, entryPath)) {
-      entries.push({
-        path: entryPath.slice(logicalPath.length),
-        label,
-      });
-    } else if (isCfcPathPrefix(entryPath, logicalPath)) {
-      entries.push({ path: [], label });
-    }
-  }
-
-  return normalizeClientCfcLabelView(entries);
 }
 
 /**

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -302,6 +302,9 @@ export class CellHandle<T = unknown> {
           ...(this.#ref.schema !== undefined && { schema: this.#ref.schema }),
           ...(this.#ref.overwrite !== undefined &&
             { overwrite: this.#ref.overwrite }),
+          ...(this.#ref.cfcLabelView !== undefined && {
+            cfcLabelView: this.#ref.cfcLabelView,
+          }),
         } as never,
       },
     };

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -11,6 +11,7 @@ import {
   type SigilLink,
   type URI,
 } from "@commonfabric/runner/shared";
+import { rebaseCfcLabelView } from "@commonfabric/runner/cfc";
 import { $conn, type RuntimeClient } from "./runtime-client.ts";
 import {
   type CellRef,
@@ -279,6 +280,9 @@ export class CellHandle<T = unknown> {
       path: [...this.#ref.path, key],
       type: this.#ref.type,
       // Child schema is unknown, so we don't include it
+      ...(this.#ref.cfcLabelView !== undefined && {
+        cfcLabelView: rebaseCfcLabelView(this.#ref.cfcLabelView, [key]),
+      }),
     };
   }
 
@@ -287,7 +291,15 @@ export class CellHandle<T = unknown> {
     // and dereferences it (e.g., when passed through event.detail.sourceCell)
     return {
       "/": {
-        [LINK_V1_TAG]: { ...this.ref() },
+        [LINK_V1_TAG]: {
+          id: this.#ref.id,
+          space: this.#ref.space,
+          path: this.#ref.path,
+          type: this.#ref.type,
+          ...(this.#ref.schema !== undefined && { schema: this.#ref.schema }),
+          ...(this.#ref.overwrite !== undefined &&
+            { overwrite: this.#ref.overwrite }),
+        } as never,
       },
     };
   }
@@ -500,6 +512,11 @@ function parseAsCellRef(
       path: (linkData.path ?? []).map((p) => p.toString()),
       type: "application/json",
       ...(linkData.schema !== undefined && { schema: linkData.schema }),
+      ...((linkData as { cfcLabelView?: CfcLabelView }).cfcLabelView !==
+          undefined && {
+        cfcLabelView: (linkData as { cfcLabelView?: CfcLabelView })
+          .cfcLabelView,
+      }),
     };
   } else if (isLegacyAlias(value)) {
     const alias = value.$alias;

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -456,8 +456,19 @@ function cellRefsEqual(a: CellRef, b: CellRef): boolean {
   for (let i = 0; i < a.path.length; i++) {
     if (a.path[i] !== b.path[i]) return false;
   }
+  if (!cfcLabelViewsEqual(a.cfcLabelView, b.cfcLabelView)) return false;
   return true;
 }
+
+function cfcLabelViewsEqual(
+  a: CfcLabelView | undefined,
+  b: CfcLabelView | undefined,
+): boolean {
+  if (a === b) return true;
+  if (a === undefined || b === undefined) return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
 /**
  * Deep equality check for cell values.
  * Handles primitives, arrays, objects, and CellHandles.

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -522,7 +522,12 @@ function mergeClientCfcLabels(
 }
 
 function cfcPathKey(path: readonly string[]): string {
-  return JSON.stringify(canonicalizeCfcLogicalPath(path));
+  const logicalPath = canonicalizeCfcLogicalPath(path);
+  return logicalPath.length === 0 ? "" : `/${
+    logicalPath
+      .map((segment) => segment.replaceAll("~", "~0").replaceAll("/", "~1"))
+      .join("/")
+  }`;
 }
 
 function normalizeClientCfcLabelView(

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -11,7 +11,6 @@ import {
   type SigilLink,
   type URI,
 } from "@commonfabric/runner/shared";
-import { rebaseCfcLabelView } from "@commonfabric/runner/cfc";
 import { $conn, type RuntimeClient } from "./runtime-client.ts";
 import {
   type CellRef,
@@ -281,7 +280,7 @@ export class CellHandle<T = unknown> {
       type: this.#ref.type,
       // Child schema is unknown, so we don't include it
       ...(this.#ref.cfcLabelView !== undefined && {
-        cfcLabelView: rebaseCfcLabelView(this.#ref.cfcLabelView, [key]),
+        cfcLabelView: rebaseClientCfcLabelView(this.#ref.cfcLabelView, [key]),
       }),
     };
   }
@@ -467,6 +466,114 @@ function cfcLabelViewsEqual(
   if (a === b) return true;
   if (a === undefined || b === undefined) return false;
   return JSON.stringify(a) === JSON.stringify(b);
+}
+
+const CFC_LABEL_KEYS = ["confidentiality", "integrity"] as const;
+
+function canonicalizeCfcLogicalPath(path: readonly string[]): string[] {
+  return path[0] === "value" ? [...path.slice(1)] : [...path];
+}
+
+function isCfcPathPrefix(
+  prefix: readonly string[],
+  path: readonly string[],
+): boolean {
+  return prefix.length <= path.length &&
+    prefix.every((segment, index) => segment === path[index]);
+}
+
+function cloneClientCfcLabel(
+  label: CfcLabelView["entries"][number]["label"],
+): CfcLabelView["entries"][number]["label"] {
+  const cloned: CfcLabelView["entries"][number]["label"] = {};
+  for (const key of CFC_LABEL_KEYS) {
+    const value = label[key];
+    if (Array.isArray(value) && value.length > 0) {
+      cloned[key] = [...value];
+    }
+  }
+  return cloned;
+}
+
+function hasClientCfcLabelValues(
+  label: CfcLabelView["entries"][number]["label"],
+): boolean {
+  return CFC_LABEL_KEYS.some((key) =>
+    Array.isArray(label[key]) && label[key]!.length > 0
+  );
+}
+
+function mergeClientCfcLabels(
+  left: CfcLabelView["entries"][number]["label"] | undefined,
+  right: CfcLabelView["entries"][number]["label"],
+): CfcLabelView["entries"][number]["label"] {
+  const merged: CfcLabelView["entries"][number]["label"] = {};
+  for (const key of CFC_LABEL_KEYS) {
+    const values = [
+      ...(Array.isArray(left?.[key]) ? left[key]! : []),
+      ...(Array.isArray(right[key]) ? right[key]! : []),
+    ];
+    const unique = [...new Set(values)];
+    if (unique.length > 0) {
+      merged[key] = unique;
+    }
+  }
+  return merged;
+}
+
+function cfcPathKey(path: readonly string[]): string {
+  return JSON.stringify(canonicalizeCfcLogicalPath(path));
+}
+
+function normalizeClientCfcLabelView(
+  entries: CfcLabelView["entries"],
+): CfcLabelView | undefined {
+  const byPath = new Map<string, CfcLabelView["entries"][number]>();
+  for (const entry of entries) {
+    const path = canonicalizeCfcLogicalPath(entry.path);
+    const label = cloneClientCfcLabel(entry.label);
+    if (!hasClientCfcLabelValues(label)) continue;
+
+    const key = cfcPathKey(path);
+    const existing = byPath.get(key);
+    byPath.set(key, {
+      path,
+      label: mergeClientCfcLabels(existing?.label, label),
+    });
+  }
+
+  const normalized = [...byPath.values()].sort((left, right) =>
+    cfcPathKey(left.path).localeCompare(cfcPathKey(right.path))
+  );
+  return normalized.length > 0
+    ? { version: 1, entries: normalized }
+    : undefined;
+}
+
+function rebaseClientCfcLabelView(
+  view: CfcLabelView | undefined,
+  path: readonly string[],
+): CfcLabelView | undefined {
+  if (!view) return undefined;
+
+  const logicalPath = canonicalizeCfcLogicalPath(path);
+  const entries: CfcLabelView["entries"] = [];
+  for (const entry of view.entries) {
+    const entryPath = canonicalizeCfcLogicalPath(entry.path);
+    const label = cloneClientCfcLabel(entry.label);
+    if (!hasClientCfcLabelValues(label)) continue;
+
+    if (isCfcPathPrefix(logicalPath, entryPath)) {
+      entries.push({
+        path: entryPath.slice(logicalPath.length),
+        label,
+      });
+    } else if (isCfcPathPrefix(entryPath, logicalPath)) {
+      entries.push({ path: [], label });
+    }
+  }
+
+  return normalizeClientCfcLabelView(entries);
 }
 
 /**

--- a/packages/runtime-client/client/connection.ts
+++ b/packages/runtime-client/client/connection.ts
@@ -57,10 +57,7 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
   #initialized = false;
   #disposed = false;
   #transport: RuntimeTransport;
-  #subscribed = new Map<
-    `${string}:${string}:${string}`,
-    Set<CellHandle>
-  >();
+  #subscribed = new Map<string, Set<CellHandle>>();
 
   constructor(transport: RuntimeTransport) {
     super();

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -11,7 +11,7 @@ import type {
   WriteStackTraceEntry,
   WriteStackTraceMatcher,
 } from "@commonfabric/runner/shared";
-import type { CfcLabelView } from "@commonfabric/runner/cfc";
+import type { CfcLabelView } from "@commonfabric/runner/cfc/label-view-core";
 import type { DID, KeyPairRaw } from "@commonfabric/identity";
 import { type Program } from "@commonfabric/js-compiler/interface";
 import { RuntimeTelemetryMarkerResult } from "@commonfabric/runtime-client";

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -23,7 +23,9 @@ export type { CfcLabelView };
 
 export type MessageId = number;
 
-export type CellRef = NormalizedFullLink;
+export type CellRef = NormalizedFullLink & {
+  cfcLabelView?: CfcLabelView;
+};
 
 export type PageRef = {
   cell: CellRef;

--- a/packages/runtime-client/shared/utils.ts
+++ b/packages/runtime-client/shared/utils.ts
@@ -1,7 +1,11 @@
+import { cloneCfcLabelView } from "@commonfabric/runner/cfc";
 import { CellRef } from "../protocol/mod.ts";
 
-export function cellRefToKey(cell: CellRef): `${string}:${string}:${string}` {
+export function cellRefToKey(cell: CellRef): string {
   const id = cell.id.startsWith("of:") ? cell.id.substring(3) : cell.id;
   const schema = cell.schema ? `:${JSON.stringify(cell.schema)}` : "";
-  return `${cell.space}:${id}:${cell.path.join(".")}${schema}`;
+  const cfcLabelView = cell.cfcLabelView
+    ? `:${JSON.stringify(cloneCfcLabelView(cell.cfcLabelView))}`
+    : "";
+  return `${cell.space}:${id}:${cell.path.join(".")}${schema}${cfcLabelView}`;
 }

--- a/packages/runtime-client/shared/utils.ts
+++ b/packages/runtime-client/shared/utils.ts
@@ -1,4 +1,4 @@
-import { cloneCfcLabelView } from "@commonfabric/runner/cfc";
+import { cloneCfcLabelView } from "@commonfabric/runner/cfc/label-view-core";
 import { CellRef } from "../protocol/mod.ts";
 
 export function cellRefToKey(cell: CellRef): string {


### PR DESCRIPTION
## Summary
- move CFC label-view accumulation onto cells produced while following links
- make `cfcLabelViewForCell()` a direct reader of stored metadata plus carried cell state, without hidden traversal or `getSourceCell()` fallback
- propagate carried label views through schema materialization, query-result proxies, array iteration/map, defaults, runtime-client IPC, and LLM observation paths

## Tests
- `deno test -A packages/runner/test/cfc-label-view.test.ts`
- `deno test -A packages/runtime-client/cell-handle.test.ts packages/runtime-client/backends/runtime-processor.test.ts`
- `deno test -A packages/runner/test/generate-object-tools.test.ts`
- `deno test -A packages/fuse/cell-bridge.test.ts`
- `deno fmt --check packages/runner/src/builtins/llm-dialog.ts packages/runner/src/builtins/llm.ts packages/runner/src/cell.ts packages/runner/src/cfc/label-view.ts packages/runner/src/cfc/label-view-state.ts packages/runner/src/cfc/mod.ts packages/runner/src/query-result-proxy.ts packages/runner/src/runtime.ts packages/runner/src/schema.ts packages/runner/test/cfc-label-view.test.ts packages/runner/test/generate-object-tools.test.ts packages/runtime-client/backends/runtime-processor.test.ts packages/runtime-client/backends/runtime-processor.ts packages/runtime-client/backends/utils.ts packages/runtime-client/cell-handle.test.ts packages/runtime-client/cell-handle.ts packages/runtime-client/protocol/types.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accumulates CFC label views on cells produced while following links and carries them through the stack. Preserves confidentiality/integrity context across UIs, LLMs, query proxies, and runtime clients without hidden reads or source-cell fallback.

- **New Features**
  - Cells carry a `cfcLabelView`; views rebase on child paths, merge on dereferences, and propagate through `resolveAsCell`, `validateAndTransform` (including defaults/asCell/asStream), and query-result proxies (iteration/map). Proxy cache keys include the carried view.
  - `cfcLabelViewForCell()` reads stored metadata plus the carried view only; no hidden traversal or source-cell fallback. LLM observation resolves the concrete result cell before serializing and collects labels from it.
  - Runtime/Client: `getCellFromLink`/`getImmutableCell` accept an optional `cfcLabelView` (also read from sigil/normalized links) and strip it from link identity; `convertCellsToLinks()` can embed it. `CellRef` and `CellHandle` carry `cfcLabelView`, rebase views on child keys, refresh when views change, and omit views from sigil-link `toJSON`. IPC returns views on resolved refs and includes carried views when serializing values.

- **Refactors**
  - Extracted pure helpers to `./cfc/label-view-core` and moved metadata/tx/dereference helpers to `./cfc/label-view-state`. Runtime-client uses core helpers/types directly.

<sup>Written for commit 5c5cdd0f1dc7605f6fbd3affda81d9e8b4e362d3. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3438?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/calendar/calendar.test.tsx = 16s
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/card-piles/main.test.tsx = 18s
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/battleship/pass-and-play/main.test.tsx = 28s
NEW_PERF_BASELINE: test: pattern-unit-1/pattern-unit-tests = 130s
