### PR TITLE
ci: split package integration tests

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -194,10 +194,34 @@ jobs:
   # ---------------------------------------------------------------------------
 
   package-integration-test:
-    name: "Package Integration Tests"
+    name: "Package Integration Tests (${{ matrix.suite_name }})"
     runs-on: ubuntu-latest
     needs: ["build-binaries"]
     environment: ci
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite_name: runner
+            package_dir: packages/runner
+            junit_name: runner
+            step_name: runner integration tests
+            headless: false
+          - suite_name: runtime-client
+            package_dir: packages/runtime-client
+            junit_name: runtime-client
+            step_name: runtime-client integration tests
+            headless: false
+          - suite_name: shell
+            package_dir: packages/shell
+            junit_name: shell
+            step_name: shell integration tests
+            headless: true
+          - suite_name: background-charm-service
+            package_dir: packages/background-charm-service
+            junit_name: background-charm-service
+            step_name: background worker integration tests
+            headless: true
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
@@ -209,56 +233,39 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: 🚀 Start Toolshed server for testing
+        env:
+          TOOLSHED_PORT: 8000
         run: |
           chmod +x ./common-binaries/toolshed
           CTTS_AI_LLM_ANTHROPIC_API_KEY=fake \
-          ./common-binaries/toolshed &
+          ./common-binaries/toolshed --port="$TOOLSHED_PORT" &
 
       # For Astral
       # https://github.com/lino-levan/astral/blob/f5ef833b2c5bde3783564a6b925073d5d46bb4b8/README.md#no-usable-sandbox-with-user-namespace-cloning-enabled
       - name: 🛡️ Disable AppArmor for browser tests
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
-      - name: 🧪 Run end-to-end runner integration tests
-        working-directory: packages/runner
+      - name: 🧪 Run ${{ matrix.step_name }}
+        working-directory: ${{ matrix.package_dir }}
+        env:
+          HEADLESS_ENABLED: ${{ matrix.headless }}
+          JUNIT_NAME: ${{ matrix.junit_name }}
+          TOOLSHED_PORT: 8000
         run: |
           mkdir -p ../../test-results
-          API_URL=http://localhost:8000/ \
-          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/runner.xml" \
-          deno task integration
-
-      - name: 🧪 Run end-to-end runtime-client integration tests
-        working-directory: packages/runtime-client
-        run: |
-          mkdir -p ../../test-results
-          API_URL=http://localhost:8000/ \
-          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/runtime-client.xml" \
-          deno task integration
-
-      - name: 🧪 Run end-to-end shell integration tests
-        working-directory: packages/shell
-        run: |
-          mkdir -p ../../test-results
-          HEADLESS=1 \
-          API_URL=http://localhost:8000/ \
-          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/shell.xml" \
-          deno task integration
-
-      - name: 🧪 Run background worker integration tests
-        working-directory: packages/background-charm-service
-        run: |
-          mkdir -p ../../test-results
-          HEADLESS=1 \
-          API_URL=http://localhost:8000/ \
-          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/background-charm-service.xml" \
+          if [ "$HEADLESS_ENABLED" = "true" ]; then
+            export HEADLESS=1
+          fi
+          API_URL="http://localhost:${TOOLSHED_PORT}/" \
+          INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml" \
           deno task integration
 
       - name: 📤 Upload test timing data
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-timing-package-integration
-          path: test-results/
+          name: test-timing-package-integration-${{ matrix.suite_name }}
+          path: test-results/${{ matrix.junit_name }}.xml
           retention-days: 90
           if-no-files-found: ignore
 

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -141,6 +141,52 @@ Deno.test("extractMetrics aggregates split CLI core jobs", () => {
   assertEquals(metrics.has("step: CLI integration"), false);
 });
 
+Deno.test("extractMetrics aggregates package integration matrix jobs", () => {
+  const metrics = extractMetrics(makeRun(), [
+    makeJob(
+      1,
+      "Package Integration Tests (runner)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:20Z",
+      [
+        makeStep(
+          "🧪 Run runner integration tests",
+          "2026-01-01T00:00:10Z",
+          "2026-01-01T00:01:00Z",
+        ),
+      ],
+    ),
+    makeJob(
+      2,
+      "Package Integration Tests (shell)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:40Z",
+      [
+        makeStep(
+          "🧪 Run shell integration tests",
+          "2026-01-01T00:00:10Z",
+          "2026-01-01T00:01:30Z",
+        ),
+      ],
+    ),
+  ]);
+
+  assertEquals(
+    metrics.get("job: Package Integration Tests (runner)")?.durationSeconds,
+    80,
+  );
+  assertEquals(
+    metrics.get("job: Package Integration Tests (shell)")?.durationSeconds,
+    100,
+  );
+  assertEquals(
+    metrics.get("job: Package Integration Tests")?.durationSeconds,
+    100,
+  );
+  assertEquals(metrics.get("step: runner integration")?.durationSeconds, 50);
+  assertEquals(metrics.get("step: shell integration")?.durationSeconds, 80);
+});
+
 Deno.test("extractMetrics aggregates pattern integration matrix shards", () => {
   const metrics = extractMetrics(makeRun(), [
     makeJob(
@@ -282,6 +328,10 @@ Deno.test("extractMetrics aggregates runner test matrix shards", () => {
 });
 
 Deno.test("timingArtifactLabel normalizes matrix shard artifacts", () => {
+  assertEquals(
+    timingArtifactLabel("test-timing-package-integration-runner"),
+    "package-integration",
+  );
   assertEquals(
     timingArtifactLabel("test-timing-pattern-integration-1"),
     "pattern-integration",

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -536,6 +536,7 @@ export const JOB_TO_LABEL: Record<string, string> = {
 export function timingArtifactLabel(artifactName: string): string {
   const label = artifactName.replace(/^test-timing-/, "");
   return label
+    .replace(/^package-integration-.+$/, "package-integration")
     .replace(/^pattern-integration-\d+$/, "pattern-integration")
     .replace(/^generated-patterns-\d+$/, "generated-patterns");
 }
@@ -615,6 +616,7 @@ const JOB_METRIC_NAMES: Record<string, string> = {
 };
 
 /** Pattern for matrix jobs like "Pattern Unit Tests (1/5)". */
+export const PACKAGE_INTEGRATION_RE = /Package Integration Tests\s*\(([^)]+)\)/;
 export const PATTERN_UNIT_RE = /Pattern Unit Tests\s*\((\d+)\/(\d+)\)/;
 export const PATTERN_INTEGRATION_RE =
   /Pattern Integration Tests\s*\((\d+)\/(\d+)\)/;
@@ -734,6 +736,9 @@ export function extractMetrics(
       metrics.set(jobMetricName, makeSample(jobDuration));
     }
 
+    const packageIntegrationMatch = PACKAGE_INTEGRATION_RE.exec(
+      normalizedJobName,
+    );
     const unitMatch = PATTERN_UNIT_RE.exec(normalizedJobName);
     const patternIntegrationMatch = PATTERN_INTEGRATION_RE.exec(
       normalizedJobName,
@@ -744,7 +749,9 @@ export function extractMetrics(
     const runnerTestMatch = RUNNER_TEST_RE.exec(normalizedJobName);
     const cliCoreSplitMatch = CLI_CORE_SPLIT_RE.exec(normalizedJobName);
 
-    const matcherJobName = unitMatch
+    const matcherJobName = packageIntegrationMatch
+      ? "Package Integration Tests"
+      : unitMatch
       ? "Pattern Unit Tests"
       : patternIntegrationMatch
       ? "Pattern Integration Tests"
@@ -755,6 +762,15 @@ export function extractMetrics(
       : cliCoreSplitMatch
       ? "CLI Integration Tests (core)"
       : normalizedJobName;
+
+    if (packageIntegrationMatch) {
+      const sample = makeSample(jobDuration);
+      metrics.set(
+        `job: Package Integration Tests (${packageIntegrationMatch[1]})`,
+        sample,
+      );
+      setMaxMetric("job: Package Integration Tests", sample);
+    }
 
     if (unitMatch) {
       metrics.set(
@@ -819,8 +835,8 @@ export function extractMetrics(
         ) {
           const sample = makeSample(stepDuration);
           if (
-            patternIntegrationMatch || generatedPatternsMatch ||
-            runnerTestMatch || cliCoreSplitMatch
+            packageIntegrationMatch || patternIntegrationMatch ||
+            generatedPatternsMatch || runnerTestMatch || cliCoreSplitMatch
           ) {
             setMaxMetric(matcher.metricName, sample);
           } else {


### PR DESCRIPTION
## Why

After #3538, Package Integration Tests are tied with the slowest CLI leg on the CI critical path. The package job already runs four independent suites serially, and the latest timing data showed runtime-client and shell as the expensive package sections while runner and background are separate, lower-cost suites. Splitting these by package lets GitHub schedule them in parallel instead of paying the combined serial wall-time.

## What Changed

- Converts `package-integration-test` into a four-leg matrix: runner, runtime-client, shell, and background-charm-service.
- Keeps the existing per-package JUnit output, now uploaded as per-leg timing artifacts.
- Preserves the package-level performance metric by aggregating split package jobs by max wall-time.
- Normalizes split package timing artifact names back to `package-integration` for existing per-test metric continuity.

## Test plan

- `deno fmt .github/workflows/deno.yml tasks/perf-lib.ts tasks/perf-lib.test.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deno.yml"); puts "yaml ok"'`
- `deno test --allow-read --allow-env tasks/perf-lib.test.ts`
- `deno check tasks/perf-lib.ts tasks/perf-lib.test.ts`
- `git diff --check`

NEW_PERF_BASELINE: step: background worker integration = 15s