### PR TITLE
chore(data-model,content-hash): backtick code-mentions in comments

### DIFF
--- a/packages/content-hash/src/sha256-deno.ts
+++ b/packages/content-hash/src/sha256-deno.ts
@@ -44,7 +44,7 @@ class DenoHasher extends BaseIncrementalHasher {
         return this.#hasher.digest(encoding);
       }
       case undefined: {
-        // node:crypto digest() returns Buffer; normalize to plain Uint8Array.
+        // `node:crypto`'s `digest()` returns `Buffer`; normalize to plain `Uint8Array`.
         const buf = this.#hasher.digest();
         return new Uint8Array(
           buf.buffer,

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -9,7 +9,7 @@
  */
 
 // ---------------------------------------------------------------------------
-// BigInt -> minimal two's-complement big-endian bytes
+// `bigint` -> minimal two's-complement big-endian bytes
 // ---------------------------------------------------------------------------
 
 /**
@@ -157,7 +157,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
 }
 
 // ---------------------------------------------------------------------------
-// Two's-complement big-endian bytes -> BigInt
+// Two's-complement big-endian bytes -> `bigint`
 // ---------------------------------------------------------------------------
 
 /**

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -68,9 +68,10 @@ function copyOwnSafeProperties(
 }
 
 /**
- * Creates a shallow copy of an Error, preserving constructor, name, message,
- * stack, cause, and custom enumerable properties. Used by `toNativeValue()`
- * when the freeze state of the wrapped Error doesn't match the requested state.
+ * Creates a shallow copy of an `Error`, preserving `constructor()`, `name`,
+ * `message`, `stack`, `cause`, and custom enumerable properties. Used by
+ * `toNativeValue()` when the freeze state of the wrapped `Error` doesn't match
+ * the requested state.
  */
 function copyError(error: Error): Error {
   const copy = new (error.constructor as ErrorConstructor)(error.message);
@@ -86,7 +87,7 @@ function copyError(error: Error): Error {
 }
 
 // ---------------------------------------------------------------------------
-// Utility: Error class lookup
+// Utility: `Error` class lookup
 // ---------------------------------------------------------------------------
 
 /** Map from Error subclass name to its constructor. */
@@ -142,7 +143,7 @@ export abstract class FabricNativeWrapper<T extends object>
 }
 
 // ---------------------------------------------------------------------------
-// FabricError
+// `FabricError`
 // ---------------------------------------------------------------------------
 
 /**
@@ -169,7 +170,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
    * into nested values -- the serialization system handles that.
    *
    * `type` is the constructor name (e.g. "TypeError") used for reconstruction.
-   * `name` is the `.name` property -- emitted as `null` when it equals `type`
+   * `name` is the `name` property -- emitted as `null` when it equals `type`
    * (the common case) to avoid redundancy.
    *
    * **Invariant**: By the time this method runs, `this.error.cause` and any
@@ -265,13 +266,13 @@ export class FabricError extends FabricNativeWrapper<Error> {
 }
 
 // ---------------------------------------------------------------------------
-// Stub native wrappers: Map, Set, Date, Uint8Array
+// Stub native wrappers: `Map`, `Set`, `Date`, `Uint8Array`
 // ---------------------------------------------------------------------------
 
 /**
  * Wrapper for `Map` instances. Stub -- `[DECONSTRUCT]` and `[RECONSTRUCT]`
- * throw until Map support is fully implemented. Extra properties beyond the
- * wrapped collection are not supported on non-Error wrappers.
+ * throw until `Map` support is fully implemented. Extra properties beyond the
+ * wrapped collection are not supported on non-`Error` wrappers.
  */
 export class FabricMap
   extends FabricNativeWrapper<Map<FabricValue, FabricValue>> {
@@ -315,8 +316,8 @@ export class FabricMap
 
 /**
  * Wrapper for `Set` instances. Stub -- `[DECONSTRUCT]` and `[RECONSTRUCT]`
- * throw until Set support is fully implemented. Extra properties beyond the
- * wrapped collection are not supported on non-Error wrappers.
+ * throw until `Set` support is fully implemented. Extra properties beyond the
+ * wrapped collection are not supported on non-`Error` wrappers.
  */
 export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
   /** @inheritDoc */
@@ -380,7 +381,7 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
   /**
    * Deconstructs into essential state for serialization. Returns
    * `{ source, flags, flavor }` -- the values needed to reconstruct the
-   * RegExp. Extra enumerable properties on the RegExp cause rejection.
+   * `RegExp`. Extra enumerable properties on the `RegExp` cause rejection.
    */
   [DECONSTRUCT](): FabricValue {
     rejectExtraRegExpProperties(this.regex);
@@ -402,7 +403,7 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
   }
 
   /**
-   * Returns a frozen copy of the RegExp. A frozen RegExp has an immutable
+   * Returns a frozen copy of the `RegExp`. A frozen `RegExp` has an immutable
    * `lastIndex`, so stateful methods (`exec()`, `test()`) won't work
    * correctly -- but that matches the "death before confusion" principle.
    */
@@ -432,7 +433,7 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
 }
 
 /**
- * Helper for `FabricRegExp.[DECONSTRUCT]()`, which rejects RegExp instances
+ * Helper for `FabricRegExp.[DECONSTRUCT]()`, which rejects `RegExp` instances
  * with extra enumerable properties. The built-in `lastIndex` property is not
  * enumerable, so `Object.keys()` won't see it. Any enumerable own property
  * is therefore user-added and causes rejection.

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -68,8 +68,8 @@ function copyOwnSafeProperties(
 }
 
 /**
- * Creates a shallow copy of an `Error`, preserving `constructor()`, `name`,
- * `message`, `stack`, `cause`, and custom enumerable properties. Used by
+ * Creates a shallow copy of an `Error`, preserving `constructor()`, `.name`,
+ * `.message`, `.stack`, `.cause`, and custom enumerable properties. Used by
  * `toNativeValue()` when the freeze state of the wrapped `Error` doesn't match
  * the requested state.
  */
@@ -165,18 +165,18 @@ export class FabricError extends FabricNativeWrapper<Error> {
   }
 
   /**
-   * Deconstructs into essential state for serialization. Returns type, name,
-   * message, stack, cause, and custom enumerable properties. Does NOT recurse
-   * into nested values -- the serialization system handles that.
+   * Deconstructs into essential state for serialization. Returns `.type`,
+   * `.name`, `.message`, `.stack`, `.cause`, and custom enumerable properties.
+   * Does NOT recurse into nested values -- the serialization system handles that.
    *
    * `type` is the constructor name (e.g. "TypeError") used for reconstruction.
-   * `name` is the `name` property -- emitted as `null` when it equals `type`
+   * `name` is the `.name` property -- emitted as `null` when it equals `type`
    * (the common case) to avoid redundancy.
    *
    * **Invariant**: By the time this method runs, `this.error.cause` and any
    * custom enumerable properties are already `FabricValue`. The conversion
    * layer (`convertErrorInternals()` in `fabric-value-modern.ts`) ensures
-   * this by recursively converting Error internals before wrapping in
+   * this by recursively converting `Error` internals before wrapping in
    * `FabricError`. The `as FabricValue` casts below are therefore safe.
    */
   [DECONSTRUCT](): FabricValue {
@@ -404,7 +404,7 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
 
   /**
    * Returns a frozen copy of the `RegExp`. A frozen `RegExp` has an immutable
-   * `lastIndex`, so stateful methods (`exec()`, `test()`) won't work
+   * `.lastIndex`, so stateful methods (`exec()`, `test()`) won't work
    * correctly -- but that matches the "death before confusion" principle.
    */
   protected toNativeFrozen(): RegExp {
@@ -434,7 +434,7 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
 
 /**
  * Helper for `FabricRegExp.[DECONSTRUCT]()`, which rejects `RegExp` instances
- * with extra enumerable properties. The built-in `lastIndex` property is not
+ * with extra enumerable properties. The built-in `.lastIndex` property is not
  * enumerable, so `Object.keys()` won't see it. Any enumerable own property
  * is therefore user-added and causes rejection.
  */

--- a/packages/data-model/fabric-value-legacy.ts
+++ b/packages/data-model/fabric-value-legacy.ts
@@ -348,8 +348,8 @@ function fabricFromNativeValueLegacyInternal(
     if (value === undefined && converted.size > 0) {
       return inArray ? null : OMIT;
     }
-    // At this point, `value` is a primitive (`null`, boolean, number, string) or
-    // `undefined` - all valid `FabricValue` types.
+    // At this point, `value` is a primitive (`null`, `boolean`, `number`,
+    // `string`) or `undefined` - all valid `FabricValue` types.
     return value as FabricValue;
   }
 

--- a/packages/data-model/fabric-value-legacy.ts
+++ b/packages/data-model/fabric-value-legacy.ts
@@ -25,7 +25,7 @@ function specialInstanceToFabricValue(
     // Return a single-key object using the `@` prefix convention established
     // elsewhere in the system. The spread captures any custom enumerable
     // properties, followed by explicit assignment of the standard (but
-    // non-enumerable) Error properties.
+    // non-enumerable) `Error` properties.
     return {
       "@Error": {
         ...error,
@@ -64,7 +64,7 @@ function hasToJSONMethod(
 /**
  * Legacy implementation of `isFabricValue()` for the JSON-only type system.
  * Determines if the given value is considered "fabric-compatible" per se (without
- * invoking any conversions such as `.toJSON()`).
+ * invoking any conversions such as `toJSON()`).
  *
  * @param value - The value to check.
  * @returns `true` if the value is fabric-compatible per se, `false` otherwise.
@@ -212,7 +212,7 @@ export function shallowFabricFromNativeValueLegacy(
         );
       } else if (Array.isArray(value)) {
         // Note that if the original `value` had a `toJSON()` method, that would
-        // have triggered the `toJSON` clause above and so we won't end up here.
+        // have triggered the `toJSON()` clause above and so we won't end up here.
         if (!isArrayWithOnlyIndexProperties(value)) {
           throw new Error(
             "Cannot store array with enumerable named properties.",
@@ -267,9 +267,9 @@ const PROCESSING = Symbol("PROCESSING");
  * @throws Error if the value (or any nested value) can't be converted.
  */
 export function fabricFromNativeValueLegacy(value: unknown): FabricValue {
-  // The internal helper can return OMIT for nested values that should be
-  // omitted, but at the top level this never happens (OMIT is only returned
-  // when converted.size > 0, i.e., in nested calls).
+  // The internal helper can return `OMIT` for nested values that should be
+  // omitted, but at the top level this never happens (`OMIT` is only returned
+  // when `converted.size > 0`, i.e., in nested calls).
   return fabricFromNativeValueLegacyInternal(
     value,
     new Map(),
@@ -342,14 +342,14 @@ function fabricFromNativeValueLegacyInternal(
       // Cache the primitive result for the original object (e.g., from toJSON).
       converted.set(original, value);
     }
-    // `undefined` at non-top-level should be omitted (matches JSON.stringify).
-    // In arrays, return `null` instead of OMIT to match JSON.stringify semantics
-    // (which coerces undefined to null in array positions).
+    // `undefined` at non-top-level should be omitted (matches `JSON.stringify()`).
+    // In arrays, return `null` instead of `OMIT` to match `JSON.stringify()` semantics
+    // (which coerces `undefined` to `null` in array positions).
     if (value === undefined && converted.size > 0) {
       return inArray ? null : OMIT;
     }
-    // At this point, value is a primitive (null, boolean, number, string) or
-    // undefined - all valid FabricValue types.
+    // At this point, `value` is a primitive (`null`, boolean, number, string) or
+    // `undefined` - all valid `FabricValue` types.
     return value as FabricValue;
   }
 

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -51,13 +51,13 @@ export function shallowFabricFromNativeValueModern(
   value: unknown,
   freeze = true,
 ): FabricValueLayer {
-  // Top-level type dispatch via tagFromNativeValue() -- O(1) constructor
-  // switch with fallbacks for exotic Error subclasses, cross-realm arrays,
-  // and null-prototype objects. Returns Primitive for non-objects.
+  // Top-level type dispatch via `tagFromNativeValue()` -- O(1) constructor
+  // switch with fallbacks for exotic `Error` subclasses, cross-realm arrays,
+  // and null-prototype objects. Returns `Primitive` for non-objects.
   const tag = tagFromNativeValue(value);
 
   switch (tag) {
-    // Special primitives are direct FabricValue members -- always frozen,
+    // Special primitives are direct `FabricValue` members -- always frozen,
     // pass through as-is regardless of the `freeze` argument.
     case NATIVE_TAGS.EpochNsec:
     case NATIVE_TAGS.EpochDays:
@@ -72,7 +72,7 @@ export function shallowFabricFromNativeValueModern(
     }
 
     case NATIVE_TAGS.Date: {
-      // Date instances are converted to FabricEpochNsec (nanoseconds from
+      // `Date` instances are converted to `FabricEpochNsec` (nanoseconds from
       // epoch). Extra enumerable properties cause rejection ("death before
       // confusion").
       rejectExtraProperties(value as object, "Date");
@@ -83,10 +83,10 @@ export function shallowFabricFromNativeValueModern(
     }
 
     case NATIVE_TAGS.RegExp: {
-      // RegExp instances are wrapped in FabricRegExp. Extra enumerable
+      // `RegExp` instances are wrapped in `FabricRegExp`. Extra enumerable
       // properties cause rejection ("death before confusion"). The
-      // rejectExtraProperties check is done inside FabricRegExp's
-      // DECONSTRUCT, but we also reject eagerly here at conversion time.
+      // `rejectExtraProperties()` check is done inside `FabricRegExp`'s
+      // `[DECONSTRUCT]`, but we also reject eagerly here at conversion time.
       rejectExtraProperties(value as object, "RegExp");
       const wrappedRegExp = new FabricRegExp(value as RegExp);
       if (freeze) Object.freeze(wrappedRegExp);
@@ -94,14 +94,14 @@ export function shallowFabricFromNativeValueModern(
     }
 
     case NATIVE_TAGS.Uint8Array: {
-      // Native Uint8Array instances are wrapped in FabricBytes.
-      // FabricBytes self-freezes in its constructor (FabricPrimitive contract).
+      // Native `Uint8Array` instances are wrapped in `FabricBytes`.
+      // `FabricBytes` self-freezes in its constructor (`FabricPrimitive` contract).
       return new FabricBytes(value as Uint8Array);
     }
 
     case NATIVE_TAGS.Array:
     case NATIVE_TAGS.Object:
-      // Arrays and plain objects: delegate frozenness handling to cloneHelper.
+      // Arrays and plain objects: delegate frozenness handling to `cloneHelper()`.
       return cloneHelper(
         value as FabricValue,
         freeze,
@@ -111,8 +111,8 @@ export function shallowFabricFromNativeValueModern(
       ) as FabricValueLayer;
 
     case NATIVE_TAGS.HasToJSON: {
-      // Objects (or arrays/class instances) with a toJSON() method.
-      // Call toJSON() and validate the result.
+      // Objects (or arrays/class instances) with a `toJSON()` method.
+      // Call `toJSON()` and validate the result.
       const converted = (value as { toJSON: () => unknown }).toJSON();
       if (!isFabricValueModern(converted)) {
         throw new Error(
@@ -129,9 +129,9 @@ export function shallowFabricFromNativeValueModern(
     }
 
     case NATIVE_TAGS.FabricInstance: {
-      // FabricInstance values (FabricError, UnknownValue, etc.)
-      // are already valid FabricValue members. Delegate frozenness
-      // handling to cloneHelper.
+      // `FabricInstance` values (`FabricError`, `UnknownValue`, etc.)
+      // are already valid `FabricValue` members. Delegate frozenness
+      // handling to `cloneHelper()`.
       return cloneHelper(
         value as FabricValue,
         freeze,
@@ -143,9 +143,9 @@ export function shallowFabricFromNativeValueModern(
 
     // deno-lint-ignore no-fallthrough
     case NATIVE_TAGS.Primitive: {
-      // Primitives: null, undefined, boolean, string, number, bigint,
-      // symbol, function. null is the only value here with typeof "object"
-      // (actual objects are routed to other tags by tagFromNativeValue).
+      // Primitives: `null`, `undefined`, boolean, string, number, bigint,
+      // symbol, function. `null` is the only value here with `typeof "object"`
+      // (actual objects are routed to other tags by `tagFromNativeValue()`).
       switch (typeof value) {
         case "object":
           // Only null reaches here (typeof null === "object").
@@ -184,8 +184,8 @@ export function shallowFabricFromNativeValueModern(
     }
 
     default:
-      // Unrecognized object types (Map, Set, Uint8Array, class instances
-      // without toJSON, etc.) -- not valid FabricValue. Death before
+      // Unrecognized object types (`Map`, `Set`, `Uint8Array`, class instances
+      // without `toJSON()`, etc.) -- not valid `FabricValue`. Death before
       // confusion!
       throw new Error(
         `Cannot store ${
@@ -237,7 +237,7 @@ export function fabricFromNativeValueModern(
   freeze = true,
 ): FabricValue {
   // Identity optimization: if the value is already a deep-frozen
-  // FabricValue, return it without copying.
+  // `FabricValue`, return it without copying.
   if (freeze && isDeepFrozenFabricValue(value)) {
     return value as FabricValue;
   }
@@ -250,9 +250,9 @@ export function fabricFromNativeValueModern(
 
 /**
  * Helper for `fabricFromNativeValueModern()` and `cloneHelper()`, which
- * indicates whether the value is a deep-frozen FabricValue (naive recursive
+ * indicates whether the value is a deep-frozen `FabricValue` (naive recursive
  * check). Returns `true` if the value is a primitive, or a frozen
- * object/array whose children are all also deep-frozen FabricValues.
+ * object/array whose children are all also deep-frozen `FabricValue`s.
  */
 function isDeepFrozenFabricValue(value: unknown): boolean {
   if (value === null || (typeof value !== "object")) return true; // primitives
@@ -288,7 +288,7 @@ function isDeepFrozenFabricValue(value: unknown): boolean {
  * conversion for the modern path. Single-pass: checks, wraps, and optionally
  * freezes each node as it's built. By the time this returns, the whole tree
  * is converted and (if `freeze` is true) deep-frozen. Unlike the legacy
- * version, this never returns OMIT -- `undefined` values are preserved.
+ * version, this never returns `OMIT` -- `undefined` values are preserved.
  */
 function fabricFromNativeValueModernInternal(
   original: unknown,
@@ -330,15 +330,15 @@ function fabricFromNativeValueModernInternal(
     return value as FabricValue;
   }
 
-  // TODO(danfuzz): Look into avoiding this special case for FabricError.
+  // TODO(danfuzz): Look into avoiding this special case for `FabricError`.
   // Ideally the recursive internals conversion would be handled generically
   // rather than requiring a type-specific branch here.
   //
-  // FabricError wraps a raw Error whose internals (cause, custom
-  // properties) may contain raw native types that aren't FabricValue.
+  // `FabricError` wraps a raw `Error` whose internals (cause, custom
+  // properties) may contain raw native types that aren't `FabricValue`.
   // We must recursively convert those internals NOW so that when
-  // [DECONSTRUCT] runs at serialization time, all nested values are
-  // already FabricValue. See spec: the conversion layer (not the
+  // `[DECONSTRUCT]` runs at serialization time, all nested values are
+  // already `FabricValue`. See spec: the conversion layer (not the
   // serializer) is responsible for ensuring this.
   if (value instanceof FabricError) {
     const convertedError = convertErrorInternals(
@@ -354,7 +354,7 @@ function fabricFromNativeValueModernInternal(
     return result as FabricValue;
   }
 
-  // FabricSpecialObject (primitives and protocol types) -- pass through
+  // `FabricSpecialObject` (primitives and protocol types) -- pass through
   // as-is. Primitives are always frozen; protocol types are managed by
   // the caller.
   if (value instanceof FabricSpecialObject) {
@@ -386,8 +386,8 @@ function fabricFromNativeValueModernInternal(
     result = resultArray as FabricValue;
   } else {
     // Recurse into object properties. Preserve `undefined`-valued properties.
-    // Use Object.create to preserve null prototypes (Object.fromEntries
-    // always produces Object.prototype-backed results).
+    // Use `Object.create()` to preserve null prototypes (`Object.fromEntries()`
+    // always produces `Object.prototype`-backed results).
     const proto = Object.getPrototypeOf(value);
     const obj = Object.create(proto) as Record<string, FabricValue>;
     for (const [key, val] of Object.entries(value)) {
@@ -422,7 +422,7 @@ function convertErrorInternals(
   converted: Map<object, unknown>,
   freeze: boolean,
 ): Error {
-  // Construct the same Error subclass.
+  // Construct the same `Error` subclass.
   const result = new (error.constructor as ErrorConstructor)(error.message);
 
   // Preserve name (covers custom names like "MyError").
@@ -435,7 +435,7 @@ function convertErrorInternals(
     result.stack = error.stack;
   }
 
-  // Recursively convert cause -- it could be a raw Error, Map, etc.
+  // Recursively convert `cause` -- it could be a raw `Error`, `Map`, etc.
   if (error.cause !== undefined) {
     result.cause = fabricFromNativeValueModernInternal(
       error.cause,
@@ -444,7 +444,7 @@ function convertErrorInternals(
     );
   }
 
-  // Recursively convert custom enumerable properties, skipping known Error
+  // Recursively convert custom enumerable properties, skipping known `Error`
   // keys (handled above) and prototype-pollution-sensitive keys.
   const SKIP_KEYS = new Set(["name", "message", "stack", "cause"]);
   for (const key of Object.keys(error)) {
@@ -490,7 +490,7 @@ export function isFabricValueModern(
       if (value === null) {
         return true;
       }
-      // FabricSpecialObject -- already a valid FabricValue.
+      // `FabricSpecialObject` -- already a valid `FabricValue`.
       if (value instanceof FabricSpecialObject) {
         return true;
       }
@@ -500,7 +500,7 @@ export function isFabricValueModern(
         return isArrayWithOnlyIndexProperties(value);
       }
       // Plain objects are accepted; class instances are not (except
-      // FabricInstance, handled above).
+      // `FabricInstance`, handled above).
       const proto = Object.getPrototypeOf(value);
       return proto === null || proto === Object.prototype;
     }
@@ -518,7 +518,7 @@ export function isFabricValueModern(
 }
 
 // ---------------------------------------------------------------------------
-// isFabricCompatible: deep check for fabric compatibility
+// `isFabricCompatible()`: deep check for fabric compatibility
 // ---------------------------------------------------------------------------
 
 /**
@@ -531,7 +531,7 @@ export function isFabricValueModern(
  * - `isFabricCompatible(x)` -- "could x be converted to a `FabricValue` via
  *   `fabricFromNativeValue()`?"
  *
- * `isFabricCompatible` additionally accepts `FabricNativeObject` types and
+ * `isFabricCompatible()` additionally accepts `FabricNativeObject` types and
  * objects/functions with `toJSON()` methods
  * that return fabric values. It checks recursively, so all nested values in
  * arrays and objects must also be fabric-compatible or convertible.
@@ -545,11 +545,11 @@ export function isFabricCompatibleModern(
 }
 
 // ---------------------------------------------------------------------------
-// Unified clone: cloneIfNecessary
+// Unified clone: `cloneIfNecessary()`
 // ---------------------------------------------------------------------------
 
 /**
- * Options for `cloneIfNecessary`.
+ * Options for `cloneIfNecessary()`.
  */
 export interface CloneOptions {
   /** Whether the result should be frozen. Default: `true`. */
@@ -578,7 +578,7 @@ export interface CloneOptions {
  * Clones an already-valid `FabricValue` to achieve a desired frozenness,
  * with control over depth and copy semantics.
  *
- * Unlike `fabricFromNativeValue` (which converts native JS values into
+ * Unlike `fabricFromNativeValue()` (which converts native JS values into
  * fabric wrappers), this function assumes the input is already a valid
  * `FabricValue` and only adjusts frozenness by cloning where necessary.
  *
@@ -628,7 +628,7 @@ function trackForCircularity(
  * matches the requested state. When `force` is true, always copies (unless
  * the value is a primitive or special primitive).
  *
- * Deep mode uses `isDeepFrozenFabricValue` for identity optimization;
+ * Deep mode uses `isDeepFrozenFabricValue()` for identity optimization;
  * shallow mode uses `Object.isFrozen(value) === frozen`.
  */
 function cloneHelper(
@@ -638,9 +638,9 @@ function cloneHelper(
   force: boolean,
   seen: Set<object> | null,
 ): FabricValue {
-  // Identity optimization: when force is off, check if the value's frozenness
-  // already matches the requested state. Deep mode uses isDeepFrozenFabricValue;
-  // shallow mode uses Object.isFrozen(v) === frozen.
+  // Identity optimization: when `force` is off, check if the value's frozenness
+  // already matches the requested state. Deep mode uses `isDeepFrozenFabricValue()`;
+  // shallow mode uses `Object.isFrozen(v) === frozen`.
   function canReturnAsIs(v: FabricValue): boolean {
     if (force) return false;
     if (deep) {
@@ -687,7 +687,7 @@ function cloneHelper(
       if (canReturnAsIs(value)) return value;
       const obj = value as object;
       if (deep) seen = trackForCircularity(obj, seen);
-      // Preserve null prototypes (e.g. Object.create(null)).
+      // Preserve null prototypes (e.g. `Object.create(null)`).
       const proto = Object.getPrototypeOf(obj);
       const copy = Object.create(proto) as Record<string, FabricValue>;
       if (deep) {
@@ -709,7 +709,7 @@ function cloneHelper(
     }
 
     default:
-      // All valid FabricValue types are handled above.
+      // All valid `FabricValue` types are handled above.
       throw new Error(
         `Cannot clone: ${(value as object).constructor?.name ?? typeof value}`,
       );
@@ -747,10 +747,10 @@ function isFabricCompatibleInternal(
     }
 
     case "object": {
-      // FabricSpecialObject -- already a valid FabricValue.
+      // `FabricSpecialObject` -- already a valid `FabricValue`.
       if (value instanceof FabricSpecialObject) return true;
 
-      // FabricNativeObject types would be wrapped by fabricFromNativeValue().
+      // `FabricNativeObject` types would be wrapped by `fabricFromNativeValue()`.
       if (isConvertibleNativeInstance(value)) {
         return true;
       }
@@ -808,18 +808,18 @@ function isFabricCompatibleInternal(
 }
 
 // ---------------------------------------------------------------------------
-// Deep unwrap: FabricValue -> native JS types (modern path)
+// Deep unwrap: `FabricValue` -> native JS types (modern path)
 // ---------------------------------------------------------------------------
 
 /**
  * Recursively walks a `FabricValue` tree, unwrapping any
  * `FabricNativeWrapper` values to their underlying native types via
- * `toNativeValue()`. Non-native `FabricInstance` values (Cell, Stream,
- * UnknownValue, etc.) pass through as-is.
+ * `toNativeValue()`. Non-native `FabricInstance` values (`Cell`, `Stream`,
+ * `UnknownValue`, etc.) pass through as-is.
  *
  * The freeze-state contract: the output's freeze state ALWAYS matches `frozen`.
  * Arrays and objects are copied and frozen/unfrozen accordingly. For
- * `FabricError`, the inner Error's `cause` and custom properties are also
+ * `FabricError`, the inner `Error`'s `cause` and custom properties are also
  * recursively unwrapped (since they may contain `FabricInstance` wrappers).
  */
 export function nativeFromFabricValueModern(
@@ -834,7 +834,7 @@ export function nativeFromFabricValueModern(
     return value.toNativeValue(frozen);
   }
 
-  // Remaining FabricSpecialObject values (not FabricNativeWrapper) pass
+  // Remaining `FabricSpecialObject` values (not `FabricNativeWrapper`) pass
   // through unchanged.
   if (value instanceof FabricSpecialObject) return value;
 

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -334,7 +334,7 @@ function fabricFromNativeValueModernInternal(
   // Ideally the recursive internals conversion would be handled generically
   // rather than requiring a type-specific branch here.
   //
-  // `FabricError` wraps a raw `Error` whose internals (cause, custom
+  // `FabricError` wraps a raw `Error` whose internals (`.cause`, custom
   // properties) may contain raw native types that aren't `FabricValue`.
   // We must recursively convert those internals NOW so that when
   // `[DECONSTRUCT]` runs at serialization time, all nested values are
@@ -409,13 +409,13 @@ function fabricFromNativeValueModernInternal(
 }
 
 /**
- * Creates a new Error with the same class and properties as the original,
- * but with `cause` and custom enumerable properties recursively converted
+ * Creates a new `Error` with the same class and properties as the original,
+ * but with `.cause` and custom enumerable properties recursively converted
  * to `FabricValue`. This ensures that when `FabricError[DECONSTRUCT]`
  * runs at serialization time, all nested values are already `FabricValue`.
  *
- * We create a new Error rather than mutating the original because the
- * caller's Error should not be modified as a side effect of storing it.
+ * We create a new `Error` rather than mutating the original because the
+ * caller's `Error` should not be modified as a side effect of storing it.
  */
 function convertErrorInternals(
   error: Error,
@@ -435,7 +435,7 @@ function convertErrorInternals(
     result.stack = error.stack;
   }
 
-  // Recursively convert `cause` -- it could be a raw `Error`, `Map`, etc.
+  // Recursively convert `.cause` -- it could be a raw `Error`, `Map`, etc.
   if (error.cause !== undefined) {
     result.cause = fabricFromNativeValueModernInternal(
       error.cause,
@@ -819,7 +819,7 @@ function isFabricCompatibleInternal(
  *
  * The freeze-state contract: the output's freeze state ALWAYS matches `frozen`.
  * Arrays and objects are copied and frozen/unfrozen accordingly. For
- * `FabricError`, the inner `Error`'s `cause` and custom properties are also
+ * `FabricError`, the inner `Error`'s `.cause` and custom properties are also
  * recursively unwrapped (since they may contain `FabricInstance` wrappers).
  */
 export function nativeFromFabricValueModern(

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -323,7 +323,7 @@ function fabricFromNativeValueModernInternal(
     throw e;
   }
 
-  // Primitives, null, and undefined don't need recursion or freezing.
+  // Primitives, `null`, and `undefined` don't need recursion or freezing.
   if (!isRecord(value)) {
     if (isOriginalRecord) {
       converted.set(original, value);

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -143,12 +143,13 @@ export function shallowFabricFromNativeValueModern(
 
     // deno-lint-ignore no-fallthrough
     case NATIVE_TAGS.Primitive: {
-      // Primitives: `null`, `undefined`, boolean, string, number, bigint,
-      // symbol, function. `null` is the only value here with `typeof "object"`
-      // (actual objects are routed to other tags by `tagFromNativeValue()`).
+      // Primitives: `null`, `undefined`, `boolean`, `string`, `number`,
+      // `bigint`, `symbol`, `function`. `null` is the only value here with
+      // `typeof "object"` (actual objects are routed to other tags by
+      // `tagFromNativeValue()`).
       switch (typeof value) {
         case "object":
-          // Only null reaches here (typeof null === "object").
+          // Only `null` reaches here (`typeof null === "object"`).
           return null;
         case "undefined":
         case "boolean":
@@ -463,8 +464,8 @@ function convertErrorInternals(
 /**
  * Indicates whether the value is a fabric value, accepting `FabricInstance`
  * values, `undefined`, and arrays with `undefined` elements or sparse holes
- * -- in addition to the base fabric types (null, boolean, number, string,
- * plain objects, dense arrays).
+ * -- in addition to the base fabric types (`null`, `boolean`, `number`,
+ * `string`, plain objects, dense arrays).
  *
  * MUST be self-contained (inline base-type checks, does NOT delegate back to
  * `isFabricValue()`) to avoid circular dispatch when the `modernDataModel`
@@ -720,7 +721,7 @@ function isFabricCompatibleInternal(
   value: unknown,
   seen: Set<object>,
 ): boolean {
-  // Primitives: null, boolean, string, number, bigint, undefined.
+  // Primitives: `null`, `boolean`, `string`, `number`, `bigint`, `undefined`.
   if (value === null || value === undefined) return true;
 
   switch (typeof value) {

--- a/packages/data-model/fabric-value.ts
+++ b/packages/data-model/fabric-value.ts
@@ -1,5 +1,5 @@
-// Re-export everything from interface.ts so that `fabric-value` remains the
-// canonical public surface for all type declarations and the FabricInstance
+// Re-export everything from `interface.ts` so that `fabric-value` remains the
+// canonical public surface for all type declarations and the `FabricInstance`
 // base class.
 export {
   DECONSTRUCT,
@@ -90,9 +90,9 @@ export function resetDataModelConfig(): void {
 /**
  * Converts a native JS value to fabric form (deep, recursive).
  *
- * Flag OFF (legacy): performs deep conversion via `fabricFromNativeValueLegacy`.
- * Flag ON (modern): wraps native types (Error, Date, RegExp, etc.) into
- * fabric wrappers and deep-freezes via `fabricFromNativeValueModern`.
+ * Flag OFF (legacy): performs deep conversion via `fabricFromNativeValueLegacy()`.
+ * Flag ON (modern): wraps native types (`Error`, `Date`, `RegExp`, etc.) into
+ * fabric wrappers and deep-freezes via `fabricFromNativeValueModern()`.
  *
  * @param freeze - When `true` (default), deep-freezes the result. Only
  *   applies when `modernDataModel` is ON; the legacy path does not
@@ -110,12 +110,12 @@ export function fabricFromNativeValue(
 /**
  * Recursively walks a `FabricValue` tree, unwrapping any
  * `FabricNativeWrapper` values to their underlying native types via
- * `toNativeValue()`. Non-native `FabricInstance` values (Cell, Stream,
- * UnknownValue, etc.) pass through as-is.
+ * `toNativeValue()`. Non-native `FabricInstance` values (`Cell`, `Stream`,
+ * `UnknownValue`, etc.) pass through as-is.
  *
  * Flag OFF (legacy): identity passthrough (legacy values contain no
  * `FabricNativeWrapper` instances). Flag ON (modern): delegates to
- * `nativeFromFabricValueModern`.
+ * `nativeFromFabricValueModern()`.
  *
  * @param frozen - When `true` (default), deep-freezes the result. Only
  *   applies when `modernDataModel` is ON; the legacy path is a
@@ -134,7 +134,7 @@ export function nativeFromFabricValue(
  * Clones an already-valid `FabricValue` to achieve a desired frozenness,
  * with control over depth and copy semantics.
  *
- * Unlike `fabricFromNativeValue` (which converts native JS values into
+ * Unlike `fabricFromNativeValue()` (which converts native JS values into
  * fabric wrappers), this function assumes the input is already a valid
  * `FabricValue` and only adjusts frozenness by cloning where necessary.
  *
@@ -189,11 +189,11 @@ export function cloneIfNecessary<T extends FabricValue>(
 
 /**
  * Determines if the given value is considered "fabric-compatible" by the system per se
- * (without invoking any conversions such as `.toJSON()`). This function does
+ * (without invoking any conversions such as `toJSON()`). This function does
  * not recursively validate nested values in arrays or objects.
  *
  * Flag OFF (legacy): fabric values are JSON-encodable values plus
- * `undefined`. Flag ON (modern): delegates to `isFabricValueModern` which
+ * `undefined`. Flag ON (modern): delegates to `isFabricValueModern()` which
  * accepts the extended type system.
  *
  * @param value - The value to check.
@@ -215,7 +215,7 @@ export function isFabricValue(
  * or a deep tree thereof.
  *
  * Flag OFF (legacy): equivalent to `isFabricValue()` (non-recursive).
- * Flag ON (modern): delegates to `isFabricCompatibleModern` which recursively
+ * Flag ON (modern): delegates to `isFabricCompatibleModern()` which recursively
  * validates nested values.
  *
  * @param value - The value to check.
@@ -241,7 +241,7 @@ export function isFabricCompatible(
  * converted via `toJSON()` if available.
  *
  * Flag OFF (legacy): JSON-only type system. Flag ON (modern): delegates to
- * `shallowFabricFromNativeValueModern` which handles the extended type system.
+ * `shallowFabricFromNativeValueModern()` which handles the extended type system.
  *
  * @param value - The value to convert.
  * @param freeze - When `true` (default), freezes the result if it is an
@@ -265,9 +265,9 @@ export function shallowFabricFromNativeValue(
 /**
  * Compares two fabric values for equality.
  *
- * Flag OFF (legacy): uses JSON.stringify comparison, matching the behavior of
- * the original `JSON.parse(JSON.stringify(...))` round-trip (strips undefined,
- * coerces NaN to null, etc.).
+ * Flag OFF (legacy): uses `JSON.stringify()` comparison, matching the behavior of
+ * the original `JSON.parse(JSON.stringify(...))` round-trip (strips `undefined`,
+ * coerces `NaN` to `null`, etc.).
  *
  * Flag ON (modern): uses deep structural equality that correctly handles
  * undefined, sparse arrays, and other extended types.

--- a/packages/data-model/fabric-value.ts
+++ b/packages/data-model/fabric-value.ts
@@ -53,8 +53,8 @@ export {
 /**
  * Module-level flag for modern data model mode, set by the `Runtime`
  * constructor via `setDataModelConfig()`. When enabled, fabric value
- * functions use the extended type system (bigint, Map, Set, Uint8Array,
- * Date, etc.).
+ * functions use the extended type system (`bigint`, `Map`, `Set`,
+ * `Uint8Array`, `Date`, etc.).
  */
 let modernDataModelEnabled = false;
 

--- a/packages/data-model/frozen-builtins.ts
+++ b/packages/data-model/frozen-builtins.ts
@@ -40,7 +40,7 @@ function throwFinalizedBuilderMutation(typeName: string): never {
 /**
  * Helper for the `FrozenMap` methods, which fetches the backing `Map` for the
  * given wrapper instance. Throws if `value` is not a recognized `FrozenMap`
- * receiver (e.g. when an intrinsic mutator was called via `.call(...)`).
+ * receiver (e.g. when an intrinsic mutator was called via `call(...)`).
  */
 function getMapBacking<K, V>(value: object): MapBacking<K, V> {
   const backing = MAP_BACKING.get(value);
@@ -83,7 +83,7 @@ function forEachSetLikeValue<T>(
 
 /**
  * Effectively-immutable `Map` wrapper. Read methods delegate to a
- * module-private backing `Map`; mutator methods (`set`, `delete`, `clear`,
+ * module-private backing `Map`; mutator methods (`set()`, `delete()`, `clear()`,
  * etc.) throw. Instances are frozen at construction time (or at builder
  * `finish()` time, see `createBuilder()`).
  */
@@ -213,8 +213,8 @@ Object.setPrototypeOf(FrozenMap, Map);
 
 /**
  * Effectively-immutable `Set` wrapper. Read methods and set-algebra methods
- * delegate to a module-private backing `Set`; mutator methods (`add`,
- * `delete`, `clear`) throw. Instances are frozen at construction time (or at
+ * delegate to a module-private backing `Set`; mutator methods (`add()`,
+ * `delete()`, `clear()`) throw. Instances are frozen at construction time (or at
  * builder `finish()` time, see `createBuilder()`).
  */
 export class FrozenSet<T> implements Set<T> {

--- a/packages/data-model/interface.ts
+++ b/packages/data-model/interface.ts
@@ -10,12 +10,12 @@
  */
 
 // ===========================================================================
-// FabricSpecialObject
+// `FabricSpecialObject`
 // ===========================================================================
 
 /**
  * Abstract base class for all fabric-system value types. This is the common
- * superclass of `FabricInstance` (protocol types with DECONSTRUCT/RECONSTRUCT)
+ * superclass of `FabricInstance` (protocol types with `[DECONSTRUCT]`/`[RECONSTRUCT]`)
  * and `FabricPrimitive` (immutable special primitives). It enables a single
  * `instanceof FabricSpecialObject` check wherever code needs to recognize any
  * fabric-system value without caring which branch of the hierarchy it
@@ -24,7 +24,7 @@
 export abstract class FabricSpecialObject {}
 
 // ===========================================================================
-// Fabric instance protocol (DECONSTRUCT / RECONSTRUCT / FabricInstance)
+// Fabric instance protocol (`[DECONSTRUCT]` / `[RECONSTRUCT]` / `FabricInstance`)
 // ===========================================================================
 
 /**
@@ -82,7 +82,7 @@ export abstract class FabricInstance extends FabricSpecialObject {
   shallowClone(frozen: boolean): FabricInstance {
     if (frozen && Object.isFrozen(this)) return this;
     const copy = this.shallowUnfrozenClone();
-    // Cast needed: Object.freeze() returns Readonly<T>, which TS considers
+    // Cast needed: `Object.freeze()` returns `Readonly<T>`, which TS considers
     // incompatible with abstract class types due to protected members.
     return frozen ? Object.freeze(copy) as FabricInstance : copy;
   }
@@ -123,7 +123,7 @@ export abstract class FabricPrimitive extends FabricSpecialObject {
  * The full set of values that the fabric storage layer can represent. This
  * is the strongly-typed "middle layer" of the three-layer architecture:
  *
- *   JavaScript "wild west" (unknown) <-> FabricValue <-> Serialized (Uint8Array)
+ *   JavaScript "wild west" (`unknown`) <-> `FabricValue` <-> Serialized (`Uint8Array`)
  *
  * Most native JS object types enter the fabric layer via wrapper classes
  * that implement `FabricInstance`. However, `FabricPrimitive` subclasses
@@ -167,10 +167,10 @@ export interface FabricArray extends ArrayLike<FabricValue> {}
 /**
  * Object/record of fabric values.
  *
- * Note: `__proto__` and `constructor` properties are not currently guarded
+ * Note: `__proto__` and `constructor()` properties are not currently guarded
  * against at the type level or at runtime in clone/conversion internals.
  * If prototype pollution becomes a concern, add boundary validation where
- * values enter the fabric system (e.g., `fabricFromNativeValue`).
+ * values enter the fabric system (e.g., `fabricFromNativeValue()`).
  */
 export interface FabricObject extends Record<string, FabricValue> {}
 
@@ -178,7 +178,7 @@ export interface FabricObject extends Record<string, FabricValue> {}
  * Single "layer" of fabric conversion -- the result of shallow conversion
  * via `shallowFabricFromNativeValue()`. Arrays and objects have the right
  * shape but their contents may still contain values requiring further
- * conversion (e.g., Error instances in a `cause` chain).
+ * conversion (e.g., `Error` instances in a `cause` chain).
  */
 export type FabricValueLayer =
   | FabricValue

--- a/packages/data-model/interface.ts
+++ b/packages/data-model/interface.ts
@@ -167,7 +167,7 @@ export interface FabricArray extends ArrayLike<FabricValue> {}
 /**
  * Object/record of fabric values.
  *
- * Note: `__proto__` and `constructor()` properties are not currently guarded
+ * Note: `.__proto__` and `constructor()` properties are not currently guarded
  * against at the type level or at runtime in clone/conversion internals.
  * If prototype pollution becomes a concern, add boundary validation where
  * values enter the fabric system (e.g., `fabricFromNativeValue()`).
@@ -178,7 +178,7 @@ export interface FabricObject extends Record<string, FabricValue> {}
  * Single "layer" of fabric conversion -- the result of shallow conversion
  * via `shallowFabricFromNativeValue()`. Arrays and objects have the right
  * shape but their contents may still contain values requiring further
- * conversion (e.g., `Error` instances in a `cause` chain).
+ * conversion (e.g., `Error` instances in a `.cause` chain).
  */
 export type FabricValueLayer =
   | FabricValue

--- a/packages/data-model/json-encoding-context.ts
+++ b/packages/data-model/json-encoding-context.ts
@@ -48,7 +48,7 @@ function isEncodedInstance(v: JsonWireValue): boolean {
  * Returns true if the already-serialized wire value `v` can be embedded
  * inside a /quote wrap without inner deserialization: primitives, plain
  * objects/arrays free of non-/quote encoded instances, and /quote-wrapped
- * values (which unquote() can collapse).
+ * values (which `unquote()` can collapse).
  */
 function isQuoteSafe(v: JsonWireValue): boolean {
   if (v === null || typeof v !== "object") return true;
@@ -115,8 +115,8 @@ export class JsonEncodingContext implements SerializationContext<string> {
     };
 
     // Register native wrapper classes for deserialization. Each wrapper's
-    // static [RECONSTRUCT] method is used by the class registry fallback
-    // path in deserialize().
+    // static `[RECONSTRUCT]` method is used by the class registry fallback
+    // path in `deserialize()`.
     this.registry.set(TAGS.Error, FabricError);
     this.registry.set(TAGS.Map, FabricMap);
     this.registry.set(TAGS.Set, FabricSet);
@@ -124,7 +124,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
   }
 
   // -------------------------------------------------------------------------
-  // SerializationContext<string> -- public boundary interface
+  // `SerializationContext<string>` -- public boundary interface
   // -------------------------------------------------------------------------
 
   /**
@@ -392,7 +392,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
 
       // A bare `"/"` key (empty tag after stripping the leading slash) is
       // always an encoding error per spec §9 — no valid tag has an empty
-      // name. Produce a ProblematicValue rather than an UnknownValue with
+      // name. Produce a `ProblematicValue` rather than an `UnknownValue` with
       // an empty tag.
       if (tag === "") {
         return new ProblematicValue(
@@ -509,7 +509,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
     }
 
     // Plain objects: recursively deserialize values and freeze. Any
-    // /-prefixed key is reserved per spec — return ProblematicValue on
+    // `/`-prefixed key is reserved per spec — return `ProblematicValue` on
     // first occurrence rather than silently round-tripping the object.
     const result: Record<string, FabricValue> = {};
     for (const [key, val] of Object.entries(data)) {

--- a/packages/data-model/json-encoding.ts
+++ b/packages/data-model/json-encoding.ts
@@ -20,7 +20,7 @@ import {
  * Module-level flag for unified JSON encoding, set by the `Runtime`
  * constructor via `setJsonEncodingConfig()`. When enabled, the public API
  * symbols dispatch to the `JsonEncodingContext` codec instead of plain
- * JSON.stringify / JSON.parse.
+ * `JSON.stringify()` / `JSON.parse()`.
  */
 let jsonEncodingEnabled = true;
 

--- a/packages/data-model/json-type-handlers.ts
+++ b/packages/data-model/json-type-handlers.ts
@@ -555,8 +555,8 @@ export const FabricInstanceHandler: TypeHandler = {
  * serialization: `FabricPrimitive` subclasses are checked first (direct
  * `FabricValue` members matched by `instanceof`), then `FabricInstance`
  * (generic protocol types), then `bigint` and `undefined`. Primitives
- * (null, boolean, number, string), arrays, and plain objects are handled
- * as fallthrough in the serializer after no handler matches.
+ * (`null`, `boolean`, `number`, `string`), arrays, and plain objects are
+ * handled as fallthrough in the serializer after no handler matches.
  */
 export function createDefaultRegistry(): TypeHandlerRegistry {
   const registry = new TypeHandlerRegistry();

--- a/packages/data-model/json-type-handlers.ts
+++ b/packages/data-model/json-type-handlers.ts
@@ -64,7 +64,7 @@ export interface TypeHandler {
   canSerialize(value: FabricValue): boolean;
 
   /**
-   * Serializes the value. Only called after `canSerialize` returned `true`.
+   * Serializes the value. Only called after `canSerialize()` returned `true`.
    * The handler is responsible for tag wrapping via `codec.wrapTag()` and for
    * recursively serializing nested values via the provided `recurse` callback.
    */
@@ -128,7 +128,7 @@ export class TypeHandlerRegistry {
 }
 
 // ---------------------------------------------------------------------------
-// Utility: ProblematicValue factory
+// Utility: `ProblematicValue` factory
 // ---------------------------------------------------------------------------
 
 /**
@@ -230,8 +230,8 @@ export const BigIntHandler: TypeHandler = {
 /**
  * Handler for `FabricEpochNsec`. Serializes to a flat base64 string encoding
  * the underlying bigint's two's-complement big-endian byte representation.
- * Wire format: `{ "/EpochNsec@1": "<base64>" }`. FabricEpochNsec is a direct
- * member of FabricValue (not a FabricInstance), so this handler uses
+ * Wire format: `{ "/EpochNsec@1": "<base64>" }`. `FabricEpochNsec` is a direct
+ * member of `FabricValue` (not a `FabricInstance`), so this handler uses
  * `instanceof` directly.
  * See Section 5.3 of the formal spec.
  */
@@ -282,8 +282,8 @@ export const EpochNsecHandler: TypeHandler = {
 /**
  * Handler for `FabricEpochDays`. Serializes to a flat base64 string encoding
  * the underlying bigint's two's-complement big-endian byte representation.
- * Wire format: `{ "/EpochDays@1": "<base64>" }`. FabricEpochDays is a direct
- * member of FabricValue (not a FabricInstance), so this handler uses
+ * Wire format: `{ "/EpochDays@1": "<base64>" }`. `FabricEpochDays` is a direct
+ * member of `FabricValue` (not a `FabricInstance`), so this handler uses
  * `instanceof` directly. Same flat encoding approach as `EpochNsecHandler`.
  * See Section 5.3 of the formal spec.
  */
@@ -430,7 +430,7 @@ export const SymbolHandler: TypeHandler = {
     codec: TypeHandlerCodec,
     _recurse: (v: FabricValue) => JsonWireValue,
   ): JsonWireValue {
-    // `canSerialize` already verified the symbol has a registry key.
+    // `canSerialize()` already verified the symbol has a registry key.
     const key = Symbol.keyFor(value as symbol)!;
     return codec.wrapTag(TAGS.Symbol, key);
   },
@@ -509,7 +509,7 @@ export const BytesHandler: TypeHandler = {
  * registry for those tags.
  */
 export const FabricInstanceHandler: TypeHandler = {
-  // This tag is not used for deserialization dispatch -- FabricInstance
+  // This tag is not used for deserialization dispatch -- `FabricInstance`
   // types are looked up by their individual tags. The handler is registered
   // for serialization matching only.
   tag: "",
@@ -525,14 +525,14 @@ export const FabricInstanceHandler: TypeHandler = {
   ): JsonWireValue {
     const inst = value as FabricInstance;
 
-    // ExplicitTagValue (UnknownValue, ProblematicValue): use
-    // preserved typeTag and re-serialize their stored state.
+    // `ExplicitTagValue` (`UnknownValue`, `ProblematicValue`): use
+    // preserved `typeTag` and re-serialize their stored state.
     if (inst instanceof ExplicitTagValue) {
       const serializedState = recurse(inst.state);
       return codec.wrapTag(inst.typeTag, serializedState);
     }
 
-    // General FabricInstance: use DECONSTRUCT and codec for tag.
+    // General `FabricInstance`: use `[DECONSTRUCT]` and codec for tag.
     const state = inst[DECONSTRUCT]();
     const tag = codec.getTagFor(inst);
     const serializedState = recurse(state);
@@ -544,8 +544,8 @@ export const FabricInstanceHandler: TypeHandler = {
     _runtime: ReconstructionContext,
     _recurse: (v: JsonWireValue) => FabricValue,
   ): FabricValue {
-    // Not reached via tag dispatch -- FabricInstance deserialization is
-    // handled by the class registry fallback in deserialize().
+    // Not reached via tag dispatch -- `FabricInstance` deserialization is
+    // handled by the class registry fallback in `deserialize()`.
     throw new Error("FabricInstanceHandler.deserialize should not be called");
   },
 };
@@ -560,13 +560,13 @@ export const FabricInstanceHandler: TypeHandler = {
  */
 export function createDefaultRegistry(): TypeHandlerRegistry {
   const registry = new TypeHandlerRegistry();
-  // FabricPrimitive subclasses first -- they are direct FabricValue members
-  // matched by instanceof, and must be checked before the generic
-  // FabricInstanceHandler.
+  // `FabricPrimitive` subclasses first -- they are direct `FabricValue` members
+  // matched by `instanceof`, and must be checked before the generic
+  // `FabricInstanceHandler`.
   registry.register(EpochNsecHandler);
   registry.register(EpochDaysHandler);
   registry.register(BytesHandler);
-  // FabricInstance (generic -- checked via instanceof).
+  // `FabricInstance` (generic -- checked via `instanceof`).
   registry.register(FabricInstanceHandler);
   // Primitives that need tagged encoding (can't be expressed in JSON natively).
   registry.register(BigIntHandler);

--- a/packages/data-model/json-type-handlers.ts
+++ b/packages/data-model/json-type-handlers.ts
@@ -526,7 +526,7 @@ export const FabricInstanceHandler: TypeHandler = {
     const inst = value as FabricInstance;
 
     // `ExplicitTagValue` (`UnknownValue`, `ProblematicValue`): use
-    // preserved `typeTag` and re-serialize their stored state.
+    // preserved `.typeTag` and re-serialize their stored state.
     if (inst instanceof ExplicitTagValue) {
       const serializedState = recurse(inst.state);
       return codec.wrapTag(inst.typeTag, serializedState);

--- a/packages/data-model/native-type-tags.ts
+++ b/packages/data-model/native-type-tags.ts
@@ -47,16 +47,16 @@ export type NativeTag = typeof NATIVE_TAGS[keyof typeof NATIVE_TAGS];
  *
  * Uses a `switch` on the constructor identity for O(1) dispatch (instead of
  * sequential `instanceof` checks). Falls back to `instanceof Error` on the
- * constructor's prototype to catch exotic Error subclasses, and checks for
+ * constructor's prototype to catch exotic `Error` subclasses, and checks for
  * `toJSON()` on the prototype for unrecognized classes. (Note:
  * `Error.isError()` doesn't work on prototype objects -- it only recognizes
- * actual Error instances, not the prototype chain -- so we use `instanceof`.)
+ * actual `Error` instances, not the prototype chain -- so we use `instanceof`.)
  */
 export function tagFromNativeClass(
   constructorFn: { prototype: unknown },
 ): NativeTag | null {
   switch (constructorFn) {
-    // Error and standard subclasses all map to the Error tag.
+    // `Error` and standard subclasses all map to the `Error` tag.
     case Error:
     case TypeError:
     case RangeError:
@@ -90,9 +90,9 @@ export function tagFromNativeClass(
       return NATIVE_TAGS.FabricBytes;
 
     default:
-      // Catch exotic Error subclasses (e.g. custom subclasses with
+      // Catch exotic `Error` subclasses (e.g. custom subclasses with
       // non-standard constructors). Guard against non-function values
-      // (e.g. null-prototype objects where .constructor is undefined).
+      // (e.g. null-prototype objects where `constructor()` is undefined).
       if (
         typeof constructorFn === "function" &&
         constructorFn.prototype instanceof Error
@@ -117,13 +117,13 @@ export function tagFromNativeClass(
  * Non-object types (null, undefined, primitives) return `Primitive`.
  *
  * Dispatches via the value's constructor (O(1) switch in `tagFromNativeClass`).
- * Falls back to `Error.isError()` for exotic Error subclasses, `Array.isArray`
+ * Falls back to `Error.isError()` for exotic `Error` subclasses, `Array.isArray()`
  * for cross-realm arrays, and prototype check for null-prototype objects.
  *
  * For tags that have pass-through handling (`Object`, `Array`) or no dedicated
- * handler (`null`), a per-instance `hasToJSON` check upgrades the tag to
- * `HasToJSON`. Dedicated types (Error, Date, Map, etc.) and `HasToJSON` from
- * `tagFromNativeClass` are returned as-is.
+ * handler (`null`), a per-instance `hasToJSON()` check upgrades the tag to
+ * `HasToJSON`. Dedicated types (`Error`, `Date`, `Map`, etc.) and `HasToJSON` from
+ * `tagFromNativeClass()` are returned as-is.
  */
 export function tagFromNativeValue(value: unknown): NativeTag | null {
   if (value === null || typeof value !== "object") {
@@ -138,8 +138,8 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
     tag = tagFromNativeClass(ctor);
   }
 
-  // tagFromNativeClass handles dedicated types (Error, Date, Map, etc.) and
-  // returns HasToJSON for classes whose prototype has toJSON(). For those,
+  // `tagFromNativeClass()` handles dedicated types (`Error`, `Date`, `Map`, etc.) and
+  // returns `HasToJSON` for classes whose prototype has `toJSON()`. For those,
   // return immediately -- no instance-level override needed.
   if (
     tag !== null && tag !== NATIVE_TAGS.Object && tag !== NATIVE_TAGS.Array
@@ -149,26 +149,26 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
 
   // Fallbacks for values whose constructor wasn't recognized (tag === null).
   if (tag === null) {
-    // Exotic Error subclasses (e.g. DOMException).
+    // Exotic `Error` subclasses (e.g. `DOMException`).
     if (Error.isError(value)) return NATIVE_TAGS.Error;
 
-    // FabricInstance values (protocol types with [DECONSTRUCT]).
+    // `FabricInstance` values (protocol types with `[DECONSTRUCT]`).
     if (value instanceof FabricInstance) return NATIVE_TAGS.FabricInstance;
 
     // Cross-realm arrays may have a different constructor.
     if (Array.isArray(value)) tag = NATIVE_TAGS.Array;
 
-    // Null-prototype objects (Object.create(null)).
+    // Null-prototype objects (`Object.create(null)`).
     if (tag === null) {
       const proto = Object.getPrototypeOf(value);
       if (proto === null) tag = NATIVE_TAGS.Object;
     }
   }
 
-  // For Object, Array, and still-null tags: a per-instance toJSON() method
-  // overrides to HasToJSON. This catches plain objects with toJSON as an own
-  // property, arrays with toJSON added, and unrecognized class instances
-  // whose prototype wasn't caught by tagFromNativeClass.
+  // For `Object`, `Array`, and still-null tags: a per-instance `toJSON()` method
+  // overrides to `HasToJSON`. This catches plain objects with `toJSON()` as an own
+  // property, arrays with `toJSON()` added, and unrecognized class instances
+  // whose prototype wasn't caught by `tagFromNativeClass()`.
   if (hasToJSON(value)) return NATIVE_TAGS.HasToJSON;
 
   return tag;

--- a/packages/data-model/native-type-tags.ts
+++ b/packages/data-model/native-type-tags.ts
@@ -114,7 +114,7 @@ export function tagFromNativeClass(
 /**
  * Maps a JS value to its native-instance tag. Returns the tag string if the
  * value is a recognized convertible native instance, or `null` otherwise.
- * Non-object types (null, undefined, primitives) return `Primitive`.
+ * Non-object types (`null`, `undefined`, primitives) return `Primitive`.
  *
  * Dispatches via the value's constructor (O(1) switch in `tagFromNativeClass`).
  * Falls back to `Error.isError()` for exotic `Error` subclasses, `Array.isArray()`

--- a/packages/data-model/schema-hash.ts
+++ b/packages/data-model/schema-hash.ts
@@ -46,7 +46,7 @@ export function hashSchema(schema: JSONSchema): string {
  * only reachable while the schema object itself is alive.
  *
  * - `booleanInterns`: prefab `SchemaAndHash` for `true` and `false` (boolean
- *   schemas are primitives and can't be WeakMap/WeakRef targets).
+ *   schemas are primitives and can't be `WeakMap`/`WeakRef` targets).
  */
 const schemaToSah = new WeakMap<JSONSchemaObj, SchemaAndHash>();
 const hashToRef = new Map<string, WeakRef<JSONSchemaObj> | boolean>();

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -306,8 +306,8 @@ export function emptySchemaObject() {
  * Returns the given `SchemaPathSelector` with its `schema` (if any) interned
  * and with both its `path` array and the selector object itself deep-frozen
  * in place. The input reference is returned — this function does not clone.
- * Idempotent on repeat calls: `internPathSelector(internPathSelector(x)) ===
- * internPathSelector(x)`.
+ * Idempotent on repeat calls:
+ * `internPathSelector(internPathSelector(x)) === internPathSelector(x)`.
  *
  * Exists so that callers who feed selectors into `MapSetStringToPathSelectors`
  * (or any other cache keyed on `hashStringOf()` of a selector) can hand in an
@@ -330,7 +330,7 @@ export function internPathSelector(
  * ... }` input) without actually traversing into it.
  *
  * Frozen at module load, but its `schema: false` member is NOT routed
- * through `internSchema` here (because doing so during `schema-utils.ts`'s
+ * through `internSchema()` here (because doing so during `schema-utils.ts`'s
  * module-load would reach into a not-yet-initialized `schema-hash.ts`
  * due to the pre-existing circular import between the two modules). The
  * boolean-schema intern path uses prefab singletons anyway, so
@@ -348,7 +348,7 @@ export const REJECTING_SELECTOR: SchemaPathSelector = Object.freeze({
  * path needs to have `"value"` in it.
  *
  * Frozen at module load; like `REJECTING_SELECTOR`, the boolean
- * `schema: true` member is not routed through `internSchema` here
+ * `schema: true` member is not routed through `internSchema()` here
  * (same circular-import reason — see `REJECTING_SELECTOR` doc comment).
  */
 export const DEFAULT_SELECTOR: SchemaPathSelector = Object.freeze({
@@ -358,13 +358,13 @@ export const DEFAULT_SELECTOR: SchemaPathSelector = Object.freeze({
 
 /**
  * Returns a cache-key string for an ordered pair of schemas, each interned
- * (and thus deep-frozen) via `internSchema`. The `|` delimiter is outside
+ * (and thus deep-frozen) via `internSchema()`. The `|` delimiter is outside
  * the base64url alphabet used by hash strings, so the two halves cannot
  * merge ambiguously.
  *
  * Used at the `traverse.ts` sites that key an intern cache on a merge
  * operation's two input schemas. Interning the inputs stabilizes their
- * identities in `internSchema`'s WeakMap, so subsequent calls with the
+ * identities in `internSchema()`'s `WeakMap`, so subsequent calls with the
  * same object references hit the hash-cache fast path in O(1) rather
  * than re-hashing. See
  * `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` §1

--- a/packages/data-model/value-hash.ts
+++ b/packages/data-model/value-hash.ts
@@ -236,7 +236,7 @@ function feedValue(hasher: IncrementalHasher, value: unknown): void {
 }
 
 /**
- * Feed an object-typed value (special primitives, FabricInstance, Array,
+ * Feed an object-typed value (special primitives, `FabricInstance`, `Array`,
  * or plain object) into the hasher. Dispatches via `tagFromNativeValue()` /
  * `NATIVE_TAGS` for recognized types. The `null` case is handled by the
  * caller (`feedValue()`).
@@ -297,7 +297,7 @@ function feedObjectValue(
     }
 
     case NATIVE_TAGS.FabricInstance: {
-      // Generic FabricInstance (protocol path via DECONSTRUCT).
+      // Generic `FabricInstance` (protocol path via `[DECONSTRUCT]`).
       hasher.update(TAG_INSTANCE_BYTES);
       const typeTag = (value as { typeTag?: unknown }).typeTag;
       if (typeof typeTag !== "string") {
@@ -314,7 +314,7 @@ function feedObjectValue(
     case NATIVE_TAGS.Date:
     case NATIVE_TAGS.RegExp:
     case NATIVE_TAGS.Uint8Array: {
-      // Native instances that have a well-defined FabricValue conversion.
+      // Native instances that have a well-defined `FabricValue` conversion.
       // Convert on-the-fly and hash the converted value.
       const converted = shallowFabricFromNativeValueModern(value, false);
       feedValue(hasher, converted);
@@ -334,7 +334,7 @@ function feedObjectValue(
 }
 
 /**
- * Feed an array value with sparse hole handling, terminated by TAG_END.
+ * Feed an array value with sparse hole handling, terminated by `TAG_END`.
  */
 function feedArray(hasher: IncrementalHasher, value: unknown[]): void {
   hasher.update(TAG_ARRAY_BYTES);
@@ -359,7 +359,7 @@ function feedArray(hasher: IncrementalHasher, value: unknown[]): void {
 
 /**
  * Feed a plain object value, keys sorted by UTF-8 byte order, terminated
- * by TAG_END.
+ * by `TAG_END`.
  */
 function feedPlainObject(
   hasher: IncrementalHasher,


### PR DESCRIPTION
## Summary

Follow-on to PR #3514 (doc-comment alignment over the same package
surface, merged 2026-05-06 at `66bc1b93a`), now broadened to cover
regular (non-JSDoc) comments under the unified "Comments" section
of `coordination/rules/code-conventions.md` (landed by Olive during
session 2026-071's `coding.md` → `code-conventions.md` split).
Pure style-rule sweep: bare class/function names in comments →
backticked (with uniform treatment across type-name enumerations);
callable names → `name()` with trailing parens; non-method property
names → `.propertyName` with leading dot (symmetric with the
callable-parens convention).

## Scope

Same package surface as PR #3514: top-level `*.ts` in
`packages/data-model` plus `src/*.ts` in `packages/content-hash`.

15 files touched, +187/-185 (net +2 lines from wrap-overflow
fixes in two doc comments where backticking pushed a sentence
onto an extra line):

- `packages/content-hash/src/sha256-deno.ts`
- `packages/data-model/`: 14 files. Largest touch surface in
  `fabric-value-modern.ts` (~65/65).

## What's in this PR

Style rules from the unified "Comments" section applied
mechanically:

1. **Markdown-style backticks for code mentions** — bare class
   names (`FabricValue`, `Error`, `Date`, `Map`, `Set`, `RegExp`,
   `Uint8Array`, `WeakMap`, `WeakRef`), identifier-shaped tokens
   (`OMIT`, `TAG_END`, `DECONSTRUCT`, `RECONSTRUCT`), and
   `Object.X` / `JSON.X` method references (`Object.create()`,
   `Object.freeze()`, `Object.isFrozen()`, `Object.fromEntries()`,
   `JSON.stringify()`, `JSON.parse()`) all wrapped in backticks.
   Type-name enumerations like `(null, boolean, number, string)`
   get uniform backtick treatment across all siblings (rather than
   mixed bare/backticked shapes).
2. **Trailing `()` on callables** — function and method names
   referenced as callables in comments now include parens (e.g.,
   `internSchema()` not `internSchema`, `cloneIfNecessary()`,
   `tagFromNativeClass()`, `hasToJSON()`, `toJSON()`,
   `canSerialize()`, `add()`, `set()`, `delete()`, `clear()`,
   `call(...)`, `constructor()`). Canonical reference for a
   callable inside a backtick is `name()` with no leading dot.
3. **Leading `.` on non-method properties** — property names
   referenced inside backticks take a leading dot (`.name`,
   `.cause`, `.message`, `.stack`, `.type`, `.typeTag`,
   `.lastIndex`, `.__proto__`), symmetric with the callable-parens
   convention. `constructor()` stays as a callable (the property-
   slot context doesn't flip that classification).
4. **Royal "we"** — surveyed clean (zero violations).

The rule reach covers both `//`-line comments and JSDoc bodies (the
"Comments" parent section sits above the "Doc comments (JSDoc)"
subsection break; style rules apply to all comment forms).

## What's NOT in this PR

- **Doc-comment wording / opening-shape**: zero applicable sites
  surfaced (PR #3514 was thorough).
- **Doc-comment coverage gaps**: zero surfaced.
- **Regular-comment coverage**: zero gaps surfaced (the rule
  doesn't compel coverage on the regular side).
- **Noise-removal** (the "comments explain *why*, not *what*"
  carve-out): zero candidates surfaced. The codebase consistently
  writes context-bearing comments.
- **Test files / subdirectories**: out of scope per PR #3514
  precedent.
- **Out-of-diff sites for the leading-`.` rule**: a handful of
  sites elsewhere in the codebase (e.g., `unknown-value.ts:13`
  `typeTag`, `frozen-builtins.ts:4` `instanceof`) are banked for
  a future pass per the in-diff-only conformance posture.
- **English-shaped type-name false positives**: phrases like "hex
  string", "JSON string", "plain string", "even number of digits"
  are linguistic uses (adjective + noun), not type-name
  references, and are left bare. Item-5's uniform-backticking only
  fires where the bare token is a type-name enumeration member.
- **Residual NITs from completeness review**: 6 additional NITs
  surfaced by reviewer-side completeness sweep (`FabricError.[DECONSTRUCT]()`
  parens, `canSerialize`, `WeakMap`×2, `BigInt`, etc.) are banked
  for a future Olive-target style-rule conformance pass against
  the firmer rule (`code-conventions.md` Dan-direct refinements
  `5399eab` + `bf8932a` landed mid-flight). Three of the original
  NIT list were Item-5-shape and are folded in here (see
  "Survey vs actual scope" Item-5 bullet); one cumulative-pass
  PR-#3514-surface site (`schema-hash.ts:49`) also folded in.

## Survey vs actual scope

Cedar's initial survey: 47 `//`-comment sites across 9 files.

Mid-flight refinements (all absorbed cleanly, in five items in the
same style-rule family):

- **Item 1** — Survey-side discriminator artifact: parent-section
  style rules also apply to JSDoc bodies. +16 JSDoc-body sites.
- **Item 2** — `.method` → `method()` discipline (Dan-direct
  mid-flight): +5 sites for leading-dot-strip + paren-add.
- **Item 3** — Backticked-without-parens callables
  (`isFabricCompatible` → `isFabricCompatible()`, etc.): +27 sites.
- **Item 4** — Leading-dot for non-method properties (Dan-direct
  mid-flight via team-lead/Rail): canonical reference for a
  non-method property inside a backtick is `.propertyName` with
  leading dot, symmetric with `methodName()` parens for callables.
  Item-2's sweep over-stripped in places where the leading dot
  belonged on a property reference rather than a method; Item-4
  restored those and added dots to never-dotted property
  references. ~12-15 sites across 4 files.
- **Item 5** — Uniform backticks on type-name enumerations
  (Dan-direct mid-flight): in enumerations like `(null, boolean,
  number, string)`, backtick all siblings uniformly rather than
  only the ones that happen to look "more code-shaped." Initial
  sweep covered ~5 sites across 3 files. **Item-5 sweep completed
  at fix-tip** with 3 additional enumeration-shape sites surfaced
  by reviewer-side completeness-pass (`fabric-value-modern.ts:326`
  flow-style enumeration, `native-type-tags.ts:117` parenthetical
  enumeration, `fabric-value.ts:56-57` mixed primitive+class
  enumeration) — Item-5-shape, not a new Item; first sweeps will
  miss structurally-equivalent sites with different surface form.
  Plus 1 cumulative-pass site from PR #3514's surface
  (`schema-hash.ts:49` `WeakMap`/`WeakRef` JSDoc parenthetical
  backticking).

Final: ~140 sites across 15 files.

## Conservation of content

All edits preserve substantive comment content. Two near-content-
loss wrap-overflows (net +2 lines total, content-preserving):

- `fabric-native-instances.ts`'s `copyError()` doc comment — the
  backticked version of `Error` + `constructor()` + `.name` +
  `.message` etc. caused the sentence to overflow its original
  two-line wrap; fixed by reflowing to three lines.
- `fabric-value-modern.ts` — backticking the full type-name
  enumeration pushed a sentence onto an additional line; fixed
  by reflowing.

A similar reflow in `schema-utils.ts:309-310` (an
`internPathSelector(internPathSelector(x))` expression had been
line-wrapped *outside* its backticks, rendering the second mention
as bare text) was fixed by reformatting the wrap so the whole
expression sits in one backtick block — net +0 lines. Item-4 also
fixed a missing-backticks site on a property enumeration in
`fabric-native-instances.ts`'s `FabricError.[DECONSTRUCT]()` JSDoc
(`.type`, `.name`, ...) — additive in coverage rather than
substitutive. Item-5-completion's `schema-hash.ts:49` site is
similarly additive (bare-class-name → backticked) rather than
substitutive.

## Pre-push gates

- `deno fmt --check`: clean (both packages, re-run on each fix-tip
  through `2c79b03b5`).
- `deno lint`: clean (both packages).
- `deno task test`: data-model 45/45 passed (17425 steps);
  content-hash 2/2 passed (705 steps). Test re-run not required
  for the per-Item fix-tips per the comment-only posture (no
  behavior change possible); gates 1+2 re-run as belt-and-
  suspenders.

## Test plan

- [x] `deno fmt --check` on `packages/data-model`.
- [x] `deno fmt --check` on `packages/content-hash`.
- [x] `deno lint` on `packages/data-model`.
- [x] `deno lint` on `packages/content-hash`.
- [x] `deno task test` on `packages/data-model`.
- [x] `deno task test` on `packages/content-hash`.
- [ ] CI green on this PR.
