### PR TITLE
ci: document wall-time revisit policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,8 @@ If you are developing runtime code, read the following documentation:
   practices
 - `docs/development/LOCAL_DEV_SERVERS.md` - **CRITICAL**: How to start local dev
   servers correctly (use `dev-local` for shell, not `dev`)
+- `docs/development/CI_PERFORMANCE.md` - When to stop or revisit CI wall-time
+  splitting/rebalancing work
 - `docs/development/UI_TESTING.md` - How to work with shadow dom in our
   integration tests
 - `docs/development/debugging/` - Runtime errors, type errors, and

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -1,0 +1,52 @@
+# CI Performance Policy
+
+This repo tracks GitHub Actions wall time so CI optimization work is driven by
+trend data, not one-off slow runs. Use this policy when deciding whether to
+split, rebalance, or otherwise optimize CI jobs.
+
+## Current Posture
+
+Stop active CI-splitting work when the required test jobs are already in the
+same rough band. As a default, stop when:
+
+- The top required test jobs are within about 20-30% of each other.
+- The slowest required test job is around 2 minutes.
+- The expected critical-path win is under about 30 seconds.
+- The proposed split adds comparable maintenance cost: more matrix entries,
+  ports, artifacts, sharding rules, or performance baselines.
+
+At that point, keep the timing instrumentation and wait for a concrete trigger
+instead of continuing to split jobs proactively.
+
+## Revisit Triggers
+
+Revisit CI wall-time optimization when at least one of these holds across
+normal runs:
+
+- A required non-deploy job is over 3 minutes.
+- One required non-deploy job is more than 50% slower than comparable jobs and
+  at least 30 seconds slower in absolute terms.
+- Required non-deploy checks take more than 8 minutes from first start to last
+  completion.
+- The same job repeatedly appears as `OVER` or `CLOSE` in Performance Check,
+  rather than as a one-run fluctuation.
+- New tests clearly cluster in one shard or suite and make it consistently
+  heavier.
+
+Performance Check prints a non-blocking `CI Wall-Time Revisit Signals` section
+for the first three triggers. Treat it as a prompt to inspect the data, not as a
+failure by itself.
+
+## How To Respond
+
+1. Start from the latest completed `main` run and its Performance Check log.
+2. Prefer timing artifacts and repeated runs over a single outlier.
+3. First look for a low-maintenance rebalance, such as moving a heavy test file
+   between existing shards.
+4. Split a job only when the boundary is already clear and the split preserves
+   local developer workflows.
+5. If Performance Check asks for a `NEW_PERF_BASELINE`, make sure the metric is
+   understood and note whether it is related to the CI change.
+
+Good CI optimization PRs should reduce critical-path wall time without making
+the workflow harder to reason about.

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -363,6 +363,9 @@ sudo update-ca-certificates
 > you don't need to verify the baseline against a clean tree before testing your
 > changes.
 
+- For CI wall-time optimization, follow
+  [CI Performance Policy](CI_PERFORMANCE.md). Do not keep splitting jobs once
+  the required test jobs are already in the same rough timing band.
 - Check typings with `deno task check`.
 - Run linter with `deno lint`.
 - Run all tests using `deno task test` (NOT `deno test`)

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -21,6 +21,7 @@ import {
   applyBaselineOverrides,
   type BaselineOverrides,
   computeBaseline,
+  computeCiWallTimeRevisitSignals,
   downloadAndParseJUnit,
   extractMetrics,
   extractTestFileMetrics,
@@ -144,6 +145,7 @@ async function main() {
   }
 
   console.log(`Extracted ${currentMetrics.size} metrics from current run.`);
+  const wallTimeSignals = computeCiWallTimeRevisitSignals(currentJobs);
 
   // 3. Fetch recent main-branch push runs for baseline
   console.log("Fetching recent main-branch runs for baseline...");
@@ -459,7 +461,21 @@ async function main() {
     }
   }
 
-  // 6c. Pass/fail outcome + override copy-paste block pinned at the bottom.
+  // 6c. Informational CI wall-time policy signals. These are intentionally
+  // non-blocking; they tell us when to consider CI split/rebalance work again.
+  if (wallTimeSignals.length > 0) {
+    console.log("\n## CI Wall-Time Revisit Signals");
+    console.log(
+      "Informational only. See docs/development/CI_PERFORMANCE.md before starting CI-splitting work.",
+    );
+    console.log("| signal | detail |");
+    console.log("|:--|:--|");
+    for (const signal of wallTimeSignals) {
+      console.log(`| ${signal.title} | ${signal.detail} |`);
+    }
+  }
+
+  // 6d. Pass/fail outcome + override copy-paste block pinned at the bottom.
   if (informationalOnly) {
     console.log("\nInformational Only:");
   }

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -1,6 +1,7 @@
 import { assertAlmostEquals, assertEquals } from "@std/assert";
 import {
   computeBaseline,
+  computeCiWallTimeRevisitSignals,
   extractMetrics,
   fetchPRBody,
   githubGet,
@@ -361,6 +362,132 @@ Deno.test("timingArtifactLabel normalizes matrix shard artifacts", () => {
   assertEquals(
     timingArtifactLabel("test-timing-package-integration"),
     "package-integration",
+  );
+});
+
+Deno.test("computeCiWallTimeRevisitSignals stays quiet for balanced CI", () => {
+  const signals = computeCiWallTimeRevisitSignals([
+    makeJob(
+      1,
+      "Pattern Integration Tests (1/4)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:02:00Z",
+      [],
+    ),
+    makeJob(
+      2,
+      "CLI Integration Tests (core-piece-call)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:50Z",
+      [],
+    ),
+    makeJob(
+      3,
+      "Package Integration Tests (shell)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:45Z",
+      [],
+    ),
+    makeJob(
+      4,
+      "Generated Patterns Integration Tests (1/4)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:40Z",
+      [],
+    ),
+    makeJob(
+      5,
+      "Runner Tests (1/4)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:35Z",
+      [],
+    ),
+  ]);
+
+  assertEquals(signals, []);
+});
+
+Deno.test("computeCiWallTimeRevisitSignals flags slow and imbalanced jobs", () => {
+  const signals = computeCiWallTimeRevisitSignals([
+    makeJob(
+      1,
+      "Pattern Integration Tests (2/4)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:04:00Z",
+      [],
+    ),
+    makeJob(
+      2,
+      "CLI Integration Tests (core-piece-call)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:40Z",
+      [],
+    ),
+    makeJob(
+      3,
+      "Package Integration Tests (shell)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:35Z",
+      [],
+    ),
+    makeJob(
+      4,
+      "Generated Patterns Integration Tests (1/4)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:30Z",
+      [],
+    ),
+    makeJob(
+      5,
+      "Runner Tests (1/4)",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:25Z",
+      [],
+    ),
+  ]);
+
+  assertEquals(
+    signals.map((signal) => signal.kind),
+    ["slow-job", "job-imbalance"],
+  );
+  assertEquals(
+    signals[0].detail,
+    "Pattern Integration Tests (2/4) took 4m 0s",
+  );
+});
+
+Deno.test("computeCiWallTimeRevisitSignals flags long required wall time", () => {
+  const signals = computeCiWallTimeRevisitSignals([
+    makeJob(
+      1,
+      "Check",
+      "2026-01-01T00:00:00Z",
+      "2026-01-01T00:01:00Z",
+      [],
+    ),
+    makeJob(
+      2,
+      "Pattern Integration Tests (1/4)",
+      "2026-01-01T00:07:30Z",
+      "2026-01-01T00:08:30Z",
+      [],
+    ),
+    makeJob(
+      3,
+      "Deploy to Toolshed (Staging)",
+      "2026-01-01T00:20:00Z",
+      "2026-01-01T00:25:00Z",
+      [],
+    ),
+  ]);
+
+  assertEquals(
+    signals.map((signal) => signal.kind),
+    ["required-wall-time"],
+  );
+  assertEquals(
+    signals[0].detail,
+    "Required non-deploy jobs took 8m 30s from first start to last completion",
   );
 });
 

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -153,6 +153,17 @@ export interface BaselineOverrides {
   metrics: Map<string, number>;
 }
 
+export type CiWallTimeRevisitSignalKind =
+  | "slow-job"
+  | "job-imbalance"
+  | "required-wall-time";
+
+export interface CiWallTimeRevisitSignal {
+  kind: CiWallTimeRevisitSignalKind;
+  title: string;
+  detail: string;
+}
+
 // ---------------------------------------------------------------------------
 // GitHub API helpers
 // ---------------------------------------------------------------------------
@@ -882,6 +893,112 @@ export function extractTestFileMetrics(
   }
 
   return metrics;
+}
+
+// ---------------------------------------------------------------------------
+// CI wall-time revisit signals
+// ---------------------------------------------------------------------------
+
+export const CI_WALL_TIME_SLOW_JOB_SECONDS = 180;
+export const CI_WALL_TIME_REQUIRED_CHECK_SECONDS = 8 * 60;
+export const CI_WALL_TIME_IMBALANCE_RATIO = 1.5;
+export const CI_WALL_TIME_IMBALANCE_MIN_DELTA_SECONDS = 30;
+export const CI_WALL_TIME_COMPARABLE_JOB_COUNT = 5;
+
+const CI_WALL_TIME_EXCLUDED_JOB_PATTERNS = [
+  /^Deploy /,
+  /^Attest and Upload Binaries$/,
+  /^Toolshed Post-Deploy Patterns Test$/,
+];
+
+function medianNumber(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+function shouldIncludeCiWallTimeJob(name: string): boolean {
+  return !CI_WALL_TIME_EXCLUDED_JOB_PATTERNS.some((re) => re.test(name));
+}
+
+export function computeCiWallTimeRevisitSignals(
+  jobs: Job[],
+): CiWallTimeRevisitSignal[] {
+  const measuredJobs = jobs
+    .map((job) => {
+      const name = normalizeName(job.name);
+      const startMs = job.started_at ? Date.parse(job.started_at) : NaN;
+      const endMs = job.completed_at ? Date.parse(job.completed_at) : NaN;
+      return {
+        name,
+        startMs,
+        endMs,
+        durationSeconds: durationSeconds(job.started_at, job.completed_at),
+      };
+    })
+    .filter((job) =>
+      shouldIncludeCiWallTimeJob(job.name) &&
+      Number.isFinite(job.startMs) &&
+      Number.isFinite(job.endMs) &&
+      job.durationSeconds > 0
+    );
+
+  if (measuredJobs.length === 0) return [];
+
+  const signals: CiWallTimeRevisitSignal[] = [];
+  const sortedByDuration = [...measuredJobs].sort((a, b) =>
+    b.durationSeconds - a.durationSeconds
+  );
+  const slowest = sortedByDuration[0];
+
+  if (slowest.durationSeconds >= CI_WALL_TIME_SLOW_JOB_SECONDS) {
+    signals.push({
+      kind: "slow-job",
+      title: "Slowest required CI job is over 3m",
+      detail: `${slowest.name} took ${formatDuration(slowest.durationSeconds)}`,
+    });
+  }
+
+  const comparableJobs = sortedByDuration.slice(
+    0,
+    Math.min(CI_WALL_TIME_COMPARABLE_JOB_COUNT, sortedByDuration.length),
+  );
+  const comparableMedian = medianNumber(
+    comparableJobs.map((job) => job.durationSeconds),
+  );
+  if (
+    slowest.durationSeconds >=
+      comparableMedian * CI_WALL_TIME_IMBALANCE_RATIO &&
+    slowest.durationSeconds - comparableMedian >=
+      CI_WALL_TIME_IMBALANCE_MIN_DELTA_SECONDS
+  ) {
+    signals.push({
+      kind: "job-imbalance",
+      title: "One required CI job is much slower than nearby jobs",
+      detail: `${slowest.name} took ${
+        formatDuration(slowest.durationSeconds)
+      }; top-${comparableJobs.length} median is ${
+        formatDuration(comparableMedian)
+      }`,
+    });
+  }
+
+  const requiredStartMs = Math.min(...measuredJobs.map((job) => job.startMs));
+  const requiredEndMs = Math.max(...measuredJobs.map((job) => job.endMs));
+  const requiredWallTimeSeconds = (requiredEndMs - requiredStartMs) / 1000;
+  if (requiredWallTimeSeconds >= CI_WALL_TIME_REQUIRED_CHECK_SECONDS) {
+    signals.push({
+      kind: "required-wall-time",
+      title: "Required CI checks are over the wall-time budget",
+      detail: `Required non-deploy jobs took ${
+        formatDuration(requiredWallTimeSeconds)
+      } from first start to last completion`,
+    });
+  }
+
+  return signals;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

After the recent CI wall-time splits, the slow required test jobs are now clustered around the same range. Continuing to split proactively is diminishing returns, but we still want future developers and agents to notice when the data says CI needs attention again. This PR writes down the stop/revisit policy and makes Performance Check print non-blocking revisit signals in the place we already inspect for CI timing.

## What Changed

- Adds `docs/development/CI_PERFORMANCE.md` with stop rules, revisit triggers, and response guidance.
- Links the policy from `docs/development/DEVELOPMENT.md` and `AGENTS.md`.
- Adds advisory CI wall-time revisit signals for slow jobs, job imbalance, and required non-deploy wall-time budget.
- Prints those signals from Performance Check without changing pass/fail behavior.
- Covers the signal helper with focused unit tests.

## Test plan

- `deno fmt AGENTS.md docs/development/CI_PERFORMANCE.md docs/development/DEVELOPMENT.md tasks/perf-check.ts tasks/perf-lib.ts tasks/perf-lib.test.ts`
- `deno test --allow-read --allow-env tasks/perf-lib.test.ts`
- `deno check tasks/perf-check.ts tasks/perf-lib.ts tasks/perf-lib.test.ts`
- `deno lint tasks/perf-check.ts tasks/perf-lib.ts tasks/perf-lib.test.ts`
- `git diff --check`