### PR TITLE
[codex] Strengthen Pattern Factory Build guidance next part

### DIFF
--- a/docs/common/ai/pattern-development-guide.md
+++ b/docs/common/ai/pattern-development-guide.md
@@ -316,6 +316,12 @@ left ephemeral.
 Start with `docs/common/patterns/`, especially the meta guidance under
 `docs/common/patterns/meta/`.
 
+For Pattern Factory Build and other implementation work that creates or
+debugs stateful UI, read these foundational references before coding:
+
+- `docs/common/concepts/reactivity.md`
+- `docs/common/patterns/new-cells.md`
+
 Then consult the targeted references as needed:
 
 - `docs/common/concepts/types-and-schemas/`

--- a/docs/common/ai/pattern-factory-build-guide.md
+++ b/docs/common/ai/pattern-factory-build-guide.md
@@ -17,17 +17,21 @@ Treat the design inputs as the product contract. Treat the loaded skills and
 their referenced docs as the implementation contract.
 
 Before writing build artifacts, read the `Read First` references from the
-configured build skills that apply to the current work. At minimum this usually
-means:
+configured build skills that apply to the current work. At minimum this means:
 
 - the shared pattern development guide
 - the shared testing guide
+- `docs/common/concepts/reactivity.md`
+- `docs/common/patterns/new-cells.md`
 - type/schema docs for `Default<>`, `Writable<>`, and pattern Input/Output
-- action/handler/reactivity docs when the pattern has interactions or local
-  state changes
+- action/handler docs when the pattern has interactions or local state changes
 - UI/component docs when implementing the visual design
 - debugging docs after any compile, test, or runtime failure that is not
   immediately obvious
+
+Treat `reactivity.md` and `new-cells.md` as baseline Build reads, not optional
+references. Pattern Factory outputs are reactive patterns; top-level patterns
+commonly render reactive fields, create local draft state, and bind controls.
 
 Record the docs consulted in `notes/pattern-maker.md` so the run is auditable.
 
@@ -70,11 +74,27 @@ gates only when the available tools or context are genuinely insufficient to
 continue, or when the surrounding harness imposes an explicit turn/time
 boundary; record the exact evidence and required next input.
 
+## Failure Recovery Discipline
+
+After any failed `cf check`, `cf test`, CLI runtime check, or browser smoke:
+
+1. Preserve the exact failing command and relevant output in
+   `reviews/test-report.md`.
+2. Read `docs/development/debugging/README.md`.
+3. Match the exact error text or symptom to the matrix and read the linked
+   gotcha, workflow, or topic page before making the next repair.
+4. If the failure mentions Cell, Writable, `Cell.of()`, `Writable.of()`,
+   reactive references, `.get()`, or a plain JavaScript string/array method
+   failing on a field, reread:
+   - `docs/common/concepts/reactivity.md`
+   - `docs/common/patterns/new-cells.md`
+5. Form a narrow hypothesis, make a targeted edit, and rerun the failed gate.
+
+Record any additional docs consulted in `notes/pattern-maker.md`.
+
 When stuck:
 
-- preserve the exact failing command and relevant output in
-  `reviews/test-report.md`
-- inspect the relevant skill docs instead of guessing
+- inspect the relevant skill/docs path instead of guessing
 - use `cf check --show-transformed` or `--verbose-errors` when compiler
   lowering or error simplification is ambiguous
 - simplify to the smallest failing pattern or test step when a test failure is

--- a/docs/common/ai/pattern-testing-guide.md
+++ b/docs/common/ai/pattern-testing-guide.md
@@ -50,6 +50,14 @@ either the implementation or an invalid test contract, and rerun the test. A
 failing pattern test is not a valid done state unless a concrete external,
 tooling, or environment blocker prevents further repair.
 
+For non-obvious `cf test` failures, read
+`docs/development/debugging/README.md` before changing the test shape. Match the
+exact error to the matrix and follow the linked doc. For Cell, Writable, or
+reactive-value failures, also reread:
+
+- `docs/common/concepts/reactivity.md`
+- `docs/common/patterns/new-cells.md`
+
 ## Test File Shape
 
 The usual shape is:

--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -9,7 +9,9 @@ Quick error reference and debugging workflows. For detailed explanations, see li
 | "Property 'set' does not exist" | Missing `Writable<>` in signature | Add `Writable<T>` for write access ([@writeable](../../common/concepts/types-and-schemas/writable.md)) |
 | "X.get is not a function" | Calling `.get()` on computed/lift result | Access directly without `.get()` - only `Writable<>` has `.get()` ([gotchas/get-is-not-a-function](gotchas/get-is-not-a-function.md)) |
 | "X.filter is not a function" | Value isn't an array (yet) | Check `Default<>`, don't assume `.get()` is the fix ([gotchas/filter-map-find-not-a-function](gotchas/filter-map-find-not-a-function.md)) |
+| "Cell.of() only accepts static data" | Passing an input prop, mapped field, or computed/reactive value into `Writable.of()` / `Cell.of()` | Use the input writable cell directly, or initialize pattern-owned local cells from static values only ([new-cells](../../common/patterns/new-cells.md), [@reactivity](../../common/concepts/reactivity.md)) |
 | "Tried to access a reactive reference outside a reactive context" | Accessing reactive value at init time (in `[NAME]`, `Writable.of()`, or object indexing) | Wrap in `computed()`, use `lift()`, or set in event handler ([gotchas/reactive-reference-outside-context](gotchas/reactive-reference-outside-context.md)) |
+| ".trim is not a function" / ".replace is not a function" / ".includes is not a function" | Calling plain string helpers on reactive fields, often from JSX or `.map()` render contexts | Render reactive values directly when possible, or derive labels/branches in `computed()` ([reactivity-issues](reactivity-issues.md), [@reactivity](../../common/concepts/reactivity.md)) |
 | "Type 'string' is not assignable to type 'CSSProperties'" | String style on HTML element | Use object syntax `style={{ ... }}` ([style-errors](style-errors.md)) |
 | Type mismatch binding item to `$checked` | Binding whole item, not property | Bind `item.done`, not `item` ([type-errors](type-errors.md)) |
 | "ReadOnlyAddressError" | onClick inside computed() | Move button outside, use disabled ([gotchas/onclick-inside-computed](gotchas/onclick-inside-computed.md)) |
@@ -41,6 +43,8 @@ These issues compile without errors but fail at runtime.
 - [.get() is Not a Function](gotchas/get-is-not-a-function.md) - Only `Writable<>` has `.get()`
 - [filter/map/find is Not a Function](gotchas/filter-map-find-not-a-function.md) - Value isn't an array yet
 - [Reactive Reference Outside Context](gotchas/reactive-reference-outside-context.md) - Use `lift()` for object indexing
+- [Local Cells](../../common/patterns/new-cells.md) - `Writable.of()` is for
+  new pattern-owned cells initialized from static values
 - [onClick Inside computed()](gotchas/onclick-inside-computed.md) - ReadOnlyAddressError
 - [ifElse with Composed Pattern Cells](gotchas/ifelse-composed-pattern-cells.md) - Piece hangs
 - [lift() Returns Stale/Empty Data](gotchas/lift-returns-stale-data.md) - Closure limitations

--- a/skills/pattern-debug/SKILL.md
+++ b/skills/pattern-debug/SKILL.md
@@ -13,6 +13,10 @@ piece issues.
 
 - `docs/development/debugging/workflow.md` - 5-step debugging process
 - `docs/development/debugging/README.md` - Error reference matrix
+- `docs/common/concepts/reactivity.md` - reactive values, Cell behavior, and
+  `.get()` / `.set()` boundaries
+- `docs/common/patterns/new-cells.md` - `Writable.of()` and local cell
+  initialization rules
 
 ## Process
 
@@ -26,6 +30,7 @@ piece issues.
    - Check `docs/development/debugging/README.md` for matching errors
 
 3. **Check gotchas:**
+   - `docs/development/debugging/gotchas/reactive-reference-outside-context.md`
    - `docs/development/debugging/gotchas/handler-inside-pattern.md`
    - `docs/development/debugging/gotchas/filter-map-find-not-a-function.md`
    - `docs/development/debugging/gotchas/onclick-inside-computed.md`
@@ -50,6 +55,25 @@ piece issues.
 
 - Check if field needs write access → use Writable<>
 - Check if field could be undefined → use Default<T, value>
+
+**`Cell.of() only accepts static data`:**
+
+- Do not pass input props, mapped fields, or computed/reactive values into
+  `Writable.of()` / `Cell.of()`
+- Use an input writable cell directly when the caller owns the state
+- For pattern-owned draft state, initialize from a static value and copy from
+  input state inside an action or another valid reactive/event context
+- See `docs/common/patterns/new-cells.md` and
+  `docs/common/concepts/reactivity.md`
+
+**String helper throws, such as `.trim()` / `.replace()` / `.includes()` is not
+a function:**
+
+- Treat the value as reactive even if TypeScript's surface type is `string`
+- Render the reactive value directly when no derivation is needed
+- Move derived labels or branch conditions into `computed()` or another valid
+  reactive expression site
+- See `docs/common/concepts/reactivity.md` and the debugging matrix
 
 **Action not triggering:**
 

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -9,6 +9,15 @@ Start with the shared pattern development guidance in:
 
 Read that guide first. It is the canonical reference.
 
+Also read the foundational reactivity references before implementing or
+debugging pattern state:
+
+- `docs/common/concepts/reactivity.md`
+- `docs/common/patterns/new-cells.md`
+
+These are required context for Common Fabric pattern work. TypeScript surface
+types can look like plain values even when runtime values are reactive cells.
+
 When working in a Pattern Factory Build workspace, also read:
 
 - `docs/common/ai/pattern-factory-build-guide.md`
@@ -81,6 +90,8 @@ Task({
 Phase skills consult as needed:
 
 - Pattern Factory Build: `docs/common/ai/pattern-factory-build-guide.md`
+- Reactivity and local cells: `docs/common/concepts/reactivity.md`,
+  `docs/common/patterns/new-cells.md`
 - Types: `docs/common/concepts/types-and-schemas/`
 - Actions/handlers: `docs/common/concepts/action.md`,
   `docs/common/concepts/handler.md`
@@ -89,4 +100,5 @@ Phase skills consult as needed:
   type-checked component catalog. Story files in
   `packages/patterns/catalog/stories/` show live usage for each component. Also
   see `docs/common/components/COMPONENTS.md` for narrative docs.
-- Debugging: `docs/development/debugging/`
+- Debugging: start with `docs/development/debugging/README.md`, then follow the
+  linked gotcha or workflow doc for the exact failure.

--- a/skills/pattern-implement/SKILL.md
+++ b/skills/pattern-implement/SKILL.md
@@ -33,25 +33,37 @@ testability.
 
 - `docs/common/ai/pattern-factory-build-guide.md` - when working in a Pattern
   Factory Build workspace
+- `docs/common/concepts/reactivity.md` - Cell behavior, reactive values, and
+  `.get()` / `.set()` boundaries
+- `docs/common/patterns/new-cells.md` - when and how to create pattern-owned
+  writable cells with static initial values
 - `docs/common/ai/pattern-development-guide.md` - especially the SES authoring
   limits and escape-hatch guidance
 - `docs/common/patterns/` - especially `meta/` for generalizable idioms
 - `docs/common/concepts/action.md` - action() for local state
 - `docs/common/concepts/handler.md` - handler() for reusable logic
-- `docs/common/concepts/reactivity.md` - Cell behavior, .get()/.set()
 - `docs/common/concepts/identity.md` - equals() for object comparison
+
+For Pattern Factory Build, do not start implementation until you have read the
+Build guide plus the two foundational reactivity/local-cell references above.
 
 ## Key Patterns
 
 **action()** - Closes over local state in pattern body:
 
 ```tsx
-const inputValue = Cell.of("");
+const inputValue = Writable.of("");
 const submit = action(() => {
   items.push({ text: inputValue.get() });
   inputValue.set("");
 });
 ```
+
+Use `Writable.of()` only for pattern-owned local cells initialized from static
+values. Do not pass an input prop, mapped field, computed value, or other
+reactive value into `Writable.of()`. If the pattern receives writable state, use
+that input cell directly; if a draft needs to copy from input state, copy in an
+action or another valid reactive/event context.
 
 Use `safeDateNow()` and `nonPrivateRandom()` instead of ambient `Date.now()` and
 `Math.random()` when a pattern needs explicit time or randomness. If a control

--- a/skills/pattern-test/SKILL.md
+++ b/skills/pattern-test/SKILL.md
@@ -19,6 +19,17 @@ It defines Pattern Factory's build completion gate and expected coverage shape.
 For patterns that stamp timestamps or IDs, prefer deterministic assertions over
 recomputing time/random values inside the test itself.
 
+If `cf test` fails before or during assertions, treat that as pattern debugging,
+not as a reason to guess at a new test shape. Before the next repair, read:
+
+- `docs/development/debugging/README.md`
+
+Then follow the linked gotcha or workflow for the exact error. For Cell,
+Writable, or reactive-value failures, also read:
+
+- `docs/common/concepts/reactivity.md`
+- `docs/common/patterns/new-cells.md`
+
 Runtime notes:
 
 - Use the `cf` skill, or read `skills/cf/SKILL.md`, when you need CLI command


### PR DESCRIPTION
## Summary

Strengthens Pattern Factory Build guidance so agents read the core reactivity and local-cell references before implementation and route failed Build gates through the debugging matrix.

Changes include:
- make `docs/common/concepts/reactivity.md` and `docs/common/patterns/new-cells.md` baseline reads for Pattern Factory Build and pattern implementation work
- require failed `cf check`, `cf test`, CLI runtime, or browser smoke gates to consult `docs/development/debugging/README.md` before the next repair
- add exact debugging entries for `Cell.of() only accepts static data` and reactive string-helper failures such as `.trim is not a function`
- align `pattern-dev`, `pattern-implement`, `pattern-test`, and `pattern-debug` skills with the canonical docs

## Why

The latest cf-harness Build smoke skipped the full reactivity reference and local-cell guidance, then failed on `Writable.of(input)` and follow-on reactive string-helper mistakes. This makes the needed docs part of the normal Build path instead of a one-off prompt hint.

## Validation

- `git diff --check`
- `deno fmt --check skills/pattern-dev/SKILL.md skills/pattern-implement/SKILL.md skills/pattern-test/SKILL.md skills/pattern-debug/SKILL.md docs/common/ai/pattern-factory-build-guide.md docs/common/ai/pattern-development-guide.md docs/common/ai/pattern-testing-guide.md docs/development/debugging/README.md`