### PR TITLE
Reserve cf-harness artifact paths

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -185,7 +185,10 @@ locator actions, and normal browser interactions.
 
 For browser-profile runs, prefer a host artifact root outside the workspace. Raw
 child artifacts are retained for operator analysis, but they are not meant to
-become ordinary workspace inputs for the parent model.
+become ordinary workspace inputs for the parent model. If an artifact root is
+physically placed under the workspace, `read_file`, `write_file`, and
+browser-profile `ls`/`find` treat that artifact tree as reserved from
+model-facing file and discovery tools.
 
 ```bash
 ROOT=/tmp/cf-harness-browser-demo

--- a/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
+++ b/packages/cf-harness/docs/IMPLEMENTATION_PLAN.md
@@ -247,12 +247,12 @@ Why:
   child artifacts for audit/debugging
 - local/browser examples should place `--artifact-root` outside `--workspace` so
   raw child artifacts do not become ordinary parent-readable workspace files
+- when artifacts are physically placed under a workspace, the artifact root is
+  reserved from `read_file`, `write_file`, and browser-profile host `ls`/`find`
+  discovery paths
 
 Still planned:
 
-- reserve artifact roots from `read_file`, `write_file`, and browser-profile
-  host discovery commands when a host physically places artifacts under a
-  workspace
 - stop treating raw host artifact paths as model-facing references; prefer
   opaque output IDs/handles for parent-visible results and keep paths in
   operator-facing run state/report data

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -836,6 +836,82 @@ export class CfHarnessEngine {
     return false;
   }
 
+  async #realHostPath(path: string): Promise<string | undefined> {
+    try {
+      return normalizeHostPath(await Deno.realPath(path));
+    } catch {
+      return undefined;
+    }
+  }
+
+  async #nearestExistingRealHostPath(
+    path: string,
+  ): Promise<string | undefined> {
+    let candidate = normalizeHostPath(path);
+    while (true) {
+      const realPath = await this.#realHostPath(candidate);
+      if (realPath !== undefined) {
+        return realPath;
+      }
+      const parent = dirname(candidate);
+      if (parent === candidate) {
+        return undefined;
+      }
+      candidate = parent;
+    }
+  }
+
+  async #isHostPathWithinArtifactRoot(
+    path: string,
+    options: { allowMissing?: boolean } = {},
+  ): Promise<boolean> {
+    const root = this.artifactStore?.artifactRoot;
+    if (root === undefined) {
+      return false;
+    }
+    const normalizedRoot = normalizeHostPath(root);
+    const normalizedPath = normalizeHostPath(path);
+    if (isHostPathWithinRoot(normalizedRoot, normalizedPath)) {
+      return true;
+    }
+    const realRoot = await this.#realHostPath(normalizedRoot);
+    if (realRoot === undefined) {
+      return false;
+    }
+    const realPath = options.allowMissing === true
+      ? await this.#nearestExistingRealHostPath(normalizedPath)
+      : await this.#realHostPath(normalizedPath);
+    return realPath !== undefined && isHostPathWithinRoot(realRoot, realPath);
+  }
+
+  async #doesHostPathIntersectArtifactRoot(
+    path: string,
+    options: { allowMissing?: boolean } = {},
+  ): Promise<boolean> {
+    const root = this.artifactStore?.artifactRoot;
+    if (root === undefined) {
+      return false;
+    }
+    const normalizedRoot = normalizeHostPath(root);
+    const normalizedPath = normalizeHostPath(path);
+    if (
+      isHostPathWithinRoot(normalizedRoot, normalizedPath) ||
+      isHostPathWithinRoot(normalizedPath, normalizedRoot)
+    ) {
+      return true;
+    }
+    const realRoot = await this.#realHostPath(normalizedRoot);
+    if (realRoot === undefined) {
+      return false;
+    }
+    const realPath = options.allowMissing === true
+      ? await this.#nearestExistingRealHostPath(normalizedPath)
+      : await this.#realHostPath(normalizedPath);
+    return realPath !== undefined &&
+      (isHostPathWithinRoot(realRoot, realPath) ||
+        isHostPathWithinRoot(realPath, realRoot));
+  }
+
   async #createCfcInvocationContext(options: {
     toolId: string;
     toolOutputId?: ToolOutputId;
@@ -899,6 +975,14 @@ export class CfHarnessEngine {
         path: string,
         options?: { allowMissing?: boolean },
       ) => this.#isHostPathWithinWorkspace(path, options),
+      isHostPathWithinArtifactRoot: (
+        path: string,
+        options?: { allowMissing?: boolean },
+      ) => this.#isHostPathWithinArtifactRoot(path, options),
+      doesHostPathIntersectArtifactRoot: (
+        path: string,
+        options?: { allowMissing?: boolean },
+      ) => this.#doesHostPathIntersectArtifactRoot(path, options),
       setCurrentDir: (path: string) => {
         const resolved = this.sandbox.resolvePath(
           path,

--- a/packages/cf-harness/src/tools/bash-no-sandbox.ts
+++ b/packages/cf-harness/src/tools/bash-no-sandbox.ts
@@ -82,6 +82,7 @@ export const bashNoSandboxTool: HarnessToolDefinition<
       context,
       hostCwd,
       plan.workspacePathArgs,
+      plan.argv,
     );
     if (hostPathFailure !== undefined) {
       context.setCurrentDir(commandCwd);
@@ -131,11 +132,22 @@ const validateHostWorkspacePaths = async (
   context: HarnessToolContext,
   hostCwd: string,
   workspacePathArgs: readonly string[],
+  argv: readonly string[],
 ): Promise<string | undefined> => {
   if (!(await context.isHostPathWithinWorkspace(hostCwd))) {
     return `cwd ${hostCwd} must resolve within the workspace`;
   }
-  for (const pathArg of workspacePathArgs) {
+  if (
+    await context.isHostPathWithinArtifactRoot(hostCwd, { allowMissing: true })
+  ) {
+    return `cwd ${
+      context.hostPathToWorkspacePath(hostCwd) ?? hostCwd
+    } is reserved for cf-harness artifacts`;
+  }
+  const pathArgs = argv[0] === "ls" && workspacePathArgs.length === 0
+    ? ["."]
+    : workspacePathArgs;
+  for (const pathArg of pathArgs) {
     const hostPath = normalize(join(hostCwd, pathArg));
     if (
       !(await context.isHostPathWithinWorkspace(hostPath, {
@@ -143,6 +155,13 @@ const validateHostWorkspacePaths = async (
       }))
     ) {
       return `path ${pathArg} must resolve within or below the workspace`;
+    }
+    if (
+      await context.doesHostPathIntersectArtifactRoot(hostPath, {
+        allowMissing: true,
+      })
+    ) {
+      return `path ${pathArg} is reserved for cf-harness artifacts`;
     }
   }
   return undefined;

--- a/packages/cf-harness/src/tools/read-file.ts
+++ b/packages/cf-harness/src/tools/read-file.ts
@@ -10,6 +10,10 @@ import {
   type StructuredFileToolErrorOutput,
   structuredFileToolErrorOutputSchema,
 } from "./file-errors.ts";
+import {
+  isResolvedPathInsideArtifactRoot,
+  RESERVED_ARTIFACT_PATH_DETAIL,
+} from "./reserved-artifacts.ts";
 
 export interface ReadFileToolInput {
   path: string;
@@ -78,6 +82,13 @@ export const readFileTool: HarnessToolDefinition<
         path: input.path,
         code: classifyPathResolutionError(error),
         detail: detailFromUnknownError(error),
+      });
+    }
+    if (await isResolvedPathInsideArtifactRoot(context, resolvedPath)) {
+      return createStructuredFileToolErrorOutput(context, "read_file", {
+        path: resolvedPath,
+        code: "permission_denied",
+        detail: RESERVED_ARTIFACT_PATH_DETAIL,
       });
     }
     const command = [

--- a/packages/cf-harness/src/tools/reserved-artifacts.ts
+++ b/packages/cf-harness/src/tools/reserved-artifacts.ts
@@ -1,0 +1,18 @@
+import type { HarnessToolContext } from "./types.ts";
+
+export const RESERVED_ARTIFACT_PATH_DETAIL =
+  "cf-harness artifact paths are reserved from model-facing tools";
+
+export const isResolvedPathInsideArtifactRoot = async (
+  context: HarnessToolContext,
+  resolvedPath: string,
+): Promise<boolean> => {
+  try {
+    return await context.isHostPathWithinArtifactRoot(
+      context.resolveHostPath(resolvedPath),
+      { allowMissing: true },
+    );
+  } catch {
+    return false;
+  }
+};

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -21,6 +21,14 @@ export interface HarnessToolContext {
     path: string,
     options?: { allowMissing?: boolean },
   ): Promise<boolean>;
+  isHostPathWithinArtifactRoot(
+    path: string,
+    options?: { allowMissing?: boolean },
+  ): Promise<boolean>;
+  doesHostPathIntersectArtifactRoot(
+    path: string,
+    options?: { allowMissing?: boolean },
+  ): Promise<boolean>;
   setCurrentDir(path: string): void;
   nextOutputId(toolId: string): ToolOutputId;
   createCfcInvocationContext(options: {

--- a/packages/cf-harness/src/tools/write-file.ts
+++ b/packages/cf-harness/src/tools/write-file.ts
@@ -10,6 +10,10 @@ import {
   type StructuredFileToolErrorOutput,
   structuredFileToolErrorOutputSchema,
 } from "./file-errors.ts";
+import {
+  isResolvedPathInsideArtifactRoot,
+  RESERVED_ARTIFACT_PATH_DETAIL,
+} from "./reserved-artifacts.ts";
 
 export type WriteFileMode = "replace" | "append";
 
@@ -81,6 +85,13 @@ export const writeFileTool: HarnessToolDefinition<
         path: input.path,
         code: classifyPathResolutionError(error),
         detail: detailFromUnknownError(error),
+      });
+    }
+    if (await isResolvedPathInsideArtifactRoot(context, resolvedPath)) {
+      return createStructuredFileToolErrorOutput(context, "write_file", {
+        path: resolvedPath,
+        code: "permission_denied",
+        detail: RESERVED_ARTIFACT_PATH_DETAIL,
       });
     }
     const mode = input.mode ?? "replace";

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -8,6 +8,7 @@ import { createToolOutputId } from "../src/contracts/tool-result.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import type { HarnessRunState } from "../src/run-state.ts";
+import { RESERVED_ARTIFACT_PATH_DETAIL } from "../src/tools/reserved-artifacts.ts";
 import type {
   ProcessRunner,
   ProcessRunRequest,
@@ -183,6 +184,86 @@ Deno.test("CfHarnessEngine denies bash-no-sandbox missing paths below escaping s
     exitCode: 126,
     cwd: "/workspace",
   });
+});
+
+Deno.test("CfHarnessEngine reserves artifact roots through host realpath mapping", async () => {
+  const workspaceHostPath = await Deno.makeTempDir({
+    prefix: "cf-harness-engine-artifacts-",
+  });
+  try {
+    const artifactRoot = `${workspaceHostPath}/.cf-harness-artifacts`;
+    const artifactLink = `${workspaceHostPath}/artifact-link`;
+    await Deno.mkdir(artifactRoot, { recursive: true });
+    await Deno.symlink(artifactRoot, artifactLink, { type: "dir" });
+    const sandbox = new FakeSandboxRuntime();
+    const hostRunner = new FakeProcessRunner();
+    const engine = new CfHarnessEngine({
+      runId: "run-artifact-reserved",
+      workspaceHostPath,
+      artifactRoot,
+      sandboxRuntime: sandbox,
+      processRunner: hostRunner,
+      cfcEnforcementMode: "observe",
+      now: (() => {
+        const timestamps = [
+          "2026-05-01T17:55:00.000Z",
+          "2026-05-01T17:55:01.000Z",
+          "2026-05-01T17:55:02.000Z",
+          "2026-05-01T17:55:03.000Z",
+          "2026-05-01T17:55:04.000Z",
+          "2026-05-01T17:55:05.000Z",
+          "2026-05-01T17:55:06.000Z",
+        ];
+        return () => timestamps.shift() ?? "2026-05-01T17:55:07.000Z";
+      })(),
+    });
+
+    const readResult = await engine.invokeBuiltinTool("read_file", {
+      path: "artifact-link/run-state.json",
+    });
+    const lsResult = await engine.invokeBuiltinTool("bash-no-sandbox", {
+      command: "ls artifact-link",
+    });
+
+    assertEquals(readResult.output, {
+      outputId: createToolOutputId(
+        "run-artifact-reserved",
+        "read_file",
+        1,
+      ),
+      path: "/workspace/artifact-link/run-state.json",
+      ok: false,
+      error: {
+        type: "cf-harness.structured-file-tool-error",
+        code: "permission_denied",
+        message: "permission denied: /workspace/artifact-link/run-state.json",
+        path: "/workspace/artifact-link/run-state.json",
+        detail: RESERVED_ARTIFACT_PATH_DETAIL,
+      },
+    });
+    assertEquals(lsResult.output, {
+      outputId: createToolOutputId(
+        "run-artifact-reserved",
+        "bash-no-sandbox",
+        2,
+      ),
+      stdout: "",
+      stderr:
+        "bash-no-sandbox command denied: path artifact-link is reserved for cf-harness artifacts",
+      exitCode: 126,
+      cwd: "/workspace",
+    });
+    assertEquals(hostRunner.calls, []);
+    assertEquals(sandbox.shellRequests.length, 1);
+    assertEquals(
+      sandbox.shellRequests.every((request) =>
+        request.command.includes(CAPABILITY_PROBE_SENTINEL)
+      ),
+      true,
+    );
+  } finally {
+    await Deno.remove(workspaceHostPath, { recursive: true });
+  }
 });
 
 Deno.test("CfHarnessEngine records tool outputs into run state on success", async () => {

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -6,6 +6,7 @@ import { createToolOutputId } from "../src/contracts/tool-result.ts";
 import { bashTool } from "../src/tools/bash.ts";
 import { bashNoSandboxTool } from "../src/tools/bash-no-sandbox.ts";
 import { readFileTool } from "../src/tools/read-file.ts";
+import { RESERVED_ARTIFACT_PATH_DETAIL } from "../src/tools/reserved-artifacts.ts";
 import { writeFileTool } from "../src/tools/write-file.ts";
 import type { HarnessToolContext } from "../src/tools/types.ts";
 import type {
@@ -104,6 +105,7 @@ const createContext = (
   initialCurrentDir = "/workspace",
   hostProcessRunner: ProcessRunner = new FakeProcessRunner(),
   cfcEnforcementMode: HarnessToolContext["cfcEnforcementMode"] = "observe",
+  artifactRootHostPath?: string,
 ): HarnessToolContext => {
   let currentDir = initialCurrentDir;
   let sequence = 0;
@@ -130,6 +132,21 @@ const createContext = (
       return Promise.resolve(
         path === workspaceHostPath ||
           path.startsWith(`${workspaceHostPath}/`),
+      );
+    },
+    isHostPathWithinArtifactRoot(path: string) {
+      return Promise.resolve(
+        artifactRootHostPath !== undefined &&
+          (path === artifactRootHostPath ||
+            path.startsWith(`${artifactRootHostPath}/`)),
+      );
+    },
+    doesHostPathIntersectArtifactRoot(path: string) {
+      return Promise.resolve(
+        artifactRootHostPath !== undefined &&
+          (path === artifactRootHostPath ||
+            path.startsWith(`${artifactRootHostPath}/`) ||
+            artifactRootHostPath.startsWith(`${path}/`)),
       );
     },
     hostPathToWorkspacePath(path: string) {
@@ -468,6 +485,44 @@ Deno.test("bash-no-sandbox denies ls and find paths that realpath outside the wo
   });
 });
 
+Deno.test("bash-no-sandbox denies ls and find paths that intersect artifact roots", async () => {
+  const hostRunner = new FakeProcessRunner();
+  const artifactRootHostPath =
+    "/tmp/cf-harness-workspace/.cf-harness-artifacts";
+  const context = createContext(
+    new FakeSandboxRuntime(),
+    "/workspace",
+    hostRunner,
+    "observe",
+    artifactRootHostPath,
+  );
+
+  const lsOutput = await bashNoSandboxTool.invoke(context, {
+    command: "ls .cf-harness-artifacts",
+  });
+  const findOutput = await bashNoSandboxTool.invoke(context, {
+    command: "find . -maxdepth 2 -type f -print",
+  });
+
+  assertEquals(hostRunner.calls, []);
+  assertEquals(lsOutput, {
+    outputId: "run-1:bash-no-sandbox:1",
+    stdout: "",
+    stderr:
+      "bash-no-sandbox command denied: path .cf-harness-artifacts is reserved for cf-harness artifacts",
+    exitCode: 126,
+    cwd: "/workspace",
+  });
+  assertEquals(findOutput, {
+    outputId: "run-1:bash-no-sandbox:2",
+    stdout: "",
+    stderr:
+      "bash-no-sandbox command denied: path . is reserved for cf-harness artifacts",
+    exitCode: 126,
+    cwd: "/workspace",
+  });
+});
+
 Deno.test("bash-no-sandbox denies host commands outside the browser policy", async () => {
   const hostRunner = new FakeProcessRunner();
   const context = createContext(
@@ -632,6 +687,51 @@ Deno.test("read_file tool returns a recoverable path_outside_workspace result", 
       message: "path outside workspace: ../outside.txt",
       path: "../outside.txt",
       detail: "path escapes workspace root: /outside.txt",
+    },
+  });
+  assertEquals(sandbox.calls, []);
+});
+
+Deno.test("read_file tool denies reserved artifact paths before shelling out", async () => {
+  const sandbox = new FakeSandboxRuntime();
+  const context = createContext(
+    sandbox,
+    "/workspace",
+    new FakeProcessRunner(),
+    "observe",
+    "/tmp/cf-harness-workspace/.cf-harness-artifacts",
+  );
+
+  const rootOutput = await readFileTool.invoke(context, {
+    path: ".cf-harness-artifacts",
+  });
+  const childOutput = await readFileTool.invoke(context, {
+    path: ".cf-harness-artifacts/run-1/transcript.json",
+  });
+
+  assertEquals(rootOutput, {
+    outputId: "run-1:read_file:1",
+    path: "/workspace/.cf-harness-artifacts",
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "permission_denied",
+      message: "permission denied: /workspace/.cf-harness-artifacts",
+      path: "/workspace/.cf-harness-artifacts",
+      detail: RESERVED_ARTIFACT_PATH_DETAIL,
+    },
+  });
+  assertEquals(childOutput, {
+    outputId: "run-1:read_file:2",
+    path: "/workspace/.cf-harness-artifacts/run-1/transcript.json",
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "permission_denied",
+      message:
+        "permission denied: /workspace/.cf-harness-artifacts/run-1/transcript.json",
+      path: "/workspace/.cf-harness-artifacts/run-1/transcript.json",
+      detail: RESERVED_ARTIFACT_PATH_DETAIL,
     },
   });
   assertEquals(sandbox.calls, []);
@@ -807,6 +907,39 @@ Deno.test("write_file tool returns a recoverable path_outside_workspace result",
       message: "path outside workspace: ../outside.txt",
       path: "../outside.txt",
       detail: "path escapes workspace root: /outside.txt",
+    },
+  });
+  assertEquals(sandbox.calls, []);
+});
+
+Deno.test("write_file tool denies reserved artifact paths before shelling out", async () => {
+  const sandbox = new FakeSandboxRuntime();
+  const output = await writeFileTool.invoke(
+    createContext(
+      sandbox,
+      "/workspace",
+      new FakeProcessRunner(),
+      "observe",
+      "/tmp/cf-harness-workspace/.cf-harness-artifacts",
+    ),
+    {
+      path: ".cf-harness-artifacts/run-1/tool-output.json",
+      content: "tainted",
+      createParents: true,
+    },
+  );
+
+  assertEquals(output, {
+    outputId: "run-1:write_file:1",
+    path: "/workspace/.cf-harness-artifacts/run-1/tool-output.json",
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "permission_denied",
+      message:
+        "permission denied: /workspace/.cf-harness-artifacts/run-1/tool-output.json",
+      path: "/workspace/.cf-harness-artifacts/run-1/tool-output.json",
+      detail: RESERVED_ARTIFACT_PATH_DETAIL,
     },
   });
   assertEquals(sandbox.calls, []);


### PR DESCRIPTION
## Summary

- reserve configured cf-harness artifact roots from `read_file` and `write_file`
- block browser-profile `bash-no-sandbox` `ls`/`find` paths that hit or traverse artifact roots, including symlink/realpath cases
- document the guardrail while leaving opaque artifact handles and explicit declassification/readback as future work

## Tests

- `deno fmt packages/cf-harness/src/engine.ts packages/cf-harness/src/tools/types.ts packages/cf-harness/src/tools/reserved-artifacts.ts packages/cf-harness/src/tools/read-file.ts packages/cf-harness/src/tools/write-file.ts packages/cf-harness/src/tools/bash-no-sandbox.ts packages/cf-harness/test/tools-execution.test.ts packages/cf-harness/test/engine.test.ts packages/cf-harness/README.md packages/cf-harness/docs/IMPLEMENTATION_PLAN.md`
- `deno test --allow-read --allow-write --allow-run packages/cf-harness/test/tools-execution.test.ts packages/cf-harness/test/engine.test.ts`
- `deno check packages/cf-harness/mod.ts packages/runner/src/cfc/mod.ts`
- `deno lint packages/cf-harness/src/engine.ts packages/cf-harness/src/tools/types.ts packages/cf-harness/src/tools/reserved-artifacts.ts packages/cf-harness/src/tools/read-file.ts packages/cf-harness/src/tools/write-file.ts packages/cf-harness/src/tools/bash-no-sandbox.ts packages/cf-harness/test/tools-execution.test.ts packages/cf-harness/test/engine.test.ts`
- `git diff --check`
- `deno task test` in `packages/cf-harness`
- `deno task check` in `packages/cf-harness`
