### PR TITLE
ci: record cli integration timings

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -320,7 +320,11 @@ jobs:
         working-directory: packages/cli
         env:
           TOOLSHED_PORT: ${{ matrix.toolshed_port }}
+          CF_CLI_INTEGRATION_TIMINGS: "1"
+          CF_CLI_INTEGRATION_TIMINGS_FILE: "../../test-results/cli-core-cf-timings.log"
         run: |
+          mkdir -p ../../test-results
+          : > "$CF_CLI_INTEGRATION_TIMINGS_FILE"
           API_URL="http://localhost:${TOOLSHED_PORT}" ./integration/${{ matrix.script }}
 
       - name: 🧪 Run CLI FUSE integration suite
@@ -342,6 +346,15 @@ jobs:
       - name: 📋 FUSE daemon log (on failure)
         if: ${{ failure() && matrix.suite_name == 'fuse' }}
         run: cat ~/.cf/fuse/fuse-daemon.log 2>/dev/null || echo "No daemon log found"
+
+      - name: 📤 Upload CLI integration timing data
+        if: ${{ always() && matrix.suite_name == 'core' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-timing-cli-core
+          path: test-results/cli-core-cf-timings.log
+          retention-days: 90
+          if-no-files-found: ignore
 
   pattern-integration-test:
     name: "Pattern Integration Tests (${{ matrix.shard }}/${{ matrix.total }})"

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -51,7 +51,11 @@ cf() {
   local status=$?
   local end_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
   local elapsed_ms=$((end_ms - start_ms))
-  >&2 echo "[cf-timing] ${elapsed_ms}ms :: cf $*"
+  local timing_line="[cf-timing] ${elapsed_ms}ms :: cf $*"
+  >&2 echo "$timing_line"
+  if [ -n "${CF_CLI_INTEGRATION_TIMINGS_FILE:-}" ]; then
+    printf '%s\n' "$timing_line" >> "$CF_CLI_INTEGRATION_TIMINGS_FILE"
+  fi
   return $status
 }
 


### PR DESCRIPTION
## Why

After #3536, `CLI Integration Tests (core)` is the longest PR-path job. Before splitting that stateful shell integration script, we need per-command timing data from the real CI environment so the split is based on measured cost rather than guesses.

## What Changed

- Enables the existing `CF_CLI_INTEGRATION_TIMINGS` wrapper for the core CLI integration matrix leg.
- Adds optional `CF_CLI_INTEGRATION_TIMINGS_FILE` support so timing lines are saved while still printing to CI logs.
- Uploads the core CLI timing file as `test-timing-cli-core`.

## Test plan

- `deno fmt .github/workflows/deno.yml`
- `bash -n packages/cli/integration/integration.sh`
- `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/deno.yml\"); puts \"yaml ok\""`