### PR TITLE
Add cf-harness image attachments

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -130,7 +130,7 @@
     "core-js/proposals/async-explicit-resource-management": "https://esm.sh/core-js@3.46.0/proposals/async-explicit-resource-management",
     "@commonfabric/ports": "./ports.json",
     "@astral/astral": "./packages/vendor-astral/mod.ts",
-    "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.8",
+    "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.8",
     "@noble/hashes": "npm:@noble/hashes@^2.2.0",
     "@std/assert": "jsr:@std/assert@^1",
     "@std/async": "jsr:@std/async@^1",

--- a/deno.lock
+++ b/deno.lock
@@ -1,11 +1,10 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@cliffy/command@^1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/command@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/flags@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/internal@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/table@1.0.0-rc.8": "1.0.0-rc.8",
-    "jsr:@cliffy/table@^1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cmd-johnson/oauth2-client@2": "2.0.0",
     "jsr:@db/sqlite@0.12": "0.12.0",
     "jsr:@deno-library/progress@^1.5.1": "1.5.1",
@@ -1880,7 +1879,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@cliffy/command@^1.0.0-rc.8",
+      "jsr:@cliffy/command@1.0.0-rc.8",
       "jsr:@std/assert@1",
       "jsr:@std/async@1",
       "jsr:@std/cli@1",
@@ -1904,7 +1903,7 @@
     "members": {
       "packages/cli": {
         "dependencies": [
-          "jsr:@cliffy/table@^1.0.0-rc.8"
+          "jsr:@cliffy/table@1.0.0-rc.8"
         ]
       },
       "packages/deno-web-test": {

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -154,6 +154,22 @@ deno task run -- \
   --print-transcript
 ```
 
+Initial prompt image attachments:
+
+```bash
+cd packages/cf-harness
+deno task run -- \
+  --workspace /path/to/workspace \
+  --gateway-auth-mode none \
+  --image captures/example.png \
+  --prompt "Describe the attached capture image and summarize useful next steps."
+```
+
+`--image` is repeatable and accepts `png`, `jpeg`, `gif`, and `webp` files
+inside the workspace. The transcript retains only image metadata (`hostPath`,
+media type, byte count, digest); base64 pixels are materialized only for the
+gateway request.
+
 Explicit skill preload:
 
 ```bash

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -166,9 +166,9 @@ deno task run -- \
 ```
 
 `--image` is repeatable and accepts `png`, `jpeg`, `gif`, and `webp` files
-inside the workspace. The transcript retains only image metadata (`hostPath`,
-media type, byte count, digest); base64 pixels are materialized only for the
-gateway request.
+inside the workspace. Relative image paths are resolved from `--workspace`. The
+transcript retains only image metadata (`hostPath`, media type, byte count,
+digest); base64 pixels are materialized only for the gateway request.
 
 Explicit skill preload:
 

--- a/packages/cf-harness/deno.json
+++ b/packages/cf-harness/deno.json
@@ -17,6 +17,7 @@
     "./gateway/openai-client": "./src/gateway/openai-client.ts",
     "./contracts/prompt-slot": "./src/contracts/prompt-slot.ts",
     "./contracts/cfc-invocation-context": "./src/contracts/cfc-invocation-context.ts",
+    "./contracts/image": "./src/contracts/image.ts",
     "./contracts/run-manifest": "./src/contracts/run-manifest.ts",
     "./contracts/observation": "./src/contracts/observation.ts",
     "./contracts/policy": "./src/contracts/policy.ts",

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -8,6 +8,11 @@ import {
   parseHarnessGatewayAuthMode,
 } from "./config.ts";
 import {
+  createHarnessImageAttachment,
+  parseImageAttachmentPaths,
+} from "./image-attachments.ts";
+import type { HarnessImageAttachment } from "./contracts/image.ts";
+import {
   readHarnessRunArtifacts,
   resolveHarnessRunPaths,
 } from "./artifacts.ts";
@@ -65,6 +70,7 @@ export interface CfHarnessCliConfig {
   streamEvents: boolean;
   promptSlotRole: PromptSlotRole;
   prompt?: string;
+  imageAttachments: readonly HarnessImageAttachment[];
   resumeRun?: string;
   systemPrompt?: string;
   skillsRoot?: string;
@@ -192,6 +198,7 @@ Options:
   --prompt-slot-role <role>     direct-command | context | quote (default: direct-command)
   --prompt <text>               Prompt text to run
   --prompt-file <path>          Read prompt text from a file
+  --image <path>                Attach an image file to the initial prompt (repeatable; png/jpeg/gif/webp)
   --resume-run <path>           Resume from a run root or run-state.json path
   --system-prompt <text>        Optional system prompt
   --skills-root <path>          Skill root containing <name>/SKILL.md
@@ -425,6 +432,7 @@ export const parseCfHarnessCliArgs = async (
       "prompt-slot-role",
       "prompt",
       "prompt-file",
+      "image",
       "system-prompt",
       "resume-run",
       "model",
@@ -446,7 +454,7 @@ export const parseCfHarnessCliArgs = async (
       "stream-events",
       "no-skill-catalog",
     ],
-    collect: ["allow-tool", "allow-subagent-profile", "skill"],
+    collect: ["allow-tool", "allow-subagent-profile", "skill", "image"],
     alias: {
       h: "help",
     },
@@ -533,6 +541,12 @@ export const parseCfHarnessCliArgs = async (
   if (resumeRun !== undefined && skillNames.length > 0) {
     throw new Error("--skill preloading is not supported with --resume-run");
   }
+  const imagePaths = parseImageAttachmentPaths(
+    args.image as string | readonly string[] | undefined,
+  );
+  if (resumeRun !== undefined && imagePaths.length > 0) {
+    throw new Error("--image is not supported with --resume-run");
+  }
   if (skillsRoot !== undefined) {
     await assertSkillsRootRealPathWithinWorkspace(workspace, skillsRoot);
   }
@@ -566,6 +580,15 @@ export const parseCfHarnessCliArgs = async (
   const gatewayAuthMode = parsedGatewayAuthMode ?? "bearer";
   const readTextFile = deps.readTextFile ?? Deno.readTextFile;
   const prompt = await resolvePrompt(args, cwd, readTextFile);
+  const imageAttachments = await Promise.all(
+    imagePaths.map((path) =>
+      createHarnessImageAttachment({
+        workspaceHostPath: workspace,
+        cwd,
+        path,
+      })
+    ),
+  );
   const env = deps.env ??
     {
       CF_HARNESS_API_KEY: Deno.env.get("CF_HARNESS_API_KEY"),
@@ -625,6 +648,7 @@ export const parseCfHarnessCliArgs = async (
     streamEvents: Boolean(args["stream-events"]),
     promptSlotRole: promptSlotRole ?? "direct-command",
     ...(prompt !== undefined ? { prompt } : {}),
+    imageAttachments,
     ...(resumeRun !== undefined ? { resumeRun } : {}),
     ...(typeof args["system-prompt"] === "string"
       ? { systemPrompt: args["system-prompt"] }
@@ -906,8 +930,12 @@ export const formatCfHarnessTranscriptEvent = (
   switch (message.role) {
     case "system":
       return undefined;
-    case "user":
-      return `user: ${message.content}\n`;
+    case "user": {
+      const imageCount = message.imageAttachments?.length ?? 0;
+      return imageCount > 0
+        ? `user: ${message.content}\nuser images: ${imageCount}\n`
+        : `user: ${message.content}\n`;
+    }
     case "assistant":
       if (message.toolCalls !== undefined && message.toolCalls.length > 0) {
         const tools = message.toolCalls.map((toolCall) => {
@@ -1176,6 +1204,7 @@ export const runCfHarnessCli = async (
       const contextMessages = await prepareSkillContextMessages(engine);
       result = await loop.runPrompt({
         prompt: parsed.prompt!,
+        imageAttachments: parsed.imageAttachments,
         systemPrompt: resolveCfHarnessCliSystemPrompt({
           ...parsed,
           fabricMountPath: parsed.fabricMount !== undefined

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -584,7 +584,7 @@ export const parseCfHarnessCliArgs = async (
     imagePaths.map((path) =>
       createHarnessImageAttachment({
         workspaceHostPath: workspace,
-        cwd,
+        cwd: workspace,
         path,
       })
     ),

--- a/packages/cf-harness/src/contracts/image.ts
+++ b/packages/cf-harness/src/contracts/image.ts
@@ -1,0 +1,15 @@
+export const HARNESS_IMAGE_ATTACHMENT_TYPE = "cf-harness.image-attachment";
+
+export type HarnessImageMediaType =
+  | "image/gif"
+  | "image/jpeg"
+  | "image/png"
+  | "image/webp";
+
+export interface HarnessImageAttachment {
+  type: typeof HARNESS_IMAGE_ATTACHMENT_TYPE;
+  hostPath: string;
+  mediaType: HarnessImageMediaType;
+  bytes: number;
+  digest: string;
+}

--- a/packages/cf-harness/src/contracts/transcript.ts
+++ b/packages/cf-harness/src/contracts/transcript.ts
@@ -1,4 +1,5 @@
 import type { ToolResultRef } from "./tool-result.ts";
+import type { HarnessImageAttachment } from "./image.ts";
 
 export interface HarnessToolCall {
   id: string;
@@ -17,6 +18,7 @@ export interface HarnessSystemTranscriptMessage {
 export interface HarnessUserTranscriptMessage {
   role: "user";
   content: string;
+  imageAttachments?: readonly HarnessImageAttachment[];
 }
 
 export interface HarnessAssistantTranscriptMessage {

--- a/packages/cf-harness/src/image-attachments.ts
+++ b/packages/cf-harness/src/image-attachments.ts
@@ -1,5 +1,5 @@
 import { encodeBase64 } from "@std/encoding/base64";
-import { extname, relative, resolve } from "@std/path";
+import { extname, isAbsolute, relative, resolve } from "@std/path";
 import {
   HARNESS_IMAGE_ATTACHMENT_TYPE,
   type HarnessImageAttachment,
@@ -14,6 +14,7 @@ const IMAGE_MEDIA_TYPES = new Set<HarnessImageMediaType>([
   "image/png",
   "image/webp",
 ]);
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^(?:[A-Za-z]:[\\/]|[\\/]{2})/;
 
 const sha256Digest = async (content: Uint8Array): Promise<string> => {
   const digestInput = new ArrayBuffer(content.byteLength);
@@ -102,16 +103,23 @@ const detectImageMediaType = (
   return mediaTypeFromExtension(path);
 };
 
+export const isRelativePathWithinWorkspace = (
+  relativePath: string,
+): boolean =>
+  relativePath === "" ||
+  !(
+    relativePath === ".." ||
+    relativePath.startsWith("../") ||
+    relativePath.startsWith("..\\") ||
+    isAbsolute(relativePath) ||
+    WINDOWS_ABSOLUTE_PATH_PATTERN.test(relativePath)
+  );
+
 const assertPathWithinWorkspace = (
   workspaceHostPath: string,
   hostPath: string,
 ): void => {
-  const relativePath = relative(workspaceHostPath, hostPath);
-  if (
-    relativePath === ".." ||
-    relativePath.startsWith("../") ||
-    relativePath.startsWith("..\\")
-  ) {
+  if (!isRelativePathWithinWorkspace(relative(workspaceHostPath, hostPath))) {
     throw new Error("--image paths must stay within the workspace");
   }
 };

--- a/packages/cf-harness/src/image-attachments.ts
+++ b/packages/cf-harness/src/image-attachments.ts
@@ -1,0 +1,199 @@
+import { encodeBase64 } from "@std/encoding/base64";
+import { extname, relative, resolve } from "@std/path";
+import {
+  HARNESS_IMAGE_ATTACHMENT_TYPE,
+  type HarnessImageAttachment,
+  type HarnessImageMediaType,
+} from "./contracts/image.ts";
+import type { OpenAIChatMessageContentPart } from "./gateway/openai-client.ts";
+
+const MAX_IMAGE_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+const IMAGE_MEDIA_TYPES = new Set<HarnessImageMediaType>([
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
+const sha256Digest = async (content: Uint8Array): Promise<string> => {
+  const digestInput = new ArrayBuffer(content.byteLength);
+  new Uint8Array(digestInput).set(content);
+  const digest = await crypto.subtle.digest("SHA-256", digestInput);
+  return `sha256:${
+    [...new Uint8Array(digest)].map((byte) =>
+      byte.toString(16).padStart(2, "0")
+    ).join("")
+  }`;
+};
+
+const mediaTypeFromExtension = (
+  path: string,
+): HarnessImageMediaType | undefined => {
+  switch (extname(path).toLowerCase()) {
+    case ".gif":
+      return "image/gif";
+    case ".jpeg":
+    case ".jpg":
+      return "image/jpeg";
+    case ".png":
+      return "image/png";
+    case ".webp":
+      return "image/webp";
+    default:
+      return undefined;
+  }
+};
+
+const detectImageMediaType = (
+  bytes: Uint8Array,
+  path: string,
+): HarnessImageMediaType | undefined => {
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  if (
+    bytes.length >= 6 &&
+    ((bytes[0] === 0x47 &&
+      bytes[1] === 0x49 &&
+      bytes[2] === 0x46 &&
+      bytes[3] === 0x38 &&
+      bytes[4] === 0x37 &&
+      bytes[5] === 0x61) ||
+      (bytes[0] === 0x47 &&
+        bytes[1] === 0x49 &&
+        bytes[2] === 0x46 &&
+        bytes[3] === 0x38 &&
+        bytes[4] === 0x39 &&
+        bytes[5] === 0x61))
+  ) {
+    return "image/gif";
+  }
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  return mediaTypeFromExtension(path);
+};
+
+const assertPathWithinWorkspace = (
+  workspaceHostPath: string,
+  hostPath: string,
+): void => {
+  const relativePath = relative(workspaceHostPath, hostPath);
+  if (
+    relativePath === ".." ||
+    relativePath.startsWith("../") ||
+    relativePath.startsWith("..\\")
+  ) {
+    throw new Error("--image paths must stay within the workspace");
+  }
+};
+
+export const parseImageAttachmentPaths = (
+  input: string | readonly string[] | undefined,
+): string[] => {
+  if (input === undefined) {
+    return [];
+  }
+  const values: readonly string[] = Array.isArray(input) ? input : [input];
+  if (values.length === 0) {
+    return [];
+  }
+  const paths = values.flatMap((value) =>
+    value.split(",").map((part) => part.trim()).filter((part) =>
+      part.length > 0
+    )
+  );
+  if (paths.length === 0) {
+    throw new Error("--image requires a non-empty path");
+  }
+  return paths;
+};
+
+export const createHarnessImageAttachment = async (
+  options: {
+    workspaceHostPath: string;
+    cwd: string;
+    path: string;
+  },
+): Promise<HarnessImageAttachment> => {
+  const workspaceHostPath = await Deno.realPath(options.workspaceHostPath);
+  const hostPath = await Deno.realPath(resolve(options.cwd, options.path));
+  assertPathWithinWorkspace(workspaceHostPath, hostPath);
+  const stat = await Deno.stat(hostPath);
+  if (!stat.isFile) {
+    throw new Error(`--image path is not a file: ${options.path}`);
+  }
+  const bytes = await Deno.readFile(hostPath);
+  if (bytes.byteLength === 0) {
+    throw new Error(`--image path is empty: ${options.path}`);
+  }
+  if (bytes.byteLength > MAX_IMAGE_ATTACHMENT_BYTES) {
+    throw new Error(
+      `--image path is too large (${bytes.byteLength} bytes, max ${MAX_IMAGE_ATTACHMENT_BYTES}): ${options.path}`,
+    );
+  }
+  const mediaType = detectImageMediaType(bytes, hostPath);
+  if (mediaType === undefined || !IMAGE_MEDIA_TYPES.has(mediaType)) {
+    throw new Error(
+      `--image path is not a supported image type: ${options.path}`,
+    );
+  }
+  return {
+    type: HARNESS_IMAGE_ATTACHMENT_TYPE,
+    hostPath,
+    mediaType,
+    bytes: bytes.byteLength,
+    digest: await sha256Digest(bytes),
+  };
+};
+
+export const materializeImageAttachmentContentPart = async (
+  attachment: HarnessImageAttachment,
+): Promise<OpenAIChatMessageContentPart> => {
+  const bytes = await Deno.readFile(attachment.hostPath);
+  if (bytes.byteLength !== attachment.bytes) {
+    throw new Error(
+      `image attachment changed after run start: ${attachment.hostPath}`,
+    );
+  }
+  const digest = await sha256Digest(bytes);
+  if (digest !== attachment.digest) {
+    throw new Error(
+      `image attachment digest changed after run start: ${attachment.hostPath}`,
+    );
+  }
+  return {
+    type: "image_url",
+    image_url: {
+      url: `data:${attachment.mediaType};base64,${encodeBase64(bytes)}`,
+    },
+  };
+};

--- a/packages/cf-harness/src/index.ts
+++ b/packages/cf-harness/src/index.ts
@@ -6,6 +6,7 @@ export * from "./subagent-return.ts";
 export * from "./artifacts.ts";
 export * from "./cli.ts";
 export * from "./gateway/openai-client.ts";
+export * from "./contracts/image.ts";
 export * from "./contracts/prompt-slot.ts";
 export * from "./contracts/cfc-invocation-context.ts";
 export * from "./contracts/cfc-policy-snapshot.ts";

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -19,11 +19,13 @@ import {
   type OpenAIChatMessageContent,
   OpenAICompatibleGatewayClient,
 } from "./gateway/openai-client.ts";
+import { materializeImageAttachmentContentPart } from "./image-attachments.ts";
 import {
   createObservationDenied as makeObservationDenied,
   createOpaqueHandle,
   type ObservationDenied,
 } from "./contracts/observation.ts";
+import type { HarnessImageAttachment } from "./contracts/image.ts";
 import type { PromptSlotBinding } from "./contracts/prompt-slot.ts";
 import {
   createHarnessCfcPolicySnapshot,
@@ -104,6 +106,7 @@ export interface RunHarnessPromptOptions {
   prompt: string;
   systemPrompt?: string;
   contextMessages?: readonly string[];
+  imageAttachments?: readonly HarnessImageAttachment[];
   maxModelTurns?: number;
   model?: string;
   promptSlotBinding?: PromptSlotBinding;
@@ -154,13 +157,30 @@ const normalizeTextContent = (content: OpenAIChatMessageContent): string => {
     .join("");
 };
 
-const toOpenAIChatMessage = (
+const toOpenAIChatMessage = async (
   message: HarnessTranscriptMessage,
-): OpenAIChatCompletionMessage => {
+): Promise<OpenAIChatCompletionMessage> => {
   switch (message.role) {
     case "system":
-    case "user":
       return { role: message.role, content: message.content };
+    case "user":
+      if (
+        message.imageAttachments === undefined ||
+        message.imageAttachments.length === 0
+      ) {
+        return { role: message.role, content: message.content };
+      }
+      return {
+        role: message.role,
+        content: [
+          ...(message.content.length > 0
+            ? [{ type: "text" as const, text: message.content }]
+            : []),
+          ...(await Promise.all(
+            message.imageAttachments.map(materializeImageAttachmentContentPart),
+          )),
+        ],
+      };
     case "assistant":
       return {
         role: "assistant",
@@ -1216,7 +1236,14 @@ export class CfHarnessPromptLoop {
         ...(options.contextMessages ?? []).map((
           content,
         ) => ({ role: "user", content } as const)),
-        { role: "user", content: options.prompt },
+        {
+          role: "user",
+          content: options.prompt,
+          ...(options.imageAttachments !== undefined &&
+              options.imageAttachments.length > 0
+            ? { imageAttachments: options.imageAttachments }
+            : {}),
+        },
       ],
       model: options.model,
       maxModelTurns: options.maxModelTurns,
@@ -1323,7 +1350,7 @@ export class CfHarnessPromptLoop {
       while (modelTurns < maxModelTurns) {
         modelTurns += 1;
         const response = await this.gatewayClient.createChatCompletionJson(
-          this.#buildChatCompletionRequest(model, transcript),
+          await this.#buildChatCompletionRequest(model, transcript),
           { onChatCompletionAttempt: recordGatewayAttempt },
         );
         const assistantMessage = createAssistantTranscriptMessage(response);
@@ -1399,13 +1426,13 @@ export class CfHarnessPromptLoop {
     throw turnLimitError;
   }
 
-  #buildChatCompletionRequest(
+  async #buildChatCompletionRequest(
     model: string,
     transcript: readonly HarnessTranscriptMessage[],
-  ): OpenAIChatCompletionRequest {
+  ): Promise<OpenAIChatCompletionRequest> {
     return {
       model,
-      messages: transcript.map(toOpenAIChatMessage),
+      messages: await Promise.all(transcript.map(toOpenAIChatMessage)),
       tools: toOpenAITools(this.#allowedToolIds),
       tool_choice: "auto",
     };

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -76,6 +76,7 @@ Deno.test("parseCfHarnessCliArgs resolves defaults from cwd and positional promp
 
 Deno.test("parseCfHarnessCliArgs resolves image attachments within the workspace", async () => {
   const workspace = await Deno.makeTempDir();
+  const launcherCwd = await Deno.makeTempDir();
   await Deno.writeFile(join(workspace, "capture.png"), ONE_PIXEL_PNG);
 
   const parsed = await parseCfHarnessCliArgs(
@@ -88,7 +89,7 @@ Deno.test("parseCfHarnessCliArgs resolves image attachments within the workspace
       "Describe the image",
     ],
     {
-      cwd: workspace,
+      cwd: launcherCwd,
       env: {},
     },
   );

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertRejects } from "@std/assert";
+import { decodeBase64 } from "@std/encoding/base64";
 import { join } from "@std/path";
 import {
   buildCfHarnessBaseSystemPrompt,
@@ -22,6 +23,10 @@ import type {
   RunHarnessPromptOptions,
   RunHarnessTranscriptOptions,
 } from "../src/prompt-loop.ts";
+
+const ONE_PIXEL_PNG = decodeBase64(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p94AAAAASUVORK5CYII=",
+);
 
 const createIoBuffers = (): {
   io: CfHarnessCliIO;
@@ -66,6 +71,123 @@ Deno.test("parseCfHarnessCliArgs resolves defaults from cwd and positional promp
   assertEquals(parsed.maxModelTurns, 8);
   assertEquals(parsed.printTranscript, false);
   assertEquals(parsed.sandboxImage, undefined);
+  assertEquals(parsed.imageAttachments, []);
+});
+
+Deno.test("parseCfHarnessCliArgs resolves image attachments within the workspace", async () => {
+  const workspace = await Deno.makeTempDir();
+  await Deno.writeFile(join(workspace, "capture.png"), ONE_PIXEL_PNG);
+
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--workspace",
+      workspace,
+      "--image",
+      "capture.png",
+      "--prompt",
+      "Describe the image",
+    ],
+    {
+      cwd: workspace,
+      env: {},
+    },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.imageAttachments.length, 1);
+  assertEquals(
+    parsed.imageAttachments[0].hostPath,
+    await Deno.realPath(join(workspace, "capture.png")),
+  );
+  assertEquals(parsed.imageAttachments[0].mediaType, "image/png");
+  assertEquals(parsed.imageAttachments[0].bytes, ONE_PIXEL_PNG.byteLength);
+  assertEquals(
+    parsed.imageAttachments[0].digest.startsWith("sha256:"),
+    true,
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs rejects image attachments outside the workspace", async () => {
+  const workspace = await Deno.makeTempDir();
+  const outside = await Deno.makeTempDir();
+  const outsideImage = join(outside, "capture.png");
+  await Deno.writeFile(outsideImage, ONE_PIXEL_PNG);
+
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--workspace",
+          workspace,
+          "--image",
+          outsideImage,
+          "--prompt",
+          "Describe the image",
+        ],
+        {
+          cwd: workspace,
+          env: {},
+        },
+      ),
+    Error,
+    "--image paths must stay within the workspace",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs rejects image symlinks that resolve outside the workspace", async () => {
+  const workspace = await Deno.makeTempDir();
+  const outside = await Deno.makeTempDir();
+  const outsideImage = join(outside, "capture.png");
+  const linkedImage = join(workspace, "linked.png");
+  await Deno.writeFile(outsideImage, ONE_PIXEL_PNG);
+  await Deno.symlink(outsideImage, linkedImage);
+
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--workspace",
+          workspace,
+          "--image",
+          linkedImage,
+          "--prompt",
+          "Describe the image",
+        ],
+        {
+          cwd: workspace,
+          env: {},
+        },
+      ),
+    Error,
+    "--image paths must stay within the workspace",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs rejects image attachments while resuming", async () => {
+  const workspace = await Deno.makeTempDir();
+  await Deno.writeFile(join(workspace, "capture.png"), ONE_PIXEL_PNG);
+
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--workspace",
+          workspace,
+          "--resume-run",
+          "run-state.json",
+          "--image",
+          "capture.png",
+        ],
+        {
+          cwd: workspace,
+          env: {},
+        },
+      ),
+    Error,
+    "--image is not supported with --resume-run",
+  );
 });
 
 Deno.test("parseCfHarnessCliArgs supports prompt files and mode overrides", async () => {
@@ -954,6 +1076,68 @@ Deno.test("runCfHarnessCli executes the prompt loop and prints result metadata",
     ],
   );
   assertEquals(stderr, []);
+});
+
+Deno.test("runCfHarnessCli passes image attachments to the prompt loop", async () => {
+  const workspace = await Deno.makeTempDir();
+  await Deno.writeFile(join(workspace, "capture.png"), ONE_PIXEL_PNG);
+  const { io, stderr } = createIoBuffers();
+  let runPromptOptions: RunHarnessPromptOptions | undefined;
+  const exitCode = await runCfHarnessCli(
+    [
+      "--workspace",
+      workspace,
+      "--image",
+      "capture.png",
+      "--prompt",
+      "Describe the image",
+    ],
+    {
+      io,
+      cwd: workspace,
+      env: { CF_HARNESS_API_KEY: "test-key" },
+      createPromptLoop: () => ({
+        runPrompt: (options) => {
+          runPromptOptions = options;
+          return Promise.resolve(
+            ({
+              model: "gpt-5.4",
+              finalAssistantText: "Image described.",
+              transcript: [
+                {
+                  role: "user",
+                  content: "Describe the image",
+                  imageAttachments: options.imageAttachments,
+                },
+                { role: "assistant", content: "Image described." },
+              ],
+              modelTurns: 1,
+              runState: {
+                runId: "run-cli-image",
+                status: "completed",
+                createdAt: "2026-05-05T22:00:00.000Z",
+                updatedAt: "2026-05-05T22:00:01.000Z",
+                cfcEnforcementMode: "disabled",
+                currentDir: "/workspace",
+                policyEvents: [],
+                toolOutputs: [],
+              },
+            }) satisfies HarnessPromptLoopResult,
+          );
+        },
+        runTranscript: () =>
+          Promise.reject(new Error("unexpected resume path")),
+      }),
+    },
+  );
+
+  assertEquals(exitCode, 0);
+  assertEquals(stderr, []);
+  assertEquals(runPromptOptions?.imageAttachments?.length, 1);
+  assertEquals(
+    runPromptOptions?.imageAttachments?.[0].hostPath,
+    await Deno.realPath(join(workspace, "capture.png")),
+  );
 });
 
 Deno.test("runCfHarnessCli passes tool and subagent profile allowlists", async () => {

--- a/packages/cf-harness/test/image-attachments.test.ts
+++ b/packages/cf-harness/test/image-attachments.test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from "@std/assert";
+import { isRelativePathWithinWorkspace } from "../src/image-attachments.ts";
+
+Deno.test("isRelativePathWithinWorkspace rejects escaped and absolute relative results", () => {
+  const cases: Array<[string, boolean]> = [
+    ["", true],
+    ["capture.png", true],
+    ["captures/example.png", true],
+    ["..capture.png", true],
+    ["..", false],
+    ["../capture.png", false],
+    ["..\\capture.png", false],
+    ["/tmp/capture.png", false],
+    ["C:\\captures\\example.png", false],
+    ["D:/captures/example.png", false],
+    ["\\\\server\\share\\capture.png", false],
+  ];
+
+  for (const [relativePath, expected] of cases) {
+    assertEquals(isRelativePathWithinWorkspace(relativePath), expected);
+  }
+});

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -1,10 +1,13 @@
 import { assert, assertEquals, assertRejects } from "@std/assert";
 import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
+import { decodeBase64 } from "@std/encoding/base64";
+import { join } from "@std/path";
 import { normalize } from "@std/path/posix";
 import type { HarnessArtifactStore } from "../src/artifacts.ts";
 import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
+import { createHarnessImageAttachment } from "../src/image-attachments.ts";
 import {
   CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
   type PromptSlotBinding,
@@ -33,6 +36,10 @@ const directPromptSlotBinding: PromptSlotBinding = {
   subject: "direct-test",
   eventId: "event-direct",
 };
+
+const ONE_PIXEL_PNG = decodeBase64(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p94AAAAASUVORK5CYII=",
+);
 
 const contextPromptSlotBinding: PromptSlotBinding = {
   type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
@@ -407,6 +414,64 @@ Deno.test("CfHarnessPromptLoop inserts context messages before the user prompt",
   ]);
   assertEquals(request?.messages[1].content, "Configured skills context.");
   assertEquals(request?.messages[2].content, "Do the task.");
+});
+
+Deno.test("CfHarnessPromptLoop materializes image attachments for gateway requests only", async () => {
+  const workspace = await Deno.makeTempDir();
+  const imagePath = join(workspace, "capture.png");
+  await Deno.writeFile(imagePath, ONE_PIXEL_PNG);
+  const imageAttachment = await createHarnessImageAttachment({
+    workspaceHostPath: workspace,
+    cwd: workspace,
+    path: "capture.png",
+  });
+  let request: OpenAIChatCompletionRequest | undefined;
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-image",
+      model: "gpt-5.4",
+    }),
+    fetchFn: (_input, init) => {
+      request = JSON.parse(String(init?.body)) as OpenAIChatCompletionRequest;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "The image is visible.",
+              },
+            }],
+          }),
+          { status: 200 },
+        ),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Describe the image.",
+    imageAttachments: [imageAttachment],
+    model: "gpt-5.4",
+  });
+
+  const content = request?.messages[0].content;
+  assert(Array.isArray(content));
+  assertEquals(content[0], { type: "text", text: "Describe the image." });
+  assertEquals((content[1] as Record<string, unknown>).type, "image_url");
+  assert(
+    ((content[1] as { image_url?: { url?: string } }).image_url?.url ?? "")
+      .startsWith("data:image/png;base64,"),
+  );
+  assertEquals(result.transcript[0], {
+    role: "user",
+    content: "Describe the image.",
+    imageAttachments: [imageAttachment],
+  });
+  assertEquals(JSON.stringify(result.transcript).includes("iVBOR"), false);
 });
 
 Deno.test("CfHarnessPromptLoop surfaces recoverable file-tool failures to the model", async () => {

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -12,6 +12,6 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@cliffy/table": "jsr:@cliffy/table@^1.0.0-rc.8"
+    "@cliffy/table": "jsr:@cliffy/table@1.0.0-rc.8"
   }
 }


### PR DESCRIPTION
## Summary
- add cf-harness image attachment metadata and repeatable `--image` CLI parsing for png/jpeg/gif/webp inputs
- materialize image bytes as OpenAI-compatible `image_url` data URLs only while building gateway requests
- keep transcripts/run-state to image metadata and add workspace/realpath/symlink bounds plus digest verification

## Tests
- `deno task test` in `packages/cf-harness` (`248 passed`)