### PR TITLE
Add reusable cf CLI launcher

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -39,7 +39,7 @@
   ],
   "tasks": {
     "check": "./tasks/check.sh",
-    "cf": "bash -lc 'ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && CF_CLI_NAME=cf deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/packages/cli/mod.ts\" \"$@\"' --",
+    "cf": "deno run --allow-run --allow-env --allow-read ./packages/cli/launcher.ts",
     "test": "./tasks/test.ts",
     "test-all": "echo \"Use 'deno task test' instead.\" && exit 1",
     "build-binaries": "./tasks/build-binaries.ts",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,8 +7,27 @@ to run the Common Fabric CLI from another repo or from a sandbox. It keeps the
 selected Labs checkout as the source of truth while making the child CLI process
 use an explicit Deno config/import map.
 
-The launcher itself intentionally uses only Deno and Node built-ins so callers
-can invoke it before the Labs import map is active.
+The launcher itself intentionally uses only Deno built-ins so callers can invoke
+it before the Labs import map is active.
+
+Launcher options are parsed before the first non-launcher argument or `--`. Use
+`--` when a `cf` argument has the same name as a launcher option:
+
+```bash
+deno task cf -- --config piece-config.json
+```
+
+Launcher `--config` is the child Deno config/import map used to start the CLI.
+It is not a `cf` command or pattern config.
+
+The child CLI working directory defaults to `INIT_CWD` when present, otherwise
+the launcher's current directory. This preserves `deno task cf` behavior from a
+caller directory. Direct sandbox or wrapper callers should pass `--cwd` when
+they need to ignore a stale inherited `INIT_CWD`.
+
+The child CLI process inherits the parent environment. The launcher only adds
+`CF_CLI_NAME=cf`, so caller-provided `CF_API_URL`, `CF_IDENTITY`, experimental
+flags, and CFC/sandbox-related environment variables continue to flow through.
 
 From the Labs checkout:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,37 @@
+# @commonfabric/cli
+
+## Launcher Contract
+
+`packages/cli/launcher.ts` is the stable Deno launcher for consumers that need
+to run the Common Fabric CLI from another repo or from a sandbox. It keeps the
+selected Labs checkout as the source of truth while making the child CLI process
+use an explicit Deno config/import map.
+
+The launcher itself intentionally uses only Deno and Node built-ins so callers
+can invoke it before the Labs import map is active.
+
+From the Labs checkout:
+
+```bash
+deno task cf --help
+deno task cf check packages/cli/fixtures/pattern.tsx --no-run
+```
+
+From a sibling consumer such as Pattern Factory:
+
+```bash
+deno run --allow-run --allow-env --allow-read ../labs/packages/cli/launcher.ts \
+  -- check workspace/<run-id>/pattern/main.tsx --no-run
+```
+
+From a vendored consumer such as Loom:
+
+```bash
+deno run --allow-run --allow-env --allow-read vendor/labs/packages/cli/launcher.ts \
+  --labs-root vendor/labs \
+  --config deno.json \
+  -- check .ops/patterns/example.tsx --no-run
+```
+
+Use `--launcher-help` for launcher-specific help. Normal CLI flags such as
+`--help` are passed through to `cf`.

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@commonfabric/cli",
   "tasks": {
-    "cli": "bash -lc 'ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && CF_CLI_NAME=cf deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/mod.ts\" \"$@\"' --",
+    "cli": "deno run --allow-run --allow-env --allow-read ./launcher.ts --labs-root ../.. --config ../../deno.json --cli-entrypoint ./mod.ts",
     "cli-no-pwd-override": "CF_CLI_NAME=cf deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run ./mod.ts",
     "test": "deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env test/*.test.ts",
     "integration": "CF_CLI_INTEGRATION_USE_LOCAL=1 CF_LOG_LEVEL=error ./integration/integration.sh",

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@commonfabric/cli",
   "tasks": {
-    "cli": "deno run --allow-run --allow-env --allow-read ./launcher.ts --labs-root ../.. --config ../../deno.json --cli-entrypoint ./mod.ts",
+    "cli": "deno run --allow-run --allow-env --allow-read ./launcher.ts --labs-root ../.. --config ../../deno.json --cli-entrypoint ./mod.ts --",
     "cli-no-pwd-override": "CF_CLI_NAME=cf deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run ./mod.ts",
     "test": "deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env test/*.test.ts",
     "integration": "CF_CLI_INTEGRATION_USE_LOCAL=1 CF_LOG_LEVEL=error ./integration/integration.sh",

--- a/packages/cli/launcher.ts
+++ b/packages/cli/launcher.ts
@@ -1,0 +1,177 @@
+import { dirname, isAbsolute, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface CfLauncherOptions {
+  denoPath: string;
+  labsRoot: string;
+  configPath: string;
+  cliEntrypoint: string;
+  cwd: string;
+  cfArgs: readonly string[];
+}
+
+export interface CfLauncherCommand {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+}
+
+export interface ParseCfLauncherArgsOptions {
+  argv: readonly string[];
+  cwd: string;
+  initCwd?: string;
+  denoPath: string;
+  modulePath: string;
+}
+
+const optionNamesWithValues = new Set([
+  "--deno",
+  "--labs-root",
+  "--config",
+  "--cli-entrypoint",
+  "--cwd",
+]);
+
+const resolvePath = (base: string, path: string): string =>
+  isAbsolute(path) ? path : resolve(base, path);
+
+export const defaultLabsRootFromModulePath = (modulePath: string): string =>
+  resolve(dirname(modulePath), "..", "..");
+
+const readInitCwd = (): string | undefined => {
+  try {
+    const value = Deno.env.get("INIT_CWD");
+    return value !== undefined && value.trim() !== "" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const usage =
+  `Usage: deno run --allow-run --allow-env --allow-read packages/cli/launcher.ts [options] [--] [cf args...]
+
+Options:
+  --deno <path>              Deno executable to use for the child CLI process
+  --labs-root <path>         Labs checkout root (defaults to this script's repo)
+  --config <path>            Deno config path (defaults to <labs-root>/deno.json)
+  --cli-entrypoint <path>    CF CLI entrypoint (defaults to <labs-root>/packages/cli/mod.ts)
+  --cwd <path>               Caller working directory for the CF CLI child process
+  --launcher-help            Show this help text
+`;
+
+export const formatCfLauncherUsage = (): string => usage;
+
+export const parseCfLauncherArgs = (
+  options: ParseCfLauncherArgsOptions,
+): CfLauncherOptions | { help: true } => {
+  const defaultLabsRoot = defaultLabsRootFromModulePath(options.modulePath);
+  let denoPath = options.denoPath;
+  let labsRoot = defaultLabsRoot;
+  let configPath: string | undefined;
+  let cliEntrypoint: string | undefined;
+  let cwd = options.initCwd ?? options.cwd;
+  const cfArgs: string[] = [];
+
+  for (let index = 0; index < options.argv.length; index += 1) {
+    const arg = options.argv[index]!;
+    if (arg === "--") {
+      cfArgs.push(...options.argv.slice(index + 1));
+      break;
+    }
+    if (arg === "--launcher-help") {
+      return { help: true };
+    }
+    if (optionNamesWithValues.has(arg)) {
+      const value = options.argv[index + 1];
+      if (value === undefined || value === "") {
+        throw new Error(`${arg} requires a value`);
+      }
+      switch (arg) {
+        case "--deno":
+          denoPath = value;
+          break;
+        case "--labs-root":
+          labsRoot = resolvePath(options.cwd, value);
+          break;
+        case "--config":
+          configPath = resolvePath(options.cwd, value);
+          break;
+        case "--cli-entrypoint":
+          cliEntrypoint = resolvePath(options.cwd, value);
+          break;
+        case "--cwd":
+          cwd = resolvePath(options.cwd, value);
+          break;
+      }
+      index += 1;
+      continue;
+    }
+    cfArgs.push(...options.argv.slice(index));
+    break;
+  }
+
+  const resolvedLabsRoot = resolvePath(options.cwd, labsRoot);
+  return {
+    denoPath,
+    labsRoot: resolvedLabsRoot,
+    configPath: configPath ?? resolve(resolvedLabsRoot, "deno.json"),
+    cliEntrypoint: cliEntrypoint ??
+      resolve(resolvedLabsRoot, "packages", "cli", "mod.ts"),
+    cwd,
+    cfArgs,
+  };
+};
+
+export const buildCfLauncherCommand = (
+  options: CfLauncherOptions,
+): CfLauncherCommand => ({
+  command: options.denoPath,
+  args: [
+    "run",
+    "--config",
+    options.configPath,
+    "--allow-net",
+    "--allow-ffi",
+    "--allow-read",
+    "--allow-write",
+    "--allow-env",
+    "--allow-run",
+    options.cliEntrypoint,
+    ...options.cfArgs,
+  ],
+  cwd: options.cwd,
+  env: {
+    CF_CLI_NAME: "cf",
+  },
+});
+
+const run = async (): Promise<number> => {
+  const modulePath = fileURLToPath(import.meta.url);
+  const parsed = parseCfLauncherArgs({
+    argv: Deno.args,
+    cwd: Deno.cwd(),
+    initCwd: readInitCwd(),
+    denoPath: Deno.execPath(),
+    modulePath,
+  });
+  if ("help" in parsed) {
+    console.log(formatCfLauncherUsage());
+    return 0;
+  }
+  const command = buildCfLauncherCommand(parsed);
+  const child = new Deno.Command(command.command, {
+    args: command.args,
+    cwd: command.cwd,
+    env: command.env,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const status = await child.spawn().status;
+  return status.code;
+};
+
+if (import.meta.main) {
+  Deno.exit(await run());
+}

--- a/packages/cli/launcher.ts
+++ b/packages/cli/launcher.ts
@@ -158,13 +158,22 @@ const usage =
 Options:
   --deno <path>              Deno executable to use for the child CLI process
   --labs-root <path>         Labs checkout root (defaults to this script's repo)
-  --config <path>            Deno config path (defaults to <labs-root>/deno.json)
+  --config <path>            Child Deno config/import-map path (defaults to <labs-root>/deno.json)
   --cli-entrypoint <path>    CF CLI entrypoint (defaults to <labs-root>/packages/cli/mod.ts)
-  --cwd <path>               Caller working directory for the CF CLI child process
+  --cwd <path>               Working directory for the CF CLI child process (defaults to INIT_CWD or current cwd)
   --launcher-help            Show this help text
 `;
 
 export const formatCfLauncherUsage = (): string => usage;
+
+export const formatCfLauncherError = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error);
+  const missingOption = message.match(/^(--[A-Za-z0-9-]+) requires a value$/);
+  const hint = missingOption === null
+    ? ""
+    : `; use -- to pass ${missingOption[1]} to cf`;
+  return `cf launcher: ${message}${hint}`;
+};
 
 export const parseCfLauncherArgs = (
   options: ParseCfLauncherArgsOptions,
@@ -278,5 +287,10 @@ const run = async (): Promise<number> => {
 };
 
 if (import.meta.main) {
-  Deno.exit(await run());
+  try {
+    Deno.exit(await run());
+  } catch (error) {
+    console.error(formatCfLauncherError(error));
+    Deno.exit(1);
+  }
 }

--- a/packages/cli/launcher.ts
+++ b/packages/cli/launcher.ts
@@ -50,13 +50,16 @@ const normalizePath = (path: string): string => {
     : normalized;
   const isAbsolute = hasUncPrefix || withoutPrefix.startsWith("/");
   const parts: string[] = [];
+  const minPartCount = hasUncPrefix ? 2 : 0;
 
   for (const part of withoutPrefix.split("/")) {
     if (part === "" || part === ".") {
       continue;
     }
     if (part === "..") {
-      if (parts.length > 0 && parts[parts.length - 1] !== "..") {
+      if (
+        parts.length > minPartCount && parts[parts.length - 1] !== ".."
+      ) {
         parts.pop();
       } else if (!isAbsolute) {
         parts.push(part);
@@ -88,7 +91,10 @@ const dirnamePath = (path: string): string => {
   if (trimmed.startsWith("//")) {
     const withoutUncPrefix = trimmed.slice(2);
     const uncIndex = withoutUncPrefix.lastIndexOf("/");
-    return uncIndex < 0 ? trimmed : `//${withoutUncPrefix.slice(0, uncIndex)}`;
+    const shareIndex = withoutUncPrefix.indexOf("/");
+    return uncIndex <= shareIndex
+      ? trimmed
+      : `//${withoutUncPrefix.slice(0, uncIndex)}`;
   }
   const index = trimmed.lastIndexOf("/");
   if (index < 0) {

--- a/packages/cli/launcher.ts
+++ b/packages/cli/launcher.ts
@@ -1,6 +1,3 @@
-import { dirname, isAbsolute, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 export interface CfLauncherOptions {
   denoPath: string;
   labsRoot: string;
@@ -33,11 +30,94 @@ const optionNamesWithValues = new Set([
   "--cwd",
 ]);
 
+const normalizeSeparators = (path: string): string =>
+  path.replaceAll("\\", "/");
+
+const isAbsolutePath = (path: string): boolean => {
+  const normalized = normalizeSeparators(path);
+  return normalized.startsWith("/") || /^[A-Za-z]:\//.test(normalized);
+};
+
+const normalizePath = (path: string): string => {
+  const normalized = normalizeSeparators(path);
+  const drivePrefix = normalized.match(/^[A-Za-z]:/)?.[0] ?? "";
+  const withoutDrive = drivePrefix === ""
+    ? normalized
+    : normalized.slice(drivePrefix.length);
+  const isAbsolute = withoutDrive.startsWith("/");
+  const parts: string[] = [];
+
+  for (const part of withoutDrive.split("/")) {
+    if (part === "" || part === ".") {
+      continue;
+    }
+    if (part === "..") {
+      if (parts.length > 0 && parts[parts.length - 1] !== "..") {
+        parts.pop();
+      } else if (!isAbsolute) {
+        parts.push(part);
+      }
+      continue;
+    }
+    parts.push(part);
+  }
+
+  const prefix = `${drivePrefix}${isAbsolute ? "/" : ""}`;
+  const suffix = parts.join("/");
+  if (suffix === "") {
+    return prefix === "" ? "." : prefix;
+  }
+  return `${prefix}${suffix}`;
+};
+
+const dirnamePath = (path: string): string => {
+  const normalized = normalizePath(path);
+  const trimmed = normalized.length > 1
+    ? normalized.replace(/\/+$/g, "")
+    : normalized;
+  const index = trimmed.lastIndexOf("/");
+  if (index < 0) {
+    return ".";
+  }
+  if (index === 0) {
+    return "/";
+  }
+  if (index === 2 && /^[A-Za-z]:/.test(trimmed)) {
+    return trimmed.slice(0, 3);
+  }
+  return trimmed.slice(0, index);
+};
+
+const resolvePathSegments = (...paths: readonly string[]): string => {
+  let resolved = "";
+  for (const path of paths) {
+    if (path === "") {
+      continue;
+    }
+    const normalized = normalizeSeparators(path);
+    if (resolved === "" || isAbsolutePath(normalized)) {
+      resolved = normalized;
+      continue;
+    }
+    resolved = `${resolved.replace(/\/+$/g, "")}/${normalized}`;
+  }
+  return normalizePath(resolved);
+};
+
 const resolvePath = (base: string, path: string): string =>
-  isAbsolute(path) ? path : resolve(base, path);
+  isAbsolutePath(path) ? normalizePath(path) : resolvePathSegments(base, path);
 
 export const defaultLabsRootFromModulePath = (modulePath: string): string =>
-  resolve(dirname(modulePath), "..", "..");
+  resolvePathSegments(dirnamePath(modulePath), "..", "..");
+
+const fileUrlToPath = (url: string): string => {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "file:") {
+    throw new Error(`expected file URL, received ${url}`);
+  }
+  const path = decodeURIComponent(parsed.pathname);
+  return /^\/[A-Za-z]:\//.test(path) ? path.slice(1) : path;
+};
 
 const readInitCwd = (): string | undefined => {
   try {
@@ -115,9 +195,10 @@ export const parseCfLauncherArgs = (
   return {
     denoPath,
     labsRoot: resolvedLabsRoot,
-    configPath: configPath ?? resolve(resolvedLabsRoot, "deno.json"),
+    configPath: configPath ??
+      resolvePathSegments(resolvedLabsRoot, "deno.json"),
     cliEntrypoint: cliEntrypoint ??
-      resolve(resolvedLabsRoot, "packages", "cli", "mod.ts"),
+      resolvePathSegments(resolvedLabsRoot, "packages", "cli", "mod.ts"),
     cwd,
     cfArgs,
   };
@@ -147,7 +228,7 @@ export const buildCfLauncherCommand = (
 });
 
 const run = async (): Promise<number> => {
-  const modulePath = fileURLToPath(import.meta.url);
+  const modulePath = fileUrlToPath(import.meta.url);
   const parsed = parseCfLauncherArgs({
     argv: Deno.args,
     cwd: Deno.cwd(),

--- a/packages/cli/launcher.ts
+++ b/packages/cli/launcher.ts
@@ -41,13 +41,17 @@ const isAbsolutePath = (path: string): boolean => {
 const normalizePath = (path: string): string => {
   const normalized = normalizeSeparators(path);
   const drivePrefix = normalized.match(/^[A-Za-z]:/)?.[0] ?? "";
-  const withoutDrive = drivePrefix === ""
-    ? normalized
-    : normalized.slice(drivePrefix.length);
-  const isAbsolute = withoutDrive.startsWith("/");
+  const hasUncPrefix = drivePrefix === "" && normalized.startsWith("//") &&
+    !normalized.startsWith("///");
+  const withoutPrefix = drivePrefix !== ""
+    ? normalized.slice(drivePrefix.length)
+    : hasUncPrefix
+    ? normalized.slice(2)
+    : normalized;
+  const isAbsolute = hasUncPrefix || withoutPrefix.startsWith("/");
   const parts: string[] = [];
 
-  for (const part of withoutDrive.split("/")) {
+  for (const part of withoutPrefix.split("/")) {
     if (part === "" || part === ".") {
       continue;
     }
@@ -62,7 +66,13 @@ const normalizePath = (path: string): string => {
     parts.push(part);
   }
 
-  const prefix = `${drivePrefix}${isAbsolute ? "/" : ""}`;
+  const prefix = drivePrefix !== ""
+    ? `${drivePrefix}${isAbsolute ? "/" : ""}`
+    : hasUncPrefix
+    ? "//"
+    : isAbsolute
+    ? "/"
+    : "";
   const suffix = parts.join("/");
   if (suffix === "") {
     return prefix === "" ? "." : prefix;
@@ -75,6 +85,11 @@ const dirnamePath = (path: string): string => {
   const trimmed = normalized.length > 1
     ? normalized.replace(/\/+$/g, "")
     : normalized;
+  if (trimmed.startsWith("//")) {
+    const withoutUncPrefix = trimmed.slice(2);
+    const uncIndex = withoutUncPrefix.lastIndexOf("/");
+    return uncIndex < 0 ? trimmed : `//${withoutUncPrefix.slice(0, uncIndex)}`;
+  }
   const index = trimmed.lastIndexOf("/");
   if (index < 0) {
     return ".";
@@ -110,12 +125,15 @@ const resolvePath = (base: string, path: string): string =>
 export const defaultLabsRootFromModulePath = (modulePath: string): string =>
   resolvePathSegments(dirnamePath(modulePath), "..", "..");
 
-const fileUrlToPath = (url: string): string => {
+export const fileUrlToPath = (url: string): string => {
   const parsed = new URL(url);
   if (parsed.protocol !== "file:") {
     throw new Error(`expected file URL, received ${url}`);
   }
   const path = decodeURIComponent(parsed.pathname);
+  if (parsed.hostname !== "" && parsed.hostname !== "localhost") {
+    return normalizePath(`//${decodeURIComponent(parsed.hostname)}${path}`);
+  }
   return /^\/[A-Za-z]:\//.test(path) ? path.slice(1) : path;
 };
 

--- a/packages/cli/test/launcher.test.ts
+++ b/packages/cli/test/launcher.test.ts
@@ -3,9 +3,14 @@ import {
   buildCfLauncherCommand,
   defaultLabsRootFromModulePath,
   fileUrlToPath,
+  formatCfLauncherError,
   formatCfLauncherUsage,
   parseCfLauncherArgs,
 } from "../launcher.ts";
+
+const launcherPath = fileUrlToPath(
+  new URL("../launcher.ts", import.meta.url).href,
+);
 
 Deno.test("defaultLabsRootFromModulePath resolves from packages/cli", () => {
   assertEquals(
@@ -57,6 +62,23 @@ Deno.test("parseCfLauncherArgs defaults to the launcher labs checkout", () => {
     cwd: "/workspace/pattern-factory",
     cfArgs: ["--help"],
   });
+});
+
+Deno.test("parseCfLauncherArgs lets explicit --cwd override INIT_CWD", () => {
+  const parsed = parseCfLauncherArgs({
+    argv: ["--cwd", "/workspace/explicit", "--", "check", "pattern.tsx"],
+    cwd: "/workspace/labs",
+    initCwd: "/workspace/stale-task-cwd",
+    denoPath: "/usr/local/bin/deno",
+    modulePath: "/workspace/labs/packages/cli/launcher.ts",
+  });
+
+  assertEquals("help" in parsed, false);
+  if ("help" in parsed) {
+    throw new Error("unexpected help result");
+  }
+  assertEquals(parsed.cwd, "/workspace/explicit");
+  assertEquals(parsed.cfArgs, ["check", "pattern.tsx"]);
 });
 
 Deno.test("parseCfLauncherArgs supports explicit consumer config", () => {
@@ -198,6 +220,115 @@ Deno.test("parseCfLauncherArgs rejects missing option values", () => {
     Error,
     "--config requires a value",
   );
+});
+
+Deno.test("formatCfLauncherError adds cf passthrough hint for launcher options", () => {
+  assertEquals(
+    formatCfLauncherError(new Error("--config requires a value")),
+    "cf launcher: --config requires a value; use -- to pass --config to cf",
+  );
+});
+
+Deno.test("launcher main renders launcher-scoped diagnostics without a stack", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-run",
+      "--allow-env",
+      "--allow-read",
+      launcherPath,
+      "--config",
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const output = await command.output();
+  assertEquals(output.code, 1);
+  assertEquals(new TextDecoder().decode(output.stdout), "");
+  const stderr = new TextDecoder().decode(output.stderr);
+  assertEquals(
+    stderr,
+    "cf launcher: --config requires a value; use -- to pass --config to cf\n",
+  );
+});
+
+Deno.test("launcher runs an outside-Labs consumer config and inherits env", async () => {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const expectedCwd = (await Deno.realPath(tempDir)).replaceAll("\\", "/");
+    await Deno.writeTextFile(
+      `${tempDir}/deno.json`,
+      JSON.stringify({
+        imports: {
+          "consumer-alias": "./consumer-alias.ts",
+        },
+      }),
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/consumer-alias.ts`,
+      `export const value = "consumer-config";\n`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/child.ts`,
+      `
+import { value } from "consumer-alias";
+
+console.log(JSON.stringify({
+  args: Deno.args,
+  cwd: Deno.cwd().replaceAll("\\\\", "/"),
+  configValue: value,
+  cfApiUrl: Deno.env.get("CF_API_URL"),
+  cfCliName: Deno.env.get("CF_CLI_NAME"),
+  initCwd: Deno.env.get("INIT_CWD"),
+}));
+`,
+    );
+
+    const command = new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "--allow-run",
+        "--allow-env",
+        "--allow-read",
+        launcherPath,
+        "--deno",
+        Deno.execPath(),
+        "--labs-root",
+        ".",
+        "--config",
+        "deno.json",
+        "--cli-entrypoint",
+        "child.ts",
+        "--cwd",
+        ".",
+        "--",
+        "check",
+        "pattern.tsx",
+      ],
+      cwd: tempDir,
+      env: {
+        CF_API_URL: "http://example.invalid",
+        INIT_CWD: "/stale/init/cwd",
+      },
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const output = await command.output();
+    assertEquals(new TextDecoder().decode(output.stderr), "");
+    assertEquals(output.code, 0);
+    assertEquals(JSON.parse(new TextDecoder().decode(output.stdout)), {
+      args: ["check", "pattern.tsx"],
+      cwd: expectedCwd,
+      configValue: "consumer-config",
+      cfApiUrl: "http://example.invalid",
+      cfCliName: "cf",
+      initCwd: "/stale/init/cwd",
+    });
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
 });
 
 Deno.test("buildCfLauncherCommand builds the child deno invocation", () => {

--- a/packages/cli/test/launcher.test.ts
+++ b/packages/cli/test/launcher.test.ts
@@ -1,0 +1,155 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  buildCfLauncherCommand,
+  defaultLabsRootFromModulePath,
+  formatCfLauncherUsage,
+  parseCfLauncherArgs,
+} from "../launcher.ts";
+
+Deno.test("defaultLabsRootFromModulePath resolves from packages/cli", () => {
+  assertEquals(
+    defaultLabsRootFromModulePath("/workspace/labs/packages/cli/launcher.ts"),
+    "/workspace/labs",
+  );
+});
+
+Deno.test("parseCfLauncherArgs defaults to the launcher labs checkout", () => {
+  const parsed = parseCfLauncherArgs({
+    argv: ["--", "--help"],
+    cwd: "/workspace/labs",
+    initCwd: "/workspace/pattern-factory",
+    denoPath: "/usr/local/bin/deno",
+    modulePath: "/workspace/labs/packages/cli/launcher.ts",
+  });
+
+  assertEquals(parsed, {
+    denoPath: "/usr/local/bin/deno",
+    labsRoot: "/workspace/labs",
+    configPath: "/workspace/labs/deno.json",
+    cliEntrypoint: "/workspace/labs/packages/cli/mod.ts",
+    cwd: "/workspace/pattern-factory",
+    cfArgs: ["--help"],
+  });
+});
+
+Deno.test("parseCfLauncherArgs supports explicit consumer config", () => {
+  const parsed = parseCfLauncherArgs({
+    argv: [
+      "--labs-root",
+      "vendor/labs",
+      "--config",
+      "deno.json",
+      "--cwd",
+      ".",
+      "--",
+      "piece",
+      "apply",
+      "--config",
+      "piece-config.json",
+    ],
+    cwd: "/workspace/loom",
+    denoPath: "/usr/local/bin/deno",
+    modulePath: "/workspace/loom/vendor/labs/packages/cli/launcher.ts",
+  });
+
+  assertEquals(parsed, {
+    denoPath: "/usr/local/bin/deno",
+    labsRoot: "/workspace/loom/vendor/labs",
+    configPath: "/workspace/loom/deno.json",
+    cliEntrypoint: "/workspace/loom/vendor/labs/packages/cli/mod.ts",
+    cwd: "/workspace/loom",
+    cfArgs: ["piece", "apply", "--config", "piece-config.json"],
+  });
+});
+
+Deno.test("parseCfLauncherArgs treats the first non-launcher arg as cf args", () => {
+  const parsed = parseCfLauncherArgs({
+    argv: ["check", "pattern.tsx", "--no-run"],
+    cwd: "/workspace/labs",
+    denoPath: "/usr/local/bin/deno",
+    modulePath: "/workspace/labs/packages/cli/launcher.ts",
+  });
+
+  assertEquals("help" in parsed, false);
+  if ("help" in parsed) {
+    throw new Error("unexpected help result");
+  }
+  assertEquals(parsed.cfArgs, ["check", "pattern.tsx", "--no-run"]);
+});
+
+Deno.test("parseCfLauncherArgs reports launcher help for launcher-specific flag", () => {
+  assertEquals(
+    parseCfLauncherArgs({
+      argv: ["--launcher-help"],
+      cwd: "/workspace/labs",
+      denoPath: "/usr/local/bin/deno",
+      modulePath: "/workspace/labs/packages/cli/launcher.ts",
+    }),
+    { help: true },
+  );
+  assertEquals(formatCfLauncherUsage().includes("--labs-root"), true);
+});
+
+Deno.test("parseCfLauncherArgs passes cf help through to the child CLI", () => {
+  const parsed = parseCfLauncherArgs({
+    argv: ["--help"],
+    cwd: "/workspace/labs",
+    denoPath: "/usr/local/bin/deno",
+    modulePath: "/workspace/labs/packages/cli/launcher.ts",
+  });
+
+  assertEquals("help" in parsed, false);
+  if ("help" in parsed) {
+    throw new Error("unexpected launcher help result");
+  }
+  assertEquals(parsed.cfArgs, ["--help"]);
+});
+
+Deno.test("parseCfLauncherArgs rejects missing option values", () => {
+  assertThrows(
+    () =>
+      parseCfLauncherArgs({
+        argv: ["--config"],
+        cwd: "/workspace/labs",
+        denoPath: "/usr/local/bin/deno",
+        modulePath: "/workspace/labs/packages/cli/launcher.ts",
+      }),
+    Error,
+    "--config requires a value",
+  );
+});
+
+Deno.test("buildCfLauncherCommand builds the child deno invocation", () => {
+  assertEquals(
+    buildCfLauncherCommand({
+      denoPath: "/usr/local/bin/deno",
+      labsRoot: "/workspace/labs",
+      configPath: "/workspace/labs/deno.json",
+      cliEntrypoint: "/workspace/labs/packages/cli/mod.ts",
+      cwd: "/workspace/pattern-factory",
+      cfArgs: ["check", "pattern.tsx", "--no-run"],
+    }),
+    {
+      command: "/usr/local/bin/deno",
+      args: [
+        "run",
+        "--config",
+        "/workspace/labs/deno.json",
+        "--allow-net",
+        "--allow-ffi",
+        "--allow-read",
+        "--allow-write",
+        "--allow-env",
+        "--allow-run",
+        "/workspace/labs/packages/cli/mod.ts",
+        "check",
+        "pattern.tsx",
+        "--no-run",
+      ],
+      cwd: "/workspace/pattern-factory",
+      env: {
+        CF_CLI_NAME: "cf",
+      },
+    },
+  );
+});

--- a/packages/cli/test/launcher.test.ts
+++ b/packages/cli/test/launcher.test.ts
@@ -21,6 +21,12 @@ Deno.test("defaultLabsRootFromModulePath preserves UNC roots", () => {
     ),
     "//server/share/labs",
   );
+  assertEquals(
+    defaultLabsRootFromModulePath(
+      "//server/share/packages/cli/launcher.ts",
+    ),
+    "//server/share",
+  );
 });
 
 Deno.test("fileUrlToPath converts drive and UNC file URLs", () => {
@@ -80,6 +86,34 @@ Deno.test("parseCfLauncherArgs supports explicit consumer config", () => {
     cliEntrypoint: "/workspace/loom/vendor/labs/packages/cli/mod.ts",
     cwd: "/workspace/loom",
     cfArgs: ["piece", "apply", "--config", "piece-config.json"],
+  });
+});
+
+Deno.test("parseCfLauncherArgs preserves explicit UNC share roots", () => {
+  const parsed = parseCfLauncherArgs({
+    argv: [
+      "--labs-root",
+      "//server/share",
+      "--config",
+      "//server/share/deno.json",
+      "--cwd",
+      "//server/share",
+      "--",
+      "check",
+      "pattern.tsx",
+    ],
+    cwd: "/workspace/labs",
+    denoPath: "/usr/local/bin/deno",
+    modulePath: "/workspace/labs/packages/cli/launcher.ts",
+  });
+
+  assertEquals(parsed, {
+    denoPath: "/usr/local/bin/deno",
+    labsRoot: "//server/share",
+    configPath: "//server/share/deno.json",
+    cliEntrypoint: "//server/share/packages/cli/mod.ts",
+    cwd: "//server/share",
+    cfArgs: ["check", "pattern.tsx"],
   });
 });
 

--- a/packages/cli/test/launcher.test.ts
+++ b/packages/cli/test/launcher.test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertThrows } from "@std/assert";
 import {
   buildCfLauncherCommand,
   defaultLabsRootFromModulePath,
+  fileUrlToPath,
   formatCfLauncherUsage,
   parseCfLauncherArgs,
 } from "../launcher.ts";
@@ -10,6 +11,26 @@ Deno.test("defaultLabsRootFromModulePath resolves from packages/cli", () => {
   assertEquals(
     defaultLabsRootFromModulePath("/workspace/labs/packages/cli/launcher.ts"),
     "/workspace/labs",
+  );
+});
+
+Deno.test("defaultLabsRootFromModulePath preserves UNC roots", () => {
+  assertEquals(
+    defaultLabsRootFromModulePath(
+      "//server/share/labs/packages/cli/launcher.ts",
+    ),
+    "//server/share/labs",
+  );
+});
+
+Deno.test("fileUrlToPath converts drive and UNC file URLs", () => {
+  assertEquals(
+    fileUrlToPath("file:///C:/workspace/labs/packages/cli/launcher.ts"),
+    "C:/workspace/labs/packages/cli/launcher.ts",
+  );
+  assertEquals(
+    fileUrlToPath("file://server/share/labs/packages/cli/launcher.ts"),
+    "//server/share/labs/packages/cli/launcher.ts",
   );
 });
 
@@ -60,6 +81,32 @@ Deno.test("parseCfLauncherArgs supports explicit consumer config", () => {
     cwd: "/workspace/loom",
     cfArgs: ["piece", "apply", "--config", "piece-config.json"],
   });
+});
+
+Deno.test("parseCfLauncherArgs forwards cf args after separator", () => {
+  const parsed = parseCfLauncherArgs({
+    argv: [
+      "--labs-root",
+      "../..",
+      "--config",
+      "../../deno.json",
+      "--cli-entrypoint",
+      "./mod.ts",
+      "--",
+      "--config",
+      "piece-config.json",
+    ],
+    cwd: "/workspace/labs/packages/cli",
+    denoPath: "/usr/local/bin/deno",
+    modulePath: "/workspace/labs/packages/cli/launcher.ts",
+  });
+
+  assertEquals("help" in parsed, false);
+  if ("help" in parsed) {
+    throw new Error("unexpected help result");
+  }
+  assertEquals(parsed.configPath, "/workspace/labs/deno.json");
+  assertEquals(parsed.cfArgs, ["--config", "piece-config.json"]);
 });
 
 Deno.test("parseCfLauncherArgs treats the first non-launcher arg as cf args", () => {


### PR DESCRIPTION
## Summary
- add a Labs-owned Deno launcher for the Common Fabric CLI that can be invoked from sibling or vendored consumers before the Labs import map is active
- switch root `deno task cf` and package-local `deno task cli` to the launcher
- document launcher usage for Labs, Pattern Factory, and Loom layouts

## Verification
- `deno fmt --check packages/cli/README.md packages/cli/launcher.ts packages/cli/test/launcher.test.ts deno.json packages/cli/deno.json`
- `deno test --allow-run --allow-env --allow-read packages/cli/test/launcher.test.ts`
- `deno task cf --help`
- `deno task cf --launcher-help`
- `deno task cf check packages/cli/fixtures/pattern.tsx --no-run`
- `deno task --cwd packages/cli cli --help`
- `deno task --cwd packages/cli test`
- `deno task check`
- external Pattern Factory cwd launcher smoke for `--help` and `cf check`