### PR TITLE
Harden cf-harness subagent return channel

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -40,6 +40,9 @@ What works today:
 - single-child subagent delegation with fresh child prompt context, explicit
   default/browser child profiles, retained child run references, and a sanitized
   summary/state return channel
+- optional schema-validated subagent structured returns, with raw child return
+  artifacts retained in the child run and open-ended strings linkified before
+  the parent sees them
 - persisted run state, transcript, Loom run manifests, capability snapshots, and
   tool outputs
 - transcript-based resumability
@@ -61,7 +64,8 @@ What works today:
 What is not done yet:
 
 - real runner-driven CFC feedback integration
-- richer opaque-handle/pass-through behavior
+- richer opaque-handle/pass-through behavior outside schema-validated subagent
+  returns
 - first-class browser operation policy on top of the provisional browser
   subagent profile
 - parallel child orchestration
@@ -156,6 +160,28 @@ deno task run -- \
   --allow-tool delegate_task \
   --allow-subagent-profile browser \
   --prompt "Delegate browser inspection of the local app and summarize the result."
+```
+
+Programmatic `delegate_task` calls may include `returnSchema`, a JSON Schema
+object or boolean. In that mode the child is required to return a single JSON
+value. The harness validates it, stores the raw child return under the child
+artifact root, and exposes `subagent.structuredReturn.value` to the parent with
+free-form strings replaced by pass-through link objects:
+
+```json
+{
+  "goal": "Assess the briefing and return only the decision facts.",
+  "returnSchema": {
+    "type": "object",
+    "properties": {
+      "approved": { "type": "boolean" },
+      "status": { "type": "string", "enum": ["approved", "not_approved"] },
+      "summary": { "type": "string" }
+    },
+    "required": ["approved", "status", "summary"],
+    "additionalProperties": false
+  }
+}
 ```
 
 Current caveat:

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -166,7 +166,8 @@ Programmatic `delegate_task` calls may include `returnSchema`, a JSON Schema
 object or boolean. In that mode the child is required to return a single JSON
 value. The harness validates it, stores the raw child return under the child
 artifact root, and exposes `subagent.structuredReturn.value` to the parent with
-free-form strings replaced by pass-through link objects:
+free-form strings and objects with unmodeled keys replaced by opaque `@link`
+objects such as `opaque:<child-run-id>#/json/pointer`:
 
 ```json
 {

--- a/packages/cf-harness/deno.json
+++ b/packages/cf-harness/deno.json
@@ -11,6 +11,7 @@
     "./config": "./src/config.ts",
     "./engine": "./src/engine.ts",
     "./prompt-loop": "./src/prompt-loop.ts",
+    "./subagent-return": "./src/subagent-return.ts",
     "./artifacts": "./src/artifacts.ts",
     "./cli": "./src/cli.ts",
     "./gateway/openai-client": "./src/gateway/openai-client.ts",

--- a/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
@@ -350,7 +350,10 @@ The package now has a first minimal subagent path: a parent can delegate one
 focused child run through `delegate_task`, and the child receives a fresh prompt
 context plus the selected profile's tool set. The default profile remains
 sandbox shell/file only; the provisional browser profile adds host shell access
-for `agent-browser`-style commands.
+for `agent-browser`-style commands. `delegate_task` can also take an optional
+`returnSchema`; when supplied, the harness validates the child JSON return,
+keeps the raw return in child artifacts, and exposes only a sanitized structured
+value with free-form strings linkified.
 
 The remaining subagent work is still substantial:
 

--- a/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
@@ -353,7 +353,8 @@ sandbox shell/file only; the provisional browser profile adds host shell access
 for `agent-browser`-style commands. `delegate_task` can also take an optional
 `returnSchema`; when supplied, the harness validates the child JSON return,
 keeps the raw return in child artifacts, and exposes only a sanitized structured
-value with free-form strings linkified.
+value with free-form strings and objects with unmodeled keys linkified through
+opaque `@link` handles.
 
 The remaining subagent work is still substantial:
 

--- a/packages/cf-harness/src/contracts/policy.ts
+++ b/packages/cf-harness/src/contracts/policy.ts
@@ -40,6 +40,8 @@ export interface HarnessDelegateTaskToolInputSummary {
   goalDigest?: string;
   contextBytes?: number;
   contextDigest?: string;
+  returnSchemaBytes?: number;
+  returnSchemaDigest?: string;
   maxModelTurns?: number;
 }
 

--- a/packages/cf-harness/src/contracts/subagent.ts
+++ b/packages/cf-harness/src/contracts/subagent.ts
@@ -1,4 +1,5 @@
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import type { JSONSchema } from "@commonfabric/api";
 import type { HarnessFailureRecord } from "../diagnostics.ts";
 import type { BuiltinToolId } from "./tool-descriptor.ts";
 
@@ -102,6 +103,8 @@ export interface HarnessSubagentInputSummary {
   goalDigest: string;
   contextBytes?: number;
   contextDigest?: string;
+  returnSchemaBytes?: number;
+  returnSchemaDigest?: string;
 }
 
 export interface HarnessSubagentRunManifest {
@@ -155,6 +158,17 @@ export interface HarnessSubagentRunStateSummary {
   primaryFailure?: HarnessSubagentFailureSummary;
 }
 
+export interface HarnessSubagentStructuredReturn {
+  type: "cf-harness.subagent-structured-return";
+  status: "valid" | "invalid";
+  schemaDigest: string;
+  rawOutputId: string;
+  rawArtifactPath?: string;
+  value?: unknown;
+  linkedStringCount?: number;
+  validationError?: string;
+}
+
 export interface HarnessSubagentResult {
   type: "cf-harness.subagent-result";
   childRunId: string;
@@ -164,6 +178,7 @@ export interface HarnessSubagentResult {
   modelTurns: number;
   runState: HarnessSubagentRunStateSummary;
   manifest: HarnessSubagentRunManifest;
+  structuredReturn?: HarnessSubagentStructuredReturn;
 }
 
 export interface HarnessSubagentRunRef {
@@ -175,6 +190,7 @@ export interface HarnessSubagentRunRef {
   summary: string;
   manifest: HarnessSubagentRunManifest;
   runState: HarnessSubagentRunStateSummary;
+  structuredReturn?: HarnessSubagentStructuredReturn;
 }
 
 export interface DelegateTaskToolInput {
@@ -182,6 +198,7 @@ export interface DelegateTaskToolInput {
   profile: HarnessSubagentProfile;
   context?: string;
   maxModelTurns?: number;
+  returnSchema?: JSONSchema;
 }
 
 export interface DelegateTaskToolOutput {

--- a/packages/cf-harness/src/index.ts
+++ b/packages/cf-harness/src/index.ts
@@ -2,6 +2,7 @@ export * from "./config.ts";
 export * from "./run-state.ts";
 export * from "./engine.ts";
 export * from "./prompt-loop.ts";
+export * from "./subagent-return.ts";
 export * from "./artifacts.ts";
 export * from "./cli.ts";
 export * from "./gateway/openai-client.ts";

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -36,7 +36,7 @@ import type {
   HarnessTranscriptEvent,
   HarnessTranscriptMessage,
 } from "./contracts/transcript.ts";
-import type { ToolResultRef } from "./contracts/tool-result.ts";
+import type { ToolOutputId, ToolResultRef } from "./contracts/tool-result.ts";
 import type {
   BuiltinToolId,
   HarnessToolDescriptor,
@@ -66,9 +66,15 @@ import {
   type HarnessSubagentResult,
   type HarnessSubagentRunManifest,
   type HarnessSubagentRunStateSummary,
+  type HarnessSubagentStructuredReturn,
   isHarnessSubagentProfile,
   MAX_SUBAGENT_MAX_MODEL_TURNS,
 } from "./contracts/subagent.ts";
+import {
+  parseSubagentReturnJson,
+  parseSubagentReturnSchema,
+  validateAndSanitizeSubagentReturn,
+} from "./subagent-return.ts";
 import { BUILTIN_TOOLS, getBuiltinTool } from "./tools/registry.ts";
 import {
   cwdMarkerForOutput,
@@ -432,6 +438,9 @@ const summarizeToolInput = async (
       const contextSummary = typeof input.context === "string"
         ? await summarizeSensitiveText(input.context)
         : undefined;
+      const returnSchemaSummary = input.returnSchema !== undefined
+        ? await summarizeSensitiveText(JSON.stringify(input.returnSchema))
+        : undefined;
       const profile = input.profile === undefined
         ? DEFAULT_SUBAGENT_PROFILE
         : typeof input.profile === "string" &&
@@ -452,6 +461,12 @@ const summarizeToolInput = async (
           ? {
             contextBytes: contextSummary.bytes,
             contextDigest: contextSummary.digest,
+          }
+          : {}),
+        ...(returnSchemaSummary !== undefined
+          ? {
+            returnSchemaBytes: returnSchemaSummary.bytes,
+            returnSchemaDigest: returnSchemaSummary.digest,
           }
           : {}),
         ...(isSafeNonNegativeInteger(input.maxModelTurns)
@@ -500,6 +515,7 @@ const parseDelegateTaskInput = (
       `delegate_task maxModelTurns must be an integer from 1 to ${MAX_SUBAGENT_MAX_MODEL_TURNS}`,
     );
   }
+  const parsedReturnSchema = parseSubagentReturnSchema(input.returnSchema);
   return {
     goal: input.goal,
     profile,
@@ -507,6 +523,9 @@ const parseDelegateTaskInput = (
       ? { context: input.context }
       : {}),
     ...(typeof maxModelTurns === "number" ? { maxModelTurns } : {}),
+    ...(parsedReturnSchema !== undefined
+      ? { returnSchema: parsedReturnSchema.schema }
+      : {}),
   };
 };
 
@@ -517,6 +536,9 @@ const createSubagentInputSummary = async (
   const contextSummary = input.context === undefined
     ? undefined
     : await summarizeSensitiveText(input.context);
+  const returnSchemaSummary = input.returnSchema === undefined
+    ? undefined
+    : await summarizeSensitiveText(JSON.stringify(input.returnSchema));
   return {
     type: "cf-harness.subagent-input-summary",
     goalBytes: goalSummary.bytes,
@@ -525,6 +547,12 @@ const createSubagentInputSummary = async (
       ? {
         contextBytes: contextSummary.bytes,
         contextDigest: contextSummary.digest,
+      }
+      : {}),
+    ...(returnSchemaSummary !== undefined
+      ? {
+        returnSchemaBytes: returnSchemaSummary.bytes,
+        returnSchemaDigest: returnSchemaSummary.digest,
       }
       : {}),
   };
@@ -569,6 +597,16 @@ const buildSubagentUserPrompt = (input: DelegateTaskToolInput): string =>
     "Task:",
     input.goal,
     ...(input.context !== undefined ? ["", "Context:", input.context] : []),
+    ...(input.returnSchema !== undefined
+      ? [
+        "",
+        "Return schema:",
+        JSON.stringify(input.returnSchema, null, 2),
+        "",
+        "Final response requirement:",
+        "Return a single JSON value matching the return schema. Do not include markdown, prose, explanation, or any text outside the JSON value.",
+      ]
+      : []),
   ].join("\n");
 
 const summarizeSubagentRunState = (
@@ -607,6 +645,118 @@ const summarizeSubagentRunState = (
       ? { primaryFailure: summarizeSubagentFailure(runState.primaryFailure) }
       : {}),
   };
+};
+
+const createStructuredSubagentReturn = async (
+  options: {
+    childEngine: CfHarnessEngine;
+    childRunId: string;
+    rawFinalAssistantText: string;
+    schema: NonNullable<DelegateTaskToolInput["returnSchema"]>;
+  },
+): Promise<{
+  structuredReturn: HarnessSubagentStructuredReturn;
+  summary: string;
+  valid: boolean;
+}> => {
+  const schemaDigest = await digestJsonValue(options.schema);
+  const rawOutputId = `${options.childRunId}:subagent_return:1` as ToolOutputId;
+  let rawArtifactPath: string | undefined;
+  const persistRawReturn = async (
+    record: Record<string, unknown>,
+  ): Promise<void> => {
+    rawArtifactPath = await options.childEngine.artifactStore
+      ?.persistToolOutput(
+        "subagent-return",
+        rawOutputId,
+        record,
+      );
+  };
+
+  let parsedValue: unknown;
+  try {
+    parsedValue = parseSubagentReturnJson(options.rawFinalAssistantText);
+  } catch (error) {
+    const validationError = error instanceof Error
+      ? error.message
+      : "child final response was not valid JSON";
+    await persistRawReturn({
+      type: "cf-harness.subagent-raw-return",
+      childRunId: options.childRunId,
+      schemaDigest,
+      rawFinalAssistantText: options.rawFinalAssistantText,
+      validationStatus: "invalid",
+      validationError,
+    });
+    return {
+      valid: false,
+      summary: `Subagent return validation failed: ${validationError}`,
+      structuredReturn: {
+        type: "cf-harness.subagent-structured-return",
+        status: "invalid",
+        schemaDigest,
+        rawOutputId,
+        ...(rawArtifactPath !== undefined ? { rawArtifactPath } : {}),
+        validationError,
+      },
+    };
+  }
+
+  try {
+    const sanitized = validateAndSanitizeSubagentReturn({
+      schema: options.schema,
+      value: parsedValue,
+      childRunId: options.childRunId,
+    });
+    await persistRawReturn({
+      type: "cf-harness.subagent-raw-return",
+      childRunId: options.childRunId,
+      schemaDigest,
+      rawFinalAssistantText: options.rawFinalAssistantText,
+      value: parsedValue,
+      validationStatus: "valid",
+    });
+    return {
+      valid: true,
+      summary:
+        "Subagent returned structured data matching the requested schema.",
+      structuredReturn: {
+        type: "cf-harness.subagent-structured-return",
+        status: "valid",
+        schemaDigest,
+        rawOutputId,
+        ...(rawArtifactPath !== undefined ? { rawArtifactPath } : {}),
+        value: sanitized.value,
+        linkedStringCount: sanitized.linkedStringCount,
+      },
+    };
+  } catch (error) {
+    const rawValidationError = error instanceof Error
+      ? error.message
+      : "structured return did not match the schema";
+    const validationError = "structured return did not match the schema";
+    await persistRawReturn({
+      type: "cf-harness.subagent-raw-return",
+      childRunId: options.childRunId,
+      schemaDigest,
+      rawFinalAssistantText: options.rawFinalAssistantText,
+      value: parsedValue,
+      validationStatus: "invalid",
+      validationError: rawValidationError,
+    });
+    return {
+      valid: false,
+      summary: `Subagent return validation failed: ${validationError}`,
+      structuredReturn: {
+        type: "cf-harness.subagent-structured-return",
+        status: "invalid",
+        schemaDigest,
+        rawOutputId,
+        ...(rawArtifactPath !== undefined ? { rawArtifactPath } : {}),
+        validationError,
+      },
+    };
+  }
 };
 
 const createAssistantTranscriptMessage = (
@@ -1688,6 +1838,7 @@ export class CfHarnessPromptLoop {
     let subagentStatus: HarnessSubagentResult["status"] = "completed";
     let summary = "";
     let childModelTurns = 0;
+    let structuredReturn: HarnessSubagentStructuredReturn | undefined;
     try {
       const childResult = await childLoop.runPrompt({
         systemPrompt: buildSubagentSystemPrompt(
@@ -1704,6 +1855,22 @@ export class CfHarnessPromptLoop {
       if (childResult.runState.status !== "completed") {
         subagentStatus = "failed";
       }
+      if (
+        delegateInput.returnSchema !== undefined &&
+        subagentStatus === "completed"
+      ) {
+        const structured = await createStructuredSubagentReturn({
+          childEngine,
+          childRunId,
+          rawFinalAssistantText: childResult.finalAssistantText,
+          schema: delegateInput.returnSchema,
+        });
+        summary = structured.summary;
+        structuredReturn = structured.structuredReturn;
+        if (!structured.valid) {
+          subagentStatus = "failed";
+        }
+      }
     } catch (error) {
       subagentStatus = "failed";
       childModelTurns = promptLoopModelTurnsFromError(error) ?? childModelTurns;
@@ -1719,6 +1886,7 @@ export class CfHarnessPromptLoop {
       modelTurns: childModelTurns,
       runState: summarizeSubagentRunState(childRunState),
       manifest,
+      ...(structuredReturn !== undefined ? { structuredReturn } : {}),
     };
     const output: DelegateTaskToolOutput = {
       type: "cf-harness.delegate-task-output",
@@ -1739,6 +1907,7 @@ export class CfHarnessPromptLoop {
       summary: subagent.summary,
       manifest,
       runState: subagent.runState,
+      ...(structuredReturn !== undefined ? { structuredReturn } : {}),
     });
     return {
       output: result.output,

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -561,6 +561,7 @@ const createSubagentInputSummary = async (
 const buildSubagentSystemPrompt = (
   currentDir: string,
   profileConfig: HarnessSubagentProfileConfig,
+  options: { structuredReturn: boolean } = { structuredReturn: false },
 ): string =>
   [
     "You are a focused cf-harness subagent working on one delegated task.",
@@ -585,11 +586,18 @@ const buildSubagentSystemPrompt = (
       : []),
     `Current sandbox directory: ${currentDir}`,
     "",
-    "When finished, return a concise summary with:",
-    "- what you did or investigated",
-    "- what you found or changed",
-    "- files modified, if any",
-    "- issues or blockers, if any",
+    ...(options.structuredReturn
+      ? [
+        "When finished, return only the JSON value requested by the task's return schema.",
+        "Do not include markdown, prose, explanations, summaries, or text outside that JSON value.",
+      ]
+      : [
+        "When finished, return a concise summary with:",
+        "- what you did or investigated",
+        "- what you found or changed",
+        "- files modified, if any",
+        "- issues or blockers, if any",
+      ]),
   ].join("\n");
 
 const buildSubagentUserPrompt = (input: DelegateTaskToolInput): string =>
@@ -1844,6 +1852,7 @@ export class CfHarnessPromptLoop {
         systemPrompt: buildSubagentSystemPrompt(
           childEngine.getRunState().currentDir,
           profileConfig,
+          { structuredReturn: delegateInput.returnSchema !== undefined },
         ),
         prompt: buildSubagentUserPrompt(delegateInput),
         model: options.model,

--- a/packages/cf-harness/src/subagent-return.ts
+++ b/packages/cf-harness/src/subagent-return.ts
@@ -143,6 +143,33 @@ const matchingBranch = (
     : resolveSchemaForValidation(branch, fullSchema);
 };
 
+const isEmptySchemaObject = (schema: JSONSchema): boolean =>
+  isRecord(schema) && Object.keys(schema).length === 0;
+
+const combineAllOf = (schemas: readonly JSONSchema[]): JSONSchema => {
+  const constrained = schemas.filter((schema) =>
+    schema !== true && !isEmptySchemaObject(schema)
+  );
+  if (constrained.some((schema) => schema === false)) {
+    return false;
+  }
+  if (constrained.length === 0) {
+    return true;
+  }
+  if (constrained.length === 1) {
+    return constrained[0]!;
+  }
+  return { allOf: constrained };
+};
+
+const schemaWithoutBranchKeyword = (
+  schema: Record<string, unknown>,
+  keyword: "anyOf" | "oneOf",
+): JSONSchema => {
+  const { [keyword]: _ignored, ...rest } = schema;
+  return rest as JSONSchema;
+};
+
 const schemaForValue = (
   schema: JSONSchema,
   value: unknown,
@@ -152,15 +179,19 @@ const schemaForValue = (
   if (!isRecord(resolved)) {
     return resolved;
   }
+  let base: JSONSchema = resolved;
+  const branches: JSONSchema[] = [];
   const oneOf = matchingBranch(resolved.oneOf, value, fullSchema);
   if (oneOf !== undefined) {
-    return oneOf;
+    base = schemaWithoutBranchKeyword(base as Record<string, unknown>, "oneOf");
+    branches.push(oneOf);
   }
   const anyOf = matchingBranch(resolved.anyOf, value, fullSchema);
   if (anyOf !== undefined) {
-    return anyOf;
+    base = schemaWithoutBranchKeyword(base as Record<string, unknown>, "anyOf");
+    branches.push(anyOf);
   }
-  return resolved;
+  return branches.length === 0 ? resolved : combineAllOf([base, ...branches]);
 };
 
 const childSchemaForKey = (
@@ -179,6 +210,13 @@ const childSchemaForKey = (
       childSchemas.push(child);
     }
   }
+  if (
+    !(isRecord(resolved.properties) && key in resolved.properties) &&
+    (typeof resolved.additionalProperties === "boolean" ||
+      isRecord(resolved.additionalProperties))
+  ) {
+    childSchemas.push(resolved.additionalProperties);
+  }
   if (Array.isArray(resolved.allOf)) {
     for (const branch of resolved.allOf) {
       const child = childSchemaForKey(branch, key, fullSchema);
@@ -187,19 +225,7 @@ const childSchemaForKey = (
       }
     }
   }
-  if (childSchemas.length === 1) {
-    return childSchemas[0]!;
-  }
-  if (childSchemas.length > 1) {
-    return { allOf: childSchemas };
-  }
-  if (
-    typeof resolved.additionalProperties === "boolean" ||
-    isRecord(resolved.additionalProperties)
-  ) {
-    return resolved.additionalProperties;
-  }
-  return true;
+  return combineAllOf(childSchemas);
 };
 
 const knownPropertyNames = (
@@ -233,14 +259,25 @@ const knownPropertyNames = (
 
 const itemSchemaForIndex = (
   schema: JSONSchema,
+  fullSchema: JSONSchema,
 ): JSONSchema => {
+  const resolved = resolveSchemaForValidation(schema, fullSchema);
+  const itemSchemas: JSONSchema[] = [];
   if (
-    isRecord(schema) &&
-    (typeof schema.items === "boolean" || isRecord(schema.items))
+    isRecord(resolved) &&
+    (typeof resolved.items === "boolean" || isRecord(resolved.items))
   ) {
-    return schema.items;
+    itemSchemas.push(resolved.items);
   }
-  return true;
+  if (isRecord(resolved) && Array.isArray(resolved.allOf)) {
+    for (const branch of resolved.allOf) {
+      const item = itemSchemaForIndex(branch, fullSchema);
+      if (item !== true) {
+        itemSchemas.push(item);
+      }
+    }
+  }
+  return combineAllOf(itemSchemas);
 };
 
 const sanitizeValue = (
@@ -262,7 +299,7 @@ const sanitizeValue = (
     const items = value.map((item, index) => {
       const sanitized = sanitizeValue(
         item,
-        itemSchemaForIndex(effectiveSchema),
+        itemSchemaForIndex(effectiveSchema, fullSchema),
         fullSchema,
         childRunId,
         [...path, index],

--- a/packages/cf-harness/src/subagent-return.ts
+++ b/packages/cf-harness/src/subagent-return.ts
@@ -1,0 +1,263 @@
+import type { JSONSchema } from "@commonfabric/api";
+import { validateAgainstSchema } from "@commonfabric/runner/cfc";
+
+export const MAX_SUBAGENT_RETURN_SCHEMA_BYTES = 32 * 1024;
+
+export interface ParsedSubagentReturnSchema {
+  schema: JSONSchema;
+  bytes: number;
+}
+
+export interface SanitizedSubagentReturn {
+  value: unknown;
+  linkedStringCount: number;
+}
+
+const textBytes = (input: string): Uint8Array =>
+  new TextEncoder().encode(input);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const jsonPointer = (path: readonly (string | number)[]): string =>
+  path.length === 0
+    ? ""
+    : `/${
+      path.map((segment) =>
+        String(segment).replaceAll("~", "~0").replaceAll("/", "~1")
+      ).join("/")
+    }`;
+
+const returnLink = (
+  childRunId: string,
+  path: readonly (string | number)[],
+): { "@link": string } => ({
+  "@link": `cf-harness://subagent-return/${encodeURIComponent(childRunId)}#${
+    jsonPointer(path)
+  }`,
+});
+
+const primitiveJsonValue = (value: unknown): boolean =>
+  value === null ||
+  typeof value === "string" ||
+  typeof value === "number" ||
+  typeof value === "boolean";
+
+const schemaAllowsRawString = (
+  schema: JSONSchema,
+  value: string,
+): boolean => {
+  if (!isRecord(schema)) {
+    return false;
+  }
+  if (Array.isArray(schema.enum)) {
+    return schema.enum.some((entry) => entry === value);
+  }
+  return "const" in schema && schema.const === value &&
+    primitiveJsonValue(schema.const);
+};
+
+const schemaDeclaresOpaqueLinkObject = (schema: JSONSchema): boolean =>
+  isRecord(schema) &&
+  isRecord(schema.properties) &&
+  isRecord(schema.properties["@link"]) &&
+  schema.properties["@link"].type === "string" &&
+  Array.isArray(schema.required) &&
+  schema.required.includes("@link") &&
+  schema.additionalProperties === false;
+
+const valueIsOpaqueLinkObject = (
+  value: unknown,
+): value is { "@link": string } =>
+  isRecord(value) &&
+  typeof value["@link"] === "string" &&
+  Object.keys(value).length === 1;
+
+const matchingBranch = (
+  branches: unknown,
+  value: unknown,
+  fullSchema: JSONSchema,
+): JSONSchema | undefined => {
+  if (!Array.isArray(branches)) {
+    return undefined;
+  }
+  return branches.find((branch): branch is JSONSchema =>
+    (typeof branch === "boolean" || isRecord(branch)) &&
+    validateAgainstSchema(branch, value, fullSchema) === undefined
+  );
+};
+
+const schemaForValue = (
+  schema: JSONSchema,
+  value: unknown,
+  fullSchema: JSONSchema,
+): JSONSchema => {
+  if (!isRecord(schema)) {
+    return schema;
+  }
+  const oneOf = matchingBranch(schema.oneOf, value, fullSchema);
+  if (oneOf !== undefined) {
+    return oneOf;
+  }
+  const anyOf = matchingBranch(schema.anyOf, value, fullSchema);
+  if (anyOf !== undefined) {
+    return anyOf;
+  }
+  return schema;
+};
+
+const childSchemaForKey = (
+  schema: JSONSchema,
+  key: string,
+): JSONSchema => {
+  if (!isRecord(schema)) {
+    return true;
+  }
+  if (isRecord(schema.properties)) {
+    const child = schema.properties[key];
+    if (typeof child === "boolean" || isRecord(child)) {
+      return child;
+    }
+  }
+  if (
+    typeof schema.additionalProperties === "boolean" ||
+    isRecord(schema.additionalProperties)
+  ) {
+    return schema.additionalProperties;
+  }
+  return true;
+};
+
+const itemSchemaForIndex = (
+  schema: JSONSchema,
+): JSONSchema => {
+  if (
+    isRecord(schema) &&
+    (typeof schema.items === "boolean" || isRecord(schema.items))
+  ) {
+    return schema.items;
+  }
+  return true;
+};
+
+const sanitizeValue = (
+  value: unknown,
+  schema: JSONSchema,
+  fullSchema: JSONSchema,
+  childRunId: string,
+  path: readonly (string | number)[],
+): SanitizedSubagentReturn => {
+  const effectiveSchema = schemaForValue(schema, value, fullSchema);
+  if (typeof value === "string") {
+    if (schemaAllowsRawString(effectiveSchema, value)) {
+      return { value, linkedStringCount: 0 };
+    }
+    return { value: returnLink(childRunId, path), linkedStringCount: 1 };
+  }
+  if (Array.isArray(value)) {
+    let linkedStringCount = 0;
+    const items = value.map((item, index) => {
+      const sanitized = sanitizeValue(
+        item,
+        itemSchemaForIndex(effectiveSchema),
+        fullSchema,
+        childRunId,
+        [...path, index],
+      );
+      linkedStringCount += sanitized.linkedStringCount;
+      return sanitized.value;
+    });
+    return { value: items, linkedStringCount };
+  }
+  if (isRecord(value)) {
+    if (
+      valueIsOpaqueLinkObject(value) &&
+      schemaDeclaresOpaqueLinkObject(effectiveSchema)
+    ) {
+      return { value, linkedStringCount: 0 };
+    }
+    let linkedStringCount = 0;
+    const entries = Object.entries(value).map(([key, child]) => {
+      const sanitized = sanitizeValue(
+        child,
+        childSchemaForKey(effectiveSchema, key),
+        fullSchema,
+        childRunId,
+        [...path, key],
+      );
+      linkedStringCount += sanitized.linkedStringCount;
+      return [key, sanitized.value] as const;
+    });
+    return { value: Object.fromEntries(entries), linkedStringCount };
+  }
+  return { value, linkedStringCount: 0 };
+};
+
+export const parseSubagentReturnSchema = (
+  input: unknown,
+): ParsedSubagentReturnSchema | undefined => {
+  if (input === undefined) {
+    return undefined;
+  }
+  let parsed = input;
+  if (typeof input === "string") {
+    try {
+      parsed = JSON.parse(input);
+    } catch {
+      throw new Error(
+        "delegate_task returnSchema string must be valid JSON",
+      );
+    }
+  }
+  if (
+    typeof parsed !== "boolean" &&
+    (!isRecord(parsed) || Array.isArray(parsed))
+  ) {
+    throw new Error(
+      "delegate_task returnSchema must be a JSON Schema object, boolean, or JSON string",
+    );
+  }
+  const encoded = JSON.stringify(parsed);
+  const bytes = textBytes(encoded).byteLength;
+  if (bytes > MAX_SUBAGENT_RETURN_SCHEMA_BYTES) {
+    throw new Error(
+      `delegate_task returnSchema must be at most ${MAX_SUBAGENT_RETURN_SCHEMA_BYTES} bytes`,
+    );
+  }
+  return {
+    schema: parsed as JSONSchema,
+    bytes,
+  };
+};
+
+export const parseSubagentReturnJson = (text: string): unknown => {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    throw new Error("child final response was empty");
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    throw new Error("child final response was not valid JSON");
+  }
+};
+
+export const validateAndSanitizeSubagentReturn = (
+  options: {
+    schema: JSONSchema;
+    value: unknown;
+    childRunId: string;
+  },
+): SanitizedSubagentReturn => {
+  const failure = validateAgainstSchema(options.schema, options.value);
+  if (failure !== undefined) {
+    throw new Error(failure);
+  }
+  return sanitizeValue(
+    options.value,
+    options.schema,
+    options.schema,
+    options.childRunId,
+    [],
+  );
+};

--- a/packages/cf-harness/src/subagent-return.ts
+++ b/packages/cf-harness/src/subagent-return.ts
@@ -82,6 +82,10 @@ const schemaAllowsRawString = (
   return false;
 };
 
+const objectSchemaIsClosed = (schema: Record<string, unknown>): boolean =>
+  schema.additionalProperties !== true &&
+  typeof schema.additionalProperties !== "object";
+
 const schemaDeclaresOpaqueLinkObject = (
   schema: JSONSchema,
   fullSchema: JSONSchema,
@@ -96,7 +100,7 @@ const schemaDeclaresOpaqueLinkObject = (
     resolved.properties["@link"].type === "string" &&
     Array.isArray(resolved.required) &&
     resolved.required.includes("@link") &&
-    resolved.additionalProperties === false
+    objectSchemaIsClosed(resolved)
   ) {
     return true;
   }

--- a/packages/cf-harness/src/subagent-return.ts
+++ b/packages/cf-harness/src/subagent-return.ts
@@ -1,5 +1,8 @@
 import type { JSONSchema } from "@commonfabric/api";
-import { validateAgainstSchema } from "@commonfabric/runner/cfc";
+import {
+  resolveSchemaForValidation,
+  validateAgainstSchema,
+} from "@commonfabric/runner/cfc";
 
 export const MAX_SUBAGENT_RETURN_SCHEMA_BYTES = 32 * 1024;
 
@@ -32,8 +35,8 @@ const returnLink = (
   childRunId: string,
   path: readonly (string | number)[],
 ): { "@link": string } => ({
-  "@link": `cf-harness://subagent-return/${encodeURIComponent(childRunId)}#${
-    jsonPointer(path)
+  "@link": `opaque:${encodeURIComponent(childRunId)}${
+    path.length === 0 ? "" : `#${jsonPointer(path)}`
   }`,
 });
 
@@ -46,25 +49,75 @@ const primitiveJsonValue = (value: unknown): boolean =>
 const schemaAllowsRawString = (
   schema: JSONSchema,
   value: string,
+  fullSchema: JSONSchema,
 ): boolean => {
-  if (!isRecord(schema)) {
+  const resolved = resolveSchemaForValidation(schema, fullSchema);
+  if (!isRecord(resolved)) {
     return false;
   }
-  if (Array.isArray(schema.enum)) {
-    return schema.enum.some((entry) => entry === value);
+  if (Array.isArray(resolved.enum)) {
+    return resolved.enum.some((entry) => entry === value);
   }
-  return "const" in schema && schema.const === value &&
-    primitiveJsonValue(schema.const);
+  if (
+    "const" in resolved && resolved.const === value &&
+    primitiveJsonValue(resolved.const)
+  ) {
+    return true;
+  }
+  if (Array.isArray(resolved.allOf)) {
+    return resolved.allOf.some((branch) =>
+      schemaAllowsRawString(branch, value, fullSchema)
+    );
+  }
+  const oneOf = matchingBranch(resolved.oneOf, value, fullSchema);
+  if (oneOf !== undefined) {
+    return schemaAllowsRawString(oneOf, value, fullSchema);
+  }
+  if (Array.isArray(resolved.anyOf)) {
+    return resolved.anyOf.some((branch) =>
+      validateAgainstSchema(branch, value, fullSchema) === undefined &&
+      schemaAllowsRawString(branch, value, fullSchema)
+    );
+  }
+  return false;
 };
 
-const schemaDeclaresOpaqueLinkObject = (schema: JSONSchema): boolean =>
-  isRecord(schema) &&
-  isRecord(schema.properties) &&
-  isRecord(schema.properties["@link"]) &&
-  schema.properties["@link"].type === "string" &&
-  Array.isArray(schema.required) &&
-  schema.required.includes("@link") &&
-  schema.additionalProperties === false;
+const schemaDeclaresOpaqueLinkObject = (
+  schema: JSONSchema,
+  fullSchema: JSONSchema,
+): boolean => {
+  const resolved = resolveSchemaForValidation(schema, fullSchema);
+  if (!isRecord(resolved)) {
+    return false;
+  }
+  if (
+    isRecord(resolved.properties) &&
+    isRecord(resolved.properties["@link"]) &&
+    resolved.properties["@link"].type === "string" &&
+    Array.isArray(resolved.required) &&
+    resolved.required.includes("@link") &&
+    resolved.additionalProperties === false
+  ) {
+    return true;
+  }
+  if (Array.isArray(resolved.allOf)) {
+    return resolved.allOf.some((branch) =>
+      schemaDeclaresOpaqueLinkObject(branch, fullSchema)
+    );
+  }
+  const oneOf = matchingBranch(
+    resolved.oneOf,
+    { "@link": "opaque:subagent-return" },
+    fullSchema,
+  );
+  if (oneOf !== undefined) {
+    return schemaDeclaresOpaqueLinkObject(oneOf, fullSchema);
+  }
+  return Array.isArray(resolved.anyOf) &&
+    resolved.anyOf.some((branch) =>
+      schemaDeclaresOpaqueLinkObject(branch, fullSchema)
+    );
+};
 
 const valueIsOpaqueLinkObject = (
   value: unknown,
@@ -81,10 +134,13 @@ const matchingBranch = (
   if (!Array.isArray(branches)) {
     return undefined;
   }
-  return branches.find((branch): branch is JSONSchema =>
+  const branch = branches.find((branch): branch is JSONSchema =>
     (typeof branch === "boolean" || isRecord(branch)) &&
     validateAgainstSchema(branch, value, fullSchema) === undefined
   );
+  return branch === undefined
+    ? undefined
+    : resolveSchemaForValidation(branch, fullSchema);
 };
 
 const schemaForValue = (
@@ -92,40 +148,87 @@ const schemaForValue = (
   value: unknown,
   fullSchema: JSONSchema,
 ): JSONSchema => {
-  if (!isRecord(schema)) {
-    return schema;
+  const resolved = resolveSchemaForValidation(schema, fullSchema);
+  if (!isRecord(resolved)) {
+    return resolved;
   }
-  const oneOf = matchingBranch(schema.oneOf, value, fullSchema);
+  const oneOf = matchingBranch(resolved.oneOf, value, fullSchema);
   if (oneOf !== undefined) {
     return oneOf;
   }
-  const anyOf = matchingBranch(schema.anyOf, value, fullSchema);
+  const anyOf = matchingBranch(resolved.anyOf, value, fullSchema);
   if (anyOf !== undefined) {
     return anyOf;
   }
-  return schema;
+  return resolved;
 };
 
 const childSchemaForKey = (
   schema: JSONSchema,
   key: string,
+  fullSchema: JSONSchema,
 ): JSONSchema => {
-  if (!isRecord(schema)) {
+  const resolved = resolveSchemaForValidation(schema, fullSchema);
+  if (!isRecord(resolved)) {
     return true;
   }
-  if (isRecord(schema.properties)) {
-    const child = schema.properties[key];
+  const childSchemas: JSONSchema[] = [];
+  if (isRecord(resolved.properties)) {
+    const child = resolved.properties[key];
     if (typeof child === "boolean" || isRecord(child)) {
-      return child;
+      childSchemas.push(child);
     }
   }
+  if (Array.isArray(resolved.allOf)) {
+    for (const branch of resolved.allOf) {
+      const child = childSchemaForKey(branch, key, fullSchema);
+      if (child !== true) {
+        childSchemas.push(child);
+      }
+    }
+  }
+  if (childSchemas.length === 1) {
+    return childSchemas[0]!;
+  }
+  if (childSchemas.length > 1) {
+    return { allOf: childSchemas };
+  }
   if (
-    typeof schema.additionalProperties === "boolean" ||
-    isRecord(schema.additionalProperties)
+    typeof resolved.additionalProperties === "boolean" ||
+    isRecord(resolved.additionalProperties)
   ) {
-    return schema.additionalProperties;
+    return resolved.additionalProperties;
   }
   return true;
+};
+
+const knownPropertyNames = (
+  schema: JSONSchema,
+  fullSchema: JSONSchema,
+): Set<string> => {
+  const resolved = resolveSchemaForValidation(schema, fullSchema);
+  const known = new Set<string>();
+  if (!isRecord(resolved)) {
+    return known;
+  }
+  if (isRecord(resolved.properties)) {
+    for (const key of Object.keys(resolved.properties)) {
+      known.add(key);
+    }
+  }
+  for (
+    const branches of [resolved.allOf, resolved.anyOf, resolved.oneOf] as const
+  ) {
+    if (!Array.isArray(branches)) {
+      continue;
+    }
+    for (const branch of branches) {
+      for (const key of knownPropertyNames(branch, fullSchema)) {
+        known.add(key);
+      }
+    }
+  }
+  return known;
 };
 
 const itemSchemaForIndex = (
@@ -149,7 +252,7 @@ const sanitizeValue = (
 ): SanitizedSubagentReturn => {
   const effectiveSchema = schemaForValue(schema, value, fullSchema);
   if (typeof value === "string") {
-    if (schemaAllowsRawString(effectiveSchema, value)) {
+    if (schemaAllowsRawString(effectiveSchema, value, fullSchema)) {
       return { value, linkedStringCount: 0 };
     }
     return { value: returnLink(childRunId, path), linkedStringCount: 1 };
@@ -172,15 +275,19 @@ const sanitizeValue = (
   if (isRecord(value)) {
     if (
       valueIsOpaqueLinkObject(value) &&
-      schemaDeclaresOpaqueLinkObject(effectiveSchema)
+      schemaDeclaresOpaqueLinkObject(effectiveSchema, fullSchema)
     ) {
       return { value, linkedStringCount: 0 };
+    }
+    const knownKeys = knownPropertyNames(effectiveSchema, fullSchema);
+    if (Object.keys(value).some((key) => !knownKeys.has(key))) {
+      return { value: returnLink(childRunId, path), linkedStringCount: 0 };
     }
     let linkedStringCount = 0;
     const entries = Object.entries(value).map(([key, child]) => {
       const sanitized = sanitizeValue(
         child,
-        childSchemaForKey(effectiveSchema, key),
+        childSchemaForKey(effectiveSchema, key, fullSchema),
         fullSchema,
         childRunId,
         [...path, key],

--- a/packages/cf-harness/src/subagent-return.ts
+++ b/packages/cf-harness/src/subagent-return.ts
@@ -86,41 +86,61 @@ const objectSchemaIsClosed = (schema: Record<string, unknown>): boolean =>
   schema.additionalProperties !== true &&
   typeof schema.additionalProperties !== "object";
 
-const schemaDeclaresOpaqueLinkObject = (
+const schemaDirectlyDeclaresOpaqueLinkObject = (
+  schema: Record<string, unknown>,
+): boolean =>
+  isRecord(schema.properties) &&
+  isRecord(schema.properties["@link"]) &&
+  schema.properties["@link"].type === "string" &&
+  Array.isArray(schema.required) &&
+  schema.required.includes("@link") &&
+  objectSchemaIsClosed(schema);
+
+const matchingBranches = (
+  branches: unknown,
+  value: unknown,
+  fullSchema: JSONSchema,
+): JSONSchema[] => {
+  if (!Array.isArray(branches)) {
+    return [];
+  }
+  return branches
+    .filter((branch): branch is JSONSchema =>
+      (typeof branch === "boolean" || isRecord(branch)) &&
+      validateAgainstSchema(branch, value, fullSchema) === undefined
+    )
+    .map((branch) => resolveSchemaForValidation(branch, fullSchema));
+};
+
+const schemaAcceptsOpaqueLinkObject = (
   schema: JSONSchema,
+  value: { "@link": string },
   fullSchema: JSONSchema,
 ): boolean => {
   const resolved = resolveSchemaForValidation(schema, fullSchema);
   if (!isRecord(resolved)) {
     return false;
   }
-  if (
-    isRecord(resolved.properties) &&
-    isRecord(resolved.properties["@link"]) &&
-    resolved.properties["@link"].type === "string" &&
-    Array.isArray(resolved.required) &&
-    resolved.required.includes("@link") &&
-    objectSchemaIsClosed(resolved)
-  ) {
+  if (validateAgainstSchema(resolved, value, fullSchema) !== undefined) {
+    return false;
+  }
+  if (schemaDirectlyDeclaresOpaqueLinkObject(resolved)) {
     return true;
   }
   if (Array.isArray(resolved.allOf)) {
     return resolved.allOf.some((branch) =>
-      schemaDeclaresOpaqueLinkObject(branch, fullSchema)
+      schemaAcceptsOpaqueLinkObject(branch, value, fullSchema)
     );
   }
-  const oneOf = matchingBranch(
-    resolved.oneOf,
-    { "@link": "opaque:subagent-return" },
-    fullSchema,
+  const oneOfBranches = matchingBranches(resolved.oneOf, value, fullSchema);
+  if (oneOfBranches.length > 0) {
+    return oneOfBranches.some((branch) =>
+      schemaAcceptsOpaqueLinkObject(branch, value, fullSchema)
+    );
+  }
+  return matchingBranches(resolved.anyOf, value, fullSchema).some((branch) =>
+    schemaAcceptsOpaqueLinkObject(branch, value, fullSchema)
   );
-  if (oneOf !== undefined) {
-    return schemaDeclaresOpaqueLinkObject(oneOf, fullSchema);
-  }
-  return Array.isArray(resolved.anyOf) &&
-    resolved.anyOf.some((branch) =>
-      schemaDeclaresOpaqueLinkObject(branch, fullSchema)
-    );
 };
 
 const valueIsOpaqueLinkObject = (
@@ -316,7 +336,7 @@ const sanitizeValue = (
   if (isRecord(value)) {
     if (
       valueIsOpaqueLinkObject(value) &&
-      schemaDeclaresOpaqueLinkObject(effectiveSchema, fullSchema)
+      schemaAcceptsOpaqueLinkObject(schema, value, fullSchema)
     ) {
       return { value, linkedStringCount: 0 };
     }

--- a/packages/cf-harness/src/tools/delegate-task.ts
+++ b/packages/cf-harness/src/tools/delegate-task.ts
@@ -47,6 +47,14 @@ export const delegateTaskTool: HarnessToolDefinition<
           description:
             "Optional child model-turn cap. Defaults to the harness subagent cap.",
         },
+        returnSchema: {
+          anyOf: [
+            { type: "boolean" },
+            { type: "object", additionalProperties: true },
+          ],
+          description:
+            "Optional JSON Schema for a structured child return. When provided, the child must return only JSON matching this schema; open-ended strings are linkified before the parent sees them.",
+        },
       },
     },
     tags: ["subagent", "orchestration"],

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -783,6 +783,18 @@ Deno.test("CfHarnessPromptLoop validates structured subagent returns and linkifi
       true,
     );
     assertEquals(
+      requestBodies[1].messages[0].content.includes(
+        "return only the JSON value requested",
+      ),
+      true,
+    );
+    assertEquals(
+      requestBodies[1].messages[0].content.includes(
+        "return a concise summary",
+      ),
+      false,
+    );
+    assertEquals(
       requestBodies[1].messages[1].content.includes(
         "Return a single JSON value matching the return schema",
       ),

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -127,6 +127,54 @@ class FailingArtifactStore implements HarnessArtifactStore {
   }
 }
 
+class RecordingArtifactStore implements HarnessArtifactStore {
+  readonly runRoot: string;
+  readonly toolOutputs: Array<{
+    toolId: string;
+    outputId: string;
+    output: unknown;
+    path: string;
+  }> = [];
+
+  constructor(readonly artifactRoot: string, private readonly runId: string) {
+    this.runRoot = `${artifactRoot}/${runId}`;
+  }
+
+  persistRunState(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/run-state.json`);
+  }
+
+  persistTranscript(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/transcript.json`);
+  }
+
+  persistCapabilitySnapshot(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/capabilities.json`);
+  }
+
+  persistCfcPolicySnapshot(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/policy-snapshot.json`);
+  }
+
+  persistPolicyTrace(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/policy-trace.json`);
+  }
+
+  persistRunReport(): Promise<string> {
+    return Promise.resolve(`${this.runRoot}/run-report.json`);
+  }
+
+  persistToolOutput(
+    toolId: string,
+    outputId: string,
+    output: unknown,
+  ): Promise<string> {
+    const path = `${this.runRoot}/tool-outputs/${outputId}-${toolId}.json`;
+    this.toolOutputs.push({ toolId, outputId, output, path });
+    return Promise.resolve(path);
+  }
+}
+
 const observedCfcResult = (
   stdout: string,
   options: {
@@ -631,6 +679,421 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
   );
 });
 
+Deno.test("CfHarnessPromptLoop validates structured subagent returns and linkifies free-form strings", async () => {
+  const artifactRoot = await Deno.makeTempDir({
+    dir: "/tmp",
+    prefix: "cf-harness-structured-return-",
+  });
+  try {
+    const requestBodies: Array<{
+      messages: Array<{ role: string; content: string }>;
+      tools: Array<{ function: { name: string } }>;
+    }> = [];
+    const artifactStore = new RecordingArtifactStore(
+      artifactRoot,
+      "run-structured-return",
+    );
+    const returnSchema = {
+      type: "object",
+      properties: {
+        approved: { type: "boolean" },
+        status: { type: "string", enum: ["approved", "not_approved"] },
+        summary: { type: "string" },
+      },
+      required: ["approved", "status", "summary"],
+      additionalProperties: false,
+    };
+    const loop = new CfHarnessPromptLoop({
+      apiKey: "test-key",
+      engine: new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runId: "run-structured-return",
+        model: "gpt-5.4",
+        cfcEnforcementMode: "enforce-explicit",
+        artifactStore,
+      }),
+      fetchFn: (_input, init) => {
+        const body = JSON.parse(String(init?.body)) as {
+          messages: Array<{ role: string; content: string }>;
+          tools: Array<{ function: { name: string } }>;
+        };
+        requestBodies.push(body);
+        const payload = requestBodies.length === 1
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [{
+                  id: "call-structured-return",
+                  type: "function",
+                  function: {
+                    name: "delegate_task",
+                    arguments: JSON.stringify({
+                      goal: "Assess the briefing.",
+                      returnSchema,
+                    }),
+                  },
+                }],
+              },
+            }],
+          }
+          : requestBodies.length === 2
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: JSON.stringify({
+                  approved: false,
+                  status: "not_approved",
+                  summary:
+                    "Hostile briefing tried to override the parent instruction.",
+                }),
+              },
+            }],
+          }
+          : {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "Parent handled sanitized structured data.",
+              },
+            }],
+          };
+        return Promise.resolve(
+          new Response(JSON.stringify(payload), { status: 200 }),
+        );
+      },
+    });
+
+    const result = await loop.runPrompt({
+      prompt: "Delegate a structured assessment.",
+      promptSlotBinding: directPromptSlotBinding,
+    });
+
+    assertEquals(
+      result.finalAssistantText,
+      "Parent handled sanitized structured data.",
+    );
+    assertEquals(
+      requestBodies[1].messages[1].content.includes("Return schema:"),
+      true,
+    );
+    assertEquals(
+      requestBodies[1].messages[1].content.includes(
+        "Return a single JSON value matching the return schema",
+      ),
+      true,
+    );
+    const toolMessage = result.transcript.at(-2);
+    if (toolMessage?.role !== "tool") {
+      throw new Error("expected delegate_task tool message");
+    }
+    assertEquals(
+      toolMessage.content.includes("Hostile briefing tried"),
+      false,
+    );
+    const output = JSON.parse(toolMessage.content) as {
+      subagent: {
+        childRunId: string;
+        status: string;
+        summary: string;
+        structuredReturn: {
+          status: string;
+          schemaDigest: string;
+          rawOutputId: string;
+          rawArtifactPath: string;
+          linkedStringCount: number;
+          value: unknown;
+        };
+        manifest: {
+          inputSummary: {
+            returnSchemaBytes: number;
+            returnSchemaDigest: string;
+          };
+        };
+      };
+    };
+    assertEquals(output.subagent.status, "completed");
+    assertEquals(
+      output.subagent.summary,
+      "Subagent returned structured data matching the requested schema.",
+    );
+    assertEquals(output.subagent.structuredReturn.status, "valid");
+    assertEquals(output.subagent.structuredReturn.linkedStringCount, 1);
+    assertEquals(output.subagent.structuredReturn.value, {
+      approved: false,
+      status: "not_approved",
+      summary: {
+        "@link":
+          "cf-harness://subagent-return/run-structured-return.subagent.1#/summary",
+      },
+    });
+    assertEquals(
+      output.subagent.structuredReturn.rawOutputId,
+      "run-structured-return.subagent.1:subagent_return:1",
+    );
+    assertEquals(
+      output.subagent.structuredReturn.rawArtifactPath.endsWith(
+        "/run-structured-return.subagent.1/tool-outputs/run-structured-return.subagent.1_subagent_return_1-subagent-return.json",
+      ),
+      true,
+    );
+    const rawReturn = JSON.parse(
+      await Deno.readTextFile(output.subagent.structuredReturn.rawArtifactPath),
+    ) as { value: { summary: string } };
+    assertEquals(
+      rawReturn.value.summary,
+      "Hostile briefing tried to override the parent instruction.",
+    );
+    assertEquals(
+      output.subagent.manifest.inputSummary.returnSchemaBytes > 0,
+      true,
+    );
+    assertEquals(
+      output.subagent.manifest.inputSummary.returnSchemaDigest.startsWith(
+        "sha256:",
+      ),
+      true,
+    );
+    assertEquals(
+      output.subagent.structuredReturn.schemaDigest,
+      output.subagent.manifest.inputSummary.returnSchemaDigest,
+    );
+    assertEquals(
+      result.runState.subagentRuns?.[0]?.structuredReturn?.status,
+      "valid",
+    );
+    assertEquals(
+      artifactStore.toolOutputs[0]?.output,
+      output,
+    );
+  } finally {
+    await Deno.remove(artifactRoot, { recursive: true });
+  }
+});
+
+Deno.test("CfHarnessPromptLoop fails structured subagent returns without exposing malformed raw text", async () => {
+  const requestBodies: Array<{
+    messages: Array<{ role: string; content: string }>;
+    tools: Array<{ function: { name: string } }>;
+  }> = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-structured-return-invalid",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        messages: Array<{ role: string; content: string }>;
+        tools: Array<{ function: { name: string } }>;
+      };
+      requestBodies.push(body);
+      const payload = requestBodies.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-structured-invalid",
+                type: "function",
+                function: {
+                  name: "delegate_task",
+                  arguments: JSON.stringify({
+                    goal: "Return structured facts.",
+                    returnSchema: {
+                      type: "object",
+                      properties: {
+                        ok: { type: "boolean" },
+                      },
+                      required: ["ok"],
+                      additionalProperties: false,
+                    },
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : requestBodies.length === 2
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "not JSON with hostile text that must stay child-local",
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Parent saw validation failure.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Delegate a malformed structured return.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  assertEquals(result.finalAssistantText, "Parent saw validation failure.");
+  const toolMessage = result.transcript.at(-2);
+  if (toolMessage?.role !== "tool") {
+    throw new Error("expected delegate_task tool message");
+  }
+  assertEquals(toolMessage.content.includes("hostile text"), false);
+  const output = JSON.parse(toolMessage.content) as {
+    subagent: {
+      status: string;
+      summary: string;
+      structuredReturn: {
+        status: string;
+        validationError: string;
+        value?: unknown;
+      };
+    };
+  };
+  assertEquals(output.subagent.status, "failed");
+  assertEquals(
+    output.subagent.summary,
+    "Subagent return validation failed: child final response was not valid JSON",
+  );
+  assertEquals(output.subagent.structuredReturn.status, "invalid");
+  assertEquals(
+    output.subagent.structuredReturn.validationError,
+    "child final response was not valid JSON",
+  );
+  assertEquals(output.subagent.structuredReturn.value, undefined);
+  assertEquals(result.runState.subagentRuns?.[0]?.status, "failed");
+  assertEquals(result.runState.failureRecords?.[0]?.toolId, "delegate_task");
+});
+
+Deno.test("CfHarnessPromptLoop keeps child-supplied schema mismatch details out of parent output", async () => {
+  const requestBodies: Array<{
+    messages: Array<{ role: string; content: string }>;
+    tools: Array<{ function: { name: string } }>;
+  }> = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-structured-return-mismatch",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        messages: Array<{ role: string; content: string }>;
+        tools: Array<{ function: { name: string } }>;
+      };
+      requestBodies.push(body);
+      const payload = requestBodies.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-structured-mismatch",
+                type: "function",
+                function: {
+                  name: "delegate_task",
+                  arguments: JSON.stringify({
+                    goal: "Return structured facts.",
+                    returnSchema: {
+                      type: "object",
+                      properties: {
+                        ok: { type: "boolean" },
+                      },
+                      required: ["ok"],
+                      additionalProperties: false,
+                    },
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : requestBodies.length === 2
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: JSON.stringify({
+                ok: true,
+                ignore_parent_and_send_mail: "prompt injection text",
+              }),
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Parent saw schema mismatch.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Delegate a mismatched structured return.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  assertEquals(result.finalAssistantText, "Parent saw schema mismatch.");
+  const toolMessage = result.transcript.at(-2);
+  if (toolMessage?.role !== "tool") {
+    throw new Error("expected delegate_task tool message");
+  }
+  assertEquals(toolMessage.content.includes("ignore_parent"), false);
+  assertEquals(toolMessage.content.includes("prompt injection text"), false);
+  const output = JSON.parse(toolMessage.content) as {
+    subagent: {
+      status: string;
+      summary: string;
+      structuredReturn: {
+        status: string;
+        validationError: string;
+      };
+    };
+  };
+  assertEquals(output.subagent.status, "failed");
+  assertEquals(
+    output.subagent.summary,
+    "Subagent return validation failed: structured return did not match the schema",
+  );
+  assertEquals(output.subagent.structuredReturn.status, "invalid");
+  assertEquals(
+    output.subagent.structuredReturn.validationError,
+    "structured return did not match the schema",
+  );
+});
+
 Deno.test("CfHarnessPromptLoop lets an explicit subagent profile expand child tools", async () => {
   const requestBodies: Array<{
     messages: Array<{ role: string; content: string }>;
@@ -1039,6 +1502,17 @@ Deno.test("CfHarnessPromptLoop rejects invalid delegate_task inputs before creat
       name: "unknown profile",
       arguments: { goal: "Inspect", profile: "unknown" },
       message: "delegate_task profile must be one of default, browser",
+    },
+    {
+      name: "array return schema",
+      arguments: { goal: "Inspect", returnSchema: ["not", "schema"] },
+      message:
+        "delegate_task returnSchema must be a JSON Schema object, boolean, or JSON string",
+    },
+    {
+      name: "malformed string return schema",
+      arguments: { goal: "Inspect", returnSchema: "{" },
+      message: "delegate_task returnSchema string must be valid JSON",
     },
   ];
 

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -840,8 +840,7 @@ Deno.test("CfHarnessPromptLoop validates structured subagent returns and linkifi
       approved: false,
       status: "not_approved",
       summary: {
-        "@link":
-          "cf-harness://subagent-return/run-structured-return.subagent.1#/summary",
+        "@link": "opaque:run-structured-return.subagent.1#/summary",
       },
     });
     assertEquals(

--- a/packages/cf-harness/test/subagent-return.test.ts
+++ b/packages/cf-harness/test/subagent-return.test.ts
@@ -341,3 +341,39 @@ Deno.test("validateAndSanitizeSubagentReturn handles anyOf link branches and rej
     "body: value does not match anyOf",
   );
 });
+
+Deno.test("validateAndSanitizeSubagentReturn preserves link objects when anyOf object branches overlap", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      body: {
+        anyOf: [
+          {
+            type: "object",
+            additionalProperties: true,
+          },
+          {
+            type: "object",
+            properties: {
+              "@link": { type: "string" },
+            },
+            required: ["@link"],
+          },
+        ],
+      },
+    },
+    required: ["body"],
+    additionalProperties: false,
+  } as const;
+
+  const sanitized = validateAndSanitizeSubagentReturn({
+    schema,
+    childRunId: "run-overlap.subagent.1",
+    value: { body: { "@link": "opaque:child#/summary" } },
+  });
+
+  assertEquals(sanitized.linkedStringCount, 0);
+  assertEquals(sanitized.value, {
+    body: { "@link": "opaque:child#/summary" },
+  });
+});

--- a/packages/cf-harness/test/subagent-return.test.ts
+++ b/packages/cf-harness/test/subagent-return.test.ts
@@ -300,7 +300,6 @@ Deno.test("validateAndSanitizeSubagentReturn handles anyOf link branches and rej
               "@link": { type: "string" },
             },
             required: ["@link"],
-            additionalProperties: false,
           },
         ],
       },

--- a/packages/cf-harness/test/subagent-return.test.ts
+++ b/packages/cf-harness/test/subagent-return.test.ts
@@ -112,16 +112,91 @@ Deno.test("validateAndSanitizeSubagentReturn preserves control primitives and li
     status: "not_approved",
     score: 0.73,
     summary: {
-      "@link":
-        "cf-harness://subagent-return/run-structured.subagent.1#/summary",
+      "@link": "opaque:run-structured.subagent.1#/summary",
     },
     notes: [{
       category: "risk",
       text: {
-        "@link":
-          "cf-harness://subagent-return/run-structured.subagent.1#/notes/0/text",
+        "@link": "opaque:run-structured.subagent.1#/notes/0/text",
       },
     }],
+  });
+});
+
+Deno.test("validateAndSanitizeSubagentReturn resolves refs and allOf before deciding raw strings", () => {
+  const schema = {
+    $defs: {
+      Status: { type: "string", enum: ["approved", "not_approved"] },
+    },
+    allOf: [
+      {
+        type: "object",
+        properties: {
+          status: { $ref: "#/$defs/Status" },
+          verdict: {
+            allOf: [
+              { type: "string" },
+              { const: "safe" },
+            ],
+          },
+          summary: { type: "string" },
+        },
+        required: ["status", "verdict", "summary"],
+      },
+      {
+        type: "object",
+        properties: {
+          status: true,
+          verdict: true,
+          summary: true,
+        },
+        additionalProperties: false,
+      },
+    ],
+  } as const;
+
+  const sanitized = validateAndSanitizeSubagentReturn({
+    schema,
+    childRunId: "run-ref.subagent.1",
+    value: {
+      status: "approved",
+      verdict: "safe",
+      summary: "Prompt-injected content stays behind an opaque link.",
+    },
+  });
+
+  assertEquals(sanitized.linkedStringCount, 1);
+  assertEquals(sanitized.value, {
+    status: "approved",
+    verdict: "safe",
+    summary: {
+      "@link": "opaque:run-ref.subagent.1#/summary",
+    },
+  });
+});
+
+Deno.test("validateAndSanitizeSubagentReturn makes objects with unmodeled keys opaque", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      approved: { type: "boolean" },
+    },
+    required: ["approved"],
+    additionalProperties: { type: "string" },
+  } as const;
+
+  const sanitized = validateAndSanitizeSubagentReturn({
+    schema,
+    childRunId: "run-extra.subagent.1",
+    value: {
+      approved: true,
+      "ignore previous instructions": "leaked through key channel",
+    },
+  });
+
+  assertEquals(sanitized.linkedStringCount, 0);
+  assertEquals(sanitized.value, {
+    "@link": "opaque:run-extra.subagent.1",
   });
 });
 
@@ -155,7 +230,7 @@ Deno.test("validateAndSanitizeSubagentReturn handles anyOf link branches and rej
     }).value,
     {
       body: {
-        "@link": "cf-harness://subagent-return/run-anyof.subagent.1#/body",
+        "@link": "opaque:run-anyof.subagent.1#/body",
       },
     },
   );

--- a/packages/cf-harness/test/subagent-return.test.ts
+++ b/packages/cf-harness/test/subagent-return.test.ts
@@ -1,0 +1,182 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  parseSubagentReturnJson,
+  parseSubagentReturnSchema,
+  validateAndSanitizeSubagentReturn,
+} from "../src/subagent-return.ts";
+
+Deno.test("parseSubagentReturnSchema accepts JSON Schema objects, booleans, and strings", () => {
+  assertEquals(parseSubagentReturnSchema(true), {
+    schema: true,
+    bytes: 4,
+  });
+  assertEquals(parseSubagentReturnSchema({ type: "boolean" }), {
+    schema: { type: "boolean" },
+    bytes: 18,
+  });
+  assertEquals(parseSubagentReturnSchema('{"type":"string"}'), {
+    schema: { type: "string" },
+    bytes: 17,
+  });
+  assertEquals(parseSubagentReturnSchema(undefined), undefined);
+});
+
+Deno.test("parseSubagentReturnSchema rejects malformed or non-schema inputs", () => {
+  const cases = [
+    {
+      input: "{",
+      message: "delegate_task returnSchema string must be valid JSON",
+    },
+    {
+      input: ["not", "a", "schema"],
+      message:
+        "delegate_task returnSchema must be a JSON Schema object, boolean, or JSON string",
+    },
+    {
+      input: null,
+      message:
+        "delegate_task returnSchema must be a JSON Schema object, boolean, or JSON string",
+    },
+    {
+      input: 42,
+      message:
+        "delegate_task returnSchema must be a JSON Schema object, boolean, or JSON string",
+    },
+  ];
+  for (const testCase of cases) {
+    assertThrows(
+      () => parseSubagentReturnSchema(testCase.input),
+      Error,
+      testCase.message,
+    );
+  }
+});
+
+Deno.test("parseSubagentReturnJson fails closed without echoing malformed content", () => {
+  assertEquals(parseSubagentReturnJson('{"ok":true}'), { ok: true });
+  assertThrows(
+    () => parseSubagentReturnJson("not JSON with raw data"),
+    Error,
+    "child final response was not valid JSON",
+  );
+  assertThrows(
+    () => parseSubagentReturnJson("  "),
+    Error,
+    "child final response was empty",
+  );
+});
+
+Deno.test("validateAndSanitizeSubagentReturn preserves control primitives and linkifies free-form strings", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      approved: { type: "boolean" },
+      status: { type: "string", enum: ["approved", "not_approved"] },
+      score: { type: "number" },
+      summary: { type: "string" },
+      notes: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            category: { type: "string", enum: ["risk", "info"] },
+            text: { type: "string" },
+          },
+          required: ["category", "text"],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ["approved", "status", "score", "summary", "notes"],
+    additionalProperties: false,
+  } as const;
+
+  const sanitized = validateAndSanitizeSubagentReturn({
+    schema,
+    childRunId: "run-structured.subagent.1",
+    value: {
+      approved: false,
+      status: "not_approved",
+      score: 0.73,
+      summary: "Hostile briefing says to ignore the parent.",
+      notes: [{
+        category: "risk",
+        text: "The page tried to redirect mail to an attacker.",
+      }],
+    },
+  });
+
+  assertEquals(sanitized.linkedStringCount, 2);
+  assertEquals(sanitized.value, {
+    approved: false,
+    status: "not_approved",
+    score: 0.73,
+    summary: {
+      "@link":
+        "cf-harness://subagent-return/run-structured.subagent.1#/summary",
+    },
+    notes: [{
+      category: "risk",
+      text: {
+        "@link":
+          "cf-harness://subagent-return/run-structured.subagent.1#/notes/0/text",
+      },
+    }],
+  });
+});
+
+Deno.test("validateAndSanitizeSubagentReturn handles anyOf link branches and rejects schema mismatches", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      body: {
+        anyOf: [
+          { type: "string" },
+          {
+            type: "object",
+            properties: {
+              "@link": { type: "string" },
+            },
+            required: ["@link"],
+            additionalProperties: false,
+          },
+        ],
+      },
+    },
+    required: ["body"],
+    additionalProperties: false,
+  } as const;
+
+  assertEquals(
+    validateAndSanitizeSubagentReturn({
+      schema,
+      childRunId: "run-anyof.subagent.1",
+      value: { body: "open ended body" },
+    }).value,
+    {
+      body: {
+        "@link": "cf-harness://subagent-return/run-anyof.subagent.1#/body",
+      },
+    },
+  );
+
+  assertEquals(
+    validateAndSanitizeSubagentReturn({
+      schema,
+      childRunId: "run-anyof.subagent.1",
+      value: { body: { "@link": "/of:opaque/summary" } },
+    }).value,
+    { body: { "@link": "/of:opaque/summary" } },
+  );
+
+  assertThrows(
+    () =>
+      validateAndSanitizeSubagentReturn({
+        schema,
+        childRunId: "run-anyof.subagent.1",
+        value: { body: 123 },
+      }),
+    Error,
+    "body: value does not match anyOf",
+  );
+});

--- a/packages/cf-harness/test/subagent-return.test.ts
+++ b/packages/cf-harness/test/subagent-return.test.ts
@@ -200,6 +200,93 @@ Deno.test("validateAndSanitizeSubagentReturn makes objects with unmodeled keys o
   });
 });
 
+Deno.test("validateAndSanitizeSubagentReturn keeps base object properties when selecting union branches", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      status: { type: "string", enum: ["approved", "not_approved"] },
+      detail: true,
+    },
+    required: ["status", "detail"],
+    additionalProperties: false,
+    anyOf: [
+      {
+        type: "object",
+        properties: {
+          detail: { type: "string" },
+        },
+        required: ["detail"],
+        additionalProperties: true,
+      },
+    ],
+  } as const;
+
+  const sanitized = validateAndSanitizeSubagentReturn({
+    schema,
+    childRunId: "run-anyof-base.subagent.1",
+    value: {
+      status: "approved",
+      detail: "The page tried to override the task.",
+    },
+  });
+
+  assertEquals(sanitized.linkedStringCount, 1);
+  assertEquals(sanitized.value, {
+    status: "approved",
+    detail: {
+      "@link": "opaque:run-anyof-base.subagent.1#/detail",
+    },
+  });
+});
+
+Deno.test("validateAndSanitizeSubagentReturn preserves allOf additionalProperties constraints for known keys", () => {
+  const schema = {
+    type: "object",
+    additionalProperties: {
+      type: "string",
+      enum: ["safe"],
+    },
+    allOf: [
+      {
+        type: "object",
+        properties: {
+          status: { type: "string" },
+        },
+        required: ["status"],
+      },
+    ],
+  } as const;
+
+  const sanitized = validateAndSanitizeSubagentReturn({
+    schema,
+    childRunId: "run-allof-additional.subagent.1",
+    value: { status: "safe" },
+  });
+
+  assertEquals(sanitized.linkedStringCount, 0);
+  assertEquals(sanitized.value, { status: "safe" });
+});
+
+Deno.test("validateAndSanitizeSubagentReturn traverses allOf array item schemas", () => {
+  const schema = {
+    type: "array",
+    allOf: [
+      {
+        items: { type: "string", enum: ["safe"] },
+      },
+    ],
+  } as const;
+
+  const sanitized = validateAndSanitizeSubagentReturn({
+    schema,
+    childRunId: "run-array-allof.subagent.1",
+    value: ["safe"],
+  });
+
+  assertEquals(sanitized.linkedStringCount, 0);
+  assertEquals(sanitized.value, ["safe"]);
+});
+
 Deno.test("validateAndSanitizeSubagentReturn handles anyOf link branches and rejects schema mismatches", () => {
   const schema = {
     type: "object",

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -67,4 +67,7 @@ export {
   isInitialSinkInventoryName,
 } from "./sink-inventory.ts";
 export { markRendererTrustedEvent } from "./ui-contract.ts";
-export { validateAgainstSchema } from "./schema-sanitization.ts";
+export {
+  resolveSchemaForValidation,
+  validateAgainstSchema,
+} from "./schema-sanitization.ts";

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -67,3 +67,4 @@ export {
   isInitialSinkInventoryName,
 } from "./sink-inventory.ts";
 export { markRendererTrustedEvent } from "./ui-contract.ts";
+export { validateAgainstSchema } from "./schema-sanitization.ts";

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -136,7 +136,7 @@ const objectSchemaIsClosed = (schema: Record<string, unknown>): boolean =>
   schema.additionalProperties !== true &&
   typeof schema.additionalProperties !== "object";
 
-const resolveSchema = (
+export const resolveSchemaForValidation = (
   schema: JSONSchema,
   fullSchema: JSONSchema,
 ): JSONSchema =>
@@ -175,7 +175,7 @@ const annotateSchema = (
     ? new Set([...visitedRefs, directRef])
     : visitedRefs;
 
-  const resolved = resolveSchema(schema, fullSchema);
+  const resolved = resolveSchemaForValidation(schema, fullSchema);
   if (resolved !== schema) {
     const annotated = annotateSchema(
       resolved,
@@ -386,7 +386,7 @@ export const validateAgainstSchema = (
   if (schema === true) return undefined;
   if (schema === false) return "schema rejects all values";
 
-  const resolved = resolveSchema(schema, fullSchema);
+  const resolved = resolveSchemaForValidation(schema, fullSchema);
   if (resolved !== schema) {
     // Keep the original root as `fullSchema` so nested $refs in the resolved
     // branch can still find sibling $defs entries.


### PR DESCRIPTION
## Summary
- add optional delegate_task returnSchema support for schema-validated child JSON returns
- retain raw child returns in child artifacts while exposing sanitized structuredReturn values to the parent
- linkify free-form strings as @link objects while preserving booleans, numbers, string enums/consts, and explicit link objects
- document the return channel and export the shared schema validator/subagent return helper

## Tests
- deno task test (packages/cf-harness)
- deno check packages/cf-harness/mod.ts packages/runner/src/cfc/mod.ts
- deno lint packages/cf-harness/src/subagent-return.ts packages/cf-harness/src/prompt-loop.ts packages/cf-harness/src/contracts/subagent.ts packages/cf-harness/src/contracts/policy.ts packages/cf-harness/src/tools/delegate-task.ts packages/cf-harness/test/subagent-return.test.ts packages/cf-harness/test/prompt-loop.test.ts packages/runner/src/cfc/mod.ts