### PR TITLE
Use runtime blob uploads for file inputs

### DIFF
--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -3771,8 +3771,7 @@ interface CFFileInputAttributes<T> extends CFHTMLAttributes<T> {
   "removable"?: boolean;
   "disabled"?: boolean;
   "maxSizeBytes"?: number;
-  "files"?: any[]; // FileData[]
-  "$files"?: any; // CellLike<FileData[]>
+  "includeData"?: boolean;
   "oncf-click"?: EventHandler<any>;
   "oncf-change"?: EventHandler<any>;
   "oncf-remove"?: EventHandler<any>;
@@ -3798,8 +3797,7 @@ interface CFImageInputAttributes<T> extends CFHTMLAttributes<T> {
   "previewSize"?: "sm" | "md" | "lg";
   "removable"?: boolean;
   "disabled"?: boolean;
-  "images"?: any[]; // ImageData[]
-  "$images"?: any; // CellLike<ImageData[]>
+  "includeData"?: boolean;
   "oncf-click"?: EventHandler<any>;
   "oncf-change"?: EventHandler<any>;
   "oncf-remove"?: EventHandler<any>;
@@ -3966,6 +3964,8 @@ interface CFCodeEditorAttributes<T> extends CFHTMLAttributes<T> {
   "oncf-change"?: any;
   "oncf-focus"?: any;
   "oncf-blur"?: any;
+  "oncf-file-paste"?: any;
+  "oncf-error"?: any;
   "onbacklink-click"?: any;
   "onbacklink-create"?: any;
 }

--- a/packages/patterns/group-chat-room.tsx
+++ b/packages/patterns/group-chat-room.tsx
@@ -154,6 +154,22 @@ const cancelAvatar = handler<
   avatarImages.set([]);
 });
 
+type ImageUploadEvent = {
+  detail?: {
+    images?: ImageData[];
+    files?: ImageData[];
+  };
+};
+
+const setUploadedImage = handler<
+  ImageUploadEvent,
+  { images: Writable<ImageData[]> }
+>(({ detail }, { images }) => {
+  const uploaded = detail?.images ?? detail?.files ?? [];
+  const first = uploaded[0];
+  images.set(first ? [first] : []);
+});
+
 // Handler to toggle emoji picker for a message
 const toggleEmojiPicker = handler<
   unknown,
@@ -231,7 +247,7 @@ export default pattern<RoomInput, RoomOutput>(
       if (!imgs || imgs.length === 0) {
         return "";
       }
-      return imgs[0].url || imgs[0].data || "";
+      return imgs[0].url || "";
     });
 
     const hasPendingChatImage = computed(
@@ -242,7 +258,7 @@ export default pattern<RoomInput, RoomOutput>(
       if (!imgs || imgs.length === 0) {
         return "";
       }
-      return imgs[0].url || imgs[0].data || "";
+      return imgs[0].url || "";
     });
 
     const isSessionValid = computed(() => {
@@ -775,13 +791,15 @@ export default pattern<RoomInput, RoomOutput>(
                       )}
                       {/* Hidden cf-image-input overlaid on avatar */}
                       <cf-image-input
-                        $images={avatarImages}
                         maxImages={1}
                         showPreview={false}
                         buttonText=""
                         variant="ghost"
                         size="sm"
                         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; opacity: 0; cursor: pointer;"
+                        oncf-change={setUploadedImage({
+                          images: avatarImages,
+                        })}
                       />
                     </div>
 
@@ -800,12 +818,12 @@ export default pattern<RoomInput, RoomOutput>(
 
                     {/* Attachment button for sending images to chat */}
                     <cf-image-input
-                      $images={chatImages}
                       maxImages={1}
                       showPreview={false}
                       buttonText="📎"
                       variant="ghost"
                       size="sm"
+                      oncf-change={setUploadedImage({ images: chatImages })}
                     />
 
                     {/* Pending avatar preview */}

--- a/packages/patterns/image-analysis.tsx
+++ b/packages/patterns/image-analysis.tsx
@@ -62,8 +62,9 @@ export default pattern<ImageChatInput, ImageChatOutput>(
       }
 
       for (const img of images.get() || []) {
-        if (img.url) {
-          parts.push({ type: "image", image: img.url });
+        const image = img.data || img.url;
+        if (image) {
+          parts.push({ type: "image", image });
         }
       }
 
@@ -77,7 +78,6 @@ export default pattern<ImageChatInput, ImageChatOutput>(
         "You are a helpful assistant that can analyze images. Describe what you see."
       ),
       prompt: contentParts,
-      model: computed(() => model || "anthropic:claude-sonnet-4-5"),
     });
 
     const ui = (
@@ -96,6 +96,7 @@ export default pattern<ImageChatInput, ImageChatOutput>(
                   <cf-image-input
                     multiple
                     maxImages={5}
+                    includeData
                     showPreview
                     previewSize="md"
                     removable

--- a/packages/patterns/image-analysis.tsx
+++ b/packages/patterns/image-analysis.tsx
@@ -47,7 +47,7 @@ const syncUploadedImages = handler<
 });
 
 export default pattern<ImageChatInput, ImageChatOutput>(
-  ({ systemPrompt, model }) => {
+  ({ systemPrompt }) => {
     const images = Writable.of<ImageData[]>([]);
     const prompt = Writable.of<string>("");
 

--- a/packages/patterns/image-analysis.tsx
+++ b/packages/patterns/image-analysis.tsx
@@ -1,6 +1,7 @@
 import {
   computed,
   generateText,
+  handler,
   ifElse,
   ImageData,
   NAME,
@@ -27,6 +28,25 @@ type ImageChatOutput = {
   ui: VNode;
 };
 
+type ImageUploadEvent = {
+  detail?: {
+    images?: ImageData[];
+    files?: ImageData[];
+  };
+};
+
+const appendUploadedImages = handler<
+  ImageUploadEvent,
+  { images: Writable<ImageData[]> }
+>(({ detail }, { images }) => {
+  const uploaded = detail?.images ?? detail?.files ?? [];
+  if (uploaded.length === 0) return;
+  images.set([
+    ...(images.get() ?? []),
+    ...uploaded,
+  ]);
+});
+
 export default pattern<ImageChatInput, ImageChatOutput>(
   ({ systemPrompt, model }) => {
     const images = Writable.of<ImageData[]>([]);
@@ -43,7 +63,9 @@ export default pattern<ImageChatInput, ImageChatOutput>(
       }
 
       for (const img of images.get() || []) {
-        parts.push({ type: "image", image: img.data });
+        if (img.url) {
+          parts.push({ type: "image", image: img.url });
+        }
       }
 
       return parts;
@@ -78,7 +100,7 @@ export default pattern<ImageChatInput, ImageChatOutput>(
                     showPreview
                     previewSize="md"
                     removable
-                    $images={images}
+                    oncf-change={appendUploadedImages({ images })}
                   />
                 </cf-vstack>
               </cf-card>

--- a/packages/patterns/image-analysis.tsx
+++ b/packages/patterns/image-analysis.tsx
@@ -31,20 +31,19 @@ type ImageChatOutput = {
 type ImageUploadEvent = {
   detail?: {
     images?: ImageData[];
+    allImages?: ImageData[];
     files?: ImageData[];
+    allFiles?: ImageData[];
   };
 };
 
-const appendUploadedImages = handler<
+const syncUploadedImages = handler<
   ImageUploadEvent,
   { images: Writable<ImageData[]> }
 >(({ detail }, { images }) => {
-  const uploaded = detail?.images ?? detail?.files ?? [];
-  if (uploaded.length === 0) return;
-  images.set([
-    ...(images.get() ?? []),
-    ...uploaded,
-  ]);
+  const uploaded = detail?.allImages ?? detail?.allFiles ?? detail?.images ??
+    detail?.files ?? [];
+  images.set(uploaded);
 });
 
 export default pattern<ImageChatInput, ImageChatOutput>(
@@ -100,7 +99,8 @@ export default pattern<ImageChatInput, ImageChatOutput>(
                     showPreview
                     previewSize="md"
                     removable
-                    oncf-change={appendUploadedImages({ images })}
+                    oncf-change={syncUploadedImages({ images })}
+                    oncf-remove={syncUploadedImages({ images })}
                   />
                 </cf-vstack>
               </cf-card>

--- a/packages/patterns/photo.tsx
+++ b/packages/patterns/photo.tsx
@@ -61,6 +61,22 @@ const clearPhoto = handler<
   images.set([]);
 });
 
+type ImageUploadEvent = {
+  detail?: {
+    images?: ImageData[];
+    files?: ImageData[];
+  };
+};
+
+const setUploadedPhoto = handler<
+  ImageUploadEvent,
+  { images: Writable<ImageData[]> }
+>(({ detail }, { images }) => {
+  const uploaded = detail?.images ?? detail?.files ?? [];
+  const first = uploaded[0];
+  images.set(first ? [first] : []);
+});
+
 // ===== The Pattern =====
 export const PhotoModule = pattern<PhotoModuleInput, PhotoModuleOutput>(
   ({ image: inputImage, label }) => {
@@ -172,10 +188,10 @@ export const PhotoModule = pattern<PhotoModuleInput, PhotoModuleOutput>(
             </cf-vstack>,
             // No photo yet - show upload input
             <cf-image-input
-              $images={images}
               maxImages={1}
               showPreview={false}
               style={{ width: "100%" }}
+              oncf-change={setUploadedPhoto({ images })}
             />,
           )}
         </cf-vstack>

--- a/packages/patterns/record-backup.tsx
+++ b/packages/patterns/record-backup.tsx
@@ -583,23 +583,28 @@ const clearImportResult = handler<
  * Handler to process uploaded file
  */
 const handleFileUpload = handler<
-  { detail: { files: Array<{ data: string; name: string }> } },
+  {
+    detail: {
+      files: Array<{
+        name: string;
+        data?: string;
+      }>;
+    };
+  },
   { importJson: Writable<string> }
 >(({ detail }, { importJson }) => {
   const files = detail?.files;
   if (!files || files.length === 0) return;
 
   const file = files[0];
-  // data is a data URL, need to extract the JSON content
-  const dataUrl = file.data;
-  const base64Match = dataUrl.match(/base64,(.+)/);
-  if (base64Match) {
-    try {
-      const jsonContent = atob(base64Match[1]);
-      importJson.set(jsonContent);
-    } catch (e) {
-      console.error("Failed to decode file:", e);
-    }
+  if (!file.data) return;
+  const commaIndex = file.data.indexOf(",");
+  const bytes = commaIndex === -1 ? file.data : file.data.slice(commaIndex + 1);
+  try {
+    const jsonContent = atob(bytes);
+    importJson.set(jsonContent);
+  } catch (e) {
+    console.error("Failed to decode file:", e);
   }
 });
 
@@ -700,6 +705,7 @@ export default pattern<Input, Output>(({ importJson }) => {
                 </p>
                 <cf-file-input
                   accept=".json,application/json"
+                  includeData
                   buttonText="📤 Upload Backup File"
                   showPreview={false}
                   oncf-change={handleFileUpload({ importJson })}

--- a/packages/patterns/record/extraction/smart-text-input.tsx
+++ b/packages/patterns/record/extraction/smart-text-input.tsx
@@ -35,13 +35,11 @@ import {
 
 // ===== Types =====
 
-// FileData matches cf-file-input's event shape (not exported from commonfabric)
 interface FileData {
   id: string;
   name: string;
   url: string;
-  data: string;
-  timestamp: number;
+  data?: string;
   size: number;
   type: string;
 }
@@ -92,17 +90,16 @@ If no text is visible, return an empty string.`;
 // ===== Handlers (defined OUTSIDE pattern function) =====
 
 /**
- * Decode base64 data URL to UTF-8 text
+ * Decode a base64 data URL to UTF-8 text
  * Uses TextDecoder for proper multi-byte character handling
  */
 function decodeBase64ToText(dataUrl: string): string {
-  const base64Match = dataUrl.match(/base64,(.+)/);
-  if (!base64Match) {
-    throw new Error("Invalid data URL format");
-  }
+  const commaIndex = dataUrl.indexOf(",");
+  if (commaIndex === -1) return dataUrl;
+  const base64Data = dataUrl.slice(commaIndex + 1);
 
   // Use TextDecoder for proper UTF-8 handling (same as uri-utils.ts)
-  const binaryString = atob(base64Match[1]);
+  const binaryString = atob(base64Data);
   const bytes = new Uint8Array(binaryString.length);
   for (let i = 0; i < binaryString.length; i++) {
     bytes[i] = binaryString.charCodeAt(i);
@@ -163,7 +160,12 @@ const handleFileUpload = handler<
       return;
     }
 
-    // Decode base64 data URL to text (UTF-8 safe)
+    if (!file.data) {
+      fileError.set(`Failed to read file: ${file.name}`);
+      return;
+    }
+
+    // Decode data URL to text (UTF-8 safe)
     try {
       const textContent = decodeBase64ToText(file.data);
       previewText.set(textContent);
@@ -258,28 +260,29 @@ const handleCancelPreview = handler<
 
 /**
  * Handle image change from cf-image-input
- * NOTE: The $images binding handles actual data flow to the imageArray Cell.
- * This handler only sets UI state flags for the preview section.
- * The image data arrives via the binding, triggering the computed() for OCR.
+ * Stores uploaded image links in the image array and updates preview state.
  */
 const handleImageChange = handler<
-  { detail: { images: ImageData[] } },
   {
+    detail: {
+      images?: ImageData[];
+      files?: ImageData[];
+    };
+  },
+  {
+    uploadedImage: Writable<ImageData[]>;
     previewText: Writable<string | null>;
     fileError: Writable<string | null>;
   }
->(({ detail }, { previewText, fileError }) => {
-  // NOTE: The $images binding handles data flow - this handler only clears state
-  // The handler fires before file processing completes, so we can't rely on
-  // detail.images to detect uploads. derivedPreviewSource handles that reactively.
-  const images = detail?.images;
+>(({ detail }, { uploadedImage, previewText, fileError }) => {
+  const images = detail?.images ?? detail?.files ?? [];
   if (!images || images.length === 0) {
-    // Image was removed - clear file errors
+    uploadedImage.set([]);
     fileError.set(null);
     return;
   }
 
-  // Image added - clear file preview state (image preview is derived from imageArray)
+  uploadedImage.set(images);
   previewText.set(null);
   fileError.set(null);
 });
@@ -317,25 +320,25 @@ export const SmartTextInput = pattern<
   // File error state (for user feedback)
   const fileError = Writable.of<string | null>(null);
 
-  // Image array for cf-image-input binding
+  // Image array for uploaded image links
   const imageArray = Writable.of<ImageData[]>([]);
 
   // ===== OCR Processing =====
 
   // Build OCR prompt directly using computed() - this ensures reactivity
-  // when the $images binding updates the imageArray Cell.
+  // when image upload events update the imageArray Cell.
   // Pattern: Match image-analysis.tsx which uses computed() to build content parts
   const ocrPrompt = computed(() => {
     const images = imageArray.get();
     const image = images.length > 0 ? images[0] : null;
 
-    if (!image || !image.data) {
+    if (!image || !image.url) {
       // Return undefined when no image - generateText will early-exit gracefully
       return undefined;
     }
 
     return [
-      { type: "image" as const, image: image.data },
+      { type: "image" as const, image: image.url },
       {
         type: "text" as const,
         text: "Extract all text from this image exactly as written.",
@@ -448,6 +451,7 @@ export const SmartTextInput = pattern<
       {/* File Upload Button */}
       <cf-file-input
         accept=".txt,.md,.csv,.json,text/plain,text/markdown,text/csv,application/json"
+        includeData
         buttonText="📄 Upload Text File"
         showPreview={false}
         variant="ghost"
@@ -462,11 +466,7 @@ export const SmartTextInput = pattern<
         })}
       />
 
-      {/* Image Upload Button */}
-      {/* Using $images binding like image-analysis.tsx - this handles data flow */}
-      {/* Handler only sets preview state flags, doesn't store image */}
       <cf-image-input
-        $images={imageArray}
         maxImages={1}
         showPreview={false}
         maxSizeBytes={maxImageSizeBytes}
@@ -474,6 +474,7 @@ export const SmartTextInput = pattern<
         variant="ghost"
         size="sm"
         oncf-change={handleImageChange({
+          uploadedImage: imageArray,
           previewText,
           fileError,
         })}

--- a/packages/patterns/record/extraction/smart-text-input.tsx
+++ b/packages/patterns/record/extraction/smart-text-input.tsx
@@ -332,13 +332,14 @@ export const SmartTextInput = pattern<
     const images = imageArray.get();
     const image = images.length > 0 ? images[0] : null;
 
-    if (!image || !image.url) {
+    const imagePayload = image?.data || image?.url;
+    if (!imagePayload) {
       // Return undefined when no image - generateText will early-exit gracefully
       return undefined;
     }
 
     return [
-      { type: "image" as const, image: image.url },
+      { type: "image" as const, image: imagePayload },
       {
         type: "text" as const,
         text: "Extract all text from this image exactly as written.",

--- a/packages/patterns/store-mapper.tsx
+++ b/packages/patterns/store-mapper.tsx
@@ -95,9 +95,27 @@ type ItemsByPos = Record<
 interface ImageData {
   id: string;
   name: string;
-  url?: string; // data URL (preferred)
-  data?: string; // data URL (for compatibility)
+  url?: string;
 }
+
+type ImageUploadEvent = {
+  detail?: {
+    images?: ImageData[];
+    files?: ImageData[];
+  };
+};
+
+const appendUploadedPhotos = handler<
+  ImageUploadEvent,
+  { uploadedPhotos: Writable<ImageData[]> }
+>(({ detail }, { uploadedPhotos }) => {
+  const uploaded = detail?.images ?? detail?.files ?? [];
+  if (uploaded.length === 0) return;
+  uploadedPhotos.set([
+    ...(uploadedPhotos.get() ?? []),
+    ...uploaded,
+  ]);
+});
 
 interface ExtractedAisle {
   name: string;
@@ -310,9 +328,9 @@ export default pattern<Input, Output>(
           'You are analyzing photos from a grocery store. Your task is to extract ALL visible aisle signs and return them as JSON.\n\nIMPORTANT: You MUST return a JSON object with an "aisles" array, even if you only see one aisle or partial information.\n\nFor each aisle sign you see:\n- Extract ONLY the aisle number (e.g., "8", "12", "5A", "5B") - DO NOT include the word "Aisle"\n- Extract each product category as a separate item in the products array\n- Include partially visible signs - do your best to read them\n\nExample output:\n{\n  "aisles": [\n    {"name": "8", "products": ["Bread", "Cereal", "Coffee"]},\n    {"name": "9", "products": ["Snacks", "Chips"]}\n  ]\n}',
         prompt: derive(photo, (p) => {
           // Safety check: photo might be undefined after deletion
-          if (!p || !p.data) return [];
+          if (!p || !p.url) return [];
           return [
-            { type: "image" as const, image: p.data },
+            { type: "image" as const, image: p.url },
             {
               type: "text" as const,
               text:
@@ -1512,7 +1530,9 @@ export default pattern<Input, Output>(
                         showPreview={false}
                         buttonText="📷 Scan Aisle Signs"
                         variant="secondary"
-                        $images={uploadedPhotos}
+                        oncf-change={appendUploadedPhotos({
+                          uploadedPhotos,
+                        })}
                       />
 
                       {/* Photo extraction results */}

--- a/packages/patterns/store-mapper.tsx
+++ b/packages/patterns/store-mapper.tsx
@@ -96,6 +96,7 @@ interface ImageData {
   id: string;
   name: string;
   url?: string;
+  data?: string;
 }
 
 type ImageUploadEvent = {
@@ -328,9 +329,10 @@ export default pattern<Input, Output>(
           'You are analyzing photos from a grocery store. Your task is to extract ALL visible aisle signs and return them as JSON.\n\nIMPORTANT: You MUST return a JSON object with an "aisles" array, even if you only see one aisle or partial information.\n\nFor each aisle sign you see:\n- Extract ONLY the aisle number (e.g., "8", "12", "5A", "5B") - DO NOT include the word "Aisle"\n- Extract each product category as a separate item in the products array\n- Include partially visible signs - do your best to read them\n\nExample output:\n{\n  "aisles": [\n    {"name": "8", "products": ["Bread", "Cereal", "Coffee"]},\n    {"name": "9", "products": ["Snacks", "Chips"]}\n  ]\n}',
         prompt: derive(photo, (p) => {
           // Safety check: photo might be undefined after deletion
-          if (!p || !p.url) return [];
+          const image = p?.data || p?.url;
+          if (!image) return [];
           return [
-            { type: "image" as const, image: p.url },
+            { type: "image" as const, image },
             {
               type: "text" as const,
               text:
@@ -1527,6 +1529,7 @@ export default pattern<Input, Output>(
                         multiple
                         maxImages={20}
                         maxSizeBytes={4000000}
+                        includeData
                         showPreview={false}
                         buttonText="📷 Scan Aisle Signs"
                         variant="secondary"

--- a/packages/patterns/text-import.tsx
+++ b/packages/patterns/text-import.tsx
@@ -55,11 +55,10 @@ interface TextImportModuleOutput {
  * Handles data URLs like "data:text/plain;base64,SGVsbG8gV29ybGQ="
  */
 function decodeBase64ToText(dataUrl: string): string {
-  // Extract the base64 portion after the comma
   const commaIndex = dataUrl.indexOf(",");
-  if (commaIndex === -1) return dataUrl; // Not a data URL, return as-is
-
-  const base64Data = dataUrl.slice(commaIndex + 1);
+  const base64Data = commaIndex === -1
+    ? dataUrl
+    : dataUrl.slice(commaIndex + 1);
 
   try {
     // Decode base64 to binary string, then convert to UTF-8
@@ -82,8 +81,8 @@ interface FileUploadEvent {
       name: string;
       type: string;
       size: number;
-      data: string; // data URL
       url: string;
+      data?: string;
     }>;
   };
 }
@@ -94,9 +93,8 @@ const handleFileUpload = handler<
   { content: Writable<string>; filename: Writable<string> }
 >(({ detail }, state) => {
   const file = detail?.files?.[0];
-  if (!file) return;
+  if (!file?.data) return;
 
-  // Decode the base64 data URL to text
   const textContent = decodeBase64ToText(file.data);
 
   state.content.set(textContent);
@@ -248,6 +246,7 @@ export const TextImportModule = pattern<
           // No file yet - show upload input
           <cf-file-input
             accept=".txt,.md,.csv,.json,text/plain,text/markdown,text/csv,application/json"
+            includeData
             buttonText={`${MODULE_METADATA.icon} Import Text File`}
             showPreview={false}
             oncf-change={handleFileUpload({ content, filename })}

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -444,7 +444,7 @@ describe("RuntimeProcessor blob upload IPC", () => {
           RuntimeProcessor.prototype.handleUploadBlob.call(processor, {
             type: RequestType.UploadBlob,
             contentType: "image/png",
-            body: new Uint8Array([1, 2, 3]),
+            body: [1, 2, 3],
             suffix: "png",
           }),
         ).resolves.toEqual({

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -839,6 +839,7 @@ export class RuntimeProcessor {
     request: UploadBlobRequest,
   ): Promise<UploadBlobResponse> {
     const suffix = (request.suffix ?? "bin").replace(/^\./, "") || "bin";
+    const bytes = Uint8Array.from(request.body);
     const target = new URL(
       `/${this.space}/blobs/upload.${encodeURIComponent(suffix)}`,
       this.apiUrl,
@@ -847,7 +848,7 @@ export class RuntimeProcessor {
     // process is running with legacy memory JSON flags.
     const body = blobUploadEncoding.encode({
       type: request.contentType,
-      body: new FabricBytes(request.body),
+      body: new FabricBytes(bytes),
     } as FabricValue);
     const response = await fetch(target, {
       method: "POST",

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -350,7 +350,7 @@ export interface SetBreakpointsRequest extends BaseRequest {
 export interface UploadBlobRequest extends BaseRequest {
   type: RequestType.UploadBlob;
   contentType: string;
-  body: Uint8Array;
+  body: number[];
   suffix?: string;
 }
 

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -452,7 +452,9 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
   }): Promise<UploadBlobResponse> {
     return await this.#conn.request<RequestType.UploadBlob>({
       type: RequestType.UploadBlob,
-      ...options,
+      contentType: options.contentType,
+      body: Array.from(options.body),
+      suffix: options.suffix,
     });
   }
 

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -84,6 +84,13 @@ import {
 } from "./features/backlinks.ts";
 import { createProseMarkdownPlugin } from "./features/prose-markdown.ts";
 
+function escapeMarkdownImageAltText(text: string): string {
+  return text.replace(/\\/g, "\\\\")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]")
+    .replace(/\r?\n/g, " ");
+}
+
 /**
  * Supported MIME types for syntax highlighting
  */
@@ -1523,7 +1530,9 @@ export class CFCodeEditor extends BaseElement {
       }
 
       const markdown = storedFiles
-        .map((file) => `![${file.name}](${file.url})`)
+        .map((file) =>
+          `![${escapeMarkdownImageAltText(file.name)}](${file.url})`
+        )
         .join("\n");
       const selection = view.state.selection.main;
       view.dispatch({

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -1,4 +1,5 @@
 import { html, PropertyValues } from "lit";
+import { property } from "lit/decorators.js";
 import { BaseElement } from "../../core/base-element.ts";
 import { styles } from "./styles.ts";
 import {
@@ -62,10 +63,14 @@ import {
   type CellHandle,
   isCellHandle,
   NAME,
+  type RuntimeClient,
 } from "@commonfabric/runtime-client";
 import { stringSchema } from "@commonfabric/runner/schemas";
 import { type InputTimingOptions } from "../../core/input-timing-controller.ts";
 import { createStringCellController } from "../../core/cell-controller.ts";
+import { consume } from "@lit/context";
+import { runtimeContext } from "../../runtime-context.ts";
+import { type StoredFile, uploadFile } from "../../utils/file-cell-storage.ts";
 import {
   Mentionable,
   MentionableArray,
@@ -216,6 +221,10 @@ export class CFCodeEditor extends BaseElement {
   declare mode: "code" | "prose";
   declare autofocus: boolean;
   declare cursorPosition: "start" | "end";
+
+  @consume({ context: runtimeContext, subscribe: true })
+  @property({ attribute: false })
+  accessor runtime: RuntimeClient | undefined = undefined;
 
   private _editorView: EditorView | undefined;
   private _lang = new Compartment();
@@ -1354,6 +1363,16 @@ export class CFCodeEditor extends BaseElement {
           this.emit("cf-blur");
           return false;
         },
+        paste: (event, view) => {
+          if (this.readonly || this.disabled) return false;
+          const files = Array.from(event.clipboardData?.files ?? [])
+            .filter((file) => file.type.startsWith("image/"));
+          if (files.length === 0) return false;
+
+          event.preventDefault();
+          this._handleImagePaste(files, view);
+          return true;
+        },
       }),
       // Add backlink click handler for Cmd/Ctrl+Click
       this.createBacklinkClickHandler(),
@@ -1479,6 +1498,50 @@ export class CFCodeEditor extends BaseElement {
    */
   get editorView(): EditorView | undefined {
     return this._editorView;
+  }
+
+  private async _handleImagePaste(
+    files: File[],
+    view: EditorView,
+  ): Promise<void> {
+    const runtime = isCellHandle(this.value)
+      ? this.value.runtime()
+      : this.runtime;
+
+    if (!runtime) {
+      this.emit("cf-error", {
+        error: new Error("Runtime is not available for pasted image storage"),
+        message: "Runtime is not available for pasted image storage",
+      });
+      return;
+    }
+
+    try {
+      const storedFiles: StoredFile[] = [];
+      for (const file of files) {
+        storedFiles.push(await uploadFile({ file, runtime }));
+      }
+
+      const markdown = storedFiles
+        .map((file) => `![${file.name}](${file.url})`)
+        .join("\n");
+      const selection = view.state.selection.main;
+      view.dispatch({
+        changes: {
+          from: selection.from,
+          to: selection.to,
+          insert: markdown,
+        },
+        selection: { anchor: selection.from + markdown.length },
+      });
+
+      this.emit("cf-file-paste", { files: storedFiles });
+    } catch (error) {
+      this.emit("cf-error", {
+        error: error as Error,
+        message: "Failed to store pasted image",
+      });
+    }
   }
 
   /**

--- a/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
+++ b/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
@@ -462,6 +462,8 @@ export class CFFileInput extends BaseElement {
         }
       }
 
+      if (newFiles.length === 0) return;
+
       // When multiple is false, replace existing files instead of appending
       const updatedFiles = this.multiple
         ? [...currentFiles, ...newFiles]

--- a/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
+++ b/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
@@ -1,10 +1,8 @@
 import { css, html, type TemplateResult } from "lit";
-import { property } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 import { BaseElement } from "../../core/base-element.ts";
 import type { ButtonSize, ButtonVariant } from "../cf-button/cf-button.ts";
-import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
-import type { Schema } from "@commonfabric/api/schema";
-import { createArrayCellController } from "../../core/cell-controller.ts";
+import type { RuntimeClient } from "@commonfabric/runtime-client";
 import { consume } from "@lit/context";
 import {
   applyThemeToElement,
@@ -13,52 +11,15 @@ import {
   defaultTheme,
 } from "../theme-context.ts";
 import { formatFileSize } from "../../utils/image-compression.ts";
+import { runtimeContext } from "../../runtime-context.ts";
+import {
+  type StoredFile,
+  type StoreFileOptions,
+  uploadFile,
+} from "../../utils/file-cell-storage.ts";
 import "../cf-button/cf-button.ts";
 
-// Schema for FileData array
-const FileDataArraySchema = {
-  type: "array",
-  items: {
-    type: "object",
-    properties: {
-      id: { type: "string" },
-      name: { type: "string" },
-      url: { type: "string" },
-      data: { type: "string" },
-      timestamp: { type: "number" },
-      size: { type: "number" },
-      type: { type: "string" },
-      width: { type: "number" },
-      height: { type: "number" },
-      metadata: { type: "object" },
-    },
-    required: ["id", "name", "url", "data", "timestamp", "size", "type"],
-  },
-} as const satisfies JSONSchema;
-
-/**
- * Generic file data structure
- */
-export interface FileData {
-  id: string;
-  name: string;
-  url: string; // data URL
-  data: string; // data URL (kept for compatibility)
-  timestamp: number;
-  size: number;
-  type: string; // MIME type
-
-  // Optional metadata (can be populated by subclasses)
-  width?: number;
-  height?: number;
-  metadata?: Record<string, unknown>;
-}
-
-// Type validation: ensure schema matches interface
-type _ValidateFileData = Schema<
-  typeof FileDataArraySchema
->[number] extends FileData ? true : never;
-const _validateFileData: _ValidateFileData = true;
+export type FileData = StoredFile;
 
 /**
  * CFFileInput - Generic file upload component
@@ -76,8 +37,9 @@ const _validateFileData: _ValidateFileData = true;
  * @attr {boolean} removable - Allow removing files (default: true)
  * @attr {boolean} disabled - Disable the input
  * @attr {number} maxSizeBytes - Max size warning threshold (default: none)
+ * @attr {boolean} includeData - Include a data URL in emitted file descriptors
  *
- * @fires cf-change - Fired when file(s) are added. detail: { files: FileData[] }
+ * @fires cf-change - Fired when file(s) are added. detail: { files: StoredFile[], allFiles: StoredFile[] }
  * @fires cf-remove - Fired when a file is removed. detail: { id: string, files: FileData[] }
  * @fires cf-error - Fired when an error occurs. detail: { error: Error, message: string }
  *
@@ -261,52 +223,53 @@ export class CFFileInput extends BaseElement {
   @property({ type: Number })
   accessor maxSizeBytes: number | undefined = undefined;
 
-  @property({ type: Array })
-  accessor files: CellHandle<FileData[]> | FileData[] = [];
+  @property({ type: Boolean })
+  accessor includeData = false;
 
   @property({ type: Boolean })
   protected accessor loading = false;
+
+  @state()
+  protected accessor storedFiles: StoredFile[] = [];
 
   // Theme consumption
   @consume({ context: cfThemeContext, subscribe: true })
   @property({ attribute: false })
   accessor theme: CFTheme = defaultTheme;
 
-  protected _cellController = createArrayCellController<FileData>(this, {
-    onChange: (_newFiles: FileData[], _oldFiles: FileData[]) => {
-      this.requestUpdate();
-    },
-  });
+  @consume({ context: runtimeContext, subscribe: true })
+  @property({ attribute: false })
+  accessor runtime: RuntimeClient | undefined = undefined;
 
-  protected _generateId(): string {
-    return `file-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+  protected getFiles(): StoredFile[] {
+    return [...this.storedFiles];
   }
 
-  protected getFiles(): FileData[] {
-    return [...this._cellController.getValue()];
-  }
-
-  protected setFiles(newFiles: FileData[]): void {
-    this._cellController.setValue(newFiles);
+  protected setFiles(newFiles: StoredFile[]): void {
+    this.storedFiles = newFiles;
   }
 
   /**
-   * Process a file and return FileData
+   * Process a file and return a stored file descriptor link.
    * Subclasses can override this to add custom processing
    */
-  protected async processFile(file: File): Promise<FileData> {
-    const id = this._generateId();
-    const dataUrl = await this._readFileAsDataURL(file);
+  protected async processFile(file: File): Promise<StoredFile> {
+    return await this.storeFile(file);
+  }
 
-    return {
-      id,
-      name: file.name,
-      url: dataUrl,
-      data: dataUrl,
-      timestamp: Date.now(),
-      size: file.size,
-      type: file.type,
-    };
+  protected async storeFile(
+    file: File,
+    metadata?: Partial<Pick<StoreFileOptions, "width" | "height" | "metadata">>,
+  ): Promise<StoredFile> {
+    if (!this.runtime) {
+      throw new Error("Runtime is not available for file storage");
+    }
+    return await uploadFile({
+      file,
+      runtime: this.runtime,
+      includeDataUrl: this.includeData,
+      ...metadata,
+    });
   }
 
   /**
@@ -329,7 +292,7 @@ export class CFFileInput extends BaseElement {
    * Render preview for a file
    * Subclasses can override for custom preview rendering
    */
-  protected renderPreview(file: FileData): TemplateResult {
+  protected renderPreview(file: StoredFile): TemplateResult {
     // Smart default preview based on MIME type
     if (file.type.startsWith("image/")) {
       return html`
@@ -433,15 +396,6 @@ export class CFFileInput extends BaseElement {
     return "📎";
   }
 
-  private _readFileAsDataURL(file: Blob): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(reader.result as string);
-      reader.onerror = () => reject(new Error("Failed to read file"));
-      reader.readAsDataURL(file);
-    });
-  }
-
   private _handleButtonClick() {
     this.emit("cf-click"); // Emit before opening file picker
     const input = this.shadowRoot?.querySelector(
@@ -474,7 +428,7 @@ export class CFFileInput extends BaseElement {
     this.loading = true;
 
     try {
-      const newFiles: FileData[] = [];
+      const newFiles: StoredFile[] = [];
 
       for (const file of Array.from(files)) {
         try {
@@ -513,7 +467,7 @@ export class CFFileInput extends BaseElement {
         ? [...currentFiles, ...newFiles]
         : newFiles;
       this.setFiles(updatedFiles);
-      this.emit("cf-change", { files: updatedFiles });
+      this.emit("cf-change", { files: newFiles, allFiles: updatedFiles });
     } finally {
       this.loading = false;
       // Reset input so same file can be selected again
@@ -526,27 +480,10 @@ export class CFFileInput extends BaseElement {
     const updatedFiles = currentFiles.filter((file) => file.id !== id);
     this.setFiles(updatedFiles);
     this.emit("cf-remove", { id, files: updatedFiles });
-    this.emit("cf-change", { files: updatedFiles });
-  }
-
-  override connectedCallback() {
-    super.connectedCallback();
-    // CellController handles subscription automatically via ReactiveController
-  }
-
-  override disconnectedCallback() {
-    super.disconnectedCallback();
-    // CellController handles cleanup automatically via ReactiveController
   }
 
   override willUpdate(changedProperties: Map<string, any>) {
     super.willUpdate(changedProperties);
-
-    // If the files property itself changed (e.g., switched to a different cell)
-    if (changedProperties.has("files")) {
-      // Bind the new value (Cell or plain array) to the controller
-      this._cellController.bind(this.files, FileDataArraySchema);
-    }
   }
 
   override updated(changedProperties: Map<string, any>) {
@@ -558,9 +495,6 @@ export class CFFileInput extends BaseElement {
   }
 
   override firstUpdated() {
-    // Bind the initial value to the cell controller
-    this._cellController.bind(this.files, FileDataArraySchema);
-
     // Apply theme after first render
     applyThemeToElement(this, this.theme ?? defaultTheme);
   }

--- a/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
+++ b/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
@@ -39,8 +39,8 @@ export type FileData = StoredFile;
  * @attr {number} maxSizeBytes - Max size warning threshold (default: none)
  * @attr {boolean} includeData - Include a data URL in emitted file descriptors
  *
- * @fires cf-change - Fired when file(s) are added. detail: { files: StoredFile[], allFiles: StoredFile[] }
- * @fires cf-remove - Fired when a file is removed. detail: { id: string, files: FileData[] }
+ * @fires cf-change - Fired when file(s) are added or removed. On add, files contains the newly added files. On remove, files contains the updated full list for compatibility. detail: { files: StoredFile[], allFiles: StoredFile[] }
+ * @fires cf-remove - Fired when a file is removed. detail: { id: string, files: StoredFile[], allFiles: StoredFile[] }
  * @fires cf-error - Fired when an error occurs. detail: { error: Error, message: string }
  *
  * @example
@@ -481,11 +481,8 @@ export class CFFileInput extends BaseElement {
     const currentFiles = this.getFiles();
     const updatedFiles = currentFiles.filter((file) => file.id !== id);
     this.setFiles(updatedFiles);
-    this.emit("cf-remove", { id, files: updatedFiles });
-  }
-
-  override willUpdate(changedProperties: Map<string, any>) {
-    super.willUpdate(changedProperties);
+    this.emit("cf-remove", { id, files: updatedFiles, allFiles: updatedFiles });
+    this.emit("cf-change", { files: updatedFiles, allFiles: updatedFiles });
   }
 
   override updated(changedProperties: Map<string, any>) {

--- a/packages/ui/src/v2/components/cf-image-input/cf-image-input.ts
+++ b/packages/ui/src/v2/components/cf-image-input/cf-image-input.ts
@@ -71,8 +71,8 @@ export interface ImageData extends StoredFile {
  * @attr {boolean} removable - Allow removing images (default: true)
  * @attr {boolean} disabled - Disable the input
  *
- * @fires cf-change - Fired when image(s) are added. detail: { images: ImageData[], allImages: ImageData[] }
- * @fires cf-remove - Fired when an image is removed. detail: { id: string, images: ImageData[] }
+ * @fires cf-change - Fired when image(s) are added or removed. On add, images contains the newly added images. On remove, images contains the updated full list for compatibility. detail: { images: ImageData[], allImages: ImageData[] }
+ * @fires cf-remove - Fired when an image is removed. detail: { id: string, images: ImageData[], allImages: ImageData[] }
  * @fires cf-error - Fired when an error occurs. detail: { error: Error, message: string }
  *
  * @example
@@ -211,25 +211,20 @@ function readImageDimensions(
   file: File,
 ): Promise<Pick<ImageData, "width" | "height">> {
   const objectUrl = URL.createObjectURL(file);
-  try {
-    return new Promise((resolve, reject) => {
-      const img = new Image();
+  return new Promise((resolve, reject) => {
+    const img = new Image();
 
-      img.onload = () => {
-        URL.revokeObjectURL(objectUrl);
-        resolve({ width: img.width, height: img.height });
-      };
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+      resolve({ width: img.width, height: img.height });
+    };
 
-      img.onerror = () => {
-        URL.revokeObjectURL(objectUrl);
-        reject(new Error("Failed to load image"));
-      };
-      img.src = objectUrl;
-    });
-  } catch (error) {
-    URL.revokeObjectURL(objectUrl);
-    throw error;
-  }
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error("Failed to load image"));
+    };
+    img.src = objectUrl;
+  });
 }
 
 customElements.define("cf-image-input", CFImageInput);

--- a/packages/ui/src/v2/components/cf-image-input/cf-image-input.ts
+++ b/packages/ui/src/v2/components/cf-image-input/cf-image-input.ts
@@ -1,7 +1,8 @@
 import { html, type TemplateResult } from "lit";
 import { property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { CFFileInput, type FileData } from "../cf-file-input/cf-file-input.ts";
+import { CFFileInput } from "../cf-file-input/cf-file-input.ts";
+import type { StoredFile } from "../../utils/file-cell-storage.ts";
 import {
   compressImage,
   formatFileSize,
@@ -44,7 +45,7 @@ export interface ExifData {
 /**
  * Image data structure (extends FileData with image-specific fields)
  */
-export interface ImageData extends FileData {
+export interface ImageData extends StoredFile {
   width?: number;
   height?: number;
   exif?: ExifData;
@@ -70,7 +71,7 @@ export interface ImageData extends FileData {
  * @attr {boolean} removable - Allow removing images (default: true)
  * @attr {boolean} disabled - Disable the input
  *
- * @fires cf-change - Fired when image(s) are added. detail: { images: ImageData[] }
+ * @fires cf-change - Fired when image(s) are added. detail: { images: ImageData[], allImages: ImageData[] }
  * @fires cf-remove - Fired when an image is removed. detail: { id: string, images: ImageData[] }
  * @fires cf-error - Fired when an error occurs. detail: { error: Error, message: string }
  *
@@ -96,14 +97,6 @@ export class CFImageInput extends CFFileInput {
 
   @property({ type: Boolean })
   accessor extractExif = false;
-
-  // Provide backward-compatible property alias
-  get images(): ImageData[] | any {
-    return this.files;
-  }
-  set images(value: ImageData[] | any) {
-    this.files = value;
-  }
 
   // Alias maxImages to maxFiles for backward compatibility
   get maxImages(): number | undefined {
@@ -148,28 +141,8 @@ export class CFImageInput extends CFFileInput {
 
   // Override: Extract image dimensions and EXIF
   protected override async processFile(file: File): Promise<ImageData> {
-    // Get base file data
-    const baseData = await super.processFile(file);
-
-    // Load image to get dimensions
-    return new Promise((resolve, reject) => {
-      const img = new Image();
-
-      img.onload = () => {
-        const imageData: ImageData = {
-          ...baseData,
-          width: img.width,
-          height: img.height,
-        };
-
-        // TODO(#exif): Add EXIF extraction if this.extractExif is true
-
-        resolve(imageData);
-      };
-
-      img.onerror = () => reject(new Error("Failed to load image"));
-      img.src = baseData.url;
-    });
+    const dimensions = await readImageDimensions(file);
+    return await this.storeFile(file, dimensions) as ImageData;
   }
 
   // Override: Always use <img> for images (we know they're images)
@@ -214,27 +187,48 @@ export class CFImageInput extends CFFileInput {
     super._handleFileChange(event);
   };
 
-  // Override emit to add backward-compatible event details
+  // Override emit to add image-specific event details
   protected override emit<T = any>(
     eventName: string,
     detail?: T,
     options?: EventInit,
   ): boolean {
-    if (eventName === "cf-change" && (detail as any)?.files) {
-      // Add 'images' property for backward compatibility
+    if (
+      (eventName === "cf-change" || eventName === "cf-remove") &&
+      (detail as any)?.files
+    ) {
       return super.emit(eventName, {
         ...detail,
         images: (detail as any).files,
+        allImages: (detail as any).allFiles,
       } as T, options);
-    } else if (eventName === "cf-remove" && (detail as any)?.files) {
-      // Add 'images' property for backward compatibility
-      return super.emit(eventName, {
-        ...detail,
-        images: (detail as any).files,
-      } as T, options);
-    } else {
-      return super.emit(eventName, detail, options);
     }
+    return super.emit(eventName, detail, options);
+  }
+}
+
+function readImageDimensions(
+  file: File,
+): Promise<Pick<ImageData, "width" | "height">> {
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+
+      img.onload = () => {
+        URL.revokeObjectURL(objectUrl);
+        resolve({ width: img.width, height: img.height });
+      };
+
+      img.onerror = () => {
+        URL.revokeObjectURL(objectUrl);
+        reject(new Error("Failed to load image"));
+      };
+      img.src = objectUrl;
+    });
+  } catch (error) {
+    URL.revokeObjectURL(objectUrl);
+    throw error;
   }
 }
 

--- a/packages/ui/src/v2/utils/file-cell-storage.test.ts
+++ b/packages/ui/src/v2/utils/file-cell-storage.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { RuntimeClient } from "@commonfabric/runtime-client";
+import {
+  fileSuffix,
+  fileToDataUrl,
+  sanitizeFileName,
+  uploadFile,
+} from "./file-cell-storage.ts";
+
+describe("file-cell-storage", () => {
+  it("encodes blobs as data urls when requested", async () => {
+    const file = new File(["hello"], "hello.txt", { type: "text/plain" });
+    expect(await fileToDataUrl(file)).toBe("data:text/plain;base64,aGVsbG8=");
+  });
+
+  it("sanitizes filenames and derives suffixes", () => {
+    expect(sanitizeFileName(" My Screen Shot 1.png ")).toBe(
+      "My-Screen-Shot-1.png",
+    );
+    expect(sanitizeFileName("")).toBe("file");
+    expect(fileSuffix("no-extension", "image/png")).toBe("png");
+    expect(fileSuffix("report.final.PDF", "application/octet-stream")).toBe(
+      "pdf",
+    );
+  });
+
+  it("uploads bytes through RuntimeClient and returns a descriptor", async () => {
+    let request: unknown;
+    const runtime = {
+      uploadBlob: (options: unknown) => {
+        request = options;
+        return Promise.resolve({
+          id: "fid1:test",
+          url: "blobs/test.txt",
+        });
+      },
+    } as unknown as RuntimeClient;
+
+    const file = new File(["hello"], "hello world.txt", {
+      type: "text/plain",
+    });
+    const stored = await uploadFile({
+      file,
+      runtime,
+      includeDataUrl: true,
+    });
+
+    expect(request).toMatchObject({
+      contentType: "text/plain",
+      suffix: "txt",
+    });
+    expect((request as { body: Uint8Array }).body).toEqual(
+      new Uint8Array([104, 101, 108, 108, 111]),
+    );
+    expect(stored).toMatchObject({
+      id: "fid1:test",
+      name: "hello world.txt",
+      url: "blobs/test.txt",
+      mediaType: "text/plain",
+      type: "text/plain",
+      size: 5,
+      data: "data:text/plain;base64,aGVsbG8=",
+    });
+  });
+});

--- a/packages/ui/src/v2/utils/file-cell-storage.ts
+++ b/packages/ui/src/v2/utils/file-cell-storage.ts
@@ -1,0 +1,110 @@
+import type { RuntimeClient } from "@commonfabric/runtime-client";
+
+export interface StoredFile {
+  id: string;
+  name: string;
+  mediaType: string;
+  type: string;
+  size: number;
+  createdAt: number;
+  timestamp: number;
+  lastModified?: number;
+  url: string;
+  data?: string;
+  width?: number;
+  height?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface StoreFileOptions {
+  file: File;
+  runtime: RuntimeClient;
+  width?: number;
+  height?: number;
+  metadata?: Record<string, unknown>;
+  includeDataUrl?: boolean;
+}
+
+export async function uploadFile(
+  options: StoreFileOptions,
+): Promise<StoredFile> {
+  const { file, runtime, width, height, metadata, includeDataUrl } = options;
+  const createdAt = Date.now();
+  const mediaType = file.type || "application/octet-stream";
+  const buffer = await file.arrayBuffer();
+  const upload = await runtime.uploadBlob({
+    contentType: mediaType,
+    body: new Uint8Array(buffer),
+    suffix: fileSuffix(file.name, mediaType),
+  });
+
+  return {
+    id: upload.id,
+    name: file.name,
+    mediaType,
+    type: mediaType,
+    size: file.size,
+    createdAt,
+    timestamp: createdAt,
+    lastModified: file.lastModified || undefined,
+    url: upload.url,
+    ...(includeDataUrl ? { data: await fileToDataUrl(file, buffer) } : {}),
+    ...(width !== undefined ? { width } : {}),
+    ...(height !== undefined ? { height } : {}),
+    ...(metadata !== undefined ? { metadata } : {}),
+  };
+}
+
+export function sanitizeFileName(name: string): string {
+  const trimmed = name.trim() || "file";
+  return trimmed
+    .replace(/[^\w.\-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "") || "file";
+}
+
+export function fileSuffix(name: string, mediaType: string): string {
+  const sanitized = sanitizeFileName(name);
+  const dot = sanitized.lastIndexOf(".");
+  if (dot >= 0 && dot < sanitized.length - 1) {
+    return sanitizeFileName(sanitized.slice(dot + 1)).toLowerCase();
+  }
+  return MIME_SUFFIXES[mediaType] ?? "bin";
+}
+
+export async function fileToDataUrl(file: Blob): Promise<string>;
+export async function fileToDataUrl(
+  file: Blob,
+  buffer: ArrayBuffer,
+): Promise<string>;
+export async function fileToDataUrl(
+  file: Blob,
+  buffer?: ArrayBuffer,
+): Promise<string> {
+  const bytes = new Uint8Array(buffer ?? await file.arrayBuffer());
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return `data:${file.type || "application/octet-stream"};base64,${
+    btoa(binary)
+  }`;
+}
+
+const MIME_SUFFIXES: Record<string, string> = {
+  "application/json": "json",
+  "application/pdf": "pdf",
+  "application/xml": "xml",
+  "image/avif": "avif",
+  "image/bmp": "bmp",
+  "image/gif": "gif",
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/svg+xml": "svg",
+  "image/webp": "webp",
+  "text/csv": "csv",
+  "text/html": "html",
+  "text/markdown": "md",
+  "text/plain": "txt",
+};

--- a/packages/ui/src/v2/utils/index.ts
+++ b/packages/ui/src/v2/utils/index.ts
@@ -5,3 +5,4 @@
 export * from "./events.ts";
 export * from "./types.ts";
 export * from "./image-compression.ts";
+export * from "./file-cell-storage.ts";


### PR DESCRIPTION
## Summary

This PR layers on top of #3488 and updates the paste/file-upload UI to use the new runtime blob upload capability instead of the older cell-backed upload approach.

- routes cf-code-editor pasted images through RuntimeClient.uploadBlob()
- updates cf-file-input/cf-image-input to emit blob URL descriptors
- keeps text import flows working with explicit includeData data URL payloads
- removes the local Toolshed file-route approach from this branch

## Validation

- deno test packages/ui/src/v2/utils/file-cell-storage.test.ts
- deno test --allow-env packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
- deno check packages/ui/src/v2/components/cf-file-input/cf-file-input.ts packages/ui/src/v2/components/cf-image-input/cf-image-input.ts packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts packages/patterns/image-analysis.tsx packages/patterns/photo.tsx packages/patterns/group-chat-room.tsx packages/patterns/store-mapper.tsx packages/patterns/text-import.tsx packages/patterns/record-backup.tsx packages/patterns/record/extraction/smart-text-input.tsx
- git diff --check origin/codex/toolshed-blob-upload...HEAD

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 134s
---END COPY-PASTE--- 