### PR TITLE
ci: shard pattern integration tests

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -290,10 +290,15 @@ jobs:
         run: cat ~/.cf/fuse/fuse-daemon.log 2>/dev/null || echo "No daemon log found"
 
   pattern-integration-test:
-    name: "Pattern Integration Tests"
+    name: "Pattern Integration Tests (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
     needs: ["build-binaries"]
     environment: ci
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+        total: [4]
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
@@ -318,17 +323,21 @@ jobs:
       - name: 🧩 Run end-to-end patterns integration tests
         working-directory: packages/patterns
         run: |
+          mapfile -t TEST_FILES < <(deno run --allow-read ../../tasks/select-pattern-integration-files.ts ${{ matrix.shard }}/${{ matrix.total }})
+          printf 'Pattern integration shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
+          printf '  %s\n' "${TEST_FILES[@]}"
           mkdir -p ../../test-results
           HEADLESS=1 \
           API_URL=http://localhost:8000/ \
-          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/patterns.xml" \
-          deno task integration
+          deno test --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
+            --junit-path=../../test-results/patterns-${{ matrix.shard }}.xml \
+            "${TEST_FILES[@]}"
 
       - name: 📤 Upload test timing data
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-timing-pattern-integration
+          name: test-timing-pattern-integration-${{ matrix.shard }}
           path: test-results/
           retention-days: 90
           if-no-files-found: ignore

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -41,6 +41,7 @@ import {
   readAndParseEvent,
   REPO,
   STDDEV_FACTOR,
+  timingArtifactLabel,
   type TimingSample,
   TOKEN,
   WORKFLOW_FILE,
@@ -126,7 +127,7 @@ async function main() {
       const suites = await downloadAndParseJUnit(artifact.id);
       const testMetrics = extractTestFileMetrics(
         currentRunInfo,
-        artifact.name.replace("test-timing-", ""),
+        timingArtifactLabel(artifact.name),
         suites,
       );
       for (const [name, sample] of testMetrics) {
@@ -191,7 +192,7 @@ async function main() {
         if (suites.length > 0) {
           const testMetrics = extractTestFileMetrics(
             run,
-            artifact.name.replace("test-timing-", ""),
+            timingArtifactLabel(artifact.name),
             suites,
           );
           for (const [name, sample] of testMetrics) {

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -6,6 +6,7 @@ import {
   githubGet,
   type Job,
   type Step,
+  timingArtifactLabel,
   type WorkflowRun,
 } from "./perf-lib.ts";
 
@@ -86,6 +87,65 @@ Deno.test("extractMetrics keeps CLI core and fuse timings separate", () => {
   );
   assertEquals(metrics.has("job: CLI Integration Tests"), false);
   assertEquals(metrics.has("step: CLI integration"), false);
+});
+
+Deno.test("extractMetrics aggregates pattern integration matrix shards", () => {
+  const metrics = extractMetrics(makeRun(), [
+    makeJob(
+      1,
+      "Pattern Integration Tests (1/4)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:40Z",
+      [
+        makeStep(
+          "🧩 Run end-to-end patterns integration tests",
+          "2026-01-01T00:00:10Z",
+          "2026-01-01T00:01:30Z",
+        ),
+      ],
+    ),
+    makeJob(
+      2,
+      "Pattern Integration Tests (2/4)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:10Z",
+      [
+        makeStep(
+          "🧩 Run end-to-end patterns integration tests",
+          "2026-01-01T00:00:10Z",
+          "2026-01-01T00:01:00Z",
+        ),
+      ],
+    ),
+  ]);
+
+  assertEquals(
+    metrics.get("job: Pattern Integration Tests (1/4)")?.durationSeconds,
+    100,
+  );
+  assertEquals(
+    metrics.get("job: Pattern Integration Tests (2/4)")?.durationSeconds,
+    70,
+  );
+  assertEquals(
+    metrics.get("job: Pattern Integration Tests")?.durationSeconds,
+    100,
+  );
+  assertEquals(
+    metrics.get("step: patterns integration")?.durationSeconds,
+    80,
+  );
+});
+
+Deno.test("timingArtifactLabel normalizes pattern integration shard artifacts", () => {
+  assertEquals(
+    timingArtifactLabel("test-timing-pattern-integration-1"),
+    "pattern-integration",
+  );
+  assertEquals(
+    timingArtifactLabel("test-timing-package-integration"),
+    "package-integration",
+  );
 });
 
 Deno.test("computeBaseline enforces the 15 percent floor for low-variance samples", () => {

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -533,6 +533,11 @@ export const JOB_TO_LABEL: Record<string, string> = {
   "Generated Patterns Integration Tests": "generated-patterns",
 };
 
+export function timingArtifactLabel(artifactName: string): string {
+  const label = artifactName.replace(/^test-timing-/, "");
+  return label.replace(/^pattern-integration-\d+$/, "pattern-integration");
+}
+
 // ---------------------------------------------------------------------------
 // Benchmark results parsing
 // ---------------------------------------------------------------------------
@@ -604,6 +609,8 @@ const JOB_METRIC_NAMES: Record<string, string> = {
 
 /** Pattern for matrix jobs like "Pattern Unit Tests (1/5)". */
 export const PATTERN_UNIT_RE = /Pattern Unit Tests\s*\((\d+)\/(\d+)\)/;
+export const PATTERN_INTEGRATION_RE =
+  /Pattern Integration Tests\s*\((\d+)\/(\d+)\)/;
 
 interface StepMetricMatcher {
   jobName: string;
@@ -693,6 +700,13 @@ export function extractMetrics(
     durationSeconds: duration,
   });
 
+  const setMaxMetric = (name: string, sample: TimingSample) => {
+    const existing = metrics.get(name);
+    if (!existing || sample.durationSeconds > existing.durationSeconds) {
+      metrics.set(name, sample);
+    }
+  };
+
   for (const job of jobs) {
     const jobDuration = durationSeconds(job.started_at, job.completed_at);
     if (jobDuration <= 0) continue;
@@ -704,16 +718,33 @@ export function extractMetrics(
       metrics.set(jobMetricName, makeSample(jobDuration));
     }
 
-    const matcherJobName = normalizedJobName.startsWith("Pattern Unit Tests")
+    const unitMatch = PATTERN_UNIT_RE.exec(normalizedJobName);
+    const patternIntegrationMatch = PATTERN_INTEGRATION_RE.exec(
+      normalizedJobName,
+    );
+
+    const matcherJobName = unitMatch
       ? "Pattern Unit Tests"
+      : patternIntegrationMatch
+      ? "Pattern Integration Tests"
       : normalizedJobName;
 
-    const unitMatch = PATTERN_UNIT_RE.exec(normalizedJobName);
     if (unitMatch) {
       metrics.set(
         `job: Pattern Unit Tests (${unitMatch[1]}/${unitMatch[2]})`,
         makeSample(jobDuration),
       );
+    }
+
+    if (patternIntegrationMatch) {
+      const sample = makeSample(jobDuration);
+      metrics.set(
+        `job: Pattern Integration Tests (${patternIntegrationMatch[1]}/${
+          patternIntegrationMatch[2]
+        })`,
+        sample,
+      );
+      setMaxMetric("job: Pattern Integration Tests", sample);
     }
 
     if (normalizedJobName.includes("Test and Build")) {
@@ -730,7 +761,12 @@ export function extractMetrics(
           matcher.jobName === matcherJobName &&
           normalizedStepName.includes(matcher.stepKeyword)
         ) {
-          metrics.set(matcher.metricName, makeSample(stepDuration));
+          const sample = makeSample(stepDuration);
+          if (patternIntegrationMatch) {
+            setMaxMetric(matcher.metricName, sample);
+          } else {
+            metrics.set(matcher.metricName, sample);
+          }
         }
       }
     }

--- a/tasks/perf-regression.ts
+++ b/tasks/perf-regression.ts
@@ -59,6 +59,7 @@ import {
   type Regression,
   REPO,
   STDDEV_FACTOR,
+  timingArtifactLabel,
   TOKEN,
   WORKFLOW_FILE,
   type WorkflowRun,
@@ -459,7 +460,7 @@ async function main() {
               artifactRunsProcessed++;
               const testMetrics = extractTestFileMetrics(
                 run,
-                artifact.name.replace("test-timing-", ""),
+                timingArtifactLabel(artifact.name),
                 suites,
               );
               for (const [name, sample] of testMetrics) {

--- a/tasks/select-pattern-integration-files.test.ts
+++ b/tasks/select-pattern-integration-files.test.ts
@@ -1,0 +1,42 @@
+import { assertEquals } from "@std/assert";
+import {
+  parseShard,
+  shardForPatternIntegrationFile,
+  stableShardForName,
+} from "./select-pattern-integration-files.ts";
+
+Deno.test("parseShard parses shard notation", () => {
+  assertEquals(parseShard("2/4"), { index: 2, total: 4 });
+});
+
+Deno.test("parseShard rejects invalid shard notation", () => {
+  try {
+    parseShard("5/4");
+    throw new Error("expected parseShard to throw");
+  } catch (error) {
+    assertEquals(
+      (error as Error).message,
+      "Shard index 5 exceeds total shard count 4",
+    );
+  }
+});
+
+Deno.test("pattern integration four-way shard keeps slow files balanced", () => {
+  assertEquals(shardForPatternIntegrationFile("all.test.ts", 4), 1);
+  assertEquals(
+    shardForPatternIntegrationFile("cfc-spec-gallery.test.ts", 4),
+    2,
+  );
+  assertEquals(
+    shardForPatternIntegrationFile("cfc-authorized-save.test.ts", 4),
+    3,
+  );
+  assertEquals(shardForPatternIntegrationFile("nested-counter.test.ts", 4), 4);
+});
+
+Deno.test("unknown pattern integration files are assigned deterministically", () => {
+  assertEquals(
+    shardForPatternIntegrationFile("new-test-file.test.ts", 4),
+    stableShardForName("new-test-file.test.ts", 4),
+  );
+});

--- a/tasks/select-pattern-integration-files.ts
+++ b/tasks/select-pattern-integration-files.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env -S deno run --allow-read
+
+type Shard = {
+  index: number;
+  total: number;
+};
+
+const FOUR_SHARD_ASSIGNMENTS: Record<string, number> = {
+  "all.test.ts": 1,
+
+  "cfc-spec-gallery.test.ts": 2,
+  "default-app.test.ts": 2,
+  "chat-note.test.ts": 2,
+  "fetch-data.test.ts": 2,
+  "instantiate-pattern.test.ts": 2,
+
+  "cfc-authorized-save.test.ts": 3,
+  "cfc-staged-publish.test.ts": 3,
+  "cfc-render-policy-demo.test.ts": 3,
+  "llm.test.ts": 3,
+
+  "nested-counter.test.ts": 4,
+  "counter.test.ts": 4,
+  "cfc-authorship-chat.test.ts": 4,
+  "chatbot.test.ts": 4,
+};
+
+export function parseShard(raw: string): Shard {
+  const match = raw.match(/^([1-9][0-9]*)\/([1-9][0-9]*)$/);
+  if (!match) {
+    throw new Error(`Expected shard argument like 1/4, got: ${raw}`);
+  }
+
+  const index = Number(match[1]);
+  const total = Number(match[2]);
+  if (index > total) {
+    throw new Error(`Shard index ${index} exceeds total shard count ${total}`);
+  }
+
+  return { index, total };
+}
+
+export function stableShardForName(name: string, total: number): number {
+  let hash = 2166136261;
+  for (const char of name) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) % total + 1;
+}
+
+export function shardForPatternIntegrationFile(
+  name: string,
+  total: number,
+): number {
+  if (total === 4 && FOUR_SHARD_ASSIGNMENTS[name]) {
+    return FOUR_SHARD_ASSIGNMENTS[name];
+  }
+  return stableShardForName(name, total);
+}
+
+async function listPatternIntegrationTests(): Promise<string[]> {
+  const integrationDir = new URL(
+    "../packages/patterns/integration/",
+    import.meta.url,
+  );
+  const files: string[] = [];
+
+  for await (const entry of Deno.readDir(integrationDir)) {
+    if (entry.isFile && entry.name.endsWith(".test.ts")) {
+      files.push(entry.name);
+    }
+  }
+
+  files.sort();
+  return files;
+}
+
+if (import.meta.main) {
+  const shard = parseShard(Deno.args[0] ?? "");
+  const files = await listPatternIntegrationTests();
+  const selected = files
+    .filter((name) =>
+      shardForPatternIntegrationFile(name, shard.total) === shard.index
+    )
+    .map((name) => `./integration/${name}`);
+
+  if (selected.length === 0) {
+    throw new Error(
+      `No pattern integration files selected for ${Deno.args[0]}`,
+    );
+  }
+
+  console.log(selected.join("\n"));
+}


### PR DESCRIPTION
## Why

The Deno workflow is still gated by the `Pattern Integration Tests` job. The latest post-merge main run spent about 4m38s inside that test step and about 5m total in the job. The JUnit timing artifact shows the suite has a few large files (`all.test.ts`, `cfc-spec-gallery.test.ts`, trusted CFC flows, counter flows) that can run independently in separate GitHub jobs.

Sharding this suite should reduce the critical path while preserving coverage and keeping future new `packages/patterns/integration/*.test.ts` files included automatically.

## What Changed

- Runs `Pattern Integration Tests` as a four-way matrix.
- Adds `tasks/select-pattern-integration-files.ts` to choose balanced shards from recent timing data, with deterministic fallback assignment for new files.
- Gives each shard a unique timing artifact name and normalizes those artifact labels back to `pattern-integration` for perf-check/regression baselines.
- Aggregates pattern integration matrix job/step metrics by max shard duration so the existing performance metric names keep working.

## Test plan

- `deno fmt .github/workflows/deno.yml tasks/select-pattern-integration-files.ts tasks/select-pattern-integration-files.test.ts tasks/perf-lib.ts tasks/perf-lib.test.ts tasks/perf-check.ts tasks/perf-regression.ts`
- `deno test --allow-read --allow-env tasks/select-pattern-integration-files.test.ts tasks/perf-lib.test.ts`
- `deno lint tasks/select-pattern-integration-files.ts tasks/select-pattern-integration-files.test.ts tasks/perf-lib.ts tasks/perf-lib.test.ts tasks/perf-check.ts tasks/perf-regression.ts`
- `deno check tasks/select-pattern-integration-files.ts tasks/perf-lib.ts tasks/perf-check.ts tasks/perf-regression.ts`
- Ruby YAML loader parse check: `yaml ok`