### PR TITLE
feat(shell/runner/toolshed): Add blob upload and serving

### DIFF
--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -158,6 +158,49 @@ Deno.test("memory v2 server allows the same session id in different spaces", asy
   }
 });
 
+Deno.test("memory v2 server direct writes schedule dirty refreshes without connections", async () => {
+  const time = new FakeTime();
+  const server = createServer(
+    "memory://memory-v2-server-direct-write-no-connections",
+    1,
+  );
+  const space = "did:key:z6Mk-memory-v2-server-direct-write-no-connections";
+  const id = "cid:fid1:direct-write-no-connections";
+  const originalFlush = server.flushSessions.bind(server);
+  let flushCalls = 0;
+
+  (server as unknown as {
+    flushSessions(
+      ...args: Parameters<Server["flushSessions"]>
+    ): ReturnType<Server["flushSessions"]>;
+  }).flushSessions = async (...args) => {
+    flushCalls += 1;
+    return await originalFlush(...args);
+  };
+
+  try {
+    await server.writeDocument(space, id, {
+      type: "text/plain",
+      body: "hello",
+    });
+    assertEquals(flushCalls, 0);
+
+    await time.tickAsync(1);
+    await time.tickAsync(0);
+
+    assertEquals(flushCalls, 1);
+    assertEquals(await server.readDocument(space, id), {
+      value: {
+        type: "text/plain",
+        body: "hello",
+      },
+    });
+  } finally {
+    await server.close();
+    time.restore();
+  }
+});
+
 Deno.test("memory v2 server binds resumed sessions to the original principal", async () => {
   const server = new Server({
     store: new URL("memory://memory-v2-server-session-principal"),

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -1,5 +1,16 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { FakeTime } from "@std/testing/time";
+import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
+import {
+  getDataModelConfig,
+  resetDataModelConfig,
+  setDataModelConfig,
+} from "@commonfabric/data-model/fabric-value";
+import {
+  getJsonEncodingConfig,
+  resetJsonEncodingConfig,
+  setJsonEncodingConfig,
+} from "@commonfabric/data-model/json-encoding";
 import { parseClientMessage, Server, SessionRegistry } from "../v2/server.ts";
 import {
   encodeMemoryBoundary,
@@ -27,6 +38,29 @@ const HELLO_OK = {
 
 const tick = async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const withUnifiedJsonEncoding = async <T>(
+  fn: () => Promise<T> | T,
+): Promise<T> => {
+  const previousJson = getJsonEncodingConfig();
+  const previousDataModel = getDataModelConfig();
+  setDataModelConfig(true);
+  setJsonEncodingConfig(true);
+  try {
+    return await fn();
+  } finally {
+    if (previousDataModel) {
+      setDataModelConfig(true);
+    } else {
+      resetDataModelConfig();
+    }
+    if (previousJson) {
+      setJsonEncodingConfig(true);
+    } else {
+      resetJsonEncodingConfig();
+    }
+  }
 };
 
 const shiftMessage = (messages: ServerMessage[]): ServerMessage => {
@@ -198,6 +232,32 @@ Deno.test("memory v2 server direct writes schedule dirty refreshes without conne
   } finally {
     await server.close();
     time.restore();
+  }
+});
+
+Deno.test("memory v2 server direct document helpers round-trip values", async () => {
+  const server = createServer("memory://memory-v2-server-direct-documents");
+  const space = "did:key:z6Mk-memory-v2-server-direct-documents";
+  const id = "cid:fid1:direct-document";
+  const contents = {
+    type: "image/png",
+    body: new FabricBytes(new Uint8Array([1, 2, 3, 4])),
+  };
+
+  try {
+    await withUnifiedJsonEncoding(async () => {
+      await server.writeDocument(space, id, contents);
+
+      assertEquals(await server.readDocument(space, id), {
+        value: contents,
+      });
+      assertEquals(
+        await server.readDocument(space, "cid:fid1:missing-document"),
+        null,
+      );
+    });
+  } finally {
+    await server.close();
   }
 });
 

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2,16 +2,6 @@ import * as FS from "@std/fs";
 import * as Path from "@std/path";
 import { resolveSpaceStoreUrl } from "./storage-path.ts";
 import {
-  getDataModelConfig,
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
-import {
-  getJsonEncodingConfig,
-  resetJsonEncodingConfig,
-  setJsonEncodingConfig,
-} from "@commonfabric/data-model/json-encoding";
-import {
   type ClientCommit,
   type ClientMessage,
   decodeMemoryBoundary,
@@ -120,33 +110,6 @@ const toError = (name: string, message: string): V2Error => ({
   name,
   message,
 });
-
-const withEncodingConfig = async <T>(
-  enabled: boolean | undefined,
-  fn: () => Promise<T> | T,
-): Promise<T> => {
-  if (enabled === undefined) {
-    return await fn();
-  }
-  const previous = getJsonEncodingConfig();
-  const previousDataModel = getDataModelConfig();
-  setDataModelConfig(enabled);
-  setJsonEncodingConfig(enabled);
-  try {
-    return await fn();
-  } finally {
-    if (previousDataModel) {
-      setDataModelConfig(true);
-    } else {
-      resetDataModelConfig();
-    }
-    if (previous) {
-      setJsonEncodingConfig(true);
-    } else {
-      resetJsonEncodingConfig();
-    }
-  }
-};
 
 const respondTypedError = <Result>(
   requestId: string,
@@ -428,6 +391,7 @@ export class Server {
   #sessions: SessionRegistry;
   #connections = new Map<string, Connection>();
   #engines = new Map<string, Promise<Engine.Engine>>();
+  // Synthesized session state for direct out-of-band document writes, such as blob uploads.
   #directSessionId = `server:${crypto.randomUUID()}`;
   #directLocalSeq = 0;
   #dirtySpaces = new Set<string>();
@@ -485,43 +449,31 @@ export class Server {
   async readDocument(
     space: string,
     id: string,
-    options: { unifiedJsonEncoding?: boolean } = {},
   ): Promise<EntityDocument | null> {
-    return await withEncodingConfig(
-      options.unifiedJsonEncoding,
-      async () => {
-        const engine = await this.openEngine(space);
-        return Engine.read(engine, { id });
-      },
-    );
+    const engine = await this.openEngine(space);
+    return Engine.read(engine, { id });
   }
 
   async writeDocument(
     space: string,
     id: string,
     value: EntityDocument["value"],
-    options: { unifiedJsonEncoding?: boolean } = {},
   ): Promise<Engine.AppliedCommit> {
-    return await withEncodingConfig(
-      options.unifiedJsonEncoding,
-      async () => {
-        const engine = await this.openEngine(space);
-        const commit = Engine.applyCommit(engine, {
-          sessionId: this.#directSessionId,
-          commit: {
-            localSeq: ++this.#directLocalSeq,
-            reads: { confirmed: [], pending: [] },
-            operations: [{
-              op: "set",
-              id,
-              value: { value },
-            }],
-          },
-        });
-        this.markSpaceDirty(space, [id]);
-        return commit;
+    const engine = await this.openEngine(space);
+    const commit = Engine.applyCommit(engine, {
+      sessionId: this.#directSessionId,
+      commit: {
+        localSeq: ++this.#directLocalSeq,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id,
+          value: { value },
+        }],
       },
-    );
+    });
+    this.markSpaceDirty(space, [id]);
+    return commit;
   }
 
   async openSession(

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2,10 +2,21 @@ import * as FS from "@std/fs";
 import * as Path from "@std/path";
 import { resolveSpaceStoreUrl } from "./storage-path.ts";
 import {
+  getDataModelConfig,
+  resetDataModelConfig,
+  setDataModelConfig,
+} from "@commonfabric/data-model/fabric-value";
+import {
+  getJsonEncodingConfig,
+  resetJsonEncodingConfig,
+  setJsonEncodingConfig,
+} from "@commonfabric/data-model/json-encoding";
+import {
   type ClientCommit,
   type ClientMessage,
   decodeMemoryBoundary,
   encodeMemoryBoundary,
+  type EntityDocument,
   type GraphQuery,
   type GraphQueryRequest,
   type GraphQueryResult,
@@ -109,6 +120,33 @@ const toError = (name: string, message: string): V2Error => ({
   name,
   message,
 });
+
+const withEncodingConfig = async <T>(
+  enabled: boolean | undefined,
+  fn: () => Promise<T> | T,
+): Promise<T> => {
+  if (enabled === undefined) {
+    return await fn();
+  }
+  const previous = getJsonEncodingConfig();
+  const previousDataModel = getDataModelConfig();
+  setDataModelConfig(enabled);
+  setJsonEncodingConfig(enabled);
+  try {
+    return await fn();
+  } finally {
+    if (previousDataModel) {
+      setDataModelConfig(true);
+    } else {
+      resetDataModelConfig();
+    }
+    if (previous) {
+      setJsonEncodingConfig(true);
+    } else {
+      resetJsonEncodingConfig();
+    }
+  }
+};
 
 const respondTypedError = <Result>(
   requestId: string,
@@ -390,6 +428,8 @@ export class Server {
   #sessions: SessionRegistry;
   #connections = new Map<string, Connection>();
   #engines = new Map<string, Promise<Engine.Engine>>();
+  #directSessionId = `server:${crypto.randomUUID()}`;
+  #directLocalSeq = 0;
   #dirtySpaces = new Set<string>();
   #dirtyDocsBySpace = new Map<string, Set<string>>();
   #refreshTimer: ReturnType<typeof setTimeout> | null = null;
@@ -440,6 +480,48 @@ export class Server {
     }
     this.#engines.clear();
     this.#connections.clear();
+  }
+
+  async readDocument(
+    space: string,
+    id: string,
+    options: { unifiedJsonEncoding?: boolean } = {},
+  ): Promise<EntityDocument | null> {
+    return await withEncodingConfig(
+      options.unifiedJsonEncoding,
+      async () => {
+        const engine = await this.openEngine(space);
+        return Engine.read(engine, { id });
+      },
+    );
+  }
+
+  async writeDocument(
+    space: string,
+    id: string,
+    document: EntityDocument,
+    options: { unifiedJsonEncoding?: boolean } = {},
+  ): Promise<Engine.AppliedCommit> {
+    return await withEncodingConfig(
+      options.unifiedJsonEncoding,
+      async () => {
+        const engine = await this.openEngine(space);
+        const commit = Engine.applyCommit(engine, {
+          sessionId: this.#directSessionId,
+          commit: {
+            localSeq: ++this.#directLocalSeq,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "set",
+              id,
+              value: document,
+            }],
+          },
+        });
+        this.markSpaceDirty(space, [id]);
+        return commit;
+      },
+    );
   }
 
   async openSession(
@@ -970,6 +1052,9 @@ export class Server {
   }
 
   markSpaceDirty(space: string, dirtyIds?: Iterable<string>): void {
+    if (this.#connections.size === 0) {
+      return;
+    }
     if (dirtyIds !== undefined) {
       let ids = this.#dirtyDocsBySpace.get(space);
       if (ids === undefined) {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1052,9 +1052,6 @@ export class Server {
   }
 
   markSpaceDirty(space: string, dirtyIds?: Iterable<string>): void {
-    if (this.#connections.size === 0) {
-      return;
-    }
     if (dirtyIds !== undefined) {
       let ids = this.#dirtyDocsBySpace.get(space);
       if (ids === undefined) {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -499,7 +499,7 @@ export class Server {
   async writeDocument(
     space: string,
     id: string,
-    document: EntityDocument,
+    value: EntityDocument["value"],
     options: { unifiedJsonEncoding?: boolean } = {},
   ): Promise<Engine.AppliedCommit> {
     return await withEncodingConfig(
@@ -514,7 +514,7 @@ export class Server {
             operations: [{
               op: "set",
               id,
-              value: document,
+              value: { value },
             }],
           },
         });

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -13,6 +13,29 @@ import {
 import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
 import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
 import { cellRefToSigilLink } from "./utils.ts";
+import {
+  getJsonEncodingConfig,
+  setJsonEncodingConfig,
+} from "@commonfabric/data-model/json-encoding";
+import {
+  getDataModelConfig,
+  setDataModelConfig,
+} from "@commonfabric/data-model/fabric-value";
+
+const withUnifiedJsonEncoding = async <T>(
+  fn: () => Promise<T> | T,
+): Promise<T> => {
+  const previousJson = getJsonEncodingConfig();
+  const previousDataModel = getDataModelConfig();
+  setDataModelConfig(true);
+  setJsonEncodingConfig(true);
+  try {
+    return await fn();
+  } finally {
+    setDataModelConfig(previousDataModel);
+    setJsonEncodingConfig(previousJson);
+  }
+};
 
 describe("sanitizeForPostMessage", () => {
   describe("primitives", () => {
@@ -416,16 +439,18 @@ describe("RuntimeProcessor blob upload IPC", () => {
     } as unknown as RuntimeProcessor;
 
     try {
-      await expect(
-        RuntimeProcessor.prototype.handleUploadBlob.call(processor, {
-          type: RequestType.UploadBlob,
-          contentType: "image/png",
-          body: new Uint8Array([1, 2, 3]),
-          suffix: "png",
-        }),
-      ).resolves.toEqual({
-        id: "fid1:test",
-        url: "blobs/test.png",
+      await withUnifiedJsonEncoding(async () => {
+        await expect(
+          RuntimeProcessor.prototype.handleUploadBlob.call(processor, {
+            type: RequestType.UploadBlob,
+            contentType: "image/png",
+            body: new Uint8Array([1, 2, 3]),
+            suffix: "png",
+          }),
+        ).resolves.toEqual({
+          id: "fid1:test",
+          url: "blobs/test.png",
+        });
       });
     } finally {
       globalThis.fetch = originalFetch;

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -423,20 +423,22 @@ describe("RuntimeProcessor blob upload IPC", () => {
     const originalFetch = globalThis.fetch;
     let requestedUrl: string | undefined;
     let requestedPayload: unknown;
-    globalThis.fetch = async (input, init) => {
+    globalThis.fetch = (input, init) => {
       requestedUrl = input.toString();
       requestedPayload = withUnifiedEncoding(() =>
         decodeMemoryBoundary(init?.body as string)
       );
-      return new Response(
-        JSON.stringify({
-          id: "fid1:test",
-          url: "blobs/test.png",
-        }),
-        {
-          status: 201,
-          headers: { "Content-Type": "application/json" },
-        },
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "fid1:test",
+            url: "blobs/test.png",
+          }),
+          {
+            status: 201,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
       );
     };
     const processor = {

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -12,16 +12,6 @@ import {
 } from "../protocol/mod.ts";
 import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
 import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
-import {
-  getDataModelConfig,
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
-import {
-  getJsonEncodingConfig,
-  resetJsonEncodingConfig,
-  setJsonEncodingConfig,
-} from "@commonfabric/data-model/json-encoding";
 import { cellRefToSigilLink } from "./utils.ts";
 
 describe("sanitizeForPostMessage", () => {
@@ -398,36 +388,13 @@ describe("RuntimeProcessor diagnosis helpers", () => {
 });
 
 describe("RuntimeProcessor blob upload IPC", () => {
-  const withUnifiedEncoding = <T>(fn: () => T): T => {
-    const previousDataModel = getDataModelConfig();
-    const previousJson = getJsonEncodingConfig();
-    setDataModelConfig(true);
-    setJsonEncodingConfig(true);
-    try {
-      return fn();
-    } finally {
-      if (previousDataModel) {
-        setDataModelConfig(true);
-      } else {
-        resetDataModelConfig();
-      }
-      if (previousJson) {
-        setJsonEncodingConfig(true);
-      } else {
-        resetJsonEncodingConfig();
-      }
-    }
-  };
-
   it("posts FabricBytes contents to the blob route and returns its URL", async () => {
     const originalFetch = globalThis.fetch;
     let requestedUrl: string | undefined;
     let requestedPayload: unknown;
     globalThis.fetch = (input, init) => {
       requestedUrl = input.toString();
-      requestedPayload = withUnifiedEncoding(() =>
-        decodeMemoryBoundary(init?.body as string)
-      );
+      requestedPayload = decodeMemoryBoundary(init?.body as string);
       return Promise.resolve(
         new Response(
           JSON.stringify({
@@ -441,6 +408,8 @@ describe("RuntimeProcessor blob upload IPC", () => {
         ),
       );
     };
+    // The constructor performs full runtime initialization; this focused unit
+    // test calls the handler with the fields it reads directly.
     const processor = {
       apiUrl: new URL("http://toolshed.test/base"),
       space: "did:key:test-space",

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -10,6 +10,18 @@ import {
   type CfcLabelView,
   RequestType,
 } from "../protocol/mod.ts";
+import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
+import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
+import {
+  getDataModelConfig,
+  resetDataModelConfig,
+  setDataModelConfig,
+} from "@commonfabric/data-model/fabric-value";
+import {
+  getJsonEncodingConfig,
+  resetJsonEncodingConfig,
+  setJsonEncodingConfig,
+} from "@commonfabric/data-model/json-encoding";
 import { cellRefToSigilLink } from "./utils.ts";
 
 describe("sanitizeForPostMessage", () => {
@@ -382,6 +394,79 @@ describe("RuntimeProcessor diagnosis helpers", () => {
       },
     );
     expect(writeTraceMatchers).toEqual([[]]);
+  });
+});
+
+describe("RuntimeProcessor blob upload IPC", () => {
+  const withUnifiedEncoding = <T>(fn: () => T): T => {
+    const previousDataModel = getDataModelConfig();
+    const previousJson = getJsonEncodingConfig();
+    setDataModelConfig(true);
+    setJsonEncodingConfig(true);
+    try {
+      return fn();
+    } finally {
+      if (previousDataModel) {
+        setDataModelConfig(true);
+      } else {
+        resetDataModelConfig();
+      }
+      if (previousJson) {
+        setJsonEncodingConfig(true);
+      } else {
+        resetJsonEncodingConfig();
+      }
+    }
+  };
+
+  it("posts FabricBytes contents to the blob route and returns its URL", async () => {
+    const originalFetch = globalThis.fetch;
+    let requestedUrl: string | undefined;
+    let requestedPayload: unknown;
+    globalThis.fetch = async (input, init) => {
+      requestedUrl = input.toString();
+      requestedPayload = withUnifiedEncoding(() =>
+        decodeMemoryBoundary(init?.body as string)
+      );
+      return new Response(
+        JSON.stringify({
+          id: "fid1:test",
+          url: "blobs/test.png",
+        }),
+        {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    };
+    const processor = {
+      apiUrl: new URL("http://toolshed.test/base"),
+      space: "did:key:test-space",
+    } as unknown as RuntimeProcessor;
+
+    try {
+      await expect(
+        RuntimeProcessor.prototype.handleUploadBlob.call(processor, {
+          type: RequestType.UploadBlob,
+          contentType: "image/png",
+          body: new Uint8Array([1, 2, 3]),
+          suffix: "png",
+        }),
+      ).resolves.toEqual({
+        id: "fid1:test",
+        url: "blobs/test.png",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(requestedUrl).toBe(
+      "http://toolshed.test/did:key:test-space/blobs/upload.png",
+    );
+    expect(requestedPayload).toEqual({
+      type: "image/png",
+      body: new FabricBytes(new Uint8Array([1, 2, 3])),
+    });
   });
 });
 

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1,4 +1,16 @@
 import { DID, Identity, type Session } from "@commonfabric/identity";
+import {
+  getDataModelConfig,
+  resetDataModelConfig,
+  setDataModelConfig,
+} from "@commonfabric/data-model/fabric-value";
+import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
+import {
+  getJsonEncodingConfig,
+  resetJsonEncodingConfig,
+  setJsonEncodingConfig,
+} from "@commonfabric/data-model/json-encoding";
+import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import { PieceManager } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
 import {
@@ -89,6 +101,8 @@ import {
   type SetTriggerTraceEnabledRequest,
   type SetWriteStackTraceMatchersRequest,
   type TriggerTraceResponse,
+  type UploadBlobRequest,
+  type UploadBlobResponse,
   type VDomEventRequest,
   type VDomMountRequest,
   type VDomMountResponse,
@@ -110,6 +124,27 @@ import type { VDomOp } from "../protocol/types.ts";
 import type { RuntimeOptions } from "@commonfabric/runner";
 
 const MAX_SERIALIZATION_DEPTH = 5;
+
+const withUnifiedEncoding = <T>(fn: () => T): T => {
+  const previousDataModel = getDataModelConfig();
+  const previousJson = getJsonEncodingConfig();
+  setDataModelConfig(true);
+  setJsonEncodingConfig(true);
+  try {
+    return fn();
+  } finally {
+    if (previousDataModel) {
+      setDataModelConfig(true);
+    } else {
+      resetDataModelConfig();
+    }
+    if (previousJson) {
+      setJsonEncodingConfig(true);
+    } else {
+      resetJsonEncodingConfig();
+    }
+  }
+};
 
 export function runtimeOptionsFromInitializationData(
   data: InitializationData,
@@ -254,6 +289,7 @@ export class RuntimeProcessor {
   private runtime: Runtime;
   private pieceManager: PieceManager;
   private cc: PiecesController;
+  private apiUrl: URL;
   private space: DID;
   private identity: Identity;
   private _isDisposed = false;
@@ -273,6 +309,7 @@ export class RuntimeProcessor {
     runtime: Runtime,
     pieceManager: PieceManager,
     cc: PiecesController,
+    apiUrl: URL,
     space: DID,
     identity: Identity,
     telemetry: RuntimeTelemetry,
@@ -280,6 +317,7 @@ export class RuntimeProcessor {
     this.runtime = runtime;
     this.pieceManager = pieceManager;
     this.cc = cc;
+    this.apiUrl = apiUrl;
     this.space = space;
     this.identity = identity;
     this.telemetry = telemetry;
@@ -392,6 +430,7 @@ export class RuntimeProcessor {
       runtime,
       pieceManager,
       cc,
+      apiUrlObj,
       space,
       identity,
       telemetry,
@@ -824,6 +863,38 @@ export class RuntimeProcessor {
   setBreakpoints(request: SetBreakpointsRequest): void {
     this.runtime.scheduler.setBreakpoints(request.actionIds);
   }
+
+  async handleUploadBlob(
+    request: UploadBlobRequest,
+  ): Promise<UploadBlobResponse> {
+    const suffix = (request.suffix ?? "bin").replace(/^\./, "") || "bin";
+    const target = new URL(
+      `/${this.space}/blobs/upload.${encodeURIComponent(suffix)}`,
+      this.apiUrl,
+    );
+    const body = withUnifiedEncoding(() =>
+      encodeMemoryBoundary({
+        type: request.contentType,
+        body: new FabricBytes(request.body),
+      })
+    );
+    const response = await fetch(target, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Blob upload failed: ${response.status} ${await response.text()}`,
+      );
+    }
+    const result = await response.json() as Partial<UploadBlobResponse>;
+    if (typeof result.id !== "string" || typeof result.url !== "string") {
+      throw new Error("Blob upload returned an invalid response");
+    }
+    return { id: result.id, url: result.url };
+  }
+
   async detectNonIdempotent(
     request: DetectNonIdempotentRequest,
   ): Promise<DetectNonIdempotentResponse> {
@@ -987,6 +1058,8 @@ export class RuntimeProcessor {
         return this.getPatternSources(request);
       case RequestType.SetBreakpoints:
         return this.setBreakpoints(request);
+      case RequestType.UploadBlob:
+        return await this.handleUploadBlob(request);
       case RequestType.VDomEvent:
         return this.handleVDomEvent(request);
       case RequestType.VDomMount:

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1,15 +1,5 @@
 import { DID, Identity, type Session } from "@commonfabric/identity";
-import {
-  getDataModelConfig,
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
 import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
-import {
-  getJsonEncodingConfig,
-  resetJsonEncodingConfig,
-  setJsonEncodingConfig,
-} from "@commonfabric/data-model/json-encoding";
 import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import { PieceManager } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
@@ -124,27 +114,6 @@ import type { VDomOp } from "../protocol/types.ts";
 import type { RuntimeOptions } from "@commonfabric/runner";
 
 const MAX_SERIALIZATION_DEPTH = 5;
-
-const withUnifiedEncoding = <T>(fn: () => T): T => {
-  const previousDataModel = getDataModelConfig();
-  const previousJson = getJsonEncodingConfig();
-  setDataModelConfig(true);
-  setJsonEncodingConfig(true);
-  try {
-    return fn();
-  } finally {
-    if (previousDataModel) {
-      setDataModelConfig(true);
-    } else {
-      resetDataModelConfig();
-    }
-    if (previousJson) {
-      setJsonEncodingConfig(true);
-    } else {
-      resetJsonEncodingConfig();
-    }
-  }
-};
 
 export function runtimeOptionsFromInitializationData(
   data: InitializationData,
@@ -872,12 +841,10 @@ export class RuntimeProcessor {
       `/${this.space}/blobs/upload.${encodeURIComponent(suffix)}`,
       this.apiUrl,
     );
-    const body = withUnifiedEncoding(() =>
-      encodeMemoryBoundary({
-        type: request.contentType,
-        body: new FabricBytes(request.body),
-      })
-    );
+    const body = encodeMemoryBoundary({
+      type: request.contentType,
+      body: new FabricBytes(request.body),
+    });
     const response = await fetch(target, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1,6 +1,7 @@
 import { DID, Identity, type Session } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
-import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { JsonEncodingContext } from "@commonfabric/data-model/json-encoding-context";
 import { PieceManager } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
 import {
@@ -114,6 +115,7 @@ import type { VDomOp } from "../protocol/types.ts";
 import type { RuntimeOptions } from "@commonfabric/runner";
 
 const MAX_SERIALIZATION_DEPTH = 5;
+const blobUploadEncoding = new JsonEncodingContext();
 
 export function runtimeOptionsFromInitializationData(
   data: InitializationData,
@@ -841,10 +843,12 @@ export class RuntimeProcessor {
       `/${this.space}/blobs/upload.${encodeURIComponent(suffix)}`,
       this.apiUrl,
     );
-    const body = encodeMemoryBoundary({
+    // Blob upload payloads must preserve FabricBytes even when the wider
+    // process is running with legacy memory JSON flags.
+    const body = blobUploadEncoding.encode({
       type: request.contentType,
       body: new FabricBytes(request.body),
-    });
+    } as FabricValue);
     const response = await fetch(target, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -67,6 +67,7 @@ export enum RequestType {
   DetectNonIdempotent = "runtime:detectNonIdempotent",
   GetPatternSources = "runtime:getPatternSources",
   SetBreakpoints = "runtime:setBreakpoints",
+  UploadBlob = "runtime:uploadBlob",
 
   // Page operations (main -> worker)
   GetSpaceRootPattern = "pattern:getSpaceRoot",
@@ -346,6 +347,18 @@ export interface SetBreakpointsRequest extends BaseRequest {
   actionIds: string[];
 }
 
+export interface UploadBlobRequest extends BaseRequest {
+  type: RequestType.UploadBlob;
+  contentType: string;
+  body: Uint8Array;
+  suffix?: string;
+}
+
+export interface UploadBlobResponse {
+  id: string;
+  url: string;
+}
+
 // Logger count types for IPC (matches @commonfabric/utils/logger types)
 export interface LogCounts {
   debug: number;
@@ -581,7 +594,8 @@ export type IPCClientRequest =
   | VDomUnmountRequest
   | DetectNonIdempotentRequest
   | GetPatternSourcesRequest
-  | SetBreakpointsRequest;
+  | SetBreakpointsRequest
+  | UploadBlobRequest;
 
 export type NullResponse = null;
 
@@ -710,7 +724,8 @@ export type RemoteResponse =
   | PageResponse
   | VDomMountResponse
   | DetectNonIdempotentResponse
-  | PatternSourcesResponse;
+  | PatternSourcesResponse
+  | UploadBlobResponse;
 
 export type IPCRemoteNotification =
   | CellUpdateNotification
@@ -887,6 +902,10 @@ export type Commands = {
   [RequestType.SetBreakpoints]: {
     request: SetBreakpointsRequest;
     response: EmptyResponse;
+  };
+  [RequestType.UploadBlob]: {
+    request: UploadBlobRequest;
+    response: UploadBlobResponse;
   };
   // VDOM requests
   [RequestType.VDomEvent]: {

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -35,6 +35,7 @@ import {
   type PatternSourcesResponse,
   RequestType,
   TelemetryNotification,
+  type UploadBlobResponse,
 } from "./protocol/mod.ts";
 import { NameSchema } from "@commonfabric/runner/schemas";
 import { RuntimeTransport } from "./client/transport.ts";
@@ -441,6 +442,17 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     await this.#conn.request<RequestType.SetBreakpoints>({
       type: RequestType.SetBreakpoints,
       actionIds,
+    });
+  }
+
+  async uploadBlob(options: {
+    contentType: string;
+    body: Uint8Array;
+    suffix?: string;
+  }): Promise<UploadBlobResponse> {
+    return await this.#conn.request<RequestType.UploadBlob>({
+      type: RequestType.UploadBlob,
+      ...options,
     });
   }
 

--- a/packages/shell/integration/blob-upload.test.ts
+++ b/packages/shell/integration/blob-upload.test.ts
@@ -1,0 +1,126 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { env, waitFor } from "@commonfabric/integration";
+import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+
+const { FRONTEND_URL } = env;
+
+describe("shell blob upload", () => {
+  const shell = new ShellIntegration();
+  shell.bindLifecycle();
+
+  it("uploads an image and displays it through a relative blobs path", async () => {
+    const identity = await Identity.generate({ implementation: "noble" });
+    const spaceName = `blob-upload-${Date.now()}`;
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName },
+      identity,
+    });
+    await waitFor(async () =>
+      await shell.page().evaluate(() =>
+        Boolean(
+          (globalThis as unknown as {
+            commonfabric?: { rt?: unknown };
+          }).commonfabric?.rt,
+        )
+      )
+    );
+
+    const result = await shell.page().evaluate(async () => {
+      const rt = (globalThis as unknown as {
+        commonfabric?: {
+          rt?: {
+            uploadBlob(options: {
+              contentType: string;
+              body: Uint8Array;
+              suffix?: string;
+            }): Promise<{ id: string; url: string }>;
+          };
+          space?: string;
+        };
+      }).commonfabric?.rt;
+      if (!rt) {
+        throw new Error("Runtime client was not exposed");
+      }
+
+      const upload = await rt.uploadBlob({
+        contentType: "image/gif",
+        suffix: "gif",
+        body: new Uint8Array([
+          0x47,
+          0x49,
+          0x46,
+          0x38,
+          0x39,
+          0x61,
+          0x01,
+          0x00,
+          0x01,
+          0x00,
+          0x80,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0xff,
+          0xff,
+          0xff,
+          0x2c,
+          0x00,
+          0x00,
+          0x00,
+          0x00,
+          0x01,
+          0x00,
+          0x01,
+          0x00,
+          0x00,
+          0x02,
+          0x02,
+          0x44,
+          0x01,
+          0x00,
+          0x3b,
+        ]),
+      });
+
+      const image = document.createElement("img");
+      image.setAttribute("data-blob-upload-test", "true");
+      image.src = upload.url;
+      document.body.append(image);
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error("Timed out loading uploaded image")),
+          5000,
+        );
+        image.onload = () => {
+          clearTimeout(timeout);
+          resolve();
+        };
+        image.onerror = () => {
+          clearTimeout(timeout);
+          reject(new Error(`Failed to load ${image.currentSrc}`));
+        };
+      });
+
+      return {
+        relativeUrl: upload.url,
+        currentSrc: image.currentSrc,
+        width: image.naturalWidth,
+        height: image.naturalHeight,
+      };
+    });
+
+    await waitFor(() => Promise.resolve(result.width === 1));
+
+    expect(result.relativeUrl.startsWith("blobs/")).toBe(true);
+    expect(result.currentSrc).toContain("/did:key:");
+    expect(result.currentSrc).toContain("/blobs/");
+    expect(result.width).toBe(1);
+    expect(result.height).toBe(1);
+  });
+});

--- a/packages/shell/integration/blob-upload.test.ts
+++ b/packages/shell/integration/blob-upload.test.ts
@@ -89,6 +89,10 @@ describe("shell blob upload", () => {
 
       const image = document.createElement("img");
       image.setAttribute("data-blob-upload-test", "true");
+      image.alt = "Uploaded blob test image";
+      image.style.width = "16px";
+      image.style.height = "16px";
+      image.style.imageRendering = "pixelated";
       image.src = upload.url;
       document.body.append(image);
 
@@ -110,17 +114,71 @@ describe("shell blob upload", () => {
       return {
         relativeUrl: upload.url,
         currentSrc: image.currentSrc,
-        width: image.naturalWidth,
-        height: image.naturalHeight,
       };
     });
 
-    await waitFor(() => Promise.resolve(result.width === 1));
+    const image = await shell.page().waitForSelector(
+      "[data-blob-upload-test='true']",
+    );
+
+    await waitFor(async () =>
+      await shell.page().evaluate(() => {
+        const image = document.querySelector<HTMLImageElement>(
+          "[data-blob-upload-test='true']",
+        );
+        if (!image) return false;
+        const rect = image.getBoundingClientRect();
+        return image.complete &&
+          image.naturalWidth === 1 &&
+          image.naturalHeight === 1 &&
+          rect.width === 16 &&
+          rect.height === 16;
+      })
+    );
+    const box = await image.boundingBox();
+
+    const rendered = await shell.page().evaluate(() => {
+      const image = document.querySelector<HTMLImageElement>(
+        "[data-blob-upload-test='true']",
+      );
+      if (!image) {
+        throw new Error("Uploaded image was not added to the document");
+      }
+
+      const canvas = document.createElement("canvas");
+      canvas.width = 1;
+      canvas.height = 1;
+      const context = canvas.getContext("2d");
+      if (!context) {
+        throw new Error("Could not read uploaded image pixels");
+      }
+      context.drawImage(image, 0, 0, 1, 1);
+      const [red, green, blue, alpha] = context.getImageData(0, 0, 1, 1).data;
+      const rect = image.getBoundingClientRect();
+
+      return {
+        complete: image.complete,
+        currentSrc: image.currentSrc,
+        naturalWidth: image.naturalWidth,
+        naturalHeight: image.naturalHeight,
+        renderedWidth: rect.width,
+        renderedHeight: rect.height,
+        pixel: { red, green, blue, alpha },
+      };
+    });
 
     expect(result.relativeUrl.startsWith("blobs/")).toBe(true);
     expect(result.currentSrc).toContain("/did:key:");
     expect(result.currentSrc).toContain("/blobs/");
-    expect(result.width).toBe(1);
-    expect(result.height).toBe(1);
+    expect(Boolean(box)).toBe(true);
+    expect(box?.width).toBe(16);
+    expect(box?.height).toBe(16);
+    expect(rendered.complete).toBe(true);
+    expect(rendered.currentSrc).toBe(result.currentSrc);
+    expect(rendered.naturalWidth).toBe(1);
+    expect(rendered.naturalHeight).toBe(1);
+    expect(rendered.renderedWidth).toBe(16);
+    expect(rendered.renderedHeight).toBe(16);
+    expect(rendered.pixel.alpha).toBe(255);
   });
 });

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -208,6 +208,15 @@ export class RuntimeInternals extends EventTarget {
     await this.#client.idle();
   }
 
+  async uploadBlob(options: {
+    contentType: string;
+    body: Uint8Array;
+    suffix?: string;
+  }): Promise<{ id: string; url: string }> {
+    this.#check();
+    return await this.#client.uploadBlob(options);
+  }
+
   async dispose(): Promise<void> {
     if (this.#disposed) return;
     this.#disposed = true;

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -40,6 +40,26 @@ function getCommonfabricGlobal(): typeof globalThis & {
   };
 }
 
+const SPACE_BASE_SELECTOR = 'base[data-commonfabric-space-base="true"]';
+
+function setSpaceBaseHref(space?: DID): void {
+  const existing = document.head.querySelector<HTMLBaseElement>(
+    SPACE_BASE_SELECTOR,
+  );
+  if (!space) {
+    existing?.remove();
+    return;
+  }
+
+  const href = `/${space}/`;
+  const base = existing ?? document.createElement("base");
+  base.setAttribute("data-commonfabric-space-base", "true");
+  base.href = href;
+  if (!existing) {
+    document.head.prepend(base);
+  }
+}
+
 // The root element for the shell application.
 //
 // Derives `RuntimeInternals` for the application from its `AppState`.
@@ -101,6 +121,7 @@ export class XRootView extends BaseView {
           // Clear the runtime and space when no app state
           this.runtime = undefined;
           this.space = undefined;
+          setSpaceBaseHref();
           const global = getCommonfabricGlobal();
           if (global.commonfabric) {
             global.commonfabric.rt = undefined;
@@ -118,6 +139,7 @@ export class XRootView extends BaseView {
           rt.dispose().catch(console.error);
           this.runtime = undefined;
           this.space = undefined;
+          setSpaceBaseHref();
           const global = getCommonfabricGlobal();
           if (global.commonfabric) {
             global.commonfabric.rt = undefined;
@@ -128,6 +150,7 @@ export class XRootView extends BaseView {
         // Update the provided runtime and space values
         this.runtime = rt.runtime();
         this.space = rt.space() as DID;
+        setSpaceBaseHref(this.space);
 
         // Expose RuntimeClient for console debugging
         // (e.g. commonfabric.rt.setLoggerLevel("debug"))
@@ -183,6 +206,7 @@ export class XRootView extends BaseView {
       "theme-preference-changed",
       this._onThemeChanged,
     );
+    setSpaceBaseHref();
     super.disconnectedCallback();
   }
 

--- a/packages/toolshed/app.ts
+++ b/packages/toolshed/app.ts
@@ -12,6 +12,7 @@ import discord from "@/routes/integrations/discord/discord.index.ts";
 import plaidOAuth from "@/routes/integrations/plaid-oauth/plaid-oauth.index.ts";
 import { buildProviderRouters } from "@/routes/integrations/provider-registry.ts";
 import memory from "@/routes/storage/memory/memory.index.ts";
+import blobs from "@/routes/blobs/blobs.index.ts";
 import whoami from "@/routes/whoami/whoami.index.ts";
 import meta from "@/routes/meta/meta.index.ts";
 import shell from "@/routes/shell/shell.index.ts";
@@ -37,6 +38,7 @@ const routes = [
   discord,
   plaidOAuth,
   memory,
+  blobs,
   whoami,
   meta,
   staticRoute,

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -9,7 +9,10 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { JsonEncodingContext } from "@commonfabric/data-model/json-encoding-context";
 import type { ReconstructionContext } from "@commonfabric/data-model/fabric-value";
-import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+} from "@commonfabric/memory/v2";
 import type { Context } from "@hono/hono";
 
 const router = createRouter();
@@ -52,6 +55,37 @@ class BlobPayloadTooLarge extends Error {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 
+const toByteArray = (value: unknown): Uint8Array | undefined => {
+  if (value instanceof Uint8Array) {
+    return value;
+  }
+  if (
+    Array.isArray(value) &&
+    value.every((item) => Number.isInteger(item) && item >= 0 && item <= 255)
+  ) {
+    return Uint8Array.from(value);
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const entries = Object.entries(value)
+    .map(([key, item]) => [Number(key), item] as const)
+    .filter(([index, item]) =>
+      Number.isInteger(index) && index >= 0 &&
+      typeof item === "number" && Number.isInteger(item) &&
+      item >= 0 && item <= 255
+    )
+    .toSorted(([left], [right]) => left - right);
+  if (
+    entries.length === 0 ||
+    entries.some(([index], position) => index !== position)
+  ) {
+    return undefined;
+  }
+  return Uint8Array.from(entries.map(([, item]) => item as number));
+};
+
 const asBlobContents = (value: unknown): BlobContents | undefined => {
   if (!isRecord(value) || typeof value.type !== "string") {
     return undefined;
@@ -59,8 +93,24 @@ const asBlobContents = (value: unknown): BlobContents | undefined => {
   if (value.body instanceof FabricBytes) {
     return { type: value.type, body: value.body };
   }
+  const bytes = toByteArray(value.body);
+  if (bytes) {
+    return { type: value.type, body: new FabricBytes(bytes) };
+  }
   return undefined;
 };
+
+const memoryBoundaryPreservesBlobContents = (contents: BlobContents): boolean =>
+  asBlobContents(decodeMemoryBoundary(encodeMemoryBoundary(contents))) !==
+    undefined;
+
+const storedBlobValue = (contents: BlobContents): BlobContents | {
+  type: string;
+  body: number[];
+} =>
+  memoryBoundaryPreservesBlobContents(contents)
+    ? contents
+    : { type: contents.type, body: Array.from(contents.body.slice()) };
 
 const parseBlobName = (
   blobName: string,
@@ -173,7 +223,7 @@ const upload = async (c: Context) => {
   await memoryServer.writeDocument(
     spaceDid,
     `cid:${id}`,
-    contents,
+    storedBlobValue(contents),
   );
 
   return c.json({ id, url: `blobs/${hash}.${suffix}` }, 201);

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -128,7 +128,7 @@ const upload = async (c: any) => {
   await memoryServer.writeDocument(
     spaceDid,
     `cid:${id}`,
-    { value: contents },
+    contents,
     { unifiedJsonEncoding: true },
   );
 

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -1,3 +1,7 @@
+// Blob routes are intentionally unauthenticated for the MVP. Anyone can POST a
+// blob into any space DID; content addressing prevents overwriting a different
+// payload, but callers can inject blobs and consume storage. Anyone with a hash
+// can GET the blob. Revisit this before any production exposure.
 import { createRouter } from "@/lib/create-app.ts";
 import { memoryServer } from "@/routes/storage/memory.ts";
 import { isDID } from "@commonfabric/identity";

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -7,20 +7,8 @@ import { memoryServer } from "@/routes/storage/memory.ts";
 import { isDID } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
 import { hashOf } from "@commonfabric/data-model/value-hash";
-import {
-  getDataModelConfig,
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
-import {
-  decodeMemoryBoundary,
-  encodeMemoryBoundary,
-} from "@commonfabric/memory/v2";
-import {
-  getJsonEncodingConfig,
-  resetJsonEncodingConfig,
-  setJsonEncodingConfig,
-} from "@commonfabric/data-model/json-encoding";
+import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
+import type { Context } from "@hono/hono";
 
 const router = createRouter();
 
@@ -37,28 +25,7 @@ const DEFAULT_SUFFIX_BY_TYPE: Record<string, string> = {
   "image/svg+xml": "svg",
 };
 
-const withUnifiedJsonEncoding = async <T>(
-  fn: () => Promise<T> | T,
-): Promise<T> => {
-  const previous = getJsonEncodingConfig();
-  const previousDataModel = getDataModelConfig();
-  setDataModelConfig(true);
-  setJsonEncodingConfig(true);
-  try {
-    return await fn();
-  } finally {
-    if (previousDataModel) {
-      setDataModelConfig(true);
-    } else {
-      resetDataModelConfig();
-    }
-    if (previous) {
-      setJsonEncodingConfig(true);
-    } else {
-      resetJsonEncodingConfig();
-    }
-  }
-};
+const VALID_SUFFIX = /^[A-Za-z0-9]{1,8}$/;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
@@ -73,9 +40,17 @@ const asBlobContents = (value: unknown): BlobContents | undefined => {
   return undefined;
 };
 
-const parseBlobName = (blobName: string): { id: string; hash: string } => {
-  const hash = blobName.split(".")[0] ?? "";
-  const id = hash.startsWith("fid1:") ? hash : `fid1:${hash}`;
+const parseBlobName = (
+  blobName: string,
+): { id: string; hash: string } | undefined => {
+  const hashSegment = blobName.split(".")[0] ?? "";
+  const id = hashSegment.startsWith("fid1:")
+    ? hashSegment
+    : `fid1:${hashSegment}`;
+  const hash = id.slice("fid1:".length);
+  if (hash.length === 0) {
+    return undefined;
+  }
   return { id, hash: id.slice("fid1:".length) };
 };
 
@@ -83,7 +58,7 @@ const suffixFor = (blobName: string | undefined, type: string): string => {
   const extension = blobName?.includes(".")
     ? blobName.split(".").pop()
     : undefined;
-  if (extension) return extension;
+  if (extension && VALID_SUFFIX.test(extension)) return extension;
   return DEFAULT_SUFFIX_BY_TYPE[type] ?? "bin";
 };
 
@@ -92,9 +67,7 @@ const readRequestContents = async (request: Request) => {
   if (!source) {
     return undefined;
   }
-  return await withUnifiedJsonEncoding(() =>
-    asBlobContents(decodeMemoryBoundary(source))
-  );
+  return asBlobContents(decodeMemoryBoundary(source));
 };
 
 const loadBlobContents = async (
@@ -104,12 +77,11 @@ const loadBlobContents = async (
   const document = await memoryServer.readDocument(
     spaceDid,
     `cid:${id}`,
-    { unifiedJsonEncoding: true },
   );
   return asBlobContents(document?.value);
 };
 
-const upload = async (c: any) => {
+const upload = async (c: Context) => {
   const spaceDid = c.req.param("spaceDid");
   if (!isDID(spaceDid)) {
     return c.text("Invalid space DID", 400);
@@ -133,7 +105,6 @@ const upload = async (c: any) => {
     spaceDid,
     `cid:${id}`,
     contents,
-    { unifiedJsonEncoding: true },
   );
 
   return c.json({ id, url: `blobs/${hash}.${suffix}` }, 201);
@@ -148,7 +119,11 @@ router.get("/:spaceDid/blobs/:blobName", async (c) => {
     return c.text("Invalid space DID", 400);
   }
 
-  const { id } = parseBlobName(c.req.param("blobName"));
+  const parsed = parseBlobName(c.req.param("blobName"));
+  if (!parsed) {
+    return c.text("Invalid blob name", 400);
+  }
+  const { id } = parsed;
   const contents = await loadBlobContents(spaceDid, id);
   if (!contents) {
     return c.text("Blob not found", 404);
@@ -164,8 +139,5 @@ router.get("/:spaceDid/blobs/:blobName", async (c) => {
     },
   });
 });
-
-export const encodeBlobContents = (contents: BlobContents): string =>
-  encodeMemoryBoundary(contents);
 
 export default router;

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -7,10 +7,18 @@ import { memoryServer } from "@/routes/storage/memory.ts";
 import { isDID } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { JsonEncodingContext } from "@commonfabric/data-model/json-encoding-context";
+import type { ReconstructionContext } from "@commonfabric/data-model/fabric-value";
 import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
 import type { Context } from "@hono/hono";
 
 const router = createRouter();
+const blobUploadEncoding = new JsonEncodingContext();
+const blobReconstructionContext: ReconstructionContext = {
+  getCell() {
+    throw new Error("Blob upload payloads cannot contain cell references");
+  },
+};
 
 type BlobContents = {
   type: string;
@@ -119,7 +127,13 @@ const readRequestContents = async (request: Request) => {
   if (!source) {
     return undefined;
   }
-  return asBlobContents(decodeMemoryBoundary(source));
+  try {
+    return asBlobContents(
+      blobUploadEncoding.decode(source, blobReconstructionContext),
+    );
+  } catch {
+    return asBlobContents(decodeMemoryBoundary(source));
+  }
 };
 
 const loadBlobContents = async (

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -25,7 +25,21 @@ const DEFAULT_SUFFIX_BY_TYPE: Record<string, string> = {
   "image/svg+xml": "svg",
 };
 
+const MAX_BLOB_UPLOAD_BYTES = 10 * 1024 * 1024;
+const SAFE_RESPONSE_TYPES = new Set([
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
 const VALID_SUFFIX = /^[A-Za-z0-9]{1,8}$/;
+
+class BlobPayloadTooLarge extends Error {
+  constructor() {
+    super("Blob payload too large");
+    this.name = "BlobPayloadTooLarge";
+  }
+}
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
@@ -62,8 +76,46 @@ const suffixFor = (blobName: string | undefined, type: string): string => {
   return DEFAULT_SUFFIX_BY_TYPE[type] ?? "bin";
 };
 
+const safeResponseType = (type: string): string =>
+  SAFE_RESPONSE_TYPES.has(type) ? type : "application/octet-stream";
+
+const readLimitedText = async (request: Request): Promise<string> => {
+  const contentLength = Number(request.headers.get("Content-Length"));
+  if (Number.isFinite(contentLength) && contentLength > MAX_BLOB_UPLOAD_BYTES) {
+    throw new BlobPayloadTooLarge();
+  }
+
+  const reader = request.body?.getReader();
+  if (!reader) {
+    return "";
+  }
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    total += value.byteLength;
+    if (total > MAX_BLOB_UPLOAD_BYTES) {
+      await reader.cancel();
+      throw new BlobPayloadTooLarge();
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
+};
+
 const readRequestContents = async (request: Request) => {
-  const source = await request.text();
+  const source = await readLimitedText(request);
   if (!source) {
     return undefined;
   }
@@ -90,7 +142,10 @@ const upload = async (c: Context) => {
   let contents: BlobContents | undefined;
   try {
     contents = await readRequestContents(c.req.raw);
-  } catch {
+  } catch (error) {
+    if (error instanceof BlobPayloadTooLarge) {
+      return c.text("Blob payload too large", 413);
+    }
     return c.text("Invalid blob payload", 400);
   }
   if (!contents) {
@@ -134,7 +189,7 @@ router.get("/:spaceDid/blobs/:blobName", async (c) => {
   return new Response(body, {
     status: 200,
     headers: {
-      "Content-Type": contents.type,
+      "Content-Type": safeResponseType(contents.type),
       "Cache-Control": "public, max-age=31536000, immutable",
     },
   });

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -1,0 +1,167 @@
+import { createRouter } from "@/lib/create-app.ts";
+import { memoryServer } from "@/routes/storage/memory.ts";
+import { isDID } from "@commonfabric/identity";
+import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import {
+  getDataModelConfig,
+  resetDataModelConfig,
+  setDataModelConfig,
+} from "@commonfabric/data-model/fabric-value";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+} from "@commonfabric/memory/v2";
+import {
+  getJsonEncodingConfig,
+  resetJsonEncodingConfig,
+  setJsonEncodingConfig,
+} from "@commonfabric/data-model/json-encoding";
+
+const router = createRouter();
+
+type BlobContents = {
+  type: string;
+  body: FabricBytes;
+};
+
+const DEFAULT_SUFFIX_BY_TYPE: Record<string, string> = {
+  "image/gif": "gif",
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/svg+xml": "svg",
+};
+
+const withUnifiedJsonEncoding = async <T>(
+  fn: () => Promise<T> | T,
+): Promise<T> => {
+  const previous = getJsonEncodingConfig();
+  const previousDataModel = getDataModelConfig();
+  setDataModelConfig(true);
+  setJsonEncodingConfig(true);
+  try {
+    return await fn();
+  } finally {
+    if (previousDataModel) {
+      setDataModelConfig(true);
+    } else {
+      resetDataModelConfig();
+    }
+    if (previous) {
+      setJsonEncodingConfig(true);
+    } else {
+      resetJsonEncodingConfig();
+    }
+  }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const asBlobContents = (value: unknown): BlobContents | undefined => {
+  if (!isRecord(value) || typeof value.type !== "string") {
+    return undefined;
+  }
+  if (value.body instanceof FabricBytes) {
+    return { type: value.type, body: value.body };
+  }
+  return undefined;
+};
+
+const parseBlobName = (blobName: string): { id: string; hash: string } => {
+  const hash = blobName.split(".")[0] ?? "";
+  const id = hash.startsWith("fid1:") ? hash : `fid1:${hash}`;
+  return { id, hash: id.slice("fid1:".length) };
+};
+
+const suffixFor = (blobName: string | undefined, type: string): string => {
+  const extension = blobName?.includes(".")
+    ? blobName.split(".").pop()
+    : undefined;
+  if (extension) return extension;
+  return DEFAULT_SUFFIX_BY_TYPE[type] ?? "bin";
+};
+
+const readRequestContents = async (request: Request) => {
+  const source = await request.text();
+  if (!source) {
+    return undefined;
+  }
+  return await withUnifiedJsonEncoding(() =>
+    asBlobContents(decodeMemoryBoundary(source))
+  );
+};
+
+const loadBlobContents = async (
+  spaceDid: string,
+  id: string,
+): Promise<BlobContents | undefined> => {
+  const document = await memoryServer.readDocument(
+    spaceDid,
+    `cid:${id}`,
+    { unifiedJsonEncoding: true },
+  );
+  return asBlobContents(document?.value);
+};
+
+const upload = async (c: any) => {
+  const spaceDid = c.req.param("spaceDid");
+  if (!isDID(spaceDid)) {
+    return c.text("Invalid space DID", 400);
+  }
+
+  let contents: BlobContents | undefined;
+  try {
+    contents = await readRequestContents(c.req.raw);
+  } catch {
+    return c.text("Invalid blob payload", 400);
+  }
+  if (!contents) {
+    return c.text("Invalid blob payload", 400);
+  }
+
+  const id = hashOf(contents).toString();
+  const blobName = c.req.param("blobName") as string | undefined;
+  const suffix = suffixFor(blobName, contents.type);
+  const hash = id.slice("fid1:".length);
+  await memoryServer.writeDocument(
+    spaceDid,
+    `cid:${id}`,
+    { value: contents },
+    { unifiedJsonEncoding: true },
+  );
+
+  return c.json({ id, url: `blobs/${hash}.${suffix}` }, 201);
+};
+
+router.post("/:spaceDid/blobs", upload);
+router.post("/:spaceDid/blobs/:blobName", upload);
+
+router.get("/:spaceDid/blobs/:blobName", async (c) => {
+  const spaceDid = c.req.param("spaceDid");
+  if (!isDID(spaceDid)) {
+    return c.text("Invalid space DID", 400);
+  }
+
+  const { id } = parseBlobName(c.req.param("blobName"));
+  const contents = await loadBlobContents(spaceDid, id);
+  if (!contents) {
+    return c.text("Blob not found", 404);
+  }
+
+  const bytes = contents.body.slice();
+  const body = new Uint8Array(bytes).buffer;
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": contents.type,
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
+  });
+});
+
+export const encodeBlobContents = (contents: BlobContents): string =>
+  encodeMemoryBoundary(contents);
+
+export default router;

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -202,6 +202,50 @@ describe("Blob Routes", () => {
     });
   });
 
+  it("rejects oversized blob uploads before decoding", async () => {
+    const identity = await Identity.fromPassphrase(
+      "toolshed-blob-route-too-large",
+    );
+
+    const post = await app.request(`/${identity.did()}/blobs/image.png`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": String(10 * 1024 * 1024 + 1),
+      },
+      body: "not decoded",
+    });
+
+    expect(post.status).toBe(413);
+  });
+
+  it("serves unsafe blob MIME types as octet-stream", async () => {
+    const identity = await Identity.fromPassphrase(
+      "toolshed-blob-route-unsafe-mime",
+    );
+    const bytes = new TextEncoder().encode("<script>alert(1)</script>");
+    const contents = {
+      type: "text/html",
+      body: new FabricBytes(bytes),
+    };
+    const id = hashOf(contents).toString();
+    const hash = id.slice("fid1:".length);
+
+    await withUnifiedJsonEncoding(async () => {
+      const post = await app.request(`/${identity.did()}/blobs/page.html`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: encodeBlobPayload(contents),
+      });
+      expect(post.status).toBe(201);
+
+      const get = await app.request(`/${identity.did()}/blobs/${hash}.html`);
+      expect(get.status).toBe(200);
+      expect(get.headers.get("Content-Type")).toBe("application/octet-stream");
+      expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
+    });
+  });
+
   it("rejects invalid blob payloads", async () => {
     const identity = await Identity.fromPassphrase("toolshed-blob-route-400");
     const post = await app.request(`/${identity.did()}/blobs/image.gif`, {

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -1,0 +1,94 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import createApp from "@/lib/create-app.ts";
+import router from "./blobs.index.ts";
+import env from "@/env.ts";
+import { Identity } from "@commonfabric/identity";
+import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
+import {
+  getJsonEncodingConfig,
+  resetJsonEncodingConfig,
+  setJsonEncodingConfig,
+} from "@commonfabric/data-model/json-encoding";
+import {
+  getDataModelConfig,
+  resetDataModelConfig,
+  setDataModelConfig,
+} from "@commonfabric/data-model/fabric-value";
+
+if (env.ENV !== "test") {
+  throw new Error("ENV must be 'test'");
+}
+
+const app = createApp().route("/", router);
+
+const withUnifiedJsonEncoding = <T>(fn: () => T): T => {
+  const previous = getJsonEncodingConfig();
+  const previousDataModel = getDataModelConfig();
+  setDataModelConfig(true);
+  setJsonEncodingConfig(true);
+  try {
+    return fn();
+  } finally {
+    if (previousDataModel) {
+      setDataModelConfig(true);
+    } else {
+      resetDataModelConfig();
+    }
+    if (previous) {
+      setJsonEncodingConfig(true);
+    } else {
+      resetJsonEncodingConfig();
+    }
+  }
+};
+
+const encodeBlobPayload = (payload: { type: string; body: FabricBytes }) =>
+  withUnifiedJsonEncoding(() => encodeMemoryBoundary(payload));
+
+describe("Blob Routes", () => {
+  it("stores and serves a FabricBytes blob by content id", async () => {
+    const identity = await Identity.fromPassphrase("toolshed-blob-route");
+    const bytes = new Uint8Array([71, 73, 70, 56, 57, 97]);
+    const contents = {
+      type: "image/gif",
+      body: new FabricBytes(bytes),
+    };
+    const id = hashOf(contents).toString();
+    const hash = id.slice("fid1:".length);
+
+    const post = await app.request(`/${identity.did()}/blobs/image.gif`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: encodeBlobPayload(contents),
+    });
+    expect(post.status).toBe(201);
+    expect(await post.json()).toEqual({
+      id,
+      url: `blobs/${hash}.gif`,
+    });
+
+    const get = await app.request(`/${identity.did()}/blobs/${hash}.png`);
+    expect(get.status).toBe(200);
+    expect(get.headers.get("Content-Type")).toBe("image/gif");
+    expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
+  });
+
+  it("returns 404 for an absent blob", async () => {
+    const identity = await Identity.fromPassphrase("toolshed-blob-route-404");
+    const get = await app.request(`/${identity.did()}/blobs/missing.png`);
+    expect(get.status).toBe(404);
+  });
+
+  it("rejects invalid blob payloads", async () => {
+    const identity = await Identity.fromPassphrase("toolshed-blob-route-400");
+    const post = await app.request(`/${identity.did()}/blobs/image.gif`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "image/gif", body: "not-bytes" }),
+    });
+    expect(post.status).toBe(400);
+  });
+});

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import createApp from "@/lib/create-app.ts";
 import router from "./blobs.index.ts";
@@ -30,20 +30,22 @@ const app = createApp()
   .route("/", memory)
   .route("/", router);
 
-const withUnifiedJsonEncoding = <T>(fn: () => T): T => {
-  const previous = getJsonEncodingConfig();
+const withUnifiedJsonEncoding = async <T>(
+  fn: () => Promise<T> | T,
+): Promise<T> => {
+  const previousJson = getJsonEncodingConfig();
   const previousDataModel = getDataModelConfig();
   setDataModelConfig(true);
   setJsonEncodingConfig(true);
   try {
-    return fn();
+    return await fn();
   } finally {
     if (previousDataModel) {
       setDataModelConfig(true);
     } else {
       resetDataModelConfig();
     }
-    if (previous) {
+    if (previousJson) {
       setJsonEncodingConfig(true);
     } else {
       resetJsonEncodingConfig();
@@ -52,9 +54,13 @@ const withUnifiedJsonEncoding = <T>(fn: () => T): T => {
 };
 
 const encodeBlobPayload = (payload: { type: string; body: FabricBytes }) =>
-  withUnifiedJsonEncoding(() => encodeMemoryBoundary(payload));
+  encodeMemoryBoundary(payload);
 
 describe("Blob Routes", () => {
+  afterEach(async () => {
+    await memoryServer.flushSessions();
+  });
+
   it("stores and serves a FabricBytes blob by content id", async () => {
     const identity = await Identity.fromPassphrase("toolshed-blob-route");
     const bytes = new Uint8Array([71, 73, 70, 56, 57, 97]);
@@ -65,21 +71,23 @@ describe("Blob Routes", () => {
     const id = hashOf(contents).toString();
     const hash = id.slice("fid1:".length);
 
-    const post = await app.request(`/${identity.did()}/blobs/image.gif`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: encodeBlobPayload(contents),
-    });
-    expect(post.status).toBe(201);
-    expect(await post.json()).toEqual({
-      id,
-      url: `blobs/${hash}.gif`,
-    });
+    await withUnifiedJsonEncoding(async () => {
+      const post = await app.request(`/${identity.did()}/blobs/image.gif`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: encodeBlobPayload(contents),
+      });
+      expect(post.status).toBe(201);
+      expect(await post.json()).toEqual({
+        id,
+        url: `blobs/${hash}.gif`,
+      });
 
-    const get = await app.request(`/${identity.did()}/blobs/${hash}.png`);
-    expect(get.status).toBe(200);
-    expect(get.headers.get("Content-Type")).toBe("image/gif");
-    expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
+      const get = await app.request(`/${identity.did()}/blobs/${hash}.png`);
+      expect(get.status).toBe(200);
+      expect(get.headers.get("Content-Type")).toBe("image/gif");
+      expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
+    });
   });
 
   it("stores blob contents as a cell document value", async () => {
@@ -93,68 +101,105 @@ describe("Blob Routes", () => {
     const cid = `cid:${id}` as const;
     const hash = id.slice("fid1:".length);
 
-    const post = await app.request(`/${identity.did()}/blobs/image.png`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: encodeBlobPayload(contents),
-    });
-    expect(post.status).toBe(201);
-
-    const document = await memoryServer.readDocument(
-      identity.did(),
-      cid,
-      { unifiedJsonEncoding: true },
-    );
-    expect(document?.value).toEqual(contents);
-
-    const server = Deno.serve({ port: 0 }, app.fetch);
-    const base = new URL(`http://${server.addr.hostname}:${server.addr.port}`);
-    const runtime = new Runtime({
-      apiUrl: base,
-      storageManager: StorageManager.open({
-        as: identity,
-        address: new URL("/api/storage/memory", base),
-      }),
-      experimental: {
-        modernDataModel: true,
-        unifiedJsonEncoding: true,
-      },
-    });
-
-    try {
-      const provider = runtime.storageManager.open(identity.did());
-      const sync = await provider.sync(cid, {
-        path: [],
-        schema: false,
+    await withUnifiedJsonEncoding(async () => {
+      const post = await app.request(`/${identity.did()}/blobs/image.png`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: encodeBlobPayload(contents),
       });
-      expect(sync).toEqual({ ok: {} });
+      expect(post.status).toBe(201);
 
-      const cell = runtime.getCellFromLink<{
-        type: string;
-        body: FabricBytes;
-      }>({
-        id: cid,
-        path: [],
-        space: identity.did(),
+      const document = await memoryServer.readDocument(
+        identity.did(),
+        cid,
+      );
+      expect(document?.value).toEqual(contents);
+
+      const server = Deno.serve({ port: 0 }, app.fetch);
+      const base = new URL(
+        `http://${server.addr.hostname}:${server.addr.port}`,
+      );
+      const runtime = new Runtime({
+        apiUrl: base,
+        storageManager: StorageManager.open({
+          as: identity,
+          address: new URL("/api/storage/memory", base),
+        }),
+        experimental: {
+          modernDataModel: true,
+          unifiedJsonEncoding: true,
+        },
       });
-      await cell.sync();
-      await runtime.storageManager.synced();
 
-      const value = cell.get();
-      expect(value.type).toBe("image/png");
-      expect(value.body).toBeTruthy();
-      expect(value.body.constructor.name).toBe("FabricBytes");
-      expect((await post.json()).url).toBe(`blobs/${hash}.png`);
-    } finally {
-      await runtime.dispose();
-      await server.shutdown();
-    }
+      try {
+        const provider = runtime.storageManager.open(identity.did());
+        const sync = await provider.sync(cid, {
+          path: [],
+          schema: false,
+        });
+        expect(sync).toEqual({ ok: {} });
+
+        const cell = runtime.getCellFromLink<{
+          type: string;
+          body: FabricBytes;
+        }>({
+          id: cid,
+          path: [],
+          space: identity.did(),
+        });
+        await cell.sync();
+        await runtime.storageManager.synced();
+
+        const value = cell.get();
+        expect(value.type).toBe("image/png");
+        expect(value.body).toBeTruthy();
+        expect(value.body.constructor.name).toBe("FabricBytes");
+        expect((await post.json()).url).toBe(`blobs/${hash}.png`);
+      } finally {
+        await runtime.dispose();
+        await server.shutdown();
+      }
+    });
   });
 
   it("returns 404 for an absent blob", async () => {
     const identity = await Identity.fromPassphrase("toolshed-blob-route-404");
     const get = await app.request(`/${identity.did()}/blobs/missing.png`);
     expect(get.status).toBe(404);
+  });
+
+  it("returns 400 for a malformed blob name", async () => {
+    const identity = await Identity.fromPassphrase(
+      "toolshed-blob-route-bad-name",
+    );
+    const get = await app.request(`/${identity.did()}/blobs/.png`);
+    expect(get.status).toBe(400);
+  });
+
+  it("falls back to the MIME default for invalid upload suffixes", async () => {
+    const identity = await Identity.fromPassphrase(
+      "toolshed-blob-route-suffix",
+    );
+    const contents = {
+      type: "image/png",
+      body: new FabricBytes(new Uint8Array([1, 2, 3])),
+    };
+    const id = hashOf(contents).toString();
+    const hash = id.slice("fid1:".length);
+
+    const post = await withUnifiedJsonEncoding(() =>
+      app.request(`/${identity.did()}/blobs/image.toolonggg`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: encodeBlobPayload(contents),
+      })
+    );
+
+    expect(post.status).toBe(201);
+    expect(await post.json()).toEqual({
+      id,
+      url: `blobs/${hash}.png`,
+    });
   });
 
   it("rejects invalid blob payloads", async () => {

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -8,6 +8,7 @@ import env from "@/env.ts";
 import { Identity } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { JsonEncodingContext } from "@commonfabric/data-model/json-encoding-context";
 import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
@@ -17,6 +18,7 @@ import {
   setJsonEncodingConfig,
 } from "@commonfabric/data-model/json-encoding";
 import {
+  type FabricValue,
   getDataModelConfig,
   resetDataModelConfig,
   setDataModelConfig,
@@ -56,6 +58,8 @@ const withUnifiedJsonEncoding = async <T>(
 const encodeBlobPayload = (payload: { type: string; body: FabricBytes }) =>
   encodeMemoryBoundary(payload);
 
+const blobUploadEncoding = new JsonEncodingContext();
+
 describe("Blob Routes", () => {
   afterEach(async () => {
     await memoryServer.flushSessions();
@@ -88,6 +92,41 @@ describe("Blob Routes", () => {
       expect(get.headers.get("Content-Type")).toBe("image/gif");
       expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
     });
+  });
+
+  it("accepts blob upload encoding without ambient unified JSON flags", async () => {
+    const identity = await Identity.fromPassphrase(
+      "toolshed-blob-route-explicit-codec",
+    );
+    const bytes = new Uint8Array([71, 73, 70, 56, 57, 97]);
+    const contents = {
+      type: "image/gif",
+      body: new FabricBytes(bytes),
+    };
+    const id = hashOf(contents).toString();
+    const hash = id.slice("fid1:".length);
+
+    setDataModelConfig(false);
+    setJsonEncodingConfig(false);
+    try {
+      const post = await app.request(`/${identity.did()}/blobs/image.gif`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: blobUploadEncoding.encode(contents as FabricValue),
+      });
+      expect(post.status).toBe(201);
+      expect(await post.json()).toEqual({
+        id,
+        url: `blobs/${hash}.gif`,
+      });
+
+      const get = await app.request(`/${identity.did()}/blobs/${hash}.gif`);
+      expect(get.status).toBe(200);
+      expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
+    } finally {
+      resetDataModelConfig();
+      resetJsonEncodingConfig();
+    }
   });
 
   it("stores blob contents as a cell document value", async () => {

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -2,11 +2,15 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import createApp from "@/lib/create-app.ts";
 import router from "./blobs.index.ts";
+import memory from "@/routes/storage/memory/memory.index.ts";
+import { memoryServer } from "@/routes/storage/memory.ts";
 import env from "@/env.ts";
 import { Identity } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
   getJsonEncodingConfig,
   resetJsonEncodingConfig,
@@ -22,7 +26,9 @@ if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
 }
 
-const app = createApp().route("/", router);
+const app = createApp()
+  .route("/", memory)
+  .route("/", router);
 
 const withUnifiedJsonEncoding = <T>(fn: () => T): T => {
   const previous = getJsonEncodingConfig();
@@ -74,6 +80,75 @@ describe("Blob Routes", () => {
     expect(get.status).toBe(200);
     expect(get.headers.get("Content-Type")).toBe("image/gif");
     expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
+  });
+
+  it("stores blob contents as a cell document value", async () => {
+    const identity = await Identity.fromPassphrase("toolshed-blob-cell");
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const contents = {
+      type: "image/png",
+      body: new FabricBytes(bytes),
+    };
+    const id = hashOf(contents).toString();
+    const cid = `cid:${id}` as const;
+    const hash = id.slice("fid1:".length);
+
+    const post = await app.request(`/${identity.did()}/blobs/image.png`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: encodeBlobPayload(contents),
+    });
+    expect(post.status).toBe(201);
+
+    const document = await memoryServer.readDocument(
+      identity.did(),
+      cid,
+      { unifiedJsonEncoding: true },
+    );
+    expect(document?.value).toEqual(contents);
+
+    const server = Deno.serve({ port: 0 }, app.fetch);
+    const base = new URL(`http://${server.addr.hostname}:${server.addr.port}`);
+    const runtime = new Runtime({
+      apiUrl: base,
+      storageManager: StorageManager.open({
+        as: identity,
+        address: new URL("/api/storage/memory", base),
+      }),
+      experimental: {
+        modernDataModel: true,
+        unifiedJsonEncoding: true,
+      },
+    });
+
+    try {
+      const provider = runtime.storageManager.open(identity.did());
+      const sync = await provider.sync(cid, {
+        path: [],
+        schema: false,
+      });
+      expect(sync).toEqual({ ok: {} });
+
+      const cell = runtime.getCellFromLink<{
+        type: string;
+        body: FabricBytes;
+      }>({
+        id: cid,
+        path: [],
+        space: identity.did(),
+      });
+      await cell.sync();
+      await runtime.storageManager.synced();
+
+      const value = cell.get();
+      expect(value.type).toBe("image/png");
+      expect(value.body).toBeTruthy();
+      expect(value.body.constructor.name).toBe("FabricBytes");
+      expect((await post.json()).url).toBe(`blobs/${hash}.png`);
+    } finally {
+      await runtime.dispose();
+      await server.shutdown();
+    }
   });
 
   it("returns 404 for an absent blob", async () => {


### PR DESCRIPTION
## Summary

This PR adds a minimal blob upload and serving path to Toolshed using the temporary `cid:` convention we discussed. It lets shell-side code hand binary data to the runner thread, have the runner store it in the current space, and receive a relative URL that can be used directly in rendered HTML, for example `<img src="blobs/<hash>.png">`.

The implementation intentionally keeps this as a `cid:fid1:<hash>` convention for now. It does not try to introduce a full content-addressed storage abstraction yet, but it uses the existing memory/data-model primitives so the stored payload has the expected hash identity.

## Security / Auth

Blob routes are intentionally unauthenticated for this MVP. Anyone can POST a blob into any space DID; because the payload is content-addressed they cannot overwrite a different payload, but they can inject blobs and consume storage. Anyone with a blob hash can GET that blob. Full UCAN-gated access is a required follow-up before any production exposure.

## What Changed

### Toolshed blob routes

Adds blob routes under a space DID:

- `POST /:spaceDid/blobs`
- `POST /:spaceDid/blobs/:blobName`
- `GET /:spaceDid/blobs/:blobName`

The POST endpoint accepts the same memory-boundary shape used by the runner upload path:

```ts
const contents = {
  type: "image/png", // MIME type
  body: new FabricBytes(rawImageData),
};
```

Toolshed computes `hashOf(contents).toString()`, stores the contents in memory as `cid:<fid1:...>` with the normal cell document shape:

```ts
{ value: contents }
```

and returns:

```ts
{
  id: "fid1:...",
  url: "blobs/<hash>.<suffix>"
}
```

The GET endpoint resolves `/:spaceDid/blobs/<hash>.<suffix>` to `cid:fid1:<hash>`, ignores the suffix for lookup, reads the stored `{ type, body }`, and serves the raw bytes with the embedded MIME type as `Content-Type`.

### Memory server helpers

Adds direct `readDocument` and `writeDocument` helpers to the memory v2 server so Toolshed can read/write the exact `cid:` document without going through websocket/session plumbing. These helpers support the unified JSON encoding path needed to preserve `FabricBytes` correctly.

Direct writes now go through the normal dirty-refresh path even when there are no live websocket connections, matching the rest of the memory server's write behavior.

### Runtime IPC upload command

Adds a new runtime-client IPC command:

```ts
RequestType.UploadBlob = "runtime:uploadBlob"
```

Request shape:

```ts
{
  type: RequestType.UploadBlob,
  contentType: string,
  body: Uint8Array,
  suffix?: string,
}
```

Response shape:

```ts
{
  id: string,
  url: string,
}
```

The main-thread caller sends bytes through `RuntimeClient.uploadBlob()`. The runtime processor handles the IPC request on the runner thread, wraps the bytes as `new FabricBytes(body)`, posts the encoded payload to Toolshed, and returns the relative `blobs/...` URL to the caller.

This keeps the actual persistence work on the runner side while still giving UI code a simple async method.

### Shell relative blob URLs

Shell now manages a space-scoped base href:

```html
<base data-commonfabric-space-base="true" href="/<spaceDid>/">
```

That means shell-rendered or component-rendered relative URLs like this:

```html
<img src="blobs/<hash>.png">
```

resolve to:

```text
/<spaceDid>/blobs/<hash>.png
```

even when the visible shell URL was opened through a space name rather than the DID.

## How To Invoke From Shell-Land Code

Shell exposes the runtime client on `globalThis.commonfabric.rt`. Any shell-side web component or UI controller that has access to the window can call `uploadBlob()` and then use the returned relative URL directly.

Example web component handler:

```ts
type BlobUploadRuntime = {
  uploadBlob(options: {
    contentType: string;
    body: Uint8Array;
    suffix?: string;
  }): Promise<{ id: string; url: string }>;
};

type CommonfabricWindow = Window & typeof globalThis & {
  commonfabric?: {
    rt?: BlobUploadRuntime;
  };
};

function fileSuffix(name: string): string | undefined {
  const suffix = name.split(".").pop();
  return suffix && suffix !== name ? suffix : undefined;
}

class ImageUploader extends HTMLElement {
  async uploadFile(file: File): Promise<void> {
    const rt = (globalThis as CommonfabricWindow).commonfabric?.rt;
    if (!rt) {
      throw new Error("Common Fabric runtime is not ready");
    }

    const upload = await rt.uploadBlob({
      contentType: file.type || "application/octet-stream",
      suffix: fileSuffix(file.name),
      body: new Uint8Array(await file.arrayBuffer()),
    });

    const img = document.createElement("img");
    img.src = upload.url;
    img.alt = file.name;
    this.replaceChildren(img);

    // upload.id is the fid1 content id.
    // upload.url is relative, e.g. "blobs/<hash>.png".
    console.log(upload.id, upload.url);
  }
}
```

For shell code that already holds a `RuntimeClient` instance, the call is the same without going through `globalThis`:

```ts
const upload = await runtimeClient.uploadBlob({
  contentType: "image/png",
  suffix: "png",
  body: pngBytes,
});
```

The returned `upload.url` is intended to be stored in pattern/shell state or assigned directly to DOM attributes. Because shell installs the space DID base href, callers should keep it relative rather than expanding it themselves.

## End-To-End Flow

1. A shell web component receives a `File`, `Blob`, canvas export, pasted image, or other binary source on the main thread.
2. The component converts it to `Uint8Array` and calls `commonfabric.rt.uploadBlob(...)`.
3. Runtime client sends the `runtime:uploadBlob` IPC request to the runner worker.
4. Runtime processor wraps the bytes as `{ type, body: new FabricBytes(...) }` and POSTs the encoded body to Toolshed.
5. Toolshed computes the content hash, writes `cid:<fid1:hash>` in the current space, and returns a relative `blobs/<hash>.<suffix>` URL.
6. The component can render that URL immediately, for example with `<img src={upload.url}>`.
7. Browser resolution uses shell's base href, so `blobs/...` loads from `/<spaceDid>/blobs/...`.
8. Toolshed serves the raw bytes with the embedded MIME type.

## Tests Added

- Toolshed route test verifies POST creates the blob cell and GET serves the stored bytes with the embedded MIME type while ignoring the suffix.
- Toolshed route test verifies the blob cell can be read through the `Cell` interface as `{ type, body }` from the same `cid:...` id.
- Memory v2 server test verifies direct `writeDocument()` calls schedule the dirty-refresh path even when there are no live connections.
- Runtime processor test verifies the IPC handler encodes bytes and posts to the space-scoped blob route.
- Shell integration test verifies a browser can call `commonfabric.rt.uploadBlob()`, append an `<img>` using the returned relative `blobs/...` URL, and load the image through the DID-scoped blob endpoint.

## Validation

- `deno task check`
- `deno task test`
- `deno task integration`
- `deno task test` in `packages/memory`
- `ENV=test deno test -A --env-file=packages/toolshed/.env.test packages/toolshed/routes/blobs/blobs.test.ts`