### PR TITLE
Add cf-harness CFC invocation sidecar transport

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -211,12 +211,22 @@ the same host result directory that `cf-harness` reads. Configure runsc with
 `CF_HARNESS_RUNSC_CFC_RESULT_DIR=/path/to/results` or pass `cfcResultDir` in the
 explicit sandbox config.
 
+CFC invocation context transport is similarly coordinated through a host sidecar
+directory. Configure runsc with
+`--cfc-invocation-context-dir=/path/to/invocations`, then set
+`CF_HARNESS_RUNSC_CFC_INVOCATION_CONTEXT_DIR=/path/to/invocations` or pass
+`cfcInvocationContextDir` in the explicit sandbox config. `cf-harness` writes
+`<containerID>.json` after `docker create` and before `docker start`; the
+current payload is an audit/provenance context, not yet an argv/stdin/cwd/env
+label enforcement contract.
+
 On Docker Desktop for macOS, use the host path for `cf-harness` and the
 `/host_mnt/...` projection for Docker's runtime args. The gVisor
 `docker-desktop-cfc-setup` helper defaults to:
 
 ```bash
 export CF_HARNESS_RUNSC_CFC_RESULT_DIR="$HOME/.local/share/runsc-cfc/cfc-results"
+export CF_HARNESS_RUNSC_CFC_INVOCATION_CONTEXT_DIR="$HOME/.local/share/runsc-cfc/cfc-invocations"
 ```
 
 ## Related Docs

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -1,6 +1,9 @@
-import { join as joinHostPath } from "@std/path";
 import {
-  isAbsolute,
+  isAbsolute as isAbsoluteHostPath,
+  join as joinHostPath,
+} from "@std/path";
+import {
+  isAbsolute as isAbsoluteSandboxPath,
   join as joinSandboxPath,
   normalize,
 } from "@std/path/posix";
@@ -8,6 +11,7 @@ import { DenoProcessRunner, type ProcessRunner } from "./process-runner.ts";
 import type {
   DockerRunscAdditionalMount,
   DockerRunscAdditionalMountConfig,
+  DockerRunscCfcInvocationContextTransport,
   DockerRunscSandboxConfig,
   ResolveDockerRunscSandboxConfigOptions,
   SandboxCommandRequest,
@@ -33,6 +37,8 @@ export const DEFAULT_SANDBOX_SHELL = "/bin/sh";
 export const DEFAULT_DOCKER_NETWORK_MODE = "none" as const;
 export const DEFAULT_FABRIC_MOUNT_PATH = "/fabric";
 export const CFC_RESULT_DIR_ENV = "CF_HARNESS_RUNSC_CFC_RESULT_DIR";
+export const CFC_INVOCATION_CONTEXT_DIR_ENV =
+  "CF_HARNESS_RUNSC_CFC_INVOCATION_CONTEXT_DIR";
 
 interface RunscCfcLabelSidecar {
   string?: unknown;
@@ -61,6 +67,16 @@ const optionalNonEmptyString = (
   value: string | undefined,
 ): string | undefined =>
   value !== undefined && value.length > 0 ? value : undefined;
+
+const validateAbsoluteHostDir = (path: string, label: string): string => {
+  if (path.trim() === "") {
+    throw new Error(`${label} must not be empty`);
+  }
+  if (!isAbsoluteHostPath(path)) {
+    throw new Error(`${label} must be an absolute host path`);
+  }
+  return path;
+};
 
 export const resolveDefaultContainerUser = (
   hostOs: typeof Deno.build.os = Deno.build.os,
@@ -114,7 +130,7 @@ const normalizeWorkspacePath = (path: string): string => {
 
 const validateSandboxRoot = (path: string, label: string): string => {
   const normalized = normalizeWorkspacePath(path);
-  if (!isAbsolute(normalized) || normalized === "/") {
+  if (!isAbsoluteSandboxPath(normalized) || normalized === "/") {
     throw new Error(`${label} must be an absolute non-root sandbox path`);
   }
   return normalized;
@@ -172,6 +188,28 @@ const dockerMountArg = (mount: {
     mount.readOnly ? ",readonly" : ""
   }`;
 
+const resolveCfcInvocationContextTransport = (
+  options: ResolveDockerRunscSandboxConfigOptions,
+): DockerRunscCfcInvocationContextTransport | undefined => {
+  if (options.cfcInvocationContextTransport !== undefined) {
+    return {
+      kind: "sidecar",
+      dir: validateAbsoluteHostDir(
+        options.cfcInvocationContextTransport.dir,
+        "cfcInvocationContextTransport.dir",
+      ),
+    };
+  }
+  const dir = optionalNonEmptyString(
+    options.cfcInvocationContextDir ??
+      readEnvVar(CFC_INVOCATION_CONTEXT_DIR_ENV),
+  );
+  return dir === undefined ? undefined : {
+    kind: "sidecar",
+    dir: validateAbsoluteHostDir(dir, "cfcInvocationContextDir"),
+  };
+};
+
 export const resolveDockerRunscSandboxConfig = (
   options: ResolveDockerRunscSandboxConfigOptions,
 ): DockerRunscSandboxConfig => {
@@ -190,6 +228,9 @@ export const resolveDockerRunscSandboxConfig = (
   const cfcResultDir = optionalNonEmptyString(
     options.cfcResultDir ?? readEnvVar(CFC_RESULT_DIR_ENV),
   );
+  const cfcInvocationContextTransport = resolveCfcInvocationContextTransport(
+    options,
+  );
   return {
     kind: "docker-runsc-cfc",
     dockerBinary: options.dockerBinary ?? DEFAULT_DOCKER_BINARY,
@@ -203,6 +244,9 @@ export const resolveDockerRunscSandboxConfig = (
     additionalMounts,
     extraDockerArgs: options.extraDockerArgs ?? [],
     ...(cfcResultDir !== undefined ? { cfcResultDir } : {}),
+    ...(cfcInvocationContextTransport !== undefined
+      ? { cfcInvocationContextTransport }
+      : {}),
   };
 };
 
@@ -221,6 +265,20 @@ const parseDockerContainerID = (stdout: string): string | undefined => {
   return firstLine !== undefined && firstLine.length > 0
     ? firstLine
     : undefined;
+};
+
+const cfcSidecarPath = (dir: string, containerID: string): string => {
+  if (
+    containerID === "" ||
+    containerID === "." ||
+    containerID === ".." ||
+    /[/\\]/.test(containerID)
+  ) {
+    throw new Error(
+      `invalid Docker container ID for CFC sidecar: ${containerID}`,
+    );
+  }
+  return joinHostPath(dir, `${containerID}.json`);
 };
 
 const parseDockerWaitExitCode = (stdout: string): number | undefined => {
@@ -454,6 +512,12 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
         mounts: this.#mountDescriptions(),
         networkMode: this.config.dockerNetworkMode,
         extraDockerArgsCount: this.config.extraDockerArgs.length,
+        ...(this.config.cfcInvocationContextTransport !== undefined
+          ? {
+            invocationContextTransport:
+              this.config.cfcInvocationContextTransport.kind,
+          }
+          : {}),
       },
     };
   }
@@ -469,7 +533,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
   }
 
   resolvePath(path: string, cwd?: string): string {
-    const normalized = isAbsolute(path)
+    const normalized = isAbsoluteSandboxPath(path)
       ? normalize(path)
       : normalize(joinSandboxPath(cwd ?? this.defaultWorkingDirectory(), path));
     if (!this.isPathWithinAllowedRoots(normalized)) {
@@ -521,6 +585,14 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
     }
 
     try {
+      const sidecarFailure = await this.writeCfcInvocationContextSidecar(
+        containerID,
+        request,
+        createResult,
+      );
+      if (sidecarFailure !== undefined) {
+        return sidecarFailure;
+      }
       const startResult = await this.runner.run({
         command: this.config.dockerBinary,
         args: [
@@ -583,10 +655,19 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
     if (this.config.cfcResultDir === undefined) {
       return undefined;
     }
-    const sidecarPath = joinHostPath(
-      this.config.cfcResultDir,
-      `${containerID}.json`,
-    );
+    let sidecarPath: string;
+    try {
+      sidecarPath = cfcSidecarPath(this.config.cfcResultDir, containerID);
+    } catch (error) {
+      return deniedCfcResult(
+        "runsc_cfc_sidecar_container_id",
+        "runsc CFC sidecar path could not be derived from the Docker container ID",
+        {
+          containerId: containerID,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
     let text: string;
     try {
       text = await Deno.readTextFile(sidecarPath);
@@ -617,6 +698,43 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
           error: error instanceof Error ? error.message : String(error),
         },
       );
+    }
+  }
+
+  private async writeCfcInvocationContextSidecar(
+    containerID: string,
+    request: SandboxCommandRequest,
+    createResult: SandboxCommandResult,
+  ): Promise<SandboxCommandResult | undefined> {
+    if (
+      this.config.cfcInvocationContextTransport === undefined ||
+      request.cfcInvocationContext === undefined
+    ) {
+      return undefined;
+    }
+    const transport = this.config.cfcInvocationContextTransport;
+    switch (transport.kind) {
+      case "sidecar": {
+        try {
+          await Deno.mkdir(transport.dir, { recursive: true });
+          await Deno.writeTextFile(
+            cfcSidecarPath(transport.dir, containerID),
+            `${JSON.stringify(request.cfcInvocationContext, null, 2)}\n`,
+          );
+          return undefined;
+        } catch (error) {
+          return {
+            stdout: createResult.stdout,
+            stderr: appendStderr(
+              createResult.stderr,
+              `failed to write CFC invocation context sidecar: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            ),
+            exitCode: 125,
+          };
+        }
+      }
     }
   }
 }

--- a/packages/cf-harness/src/sandbox/types.ts
+++ b/packages/cf-harness/src/sandbox/types.ts
@@ -27,6 +27,14 @@ export interface DockerRunscAdditionalMount {
   readOnly: boolean;
 }
 
+export interface DockerRunscCfcInvocationContextSidecarTransport {
+  kind: "sidecar";
+  dir: string;
+}
+
+export type DockerRunscCfcInvocationContextTransport =
+  DockerRunscCfcInvocationContextSidecarTransport;
+
 export interface DockerRunscSandboxConfig {
   kind: "docker-runsc-cfc";
   dockerBinary: string;
@@ -40,6 +48,7 @@ export interface DockerRunscSandboxConfig {
   additionalMounts: readonly DockerRunscAdditionalMount[];
   extraDockerArgs: readonly string[];
   cfcResultDir?: string;
+  cfcInvocationContextTransport?: DockerRunscCfcInvocationContextTransport;
 }
 
 export type HarnessSandboxConfig = DockerRunscSandboxConfig;
@@ -56,6 +65,8 @@ export interface ResolveDockerRunscSandboxConfigOptions {
   additionalMounts?: readonly DockerRunscAdditionalMountConfig[];
   extraDockerArgs?: readonly string[];
   cfcResultDir?: string;
+  cfcInvocationContextDir?: string;
+  cfcInvocationContextTransport?: DockerRunscCfcInvocationContextTransport;
 }
 
 export interface SandboxCommandRequest {
@@ -92,6 +103,7 @@ export interface SandboxRuntimeDescription {
     mounts?: readonly SandboxRuntimeMountDescription[];
     networkMode?: DockerNetworkMode;
     extraDockerArgsCount?: number;
+    invocationContextTransport?: string;
   };
 }
 

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -5,6 +5,8 @@ import {
   resolveDefaultContainerUser,
   resolveDockerRunscSandboxConfig,
 } from "../src/sandbox/docker-runsc.ts";
+import { createHarnessCfcInvocationContext } from "../src/contracts/cfc-invocation-context.ts";
+import { createToolOutputId } from "../src/contracts/tool-result.ts";
 import type {
   ProcessRunner,
   ProcessRunRequest,
@@ -73,6 +75,7 @@ Deno.test("resolveDockerRunscSandboxConfig fills the expected defaults", () => {
   assertEquals(config.additionalMounts, []);
   assertEquals(config.extraDockerArgs, []);
   assertEquals(config.cfcResultDir, undefined);
+  assertEquals(config.cfcInvocationContextTransport, undefined);
 });
 
 Deno.test("resolveDefaultContainerUser omits default --user on macOS", () => {
@@ -199,6 +202,30 @@ Deno.test("resolveDockerRunscSandboxConfig rejects overlapping sandbox roots", (
   );
 });
 
+Deno.test("resolveDockerRunscSandboxConfig resolves invocation context sidecar transport", () => {
+  const config = resolveDockerRunscSandboxConfig({
+    workspaceHostPath: "/host/project",
+    cfcInvocationContextDir: "/tmp/cfc-invocations",
+  });
+
+  assertEquals(config.cfcInvocationContextTransport, {
+    kind: "sidecar",
+    dir: "/tmp/cfc-invocations",
+  });
+});
+
+Deno.test("resolveDockerRunscSandboxConfig rejects relative invocation context sidecar dirs", () => {
+  assertThrows(
+    () =>
+      resolveDockerRunscSandboxConfig({
+        workspaceHostPath: "/host/project",
+        cfcInvocationContextDir: "relative/cfc-invocations",
+      }),
+    Error,
+    "cfcInvocationContextDir must be an absolute host path",
+  );
+});
+
 Deno.test("DockerRunscSandboxRuntime runShell honors an explicit container user override", async () => {
   const runner = new FakeProcessRunner(dockerLifecycleResults({ stdout: "" }));
   const runtime = new DockerRunscSandboxRuntime(
@@ -238,6 +265,106 @@ Deno.test("DockerRunscSandboxRuntime runShell honors an explicit container user 
       "arg-2",
     ],
   });
+});
+
+Deno.test("DockerRunscSandboxRuntime writes invocation context sidecars before start", async () => {
+  const cfcInvocationContextDir = await Deno.makeTempDir();
+  try {
+    const cfcInvocationContext = await createHarnessCfcInvocationContext({
+      sequence: 1,
+      runId: "run-1",
+      createdAt: "2026-04-30T00:00:00.000Z",
+      toolId: "bash",
+      toolOutputId: createToolOutputId("run-1", "bash", 1),
+      operation: "shell",
+      cfcEnforcementMode: "observe",
+      cwd: "/workspace",
+      runManifest: { present: false },
+      command: "echo hello",
+    });
+    const runner = new FakeProcessRunner(dockerLifecycleResults());
+    const runtime = new DockerRunscSandboxRuntime(
+      resolveDockerRunscSandboxConfig({
+        workspaceHostPath: "/host/project",
+        cfcInvocationContextDir,
+      }),
+      runner,
+    );
+
+    await runtime.run({
+      argv: ["/bin/echo", "hello"],
+      cfcInvocationContext,
+    });
+
+    assertEquals(
+      JSON.parse(
+        await Deno.readTextFile(
+          `${cfcInvocationContextDir}/container-123.json`,
+        ),
+      ),
+      cfcInvocationContext,
+    );
+    assertEquals(runner.requests[1]?.args, [
+      "start",
+      "--attach",
+      "container-123",
+    ]);
+  } finally {
+    await Deno.remove(cfcInvocationContextDir, { recursive: true });
+  }
+});
+
+Deno.test("DockerRunscSandboxRuntime reports sidecar write failures before start", async () => {
+  const cfcInvocationContextDir = await Deno.makeTempDir();
+  try {
+    const cfcInvocationContext = await createHarnessCfcInvocationContext({
+      sequence: 1,
+      runId: "run-1",
+      createdAt: "2026-04-30T00:00:00.000Z",
+      toolId: "bash",
+      operation: "shell",
+      cfcEnforcementMode: "observe",
+      cwd: "/workspace",
+      runManifest: { present: false },
+      command: "echo hello",
+    });
+    const runner = new FakeProcessRunner([
+      {
+        stdout: "../container\n",
+        stderr: "",
+        exitCode: 0,
+      },
+      {
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+      },
+    ]);
+    const runtime = new DockerRunscSandboxRuntime(
+      resolveDockerRunscSandboxConfig({
+        workspaceHostPath: "/host/project",
+        cfcInvocationContextDir,
+      }),
+      runner,
+    );
+
+    const result = await runtime.run({
+      argv: ["/bin/echo", "hello"],
+      cfcInvocationContext,
+    });
+
+    assertEquals(result.exitCode, 125);
+    assertMatch(
+      result.stderr,
+      /failed to write CFC invocation context sidecar/,
+    );
+    assertEquals(runner.requests.map((request) => request.args[0]), [
+      "create",
+      "rm",
+    ]);
+  } finally {
+    await Deno.remove(cfcInvocationContextDir, { recursive: true });
+  }
 });
 
 Deno.test("DockerRunscSandboxRuntime attaches observed CFC sidecar output", async () => {


### PR DESCRIPTION
## Summary
- add an optional `sidecar` CFC invocation-context transport to the Docker/runsc sandbox config
- write `<containerID>.json` after `docker create` and before `docker start` when a sandbox request includes a CFC invocation context
- document the matching `--cfc-invocation-context-dir` / `CF_HARNESS_RUNSC_CFC_INVOCATION_CONTEXT_DIR` setup

## Notes
This follows Wilk's provisional gVisor sidecar interface in commontoolsinc/gvisor#17. The transport is intentionally mechanical: it moves the existing cf-harness invocation-context JSON into runsc's host-controlled sidecar directory, but it does not add or claim runtime enforcement for argv/stdin/cwd/env labels.

The config is shaped as a transport object so a future socket/runtime-annotation path can replace the file sidecar without changing tool-call code.

## Tests
- `deno test -A packages/cf-harness/test/docker-runsc-sandbox.test.ts`
- `deno check packages/cf-harness/src/index.ts packages/cf-harness/integration/engine.integration.test.ts`
- `cd packages/cf-harness && deno task test`
- `deno test -A packages/cf-harness/integration/engine.integration.test.ts` (6 ignored without integration env vars)
- `git diff --check`
