### PR TITLE
Add cf-harness view_image tool

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -40,11 +40,13 @@ What works today:
   - `bash`
   - `bash-no-sandbox` (provisional host shell for named subagent profiles only)
   - `read_file`
+  - `view_image`
   - `read_skill_resource`
   - `edit_file`
   - `write_file`
   - `delegate_task`
 - targeted exact-string edits plus whole-file replace/create and append writes
+- initial and in-run image attachments for model vision-capable flows
 - bounded OpenAI-compatible prompt/tool loop
 - single-child subagent delegation with fresh child prompt context, explicit
   default/browser child profiles, retained child run references, and a sanitized
@@ -239,8 +241,8 @@ locator actions, and normal browser interactions.
 For browser-profile runs, prefer a host artifact root outside the workspace. Raw
 child artifacts are retained for operator analysis, but they are not meant to
 become ordinary workspace inputs for the parent model. If an artifact root is
-physically placed under the workspace, `read_file`, `write_file`, and
-`edit_file`, plus browser-profile `ls`/`find`, treat that artifact tree as
+physically placed under the workspace, `read_file`, `view_image`, `write_file`,
+and `edit_file`, plus browser-profile `ls`/`find`, treat that artifact tree as
 reserved from model-facing file and discovery tools.
 
 ```bash

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -191,7 +191,7 @@ Options:
   --workspace <path>            Workspace host path (defaults to current directory)
   --cwd <path>                  Initial working directory inside the workspace
   --focus-root <path>           Narrow exploration to a workspace subpath when possible
-  --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | read_skill_resource | edit_file | write_file | delegate_task)
+  --allow-tool <tool>           Restrict available tools (repeatable: bash | read_file | view_image | read_skill_resource | edit_file | write_file | delegate_task)
   --allow-subagent-profile <p>  Authorize delegate_task to spawn a profile (repeatable: default | browser)
   --output-mode <mode>          operator | batch (default: operator)
   --stream-events               Print transcript events as they happen

--- a/packages/cf-harness/src/contracts/subagent.ts
+++ b/packages/cf-harness/src/contracts/subagent.ts
@@ -12,12 +12,14 @@ export const DEFAULT_SUBAGENT_RETURN_CHANNEL =
 export const DEFAULT_SUBAGENT_ALLOWED_TOOL_IDS = [
   "bash",
   "read_file",
+  "view_image",
   "edit_file",
   "write_file",
 ] as const satisfies readonly BuiltinToolId[];
 export const BROWSER_SUBAGENT_ALLOWED_TOOL_IDS = [
   "bash-no-sandbox",
   "read_file",
+  "view_image",
 ] as const satisfies readonly BuiltinToolId[];
 export const NO_HOST_TOOL_IDS = [] as const satisfies readonly BuiltinToolId[];
 export const BROWSER_SUBAGENT_HOST_TOOL_IDS = [

--- a/packages/cf-harness/src/contracts/tool-descriptor.ts
+++ b/packages/cf-harness/src/contracts/tool-descriptor.ts
@@ -4,6 +4,7 @@ export type BuiltinToolId =
   | "bash"
   | "bash-no-sandbox"
   | "read_file"
+  | "view_image"
   | "read_skill_resource"
   | "edit_file"
   | "write_file"
@@ -12,6 +13,7 @@ export type BuiltinToolId =
 export const DEFAULT_PARENT_TOOL_IDS = [
   "bash",
   "read_file",
+  "view_image",
   "read_skill_resource",
   "edit_file",
   "write_file",

--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -703,6 +703,7 @@ export const classifyBuiltinToolFailure = (
         toolId,
       );
     case "read_file":
+    case "view_image":
     case "edit_file":
     case "write_file":
       return classifyStructuredFileToolFailure(toolId, output, at);
@@ -775,7 +776,7 @@ const fileFailureKindForCode = (
 };
 
 const classifyStructuredFileToolFailure = (
-  toolId: "read_file" | "write_file" | "edit_file",
+  toolId: "read_file" | "view_image" | "write_file" | "edit_file",
   output: unknown,
   at: string,
 ): HarnessFailureRecord | undefined => {

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -104,6 +104,10 @@ import {
   type ReadFileToolOutput,
 } from "./tools/read-file.ts";
 import {
+  type ViewImageToolInput,
+  type ViewImageToolOutput,
+} from "./tools/view-image.ts";
+import {
   type ReadSkillResourceToolInput,
   type ReadSkillResourceToolOutput,
 } from "./tools/read-skill-resource.ts";
@@ -117,6 +121,7 @@ export interface BuiltinToolInputMap {
   bash: BashToolInput;
   "bash-no-sandbox": BashToolInput;
   read_file: ReadFileToolInput;
+  view_image: ViewImageToolInput;
   read_skill_resource: ReadSkillResourceToolInput;
   edit_file: EditFileToolInput;
   write_file: WriteFileToolInput;
@@ -127,6 +132,7 @@ export interface BuiltinToolOutputMap {
   bash: BashToolOutput;
   "bash-no-sandbox": BashToolOutput;
   read_file: ReadFileToolOutput;
+  view_image: ViewImageToolOutput;
   read_skill_resource: ReadSkillResourceToolOutput;
   edit_file: EditFileToolOutput;
   write_file: WriteFileToolOutput;
@@ -1004,6 +1010,7 @@ export class CfHarnessEngine {
       runId: this.#runState.runId,
       cfcEnforcementMode: this.#runState.cfcEnforcementMode,
       currentDir: this.#runState.currentDir,
+      workspaceHostPath: this.workspaceHostPath,
       skillRegistry: this.#runState.skillRegistry,
       sandbox: this.sandbox,
       hostProcessRunner: this.hostProcessRunner,

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -84,6 +84,7 @@ import {
   cwdMarkerForOutput,
   extractFinalWorkingDirectory,
 } from "./tools/shell-cwd.ts";
+import { isViewImageToolSuccessOutput } from "./tools/view-image.ts";
 import type { HarnessFailureRecord } from "./diagnostics.ts";
 import { DEFAULT_PARENT_TOOL_IDS as DEFAULT_PROMPT_LOOP_TOOL_IDS } from "./contracts/tool-descriptor.ts";
 
@@ -421,11 +422,12 @@ const summarizeToolInput = async (
       };
     }
     case "read_file":
+    case "view_image":
       return {
         type: "cf-harness.tool-input-summary",
         toolId,
         ...(typeof input.path === "string" ? { path: input.path } : {}),
-        ...(isSafeNonNegativeInteger(input.maxBytes)
+        ...(toolId === "read_file" && isSafeNonNegativeInteger(input.maxBytes)
           ? { maxBytes: input.maxBytes }
           : {}),
       };
@@ -889,6 +891,11 @@ type ModelFacingToolOutput = unknown;
 type RecordHarnessPolicyEvent = (
   event: Parameters<CfHarnessEngine["recordPolicyEvent"]>[0],
 ) => Promise<void>;
+
+interface InvokedToolCallMessages {
+  toolMessage: HarnessToolTranscriptMessage;
+  followupMessages?: readonly HarnessTranscriptMessage[];
+}
 
 interface CfcSandboxResultCarrier {
   cfcResult?: CfcSandboxResult;
@@ -1427,14 +1434,16 @@ export class CfHarnessPromptLoop {
             runState: this.engine.getRunState(),
           };
         }
+        const followupMessages: HarnessTranscriptMessage[] = [];
         for (const toolCall of toolCalls) {
-          const toolMessage = await this.#invokeToolCall(
+          const invokedToolCall = await this.#invokeToolCall(
             toolCall,
             model,
             promptSlotBinding,
             toolActivity.length + 1,
             (activity) => toolActivity.push(activity),
           );
+          const toolMessage = invokedToolCall.toolMessage;
           transcript.push(toolMessage);
           await this.engine.persistTranscript(transcript);
           reportTimeline.push(transcriptTimelineEntry(
@@ -1445,6 +1454,23 @@ export class CfHarnessPromptLoop {
           ));
           await options.onTranscriptEvent?.({
             message: toolMessage,
+            transcript,
+          });
+          if (invokedToolCall.followupMessages !== undefined) {
+            followupMessages.push(...invokedToolCall.followupMessages);
+          }
+        }
+        for (const followupMessage of followupMessages) {
+          transcript.push(followupMessage);
+          await this.engine.persistTranscript(transcript);
+          reportTimeline.push(transcriptTimelineEntry(
+            followupMessage,
+            transcript.length - 1,
+            this.engine.getRunState().updatedAt,
+            modelTurns,
+          ));
+          await options.onTranscriptEvent?.({
+            message: followupMessage,
             transcript,
           });
         }
@@ -1492,7 +1518,7 @@ export class CfHarnessPromptLoop {
     promptSlotBinding?: PromptSlotBinding,
     sequence = 1,
     recordActivity: (activity: HarnessToolActivity) => void = () => {},
-  ): Promise<HarnessToolTranscriptMessage> {
+  ): Promise<InvokedToolCallMessages> {
     if (!isBuiltinToolId(toolCall.function.name)) {
       throw new Error(
         `unknown builtin tool requested: ${toolCall.function.name}`,
@@ -1583,10 +1609,12 @@ export class CfHarnessPromptLoop {
         ...optionalPolicyEventIndexes(policyEventIndexes),
       });
       return {
-        role: "tool",
-        toolCallId: toolCall.id,
-        toolName: toolCall.function.name,
-        content: JSON.stringify(denial),
+        toolMessage: {
+          role: "tool",
+          toolCallId: toolCall.id,
+          toolName: toolCall.function.name,
+          content: JSON.stringify(denial),
+        },
       };
     }
     const input = parsedInputForDeniedTool ?? parseToolArguments(toolCall);
@@ -1655,10 +1683,12 @@ export class CfHarnessPromptLoop {
         ...optionalPolicyEventIndexes(policyEventIndexes),
       });
       return {
-        role: "tool",
-        toolCallId: toolCall.id,
-        toolName: toolCall.function.name,
-        content: JSON.stringify(denial),
+        toolMessage: {
+          role: "tool",
+          toolCallId: toolCall.id,
+          toolName: toolCall.function.name,
+          content: JSON.stringify(denial),
+        },
       };
     }
     let delegateInput: DelegateTaskToolInput | undefined;
@@ -1734,10 +1764,12 @@ export class CfHarnessPromptLoop {
           ...optionalPolicyEventIndexes(policyEventIndexes),
         });
         return {
-          role: "tool",
-          toolCallId: toolCall.id,
-          toolName: toolCall.function.name,
-          content: JSON.stringify(denial),
+          toolMessage: {
+            role: "tool",
+            toolCallId: toolCall.id,
+            toolName: toolCall.function.name,
+            content: JSON.stringify(denial),
+          },
         };
       }
       policyDecisionReasonCodes.push("subagent_profile_allowed");
@@ -1817,13 +1849,25 @@ export class CfHarnessPromptLoop {
       ...optionalPolicyEventIndexes(policyEventIndexes),
       resultRef: result.resultRef,
     });
-    return {
+    const toolMessage: HarnessToolTranscriptMessage = {
       role: "tool",
       toolCallId: toolCall.id,
       toolName: toolCall.function.name,
       content: JSON.stringify(modelOutput),
       resultRef: result.resultRef,
     };
+    if (isViewImageToolSuccessOutput(result.output)) {
+      return {
+        toolMessage,
+        followupMessages: [{
+          role: "user",
+          content:
+            `Image loaded by view_image from ${result.output.path} (outputId: ${result.output.outputId}).`,
+          imageAttachments: [result.output.imageAttachment],
+        }],
+      };
+    }
+    return { toolMessage };
   }
 
   async #modelFacingToolOutput(
@@ -1837,6 +1881,16 @@ export class CfHarnessPromptLoop {
       ((event) => this.engine.recordPolicyEvent(event));
     const mode = this.engine.getRunState().cfcEnforcementMode;
     const cfcResult = cfcResultFromOutput(output);
+    if (toolId === "view_image" && isViewImageToolSuccessOutput(output)) {
+      return {
+        outputId: output.outputId,
+        path: output.path,
+        mediaType: output.mediaType,
+        bytes: output.bytes,
+        digest: output.digest,
+        imageAttached: true,
+      };
+    }
     if (!toolOutputNeedsSandboxMediation(toolId)) {
       return stripInternalCfcFields(output);
     }

--- a/packages/cf-harness/src/tools/file-errors.ts
+++ b/packages/cf-harness/src/tools/file-errors.ts
@@ -101,7 +101,7 @@ const messageForFileToolError = (
 
 export const createStructuredFileToolErrorOutput = (
   context: HarnessToolContext,
-  toolId: "read_file" | "write_file" | "edit_file",
+  toolId: "read_file" | "view_image" | "write_file" | "edit_file",
   options: {
     path: string;
     code: StructuredFileToolErrorCode;

--- a/packages/cf-harness/src/tools/registry.ts
+++ b/packages/cf-harness/src/tools/registry.ts
@@ -5,6 +5,7 @@ import { delegateTaskTool } from "./delegate-task.ts";
 import { editFileTool } from "./edit-file.ts";
 import { readFileTool } from "./read-file.ts";
 import { readSkillResourceTool } from "./read-skill-resource.ts";
+import { viewImageTool } from "./view-image.ts";
 import { writeFileTool } from "./write-file.ts";
 import type { HarnessToolDefinition } from "./types.ts";
 
@@ -12,6 +13,7 @@ export const BUILTIN_TOOLS = [
   bashTool,
   bashNoSandboxTool,
   readFileTool,
+  viewImageTool,
   readSkillResourceTool,
   editFileTool,
   writeFileTool,

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -19,6 +19,7 @@ export interface HarnessToolContext {
   sandbox: SandboxRuntime;
   hostProcessRunner: ProcessRunner;
   currentDir: string;
+  workspaceHostPath?: string;
   resolvePath(path: string): string;
   resolveHostPath(path: string): string;
   hostPathToWorkspacePath(path: string): string | undefined;

--- a/packages/cf-harness/src/tools/view-image.ts
+++ b/packages/cf-harness/src/tools/view-image.ts
@@ -1,0 +1,178 @@
+import type { JSONSchema } from "@commonfabric/api";
+import type { HarnessImageAttachment } from "../contracts/image.ts";
+import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
+import { createHarnessImageAttachment } from "../image-attachments.ts";
+import type { HarnessToolDefinition } from "./types.ts";
+import {
+  classifyPathResolutionError,
+  createStructuredFileToolErrorOutput,
+  detailFromUnknownError,
+  type StructuredFileToolErrorOutput,
+  structuredFileToolErrorOutputSchema,
+} from "./file-errors.ts";
+import {
+  isResolvedPathInsideArtifactRoot,
+  RESERVED_ARTIFACT_PATH_DETAIL,
+} from "./reserved-artifacts.ts";
+
+export interface ViewImageToolInput {
+  path: string;
+}
+
+export interface ViewImageToolSuccessOutput {
+  outputId: string;
+  path: string;
+  mediaType: HarnessImageAttachment["mediaType"];
+  bytes: number;
+  digest: string;
+  imageAttachment: HarnessImageAttachment;
+}
+
+export type ViewImageToolOutput =
+  | ViewImageToolSuccessOutput
+  | StructuredFileToolErrorOutput;
+
+export const isViewImageToolSuccessOutput = (
+  output: unknown,
+): output is ViewImageToolSuccessOutput =>
+  typeof output === "object" &&
+  output !== null &&
+  "imageAttachment" in output &&
+  typeof output.imageAttachment === "object" &&
+  output.imageAttachment !== null &&
+  "type" in output.imageAttachment &&
+  output.imageAttachment.type === "cf-harness.image-attachment";
+
+export const viewImageToolDescriptor: HarnessToolDescriptor = {
+  toolId: "view_image",
+  title: "View Image",
+  description:
+    "Attach an image file from the target VM to the next model turn. Supports PNG, JPEG, GIF, and WebP files inside the workspace.",
+  effectClass: "read",
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: { type: "string" },
+    },
+    required: ["path"],
+    additionalProperties: false,
+  } satisfies JSONSchema,
+  outputSchema: {
+    oneOf: [{
+      type: "object",
+      properties: {
+        outputId: { type: "string" },
+        path: { type: "string" },
+        mediaType: {
+          type: "string",
+          enum: ["image/gif", "image/jpeg", "image/png", "image/webp"],
+        },
+        bytes: { type: "integer", minimum: 1 },
+        digest: { type: "string" },
+        imageAttachment: {
+          type: "object",
+          properties: {
+            type: {
+              type: "string",
+              const: "cf-harness.image-attachment",
+            },
+            hostPath: { type: "string" },
+            mediaType: {
+              type: "string",
+              enum: ["image/gif", "image/jpeg", "image/png", "image/webp"],
+            },
+            bytes: { type: "integer", minimum: 1 },
+            digest: { type: "string" },
+          },
+          required: ["type", "hostPath", "mediaType", "bytes", "digest"],
+          additionalProperties: false,
+        },
+      },
+      required: [
+        "outputId",
+        "path",
+        "mediaType",
+        "bytes",
+        "digest",
+        "imageAttachment",
+      ],
+      additionalProperties: false,
+    }, structuredFileToolErrorOutputSchema],
+  } satisfies JSONSchema,
+  tags: ["file", "image", "read", "vision", "vm"],
+};
+
+export const viewImageTool: HarnessToolDefinition<
+  ViewImageToolInput,
+  ViewImageToolOutput
+> = {
+  descriptor: viewImageToolDescriptor,
+  async invoke(context, input) {
+    let resolvedPath: string;
+    try {
+      resolvedPath = context.resolvePath(input.path);
+    } catch (error) {
+      return createStructuredFileToolErrorOutput(context, "view_image", {
+        path: input.path,
+        code: classifyPathResolutionError(error),
+        detail: detailFromUnknownError(error),
+      });
+    }
+    if (await isResolvedPathInsideArtifactRoot(context, resolvedPath)) {
+      return createStructuredFileToolErrorOutput(context, "view_image", {
+        path: resolvedPath,
+        code: "permission_denied",
+        detail: RESERVED_ARTIFACT_PATH_DETAIL,
+      });
+    }
+    if (context.workspaceHostPath === undefined) {
+      return createStructuredFileToolErrorOutput(context, "view_image", {
+        path: resolvedPath,
+        code: "unknown",
+        detail: "workspace host path is not configured",
+      });
+    }
+    let hostPath: string;
+    try {
+      hostPath = context.resolveHostPath(resolvedPath);
+    } catch (error) {
+      return createStructuredFileToolErrorOutput(context, "view_image", {
+        path: resolvedPath,
+        code: classifyPathResolutionError(error),
+        detail: detailFromUnknownError(error),
+      });
+    }
+    try {
+      const imageAttachment = await createHarnessImageAttachment({
+        workspaceHostPath: context.workspaceHostPath,
+        cwd: context.workspaceHostPath,
+        path: hostPath,
+      });
+      return {
+        outputId: context.nextOutputId("view_image"),
+        path: resolvedPath,
+        mediaType: imageAttachment.mediaType,
+        bytes: imageAttachment.bytes,
+        digest: imageAttachment.digest,
+        imageAttachment,
+      };
+    } catch (error) {
+      const detail = detailFromUnknownError(error);
+      return createStructuredFileToolErrorOutput(context, "view_image", {
+        path: resolvedPath,
+        code: detail.includes("not a file")
+          ? "not_a_file"
+          : detail.includes("paths must stay within the workspace")
+          ? "path_outside_workspace"
+          : detail.includes("path is not a file")
+          ? "not_a_file"
+          : detail.includes("path is empty") ||
+              detail.includes("path is too large") ||
+              detail.includes("supported image type")
+          ? "unknown"
+          : "file_not_found",
+        detail,
+      });
+    }
+  },
+};

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -430,6 +430,7 @@ Deno.test({
         allowedToolIds: [
           "bash",
           "read_file",
+          "view_image",
           "read_skill_resource",
           "edit_file",
           "write_file",
@@ -441,7 +442,7 @@ Deno.test({
       ]);
       assertEquals(
         persistedPolicySnapshot.subagents.profileConfigs[0].allowedToolIds,
-        ["bash", "read_file", "edit_file", "write_file"],
+        ["bash", "read_file", "view_image", "edit_file", "write_file"],
       );
       assertEquals(
         persistedPolicySnapshot.substrate?.sandbox?.kind,
@@ -566,7 +567,7 @@ Deno.test({
         {
           model: "gpt-5.4",
           messageCount: 1,
-          toolCount: 6,
+          toolCount: 7,
         },
       );
       assert(
@@ -773,6 +774,7 @@ Deno.test({
       assertEquals(subagentRun.manifest.allowedToolIds, [
         "bash",
         "read_file",
+        "view_image",
         "edit_file",
         "write_file",
       ]);

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -471,6 +471,8 @@ Deno.test("parseCfHarnessCliArgs supports allowed tools and result json path", a
       "--allow-tool",
       "read_file",
       "--allow-tool",
+      "view_image",
+      "--allow-tool",
       "read_skill_resource",
       "--allow-tool",
       "bash",
@@ -488,6 +490,7 @@ Deno.test("parseCfHarnessCliArgs supports allowed tools and result json path", a
   }
   assertEquals(parsed.allowedToolIds, [
     "read_file",
+    "view_image",
     "read_skill_resource",
     "bash",
   ]);
@@ -672,7 +675,7 @@ Deno.test("parseCfHarnessCliArgs rejects bash-no-sandbox as a parent allow-tool"
         },
       ),
     Error,
-    "allowed tools must be one or more of bash, read_file, read_skill_resource, edit_file, write_file, delegate_task",
+    "allowed tools must be one or more of bash, read_file, view_image, read_skill_resource, edit_file, write_file, delegate_task",
   );
 });
 
@@ -694,7 +697,7 @@ Deno.test("parseCfHarnessCliArgs rejects unknown allowed tools before resolving 
         },
       ),
     Error,
-    "allowed tools must be one or more of bash, read_file, read_skill_resource, edit_file, write_file, delegate_task",
+    "allowed tools must be one or more of bash, read_file, view_image, read_skill_resource, edit_file, write_file, delegate_task",
   );
 });
 

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -359,6 +359,7 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
     [
       "bash",
       "read_file",
+      "view_image",
       "read_skill_resource",
       "edit_file",
       "write_file",
@@ -377,6 +378,110 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
       }),
     },
   );
+});
+
+Deno.test("CfHarnessPromptLoop attaches images loaded by view_image on the next model turn", async () => {
+  const workspace = await Deno.realPath(await Deno.makeTempDir());
+  await Deno.writeFile(join(workspace, "capture.png"), ONE_PIXEL_PNG);
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      workspaceHostPath: workspace,
+      runId: "run-view-image",
+      model: "gpt-5.4",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-image",
+                type: "function",
+                function: {
+                  name: "view_image",
+                  arguments: JSON.stringify({ path: "capture.png" }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "The image was available on the second turn.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    systemPrompt: "You are a test harness.",
+    prompt: "Inspect the image if needed.",
+  });
+
+  assertEquals(
+    result.finalAssistantText,
+    "The image was available on the second turn.",
+  );
+  const toolMessage = result.transcript.at(-3);
+  if (toolMessage?.role !== "tool") {
+    throw new Error("expected view_image tool message");
+  }
+  const modelFacingOutput = JSON.parse(toolMessage.content) as {
+    outputId: string;
+    path: string;
+    mediaType: string;
+    bytes: number;
+    digest: string;
+    imageAttached: boolean;
+    imageAttachment?: unknown;
+  };
+  assertEquals(modelFacingOutput.outputId, "run-view-image:view_image:1");
+  assertEquals(modelFacingOutput.path, "/workspace/capture.png");
+  assertEquals(modelFacingOutput.mediaType, "image/png");
+  assertEquals(modelFacingOutput.bytes, ONE_PIXEL_PNG.byteLength);
+  assertEquals(modelFacingOutput.imageAttached, true);
+  assertEquals(modelFacingOutput.imageAttachment, undefined);
+
+  const followup = result.transcript.at(-2);
+  if (followup?.role !== "user") {
+    throw new Error("expected view_image followup user message");
+  }
+  assertEquals(
+    followup.imageAttachments?.[0]?.hostPath,
+    join(workspace, "capture.png"),
+  );
+
+  const secondRequest = JSON.parse(String(fetchCalls[1]?.body)) as {
+    messages: Array<{ role: string; content: unknown }>;
+  };
+  const requestFollowup = secondRequest.messages.at(-1);
+  assertEquals(requestFollowup?.role, "user");
+  assert(Array.isArray(requestFollowup?.content));
+  assertEquals(requestFollowup.content[0], {
+    type: "text",
+    text:
+      "Image loaded by view_image from /workspace/capture.png (outputId: run-view-image:view_image:1).",
+  });
+  const imagePart = requestFollowup.content[1] as {
+    type?: string;
+    image_url?: { url?: string };
+  };
+  assertEquals(imagePart.type, "image_url");
+  assert(imagePart.image_url?.url?.startsWith("data:image/png;base64,"));
 });
 
 Deno.test("CfHarnessPromptLoop inserts context messages before the user prompt", async () => {
@@ -714,6 +819,7 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
     [
       "bash",
       "read_file",
+      "view_image",
       "read_skill_resource",
       "edit_file",
       "write_file",
@@ -722,7 +828,7 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
   );
   assertEquals(
     requestBodies[1].tools.map((tool) => tool.function.name),
-    ["bash", "read_file", "edit_file", "write_file"],
+    ["bash", "read_file", "view_image", "edit_file", "write_file"],
   );
   assertEquals(
     requestBodies[1].messages.map((message) => message.role),
@@ -788,6 +894,7 @@ Deno.test("CfHarnessPromptLoop delegates one fresh child run and returns a summa
   assertEquals(output.subagent.manifest.allowedToolIds, [
     "bash",
     "read_file",
+    "view_image",
     "edit_file",
     "write_file",
   ]);
@@ -1342,7 +1449,7 @@ Deno.test("CfHarnessPromptLoop lets an explicit subagent profile expand child to
   );
   assertEquals(
     requestBodies[1].tools.map((tool) => tool.function.name),
-    ["bash", "read_file", "edit_file", "write_file"],
+    ["bash", "read_file", "view_image", "edit_file", "write_file"],
   );
   assertEquals(result.runState.cfcPolicySnapshot?.parentTools, {
     allowance: "restricted",
@@ -1369,6 +1476,7 @@ Deno.test("CfHarnessPromptLoop lets an explicit subagent profile expand child to
   assertEquals(output.subagent.manifest.allowedToolIds, [
     "bash",
     "read_file",
+    "view_image",
     "edit_file",
     "write_file",
   ]);
@@ -1441,6 +1549,7 @@ Deno.test("CfHarnessPromptLoop keeps bash-no-sandbox unavailable to the parent b
     [
       "bash",
       "read_file",
+      "view_image",
       "read_skill_resource",
       "edit_file",
       "write_file",
@@ -1545,7 +1654,7 @@ Deno.test("CfHarnessPromptLoop gives bash-no-sandbox only to the authorized brow
   );
   assertEquals(
     requestBodies[1].tools.map((tool) => tool.function.name),
-    ["bash-no-sandbox", "read_file"],
+    ["bash-no-sandbox", "read_file", "view_image"],
   );
   assertEquals(
     requestBodies[1].messages[0].content.includes(
@@ -1563,6 +1672,7 @@ Deno.test("CfHarnessPromptLoop gives bash-no-sandbox only to the authorized brow
   assertEquals(output.subagent.manifest.allowedToolIds, [
     "bash-no-sandbox",
     "read_file",
+    "view_image",
   ]);
   assertEquals(output.subagent.manifest.hostToolIds, ["bash-no-sandbox"]);
   assertEquals(result.finalAssistantText, "Browser-profile parent completed.");
@@ -1710,7 +1820,7 @@ Deno.test("CfHarnessPromptLoop keeps browser subagent observations behind struct
     );
     assertEquals(
       requestBodies[1].tools.map((tool) => tool.function.name),
-      ["bash-no-sandbox", "read_file"],
+      ["bash-no-sandbox", "read_file", "view_image"],
     );
     assertEquals(
       requestBodies[1].messages[0].content.includes(
@@ -2061,7 +2171,7 @@ Deno.test("CfHarnessPromptLoop reports child run failures through delegate_task 
   );
   assertEquals(
     requestBodies[1].tools.map((tool) => tool.function.name),
-    ["bash", "read_file", "edit_file", "write_file"],
+    ["bash", "read_file", "view_image", "edit_file", "write_file"],
   );
   const toolMessage = result.transcript.at(-2);
   if (toolMessage?.role !== "tool") {
@@ -2124,7 +2234,13 @@ Deno.test("CfHarnessPromptLoop continues subagent ids from retained run state", 
       depth: 1,
       cfcEnforcementMode: "disabled",
       model: "gpt-5.4",
-      allowedToolIds: ["bash", "read_file", "edit_file", "write_file"],
+      allowedToolIds: [
+        "bash",
+        "read_file",
+        "view_image",
+        "edit_file",
+        "write_file",
+      ],
       hostToolIds: [],
       maxModelTurns: 8,
       returnPolicy: {

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { decodeBase64 } from "@std/encoding/base64";
 import { join } from "@std/path";
 import { normalize } from "@std/path/posix";
 import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
@@ -15,6 +16,7 @@ import { editFileTool } from "../src/tools/edit-file.ts";
 import { readFileTool } from "../src/tools/read-file.ts";
 import { RESERVED_ARTIFACT_PATH_DETAIL } from "../src/tools/reserved-artifacts.ts";
 import { readSkillResourceTool } from "../src/tools/read-skill-resource.ts";
+import { viewImageTool } from "../src/tools/view-image.ts";
 import { writeFileTool } from "../src/tools/write-file.ts";
 import type { HarnessToolContext } from "../src/tools/types.ts";
 import type {
@@ -28,6 +30,10 @@ import type {
   SandboxRuntime,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
+
+const ONE_PIXEL_PNG = decodeBase64(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p94AAAAASUVORK5CYII=",
+);
 
 class FakeSandboxRuntime implements SandboxRuntime {
   readonly kind = "docker-runsc-cfc" as const;
@@ -116,14 +122,15 @@ const createContext = (
   artifactRootHostPath?: string,
   skillRegistry?: HarnessSkillRegistry,
   skillResourceReads: HarnessSkillResourceRead[] = [],
+  workspaceHostPath = "/tmp/cf-harness-workspace",
 ): HarnessToolContext => {
   let currentDir = initialCurrentDir;
   let sequence = 0;
   let cfcInvocationSequence = 0;
-  const workspaceHostPath = "/tmp/cf-harness-workspace";
   return {
     runId: "run-1",
     cfcEnforcementMode,
+    workspaceHostPath,
     skillRegistry,
     get currentDir() {
       return currentDir;
@@ -1448,6 +1455,73 @@ Deno.test("write_file tool denies reserved artifact paths before shelling out", 
       message:
         "permission denied: /workspace/.cf-harness-artifacts/run-1/tool-output.json",
       path: "/workspace/.cf-harness-artifacts/run-1/tool-output.json",
+      detail: RESERVED_ARTIFACT_PATH_DETAIL,
+    },
+  });
+  assertEquals(sandbox.calls, []);
+});
+
+Deno.test("view_image tool attaches a workspace image without shelling out", async () => {
+  const workspace = await Deno.realPath(await Deno.makeTempDir());
+  await Deno.writeFile(join(workspace, "capture.png"), ONE_PIXEL_PNG);
+  const sandbox = new FakeSandboxRuntime();
+
+  const output = await viewImageTool.invoke(
+    createContext(
+      sandbox,
+      "/workspace",
+      new FakeProcessRunner(),
+      "observe",
+      undefined,
+      undefined,
+      [],
+      workspace,
+    ),
+    { path: "capture.png" },
+  );
+
+  assertEquals(output.outputId, "run-1:view_image:1");
+  assertEquals(output.path, "/workspace/capture.png");
+  if (!("imageAttachment" in output)) {
+    throw new Error("expected view_image success output");
+  }
+  assertEquals(output.mediaType, "image/png");
+  assertEquals(output.bytes, ONE_PIXEL_PNG.byteLength);
+  assertEquals(output.imageAttachment.hostPath, join(workspace, "capture.png"));
+  assertEquals(sandbox.calls, []);
+});
+
+Deno.test("view_image tool denies reserved artifact paths", async () => {
+  const workspace = await Deno.realPath(await Deno.makeTempDir());
+  const artifactRoot = join(workspace, ".cf-harness-artifacts");
+  await Deno.mkdir(artifactRoot, { recursive: true });
+  await Deno.writeFile(join(artifactRoot, "capture.png"), ONE_PIXEL_PNG);
+  const sandbox = new FakeSandboxRuntime();
+
+  const output = await viewImageTool.invoke(
+    createContext(
+      sandbox,
+      "/workspace",
+      new FakeProcessRunner(),
+      "observe",
+      artifactRoot,
+      undefined,
+      [],
+      workspace,
+    ),
+    { path: ".cf-harness-artifacts/capture.png" },
+  );
+
+  assertEquals(output, {
+    outputId: "run-1:view_image:1",
+    path: "/workspace/.cf-harness-artifacts/capture.png",
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "permission_denied",
+      message:
+        "permission denied: /workspace/.cf-harness-artifacts/capture.png",
+      path: "/workspace/.cf-harness-artifacts/capture.png",
       detail: RESERVED_ARTIFACT_PATH_DETAIL,
     },
   });

--- a/packages/cf-harness/test/tools-registry.test.ts
+++ b/packages/cf-harness/test/tools-registry.test.ts
@@ -15,17 +15,19 @@ Deno.test("builtin tool registry includes the agreed first-pass tool floor", () 
     "bash",
     "bash-no-sandbox",
     "read_file",
+    "view_image",
     "read_skill_resource",
     "edit_file",
     "write_file",
     "delegate_task",
   ]);
-  assertEquals(BUILTIN_TOOL_REGISTRY.size, 7);
+  assertEquals(BUILTIN_TOOL_REGISTRY.size, 8);
   assertEquals(
     [...DEFAULT_PARENT_TOOL_IDS],
     [
       "bash",
       "read_file",
+      "view_image",
       "read_skill_resource",
       "edit_file",
       "write_file",


### PR DESCRIPTION
## Summary
- add a built-in cf-harness view_image tool for workspace image attachments during a run
- attach viewed images to the next model turn while keeping host paths out of model-facing tool output
- include view_image in parent/default/browser tool profiles and update docs/tests

## Verification
- deno task test in packages/cf-harness: 259 passed
- git diff --check