### PR TITLE
perf(memory): Optimize WatchView sync updates

### DIFF
--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -349,6 +349,81 @@ Deno.test("memory v2 watch view keeps emitted snapshots incrementally ordered", 
   );
 });
 
+Deno.test("memory v2 watch view batches structural syncs deterministically", () => {
+  const view = WatchView.fromSync({
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:doc:d",
+      seq: 1,
+      doc: { value: { label: "d" } },
+    }, {
+      branch: "",
+      id: "of:doc:a",
+      seq: 1,
+      doc: { value: { label: "a" } },
+    }, {
+      branch: "",
+      id: "of:doc:c",
+      seq: 1,
+      doc: { value: { label: "c" } },
+    }],
+    removes: [],
+  });
+
+  view.applySync({
+    type: "sync",
+    fromSeq: 1,
+    toSeq: 2,
+    upserts: [{
+      branch: "",
+      id: "of:doc:c",
+      seq: 2,
+      doc: { value: { label: "c2" } },
+    }, {
+      branch: "",
+      id: "of:doc:b",
+      seq: 2,
+      doc: { value: { label: "b-old" } },
+    }, {
+      branch: "",
+      id: "of:doc:b",
+      seq: 3,
+      doc: { value: { label: "b-new" } },
+    }, {
+      branch: "",
+      id: "of:doc:f",
+      seq: 2,
+      doc: { value: { label: "removed" } },
+    }],
+    removes: [{
+      branch: "",
+      id: "of:doc:d",
+    }, {
+      branch: "",
+      id: "of:doc:f",
+    }, {
+      branch: "",
+      id: "of:doc:missing",
+    }],
+  }, false);
+
+  assertEquals(
+    view.entities.map((entity) => entity.id),
+    ["of:doc:a", "of:doc:b", "of:doc:c"],
+  );
+  assertEquals(
+    view.entities.find((entity) => entity.id === "of:doc:b")?.document,
+    { value: { label: "b-new" } },
+  );
+  assertEquals(
+    view.entities.find((entity) => entity.id === "of:doc:c")?.document,
+    { value: { label: "c2" } },
+  );
+});
+
 Deno.test("memory v2 client close settles a pending ack flush", async () => {
   const time = new FakeTime();
   const transport = new HangingAckTransport();

--- a/packages/memory/test/v2-watch-view.bench.ts
+++ b/packages/memory/test/v2-watch-view.bench.ts
@@ -1,0 +1,152 @@
+import { WatchView } from "../v2/client.ts";
+import type { EntityDocument, SessionSync, SessionSyncUpsert } from "../v2.ts";
+
+const ENTITY_COUNT = readIntEnv("WATCH_VIEW_ENTITY_COUNT", 10_000, 1);
+const CHANGE_COUNT = readIntEnv("WATCH_VIEW_CHANGE_COUNT", 1_000, 1);
+
+const documentFor = (id: string, seq: number): EntityDocument => ({
+  value: { id, seq },
+});
+
+const idFor = (index: number): string =>
+  `of:watch-view:${String(index).padStart(8, "0")}`;
+
+const interleavedIdAfter = (index: number): string => `${idFor(index)}:new`;
+
+const snapshotFor = (index: number, seq = 1): SessionSyncUpsert => {
+  const id = idFor(index);
+  return { branch: "", id, seq, doc: documentFor(id, seq) };
+};
+
+const snapshotForId = (id: string, seq = 1): SessionSyncUpsert => ({
+  branch: "",
+  id,
+  seq,
+  doc: documentFor(id, seq),
+});
+
+function readIntEnv(name: string, defaultValue: number, min: number): number {
+  const raw = Deno.env.get(name);
+  if (raw === undefined || raw === "") return defaultValue;
+
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min) {
+    throw new Error(
+      `${name} must be an integer >= ${min}; got ${JSON.stringify(raw)}`,
+    );
+  }
+
+  return value;
+}
+
+function makeSync(
+  upserts: SessionSyncUpsert[],
+  toSeq: number,
+  removes: Array<{ branch: string; id: string }> = [],
+): SessionSync {
+  return {
+    type: "sync",
+    fromSeq: toSeq - 1,
+    toSeq,
+    upserts,
+    removes,
+  };
+}
+
+function makeView(entityCount = ENTITY_COUNT): WatchView {
+  return WatchView.fromSync(makeSync(
+    Array.from({ length: entityCount }, (_, index) => snapshotFor(index)),
+    1,
+  ));
+}
+
+function evenlySpacedExistingIndexes(
+  count: number,
+  entityCount = ENTITY_COUNT,
+): number[] {
+  const safeCount = Math.min(count, entityCount);
+  const stride = Math.max(1, Math.floor(entityCount / safeCount));
+  return Array.from(
+    { length: safeCount },
+    (_, index) => Math.min(entityCount - 1, index * stride),
+  );
+}
+
+function interleavedNewIds(
+  count: number,
+  entityCount = ENTITY_COUNT,
+): string[] {
+  const safeCount = Math.min(count, entityCount);
+  const stride = Math.max(1, Math.floor(entityCount / safeCount));
+  return Array.from(
+    { length: safeCount },
+    (_, index) => interleavedIdAfter(Math.min(entityCount - 1, index * stride)),
+  );
+}
+
+Deno.bench({
+  name:
+    `WatchView.applySync existing upserts - entities=${ENTITY_COUNT}, changes=${CHANGE_COUNT}`,
+  group: "watch-view-apply-sync",
+  baseline: true,
+  fn(b) {
+    const view = makeView();
+    const upserts = evenlySpacedExistingIndexes(CHANGE_COUNT).map((index) =>
+      snapshotFor(index, 2)
+    );
+
+    b.start();
+    view.applySync(makeSync(upserts, 2), false);
+    b.end();
+  },
+});
+
+Deno.bench({
+  name:
+    `WatchView.applySync new interleaved upserts - entities=${ENTITY_COUNT}, changes=${CHANGE_COUNT}`,
+  group: "watch-view-apply-sync",
+  fn(b) {
+    const view = makeView();
+    const upserts = interleavedNewIds(CHANGE_COUNT).map((id) =>
+      snapshotForId(id, 2)
+    );
+
+    b.start();
+    view.applySync(makeSync(upserts, 2), false);
+    b.end();
+  },
+});
+
+Deno.bench({
+  name:
+    `WatchView.applySync new tail upserts - entities=${ENTITY_COUNT}, changes=${CHANGE_COUNT}`,
+  group: "watch-view-apply-sync",
+  fn(b) {
+    const view = makeView();
+    const upserts = Array.from(
+      { length: CHANGE_COUNT },
+      (_, index) => snapshotFor(ENTITY_COUNT + index, 2),
+    );
+
+    b.start();
+    view.applySync(makeSync(upserts, 2), false);
+    b.end();
+  },
+});
+
+Deno.bench({
+  name:
+    `WatchView.applySync interleaved removes - entities=${ENTITY_COUNT}, changes=${CHANGE_COUNT}`,
+  group: "watch-view-apply-sync",
+  fn(b) {
+    const view = makeView();
+    const removes = evenlySpacedExistingIndexes(CHANGE_COUNT).map((index) => ({
+      branch: "",
+      id: idFor(index),
+    }));
+
+    b.start();
+    view.applySync(makeSync([], 2, removes), false);
+    b.end();
+  },
+});

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -74,6 +74,42 @@ const reconnectDelayMs = (attempt: number): number => {
 
 const watchKey = (branch: string, id: string): string => `${branch}\0${id}`;
 
+const compareEntitySnapshot = (
+  left: EntitySnapshot,
+  right: EntitySnapshot,
+): number =>
+  left.branch.localeCompare(right.branch) || left.id.localeCompare(right.id);
+
+const mergeOrderedEntities = (
+  left: EntitySnapshot[],
+  right: EntitySnapshot[],
+): EntitySnapshot[] => {
+  const merged: EntitySnapshot[] = [];
+  let leftIndex = 0;
+  let rightIndex = 0;
+
+  while (leftIndex < left.length && rightIndex < right.length) {
+    const leftEntity = left[leftIndex]!;
+    const rightEntity = right[rightIndex]!;
+    if (compareEntitySnapshot(leftEntity, rightEntity) <= 0) {
+      merged.push(leftEntity);
+      leftIndex += 1;
+    } else {
+      merged.push(rightEntity);
+      rightIndex += 1;
+    }
+  }
+
+  if (leftIndex < left.length) {
+    merged.push(...left.slice(leftIndex));
+  }
+  if (rightIndex < right.length) {
+    merged.push(...right.slice(rightIndex));
+  }
+
+  return merged;
+};
+
 export class Client {
   #pending = new Map<string, PromiseWithResolvers<unknown>>();
   #spaces = new Set<SpaceSession>();
@@ -874,17 +910,61 @@ export class WatchView {
   }
 
   applySync(sync: SessionSync, emit: boolean): void {
+    const upserts = new Map<string, EntitySnapshot>();
     for (const upsert of sync.upserts) {
-      this.upsertEntity({
+      upserts.set(watchKey(upsert.branch, upsert.id), {
         branch: upsert.branch,
         id: upsert.id,
         seq: upsert.seq,
         document: upsert.doc ?? null,
       });
     }
+
+    const removeKeys = new Set<string>();
+    let hasRemovedExistingEntity = false;
     for (const remove of sync.removes) {
-      this.removeEntity(remove.branch, remove.id);
+      const key = watchKey(remove.branch, remove.id);
+      removeKeys.add(key);
+      hasRemovedExistingEntity ||= this.#entityPositions.has(key);
     }
+
+    const newEntities: EntitySnapshot[] = [];
+    for (const [key, entity] of upserts) {
+      const existingIndex = this.#entityPositions.get(key);
+      if (existingIndex !== undefined) {
+        this.#orderedEntities[existingIndex] = entity;
+      } else if (!removeKeys.has(key)) {
+        newEntities.push(entity);
+      }
+    }
+
+    if (hasRemovedExistingEntity || newEntities.length > 0) {
+      newEntities.sort(compareEntitySnapshot);
+
+      const retainedEntities = hasRemovedExistingEntity
+        ? this.#orderedEntities.filter((entity) =>
+          !removeKeys.has(watchKey(entity.branch, entity.id))
+        )
+        : this.#orderedEntities;
+
+      const lastRetained = retainedEntities.at(-1);
+      if (
+        newEntities.length > 0 &&
+        lastRetained !== undefined &&
+        compareEntitySnapshot(lastRetained, newEntities[0]!) < 0
+      ) {
+        this.#orderedEntities = [...retainedEntities, ...newEntities];
+      } else if (newEntities.length > 0) {
+        this.#orderedEntities = mergeOrderedEntities(
+          retainedEntities,
+          newEntities,
+        );
+      } else {
+        this.#orderedEntities = retainedEntities;
+      }
+      this.rebuildEntityPositions();
+    }
+
     this.#serverSeq = Math.max(this.#serverSeq, sync.toSeq);
     if (emit) {
       this.emit(sync);
@@ -972,53 +1052,9 @@ export class WatchView {
     this.#syncQueue = [];
   }
 
-  private upsertEntity(entity: EntitySnapshot): void {
-    const key = watchKey(entity.branch, entity.id);
-    const existingIndex = this.#entityPositions.get(key);
-    if (existingIndex !== undefined) {
-      this.#orderedEntities[existingIndex] = entity;
-      return;
-    }
-
-    const insertIndex = this.findInsertIndex(entity.branch, entity.id);
-    this.#orderedEntities.splice(insertIndex, 0, entity);
-    this.#entityPositions.set(key, insertIndex);
-    this.reindexFrom(insertIndex + 1);
-  }
-
-  private removeEntity(branch: string, id: string): void {
-    const key = watchKey(branch, id);
-    const existingIndex = this.#entityPositions.get(key);
-    if (existingIndex === undefined) {
-      return;
-    }
-
-    this.#orderedEntities.splice(existingIndex, 1);
-    this.#entityPositions.delete(key);
-    this.reindexFrom(existingIndex);
-  }
-
-  private findInsertIndex(branch: string, id: string): number {
-    let low = 0;
-    let high = this.#orderedEntities.length;
-
-    while (low < high) {
-      const mid = (low + high) >> 1;
-      const current = this.#orderedEntities[mid]!;
-      const compared = current.branch.localeCompare(branch) ||
-        current.id.localeCompare(id);
-      if (compared < 0) {
-        low = mid + 1;
-      } else {
-        high = mid;
-      }
-    }
-
-    return low;
-  }
-
-  private reindexFrom(start: number): void {
-    for (let index = start; index < this.#orderedEntities.length; index += 1) {
+  private rebuildEntityPositions(): void {
+    this.#entityPositions.clear();
+    for (let index = 0; index < this.#orderedEntities.length; index += 1) {
       const entity = this.#orderedEntities[index]!;
       this.#entityPositions.set(watchKey(entity.branch, entity.id), index);
     }

--- a/packages/runner/test/cell-set-nested-array-docs.bench.ts
+++ b/packages/runner/test/cell-set-nested-array-docs.bench.ts
@@ -48,7 +48,7 @@ const DOCUMENT_COUNT = countArrayObjects(DEPTH, WIDTH);
 const SET_DOCUMENT_COUNT = DOCUMENT_COUNT * RUNS;
 const UPDATE_COUNT = Math.min(
   DOCUMENT_COUNT,
-  Math.max(1, Math.floor(DOCUMENT_COUNT * (UPDATE_PERCENT / 100))),
+  Math.floor(DOCUMENT_COUNT * (UPDATE_PERCENT / 100)),
 );
 
 type NestedArrayDocValue = {
@@ -255,12 +255,15 @@ Deno.bench({
       undefined,
       tx,
     );
+    const values = Array.from(
+      { length: RUNS },
+      (_, run) => makeNodes(run, 0, DEPTH, ""),
+    );
 
     try {
       b.start();
       for (let run = 0; run < RUNS; run++) {
-        const value = makeNodes(run, 0, DEPTH, "");
-        cell.set(value);
+        cell.set(values[run]!);
       }
       await tx.commit();
       b.end();

--- a/packages/runner/test/cell-set-nested-array-docs.bench.ts
+++ b/packages/runner/test/cell-set-nested-array-docs.bench.ts
@@ -1,42 +1,72 @@
 /**
  * Benchmarks Cell.set() for nested arrays in a local frame.
  *
- * With a frame captured by the Cell, Cell.set() annotates each object found as
- * an array element with a generated ID. The diff/write path then stores those
- * array objects as their own documents and writes everything in one
- * transaction.
+ * Each array element is written as Writable.for(key).set(value), where key is
+ * globally unique and stable across transactions. The parent array stores cell
+ * links, while each array object lives in its own document.
  *
  * Environment controls:
  * - CELL_SET_NESTED_ARRAY_DEPTH: nested child-array levels, default 4
  * - CELL_SET_NESTED_ARRAY_WIDTH: objects per array level, default 4
  * - CELL_SET_NESTED_ARRAY_PAYLOAD_FIELDS: scalar fields per object, default 4
  * - CELL_SET_NESTED_ARRAY_RUNS: number of Cell.set() calls before commit, default 1
+ * - CELL_SET_NESTED_ARRAY_UPDATE_TRANSACTIONS: update transactions, default 100
+ * - CELL_SET_NESTED_ARRAY_UPDATE_PERCENT: percent of documents changed per update transaction, default 1
  */
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
+import { createBuilder } from "../src/builder/factory.ts";
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
-import { type Frame } from "../src/builder/types.ts";
+import { type Cell, type Frame } from "../src/builder/types.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { BENCH_MEMORY_VERSION } from "./bench-memory-version.ts";
 
 const signer = await Identity.fromPassphrase("bench nested array docs");
 const space = signer.did();
+const { commonfabric: { Writable } } = createBuilder();
+const WRITABLE_FRAME_CAUSE = {
+  type: "bench-cell-set-nested-array-docs-writable",
+};
 
 const DEPTH = readIntEnv("CELL_SET_NESTED_ARRAY_DEPTH", 4, 0);
 const WIDTH = readIntEnv("CELL_SET_NESTED_ARRAY_WIDTH", 4, 1);
 const PAYLOAD_FIELDS = readIntEnv("CELL_SET_NESTED_ARRAY_PAYLOAD_FIELDS", 4, 0);
 const RUNS = readIntEnv("CELL_SET_NESTED_ARRAY_RUNS", 1, 1);
-const DOCUMENT_COUNT = countArrayObjects(DEPTH, WIDTH) * RUNS;
+const UPDATE_TRANSACTIONS = readIntEnv(
+  "CELL_SET_NESTED_ARRAY_UPDATE_TRANSACTIONS",
+  100,
+  1,
+);
+const UPDATE_PERCENT = readNumberEnv(
+  "CELL_SET_NESTED_ARRAY_UPDATE_PERCENT",
+  1,
+  0,
+);
+const DOCUMENT_COUNT = countArrayObjects(DEPTH, WIDTH);
+const SET_DOCUMENT_COUNT = DOCUMENT_COUNT * RUNS;
+const UPDATE_COUNT = Math.min(
+  DOCUMENT_COUNT,
+  Math.max(1, Math.floor(DOCUMENT_COUNT * (UPDATE_PERCENT / 100))),
+);
 
-type NestedArrayDoc = {
+type NestedArrayDocValue = {
   label: string;
   level: number;
   index: number;
   path: string;
   payload: Record<string, string | number | boolean>;
-  children?: NestedArrayDoc[];
+  children?: NestedArrayDocCell[];
+};
+
+type NestedArrayDocCell = Cell<any>;
+
+type NestedArrayDocRef = {
+  key: string;
+  value: NestedArrayDocValue;
+  container: NestedArrayDocCell[];
+  index: number;
 };
 
 function readIntEnv(name: string, defaultValue: number, min: number): number {
@@ -53,6 +83,24 @@ function readIntEnv(name: string, defaultValue: number, min: number): number {
   return value;
 }
 
+function readNumberEnv(
+  name: string,
+  defaultValue: number,
+  min: number,
+): number {
+  const raw = Deno.env.get(name);
+  if (raw === undefined || raw === "") return defaultValue;
+
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < min) {
+    throw new Error(
+      `${name} must be a number >= ${min}; got ${JSON.stringify(raw)}`,
+    );
+  }
+
+  return value;
+}
+
 function countArrayObjects(depth: number, width: number): number {
   let total = 0;
   let levelCount = width;
@@ -63,6 +111,28 @@ function countArrayObjects(depth: number, width: number): number {
   }
 
   return total;
+}
+
+function makeRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (1664525 * state + 1013904223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+}
+
+function chooseRandomDocs(
+  docs: NestedArrayDocRef[],
+  count: number,
+  random: () => number,
+): NestedArrayDocRef[] {
+  const selected = new Set<number>();
+
+  while (selected.size < count) {
+    selected.add(Math.floor(random() * docs.length));
+  }
+
+  return [...selected].map((index) => docs[index]);
 }
 
 function makePayload(
@@ -82,15 +152,23 @@ function makePayload(
   return payload;
 }
 
+function makeDocumentKey(run: number, path: string): string {
+  return `bench-cell-set-nested-array-docs:${run}:${path}`;
+}
+
 function makeNodes(
   run: number,
   level: number,
   maxDepth: number,
   path: string,
-): NestedArrayDoc[] {
-  return Array.from({ length: WIDTH }, (_, index) => {
+  docs: NestedArrayDocRef[] = [],
+): NestedArrayDocCell[] {
+  const cells: NestedArrayDocCell[] = [];
+
+  for (let index = 0; index < WIDTH; index++) {
     const childPath = path === "" ? `${index}` : `${path}.${index}`;
-    const node: NestedArrayDoc = {
+
+    const value: NestedArrayDocValue = {
       label: `node-${run}-${childPath}`,
       level,
       index,
@@ -99,11 +177,31 @@ function makeNodes(
     };
 
     if (level < maxDepth) {
-      node.children = makeNodes(run, level + 1, maxDepth, childPath);
+      value.children = makeNodes(
+        run,
+        level + 1,
+        maxDepth,
+        childPath,
+        docs,
+      );
     }
 
-    return node;
-  });
+    const key = makeDocumentKey(run, childPath);
+    const cell = Writable.for<any>(key).set(value) as NestedArrayDocCell;
+    cells.push(cell);
+    docs.push({ key, value, container: cells, index });
+  }
+
+  return cells;
+}
+
+function makeValueWithDocs(run: number): {
+  value: NestedArrayDocCell[];
+  docs: NestedArrayDocRef[];
+} {
+  const docs: NestedArrayDocRef[] = [];
+  const value = makeNodes(run, 0, DEPTH, "", docs);
+  return { value, docs };
 }
 
 function setup() {
@@ -134,17 +232,14 @@ async function cleanup(
 
 Deno.bench({
   name:
-    `Cell.set() nested array docs - depth=${DEPTH}, width=${WIDTH}, docs=${DOCUMENT_COUNT}, runs=${RUNS}`,
+    `Cell.set() nested array docs - depth=${DEPTH}, width=${WIDTH}, docs=${SET_DOCUMENT_COUNT}, runs=${RUNS}`,
   group: "cell-set-nested-array-docs",
   async fn(b) {
     const { runtime, storageManager, tx } = setup();
-    const values = Array.from(
-      { length: RUNS },
-      (_, run) => makeNodes(run, 0, DEPTH, ""),
-    );
     const frame: Frame = pushFrame({
       cause: {
-        type: "bench-cell-set-nested-array-docs",
+        ...WRITABLE_FRAME_CAUSE,
+        operation: "set",
         depth: DEPTH,
         width: WIDTH,
         runs: RUNS,
@@ -154,7 +249,7 @@ Deno.bench({
       space,
       inHandler: true,
     });
-    const cell = runtime.getCell<NestedArrayDoc[]>(
+    const cell = runtime.getCell<NestedArrayDocCell[]>(
       space,
       "bench-cell-set-nested-array-docs",
       undefined,
@@ -163,7 +258,8 @@ Deno.bench({
 
     try {
       b.start();
-      for (const value of values) {
+      for (let run = 0; run < RUNS; run++) {
+        const value = makeNodes(run, 0, DEPTH, "");
         cell.set(value);
       }
       await tx.commit();
@@ -171,6 +267,98 @@ Deno.bench({
     } finally {
       popFrame(frame);
       await cleanup(runtime, storageManager, tx);
+    }
+  },
+});
+
+Deno.bench({
+  name:
+    `Cell.set() nested array docs update - depth=${DEPTH}, width=${WIDTH}, docs=${DOCUMENT_COUNT}, txs=${UPDATE_TRANSACTIONS}, root-sets=${UPDATE_TRANSACTIONS}, changed/tx=${UPDATE_COUNT}`,
+  group: "cell-set-nested-array-docs",
+  async fn(b) {
+    const { runtime, storageManager, tx: setupTx } = setup();
+    const setupFrame: Frame = pushFrame({
+      cause: {
+        ...WRITABLE_FRAME_CAUSE,
+        operation: "update",
+        depth: DEPTH,
+        width: WIDTH,
+      },
+      runtime,
+      tx: setupTx,
+      space,
+      inHandler: true,
+    });
+    const setupCell = runtime.getCell<NestedArrayDocCell[]>(
+      space,
+      "bench-cell-set-nested-array-docs-update",
+      undefined,
+      setupTx,
+    );
+
+    let currentValue: NestedArrayDocCell[] = [];
+    let docs: NestedArrayDocRef[] = [];
+    try {
+      ({ value: currentValue, docs } = makeValueWithDocs(0));
+      setupCell.set(currentValue);
+      await setupTx.commit();
+    } finally {
+      popFrame(setupFrame);
+    }
+
+    try {
+      const random = makeRandom(0x5eed);
+      const updates = Array.from(
+        { length: UPDATE_TRANSACTIONS },
+        () => chooseRandomDocs(docs, UPDATE_COUNT, random),
+      );
+
+      b.start();
+      for (
+        let transaction = 0;
+        transaction < UPDATE_TRANSACTIONS;
+        transaction++
+      ) {
+        const tx = runtime.edit();
+        const frame = pushFrame({
+          cause: {
+            ...WRITABLE_FRAME_CAUSE,
+            operation: "update",
+          },
+          runtime,
+          tx,
+          space,
+          inHandler: true,
+        });
+        const cell = runtime.getCell<NestedArrayDocCell[]>(
+          space,
+          "bench-cell-set-nested-array-docs-update",
+          undefined,
+          tx,
+        );
+
+        try {
+          for (let update = 0; update < updates[transaction].length; update++) {
+            const doc = updates[transaction][update];
+            doc.value.payload.mutation = `tx-${transaction}:update-${update}`;
+            doc.container[doc.index] = Writable
+              .for<any>(doc.key)
+              .set(doc.value) as NestedArrayDocCell;
+          }
+          // Exercise the top-level Cell.set() diff path after mutating the
+          // retained in-memory tree.
+          cell.set(currentValue);
+          await tx.commit();
+        } finally {
+          popFrame(frame);
+          if (tx.status().status === "ready") {
+            tx.abort();
+          }
+        }
+      }
+      b.end();
+    } finally {
+      await cleanup(runtime, storageManager, setupTx);
     }
   },
 });


### PR DESCRIPTION
## Summary
- Optimize `WatchView.applySync()` so structural syncs batch new/removal work instead of doing one sorted-array `splice()` plus suffix position-map reindex per changed entity.
- Preserve the observable sorted `(branch, id)` snapshot order by sorting/merging once per structural sync and rebuilding `#entityPositions` once.
- Add a focused `WatchView` benchmark for existing upserts, tail inserts, interleaved inserts, and interleaved removes.
- Keep the nested-array root-set benchmark that exposed this path: setup creates linked writable documents outside measurement, then measured transactions mutate the retained in-memory tree and call one top-level `cell.set(currentValue)`.

## Root Cause
`WatchView` stored entities in a sorted array and tracked `docKey -> array index`. Interleaved inserts/removes used `splice()`, then `reindexFrom()` repaired every shifted index after the insertion/removal point. In workloads where changed documents become newly watched in random order, that turns a batch of changes into repeated O(N) suffix rewrites.

The new path separates non-structural updates from membership changes:
- existing upserts update in place
- duplicate upserts collapse with last-write-wins
- removes win over upserts, matching the old upsert-then-remove behavior
- structural changes filter/merge/sort once and rebuild positions once

## Findings
Before switching array entries to `Writable.for(key).set(value)`, the 50k-ish root-set update workload took about **16m 19s** total, or **9.79s/tx**, and default V8 heap OOMed.

After the `Writable.for(key).set(value)` benchmark change but before this WatchView optimization, the same 47,988 doc / 100 transaction / 1% changed workload took about **5m 12s** total, or **3.12s/tx**.

After this WatchView optimization, the same workload completed in **28.1s** total, or **281ms/tx**.

Latest nested-array root-set update measurements on this branch:

| Shape | Docs | Transactions | Changed/tx | Measurement | Result |
|---|---:|---:|---:|---|---:|
| depth=2, width=21 | 9,723 | 100 | 97 | `deno bench` | **4.3s total**, about **43ms/tx** |
| depth=2, width=36 | 47,988 | 100 | 479 | one-shot, high heap | **28.13s total**, about **281.3ms/tx** |

`deno bench` still did not emit a 50k row after about 2.5 minutes, so the 50k result above uses the same one-shot 100-transaction measurement path as the earlier 50k runs.

Focused WatchView benchmark at 10k entities / 1k changes:

| Case | Before | After |
|---|---:|---:|
| Existing upserts | ~137.6µs | 128.5µs |
| New tail upserts | ~598.9µs | 1.3ms |
| New interleaved upserts | ~441.6ms | 1.6ms |
| Interleaved removes | ~436.4ms | 1.9ms |

The tradeoff is intentional: tail-only structural upserts get slightly slower, but the random/interleaved cases that dominate the nested-array update workload drop by roughly two orders of magnitude.

## Verification
- `deno task test`
- `deno fmt packages/memory/v2/client.ts packages/memory/test/v2-client-test.ts packages/memory/test/v2-watch-view.bench.ts packages/runner/test/cell-set-nested-array-docs.bench.ts`
- `deno lint packages/memory/v2/client.ts packages/memory/test/v2-client-test.ts packages/memory/test/v2-watch-view.bench.ts packages/runner/test/cell-set-nested-array-docs.bench.ts`
- `deno check packages/memory/test/v2-watch-view.bench.ts`
- `deno check packages/runner/test/cell-set-nested-array-docs.bench.ts`
- `deno test --allow-read --allow-write --allow-net --allow-ffi --allow-env packages/memory/test/v2-client-test.ts`
- `deno test --allow-read --allow-write --allow-net --allow-ffi --allow-env packages/memory/test/v2-client-watch-test.ts packages/memory/test/v2-watch-sync-test.ts`
- `WATCH_VIEW_ENTITY_COUNT=10000 WATCH_VIEW_CHANGE_COUNT=1000 deno bench --no-check --allow-all packages/memory/test/v2-watch-view.bench.ts`
- `CELL_SET_NESTED_ARRAY_DEPTH=2 CELL_SET_NESTED_ARRAY_WIDTH=21 CELL_SET_NESTED_ARRAY_UPDATE_TRANSACTIONS=100 CELL_SET_NESTED_ARRAY_UPDATE_PERCENT=1 deno bench --filter "nested array docs update" --no-check --allow-all packages/runner/test/cell-set-nested-array-docs.bench.ts`
- `DENO_V8_FLAGS=--max-old-space-size=16384 PROFILE_START_DELAY_MS=0 PROFILE_READY_DELAY_MS=0 PROFILE_WAIT_MS=0 PROFILE_DEPTH=2 PROFILE_WIDTH=36 PROFILE_TXS=100 PROFILE_UPDATE_PERCENT=1 PROFILE_MODE=root-set PROFILE_SELECTION=random deno run --config deno.json --no-check --allow-all /tmp/cf-profile-nested-array-update.ts`
