### PR TITLE
fix(transformer): fix mapped pattern factory call lowering

### DIFF
--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -30,6 +30,10 @@ import type { AnalyzeFn } from "./expression-rewrite/types.ts";
 import type { ExpressionContainerKind } from "./expression-site-types.ts";
 import { createDeriveCall } from "./builtins/derive.ts";
 import { classifyOpaquePathTerminalCall } from "./opaque-roots.ts";
+import {
+  isPatternFactoryCalleeExpression,
+  returnsOpaqueRefResult,
+} from "./structural-reactive-factory.ts";
 
 interface RewriteExpressionSiteParams {
   readonly expression: ts.Expression;
@@ -706,6 +710,17 @@ export function rewriteArrayMethodCallbackExpressionSites(
     }
 
     const current = unwrapExpression(expression);
+    if (ts.isCallExpression(current)) {
+      const callKind = detectCallKind(current, context.checker);
+      if (
+        (callKind?.kind === "builder" && callKind.builderName === "pattern") ||
+        returnsOpaqueRefResult(current, context.checker) ||
+        isPatternFactoryCalleeExpression(current.expression, context.checker)
+      ) {
+        return false;
+      }
+    }
+
     return !(
       ts.isPropertyAccessExpression(current) ||
       ts.isElementAccessExpression(current) ||

--- a/packages/ts-transformers/test/pipeline-regressions.test.ts
+++ b/packages/ts-transformers/test/pipeline-regressions.test.ts
@@ -480,6 +480,55 @@ export default pattern(() => {
 );
 
 Deno.test(
+  "Pipeline regression: mapped pattern factory calls with element fields stay structural",
+  async () => {
+    const source = `import { UI, pattern, type VNode } from "commonfabric";
+
+type Entry = {
+  piece: any;
+  name: string;
+  backlinks: any[];
+};
+
+const EntryRow = pattern<Entry, { [UI]: VNode }>(({ piece, backlinks }) => ({
+  [UI]: <div>{piece}{backlinks.length}</div>,
+}));
+
+export default pattern<{ entries: Entry[] }, { [UI]: VNode }>(({ entries }) => ({
+  [UI]: (
+    <div>
+      {entries.map((entry) => {
+        const row = EntryRow({
+          piece: entry.piece,
+          name: entry.name,
+          backlinks: entry.backlinks,
+        });
+        return row[UI];
+      })}
+    </div>
+  ),
+}));
+`;
+
+    const output = await transformSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+
+    assertStringIncludes(output, "const row = EntryRow({");
+    assertStringIncludes(output, 'piece: entry.key("piece")');
+    assertStringIncludes(output, 'name: entry.key("name")');
+    assertStringIncludes(output, 'backlinks: entry.key("backlinks")');
+    assert(
+      !/__cfHelpers\.derive\([\s\S]{0,500}EntryRow: EntryRow[\s\S]{0,500}EntryRow\(\{/
+        .test(
+          output,
+        ),
+      "expected mapped pattern factory invocation to stay structural instead of being wrapped in derive",
+    );
+  },
+);
+
+Deno.test(
   "Pipeline regression: opaque-returning factory helpers with local cells stay structural",
   async () => {
     const source = `import { pattern, Writable } from "commonfabric";


### PR DESCRIPTION
## Summary
- Keep mapped callback-local pattern factory calls structural when their arguments include mapped element fields.
- Preserve structural lowering of `entry.foo` arguments to `entry.key("foo")` instead of wrapping the whole pattern call in `derive`.
- Add a pipeline regression for the `EntryRow({ piece: entry.piece, ... })` / `row[UI]` shape that regressed in `system/backlinks-index.tsx`.

## Root Cause
The mapped-element property-read fix added forced wrapping for non-JSX expressions that contain mapped element member reads. That was correct for scalar computations like comparisons, but too broad for structural factory calls. In `EntryRow({ piece: entry.piece, name: entry.name, backlinks: entry.backlinks })`, the whole pattern factory invocation was derive-wrapped and `EntryRow` became a derive input. At runtime the derive callback received a value for `EntryRow` instead of the callable pattern factory, producing `EntryRow is not a function`.

## Fix
`isElementParamMemberComputation` now excludes pattern builder calls, pattern factory calls, and opaque-returning factory calls from the forced computation path. Their child arguments still lower structurally, so the generated map callback keeps a direct call like `EntryRow({ piece: entry.key("piece"), ... }).for("row", true)`.

## Validation
- `deno task check` in `packages/ts-transformers`
- `deno task test` in `packages/ts-transformers`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mapped pattern factory call lowering in `packages/ts-transformers` so calls stay structural inside mapped callbacks. Preserves `entry.foo` -> `entry.key("foo")` lowering and prevents the “EntryRow is not a function” runtime error.

- **Bug Fixes**
  - Updated `isElementParamMemberComputation` to skip pattern builders, pattern factories, and opaque-returning factories; only their args lower structurally.
  - Keeps calls like `EntryRow({ piece: entry.key("piece"), ... })` instead of wrapping the whole call in `derive(...)`.
  - Added a pipeline regression test for the `EntryRow({ piece: entry.piece, ... })` / `row[UI]` shape to cover the `system/backlinks-index.tsx` case.

<sup>Written for commit ee2407e57a1395e154a471bd1e50da16d3f3dc50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

