### PR TITLE
ci: shard generated patterns integration tests

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -103,9 +103,14 @@ jobs:
             ./dist/cf
 
   generated-patterns-integration-test:
-    name: "Generated Patterns Integration Tests"
+    name: "Generated Patterns Integration Tests (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
     environment: ci
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+        total: [4]
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
@@ -122,15 +127,23 @@ jobs:
       - name: 🧪 Run generated patterns integration tests
         working-directory: packages/generated-patterns
         run: |
+          TEST_FILES=$(deno run --allow-read ../../tasks/select-generated-pattern-files.ts ${{ matrix.shard }}/${{ matrix.total }})
+          if [ -z "$TEST_FILES" ]; then
+            echo "::error::No generated pattern files selected for shard ${{ matrix.shard }}/${{ matrix.total }}"
+            exit 1
+          fi
+          printf 'Generated patterns shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
+          printf '  %s\n' $TEST_FILES
           mkdir -p ../../test-results
-          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/generated-patterns.xml" \
-          deno task integration
+          LOG_LEVEL=warn deno test --trace-leaks -A --parallel \
+            --junit-path=../../test-results/generated-patterns-${{ matrix.shard }}.xml \
+            $TEST_FILES
 
       - name: 📤 Upload test timing data
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-timing-generated-patterns
+          name: test-timing-generated-patterns-${{ matrix.shard }}
           path: test-results/
           retention-days: 90
           if-no-files-found: ignore

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -137,10 +137,64 @@ Deno.test("extractMetrics aggregates pattern integration matrix shards", () => {
   );
 });
 
-Deno.test("timingArtifactLabel normalizes pattern integration shard artifacts", () => {
+Deno.test("extractMetrics aggregates generated patterns matrix shards", () => {
+  const metrics = extractMetrics(makeRun(), [
+    makeJob(
+      1,
+      "Generated Patterns Integration Tests (1/4)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:40Z",
+      [
+        makeStep(
+          "🧪 Run generated patterns integration tests",
+          "2026-01-01T00:00:10Z",
+          "2026-01-01T00:01:30Z",
+        ),
+      ],
+    ),
+    makeJob(
+      2,
+      "Generated Patterns Integration Tests (2/4)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:10Z",
+      [
+        makeStep(
+          "🧪 Run generated patterns integration tests",
+          "2026-01-01T00:00:10Z",
+          "2026-01-01T00:01:00Z",
+        ),
+      ],
+    ),
+  ]);
+
+  assertEquals(
+    metrics.get("job: Generated Patterns Integration Tests (1/4)")
+      ?.durationSeconds,
+    100,
+  );
+  assertEquals(
+    metrics.get("job: Generated Patterns Integration Tests (2/4)")
+      ?.durationSeconds,
+    70,
+  );
+  assertEquals(
+    metrics.get("job: Generated Patterns Integration Tests")?.durationSeconds,
+    100,
+  );
+  assertEquals(
+    metrics.get("step: generated patterns integration")?.durationSeconds,
+    80,
+  );
+});
+
+Deno.test("timingArtifactLabel normalizes matrix shard artifacts", () => {
   assertEquals(
     timingArtifactLabel("test-timing-pattern-integration-1"),
     "pattern-integration",
+  );
+  assertEquals(
+    timingArtifactLabel("test-timing-generated-patterns-1"),
+    "generated-patterns",
   );
   assertEquals(
     timingArtifactLabel("test-timing-package-integration"),

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -535,7 +535,9 @@ export const JOB_TO_LABEL: Record<string, string> = {
 
 export function timingArtifactLabel(artifactName: string): string {
   const label = artifactName.replace(/^test-timing-/, "");
-  return label.replace(/^pattern-integration-\d+$/, "pattern-integration");
+  return label
+    .replace(/^pattern-integration-\d+$/, "pattern-integration")
+    .replace(/^generated-patterns-\d+$/, "generated-patterns");
 }
 
 // ---------------------------------------------------------------------------
@@ -611,6 +613,8 @@ const JOB_METRIC_NAMES: Record<string, string> = {
 export const PATTERN_UNIT_RE = /Pattern Unit Tests\s*\((\d+)\/(\d+)\)/;
 export const PATTERN_INTEGRATION_RE =
   /Pattern Integration Tests\s*\((\d+)\/(\d+)\)/;
+export const GENERATED_PATTERNS_RE =
+  /Generated Patterns Integration Tests\s*\((\d+)\/(\d+)\)/;
 
 interface StepMetricMatcher {
   jobName: string;
@@ -722,11 +726,16 @@ export function extractMetrics(
     const patternIntegrationMatch = PATTERN_INTEGRATION_RE.exec(
       normalizedJobName,
     );
+    const generatedPatternsMatch = GENERATED_PATTERNS_RE.exec(
+      normalizedJobName,
+    );
 
     const matcherJobName = unitMatch
       ? "Pattern Unit Tests"
       : patternIntegrationMatch
       ? "Pattern Integration Tests"
+      : generatedPatternsMatch
+      ? "Generated Patterns Integration Tests"
       : normalizedJobName;
 
     if (unitMatch) {
@@ -747,6 +756,17 @@ export function extractMetrics(
       setMaxMetric("job: Pattern Integration Tests", sample);
     }
 
+    if (generatedPatternsMatch) {
+      const sample = makeSample(jobDuration);
+      metrics.set(
+        `job: Generated Patterns Integration Tests (${
+          generatedPatternsMatch[1]
+        }/${generatedPatternsMatch[2]})`,
+        sample,
+      );
+      setMaxMetric("job: Generated Patterns Integration Tests", sample);
+    }
+
     if (normalizedJobName.includes("Test and Build")) {
       metrics.set("job: Test and Build", makeSample(jobDuration));
     }
@@ -762,7 +782,7 @@ export function extractMetrics(
           normalizedStepName.includes(matcher.stepKeyword)
         ) {
           const sample = makeSample(stepDuration);
-          if (patternIntegrationMatch) {
+          if (patternIntegrationMatch || generatedPatternsMatch) {
             setMaxMetric(matcher.metricName, sample);
           } else {
             metrics.set(matcher.metricName, sample);

--- a/tasks/select-generated-pattern-files.test.ts
+++ b/tasks/select-generated-pattern-files.test.ts
@@ -1,0 +1,41 @@
+import { assertEquals } from "@std/assert";
+import {
+  parseShard,
+  selectGeneratedPatternFiles,
+} from "./select-generated-pattern-files.ts";
+
+Deno.test("parseShard parses shard notation", () => {
+  assertEquals(parseShard("2/4"), { index: 2, total: 4 });
+});
+
+Deno.test("parseShard rejects invalid shard notation", () => {
+  try {
+    parseShard("5/4");
+    throw new Error("expected parseShard to throw");
+  } catch (error) {
+    assertEquals(
+      (error as Error).message,
+      "Shard index 5 exceeds total shard count 4",
+    );
+  }
+});
+
+Deno.test("selectGeneratedPatternFiles round-robins sorted names", () => {
+  const files = [
+    "delta.test.ts",
+    "alpha.test.ts",
+    "echo.test.ts",
+    "bravo.test.ts",
+    "charlie.test.ts",
+  ];
+
+  assertEquals(selectGeneratedPatternFiles(files, { index: 1, total: 2 }), [
+    "alpha.test.ts",
+    "charlie.test.ts",
+    "echo.test.ts",
+  ]);
+  assertEquals(selectGeneratedPatternFiles(files, { index: 2, total: 2 }), [
+    "bravo.test.ts",
+    "delta.test.ts",
+  ]);
+});

--- a/tasks/select-generated-pattern-files.ts
+++ b/tasks/select-generated-pattern-files.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env -S deno run --allow-read
+
+type Shard = {
+  index: number;
+  total: number;
+};
+
+export function parseShard(raw: string): Shard {
+  const match = raw.match(/^([1-9][0-9]*)\/([1-9][0-9]*)$/);
+  if (!match) {
+    throw new Error(`Expected shard argument like 1/4, got: ${raw}`);
+  }
+
+  const index = Number(match[1]);
+  const total = Number(match[2]);
+  if (index > total) {
+    throw new Error(`Shard index ${index} exceeds total shard count ${total}`);
+  }
+
+  return { index, total };
+}
+
+export function selectGeneratedPatternFiles(
+  names: string[],
+  shard: Shard,
+): string[] {
+  return [...names]
+    .sort()
+    .filter((_, index) => index % shard.total === shard.index - 1);
+}
+
+async function listGeneratedPatternTests(): Promise<string[]> {
+  const integrationDir = new URL(
+    "../packages/generated-patterns/integration/patterns/",
+    import.meta.url,
+  );
+  const files: string[] = [];
+
+  for await (const entry of Deno.readDir(integrationDir)) {
+    if (entry.isFile && entry.name.endsWith(".test.ts")) {
+      files.push(entry.name);
+    }
+  }
+
+  files.sort();
+  return files;
+}
+
+if (import.meta.main) {
+  const shard = parseShard(Deno.args[0] ?? "");
+  const files = await listGeneratedPatternTests();
+  const selected = selectGeneratedPatternFiles(files, shard)
+    .map((name) => `./integration/patterns/${name}`);
+
+  if (selected.length === 0) {
+    throw new Error(
+      `No generated pattern files selected for ${Deno.args[0]}`,
+    );
+  }
+
+  console.log(selected.join("\n"));
+}


### PR DESCRIPTION
## Why

Generated Patterns Integration Tests became one of the longest remaining CI jobs after #3530 split pattern integration tests. The suite has 145 independent files, so running it as one GitHub Actions job leaves easy wall-time reduction on the table.

## What Changed

- Split the generated-patterns integration job into a 4-way matrix.
- Added a sorted round-robin selector so shards stay balanced by file count.
- Upload per-shard timing artifacts and normalize them back to the existing generated-patterns perf label.
- Aggregate generated-pattern matrix job and step durations by max shard duration in the perf gate.

## Test plan

- deno test --allow-read --allow-env tasks/select-generated-pattern-files.test.ts tasks/perf-lib.test.ts
- deno check tasks/select-generated-pattern-files.ts tasks/select-generated-pattern-files.test.ts tasks/perf-lib.ts tasks/perf-lib.test.ts
- deno lint tasks/select-generated-pattern-files.ts tasks/select-generated-pattern-files.test.ts tasks/perf-lib.ts tasks/perf-lib.test.ts
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deno.yml"); puts "yaml ok"'
- Local generated-pattern shard 4 command: 36 passed, 0 failed
- Accidental full local generated-pattern run: 145 passed, 0 failed