### PR TITLE
Enable bridged network access for cf-harness

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -27,6 +27,11 @@ The current design direction is:
 What works today:
 
 - shell-centric execution against the local `runsc-cfc` sandbox path
+- sandbox containers default to Docker `--network bridge` so local Loom/Fabric
+  helper services can be reached through Docker Desktop's `host.docker.internal`
+  host alias during early integration work; set
+  `CF_HARNESS_DOCKER_NETWORK_MODE=host` when a runtime should explicitly use
+  host networking
 - default sandbox image aligned with the public CFC kitchen-sink image published
   from the sibling `gvisor` repo:
   - `us-docker.pkg.dev/commontools-core/common-fabric/sandbox-kitchensink:latest`
@@ -53,6 +58,14 @@ What works today:
 - runtime-generated supporting-resource indexes in `skill-registry.json`
 - text-first supporting-resource reads through `read_skill_resource`, recorded
   in `skill-resource-reads.json`
+
+The sandbox `bash` tool has a provisional direct-`curl` guard while sandbox
+networking is enabled: explicit `curl` invocations may target loopback HTTP(S)
+hosts such as `localhost`, `127.0.0.1`, and Docker Desktop's
+`host.docker.internal` host alias, but obvious external `curl` targets are
+denied before sandbox execution. This is an integration unblock, not a complete
+network confinement model.
+
 - CFC mode plumbing with:
   - `disabled`
   - `observe`

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -208,6 +208,7 @@ Options:
 Environment:
   CF_HARNESS_API_KEY            Preferred API key for the OpenAI-compatible gateway
   OPENAI_API_KEY                Fallback API key if CF_HARNESS_API_KEY is unset
+  CF_HARNESS_DOCKER_NETWORK_MODE none | bridge | host (default: bridge)
 `;
 
 const parsePositiveInteger = (

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -9,6 +9,7 @@ import {
 } from "@std/path/posix";
 import { DenoProcessRunner, type ProcessRunner } from "./process-runner.ts";
 import type {
+  DockerNetworkMode,
   DockerRunscAdditionalMount,
   DockerRunscAdditionalMountConfig,
   DockerRunscCfcInvocationContextTransport,
@@ -34,8 +35,9 @@ export const DEFAULT_DOCKER_RUNTIME_NAME = "runsc-cfc";
 export const DEFAULT_DOCKER_BINARY = "docker";
 export const DEFAULT_WORKSPACE_MOUNT_PATH = "/workspace";
 export const DEFAULT_SANDBOX_SHELL = "/bin/sh";
-export const DEFAULT_DOCKER_NETWORK_MODE = "none" as const;
+export const DEFAULT_DOCKER_NETWORK_MODE = "bridge" as const;
 export const DEFAULT_FABRIC_MOUNT_PATH = "/fabric";
+export const DOCKER_NETWORK_MODE_ENV = "CF_HARNESS_DOCKER_NETWORK_MODE";
 export const CFC_RESULT_DIR_ENV = "CF_HARNESS_RUNSC_CFC_RESULT_DIR";
 export const CFC_INVOCATION_CONTEXT_DIR_ENV =
   "CF_HARNESS_RUNSC_CFC_INVOCATION_CONTEXT_DIR";
@@ -67,6 +69,20 @@ const optionalNonEmptyString = (
   value: string | undefined,
 ): string | undefined =>
   value !== undefined && value.length > 0 ? value : undefined;
+
+const parseDockerNetworkMode = (
+  value: string | undefined,
+): DockerNetworkMode | undefined => {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+  if (value === "none" || value === "bridge" || value === "host") {
+    return value;
+  }
+  throw new Error(
+    `${DOCKER_NETWORK_MODE_ENV} must be one of none, bridge, or host`,
+  );
+};
 
 const validateAbsoluteHostDir = (path: string, label: string): string => {
   if (path.trim() === "") {
@@ -240,7 +256,9 @@ export const resolveDockerRunscSandboxConfig = (
     workspaceHostPath: options.workspaceHostPath,
     workspaceMountPath,
     shellPath: options.shellPath ?? DEFAULT_SANDBOX_SHELL,
-    dockerNetworkMode: options.dockerNetworkMode ?? DEFAULT_DOCKER_NETWORK_MODE,
+    dockerNetworkMode: options.dockerNetworkMode ??
+      parseDockerNetworkMode(readEnvVar(DOCKER_NETWORK_MODE_ENV)) ??
+      DEFAULT_DOCKER_NETWORK_MODE,
     additionalMounts,
     extraDockerArgs: options.extraDockerArgs ?? [],
     ...(cfcResultDir !== undefined ? { cfcResultDir } : {}),

--- a/packages/cf-harness/src/tools/bash-curl-policy.ts
+++ b/packages/cf-harness/src/tools/bash-curl-policy.ts
@@ -1,0 +1,326 @@
+export interface BashCurlPolicyResult {
+  allowed: boolean;
+  reason?: string;
+}
+
+export const BASH_COMMAND_DENIED_EXIT_CODE = 126;
+export const BASH_COMMAND_DENIED_PREFIX = "bash command denied";
+
+const CURL_COMMAND_NAME = "curl";
+const SHELL_OPERATORS = new Set([
+  "|",
+  "||",
+  "&",
+  "&&",
+  ";",
+  "<",
+  ">",
+  ">>",
+]);
+
+const CURL_VALUE_FLAGS = new Set([
+  "-A",
+  "-b",
+  "-c",
+  "-d",
+  "-e",
+  "-F",
+  "-H",
+  "-m",
+  "-o",
+  "-u",
+  "-w",
+  "-X",
+  "--connect-timeout",
+  "--cookie",
+  "--cookie-jar",
+  "--data",
+  "--data-ascii",
+  "--data-binary",
+  "--data-raw",
+  "--form",
+  "--header",
+  "--max-time",
+  "--output",
+  "--referer",
+  "--request",
+  "--user",
+  "--user-agent",
+  "--write-out",
+]);
+
+const CURL_LOCAL_URL_FLAGS = new Set([
+  "--url",
+]);
+
+const CURL_DISALLOWED_FLAGS = new Set([
+  "--abstract-unix-socket",
+  "--connect-to",
+  "--dns-interface",
+  "--dns-ipv4-addr",
+  "--dns-ipv6-addr",
+  "--dns-servers",
+  "--interface",
+  "--preproxy",
+  "--proxy",
+  "--proxy-header",
+  "--proxy-user",
+  "--resolve",
+  "--unix-socket",
+  "-x",
+]);
+
+const CURL_TEXT_SEARCH_COMMANDS = new Set([
+  "grep",
+  "rg",
+]);
+
+export const validateBashCurlCommand = (
+  command: string,
+): BashCurlPolicyResult => {
+  if (!containsCurlWord(command)) {
+    return { allowed: true };
+  }
+
+  const parsed = tokenizeShell(command);
+  if (parsed.error !== undefined) {
+    return { allowed: false, reason: parsed.error };
+  }
+
+  let commandStart = true;
+  let commandName: string | undefined;
+  for (let index = 0; index < parsed.tokens.length; index += 1) {
+    const token = parsed.tokens[index]!;
+    if (SHELL_OPERATORS.has(token)) {
+      commandStart = true;
+      commandName = undefined;
+      continue;
+    }
+    if (!commandStart) {
+      if (
+        containsCurlWord(token) &&
+        !CURL_TEXT_SEARCH_COMMANDS.has(commandName ?? "")
+      ) {
+        return {
+          allowed: false,
+          reason: "curl commands must be direct shell commands",
+        };
+      }
+      continue;
+    }
+    if (isShellAssignment(token)) {
+      continue;
+    }
+    commandStart = false;
+    commandName = shellBasename(token);
+    if (commandName !== CURL_COMMAND_NAME) {
+      continue;
+    }
+    const args: string[] = [];
+    for (let cursor = index + 1; cursor < parsed.tokens.length; cursor += 1) {
+      const arg = parsed.tokens[cursor]!;
+      if (SHELL_OPERATORS.has(arg)) {
+        break;
+      }
+      args.push(arg);
+    }
+    const curlResult = validateCurlArgs(args);
+    if (!curlResult.allowed) {
+      return curlResult;
+    }
+  }
+
+  return { allowed: true };
+};
+
+const validateCurlArgs = (args: readonly string[]): BashCurlPolicyResult => {
+  let allowFlags = true;
+  let sawTarget = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (arg === "--") {
+      allowFlags = false;
+      continue;
+    }
+    if (allowFlags && arg.startsWith("-")) {
+      const [flag, inlineValue] = splitLongFlagValue(arg);
+      if (CURL_DISALLOWED_FLAGS.has(flag)) {
+        return {
+          allowed: false,
+          reason: `curl flag ${flag} is not allowed from cf-harness bash`,
+        };
+      }
+      if (CURL_LOCAL_URL_FLAGS.has(flag)) {
+        const target = inlineValue ?? args[index + 1];
+        if (target === undefined) {
+          return {
+            allowed: false,
+            reason: `curl flag ${flag} requires a localhost URL`,
+          };
+        }
+        const result = validateLocalhostCurlTarget(target);
+        if (!result.allowed) {
+          return result;
+        }
+        if (inlineValue === undefined) {
+          index += 1;
+        }
+        sawTarget = true;
+        continue;
+      }
+      if (CURL_VALUE_FLAGS.has(flag)) {
+        if (inlineValue === undefined) {
+          index += 1;
+        }
+        continue;
+      }
+      continue;
+    }
+
+    const result = validateLocalhostCurlTarget(arg);
+    if (!result.allowed) {
+      return result;
+    }
+    sawTarget = true;
+  }
+
+  return sawTarget || args.length === 0 || args.some(isCurlInfoFlag)
+    ? { allowed: true }
+    : { allowed: true };
+};
+
+const validateLocalhostCurlTarget = (target: string): BashCurlPolicyResult => {
+  if (/[`$\\{}[\]]/.test(target)) {
+    return {
+      allowed: false,
+      reason: "curl targets may not use shell expansion or URL glob syntax",
+    };
+  }
+  const url = parseCurlTarget(target);
+  if (url === undefined) {
+    return {
+      allowed: false,
+      reason: `curl target ${target} must be an http(s) localhost URL`,
+    };
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return {
+      allowed: false,
+      reason:
+        `curl protocol ${url.protocol} is not allowed from cf-harness bash`,
+    };
+  }
+  if (!isLoopbackHost(url.hostname)) {
+    return {
+      allowed: false,
+      reason:
+        `curl host ${url.hostname} is not allowed from cf-harness bash; use localhost or host.docker.internal`,
+    };
+  }
+  return { allowed: true };
+};
+
+const parseCurlTarget = (target: string): URL | undefined => {
+  const candidate = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(target)
+    ? target
+    : `http://${target}`;
+  try {
+    return new URL(candidate);
+  } catch {
+    return undefined;
+  }
+};
+
+const isLoopbackHost = (hostname: string): boolean => {
+  const normalized = hostname.toLowerCase();
+  return normalized === "localhost" ||
+    normalized === "host.docker.internal" ||
+    normalized === "::1" ||
+    /^127(?:\.\d{1,3}){1,3}$/.test(normalized);
+};
+
+const isCurlInfoFlag = (arg: string): boolean =>
+  arg === "--help" || arg === "--version" || arg === "-V";
+
+const splitLongFlagValue = (arg: string): [string, string | undefined] => {
+  if (!arg.startsWith("--")) {
+    return [arg, undefined];
+  }
+  const equalsIndex = arg.indexOf("=");
+  return equalsIndex === -1
+    ? [arg, undefined]
+    : [arg.slice(0, equalsIndex), arg.slice(equalsIndex + 1)];
+};
+
+const containsCurlWord = (command: string): boolean =>
+  /(^|[^A-Za-z0-9_.-])curl([^A-Za-z0-9_.-]|$)/.test(command);
+
+const isCurlToken = (token: string): boolean => {
+  return shellBasename(token) === CURL_COMMAND_NAME;
+};
+
+const shellBasename = (token: string): string =>
+  token.split("/").pop() ?? token;
+
+const isShellAssignment = (token: string): boolean =>
+  /^[A-Za-z_][A-Za-z0-9_]*=.*$/.test(token);
+
+type ShellTokenizeResult =
+  | { tokens: string[]; error?: undefined }
+  | { tokens?: undefined; error: string };
+
+const tokenizeShell = (command: string): ShellTokenizeResult => {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]!;
+    if (quote !== undefined) {
+      if (char === quote) {
+        quote = undefined;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      pushCurrent();
+      continue;
+    }
+    if (isShellOperatorStart(char)) {
+      pushCurrent();
+      const next = command[index + 1];
+      if ((char === "|" || char === "&" || char === ">") && next === char) {
+        tokens.push(`${char}${next}`);
+        index += 1;
+      } else {
+        tokens.push(char);
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (quote !== undefined) {
+    return { error: "unterminated quote in curl command" };
+  }
+  pushCurrent();
+  return { tokens };
+
+  function pushCurrent() {
+    if (current !== "") {
+      tokens.push(current);
+      current = "";
+    }
+  }
+};
+
+const isShellOperatorStart = (char: string): boolean =>
+  char === "|" ||
+  char === "&" ||
+  char === ";" ||
+  char === "<" ||
+  char === ">";

--- a/packages/cf-harness/src/tools/bash-curl-policy.ts
+++ b/packages/cf-harness/src/tools/bash-curl-policy.ts
@@ -184,9 +184,13 @@ const validateCurlArgs = (args: readonly string[]): BashCurlPolicyResult => {
     sawTarget = true;
   }
 
-  return sawTarget || args.length === 0 || args.some(isCurlInfoFlag)
-    ? { allowed: true }
-    : { allowed: true };
+  if (sawTarget || args.length === 0 || args.some(isCurlInfoFlag)) {
+    return { allowed: true };
+  }
+  return {
+    allowed: false,
+    reason: "curl commands must include a localhost URL target",
+  };
 };
 
 const validateLocalhostCurlTarget = (target: string): BashCurlPolicyResult => {
@@ -254,10 +258,6 @@ const splitLongFlagValue = (arg: string): [string, string | undefined] => {
 
 const containsCurlWord = (command: string): boolean =>
   /(^|[^A-Za-z0-9_.-])curl([^A-Za-z0-9_.-]|$)/.test(command);
-
-const isCurlToken = (token: string): boolean => {
-  return shellBasename(token) === CURL_COMMAND_NAME;
-};
 
 const shellBasename = (token: string): string =>
   token.split("/").pop() ?? token;

--- a/packages/cf-harness/src/tools/bash.ts
+++ b/packages/cf-harness/src/tools/bash.ts
@@ -2,6 +2,11 @@ import type { JSONSchema } from "@commonfabric/api";
 import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import {
+  BASH_COMMAND_DENIED_EXIT_CODE,
+  BASH_COMMAND_DENIED_PREFIX,
+  validateBashCurlCommand,
+} from "./bash-curl-policy.ts";
+import {
   commandWithFinalWorkingDirectoryMarker,
   cwdMarkerForOutput,
   extractFinalWorkingDirectory,
@@ -71,6 +76,18 @@ export const bashTool: HarnessToolDefinition<BashToolInput, BashToolOutput> = {
     const commandCwd = input.cwd !== undefined
       ? context.resolvePath(input.cwd)
       : context.currentDir;
+    const curlPolicy = validateBashCurlCommand(input.command);
+    if (!curlPolicy.allowed) {
+      return {
+        outputId,
+        stdout: "",
+        stderr: `${BASH_COMMAND_DENIED_PREFIX}: ${
+          curlPolicy.reason ?? "curl is not allowed"
+        }`,
+        exitCode: BASH_COMMAND_DENIED_EXIT_CODE,
+        cwd: commandCwd,
+      };
+    }
     const cwdMarker = cwdMarkerForOutput(CWD_MARKER_PREFIX, outputId);
     const command = commandWithFinalWorkingDirectoryMarker(
       input.command,

--- a/packages/cf-harness/src/tools/bash.ts
+++ b/packages/cf-harness/src/tools/bash.ts
@@ -78,6 +78,7 @@ export const bashTool: HarnessToolDefinition<BashToolInput, BashToolOutput> = {
       : context.currentDir;
     const curlPolicy = validateBashCurlCommand(input.command);
     if (!curlPolicy.allowed) {
+      context.setCurrentDir(commandCwd);
       return {
         outputId,
         stdout: "",

--- a/packages/cf-harness/test/bash-curl-policy.test.ts
+++ b/packages/cf-harness/test/bash-curl-policy.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals } from "@std/assert";
+import { validateBashCurlCommand } from "../src/tools/bash-curl-policy.ts";
+
+const assertAllowed = (command: string) =>
+  assertEquals(validateBashCurlCommand(command), { allowed: true });
+
+const assertDenied = (command: string) =>
+  assertEquals(validateBashCurlCommand(command).allowed, false);
+
+Deno.test("validateBashCurlCommand allows loopback curl targets", () => {
+  assertAllowed("curl http://localhost:8000/projects");
+  assertAllowed("curl -fsS http://127.0.0.1:8000/context");
+  assertAllowed("curl --url=http://localhost:8000/capture-progress");
+  assertAllowed("curl --url http://127.0.0.1:8000/projects");
+  assertAllowed("curl localhost:8000/projects");
+  assertAllowed("curl http://host.docker.internal:8000/projects");
+  assertAllowed("curl --version");
+});
+
+Deno.test("validateBashCurlCommand allows non-curl bash commands", () => {
+  assertAllowed("find . -maxdepth 2 -type f");
+  assertAllowed("grep -R capture .");
+  assertAllowed("grep curl README.md");
+});
+
+Deno.test("validateBashCurlCommand denies external curl targets", () => {
+  assertDenied("curl https://example.com");
+  assertDenied("curl example.com");
+  assertDenied("curl --url=https://example.com");
+  assertDenied("curl -fsS https://commontools.org | head");
+});
+
+Deno.test("validateBashCurlCommand denies curl routing overrides", () => {
+  assertDenied("curl --proxy http://localhost:8888 http://localhost:8000");
+  assertDenied("curl --resolve example.com:443:127.0.0.1 https://example.com");
+  assertDenied(
+    "curl --connect-to example.com:443:localhost:8443 https://example.com",
+  );
+});
+
+Deno.test("validateBashCurlCommand denies dynamic curl targets", () => {
+  assertDenied('curl "$URL"');
+  assertDenied("curl http://localhost:8000/items[1-3]");
+  assertDenied("command curl https://example.com");
+  assertDenied("env curl https://example.com");
+  assertDenied("bash -lc 'curl https://example.com'");
+});

--- a/packages/cf-harness/test/bash-curl-policy.test.ts
+++ b/packages/cf-harness/test/bash-curl-policy.test.ts
@@ -28,6 +28,8 @@ Deno.test("validateBashCurlCommand denies external curl targets", () => {
   assertDenied("curl example.com");
   assertDenied("curl --url=https://example.com");
   assertDenied("curl -fsS https://commontools.org | head");
+  assertDenied("curl -fsS");
+  assertDenied("curl --request GET");
 });
 
 Deno.test("validateBashCurlCommand denies curl routing overrides", () => {

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -71,7 +71,7 @@ Deno.test("resolveDockerRunscSandboxConfig fills the expected defaults", () => {
   );
   assertEquals(config.workspaceMountPath, "/workspace");
   assertEquals(config.shellPath, "/bin/sh");
-  assertEquals(config.dockerNetworkMode, "none");
+  assertEquals(config.dockerNetworkMode, "bridge");
   assertEquals(config.additionalMounts, []);
   assertEquals(config.extraDockerArgs, []);
   assertEquals(config.cfcResultDir, undefined);
@@ -88,6 +88,15 @@ Deno.test("resolveDefaultContainerUser keeps host UID/GID default on Linux", () 
   }
 
   assertMatch(resolveDefaultContainerUser("linux") ?? "", /^\d+:\d+$/);
+});
+
+Deno.test("resolveDockerRunscSandboxConfig accepts explicit docker network mode", () => {
+  const config = resolveDockerRunscSandboxConfig({
+    workspaceHostPath: "/host/project",
+    dockerNetworkMode: "bridge",
+  });
+
+  assertEquals(config.dockerNetworkMode, "bridge");
 });
 
 Deno.test("DockerRunscSandboxRuntime builds a docker create/start/wait/rm invocation", async () => {
@@ -119,7 +128,7 @@ Deno.test("DockerRunscSandboxRuntime builds a docker create/start/wait/rm invoca
       "--runtime",
       "runsc-cfc",
       "--network",
-      "none",
+      "bridge",
       ...(config.containerUser !== undefined
         ? ["--user", config.containerUser]
         : []),
@@ -249,7 +258,7 @@ Deno.test("DockerRunscSandboxRuntime runShell honors an explicit container user 
       "--runtime",
       "runsc-cfc",
       "--network",
-      "none",
+      "bridge",
       "--user",
       "1234:2345",
       "--mount",
@@ -537,7 +546,7 @@ Deno.test("DockerRunscSandboxRuntime mounts Fabric separately and accepts Fabric
     "--runtime",
     "runsc-cfc",
     "--network",
-    "none",
+    "bridge",
     ...(runtime.config.containerUser !== undefined
       ? ["--user", runtime.config.containerUser]
       : []),

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -319,9 +319,10 @@ Deno.test("bash tool allows curl to localhost through the sandbox shell runtime"
 
 Deno.test("bash tool denies curl to non-localhost targets before sandbox execution", async () => {
   const sandbox = new FakeSandboxRuntime();
-  const context = createContext(sandbox);
+  const context = createContext(sandbox, "/workspace/old");
   const output = await bashTool.invoke(context, {
     command: "curl https://example.com",
+    cwd: "/workspace/new",
   });
 
   assertEquals(output, {
@@ -330,9 +331,10 @@ Deno.test("bash tool denies curl to non-localhost targets before sandbox executi
     stderr:
       "bash command denied: curl host example.com is not allowed from cf-harness bash; use localhost or host.docker.internal",
     exitCode: 126,
-    cwd: "/workspace",
+    cwd: "/workspace/new",
   });
   assertEquals(sandbox.calls, []);
+  assertEquals(context.currentDir, "/workspace/new");
 });
 
 Deno.test("bash tool updates currentDir in enforce mode from observed CFC stdout", async () => {

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -291,6 +291,50 @@ Deno.test("bash tool preserves currentDir inside a configured Fabric mount", asy
   assertEquals(context.currentDir, "/fabric/home");
 });
 
+Deno.test("bash tool allows curl to localhost through the sandbox shell runtime", async () => {
+  const sandbox = new FakeSandboxRuntime([{
+    stdout: "pong\n",
+    stderr: "",
+    exitCode: 0,
+  }]);
+  const context = createContext(sandbox);
+  const output = await bashTool.invoke(context, {
+    command: "curl -fsS http://localhost:8000/health",
+  });
+
+  assertEquals(output.stdout, "pong\n");
+  assertEquals(stripCfcInvocationContexts(sandbox.calls), [{
+    type: "runShell",
+    request: {
+      command: [
+        '__cf_harness_cwd_marker="__CF_HARNESS_CWD__run-1:bash:1__"',
+        'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
+        "curl -fsS http://localhost:8000/health",
+      ].join("\n"),
+      cwd: "/workspace",
+      timeoutMs: undefined,
+    },
+  }]);
+});
+
+Deno.test("bash tool denies curl to non-localhost targets before sandbox execution", async () => {
+  const sandbox = new FakeSandboxRuntime();
+  const context = createContext(sandbox);
+  const output = await bashTool.invoke(context, {
+    command: "curl https://example.com",
+  });
+
+  assertEquals(output, {
+    outputId: "run-1:bash:1",
+    stdout: "",
+    stderr:
+      "bash command denied: curl host example.com is not allowed from cf-harness bash; use localhost or host.docker.internal",
+    exitCode: 126,
+    cwd: "/workspace",
+  });
+  assertEquals(sandbox.calls, []);
+});
+
 Deno.test("bash tool updates currentDir in enforce mode from observed CFC stdout", async () => {
   const outputId = createToolOutputId("run-1", "bash", 1);
   const cwdMarker = `__CF_HARNESS_CWD__${outputId}__`;


### PR DESCRIPTION
## Summary
- default cf-harness Docker/runsc sandbox networking to `bridge` with `CF_HARNESS_DOCKER_NETWORK_MODE` override for `none|bridge|host`
- add a provisional sandbox `bash` curl policy that permits loopback/host-alias HTTP(S) targets and denies obvious external/routing-override curl commands before execution
- document the temporary networking posture and add focused policy/runtime tests

## Validation
- `deno check packages/cf-harness/src/main.ts`
- `deno task test` in `packages/cf-harness` (236 passed)

## Notes
This is intentionally scoped as a functionality unblock for local Loom/Fabric helper calls. The curl guard is command-level mediation, not a complete long-term network confinement story.