### PR TITLE
docs(spec): sync data-model specs for interned-symbol acceptance

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -87,6 +87,7 @@ type FabricValue =
   | string
   | undefined // first-class fabric value; requires tagged representation in formats lacking native `undefined`
   | bigint    // large integers; rides through without wrapping (like `undefined`)
+  | symbol    // registry-interned symbols only (`Symbol.keyFor(s)` returns a string); see Section 1.3
 
   // (b) Special primitives (FabricPrimitive subclasses — always frozen)
   | FabricEpochNsec
@@ -107,22 +108,31 @@ type FabricValue =
   | { [key: string]: FabricValue };
 ```
 
-> **Excluded JS types.** The following JavaScript types are explicitly **not**
-> representable as fabric values, eliciting a thrown error from
-> `fabricFromNativeValue()` and a `false` return value from
-> `isFabricCompatible()`:
+> **Restricted and excluded JS types.**
 >
-> - `symbol` — Symbols are inherently local (not serializable across realms or
->   processes). Symbol-keyed properties on objects are silently ignored; a bare
->   `symbol` value is rejected outright.
-> - `function` — Functions are opaque closures with no portable representation.
->   Objects with a `[DECONSTRUCT]` method are not functions in this sense — they
->   are `FabricInstance`s.
+> - `symbol` — **Conditionally** part of the universe. Registry-interned
+>   symbols (`Symbol.for(key)`, where `Symbol.keyFor(s)` returns a string)
+>   are first-class fabric values: they are portable across realms and
+>   processes via their registry key. **Unique** symbols (`Symbol(desc)`,
+>   where `Symbol.keyFor(s)` returns `undefined`) have no portable
+>   representation and are rejected. The TypeScript `symbol` type cannot
+>   express this distinction, so it is enforced at runtime by the
+>   conversion, hashing, and serialization boundaries (Sections 4.9, 6,
+>   and 5). Symbol-keyed *properties* on plain objects are a separate
+>   matter — see Section 1.5 (Recursive Containers / Objects).
+> - `function` — Functions are opaque closures with no portable
+>   representation. They are explicitly **not** representable as fabric
+>   values, eliciting a thrown error from `fabricFromNativeValue()` and a
+>   `false` return value from `isFabricCompatible()`. Objects with a
+>   `[DECONSTRUCT]` method are not functions in this sense — they are
+>   `FabricInstance`s.
 >
-> These are the two JS primitive types (`typeof` returns `"symbol"` or
-> `"function"`) that are absent from the `FabricValue` union. All other
-> `typeof` results (`"undefined"`, `"boolean"`, `"number"`, `"string"`,
-> `"bigint"`, `"object"`) have corresponding `FabricValue` arms.
+> Of the two JS primitive types whose `typeof` results (`"symbol"` and
+> `"function"`) describe non-data values, `symbol` has a corresponding
+> `FabricValue` arm (with the runtime interned-vs-unique restriction
+> above) and `"function"` does not. All other `typeof` results
+> (`"undefined"`, `"boolean"`, `"number"`, `"string"`, `"bigint"`,
+> `"object"`) have unconditional `FabricValue` arms.
 
 #### `FabricNativeObject`
 
@@ -174,6 +184,7 @@ member of `FabricValue`.
 | `string` | None | Unicode text |
 | `undefined` | None | First-class fabric value; see note below |
 | `bigint` | None | Large integers; JSON-encoded as base64url (RFC 4648, Section 5) of two's complement big-endian bytes (Section 3 of `3-json-encoding.md`) |
+| `symbol` | Registry-interned only | Only symbols for which `Symbol.keyFor(s)` returns a string (i.e., `Symbol.for(key)` symbols) are admitted. Unique symbols (`Symbol(desc)`) are rejected. Conversion-gate behavior is flag-bifurcated; see Section 4.9 and the callout below. |
 
 > **`undefined` as a first-class fabric value.** `undefined` is a first-class
 > fabric value that round-trips faithfully through serialization. Because most
@@ -204,6 +215,29 @@ member of `FabricValue`.
 > - **Legacy path (`modernDataModel: false`):**
 >   `fabricFromNativeValueLegacy()` normalizes `-0` to `+0` and rejects
 >   `NaN` / `±Infinity` with a thrown error. Code paths that bypass the
+>   conversion gate (direct callers of the hasher or the JSON encoder)
+>   see the modern-path behavior regardless of the flag, since the
+>   lower-layer specs describe their own behavior unconditionally.
+
+> **Interned vs. unique symbols.** The hashing layer (Section 6.4 and
+> `2-hash-byte-format.md` Section 4.6) and the JSON wire format
+> (Section 5; `3-json-encoding.md` Section 3, `Symbol@1`) both faithfully
+> represent registry-interned symbols, identifying them by their registry
+> key (`Symbol.keyFor(s)`). Unique symbols (`Symbol(desc)` — those for
+> which `Symbol.keyFor(s)` returns `undefined`) have no portable
+> representation and are rejected at every layer. Whether a symbol value
+> reaches those layers at all is gated by the `modernDataModel` conversion
+> path (Section 4.9):
+>
+> - **Modern path (`modernDataModel: true`):** Interned symbols pass
+>   through `shallowFabricFromNativeValueModern()` and
+>   `fabricFromNativeValueModern()` unchanged. Round-trip via
+>   `Symbol.for(key)` yields a result that is `===` to any other
+>   `Symbol.for(key)` in the same realm. Unique symbols throw with the
+>   message `"Cannot store unique (uninterned) symbol"`.
+> - **Legacy path (`modernDataModel: false`):**
+>   `fabricFromNativeValueLegacy()` rejects all symbols (interned and
+>   unique alike) with a thrown error. Code paths that bypass the
 >   conversion gate (direct callers of the hasher or the JSON encoder)
 >   see the modern-path behavior regardless of the flag, since the
 >   lower-layer specs describe their own behavior unconditionally.
@@ -893,7 +927,9 @@ Section 4.5.
 
 **Objects:**
 - Plain objects only (class instances must implement the fabric protocol)
-- Keys must be strings; symbol keys cause rejection
+- Keys must be strings; symbol-keyed *properties* cause rejection (this
+  is distinct from symbol *values*, which are admitted per Section 1.2
+  with the runtime restriction in Section 1.3)
 - Values must be valid fabric values; properties whose value is `undefined` are preserved
   (not omitted) — `undefined` is a first-class value, not a signal for deletion
 - No distinction between regular and null-prototype objects; reconstruction
@@ -1837,6 +1873,7 @@ organized into four categories by high nibble:
 | `TAG_EPOCH_NSEC`  | `0x27` | 39      | `FabricEpochNsec`                 |
 | `TAG_EPOCH_DAYS`  | `0x28` | 40      | `FabricEpochDays`                 |
 | `TAG_CONTENT_ID`  | `0x29` | 41      | `FabricHash`                      |
+| `TAG_SYMBOL`      | `0x2A` | 42      | `symbol` (registry-interned only) |
 
 **Optimized tags (`0xFN`)** — hash-level substitutes that replace the raw
 payload of a primitive type with a digest, when doing so shortens the byte
@@ -2209,6 +2246,7 @@ export function fabricFromNativeValue(
 | Input Type | Output |
 |------------|--------|
 | `null`, `boolean`, `number`, `string`, `undefined`, `bigint` | Returned as-is (primitives are `FabricValue` directly). Modern path passes all numbers through unchanged, including `-0`, `NaN`, and `±Infinity`. Legacy path normalizes `-0` to `0` and rejects `NaN` / `±Infinity` with a thrown error. See Section 1.3 callout for layer-by-layer details. |
+| `symbol` | Modern path: registry-interned symbols (`Symbol.keyFor(s)` returns a string) returned as-is; unique symbols (`Symbol(desc)`) throw with the message `"Cannot store unique (uninterned) symbol"`. Legacy path: all symbols throw. See Section 1.3 callout for layer-by-layer details. |
 | `FabricPrimitive` (`FabricEpochNsec`, `FabricEpochDays`, `FabricHash`, `FabricBytes`) | Returned as-is. Always-frozen: the `freeze` option has no effect on these types (see Section 1.4.6). |
 | `FabricInstance` (including wrapper classes) | Returned as-is (already `FabricValue`). |
 | `Error` | Wrapped into `FabricError`. Before wrapping, `cause` and custom enumerable properties are recursively converted to `FabricValue` (deep variant) or left as-is (shallow variant). Extra enumerable properties are preserved (see Section 1.4.1). This ensures that by the time `FabricError.[DECONSTRUCT]` runs, all nested values are already valid `FabricValue`. |
@@ -2351,6 +2389,10 @@ if the value is:
   All numbers are accepted on the modern path, including `-0`, `NaN`, and
   `±Infinity`. On the legacy path, `NaN` and `±Infinity` are rejected; see
   Section 1.3 callout for the per-path detail.
+- A registry-interned `symbol` (one for which `Symbol.keyFor(s)` returns a
+  string), on the modern path only. Unique symbols return `false` on
+  either path; all symbols return `false` on the legacy path. See
+  Section 1.3 callout for the per-path detail.
 - A `FabricInstance` (including the native object wrapper classes)
 - A `FabricNativeObject` (`Error`, `Map`, `Set`, `Date`, `RegExp`,
   `Uint8Array`, or an object with a `toJSON()` method — legacy)
@@ -2358,9 +2400,10 @@ if the value is:
 - A plain object where every value satisfies `isFabricCompatible()`
 
 It returns `false` for unsupported types (`WeakMap`, `Promise`, DOM nodes,
-class instances that don't implement `FabricInstance`, etc.). On the legacy
-path it additionally returns `false` for non-finite numbers; the modern path
-accepts them.
+class instances that don't implement `FabricInstance`, etc.) and for unique
+symbols. On the legacy path it additionally returns `false` for non-finite
+numbers and for all symbols (interned and unique alike); the modern path
+accepts non-finite numbers and registry-interned symbols.
 
 > **Performance note.** `isFabricCompatible()` walks the value tree without
 > allocating wrappers or frozen copies. For large trees, this is cheaper than

--- a/docs/specs/space-model-formal-spec/2-hash-byte-format.md
+++ b/docs/specs/space-model-formal-spec/2-hash-byte-format.md
@@ -191,9 +191,9 @@ type tags (`0x24` vs. `0xF0`), they are unambiguous and cannot collide.
 must use the threshold when deciding which form to emit.
 
 The hashed form applies everywhere this spec encodes a string via the
-`TAG_STRING` layout: standalone strings (this section), object keys (Section
-4.12), `FabricInstance` type tags (Section 4.13), and `FabricHash` algorithm
-tags (Section 4.10).
+`TAG_STRING` layout: standalone strings (this section), `symbol` keys
+(Section 4.6), object keys (Section 4.13), `FabricInstance` type tags
+(Section 4.14), and `FabricHash` algorithm tags (Section 4.11).
 
 ### 4.5 `bigint`
 
@@ -217,7 +217,37 @@ Total: 1 + len(LEB128) + N bytes, where N is the minimal encoding length.
     byte is `1`. For example, `-1n` is `0xFF` (1 byte), `-128n` is `0x80`
     (1 byte), and `-129n` is `0xFF 0x7F` (2 bytes).
 
-### 4.6 `undefined`
+### 4.6 `symbol`
+
+```
+Bytes: TAG_SYMBOL  KEY_STRING
+       0x2A        <string, §4.4>
+```
+
+- **Key string**: The result of `Symbol.keyFor(s)` — a JavaScript string —
+  encoded as a complete tagged string value per Section 4.4. Concretely,
+  this emits either the direct form (`TAG_STRING` + LEB128 length + UTF-8
+  bytes) for keys whose UTF-8 encoding is 64 bytes or fewer, or the hashed
+  form (`TAG_STRING_HASH` + 32-byte SHA-256 of the UTF-8) for longer keys.
+
+Only **registry-interned** symbols (those for which `Symbol.keyFor(s)`
+returns a string) are hashable. **Unique** symbols (`Symbol(desc)`, where
+`Symbol.keyFor(s)` returns `undefined`) have no portable representation; a
+conforming implementation must throw rather than producing a hash. The
+required error message is `"Cannot hash unique (uninterned) symbol"`.
+
+The two-tag encoding (`TAG_SYMBOL` followed by `TAG_STRING` / `TAG_STRING_HASH`)
+ensures that a `Symbol.for("foo")` and the string `"foo"` produce different
+hashes, while inheriting the short/long string-encoding delegation
+unchanged.
+
+> **Conversion-gate cross-reference.** Whether a symbol value reaches this
+> layer in a given run depends on the `modernDataModel` flag at the
+> fabric-value conversion gate; see `1-fabric-values.md` Section 4.9. The
+> byte-level encoding above is the hasher's contract regardless of how the
+> value arrived.
+
+### 4.7 `undefined`
 
 ```
 Bytes: TAG_UNDEFINED
@@ -226,7 +256,7 @@ Bytes: TAG_UNDEFINED
 
 Total: 1 byte. No payload.
 
-### 4.7 `FabricBytes`
+### 4.8 `FabricBytes`
 
 ```
 Bytes: TAG_BYTES  LENGTH_LEB128  RAW_BYTES
@@ -241,7 +271,7 @@ Total: 1 + len(LEB128) + N bytes, where N is the byte array length.
 Empty byte array is encoded as `0x25 0x00` — the tag plus a zero-length prefix
 and no payload bytes.
 
-### 4.8 `FabricEpochNsec`
+### 4.9 `FabricEpochNsec`
 
 ```
 Bytes: TAG_EPOCH_NSEC  LENGTH_LEB128  TWO_COMP_BYTES
@@ -262,7 +292,7 @@ The encoding is structurally identical to `TAG_BIGINT` but uses a different type
 tag (`0x27` instead of `0x26`), ensuring that `FabricEpochNsec(42n)` and
 `42n` produce distinct hashes.
 
-### 4.9 `FabricEpochDays`
+### 4.10 `FabricEpochDays`
 
 ```
 Bytes: TAG_EPOCH_DAYS  LENGTH_LEB128  TWO_COMP_BYTES
@@ -284,7 +314,7 @@ tag (`0x28` instead of `0x26`), ensuring that `FabricEpochDays(42n)` and
 `42n` produce distinct hashes. It also differs from `FabricEpochNsec` (`0x27`)
 so the two temporal types are always distinguishable.
 
-### 4.10 `FabricHash`
+### 4.11 `FabricHash`
 
 ```
 Bytes: TAG_CONTENT_ID  ALG_TAG_STRING   HASH_LEN_LEB128  HASH_BYTES
@@ -307,7 +337,7 @@ tag. It is a `FabricPrimitive` subclass and has a dedicated type tag.
 The two-field encoding ensures that content IDs with different algorithm tags
 but identical hash bytes produce different hashes, and vice versa.
 
-### 4.11 Array
+### 4.12 Array
 
 ```
 Bytes: TAG_ARRAY  ELEMENT_0  ELEMENT_1  ...  ELEMENT_N-1  TAG_END
@@ -317,7 +347,7 @@ Bytes: TAG_ARRAY  ELEMENT_0  ELEMENT_1  ...  ELEMENT_N-1  TAG_END
 - **Elements**: Each element is hashed recursively in index order (0, 1, 2,
   ...). Present elements are fed to the hasher as complete tagged values
   (starting with their own type tag). Holes are encoded using run-length
-  encoding (see Section 4.14).
+  encoding (see Section 4.15).
 - **Terminator**: `TAG_END` (`0x00`) marks the end of the element sequence.
   This is unambiguous because `TAG_END` cannot appear as the start of any
   element value.
@@ -325,7 +355,7 @@ Bytes: TAG_ARRAY  ELEMENT_0  ELEMENT_1  ...  ELEMENT_N-1  TAG_END
 Empty array (`[]`) is encoded as `0x10 0x00` — the tag immediately followed by
 `TAG_END`.
 
-### 4.12 Object
+### 4.13 Object
 
 ```
 Bytes: TAG_OBJECT  KEY_0  VALUE_0  KEY_1  VALUE_1  ...  TAG_END
@@ -348,7 +378,7 @@ Bytes: TAG_OBJECT  KEY_0  VALUE_0  KEY_1  VALUE_1  ...  TAG_END
 Empty object (`{}`) is encoded as `0x11 0x00` — the tag immediately followed by
 `TAG_END`.
 
-### 4.13 `FabricInstance`
+### 4.14 `FabricInstance`
 
 ```
 Bytes: TAG_INSTANCE  TYPE_TAG_STRING  STATE
@@ -368,10 +398,10 @@ Bytes: TAG_INSTANCE  TYPE_TAG_STRING  STATE
 > **Note on types with dedicated tags.** `FabricBytes`,
 > `FabricEpochNsec`, `FabricEpochDays`, and `FabricHash` are **not**
 > hashed via `TAG_INSTANCE`. Each has a dedicated type tag and is encoded
-> directly (see Sections 4.7, 4.8, 4.9, and 4.10 respectively). These are
+> directly (see Sections 4.8, 4.9, 4.10, and 4.11 respectively). These are
 > all `FabricPrimitive` subclasses — they do not implement `[DECONSTRUCT]`.
 
-### 4.14 Holes (sparse array elements)
+### 4.15 Holes (sparse array elements)
 
 ```
 Bytes: TAG_HOLE  RUN_COUNT_LEB128
@@ -380,7 +410,7 @@ Bytes: TAG_HOLE  RUN_COUNT_LEB128
 
 Total: 1 + len(LEB128) bytes per run (typically 2 bytes for small runs).
 
-Holes appear only within array encodings (Section 4.11). Consecutive holes are
+Holes appear only within array encodings (Section 4.12). Consecutive holes are
 **always coalesced** into maximal runs:
 
 - A single hole at index `i` with present elements at `i-1` and `i+1` is
@@ -671,25 +701,28 @@ the rule is "64 bytes or fewer → direct". A 65-byte UTF-8 string uses the
 hashed form.
 
 This rule applies to every string the hasher feeds, including standalone
-strings (Section 4.4), object keys (Section 4.12), `FabricInstance` type
-tags (Section 4.13), and `FabricHash` algorithm tags (Section 4.10). The
-threshold is evaluated per-string independently: an object may mix short
-keys (direct form) and long keys (hashed form) in the same key-value
-sequence.
+strings (Section 4.4), `symbol` keys (Section 4.6), object keys (Section
+4.13), `FabricInstance` type tags (Section 4.14), and `FabricHash`
+algorithm tags (Section 4.11). The threshold is evaluated per-string
+independently: an object may mix short keys (direct form) and long keys
+(hashed form) in the same key-value sequence.
 
 ---
 
 ## 8. Rejected Values
 
-The following JavaScript values are rejected by `fabricFromNativeValue()` and
-must never be passed to the hasher:
+The following JavaScript values must never be passed to the hasher:
 
-- `Symbol` values
-- `Function` values
+- **Unique (uninterned) `Symbol` values** — those for which
+  `Symbol.keyFor(s)` returns `undefined`. Registry-interned symbols
+  (`Symbol.for(key)`) **are** hashable; see Section 4.6. The required
+  error message is `"Cannot hash unique (uninterned) symbol"`.
+- **`Function` values** — opaque closures with no portable representation.
 
 A conforming implementation should throw an error if it encounters either
 of these rather than producing a hash. (`NaN`, `±Infinity`, and `-0` are
-**not** rejected; they have well-defined byte encodings — see Section 4.3.)
+**not** rejected; they have well-defined byte encodings — see Section
+4.3.)
 
 ---
 
@@ -706,6 +739,7 @@ of these rather than producing a hash. (`NaN`, `±Infinity`, and `-0` are
 | `FabricHash` algorithm tag        | string (§4.4)   | Emitted as a complete tagged string value (direct or hashed form) |
 | `FabricHash` hash bytes           | unsigned LEB128 | Byte count of raw hash payload   |
 | `FabricInstance` type tag         | string (§4.4)   | Emitted as a complete tagged string value (direct or hashed form) |
+| `symbol` registry key             | string (§4.4)   | Emitted as a complete tagged string value (direct or hashed form), prefixed by `TAG_SYMBOL` |
 | Object keys                       | string (§4.4)   | Emitted as complete tagged string values (direct or hashed form per key) |
 | Hole run count                    | unsigned LEB128 | Number of consecutive holes      |
 | Array elements                    | `TAG_END`       | Sentinel after last element      |

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -169,6 +169,28 @@ round-trip correctly.
 // `modernDataModel` flag at the fabric-value conversion gate; see
 // `1-fabric-values.md` Section 4.9. The wire format above is the encoder's
 // contract regardless of how the values arrived.
+
+// Registry-interned symbols (`Symbol.for(key)`).
+// Tag: "Symbol@1"
+// { "/Symbol@1": string }
+//
+// The state is the registry key — the JavaScript string returned by
+// `Symbol.keyFor(s)`. On deserialization, `Symbol.for(state)` retrieves
+// (or creates) the registry symbol with the matching key, so the result
+// is `===` to any other `Symbol.for(state)` in the same realm.
+//
+// Unique symbols (`Symbol(desc)`, where `Symbol.keyFor(s)` returns
+// `undefined`) have no portable representation. The handler's
+// `canSerialize()` returns `false` for them, which routes them to the
+// registry's "unhandled value" path rather than coercing them silently
+// to a registry key. On deserialization, any state other than a string
+// yields a `ProblematicValue` (see `1-fabric-values.md` Section 3.5)
+// per the general handler-validation rule below.
+//
+// Whether a symbol value reaches this encoder in a given run is gated
+// by the `modernDataModel` flag at the fabric-value conversion gate;
+// see `1-fabric-values.md` Section 4.9. The wire format above is the
+// encoder's contract regardless of how the value arrived.
 ```
 
 > **Deserialization validation.** Deserialization cannot assume type safety from

--- a/docs/specs/space-model/1-data-model.md
+++ b/docs/specs/space-model/1-data-model.md
@@ -78,9 +78,33 @@ fabric-value conversion gate:
 These types cannot be stored directly:
 
 - `bigint` — throws error
-- `symbol` — throws error
+- `symbol` — bifurcated by the `modernDataModel` flag (see Symbols below)
 - `function` — throws error unless it has a `toJSON()` method
 - Class instances — throws error unless they have `toJSON()` or special handling
+
+#### Symbols
+
+Symbol handling is bifurcated by the `modernDataModel` flag at the
+fabric-value conversion gate:
+
+- **Legacy path (`modernDataModel: false`):**
+  - All symbols throw errors during conversion
+- **Modern path (`modernDataModel: true`):**
+  - Registry-interned symbols (`Symbol.for(key)`, where
+    `Symbol.keyFor(s)` returns a string) are first-class fabric values,
+    portable across realms and processes via their registry key
+  - Unique symbols (`Symbol(desc)`) throw with the message
+    `"Cannot store unique (uninterned) symbol"`
+  - Round-trip via the `Symbol@1` JSON envelope (see
+    `space-model-formal-spec/3-json-encoding.md` Section 3) and via the
+    byte-level form in `space-model-formal-spec/2-hash-byte-format.md`
+    Section 4.6, both of which describe the lower-layer behavior
+    unconditionally; the formal `1-fabric-values.md` Section 4.9 carries
+    the conversion-gate flag-bifurcation language
+
+Note: this is about symbol *values*. Symbol-keyed *properties* on plain
+objects continue to cause rejection regardless of the flag (see "Objects"
+above), because plain-object keys must be strings.
 
 ### Special Object Shapes
 


### PR DESCRIPTION
## Summary

Spec-only sync pass aligning the data-model formal and informal
specs with the **interned-symbols cluster** that landed on `main`
2026-05-06. No code touched. Triggering Dan-direct cluster:

- **PR #3503** — admit interned symbols into the `FabricValue` type
  union; allocate hash tag byte `TAG_SYMBOL = 0x2A`; introduce the
  `Symbol@1` JSON wire form `{ "/Symbol@1": "<key>" }`.
- **PR #3510** — relax the modern fabric-value gate to admit
  registry-interned symbols (`Symbol.keyFor(s) !== undefined`) while
  throwing for unique symbols.
- **PR #3511** — runner-level cell-storage Symbol test bifurcation
  (test-only; spec-irrelevant by itself; included for cluster
  completeness).

All three commit messages flagged "spec catch-up is deferred to the
same future spec-work session as the weird-numbers spec update" —
this PR is that session.

## Per-spec-file walkthrough

### `1-fabric-values.md` (formal)

- **§1.2** — admit a `symbol` arm to the `FabricValue` union code
  block. Reframe the "Excluded JS types" callout into "Restricted
  and excluded": `symbol` becomes **conditionally** part of the
  universe (registry-interned admitted; unique rejected) with the
  TS type unable to express the distinction so it is enforced at
  runtime; `function` remains fully excluded.
- **§1.3** — add a `symbol` row to the primitives table and a
  layer-bifurcated callout modeled on the `-0`/NaN/Infinity callout
  from PR #3502. The callout describes the modern path
  (interned passes through `shallowFabricFromNativeValueModern()` /
  `fabricFromNativeValueModern()`, unique symbols throw
  `"Cannot store unique (uninterned) symbol"`) and the legacy path
  (rejects all symbols), and cross-references §4.9.
- **§1.5 (Recursive Containers)** — disambiguate "symbol keys cause
  rejection" so it clearly applies to symbol-keyed *properties* and
  is distinct from symbol *values*, which are admitted per §1.2.
- **§6.3** — add `TAG_SYMBOL = 0x2A` row to the primitive-tag table.
- **§8.2** — add `symbol` row to the conversion rules table.
- **§8.3** — extend `isFabricCompatible()` per-path bullets to
  cover the symbol case (modern accepts interned only, legacy
  rejects all).

### `2-hash-byte-format.md` (formal)

- **New §4.6 `symbol`** — bytes are `[TAG_SYMBOL]` followed by the
  §4.4 string production for `Symbol.keyFor(s)` (direct or
  `TAG_STRING_HASH` long form). Two-tag encoding ensures
  `Symbol.for("foo")` and the string `"foo"` produce different
  hashes. Required throw message for unique symbols:
  `"Cannot hash unique (uninterned) symbol"`. Cross-reference back
  to `1-fabric-values.md` §4.9 for the conversion gate.
- **§4.x renumber** — inserting `symbol` between `bigint` and
  `undefined` pushes §4.7-§4.15 down one each. Sage spot-checked
  all 5 internal cross-refs (§4.4 short/long string-rule listing
  in §6.4; §4.13 "types with dedicated tags" note pointing at
  §4.8/§4.9/§4.10/§4.11; §4.12 array → §4.15 holes ref; §4.15
  holes → §4.12 array back-ref) and verified no external files
  reference §4.5+.
- **§8 Rejected Values** — refine "Symbol values" to
  "**Unique (uninterned)** `Symbol` values," cross-reference §4.6
  for the interned case.
- **§9 Summary table** — add `symbol` registry key row.

### `3-json-encoding.md` (formal)

- **§3 standard type encodings** — add a `Symbol@1` block after
  `SpecialNumber@1`, modeled on `BigInt@1`. Wire form
  `{ "/Symbol@1": "<key>" }` where the state is the registry key
  (`Symbol.keyFor(s)`); deserialization via `Symbol.for(state)`,
  yielding `===`-equal results within a realm. Documents
  `canSerialize() === false` for unique symbols (routing them to
  the unhandled-value path) and non-string state →
  `ProblematicValue` per the general handler-validation rule.
  Cross-references `1-fabric-values.md` §4.9.

### `1-data-model.md` (informal)

- Non-Fabric-Types list: `symbol` line rewritten to point at the
  new bifurcated subsection.
- New **Symbols** subsection mirroring the bifurcated Numbers
  subsection from PR #3502: legacy rejects all; modern admits
  registry-interned, rejects unique with the canonical error
  message; cross-references the formal lower layers (§4.6 hash
  byte format, §3 JSON encoding) and the gate layer (§4.9).
  Closing note disambiguates symbol *values* from symbol-keyed
  *properties*.

## Per-layer-vs-cross-cutting framing

Lower-layer specs (`2-hash-byte-format.md`, `3-json-encoding.md`,
informal `1-data-model.md` Symbols subsection) describe their own
behavior unconditionally and cross-reference back to
`1-fabric-values.md` §4.9. The conversion-gate spec carries the
flag-bifurcation language. `Symbol@1` followed the
`SpecialNumber@1` template (PR #3502) cleanly — durable
methodology from `coordination/roles/spec-writer.md`'s "Per-layer
spec sync over cross-cutting flag-bifurcation" subsection
(promoted to durable rule end of session 2026-069).

## Risk

Spec-only sync; no production code touched. `deno fmt` excludes
`docs/`, `deno lint` doesn't apply to `.md`, so no fmt/lint gate
concerns. Reverts are trivial if the underlying upstream cluster
is rolled back.

---

Co-Authored-By: spec-writer-sage (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>

## Performance Baseline

This PR is doc-only, so the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/notes/note-md.test.tsx = 31s
NEW_PERF_BASELINE: job: Check = 74s
