### PR TITLE
ci: split CLI core integration tests

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -272,14 +272,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - suite_name: core
+          - suite_name: core-piece-basics
             script: integration.sh
+            section: piece-basics
             toolshed_port: 8000
+            install_fuse_deps: false
+            timeout_minutes: 10
+          - suite_name: core-piece-call
+            script: integration.sh
+            section: piece-call
+            toolshed_port: 8001
             install_fuse_deps: false
             timeout_minutes: 10
           - suite_name: fuse
             script: fuse-exec.sh
-            toolshed_port: 8001
+            section: ""
+            toolshed_port: 8002
             install_fuse_deps: true
             timeout_minutes: 15
     steps:
@@ -316,12 +324,13 @@ jobs:
           fi
 
       - name: 🧪 Run CLI integration suite
-        if: ${{ matrix.suite_name == 'core' }}
+        if: ${{ startsWith(matrix.suite_name, 'core-') }}
         working-directory: packages/cli
         env:
           TOOLSHED_PORT: ${{ matrix.toolshed_port }}
+          CF_CLI_INTEGRATION_SECTION: ${{ matrix.section }}
           CF_CLI_INTEGRATION_TIMINGS: "1"
-          CF_CLI_INTEGRATION_TIMINGS_FILE: "../../test-results/cli-core-cf-timings.log"
+          CF_CLI_INTEGRATION_TIMINGS_FILE: "../../test-results/cli-${{ matrix.suite_name }}-cf-timings.log"
         run: |
           mkdir -p ../../test-results
           : > "$CF_CLI_INTEGRATION_TIMINGS_FILE"
@@ -348,11 +357,11 @@ jobs:
         run: cat ~/.cf/fuse/fuse-daemon.log 2>/dev/null || echo "No daemon log found"
 
       - name: 📤 Upload CLI integration timing data
-        if: ${{ always() && matrix.suite_name == 'core' }}
+        if: ${{ always() && startsWith(matrix.suite_name, 'core-') }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-timing-cli-core
-          path: test-results/cli-core-cf-timings.log
+          name: test-timing-cli-${{ matrix.suite_name }}
+          path: test-results/cli-${{ matrix.suite_name }}-cf-timings.log
           retention-days: 90
           if-no-files-found: ignore
 

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -59,72 +59,33 @@ cf() {
   return $status
 }
 
-if [ -z "$API_URL" ]; then
-  error "API_URL must be defined."
-fi
-SPACE=$(mktemp -u XXXXXXXXXX) # generates a random space
-IDENTITY=$(mktemp)
-SPACE_ARGS="--api-url=$API_URL --identity=$IDENTITY --space=$SPACE"
 PATTERN_SRC="$SCRIPT_DIR/pattern/main.tsx"
-WORK_DIR=$(mktemp -d)
 CUSTOM_EXPORT="customPatternExport" # for testing this feature
+SECTION="${CF_CLI_INTEGRATION_SECTION:-${1:-all}}"
 
-echo "API_URL=$API_URL"
-echo "SPACE=$SPACE"
-echo "IDENTITY=$IDENTITY"
-echo "WORK_DIR=$WORK_DIR"
+setup_space() {
+  if [ -z "$API_URL" ]; then
+    error "API_URL must be defined."
+  fi
 
-# Create a key
-cf id new > $IDENTITY
+  SPACE=$(mktemp -u XXXXXXXXXX) # generates a random space
+  IDENTITY=$(mktemp)
+  SPACE_ARGS="--api-url=$API_URL --identity=$IDENTITY --space=$SPACE"
+  WORK_DIR=$(mktemp -d)
 
-# Check space is empty
-if [ "$(cf piece ls $SPACE_ARGS)" != "" ]; then
-  error "Space not empty."
-fi
+  echo "API_URL=$API_URL"
+  echo "SPACE=$SPACE"
+  echo "IDENTITY=$IDENTITY"
+  echo "WORK_DIR=$WORK_DIR"
 
-# Create a new piece using custom default export as input
-PIECE_ID=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS $PATTERN_SRC)
-echo "Created piece: $PIECE_ID"
+  # Create a key
+  cf id new > "$IDENTITY"
 
-echo "Fetching piece source to $WORK_DIR"
-# Retrieve the source code for $PIECE_ID to $WORK_DIR
-cf piece getsrc $SPACE_ARGS --piece $PIECE_ID $WORK_DIR
-
-# Check file was retrieved
-if [ ! -f "$WORK_DIR/main.tsx" ]; then
-  error "Source code was not retrieved from $PIECE_ID"
-fi
-if [ ! -f "$WORK_DIR/utils.ts" ]; then
-  error "Source code was not retrieved from $PIECE_ID"
-fi
-
-echo "Updating piece source."
-
-# Update the piece's source code
-replace 's/Simple counter:/Simple counter 2:/g' "$WORK_DIR/main.tsx"
-cf piece setsrc --main-export $CUSTOM_EXPORT $SPACE_ARGS --piece $PIECE_ID $WORK_DIR/main.tsx
-
-# (Again) Retrieve the source code for $PIECE_ID to $WORK_DIR
-rm "$WORK_DIR/main.tsx"
-cf piece getsrc $SPACE_ARGS --piece $PIECE_ID $WORK_DIR
-
-# Check file was retrieved with modifications
-grep -q "Simple counter 2" "$WORK_DIR/main.tsx"
-if [ $? -ne 0 ]; then
-  error "Retrieved source code was not modified"
-fi
-
-echo "Applying piece input."
-
-# Apply new input to piece
-echo '{"value":5}' | cf piece apply $SPACE_ARGS --piece $PIECE_ID
-
-# get, set and then re-get a value from the piece
-echo '10' | cf piece set $SPACE_ARGS --piece $PIECE_ID value
-
-# Verify the get returned what we expect
-RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID value)
-assert_json_eq "$RESULT" '10' "Get operation did not return expected value. Expected: 10, Got: $RESULT"
+  # Check space is empty
+  if [ "$(cf piece ls $SPACE_ARGS)" != "" ]; then
+    error "Space not empty."
+  fi
+}
 
 # Helper functions for testing
 test_value() {
@@ -187,181 +148,250 @@ test_get_only() {
   fi
 }
 
-echo "Testing different data types and nested paths..."
+run_piece_basics() {
+  setup_space
 
-# Test different data types
-test_value "String value" "stringField" '"hello world"' '"hello world"'
-test_value "Number value" "numberField" '42' '42'
-test_value "Boolean value" "booleanField" 'true' 'true'
-test_json_value "Array value" "arrayField" '[1,2,3]'
-test_json_value "Nested object" "userData" '{"user":{"name":"John","age":30}}'
+  # Create a new piece using custom default export as input
+  PIECE_ID=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS $PATTERN_SRC)
+  echo "Created piece: $PIECE_ID"
 
-# Test nested path access
-test_get_only "Nested path access" "userData/user/name" '"John"'
-test_json_value "Array indexing" "listField" '["first","second","third"]'
-test_get_only "Array index access" "listField/1" '"second"'
+  echo "Fetching piece source to $WORK_DIR"
+  # Retrieve the source code for $PIECE_ID to $WORK_DIR
+  cf piece getsrc $SPACE_ARGS --piece $PIECE_ID $WORK_DIR
 
-# Test setting nested value
-test_value "Nested path set" "userData/user/name" '"Jane"' '"Jane"'
+  # Check file was retrieved
+  if [ ! -f "$WORK_DIR/main.tsx" ]; then
+    error "Source code was not retrieved from $PIECE_ID"
+  fi
+  if [ ! -f "$WORK_DIR/utils.ts" ]; then
+    error "Source code was not retrieved from $PIECE_ID"
+  fi
 
-echo "Testing --input flag operations..."
+  echo "Updating piece source."
 
-# Test input flag operations
-test_json_value "Input flag set" "userData" '{"user":{"name":"test"}}' "--input"
-test_value "Nested input path" "userData/user/name" '"inputValue"' '"inputValue"' "--input"
+  # Update the piece's source code
+  replace 's/Simple counter:/Simple counter 2:/g' "$WORK_DIR/main.tsx"
+  cf piece setsrc --main-export $CUSTOM_EXPORT $SPACE_ARGS --piece $PIECE_ID $WORK_DIR/main.tsx
 
-echo "Testing piece step..."
+  # (Again) Retrieve the source code for $PIECE_ID to $WORK_DIR
+  rm "$WORK_DIR/main.tsx"
+  cf piece getsrc $SPACE_ARGS --piece $PIECE_ID $WORK_DIR
 
-# Recompute (one iteration) with updated inputs
-cf piece step $SPACE_ARGS --piece $PIECE_ID
+  # Check file was retrieved with modifications
+  if ! grep -q "Simple counter 2" "$WORK_DIR/main.tsx"; then
+    error "Retrieved source code was not modified"
+  fi
 
-# Check space has new piece with correct inputs and title
-TITLE="Simple counter 2: 10"
-if ! cf piece ls $SPACE_ARGS | grep -q "$PIECE_ID $TITLE <unnamed>"; then
-  error "Piece did not appear in list of space pieces."
-fi
+  echo "Applying piece input."
 
-echo "Testing piece link..."
+  # Apply new input to piece
+  echo '{"value":5}' | cf piece apply $SPACE_ARGS --piece $PIECE_ID
 
-# Create a second piece from the same pattern
-PIECE_ID2=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS $PATTERN_SRC)
-echo "Created second piece: $PIECE_ID2"
+  # get, set and then re-get a value from the piece
+  echo '10' | cf piece set $SPACE_ARGS --piece $PIECE_ID value
 
-# Initialize piece2 with value 0 and step so output is computed
-echo '0' | cf piece set $SPACE_ARGS --piece $PIECE_ID2 value --input
-cf piece step $SPACE_ARGS --piece $PIECE_ID2
+  # Verify the get returned what we expect
+  RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID value)
+  assert_json_eq "$RESULT" '10' "Get operation did not return expected value. Expected: 10, Got: $RESULT"
 
-# Verify piece2 starts with value 0
-RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID2 value)
-if [ "$RESULT" != "0" ]; then
-  error "Piece2 value should be 0 before linking, got: $RESULT"
-fi
+  echo "Testing different data types and nested paths..."
 
-# Linking from a nonexistent source path should fail
-if cf piece link $SPACE_ARGS $PIECE_ID/nonexistent $PIECE_ID2/value 2>/dev/null; then
-  error "Linking from nonexistent source path should have failed"
-fi
+  # Test different data types
+  test_value "String value" "stringField" '"hello world"' '"hello world"'
+  test_value "Number value" "numberField" '42' '42'
+  test_value "Boolean value" "booleanField" 'true' 'true'
+  test_json_value "Array value" "arrayField" '[1,2,3]'
+  test_json_value "Nested object" "userData" '{"user":{"name":"John","age":30}}'
 
-# Linking to a nonexistent target path should fail
-if cf piece link $SPACE_ARGS $PIECE_ID/value $PIECE_ID2/nonexistent 2>/dev/null; then
-  error "Linking to nonexistent target path should have failed"
-fi
+  # Test nested path access
+  test_get_only "Nested path access" "userData/user/name" '"John"'
+  test_json_value "Array indexing" "listField" '["first","second","third"]'
+  test_get_only "Array index access" "listField/1" '"second"'
 
-# Link piece1's output value to piece2's input value
-cf piece link $SPACE_ARGS $PIECE_ID/value $PIECE_ID2/value
+  # Test setting nested value
+  test_value "Nested path set" "userData/user/name" '"Jane"' '"Jane"'
 
-# Read back piece2's input value - should be piece1's output value (10)
-RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID2 value --input)
-if [ "$RESULT" != "10" ]; then
-  error "After linking, piece2's input value should be 10 (from piece1), got: $RESULT"
-fi
+  echo "Testing --input flag operations..."
 
-# Step piece2 to recompute with linked input
-cf piece step $SPACE_ARGS --piece $PIECE_ID2
+  # Test input flag operations
+  test_json_value "Input flag set" "userData" '{"user":{"name":"test"}}' "--input"
+  test_value "Nested input path" "userData/user/name" '"inputValue"' '"inputValue"' "--input"
 
-# Verify piece2's output value is now 10 (from piece1 via link)
-RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID2 value)
-if [ "$RESULT" != "10" ]; then
-  error "After linking and stepping, piece2's output value should be 10, got: $RESULT"
-fi
+  echo "Testing piece step..."
 
-# Call increment handler on piece2 — since its value is linked to piece1's
-# output cell, this should update piece1's value too
-cf piece call $SPACE_ARGS --piece $PIECE_ID2 increment '{}'
+  # Recompute (one iteration) with updated inputs
+  cf piece step $SPACE_ARGS --piece $PIECE_ID
 
-# Verify piece1's value is now 11 (was 10, incremented via piece2's handler)
-RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID value)
-if [ "$RESULT" != "11" ]; then
-  error "After calling increment on piece2, piece1's value should be 11, got: $RESULT"
-fi
+  # Check space has new piece with correct inputs and title
+  TITLE="Simple counter 2: 10"
+  if ! cf piece ls $SPACE_ARGS | grep -q "$PIECE_ID $TITLE <unnamed>"; then
+    error "Piece did not appear in list of space pieces."
+  fi
 
-echo "Testing piece link with invented piece ID..."
+  echo "Testing piece link..."
 
-# Use an invented piece ID (not created via cf piece new) as a data source
-INVENTED_ID="baedreizzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+  # Create a second piece from the same pattern
+  PIECE_ID2=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS $PATTERN_SRC)
+  echo "Created second piece: $PIECE_ID2"
 
-# Write a value to the invented piece
-echo '42' | cf piece set $SPACE_ARGS --piece $INVENTED_ID value
+  # Initialize piece2 with value 0 and step so output is computed
+  echo '0' | cf piece set $SPACE_ARGS --piece $PIECE_ID2 value --input
+  cf piece step $SPACE_ARGS --piece $PIECE_ID2
 
-# Create a third piece and link the invented piece's value to its input
-PIECE_ID3=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS $PATTERN_SRC)
-echo "Created third piece: $PIECE_ID3"
+  # Verify piece2 starts with value 0
+  RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID2 value)
+  if [ "$RESULT" != "0" ]; then
+    error "Piece2 value should be 0 before linking, got: $RESULT"
+  fi
 
-# Linking from invented piece should fail without --allow-non-existing
-if cf piece link $SPACE_ARGS $INVENTED_ID/value $PIECE_ID3/value 2>/dev/null; then
-  error "Linking from invented piece should have failed without --allow-non-existing"
-fi
+  # Linking from a nonexistent source path should fail
+  if cf piece link $SPACE_ARGS $PIECE_ID/nonexistent $PIECE_ID2/value 2>/dev/null; then
+    error "Linking from nonexistent source path should have failed"
+  fi
 
-# Now link with --allow-non-existing
-cf piece link $SPACE_ARGS --allow-non-existing $INVENTED_ID/value $PIECE_ID3/value
+  # Linking to a nonexistent target path should fail
+  if cf piece link $SPACE_ARGS $PIECE_ID/value $PIECE_ID2/nonexistent 2>/dev/null; then
+    error "Linking to nonexistent target path should have failed"
+  fi
 
-# Read back piece3's input value - should be 42 from the invented piece
-RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID3 value --input)
-if [ "$RESULT" != "42" ]; then
-  error "After linking invented piece, piece3's input value should be 42, got: $RESULT"
-fi
+  # Link piece1's output value to piece2's input value
+  cf piece link $SPACE_ARGS $PIECE_ID/value $PIECE_ID2/value
 
-# Step piece3 to recompute with linked input
-cf piece step $SPACE_ARGS --piece $PIECE_ID3
+  # Read back piece2's input value - should be piece1's output value (10)
+  RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID2 value --input)
+  if [ "$RESULT" != "10" ]; then
+    error "After linking, piece2's input value should be 10 (from piece1), got: $RESULT"
+  fi
 
-# Verify piece3's output value is 42
-RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID3 value)
-if [ "$RESULT" != "42" ]; then
-  error "After stepping piece3 with invented link, output value should be 42, got: $RESULT"
-fi
+  # Step piece2 to recompute with linked input
+  cf piece step $SPACE_ARGS --piece $PIECE_ID2
 
-# Call increment on piece3 and verify the invented piece's value updates
-cf piece call $SPACE_ARGS --piece $PIECE_ID3 increment '{}'
+  # Verify piece2's output value is now 10 (from piece1 via link)
+  RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID2 value)
+  if [ "$RESULT" != "10" ]; then
+    error "After linking and stepping, piece2's output value should be 10, got: $RESULT"
+  fi
 
-RESULT=$(cf piece get $SPACE_ARGS --piece $INVENTED_ID value)
-if [ "$RESULT" != "43" ]; then
-  error "After calling increment on piece3, invented piece's value should be 43, got: $RESULT"
-fi
+  # Call increment handler on piece2; since its value is linked to piece1's
+  # output cell, this should update piece1's value too.
+  cf piece call $SPACE_ARGS --piece $PIECE_ID2 increment '{}'
 
-echo "Testing piece call with schema-derived flags and tools..."
+  # Verify piece1's value is now 11 (was 10, incremented via piece2's handler)
+  RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID value)
+  if [ "$RESULT" != "11" ]; then
+    error "After calling increment on piece2, piece1's value should be 11, got: $RESULT"
+  fi
 
-CALLABLE_PATTERN_SRC="$SCRIPT_DIR/pattern/fuse-exec.tsx"
-CALLABLE_PIECE_ID=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS $CALLABLE_PATTERN_SRC)
-echo "Created callable piece: $CALLABLE_PIECE_ID"
+  echo "Testing piece link with invented piece ID..."
 
-CALL_HELP=$(cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID search --help)
-echo "$CALL_HELP" | grep -q "cf piece call ... search --help" ||
-  error "Top-level callable help should work without the delimiter"
-echo "$CALL_HELP" | grep -q "cf piece call ... search <json>" ||
-  error "Piece-call help should describe JSON input without --json"
+  # Use an invented piece ID (not created via cf piece new) as a data source
+  INVENTED_ID="baedreizzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
 
-CALL_HELP_JSON=$(cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID search --help --json)
-echo "$CALL_HELP_JSON" | jq -e '.inputSchema.properties.query.type == "string"' > /dev/null ||
-  error "Top-level --help --json should return the machine-readable schema"
+  # Write a value to the invented piece
+  echo '42' | cf piece set $SPACE_ARGS --piece $INVENTED_ID value
 
-# --json is now a registered no-op on cf piece call (CT-1393): agents expect
-# it to work because it's valid on all other piece subcommands.
-cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID search --json < /dev/null > /dev/null 2>&1 ||
-  error "Redundant --json should be accepted (no-op) on cf piece call"
+  # Create a third piece and link the invented piece's value to its input
+  PIECE_ID3=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS $PATTERN_SRC)
+  echo "Created third piece: $PIECE_ID3"
 
-cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID recordMessage -- --message "piece-flags"
-RESULT=$(cf piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID lastMessage)
-if [ "$RESULT" != '"piece-flags"' ]; then
-  error "Flag-based handler call should update lastMessage, got: $RESULT"
-fi
+  # Linking from invented piece should fail without --allow-non-existing
+  if cf piece link $SPACE_ARGS $INVENTED_ID/value $PIECE_ID3/value 2>/dev/null; then
+    error "Linking from invented piece should have failed without --allow-non-existing"
+  fi
 
-LEGACY_COUNT_BEFORE=$(read_piece_value_or_default "$CALLABLE_PIECE_ID" "legacyCount" "0")
-cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyWrite
-RESULT=$(cf piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyCount)
-if [ "$RESULT" != "$((LEGACY_COUNT_BEFORE + 1))" ]; then
-  error "Bare no-arg handler call should increment legacyCount, got: $RESULT"
-fi
+  # Now link with --allow-non-existing
+  cf piece link $SPACE_ARGS --allow-non-existing $INVENTED_ID/value $PIECE_ID3/value
 
-cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyWrite -- invoke
-RESULT=$(cf piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyCount)
-if [ "$RESULT" != "$((LEGACY_COUNT_BEFORE + 2))" ]; then
-  error "Explicit invoke should still call an empty-object handler, got legacyCount=$RESULT"
-fi
+  # Read back piece3's input value - should be 42 from the invented piece
+  RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID3 value --input)
+  if [ "$RESULT" != "42" ]; then
+    error "After linking invented piece, piece3's input value should be 42, got: $RESULT"
+  fi
 
-TOOL_RESULT=$(cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID search -- --query tea)
-assert_json_eq \
-  "$TOOL_RESULT" \
-  '{"query":"tea","help":"","source":"bound-source","summary":"bound-source:tea:"}' \
-  "Flag-based tool call should return the tool result"
+  # Step piece3 to recompute with linked input
+  cf piece step $SPACE_ARGS --piece $PIECE_ID3
 
-echo "Successfully ran integration tests for ${API_URL}/${SPACE}/${PIECE_ID}."
+  # Verify piece3's output value is 42
+  RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID3 value)
+  if [ "$RESULT" != "42" ]; then
+    error "After stepping piece3 with invented link, output value should be 42, got: $RESULT"
+  fi
+
+  # Call increment on piece3 and verify the invented piece's value updates
+  cf piece call $SPACE_ARGS --piece $PIECE_ID3 increment '{}'
+
+  RESULT=$(cf piece get $SPACE_ARGS --piece $INVENTED_ID value)
+  if [ "$RESULT" != "43" ]; then
+    error "After calling increment on piece3, invented piece's value should be 43, got: $RESULT"
+  fi
+
+  echo "Successfully ran CLI piece basics integration tests for ${API_URL}/${SPACE}/${PIECE_ID}."
+}
+
+run_piece_call() {
+  setup_space
+
+  echo "Testing piece call with schema-derived flags and tools..."
+
+  CALLABLE_PATTERN_SRC="$SCRIPT_DIR/pattern/fuse-exec.tsx"
+  CALLABLE_PIECE_ID=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS $CALLABLE_PATTERN_SRC)
+  echo "Created callable piece: $CALLABLE_PIECE_ID"
+
+  CALL_HELP=$(cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID search --help)
+  echo "$CALL_HELP" | grep -q "cf piece call ... search --help" ||
+    error "Top-level callable help should work without the delimiter"
+  echo "$CALL_HELP" | grep -q "cf piece call ... search <json>" ||
+    error "Piece-call help should describe JSON input without --json"
+
+  CALL_HELP_JSON=$(cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID search --help --json)
+  echo "$CALL_HELP_JSON" | jq -e '.inputSchema.properties.query.type == "string"' > /dev/null ||
+    error "Top-level --help --json should return the machine-readable schema"
+
+  # --json is now a registered no-op on cf piece call (CT-1393): agents expect
+  # it to work because it's valid on all other piece subcommands.
+  cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID search --json < /dev/null > /dev/null 2>&1 ||
+    error "Redundant --json should be accepted (no-op) on cf piece call"
+
+  cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID recordMessage -- --message "piece-flags"
+  RESULT=$(cf piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID lastMessage)
+  if [ "$RESULT" != '"piece-flags"' ]; then
+    error "Flag-based handler call should update lastMessage, got: $RESULT"
+  fi
+
+  LEGACY_COUNT_BEFORE=$(read_piece_value_or_default "$CALLABLE_PIECE_ID" "legacyCount" "0")
+  cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyWrite
+  RESULT=$(cf piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyCount)
+  if [ "$RESULT" != "$((LEGACY_COUNT_BEFORE + 1))" ]; then
+    error "Bare no-arg handler call should increment legacyCount, got: $RESULT"
+  fi
+
+  cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyWrite -- invoke
+  RESULT=$(cf piece get $SPACE_ARGS --piece $CALLABLE_PIECE_ID legacyCount)
+  if [ "$RESULT" != "$((LEGACY_COUNT_BEFORE + 2))" ]; then
+    error "Explicit invoke should still call an empty-object handler, got legacyCount=$RESULT"
+  fi
+
+  TOOL_RESULT=$(cf piece call $SPACE_ARGS --piece $CALLABLE_PIECE_ID search -- --query tea)
+  assert_json_eq \
+    "$TOOL_RESULT" \
+    '{"query":"tea","help":"","source":"bound-source","summary":"bound-source:tea:"}' \
+    "Flag-based tool call should return the tool result"
+
+  echo "Successfully ran CLI piece call integration tests for ${API_URL}/${SPACE}/${CALLABLE_PIECE_ID}."
+}
+
+case "$SECTION" in
+  all)
+    run_piece_basics
+    run_piece_call
+    ;;
+  piece-basics)
+    run_piece_basics
+    ;;
+  piece-call)
+    run_piece_call
+    ;;
+  *)
+    error "Unknown CLI integration section: $SECTION"
+    ;;
+esac

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -89,6 +89,58 @@ Deno.test("extractMetrics keeps CLI core and fuse timings separate", () => {
   assertEquals(metrics.has("step: CLI integration"), false);
 });
 
+Deno.test("extractMetrics aggregates split CLI core jobs", () => {
+  const metrics = extractMetrics(makeRun(), [
+    makeJob(
+      1,
+      "CLI Integration Tests (core-piece-basics)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:03:20Z",
+      [
+        makeStep(
+          "🧪 Run CLI integration suite",
+          "2026-01-01T00:01:00Z",
+          "2026-01-01T00:03:00Z",
+        ),
+      ],
+    ),
+    makeJob(
+      2,
+      "CLI Integration Tests (core-piece-call)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:02:40Z",
+      [
+        makeStep(
+          "🧪 Run CLI integration suite",
+          "2026-01-01T00:01:00Z",
+          "2026-01-01T00:02:30Z",
+        ),
+      ],
+    ),
+  ]);
+
+  assertEquals(
+    metrics.get("job: CLI Integration Tests (core-piece-basics)")
+      ?.durationSeconds,
+    200,
+  );
+  assertEquals(
+    metrics.get("job: CLI Integration Tests (core-piece-call)")
+      ?.durationSeconds,
+    160,
+  );
+  assertEquals(
+    metrics.get("job: CLI Integration Tests (core)")?.durationSeconds,
+    200,
+  );
+  assertEquals(
+    metrics.get("step: CLI integration (core)")?.durationSeconds,
+    120,
+  );
+  assertEquals(metrics.has("job: CLI Integration Tests"), false);
+  assertEquals(metrics.has("step: CLI integration"), false);
+});
+
 Deno.test("extractMetrics aggregates pattern integration matrix shards", () => {
   const metrics = extractMetrics(makeRun(), [
     makeJob(

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -597,6 +597,10 @@ export function normalizeName(name: string): string {
 const JOB_METRIC_NAMES: Record<string, string> = {
   "Package Integration Tests": "job: Package Integration Tests",
   "CLI Integration Tests (core)": "job: CLI Integration Tests (core)",
+  "CLI Integration Tests (core-piece-basics)":
+    "job: CLI Integration Tests (core-piece-basics)",
+  "CLI Integration Tests (core-piece-call)":
+    "job: CLI Integration Tests (core-piece-call)",
   "CLI Integration Tests (fuse)": "job: CLI Integration Tests (fuse)",
   // Legacy pre-matrix job name retained for older baselines and overrides.
   "CLI Integration Tests": "job: CLI Integration Tests",
@@ -617,6 +621,7 @@ export const PATTERN_INTEGRATION_RE =
 export const GENERATED_PATTERNS_RE =
   /Generated Patterns Integration Tests\s*\((\d+)\/(\d+)\)/;
 export const RUNNER_TEST_RE = /Runner Tests\s*\((\d+)\/(\d+)\)/;
+export const CLI_CORE_SPLIT_RE = /CLI Integration Tests\s*\((core-[^)]+)\)/;
 
 interface StepMetricMatcher {
   jobName: string;
@@ -737,6 +742,7 @@ export function extractMetrics(
       normalizedJobName,
     );
     const runnerTestMatch = RUNNER_TEST_RE.exec(normalizedJobName);
+    const cliCoreSplitMatch = CLI_CORE_SPLIT_RE.exec(normalizedJobName);
 
     const matcherJobName = unitMatch
       ? "Pattern Unit Tests"
@@ -746,6 +752,8 @@ export function extractMetrics(
       ? "Generated Patterns Integration Tests"
       : runnerTestMatch
       ? "Runner Tests"
+      : cliCoreSplitMatch
+      ? "CLI Integration Tests (core)"
       : normalizedJobName;
 
     if (unitMatch) {
@@ -786,6 +794,15 @@ export function extractMetrics(
       setMaxMetric("job: Runner Tests", sample);
     }
 
+    if (cliCoreSplitMatch) {
+      const sample = makeSample(jobDuration);
+      metrics.set(
+        `job: CLI Integration Tests (${cliCoreSplitMatch[1]})`,
+        sample,
+      );
+      setMaxMetric("job: CLI Integration Tests (core)", sample);
+    }
+
     if (normalizedJobName.includes("Test and Build")) {
       metrics.set("job: Test and Build", makeSample(jobDuration));
     }
@@ -803,7 +820,7 @@ export function extractMetrics(
           const sample = makeSample(stepDuration);
           if (
             patternIntegrationMatch || generatedPatternsMatch ||
-            runnerTestMatch
+            runnerTestMatch || cliCoreSplitMatch
           ) {
             setMaxMetric(matcher.metricName, sample);
           } else {


### PR DESCRIPTION
## Why

#3537 enabled per-command timing for the core CLI integration job and showed the single core leg taking about 3m39s, with the final `piece call` section accounting for roughly 76s of serialized work. Splitting that stateful script into two independent core sections lets GitHub schedule the basics and call coverage in parallel while preserving the existing local default that runs everything.

## What Changed

- Adds a section selector to `packages/cli/integration/integration.sh`: `all` by default, plus `piece-basics` and `piece-call` for CI.
- Expands the CLI integration matrix to `core-piece-basics`, `core-piece-call`, and `fuse`, each with its own Toolshed port.
- Uploads separate core timing artifacts for each split leg.
- Updates perf extraction so split core jobs keep per-leg metrics and aggregate the core metric by max wall-time.

## Test plan

- `deno fmt .github/workflows/deno.yml tasks/perf-lib.ts tasks/perf-lib.test.ts`
- `bash -n packages/cli/integration/integration.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deno.yml"); puts "yaml ok"'`
- `deno test --allow-read --allow-env tasks/perf-lib.test.ts`
- `deno check tasks/perf-lib.ts tasks/perf-lib.test.ts`