### PR TITLE
Admit interned symbols into FabricValue type, hash, and JSON encoding

### DIFF
--- a/packages/data-model/fabric-type-tags.ts
+++ b/packages/data-model/fabric-type-tags.ts
@@ -23,6 +23,7 @@ export const TAGS = Object.freeze(
     // -- Primitive type handlers --
     BigInt: "BigInt@1",
     SpecialNumber: "SpecialNumber@1",
+    Symbol: "Symbol@1",
     Undefined: "Undefined@1",
 
     // -- Structural / meta tags (serialization format) --

--- a/packages/data-model/interface.ts
+++ b/packages/data-model/interface.ts
@@ -134,6 +134,16 @@ export abstract class FabricPrimitive extends FabricSpecialObject {
  * `undefined` is preserved when the `modernDataModel` flag is ON. When the
  * flag is OFF, `undefined` in arrays is converted to `null` and `undefined`
  * object properties are omitted -- matching legacy behavior.
+ *
+ * `symbol` values are restricted at runtime to **registry-interned** symbols
+ * -- those for which `Symbol.keyFor(s)` returns a string. These are
+ * portable across realms and processes via their registry key. Unique
+ * symbols (`Symbol(desc)`) are not portable and are rejected at the fabric
+ * boundary. TypeScript's `symbol` type cannot distinguish the two, so the
+ * gate is a runtime one. Note also that the modern fabric-value path
+ * separately rejects all symbols at the entrance (relaxation deferred to a
+ * follow-up); the type union admits `symbol` so the lower layers (hashing,
+ * JSON encoding) can be written and tested ahead of that gate change.
  */
 export type FabricValue =
   // -- Primitives --
@@ -142,6 +152,7 @@ export type FabricValue =
   | number
   | string
   | bigint
+  | symbol
   // -- Fabric special objects --
   | FabricSpecialObject
   // -- Containers --

--- a/packages/data-model/json-type-handlers.ts
+++ b/packages/data-model/json-type-handlers.ts
@@ -407,6 +407,51 @@ export const SpecialNumberHandler: TypeHandler = {
 };
 
 /**
+ * Handler for registry-interned symbols. Serializes the registry key as a
+ * JSON string. Wire format: `{ "/Symbol@1": "<key>" }`. On deserialize,
+ * `Symbol.for(key)` retrieves (or creates) the registry symbol with the
+ * matching key, so the result is `===` to any other `Symbol.for(key)` in
+ * the same realm.
+ *
+ * Unique symbols (`Symbol(desc)`, where `Symbol.keyFor()` returns
+ * `undefined`) have no portable representation; `canSerialize()` returns
+ * `false` for them, which routes them to the registry's "unhandled value"
+ * path instead of being silently coerced to a registry symbol.
+ */
+export const SymbolHandler: TypeHandler = {
+  tag: TAGS.Symbol,
+
+  canSerialize(value: FabricValue): boolean {
+    return typeof value === "symbol" && Symbol.keyFor(value) !== undefined;
+  },
+
+  serialize(
+    value: FabricValue,
+    codec: TypeHandlerCodec,
+    _recurse: (v: FabricValue) => JsonWireValue,
+  ): JsonWireValue {
+    // `canSerialize` already verified the symbol has a registry key.
+    const key = Symbol.keyFor(value as symbol)!;
+    return codec.wrapTag(TAGS.Symbol, key);
+  },
+
+  deserialize(
+    state: JsonWireValue,
+    _runtime: ReconstructionContext,
+    _recurse: (v: JsonWireValue) => FabricValue,
+  ): FabricValue {
+    if (typeof state !== "string") {
+      return makeProblematic(
+        TAGS.Symbol,
+        state,
+        `Symbol: expected string state, got ${typeof state}`,
+      );
+    }
+    return Symbol.for(state);
+  },
+};
+
+/**
  * Handler for `FabricBytes`. Serializes to a flat base64url string
  * encoding the raw bytes. Wire format: `{ "/Bytes@1": "<base64>" }`.
  * `FabricBytes` is a direct member of `FabricValue` (via
@@ -526,6 +571,7 @@ export function createDefaultRegistry(): TypeHandlerRegistry {
   // Primitives that need tagged encoding (can't be expressed in JSON natively).
   registry.register(BigIntHandler);
   registry.register(SpecialNumberHandler);
+  registry.register(SymbolHandler);
   registry.register(UndefinedHandler);
   return registry;
 }

--- a/packages/data-model/test/json-encoding-context.test.ts
+++ b/packages/data-model/test/json-encoding-context.test.ts
@@ -522,6 +522,88 @@ describe("JsonEncodingContext", () => {
   });
 
   // --------------------------------------------------------------------------
+  // Symbol (registry-interned)
+  // --------------------------------------------------------------------------
+
+  describe("Symbol", () => {
+    it("serializes Symbol.for('foo') to /Symbol@1 with the key as state", () => {
+      expect(toWireFormat(Symbol.for("foo") as FabricValue)).toEqual({
+        "/Symbol@1": "foo",
+      });
+    });
+
+    it("serializes Symbol.for('') (empty key)", () => {
+      expect(toWireFormat(Symbol.for("") as FabricValue)).toEqual({
+        "/Symbol@1": "",
+      });
+    });
+
+    it("round-trips an interned symbol to the same registry instance", () => {
+      const result = roundTrip(Symbol.for("hello") as FabricValue);
+      expect(typeof result).toBe("symbol");
+      expect(result).toBe(Symbol.for("hello"));
+    });
+
+    it("round-trips a key with non-ASCII characters", () => {
+      const key = "café-☕-\u{1F600}";
+      const result = roundTrip(Symbol.for(key) as FabricValue);
+      expect(result).toBe(Symbol.for(key));
+    });
+
+    it("round-trips inside arrays", () => {
+      const arr = [
+        Symbol.for("a"),
+        1,
+        Symbol.for("b"),
+      ] as unknown as FabricValue;
+      const result = roundTrip(arr) as unknown[];
+      expect(result[0]).toBe(Symbol.for("a"));
+      expect(result[1]).toBe(1);
+      expect(result[2]).toBe(Symbol.for("b"));
+    });
+
+    it("round-trips as object values", () => {
+      const obj = {
+        kind: Symbol.for("event"),
+        flag: Symbol.for("ready"),
+      } as unknown as FabricValue;
+      const result = roundTrip(obj) as Record<string, unknown>;
+      expect(result.kind).toBe(Symbol.for("event"));
+      expect(result.flag).toBe(Symbol.for("ready"));
+    });
+
+    it("does not intercept Symbol(desc) (unique / uninterned)", () => {
+      // canSerialize() returns false for unique symbols. The handler does not
+      // claim them, which means they fall through to the registry's default
+      // unhandled-value treatment rather than being silently coerced into a
+      // registry symbol.
+      const uniq = Symbol("nope") as FabricValue;
+      const wire = toWireFormat(uniq);
+      // The result should NOT be a Symbol@1 wrapping. (It will be an
+      // UnknownValue or similar; the precise shape isn't what matters here --
+      // what matters is that we didn't spuriously fabricate a registry key.)
+      expect(typeof wire === "object" && wire !== null && "/Symbol@1" in wire)
+        .toBe(false);
+    });
+
+    it("non-string state -> ProblematicValue (lenient)", () => {
+      const ctx = new JsonEncodingContext({ lenient: true });
+      const runtime: ReconstructionContext = {
+        getCell(_ref) {
+          throw new Error("getCell not implemented in test runtime");
+        },
+      };
+      const encodedJson = ENCODING_PREFIX +
+        JSON.stringify({ "/Symbol@1": 42 });
+      const result = ctx.decode(encodedJson, runtime);
+      expect(result).toBeInstanceOf(ProblematicValue);
+      expect((result as unknown as ProblematicValue).typeTag).toBe(
+        "Symbol@1",
+      );
+    });
+  });
+
+  // --------------------------------------------------------------------------
   // FabricEpochNsec
   // --------------------------------------------------------------------------
 

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -254,6 +254,26 @@ describe("hashOf()", () => {
     expect(hashBytesOf(emoji)).toEqual(expected);
   });
 
+  it("long string takes the TAG_STRING_HASH path", () => {
+    // utf8Length(100) > MAX_DIRECT_STRING_LENGTH(64), so the value is fed
+    // as [TAG_STRING_HASH][sha256(utf8)] -- a fixed-length compaction in
+    // place of the inline `[TAG_STRING][len][utf8]` form.
+    const value = "x".repeat(100);
+    const valueHash = sha256(new TextEncoder().encode(value));
+    const expected = sha256([0xf0, ...valueHash]);
+    expect(hashBytesOf(value)).toEqual(expected);
+  });
+
+  it("long-string path is deterministic and value-distinct", () => {
+    // Two different strings both > 64 utf8 bytes should hash differently;
+    // identical long strings should hash the same.
+    const a1 = "a".repeat(100);
+    const a2 = "a".repeat(100);
+    const b = "b".repeat(100);
+    expect(hex(hashBytesOf(a1))).toBe(hex(hashBytesOf(a2)));
+    expect(hex(hashBytesOf(a1))).not.toBe(hex(hashBytesOf(b)));
+  });
+
   // --- bigint ---
 
   it("0n encodes as TAG_BIGINT + LEB128 length 1 + [0x00]", () => {
@@ -896,6 +916,41 @@ describe("hashOf()", () => {
       0x00,
     ]);
     expect(hex(hashBytesOf(obj))).not.toBe(hex(wrongOrder));
+  });
+
+  it("long object key takes the TAG_STRING_HASH path", () => {
+    // utf8Length(100) > MAX_DIRECT_STRING_LENGTH(64). Object keys go through
+    // the same `getStringRep()` codepath as bare string values, so a long
+    // key is fed as `[TAG_STRING_HASH][sha256(utf8)]`.
+    const longKey = "x".repeat(100);
+    const obj = { [longKey]: 1 } as unknown as FabricValue;
+    const keyHash = sha256(new TextEncoder().encode(longKey));
+    // Stream: TAG_OBJECT, [TAG_STRING_HASH, keyHash], value(1.0), TAG_END
+    const expected = sha256([
+      0x11, // TAG_OBJECT
+      0xf0, // TAG_STRING_HASH
+      ...keyHash,
+      // Value `1`: TAG_NUMBER + IEEE-754 BE bit pattern for 1.0
+      0x23,
+      0x3f,
+      0xf0,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x00, // TAG_END
+    ]);
+    expect(hashBytesOf(obj)).toEqual(expected);
+  });
+
+  it("long object keys are deterministic and key-distinct", () => {
+    const a1 = { ["a".repeat(100)]: 1 } as unknown as FabricValue;
+    const a2 = { ["a".repeat(100)]: 1 } as unknown as FabricValue;
+    const b = { ["b".repeat(100)]: 1 } as unknown as FabricValue;
+    expect(hex(hashBytesOf(a1))).toBe(hex(hashBytesOf(a2)));
+    expect(hex(hashBytesOf(a1))).not.toBe(hex(hashBytesOf(b)));
   });
 
   // =========================================================================

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -1278,3 +1278,61 @@ describe("IncrementalHasher digest base64url", () => {
     expect(h1.digest("base64url")).not.toBe(h2.digest("base64url"));
   });
 });
+
+// Registry-interned symbols: hashed via TAG_SYMBOL (0x2a) followed by
+// ULEB128(byteLength) and the UTF-8 bytes of `Symbol.keyFor(s)`. Unique
+// (uninterned) symbols have no portable key and throw.
+describe("hashOf() interned symbols", () => {
+  it("Symbol.for('foo') produces TAG_SYMBOL + ULEB128(3) + 'foo' bytes", () => {
+    // [0x2a, 0x03, 0x66, 0x6f, 0x6f]
+    const expected = sha256([0x2a, 0x03, 0x66, 0x6f, 0x6f]);
+    expect(hashBytesOf(Symbol.for("foo") as FabricValue)).toEqual(expected);
+  });
+
+  it("Symbol.for('') produces TAG_SYMBOL + ULEB128(0)", () => {
+    // [0x2a, 0x00]
+    const expected = sha256([0x2a, 0x00]);
+    expect(hashBytesOf(Symbol.for("") as FabricValue)).toEqual(expected);
+  });
+
+  it("equal-keyed interned symbols hash identically", () => {
+    expect(hex(hashBytesOf(Symbol.for("hello") as FabricValue)))
+      .toBe(hex(hashBytesOf(Symbol.for("hello") as FabricValue)));
+  });
+
+  it("differently-keyed interned symbols hash differently", () => {
+    expect(hex(hashBytesOf(Symbol.for("a") as FabricValue)))
+      .not.toBe(hex(hashBytesOf(Symbol.for("b") as FabricValue)));
+  });
+
+  it("interned symbol does not collide with the same-key string", () => {
+    // The TAG_SYMBOL prefix must distinguish a symbol from its key string.
+    expect(hex(hashBytesOf(Symbol.for("x") as FabricValue)))
+      .not.toBe(hex(hashBytesOf("x")));
+  });
+
+  it("interned symbol nested in an object hashes deterministically", () => {
+    const a = { tag: Symbol.for("nested-tag") } as unknown as FabricValue;
+    const b = { tag: Symbol.for("nested-tag") } as unknown as FabricValue;
+    expect(hex(hashBytesOf(a))).toBe(hex(hashBytesOf(b)));
+  });
+
+  it("interned symbol nested in an array hashes deterministically", () => {
+    const a = [Symbol.for("x"), 1] as unknown as FabricValue;
+    const b = [Symbol.for("x"), 1] as unknown as FabricValue;
+    expect(hex(hashBytesOf(a))).toBe(hex(hashBytesOf(b)));
+  });
+
+  it("Symbol(desc) (unique / uninterned) throws", () => {
+    expect(() => hashOf(Symbol("nope") as FabricValue)).toThrow(
+      "Cannot hash unique (uninterned) symbol",
+    );
+  });
+
+  it("unique symbol nested in an object also throws", () => {
+    const value = { tag: Symbol("nope") } as unknown as FabricValue;
+    expect(() => hashOf(value)).toThrow(
+      "Cannot hash unique (uninterned) symbol",
+    );
+  });
+});

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -1279,20 +1279,43 @@ describe("IncrementalHasher digest base64url", () => {
   });
 });
 
-// Registry-interned symbols: hashed via TAG_SYMBOL (0x2a) followed by
-// ULEB128(byteLength) and the UTF-8 bytes of `Symbol.keyFor(s)`. Unique
-// (uninterned) symbols have no portable key and throw.
+// Registry-interned symbols: hashed via TAG_SYMBOL (0x2a) followed by a
+// self-tagged string-rep of `Symbol.keyFor(s)` (i.e., the same byte stream
+// that a plain string of that key would feed). Unique (uninterned) symbols
+// have no portable key and throw.
 describe("hashOf() interned symbols", () => {
-  it("Symbol.for('foo') produces TAG_SYMBOL + ULEB128(3) + 'foo' bytes", () => {
-    // [0x2a, 0x03, 0x66, 0x6f, 0x6f]
-    const expected = sha256([0x2a, 0x03, 0x66, 0x6f, 0x6f]);
+  it("short key takes the inline TAG_STRING path", () => {
+    // utf8Length(3) <= MAX_DIRECT_STRING_LENGTH(64), so the key is fed as
+    // [TAG_STRING][len][utf8].
+    // Final stream: [TAG_SYMBOL=0x2a, TAG_STRING=0x24, len=0x03, 'f','o','o']
+    const expected = sha256([0x2a, 0x24, 0x03, 0x66, 0x6f, 0x6f]);
     expect(hashBytesOf(Symbol.for("foo") as FabricValue)).toEqual(expected);
   });
 
-  it("Symbol.for('') produces TAG_SYMBOL + ULEB128(0)", () => {
-    // [0x2a, 0x00]
-    const expected = sha256([0x2a, 0x00]);
+  it("empty-key Symbol.for('') has length zero, not absent", () => {
+    // [TAG_SYMBOL=0x2a, TAG_STRING=0x24, len=0x00]
+    const expected = sha256([0x2a, 0x24, 0x00]);
     expect(hashBytesOf(Symbol.for("") as FabricValue)).toEqual(expected);
+  });
+
+  it("long key takes the TAG_STRING_HASH path", () => {
+    // utf8Length(100) > MAX_DIRECT_STRING_LENGTH(64), so the key is fed as
+    // [TAG_STRING_HASH][sha256(utf8)] -- a fixed-length compaction.
+    // Final stream: [TAG_SYMBOL=0x2a, TAG_STRING_HASH=0xf0, ...keyHash]
+    const key = "x".repeat(100);
+    const keyHash = sha256(new TextEncoder().encode(key));
+    const expected = sha256([0x2a, 0xf0, ...keyHash]);
+    expect(hashBytesOf(Symbol.for(key) as FabricValue)).toEqual(expected);
+  });
+
+  it("long-key path is deterministic and key-distinct", () => {
+    // Two different keys both > 64 utf8 bytes should hash differently;
+    // identical long keys should hash the same.
+    const a1 = Symbol.for("a".repeat(100)) as FabricValue;
+    const a2 = Symbol.for("a".repeat(100)) as FabricValue;
+    const b = Symbol.for("b".repeat(100)) as FabricValue;
+    expect(hex(hashBytesOf(a1))).toBe(hex(hashBytesOf(a2)));
+    expect(hex(hashBytesOf(a1))).not.toBe(hex(hashBytesOf(b)));
   });
 
   it("equal-keyed interned symbols hash identically", () => {

--- a/packages/data-model/value-hash.ts
+++ b/packages/data-model/value-hash.ts
@@ -36,7 +36,7 @@ const TAG_ARRAY = 0x10;
 const TAG_OBJECT = 0x11;
 const TAG_INSTANCE = 0x12;
 
-// Primitive (0x2N) -- ordered by conceptual size
+// Primitive (0x2N)
 const TAG_NULL = 0x20;
 const TAG_UNDEFINED = 0x21;
 const TAG_BOOLEAN = 0x22;
@@ -47,6 +47,7 @@ const TAG_BIGINT = 0x26;
 const TAG_EPOCH_NSEC = 0x27;
 const TAG_EPOCH_DAYS = 0x28;
 const TAG_CONTENT_HASH = 0x29;
+const TAG_SYMBOL = 0x2a;
 
 // Special for hashing:
 const TAG_STRING_HASH = 0xf0;
@@ -70,6 +71,7 @@ const TAG_BIGINT_BYTES = new Uint8Array([TAG_BIGINT]);
 const TAG_EPOCH_NSEC_BYTES = new Uint8Array([TAG_EPOCH_NSEC]);
 const TAG_EPOCH_DAYS_BYTES = new Uint8Array([TAG_EPOCH_DAYS]);
 const TAG_CONTENT_HASH_BYTES = new Uint8Array([TAG_CONTENT_HASH]);
+const TAG_SYMBOL_BYTES = new Uint8Array([TAG_SYMBOL]);
 
 // ---------------------------------------------------------------------------
 // Core: recursive value feeding
@@ -201,6 +203,18 @@ function feedValue(hasher: IncrementalHasher, value: unknown): void {
       const bytes = bigintToMinimalTwosComplement(value);
       feedLength(hasher, bytes.length);
       hasher.update(bytes);
+      break;
+    }
+
+    case "symbol": {
+      const key = Symbol.keyFor(value);
+      if (key === undefined) {
+        throw new Error("Cannot hash unique (uninterned) symbol");
+      }
+      hasher.update(TAG_SYMBOL_BYTES);
+      const utf8 = encoder.encode(key);
+      feedLength(hasher, utf8.length);
+      hasher.update(utf8);
       break;
     }
 
@@ -407,11 +421,12 @@ const NEGATIVE_ZERO_HASH = computeHash(-0);
 
 /**
  * LRU cache for primitive value hashes. Primitives (strings, numbers,
- * bigints) can't be WeakMap keys, so they use a bounded cache. Sizing is based
- * on historical testing (expected ~97% hit rate in practice).
+ * bigints, registry-interned symbols) can't be WeakMap keys, so they use a
+ * bounded cache. Sizing is based on historical testing (expected ~97% hit
+ * rate in practice).
  */
 const primitiveHashCache = new LRUCache<
-  string | number | bigint,
+  string | number | bigint | symbol,
   FabricHash
 >({
   capacity: 50_000,
@@ -429,7 +444,9 @@ const frozenObjectHashCache = new WeakMap<object, FabricHash>();
  * miss. Caller must filter out values that don't behave under `Map`'s
  * SameValueZero keying (notably `-0`, which collides with `+0`).
  */
-function cachedPrimitiveHash(value: string | number | bigint): FabricHash {
+function cachedPrimitiveHash(
+  value: string | number | bigint | symbol,
+): FabricHash {
   const cached = primitiveHashCache.get(value);
   if (cached !== undefined) return cached;
   const result = computeHash(value);
@@ -472,6 +489,16 @@ function hashOfInternal(
 
     case "undefined":
       return UNDEFINED_HASH;
+
+    case "symbol": {
+      // Only registry-interned symbols are hashable; unique symbols have
+      // no portable representation. The throw inside `feedValue` covers the
+      // unique case structurally; check here so that the cache key is sound.
+      if (Symbol.keyFor(value) === undefined) {
+        throw new Error("Cannot hash unique (uninterned) symbol");
+      }
+      return cachedPrimitiveHash(value);
+    }
 
     case "object": {
       if (value === null) return NULL_HASH;

--- a/packages/data-model/value-hash.ts
+++ b/packages/data-model/value-hash.ts
@@ -212,9 +212,12 @@ function feedValue(hasher: IncrementalHasher, value: unknown): void {
         throw new Error("Cannot hash unique (uninterned) symbol");
       }
       hasher.update(TAG_SYMBOL_BYTES);
-      const utf8 = encoder.encode(key);
-      feedLength(hasher, utf8.length);
-      hasher.update(utf8);
+      // Delegate to `getStringRep()` so the key encoding picks up the
+      // same LRU cache and long-string-hashing fallback that string
+      // values get. The emitted bytes are `TAG_SYMBOL` followed by a
+      // self-tagged string-rep (`TAG_STRING + len + utf8` for short
+      // keys; `TAG_STRING_HASH + hash` for long ones).
+      hasher.update(getStringRep(key));
       break;
     }
 

--- a/packages/data-model/value-hash.ts
+++ b/packages/data-model/value-hash.ts
@@ -212,11 +212,6 @@ function feedValue(hasher: IncrementalHasher, value: unknown): void {
         throw new Error("Cannot hash unique (uninterned) symbol");
       }
       hasher.update(TAG_SYMBOL_BYTES);
-      // Delegate to `getStringRep()` so the key encoding picks up the
-      // same LRU cache and long-string-hashing fallback that string
-      // values get. The emitted bytes are `TAG_SYMBOL` followed by a
-      // self-tagged string-rep (`TAG_STRING + len + utf8` for short
-      // keys; `TAG_STRING_HASH + hash` for long ones).
       hasher.update(getStringRep(key));
       break;
     }
@@ -495,7 +490,7 @@ function hashOfInternal(
 
     case "symbol": {
       // Only registry-interned symbols are hashable; unique symbols have
-      // no portable representation. The throw inside `feedValue` covers the
+      // no portable representation. The throw inside `feedValue()` covers the
       // unique case structurally; check here so that the cache key is sound.
       if (Symbol.keyFor(value) === undefined) {
         throw new Error("Cannot hash unique (uninterned) symbol");


### PR DESCRIPTION
## Summary

First of three planned PRs that bring **registry-interned symbols**
(`Symbol.for(key)`, where `Symbol.keyFor(s)` returns a string) into the
fabric value system, structured like the "weird-numbers" rollout
(#3492/#3493/#3495). **Unique** symbols (`Symbol(desc)`) stay
unsupported — they have no portable representation across realms or
processes.

The symbol case is simpler than the four-special-numbers case, so this
PR bundles three things into one diff:

### 1. Type union

Adds `symbol` to the `FabricValue` union in `interface.ts`, with a doc
comment explaining the interned-vs-unique runtime distinction. The
TypeScript `symbol` type can't distinguish the two, so the gate is a
runtime one at conversion / hashing / serialization boundaries.

### 2. Hashing

- Allocates wire tag byte `TAG_SYMBOL = 0x2a` (next free slot in the
  `0x2N` primitive range).
- Adds `case "symbol":` arms in `feedValue` and in `hashOfInternal`
  (cache lookup via the existing primitive LRU).
- The key encoding is delegated to the existing `getStringRep()`
  helper, which gives symbol keys the same caching and
  long-string-hashing fallback as bare string values get. The wire
  form is `[TAG_SYMBOL][TAG_STRING][len][utf8]` for short keys and
  `[TAG_SYMBOL][TAG_STRING_HASH][sha256(utf8)]` for keys whose UTF-8
  length exceeds `MAX_DIRECT_STRING_LENGTH` (64 bytes).
- Widens `cachedPrimitiveHash`'s key type to include `symbol`. The
  LRU's `Map` keys interned symbols by identity, which works correctly
  because `Symbol.for(k) === Symbol.for(k)` within a realm.
- Throws `"Cannot hash unique (uninterned) symbol"` if `Symbol.keyFor`
  returns `undefined`.

Also drops a stale `// Primitive (0x2N) -- ordered by conceptual size`
comment whose ordering claim hadn't been accurate for a while.

### 3. Unified JSON encoding

- Adds `Symbol: "Symbol@1"` to `TAGS` in `fabric-type-tags.ts`.
- Registers `SymbolHandler` in `json-type-handlers.ts`, modeled on
  `BigIntHandler`. Wire form: `{ "/Symbol@1": "<key>" }`.
- `canSerialize()` returns `false` for unique symbols, so they fall
  through to the registry's standard "unhandled value" path rather
  than being silently coerced to a registry symbol.
- `deserialize()` of non-string state yields a `ProblematicValue`
  (lenient mode) / throws (strict mode).
- Round-trip uses `Symbol.for(state)`, so the decoded result is `===`
  to any other `Symbol.for(key)` in the same realm.

### 4. Plain-string / plain-object-key long-path test coverage

Audit of `getStringRep()` callers found that two surfaces hashed
user-controlled strings without any focused, byte-level test for the
long-string `TAG_STRING_HASH` compaction path: bare string values fed
via `feedValue()`, and plain-object property keys fed via
`feedPlainObject()`. The path was previously only exercised
incidentally via `error.error.stack` inside the FabricError test.

This PR adds four focused tests pinning the `[TAG_STRING_HASH]
[sha256(utf8)]` wire shape for both surfaces, plus determinism +
key-distinctness on each. (The other two `getStringRep()` callers —
`FabricHash.tag` and `FabricInstance.typeTag` — handle structurally
short identifiers like `"fid1"` and `"Error@1"`; long forms are
unreachable in practice.)

## Scope and compatibility

- **Modern fabric-value gate is unchanged.** `fabric-value-modern.ts`
  still throws on all symbols at the conversion entrance. The type
  union admits `symbol` ahead of that gate relaxation so the lower
  layers can be written and tested first; the next PR in this series
  relaxes the gate.
- **Legacy path unchanged.** `fabric-value-legacy.ts` continues to
  reject all symbols. Same shape as the weird-numbers rollout.
- **Spec docs deferred.** `1-fabric-values.md` §2.2,
  `2-hash-byte-format.md`, and `3-json-encoding.md` still describe the
  old "rejected outright" contract. Spec catch-up is rolled into the
  same future spec-work session as the weird-numbers spec update.

## Test plan

- [x] `deno task test` from monorepo root — all packages pass.
- [x] `hashOf() interned symbols` block in `value-hash.test.ts`:
      11 cases (byte-level expectations for short keys, the empty key,
      and the long-key `TAG_STRING_HASH` path; identity / distinctness;
      no collision with the same-keyed string; nested in objects /
      arrays; long-key determinism + key-distinctness; throws for
      unique symbols at top level and when nested).
- [x] `Symbol` block in `json-encoding-context.test.ts`: 8 cases
      (wire-form expectations, round-trip including non-ASCII / emoji
      keys, nested in arrays / objects, non-string state →
      `ProblematicValue` under lenient decode, and confirmation that
      unique symbols are not claimed by `SymbolHandler`).
- [x] Four added long-path tests in the existing string and
      plain-object describes: byte-level pinning + determinism /
      distinctness for both surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
