### PR TITLE
Prepare cf-harness Fabric FUSE mounts

### DIFF
--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -4,6 +4,8 @@ import { ProcessTimeoutError } from "./sandbox/process-runner.ts";
 import type {
   SandboxRuntime,
   SandboxRuntimeDescription,
+  SandboxRuntimeMountDescription,
+  SandboxRuntimeMountKind,
 } from "./sandbox/types.ts";
 import type { HarnessPolicyEvent } from "./contracts/policy.ts";
 import type { ToolOutputId } from "./contracts/tool-result.ts";
@@ -52,6 +54,15 @@ export type HarnessCfcSubstrateStatus =
   | "not-attested"
   | "missing";
 
+export type HarnessCfcMountStatus = "configured" | "not-configured";
+
+export interface HarnessCfcMountSnapshot {
+  kind: SandboxRuntimeMountKind;
+  status: HarnessCfcMountStatus;
+  sandboxPath: string;
+  readOnly?: boolean;
+}
+
 export interface HarnessCfcCapabilitySnapshot {
   enforcementMode: CfcEnforcementMode;
   absenceBehavior: HarnessCfcAbsenceBehavior;
@@ -62,6 +73,10 @@ export interface HarnessCfcCapabilitySnapshot {
     path?: string;
   };
   sandbox: SandboxRuntimeDescription;
+  mounts: {
+    workspace: HarnessCfcMountSnapshot;
+    fabric: HarnessCfcMountSnapshot;
+  };
   protectedXattrs: {
     expectedSandboxVisible: false;
     sandboxVisibility: "not-probed";
@@ -232,12 +247,54 @@ const describeSandbox = (
     },
   };
 
+const findMountDescription = (
+  mounts: readonly SandboxRuntimeMountDescription[] | undefined,
+  kind: SandboxRuntimeMountKind,
+): SandboxRuntimeMountDescription | undefined =>
+  mounts?.find((mount) => mount.kind === kind);
+
+const createCfcMountSnapshots = (
+  sandboxDescription: SandboxRuntimeDescription,
+): HarnessCfcCapabilitySnapshot["mounts"] => {
+  const workspaceMount = findMountDescription(
+    sandboxDescription.cfc?.mounts,
+    "workspace",
+  );
+  const fabricMount = findMountDescription(
+    sandboxDescription.cfc?.mounts,
+    "fabric-fuse",
+  );
+  return {
+    workspace: {
+      kind: "workspace",
+      status: "configured",
+      sandboxPath: workspaceMount?.sandboxPath ??
+        sandboxDescription.cfc?.workspaceMountPath ??
+        sandboxDescription.defaultWorkingDirectory,
+      readOnly: workspaceMount?.readOnly ?? false,
+    },
+    fabric: fabricMount
+      ? {
+        kind: "fabric-fuse",
+        status: "configured",
+        sandboxPath: fabricMount.sandboxPath,
+        readOnly: fabricMount.readOnly,
+      }
+      : {
+        kind: "fabric-fuse",
+        status: "not-configured",
+        sandboxPath: "/fabric",
+      },
+  };
+};
+
 const createCfcCapabilitySnapshot = (
   sandbox: SandboxRuntime,
   cwd: string,
   options: CollectHarnessCapabilitySnapshotOptions,
 ): HarnessCfcCapabilitySnapshot => {
   const mode = options.cfcEnforcementMode ?? "enforce-explicit";
+  const sandboxDescription = describeSandbox(sandbox, cwd);
   return {
     enforcementMode: mode,
     absenceBehavior: cfcAbsenceBehaviorForMode(mode),
@@ -254,7 +311,8 @@ const createCfcCapabilitySnapshot = (
         ? { path: options.runManifestPath }
         : {}),
     },
-    sandbox: describeSandbox(sandbox, cwd),
+    sandbox: sandboxDescription,
+    mounts: createCfcMountSnapshots(sandboxDescription),
     protectedXattrs: {
       expectedSandboxVisible: false,
       sandboxVisibility: "not-probed",

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -191,6 +191,19 @@ const isHostPathWithinRoot = (root: string, path: string): boolean => {
     (!relativePath.startsWith("..") && !relativePath.startsWith("/"));
 };
 
+const isSandboxPathWithinRoot = (root: string, path: string): boolean => {
+  const normalizedRoot = normalizeSandboxRoot(root);
+  const normalizedPath = normalizeSandboxRoot(path);
+  return normalizedPath === normalizedRoot ||
+    normalizedPath.startsWith(`${normalizedRoot}/`);
+};
+
+type HostSandboxMount = {
+  kind: string;
+  hostPath: string;
+  sandboxPath: string;
+};
+
 export class CfHarnessEngine {
   readonly config: HarnessConfig;
   readonly sandbox: SandboxRuntime;
@@ -202,6 +215,7 @@ export class CfHarnessEngine {
   #runState: HarnessRunState;
   #outputSequence: number;
   readonly #now: () => string;
+  readonly #hostMounts: readonly HostSandboxMount[];
 
   constructor(options: CreateHarnessEngineOptions = {}) {
     this.#now = options.now ?? (() => new Date().toISOString());
@@ -220,6 +234,26 @@ export class CfHarnessEngine {
       sandboxConfig?.workspaceMountPath ??
         this.sandbox.defaultWorkingDirectory(),
     );
+    this.#hostMounts = sandboxConfig !== undefined
+      ? [
+        {
+          kind: "workspace",
+          hostPath: sandboxConfig.workspaceHostPath,
+          sandboxPath: sandboxConfig.workspaceMountPath,
+        },
+        ...sandboxConfig.additionalMounts.map((mount) => ({
+          kind: mount.kind,
+          hostPath: mount.hostPath,
+          sandboxPath: mount.sandboxPath,
+        })),
+      ]
+      : this.workspaceHostPath !== undefined
+      ? [{
+        kind: "workspace",
+        hostPath: this.workspaceHostPath,
+        sandboxPath: this.workspaceMountPath,
+      }]
+      : [];
     this.artifactStore = options.artifactStore ??
       ((this.config.artifactRoot ?? options.runState?.artifactRoot) !==
           undefined
@@ -643,46 +677,51 @@ export class CfHarnessEngine {
   }
 
   #resolveHostPath(path: string): string {
-    if (this.workspaceHostPath === undefined) {
+    if (this.#hostMounts.length === 0) {
       throw new Error(
-        "bash-no-sandbox requires a workspace host path to map sandbox paths",
+        "bash-no-sandbox requires a host mount path to map sandbox paths",
       );
     }
     const sandboxPath = this.sandbox.resolvePath(
       path,
       this.#runState.currentDir,
     );
-    const mountPath = this.workspaceMountPath;
-    if (sandboxPath === mountPath) {
-      return normalizeHostPath(this.workspaceHostPath);
+    const mount = this.#hostMounts.find((candidate) =>
+      isSandboxPathWithinRoot(candidate.sandboxPath, sandboxPath)
+    );
+    if (mount === undefined) {
+      throw new Error(`path escapes host-backed sandbox roots: ${path}`);
     }
-    if (!sandboxPath.startsWith(`${mountPath}/`)) {
-      throw new Error(`path escapes workspace root: ${path}`);
+    const sandboxRoot = normalizeSandboxRoot(mount.sandboxPath);
+    if (sandboxPath === sandboxRoot) {
+      return normalizeHostPath(mount.hostPath);
     }
     return normalizeHostPath(
       joinHostPath(
-        this.workspaceHostPath,
-        sandboxPath.slice(mountPath.length + 1),
+        mount.hostPath,
+        sandboxPath.slice(sandboxRoot.length + 1),
       ),
     );
   }
 
   #hostPathToWorkspacePath(path: string): string | undefined {
-    if (this.workspaceHostPath === undefined) {
-      return undefined;
-    }
-    const hostRoot = normalizeHostPath(this.workspaceHostPath);
     const hostPath = normalizeHostPath(path);
-    if (!isHostPathWithinRoot(hostRoot, hostPath)) {
-      return undefined;
+    for (const mount of this.#hostMounts) {
+      const hostRoot = normalizeHostPath(mount.hostPath);
+      if (!isHostPathWithinRoot(hostRoot, hostPath)) {
+        continue;
+      }
+      const relativePath = relativeHostPath(hostRoot, hostPath);
+      if (relativePath === "") {
+        return normalizeSandboxRoot(mount.sandboxPath);
+      }
+      return normalizeSandboxPath(
+        `${normalizeSandboxRoot(mount.sandboxPath)}/${
+          relativePath.replaceAll("\\", "/")
+        }`,
+      );
     }
-    const relativePath = relativeHostPath(hostRoot, hostPath);
-    if (relativePath === "") {
-      return this.workspaceMountPath;
-    }
-    return normalizeSandboxPath(
-      `${this.workspaceMountPath}/${relativePath.replaceAll("\\", "/")}`,
-    );
+    return undefined;
   }
 
   #createToolContext() {

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -1367,6 +1367,7 @@ export class CfHarnessPromptLoop {
     const childEngine = new CfHarnessEngine({
       runId: childRunId,
       sandboxRuntime: this.engine.sandbox,
+      sandbox: this.engine.config.sandbox,
       workspaceHostPath: this.engine.workspaceHostPath,
       processRunner: this.engine.hostProcessRunner,
       artifactRoot: this.engine.artifactStore?.artifactRoot,

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -1,12 +1,15 @@
 import { isAbsolute, join, normalize } from "@std/path/posix";
 import { DenoProcessRunner, type ProcessRunner } from "./process-runner.ts";
 import type {
+  DockerRunscAdditionalMount,
+  DockerRunscAdditionalMountConfig,
   DockerRunscSandboxConfig,
   ResolveDockerRunscSandboxConfigOptions,
   SandboxCommandRequest,
   SandboxCommandResult,
   SandboxRuntime,
   SandboxRuntimeDescription,
+  SandboxRuntimeMountDescription,
   SandboxShellRequest,
 } from "./types.ts";
 
@@ -17,6 +20,7 @@ export const DEFAULT_DOCKER_BINARY = "docker";
 export const DEFAULT_WORKSPACE_MOUNT_PATH = "/workspace";
 export const DEFAULT_SANDBOX_SHELL = "/bin/sh";
 export const DEFAULT_DOCKER_NETWORK_MODE = "none" as const;
+export const DEFAULT_FABRIC_MOUNT_PATH = "/fabric";
 
 const readEnvVar = (name: string): string | undefined => {
   try {
@@ -74,6 +78,14 @@ const normalizeWorkspacePath = (path: string): string => {
     : normalized;
 };
 
+const validateSandboxRoot = (path: string, label: string): string => {
+  const normalized = normalizeWorkspacePath(path);
+  if (!isAbsolute(normalized) || normalized === "/") {
+    throw new Error(`${label} must be an absolute non-root sandbox path`);
+  }
+  return normalized;
+};
+
 const isWithinRoot = (root: string, path: string): boolean => {
   const normalizedRoot = normalizeWorkspacePath(root);
   const normalizedPath = normalizeWorkspacePath(path);
@@ -81,10 +93,66 @@ const isWithinRoot = (root: string, path: string): boolean => {
     normalizedPath.startsWith(`${normalizedRoot}/`);
 };
 
+const rootsOverlap = (left: string, right: string): boolean =>
+  isWithinRoot(left, right) || isWithinRoot(right, left);
+
+const normalizeAdditionalMount = (
+  mount: DockerRunscAdditionalMountConfig,
+): DockerRunscAdditionalMount => {
+  if (mount.hostPath.trim() === "") {
+    throw new Error(`${mount.kind} hostPath must not be empty`);
+  }
+  return {
+    kind: mount.kind,
+    hostPath: mount.hostPath,
+    sandboxPath: validateSandboxRoot(
+      mount.sandboxPath ?? DEFAULT_FABRIC_MOUNT_PATH,
+      `${mount.kind} sandboxPath`,
+    ),
+    readOnly: mount.readOnly ?? false,
+  };
+};
+
+const validateNonOverlappingMounts = (
+  mounts: readonly { kind: string; sandboxPath: string }[],
+): void => {
+  for (let i = 0; i < mounts.length; i += 1) {
+    for (let j = i + 1; j < mounts.length; j += 1) {
+      const left = mounts[i]!;
+      const right = mounts[j]!;
+      if (rootsOverlap(left.sandboxPath, right.sandboxPath)) {
+        throw new Error(
+          `sandbox mount paths overlap: ${left.sandboxPath} (${left.kind}) and ${right.sandboxPath} (${right.kind})`,
+        );
+      }
+    }
+  }
+};
+
+const dockerMountArg = (mount: {
+  hostPath: string;
+  sandboxPath: string;
+  readOnly: boolean;
+}): string =>
+  `type=bind,src=${mount.hostPath},dst=${mount.sandboxPath}${
+    mount.readOnly ? ",readonly" : ""
+  }`;
+
 export const resolveDockerRunscSandboxConfig = (
   options: ResolveDockerRunscSandboxConfigOptions,
 ): DockerRunscSandboxConfig => {
   const containerUser = options.containerUser ?? resolveDefaultContainerUser();
+  const workspaceMountPath = validateSandboxRoot(
+    options.workspaceMountPath ?? DEFAULT_WORKSPACE_MOUNT_PATH,
+    "workspaceMountPath",
+  );
+  const additionalMounts = (options.additionalMounts ?? []).map(
+    normalizeAdditionalMount,
+  );
+  validateNonOverlappingMounts([
+    { kind: "workspace", sandboxPath: workspaceMountPath },
+    ...additionalMounts,
+  ]);
   return {
     kind: "docker-runsc-cfc",
     dockerBinary: options.dockerBinary ?? DEFAULT_DOCKER_BINARY,
@@ -92,10 +160,10 @@ export const resolveDockerRunscSandboxConfig = (
     image: options.image ?? DEFAULT_DOCKER_RUNSC_IMAGE,
     ...(containerUser !== undefined ? { containerUser } : {}),
     workspaceHostPath: options.workspaceHostPath,
-    workspaceMountPath: options.workspaceMountPath ??
-      DEFAULT_WORKSPACE_MOUNT_PATH,
+    workspaceMountPath,
     shellPath: options.shellPath ?? DEFAULT_SANDBOX_SHELL,
     dockerNetworkMode: options.dockerNetworkMode ?? DEFAULT_DOCKER_NETWORK_MODE,
+    additionalMounts,
     extraDockerArgs: options.extraDockerArgs ?? [],
   };
 };
@@ -112,6 +180,31 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
     return normalizeWorkspacePath(this.config.workspaceMountPath);
   }
 
+  #mounts(): Array<{
+    kind: SandboxRuntimeMountDescription["kind"];
+    hostPath: string;
+    sandboxPath: string;
+    readOnly: boolean;
+  }> {
+    return [
+      {
+        kind: "workspace",
+        hostPath: this.config.workspaceHostPath,
+        sandboxPath: this.config.workspaceMountPath,
+        readOnly: false,
+      },
+      ...this.config.additionalMounts,
+    ];
+  }
+
+  #mountDescriptions(): SandboxRuntimeMountDescription[] {
+    return this.#mounts().map(({ kind, sandboxPath, readOnly }) => ({
+      kind,
+      sandboxPath,
+      readOnly,
+    }));
+  }
+
   describe(): SandboxRuntimeDescription {
     return {
       kind: this.kind,
@@ -120,6 +213,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
         runtimeRequested: true,
         runtimeName: this.config.runtimeName,
         workspaceMountPath: this.config.workspaceMountPath,
+        mounts: this.#mountDescriptions(),
         networkMode: this.config.dockerNetworkMode,
         extraDockerArgsCount: this.config.extraDockerArgs.length,
       },
@@ -130,12 +224,21 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
     return isWithinRoot(this.config.workspaceMountPath, path);
   }
 
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.#mounts().some((mount) =>
+      isWithinRoot(mount.sandboxPath, path)
+    );
+  }
+
   resolvePath(path: string, cwd?: string): string {
     const normalized = isAbsolute(path)
       ? normalize(path)
       : normalize(join(cwd ?? this.defaultWorkingDirectory(), path));
-    if (!this.isPathWithinWorkspace(normalized)) {
-      throw new Error(`path escapes workspace root: ${path}`);
+    if (!this.isPathWithinAllowedRoots(normalized)) {
+      const rootLabel = this.config.additionalMounts.length === 0
+        ? "workspace root"
+        : "allowed sandbox roots";
+      throw new Error(`path escapes ${rootLabel}: ${path}`);
     }
     return normalized;
   }
@@ -152,8 +255,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
       ...(this.config.containerUser !== undefined
         ? ["--user", this.config.containerUser]
         : []),
-      "--mount",
-      `type=bind,src=${this.config.workspaceHostPath},dst=${this.config.workspaceMountPath}`,
+      ...this.#mounts().flatMap((mount) => ["--mount", dockerMountArg(mount)]),
       "-w",
       request.cwd
         ? this.resolvePath(request.cwd)

--- a/packages/cf-harness/src/sandbox/types.ts
+++ b/packages/cf-harness/src/sandbox/types.ts
@@ -2,6 +2,28 @@ export type HarnessSandboxKind = "docker-runsc-cfc";
 
 export type DockerNetworkMode = "none" | "bridge" | "host";
 
+export type SandboxRuntimeMountKind = "workspace" | "fabric-fuse";
+
+export interface SandboxRuntimeMountDescription {
+  kind: SandboxRuntimeMountKind;
+  sandboxPath: string;
+  readOnly: boolean;
+}
+
+export interface DockerRunscAdditionalMountConfig {
+  kind: "fabric-fuse";
+  hostPath: string;
+  sandboxPath?: string;
+  readOnly?: boolean;
+}
+
+export interface DockerRunscAdditionalMount {
+  kind: "fabric-fuse";
+  hostPath: string;
+  sandboxPath: string;
+  readOnly: boolean;
+}
+
 export interface DockerRunscSandboxConfig {
   kind: "docker-runsc-cfc";
   dockerBinary: string;
@@ -12,6 +34,7 @@ export interface DockerRunscSandboxConfig {
   workspaceMountPath: string;
   shellPath: string;
   dockerNetworkMode: DockerNetworkMode;
+  additionalMounts: readonly DockerRunscAdditionalMount[];
   extraDockerArgs: readonly string[];
 }
 
@@ -26,6 +49,7 @@ export interface ResolveDockerRunscSandboxConfigOptions {
   workspaceMountPath?: string;
   shellPath?: string;
   dockerNetworkMode?: DockerNetworkMode;
+  additionalMounts?: readonly DockerRunscAdditionalMountConfig[];
   extraDockerArgs?: readonly string[];
 }
 
@@ -57,6 +81,7 @@ export interface SandboxRuntimeDescription {
     runtimeRequested: boolean;
     runtimeName?: string;
     workspaceMountPath?: string;
+    mounts?: readonly SandboxRuntimeMountDescription[];
     networkMode?: DockerNetworkMode;
     extraDockerArgsCount?: number;
   };
@@ -67,6 +92,7 @@ export interface SandboxRuntime {
   describe?(): SandboxRuntimeDescription;
   resolvePath(path: string, cwd?: string): string;
   isPathWithinWorkspace(path: string): boolean;
+  isPathWithinAllowedRoots?(path: string): boolean;
   defaultWorkingDirectory(): string;
   run(request: SandboxCommandRequest): Promise<SandboxCommandResult>;
   runShell(request: SandboxShellRequest): Promise<SandboxCommandResult>;

--- a/packages/cf-harness/src/tools/bash.ts
+++ b/packages/cf-harness/src/tools/bash.ts
@@ -71,8 +71,11 @@ export const bashTool: HarnessToolDefinition<BashToolInput, BashToolOutput> = {
       timeoutMs: input.timeoutMs,
     });
     const parsedResult = extractFinalWorkingDirectory(result.stdout, cwdMarker);
+    const isAllowedCurrentDir = parsedResult.cwd !== undefined &&
+      (context.sandbox.isPathWithinAllowedRoots?.(parsedResult.cwd) ??
+        context.sandbox.isPathWithinWorkspace(parsedResult.cwd));
     const nextCurrentDir = parsedResult.cwd !== undefined &&
-        context.sandbox.isPathWithinWorkspace(parsedResult.cwd)
+        isAllowedCurrentDir
       ? parsedResult.cwd
       : commandCwd;
     context.setCurrentDir(nextCurrentDir);

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -152,6 +152,19 @@ Deno.test({
                 workspaceMountPath: "/workspace",
               },
             },
+            mounts: {
+              workspace: {
+                kind: "workspace",
+                status: "configured",
+                sandboxPath: "/workspace",
+                readOnly: false,
+              },
+              fabric: {
+                kind: "fabric-fuse",
+                status: "not-configured",
+                sandboxPath: "/fabric",
+              },
+            },
             protectedXattrs: {
               expectedSandboxVisible: false,
               sandboxVisibility: "not-probed",

--- a/packages/cf-harness/test/diagnostics.test.ts
+++ b/packages/cf-harness/test/diagnostics.test.ts
@@ -16,6 +16,7 @@ import type {
   SandboxCommandRequest,
   SandboxCommandResult,
   SandboxRuntime,
+  SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
 
@@ -58,6 +59,24 @@ class FakeSandboxRuntime implements SandboxRuntime {
   }
 }
 
+class FakeFabricSandboxRuntime extends FakeSandboxRuntime {
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: "/workspace",
+      cfc: {
+        runtimeRequested: true,
+        runtimeName: "runsc-cfc",
+        workspaceMountPath: "/workspace",
+        mounts: [
+          { kind: "workspace", sandboxPath: "/workspace", readOnly: false },
+          { kind: "fabric-fuse", sandboxPath: "/fabric", readOnly: false },
+        ],
+      },
+    };
+  }
+}
+
 Deno.test("collectHarnessCapabilitySnapshot captures fixed sandbox capabilities", async () => {
   const snapshot = await collectHarnessCapabilitySnapshot(
     new FakeSandboxRuntime(),
@@ -79,6 +98,19 @@ Deno.test("collectHarnessCapabilitySnapshot captures fixed sandbox capabilities"
         cfc: {
           runtimeRequested: true,
           workspaceMountPath: "/workspace",
+        },
+      },
+      mounts: {
+        workspace: {
+          kind: "workspace",
+          status: "configured",
+          sandboxPath: "/workspace",
+          readOnly: false,
+        },
+        fabric: {
+          kind: "fabric-fuse",
+          status: "not-configured",
+          sandboxPath: "/fabric",
         },
       },
       protectedXattrs: {
@@ -114,6 +146,29 @@ Deno.test("collectHarnessCapabilitySnapshot captures fixed sandbox capabilities"
         path: "/usr/bin/git",
         version: "git version 2.45.1",
       },
+    },
+  });
+});
+
+Deno.test("collectHarnessCapabilitySnapshot reports configured Fabric mounts", async () => {
+  const snapshot = await collectHarnessCapabilitySnapshot(
+    new FakeFabricSandboxRuntime(),
+    "/workspace",
+    "2026-04-29T23:00:00.000Z",
+  );
+
+  assertEquals(snapshot.cfc.mounts, {
+    workspace: {
+      kind: "workspace",
+      status: "configured",
+      sandboxPath: "/workspace",
+      readOnly: false,
+    },
+    fabric: {
+      kind: "fabric-fuse",
+      status: "configured",
+      sandboxPath: "/fabric",
+      readOnly: false,
     },
   });
 });

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -36,6 +36,7 @@ Deno.test("resolveDockerRunscSandboxConfig fills the expected defaults", () => {
   assertEquals(config.workspaceMountPath, "/workspace");
   assertEquals(config.shellPath, "/bin/sh");
   assertEquals(config.dockerNetworkMode, "none");
+  assertEquals(config.additionalMounts, []);
   assertEquals(config.extraDockerArgs, []);
 });
 
@@ -117,6 +118,39 @@ Deno.test("DockerRunscSandboxRuntime describe preserves custom CFC runtime alias
   assertEquals(description.cfc.runtimeName, "corp-runsc-prod");
 });
 
+Deno.test("resolveDockerRunscSandboxConfig normalizes a Fabric FUSE mount", () => {
+  const config = resolveDockerRunscSandboxConfig({
+    workspaceHostPath: "/host/project",
+    additionalMounts: [{
+      kind: "fabric-fuse",
+      hostPath: "/tmp/cf-fuse",
+    }],
+  });
+
+  assertEquals(config.additionalMounts, [{
+    kind: "fabric-fuse",
+    hostPath: "/tmp/cf-fuse",
+    sandboxPath: "/fabric",
+    readOnly: false,
+  }]);
+});
+
+Deno.test("resolveDockerRunscSandboxConfig rejects overlapping sandbox roots", () => {
+  assertThrows(
+    () =>
+      resolveDockerRunscSandboxConfig({
+        workspaceHostPath: "/host/project",
+        additionalMounts: [{
+          kind: "fabric-fuse",
+          hostPath: "/tmp/cf-fuse",
+          sandboxPath: "/workspace/fabric",
+        }],
+      }),
+    Error,
+    "sandbox mount paths overlap",
+  );
+});
+
 Deno.test("DockerRunscSandboxRuntime runShell honors an explicit container user override", async () => {
   const runner = new FakeProcessRunner({
     stdout: "",
@@ -196,4 +230,62 @@ Deno.test("DockerRunscSandboxRuntime accepts workspace paths when the mount path
     runtime.isPathWithinWorkspace("/workspace/notes/todo.txt"),
     true,
   );
+});
+
+Deno.test("DockerRunscSandboxRuntime mounts Fabric separately and accepts Fabric paths", async () => {
+  const runner = new FakeProcessRunner({
+    stdout: "",
+    stderr: "",
+    exitCode: 0,
+  });
+  const runtime = new DockerRunscSandboxRuntime(
+    resolveDockerRunscSandboxConfig({
+      workspaceHostPath: "/host/project",
+      image: "sandbox:latest",
+      additionalMounts: [{
+        kind: "fabric-fuse",
+        hostPath: "/tmp/cf-fuse",
+        readOnly: true,
+      }],
+    }),
+    runner,
+  );
+
+  assertEquals(
+    runtime.resolvePath("/fabric/home/pieces"),
+    "/fabric/home/pieces",
+  );
+  assertEquals(runtime.isPathWithinWorkspace("/fabric/home"), false);
+  assertEquals(runtime.isPathWithinAllowedRoots("/fabric/home"), true);
+
+  const description = runtime.describe();
+  assertEquals(description.cfc?.mounts, [
+    { kind: "workspace", sandboxPath: "/workspace", readOnly: false },
+    { kind: "fabric-fuse", sandboxPath: "/fabric", readOnly: true },
+  ]);
+
+  await runtime.run({
+    argv: ["/bin/pwd"],
+    cwd: "/fabric/home",
+  });
+
+  assertEquals(runner.requests[0]?.args, [
+    "run",
+    "--rm",
+    "--runtime",
+    "runsc-cfc",
+    "--network",
+    "none",
+    ...(runtime.config.containerUser !== undefined
+      ? ["--user", runtime.config.containerUser]
+      : []),
+    "--mount",
+    "type=bind,src=/host/project,dst=/workspace",
+    "--mount",
+    "type=bind,src=/tmp/cf-fuse,dst=/fabric,readonly",
+    "-w",
+    "/fabric/home",
+    "sandbox:latest",
+    "/bin/pwd",
+  ]);
 });

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -70,6 +70,14 @@ class StrictFakeSandboxRuntime extends FakeSandboxRuntime {
   }
 }
 
+class MultiRootFakeSandboxRuntime extends FakeSandboxRuntime {
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path) ||
+      path === "/fabric" ||
+      path.startsWith("/fabric/");
+  }
+}
+
 class FakeProcessRunner implements ProcessRunner {
   readonly calls: ProcessRunRequest[] = [];
 
@@ -164,6 +172,21 @@ Deno.test("bash tool executes the command through the sandbox shell runtime", as
     },
   }]);
   assertEquals(context.currentDir, "/workspace/repo");
+});
+
+Deno.test("bash tool preserves currentDir inside a configured Fabric mount", async () => {
+  const sandbox = new MultiRootFakeSandboxRuntime([{
+    stdout: "__CF_HARNESS_CWD__run-1:bash:1__/fabric/home",
+    stderr: "",
+    exitCode: 0,
+  }]);
+  const context = createContext(sandbox);
+  const output = await bashTool.invoke(context, {
+    command: "cd /fabric/home",
+  });
+
+  assertEquals(output.cwd, "/fabric/home");
+  assertEquals(context.currentDir, "/fabric/home");
 });
 
 Deno.test("bash-no-sandbox tool executes the command through the host process runner", async () => {


### PR DESCRIPTION
## Summary
- add typed Docker/runsc additional mounts for Fabric FUSE, defaulting to /fabric
- keep /workspace and /fabric as distinct sandbox roots, with Docker mount args and path guards updated accordingly
- surface workspace/Fabric mount status in cf-harness capability diagnostics

## Notes
- intentionally does not add CLI flags or real FUSE probing yet
- meant as prep for Wilk's host-FUSE-bind-mounted-into-runsc work

## Tests
- deno check packages/cf-harness/src/index.ts
- deno test -A packages/cf-harness/test/docker-runsc-sandbox.test.ts
- deno test -A packages/cf-harness/test/diagnostics.test.ts packages/cf-harness/test/artifacts.test.ts packages/cf-harness/test/tools-execution.test.ts
- cd packages/cf-harness && deno task test
- git diff --check