### PR TITLE
[codex] Make binary builds use deno.lock

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -130,7 +130,7 @@
     "core-js/proposals/async-explicit-resource-management": "https://esm.sh/core-js@3.46.0/proposals/async-explicit-resource-management",
     "@commonfabric/ports": "./ports.json",
     "@astral/astral": "./packages/vendor-astral/mod.ts",
-    "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.8",
+    "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.8",
     "@noble/hashes": "npm:@noble/hashes@^2.2.0",
     "@std/assert": "jsr:@std/assert@^1",
     "@std/async": "jsr:@std/async@^1",

--- a/deno.lock
+++ b/deno.lock
@@ -1,10 +1,11 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@cliffy/command@1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/command@^1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/flags@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/internal@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/table@1.0.0-rc.8": "1.0.0-rc.8",
+    "jsr:@cliffy/table@^1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cmd-johnson/oauth2-client@2": "2.0.0",
     "jsr:@db/sqlite@0.12": "0.12.0",
     "jsr:@deno-library/progress@^1.5.1": "1.5.1",
@@ -1879,7 +1880,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@cliffy/command@1.0.0-rc.8",
+      "jsr:@cliffy/command@^1.0.0-rc.8",
       "jsr:@std/assert@1",
       "jsr:@std/async@1",
       "jsr:@std/cli@1",
@@ -1903,7 +1904,7 @@
     "members": {
       "packages/cli": {
         "dependencies": [
-          "jsr:@cliffy/table@1.0.0-rc.8"
+          "jsr:@cliffy/table@^1.0.0-rc.8"
         ]
       },
       "packages/deno-web-test": {

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -12,6 +12,6 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@cliffy/table": "jsr:@cliffy/table@1.0.0-rc.8"
+    "@cliffy/table": "jsr:@cliffy/table@^1.0.0-rc.8"
   }
 }

--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -39,10 +39,6 @@ class BuildConfig {
     return this.path("deno.lock");
   }
 
-  workspaceTempLockPath() {
-    return this.path("_deno.lock");
-  }
-
   shellProjectPath() {
     return this.path("packages", "shell");
   }
@@ -189,7 +185,7 @@ async function buildToolshed(config: BuildConfig): Promise<void> {
       OTEL_DENO: "true",
     },
     args: [
-      "compile",
+      ...lockedCompileArgs(config),
       // Run `--no-check` here, as the `--include`'d
       // `es2023.d.ts` file will attempt to be checked
       // as a non-static asset. Checking should be done
@@ -226,7 +222,7 @@ async function buildBgCharmService(config: BuildConfig): Promise<void> {
   console.log("Building background charm service binary...");
   const { success } = await new Deno.Command(Deno.execPath(), {
     args: [
-      "compile",
+      ...lockedCompileArgs(config),
       // Run `--no-check` here, as the `--include`'d
       // `es2023.d.ts` file will attempt to be checked
       // as a non-static asset. Checking should be done
@@ -284,7 +280,7 @@ async function buildCli(config: BuildConfig): Promise<void> {
   ];
   const { success } = await new Deno.Command(Deno.execPath(), {
     args: [
-      "compile",
+      ...lockedCompileArgs(config),
       "--output",
       config.distPath("cf"),
       // Run `--no-check` here, as the `--include`'d
@@ -317,24 +313,31 @@ async function buildCli(config: BuildConfig): Promise<void> {
   console.log("CLI binary built successfully");
 }
 
-// `deno compile` appears to bundle *all* workspace
-// dependencies e.g. dev dependencies. We can sidestep
-// this by removing the lock file, and only calling compile
-// from `toolshed`, not the project root.
-// https://github.com/denoland/deno/issues/21504
-//
-// Additionally, we have some frontend types that
+function lockedCompileArgs(config: BuildConfig): string[] {
+  // Keep compiled binaries on the same resolved dependency graph as normal
+  // install/test flows, even when compile runs from a package cwd.
+  return [
+    "compile",
+    "--lock",
+    config.workspaceLockPath(),
+    "--frozen=true",
+  ];
+}
+
+// Some frontend types in the workspace manifest
 // must be removed from the compiler options
 // that do not work with toolshed.
 async function prepareWorkspace(
   config: BuildConfig,
 ): Promise<void> {
   const denoJsonPath = config.workspaceManifestPath();
-  const denoLockPath = config.workspaceLockPath();
-  const denoTempLockPath = config.workspaceTempLockPath();
 
-  // "Remove" the lock file
-  await Deno.rename(denoLockPath, denoTempLockPath);
+  if (!(await exists(config.workspaceLockPath()))) {
+    throw new Error(
+      `Cannot build binaries without ${config.workspaceLockPath()}`,
+    );
+  }
+
   // Remove `compilerOptions.types`
   const manifest = config.manifest();
   delete manifest.compilerOptions.types;
@@ -349,17 +352,7 @@ async function prepareWorkspace(
 
 async function revertWorkspace(config: BuildConfig): Promise<void> {
   const denoJsonPath = config.workspaceManifestPath();
-  const denoLockPath = config.workspaceLockPath();
-  const denoTempLockPath = config.workspaceTempLockPath();
   const toolshedEnvPath = config.toolshedEnvPath();
-
-  // Move temp lock file back
-  if ((await exists(denoTempLockPath))) {
-    await Deno.rename(
-      denoTempLockPath,
-      denoLockPath,
-    );
-  }
 
   // Restore the workspace manifest
   await Deno.writeTextFile(


### PR DESCRIPTION
## Summary
- stop renaming `deno.lock` out of the workspace during binary builds
- pass the workspace lockfile to every `deno compile` invocation with `--frozen=true`
- restore the Cliffy import ranges while keeping the checked-in lock resolved to `1.0.0-rc.8`

## Why
Follow-up to Wilk's approval comment on #3496. The exact Cliffy pin was a tactical stabilization for binary CI, but the healthier fix is making compiled binaries use the same locked dependency graph as install/test flows.

## Tests
- `deno install --frozen=true`
- `deno fmt --check`
- `git diff --check`
- `deno task check`
- `deno task build-binaries --cli-only`
- `deno task build-binaries`
- local `./dist/cf piece call --api-url=http://localhost:1 --identity=/tmp/no-such-key --space=x --piece y increment '{}'` parser smoke reached identity-file loading
- cross-compiled Linux `cf` with `--lock deno.lock --frozen=true`, then Docker-smoked the same `piece call` command to identity-file loading

Base: #3496 / `codex/cf-harness-image-attachments`. Retarget to `main` after #3496 merges.