### PR TITLE
feat(runner): swap JSON.stringify for debug-stringifiers in 2 files (+ TODO in plain-data)

### DIFF
--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -5,6 +5,7 @@ import {
   isArrayIndexPropertyName,
   shallowFabricFromNativeValue,
 } from "@commonfabric/data-model/fabric-value";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
 import { ID, ID_FIELD, type JSONSchema } from "./builder/types.ts";
 import { createRef } from "./create-ref.ts";
@@ -282,7 +283,7 @@ export function diffAndUpdate(
   );
   diffLogger.debug(
     "diff",
-    () => `[diffAndUpdate] changes: ${JSON.stringify(changes)}`,
+    () => `[diffAndUpdate] changes: ${toCompactDebugString(changes)}`,
   );
   applyChangeSet(tx, changes);
   return changes.length > 0;
@@ -333,7 +334,7 @@ export function normalizeAndDiff(
     "diff",
     () =>
       `[DIFF_ENTER] path=${pathStr} type=${valueType} newValue=${
-        JSON.stringify(newValue as any)
+        toCompactDebugString(newValue)
       }`,
   );
 
@@ -547,7 +548,7 @@ export function normalizeAndDiff(
       "diff",
       () =>
         `[BRANCH_CELL_LINK] Processing cell link at path=${pathStr} link=${
-          JSON.stringify(newValue as any)
+          toCompactDebugString(newValue)
         }`,
     );
     const carriedCfcLabelView = cfcLabelViewForPrimitiveLink(newValue);

--- a/packages/runner/src/sandbox/plain-data.ts
+++ b/packages/runner/src/sandbox/plain-data.ts
@@ -1,4 +1,5 @@
 import { FrozenMap, FrozenSet } from "@commonfabric/data-model/frozen-builtins";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 
 // Resolve `entries`/`values` from the prototype chain so own-property shadows
 // on Map/Set instances cannot interfere, while still working correctly for
@@ -487,7 +488,7 @@ function pathForIndex(path: string, index: number): string {
 function pathForProperty(path: string, name: string): string {
   return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name)
     ? `${path}.${name}`
-    : `${path}[${JSON.stringify(name)}]`;
+    : `${path}[${toCompactDebugString(name)}]`;
 }
 
 function validationError(

--- a/packages/runner/src/sandbox/plain-data.ts
+++ b/packages/runner/src/sandbox/plain-data.ts
@@ -1,5 +1,4 @@
 import { FrozenMap, FrozenSet } from "@commonfabric/data-model/frozen-builtins";
-import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 
 // Resolve `entries`/`values` from the prototype chain so own-property shadows
 // on Map/Set instances cannot interfere, while still working correctly for
@@ -98,6 +97,9 @@ function validateModuleSafeValue(
   }
   visited.add(objectValue);
 
+  // TODO(danfuzz): This part of the code will probably have to gain the
+  // ability to reason specifically about `FabricSpecialObject`s in order
+  // to fully support the modern data model.
   try {
     if (Array.isArray(objectValue)) {
       validateOwnProperties(objectValue, path, visited, { skipLength: true });
@@ -488,7 +490,7 @@ function pathForIndex(path: string, index: number): string {
 function pathForProperty(path: string, name: string): string {
   return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name)
     ? `${path}.${name}`
-    : `${path}[${toCompactDebugString(name)}]`;
+    : `${path}[${JSON.stringify(name)}]`;
 }
 
 function validationError(

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -3154,13 +3154,11 @@ export class SchemaObjectTraverser<V extends FabricValue>
     if (doc.value === undefined) {
       return "undefined";
     }
-    return JSON.stringify(
+    return toIndentedDebugString(
       this.traverseWithSelector(doc, {
         path: doc.address.path,
         schema: true,
       }),
-      getCircularReplacer(),
-      2,
     );
   }
 }
@@ -3404,23 +3402,6 @@ function _mergeAnyOfBranchSchemasUncached(
     ...((outerSchema.asCell || outerSchema.asStream) &&
       { asCell: outerSchema.asCell ?? ["stream"] }),
   } as JSONSchemaObj;
-}
-
-// Utility function used for debugging so we can convert proxy objects into
-// regular objects when there's circular references.
-function getCircularReplacer() {
-  const ancestors: object[] = [];
-  return function (_key: string, value: any) {
-    if (typeof value !== "object" || value === null) {
-      return value;
-    }
-    // Check if the value has been seen before in the current ancestry path
-    if (ancestors.includes(value)) {
-      return "[Circular]"; // Replace cyclic reference with a string
-    }
-    ancestors.push(value);
-    return value;
-  };
 }
 
 /**


### PR DESCRIPTION
Track C of the `JSON.parse/stringify` migration arc in runner+memory: 4 SWAP sites in 2 files (3 in `data-updating.ts`, 1 in `traverse.ts`), plus a `TODO(danfuzz)` add in 1 file (`sandbox/plain-data.ts`) in lieu of a swap there.

- **`data-updating.ts`**: 3 debug-log lazy templates use `toCompactDebugString`.
- **`sandbox/plain-data.ts`**: original `pathForProperty()` swap was reverted after review — `pathForProperty()` is reached from `defineSnapshotProperties()` via `copyOwnProperties()` / `pathForKey()` in non-debug contexts, so a debug-stringifier swap there isn't appropriate. Added a `TODO(danfuzz)` block above the `try` at `validateModuleSafeValue` (line 101) noting that this code will likely need `FabricSpecialObject` awareness to fully support the modern data model.
- **`traverse.ts`**: `SchemaObjectTraverser.getDebugValue()` uses `toIndentedDebugString`. The old `getCircularReplacer()` helper is now dead code (`toIndentedDebugString` handles cycles natively per PR #3431) and is removed.

### Track A — not in this PR

Track A from the same review (the four `TODO(danfuzz)` sites in `runner/src/builtins/llm{,-dialog}.ts` naming `cloneSchemaMutable()` as the eventual replacement) is **not** in this PR. The TODO comments themselves read "...before turning on modern data-model" and the helper's doc-comment caveat names runtime-proxy-wrapped schemas as the explicit don't-use-yet condition. Per-site audit at HEAD found all 4 TODO sites + 4 additional A2 schema-cloning sites in those files trace their inputs back to runtime cell machinery (`Cell.get()` reads or cell-link metadata). Per Dan's call: strict gate, those sites stay on raw `JSON.parse(JSON.stringify(...))` until `modernDataModel` graduates.

### D5 LLM-prompt-embed site preserved

D5 LLM-prompt-embed site at `builtins/llm-dialog.ts:1485` (JSON-fenced-into-LLM-prompt) intentionally stays on raw `JSON.stringify` because the LLM is the parser.

### Test plan

- [x] `deno fmt --check` clean on `packages/runner`.
- [x] `deno lint` clean on `packages/runner`.
- [x] `packages/runner` test suite passes.
- [x] Branch shape at fixup `45c787d42`: +8/-23 across 3 files (the net negative is the dead-code removal of `getCircularReplacer()`).
