### PR TITLE
Add cf-harness edit_file tool

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -41,9 +41,10 @@ What works today:
   - `bash-no-sandbox` (provisional host shell for named subagent profiles only)
   - `read_file`
   - `read_skill_resource`
+  - `edit_file`
   - `write_file`
   - `delegate_task`
-- whole-file replace/create plus append writes
+- targeted exact-string edits plus whole-file replace/create and append writes
 - bounded OpenAI-compatible prompt/tool loop
 - single-child subagent delegation with fresh child prompt context, explicit
   default/browser child profiles, retained child run references, and a sanitized
@@ -226,9 +227,9 @@ The provisional browser profile is the only CLI-supported path to
 subagent result. Browser/page output is treated as untrusted child-local data;
 with a `returnSchema`, parent-visible free-form strings are replaced by opaque
 links while raw observations stay in child artifacts. The browser child can read
-workspace files but does not receive `write_file`, so it should return findings
-through the structured return channel rather than by writing browser
-observations into the workspace. The host shell is policy-restricted to
+workspace files but does not receive `edit_file` or `write_file`, so it should
+return findings through the structured return channel rather than by writing
+browser observations into the workspace. The host shell is policy-restricted to
 `agent-browser`, `agent-browser` discovery (`which agent-browser`,
 `command -v agent-browser`), `pwd`, `ls`, and bounded workspace-local `find`
 commands. `agent-browser eval` is not available in this profile; browser
@@ -239,8 +240,8 @@ For browser-profile runs, prefer a host artifact root outside the workspace. Raw
 child artifacts are retained for operator analysis, but they are not meant to
 become ordinary workspace inputs for the parent model. If an artifact root is
 physically placed under the workspace, `read_file`, `write_file`, and
-browser-profile `ls`/`find` treat that artifact tree as reserved from
-model-facing file and discovery tools.
+`edit_file`, plus browser-profile `ls`/`find`, treat that artifact tree as
+reserved from model-facing file and discovery tools.
 
 ```bash
 ROOT=/tmp/cf-harness-browser-demo

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -191,7 +191,7 @@ Options:
   --workspace <path>            Workspace host path (defaults to current directory)
   --cwd <path>                  Initial working directory inside the workspace
   --focus-root <path>           Narrow exploration to a workspace subpath when possible
-  --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | read_skill_resource | write_file | delegate_task)
+  --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | read_skill_resource | edit_file | write_file | delegate_task)
   --allow-subagent-profile <p>  Authorize delegate_task to spawn a profile (repeatable: default | browser)
   --output-mode <mode>          operator | batch (default: operator)
   --stream-events               Print transcript events as they happen
@@ -889,6 +889,18 @@ const summarizeToolCallArguments = (
         return typeof parsed.path === "string"
           ? `path=${JSON.stringify(parsed.path)}`
           : undefined;
+      case "edit_file": {
+        const path = typeof parsed.path === "string"
+          ? `path=${JSON.stringify(parsed.path)}`
+          : undefined;
+        const editCount = Array.isArray(parsed.edits)
+          ? `edits=${parsed.edits.length}`
+          : undefined;
+        return [path, editCount].filter((value): value is string =>
+          value !== undefined
+        )
+          .join(" ");
+      }
       case "read_skill_resource": {
         const skill = typeof parsed.skill === "string"
           ? `skill=${JSON.stringify(parsed.skill)}`

--- a/packages/cf-harness/src/contracts/policy.ts
+++ b/packages/cf-harness/src/contracts/policy.ts
@@ -40,6 +40,18 @@ export interface HarnessWriteFileToolInputSummary {
   contentDigest?: string;
 }
 
+export interface HarnessEditFileToolInputSummary {
+  type: "cf-harness.tool-input-summary";
+  toolId: "edit_file";
+  path?: string;
+  editCount?: number;
+  expectedDigest?: string;
+  oldTextBytes?: number;
+  oldTextDigest?: string;
+  newTextBytes?: number;
+  newTextDigest?: string;
+}
+
 export interface HarnessDelegateTaskToolInputSummary {
   type: "cf-harness.tool-input-summary";
   toolId: "delegate_task";
@@ -57,6 +69,7 @@ export type HarnessToolInputSummary =
   | HarnessBashToolInputSummary
   | HarnessReadFileToolInputSummary
   | HarnessReadSkillResourceToolInputSummary
+  | HarnessEditFileToolInputSummary
   | HarnessWriteFileToolInputSummary
   | HarnessDelegateTaskToolInputSummary
   | {

--- a/packages/cf-harness/src/contracts/subagent.ts
+++ b/packages/cf-harness/src/contracts/subagent.ts
@@ -12,6 +12,7 @@ export const DEFAULT_SUBAGENT_RETURN_CHANNEL =
 export const DEFAULT_SUBAGENT_ALLOWED_TOOL_IDS = [
   "bash",
   "read_file",
+  "edit_file",
   "write_file",
 ] as const satisfies readonly BuiltinToolId[];
 export const BROWSER_SUBAGENT_ALLOWED_TOOL_IDS = [

--- a/packages/cf-harness/src/contracts/tool-descriptor.ts
+++ b/packages/cf-harness/src/contracts/tool-descriptor.ts
@@ -5,6 +5,7 @@ export type BuiltinToolId =
   | "bash-no-sandbox"
   | "read_file"
   | "read_skill_resource"
+  | "edit_file"
   | "write_file"
   | "delegate_task";
 
@@ -12,6 +13,7 @@ export const DEFAULT_PARENT_TOOL_IDS = [
   "bash",
   "read_file",
   "read_skill_resource",
+  "edit_file",
   "write_file",
   "delegate_task",
 ] as const satisfies readonly BuiltinToolId[];

--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -703,6 +703,7 @@ export const classifyBuiltinToolFailure = (
         toolId,
       );
     case "read_file":
+    case "edit_file":
     case "write_file":
       return classifyStructuredFileToolFailure(toolId, output, at);
     case "read_skill_resource":
@@ -760,6 +761,8 @@ const fileFailureKindForCode = (
   switch (code) {
     case "file_not_found":
       return "file_not_found";
+    case "edit_conflict":
+      return "harness_error";
     case "not_a_file":
       return "not_a_file";
     case "permission_denied":
@@ -772,7 +775,7 @@ const fileFailureKindForCode = (
 };
 
 const classifyStructuredFileToolFailure = (
-  toolId: "read_file" | "write_file",
+  toolId: "read_file" | "write_file" | "edit_file",
   output: unknown,
   at: string,
 ): HarnessFailureRecord | undefined => {

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -96,6 +96,10 @@ import {
   type DelegateTaskToolOutput,
 } from "./contracts/subagent.ts";
 import {
+  type EditFileToolInput,
+  type EditFileToolOutput,
+} from "./tools/edit-file.ts";
+import {
   type ReadFileToolInput,
   type ReadFileToolOutput,
 } from "./tools/read-file.ts";
@@ -114,6 +118,7 @@ export interface BuiltinToolInputMap {
   "bash-no-sandbox": BashToolInput;
   read_file: ReadFileToolInput;
   read_skill_resource: ReadSkillResourceToolInput;
+  edit_file: EditFileToolInput;
   write_file: WriteFileToolInput;
   delegate_task: DelegateTaskToolInput;
 }
@@ -123,6 +128,7 @@ export interface BuiltinToolOutputMap {
   "bash-no-sandbox": BashToolOutput;
   read_file: ReadFileToolOutput;
   read_skill_resource: ReadSkillResourceToolOutput;
+  edit_file: EditFileToolOutput;
   write_file: WriteFileToolOutput;
   delegate_task: DelegateTaskToolOutput;
 }

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -439,6 +439,54 @@ const summarizeToolInput = async (
           ? { maxBytes: input.maxBytes }
           : {}),
       };
+    case "edit_file": {
+      let oldTextBytes = 0;
+      let newTextBytes = 0;
+      const oldTextDigests: string[] = [];
+      const newTextDigests: string[] = [];
+      const edits = Array.isArray(input.edits) ? input.edits : [];
+      for (const edit of edits) {
+        if (
+          typeof edit === "object" && edit !== null &&
+          "oldText" in edit &&
+          typeof edit.oldText === "string"
+        ) {
+          const summary = await summarizeSensitiveText(edit.oldText);
+          oldTextBytes += summary.bytes;
+          oldTextDigests.push(summary.digest);
+        }
+        if (
+          typeof edit === "object" && edit !== null &&
+          "newText" in edit &&
+          typeof edit.newText === "string"
+        ) {
+          const summary = await summarizeSensitiveText(edit.newText);
+          newTextBytes += summary.bytes;
+          newTextDigests.push(summary.digest);
+        }
+      }
+      return {
+        type: "cf-harness.tool-input-summary",
+        toolId,
+        ...(typeof input.path === "string" ? { path: input.path } : {}),
+        ...(edits.length > 0 ? { editCount: edits.length } : {}),
+        ...(typeof input.expectedDigest === "string"
+          ? { expectedDigest: input.expectedDigest }
+          : {}),
+        ...(oldTextDigests.length > 0
+          ? {
+            oldTextBytes,
+            oldTextDigest: await digestJsonValue(oldTextDigests),
+          }
+          : {}),
+        ...(newTextDigests.length > 0
+          ? {
+            newTextBytes,
+            newTextDigest: await digestJsonValue(newTextDigests),
+          }
+          : {}),
+      };
+    }
     case "write_file": {
       const contentSummary = typeof input.content === "string"
         ? await summarizeSensitiveText(input.content)

--- a/packages/cf-harness/src/tools/edit-file.ts
+++ b/packages/cf-harness/src/tools/edit-file.ts
@@ -54,7 +54,23 @@ interface ApplyEditsResult {
   replacements: number;
 }
 
+interface ChangedLineSpan {
+  oldStart: number;
+  oldEnd: number;
+  newStart: number;
+  newEnd: number;
+}
+
+interface UnifiedDiffHunk {
+  oldStart: number;
+  oldEnd: number;
+  newStart: number;
+  newEnd: number;
+  spans: ChangedLineSpan[];
+}
+
 const textEncoder = new TextEncoder();
+const MAX_UNIFIED_DIFF_LINES = 400;
 
 const bytesForText = (text: string): Uint8Array => textEncoder.encode(text);
 
@@ -196,7 +212,201 @@ const renderDiffLine = (prefix: string, line: string): string =>
   `${prefix}${line.endsWith("\n") ? line.slice(0, -1) : line}`;
 
 const rangeHeader = (startZeroBased: number, count: number): string =>
-  `${startZeroBased + 1},${count}`;
+  count === 0 ? `${startZeroBased},0` : `${startZeroBased + 1},${count}`;
+
+const findUniqueCommonAnchor = (
+  oldLines: readonly string[],
+  newLines: readonly string[],
+  oldStart: number,
+  oldEnd: number,
+  newStart: number,
+  newEnd: number,
+): { oldIndex: number; newIndex: number } | undefined => {
+  const oldOccurrences = new Map<string, { count: number; index: number }>();
+  const newOccurrences = new Map<string, { count: number; index: number }>();
+
+  for (let index = oldStart; index < oldEnd; index += 1) {
+    const line = oldLines[index]!;
+    const occurrence = oldOccurrences.get(line);
+    oldOccurrences.set(line, {
+      count: (occurrence?.count ?? 0) + 1,
+      index,
+    });
+  }
+  for (let index = newStart; index < newEnd; index += 1) {
+    const line = newLines[index]!;
+    const occurrence = newOccurrences.get(line);
+    newOccurrences.set(line, {
+      count: (occurrence?.count ?? 0) + 1,
+      index,
+    });
+  }
+
+  const oldMidpoint = (oldStart + oldEnd) / 2;
+  const newMidpoint = (newStart + newEnd) / 2;
+  let best:
+    | { oldIndex: number; newIndex: number; score: number }
+    | undefined;
+  for (const [line, oldOccurrence] of oldOccurrences) {
+    const newOccurrence = newOccurrences.get(line);
+    if (
+      oldOccurrence.count !== 1 ||
+      newOccurrence === undefined ||
+      newOccurrence.count !== 1
+    ) {
+      continue;
+    }
+    const score = Math.abs(oldOccurrence.index - oldMidpoint) +
+      Math.abs(newOccurrence.index - newMidpoint);
+    if (best === undefined || score < best.score) {
+      best = {
+        oldIndex: oldOccurrence.index,
+        newIndex: newOccurrence.index,
+        score,
+      };
+    }
+  }
+  return best;
+};
+
+const collectChangedLineSpans = (
+  oldLines: readonly string[],
+  newLines: readonly string[],
+  oldStart = 0,
+  oldEnd = oldLines.length,
+  newStart = 0,
+  newEnd = newLines.length,
+): ChangedLineSpan[] => {
+  while (
+    oldStart < oldEnd &&
+    newStart < newEnd &&
+    oldLines[oldStart] === newLines[newStart]
+  ) {
+    oldStart += 1;
+    newStart += 1;
+  }
+  while (
+    oldEnd > oldStart &&
+    newEnd > newStart &&
+    oldLines[oldEnd - 1] === newLines[newEnd - 1]
+  ) {
+    oldEnd -= 1;
+    newEnd -= 1;
+  }
+  if (oldStart === oldEnd && newStart === newEnd) {
+    return [];
+  }
+
+  const anchor = findUniqueCommonAnchor(
+    oldLines,
+    newLines,
+    oldStart,
+    oldEnd,
+    newStart,
+    newEnd,
+  );
+  if (anchor === undefined) {
+    return [{ oldStart, oldEnd, newStart, newEnd }];
+  }
+
+  return [
+    ...collectChangedLineSpans(
+      oldLines,
+      newLines,
+      oldStart,
+      anchor.oldIndex,
+      newStart,
+      anchor.newIndex,
+    ),
+    ...collectChangedLineSpans(
+      oldLines,
+      newLines,
+      anchor.oldIndex + 1,
+      oldEnd,
+      anchor.newIndex + 1,
+      newEnd,
+    ),
+  ];
+};
+
+const createUnifiedDiffHunks = (
+  spans: readonly ChangedLineSpan[],
+  oldLineCount: number,
+  newLineCount: number,
+  contextLineCount: number,
+): UnifiedDiffHunk[] => {
+  const hunks: UnifiedDiffHunk[] = [];
+  for (const span of spans) {
+    const hunk: UnifiedDiffHunk = {
+      oldStart: Math.max(0, span.oldStart - contextLineCount),
+      oldEnd: Math.min(oldLineCount, span.oldEnd + contextLineCount),
+      newStart: Math.max(0, span.newStart - contextLineCount),
+      newEnd: Math.min(newLineCount, span.newEnd + contextLineCount),
+      spans: [span],
+    };
+    const previous = hunks.at(-1);
+    if (
+      previous !== undefined &&
+      hunk.oldStart <= previous.oldEnd &&
+      hunk.newStart <= previous.newEnd
+    ) {
+      previous.oldEnd = Math.max(previous.oldEnd, hunk.oldEnd);
+      previous.newEnd = Math.max(previous.newEnd, hunk.newEnd);
+      previous.spans.push(span);
+    } else {
+      hunks.push(hunk);
+    }
+  }
+  return hunks;
+};
+
+const renderUnifiedDiffHunk = (
+  lines: string[],
+  oldLines: readonly string[],
+  newLines: readonly string[],
+  hunk: UnifiedDiffHunk,
+): void => {
+  lines.push(
+    `@@ -${rangeHeader(hunk.oldStart, hunk.oldEnd - hunk.oldStart)} +${
+      rangeHeader(hunk.newStart, hunk.newEnd - hunk.newStart)
+    } @@`,
+  );
+
+  let oldCursor = hunk.oldStart;
+  let newCursor = hunk.newStart;
+  for (const span of hunk.spans) {
+    while (oldCursor < span.oldStart && newCursor < span.newStart) {
+      lines.push(renderDiffLine(" ", oldLines[oldCursor]!));
+      oldCursor += 1;
+      newCursor += 1;
+    }
+    for (let index = span.oldStart; index < span.oldEnd; index += 1) {
+      lines.push(renderDiffLine("-", oldLines[index]!));
+    }
+    for (let index = span.newStart; index < span.newEnd; index += 1) {
+      lines.push(renderDiffLine("+", newLines[index]!));
+    }
+    oldCursor = span.oldEnd;
+    newCursor = span.newEnd;
+  }
+  while (oldCursor < hunk.oldEnd && newCursor < hunk.newEnd) {
+    lines.push(renderDiffLine(" ", oldLines[oldCursor]!));
+    oldCursor += 1;
+    newCursor += 1;
+  }
+};
+
+const truncateUnifiedDiffLines = (lines: readonly string[]): string[] => {
+  if (lines.length <= MAX_UNIFIED_DIFF_LINES) {
+    return [...lines];
+  }
+  const retainedLineCount = MAX_UNIFIED_DIFF_LINES - 1;
+  const omittedLineCount = lines.length - retainedLineCount;
+  return [
+    ...lines.slice(0, retainedLineCount),
+    `[diff truncated: ${omittedLineCount} additional line(s) omitted]`,
+  ];
+};
 
 const createUnifiedDiff = (
   path: string,
@@ -209,55 +419,21 @@ const createUnifiedDiff = (
   }
   const oldLines = splitLines(oldContent);
   const newLines = splitLines(newContent);
-  let prefix = 0;
-  while (
-    prefix < oldLines.length &&
-    prefix < newLines.length &&
-    oldLines[prefix] === newLines[prefix]
-  ) {
-    prefix += 1;
-  }
-  let oldSuffix = oldLines.length;
-  let newSuffix = newLines.length;
-  while (
-    oldSuffix > prefix &&
-    newSuffix > prefix &&
-    oldLines[oldSuffix - 1] === newLines[newSuffix - 1]
-  ) {
-    oldSuffix -= 1;
-    newSuffix -= 1;
-  }
-
-  const oldHunkStart = Math.max(0, prefix - contextLineCount);
-  const newHunkStart = Math.max(0, prefix - contextLineCount);
-  const oldHunkEnd = Math.min(
+  const spans = collectChangedLineSpans(oldLines, newLines);
+  const hunks = createUnifiedDiffHunks(
+    spans,
     oldLines.length,
-    oldSuffix + contextLineCount,
-  );
-  const newHunkEnd = Math.min(
     newLines.length,
-    newSuffix + contextLineCount,
+    contextLineCount,
   );
   const lines = [
     `--- ${path}`,
     `+++ ${path}`,
-    `@@ -${rangeHeader(oldHunkStart, oldHunkEnd - oldHunkStart)} +${
-      rangeHeader(newHunkStart, newHunkEnd - newHunkStart)
-    } @@`,
   ];
-  for (let index = oldHunkStart; index < prefix; index += 1) {
-    lines.push(renderDiffLine(" ", oldLines[index]!));
+  for (const hunk of hunks) {
+    renderUnifiedDiffHunk(lines, oldLines, newLines, hunk);
   }
-  for (let index = prefix; index < oldSuffix; index += 1) {
-    lines.push(renderDiffLine("-", oldLines[index]!));
-  }
-  for (let index = prefix; index < newSuffix; index += 1) {
-    lines.push(renderDiffLine("+", newLines[index]!));
-  }
-  for (let index = oldSuffix; index < oldHunkEnd; index += 1) {
-    lines.push(renderDiffLine(" ", oldLines[index]!));
-  }
-  return `${lines.join("\n")}\n`;
+  return `${truncateUnifiedDiffLines(lines).join("\n")}\n`;
 };
 
 const READ_FILE_COMMAND = [

--- a/packages/cf-harness/src/tools/edit-file.ts
+++ b/packages/cf-harness/src/tools/edit-file.ts
@@ -1,0 +1,488 @@
+import type { JSONSchema } from "@commonfabric/api";
+import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
+import type { HarnessToolDefinition } from "./types.ts";
+import {
+  classifyFileToolShellFailure,
+  classifyPathResolutionError,
+  createStructuredFileToolErrorOutput,
+  detailFromShellFailure,
+  detailFromUnknownError,
+  type StructuredFileToolErrorOutput,
+  structuredFileToolErrorOutputSchema,
+} from "./file-errors.ts";
+import {
+  isResolvedPathInsideArtifactRoot,
+  RESERVED_ARTIFACT_PATH_DETAIL,
+} from "./reserved-artifacts.ts";
+
+export interface EditFileTextEdit {
+  oldText: string;
+  newText: string;
+  replaceAll?: boolean;
+  expectedReplacements?: number;
+}
+
+export interface EditFileToolInput {
+  path: string;
+  edits: EditFileTextEdit[];
+  expectedDigest?: string;
+}
+
+export interface EditFileToolSuccessOutput {
+  outputId: string;
+  path: string;
+  editsApplied: number;
+  replacements: number;
+  oldDigest: string;
+  newDigest: string;
+  oldSizeBytes: number;
+  newSizeBytes: number;
+  diff: string;
+}
+
+export type EditFileToolOutput =
+  | EditFileToolSuccessOutput
+  | StructuredFileToolErrorOutput;
+
+interface AppliedEditResult {
+  content: string;
+  replacements: number;
+}
+
+interface ApplyEditsResult {
+  content: string;
+  replacements: number;
+}
+
+const textEncoder = new TextEncoder();
+
+const bytesForText = (text: string): Uint8Array => textEncoder.encode(text);
+
+const sha256Digest = async (input: Uint8Array): Promise<string> => {
+  const digestInput = input.buffer.slice(
+    input.byteOffset,
+    input.byteOffset + input.byteLength,
+  ) as ArrayBuffer;
+  const digest = await crypto.subtle.digest("SHA-256", digestInput);
+  return `sha256:${
+    [...new Uint8Array(digest)]
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("")
+  }`;
+};
+
+const summarizeText = async (
+  text: string,
+): Promise<{ bytes: number; digest: string }> => {
+  const bytes = bytesForText(text);
+  return {
+    bytes: bytes.byteLength,
+    digest: await sha256Digest(bytes),
+  };
+};
+
+const findOccurrences = (content: string, needle: string): number[] => {
+  const positions: number[] = [];
+  let offset = 0;
+  while (offset <= content.length) {
+    const index = content.indexOf(needle, offset);
+    if (index === -1) {
+      break;
+    }
+    positions.push(index);
+    offset = index + needle.length;
+  }
+  return positions;
+};
+
+const validateExpectedReplacements = (
+  edit: EditFileTextEdit,
+  editIndex: number,
+): number | undefined => {
+  if (edit.expectedReplacements === undefined) {
+    return undefined;
+  }
+  if (
+    !Number.isSafeInteger(edit.expectedReplacements) ||
+    edit.expectedReplacements <= 0
+  ) {
+    throw new Error(
+      `edit ${editIndex + 1} expectedReplacements must be a positive integer`,
+    );
+  }
+  if (edit.expectedReplacements !== 1 && edit.replaceAll !== true) {
+    throw new Error(
+      `edit ${
+        editIndex + 1
+      } expectedReplacements greater than 1 requires replaceAll=true`,
+    );
+  }
+  return edit.expectedReplacements;
+};
+
+const applySingleEdit = (
+  content: string,
+  edit: EditFileTextEdit,
+  editIndex: number,
+): AppliedEditResult => {
+  if (edit.oldText.length === 0) {
+    throw new Error(`edit ${editIndex + 1} oldText must be non-empty`);
+  }
+  const expectedReplacements = validateExpectedReplacements(edit, editIndex);
+  const occurrences = findOccurrences(content, edit.oldText);
+  if (occurrences.length === 0) {
+    throw new Error(`edit ${editIndex + 1} oldText was not found`);
+  }
+  if (
+    expectedReplacements !== undefined &&
+    occurrences.length !== expectedReplacements
+  ) {
+    throw new Error(
+      `edit ${
+        editIndex + 1
+      } expected ${expectedReplacements} replacement(s) but found ${occurrences.length}`,
+    );
+  }
+  if (edit.replaceAll === true) {
+    return {
+      content: content.split(edit.oldText).join(edit.newText),
+      replacements: occurrences.length,
+    };
+  }
+  if (occurrences.length !== 1) {
+    throw new Error(
+      `edit ${
+        editIndex + 1
+      } oldText matched ${occurrences.length} times; provide more surrounding context or set replaceAll=true`,
+    );
+  }
+  const index = occurrences[0]!;
+  return {
+    content: content.slice(0, index) + edit.newText +
+      content.slice(index + edit.oldText.length),
+    replacements: 1,
+  };
+};
+
+const applyEdits = (
+  content: string,
+  edits: readonly EditFileTextEdit[],
+): ApplyEditsResult => {
+  if (edits.length === 0) {
+    throw new Error("edit_file edits must include at least one edit");
+  }
+  let nextContent = content;
+  let replacements = 0;
+  for (const [index, edit] of edits.entries()) {
+    const result = applySingleEdit(nextContent, edit, index);
+    nextContent = result.content;
+    replacements += result.replacements;
+  }
+  return { content: nextContent, replacements };
+};
+
+const splitLines = (text: string): string[] => {
+  if (text.length === 0) {
+    return [];
+  }
+  const parts = text.split("\n");
+  const lines = parts.map((line, index) =>
+    index < parts.length - 1 ? `${line}\n` : line
+  );
+  return lines.at(-1) === "" ? lines.slice(0, -1) : lines;
+};
+
+const renderDiffLine = (prefix: string, line: string): string =>
+  `${prefix}${line.endsWith("\n") ? line.slice(0, -1) : line}`;
+
+const rangeHeader = (startZeroBased: number, count: number): string =>
+  `${startZeroBased + 1},${count}`;
+
+const createUnifiedDiff = (
+  path: string,
+  oldContent: string,
+  newContent: string,
+  contextLineCount = 3,
+): string => {
+  if (oldContent === newContent) {
+    return "";
+  }
+  const oldLines = splitLines(oldContent);
+  const newLines = splitLines(newContent);
+  let prefix = 0;
+  while (
+    prefix < oldLines.length &&
+    prefix < newLines.length &&
+    oldLines[prefix] === newLines[prefix]
+  ) {
+    prefix += 1;
+  }
+  let oldSuffix = oldLines.length;
+  let newSuffix = newLines.length;
+  while (
+    oldSuffix > prefix &&
+    newSuffix > prefix &&
+    oldLines[oldSuffix - 1] === newLines[newSuffix - 1]
+  ) {
+    oldSuffix -= 1;
+    newSuffix -= 1;
+  }
+
+  const oldHunkStart = Math.max(0, prefix - contextLineCount);
+  const newHunkStart = Math.max(0, prefix - contextLineCount);
+  const oldHunkEnd = Math.min(
+    oldLines.length,
+    oldSuffix + contextLineCount,
+  );
+  const newHunkEnd = Math.min(
+    newLines.length,
+    newSuffix + contextLineCount,
+  );
+  const lines = [
+    `--- ${path}`,
+    `+++ ${path}`,
+    `@@ -${rangeHeader(oldHunkStart, oldHunkEnd - oldHunkStart)} +${
+      rangeHeader(newHunkStart, newHunkEnd - newHunkStart)
+    } @@`,
+  ];
+  for (let index = oldHunkStart; index < prefix; index += 1) {
+    lines.push(renderDiffLine(" ", oldLines[index]!));
+  }
+  for (let index = prefix; index < oldSuffix; index += 1) {
+    lines.push(renderDiffLine("-", oldLines[index]!));
+  }
+  for (let index = prefix; index < newSuffix; index += 1) {
+    lines.push(renderDiffLine("+", newLines[index]!));
+  }
+  for (let index = oldSuffix; index < oldHunkEnd; index += 1) {
+    lines.push(renderDiffLine(" ", oldLines[index]!));
+  }
+  return `${lines.join("\n")}\n`;
+};
+
+const READ_FILE_COMMAND = [
+  "set -eu",
+  'if [ ! -e "$1" ]; then',
+  '  echo "file not found: $1" >&2',
+  "  exit 10",
+  "fi",
+  'if [ ! -f "$1" ]; then',
+  '  echo "not a file: $1" >&2',
+  "  exit 11",
+  "fi",
+  'exec cat "$1"',
+].join("\n");
+
+const WRITE_FILE_COMMAND = [
+  "set -eu",
+  'path="$1"',
+  'if [ ! -e "$path" ]; then',
+  '  echo "file not found: $path" >&2',
+  "  exit 10",
+  "fi",
+  'if [ ! -f "$path" ]; then',
+  '  echo "not a file: $path" >&2',
+  "  exit 11",
+  "fi",
+  'cat > "$path"',
+].join("\n");
+
+export const editFileToolDescriptor: HarnessToolDescriptor = {
+  toolId: "edit_file",
+  title: "Edit File",
+  description:
+    "Apply exact string-replacement edits to an existing file in the target VM. Use this for targeted changes after reading the file; use write_file for new files or full rewrites.",
+  effectClass: "write",
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: { type: "string" },
+      edits: {
+        type: "array",
+        minItems: 1,
+        items: {
+          type: "object",
+          properties: {
+            oldText: { type: "string", minLength: 1 },
+            newText: { type: "string" },
+            replaceAll: { type: "boolean" },
+            expectedReplacements: { type: "integer", minimum: 1 },
+          },
+          required: ["oldText", "newText"],
+          additionalProperties: false,
+        },
+      },
+      expectedDigest: { type: "string" },
+    },
+    required: ["path", "edits"],
+    additionalProperties: false,
+  } satisfies JSONSchema,
+  outputSchema: {
+    oneOf: [{
+      type: "object",
+      properties: {
+        outputId: { type: "string" },
+        path: { type: "string" },
+        editsApplied: { type: "integer", minimum: 0 },
+        replacements: { type: "integer", minimum: 0 },
+        oldDigest: { type: "string" },
+        newDigest: { type: "string" },
+        oldSizeBytes: { type: "integer", minimum: 0 },
+        newSizeBytes: { type: "integer", minimum: 0 },
+        diff: { type: "string" },
+      },
+      required: [
+        "outputId",
+        "path",
+        "editsApplied",
+        "replacements",
+        "oldDigest",
+        "newDigest",
+        "oldSizeBytes",
+        "newSizeBytes",
+        "diff",
+      ],
+      additionalProperties: false,
+    }, structuredFileToolErrorOutputSchema],
+  } satisfies JSONSchema,
+  tags: ["file", "write", "vm", "edit"],
+};
+
+export const editFileTool: HarnessToolDefinition<
+  EditFileToolInput,
+  EditFileToolOutput
+> = {
+  descriptor: editFileToolDescriptor,
+  async invoke(context, input) {
+    let resolvedPath: string;
+    try {
+      resolvedPath = context.resolvePath(input.path);
+    } catch (error) {
+      return createStructuredFileToolErrorOutput(context, "edit_file", {
+        path: input.path,
+        code: classifyPathResolutionError(error),
+        detail: detailFromUnknownError(error),
+      });
+    }
+    if (await isResolvedPathInsideArtifactRoot(context, resolvedPath)) {
+      return createStructuredFileToolErrorOutput(context, "edit_file", {
+        path: resolvedPath,
+        code: "permission_denied",
+        detail: RESERVED_ARTIFACT_PATH_DETAIL,
+      });
+    }
+
+    const readArgs = [resolvedPath];
+    const readResult = await context.sandbox.runShell({
+      command: READ_FILE_COMMAND,
+      args: readArgs,
+      cwd: context.currentDir,
+      cfcInvocationContext: await context.createCfcInvocationContext({
+        toolId: "edit_file",
+        operation: "shell",
+        cwd: context.currentDir,
+        command: READ_FILE_COMMAND,
+        args: readArgs,
+      }),
+    });
+    if (readResult.exitCode !== 0) {
+      return createStructuredFileToolErrorOutput(context, "edit_file", {
+        path: resolvedPath,
+        code: classifyFileToolShellFailure(readResult),
+        detail: detailFromShellFailure(readResult),
+        exitCode: readResult.exitCode,
+      });
+    }
+
+    const oldSummary = await summarizeText(readResult.stdout);
+    if (
+      input.expectedDigest !== undefined &&
+      input.expectedDigest !== oldSummary.digest
+    ) {
+      return createStructuredFileToolErrorOutput(context, "edit_file", {
+        path: resolvedPath,
+        code: "edit_conflict",
+        detail:
+          `expected digest ${input.expectedDigest} but current digest is ${oldSummary.digest}`,
+      });
+    }
+
+    let edited: ApplyEditsResult;
+    try {
+      edited = applyEdits(readResult.stdout, input.edits);
+    } catch (error) {
+      return createStructuredFileToolErrorOutput(context, "edit_file", {
+        path: resolvedPath,
+        code: "edit_conflict",
+        detail: detailFromUnknownError(error),
+      });
+    }
+
+    const newSummary = await summarizeText(edited.content);
+    const writeArgs = [resolvedPath];
+    const writeResult = await context.sandbox.runShell({
+      command: WRITE_FILE_COMMAND,
+      args: writeArgs,
+      cwd: context.currentDir,
+      stdinText: edited.content,
+      cfcInvocationContext: await context.createCfcInvocationContext({
+        toolId: "edit_file",
+        operation: "shell",
+        cwd: context.currentDir,
+        command: WRITE_FILE_COMMAND,
+        args: writeArgs,
+        stdinText: edited.content,
+      }),
+    });
+    if (writeResult.exitCode !== 0) {
+      return createStructuredFileToolErrorOutput(context, "edit_file", {
+        path: resolvedPath,
+        code: classifyFileToolShellFailure(writeResult),
+        detail: detailFromShellFailure(writeResult),
+        exitCode: writeResult.exitCode,
+      });
+    }
+
+    const verifyResult = await context.sandbox.runShell({
+      command: READ_FILE_COMMAND,
+      args: readArgs,
+      cwd: context.currentDir,
+      cfcInvocationContext: await context.createCfcInvocationContext({
+        toolId: "edit_file",
+        operation: "shell",
+        cwd: context.currentDir,
+        command: READ_FILE_COMMAND,
+        args: readArgs,
+      }),
+    });
+    if (verifyResult.exitCode !== 0) {
+      return createStructuredFileToolErrorOutput(context, "edit_file", {
+        path: resolvedPath,
+        code: classifyFileToolShellFailure(verifyResult),
+        detail: detailFromShellFailure(verifyResult),
+        exitCode: verifyResult.exitCode,
+      });
+    }
+    if (verifyResult.stdout !== edited.content) {
+      const observedSummary = await summarizeText(verifyResult.stdout);
+      return createStructuredFileToolErrorOutput(context, "edit_file", {
+        path: resolvedPath,
+        code: "edit_conflict",
+        detail:
+          `post-write verification failed: expected ${newSummary.digest} but observed ${observedSummary.digest}`,
+      });
+    }
+
+    return {
+      outputId: context.nextOutputId("edit_file"),
+      path: resolvedPath,
+      editsApplied: input.edits.length,
+      replacements: edited.replacements,
+      oldDigest: oldSummary.digest,
+      newDigest: newSummary.digest,
+      oldSizeBytes: oldSummary.bytes,
+      newSizeBytes: newSummary.bytes,
+      diff: createUnifiedDiff(resolvedPath, readResult.stdout, edited.content),
+    };
+  },
+};

--- a/packages/cf-harness/src/tools/file-errors.ts
+++ b/packages/cf-harness/src/tools/file-errors.ts
@@ -3,6 +3,7 @@ import type { HarnessToolContext } from "./types.ts";
 
 export const STRUCTURED_FILE_TOOL_ERROR_CODES = [
   "file_not_found",
+  "edit_conflict",
   "not_a_file",
   "permission_denied",
   "path_outside_workspace",
@@ -81,6 +82,10 @@ const messageForFileToolError = (
   switch (code) {
     case "file_not_found":
       return `file not found: ${path}`;
+    case "edit_conflict":
+      return detail !== undefined && detail !== ""
+        ? `edit conflict for ${path}: ${detail}`
+        : `edit conflict for ${path}`;
     case "not_a_file":
       return `not a file: ${path}`;
     case "permission_denied":
@@ -96,7 +101,7 @@ const messageForFileToolError = (
 
 export const createStructuredFileToolErrorOutput = (
   context: HarnessToolContext,
-  toolId: "read_file" | "write_file",
+  toolId: "read_file" | "write_file" | "edit_file",
   options: {
     path: string;
     code: StructuredFileToolErrorCode;

--- a/packages/cf-harness/src/tools/registry.ts
+++ b/packages/cf-harness/src/tools/registry.ts
@@ -2,6 +2,7 @@ import type { BuiltinToolId } from "../contracts/tool-descriptor.ts";
 import { bashTool } from "./bash.ts";
 import { bashNoSandboxTool } from "./bash-no-sandbox.ts";
 import { delegateTaskTool } from "./delegate-task.ts";
+import { editFileTool } from "./edit-file.ts";
 import { readFileTool } from "./read-file.ts";
 import { readSkillResourceTool } from "./read-skill-resource.ts";
 import { writeFileTool } from "./write-file.ts";
@@ -12,6 +13,7 @@ export const BUILTIN_TOOLS = [
   bashNoSandboxTool,
   readFileTool,
   readSkillResourceTool,
+  editFileTool,
   writeFileTool,
   delegateTaskTool,
 ] as const;

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -431,6 +431,7 @@ Deno.test({
           "bash",
           "read_file",
           "read_skill_resource",
+          "edit_file",
           "write_file",
           "delegate_task",
         ],
@@ -440,7 +441,7 @@ Deno.test({
       ]);
       assertEquals(
         persistedPolicySnapshot.subagents.profileConfigs[0].allowedToolIds,
-        ["bash", "read_file", "write_file"],
+        ["bash", "read_file", "edit_file", "write_file"],
       );
       assertEquals(
         persistedPolicySnapshot.substrate?.sandbox?.kind,
@@ -565,7 +566,7 @@ Deno.test({
         {
           model: "gpt-5.4",
           messageCount: 1,
-          toolCount: 5,
+          toolCount: 6,
         },
       );
       assert(
@@ -772,6 +773,7 @@ Deno.test({
       assertEquals(subagentRun.manifest.allowedToolIds, [
         "bash",
         "read_file",
+        "edit_file",
         "write_file",
       ]);
       assertEquals(subagentRun.manifest.hostToolIds, []);

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -672,7 +672,7 @@ Deno.test("parseCfHarnessCliArgs rejects bash-no-sandbox as a parent allow-tool"
         },
       ),
     Error,
-    "allowed tools must be one or more of bash, read_file, read_skill_resource, write_file, delegate_task",
+    "allowed tools must be one or more of bash, read_file, read_skill_resource, edit_file, write_file, delegate_task",
   );
 });
 
@@ -694,7 +694,7 @@ Deno.test("parseCfHarnessCliArgs rejects unknown allowed tools before resolving 
         },
       ),
     Error,
-    "allowed tools must be one or more of bash, read_file, read_skill_resource, write_file, delegate_task",
+    "allowed tools must be one or more of bash, read_file, read_skill_resource, edit_file, write_file, delegate_task",
   );
 });
 

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -356,7 +356,14 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
 
   assertEquals(
     firstRequest.tools.map((tool) => tool.function.name),
-    ["bash", "read_file", "read_skill_resource", "write_file", "delegate_task"],
+    [
+      "bash",
+      "read_file",
+      "read_skill_resource",
+      "edit_file",
+      "write_file",
+      "delegate_task",
+    ],
   );
   assertEquals(
     secondRequest.messages.at(-1),
@@ -704,11 +711,18 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
   assertEquals(result.finalAssistantText, "Parent received the child summary.");
   assertEquals(
     requestBodies[0].tools.map((tool) => tool.function.name),
-    ["bash", "read_file", "read_skill_resource", "write_file", "delegate_task"],
+    [
+      "bash",
+      "read_file",
+      "read_skill_resource",
+      "edit_file",
+      "write_file",
+      "delegate_task",
+    ],
   );
   assertEquals(
     requestBodies[1].tools.map((tool) => tool.function.name),
-    ["bash", "read_file", "write_file"],
+    ["bash", "read_file", "edit_file", "write_file"],
   );
   assertEquals(
     requestBodies[1].messages.map((message) => message.role),
@@ -774,6 +788,7 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
   assertEquals(output.subagent.manifest.allowedToolIds, [
     "bash",
     "read_file",
+    "edit_file",
     "write_file",
   ]);
   assertEquals(output.subagent.manifest.hostToolIds, []);
@@ -1327,7 +1342,7 @@ Deno.test("CfHarnessPromptLoop lets an explicit subagent profile expand child to
   );
   assertEquals(
     requestBodies[1].tools.map((tool) => tool.function.name),
-    ["bash", "read_file", "write_file"],
+    ["bash", "read_file", "edit_file", "write_file"],
   );
   assertEquals(result.runState.cfcPolicySnapshot?.parentTools, {
     allowance: "restricted",
@@ -1354,6 +1369,7 @@ Deno.test("CfHarnessPromptLoop lets an explicit subagent profile expand child to
   assertEquals(output.subagent.manifest.allowedToolIds, [
     "bash",
     "read_file",
+    "edit_file",
     "write_file",
   ]);
   assertEquals(output.subagent.manifest.hostToolIds, []);
@@ -1422,7 +1438,14 @@ Deno.test("CfHarnessPromptLoop keeps bash-no-sandbox unavailable to the parent b
 
   assertEquals(
     firstRequest.tools.map((tool) => tool.function.name),
-    ["bash", "read_file", "read_skill_resource", "write_file", "delegate_task"],
+    [
+      "bash",
+      "read_file",
+      "read_skill_resource",
+      "edit_file",
+      "write_file",
+      "delegate_task",
+    ],
   );
   assertEquals(denied.detail, "bash-no-sandbox is not allowed in this run");
   assertEquals(result.runState.toolOutputs, []);
@@ -2038,7 +2061,7 @@ Deno.test("CfHarnessPromptLoop reports child run failures through delegate_task 
   );
   assertEquals(
     requestBodies[1].tools.map((tool) => tool.function.name),
-    ["bash", "read_file", "write_file"],
+    ["bash", "read_file", "edit_file", "write_file"],
   );
   const toolMessage = result.transcript.at(-2);
   if (toolMessage?.role !== "tool") {
@@ -2101,7 +2124,7 @@ Deno.test("CfHarnessPromptLoop continues subagent ids from retained run state", 
       depth: 1,
       cfcEnforcementMode: "disabled",
       model: "gpt-5.4",
-      allowedToolIds: ["bash", "read_file", "write_file"],
+      allowedToolIds: ["bash", "read_file", "edit_file", "write_file"],
       hostToolIds: [],
       maxModelTurns: 8,
       returnPolicy: {

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import { normalize } from "@std/path/posix";
 import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
@@ -11,6 +11,7 @@ import { createToolOutputId } from "../src/contracts/tool-result.ts";
 import { discoverHarnessSkills } from "../src/skills/registry.ts";
 import { bashTool } from "../src/tools/bash.ts";
 import { bashNoSandboxTool } from "../src/tools/bash-no-sandbox.ts";
+import { editFileTool } from "../src/tools/edit-file.ts";
 import { readFileTool } from "../src/tools/read-file.ts";
 import { RESERVED_ARTIFACT_PATH_DETAIL } from "../src/tools/reserved-artifacts.ts";
 import { readSkillResourceTool } from "../src/tools/read-skill-resource.ts";
@@ -228,6 +229,20 @@ const observedCfcResult = (stdout: string): CfcSandboxResult => ({
     value: 0,
   },
 });
+
+const digestText = async (text: string): Promise<string> => {
+  const bytes = new TextEncoder().encode(text);
+  const digestInput = bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
+  const digest = await crypto.subtle.digest("SHA-256", digestInput);
+  return `sha256:${
+    [...new Uint8Array(digest)]
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("")
+  }`;
+};
 
 Deno.test("bash tool executes the command through the sandbox shell runtime", async () => {
   const sandbox = new FakeSandboxRuntime([{
@@ -1038,6 +1053,135 @@ Deno.test({
       await Deno.remove(root, { recursive: true });
     }
   },
+});
+
+Deno.test("edit_file applies exact replacements and returns a unified diff", async () => {
+  const original = "one\ntwo\nthree\n";
+  const edited = "one\nTWO\nthree\n";
+  const sandbox = new FakeSandboxRuntime([
+    { stdout: original, stderr: "", exitCode: 0 },
+    { stdout: "", stderr: "", exitCode: 0 },
+    { stdout: edited, stderr: "", exitCode: 0 },
+  ]);
+
+  const output = await editFileTool.invoke(createContext(sandbox), {
+    path: "notes/log.txt",
+    edits: [{ oldText: "two\n", newText: "TWO\n" }],
+  });
+
+  assertEquals(output, {
+    outputId: "run-1:edit_file:1",
+    path: "/workspace/notes/log.txt",
+    editsApplied: 1,
+    replacements: 1,
+    oldDigest: await digestText(original),
+    newDigest: await digestText(edited),
+    oldSizeBytes: original.length,
+    newSizeBytes: edited.length,
+    diff: [
+      "--- /workspace/notes/log.txt",
+      "+++ /workspace/notes/log.txt",
+      "@@ -1,3 +1,3 @@",
+      " one",
+      "-two",
+      "+TWO",
+      " three",
+      "",
+    ].join("\n"),
+  });
+  const calls = stripCfcInvocationContexts(sandbox.calls);
+  assertEquals(calls.map((call) => call.type), [
+    "runShell",
+    "runShell",
+    "runShell",
+  ]);
+  if (calls[1]?.type !== "runShell") {
+    throw new Error("expected edit_file write shell call");
+  }
+  assertEquals(calls[1].request.args, ["/workspace/notes/log.txt"]);
+  assertEquals(calls[1].request.cwd, "/workspace");
+  assertEquals(calls[1].request.stdinText, edited);
+  assertEquals(
+    sandbox.calls[1]?.request.cfcInvocationContext?.toolId,
+    "edit_file",
+  );
+  assertEquals(
+    sandbox.calls[1]?.request.cfcInvocationContext?.inputs.stdin?.bytes,
+    edited.length,
+  );
+});
+
+Deno.test("edit_file applies replaceAll edits with expected replacement counts", async () => {
+  const original = "red blue red\n";
+  const edited = "green blue green\n";
+  const sandbox = new FakeSandboxRuntime([
+    { stdout: original, stderr: "", exitCode: 0 },
+    { stdout: "", stderr: "", exitCode: 0 },
+    { stdout: edited, stderr: "", exitCode: 0 },
+  ]);
+
+  const output = await editFileTool.invoke(createContext(sandbox), {
+    path: "notes/colors.txt",
+    edits: [{
+      oldText: "red",
+      newText: "green",
+      replaceAll: true,
+      expectedReplacements: 2,
+    }],
+    expectedDigest: await digestText(original),
+  });
+
+  if ("ok" in output) {
+    throw new Error("expected successful edit_file output");
+  }
+  assertEquals(output.path, "/workspace/notes/colors.txt");
+  assertEquals(output.replacements, 2);
+  assertEquals(output.editsApplied, 1);
+});
+
+Deno.test("edit_file rejects ambiguous single replacements without writing", async () => {
+  const sandbox = new FakeSandboxRuntime([{
+    stdout: "name: alpha\nname: beta\n",
+    stderr: "",
+    exitCode: 0,
+  }]);
+
+  const output = await editFileTool.invoke(createContext(sandbox), {
+    path: "notes/names.txt",
+    edits: [{ oldText: "name:", newText: "label:" }],
+  });
+
+  assertEquals(output.outputId, "run-1:edit_file:1");
+  assertEquals(output.path, "/workspace/notes/names.txt");
+  if (!("ok" in output) || output.ok !== false) {
+    throw new Error("expected edit_file conflict output");
+  }
+  assertEquals(output.error.code, "edit_conflict");
+  assertStringIncludes(output.error.detail ?? "", "matched 2 times");
+  assertEquals(sandbox.calls.length, 1);
+});
+
+Deno.test("edit_file rejects stale expected digests without writing", async () => {
+  const sandbox = new FakeSandboxRuntime([{
+    stdout: "hello\n",
+    stderr: "",
+    exitCode: 0,
+  }]);
+
+  const output = await editFileTool.invoke(createContext(sandbox), {
+    path: "notes/hello.txt",
+    expectedDigest: "sha256:not-current",
+    edits: [{ oldText: "hello", newText: "hi" }],
+  });
+
+  assertEquals(output.outputId, "run-1:edit_file:1");
+  assertEquals(output.path, "/workspace/notes/hello.txt");
+  if (!("ok" in output) || output.ok !== false) {
+    throw new Error("expected edit_file conflict output");
+  }
+  assertEquals(output.error.code, "edit_conflict");
+  assertStringIncludes(output.error.detail ?? "", "expected digest");
+  assertEquals(sandbox.calls.length, 1);
 });
 
 Deno.test("write_file tool supports append mode and passes content over stdin", async () => {

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -1111,6 +1111,68 @@ Deno.test("edit_file applies exact replacements and returns a unified diff", asy
   );
 });
 
+Deno.test("edit_file returns separate hunks for distant edits", async () => {
+  const original = Array.from(
+    { length: 30 },
+    (_, index) => `line ${String(index + 1).padStart(2, "0")}\n`,
+  ).join("");
+  const edited = original
+    .replace("line 02\n", "line 02 changed\n")
+    .replace("line 29\n", "line 29 changed\n");
+  const sandbox = new FakeSandboxRuntime([
+    { stdout: original, stderr: "", exitCode: 0 },
+    { stdout: "", stderr: "", exitCode: 0 },
+    { stdout: edited, stderr: "", exitCode: 0 },
+  ]);
+
+  const output = await editFileTool.invoke(createContext(sandbox), {
+    path: "notes/distant.txt",
+    edits: [
+      { oldText: "line 02\n", newText: "line 02 changed\n" },
+      { oldText: "line 29\n", newText: "line 29 changed\n" },
+    ],
+  });
+
+  if ("ok" in output) {
+    throw new Error("expected successful edit_file output");
+  }
+  assertStringIncludes(output.diff, "@@ -1,5 +1,5 @@");
+  assertStringIncludes(output.diff, "-line 02");
+  assertStringIncludes(output.diff, "+line 02 changed");
+  assertStringIncludes(output.diff, "@@ -26,5 +26,5 @@");
+  assertStringIncludes(output.diff, "-line 29");
+  assertStringIncludes(output.diff, "+line 29 changed");
+  assertEquals(output.diff.includes("line 15"), false);
+  assertEquals(output.diff.match(/^@@ /gm)?.length, 2);
+});
+
+Deno.test("edit_file caps oversized diff output", async () => {
+  const original = Array.from(
+    { length: 450 },
+    (_, index) => `old ${String(index + 1).padStart(3, "0")}\n`,
+  ).join("");
+  const edited = Array.from(
+    { length: 450 },
+    (_, index) => `new ${String(index + 1).padStart(3, "0")}\n`,
+  ).join("");
+  const sandbox = new FakeSandboxRuntime([
+    { stdout: original, stderr: "", exitCode: 0 },
+    { stdout: "", stderr: "", exitCode: 0 },
+    { stdout: edited, stderr: "", exitCode: 0 },
+  ]);
+
+  const output = await editFileTool.invoke(createContext(sandbox), {
+    path: "notes/large.txt",
+    edits: [{ oldText: original, newText: edited }],
+  });
+
+  if ("ok" in output) {
+    throw new Error("expected successful edit_file output");
+  }
+  assertStringIncludes(output.diff, "[diff truncated:");
+  assertEquals(output.diff.split("\n").length, 401);
+});
+
 Deno.test("edit_file applies replaceAll edits with expected replacement counts", async () => {
   const original = "red blue red\n";
   const edited = "green blue green\n";

--- a/packages/cf-harness/test/tools-registry.test.ts
+++ b/packages/cf-harness/test/tools-registry.test.ts
@@ -16,19 +16,53 @@ Deno.test("builtin tool registry includes the agreed first-pass tool floor", () 
     "bash-no-sandbox",
     "read_file",
     "read_skill_resource",
+    "edit_file",
     "write_file",
     "delegate_task",
   ]);
-  assertEquals(BUILTIN_TOOL_REGISTRY.size, 6);
+  assertEquals(BUILTIN_TOOL_REGISTRY.size, 7);
   assertEquals(
     [...DEFAULT_PARENT_TOOL_IDS],
     [
       "bash",
       "read_file",
       "read_skill_resource",
+      "edit_file",
       "write_file",
       "delegate_task",
     ] satisfies BuiltinToolId[],
+  );
+});
+
+Deno.test("edit_file descriptor exposes exact replacement edits", () => {
+  const editFileTool = getBuiltinTool("edit_file");
+  assert(editFileTool);
+  assertEquals(editFileTool.descriptor.effectClass, "write");
+  assertEquals(
+    (editFileTool.descriptor.inputSchema as {
+      properties: {
+        edits: {
+          items: {
+            required: string[];
+            properties: { expectedReplacements: { minimum: number } };
+          };
+        };
+      };
+    }).properties.edits.items.required,
+    ["oldText", "newText"],
+  );
+  assertEquals(
+    (editFileTool.descriptor.inputSchema as {
+      properties: {
+        edits: {
+          items: {
+            required: string[];
+            properties: { expectedReplacements: { minimum: number } };
+          };
+        };
+      };
+    }).properties.edits.items.properties.expectedReplacements.minimum,
+    1,
   );
 });
 

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -3,6 +3,7 @@ import {
   computeBaseline,
   extractMetrics,
   fetchPRBody,
+  githubGet,
   type Job,
   type Step,
   type WorkflowRun,
@@ -122,6 +123,63 @@ Deno.test("fetchPRBody reads the live pull request body from the GitHub API", as
       requestedUrl,
       "https://api.github.com/repos/commontoolsinc/labs/pulls/3427",
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("githubGet retries transient GitHub responses", async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  try {
+    globalThis.fetch = ((input, _init) => {
+      calls++;
+      if (calls < 3) {
+        return Promise.resolve(
+          new Response("temporary GitHub timeout", {
+            status: 504,
+            headers: { "retry-after": "0" },
+          }),
+        );
+      }
+
+      const requestedUrl = input instanceof Request ? input.url : String(input);
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: requestedUrl }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }) as typeof fetch;
+
+    assertEquals(
+      await githubGet<{ ok: string }>("/repos/commontoolsinc/labs/actions"),
+      { ok: "https://api.github.com/repos/commontoolsinc/labs/actions" },
+    );
+    assertEquals(calls, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("githubGet does not retry non-transient GitHub responses", async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  try {
+    globalThis.fetch = ((_input, _init) => {
+      calls++;
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    }) as typeof fetch;
+
+    let rejected = false;
+    try {
+      await githubGet("/repos/commontoolsinc/labs/missing");
+    } catch {
+      rejected = true;
+    }
+
+    assertEquals(rejected, true);
+    assertEquals(calls, 1);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -165,14 +165,76 @@ export function apiHeaders(): Record<string, string> {
   };
 }
 
+const GITHUB_GET_MAX_ATTEMPTS = 4;
+const GITHUB_GET_RETRY_BASE_DELAY_MS = 250;
+const GITHUB_GET_RETRY_MAX_DELAY_MS = 5_000;
+const RETRYABLE_GITHUB_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+
+function retryAfterDelayMs(value: string | null): number | undefined {
+  if (value == null) return undefined;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, seconds * 1_000);
+  }
+
+  const dateMs = Date.parse(value);
+  if (Number.isFinite(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+
+  return undefined;
+}
+
+function githubRetryDelayMs(resp: Response, attempt: number): number {
+  return Math.min(
+    retryAfterDelayMs(resp.headers.get("retry-after")) ??
+      GITHUB_GET_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+    GITHUB_GET_RETRY_MAX_DELAY_MS,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function githubGet<T>(path: string): Promise<T> {
   const url = path.startsWith("http") ? path : `https://api.github.com${path}`;
-  const resp = await fetch(url, { headers: apiHeaders() });
-  if (!resp.ok) {
-    const body = await resp.text();
-    throw new Error(`GitHub API ${resp.status}: ${path}\n${body}`);
+  for (let attempt = 1; attempt <= GITHUB_GET_MAX_ATTEMPTS; attempt++) {
+    let resp: Response;
+    try {
+      resp = await fetch(url, { headers: apiHeaders() });
+    } catch (error) {
+      if (attempt === GITHUB_GET_MAX_ATTEMPTS) {
+        throw error;
+      }
+      await sleep(
+        Math.min(
+          GITHUB_GET_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+          GITHUB_GET_RETRY_MAX_DELAY_MS,
+        ),
+      );
+      continue;
+    }
+
+    if (resp.ok) {
+      return resp.json();
+    }
+
+    if (
+      !RETRYABLE_GITHUB_STATUSES.has(resp.status) ||
+      attempt === GITHUB_GET_MAX_ATTEMPTS
+    ) {
+      const body = await resp.text();
+      throw new Error(`GitHub API ${resp.status}: ${path}\n${body}`);
+    }
+
+    await resp.body?.cancel();
+    await sleep(githubRetryDelayMs(resp, attempt));
   }
-  return resp.json();
+
+  throw new Error(`GitHub API GET retry loop exhausted unexpectedly: ${path}`);
 }
 
 export async function githubPost<T>(


### PR DESCRIPTION
## Summary
- add an exact string-replacement edit_file tool to cf-harness
- wire it into tool registration, CLI allow-lists, policy summaries, diagnostics, default parent tools, and default non-browser subagents
- add focused execution, registry, CLI, prompt-loop, and artifact tests

## Testing
- deno task check
- deno test --allow-read --allow-write --allow-env --allow-run test/tools-registry.test.ts test/tools-execution.test.ts test/cli.test.ts test/prompt-loop.test.ts test/artifacts.test.ts
- deno task test
- deno test --allow-read --allow-write --allow-env --allow-run test/tools-execution.test.ts
- git diff --check

## Local smoke
- Pattern Factory cf-harness Build smoke on workspace/2026-05-05-device-can5 exposed edit_file and the model used it 4 times. The smoke still failed host-side cf check due generated pattern authoring issues around Writable<DeviceRecord> field access, so this validates tool availability/use but not Build quality.