### PR TITLE
Embrace interned symbols in the modern fabric-value path

### DIFF
--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -167,7 +167,12 @@ export function shallowFabricFromNativeValueModern(
             "Cannot store function per se (needs to have a `toJSON()` method)",
           );
         case "symbol":
-          throw new Error(`Cannot store ${typeof value}`);
+          // Registry-interned symbols are valid fabric primitives; unique
+          // ones have no portable representation and are rejected.
+          if (Symbol.keyFor(value) === undefined) {
+            throw new Error("Cannot store unique (uninterned) symbol");
+          }
+          return value;
         default:
           throw new Error(
             `Shouldn't happen: Unrecognized type ${typeof value}`,
@@ -491,8 +496,12 @@ export function isFabricValueModern(
       return proto === null || proto === Object.prototype;
     }
 
+    case "symbol": {
+      // Registry-interned symbols are valid fabric values; unique ones are not.
+      return Symbol.keyFor(value) !== undefined;
+    }
+
     case "function":
-    case "symbol":
     default: {
       return false;
     }
@@ -712,10 +721,14 @@ function isFabricCompatibleInternal(
       return true;
     }
 
-    case "symbol":
+    case "symbol": {
+      // Registry-interned symbols are fabric-compatible; unique ones are not.
+      return Symbol.keyFor(value) !== undefined;
+    }
+
     case "function": {
       // Functions are only fabric-compatible if they have toJSON().
-      if (typeof value === "function" && hasToJSONMethod(value)) {
+      if (hasToJSONMethod(value)) {
         const converted = value.toJSON();
         return isFabricCompatibleInternal(converted, seen);
       }

--- a/packages/data-model/test/fabric-value.test.ts
+++ b/packages/data-model/test/fabric-value.test.ts
@@ -1441,6 +1441,80 @@ describe("fabric-value", () => {
   });
 
   // =========================================================================
+  // Interned symbols (modern path)
+  //
+  // Modern mode admits registry-interned symbols (`Symbol.for(key)`, where
+  // `Symbol.keyFor(s)` returns a string) as fabric primitives. Unique
+  // symbols (`Symbol(desc)`) have no portable representation and continue
+  // to be rejected. The legacy path is unchanged (covered above).
+  // =========================================================================
+
+  describe("interned symbols (modern path)", () => {
+    beforeEach(() => {
+      setDataModelConfig(true);
+    });
+    afterEach(() => {
+      resetDataModelConfig();
+    });
+
+    it("isFabricValue accepts an interned symbol", () => {
+      expect(isFabricValue(Symbol.for("k"))).toBe(true);
+    });
+
+    it("isFabricValue rejects a unique symbol", () => {
+      expect(isFabricValue(Symbol("k"))).toBe(false);
+    });
+
+    it("shallowFabricFromNativeValue passes an interned symbol through", () => {
+      const sym = Symbol.for("k");
+      // Interned symbols are primitives -- pass-through, no wrapping.
+      expect(shallowFabricFromNativeValue(sym)).toBe(sym);
+    });
+
+    it("shallowFabricFromNativeValue throws on a unique symbol", () => {
+      expect(() => shallowFabricFromNativeValue(Symbol("nope"))).toThrow(
+        "Cannot store unique (uninterned) symbol",
+      );
+    });
+
+    it("fabricFromNativeValue passes an interned symbol through", () => {
+      const sym = Symbol.for("top-level");
+      expect(fabricFromNativeValue(sym)).toBe(sym);
+    });
+
+    it("fabricFromNativeValue preserves interned symbols in objects", () => {
+      const result = fabricFromNativeValue({
+        kind: Symbol.for("event"),
+        flag: Symbol.for("ready"),
+      }) as Record<string, symbol>;
+      expect(result.kind).toBe(Symbol.for("event"));
+      expect(result.flag).toBe(Symbol.for("ready"));
+    });
+
+    it("fabricFromNativeValue preserves interned symbols in arrays", () => {
+      const result = fabricFromNativeValue(
+        [Symbol.for("a"), 1, Symbol.for("b")],
+      ) as unknown[];
+      expect(result[0]).toBe(Symbol.for("a"));
+      expect(result[1]).toBe(1);
+      expect(result[2]).toBe(Symbol.for("b"));
+    });
+
+    it("fabricFromNativeValue throws on a nested unique symbol", () => {
+      expect(() => fabricFromNativeValue({ k: Symbol("nope") })).toThrow(
+        "Cannot store unique (uninterned) symbol",
+      );
+    });
+
+    it("interned symbols round-trip with stable identity", () => {
+      // Same registry key in any realm yields the same symbol instance
+      // -- so the result equals the constructed sentinel by identity.
+      const out = fabricFromNativeValue(Symbol.for("identity-check"));
+      expect(Object.is(out, Symbol.for("identity-check"))).toBe(true);
+    });
+  });
+
+  // =========================================================================
   // isFabricCompatible: deep storability check (modern path)
   // =========================================================================
 
@@ -1486,9 +1560,14 @@ describe("fabric-value", () => {
       expect(isFabricCompatible(0n)).toBe(true);
     });
 
+    it("accepts interned symbols", () => {
+      expect(isFabricCompatible(Symbol.for("k"))).toBe(true);
+      expect(isFabricCompatible(Symbol.for(""))).toBe(true);
+    });
+
     // -- Primitives that are NOT fabric-compatible --
 
-    it("rejects symbols", () => {
+    it("rejects unique (uninterned) symbols", () => {
       expect(isFabricCompatible(Symbol("test"))).toBe(false);
     });
 


### PR DESCRIPTION
## Summary

Second of three planned PRs that bring registry-interned symbols
(`Symbol.for(key)`, where `Symbol.keyFor(s)` returns a string) into the
fabric value system. PR 1 (#3503) added the type union admission,
hashing, and unified JSON encoding. **This PR relaxes the modern-path
gate** so an interned symbol survives the conversion entrance and flows
through `cell.set` / `cell.get` end-to-end.

Three sites in `fabric-value-modern.ts` updated:

- `shallowFabricFromNativeValueModern` — symbol case was an
  unconditional `throw "Cannot store symbol"`. Now: registry-interned
  symbols pass through as primitives; unique symbols throw with the
  more specific `"Cannot store unique (uninterned) symbol"`.
- `isFabricValueModern` — symbol case was sharing a `return false` arm
  with `function` / `default`. Split into its own arm that returns
  `Symbol.keyFor(value) !== undefined`.
- `isFabricCompatibleInternal` — same split. Was sharing a
  toJSON-checking arm with `function`; symbols get a dedicated
  interned-vs-unique gate.

## Per-flag behavior

| flag | interned `Symbol.for("k")` | unique `Symbol("k")` |
|---|---|---|
| legacy (`modernDataModel = false`) | throws `"Cannot store symbol"` (unchanged) | throws `"Cannot store symbol"` (unchanged) |
| modern (`modernDataModel = true`) | **round-trips** | throws `"Cannot store unique (uninterned) symbol"` |

## Tests

- New `interned symbols (modern path)` describe in
  `fabric-value.test.ts`, mirroring the existing `special numbers
  (modern path)` block: `isFabricValue`, `shallowFabricFromNativeValue`,
  and `fabricFromNativeValue` accept interned, reject unique; preserved
  nested in objects and arrays; nested unique symbol throws; identity
  round-trip (`Object.is(out, Symbol.for(sameKey))` is `true`).
- Existing `isFabricCompatible` "rejects symbols" test split into
  "accepts interned symbols" (true) and "rejects unique (uninterned)
  symbols" (false).

## Scope and follow-ups

- **Legacy path unchanged.** Same shape as the weird-numbers rollout.
- **Runner-level cell-core Symbol test left alone.** It runs under the
  default flag (legacy) and uses a unique symbol, so it continues to
  pass with the unchanged legacy `"Cannot store symbol"`. A bifurcated
  test exercising the new modern behavior end-to-end through `cell.set`
  is the natural follow-up PR (analog of #3499 for special numbers).
- **Spec docs deferred.** `1-fabric-values.md` §2.2 and friends still
  describe the old "rejected outright" contract; spec catch-up rolls
  into the same future spec-work session as the weird-numbers update.

## Test plan

- [x] `deno task test` from monorepo root: all 28 packages pass (76s).
- [x] New describe block: 9 cases (interned acceptance via 3 entry
      points, unique rejection via 3, nested in objects + arrays,
      nested-unique throw, identity round-trip).
- [x] Updated `isFabricCompatible` split: 2 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
