### PR TITLE
Express the CFC address-immutability invariant in the type system

### DIFF
--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -23,9 +23,11 @@ import { cloneCfcLabelView } from "./label-view-core.ts";
  * canonicalize* re-runs on already-canonical input (e.g. during a CFC
  * commit-recheck pass).
  */
-export const canonicalizeLogicalPath = (path: readonly string[]): string[] => {
+export const canonicalizeLogicalPath = (
+  path: readonly string[],
+): readonly string[] => {
   if (path[0] !== "value" && Object.isFrozen(path)) {
-    return path as string[];
+    return path;
   }
   const next = path[0] === "value" ? path.slice(1) : path.slice();
   Object.freeze(next);

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -4,7 +4,7 @@ export type IFCLabel = {
 };
 
 export type CfcLabelViewEntry = {
-  path: string[];
+  path: readonly string[];
   label: IFCLabel;
 };
 

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -60,7 +60,7 @@ const labelAtPath = (
   }
   let match:
     | {
-      path: string[];
+      path: readonly string[];
       label: IFCLabel;
     }
     | undefined;
@@ -121,7 +121,7 @@ const hasPersistedPolicyClaim = (schema: JSONSchema): boolean => {
 
 const claimPathToLogicalPath = (
   claim: unknown,
-): string[] | undefined => {
+): readonly string[] | undefined => {
   if (
     Array.isArray(claim) &&
     claim.every((segment) => typeof segment === "string")
@@ -392,7 +392,7 @@ const linkWriteCoversAffectedPath = (
 
 const linkWritesCoverCfcAffectedPaths = (
   metadata: CfcMetadata,
-  writePaths: readonly string[][],
+  writePaths: readonly (readonly string[])[],
   inputs: readonly LinkWritePolicyInput[],
 ): boolean =>
   writePaths.every((writePath) =>
@@ -487,11 +487,21 @@ const valueWriteTargets = (
   tx: IExtendedStorageTransaction,
 ): Map<
   string,
-  { space: MemorySpace; id: URI; type: MediaType; paths: string[][] }
+  {
+    space: MemorySpace;
+    id: URI;
+    type: MediaType;
+    paths: (readonly string[])[];
+  }
 > => {
   const result = new Map<
     string,
-    { space: MemorySpace; id: URI; type: MediaType; paths: string[][] }
+    {
+      space: MemorySpace;
+      id: URI;
+      type: MediaType;
+      paths: (readonly string[])[];
+    }
   >();
   const log = tx.getReactivityLog?.();
   const seenWriteSpaces = new Set<MemorySpace>(
@@ -532,8 +542,10 @@ const valueWriteTargets = (
 
 const walkIfcSchema = (
   schema: JSONSchema,
-  path: string[] = [],
-  entries: Array<{ path: string[]; label: IFCLabel; schema: JSONSchema }> = [],
+  path: readonly string[] = [],
+  entries: Array<
+    { path: readonly string[]; label: IFCLabel; schema: JSONSchema }
+  > = [],
 ): typeof entries => {
   if (typeof schema === "boolean") {
     return entries;
@@ -616,7 +628,7 @@ const unsupportedTrustSensitiveReason = (
 
 const exactCopySourcePath = (
   schema: JSONSchema,
-): string[] | undefined => {
+): readonly string[] | undefined => {
   if (!isRecord(schema) || !isRecord(schema.ifc)) {
     return undefined;
   }
@@ -842,7 +854,7 @@ const persistedLabelFromSchemaAtPath = (
   const logicalPath = canonicalizeLogicalPath(path);
   const entries = walkIfcSchema(schema);
   let match:
-    | { path: string[]; label: IFCLabel; schema: JSONSchema }
+    | { path: readonly string[]; label: IFCLabel; schema: JSONSchema }
     | undefined;
   for (const entry of entries) {
     if (!isPrefix(entry.path, logicalPath)) {
@@ -961,9 +973,12 @@ const cloneLabel = (label: IFCLabel): IFCLabel => ({
 });
 
 const coalesceLabelEntries = (
-  entries: Array<{ path: string[]; label: IFCLabel }>,
-): Array<{ path: string[]; label: IFCLabel }> => {
-  const byPath = new Map<string, { path: string[]; label: IFCLabel }>();
+  entries: ReadonlyArray<{ path: readonly string[]; label: IFCLabel }>,
+): Array<{ path: readonly string[]; label: IFCLabel }> => {
+  const byPath = new Map<
+    string,
+    { path: readonly string[]; label: IFCLabel }
+  >();
   for (const entry of entries) {
     const path = [...entry.path];
     const key = pathKey(path);

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema } from "../builder/types.ts";
 import type { FabricValue, MemorySpace } from "@commonfabric/memory/interface";
+import type { Immutable } from "@commonfabric/utils/types";
 import type { Metadata } from "../storage/interface.ts";
 import type { CfcLabelView, IFCLabel } from "./label-view-core.ts";
 
@@ -108,7 +109,7 @@ export type CfcMetadata = {
   labelMap: {
     version: 1;
     entries: Array<{
-      path: string[];
+      path: readonly string[];
       label: IFCLabel;
     }>;
   };
@@ -120,24 +121,32 @@ export type EntityDocumentWithCfc = {
   cfc?: CfcMetadata;
 };
 
-export type CfcAddress = {
+// CFC value types are deeply immutable by contract. The chokepoints
+// that produce them (`canonicalizeLogicalPath()`, the `record*` /
+// `set*` methods on `IExtendedStorageTransaction`, and
+// `buildPreparedDigestInput()`) deep-freeze every record they emit,
+// and the `Immutable<>` wrappers below pin the same shape into the
+// type system so consumers see the invariant statically.
+export type CfcAddress = Immutable<{
   space: MemorySpace;
   id: string;
   path: string[];
-};
+}>;
 
-export type ConsumedRead = CfcAddress & {
-  meta?: Metadata;
-  nonRecursive?: boolean;
-};
+export type ConsumedRead =
+  & CfcAddress
+  & Immutable<{
+    meta?: Metadata;
+    nonRecursive?: boolean;
+  }>;
 
 export type AttemptedWrite = CfcAddress;
 
-export type CfcDereferenceTrace = {
+export type CfcDereferenceTrace = Immutable<{
   source: CfcAddress;
   target: CfcAddress;
   kind: "value" | "write-redirect";
-};
+}>;
 
 export type ImplementationIdentity =
   | { kind: "builtin"; builtinId: string }
@@ -157,53 +166,61 @@ export type TrustSnapshot = {
   revision?: string;
 };
 
+// `WritePolicyInput` is field-level `readonly` rather than `Immutable<>`
+// because its `link-write` variant carries a `CfcLabelView` whose
+// implementation-side helpers (`cloneCfcLabelView()`,
+// `hasCfcLabelValues()`, etc.) operate on the mutable shape; pulling
+// those into `Immutable<>` would cascade further than this cleanup
+// pass. The runtime invariant still holds (the chokepoint
+// `deepFreeze()` covers the whole record); this just keeps the type
+// surface narrower.
 export type WritePolicyInput =
   | {
-    kind: "schema";
-    target: CfcAddress;
-    schemaHash?: string;
-    schema?: JSONSchema;
+    readonly kind: "schema";
+    readonly target: CfcAddress;
+    readonly schemaHash?: string;
+    readonly schema?: JSONSchema;
   }
   | {
-    kind: "structural-provenance";
-    target: CfcAddress;
-    claim: string;
-    sources: CfcAddress[];
+    readonly kind: "structural-provenance";
+    readonly target: CfcAddress;
+    readonly claim: string;
+    readonly sources: readonly CfcAddress[];
   }
   | {
-    kind: "trusted-event";
-    target: CfcAddress;
-    eventId: string;
-    provenance?: FabricValue;
+    readonly kind: "trusted-event";
+    readonly target: CfcAddress;
+    readonly eventId: string;
+    readonly provenance?: FabricValue;
   }
   | {
-    kind: "link-write";
-    target: CfcAddress;
-    source: CfcAddress;
-    linkSchema?: JSONSchema;
-    cfcLabelView?: CfcLabelView;
+    readonly kind: "link-write";
+    readonly target: CfcAddress;
+    readonly source: CfcAddress;
+    readonly linkSchema?: JSONSchema;
+    readonly cfcLabelView?: CfcLabelView;
   }
   | {
-    kind: "sink-request";
-    effectId: string;
-    sink: string;
-    request: FabricValue;
+    readonly kind: "sink-request";
+    readonly effectId: string;
+    readonly sink: string;
+    readonly request: FabricValue;
   }
   | {
-    kind: "custom";
-    target?: CfcAddress;
-    name: string;
-    value: FabricValue;
+    readonly kind: "custom";
+    readonly target?: CfcAddress;
+    readonly name: string;
+    readonly value: FabricValue;
   };
 
 export type PreparedDigestInput = {
-  consumedReads: ConsumedRead[];
-  potentialWrites: AttemptedWrite[];
-  writes: AttemptedWrite[];
-  dereferenceTraces: CfcDereferenceTrace[];
-  writePolicyInputs: WritePolicyInput[];
-  implementationIdentity?: ImplementationIdentity;
-  trustSnapshot?: TrustSnapshot;
+  readonly consumedReads: readonly ConsumedRead[];
+  readonly potentialWrites: readonly AttemptedWrite[];
+  readonly writes: readonly AttemptedWrite[];
+  readonly dereferenceTraces: readonly CfcDereferenceTrace[];
+  readonly writePolicyInputs: readonly WritePolicyInput[];
+  readonly implementationIdentity?: ImplementationIdentity;
+  readonly trustSnapshot?: TrustSnapshot;
 };
 
 export type PostCommitSideEffect = {

--- a/packages/runner/test/cfc-canonicalize.bench.ts
+++ b/packages/runner/test/cfc-canonicalize.bench.ts
@@ -51,7 +51,7 @@ const freezePolicies = (
 // canonicalize cost paid once at the chokepoint; warm variants measure
 // the steady-state per-`preparedDigestFor` cost.
 const warm = (input: PreparedDigestInput): PreparedDigestInput => {
-  const warmAddr = <T extends { path: string[] }>(a: T): T =>
+  const warmAddr = <T extends { path: readonly string[] }>(a: T): T =>
     deepFreeze({ ...a, path: canonicalizeLogicalPath(a.path) });
   return deepFreeze({
     consumedReads: input.consumedReads.map(warmAddr),

--- a/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
+++ b/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
@@ -127,7 +127,7 @@ export const formatCfcLabelAtom = (value: unknown): string => {
   return JSON.stringify(value);
 };
 
-const formatPath = (path: string[]): string =>
+const formatPath = (path: readonly string[]): string =>
   path.length === 0 ? "/" : `/${path.join("/")}`;
 
 /**


### PR DESCRIPTION
## Summary

Cleanup pass following #3480, which `deepFreeze()`s every `CfcAddress` flowing into a `PreparedDigestInput` at the runtime chokepoints. Now the type system reflects that contract — same spirit as `JSONSchemaObj`, which is effectively-immutable mostly by virtue of a lot of `readonly` markers — so consumers see the invariant statically and can no longer accidentally type a mutating call site.

## Changes

### `packages/runner/src/cfc/types.ts`

- **`CfcAddress`** and **`ConsumedRead`** are wrapped in `Immutable<>` (from `@commonfabric/utils/types`). Their `path` arrays become `readonly string[]`, every field is `readonly`, and (for `ConsumedRead.meta`) nested record values are recursively readonly.
- **`CfcDereferenceTrace`** is `Immutable<>`-wrapped for the same reason — its `source` and `target` are `CfcAddress`-shaped.
- **`WritePolicyInput`** uses field-level `readonly` markers (plus `readonly CfcAddress[]` for `sources`) rather than `Immutable<>`. Its `link-write` variant carries a `CfcLabelView` whose consumer helpers (`cloneCfcLabelView()` / `hasCfcLabelValues()`, etc.) operate on the mutable shape, and pulling those into `Immutable<>` would cascade further than a cleanup pass should. The runtime invariant still holds (the chokepoint `deepFreeze()` covers the whole record); the type surface is just narrower than for the address-bearing types.
- **`PreparedDigestInput`**'s array fields become `readonly` arrays of the appropriate readonly element types.
- **`CfcMetadata.labelMap.entries[].path`** and the parallel **`CfcLabelViewEntry.path`** are `readonly string[]`, matching what `canonicalizeLogicalPath()` actually returns.

### `packages/runner/src/cfc/canonical.ts`

- **`canonicalizeLogicalPath()`** return type is now `readonly string[]` (instead of `string[]` with an `as` cast), so the signature matches the runtime invariant. The `Object.freeze()` call is unchanged.

### `packages/runner/src/cfc/prepare.ts`

- Helpers that produce or shuttle canonical paths (`claimPathToLogicalPath`, `exactCopySourcePath`, `walkIfcSchema`, `coalesceLabelEntries`, `linkWritesCoverCfcAffectedPaths`, `valueWriteTargets`, plus several inline `let match: ...` declarations) get their `path` / `paths` fields retyped to `readonly string[]` (or `readonly (readonly string[])[]` for `valueWriteTargets`'s `paths`).

### `packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts`

- `formatPath()`'s parameter is now `readonly string[]` — matches what it receives from `CfcLabelViewEntry`.

### `packages/runner/test/cfc-canonicalize.bench.ts`

- Bench-only helper `warm()`'s inner generic is updated from `<T extends { path: string[] }>` to `<T extends { path: readonly string[] }>`.

## Why this is small

Notably no functional changes. Every site touched here was already not mutating these arrays at runtime — `#3478` and `#3480` had already established the chokepoint freezes — the type system just hadn't been told yet. The cascade was contained: 6 files, no test changes needed.

## Test plan

- [x] `deno task test` (full repo, ~70s) passes
- [x] `deno check` clean across `packages/runner`
- [ ] CI on the full repo

&#x1F916; Generated with [Claude Code](https://claude.com/claude-code)
