### PR TITLE
fix(runner): await event handler commit before settle (proposal)

### DIFF
--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -4443,7 +4443,7 @@ export class Scheduler {
             }
           };
 
-          const finalize = (error?: unknown) => {
+          const finalize = async (error?: unknown) => {
             if (error) {
               try {
                 this.handleError(error as Error, action);
@@ -4456,7 +4456,13 @@ export class Scheduler {
             }
 
             this.runtime.prepareTxForCommit(tx);
-            tx.commit().then((result) => {
+            // In pull mode, settle correctness depends on the storage
+            // subscription firing (and propagating dirty + dependents) before
+            // the post-event settle phase observes the work set. Awaiting the
+            // commit here ensures that propagation has completed before
+            // `execute()` proceeds. See PR description for context.
+            try {
+              const result = await tx.commit();
               if (result.error && retriesLeft > 0) {
                 logger.warn(
                   "scheduler",
@@ -4482,13 +4488,13 @@ export class Scheduler {
                   { error: result.error, handlerId },
                 );
               }
-            }).catch((error) => {
+            } catch (commitError) {
               logger.error(
                 "schedule-error",
                 "Event handler commit promise rejected:",
-                error,
+                commitError,
               );
-            });
+            }
           };
 
           try {
@@ -4505,7 +4511,7 @@ export class Scheduler {
             try {
               this.runningPromise = Promise.resolve(
                 this.runtime.harness.invoke(() => action(tx)),
-              ).then(() => {
+              ).then(async () => {
                 const trustedEventCandidates =
                   trustedEventWriteCandidatesFromTransaction(tx, handler, [
                     queuedEvent.eventLink.space,
@@ -4524,7 +4530,7 @@ export class Scheduler {
                     `Action ${actionId} completed in ${duration.toFixed(3)}s`,
                   ];
                 });
-                finalize();
+                await finalize();
               }).catch((error) => finalize(error));
               await this.runningPromise;
             } finally {


### PR DESCRIPTION
## TL;DR

**This is a proposal, not a confident fix.** Opening so the
runner/scheduler folks (especially around PR #3529) have a starting
point to evaluate. The diff is one file, ~13/7 lines, and the
reasoning below may be wrong in subtle ways that someone closer to
the scheduler will spot quickly.

## The failing test

`default-app flow test > should render every rapidly created notebook note`
at `packages/patterns/integration/default-app.test.ts:655`.

It enables pull mode, then rapid-clicks 6× "Create Another" + 1× "Create"
to create 7 notebook notes, then asserts:

```ts
assertEquals(summary.noteCount, noteCreates);          // line 654 — passes
assertEquals(summary.renderedNoteChips, noteCreates);  // line 655 — fails
```

The assertion fires at line 655 with `Actual: 6 / Expected: 7`. So 7
notes exist in the cell, but only 6 chips render in the DOM. (Counts
are gathered via the `Page` evaluator in `collectNotebookRenderState`
around line 2637.)

## Evidence this isn't a transient race

The test uses `waitFor(...)` before asserting — the system is given
time to settle. The failure mode is **permanent**: 6 chips stay 6
chips, and the diagnostic dump (`collectNotebookDiagnostics`) shows:

- `pendingEffects: []` — no effects in flight.
- `actionTraceTail: []` — scheduler is quiescent.
- `dirtyComputations: [...]` — multiple per-note computations from
  `note.tsx:334:42` (`parentNotebookLabel`) and `:335:44` are
  **dirty but `isPending: false`**.

In pull mode, "dirty but not pending" means "dirty but not demanded by
any live effect" — orphaned from the demand graph. So the 7th note's
internal computations exist but are never going to run, because the
renderer never demanded their chip slot.

## Failure rate

Three known hits, all on the same test:

1. `f30eb680e` on `main` (the PR #3529 merge commit itself, May 8) —
   the PR that introduced this rapid-create repro.
2. PR #3545 run `25682274933` (May 11 16:13 UTC).
3. PR #3545 run `25684590326` (May 11 16:57 UTC).

In between #1 and #2/#3, four `main` builds passed (`#3536`/`#3538`/
`#3540`/`#3542`/`#3543`). PR #3545 is **comment-only**, so any
difference between its CI and `main`'s CI is by definition not caused
by the PR's changes — it's pre-existing flakiness.

## Hypothesis

The smoking gun is in `scheduler.ts` event-handler processing, around
the old line 4459. The `finalize()` closure calls `tx.commit()` and
returns immediately:

```ts
const finalize = (error?: unknown) => {
  if (error) { /* ... */ return; }
  this.runtime.prepareTxForCommit(tx);
  tx.commit().then((result) => { /* retry / log */ });  // fire-and-forget
};
```

And the call site:

```ts
this.runningPromise = Promise.resolve(
  this.runtime.harness.invoke(() => action(tx)),
).then(() => {
  // ...
  finalize();
}).catch((error) => finalize(error));
await this.runningPromise;
```

So `await this.runningPromise` resolves the moment `finalize()` is
**called**, not when `tx.commit()` **completes**. `execute()` then
proceeds to the settle phase with the storage subscription's
`markDirty(reader) + scheduleAffectedEffects(reader)` propagation
still in flight.

In pull mode this matters because settle's seed-building reads the
`pending`/`dirty` sets and the `dependents` reverse-dep graph. If the
commit notification fires **after** settle has built its work set —
or worse, after settle has declared the system idle for this event —
the new note's chip slot is never wired into demand.

PR #3529 added the `rerunAfterCurrentExecute` safety net for the case
where `queueExecution()` fires during an in-flight `execute()`. But
that safety net relies on the storage notification arriving **during**
the current `execute()`. If it arrives during the awkward window
between settle declaring idle and the next event being dequeued, or
after the last event's `execute()` returns entirely, it's possible
for one path of demand reconstruction to be missed.

The "6 out of 7" consistency fits: the last event has no follow-up
`execute()` to clean up after it, so its commit-propagation race is
the most exposed.

## The proposed change

Make `finalize()` `async` and `await tx.commit()` inside it, then
`await finalize()` from the `runningPromise` chain. After this, by
the time `await this.runningPromise` returns, the storage
subscription has fired synchronously inside commit and updated dirty
+ dependents — so the settle phase that follows in the **same**
`execute()` cycle sees the full demand graph.

The retry path (`retriesLeft > 0`) is preserved by structure: the
re-enqueue + `queueExecution()` happens before `await finalize()`
returns, so the next event-processing iteration of `execute()` picks
it up normally.

## Caveats & open questions for reviewers

This is where I'd most appreciate scrutiny from someone with deep
context:

1. **Is the fire-and-forget commit deliberate for pipelining?**
   If event-handler commits were intentionally allowed to overlap
   with settle for throughput, awaiting them serializes that
   pipeline. I haven't been able to measure the throughput impact.
2. **Does this race exist in push mode too, or only pull?**
   I think push mode doesn't depend on demand reconstruction the same
   way, so awaiting is harmless there. But worth confirming.
3. **Is there a simpler/cheaper fix at the storage-subscription
   layer** — e.g., having the subscription synchronously update
   `dependents` and the work-set before settle decides idle —
   that would avoid changing the commit-await pattern at all?
4. **Are there tests that rely on the fire-and-forget shape?**
   I didn't find any obvious ones (runner tests still pass), but
   integration-level expectations around event ordering might be
   affected.
5. **Could the real root cause be elsewhere entirely** — e.g., in
   `map.ts`'s `elementRuns` tracking, or in how `cf-cell-context`
   subscribes to its child cells under pull-mode demand? The
   orphaned-dirty computations I saw were internal to the `Note`
   pattern, which is consistent with "the chip slot never got
   created" rather than "the chip got created but rendered with the
   wrong label."

## Pre-push gates I ran

- `deno fmt --check` on `packages/runner/src/scheduler.ts`: clean.
- `deno lint` on `packages/runner`: clean (365 files).
- `deno task test` on `packages/runner`: **414 passed (2373 steps),
  0 failed, 0 ignored** in 1m3s.

I did **not** run the integration test that exhibits the failure
locally (it requires the full shell/toolshed stack), nor the full
repo test suite — leaning on CI for both.

## Test plan

- [ ] CI green on this PR.
- [ ] Specifically: `Pattern Integration Tests (2/4)` job, which
  is where `default-app.test.ts` runs. Multiple consecutive green
  runs would be more reassuring than one, given the test's
  historical flake rate.
- [ ] Reviewer check: does awaiting the commit introduce noticeable
  throughput regression in any benchmark?
- [ ] Consider: should the runner-side unit test suite gain a small
  repro for "N rapid `tx.commit()` calls → renderer sees all N
  items" so the next iteration of this bug surfaces at unit-test
  level instead of in an integration job?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Await event handler `tx.commit()` in the scheduler so storage propagation completes before settle, preventing missed renders after rapid events in pull mode. Fixes the intermittent case where the last rapidly created notebook note didn’t render.

- **Bug Fixes**
  - Made `finalize()` async and `await tx.commit()`; also `await finalize()` in the `runningPromise` chain (`packages/runner/src/scheduler.ts`).
  - Ensures settle sees updated dirty/dependents before building its work set in pull mode.
  - Preserves retry behavior and error logging; no API changes.

<sup>Written for commit d5ba387771cdee1857d7eb4caf4f2bd3ba99b635. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

