### PR TITLE
Hash -0, NaN, and infinities instead of throwing

### DIFF
--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -97,20 +97,88 @@ describe("hashOf()", () => {
     expect(hashBytesOf(0)).toEqual(expected);
   });
 
-  it("-0 normalizes to +0 (same hash)", () => {
-    expect(hashBytesOf(-0)).toEqual(hashBytesOf(0));
+  it("-0 produces TAG_NUMBER + IEEE 754 negative-zero bit pattern", () => {
+    // 80 00 00 00 00 00 00 00
+    const expected = sha256([
+      0x23,
+      0x80,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+    ]);
+    expect(hashBytesOf(-0)).toEqual(expected);
   });
 
-  it("NaN throws", () => {
-    expect(() => hashBytesOf(NaN)).toThrow("non-finite");
+  it("-0 and +0 produce different hashes", () => {
+    expect(hex(hashBytesOf(-0))).not.toBe(hex(hashBytesOf(0)));
   });
 
-  it("Infinity throws", () => {
-    expect(() => hashBytesOf(Infinity)).toThrow("non-finite");
+  it("NaN produces TAG_NUMBER + canonical quiet NaN bytes", () => {
+    // 7F F8 00 00 00 00 00 00
+    const expected = sha256([
+      0x23,
+      0x7f,
+      0xf8,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+    ]);
+    expect(hashBytesOf(NaN)).toEqual(expected);
   });
 
-  it("-Infinity throws", () => {
-    expect(() => hashBytesOf(-Infinity)).toThrow("non-finite");
+  it("non-canonical NaN bit patterns hash to the canonical NaN", () => {
+    // Construct a NaN with a non-zero payload (still a valid quiet NaN) and
+    // confirm it canonicalizes. The hashed bytes must match the literal `NaN`.
+    const view = new DataView(new ArrayBuffer(8));
+    view.setBigUint64(0, 0x7ff8000000000001n, false);
+    const nonCanonicalNaN = view.getFloat64(0, false);
+    expect(Number.isNaN(nonCanonicalNaN)).toBe(true);
+    expect(hex(hashBytesOf(nonCanonicalNaN))).toBe(hex(hashBytesOf(NaN)));
+  });
+
+  it("Infinity produces TAG_NUMBER + IEEE 754 +Infinity bit pattern", () => {
+    // 7F F0 00 00 00 00 00 00
+    const expected = sha256([
+      0x23,
+      0x7f,
+      0xf0,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+    ]);
+    expect(hashBytesOf(Infinity)).toEqual(expected);
+  });
+
+  it("-Infinity produces TAG_NUMBER + IEEE 754 -Infinity bit pattern", () => {
+    // FF F0 00 00 00 00 00 00
+    const expected = sha256([
+      0x23,
+      0xff,
+      0xf0,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+    ]);
+    expect(hashBytesOf(-Infinity)).toEqual(expected);
+  });
+
+  it("NaN, +Infinity, and -Infinity produce distinct hashes", () => {
+    expect(hex(hashBytesOf(NaN))).not.toBe(hex(hashBytesOf(Infinity)));
+    expect(hex(hashBytesOf(NaN))).not.toBe(hex(hashBytesOf(-Infinity)));
+    expect(hex(hashBytesOf(Infinity))).not.toBe(hex(hashBytesOf(-Infinity)));
   });
 
   it("different numbers produce different hashes", () => {

--- a/packages/data-model/value-hash.ts
+++ b/packages/data-model/value-hash.ts
@@ -99,6 +99,21 @@ const f64View = new DataView(f64Buf);
 /** Byte-array "view" of `f64Buf`. */
 const f64Bytes = new Uint8Array(f64Buf);
 
+/**
+ * Canonical quiet-NaN payload (big-endian `7F F8 00 00 00 00 00 00`). All NaN
+ * bit patterns hash to this single representation.
+ */
+const CANONICAL_NAN_BYTES = new Uint8Array([
+  0x7f,
+  0xf8,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+]);
+
 /** LRU cache for string representations. */
 const stringRepCache = new LRUCache<string, Uint8Array>({
   capacity: 50_000,
@@ -167,15 +182,13 @@ function feedValue(hasher: IncrementalHasher, value: unknown): void {
       break;
 
     case "number":
-      if (!Number.isFinite(value)) {
-        throw new Error(
-          `hashOf: non-finite number not allowed: ${value}`,
-        );
-      }
       hasher.update(TAG_NUMBER_BYTES);
-      // Normalize -0 to +0.
-      f64View.setFloat64(0, value === 0 ? 0 : value, false); // big-endian
-      hasher.update(f64Bytes);
+      if (Number.isNaN(value)) {
+        hasher.update(CANONICAL_NAN_BYTES);
+      } else {
+        f64View.setFloat64(0, value, false); // big-endian
+        hasher.update(f64Bytes);
+      }
       break;
 
     case "string": {
@@ -390,6 +403,7 @@ const NULL_HASH = computeHash(null);
 const UNDEFINED_HASH = computeHash(undefined);
 const TRUE_HASH = computeHash(true);
 const FALSE_HASH = computeHash(false);
+const NEGATIVE_ZERO_HASH = computeHash(-0);
 
 /**
  * LRU cache for primitive value hashes. Primitives (strings, numbers,
@@ -409,6 +423,19 @@ const primitiveHashCache = new LRUCache<
  * Mutable objects are always recomputed.
  */
 const frozenObjectHashCache = new WeakMap<object, FabricHash>();
+
+/**
+ * Looks up the given primitive in the LRU cache, computing and storing on
+ * miss. Caller must filter out values that don't behave under `Map`'s
+ * SameValueZero keying (notably `-0`, which collides with `+0`).
+ */
+function cachedPrimitiveHash(value: string | number | bigint): FabricHash {
+  const cached = primitiveHashCache.get(value);
+  if (cached !== undefined) return cached;
+  const result = computeHash(value);
+  primitiveHashCache.put(value, result);
+  return result;
+}
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -432,14 +459,16 @@ function hashOfInternal(
       return value ? TRUE_HASH : FALSE_HASH;
 
     case "string":
+    case "bigint":
+      return cachedPrimitiveHash(value);
+
     case "number":
-    case "bigint": {
-      const cached = primitiveHashCache.get(value);
-      if (cached !== undefined) return cached;
-      const result = computeHash(value);
-      primitiveHashCache.put(value, result);
-      return result;
-    }
+      // `Map` keys via SameValueZero, which conflates `-0` with `+0`. Use the
+      // pre-computed hash for `-0` so it doesn't collide with (or pollute)
+      // the `+0` cache entry.
+      return Object.is(value, -0)
+        ? NEGATIVE_ZERO_HASH
+        : cachedPrimitiveHash(value);
 
     case "undefined":
       return UNDEFINED_HASH;


### PR DESCRIPTION
## Summary

- value-hash.ts now hashes -0, NaN, and ±Infinity instead of throwing. Byte form is unchanged: TAG_NUMBER plus the 8-byte big-endian IEEE 754 binary64 payload. -0 and ±Infinity ride through with their natural bit patterns; any NaN is canonicalized to the canonical quiet form (7F F8 00 00 00 00 00 00).
- The "number" case in hashOfInternal short-circuits -0 to a new pre-computed NEGATIVE_ZERO_HASH constant. This avoids the primitive LRU cache, which keys via SameValueZero and would otherwise conflate -0 with +0. "string" and "bigint" go through a new cachedPrimitiveHash() helper unchanged.

## Scope

This PR only changes the hasher. The fabric-value gating layer (fabric-value-modern.ts and fabric-value-legacy.ts) still rejects non-finite numbers and still normalizes -0, so the new behavior is only reachable from direct hashOf() callers today. Spec updates (1-fabric-values.md, 2-hash-byte-format.md) and gating-layer relaxation will follow in separate PRs.

## Test plan

- [x] Existing data-model test suite passes (42 files, 1247 steps).
- [x] Flipped value-hash.test.ts:
  - "-0 normalizes to +0" → "-0 produces 80 00 ..." plus "differs from +0 hash"
  - "NaN throws" → "NaN produces 7F F8 00 ..." plus a non-canonical-bit-pattern canonicalization test
  - "Infinity throws" / "-Infinity throws" → byte-format assertions for 7F F0 ... and FF F0 ...
  - Added "NaN, +Infinity, -Infinity produce distinct hashes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
