### PR TITLE
refactor: use cloneIfNecessary() for 3 deep-clone sites in runner + fuse

### DIFF
--- a/packages/fuse/cfc-writeback.ts
+++ b/packages/fuse/cfc-writeback.ts
@@ -1098,7 +1098,7 @@ export class CfcWritebackStore {
 
   snapshot(): CfcWritebackSnapshot {
     const records = [...this.records.values()].map((record) =>
-      cloneRecoveryRecord(record)
+      cloneRecoveryRecord(record, true)
     );
     const counts = Object.fromEntries(
       RECOVERY_STATUSES.map((status) => [status, 0]),
@@ -1201,7 +1201,7 @@ export class CfcWritebackStore {
     }
     for (const record of parsed.records) {
       if (!isRecoveryRecord(record)) continue;
-      const cloned = cloneRecoveryRecord(record);
+      const cloned = cloneRecoveryRecord(record, false);
       this.records.set(cloned.key, cloned);
       if (cloned.prepared) this.prepared.set(cloned.key, cloned.prepared);
     }
@@ -1372,11 +1372,10 @@ function applyPreparedForRecovery(
 
 function cloneRecoveryRecord(
   record: CfcWritebackRecoveryRecord,
+  frozen: boolean,
 ): CfcWritebackRecoveryRecord {
   return cloneIfNecessary(record as FabricValue, {
-    frozen: false,
-    deep: true,
-    force: true,
+    frozen,
   }) as CfcWritebackRecoveryRecord;
 }
 

--- a/packages/fuse/cfc-writeback.ts
+++ b/packages/fuse/cfc-writeback.ts
@@ -3,6 +3,10 @@ import {
   DEFAULT_CFC_ENFORCEMENT_MODE,
 } from "@commonfabric/runner/cfc";
 import { sha256 } from "@commonfabric/content-hash";
+import {
+  cloneIfNecessary,
+  type FabricValue,
+} from "@commonfabric/data-model/fabric-value";
 import { encodeHex } from "@std/encoding/hex";
 import {
   canonicalCfcJsonStringify,
@@ -1369,7 +1373,11 @@ function applyPreparedForRecovery(
 function cloneRecoveryRecord(
   record: CfcWritebackRecoveryRecord,
 ): CfcWritebackRecoveryRecord {
-  return JSON.parse(JSON.stringify(record)) as CfcWritebackRecoveryRecord;
+  return cloneIfNecessary(record as FabricValue, {
+    frozen: false,
+    deep: true,
+    force: true,
+  }) as CfcWritebackRecoveryRecord;
 }
 
 function isRecoveryRecord(

--- a/packages/runner/src/acl-manager.ts
+++ b/packages/runner/src/acl-manager.ts
@@ -26,11 +26,7 @@ export class ACLManager {
       throw new Error("No ACL initialized for space.");
     }
 
-    return cloneIfNecessary(aclData as FabricValue, {
-      frozen: false,
-      deep: true,
-      force: true,
-    }) as ACL;
+    return cloneIfNecessary(aclData as FabricValue, { frozen: false }) as ACL;
   }
 
   async set(user: ACLUser, capability: Capability): Promise<void> {

--- a/packages/runner/src/acl-manager.ts
+++ b/packages/runner/src/acl-manager.ts
@@ -1,5 +1,9 @@
 import { ACL, ACLUser, DID } from "@commonfabric/memory/acl";
 import { Capability } from "@commonfabric/memory/interface";
+import {
+  cloneIfNecessary,
+  type FabricValue,
+} from "@commonfabric/data-model/fabric-value";
 import type { Cell } from "./cell.ts";
 import type { Runtime } from "./runtime.ts";
 
@@ -22,7 +26,11 @@ export class ACLManager {
       throw new Error("No ACL initialized for space.");
     }
 
-    return JSON.parse(JSON.stringify(aclData)) as ACL;
+    return cloneIfNecessary(aclData as FabricValue, {
+      frozen: false,
+      deep: true,
+      force: true,
+    }) as ACL;
   }
 
   async set(user: ACLUser, capability: Capability): Promise<void> {

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -41,11 +41,7 @@ const isPrimitiveJsonValue = (value: unknown): boolean =>
   typeof value === "boolean";
 
 const cloneJson = <T>(value: T): T =>
-  cloneIfNecessary(value as FabricValue, {
-    frozen: false,
-    deep: true,
-    force: true,
-  }) as T;
+  cloneIfNecessary(value as FabricValue, { frozen: true }) as T;
 
 const uniqueAtoms = (
   atoms: Iterable<unknown>,

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -1,4 +1,8 @@
 import type { ImmutableJSONValue, JSONSchema } from "@commonfabric/api";
+import {
+  cloneIfNecessary,
+  type FabricValue,
+} from "@commonfabric/data-model/fabric-value";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isRecord } from "@commonfabric/utils/types";
 import { ContextualFlowControl } from "../cfc.ts";
@@ -36,7 +40,12 @@ const isPrimitiveJsonValue = (value: unknown): boolean =>
   typeof value === "number" ||
   typeof value === "boolean";
 
-const cloneJson = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+const cloneJson = <T>(value: T): T =>
+  cloneIfNecessary(value as FabricValue, {
+    frozen: false,
+    deep: true,
+    force: true,
+  }) as T;
 
 const uniqueAtoms = (
   atoms: Iterable<unknown>,


### PR DESCRIPTION
Swaps three `JSON.parse(JSON.stringify(x))` deep-clone sites in `runner` and `fuse` to `cloneIfNecessary(x, …)` per the durability-under-modern-values standard. The substitute was unblocked by PR #3494 (`cloneIfNecessaryLegacy()` → `cloneIfNecessaryModern()` delegation, session 2026-069); the audit at `coordination/docs/2026-05-05-clone-if-necessary-swap-audit.md` confirmed all 11 prior caller sites are CLEAN under modern semantics. The 3 new caller sites in this PR adopt the same call shape and `as FabricValue` cast precedent.

Per Dan-direct review the call shape at each site was further refined for per-site mutability requirements (see "Pre-merge mutability review" below), and the `CloneOptions` defaults were verified to allow trimming `deep` and `force` across all 3 sites for the canonical minimal call shape.

### Sites changed

- **`packages/runner/src/acl-manager.ts:25`** — defensive deep-clone of cell ACL data for caller-mutation in `ACLManager.get()`. `ACL = Record<ACLUser, Capability>` (plain JSON shape; `Capability` is a string-literal union). Final call: `cloneIfNecessary(aclData as FabricValue, { frozen: false })`. Closest audit-doc precedent: §2.2 (`Cell.getRawUntyped`).
- **`packages/runner/src/cfc/schema-sanitization.ts:39`** — internal `cloneJson` helper body. Generic signature `<T>(value: T): T` preserved so callers are unchanged. Final call: `cloneIfNecessary(value as FabricValue, { frozen: true })`. Inputs are `JSONSchema` and `ImmutableJSONValue`-shaped atoms — pure JSON, both already typed as immutable upstream. Helper name retained for this PR; a rename (now slightly misleading since it no longer round-trips JSON) is out of scope and can land in a follow-up. Closest audit-doc precedent: §2.9 (`cloneSchemaMutable`).
- **`packages/fuse/cfc-writeback.ts:1372`** — `cloneRecoveryRecord()`, now signature `(record, frozen)`. `CfcWritebackRecoveryRecord` is plain JSON (strings, arrays of strings, plain objects); the three `unknown`-typed slots (`CfcLabel.confidentiality`/`integrity`, `target.targetIdentity`) trace back to `JSON.parse(text)` origin. Final call: `cloneIfNecessary(record as FabricValue, { frozen })` with the parameter forwarded. Closest audit-doc precedent: §2.5 / §2.6 / §2.7 (storage v2 `cloneIfNecessary` callers).

### Notable things to call out for review

- **Pre-merge mutability review (Dan-direct).** Each site verified per-site for whether mutability is actually required, with three different verdicts:
  - **Site 1 (`acl-manager.ts`)**: retained `frozen: false`. `ACLManager.set` and `ACLManager.remove` both internally do `const acl = await this.get(); acl[user] = capability` (or `delete acl[user]`); the `get()` defensive clone is exactly what makes those in-place mutations safe.
  - **Site 2 (`cloneJson` helper)**: flipped to `frozen: true` (cache-win available). Both callers (`uniqueAtoms` and `schemaWithInjectionSafeAnnotations`) consume the cloned value read-only — pure-functional `{...schema, ...}` spread construction, no in-place mutation. Frozen mode delivers identity-passthrough for already-deep-frozen inputs and deep-clone-and-freeze for unfrozen ones, aligning runtime with the type system (`JSONSchema` / `ImmutableJSONValue` are already typed immutable upstream).
  - **Site 3 (`cloneRecoveryRecord`)**: made parametric on `frozen` because the two callers diverge. `snapshot()` consumes read-only (test code + `status()`) and passes `true` for cache-win. The load-from-disk path stores into `this.records` and mutates in-place at lines 1058-1087 inside the reconcile-against-tree loop, so it passes `false`. The divergent requirements are expressed as a parameter contract rather than asymmetric call sites or a split helper.

- **`CloneOptions` defaults trim.** Across all 3 sites, dropped redundant `deep: true, force: true` per the `CloneOptions` defaults verified at `fabric-value-modern.ts:554-575` + `fabric-value.ts:163-165`: `frozen` defaults `true`, `deep` defaults `true`, `force` defaults `frozen ? false : true`. Resulting calls are exactly equivalent to the explicit shapes but match the canonical minimal idiom.

- **`fuse` first-time direct `data-model` import.** This PR adds fuse's first direct import from `@commonfabric/data-model/fabric-value`. data-model was already pulled transitively via `@commonfabric/runner/cfc` and `@commonfabric/content-hash` at HEAD, so the package boundary is not new — only the file-level direct import is. Strict-mode cascade risk is nil: fuse's `deno.json` and the workspace-root `deno.json` `compilerOptions` both lack `noUncheckedIndexedAccess`. `deno task test` in `packages/fuse` stayed clean.

- **Strip-methods classification.** Per-site verify of the original 6-site A2 plain-JSON candidate list (Remy's 2026-067 review §4.2.2(b)) found that 4 of 6 candidate sites are *strip-methods idioms* — `JSON.parse(JSON.stringify(x))` used to project to plain JSON shape by losing class methods, NOT to deep-clone. A `cloneIfNecessary` swap at those sites would be **incorrect** because it preserves class identity. Those 4 sites (`runner/src/create-ref.ts:122-123`, `memory/consumer.ts:900`, `runner/src/scheduler.ts:5173-5175`, `runner/src/uri-utils.ts:12`) are explicitly out of scope for this PR; they're tracked under "Strip-methods idiom: classify and fix the 4 sites mis-classified as A2 deep-clones" in the project's tasks list, awaiting a follow-up scoping pass.

- **Class-blindness narrowing post-swap.** Per audit doc §5.1, `cloneHelper` (modern path) throws on raw `Map`/`Set`/`Date`/`RegExp`/`Uint8Array`/`Error` inputs (narrower than legacy `structuredClone()`). None of the 3 sites pass such inputs in normal flow per per-site verify; this is a banked post-swap failure mode if any escape upstream normalization.

- **Conservation of content.** Each commit is a tactical mechanical swap or a focused refinement — no drive-by cleanups, no renames, no out-of-scope refactors. Each commit message names the audit-doc precedent (or for the fixups, the mutability-verdict trace) and the input-shape claim.

### Test plan

- [x] `deno fmt --check` clean on the 3 edited files.
- [x] `deno lint` clean on the 3 edited files.
- [x] `packages/runner` test suite: 413 passed, 0 failed (re-run on tip `13779d7dc`).
- [x] `packages/fuse` test suite: 183 passed, 0 failed (re-run on tip `13779d7dc`).

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: reviewer-flux (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
