### PR TITLE
fix: schema-generator transitive-dep strict-mode errors

### DIFF
--- a/packages/content-hash/src/sha256-wasm.ts
+++ b/packages/content-hash/src/sha256-wasm.ts
@@ -53,7 +53,7 @@ let moduleIsUsable: boolean = false;
  * Gets and initializes the unique one-shot hasher instance.
  */
 function getOneShotHasher(): IHasher {
-  const result = theOneShotHasher[0];
+  const result = theOneShotHasher[0]!;
   result.init();
   return result;
 }

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -146,7 +146,7 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
   }
 
   // Determine sign from the high bit of the first byte.
-  const negative = (bytes[0] & 0x80) !== 0;
+  const negative = (bytes[0]! & 0x80) !== 0;
 
   // Fast path: use DataView.getBigUint64() for values that fit in 8 bytes.
   if (bytes.length <= 8) {
@@ -160,7 +160,7 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
   // Fallback: per-byte shift loop for larger values.
   let result = 0n;
   for (let i = 0; i < bytes.length; i++) {
-    result = (result << 8n) | BigInt(bytes[i]);
+    result = (result << 8n) | BigInt(bytes[i]!);
   }
 
   if (!negative) {

--- a/packages/data-model/value-hash.ts
+++ b/packages/data-model/value-hash.ts
@@ -167,7 +167,7 @@ function getStringRep(value: string) {
  */
 function feedLength(hasher: IncrementalHasher, value: number): void {
   const valueBuf = (value <= MAX_CACHED_SMALL_LENGTH)
-    ? smallLengthCache[value]
+    ? smallLengthCache[value]!
     : encodeULEB128(value);
 
   hasher.update(valueBuf);

--- a/packages/leb128/mod.ts
+++ b/packages/leb128/mod.ts
@@ -74,7 +74,7 @@ export function decodeULEB128(
     if (index >= buffer.length) {
       throw new Error("decodeULEB128: unexpected end of buffer");
     }
-    byte = buffer[index];
+    byte = buffer[index]!;
     // At shift 28, only 4 bits remain in a 32-bit value; reject if
     // the payload bits would overflow.
     if (shift >= 28 && (byte & 0x7f) > 0x0f) {
@@ -152,7 +152,7 @@ export function decodeSLEB128(
     if (index >= buffer.length) {
       throw new Error("decodeSLEB128: unexpected end of buffer");
     }
-    byte = buffer[index];
+    byte = buffer[index]!;
     if (shift >= 35) {
       throw new Error("decodeSLEB128: value exceeds signed 32-bit range");
     }

--- a/packages/utils/src/base64url.ts
+++ b/packages/utils/src/base64url.ts
@@ -48,7 +48,7 @@ export function toBase64Polyfill(bytes: Uint8Array): string {
 
   // Process 3 bytes at a time -> 4 base64 chars.
   for (; i + 2 < len; i += 3) {
-    const n = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+    const n = (bytes[i]! << 16) | (bytes[i + 1]! << 8) | bytes[i + 2]!;
     result += B64_CHARS[(n >> 18) & 0x3f];
     result += B64_CHARS[(n >> 12) & 0x3f];
     result += B64_CHARS[(n >> 6) & 0x3f];
@@ -57,11 +57,11 @@ export function toBase64Polyfill(bytes: Uint8Array): string {
 
   // Handle remaining 1 or 2 bytes (no padding appended).
   if (i < len) {
-    const n1 = bytes[i];
+    const n1 = bytes[i]!;
     result += B64_CHARS[(n1 >> 2) & 0x3f];
     if (i + 1 < len) {
       // 2 remaining bytes -> 3 base64 chars.
-      const n2 = bytes[i + 1];
+      const n2 = bytes[i + 1]!;
       result += B64_CHARS[((n1 & 0x03) << 4) | ((n2 >> 4) & 0x0f)];
       result += B64_CHARS[(n2 & 0x0f) << 2];
     } else {


### PR DESCRIPTION
Fixes 15 pre-existing `noUncheckedIndexedAccess` strict-mode type errors in transitive deps of `@commonfabric/data-model`. The errors only surface when `schema-generator` (or another package with strict tsconfig) imports from data-model — they've been latent because `schema-generator`'s strict tsconfig propagates to transitively-imported files only under `deno check --all`, and the workspace-root `deno task check` doesn't include the affected packages in its DIRS list (per `tasks.md:1296-1349`).

This is the **prep PR** that gates 4 deferred follow-on sites: 3 `schema-generator` `internSchema()`-identity-dedup sites at `common-fabric-formatter.ts:1725` + `union-formatter.ts:946,947` + `union-formatter.ts:909`, plus the Z4 `schema-generator/test/utils.ts:419` deep-clone site that was excluded from PR #3526's scope. Same-arc continuation of session 2026-072's `JSON.{parse,stringify}` cleanup arc — but the fix surface is type-checking, not call-site swaps.

### Files changed

5 files, +9/-9. All fixes are smallest-possible `!` non-null assertions on indexed accesses where surrounding logic guarantees safety:

- **`packages/utils/src/base64url.ts`** — 5 `!` covering 8 errors via cascading `n1`/`n2` narrowing in `toBase64Polyfill`. Three sites in the loop body at line 51 (guarded by `for (; i + 2 < len; i += 3)`); `n1 = bytes[i]!` at line 60 (guarded by `if (i < len)`); `n2 = bytes[i + 1]!` at line 64 (guarded by `if (i + 1 < len)`). Once `n1` and `n2` are non-undefined, the four downstream `B64_CHARS[…]` expressions also type-check.
- **`packages/leb128/mod.ts`** — 2 `!` on `buffer[index]` in `decodeULEB128` (line 77) and `decodeSLEB128` (line 155). Each access is preceded by an explicit `if (index >= buffer.length) throw …` guard.
- **`packages/content-hash/src/sha256-wasm.ts`** — 1 `!` on `theOneShotHasher[0]` in `getOneShotHasher`. Lazy-init pattern: `initWasm()` (line 79) fills the singleton-array slot before any caller is supposed to invoke `getOneShotHasher()`; callers gate via `assertUsable()` / `moduleIsUsable`.
- **`packages/data-model/bigint-encoding.ts`** — 2 `!` in `bigintFromMinimalTwosComplement`: `bytes[0]!` at line 149 (preceded by `if (bytes.length === 0) throw …` at line 144); `bytes[i]!` at line 163 inside `for (let i = 0; i < bytes.length; i++)` (textbook bounds-safe loop).
- **`packages/data-model/value-hash.ts`** — 1 `!` on `smallLengthCache[value]` in `feedLength()`. Lookup is guarded by `value <= MAX_CACHED_SMALL_LENGTH`, and `smallLengthCache` is fully prepopulated at module load with `MAX_CACHED_SMALL_LENGTH + 1` entries (line 125).

### Notable things to call out for review

- **Probe-import strategy.** `deno check --all <entry>` is the cascade-trigger that surfaces these errors — NOT plain `deno check` or `deno task test`. The probe needed widening as well: `fabric-value` alone surfaced 8 errors, but the full set required `fabric-value` + `value-hash` + `fabric-hash` + `schema-hash` to exercise all transitive paths. Probe imports were backed out before commit. Worth banking for future cross-package strict-tsconfig investigation.

- **`!`-vs-guard discipline.** Each fix uses the smallest-possible `!` annotation; every site has obviously-safe surrounding logic (explicit bounds-check throw / prepopulated cache / lazy-init invariant). No `!`-vs-guard ambiguity surfaced during the fix pass — at sites where a guard would have been more honest than `!`, the bounds-guarantee was already explicit upstream and a guard would have been redundant.

- **Scope-excluded `@types/node` TS2502.** `@types/node/crypto.d.ts:4523` surfaces a TS2502 error under `deno check --all`; pre-existing at HEAD and unrelated to `noUncheckedIndexedAccess`. Excluded from this PR's scope.

- **Stale path in task entry.** `tasks.md:1321-1322` named the cache-lookup site as `value-hash-modern.ts`, but the modern + legacy paths have since been merged into `value-hash.ts` (the actual fixed path). Foreman/ombudsman cleanup post-merge.

- **Conservation of content.** Each commit is a tactical mechanical fix, single-file, +1 to +6 / −1 to −6. Each commit message names the bounds-guarantee shape that justifies the `!` and locates the prep-PR-cascade-trigger context.

### Test plan

- [x] `deno fmt --check` clean on the 5 edited files.
- [x] `deno lint` clean on the 5 edited files.
- [x] `packages/utils` test: 15 passed, 0 failed.
- [x] `packages/leb128` test: 4 passed, 0 failed.
- [x] `packages/content-hash` test: 2 passed, 0 failed.
- [x] `packages/data-model` test: 44 passed, 0 failed.
- [x] `packages/schema-generator` test: 23 passed, 0 failed.

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
