### PR TITLE
Restructure `bigint-encoding` tests around a fixture array

### DIFF
--- a/packages/data-model/test/bigint-encoding.test.ts
+++ b/packages/data-model/test/bigint-encoding.test.ts
@@ -80,11 +80,11 @@ const rawFixtures: bigint[] = [
   -(2n ** 128n),
   0x112233445566778899abcdefn,
   -0x112233445566778899abcdefn,
-  // Byte-length corner cases that exercised historical encoder bugs (see
-  // PR #3527): odd-hex-length positive with high nibble in 8..F, and
-  // negatives whose two's-complement remainder would have leading-zero
-  // padding in its byte form.
-  0xcf1205dn,
+  // Negatives whose two's-complement remainder has leading-zero padding in
+  // its byte form -- a corner case that exercised a historical encoder bug
+  // (see PR #3527). The corresponding positive case (odd-hex-length with
+  // high nibble in 8..F) is reached via the recurrence below at iteration
+  // 2, where `n = 217129053n` (= `0xCF1205D`).
   -241n,
   -242n,
   -243n,

--- a/packages/data-model/test/bigint-encoding.test.ts
+++ b/packages/data-model/test/bigint-encoding.test.ts
@@ -10,108 +10,198 @@ import {
 } from "@commonfabric/utils/base64url";
 
 // ============================================================================
-// bigintToMinimalTwosComplement
+// Reference encoder
 // ============================================================================
 
-describe("bigintToMinimalTwosComplement", () => {
-  it("encodes 0n as [0x00]", () => {
-    expect(bigintToMinimalTwosComplement(0n)).toEqual(new Uint8Array([0x00]));
+/**
+ * Deliberately-naive minimal two's-complement encoder, used as the test
+ * oracle. Optimized for obviousness rather than speed: derive the byte
+ * length from the magnitude's binary representation, apply two's complement
+ * via plain bigint arithmetic, then materialize bytes through `toString(16)`
+ * plus `parseInt`.
+ */
+function referenceEncode(value: bigint): Uint8Array {
+  if (value === 0n) return new Uint8Array([0]);
+
+  const abs = value < 0n ? -value : value;
+  const magBits = abs.toString(2).length;
+
+  // For positive `v`, the encoding needs `magBits + 1` bits (extra leading
+  // 0 for the sign). For negative `v`, the same holds, except the boundary
+  // value `-(2^(magBits-1))` (a power of two) fits in exactly `magBits`
+  // bits because its high bit doubles as the sign bit.
+  let totalBits: number;
+  if (value > 0n) {
+    totalBits = magBits + 1;
+  } else if ((1n << BigInt(magBits - 1)) === abs) {
+    totalBits = magBits;
+  } else {
+    totalBits = magBits + 1;
+  }
+  const byteLen = (totalBits + 7) >> 3;
+
+  // Map negatives onto their unsigned two's-complement representation.
+  const unsigned = value < 0n ? value + (1n << BigInt(byteLen * 8)) : value;
+
+  // Hex pad to even, then parse byte-by-byte.
+  let hex = unsigned.toString(16);
+  while (hex.length < byteLen * 2) hex = "0" + hex;
+  const bytes = new Uint8Array(byteLen);
+  for (let i = 0; i < byteLen; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const rawFixtures: bigint[] = [
+  // Explicit corner cases preserved from the original tests.
+  0n,
+  1n,
+  -1n,
+  42n,
+  -42n,
+  127n,
+  128n,
+  -128n,
+  -129n,
+  255n,
+  256n,
+  -256n,
+  -999n,
+  2n ** 32n,
+  -(2n ** 32n),
+  2n ** 64n,
+  -(2n ** 64n),
+  2n ** 128n,
+  -(2n ** 128n),
+  0x112233445566778899abcdefn,
+  -0x112233445566778899abcdefn,
+  // Byte-length corner cases that exercised historical encoder bugs (see
+  // PR #3527): odd-hex-length positive with high nibble in 8..F, and
+  // negatives whose two's-complement remainder would have leading-zero
+  // padding in its byte form.
+  0xcf1205dn,
+  -241n,
+  -242n,
+  -243n,
+  -244n,
+  -245n,
+  -246n,
+  -247n,
+  -248n,
+];
+
+// Programmatic expansion via a deterministic recurrence. The multiplier `99`
+// adds ~6.63 bits per step, so 2000 iterations sweep magnitudes from a few
+// bits up to roughly 13_270 bits (~1659 bytes), with both signs at every step.
+{
+  let n = 123n;
+  for (let i = 0; i < 2000; i++) {
+    n = (n * 99n) + 9876n;
+    rawFixtures.push(n);
+    rawFixtures.push(-n);
+  }
+}
+
+/**
+ * Format a bigint for use in a test name. Decimals up to 64 bits, hex up to
+ * 128 bits, and beyond that just a hex prefix and the encoded byte count.
+ */
+function fixtureLabel(v: bigint, encoded: Uint8Array): string {
+  if (v === 0n) return "0n";
+  const sign = v < 0n ? "-" : "";
+  const abs = v < 0n ? -v : v;
+  if (abs < 1n << 64n) return `${v}n`;
+  const hex = abs.toString(16);
+  if (hex.length <= 32) return `${sign}0x${hex}n`;
+  return `${sign}0x${hex.slice(0, 12)}... (${encoded.length} bytes)`;
+}
+
+interface Fixture {
+  value: bigint;
+  encoded: Uint8Array;
+  label: string;
+}
+
+const fixtures: readonly Fixture[] = rawFixtures.map((value) => {
+  const encoded = referenceEncode(value);
+  return { value, encoded, label: fixtureLabel(value, encoded) };
+});
+
+// ============================================================================
+// Reference encoder anchor
+// ============================================================================
+
+// A small set of explicit byte-level assertions that pin `referenceEncode`
+// against the spec. The rest of the suite trusts it as an oracle, so it
+// matters that these can't both be wrong in the same way.
+describe("referenceEncode (test oracle)", () => {
+  it("encodes 0n", () => {
+    expect(referenceEncode(0n)).toEqual(new Uint8Array([0x00]));
   });
 
-  it("encodes 1n as [0x01]", () => {
-    expect(bigintToMinimalTwosComplement(1n)).toEqual(new Uint8Array([0x01]));
+  it("encodes 1n", () => {
+    expect(referenceEncode(1n)).toEqual(new Uint8Array([0x01]));
   });
 
-  it("encodes 127n as [0x7F]", () => {
-    expect(bigintToMinimalTwosComplement(127n)).toEqual(
-      new Uint8Array([0x7f]),
-    );
+  it("encodes 127n", () => {
+    expect(referenceEncode(127n)).toEqual(new Uint8Array([0x7f]));
   });
 
-  it("encodes 128n as [0x00, 0x80] (sign extension)", () => {
-    expect(bigintToMinimalTwosComplement(128n)).toEqual(
-      new Uint8Array([0x00, 0x80]),
-    );
+  it("encodes 128n (sign extension)", () => {
+    expect(referenceEncode(128n)).toEqual(new Uint8Array([0x00, 0x80]));
   });
 
-  it("encodes -1n as [0xFF]", () => {
-    expect(bigintToMinimalTwosComplement(-1n)).toEqual(
-      new Uint8Array([0xff]),
-    );
+  it("encodes 255n", () => {
+    expect(referenceEncode(255n)).toEqual(new Uint8Array([0x00, 0xff]));
   });
 
-  it("encodes -128n as [0x80]", () => {
-    expect(bigintToMinimalTwosComplement(-128n)).toEqual(
-      new Uint8Array([0x80]),
-    );
+  it("encodes 256n", () => {
+    expect(referenceEncode(256n)).toEqual(new Uint8Array([0x01, 0x00]));
   });
 
-  it("encodes -129n as [0xFF, 0x7F]", () => {
-    expect(bigintToMinimalTwosComplement(-129n)).toEqual(
-      new Uint8Array([0xff, 0x7f]),
-    );
+  it("encodes -1n", () => {
+    expect(referenceEncode(-1n)).toEqual(new Uint8Array([0xff]));
   });
 
-  it("encodes 255n as [0x00, 0xFF]", () => {
-    expect(bigintToMinimalTwosComplement(255n)).toEqual(
-      new Uint8Array([0x00, 0xff]),
-    );
+  it("encodes -128n", () => {
+    expect(referenceEncode(-128n)).toEqual(new Uint8Array([0x80]));
   });
 
-  it("encodes 256n as [0x01, 0x00]", () => {
-    expect(bigintToMinimalTwosComplement(256n)).toEqual(
-      new Uint8Array([0x01, 0x00]),
-    );
+  it("encodes -129n (sign extension)", () => {
+    expect(referenceEncode(-129n)).toEqual(new Uint8Array([0xff, 0x7f]));
   });
 
   it("encodes 2^64 as 9 bytes", () => {
-    const bytes = bigintToMinimalTwosComplement(2n ** 64n);
+    const bytes = referenceEncode(2n ** 64n);
     expect(bytes.length).toBe(9);
     expect(bytes[0]).toBe(0x01);
-    for (let i = 1; i < 9; i++) {
-      expect(bytes[i]).toBe(0x00);
-    }
+    for (let i = 1; i < 9; i++) expect(bytes[i]).toBe(0x00);
   });
 });
 
 // ============================================================================
-// bigintFromMinimalTwosComplement
+// Per-function fixture loops
 // ============================================================================
 
+describe("bigintToMinimalTwosComplement", () => {
+  for (const { value, encoded, label } of fixtures) {
+    it(`encodes ${label}`, () => {
+      expect(bigintToMinimalTwosComplement(value)).toEqual(encoded);
+    });
+  }
+});
+
 describe("bigintFromMinimalTwosComplement", () => {
-  it("decodes [0x00] as 0n", () => {
-    expect(bigintFromMinimalTwosComplement(new Uint8Array([0x00]))).toBe(0n);
-  });
-
-  it("decodes [0x01] as 1n", () => {
-    expect(bigintFromMinimalTwosComplement(new Uint8Array([0x01]))).toBe(1n);
-  });
-
-  it("decodes [0x7F] as 127n", () => {
-    expect(bigintFromMinimalTwosComplement(new Uint8Array([0x7f]))).toBe(127n);
-  });
-
-  it("decodes [0x00, 0x80] as 128n", () => {
-    expect(bigintFromMinimalTwosComplement(new Uint8Array([0x00, 0x80]))).toBe(
-      128n,
-    );
-  });
-
-  it("decodes [0xFF] as -1n", () => {
-    expect(bigintFromMinimalTwosComplement(new Uint8Array([0xff]))).toBe(-1n);
-  });
-
-  it("decodes [0x80] as -128n", () => {
-    expect(bigintFromMinimalTwosComplement(new Uint8Array([0x80]))).toBe(
-      -128n,
-    );
-  });
-
-  it("decodes [0xFF, 0x7F] as -129n", () => {
-    expect(bigintFromMinimalTwosComplement(new Uint8Array([0xff, 0x7f]))).toBe(
-      -129n,
-    );
-  });
+  for (const { value, encoded, label } of fixtures) {
+    it(`decodes ${label}`, () => {
+      expect(bigintFromMinimalTwosComplement(encoded)).toBe(value);
+    });
+  }
 
   it("throws on empty input", () => {
     expect(() => bigintFromMinimalTwosComplement(new Uint8Array([]))).toThrow(
@@ -120,60 +210,22 @@ describe("bigintFromMinimalTwosComplement", () => {
   });
 });
 
-// ============================================================================
-// Round-trip: encode -> decode
-// ============================================================================
-
 describe("bigint encoding round-trip", () => {
-  const values = [
-    0n,
-    1n,
-    -1n,
-    42n,
-    -42n,
-    127n,
-    128n,
-    -128n,
-    -129n,
-    255n,
-    256n,
-    -256n,
-    -999n,
-    2n ** 32n,
-    -(2n ** 32n),
-    2n ** 64n,
-    -(2n ** 64n),
-    2n ** 128n,
-    -(2n ** 128n),
-    // Large positive
-    0x112233445566778899abcdefn,
-    // Large negative
-    -0x112233445566778899abcdefn,
-  ];
-
-  for (const value of values) {
-    it(`round-trips ${value}n`, () => {
+  for (const { value, label } of fixtures) {
+    it(`round-trips ${label}`, () => {
       const bytes = bigintToMinimalTwosComplement(value);
-      const result = bigintFromMinimalTwosComplement(bytes);
-      expect(result).toBe(value);
+      expect(bigintFromMinimalTwosComplement(bytes)).toBe(value);
     });
   }
 });
 
-// ============================================================================
-// Full pipeline: bigint -> bytes -> base64url -> bytes -> bigint
-// ============================================================================
-
 describe("bigint -> base64url -> bigint round-trip", () => {
-  const values = [0n, 1n, -1n, 42n, -999n, 128n, -128n, 2n ** 64n];
-
-  for (const value of values) {
-    it(`round-trips ${value}n through base64url`, () => {
+  for (const { value, label } of fixtures) {
+    it(`round-trips ${label} through base64url`, () => {
       const bytes = bigintToMinimalTwosComplement(value);
       const b64 = toUnpaddedBase64url(bytes);
       const decodedBytes = fromBase64url(b64);
-      const result = bigintFromMinimalTwosComplement(decodedBytes);
-      expect(result).toBe(value);
+      expect(bigintFromMinimalTwosComplement(decodedBytes)).toBe(value);
     });
   }
 });


### PR DESCRIPTION
## Summary

Replaces the handful of individually-crafted `it()` blocks in
`packages/data-model/test/bigint-encoding.test.ts` with a single
`fixtures: bigint[]` driven by an oracle-based test loop.

- A small **`referenceEncode()`** -- deliberately naive: derive byte length
  from the magnitude's binary representation, apply two's complement via
  plain bigint arithmetic, materialize bytes through `toString(16)` +
  `parseInt`. Pinned against the spec by a focused
  `referenceEncode (test oracle)` describe block (10 explicit byte-level
  assertions like `0n -> [0x00]`, `128n -> [0x00, 0x80]`, etc.).
- The fixture array is seeded with all the explicit corner cases preserved
  from the original file (`0n`, `±1n`, `±128n`, `±129n`, …, `2^128`,
  `±0x1122…cdef`), the byte-length-corner-case values that motivated PR
  #3527 (`0xCF1205Dn`, `-241n` … `-248n`), and then programmatically
  expanded via a deterministic recurrence:
  ```ts
  let n = 123n;
  for (let i = 0; i < 2000; i++) {
    n = (n * 99n) + 9876n;
    rawFixtures.push(n);
    rawFixtures.push(-n);
  }
  ```
  `n *= 99` adds ~6.63 bits per step, so 2000 iterations sweep magnitudes
  from a few bits up to roughly 13_270 bits (~1659 bytes), with both signs
  at every step.
- Each function under test gets a single fixture loop emitting one `it()`
  per fixture:
  - `bigintToMinimalTwosComplement(v)` matches `referenceEncode(v)`
  - `bigintFromMinimalTwosComplement(referenceEncode(v))` returns `v`
  - encode → decode round-trip
  - bytes → base64url → bytes → bigint round-trip

## Test names

`fixtureLabel()`: decimal up to 64 bits, hex up to 128 bits, and beyond
that just a hex prefix plus the encoded byte count, so output stays
scannable for the very large recurrence values:

```
encodes 0n
encodes -129n
encodes 18446744073709551616n
encodes -0x112233445566778899abcdefn
encodes 0xff44b6f7e7c4... (113 bytes)
encodes -0xf17e1ae4c263... (118 bytes)
```

## Performance

Reference encodings are pre-computed once per fixture (rather than recomputed
per-`it()`), so the per-test overhead is just the function-under-test call
plus the equality check.

| | steps | wall |
| --- | --- | --- |
| original suite | 47 | <1s |
| this suite | 16,140 | ~4s |

## Test plan

- [x] `deno test packages/data-model/test/bigint-encoding.test.ts` -- 6
      passed (16,140 steps), 0 failed.
- [x] `deno task test` in `packages/data-model` -- 45 passed (17,413
      steps), 0 failed.
- [x] `deno task test` at the repo root -- all 33 workspace packages
      pass (66.2s total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
