### PR TITLE
[codex] Log memory v2 stored decode failures

### DIFF
--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -23,6 +23,7 @@ import {
 import {
   decodeMemoryBoundary,
   DEFAULT_BRANCH,
+  encodeMemoryBoundary,
   type EntityDocument,
   toDocumentPath,
 } from "../v2.ts";
@@ -372,6 +373,119 @@ Deno.test("memory v2 engine logs stored patch decode failures with row context",
     assertStringIncludes(serialized, "revision");
     assertStringIncludes(serialized, "patch");
     assertStringIncludes(serialized, "fvj1");
+  } finally {
+    console.error = originalConsoleError;
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 engine preserves structured invalid stored document details in logs", async () => {
+  const { engine, path } = await createEngine();
+  const consoleErrors: unknown[][] = [];
+  const originalConsoleError = console.error;
+  console.error = (...args: unknown[]) => {
+    consoleErrors.push(args);
+  };
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:invalid-document-root",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:invalid-document-root",
+          value: toEntityDocument({ ok: true }),
+        }],
+      },
+    });
+
+    engine.database.prepare(
+      `UPDATE revision
+       SET data = :data
+       WHERE branch = '' AND id = :id AND seq = 1 AND op_index = 0`,
+    ).run({
+      data: encodeMemoryBoundary(["not", "a", "document"]),
+      id: "entity:invalid-document-root",
+    });
+
+    assertThrows(() => read(engine, { id: "entity:invalid-document-root" }));
+
+    const serialized = serializeConsoleArgs(consoleErrors);
+    assertStringIncludes(serialized, "stored-document-invalid-root");
+    assertStringIncludes(serialized, "entity:invalid-document-root");
+    assertStringIncludes(
+      serialized,
+      "memory v2 stored documents must be plain object roots",
+    );
+    assertStringIncludes(serialized, "decodedType");
+    assertStringIncludes(serialized, "array");
+  } finally {
+    console.error = originalConsoleError;
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 engine preserves structured invalid stored patch details in logs", async () => {
+  const { engine, path } = await createEngine();
+  const consoleErrors: unknown[][] = [];
+  const originalConsoleError = console.error;
+  console.error = (...args: unknown[]) => {
+    consoleErrors.push(args);
+  };
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:invalid-patch-root",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:invalid-patch-root",
+          value: toEntityDocument({ count: 1 }),
+        }],
+      },
+    });
+    applyCommit(engine, {
+      sessionId: "session:invalid-patch-root",
+      invocation: invocationFor(2),
+      authorization,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id: "entity:invalid-patch-root",
+          patches: [{ op: "replace", path: "/value/count", value: 2 }],
+        }],
+      },
+    });
+
+    engine.database.prepare(
+      `UPDATE revision
+       SET data = :data
+       WHERE branch = '' AND id = :id AND seq = 2 AND op_index = 0`,
+    ).run({
+      data: encodeMemoryBoundary({ not: "patches" }),
+      id: "entity:invalid-patch-root",
+    });
+
+    assertThrows(() => read(engine, { id: "entity:invalid-patch-root" }));
+
+    const serialized = serializeConsoleArgs(consoleErrors);
+    assertStringIncludes(serialized, "stored-patch-list-invalid-root");
+    assertStringIncludes(serialized, "entity:invalid-patch-root");
+    assertStringIncludes(serialized, "memory v2 stored patches must be arrays");
+    assertStringIncludes(serialized, "decodedType");
+    assertStringIncludes(serialized, "object");
   } finally {
     console.error = originalConsoleError;
     close(engine);

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -1,4 +1,9 @@
-import { assertEquals, assertExists, assertThrows } from "@std/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
 import { toFileUrl } from "@std/path";
 import {
   resetDataModelConfig,
@@ -77,6 +82,15 @@ const toEntityDocument = (
   }
   return document as EntityDocument;
 };
+
+const serializeConsoleArgs = (calls: unknown[][]): string =>
+  JSON.stringify(
+    calls,
+    (_key, value) =>
+      value instanceof Error
+        ? { name: value.name, message: value.message, stack: value.stack }
+        : value,
+  );
 
 Deno.test("memory v2 engine persists set and delete commits as seq revisions", async () => {
   const { engine, path } = await createEngine();
@@ -251,6 +265,115 @@ Deno.test("memory v2 engine preserves source-only entity documents", async () =>
       toEntityDocument(undefined, toSourceLink("process:1")),
     );
   } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 engine logs stored document decode failures with row context", async () => {
+  const { engine, path } = await createEngine();
+  const consoleErrors: unknown[][] = [];
+  const originalConsoleError = console.error;
+  console.error = (...args: unknown[]) => {
+    consoleErrors.push(args);
+  };
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:bad-document",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:bad-document",
+          value: toEntityDocument({ ok: true }),
+        }],
+      },
+    });
+
+    engine.database.prepare(
+      `UPDATE revision
+       SET data = :data
+       WHERE branch = '' AND id = :id AND seq = 1 AND op_index = 0`,
+    ).run({
+      data: `fvj1:{"value":`,
+      id: "entity:bad-document",
+    });
+
+    assertThrows(() => read(engine, { id: "entity:bad-document" }));
+
+    const serialized = serializeConsoleArgs(consoleErrors);
+    assertStringIncludes(serialized, "stored-document-decode-failed");
+    assertStringIncludes(serialized, "entity:bad-document");
+    assertStringIncludes(serialized, "revision");
+    assertStringIncludes(serialized, "fvj1");
+  } finally {
+    console.error = originalConsoleError;
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 engine logs stored patch decode failures with row context", async () => {
+  const { engine, path } = await createEngine();
+  const consoleErrors: unknown[][] = [];
+  const originalConsoleError = console.error;
+  console.error = (...args: unknown[]) => {
+    consoleErrors.push(args);
+  };
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:bad-patch",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:bad-patch",
+          value: toEntityDocument({ count: 1 }),
+        }],
+      },
+    });
+    applyCommit(engine, {
+      sessionId: "session:bad-patch",
+      invocation: invocationFor(2),
+      authorization,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id: "entity:bad-patch",
+          patches: [{ op: "replace", path: "/value/count", value: 2 }],
+        }],
+      },
+    });
+
+    engine.database.prepare(
+      `UPDATE revision
+       SET data = :data
+       WHERE branch = '' AND id = :id AND seq = 2 AND op_index = 0`,
+    ).run({
+      data: `fvj1:[`,
+      id: "entity:bad-patch",
+    });
+
+    assertThrows(() => read(engine, { id: "entity:bad-patch" }));
+
+    const serialized = serializeConsoleArgs(consoleErrors);
+    assertStringIncludes(serialized, "stored-patch-list-decode-failed");
+    assertStringIncludes(serialized, "entity:bad-patch");
+    assertStringIncludes(serialized, "revision");
+    assertStringIncludes(serialized, "patch");
+    assertStringIncludes(serialized, "fvj1");
+  } finally {
+    console.error = originalConsoleError;
     close(engine);
     await Deno.remove(path);
   }

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1447,6 +1447,8 @@ const logStoredDecodeFailure = (
     storedData: summarizeStoredData(data),
     error: error instanceof Error
       ? { name: error.name, message: error.message, stack: error.stack }
+      : typeof error === "object" && error !== null
+      ? error
       : String(error),
   });
 };

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1,4 +1,5 @@
 import { Database } from "@db/sqlite";
+import { getLogger } from "@commonfabric/utils/logger";
 import type { FabricValue } from "../interface.ts";
 import { applyPatch } from "./patch.ts";
 import { parentPath, parsePointer, pathsOverlap } from "./path.ts";
@@ -16,6 +17,12 @@ import {
   type Reference,
   type SessionId,
 } from "../v2.ts";
+
+const logger = getLogger("memory-v2-engine", {
+  enabled: true,
+  level: "error",
+  logCountEvery: 0,
+});
 
 const PRAGMAS = `
   PRAGMA journal_mode = WAL;
@@ -716,7 +723,14 @@ export const readState = (
   let document: EntityDocument | null;
   switch (row.op) {
     case "set":
-      document = decodeStoredDocument(row.data);
+      document = decodeStoredDocument(row.data, {
+        table: "revision",
+        branch: resolvedBranch,
+        id,
+        seq: row.seq,
+        opIndex: row.op_index,
+        op: row.op,
+      });
       break;
     case "delete":
       document = null;
@@ -1044,12 +1058,20 @@ const findConflictSeq = (
       after_seq: afterSeq,
     }) as Iterable<{
       seq: number;
+      op_index: number;
       data: string | null;
     }>
   ) {
     if (
       patchOverlapsRead(
-        decodeStoredPatchList(conflict.data),
+        decodeStoredPatchList(conflict.data, {
+          table: "revision",
+          branch,
+          id,
+          seq: conflict.seq,
+          opIndex: conflict.op_index,
+          op: "patch",
+        }),
         readPath,
       )
     ) {
@@ -1107,13 +1129,29 @@ const selectCommitRevisions = (
     if (row.op === "set") {
       return {
         ...base,
-        document: decodeStoredDocument(row.data),
+        document: decodeStoredDocument(row.data, {
+          table: "revision",
+          branch: row.branch,
+          id: row.id,
+          seq: row.seq,
+          opIndex: row.op_index,
+          op: row.op,
+          commitSeq: row.commit_seq,
+        }),
       } satisfies AppliedRevision;
     }
     if (row.op === "patch") {
       return {
         ...base,
-        patches: decodeStoredPatchList(row.data),
+        patches: decodeStoredPatchList(row.data, {
+          table: "revision",
+          branch: row.branch,
+          id: row.id,
+          seq: row.seq,
+          opIndex: row.op_index,
+          op: row.op,
+          commitSeq: row.commit_seq,
+        }),
       } satisfies AppliedRevision;
     }
     return base as AppliedRevision;
@@ -1235,12 +1273,24 @@ const reconstructPatchedDocument = (
   if (snapshotRow && (!baseRow || snapshotRow.seq >= baseRow.seq)) {
     baseSeq = snapshotRow.seq;
     baseOpIndex = Number.MAX_SAFE_INTEGER;
-    document = decodeStoredDocument(snapshotRow.value);
+    document = decodeStoredDocument(snapshotRow.value, {
+      table: "snapshot",
+      branch,
+      id,
+      seq: snapshotRow.seq,
+    });
   } else if (baseRow) {
     baseSeq = baseRow.seq;
     baseOpIndex = baseRow.op_index;
     if (baseRow.op === "set") {
-      document = decodeStoredDocument(baseRow.data);
+      document = decodeStoredDocument(baseRow.data, {
+        table: "revision",
+        branch,
+        id,
+        seq: baseRow.seq,
+        opIndex: baseRow.op_index,
+        op: baseRow.op,
+      });
     }
   }
 
@@ -1256,7 +1306,14 @@ const reconstructPatchedDocument = (
   for (const patch of patches) {
     document = applyPatchDocument(
       document,
-      decodeStoredPatchList(patch.data),
+      decodeStoredPatchList(patch.data, {
+        table: "revision",
+        branch,
+        id,
+        seq: patch.seq,
+        opIndex: patch.op_index,
+        op: "patch",
+      }),
     );
   }
 
@@ -1355,18 +1412,97 @@ const ensureActiveBranch = (engine: Engine, branch: BranchName): void => {
 
 const emptyEntityDocument = (): EntityDocument => ({});
 
-const decodeStoredDocument = (data: string | null): EntityDocument => {
-  const parsed = decodeMemoryBoundary<unknown>(data ?? "null");
+type DecodeStoredContext = {
+  table: "revision" | "snapshot";
+  branch: BranchName;
+  id: EntityId;
+  seq: number;
+  opIndex?: number;
+  op?: Operation["op"];
+  commitSeq?: number;
+};
+
+const summarizeStoredData = (data: string | null): {
+  length: number;
+  prefix: string | null;
+} => ({
+  length: data?.length ?? 0,
+  prefix: data?.slice(0, 160) ?? null,
+});
+
+const classifyValue = (value: unknown): string => {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+};
+
+const logStoredDecodeFailure = (
+  key: string,
+  context: DecodeStoredContext,
+  data: string | null,
+  error: unknown,
+): void => {
+  logger.error(key, {
+    context,
+    storedData: summarizeStoredData(data),
+    error: error instanceof Error
+      ? { name: error.name, message: error.message, stack: error.stack }
+      : String(error),
+  });
+};
+
+const decodeStoredDocument = (
+  data: string | null,
+  context: DecodeStoredContext,
+): EntityDocument => {
+  let parsed: unknown;
+  try {
+    parsed = decodeMemoryBoundary<unknown>(data ?? "null");
+  } catch (error) {
+    logStoredDecodeFailure(
+      "stored-document-decode-failed",
+      context,
+      data,
+      error,
+    );
+    throw error;
+  }
   if (!isEntityDocument(parsed)) {
-    throw new Error("memory v2 stored documents must be plain object roots");
+    const error = new Error(
+      "memory v2 stored documents must be plain object roots",
+    );
+    logStoredDecodeFailure("stored-document-invalid-root", context, data, {
+      message: error.message,
+      decodedType: classifyValue(parsed),
+    });
+    throw error;
   }
   return parsed;
 };
 
-const decodeStoredPatchList = (data: string | null): PatchOp[] => {
-  const parsed = decodeMemoryBoundary<unknown>(data ?? "[]");
+const decodeStoredPatchList = (
+  data: string | null,
+  context: DecodeStoredContext,
+): PatchOp[] => {
+  let parsed: unknown;
+  try {
+    parsed = decodeMemoryBoundary<unknown>(data ?? "[]");
+  } catch (error) {
+    logStoredDecodeFailure(
+      "stored-patch-list-decode-failed",
+      context,
+      data,
+      error,
+    );
+    throw error;
+  }
   if (!Array.isArray(parsed)) {
-    throw new Error("memory v2 stored patches must be arrays");
+    const error = new Error("memory v2 stored patches must be arrays");
+    logStoredDecodeFailure("stored-patch-list-invalid-root", context, data, {
+      message: error.message,
+      decodedType: classifyValue(parsed),
+    });
+    throw error;
   }
   return parsed as PatchOp[];
 };


### PR DESCRIPTION
## Summary

Adds loud `logger.error` diagnostics when memory v2 fails to decode stored document or patch-list payloads from SQLite. The log now includes the storage table, branch, entity id, sequence, op index, operation, commit sequence when available, and a short stored payload prefix.

This makes invariant-breaking storage decode failures, such as an unexpected `fvj1:` payload at a JSON boundary, visible from server logs with enough context to find the affected document quickly.

## Validation

- `deno check packages/memory/v2/engine.ts packages/memory/test/v2-engine-test.ts`
- `deno test --allow-read --allow-write --allow-net --allow-ffi --allow-env packages/memory/test/v2-engine-test.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add structured error logging for memory v2 decode failures when reading stored documents and patch lists from SQLite. Logs include row context, stored data summaries, and typed invalid-root details to speed up debugging.

- **New Features**
  - Emit `logger.error` via `@commonfabric/utils/logger` with context (table, branch, id, seq, opIndex, op, commitSeq) and stored data length/prefix; keys: `stored-document-decode-failed`, `stored-patch-list-decode-failed`, plus `stored-document-invalid-root`/`stored-patch-list-invalid-root` with `decodedType`.
  - Refactor `decodeStoredDocument`/`decodeStoredPatchList` to accept context, catch boundary parse errors, log structured errors, and rethrow; tests cover corrupted payloads and invalid roots and assert log details.

<sup>Written for commit 6d622f91cb0602c7423dd68bd83a78d9381366fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

