### PR TITLE
[codex] Accept CFC writeback compat xattrs

### DIFF
--- a/docs/specs/fuse-filesystem/9-cfc-annotations.md
+++ b/docs/specs/fuse-filesystem/9-cfc-annotations.md
@@ -44,6 +44,11 @@ symlinks, truncates, and metadata mutations while recording diagnostics.
 Enforce-* modes require the prepare/finalize flow before those operations
 proceed. The existing non-CFC behavior is unchanged.
 
+The temporary writeback xattr bridge accepts the trusted prepare/finalize names
+and the equivalent `user.commonfabric.cfc.*` compatibility spellings when a host
+transport cannot carry `trusted.*` xattrs. gVisor remains responsible for
+exposing only the trusted logical namespace to the sandbox.
+
 Derived slot metadata is emitted as an explicit empty `no-trusted-derived-slots`
 structure. Digest-looking names therefore remain ordinary names unless a future
 trusted-derived identifier source supplies evidence.

--- a/packages/fuse/README.md
+++ b/packages/fuse/README.md
@@ -270,15 +270,17 @@ metadata-only `setattr` attempts such as chmod/chown/timestamp updates. In
 trusted prepare metadata. In `enforce-strict`, projected writes fail closed when
 annotations or prepare metadata are missing, malformed, or stale. Direct
 pre-gVisor testing can enable the temporary xattr prepare/finalize path with
-`--cfc-writeback-xattrs`; this accepts only `trusted.cfc.writeback.prepare` and
-`trusted.cfc.writeback.finalize` and is not a sandbox trust boundary.
-Prepared/fail-closed writeback records are persisted outside the mount so a
-daemon restart or subtree rebuild can reconcile them without exposing lower
-labels. Use `--cfc-writeback-state=<path>` to choose the recovery file;
-otherwise CFC modes use a mountpoint-derived file under
-`$CF_CFC_WRITEBACK_STATE_DIR`, `$XDG_STATE_HOME/commonfabric-fuse`, or
-`~/.cache/commonfabric-fuse`, in that order. The mount `.status` file includes a
-`cfc` section with writeback phase counts and recent diagnostics.
+`--cfc-writeback-xattrs`; this accepts `trusted.cfc.writeback.prepare` and
+`trusted.cfc.writeback.finalize`, plus their `user.commonfabric.cfc.*`
+compatibility spellings for host transports that cannot carry `trusted.*`
+xattrs. It is not a sandbox trust boundary. Prepared/fail-closed writeback
+records are persisted outside the mount so a daemon restart or subtree rebuild
+can reconcile them without exposing lower labels. Use
+`--cfc-writeback-state=<path>` to choose the recovery file; otherwise CFC modes
+use a mountpoint-derived file under `$CF_CFC_WRITEBACK_STATE_DIR`,
+`$XDG_STATE_HOME/commonfabric-fuse`, or `~/.cache/commonfabric-fuse`, in that
+order. The mount `.status` file includes a `cfc` section with writeback phase
+counts and recent diagnostics.
 
 Arbitrary symlink targets and callable-send writeback are still out of scope for
 CFC enforcing modes and are rejected there. gVisor remains responsible for

--- a/packages/fuse/cfc-writeback.test.ts
+++ b/packages/fuse/cfc-writeback.test.ts
@@ -14,10 +14,13 @@ import {
   authorizeMetadataWriteback,
   authorizeNamespaceMutationWriteback,
   authorizeSymlinkWriteback,
+  CFC_COMPAT_WRITEBACK_FINALIZE_XATTR,
+  CFC_COMPAT_WRITEBACK_PREPARE_XATTR,
   CFC_WRITEBACK_FINALIZE_XATTR,
   CFC_WRITEBACK_PREPARE_XATTR,
   CfcWritebackStore,
   metadataFieldsForSetattrFlags,
+  normalizeCfcWritebackXattrName,
   parseCfcMode,
   resolveCfcMode,
   shouldEnableCfcAnnotations,
@@ -1148,18 +1151,29 @@ Deno.test("same-parent rename can use one prepare record covering both names", (
   );
 });
 
-Deno.test("writeback xattrs accept trusted prepare/finalize names only", () => {
+Deno.test("writeback xattrs accept trusted names and compat transport names", () => {
+  assertEquals(
+    normalizeCfcWritebackXattrName(CFC_COMPAT_WRITEBACK_PREPARE_XATTR),
+    CFC_WRITEBACK_PREPARE_XATTR,
+  );
+  assertEquals(
+    normalizeCfcWritebackXattrName(CFC_COMPAT_WRITEBACK_FINALIZE_XATTR),
+    CFC_WRITEBACK_FINALIZE_XATTR,
+  );
+  assertEquals(normalizeCfcWritebackXattrName("user.example"), null);
+
   const { fileIno, ref } = makeAnnotatedTree();
   const store = new CfcWritebackStore();
 
   assertEquals(
     store.setPreparedXattr(
       fileIno,
-      "user.commonfabric.cfc.writeback.prepare",
+      CFC_COMPAT_WRITEBACK_PREPARE_XATTR,
       prepareJson("write", ref),
     ).ok,
-    false,
+    true,
   );
+  assertExists(store.getPrepared(fileIno, "write"));
   assertEquals(
     store.setPreparedXattr(fileIno, CFC_WRITEBACK_PREPARE_XATTR, "{").ok,
     false,
@@ -1176,7 +1190,7 @@ Deno.test("writeback xattrs accept trusted prepare/finalize names only", () => {
   assertEquals(
     store.setFinalizeXattr(
       fileIno,
-      CFC_WRITEBACK_FINALIZE_XATTR,
+      CFC_COMPAT_WRITEBACK_FINALIZE_XATTR,
       JSON.stringify({
         version: 1,
         operation: "write",

--- a/packages/fuse/cfc-writeback.ts
+++ b/packages/fuse/cfc-writeback.ts
@@ -67,6 +67,26 @@ export type CfcMetadataLabelKey = keyof CfcMetadataLabels;
 
 export const CFC_WRITEBACK_PREPARE_XATTR = "trusted.cfc.writeback.prepare";
 export const CFC_WRITEBACK_FINALIZE_XATTR = "trusted.cfc.writeback.finalize";
+export const CFC_COMPAT_WRITEBACK_PREPARE_XATTR =
+  "user.commonfabric.cfc.writeback.prepare";
+export const CFC_COMPAT_WRITEBACK_FINALIZE_XATTR =
+  "user.commonfabric.cfc.writeback.finalize";
+
+export function normalizeCfcWritebackXattrName(name: string): string | null {
+  if (
+    name === CFC_WRITEBACK_PREPARE_XATTR ||
+    name === CFC_COMPAT_WRITEBACK_PREPARE_XATTR
+  ) {
+    return CFC_WRITEBACK_PREPARE_XATTR;
+  }
+  if (
+    name === CFC_WRITEBACK_FINALIZE_XATTR ||
+    name === CFC_COMPAT_WRITEBACK_FINALIZE_XATTR
+  ) {
+    return CFC_WRITEBACK_FINALIZE_XATTR;
+  }
+  return null;
+}
 
 export type CfcPreparedWritebackLabels = {
   contentLabel?: CfcLabel;
@@ -854,7 +874,7 @@ export class CfcWritebackStore {
     ok: false;
     reason: string;
   } {
-    if (name !== CFC_WRITEBACK_PREPARE_XATTR) {
+    if (normalizeCfcWritebackXattrName(name) !== CFC_WRITEBACK_PREPARE_XATTR) {
       this.recordMalformed(ino, name, "unsupported writeback xattr");
       return { ok: false, reason: "unsupported writeback xattr" };
     }
@@ -893,7 +913,9 @@ export class CfcWritebackStore {
     ok: false;
     reason: string;
   } {
-    if (name !== CFC_WRITEBACK_FINALIZE_XATTR) {
+    if (
+      normalizeCfcWritebackXattrName(name) !== CFC_WRITEBACK_FINALIZE_XATTR
+    ) {
       return { ok: false, reason: "unsupported writeback xattr" };
     }
     const parsed = parseFinalizedWriteback(value);

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -40,6 +40,7 @@ import {
   CfcWritebackStore,
   isCfcEnforcing,
   metadataFieldsForSetattrFlags,
+  normalizeCfcWritebackXattrName,
   parseCfcMode,
   resolveCfcMode,
   shouldEnableCfcAnnotations,
@@ -413,7 +414,8 @@ export async function main(argv: string[] = Deno.args) {
       // When the backend transport is dead, report all files as read-only
       // so writes fail with EACCES instead of silently succeeding.
       isWritable: !bridge?.disconnected && Boolean(
-        bridge?.resolveWritePath(ino) || bridge?.resolveSourceWritePath(ino),
+        cfcWritebackXattrs ||
+          bridge?.resolveWritePath(ino) || bridge?.resolveSourceWritePath(ino),
       ),
       ownership: mountOwnership,
     });
@@ -2050,13 +2052,14 @@ export async function main(argv: string[] = Deno.args) {
         return;
       }
       const name = readCString(namePtr);
+      const normalizedName = normalizeCfcWritebackXattrName(name);
       const value = new TextDecoder().decode(readBuffer(valuePtr, size));
       let result:
         | ReturnType<CfcWritebackStore["setPreparedXattr"]>
         | ReturnType<CfcWritebackStore["setFinalizeXattr"]>;
-      if (name === CFC_WRITEBACK_PREPARE_XATTR) {
+      if (normalizedName === CFC_WRITEBACK_PREPARE_XATTR) {
         result = cfcWritebacks.setPreparedXattr(ino, name, value);
-      } else if (name === CFC_WRITEBACK_FINALIZE_XATTR) {
+      } else if (normalizedName === CFC_WRITEBACK_FINALIZE_XATTR) {
         result = cfcWritebacks.setFinalizeXattr(ino, name, value);
       } else {
         fuse.symbols.fuse_reply_err(req, EACCES);
@@ -2087,9 +2090,10 @@ export async function main(argv: string[] = Deno.args) {
         return;
       }
       const name = readCString(namePtr);
+      const normalizedName = normalizeCfcWritebackXattrName(name);
       if (
-        name !== CFC_WRITEBACK_PREPARE_XATTR &&
-        name !== CFC_WRITEBACK_FINALIZE_XATTR
+        normalizedName !== CFC_WRITEBACK_PREPARE_XATTR &&
+        normalizedName !== CFC_WRITEBACK_FINALIZE_XATTR
       ) {
         fuse.symbols.fuse_reply_err(req, EACCES);
         return;
@@ -2946,7 +2950,10 @@ export async function main(argv: string[] = Deno.args) {
   // --- Mount ---
   const fuseArgs = ["fuse_ct"];
   if (Deno.build.os === "linux" && args["allow-other"]) {
-    fuseArgs.push("-o", "allow_other", "-o", "default_permissions");
+    fuseArgs.push("-o", "allow_other");
+    if (!cfcWritebackXattrs) {
+      fuseArgs.push("-o", "default_permissions");
+    }
   }
   const { argsBuf, argv: _argv, encodedArgs: _ea } = platform.createFuseArgs(
     fuseArgs,


### PR DESCRIPTION
## Summary

This adds the Labs FUSE side of the gVisor CFC writeback transport:

- accepts `user.commonfabric.cfc.writeback.prepare` and `user.commonfabric.cfc.writeback.finalize` as host transport aliases for the trusted CFC writeback xattrs
- normalizes trusted and compatibility xattr names before dispatching prepare/finalize handling
- keeps FUSE permission handling compatible with writeback xattr operation
- documents the compatibility namespace used when `trusted.*` cannot be carried by the host/FUSE layer
- adds a targeted regression test for both trusted and compatibility writeback xattr names

## Root Cause

The sandbox-facing API uses `trusted.cfc.writeback.*`, but host FUSE transport may need to carry those requests as `user.commonfabric.cfc.writeback.*`. Without accepting the compatibility spelling, Labs FUSE could publish content labels but could not complete the explicit writeback prepare/finalize protocol through gVisor.

## Namespace Model

`trusted.cfc.*` is the sandbox-facing CFC control namespace. gVisor treats these xattrs as runtime/security metadata: content labels can taint tasks, direct unprivileged writes to content labels are blocked, and the writeback protocol is handled through specific CFC rules.

`user.commonfabric.cfc.*` is only the host/FUSE transport spelling. Linux and FUSE often cannot carry `trusted.*` xattrs through an unprivileged userspace daemon, so Labs FUSE exposes the same CFC metadata under a `user.*` compatibility namespace for the host side.

Keeping the sandbox API on `trusted.cfc.*` matters because `user.*` xattrs are ordinary application metadata. A tainted task that can freely set `user.*` xattrs could encode secrets into metadata on a public file, so gVisor treats `user.*` writes as a storage channel. The compatibility `user.commonfabric.cfc.*` names should therefore stay below the gofer/FUSE boundary as transport details, not become the guest API.

## Validation

Fresh worktree checks:

- `git diff --cached --check`
- `deno fmt --check packages/fuse/cfc-writeback.ts packages/fuse/mod.ts packages/fuse/cfc-writeback.test.ts packages/fuse/README.md docs/specs/fuse-filesystem/9-cfc-annotations.md`
- `deno test --allow-env --allow-read --allow-write packages/fuse/cfc-writeback.test.ts packages/fuse/mod.test.ts`

Earlier end-to-end validation with the paired gVisor patch:

- `LABS_DIR=/tmp/labs-pr-3445 TOOLSHED_URL=http://localhost:8000 bash demo/docker-runsc-cfc-labs-fuse-validate.sh`

The end-to-end harness proved content-label publication, sandbox xattr label reads and tainting, and writeback prepare/finalize cleanup.