### PR TITLE
[codex] Fix pull-mode demanded rendering

### DIFF
--- a/packages/generated-patterns/integration/pattern-harness.ts
+++ b/packages/generated-patterns/integration/pattern-harness.ts
@@ -110,6 +110,7 @@ export async function runPatternScenario(scenario: PatternIntegrationScenario) {
           (cell, segment) => cell.key(segment),
           result,
         );
+        await targetCell.pull();
         await runtime.editWithRetry((tx) =>
           targetCell.withTx(tx).send(event.payload)
         );

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -578,22 +578,19 @@ describe("default-app flow test", () => {
 
   it("should render every rapidly created notebook note", async () => {
     identity = await Identity.generate({ implementation: "noble" });
+    const notebookSpaceName = globalThis.crypto.randomUUID();
 
     const page = shell.page();
     await shell.goto({
       frontendUrl: FRONTEND_URL,
-      view: { spaceName },
+      view: { spaceName: notebookSpaceName },
       identity,
     });
 
-    if (SCHEDULER_PULL_MODE !== undefined) {
-      console.log(
-        `Set scheduler mode: ${SCHEDULER_PULL_MODE ? "pull" : "push"}...`,
-      );
-      await waitFor(async () => {
-        return await setSchedulerPullMode(page, SCHEDULER_PULL_MODE);
-      });
-    }
+    console.log("Set scheduler mode: pull for notebook regression...");
+    await waitFor(async () => {
+      return await setSchedulerPullMode(page, true);
+    });
 
     await waitFor(async () => {
       return !!(await clickButtonWithText(page, "Notes"));
@@ -601,13 +598,18 @@ describe("default-app flow test", () => {
     await waitFor(async () => {
       return !!(await clickButtonWithText(page, "New Notebook"));
     });
-    await waitFor(async () => {
-      return await waitForRuntimeIdle(page);
-    });
-    await waitFor(async () => {
-      const diagnostics = await collectNotebookDiagnostics(page);
-      return diagnostics.isNotebook;
-    });
+    try {
+      await waitFor(async () => {
+        const state = await collectNotebookRenderState(page);
+        return state.isNotebook;
+      });
+    } catch (error) {
+      console.log(
+        "Notebook navigation diagnostics:",
+        JSON.stringify(await collectNavigationDiagnostics(page), null, 2),
+      );
+      throw error;
+    }
 
     await waitFor(async () => {
       return !!(await clickButtonWithTitle(page, "New Note"));
@@ -615,7 +617,6 @@ describe("default-app flow test", () => {
     await waitFor(async () => {
       return !!(await findButtonWithText(page, "Create Another"));
     });
-    await armActionRunTrace(page);
 
     const noteCreates = 7;
     for (let i = 0; i < noteCreates - 1; i++) {
@@ -629,27 +630,29 @@ describe("default-app flow test", () => {
       "Expected final Create click to succeed",
     );
 
-    await waitFor(async () => {
-      return await waitForRuntimeIdle(page);
-    });
     try {
       await waitFor(async () => {
-        const diagnostics = await collectNotebookDiagnostics(page);
-        return diagnostics.noteCount === noteCreates &&
-          diagnostics.renderedNoteChips === noteCreates;
+        const state = await collectNotebookRenderState(page);
+        return state.noteCount === noteCreates &&
+          state.renderedNoteChips === noteCreates;
       });
     } catch (_) {
       // Keep the final assertions below so failures include diagnostics.
     }
 
-    const diagnostics = await collectNotebookDiagnostics(page);
-    console.log(
-      "Notebook rapid create diagnostics:",
-      JSON.stringify(diagnostics, null, 2),
-    );
+    const summary = await collectNotebookRenderState(page);
+    if (
+      summary.noteCount !== noteCreates ||
+      summary.renderedNoteChips !== noteCreates
+    ) {
+      console.log(
+        "Notebook rapid create diagnostics:",
+        JSON.stringify(await collectNotebookDiagnostics(page), null, 2),
+      );
+    }
 
-    assertEquals(diagnostics.noteCount, noteCreates);
-    assertEquals(diagnostics.renderedNoteChips, noteCreates);
+    assertEquals(summary.noteCount, noteCreates);
+    assertEquals(summary.renderedNoteChips, noteCreates);
   });
 });
 
@@ -2631,47 +2634,73 @@ async function clickButtonWithTitle(
   }
 }
 
-async function collectNotebookDiagnostics(page: Page): Promise<{
+async function collectNotebookRenderState(page: Page): Promise<{
   isNotebook: boolean;
   noteCount: number;
   notesLength: number;
   renderedNoteChips: number;
   renderedNoteLabels: string[];
-  dirtyComputations?: Array<{
-    id: string;
-    preview?: string;
-    isPending: boolean;
-    reads: string[];
-    writes: string[];
-    outgoing: Array<{ to: string; cells?: string[]; edgeType?: string }>;
-  }>;
-  pendingEffects?: Array<{ id: string; preview?: string }>;
-  actionTraceTail?: Array<{ id: string; type: string; writes: string[] }>;
 }> {
   return await page.evaluate(async () => {
     const commonfabric = globalThis.commonfabric as any;
     const current = await commonfabric?.readCell?.();
-    const graph = await commonfabric?.rt?.getGraphSnapshot?.();
-    const actionTrace = await commonfabric?.rt?.getActionRunTrace?.();
     const notes = Array.isArray(current?.notes) ? current.notes : [];
-    const noteLabels: string[] = [];
+    const collectRenderedNoteLabels = (root: Document | ShadowRoot) => {
+      const labels: string[] = [];
 
-    function collectNoteLabels(root: Document | ShadowRoot): void {
-      for (const el of root.querySelectorAll("*")) {
-        if (el.localName === "cf-chip") {
-          const label = ((el as any).label ?? el.getAttribute("label") ?? "")
-            .trim();
-          if (label.startsWith("📝 New Note")) {
-            noteLabels.push(label);
+      function collect(currentRoot: Document | ShadowRoot): void {
+        for (const el of currentRoot.querySelectorAll("*")) {
+          if (el.localName === "cf-chip") {
+            const label = ((el as any).label ?? el.getAttribute("label") ?? "")
+              .trim();
+            if (label.startsWith("📝 New Note")) {
+              labels.push(label);
+            }
+          }
+          if ((el as HTMLElement).shadowRoot) {
+            collect((el as HTMLElement).shadowRoot!);
           }
         }
-        if ((el as HTMLElement).shadowRoot) {
-          collectNoteLabels((el as HTMLElement).shadowRoot!);
-        }
       }
-    }
 
-    collectNoteLabels(document);
+      collect(root);
+      return labels;
+    };
+    const noteLabels = collectRenderedNoteLabels(document);
+
+    return {
+      isNotebook: current?.isNotebook === true,
+      noteCount: typeof current?.noteCount === "number"
+        ? current.noteCount
+        : -1,
+      notesLength: notes.length,
+      renderedNoteChips: noteLabels.length,
+      renderedNoteLabels: noteLabels,
+    };
+  });
+}
+
+async function collectNotebookDiagnostics(
+  page: Page,
+): Promise<
+  Awaited<ReturnType<typeof collectNotebookRenderState>> & {
+    dirtyComputations?: Array<{
+      id: string;
+      preview?: string;
+      isPending: boolean;
+      reads: string[];
+      writes: string[];
+      outgoing: Array<{ to: string; cells?: string[]; edgeType?: string }>;
+    }>;
+    pendingEffects?: Array<{ id: string; preview?: string }>;
+    actionTraceTail?: Array<{ id: string; type: string; writes: string[] }>;
+  }
+> {
+  const renderState = await collectNotebookRenderState(page);
+  const graphState = await page.evaluate(async () => {
+    const commonfabric = globalThis.commonfabric as any;
+    const graph = await commonfabric?.rt?.getGraphSnapshot?.();
+    const actionTrace = await commonfabric?.rt?.getActionRunTrace?.();
     const edgesByFrom = new Map<string, any[]>();
     for (const edge of graph?.edges ?? []) {
       const edges = edgesByFrom.get(edge.from) ?? [];
@@ -2710,16 +2739,43 @@ async function collectNotebookDiagnostics(page: Page): Promise<{
     }));
 
     return {
-      isNotebook: current?.isNotebook === true,
-      noteCount: typeof current?.noteCount === "number"
-        ? current.noteCount
-        : -1,
-      notesLength: notes.length,
-      renderedNoteChips: noteLabels.length,
-      renderedNoteLabels: noteLabels,
       dirtyComputations,
       pendingEffects,
       actionTraceTail,
+    };
+  });
+
+  return { ...renderState, ...graphState };
+}
+
+async function collectNavigationDiagnostics(page: Page): Promise<unknown> {
+  return await page.evaluate(async () => {
+    const commonfabric = globalThis.commonfabric as any;
+    const current = await commonfabric?.readCell?.();
+    const appState = globalThis.app?.serialize?.();
+    const buttonTexts: string[] = [];
+
+    function collectButtonTexts(root: Document | ShadowRoot): void {
+      for (const el of root.querySelectorAll("cf-button, button, a")) {
+        const text = (el.textContent ?? "").trim().replace(/\s+/g, " ");
+        if (text) buttonTexts.push(text);
+        if ((el as HTMLElement).shadowRoot) {
+          collectButtonTexts((el as HTMLElement).shadowRoot!);
+        }
+      }
+    }
+
+    collectButtonTexts(document);
+
+    return {
+      location: globalThis.location.href,
+      appState,
+      currentName: current?.$NAME,
+      currentIsNotebook: current?.isNotebook === true,
+      currentKeys: current && typeof current === "object"
+        ? Object.keys(current).slice(0, 30)
+        : [],
+      buttonTexts: buttonTexts.slice(0, 40),
     };
   });
 }

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -575,6 +575,82 @@ describe("default-app flow test", () => {
       );
     }
   });
+
+  it("should render every rapidly created notebook note", async () => {
+    identity = await Identity.generate({ implementation: "noble" });
+
+    const page = shell.page();
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName },
+      identity,
+    });
+
+    if (SCHEDULER_PULL_MODE !== undefined) {
+      console.log(
+        `Set scheduler mode: ${SCHEDULER_PULL_MODE ? "pull" : "push"}...`,
+      );
+      await waitFor(async () => {
+        return await setSchedulerPullMode(page, SCHEDULER_PULL_MODE);
+      });
+    }
+
+    await waitFor(async () => {
+      return !!(await clickButtonWithText(page, "Notes"));
+    });
+    await waitFor(async () => {
+      return !!(await clickButtonWithText(page, "New Notebook"));
+    });
+    await waitFor(async () => {
+      return await waitForRuntimeIdle(page);
+    });
+    await waitFor(async () => {
+      const diagnostics = await collectNotebookDiagnostics(page);
+      return diagnostics.isNotebook;
+    });
+
+    await waitFor(async () => {
+      return !!(await clickButtonWithTitle(page, "New Note"));
+    });
+    await waitFor(async () => {
+      return !!(await findButtonWithText(page, "Create Another"));
+    });
+    await armActionRunTrace(page);
+
+    const noteCreates = 7;
+    for (let i = 0; i < noteCreates - 1; i++) {
+      assert(
+        await clickButtonWithText(page, "Create Another"),
+        `Expected Create Another click ${i + 1} to succeed`,
+      );
+    }
+    assert(
+      await clickButtonWithExactText(page, "Create"),
+      "Expected final Create click to succeed",
+    );
+
+    await waitFor(async () => {
+      return await waitForRuntimeIdle(page);
+    });
+    try {
+      await waitFor(async () => {
+        const diagnostics = await collectNotebookDiagnostics(page);
+        return diagnostics.noteCount === noteCreates &&
+          diagnostics.renderedNoteChips === noteCreates;
+      });
+    } catch (_) {
+      // Keep the final assertions below so failures include diagnostics.
+    }
+
+    const diagnostics = await collectNotebookDiagnostics(page);
+    console.log(
+      "Notebook rapid create diagnostics:",
+      JSON.stringify(diagnostics, null, 2),
+    );
+
+    assertEquals(diagnostics.noteCount, noteCreates);
+    assertEquals(diagnostics.renderedNoteChips, noteCreates);
+  });
 });
 
 async function armTriggerTrace(page: Page): Promise<boolean> {
@@ -2447,6 +2523,28 @@ async function clickButtonWithText(
   page: Page,
   searchText: string,
 ): Promise<boolean> {
+  const button = await findButtonWithText(page, searchText);
+  if (!button) return false;
+  try {
+    await button.click();
+    return true;
+  } catch (_) {
+    return await page.evaluate((searchText: string) => {
+      for (const el of document.querySelectorAll("cf-button, button, a")) {
+        if (el.textContent?.trim().includes(searchText)) {
+          (el as HTMLElement).click();
+          return true;
+        }
+      }
+      return false;
+    }, { args: [searchText] });
+  }
+}
+
+async function findButtonWithText(
+  page: Page,
+  searchText: string,
+): Promise<any | null> {
   try {
     // Search cf-button, button, and a elements with piercing selector
     const buttons = await page.$$("cf-button, button, a", {
@@ -2455,14 +2553,171 @@ async function clickButtonWithText(
     for (const button of buttons) {
       const text = await button.innerText();
       if (text?.trim().includes(searchText)) {
-        await button.click();
-        return true;
+        return button;
+      }
+    }
+    return null;
+  } catch (_) {
+    return null;
+  }
+}
+
+async function clickButtonWithExactText(
+  page: Page,
+  searchText: string,
+): Promise<boolean> {
+  try {
+    const buttons = await page.$$("cf-button, button, a", {
+      strategy: "pierce",
+    });
+    for (const button of buttons) {
+      const text = await button.innerText();
+      if (text?.trim() === searchText) {
+        try {
+          await button.click();
+          return true;
+        } catch (_) {
+          return await page.evaluate((searchText: string) => {
+            for (const el of document.querySelectorAll(
+              "cf-button, button, a",
+            )) {
+              if (el.textContent?.trim() === searchText) {
+                (el as HTMLElement).click();
+                return true;
+              }
+            }
+            return false;
+          }, { args: [searchText] });
+        }
       }
     }
     return false;
   } catch (_) {
     return false;
   }
+}
+
+async function clickButtonWithTitle(
+  page: Page,
+  title: string,
+): Promise<boolean> {
+  try {
+    const buttons = await page.$$("cf-button, button", {
+      strategy: "pierce",
+    });
+    for (const button of buttons) {
+      const actualTitle = await button.getAttribute("title");
+      if (actualTitle === title) {
+        try {
+          await button.click();
+          return true;
+        } catch (_) {
+          return await page.evaluate((title: string) => {
+            const el = document.querySelector(
+              `cf-button[title="${title}"], button[title="${title}"]`,
+            );
+            if (!el) return false;
+            (el as HTMLElement).click();
+            return true;
+          }, { args: [title] });
+        }
+      }
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
+
+async function collectNotebookDiagnostics(page: Page): Promise<{
+  isNotebook: boolean;
+  noteCount: number;
+  notesLength: number;
+  renderedNoteChips: number;
+  renderedNoteLabels: string[];
+  dirtyComputations?: Array<{
+    id: string;
+    preview?: string;
+    isPending: boolean;
+    reads: string[];
+    writes: string[];
+    outgoing: Array<{ to: string; cells?: string[]; edgeType?: string }>;
+  }>;
+  pendingEffects?: Array<{ id: string; preview?: string }>;
+  actionTraceTail?: Array<{ id: string; type: string; writes: string[] }>;
+}> {
+  return await page.evaluate(async () => {
+    const commonfabric = globalThis.commonfabric as any;
+    const current = await commonfabric?.readCell?.();
+    const graph = await commonfabric?.rt?.getGraphSnapshot?.();
+    const actionTrace = await commonfabric?.rt?.getActionRunTrace?.();
+    const notes = Array.isArray(current?.notes) ? current.notes : [];
+    const noteLabels: string[] = [];
+
+    function collectNoteLabels(root: Document | ShadowRoot): void {
+      for (const el of root.querySelectorAll("*")) {
+        if (el.localName === "cf-chip") {
+          const label =
+            ((el as any).label ?? el.getAttribute("label") ?? "").trim();
+          if (label.startsWith("📝 New Note")) {
+            noteLabels.push(label);
+          }
+        }
+        if ((el as HTMLElement).shadowRoot) {
+          collectNoteLabels((el as HTMLElement).shadowRoot!);
+        }
+      }
+    }
+
+    collectNoteLabels(document);
+    const edgesByFrom = new Map<string, any[]>();
+    for (const edge of graph?.edges ?? []) {
+      const edges = edgesByFrom.get(edge.from) ?? [];
+      edges.push(edge);
+      edgesByFrom.set(edge.from, edges);
+    }
+    const dirtyComputations = (graph?.nodes ?? [])
+      .filter((node: any) => node.type === "computation" && node.isDirty)
+      .slice(0, 20)
+      .map((node: any) => ({
+        id: node.id,
+        preview: node.preview,
+        isPending: node.isPending,
+        reads: (node.reads ?? []).slice(0, 12),
+        writes: (node.writes ?? []).slice(0, 8),
+        outgoing: (edgesByFrom.get(node.id) ?? [])
+          .slice(0, 8)
+          .map((edge: any) => ({
+            to: edge.to,
+            cells: (edge.cells ?? []).slice(0, 4),
+            edgeType: edge.edgeType,
+          })),
+      }));
+    const pendingEffects = (graph?.nodes ?? [])
+      .filter((node: any) => node.type === "effect" && node.isPending)
+      .slice(0, 20)
+      .map((node: any) => ({ id: node.id, preview: node.preview }));
+    const actionTraceTail = (actionTrace ?? []).slice(-20).map((entry: any) => ({
+      id: entry.actionId,
+      type: entry.actionType,
+      writes: (entry.actualWrites ?? []).slice(0, 4).map((write: any) =>
+        `${write.space}/${write.entityId}/${write.path.join("/")}`
+      ),
+    }));
+
+    return {
+      isNotebook: current?.isNotebook === true,
+      noteCount: typeof current?.noteCount === "number"
+        ? current.noteCount
+        : -1,
+      notesLength: notes.length,
+      renderedNoteChips: noteLabels.length,
+      renderedNoteLabels: noteLabels,
+      dirtyComputations,
+      pendingEffects,
+      actionTraceTail,
+    };
+  });
 }
 
 async function clickPieceLinkWithText(

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -2578,9 +2578,11 @@ async function clickButtonWithExactText(
           return true;
         } catch (_) {
           return await page.evaluate((searchText: string) => {
-            for (const el of document.querySelectorAll(
-              "cf-button, button, a",
-            )) {
+            for (
+              const el of document.querySelectorAll(
+                "cf-button, button, a",
+              )
+            ) {
               if (el.textContent?.trim() === searchText) {
                 (el as HTMLElement).click();
                 return true;
@@ -2657,8 +2659,8 @@ async function collectNotebookDiagnostics(page: Page): Promise<{
     function collectNoteLabels(root: Document | ShadowRoot): void {
       for (const el of root.querySelectorAll("*")) {
         if (el.localName === "cf-chip") {
-          const label =
-            ((el as any).label ?? el.getAttribute("label") ?? "").trim();
+          const label = ((el as any).label ?? el.getAttribute("label") ?? "")
+            .trim();
           if (label.startsWith("📝 New Note")) {
             noteLabels.push(label);
           }
@@ -2697,7 +2699,9 @@ async function collectNotebookDiagnostics(page: Page): Promise<{
       .filter((node: any) => node.type === "effect" && node.isPending)
       .slice(0, 20)
       .map((node: any) => ({ id: node.id, preview: node.preview }));
-    const actionTraceTail = (actionTrace ?? []).slice(-20).map((entry: any) => ({
+    const actionTraceTail = (actionTrace ?? []).slice(-20).map((
+      entry: any,
+    ) => ({
       id: entry.actionId,
       type: entry.actionType,
       writes: (entry.actualWrites ?? []).slice(0, 4).map((write: any) =>

--- a/packages/runner/src/builtins/index.ts
+++ b/packages/runner/src/builtins/index.ts
@@ -34,7 +34,7 @@ export function registerBuiltins(runtime: Runtime) {
   moduleRegistry.addModuleByRef("fetchData", raw(fetchData));
   moduleRegistry.addModuleByRef("fetchProgram", raw(fetchProgram));
   moduleRegistry.addModuleByRef("streamData", raw(streamData));
-  moduleRegistry.addModuleByRef("llm", raw(llm));
+  moduleRegistry.addModuleByRef("llm", raw(llm, { isEffect: true }));
   moduleRegistry.addModuleByRef("llmDialog", raw(llmDialog));
   moduleRegistry.addModuleByRef("ifElse", raw(ifElse));
   moduleRegistry.addModuleByRef("when", raw(when));
@@ -47,7 +47,7 @@ export function registerBuiltins(runtime: Runtime) {
       result: Cell<Record<string, unknown> | undefined>;
       partial: Cell<string | undefined>;
       requestHash: Cell<string | undefined>;
-    }>(generateObject),
+    }>(generateObject, { isEffect: true }),
   );
   moduleRegistry.addModuleByRef(
     "generateText",
@@ -56,7 +56,7 @@ export function registerBuiltins(runtime: Runtime) {
       result: Cell<string | undefined>;
       partial: Cell<string | undefined>;
       requestHash: Cell<string | undefined>;
-    }>(generateText),
+    }>(generateText, { isEffect: true }),
   );
   moduleRegistry.addModuleByRef(
     "navigateTo",

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -685,6 +685,15 @@ export class CellImpl<T extends FabricValue>
       resolvedToValueLink = resolveLink(this.runtime, tx, this.link);
     }
 
+    if (
+      ContextualFlowControl.getAsCellValues(resolvedToValueLink.schema).at(
+        0,
+      ) ===
+        "stream"
+    ) {
+      return true;
+    }
+
     const value = tx.readValueOrThrow(resolvedToValueLink, {
       meta: ignoreReadForScheduling,
     });

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2142,6 +2142,7 @@ export class Runner {
           this.stop(resultCell);
         }
       });
+      this.pullCellOnceAfterSuccessfulCommit(tx, resultCell);
     }
 
     previousResultCellRef.current ??= resultCell;

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -429,7 +429,7 @@ export class Scheduler {
   private stale = new Set<Action>();
   private upstreamStaleWriters = new WeakMap<Action, Set<Action>>();
   private upstreamStaleCount = new WeakMap<Action, number>();
-  private pullMode = false;
+  private pullMode = true;
 
   // Debugger breakpoints: action IDs that should trigger `debugger` before execution
   private breakpoints = new Set<string>();

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -421,6 +421,8 @@ export class Scheduler {
   private computations = new Set<Action>();
   private dependents = new WeakMap<Action, Set<Action>>();
   private reverseDependencies = new WeakMap<Action, Set<Action>>();
+  private activePullDemandActions = new WeakSet<Action>();
+  private pullDemandedFirstRunComputations = new WeakSet<Action>();
   // Track which actions are effects persistently (survives unsubscribe/re-subscribe)
   private isEffectAction = new WeakMap<Action, boolean>();
   // In pull mode, `dirty` means direct dirty. `stale` additionally includes
@@ -429,7 +431,7 @@ export class Scheduler {
   private stale = new Set<Action>();
   private upstreamStaleWriters = new WeakMap<Action, Set<Action>>();
   private upstreamStaleCount = new WeakMap<Action, number>();
-  private pullMode = true;
+  private pullMode = false;
 
   // Debugger breakpoints: action IDs that should trigger `debugger` before execution
   private breakpoints = new Set<string>();
@@ -446,6 +448,7 @@ export class Scheduler {
   // Cycle-aware debounce: track runs per action within current execute() call
   private runsThisExecute = new Map<Action, number>();
   private executeStartTime = 0;
+  private rerunAfterCurrentExecute = false;
 
   // Non-settling heuristic (Phase 1): detects when the system is churning
   private settlingTracker = {
@@ -931,6 +934,16 @@ export class Scheduler {
 
     // Track parent-child relationship if action is created during another action's execution
     this.registerParentChild(action);
+    const parent = this.actionParent.get(action);
+    if (
+      this.pullMode &&
+      !actionIsEffect &&
+      parent &&
+      this.activePullDemandActions.has(parent)
+    ) {
+      this.pullDemandedFirstRunComputations.add(action);
+      this.queueExecution();
+    }
 
     logger.debug(
       "schedule",
@@ -1039,13 +1052,15 @@ export class Scheduler {
       log,
     );
 
-    // Update reverse dependency graph
-    if (this.pullMode) this.updateDependents(action, schedulingLog);
-
     // Track action type for pull-based scheduling
     // Once an action is marked as an effect, it stays an effect
     const actionIsEffect = this.updateActionType(action, isEffect);
     const actionId = this.getActionId(action);
+
+    // Update reverse dependency graph after the action type is restored. In
+    // pull mode, registering a new edge to a live effect can be the moment a
+    // stale upstream computation becomes demanded.
+    if (this.pullMode) this.updateDependents(action, schedulingLog);
 
     // Track parent-child relationship if action is created during another action's execution
     // Only set if not already set (resubscribe can be called multiple times)
@@ -1175,6 +1190,7 @@ export class Scheduler {
     // Clean up effect/computation tracking
     this.effects.delete(action);
     this.computations.delete(action);
+    this.pullDemandedFirstRunComputations.delete(action);
     // Clean up writersByEntity index
     const writeEntities = this.actionWriteEntities.get(action);
     if (writeEntities) {
@@ -1230,6 +1246,7 @@ export class Scheduler {
         const elapsed = performance.now() - actionStartTime;
         this.recordActionTime(action, elapsed);
         this.actionHasRun.add(action);
+        this.pullDemandedFirstRunComputations.delete(action);
 
         try {
           if (error) {
@@ -1417,11 +1434,20 @@ export class Scheduler {
         Promise.allSettled([...this.backgroundTasks]).then(() =>
           this.idle().then(resolve)
         );
-      } else if (this.eventQueueWakeTimer !== null) {
+      } else if (
+        this.eventQueueWakeTimer !== null &&
+        ((this.eventQueue.length > 0 && this.isHeadEventParked()) ||
+          this.hasDeferredDirtyEffectWork())
+      ) {
         // A queued event is parked behind a throttled dependency. Wait for the
         // wake timer to re-schedule the queue and then re-check.
         this.idlePromises.push(resolve);
       } else if (!this.scheduled) {
+        if (this.pullMode && this.hasRunnablePullWork()) {
+          this.queueExecution();
+          this.idlePromises.push(resolve);
+          return;
+        }
         // Nothing is scheduled to run - we're idle.
         // In pull mode, pending computations won't run without an effect to pull them,
         // so we don't wait for them.
@@ -1706,7 +1732,12 @@ export class Scheduler {
 
   queueExecution(): void {
     if (this.disposed) return;
-    if (this.scheduled) return;
+    if (this.scheduled) {
+      if (this.pendingQueueTaskTimer === null) {
+        this.rerunAfterCurrentExecute = true;
+      }
+      return;
+    }
     this.pendingQueueTaskTimer = queueTask(() => {
       this.pendingQueueTaskTimer = null;
       this.execute();
@@ -2153,6 +2184,9 @@ export class Scheduler {
 
     if (!alreadyDependent && this.isStale(writer)) {
       this.addStaleUpstream(writer, dependent);
+      if (this.isDemandedPullComputation(writer)) {
+        this.queueExecution();
+      }
     }
   }
 
@@ -2605,6 +2639,9 @@ export class Scheduler {
   private markDirty(action: Action): void {
     this.markDirectDirty(action);
     this.scheduleComputationDebounce(action);
+    if (this.isDemandedPullComputation(action)) {
+      this.queueExecution();
+    }
   }
 
   private markDirectDirty(action: Action): boolean {
@@ -2948,6 +2985,83 @@ export class Scheduler {
     return false;
   }
 
+  private hasTransitiveEffectDependent(
+    action: Action,
+    visited = new Set<Action>(),
+  ): boolean {
+    if (visited.has(action)) return false;
+    visited.add(action);
+
+    const dependents = this.dependents.get(action);
+    if (!dependents) return false;
+
+    for (const dependent of dependents) {
+      if (this.isLiveEffect(dependent)) return true;
+      if (this.hasTransitiveEffectDependent(dependent, visited)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private isDemandedPullComputation(
+    action: Action,
+    visited = new Set<Action>(),
+  ): boolean {
+    if (
+      !this.pullMode ||
+      !this.computations.has(action) ||
+      this.isLiveEffect(action)
+    ) {
+      return false;
+    }
+    if (visited.has(action)) return false;
+    visited.add(action);
+
+    return this.hasTransitiveEffectDependent(action) ||
+      this.hasDemandedParentContext(action, visited);
+  }
+
+  private hasDemandedParentContext(
+    action: Action,
+    visited = new Set<Action>(),
+  ): boolean {
+    const parent = this.actionParent.get(action);
+    if (!parent) return false;
+
+    if (this.isLiveEffect(parent)) {
+      return (this.getSchedulingWrites(parent)?.length ?? 0) === 0;
+    }
+
+    return this.isDemandedPullComputation(parent, visited);
+  }
+
+  private isLiveEffect(action: Action): boolean {
+    if (this.effects.has(action)) return true;
+
+    // During resubscribe, dependencies can be registered before all effect
+    // bookkeeping is restored. Treat only dependency-bearing historical effects
+    // as live so unsubscribed effects do not keep old pull graphs demanded.
+    return (this.isEffectAction.get(action) ?? false) &&
+      this.dependencies.has(action);
+  }
+
+  private shouldRunFirstPullComputationInDemandContext(
+    action: Action,
+  ): boolean {
+    if (
+      !this.pullMode ||
+      !this.computations.has(action) ||
+      this.effects.has(action) ||
+      this.actionHasRun.has(action)
+    ) {
+      return false;
+    }
+
+    return this.pullDemandedFirstRunComputations.has(action);
+  }
+
   private markEffectConditionallyScheduled(effect: Action): void {
     if (!this.conditionallyScheduledEffects.has(effect)) {
       this.conditionallyScheduledEffects.set(
@@ -3126,19 +3240,56 @@ export class Scheduler {
    */
   private collectPullIterationSeeds(workSet: Set<Action>): void {
     for (const action of this.pending) {
-      if (this.effects.has(action)) {
+      if (
+        this.effects.has(action) ||
+        this.isDemandedPullComputation(action) ||
+        this.shouldRunFirstPullComputationInDemandContext(action)
+      ) {
         workSet.add(action);
       }
     }
 
     for (const action of this.dirty) {
-      if (this.effects.has(action)) {
+      if (
+        this.effects.has(action) ||
+        this.isDemandedPullComputation(action)
+      ) {
         if (!this.isThrottled(action)) {
           this.pending.add(action);
           workSet.add(action);
         }
       }
     }
+  }
+
+  private hasRunnablePullWork(): boolean {
+    for (const action of this.pending) {
+      if (this.effects.has(action) || this.isDemandedPullComputation(action)) {
+        return true;
+      }
+      if (this.shouldRunFirstPullComputationInDemandContext(action)) {
+        return true;
+      }
+    }
+
+    for (const action of this.dirty) {
+      if (
+        (this.effects.has(action) || this.isDemandedPullComputation(action)) &&
+        !this.isThrottled(action) &&
+        !this.isDebouncedComputationWaiting(action)
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private hasDeferredDirtyEffectWork(): boolean {
+    for (const action of this.dirty) {
+      if (this.effects.has(action)) return true;
+    }
+    return false;
   }
 
   /**
@@ -4688,7 +4839,20 @@ export class Scheduler {
           }
           this.handleError(error, fn);
         } else {
-          await this.run(fn);
+          const activePullDemand = this.pullMode &&
+            (this.computations.has(fn) ||
+              (this.effects.has(fn) &&
+                (this.getSchedulingWrites(fn)?.length ?? 0) === 0));
+          if (activePullDemand) {
+            this.activePullDemandActions.add(fn);
+          }
+          try {
+            await this.run(fn);
+          } finally {
+            if (activePullDemand) {
+              this.activePullDemandActions.delete(fn);
+            }
+          }
         }
       }
 
@@ -4749,7 +4913,8 @@ export class Scheduler {
       for (const comp of earlyIterationComputations) {
         if (
           lastWorkSet.has(comp) && this.dirty.has(comp) &&
-          !this.isThrottled(comp)
+          !this.isThrottled(comp) &&
+          (this.runsThisExecute.get(comp) ?? 0) > 1
         ) {
           logger.debug("schedule-cycle", () => [
             `[CYCLE-BREAK] Clearing cyclic computation: ${
@@ -4777,11 +4942,18 @@ export class Scheduler {
       }
     }
 
-    // Apply cycle-aware debounce to actions that ran multiple times this execute()
+    // Apply cycle-aware debounce to effects that ran multiple times this execute().
+    // Pull computations are already demand-gated; debouncing them can leave a
+    // live renderer observing stale materialized data until an arbitrary timer
+    // fires.
     const executeElapsed = performance.now() - this.executeStartTime;
     if (this.pullMode && executeElapsed >= CYCLE_DEBOUNCE_THRESHOLD_MS) {
       for (const [action, runs] of this.runsThisExecute) {
-        if (runs >= CYCLE_DEBOUNCE_MIN_RUNS && !this.noDebounce.get(action)) {
+        if (
+          this.effects.has(action) &&
+          runs >= CYCLE_DEBOUNCE_MIN_RUNS &&
+          !this.noDebounce.get(action)
+        ) {
           // This action is cycling - apply adaptive debounce
           const adaptiveDelay = Math.round(
             CYCLE_DEBOUNCE_MULTIPLIER * executeElapsed,
@@ -4835,35 +5007,70 @@ export class Scheduler {
       }
     }
 
-    // In pull mode, we consider ourselves done when there are no effects to execute.
-    // Check both pending AND dirty effects - dirty effects may exist from:
-    // - Cycle detection (effect re-dirtied, skipped to prevent infinite loop)
-    // - Throttling (effect throttled, kept dirty for later)
-    const hasPendingEffects = this.pullMode
-      ? [...this.pending].some((a) => this.effects.has(a))
+    // In pull mode, we consider ourselves done when there are no effects or
+    // effect-demanded computations to execute.
+    const hasPendingPullWork = this.pullMode
+      ? [...this.pending].some((a) =>
+        this.effects.has(a) ||
+        this.isDemandedPullComputation(a) ||
+        this.shouldRunFirstPullComputationInDemandContext(a)
+      )
       : this.pending.size > 0;
-    let nextDirtyEffectRunAt: number | undefined;
-    const hasDirtyEffects = this.pullMode &&
+    let nextDirtyPullRunAt: number | undefined;
+    let nextDirtyPullRunWaitsForIdle = false;
+    const hasDirtyPullWork = this.pullMode &&
       [...this.dirty].some((action) => {
-        if (!this.effects.has(action)) return false;
+        if (
+          !this.effects.has(action) &&
+          !this.isDemandedPullComputation(action)
+        ) {
+          return false;
+        }
+        if (this.isDebouncedComputationWaiting(action)) {
+          const nextDebounceAt = this.getNextDebounceRunTime(action);
+          if (nextDebounceAt !== undefined) {
+            nextDirtyPullRunAt = nextDirtyPullRunAt === undefined
+              ? nextDebounceAt
+              : Math.min(nextDirtyPullRunAt, nextDebounceAt);
+            nextDirtyPullRunWaitsForIdle ||= this.effects.has(action);
+          }
+          return false;
+        }
         const nextEligibleAt = this.getNextEligibleRunTime(action);
         if (
           nextEligibleAt !== undefined &&
           nextEligibleAt > performance.now()
         ) {
-          nextDirtyEffectRunAt = nextDirtyEffectRunAt === undefined
+          nextDirtyPullRunAt = nextDirtyPullRunAt === undefined
             ? nextEligibleAt
-            : Math.min(nextDirtyEffectRunAt, nextEligibleAt);
+            : Math.min(nextDirtyPullRunAt, nextEligibleAt);
+          nextDirtyPullRunWaitsForIdle ||= this.effects.has(action);
           return false;
         }
         return true;
       });
     const hasQueuedEventReadyNow = this.eventQueue.length > 0 &&
       !this.isHeadEventParked();
+    const hasParkedHeadEvent = this.eventQueue.length > 0 &&
+      this.isHeadEventParked();
+    const shouldRerunAfterCurrentExecute = this.rerunAfterCurrentExecute;
+    this.rerunAfterCurrentExecute = false;
+    const hasImmediateRerunRequest = shouldRerunAfterCurrentExecute &&
+      nextDirtyPullRunAt === undefined;
 
-    if (!hasPendingEffects && !hasDirtyEffects && !hasQueuedEventReadyNow) {
-      if (nextDirtyEffectRunAt !== undefined) {
-        this.scheduleEventQueueWake(nextDirtyEffectRunAt);
+    if (
+      !hasImmediateRerunRequest &&
+      !hasPendingPullWork &&
+      !hasDirtyPullWork &&
+      !hasQueuedEventReadyNow
+    ) {
+      if (nextDirtyPullRunAt !== undefined) {
+        this.scheduleEventQueueWake(nextDirtyPullRunAt);
+        const promises = this.idlePromises;
+        if (!hasParkedHeadEvent && !nextDirtyPullRunWaitsForIdle) {
+          for (const resolve of promises) resolve();
+          this.idlePromises.length = 0;
+        }
         this.loopCounter = new WeakMap();
         this.scheduled = false;
       } else if (this.eventQueueWakeTimer !== null) {

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -1034,6 +1034,13 @@ export class Scheduler {
 
     this.updateChangeGroup(action, options);
 
+    // Track action type before rebuilding reverse dependencies. When a new
+    // edge is registered against an already-stale writer, the edge registration
+    // path needs to know whether this action is an effect or computation so it
+    // can schedule the downstream pull.
+    const actionIsEffect = this.updateActionType(action, isEffect);
+    const actionId = this.getActionId(action);
+
     const { reads, shallowReads, log: schedulingLog } = this.setDependencies(
       action,
       log,
@@ -1041,11 +1048,6 @@ export class Scheduler {
 
     // Update reverse dependency graph
     if (this.pullMode) this.updateDependents(action, schedulingLog);
-
-    // Track action type for pull-based scheduling
-    // Once an action is marked as an effect, it stays an effect
-    const actionIsEffect = this.updateActionType(action, isEffect);
-    const actionId = this.getActionId(action);
 
     // Track parent-child relationship if action is created during another action's execution
     // Only set if not already set (resubscribe can be called multiple times)
@@ -2153,6 +2155,14 @@ export class Scheduler {
 
     if (!alreadyDependent && this.isStale(writer)) {
       this.addStaleUpstream(writer, dependent);
+      if (this.pullMode) {
+        if (this.effects.has(dependent)) {
+          this.conditionallyScheduledEffects.delete(dependent);
+          this.scheduleWithDebounce(dependent);
+        } else if (this.computations.has(dependent)) {
+          this.scheduleAffectedEffects(dependent);
+        }
+      }
     }
   }
 

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -1034,13 +1034,6 @@ export class Scheduler {
 
     this.updateChangeGroup(action, options);
 
-    // Track action type before rebuilding reverse dependencies. When a new
-    // edge is registered against an already-stale writer, the edge registration
-    // path needs to know whether this action is an effect or computation so it
-    // can schedule the downstream pull.
-    const actionIsEffect = this.updateActionType(action, isEffect);
-    const actionId = this.getActionId(action);
-
     const { reads, shallowReads, log: schedulingLog } = this.setDependencies(
       action,
       log,
@@ -1048,6 +1041,11 @@ export class Scheduler {
 
     // Update reverse dependency graph
     if (this.pullMode) this.updateDependents(action, schedulingLog);
+
+    // Track action type for pull-based scheduling
+    // Once an action is marked as an effect, it stays an effect
+    const actionIsEffect = this.updateActionType(action, isEffect);
+    const actionId = this.getActionId(action);
 
     // Track parent-child relationship if action is created during another action's execution
     // Only set if not already set (resubscribe can be called multiple times)
@@ -2155,14 +2153,6 @@ export class Scheduler {
 
     if (!alreadyDependent && this.isStale(writer)) {
       this.addStaleUpstream(writer, dependent);
-      if (this.pullMode) {
-        if (this.effects.has(dependent)) {
-          this.conditionallyScheduledEffects.delete(dependent);
-          this.scheduleWithDebounce(dependent);
-        } else if (this.computations.has(dependent)) {
-          this.scheduleAffectedEffects(dependent);
-        }
-      }
     }
   }
 

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -2690,6 +2690,12 @@ export class SchemaObjectTraverser<V extends FabricValue>
     const docArray = doc.value as Immutable<FabricValue>[];
     const arrayObj = new Array<Immutable<FabricValue>>(docArray.length);
 
+    // Rendering or otherwise consuming a schema-backed array depends on its
+    // direct structure, not just the indices that exist right now. Record a
+    // shallow read of the array itself so appends/removes can demand lazy
+    // upstream computations in pull mode.
+    this.tx.read(doc.address, READ_NON_RECURSIVE_FOR_SCHEDULING);
+
     // We use `every` here so if our input is a sparse array, so is our output.
     const valid = docArray.every((item, index) => {
       const itemSchema = this.cfc.schemaAtPath(schema, [index.toString()]);

--- a/packages/runner/test/scheduler-pull.test.ts
+++ b/packages/runner/test/scheduler-pull.test.ts
@@ -56,6 +56,10 @@ describe("pull-based scheduling", () => {
     await storageManager?.close();
   });
 
+  it("should default to pull mode", () => {
+    expect(runtime.scheduler.isPullModeEnabled()).toBe(true);
+  });
+
   it("should have unchanged behavior with pullMode = false", async () => {
     // Explicitly set push mode for this test
     runtime.scheduler.disablePullMode();

--- a/packages/runner/test/scheduler-pull.test.ts
+++ b/packages/runner/test/scheduler-pull.test.ts
@@ -22,8 +22,32 @@ const space = signer.did();
 
 type StaleSchedulerInternals = {
   isStale: (action: Action) => boolean;
+  isDemandedPullComputation: (action: Action) => boolean;
   getUpstreamStaleCount: (action: Action) => number;
   clearDirectDirty: (action: Action) => boolean;
+  isEffectAction: WeakMap<Action, boolean>;
+  setDependencies: (
+    action: Action,
+    log: {
+      reads: ReturnType<typeof toMemorySpaceAddress>[];
+      shallowReads: ReturnType<typeof toMemorySpaceAddress>[];
+      writes: ReturnType<typeof toMemorySpaceAddress>[];
+    },
+  ) => {
+    log: {
+      reads: ReturnType<typeof toMemorySpaceAddress>[];
+      shallowReads: ReturnType<typeof toMemorySpaceAddress>[];
+      writes: ReturnType<typeof toMemorySpaceAddress>[];
+    };
+  };
+  updateDependents: (
+    action: Action,
+    log: {
+      reads: ReturnType<typeof toMemorySpaceAddress>[];
+      shallowReads: ReturnType<typeof toMemorySpaceAddress>[];
+      writes: ReturnType<typeof toMemorySpaceAddress>[];
+    },
+  ) => void;
   collectDirtyDependencies: (
     action: Action,
     workSet: Set<Action>,
@@ -56,8 +80,49 @@ describe("pull-based scheduling", () => {
     await storageManager?.close();
   });
 
-  it("should default to pull mode", () => {
-    expect(runtime.scheduler.isPullModeEnabled()).toBe(true);
+  it("should default to push mode", () => {
+    expect(runtime.scheduler.isPullModeEnabled()).toBe(false);
+  });
+
+  it("should dispatch schema-marked streams without a materialized stream marker", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const stream = runtime.getCell<{ amount: number }>(
+      space,
+      "schema-marked-stream-without-marker",
+      {
+        asCell: ["stream"],
+        type: "object",
+        properties: {
+          amount: { type: "number" },
+        },
+      } as JSONSchema,
+      tx,
+    );
+    const result = runtime.getCell<number>(
+      space,
+      "schema-marked-stream-result",
+      undefined,
+      tx,
+    );
+    result.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let handlerRuns = 0;
+    runtime.scheduler.addEventHandler(
+      (eventTx, event: { amount: number }) => {
+        handlerRuns++;
+        result.withTx(eventTx).send(event.amount);
+      },
+      stream.getAsNormalizedFullLink(),
+    );
+
+    stream.send({ amount: 7 });
+    await runtime.scheduler.idle();
+
+    expect(handlerRuns).toBe(1);
+    expect(await result.pull()).toBe(7);
   });
 
   it("should have unchanged behavior with pullMode = false", async () => {
@@ -564,6 +629,318 @@ describe("pull-based scheduling", () => {
 
     // Effect should have run (triggered via scheduleAffectedEffects)
     expect(effectRuns).toBeGreaterThan(initialEffectRuns);
+  });
+
+  it("should run dirty computations with live downstream effect demand", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const source = runtime.getCell<number>(
+      space,
+      "pull-demanded-dirty-source",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    const derived = runtime.getCell<number>(
+      space,
+      "pull-demanded-dirty-derived",
+      undefined,
+      tx,
+    );
+    derived.set(0);
+    const effectResult = runtime.getCell<number>(
+      space,
+      "pull-demanded-dirty-effect",
+      undefined,
+      tx,
+    );
+    effectResult.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let computationRuns = 0;
+    let effectRuns = 0;
+
+    const computation: Action = (actionTx) => {
+      computationRuns++;
+      derived.withTx(actionTx).send(
+        (source.withTx(actionTx).get() ?? 0) * 10,
+      );
+    };
+
+    const effect: Action = (actionTx) => {
+      effectRuns++;
+      effectResult.withTx(actionTx).send(
+        (derived.withTx(actionTx).get() ?? 0) + 5,
+      );
+    };
+
+    runtime.scheduler.subscribe(
+      computation,
+      {
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(derived.getAsNormalizedFullLink())],
+      },
+      {},
+    );
+    runtime.scheduler.subscribe(
+      effect,
+      {
+        reads: [toMemorySpaceAddress(derived.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(effectResult.getAsNormalizedFullLink())],
+      },
+      { isEffect: true },
+    );
+
+    await runtime.scheduler.idle();
+
+    expect(computationRuns).toBe(1);
+    expect(effectRuns).toBe(1);
+    expect(effectResult.get()).toBe(15);
+
+    source.withTx(tx).send(2);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const schedulerInternal = runtime.scheduler as unknown as {
+      pending: Set<Action>;
+      dirty: Set<Action>;
+      markDirty: (action: Action) => void;
+    };
+    schedulerInternal.pending.delete(effect);
+    schedulerInternal.dirty.delete(effect);
+    schedulerInternal.markDirty(computation);
+    runtime.scheduler.queueExecution();
+
+    await runtime.scheduler.idle();
+
+    expect(computationRuns).toBe(2);
+    expect(effectRuns).toBe(2);
+    expect(effectResult.get()).toBe(25);
+  });
+
+  it("should demand dirty computations from dependency-bearing live effects", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const source = runtime.getCell<number>(
+      space,
+      "pull-demand-live-effect-source",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    const derived = runtime.getCell<number>(
+      space,
+      "pull-demand-live-effect-derived",
+      undefined,
+      tx,
+    );
+    derived.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let computationRuns = 0;
+    const computation: Action = (actionTx) => {
+      computationRuns++;
+      derived.withTx(actionTx).send(source.withTx(actionTx).get() ?? 0);
+    };
+
+    runtime.scheduler.subscribe(
+      computation,
+      {
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(derived.getAsNormalizedFullLink())],
+      },
+      {},
+    );
+
+    const effect: Action = (actionTx) => {
+      derived.withTx(actionTx).get();
+    };
+    const schedulerInternal = runtime
+      .scheduler as unknown as StaleSchedulerInternals;
+    schedulerInternal.isEffectAction.set(effect, true);
+    const { log } = schedulerInternal.setDependencies(effect, {
+      reads: [toMemorySpaceAddress(derived.getAsNormalizedFullLink())],
+      shallowReads: [],
+      writes: [],
+    });
+    schedulerInternal.updateDependents(effect, log);
+
+    expect(schedulerInternal.isDemandedPullComputation(computation)).toBe(
+      true,
+    );
+
+    await runtime.scheduler.idle();
+
+    expect(computationRuns).toBe(1);
+    expect(derived.get()).toBe(1);
+  });
+
+  it("should discover writes for new child computations in demanded subgraphs", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const source = runtime.getCell<number>(
+      space,
+      "pull-demanded-child-source",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    const parentResult = runtime.getCell<number>(
+      space,
+      "pull-demanded-child-parent-result",
+      undefined,
+      tx,
+    );
+    parentResult.set(0);
+    const childResult = runtime.getCell<number>(
+      space,
+      "pull-demanded-child-result",
+      undefined,
+      tx,
+    );
+    childResult.set(0);
+    const effectResult = runtime.getCell<number>(
+      space,
+      "pull-demanded-child-effect",
+      undefined,
+      tx,
+    );
+    effectResult.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let childSubscribed = false;
+    let parentRuns = 0;
+    let childRuns = 0;
+    let effectRuns = 0;
+
+    const child: Action = (actionTx) => {
+      childRuns++;
+      childResult.withTx(actionTx).send(
+        (source.withTx(actionTx).get() ?? 0) * 10,
+      );
+    };
+
+    const parent: Action = (actionTx) => {
+      parentRuns++;
+      parentResult.withTx(actionTx).send(source.withTx(actionTx).get() ?? 0);
+      if (!childSubscribed) {
+        childSubscribed = true;
+        runtime.scheduler.subscribe(
+          child,
+          {
+            reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+            shallowReads: [],
+            writes: [],
+          },
+          {},
+        );
+      }
+    };
+
+    const effect: Action = (actionTx) => {
+      effectRuns++;
+      effectResult.withTx(actionTx).send(
+        (parentResult.withTx(actionTx).get() ?? 0) +
+          (childResult.withTx(actionTx).get() ?? 0),
+      );
+    };
+
+    runtime.scheduler.subscribe(
+      parent,
+      {
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(parentResult.getAsNormalizedFullLink())],
+      },
+      {},
+    );
+    runtime.scheduler.subscribe(
+      effect,
+      {
+        reads: [
+          toMemorySpaceAddress(parentResult.getAsNormalizedFullLink()),
+          toMemorySpaceAddress(childResult.getAsNormalizedFullLink()),
+        ],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(effectResult.getAsNormalizedFullLink())],
+      },
+      { isEffect: true },
+    );
+
+    await runtime.scheduler.idle();
+
+    expect(parentRuns).toBe(1);
+    expect(childRuns).toBe(1);
+    expect(effectRuns).toBeGreaterThanOrEqual(2);
+    expect(effectResult.get()).toBe(11);
+  });
+
+  it("should first-run child computations created by demand-root effects", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const source = runtime.getCell<number>(
+      space,
+      "pull-demanded-effect-child-source",
+      undefined,
+      tx,
+    );
+    source.set(3);
+    const childResult = runtime.getCell<number>(
+      space,
+      "pull-demanded-effect-child-result",
+      undefined,
+      tx,
+    );
+    childResult.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let effectRuns = 0;
+    let childRuns = 0;
+    let childSubscribed = false;
+
+    const child: Action = (actionTx) => {
+      childRuns++;
+      childResult.withTx(actionTx).send(
+        (source.withTx(actionTx).get() ?? 0) * 10,
+      );
+    };
+
+    const effect: Action = () => {
+      effectRuns++;
+      if (!childSubscribed) {
+        childSubscribed = true;
+        runtime.scheduler.subscribe(
+          child,
+          {
+            reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+            shallowReads: [],
+            writes: [
+              toMemorySpaceAddress(childResult.getAsNormalizedFullLink()),
+            ],
+          },
+          {},
+        );
+      }
+    };
+
+    runtime.scheduler.subscribe(
+      effect,
+      { reads: [], shallowReads: [], writes: [] },
+      { isEffect: true },
+    );
+
+    await runtime.scheduler.idle();
+
+    expect(effectRuns).toBe(1);
+    expect(childRuns).toBe(1);
+    expect(childResult.get()).toBe(30);
   });
 
   it("should collect shared dirty dependencies consistently across effect seeds", async () => {
@@ -3254,6 +3631,38 @@ describe("pull mode array reactivity", () => {
     // Verify sink was called with updated array
     expect(sinkValues.length).toBe(2);
     expect(sinkValues[1]).toEqual(["a", "b", "c"]);
+
+    cancel();
+  });
+
+  it("should record schema array sinks as shallow structural reads", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const arrayCell = runtime.getCell<string[]>(
+      space,
+      "schema-array-structural-sink",
+      { type: "array", items: { type: "string" } },
+      tx,
+    );
+    arrayCell.set(["a", "b"]);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const cancel = arrayCell.withTx(tx).sink(() => {});
+    await runtime.scheduler.idle();
+
+    const link = arrayCell.getAsNormalizedFullLink();
+    const expectedAddress = toMemorySpaceAddress(link);
+    const expectedRead = `${expectedAddress.space}/${expectedAddress.id}/${
+      expectedAddress.path.join("/")
+    }`;
+    const graph = runtime.scheduler.getGraphSnapshot();
+    const sinkNode = graph.nodes.find((node) =>
+      node.type === "effect" &&
+      node.id.startsWith(`sink:${link.space}/${link.id}/`)
+    );
+
+    expect(sinkNode?.shallowReads ?? []).toContain(expectedRead);
 
     cancel();
   });

--- a/packages/runner/test/scheduler-timing.test.ts
+++ b/packages/runner/test/scheduler-timing.test.ts
@@ -631,6 +631,91 @@ describe("debounce and throttling", () => {
     expect(runtime.scheduler.getDebounce(slowCycling)).toBeUndefined();
   });
 
+  it("should not cycle-debounce pull computations with live effect demand", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const counter = runtime.getCell<number>(
+      space,
+      "no-cycle-debounce-computation-counter",
+      undefined,
+      tx,
+    );
+    const output = runtime.getCell<number>(
+      space,
+      "no-cycle-debounce-computation-output",
+      undefined,
+      tx,
+    );
+    const sink = runtime.getCell<number>(
+      space,
+      "no-cycle-debounce-computation-sink",
+      undefined,
+      tx,
+    );
+    counter.set(0);
+    output.set(0);
+    sink.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let producerRuns = 0;
+    let feedbackRuns = 0;
+
+    const producer: Action = async (actionTx) => {
+      producerRuns++;
+      await new Promise((resolve) => setTimeout(resolve, 35));
+      output.withTx(actionTx).send(counter.withTx(actionTx).get() ?? 0);
+    };
+
+    const feedback: Action = async (actionTx) => {
+      feedbackRuns++;
+      await new Promise((resolve) => setTimeout(resolve, 35));
+      const value = output.withTx(actionTx).get() ?? 0;
+      if (value < 3) {
+        counter.withTx(actionTx).send(value + 1);
+      }
+    };
+
+    const effect: Action = (actionTx) => {
+      sink.withTx(actionTx).send(output.withTx(actionTx).get() ?? 0);
+    };
+
+    runtime.scheduler.subscribe(
+      producer,
+      {
+        reads: [toMemorySpaceAddress(counter.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
+      },
+      {},
+    );
+    runtime.scheduler.subscribe(
+      feedback,
+      {
+        reads: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(counter.getAsNormalizedFullLink())],
+      },
+      {},
+    );
+    runtime.scheduler.subscribe(
+      effect,
+      {
+        reads: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(sink.getAsNormalizedFullLink())],
+      },
+      { isEffect: true },
+    );
+
+    await runtime.scheduler.idle();
+
+    expect(producerRuns).toBeGreaterThanOrEqual(3);
+    expect(feedbackRuns).toBeGreaterThanOrEqual(3);
+    expect(runtime.scheduler.getDebounce(producer)).toBeUndefined();
+    expect(runtime.scheduler.getDebounce(feedback)).toBeUndefined();
+  });
+
   it("should only increase debounce if cycle debounce is larger than existing", async () => {
     // If an action already has a higher debounce set (manually or from previous
     // cycle debounce), the cycle-aware mechanism should not reduce it.


### PR DESCRIPTION
## Summary

- Fix pull-mode demand propagation without enabling pull mode by default; the scheduler default remains push mode.
- Keep mounted/rendered pull subgraphs lazy by running only computations with live downstream effect demand, plus first-run child computations created inside demanded pull executions.
- Preserve lazy pull-mode behavior for ordinary `map`/`filter`/`flatMap`; this PR does not make map globally eager.
- Prevent adaptive cycle debounce from being applied to pull computations that feed live rendered demand, so rapid notebook row materialization cannot remain one item behind a debounce timer.
- Add regression coverage for rapid notebook note creation, schema-backed array structural reads, schema-marked streams, pull-demanded computation scheduling, live-effect resubscribe demand, and non-debounced demanded pull computations.

## Implementation Notes

- The notebook bug was a demand-propagation/timing gap in pull mode. Rapid `Create Another` writes updated notebook data and the counter, but some note-row/map computations could remain dirty while the rendered effect was still live.
- The fix does not make `map`, `filter`, or `flatMap` eager. Instead, pull mode now runs only computations that have transitive downstream effect demand, plus first-run child computations created while a demanded pull execution is active. That lets mounted UI catch up while unobserved mapped work stays lazy.
- Resubscribe restores effect classification before rebuilding reverse dependency edges, and dependency-bearing historical effects count as live during that narrow resubscribe window. Registering a new edge to a live sink can therefore immediately make stale upstream computations demanded instead of leaving the scheduler idle with dirty rendered work.
- Cycle-aware debounce now applies only to effects. Pull computations are already gated by demand, and debouncing them can leave rendered materialized data stale until an arbitrary timer fires.
- Schema-backed array traversal records a shallow structural read, so appends/removes invalidate the rendered list shape without recursively forcing every item.
- The rapid notebook integration regression explicitly enables pull mode for that test so this fix remains covered even though the default flag flip is intentionally left for a separate PR.

## Validation

- `deno fmt --check packages/runner/src/scheduler.ts packages/runner/test/scheduler-timing.test.ts packages/runner/test/scheduler-pull.test.ts packages/patterns/integration/default-app.test.ts`
- `deno test -A packages/runner/test/scheduler-timing.test.ts`
- `deno test -A packages/runner/test/scheduler-pull.test.ts`
- `HEADLESS=1 API_URL=http://localhost:8124/ FRONTEND_URL=http://localhost:5297 deno test --v8-flags=--max-old-space-size=4096 --trace-leaks -A --junit-path=/tmp/patterns-2-local-after-live-effect-fix.xml ./integration/cfc-spec-gallery.test.ts ./integration/chat-note.test.ts ./integration/default-app.test.ts ./integration/fetch-data.test.ts ./integration/instantiate-pattern.test.ts` from `packages/patterns`
- `deno task check`

## Performance Baselines

NEW_PERF_BASELINE: job: Pattern Integration Tests (2/4) = 132s

