### PR TITLE
fix(fuse): Fix various FUSE review findings

### DIFF
--- a/docs/specs/fuse-filesystem/4-read-write.md
+++ b/docs/specs/fuse-filesystem/4-read-write.md
@@ -95,8 +95,12 @@ target path parsing rules and examples.
    [JSON Mapping](./3-json-mapping.md#type-preservation-on-write)).
 3. Construct a cell write: navigate to the parent object/array, set the
    key/index to the new value.
-4. Execute via `cell.set()` or `cell.update()`.
-5. Wait for the write to be acknowledged before returning from `flush`.
+4. Validate deterministic local policy first. Invalid sizes, invalid JSON, and
+   CFC/writeback denials fail immediately.
+5. Return success from `flush` after the mutation has been accepted into the
+   local write pipeline. The backend cell write is optimistic and may complete
+   after the syscall returns; later conflicts or transport failures are exposed
+   through mount status, logs, and CFC writeback reconciliation.
 
 ### `write` to `.json` File
 
@@ -104,7 +108,8 @@ target path parsing rules and examples.
 2. On flush: parse the buffer as JSON.
 3. If the path is `result.json`, replace the entire result cell.
 4. If the path is `result/items/0.json`, replace just that subtree.
-5. Execute via `cell.set()` at the appropriate path.
+5. Queue `cell.set()` at the appropriate path using the same optimistic
+   acknowledgement contract as scalar writes.
 
 ### `write` to `.handler` File
 
@@ -114,7 +119,8 @@ target path parsing rules and examples.
    handler writes elsewhere in FUSE.
 4. Deduplicate `flush`/`release` so one buffered write triggers one handler
    invocation.
-5. Return success after the write has been handed to the runtime.
+5. Return success after the write has been handed to the runtime, subject to
+   immediate local/CFC validation failures.
 
 Handlers remain writable so legacy flows like
 `echo '{"message":"hi"}' > result/addItem.handler` keep working.
@@ -206,7 +212,9 @@ Cross-cell renames (moving between `input/` and `result/`) are rejected with
 ### `truncate`
 
 Truncating a file to 0 bytes sets the value to an empty string (`""`).
-Truncating a `.json` file to 0 is an error (`EINVAL`).
+Truncating a `.json` file to 0 is an error (`EINVAL`). Path-based truncate
+without a file handle must either queue the same writeback as handle-based
+truncate or fail immediately; it must not be memory-only.
 
 ## Atomicity
 
@@ -226,8 +234,10 @@ updates, write to the appropriate `.json` file instead.
 | Permission denied | `EACCES` |
 | Write to read-only cell | `EROFS` |
 | Invalid JSON on write | `EINVAL` |
+| Invalid offset/size | `EINVAL` |
+| Exceeds virtual file size limit | `EFBIG` |
 | Cross-cell rename | `EXDEV` |
-| Network/timeout | `EIO` |
+| Immediate network/timeout before local acceptance | `EIO` |
 | Space not available | `ENOENT` |
 
 ---

--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -60,11 +60,32 @@ export type HarnessCfcSubstrateStatus =
 
 export type HarnessCfcMountStatus = "configured" | "not-configured";
 
+export type HarnessFabricStatusProbeStatus =
+  | "not-probed"
+  | "missing"
+  | "present"
+  | "invalid";
+
+export type HarnessFabricWriteGovernancePolicy =
+  | "not-configured"
+  | "host-read-only"
+  | "host-writable-non-strict"
+  | "host-writable-cfc-strict-attested"
+  | "host-writable-cfc-strict-unattested";
+
+export interface HarnessFabricWriteGovernanceSnapshot {
+  policy: HarnessFabricWriteGovernancePolicy;
+  statusProbe: HarnessFabricStatusProbeStatus;
+  delegatedToCfc: boolean;
+  attestedMode?: CfcEnforcementMode;
+}
+
 export interface HarnessCfcMountSnapshot {
   kind: SandboxRuntimeMountKind;
   status: HarnessCfcMountStatus;
   sandboxPath: string;
   readOnly?: boolean;
+  writeGovernance?: HarnessFabricWriteGovernanceSnapshot;
 }
 
 export interface HarnessCfcCapabilitySnapshot {
@@ -132,6 +153,8 @@ export interface ClassifyHarnessRunErrorOptions {
 }
 
 export const CAPABILITY_PROBE_SENTINEL = "__CF_HARNESS_CAPABILITY_PROBE__";
+export const FABRIC_STATUS_PROBE_SENTINEL =
+  "__CF_HARNESS_FABRIC_STATUS_PROBE__";
 
 const CAPABILITY_PROBE_SCRIPT = [
   `# ${CAPABILITY_PROBE_SENTINEL}`,
@@ -148,6 +171,23 @@ const CAPABILITY_PROBE_SCRIPT = [
   "}",
   ...HARNESS_CAPABILITY_COMMANDS.map((command) => `probe ${command}`),
 ].join("\n");
+
+const shellSingleQuote = (value: string): string =>
+  `'${value.replaceAll("'", "'\\''")}'`;
+
+const createFabricStatusProbeScript = (sandboxPath: string): string =>
+  [
+    `# ${FABRIC_STATUS_PROBE_SENTINEL}`,
+    "set +e",
+    `status_file=${shellSingleQuote(`${sandboxPath}/.status`)}`,
+    'if [ -r "$status_file" ]; then',
+    "  printf 'present\\t'",
+    '  cat "$status_file"',
+    "  printf '\\n'",
+    "else",
+    "  printf 'missing\\t\\n'",
+    "fi",
+  ].join("\n");
 
 const isHarnessCapabilityCommand = (
   input: string,
@@ -168,6 +208,12 @@ const createEmptyCapabilitySnapshot = (
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isCfcEnforcementMode = (
+  value: unknown,
+): value is CfcEnforcementMode =>
+  value === "disabled" || value === "observe" ||
+  value === "enforce-explicit" || value === "enforce-strict";
 
 const isFailedDelegateTaskOutput = (
   output: unknown,
@@ -259,6 +305,7 @@ const findMountDescription = (
 
 const createCfcMountSnapshots = (
   sandboxDescription: SandboxRuntimeDescription,
+  mode: CfcEnforcementMode,
 ): HarnessCfcCapabilitySnapshot["mounts"] => {
   const workspaceMount = findMountDescription(
     sandboxDescription.cfc?.mounts,
@@ -283,12 +330,95 @@ const createCfcMountSnapshots = (
         status: "configured",
         sandboxPath: fabricMount.sandboxPath,
         readOnly: fabricMount.readOnly,
+        writeGovernance: createFabricWriteGovernance({
+          mode,
+          readOnly: fabricMount.readOnly,
+          statusProbe: "not-probed",
+        }),
       }
       : {
         kind: "fabric-fuse",
         status: "not-configured",
         sandboxPath: "/fabric",
+        writeGovernance: {
+          policy: "not-configured",
+          statusProbe: "not-probed",
+          delegatedToCfc: false,
+        },
       },
+  };
+};
+
+interface FabricStatusProbeResult {
+  statusProbe: HarnessFabricStatusProbeStatus;
+  attestedMode?: CfcEnforcementMode;
+}
+
+const parseFabricStatusProbeOutput = (
+  stdout: string,
+): FabricStatusProbeResult => {
+  const trimmed = stdout.trimEnd();
+  const separator = trimmed.indexOf("\t");
+  const status = separator === -1 ? trimmed : trimmed.slice(0, separator);
+  const payload = separator === -1 ? "" : trimmed.slice(separator + 1).trim();
+  if (status === "missing") {
+    return { statusProbe: "missing" };
+  }
+  if (status !== "present") {
+    return { statusProbe: "invalid" };
+  }
+  try {
+    const parsed = JSON.parse(payload);
+    const cfc = isRecord(parsed) ? parsed.cfc : undefined;
+    const mode = isRecord(cfc) ? cfc.mode : undefined;
+    return {
+      statusProbe: "present",
+      ...(isCfcEnforcementMode(mode) ? { attestedMode: mode } : {}),
+    };
+  } catch {
+    return { statusProbe: "invalid" };
+  }
+};
+
+const createFabricWriteGovernance = (options: {
+  mode: CfcEnforcementMode;
+  readOnly: boolean;
+  statusProbe: HarnessFabricStatusProbeStatus;
+  attestedMode?: CfcEnforcementMode;
+}): HarnessFabricWriteGovernanceSnapshot => {
+  if (options.readOnly) {
+    return {
+      policy: "host-read-only",
+      statusProbe: options.statusProbe,
+      delegatedToCfc: false,
+      ...(options.attestedMode !== undefined
+        ? { attestedMode: options.attestedMode }
+        : {}),
+    };
+  }
+
+  if (options.mode !== "enforce-strict") {
+    return {
+      policy: "host-writable-non-strict",
+      statusProbe: options.statusProbe,
+      delegatedToCfc: false,
+      ...(options.attestedMode !== undefined
+        ? { attestedMode: options.attestedMode }
+        : {}),
+    };
+  }
+
+  const strictAttested = options.statusProbe === "present" &&
+    options.attestedMode === "enforce-strict";
+  return {
+    policy: strictAttested
+      ? "host-writable-cfc-strict-attested"
+      : "host-writable-cfc-strict-unattested",
+    statusProbe: options.statusProbe,
+    delegatedToCfc: true,
+    ...(options.attestedMode !== undefined
+      ? { attestedMode: options.attestedMode }
+      : {}),
   };
 };
 
@@ -316,7 +446,7 @@ const createCfcCapabilitySnapshot = (
         : {}),
     },
     sandbox: sandboxDescription,
-    mounts: createCfcMountSnapshots(sandboxDescription),
+    mounts: createCfcMountSnapshots(sandboxDescription, mode),
     protectedXattrs: {
       expectedSandboxVisible: false,
       sandboxVisibility: "not-probed",
@@ -348,7 +478,23 @@ export const collectHarnessCapabilitySnapshot = async (
       }`,
     );
   }
-  return parseCapabilityProbeOutput(result.stdout, at, cfc);
+  const snapshot = parseCapabilityProbeOutput(result.stdout, at, cfc);
+  const fabricMount = snapshot.cfc.mounts.fabric;
+  if (fabricMount.status === "configured") {
+    const fabricStatus = await sandbox.runShell({
+      command: createFabricStatusProbeScript(fabricMount.sandboxPath),
+      cwd,
+    });
+    const statusProbe = fabricStatus.exitCode === 0
+      ? parseFabricStatusProbeOutput(fabricStatus.stdout)
+      : { statusProbe: "invalid" as const };
+    fabricMount.writeGovernance = createFabricWriteGovernance({
+      mode: snapshot.cfc.enforcementMode,
+      readOnly: fabricMount.readOnly ?? false,
+      ...statusProbe,
+    });
+  }
+  return snapshot;
 };
 
 export const createHarnessFailureRecord = (

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -184,6 +184,11 @@ Deno.test({
                 kind: "fabric-fuse",
                 status: "not-configured",
                 sandboxPath: "/fabric",
+                writeGovernance: {
+                  policy: "not-configured",
+                  statusProbe: "not-probed",
+                  delegatedToCfc: false,
+                },
               },
             },
             protectedXattrs: {

--- a/packages/cf-harness/test/diagnostics.test.ts
+++ b/packages/cf-harness/test/diagnostics.test.ts
@@ -8,6 +8,7 @@ import {
   classifyHarnessRunError,
   collectHarnessCapabilitySnapshot,
   createHarnessFailureRecord,
+  FABRIC_STATUS_PROBE_SENTINEL,
   selectPrimaryHarnessFailure,
 } from "../src/diagnostics.ts";
 import { createHarnessPolicyEvent } from "../src/contracts/policy.ts";
@@ -60,6 +61,27 @@ class FakeSandboxRuntime implements SandboxRuntime {
 }
 
 class FakeFabricSandboxRuntime extends FakeSandboxRuntime {
+  constructor(private readonly fabricStatusJson?: string) {
+    super();
+  }
+
+  override runShell(
+    request: SandboxShellRequest,
+  ): Promise<SandboxCommandResult> {
+    if (request.command.includes(FABRIC_STATUS_PROBE_SENTINEL)) {
+      return Promise.resolve(
+        this.fabricStatusJson === undefined
+          ? { stdout: "missing\t\n", stderr: "", exitCode: 0 }
+          : {
+            stdout: `present\t${this.fabricStatusJson}\n`,
+            stderr: "",
+            exitCode: 0,
+          },
+      );
+    }
+    return super.runShell(request);
+  }
+
   describe(): SandboxRuntimeDescription {
     return {
       kind: "docker-runsc-cfc",
@@ -111,6 +133,11 @@ Deno.test("collectHarnessCapabilitySnapshot captures fixed sandbox capabilities"
           kind: "fabric-fuse",
           status: "not-configured",
           sandboxPath: "/fabric",
+          writeGovernance: {
+            policy: "not-configured",
+            statusProbe: "not-probed",
+            delegatedToCfc: false,
+          },
         },
       },
       protectedXattrs: {
@@ -169,7 +196,45 @@ Deno.test("collectHarnessCapabilitySnapshot reports configured Fabric mounts", a
       status: "configured",
       sandboxPath: "/fabric",
       readOnly: false,
+      writeGovernance: {
+        policy: "host-writable-non-strict",
+        statusProbe: "missing",
+        delegatedToCfc: false,
+      },
     },
+  });
+});
+
+Deno.test("collectHarnessCapabilitySnapshot records strict CFC attestation for writable Fabric mounts", async () => {
+  const snapshot = await collectHarnessCapabilitySnapshot(
+    new FakeFabricSandboxRuntime(
+      JSON.stringify({ cfc: { mode: "enforce-strict" } }),
+    ),
+    "/workspace",
+    "2026-04-29T23:05:00.000Z",
+    { cfcEnforcementMode: "enforce-strict" },
+  );
+
+  assertEquals(snapshot.cfc.mounts.fabric.writeGovernance, {
+    policy: "host-writable-cfc-strict-attested",
+    statusProbe: "present",
+    delegatedToCfc: true,
+    attestedMode: "enforce-strict",
+  });
+});
+
+Deno.test("collectHarnessCapabilitySnapshot records strict writable Fabric mounts without attestation", async () => {
+  const snapshot = await collectHarnessCapabilitySnapshot(
+    new FakeFabricSandboxRuntime(),
+    "/workspace",
+    "2026-04-29T23:10:00.000Z",
+    { cfcEnforcementMode: "enforce-strict" },
+  );
+
+  assertEquals(snapshot.cfc.mounts.fabric.writeGovernance, {
+    policy: "host-writable-cfc-strict-unattested",
+    statusProbe: "missing",
+    delegatedToCfc: true,
   });
 });
 

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -85,16 +85,46 @@ wait_for_path() {
   error "Timed out waiting for path: $path"
 }
 
+fuse_encode_component() {
+  local value="$1"
+  value="${value//%/%25}"
+  value="${value//:/%3A}"
+  value="${value//\//%2F}"
+  if [[ "$value" == .* ]]; then
+    value="%2E${value:1}"
+  fi
+  printf '%s\n' "$value"
+}
+
 resolve_entity_dir() {
   local entities_dir="$1"
-  local bare_id="$2"
+  local entity_id="$2"
   local timeout_seconds="${3:-20}"
   local started_at
   started_at=$(date +%s)
+  local bare_id="${entity_id#of:}"
   local canonical_entity_dir="$entities_dir/of:$bare_id"
   local bare_entity_dir="$entities_dir/$bare_id"
+  local encoded_entity_dir="$entities_dir/$(fuse_encode_component "$entity_id")"
+  local encoded_canonical_entity_dir="$entities_dir/$(fuse_encode_component "of:$bare_id")"
+  local encoded_bare_entity_dir="$entities_dir/$(fuse_encode_component "$bare_id")"
 
   while true; do
+    if path_exists "$encoded_entity_dir" 1; then
+      printf '%s\n' "$encoded_entity_dir"
+      return 0
+    fi
+
+    if path_exists "$encoded_canonical_entity_dir" 1; then
+      printf '%s\n' "$encoded_canonical_entity_dir"
+      return 0
+    fi
+
+    if path_exists "$encoded_bare_entity_dir" 1; then
+      printf '%s\n' "$encoded_bare_entity_dir"
+      return 0
+    fi
+
     if path_exists "$canonical_entity_dir" 1; then
       printf '%s\n' "$canonical_entity_dir"
       return 0
@@ -210,7 +240,7 @@ PIECE_ID=$(cf piece new --main-export "$CUSTOM_EXPORT" $SPACE_ARGS "$PATTERN_SRC
 echo "Created piece: $PIECE_ID"
 cf piece step $SPACE_ARGS --piece "$PIECE_ID"
 echo "Stepped piece: $PIECE_ID"
-MOUNT_OUTPUT=$(cf fuse mount "$MOUNTPOINT" --api-url="$API_URL" --identity="$IDENTITY" --background)
+MOUNT_OUTPUT=$(cf fuse mount "$MOUNTPOINT" --api-url="$API_URL" --identity="$IDENTITY" --space="$SPACE" --background)
 echo "$MOUNT_OUTPUT"
 
 MOUNT_PID="${MOUNT_OUTPUT#*PID }"
@@ -255,9 +285,9 @@ ENTITY_BARE_ID="${ENTITY_ID#of:}"
 ENTITY_DEEP_PROBE="${FUSE_DEEP_ENTITY_PROBE:-0}"
 ENTITIES_DIR="$MOUNTPOINT/$SPACE/entities"
 wait_for_path "$ENTITIES_DIR"
-ENTITY_DIR=$(resolve_entity_dir "$ENTITIES_DIR" "$ENTITY_BARE_ID" 20 || true)
+ENTITY_DIR=$(resolve_entity_dir "$ENTITIES_DIR" "$ENTITY_ID" 20 || true)
 if [ -z "$ENTITY_DIR" ]; then
-  error "Timed out waiting for entity directory entry for $ENTITY_BARE_ID."
+  error "Timed out waiting for entity directory entry for $ENTITY_ID."
 fi
 
 HANDLER_FILE="$RESULT_DIR/recordMessage.handler"

--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -268,6 +268,8 @@ wait_for_path "$MOUNTPOINT/$SPACE/pieces"
 
 PIECE_NAME="Fuse-Exec-Fixture"
 PIECE_DIR="$MOUNTPOINT/$SPACE/pieces/$PIECE_NAME"
+INPUT_DIR="$PIECE_DIR/input"
+INPUT_LAST_MESSAGE="$INPUT_DIR/lastMessage"
 RESULT_DIR="$PIECE_DIR/result"
 RESULT_JSON="$PIECE_DIR/result.json"
 META_JSON="$PIECE_DIR/meta.json"
@@ -448,5 +450,18 @@ LEGACY_COUNT_BEFORE=$(read_piece_value_or_default "legacyCount" "0")
 echo '{}' > "$LEGACY_HANDLER_FILE"
 wait_for_piece_value "legacyCount" "$((LEGACY_COUNT_BEFORE + 1))"
 success "Legacy handler write-through still works"
+
+wait_for_path "$INPUT_LAST_MESSAGE"
+exec 9<> "$INPUT_LAST_MESSAGE"
+printf 'open-stale' >&9
+: > "$INPUT_LAST_MESSAGE"
+exec 9>&-
+wait_for_piece_value "lastMessage" '""'
+sleep 0.5
+LAST_MESSAGE_AFTER_TRUNCATE=$(cf piece get $SPACE_ARGS --piece "$PIECE_ID" "lastMessage" 2>/dev/null || true)
+if [ "$LAST_MESSAGE_AFTER_TRUNCATE" != '""' ]; then
+  error "Path truncate should not be undone by a stale open file handle. Got: $LAST_MESSAGE_AFTER_TRUNCATE"
+fi
+success "Path truncate clears stale open write handles"
 
 echo "FUSE exec integration passed."

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -99,7 +99,7 @@ export interface ExecutedCallable {
   outputText?: string;
 }
 
-interface CallablePatternLike {
+interface CallablePatternLike extends Record<string, unknown> {
   argumentSchema?: JSONSchema;
   resultSchema?: JSONSchema;
 }
@@ -109,10 +109,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 function asCallablePattern(value: unknown): CallablePatternLike | undefined {
   if (!isRecord(value)) return undefined;
-  return {
-    argumentSchema: value.argumentSchema as JSONSchema | undefined,
-    resultSchema: value.resultSchema as JSONSchema | undefined,
-  };
+  return value as CallablePatternLike;
 }
 
 function asExtraParams(value: unknown): Record<string, unknown> {

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -235,7 +235,8 @@ export function detectCallableKind(
 
   const callableKind =
     classifyCallableEntry(callableValue, callableCell?.schema) ??
-      classifyCallableEntry(resolvedValue, callableCell?.schema);
+      classifyCallableEntry(resolvedValue, callableCell?.schema) ??
+      classifyCallableEntry(callableCell, callableCell?.schema);
   if (callableKind) {
     return callableKind;
   }
@@ -298,7 +299,7 @@ export async function executeResolvedCallable(
       const tx = await new Promise<CallableTransactionLike>(
         (resolve, reject) => {
           try {
-            send(input, resolve);
+            send.call(resolved.callableCell, input, resolve);
           } catch (error) {
             reject(error);
           }

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -16,24 +16,107 @@ export interface CliRuntimeErrorRecord {
   space?: string;
 }
 
+export interface CallableTransactionStatus {
+  status: string;
+  error?: Error;
+}
+
+export interface CallableTransactionLike {
+  status?: () => CallableTransactionStatus;
+  commit?: () => Promise<unknown>;
+}
+
+export interface CallableCellLike {
+  schema?: JSONSchema;
+  get: () => unknown;
+  getRaw?: () => unknown;
+  asSchemaFromLinks?: () => CallableCellLike;
+  key: (segment: string) => CallableCellLike;
+  pull?: () => Promise<unknown>;
+  send?: (
+    value: unknown,
+    onCommit?: (tx: CallableTransactionLike) => void,
+  ) => void;
+}
+
+export interface CallablePieceIoLike {
+  getCell: () => Promise<CallableCellLike>;
+  set: (value: unknown, path?: (string | number)[]) => Promise<void>;
+}
+
+export interface CallableRuntimeLike {
+  [CF_RUNTIME_ERROR_LOG]?: CliRuntimeErrorRecord[];
+  storageManager?: { synced: () => Promise<void> };
+  idle: () => Promise<void>;
+  edit: () => CallableTransactionLike;
+  getCell: (
+    space: string,
+    id: string,
+    schema: JSONSchema | undefined,
+    tx: CallableTransactionLike,
+  ) => CallableCellLike;
+  run: (
+    tx: CallableTransactionLike,
+    pattern: unknown,
+    input: unknown,
+    resultCell: CallableCellLike,
+  ) => { sink?: (fn: (value: unknown) => void) => (() => void) | void } | void;
+  prepareTxForCommit?: (tx: CallableTransactionLike) => void;
+}
+
+export interface CallableManagerLike {
+  runtime: CallableRuntimeLike;
+  synced: () => Promise<void>;
+  getSpace?: () => string;
+}
+
+export interface CallablePieceLike {
+  input: CallablePieceIoLike;
+  result: CallablePieceIoLike;
+  getCell?: () => { pull?: () => Promise<unknown> };
+}
+
 export interface CallableResolution {
-  callableCell: any;
+  callableCell: CallableCellLike;
   callableKind: CallableKind;
   cellKey: string;
   cellProp: "input" | "result";
-  manager: any;
-  piece: any;
+  manager: CallableManagerLike;
+  piece: CallablePieceLike;
   space: string;
 }
 
 export interface CallableExecutionDeps {
   timeoutMs?: number;
   uuid?: () => string;
-  waitForResult?: (resultCell: any, timeoutMs: number) => Promise<unknown>;
+  waitForResult?: (
+    resultCell: CallableCellLike,
+    timeoutMs: number,
+  ) => Promise<unknown>;
 }
 
 export interface ExecutedCallable {
   outputText?: string;
+}
+
+interface CallablePatternLike {
+  argumentSchema?: JSONSchema;
+  resultSchema?: JSONSchema;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+function asCallablePattern(value: unknown): CallablePatternLike | undefined {
+  if (!isRecord(value)) return undefined;
+  return {
+    argumentSchema: value.argumentSchema as JSONSchema | undefined,
+    resultSchema: value.resultSchema as JSONSchema | undefined,
+  };
+}
+
+function asExtraParams(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
 }
 
 function runtimeErrorLog(runtime: unknown): CliRuntimeErrorRecord[] {
@@ -121,9 +204,12 @@ function mergeToolInput(
 }
 
 async function defaultWaitForResult(
-  resultCell: { pull: () => Promise<unknown> },
+  resultCell: CallableCellLike,
   timeoutMs: number,
 ): Promise<unknown> {
+  if (typeof resultCell.pull !== "function") {
+    throw new Error("Callable result cell cannot be pulled");
+  }
   const startedAt = Date.now();
   while (Date.now() - startedAt <= timeoutMs) {
     const value = await resultCell.pull();
@@ -137,7 +223,7 @@ async function defaultWaitForResult(
 
 export function detectCallableKind(
   callableValue: unknown,
-  callableCell: any,
+  callableCell: CallableCellLike,
 ): CallableKind | null {
   let resolvedValue = callableValue;
   try {
@@ -169,7 +255,7 @@ export function detectCallableKind(
 }
 
 export function callableCommandSpec(
-  callableCell: any,
+  callableCell: CallableCellLike,
   callableKind: CallableKind,
 ): ExecCommandSpec {
   if (callableKind === "handler") {
@@ -180,9 +266,13 @@ export function callableCommandSpec(
     };
   }
 
-  const pattern = callableCell.key("pattern").getRaw?.() ??
-    callableCell.key("pattern").get();
-  const extraParams = callableCell.key("extraParams").get() ?? {};
+  const pattern = asCallablePattern(
+    callableCell.key("pattern").getRaw?.() ??
+      callableCell.key("pattern").get(),
+  );
+  const extraParams = asExtraParams(
+    callableCell.key("extraParams").get?.(),
+  );
 
   return {
     callableKind: "tool",
@@ -201,16 +291,19 @@ export async function executeResolvedCallable(
   deps: CallableExecutionDeps = {},
 ): Promise<ExecutedCallable> {
   if (resolved.callableKind === "handler") {
-    if (typeof resolved.callableCell?.send === "function") {
+    const send = resolved.callableCell.send;
+    if (typeof send === "function") {
       const runtimeErrors = runtimeErrorLog(resolved.manager.runtime);
       const errorCountBefore = runtimeErrors.length;
-      const tx = await new Promise<any>((resolve, reject) => {
-        try {
-          resolved.callableCell.send(input, resolve);
-        } catch (error) {
-          reject(error);
-        }
-      });
+      const tx = await new Promise<CallableTransactionLike>(
+        (resolve, reject) => {
+          try {
+            send(input, resolve);
+          } catch (error) {
+            reject(error);
+          }
+        },
+      );
       await resolved.manager.runtime.idle();
       await resolved.manager.synced();
 
@@ -235,9 +328,13 @@ export async function executeResolvedCallable(
     return {};
   }
 
-  const pattern = resolved.callableCell.key("pattern").getRaw?.() ??
-    resolved.callableCell.key("pattern").get();
-  const extraParams = resolved.callableCell.key("extraParams").get() ?? {};
+  const pattern = asCallablePattern(
+    resolved.callableCell.key("pattern").getRaw?.() ??
+      resolved.callableCell.key("pattern").get(),
+  );
+  const extraParams = asExtraParams(
+    resolved.callableCell.key("extraParams").get?.(),
+  );
   const tx = resolved.manager.runtime.edit();
   const resultCell = resolved.manager.runtime.getCell(
     resolved.space,
@@ -258,6 +355,9 @@ export async function executeResolvedCallable(
   let outputValue: unknown;
   try {
     resolved.manager.runtime.prepareTxForCommit?.(tx);
+    if (typeof tx.commit !== "function") {
+      throw new Error("Callable runtime transaction is not committable");
+    }
     await tx.commit();
     await resolved.manager.runtime.idle();
     await resolved.manager.synced();
@@ -265,7 +365,7 @@ export async function executeResolvedCallable(
     const timeoutMs = deps.timeoutMs ?? 5000;
 
     await waitForResult(resultCell, timeoutMs);
-    await resolved.manager.runtime.storageManager.synced();
+    await resolved.manager.runtime.storageManager?.synced();
     outputValue = await waitForResult(resultCell, timeoutMs);
   } finally {
     cancelSink?.();

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -1,10 +1,16 @@
+import type { PieceManager } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
 import { dirname, join, relative, resolve } from "@std/path";
 import {
   type MountedCallablePath,
   parseMountedCallablePath,
 } from "../../fuse/callable-path.ts";
-import { callableCommandSpec } from "./callable.ts";
+import {
+  type CallableCellLike,
+  callableCommandSpec,
+  type CallableManagerLike,
+  type CallablePieceLike,
+} from "./callable.ts";
 import { executeCallableCommand } from "./callable-command.ts";
 import {
   type ExecCommandSpec,
@@ -29,22 +35,28 @@ export interface MountedPieceMeta {
 export interface ResolvedMountedCallableFile {
   absPath: string;
   callablePath: MountedCallablePath;
-  callableCell: any;
+  callableCell: CallableCellLike;
   commandSpec: ExecCommandSpec;
-  manager: any;
+  manager: CallableManagerLike;
   mount: { entry: MountStateEntry; path: string };
-  piece: any;
+  piece: CallablePieceLike;
   pieceId: string;
   pieceMeta: MountedPieceMeta;
 }
 
 export interface ExecDependencies {
   stateDir?: string;
-  loadManager?: (config: SpaceConfig) => Promise<any>;
-  loadPiece?: (manager: any, pieceId: string) => Promise<any>;
+  loadManager?: (config: SpaceConfig) => Promise<CallableManagerLike>;
+  loadPiece?: (
+    manager: CallableManagerLike,
+    pieceId: string,
+  ) => Promise<CallablePieceLike>;
   timeoutMs?: number;
   uuid?: () => string;
-  waitForResult?: (resultCell: any, timeoutMs: number) => Promise<unknown>;
+  waitForResult?: (
+    resultCell: CallableCellLike,
+    timeoutMs: number,
+  ) => Promise<unknown>;
   invocationStyle?: "cf" | "direct";
   readJsonInput?: () => Promise<unknown>;
   readTextInput?: () => Promise<string>;
@@ -59,8 +71,14 @@ export interface ExecutedMountedCallableFile {
   resolved: ResolvedMountedCallableFile;
 }
 
-async function defaultLoadPiece(manager: any, pieceId: string) {
-  return await new PiecesController(manager).get(pieceId, true);
+async function defaultLoadPiece(
+  manager: CallableManagerLike,
+  pieceId: string,
+): Promise<CallablePieceLike> {
+  return await new PiecesController(manager as unknown as PieceManager).get(
+    pieceId,
+    true,
+  );
 }
 
 async function readMountedPieceMeta(
@@ -150,17 +168,24 @@ export async function resolveMountedCallableFile(
 
   await assertMountedCallableFileExists(absPath);
   const pieceMeta = await readMountedPieceMeta(absPath, callablePath);
-  const manager = await (deps.loadManager ?? loadManager)({
-    apiUrl: mount.entry.apiUrl,
-    identity: mount.entry.identity,
-    space: callablePath.spaceName,
-  });
+  const manager = deps.loadManager
+    ? await deps.loadManager({
+      apiUrl: mount.entry.apiUrl,
+      identity: mount.entry.identity,
+      space: callablePath.spaceName,
+    })
+    : await loadManager({
+      apiUrl: mount.entry.apiUrl,
+      identity: mount.entry.identity,
+      space: callablePath.spaceName,
+    }) as unknown as CallableManagerLike;
   const piece = await (deps.loadPiece ?? defaultLoadPiece)(
     manager,
     pieceMeta.id,
   );
   const rootCell = await piece[callablePath.cellProp].getCell();
-  const callableCell = rootCell.key(callablePath.cellKey).asSchemaFromLinks();
+  const childCell = rootCell.key(callablePath.cellKey);
+  const callableCell = childCell.asSchemaFromLinks?.() ?? childCell;
 
   return {
     absPath,
@@ -207,9 +232,12 @@ export async function executeMountedCallableFile(
 
   // Auto-step: trigger reactive recomputation after handler execution.
   // Skip if --help was shown — no mutation occurred.
-  if (!result.helpText && typeof resolved.piece?.getCell === "function") {
+  if (!result.helpText && typeof resolved.piece.getCell === "function") {
     try {
-      await resolved.piece.getCell().pull();
+      const pieceCell = resolved.piece.getCell();
+      if (typeof pieceCell.pull === "function") {
+        await pieceCell.pull();
+      }
       await resolved.manager.synced();
     } catch {
       // Auto-step is best-effort; the handler already executed successfully.

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -10,6 +10,7 @@ import {
   callableCommandSpec,
   type CallableManagerLike,
   type CallablePieceLike,
+  detectCallableKind,
 } from "./callable.ts";
 import { executeCallableCommand } from "./callable-command.ts";
 import {
@@ -157,17 +158,21 @@ export async function resolveMountedCallableFile(
     );
   }
 
+  const canonicalMountpoint = await canonicalizeMountLookupPath(
+    mount.entry.mountpoint,
+  );
+  const canonicalAbsPath = await canonicalizeMountLookupPath(absPath);
   const relativePath = relative(
-    await canonicalizeMountLookupPath(mount.entry.mountpoint),
-    await canonicalizeMountLookupPath(absPath),
+    canonicalMountpoint,
+    canonicalAbsPath,
   );
   const callablePath = parseMountedCallablePath(relativePath);
   if (!callablePath) {
     throw new Error(`Path is not a mounted callable file: ${absPath}`);
   }
 
-  await assertMountedCallableFileExists(absPath);
-  const pieceMeta = await readMountedPieceMeta(absPath, callablePath);
+  await assertMountedCallableFileExists(canonicalAbsPath);
+  const pieceMeta = await readMountedPieceMeta(canonicalAbsPath, callablePath);
   const manager = deps.loadManager
     ? await deps.loadManager({
       apiUrl: mount.entry.apiUrl,
@@ -186,6 +191,12 @@ export async function resolveMountedCallableFile(
   const rootCell = await piece[callablePath.cellProp].getCell();
   const childCell = rootCell.key(callablePath.cellKey);
   const callableCell = childCell.asSchemaFromLinks?.() ?? childCell;
+  const actualKind = detectCallableKind(undefined, callableCell);
+  if (actualKind !== callablePath.callableKind) {
+    throw new Error(
+      `Mounted callable path "${absPath}" does not resolve to a ${callablePath.callableKind}`,
+    );
+  }
 
   return {
     absPath,

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -65,8 +65,14 @@ async function defaultLoadPiece(manager: any, pieceId: string) {
 
 async function readMountedPieceMeta(
   absFilePath: string,
+  callablePath: MountedCallablePath,
 ): Promise<MountedPieceMeta> {
-  const metaPath = join(dirname(dirname(absFilePath)), "meta.json");
+  const metaPath = join(
+    callablePath.rootLevel
+      ? dirname(absFilePath)
+      : dirname(dirname(absFilePath)),
+    "meta.json",
+  );
   let parsed: unknown;
   try {
     parsed = JSON.parse(await Deno.readTextFile(metaPath));
@@ -143,7 +149,7 @@ export async function resolveMountedCallableFile(
   }
 
   await assertMountedCallableFileExists(absPath);
-  const pieceMeta = await readMountedPieceMeta(absPath);
+  const pieceMeta = await readMountedPieceMeta(absPath, callablePath);
   const manager = await (deps.loadManager ?? loadManager)({
     apiUrl: mount.entry.apiUrl,
     identity: mount.entry.identity,

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -776,6 +776,40 @@ describe("mounted callable resolution and execution", () => {
     ).rejects.toThrow(/not a mounted callable file/i);
   });
 
+  it("rejects suffix-only callable paths whose cell kind does not match", async () => {
+    const mountpoint = join(tmpDir, "mount");
+    const filePath = await createMountedFile(mountpoint, {
+      relativePath: "home/pieces/notes-2/result/title.handler",
+      pieceId: "of:piece-123",
+    });
+    const harness = createExecHarness({
+      callableKind: "tool",
+      cellProp: "result",
+      cellKey: "title",
+      pieceId: "of:piece-123",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+      },
+      pattern: {
+        argumentSchema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+        },
+      },
+    });
+
+    await writeLiveMountState(stateDir, mountpoint);
+
+    await expect(
+      resolveMountedCallableFile(filePath, {
+        stateDir,
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+      }),
+    ).rejects.toThrow(/does not resolve to a handler/i);
+  });
+
   it("rejects fabricated mounted callable paths whose file is missing", async () => {
     const mountpoint = join(tmpDir, "mount");
     const pieceDir = join(mountpoint, "home/pieces/notes-2");
@@ -1029,6 +1063,35 @@ describe("mounted callable resolution and execution", () => {
     expect(resolved.pieceId).toBe("of:piece-123");
   });
 
+  it("resolves sparse stream handler cells whose value is undefined", async () => {
+    const mountpoint = join(tmpDir, "mount");
+    const filePath = await createMountedFile(mountpoint, {
+      relativePath: "home/pieces/notes-2/result/add.handler",
+      pieceId: "of:piece-123",
+    });
+    const harness = createExecHarness({
+      callableKind: "handler",
+      cellProp: "result",
+      cellKey: "add",
+      pieceId: "of:piece-123",
+      sparseHandlerCell: true,
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+      },
+    });
+
+    await writeLiveMountState(stateDir, mountpoint);
+
+    const resolved = await resolveMountedCallableFile(filePath, {
+      stateDir,
+      loadManager: () => Promise.resolve(harness.manager),
+      loadPiece: () => Promise.resolve(harness.piece),
+    });
+
+    expect(resolved.callablePath.callableKind).toBe("handler");
+  });
+
   it("resolves callable paths through a symlinked alias of the mountpoint", async () => {
     const realRoot = join(tmpDir, "real");
     const mountpoint = join(realRoot, "mount");
@@ -1065,6 +1128,50 @@ describe("mounted callable resolution and execution", () => {
 
     expect(resolved.callablePath.rootKind).toBe("pieces");
     expect(resolved.pieceId).toBe("of:piece-123");
+  });
+
+  it("reads mounted metadata from the canonical target of symlinked callable paths", async () => {
+    const mountpoint = join(tmpDir, "mount");
+    const realPath = await createMountedFile(mountpoint, {
+      relativePath: "home/pieces/notes-2/result/add.handler",
+      pieceId: "of:real-piece",
+    });
+    const aliasDir = join(tmpDir, "alias", "result");
+    await Deno.mkdir(aliasDir, { recursive: true });
+    const aliasPath = join(aliasDir, "add.handler");
+    await Deno.symlink(realPath, aliasPath);
+    await Deno.writeTextFile(
+      join(tmpDir, "alias", "meta.json"),
+      JSON.stringify({
+        id: "of:fake-piece",
+        entityId: "of:fake-piece",
+        name: "Fake Piece",
+        patternName: "fake",
+      }),
+    );
+    const harness = createExecHarness({
+      callableKind: "handler",
+      cellProp: "result",
+      cellKey: "add",
+      pieceId: "of:real-piece",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+      },
+    });
+
+    await writeLiveMountState(stateDir, mountpoint);
+
+    const resolved = await resolveMountedCallableFile(aliasPath, {
+      stateDir,
+      loadManager: () => Promise.resolve(harness.manager),
+      loadPiece: (_manager, pieceId) => {
+        expect(pieceId).toBe("of:real-piece");
+        return Promise.resolve(harness.piece);
+      },
+    });
+
+    expect(resolved.pieceId).toBe("of:real-piece");
   });
 
   it("calls asSchemaFromLinks on the resolved child cell", async () => {
@@ -1174,6 +1281,41 @@ describe("mounted callable resolution and execution", () => {
     );
 
     expect(result.outputText).toBeUndefined();
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["add"],
+        value: { query: "milk" },
+      },
+    ]);
+  });
+
+  it("preserves the Cell.send receiver when dispatching mounted handlers", async () => {
+    const mountpoint = join(tmpDir, "mount");
+    const filePath = await createMountedFile(mountpoint, {
+      relativePath: "home/pieces/notes-2/result/add.handler",
+      pieceId: "of:piece-123",
+    });
+    const harness = createExecHarness({
+      callableKind: "handler",
+      cellProp: "result",
+      cellKey: "add",
+      pieceId: "of:piece-123",
+      handlerSendRequiresReceiver: true,
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+      },
+    });
+
+    await writeLiveMountState(stateDir, mountpoint);
+
+    await executeMountedCallableFile(filePath, ["--query", "milk"], {
+      stateDir,
+      loadManager: () => Promise.resolve(harness.manager),
+      loadPiece: () => Promise.resolve(harness.piece),
+    });
+
     expect(harness.tracker.handlerWrites).toEqual([
       {
         cellProp: "result",
@@ -1846,6 +1988,8 @@ function createExecHarness(options: {
   toolResultGetValue?: unknown;
   toolResultPullValue?: unknown;
   handlerFailureMessage?: string;
+  handlerSendRequiresReceiver?: boolean;
+  sparseHandlerCell?: boolean;
 }) {
   const tracker = {
     asSchemaFromLinksCalls: 0,
@@ -1872,9 +2016,40 @@ function createExecHarness(options: {
       pattern: options.pattern,
       extraParams: options.extraParams ?? {},
     }
+    : options.sparseHandlerCell
+    ? undefined
     : { $stream: true };
   const runtimeErrors: Array<{ message: string }> = [];
-  const callableCell = createMockCell(
+  let callableCell: ReturnType<typeof createMockCell>;
+  const handlerSend = function (
+    this: unknown,
+    value: unknown,
+    onCommit?: (
+      tx: { status: () => { status: string; error?: Error } },
+    ) => void,
+  ) {
+    if (options.handlerSendRequiresReceiver && this !== callableCell) {
+      throw new Error("Cell.send receiver lost");
+    }
+    tracker.handlerWrites.push({
+      cellProp: "result",
+      path: [options.cellKey],
+      value,
+    });
+    if (options.handlerFailureMessage) {
+      runtimeErrors.push({ message: options.handlerFailureMessage });
+    }
+    onCommit?.({
+      status: () =>
+        options.handlerFailureMessage
+          ? {
+            status: "error",
+            error: new Error(options.handlerFailureMessage),
+          }
+          : { status: "done" },
+    });
+  };
+  callableCell = createMockCell(
     callableValue,
     callableSchema,
     options.callableKind === "handler"
@@ -1882,30 +2057,8 @@ function createExecHarness(options: {
         onSchemaFromLinks: () => {
           tracker.asSchemaFromLinksCalls++;
         },
-        send: (
-          value: unknown,
-          onCommit?: (
-            tx: { status: () => { status: string; error?: Error } },
-          ) => void,
-        ) => {
-          tracker.handlerWrites.push({
-            cellProp: "result",
-            path: [options.cellKey],
-            value,
-          });
-          if (options.handlerFailureMessage) {
-            runtimeErrors.push({ message: options.handlerFailureMessage });
-          }
-          onCommit?.({
-            status: () =>
-              options.handlerFailureMessage
-                ? {
-                  status: "error",
-                  error: new Error(options.handlerFailureMessage),
-                }
-                : { status: "done" },
-          });
-        },
+        isStream: () => options.sparseHandlerCell === true,
+        send: handlerSend,
       }
       : {
         onSchemaFromLinks: () => {
@@ -2011,6 +2164,7 @@ function createMockCell(
         tx: { status: () => { status: string; error?: Error } },
       ) => void,
     ) => void;
+    isStream?: () => boolean;
   },
 ) {
   const cell = {
@@ -2022,6 +2176,7 @@ function createMockCell(
       return cell;
     },
     send: options?.send,
+    isStream: options?.isStream,
     key: (key: string) => {
       if (options?.childOverrides?.[key]) {
         return options.childOverrides[key];

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -2020,7 +2020,6 @@ function createExecHarness(options: {
     ? undefined
     : { $stream: true };
   const runtimeErrors: Array<{ message: string }> = [];
-  let callableCell: ReturnType<typeof createMockCell>;
   const handlerSend = function (
     this: unknown,
     value: unknown,
@@ -2049,7 +2048,7 @@ function createExecHarness(options: {
           : { status: "done" },
     });
   };
-  callableCell = createMockCell(
+  const callableCell = createMockCell(
     callableValue,
     callableSchema,
     options.callableKind === "handler"

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -983,6 +983,52 @@ describe("mounted callable resolution and execution", () => {
     expect(entitiesResolved.pieceId).toBe("of:piece-123");
   });
 
+  it("resolves root-level FS projection callables as result callables", async () => {
+    const mountpoint = join(tmpDir, "mount");
+    const pieceDir = join(mountpoint, "home/pieces/notes-2");
+    const filePath = join(pieceDir, "add.handler");
+    await Deno.mkdir(pieceDir, { recursive: true });
+    await Deno.writeTextFile(filePath, "");
+    await Deno.writeTextFile(
+      join(pieceDir, "meta.json"),
+      JSON.stringify({
+        id: "of:piece-123",
+        entityId: "of:piece-123",
+        name: "Fixture Piece",
+        patternName: "fixture",
+      }),
+    );
+    const harness = createExecHarness({
+      callableKind: "handler",
+      cellProp: "result",
+      cellKey: "add",
+      pieceId: "of:piece-123",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+      },
+    });
+
+    await writeLiveMountState(stateDir, mountpoint);
+
+    const resolved = await resolveMountedCallableFile(filePath, {
+      stateDir,
+      loadManager: () => Promise.resolve(harness.manager),
+      loadPiece: () => Promise.resolve(harness.piece),
+    });
+
+    expect(resolved.callablePath).toEqual({
+      spaceName: "home",
+      rootKind: "pieces",
+      rootName: "notes-2",
+      cellProp: "result",
+      cellKey: "add",
+      callableKind: "handler",
+      rootLevel: true,
+    });
+    expect(resolved.pieceId).toBe("of:piece-123");
+  });
+
   it("resolves callable paths through a symlinked alias of the mountpoint", async () => {
     const realRoot = join(tmpDir, "real");
     const mountpoint = join(realRoot, "mount");

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -45,6 +45,29 @@ describe("executePieceCallable", () => {
   });
 
   it("runs tools from schema-derived flags and returns JSON output", async () => {
+    const toolPattern: {
+      nodes: Array<{ module: string }>;
+      argumentSchema: JSONSchema;
+      resultSchema: JSONSchema;
+    } = {
+      nodes: [{ module: "sentinel-node" }],
+      argumentSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          help: { type: "string" },
+          source: { type: "string" },
+        },
+        required: ["query", "source"],
+      },
+      resultSchema: {
+        type: "object",
+        properties: {
+          summary: { type: "string" },
+          source: { type: "string" },
+        },
+      },
+    };
     const harness = createPieceCallableHarness({
       callableKind: "tool",
       cellKey: "search",
@@ -56,24 +79,7 @@ describe("executePieceCallable", () => {
         },
         required: ["query"],
       },
-      pattern: {
-        argumentSchema: {
-          type: "object",
-          properties: {
-            query: { type: "string" },
-            help: { type: "string" },
-            source: { type: "string" },
-          },
-          required: ["query", "source"],
-        },
-        resultSchema: {
-          type: "object",
-          properties: {
-            summary: { type: "string" },
-            source: { type: "string" },
-          },
-        },
-      },
+      pattern: toolPattern,
       extraParams: {
         source: "bound-source",
       },
@@ -100,6 +106,7 @@ describe("executePieceCallable", () => {
     );
 
     expect(result.resolved.callableKind).toBe("tool");
+    expect(harness.tracker.toolRunPattern).toBe(toolPattern);
     expect(harness.tracker.toolRunInput).toEqual({
       query: "tea",
       help: "",
@@ -496,7 +503,7 @@ function createPieceCallableHarness(options: {
   pattern?: {
     argumentSchema: JSONSchema;
     resultSchema?: JSONSchema;
-  };
+  } & Record<string, unknown>;
   extraParams?: Record<string, unknown>;
   toolResult?: unknown;
   handlerFailureMessage?: string;
@@ -507,6 +514,7 @@ function createPieceCallableHarness(options: {
       path: (string | number)[] | undefined;
       value: unknown;
     }>,
+    toolRunPattern: undefined as unknown,
     toolRunInput: undefined as unknown,
   };
 
@@ -630,10 +638,11 @@ function createPieceCallableHarness(options: {
       ) => resultCell,
       run: (
         _tx: unknown,
-        _pattern: unknown,
+        pattern: unknown,
         input: unknown,
         _result: unknown,
       ) => {
+        tracker.toolRunPattern = pattern;
         tracker.toolRunInput = input;
         state.value = options.toolResult;
         return {

--- a/packages/fuse/callable-path.test.ts
+++ b/packages/fuse/callable-path.test.ts
@@ -46,6 +46,15 @@ Deno.test("parseMountedCallablePath accepts root-level result callables", () => 
   );
 });
 
+Deno.test("parseMountedCallablePath decodes encoded space names", () => {
+  assertEquals(
+    parseMountedCallablePath(
+      "did%3Akey%3AzSpace/pieces/notes/result/search.tool",
+    )?.spaceName,
+    "did:key:zSpace",
+  );
+});
+
 Deno.test("parseMountedCallablePath accepts entity handler paths", () => {
   assertEquals(
     parseMountedCallablePath("home/entities/of:abc123/result/addItem.handler"),

--- a/packages/fuse/callable-path.test.ts
+++ b/packages/fuse/callable-path.test.ts
@@ -11,6 +11,7 @@ Deno.test("parseMountedCallablePath accepts piece handler paths", () => {
       cellProp: "input",
       cellKey: "addItem",
       callableKind: "handler",
+      rootLevel: false,
     },
   );
 });
@@ -25,6 +26,22 @@ Deno.test("parseMountedCallablePath accepts piece tool paths", () => {
       cellProp: "result",
       cellKey: "search",
       callableKind: "tool",
+      rootLevel: false,
+    },
+  );
+});
+
+Deno.test("parseMountedCallablePath accepts root-level result callables", () => {
+  assertEquals(
+    parseMountedCallablePath("home/pieces/notes/add%3Aitem.handler"),
+    {
+      spaceName: "home",
+      rootKind: "pieces",
+      rootName: "notes",
+      cellProp: "result",
+      cellKey: "add:item",
+      callableKind: "handler",
+      rootLevel: true,
     },
   );
 });
@@ -39,6 +56,7 @@ Deno.test("parseMountedCallablePath accepts entity handler paths", () => {
       cellProp: "result",
       cellKey: "addItem",
       callableKind: "handler",
+      rootLevel: false,
     },
   );
 });
@@ -53,6 +71,7 @@ Deno.test("parseMountedCallablePath accepts entity tool paths", () => {
       cellProp: "input",
       cellKey: "search",
       callableKind: "tool",
+      rootLevel: false,
     },
   );
 });

--- a/packages/fuse/callable-path.ts
+++ b/packages/fuse/callable-path.ts
@@ -1,3 +1,5 @@
+import { decodeFuseComponent } from "./path-codec.ts";
+
 export interface MountedCallablePath {
   spaceName: string;
   rootKind: "pieces" | "entities";
@@ -24,7 +26,8 @@ export function parseMountedCallablePath(
   const match = /^(.+)\.(handler|tool)$/.exec(fileName);
   if (!match) return null;
 
-  const [, cellKey, callableKind] = match;
+  const [, encodedCellKey, callableKind] = match;
+  const cellKey = decodeFuseComponent(encodedCellKey);
   if (!cellKey) return null;
 
   return {

--- a/packages/fuse/callable-path.ts
+++ b/packages/fuse/callable-path.ts
@@ -7,6 +7,7 @@ export interface MountedCallablePath {
   cellProp: "input" | "result";
   cellKey: string;
   callableKind: "handler" | "tool";
+  rootLevel: boolean;
 }
 
 export function parseMountedCallablePath(
@@ -16,7 +17,30 @@ export function parseMountedCallablePath(
   if (!normalized) return null;
 
   const segments = normalized.split("/");
-  if (segments.length !== 5) return null;
+  if (segments.length !== 4 && segments.length !== 5) return null;
+
+  if (segments.length === 4) {
+    const [spaceName, rootKind, rootName, fileName] = segments;
+    if (!spaceName || !rootName) return null;
+    if (rootKind !== "pieces" && rootKind !== "entities") return null;
+
+    const match = /^(.+)\.(handler|tool)$/.exec(fileName);
+    if (!match) return null;
+
+    const [, encodedCellKey, callableKind] = match;
+    const cellKey = decodeFuseComponent(encodedCellKey);
+    if (!cellKey) return null;
+
+    return {
+      spaceName,
+      rootKind,
+      rootName: decodeFuseComponent(rootName),
+      cellProp: "result",
+      cellKey,
+      callableKind: callableKind as "handler" | "tool",
+      rootLevel: true,
+    };
+  }
 
   const [spaceName, rootKind, rootName, cellProp, fileName] = segments;
   if (!spaceName || !rootName) return null;
@@ -33,9 +57,10 @@ export function parseMountedCallablePath(
   return {
     spaceName,
     rootKind,
-    rootName,
+    rootName: decodeFuseComponent(rootName),
     cellProp,
     cellKey,
     callableKind: callableKind as "handler" | "tool",
+    rootLevel: false,
   };
 }

--- a/packages/fuse/callable-path.ts
+++ b/packages/fuse/callable-path.ts
@@ -32,7 +32,7 @@ export function parseMountedCallablePath(
     if (!cellKey) return null;
 
     return {
-      spaceName,
+      spaceName: decodeFuseComponent(spaceName),
       rootKind,
       rootName: decodeFuseComponent(rootName),
       cellProp: "result",
@@ -55,7 +55,7 @@ export function parseMountedCallablePath(
   if (!cellKey) return null;
 
   return {
-    spaceName,
+    spaceName: decodeFuseComponent(spaceName),
     rootKind,
     rootName: decodeFuseComponent(rootName),
     cellProp,

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -12,6 +12,7 @@ import {
   CFC_FAIL_CLOSED_ATOM_CLASS,
   listCfcXattrNames,
 } from "./annotations.ts";
+import { encodeFuseComponent } from "./path-codec.ts";
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -132,7 +133,7 @@ function buildTestSpace(
   fakePieces: unknown[],
 ): SpaceState {
   const tree = bridge.tree;
-  const spaceIno = tree.addDir(tree.rootIno, spaceName);
+  const spaceIno = tree.addDir(tree.rootIno, encodeFuseComponent(spaceName));
   const piecesIno = tree.addDir(spaceIno, "pieces");
   const entitiesIno = tree.addDir(spaceIno, "entities");
 
@@ -1537,6 +1538,58 @@ Deno.test("CellBridge.buildSourceTree encodes source path segments and decodes w
   );
 });
 
+Deno.test("CellBridge decodes encoded space directory names for write paths", () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "did:key:zSpace", []);
+  const piece = {
+    id: "of:encoded-space-piece",
+    name: () => "Encoded Space Piece",
+  };
+  state.pieceControllers.set("notes", piece as never);
+
+  const pieceIno = tree.addDir(state.piecesIno, "notes");
+  const resultIno = tree.addDir(pieceIno, "result");
+  const titleIno = tree.addFile(resultIno, "title", "hello", "string");
+
+  const writePath = bridge.resolveWritePath(titleIno);
+  assertEquals(writePath?.spaceName, "did:key:zSpace");
+  assertEquals(writePath?.pieceName, "notes");
+  assertEquals(writePath?.cell, "result");
+  assertEquals(writePath?.jsonPath, ["title"]);
+});
+
+Deno.test("CellBridge decodes encoded space directory names for source write paths", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "did:key:zSource", []);
+  const pieceIno = tree.addDir(state.piecesIno, "notes");
+  const piece = {
+    id: "of:encoded-source-piece",
+    getPatternMeta: () =>
+      Promise.resolve({
+        program: {
+          main: "/src/main.ts",
+          files: [{ name: "/src/main.ts", contents: "export default 1;" }],
+        },
+      }),
+  };
+  state.pieceControllers.set("notes", piece as never);
+  state.srcInos.set("notes", pieceIno);
+
+  await (bridge as unknown as { buildSourceTree: BuildSourceTree })
+    .buildSourceTree(pieceIno, piece, state, "notes");
+
+  const srcIno = tree.lookup(pieceIno, ".src")!;
+  const srcDirIno = tree.lookup(srcIno, "src")!;
+  const sourceIno = tree.lookup(srcDirIno, "main.ts")!;
+  const sourcePath = bridge.resolveSourceWritePath(sourceIno);
+
+  assertEquals(sourcePath?.spaceName, "did:key:zSource");
+  assertEquals(sourcePath?.pieceName, "notes");
+  assertEquals(sourcePath?.relPath, "src/main.ts");
+});
+
 // ---------------------------------------------------------------------------
 // Group 4: syncPieceListOnce — add/remove
 // ---------------------------------------------------------------------------
@@ -2211,6 +2264,50 @@ Deno.test("CellBridge.invalidateHandlerTarget clears hydrated entity result cach
     tree.getChildren(resultIno!).length,
     0,
     "entity result/ should be restored as an empty stub after handler invalidation",
+  );
+});
+
+Deno.test("CellBridge.resolveEntity rejects non-canonical entity aliases", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+  const piece = {
+    id: "of:alias-piece",
+    name: () => "Alias Piece",
+    getPatternMeta: () => Promise.resolve({ patternName: "note" }),
+    input: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+    result: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+    manager: () => ({
+      runtime: { idle: () => Promise.resolve() },
+      synced: () => Promise.resolve(),
+    }),
+  };
+  state.pieceControllers.set("Alias-Piece", piece as never);
+
+  assertEquals(
+    await bridge.resolveEntity(state.entitiesIno, "of:alias-piece"),
+    false,
+  );
+  assertEquals(
+    await bridge.resolveEntity(state.entitiesIno, "%6Ff%3Aalias-piece"),
+    false,
+  );
+  assertEquals(tree.lookup(state.entitiesIno, "of:alias-piece"), undefined);
+  assertEquals(tree.lookup(state.entitiesIno, "%6Ff%3Aalias-piece"), undefined);
+
+  assertEquals(
+    await bridge.resolveEntity(state.entitiesIno, "of%3Aalias-piece"),
+    true,
+  );
+  assertEquals(
+    tree.lookup(state.entitiesIno, "of%3Aalias-piece") !== undefined,
+    true,
   );
 });
 

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -207,6 +207,13 @@ type RebuildPieceProp = (args: {
   spaceName: string;
 }) => Promise<void>;
 
+type BuildSourceTree = (
+  pieceIno: bigint,
+  piece: unknown,
+  state: SpaceState,
+  pieceName: string,
+) => Promise<void>;
+
 type WriteFsFile = (
   writePath: unknown,
   text: string,
@@ -1326,14 +1333,14 @@ Deno.test("CellBridge.updatePiecesJson writes cached manifest data without piece
       name: "Alpha",
       pattern: "alpha-pattern",
       summary: "alpha summary",
-      entityPath: "entities/of:alpha",
+      entityPath: "entities/of%3Aalpha",
     },
     {
       id: "of:beta",
       name: "Beta",
       pattern: "beta-pattern",
       summary: "beta summary",
-      entityPath: "entities/of:beta",
+      entityPath: "entities/of%3Abeta",
     },
   ]);
 });
@@ -1496,6 +1503,38 @@ Deno.test("CellBridge.writeFsFile removes deleted keys from application/json pro
     { path: ["$FS", "content", "title"], value: "New" },
     { path: ["$FS", "content", "stale"], value: undefined },
   ]);
+});
+
+Deno.test("CellBridge.buildSourceTree encodes source path segments and decodes write paths", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+  const pieceIno = tree.addDir(state.piecesIno, "notes");
+  const piece = {
+    id: "of:source-piece",
+    getPatternMeta: () =>
+      Promise.resolve({
+        program: {
+          main: "/src/has:colon.tsx",
+          files: [
+            { name: "/src/has:colon.tsx", contents: "export default 1;" },
+          ],
+        },
+      }),
+  };
+  state.pieceControllers.set("notes", piece as never);
+  state.srcInos.set("notes", pieceIno);
+
+  await (bridge as unknown as { buildSourceTree: BuildSourceTree })
+    .buildSourceTree(pieceIno, piece, state, "notes");
+
+  const srcIno = tree.lookup(pieceIno, ".src")!;
+  const srcDirIno = tree.lookup(srcIno, "src")!;
+  const sourceIno = tree.lookup(srcDirIno, "has%3Acolon.tsx")!;
+  assertEquals(
+    bridge.resolveSourceWritePath(sourceIno)?.relPath,
+    "src/has:colon.tsx",
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -2151,8 +2190,11 @@ Deno.test("CellBridge.invalidateHandlerTarget clears hydrated entity result cach
     .addPieceToSpace.bind(bridge);
   await addPiece(state, piece, "home");
 
-  await bridge.resolveEntity(state.entitiesIno, piece.id);
-  const entityIno = tree.lookup(state.entitiesIno, piece.id)!;
+  await bridge.resolveEntity(state.entitiesIno, "of%3Aentity-handler-piece");
+  const entityIno = tree.lookup(
+    state.entitiesIno,
+    "of%3Aentity-handler-piece",
+  )!;
   await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
     .hydratePieceProp.call(bridge, entityIno, "result");
   assertEquals(tree.lookup(entityIno, "result") !== undefined, true);

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -32,6 +32,12 @@ import {
   isVNode,
   safeStringify,
 } from "./tree-builder.ts";
+import {
+  decodeFuseComponent,
+  decodeFusePathSegments,
+  encodeFuseComponent,
+  encodeFusePathSegments,
+} from "./path-codec.ts";
 import type { JSONSchema } from "@commonfabric/api";
 import type { PieceManager } from "@commonfabric/piece";
 import type {
@@ -544,7 +550,7 @@ export class CellBridge {
         name,
         pattern: manifest.pattern,
         summary: manifest.summary,
-        entityPath: `entities/${id}`,
+        entityPath: `entities/${encodeFuseComponent(id)}`,
       });
     }
 
@@ -849,8 +855,11 @@ export class CellBridge {
 
       // Convert numeric segments to numbers for array indexing
       jsonPath = remaining.map((s) => {
-        const n = Number(s);
-        return Number.isInteger(n) && n >= 0 && String(n) === s ? n : s;
+        const decoded = decodeFuseComponent(s);
+        const n = Number(decoded);
+        return Number.isInteger(n) && n >= 0 && String(n) === decoded
+          ? n
+          : decoded;
       });
     } else {
       // Not a recognized cell segment
@@ -887,7 +896,7 @@ export class CellBridge {
 
     const spaceName = segments[0];
     const pieceName = segments[2];
-    const relPath = segments.slice(4).join("/");
+    const relPath = decodeFusePathSegments(segments.slice(4)).join("/");
 
     const space = this.spaces.get(spaceName);
     if (!space) return null;
@@ -1428,7 +1437,10 @@ export class CellBridge {
         }
       }
 
-      const entityIno = this.tree.lookup(state.entitiesIno, pieceId);
+      const entityIno = this.tree.lookup(
+        state.entitiesIno,
+        encodeFuseComponent(pieceId),
+      );
       if (entityIno !== undefined) {
         this.invalidateRootPropCache(entityIno, propName);
       }
@@ -1519,8 +1531,9 @@ export class CellBridge {
     // Match: /<space>/entities/<hash>[/<path...>]
     if (resolved.length >= 3 && resolved[1] === "entities") {
       const targetSpace = resolved[0];
-      const hash = resolved[2];
-      const pathParts = resolved.slice(3);
+      const decodedTargetSpace = decodeFuseComponent(targetSpace);
+      const hash = decodeFuseComponent(resolved[2]);
+      const pathParts = decodeFusePathSegments(resolved.slice(3));
 
       const result: { id?: string; path?: string[]; space?: string } = {
         id: hash,
@@ -1532,8 +1545,8 @@ export class CellBridge {
 
       // Omit space if same as current
       if (targetSpace !== currentSpace) {
-        const did = this.knownSpaces.get(targetSpace);
-        result.space = did || targetSpace;
+        const did = this.knownSpaces.get(decodedTargetSpace);
+        result.space = did || decodedTargetSpace;
       }
 
       return result;
@@ -1542,7 +1555,7 @@ export class CellBridge {
     // Self-reference: target within same piece, no entities/ segment
     // Resolved path: [space, "pieces", pieceName, cell, ...subpath]
     if (resolved.length >= 4 && resolved[1] === "pieces") {
-      const subpath = resolved.slice(4);
+      const subpath = decodeFusePathSegments(resolved.slice(4));
       if (subpath.length > 0) {
         return { path: subpath };
       }
@@ -1803,7 +1816,10 @@ export class CellBridge {
     if (!state || !spaceName) return false;
 
     // Match entity ID against known pieces (with or without of: prefix)
-    const bareId = entityId.startsWith("of:") ? entityId.slice(3) : entityId;
+    const decodedEntityId = decodeFuseComponent(entityId);
+    const bareId = decodedEntityId.startsWith("of:")
+      ? decodedEntityId.slice(3)
+      : decodedEntityId;
     let matchedPiece: PieceController | undefined;
     for (const [, piece] of state.pieceControllers) {
       const pieceBareid = piece.id.startsWith("of:")
@@ -1873,7 +1889,8 @@ export class CellBridge {
     // Create a lightweight stub entity dir so `ls entities/` shows stable IDs
     // immediately. Full content is populated lazily by resolveEntity() on
     // first access, avoiding doubled subscriptions and startup cost.
-    const entityStubIno = this.tree.addDir(state.entitiesIno, piece.id);
+    const entityName = encodeFuseComponent(piece.id);
+    const entityStubIno = this.tree.addDir(state.entitiesIno, entityName);
     const entityMetaObject = {
       id: piece.id,
       entityId: piece.id,
@@ -1887,7 +1904,11 @@ export class CellBridge {
       value: entityMetaObject,
     });
     entityAnnotator?.annotateJsonDirectory(entityStubIno, [], {});
-    entityAnnotator?.annotateEntry(state.entitiesIno, piece.id, entityStubIno);
+    entityAnnotator?.annotateEntry(
+      state.entitiesIno,
+      entityName,
+      entityStubIno,
+    );
     const entityMetaIno = this.tree.addFile(
       entityStubIno,
       "meta.json",
@@ -1904,7 +1925,7 @@ export class CellBridge {
     this.registerPieceRoot(entityStubIno, {
       spaceName,
       rootKind: "entities",
-      rootName: piece.id,
+      rootName: entityName,
       pieceId: piece.id,
       piece,
     });
@@ -1935,12 +1956,13 @@ export class CellBridge {
 
     // Clean up entity tree
     if (pieceId) {
-      const entityIno = this.tree.lookup(state.entitiesIno, pieceId);
+      const entityName = encodeFuseComponent(pieceId);
+      const entityIno = this.tree.lookup(state.entitiesIno, entityName);
       if (entityIno !== undefined) {
         this.unregisterPieceRoot(entityIno);
         this.fsProjectionEntries.delete(entityIno);
       }
-      this.tree.removeChild(state.entitiesIno, pieceId);
+      this.tree.removeChild(state.entitiesIno, entityName);
     }
 
     state.pieceMap.delete(name);
@@ -2047,7 +2069,7 @@ export class CellBridge {
       const entityInvalidIds = [
         ...removedEntityIds,
         ...toAdd.map((p) => p.id),
-      ];
+      ].map((id) => encodeFuseComponent(id));
       if (entityInvalidIds.length > 0) {
         this.onInvalidate(state.entitiesIno, entityInvalidIds);
       }
@@ -2184,7 +2206,7 @@ export class CellBridge {
       pieceId,
       (siblingParentIno, name, value) => {
         if (siblingParentIno === pieceIno) {
-          entries.add(name);
+          entries.add(encodeFuseComponent(name, { reserveJsonSuffix: true }));
         }
         this.makeFsSubtreeBuilder(
           resolveLink,
@@ -2210,13 +2232,13 @@ export class CellBridge {
       !Array.isArray(treeValue)
     ) {
       for (const [key, value] of Object.entries(treeValue)) {
-        if (isVNode(value)) entries.add(`${key}.json`);
+        if (isVNode(value)) entries.add(`${encodeFuseComponent(key)}.json`);
       }
     }
 
     this.addCallableFiles(pieceIno, callables, "result", annotator);
     for (const { key, callableKind } of callables) {
-      entries.add(`${key}.${callableKind}`);
+      entries.add(`${encodeFuseComponent(key)}.${callableKind}`);
     }
 
     this.fsProjectionEntries.set(pieceIno, entries);
@@ -2392,9 +2414,10 @@ export class CellBridge {
     for (const { key, callableKind, schema } of callables) {
       const typeStr = displayCallableInputType(callableKind, schema);
       const script = buildCallableScript(this.execCli, schema, typeStr);
+      const fileName = `${encodeFuseComponent(key)}.${callableKind}`;
       const callableIno = this.tree.addCallable(
         propIno,
-        `${key}.${callableKind}`,
+        fileName,
         callableKind,
         key,
         cellProp,
@@ -2409,7 +2432,7 @@ export class CellBridge {
         cellProp,
         schemaLabel,
       });
-      annotator?.annotateEntry(propIno, `${key}.${callableKind}`, callableIno, {
+      annotator?.annotateEntry(propIno, fileName, callableIno, {
         labelPath: [key],
       });
     }
@@ -2434,12 +2457,14 @@ export class CellBridge {
         const [key, val] of Object.entries(value as Record<string, unknown>)
       ) {
         if (isVNode(val)) {
-          currentVNodeKeys.add(key);
-          const existing = this.tree.lookup(parentIno, `${key}.json`);
+          const encodedKey = encodeFuseComponent(key);
+          const fileName = `${encodedKey}.json`;
+          currentVNodeKeys.add(encodedKey);
+          const existing = this.tree.lookup(parentIno, fileName);
           if (existing !== undefined) this.tree.clear(existing);
           const vnodeIno = this.tree.addFile(
             parentIno,
-            `${key}.json`,
+            fileName,
             safeStringify(val),
             "object",
           );
@@ -2449,7 +2474,7 @@ export class CellBridge {
             vnodeIno,
             "aggregate-json",
             [key],
-            { ino: parentIno, name: `${key}.json` },
+            { ino: parentIno, name: fileName },
             contentLabel,
           );
         }
@@ -2788,7 +2813,10 @@ export class CellBridge {
             if (renamedPieceIno !== undefined) {
               this.updatePieceMetaName(renamedPieceIno, newName);
             }
-            const entityIno = this.tree.lookup(state.entitiesIno, piece.id);
+            const entityIno = this.tree.lookup(
+              state.entitiesIno,
+              encodeFuseComponent(piece.id),
+            );
             if (entityIno !== undefined) {
               this.updatePieceMetaName(entityIno, newName);
             }
@@ -2857,30 +2885,53 @@ export class CellBridge {
         string,
         unknown
       >;
-      const linkData = inner["link@1"] as {
-        id?: string;
-        path?: readonly string[];
-        space?: string;
+      const rawLinkData = inner["link@1"];
+      if (
+        typeof rawLinkData !== "object" || rawLinkData === null ||
+        Array.isArray(rawLinkData)
+      ) {
+        return null;
+      }
+      const linkData = rawLinkData as {
+        id?: unknown;
+        path?: unknown;
+        space?: unknown;
       };
+      if (linkData.id !== undefined && typeof linkData.id !== "string") {
+        return null;
+      }
+      if (
+        linkData.space !== undefined && typeof linkData.space !== "string"
+      ) {
+        return null;
+      }
+      if (
+        linkData.path !== undefined &&
+        (!Array.isArray(linkData.path) ||
+          !linkData.path.every((part) => typeof part === "string"))
+      ) {
+        return null;
+      }
 
-      const pathSuffix = linkData.path?.length
-        ? "/" + linkData.path.join("/")
-        : "";
+      const encodedPath = Array.isArray(linkData.path)
+        ? encodeFusePathSegments(linkData.path as string[])
+        : undefined;
+      const pathSuffix = encodedPath?.length ? "/" + encodedPath.join("/") : "";
 
       if (!linkData.id) {
         // Self-reference: just the path relative to piece root
-        return linkData.path?.length ? linkData.path.join("/") : null;
+        return encodedPath?.length ? encodedPath.join("/") : null;
       }
 
-      const entityHash = linkData.id;
+      const entityHash = encodeFuseComponent(linkData.id);
       // depth is relative to the piece dir (input/ or result/ adds 1)
       // We need to go up to the space dir: up from current depth + up past piece name + up past "pieces"
       const upToSpace = "../".repeat(depth + 2);
 
       if (linkData.space && linkData.space !== spaceName) {
         // Cross-space: go up to mount root, then into other space
-        return upToSpace + "../" + linkData.space + "/entities/" + entityHash +
-          pathSuffix;
+        return upToSpace + "../" + encodeFuseComponent(linkData.space) +
+          "/entities/" + entityHash + pathSuffix;
       }
 
       // Same-space: go up to space dir, then into entities/
@@ -3026,23 +3077,25 @@ export class CellBridge {
         ? file.name.slice(1)
         : file.name;
       const parts = relPath.split("/");
+      const encodedParts = encodeFusePathSegments(parts);
       let parentIno = srcIno;
       // Create intermediate directories
       for (let i = 0; i < parts.length - 1; i++) {
-        const existing = this.tree.lookup(parentIno, parts[i]);
+        const encodedPart = encodedParts[i];
+        const existing = this.tree.lookup(parentIno, encodedPart);
         if (existing !== undefined) {
           parentIno = existing;
         } else {
-          const dirIno = this.tree.addDir(parentIno, parts[i]);
+          const dirIno = this.tree.addDir(parentIno, encodedPart);
           const dirPath = [".src", ...parts.slice(0, i + 1)];
           annotator?.annotateJsonDirectory(dirIno, dirPath, {});
-          annotator?.annotateEntry(parentIno, parts[i], dirIno, {
+          annotator?.annotateEntry(parentIno, encodedPart, dirIno, {
             labelPath: dirPath,
           });
           parentIno = dirIno;
         }
       }
-      const fileName = parts[parts.length - 1];
+      const fileName = encodedParts[encodedParts.length - 1];
       const sourceIno = this.tree.addFile(
         parentIno,
         fileName,

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -25,9 +25,9 @@ import {
 import { parseMountedCallablePath } from "./callable-path.ts";
 import {
   buildFsProjection,
-  buildInternalJsonTreeAsync,
   buildJsonTree,
   buildJsonTreeAsync,
+  buildPendingJsonTreeAsync,
   type FsValue,
   isSigilLink,
   isVNode,
@@ -1203,21 +1203,31 @@ export class CellBridge {
       const buildRootName = existingIno !== undefined || jsonIno !== undefined
         ? pendingPropName
         : propName;
-      const buildPropTree = buildRootName === pendingPropName
-        ? buildInternalJsonTreeAsync
-        : buildJsonTreeAsync;
-      const propIno = await buildPropTree(
-        this.tree,
-        pieceIno,
-        buildRootName,
-        treeValue,
-        undefined,
-        resolveLink,
-        0,
-        skipEntry,
-        classifyEntry,
-        cfcAnnotator?.jsonContext([]),
-      );
+      const propIno = buildRootName === pendingPropName
+        ? await buildPendingJsonTreeAsync(
+          this.tree,
+          pieceIno,
+          propName,
+          treeValue,
+          undefined,
+          resolveLink,
+          0,
+          skipEntry,
+          classifyEntry,
+          cfcAnnotator?.jsonContext([]),
+        )
+        : await buildJsonTreeAsync(
+          this.tree,
+          pieceIno,
+          propName,
+          treeValue,
+          undefined,
+          resolveLink,
+          0,
+          skipEntry,
+          classifyEntry,
+          cfcAnnotator?.jsonContext([]),
+        );
       this.addCallableFiles(propIno, callables, propName, cfcAnnotator);
       if (propName === "result") {
         this.addVNodeJsonFiles(propIno, treeValue, cfcAnnotator);

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -25,6 +25,7 @@ import {
 import { parseMountedCallablePath } from "./callable-path.ts";
 import {
   buildFsProjection,
+  buildInternalJsonTreeAsync,
   buildJsonTree,
   buildJsonTreeAsync,
   type FsValue,
@@ -1202,7 +1203,10 @@ export class CellBridge {
       const buildRootName = existingIno !== undefined || jsonIno !== undefined
         ? pendingPropName
         : propName;
-      const propIno = await buildJsonTreeAsync(
+      const buildPropTree = buildRootName === pendingPropName
+        ? buildInternalJsonTreeAsync
+        : buildJsonTreeAsync;
+      const propIno = await buildPropTree(
         this.tree,
         pieceIno,
         buildRootName,

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -147,6 +147,14 @@ function resolveProjectedPieceName(
   return fallback || "piece";
 }
 
+function encodeSpaceDirectoryName(spaceName: string): string {
+  return encodeFuseComponent(spaceName);
+}
+
+function decodeSpaceDirectoryName(spaceName: string): string {
+  return decodeFuseComponent(spaceName);
+}
+
 type Cancel = () => void;
 
 type ResolveLink = (value: unknown, depth: number) => string | null;
@@ -790,7 +798,7 @@ export class CellBridge {
     // Minimum: spaceName/pieces/pieceName/cell = 4 segments
     if (segments.length < 4) return null;
 
-    const spaceName = segments[0];
+    const spaceName = decodeSpaceDirectoryName(segments[0]);
     if (segments[1] !== "pieces") return null;
     const pieceName = segments[2];
 
@@ -894,7 +902,7 @@ export class CellBridge {
     if (segments[1] !== "pieces") return null;
     if (segments[3] !== ".src") return null;
 
-    const spaceName = segments[0];
+    const spaceName = decodeSpaceDirectoryName(segments[0]);
     const pieceName = segments[2];
     const relPath = decodeFusePathSegments(segments.slice(4)).join("/");
 
@@ -1525,7 +1533,7 @@ export class CellBridge {
 
     // Determine current space from parent's path
     const currentSpace = parentSegments.length > 0
-      ? parentSegments[0]
+      ? decodeSpaceDirectoryName(parentSegments[0])
       : undefined;
 
     // Match: /<space>/entities/<hash>[/<path...>]
@@ -1544,7 +1552,7 @@ export class CellBridge {
       }
 
       // Omit space if same as current
-      if (targetSpace !== currentSpace) {
+      if (decodedTargetSpace !== currentSpace) {
         const did = this.knownSpaces.get(decodedTargetSpace);
         result.space = did || decodedTargetSpace;
       }
@@ -1699,7 +1707,10 @@ export class CellBridge {
     const pieces = new PiecesController(manager);
 
     // Create space directory structure
-    const spaceIno = this.tree.addDir(this.tree.rootIno, spaceName);
+    const spaceIno = this.tree.addDir(
+      this.tree.rootIno,
+      encodeSpaceDirectoryName(spaceName),
+    );
     const piecesIno = this.tree.addDir(spaceIno, "pieces");
     const entitiesIno = this.tree.addDir(spaceIno, "entities");
 
@@ -1798,6 +1809,11 @@ export class CellBridge {
     entitiesIno: bigint,
     entityId: string,
   ): Promise<boolean> {
+    const decodedEntityId = decodeFuseComponent(entityId);
+    if (encodeFuseComponent(decodedEntityId) !== entityId) {
+      return false;
+    }
+
     const existingEntityIno = this.tree.lookup(entitiesIno, entityId);
     if (existingEntityIno !== undefined) {
       return true;
@@ -1816,7 +1832,6 @@ export class CellBridge {
     if (!state || !spaceName) return false;
 
     // Match entity ID against known pieces (with or without of: prefix)
-    const decodedEntityId = decodeFuseComponent(entityId);
     const bareId = decodedEntityId.startsWith("of:")
       ? decodedEntityId.slice(3)
       : decodedEntityId;
@@ -1831,11 +1846,12 @@ export class CellBridge {
       }
     }
     if (!matchedPiece) return false;
+    if (encodeFuseComponent(matchedPiece.id) !== entityId) return false;
 
     await this.loadPieceTree(
       matchedPiece,
       entitiesIno,
-      entityId,
+      encodeFuseComponent(matchedPiece.id),
       spaceName,
       existingEntityIno,
       "entities",

--- a/packages/fuse/handles.test.ts
+++ b/packages/fuse/handles.test.ts
@@ -78,11 +78,15 @@ Deno.test("HandleMap only marks the truncating handle pending when provided", ()
   assertEquals(staleHandle?.buffer.length, 0);
   assertEquals(staleHandle?.dirty, false);
   assertEquals(staleHandle?.truncatePending, false);
+  assertEquals(handleHasPendingChanges(staleHandle), false);
+  assertEquals(handleHasBufferedContent(staleHandle), true);
 
   const truncatingHandle = handles.get(truncating);
   assertEquals(truncatingHandle?.buffer.length, 0);
   assertEquals(truncatingHandle?.dirty, false);
   assertEquals(truncatingHandle?.truncatePending, true);
+  assertEquals(handleHasPendingChanges(truncatingHandle), true);
+  assertEquals(handleHasBufferedContent(truncatingHandle), true);
 });
 
 Deno.test("HandleMap rejects invalid and oversized write allocations", () => {

--- a/packages/fuse/handles.test.ts
+++ b/packages/fuse/handles.test.ts
@@ -3,6 +3,8 @@ import {
   handleHasBufferedContent,
   handleHasPendingChanges,
   HandleMap,
+  MAX_VIRTUAL_FILE_SIZE,
+  validateVirtualFileRange,
 } from "./handles.ts";
 import { O_RDWR } from "./platform.ts";
 
@@ -36,6 +38,48 @@ Deno.test("HandleMap clears pending truncates when content arrives", () => {
   assertEquals(handle?.dirty, true);
   assertEquals(handle?.truncatePending, false);
   assertEquals(handleHasPendingChanges(handle), true);
+});
+
+Deno.test("HandleMap rejects invalid and oversized write allocations", () => {
+  const handles = new HandleMap();
+  const fh = handles.open(1n, O_RDWR, new Uint8Array(0));
+
+  assertEquals(handles.write(fh, encoder.encode("x"), -1), false);
+  assertEquals(
+    handles.write(fh, encoder.encode("x"), MAX_VIRTUAL_FILE_SIZE),
+    false,
+  );
+
+  const handle = handles.get(fh);
+  assertEquals(handle?.buffer.length, 0);
+  assertEquals(handle?.dirty, false);
+});
+
+Deno.test("HandleMap rejects oversized truncates without resizing buffers", () => {
+  const handles = new HandleMap();
+  const fh = handles.open(1n, O_RDWR, encoder.encode("hello"));
+
+  assertEquals(handles.truncate(fh, MAX_VIRTUAL_FILE_SIZE + 1), false);
+  assertEquals(handles.truncate(fh, -1), false);
+  assertEquals(new TextDecoder().decode(handles.get(fh)?.buffer), "hello");
+});
+
+Deno.test("validateVirtualFileRange classifies invalid and too-large ranges", () => {
+  assertEquals(validateVirtualFileRange(-1, 1), {
+    ok: false,
+    reason: "invalid",
+  });
+  assertEquals(validateVirtualFileRange(0, -1), {
+    ok: false,
+    reason: "invalid",
+  });
+  assertEquals(validateVirtualFileRange(MAX_VIRTUAL_FILE_SIZE, 1), {
+    ok: false,
+    reason: "too-large",
+  });
+  assertEquals(validateVirtualFileRange(MAX_VIRTUAL_FILE_SIZE - 1, 1), {
+    ok: true,
+  });
 });
 
 Deno.test("HandleMap stores stable write targets on open handles", () => {

--- a/packages/fuse/handles.test.ts
+++ b/packages/fuse/handles.test.ts
@@ -40,6 +40,51 @@ Deno.test("HandleMap clears pending truncates when content arrives", () => {
   assertEquals(handleHasPendingChanges(handle), true);
 });
 
+Deno.test("HandleMap truncates every open handle for an inode", () => {
+  const handles = new HandleMap();
+  const first = handles.open(1n, O_RDWR, encoder.encode("first"));
+  const second = handles.open(1n, O_RDWR, encoder.encode("second"));
+  const other = handles.open(2n, O_RDWR, encoder.encode("other"));
+
+  handles.write(first, encoder.encode("stale"), 0);
+
+  assertEquals(handles.truncateByIno(1n, 0), true);
+
+  for (const fh of [first, second]) {
+    const handle = handles.get(fh);
+    assertEquals(handle?.buffer.length, 0);
+    assertEquals(handle?.dirty, false);
+    assertEquals(handle?.truncatePending, true);
+  }
+  assertEquals(new TextDecoder().decode(handles.get(other)?.buffer), "other");
+
+  handles.write(first, encoder.encode("fresh"), 0);
+  const firstHandle = handles.get(first);
+  assertEquals(new TextDecoder().decode(firstHandle?.buffer), "fresh");
+  assertEquals(firstHandle?.dirty, true);
+  assertEquals(firstHandle?.truncatePending, false);
+});
+
+Deno.test("HandleMap only marks the truncating handle pending when provided", () => {
+  const handles = new HandleMap();
+  const stale = handles.open(1n, O_RDWR, encoder.encode("stale"));
+  const truncating = handles.open(1n, O_RDWR, encoder.encode("current"));
+
+  handles.write(stale, encoder.encode("dirty"), 0);
+
+  assertEquals(handles.truncateByIno(1n, 0, { pendingFh: truncating }), true);
+
+  const staleHandle = handles.get(stale);
+  assertEquals(staleHandle?.buffer.length, 0);
+  assertEquals(staleHandle?.dirty, false);
+  assertEquals(staleHandle?.truncatePending, false);
+
+  const truncatingHandle = handles.get(truncating);
+  assertEquals(truncatingHandle?.buffer.length, 0);
+  assertEquals(truncatingHandle?.dirty, false);
+  assertEquals(truncatingHandle?.truncatePending, true);
+});
+
 Deno.test("HandleMap rejects invalid and oversized write allocations", () => {
   const handles = new HandleMap();
   const fh = handles.open(1n, O_RDWR, new Uint8Array(0));

--- a/packages/fuse/handles.ts
+++ b/packages/fuse/handles.ts
@@ -34,6 +34,7 @@ export interface HandleState {
   dirty: boolean;
   flushing: boolean;
   buffer: Uint8Array;
+  bufferValid: boolean;
   truncatePending: boolean;
   version: number;
   writeTarget?: unknown;
@@ -52,7 +53,7 @@ export function handleHasBufferedContent(
 ): boolean {
   return Boolean(
     handle &&
-      (handle.buffer.length > 0 || handle.dirty || handle.truncatePending),
+      (handle.bufferValid || handle.dirty || handle.truncatePending),
   );
 }
 
@@ -79,6 +80,7 @@ export class HandleMap {
       dirty: false,
       flushing: false,
       buffer: isWritable ? new Uint8Array(content ?? []) : new Uint8Array(0),
+      bufferValid: isWritable,
       truncatePending: false,
       version: 0,
       writeTarget: options?.writeTarget,
@@ -132,6 +134,7 @@ export class HandleMap {
       state.buffer = newBuf;
     }
     state.buffer.set(data, offset);
+    state.bufferValid = true;
     state.dirty = true;
     state.truncatePending = false;
     state.version++;
@@ -143,6 +146,7 @@ export class HandleMap {
     const state = this.handles.get(fh);
     if (!state) return false;
     state.buffer = new Uint8Array(0);
+    state.bufferValid = true;
     state.dirty = false;
     state.truncatePending = true;
     state.version++;
@@ -162,6 +166,7 @@ export class HandleMap {
           options.pendingFh === fh;
         if (size === 0) {
           state.buffer = new Uint8Array(0);
+          state.bufferValid = true;
           state.dirty = false;
           state.truncatePending = shouldFlush;
         } else {
@@ -172,6 +177,7 @@ export class HandleMap {
             newBuf.set(state.buffer);
             state.buffer = newBuf;
           }
+          state.bufferValid = true;
           state.dirty = shouldFlush;
           state.truncatePending = false;
         }
@@ -189,6 +195,7 @@ export class HandleMap {
 
     if (size === 0) {
       state.buffer = new Uint8Array(0);
+      state.bufferValid = true;
       state.dirty = false;
       state.truncatePending = true;
     } else {
@@ -199,6 +206,7 @@ export class HandleMap {
         newBuf.set(state.buffer);
         state.buffer = newBuf;
       }
+      state.bufferValid = true;
       state.dirty = true;
       state.truncatePending = false;
     }

--- a/packages/fuse/handles.ts
+++ b/packages/fuse/handles.ts
@@ -4,6 +4,30 @@ import type { CfcNodeAnnotation } from "./annotations.ts";
 import type { CfcExistingWritebackOperation } from "./cfc-writeback.ts";
 import { O_RDWR, O_WRONLY } from "./platform.ts";
 
+export const MAX_VIRTUAL_FILE_SIZE = 64 * 1024 * 1024;
+
+export type VirtualFileRangeValidation =
+  | { ok: true }
+  | { ok: false; reason: "invalid" | "too-large" };
+
+export function validateVirtualFileRange(
+  offset: number,
+  length: number,
+  maxSize = MAX_VIRTUAL_FILE_SIZE,
+): VirtualFileRangeValidation {
+  if (
+    !Number.isSafeInteger(offset) || !Number.isSafeInteger(length) ||
+    offset < 0 || length < 0
+  ) {
+    return { ok: false, reason: "invalid" };
+  }
+  const end = offset + length;
+  if (!Number.isSafeInteger(end) || end > maxSize) {
+    return { ok: false, reason: "too-large" };
+  }
+  return { ok: true };
+}
+
 export interface HandleState {
   ino: bigint;
   flags: number;
@@ -99,6 +123,7 @@ export class HandleMap {
     const state = this.handles.get(fh);
     if (!state) return false;
 
+    if (!validateVirtualFileRange(offset, data.length).ok) return false;
     const end = offset + data.length;
     if (end > state.buffer.length) {
       // Extend buffer
@@ -125,7 +150,8 @@ export class HandleMap {
   }
 
   /** Truncate all handles for a given inode to the specified size. */
-  truncateByIno(ino: bigint, size: number): void {
+  truncateByIno(ino: bigint, size: number): boolean {
+    if (!validateVirtualFileRange(0, size).ok) return false;
     for (const [, state] of this.handles) {
       if (state.ino === ino) {
         if (size === 0) {
@@ -146,12 +172,14 @@ export class HandleMap {
         state.version++;
       }
     }
+    return true;
   }
 
   /** Truncate the handle's buffer to the given size. */
   truncate(fh: bigint, size: number): boolean {
     const state = this.handles.get(fh);
     if (!state) return false;
+    if (!validateVirtualFileRange(0, size).ok) return false;
 
     if (size === 0) {
       state.buffer = new Uint8Array(0);

--- a/packages/fuse/handles.ts
+++ b/packages/fuse/handles.ts
@@ -150,14 +150,20 @@ export class HandleMap {
   }
 
   /** Truncate all handles for a given inode to the specified size. */
-  truncateByIno(ino: bigint, size: number): boolean {
+  truncateByIno(
+    ino: bigint,
+    size: number,
+    options?: { pendingFh?: bigint },
+  ): boolean {
     if (!validateVirtualFileRange(0, size).ok) return false;
-    for (const [, state] of this.handles) {
+    for (const [fh, state] of this.handles) {
       if (state.ino === ino) {
+        const shouldFlush = options?.pendingFh === undefined ||
+          options.pendingFh === fh;
         if (size === 0) {
           state.buffer = new Uint8Array(0);
           state.dirty = false;
-          state.truncatePending = true;
+          state.truncatePending = shouldFlush;
         } else {
           if (size < state.buffer.length) {
             state.buffer = state.buffer.slice(0, size);
@@ -166,7 +172,7 @@ export class HandleMap {
             newBuf.set(state.buffer);
             state.buffer = newBuf;
           }
-          state.dirty = true;
+          state.dirty = shouldFlush;
           state.truncatePending = false;
         }
         state.version++;

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -1,8 +1,13 @@
 import { assertEquals } from "@std/assert";
 import {
+  appendDecodedJsonPath,
+  bufferForNoHandleTruncate,
+  decodeFuseNamespaceName,
   DEFAULT_CFC_XATTR_NAMESPACE,
   defaultCfcWritebackStatePath,
   parseCfcXattrNamespace,
+  rootSpaceLookupNames,
+  sourceRelPathToTreeSegments,
 } from "./mod.ts";
 
 function env(values: Record<string, string | undefined>) {
@@ -57,4 +62,36 @@ Deno.test("default CFC writeback state path avoids /tmp fallback", () => {
     ),
     "/home/alice/.cache/commonfabric-fuse/cfc-writeback-_2Fmnt_2Fcf.json",
   );
+});
+
+Deno.test("FUSE namespace writeback decodes path component names", () => {
+  assertEquals(decodeFuseNamespaceName("of%3Aentity"), "of:entity");
+  assertEquals(
+    appendDecodedJsonPath(["items"], "of%3Aentity"),
+    ["items", "of:entity"],
+  );
+});
+
+Deno.test("source writeback re-encodes decoded source relpaths for tree lookup", () => {
+  assertEquals(
+    sourceRelPathToTreeSegments("src/has:colon.tsx"),
+    ["src", "has%3Acolon.tsx"],
+  );
+});
+
+Deno.test("no-handle truncate opens only the bounded target prefix", () => {
+  const content = new Uint8Array([1, 2, 3, 4, 5]);
+  assertEquals([...bufferForNoHandleTruncate(content, 2)], [1, 2]);
+  assertEquals(bufferForNoHandleTruncate(content, 0).length, 0);
+});
+
+Deno.test("root space lookup decodes request names and replies with canonical names", () => {
+  assertEquals(rootSpaceLookupNames("did%3Akey%3AzSpace"), {
+    spaceName: "did:key:zSpace",
+    directoryName: "did%3Akey%3AzSpace",
+  });
+  assertEquals(rootSpaceLookupNames("home"), {
+    spaceName: "home",
+    directoryName: "home",
+  });
 });

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -965,7 +965,11 @@ export async function main(argv: string[] = Deno.args) {
         { writeTarget, cfcAuthorizedOperations, cfcAuthorizationAnnotation },
       );
       if (truncate) {
-        handles.markTruncated(fh);
+        if (!handles.truncateByIno(inode, 0, { pendingFh: fh })) {
+          handles.close(fh);
+          fuse.symbols.fuse_reply_err(req, EIO);
+          return;
+        }
       }
       writeFileInfo(fi, fh);
       fuse.symbols.fuse_reply_open(req, fi);
@@ -1699,7 +1703,10 @@ export async function main(argv: string[] = Deno.args) {
         const { fh } = readFileInfo(fi);
         const handle = handles.get(fh);
         if (handle) {
-          if (!handles.truncate(fh, newSize)) {
+          const truncated = node.kind === "file"
+            ? handles.truncateByIno(inode, newSize, { pendingFh: fh })
+            : handles.truncate(fh, newSize);
+          if (!truncated) {
             fuse.symbols.fuse_reply_err(req, EIO);
             return;
           }
@@ -1736,7 +1743,11 @@ export async function main(argv: string[] = Deno.args) {
                 cfcAuthorizationAnnotation: node.cfc,
               },
             );
-            if (!handles.truncate(truncateFh, newSize)) {
+            if (
+              !handles.truncateByIno(inode, newSize, {
+                pendingFh: truncateFh,
+              })
+            ) {
               handles.close(truncateFh);
               fuse.symbols.fuse_reply_err(req, EIO);
               return;

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -107,7 +107,8 @@ globalThis.addEventListener("error", (e) => {
 type HandleWriteTarget =
   | { kind: "handler"; target: HandlerTarget }
   | { kind: "value"; target: WritePath }
-  | { kind: "source"; target: SourceWritePath };
+  | { kind: "source"; target: SourceWritePath }
+  | { kind: "ignored" };
 
 export const DEFAULT_CFC_XATTR_NAMESPACE: CfcXattrNamespace = "both";
 
@@ -928,8 +929,11 @@ export async function main(argv: string[] = Deno.args) {
       const cfcAuthorizedOperations: CfcExistingWritebackOperation[] = [];
       const cfcAuthorizationAnnotation = node.cfc;
       if (isWriting && bridge) {
+        const nodeName = tree.getNameForIno(inode) ?? "";
         const sourceWritePath = bridge.resolveSourceWritePath(inode);
-        if (sourceWritePath) {
+        if (nodeName.startsWith("._")) {
+          writeTarget = { kind: "ignored" };
+        } else if (sourceWritePath) {
           writeTarget = { kind: "source", target: sourceWritePath };
         } else {
           const writePath = bridge.resolveWritePath(inode);
@@ -944,7 +948,7 @@ export async function main(argv: string[] = Deno.args) {
       // Get current content for the handle buffer
       const content = node.kind === "file" ? node.content : new Uint8Array(0);
       const truncate = (flags & O_TRUNC) !== 0;
-      if (isWriting) {
+      if (isWriting && writeTarget?.kind !== "ignored") {
         const operation: CfcExistingWritebackOperation = truncate
           ? "truncate"
           : "write";
@@ -1202,6 +1206,15 @@ export async function main(argv: string[] = Deno.args) {
       }
     };
     try {
+      if (writeTarget?.kind === "ignored") {
+        if (handle.version === flushVersion) {
+          handle.dirty = false;
+          handle.truncatePending = false;
+          handle.buffer = new Uint8Array(0);
+        }
+        return 0;
+      }
+
       if (writeTarget?.kind === "handler") {
         const text = new TextDecoder().decode(buffer);
         const trimmed = text.trim();
@@ -1527,7 +1540,11 @@ export async function main(argv: string[] = Deno.args) {
         view.copyInto(data);
       }
 
-      if (!authorizeHandleCfcWrite(fh, handle, "write")) {
+      const writeTarget = handle.writeTarget as HandleWriteTarget | undefined;
+      if (
+        writeTarget?.kind !== "ignored" &&
+        !authorizeHandleCfcWrite(fh, handle, "write")
+      ) {
         fuse.symbols.fuse_reply_err(req, EACCES);
         return;
       }
@@ -1601,6 +1618,16 @@ export async function main(argv: string[] = Deno.args) {
       const node = tree.getNode(inode);
       if (!node) {
         fuse.symbols.fuse_reply_err(req, ENOENT);
+        return;
+      }
+      if ((tree.getNameForIno(inode) ?? "").startsWith("._")) {
+        const statBuf = new ArrayBuffer(STAT_SIZE);
+        writeStat(statBuf, buildStat(node, inode));
+        fuse.symbols.fuse_reply_attr(
+          req,
+          Deno.UnsafePointer.of(new Uint8Array(statBuf)),
+          0,
+        );
         return;
       }
       const sizeChange = (toSet & FUSE_SET_ATTR_SIZE) !== 0;
@@ -1677,50 +1704,55 @@ export async function main(argv: string[] = Deno.args) {
             return;
           }
         } else {
-          if (!bridge || node.kind !== "file") {
+          if (node.kind === "callable" && node.callableKind === "handler") {
+            // FUSE-T may issue O_TRUNC as a separate setattr without a file
+            // handle. Handler contents are delivered through write/flush, so
+            // this size-only setattr is just the shell clearing the send buffer.
+          } else if (!bridge || node.kind !== "file") {
             fuse.symbols.fuse_reply_err(req, EACCES);
             return;
-          }
-          const sourceWritePath = bridge.resolveSourceWritePath(inode);
-          const valueWritePath = sourceWritePath === null
-            ? bridge.resolveWritePath(inode)
-            : null;
-          const writeTarget: HandleWriteTarget | undefined = sourceWritePath
-            ? { kind: "source", target: sourceWritePath }
-            : valueWritePath
-            ? { kind: "value", target: valueWritePath }
-            : undefined;
-          if (!writeTarget) {
-            fuse.symbols.fuse_reply_err(req, EACCES);
-            return;
-          }
+          } else {
+            const sourceWritePath = bridge.resolveSourceWritePath(inode);
+            const valueWritePath = sourceWritePath === null
+              ? bridge.resolveWritePath(inode)
+              : null;
+            const writeTarget: HandleWriteTarget | undefined = sourceWritePath
+              ? { kind: "source", target: sourceWritePath }
+              : valueWritePath
+              ? { kind: "value", target: valueWritePath }
+              : undefined;
+            if (!writeTarget) {
+              fuse.symbols.fuse_reply_err(req, EACCES);
+              return;
+            }
 
-          const truncateFh = handles.open(
-            inode,
-            O_WRONLY,
-            bufferForNoHandleTruncate(node.content, newSize),
-            {
-              writeTarget,
-              cfcAuthorizedOperations: ["truncate"],
-              cfcAuthorizationAnnotation: node.cfc,
-            },
-          );
-          if (!handles.truncate(truncateFh, newSize)) {
-            handles.close(truncateFh);
-            fuse.symbols.fuse_reply_err(req, EIO);
-            return;
+            const truncateFh = handles.open(
+              inode,
+              O_WRONLY,
+              bufferForNoHandleTruncate(node.content, newSize),
+              {
+                writeTarget,
+                cfcAuthorizedOperations: ["truncate"],
+                cfcAuthorizationAnnotation: node.cfc,
+              },
+            );
+            if (!handles.truncate(truncateFh, newSize)) {
+              handles.close(truncateFh);
+              fuse.symbols.fuse_reply_err(req, EIO);
+              return;
+            }
+            const truncateHandle = handles.get(truncateFh);
+            if (!truncateHandle) {
+              fuse.symbols.fuse_reply_err(req, EIO);
+              return;
+            }
+            tree.updateFile(inode, truncateHandle.buffer, node.jsonType);
+            flushHandle(truncateHandle).catch((e) => {
+              console.error(`[fuse] truncate write error: ${e}`);
+            }).finally(() => {
+              handles.close(truncateFh);
+            });
           }
-          const truncateHandle = handles.get(truncateFh);
-          if (!truncateHandle) {
-            fuse.symbols.fuse_reply_err(req, EIO);
-            return;
-          }
-          tree.updateFile(inode, truncateHandle.buffer, node.jsonType);
-          flushHandle(truncateHandle).catch((e) => {
-            console.error(`[fuse] truncate write error: ${e}`);
-          }).finally(() => {
-            handles.close(truncateFh);
-          });
         }
       }
 
@@ -1989,9 +2021,29 @@ export async function main(argv: string[] = Deno.args) {
       const parent = BigInt(parentIno);
       const name = readCString(namePtr);
 
-      // Reject macOS resource fork / metadata files
       if (name.startsWith("._")) {
-        fuse.symbols.fuse_reply_err(req, EACCES);
+        // FUSE-T/macOS may create AppleDouble sidecars before opening the real
+        // file. Keep them local so they don't block writes or persist into cells.
+        const existingIno = tree.lookup(parent, name);
+        const ino = existingIno ?? tree.addFile(parent, name, "", "string");
+        const fh = handles.open(ino, O_RDWR, new Uint8Array(0), {
+          writeTarget: { kind: "ignored" } satisfies HandleWriteTarget,
+        });
+        writeFileInfo(fi, fh);
+
+        const node = tree.getNode(ino);
+        const entryBuf = new ArrayBuffer(ENTRY_PARAM_SIZE);
+        writeEntryParam(entryBuf, {
+          ino,
+          attr: buildStat(node!, ino),
+          attrTimeout: 0,
+          entryTimeout: 0,
+        });
+        fuse.symbols.fuse_reply_create(
+          req,
+          Deno.UnsafePointer.of(new Uint8Array(entryBuf)),
+          fi,
+        );
         return;
       }
 
@@ -2143,6 +2195,11 @@ export async function main(argv: string[] = Deno.args) {
 
       const parent = BigInt(parentIno);
       const name = readCString(namePtr);
+      if (name.startsWith("._")) {
+        tree.removeChild(parent, name);
+        fuse.symbols.fuse_reply_err(req, 0);
+        return;
+      }
 
       let parentPath = null as ReturnType<CellBridge["resolveWritePath"]>;
       let authorization = undefined as

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -1215,6 +1215,7 @@ export async function main(argv: string[] = Deno.args) {
           handle.dirty = false;
           handle.truncatePending = false;
           handle.buffer = new Uint8Array(0);
+          handle.bufferValid = false;
         }
         return 0;
       }
@@ -1240,6 +1241,7 @@ export async function main(argv: string[] = Deno.args) {
           handle.dirty = false;
           handle.truncatePending = false;
           handle.buffer = new Uint8Array(0); // fire-and-forget
+          handle.bufferValid = false;
         }
         return 0;
       }

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -47,6 +47,7 @@ import {
 import {
   DIR_MODE,
   EACCES,
+  EFBIG,
   EINVAL,
   EIO,
   EISDIR,
@@ -67,6 +68,7 @@ import {
   handleHasPendingChanges,
   HandleMap,
   type HandleState,
+  validateVirtualFileRange,
 } from "./handles.ts";
 import { buildNodeStat, getMountOwnership, nodeMode } from "./stat.ts";
 
@@ -328,6 +330,15 @@ export async function main(argv: string[] = Deno.args) {
 
   // File handle tracking for write support
   const handles = new HandleMap();
+
+  function virtualFileRangeErrno(
+    offset: number,
+    length: number,
+  ): number | null {
+    const validation = validateVirtualFileRange(offset, length);
+    if (validation.ok) return null;
+    return validation.reason === "too-large" ? EFBIG : EINVAL;
+  }
 
   function buildStat(
     node: NonNullable<ReturnType<typeof tree.getNode>>,
@@ -1467,6 +1478,11 @@ export async function main(argv: string[] = Deno.args) {
 
       const sz = Number(size);
       const off = Number(offset);
+      const rangeErrno = virtualFileRangeErrno(off, sz);
+      if (rangeErrno !== null) {
+        fuse.symbols.fuse_reply_err(req, rangeErrno);
+        return;
+      }
 
       // Read data from the FUSE-provided buffer
       const data = new Uint8Array(sz);
@@ -1480,7 +1496,10 @@ export async function main(argv: string[] = Deno.args) {
         return;
       }
 
-      handles.write(fh, data, off);
+      if (!handles.write(fh, data, off)) {
+        fuse.symbols.fuse_reply_err(req, EIO);
+        return;
+      }
       fuse.symbols.fuse_reply_write(req, BigInt(sz));
     },
   );
@@ -1554,6 +1573,16 @@ export async function main(argv: string[] = Deno.args) {
       const metadataFields = metadataChange
         ? metadataFieldsForSetattrFlags(metadataFlags)
         : [];
+      let newSize = 0;
+      if (sizeChange) {
+        const attrView = new Deno.UnsafePointerView(_attrPtr!);
+        newSize = Number(attrView.getBigInt64(STAT_ST_SIZE_OFFSET));
+        const rangeErrno = virtualFileRangeErrno(0, newSize);
+        if (rangeErrno !== null) {
+          fuse.symbols.fuse_reply_err(req, rangeErrno);
+          return;
+        }
+      }
 
       let truncateAuthorization = undefined as
         | ReturnType<typeof authorizeExistingWriteback>
@@ -1604,23 +1633,58 @@ export async function main(argv: string[] = Deno.args) {
 
       // Handle truncate / size change
       if (sizeChange) {
-        // Read new size from attr struct
-        const attrView = new Deno.UnsafePointerView(_attrPtr!);
-        const newSize = Number(attrView.getBigInt64(STAT_ST_SIZE_OFFSET));
         const { fh } = readFileInfo(fi);
         const handle = handles.get(fh);
         if (handle) {
-          handles.truncate(fh, newSize);
-        } else {
-          // No valid fh — NFS/FUSE-T calls setattr(size=0) separately.
-          // Truncate all open handles for this inode and the tree node.
-          handles.truncateByIno(inode, newSize);
-          if (node.kind === "file") {
-            tree.updateFile(
-              inode,
-              newSize === 0 ? "" : node.content.slice(0, newSize),
-            );
+          if (!handles.truncate(fh, newSize)) {
+            fuse.symbols.fuse_reply_err(req, EIO);
+            return;
           }
+        } else {
+          if (!bridge || node.kind !== "file") {
+            fuse.symbols.fuse_reply_err(req, EACCES);
+            return;
+          }
+          const sourceWritePath = bridge.resolveSourceWritePath(inode);
+          const valueWritePath = sourceWritePath === null
+            ? bridge.resolveWritePath(inode)
+            : null;
+          const writeTarget: HandleWriteTarget | undefined = sourceWritePath
+            ? { kind: "source", target: sourceWritePath }
+            : valueWritePath
+            ? { kind: "value", target: valueWritePath }
+            : undefined;
+          if (!writeTarget) {
+            fuse.symbols.fuse_reply_err(req, EACCES);
+            return;
+          }
+
+          const truncateFh = handles.open(
+            inode,
+            O_WRONLY,
+            node.content,
+            {
+              writeTarget,
+              cfcAuthorizedOperations: ["truncate"],
+              cfcAuthorizationAnnotation: node.cfc,
+            },
+          );
+          if (!handles.truncate(truncateFh, newSize)) {
+            handles.close(truncateFh);
+            fuse.symbols.fuse_reply_err(req, EIO);
+            return;
+          }
+          const truncateHandle = handles.get(truncateFh);
+          if (!truncateHandle) {
+            fuse.symbols.fuse_reply_err(req, EIO);
+            return;
+          }
+          tree.updateFile(inode, truncateHandle.buffer, node.jsonType);
+          flushHandle(truncateHandle).catch((e) => {
+            console.error(`[fuse] truncate write error: ${e}`);
+          }).finally(() => {
+            handles.close(truncateFh);
+          });
         }
       }
 

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -70,6 +70,7 @@ import {
   type HandleState,
   validateVirtualFileRange,
 } from "./handles.ts";
+import { decodeFuseComponent, encodeFusePathSegments } from "./path-codec.ts";
 import { buildNodeStat, getMountOwnership, nodeMode } from "./stat.ts";
 
 const encoder = new TextEncoder();
@@ -141,6 +142,40 @@ export function defaultCfcWritebackStatePath(
     .replace(/[^A-Za-z0-9_.-]/g, "_")
     .slice(0, 120) || "mount";
   return `${stateDir}/cfc-writeback-${safeMount}.json`;
+}
+
+export function decodeFuseNamespaceName(name: string): string {
+  return decodeFuseComponent(name);
+}
+
+export function appendDecodedJsonPath(
+  basePath: readonly (string | number)[],
+  name: string,
+): (string | number)[] {
+  return [...basePath, decodeFuseNamespaceName(name)];
+}
+
+export function sourceRelPathToTreeSegments(relPath: string): string[] {
+  return encodeFusePathSegments(relPath.split("/"));
+}
+
+export function bufferForNoHandleTruncate(
+  content: Uint8Array,
+  newSize: number,
+): Uint8Array {
+  if (newSize <= 0) return new Uint8Array(0);
+  return content.slice(0, Math.min(newSize, content.length));
+}
+
+export function rootSpaceLookupNames(name: string): {
+  spaceName: string;
+  directoryName: string;
+} {
+  const spaceName = decodeFuseNamespaceName(name);
+  return {
+    spaceName,
+    directoryName: encodeFusePathSegments([spaceName])[0],
+  };
 }
 
 function readBuffer(ptr: Deno.PointerValue, size: bigint): Uint8Array {
@@ -720,11 +755,12 @@ export async function main(argv: string[] = Deno.args) {
       // If at root and bridge is available, try async space connection.
       // Reply from tree synchronously if space is already connected.
       if (parent === tree.rootIno && bridge && !name.startsWith(".")) {
-        if (replyLookupFromTree(req, parent, name)) {
+        const lookup = rootSpaceLookupNames(name);
+        if (replyLookupFromTree(req, parent, lookup.directoryName)) {
           return;
         }
-        bridge.connectSpace(name).then(() => {
-          if (!replyLookupFromTree(req, parent, name)) {
+        bridge.connectSpace(lookup.spaceName).then(() => {
+          if (!replyLookupFromTree(req, parent, lookup.directoryName)) {
             fuse.symbols.fuse_reply_err(req, ENOENT);
           }
         }).catch(() => {
@@ -1197,7 +1233,7 @@ export async function main(argv: string[] = Deno.args) {
 
         // Optimistically update the file content in the tree
         let fileIno: bigint | undefined = srcIno;
-        for (const part of relPath.split("/")) {
+        for (const part of sourceRelPathToTreeSegments(relPath)) {
           fileIno = fileIno !== undefined
             ? tree.lookup(fileIno, part)
             : undefined;
@@ -1662,7 +1698,7 @@ export async function main(argv: string[] = Deno.args) {
           const truncateFh = handles.open(
             inode,
             O_WRONLY,
-            node.content,
+            bufferForNoHandleTruncate(node.content, newSize),
             {
               writeTarget,
               cfcAuthorizedOperations: ["truncate"],
@@ -1984,7 +2020,10 @@ export async function main(argv: string[] = Deno.args) {
         {
           writeTarget: {
             kind: "value",
-            target: { ...parentPath, jsonPath: [...parentPath.jsonPath, name] },
+            target: {
+              ...parentPath,
+              jsonPath: appendDecodedJsonPath(parentPath.jsonPath, name),
+            },
           } satisfies HandleWriteTarget,
         },
       );
@@ -2012,7 +2051,7 @@ export async function main(argv: string[] = Deno.args) {
       );
 
       // Fire-and-forget write to cell
-      const newPath = [...parentPath.jsonPath, name];
+      const newPath = appendDecodedJsonPath(parentPath.jsonPath, name);
       bridge.writeValue(
         { ...parentPath, jsonPath: newPath },
         "",
@@ -2071,7 +2110,7 @@ export async function main(argv: string[] = Deno.args) {
       replyEntry(req, ino, node);
 
       // Fire-and-forget write to cell
-      const newPath = [...parentPath.jsonPath, name];
+      const newPath = appendDecodedJsonPath(parentPath.jsonPath, name);
       bridge.writeValue(
         { ...parentPath, jsonPath: newPath },
         {},
@@ -2175,7 +2214,7 @@ export async function main(argv: string[] = Deno.args) {
             parentPath.jsonPath.length > 0 ? parentPath.jsonPath : undefined,
           );
           if (Array.isArray(currentValue)) {
-            const idx = Number(name);
+            const idx = Number(decodeFuseNamespaceName(name));
             if (!isNaN(idx) && idx >= 0 && idx < currentValue.length) {
               currentValue.splice(idx, 1);
               await bridge!.writeValue(parentPath, currentValue);
@@ -2202,7 +2241,7 @@ export async function main(argv: string[] = Deno.args) {
             !Array.isArray(currentValue)
           ) {
             const obj = { ...(currentValue as Record<string, unknown>) };
-            delete obj[name];
+            delete obj[decodeFuseNamespaceName(name)];
             await bridge!.writeValue(parentPath, obj);
             cfcWritebacks.markReadyForExactRecomputation(
               parent,
@@ -2312,7 +2351,7 @@ export async function main(argv: string[] = Deno.args) {
             parentPath.jsonPath.length > 0 ? parentPath.jsonPath : undefined,
           );
           if (Array.isArray(currentValue)) {
-            const idx = Number(name);
+            const idx = Number(decodeFuseNamespaceName(name));
             if (!isNaN(idx) && idx >= 0 && idx < currentValue.length) {
               currentValue.splice(idx, 1);
               await bridge!.writeValue(parentPath, currentValue);
@@ -2339,7 +2378,7 @@ export async function main(argv: string[] = Deno.args) {
             !Array.isArray(currentValue)
           ) {
             const obj = { ...(currentValue as Record<string, unknown>) };
-            delete obj[name];
+            delete obj[decodeFuseNamespaceName(name)];
             await bridge!.writeValue(parentPath, obj);
             cfcWritebacks.markReadyForExactRecomputation(
               parent,
@@ -2463,7 +2502,10 @@ export async function main(argv: string[] = Deno.args) {
         );
 
         // Write at new path
-        const destPath = [...newParentPath.jsonPath, newName];
+        const destPath = appendDecodedJsonPath(
+          newParentPath.jsonPath,
+          newName,
+        );
         await bridge!.writeValue(
           { ...newParentPath, jsonPath: destPath },
           value,
@@ -2480,10 +2522,10 @@ export async function main(argv: string[] = Deno.args) {
           !Array.isArray(parentValue)
         ) {
           const obj = { ...(parentValue as Record<string, unknown>) };
-          delete obj[oldName];
+          delete obj[decodeFuseNamespaceName(oldName)];
           await bridge!.writeValue(oldParentWritePath, obj);
         } else if (Array.isArray(parentValue)) {
-          const idx = Number(oldName);
+          const idx = Number(decodeFuseNamespaceName(oldName));
           if (!isNaN(idx)) {
             parentValue.splice(idx, 1);
             await bridge!.writeValue(oldParentWritePath, parentValue);
@@ -2653,7 +2695,7 @@ export async function main(argv: string[] = Deno.args) {
       const sigilValue = { "/": { "link@1": sigil } };
       const writePath = {
         ...parentPath,
-        jsonPath: [...parentPath.jsonPath, name],
+        jsonPath: appendDecodedJsonPath(parentPath.jsonPath, name),
       };
 
       // Optimistic: add to tree and reply immediately, then write to cell.

--- a/packages/fuse/path-codec.test.ts
+++ b/packages/fuse/path-codec.test.ts
@@ -1,0 +1,41 @@
+import { assertEquals } from "@std/assert";
+import {
+  decodeFuseComponent,
+  decodeFusePathSegments,
+  encodeFuseComponent,
+  encodeFusePathSegments,
+} from "./path-codec.ts";
+
+Deno.test("path codec leaves ordinary components stable", () => {
+  assertEquals(encodeFuseComponent("title"), "title");
+  assertEquals(encodeFuseComponent("item-01"), "item-01");
+  assertEquals(decodeFuseComponent("item-01"), "item-01");
+});
+
+Deno.test("path codec escapes unsafe and macOS-special components", () => {
+  assertEquals(encodeFuseComponent("has/slash"), "has%2Fslash");
+  assertEquals(encodeFuseComponent("of:entity"), "of%3Aentity");
+  assertEquals(encodeFuseComponent("literal%"), "literal%25");
+  assertEquals(encodeFuseComponent(".hidden"), "%2Ehidden");
+  assertEquals(encodeFuseComponent("."), "%2E");
+  assertEquals(encodeFuseComponent(".."), "%2E%2E");
+  assertEquals(
+    encodeFuseComponent("value.json", { reserveJsonSuffix: true }),
+    "value%2Ejson",
+  );
+});
+
+Deno.test("path codec decodes escaped components and paths", () => {
+  assertEquals(decodeFuseComponent("has%2Fslash"), "has/slash");
+  assertEquals(decodeFuseComponent("of%3Aentity"), "of:entity");
+  assertEquals(decodeFuseComponent("literal%25"), "literal%");
+  assertEquals(decodeFuseComponent("%2Ehidden"), ".hidden");
+  assertEquals(
+    decodeFusePathSegments(["src", "has%3Acolon.tsx"]),
+    ["src", "has:colon.tsx"],
+  );
+  assertEquals(
+    encodeFusePathSegments(["src", "has:colon.tsx"]),
+    ["src", "has%3Acolon.tsx"],
+  );
+});

--- a/packages/fuse/path-codec.ts
+++ b/packages/fuse/path-codec.ts
@@ -1,0 +1,92 @@
+// path-codec.ts — reversible filesystem component encoding for user data
+
+export interface EncodeFuseComponentOptions {
+  reserveJsonSuffix?: boolean;
+}
+
+const EMPTY_COMPONENT = "%_empty";
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const hex = (byte: number): string =>
+  byte.toString(16).toUpperCase().padStart(
+    2,
+    "0",
+  );
+
+const isHex = (value: string): boolean => /^[0-9A-Fa-f]$/.test(value);
+
+function encodeUtf8(value: string): string {
+  return [...encoder.encode(value)].map((byte) => `%${hex(byte)}`).join("");
+}
+
+function mustEscape(raw: string, char: string, index: number): boolean {
+  if (char === "/" || char === "\0" || char === "%" || char === ":") {
+    return true;
+  }
+  if (index === 0 && char === ".") return true;
+  if ((raw === "." || raw === "..") && char === ".") return true;
+  return false;
+}
+
+export function encodeFuseComponent(
+  raw: string,
+  options: EncodeFuseComponentOptions = {},
+): string {
+  if (raw === "") return EMPTY_COMPONENT;
+  let encoded = "";
+  let index = 0;
+  for (const char of raw) {
+    encoded += mustEscape(raw, char, index) ? encodeUtf8(char) : char;
+    index += char.length;
+  }
+  if (options.reserveJsonSuffix && encoded.endsWith(".json")) {
+    encoded = `${encoded.slice(0, -5)}%2Ejson`;
+  }
+  return encoded;
+}
+
+export function encodeFusePathSegments(
+  segments: readonly string[],
+  options?: EncodeFuseComponentOptions,
+): string[] {
+  return segments.map((segment) => encodeFuseComponent(segment, options));
+}
+
+export function decodeFuseComponent(component: string): string {
+  if (component === EMPTY_COMPONENT) return "";
+
+  let output = "";
+  let pendingBytes: number[] = [];
+  const flush = () => {
+    if (pendingBytes.length === 0) return;
+    output += decoder.decode(new Uint8Array(pendingBytes));
+    pendingBytes = [];
+  };
+
+  for (let index = 0; index < component.length;) {
+    if (
+      component[index] === "%" &&
+      index + 2 < component.length &&
+      isHex(component[index + 1]) &&
+      isHex(component[index + 2])
+    ) {
+      pendingBytes.push(
+        Number.parseInt(component.slice(index + 1, index + 3), 16),
+      );
+      index += 3;
+      continue;
+    }
+    flush();
+    output += component[index];
+    index++;
+  }
+  flush();
+  return output;
+}
+
+export function decodeFusePathSegments(
+  segments: readonly string[],
+): string[] {
+  return segments.map(decodeFuseComponent);
+}

--- a/packages/fuse/platform.ts
+++ b/packages/fuse/platform.ts
@@ -221,6 +221,7 @@ export const EXDEV = 18;
 export const ENOTDIR = 20;
 export const EISDIR = 21;
 export const EINVAL = 22;
+export const EFBIG = 27;
 export const ENOSPC = 28;
 export const EROFS = 30;
 export const ERANGE = 34;

--- a/packages/fuse/platform.ts
+++ b/packages/fuse/platform.ts
@@ -289,12 +289,12 @@ export const S_IRWXO = 0o007;
 
 // Common modes
 export const DIR_MODE = S_IFDIR | 0o555;
-export const DIR_MODE_RW = S_IFDIR | 0o755;
+export const DIR_MODE_RW = S_IFDIR | 0o777;
 export const FILE_MODE = S_IFREG | 0o444;
-export const FILE_MODE_RW = S_IFREG | 0o644;
+export const FILE_MODE_RW = S_IFREG | 0o666;
 export const FILE_MODE_RX = S_IFREG | 0o555;
-export const FILE_MODE_RWX = S_IFREG | 0o755;
-export const FILE_MODE_WO = S_IFREG | 0o200;
+export const FILE_MODE_RWX = S_IFREG | 0o777;
+export const FILE_MODE_WO = S_IFREG | 0o222;
 export const SYMLINK_MODE = S_IFLNK | 0o777;
 
 // --- Shared utility ---

--- a/packages/fuse/stat.test.ts
+++ b/packages/fuse/stat.test.ts
@@ -73,3 +73,26 @@ Deno.test("nodeMode exposes writable directories with write bits", () => {
 
   assertEquals(nodeMode(node, true), DIR_MODE_RW);
 });
+
+Deno.test("nodeMode gives writable nodes user-independent write bits", () => {
+  const file: FsNode = {
+    kind: "file",
+    content: new Uint8Array(),
+    jsonType: "string",
+  };
+  const dir: FsNode = {
+    kind: "dir",
+    children: new Map(),
+  };
+  const handler: FsNode = {
+    kind: "callable",
+    callableKind: "handler",
+    cellKey: "addItem",
+    cellProp: "result",
+    script: new Uint8Array(),
+  };
+
+  assertEquals(nodeMode(file, true) & 0o777, 0o666);
+  assertEquals(nodeMode(dir, true) & 0o777, 0o777);
+  assertEquals(nodeMode(handler) & 0o777, 0o777);
+});

--- a/packages/fuse/tree-builder.test.ts
+++ b/packages/fuse/tree-builder.test.ts
@@ -222,6 +222,44 @@ Deno.test("buildJsonTree - circular references become [Circular]", () => {
   assertEquals(parsed.self, "[Circular]");
 });
 
+Deno.test("buildJsonTree - shared DAG objects are not circular", () => {
+  const tree = new FsTree();
+  const shared = { leaf: "same" };
+  const data = { a: shared, b: shared };
+
+  buildJsonTree(tree, tree.rootIno, "dag", data);
+
+  const dagIno = tree.lookup(tree.rootIno, "dag")!;
+  const aIno = tree.lookup(dagIno, "a")!;
+  const bIno = tree.lookup(dagIno, "b")!;
+
+  assertEquals(getFileContent(tree, aIno, "leaf"), "same");
+  assertEquals(getFileContent(tree, bIno, "leaf"), "same");
+  assertEquals(JSON.parse(getFileContent(tree, tree.rootIno, "dag.json")), {
+    a: { leaf: "same" },
+    b: { leaf: "same" },
+  });
+});
+
+Deno.test("buildJsonTreeAsync - shared DAG objects are not circular", async () => {
+  const tree = new FsTree();
+  const shared = { leaf: "same" };
+  const data = { a: shared, b: shared };
+
+  await buildJsonTreeAsync(tree, tree.rootIno, "dag", data);
+
+  const dagIno = tree.lookup(tree.rootIno, "dag")!;
+  const aIno = tree.lookup(dagIno, "a")!;
+  const bIno = tree.lookup(dagIno, "b")!;
+
+  assertEquals(getFileContent(tree, aIno, "leaf"), "same");
+  assertEquals(getFileContent(tree, bIno, "leaf"), "same");
+  assertEquals(JSON.parse(getFileContent(tree, tree.rootIno, "dag.json")), {
+    a: { leaf: "same" },
+    b: { leaf: "same" },
+  });
+});
+
 Deno.test("safeStringify - handles circular refs", () => {
   // deno-lint-ignore no-explicit-any
   const a: any = { x: 1 };
@@ -229,6 +267,15 @@ Deno.test("safeStringify - handles circular refs", () => {
   const result = JSON.parse(safeStringify(a));
   assertEquals(result.x, 1);
   assertEquals(result.y, "[Circular]");
+});
+
+Deno.test("safeStringify - preserves shared DAG objects", () => {
+  const shared = { leaf: "same" };
+  const result = JSON.parse(safeStringify({ a: shared, b: shared }));
+  assertEquals(result, {
+    a: { leaf: "same" },
+    b: { leaf: "same" },
+  });
 });
 
 Deno.test("FsTree - addSymlink", () => {

--- a/packages/fuse/tree-builder.test.ts
+++ b/packages/fuse/tree-builder.test.ts
@@ -7,6 +7,7 @@ import {
   isPatternToolValue,
 } from "./callables.ts";
 import {
+  buildInternalJsonTreeAsync,
   buildJsonTree,
   buildJsonTreeAsync,
   isHandlerCell,
@@ -126,6 +127,41 @@ Deno.test("buildJsonTree - encodes user keys that look like internal pending roo
   assertEquals(tree.lookup(dataIno, ".result.pending"), undefined);
   assertEquals(getFileContent(tree, dataIno, "%2Einput.pending"), "1");
   assertEquals(getFileContent(tree, dataIno, "%2Eresult.pending"), "2");
+});
+
+Deno.test("buildJsonTree - encodes depth-zero names that look like internal pending roots by default", () => {
+  const tree = new FsTree();
+
+  buildJsonTree(tree, tree.rootIno, ".result.pending", { value: 1 });
+
+  assertEquals(tree.lookup(tree.rootIno, ".result.pending"), undefined);
+  const dataIno = tree.lookup(tree.rootIno, "%2Eresult.pending")!;
+  assertEquals(getFileContent(tree, dataIno, "value"), "1");
+});
+
+Deno.test("buildJsonTreeAsync - encodes depth-zero names that look like internal pending roots by default", async () => {
+  const tree = new FsTree();
+
+  await buildJsonTreeAsync(tree, tree.rootIno, ".input.pending", { value: 1 });
+
+  assertEquals(tree.lookup(tree.rootIno, ".input.pending"), undefined);
+  const dataIno = tree.lookup(tree.rootIno, "%2Einput.pending")!;
+  assertEquals(getFileContent(tree, dataIno, "value"), "1");
+});
+
+Deno.test("buildInternalJsonTreeAsync - preserves pending roots for rebuild staging", async () => {
+  const tree = new FsTree();
+
+  await buildInternalJsonTreeAsync(
+    tree,
+    tree.rootIno,
+    ".result.pending",
+    { value: 1 },
+  );
+
+  const dataIno = tree.lookup(tree.rootIno, ".result.pending")!;
+  assertEquals(getFileContent(tree, dataIno, "value"), "1");
+  assertEquals(tree.lookup(tree.rootIno, "%2Eresult.pending"), undefined);
 });
 
 Deno.test("buildJsonTree - array creates directory with numeric indices", () => {

--- a/packages/fuse/tree-builder.test.ts
+++ b/packages/fuse/tree-builder.test.ts
@@ -86,6 +86,32 @@ Deno.test("buildJsonTree - object creates directory with children", () => {
   assertEquals(JSON.parse(jsonContent), obj);
 });
 
+Deno.test("buildJsonTree - encodes unsafe object keys in path names", () => {
+  const tree = new FsTree();
+  const data = {
+    "has/slash": 1,
+    "of:entity": 2,
+    "literal%": 3,
+    ".hidden": 4,
+    "..": 5,
+    "value.json": 6,
+  };
+
+  buildJsonTree(tree, tree.rootIno, "data", data);
+
+  const dataIno = tree.lookup(tree.rootIno, "data")!;
+  assertEquals(getFileContent(tree, dataIno, "has%2Fslash"), "1");
+  assertEquals(getFileContent(tree, dataIno, "of%3Aentity"), "2");
+  assertEquals(getFileContent(tree, dataIno, "literal%25"), "3");
+  assertEquals(getFileContent(tree, dataIno, "%2Ehidden"), "4");
+  assertEquals(getFileContent(tree, dataIno, "%2E%2E"), "5");
+  assertEquals(getFileContent(tree, dataIno, "value%2Ejson"), "6");
+  assertEquals(
+    JSON.parse(getFileContent(tree, tree.rootIno, "data.json")),
+    data,
+  );
+});
+
 Deno.test("buildJsonTree - array creates directory with numeric indices", () => {
   const tree = new FsTree();
   const arr = ["a", "b", "c"];
@@ -1248,4 +1274,47 @@ Deno.test("parseSymlinkTarget - unknown cross-space uses name as fallback", () =
   );
 
   assertEquals(result, { id: "abc", space: "unknown" });
+});
+
+type MakeLinkResolver = (
+  spaceName: string,
+) => (value: unknown, depth: number) => string | null;
+
+Deno.test("makeLinkResolver encodes unsafe link components", () => {
+  const bridge = new CellBridge(new FsTree());
+  const resolveLink =
+    (bridge as unknown as { makeLinkResolver: MakeLinkResolver })
+      .makeLinkResolver("home");
+
+  assertEquals(
+    resolveLink({
+      "/": {
+        "link@1": {
+          id: "of:abc",
+          space: "other:space",
+          path: ["..", "has/slash", ":mac"],
+        },
+      },
+    }, 0),
+    "../../../other%3Aspace/entities/of%3Aabc/%2E%2E/has%2Fslash/%3Amac",
+  );
+});
+
+Deno.test("makeLinkResolver leaves malformed link paths inert", () => {
+  const bridge = new CellBridge(new FsTree());
+  const resolveLink =
+    (bridge as unknown as { makeLinkResolver: MakeLinkResolver })
+      .makeLinkResolver("home");
+
+  assertEquals(
+    resolveLink({
+      "/": {
+        "link@1": {
+          id: "of:abc",
+          path: ["ok", 1],
+        },
+      },
+    }, 0),
+    null,
+  );
 });

--- a/packages/fuse/tree-builder.test.ts
+++ b/packages/fuse/tree-builder.test.ts
@@ -7,9 +7,9 @@ import {
   isPatternToolValue,
 } from "./callables.ts";
 import {
-  buildInternalJsonTreeAsync,
   buildJsonTree,
   buildJsonTreeAsync,
+  buildPendingJsonTreeAsync,
   isHandlerCell,
   isSigilLink,
   isStreamValue,
@@ -149,13 +149,13 @@ Deno.test("buildJsonTreeAsync - encodes depth-zero names that look like internal
   assertEquals(getFileContent(tree, dataIno, "value"), "1");
 });
 
-Deno.test("buildInternalJsonTreeAsync - preserves pending roots for rebuild staging", async () => {
+Deno.test("buildPendingJsonTreeAsync - preserves pending roots for rebuild staging", async () => {
   const tree = new FsTree();
 
-  await buildInternalJsonTreeAsync(
+  await buildPendingJsonTreeAsync(
     tree,
     tree.rootIno,
-    ".result.pending",
+    "result",
     { value: 1 },
   );
 

--- a/packages/fuse/tree-builder.test.ts
+++ b/packages/fuse/tree-builder.test.ts
@@ -112,6 +112,22 @@ Deno.test("buildJsonTree - encodes unsafe object keys in path names", () => {
   );
 });
 
+Deno.test("buildJsonTree - encodes user keys that look like internal pending roots", () => {
+  const tree = new FsTree();
+  const data = {
+    ".input.pending": 1,
+    ".result.pending": 2,
+  };
+
+  buildJsonTree(tree, tree.rootIno, "data", data);
+
+  const dataIno = tree.lookup(tree.rootIno, "data")!;
+  assertEquals(tree.lookup(dataIno, ".input.pending"), undefined);
+  assertEquals(tree.lookup(dataIno, ".result.pending"), undefined);
+  assertEquals(getFileContent(tree, dataIno, "%2Einput.pending"), "1");
+  assertEquals(getFileContent(tree, dataIno, "%2Eresult.pending"), "2");
+});
+
 Deno.test("buildJsonTree - array creates directory with numeric indices", () => {
   const tree = new FsTree();
   const arr = ["a", "b", "c"];

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -15,8 +15,8 @@ const INTERNAL_JSON_ENTRY_NAMES = new Set([
   ".result.pending",
 ]);
 
-function encodeJsonEntryName(name: string): string {
-  return INTERNAL_JSON_ENTRY_NAMES.has(name)
+function encodeJsonEntryName(name: string, allowInternal = false): string {
+  return allowInternal && INTERNAL_JSON_ENTRY_NAMES.has(name)
     ? name
     : encodeFuseComponent(name, { reserveJsonSuffix: true });
 }
@@ -295,8 +295,9 @@ function buildJsonLeaf(
   name: string,
   value: unknown,
   annotation?: CfcJsonAnnotationContext,
+  allowInternalName = false,
 ): bigint {
-  const fsName = encodeJsonEntryName(name);
+  const fsName = encodeJsonEntryName(name, allowInternalName);
   return addJsonScalarEntry(tree, parentIno, fsName, value, annotation);
 }
 
@@ -380,7 +381,7 @@ function buildJsonTreeWithAncestors(
     | undefined,
   annotation?: CfcJsonAnnotationContext,
 ): bigint {
-  const fsName = encodeJsonEntryName(name);
+  const fsName = encodeJsonEntryName(name, depth === 0);
 
   if (value === null || value === undefined || typeof value !== "object") {
     return addJsonScalarEntry(tree, parentIno, fsName, value, annotation);
@@ -514,7 +515,7 @@ export async function buildJsonTreeAsync(
     const task = queue[nextIndex++];
     const d = task.depth;
     const candidate = task.value;
-    const fsName = encodeJsonEntryName(task.name);
+    const fsName = encodeJsonEntryName(task.name, task.depth === 0);
 
     let builtIno: bigint | undefined;
 
@@ -525,6 +526,7 @@ export async function buildJsonTreeAsync(
         task.name,
         candidate,
         task.annotation,
+        task.depth === 0,
       );
     } else if (typeof candidate === "object") {
       const objectValue = candidate as object;
@@ -628,6 +630,7 @@ export async function buildJsonTreeAsync(
         task.name,
         candidate,
         task.annotation,
+        task.depth === 0,
       );
     }
 

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -489,7 +489,7 @@ function buildJsonTreeWithAncestors(
   return dirIno;
 }
 
-export async function buildJsonTreeAsync(
+export function buildJsonTreeAsync(
   tree: FsTree,
   parentIno: bigint,
   name: string,
@@ -517,7 +517,7 @@ export async function buildJsonTreeAsync(
 }
 
 /** Build a pending rebuild root with reserved internal staging names intact. */
-export async function buildInternalJsonTreeAsync(
+export function buildInternalJsonTreeAsync(
   tree: FsTree,
   parentIno: bigint,
   name: string,

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -10,13 +10,18 @@ import type { CfcJsonAnnotationContext } from "./annotations.ts";
 import { FsTree } from "./tree.ts";
 import { encodeFuseComponent } from "./path-codec.ts";
 
-const INTERNAL_JSON_ENTRY_NAMES = new Set([
-  ".input.pending",
-  ".result.pending",
-]);
+type JsonPropName = "input" | "result";
+type PendingJsonRootName = ".input.pending" | ".result.pending";
 
-function encodeJsonEntryName(name: string, allowInternal = false): string {
-  return allowInternal && INTERNAL_JSON_ENTRY_NAMES.has(name)
+function pendingJsonRootName(propName: JsonPropName): PendingJsonRootName {
+  return `.${propName}.pending`;
+}
+
+function encodeJsonEntryName(
+  name: string,
+  internalRootName?: PendingJsonRootName,
+): string {
+  return internalRootName !== undefined && name === internalRootName
     ? name
     : encodeFuseComponent(name, { reserveJsonSuffix: true });
 }
@@ -179,7 +184,7 @@ interface BuildJsonTreeTask {
   ancestors: readonly object[];
   depth: number;
   annotation?: CfcJsonAnnotationContext;
-  allowInternalName?: boolean;
+  internalRootName?: PendingJsonRootName;
   onBuilt?: (ino: bigint) => void;
 }
 
@@ -296,9 +301,9 @@ function buildJsonLeaf(
   name: string,
   value: unknown,
   annotation?: CfcJsonAnnotationContext,
-  allowInternalName = false,
+  internalRootName?: PendingJsonRootName,
 ): bigint {
-  const fsName = encodeJsonEntryName(name, allowInternalName);
+  const fsName = encodeJsonEntryName(name, internalRootName);
   return addJsonScalarEntry(tree, parentIno, fsName, value, annotation);
 }
 
@@ -346,7 +351,7 @@ export function buildJsonTree(
     skipEntry,
     classifyCallableEntry,
     annotation,
-    false,
+    undefined,
   );
 }
 
@@ -382,11 +387,11 @@ function buildJsonTreeWithAncestors(
     | ((key: string, value: unknown) => CallableKind | null)
     | undefined,
   annotation?: CfcJsonAnnotationContext,
-  allowInternalRootName = false,
+  internalRootName?: PendingJsonRootName,
 ): bigint {
   const fsName = encodeJsonEntryName(
     name,
-    depth === 0 && allowInternalRootName,
+    depth === 0 ? internalRootName : undefined,
   );
 
   if (value === null || value === undefined || typeof value !== "object") {
@@ -512,15 +517,15 @@ export function buildJsonTreeAsync(
     skipEntry,
     classifyCallableEntry,
     annotation,
-    false,
+    undefined,
   );
 }
 
 /** Build a pending rebuild root with reserved internal staging names intact. */
-export function buildInternalJsonTreeAsync(
+export function buildPendingJsonTreeAsync(
   tree: FsTree,
   parentIno: bigint,
-  name: string,
+  propName: JsonPropName,
   value: unknown,
   seen?: WeakSet<object>,
   resolveLink?: (value: unknown, depth: number) => string | null,
@@ -529,10 +534,11 @@ export function buildInternalJsonTreeAsync(
   classifyCallableEntry?: (key: string, value: unknown) => CallableKind | null,
   annotation?: CfcJsonAnnotationContext,
 ): Promise<bigint> {
+  const rootName = pendingJsonRootName(propName);
   return buildJsonTreeAsyncImpl(
     tree,
     parentIno,
-    name,
+    rootName,
     value,
     seen,
     resolveLink,
@@ -540,7 +546,7 @@ export function buildInternalJsonTreeAsync(
     skipEntry,
     classifyCallableEntry,
     annotation,
-    true,
+    rootName,
   );
 }
 
@@ -557,7 +563,7 @@ async function buildJsonTreeAsyncImpl(
     | ((key: string, value: unknown) => CallableKind | null)
     | undefined,
   annotation: CfcJsonAnnotationContext | undefined,
-  allowInternalRootName: boolean,
+  internalRootName?: PendingJsonRootName,
 ): Promise<bigint> {
   const queue: BuildJsonTreeTask[] = [{
     parentIno,
@@ -566,7 +572,7 @@ async function buildJsonTreeAsyncImpl(
     ancestors: legacySeenContains(value, seen) ? [value as object] : [],
     depth: depth ?? 0,
     annotation,
-    allowInternalName: allowInternalRootName,
+    internalRootName,
   }];
   let nextIndex = 0;
   let processed = 0;
@@ -580,9 +586,10 @@ async function buildJsonTreeAsyncImpl(
     const task = queue[nextIndex++];
     const d = task.depth;
     const candidate = task.value;
-    const allowInternalName = task.depth === 0 &&
-      task.allowInternalName === true;
-    const fsName = encodeJsonEntryName(task.name, allowInternalName);
+    const taskInternalRootName = task.depth === 0
+      ? task.internalRootName
+      : undefined;
+    const fsName = encodeJsonEntryName(task.name, taskInternalRootName);
 
     let builtIno: bigint | undefined;
 
@@ -593,7 +600,7 @@ async function buildJsonTreeAsyncImpl(
         task.name,
         candidate,
         task.annotation,
-        allowInternalName,
+        taskInternalRootName,
       );
     } else if (typeof candidate === "object") {
       const objectValue = candidate as object;
@@ -697,7 +704,7 @@ async function buildJsonTreeAsyncImpl(
         task.name,
         candidate,
         task.annotation,
-        allowInternalName,
+        taskInternalRootName,
       );
     }
 

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -8,6 +8,18 @@ import {
 } from "./callables.ts";
 import type { CfcJsonAnnotationContext } from "./annotations.ts";
 import { FsTree } from "./tree.ts";
+import { encodeFuseComponent } from "./path-codec.ts";
+
+const INTERNAL_JSON_ENTRY_NAMES = new Set([
+  ".input.pending",
+  ".result.pending",
+]);
+
+function encodeJsonEntryName(name: string): string {
+  return INTERNAL_JSON_ENTRY_NAMES.has(name)
+    ? name
+    : encodeFuseComponent(name, { reserveJsonSuffix: true });
+}
 
 /**
  * JSON.stringify that replaces circular references with "[Circular]".
@@ -171,32 +183,33 @@ function buildJsonLeaf(
   value: unknown,
   annotation?: CfcJsonAnnotationContext,
 ): bigint {
+  const fsName = encodeJsonEntryName(name);
   let ino: bigint;
   if (value === null || value === undefined) {
-    ino = tree.addFile(parentIno, name, "", "null");
+    ino = tree.addFile(parentIno, fsName, "", "null");
     annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
     return ino;
   }
 
   if (typeof value === "boolean") {
-    ino = tree.addFile(parentIno, name, String(value), "boolean");
+    ino = tree.addFile(parentIno, fsName, String(value), "boolean");
     annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
     return ino;
   }
 
   if (typeof value === "number") {
-    ino = tree.addFile(parentIno, name, String(value), "number");
+    ino = tree.addFile(parentIno, fsName, String(value), "number");
     annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
     return ino;
   }
 
   if (typeof value === "string") {
-    ino = tree.addFile(parentIno, name, value, "string");
+    ino = tree.addFile(parentIno, fsName, value, "string");
     annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
     return ino;
   }
 
-  ino = tree.addFile(parentIno, name, String(value), "string");
+  ino = tree.addFile(parentIno, fsName, String(value), "string");
   annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
   return ino;
 }
@@ -232,11 +245,12 @@ export function buildJsonTree(
   annotation?: CfcJsonAnnotationContext,
 ): bigint {
   const d = depth ?? 0;
+  const fsName = encodeJsonEntryName(name);
 
   if (value === null || value === undefined) {
-    const ino = tree.addFile(parentIno, name, "", "null");
+    const ino = tree.addFile(parentIno, fsName, "", "null");
     annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-    annotation?.annotator.annotateEntry(parentIno, name, ino, {
+    annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
       labelPath: annotation.path,
     });
     return ino;
@@ -246,9 +260,9 @@ export function buildJsonTree(
   if (typeof value === "object") {
     if (!seen) seen = new WeakSet();
     if (seen.has(value as object)) {
-      const ino = tree.addFile(parentIno, name, "[Circular]", "string");
+      const ino = tree.addFile(parentIno, fsName, "[Circular]", "string");
       annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-      annotation?.annotator.annotateEntry(parentIno, name, ino, {
+      annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
         labelPath: annotation.path,
       });
       return ino;
@@ -260,9 +274,9 @@ export function buildJsonTree(
   if (isSigilLink(value) && resolveLink) {
     const target = resolveLink(value, d);
     if (target) {
-      const ino = tree.addSymlink(parentIno, name, target);
+      const ino = tree.addSymlink(parentIno, fsName, target);
       annotation?.annotator.annotateJsonSymlink(ino, annotation.path, target);
-      annotation?.annotator.annotateEntry(parentIno, name, ino, {
+      annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
         labelPath: annotation.path,
       });
       return ino;
@@ -275,12 +289,12 @@ export function buildJsonTree(
   if (type === "boolean") {
     const ino = tree.addFile(
       parentIno,
-      name,
+      fsName,
       String(value),
       "boolean",
     );
     annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-    annotation?.annotator.annotateEntry(parentIno, name, ino, {
+    annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
       labelPath: annotation.path,
     });
     return ino;
@@ -289,12 +303,12 @@ export function buildJsonTree(
   if (type === "number") {
     const ino = tree.addFile(
       parentIno,
-      name,
+      fsName,
       String(value),
       "number",
     );
     annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-    annotation?.annotator.annotateEntry(parentIno, name, ino, {
+    annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
       labelPath: annotation.path,
     });
     return ino;
@@ -303,28 +317,28 @@ export function buildJsonTree(
   if (type === "string") {
     const ino = tree.addFile(
       parentIno,
-      name,
+      fsName,
       value as string,
       "string",
     );
     annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-    annotation?.annotator.annotateEntry(parentIno, name, ino, {
+    annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
       labelPath: annotation.path,
     });
     return ino;
   }
 
   if (Array.isArray(value)) {
-    const dirIno = tree.addDir(parentIno, name, "array");
+    const dirIno = tree.addDir(parentIno, fsName, "array");
     annotation?.annotator.annotateJsonDirectory(dirIno, annotation.path, value);
-    annotation?.annotator.annotateEntry(parentIno, name, dirIno, {
+    annotation?.annotator.annotateEntry(parentIno, fsName, dirIno, {
       labelPath: annotation.path,
     });
 
     // Add .json sibling for the whole array
     const jsonIno = tree.addFile(
       parentIno,
-      `${name}.json`,
+      `${fsName}.json`,
       safeStringify(value),
       "array",
     );
@@ -333,7 +347,7 @@ export function buildJsonTree(
       annotation.path,
       value,
     );
-    annotation?.annotator.annotateEntry(parentIno, `${name}.json`, jsonIno, {
+    annotation?.annotator.annotateEntry(parentIno, `${fsName}.json`, jsonIno, {
       labelPath: annotation.path,
     });
 
@@ -362,9 +376,9 @@ export function buildJsonTree(
 
   if (type === "object") {
     const obj = value as Record<string, unknown>;
-    const dirIno = tree.addDir(parentIno, name, "object");
+    const dirIno = tree.addDir(parentIno, fsName, "object");
     annotation?.annotator.annotateJsonDirectory(dirIno, annotation.path, value);
-    annotation?.annotator.annotateEntry(parentIno, name, dirIno, {
+    annotation?.annotator.annotateEntry(parentIno, fsName, dirIno, {
       labelPath: annotation.path,
     });
 
@@ -379,7 +393,7 @@ export function buildJsonTree(
       : value;
     const jsonIno = tree.addFile(
       parentIno,
-      `${name}.json`,
+      `${fsName}.json`,
       safeStringify(jsonValue),
       "object",
     );
@@ -388,7 +402,7 @@ export function buildJsonTree(
       annotation.path,
       jsonValue,
     );
-    annotation?.annotator.annotateEntry(parentIno, `${name}.json`, jsonIno, {
+    annotation?.annotator.annotateEntry(parentIno, `${fsName}.json`, jsonIno, {
       labelPath: annotation.path,
     });
 
@@ -420,12 +434,12 @@ export function buildJsonTree(
   // Fallback: stringify anything else
   const ino = tree.addFile(
     parentIno,
-    name,
+    fsName,
     String(value),
     "string",
   );
   annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-  annotation?.annotator.annotateEntry(parentIno, name, ino, {
+  annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
     labelPath: annotation.path,
   });
   return ino;
@@ -463,6 +477,7 @@ export async function buildJsonTreeAsync(
     const task = queue[nextIndex++];
     const d = task.depth;
     const candidate = task.value;
+    const fsName = encodeJsonEntryName(task.name);
 
     let builtIno: bigint | undefined;
 
@@ -480,7 +495,7 @@ export async function buildJsonTreeAsync(
       if (taskSeen.has(objectValue)) {
         builtIno = tree.addFile(
           task.parentIno,
-          task.name,
+          fsName,
           "[Circular]",
           "string",
         );
@@ -495,7 +510,7 @@ export async function buildJsonTreeAsync(
         if (isSigilLink(candidate) && resolveLink) {
           const target = resolveLink(candidate, d);
           if (target) {
-            builtIno = tree.addSymlink(task.parentIno, task.name, target);
+            builtIno = tree.addSymlink(task.parentIno, fsName, target);
             task.annotation?.annotator.annotateJsonSymlink(
               builtIno,
               task.annotation.path,
@@ -506,7 +521,7 @@ export async function buildJsonTreeAsync(
 
         if (builtIno === undefined) {
           if (Array.isArray(candidate)) {
-            builtIno = tree.addDir(task.parentIno, task.name, "array");
+            builtIno = tree.addDir(task.parentIno, fsName, "array");
             task.annotation?.annotator.annotateJsonDirectory(
               builtIno,
               task.annotation.path,
@@ -514,7 +529,7 @@ export async function buildJsonTreeAsync(
             );
             const jsonIno = tree.addFile(
               task.parentIno,
-              `${task.name}.json`,
+              `${fsName}.json`,
               safeStringify(candidate),
               "array",
             );
@@ -525,7 +540,7 @@ export async function buildJsonTreeAsync(
             );
             task.annotation?.annotator.annotateEntry(
               task.parentIno,
-              `${task.name}.json`,
+              `${fsName}.json`,
               jsonIno,
               { labelPath: task.annotation.path },
             );
@@ -545,7 +560,7 @@ export async function buildJsonTreeAsync(
             }
           } else {
             const obj = candidate as Record<string, unknown>;
-            builtIno = tree.addDir(task.parentIno, task.name, "object");
+            builtIno = tree.addDir(task.parentIno, fsName, "object");
             task.annotation?.annotator.annotateJsonDirectory(
               builtIno,
               task.annotation.path,
@@ -558,7 +573,7 @@ export async function buildJsonTreeAsync(
               : candidate;
             const jsonIno = tree.addFile(
               task.parentIno,
-              `${task.name}.json`,
+              `${fsName}.json`,
               safeStringify(jsonValue),
               "object",
             );
@@ -569,7 +584,7 @@ export async function buildJsonTreeAsync(
             );
             task.annotation?.annotator.annotateEntry(
               task.parentIno,
-              `${task.name}.json`,
+              `${fsName}.json`,
               jsonIno,
               { labelPath: task.annotation.path },
             );
@@ -604,7 +619,7 @@ export async function buildJsonTreeAsync(
 
     task.annotation?.annotator.annotateEntry(
       task.parentIno,
-      task.name,
+      fsName,
       builtIno!,
       { labelPath: task.annotation.path },
     );

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -25,13 +25,19 @@ function encodeJsonEntryName(name: string): string {
  * JSON.stringify that replaces circular references with "[Circular]".
  */
 export function safeStringify(value: unknown, indent = 2): string {
-  const seen = new WeakSet();
+  const ancestors: object[] = [];
   return JSON.stringify(
     value,
-    (_key, val) => {
+    function (this: unknown, _key, val) {
       if (val !== null && typeof val === "object") {
-        if (seen.has(val)) return "[Circular]";
-        seen.add(val);
+        while (
+          ancestors.length > 0 &&
+          ancestors[ancestors.length - 1] !== this
+        ) {
+          ancestors.pop();
+        }
+        if (ancestors.includes(val)) return "[Circular]";
+        ancestors.push(val);
       }
       return val;
     },
@@ -46,7 +52,7 @@ export function safeStringify(value: unknown, indent = 2): string {
  *
  * Only creates a new object when replacements are present.
  * Returns the original reference otherwise, preserving circular-ref
- * identity for safeStringify's WeakSet-based detection.
+ * identity for safeStringify's ancestry-based detection.
  */
 export function transformStreamValues(value: unknown): unknown {
   return transformCallableValues(
@@ -170,10 +176,117 @@ interface BuildJsonTreeTask {
   parentIno: bigint;
   name: string;
   value: unknown;
-  seen?: WeakSet<object>;
+  ancestors: readonly object[];
   depth: number;
   annotation?: CfcJsonAnnotationContext;
   onBuilt?: (ino: bigint) => void;
+}
+
+type JsonScalarType = "string" | "number" | "boolean" | "null";
+type JsonAggregateType = "object" | "array";
+
+function annotateEntry(
+  parentIno: bigint,
+  fsName: string,
+  ino: bigint,
+  annotation?: CfcJsonAnnotationContext,
+): void {
+  annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
+    labelPath: annotation.path,
+  });
+}
+
+function addJsonScalarEntry(
+  tree: FsTree,
+  parentIno: bigint,
+  fsName: string,
+  value: unknown,
+  annotation?: CfcJsonAnnotationContext,
+): bigint {
+  let content: string;
+  let jsonType: JsonScalarType;
+
+  if (value === null || value === undefined) {
+    content = "";
+    jsonType = "null";
+  } else if (typeof value === "boolean") {
+    content = String(value);
+    jsonType = "boolean";
+  } else if (typeof value === "number") {
+    content = String(value);
+    jsonType = "number";
+  } else if (typeof value === "string") {
+    content = value;
+    jsonType = "string";
+  } else {
+    content = String(value);
+    jsonType = "string";
+  }
+
+  const ino = tree.addFile(parentIno, fsName, content, jsonType);
+  annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
+  annotateEntry(parentIno, fsName, ino, annotation);
+  return ino;
+}
+
+function addJsonCircularEntry(
+  tree: FsTree,
+  parentIno: bigint,
+  fsName: string,
+  value: unknown,
+  annotation?: CfcJsonAnnotationContext,
+): bigint {
+  const ino = tree.addFile(parentIno, fsName, "[Circular]", "string");
+  annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
+  annotateEntry(parentIno, fsName, ino, annotation);
+  return ino;
+}
+
+function addJsonSymlinkEntry(
+  tree: FsTree,
+  parentIno: bigint,
+  fsName: string,
+  target: string,
+  annotation?: CfcJsonAnnotationContext,
+): bigint {
+  const ino = tree.addSymlink(parentIno, fsName, target);
+  annotation?.annotator.annotateJsonSymlink(ino, annotation.path, target);
+  annotateEntry(parentIno, fsName, ino, annotation);
+  return ino;
+}
+
+function addJsonDirectoryEntry(
+  tree: FsTree,
+  parentIno: bigint,
+  fsName: string,
+  value: unknown,
+  jsonType: JsonAggregateType,
+  annotation?: CfcJsonAnnotationContext,
+): bigint {
+  const ino = tree.addDir(parentIno, fsName, jsonType);
+  annotation?.annotator.annotateJsonDirectory(ino, annotation.path, value);
+  annotateEntry(parentIno, fsName, ino, annotation);
+  return ino;
+}
+
+function addJsonAggregateSibling(
+  tree: FsTree,
+  parentIno: bigint,
+  fsName: string,
+  value: unknown,
+  jsonType: JsonAggregateType,
+  annotation?: CfcJsonAnnotationContext,
+): bigint {
+  const jsonName = `${fsName}.json`;
+  const ino = tree.addFile(
+    parentIno,
+    jsonName,
+    safeStringify(value),
+    jsonType,
+  );
+  annotation?.annotator.annotateJsonAggregate(ino, annotation.path, value);
+  annotateEntry(parentIno, jsonName, ino, annotation);
+  return ino;
 }
 
 function buildJsonLeaf(
@@ -184,34 +297,7 @@ function buildJsonLeaf(
   annotation?: CfcJsonAnnotationContext,
 ): bigint {
   const fsName = encodeJsonEntryName(name);
-  let ino: bigint;
-  if (value === null || value === undefined) {
-    ino = tree.addFile(parentIno, fsName, "", "null");
-    annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-    return ino;
-  }
-
-  if (typeof value === "boolean") {
-    ino = tree.addFile(parentIno, fsName, String(value), "boolean");
-    annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-    return ino;
-  }
-
-  if (typeof value === "number") {
-    ino = tree.addFile(parentIno, fsName, String(value), "number");
-    annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-    return ino;
-  }
-
-  if (typeof value === "string") {
-    ino = tree.addFile(parentIno, fsName, value, "string");
-    annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-    return ino;
-  }
-
-  ino = tree.addFile(parentIno, fsName, String(value), "string");
-  annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-  return ino;
+  return addJsonScalarEntry(tree, parentIno, fsName, value, annotation);
 }
 
 async function yieldToEventLoop(): Promise<void> {
@@ -244,205 +330,156 @@ export function buildJsonTree(
   classifyCallableEntry?: (key: string, value: unknown) => CallableKind | null,
   annotation?: CfcJsonAnnotationContext,
 ): bigint {
-  const d = depth ?? 0;
+  const initialAncestors = legacySeenContains(value, seen)
+    ? [value as object]
+    : [];
+  return buildJsonTreeWithAncestors(
+    tree,
+    parentIno,
+    name,
+    value,
+    initialAncestors,
+    resolveLink,
+    depth ?? 0,
+    skipEntry,
+    classifyCallableEntry,
+    annotation,
+  );
+}
+
+function legacySeenContains(
+  value: unknown,
+  seen?: WeakSet<object>,
+): boolean {
+  return value !== null && typeof value === "object" &&
+    seen?.has(value as object) === true;
+}
+
+function aggregateJsonValue(
+  value: unknown,
+  depth: number,
+  classifyCallableEntry?: (key: string, value: unknown) => CallableKind | null,
+): unknown {
+  if (depth !== 0) return value;
+  return classifyCallableEntry
+    ? transformCallableValues(value, classifyCallableEntry)
+    : transformStreamValues(value);
+}
+
+function buildJsonTreeWithAncestors(
+  tree: FsTree,
+  parentIno: bigint,
+  name: string,
+  value: unknown,
+  ancestors: readonly object[],
+  resolveLink: ((value: unknown, depth: number) => string | null) | undefined,
+  depth: number,
+  skipEntry: ((value: unknown) => boolean) | undefined,
+  classifyCallableEntry:
+    | ((key: string, value: unknown) => CallableKind | null)
+    | undefined,
+  annotation?: CfcJsonAnnotationContext,
+): bigint {
   const fsName = encodeJsonEntryName(name);
 
-  if (value === null || value === undefined) {
-    const ino = tree.addFile(parentIno, fsName, "", "null");
-    annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-    annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
-      labelPath: annotation.path,
-    });
-    return ino;
+  if (value === null || value === undefined || typeof value !== "object") {
+    return addJsonScalarEntry(tree, parentIno, fsName, value, annotation);
   }
 
-  // Detect circular references
-  if (typeof value === "object") {
-    if (!seen) seen = new WeakSet();
-    if (seen.has(value as object)) {
-      const ino = tree.addFile(parentIno, fsName, "[Circular]", "string");
-      annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-      annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
-        labelPath: annotation.path,
-      });
-      return ino;
-    }
-    seen.add(value as object);
+  const objectValue = value as object;
+  if (ancestors.includes(objectValue)) {
+    return addJsonCircularEntry(tree, parentIno, fsName, value, annotation);
   }
 
   // Sigil link → symlink
   if (isSigilLink(value) && resolveLink) {
-    const target = resolveLink(value, d);
+    const target = resolveLink(value, depth);
     if (target) {
-      const ino = tree.addSymlink(parentIno, fsName, target);
-      annotation?.annotator.annotateJsonSymlink(ino, annotation.path, target);
-      annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
-        labelPath: annotation.path,
-      });
-      return ino;
+      return addJsonSymlinkEntry(
+        tree,
+        parentIno,
+        fsName,
+        target,
+        annotation,
+      );
     }
-    // Fall through to normal object handling if link can't be resolved
+    // Fall through to normal object handling if link can't be resolved.
   }
 
-  const type = typeof value;
-
-  if (type === "boolean") {
-    const ino = tree.addFile(
-      parentIno,
-      fsName,
-      String(value),
-      "boolean",
-    );
-    annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-    annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
-      labelPath: annotation.path,
-    });
-    return ino;
-  }
-
-  if (type === "number") {
-    const ino = tree.addFile(
-      parentIno,
-      fsName,
-      String(value),
-      "number",
-    );
-    annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-    annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
-      labelPath: annotation.path,
-    });
-    return ino;
-  }
-
-  if (type === "string") {
-    const ino = tree.addFile(
-      parentIno,
-      fsName,
-      value as string,
-      "string",
-    );
-    annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-    annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
-      labelPath: annotation.path,
-    });
-    return ino;
-  }
+  const childAncestors = [...ancestors, objectValue];
 
   if (Array.isArray(value)) {
-    const dirIno = tree.addDir(parentIno, fsName, "array");
-    annotation?.annotator.annotateJsonDirectory(dirIno, annotation.path, value);
-    annotation?.annotator.annotateEntry(parentIno, fsName, dirIno, {
-      labelPath: annotation.path,
-    });
-
-    // Add .json sibling for the whole array
-    const jsonIno = tree.addFile(
+    const dirIno = addJsonDirectoryEntry(
+      tree,
       parentIno,
-      `${fsName}.json`,
-      safeStringify(value),
-      "array",
-    );
-    annotation?.annotator.annotateJsonAggregate(
-      jsonIno,
-      annotation.path,
+      fsName,
       value,
+      "array",
+      annotation,
     );
-    annotation?.annotator.annotateEntry(parentIno, `${fsName}.json`, jsonIno, {
-      labelPath: annotation.path,
-    });
+    addJsonAggregateSibling(
+      tree,
+      parentIno,
+      fsName,
+      value,
+      "array",
+      annotation,
+    );
 
-    // Recurse for each element
     for (let i = 0; i < value.length; i++) {
-      const childAnnotation = annotation?.annotator.childContext(
-        annotation,
-        i,
-      );
-      buildJsonTree(
+      buildJsonTreeWithAncestors(
         tree,
         dirIno,
         String(i),
         value[i],
-        seen,
+        childAncestors,
         resolveLink,
-        d + 1,
+        depth + 1,
         skipEntry,
         classifyCallableEntry,
-        childAnnotation,
+        annotation?.annotator.childContext(annotation, i),
       );
     }
 
     return dirIno;
   }
 
-  if (type === "object") {
-    const obj = value as Record<string, unknown>;
-    const dirIno = tree.addDir(parentIno, fsName, "object");
-    annotation?.annotator.annotateJsonDirectory(dirIno, annotation.path, value);
-    annotation?.annotator.annotateEntry(parentIno, fsName, dirIno, {
-      labelPath: annotation.path,
-    });
-
-    // Add .json sibling, replacing stream/handler values with handler sigils
-    const jsonValue = d === 0
-      ? classifyCallableEntry
-        ? transformCallableValues(
-          value,
-          classifyCallableEntry,
-        )
-        : transformStreamValues(value)
-      : value;
-    const jsonIno = tree.addFile(
-      parentIno,
-      `${fsName}.json`,
-      safeStringify(jsonValue),
-      "object",
-    );
-    annotation?.annotator.annotateJsonAggregate(
-      jsonIno,
-      annotation.path,
-      jsonValue,
-    );
-    annotation?.annotator.annotateEntry(parentIno, `${fsName}.json`, jsonIno, {
-      labelPath: annotation.path,
-    });
-
-    // Recurse for each key, skipping stream/handler values (handler files created separately)
-    for (const [key, val] of Object.entries(obj)) {
-      if (isStreamValue(val) || isHandlerCell(val)) continue;
-      if (skipEntry?.(val)) continue;
-      const childAnnotation = annotation?.annotator.childContext(
-        annotation,
-        key,
-      );
-      buildJsonTree(
-        tree,
-        dirIno,
-        key,
-        val,
-        seen,
-        resolveLink,
-        d + 1,
-        skipEntry,
-        classifyCallableEntry,
-        childAnnotation,
-      );
-    }
-
-    return dirIno;
-  }
-
-  // Fallback: stringify anything else
-  const ino = tree.addFile(
+  const obj = value as Record<string, unknown>;
+  const dirIno = addJsonDirectoryEntry(
+    tree,
     parentIno,
     fsName,
-    String(value),
-    "string",
+    value,
+    "object",
+    annotation,
   );
-  annotation?.annotator.annotateJsonScalar(ino, annotation.path, value);
-  annotation?.annotator.annotateEntry(parentIno, fsName, ino, {
-    labelPath: annotation.path,
-  });
-  return ino;
+  addJsonAggregateSibling(
+    tree,
+    parentIno,
+    fsName,
+    aggregateJsonValue(value, depth, classifyCallableEntry),
+    "object",
+    annotation,
+  );
+
+  for (const [key, val] of Object.entries(obj)) {
+    if (isStreamValue(val) || isHandlerCell(val)) continue;
+    if (skipEntry?.(val)) continue;
+    buildJsonTreeWithAncestors(
+      tree,
+      dirIno,
+      key,
+      val,
+      childAncestors,
+      resolveLink,
+      depth + 1,
+      skipEntry,
+      classifyCallableEntry,
+      annotation?.annotator.childContext(annotation, key),
+    );
+  }
+
+  return dirIno;
 }
 
 export async function buildJsonTreeAsync(
@@ -461,7 +498,7 @@ export async function buildJsonTreeAsync(
     parentIno,
     name,
     value,
-    seen,
+    ancestors: legacySeenContains(value, seen) ? [value as object] : [],
     depth: depth ?? 0,
     annotation,
   }];
@@ -491,58 +528,47 @@ export async function buildJsonTreeAsync(
       );
     } else if (typeof candidate === "object") {
       const objectValue = candidate as object;
-      const taskSeen = task.seen ?? new WeakSet<object>();
-      if (taskSeen.has(objectValue)) {
-        builtIno = tree.addFile(
+      if (task.ancestors.includes(objectValue)) {
+        builtIno = addJsonCircularEntry(
+          tree,
           task.parentIno,
           fsName,
-          "[Circular]",
-          "string",
-        );
-        task.annotation?.annotator.annotateJsonScalar(
-          builtIno,
-          task.annotation.path,
           candidate,
+          task.annotation,
         );
       } else {
-        taskSeen.add(objectValue);
-
         if (isSigilLink(candidate) && resolveLink) {
           const target = resolveLink(candidate, d);
           if (target) {
-            builtIno = tree.addSymlink(task.parentIno, fsName, target);
-            task.annotation?.annotator.annotateJsonSymlink(
-              builtIno,
-              task.annotation.path,
+            builtIno = addJsonSymlinkEntry(
+              tree,
+              task.parentIno,
+              fsName,
               target,
+              task.annotation,
             );
           }
         }
 
         if (builtIno === undefined) {
+          const childAncestors = [...task.ancestors, objectValue];
+
           if (Array.isArray(candidate)) {
-            builtIno = tree.addDir(task.parentIno, fsName, "array");
-            task.annotation?.annotator.annotateJsonDirectory(
-              builtIno,
-              task.annotation.path,
-              candidate,
-            );
-            const jsonIno = tree.addFile(
+            builtIno = addJsonDirectoryEntry(
+              tree,
               task.parentIno,
-              `${fsName}.json`,
-              safeStringify(candidate),
+              fsName,
+              candidate,
               "array",
+              task.annotation,
             );
-            task.annotation?.annotator.annotateJsonAggregate(
-              jsonIno,
-              task.annotation.path,
-              candidate,
-            );
-            task.annotation?.annotator.annotateEntry(
+            addJsonAggregateSibling(
+              tree,
               task.parentIno,
-              `${fsName}.json`,
-              jsonIno,
-              { labelPath: task.annotation.path },
+              fsName,
+              candidate,
+              "array",
+              task.annotation,
             );
 
             for (let i = 0; i < candidate.length; i++) {
@@ -550,7 +576,7 @@ export async function buildJsonTreeAsync(
                 parentIno: builtIno,
                 name: String(i),
                 value: candidate[i],
-                seen: taskSeen,
+                ancestors: childAncestors,
                 depth: d + 1,
                 annotation: task.annotation?.annotator.childContext(
                   task.annotation,
@@ -560,33 +586,21 @@ export async function buildJsonTreeAsync(
             }
           } else {
             const obj = candidate as Record<string, unknown>;
-            builtIno = tree.addDir(task.parentIno, fsName, "object");
-            task.annotation?.annotator.annotateJsonDirectory(
-              builtIno,
-              task.annotation.path,
+            builtIno = addJsonDirectoryEntry(
+              tree,
+              task.parentIno,
+              fsName,
               candidate,
-            );
-            const jsonValue = d === 0
-              ? classifyCallableEntry
-                ? transformCallableValues(candidate, classifyCallableEntry)
-                : transformStreamValues(candidate)
-              : candidate;
-            const jsonIno = tree.addFile(
-              task.parentIno,
-              `${fsName}.json`,
-              safeStringify(jsonValue),
               "object",
+              task.annotation,
             );
-            task.annotation?.annotator.annotateJsonAggregate(
-              jsonIno,
-              task.annotation.path,
-              jsonValue,
-            );
-            task.annotation?.annotator.annotateEntry(
+            addJsonAggregateSibling(
+              tree,
               task.parentIno,
-              `${fsName}.json`,
-              jsonIno,
-              { labelPath: task.annotation.path },
+              fsName,
+              aggregateJsonValue(candidate, d, classifyCallableEntry),
+              "object",
+              task.annotation,
             );
 
             for (const [key, val] of Object.entries(obj)) {
@@ -596,7 +610,7 @@ export async function buildJsonTreeAsync(
                 parentIno: builtIno,
                 name: key,
                 value: val,
-                seen: taskSeen,
+                ancestors: childAncestors,
                 depth: d + 1,
                 annotation: task.annotation?.annotator.childContext(
                   task.annotation,
@@ -617,12 +631,6 @@ export async function buildJsonTreeAsync(
       );
     }
 
-    task.annotation?.annotator.annotateEntry(
-      task.parentIno,
-      fsName,
-      builtIno!,
-      { labelPath: task.annotation.path },
-    );
     task.onBuilt?.(builtIno!);
     processed++;
     if (processed % ASYNC_BUILD_BATCH_SIZE === 0) {

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -179,6 +179,7 @@ interface BuildJsonTreeTask {
   ancestors: readonly object[];
   depth: number;
   annotation?: CfcJsonAnnotationContext;
+  allowInternalName?: boolean;
   onBuilt?: (ino: bigint) => void;
 }
 
@@ -345,6 +346,7 @@ export function buildJsonTree(
     skipEntry,
     classifyCallableEntry,
     annotation,
+    false,
   );
 }
 
@@ -380,8 +382,12 @@ function buildJsonTreeWithAncestors(
     | ((key: string, value: unknown) => CallableKind | null)
     | undefined,
   annotation?: CfcJsonAnnotationContext,
+  allowInternalRootName = false,
 ): bigint {
-  const fsName = encodeJsonEntryName(name, depth === 0);
+  const fsName = encodeJsonEntryName(
+    name,
+    depth === 0 && allowInternalRootName,
+  );
 
   if (value === null || value === undefined || typeof value !== "object") {
     return addJsonScalarEntry(tree, parentIno, fsName, value, annotation);
@@ -495,6 +501,64 @@ export async function buildJsonTreeAsync(
   classifyCallableEntry?: (key: string, value: unknown) => CallableKind | null,
   annotation?: CfcJsonAnnotationContext,
 ): Promise<bigint> {
+  return buildJsonTreeAsyncImpl(
+    tree,
+    parentIno,
+    name,
+    value,
+    seen,
+    resolveLink,
+    depth,
+    skipEntry,
+    classifyCallableEntry,
+    annotation,
+    false,
+  );
+}
+
+/** Build a pending rebuild root with reserved internal staging names intact. */
+export async function buildInternalJsonTreeAsync(
+  tree: FsTree,
+  parentIno: bigint,
+  name: string,
+  value: unknown,
+  seen?: WeakSet<object>,
+  resolveLink?: (value: unknown, depth: number) => string | null,
+  depth?: number,
+  skipEntry?: (value: unknown) => boolean,
+  classifyCallableEntry?: (key: string, value: unknown) => CallableKind | null,
+  annotation?: CfcJsonAnnotationContext,
+): Promise<bigint> {
+  return buildJsonTreeAsyncImpl(
+    tree,
+    parentIno,
+    name,
+    value,
+    seen,
+    resolveLink,
+    depth,
+    skipEntry,
+    classifyCallableEntry,
+    annotation,
+    true,
+  );
+}
+
+async function buildJsonTreeAsyncImpl(
+  tree: FsTree,
+  parentIno: bigint,
+  name: string,
+  value: unknown,
+  seen: WeakSet<object> | undefined,
+  resolveLink: ((value: unknown, depth: number) => string | null) | undefined,
+  depth: number | undefined,
+  skipEntry: ((value: unknown) => boolean) | undefined,
+  classifyCallableEntry:
+    | ((key: string, value: unknown) => CallableKind | null)
+    | undefined,
+  annotation: CfcJsonAnnotationContext | undefined,
+  allowInternalRootName: boolean,
+): Promise<bigint> {
   const queue: BuildJsonTreeTask[] = [{
     parentIno,
     name,
@@ -502,6 +566,7 @@ export async function buildJsonTreeAsync(
     ancestors: legacySeenContains(value, seen) ? [value as object] : [],
     depth: depth ?? 0,
     annotation,
+    allowInternalName: allowInternalRootName,
   }];
   let nextIndex = 0;
   let processed = 0;
@@ -515,7 +580,9 @@ export async function buildJsonTreeAsync(
     const task = queue[nextIndex++];
     const d = task.depth;
     const candidate = task.value;
-    const fsName = encodeJsonEntryName(task.name, task.depth === 0);
+    const allowInternalName = task.depth === 0 &&
+      task.allowInternalName === true;
+    const fsName = encodeJsonEntryName(task.name, allowInternalName);
 
     let builtIno: bigint | undefined;
 
@@ -526,7 +593,7 @@ export async function buildJsonTreeAsync(
         task.name,
         candidate,
         task.annotation,
-        task.depth === 0,
+        allowInternalName,
       );
     } else if (typeof candidate === "object") {
       const objectValue = candidate as object;
@@ -630,7 +697,7 @@ export async function buildJsonTreeAsync(
         task.name,
         candidate,
         task.annotation,
-        task.depth === 0,
+        allowInternalName,
       );
     }
 


### PR DESCRIPTION
## Summary

Addresses the FUSE review findings across `packages/fuse`, `packages/cli`, and `packages/cf-harness`.

- Add Fabric mount governance diagnostics without changing the writable default, including CFC-strict delegated enforcement messaging.
- Add a shared FUSE path component codec and apply it to cell-derived names, source path segments, callable names, entity IDs, and link rendering.
- Harden link rendering against mount escapes, add root-level callable parsing, and preserve full callable tool patterns during CLI invocation.
- Bound virtual file writes/truncates, reject unsafe no-handle truncates, and document the optimistic write acknowledgement contract.
- Replace public callable exec `any` types with narrower interfaces and fix JSON tree DAG rendering by tracking recursion stack.
- Add regression coverage for the security, correctness, path encoding, callable, write-limit, truncate, and DAG cases.

## Validation

- `deno task check` (after final rebase onto current `origin/main`)
- `deno task test` (passed before the final rebase; branch changes unchanged)
- `deno task integration` (passed before the final rebase; branch changes unchanged, 8/8 suites)

## Notes

The final rebase only incorporated the latest `origin/main` UI tab-list commit before opening this PR; the branch diff itself remained the FUSE/CLI/cf-harness fix set.