### PR TITLE
chore(data-model,content-hash): align doc comments with revised guidelines

### DIFF
--- a/packages/content-hash/src/BaseCollectingHasher.ts
+++ b/packages/content-hash/src/BaseCollectingHasher.ts
@@ -27,9 +27,9 @@ export abstract class BaseCollectingHasher extends BaseIncrementalHasher {
   #currentOffset = 0;
 
   /**
-   * This is called by the base class to perform a digest operation using the
-   * underlying hash implementation. It is allowed to ignore the `encoding` and
-   * always return a `Uint8Array`.
+   * Performs a digest operation on the collected chunks using the underlying
+   * hash implementation. Called by the base class. May ignore the `encoding`
+   * and always return a `Uint8Array`.
    */
   protected abstract _digestChunks(
     encoding: string | undefined,

--- a/packages/content-hash/src/BaseIncrementalHasher.ts
+++ b/packages/content-hash/src/BaseIncrementalHasher.ts
@@ -51,15 +51,15 @@ export abstract class BaseIncrementalHasher implements IncrementalHasher {
   }
 
   /**
-   * This is called by the base class when there is data to be passed to the
-   * underlying hash implementation.
+   * Passes data to the underlying hash implementation. Called by the base
+   * class when there is data to be hashed.
    */
   protected abstract _rawUpdate(data: Uint8Array): void;
 
   /**
-   * This is called by the base class to perform a digest operation using the
-   * underlying hash implementation. It is allowed to ignore the `encoding` and
-   * always return a `Uint8Array`.
+   * Performs a digest operation using the underlying hash implementation.
+   * Called by the base class. May ignore the `encoding` and always return a
+   * `Uint8Array`.
    */
   protected abstract _rawDigest(
     encoding: string | undefined,

--- a/packages/content-hash/src/BaseSmallChunkUpdatingHasher.ts
+++ b/packages/content-hash/src/BaseSmallChunkUpdatingHasher.ts
@@ -21,6 +21,7 @@ export abstract class BaseSmallChunkUpdatingHasher
   #smalls = new Uint8Array(SMALLS_SIZE);
   #smallsOffset: number = 0;
 
+  /** @inheritDoc */
   override digest(): Uint8Array;
   override digest(encoding: "base64url"): string;
   override digest(encoding: string | undefined): Uint8Array | string;
@@ -29,6 +30,7 @@ export abstract class BaseSmallChunkUpdatingHasher
     return super.digest(encoding);
   }
 
+  /** @inheritDoc */
   override update(data: Uint8Array) {
     const length = data.length;
 

--- a/packages/content-hash/src/InstancePool.ts
+++ b/packages/content-hash/src/InstancePool.ts
@@ -39,7 +39,7 @@ export class InstancePool<T extends WeakKey> {
   }
 
   /**
-   * Is there an instance available for acquisition?
+   * Indicates whether an instance is available for acquisition.
    */
   canAcquire() {
     return this.#pool.length !== 0;

--- a/packages/content-hash/src/index.ts
+++ b/packages/content-hash/src/index.ts
@@ -39,6 +39,6 @@ if (canUseDeno()) {
 export { sha256 };
 
 /**
- * Create a new incremental SHA-256 hasher.
+ * Creates a new incremental SHA-256 hasher.
  */
 export { createHasher };

--- a/packages/content-hash/src/interface.ts
+++ b/packages/content-hash/src/interface.ts
@@ -3,8 +3,16 @@
  * `digest()`. A hasher must not be reused after `digest()` is called.
  */
 export interface IncrementalHasher {
+  /** Feeds the given data into the hasher. Must not be called after `digest()`. */
   update(data: Uint8Array): void;
+
+  /** Finalizes the hash and returns the digest as a `Uint8Array`. */
   digest(): Uint8Array;
+
+  /**
+   * Finalizes the hash and returns the digest as a string in the given
+   * encoding. Currently only `"base64url"` (unpadded) is supported.
+   */
   digest(encoding: "base64url"): string;
 }
 

--- a/packages/content-hash/src/sha256-deno.ts
+++ b/packages/content-hash/src/sha256-deno.ts
@@ -60,7 +60,7 @@ class DenoHasher extends BaseIncrementalHasher {
 }
 
 /**
- * Is this module usable?
+ * Indicates whether this module is usable.
  */
 export function canUseDeno() {
   return crypto !== null;

--- a/packages/content-hash/src/sha256-wasm.ts
+++ b/packages/content-hash/src/sha256-wasm.ts
@@ -23,6 +23,7 @@ const HASHER_POOL_SIZE = 5;
  * used synchronously).
  */
 class HasherPool extends InstancePool<IHasher> {
+  /** @inheritDoc */
   protected override _initInstance(instance: IHasher) {
     instance.init();
   }

--- a/packages/content-hash/src/sha256-wasm.ts
+++ b/packages/content-hash/src/sha256-wasm.ts
@@ -32,8 +32,8 @@ class HasherPool extends InstancePool<IHasher> {
 const hasherPool = new HasherPool();
 
 /**
- * A hasher instance which _isn't_ allowed to be acquired for concurrent use.
- * This is the one used to serve one-shot hash requests.
+ * The one-shot hasher instance, _not_ allowed to be acquired for concurrent
+ * use. Used to serve one-shot hash requests.
  */
 const theOneShotHasher: IHasher[] = [];
 
@@ -44,7 +44,7 @@ const theOneShotHasher: IHasher[] = [];
 let initResult: Promise<boolean> | null = null;
 
 /**
- * Is this module actually usable?
+ * Whether this module is actually usable.
  */
 let moduleIsUsable: boolean = false;
 

--- a/packages/data-model/array-utils.ts
+++ b/packages/data-model/array-utils.ts
@@ -73,9 +73,9 @@ export function isArrayIndexPropertyName(name: string): boolean {
 }
 
 /**
- * Helper which accepts an array and checks to see whether all of its enumerable
- * own properties are numeric indices (that is, it has no named properties).
- * This returns `true` for sparse arrays.
+ * Indicates whether all of the given array's enumerable own properties are
+ * numeric indices (that is, it has no named properties). Returns `true` for
+ * sparse arrays.
  *
  * @param array The array to check.
  * @returns `true` if the array has only numeric properties, `false` otherwise.

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -13,9 +13,10 @@
 // ---------------------------------------------------------------------------
 
 /**
- * Converts a hex digit char code to its 4-bit numeric value. Handles '0'-'9'
- * (0x30-0x39) and 'a'-'f' (0x61-0x66). Used instead of `parseInt` for ~2x
- * faster hex-to-byte conversion (see bigint-hashing-performance.md).
+ * Helper for `bigintToMinimalTwosComplement()`, which converts a hex digit
+ * char code to its 4-bit numeric value. Handles '0'-'9' (0x30-0x39) and
+ * 'a'-'f' (0x61-0x66). Used instead of `parseInt` for ~2x faster
+ * hex-to-byte conversion (see bigint-hashing-performance.md).
  */
 function hexToNibble(c: number): number {
   // '0'-'9' = 0x30-0x39, 'a'-'f' = 0x61-0x66

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -13,7 +13,7 @@
 // ---------------------------------------------------------------------------
 
 /**
- * Convert a hex digit char code to its 4-bit numeric value. Handles '0'-'9'
+ * Converts a hex digit char code to its 4-bit numeric value. Handles '0'-'9'
  * (0x30-0x39) and 'a'-'f' (0x61-0x66). Used instead of `parseInt` for ~2x
  * faster hex-to-byte conversion (see bigint-hashing-performance.md).
  */
@@ -33,7 +33,7 @@ const dv64View = new DataView(dv64Buf);
 const dv64Bytes = new Uint8Array(dv64Buf);
 
 /**
- * Convert a bigint to its minimal two's-complement big-endian byte
+ * Converts a bigint to its minimal two's-complement big-endian byte
  * representation. The encoding is the same one used by the hash
  * byte-level spec (Section 3.7).
  *
@@ -125,7 +125,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
 // ---------------------------------------------------------------------------
 
 /**
- * Interpret a byte array as a two's-complement big-endian integer and return
+ * Interprets a byte array as a two's-complement big-endian integer and returns
  * the corresponding bigint. Empty input throws.
  */
 export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {

--- a/packages/data-model/deep-freeze.ts
+++ b/packages/data-model/deep-freeze.ts
@@ -65,7 +65,7 @@ export function isDeepFrozen(value: unknown): boolean {
 }
 
 /**
- * Internal recursive deep-frozen check with cycle detection.
+ * Performs the recursive deep-frozen check with cycle detection.
  */
 function isDeepFrozenInProgress(
   value: unknown,

--- a/packages/data-model/deep-freeze.ts
+++ b/packages/data-model/deep-freeze.ts
@@ -120,6 +120,12 @@ function isDeepFrozenInProgress(
   return result;
 }
 
+/**
+ * Recursively freezes the given value in place: arrays and plain objects are
+ * frozen after their children are recursively frozen. Primitives pass through
+ * unchanged. Records the result in the deep-frozen cache so subsequent
+ * `isDeepFrozen()` checks return in O(1). Returns the (now-frozen) value.
+ */
 export function deepFreeze<T>(value: T): T {
   if (isNecessarilyOrKnownDeepFrozen(value)) {
     return value;

--- a/packages/data-model/fabric-bytes.ts
+++ b/packages/data-model/fabric-bytes.ts
@@ -37,7 +37,7 @@ export class FabricBytes extends FabricPrimitive {
   }
 
   /**
-   * Return a copy of the bytes (or a sub-range). The returned array is
+   * Returns a copy of the bytes (or a sub-range). The returned array is
    * unshared -- the caller may mutate it freely.
    *
    * @param start - Start index (inclusive, default 0).
@@ -48,7 +48,7 @@ export class FabricBytes extends FabricPrimitive {
   }
 
   /**
-   * Copy bytes from this instance into a caller-provided buffer.
+   * Copies bytes from this instance into a caller-provided buffer.
    *
    * @param target - The destination buffer.
    * @param offset - Byte offset in the source to start copying from (default 0).

--- a/packages/data-model/fabric-hash.ts
+++ b/packages/data-model/fabric-hash.ts
@@ -9,7 +9,7 @@ import {
 } from "@commonfabric/utils/base64url";
 
 /**
- * A content-addressed identifier: a hash digest paired with an algorithm tag.
+ * Content-addressed identifier: a hash digest paired with an algorithm tag.
  * Extends `FabricPrimitive` -- treated like a primitive in the fabric
  * type system (always frozen, passes through conversion unchanged).
  *
@@ -84,7 +84,7 @@ export class FabricHash extends FabricPrimitive implements ApiFabricHash {
     return this.#justHashString;
   }
 
-  /** Copy the hash bytes into `target` starting at offset 0. Returns `target`. */
+  /** Copies the hash bytes into `target` starting at offset 0. Returns `target`. */
   copyInto(target: Uint8Array): Uint8Array {
     target.set(this.#hash);
     return target;
@@ -96,7 +96,7 @@ export class FabricHash extends FabricPrimitive implements ApiFabricHash {
   }
 
   /**
-   * JSON representation: `{ '/': '<tag>:<base64urlHash>' }`.
+   * Returns the JSON representation: `{ '/': '<tag>:<base64urlHash>' }`.
    * Preserves the `{"/": string}` shape used by `Reference.View.toJSON()`.
    */
   toJSON(): { "/": string } {

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -50,7 +50,8 @@ export const UNSAFE_KEYS: FrozenSet<string> = new FrozenSet([
 ]);
 
 /**
- * Copies own enumerable properties from `source` to `target`, skipping
+ * Helper for `copyError()` and `FabricError.[DECONSTRUCT]()`, which copies
+ * own enumerable properties from `source` to `target`, skipping
  * prototype-sensitive keys (`__proto__`, `constructor`). When `noOverride`
  * is `true`, keys already present on `target` are also skipped.
  */
@@ -99,8 +100,9 @@ const ERROR_CLASS_BY_TYPE: ReadonlyMap<string, ErrorConstructor> = new Map([
 ]);
 
 /**
- * Returns the `Error` constructor for the given type string (e.g. `"TypeError"`).
- * Falls back to the base `Error` constructor for unknown types.
+ * Helper for `FabricError.[RECONSTRUCT]()`, which returns the `Error`
+ * constructor for the given type string (e.g. `"TypeError"`). Falls back
+ * to the base `Error` constructor for unknown types.
  */
 function errorClassFromType(type: string): ErrorConstructor {
   return ERROR_CLASS_BY_TYPE.get(type) ?? Error;
@@ -413,9 +415,10 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
 }
 
 /**
- * Rejects RegExp instances with extra enumerable properties. The built-in
- * `lastIndex` property is not enumerable, so `Object.keys()` won't see it.
- * Any enumerable own property is therefore user-added and causes rejection.
+ * Helper for `FabricRegExp.[DECONSTRUCT]()`, which rejects RegExp instances
+ * with extra enumerable properties. The built-in `lastIndex` property is not
+ * enumerable, so `Object.keys()` won't see it. Any enumerable own property
+ * is therefore user-added and causes rejection.
  */
 function rejectExtraRegExpProperties(regex: RegExp): void {
   if (Object.keys(regex).length > 0) {

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -153,7 +153,7 @@ export abstract class FabricNativeWrapper<T extends object>
  * See Section 1.4.1 of the formal spec.
  */
 export class FabricError extends FabricNativeWrapper<Error> {
-  /** The type tag used in the wire format (`TAGS.Error`). */
+  /** @inheritDoc */
   readonly typeTag = TAGS.Error;
 
   constructor(
@@ -200,18 +200,22 @@ export class FabricError extends FabricNativeWrapper<Error> {
     return state as FabricValue;
   }
 
+  /** @inheritDoc */
   protected shallowUnfrozenClone(): FabricError {
     return new FabricError(this.error);
   }
 
+  /** @inheritDoc */
   protected get wrappedValue(): Error {
     return this.error;
   }
 
+  /** @inheritDoc */
   protected toNativeFrozen(): Error {
     return Object.freeze(copyError(this.error));
   }
 
+  /** @inheritDoc */
   protected toNativeThawed(): Error {
     return copyError(this.error);
   }
@@ -271,6 +275,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
  */
 export class FabricMap
   extends FabricNativeWrapper<Map<FabricValue, FabricValue>> {
+  /** @inheritDoc */
   readonly typeTag = TAGS.Map;
   constructor(readonly map: Map<FabricValue, FabricValue>) {
     super();
@@ -280,18 +285,22 @@ export class FabricMap
     throw new Error("FabricMap: not yet implemented");
   }
 
+  /** @inheritDoc */
   protected shallowUnfrozenClone(): FabricMap {
     return new FabricMap(this.map);
   }
 
+  /** @inheritDoc */
   protected get wrappedValue(): Map<FabricValue, FabricValue> {
     return this.map;
   }
 
+  /** @inheritDoc */
   protected toNativeFrozen(): FrozenMap<FabricValue, FabricValue> {
     return new FrozenMap(this.map);
   }
 
+  /** @inheritDoc */
   protected toNativeThawed(): Map<FabricValue, FabricValue> {
     return new Map(this.map);
   }
@@ -310,6 +319,7 @@ export class FabricMap
  * wrapped collection are not supported on non-Error wrappers.
  */
 export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
+  /** @inheritDoc */
   readonly typeTag = TAGS.Set;
   constructor(readonly set: Set<FabricValue>) {
     super();
@@ -319,18 +329,22 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
     throw new Error("FabricSet: not yet implemented");
   }
 
+  /** @inheritDoc */
   protected shallowUnfrozenClone(): FabricSet {
     return new FabricSet(this.set);
   }
 
+  /** @inheritDoc */
   protected get wrappedValue(): Set<FabricValue> {
     return this.set;
   }
 
+  /** @inheritDoc */
   protected toNativeFrozen(): FrozenSet<FabricValue> {
     return new FrozenSet(this.set);
   }
 
+  /** @inheritDoc */
   protected toNativeThawed(): Set<FabricValue> {
     return new Set(this.set);
   }
@@ -351,7 +365,7 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
  * See Section 1.4.1 of the formal spec.
  */
 export class FabricRegExp extends FabricNativeWrapper<RegExp> {
-  /** The type tag used in the wire format (`TAGS.RegExp`). */
+  /** @inheritDoc */
   readonly typeTag = TAGS.RegExp;
 
   constructor(
@@ -377,10 +391,12 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
     } as FabricValue;
   }
 
+  /** @inheritDoc */
   protected shallowUnfrozenClone(): FabricRegExp {
     return new FabricRegExp(this.regex, this.flavor);
   }
 
+  /** @inheritDoc */
   protected get wrappedValue(): RegExp {
     return this.regex;
   }
@@ -394,6 +410,7 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
     return Object.freeze(new RegExp(this.regex));
   }
 
+  /** @inheritDoc */
   protected toNativeThawed(): RegExp {
     return new RegExp(this.regex);
   }

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -119,6 +119,7 @@ function errorClassFromType(type: string): ErrorConstructor {
  */
 export abstract class FabricNativeWrapper<T extends object>
   extends FabricInstance {
+  /** The wire format tag for this wrapper's type (e.g. `TAGS.Error`). */
   abstract readonly typeTag: string;
 
   /** The wrapped native value, used by `toNativeValue` for freeze-state checks. */

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -50,7 +50,7 @@ export const UNSAFE_KEYS: FrozenSet<string> = new FrozenSet([
 ]);
 
 /**
- * Copy own enumerable properties from `source` to `target`, skipping
+ * Copies own enumerable properties from `source` to `target`, skipping
  * prototype-sensitive keys (`__proto__`, `constructor`). When `noOverride`
  * is `true`, keys already present on `target` are also skipped.
  */
@@ -67,7 +67,7 @@ function copyOwnSafeProperties(
 }
 
 /**
- * Create a shallow copy of an Error, preserving constructor, name, message,
+ * Creates a shallow copy of an Error, preserving constructor, name, message,
  * stack, cause, and custom enumerable properties. Used by `toNativeValue()`
  * when the freeze state of the wrapped Error doesn't match the requested state.
  */
@@ -99,7 +99,7 @@ const ERROR_CLASS_BY_TYPE: ReadonlyMap<string, ErrorConstructor> = new Map([
 ]);
 
 /**
- * Return the `Error` constructor for the given type string (e.g. `"TypeError"`).
+ * Returns the `Error` constructor for the given type string (e.g. `"TypeError"`).
  * Falls back to the base `Error` constructor for unknown types.
  */
 function errorClassFromType(type: string): ErrorConstructor {
@@ -124,13 +124,13 @@ export abstract class FabricNativeWrapper<T extends object>
   /** The wrapped native value, used by `toNativeValue` for freeze-state checks. */
   protected abstract get wrappedValue(): T;
 
-  /** Convert the wrapped value to frozen form (only called on state mismatch). */
+  /** Converts the wrapped value to frozen form (only called on state mismatch). */
   protected abstract toNativeFrozen(): T;
 
-  /** Convert the wrapped value to thawed form (only called on state mismatch). */
+  /** Converts the wrapped value to thawed form (only called on state mismatch). */
   protected abstract toNativeThawed(): T;
 
-  /** Return the underlying native value, optionally frozen. */
+  /** Returns the underlying native value, optionally frozen. */
   toNativeValue(frozen: boolean): T {
     const value = this.wrappedValue;
     if (frozen === Object.isFrozen(value)) return value;
@@ -161,7 +161,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
   }
 
   /**
-   * Deconstruct into essential state for serialization. Returns type, name,
+   * Deconstructs into essential state for serialization. Returns type, name,
    * message, stack, cause, and custom enumerable properties. Does NOT recurse
    * into nested values -- the serialization system handles that.
    *
@@ -214,7 +214,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
   }
 
   /**
-   * Reconstruct a `FabricError` from its essential state. Nested values
+   * Reconstructs a `FabricError` from its essential state. Nested values
    * in `state` have already been reconstructed by the serialization system.
    * Returns a `FabricError` wrapping the reconstructed `Error`; callers
    * who need the native `Error` use `nativeFromFabricValue()`.
@@ -361,7 +361,7 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
   }
 
   /**
-   * Deconstruct into essential state for serialization. Returns
+   * Deconstructs into essential state for serialization. Returns
    * `{ source, flags, flavor }` -- the values needed to reconstruct the
    * RegExp. Extra enumerable properties on the RegExp cause rejection.
    */
@@ -383,7 +383,7 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
   }
 
   /**
-   * Return a frozen copy of the RegExp. A frozen RegExp has an immutable
+   * Returns a frozen copy of the RegExp. A frozen RegExp has an immutable
    * `lastIndex`, so stateful methods (`exec()`, `test()`) won't work
    * correctly -- but that matches the "death before confusion" principle.
    */
@@ -396,7 +396,7 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
   }
 
   /**
-   * Reconstruct a `FabricRegExp` from its essential state
+   * Reconstructs a `FabricRegExp` from its essential state
    * (`{ source, flags, flavor }`).
    */
   static [RECONSTRUCT](
@@ -412,7 +412,7 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
 }
 
 /**
- * Reject RegExp instances with extra enumerable properties. The built-in
+ * Rejects RegExp instances with extra enumerable properties. The built-in
  * `lastIndex` property is not enumerable, so `Object.keys()` won't see it.
  * Any enumerable own property is therefore user-added and causes rejection.
  */

--- a/packages/data-model/fabric-value-legacy.ts
+++ b/packages/data-model/fabric-value-legacy.ts
@@ -48,6 +48,8 @@ function specialInstanceToFabricValue(
  *
  * @param value - The value to check.
  * @returns `true` if the value has a `toJSON` method that is a function.
+ *
+ * This function is a TypeScript type guard for `{ toJSON: () => unknown }`.
  */
 function hasToJSONMethod(
   value: unknown,
@@ -66,6 +68,8 @@ function hasToJSONMethod(
  *
  * @param value - The value to check.
  * @returns `true` if the value is fabric-compatible per se, `false` otherwise.
+ *
+ * This function is a TypeScript type guard for `FabricValueLayer`.
  */
 export function isFabricValueLegacy(
   value: unknown,
@@ -110,6 +114,8 @@ export function isFabricValueLegacy(
  *
  * @param value - The value to check.
  * @returns `true` if the value can be stored, `false` otherwise.
+ *
+ * This function is a TypeScript type guard for `FabricValue | FabricNativeObject`.
  */
 export function isFabricCompatibleLegacy(
   value: unknown,

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -19,7 +19,10 @@ import { FabricBytes } from "./fabric-bytes.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { isArrayWithOnlyIndexProperties } from "./array-utils.ts";
 
-/** Rejects native objects with extra enumerable properties. */
+/**
+ * Helper for `shallowFabricFromNativeValueModern()`, which rejects native
+ * objects with extra enumerable properties.
+ */
 function rejectExtraProperties(value: object, typeName: string): void {
   if (Object.keys(value).length > 0) {
     throw new Error(
@@ -246,9 +249,10 @@ export function fabricFromNativeValueModern(
 }
 
 /**
- * Indicates whether the value is a deep-frozen FabricValue (naive recursive
- * check). Returns `true` if the value is a primitive, or a frozen object/array
- * whose children are all also deep-frozen FabricValues.
+ * Helper for `fabricFromNativeValueModern()` and `cloneHelper()`, which
+ * indicates whether the value is a deep-frozen FabricValue (naive recursive
+ * check). Returns `true` if the value is a primitive, or a frozen
+ * object/array whose children are all also deep-frozen FabricValues.
  */
 function isDeepFrozenFabricValue(value: unknown): boolean {
   if (value === null || (typeof value !== "object")) return true; // primitives
@@ -280,11 +284,11 @@ function isDeepFrozenFabricValue(value: unknown): boolean {
 }
 
 /**
- * Performs the recursive conversion for the modern path. Single-pass: checks,
- * wraps, and optionally freezes each node as it's built. By the time this
- * returns, the whole tree is converted and (if `freeze` is true) deep-frozen.
- * Unlike the legacy version, this never returns OMIT -- `undefined` values
- * are preserved.
+ * Helper for `fabricFromNativeValueModern()`, which performs the recursive
+ * conversion for the modern path. Single-pass: checks, wraps, and optionally
+ * freezes each node as it's built. By the time this returns, the whole tree
+ * is converted and (if `freeze` is true) deep-frozen. Unlike the legacy
+ * version, this never returns OMIT -- `undefined` values are preserved.
  */
 function fabricFromNativeValueModernInternal(
   original: unknown,

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -197,6 +197,8 @@ export function shallowFabricFromNativeValueModern(
  *
  * TODO: Remove `toJSON()` support once all callers have migrated to
  * `[DECONSTRUCT]`. See spec Section 7.1.
+ *
+ * This function is a TypeScript type guard for `{ toJSON: () => unknown }`.
  */
 function hasToJSONMethod(
   value: unknown,
@@ -465,6 +467,8 @@ function convertErrorInternals(
  * flag is ON. See session 2 notes about the stack overflow this caused.
  *
  * Used when the `modernDataModel` flag is ON.
+ *
+ * This function is a TypeScript type guard for `FabricValueLayer`.
  */
 export function isFabricValueModern(
   value: unknown,
@@ -527,6 +531,8 @@ export function isFabricValueModern(
  * objects/functions with `toJSON()` methods
  * that return fabric values. It checks recursively, so all nested values in
  * arrays and objects must also be fabric-compatible or convertible.
+ *
+ * This function is a TypeScript type guard for `FabricValue | FabricNativeObject`.
  */
 export function isFabricCompatibleModern(
   value: unknown,

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -19,7 +19,7 @@ import { FabricBytes } from "./fabric-bytes.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { isArrayWithOnlyIndexProperties } from "./array-utils.ts";
 
-/** Reject native objects with extra enumerable properties. */
+/** Rejects native objects with extra enumerable properties. */
 function rejectExtraProperties(value: object, typeName: string): void {
   if (Object.keys(value).length > 0) {
     throw new Error(
@@ -29,7 +29,7 @@ function rejectExtraProperties(value: object, typeName: string): void {
 }
 
 /**
- * Shallow conversion from JS values to `FabricValue`. Wraps `Error`
+ * Performs shallow conversion from JS values to `FabricValue`. Wraps `Error`
  * instances into `FabricError`; preserves `undefined`; optionally freezes
  * the result if it is an object or array. If the value is already a frozen
  * `FabricValue`, returns it as-is (identity optimization).
@@ -214,7 +214,7 @@ function hasToJSONMethod(
 const PROCESSING = Symbol("PROCESSING");
 
 /**
- * Recursive conversion from JS values to `FabricValue`. Single-pass:
+ * Performs recursive conversion from JS values to `FabricValue`. Single-pass:
  * wraps `Error` instances into `FabricError`, preserves `undefined`, and
  * deep-freezes each node as it's built (no separate freeze pass). If the
  * input is already a deep-frozen `FabricValue`, returns it as-is (identity
@@ -244,8 +244,8 @@ export function fabricFromNativeValueModern(
 }
 
 /**
- * Naive recursive check: is the value a deep-frozen FabricValue?
- * Returns `true` if the value is a primitive, or a frozen object/array
+ * Indicates whether the value is a deep-frozen FabricValue (naive recursive
+ * check). Returns `true` if the value is a primitive, or a frozen object/array
  * whose children are all also deep-frozen FabricValues.
  */
 function isDeepFrozenFabricValue(value: unknown): boolean {
@@ -278,7 +278,7 @@ function isDeepFrozenFabricValue(value: unknown): boolean {
 }
 
 /**
- * Internal recursive implementation for the modern path. Single-pass: checks,
+ * Performs the recursive conversion for the modern path. Single-pass: checks,
  * wraps, and optionally freezes each node as it's built. By the time this
  * returns, the whole tree is converted and (if `freeze` is true) deep-frozen.
  * Unlike the legacy version, this never returns OMIT -- `undefined` values
@@ -455,9 +455,10 @@ function convertErrorInternals(
 }
 
 /**
- * Type guard that accepts `FabricInstance` values, `undefined`, and arrays
- * with `undefined` elements or sparse holes -- in addition to the base fabric
- * types (null, boolean, number, string, plain objects, dense arrays).
+ * Indicates whether the value is a fabric value, accepting `FabricInstance`
+ * values, `undefined`, and arrays with `undefined` elements or sparse holes
+ * -- in addition to the base fabric types (null, boolean, number, string,
+ * plain objects, dense arrays).
  *
  * MUST be self-contained (inline base-type checks, does NOT delegate back to
  * `isFabricValue()`) to avoid circular dispatch when the `modernDataModel`
@@ -564,7 +565,7 @@ export interface CloneOptions {
 }
 
 /**
- * Clone an already-valid `FabricValue` to achieve a desired frozenness,
+ * Clones an already-valid `FabricValue` to achieve a desired frozenness,
  * with control over depth and copy semantics.
  *
  * Unlike `fabricFromNativeValue` (which converts native JS values into
@@ -589,7 +590,7 @@ export function cloneIfNecessaryModern(
 }
 
 /**
- * Track an object for circular reference detection during deep cloning.
+ * Tracks an object for circular reference detection during deep cloning.
  * Lazily allocates the `seen` set on first use, throws if a cycle is
  * detected, and adds the object to the set. Returns the (possibly
  * newly-allocated) set.
@@ -607,7 +608,7 @@ function trackForCircularity(
 }
 
 /**
- * Unified clone helper for both shallow and deep modes.
+ * Performs the unified clone for both shallow and deep modes.
  *
  * When `deep` is true, recursively clones containers and detects circular
  * references via `seen`. When `deep` is false, copies only the top-level
@@ -801,7 +802,7 @@ function isFabricCompatibleInternal(
 // ---------------------------------------------------------------------------
 
 /**
- * Deep unwrap: recursively walk a `FabricValue` tree, unwrapping any
+ * Recursively walks a `FabricValue` tree, unwrapping any
  * `FabricNativeWrapper` values to their underlying native types via
  * `toNativeValue()`. Non-native `FabricInstance` values (Cell, Stream,
  * UnknownValue, etc.) pass through as-is.

--- a/packages/data-model/fabric-value.ts
+++ b/packages/data-model/fabric-value.ts
@@ -88,7 +88,7 @@ export function resetDataModelConfig(): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Convert a native JS value to fabric form (deep, recursive).
+ * Converts a native JS value to fabric form (deep, recursive).
  *
  * Flag OFF (legacy): performs deep conversion via `fabricFromNativeValueLegacy`.
  * Flag ON (modern): wraps native types (Error, Date, RegExp, etc.) into
@@ -108,7 +108,7 @@ export function fabricFromNativeValue(
 }
 
 /**
- * Deep unwrap: recursively walk a `FabricValue` tree, unwrapping any
+ * Recursively walks a `FabricValue` tree, unwrapping any
  * `FabricNativeWrapper` values to their underlying native types via
  * `toNativeValue()`. Non-native `FabricInstance` values (Cell, Stream,
  * UnknownValue, etc.) pass through as-is.
@@ -131,7 +131,7 @@ export function nativeFromFabricValue(
 }
 
 /**
- * Clone an already-valid `FabricValue` to achieve a desired frozenness,
+ * Clones an already-valid `FabricValue` to achieve a desired frozenness,
  * with control over depth and copy semantics.
  *
  * Unlike `fabricFromNativeValue` (which converts native JS values into

--- a/packages/data-model/fabric-value.ts
+++ b/packages/data-model/fabric-value.ts
@@ -198,6 +198,8 @@ export function cloneIfNecessary<T extends FabricValue>(
  *
  * @param value - The value to check.
  * @returns `true` if the value is fabric-compatible per se, `false` otherwise.
+ *
+ * This function is a TypeScript type guard for `FabricValueLayer`.
  */
 export function isFabricValue(
   value: unknown,
@@ -218,6 +220,8 @@ export function isFabricValue(
  *
  * @param value - The value to check.
  * @returns `true` if the value can be stored, `false` otherwise.
+ *
+ * This function is a TypeScript type guard for `FabricValue | FabricNativeObject`.
  */
 export function isFabricCompatible(
   value: unknown,

--- a/packages/data-model/frozen-builtins.ts
+++ b/packages/data-model/frozen-builtins.ts
@@ -27,14 +27,21 @@ const SET_BACKING = new WeakMap<object, SetBacking<unknown>>();
 const INTERNAL_MAP_BUILDER = Symbol("FrozenMapBuilder");
 const INTERNAL_SET_BUILDER = Symbol("FrozenSetBuilder");
 
+/** Helper for the mutator methods, which throws to signal a frozen-mutation attempt. */
 function throwFrozenMutation(typeName: string): never {
   throw new TypeError(`Cannot mutate a ${typeName}`);
 }
 
+/** Helper for builders, which throws to signal a post-`finish()` mutation attempt. */
 function throwFinalizedBuilderMutation(typeName: string): never {
   throw new TypeError(`Cannot mutate a finalized ${typeName} builder`);
 }
 
+/**
+ * Helper for the `FrozenMap` methods, which fetches the backing `Map` for the
+ * given wrapper instance. Throws if `value` is not a recognized `FrozenMap`
+ * receiver (e.g. when an intrinsic mutator was called via `.call(...)`).
+ */
 function getMapBacking<K, V>(value: object): MapBacking<K, V> {
   const backing = MAP_BACKING.get(value);
   if (!backing) {
@@ -43,6 +50,11 @@ function getMapBacking<K, V>(value: object): MapBacking<K, V> {
   return backing as MapBacking<K, V>;
 }
 
+/**
+ * Helper for the `FrozenSet` methods, which fetches the backing `Set` for the
+ * given wrapper instance. Throws if `value` is not a recognized `FrozenSet`
+ * receiver.
+ */
 function getSetBacking<T>(value: object): SetBacking<T> {
   const backing = SET_BACKING.get(value);
   if (!backing) {
@@ -51,6 +63,10 @@ function getSetBacking<T>(value: object): SetBacking<T> {
   return backing as SetBacking<T>;
 }
 
+/**
+ * Helper for the set-algebra methods, which iterates the values of a
+ * `ReadonlySetLike`, invoking `callback` for each.
+ */
 function forEachSetLikeValue<T>(
   setLike: ReadonlySetLike<T>,
   callback: (value: T) => void,
@@ -65,7 +81,18 @@ function forEachSetLikeValue<T>(
   }
 }
 
+/**
+ * Effectively-immutable `Map` wrapper. Read methods delegate to a
+ * module-private backing `Map`; mutator methods (`set`, `delete`, `clear`,
+ * etc.) throw. Instances are frozen at construction time (or at builder
+ * `finish()` time, see `createBuilder()`).
+ */
 export class FrozenMap<K, V> implements Map<K, V> {
+  /**
+   * Constructs an instance from the given entries. The instance is frozen
+   * unless `builderToken` matches the module-private builder symbol (used by
+   * `createBuilder()` to allow staged population before freezing).
+   */
   constructor(
     entries?: Iterable<readonly [K, V]> | null,
     builderToken?: symbol,
@@ -76,6 +103,11 @@ export class FrozenMap<K, V> implements Map<K, V> {
     }
   }
 
+  /**
+   * Returns a builder that can be used to populate a `FrozenMap` incrementally
+   * before freezing it. Call `set()` to add entries, then `finish()` to freeze
+   * the wrapper and return it.
+   */
   static createBuilder<K, V>(): MapBuilder<K, V> {
     const wrapper = new FrozenMap<K, V>(undefined, INTERNAL_MAP_BUILDER);
     let finalized = false;
@@ -100,34 +132,42 @@ export class FrozenMap<K, V> implements Map<K, V> {
     };
   }
 
+  /** Same as `Map.prototype.size`. */
   get size(): number {
     return getMapBacking<K, V>(this).size;
   }
 
+  /** Same as `Map.prototype[Symbol.toStringTag]`; always `"Map"`. */
   get [Symbol.toStringTag](): string {
     return "Map";
   }
 
+  /** Same as `Map.prototype.get`. */
   get(key: K): V | undefined {
     return getMapBacking<K, V>(this).get(key);
   }
 
+  /** Same as `Map.prototype.has`. */
   has(key: K): boolean {
     return getMapBacking<K, V>(this).has(key);
   }
 
+  /** Same as `Map.prototype.entries`. */
   entries(): ReturnType<Map<K, V>["entries"]> {
     return getMapBacking<K, V>(this).entries();
   }
 
+  /** Same as `Map.prototype.keys`. */
   keys(): ReturnType<Map<K, V>["keys"]> {
     return getMapBacking<K, V>(this).keys();
   }
 
+  /** Same as `Map.prototype.values`. */
   values(): ReturnType<Map<K, V>["values"]> {
     return getMapBacking<K, V>(this).values();
   }
 
+  /** Same as `Map.prototype.forEach`. */
   forEach(
     callbackfn: (value: V, key: K, map: Map<K, V>) => void,
     thisArg?: unknown,
@@ -137,26 +177,32 @@ export class FrozenMap<K, V> implements Map<K, V> {
     });
   }
 
+  /** Same as `Map.prototype[Symbol.iterator]`. */
   [Symbol.iterator](): ReturnType<Map<K, V>[typeof Symbol.iterator]> {
     return this.entries();
   }
 
+  /** Always throws (instance is frozen). */
   set(_key: K, _value: V): this {
     throwFrozenMutation("FrozenMap");
   }
 
+  /** Always throws (instance is frozen). */
   getOrInsert(_key: K, _defaultValue: V): V {
     throwFrozenMutation("FrozenMap");
   }
 
+  /** Always throws (instance is frozen). */
   getOrInsertComputed(_key: K, _callback: (key: K) => V): V {
     throwFrozenMutation("FrozenMap");
   }
 
+  /** Always throws (instance is frozen). */
   delete(_key: K): boolean {
     throwFrozenMutation("FrozenMap");
   }
 
+  /** Always throws (instance is frozen). */
   clear(): void {
     throwFrozenMutation("FrozenMap");
   }
@@ -165,7 +211,18 @@ export class FrozenMap<K, V> implements Map<K, V> {
 Object.setPrototypeOf(FrozenMap.prototype, Map.prototype);
 Object.setPrototypeOf(FrozenMap, Map);
 
+/**
+ * Effectively-immutable `Set` wrapper. Read methods and set-algebra methods
+ * delegate to a module-private backing `Set`; mutator methods (`add`,
+ * `delete`, `clear`) throw. Instances are frozen at construction time (or at
+ * builder `finish()` time, see `createBuilder()`).
+ */
 export class FrozenSet<T> implements Set<T> {
+  /**
+   * Constructs an instance from the given values. The instance is frozen
+   * unless `builderToken` matches the module-private builder symbol (used by
+   * `createBuilder()` to allow staged population before freezing).
+   */
   constructor(values?: Iterable<T> | null, builderToken?: symbol) {
     SET_BACKING.set(this, new Set(values ?? undefined));
     if (builderToken !== INTERNAL_SET_BUILDER) {
@@ -173,6 +230,11 @@ export class FrozenSet<T> implements Set<T> {
     }
   }
 
+  /**
+   * Returns a builder that can be used to populate a `FrozenSet` incrementally
+   * before freezing it. Call `add()` to add values, then `finish()` to freeze
+   * the wrapper and return it.
+   */
   static createBuilder<T>(): SetBuilder<T> {
     const wrapper = new FrozenSet<T>(undefined, INTERNAL_SET_BUILDER);
     let finalized = false;
@@ -197,30 +259,37 @@ export class FrozenSet<T> implements Set<T> {
     };
   }
 
+  /** Same as `Set.prototype.size`. */
   get size(): number {
     return getSetBacking<T>(this).size;
   }
 
+  /** Same as `Set.prototype[Symbol.toStringTag]`; always `"Set"`. */
   get [Symbol.toStringTag](): string {
     return "Set";
   }
 
+  /** Same as `Set.prototype.has`. */
   has(value: T): boolean {
     return getSetBacking<T>(this).has(value);
   }
 
+  /** Same as `Set.prototype.entries`. */
   entries(): ReturnType<Set<T>["entries"]> {
     return getSetBacking<T>(this).entries();
   }
 
+  /** Same as `Set.prototype.keys`. */
   keys(): ReturnType<Set<T>["keys"]> {
     return getSetBacking<T>(this).keys();
   }
 
+  /** Same as `Set.prototype.values`. */
   values(): ReturnType<Set<T>["values"]> {
     return getSetBacking<T>(this).values();
   }
 
+  /** Same as `Set.prototype.forEach`. */
   forEach(
     callbackfn: (value: T, key: T, set: Set<T>) => void,
     thisArg?: unknown,
@@ -230,10 +299,12 @@ export class FrozenSet<T> implements Set<T> {
     });
   }
 
+  /** Same as `Set.prototype[Symbol.iterator]`. */
   [Symbol.iterator](): ReturnType<Set<T>[typeof Symbol.iterator]> {
     return this.values();
   }
 
+  /** Same as `Set.prototype.union`. Returns a new (mutable) `Set`. */
   union<U>(other: ReadonlySetLike<U>): Set<T | U> {
     const result = new Set<T | U>(this.values());
     forEachSetLikeValue(other, (value) => {
@@ -242,6 +313,7 @@ export class FrozenSet<T> implements Set<T> {
     return result;
   }
 
+  /** Same as `Set.prototype.intersection`. Returns a new (mutable) `Set`. */
   intersection<U>(other: ReadonlySetLike<U>): Set<T & U> {
     const result = new Set<T & U>();
     for (const value of this.values()) {
@@ -252,6 +324,7 @@ export class FrozenSet<T> implements Set<T> {
     return result;
   }
 
+  /** Same as `Set.prototype.difference`. Returns a new (mutable) `Set`. */
   difference<U>(other: ReadonlySetLike<U>): Set<T> {
     const result = new Set<T>();
     for (const value of this.values()) {
@@ -262,6 +335,7 @@ export class FrozenSet<T> implements Set<T> {
     return result;
   }
 
+  /** Same as `Set.prototype.symmetricDifference`. Returns a new (mutable) `Set`. */
   symmetricDifference<U>(other: ReadonlySetLike<U>): Set<T | U> {
     const result = new Set<T | U>(this.values());
     forEachSetLikeValue(other, (value) => {
@@ -274,6 +348,7 @@ export class FrozenSet<T> implements Set<T> {
     return result;
   }
 
+  /** Same as `Set.prototype.isSubsetOf`. */
   isSubsetOf(other: Parameters<Set<T>["isSubsetOf"]>[0]): boolean {
     for (const value of this.values()) {
       if (!other.has(value)) {
@@ -283,6 +358,7 @@ export class FrozenSet<T> implements Set<T> {
     return true;
   }
 
+  /** Same as `Set.prototype.isSupersetOf`. */
   isSupersetOf(other: Parameters<Set<T>["isSupersetOf"]>[0]): boolean {
     let result = true;
     forEachSetLikeValue(other, (value) => {
@@ -293,6 +369,7 @@ export class FrozenSet<T> implements Set<T> {
     return result;
   }
 
+  /** Same as `Set.prototype.isDisjointFrom`. */
   isDisjointFrom(other: Parameters<Set<T>["isDisjointFrom"]>[0]): boolean {
     let result = true;
     forEachSetLikeValue(other, (value) => {
@@ -303,14 +380,17 @@ export class FrozenSet<T> implements Set<T> {
     return result;
   }
 
+  /** Always throws (instance is frozen). */
   add(_value: T): this {
     throwFrozenMutation("FrozenSet");
   }
 
+  /** Always throws (instance is frozen). */
   delete(_value: T): boolean {
     throwFrozenMutation("FrozenSet");
   }
 
+  /** Always throws (instance is frozen). */
   clear(): void {
     throwFrozenMutation("FrozenSet");
   }

--- a/packages/data-model/interface.ts
+++ b/packages/data-model/interface.ts
@@ -161,11 +161,11 @@ export type FabricValue =
   // -- undefined --
   | undefined;
 
-/** An array of fabric values. */
+/** Array of fabric values. */
 export interface FabricArray extends ArrayLike<FabricValue> {}
 
 /**
- * An object/record of fabric values.
+ * Object/record of fabric values.
  *
  * Note: `__proto__` and `constructor` properties are not currently guarded
  * against at the type level or at runtime in clone/conversion internals.
@@ -175,7 +175,7 @@ export interface FabricArray extends ArrayLike<FabricValue> {}
 export interface FabricObject extends Record<string, FabricValue> {}
 
 /**
- * A single "layer" of fabric conversion -- the result of shallow conversion
+ * Single "layer" of fabric conversion -- the result of shallow conversion
  * via `shallowFabricFromNativeValue()`. Arrays and objects have the right
  * shape but their contents may still contain values requiring further
  * conversion (e.g., Error instances in a `cause` chain).
@@ -216,14 +216,14 @@ export type FabricNativeObject =
 // ===========================================================================
 
 /**
- * A class that can reconstruct fabric instances from essential state. The
- * static `[RECONSTRUCT]` method is separate from the constructor to support
- * reconstruction-specific context and instance interning.
+ * Interface for classes that can reconstruct fabric instances from essential
+ * state. The static `[RECONSTRUCT]` method is separate from the constructor
+ * to support reconstruction-specific context and instance interning.
  * See Section 2.4 of the formal spec.
  */
 export interface FabricClass<T extends FabricInstance> {
   /**
-   * Reconstruct an instance from essential state. Nested values in `state`
+   * Reconstructs an instance from essential state. Nested values in `state`
    * have already been reconstructed by the serialization system. May return
    * an existing instance (interning) rather than creating a new one.
    */
@@ -231,14 +231,14 @@ export interface FabricClass<T extends FabricInstance> {
 }
 
 /**
- * A converter that can reconstruct arbitrary values (not necessarily
+ * Converter that can reconstruct arbitrary values (not necessarily
  * `FabricInstance`s) from essential state. Used for built-in JS types like
  * `Error` that participate in the serialization protocol but don't implement
  * `FabricInstance`. See Section 1.4.1 of the formal spec.
  */
 export interface FabricValueConverter<T> {
   /**
-   * Reconstruct a value from essential state. Nested values in `state`
+   * Reconstructs a value from essential state. Nested values in `state`
    * have already been reconstructed by the serialization system.
    */
   [RECONSTRUCT](state: FabricValue, context: ReconstructionContext): T;
@@ -251,7 +251,7 @@ export interface FabricValueConverter<T> {
  * See Section 2.5 of the formal spec.
  */
 export interface ReconstructionContext {
-  /** Resolve a cell reference. Used by types that need to intern or look up
+  /** Resolves a cell reference. Used by types that need to intern or look up
    *  existing instances during reconstruction. */
   getCell(
     ref: { id: string; path: string[]; space: string },
@@ -272,10 +272,10 @@ export interface SerializationContext<SerializedForm = unknown> {
    *  throwing. @default false */
   readonly lenient: boolean;
 
-  /** Encode a fabric value into serialized form for boundary crossing. */
+  /** Encodes a fabric value into serialized form for boundary crossing. */
   encode(value: FabricValue): SerializedForm;
 
-  /** Decode a serialized form back into a fabric value. */
+  /** Decodes a serialized form back into a fabric value. */
   decode(
     data: SerializedForm,
     runtime: ReconstructionContext,

--- a/packages/data-model/json-encoding-context.ts
+++ b/packages/data-model/json-encoding-context.ts
@@ -124,7 +124,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
   // -------------------------------------------------------------------------
 
   /**
-   * Encode a fabric value to a JSON string. Serializes modern types into
+   * Encodes a fabric value to a JSON string. Serializes modern types into
    * the `/<Type>@<Version>` tagged wire format, then stringifies.
    */
   encode(value: FabricValue): string {
@@ -132,7 +132,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
   }
 
   /**
-   * Decode a JSON string back into a fabric value. Parses the string,
+   * Decodes a JSON string back into a fabric value. Parses the string,
    * then deserializes tagged forms back into modern runtime types.
    */
   decode(data: string, runtime: ReconstructionContext): FabricValue {
@@ -166,14 +166,14 @@ export class JsonEncodingContext implements SerializationContext<string> {
   // -------------------------------------------------------------------------
 
   /**
-   * Serialize a fabric value to UTF-8 JSON bytes.
+   * Serializes a fabric value to UTF-8 JSON bytes.
    */
   encodeToBytes(value: FabricValue): Uint8Array {
     return this.toBytes(this.serialize(value));
   }
 
   /**
-   * Deserialize UTF-8 JSON bytes back into a fabric value.
+   * Deserializes UTF-8 JSON bytes back into a fabric value.
    */
   decodeFromBytes(
     bytes: Uint8Array,
@@ -187,7 +187,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
   // Tag wrapping/unwrapping (private)
   // -------------------------------------------------------------------------
 
-  /** Get the wire format tag for a fabric instance's type. */
+  /** Returns the wire format tag for a fabric instance's type. */
   private getTagFor(value: FabricInstance): string {
     if (value instanceof ExplicitTagValue) {
       return value.typeTag;
@@ -201,7 +201,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
     );
   }
 
-  /** Get the class that can reconstruct instances for a given tag. */
+  /** Returns the class that can reconstruct instances for a given tag. */
   private getClassFor(
     tag: string,
   ): FabricClass<FabricInstance> | undefined {
@@ -209,7 +209,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
   }
 
   /**
-   * Wrap a tag and state into the `/<tag>` wire format. Prepends `/` to the
+   * Wraps a tag and state into the `/<tag>` wire format. Prepends `/` to the
    * tag to produce the JSON key. See Section 5.2 of the formal spec.
    */
   private wrapTag(tag: string, state: JsonWireValue): JsonWireValue {
@@ -217,7 +217,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
   }
 
   /**
-   * Unwrap a wire representation. Detects single-key objects with `/`-prefixed
+   * Unwraps a wire representation. Detects single-key objects with `/`-prefixed
    * keys. Returns `{ tag, state }` or `null` if not a tagged value.
    * See Section 5.4 of the formal spec.
    */
@@ -244,12 +244,12 @@ export class JsonEncodingContext implements SerializationContext<string> {
   // Byte conversion (private)
   // -------------------------------------------------------------------------
 
-  /** Convert a wire-format tree to UTF-8-encoded JSON bytes. */
+  /** Converts a wire-format tree to UTF-8-encoded JSON bytes. */
   private toBytes(data: JsonWireValue): Uint8Array {
     return new TextEncoder().encode(JSON.stringify(data));
   }
 
-  /** Parse UTF-8-encoded JSON bytes back into a wire-format tree. */
+  /** Parses UTF-8-encoded JSON bytes back into a wire-format tree. */
   private fromBytes(bytes: Uint8Array): JsonWireValue {
     return JSON.parse(new TextDecoder().decode(bytes)) as JsonWireValue;
   }
@@ -262,7 +262,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
   // -------------------------------------------------------------------------
 
   /**
-   * Serialize a fabric value into wire format. Recursively processes nested
+   * Serializes a fabric value into wire format. Recursively processes nested
    * values. See Section 4.5 of the formal spec.
    */
   private serialize(
@@ -374,7 +374,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
   // -------------------------------------------------------------------------
 
   /**
-   * Deserialize a wire-format value back into modern runtime types.
+   * Deserializes a wire-format value back into modern runtime types.
    * See Section 4.5 of the formal spec.
    */
   private deserialize(

--- a/packages/data-model/json-encoding-context.ts
+++ b/packages/data-model/json-encoding-context.ts
@@ -101,6 +101,10 @@ export class JsonEncodingContext implements SerializationContext<string> {
   /** Narrow codec view for type handlers (avoids exposing private methods). */
   private readonly codec: TypeHandlerCodec;
 
+  /**
+   * Constructs an instance, optionally configured for lenient mode (which
+   * produces `ProblematicValue` on failed reconstruction instead of throwing).
+   */
   constructor(options?: { lenient?: boolean }) {
     this.lenient = options?.lenient ?? false;
 

--- a/packages/data-model/json-type-handlers.ts
+++ b/packages/data-model/json-type-handlers.ts
@@ -40,9 +40,9 @@ import {
  * passed to type handlers by the internal tree-walking engine.
  */
 export interface TypeHandlerCodec {
-  /** Wrap a tag and state into the wire format's tagged representation. */
+  /** Wraps a tag and state into the wire format's tagged representation. */
   wrapTag(tag: string, state: JsonWireValue): JsonWireValue;
-  /** Get the wire format tag for a fabric instance's type. */
+  /** Returns the wire format tag for a fabric instance's type. */
   getTagFor(value: FabricInstance): string;
 }
 
@@ -64,7 +64,7 @@ export interface TypeHandler {
   canSerialize(value: FabricValue): boolean;
 
   /**
-   * Serialize the value. Only called after `canSerialize` returned `true`.
+   * Serializes the value. Only called after `canSerialize` returned `true`.
    * The handler is responsible for tag wrapping via `codec.wrapTag()` and for
    * recursively serializing nested values via the provided `recurse` callback.
    */
@@ -75,7 +75,7 @@ export interface TypeHandler {
   ): JsonWireValue;
 
   /**
-   * Deserialize a value from its wire format state. The state has already been
+   * Deserializes a value from its wire format state. The state has already been
    * unwrapped (tag stripped) but inner values have NOT been recursively
    * deserialized -- the handler must call `recurse` on nested values.
    */
@@ -97,7 +97,7 @@ export class TypeHandlerRegistry {
   /** Tag -> handler map for O(1) deserialization dispatch. */
   private readonly tagMap = new Map<string, TypeHandler>();
 
-  /** Register a handler. Handlers with non-empty tags are indexed for
+  /** Registers a handler. Handlers with non-empty tags are indexed for
    *  O(1) deserialization lookup. Handlers with empty tags (like
    *  `FabricInstanceHandler`) participate in serialization matching only. */
   register(handler: TypeHandler): void {
@@ -108,7 +108,7 @@ export class TypeHandlerRegistry {
   }
 
   /**
-   * Find a handler that can serialize the given value. Returns `undefined`
+   * Finds a handler that can serialize the given value. Returns `undefined`
    * if no handler matches (the caller should fall through to structural
    * handling for primitives, arrays, and plain objects).
    */
@@ -121,7 +121,7 @@ export class TypeHandlerRegistry {
     return undefined;
   }
 
-  /** Look up a handler by tag for deserialization. */
+  /** Looks up a handler by tag for deserialization. */
   getDeserializer(tag: string): TypeHandler | undefined {
     return this.tagMap.get(tag);
   }
@@ -132,7 +132,7 @@ export class TypeHandlerRegistry {
 // ---------------------------------------------------------------------------
 
 /**
- * Create a `ProblematicValue` for a deserialization failure. The type tag
+ * Creates a `ProblematicValue` for a deserialization failure. The type tag
  * is preserved for round-tripping; the message provides human-readable
  * diagnostics.
  */
@@ -551,7 +551,7 @@ export const FabricInstanceHandler: TypeHandler = {
 };
 
 /**
- * Create a registry with the built-in type handlers. The order matters for
+ * Creates a registry with the built-in type handlers. The order matters for
  * serialization: `FabricPrimitive` subclasses are checked first (direct
  * `FabricValue` members matched by `instanceof`), then `FabricInstance`
  * (generic protocol types), then `bigint` and `undefined`. Primitives

--- a/packages/data-model/native-type-tags.ts
+++ b/packages/data-model/native-type-tags.ts
@@ -41,9 +41,9 @@ export const NATIVE_TAGS = Object.freeze(
 export type NativeTag = typeof NATIVE_TAGS[keyof typeof NATIVE_TAGS];
 
 /**
- * Canonical mapping from a constructor to its native-instance tag. Returns the
- * tag string if the constructor is a recognized type (JS builtins or
- * system-defined special primitives), or `null` otherwise.
+ * Maps a constructor to its native-instance tag. Returns the tag string if
+ * the constructor is a recognized type (JS builtins or system-defined
+ * special primitives), or `null` otherwise.
  *
  * Uses a `switch` on the constructor identity for O(1) dispatch (instead of
  * sequential `instanceof` checks). Falls back to `instanceof Error` on the
@@ -112,10 +112,9 @@ export function tagFromNativeClass(
 }
 
 /**
- * Canonical mapping from a JS value to its native-instance tag. Returns the
- * tag string if the value is a recognized convertible native instance, or
- * `null` otherwise. Non-object types (null, undefined, primitives) return
- * `Primitive`.
+ * Maps a JS value to its native-instance tag. Returns the tag string if the
+ * value is a recognized convertible native instance, or `null` otherwise.
+ * Non-object types (null, undefined, primitives) return `Primitive`.
  *
  * Dispatches via the value's constructor (O(1) switch in `tagFromNativeClass`).
  * Falls back to `Error.isError()` for exotic Error subclasses, `Array.isArray`

--- a/packages/data-model/problematic-value.ts
+++ b/packages/data-model/problematic-value.ts
@@ -7,16 +7,16 @@ import {
 import { ExplicitTagValue } from "./explicit-tag-value.ts";
 
 /**
- * Holds a value whose deconstruction or reconstruction failed. Preserves the
- * original tag and raw state for round-tripping and debugging. Used in lenient
- * mode to allow graceful degradation rather than hard failures.
- * See Section 3.5 of the formal spec.
+ * Container for a value whose deconstruction or reconstruction failed.
+ * Preserves the original tag and raw state for round-tripping and debugging.
+ * Used in lenient mode to allow graceful degradation rather than hard
+ * failures. See Section 3.5 of the formal spec.
  */
 export class ProblematicValue extends ExplicitTagValue {
   constructor(
     typeTag: string,
     state: FabricValue,
-    /** A description of what went wrong. */
+    /** Description of what went wrong. */
     readonly error: string,
   ) {
     super(typeTag, state);

--- a/packages/data-model/schema-and-hash.ts
+++ b/packages/data-model/schema-and-hash.ts
@@ -1,5 +1,9 @@
+import type { JSONSchema } from "@commonfabric/api";
+import { isDeepFrozen } from "./deep-freeze.ts";
+import type { FabricHash } from "./fabric-hash.ts";
+
 /**
- * A deep-frozen container pairing a `JSONSchema` with its content hash.
+ * Deep-frozen container pairing a `JSONSchema` with its content hash.
  * Ensures that schemas are always stored in their canonical deep-frozen
  * form and that the hash is computed once.
  *
@@ -7,10 +11,6 @@
  * it handles freezing, hashing, and caching. The constructor is public
  * for direct use when both the frozen schema and hash are already in hand.
  */
-import type { JSONSchema } from "@commonfabric/api";
-import { isDeepFrozen } from "./deep-freeze.ts";
-import type { FabricHash } from "./fabric-hash.ts";
-
 export class SchemaAndHash {
   readonly #schema: JSONSchema;
   readonly #hash: FabricHash;

--- a/packages/data-model/schema-hash.ts
+++ b/packages/data-model/schema-hash.ts
@@ -14,7 +14,7 @@ import { hashOf, hashStringOf } from "./value-hash.ts";
 // ---------------------------------------------------------------------------
 
 /**
- * Compute a deterministic hash of a JSONSchema. Structurally-equal schemas
+ * Computes a deterministic hash of a JSONSchema. Structurally-equal schemas
  * always produce the same hash. Returns a string for use as a map key or cache
  * key.
  *
@@ -68,7 +68,7 @@ hashToRef.set(booleanInterns.true.hashString, true);
 hashToRef.set(booleanInterns.false.hashString, false);
 
 /**
- * Helper for `internSchema()` which always returns a `SchemaAndHash`.
+ * Helper for `internSchema()`, which always returns a `SchemaAndHash`.
  */
 function internSchemaReturningSchemaAndHash(schema: JSONSchema): SchemaAndHash {
   // Boolean schemas are primitives — return prefab instances.
@@ -132,7 +132,7 @@ function internSchemaReturningSchemaAndHash(schema: JSONSchema): SchemaAndHash {
 }
 
 /**
- * Intern a schema: Freeze it, compute its hash, and cache the bidirectional
+ * Interns a schema: freezes it, computes its hash, and caches the bidirectional
  * mapping. Returns the actual interned schema object or, optionally, the full
  * `SchemaAndHash`. The returned schema object is the same as (`===` to) the
  * given `schema` only if an identical schema was not already interned.
@@ -166,7 +166,7 @@ export function internSchema<T extends JSONSchema>(
 }
 
 /**
- * Look up a previously interned schema by its hash. Accepts a
+ * Looks up a previously interned schema by its hash. Accepts a
  * `FabricHash` or a plain string. Returns `undefined` if the schema
  * has not been interned or has been garbage-collected. If found, returns either
  * the `schema` or full `SchemaAndHash` depending on the `wantSchemaAndHash`

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -25,8 +25,8 @@ import { type FabricValue } from "./interface.ts";
 const BASIC_SCHEMAS: Record<string, JSONSchemaObj> = {};
 
 /**
- * Helper for `schemaForValueType()` and `emptySchemaObject()` to do the
- * lookup and interning as necessary.
+ * Helper for `schemaForValueType()` and `emptySchemaObject()`, which does
+ * the lookup and interning as necessary.
  */
 function getBasicSchema(key: string) {
   const found = BASIC_SCHEMAS[key];
@@ -65,7 +65,7 @@ export function isNontrivialSchema(
 }
 
 /**
- * Return a deep-frozen copy of (or reference to) a JSONSchema.
+ * Returns a deep-frozen copy of (or reference to) a JSONSchema.
  *
  * - When `canShare` is `true`, the input `schema` is allowed to be modified,
  *   including freezing it in place and returning it directly. Use this when the
@@ -126,7 +126,7 @@ export function toDeepFrozenSchema<T extends JSONSchema>(
 }
 
 /**
- * Return a mutable object copy of a JSONSchema. Boolean schemas (`true` and
+ * Returns a mutable object copy of a JSONSchema. Boolean schemas (`true` and
  * `false`) and `undefined` are converted to their object-form equivalents:
  * `undefined` and `true` become `{}` (accept any value), `false` becomes
  * `{ not: true }` (reject all values).
@@ -152,7 +152,7 @@ export function cloneSchemaMutable(
 }
 
 /**
- * Return a deep-frozen shallow copy of a schema with the given property
+ * Returns a deep-frozen shallow copy of a schema with the given property
  * overrides applied. This function provides "intern contagion:" If the given
  * `schema` is interned, then the result of this function will also be interned.
  *
@@ -204,7 +204,7 @@ export function schemaWithProperties(
 }
 
 /**
- * Return a deep-frozen shallow copy of a schema with the named properties
+ * Returns a deep-frozen shallow copy of a schema with the named properties
  * removed. This function provides "intern contagion:" If the given
  * `schema` is interned, then the result of this function will also be interned.
  *
@@ -303,7 +303,7 @@ export function emptySchemaObject() {
 }
 
 /**
- * Return the given `SchemaPathSelector` with its `schema` (if any) interned
+ * Returns the given `SchemaPathSelector` with its `schema` (if any) interned
  * and with both its `path` array and the selector object itself deep-frozen
  * in place. The input reference is returned — this function does not clone.
  * Idempotent on repeat calls: `internPathSelector(internPathSelector(x)) ===

--- a/packages/data-model/unknown-value.ts
+++ b/packages/data-model/unknown-value.ts
@@ -7,10 +7,11 @@ import {
 import { ExplicitTagValue } from "./explicit-tag-value.ts";
 
 /**
- * Holds an unrecognized type's data for round-tripping. When the serialization
- * system encounters an unknown tag during deserialization, it wraps the tag and
- * state here; on re-serialization, it uses the preserved `typeTag` to produce
- * the original wire format. See Section 3.3 of the formal spec.
+ * Container for an unrecognized type's data, used for round-tripping. When
+ * the serialization system encounters an unknown tag during deserialization,
+ * it wraps the tag and state here; on re-serialization, it uses the preserved
+ * `typeTag` to produce the original wire format. See Section 3.3 of the
+ * formal spec.
  */
 export class UnknownValue extends ExplicitTagValue {
   constructor(typeTag: string, state: FabricValue) {

--- a/packages/data-model/value-debug.ts
+++ b/packages/data-model/value-debug.ts
@@ -45,6 +45,10 @@ class DebugStringifier {
     this.#indent = indent;
   }
 
+  /**
+   * Renders the debug-string form of the configured value, with the configured
+   * indentation if any.
+   */
   render() {
     this.#findCircles(this.#value);
 


### PR DESCRIPTION
## Summary

Doc-comment hygiene pass over `packages/data-model/` (top-level
`.ts`) and `packages/content-hash/src/`, applying the
recently-revised "Doc comments" subsection of
`coordination/rules/coding.md`. No behavioral changes; tests
unaffected.

The rule was revised across three Dan-direct commits:

- `bec07f0` (2026-05-05) — added the wording-shape recommendations
  (subjectless third-person verb-phrase for functions/methods;
  noun-phrase for variables/types).
- `ba71d85` (2026-05-06) — tightened coverage from "should" to
  "**must**" for exported symbols and public class members.
- `d8e8ec7` (2026-05-06, mid-session) — added the helper-shape
  sub-clause for non-exported internal helpers
  (`Helper for X, which Y.`).

This pass parallels Cedar's PR #3505 (`data-model` test
sanitization, session 2026-069) in shape: bounded hygiene scope,
conservation-of-content discipline, two-axis decomposition.

## Per-axis walkthrough

### Axis 1 — Wording re-stamp (commit `6d19e0552`, 22 files, +115/-114)

Re-stamps existing doc-comment openings to the revised wording
shapes:

- **Functions / methods** — subjectless third-person verb-phrase
  (e.g., "Convert X" → "Converts X"; "Returns ..." kept as-is).
- **Variables / non-method properties** — article-less or
  "The..."-singleton noun-phrase.
- **Classes / interfaces / types** — noun-phrase (analogous to
  variables).
- **Internal (non-`exported`) helpers** — helper-shape per the
  `d8e8ec7` sub-clause: `Helper for X, which Y.`

Each re-stamp preserves the doc's substantive what/why content;
only the opening was rewritten.

### Axis 2 — Coverage fill (commit `d7e8ea696`, 7 files, +108/-5)

Adds doc-comments to symbols the revised "must" rule covers:
exported symbols + all public class members (whether the class
itself is exported or not) + non-trivial internal functions.

Biggest single-file lump: `packages/data-model/frozen-builtins.ts`
(~30 stdlib-mirror methods on `FrozenMap` / `FrozenSet`,
documented via the template
`Same as \`<X>.prototype.<Y>\`. Throws if instance is frozen.`).
Other coverage-fill sites: `interface.ts` member docs,
`BaseIncrementalHasher` public methods in `content-hash`, plus a
handful of singletons.

## Post-push refinement arc

Three follow-up commits applied focused refinements after the
initial axis-1/axis-2 pair landed:

### Commit `63e8f5d57` — Type-guard framing preservation (3 files, +16)

Adds an explicit closing sentence
`This function is a TypeScript type guard for \`<TypeName>\`.` to 8
predicate doc-comments in `fabric-value.ts`,
`fabric-value-legacy.ts`, and `fabric-value-modern.ts`. The opening
verb-leading shape from axis 1 stays as the wording rule requires;
the type-guard role-claim is restored as load-bearing closing
content (it was elided during the axis-1 re-stamp because the
opening-shape rewrite shifted focus from "what the function is"
to "what it does").

### Commit `a90e40153` — Helper-shape surfacing (3 files, +26/-18)

Applies the `d8e8ec7` helper-shape framing
(`Helper for X, which Y.`) to 7 helpers whose existing wording
buried the "serves X" relationship in a downstream "Used by..."
sentence. Scope-discipline: applied only to helpers whose wording
the axis-1 pass had **already re-stamped**, so the surface stays
bundled with the rule-application — not a quality-improvement
sweep. Helpers whose existing wording already framed the
relationship inline (e.g., `copyError()`) were left untouched.

### Commit `096b11309` — `/** @inheritDoc */` adoption (3 files, +22/-2)

Resolves Flux's NIT-1 against the Q3 spirit-reading: contract-
faithful overrides get a uniform `/** @inheritDoc */` sentinel
rather than copy-pasted base-class doc text. 22 placements,
distributed:

- **`packages/data-model/fabric-native-instances.ts`** — 19 sites
  across `FabricError` / `FabricMap` / `FabricSet` / `FabricRegExp`
  (~5 each).
- **`packages/content-hash/src/`** — 3 sites:
  `BaseSmallChunkUpdatingHasher` × 2 +
  `sha256-wasm.ts HasherPool._initInstance` × 1.

Completeness verified by grep: 22 placements found.

**Out of scope** per Dan-explicit ratification: Q5 (stub overrides
that aren't truly inheriting a contract — they're pre-overrides
that the base would never have implemented) and Q6 (overrides
whose semantics substantively diverge from the base — re-doc
required, not `@inheritDoc`). Both site-classes were enumerated
during the pre-push survey and left untouched.

## Foreman-ratified judgment-call dimensions

Six pre-draft judgment calls shaped the coverage and override-
treatment surfaces:

- **Q1 — Class/interface/type opening shape**: noun-phrase
  (analogous to variables, not subjectless verb-phrase).
- **Q2 — Spirit-reading for exported interface members**: members
  on an exported interface count as "exported symbols" for
  must-have purposes, not just the interface itself.
- **Q3 — Override semantics**: overrides inherit base-class doc
  by default; only re-doc when the override semantics diverge.
  **Resolved post-push** via `/** @inheritDoc */` (commit
  `096b11309`) after Flux's NIT-1 surfaced the
  spirit-reading-vs-uniform-shape gap.
- **Q4 — Pure pass-through type re-exports**: stay undocumented
  (the upstream definition carries the doc).
- **Q5 — Stub overrides**: untouched (no contract to inherit;
  pre-override at a site the base would never have implemented).
- **Q6 — Substantively divergent overrides**: untouched
  (`@inheritDoc` would mislead — re-doc required when override
  semantics diverge from base).

## Conservation-of-content recipe

Following the verification-recipes shape from `rules/code-review.md`
(banked end of session 2026-069 from PR #3505's relocation
methodology):

- **Axis 1 (wording)** — comment-count after = before. Every
  re-stamped opening preserved its doc; the substantive what/why
  body stayed character-identical (or trivially-rewrapped) across
  all re-stamps.
- **Axis 2 (coverage)** — purely additive. Comment-count after >
  before by ~40 (the `FrozenMap` / `FrozenSet` member docs
  dominate; plus class-level docs and internal-helper singletons).
- **Post-push arc** — `63e8f5d57` and `a90e40153` are
  content-additive (closing sentences / surfaced framing);
  `096b11309` is content-substitutive (`@inheritDoc` replaces
  inline copies but base-class doc remains the source of truth via
  inheritance).

## Pre-push gates

All re-run clean after each post-push commit:

- `deno fmt --check` — clean across both packages
  (data-model: 50 files, content-hash: 14 files).
- `deno lint` — clean
  (data-model: 49 files, content-hash: 13 files).
- `deno task test` — green across both:
  - `packages/data-model`: 43 passed, 1320 steps.
  - `packages/content-hash`: 2 passed, 705 steps.

Doc-comment-only pass; zero behavioral surface.

---

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
