### PR TITLE
refactor(patterns): swap raw JSON.stringify for {Compact,Indented}DebugString in non-test DEBUG+DISPLAY sites

### DIFF
--- a/packages/patterns/airtable/airtable-importer.tsx
+++ b/packages/patterns/airtable/airtable-importer.tsx
@@ -5,7 +5,6 @@ import {
   ifElse,
   NAME,
   pattern,
-  toCompactDebugString,
   UI,
   Writable,
 } from "commonfabric";
@@ -663,7 +662,8 @@ function formatCellValue(value: unknown): string {
     return value.map((v) => formatCellValue(v)).join(", ");
   }
   if (typeof value === "object") {
-    return toCompactDebugString(value);
+    // Plain JSON: this fallback feeds user-visible UI cell content, not debug output
+    return JSON.stringify(value);
   }
   return String(value);
 }

--- a/packages/patterns/airtable/airtable-importer.tsx
+++ b/packages/patterns/airtable/airtable-importer.tsx
@@ -5,6 +5,7 @@ import {
   ifElse,
   NAME,
   pattern,
+  toCompactDebugString,
   UI,
   Writable,
 } from "commonfabric";
@@ -662,7 +663,7 @@ function formatCellValue(value: unknown): string {
     return value.map((v) => formatCellValue(v)).join(", ");
   }
   if (typeof value === "object") {
-    return JSON.stringify(value);
+    return toCompactDebugString(value);
   }
   return String(value);
 }

--- a/packages/patterns/budget-tracker/expense-form.tsx
+++ b/packages/patterns/budget-tracker/expense-form.tsx
@@ -14,6 +14,7 @@ import {
   NAME,
   pattern,
   Stream,
+  toIndentedDebugString,
   UI,
   Writable,
 } from "commonfabric";
@@ -278,7 +279,7 @@ export default pattern<Input>(({ expenses, budgets }) => {
             }}
           >
             {computed(() =>
-              JSON.stringify(
+              toIndentedDebugString(
                 {
                   newDescription: newDescription.get(),
                   newAmount: newAmount.get(),
@@ -286,8 +287,6 @@ export default pattern<Input>(({ expenses, budgets }) => {
                   budgetCategory: budgetCategory.get(),
                   budgetLimit: budgetLimit.get(),
                 },
-                null,
-                2
               )
             )}
           </pre>
@@ -305,13 +304,11 @@ export default pattern<Input>(({ expenses, budgets }) => {
             }}
           >
             {computed(() =>
-              JSON.stringify(
+              toIndentedDebugString(
                 {
                   expenses: expenses.get(),
                   budgets: budgets.get(),
                 },
-                null,
-                2
               )
             )}
           </pre>

--- a/packages/patterns/cfc-agent-prompt-injection-demo/main.tsx
+++ b/packages/patterns/cfc-agent-prompt-injection-demo/main.tsx
@@ -11,6 +11,7 @@ import {
   patternTool,
   safeDateNow,
   type Stream,
+  toIndentedDebugString,
   UI,
   Writable,
 } from "commonfabric";
@@ -308,7 +309,7 @@ type LabelPreviewProps = {
 };
 
 const formatLabelAtom = (atom: unknown) =>
-  typeof atom === "string" ? atom : JSON.stringify(atom, null, 2);
+  typeof atom === "string" ? atom : toIndentedDebugString(atom);
 
 function LabelPreview(
   { confidentiality = [], integrity = [] }: LabelPreviewProps,

--- a/packages/patterns/examples/fetch-program-test.tsx
+++ b/packages/patterns/examples/fetch-program-test.tsx
@@ -4,6 +4,7 @@ import {
   fetchProgram,
   NAME,
   pattern,
+  toIndentedDebugString,
   UI,
   Writable,
 } from "commonfabric";
@@ -50,7 +51,7 @@ export default pattern(() => {
         {result && (
           <div style="color: green">
             Successfully compiled pattern! Piece ID: {result}
-            <pre>{computed(() => JSON.stringify(result, null, 2))}</pre>
+            <pre>{computed(() => toIndentedDebugString(result))}</pre>
           </div>
         )}
       </div>

--- a/packages/patterns/examples/nested-mentionables.tsx
+++ b/packages/patterns/examples/nested-mentionables.tsx
@@ -1,4 +1,4 @@
-import { NAME, pattern, UI } from "commonfabric";
+import { NAME, pattern, toIndentedDebugString, UI } from "commonfabric";
 
 interface Node {
   label: string;
@@ -38,7 +38,7 @@ export default pattern<Record<string, never>>((_) => {
     [UI]: (
       <div>
         <p>This pattern exports a recursive mentionable tree:</p>
-        <pre>{JSON.stringify(TREE, null, 2)}</pre>
+        <pre>{toIndentedDebugString(TREE)}</pre>
       </div>
     ),
     mentionable: mentionables,

--- a/packages/patterns/gideon-tests/test-33-computed-projection-writability.tsx
+++ b/packages/patterns/gideon-tests/test-33-computed-projection-writability.tsx
@@ -18,6 +18,7 @@ import {
   NAME,
   pattern,
   safeDateNow,
+  toIndentedDebugString,
   UI,
 } from "commonfabric";
 
@@ -287,7 +288,7 @@ export default pattern<InputSchema, Output>(({ source }) => {
         >
           <h3>Raw Source State:</h3>
           <pre style={{ fontSize: "12px", overflow: "auto" }}>
-            {computed(() => JSON.stringify({ auth: source.auth, name: source.name }, null, 2))}
+            {computed(() => toIndentedDebugString({ auth: source.auth, name: source.name }))}
           </pre>
         </div>
       </div>

--- a/packages/patterns/gideon-tests/test-cell-equals-diagnostic.tsx
+++ b/packages/patterns/gideon-tests/test-cell-equals-diagnostic.tsx
@@ -13,6 +13,8 @@ import {
   nonPrivateRandom,
   pattern,
   safeDateNow,
+  toCompactDebugString,
+  toIndentedDebugString,
   UI,
   Writable,
 } from "commonfabric";
@@ -58,7 +60,7 @@ const selectByIndex = handler<
     log.push(`items.get() returned array of length: ${itemsArray.length}`);
 
     const targetItem = itemsArray[index];
-    log.push(`itemsArray[${index}] = ${JSON.stringify(targetItem)}`);
+    log.push(`itemsArray[${index}] = ${toCompactDebugString(targetItem)}`);
     log.push(`typeof targetItem: ${typeof targetItem}`);
     log.push(`targetItem constructor: ${targetItem?.constructor?.name}`);
 
@@ -72,11 +74,11 @@ const selectByIndex = handler<
 
     // Read back
     const readBack = selectedItem.get();
-    log.push(`selectedItem.get() = ${JSON.stringify(readBack)}`);
+    log.push(`selectedItem.get() = ${toCompactDebugString(readBack)}`);
 
     // Check items again
     const itemsAfter = items.get();
-    log.push(`items after set: ${JSON.stringify(itemsAfter)}`);
+    log.push(`items after set: ${toCompactDebugString(itemsAfter)}`);
   },
 );
 
@@ -159,7 +161,7 @@ export default pattern<DiagInput, DiagInput>(
                 marginTop: "0.25rem",
               }}
             >
-              <pre>{JSON.stringify(selectedItem, null, 2)}</pre>
+              <pre>{toIndentedDebugString(selectedItem)}</pre>
             </div>
           </div>
 

--- a/packages/patterns/gideon-tests/test-cross-charm-client.tsx
+++ b/packages/patterns/gideon-tests/test-cross-charm-client.tsx
@@ -30,6 +30,8 @@ import {
   NAME,
   pattern,
   Stream,
+  toCompactDebugString,
+  toIndentedDebugString,
   UI,
   wish,
   Writable,
@@ -79,7 +81,7 @@ const invokeServerStream = handler<
       );
     } else {
       state.lastInvocationStatus.set(
-        `Stream not found or invalid: ${JSON.stringify(innerValue)}`,
+        `Stream not found or invalid: ${toCompactDebugString(innerValue)}`,
       );
     }
   } catch (error) {
@@ -237,7 +239,7 @@ export default pattern<Input, Output>(
                 Debug Info
               </summary>
               <pre style={{ fontSize: "10px", overflow: "auto" }}>
-              {JSON.stringify(
+              {toIndentedDebugString(
                 {
                   useCfRender,
                   invocationCount,
@@ -245,8 +247,6 @@ export default pattern<Input, Output>(
                   serverPieceExists: serverPiece !== undefined && serverPiece !== null,
                   serverStreamExists: serverStream !== undefined && serverStream !== null,
                 },
-                null,
-                2
               )}
               </pre>
             </details>

--- a/packages/patterns/gideon-tests/test-generateobject-error-handling.tsx
+++ b/packages/patterns/gideon-tests/test-generateobject-error-handling.tsx
@@ -26,6 +26,7 @@ import {
   ifElse,
   NAME,
   pattern,
+  toIndentedDebugString,
   UI,
 } from "commonfabric";
 
@@ -51,9 +52,7 @@ export default pattern<Input, Input>(({ userInput }) => {
   const errorMessage = derive(
     idea.error,
     (err) =>
-      err
-        ? (typeof err === "string" ? err : JSON.stringify(err, null, 2))
-        : null,
+      err ? (typeof err === "string" ? err : toIndentedDebugString(err)) : null,
   );
 
   return {

--- a/packages/patterns/gideon-tests/test-idempotent-side-effects.tsx
+++ b/packages/patterns/gideon-tests/test-idempotent-side-effects.tsx
@@ -31,6 +31,7 @@ import {
   NAME,
   pattern,
   safeDateNow,
+  toIndentedDebugString,
   UI,
   Writable,
 } from "commonfabric";
@@ -192,7 +193,7 @@ export default pattern<TestInput, TestOutput>(({ triggerCount }) => {
             >
               <strong>Data (keeps growing):</strong>
               <pre style={{ fontSize: "11px", margin: "5px 0" }}>
-                {JSON.stringify(nonIdempotentArray.get(), null, 2)}
+                {toIndentedDebugString(nonIdempotentArray.get())}
               </pre>
             </div>
 
@@ -245,7 +246,7 @@ export default pattern<TestInput, TestOutput>(({ triggerCount }) => {
             >
               <strong>Data (stable):</strong>
               <pre style={{ fontSize: "11px", margin: "5px 0" }}>
-                {JSON.stringify(idempotentMap.get(), null, 2)}
+                {toIndentedDebugString(idempotentMap.get())}
               </pre>
             </div>
 

--- a/packages/patterns/gideon-tests/test-record-key-set-56.tsx
+++ b/packages/patterns/gideon-tests/test-record-key-set-56.tsx
@@ -8,7 +8,15 @@
  *
  * Error observed: "Value at path value/argument/corrections/0-Technical_Expertise is not an object"
  */
-import { Cell, Default, handler, NAME, pattern, UI } from "commonfabric";
+import {
+  Cell,
+  Default,
+  handler,
+  NAME,
+  pattern,
+  toCompactDebugString,
+  UI,
+} from "commonfabric";
 
 interface Item {
   value: string;
@@ -166,8 +174,8 @@ export default pattern<Input>(({ emptyRecord, populatedRecord, logs }) => {
         >
           <strong>Current State:</strong>
           <div style={{ fontSize: "0.8rem", fontFamily: "monospace" }}>
-            <div>emptyRecord: {JSON.stringify(emptyRecord)}</div>
-            <div>populatedRecord: {JSON.stringify(populatedRecord)}</div>
+            <div>emptyRecord: {toCompactDebugString(emptyRecord)}</div>
+            <div>populatedRecord: {toCompactDebugString(populatedRecord)}</div>
           </div>
         </div>
 

--- a/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
+++ b/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
@@ -35,6 +35,7 @@ import {
   pattern,
   safeDateNow,
   Stream,
+  toIndentedDebugString,
   UI,
   wish,
   Writable,
@@ -2100,7 +2101,7 @@ When you're done searching, STOP calling tools and produce your final structured
                                   fontSize: "10px",
                                 }}
                               >
-                                {JSON.stringify(entry.details, null, 2)}
+                                {toIndentedDebugString(entry.details)}
                               </div>
                             )}
                           </div>

--- a/packages/patterns/google/extractors/berkeley-library.tsx
+++ b/packages/patterns/google/extractors/berkeley-library.tsx
@@ -29,6 +29,7 @@ import {
   NAME,
   pattern,
   Stream,
+  toIndentedDebugString,
   UI,
   Writable,
 } from "commonfabric";
@@ -1785,10 +1786,8 @@ export default pattern<PatternInput, PatternOutput>(
                                   }}
                                 >
                                 {computed(() =>
-                                  JSON.stringify(
+                                  toIndentedDebugString(
                                     debugResult?.items || [],
-                                    null,
-                                    2,
                                   )
                                 )}
                                 </pre>

--- a/packages/patterns/google/extractors/email-pattern-launcher.tsx
+++ b/packages/patterns/google/extractors/email-pattern-launcher.tsx
@@ -26,6 +26,7 @@ import {
   NAME,
   navigateTo,
   pattern,
+  toIndentedDebugString,
   UI,
   when,
 } from "commonfabric";
@@ -390,7 +391,7 @@ export default pattern<PatternInput, PatternOutput>(({ overrideAuth }) => {
                   console.log("registryError 2", registryError);
                   return "";
                 })}
-                <pre>{JSON.stringify(registryError, null, 2)}</pre>
+                <pre>{toIndentedDebugString(registryError)}</pre>
               </div>,
             )}
 

--- a/packages/patterns/google/extractors/flight-calendar-bridge.tsx
+++ b/packages/patterns/google/extractors/flight-calendar-bridge.tsx
@@ -26,6 +26,7 @@ import {
   ifElse,
   NAME,
   pattern,
+  toIndentedDebugString,
   UI,
   wish,
   Writable,
@@ -891,7 +892,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
                       whiteSpace: "pre-wrap",
                     }}
                   >
-                    {computed(() => JSON.stringify(allEvents, null, 2))}
+                    {computed(() => toIndentedDebugString(allEvents))}
                   </pre>
                 </div>
               </div>

--- a/packages/patterns/google/extractors/united-flight-tracker.tsx
+++ b/packages/patterns/google/extractors/united-flight-tracker.tsx
@@ -16,7 +16,15 @@
  * 2. Deploy this pattern
  * 3. Link: cf piece link google-auth/auth united-flight-tracker/overrideAuth
  */
-import { computed, ifElse, JSONSchema, NAME, pattern, UI } from "commonfabric";
+import {
+  computed,
+  ifElse,
+  JSONSchema,
+  NAME,
+  pattern,
+  toIndentedDebugString,
+  UI,
+} from "commonfabric";
 import type { Schema } from "commonfabric/schema";
 import GmailExtractor from "../core/gmail-extractor.tsx";
 import type { Auth } from "../core/gmail-extractor.tsx";
@@ -1676,11 +1684,10 @@ export default pattern<Input, Output>(({ overrideAuth }) => {
                                 {computed(() => debugResult?.summary || "N/A")}
                               </div>
                               <div style={{ marginTop: "4px" }}>
-                                <strong>Flights:</strong> {computed(() =>
-                                  JSON.stringify(
+                                <strong>Flights:</strong>{" "}
+                                {computed(() =>
+                                  toIndentedDebugString(
                                     debugResult?.flights || [],
-                                    null,
-                                    2,
                                   )
                                 )}
                               </div>

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -1,4 +1,5 @@
 import { Page, waitFor } from "@commonfabric/integration";
+import { toIndentedDebugString } from "@commonfabric/data-model/value-debug";
 
 const DEFAULT_CFC_BROWSER_TIMEOUT = 30_000;
 const CLICK_TARGET_ATTR = "data-cfc-click-target";
@@ -34,7 +35,7 @@ export async function clickTrustedAction(
     probe ??= await readTrustedActionProbe(page, action).catch(() => undefined);
     throw new Error(
       `Timed out clicking trusted action "${action}". Last probe: ${
-        JSON.stringify(probe, null, 2)
+        toIndentedDebugString(probe)
       }`,
       { cause },
     );
@@ -79,7 +80,7 @@ export async function clickTrustedActionAndWaitForText(
     textProbe ??= await readTextProbe(page, selector).catch(() => undefined);
     throw new Error(
       `Timed out clicking trusted action "${action}" until "${selector}" contained "${text}". Last probes: ${
-        JSON.stringify({ actionProbe, textProbe }, null, 2)
+        toIndentedDebugString({ actionProbe, textProbe })
       }`,
       { cause },
     );
@@ -110,7 +111,7 @@ export async function waitForText(
     probe ??= await readTextProbe(page, selector).catch(() => undefined);
     throw new Error(
       `Timed out waiting for "${selector}" to contain "${text}". Last probe: ${
-        JSON.stringify(probe, null, 2)
+        toIndentedDebugString(probe)
       }`,
       { cause },
     );
@@ -141,7 +142,7 @@ export async function waitForTextAbsent(
     probe ??= await readTextProbe(page, selector).catch(() => undefined);
     throw new Error(
       `Timed out waiting for "${selector}" not to contain "${text}". Last probe: ${
-        JSON.stringify(probe, null, 2)
+        toIndentedDebugString(probe)
       }`,
       { cause },
     );
@@ -280,7 +281,7 @@ export async function fillCfInput(
   } catch (cause) {
     throw new Error(
       `Timed out filling cf input "${selector}" with "${value}". Last probe: ${
-        JSON.stringify(probe, null, 2)
+        toIndentedDebugString(probe)
       }`,
       { cause },
     );

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -33,6 +33,7 @@ export async function clickTrustedAction(
     }, { timeout, delay: 250 });
   } catch (cause) {
     probe ??= await readTrustedActionProbe(page, action).catch(() => undefined);
+    // Indented for readable test-log output
     throw new Error(
       `Timed out clicking trusted action "${action}". Last probe: ${
         toIndentedDebugString(probe)

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -14,6 +14,7 @@ import {
   type PatternToolResult,
   SELF,
   type Stream,
+  toCompactDebugString,
   UI,
   type VNode,
   wish,
@@ -273,7 +274,7 @@ const Note = pattern<NoteInput, NoteOutput>(
         if (typeof value !== "string") {
           console.error(
             `editContent: invalid input shape. Expected { detail: { value: string } }, got: ${
-              JSON.stringify(rawInput)
+              toCompactDebugString(rawInput)
             }`,
           );
           return;

--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -22,6 +22,7 @@ import {
   safeDateNow,
   SELF,
   str,
+  toCompactDebugString,
   UI,
   Writable,
 } from "commonfabric";
@@ -687,7 +688,7 @@ const handleUpdateModule = handler<
       if (result) {
         result.set({
           success: true,
-          message: `Updated ${field} to ${JSON.stringify(value)}`,
+          message: `Updated ${field} to ${toCompactDebugString(value)}`,
         });
       }
     } else if (fieldCell && typeof fieldCell.key === "function") {

--- a/packages/patterns/record/extraction/extractor-module.tsx
+++ b/packages/patterns/record/extraction/extractor-module.tsx
@@ -389,7 +389,7 @@ function isEmpty(value: unknown): boolean {
 /**
  * Format a value for display in the diff view
  */
-function formatValue(value: unknown): string {
+function debugFormatValue(value: unknown): string {
   if (isEmpty(value)) return "(empty)";
   if (Array.isArray(value)) return toCompactDebugString(value);
   if (typeof value === "object") return toCompactDebugString(value);
@@ -2993,8 +2993,8 @@ export const ExtractorModule = pattern<
                             fontFamily: "monospace",
                           }}
                         >
-                          {formatValue(f.currentValue)} -&gt;{" "}
-                          {formatValue(f.extractedValue)}
+                          {debugFormatValue(f.currentValue)} -&gt;{" "}
+                          {debugFormatValue(f.extractedValue)}
                         </div>
                         {ifElse(
                           f.explanation !== undefined && f.explanation !== "",

--- a/packages/patterns/record/extraction/extractor-module.tsx
+++ b/packages/patterns/record/extraction/extractor-module.tsx
@@ -25,6 +25,7 @@ import {
   NAME,
   pattern,
   safeDateNow,
+  toCompactDebugString,
   UI,
   Writable,
 } from "commonfabric";
@@ -390,8 +391,8 @@ function isEmpty(value: unknown): boolean {
  */
 function formatValue(value: unknown): string {
   if (isEmpty(value)) return "(empty)";
-  if (Array.isArray(value)) return JSON.stringify(value);
-  if (typeof value === "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return toCompactDebugString(value);
+  if (typeof value === "object") return toCompactDebugString(value);
   return String(value);
 }
 
@@ -1125,7 +1126,7 @@ function applyFieldToModule(
     console.warn(
       `[Extract] Type mismatch for ${moduleType}.${actualFieldName}: ` +
         `expected ${fieldSchema?.type}, got ${actualType}. ` +
-        `Value: ${JSON.stringify(extractedValue)}. Skipping field.`,
+        `Value: ${toCompactDebugString(extractedValue)}. Skipping field.`,
     );
     return false;
   }
@@ -1175,7 +1176,9 @@ function createModuleWithFields(
       console.warn(
         `[Extract] Type mismatch for new module ${moduleType}.${actualFieldName}: ` +
           `expected ${fieldSchema?.type}, got ${actualType}. ` +
-          `Value: ${JSON.stringify(field.extractedValue)}. Skipping field.`,
+          `Value: ${
+            toCompactDebugString(field.extractedValue)
+          }. Skipping field.`,
       );
       continue;
     }
@@ -1531,7 +1534,7 @@ const applySelected = handler<
               anySuccess = true;
               console.debug(
                 `[Extract] Created new ${moduleType} instance: ${
-                  JSON.stringify(initialValues)
+                  toCompactDebugString(initialValues)
                 }`,
               );
             } catch (e) {

--- a/packages/patterns/self-improving-classifier.tsx
+++ b/packages/patterns/self-improving-classifier.tsx
@@ -25,6 +25,7 @@ import {
   pattern,
   safeDateNow,
   Stream,
+  toIndentedDebugString,
   UI,
   Writable,
 } from "commonfabric";
@@ -2189,10 +2190,10 @@ Each suggestion should have:
                       {computed(() => {
                         const result = currentClassificationResult;
                         if (result) {
-                          return JSON.stringify(result.item.fields, null, 2);
+                          return toIndentedDebugString(result.item.fields);
                         }
                         const item = currentItem.get();
-                        return item ? JSON.stringify(item.fields, null, 2) : "";
+                        return item ? toIndentedDebugString(item.fields) : "";
                       })}
                     </pre>
 
@@ -2300,7 +2301,7 @@ Each suggestion should have:
                       {computed(() => {
                         const undone = undoneAutoItem.get();
                         return undone
-                          ? JSON.stringify(undone.input.fields, null, 2)
+                          ? toIndentedDebugString(undone.input.fields)
                           : "";
                       })}
                     </pre>
@@ -2376,7 +2377,7 @@ Each suggestion should have:
                         <cf-vstack gap="2">
                           <pre style="font-size: 0.75rem; overflow: auto; max-height: 100px; margin: 0;">
                             {computed(() =>
-                              JSON.stringify(pending.input.fields, null, 2)
+                              toIndentedDebugString(pending.input.fields)
                             )}
                           </pre>
 
@@ -2743,10 +2744,8 @@ Each suggestion should have:
                                 </span>
                                 <pre style="font-size: 0.75rem; overflow: auto; max-height: 150px; margin: 0; background: white; padding: 0.5rem; border-radius: 4px; border: 1px solid var(--cf-color-gray-200);">
                                   {computed(() =>
-                                    JSON.stringify(
+                                    toIndentedDebugString(
                                       example.input.fields,
-                                      null,
-                                      2,
                                     )
                                   )}
                                 </pre>

--- a/packages/patterns/system/journal.tsx
+++ b/packages/patterns/system/journal.tsx
@@ -9,6 +9,7 @@ import {
   handler,
   NAME,
   pattern,
+  toIndentedDebugString,
   UI,
   wish,
   Writable,
@@ -86,7 +87,7 @@ export default pattern<Record<string, never>>((_) => {
   // Debug: stringify raw result for the debug panel
   const debugRaw = computed(() => {
     const raw = journalResult.result;
-    return JSON.stringify(raw, null, 2);
+    return toIndentedDebugString(raw);
   });
 
   // Most recent entries first


### PR DESCRIPTION
Migrates 41 of 92 surveyed `JSON.stringify` call sites in `packages/patterns` to the `toCompactDebugString` / `toIndentedDebugString` helpers exposed via the `commonfabric` builder surface in PR #3436. Patterns-side follow-up to the migration arc that landed for `runner` (#3411), `memory` (#3416), and `cli` (#3426) in session 2026-065.

This PR exercises the surface that #3436 introduced — the `js-compiler` test suite (3/0 pass) is the architectural-acceptance signal that pattern code can actually import and use the new helpers via the symlink-driven flat-copy mechanism.

## Migration shape (41 SWAP / 51 SKIP / 92 surveyed = 45%)

**Helper-variant breakdown:**

- **`toIndentedDebugString`: 27 sites** — `<pre>` UI displays, Debug Info panels, test-infra error-throw diagnostics, multi-line displays. (Distribution leans DISPLAY-heavy here, in contrast to the prior cadence PRs which were DEBUG-heavy.)
- **`toCompactDebugString`: 14 sites** — `console.warn` / `error` / `debug`, `log.push` embeds, error-message string interpolation, table-cell formatters.

**Sites left in place (51 of 92):**

- **18** HTTP `body: JSON.stringify(...)` — wire format, never migratable.
- **11** `Writable<string>` JSON-cell storage in scrabble (`bagJson`, `boardJson`, etc.) — typed `Writable<string>` partnered with `JSON.parse`.
- **10** LLM-prompt-embed (D5, see below):
  - 6 in `self-improving-classifier.tsx` (`prompt += ...`)
  - **2 in `tools/importer-prompt.ts`** — both inside `AIRTABLE_*_SOURCE` template literals consumed as `<reference-implementations>` example code for the LLM to mimic. **Worth flagging:** this is *not* the `prompt += ...` shape — it's reference-implementation source-code embedded in a template literal — and a quick scan could miss the D5 application here.
  - 1 in `chatbot.tsx` (`previewMessage` → `generateObject` prompt)
  - 1 in `subAgent.tsx` (`appendTaskToSystem` system-prompt)
- **6** wiki-link / pattern-identity strings (`recordPatternJson`, `linkPattern`, `schemaTag`) — used as identity keys downstream.
- **2** `JSON.parse(JSON.stringify(input))` deep-clone idiom.
- **1** structural equality via `JSON.stringify(a) === JSON.stringify(b)`.
- **1** export-JSON file download (`<cf-file-download mimeType="application/json">`).
- **1** `home-ben.tsx:98 valueExcerpt` — D5 wins over Lens-1 here (lossy-body disqualifier) because the comment names LLM-context as the consumer; consumer-contract lens is more specific than body-shape lens.
- **1** in `packages/patterns/deprecated/charm-ref-in-cell.tsx` — deprecated subdir convention, not migrated.

## Lens recap (for new reviewers)

Same six-point review template as prior cadence PRs (idiom consistency; helper-variant fit; no guards/casts dropped; error-message readability; DEBUG-vs-WIRE classification with the three lens-refinements — lossy-body disqualifier, error-path catch ≠ lossy-body, mixed-idiom partial-migration smell; function-name-as-contract).

Two function-name-as-contract calls worth surfacing:

- **`formatExportJson` (record-backup.tsx)** — left WIRE despite the `format` prefix. Intentionally produces parseable JSON for file download.
- **`formatCellValue` (airtable-importer + extractor-module)** — *not* a contract claim (returns bare strings, joined arrays, etc.). Migrated.

**New lens applied: D5 LLM-prompt-embed.** Sites where serialized state is embedded in an LLM prompt (` ```json ` fences, `prompt += `, system-prompt construction, or reference-implementation source-code in template literals) are left on raw `JSON.stringify` — the LLM is the parser, and debug-stringifier sentinels would change what the LLM sees. **D5 > Lens-1 principle:** when LLM-embed and lossy-body both apply, D5 wins (consumer-contract lens is more specific than body-shape lens).

## Validation

- `deno fmt --check`, `deno lint`, `deno task check` (full): clean.
- `deno task test` on `runner` (422/0) and `js-compiler` (3/0).
- `packages/patterns` has no test task; integration tests are gated on network/LLM and not run.
