### PR TITLE
Redirect `sha256` to our smart implementation selector.

### DIFF
--- a/packages/fuse/annotations.ts
+++ b/packages/fuse/annotations.ts
@@ -1,5 +1,5 @@
 import { cfcAtom } from "@commonfabric/runner";
-import { sha256 } from "@noble/hashes/sha2.js";
+import { sha256 } from "@commonfabric/content-hash";
 import { encodeHex } from "@std/encoding/hex";
 import type { CallableKind } from "./callables.ts";
 

--- a/packages/fuse/cfc-writeback.ts
+++ b/packages/fuse/cfc-writeback.ts
@@ -2,7 +2,7 @@ import {
   type CfcEnforcementMode as RunnerCfcEnforcementMode,
   DEFAULT_CFC_ENFORCEMENT_MODE,
 } from "@commonfabric/runner/cfc";
-import { sha256 } from "@noble/hashes/sha2.js";
+import { sha256 } from "@commonfabric/content-hash";
 import { encodeHex } from "@std/encoding/hex";
 import {
   canonicalCfcJsonStringify,


### PR DESCRIPTION
These were just pegged at the Noble implementation, which is the final and measured-slowest choice in our list of prioritized choices.