### PR TITLE
docs(spec): sync formal+informal specs for fvj1: prefix and post-#3437 hash residue

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -700,7 +700,7 @@ export class FabricHash extends FabricPrimitive {
     return this.#hash.length;
   }
 
-  /** The algorithm tag (e.g., `"fid1"`, `"legacy"`). */
+  /** The algorithm tag (e.g., `"fid1"`). */
   get tag(): string {
     return this.#tag;
   }

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -34,7 +34,7 @@ a string is sufficient to tell whether it carries a fabric-value payload.
 
 - A conforming **encoder** emits the prefix exactly once, immediately before
   the JSON body, on every encoded value (including encoded primitives — e.g.,
-  the number `42` encodes as the eight-character string `fvj1:42`).
+  the number `42` encodes as the seven-character string `fvj1:42`).
 - A conforming **decoder** verifies the prefix is present before parsing the
   remainder as JSON, and strips the prefix before processing.
 - A short detection helper (`seemsLikeJsonEncodedFabricValue`) tests for the

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -1,9 +1,9 @@
 # JSON Encoding for Fabric Values
 
 This document specifies the JSON-compatible wire format used to represent
-fabric values, including the tagged-object convention, escaping mechanisms,
-serialization context responsibilities, and the reservation rules for
-`/`-prefixed keys.
+fabric values, including the `fvj1:` encoding prefix, the tagged-object
+convention, escaping mechanisms, serialization context responsibilities, and
+the reservation rules for `/`-prefixed keys.
 
 ## Status
 
@@ -17,6 +17,36 @@ This section specifies the JSON-compatible wire format for special types. While
 the system will maintain a JSON encoding indefinitely (for debugging and
 interoperability), other wire and storage formats (e.g., CBOR) may represent
 types more directly without layering on JSON.
+
+### 1.1 Encoding Prefix
+
+Every encoded fabric value carries an unambiguous textual prefix, before the
+JSON itself:
+
+```
+fvj1:<json>
+```
+
+The literal string `fvj1:` stands for "Fabric Value JSON, version 1". Its
+purpose is to make the encoded form distinguishable, on inspection, from
+arbitrary JSON produced by some other source — a brief peek at the start of
+a string is sufficient to tell whether it carries a fabric-value payload.
+
+- A conforming **encoder** emits the prefix exactly once, immediately before
+  the JSON body, on every encoded value (including encoded primitives — e.g.,
+  the number `42` encodes as the eight-character string `fvj1:42`).
+- A conforming **decoder** verifies the prefix is present before parsing the
+  remainder as JSON, and strips the prefix before processing.
+- A short detection helper (`seemsLikeJsonEncodedFabricValue`) tests for the
+  prefix without parsing — useful for routing arbitrary input through the
+  right decode path.
+
+**Forward compatibility.** The trailing `1` is a version digit, reserving the
+prefix space for future incompatible revisions of the wire format. Should the
+encoding ever evolve in a way older decoders cannot interpret, a new prefix
+(`fvj2:`, etc.) signals the change; older decoders can reject the input
+cleanly rather than parsing it incorrectly. The current spec defines only
+`fvj1:`.
 
 ## 2. Key Convention: `/<Type>@<Version>`
 

--- a/docs/specs/space-model-formal-spec/README.md
+++ b/docs/specs/space-model-formal-spec/README.md
@@ -15,8 +15,9 @@ This spec covers:
 - **Unknown types** (Section 3) -- forward-compatibility via `UnknownValue`
 - **Serialization contexts** (Section 4) -- boundary-crossing serialization
   strategy, the `serialize()`/`deserialize()` functions, and boundary inventory
-- **JSON encoding** -- the `/<Type>@<Version>` wire format for special types,
-  escaping, detection rules, and the `/`-key reservation rule
+- **JSON encoding** -- the `fvj1:` encoding prefix, the `/<Type>@<Version>`
+  wire format for special types, escaping, detection rules, and the `/`-key
+  reservation rule
 - **Hashing** (Section 6) -- content-based identity for fabric values
 - **Implementation guidance** (Section 7) -- migration from legacy formats
 
@@ -32,5 +33,6 @@ system, schemas.
 - [2-hash-byte-format.md](./2-hash-byte-format.md) --
   Byte-level encoding for the hash algorithm.
 - [3-json-encoding.md](./3-json-encoding.md) -- The JSON wire format for
-  fabric values: `/<Type>@<Version>` tagged objects, standard type encodings,
-  detection, escaping, and the `/`-key reservation rule.
+  fabric values: the `fvj1:` encoding prefix, `/<Type>@<Version>` tagged
+  objects, standard type encodings, detection, escaping, and the `/`-key
+  reservation rule.

--- a/docs/specs/space-model/1-data-model.md
+++ b/docs/specs/space-model/1-data-model.md
@@ -548,6 +548,23 @@ translation from "native types" to JSON. Other encodings like CBOR may represent
 types more directly — for example, using CBOR's native byte array rather than `{
 "/Bytes@1": "base64..." }`.
 
+> **Pointer to formal spec.** The mechanics summarized in this section —
+> tagged-key form, escapes, detection, and the `/`-key reservation rule — are
+> defined precisely in the formal spec at `space-model-formal-spec/3-json-encoding.md`.
+> The text below is a prose summary; the formal spec is authoritative on
+> conformance details.
+
+#### Encoding Prefix: `fvj1:`
+
+Every encoded fabric value carries a literal `fvj1:` prefix in front of the
+JSON itself. The prefix lets a recipient distinguish, at a glance, JSON that
+came from the fabric encoder from arbitrary JSON of unrelated origin.
+"`fvj1`" stands for "Fabric Value JSON, version 1"; the trailing version
+digit reserves space for future incompatible revisions of the wire format.
+
+For full details — including how decoders verify and strip the prefix —
+see Section 1.1 of the formal spec.
+
 #### Current State: Three Conventions
 
 The current system uses three different conventions for special object shapes:
@@ -596,13 +613,15 @@ whatever representation makes the most sense in their context.
 
 #### Detection
 
-A value is a special type if:
-1. It is a plain object
-2. It has exactly one key
-3. That key starts with `/`
+In the JSON wire format, **any plain object containing at least one key that
+starts with `/`** is a reserved form — either a tagged value, a built-in
+escape, or an encoding error. The common case is a single-key object whose
+sole key starts with `/` (a tagged value); multi-key objects with one or
+more `/`-prefixed keys are also reserved (see "Reservation Rule" below for
+how each form is interpreted).
 
-This simple rule is quick to check and provides maximum flexibility to evolve
-the key format.
+This rule provides maximum flexibility to evolve the key format while
+keeping the boundary between encoding signals and user data unambiguous.
 
 #### Stateless Types
 
@@ -655,6 +674,38 @@ Use cases for `/quote`:
 - `/object`: You have a plain object with a slash-prefixed key, but values should
   still be interpreted normally
 - `/quote`: You want the entire subtree treated as literal JSON data
+
+**Encoder dispatch (recommended best practice).** When the encoder must wrap
+a plain object with `/`-prefixed keys, both forms are valid wire output, but
+the recommended choice is `/quote` when the entire subtree is fully literal
+(no descendants need encoding) and `/object` otherwise. The wire form is
+unambiguous either way — a conforming encoder may emit `/object` in any
+case, and **a conforming decoder must accept both forms**. See Section 6 of
+the formal spec for the precise dispatch rule and motivation.
+
+#### Reservation Rule
+
+The `/` prefix is wholly owned by the encoding system in the wire format.
+That means a wire-format object containing any `/`-prefixed key is always
+either a tagged value, a built-in escape, or an encoding error — never a
+literal user-data key. User-data plain objects may carry `/`-prefixed keys
+at the data level, but a conforming encoder always wraps them via `/object`
+or `/quote` before they reach the wire (see Escaping above).
+
+Concretely:
+
+- A bare `"/"` key (i.e. the tag name is empty after stripping the leading
+  `/`) is always an encoding error. Decoders should produce a
+  `ProblematicValue` rather than treating it as a tagged form.
+- A single-key object whose sole key starts with `/` is a tagged value of
+  a known type, a built-in escape (`/object`, `/quote`), or an unrecognized
+  tag (preserved as `UnknownValue` for round-tripping).
+- A multi-key object containing one or more `/`-prefixed keys among its
+  keys is a structural encoding error — also `ProblematicValue`. It is not
+  a valid plain object.
+
+See Section 9 of the formal spec for the full rule and the
+`ProblematicValue` interpretation across the cases above.
 
 #### Unknown Type Handling
 


### PR DESCRIPTION
Spec sync pass over both the informal (`docs/specs/space-model/`) and
formal (`docs/specs/space-model-formal-spec/`) specs, accounting for
recent activity around the modern-hash flag graduation and the
unambiguous prefix on encoded JSON emitted by the data model.

### Open questions for review

Two placement / scope questions called out for human reviewer rather
than guessed:

1. The `fvj1:` section is drafted as §1.1 within the Overview, on
   the structural-outermost-concept argument. A new top-level §10
   "Encoding Prefix" at the end of `3-json-encoding.md` would also be
   reasonable. Reversible either way.
2. Spec describes the prefix's role (encoders MUST emit, decoders
   MUST verify) without specifying error behavior on missing prefix.
   That's an implementation strictness choice, not a decision settled
   in writing — left to implementations.

### Topic 1 — modernHash graduation residue (post-#3437/#3448/#3449)

PR #3437 already scrubbed `modernHash` / "canonical hash" framing
across 9 spec files (file 2 renamed `2-canonical-hash-byte-format.md`
→ `2-hash-byte-format.md`); subsequent renames in PRs #3448 and
#3449 routed callers through public hash names. One stale residue
remained: an example algorithm tag of `"legacy"` in the
`FabricHash.tag` doc-comment (`1-fabric-values.md:703`). Removed; the
legacy hashing path is gone with the flag.

### Topic 2 — `fvj1:` encoding prefix (PR #3429, the load-bearing add)

Documents the literal `fvj1:` prefix prepended to every JSON-encoded
fabric value. Spec was previously silent on the prefix (zero matches
in `docs/specs/`). Added:

- **Formal:** new §1.1 "Encoding Prefix" in `3-json-encoding.md`,
  describing the prefix purpose ("Fabric Value JSON, version 1"), the
  encoder/decoder MUST clauses, the detection helper, and the
  forward-compatibility note about the trailing version digit.
  Title-blurb and README scope updated to mention the prefix.
- **Informal:** brief "Encoding Prefix" subsection in `1-data-model.md`
  "JSON Encoding for Special Types" section, prose-summary voice,
  cross-referencing the formal spec as authoritative.

### Topic 2-prime — `/`-key + `/quote`/`/object` cluster

Formal spec was already internally consistent (PRs #3392, #3401, #3406
landed cleanly); no formal-spec edits needed. Informal spec was
behind: the existing "JSON Encoding for Special Types" section still
described the narrower single-key Detection rule and lacked the
reservation rule and encoder-dispatch best-practice. Added:

- Updated Detection subsection to match the formal spec's broader
  rule (any `/`-prefixed key is reserved, not just single-key).
- Added "Encoder dispatch (recommended best practice)" paragraph in
  the Escaping subsection, summarizing the `/quote`-vs-`/object`
  dispatch and the decoder-MUST-accept-both clause.
- New "Reservation Rule" subsection covering bare `"/"`, single-key,
  and multi-key cases with `ProblematicValue` / `UnknownValue`
  interpretations. Cross-references formal §9.
- Pointer-to-formal-spec callout at the top of the section.

### Topic 3 — judgment-call candidates (negative outcomes)

- Storable→Fabric residue: zero matches across both spec dirs
  (sessions 2026-050 / 2026-056 left it clean). No edit needed.
- Debug-stringifier helpers (#3408 / #3431 / #3436): zero matches.
  Spec correctly stays silent on debug utilities. No edit needed.
- PR #3410 / #3412 (`EMPTY_RECONSTRUCTION_CONTEXT`, `valueFromJson`
  consistency): caller-side / API-shape, below the spec's abstraction
  line. No edit needed.

### Forward-pointer noted in passing

The informal `1-data-model.md` "Late Serialization: Rich Types Within
the Runtime" section is labeled "Proposed Directions" but the formal
spec has long since landed it; the embedded "Open Questions" lists
are also historical. This proposal-spec drift is real and worth a
separate sweep, but is out of scope here.

### Test plan

Spec-only PR — no source-code changes, so no CI tests cover
`docs/specs/`.

- [x] `deno fmt` excludes `docs/` (verified per repo config); no
  formatter run required.
- [x] Single-commit shape: `f48813b2c`, +97/-14 across 4 files
  (formal `1-fabric-values.md`, `3-json-encoding.md`, formal
  `README.md`, informal `1-data-model.md`).
