### PR TITLE
Sort JSON-encoded plain object keys by UTF-8 byte order

### DIFF
--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -350,3 +350,49 @@ The `/object` escape (Section 6) ensures that legitimate plain objects with
 encoder will never emit a plain-object form that violates this rule. A
 conforming decoder that encounters a violation should treat it as an encoding
 error.
+
+## 10. Plain Object Key Ordering
+
+A conforming encoder **must** emit the keys of every plain object in **UTF-8
+byte order**, using the same comparison defined for hashing in
+`2-hash-byte-format.md` Section 5:
+
+1. Compare byte-by-byte, treating each byte as an unsigned integer (0--255).
+2. At each position, the byte with the smaller unsigned value comes first.
+3. If one key is a prefix of another, the shorter key comes first.
+
+This requirement applies to every plain object that reaches the wire,
+including:
+
+- Bare plain objects (no `/`-prefixed keys).
+- Plain objects wrapped in `/object` (Section 6) — the keys of the wrapped
+  inner object must be sorted.
+- Plain objects wrapped in `/quote` (Section 6) — the keys of the quoted
+  literal must be sorted.
+
+> **Why sort.** Sorting makes the JSON wire form **canonical**: two plain
+> objects with the same keys and values produce the same JSON bytes regardless
+> of the order in which their keys were inserted. This in turn lets two
+> independently-built encoders agree on a single byte-for-byte encoding for the
+> same logical value, which simplifies content addressing, deduplication, and
+> diffing. The sort key is the same UTF-8 byte order used by hashing, so the
+> two systems share one specification of "canonical key order."
+>
+> The keys of a single-key tagged object (`/<Type>@<Version>`, `/object`,
+> `/quote`, `/hole`, etc.) are trivially "sorted" — there is only one key.
+> The requirement is meaningful only for plain objects with two or more keys,
+> and for the inner contents of `/object` and `/quote` wrappers.
+
+> **JS implementation note.** JavaScript's native string comparison (`<`, `>`,
+> `Array.prototype.sort` with no comparator) sorts by UTF-16 code units, which
+> differs from UTF-8 byte order when supplementary characters (U+10000 and
+> above) are present. An implementation must use a UTF-8-aware comparator
+> (or equivalently, sort by Unicode code point) when supplementary characters
+> may appear in keys. See `2-hash-byte-format.md` Section 5 for the detailed
+> rationale and example.
+
+> **Decoder behavior.** A decoder is **not** required to validate that incoming
+> keys are sorted. The deserialized value is a plain JS object whose
+> own-property iteration order will reflect whatever order the encoder used.
+> Re-encoding a decoded value through a conforming encoder restores canonical
+> sorted order regardless of the order in which keys were received.

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -392,7 +392,9 @@ including:
 > rationale and example.
 
 > **Decoder behavior.** A decoder is **not** required to validate that incoming
-> keys are sorted. The deserialized value is a plain JS object whose
-> own-property iteration order will reflect whatever order the encoder used.
-> Re-encoding a decoded value through a conforming encoder restores canonical
-> sorted order regardless of the order in which keys were received.
+> keys are sorted. The host language's own object representation may impose its
+> own iteration order on the decoded value (for example, in JavaScript,
+> integer-index-like keys iterate in numeric order ahead of other string keys,
+> regardless of the order in which they appeared on the wire). A conforming
+> encoder re-establishes UTF-8 canonical key order on output regardless of the
+> order in which keys were received or the host language's iteration rules.

--- a/packages/data-model/json-encoding-context.ts
+++ b/packages/data-model/json-encoding-context.ts
@@ -23,6 +23,7 @@ import {
   FabricSet,
 } from "./fabric-native-instances.ts";
 import { TAGS } from "./fabric-type-tags.ts";
+import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 
 /**
  * Tag prefix for the encoded form used by this module. We use this explicit
@@ -339,13 +340,14 @@ export class JsonEncodingContext implements SerializationContext<string> {
     }
     seen.add(value as object);
 
+    // Iterate keys in UTF-8 byte order. This matches the canonical key order
+    // used by `value-hash.ts`, and makes JSON encoding deterministic across
+    // implementations and across objects whose keys differ only in insertion
+    // order. See `3-json-encoding.md` Section 10 for the spec.
     const result: Record<string, JsonWireValue> = {};
-    for (
-      const [key, val] of Object.entries(
-        value as Record<string, FabricValue>,
-      )
-    ) {
-      result[key] = this.serialize(val, seen, registry);
+    const valueRec = value as Record<string, FabricValue>;
+    for (const key of utf8SortedKeysOf(valueRec)) {
+      result[key] = this.serialize(valueRec[key], seen, registry);
     }
     seen.delete(value as object);
 

--- a/packages/data-model/test/json-encoding-context.test.ts
+++ b/packages/data-model/test/json-encoding-context.test.ts
@@ -936,6 +936,62 @@ describe("JsonEncodingContext", () => {
       expect(result.b).toBe(undefined);
       expect("b" in result).toBe(true);
     });
+
+    // --- Key ordering (Section 10) ---
+
+    it("emits keys in UTF-8 byte order for a bare plain object", () => {
+      const obj = { c: 3, a: 1, b: 2 } as unknown as FabricValue;
+      const wire = toWireFormat(obj) as Record<string, JsonWireValue>;
+      expect(Object.keys(wire)).toEqual(["a", "b", "c"]);
+    });
+
+    it("emits keys in UTF-8 byte order regardless of insertion order", () => {
+      const obj1 = { x: 1, y: 2, z: 3 } as unknown as FabricValue;
+      const obj2 = { z: 3, x: 1, y: 2 } as unknown as FabricValue;
+      const obj3 = { y: 2, z: 3, x: 1 } as unknown as FabricValue;
+      const ctx = new JsonEncodingContext();
+      expect(ctx.encode(obj1)).toBe(ctx.encode(obj2));
+      expect(ctx.encode(obj1)).toBe(ctx.encode(obj3));
+    });
+
+    it("sorts keys in nested plain objects", () => {
+      const obj = {
+        b: { z: 1, a: 2 },
+        a: 0,
+      } as unknown as FabricValue;
+      const wire = toWireFormat(obj) as Record<string, JsonWireValue>;
+      expect(Object.keys(wire)).toEqual(["a", "b"]);
+      const inner = wire.b as Record<string, JsonWireValue>;
+      expect(Object.keys(inner)).toEqual(["a", "z"]);
+    });
+
+    it("sorts keys correctly for supplementary characters (UTF-8 vs UTF-16)", () => {
+      // U+10000 (UTF-16: D800 DC00; UTF-8: F0 90 80 80) sorts AFTER U+E000
+      // (UTF-16: E000; UTF-8: EE 80 80) in UTF-8 byte order, but BEFORE it in
+      // JS native (UTF-16) order. The encoder must use UTF-8 order.
+      const obj = {
+        ["\u{10000}"]: 1,
+        [""]: 2,
+      } as unknown as FabricValue;
+      const wire = toWireFormat(obj) as Record<string, JsonWireValue>;
+      expect(Object.keys(wire)).toEqual(["", "\u{10000}"]);
+    });
+
+    it("matches the key order used by `value-hash.ts`", async () => {
+      // Both subsystems must agree on the canonical sort order. Cross-check
+      // via `utf8SortedKeysOf`, which is the function value-hash.ts uses.
+      const { utf8SortedKeysOf } = await import(
+        "@commonfabric/utils/utf8"
+      );
+      const obj = {
+        ["\u{1F600}"]: 1,
+        b: 2,
+        ["﻿"]: 3,
+        a: 4,
+      } as unknown as FabricValue;
+      const wire = toWireFormat(obj) as Record<string, JsonWireValue>;
+      expect(Object.keys(wire)).toEqual([...utf8SortedKeysOf(obj as object)]);
+    });
   });
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The modern JSON encoder (`JsonEncodingContext`, used by `json-encoding-modern.ts`) now emits plain-object keys in UTF-8 byte order via `utf8SortedKeysOf()` — the same canonical key order used by `value-hash.ts`. This makes JSON encoding deterministic across implementations and across objects whose keys differ only in insertion order, and aligns the wire format with the hash byte format's existing key-sorting rule.
- Adds Section 10 ("Plain Object Key Ordering") to `docs/specs/space-model-formal-spec/3-json-encoding.md` to specify the new requirement, cross-referencing `2-hash-byte-format.md` Section 5 for the comparison itself.

## Test plan

- [x] `deno task test` in `packages/data-model` (1244 steps, all passing) — including 5 new tests in `test/json-encoding-context.test.ts` covering: bare-object sorting, sort-stability across insertion order, nested objects, supplementary-character (UTF-8 vs UTF-16) handling, and a cross-check that the order matches `utf8SortedKeysOf()` (the same function `value-hash.ts` uses).
- [x] `deno lint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This PR changes code that is only barely used when the unified JSON flag is off (as it is in `main`). As such, the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 495s

