### PR TITLE
Speed up `bigintFromMinimalTwosComplement()`

### DIFF
--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -172,25 +172,25 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
   // Determine sign from the high bit of the first byte.
   const negative = (bytes[0]! & 0x80) !== 0;
 
-  // Fast path: use DataView.getBigUint64() for values that fit in 8 bytes.
   if (bytes.length <= 8) {
-    dv64Bytes.fill(0);
+    // Fast path for `bytes.length <= 8`.
+    dv64Bytes.fill(negative ? 0xff : 0);
     dv64Bytes.set(bytes, 8 - bytes.length);
-    const raw = dv64View.getBigUint64(0, false); // big-endian
-    if (!negative) return raw;
-    return raw - (1n << BigInt(bytes.length * 8));
-  }
-
-  // Fallback: per-byte shift loop for larger values.
-  let result = 0n;
-  for (let i = 0; i < bytes.length; i++) {
-    result = (result << 8n) | BigInt(bytes[i]!);
-  }
-
-  if (!negative) {
+    return dv64View.getBigInt64(0, false); // `false` means big-endian.
+  } else if (negative) {
+    // Slow path for negative values. This uses a similar ones-complement trick
+    // as is done in the encoder function, above.
+    let result = 0n;
+    for (let i = 0; i < bytes.length; i++) {
+      result = (result << 8n) | BigInt(0xff - bytes[i]!);
+    }
+    return ~result;
+  } else {
+    // Slow path for positive values.
+    let result = 0n;
+    for (let i = 0; i < bytes.length; i++) {
+      result = (result << 8n) | BigInt(bytes[i]!);
+    }
     return result;
   }
-
-  // Two's complement: subtract 2^(byteLen*8) to get the negative value.
-  return result - (1n << BigInt(bytes.length * 8));
 }


### PR DESCRIPTION
## Summary

Two targeted improvements on the decode side of `bigint-encoding.ts`,
mirroring techniques applied to the encoder in #3534. Encode path is
untouched.

## What changed

**Fast path (≤8 bytes)** -- switch from `getBigUint64()` + manual sign
adjust to `getBigInt64()`. The shared 8-byte buffer is now pre-filled
with `0xff` for negatives (so the leading bytes look like sign extension
to `getBigInt64()`) instead of `0x00`, and the function just returns
what `getBigInt64()` produces. This eliminates the per-call
`raw - (1n << BigInt(bytes.length * 8))` subtract on negatives.

**Slow path (>8 bytes)** -- split into separate positive and negative
branches. The negative branch uses the same ones-complement trick as the
encoder: shift in `0xff - byte` instead of `byte`, and bitwise-NOT the
final result. This avoids the giant
`result - (1n << BigInt(bytes.length * 8))` subtract on long negatives.

## Approximate perf delta

(Per-op times, current vs. a reference snapshot whose decode numbers
predate any decode change in this session -- so it's a clean
"pre-decode-rework" reference for the decode tracks.)

| track | mean Δ | best | worst |
| --- | ---: | ---: | ---: |
| **decode negative** | **-9.4%** | **-35.4%** | +2.0% |
| decode positive | -2.8% | -7.3% | +2.1% |

Highlights:
- **Decode negative 1-8B: -32% to -35%.** The asymmetry between
  positive and negative small-decode collapses entirely -- both are now
  ~14 ns/op (vs 14 ns positive / 21 ns negative before).
- Decode negative 9-32B: -1% to -7%, modest improvements where the
  per-byte loop dominates.
- Decode positive 17-32B: -3% to -7%, presumably from the slow path
  splitting cleanly in two so the JIT can specialize each branch.
- Decode 64-1024B: within noise; the giant per-byte BigInt-shift loop
  still dominates that regime.

The decode side now has the same byte-form-is-the-byte-form symmetry as
the encode side: positive and negative ≤8B operations take the same
time.

## Test plan

- [x] `deno test packages/data-model/test/bigint-encoding.test.ts` --
      16,152 steps pass against the 2000-iter fixture-driven oracle
      suite (covers both signs at every magnitude from 1B up to ~1659B).
- [x] `deno task test` in `packages/data-model` -- 45 passed
      (17,425 steps), 0 failed.
- [x] `deno task test` at the repo root -- all 33 workspace packages
      pass (75.4s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This very-targeted PR only touches one function, and improves performance on it. The following tests don't call the code that was changed, which means we're looking at spurious failure here:

NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-trusted-component-examples/confirmation-release-examples.test.tsx = 17s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-trusted-component-examples/process-examples.test.tsx = 17s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/contacts/contact-book.test.tsx = 11s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-trusted-component-examples/send-publish-examples.test.tsx = 21s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-trusted-component-examples/disclaimer-examples.test.tsx = 16s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-trusted-component-examples/main.test.tsx = 35s
NEW_PERF_BASELINE: test: pattern-unit-2/pattern-unit-tests = 173s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-trusted-surfaces/main.test.tsx = 20s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-staged-publish/main.test.tsx = 16s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-spec-gallery/main.test.tsx = 23s
