### PR TITLE
Speed up `bigintToMinimalTwosComplement()`

### DIFF
--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -13,15 +13,25 @@
 // ---------------------------------------------------------------------------
 
 /**
- * Helper for `bigintToMinimalTwosComplement()`, which converts a hex digit char
- * code at a particular index in a string to its 4-bit numeric value. Handles
- * '0'-'9' (0x30-0x39) and 'a'-'f' (0x61-0x66).
+ * Helper for `bigintToMinimalTwosComplement()`, which converts a hex digit at a
+ * particular index in a string to its 4-bit (nibble-sized) numeric value.
+ * Handles '0'-'9' (0x30-0x39) and 'a'-'f' (0x61-0x66).
+ *
  */
-function hexValueAt(hex: string, at: number): number {
+function nibbleValueAt(hex: string, at: number): number {
   const c = hex.charCodeAt(at);
 
   // '0'-'9' = 0x30-0x39, 'a'-'f' = 0x61-0x66
   return c < 0x3a ? c - 0x30 : c - 0x57;
+}
+
+/**
+ * Helper for `bigintToMinimalTwosComplement()`, which converts a pair of hex
+ * digits at a particular index in a string to its 8-bit (byte-sized) numeric
+ * value. Handles '0'-'9' (0x30-0x39) and 'a'-'f' (0x61-0x66).
+ */
+function byteValueAt(hex: string, at: number): number {
+  return (nibbleValueAt(hex, at) << 4) | nibbleValueAt(hex, at + 1);
 }
 
 /**
@@ -101,7 +111,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
       if ((hex.length & 1) === 1) {
         // Round up to an even number of nibbles.
         return "0" + hex;
-      } else if (hexValueAt(hex, 0) >= 8) {
+      } else if (nibbleValueAt(hex, 0) >= 8) {
         // Add an extra `0x00` byte, because the high-order bit would otherwise
         // be `1` and therefore the encoded result would be negative, which
         // would be wrong.
@@ -115,8 +125,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     const bytes = new Uint8Array(byteLen);
 
     for (let i = 0; i < bytes.length; i++) {
-      const j = i * 2;
-      bytes[i] = (hexValueAt(hex, j) << 4) | hexValueAt(hex, j + 1);
+      bytes[i] = byteValueAt(hex, i * 2);
     }
 
     return bytes;
@@ -146,7 +155,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     // In either case we need one more byte to keep the high bit set.
     const twosHex = twos.toString(16);
     if (
-      twosHex.length < byteLen * 2 || hexValueAt(twosHex, 0) < 8
+      twosHex.length < byteLen * 2 || nibbleValueAt(twosHex, 0) < 8
     ) {
       byteLen++;
       twos = (1n << BigInt(byteLen * 8)) - abs;
@@ -156,8 +165,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     while (hex.length < byteLen * 2) hex = "0" + hex;
     const bytes = new Uint8Array(byteLen);
     for (let i = 0; i < bytes.length; i++) {
-      const j = i * 2;
-      bytes[i] = (hexValueAt(hex, j) << 4) | hexValueAt(hex, j + 1);
+      bytes[i] = byteValueAt(hex, i * 2);
     }
     return bytes;
   }

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -122,11 +122,11 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
       return convertSmallValue(false);
     }
 
-    // Slow path for positive numbers: Stringify and parse. We use
-    // toString(16).length to determine byte count because V8 has no BigInt
-    // bit-length API. The TC39 BigInt Math proposal (Stage 1) includes
-    // BigInt.bitLength() which would eliminate this string round-trip. See:
-    // https://github.com/tc39/proposal-bigint-math
+    // Slow path for positive numbers: This stringifies and then parses back the
+    // `value`, to work around JS's very limited set of `bigint` functionality.
+    // If and when the TC39 BigInt Math proposal lands, this code could be
+    // reworked to be muchb more performant. See:
+    // <https://github.com/tc39/proposal-bigint-math>.
 
     const hex = hexStringFromPositiveValue(value);
     const bytes = new Uint8Array(hex.length >> 1);

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -124,7 +124,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     // Slow path for positive numbers: This stringifies and then parses back the
     // `value`, to work around JS's very limited set of `bigint` functionality.
     // If and when the TC39 BigInt Math proposal lands, this code could be
-    // reworked to be muchb more performant. See:
+    // reworked to be much more performant. See:
     // <https://github.com/tc39/proposal-bigint-math>.
 
     const hex = hexStringFromPositiveValue(value);

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -71,6 +71,7 @@ const NEGATIVE_ONE_BYTES = new Uint8Array([0xFF]);
  *   when the high bit would otherwise be clear (sign extension for negative).
  */
 export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
+  // Converts a value that fits into 64 bits.
   const convertSmallValue = (negative: boolean) => {
     dv64View.setBigUint64(0, value, false); // big-endian
 
@@ -93,6 +94,22 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     }
   };
 
+  // Converts a positive value to a hex string.
+  const hexStringFromPositiveValue = (value: bigint) => {
+    const hex = value.toString(16);
+    if ((hex.length & 1) === 1) {
+      // Round up to an even number of nibbles.
+      return "0" + hex;
+    } else if (nibbleValueAt(hex, 0) >= 8) {
+      // Add an extra `0x00` byte, because the high-order bit would otherwise
+      // be `1` and therefore the encoded result would be negative, which
+      // would be wrong.
+      return "00" + hex;
+    } else {
+      return hex;
+    }
+  };
+
   if (value >= 0n) {
     if (value === 0n) {
       return ZERO_BYTES.slice();
@@ -106,21 +123,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     // BigInt.bitLength() which would eliminate this string round-trip. See:
     // https://github.com/tc39/proposal-bigint-math
 
-    const hex = (() => {
-      const hex = value.toString(16);
-      if ((hex.length & 1) === 1) {
-        // Round up to an even number of nibbles.
-        return "0" + hex;
-      } else if (nibbleValueAt(hex, 0) >= 8) {
-        // Add an extra `0x00` byte, because the high-order bit would otherwise
-        // be `1` and therefore the encoded result would be negative, which
-        // would be wrong.
-        return "00" + hex;
-      } else {
-        return hex;
-      }
-    })();
-
+    const hex = hexStringFromPositiveValue(value);
     const byteLen = hex.length >> 1;
     const bytes = new Uint8Array(byteLen);
 
@@ -136,37 +139,21 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
       return convertSmallValue(true);
     }
 
-    // Slow path for negative numbers. See above for details.
+    // Slow path for negative numbers. See above for details. The extra twist
+    // here is that we need to end up with a string that correctly represents
+    // `value` as a twos-complement negative value. The trick we do here is
+    // convert the _ones_-complement of `value` to a string, and then undo it
+    // byte-by-byte when storing the result.
 
-    // Compute two's complement.
-    const abs = -value;
-    const absHex = abs.toString(16);
-    // Number of bits for the magnitude.
-    const bitLen = absHex.length * 4;
-    // We need enough bytes to represent the value, rounded up.
-    let byteLen = Math.ceil(bitLen / 8);
-    // Two's complement of -abs is 2^n - abs where n is the byte-aligned size.
-    let twos = (1n << BigInt(byteLen * 8)) - abs;
-    // Verify the high bit of byte 0 of the encoded form is set (value must
-    // look negative). It is *not* set if either:
-    //   (a) `twosHex` is shorter than `byteLen * 2` (so byte 0 starts with a
-    //       padding-zero nibble), or
-    //   (b) `twosHex.length === byteLen * 2` but its leading nibble is < 8.
-    // In either case we need one more byte to keep the high bit set.
-    const twosHex = twos.toString(16);
-    if (
-      twosHex.length < byteLen * 2 || nibbleValueAt(twosHex, 0) < 8
-    ) {
-      byteLen++;
-      twos = (1n << BigInt(byteLen * 8)) - abs;
-    }
-
-    let hex = twos.toString(16);
-    while (hex.length < byteLen * 2) hex = "0" + hex;
+    const hex = hexStringFromPositiveValue(~value);
+    const byteLen = hex.length >> 1;
     const bytes = new Uint8Array(byteLen);
+
     for (let i = 0; i < bytes.length; i++) {
-      bytes[i] = byteValueAt(hex, i * 2);
+      // `0xff - value` to undo the ones-complement in `~value` above.
+      bytes[i] = 0xff - byteValueAt(hex, i * 2);
     }
+
     return bytes;
   }
 }

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -34,6 +34,16 @@ const dv64View = new DataView(dv64Buf);
 const dv64Bytes = new Uint8Array(dv64Buf);
 
 /**
+ * Cached result of `0n` as a `Uint8Array`.
+ */
+const ZERO_BYTES = new Uint8Array([0x00]);
+
+/**
+ * Cached result of `-1n` as a `Uint8Array`.
+ */
+const NEGATIVE_ONE_BYTES = new Uint8Array([0xFF]);
+
+/**
  * Converts a bigint to its minimal two's-complement big-endian byte
  * representation. The encoding is the same one used by the hash
  * byte-level spec (Section 3.7).
@@ -50,20 +60,34 @@ const dv64Bytes = new Uint8Array(dv64Buf);
  *   when the high bit would otherwise be clear (sign extension for negative).
  */
 export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
-  if (value === 0n) {
-    return new Uint8Array([0]);
-  }
+  if (value >= 0n) {
+    if (value === 0n) {
+      return ZERO_BYTES.slice();
+    } else if (value <= 0x7fff_ffff_ffff_ffffn) {
+      dv64View.setBigUint64(0, value, false); // big-endian
 
-  const negative = value < 0n;
+      // Note: Loop necessarily ends before running off the end of the array
+      // because `value !== 0n` (that is, there's definitely a non-skipped
+      // byte).
+      for (let i = 0; /*i*/; i++) {
+        const byte = dv64Bytes[i];
+        if (byte !== 0) {
+          return dv64Bytes.slice((byte <= 0x7f) ? i : i - 1);
+        }
+      }
+    }
 
-  if (!negative) {
-    // We use toString(16).length to determine byte count because V8 has no
-    // BigInt bit-length API. The TC39 BigInt Math proposal (Stage 1) includes
-    // BigInt.bitLength() which would eliminate this string round-trip.
-    // See: https://github.com/tc39/proposal-bigint-math
+    // Slow path for positive numbers: Stringify and parse. We use
+    // toString(16).length to determine byte count because V8 has no BigInt
+    // bit-length API. The TC39 BigInt Math proposal (Stage 1) includes
+    // BigInt.bitLength() which would eliminate this string round-trip. See:
+    // https://github.com/tc39/proposal-bigint-math
+
     const hex = value.toString(16);
+
     // Determine minimal byte length from hex digit count.
     let byteLen = (hex.length + 1) >> 1; // ceil(hex.length / 2)
+
     // If the high nibble of byte 0 has bit 3 set, we need a sign-extension
     // zero byte. For odd hex length the byte's high nibble is 0 (from the
     // implicit leading-zero pad), so the check only applies for even
@@ -72,64 +96,70 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
       byteLen++;
     }
 
-    // Fast path: use DataView.setBigUint64() for values that fit in 8 bytes.
-    if (byteLen <= 8) {
-      dv64View.setBigUint64(0, value, false); // big-endian
-      return dv64Bytes.slice(8 - byteLen);
-    }
-
-    // Fallback: hex+nibble for larger values.
     let padded = hex;
     if (padded.length % 2 !== 0) padded = "0" + padded;
     if (hexToNibble(padded.charCodeAt(0)) >= 8) padded = "00" + padded;
     const bytes = new Uint8Array(padded.length / 2);
+
     for (let i = 0; i < bytes.length; i++) {
       const j = i * 2;
       bytes[i] = (hexToNibble(padded.charCodeAt(j)) << 4) |
         hexToNibble(padded.charCodeAt(j + 1));
     }
+
+    return bytes;
+  } else {
+    if (value === -1n) {
+      return NEGATIVE_ONE_BYTES.slice();
+    } else if (value >= -0x8000_0000_0000_0000n) {
+      dv64View.setBigUint64(0, value, false); // big-endian
+
+      // Note: Loop necessarily ends before running off the end of the array
+      // because `value !== -1n` (that is, there's definitely a non-skipped
+      // byte).
+      for (let i = 0; /*i*/; i++) {
+        const byte = dv64Bytes[i];
+        if (byte !== 0xff) {
+          return dv64Bytes.slice((byte >= 0x80) ? i : i - 1);
+        }
+      }
+    }
+
+    // Slow path for negative numbers. See above for details.
+
+    // Compute two's complement.
+    const abs = -value;
+    const absHex = abs.toString(16);
+    // Number of bits for the magnitude.
+    const bitLen = absHex.length * 4;
+    // We need enough bytes to represent the value, rounded up.
+    let byteLen = Math.ceil(bitLen / 8);
+    // Two's complement of -abs is 2^n - abs where n is the byte-aligned size.
+    let twos = (1n << BigInt(byteLen * 8)) - abs;
+    // Verify the high bit of byte 0 of the encoded form is set (value must
+    // look negative). It is *not* set if either:
+    //   (a) `twosHex` is shorter than `byteLen * 2` (so byte 0 starts with a
+    //       padding-zero nibble), or
+    //   (b) `twosHex.length === byteLen * 2` but its leading nibble is < 8.
+    // In either case we need one more byte to keep the high bit set.
+    const twosHex = twos.toString(16);
+    if (
+      twosHex.length < byteLen * 2 || hexToNibble(twosHex.charCodeAt(0)) < 8
+    ) {
+      byteLen++;
+      twos = (1n << BigInt(byteLen * 8)) - abs;
+    }
+
+    let hex = twos.toString(16);
+    while (hex.length < byteLen * 2) hex = "0" + hex;
+    const bytes = new Uint8Array(byteLen);
+    for (let i = 0; i < bytes.length; i++) {
+      const j = i * 2;
+      bytes[i] = (hexToNibble(hex.charCodeAt(j)) << 4) |
+        hexToNibble(hex.charCodeAt(j + 1));
+    }
     return bytes;
   }
-
-  // For negative numbers, compute two's complement.
-  const abs = -value;
-  const absHex = abs.toString(16);
-  // Number of bits for the magnitude.
-  const bitLen = absHex.length * 4;
-  // We need enough bytes to represent the value, rounded up.
-  let byteLen = Math.ceil(bitLen / 8);
-  // Two's complement of -abs is 2^n - abs where n is the byte-aligned size.
-  let twos = (1n << BigInt(byteLen * 8)) - abs;
-  // Verify the high bit of byte 0 of the encoded form is set (value must
-  // look negative). It is *not* set if either:
-  //   (a) `twosHex` is shorter than `byteLen * 2` (so byte 0 starts with a
-  //       padding-zero nibble), or
-  //   (b) `twosHex.length === byteLen * 2` but its leading nibble is < 8.
-  // In either case we need one more byte to keep the high bit set.
-  const twosHex = twos.toString(16);
-  if (
-    twosHex.length < byteLen * 2 || hexToNibble(twosHex.charCodeAt(0)) < 8
-  ) {
-    byteLen++;
-    twos = (1n << BigInt(byteLen * 8)) - abs;
-  }
-
-  // Fast path: use DataView.setBigUint64() for values that fit in 8 bytes.
-  if (byteLen <= 8) {
-    dv64View.setBigUint64(0, twos, false); // big-endian
-    return dv64Bytes.slice(8 - byteLen);
-  }
-
-  // Fallback: hex+nibble for larger values.
-  let hex = twos.toString(16);
-  while (hex.length < byteLen * 2) hex = "0" + hex;
-  const bytes = new Uint8Array(byteLen);
-  for (let i = 0; i < bytes.length; i++) {
-    const j = i * 2;
-    bytes[i] = (hexToNibble(hex.charCodeAt(j)) << 4) |
-      hexToNibble(hex.charCodeAt(j + 1));
-  }
-  return bytes;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -13,18 +13,15 @@
 // ---------------------------------------------------------------------------
 
 /**
- * Helper for `bigintToMinimalTwosComplement()`, which converts a hex digit
- * char code to its 4-bit numeric value. Handles '0'-'9' (0x30-0x39) and
- * 'a'-'f' (0x61-0x66). Used instead of `parseInt` for ~2x faster
- * hex-to-byte conversion (see bigint-hashing-performance.md).
+ * Helper for `bigintToMinimalTwosComplement()`, which converts a hex digit char
+ * code at a particular index in a string to its 4-bit numeric value. Handles
+ * '0'-'9' (0x30-0x39) and 'a'-'f' (0x61-0x66).
  */
-function hexToNibble(c: number): number {
+function hexValueAt(hex: string, at: number): number {
+  const c = hex.charCodeAt(at);
+
   // '0'-'9' = 0x30-0x39, 'a'-'f' = 0x61-0x66
   return c < 0x3a ? c - 0x30 : c - 0x57;
-}
-
-function hexValueAt(hex: string, at: number): number {
-  return hexToNibble(hex.charCodeAt(at));
 }
 
 /**
@@ -149,7 +146,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     // In either case we need one more byte to keep the high bit set.
     const twosHex = twos.toString(16);
     if (
-      twosHex.length < byteLen * 2 || hexToNibble(twosHex.charCodeAt(0)) < 8
+      twosHex.length < byteLen * 2 || hexValueAt(twosHex, 0) < 8
     ) {
       byteLen++;
       twos = (1n << BigInt(byteLen * 8)) - abs;
@@ -160,8 +157,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     const bytes = new Uint8Array(byteLen);
     for (let i = 0; i < bytes.length; i++) {
       const j = i * 2;
-      bytes[i] = (hexToNibble(hex.charCodeAt(j)) << 4) |
-        hexToNibble(hex.charCodeAt(j + 1));
+      bytes[i] = (hexValueAt(hex, j) << 4) | hexValueAt(hex, j + 1);
     }
     return bytes;
   }

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -60,21 +60,33 @@ const NEGATIVE_ONE_BYTES = new Uint8Array([0xFF]);
  *   when the high bit would otherwise be clear (sign extension for negative).
  */
 export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
+  const convertSmallValue = (negative: boolean) => {
+    dv64View.setBigUint64(0, value, false); // big-endian
+
+    // Note: Loop necessarily ends before running off the end of the array
+    // because by virtue of the caller's up-front check, there's definitely a
+    // non-skipped byte).
+    const skipByte = negative ? 0xff : 0x00;
+    for (let i = 0; /*i*/; i++) {
+      const byte = dv64Bytes[i];
+      if (byte !== skipByte) {
+        // Adjust starting index backwards if the non-skipped byte would flip
+        // the sign of the result.
+        if (negative) {
+          if (byte <= 0x7f) i--;
+        } else {
+          if (byte >= 0x80) i--;
+        }
+        return dv64Bytes.slice(i);
+      }
+    }
+  };
+
   if (value >= 0n) {
     if (value === 0n) {
       return ZERO_BYTES.slice();
     } else if (value <= 0x7fff_ffff_ffff_ffffn) {
-      dv64View.setBigUint64(0, value, false); // big-endian
-
-      // Note: Loop necessarily ends before running off the end of the array
-      // because `value !== 0n` (that is, there's definitely a non-skipped
-      // byte).
-      for (let i = 0; /*i*/; i++) {
-        const byte = dv64Bytes[i];
-        if (byte !== 0) {
-          return dv64Bytes.slice((byte <= 0x7f) ? i : i - 1);
-        }
-      }
+      return convertSmallValue(false);
     }
 
     // Slow path for positive numbers: Stringify and parse. We use
@@ -112,17 +124,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     if (value === -1n) {
       return NEGATIVE_ONE_BYTES.slice();
     } else if (value >= -0x8000_0000_0000_0000n) {
-      dv64View.setBigUint64(0, value, false); // big-endian
-
-      // Note: Loop necessarily ends before running off the end of the array
-      // because `value !== -1n` (that is, there's definitely a non-skipped
-      // byte).
-      for (let i = 0; /*i*/; i++) {
-        const byte = dv64Bytes[i];
-        if (byte !== 0xff) {
-          return dv64Bytes.slice((byte >= 0x80) ? i : i - 1);
-        }
-      }
+      return convertSmallValue(true);
     }
 
     // Slow path for negative numbers. See above for details.

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -16,7 +16,6 @@
  * Helper for `bigintToMinimalTwosComplement()`, which converts a hex digit at a
  * particular index in a string to its 4-bit (nibble-sized) numeric value.
  * Handles '0'-'9' (0x30-0x39) and 'a'-'f' (0x61-0x66).
- *
  */
 function nibbleValueAt(hex: string, at: number): number {
   const c = hex.charCodeAt(at);

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -79,10 +79,6 @@ const NEGATIVE_ONE_BYTES = new Uint8Array([0xFF]);
  * representation. The encoding is the same one used by the hash
  * byte-level spec (Section 3.7).
  *
- * Uses a hybrid strategy: values that fit in 64 bits (the common case) are
- * extracted via a single `DataView.setBigUint64()` call (~2x faster), while
- * larger values fall back to hex+nibble conversion.
- *
  * Edge cases:
  * - `0n` -> `[0x00]` (single zero byte)
  * - Positive values get a leading `0x00` byte when the high bit would

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -35,6 +35,27 @@ function byteValueAt(hex: string, at: number): number {
 }
 
 /**
+ * Helper for `bigintToMinimalTwosComplement()`, which converts a positive
+ * `bigint` to a hex string with an even number of digits, _and_ a leading
+ * `00` if it would otherwise be interpreted as a negative number in
+ * twos-complement.
+ */
+function hexStringFromPositiveValue(value: bigint): string {
+  const hex = value.toString(16);
+  if ((hex.length & 1) === 1) {
+    // Round up to an even number of nibbles.
+    return "0" + hex;
+  } else if (nibbleValueAt(hex, 0) >= 8) {
+    // Add an extra `0x00` byte, because the high-order bit would otherwise
+    // be `1` and therefore the encoded result would be negative, which
+    // would be wrong.
+    return "00" + hex;
+  } else {
+    return hex;
+  }
+}
+
+/**
  * Shared 8-byte scratch buffer for the DataView fast path. A single
  * `setBigUint64()` call writes all 8 bytes at once, avoiding hex string
  * processing for values that fit in 64 bits. Same shared-buffer pattern as
@@ -94,22 +115,6 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     }
   };
 
-  // Converts a positive value to a hex string.
-  const hexStringFromPositiveValue = (value: bigint) => {
-    const hex = value.toString(16);
-    if ((hex.length & 1) === 1) {
-      // Round up to an even number of nibbles.
-      return "0" + hex;
-    } else if (nibbleValueAt(hex, 0) >= 8) {
-      // Add an extra `0x00` byte, because the high-order bit would otherwise
-      // be `1` and therefore the encoded result would be negative, which
-      // would be wrong.
-      return "00" + hex;
-    } else {
-      return hex;
-    }
-  };
-
   if (value >= 0n) {
     if (value === 0n) {
       return ZERO_BYTES.slice();
@@ -124,8 +129,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     // https://github.com/tc39/proposal-bigint-math
 
     const hex = hexStringFromPositiveValue(value);
-    const byteLen = hex.length >> 1;
-    const bytes = new Uint8Array(byteLen);
+    const bytes = new Uint8Array(hex.length >> 1);
 
     for (let i = 0; i < bytes.length; i++) {
       bytes[i] = byteValueAt(hex, i * 2);
@@ -146,8 +150,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     // byte-by-byte when storing the result.
 
     const hex = hexStringFromPositiveValue(~value);
-    const byteLen = hex.length >> 1;
-    const bytes = new Uint8Array(byteLen);
+    const bytes = new Uint8Array(hex.length >> 1);
 
     for (let i = 0; i < bytes.length; i++) {
       // `0xff - value` to undo the ones-complement in `~value` above.

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -89,7 +89,7 @@ const NEGATIVE_ONE_BYTES = new Uint8Array([0xFF]);
 export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
   // Converts a value that fits into 64 bits.
   const convertSmallValue = (negative: boolean) => {
-    dv64View.setBigUint64(0, value, false); // big-endian
+    dv64View.setBigInt64(0, value, false); // `false` means big-endian.
 
     // Note: Loop necessarily ends before running off the end of the array
     // because by virtue of the caller's up-front check, there's definitely a

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -23,6 +23,10 @@ function hexToNibble(c: number): number {
   return c < 0x3a ? c - 0x30 : c - 0x57;
 }
 
+function hexValueAt(hex: string, at: number): number {
+  return hexToNibble(hex.charCodeAt(at));
+}
+
 /**
  * Shared 8-byte scratch buffer for the DataView fast path. A single
  * `setBigUint64()` call writes all 8 bytes at once, avoiding hex string
@@ -67,7 +71,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     // because by virtue of the caller's up-front check, there's definitely a
     // non-skipped byte).
     const skipByte = negative ? 0xff : 0x00;
-    for (let i = 0; /*i*/; i++) {
+    for (let i = 0; true; i++) {
       const byte = dv64Bytes[i];
       if (byte !== skipByte) {
         // Adjust starting index backwards if the non-skipped byte would flip
@@ -95,28 +99,27 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     // BigInt.bitLength() which would eliminate this string round-trip. See:
     // https://github.com/tc39/proposal-bigint-math
 
-    const hex = value.toString(16);
+    const hex = (() => {
+      const hex = value.toString(16);
+      if ((hex.length & 1) === 1) {
+        // Round up to an even number of nibbles.
+        return "0" + hex;
+      } else if (hexValueAt(hex, 0) >= 8) {
+        // Add an extra `0x00` byte, because the high-order bit would otherwise
+        // be `1` and therefore the encoded result would be negative, which
+        // would be wrong.
+        return "00" + hex;
+      } else {
+        return hex;
+      }
+    })();
 
-    // Determine minimal byte length from hex digit count.
-    let byteLen = (hex.length + 1) >> 1; // ceil(hex.length / 2)
-
-    // If the high nibble of byte 0 has bit 3 set, we need a sign-extension
-    // zero byte. For odd hex length the byte's high nibble is 0 (from the
-    // implicit leading-zero pad), so the check only applies for even
-    // hex.length, where `hex[0]` *is* the leading byte's high nibble.
-    if ((hex.length & 1) === 0 && hexToNibble(hex.charCodeAt(0)) >= 8) {
-      byteLen++;
-    }
-
-    let padded = hex;
-    if (padded.length % 2 !== 0) padded = "0" + padded;
-    if (hexToNibble(padded.charCodeAt(0)) >= 8) padded = "00" + padded;
-    const bytes = new Uint8Array(padded.length / 2);
+    const byteLen = hex.length >> 1;
+    const bytes = new Uint8Array(byteLen);
 
     for (let i = 0; i < bytes.length; i++) {
       const j = i * 2;
-      bytes[i] = (hexToNibble(padded.charCodeAt(j)) << 4) |
-        hexToNibble(padded.charCodeAt(j + 1));
+      bytes[i] = (hexValueAt(hex, j) << 4) | hexValueAt(hex, j + 1);
     }
 
     return bytes;

--- a/packages/data-model/test/bigint-encoding.test.ts
+++ b/packages/data-model/test/bigint-encoding.test.ts
@@ -93,6 +93,13 @@ const rawFixtures: bigint[] = [
   -246n,
   -247n,
   -248n,
+  // Boundaries of the 64-bit fast path in `convertSmallValue()`: the
+  // largest positive and the most-negative value it handles, plus one
+  // step beyond each into the slow path.
+  0x7fff_ffff_ffff_ffffn, //  2^63 - 1,  max fast-path positive
+  0x8000_0000_0000_0000n, //  2^63,      first slow-path positive
+  -0x8000_0000_0000_0000n, // -2^63,     most-negative fast-path
+  -0x8000_0000_0000_0001n, // -2^63 - 1, first slow-path negative
 ];
 
 // Programmatic expansion via a deterministic recurrence. The multiplier `99`


### PR DESCRIPTION
## Summary

Substantial encode-side perf wins for `bigintToMinimalTwosComplement()`
across the full byte-length spectrum, with no behavior changes. Decode path
is untouched.

The change is structured as 14 small commits that walk you through the
rework in steps -- recommend reviewing commit-by-commit rather than as a
single diff.

## What changed, and why it's faster

**Small (`abs <= 2^63 - 1`) fast path** -- new short-circuit that does a
single `DataView.setBigInt64()` write into the shared 8-byte buffer, then
walks for the first non-skip byte (`0x00` for positives, `0xff` for
negatives) and returns a slice. Eliminates the hex-string round-trip on
the common case. Also caches `0n -> [0x00]` and `-1n -> [0xff]` as
pre-allocated `Uint8Array`s.

**Long-positive slow path** -- simplified into a small helper
`hexStringFromPositiveValue()` that handles odd-length padding and
sign-extension uniformly, then the main loop just walks the (now
guaranteed-even, guaranteed-sign-correct) hex string two chars at a
time. Same `byteValueAt()` helper used as the long-negative path.

**Long-negative slow path** -- the headline trick: instead of computing
`twos = 2^(byteLen*8) - abs` (a bigint subtraction at full magnitude
size), compute `~value.toString(16)` (= ones-complement of the input,
which is positive and has roughly the same hex length as `abs`), then
emit each byte as `0xff - byteValueAt(...)` to undo the ones-complement
on the way out. This avoids the giant `1n << BigInt(byteLen * 8)` shift
and the corresponding subtract. It's the source of the -19% to -36%
improvement on long negatives.

The negative-vs-positive asymmetry on long values has effectively
collapsed: long-negative encode used to be 30-50% slower than
long-positive; it's now within ~10%.

## Approximate perf delta (vs main on Apple M5 Pro)

Per-op times, accumulated across iterations of the rework. Final cumulative
numbers are within a few % of these:

| track           | 1-8B          | 9-32B         | 64-1024B      |
| --------------- | ------------: | ------------: | ------------: |
| encode positive |  -14% to -23% |   -1% to -10% |   -1% to -10% |
| encode negative |  -23% to -37% |  -19% to -36% |  -19% to -36% |
| decode (both)   |     unchanged |     unchanged |     unchanged |

Run `deno bench --no-check packages/data-model/test/bigint-encoding.bench.ts`
for the current cumulative picture.

## Test plan

- [x] `deno test packages/data-model/test/bigint-encoding.test.ts` --
      16,152 steps pass against the 2000-iter fixture-driven oracle suite
      (covers magnitudes up to ~1659 bytes for both signs, plus boundary
      values around the new 2^63 fast/slow path cutoff).
- [x] `deno task test` in `packages/data-model` -- 45 passed
      (17,409 steps), 0 failed.
- [x] `deno task test` at the repo root -- all 33 workspace packages
      pass (75.4s).
- [x] Added explicit boundary-value fixtures
      (`±2^63` and one step into the slow path each side) so the new
      fast/slow cutoff is regression-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
