### PR TITLE
fix(pieces): Sync default pattern recreation

### DIFF
--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -209,6 +209,7 @@ export class PiecesController<T = unknown> {
     // We need to stop it to prevent resource leaks or duplicate behavior from the old pattern
     // Access the space cell directly to get the pattern reference without running it
     const spaceCellContents = this.#manager.getSpaceCellContents();
+    await spaceCellContents.sync();
     const defaultPatternRef = spaceCellContents.key("defaultPattern").get();
     if (defaultPatternRef) {
       // Stop the existing pattern (no-op if not running)
@@ -267,7 +268,7 @@ export class PiecesController<T = unknown> {
     // Create new piece cell
     let pieceCell: Cell<NameSchema>;
 
-    await this.#manager.runtime.editWithRetry((tx) => {
+    const { error } = await this.#manager.runtime.editWithRetry((tx) => {
       // Create piece cell within this transaction
       pieceCell = this.#manager.runtime.getCell<NameSchema>(
         this.#manager.getSpace(),
@@ -280,10 +281,16 @@ export class PiecesController<T = unknown> {
       this.#manager.runtime.run(tx, pattern, {}, pieceCell);
 
       // Link as default pattern within same transaction
-      const spaceCellWithTx = this.#manager.getSpaceCellContents().withTx(tx);
+      const spaceCellWithTx = spaceCellContents.withTx(tx);
       const defaultPatternCell = spaceCellWithTx.key("defaultPattern");
       defaultPatternCell.set(pieceCell.withTx(tx));
     });
+    if (error) {
+      throw new Error(
+        `Updating the default pattern failed because storage returned ${error.name}: ${error.message}`,
+        { cause: error },
+      );
+    }
 
     // Fetch the final result
     const finalPattern = await this.#manager.getDefaultPattern(false);

--- a/packages/piece/test/ensure-default-pattern.test.ts
+++ b/packages/piece/test/ensure-default-pattern.test.ts
@@ -275,8 +275,10 @@ describe("PiecesController.recreateDefaultPattern", () => {
       message: "commit rejected for test",
       reason: new Error("storage reason"),
     };
-    runtime.editWithRetry = (() => Promise.resolve({ error: storageError })) as
-      typeof runtime.editWithRetry;
+    runtime.editWithRetry = (() =>
+      Promise.resolve({
+        error: storageError,
+      })) as typeof runtime.editWithRetry;
 
     try {
       await controller.recreateDefaultPattern({

--- a/packages/piece/test/ensure-default-pattern.test.ts
+++ b/packages/piece/test/ensure-default-pattern.test.ts
@@ -1,12 +1,36 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Runtime } from "@commonfabric/runner";
+import type { RuntimeProgram } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createSession, Identity } from "@commonfabric/identity";
 import { PieceManager } from "../src/manager.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
 
 const signer = await Identity.fromPassphrase("test default pattern");
+
+const defaultPatternProgram: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        "/// <cf-disable-transform />",
+        "import { handler, pattern } from 'commonfabric';",
+        "const addPiece = handler<{ piece: unknown }, { allPieces: unknown[] }>(",
+        "  ({ piece }, { allPieces }) => {",
+        "    allPieces.push(piece);",
+        "  },",
+        "  { proxy: true },",
+        ");",
+        "export default pattern<{ allPieces: unknown[] }>(({ allPieces }) => ({",
+        "  allPieces,",
+        "  addPiece: addPiece({ allPieces }),",
+        "}));",
+      ].join("\n"),
+    },
+  ],
+};
 
 describe("PiecesController.ensureDefaultPattern", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
@@ -243,5 +267,31 @@ describe("PiecesController.recreateDefaultPattern", () => {
 
     // Should still attempt to create (and fail due to fake server)
     await expect(controller.recreateDefaultPattern()).rejects.toThrow();
+  });
+
+  it("should explain storage transaction errors when updating defaultPattern fails", async () => {
+    const storageError = {
+      name: "StorageTransactionAborted" as const,
+      message: "commit rejected for test",
+      reason: new Error("storage reason"),
+    };
+    runtime.editWithRetry = (() => Promise.resolve({ error: storageError })) as
+      typeof runtime.editWithRetry;
+
+    try {
+      await controller.recreateDefaultPattern({
+        customProgram: defaultPatternProgram,
+      });
+      throw new Error("Expected recreateDefaultPattern to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain(
+        "Updating the default pattern failed",
+      );
+      expect((error as Error).message).toContain(
+        "StorageTransactionAborted",
+      );
+      expect((error as Error).cause).toBe(storageError);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Sync the space cell before `recreateDefaultPattern()` reads or writes the `defaultPattern` link.
- Reuse the synced space cell handle inside the creation transaction.
- Wrap `editWithRetry` storage failures with a default-pattern update error message while preserving the returned storage error as `cause`.
- Add regression coverage for the storage-error wrapper path.

## Why

Default pattern recreation reads the existing `defaultPattern` link, unlinks it, then creates and links a replacement. The space cell needs to be current before those operations, and storage commit failures should explain that updating the default pattern failed while preserving the underlying storage error for debugging.

## Validation

- `deno task --cwd packages/piece test --filter recreateDefaultPattern`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the space cell before default pattern recreation and add clear error wrapping for storage failures. Prevents stale `defaultPattern` links and improves debuggability.

- **Bug Fixes**
  - Sync the space cell before reading/unlinking/linking `defaultPattern`, and reuse it inside the transaction to avoid stale reads.
  - Use the `editWithRetry` result to throw a clear “Updating the default pattern failed …” error and preserve the original error as `cause`.
  - Add a regression test that verifies the error message includes the storage error name and keeps the original error as `cause`.

<sup>Written for commit 614747fbb0a1bb7b3f3fc14fb770aa8140a97ad5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

