### PR TITLE
[codex] Improve Pattern Factory Build guidance

### DIFF
--- a/docs/common/ai/pattern-factory-build-guide.md
+++ b/docs/common/ai/pattern-factory-build-guide.md
@@ -1,0 +1,101 @@
+# Pattern Factory Build Guide
+
+This guide is for agents implementing the Build phase in a Pattern Factory
+workspace. It complements the general pattern development and testing guides.
+
+## Build Contract
+
+Pattern Factory Build turns an existing brief, spec, UX design, and UI design
+into a top-level pattern deliverable:
+
+- `pattern/main.tsx`
+- `pattern/main.test.tsx`
+- `notes/pattern-maker.md`
+- `reviews/test-report.md`
+
+Treat the design inputs as the product contract. Treat the loaded skills and
+their referenced docs as the implementation contract.
+
+Before writing build artifacts, read the `Read First` references from the
+configured build skills that apply to the current work. At minimum this usually
+means:
+
+- the shared pattern development guide
+- the shared testing guide
+- type/schema docs for `Default<>`, `Writable<>`, and pattern Input/Output
+- action/handler/reactivity docs when the pattern has interactions or local
+  state changes
+- UI/component docs when implementing the visual design
+- debugging docs after any compile, test, or runtime failure that is not
+  immediately obvious
+
+Record the docs consulted in `notes/pattern-maker.md` so the run is auditable.
+
+## Top-Level Pattern Mode
+
+Pattern Factory create-mode deliverables are usually top-level patterns, not
+only reusable sub-patterns.
+
+For a top-level pattern:
+
+- make the pattern usable when invoked by itself with sensible defaults
+- own local state inside the pattern unless the spec explicitly requires
+  caller-owned cells, linking, or embedding
+- expose user-triggered behaviors as typed `Stream<T>` outputs when tests or
+  other patterns need to drive them
+- return an output shape that mirrors the user-visible state and actions
+- include `[UI]` in the output when the pattern renders UI
+
+Use sub-pattern conventions when you intentionally build a nested reusable
+piece. Sub-patterns often receive caller-owned writable inputs and must include
+`[NAME]`/`[UI]` for composition. Do not let those conventions force the
+top-level deliverable to require external writable inputs when the brief expects
+a standalone pattern.
+
+## Build Verification
+
+Build is complete only when the generated pattern compiles and its pattern tests
+pass.
+
+Use the `cf` skill for exact CLI syntax. The normal gate is:
+
+```bash
+deno task cf check <pattern>.tsx --no-run
+deno task cf test <pattern>.test.tsx
+```
+
+If either command fails, continue repair work. A failing compile, typecheck, or
+pattern test is not by itself a valid completion state. Hand off with unmet
+gates only when the available tools or context are genuinely insufficient to
+continue, or when the surrounding harness imposes an explicit turn/time
+boundary; record the exact evidence and required next input.
+
+When stuck:
+
+- preserve the exact failing command and relevant output in
+  `reviews/test-report.md`
+- inspect the relevant skill docs instead of guessing
+- use `cf check --show-transformed` or `--verbose-errors` when compiler
+  lowering or error simplification is ambiguous
+- simplify to the smallest failing pattern or test step when a test failure is
+  unclear
+- repair either the implementation or an invalid test contract, then rerun the
+  gate
+
+After compile and pattern tests pass, use local runtime, CLI state checks, and
+browser smoke checks when the surrounding task asks for them.
+
+## Test Coverage
+
+Pattern Factory Build tests should exercise the pattern contract, not only the
+golden path. Prefer coverage for:
+
+- first-run/default and sparse input states
+- primary add, remove, edit, toggle, or submit flows
+- repeated actions and state transitions
+- important validation, empty, partial, or edge-case branches from the spec
+- helper or wrapper behavior that would otherwise only be tested manually
+
+Avoid padding tests with assertions that only restate static markup. If a
+behavior is easier and more meaningful to verify with CLI or browser runtime
+checks, record that in the test report.

--- a/docs/common/ai/pattern-testing-guide.md
+++ b/docs/common/ai/pattern-testing-guide.md
@@ -23,6 +23,15 @@ Write tests for:
 - regressions that are easy to reintroduce
 - edge cases with real branching logic
 
+For Pattern Factory Build, prefer tests that cover the product contract rather
+than only the happy path:
+
+- first-run/default and sparse states
+- primary add, remove, edit, toggle, or submit flows
+- repeated actions and important state transitions
+- validation, empty, partial, or edge-case branches from the spec
+- helper or wrapper behavior that would otherwise only fail in a browser
+
 Avoid tests for:
 
 - code that is still only a sketch
@@ -34,6 +43,12 @@ Avoid tests for:
 ```bash
 deno task cf test <pattern>.test.tsx
 ```
+
+If `cf test` fails, treat that as repair work. Preserve the failing command and
+relevant output, isolate the smallest failing action/assertion when useful, fix
+either the implementation or an invalid test contract, and rerun the test. A
+failing pattern test is not a valid done state unless a concrete external,
+tooling, or environment blocker prevents further repair.
 
 ## Test File Shape
 

--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -24,6 +24,7 @@ Quick error reference and debugging workflows. For detailed explanations, see li
 | CLI `get` returns stale computed values | `piece set` doesn't trigger recompute | Run `piece step` after `set` to trigger re-evaluation ([cli-debugging](cli-debugging.md#stale-computed-values-after-piece-set)) |
 | "handler() should be defined at module scope" | handler() inside pattern body | Move handler() outside pattern ([gotchas/handler-inside-pattern](gotchas/handler-inside-pattern.md)) |
 | UI churning, high CPU, never settles | Non-idempotent computed or action cycle | Run `await commonfabric.detectNonIdempotent()` ([non-idempotent-detection](non-idempotent-detection.md)) |
+| `non-idempotent raw:map` or `Too many iterations: ... raw:map` | Mapped render body is doing work during render, often an event prop invoking `.send()` immediately | Inspect `.map()` JSX for `onClick={stream.send(...)}` or other render-time writes ([gotchas/immediate-event-invocation](gotchas/immediate-event-invocation.md)) |
 | "Function creation is not allowed in pattern context" | Helper function inside pattern | Move function to module scope ([gotchas/handler-inside-pattern](gotchas/handler-inside-pattern.md)) |
 | "lift() should not be immediately invoked inside a pattern" | `lift(...)(args)` inside pattern | Use `computed()` instead, or define lift() at module scope ([gotchas/handler-inside-pattern](gotchas/handler-inside-pattern.md)) |
 | Click handler does nothing, ID lookup fails silently | Using custom `id` property for lookups | Use `equals()` for identity, not custom IDs ([gotchas/custom-id-property-pitfall](gotchas/custom-id-property-pitfall.md)) |
@@ -44,6 +45,7 @@ These issues compile without errors but fail at runtime.
 - [ifElse with Composed Pattern Cells](gotchas/ifelse-composed-pattern-cells.md) - Piece hangs
 - [lift() Returns Stale/Empty Data](gotchas/lift-returns-stale-data.md) - Closure limitations
 - [Handler Binding Error](gotchas/handler-binding-error.md) - Two-step binding pattern
+- [Immediate Event Invocation](gotchas/immediate-event-invocation.md) - Event props invoking streams or writes during render
 - [Stream.of() / .subscribe() Don't Exist](gotchas/stream-subscribe-dont-exist.md) - Bound handlers ARE streams
 - [handler() or Function Inside Pattern](gotchas/handler-inside-pattern.md) - Module scope requirement
 - [Custom `id` Property Pitfall](gotchas/custom-id-property-pitfall.md) - Use `equals()` for identity

--- a/docs/development/debugging/gotchas/immediate-event-invocation.md
+++ b/docs/development/debugging/gotchas/immediate-event-invocation.md
@@ -1,0 +1,71 @@
+# Immediate Event Invocation
+
+**Symptom:** Pattern tests or runtime checks report a non-idempotent `raw:map`,
+`Too many iterations: ... raw:map`, link-resolution churn, or an action timeout
+after rendering a list.
+
+**Cause:** A JSX event prop is invoking a stream or mutation while the UI is
+rendering, instead of passing a handler to run later.
+
+```tsx
+// WRONG - sends during render
+{items.map((item, index) => (
+  <cf-button onClick={selectItem.send(index)}>Select</cf-button>
+))}
+```
+
+In a mapped row this is especially dangerous: the render-time send or write can
+mutate the same array that `raw:map` is rendering. That retriggers the map,
+which sends or writes again, and the scheduler may never settle.
+
+## Fix
+
+Pass a handler or stream value to the event prop. If the stream needs an
+argument, wrap the `.send(...)` call in a callback so it runs only when the
+event fires.
+
+```tsx
+// CORRECT - sends only when clicked
+{items.map((item, index) => (
+  <cf-button onClick={() => selectItem.send(index)}>Select</cf-button>
+))}
+```
+
+When the same behavior is reused with different state bindings, prefer a
+module-scope `handler()` and bind it inside the map.
+
+```tsx
+const deleteItem = handler<void, { items: Writable<Item[]>; index: number }>(
+  (_, { items, index }) => items.set(items.get().toSpliced(index, 1)),
+);
+
+export default pattern(({ items }) => ({
+  [UI]: (
+    <>
+      {items.map((item, index) => (
+        <cf-button onClick={deleteItem({ items, index })}>Delete</cf-button>
+      ))}
+    </>
+  ),
+}));
+```
+
+## Diagnosis Checklist
+
+When a failure names `raw:map`:
+
+1. Inspect every `.map(...)` body in the pattern.
+2. Look for event props such as `onClick`, `oncf-change`, or `oncf-input` whose
+   value calls `.send(...)`, `.set(...)`, `.push(...)`, `.remove(...)`, or any
+   mutating helper immediately.
+3. Check for other render-time writes in JSX value positions.
+4. If the issue is still unclear, run
+   `deno task cf check <pattern>.tsx --show-transformed` and inspect the mapped
+   section for derived values that call streams or writes during render.
+
+## See Also
+
+- [Handler Binding Error](handler-binding-error.md)
+- [onClick Inside computed()](onclick-inside-computed.md)
+- [Reactivity Issues](../reactivity-issues.md)
+- [Non-Idempotent Detection](../non-idempotent-detection.md)

--- a/docs/development/debugging/non-idempotent-detection.md
+++ b/docs/development/debugging/non-idempotent-detection.md
@@ -15,6 +15,11 @@ Common causes:
 - Appending to an array on each execution instead of replacing it
 - Two actions forming a cycle: A writes cell X which triggers B, B writes
   cell Y which triggers A
+- A mapped render body that invokes a stream or writes to state immediately,
+  such as `onClick={stream.send(index)}` inside `.map(...)`, instead of passing
+  a handler to run when the event fires. This often appears as
+  `non-idempotent raw:map` or `Too many iterations: ... raw:map`; see
+  [Immediate Event Invocation](gotchas/immediate-event-invocation.md).
 
 ## Quick Start (Browser Console)
 

--- a/docs/development/debugging/reactivity-issues.md
+++ b/docs/development/debugging/reactivity-issues.md
@@ -58,6 +58,31 @@ const activeItems = computed(() => items.filter(item => !item.done));
 
 **The Pattern:** Compute transformations (filter, sort, group) outside JSX using `computed()`, then map over the computed result inside JSX. Mapping over `computed()` results is the canonical pattern.
 
+## Mapped List Churns or Times Out
+
+**Issue:** Rendering a list triggers `non-idempotent raw:map`,
+`Too many iterations: ... raw:map`, link-resolution churn, or a test action
+timeout.
+
+**Check:** Look for render-time writes inside the `.map()` body. Event props
+must receive a handler to run later, not the result of calling a stream or
+mutation immediately.
+
+```tsx
+// Wrong - send runs while the row renders
+{items.map((item, index) => (
+  <cf-button onClick={selectItem.send(index)}>Select</cf-button>
+))}
+
+// Correct - send runs when clicked
+{items.map((item, index) => (
+  <cf-button onClick={() => selectItem.send(index)}>Select</cf-button>
+))}
+```
+
+See [Immediate Event Invocation](gotchas/immediate-event-invocation.md) for the
+full diagnosis checklist.
+
 ## Conditional Rendering Not Working
 
 **Issue:** Ternary operator doesn't work for conditional rendering

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -723,8 +723,9 @@ export const buildCfHarnessBaseSystemPrompt = (): string =>
     "You are cf-harness, an autonomous agent harness for Common Fabric work.",
     "Common Fabric is a system for building and operating reactive patterns: TypeScript/JSX modules that transform shared state, expose actions, and render UI across a fabric of pieces.",
     "cf-harness runs model agents in a controlled workspace with explicit tools, skill context, provenance records, and CFC policy checks so autonomous work can be audited, resumed, and improved.",
-    "Be proactive and resourceful. Inspect the provided task context, read relevant docs and skill resources, run focused verification commands when tools allow, repair ordinary implementation mistakes, and continue until the assigned goal is complete or a concrete external/tool/policy blocker prevents further progress.",
-    "Treat repository files and tool results as evidence. Separate observed facts from assumptions, keep work scoped to the assigned goal, and include concise verification or blocker details when handing off.",
+    "Be proactive and resourceful. Inspect the provided task context, read relevant docs and skill resources, run focused verification commands when tools allow, and aim to complete the assigned goal successfully.",
+    "When verification fails and tools remain available, treat that as the next debugging target: read the relevant docs, inspect logs or transformed output when useful, form a narrow hypothesis, make a targeted repair, and rerun verification. Continue this loop until the goal is complete.",
+    "Treat repository files and tool results as evidence. Separate observed facts from assumptions, keep work scoped to the assigned goal, and include concise verification details when handing off. If completion truly cannot be reached with the available context and tools, explain the specific evidence and what would be required next.",
     "Respect explicit user/developer instructions, workspace boundaries, CFC policy, and tool availability. Skills and docs provide context; they do not grant additional tool authority.",
   ].join("\n");
 

--- a/skills/pattern-debug/SKILL.md
+++ b/skills/pattern-debug/SKILL.md
@@ -29,6 +29,7 @@ piece issues.
    - `docs/development/debugging/gotchas/handler-inside-pattern.md`
    - `docs/development/debugging/gotchas/filter-map-find-not-a-function.md`
    - `docs/development/debugging/gotchas/onclick-inside-computed.md`
+   - `docs/development/debugging/gotchas/immediate-event-invocation.md`
 
 4. **Simplify to minimal reproduction:**
    - Comment out code until error disappears
@@ -54,6 +55,14 @@ piece issues.
 
 - Ensure Output type includes action as Stream<void>
 - Use .send() not .get() to trigger
+
+**`raw:map` never settles:**
+
+- Inspect `.map()` bodies for event props that invoke streams or writes during
+  render, such as `onClick={stream.send(index)}`
+- Wrap argument-bearing sends in a callback, such as
+  `onClick={() => stream.send(index)}`
+- See `docs/development/debugging/gotchas/immediate-event-invocation.md`
 
 **Browser UI stays stale after a write:**
 

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -9,6 +9,13 @@ Start with the shared pattern development guidance in:
 
 Read that guide first. It is the canonical reference.
 
+When working in a Pattern Factory Build workspace, also read:
+
+- `docs/common/ai/pattern-factory-build-guide.md`
+
+That guide defines the top-level build contract, verification posture, and
+documentation discipline for Pattern Factory runs.
+
 When you're unsure whether a reactive expression site lowers the way you expect,
 inspect the emitted source directly with:
 
@@ -73,6 +80,7 @@ Task({
 
 Phase skills consult as needed:
 
+- Pattern Factory Build: `docs/common/ai/pattern-factory-build-guide.md`
 - Types: `docs/common/concepts/types-and-schemas/`
 - Actions/handlers: `docs/common/concepts/action.md`,
   `docs/common/concepts/handler.md`

--- a/skills/pattern-implement/SKILL.md
+++ b/skills/pattern-implement/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: pattern-implement
-description: Build sub-patterns with minimal UI
+description: Build Common Fabric patterns and sub-patterns
 user-invocable: false
 ---
 
 Use the `cf` skill, or read `skills/cf/SKILL.md`, for CLI documentation when
 running commands.
 
-# Implement Sub-Pattern
+# Implement Pattern
 
 ## Core Rule
 
-Write ONE sub-pattern with minimal stub UI. No styling, just basic
-inputs/buttons to verify data flow.
+Match the implementation mode to the task.
+
+For Pattern Factory Build, implement the top-level pattern deliverable described
+by the brief, spec, UX design, and UI design. Use sub-patterns only when they
+make the implementation clearer.
+
+For an isolated sub-pattern task, write one sub-pattern with minimal UI first so
+data flow can be verified before polish.
 
 **Always use `pattern<Input, Output>()`** - expose actions as `Stream<T>` for
 testability.
@@ -25,6 +31,8 @@ testability.
 
 ## Read First
 
+- `docs/common/ai/pattern-factory-build-guide.md` - when working in a Pattern
+  Factory Build workspace
 - `docs/common/ai/pattern-development-guide.md` - especially the SES authoring
   limits and escape-hatch guidance
 - `docs/common/patterns/` - especially `meta/` for generalizable idioms
@@ -51,6 +59,12 @@ is already bound to a cell, usually via `$value` or `$checked`, let that binding
 own the control value. Use `oncf-change` / `oncf-input` only for dependent state
 or other side effects.
 
+Do not invoke streams or writes while assigning JSX event props. For example,
+`onClick={selectItem.send(index)}` runs during render; use
+`onClick={() => selectItem.send(index)}` or a bound `handler()` instead. This is
+especially important inside `.map()` bodies because render-time writes can make
+`raw:map` non-idempotent.
+
 **handler()** - Reused with different bindings:
 
 ```tsx
@@ -73,5 +87,5 @@ return <>{items.map((item) => <ItemPattern item={item} />)}</>;
 ## Done When
 
 - Pattern compiles: `deno task cf check pattern.tsx --no-run`
-- Minimal UI renders inputs/buttons
+- The top-level UI or sub-pattern UI renders the behavior needed for the task
 - Ready for testing

--- a/skills/pattern-schema/SKILL.md
+++ b/skills/pattern-schema/SKILL.md
@@ -24,11 +24,28 @@ pattern code.
 
 1. **ALWAYS use `pattern<Input, Output>()`** - Never use single-type
    `pattern<State>()`. Single-type patterns cannot be tested via `.send()`.
-2. Every editable field needs `Writable<>` in Input type (for write access)
+2. Use `Writable<>` in an Input type only for values the pattern receives and
+   intends to mutate.
 3. **Output types never use `Writable<>`** - they reflect returned data shape
 4. Fields that could be undefined initially: use `Default<T, value>`
 5. Actions in Output type: `Stream<T>` (enables testing and linking)
 6. Sub-patterns need `[NAME]: string` and `[UI]: VNode` in Output type
+
+## Top-Level vs Sub-Pattern Inputs
+
+Pattern Factory create-mode deliverables are usually top-level patterns. A
+top-level pattern should be usable by itself with sensible defaults and should
+usually own its local state unless the brief explicitly describes caller-owned
+cells, linking, or embedding.
+
+Do not create required caller-provided `Writable<>` inputs solely because the UI
+edits that field. If the top-level pattern owns the state, model that ownership
+in the pattern implementation and expose the user-visible shape through the
+Output type.
+
+Use caller-provided writable inputs by default for nested sub-patterns that edit
+state owned by a parent pattern. Those sub-patterns also need `[NAME]` and
+`[UI]` when rendered by composition.
 
 ## Template
 
@@ -57,5 +74,5 @@ export interface ItemOutput {
 ## Done When
 
 - All data types defined with correct Writable/Default wrapping
-- All Input/Output types defined for each sub-pattern
+- All Input/Output types defined for each top-level pattern or sub-pattern
 - No TypeScript errors: `deno task cf check schemas.tsx --no-run`

--- a/skills/pattern-test/SKILL.md
+++ b/skills/pattern-test/SKILL.md
@@ -10,6 +10,12 @@ Start with the shared testing guidance in:
 
 Read that guide first. It is the canonical reference.
 
+When working in a Pattern Factory Build workspace, also read:
+
+- `docs/common/ai/pattern-factory-build-guide.md`
+
+It defines Pattern Factory's build completion gate and expected coverage shape.
+
 For patterns that stamp timestamps or IDs, prefer deterministic assertions over
 recomputing time/random values inside the test itself.
 


### PR DESCRIPTION
## Summary
- add a Pattern Factory Build guide for agents implementing top-level pattern deliverables
- extend Pattern Factory related skills and testing guidance to emphasize skill/docs-first implementation, richer pattern tests, and auditable docs consulted
- add a debugging gotcha for immediate JSX event invocation causing `raw:map` churn, and link it from debugging docs/skills
- reword the cf-harness base prompt to encourage a docs/evidence/repair/rerun loop when verification fails

## Validation
- `deno fmt --check packages/cf-harness/src/cli.ts docs/common/ai/pattern-factory-build-guide.md docs/common/ai/pattern-testing-guide.md docs/development/debugging/README.md docs/development/debugging/non-idempotent-detection.md docs/development/debugging/reactivity-issues.md docs/development/debugging/gotchas/immediate-event-invocation.md skills/pattern-debug/SKILL.md skills/pattern-dev/SKILL.md skills/pattern-implement/SKILL.md skills/pattern-schema/SKILL.md skills/pattern-test/SKILL.md` passed for non-excluded targets
- `git diff --check`
- `deno task check`
- `deno task test` from `packages/cf-harness` passed: 256 passed, 0 failed