### PR TITLE
docs(spec): sync data-model specs for unifiedJsonEncoding default-on, SpecialNumber@1, and -0/NaN/Infinity acceptance

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -83,7 +83,7 @@ type FabricValue =
   // (a) Primitives
   | null
   | boolean
-  | number    // finite only; `NaN` and `Infinity` rejected
+  | number    // any number, including `-0`, `NaN`, and `±Infinity`; see Section 1.3
   | string
   | undefined // first-class fabric value; requires tagged representation in formats lacking native `undefined`
   | bigint    // large integers; rides through without wrapping (like `undefined`)
@@ -170,7 +170,7 @@ member of `FabricValue`.
 |------|-------------|-------|
 | `null` | None | The null value |
 | `boolean` | None | `true` or `false` |
-| `number` | Must be finite | `-0` normalized to `0`; `NaN`/`Infinity` rejected |
+| `number` | None | Any IEEE 754 binary64 value, including `-0`, `NaN`, and `±Infinity`. Conversion-gate behavior is flag-bifurcated; see Section 4.9 and the callout below. |
 | `string` | None | Unicode text |
 | `undefined` | None | First-class fabric value; see note below |
 | `bigint` | None | Large integers; JSON-encoded as base64url (RFC 4648, Section 5) of two's complement big-endian bytes (Section 3 of `3-json-encoding.md`) |
@@ -186,19 +186,27 @@ member of `FabricValue`.
 > serializer faithfully records `undefined` and the application layer interprets
 > the result.
 
-> **`-0` normalization:** Negative zero (`-0`) is normalized to positive zero
-> (`0`) during fabric-value conversion (i.e., `shallowFabricFromNativeValue()`),
-> before the value reaches a serialization boundary. This matches
-> `JSON.stringify` behavior and ensures that `0` and `-0` produce the same
-> serialized form and hash. In the current codebase, this
-> normalization happens in `packages/data-model/fabric-value-modern.ts` at the
-> `shallowFabricFromNativeValueModern()` call site.
-
-> **Future: `-0` and non-finite numbers.** The current design normalizes `-0`
-> and rejects `NaN`/`Infinity`/`-Infinity`. Because the serialization system
-> uses typed tags (Section 5), a future version could represent these values
-> with full fidelity via dedicated type tags, without ambiguity. This option is
-> preserved by the architecture but not currently needed.
+> **`-0`, `NaN`, and `±Infinity`.** The hashing layer (Section 6.4 and
+> `2-hash-byte-format.md` Section 4.3) and the JSON wire format (Section 5;
+> `3-json-encoding.md` Section 3, `SpecialNumber@1`) both faithfully
+> represent `-0`, `NaN`, `+Infinity`, and `-Infinity` as first-class
+> values, distinct from `0` and from each other. Whether such values reach
+> those layers is gated by the `modernDataModel` conversion path
+> (Section 4.9):
+>
+> - **Modern path (`modernDataModel: true`):** All four values pass
+>   through `shallowFabricFromNativeValueModern()` and
+>   `fabricFromNativeValueModern()` unchanged — `-0` retains its sign
+>   (`Object.is(result, -0) === true`), and `NaN` / `±Infinity`
+>   round-trip through hashing and JSON encoding via the byte-level
+>   forms in `2-hash-byte-format.md` Section 4.3 and the
+>   `SpecialNumber@1` envelope in `3-json-encoding.md` Section 3.
+> - **Legacy path (`modernDataModel: false`):**
+>   `fabricFromNativeValueLegacy()` normalizes `-0` to `+0` and rejects
+>   `NaN` / `±Infinity` with a thrown error. Code paths that bypass the
+>   conversion gate (direct callers of the hasher or the JSON encoder)
+>   see the modern-path behavior regardless of the flag, since the
+>   lower-layer specs describe their own behavior unconditionally.
 
 ### 1.4 Native Object Wrapper Classes
 
@@ -1661,16 +1669,17 @@ The dispatch is configured by `setJsonEncodingConfig(enabled)` /
 `resetJsonEncodingConfig()`, called from the `Runtime` constructor and
 `Runtime.dispose()` respectively:
 
-- **Flag OFF (default):** `jsonFromValue` wraps `JSON.stringify` with a
+- **Flag ON (current default):** `jsonFromValue` routes through
+  `JsonEncodingContext.encode()`, `valueFromJson` routes through
+  `JsonEncodingContext.decode()`. Modern types are preserved across the
+  storage boundary.
+- **Flag OFF (legacy path):** `jsonFromValue` wraps `JSON.stringify` with a
   defensive guard that throws if the result is `undefined` — this can happen
   when the input is `undefined` (a first-class `FabricValue` per Section
   1.3), since `JSON.stringify(undefined)` returns `undefined` rather than a
   string. The guard ensures `jsonFromValue` always returns a `string` as its
-  type signature promises. `valueFromJson` = `JSON.parse`. This is the legacy
-  path — the storage layer sees plain JSON values with no tagged types.
-- **Flag ON:** `jsonFromValue` routes through `JsonEncodingContext.encode()`,
-  `valueFromJson` routes through `JsonEncodingContext.decode()`. Modern types
-  are preserved across the storage boundary.
+  type signature promises. `valueFromJson` = `JSON.parse`. The storage layer
+  sees plain JSON values with no tagged types.
 
 The dispatch module creates a single stateless `JsonEncodingContext` instance at
 module load time and reuses it for all encode/decode operations.
@@ -1816,18 +1825,18 @@ organized into four categories by high nibble:
 
 **Primitive tags (`0x2N`)** — leaf value types:
 
-| Tag               | Hex    | Decimal | Used for                        |
-|:------------------|:-------|:--------|:--------------------------------|
-| `TAG_NULL`        | `0x20` | 32      | `null`                          |
-| `TAG_UNDEFINED`   | `0x21` | 33      | `undefined`                     |
-| `TAG_BOOLEAN`     | `0x22` | 34      | `boolean`                       |
-| `TAG_NUMBER`      | `0x23` | 35      | `number` (finite, non-NaN)      |
-| `TAG_STRING`      | `0x24` | 36      | `string` (direct form)          |
-| `TAG_BYTES`       | `0x25` | 37      | `FabricBytes`                 |
-| `TAG_BIGINT`      | `0x26` | 38      | `bigint`                        |
-| `TAG_EPOCH_NSEC`  | `0x27` | 39      | `FabricEpochNsec`             |
-| `TAG_EPOCH_DAYS`  | `0x28` | 40      | `FabricEpochDays`             |
-| `TAG_CONTENT_ID`  | `0x29` | 41      | `FabricHash`             |
+| Tag               | Hex    | Decimal | Used for                          |
+|:------------------|:-------|:--------|:----------------------------------|
+| `TAG_NULL`        | `0x20` | 32      | `null`                            |
+| `TAG_UNDEFINED`   | `0x21` | 33      | `undefined`                       |
+| `TAG_BOOLEAN`     | `0x22` | 34      | `boolean`                         |
+| `TAG_NUMBER`      | `0x23` | 35      | `number` (any IEEE 754 binary64)  |
+| `TAG_STRING`      | `0x24` | 36      | `string` (direct form)            |
+| `TAG_BYTES`       | `0x25` | 37      | `FabricBytes`                     |
+| `TAG_BIGINT`      | `0x26` | 38      | `bigint`                          |
+| `TAG_EPOCH_NSEC`  | `0x27` | 39      | `FabricEpochNsec`                 |
+| `TAG_EPOCH_DAYS`  | `0x28` | 40      | `FabricEpochDays`                 |
+| `TAG_CONTENT_ID`  | `0x29` | 41      | `FabricHash`                      |
 
 **Optimized tags (`0xFN`)** — hash-level substitutes that replace the raw
 payload of a primitive type with a digest, when doing so shortens the byte
@@ -2199,7 +2208,7 @@ export function fabricFromNativeValue(
 
 | Input Type | Output |
 |------------|--------|
-| `null`, `boolean`, `number`, `string`, `undefined`, `bigint` | Returned as-is (primitives are `FabricValue` directly). `-0` is normalized to `0`. Non-finite numbers (`NaN`, `Infinity`) cause rejection. |
+| `null`, `boolean`, `number`, `string`, `undefined`, `bigint` | Returned as-is (primitives are `FabricValue` directly). Modern path passes all numbers through unchanged, including `-0`, `NaN`, and `±Infinity`. Legacy path normalizes `-0` to `0` and rejects `NaN` / `±Infinity` with a thrown error. See Section 1.3 callout for layer-by-layer details. |
 | `FabricPrimitive` (`FabricEpochNsec`, `FabricEpochDays`, `FabricHash`, `FabricBytes`) | Returned as-is. Always-frozen: the `freeze` option has no effect on these types (see Section 1.4.6). |
 | `FabricInstance` (including wrapper classes) | Returned as-is (already `FabricValue`). |
 | `Error` | Wrapped into `FabricError`. Before wrapping, `cause` and custom enumerable properties are recursively converted to `FabricValue` (deep variant) or left as-is (shallow variant). Extra enumerable properties are preserved (see Section 1.4.1). This ensures that by the time `FabricError.[DECONSTRUCT]` runs, all nested values are already valid `FabricValue`. |
@@ -2338,8 +2347,10 @@ export function isFabricCompatible(
 The function recursively checks the value tree. It returns `true` if and only
 if the value is:
 
-- A primitive (`null`, `boolean`, `number` (finite), `string`, `undefined`,
-  `bigint`)
+- A primitive (`null`, `boolean`, `number`, `string`, `undefined`, `bigint`).
+  All numbers are accepted on the modern path, including `-0`, `NaN`, and
+  `±Infinity`. On the legacy path, `NaN` and `±Infinity` are rejected; see
+  Section 1.3 callout for the per-path detail.
 - A `FabricInstance` (including the native object wrapper classes)
 - A `FabricNativeObject` (`Error`, `Map`, `Set`, `Date`, `RegExp`,
   `Uint8Array`, or an object with a `toJSON()` method — legacy)
@@ -2347,8 +2358,9 @@ if the value is:
 - A plain object where every value satisfies `isFabricCompatible()`
 
 It returns `false` for unsupported types (`WeakMap`, `Promise`, DOM nodes,
-class instances that don't implement `FabricInstance`, non-finite numbers,
-etc.).
+class instances that don't implement `FabricInstance`, etc.). On the legacy
+path it additionally returns `false` for non-finite numbers; the modern path
+accepts them.
 
 > **Performance note.** `isFabricCompatible()` walks the value tree without
 > allocating wrappers or frozen copies. For large trees, this is cheaper than

--- a/docs/specs/space-model-formal-spec/2-hash-byte-format.md
+++ b/docs/specs/space-model-formal-spec/2-hash-byte-format.md
@@ -109,22 +109,34 @@ Bytes: TAG_NUMBER  IEEE_754_FLOAT64_BE
 Total: 9 bytes.
 
 The payload is the IEEE 754 binary64 representation of the number, in
-big-endian byte order.
+big-endian byte order. All JavaScript numbers are accepted, including the
+four special values that JSON cannot represent natively (`-0`, `NaN`,
+`+Infinity`, `-Infinity`).
 
-**Normalization rules:**
+**Encoding rules:**
 
-- **Negative zero (`-0`)** must be normalized to positive zero (`+0`) before
-  encoding. That is, the 8-byte payload for `-0` is
-  `00 00 00 00 00 00 00 00`, not `80 00 00 00 00 00 00 00`. This ensures `-0`
-  and `+0` produce identical hashes, matching JavaScript semantics where
-  `-0 === 0` is `true`.
+- **Negative zero (`-0`)** is encoded with its natural sign bit. The 8-byte
+  payload for `-0` is `80 00 00 00 00 00 00 00`, distinct from the payload
+  for `+0` (`00 00 00 00 00 00 00 00`). The two values therefore produce
+  different hashes.
 
-- **`NaN`** must not appear. `fabricFromNativeValue()` rejects `NaN` values; a
-  conforming hasher may assume `NaN` is never encountered. If a hasher does
-  encounter `NaN`, it should throw rather than produce a hash.
+- **`+Infinity`** is encoded as `7F F0 00 00 00 00 00 00`.
 
-- **`Infinity` / `-Infinity`** must not appear. Like `NaN`, these are rejected
-  by `fabricFromNativeValue()`. A conforming hasher should throw if encountered.
+- **`-Infinity`** is encoded as `FF F0 00 00 00 00 00 00`.
+
+- **`NaN`** is canonicalized to a single representation: the **quiet NaN**
+  payload `7F F8 00 00 00 00 00 00`. Any input NaN bit pattern (signaling,
+  quiet, with arbitrary payload bits) hashes via this canonical 8-byte
+  sequence. This ensures all NaN values produce identical hashes,
+  consistent with JavaScript semantics where every NaN compares unequal
+  to itself but is observationally indistinguishable from every other NaN
+  at the language level.
+
+> **Conversion-gate cross-reference.** Whether `-0`, `NaN`, or `±Infinity`
+> reach this layer in a given run depends on the `modernDataModel` flag at
+> the fabric-value conversion gate; see `1-fabric-values.md` Section 4.9.
+> The byte-level encoding above is the hasher's contract regardless of how
+> the values arrived.
 
 ### 4.4 `string`
 
@@ -481,7 +493,8 @@ IEEE 754 binary64 for `42.0` is `0x4045000000000000`.
 23  00 00 00 00 00 00 00 00
 ```
 
-Note: `-0` produces the same byte stream (normalized to `+0`).
+`-0` produces a distinct byte stream `23  80 00 00 00 00 00 00 00` (sign
+bit set; see Section 4.3).
 
 ### 7.6 `"hello"` (string)
 
@@ -668,17 +681,15 @@ sequence.
 
 ## 8. Rejected Values
 
-The following JavaScript values are rejected by `fabricFromNativeValue()` and must
-never be passed to the hasher:
+The following JavaScript values are rejected by `fabricFromNativeValue()` and
+must never be passed to the hasher:
 
-- `NaN`
-- `Infinity`
-- `-Infinity`
 - `Symbol` values
 - `Function` values
 
-A conforming implementation should throw an error if it encounters any of these
-rather than producing a hash.
+A conforming implementation should throw an error if it encounters either
+of these rather than producing a hash. (`NaN`, `±Infinity`, and `-0` are
+**not** rejected; they have well-defined byte encodings — see Section 4.3.)
 
 ---
 

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -146,6 +146,29 @@ round-trip correctly.
 //   - `-128n` → 0x80           → "gA"
 // This matches the hash byte format (2-hash-byte-format.md), which already
 // uses two's complement big-endian for BigInt payloads.
+
+// Special numeric values that JSON cannot represent natively.
+// Tag: "SpecialNumber@1"
+// { "/SpecialNumber@1": string }
+//
+// The state is one of exactly four literal strings:
+//   - "-0"          → the negative-zero value
+//   - "NaN"         → Number.NaN (any input NaN bit pattern serializes as
+//                     this single literal and round-trips back to NaN)
+//   - "+Infinity"   → positive infinity
+//   - "-Infinity"   → negative infinity
+//
+// String state (rather than a JSON number) is used because JSON.stringify
+// emits `null` for NaN/±Infinity and drops the sign on -0; a numeric-state
+// form would be lossy through the JSON layer. On deserialization, any state
+// other than these four literals — including a non-string state — produces
+// a `ProblematicValue` (see `1-fabric-values.md` Section 3.5) per the
+// general handler-validation rule below.
+//
+// Whether such values reach this encoder in a given run is gated by the
+// `modernDataModel` flag at the fabric-value conversion gate; see
+// `1-fabric-values.md` Section 4.9. The wire format above is the encoder's
+// contract regardless of how the values arrived.
 ```
 
 > **Deserialization validation.** Deserialization cannot assume type safety from

--- a/docs/specs/space-model/1-data-model.md
+++ b/docs/specs/space-model/1-data-model.md
@@ -25,16 +25,28 @@ Fabric values are JSON-compatible with specific constraints:
 |------|-------|
 | `null` | JSON null |
 | `boolean` | `true` or `false` |
-| `number` | Finite only; `NaN` and `Infinity` rejected |
+| `number` | Legacy path: finite only; `NaN` and `Infinity` rejected. Modern path: any IEEE 754 binary64 (see Numbers below). |
 | `string` | Unicode text |
 | `array` | Ordered sequence of fabric values |
 | `object` | String-keyed map of fabric values |
 
 #### Numbers
 
-- Only finite numbers are fabric-compatible
-- `-0` is normalized to `0` during conversion
-- `NaN` and `Infinity` throw errors
+Number handling is bifurcated by the `modernDataModel` flag at the
+fabric-value conversion gate:
+
+- **Legacy path (`modernDataModel: false`):**
+  - Only finite numbers are fabric-compatible
+  - `-0` is normalized to `0` during conversion
+  - `NaN` and `Infinity` throw errors
+- **Modern path (`modernDataModel: true`):**
+  - All IEEE 754 binary64 values are accepted, including `-0`, `NaN`,
+    `+Infinity`, and `-Infinity`
+  - `-0` retains its sign
+  - `NaN` and `±Infinity` round-trip via the `SpecialNumber@1` JSON
+    envelope (see `space-model-formal-spec/3-json-encoding.md` Section 3)
+    and via the byte-level forms in
+    `space-model-formal-spec/2-hash-byte-format.md` Section 4.3
 
 #### Arrays
 


### PR DESCRIPTION
## Summary

Spec-only sync pass aligning the data-model formal and informal specs with two recently-landed work streams. No code touched; both topic clusters were ratified before drafting.

## Topic A: `unifiedJsonEncoding` default-on (PR #3391)

`docs/specs/space-model-formal-spec/1-fabric-values.md` §4.8 now reflects the current dispatch behavior with the `unifiedJsonEncoding` flag default-on. Soak-revert posture is preserved deliberately: language uses **"current default"** rather than graduation language, so a revert via the upstream `revert-3391-...` branch keeps the spec accurate without further edits. This is the same hard-non-conflation discipline Sage applied during the modernHash arc (PR #3454).

## Topic B: `-0` / NaN / Infinity acceptance + `SpecialNumber@1` wire format

Reflects the pair of landings that added the `SpecialNumber@1` JSON-encoding type tag and accepted previously-rejected non-finite/`-0` numbers under the modern data model:

- PR #3492 (hasher).
- PR #3493 (JSON encoder; introduces `SpecialNumber@1` with four literal strings: `-0`, `NaN`, `+Infinity`, `-Infinity`; malformed payloads decode to `ProblematicValue`).

Per-spec-layer separation of concerns:

- **Lower layers** (`2-hash-byte-format.md` §4.3, §7.5, §8; `3-json-encoding.md` new §3 entry on `SpecialNumber@1`) describe their own layer's unconditional behavior, with one-paragraph cross-references back up to the conversion gate.
- **Conversion-gate layer** (`1-fabric-values.md` §1.3 + §8.2) is where the flag-bifurcation language lives ("modern accepts, legacy rejects"). §4.9's existing "Flag OFF (default)" language for `modernDataModel` was deliberately not touched — that flag has not flipped (verified at `packages/data-model/fabric-value.ts:59`).
- **Informal spec** (`docs/specs/space-model/1-data-model.md`) updates the base-types table and the Numbers section to track.

## Risk

Spec-only sync; no production code touched. `deno fmt` excludes `docs/`, `deno lint` doesn't apply to `.md`, so no fmt/lint gate concerns. Reverts are trivial if either topic's underlying upstream change is rolled back.

---

Co-Authored-By: spec-writer-sage (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
