### PR TITLE
ci: cancel superseded PR workflow runs

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Define the list of binaries we're building
 # This makes it easy to add more binaries in the future
 env:


### PR DESCRIPTION
## Why

Superseded pull request runs can continue consuming CI capacity after a newer push has made their results obsolete. Canceling older runs for the same PR should reduce queue pressure and help the latest run finish sooner without changing main-branch CI behavior.

## What Changed

Added workflow-level concurrency to the Deno workflow. Pull request runs share a PR-number-based group and cancel in progress; push runs use the unique run ID so main runs are not coalesced.

## Test plan

- Parsed `.github/workflows/deno.yml` with Ruby YAML loader: `yaml ok`