### PR TITLE
Bifurcate cell-storage Symbol tests across modernDataModel

### DIFF
--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -307,18 +307,6 @@ describe("Cell", () => {
     expect(result?.arr).toBe("custom-array-value");
   });
 
-  it("should throw when setting Symbol", () => {
-    const c = runtime.getCell<unknown>(
-      space,
-      "should throw when setting Symbol",
-      undefined,
-      tx,
-    );
-    expect(() => c.set({ value: Symbol("test") })).toThrow(
-      "Cannot store symbol",
-    );
-  });
-
   it("should throw when setting BigInt with modernDataModel OFF", async () => {
     const sm = StorageManager.emulate({ as: signer });
     const rt = new Runtime({
@@ -1310,6 +1298,108 @@ for (const modernDataModel of [false, true]) {
           );
           expect(() => c.set({ value: -Infinity })).toThrow(
             "Cannot store non-finite number",
+          );
+        });
+      }
+    },
+  );
+}
+
+// Cell-storage behavior for symbols. The two data-model paths diverge:
+//
+// * Legacy (`modernDataModel = false`): any symbol -- registry-interned or
+//   unique -- throws `"Cannot store symbol"` at the fabric-value boundary
+//   inside `cell.set()`.
+// * Modern  (`modernDataModel = true`): registry-interned symbols
+//   (`Symbol.for(key)`) round-trip end-to-end, with `Object.is` identity
+//   preserved against any same-key `Symbol.for` in the same realm. Unique
+//   symbols (`Symbol(desc)`) throw the more specific `"Cannot store unique
+//   (uninterned) symbol"` (PRs #3503/#3510).
+for (const modernDataModel of [false, true]) {
+  describe(
+    `Cell symbol storage with \`modernDataModel = ${modernDataModel}\``,
+    () => {
+      let runtime: Runtime;
+      let storageManager: ReturnType<typeof StorageManager.emulate>;
+      let tx: IExtendedStorageTransaction;
+
+      beforeEach(() => {
+        storageManager = StorageManager.emulate({ as: signer });
+        runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager,
+          experimental: { modernDataModel },
+        });
+        tx = runtime.edit();
+      });
+
+      afterEach(async () => {
+        await tx.commit();
+        await runtime?.dispose();
+        await storageManager?.close();
+      });
+
+      if (modernDataModel) {
+        it("round-trips an interned symbol with stable identity", () => {
+          const c = runtime.getCell<unknown>(
+            space,
+            "modern: interned symbol round-trip",
+            undefined,
+            tx,
+          );
+          c.set({ tag: Symbol.for("status") });
+          const result = c.get() as { tag: symbol } | undefined;
+          // Same registry key in the same realm yields the same symbol
+          // instance, so the round-tripped value is `Object.is` to the
+          // constructed sentinel.
+          expect(Object.is(result?.tag, Symbol.for("status"))).toBe(true);
+        });
+
+        it("round-trips an interned symbol with an empty key", () => {
+          const c = runtime.getCell<unknown>(
+            space,
+            "modern: interned empty-key symbol",
+            undefined,
+            tx,
+          );
+          c.set({ tag: Symbol.for("") });
+          const result = c.get() as { tag: symbol } | undefined;
+          expect(Object.is(result?.tag, Symbol.for(""))).toBe(true);
+        });
+
+        it("throws on a unique (uninterned) symbol", () => {
+          const c = runtime.getCell<unknown>(
+            space,
+            "modern: throw on unique symbol",
+            undefined,
+            tx,
+          );
+          expect(() => c.set({ value: Symbol("nope") })).toThrow(
+            "Cannot store unique (uninterned) symbol",
+          );
+        });
+      } else {
+        it("throws on an interned symbol", () => {
+          const c = runtime.getCell<unknown>(
+            space,
+            "legacy: throw on interned symbol",
+            undefined,
+            tx,
+          );
+          expect(() => c.set({ tag: Symbol.for("status") })).toThrow(
+            "Cannot store symbol",
+          );
+        });
+
+        it("throws on a unique (uninterned) symbol", () => {
+          const c = runtime.getCell<unknown>(
+            space,
+            "legacy: throw on unique symbol",
+            undefined,
+            tx,
+          );
+          expect(() => c.set({ value: Symbol("nope") })).toThrow(
+            "Cannot store symbol",
           );
         });
       }


### PR DESCRIPTION
## Summary

Third of the three-PR symbol series. #3503 admitted interned symbols
into the type union, hashing, and unified JSON encoding; #3510 relaxed
the modern fabric-value gate so registry-interned symbols
(`Symbol.for(key)`) round-trip end-to-end through `cell.set()` in
modern mode.

The runner-level cell-core Symbol test was left unchanged through both
of those PRs because it ran under the default flag (legacy, where any
symbol still throws) and used a unique symbol — it continued to pass
on its existing assertion but didn't actually cover the cross-interaction
with the modern data model.

This PR closes the gap with the same bifurcation pattern that #3499
used for the special-numbers rollout:

- Removes the existing `should throw when setting Symbol` test from
  the default-flag `describe("Cell")` block.
- Adds a new top-level `for (const modernDataModel of [false, true])`
  describe block at the bottom of the file (mirroring the structure
  of `Cell special-number storage with ...` just above it).

## Per-flag coverage

| flag | interned `Symbol.for("k")` | unique `Symbol("k")` |
|---|---|---|
| `modernDataModel = false` (legacy) | throws `"Cannot store symbol"` | throws `"Cannot store symbol"` |
| `modernDataModel = true`  (modern) | round-trips, `Object.is` to `Symbol.for(sameKey)` | throws `"Cannot store unique (uninterned) symbol"` |

Tests in the modern branch cover both a non-empty key and the empty-key
edge case (`Symbol.for("")`).

## Scope

Test-only — no production changes.

## Test plan

- [x] `deno test test/cell-core.test.ts` from `packages/runner`: 9
      top-level groups / 68 steps, all green.
- [x] Filtered run of the new block (`--filter "Cell symbol storage"`):
      2 groups × 2-3 steps each, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
