### PR TITLE
Fold away `HashObject`; route memory's `FabricHash` through data-model

### DIFF
--- a/packages/data-model/fabric-hash.ts
+++ b/packages/data-model/fabric-hash.ts
@@ -1,3 +1,7 @@
+import type {
+  FabricHash as ApiFabricHash,
+  FabricHashConstructor as ApiFabricHashConstructor,
+} from "@commonfabric/api";
 import { FabricPrimitive } from "./interface.ts";
 import {
   fromBase64url,
@@ -19,7 +23,7 @@ import {
  * freeze `ArrayBuffer` contents). The string form is cached internally so
  * that repeated `toString()` calls are O(1).
  */
-export class FabricHash extends FabricPrimitive {
+export class FabricHash extends FabricPrimitive implements ApiFabricHash {
   readonly #hash: Uint8Array;
   readonly #tag: string;
   readonly #justHashString: string;
@@ -113,3 +117,8 @@ export class FabricHash extends FabricPrimitive {
     return new FabricHash(fromBase64url(hashBase64url), tag);
   }
 }
+
+// Compile-time check that the exported `FabricHash` constructor matches the
+// `FabricHashConstructor` declared in `@commonfabric/api`. This catches drift
+// between the public type contract and this implementation.
+FabricHash satisfies ApiFabricHashConstructor;

--- a/packages/data-model/value-hash.ts
+++ b/packages/data-model/value-hash.ts
@@ -10,41 +10,25 @@ import { FabricHash } from "./fabric-hash.ts";
 import type { FabricValue } from "./interface.ts";
 
 // ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
-
-/**
- * Content hash -- a hash-based reference to a value.
- *
- * The phantom type parameter `T` is kept for compatibility with generic call
- * sites; `FabricHash` ignores it (no phantom member).
- */
-export type HashObject<T extends FabricValue = FabricValue> = FabricHash;
-
-// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /** Parse a hash object from its string representation. */
-export function hashObjectFromString(source: string): HashObject {
+export function hashObjectFromString(source: string): FabricHash {
   return FabricHash.fromString(source);
 }
 
 /** Type guard: returns true if the value is a content hash. */
-export function isHashObject<T extends FabricValue>(
-  value: unknown | HashObject<T>,
-): value is HashObject<T> {
+export function isHashObject(value: unknown): value is FabricHash {
   return value instanceof FabricHash;
 }
 
 /** Reconstructs a hash object from its JSON representation. */
-export function hashObjectFromJson(source: { "/": string }): HashObject {
+export function hashObjectFromJson(source: { "/": string }): FabricHash {
   return FabricHash.fromString(source["/"]);
 }
 
 /** Compute a content hash for the given source value. */
-export function hashOf<T extends FabricValue>(
-  source: T,
-): HashObject<T> {
+export function hashOf(source: FabricValue): FabricHash {
   return hashOfModern(source);
 }

--- a/packages/memory/access.ts
+++ b/packages/memory/access.ts
@@ -7,7 +7,8 @@ import {
   Proof,
   Signer,
 } from "./interface.ts";
-import { type HashObject, hashOf } from "@commonfabric/data-model/value-hash";
+import type { FabricHash } from "@commonfabric/data-model/fabric-hash";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 import { unauthorized } from "./error.ts";
 import { type DID } from "@commonfabric/identity";
 import { fromDID } from "./util.ts";
@@ -106,7 +107,7 @@ export const claim = async <Access extends Invocation>(
 /**
  * Issues verifiable authorization signed by the given signer.
  */
-export const authorize = async <Access extends HashObject[]>(
+export const authorize = async <Access extends FabricHash[]>(
   access: Access,
   as: Signer,
 ): AsyncResult<Authorization<Access[number]>, Error> => {

--- a/packages/memory/commit.ts
+++ b/packages/memory/commit.ts
@@ -8,7 +8,7 @@ import type {
   Revision,
   Transaction,
 } from "./interface.ts";
-import type { HashObject } from "@commonfabric/data-model/value-hash";
+import type { FabricHash } from "@commonfabric/data-model/fabric-hash";
 import { assert } from "./fact.ts";
 import { hashObjectFromString } from "@commonfabric/data-model/value-hash";
 
@@ -22,7 +22,7 @@ export const create = <Space extends MemorySpace>({
   space: Space;
   since?: number;
   transaction: Transaction;
-  cause?: HashObject<Assertion> | Assertion | null | undefined;
+  cause?: FabricHash | Assertion | null | undefined;
 }): Assertion<typeof COMMIT_LOG_TYPE, Space, CommitData> =>
   assert({
     the: COMMIT_LOG_TYPE,
@@ -45,7 +45,7 @@ export const toRevision = (
       the: COMMIT_LOG_TYPE,
       of: space as MemorySpace,
       is,
-      cause: hashObjectFromString(cause) as HashObject<Fact>,
+      cause: hashObjectFromString(cause) as FabricHash,
     }),
     since: is.since,
   };

--- a/packages/memory/consumer.ts
+++ b/packages/memory/consumer.ts
@@ -48,9 +48,9 @@ import type {
   UTCUnixTimestampInSeconds,
 } from "./interface.ts";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricHash } from "@commonfabric/data-model/fabric-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import {
-  type HashObject,
   hashObjectFromJson,
   hashOf,
 } from "@commonfabric/data-model/value-hash";
@@ -155,7 +155,7 @@ class MemoryConsumerSession<
     >
     | undefined;
   invocations: Map<
-    InvocationURL<HashObject<Invocation>>,
+    InvocationURL<FabricHash>,
     Job<Abilities<MemoryProtocol>, MemoryProtocol>
   > = new Map();
 
@@ -386,7 +386,7 @@ class MemoryConsumerSession<
 
   private executeAuthorized<
     Ability extends string,
-    Access extends HashObject[],
+    Access extends FabricHash[],
   >(
     authorizationResult: Result<Authorization<Access[number]>, Error>,
     invocation: ConsumerInvocation<Ability, MemoryProtocol>,
@@ -592,7 +592,7 @@ class ConsumerInvocation<Ability extends string, Protocol extends Proto> {
 
   source: ConsumerInvocationFor<Ability, Protocol>;
 
-  #reference: HashObject<Invocation>;
+  #reference: FabricHash;
 
   static create<Ability extends string, Protocol extends Proto>(
     as: DID,

--- a/packages/memory/fact.ts
+++ b/packages/memory/fact.ts
@@ -1,5 +1,6 @@
 import type { URI } from "./interface.ts";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue } from "@commonfabric/api";
+import type { FabricHash } from "@commonfabric/data-model/fabric-hash";
 import {
   Assertion,
   Fact,
@@ -12,7 +13,6 @@ import {
   Unclaimed,
 } from "./interface.ts";
 import {
-  HashObject,
   hashObjectFromJson,
   hashObjectFromString,
   hashOf,
@@ -43,7 +43,7 @@ const frozenUnclaimedCache = new Map<
  */
 export const unclaimedRef = (
   { the, of }: { the: MIME; of: URI },
-): HashObject<Unclaimed> => {
+): FabricHash => {
   const key = `${the}\0${of}`;
   let frozen = frozenUnclaimedCache.get(key);
   if (!frozen) {
@@ -66,7 +66,7 @@ export const assert = <
   the: T;
   of: Of;
   is: Is;
-  cause?: Fact | HashObject<Fact> | null | undefined;
+  cause?: Fact | FabricHash | null | undefined;
 }) =>
   ({
     the,
@@ -135,9 +135,7 @@ export function normalizeFact<
     of: Of;
     is: Is;
     cause?:
-      | HashObject<Assertion<T, Of, Is>>
-      | HashObject<Retraction<T, Of, Is>>
-      | HashObject<Unclaimed<T, Of>>
+      | FabricHash
       | Fact
       | { "/": string };
   },
@@ -152,9 +150,7 @@ export function normalizeFact<
     the: T;
     of: Of;
     cause?:
-      | HashObject<Assertion<T, Of, Is>>
-      | HashObject<Retraction<T, Of, Is>>
-      | HashObject<Unclaimed<T, Of>>
+      | FabricHash
       | Fact
       | { "/": string };
   },
@@ -170,9 +166,7 @@ export function normalizeFact<
     of: Of;
     is?: Is;
     cause?:
-      | HashObject<Assertion<T, Of, Is>>
-      | HashObject<Retraction<T, Of, Is>>
-      | HashObject<Unclaimed<T, Of>>
+      | FabricHash
       | Fact
       | { "/": string };
   },
@@ -205,6 +199,6 @@ export function normalizeFact<
   }
 }
 
-export const factReference = (fact: Fact): HashObject<Fact> => {
+export const factReference = (fact: Fact): FabricHash => {
   return hashOf(normalizeFact(fact));
 };

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -1,6 +1,6 @@
-import type { HashObject } from "@commonfabric/data-model/value-hash";
-import type { JSONValue } from "@commonfabric/api";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { FabricValue, JSONValue } from "@commonfabric/api";
+import type { FabricHash } from "@commonfabric/data-model/fabric-hash";
+
 import type { SchemaPathSelector } from "@commonfabric/api";
 export type { SchemaPathSelector };
 
@@ -58,7 +58,7 @@ export interface Principal<ID extends DID = DID> {
  */
 export interface Authority extends Principal {
   authorize<T extends FabricValue>(
-    access: Iterable<HashObject<T> | T>,
+    access: Iterable<FabricHash | T>,
   ): AwaitResult<Authorization<T>, AuthorizationError>;
 }
 
@@ -96,7 +96,7 @@ export type UCAN<Command extends Invocation> = {
  * Proof of authorization for a given access.
  */
 export interface Proof<Access extends FabricValue = FabricValue> {
-  [link: AsString<HashObject<Access>>]: Unit;
+  [link: AsString<FabricHash>]: Unit;
 }
 
 /**
@@ -435,18 +435,18 @@ export type Receipt<
 > =
   | {
     the: "task/return";
-    of: InvocationURL<HashObject<Command>>;
+    of: InvocationURL<FabricHash>;
     is: Awaited<Result>;
   }
   | (Effect extends never ? never
     : {
       the: "task/effect";
-      of: InvocationURL<HashObject<Command>>;
+      of: InvocationURL<FabricHash>;
       is: Effect;
     });
 
 export type Effect<Of extends NonNullable<unknown>, Command> = {
-  of: HashObject<Of>;
+  of: FabricHash;
   run: Command;
   is?: undefined;
 };
@@ -455,7 +455,7 @@ export type Return<
   Of extends NonNullable<unknown>,
   Result extends FabricValue,
 > = {
-  of: HashObject<Of>;
+  of: FabricHash;
   is: Result;
   run?: undefined;
 };
@@ -605,10 +605,7 @@ export interface Assertion<
   the: T;
   of: Of;
   is: Is;
-  cause:
-    | HashObject<Assertion<T, Of, Is>>
-    | HashObject<Retraction<T, Of, Is>>
-    | HashObject<Unclaimed<T, Of>>;
+  cause: FabricHash;
 }
 
 /**
@@ -623,7 +620,7 @@ export interface Retraction<
   the: T;
   of: Of;
   is?: undefined;
-  cause: HashObject<Assertion<T, Of, Is>>;
+  cause: FabricHash;
 }
 
 export interface Invariant<
@@ -633,7 +630,7 @@ export interface Invariant<
 > {
   the: T;
   of: Of;
-  fact: HashObject<Fact<T, Of, Is>>;
+  fact: FabricHash;
 
   is?: undefined;
   cause?: undefined;
@@ -814,7 +811,7 @@ export type Subscribe<Space extends MemorySpace = MemorySpace> = Invocation<
 export type Unsubscribe<Space extends MemorySpace = MemorySpace> = Invocation<
   "/memory/query/unsubscribe",
   Space,
-  { source: InvocationURL<HashObject<Subscribe<Space>>> }
+  { source: InvocationURL<FabricHash> }
 >;
 
 export type SchemaQueryArgs = {
@@ -963,7 +960,7 @@ export type Conflict = {
   /**
    * Expected state in the replica.
    */
-  expected: HashObject<Fact> | null;
+  expected: FabricHash | null;
 
   /**
    * Actual memory state in the replica repository.

--- a/packages/memory/provider.ts
+++ b/packages/memory/provider.ts
@@ -28,7 +28,6 @@ import {
   Revision,
   SchemaQuery,
   Selection,
-  Subscribe,
   Subscriber,
   Transaction,
   UCAN,
@@ -40,8 +39,8 @@ import {
 } from "@commonfabric/data-model/value-debug";
 import * as SelectionBuilder from "./selection.ts";
 import * as Memory from "./memory.ts";
+import type { FabricHash } from "@commonfabric/data-model/fabric-hash";
 import {
-  type HashObject,
   hashObjectFromString as causeFromString,
   hashOf,
 } from "@commonfabric/data-model/value-hash";
@@ -206,7 +205,7 @@ export * as Subscription from "./subscription.ts";
 export * from "./util.ts";
 
 // Convenient shorthand so I don't need this long type for this string
-type JobId = InvocationURL<HashObject<ConsumerCommandInvocation<Protocol>>>;
+type JobId = InvocationURL<FabricHash>;
 export type Options = Memory.Options;
 
 export const open = async (
@@ -339,11 +338,10 @@ class MemoryProviderSession<
     | ReadableStreamDefaultController<ProviderCommand<MemoryProtocol>>
     | undefined;
 
-  channels: Map<InvocationURL<HashObject<Subscribe>>, Set<string>> = new Map();
+  channels: Map<InvocationURL<FabricHash>, Set<string>> = new Map();
   // Reverse index: watchAddress → Set of channel IDs that watch it.
   // Allows O(changes) commit matching instead of O(channels × changes).
-  private watchIndex: Map<string, Set<InvocationURL<HashObject<Subscribe>>>> =
-    new Map();
+  private watchIndex: Map<string, Set<InvocationURL<FabricHash>>> = new Map();
   schemaChannels: Map<JobId, SchemaSubscription> = new Map();
   // Mapping from fact key to since value of the last fact sent to the client
   lastRevision: Map<string, number> = new Map();
@@ -541,16 +539,12 @@ class MemoryProviderSession<
       );
       return this.perform({
         the: "task/return",
-        of: `job:${hashOf(invocation)}` as InvocationURL<
-          HashObject<ConsumerCommandInvocation<MemoryProtocol>>
-        >,
+        of: `job:${hashOf(invocation)}` as InvocationURL<FabricHash>,
         is: { error },
       });
     }
 
-    const of = `job:${hashOf(invocation)}` as InvocationURL<
-      HashObject<ConsumerCommandInvocation<Protocol>>
-    >;
+    const of = `job:${hashOf(invocation)}` as InvocationURL<FabricHash>;
 
     switch (invocation.cmd) {
       case "/memory/query": {
@@ -923,10 +917,10 @@ class MemoryProviderSession<
    */
   private findMatchingChannels(
     transaction: Transaction<MemorySpace>,
-  ): InvocationURL<HashObject<Subscribe>>[] {
+  ): InvocationURL<FabricHash>[] {
     if (this.watchIndex.size === 0) return [];
 
-    const matched = new Set<InvocationURL<HashObject<Subscribe>>>();
+    const matched = new Set<InvocationURL<FabricHash>>();
     const space = transaction.sub;
 
     // Check commit-log watchers first
@@ -944,7 +938,7 @@ class MemoryProviderSession<
 
   /** Look up the 4 watch address variants and add matching channel IDs. */
   private collectWatchMatches(
-    matched: Set<InvocationURL<HashObject<Subscribe>>>,
+    matched: Set<InvocationURL<FabricHash>>,
     space: string,
     of: string,
     the: string,
@@ -970,7 +964,7 @@ class MemoryProviderSession<
   }
 
   private addWatchHits(
-    matched: Set<InvocationURL<HashObject<Subscribe>>>,
+    matched: Set<InvocationURL<FabricHash>>,
     addr: string,
   ) {
     const ids = this.watchIndex.get(addr);
@@ -980,7 +974,7 @@ class MemoryProviderSession<
   }
 
   /** Remove a channel and clean up its entries in the watchIndex. */
-  private removeChannel(id: InvocationURL<HashObject<Subscribe>>) {
+  private removeChannel(id: InvocationURL<FabricHash>) {
     const addresses = this.channels.get(id);
     if (addresses) {
       for (const addr of addresses) {
@@ -1301,8 +1295,8 @@ class MemoryProviderSession<
    */
   private findCommitLogChannels(
     space: MemorySpace,
-  ): InvocationURL<HashObject<Subscribe>>[] {
-    const matched = new Set<InvocationURL<HashObject<Subscribe>>>();
+  ): InvocationURL<FabricHash>[] {
+    const matched = new Set<InvocationURL<FabricHash>>();
     this.collectWatchMatches(matched, space, space, COMMIT_LOG_TYPE);
     return [...matched];
   }

--- a/packages/memory/reference.ts
+++ b/packages/memory/reference.ts
@@ -1,7 +1,7 @@
 export type {
-  HashObject,
-  HashObject as ContentId,
-} from "@commonfabric/data-model/value-hash";
+  FabricHash,
+  FabricHash as ContentId,
+} from "@commonfabric/data-model/fabric-hash";
 
 export {
   hashObjectFromJson as contentIdFromJSON,

--- a/packages/memory/space.ts
+++ b/packages/memory/space.ts
@@ -8,15 +8,14 @@ import {
 import { COMMIT_LOG_TYPE, create as createCommit } from "./commit.ts";
 import * as SelectionBuilder from "./selection.ts";
 import { unclaimedRef } from "./fact.ts";
+import type { FabricHash } from "@commonfabric/data-model/fabric-hash";
 import {
-  type HashObject,
   hashObjectFromString,
   hashOf,
 } from "@commonfabric/data-model/value-hash";
 import { addMemoryAttributes, traceAsync, traceSync } from "./telemetry.ts";
 import type {
   Assert,
-  Assertion,
   AsyncResult,
   AuthorizationError,
   CauseString,
@@ -552,7 +551,7 @@ const recall = <Space extends MemorySpace>(
       of,
       cause: (row.cause
         ? hashObjectFromString(row.cause)
-        : unclaimedRef({ the, of })) as HashObject<Assertion>,
+        : unclaimedRef({ the, of })) as FabricHash,
       since: row.since,
       fact: row.fact, // Include stored hash to avoid recomputing with hashOf()
     };
@@ -638,7 +637,7 @@ const getFact = <Space extends MemorySpace>(
     cause:
       (row.cause
         ? hashObjectFromString(row.cause)
-        : unclaimedRef(row as FactAddress)) as HashObject<Assertion>,
+        : unclaimedRef(row as FactAddress)) as FabricHash,
     since: row.since,
   };
   if (row.is) {
@@ -830,7 +829,7 @@ const swap = <Space extends MemorySpace>(
     : [source.claim, source.claim.fact];
   const cause = expect.toString();
   const base = unclaimedRef({ the, of }).toString();
-  const expected = cause === base ? null : (expect as HashObject<Fact>);
+  const expected = cause === base ? null : (expect as FabricHash);
 
   // Derive the merkle reference to the fact that memory will have after
   // successful update. If we have an assertion or retraction we derive fact
@@ -951,9 +950,9 @@ const commit = <Space extends MemorySpace>(
   const [since, cause] = row
     ? [
       plainObjectFromJson<CommitData>(row.is as string).since + 1,
-      hashObjectFromString(row.fact) as HashObject<Assertion>,
+      hashObjectFromString(row.fact) as FabricHash,
     ]
-    : [0, unclaimedRef({ the, of }) as HashObject as HashObject<Assertion>];
+    : [0, unclaimedRef({ the, of }) as FabricHash];
 
   const commit = createCommit({
     space: of,


### PR DESCRIPTION
## Summary

- `HashObject` is gone; `value-hash.ts` exposes `FabricHash` (the data-model class) directly. `isHashObject` is now a non-generic predicate.
- The 8 `memory/` consumers that imported `FabricHash` from `@commonfabric/api` now import it from `@commonfabric/data-model/fabric-hash`, so the type predicate's target lines up with the union member at narrow sites. (Without this, `FabricHash | Fact` failed to narrow to `Fact` in `isHashObject`'s false branch — the api interface and the data-model class are two distinct declarations even though structurally identical.)
- The api's `FabricHash` interface and `FabricHashConstructor` stay — some api consumers don't have direct access to the runtime — but `data-model/fabric-hash.ts` now pins itself to that contract via `implements FabricHash` (instance side) and a `satisfies FabricHashConstructor` check at the bottom of the file (static side), so drift is caught at compile time.

## Test plan

- [ ] `deno task test` from the repo root
- [ ] Spot-check `data-model` and `memory` (already green locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
