### PR TITLE
Extract the UTF8 sorting from `data-model`, and expand it.

### DIFF
--- a/packages/data-model/value-hash.ts
+++ b/packages/data-model/value-hash.ts
@@ -21,7 +21,7 @@ import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { encodeULEB128 } from "@commonfabric/leb128";
 import { bigintToMinimalTwosComplement } from "./bigint-encoding.ts";
 import { LRUCache } from "@commonfabric/utils/cache";
-import { utf8Compare } from "@commonfabric/utils/utf8";
+import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 
 // ---------------------------------------------------------------------------
 // Type tag bytes (Section 2 of the byte-level spec)
@@ -346,7 +346,7 @@ function feedPlainObject(
   // those other languages don't necessarily have the same encoding bias as JS,
   // and (c) we want to make the specification for hashing straightforward
   // anyway (and are willing to pay a performance cost because of it).
-  const keys = Object.keys(value).sort(utf8Compare);
+  const keys = utf8SortedKeysOf(value);
 
   hasher.update(TAG_OBJECT_BYTES);
   for (const key of keys) {

--- a/packages/data-model/value-hash.ts
+++ b/packages/data-model/value-hash.ts
@@ -21,7 +21,7 @@ import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { encodeULEB128 } from "@commonfabric/leb128";
 import { bigintToMinimalTwosComplement } from "./bigint-encoding.ts";
 import { LRUCache } from "@commonfabric/utils/cache";
-import { compareUtf8 } from "@commonfabric/utils/utf8";
+import { utf8Compare } from "@commonfabric/utils/utf8";
 
 // ---------------------------------------------------------------------------
 // Type tag bytes (Section 2 of the byte-level spec)
@@ -346,7 +346,7 @@ function feedPlainObject(
   // those other languages don't necessarily have the same encoding bias as JS,
   // and (c) we want to make the specification for hashing straightforward
   // anyway (and are willing to pay a performance cost because of it).
-  const keys = Object.keys(value).sort(compareUtf8);
+  const keys = Object.keys(value).sort(utf8Compare);
 
   hasher.update(TAG_OBJECT_BYTES);
   for (const key of keys) {

--- a/packages/data-model/value-hash.ts
+++ b/packages/data-model/value-hash.ts
@@ -21,6 +21,7 @@ import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { encodeULEB128 } from "@commonfabric/leb128";
 import { bigintToMinimalTwosComplement } from "./bigint-encoding.ts";
 import { LRUCache } from "@commonfabric/utils/cache";
+import { compareUtf8 } from "@commonfabric/utils/utf8";
 
 // ---------------------------------------------------------------------------
 // Type tag bytes (Section 2 of the byte-level spec)
@@ -141,82 +142,6 @@ function getStringRep(value: string) {
 
   stringRepCache.put(value, result);
   return result;
-}
-
-/**
- * Helper for `compareStrings()`: Is the given character code a surrogate?
- */
-function isSurrogateCharCode(c: number) {
-  return (c >= 0xd800) && (c <= 0xdfff);
-}
-
-/**
- * Helper for `compareStrings()`: Does the given string contain any surrogate
- * code points?
- */
-function hasSurrogateCharCode(value: string) {
-  return /[\ud800-\udfff]/.test(value);
-}
-
-/**
- * Compares strings by UTF-8 sort order.
- *
- * Note: Even though we could conceivably define the sort to be something
- * easier to calculate in JS, (a) ultimately we want this implementation to be
- * but one of several that aren't all written in JS, (b) those other languages
- * don't necessarily have the same encoding bias as JS, and (c) we want to make
- * the specification for hashing straightforward anyway (and are willing to pay
- * a performance cost because of it).
- */
-function compareStrings(a: string, b: string): number {
-  // Credit where due: Though this started out as an independent implementation
-  // of the key insight for fast sorting, this incorporates ideas from
-  // <https://github.com/rocicorp/compare-utf8>.
-
-  // Here's what's going on: JS native string sort and UTF-8 sort can differ
-  // only when at least one of the JS-form strings contains a codepoint for a
-  // surrogate-pair. As long as we don't run into one of those, we can just
-  // do a regular difference-based comparison. But if we _do_ run into one, then
-  // we have to do something extra, one way or another.
-
-  if (a === b) {
-    // Easy out!
-    return 0;
-  }
-
-  const minCharLen = Math.min(a.length, b.length);
-
-  if (
-    (minCharLen >= 20) && !(hasSurrogateCharCode(a) || hasSurrogateCharCode(b))
-  ) {
-    // Strings are long enough that it's worth a preflight check for surrogate
-    // pairs, and it turns out that neither had them.
-    return (a < b) ? -1 : ((a > b) ? 1 : 0);
-  }
-
-  // No luck for us today. Gotta do it the hard way.
-
-  for (let i = 0; i < minCharLen; i++) {
-    const aChar = a.charCodeAt(i);
-    const bChar = b.charCodeAt(i);
-    if (aChar === bChar) {
-      continue;
-    } else if (!(isSurrogateCharCode(aChar) || isSurrogateCharCode(bChar))) {
-      return aChar - bChar;
-    } else {
-      // At least one is a surrogate. Use `codePointAt()` to decode whichever of
-      // the strings have surrogate characters. That method operates reasonably
-      // whether or not the code point is in the basic or astral plane, and it
-      // also returns a reasonable value given an invalid surrogate-pair
-      // sequence. Importantly, Unicode code-point order corresponds to UTF-8
-      // byte order.
-      const aPoint = a.codePointAt(i)!;
-      const bPoint = b.codePointAt(i)!;
-      return aPoint - bPoint;
-    }
-  }
-
-  return a.length - b.length;
 }
 
 /**
@@ -415,7 +340,13 @@ function feedPlainObject(
   hasher: IncrementalHasher,
   value: Record<string, unknown>,
 ): void {
-  const keys = Object.keys(value).sort(compareStrings);
+  // Note: Even though we could conceivably define the key sort order to be
+  // something easier to calculate in JS, (a) ultimately we want this
+  // implementation to be but one of several that aren't all written in JS, (b)
+  // those other languages don't necessarily have the same encoding bias as JS,
+  // and (c) we want to make the specification for hashing straightforward
+  // anyway (and are willing to pay a performance cost because of it).
+  const keys = Object.keys(value).sort(compareUtf8);
 
   hasher.update(TAG_OBJECT_BYTES);
   for (const key of keys) {

--- a/packages/utils/deno.json
+++ b/packages/utils/deno.json
@@ -7,16 +7,17 @@
     ".": "./src/index.ts",
     "./base64url": "./src/base64url.ts",
     "./cache": "./src/cache.ts",
+    "./deep-equal": "./src/deep-equal.ts",
     "./defer": "./src/defer.ts",
     "./encoding": "./src/encoding.ts",
     "./env": "./src/env.ts",
-    "./deep-equal": "./src/deep-equal.ts",
     "./equal-ignoring-symbols": "./src/equal-ignoring-symbols.ts",
+    "./integration": "./src/integration.ts",
+    "./logger": "./src/logger.ts",
     "./sandbox-contract": "./src/sandbox-contract.ts",
     "./sleep": "./src/sleep.ts",
     "./types": "./src/types.ts",
-    "./integration": "./src/integration.ts",
-    "./zod-utils": "./src/zod-utils.ts",
-    "./logger": "./src/logger.ts"
+    "./utf8": "./src/utf8.ts",
+    "./zod-utils": "./src/zod-utils.ts"
   }
 }

--- a/packages/utils/src/utf8.ts
+++ b/packages/utils/src/utf8.ts
@@ -3,6 +3,12 @@
  */
 
 /**
+ * `WeakMap` cache from frozen objects to already-calculated sorted keys. Used
+ * by `utf8SortedKeysOf()`.
+ */
+const sortedKeyCache = new WeakMap<object, string[]>();
+
+/**
  * Helper for `compareUtf8()`: Is the given character code a surrogate?
  */
 function isSurrogateCharCode(c: number) {
@@ -69,4 +75,29 @@ export function compareUtf8(a: string, b: string): number {
   }
 
   return a.length - b.length;
+}
+
+/**
+ * Produces a frozen array containing the ordered keys of the given object,
+ * in UTF-8 sort order. If the given object is frozen, it gets cached for
+ * possible reuse.
+ */
+export function utf8SortedKeysOf(value: object): string[] {
+  if (value === null) {
+    throw new TypeError("Value must not be `null`.");
+  }
+
+  const cached = sortedKeyCache.get(value);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const unsorted = Object.keys(value);
+  const sorted = unsorted.sort(compareUtf8);
+
+  if (Object.isFrozen(value)) {
+    sortedKeyCache.set(value, sorted);
+  }
+
+  return sorted;
 }

--- a/packages/utils/src/utf8.ts
+++ b/packages/utils/src/utf8.ts
@@ -1,0 +1,72 @@
+/**
+ * UTF8 helper functions.
+ */
+
+/**
+ * Helper for `compareUtf8()`: Is the given character code a surrogate?
+ */
+function isSurrogateCharCode(c: number) {
+  return (c >= 0xd800) && (c <= 0xdfff);
+}
+
+/**
+ * Helper for `compareUtf8()`: Does the given string contain any surrogate code
+ * points?
+ */
+function hasSurrogateCharCode(value: string) {
+  return /[\ud800-\udfff]/.test(value);
+}
+
+/**
+ * Compares strings by UTF-8 sort order.
+ */
+export function compareUtf8(a: string, b: string): number {
+  // Credit where due: Though this started out as an independent implementation
+  // of the key insight for fast sorting, this incorporates ideas from
+  // <https://github.com/rocicorp/compare-utf8>.
+
+  // Here's what's going on: JS native string sort and UTF-8 sort can differ
+  // only when at least one of the JS-form strings contains a codepoint for a
+  // surrogate-pair. As long as we don't run into one of those, we can just
+  // do a regular difference-based comparison. But if we _do_ run into one, then
+  // we have to do something extra, one way or another.
+
+  if (a === b) {
+    // Easy out!
+    return 0;
+  }
+
+  const minCharLen = Math.min(a.length, b.length);
+
+  if (
+    (minCharLen >= 20) && !(hasSurrogateCharCode(a) || hasSurrogateCharCode(b))
+  ) {
+    // Strings are long enough that it's worth a preflight check for surrogate
+    // pairs, and it turns out that neither had them.
+    return (a < b) ? -1 : ((a > b) ? 1 : 0);
+  }
+
+  // No luck for us today. Gotta do it the hard way.
+
+  for (let i = 0; i < minCharLen; i++) {
+    const aChar = a.charCodeAt(i);
+    const bChar = b.charCodeAt(i);
+    if (aChar === bChar) {
+      continue;
+    } else if (!(isSurrogateCharCode(aChar) || isSurrogateCharCode(bChar))) {
+      return aChar - bChar;
+    } else {
+      // At least one is a surrogate. Use `codePointAt()` to decode whichever of
+      // the strings have surrogate characters. That method operates reasonably
+      // whether or not the code point is in the basic or astral plane, and it
+      // also returns a reasonable value given an invalid surrogate-pair
+      // sequence. Importantly, Unicode code-point order corresponds to UTF-8
+      // byte order.
+      const aPoint = a.codePointAt(i)!;
+      const bPoint = b.codePointAt(i)!;
+      return aPoint - bPoint;
+    }
+  }
+
+  return a.length - b.length;
+}

--- a/packages/utils/src/utf8.ts
+++ b/packages/utils/src/utf8.ts
@@ -6,17 +6,17 @@
  * `WeakMap` cache from frozen objects to already-calculated sorted keys. Used
  * by `utf8SortedKeysOf()`.
  */
-const sortedKeyCache = new WeakMap<object, string[]>();
+const sortedKeyCache = new WeakMap<object, readonly string[]>();
 
 /**
- * Helper for `compareUtf8()`: Is the given character code a surrogate?
+ * Helper for `utf8Compare()`: Is the given character code a surrogate?
  */
 function isSurrogateCharCode(c: number) {
   return (c >= 0xd800) && (c <= 0xdfff);
 }
 
 /**
- * Helper for `compareUtf8()`: Does the given string contain any surrogate code
+ * Helper for `utf8Compare()`: Does the given string contain any surrogate code
  * points?
  */
 function hasSurrogateCharCode(value: string) {
@@ -26,7 +26,7 @@ function hasSurrogateCharCode(value: string) {
 /**
  * Compares strings by UTF-8 sort order.
  */
-export function compareUtf8(a: string, b: string): number {
+export function utf8Compare(a: string, b: string): number {
   // Credit where due: Though this started out as an independent implementation
   // of the key insight for fast sorting, this incorporates ideas from
   // <https://github.com/rocicorp/compare-utf8>.
@@ -82,7 +82,7 @@ export function compareUtf8(a: string, b: string): number {
  * in UTF-8 sort order. If the given object is frozen, it gets cached for
  * possible reuse.
  */
-export function utf8SortedKeysOf(value: object): string[] {
+export function utf8SortedKeysOf(value: object): readonly string[] {
   if (value === null) {
     throw new TypeError("Value must not be `null`.");
   }
@@ -93,7 +93,7 @@ export function utf8SortedKeysOf(value: object): string[] {
   }
 
   const unsorted = Object.keys(value);
-  const sorted = unsorted.sort(compareUtf8);
+  const sorted = Object.freeze(unsorted.sort(utf8Compare));
 
   if (Object.isFrozen(value)) {
     sortedKeyCache.set(value, sorted);

--- a/packages/utils/test/utf8.test.ts
+++ b/packages/utils/test/utf8.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { compareUtf8 } from "@commonfabric/utils/utf8";
+
+describe("compareUtf8", () => {
+  it("returns `0` for two equal UTF-8 strings", () => {
+    expect(compareUtf8("abc", "abc")).toBe(0);
+  });
+
+  it("returns a negative number if `first < second`", () => {
+    expect(compareUtf8("abc", "def")).toBeLessThan(0);
+  });
+
+  it("returns a positive number if `first > second`", () => {
+    expect(compareUtf8("def", "abc")).toBeGreaterThan(0);
+  });
+
+  it("returns a negative number if `first` is a prefix of `second`", () => {
+    expect(compareUtf8("abc", "abcd")).toBeLessThan(0);
+  });
+
+  it("returns a positive number if `second` is a prefix of `first`", () => {
+    expect(compareUtf8("abcd", "abc")).toBeGreaterThan(0);
+  });
+
+  describe("strings with astral-plane characters", () => {
+    it("returns `0` for two equal astral-plane characters", () => {
+      expect(compareUtf8("😊", "😊")).toBe(0);
+    });
+
+    it("returns a negative number if `first < second`", () => {
+      expect(compareUtf8("😊", "😎")).toBeLessThan(0);
+    });
+
+    it("returns a positive number if `first > second`", () => {
+      expect(compareUtf8("😎", "😊")).toBeGreaterThan(0);
+    });
+
+    it("returns `0` for two equal multi-character strings with astral-plane characters", () => {
+      expect(compareUtf8("happy 😊😊 folks", "happy 😊😊 folks")).toBe(0);
+    });
+
+    it("returns a negative number if `first < second` for multi-character strings with _same_ astral-plane characters", () => {
+      expect(compareUtf8("What 😊 is a biscuit?", "What 😊 is a muffin?")).toBeLessThan(0);
+    });
+
+    it("returns a positive number if `first > second` for multi-character strings with _same_ astral-plane characters", () => {
+      expect(compareUtf8("What 😊 is a muffin?", "What 😊 is a biscuit?")).toBeGreaterThan(0);
+    });
+
+    it("sorts astral plane characters after non-astral-plane characters", () => {
+      const firstAstral = String.fromCodePoint(0x10000);
+
+      expect(compareUtf8("\x00", firstAstral)).toBeLessThan(0);
+      expect(compareUtf8("\uffff", firstAstral)).toBeLessThan(0);
+      expect(compareUtf8(firstAstral, "\x00")).toBeGreaterThan(0);
+      expect(compareUtf8(firstAstral, "\uffff")).toBeGreaterThan(0);
+
+      for (let ch = 123; ch < 0xffff; ch += 876) {
+        const str = String.fromCharCode(ch);
+        expect(compareUtf8(str, firstAstral)).toBeLessThan(0);
+        expect(compareUtf8(firstAstral, str)).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/packages/utils/test/utf8.test.ts
+++ b/packages/utils/test/utf8.test.ts
@@ -1,83 +1,83 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { compareUtf8 } from "@commonfabric/utils/utf8";
+import { utf8Compare, utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 
-describe("compareUtf8", () => {
+describe("utf8Compare", () => {
   it("returns `0` for two equal UTF-8 strings", () => {
-    expect(compareUtf8("abc", "abc")).toBe(0);
+    expect(utf8Compare("abc", "abc")).toBe(0);
   });
 
   it("returns a negative number if `first < second`", () => {
-    expect(compareUtf8("abc", "def")).toBeLessThan(0);
+    expect(utf8Compare("abc", "def")).toBeLessThan(0);
   });
 
   it("returns a positive number if `first > second`", () => {
-    expect(compareUtf8("def", "abc")).toBeGreaterThan(0);
+    expect(utf8Compare("def", "abc")).toBeGreaterThan(0);
   });
 
   it("returns a negative number if `first` is a prefix of `second`", () => {
-    expect(compareUtf8("abc", "abcd")).toBeLessThan(0);
+    expect(utf8Compare("abc", "abcd")).toBeLessThan(0);
   });
 
   it("returns a positive number if `second` is a prefix of `first`", () => {
-    expect(compareUtf8("abcd", "abc")).toBeGreaterThan(0);
+    expect(utf8Compare("abcd", "abc")).toBeGreaterThan(0);
   });
 
   describe("strings with astral-plane characters", () => {
     it("returns `0` for two equal astral-plane characters", () => {
-      expect(compareUtf8("😊", "😊")).toBe(0);
+      expect(utf8Compare("😊", "😊")).toBe(0);
     });
 
     it("returns a negative number if `first < second`", () => {
-      expect(compareUtf8("😊", "😎")).toBeLessThan(0);
+      expect(utf8Compare("😊", "😎")).toBeLessThan(0);
     });
 
     it("returns a positive number if `first > second`", () => {
-      expect(compareUtf8("😎", "😊")).toBeGreaterThan(0);
+      expect(utf8Compare("😎", "😊")).toBeGreaterThan(0);
     });
 
     it("returns `0` for two equal multi-character strings with astral-plane characters", () => {
-      expect(compareUtf8("happy 😊😊 folks", "happy 😊😊 folks")).toBe(0);
+      expect(utf8Compare("happy 😊😊 folks", "happy 😊😊 folks")).toBe(0);
     });
 
     it("returns a negative number if `first < second` for multi-character strings with _same_ astral-plane characters", () => {
-      expect(compareUtf8("What 😊 is a biscuit?", "What 😊 is a muffin?"))
+      expect(utf8Compare("What 😊 is a biscuit?", "What 😊 is a muffin?"))
         .toBeLessThan(0);
     });
 
     it("returns a positive number if `first > second` for multi-character strings with _same_ astral-plane characters", () => {
-      expect(compareUtf8("What 😊 is a muffin?", "What 😊 is a biscuit?"))
+      expect(utf8Compare("What 😊 is a muffin?", "What 😊 is a biscuit?"))
         .toBeGreaterThan(0);
     });
 
     it("sorts astral plane characters after non-astral-plane characters", () => {
       const firstAstral = String.fromCodePoint(0x10000);
 
-      expect(compareUtf8("\x00", firstAstral)).toBeLessThan(0);
-      expect(compareUtf8("\uffff", firstAstral)).toBeLessThan(0);
-      expect(compareUtf8(firstAstral, "\x00")).toBeGreaterThan(0);
-      expect(compareUtf8(firstAstral, "\uffff")).toBeGreaterThan(0);
+      expect(utf8Compare("\x00", firstAstral)).toBeLessThan(0);
+      expect(utf8Compare("\uffff", firstAstral)).toBeLessThan(0);
+      expect(utf8Compare(firstAstral, "\x00")).toBeGreaterThan(0);
+      expect(utf8Compare(firstAstral, "\uffff")).toBeGreaterThan(0);
 
       for (let ch = 123; ch < 0xffff; ch += 876) {
         const str = String.fromCharCode(ch);
-        expect(compareUtf8(str, firstAstral)).toBeLessThan(0);
-        expect(compareUtf8(firstAstral, str)).toBeGreaterThan(0);
+        expect(utf8Compare(str, firstAstral)).toBeLessThan(0);
+        expect(utf8Compare(firstAstral, str)).toBeGreaterThan(0);
       }
     });
   });
 });
 
-describe("utf8SortedKeys", () => {
+describe("utf8SortedKeysOf", () => {
   it("returns a sorted array of keys for an object", () => {
     const obj = { b: 2, a: 1, c: 3 };
-    const sorted = utf8SortedKeys(obj);
+    const sorted = utf8SortedKeysOf(obj);
     expect(sorted).toEqual(["a", "b", "c"]);
   });
 
   it("returns a frozen value", () => {
     const obj = { beep: "x", bop: "y", awOOOOga: "z" };
-    const sorted = utf8SortedKeys(obj);
-    expect(sorted).toBeFrozen();
+    const sorted = utf8SortedKeysOf(obj);
+    expect(Object.isFrozen(sorted)).toBe(true);
   });
 
   it("returns the same (`===`) value on two different calls, given the same frozen object", () => {
@@ -89,8 +89,8 @@ describe("utf8SortedKeys", () => {
       "be": null,
       "alive": true,
     });
-    const sorted1 = utf8SortedKeys(obj);
-    const sorted2 = utf8SortedKeys(obj);
+    const sorted1 = utf8SortedKeysOf(obj);
+    const sorted2 = utf8SortedKeysOf(obj);
     expect(sorted1).toBe(sorted2);
   });
 });

--- a/packages/utils/test/utf8.test.ts
+++ b/packages/utils/test/utf8.test.ts
@@ -41,11 +41,13 @@ describe("compareUtf8", () => {
     });
 
     it("returns a negative number if `first < second` for multi-character strings with _same_ astral-plane characters", () => {
-      expect(compareUtf8("What 😊 is a biscuit?", "What 😊 is a muffin?")).toBeLessThan(0);
+      expect(compareUtf8("What 😊 is a biscuit?", "What 😊 is a muffin?"))
+        .toBeLessThan(0);
     });
 
     it("returns a positive number if `first > second` for multi-character strings with _same_ astral-plane characters", () => {
-      expect(compareUtf8("What 😊 is a muffin?", "What 😊 is a biscuit?")).toBeGreaterThan(0);
+      expect(compareUtf8("What 😊 is a muffin?", "What 😊 is a biscuit?"))
+        .toBeGreaterThan(0);
     });
 
     it("sorts astral plane characters after non-astral-plane characters", () => {
@@ -62,5 +64,33 @@ describe("compareUtf8", () => {
         expect(compareUtf8(firstAstral, str)).toBeGreaterThan(0);
       }
     });
+  });
+});
+
+describe("utf8SortedKeys", () => {
+  it("returns a sorted array of keys for an object", () => {
+    const obj = { b: 2, a: 1, c: 3 };
+    const sorted = utf8SortedKeys(obj);
+    expect(sorted).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns a frozen value", () => {
+    const obj = { beep: "x", bop: "y", awOOOOga: "z" };
+    const sorted = utf8SortedKeys(obj);
+    expect(sorted).toBeFrozen();
+  });
+
+  it("returns the same (`===`) value on two different calls, given the same frozen object", () => {
+    const obj = Object.freeze({
+      "what": [],
+      "a": [1, 2, 3],
+      "feeling": [4],
+      "to": -99,
+      "be": null,
+      "alive": true,
+    });
+    const sorted1 = utf8SortedKeys(obj);
+    const sorted2 = utf8SortedKeys(obj);
+    expect(sorted1).toBe(sorted2);
   });
 });


### PR DESCRIPTION
This PR extracts the UTF8 sorting function out of the guts of the `data-model` hashing implementation, giving it a nice home in `utils`. It also adds a handy function `utf8SortedKeysOf()` which does as it says, and does smart caching of results.