### PR TITLE
JSON-encode -0, NaN, and infinities via a SpecialNumber@1 type tag

### DIFF
--- a/packages/data-model/fabric-type-tags.ts
+++ b/packages/data-model/fabric-type-tags.ts
@@ -22,6 +22,7 @@ export const TAGS = Object.freeze(
 
     // -- Primitive type handlers --
     BigInt: "BigInt@1",
+    SpecialNumber: "SpecialNumber@1",
     Undefined: "Undefined@1",
 
     // -- Structural / meta tags (serialization format) --

--- a/packages/data-model/json-type-handlers.ts
+++ b/packages/data-model/json-type-handlers.ts
@@ -332,6 +332,81 @@ export const EpochDaysHandler: TypeHandler = {
 };
 
 /**
+ * Handler for the four "special" numeric values that JSON cannot represent
+ * faithfully: `-0`, `NaN`, `+Infinity`, and `-Infinity`. Wire format:
+ * `{ "/SpecialNumber@1": "<literal>" }`, where `<literal>` is one of `-0`,
+ * `NaN`, `+Infinity`, or `-Infinity`.
+ *
+ * String state (rather than a JSON number) is used because `JSON.stringify`
+ * emits `null` for `NaN`/`±Infinity` and drops the sign on `-0`, which would
+ * make a numeric-state form lossy through the JSON layer.
+ *
+ * Any NaN bit pattern serializes as the literal `"NaN"` and round-trips
+ * back to `Number.NaN`.
+ */
+export const SpecialNumberHandler: TypeHandler = {
+  tag: TAGS.SpecialNumber,
+
+  canSerialize(value: FabricValue): boolean {
+    if (typeof value !== "number") return false;
+    return Number.isNaN(value) ||
+      value === Infinity ||
+      value === -Infinity ||
+      Object.is(value, -0);
+  },
+
+  serialize(
+    value: FabricValue,
+    codec: TypeHandlerCodec,
+    _recurse: (v: FabricValue) => JsonWireValue,
+  ): JsonWireValue {
+    const num = value as number;
+    let state: string;
+    if (Number.isNaN(num)) {
+      state = "NaN";
+    } else if (num === Infinity) {
+      state = "+Infinity";
+    } else if (num === -Infinity) {
+      state = "-Infinity";
+    } else {
+      // The remaining canSerialize case is `Object.is(num, -0)`.
+      state = "-0";
+    }
+    return codec.wrapTag(TAGS.SpecialNumber, state);
+  },
+
+  deserialize(
+    state: JsonWireValue,
+    _runtime: ReconstructionContext,
+    _recurse: (v: JsonWireValue) => FabricValue,
+  ): FabricValue {
+    if (typeof state !== "string") {
+      return makeProblematic(
+        TAGS.SpecialNumber,
+        state,
+        `SpecialNumber: expected string state, got ${typeof state}`,
+      );
+    }
+    switch (state) {
+      case "-0":
+        return -0;
+      case "+Infinity":
+        return Infinity;
+      case "-Infinity":
+        return -Infinity;
+      case "NaN":
+        return NaN;
+      default:
+        return makeProblematic(
+          TAGS.SpecialNumber,
+          state,
+          `SpecialNumber: unknown literal ${JSON.stringify(state)}`,
+        );
+    }
+  },
+};
+
+/**
  * Handler for `FabricBytes`. Serializes to a flat base64url string
  * encoding the raw bytes. Wire format: `{ "/Bytes@1": "<base64>" }`.
  * `FabricBytes` is a direct member of `FabricValue` (via
@@ -450,6 +525,7 @@ export function createDefaultRegistry(): TypeHandlerRegistry {
   registry.register(FabricInstanceHandler);
   // Primitives that need tagged encoding (can't be expressed in JSON natively).
   registry.register(BigIntHandler);
+  registry.register(SpecialNumberHandler);
   registry.register(UndefinedHandler);
   return registry;
 }

--- a/packages/data-model/test/json-encoding-context.test.ts
+++ b/packages/data-model/test/json-encoding-context.test.ts
@@ -420,6 +420,121 @@ describe("JsonEncodingContext", () => {
   });
 
   // --------------------------------------------------------------------------
+  // SpecialNumber (-0, NaN, +/-Infinity)
+  // --------------------------------------------------------------------------
+
+  describe("SpecialNumber", () => {
+    it('serializes -0 to /SpecialNumber@1 with state "-0"', () => {
+      expect(toWireFormat(-0)).toEqual({ "/SpecialNumber@1": "-0" });
+    });
+
+    it('serializes NaN to /SpecialNumber@1 with state "NaN"', () => {
+      expect(toWireFormat(NaN)).toEqual({ "/SpecialNumber@1": "NaN" });
+    });
+
+    it('serializes +Infinity to /SpecialNumber@1 with state "+Infinity"', () => {
+      expect(toWireFormat(Infinity)).toEqual({
+        "/SpecialNumber@1": "+Infinity",
+      });
+    });
+
+    it('serializes -Infinity to /SpecialNumber@1 with state "-Infinity"', () => {
+      expect(toWireFormat(-Infinity)).toEqual({
+        "/SpecialNumber@1": "-Infinity",
+      });
+    });
+
+    it("does not intercept +0 (round-trips as a plain number)", () => {
+      expect(toWireFormat(0)).toBe(0);
+      expect(roundTrip(0)).toBe(0);
+    });
+
+    it("round-trips -0 (preserves sign of zero)", () => {
+      const result = roundTrip(-0);
+      expect(Object.is(result, -0)).toBe(true);
+    });
+
+    it("round-trips NaN", () => {
+      expect(Number.isNaN(roundTrip(NaN))).toBe(true);
+    });
+
+    it("round-trips +Infinity", () => {
+      expect(roundTrip(Infinity)).toBe(Infinity);
+    });
+
+    it("round-trips -Infinity", () => {
+      expect(roundTrip(-Infinity)).toBe(-Infinity);
+    });
+
+    it('any NaN bit pattern serializes as the literal "NaN"', () => {
+      const view = new DataView(new ArrayBuffer(8));
+      view.setBigUint64(0, 0x7ff8000000000001n, false);
+      const nonCanonicalNaN = view.getFloat64(0, false);
+      expect(Number.isNaN(nonCanonicalNaN)).toBe(true);
+      expect(toWireFormat(nonCanonicalNaN)).toEqual({
+        "/SpecialNumber@1": "NaN",
+      });
+    });
+
+    it("round-trips inside arrays", () => {
+      const arr = [1, NaN, -0, Infinity, -Infinity, 2] as FabricValue;
+      const result = roundTrip(arr) as number[];
+      expect(result[0]).toBe(1);
+      expect(Number.isNaN(result[1])).toBe(true);
+      expect(Object.is(result[2], -0)).toBe(true);
+      expect(result[3]).toBe(Infinity);
+      expect(result[4]).toBe(-Infinity);
+      expect(result[5]).toBe(2);
+    });
+
+    it("round-trips as object values", () => {
+      const obj = {
+        nz: -0,
+        nan: NaN,
+        pinf: Infinity,
+        ninf: -Infinity,
+      } as unknown as FabricValue;
+      const result = roundTrip(obj) as Record<string, number>;
+      expect(Object.is(result.nz, -0)).toBe(true);
+      expect(Number.isNaN(result.nan)).toBe(true);
+      expect(result.pinf).toBe(Infinity);
+      expect(result.ninf).toBe(-Infinity);
+    });
+
+    it("non-string state -> ProblematicValue (lenient)", () => {
+      const ctx = new JsonEncodingContext({ lenient: true });
+      const runtime: ReconstructionContext = {
+        getCell(_ref) {
+          throw new Error("getCell not implemented in test runtime");
+        },
+      };
+      const encoded = ENCODING_PREFIX +
+        JSON.stringify({ "/SpecialNumber@1": 0 });
+      const result = ctx.decode(encoded, runtime);
+      expect(result).toBeInstanceOf(ProblematicValue);
+      expect((result as unknown as ProblematicValue).typeTag).toBe(
+        "SpecialNumber@1",
+      );
+    });
+
+    it("unknown literal -> ProblematicValue (lenient)", () => {
+      const ctx = new JsonEncodingContext({ lenient: true });
+      const runtime: ReconstructionContext = {
+        getCell(_ref) {
+          throw new Error("getCell not implemented in test runtime");
+        },
+      };
+      const encoded = ENCODING_PREFIX +
+        JSON.stringify({ "/SpecialNumber@1": "Infinity" }); // missing leading +
+      const result = ctx.decode(encoded, runtime);
+      expect(result).toBeInstanceOf(ProblematicValue);
+      expect((result as unknown as ProblematicValue).typeTag).toBe(
+        "SpecialNumber@1",
+      );
+    });
+  });
+
+  // --------------------------------------------------------------------------
   // FabricEpochNsec
   // --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds a SpecialNumberHandler in json-type-handlers.ts with wire form `{ "/SpecialNumber@1": "<literal>" }`, where `<literal>` is one of the four strings `"-0"`, `"NaN"`, `"+Infinity"`, `"-Infinity"`. String state is used because JSON.stringify emits `null` for NaN/±Infinity and drops the sign on -0, which would make a numeric-state form lossy through the JSON layer.
- Any NaN bit pattern serializes as the literal `"NaN"` and round-trips back to Number.NaN. Plain `+0` continues to ride through as a JSON number (it's not a special case).
- Adds `TAGS.SpecialNumber` to the canonical tag list and registers the handler alongside the other primitive-shaped handlers (BigInt, Undefined).
- Decoder returns ProblematicValue on non-string state or unknown literal strings (e.g. `"Infinity"` without the leading `+`).

## Scope

This PR only changes the JSON encoder. The fabric-value gating layer (fabric-value-modern.ts / fabric-value-legacy.ts) still rejects non-finite numbers and still normalizes -0, so the new behavior is only reachable from direct `JsonEncodingContext.encode()` callers today — parallel scope to #3492 on the hasher side. Spec updates and gating-layer relaxation will follow in separate PRs.

## Test plan

- [x] `deno task test` in packages/data-model — 42 files, 1262 steps (15 new), all green, type-check clean.
- [x] New `describe("SpecialNumber", ...)` block covers:
  - Wire form for each of the four values
  - Round-trip for each (Object.is for -0, Number.isNaN for NaN, equality for ±Infinity)
  - +0 is *not* intercepted (still a plain JSON number)
  - Round-trip nested in arrays and as object values
  - Non-canonical NaN bit pattern serializes as `"NaN"`
  - Lenient mode: non-string state and unknown-literal state both yield ProblematicValue with typeTag `"SpecialNumber@1"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
