### PR TITLE
perf(memory): Use map-backed WatchView state

### DIFF
--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -424,6 +424,46 @@ Deno.test("memory v2 watch view batches structural syncs deterministically", () 
   );
 });
 
+Deno.test("memory v2 watch view return clears pending snapshot waiters", async () => {
+  const view = WatchView.fromSync({
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [],
+    removes: [],
+  });
+
+  const canceled = view.subscribe();
+  const canceledNext = canceled.next();
+  await canceled.return?.();
+  assertEquals(await canceledNext, {
+    done: true,
+    value: undefined,
+  });
+
+  const active = view.subscribe();
+  const activeNext = active.next();
+  view.applySync({
+    type: "sync",
+    fromSeq: 1,
+    toSeq: 2,
+    upserts: [{
+      branch: "",
+      id: "of:doc:active",
+      seq: 2,
+      doc: { value: { label: "active" } },
+    }],
+    removes: [],
+  }, true);
+
+  const snapshot = await activeNext;
+  assertEquals(snapshot.done, false);
+  assertEquals(
+    snapshot.value.entities.map((entity: EntitySnapshot) => entity.id),
+    ["of:doc:active"],
+  );
+});
+
 Deno.test("memory v2 client close settles a pending ack flush", async () => {
   const time = new FakeTime();
   const transport = new HangingAckTransport();

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -861,6 +861,9 @@ export class WatchView {
   subscribe(): AsyncIterator<GraphQueryResult> {
     this.#subscribers += 1;
     let active = true;
+    const iteratorPending = new Set<
+      PromiseWithResolvers<IteratorResult<GraphQueryResult>>
+    >();
     return {
       next: async () => {
         if (this.#closed || !active) {
@@ -877,13 +880,26 @@ export class WatchView {
           IteratorResult<GraphQueryResult>
         >();
         this.#pending.add(pending);
-        return await pending.promise;
+        iteratorPending.add(pending);
+        try {
+          return await pending.promise;
+        } finally {
+          iteratorPending.delete(pending);
+        }
       },
       return: () => {
         if (active) {
           active = false;
           this.#subscribers = Math.max(0, this.#subscribers - 1);
         }
+        for (const pending of iteratorPending) {
+          this.#pending.delete(pending);
+          pending.resolve({
+            done: true,
+            value: undefined as never,
+          });
+        }
+        iteratorPending.clear();
         return Promise.resolve({
           done: true,
           value: undefined as never,

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -80,36 +80,6 @@ const compareEntitySnapshot = (
 ): number =>
   left.branch.localeCompare(right.branch) || left.id.localeCompare(right.id);
 
-const mergeOrderedEntities = (
-  left: EntitySnapshot[],
-  right: EntitySnapshot[],
-): EntitySnapshot[] => {
-  const merged: EntitySnapshot[] = [];
-  let leftIndex = 0;
-  let rightIndex = 0;
-
-  while (leftIndex < left.length && rightIndex < right.length) {
-    const leftEntity = left[leftIndex]!;
-    const rightEntity = right[rightIndex]!;
-    if (compareEntitySnapshot(leftEntity, rightEntity) <= 0) {
-      merged.push(leftEntity);
-      leftIndex += 1;
-    } else {
-      merged.push(rightEntity);
-      rightIndex += 1;
-    }
-  }
-
-  if (leftIndex < left.length) {
-    merged.push(...left.slice(leftIndex));
-  }
-  if (rightIndex < right.length) {
-    merged.push(...right.slice(rightIndex));
-  }
-
-  return merged;
-};
-
 export class Client {
   #pending = new Map<string, PromiseWithResolvers<unknown>>();
   #spaces = new Set<SpaceSession>();
@@ -866,10 +836,11 @@ export class SpaceSession {
 export class WatchView {
   #queue: GraphQueryResult[] = [];
   #pending = new Set<PromiseWithResolvers<IteratorResult<GraphQueryResult>>>();
+  #subscribers = 0;
   #syncQueue: SessionSync[] = [];
   #syncPending = new Set<PromiseWithResolvers<IteratorResult<SessionSync>>>();
-  #entityPositions = new Map<string, number>();
-  #orderedEntities: EntitySnapshot[] = [];
+  #entities = new Map<string, EntitySnapshot>();
+  #orderedEntities: EntitySnapshot[] | null = null;
   #closed = false;
   #serverSeq = 0;
 
@@ -880,7 +851,7 @@ export class WatchView {
   }
 
   get entities(): EntitySnapshot[] {
-    return [...this.#orderedEntities];
+    return [...this.orderedEntities()];
   }
 
   get serverSeq(): number {
@@ -888,9 +859,11 @@ export class WatchView {
   }
 
   subscribe(): AsyncIterator<GraphQueryResult> {
+    this.#subscribers += 1;
+    let active = true;
     return {
       next: async () => {
-        if (this.#closed) {
+        if (this.#closed || !active) {
           return {
             done: true,
             value: undefined as never,
@@ -905,6 +878,16 @@ export class WatchView {
         >();
         this.#pending.add(pending);
         return await pending.promise;
+      },
+      return: () => {
+        if (active) {
+          active = false;
+          this.#subscribers = Math.max(0, this.#subscribers - 1);
+        }
+        return Promise.resolve({
+          done: true,
+          value: undefined as never,
+        });
       },
     };
   }
@@ -921,48 +904,25 @@ export class WatchView {
     }
 
     const removeKeys = new Set<string>();
-    let hasRemovedExistingEntity = false;
     for (const remove of sync.removes) {
       const key = watchKey(remove.branch, remove.id);
       removeKeys.add(key);
-      hasRemovedExistingEntity ||= this.#entityPositions.has(key);
     }
 
-    const newEntities: EntitySnapshot[] = [];
+    let changedEntities = false;
     for (const [key, entity] of upserts) {
-      const existingIndex = this.#entityPositions.get(key);
-      if (existingIndex !== undefined) {
-        this.#orderedEntities[existingIndex] = entity;
-      } else if (!removeKeys.has(key)) {
-        newEntities.push(entity);
+      if (!removeKeys.has(key)) {
+        this.#entities.set(key, entity);
+        changedEntities = true;
       }
     }
 
-    if (hasRemovedExistingEntity || newEntities.length > 0) {
-      newEntities.sort(compareEntitySnapshot);
+    for (const key of removeKeys) {
+      changedEntities = this.#entities.delete(key) || changedEntities;
+    }
 
-      const retainedEntities = hasRemovedExistingEntity
-        ? this.#orderedEntities.filter((entity) =>
-          !removeKeys.has(watchKey(entity.branch, entity.id))
-        )
-        : this.#orderedEntities;
-
-      const lastRetained = retainedEntities.at(-1);
-      if (
-        newEntities.length > 0 &&
-        lastRetained !== undefined &&
-        compareEntitySnapshot(lastRetained, newEntities[0]!) < 0
-      ) {
-        this.#orderedEntities = [...retainedEntities, ...newEntities];
-      } else if (newEntities.length > 0) {
-        this.#orderedEntities = mergeOrderedEntities(
-          retainedEntities,
-          newEntities,
-        );
-      } else {
-        this.#orderedEntities = retainedEntities;
-      }
-      this.rebuildEntityPositions();
+    if (changedEntities) {
+      this.#orderedEntities = null;
     }
 
     this.#serverSeq = Math.max(this.#serverSeq, sync.toSeq);
@@ -973,13 +933,17 @@ export class WatchView {
 
   emit(sync: SessionSync): void {
     this.pushSync(sync);
-    this.push(this.snapshot());
+    if (
+      this.#subscribers > 0 || this.#pending.size > 0 || this.#queue.length > 0
+    ) {
+      this.push(this.snapshot());
+    }
   }
 
   snapshot(): GraphQueryResult {
     return {
       serverSeq: this.#serverSeq,
-      entities: [...this.#orderedEntities],
+      entities: [...this.orderedEntities()],
     };
   }
 
@@ -1041,6 +1005,7 @@ export class WatchView {
       });
     }
     this.#pending.clear();
+    this.#subscribers = 0;
     for (const pending of this.#syncPending) {
       pending.resolve({
         done: true,
@@ -1052,12 +1017,12 @@ export class WatchView {
     this.#syncQueue = [];
   }
 
-  private rebuildEntityPositions(): void {
-    this.#entityPositions.clear();
-    for (let index = 0; index < this.#orderedEntities.length; index += 1) {
-      const entity = this.#orderedEntities[index]!;
-      this.#entityPositions.set(watchKey(entity.branch, entity.id), index);
+  private orderedEntities(): EntitySnapshot[] {
+    if (this.#orderedEntities === null) {
+      this.#orderedEntities = [...this.#entities.values()]
+        .sort(compareEntitySnapshot);
     }
+    return this.#orderedEntities;
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace `WatchView`'s sorted dense-array mutation state with a keyed `Map<watchKey, EntitySnapshot>`.
- Keep deterministic `entities` / `snapshot()` output by lazily sorting only at snapshot/read boundaries.
- Avoid building full graph snapshots for sync-only consumers; the runner storage path consumes `subscribeSync()`, so it should not pay snapshot construction cost unless a graph snapshot subscriber exists.

## Why
The previous optimization batched sorted-array updates, but tail additions and interleaved additions were still different code paths because the primary structure was ordered. There is no semantic invalidation of later documents when a new document sorts before them; the old cost was an artifact of maintaining dense array positions.

With map-backed state, existing upserts, tail additions, interleaved additions, and removes are all keyed operations. Order is preserved only where it is observable as presentation/snapshot output.

## Benchmark Results
Focused `WatchView` benchmark at 10k entities / 1k changes:

| Case | Previous PR | This PR |
|---|---:|---:|
| Existing upserts | 128.5µs | 138.5µs |
| New tail upserts | 1.3ms | 134.3µs |
| New interleaved upserts | 1.6ms | 135.0µs |
| Interleaved removes | 1.9ms | 119.4µs |

End-to-end nested-array root-set update benchmark:

| Shape | Previous PR | This PR |
|---|---:|---:|
| 9,723 docs, 100 tx, 97 changed/tx | 4.3s total, ~43ms/tx | 3.5s total, ~35ms/tx |
| 47,988 docs, 100 tx, 479 changed/tx | 28.1s total, ~281ms/tx | 23.67s total, ~236.7ms/tx |

## Verification
- `deno task --cwd packages/memory test`
- `deno check packages/memory/v2/client.ts packages/memory/test/v2-watch-view.bench.ts`
- `deno lint packages/memory/v2/client.ts`
- `git diff --check`
- `WATCH_VIEW_ENTITY_COUNT=10000 WATCH_VIEW_CHANGE_COUNT=1000 deno bench --no-check --allow-all packages/memory/test/v2-watch-view.bench.ts`
- `CELL_SET_NESTED_ARRAY_DEPTH=2 CELL_SET_NESTED_ARRAY_WIDTH=21 CELL_SET_NESTED_ARRAY_UPDATE_TRANSACTIONS=100 CELL_SET_NESTED_ARRAY_UPDATE_PERCENT=1 deno bench --filter "nested array docs update" --no-check --allow-all packages/runner/test/cell-set-nested-array-docs.bench.ts`
- `DENO_V8_FLAGS=--max-old-space-size=16384 PROFILE_START_DELAY_MS=0 PROFILE_READY_DELAY_MS=0 PROFILE_WAIT_MS=0 PROFILE_DEPTH=2 PROFILE_WIDTH=36 PROFILE_TXS=100 PROFILE_UPDATE_PERCENT=1 PROFILE_MODE=root-set PROFILE_SELECTION=random deno run --config deno.json --no-check --allow-all /tmp/cf-profile-nested-array-update.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `WatchView` state to a keyed `Map` and lazily sort only on read, cutting update costs and avoiding unnecessary snapshot work when only sync consumers are present. End-to-end updates are ~16–19% faster; tail/interleaved upserts drop from ~1.3–1.9ms to ~120–135µs in focused benchmarks.

- **Refactors**
  - Replaced ordered array and position index with `Map<watchKey, EntitySnapshot>`; sort only at snapshot/read boundaries.
  - Invalidate cached order on changes; `entities`/`snapshot()` return deterministically sorted arrays.
  - Track active subscribers and only push snapshots when listeners exist; skip snapshot construction for `subscribeSync()`-only paths.
  - Simplified upserts/removes to keyed operations; removed merge logic and dense-array mutation paths.

- **Bug Fixes**
  - Clear pending snapshot waiters when a subscriber cancels via `return()`, ensuring `.next()` resolves `done: true` and preventing leaks (covered by new test).

<sup>Written for commit 115636172b44046d81d0b44d9a93ccd22ef8bdab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

