### PR TITLE
Route callers through the public hash names; rename `*Modern` exports

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -659,8 +659,7 @@ export class FabricEpochDays extends FabricPrimitive {
  * system (always frozen, passes through conversion unchanged).
  *
  * The first algorithm tag is `fid1` ("fabric ID, v1"), which corresponds
- * to the SHA-256-based hash produced by `hashOfModern()`
- * (Section 6.4).
+ * to the SHA-256-based hash produced by `hashOf()` (Section 6.4).
  *
  * Stringification produces `<tag>:<base64urlHash>` where `<base64urlHash>`
  * is the unpadded base64url encoding (RFC 4648 Section 5) of the hash
@@ -1871,8 +1870,8 @@ regardless of nibble range.
  * Section 3 of `3-json-encoding.md`).
  *
  * Two public entry points are provided:
- * - `hashOfModern(value)` — returns a `FabricHash`.
- * - `hashOfModernAsString(value)` — returns a plain `string` (the hash
+ * - `hashOf(value)` — returns a `FabricHash`.
+ * - `hashStringOf(value)` — returns a plain `string` (the hash
  *   as base64url, without the algorithm tag). This avoids `FabricHash`
  *   allocation when only the string form is needed.
  *
@@ -1885,7 +1884,7 @@ regardless of nibble range.
  * (`shallowFabricFromNativeValueModern`), then hashed in their converted
  * form.
  */
-export function hashOfModern(value: unknown): FabricHash {
+export function hashOf(value: unknown): FabricHash {
   // Type tag bytes — see Section 6.3 for the full table.
   // Tag categories: meta (0x0N), compound (0x1N), primitive (0x2N),
   // optimized (0xFN).
@@ -1921,7 +1920,7 @@ export function hashOfModern(value: unknown): FabricHash {
   //                        (algorithm tag as a tagged string, then raw hash bytes)
   // - array:               hash(TAG_ARRAY, ...elements, TAG_END)
   //                        Elements are hashed in index order:
-  //                          if `i in array`: hashOfModern(array[i])
+  //                          if `i in array`: hashOf(array[i])
   //                          else (hole run): hash(TAG_HOLE, leb128(N))
   //                        TAG_END marks the end of the element sequence.
   //                        (order-preserving)
@@ -1952,7 +1951,7 @@ export function hashOfModern(value: unknown): FabricHash {
   //                        Each pair: hashStr(key) + tagged value.
   //                        TAG_END marks the end of the pair sequence.
   // - `FabricInstance`:  hash(TAG_INSTANCE, hashStr(typeTag),
-  //                              hashOfModern(deconstructedState))
+  //                              hashOf(deconstructedState))
   //
   // The native object wrappers and temporal types are hashed as follows:
   //
@@ -1960,7 +1959,7 @@ export function hashOfModern(value: unknown): FabricHash {
   //   and other `FabricInstance`s with recursively-processable
   //   deconstructed state are hashed via TAG_INSTANCE:
   //     hash(TAG_INSTANCE, hashStr(typeTag),
-  //          hashOfModern(deconstructedState))
+  //          hashOf(deconstructedState))
   //
   // - `FabricBytes` uses TAG_BYTES (dedicated primitive tag).
   // - `FabricEpochNsec` uses TAG_EPOCH_NSEC (dedicated primitive tag).
@@ -1970,12 +1969,12 @@ export function hashOfModern(value: unknown): FabricHash {
   // Examples (existing type tags are all short enough for the direct
   // string form, so `hashStr(tag)` below expands to
   // `TAG_STRING, leb128(utf8ByteLen), utf8Bytes`):
-  // - `FabricError`:      hash(TAG_INSTANCE, hashStr("Error@1"), hashOfModern(errorState))
-  // - `FabricMap`:        hash(TAG_INSTANCE, hashStr("Map@1"), hashOfModern(entries))
+  // - `FabricError`:      hash(TAG_INSTANCE, hashStr("Error@1"), hashOf(errorState))
+  // - `FabricMap`:        hash(TAG_INSTANCE, hashStr("Map@1"), hashOf(entries))
   //                         where entries are hashed in insertion order
-  // - `FabricSet`:        hash(TAG_INSTANCE, hashStr("Set@1"), hashOfModern(elements))
+  // - `FabricSet`:        hash(TAG_INSTANCE, hashStr("Set@1"), hashOf(elements))
   //                         where elements are hashed in insertion order
-  // - `FabricRegExp`:     hash(TAG_INSTANCE, hashStr("RegExp@1"), hashOfModern({source, flags, flavor}))
+  // - `FabricRegExp`:     hash(TAG_INSTANCE, hashStr("RegExp@1"), hashOf({source, flags, flavor}))
   // - `FabricEpochNsec`:  hash(TAG_EPOCH_NSEC, leb128(byteLen), twosComplementBytes)
   // - `FabricEpochDays`:  hash(TAG_EPOCH_DAYS, leb128(byteLen), twosComplementBytes)
   // - `FabricHash`:  hash(TAG_CONTENT_ID, hashStr(algTag),

--- a/docs/specs/space-model-formal-spec/2-hash-byte-format.md
+++ b/docs/specs/space-model-formal-spec/2-hash-byte-format.md
@@ -24,12 +24,12 @@ The hash function is **SHA-256** (FIPS 180-4). All byte sequences described in
 this document are fed to a SHA-256 context in the order specified.
 
 The digest output is **32 raw bytes** (256 bits). The `hashOfModern()` function
-wraps the raw bytes into a `FabricHash` instance (Section 1.4.9 of the
-formal spec) with algorithm tag `fid1`. Callers who need a string
-representation call `toString()` on the result, which produces
-`fid1:<base64urlhash>` (unpadded base64url, RFC 4648 Section 5).
-`hashOfModernAsString()` returns the base64url hash directly as a plain
-string, avoiding `FabricHash` allocation when only the string form is needed.
+wraps the raw bytes into a `FabricHash` instance (Section 1.4.9 of the formal
+spec) with algorithm tag `fid1`. Callers who need a string representation call
+`toString()` on the result, which produces `fid1:<base64urlhash>` (unpadded
+base64url, RFC 4648 Section 5). `hashStringOf()` returns the base64url hash
+directly as a plain string, avoiding `FabricHash` allocation when only the
+string form is needed.
 
 > **Future addition.** BLAKE2b is listed as a recommended second algorithm in
 > the formal spec. When added, it will use the same byte-level input format

--- a/docs/specs/space-model-formal-spec/2-hash-byte-format.md
+++ b/docs/specs/space-model-formal-spec/2-hash-byte-format.md
@@ -23,9 +23,9 @@ implementation plan Phase 6.1.
 The hash function is **SHA-256** (FIPS 180-4). All byte sequences described in
 this document are fed to a SHA-256 context in the order specified.
 
-The digest output is **32 raw bytes** (256 bits). The `hashOfModern()` function
-wraps the raw bytes into a `FabricHash` instance (Section 1.4.9 of the formal
-spec) with algorithm tag `fid1`. Callers who need a string representation call
+The digest output is **32 raw bytes** (256 bits). The `hashOf()` function wraps
+the raw bytes into a `FabricHash` instance (Section 1.4.9 of the formal spec)
+with algorithm tag `fid1`. Callers who need a string representation call
 `toString()` on the result, which produces `fid1:<base64urlhash>` (unpadded
 base64url, RFC 4648 Section 5). `hashStringOf()` returns the base64url hash
 directly as a plain string, avoiding `FabricHash` allocation when only the

--- a/packages/data-model/schema-hash-legacy.ts
+++ b/packages/data-model/schema-hash-legacy.ts
@@ -6,8 +6,7 @@
  * representation of a value with sorted object keys and per-identity
  * WeakMap caching.
  *
- * Used by `schema-hash.ts` as the legacy dispatch target; will be
- * replaced by `hashOfModern` behind a flag.
+ * Used by `schema-hash.ts` as the legacy dispatch target.
  */
 
 import type { JSONSchema } from "@commonfabric/api";

--- a/packages/data-model/schema-hash-modern.ts
+++ b/packages/data-model/schema-hash-modern.ts
@@ -1,7 +1,7 @@
 /**
  * Modern schema hashing via content identification.
  *
- * Delegates to `hashOfModern()` from `value-hash-modern.ts` to produce
+ * Delegates to `hashOf()` from `value-hash-modern.ts` to produce
  * deterministic hashes using the main value hashing pipeline. Returns
  * `FabricHash` directly.
  *

--- a/packages/data-model/schema-hash-modern.ts
+++ b/packages/data-model/schema-hash-modern.ts
@@ -12,16 +12,17 @@
 import type { JSONSchema } from "@commonfabric/api";
 import type { FabricHash } from "./fabric-hash.ts";
 import type { FabricValue } from "./interface.ts";
-import { hashOfModern, hashOfModernAsString } from "./value-hash-modern.ts";
+import { hashOfModern } from "./value-hash-modern.ts";
+import { hashStringOf } from "./value-hash.ts";
 
 /** Modern hash of a JSONSchema, returned as a string. */
 export function hashSchemaModernAsString(schema: JSONSchema): string {
-  return hashOfModernAsString(schema);
+  return hashStringOf(schema);
 }
 
 /** Modern hash of a schema-related item, returned as a string. */
 export function hashSchemaItemModernAsString(item: FabricValue): string {
-  return hashOfModernAsString(item);
+  return hashStringOf(item);
 }
 
 /** Modern hash of a schema-related item, returned as a FabricHash. */

--- a/packages/data-model/schema-hash-modern.ts
+++ b/packages/data-model/schema-hash-modern.ts
@@ -12,8 +12,7 @@
 import type { JSONSchema } from "@commonfabric/api";
 import type { FabricHash } from "./fabric-hash.ts";
 import type { FabricValue } from "./interface.ts";
-import { hashOfModern } from "./value-hash-modern.ts";
-import { hashStringOf } from "./value-hash.ts";
+import { hashOf, hashStringOf } from "./value-hash.ts";
 
 /** Modern hash of a JSONSchema, returned as a string. */
 export function hashSchemaModernAsString(schema: JSONSchema): string {
@@ -29,5 +28,5 @@ export function hashSchemaItemModernAsString(item: FabricValue): string {
 export function hashSchemaItemModern(
   item: FabricValue,
 ): FabricHash {
-  return hashOfModern(item);
+  return hashOf(item);
 }

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -309,14 +309,11 @@ export function emptySchemaObject() {
  * Idempotent on repeat calls: `internPathSelector(internPathSelector(x)) ===
  * internPathSelector(x)`.
  *
- * Exists so that callers who feed selectors into
- * `MapSetStringToPathSelectors` (or any other cache keyed on
- * `hashSchemaItem` of a selector) can hand in an already-interned,
- * deep-frozen selector. That satisfies the `isDeepFrozen` guard in
- * `hashOfModernInternal` and lets the modern-hash WeakMap cache retain
- * its hash across repeat calls. See
- * `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` §4
- * Phase 2 "DEFEAT-8" for the motivating analysis.
+ * Exists so that callers who feed selectors into `MapSetStringToPathSelectors`
+ * (or any other cache keyed on `hashSchemaItem` of a selector) can hand in an
+ * already-interned, deep-frozen selector. That satisfies the `isDeepFrozen`
+ * guard internal to `hashOf()` and lets its `WeakMap` cache retain its hash
+ * across repeat calls.
  */
 export function internPathSelector(
   selector: SchemaPathSelector,

--- a/packages/data-model/test/fabric-regexp.test.ts
+++ b/packages/data-model/test/fabric-regexp.test.ts
@@ -23,7 +23,7 @@ import {
   tagFromNativeClass,
   tagFromNativeValue,
 } from "../native-type-tags.ts";
-import { hashOfModern } from "../value-hash-modern.ts";
+import { hashOf } from "../value-hash.ts";
 
 /** Dummy reconstruction context for tests. */
 const dummyContext: ReconstructionContext = {
@@ -293,10 +293,10 @@ describe("FabricRegExp", () => {
   // Hash
   // --------------------------------------------------------------------------
 
-  describe("hashOfModern", () => {
+  describe("hashOf", () => {
     it("produces a hash for FabricRegExp", () => {
       const sr = new FabricRegExp(/abc/gi);
-      const hash = hashOfModern(sr);
+      const hash = hashOf(sr);
       expect(hash.bytes).toBeInstanceOf(Uint8Array);
       expect(hash.length).toBe(32); // SHA-256
     });
@@ -304,20 +304,20 @@ describe("FabricRegExp", () => {
     it("same regex produces same hash", () => {
       const sr1 = new FabricRegExp(/abc/gi);
       const sr2 = new FabricRegExp(/abc/gi);
-      const h1 = hashOfModern(sr1).bytes;
-      const h2 = hashOfModern(sr2).bytes;
+      const h1 = hashOf(sr1).bytes;
+      const h2 = hashOf(sr2).bytes;
       expect(h1).toEqual(h2);
     });
 
     it("different source produces different hash", () => {
-      const h1 = hashOfModern(new FabricRegExp(/abc/)).bytes;
-      const h2 = hashOfModern(new FabricRegExp(/def/)).bytes;
+      const h1 = hashOf(new FabricRegExp(/abc/)).bytes;
+      const h2 = hashOf(new FabricRegExp(/def/)).bytes;
       expect(h1).not.toEqual(h2);
     });
 
     it("different flags produce different hash", () => {
-      const h1 = hashOfModern(new FabricRegExp(/abc/g)).bytes;
-      const h2 = hashOfModern(new FabricRegExp(/abc/i)).bytes;
+      const h1 = hashOf(new FabricRegExp(/abc/g)).bytes;
+      const h2 = hashOf(new FabricRegExp(/abc/i)).bytes;
       expect(h1).not.toEqual(h2);
     });
   });

--- a/packages/data-model/test/hashing-bench.ts
+++ b/packages/data-model/test/hashing-bench.ts
@@ -5,7 +5,6 @@
  */
 
 import { hashOf } from "../value-hash.ts";
-import { hashOfModern } from "../value-hash-modern.ts";
 import { deepFreeze } from "../deep-freeze.ts";
 
 // ---------------------------------------------------------------------------
@@ -260,7 +259,7 @@ Deno.bench({
   name: "sparse array (100 slots, 34 filled)",
   group: "sparse-array",
   fn() {
-    hashOfModern(sparseArray);
+    hashOf(sparseArray);
   },
 });
 

--- a/packages/data-model/test/value-hash-modern.test.ts
+++ b/packages/data-model/test/value-hash-modern.test.ts
@@ -38,7 +38,7 @@ function modernHash(value: FabricValue): Uint8Array {
 // Primitive types
 // =========================================================================
 
-describe("modernHash", () => {
+describe("hashOf()", () => {
   // --- null ---
 
   it("null produces TAG_NULL byte stream", () => {
@@ -396,7 +396,7 @@ describe("modernHash", () => {
   it("FabricError matches byte stream built from DECONSTRUCT output", () => {
     // Build the expected byte stream programmatically because the
     // deconstructed state includes `stack` which is environment-dependent.
-    // We construct the stream the same way modernHash does, then SHA-256 it.
+    // We construct the stream the same way `hashOf()` does, then SHA-256 it.
     const error = new FabricError(new Error("test"));
     const enc = new TextEncoder();
 
@@ -892,10 +892,10 @@ describe("modernHash", () => {
   });
 
   // =========================================================================
-  // modernHash returns FabricHash
+  // hashOf() returns FabricHash
   // =========================================================================
 
-  it("modernHash returns FabricHash with fid1 tag", () => {
+  it("hashOf() returns FabricHash with fid1 tag", () => {
     const result = hashOf(42);
     expect(result).toBeInstanceOf(FabricHash);
     expect(result.tag).toBe("fid1");
@@ -920,7 +920,7 @@ describe("modernHash", () => {
 // Caching behavior
 // ---------------------------------------------------------------------------
 
-describe("modernHash caching", () => {
+describe("hashOf() caching", () => {
   it("null returns same object (precomputed constant)", () => {
     const a = hashOf(null);
     const b = hashOf(null);
@@ -991,7 +991,7 @@ describe("modernHash caching", () => {
 // Native instance hashing (on-the-fly conversion)
 // ---------------------------------------------------------------------------
 
-describe("modernHash native instances", () => {
+describe("hashOf() native instances", () => {
   // --- Date ---
 
   it("native Date hashes without throwing", () => {

--- a/packages/data-model/test/value-hash-modern.test.ts
+++ b/packages/data-model/test/value-hash-modern.test.ts
@@ -1,9 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import {
-  hashOfModern as modernHashRaw,
-  hashOfModernAsString,
-} from "../value-hash-modern.ts";
+import { hashStringOf } from "../value-hash.ts";
+import { hashOfModern as modernHashRaw } from "../value-hash-modern.ts";
 import { createHasher } from "@commonfabric/content-hash";
 import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
 import { FabricHash } from "../fabric-hash.ts";
@@ -1085,12 +1083,12 @@ describe("modernHash native instances", () => {
 });
 
 // ---------------------------------------------------------------------------
-// hashOfModernAsString
+// hashStringOf
 // ---------------------------------------------------------------------------
 
-describe("hashOfModernAsString", () => {
+describe("hashStringOf", () => {
   it("returns a string", () => {
-    const result = hashOfModernAsString(42);
+    const result = hashStringOf(42);
     expect(typeof result).toBe("string");
   });
 
@@ -1108,38 +1106,38 @@ describe("hashOfModernAsString", () => {
       undefined,
     ];
     for (const v of values) {
-      expect(hashOfModernAsString(v)).toBe(modernHashRaw(v).hashString);
+      expect(hashStringOf(v)).toBe(modernHashRaw(v).hashString);
     }
   });
 
   it("matches FabricHash.hashString for frozen objects", () => {
     const obj = Object.freeze({ a: 1, b: Object.freeze({ c: 2 }) });
-    expect(hashOfModernAsString(obj)).toBe(modernHashRaw(obj).hashString);
+    expect(hashStringOf(obj)).toBe(modernHashRaw(obj).hashString);
   });
 
   it("matches FabricHash.hashString for mutable objects", () => {
     const obj = { x: [1, 2, 3] };
-    expect(hashOfModernAsString(obj)).toBe(modernHashRaw(obj).hashString);
+    expect(hashStringOf(obj)).toBe(modernHashRaw(obj).hashString);
   });
 
   it("returns consistent results", () => {
-    expect(hashOfModernAsString("test")).toBe(hashOfModernAsString("test"));
+    expect(hashStringOf("test")).toBe(hashStringOf("test"));
   });
 
   it("different values produce different strings", () => {
-    const a = hashOfModernAsString(1);
-    const b = hashOfModernAsString(2);
+    const a = hashStringOf(1);
+    const b = hashStringOf(2);
     expect(a).not.toBe(b);
   });
 
   it("result does not contain algorithm tag or colon", () => {
-    const result = hashOfModernAsString({ hello: "world" });
+    const result = hashStringOf({ hello: "world" });
     expect(result.includes("fid1")).toBe(false);
     expect(result.includes(":")).toBe(false);
   });
 
   it("result is valid unpadded base64url", () => {
-    const result = hashOfModernAsString(42);
+    const result = hashStringOf(42);
     // No padding characters.
     expect(result.includes("=")).toBe(false);
     // Only base64url characters.

--- a/packages/data-model/test/value-hash-modern.test.ts
+++ b/packages/data-model/test/value-hash-modern.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { hashStringOf } from "../value-hash.ts";
-import { hashOfModern as modernHashRaw } from "../value-hash-modern.ts";
+import { hashOf, hashStringOf } from "../value-hash.ts";
 import { createHasher } from "@commonfabric/content-hash";
 import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
 import { FabricHash } from "../fabric-hash.ts";
@@ -31,8 +30,8 @@ function hex(hash: Uint8Array): string {
 }
 
 /** Extract the raw hash bytes from modernHash for comparison. */
-function modernHash(value: unknown): Uint8Array {
-  return modernHashRaw(value).bytes;
+function modernHash(value: FabricValue): Uint8Array {
+  return hashOf(value).bytes;
 }
 
 // =========================================================================
@@ -652,7 +651,7 @@ describe("modernHash", () => {
   });
 
   it("all hashes are 32 bytes (SHA-256)", () => {
-    const values: unknown[] = [
+    const values: FabricValue[] = [
       null,
       true,
       false,
@@ -889,7 +888,7 @@ describe("modernHash", () => {
       is: { value: 914 },
     };
 
-    expect(() => modernHashRaw(fact)).not.toThrow();
+    expect(() => hashOf(fact)).not.toThrow();
   });
 
   // =========================================================================
@@ -897,14 +896,14 @@ describe("modernHash", () => {
   // =========================================================================
 
   it("modernHash returns FabricHash with fid1 tag", () => {
-    const result = modernHashRaw(42);
+    const result = hashOf(42);
     expect(result).toBeInstanceOf(FabricHash);
     expect(result.tag).toBe("fid1");
     expect(result.length).toBe(32);
   });
 
   it("FabricHash.toString() produces fid1:<base64>", () => {
-    const result = modernHashRaw(42);
+    const result = hashOf(42);
     const str = result.toString();
     expect(str.startsWith("fid1:")).toBe(true);
     // Should not contain padding (unpadded base64).
@@ -912,7 +911,7 @@ describe("modernHash", () => {
   });
 
   it("FabricHash is frozen (FabricPrimitive)", () => {
-    const result = modernHashRaw(42);
+    const result = hashOf(42);
     expect(Object.isFrozen(result)).toBe(true);
   });
 });
@@ -923,67 +922,67 @@ describe("modernHash", () => {
 
 describe("modernHash caching", () => {
   it("null returns same object (precomputed constant)", () => {
-    const a = modernHashRaw(null);
-    const b = modernHashRaw(null);
+    const a = hashOf(null);
+    const b = hashOf(null);
     expect(a).toBe(b);
   });
 
   it("undefined returns same object (precomputed constant)", () => {
-    const a = modernHashRaw(undefined);
-    const b = modernHashRaw(undefined);
+    const a = hashOf(undefined);
+    const b = hashOf(undefined);
     expect(a).toBe(b);
   });
 
   it("true returns same object (precomputed constant)", () => {
-    const a = modernHashRaw(true);
-    const b = modernHashRaw(true);
+    const a = hashOf(true);
+    const b = hashOf(true);
     expect(a).toBe(b);
   });
 
   it("false returns same object (precomputed constant)", () => {
-    const a = modernHashRaw(false);
-    const b = modernHashRaw(false);
+    const a = hashOf(false);
+    const b = hashOf(false);
     expect(a).toBe(b);
   });
 
   it("primitive string cache returns same object", () => {
-    const a = modernHashRaw("cache-test-string");
-    const b = modernHashRaw("cache-test-string");
+    const a = hashOf("cache-test-string");
+    const b = hashOf("cache-test-string");
     expect(a).toBe(b);
   });
 
   it("primitive number cache returns same object", () => {
-    const a = modernHashRaw(98765);
-    const b = modernHashRaw(98765);
+    const a = hashOf(98765);
+    const b = hashOf(98765);
     expect(a).toBe(b);
   });
 
   it("primitive bigint cache returns same object", () => {
-    const a = modernHashRaw(99887766n);
-    const b = modernHashRaw(99887766n);
+    const a = hashOf(99887766n);
+    const b = hashOf(99887766n);
     expect(a).toBe(b);
   });
 
   it("deep-frozen object cache returns same object", () => {
     const obj = Object.freeze({ a: 1, b: Object.freeze({ c: 2 }) });
-    const a = modernHashRaw(obj);
-    const b = modernHashRaw(obj);
+    const a = hashOf(obj);
+    const b = hashOf(obj);
     expect(a).toBe(b);
   });
 
   it("mutable object is not cached (recomputed each time)", () => {
     const obj = { a: 1 };
-    const a = modernHashRaw(obj);
+    const a = hashOf(obj);
     // Mutate
     obj.a = 2;
-    const b = modernHashRaw(obj);
+    const b = hashOf(obj);
     // Hashes should differ because the object changed
     expect(hex(a.bytes)).not.toEqual(hex(b.bytes));
   });
 
   it("different primitives with same type produce different hashes", () => {
-    const a = modernHashRaw("hello");
-    const b = modernHashRaw("world");
+    const a = hashOf("hello");
+    const b = hashOf("world");
     expect(hex(a.bytes)).not.toEqual(hex(b.bytes));
   });
 });
@@ -1060,26 +1059,26 @@ describe("modernHash native instances", () => {
   // --- Deferred types (not yet handled — these document known gaps) ---
 
   it("Map throws (deferred — needs recursive translation)", () => {
-    expect(() => modernHashRaw(new Map([["a", 1]]))).toThrow(
+    expect(() => hashOf(new Map([["a", 1]]))).toThrow(
       "unsupported object type",
     );
   });
 
   it("Set throws (deferred — needs recursive translation)", () => {
-    expect(() => modernHashRaw(new Set([1, 2, 3]))).toThrow(
+    expect(() => hashOf(new Set([1, 2, 3]))).toThrow(
       "unsupported object type",
     );
   });
 
   it("Error throws (deferred — needs recursive translation)", () => {
-    expect(() => modernHashRaw(new Error("test"))).toThrow(
+    expect(() => hashOf(new Error("test"))).toThrow(
       "unsupported object type",
     );
   });
 
   it("HasToJSON throws (deferred — needs recursive translation)", () => {
     const obj = { toJSON: () => "hello" };
-    expect(() => modernHashRaw(obj)).toThrow("unsupported object type");
+    expect(() => hashOf(obj)).toThrow("unsupported object type");
   });
 });
 
@@ -1107,18 +1106,18 @@ describe("hashStringOf", () => {
       undefined,
     ];
     for (const v of values) {
-      expect(hashStringOf(v)).toBe(modernHashRaw(v).hashString);
+      expect(hashStringOf(v)).toBe(hashOf(v).hashString);
     }
   });
 
   it("matches FabricHash.hashString for frozen objects", () => {
     const obj = Object.freeze({ a: 1, b: Object.freeze({ c: 2 }) });
-    expect(hashStringOf(obj)).toBe(modernHashRaw(obj).hashString);
+    expect(hashStringOf(obj)).toBe(hashOf(obj).hashString);
   });
 
   it("matches FabricHash.hashString for mutable objects", () => {
     const obj = { x: [1, 2, 3] };
-    expect(hashStringOf(obj)).toBe(modernHashRaw(obj).hashString);
+    expect(hashStringOf(obj)).toBe(hashOf(obj).hashString);
   });
 
   it("returns consistent results", () => {

--- a/packages/data-model/test/value-hash-modern.test.ts
+++ b/packages/data-model/test/value-hash-modern.test.ts
@@ -5,6 +5,7 @@ import { hashOfModern as modernHashRaw } from "../value-hash-modern.ts";
 import { createHasher } from "@commonfabric/content-hash";
 import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
 import { FabricHash } from "../fabric-hash.ts";
+import { FabricValue } from "../interface.ts";
 import { FabricEpochDays, FabricEpochNsec } from "../fabric-epoch.ts";
 import { FabricError, FabricRegExp } from "../fabric-native-instances.ts";
 import { FabricBytes } from "../fabric-bytes.ts";
@@ -1093,7 +1094,7 @@ describe("hashStringOf", () => {
   });
 
   it("matches FabricHash.hashString for primitives", () => {
-    const values: unknown[] = [
+    const values: FabricValue[] = [
       null,
       true,
       false,

--- a/packages/data-model/test/value-hash-modern.test.ts
+++ b/packages/data-model/test/value-hash-modern.test.ts
@@ -29,8 +29,8 @@ function hex(hash: Uint8Array): string {
   return Array.from(hash).map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-/** Extract the raw hash bytes from modernHash for comparison. */
-function modernHash(value: FabricValue): Uint8Array {
+/** Extract the raw hash bytes from `hashOf()` for comparison. */
+function hashBytesOf(value: FabricValue): Uint8Array {
   return hashOf(value).bytes;
 }
 
@@ -44,7 +44,7 @@ describe("hashOf()", () => {
   it("null produces TAG_NULL byte stream", () => {
     // Byte stream: [0x20]
     const expected = sha256([0x20]);
-    expect(modernHash(null)).toEqual(expected);
+    expect(hashBytesOf(null)).toEqual(expected);
   });
 
   // --- boolean ---
@@ -52,17 +52,17 @@ describe("hashOf()", () => {
   it("true produces TAG_BOOLEAN + 0x01", () => {
     // [0x22, 0x01]
     const expected = sha256([0x22, 0x01]);
-    expect(modernHash(true)).toEqual(expected);
+    expect(hashBytesOf(true)).toEqual(expected);
   });
 
   it("false produces TAG_BOOLEAN + 0x00", () => {
     // [0x22, 0x00]
     const expected = sha256([0x22, 0x00]);
-    expect(modernHash(false)).toEqual(expected);
+    expect(hashBytesOf(false)).toEqual(expected);
   });
 
   it("true and false produce different hashes", () => {
-    expect(hex(modernHash(true))).not.toBe(hex(modernHash(false)));
+    expect(hex(hashBytesOf(true))).not.toBe(hex(hashBytesOf(false)));
   });
 
   // --- number ---
@@ -79,7 +79,7 @@ describe("hashOf()", () => {
       0x00,
       0x00,
     ]);
-    expect(modernHash(42)).toEqual(expected);
+    expect(hashBytesOf(42)).toEqual(expected);
   });
 
   it("0 produces TAG_NUMBER + all zeros", () => {
@@ -94,29 +94,29 @@ describe("hashOf()", () => {
       0x00,
       0x00,
     ]);
-    expect(modernHash(0)).toEqual(expected);
+    expect(hashBytesOf(0)).toEqual(expected);
   });
 
   it("-0 normalizes to +0 (same hash)", () => {
-    expect(modernHash(-0)).toEqual(modernHash(0));
+    expect(hashBytesOf(-0)).toEqual(hashBytesOf(0));
   });
 
   it("NaN throws", () => {
-    expect(() => modernHash(NaN)).toThrow("non-finite");
+    expect(() => hashBytesOf(NaN)).toThrow("non-finite");
   });
 
   it("Infinity throws", () => {
-    expect(() => modernHash(Infinity)).toThrow("non-finite");
+    expect(() => hashBytesOf(Infinity)).toThrow("non-finite");
   });
 
   it("-Infinity throws", () => {
-    expect(() => modernHash(-Infinity)).toThrow("non-finite");
+    expect(() => hashBytesOf(-Infinity)).toThrow("non-finite");
   });
 
   it("different numbers produce different hashes", () => {
-    expect(hex(modernHash(1))).not.toBe(hex(modernHash(2)));
-    expect(hex(modernHash(0))).not.toBe(hex(modernHash(1)));
-    expect(hex(modernHash(-1))).not.toBe(hex(modernHash(1)));
+    expect(hex(hashBytesOf(1))).not.toBe(hex(hashBytesOf(2)));
+    expect(hex(hashBytesOf(0))).not.toBe(hex(hashBytesOf(1)));
+    expect(hex(hashBytesOf(-1))).not.toBe(hex(hashBytesOf(1)));
   });
 
   it("Number.MAX_VALUE produces TAG_NUMBER + all-nonzero IEEE 754 bytes", () => {
@@ -133,7 +133,7 @@ describe("hashOf()", () => {
       0xff,
       0xff,
     ]);
-    expect(hex(modernHash(Number.MAX_VALUE))).toBe(hex(expected));
+    expect(hex(hashBytesOf(Number.MAX_VALUE))).toBe(hex(expected));
   });
 
   // --- string ---
@@ -150,25 +150,25 @@ describe("hashOf()", () => {
       0x6c,
       0x6f,
     ]);
-    expect(modernHash("hello")).toEqual(expected);
+    expect(hashBytesOf("hello")).toEqual(expected);
   });
 
   it("empty string produces TAG_STRING + zero length", () => {
     // LEB128(0) = [0x00]
     const expected = sha256([0x24, 0x00]);
-    expect(modernHash("")).toEqual(expected);
+    expect(hashBytesOf("")).toEqual(expected);
   });
 
   it("different strings produce different hashes", () => {
-    expect(hex(modernHash("a"))).not.toBe(hex(modernHash("b")));
-    expect(hex(modernHash(""))).not.toBe(hex(modernHash("a")));
+    expect(hex(hashBytesOf("a"))).not.toBe(hex(hashBytesOf("b")));
+    expect(hex(hashBytesOf(""))).not.toBe(hex(hashBytesOf("a")));
   });
 
   it("multi-byte UTF-8 characters encode correctly", () => {
     // Verify consistency (same value -> same hash)
-    expect(modernHash("\u00e9")).toEqual(modernHash("\u00e9"));
+    expect(hashBytesOf("\u00e9")).toEqual(hashBytesOf("\u00e9"));
     // e-acute is 2 bytes in UTF-8
-    expect(hex(modernHash("e"))).not.toBe(hex(modernHash("\u00e9")));
+    expect(hex(hashBytesOf("e"))).not.toBe(hex(hashBytesOf("\u00e9")));
   });
 
   it("surrogate pairs (emoji) encode correctly", () => {
@@ -183,7 +183,7 @@ describe("hashOf()", () => {
       0x04,
       ...utf8,
     ]);
-    expect(modernHash(emoji)).toEqual(expected);
+    expect(hashBytesOf(emoji)).toEqual(expected);
   });
 
   // --- bigint ---
@@ -191,45 +191,45 @@ describe("hashOf()", () => {
   it("0n encodes as TAG_BIGINT + LEB128 length 1 + [0x00]", () => {
     // LEB128(1) = [0x01]
     const expected = sha256([0x26, 0x01, 0x00]);
-    expect(modernHash(0n)).toEqual(expected);
+    expect(hashBytesOf(0n)).toEqual(expected);
   });
 
   it("127n encodes as 1 byte: 0x7F", () => {
     const expected = sha256([0x26, 0x01, 0x7f]);
-    expect(modernHash(127n)).toEqual(expected);
+    expect(hashBytesOf(127n)).toEqual(expected);
   });
 
   it("128n encodes as 2 bytes: 0x00, 0x80", () => {
     // 128 = 0x80, but high bit set means negative in two's complement,
     // so we need a leading 0x00. LEB128(2) = [0x02].
     const expected = sha256([0x26, 0x02, 0x00, 0x80]);
-    expect(modernHash(128n)).toEqual(expected);
+    expect(hashBytesOf(128n)).toEqual(expected);
   });
 
   it("-1n encodes as 1 byte: 0xFF", () => {
     const expected = sha256([0x26, 0x01, 0xff]);
-    expect(modernHash(-1n)).toEqual(expected);
+    expect(hashBytesOf(-1n)).toEqual(expected);
   });
 
   it("-128n encodes as 1 byte: 0x80", () => {
     const expected = sha256([0x26, 0x01, 0x80]);
-    expect(modernHash(-128n)).toEqual(expected);
+    expect(hashBytesOf(-128n)).toEqual(expected);
   });
 
   it("-129n encodes as 2 bytes: 0xFF, 0x7F", () => {
     const expected = sha256([0x26, 0x02, 0xff, 0x7f]);
-    expect(modernHash(-129n)).toEqual(expected);
+    expect(hashBytesOf(-129n)).toEqual(expected);
   });
 
   it("large bigint encodes correctly", () => {
     // 2^64 = 18446744073709551616n
     // hex: 10000000000000000 -> 9 bytes: 01 00 00 00 00 00 00 00 00
     const big = 2n ** 64n;
-    const hash = modernHash(big);
+    const hash = hashBytesOf(big);
     expect(hash.length).toBe(32); // SHA-256 produces 32 bytes
 
     // Verify it's consistent
-    expect(modernHash(big)).toEqual(hash);
+    expect(hashBytesOf(big)).toEqual(hash);
   });
 
   it("0x112233445566778899abcdefn matches hand-computed byte stream", () => {
@@ -251,7 +251,7 @@ describe("hashOf()", () => {
       0xcd,
       0xef,
     ]);
-    expect(hex(modernHash(0x112233445566778899abcdefn))).toBe(hex(expected));
+    expect(hex(hashBytesOf(0x112233445566778899abcdefn))).toBe(hex(expected));
   });
 
   it("-0x112233445566778899abcdefn matches hand-computed byte stream", () => {
@@ -276,7 +276,7 @@ describe("hashOf()", () => {
       0x32,
       0x11,
     ]);
-    expect(hex(modernHash(-0x112233445566778899abcdefn))).toBe(hex(expected));
+    expect(hex(hashBytesOf(-0x112233445566778899abcdefn))).toBe(hex(expected));
   });
 
   // --- undefined ---
@@ -284,24 +284,24 @@ describe("hashOf()", () => {
   it("undefined produces TAG_UNDEFINED", () => {
     // [0x21]
     const expected = sha256([0x21]);
-    expect(modernHash(undefined)).toEqual(expected);
+    expect(hashBytesOf(undefined)).toEqual(expected);
   });
 
   // --- cross-type distinctness ---
 
   it("null vs undefined vs false produce different hashes", () => {
-    const nullH = hex(modernHash(null));
-    const undefH = hex(modernHash(undefined));
-    const falseH = hex(modernHash(false));
+    const nullH = hex(hashBytesOf(null));
+    const undefH = hex(hashBytesOf(undefined));
+    const falseH = hex(hashBytesOf(false));
     expect(nullH).not.toBe(undefH);
     expect(nullH).not.toBe(falseH);
     expect(undefH).not.toBe(falseH);
   });
 
   it("number 0 vs bigint 0n vs string '0' are distinct", () => {
-    const numH = hex(modernHash(0));
-    const bigH = hex(modernHash(0n));
-    const strH = hex(modernHash("0"));
+    const numH = hex(hashBytesOf(0));
+    const bigH = hex(hashBytesOf(0n));
+    const strH = hex(hashBytesOf("0"));
     expect(numH).not.toBe(bigH);
     expect(numH).not.toBe(strH);
     expect(bigH).not.toBe(strH);
@@ -321,13 +321,13 @@ describe("hashOf()", () => {
       0x02,
       0x03,
     ]);
-    expect(modernHash(bytes)).toEqual(expected);
+    expect(hashBytesOf(bytes)).toEqual(expected);
   });
 
   it("empty FabricBytes produces TAG_BYTES + zero length", () => {
     const bytes = new FabricBytes(new Uint8Array([]));
     const expected = sha256([0x25, 0x00]);
-    expect(modernHash(bytes)).toEqual(expected);
+    expect(hashBytesOf(bytes)).toEqual(expected);
   });
 
   // =========================================================================
@@ -341,18 +341,18 @@ describe("hashOf()", () => {
       0x01,
       0x00,
     ]);
-    expect(modernHash(new FabricEpochNsec(0n))).toEqual(expected);
+    expect(hashBytesOf(new FabricEpochNsec(0n))).toEqual(expected);
   });
 
   it("FabricEpochNsec with different values differ", () => {
     const d1 = new FabricEpochNsec(0n);
     const d2 = new FabricEpochNsec(1704067200000000000n);
-    expect(hex(modernHash(d1))).not.toBe(hex(modernHash(d2)));
+    expect(hex(hashBytesOf(d1))).not.toBe(hex(hashBytesOf(d2)));
   });
 
   it("FabricEpochNsec with negative value (pre-epoch)", () => {
     const nsec = new FabricEpochNsec(-1000000000n);
-    const hash = modernHash(nsec);
+    const hash = hashBytesOf(nsec);
     expect(hash.length).toBe(32);
   });
 
@@ -367,18 +367,18 @@ describe("hashOf()", () => {
       0x01,
       0x00,
     ]);
-    expect(modernHash(new FabricEpochDays(0n))).toEqual(expected);
+    expect(hashBytesOf(new FabricEpochDays(0n))).toEqual(expected);
   });
 
   it("FabricEpochDays with different values differ", () => {
     const d1 = new FabricEpochDays(0n);
     const d2 = new FabricEpochDays(19723n);
-    expect(hex(modernHash(d1))).not.toBe(hex(modernHash(d2)));
+    expect(hex(hashBytesOf(d1))).not.toBe(hex(hashBytesOf(d2)));
   });
 
   it("FabricEpochDays with negative value (pre-epoch)", () => {
     const days = new FabricEpochDays(-365n);
-    const hash = modernHash(days);
+    const hash = hashBytesOf(days);
     expect(hash.length).toBe(32);
   });
 
@@ -386,7 +386,7 @@ describe("hashOf()", () => {
     // Same underlying value, different tag -> different hash
     const nsec = new FabricEpochNsec(100n);
     const days = new FabricEpochDays(100n);
-    expect(hex(modernHash(nsec))).not.toBe(hex(modernHash(days)));
+    expect(hex(hashBytesOf(nsec))).not.toBe(hex(hashBytesOf(days)));
   });
 
   // =========================================================================
@@ -442,19 +442,19 @@ describe("hashOf()", () => {
     stream.push(0x00);
 
     const expected = sha256(stream);
-    expect(modernHash(error)).toEqual(expected);
+    expect(hashBytesOf(error)).toEqual(expected);
   });
 
   it("different errors produce different hashes", () => {
     const e1 = new FabricError(new Error("hello"));
     const e2 = new FabricError(new Error("world"));
-    expect(hex(modernHash(e1))).not.toBe(hex(modernHash(e2)));
+    expect(hex(hashBytesOf(e1))).not.toBe(hex(hashBytesOf(e2)));
   });
 
   it("TypeError vs Error produce different hashes", () => {
     const e1 = new FabricError(new Error("msg"));
     const e2 = new FabricError(new TypeError("msg"));
-    expect(hex(modernHash(e1))).not.toBe(hex(modernHash(e2)));
+    expect(hex(hashBytesOf(e1))).not.toBe(hex(hashBytesOf(e2)));
   });
 
   // =========================================================================
@@ -463,7 +463,7 @@ describe("hashOf()", () => {
 
   it("empty array produces TAG_ARRAY + TAG_END", () => {
     const expected = sha256([0x10, 0x00]);
-    expect(modernHash([])).toEqual(expected);
+    expect(hashBytesOf([])).toEqual(expected);
   });
 
   it("sparse array [1, , 3] uses hole run-length encoding", () => {
@@ -502,7 +502,7 @@ describe("hashOf()", () => {
       0x00,
     ]);
     // deno-lint-ignore no-sparse-arrays
-    expect(modernHash([1, , 3])).toEqual(expected);
+    expect(hashBytesOf([1, , 3])).toEqual(expected);
   });
 
   it("multiple consecutive holes are coalesced into one run", () => {
@@ -510,7 +510,7 @@ describe("hashOf()", () => {
     const arr = new Array(5);
     arr[0] = 1;
     arr[4] = 5;
-    const hash = modernHash(arr);
+    const hash = hashBytesOf(arr);
 
     // Verify by building the expected byte stream manually
     const expected = sha256([
@@ -547,9 +547,9 @@ describe("hashOf()", () => {
 
   it("[1, undefined, 3] vs [1, , 3] vs [1, null, 3] are all distinct", () => {
     // deno-lint-ignore no-sparse-arrays
-    const sparseH = hex(modernHash([1, , 3]));
-    const undefH = hex(modernHash([1, undefined, 3]));
-    const nullH = hex(modernHash([1, null, 3]));
+    const sparseH = hex(hashBytesOf([1, , 3]));
+    const undefH = hex(hashBytesOf([1, undefined, 3]));
+    const nullH = hex(hashBytesOf([1, null, 3]));
 
     expect(sparseH).not.toBe(undefH);
     expect(sparseH).not.toBe(nullH);
@@ -557,10 +557,10 @@ describe("hashOf()", () => {
   });
 
   it("nested arrays are recursively hashed", () => {
-    const hash = modernHash([[1, 2], [3]]);
+    const hash = hashBytesOf([[1, 2], [3]]);
     expect(hash.length).toBe(32);
     // Different from flat array
-    expect(hex(hash)).not.toBe(hex(modernHash([1, 2, 3])));
+    expect(hex(hash)).not.toBe(hex(hashBytesOf([1, 2, 3])));
   });
 
   // =========================================================================
@@ -569,13 +569,13 @@ describe("hashOf()", () => {
 
   it("empty object produces TAG_OBJECT + TAG_END", () => {
     const expected = sha256([0x11, 0x00]);
-    expect(modernHash({})).toEqual(expected);
+    expect(hashBytesOf({})).toEqual(expected);
   });
 
   it("object key order is deterministic (sorted by UTF-8)", () => {
     // Keys inserted in different orders produce the same hash.
-    const h1 = modernHash({ a: 1, b: 2 });
-    const h2 = modernHash({ b: 2, a: 1 });
+    const h1 = hashBytesOf({ a: 1, b: 2 });
+    const h2 = hashBytesOf({ b: 2, a: 1 });
     expect(h1).toEqual(h2);
   });
 
@@ -616,17 +616,17 @@ describe("hashOf()", () => {
       // TAG_END
       0x00,
     ]);
-    expect(modernHash({ a: 1, b: 2 })).toEqual(expected);
+    expect(hashBytesOf({ a: 1, b: 2 })).toEqual(expected);
   });
 
   it("nested objects are recursively hashed", () => {
-    const hash = modernHash({ x: { y: 1 } });
+    const hash = hashBytesOf({ x: { y: 1 } });
     expect(hash.length).toBe(32);
-    expect(hex(hash)).not.toBe(hex(modernHash({ x: 1 })));
+    expect(hex(hash)).not.toBe(hex(hashBytesOf({ x: 1 })));
   });
 
   it("object with mixed value types", () => {
-    const hash = modernHash({
+    const hash = hashBytesOf({
       str: "hello",
       num: 42,
       bool: true,
@@ -635,7 +635,7 @@ describe("hashOf()", () => {
     expect(hash.length).toBe(32);
     // Consistency
     expect(hash).toEqual(
-      modernHash({ str: "hello", num: 42, bool: true, nil: null }),
+      hashBytesOf({ str: "hello", num: 42, bool: true, nil: null }),
     );
   });
 
@@ -644,10 +644,10 @@ describe("hashOf()", () => {
   // =========================================================================
 
   it("same value always produces the same hash", () => {
-    expect(modernHash(42)).toEqual(modernHash(42));
-    expect(modernHash("hello")).toEqual(modernHash("hello"));
-    expect(modernHash([1, 2, 3])).toEqual(modernHash([1, 2, 3]));
-    expect(modernHash({ a: 1 })).toEqual(modernHash({ a: 1 }));
+    expect(hashBytesOf(42)).toEqual(hashBytesOf(42));
+    expect(hashBytesOf("hello")).toEqual(hashBytesOf("hello"));
+    expect(hashBytesOf([1, 2, 3])).toEqual(hashBytesOf([1, 2, 3]));
+    expect(hashBytesOf({ a: 1 })).toEqual(hashBytesOf({ a: 1 }));
   });
 
   it("all hashes are 32 bytes (SHA-256)", () => {
@@ -672,21 +672,21 @@ describe("hashOf()", () => {
       new FabricError(new Error("x")),
     ];
     for (const v of values) {
-      expect(modernHash(v).length).toBe(32);
+      expect(hashBytesOf(v).length).toBe(32);
     }
   });
 
   it("different values of different types produce different hashes", () => {
     const hashes = new Set([
-      hex(modernHash(null)),
-      hex(modernHash(true)),
-      hex(modernHash(false)),
-      hex(modernHash(0)),
-      hex(modernHash("")),
-      hex(modernHash(0n)),
-      hex(modernHash(undefined)),
-      hex(modernHash([])),
-      hex(modernHash({})),
+      hex(hashBytesOf(null)),
+      hex(hashBytesOf(true)),
+      hex(hashBytesOf(false)),
+      hex(hashBytesOf(0)),
+      hex(hashBytesOf("")),
+      hex(hashBytesOf(0n)),
+      hex(hashBytesOf(undefined)),
+      hex(hashBytesOf([])),
+      hex(hashBytesOf({})),
     ]);
     // All 9 should be distinct.
     expect(hashes.size).toBe(9);
@@ -698,14 +698,14 @@ describe("hashOf()", () => {
 
   it("deeply nested structure", () => {
     const deep = { a: { b: { c: { d: [1, { e: true }] } } } };
-    const hash = modernHash(deep);
+    const hash = hashBytesOf(deep);
     expect(hash.length).toBe(32);
-    expect(modernHash(deep)).toEqual(hash);
+    expect(hashBytesOf(deep)).toEqual(hash);
   });
 
   it("array with all holes", () => {
     const arr = new Array(5); // all holes
-    const hash = modernHash(arr);
+    const hash = hashBytesOf(arr);
     expect(hash.length).toBe(32);
 
     // TAG_ARRAY + TAG_HOLE + LEB128(5) + TAG_END
@@ -720,8 +720,8 @@ describe("hashOf()", () => {
 
   it("object with non-ASCII keys sorts by UTF-8 bytes", () => {
     // Keys with non-ASCII should sort by UTF-8 byte values.
-    const h1 = modernHash({ "\u00e9": 1, "a": 2 });
-    const h2 = modernHash({ "a": 2, "\u00e9": 1 });
+    const h1 = hashBytesOf({ "\u00e9": 1, "a": 2 });
+    const h2 = hashBytesOf({ "a": 2, "\u00e9": 1 });
     expect(h1).toEqual(h2);
   });
 
@@ -788,7 +788,7 @@ describe("hashOf()", () => {
       // TAG_END
       0x00,
     ]);
-    expect(modernHash(obj)).toEqual(expected);
+    expect(hashBytesOf(obj)).toEqual(expected);
 
     // Also verify the wrong (UTF-16) order produces a different hash.
     const wrongOrder = sha256([
@@ -827,7 +827,7 @@ describe("hashOf()", () => {
       // TAG_END
       0x00,
     ]);
-    expect(hex(modernHash(obj))).not.toBe(hex(wrongOrder));
+    expect(hex(hashBytesOf(obj))).not.toBe(hex(wrongOrder));
   });
 
   // =========================================================================
@@ -856,14 +856,14 @@ describe("hashOf()", () => {
       0xBE,
       0xEF,
     ]);
-    expect(hex(modernHash(cid))).toBe(hex(expected));
+    expect(hex(hashBytesOf(cid))).toBe(hex(expected));
   });
 
   it("FabricHash with different algorithm tags produce different hashes", () => {
     const bytes = new Uint8Array([0x01, 0x02, 0x03]);
     const cid1 = new FabricHash(bytes, "fid1");
     const cid2 = new FabricHash(bytes, "fid2");
-    expect(hex(modernHash(cid1))).not.toBe(hex(modernHash(cid2)));
+    expect(hex(hashBytesOf(cid1))).not.toBe(hex(hashBytesOf(cid2)));
   });
 
   it("FabricHash with different hash bytes produce different hashes", () => {
@@ -875,7 +875,7 @@ describe("hashOf()", () => {
       new Uint8Array([0x03, 0x04]),
       "fid1",
     );
-    expect(hex(modernHash(cid1))).not.toBe(hex(modernHash(cid2)));
+    expect(hex(hashBytesOf(cid1))).not.toBe(hex(hashBytesOf(cid2)));
   });
 
   it("FabricHash in a plain object works (doesn't `throw`)", () => {
@@ -996,64 +996,64 @@ describe("hashOf() native instances", () => {
 
   it("native Date hashes without throwing", () => {
     const date = new Date("2024-01-01T00:00:00Z");
-    const hash = modernHash(date);
+    const hash = hashBytesOf(date);
     expect(hash.length).toBe(32);
   });
 
   it("native Date produces same hash as equivalent FabricEpochNsec", () => {
     const date = new Date("2024-01-01T00:00:00Z");
     const nsec = BigInt(date.getTime()) * 1_000_000n;
-    const dateHash = hex(modernHash(date));
-    const epochHash = hex(modernHash(new FabricEpochNsec(nsec)));
+    const dateHash = hex(hashBytesOf(date));
+    const epochHash = hex(hashBytesOf(new FabricEpochNsec(nsec)));
     expect(dateHash).toBe(epochHash);
   });
 
   it("different Dates produce different hashes", () => {
     const d1 = new Date("2024-01-01T00:00:00Z");
     const d2 = new Date("2025-06-15T12:00:00Z");
-    expect(hex(modernHash(d1))).not.toBe(hex(modernHash(d2)));
+    expect(hex(hashBytesOf(d1))).not.toBe(hex(hashBytesOf(d2)));
   });
 
   // --- RegExp ---
 
   it("native RegExp hashes without throwing", () => {
     const re = /hello/gi;
-    const hash = modernHash(re);
+    const hash = hashBytesOf(re);
     expect(hash.length).toBe(32);
   });
 
   it("native RegExp produces same hash as equivalent FabricRegExp", () => {
     const re = /hello/gi;
-    const nativeHash = hex(modernHash(re));
-    const fabricHash = hex(modernHash(new FabricRegExp(re)));
+    const nativeHash = hex(hashBytesOf(re));
+    const fabricHash = hex(hashBytesOf(new FabricRegExp(re)));
     expect(nativeHash).toBe(fabricHash);
   });
 
   it("different RegExps produce different hashes", () => {
     const r1 = /foo/;
     const r2 = /bar/;
-    expect(hex(modernHash(r1))).not.toBe(hex(modernHash(r2)));
+    expect(hex(hashBytesOf(r1))).not.toBe(hex(hashBytesOf(r2)));
   });
 
   // --- Uint8Array ---
 
   it("native Uint8Array hashes without throwing", () => {
     const buf = new Uint8Array([1, 2, 3]);
-    const hash = modernHash(buf);
+    const hash = hashBytesOf(buf);
     expect(hash.length).toBe(32);
   });
 
   it("native Uint8Array produces same hash as FabricBytes with same bytes", () => {
     const bytes = new Uint8Array([10, 20, 30]);
-    const nativeHash = hex(modernHash(bytes));
-    const fabricHash = hex(modernHash(new FabricBytes(bytes)));
+    const nativeHash = hex(hashBytesOf(bytes));
+    const fabricHash = hex(hashBytesOf(new FabricBytes(bytes)));
     expect(nativeHash).toBe(fabricHash);
   });
 
   it("different Uint8Arrays produce different hashes", () => {
     const b1 = new Uint8Array([1, 2, 3]);
     const b2 = new Uint8Array([4, 5, 6]);
-    expect(hex(modernHash(b1))).not.toBe(hex(modernHash(b2)));
+    expect(hex(hashBytesOf(b1))).not.toBe(hex(hashBytesOf(b2)));
   });
 
   // --- Deferred types (not yet handled — these document known gaps) ---

--- a/packages/data-model/value-hash-modern.ts
+++ b/packages/data-model/value-hash-modern.ts
@@ -243,7 +243,7 @@ function feedValue(hasher: IncrementalHasher, value: unknown): void {
     case "number":
       if (!Number.isFinite(value)) {
         throw new Error(
-          `hashOfModern: non-finite number not allowed: ${value}`,
+          `hashOf: non-finite number not allowed: ${value}`,
         );
       }
       hasher.update(TAG_NUMBER_BYTES);
@@ -279,7 +279,7 @@ function feedValue(hasher: IncrementalHasher, value: unknown): void {
 
     default:
       throw new Error(
-        `hashOfModern: unsupported type: ${typeof value}`,
+        `hashOf: unsupported type: ${typeof value}`,
       );
   }
 }
@@ -351,7 +351,7 @@ function feedObjectValue(
       const typeTag = (value as { typeTag?: unknown }).typeTag;
       if (typeof typeTag !== "string") {
         throw new Error(
-          `hashOfModern: FabricInstance missing typeTag property`,
+          `hashOf: FabricInstance missing typeTag property`,
         );
       }
       hasher.update(getStringRep(typeTag));
@@ -374,7 +374,7 @@ function feedObjectValue(
       // Nothing else is handled. As of this writing, specifically missing are
       // `Map`, `Set`, `Error`, and `HasToJSON`.
       throw new Error(
-        `hashOfModern: unsupported object type: ${
+        `hashOf: unsupported object type: ${
           value?.constructor?.name ?? typeof value
         }`,
       );

--- a/packages/data-model/value-hash.ts
+++ b/packages/data-model/value-hash.ts
@@ -4,15 +4,24 @@
  * Re-exports the modern (`value-hash-modern.ts`) implementation under the
  * stable name `hashOf`.
  */
-import { hashOfModern } from "./value-hash-modern.ts";
+import { hashOfModern, hashOfModernAsString } from "./value-hash-modern.ts";
 import { FabricHash } from "./fabric-hash.ts";
 import type { FabricValue } from "./interface.ts";
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
+/**
+ * Computes the SHA-256 hash of a `FabricValue`. Returns a `FabricHash` with
+ * algorithm tag `fid1` ("Fabric ID, Version 1").
+ *
+ * Caches results for primitives (LRU) and deep-frozen objects (`WeakMap`).
+ */
+export function hashOf(value: FabricValue): FabricHash {
+  return hashOfModern(value);
+}
 
-/** Compute a content hash for the given source value. */
-export function hashOf(source: FabricValue): FabricHash {
-  return hashOfModern(source);
+/**
+ * Like `hashOf()`, except always returns a plain string of the hash, encoded as
+ * base64url (no `<type>:` prefix).
+ */
+export function hashStringOf(value: FabricValue): string {
+  return hashOfModernAsString(value);
 }

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -402,8 +402,7 @@ export const toValuePath = (path: readonly string[]): ValuePath =>
  * schema path selector. The result is interned-and-frozen via
  * `internPathSelector`, so callers can feed it directly to
  * `MapSetStringToPathSelectors` (or any other `hashSchemaItem`-keyed
- * cache) and get the `hashOfModernInternal` WeakMap fast-path on
- * repeat hashes.
+ * cache) and get the `hashOf()` `WeakMap` fast-path on repeat hashes.
  */
 export const toDocumentSelector = (
   selector: Pick<SchemaPathSelector, "path" | "schema">,

--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -1,4 +1,4 @@
-import { hashOfModernAsString } from "@commonfabric/data-model/value-hash-modern";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { encodePointer } from "../../../memory/v2/path.ts";
 import { stableHash } from "../traverse.ts";
 import type {
@@ -129,4 +129,4 @@ export const canonicalizePreparedDigestInput = (
 });
 
 export const preparedDigestFor = (input: PreparedDigestInput): string =>
-  hashOfModernAsString(canonicalizePreparedDigestInput(input));
+  hashStringOf(canonicalizePreparedDigestInput(input));

--- a/scripts/benchmark-object-hashing/main.ts
+++ b/scripts/benchmark-object-hashing/main.ts
@@ -12,7 +12,7 @@
  */
 
 // Import our own hasher for comparison
-import { hashOfModernAsString } from "../../packages/data-model/value-hash-modern.ts";
+import { hashStringOf } from "../../packages/data-model/value-hash.ts";
 
 // Import libraries from esm.sh to avoid adding dependencies
 // @ts-ignore - dynamic import from esm.sh
@@ -915,9 +915,9 @@ async function createStrategies() {
     return cid.toString();
   };
 
-  // hashOfModernAsString (our own hasher)
-  strategies["hashOfModernAsString"] = (obj: any) => {
-    return hashOfModernAsString(obj);
+  // hashStringOf (our own hasher)
+  strategies["hashStringOf"] = (obj: any) => {
+    return hashStringOf(obj);
   };
 
   return strategies;


### PR DESCRIPTION
## Summary

Tidies the hash entry points now that the legacy/modern dispatch is gone, so the only names callers (and docs) use are the public ones from `value-hash.ts`.

- Stop reaching into `value-hash-modern.ts` from outside `data-model`. Callers in `memory/`, `runner/`, the schema-hash files, and the benchmark script were still importing `hashOfModern` / `hashOfModernAsString` directly; those now go through `value-hash.ts`.
- Rename the public exports to drop the now-vestigial `Modern` qualifier:
  - `hashOfModern` → `hashOf`
  - `hashOfModernAsString` → `hashStringOf`
- Internal error messages and spec/doc pseudocode (in `1-fabric-values.md` and `2-hash-byte-format.md`) updated to match the new names.
- Test helper in `value-hash-modern.test.ts` renamed to `hashBytesOf()` for consistency.

Sets us up to merge `value-hash-modern.ts`'s contents back into `value-hash.ts` in a future PR (preparation noted in one of the commits).

Net: 13 files, +220/-220, no behavioral change.

## Test plan

- [x] `deno task test` from the repo root — all 34 packages green locally
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
