### PR TITLE
Standardize internal path-key encoding on `encodePointer()`; drop `localeCompare()` from CFC/storage sort paths

### DIFF
--- a/packages/memory/v2/path.ts
+++ b/packages/memory/v2/path.ts
@@ -1,3 +1,7 @@
+/**
+ * Parses a JSON Pointer (RFC 6901) string into its segment array, decoding
+ * `~1` → `/` and `~0` → `~`. Inverse of `encodePointer()`.
+ */
 export const parsePointer = (path: string): string[] => {
   if (path === "") {
     return [];
@@ -10,6 +14,16 @@ export const parsePointer = (path: string): string[] => {
   );
 };
 
+/**
+ * Encodes a path-segment array as a JSON Pointer (RFC 6901): empty path
+ * becomes `""`, otherwise each segment is escaped (`~` → `~0`, `/` → `~1`)
+ * and segments are joined with leading and inter-segment `/`. Inverse of
+ * `parsePointer()`.
+ *
+ * Used both as a wire format (the `path` field of RFC 6902 JSON Patch
+ * operations is a JSON Pointer) and as a canonical "logical-path → string"
+ * Map-key form within this codebase.
+ */
 export const encodePointer = (path: readonly string[]): string => {
   return path.length === 0
     ? ""

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -1,3 +1,5 @@
+import { encodePointer } from "../../../memory/v2/path.ts";
+
 export type IFCLabel = {
   confidentiality?: unknown[];
   integrity?: unknown[];
@@ -22,14 +24,8 @@ export const canonicalizeCfcLogicalPath = (
   path: readonly string[],
 ): string[] => path[0] === "value" ? [...path.slice(1)] : [...path];
 
-export const cfcLabelViewPathKey = (path: readonly string[]): string => {
-  const logicalPath = canonicalizeCfcLogicalPath(path);
-  return logicalPath.length === 0 ? "" : `/${
-    logicalPath
-      .map((segment) => segment.replaceAll("~", "~0").replaceAll("/", "~1"))
-      .join("/")
-  }`;
-};
+export const cfcLabelViewPathKey = (path: readonly string[]): string =>
+  encodePointer(canonicalizeCfcLogicalPath(path));
 
 export const cfcLabelPathPrefixMatches = (
   prefix: readonly string[],

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -58,11 +58,11 @@ export const hasCfcLabelValues = (label: IFCLabel): boolean =>
   LABEL_KEYS.some((key) => Array.isArray(label[key]) && label[key]!.length > 0);
 
 const sortEntries = (entries: CfcLabelViewEntry[]): CfcLabelViewEntry[] =>
-  entries.sort((left, right) =>
-    cfcLabelViewPathKey(left.path).localeCompare(
-      cfcLabelViewPathKey(right.path),
-    )
-  );
+  entries.sort((left, right) => {
+    const leftKey = cfcLabelViewPathKey(left.path);
+    const rightKey = cfcLabelViewPathKey(right.path);
+    return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+  });
 
 const mergeLabel = (
   left: IFCLabel | undefined,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -987,9 +987,11 @@ const coalesceLabelEntries = (
       label: mergeLabels(existing?.label, cloneLabel(entry.label)),
     });
   }
-  return [...byPath.values()].sort((left, right) =>
-    pathKey(left.path).localeCompare(pathKey(right.path))
-  );
+  return [...byPath.values()].sort((left, right) => {
+    const leftKey = pathKey(left.path);
+    const rightKey = pathKey(right.path);
+    return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+  });
 };
 
 const ensureSchemaDocument = (

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -23,6 +23,7 @@ import {
   parseLink,
 } from "../link-utils.ts";
 import { getValueAtPath } from "../path-utils.ts";
+import { encodePointer } from "../../../memory/v2/path.ts";
 import { canonicalizeLogicalPath } from "./canonical.ts";
 import { mergeCfcSchemaEnvelopes } from "./schema-merge.ts";
 import {
@@ -372,7 +373,7 @@ const linkWritesByTarget = (
 };
 
 const pathKey = (path: readonly string[]): string =>
-  canonicalizeLogicalPath(path).join("\u0000");
+  encodePointer(canonicalizeLogicalPath(path));
 
 const pathsOverlap = (
   left: readonly string[],
@@ -830,9 +831,7 @@ const derivePersistedLabel = (
 ): IFCLabel => {
   const ifc = isRecord(schema) ? schema.ifc : undefined;
   const copiedInputLabel = sourceEntryLabels && exactCopySourcePath(schema)
-    ? sourceEntryLabels.get(
-      canonicalizeLogicalPath(exactCopySourcePath(schema)!).join("\u0000"),
-    )
+    ? sourceEntryLabels.get(pathKey(exactCopySourcePath(schema)!))
     : undefined;
   return {
     confidentiality: mergeLabelValues(

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -374,9 +374,10 @@ const comparePath = (left: readonly string[], right: readonly string[]) => {
   }
   const limit = Math.min(left.length, right.length);
   for (let index = 0; index < limit; index++) {
-    const compared = left[index].localeCompare(right[index]);
-    if (compared !== 0) {
-      return compared;
+    const a = left[index];
+    const b = right[index];
+    if (a !== b) {
+      return a < b ? -1 : 1;
     }
   }
   return 0;
@@ -389,9 +390,8 @@ const compactCommitReads = <
   reads: Read[],
 ): Read[] => {
   const sorted = [...reads].sort((left, right) => {
-    const idCompared = left.id.localeCompare(right.id);
-    if (idCompared !== 0) {
-      return idCompared;
+    if (left.id !== right.id) {
+      return left.id < right.id ? -1 : 1;
     }
 
     if ("seq" in left && "seq" in right && left.seq !== right.seq) {
@@ -460,9 +460,8 @@ const compactCommitReads = <
   }
 
   return compacted.toSorted((left, right) => {
-    const idCompared = left.id.localeCompare(right.id);
-    if (idCompared !== 0) {
-      return idCompared;
+    if (left.id !== right.id) {
+      return left.id < right.id ? -1 : 1;
     }
 
     if ("seq" in left && "seq" in right && left.seq !== right.seq) {


### PR DESCRIPTION
## Summary

Three small cleanups that fell out of the address-immutability work in #3483.

### `encodePointer()` standardization

Two places in `packages/runner/src/cfc/` were rolling their own
"logical-path -> string" encoding for use as `Map` keys / sort keys:

- `pathKey()` in `prepare.ts` joined with NUL.
- `cfcLabelViewPathKey()` in `label-view-core.ts` did its own copy of
  the `~0`/`~1` JSON-Pointer escape -- a literal duplicate of
  `encodePointer()` from `memory/v2/path.ts`, which already implements
  RFC 6901.

Both now delegate to `encodePointer(canonicalize*LogicalPath(path))`.
RFC 6901 was already the project's standard (it's the format of the
`path` field on the RFC 6902 JSON Patch operations emitted from
`v2-transaction.ts`); this just stops the two internal helpers from
re-inventing it.

Also fixed an inline open-coded copy of the old NUL-join keying in
`derivePersistedLabel()` -- it was looking up in a `Map` that
`pathKey()` populated, so once `pathKey()`'s encoding changed the
lookup silently missed and exact-copy label propagation broke (caught
by `cfc-exact-copy.test.ts`). The lookup now goes through `pathKey()`
for symmetry.

Added a doc comment on `encodePointer()` (and `parsePointer()`) noting
the RFC 6901 lineage and its dual role as wire format (JSON Patch) and
canonical Map-key form, so future readers don't have to re-derive that.

### `localeCompare()` cleanup, round 2

Tail end of the earlier `localeCompare()` -> `<`/`>` ternary sweep
(`canonical.ts`, `compareWritePolicyInput`, etc.). Five remaining sites:

- `coalesceLabelEntries()` in `prepare.ts` and `sortEntries()` in
  `label-view-core.ts` were sorting label entries by `pathKey()` /
  `cfcLabelViewPathKey()` strings.
- `comparePath()` in `storage/v2.ts` was doing a per-segment
  `localeCompare()`.
- The two sort comparators inside `compactCommitReads()` (also
  `storage/v2.ts`) were leading with `left.id.localeCompare(right.id)`.

All of these sort purely-internal identifiers -- path segments (JSON
object keys), document `id` URIs (`of:doc-...`), pointer-encoded keys
-- for canonicalization and dedup, never user display. Locale
sensitivity adds zero value and a small but real risk that some future
non-ASCII segment sorts differently across machines/locales.

`compactCommitReads()` runs on the per-commit path. Microbench (Apple
M5 Pro) shows ~25-30% per-comparator win:

```
sort 10k DID-shaped ids:      1.6 ms -> 1.2 ms  (-25%)
sort 10k 5-segment paths:     1.5 ms -> 1.1 ms  (-27%)
```

System-level visibility depends on confirmed/pending read array sizes
in practice (typically way below 10k), but it scales linearly so it's
free perf wherever it shows up.

## Test plan

- [x] `deno task test` (full repo, ~67s) passes
- [x] `deno check` clean across affected files
- [x] `cfc-exact-copy.test.ts` continues to pass (caught the
  `derivePersistedLabel()` keying mismatch)
- [ ] CI on the full repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
