### PR TITLE
[codex] Clear memory receive drain timeout

### DIFF
--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -205,10 +205,15 @@ class Connection {
         this.#receiveIdle = Promise.withResolvers<void>();
       }
       const idle = this.#receiveIdle.promise.then(() => true);
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
       const timeout = new Promise<boolean>((resolve) => {
-        setTimeout(() => resolve(false), remainingMs);
+        timeoutId = setTimeout(() => resolve(false), remainingMs);
       });
-      if (!await Promise.race([idle, timeout])) {
+      const drained = await Promise.race([idle, timeout]);
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+      if (!drained) {
         return this.#pendingReceives === 0;
       }
     }


### PR DESCRIPTION
## Summary

Fix a timer leak in the memory v2 server receive-queue drain path.

`Connection.waitForReceiveQueueToDrain()` raced queue-idle against a timeout, but when the idle path won it left the timeout armed. In the toolshed memory websocket tests, `memoryServer.idle()` can call this path during per-test cleanup, so Deno's leak sanitizer could report the timeout as either started during the current test or started before the next test and completed inside it.

This clears the timeout after the race resolves.

## Verification

- `deno fmt --check packages/memory/v2/server.ts`
- `deno check packages/memory/v2/server.ts`
- `deno test -A --trace-leaks packages/toolshed/routes/storage/memory/memory.test.ts`
- `deno task test` in `packages/toolshed`
- `deno task test` in `packages/memory`
- `git diff --check`
