### PR TITLE
Fix UI defaults, editor autofocus, and tab overflow

### DIFF
--- a/packages/patterns/catalog/stories/cf-tab-list-story.tsx
+++ b/packages/patterns/catalog/stories/cf-tab-list-story.tsx
@@ -68,6 +68,40 @@ export default pattern<TabListStoryInput, TabListStoryOutput>(() => {
             </cf-tabs>
           </div>
         </div>
+
+        <div style={{ marginTop: "2rem" }}>
+          <div style="font-size: 13px; font-weight: 600; color: #374151; margin-bottom: 8px;">
+            Narrow mobile header overflow
+          </div>
+          <div
+            style={{
+              maxWidth: "280px",
+              border: "1px dashed #d1d5db",
+              borderRadius: "8px",
+              padding: "8px",
+            }}
+          >
+            <cf-hstack align="center" gap="2" style="width: 100%;">
+              <cf-button variant="ghost" size="icon">×</cf-button>
+              <cf-tabs
+                $value={activeChipTab}
+                style="--cf-tabs-width: auto; min-width: 0; flex: 1;"
+              >
+                <cf-tab-list variant="chip">
+                  <cf-tab value="all">All</cf-tab>
+                  <cf-tab value="notes">Notes</cf-tab>
+                  <cf-tab value="bookmarks">Bookmarks</cf-tab>
+                  <cf-tab value="highlights">Highlights</cf-tab>
+                  <cf-tab value="summaries">Summaries</cf-tab>
+                </cf-tab-list>
+              </cf-tabs>
+              <cf-button variant="ghost" size="icon">+</cf-button>
+              <cf-button variant="solid" color="primary" size="icon">
+                ✓
+              </cf-button>
+            </cf-hstack>
+          </div>
+        </div>
       </div>
     ),
     controls: (

--- a/packages/patterns/catalog/stories/cf-tab-list-story.tsx
+++ b/packages/patterns/catalog/stories/cf-tab-list-story.tsx
@@ -93,6 +93,8 @@ export default pattern<TabListStoryInput, TabListStoryOutput>(() => {
                   <cf-tab value="bookmarks">Bookmarks</cf-tab>
                   <cf-tab value="highlights">Highlights</cf-tab>
                   <cf-tab value="summaries">Summaries</cf-tab>
+                  <cf-tab value="drafts">Drafts</cf-tab>
+                  <cf-tab value="archived">Archived</cf-tab>
                 </cf-tab-list>
               </cf-tabs>
               <cf-button variant="ghost" size="icon">+</cf-button>

--- a/packages/ui/src/v2/components/cf-badge/cf-badge.ts
+++ b/packages/ui/src/v2/components/cf-badge/cf-badge.ts
@@ -1,5 +1,6 @@
 import { css, html } from "lit";
 import { BaseElement } from "../../core/base-element.ts";
+import { oneOf } from "../../core/property-guards.ts";
 import type { ColorIntent, ComponentSize } from "../theme-context.ts";
 
 /**
@@ -21,6 +22,10 @@ import type { ColorIntent, ComponentSize } from "../theme-context.ts";
  */
 
 export type BadgeVariant = "solid" | "outline";
+
+const badgeVariants = ["solid", "outline"] as const;
+const badgeColors = ["neutral", "primary", "accent", "danger"] as const;
+const badgeSizes = ["xs", "sm", "md", "lg", "xl"] as const;
 
 export class CFBadge extends BaseElement {
   static override styles = [
@@ -262,6 +267,21 @@ export class CFBadge extends BaseElement {
       this.variant = "solid";
       this.removable = false;
       this.size = "sm";
+    }
+
+    protected override willUpdate(
+      changedProperties: Map<string | number | symbol, unknown>,
+    ): void {
+      super.willUpdate(changedProperties);
+      if (
+        changedProperties.has("color") ||
+        changedProperties.has("variant") ||
+        changedProperties.has("size")
+      ) {
+        this.color = oneOf(this.color, badgeColors, "neutral");
+        this.variant = oneOf(this.variant, badgeVariants, "solid");
+        this.size = oneOf(this.size, badgeSizes, "sm");
+      }
     }
 
     override render() {

--- a/packages/ui/src/v2/components/cf-button/cf-button.test.ts
+++ b/packages/ui/src/v2/components/cf-button/cf-button.test.ts
@@ -42,6 +42,28 @@ describe("CFButton", () => {
     expect(element.type).toBe("button");
   });
 
+  it("should normalize invalid enum-like properties to defaults", () => {
+    const element = new CFButton();
+    element.color = "unexpected" as never;
+    element.variant = "secondary" as never;
+    element.size = "xxl" as never;
+    element.type = "menu" as never;
+
+    (element as any).willUpdate(
+      new Map([
+        ["color", "primary"],
+        ["variant", "solid"],
+        ["size", "md"],
+        ["type", "button"],
+      ]),
+    );
+
+    expect(element.color).toBe("primary");
+    expect(element.variant).toBe("solid");
+    expect(element.size).toBe("md");
+    expect(element.type).toBe("button");
+  });
+
   it("should expose button semantics on the host", () => {
     const element = new CFButton();
     element.updated(new Map([["disabled", undefined]]));

--- a/packages/ui/src/v2/components/cf-button/cf-button.ts
+++ b/packages/ui/src/v2/components/cf-button/cf-button.ts
@@ -1,9 +1,10 @@
-import { html } from "lit";
+import { html, type PropertyValues } from "lit";
 import { styles } from "./styles.ts";
 import { property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { consume } from "@lit/context";
 import { BaseElement } from "../../core/base-element.ts";
+import { oneOf } from "../../core/property-guards.ts";
 import {
   applyThemeToElement,
   type CFTheme,
@@ -33,6 +34,11 @@ import {
 export type ButtonVariant = "solid" | "outline" | "ghost";
 
 export type ButtonSize = ComponentSize | "icon";
+
+const buttonVariants = ["solid", "outline", "ghost"] as const;
+const buttonColors = ["neutral", "primary", "accent", "danger"] as const;
+const buttonSizes = ["xs", "sm", "md", "lg", "xl", "icon"] as const;
+const buttonTypes = ["button", "submit", "reset"] as const;
 
 // ── Accessibility strategy ───────────────────────────────────────────
 //
@@ -149,6 +155,21 @@ export class CFButton extends BaseElement {
     }
     if (changedProperties.has("theme")) {
       this._updateThemeProperties();
+    }
+  }
+
+  protected override willUpdate(changedProperties: PropertyValues): void {
+    super.willUpdate(changedProperties);
+    if (
+      changedProperties.has("color") ||
+      changedProperties.has("variant") ||
+      changedProperties.has("size") ||
+      changedProperties.has("type")
+    ) {
+      this.color = oneOf(this.color, buttonColors, "primary");
+      this.variant = oneOf(this.variant, buttonVariants, "solid");
+      this.size = oneOf(this.size, buttonSizes, "md");
+      this.type = oneOf(this.type, buttonTypes, "button");
     }
   }
 

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
@@ -54,4 +54,19 @@ describe("CFCodeEditor", () => {
     expect(element.autofocus).toBe(true);
     expect(element.cursorPosition).toBe("end");
   });
+
+  it("should focus the editor when autofocus becomes true", () => {
+    const element = new CFCodeEditor();
+    let focused = false;
+    (element as any)._editorView = {
+      focus: () => {
+        focused = true;
+      },
+    };
+
+    element.autofocus = true;
+    (element as any).updated(new Map([["autofocus", false]]));
+
+    expect(focused).toBe(true);
+  });
 });

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -233,6 +233,10 @@ export class CFCodeEditor extends BaseElement {
   private _cleanupFns: Array<() => void> = [];
   private _mentionableUnsub: (() => void) | null = null;
   private _mentionedUnsub: (() => void) | null = null;
+  private _autofocusPending = false;
+  private _autofocusFrame: number | null = null;
+  private _autofocusIntersectionObserver: IntersectionObserver | null = null;
+  private _autofocusResizeObserver: ResizeObserver | null = null;
   // Track previous backlink names to detect changes for syncing to piece NAME
   private _previousBacklinkNames = new Map<string, string>();
   // Track subscriptions to piece NAME cells for bidirectional sync
@@ -764,6 +768,9 @@ export class CFCodeEditor extends BaseElement {
 
   override connectedCallback() {
     super.connectedCallback();
+    if (this.autofocus && this._editorView) {
+      this._queueAutofocus();
+    }
   }
 
   override disconnectedCallback() {
@@ -890,6 +897,7 @@ export class CFCodeEditor extends BaseElement {
   }
 
   private _cleanup(): void {
+    this._cancelAutofocus();
     this._cleanupCellSyncHandler();
     this._cleanupPieceNameSubscriptions();
     this._resolvedPieceIds.clear();
@@ -1049,6 +1057,14 @@ export class CFCodeEditor extends BaseElement {
         ],
       });
     }
+
+    if (changedProperties.has("autofocus")) {
+      if (this.autofocus) {
+        this._queueAutofocus();
+      } else {
+        this._cancelAutofocus();
+      }
+    }
   }
 
   protected override firstUpdated(_changedProperties: PropertyValues): void {
@@ -1078,9 +1094,98 @@ export class CFCodeEditor extends BaseElement {
     // Set up subscriptions for bidirectional NAME sync
     this._setupPieceNameSubscriptions();
 
-    if (this.autofocus) {
-      this._editorView?.focus();
+    this._queueAutofocus();
+  }
+
+  private _queueAutofocus(): void {
+    if (!this.autofocus) return;
+    this._autofocusPending = true;
+    this._observeAutofocusVisibility();
+    this._scheduleAutofocusAttempt();
+  }
+
+  private _scheduleAutofocusAttempt(): void {
+    if (!this._autofocusPending || this._autofocusFrame !== null) return;
+    if (typeof requestAnimationFrame !== "function") {
+      this._attemptAutofocus();
+      return;
     }
+    this._autofocusFrame = requestAnimationFrame(() => {
+      this._autofocusFrame = null;
+      this._attemptAutofocus();
+    });
+  }
+
+  private _attemptAutofocus(): void {
+    if (!this._autofocusPending || !this.autofocus) {
+      this._cancelAutofocus();
+      return;
+    }
+    if (!this._editorView) return;
+    if (typeof document !== "undefined" && !this.isConnected) return;
+
+    if (!this._isVisibleForAutofocus()) {
+      this._observeAutofocusVisibility();
+      return;
+    }
+
+    this._editorView.focus();
+    this._autofocusPending = false;
+    this._teardownAutofocusObservers();
+  }
+
+  private _isVisibleForAutofocus(): boolean {
+    if (typeof document === "undefined") return true;
+    const rect = this.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  }
+
+  private _observeAutofocusVisibility(): void {
+    if (typeof document === "undefined") return;
+
+    if (
+      !this._autofocusIntersectionObserver &&
+      typeof IntersectionObserver !== "undefined"
+    ) {
+      this._autofocusIntersectionObserver = new IntersectionObserver(
+        (entries) => {
+          if (entries.some((entry) => entry.isIntersecting)) {
+            this._scheduleAutofocusAttempt();
+          }
+        },
+      );
+      this._autofocusIntersectionObserver.observe(this);
+    }
+
+    if (
+      !this._autofocusResizeObserver && typeof ResizeObserver !== "undefined"
+    ) {
+      this._autofocusResizeObserver = new ResizeObserver(() => {
+        if (this._isVisibleForAutofocus()) {
+          this._scheduleAutofocusAttempt();
+        }
+      });
+      this._autofocusResizeObserver.observe(this);
+    }
+  }
+
+  private _cancelAutofocus(): void {
+    this._autofocusPending = false;
+    if (
+      this._autofocusFrame !== null &&
+      typeof cancelAnimationFrame === "function"
+    ) {
+      cancelAnimationFrame(this._autofocusFrame);
+    }
+    this._autofocusFrame = null;
+    this._teardownAutofocusObservers();
+  }
+
+  private _teardownAutofocusObservers(): void {
+    this._autofocusIntersectionObserver?.disconnect();
+    this._autofocusIntersectionObserver = null;
+    this._autofocusResizeObserver?.disconnect();
+    this._autofocusResizeObserver = null;
   }
 
   /**

--- a/packages/ui/src/v2/components/cf-skeleton/cf-skeleton.ts
+++ b/packages/ui/src/v2/components/cf-skeleton/cf-skeleton.ts
@@ -27,8 +27,11 @@
 import { css, html } from "lit";
 import { styleMap } from "lit/directives/style-map.js";
 import { BaseElement } from "../../core/base-element.ts";
+import { oneOf } from "../../core/property-guards.ts";
 
 export type SkeletonVariant = "default" | "text" | "circular";
+
+const skeletonVariants = ["default", "text", "circular"] as const;
 
 /**
  * CFSkeleton displays an animated loading placeholder.
@@ -142,6 +145,15 @@ export class CFSkeleton extends BaseElement {
     this.animated = true;
     this.width = null;
     this.height = null;
+  }
+
+  protected override willUpdate(
+    changedProperties: Map<string | number | symbol, unknown>,
+  ): void {
+    super.willUpdate(changedProperties);
+    if (changedProperties.has("variant")) {
+      this.variant = oneOf(this.variant, skeletonVariants, "default");
+    }
   }
 
   override render() {

--- a/packages/ui/src/v2/components/cf-tab-list/cf-tab-list.test.ts
+++ b/packages/ui/src/v2/components/cf-tab-list/cf-tab-list.test.ts
@@ -34,4 +34,11 @@ describe("CFTabList", () => {
     expect(element.orientation).toBe("horizontal");
     expect(element.variant).toBe("underline");
   });
+
+  it("should start-align horizontal tabs so overflow remains reachable", () => {
+    const styles = String(CFTabList.styles);
+
+    expect(styles).toContain('.tab-list[data-orientation="horizontal"]');
+    expect(styles).toContain("justify-content: flex-start");
+  });
 });

--- a/packages/ui/src/v2/components/cf-tab-list/cf-tab-list.test.ts
+++ b/packages/ui/src/v2/components/cf-tab-list/cf-tab-list.test.ts
@@ -1,0 +1,37 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { CFTabList } from "./cf-tab-list.ts";
+
+describe("CFTabList", () => {
+  it("should have default properties", () => {
+    const element = new CFTabList();
+
+    expect(element.orientation).toBe("horizontal");
+    expect(element.variant).toBe("underline");
+  });
+
+  it("should reflect orientation for host and child orientation styling", () => {
+    const properties = CFTabList.properties as Record<
+      string,
+      { reflect?: boolean }
+    >;
+
+    expect(properties.orientation.reflect).toBe(true);
+  });
+
+  it("should normalize invalid enum-like properties to defaults", () => {
+    const element = new CFTabList();
+    element.orientation = "diagonal" as never;
+    element.variant = "pills" as never;
+
+    (element as any).willUpdate(
+      new Map([
+        ["orientation", "horizontal"],
+        ["variant", "underline"],
+      ]),
+    );
+
+    expect(element.orientation).toBe("horizontal");
+    expect(element.variant).toBe("underline");
+  });
+});

--- a/packages/ui/src/v2/components/cf-tab-list/cf-tab-list.ts
+++ b/packages/ui/src/v2/components/cf-tab-list/cf-tab-list.ts
@@ -66,6 +66,7 @@ export class CFTabList extends BaseElement {
 
       .tab-list[data-orientation="horizontal"] {
         flex-direction: row;
+        justify-content: flex-start;
         width: 100%;
         min-width: 0;
         overflow-x: auto;

--- a/packages/ui/src/v2/components/cf-tab-list/cf-tab-list.ts
+++ b/packages/ui/src/v2/components/cf-tab-list/cf-tab-list.ts
@@ -1,5 +1,9 @@
 import { css, html } from "lit";
 import { BaseElement } from "../../core/base-element.ts";
+import { oneOf } from "../../core/property-guards.ts";
+
+const tabListOrientations = ["horizontal", "vertical"] as const;
+const tabListVariants = ["underline", "chip"] as const;
 
 /**
  * CFTabList - Container component for tab buttons
@@ -35,7 +39,15 @@ export class CFTabList extends BaseElement {
         --cf-tab-list-color-surface: var(--cf-theme-color-surface, #f1f5f9);
 
         display: flex;
+        flex-shrink: 1;
+        min-width: 0;
+        max-width: 100%;
+        box-sizing: border-box;
+      }
+
+      :host([orientation="vertical"]) {
         flex-shrink: 0;
+        max-width: none;
       }
 
       .tab-list {
@@ -47,10 +59,14 @@ export class CFTabList extends BaseElement {
         padding: var(--cf-spacing-1);
         height: 2.5rem;
         gap: 0.125rem;
+        max-width: 100%;
+        min-width: 0;
+        box-sizing: border-box;
       }
 
       .tab-list[data-orientation="horizontal"] {
         flex-direction: row;
+        width: 100%;
         min-width: 0;
         overflow-x: auto;
         overflow-y: hidden;
@@ -93,7 +109,7 @@ export class CFTabList extends BaseElement {
   ];
 
   static override properties = {
-    orientation: { type: String },
+    orientation: { type: String, reflect: true },
     variant: { type: String, reflect: true },
   };
 
@@ -128,6 +144,22 @@ export class CFTabList extends BaseElement {
     }
     if (changedProperties.has("variant")) {
       this._propagateVariant();
+    }
+  }
+
+  protected override willUpdate(
+    changedProperties: Map<string | number | symbol, unknown>,
+  ): void {
+    super.willUpdate(changedProperties);
+    if (
+      changedProperties.has("orientation") || changedProperties.has("variant")
+    ) {
+      this.orientation = oneOf(
+        this.orientation,
+        tabListOrientations,
+        "horizontal",
+      );
+      this.variant = oneOf(this.variant, tabListVariants, "underline");
     }
   }
 

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
@@ -43,6 +43,8 @@ export class CFTabs extends BaseElement {
         display: flex;
         flex-direction: column;
         width: var(--cf-tabs-width, 100%);
+        max-width: 100%;
+        min-width: 0;
         min-height: 0;
         flex: var(--cf-tabs-flex, 1);
       }
@@ -51,6 +53,8 @@ export class CFTabs extends BaseElement {
         display: flex;
         flex-direction: column;
         width: 100%;
+        max-width: 100%;
+        min-width: 0;
         flex: 1;
         min-height: 0;
       }
@@ -65,7 +69,9 @@ export class CFTabs extends BaseElement {
 
       /* Ensure proper layout for slotted content */
       ::slotted(cf-tab-list) {
-        flex-shrink: 0;
+        flex: 0 1 auto;
+        min-width: 0;
+        max-width: 100%;
       }
 
       ::slotted(cf-tab-panel) {

--- a/packages/ui/src/v2/components/cf-toggle/cf-toggle.ts
+++ b/packages/ui/src/v2/components/cf-toggle/cf-toggle.ts
@@ -1,6 +1,7 @@
 import { html, PropertyValues, unsafeCSS } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { BaseElement } from "../../core/base-element.ts";
+import { oneOf } from "../../core/property-guards.ts";
 import { toggleStyles } from "./styles.ts";
 
 /** @deprecated Use ComponentSize instead */
@@ -25,6 +26,9 @@ export type ToggleSize = "sm" | "md" | "lg";
  * <cf-toggle pressed>Bold</cf-toggle>
  */
 export type ToggleVariant = "default" | "outline";
+
+const toggleVariants = ["default", "outline"] as const;
+const toggleSizes = ["sm", "md", "lg"] as const;
 
 export class CFToggle extends BaseElement {
   // No delegatesFocus — the host owns role="button", tabindex, and all
@@ -71,6 +75,14 @@ export class CFToggle extends BaseElement {
     // (cf-toggle-group) programmatically sets pressed.
     if (changedProperties.has("pressed") || changedProperties.has("disabled")) {
       this._updateAriaAttributes();
+    }
+  }
+
+  protected override willUpdate(changedProperties: PropertyValues): void {
+    super.willUpdate(changedProperties);
+    if (changedProperties.has("variant") || changedProperties.has("size")) {
+      this.variant = oneOf(this.variant, toggleVariants, "default");
+      this.size = oneOf(this.size, toggleSizes, "md");
     }
   }
 

--- a/packages/ui/src/v2/core/property-guards.ts
+++ b/packages/ui/src/v2/core/property-guards.ts
@@ -1,0 +1,10 @@
+export function oneOf<T extends string>(
+  value: unknown,
+  validValues: readonly T[],
+  fallback: T,
+): T {
+  return typeof value === "string" &&
+      (validValues as readonly string[]).includes(value)
+    ? value as T
+    : fallback;
+}


### PR DESCRIPTION
Summary:
- Default invalid enum-like component props back to safe defaults for button-like UI primitives.
- Make cf-code-editor autofocus wait until the editor is connected and visible.
- Fix horizontal cf-tab-list overflow alignment and add/complete catalog repro stories for narrow mobile headers.

Validation:
- deno task --cwd packages/ui test
- deno test --allow-env --allow-ffi --allow-read --allow-write --allow-run packages/ui/src/v2/components/cf-tab-list/cf-tab-list.test.ts

Preview:
http://localhost:8000/2026-05-04-ben/fid1:W5nillNCGZOupSsFZ6JqNJxLFiDYI-SPj6qKRIekuT4