### PR TITLE
ci: split CLI basics integration tests

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -279,22 +279,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - suite_name: core-piece-basics
+          - suite_name: core-piece-values
             script: integration.sh
-            section: piece-basics
+            section: piece-values
             toolshed_port: 8000
+            install_fuse_deps: false
+            timeout_minutes: 10
+          - suite_name: core-piece-links
+            script: integration.sh
+            section: piece-links
+            toolshed_port: 8001
             install_fuse_deps: false
             timeout_minutes: 10
           - suite_name: core-piece-call
             script: integration.sh
             section: piece-call
-            toolshed_port: 8001
+            toolshed_port: 8002
             install_fuse_deps: false
             timeout_minutes: 10
           - suite_name: fuse
             script: fuse-exec.sh
             section: ""
-            toolshed_port: 8002
+            toolshed_port: 8003
             install_fuse_deps: true
             timeout_minutes: 15
     steps:

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -148,7 +148,23 @@ test_get_only() {
   fi
 }
 
-run_piece_basics() {
+create_stepped_counter_piece() {
+  local value="$1"
+
+  PIECE_ID=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS $PATTERN_SRC)
+  echo "Created source piece: $PIECE_ID"
+
+  printf '{"value":%s}\n' "$value" | cf piece apply $SPACE_ARGS --piece $PIECE_ID
+  echo "$value" | cf piece set $SPACE_ARGS --piece $PIECE_ID value
+  cf piece step $SPACE_ARGS --piece $PIECE_ID
+
+  RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID value)
+  if [ "$RESULT" != "$value" ]; then
+    error "Source piece value should be $value before linking, got: $RESULT"
+  fi
+}
+
+run_piece_values() {
   setup_space
 
   # Create a new piece using custom default export as input
@@ -227,6 +243,14 @@ run_piece_basics() {
   if ! cf piece ls $SPACE_ARGS | grep -q "$PIECE_ID $TITLE <unnamed>"; then
     error "Piece did not appear in list of space pieces."
   fi
+
+  echo "Successfully ran CLI piece values integration tests for ${API_URL}/${SPACE}/${PIECE_ID}."
+}
+
+run_piece_links() {
+  setup_space
+
+  create_stepped_counter_piece 10
 
   echo "Testing piece link..."
 
@@ -325,7 +349,7 @@ run_piece_basics() {
     error "After calling increment on piece3, invented piece's value should be 43, got: $RESULT"
   fi
 
-  echo "Successfully ran CLI piece basics integration tests for ${API_URL}/${SPACE}/${PIECE_ID}."
+  echo "Successfully ran CLI piece link integration tests for ${API_URL}/${SPACE}/${PIECE_ID}."
 }
 
 run_piece_call() {
@@ -382,11 +406,19 @@ run_piece_call() {
 
 case "$SECTION" in
   all)
-    run_piece_basics
+    run_piece_values
+    run_piece_links
     run_piece_call
     ;;
   piece-basics)
-    run_piece_basics
+    run_piece_values
+    run_piece_links
+    ;;
+  piece-values)
+    run_piece_values
+    ;;
+  piece-links)
+    run_piece_links
     ;;
   piece-call)
     run_piece_call

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -93,7 +93,20 @@ Deno.test("extractMetrics aggregates split CLI core jobs", () => {
   const metrics = extractMetrics(makeRun(), [
     makeJob(
       1,
-      "CLI Integration Tests (core-piece-basics)",
+      "CLI Integration Tests (core-piece-values)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:40Z",
+      [
+        makeStep(
+          "🧪 Run CLI integration suite",
+          "2026-01-01T00:00:10Z",
+          "2026-01-01T00:01:20Z",
+        ),
+      ],
+    ),
+    makeJob(
+      2,
+      "CLI Integration Tests (core-piece-links)",
       "2026-01-01T00:00:00Z",
       "2026-01-01T00:03:20Z",
       [
@@ -105,7 +118,7 @@ Deno.test("extractMetrics aggregates split CLI core jobs", () => {
       ],
     ),
     makeJob(
-      2,
+      3,
       "CLI Integration Tests (core-piece-call)",
       "2026-01-01T00:00:00Z",
       "2026-01-01T00:02:40Z",
@@ -120,7 +133,12 @@ Deno.test("extractMetrics aggregates split CLI core jobs", () => {
   ]);
 
   assertEquals(
-    metrics.get("job: CLI Integration Tests (core-piece-basics)")
+    metrics.get("job: CLI Integration Tests (core-piece-values)")
+      ?.durationSeconds,
+    100,
+  );
+  assertEquals(
+    metrics.get("job: CLI Integration Tests (core-piece-links)")
       ?.durationSeconds,
     200,
   );

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -600,6 +600,10 @@ const JOB_METRIC_NAMES: Record<string, string> = {
   "CLI Integration Tests (core)": "job: CLI Integration Tests (core)",
   "CLI Integration Tests (core-piece-basics)":
     "job: CLI Integration Tests (core-piece-basics)",
+  "CLI Integration Tests (core-piece-values)":
+    "job: CLI Integration Tests (core-piece-values)",
+  "CLI Integration Tests (core-piece-links)":
+    "job: CLI Integration Tests (core-piece-links)",
   "CLI Integration Tests (core-piece-call)":
     "job: CLI Integration Tests (core-piece-call)",
   "CLI Integration Tests (fuse)": "job: CLI Integration Tests (fuse)",


### PR DESCRIPTION
## Why

After #3540, `CLI Integration Tests (core-piece-basics)` is the longest test-side CI leg (~2m40 in the #3540 merge run). The timing data showed the basics script is really two independent chunks: source/value/input coverage and link coverage. Splitting those lets CI schedule them separately while keeping the local `piece-basics` alias and `all` path intact.

## What Changed

- Splits `integration.sh` basics coverage into `piece-values` and `piece-links` sections.
- Keeps `piece-basics` as a compatibility alias that runs both new sections.
- Expands the CLI integration matrix to `core-piece-values`, `core-piece-links`, `core-piece-call`, and `fuse` with distinct ports.
- Adds perf metric labels for the new CLI core split legs; existing aggregate `job: CLI Integration Tests (core)` remains max of core legs.

## Test plan

- `deno fmt .github/workflows/deno.yml tasks/perf-lib.ts tasks/perf-lib.test.ts`
- `bash -n packages/cli/integration/integration.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deno.yml"); puts "yaml ok"'`
- `deno test --allow-read --allow-env tasks/perf-lib.test.ts`
- `deno check tasks/perf-lib.ts tasks/perf-lib.test.ts`
- `git diff --check`

NEW_PERF_BASELINE: job: Pattern Integration Tests (2/4) = 122s