### PR TITLE
Retry CFC label rendering after metadata catch-up

### DIFF
--- a/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.test.ts
+++ b/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.test.ts
@@ -125,6 +125,73 @@ describe("CFCFCLabel", () => {
     expect(element.cfcLabel).toEqual(cfcLabel);
   });
 
+  it("retries when label metadata arrives after the first value query", async () => {
+    const cfcLabel = {
+      version: 1 as const,
+      entries: [{
+        path: [],
+        label: { confidentiality: ["prompt-influence"] },
+      }],
+    };
+    let labelAvailable = false;
+    const element = new CFCFCLabel();
+    Object.defineProperty(element, "isConnected", {
+      value: true,
+      configurable: true,
+    });
+
+    try {
+      element.value = {
+        getCfcLabel: () =>
+          Promise.resolve(labelAvailable ? cfcLabel : undefined),
+        subscribe: () => () => {},
+      };
+      await Promise.resolve();
+      expect(element.cfcLabel).toBeUndefined();
+
+      labelAvailable = true;
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(element.cfcLabel).toEqual(cfcLabel);
+    } finally {
+      element.disconnectedCallback();
+    }
+  });
+
+  it("replaces stale pending retries after a newer refresh", async () => {
+    const cfcLabel = {
+      version: 1 as const,
+      entries: [{
+        path: [],
+        label: { confidentiality: ["prompt-influence"] },
+      }],
+    };
+    let labelAvailable = false;
+    const element = new CFCFCLabel();
+    Object.defineProperty(element, "isConnected", {
+      value: true,
+      configurable: true,
+    });
+
+    try {
+      element.value = {
+        getCfcLabel: () =>
+          Promise.resolve(labelAvailable ? cfcLabel : undefined),
+        subscribe: () => () => {},
+      };
+      await Promise.resolve();
+      expect(element.cfcLabel).toBeUndefined();
+
+      await element.refreshLabel();
+      labelAvailable = true;
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(element.cfcLabel).toEqual(cfcLabel);
+    } finally {
+      element.disconnectedCallback();
+    }
+  });
+
   it("does not duplicate label refreshes for the same bound value", async () => {
     const cfcLabel = {
       version: 1 as const,

--- a/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
+++ b/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
@@ -22,6 +22,9 @@ const LABEL_KEYS = [
   "integrity",
 ] as const satisfies readonly LabelKey[];
 
+const LABEL_RETRY_INTERVAL_MS = 100;
+const MAX_LABEL_RETRY_COUNT = 100;
+
 const hasLabelQuery = (value: unknown): value is CfcLabelQueryableValue =>
   typeof value === "object" && value !== null &&
   "getCfcLabel" in value &&
@@ -205,6 +208,8 @@ export class CFCFCLabel extends BaseElement {
   private _value: unknown = undefined;
   private _observedValue: unknown = undefined;
   private _unsubscribeValue: (() => void) | undefined;
+  private _labelRetryTimeout: ReturnType<typeof setTimeout> | undefined;
+  private _labelRetryCount = 0;
 
   constructor() {
     super();
@@ -230,6 +235,7 @@ export class CFCFCLabel extends BaseElement {
   }
 
   override disconnectedCallback() {
+    this.clearLabelRetry();
     this.clearValueSubscription();
     super.disconnectedCallback();
   }
@@ -264,6 +270,8 @@ export class CFCFCLabel extends BaseElement {
     }
 
     this.clearValueSubscription();
+    this.clearLabelRetry();
+    this._labelRetryCount = 0;
     this._observedValue = value;
 
     if (!hasLabelSubscription(value)) {
@@ -282,9 +290,40 @@ export class CFCFCLabel extends BaseElement {
     this._observedValue = undefined;
   }
 
+  private clearLabelRetry(): void {
+    if (this._labelRetryTimeout === undefined) {
+      return;
+    }
+    clearTimeout(this._labelRetryTimeout);
+    this._labelRetryTimeout = undefined;
+  }
+
+  private scheduleLabelRetry(requestId: number): void {
+    if (
+      !this.isConnected ||
+      this._labelRetryCount >= MAX_LABEL_RETRY_COUNT
+    ) {
+      return;
+    }
+
+    this.clearLabelRetry();
+    this._labelRetryTimeout = setTimeout(() => {
+      this._labelRetryTimeout = undefined;
+      if (
+        requestId === this._labelRequestId &&
+        this.cfcLabel === undefined &&
+        hasLabelQuery(this.value)
+      ) {
+        this._labelRetryCount += 1;
+        void this.refreshLabel();
+      }
+    }, LABEL_RETRY_INTERVAL_MS);
+  }
+
   async refreshLabel(): Promise<void> {
     const requestId = ++this._labelRequestId;
     if (!hasLabelQuery(this.value)) {
+      this.clearLabelRetry();
       const previous = this.cfcLabel;
       this.cfcLabel = undefined;
       this.requestUpdate("cfcLabel", previous);
@@ -296,6 +335,12 @@ export class CFCFCLabel extends BaseElement {
       const previous = this.cfcLabel;
       this.cfcLabel = cfcLabel;
       this.requestUpdate("cfcLabel", previous);
+      if (cfcLabel === undefined) {
+        this.scheduleLabelRetry(requestId);
+      } else {
+        this.clearLabelRetry();
+        this._labelRetryCount = 0;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- fixes a race where cf-cfc-label could render the initial empty state forever if getCfcLabel() returned undefined before label metadata caught up
- adds a bounded retry while the label element is connected
- adds a unit regression test for delayed label metadata

## Main failure investigated
- GitHub Actions run: https://github.com/commontoolsinc/labs/actions/runs/25188658577/job/73852758529
- Failing test: packages/patterns/integration/cfc-spec-gallery.test.ts renders disclaimer-style labels without a trusted click

## Validation
- deno test --allow-env --allow-ffi --allow-read --allow-write --allow-run packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.test.ts
- deno lint packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.test.ts packages/patterns/integration/cfc-spec-gallery.test.ts
- deno check packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.test.ts packages/patterns/integration/cfc-spec-gallery.test.ts
- deno task test (in packages/ui)
- deno task integration patterns cfc-spec-gallery