### PR TITLE
Record cf-harness gateway attempts

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -45,8 +45,12 @@ What works today:
 - optional schema-validated subagent structured returns, with raw child return
   artifacts retained in the child run and open-ended strings linkified before
   the parent sees them
-- persisted run state, transcript, Loom run manifests, capability snapshots, and
-  tool outputs, plus explicit skill registry and activation artifacts
+- persisted run state, transcript, run reports, Loom run manifests, capability
+  snapshots, and tool outputs, plus explicit skill registry and activation
+  artifacts
+- run-report gateway attempt diagnostics with chat-completion request size,
+  timing, HTTP status, selected response headers/request IDs, and non-OK
+  response body excerpts
 - transcript-based resumability
 - package-local operator CLI
 - explicit Agent Skills preload via `--skills-root` and repeatable `--skill`
@@ -92,8 +96,8 @@ What is not done yet:
 - [src/cli.ts](src/cli.ts)
   - package-local operator CLI
 - [src/artifacts.ts](src/artifacts.ts)
-  - persisted run state, run manifest, transcript, capability snapshot, and tool
-    output storage
+  - persisted run state, run manifest, transcript, run report, capability
+    snapshot, and tool output storage
 - [src/skills/](src/skills/)
   - Agent Skills registry scanning, validation, and explicit preload context
 - [src/contracts/](src/contracts/)

--- a/packages/cf-harness/src/contracts/run-report.ts
+++ b/packages/cf-harness/src/contracts/run-report.ts
@@ -13,6 +13,7 @@ import type { HarnessSubagentRunRef } from "./subagent.ts";
 import type { HarnessToolEffectClass } from "./tool-descriptor.ts";
 import type { HarnessTranscriptMessage } from "./transcript.ts";
 import type { ToolResultRef } from "./tool-result.ts";
+import type { OpenAIChatCompletionAttemptDiagnostic } from "../gateway/openai-client.ts";
 
 export type HarnessToolPolicyDecision = "allowed" | "warned" | "denied";
 export type HarnessToolExecutionStatus = "completed" | "failed" | "not-run";
@@ -42,6 +43,13 @@ export interface HarnessToolActivity {
   policyEventIndexes?: number[];
   resultRef?: ToolResultRef;
   errorDetail?: string;
+}
+
+export interface HarnessGatewayAttempt
+  extends OpenAIChatCompletionAttemptDiagnostic {
+  runId: string;
+  sequence: number;
+  modelTurn: number;
 }
 
 export interface HarnessRunTimelineEntry {
@@ -106,6 +114,7 @@ export interface HarnessRunReport {
   policyDecisions: HarnessPolicyDecisionRecord[];
   timeline: HarnessRunTimelineEntry[];
   toolActivity: HarnessToolActivity[];
+  gatewayAttempts?: HarnessGatewayAttempt[];
   toolOutputs: ToolResultRef[];
   subagentRuns?: HarnessSubagentRunRef[];
 }
@@ -137,6 +146,7 @@ export interface CreateHarnessRunReportOptions {
   finalAssistantText?: string;
   timeline?: readonly HarnessRunTimelineEntryInput[];
   toolActivity: readonly HarnessToolActivity[];
+  gatewayAttempts?: readonly HarnessGatewayAttempt[];
 }
 
 export const createHarnessRunTimeline = (
@@ -307,6 +317,9 @@ export const createHarnessRunReport = (
       toolActivity: options.toolActivity,
     }),
     toolActivity: [...options.toolActivity],
+    ...((options.gatewayAttempts?.length ?? 0) > 0
+      ? { gatewayAttempts: [...(options.gatewayAttempts ?? [])] }
+      : {}),
     toolOutputs: [...options.runState.toolOutputs],
     ...(options.runState.subagentRuns !== undefined &&
         options.runState.subagentRuns.length > 0

--- a/packages/cf-harness/src/gateway/openai-client.ts
+++ b/packages/cf-harness/src/gateway/openai-client.ts
@@ -56,6 +56,44 @@ export interface OpenAIChatCompletionRequest {
   tool_choice?: "auto" | "none" | Record<string, unknown>;
 }
 
+export interface OpenAIChatCompletionRequestDiagnosticSummary {
+  model: string;
+  messageCount: number;
+  toolCount: number;
+  serializedBytes: number;
+}
+
+export type OpenAIChatCompletionAttemptOutcome =
+  | "http_response"
+  | "transport_error";
+
+export interface OpenAIChatCompletionAttemptDiagnostic {
+  type: "cf-harness.gateway.chat-completion-attempt";
+  operation: "chat.completions";
+  endpoint: string;
+  attempt: number;
+  maxTransportAttempts: number;
+  startedAt: string;
+  endedAt: string;
+  durationMs: number;
+  request: OpenAIChatCompletionRequestDiagnosticSummary;
+  outcome: OpenAIChatCompletionAttemptOutcome;
+  httpStatus?: number;
+  httpStatusText?: string;
+  requestId?: string;
+  responseHeaders?: Record<string, string>;
+  responseBodyBytes?: number;
+  responseBodyExcerpt?: string;
+  responseBodyTruncated?: boolean;
+  errorDetail?: string;
+}
+
+export interface OpenAIChatCompletionAttemptOptions {
+  onChatCompletionAttempt?: (
+    diagnostic: OpenAIChatCompletionAttemptDiagnostic,
+  ) => void | Promise<void>;
+}
+
 export interface OpenAIChatCompletionChoice {
   index: number;
   message: OpenAIChatCompletionMessage;
@@ -69,6 +107,22 @@ export interface OpenAIChatCompletionResponse {
 
 const DEFAULT_CHAT_COMPLETION_TRANSPORT_RETRIES = 1;
 const DEFAULT_CHAT_COMPLETION_RETRY_DELAY_MS = 1_000;
+const MAX_ERROR_BODY_EXCERPT_CHARS = 2_048;
+const SELECTED_RESPONSE_HEADERS = [
+  "x-request-id",
+  "x-openai-request-id",
+  "x-cf-request-id",
+  "cf-ray",
+  "retry-after",
+  "content-type",
+  "date",
+] as const;
+const REQUEST_ID_HEADER_NAMES = [
+  "x-request-id",
+  "x-openai-request-id",
+  "x-cf-request-id",
+  "cf-ray",
+] as const;
 
 const nonNegativeIntegerOrDefault = (
   input: number | undefined,
@@ -86,6 +140,59 @@ const sleep = (ms: number): Promise<void> =>
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
+const textByteLength = (input: string): number =>
+  new TextEncoder().encode(input).byteLength;
+
+const summarizeChatCompletionRequest = (
+  payload: OpenAIChatCompletionRequest,
+  serializedPayload: string,
+): OpenAIChatCompletionRequestDiagnosticSummary => ({
+  model: payload.model,
+  messageCount: payload.messages.length,
+  toolCount: payload.tools?.length ?? 0,
+  serializedBytes: textByteLength(serializedPayload),
+});
+
+const selectResponseHeaders = (
+  headers: Headers,
+): Record<string, string> | undefined => {
+  const selected: Record<string, string> = {};
+  for (const header of SELECTED_RESPONSE_HEADERS) {
+    const value = headers.get(header);
+    if (value !== null) {
+      selected[header] = value;
+    }
+  }
+  return Object.keys(selected).length > 0 ? selected : undefined;
+};
+
+const selectRequestId = (headers: Headers): string | undefined => {
+  for (const header of REQUEST_ID_HEADER_NAMES) {
+    const value = headers.get(header);
+    if (value !== null && value.trim() !== "") {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const responseBodyDiagnosticFields = (body: string) => ({
+  responseBodyBytes: textByteLength(body),
+  responseBodyExcerpt: body.slice(0, MAX_ERROR_BODY_EXCERPT_CHARS),
+  responseBodyTruncated: body.length > MAX_ERROR_BODY_EXCERPT_CHARS,
+});
+
+const emitChatCompletionAttempt = async (
+  options: OpenAIChatCompletionAttemptOptions | undefined,
+  diagnostic: OpenAIChatCompletionAttemptDiagnostic,
+): Promise<void> => {
+  try {
+    await options?.onChatCompletionAttempt?.(diagnostic);
+  } catch {
+    // Diagnostics must not change gateway request behavior.
+  }
+};
+
 const transportErrorAfterRetries = (
   endpoint: URL,
   attempts: number,
@@ -96,6 +203,11 @@ const transportErrorAfterRetries = (
       attempts === 1 ? "attempt" : "attempts"
     } for ${endpoint.toString()}: ${errorMessage(error)}`,
   );
+
+interface ChatCompletionFetchResult {
+  response: Response;
+  diagnostic: OpenAIChatCompletionAttemptDiagnostic;
+}
 
 export class OpenAICompatibleGatewayClient {
   readonly baseUrl: URL;
@@ -163,35 +275,99 @@ export class OpenAICompatibleGatewayClient {
 
   async createChatCompletion(
     payload: OpenAIChatCompletionRequest,
+    options: OpenAIChatCompletionAttemptOptions = {},
   ): Promise<Response> {
+    const { response, diagnostic } = await this.#fetchChatCompletion(
+      payload,
+      options,
+    );
+    await emitChatCompletionAttempt(options, diagnostic);
+    return response;
+  }
+
+  async #fetchChatCompletion(
+    payload: OpenAIChatCompletionRequest,
+    options: OpenAIChatCompletionAttemptOptions,
+  ): Promise<ChatCompletionFetchResult> {
     const endpoint = this.endpoint("/v1/chat/completions");
+    const serializedPayload = JSON.stringify(payload);
+    const request = summarizeChatCompletionRequest(payload, serializedPayload);
     const init: RequestInit = {
       method: "POST",
       headers: this.headers(),
-      body: JSON.stringify(payload),
+      body: serializedPayload,
     };
-    const maxAttempts = this.#chatCompletionTransportRetries + 1;
+    const maxTransportAttempts = this.#chatCompletionTransportRetries + 1;
     let lastError: unknown;
-    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    for (let attempt = 1; attempt <= maxTransportAttempts; attempt += 1) {
+      const startedAt = new Date();
+      const startedAtMs = performance.now();
       try {
-        return await this.#fetchFn(endpoint, init);
+        const response = await this.#fetchFn(endpoint, init);
+        const endedAt = new Date();
+        const responseHeaders = selectResponseHeaders(response.headers);
+        const requestId = selectRequestId(response.headers);
+        return {
+          response,
+          diagnostic: {
+            type: "cf-harness.gateway.chat-completion-attempt",
+            operation: "chat.completions",
+            endpoint: endpoint.toString(),
+            attempt,
+            maxTransportAttempts,
+            startedAt: startedAt.toISOString(),
+            endedAt: endedAt.toISOString(),
+            durationMs: Math.max(
+              0,
+              Math.round(performance.now() - startedAtMs),
+            ),
+            request,
+            outcome: "http_response",
+            httpStatus: response.status,
+            httpStatusText: response.statusText,
+            ...(requestId !== undefined ? { requestId } : {}),
+            ...(responseHeaders !== undefined ? { responseHeaders } : {}),
+          },
+        };
       } catch (error) {
         lastError = error;
-        if (attempt >= maxAttempts) {
+        const endedAt = new Date();
+        await emitChatCompletionAttempt(options, {
+          type: "cf-harness.gateway.chat-completion-attempt",
+          operation: "chat.completions",
+          endpoint: endpoint.toString(),
+          attempt,
+          maxTransportAttempts,
+          startedAt: startedAt.toISOString(),
+          endedAt: endedAt.toISOString(),
+          durationMs: Math.max(0, Math.round(performance.now() - startedAtMs)),
+          request,
+          outcome: "transport_error",
+          errorDetail: errorMessage(error),
+        });
+        if (attempt >= maxTransportAttempts) {
           throw transportErrorAfterRetries(endpoint, attempt, error);
         }
         await sleep(this.#chatCompletionRetryDelayMs * attempt);
       }
     }
-    throw transportErrorAfterRetries(endpoint, maxAttempts, lastError);
+    throw transportErrorAfterRetries(endpoint, maxTransportAttempts, lastError);
   }
 
   async createChatCompletionJson(
     payload: OpenAIChatCompletionRequest,
+    options: OpenAIChatCompletionAttemptOptions = {},
   ): Promise<OpenAIChatCompletionResponse> {
-    const response = await this.createChatCompletion(payload);
+    const { response, diagnostic } = await this.#fetchChatCompletion(
+      payload,
+      options,
+    );
     if (!response.ok) {
       const body = await response.text();
+      await emitChatCompletionAttempt(options, {
+        ...diagnostic,
+        ...responseBodyDiagnosticFields(body),
+      });
       if (response.status === 401) {
         const sourceText = this.authMode === "none"
           ? "unauthenticated caller mode was used; gateway or upstream credentials rejected the request"
@@ -206,6 +382,7 @@ export class OpenAICompatibleGatewayClient {
         `chat completion request failed (${response.status}): ${body}`,
       );
     }
+    await emitChatCompletionAttempt(options, diagnostic);
     return await response.json() as OpenAIChatCompletionResponse;
   }
 }

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -11,6 +11,7 @@ import {
   evaluateHarnessWriteFileAuthorization,
 } from "@commonfabric/runner/cfc";
 import {
+  type OpenAIChatCompletionAttemptDiagnostic,
   type OpenAIChatCompletionMessage,
   type OpenAIChatCompletionRequest,
   type OpenAIChatCompletionResponse,
@@ -48,6 +49,7 @@ import {
 } from "./contracts/policy-trace.ts";
 import {
   createHarnessRunReport,
+  type HarnessGatewayAttempt,
   type HarnessRunTimelineEntryInput,
   type HarnessToolActivity,
   type HarnessToolPolicyDecision,
@@ -1245,6 +1247,7 @@ export class CfHarnessPromptLoop {
     const transcript: HarnessTranscriptMessage[] = [...options.transcript];
     const maxModelTurns = options.maxModelTurns ?? this.#maxModelTurns;
     const toolActivity: HarnessToolActivity[] = [];
+    const gatewayAttempts: HarnessGatewayAttempt[] = [];
     const reportTimeline: HarnessRunTimelineEntryInput[] = [];
     let modelTurns = 0;
     const buildPolicyTrace = async () => {
@@ -1280,8 +1283,19 @@ export class CfHarnessPromptLoop {
           ...(finalAssistantText !== undefined ? { finalAssistantText } : {}),
           timeline: reportTimeline,
           toolActivity,
+          gatewayAttempts,
         }),
       );
+    };
+    const recordGatewayAttempt = (
+      attempt: OpenAIChatCompletionAttemptDiagnostic,
+    ): void => {
+      gatewayAttempts.push({
+        ...attempt,
+        runId: this.engine.getRunState().runId,
+        sequence: gatewayAttempts.length + 1,
+        modelTurn: modelTurns,
+      });
     };
     await this.engine.ensureDiagnosticsInitialized();
     this.engine.setRunStatus("running");
@@ -1310,6 +1324,7 @@ export class CfHarnessPromptLoop {
         modelTurns += 1;
         const response = await this.gatewayClient.createChatCompletionJson(
           this.#buildChatCompletionRequest(model, transcript),
+          { onChatCompletionAttempt: recordGatewayAttempt },
         );
         const assistantMessage = createAssistantTranscriptMessage(response);
         transcript.push(assistantMessage);

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { join } from "@std/path";
 import { normalize } from "@std/path/posix";
 import {
@@ -537,6 +537,51 @@ Deno.test({
         },
         resultRef: result.runState.toolOutputs[0],
       });
+      assertEquals(persistedReport.gatewayAttempts?.length, 2);
+      assertEquals(
+        persistedReport.gatewayAttempts?.map((attempt) => attempt.sequence),
+        [1, 2],
+      );
+      assertEquals(
+        persistedReport.gatewayAttempts?.map((attempt) => attempt.modelTurn),
+        [1, 2],
+      );
+      assertEquals(
+        persistedReport.gatewayAttempts?.map((attempt) => attempt.runId),
+        ["run-loop-persisted", "run-loop-persisted"],
+      );
+      assertEquals(
+        persistedReport.gatewayAttempts?.[0].outcome,
+        "http_response",
+      );
+      assertEquals(persistedReport.gatewayAttempts?.[0].httpStatus, 200);
+      assertEquals(
+        {
+          model: persistedReport.gatewayAttempts?.[0].request.model,
+          messageCount: persistedReport.gatewayAttempts?.[0].request
+            .messageCount,
+          toolCount: persistedReport.gatewayAttempts?.[0].request.toolCount,
+        },
+        {
+          model: "gpt-5.4",
+          messageCount: 1,
+          toolCount: 5,
+        },
+      );
+      assert(
+        (persistedReport.gatewayAttempts?.[0].request.serializedBytes ?? 0) >
+          0,
+      );
+      assertEquals(
+        persistedReport.gatewayAttempts?.[1].request.messageCount,
+        3,
+      );
+      assertEquals(
+        JSON.stringify(persistedReport.gatewayAttempts).includes(
+          "Summarize the todo file.",
+        ),
+        false,
+      );
       assertEquals(
         persistedReport.timeline.map((entry) => entry.kind),
         [

--- a/packages/cf-harness/test/openai-client.test.ts
+++ b/packages/cf-harness/test/openai-client.test.ts
@@ -1,5 +1,8 @@
-import { assertEquals, assertRejects } from "@std/assert";
-import { OpenAICompatibleGatewayClient } from "../src/gateway/openai-client.ts";
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import {
+  type OpenAIChatCompletionAttemptDiagnostic,
+  OpenAICompatibleGatewayClient,
+} from "../src/gateway/openai-client.ts";
 
 Deno.test("OpenAICompatibleGatewayClient resolves endpoint URLs against the base URL", () => {
   const client = new OpenAICompatibleGatewayClient({
@@ -96,6 +99,7 @@ Deno.test("OpenAICompatibleGatewayClient parses successful chat completion JSON 
 
 Deno.test("OpenAICompatibleGatewayClient retries chat completion transport failures once by default", async () => {
   let calls = 0;
+  const attempts: OpenAIChatCompletionAttemptDiagnostic[] = [];
   const client = new OpenAICompatibleGatewayClient({
     baseUrl: "https://llm.stage.commontools.dev/",
     apiKey: "test-key",
@@ -122,10 +126,21 @@ Deno.test("OpenAICompatibleGatewayClient retries chat completion transport failu
   const response = await client.createChatCompletionJson({
     model: "gpt-5.4",
     messages: [],
+  }, {
+    onChatCompletionAttempt: (attempt) => {
+      attempts.push(attempt);
+    },
   });
 
   assertEquals(calls, 2);
   assertEquals(response.choices[0]?.message.content, "ok");
+  assertEquals(attempts.map((attempt) => attempt.outcome), [
+    "transport_error",
+    "http_response",
+  ]);
+  assertEquals(attempts.map((attempt) => attempt.attempt), [1, 2]);
+  assertEquals(attempts[0].errorDetail, "connection error: timed out");
+  assertEquals(attempts[1].httpStatus, 200);
 });
 
 Deno.test("OpenAICompatibleGatewayClient surfaces exhausted chat completion transport retries", async () => {
@@ -153,6 +168,7 @@ Deno.test("OpenAICompatibleGatewayClient surfaces exhausted chat completion tran
 });
 
 Deno.test("OpenAICompatibleGatewayClient surfaces chat completion errors with response text", async () => {
+  const attempts: OpenAIChatCompletionAttemptDiagnostic[] = [];
   const client = new OpenAICompatibleGatewayClient({
     baseUrl: "https://llm.stage.commontools.dev/",
     apiKey: "test-key",
@@ -161,6 +177,9 @@ Deno.test("OpenAICompatibleGatewayClient surfaces chat completion errors with re
         new Response("bad request", {
           status: 400,
           statusText: "Bad Request",
+          headers: {
+            "x-request-id": "req-bad-request",
+          },
         }),
       ),
   });
@@ -169,11 +188,42 @@ Deno.test("OpenAICompatibleGatewayClient surfaces chat completion errors with re
     () =>
       client.createChatCompletionJson({
         model: "gpt-5.4",
-        messages: [],
+        messages: [{ role: "user", content: "hello" }],
+        tools: [{
+          type: "function",
+          function: {
+            name: "read_file",
+          },
+        }],
+      }, {
+        onChatCompletionAttempt: (attempt) => {
+          attempts.push(attempt);
+        },
       }),
     Error,
     "chat completion request failed (400): bad request",
   );
+  assertEquals(attempts.length, 1);
+  const attempt = attempts[0];
+  assertEquals(attempt.type, "cf-harness.gateway.chat-completion-attempt");
+  assertEquals(attempt.operation, "chat.completions");
+  assertEquals(attempt.outcome, "http_response");
+  assertEquals(attempt.attempt, 1);
+  assertEquals(attempt.maxTransportAttempts, 2);
+  assertEquals(attempt.request.model, "gpt-5.4");
+  assertEquals(attempt.request.messageCount, 1);
+  assertEquals(attempt.request.toolCount, 1);
+  assert(attempt.request.serializedBytes > 0);
+  assertEquals(attempt.httpStatus, 400);
+  assertEquals(attempt.httpStatusText, "Bad Request");
+  assertEquals(attempt.requestId, "req-bad-request");
+  assertEquals(attempt.responseHeaders?.["x-request-id"], "req-bad-request");
+  assertEquals(attempt.responseBodyBytes, 11);
+  assertEquals(attempt.responseBodyExcerpt, "bad request");
+  assertEquals(attempt.responseBodyTruncated, false);
+  assert(attempt.durationMs >= 0);
+  assert(new Date(attempt.startedAt).toString() !== "Invalid Date");
+  assert(new Date(attempt.endedAt).toString() !== "Invalid Date");
 });
 
 Deno.test("OpenAICompatibleGatewayClient fails clearly when no API key is configured", async () => {


### PR DESCRIPTION
## Summary
- record chat-completion attempt diagnostics from the OpenAI-compatible gateway client
- include gatewayAttempts in cf-harness run reports with request size, timing, status, selected headers/request IDs, and capped non-OK response excerpts
- document the new diagnostics and cover transport retry/non-OK/persisted-report behavior

## Tests
- deno task check
- deno task test