### PR TITLE
Expose cf-harness sandbox image selection

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -35,6 +35,7 @@ What works today:
 - default sandbox image aligned with the public CFC kitchen-sink image published
   from the sibling `gvisor` repo:
   - `us-docker.pkg.dev/commontools-core/common-fabric/sandbox-kitchensink:latest`
+  - override per run with `--sandbox-image` or `CF_HARNESS_SANDBOX_IMAGE`
 - built-in tools:
   - `bash`
   - `bash-no-sandbox` (provisional host shell for named subagent profiles only)
@@ -166,6 +167,21 @@ deno task run -- \
   --prompt "Build this pattern."
 ```
 
+Sandbox image override:
+
+```bash
+deno task run -- \
+  --workspace /path/to/common-fabric-2 \
+  --cwd pattern-factory \
+  --gateway-auth-mode none \
+  --sandbox-image registry.example/cf-harness-sandbox:deno2 \
+  --prompt "Run deno task cf --help and report whether it works."
+```
+
+Use this for Deno 2 / Common Fabric CLI validation while keeping the mounted
+workspace as the source of truth for Labs, Pattern Factory, and Loom code. Run
+reports include the selected sandbox image in the capability snapshot.
+
 Loom-backed batch runs may also pass a retained manifest:
 
 ```bash
@@ -279,6 +295,21 @@ deno task test:integration
 The integration suite requires a working local Docker + `runsc-cfc` environment.
 By default it also uses the published kitchen-sink image above, unless you
 override `CF_HARNESS_INTEGRATION_IMAGE`.
+
+To opt into a local Labs CLI smoke inside the sandbox, use a Deno 2-compatible
+image and enable the CF CLI case:
+
+```bash
+cd packages/cf-harness
+CF_HARNESS_INTEGRATION_IMAGE=registry.example/cf-harness-sandbox:deno2 \
+CF_HARNESS_INTEGRATION_CF_CLI=1 \
+deno task test:integration
+```
+
+That case mounts the current Labs checkout as `/workspace` and runs
+`deno task cf --help` inside the `runsc-cfc` sandbox. It is skipped by default
+because the published kitchen-sink image may not have the required Deno version
+or cache state.
 
 To also exercise a real host Fabric FUSE mount bind-mounted into the sandbox at
 `/fabric`, start `cf fuse mount` separately and pass the mountpoint:

--- a/packages/cf-harness/integration/engine.integration.test.ts
+++ b/packages/cf-harness/integration/engine.integration.test.ts
@@ -1,4 +1,5 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { fromFileUrl } from "@std/path";
 import type { CfcEnforcementMode, IFCLabel } from "@commonfabric/runner/cfc";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
@@ -27,6 +28,9 @@ const FABRIC_MOUNT = Deno.env.get("CF_HARNESS_INTEGRATION_FABRIC_MOUNT");
 const FABRIC_INTEGRATION = INTEGRATION &&
   FABRIC_MOUNT !== undefined &&
   FABRIC_MOUNT.trim() !== "";
+const CF_CLI_INTEGRATION = INTEGRATION &&
+  Deno.env.get("CF_HARNESS_INTEGRATION_CF_CLI") === "1";
+const LABS_ROOT_URL = new URL("../../..", import.meta.url);
 
 const defaultCfcPolicyFile = (): string => {
   const home = Deno.env.get("HOME");
@@ -55,6 +59,9 @@ const makeIntegrationTempDir = async (prefix: string): Promise<string> =>
     prefix,
     dir: await integrationTempRoot(),
   });
+
+const labsRootPath = (): Promise<string> =>
+  Deno.realPath(fromFileUrl(LABS_ROOT_URL));
 
 interface WithHarnessOptions {
   cfcEnforcementMode?: CfcEnforcementMode;
@@ -210,6 +217,32 @@ Deno.test({
       },
       { cfcEnforcementMode: "observe" },
     );
+  },
+});
+
+Deno.test({
+  name: "cf-harness integration: local Labs deno task cf help runs in sandbox",
+  ignore: !CF_CLI_INTEGRATION,
+  permissions: { env: true, read: true, run: true, write: true },
+  async fn() {
+    await assertRunscRuntimeAvailable();
+    const engine = new CfHarnessEngine({
+      runId: "integration-cf-cli-help",
+      cfcEnforcementMode: "observe",
+      sandbox: resolveDockerRunscSandboxConfig({
+        workspaceHostPath: await labsRootPath(),
+        runtimeName: DOCKER_RUNTIME,
+        image: DOCKER_IMAGE,
+      }),
+    });
+
+    const result = await engine.invokeBuiltinTool("bash", {
+      command: "deno task cf --help",
+      timeoutMs: 120_000,
+    });
+    assertEquals(result.output.exitCode, 0);
+    assertStringIncludes(result.output.stdout, "Usage:");
+    assertStringIncludes(result.output.stdout, "cf");
   },
 });
 

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -33,7 +33,10 @@ import type {
   HarnessTranscriptMessage,
 } from "./contracts/transcript.ts";
 import { CfHarnessEngine } from "./engine.ts";
-import { DEFAULT_FABRIC_MOUNT_PATH } from "./sandbox/docker-runsc.ts";
+import {
+  DEFAULT_DOCKER_RUNSC_IMAGE,
+  DEFAULT_FABRIC_MOUNT_PATH,
+} from "./sandbox/docker-runsc.ts";
 import {
   CfHarnessPromptLoop,
   type CreateHarnessPromptLoopOptions,
@@ -79,6 +82,7 @@ export interface CfHarnessCliConfig {
   printTranscript: boolean;
   apiKey?: string;
   apiKeySource?: "CF_HARNESS_API_KEY" | "OPENAI_API_KEY";
+  sandboxImage?: string;
   fabricMount?: string;
 }
 
@@ -200,6 +204,7 @@ Options:
   --result-json-path <path>     Optional structured result sidecar path
   --run-manifest <path>         Optional Loom run manifest JSON path
   --cfc-enforcement-mode <mode> disabled | observe | enforce-explicit | enforce-strict
+  --sandbox-image <image>       Docker image for the runsc-cfc sandbox (default: ${DEFAULT_DOCKER_RUNSC_IMAGE})
   --fabric-mount <path>         Host path for a Fabric FUSE mount (mounted at /fabric in the sandbox)
   --max-model-turns <n>         Maximum model turns before aborting
   --print-transcript            Print the final transcript JSON after the response
@@ -209,6 +214,7 @@ Environment:
   CF_HARNESS_API_KEY            Preferred API key for the OpenAI-compatible gateway
   OPENAI_API_KEY                Fallback API key if CF_HARNESS_API_KEY is unset
   CF_HARNESS_DOCKER_NETWORK_MODE none | bridge | host (default: bridge)
+  CF_HARNESS_SANDBOX_IMAGE      Default value for --sandbox-image
 `;
 
 const parsePositiveInteger = (
@@ -430,6 +436,7 @@ export const parseCfHarnessCliArgs = async (
       "result-json-path",
       "run-manifest",
       "cfc-enforcement-mode",
+      "sandbox-image",
       "max-model-turns",
       "fabric-mount",
     ],
@@ -567,7 +574,16 @@ export const parseCfHarnessCliArgs = async (
         "CF_HARNESS_CFC_ENFORCEMENT_MODE",
       ),
       CF_CFC_MODE: Deno.env.get("CF_CFC_MODE"),
+      CF_HARNESS_SANDBOX_IMAGE: Deno.env.get("CF_HARNESS_SANDBOX_IMAGE"),
     };
+  const rawSandboxImage = typeof args["sandbox-image"] === "string"
+    ? args["sandbox-image"].trim()
+    : undefined;
+  if (rawSandboxImage !== undefined && rawSandboxImage === "") {
+    throw new Error("--sandbox-image requires a non-empty image reference");
+  }
+  const sandboxImage = rawSandboxImage ??
+    nonEmptyEnvValue(env.CF_HARNESS_SANDBOX_IMAGE);
   const explicitCfcMode = typeof args["cfc-enforcement-mode"] === "string"
     ? args["cfc-enforcement-mode"]
     : undefined;
@@ -639,6 +655,7 @@ export const parseCfHarnessCliArgs = async (
     printTranscript: Boolean(args["print-transcript"]),
     ...(apiKey !== undefined ? { apiKey } : {}),
     ...(apiKeySource !== undefined ? { apiKeySource } : {}),
+    ...(sandboxImage !== undefined ? { sandboxImage } : {}),
     ...(fabricMount !== undefined ? { fabricMount } : {}),
   };
 };
@@ -1001,6 +1018,9 @@ export const runCfHarnessCli = async (
         runState: artifacts.runState,
         artifactRoot: parsed.artifactRoot,
         workspaceHostPath: parsed.workspace,
+        ...(parsed.sandboxImage !== undefined
+          ? { sandboxImage: parsed.sandboxImage }
+          : {}),
         model: parsed.model ?? artifacts.runState.model,
         gatewayBaseUrl: parsed.gatewayBaseUrl,
         gatewayAuthMode: parsed.gatewayAuthMode,
@@ -1064,6 +1084,9 @@ export const runCfHarnessCli = async (
       const engine = new CfHarnessEngine({
         workspaceHostPath: parsed.workspace,
         artifactRoot: parsed.artifactRoot,
+        ...(parsed.sandboxImage !== undefined
+          ? { sandboxImage: parsed.sandboxImage }
+          : {}),
         model: parsed.model,
         gatewayBaseUrl: parsed.gatewayBaseUrl,
         gatewayAuthMode: parsed.gatewayAuthMode,

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -136,6 +136,7 @@ export interface CreateHarnessEngineOptions
   runId?: string;
   runState?: HarnessRunState;
   workspaceHostPath?: string;
+  sandboxImage?: string;
   additionalMounts?: readonly DockerRunscAdditionalMountConfig[];
   sandboxRuntime?: SandboxRuntime;
   artifactStore?: HarnessArtifactStore;
@@ -160,6 +161,7 @@ const isToolOutputWithId = (value: unknown): value is ToolOutputWithId =>
 const resolveSandboxConfig = (
   config: HarnessConfig,
   workspaceHostPath?: string,
+  sandboxImage?: string,
   additionalMounts?: readonly DockerRunscAdditionalMountConfig[],
 ): HarnessSandboxConfig => {
   if (config.sandbox !== undefined) {
@@ -172,6 +174,7 @@ const resolveSandboxConfig = (
   }
   return resolveDockerRunscSandboxConfig({
     workspaceHostPath,
+    ...(sandboxImage !== undefined ? { image: sandboxImage } : {}),
     ...(additionalMounts !== undefined && additionalMounts.length > 0
       ? { additionalMounts }
       : {}),
@@ -258,6 +261,7 @@ export class CfHarnessEngine {
       ? resolveSandboxConfig(
         this.config,
         options.workspaceHostPath,
+        options.sandboxImage,
         options.additionalMounts,
       )
       : this.config.sandbox;

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -526,6 +526,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
       cfc: {
         runtimeRequested: true,
         runtimeName: this.config.runtimeName,
+        image: this.config.image,
         workspaceMountPath: this.config.workspaceMountPath,
         mounts: this.#mountDescriptions(),
         networkMode: this.config.dockerNetworkMode,

--- a/packages/cf-harness/src/sandbox/types.ts
+++ b/packages/cf-harness/src/sandbox/types.ts
@@ -99,6 +99,7 @@ export interface SandboxRuntimeDescription {
   cfc?: {
     runtimeRequested: boolean;
     runtimeName?: string;
+    image?: string;
     workspaceMountPath?: string;
     mounts?: readonly SandboxRuntimeMountDescription[];
     networkMode?: DockerNetworkMode;

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -63,6 +63,7 @@ Deno.test("parseCfHarnessCliArgs resolves defaults from cwd and positional promp
   assertEquals(parsed.artifactRoot, "/tmp/project/.cf-harness-artifacts");
   assertEquals(parsed.maxModelTurns, 8);
   assertEquals(parsed.printTranscript, false);
+  assertEquals(parsed.sandboxImage, undefined);
 });
 
 Deno.test("parseCfHarnessCliArgs supports prompt files and mode overrides", async () => {
@@ -1969,6 +1970,51 @@ Deno.test("parseCfHarnessCliArgs resolves fabric-mount to an absolute path", asy
   assertEquals(parsed.fabricMount, "/tmp/cf-fuse");
 });
 
+Deno.test("parseCfHarnessCliArgs supports sandbox image flag", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    ["--prompt", "hi", "--sandbox-image", "registry.example/cf:deno2"],
+    { cwd: "/tmp/project", env: {} },
+  );
+  if ("help" in parsed) throw new Error("expected config result");
+  assertEquals(parsed.sandboxImage, "registry.example/cf:deno2");
+});
+
+Deno.test("parseCfHarnessCliArgs supports sandbox image environment default", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    ["--prompt", "hi"],
+    {
+      cwd: "/tmp/project",
+      env: { CF_HARNESS_SANDBOX_IMAGE: "registry.example/cf:local" },
+    },
+  );
+  if ("help" in parsed) throw new Error("expected config result");
+  assertEquals(parsed.sandboxImage, "registry.example/cf:local");
+});
+
+Deno.test("parseCfHarnessCliArgs prefers sandbox image flag over environment", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    ["--prompt", "hi", "--sandbox-image", "registry.example/cf:flag"],
+    {
+      cwd: "/tmp/project",
+      env: { CF_HARNESS_SANDBOX_IMAGE: "registry.example/cf:env" },
+    },
+  );
+  if ("help" in parsed) throw new Error("expected config result");
+  assertEquals(parsed.sandboxImage, "registry.example/cf:flag");
+});
+
+Deno.test("parseCfHarnessCliArgs rejects empty sandbox image value", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        ["--prompt", "hi", "--sandbox-image", ""],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "--sandbox-image requires a non-empty image reference",
+  );
+});
+
 Deno.test("parseCfHarnessCliArgs omits fabricMount when flag is absent", async () => {
   const parsed = await parseCfHarnessCliArgs(
     ["--prompt", "hi"],
@@ -2086,5 +2132,63 @@ Deno.test("runCfHarnessCli threads fabric-mount into engine additionalMounts", a
       "A Common Fabric space is mounted at /fabric",
     ),
     true,
+  );
+});
+
+Deno.test("runCfHarnessCli threads sandbox-image into engine sandbox config", async () => {
+  const { io, stderr } = createIoBuffers();
+  let createdOptions: Record<string, unknown> | undefined;
+  const exitCode = await runCfHarnessCli(
+    [
+      "--workspace",
+      "/tmp/project",
+      "--prompt",
+      "Inspect the workspace",
+      "--sandbox-image",
+      "registry.example/cf:deno2",
+      "--gateway-auth-mode",
+      "none",
+    ],
+    {
+      io,
+      env: {},
+      createPromptLoop: (options) => {
+        createdOptions = options as Record<string, unknown>;
+        return {
+          runPrompt: () =>
+            Promise.resolve(
+              ({
+                model: "gpt-5.4",
+                finalAssistantText: "Done.",
+                transcript: [
+                  { role: "user", content: "Inspect the workspace" },
+                  { role: "assistant", content: "Done." },
+                ],
+                modelTurns: 1,
+                runState: {
+                  runId: "run-sandbox-image",
+                  status: "completed",
+                  createdAt: "2026-05-01T00:00:00.000Z",
+                  updatedAt: "2026-05-01T00:00:01.000Z",
+                  cfcEnforcementMode: "disabled",
+                  currentDir: "/workspace",
+                  policyEvents: [],
+                  toolOutputs: [],
+                },
+              }) satisfies HarnessPromptLoopResult,
+            ),
+          runTranscript: () =>
+            Promise.reject(new Error("unexpected resume path")),
+        };
+      },
+    },
+  );
+
+  assertEquals(exitCode, 0);
+  assertEquals(stderr, []);
+  const engine = createdOptions?.engine as CfHarnessEngine | undefined;
+  assertEquals(
+    engine?.sandbox.describe?.()?.cfc?.image,
+    "registry.example/cf:deno2",
   );
 });

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -167,6 +167,7 @@ Deno.test("DockerRunscSandboxRuntime describe preserves custom CFC runtime alias
     resolveDockerRunscSandboxConfig({
       workspaceHostPath: "/host/project",
       runtimeName: "corp-runsc-prod",
+      image: "sandbox:deno2",
     }),
   );
   const description = runtime.describe();
@@ -176,6 +177,7 @@ Deno.test("DockerRunscSandboxRuntime describe preserves custom CFC runtime alias
 
   assertEquals(description.cfc.runtimeRequested, true);
   assertEquals(description.cfc.runtimeName, "corp-runsc-prod");
+  assertEquals(description.cfc.image, "sandbox:deno2");
 });
 
 Deno.test("resolveDockerRunscSandboxConfig normalizes a Fabric FUSE mount", () => {

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -113,6 +113,18 @@ Deno.test("CfHarnessEngine builds a default docker-runsc sandbox when given a wo
   });
 });
 
+Deno.test("CfHarnessEngine accepts a default sandbox image override", () => {
+  const engine = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    sandboxImage: "registry.example/cf:deno2",
+  });
+
+  assertEquals(
+    engine.sandbox.describe?.()?.cfc?.image,
+    "registry.example/cf:deno2",
+  );
+});
+
 Deno.test("CfHarnessEngine lets bash-no-sandbox host commands handle missing workspace paths", async () => {
   const workspaceHostPath = await Deno.makeTempDir({
     prefix: "cf-harness-engine-missing-",


### PR DESCRIPTION
## Summary
- add cf-harness CLI/config plumbing for selecting the runsc-cfc sandbox image via --sandbox-image or CF_HARNESS_SANDBOX_IMAGE
- thread the selected image into engine sandbox config and run diagnostics
- add an opt-in integration smoke that runs deno task cf --help inside runsc-cfc

## Validation
- deno fmt packages/cf-harness/README.md packages/cf-harness/src/cli.ts packages/cf-harness/src/engine.ts packages/cf-harness/src/sandbox/docker-runsc.ts packages/cf-harness/src/sandbox/types.ts packages/cf-harness/test/cli.test.ts packages/cf-harness/test/docker-runsc-sandbox.test.ts packages/cf-harness/test/engine.test.ts packages/cf-harness/integration/engine.integration.test.ts
- deno check packages/cf-harness/src/main.ts packages/cf-harness/integration/engine.integration.test.ts
- git diff --check
- deno task run -- --help
- deno task test, from packages/cf-harness: 242 passed
- deno test -A integration/engine.integration.test.ts, from packages/cf-harness with env gates unset: 7 ignored
- deno task check
- docker pull us-docker.pkg.dev/commontools-core/common-fabric/sandbox-kitchensink:latest
- docker run --rm us-docker.pkg.dev/commontools-core/common-fabric/sandbox-kitchensink:latest deno --version: deno 2.7.14
- CF_HARNESS_INTEGRATION_CF_CLI=1 deno task test:integration, from packages/cf-harness: 4 passed, 0 failed, 3 ignored