### PR TITLE
fix(ts-transformers): track mapped element property reads

### DIFF
--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -1,12 +1,17 @@
 import ts from "typescript";
 import {
   detectCallKind,
+  getExpressionText,
   isFunctionLikeExpression,
+  isMethodCall,
+  type NormalizedDataFlow,
   visitEachChildWithJsx,
 } from "../ast/mod.ts";
 import type { TransformationContext } from "../core/mod.ts";
 import { shouldTransformArrayMethod } from "../closures/strategies/array-method-policy.ts";
 import { transformArrayMethodCallback } from "../closures/strategies/array-method-transform.ts";
+import { parseCaptureExpression } from "../utils/capture-tree.ts";
+import { unwrapExpression } from "../utils/expression.ts";
 import {
   classifyExpressionSiteHandling,
   containsLogicalBinaryOperator,
@@ -613,6 +618,101 @@ export function rewriteArrayMethodCallbackExpressionSites(
   context: TransformationContext,
 ): ts.ConciseBody {
   const analyze = context.getDataFlowAnalyzer();
+  const callback = ts.isFunctionLike(body.parent) ? body.parent : undefined;
+  const elementParam = callback?.parameters[0];
+  const elementParamName = elementParam && ts.isIdentifier(elementParam.name)
+    ? elementParam.name
+    : undefined;
+
+  const isElementParamRoot = (
+    access: ts.PropertyAccessExpression,
+  ): boolean => {
+    if (!elementParamName) return false;
+
+    const capture = parseCaptureExpression(access);
+    if (!capture || capture.path.length === 0) return false;
+    if (capture.root !== elementParamName.text) return false;
+
+    let current: ts.Expression = access;
+    while (ts.isPropertyAccessExpression(current)) {
+      current = current.expression;
+    }
+    if (!ts.isIdentifier(current)) return true;
+
+    const identifierSymbol = context.checker.getSymbolAtLocation(current);
+    const paramSymbol = context.checker.getSymbolAtLocation(elementParamName);
+    return !identifierSymbol || !paramSymbol ||
+      identifierSymbol === paramSymbol;
+  };
+
+  const collectElementParamMemberAccesses = (
+    expression: ts.Expression,
+  ): ts.Expression[] => {
+    if (!elementParamName) return [];
+
+    const accesses: ts.Expression[] = [];
+    const seen = new Set<string>();
+    const visit = (node: ts.Node): void => {
+      if (node !== expression && ts.isFunctionLike(node)) return;
+
+      if (ts.isPropertyAccessExpression(node)) {
+        if (isElementParamRoot(node) && !isMethodCall(node)) {
+          const parent = node.parent;
+          const isReceiverForLongerPropertyAccess =
+            ts.isPropertyAccessExpression(parent) &&
+            parent.expression === node &&
+            !isMethodCall(parent);
+
+          if (!isReceiverForLongerPropertyAccess) {
+            const key = getExpressionText(node);
+            if (!seen.has(key)) {
+              seen.add(key);
+              accesses.push(node);
+            }
+          }
+        }
+      }
+
+      ts.forEachChild(node, visit);
+    };
+    visit(expression);
+    return accesses;
+  };
+
+  const appendElementParamMemberDataFlows = (
+    expression: ts.Expression,
+    dataFlows: readonly NormalizedDataFlow[],
+  ): readonly NormalizedDataFlow[] => {
+    const existing = new Set(
+      dataFlows.map((dataFlow) => getExpressionText(dataFlow.expression)),
+    );
+    const additional = collectElementParamMemberAccesses(expression)
+      .filter((access) => !existing.has(getExpressionText(access)))
+      .map((access): NormalizedDataFlow => ({
+        canonicalKey: `array-element:${getExpressionText(access)}`,
+        expression: access,
+        occurrences: [],
+        scopeId: -1,
+      }));
+
+    return additional.length === 0 ? dataFlows : [...dataFlows, ...additional];
+  };
+
+  const isElementParamMemberComputation = (
+    expression: ts.Expression,
+  ): boolean => {
+    if (collectElementParamMemberAccesses(expression).length === 0) {
+      return false;
+    }
+
+    const current = unwrapExpression(expression);
+    return !(
+      ts.isPropertyAccessExpression(current) ||
+      ts.isElementAccessExpression(current) ||
+      ts.isObjectLiteralExpression(current) ||
+      ts.isArrayLiteralExpression(current)
+    );
+  };
 
   const rewriteArrayMethodOwnedReceiverMethodExpressionSite = (
     expression: ts.Expression,
@@ -651,13 +751,17 @@ export function rewriteArrayMethodCallbackExpressionSites(
     const relevantDataFlows = context.getRelevantDataFlowsFromAnalysis(
       analysis,
     );
-    if (relevantDataFlows.length === 0) {
+    const augmentedDataFlows = appendElementParamMemberDataFlows(
+      expression,
+      relevantDataFlows,
+    );
+    if (augmentedDataFlows.length === 0) {
       return undefined;
     }
 
     return createReactiveWrapperForExpression(
       expression,
-      relevantDataFlows,
+      augmentedDataFlows,
       context,
       {
         allowDirectExpressionWrap: true,
@@ -673,9 +777,13 @@ export function rewriteArrayMethodCallbackExpressionSites(
     } = {},
   ): ts.Expression | undefined => {
     const analysis = analyze(expression);
-    if (analysis.containsOpaqueRef && analysis.requiresRewrite) {
-      const relevantDataFlows = context.getRelevantDataFlowsFromAnalysis(
-        analysis,
+    if (
+      (analysis.containsOpaqueRef && analysis.requiresRewrite) ||
+      isElementParamMemberComputation(expression)
+    ) {
+      const relevantDataFlows = appendElementParamMemberDataFlows(
+        expression,
+        context.getRelevantDataFlowsFromAnalysis(analysis),
       );
       if (relevantDataFlows.length === 0) {
         return undefined;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
@@ -1,0 +1,262 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+/**
+ * TRANSFORM REPRO: mapped element field comparisons inside helper-call roots
+ *
+ * The mapped element is lowered to a cell input. A non-JSX comparison such as
+ * `message.author === senderName(name.get())` must read `message.author`
+ * through a reactive field dependency, not as a plain property on the cell.
+ */
+import { Default, pattern, UI, VNode, Writable, } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Message {
+    author: string;
+    body: string;
+}
+interface Input {
+    name: Writable<Default<string, "">>;
+    selectedRoom: Writable<Default<{
+        messages: Message[];
+    }, {
+        messages: [
+        ];
+    }>>;
+}
+interface Output {
+    [UI]: VNode;
+}
+const senderName = __cfHardenFn((name?: string) => name?.trim() || "Anonymous");
+export default pattern((__cf_pattern_input) => {
+    const name = __cf_pattern_input.key("name");
+    const selectedRoom = __cf_pattern_input.key("selectedRoom");
+    return {
+        [UI]: (<div>
+        {__cfHelpers.derive({
+            type: "object",
+            properties: {
+                selectedRoom: {
+                    type: "object",
+                    properties: {
+                        messages: {
+                            type: "array",
+                            items: {
+                                $ref: "#/$defs/Message"
+                            }
+                        }
+                    },
+                    required: ["messages"],
+                    asCell: ["cell"]
+                }
+            },
+            required: ["selectedRoom"],
+            $defs: {
+                Message: {
+                    type: "object",
+                    properties: {
+                        author: {
+                            type: "string"
+                        },
+                        body: {
+                            type: "string"
+                        }
+                    },
+                    required: ["author", "body"]
+                }
+            }
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Message"
+            },
+            $defs: {
+                Message: {
+                    type: "object",
+                    properties: {
+                        author: {
+                            type: "string"
+                        },
+                        body: {
+                            type: "string"
+                        }
+                    },
+                    required: ["author", "body"]
+                }
+            }
+        } as const satisfies __cfHelpers.JSONSchema, { selectedRoom: selectedRoom }, ({ selectedRoom }) => selectedRoom.get()?.messages).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
+            const message = __cf_pattern_input.key("element");
+            const name = __cf_pattern_input.key("params", "name");
+            const isMine = __cfHelpers.derive({
+                type: "object",
+                properties: {
+                    message: {
+                        type: "object",
+                        properties: {
+                            author: {
+                                type: "string"
+                            }
+                        },
+                        required: ["author"]
+                    },
+                    name: {
+                        type: "string",
+                        asCell: ["cell"]
+                    }
+                },
+                required: ["message", "name"]
+            } as const satisfies __cfHelpers.JSONSchema, {
+                type: "boolean"
+            } as const satisfies __cfHelpers.JSONSchema, {
+                name: name,
+                message: {
+                    author: message.key("author")
+                }
+            }, ({ name, message }) => message.author === senderName(name.get())).for("isMine", true);
+            const isKnownAuthor = __cfHelpers.derive({
+                type: "object",
+                properties: {
+                    message: {
+                        type: "object",
+                        properties: {
+                            author: {
+                                type: "string"
+                            }
+                        },
+                        required: ["author"]
+                    }
+                },
+                required: ["message"]
+            } as const satisfies __cfHelpers.JSONSchema, {
+                type: "boolean"
+            } as const satisfies __cfHelpers.JSONSchema, { message: {
+                    author: message.key("author")
+                } }, ({ message }) => message.author === "Alice").for("isKnownAuthor", true);
+            return (<div data-author-kind={isKnownAuthor ? "known" : "other"} style={{ justifyContent: __cfHelpers.ifElse({
+                    type: "boolean"
+                } as const satisfies __cfHelpers.JSONSchema, {
+                    type: "string"
+                } as const satisfies __cfHelpers.JSONSchema, {
+                    type: "string"
+                } as const satisfies __cfHelpers.JSONSchema, {
+                    "enum": ["flex-end", "flex-start"]
+                } as const satisfies __cfHelpers.JSONSchema, isMine, "flex-end", "flex-start") }}>
+              {message.key("author")}
+              {message.key("body")}
+            </div>);
+        }, {
+            type: "object",
+            properties: {
+                element: {
+                    $ref: "#/$defs/Message"
+                },
+                params: {
+                    type: "object",
+                    properties: {
+                        name: {
+                            type: "string",
+                            asCell: ["cell"]
+                        }
+                    },
+                    required: ["name"]
+                }
+            },
+            required: ["element", "params"],
+            $defs: {
+                Message: {
+                    type: "object",
+                    properties: {
+                        author: {
+                            type: "string"
+                        },
+                        body: {
+                            type: "string"
+                        }
+                    },
+                    required: ["author", "body"]
+                }
+            }
+        } as const satisfies __cfHelpers.JSONSchema, {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    $ref: "#/$defs/UIRenderable"
+                }, {
+                    type: "object",
+                    properties: {}
+                }],
+            $defs: {
+                UIRenderable: {
+                    type: "object",
+                    properties: {
+                        $UI: {
+                            $ref: "https://commonfabric.org/schemas/vnode.json"
+                        }
+                    },
+                    required: ["$UI"]
+                }
+            }
+        } as const satisfies __cfHelpers.JSONSchema), {
+            name: name
+        })}
+      </div>)
+    };
+}, {
+    type: "object",
+    properties: {
+        name: {
+            type: "string",
+            "default": "",
+            asCell: ["cell"]
+        },
+        selectedRoom: {
+            type: "object",
+            properties: {
+                messages: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Message"
+                    }
+                }
+            },
+            required: ["messages"],
+            "default": {
+                messages: []
+            },
+            asCell: ["cell"]
+        }
+    },
+    required: ["name", "selectedRoom"],
+    $defs: {
+        Message: {
+            type: "object",
+            properties: {
+                author: {
+                    type: "string"
+                },
+                body: {
+                    type: "string"
+                }
+            },
+            required: ["author", "body"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $UI: {
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }
+    },
+    required: ["$UI"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.input.tsx
@@ -1,0 +1,52 @@
+/**
+ * TRANSFORM REPRO: mapped element field comparisons inside helper-call roots
+ *
+ * The mapped element is lowered to a cell input. A non-JSX comparison such as
+ * `message.author === senderName(name.get())` must read `message.author`
+ * through a reactive field dependency, not as a plain property on the cell.
+ */
+import {
+  Default,
+  pattern,
+  UI,
+  VNode,
+  Writable,
+} from "commonfabric";
+
+interface Message {
+  author: string;
+  body: string;
+}
+
+interface Input {
+  name: Writable<Default<string, "">>;
+  selectedRoom: Writable<Default<{ messages: Message[] }, { messages: [] }>>;
+}
+
+interface Output {
+  [UI]: VNode;
+}
+
+const senderName = (name?: string) => name?.trim() || "Anonymous";
+
+export default pattern<Input, Output>(({ name, selectedRoom }) => {
+  return {
+    [UI]: (
+      <div>
+        {selectedRoom.get()?.messages.map((message) => {
+          const isMine = message.author === senderName(name.get());
+          const isKnownAuthor = message.author === "Alice";
+          return (
+            <div
+              data-author-kind={isKnownAuthor ? "known" : "other"}
+              style={{ justifyContent: isMine ? "flex-end" : "flex-start" }}
+            >
+              {message.author}
+              {message.body}
+            </div>
+          );
+        })}
+      </div>
+    ),
+  };
+});


### PR DESCRIPTION
## Summary
- include mapped element member accesses when array-callback expression lowering wraps a mixed reactive expression
- add a regression fixture for selectedRoom.get()?.messages.map where message.author drives conditional UI style
- preserve existing JSX lowering for message.author/message.body rendering

## Known Shortcoming / Follow-Up
This PR is intentionally narrow. It fixes the observed mapped-element property-read bug in array-callback expression lowering, but it does not fully resolve the underlying ordering concern: pattern-owned array callbacks currently pass through multiple lowering phases where callback parameters can become pattern inputs before expression-site lowering has a general chance to handle source-level property reads.

I checked `patternTool` as a related case. It does not appear to need the same treatment because its strategy captures module-scoped reactive values into `extraParams`; it does not create a per-element sub-pattern callback whose parameters are lowered to `__cf_pattern_input.key(...)`.

A quick local attempt at a broader ordering change caused broad golden churn and at least one real schema-shrinking regression, so that refactor should be handled separately instead of broadening this PR.

### Follow-Up Implementer Prompt
```text
We have a narrow fix in PR #3539 for mapped array element property reads in non-JSX expressions. Please investigate and implement the deeper/root-cause fix if feasible: the issue appears to be transform ordering around pattern-owned array callbacks, where callback params are lowered into pattern inputs before expression-site lowering has a chance to treat source-level property reads consistently.

Context:
- Original bug: inside reactive `.map()` callbacks, `message.author` in non-JSX expressions like
  `const isMine = message.author === senderName(name.get())`
  was treated as a plain property on the lowered cell-like object instead of a reactive field dependency.
- JSX reads like `{message.author}` were already lowered correctly.
- PR #3539 added a focused special-case in expression-site lowering plus a regression fixture:
  `packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.*`
- That fix works, but review feedback questioned whether this should be solved more generally by fixing transform ordering rather than adding map-element-specific dataflow logic.

Please:
1. Start by reading the current array callback lowering, pattern callback lowering, JSX/expression-site lowering, and schema-shrink interactions.
   Useful starting points:
   - `packages/ts-transformers/src/transformers/expression-site-lowering.ts`
   - array method callback transform/lowering strategy files under `packages/ts-transformers/src`
   - pattern callback lowering transformer files under `packages/ts-transformers/src`
   - existing map callback fixtures under `packages/ts-transformers/test/fixtures`
2. Determine whether we can remove or reduce the special-case logic from PR #3539 by changing the phase ordering more generally.
3. Be careful: a naive wholesale move of expression-site lowering after pattern callback lowering caused broad golden churn and at least one real regression around schema shrinking for nested writable map fields. It also disturbed ternary/derive absorption and ifElse predicate behavior. Avoid a broad reorder unless all existing semantics are preserved.
4. Prefer a targeted architectural fix:
   - split array callback lowering into phases if needed;
   - create the sub-pattern callback/input/prologue early enough for later passes;
   - run expression-site lowering while source-level property reads are still visible enough to collect dependencies;
   - only then perform pattern-body key/path lowering that turns inputs into `__cf_pattern_input.key(...)`.
5. Preserve existing behavior for:
   - JSX rendering of mapped element properties;
   - nested map callbacks;
   - `mapWithPattern` / authored `pattern(...)` cases;
   - schema shrinking for mapped array element fields;
   - conditional/ternary/style prop lowering;
   - explicit `computed`, `derive`, and `ifElse` expressions.
6. Quickly check `patternTool`, but it probably does not need this treatment. It captures module-scoped reactive values into `extraParams`; it does not create per-element sub-pattern callbacks whose parameters become `__cf_pattern_input.key(...)`.

Acceptance criteria:
- The original source-level pattern works without the explicit workaround:
  `const isMine = message.author === senderName(name.get())`
- The transformed output includes the mapped element field as a reactive dependency, semantically equivalent to:
  `const author = message.key("author");`
  followed by a `derive`/computed input that includes both `author` and `name`.
- The current PR #3539 regression stays covered, but the implementation is generalized enough that similar non-JSX mapped element property reads are handled by normal expression-site lowering rather than a one-off collector if possible.
- Existing golden fixtures either remain stable or only change where the new ordering is clearly more correct.
- Validation:
  - run `deno task check` in `packages/ts-transformers`
  - run `deno task test` in `packages/ts-transformers`
  - inspect any changed goldens carefully; do not bulk-update without explaining why each class of change is expected.

Scope:
Keep this follow-up narrowly focused on transformer/lowering correctness for pattern-owned array callbacks. Do not broaden into runtime behavior, pattern authoring changes, or unrelated transformer cleanup.
```

## Validation
- deno task check (packages/ts-transformers)
- deno task test (packages/ts-transformers)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reactivity in array `.map` callbacks by tracking mapped element property reads (e.g., `message.author`), including inside helper-call roots. Non-JSX computations that read element fields now recompute when those fields change; JSX rendering stays the same.

- **Bug Fixes**
  - Augment data-flow when lowering array-callbacks to include element member reads; skip method calls, chained receivers, and nested functions; de-duplicate accesses.
  - Force reactive wrapping for non-JSX computations that read element members, even when no other rewrite is required.
  - Preserve existing JSX lowering for `message.author`/`message.body`.
  - Add a regression fixture for helper-root comparisons in `selectedRoom.get()?.messages.map(...)` to verify style updates.

Validation: `deno task check` and `deno task test` in `packages/ts-transformers`.

<sup>Written for commit acd51f2a3ce08d09ea0ffad348a9d6525edfab25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
