### PR TITLE
Fetch live PR bodies in perf check

### DIFF
--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -2,8 +2,8 @@ import { assertAlmostEquals, assertEquals } from "@std/assert";
 import {
   computeBaseline,
   extractMetrics,
+  fetchPRBody,
   type Job,
-  readPRBodyFromEventPayload,
   type Step,
   type WorkflowRun,
 } from "./perf-lib.ts";
@@ -103,25 +103,26 @@ Deno.test("computeBaseline uses the 3 sigma threshold when it exceeds 15 percent
   assertEquals(baseline?.threshold, 160);
 });
 
-Deno.test("readPRBodyFromEventPayload reads matching pull request bodies", async () => {
-  const eventPath = await Deno.makeTempFile();
+Deno.test("fetchPRBody reads the live pull request body from the GitHub API", async () => {
+  const originalFetch = globalThis.fetch;
+  let requestedUrl: string | undefined;
   try {
-    await Deno.writeTextFile(
-      eventPath,
-      JSON.stringify({
-        pull_request: {
-          number: 3427,
-          body: "NEW_PERF_BASELINE: job: Test = 300s",
-        },
-      }),
-    );
+    globalThis.fetch = ((input, _init) => {
+      requestedUrl = input instanceof Request ? input.url : String(input);
+      return Promise.resolve(
+        new Response(JSON.stringify({ body: "LIVE PR BODY" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }) as typeof fetch;
 
+    assertEquals(await fetchPRBody(3427), "LIVE PR BODY");
     assertEquals(
-      await readPRBodyFromEventPayload(3427, eventPath),
-      "NEW_PERF_BASELINE: job: Test = 300s",
+      requestedUrl,
+      "https://api.github.com/repos/commontoolsinc/labs/pulls/3427",
     );
-    assertEquals(await readPRBodyFromEventPayload(1, eventPath), undefined);
   } finally {
-    await Deno.remove(eventPath);
+    globalThis.fetch = originalFetch;
   }
 });

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -148,13 +148,6 @@ export interface PRInfo {
   merged_at: string | null;
 }
 
-export interface PullRequestEventPayload {
-  pull_request?: {
-    number?: number;
-    body?: string | null;
-  };
-}
-
 export interface BaselineOverrides {
   /** Metric name -> value in the metric's native unit (seconds or nanoseconds). */
   metrics: Map<string, number>;
@@ -817,35 +810,11 @@ export async function fetchPRForCommit(
 }
 
 /** Fetch the full body of a PR by number. */
-export async function fetchPRBody(
-  prNumber: number,
-  eventPath?: string | undefined,
-): Promise<string> {
-  const bodyFromEvent = await readPRBodyFromEventPayload(prNumber, eventPath);
-  if (bodyFromEvent !== undefined) {
-    return bodyFromEvent;
-  }
+export async function fetchPRBody(prNumber: number): Promise<string> {
   const pr = await githubGet<{ body: string | null }>(
     `/repos/${REPO}/pulls/${prNumber}`,
   );
   return pr.body ?? "";
-}
-
-export async function readPRBodyFromEventPayload(
-  prNumber: number,
-  eventPath?: string | undefined,
-): Promise<string | undefined> {
-  const payload = await readAndParseEvent(eventPath);
-
-  if (payload !== undefined) {
-    const prInfo = (payload as PullRequestEventPayload).pull_request;
-    if (prInfo?.number === prNumber) {
-      const body = prInfo?.body;
-      return (body && (body !== "")) ? body : undefined;
-    }
-  }
-
-  return undefined;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make perf-check PR override parsing fetch the live PR body from the GitHub API again
- remove the stale GITHUB_EVENT_PATH PR-body shortcut and replace its test with an API-fetch regression test
- keep event logging for diagnostics

## Test plan
- deno fmt --check tasks/perf-lib.ts tasks/perf-lib.test.ts
- deno check tasks/perf-check.ts tasks/perf-lib.ts tasks/perf-lib.test.ts
- deno test -A tasks/perf-lib.test.ts
- git diff --check