### PR TITLE
Drain the toolshed memoryServer between tests to fix flaky leak checks

### DIFF
--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -446,6 +446,23 @@ export class Server {
     this.#connections.clear();
   }
 
+  /**
+   * Drains any in-flight or scheduled subscription refresh, returning when
+   * the server has no pending work. Tests use this to drain the
+   * module-level singleton's `#refreshTimer` between cases so it doesn't
+   * leak across the Deno test boundary -- the singleton survives across
+   * tests but its pending timer must not.
+   *
+   * `flushSessions()` (called with no `spaces` argument) cancels any
+   * pending timer, runs the refresh loop to completion, and intentionally
+   * does not reschedule, so a single call is sufficient.
+   */
+  async idle(): Promise<void> {
+    if (this.#refreshTimer !== null || this.#refreshing !== null) {
+      await this.flushSessions();
+    }
+  }
+
   async readDocument(
     space: string,
     id: string,

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -1,5 +1,6 @@
 import { assert, assertEquals } from "@std/assert";
 import app from "../../../app.ts";
+import { memoryServer } from "../memory.ts";
 import {
   decodeMemoryBoundary,
   encodeMemoryBoundary,
@@ -109,6 +110,15 @@ const serialTest = (
     try {
       await fn();
     } finally {
+      // The toolshed `memoryServer` is a module-level singleton. Its
+      // `#refreshTimer` (armed when sessions write into dirty spaces) is
+      // not cancelled by per-test `Deno.serve().shutdown()`. Drain it
+      // here so the timer doesn't survive into a later test, where
+      // Deno's leak sanitizer would flag it as either "started in this
+      // test, but never completed" (timer still pending at test end) or
+      // "started before the test, but completed during the test" (timer
+      // from a prior test fires inside this one).
+      await memoryServer.idle();
       current.resolve();
     }
   });


### PR DESCRIPTION
## Summary

Fixes a flaky CI failure in `packages/toolshed/routes/storage/memory/memory.test.ts` where two tests periodically fail with one of two Deno leak-sanitizer messages:

> `A timer was started in this test, but never completed.`
>
> `A timer was started before the test, but completed during the test.`

The two messages are different faces of the same singleton-timer leak.

## Root cause

`packages/toolshed/routes/storage/memory.ts` exports `memoryServer` as a module-level singleton. Its `#refreshTimer` is armed via `scheduleRefresh()` whenever sessions write into dirty spaces (`memory/v2/server.ts:1066-1077`) and is properly cancelled by `Server.close()` — but the test fixture's per-test cleanup is `await server.shutdown()`, where `server` is the per-test `Deno.serve()` HTTP listener. That stops accepting new connections but doesn't touch the singleton's refresh timer.

So:

- If a write near end-of-test arms the timer and it's still pending when the test function returns → "started in this test, but never completed".
- If the timer from a prior test fires inside the next test's window → "started before, completed during".

Hence the "rerunning fixes it" character — timing variation moves which test the wandering timer lands in.

## Fix

Two-part change:

- **`packages/memory/v2/server.ts`**: add `Server.idle()` that drains any in-flight or scheduled refresh. It calls `flushSessions()`, which cancels any pending timer, runs the refresh loop to completion, and — when called with no `spaces` argument — intentionally does not reschedule, so a single call is sufficient.
- **`packages/toolshed/routes/storage/memory/memory.test.ts`**: hoist the drain into the existing `serialTest` helper's `finally` block, so every test (success or failure) calls `await memoryServer.idle()` before signalling the next test in the queue. The singleton stays alive across tests as before; only its pending timer state is drained.

## Test plan

- [x] Local toolshed suite: `29 passed (98 steps) | 0 failed` — vs. the recurring `27 passed | 2 failed` on the flaky cases.
- [x] Full repo `deno task test` from monorepo root: all 28 packages pass (70s).
- [x] Type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
