### PR TITLE
ci: shard runner tests

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -72,6 +72,47 @@ jobs:
 
       - name: 🧪 Run parallel workspace tests
         run: deno task test
+        env:
+          TEST_DISABLED_PACKAGES: runner
+
+  runner-test:
+    name: "Runner Tests (${{ matrix.shard }}/${{ matrix.total }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+        total: [4]
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        run: deno install --frozen=true
+
+      - name: 📥 Download Deno dependency binaries
+        run: deno task initialize-db
+
+      - name: 🧪 Run runner tests
+        working-directory: packages/runner
+        run: |
+          TEST_FILES=$(deno run --allow-read ../../tasks/select-runner-test-files.ts ${{ matrix.shard }}/${{ matrix.total }})
+          if [ -z "$TEST_FILES" ]; then
+            echo "::error::No runner test files selected for shard ${{ matrix.shard }}/${{ matrix.total }}"
+            exit 1
+          fi
+          printf 'Runner test shard ${{ matrix.shard }}/${{ matrix.total }} files:\n'
+          printf '  %s\n' $TEST_FILES
+          ENV=test deno test \
+            --allow-ffi \
+            --allow-env \
+            --allow-read \
+            --allow-write=/tmp,/var/folders \
+            --allow-run=git \
+            $TEST_FILES
 
   build-binaries:
     name: "Build Binaries"
@@ -411,6 +452,7 @@ jobs:
       - pattern-integration-test
       - pattern-unit-test
       - generated-patterns-integration-test
+      - runner-test
     permissions:
       contents: read
       actions: read
@@ -440,6 +482,7 @@ jobs:
       [
         "test",
         "check",
+        "runner-test",
         "pattern-integration-test",
         "pattern-unit-test",
         "package-integration-test",

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -187,6 +187,48 @@ Deno.test("extractMetrics aggregates generated patterns matrix shards", () => {
   );
 });
 
+Deno.test("extractMetrics aggregates runner test matrix shards", () => {
+  const metrics = extractMetrics(makeRun(), [
+    makeJob(
+      1,
+      "Runner Tests (1/4)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:40Z",
+      [
+        makeStep(
+          "🧪 Run runner tests",
+          "2026-01-01T00:00:10Z",
+          "2026-01-01T00:01:30Z",
+        ),
+      ],
+    ),
+    makeJob(
+      2,
+      "Runner Tests (2/4)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:10Z",
+      [
+        makeStep(
+          "🧪 Run runner tests",
+          "2026-01-01T00:00:10Z",
+          "2026-01-01T00:01:00Z",
+        ),
+      ],
+    ),
+  ]);
+
+  assertEquals(
+    metrics.get("job: Runner Tests (1/4)")?.durationSeconds,
+    100,
+  );
+  assertEquals(
+    metrics.get("job: Runner Tests (2/4)")?.durationSeconds,
+    70,
+  );
+  assertEquals(metrics.get("job: Runner Tests")?.durationSeconds, 100);
+  assertEquals(metrics.get("step: runner tests")?.durationSeconds, 80);
+});
+
 Deno.test("timingArtifactLabel normalizes matrix shard artifacts", () => {
   assertEquals(
     timingArtifactLabel("test-timing-pattern-integration-1"),

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -603,6 +603,7 @@ const JOB_METRIC_NAMES: Record<string, string> = {
   "Pattern Integration Tests": "job: Pattern Integration Tests",
   "Generated Patterns Integration Tests":
     "job: Generated Patterns Integration Tests",
+  "Runner Tests": "job: Runner Tests",
   "Build Binaries": "job: Build Binaries",
   "Test": "job: Test",
   "Check": "job: Check",
@@ -615,6 +616,7 @@ export const PATTERN_INTEGRATION_RE =
   /Pattern Integration Tests\s*\((\d+)\/(\d+)\)/;
 export const GENERATED_PATTERNS_RE =
   /Generated Patterns Integration Tests\s*\((\d+)\/(\d+)\)/;
+export const RUNNER_TEST_RE = /Runner Tests\s*\((\d+)\/(\d+)\)/;
 
 interface StepMetricMatcher {
   jobName: string;
@@ -652,6 +654,11 @@ const STEP_METRIC_MATCHERS: StepMetricMatcher[] = [
     jobName: "Generated Patterns Integration Tests",
     stepKeyword: "generated patterns integration",
     metricName: "step: generated patterns integration",
+  },
+  {
+    jobName: "Runner Tests",
+    stepKeyword: "runner tests",
+    metricName: "step: runner tests",
   },
   {
     jobName: "CLI Integration Tests (core)",
@@ -729,6 +736,7 @@ export function extractMetrics(
     const generatedPatternsMatch = GENERATED_PATTERNS_RE.exec(
       normalizedJobName,
     );
+    const runnerTestMatch = RUNNER_TEST_RE.exec(normalizedJobName);
 
     const matcherJobName = unitMatch
       ? "Pattern Unit Tests"
@@ -736,6 +744,8 @@ export function extractMetrics(
       ? "Pattern Integration Tests"
       : generatedPatternsMatch
       ? "Generated Patterns Integration Tests"
+      : runnerTestMatch
+      ? "Runner Tests"
       : normalizedJobName;
 
     if (unitMatch) {
@@ -767,6 +777,15 @@ export function extractMetrics(
       setMaxMetric("job: Generated Patterns Integration Tests", sample);
     }
 
+    if (runnerTestMatch) {
+      const sample = makeSample(jobDuration);
+      metrics.set(
+        `job: Runner Tests (${runnerTestMatch[1]}/${runnerTestMatch[2]})`,
+        sample,
+      );
+      setMaxMetric("job: Runner Tests", sample);
+    }
+
     if (normalizedJobName.includes("Test and Build")) {
       metrics.set("job: Test and Build", makeSample(jobDuration));
     }
@@ -782,7 +801,10 @@ export function extractMetrics(
           normalizedStepName.includes(matcher.stepKeyword)
         ) {
           const sample = makeSample(stepDuration);
-          if (patternIntegrationMatch || generatedPatternsMatch) {
+          if (
+            patternIntegrationMatch || generatedPatternsMatch ||
+            runnerTestMatch
+          ) {
             setMaxMetric(matcher.metricName, sample);
           } else {
             metrics.set(matcher.metricName, sample);

--- a/tasks/select-runner-test-files.test.ts
+++ b/tasks/select-runner-test-files.test.ts
@@ -1,0 +1,39 @@
+import { assertEquals } from "@std/assert";
+import {
+  parseShard,
+  selectRunnerTestFiles,
+} from "./select-runner-test-files.ts";
+
+Deno.test("parseShard parses shard notation", () => {
+  assertEquals(parseShard("2/4"), { index: 2, total: 4 });
+});
+
+Deno.test("parseShard rejects invalid shard notation", () => {
+  try {
+    parseShard("5/4");
+    throw new Error("expected parseShard to throw");
+  } catch (error) {
+    assertEquals(
+      (error as Error).message,
+      "Shard index 5 exceeds total shard count 4",
+    );
+  }
+});
+
+Deno.test("selectRunnerTestFiles balances by file size", () => {
+  const files = [
+    { name: "large.test.ts", size: 100 },
+    { name: "medium.test.ts", size: 60 },
+    { name: "small-a.test.ts", size: 20 },
+    { name: "small-b.test.ts", size: 20 },
+  ];
+
+  assertEquals(selectRunnerTestFiles(files, { index: 1, total: 2 }), [
+    "large.test.ts",
+  ]);
+  assertEquals(selectRunnerTestFiles(files, { index: 2, total: 2 }), [
+    "medium.test.ts",
+    "small-a.test.ts",
+    "small-b.test.ts",
+  ]);
+});

--- a/tasks/select-runner-test-files.ts
+++ b/tasks/select-runner-test-files.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env -S deno run --allow-read
+
+type Shard = {
+  index: number;
+  total: number;
+};
+
+type RunnerTestFile = {
+  name: string;
+  size: number;
+};
+
+export function parseShard(raw: string): Shard {
+  const match = raw.match(/^([1-9][0-9]*)\/([1-9][0-9]*)$/);
+  if (!match) {
+    throw new Error(`Expected shard argument like 1/4, got: ${raw}`);
+  }
+
+  const index = Number(match[1]);
+  const total = Number(match[2]);
+  if (index > total) {
+    throw new Error(`Shard index ${index} exceeds total shard count ${total}`);
+  }
+
+  return { index, total };
+}
+
+export function selectRunnerTestFiles(
+  files: RunnerTestFile[],
+  shard: Shard,
+): string[] {
+  const buckets = Array.from({ length: shard.total }, () => ({
+    size: 0,
+    names: [] as string[],
+  }));
+
+  for (
+    const file of [...files].sort((a, b) =>
+      b.size - a.size || a.name.localeCompare(b.name)
+    )
+  ) {
+    const bucket = buckets.reduce((smallest, candidate) =>
+      candidate.size < smallest.size ? candidate : smallest
+    );
+    bucket.size += file.size;
+    bucket.names.push(file.name);
+  }
+
+  return buckets[shard.index - 1].names.sort();
+}
+
+async function listRunnerTests(): Promise<RunnerTestFile[]> {
+  const testDir = new URL("../packages/runner/test/", import.meta.url);
+  const files: RunnerTestFile[] = [];
+
+  for await (const entry of Deno.readDir(testDir)) {
+    if (entry.isFile && entry.name.endsWith(".test.ts")) {
+      const info = await Deno.stat(new URL(entry.name, testDir));
+      files.push({ name: entry.name, size: info.size });
+    }
+  }
+
+  files.sort((a, b) => a.name.localeCompare(b.name));
+  return files;
+}
+
+if (import.meta.main) {
+  const shard = parseShard(Deno.args[0] ?? "");
+  const files = await listRunnerTests();
+  const selected = selectRunnerTestFiles(files, shard)
+    .map((name) => `./test/${name}`);
+
+  if (selected.length === 0) {
+    throw new Error(`No runner test files selected for ${Deno.args[0]}`);
+  }
+
+  console.log(selected.join("\n"));
+}

--- a/tasks/test.test.ts
+++ b/tasks/test.test.ts
@@ -1,0 +1,16 @@
+import { assertEquals } from "@std/assert";
+import { parseDisabledPackageList } from "./test.ts";
+
+Deno.test("parseDisabledPackageList parses comma and whitespace separated names", () => {
+  assertEquals(parseDisabledPackageList("runner, ui\nshell\tcli"), [
+    "runner",
+    "ui",
+    "shell",
+    "cli",
+  ]);
+});
+
+Deno.test("parseDisabledPackageList ignores empty entries", () => {
+  assertEquals(parseDisabledPackageList(" runner, ,ui "), ["runner", "ui"]);
+  assertEquals(parseDisabledPackageList(undefined), []);
+});

--- a/tasks/test.ts
+++ b/tasks/test.ts
@@ -12,6 +12,10 @@ export function getPackageName(memberPath: string): string {
   return relativePath.replace(/^packages\//, "");
 }
 
+export function parseDisabledPackageList(raw: string | undefined): string[] {
+  return (raw ?? "").split(/[,\s]+/).filter((name) => name.length > 0);
+}
+
 export async function testPackage(
   memberPath: string,
   packageName: string,
@@ -109,5 +113,8 @@ export async function runTests(disabledPackages: string[]): Promise<boolean> {
 
 // Only run if this is the main module
 if (import.meta.main) {
-  await runTests(ALL_DISABLED);
+  await runTests([
+    ...ALL_DISABLED,
+    ...parseDisabledPackageList(Deno.env.get("TEST_DISABLED_PACKAGES")),
+  ]);
 }


### PR DESCRIPTION
## Why

The main `Test` job is still pinned by `packages/runner` after the prior generated-patterns split (#3533). Latest measurements before this branch had runner at about 168s, with the next slowest package closer to 56s, so the root workspace job could not benefit much from the earlier CI sharding work.

## What Changed

- Added `TEST_DISABLED_PACKAGES` support to `tasks/test.ts` and used it to skip `runner` in the root workflow test job.
- Added a four-way `Runner Tests` matrix job that selects `packages/runner/test/*.test.ts` deterministically by file size.
- Added tests for the selector and disabled-package parser.
- Taught perf metrics extraction to aggregate the runner matrix.

## Test plan

- `deno fmt .github/workflows/deno.yml tasks/test.ts tasks/test.test.ts tasks/select-runner-test-files.ts tasks/select-runner-test-files.test.ts tasks/perf-lib.ts tasks/perf-lib.test.ts`
- `deno test --allow-read --allow-env tasks/test.test.ts tasks/select-runner-test-files.test.ts tasks/perf-lib.test.ts`
- `deno check tasks/test.ts tasks/test.test.ts tasks/select-runner-test-files.ts tasks/select-runner-test-files.test.ts tasks/perf-lib.ts tasks/perf-lib.test.ts`
- `deno lint tasks/test.ts tasks/test.test.ts tasks/select-runner-test-files.ts tasks/select-runner-test-files.test.ts tasks/perf-lib.ts tasks/perf-lib.test.ts`
- `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/deno.yml\"); puts \"yaml ok\""`
- Verified selector coverage: `all=165 selected=165 unique=165 missing=0 extra=0`
- `env TEST_DISABLED_PACKAGES=runner deno task test`
- Runner shards 1/4 through 4/4 all passed locally