### PR TITLE
perf(memory): skip covered query traversal

### DIFF
--- a/packages/memory/test/v2-query-coverage.bench.ts
+++ b/packages/memory/test/v2-query-coverage.bench.ts
@@ -5,6 +5,7 @@ import type { GraphQuery } from "../v2.ts";
 import { applyCommit, close, type Engine, open } from "../v2/engine.ts";
 import {
   extendTrackedGraph,
+  type QueryTraversalStats,
   refreshTrackedGraph,
   type TrackedGraphState,
   trackGraph,
@@ -17,6 +18,7 @@ const DIRTY_COUNT = Math.max(
   Math.min(DOC_COUNT - 1, Math.floor(DOC_COUNT * (DIRTY_PERCENT / 100))),
 );
 const HIDDEN_COUNT = DIRTY_COUNT;
+const INCLUDE_STATS = readBoolEnv("V2_QUERY_COVERAGE_STATS", true);
 
 const space = "did:key:z6Mk-memory-v2-query-coverage";
 const rootId = "of:v2-query-coverage-root" as URI;
@@ -89,6 +91,16 @@ function readNumberEnv(
   }
 
   return value;
+}
+
+function readBoolEnv(name: string, defaultValue: boolean): boolean {
+  const raw = Deno.env.get(name);
+  if (raw === undefined || raw === "") return defaultValue;
+  if (raw === "1" || raw === "true") return true;
+  if (raw === "0" || raw === "false") return false;
+  throw new Error(
+    `${name} must be one of 1, true, 0, false; got ${JSON.stringify(raw)}`,
+  );
 }
 
 const invocationFor = (localSeq: number) => ({
@@ -243,8 +255,128 @@ async function cleanup(engine: Engine, path: string): Promise<void> {
   await Deno.remove(path);
 }
 
+type DiagnosticCase =
+  | "track-cold"
+  | "extend-covered"
+  | "extend-overlap"
+  | "refresh-leaves"
+  | "refresh-root-stable"
+  | "refresh-root-retargeted";
+
+type Diagnostics = Partial<Record<DiagnosticCase, QueryTraversalStats>>;
+
+async function collectDiagnostics(): Promise<Diagnostics> {
+  if (!INCLUDE_STATS) {
+    return {};
+  }
+
+  const diagnostics: Diagnostics = {};
+
+  {
+    const { engine, path } = await setupSeededEngine();
+    try {
+      diagnostics["track-cold"] = trackGraph(
+        space,
+        engine,
+        graphQuery(),
+      ).stats;
+    } finally {
+      await cleanup(engine, path);
+    }
+  }
+
+  {
+    const { engine, path, tracked } = await setupTrackedEngine();
+    try {
+      diagnostics["extend-covered"] = extendTrackedGraph(
+        space,
+        engine,
+        tracked,
+        graphQuery(baseChildId(0)),
+      ).stats;
+    } finally {
+      await cleanup(engine, path);
+    }
+  }
+
+  {
+    const { engine, path, tracked } = await setupTrackedEngine();
+    try {
+      diagnostics["extend-overlap"] = extendTrackedGraph(
+        space,
+        engine,
+        tracked,
+        graphQuery(overlapRootId),
+      ).stats;
+    } finally {
+      await cleanup(engine, path);
+    }
+  }
+
+  {
+    const { engine, path, tracked } = await setupTrackedEngine();
+    const dirtyIds = baseChildIds().slice(0, DIRTY_COUNT);
+    updateLeaves(engine, dirtyIds, 1);
+    try {
+      diagnostics["refresh-leaves"] = refreshTrackedGraph(
+        space,
+        engine,
+        tracked,
+        new Set(dirtyIds),
+      )?.stats;
+    } finally {
+      await cleanup(engine, path);
+    }
+  }
+
+  {
+    const { engine, path, tracked } = await setupTrackedEngine();
+    updateRoot(engine, rootValue(1), 1);
+    try {
+      diagnostics["refresh-root-stable"] = refreshTrackedGraph(
+        space,
+        engine,
+        tracked,
+        new Set([rootId]),
+      )?.stats;
+    } finally {
+      await cleanup(engine, path);
+    }
+  }
+
+  {
+    const { engine, path, tracked } = await setupTrackedEngine();
+    updateRoot(engine, retargetedRootValue(), 1);
+    try {
+      diagnostics["refresh-root-retargeted"] = refreshTrackedGraph(
+        space,
+        engine,
+        tracked,
+        new Set([rootId]),
+      )?.stats;
+    } finally {
+      await cleanup(engine, path);
+    }
+  }
+
+  return diagnostics;
+}
+
+const diagnostics = await collectDiagnostics();
+
+function withStats(name: string, key: DiagnosticCase): string {
+  const stats = diagnostics[key];
+  if (stats === undefined) {
+    return name;
+  }
+  return `${name}, reads=${stats.managerReads}, traversals=${stats.schemaTraversals}, skips=${stats.coveredSelectorSkips}, memoHits=${stats.schemaMemoHits}`;
+}
+
 Deno.bench({
-  name: `trackGraph cold linked graph - docs=${DOC_COUNT}`,
+  name: withStats(
+    `trackGraph cold linked graph - docs=${DOC_COUNT}`,
+    "track-cold",
+  ),
   group: "v2-query-coverage",
   baseline: true,
   async fn(b) {
@@ -260,8 +392,10 @@ Deno.bench({
 });
 
 Deno.bench({
-  name:
+  name: withStats(
     `extendTrackedGraph already-covered descendant root - docs=${DOC_COUNT}`,
+    "extend-covered",
+  ),
   group: "v2-query-coverage",
   async fn(b) {
     const { engine, path, tracked } = await setupTrackedEngine();
@@ -276,8 +410,10 @@ Deno.bench({
 });
 
 Deno.bench({
-  name:
+  name: withStats(
     `extendTrackedGraph overlapping root - docs=${DOC_COUNT}, new=${HIDDEN_COUNT}`,
+    "extend-overlap",
+  ),
   group: "v2-query-coverage",
   async fn(b) {
     const { engine, path, tracked } = await setupTrackedEngine();
@@ -292,8 +428,10 @@ Deno.bench({
 });
 
 Deno.bench({
-  name:
+  name: withStats(
     `refreshTrackedGraph dirty leaves - docs=${DOC_COUNT}, dirty=${DIRTY_COUNT}`,
+    "refresh-leaves",
+  ),
   group: "v2-query-coverage",
   async fn(b) {
     const { engine, path, tracked } = await setupTrackedEngine();
@@ -310,7 +448,10 @@ Deno.bench({
 });
 
 Deno.bench({
-  name: `refreshTrackedGraph dirty root stable links - docs=${DOC_COUNT}`,
+  name: withStats(
+    `refreshTrackedGraph dirty root stable links - docs=${DOC_COUNT}`,
+    "refresh-root-stable",
+  ),
   group: "v2-query-coverage",
   async fn(b) {
     const { engine, path, tracked } = await setupTrackedEngine();
@@ -326,8 +467,10 @@ Deno.bench({
 });
 
 Deno.bench({
-  name:
+  name: withStats(
     `refreshTrackedGraph dirty root retargeted links - docs=${DOC_COUNT}, new=${HIDDEN_COUNT}`,
+    "refresh-root-retargeted",
+  ),
   group: "v2-query-coverage",
   async fn(b) {
     const { engine, path, tracked } = await setupTrackedEngine();

--- a/packages/memory/test/v2-query-coverage.bench.ts
+++ b/packages/memory/test/v2-query-coverage.bench.ts
@@ -1,0 +1,343 @@
+import { toFileUrl } from "@std/path";
+import type { JSONSchema } from "../../runner/src/builder/types.ts";
+import type { URI } from "../interface.ts";
+import type { GraphQuery } from "../v2.ts";
+import { applyCommit, close, type Engine, open } from "../v2/engine.ts";
+import {
+  extendTrackedGraph,
+  refreshTrackedGraph,
+  type TrackedGraphState,
+  trackGraph,
+} from "../v2/query.ts";
+
+const DOC_COUNT = readIntEnv("V2_QUERY_COVERAGE_DOCS", 1_000, 2);
+const DIRTY_PERCENT = readNumberEnv("V2_QUERY_COVERAGE_DIRTY_PERCENT", 1, 0);
+const DIRTY_COUNT = Math.max(
+  1,
+  Math.min(DOC_COUNT - 1, Math.floor(DOC_COUNT * (DIRTY_PERCENT / 100))),
+);
+const HIDDEN_COUNT = DIRTY_COUNT;
+
+const space = "did:key:z6Mk-memory-v2-query-coverage";
+const rootId = "of:v2-query-coverage-root" as URI;
+const overlapRootId = "of:v2-query-coverage-overlap-root" as URI;
+
+type Link = {
+  "/": {
+    "link@1": {
+      id: URI;
+      path: [];
+      space: string;
+    };
+  };
+};
+
+type NodeValue = {
+  label: string;
+  version: number;
+  children?: Link[];
+};
+
+const nodeSchema = {
+  type: "object",
+  properties: {
+    label: { type: "string" },
+    version: { type: "number" },
+    children: {
+      type: "array",
+      items: { $ref: "#/$defs/node" },
+    },
+  },
+  required: ["label", "version"],
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+const graphSchema = {
+  ...nodeSchema,
+  $defs: {
+    node: nodeSchema,
+  },
+} as const satisfies JSONSchema;
+
+function readIntEnv(name: string, defaultValue: number, min: number): number {
+  const raw = Deno.env.get(name);
+  if (raw === undefined || raw === "") return defaultValue;
+
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min) {
+    throw new Error(
+      `${name} must be an integer >= ${min}; got ${JSON.stringify(raw)}`,
+    );
+  }
+
+  return value;
+}
+
+function readNumberEnv(
+  name: string,
+  defaultValue: number,
+  min: number,
+): number {
+  const raw = Deno.env.get(name);
+  if (raw === undefined || raw === "") return defaultValue;
+
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < min) {
+    throw new Error(
+      `${name} must be a number >= ${min}; got ${JSON.stringify(raw)}`,
+    );
+  }
+
+  return value;
+}
+
+const invocationFor = (localSeq: number) => ({
+  iss: "did:key:alice",
+  aud: "did:key:service",
+  cmd: "/memory/transact",
+  sub: space,
+  args: { localSeq },
+});
+
+const authorization = {
+  signature: "sig:alice",
+  access: { "proof:1": {} },
+};
+
+const baseChildId = (index: number) =>
+  `of:v2-query-coverage-child-${String(index).padStart(8, "0")}` as URI;
+
+const hiddenId = (index: number) =>
+  `of:v2-query-coverage-hidden-${String(index).padStart(8, "0")}` as URI;
+
+const linkTo = (id: URI): Link => ({
+  "/": {
+    "link@1": {
+      id,
+      path: [],
+      space,
+    },
+  },
+});
+
+const baseChildIds = (): URI[] =>
+  Array.from({ length: DOC_COUNT - 1 }, (_, index) => baseChildId(index));
+
+const hiddenIds = (): URI[] =>
+  Array.from({ length: HIDDEN_COUNT }, (_, index) => hiddenId(index));
+
+const rootValue = (version: number, childIds = baseChildIds()): NodeValue => ({
+  label: "root",
+  version,
+  children: childIds.map(linkTo),
+});
+
+const leafValue = (id: URI, version: number): NodeValue => ({
+  label: id,
+  version,
+});
+
+const overlapRootValue = (): NodeValue => {
+  const existing = baseChildIds().slice(0, Math.max(0, DOC_COUNT - 1));
+  existing.splice(0, HIDDEN_COUNT, ...hiddenIds());
+  return {
+    label: "overlap-root",
+    version: 0,
+    children: existing.map(linkTo),
+  };
+};
+
+const retargetedRootValue = (): NodeValue => {
+  const children = baseChildIds();
+  children.splice(0, HIDDEN_COUNT, ...hiddenIds());
+  return rootValue(1, children);
+};
+
+const graphQuery = (id = rootId): GraphQuery => ({
+  roots: [{
+    id,
+    selector: {
+      path: [],
+      schema: graphSchema,
+    },
+  }],
+});
+
+const setOperation = (id: URI, value: NodeValue) => ({
+  op: "set" as const,
+  id,
+  value: { value },
+});
+
+async function createEngine(): Promise<{ engine: Engine; path: string }> {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const engine = await open({ url: toFileUrl(path) });
+  return { engine, path };
+}
+
+function seedGraph(engine: Engine): void {
+  applyCommit(engine, {
+    sessionId: "session:writer",
+    invocation: invocationFor(1),
+    authorization,
+    commit: {
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [
+        setOperation(rootId, rootValue(0)),
+        ...baseChildIds().map((id) => setOperation(id, leafValue(id, 0))),
+        ...hiddenIds().map((id) => setOperation(id, leafValue(id, 0))),
+        setOperation(overlapRootId, overlapRootValue()),
+      ],
+    },
+  });
+}
+
+function updateLeaves(engine: Engine, ids: URI[], version: number): void {
+  applyCommit(engine, {
+    sessionId: "session:writer",
+    invocation: invocationFor(version + 1),
+    authorization,
+    commit: {
+      localSeq: version + 1,
+      reads: { confirmed: [], pending: [] },
+      operations: ids.map((id) => setOperation(id, leafValue(id, version))),
+    },
+  });
+}
+
+function updateRoot(engine: Engine, value: NodeValue, version: number): void {
+  applyCommit(engine, {
+    sessionId: "session:writer",
+    invocation: invocationFor(version + 1),
+    authorization,
+    commit: {
+      localSeq: version + 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [setOperation(rootId, value)],
+    },
+  });
+}
+
+async function setupSeededEngine(): Promise<{
+  engine: Engine;
+  path: string;
+}> {
+  const result = await createEngine();
+  seedGraph(result.engine);
+  return result;
+}
+
+async function setupTrackedEngine(): Promise<{
+  engine: Engine;
+  path: string;
+  tracked: TrackedGraphState;
+}> {
+  const result = await setupSeededEngine();
+  const tracked = trackGraph(space, result.engine, graphQuery()).state;
+  return { ...result, tracked };
+}
+
+async function cleanup(engine: Engine, path: string): Promise<void> {
+  close(engine);
+  await Deno.remove(path);
+}
+
+Deno.bench({
+  name: `trackGraph cold linked graph - docs=${DOC_COUNT}`,
+  group: "v2-query-coverage",
+  baseline: true,
+  async fn(b) {
+    const { engine, path } = await setupSeededEngine();
+    try {
+      b.start();
+      trackGraph(space, engine, graphQuery());
+      b.end();
+    } finally {
+      await cleanup(engine, path);
+    }
+  },
+});
+
+Deno.bench({
+  name:
+    `extendTrackedGraph already-covered descendant root - docs=${DOC_COUNT}`,
+  group: "v2-query-coverage",
+  async fn(b) {
+    const { engine, path, tracked } = await setupTrackedEngine();
+    try {
+      b.start();
+      extendTrackedGraph(space, engine, tracked, graphQuery(baseChildId(0)));
+      b.end();
+    } finally {
+      await cleanup(engine, path);
+    }
+  },
+});
+
+Deno.bench({
+  name:
+    `extendTrackedGraph overlapping root - docs=${DOC_COUNT}, new=${HIDDEN_COUNT}`,
+  group: "v2-query-coverage",
+  async fn(b) {
+    const { engine, path, tracked } = await setupTrackedEngine();
+    try {
+      b.start();
+      extendTrackedGraph(space, engine, tracked, graphQuery(overlapRootId));
+      b.end();
+    } finally {
+      await cleanup(engine, path);
+    }
+  },
+});
+
+Deno.bench({
+  name:
+    `refreshTrackedGraph dirty leaves - docs=${DOC_COUNT}, dirty=${DIRTY_COUNT}`,
+  group: "v2-query-coverage",
+  async fn(b) {
+    const { engine, path, tracked } = await setupTrackedEngine();
+    const dirtyIds = baseChildIds().slice(0, DIRTY_COUNT);
+    updateLeaves(engine, dirtyIds, 1);
+    try {
+      b.start();
+      refreshTrackedGraph(space, engine, tracked, new Set(dirtyIds));
+      b.end();
+    } finally {
+      await cleanup(engine, path);
+    }
+  },
+});
+
+Deno.bench({
+  name: `refreshTrackedGraph dirty root stable links - docs=${DOC_COUNT}`,
+  group: "v2-query-coverage",
+  async fn(b) {
+    const { engine, path, tracked } = await setupTrackedEngine();
+    updateRoot(engine, rootValue(1), 1);
+    try {
+      b.start();
+      refreshTrackedGraph(space, engine, tracked, new Set([rootId]));
+      b.end();
+    } finally {
+      await cleanup(engine, path);
+    }
+  },
+});
+
+Deno.bench({
+  name:
+    `refreshTrackedGraph dirty root retargeted links - docs=${DOC_COUNT}, new=${HIDDEN_COUNT}`,
+  group: "v2-query-coverage",
+  async fn(b) {
+    const { engine, path, tracked } = await setupTrackedEngine();
+    updateRoot(engine, retargetedRootValue(), 1);
+    try {
+      b.start();
+      refreshTrackedGraph(space, engine, tracked, new Set([rootId]));
+      b.end();
+    } finally {
+      await cleanup(engine, path);
+    }
+  },
+});

--- a/packages/memory/test/v2-query-test.ts
+++ b/packages/memory/test/v2-query-test.ts
@@ -365,6 +365,136 @@ Deno.test("memory v2 query reuses a persistent manager cache for shared source g
   }
 });
 
+Deno.test("memory v2 query refresh skips already-covered stable linked docs", async () => {
+  const { engine, path } = await createEngine();
+  const space = "did:key:z6Mk-memory-v2-query-refresh-covered-links";
+  const fixture = createGraphFixture(space);
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:writer",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: fixture.docs.map((doc) => ({
+          op: "set" as const,
+          id: doc.id,
+          value: { value: doc.value },
+        })),
+      },
+    });
+
+    const tracked = trackGraph(space, engine, {
+      roots: [{
+        id: fixture.rootId,
+        selector: {
+          path: [],
+          schema: fixture.schema,
+        },
+      }],
+    });
+
+    const rootDoc = fixture.docs.find((doc) => doc.id === fixture.rootId);
+    assertExists(rootDoc);
+    applyCommit(engine, {
+      sessionId: "session:writer",
+      invocation: invocationFor(2),
+      authorization,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: fixture.rootId,
+          value: {
+            value: {
+              ...rootDoc.value,
+              metadata: { tag: "updated-root" },
+            },
+          },
+        }],
+      },
+    });
+
+    const refreshed = refreshTrackedGraph(
+      space,
+      engine,
+      tracked.state,
+      new Set([fixture.rootId]),
+    );
+    assertExists(refreshed);
+    assertEquals(
+      [...refreshed.updates.values()].map((entity) => entity.id).sort(),
+      [fixture.rootId],
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 query treats schema true as covering narrower selectors", async () => {
+  const { engine, path } = await createEngine();
+  const space = "did:key:z6Mk-memory-v2-query-true-covers-narrower";
+  const rootId = "of:true-covers-narrower-root";
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:writer",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: rootId,
+          value: {
+            value: {
+              child: { label: "already covered" },
+            },
+          },
+        }],
+      },
+    });
+
+    const tracked = trackGraph(space, engine, {
+      roots: [{
+        id: rootId,
+        selector: {
+          path: [],
+          schema: true,
+        },
+      }],
+    });
+    const rootKey = `${space}/${rootId}/application/json`;
+    assertEquals(tracked.state.tracker.get(rootKey)?.size, 1);
+
+    extendTrackedGraph(space, engine, tracked.state, {
+      roots: [{
+        id: rootId,
+        selector: {
+          path: ["child"],
+          schema: {
+            type: "object",
+            properties: {
+              label: { type: "string" },
+            },
+            required: ["label"],
+          },
+        },
+      }],
+    });
+
+    assertEquals(tracked.state.tracker.get(rootKey)?.size, 1);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 query uses a fresh memo for write-triggered refreshes", async () => {
   const { engine, path } = await createEngine();
   const space = "did:key:z6Mk-memory-v2-query-refresh";
@@ -426,7 +556,12 @@ Deno.test("memory v2 query uses a fresh memo for write-triggered refreshes", asy
 
     assertEquals(
       [...refreshed.updates.values()].map((entity) => entity.id).sort(),
-      fixture.expandedReachableIds,
+      [
+        fixture.rootId,
+        ...fixture.expandedReachableIds.filter((id) =>
+          !fixture.initialReachableIds.includes(id)
+        ),
+      ],
     );
   } finally {
     close(engine);

--- a/packages/memory/test/v2-query-test.ts
+++ b/packages/memory/test/v2-query-test.ts
@@ -100,6 +100,63 @@ Deno.test("memory v2 query retains a persistent memo for incremental watch growt
   }
 });
 
+Deno.test("memory v2 query reports read and traversal stats", async () => {
+  const { engine, path } = await createEngine();
+  const space = "did:key:z6Mk-memory-v2-query-stats";
+  const fixture = createGraphFixture(space);
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:writer",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: fixture.docs.map((doc) => ({
+          op: "set" as const,
+          id: doc.id,
+          value: { value: doc.value },
+        })),
+      },
+    });
+
+    const tracked = trackGraph(space, engine, {
+      roots: [{
+        id: fixture.rootId,
+        selector: {
+          path: [],
+          schema: fixture.schema,
+        },
+      }],
+    });
+
+    assertEquals(
+      tracked.stats.managerReads,
+      fixture.initialReachableIds.length,
+    );
+    assert(tracked.stats.schemaTraversals > 0);
+    assertEquals(tracked.stats.coveredSelectorSkips, 0);
+
+    const extended = extendTrackedGraph(space, engine, tracked.state, {
+      roots: [{
+        id: fixture.rootId,
+        selector: {
+          path: [],
+          schema: fixture.schema,
+        },
+      }],
+    });
+
+    assertEquals(extended.stats.managerReads, 0);
+    assertEquals(extended.stats.schemaTraversals, 0);
+    assertEquals(extended.stats.coveredSelectorSkips, 1);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 query does not include linked opaque cells in graph entities", async () => {
   const { engine, path } = await createEngine();
   const space = "did:key:z6Mk-memory-v2-query-opaque-link";

--- a/packages/memory/test/v2-query-test.ts
+++ b/packages/memory/test/v2-query-test.ts
@@ -14,6 +14,7 @@ import {
 } from "../v2/engine.ts";
 import {
   extendTrackedGraph,
+  isGraphQueryCoveredByState,
   queryGraph,
   refreshTrackedGraph,
   trackGraph,
@@ -546,6 +547,84 @@ Deno.test("memory v2 query treats schema true as covering narrower selectors", a
     });
 
     assertEquals(tracked.state.tracker.get(rootKey)?.size, 1);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 query detects graph queries covered by tracked state", async () => {
+  const { engine, path } = await createEngine();
+  const space = "did:key:z6Mk-memory-v2-query-covered-graph";
+  const rootId = "of:covered-graph-root";
+  const otherId = "of:covered-graph-other";
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:writer",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: rootId,
+          value: {
+            value: {
+              child: { label: "already covered" },
+            },
+          },
+        }, {
+          op: "set",
+          id: otherId,
+          value: {
+            value: {
+              child: { label: "not covered" },
+            },
+          },
+        }],
+      },
+    });
+
+    const tracked = trackGraph(space, engine, {
+      roots: [{
+        id: rootId,
+        selector: {
+          path: [],
+          schema: true,
+        },
+      }],
+    });
+
+    assert(isGraphQueryCoveredByState(space, tracked.state, {
+      roots: [{
+        id: rootId,
+        selector: {
+          path: ["child"],
+          schema: {
+            type: "object",
+            properties: {
+              label: { type: "string" },
+            },
+            required: ["label"],
+          },
+        },
+      }],
+    }));
+
+    assertEquals(
+      isGraphQueryCoveredByState(space, tracked.state, {
+        roots: [{
+          id: otherId,
+          selector: {
+            path: [],
+            schema: true,
+          },
+        }],
+      }),
+      false,
+    );
   } finally {
     close(engine);
     await Deno.remove(path);

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -394,6 +394,17 @@ export const extendTrackedGraph = (
   };
 };
 
+export const isGraphQueryCoveredByState = (
+  space: string,
+  state: TrackedGraphState,
+  query: GraphQuery,
+): boolean =>
+  query.roots.every((root) => {
+    const selector = toDocumentSelector(root.selector);
+    const rootKey = toDocKey(space, root.id, "application/json");
+    return schemaTrackerCoversSelector(state.tracker, rootKey, selector);
+  });
+
 export const queryGraph = (
   space: string,
   engine: Engine.Engine,

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -35,6 +35,43 @@ export interface TrackedGraphState {
   manager: EngineObjectManager;
 }
 
+export interface QueryTraversalStats {
+  managerReads: number;
+  coveredSelectorSkips: number;
+  schemaTraversals: number;
+  pointerTraversals: number;
+  arrayTraversals: number;
+  objectTraversals: number;
+  dagTraversals: number;
+  getDocAtPathCalls: number;
+  schemaMemoHits: number;
+}
+
+const createQueryTraversalStats = (): QueryTraversalStats => ({
+  managerReads: 0,
+  coveredSelectorSkips: 0,
+  schemaTraversals: 0,
+  pointerTraversals: 0,
+  arrayTraversals: 0,
+  objectTraversals: 0,
+  dagTraversals: 0,
+  getDocAtPathCalls: 0,
+  schemaMemoHits: 0,
+});
+
+const addTraverserStats = (
+  stats: QueryTraversalStats,
+  traverser: SchemaObjectTraverser<FabricValue>,
+): void => {
+  stats.schemaTraversals += traverser.traverseWithSchemaCalls;
+  stats.pointerTraversals += traverser.traversePointerCalls;
+  stats.arrayTraversals += traverser.traverseArrayCalls;
+  stats.objectTraversals += traverser.traverseObjectCalls;
+  stats.dagTraversals += traverser.traverseDAGCalls;
+  stats.getDocAtPathCalls += traverser.getDocAtPathCalls;
+  stats.schemaMemoHits += traverser.schemaMemoHits;
+};
+
 export class EngineObjectManager implements ObjectStorageManager {
   #attestations = new Map<string, IAttestation>();
   #details = new Map<string, {
@@ -223,6 +260,7 @@ export const trackGraph = (
 ): {
   serverSeq: number;
   state: TrackedGraphState;
+  stats: QueryTraversalStats;
 } => {
   const branch = query.branch ?? "";
   const managerKey = options.readSeq === undefined
@@ -240,6 +278,8 @@ export const trackGraph = (
   const schemaTracker = new MapSetStringToPathSelectors(true);
   const cfc = new ContextualFlowControl();
   const sharedMemo = createSchemaMemo();
+  const stats = createQueryTraversalStats();
+  const readCountBefore = manager.readCount;
 
   for (const root of query.roots) {
     const selector = toDocumentSelector(root.selector);
@@ -254,6 +294,7 @@ export const trackGraph = (
         space,
         schemaTracker,
         sharedMemo,
+        stats,
       );
     } else {
       schemaTracker.add(
@@ -262,6 +303,8 @@ export const trackGraph = (
       );
     }
   }
+
+  stats.managerReads = manager.readCount - readCountBefore;
 
   return {
     serverSeq: Engine.serverSeq(engine),
@@ -277,6 +320,7 @@ export const trackGraph = (
       memo: sharedMemo,
       manager,
     },
+    stats,
   };
 };
 
@@ -288,8 +332,11 @@ export const extendTrackedGraph = (
 ): {
   serverSeq: number;
   updates: Map<QueryDocKey, EntitySnapshot>;
+  stats: QueryTraversalStats;
 } => {
   const manager = state.manager;
+  const stats = createQueryTraversalStats();
+  const readCountBefore = manager.readCount;
   const previouslyLoaded = new Set(
     manager.loadedAddresses().map((address) => `${address.id}/${address.type}`),
   );
@@ -306,6 +353,7 @@ export const extendTrackedGraph = (
       selector,
       state.tracker,
       state.memo,
+      stats,
     );
   }
 
@@ -337,9 +385,12 @@ export const extendTrackedGraph = (
     updates.set(key, snapshot);
   }
 
+  stats.managerReads = manager.readCount - readCountBefore;
+
   return {
     serverSeq: Engine.serverSeq(engine),
     updates,
+    stats,
   };
 };
 
@@ -370,6 +421,7 @@ export const refreshTrackedGraph = (
 ): {
   serverSeq: number;
   updates: Map<QueryDocKey, EntitySnapshot>;
+  stats: QueryTraversalStats;
 } | null => {
   const affectedDocs = new Map<QueryDocKey, Set<SchemaPathSelector>>();
   for (const dirtyId of dirtyIds) {
@@ -385,6 +437,8 @@ export const refreshTrackedGraph = (
 
   const manager = new EngineObjectManager(engine, state.branch);
   const sharedMemo = createSchemaMemo();
+  const stats = createQueryTraversalStats();
+  const readCountBefore = manager.readCount;
 
   for (const key of affectedDocs.keys()) {
     state.tracker.delete(key);
@@ -400,6 +454,7 @@ export const refreshTrackedGraph = (
         selector,
         state.tracker,
         sharedMemo,
+        stats,
       );
     }
   }
@@ -432,9 +487,12 @@ export const refreshTrackedGraph = (
   state.manager.invalidateIds(dirtyIds);
   state.manager.mergeFrom(manager);
 
+  stats.managerReads = manager.readCount - readCountBefore;
+
   return {
     serverSeq: Engine.serverSeq(engine),
     updates,
+    stats,
   };
 };
 
@@ -450,6 +508,7 @@ const loadFactsForDoc = (
   space: string,
   schemaTracker: MapSetStringToPathSelectors,
   sharedMemo: ReturnType<typeof createSchemaMemo>,
+  stats: QueryTraversalStats,
 ) => {
   if (selector.schema === undefined) {
     selector = { ...selector, schema: false };
@@ -458,6 +517,7 @@ const loadFactsForDoc = (
   const docKey = toDocKey(space, fact.address.id, fact.address.type);
   const internedSelector = internPathSelector(selector);
   if (schemaTrackerCoversSelector(schemaTracker, docKey, internedSelector)) {
+    stats.coveredSelectorSkips++;
     return;
   }
   schemaTracker.add(docKey, internedSelector);
@@ -503,6 +563,7 @@ const loadFactsForDoc = (
       sharedMemo,
     );
     traverser.traverse(nextDoc);
+    addTraverserStats(stats, traverser);
   }
 
   loadSource(
@@ -523,6 +584,7 @@ const evaluateTrackedDocument = (
   selector: SchemaPathSelector,
   schemaTracker: MapSetStringToPathSelectors,
   sharedMemo: ReturnType<typeof createSchemaMemo>,
+  stats: QueryTraversalStats,
 ) => {
   const loaded = manager.load(address);
   if (loaded === null || loaded.value === undefined) {
@@ -546,6 +608,7 @@ const evaluateTrackedDocument = (
     space,
     schemaTracker,
     sharedMemo,
+    stats,
   );
 };
 

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -10,6 +10,7 @@ import {
   type ObjectStorageManager,
   SchemaObjectTraverser,
   type SchemaPathSelector,
+  schemaTrackerCoversSelector,
 } from "@commonfabric/runner/traverse";
 import type { JSONSchema } from "../../runner/src/builder/types.ts";
 import { ExtendedStorageTransaction } from "../../runner/src/storage/extended-storage-transaction.ts";
@@ -456,7 +457,7 @@ const loadFactsForDoc = (
 
   const docKey = toDocKey(space, fact.address.id, fact.address.type);
   const internedSelector = internPathSelector(selector);
-  if (schemaTracker.hasValue(docKey, internedSelector)) {
+  if (schemaTrackerCoversSelector(schemaTracker, docKey, internedSelector)) {
     return;
   }
   schemaTracker.add(docKey, internedSelector);

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -32,6 +32,7 @@ import * as Engine from "./engine.ts";
 import {
   cloneTrackedGraphState,
   extendTrackedGraph,
+  isGraphQueryCoveredByState,
   queryGraph,
   type QueryGraphReuseContext,
   refreshTrackedGraph,
@@ -681,6 +682,10 @@ export class Server {
             const entry = toCacheEntry(entity);
             updates.set(cacheKeyForEntity(entry.branch, entry.id), entry);
           }
+          continue;
+        }
+
+        if (isGraphQueryCoveredByState(message.space, existing, query)) {
           continue;
         }
 

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -340,6 +340,46 @@ export class MapSetStringToStrings extends MapSet<string, string> {
   }
 }
 
+const pathStartsWith = (
+  path: readonly string[],
+  prefix: readonly string[],
+): boolean =>
+  prefix.length <= path.length &&
+  prefix.every((part, index) => path[index] === part);
+
+export const schemaTrackerCoversSelector = (
+  schemaTracker: MapSet<string, SchemaPathSelector>,
+  key: string,
+  selector: SchemaPathSelector,
+): boolean => {
+  const internedSelector = selector.schema !== undefined &&
+      Object.isFrozen(selector) && Object.isFrozen(selector.path)
+    ? selector
+    : internPathSelector({
+      path: [...selector.path],
+      schema: selector.schema ?? false,
+    });
+  if (schemaTracker.hasValue(key, internedSelector)) {
+    return true;
+  }
+
+  const existingSelectors = schemaTracker.get(key);
+  if (existingSelectors === undefined) {
+    return false;
+  }
+
+  for (const existing of existingSelectors) {
+    if (
+      existing.schema !== undefined &&
+      ContextualFlowControl.isTrueSchema(existing.schema) &&
+      pathStartsWith(internedSelector.path, existing.path)
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
 export class CycleTracker<K> {
   private partial: Set<K>;
   private expectCycles: boolean;
@@ -698,6 +738,7 @@ export abstract class BaseObjectTraverser {
     protected traverseCells = true,
   ) {}
   protected dagMemo = new Map<string, Immutable<FabricValue>>();
+  private coverageSelectorCache = new Map<string, SchemaPathSelector>();
   traverseDAGCalls = 0;
   getDocAtPathCalls = 0;
   abstract traverse(
@@ -819,21 +860,13 @@ export abstract class BaseObjectTraverser {
     } else if (isRecord(doc.value)) {
       // First, see if we need special handling
       if (isPrimitiveCellLink(doc.value)) {
-        // Check if target doc is already tracked BEFORE calling getAtPath,
-        // since getAtPath/followPointer will add it to schemaTracker
-        let alreadyTracked = false;
-        // If the link didn't have a space/type, make sure we add one
+        // Check coverage before getAtPath/followPointer adds this link target
+        // to schemaTracker.
+        const alreadyTracked = this.isLinkedDocumentCovered(
+          doc,
+          DEFAULT_SELECTOR,
+        );
         const link = parseLink(doc.value, doc.address);
-        if (link.id !== undefined) {
-          const targetKey = `${link.space}/${link.id}/${link.type}`;
-          alreadyTracked = this.schemaTracker.hasValue(
-            targetKey,
-            internPathSelector({
-              path: ["value", ...link.path],
-              schema: true,
-            }),
-          );
-        }
         const [redirDoc, _redirSelector] = this.getDocAtPath(
           doc,
           [],
@@ -973,6 +1006,54 @@ export abstract class BaseObjectTraverser {
     } else {
       return [doc, selector];
     }
+  }
+
+  protected isLinkedDocumentCovered(
+    doc: IMemorySpaceValueAttestation,
+    selector: SchemaPathSelector,
+  ): boolean {
+    const link = parseLink(doc.value, doc.address);
+    if (link?.id === undefined) {
+      return false;
+    }
+
+    const targetSelector = narrowSchema(
+      doc.address.path,
+      selector,
+      ["value", ...(link.path as readonly string[])],
+      this.cfc,
+    );
+    targetSelector.schema = combineOptionalSchema(
+      targetSelector.schema,
+      link.schema,
+    );
+
+    return schemaTrackerCoversSelector(
+      this.schemaTracker,
+      `${link.space}/${link.id}/${link.type}`,
+      this.internCoverageSelector(targetSelector),
+    );
+  }
+
+  private internCoverageSelector(
+    selector: SchemaPathSelector,
+  ): SchemaPathSelector {
+    const schema = selector.schema ?? false;
+    const schemaKey = typeof schema === "boolean"
+      ? String(schema)
+      : hashSchema(schema);
+    const cacheKey = `${selector.path.join("\0")}\0${schemaKey}`;
+    const cached = this.coverageSelectorCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const interned = internPathSelector({
+      path: [...selector.path],
+      schema,
+    });
+    this.coverageSelectorCache.set(cacheKey, interned);
+    return interned;
   }
 
   /**
@@ -2700,6 +2781,18 @@ export class SchemaObjectTraverser<V extends FabricValue>
       // let createdDataURI = false;
       // const maybeLink = parseLink(item, arrayLink);
       if (isPrimitiveCellLink(item)) {
+        const alreadyTracked = this.isLinkedDocumentCovered(
+          curDoc,
+          curSelector,
+        );
+        const link = parseLink(item, curDoc.address);
+        if (
+          this.traverseCells && alreadyTracked && link?.id !== doc.address.id
+        ) {
+          this.tx.read(curDoc.address, READ_FOR_SCHEDULING);
+          arrayObj[index] = null;
+          return true;
+        }
         this.tx.read(curDoc.address, READ_FOR_SCHEDULING);
         const [redirDoc, selector] = this.getDocAtPath(
           curDoc,
@@ -2996,6 +3089,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
   ): TraverseResult<Immutable<FabricValue>> {
     this.traversePointerCalls++;
     const selector = { path: doc.address.path, schema };
+    const alreadyTracked = this.isLinkedDocumentCovered(doc, selector);
 
     // In the case of an opaque cell, we want to skip any deeper reads
     // This means we don't follow any redirects
@@ -3003,6 +3097,14 @@ export class SchemaObjectTraverser<V extends FabricValue>
     if (asCellValues.at(0) === "opaque") {
       const cellLink = getNextCellLink(doc, schema);
       return { ok: this.objectCreator.createObject(cellLink, undefined) };
+    }
+
+    const pointerLink = parseLink(doc.value, doc.address);
+    if (
+      this.traverseCells && alreadyTracked &&
+      pointerLink?.id !== doc.address.id
+    ) {
+      return { ok: null };
     }
 
     const [redirDoc, redirSelector] = this.getDocAtPath(
@@ -3046,6 +3148,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
           : fail(TRAVERSE_FAILURES.undefinedLink);
       }
     }
+
     // For the runtime, where we don't traverse cells, we just want
     // to create a cell object and don't walk into the object beyond
     // what we need to resolve the pointers.


### PR DESCRIPTION
## Summary

- add a focused v2 query coverage benchmark for cold graph tracking, overlapping selector extension, dirty leaf refreshes, dirty root refreshes, and covered watch additions
- report query traversal diagnostics from the benchmark: object-manager reads, schema/object/array/DAG traversal counts, coverage skips, and memo hits
- skip re-traversing linked documents when the target `(doc, path, schema)` is already covered by the watched query set
- skip server-side `watchAdd` graph cloning/growth entirely when the added graph query is already covered by existing tracked state

## Original Optimization Checklist

- **Focused benchmark with counters:** done in `packages/memory/test/v2-query-coverage.bench.ts`; row labels include reads, traversals, coverage skips, and memo hits.
- **Server-side selector coverage checks:** done for traversal and for `watchAdd` before defensive graph cloning.
- **Memo reuse with dirty-id invalidation:** red-tested and trialed, then reverted. In this workload it produced `memoHits=0` and regressed dirty-leaf refreshes because invalidation scanned memo entries without creating useful hits.
- **Transaction bookkeeping probe:** done against the nested-array runner benchmark. The remaining 10k-doc update time is not query traversal and not raw engine apply; the next layer to inspect is the runtime storage session transact/confirmation path.

## Query Benchmark Results

Command:

```sh
V2_QUERY_COVERAGE_DOCS=<N> V2_QUERY_COVERAGE_DIRTY_PERCENT=1 deno bench --no-check --allow-all packages/memory/test/v2-query-coverage.bench.ts
```

1k docs / 1% dirty, final local run:

| Case | Time | Reads | Traversals | Skips | Memo Hits |
| --- | ---: | ---: | ---: | ---: | ---: |
| Cold linked graph | 55.0ms | 1,000 | 3,001 | 0 | 0 |
| Already-covered descendant root | 361.8us | 0 | 3 | 0 | 2 |
| Overlapping root, 10 new docs | 6.0ms | 11 | 34 | 0 | 0 |
| Dirty leaves, 10 docs | 487.9us | 10 | 30 | 0 | 0 |
| Dirty root, stable links | 4.9ms | 1 | 4 | 0 | 0 |
| Dirty root, retargeted links to 10 new docs | 5.4ms | 11 | 34 | 0 | 0 |

10k docs / 1% dirty, final local run:

| Case | Time | Reads | Traversals | Skips | Memo Hits |
| --- | ---: | ---: | ---: | ---: | ---: |
| Cold linked graph | 601.3ms | 10,000 | 30,001 | 0 | 0 |
| Already-covered descendant root | 7.6ms | 0 | 3 | 0 | 2 |
| Overlapping root, 100 new docs | 66.6ms | 101 | 304 | 0 | 0 |
| Dirty leaves, 100 docs | 4.9ms | 100 | 300 | 0 | 0 |
| Dirty root, stable links | 54.5ms | 1 | 4 | 0 | 0 |
| Dirty root, retargeted links to 100 new docs | 60.0ms | 101 | 304 | 0 | 0 |

Earlier before/after timing from this branch still holds: at 10k docs, dirty-root stable links dropped from about `542ms` to about `55ms`, and dirty-root retargeted links dropped from about `577ms` to about `60ms`. The remaining dirty-root cost is linear in scanning the changed root link array; the extra walk of already watched linked documents is gone.

## Memo Reuse Trial

I added the failing test first, implemented a trial that reused `state.memo` during refresh while invalidating dirty doc ids, and benchmarked it. It passed the behavioral test but regressed measured refreshes:

- 1k dirty leaves: about `0.49ms` -> about `0.92ms`
- 10k dirty leaves: about `4.9ms` -> about `9.4ms`
- measured rows still showed `memoHits=0`

That makes memo reuse the wrong first landing change here. The branch keeps fresh refresh memos and the test now pins that behavior.

## Transaction Bookkeeping Probe

Nested-array runner benchmark shape:

```sh
CELL_SET_NESTED_ARRAY_DEPTH=1 CELL_SET_NESTED_ARRAY_WIDTH=100 CELL_SET_NESTED_ARRAY_UPDATE_TRANSACTIONS=10 CELL_SET_NESTED_ARRAY_UPDATE_PERCENT=1 deno bench --no-check --allow-all packages/runner/test/cell-set-nested-array-docs.bench.ts
```

Result: setup for 10,100 docs was about `871ms`; 10 measured update transactions changing 101 docs each took about `423ms` total.

A one-shot timing probe for one 10k-doc / 1% update showed:

| Segment | Time |
| --- | ---: |
| mutate in-memory tree | 8.2ms |
| top-level `Cell.set()` | 1.1ms |
| awaited commit | 107.7ms |
| logged `commitOperations` total | 3.9ms |
| direct memory engine apply for 101 update ops | 2.2ms |

So the remaining nested-array update cost is not schema traversal, not `commitOperations/buildCommit`, not `notifyOptimistic`, and not raw memory engine apply. The next optimization target should be the runtime storage session transact / server confirmation path around the commit.

## Validation

- `deno fmt packages/runner/src/traverse.ts packages/memory/v2/query.ts packages/memory/v2/server.ts packages/memory/test/v2-query-test.ts packages/memory/test/v2-query-coverage.bench.ts`
- `deno check packages/memory/test/v2-query-test.ts packages/memory/test/v2-query-coverage.bench.ts`
- `deno test --allow-all packages/memory/test/v2-query-test.ts`
- `deno test --allow-all packages/memory/test/v2-query-test.ts packages/memory/test/v2-server-test.ts`
- `V2_QUERY_COVERAGE_DOCS=1000 V2_QUERY_COVERAGE_DIRTY_PERCENT=1 deno bench --no-check --allow-all packages/memory/test/v2-query-coverage.bench.ts`
- `V2_QUERY_COVERAGE_DOCS=10000 V2_QUERY_COVERAGE_DIRTY_PERCENT=1 deno bench --no-check --allow-all packages/memory/test/v2-query-coverage.bench.ts`
- `deno task check`
- `deno task test`
- `deno task integration`
