### PR TITLE
Fix `bigintToMinimalTwosComplement` byte-length corner cases

### DIFF
--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -64,8 +64,13 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     const hex = value.toString(16);
     // Determine minimal byte length from hex digit count.
     let byteLen = (hex.length + 1) >> 1; // ceil(hex.length / 2)
-    // If high nibble has bit 7 set, need a sign-extension zero byte.
-    if (hexToNibble(hex.charCodeAt(0)) >= 8) byteLen++;
+    // If the high nibble of byte 0 has bit 3 set, we need a sign-extension
+    // zero byte. For odd hex length the byte's high nibble is 0 (from the
+    // implicit leading-zero pad), so the check only applies for even
+    // hex.length, where `hex[0]` *is* the leading byte's high nibble.
+    if ((hex.length & 1) === 0 && hexToNibble(hex.charCodeAt(0)) >= 8) {
+      byteLen++;
+    }
 
     // Fast path: use DataView.setBigUint64() for values that fit in 8 bytes.
     if (byteLen <= 8) {
@@ -95,10 +100,16 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
   let byteLen = Math.ceil(bitLen / 8);
   // Two's complement of -abs is 2^n - abs where n is the byte-aligned size.
   let twos = (1n << BigInt(byteLen * 8)) - abs;
-  // Verify the high bit is set (value must look negative).
+  // Verify the high bit of byte 0 of the encoded form is set (value must
+  // look negative). It is *not* set if either:
+  //   (a) `twosHex` is shorter than `byteLen * 2` (so byte 0 starts with a
+  //       padding-zero nibble), or
+  //   (b) `twosHex.length === byteLen * 2` but its leading nibble is < 8.
+  // In either case we need one more byte to keep the high bit set.
   const twosHex = twos.toString(16);
-  if (hexToNibble(twosHex.charCodeAt(0)) < 8) {
-    // High bit not set -- need one more byte.
+  if (
+    twosHex.length < byteLen * 2 || hexToNibble(twosHex.charCodeAt(0)) < 8
+  ) {
     byteLen++;
     twos = (1n << BigInt(byteLen * 8)) - abs;
   }

--- a/packages/data-model/test/bigint-encoding.test.ts
+++ b/packages/data-model/test/bigint-encoding.test.ts
@@ -177,3 +177,34 @@ describe("bigint -> base64url -> bigint round-trip", () => {
     });
   }
 });
+
+// ============================================================================
+// Byte-length boundary regressions
+// ============================================================================
+
+// Both `bigintToMinimalTwosComplement` paths used to confuse "leading char
+// of `value.toString(16)`" with "high nibble of byte 0 of the encoded form".
+// They differ when the hex string would need leading-zero padding to fill
+// `byteLen * 2` characters: the hex's leading char is non-zero, but the
+// padded byte representation has byte 0 starting with a zero nibble.
+describe("bigintToMinimalTwosComplement byte-length corner cases", () => {
+  // Positive: an odd-length hex with leading nibble in 8..F. The fast path
+  // historically inserted an unnecessary sign-extension byte.
+  it("does not over-pad 217129053n (= 0xCF1205D)", () => {
+    expect(bigintToMinimalTwosComplement(217129053n)).toEqual(
+      new Uint8Array([0x0c, 0xf1, 0x20, 0x5d]),
+    );
+  });
+
+  // Negatives with abs in [241, 248]. Production historically encoded these
+  // as a single byte with the high bit *clear*, breaking the round-trip
+  // (e.g., -241n decoded back as 15n).
+  for (let i = 241; i <= 248; i++) {
+    const v = BigInt(-i);
+    it(`round-trips ${v}n with sign bit set`, () => {
+      const bytes = bigintToMinimalTwosComplement(v);
+      expect(bytes[0] & 0x80).not.toBe(0);
+      expect(bigintFromMinimalTwosComplement(bytes)).toBe(v);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

`bigintToMinimalTwosComplement` had two byte-length determination bugs that
share a root cause: the encoder treated the leading character of
`value.toString(16)` as if it were the high nibble of byte 0 of the encoded
form. Those differ when the hex string would need leading-zero padding to
fill `byteLen * 2` characters — `toString(16)` strips the leading zero, so
its first character is non-zero, but the padded byte representation has byte 0
starting with a zero nibble.

This PR is structured red→green: the first commit adds focused tests that
fail against current `main`, the second commit applies the minimal fixes.

## Bug 1 — positive, fast path only

For positive values whose magnitude has odd hex length and a leading nibble in
`8..F`, the encoder inserted an unnecessary sign-extension byte. Reproduces at
`217129053n` (= `0xCF1205D`):

| | byte form | length |
| --- | --- | --- |
| current `main` | `[0x00, 0x0C, 0xF1, 0x20, 0x5D]` | 5 |
| spec-minimal | `[0x0C, 0xF1, 0x20, 0x5D]` | 4 |

Round-trip still works (the leading `0x00` decodes correctly), but the output
is non-minimal as the function name promises, and so any spec-compliant
consumer would compute a different hash for the same bigint.

This bug is confined to the fast path because the buggy `byteLen++` happens
*before* the `byteLen <= 8` dispatch; the fallback path independently
recomputes from a padded hex string and gets it right.

## Bug 2 — negative, both paths, silent corruption

When `2^(byteLen*8) - abs` (the unsigned two's-complement remainder) would
have leading-zero padding in its byte form, the encoder failed to add the
required `0xFF` sign-extension byte. The encoded byte 0 then has the high
bit clear, so decoding gives back a *positive* value. Reproduces at all of
`-241n` through `-248n`:

```
-241n -> [0x0F]   decodes back as  15n
-242n -> [0x0E]   decodes back as  14n
...
-248n -> [0x08]   decodes back as   8n
```

This is silent round-trip corruption: anything that persists or hashes a
bigint via this encoder (notably `value-hash.ts` and `json-type-handlers.ts`,
which feed the broader hashing and JSON serialization paths) and then reads
it back gets the wrong value. The bug also fires at scale on much larger
negatives — every recurrence iteration that yields a magnitude whose hex
starts with `f` (and matches the padding-divergence shape) triggers it.

## Fix

Both checks are narrowed to consider what byte 0 of the *encoded* form
actually looks like:

- **Positive path**: only consider the high-nibble check meaningful when
  `hex.length` is even. For odd lengths, byte 0's high nibble is 0 from the
  implicit pad, so a sign-extension byte is never needed.
- **Negative path**: also bump `byteLen` when `twosHex.length < byteLen * 2`
  (i.e., the leading byte's high nibble would be a padding zero), in addition
  to the existing leading-nibble-`< 8` check.

Diff is 16 lines in `packages/data-model/bigint-encoding.ts`; the fast and
fallback paths both pick up the corrected `byteLen` automatically.

## Backward compatibility note

Behavior change for affected bigint values:
- **Hashes** of affected bigints will differ from any hashes computed by
  pre-fix code. Cached/persisted hashes for these values will appear to have
  changed.
- **JSON-encoded** affected values will now serialize with the correct byte
  form. Old data persisted with bug-2 byte forms (e.g., `-241n` written as
  `[0x0F]`) decodes as the wrong value (`15n`) and cannot be recovered — but
  that data was already corrupt; this fix prevents *new* corruption.

## Test plan

- [x] `deno test packages/data-model/test/bigint-encoding.test.ts` — all 56
      steps pass (was failing 9 in the new corner-cases block).
- [x] `deno task test` in `packages/data-model` — 44 passed (1329 steps), 0
      failed.
- [x] `deno task test` at the repo root — all 33 workspace packages pass
      (77.3s total).
- [x] No tests elsewhere reference the specific buggy values (`grep` confirms
      `0xCF1205D` and `-241n..-248n` appear only in the new test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This PR does not affect the indicated test nor should it affect build time, so this line accounts for a spurious perf check failure:

NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/calendar/event-detail.test.tsx = 13s
NEW_PERF_BASELINE: job: Build Binaries = 75s

