### PR TITLE
Remove redundant `stableHash`/`stableStringify` from `traverse.ts`.

### DIFF
--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -1,6 +1,5 @@
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { encodePointer } from "../../../memory/v2/path.ts";
-import { stableHash } from "../traverse.ts";
 import type {
   AttemptedWrite,
   CfcAddress,
@@ -25,7 +24,48 @@ const compareAddress = (left: CfcAddress, right: CfcAddress): number => {
   const rightKey = `${right.space}\u0000${right.id}\u0000${
     logicalPathToPointer(right.path)
   }`;
-  return leftKey.localeCompare(rightKey);
+  return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+};
+
+const compareWritePolicyInput = (
+  left: WritePolicyInput,
+  right: WritePolicyInput,
+): number => {
+  if (left.kind < right.kind) return -1;
+  if (left.kind > right.kind) return 1;
+
+  // Same kind on both sides. Use a structurally meaningful sub-key
+  // so canonical order is readable in debug output; fall back to the
+  // canonical hash to give a total order on otherwise-distinct records.
+  let primary = 0;
+  switch (left.kind) {
+    case "schema":
+    case "structural-provenance":
+    case "trusted-event":
+    case "link-write": {
+      const r = right as typeof left;
+      primary = compareAddress(left.target, r.target);
+      break;
+    }
+    case "custom": {
+      const r = right as typeof left;
+      primary = left.name < r.name ? -1 : left.name > r.name ? 1 : 0;
+      break;
+    }
+    case "sink-request": {
+      const r = right as typeof left;
+      primary = left.effectId < r.effectId
+        ? -1
+        : left.effectId > r.effectId
+        ? 1
+        : 0;
+      break;
+    }
+  }
+  if (primary !== 0) return primary;
+  const leftHash = hashStringOf(left);
+  const rightHash = hashStringOf(right);
+  return leftHash < rightHash ? -1 : leftHash > rightHash ? 1 : 0;
 };
 
 export const canonicalizeConsumedRead = (
@@ -94,11 +134,11 @@ export const canonicalizeCfcMetadata = (
     entries: [...metadata.labelMap.entries].map((entry) => ({
       path: canonicalizeLogicalPath(entry.path),
       label: entry.label,
-    })).sort((left, right) =>
-      logicalPathToPointer(left.path).localeCompare(
-        logicalPathToPointer(right.path),
-      )
-    ),
+    })).sort((left, right) => {
+      const leftKey = logicalPathToPointer(left.path);
+      const rightKey = logicalPathToPointer(right.path);
+      return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+    }),
   },
 });
 
@@ -121,13 +161,12 @@ export const canonicalizePreparedDigestInput = (
       return sourceCompare;
     }
     const targetCompare = compareAddress(left.target, right.target);
-    return targetCompare !== 0
-      ? targetCompare
-      : left.kind.localeCompare(right.kind);
+    if (targetCompare !== 0) return targetCompare;
+    return left.kind < right.kind ? -1 : left.kind > right.kind ? 1 : 0;
   }),
   writePolicyInputs: [...input.writePolicyInputs].map(
     canonicalizeWritePolicyInput,
-  ).sort((left, right) => stableHash(left).localeCompare(stableHash(right))),
+  ).sort(compareWritePolicyInput),
   implementationIdentity: input.implementationIdentity,
   trustSnapshot: input.trustSnapshot,
 });

--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -18,13 +18,13 @@ export const logicalPathToPointer = (path: readonly string[]): string =>
   encodePointer(canonicalizeLogicalPath(path));
 
 const compareAddress = (left: CfcAddress, right: CfcAddress): number => {
-  const leftKey = `${left.space}\u0000${left.id}\u0000${
-    logicalPathToPointer(left.path)
-  }`;
-  const rightKey = `${right.space}\u0000${right.id}\u0000${
-    logicalPathToPointer(right.path)
-  }`;
-  return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+  if (left.space !== right.space) {
+    return left.space < right.space ? -1 : 1;
+  }
+  if (left.id !== right.id) return left.id < right.id ? -1 : 1;
+  const leftPointer = logicalPathToPointer(left.path);
+  const rightPointer = logicalPathToPointer(right.path);
+  return leftPointer < rightPointer ? -1 : leftPointer > rightPointer ? 1 : 0;
 };
 
 const compareWritePolicyInput = (

--- a/packages/runner/src/storage/v2-watch.ts
+++ b/packages/runner/src/storage/v2-watch.ts
@@ -4,7 +4,7 @@ import {
   REJECTING_SELECTOR,
 } from "@commonfabric/data-model/schema-utils";
 import type { MIME } from "@commonfabric/memory/interface";
-import { stableHash } from "../traverse.ts";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { ContextualFlowControl } from "../cfc.ts";
 import { SelectorTracker } from "./selector-tracker.ts";
 import type {
@@ -63,7 +63,7 @@ export const compactWatchEntries = (
 };
 
 const selectorIdentity = (selector: SchemaPathSelector): string =>
-  stableHash({
+  hashStringOf({
     path: selector.path,
     schemaHash: selector.schema === undefined
       ? ""
@@ -76,7 +76,7 @@ export const watchIdForEntry = (
   branch = "",
 ): string =>
   `replica:${
-    stableHash({
+    hashStringOf({
       branch,
       id: address.id,
       type: DOCUMENT_MIME,

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -26,8 +26,8 @@ import { isObject, isRecord } from "@commonfabric/utils/types";
 import type { Cell } from "../cell.ts";
 import type { JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { sortAndCompactPaths } from "../reactive-dependencies.ts";
-import { stableHash } from "../traverse.ts";
 import { getJSONFromDataURI } from "../uri-utils.ts";
 import {
   isPrimitiveCellLink,
@@ -637,7 +637,7 @@ export class StorageManager implements IStorageManager {
     schema: JSONSchema | undefined,
   ): Promise<Cell<T>> {
     const pathStr = JSON.stringify(cell.path);
-    const schemaStr = schema ? stableHash(schema) : "";
+    const schemaStr = schema ? hashStringOf(schema) : "";
     const cacheKey = `${id}|${schemaStr}|${pathStr}|${space}`;
     const existing = dataURISyncCache.get(cacheKey);
     if (existing) {
@@ -978,7 +978,7 @@ class SpaceReplica implements ISpaceReplica {
     }
 
     const normalizedEntries = normalizeSyncEntries(entries);
-    const key = stableHash(normalizedEntries.map(([address, selector]) => ({
+    const key = hashStringOf(normalizedEntries.map(([address, selector]) => ({
       id: address.id,
       selector,
     })));

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -105,14 +105,6 @@ export type IMemorySpaceValueAttestation = IMemorySpaceAttestation & {
   address: IMemorySpaceValueAddress;
 };
 
-/**
- * Produces a canonical string representation for use as a hash key.
- * Object keys are sorted for deterministic output so structurally-equal
- * objects always hash identically. Results are cached per object identity
- * via WeakMap, so repeated hashing of the same schema object is O(1).
- */
-const _hashCache = new WeakMap<object, string>();
-
 // Schema operation intern caches: memoize merge/combine results so
 // structurally-identical operations return the same object identity.
 // The cached value is run through `internSchema`, which deep-freezes and
@@ -137,39 +129,6 @@ function internSet(
   cache.set(key, result);
   return result;
 }
-export function stableStringify(value: unknown): string {
-  if (value === null) return "n";
-  if (value === undefined) return "u";
-  const t = typeof value;
-  if (t === "boolean") return value ? "T" : "F";
-  if (t === "number") return `#${value}`;
-  if (t === "string") return `s${(value as string).length}:${value}`;
-
-  const obj = value as object;
-  const cached = _hashCache.get(obj);
-  if (cached !== undefined) return cached;
-
-  let result: string;
-  if (Array.isArray(obj)) {
-    result = "[" + obj.map(stableStringify).join(",") + "]";
-  } else if (obj instanceof Date) {
-    result = `D${(obj as Date).getTime()}`;
-  } else if (obj instanceof RegExp) {
-    result = `R${(obj as RegExp).toString()}`;
-  } else {
-    const keys = Object.keys(obj).sort();
-    result = "{" +
-      keys.map((k) =>
-        k + ":" + stableStringify((obj as Record<string, unknown>)[k])
-      ).join(",") +
-      "}";
-  }
-
-  _hashCache.set(obj, result);
-  return result;
-}
-
-export const stableHash = stableStringify;
 /**
  * A data structure that maps keys to sets of values, allowing multiple values
  * to be associated with a single key without duplication.

--- a/packages/runner/test/cfc-canonicalize.bench.ts
+++ b/packages/runner/test/cfc-canonicalize.bench.ts
@@ -1,0 +1,165 @@
+/**
+ * Benchmarks for the CFC canonicalization helpers and watch-key construction.
+ *
+ * The functions exercised here are on the hot path of the CFC commit-boundary
+ * gate (`preparedDigestFor` is called from
+ * `extended-storage-transaction.ts` on every prepare and again during commit
+ * re-check) and on the storage subscription path (`watchIdForEntry` is hit
+ * once per watch registration).
+ *
+ * Tracked metrics live under `bench: packages/runner/test/cfc-canonicalize.bench.ts > ...`
+ * once `benchmarks.yml` runs on a main-branch push and the artifact is
+ * ingested by `tasks/perf-regression.ts`.
+ */
+
+import { preparedDigestFor, type PreparedDigestInput } from "../src/cfc/mod.ts";
+import { canonicalizePreparedDigestInput } from "../src/cfc/canonical.ts";
+import { watchIdForEntry } from "../src/storage/v2-watch.ts";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import type { WritePolicyInput } from "../src/cfc/types.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const SPACE: MemorySpace =
+  "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSdoom8Beere1L9DwwTm";
+
+const makeAddress = (idSuffix: string, ...path: (string | number)[]) => ({
+  space: SPACE,
+  id: `of:doc-${idSuffix}`,
+  type: "application/json",
+  path: ["value", ...path.map(String)],
+});
+
+// A small `PreparedDigestInput` that approximates a typical pattern-tick
+// boundary: a handful of reads and writes, one or two policy inputs, no
+// dereferences. Realistic for a simple Cell.set() commit.
+const SMALL_INPUT: PreparedDigestInput = {
+  consumedReads: [
+    makeAddress("a", "items"),
+    makeAddress("b", "title"),
+  ],
+  potentialWrites: [
+    makeAddress("a", "items", 0),
+  ],
+  writes: [
+    makeAddress("a", "items", 0),
+  ],
+  dereferenceTraces: [],
+  writePolicyInputs: [
+    {
+      kind: "schema",
+      target: makeAddress("a", "items", 0),
+      schemaHash: "schemaHash-1",
+    },
+  ],
+  implementationIdentity: { kind: "builtin", builtinId: "test-builtin" },
+  trustSnapshot: undefined,
+};
+
+// A larger `PreparedDigestInput` that approximates a busy commit: a dozen
+// reads, several writes, multiple dereference traces, a varied set of policy
+// inputs across kinds. This is where the canonical-sort costs scale.
+const LARGE_INPUT: PreparedDigestInput = {
+  consumedReads: Array.from(
+    { length: 12 },
+    (_, i) => makeAddress(`r${i}`, "field", i),
+  ),
+  potentialWrites: Array.from(
+    { length: 4 },
+    (_, i) => makeAddress(`w${i}`, "out", i),
+  ),
+  writes: Array.from({ length: 4 }, (_, i) => makeAddress(`w${i}`, "out", i)),
+  dereferenceTraces: Array.from({ length: 6 }, (_, i) => ({
+    source: makeAddress(`d${i}`, "src"),
+    target: makeAddress(`d${i}`, "dst"),
+    kind: i % 2 === 0 ? "value" as const : "write-redirect" as const,
+  })),
+  writePolicyInputs: [
+    {
+      kind: "schema",
+      target: makeAddress("w0", "out", 0),
+      schemaHash: "schemaHash-1",
+    } satisfies WritePolicyInput,
+    {
+      kind: "schema",
+      target: makeAddress("w1", "out", 1),
+      schemaHash: "schemaHash-2",
+    } satisfies WritePolicyInput,
+    {
+      kind: "trusted-event",
+      target: makeAddress("w2", "out", 2),
+      eventId: "evt-1",
+    } satisfies WritePolicyInput,
+    {
+      kind: "link-write",
+      target: makeAddress("w3", "out", 3),
+      source: makeAddress("ref", "linked"),
+    } satisfies WritePolicyInput,
+    {
+      kind: "custom",
+      name: "policy-b",
+      value: { allow: true },
+    } satisfies WritePolicyInput,
+    {
+      kind: "custom",
+      name: "policy-a",
+      value: { allow: false },
+    } satisfies WritePolicyInput,
+  ],
+  implementationIdentity: { kind: "builtin", builtinId: "test-builtin" },
+  trustSnapshot: undefined,
+};
+
+Deno.bench(
+  "preparedDigestFor — small (typical pattern-tick boundary)",
+  { group: "preparedDigestFor" },
+  () => {
+    preparedDigestFor(SMALL_INPUT);
+  },
+);
+
+Deno.bench(
+  "preparedDigestFor — large (busy commit with 12 reads, 6 traces, 6 policies)",
+  { group: "preparedDigestFor" },
+  () => {
+    preparedDigestFor(LARGE_INPUT);
+  },
+);
+
+Deno.bench(
+  "canonicalizePreparedDigestInput only — large (sort/comparator cost, no final hash)",
+  { group: "preparedDigestFor" },
+  () => {
+    canonicalizePreparedDigestInput(LARGE_INPUT);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// watchIdForEntry — exercises hashStringOf on a fresh, ad-hoc watch key
+// ---------------------------------------------------------------------------
+
+const WATCH_SCHEMA: JSONSchema = internSchema({
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    body: { type: "string" },
+  },
+});
+
+const WATCH_ADDRESS = {
+  id: `of:doc-watch` as const,
+  type: "application/json" as const,
+};
+
+const WATCH_SELECTOR = {
+  path: ["value", "items"],
+  schema: WATCH_SCHEMA,
+};
+
+Deno.bench(
+  "watchIdForEntry — typical address + interned-schema selector",
+  { group: "watchIdForEntry" },
+  () => {
+    watchIdForEntry(WATCH_ADDRESS, WATCH_SELECTOR, "main");
+  },
+);


### PR DESCRIPTION
## Summary

- Removes `stableHash` / `stableStringify` from `traverse.ts` and switches the four external call sites in `runner` to `hashStringOf()`. `stableHash` was a homegrown structural-fingerprint function strictly narrower than `hashStringOf()` (it doesn't recognize `bigint`, `Map`, `Set`, `Uint8Array`, or `FabricInstance`), so every modern-data-model type that lands in a hashed value would silently miscount under `stableHash`. Every external call site was already pure equality/Map-key use — no round-tripping, no JSON persistence — so the swap is behavior-preserving.
- In `cfc/canonical.ts`, replaces the `stableHash`-based comparator for `writePolicyInputs` with a structurally meaningful `compareWritePolicyInput` (sort by `kind`, then a kind-specific natural sub-key — `target` / `name` / `effectId` — with `hashStringOf()` as a final tiebreaker so the order is total). `stableHash`'s output happened to be lexicographic-by-input, which is what `cfc-boundary.test.ts` was implicitly asserting. The new comparator preserves that natural order for human-readable debug output and matches the structural-comparator pattern already used for every other sort in the file.
- While in `cfc/canonical.ts`, replaces every `String#localeCompare()` with plain codepoint-order `<`/`>` ternaries. `localeCompare()` consults the runtime's default locale — system-dependent — which is a quietly nondeterministic choice for a canonicalizer whose contract is "produce the same output everywhere." Plain `<`/`>` is also faster.
- Adds `packages/runner/test/cfc-canonicalize.bench.ts` covering the touched hot paths. The file matches the glob in `benchmarks.yml`, so once this PR lands and the next push to `main` builds, the bench numbers flow into the bench artifact and from there into `tasks/perf-regression.ts` for drift detection.

## Performance

Apples-to-apples comparison, same machine (Apple M5 Pro, Deno 2.7.8), same bench file copied to a `main`-branch worktree:

| Metric | `main` | this branch | Δ |
| --- | --- | --- | --- |
| `preparedDigestFor` — small (typical pattern-tick) | 4.95 µs | 4.53 µs | **−8%** |
| `preparedDigestFor` — large (12 reads, 6 traces, 6 policies) | 39.47 µs | **25.41 µs** | **−36%** |
| `canonicalizePreparedDigestInput` only — large | 15.29 µs | **2.12 µs** | **−86%** |
| `watchIdForEntry` — typical address + interned schema | 525 ns | 1.56 µs | **+197%** |

Reading these:

- The big win is in `canonicalizePreparedDigestInput` and through it `preparedDigestFor`. Three changes in this PR compound there: the allocation-free `compareAddress` (field-by-field early return instead of building two NUL-joined keys per pair), the `localeCompare()` → `<`/`>` switch (ICU-collation lookup is microseconds; codepoint compare is nanoseconds), and the structural `compareWritePolicyInput` that short-circuits before reaching `hashStringOf()` in the common case. CFC-gated commits hit this on every prepare and again during commit re-check, so this is the path that actually runs a lot.
- The loss is in `watchIdForEntry`, which used to feed an ad-hoc fresh object into `stableHash` (just string-building, no real hashing) and now feeds it into `hashStringOf` (real SHA-256 + base64url). Watch keys aren't deep-frozen, so neither implementation's WeakMap cache helps the per-call cost. 1.6 µs is still well below the noise floor of any test that does subscription work, but it's a real per-call regression. Could be addressed later by memoizing watch IDs at the registration level if it ever shows up.

Net: the change favors the path that runs more often, by a larger margin, with a cleaner correctness story. The watch-id slowdown is real but small and on a less-frequent path.

## Note on perf-check CI visibility

The per-PR Performance Check job (`tasks/perf-check.ts`) consumes only job/step durations and JUnit test-timing artifacts; it doesn't fetch bench artifacts. So this PR's bench numbers won't appear in the perf-check report. Bench drift is tracked separately by the hourly `tasks/perf-regression.ts`, which does ingest the `bench-results` artifact produced by `benchmarks.yml` on each push to `main`. Wiring per-PR perf-check to bench artifacts would require running benchmarks during PR builds, which would be a separate workflow change beyond the scope of this PR.

## Test plan

- [x] `packages/runner` package suite green (429 tests / 2716 steps).
- [x] Full repo suite green (`deno task test` across all 28 packages, ~78s).
- [x] New bench runs locally and produces stable numbers.
- [ ] CI on the full repo.

&#x1F916; Generated with [Claude Code](https://claude.com/claude-code)

