### PR TITLE
Fix sub-pattern calls captured as reactive data in maps

### DIFF
--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -30,6 +30,10 @@ import type { AnalyzeFn } from "./expression-rewrite/types.ts";
 import type { ExpressionContainerKind } from "./expression-site-types.ts";
 import { createDeriveCall } from "./builtins/derive.ts";
 import { classifyOpaquePathTerminalCall } from "./opaque-roots.ts";
+import {
+  isPatternFactoryCalleeExpression,
+  isPatternFactoryHelperExpression,
+} from "./structural-reactive-factory.ts";
 
 interface RewriteExpressionSiteParams {
   readonly expression: ts.Expression;
@@ -59,6 +63,18 @@ function getReactiveHelperWrapperKind(
   }
 
   return undefined;
+}
+
+function isPatternFactoryCallExpression(
+  expression: ts.Expression,
+  context: TransformationContext,
+): boolean {
+  const call = unwrapExpression(expression);
+  return ts.isCallExpression(call) &&
+    (
+      isPatternFactoryCalleeExpression(call.expression, context.checker) ||
+      isPatternFactoryHelperExpression(call.expression, context.checker)
+    );
 }
 
 function isDirectDeriveCall(
@@ -776,6 +792,10 @@ export function rewriteArrayMethodCallbackExpressionSites(
       allowDirectExpressionWrap?: boolean;
     } = {},
   ): ts.Expression | undefined => {
+    if (isPatternFactoryCallExpression(expression, context)) {
+      return undefined;
+    }
+
     const analysis = analyze(expression);
     if (
       (analysis.containsOpaqueRef && analysis.requiresRewrite) ||

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -29,6 +29,7 @@ import { classifyOpaquePathTerminalCall } from "./opaque-roots.ts";
 import type { ExpressionContainerKind } from "./expression-site-types.ts";
 import {
   isPatternFactoryCalleeExpression,
+  isPatternFactoryHelperExpression,
   isStructuralReactiveFactoryExpression,
   returnsOpaqueRefResult,
 } from "./structural-reactive-factory.ts";
@@ -243,7 +244,8 @@ function classifyCallExpressionRoot(
   }
 
   if (
-    isPatternFactoryCalleeExpression(expression.expression, context.checker)
+    isPatternFactoryCalleeExpression(expression.expression, context.checker) ||
+    isPatternFactoryHelperExpression(expression.expression, context.checker)
   ) {
     return "other";
   }

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -598,7 +598,8 @@ function shouldAddReactiveFor(
   }
 
   if (
-    isPatternFactoryCalleeExpression(expression.expression, context.checker)
+    isPatternFactoryCalleeExpression(expression.expression, context.checker) ||
+    isPatternFactoryHelperExpression(expression.expression, context.checker)
   ) {
     return false;
   }

--- a/packages/ts-transformers/test/pipeline-regressions.test.ts
+++ b/packages/ts-transformers/test/pipeline-regressions.test.ts
@@ -480,6 +480,41 @@ export default pattern(() => {
 );
 
 Deno.test(
+  "Pipeline regression: module-scope sub-pattern calls in maps stay structural",
+  async () => {
+    const source = `import { pattern, UI, type VNode } from "commonfabric";
+
+type Entry = { value: number };
+
+const EntryRow = pattern<Entry, { [UI]: VNode }>(({ value }) => ({
+  [UI]: <span>{value}</span>,
+}));
+
+export default pattern<{ entries: Entry[] }, { [UI]: VNode }>(({ entries }) => ({
+  [UI]: (
+    <div>
+      {entries.map((entry) => {
+        const row = EntryRow({ value: entry.value });
+        return row[UI];
+      })}
+    </div>
+  ),
+}));
+`;
+
+    const output = await transformSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+
+    assertStringIncludes(output, "const row = EntryRow({");
+    assert(
+      !output.includes("EntryRow: EntryRow"),
+      "expected module-scope pattern factory to stay in lexical scope instead of being captured as derive data",
+    );
+  },
+);
+
+Deno.test(
   "Pipeline regression: opaque-returning factory helpers with local cells stay structural",
   async () => {
     const source = `import { pattern, Writable } from "commonfabric";


### PR DESCRIPTION
## Summary
- Preserve module-scope pattern factory calls during array-method expression-site lowering.
- Treat declaration-resolved pattern factories the same as directly typed `PatternFactory` callees in call-root classification and reactive `.for()` insertion.
- Add a regression covering the original failing shape: `const row = EntryRow(...); return row[UI];` inside a mapped UI callback.

## How we found it
Deploying basic patterns such as `notes/note.tsx` failed while the system `backlinks-index` pattern was running, with `TypeError: EntryRow is not a function` at `packages/patterns/system/backlinks-index.tsx:205`.

Running `deno task cf check packages/patterns/system/backlinks-index.tsx --root packages/patterns --show-transformed` showed that the authored map callback:

```tsx
const row = EntryRow({ ... });
return row[UI];
```

was lowered into a derive that captured `EntryRow` as reactive input data:

```ts
({ EntryRow, entry }) => EntryRow({ ... })
```

At runtime that captured value is pattern metadata, not the callable pattern factory, which explains the non-callable `EntryRow` error.

## Fix
The transformer now recognizes declaration-resolved pattern factory helpers, not just callees whose type checker surface still directly looks like a `PatternFactory`. That prevents module-scope sub-pattern calls from being wrapped as reactive computations or converted into `.for()` data.

## Verification
- `deno test --allow-read --allow-env packages/ts-transformers/test/pipeline-regressions.test.ts`
- `deno task cf check packages/patterns/system/backlinks-index.tsx --root packages/patterns --no-run`
- `deno task cf check packages/patterns/notes/note.tsx --root packages/patterns --no-run`
- `deno task cf check packages/patterns/counter/counter.tsx --root packages/patterns --no-run`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pattern factory calls being captured as reactive data in map callbacks, which caused “EntryRow is not a function” at runtime. Module-scope sub-pattern calls now stay structural and are not wrapped by derive or `.for()`.

- **Bug Fixes**
  - Preserve module-scope pattern factory calls during array-method expression-site lowering.
  - Treat declaration-resolved pattern factory helpers the same as direct `PatternFactory` callees in call-root classification and reactive `.for()` checks.
  - Add a regression test for `const row = EntryRow(...); return row[UI];` inside a mapped UI callback.

<sup>Written for commit 5686c176489f1734aa2783e4e7a9aa5bbba23b78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

