### PR TITLE
ci: accept tag or SHA in manual production deployment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,8 +3,8 @@ name: Manual Production Deployment
 on:
   workflow_dispatch:
     inputs:
-      commit_sha:
-        description: "Git commit SHA to deploy"
+      ref:
+        description: "Git commit SHA or tag to deploy"
         required: true
         type: string
 
@@ -15,15 +15,17 @@ jobs:
     environment: estuary # Protection rules configured in GitHub repo settings
 
     steps:
-      - name: 📥 Checkout specific commit
+      - name: 📥 Checkout specific ref
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.commit_sha }}
+          ref: ${{ github.event.inputs.ref }}
 
-      - name: 🔍 Validate commit SHA
+      - name: 🔍 Resolve ref to commit SHA
+        id: resolve
         run: |
-          echo "Deploying commit: ${{ github.event.inputs.commit_sha }}"
-          git rev-parse --verify ${{ github.event.inputs.commit_sha }}
+          SHA=$(git rev-parse HEAD)
+          echo "Deploying ref: ${{ github.event.inputs.ref }} (commit: $SHA)"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
       # Download the artifacts for this specific SHA from the artifact storage
       - name: 🔑 Authenticate to Google Cloud
@@ -37,11 +39,11 @@ jobs:
       - name: 📥 Download tarball from GCS
         run: |
           mkdir -p downloaded-artifacts
-          gsutil cp gs://commontools-build-artifacts/workspace-artifacts/labs-${{ github.event.inputs.commit_sha }}.tar.gz downloaded-artifacts/
+          gsutil cp gs://commontools-build-artifacts/workspace-artifacts/labs-${{ steps.resolve.outputs.sha }}.tar.gz downloaded-artifacts/
 
           # Verify the tarball exists
-          if [ ! -f downloaded-artifacts/labs-${{ github.event.inputs.commit_sha }}.tar.gz ]; then
-            echo "::error::Artifact tarball for commit ${{ github.event.inputs.commit_sha }} not found!"
+          if [ ! -f downloaded-artifacts/labs-${{ steps.resolve.outputs.sha }}.tar.gz ]; then
+            echo "::error::Artifact tarball for commit ${{ steps.resolve.outputs.sha }} not found!"
             echo "Make sure this commit was successfully built and artifacts were uploaded."
             exit 1
           fi
@@ -58,4 +60,4 @@ jobs:
           host: ${{ secrets.BASTION_HOST }}
           username: bastion
           key: ${{ secrets.BASTION_SSH_PRIVATE_KEY }}
-          script: /opt/cf/deploy.sh ${{ vars.DEPLOYMENT_ENVIRONMENT }} ${{ github.event.inputs.commit_sha }}
+          script: /opt/cf/deploy.sh ${{ vars.DEPLOYMENT_ENVIRONMENT }} ${{ steps.resolve.outputs.sha }}


### PR DESCRIPTION
## Why

The Manual Production Deployment workflow only accepts a commit SHA, which is awkward when we want to deploy a release tag — you have to look up the SHA the tag points at and paste that in. This change lets the operator paste either form into the **Run workflow** dialog.

## ⚠️ Breaking change

The `workflow_dispatch` input is **renamed from `commit_sha` to `ref`**. Anyone dispatching this workflow via the GitHub API or `gh workflow run --field commit_sha=…` will break and must update the field name to `ref`. The manual GitHub UI is unaffected beyond a relabeled field. There is no backwards-compat alias; if we discover a caller that relies on `commit_sha`, we'll need to add one.

## What Changed

- Renamed input `commit_sha` → `ref`; description now reads "Git commit SHA or tag to deploy".
- `actions/checkout@v4` already accepts SHA / branch / tag for `ref:`, so no extra resolution is needed there.
- Replaced the old `git rev-parse --verify <sha>` validation step with a "Resolve ref to commit SHA" step that captures `git rev-parse HEAD` into `steps.resolve.outputs.sha`. Invalid refs already fail at the checkout step, so the explicit verify was redundant.
- All downstream consumers (artifact filename `labs-<sha>.tar.gz`, GCS download, error message, `deploy.sh <env> <sha>` over SSH) now reference the resolved SHA — a tag input still produces the right artifact path, and the deploy log records the commit that was actually shipped rather than the tag name.

## Test plan

- [ ] Dispatch the workflow with a known-good commit SHA (existing flow); confirms the rename didn't regress the SHA path.
- [ ] Dispatch the workflow with a release tag pointing at the same commit; confirm the resolve step prints the expected SHA, the GCS download succeeds, and `deploy.sh` is invoked with the SHA (not the tag).
- [ ] Dispatch with a bogus ref; confirm the checkout step fails fast with a clear error.