### PR TITLE
Index cf-harness skill resources

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -49,6 +49,7 @@ What works today:
 - transcript-based resumability
 - package-local operator CLI
 - explicit Agent Skills preload via `--skills-root` and repeatable `--skill`
+- runtime-generated supporting-resource indexes in `skill-registry.json`
 - CFC mode plumbing with:
   - `disabled`
   - `observe`
@@ -71,7 +72,7 @@ What is not done yet:
 - first-class browser operation policy on top of the provisional browser
   subagent profile
 - dynamic/model-driven Agent Skills activation and supporting-file resource
-  loading
+  reads
 - parallel child orchestration
 - app UI event provenance
 - streaming model responses

--- a/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
@@ -244,13 +244,15 @@ Why:
 - explicit `skillsRoot` configuration and CLI flags
 - explicit skill preload for batch/product runs
 - persisted skill registry and activation artifacts
+- runtime-generated supporting-resource indexes in skill registry artifacts
 - CFC classification of skill content as context, not direct-command authority
 - context message insertion before the final task prompt
 
 Still planned:
 
 - eventual dedicated `load_skill` tool for model-driven activation
-- supporting-file/resource loading from skill directories
+- supporting-file/resource reads from skill directories
+- script execution through a separately permissioned boundary
 - explicit subagent skill activation policy
 
 Why:

--- a/packages/cf-harness/docs/SKILLS_SUPPORT_SPEC.md
+++ b/packages/cf-harness/docs/SKILLS_SUPPORT_SPEC.md
@@ -38,9 +38,11 @@ and `description`, then point to canonical repo docs. Examples:
   `docs/common/ai/pattern-testing-guide.md`.
 - `skills/cf/SKILL.md` provides current CLI command guidance.
 
-`cf-harness` already has a dormant `skillsRoot?: string` field in
-`src/config.ts`, but the CLI, prompt loop, artifacts, and tool surface do not
-use it yet.
+`cf-harness` now uses `skillsRoot?: string` in `src/config.ts` for explicit
+skill preload. The CLI, prompt loop, and artifact store persist the discovered
+registry and activation artifacts. The registry is also being extended to
+snapshot supporting resources that are actually present in the configured skill
+directories at run start.
 
 ## External Models Reviewed
 
@@ -143,6 +145,50 @@ Validation should be lenient where that improves compatibility:
 - Symlinked skill directories are allowed only when the resolved `SKILL.md`
   stays under the configured skill root or another explicitly allowed root.
 
+## Supporting Resource Index
+
+Supporting resources should be discovered automatically from the filesystem at
+runtime. Normal skills should not need a hand-authored resource manifest.
+
+At run start, `cf-harness` should snapshot every accepted skill directory and
+record a resource index inside `skill-registry.json`. This index is bounded by
+the configured `skillsRoot` and the resolved skill directory, not by global host
+filesystem discovery.
+
+Resource classification is path-convention based:
+
+- `references/**` -> `reference`
+- `assets/**` -> `asset`
+- `templates/**` -> `template`
+- `scripts/**` -> `script`
+- any other accepted file under the skill directory -> `other`
+
+Each resource record should include:
+
+- path relative to the skill directory
+- kind
+- host path
+- sandbox path
+- byte size
+- digest
+- text/binary content guess
+- diagnostics
+
+Resource discovery must:
+
+- skip the root `SKILL.md`
+- sort paths deterministically
+- reject or skip resources whose resolved paths escape the skill directory or
+  configured skills root
+- avoid following cyclic directory structures
+- preserve diagnostics for unreadable, unresolvable, out-of-bound, or
+  scan-limited resources
+
+The registry is a snapshot. A later `read_skill_resource` tool should stat/read
+the actual file at call time. If the file differs from the run-start snapshot,
+the tool should report the mismatch in its output and artifacts rather than
+silently treating the snapshot as exact.
+
 ## CLI and Config Surface
 
 Use the existing config field:
@@ -201,10 +247,12 @@ Behavior:
 1. Resolve and validate `skillsRoot`.
 2. Build a registry of `skillsRoot/**/SKILL.md` with bounded traversal.
 3. Validate frontmatter and produce diagnostics.
-4. For each explicit `--skill`, read the full `SKILL.md`.
-5. Inject a structured skill context block before the user task.
-6. Record skill registry and skill activation artifacts.
-7. Preserve the activated skill context in transcript/resume state.
+4. For each accepted skill, index supporting resources from the runtime
+   filesystem and record them in `skill-registry.json`.
+5. For each explicit `--skill`, read the full `SKILL.md`.
+6. Inject a structured skill context block before the user task.
+7. Record skill registry and skill activation artifacts.
+8. Preserve the activated skill context in transcript/resume state.
 
 The injected block should be labeled as configured context, not as a direct user
 command:

--- a/packages/cf-harness/src/contracts/skill.ts
+++ b/packages/cf-harness/src/contracts/skill.ts
@@ -15,6 +15,26 @@ export type HarnessSkillFrontmatterValue =
   | boolean
   | readonly string[];
 
+export type HarnessSkillResourceKind =
+  | "reference"
+  | "asset"
+  | "template"
+  | "script"
+  | "other";
+
+export type HarnessSkillResourceContentKind = "text" | "binary";
+
+export interface HarnessSkillResourceRecord {
+  path: string;
+  kind: HarnessSkillResourceKind;
+  resourcePath: string;
+  sandboxResourcePath: string;
+  sizeBytes: number;
+  digest: string;
+  contentKind: HarnessSkillResourceContentKind;
+  diagnostics: HarnessSkillDiagnostic[];
+}
+
 export interface HarnessSkillRecord {
   name: string;
   description: string;
@@ -23,6 +43,7 @@ export interface HarnessSkillRecord {
   sandboxSkillPath: string;
   sandboxSkillDir: string;
   digest: string;
+  resources: HarnessSkillResourceRecord[];
   frontmatter: Record<string, HarnessSkillFrontmatterValue>;
   diagnostics: HarnessSkillDiagnostic[];
 }

--- a/packages/cf-harness/src/skills/registry.ts
+++ b/packages/cf-harness/src/skills/registry.ts
@@ -20,11 +20,18 @@ import {
   type HarnessSkillFrontmatterValue,
   type HarnessSkillRecord,
   type HarnessSkillRegistry,
+  type HarnessSkillResourceContentKind,
+  type HarnessSkillResourceKind,
+  type HarnessSkillResourceRecord,
 } from "../contracts/skill.ts";
 
 const SKILL_FILE_NAME = "SKILL.md";
 const MAX_SKILL_SCAN_DEPTH = 6;
 const MAX_SKILL_SCAN_DIRECTORIES = 2000;
+const MAX_SKILL_RESOURCE_SCAN_DEPTH = 8;
+const MAX_SKILL_RESOURCE_SCAN_DIRECTORIES = 1000;
+const MAX_SKILL_RESOURCE_FILES = 2000;
+const TEXT_DETECTION_SAMPLE_BYTES = 8192;
 const EXCLUDED_SKILL_DIRS = new Set([
   ".git",
   ".github",
@@ -160,10 +167,12 @@ const firstBodyParagraph = (body: string): string | undefined => {
   return undefined;
 };
 
-const sha256Digest = async (content: string): Promise<string> => {
+const sha256BytesDigest = async (content: Uint8Array): Promise<string> => {
+  const buffer = new ArrayBuffer(content.byteLength);
+  new Uint8Array(buffer).set(content);
   const digest = await crypto.subtle.digest(
     "SHA-256",
-    new TextEncoder().encode(content),
+    buffer,
   );
   return `sha256:${
     [...new Uint8Array(digest)]
@@ -171,6 +180,9 @@ const sha256Digest = async (content: string): Promise<string> => {
       .join("")
   }`;
 };
+
+const sha256Digest = async (content: string): Promise<string> =>
+  await sha256BytesDigest(new TextEncoder().encode(content));
 
 const pathExists = async (path: string): Promise<boolean> => {
   try {
@@ -275,6 +287,233 @@ const collectSkillFiles = async (
   return { skillFiles, diagnostics };
 };
 
+const normalizeSkillResourcePath = (path: string): string =>
+  path.replaceAll("\\", "/");
+
+const classifySkillResourceKind = (
+  relativePath: string,
+): HarnessSkillResourceKind => {
+  const [firstSegment] = normalizeSkillResourcePath(relativePath).split("/");
+  switch (firstSegment) {
+    case "references":
+      return "reference";
+    case "assets":
+      return "asset";
+    case "templates":
+      return "template";
+    case "scripts":
+      return "script";
+    default:
+      return "other";
+  }
+};
+
+const guessSkillResourceContentKind = (
+  content: Uint8Array,
+): HarnessSkillResourceContentKind => {
+  const sample = content.slice(0, TEXT_DETECTION_SAMPLE_BYTES);
+  if (sample.includes(0)) {
+    return "binary";
+  }
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(sample);
+    return "text";
+  } catch {
+    return "binary";
+  }
+};
+
+const collectSkillResources = async (
+  options: {
+    skillsRoot: string;
+    resolvedSkillsRoot: string;
+    sandboxSkillsRoot: string;
+    skillDir: string;
+    resolvedSkillDir: string;
+  },
+): Promise<{
+  resources: HarnessSkillResourceRecord[];
+  diagnostics: HarnessSkillDiagnostic[];
+}> => {
+  const resources: HarnessSkillResourceRecord[] = [];
+  const diagnostics: HarnessSkillDiagnostic[] = [];
+  const visitedDirectories = new Set<string>();
+  let directoriesVisited = 0;
+  let filesVisited = 0;
+  const rootSkillPath = resolve(options.skillDir, SKILL_FILE_NAME);
+
+  const visit = async (dir: string, depth: number): Promise<void> => {
+    let resolvedDir: string;
+    try {
+      resolvedDir = await Deno.realPath(dir);
+    } catch {
+      diagnostics.push(createDiagnostic({
+        severity: "warning",
+        code: "unresolvable-skill-resource-scan-path",
+        detail: `Could not resolve skill resource scan path: ${dir}`,
+        path: dir,
+      }));
+      return;
+    }
+    if (
+      !isPathWithinRoot(options.resolvedSkillDir, resolvedDir) ||
+      !isPathWithinRoot(options.resolvedSkillsRoot, resolvedDir)
+    ) {
+      diagnostics.push(createDiagnostic({
+        severity: "warning",
+        code: "skill-resource-scan-outside-root",
+        detail:
+          `Skipped skill resource scan path because it resolves outside the skill directory or configured skills root.`,
+        path: dir,
+      }));
+      return;
+    }
+    if (visitedDirectories.has(resolvedDir)) {
+      return;
+    }
+    visitedDirectories.add(resolvedDir);
+    directoriesVisited += 1;
+    if (directoriesVisited > MAX_SKILL_RESOURCE_SCAN_DIRECTORIES) {
+      diagnostics.push(createDiagnostic({
+        severity: "warning",
+        code: "resource-scan-limit-exceeded",
+        detail:
+          `Stopped scanning skill resources after ${MAX_SKILL_RESOURCE_SCAN_DIRECTORIES} directories.`,
+        path: dir,
+      }));
+      return;
+    }
+    if (depth > MAX_SKILL_RESOURCE_SCAN_DEPTH) {
+      diagnostics.push(createDiagnostic({
+        severity: "warning",
+        code: "resource-max-depth-exceeded",
+        detail:
+          `Skipped skill resource scan path beyond max depth ${MAX_SKILL_RESOURCE_SCAN_DEPTH}.`,
+        path: dir,
+      }));
+      return;
+    }
+
+    let entries: Deno.DirEntry[];
+    try {
+      entries = [];
+      for await (const entry of Deno.readDir(dir)) {
+        entries.push(entry);
+      }
+    } catch (error) {
+      diagnostics.push(createDiagnostic({
+        severity: "warning",
+        code: "unreadable-skill-resource-directory",
+        detail: error instanceof Error ? error.message : String(error),
+        path: dir,
+      }));
+      return;
+    }
+
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      if (EXCLUDED_SKILL_DIRS.has(entry.name)) {
+        continue;
+      }
+      const entryPath = join(dir, entry.name);
+      let stat: Deno.FileInfo;
+      try {
+        stat = await Deno.stat(entryPath);
+      } catch {
+        diagnostics.push(createDiagnostic({
+          severity: "warning",
+          code: "unstatable-skill-resource",
+          detail: `Could not stat skill resource path: ${entryPath}`,
+          path: entryPath,
+        }));
+        continue;
+      }
+      if (stat.isDirectory) {
+        await visit(entryPath, depth + 1);
+        continue;
+      }
+      if (!stat.isFile) {
+        continue;
+      }
+      if (resolve(entryPath) === rootSkillPath) {
+        continue;
+      }
+      filesVisited += 1;
+      if (filesVisited > MAX_SKILL_RESOURCE_FILES) {
+        diagnostics.push(createDiagnostic({
+          severity: "warning",
+          code: "resource-file-limit-exceeded",
+          detail:
+            `Stopped indexing skill resources after ${MAX_SKILL_RESOURCE_FILES} files.`,
+          path: entryPath,
+        }));
+        return;
+      }
+
+      let resolvedResourcePath: string;
+      try {
+        resolvedResourcePath = await Deno.realPath(entryPath);
+      } catch {
+        diagnostics.push(createDiagnostic({
+          severity: "warning",
+          code: "unresolvable-skill-resource",
+          detail: `Could not resolve skill resource path: ${entryPath}`,
+          path: entryPath,
+        }));
+        continue;
+      }
+      if (
+        !isPathWithinRoot(options.resolvedSkillDir, resolvedResourcePath) ||
+        !isPathWithinRoot(options.resolvedSkillsRoot, resolvedResourcePath)
+      ) {
+        diagnostics.push(createDiagnostic({
+          severity: "warning",
+          code: "skill-resource-outside-root",
+          detail:
+            `Skipped skill resource because its resolved path is outside the skill directory or configured skills root.`,
+          path: entryPath,
+        }));
+        continue;
+      }
+
+      let content: Uint8Array;
+      try {
+        content = await Deno.readFile(entryPath);
+      } catch (error) {
+        diagnostics.push(createDiagnostic({
+          severity: "warning",
+          code: "unreadable-skill-resource",
+          detail: error instanceof Error ? error.message : String(error),
+          path: entryPath,
+        }));
+        continue;
+      }
+
+      const resourcePath = normalizeSkillResourcePath(
+        relative(options.skillDir, entryPath),
+      );
+      resources.push({
+        path: resourcePath,
+        kind: classifySkillResourceKind(resourcePath),
+        resourcePath: entryPath,
+        sandboxResourcePath: hostPathToSandboxPath(
+          options.skillsRoot,
+          options.sandboxSkillsRoot,
+          entryPath,
+        ),
+        sizeBytes: stat.size,
+        digest: await sha256BytesDigest(content),
+        contentKind: guessSkillResourceContentKind(content),
+        diagnostics: [],
+      });
+    }
+  };
+
+  await visit(options.skillDir, 0);
+  resources.sort((a, b) => a.path.localeCompare(b.path));
+  return { resources, diagnostics };
+};
+
 export const discoverHarnessSkills = async (
   options: DiscoverHarnessSkillsOptions,
 ): Promise<HarnessSkillRegistry> => {
@@ -320,6 +559,7 @@ export const discoverHarnessSkills = async (
       }));
       continue;
     }
+    const resolvedSkillDir = dirname(resolvedSkillPath);
     let content: string;
     try {
       content = await Deno.readTextFile(skillPath);
@@ -390,6 +630,15 @@ export const discoverHarnessSkills = async (
       continue;
     }
     seenNames.add(name);
+    const { resources, diagnostics: resourceDiagnostics } =
+      await collectSkillResources({
+        skillsRoot,
+        resolvedSkillsRoot,
+        sandboxSkillsRoot,
+        skillDir,
+        resolvedSkillDir,
+      });
+    recordDiagnostics.push(...resourceDiagnostics);
     skills.push({
       name,
       description,
@@ -406,6 +655,7 @@ export const discoverHarnessSkills = async (
         skillDir,
       ),
       digest: await sha256Digest(content),
+      resources,
       frontmatter: parsed.frontmatter,
       diagnostics: recordDiagnostics,
     });

--- a/packages/cf-harness/test/skills-registry.test.ts
+++ b/packages/cf-harness/test/skills-registry.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertRejects } from "@std/assert";
-import { join } from "@std/path";
+import { dirname, join } from "@std/path";
 import {
   discoverHarnessSkills,
   loadHarnessSkillContext,
@@ -14,6 +14,21 @@ const writeSkill = async (
   const dir = join(root, name);
   await Deno.mkdir(dir, { recursive: true });
   await Deno.writeTextFile(join(dir, "SKILL.md"), content);
+};
+
+const writeSkillResource = async (
+  root: string,
+  skillName: string,
+  resourcePath: string,
+  content: string | Uint8Array,
+): Promise<void> => {
+  const path = join(root, skillName, resourcePath);
+  await Deno.mkdir(dirname(path), { recursive: true });
+  if (typeof content === "string") {
+    await Deno.writeTextFile(path, content);
+  } else {
+    await Deno.writeFile(path, content);
+  }
 };
 
 Deno.test("parseHarnessSkillFile handles simple frontmatter and continued descriptions", () => {
@@ -57,6 +72,36 @@ Deno.test({
           "",
           "# Pattern Dev",
         ].join("\n"),
+      );
+      await writeSkillResource(
+        root,
+        "pattern-dev",
+        "references/guide.md",
+        "# Guide\n",
+      );
+      await writeSkillResource(
+        root,
+        "pattern-dev",
+        "assets/logo.bin",
+        new Uint8Array([0, 159, 146, 150]),
+      );
+      await writeSkillResource(
+        root,
+        "pattern-dev",
+        "templates/scaffold.sh",
+        "#!/usr/bin/env bash\n",
+      );
+      await writeSkillResource(
+        root,
+        "pattern-dev",
+        "scripts/check.ts",
+        "console.log('ok');\n",
+      );
+      await writeSkillResource(
+        root,
+        "pattern-dev",
+        "notes.txt",
+        "Other local note\n",
       );
       await writeSkill(
         root,
@@ -122,6 +167,57 @@ Deno.test({
           ?.frontmatter["user-invocable"],
         false,
       );
+      const patternDev = registry.skills.find((skill) =>
+        skill.name === "pattern-dev"
+      );
+      assertEquals(
+        patternDev?.resources.map((resource) => [
+          resource.path,
+          resource.kind,
+          resource.contentKind,
+          resource.sandboxResourcePath,
+        ]),
+        [
+          [
+            "assets/logo.bin",
+            "asset",
+            "binary",
+            "/workspace/labs/skills/pattern-dev/assets/logo.bin",
+          ],
+          [
+            "notes.txt",
+            "other",
+            "text",
+            "/workspace/labs/skills/pattern-dev/notes.txt",
+          ],
+          [
+            "references/guide.md",
+            "reference",
+            "text",
+            "/workspace/labs/skills/pattern-dev/references/guide.md",
+          ],
+          [
+            "scripts/check.ts",
+            "script",
+            "text",
+            "/workspace/labs/skills/pattern-dev/scripts/check.ts",
+          ],
+          [
+            "templates/scaffold.sh",
+            "template",
+            "text",
+            "/workspace/labs/skills/pattern-dev/templates/scaffold.sh",
+          ],
+        ],
+      );
+      assertEquals(patternDev?.resources[0].sizeBytes, 4);
+      assertEquals(patternDev?.resources[0].digest.startsWith("sha256:"), true);
+      assertEquals(
+        patternDev?.resources.every((resource) =>
+          resource.diagnostics.length === 0
+        ),
+        true,
+      );
       assertEquals(
         registry.diagnostics.map((diagnostic) => diagnostic.code).sort(),
         ["duplicate-skill-name", "missing-description"],
@@ -167,6 +263,51 @@ Deno.test({
       assertEquals(
         registry.diagnostics.map((diagnostic) => diagnostic.code),
         ["skill-scan-outside-root"],
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+      await Deno.remove(outside, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "discoverHarnessSkills skips resources that resolve outside the skill directory",
+  permissions: { read: true, write: true },
+  async fn() {
+    const root = await Deno.makeTempDir({ prefix: "cf-harness-skills-" });
+    const outside = await Deno.makeTempDir({
+      prefix: "cf-harness-outside-resource-",
+    });
+    try {
+      await writeSkill(
+        root,
+        "pattern-dev",
+        [
+          "---",
+          "name: pattern-dev",
+          "description: Build Common Fabric patterns",
+          "---",
+          "",
+          "# Pattern Dev",
+        ].join("\n"),
+      );
+      await Deno.writeTextFile(join(outside, "external.md"), "# External\n");
+      await Deno.mkdir(join(root, "pattern-dev", "references"), {
+        recursive: true,
+      });
+      await Deno.symlink(
+        join(outside, "external.md"),
+        join(root, "pattern-dev", "references", "external.md"),
+      );
+
+      const registry = await discoverHarnessSkills({ skillsRoot: root });
+
+      assertEquals(registry.skills[0].resources, []);
+      assertEquals(
+        registry.skills[0].diagnostics.map((diagnostic) => diagnostic.code),
+        ["skill-resource-outside-root"],
       );
     } finally {
       await Deno.remove(root, { recursive: true });


### PR DESCRIPTION
## Summary
- add runtime-generated supporting resource records to cf-harness skill registry artifacts
- classify references/assets/templates/scripts/other resources with size, digest, sandbox path, and text/binary metadata
- document resource indexing as implemented while keeping resource reads and script execution as future slices

## Tests
- deno test --allow-read --allow-write packages/cf-harness/test/skills-registry.test.ts
- deno task test (from packages/cf-harness)