### PR TITLE
Bifurcate cell-storage special-number tests across modernDataModel

### DIFF
--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -307,49 +307,6 @@ describe("Cell", () => {
     expect(result?.arr).toBe("custom-array-value");
   });
 
-  it("should convert -0 to 0 during set", () => {
-    const c = runtime.getCell<unknown>(
-      space,
-      "should convert -0 to 0 during set",
-      undefined,
-      tx,
-    );
-    c.set({ value: -0 });
-
-    const result = c.get() as { value: number } | undefined;
-    expect(result?.value).toBe(0);
-    // Verify it's actually 0, not -0
-    expect(Object.is(result?.value, 0)).toBe(true);
-    expect(Object.is(result?.value, -0)).toBe(false);
-  });
-
-  it("should throw when setting NaN", () => {
-    const c = runtime.getCell<unknown>(
-      space,
-      "should throw when setting NaN",
-      undefined,
-      tx,
-    );
-    expect(() => c.set({ value: NaN })).toThrow(
-      "Cannot store non-finite number",
-    );
-  });
-
-  it("should throw when setting Infinity", () => {
-    const c = runtime.getCell<unknown>(
-      space,
-      "should throw when setting Infinity",
-      undefined,
-      tx,
-    );
-    expect(() => c.set({ value: Infinity })).toThrow(
-      "Cannot store non-finite number",
-    );
-    expect(() => c.set({ value: -Infinity })).toThrow(
-      "Cannot store non-finite number",
-    );
-  });
-
   it("should throw when setting Symbol", () => {
     const c = runtime.getCell<unknown>(
       space,
@@ -1234,6 +1191,128 @@ for (const unifiedJsonEncoding of [false, true]) {
           expect(Object.prototype.hasOwnProperty.call(value, "/")).toBe(true);
         },
       );
+    },
+  );
+}
+
+// Cell-storage behavior for the four "weird" numeric values: `-0`, `NaN`,
+// `+Infinity`, `-Infinity`. The two data-model paths diverge sharply here:
+//
+// * Legacy (`modernDataModel = false`): `-0` is normalized to `0` on set, and
+//   any non-finite number throws `"Cannot store non-finite number"` at the
+//   fabric-value boundary inside `cell.set()`.
+// * Modern  (`modernDataModel = true`): all four values flow through end-to-end
+//   (PRs #3492/#3493/#3495). `-0` keeps its sign; `NaN` and `±Infinity` are
+//   stored faithfully and read back as themselves.
+//
+// These tests pin both behaviors so a future flag-default change can't quietly
+// regress either path.
+for (const modernDataModel of [false, true]) {
+  describe(
+    `Cell special-number storage with \`modernDataModel = ${modernDataModel}\``,
+    () => {
+      let runtime: Runtime;
+      let storageManager: ReturnType<typeof StorageManager.emulate>;
+      let tx: IExtendedStorageTransaction;
+
+      beforeEach(() => {
+        storageManager = StorageManager.emulate({ as: signer });
+        runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager,
+          experimental: { modernDataModel },
+        });
+        tx = runtime.edit();
+      });
+
+      afterEach(async () => {
+        await tx.commit();
+        await runtime?.dispose();
+        await storageManager?.close();
+      });
+
+      if (modernDataModel) {
+        it("preserves the sign of -0 on set", () => {
+          const c = runtime.getCell<unknown>(
+            space,
+            "modern: preserve -0",
+            undefined,
+            tx,
+          );
+          c.set({ value: -0 });
+          const result = c.get() as { value: number } | undefined;
+          expect(Object.is(result?.value, -0)).toBe(true);
+          expect(Object.is(result?.value, 0)).toBe(false);
+        });
+
+        it("stores NaN", () => {
+          const c = runtime.getCell<unknown>(
+            space,
+            "modern: store NaN",
+            undefined,
+            tx,
+          );
+          c.set({ value: NaN });
+          const result = c.get() as { value: number } | undefined;
+          expect(Number.isNaN(result?.value)).toBe(true);
+        });
+
+        it("stores +Infinity and -Infinity", () => {
+          const c = runtime.getCell<unknown>(
+            space,
+            "modern: store infinities",
+            undefined,
+            tx,
+          );
+          c.set({ pos: Infinity, neg: -Infinity });
+          const result = c.get() as
+            | { pos: number; neg: number }
+            | undefined;
+          expect(result?.pos).toBe(Infinity);
+          expect(result?.neg).toBe(-Infinity);
+        });
+      } else {
+        it("converts -0 to 0 on set", () => {
+          const c = runtime.getCell<unknown>(
+            space,
+            "legacy: -0 to 0",
+            undefined,
+            tx,
+          );
+          c.set({ value: -0 });
+          const result = c.get() as { value: number } | undefined;
+          expect(result?.value).toBe(0);
+          expect(Object.is(result?.value, 0)).toBe(true);
+          expect(Object.is(result?.value, -0)).toBe(false);
+        });
+
+        it("throws when setting NaN", () => {
+          const c = runtime.getCell<unknown>(
+            space,
+            "legacy: throw on NaN",
+            undefined,
+            tx,
+          );
+          expect(() => c.set({ value: NaN })).toThrow(
+            "Cannot store non-finite number",
+          );
+        });
+
+        it("throws when setting +Infinity or -Infinity", () => {
+          const c = runtime.getCell<unknown>(
+            space,
+            "legacy: throw on infinities",
+            undefined,
+            tx,
+          );
+          expect(() => c.set({ value: Infinity })).toThrow(
+            "Cannot store non-finite number",
+          );
+          expect(() => c.set({ value: -Infinity })).toThrow(
+            "Cannot store non-finite number",
+          );
+        });
+      }
     },
   );
 }


### PR DESCRIPTION
## Summary

Three cell-storage tests in `packages/runner/test/cell-core.test.ts` (`-0` is converted to `0` on set, `NaN` throws, `±Infinity` throws) were pegged to the default `modernDataModel = false` flag state — and so weren't covering the modern path that #3492 / #3493 / #3495 reshaped to embrace `-0`, `NaN`, `+Infinity`, and `-Infinity` end-to-end. The PR body for #3495 noted this gap explicitly.

This PR closes the gap by replacing the three flag-OFF-only tests with a parameterized `for (const modernDataModel of [false, true])` describe block that asserts both behaviors:

- **legacy** (`modernDataModel = false`): `-0` normalizes to `0` on set, non-finite numbers throw `"Cannot store non-finite number"`.
- **modern** (`modernDataModel = true`): `-0` keeps its sign; `NaN` and `±Infinity` round-trip through `cell.set` / `cell.get`.

Mirrors the parameterized-describe pattern already in this file (the `unifiedJsonEncoding` block at the bottom) and in the data-model tests (`fabric-value.test.ts` "special numbers (modern path)", `clone-if-necessary.test.ts` legacy/modern split).

## Scope

Test-only. No production-code changes. This is a no-op on `main` semantically — every assertion that used to run still runs (in the legacy branch of the new block), plus three new modern-path assertions.

The Symbol test (line ~310) is unchanged: its `"Cannot store symbol"` behavior is identical across both flag states. The BigInt test is also unchanged: it's already explicit about `modernDataModel: false`, with an in-source note that the flag-ON case is deferred pending storage-layer JSON support for BigInt.

## Test plan

- [x] `deno test test/cell-core.test.ts` from `packages/runner`: 7 top-level groups / 64 steps, all green.
- [x] Filtered run of the new block (`--filter "Cell special-number storage"`): 2 groups × 3 steps each, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
