### PR TITLE
Add cf-harness invocation context provenance tests

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -369,6 +369,43 @@ That opt-in case verifies that cf-harness can navigate `/fabric` through
 `runsc-cfc` and read the FUSE `.status` file. Without
 `CF_HARNESS_INTEGRATION_FABRIC_MOUNT`, the Fabric mount case is skipped.
 
+To exercise label flow through a live Fabric FUSE projection, enable the
+additional CFC flow tests and provide concrete read/write projection paths under
+`/fabric`:
+
+```bash
+# In another terminal, mount FUSE with Docker traversal enabled.
+cf fuse mount /tmp/cf --allow-other --cfc-mode=observe --cfc-writeback-xattrs
+
+cd packages/cf-harness
+CF_HARNESS_RUNSC_CFC_RESULT_DIR="$HOME/.local/share/runsc-cfc/cfc-results" \
+CF_HARNESS_RUNSC_CFC_INVOCATION_CONTEXT_DIR="$HOME/.local/share/runsc-cfc/cfc-invocations" \
+CF_HARNESS_INTEGRATION_FABRIC_MOUNT=/tmp/cf \
+CF_HARNESS_INTEGRATION_FABRIC_CFC_FLOW=1 \
+CF_HARNESS_INTEGRATION_FABRIC_CFC_READ_PATH=/fabric/home/pieces/example/result/secret \
+CF_HARNESS_INTEGRATION_FABRIC_CFC_WRITE_PATH=/fabric/home/pieces/example/result/output \
+CF_HARNESS_INTEGRATION_FABRIC_CFC_LABEL_SUBJECT=did:key:fabric \
+deno task test:integration
+```
+
+When those env vars point at a real labeled FUSE fixture, the extra tests probe
+FUSE-to-sandbox taint, command completion after a FUSE read, FUSE write
+attempts, and joins between explicit `cfcInputLabels` and a prior FUSE read. The
+result sidecar env var is required for all CFC flow assertions, and the
+invocation context sidecar env var is required for the cases that seed
+`cfcInputLabels`. The installed Docker `runsc-cfc` runtime must also be
+configured with the same `--cfc-invocation-context-dir`, otherwise those
+invocation-label cases are skipped even if cf-harness writes sidecars.
+
+The default Fabric CFC flow gate exercises the immediate result sidecar after a
+FUSE read. The stricter host-bind readback probe is opt-in with
+`CF_HARNESS_INTEGRATION_FABRIC_CFC_DURABLE_HOST_LABEL=1` because durable
+`FUSE -> sandbox -> host -> sandbox` label persistence is still a live-stack
+validation target. FUSE write assertions are also probes of the live stack:
+durable cell-label writeback depends on the runner/runtime emitting FUSE
+prepare/finalize metadata, not arbitrary direct writes to
+`trusted.cfc.contentLabel`.
+
 On Linux, Docker/runsc runs default to the host UID/GID. On macOS, the default
 omits `--user` because Docker Desktop bind mounts may expose host files as
 `root:root`, which prevents non-root container users from writing mounted Loom
@@ -386,8 +423,10 @@ directory. Configure runsc with
 `CF_HARNESS_RUNSC_CFC_INVOCATION_CONTEXT_DIR=/path/to/invocations` or pass
 `cfcInvocationContextDir` in the explicit sandbox config. `cf-harness` writes
 `<containerID>.json` after `docker create` and before `docker start`; the
-current payload is an audit/provenance context, not yet an argv/stdin/cwd/env
-label enforcement contract.
+payload contains audit/provenance context plus optional trusted `cfcInputLabels`
+for supported startup inputs (`command`, `argv`, `args`, `env`, `cwd`, and
+`stdin`). `stdin` labels are modeled as labels on the stdin source and taint
+only after the sandbox reads or maps fd 0, not as automatic startup task taint.
 
 On Docker Desktop for macOS, use the host path for `cf-harness` and the
 `/host_mnt/...` projection for Docker's runtime args. The gVisor

--- a/packages/cf-harness/integration/engine.integration.test.ts
+++ b/packages/cf-harness/integration/engine.integration.test.ts
@@ -1,9 +1,14 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { fromFileUrl } from "@std/path";
-import type { CfcEnforcementMode, IFCLabel } from "@commonfabric/runner/cfc";
+import type {
+  CfcEnforcementMode,
+  CfcLabelView,
+  IFCLabel,
+} from "@commonfabric/runner/cfc";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
 import {
+  CFC_INVOCATION_CONTEXT_DIR_ENV,
   CFC_RESULT_DIR_ENV,
   DEFAULT_DOCKER_RUNSC_IMAGE,
   resolveDockerRunscSandboxConfig,
@@ -23,7 +28,10 @@ const CFC_TAINT_IMAGE = Deno.env.get("CF_HARNESS_INTEGRATION_TAINT_IMAGE") ??
   "alpine:3.20";
 const CFC_RESULT_DIR_CONFIGURED =
   (Deno.env.get(CFC_RESULT_DIR_ENV) ?? "").length > 0;
+const CFC_INVOCATION_CONTEXT_DIR_CONFIGURED =
+  (Deno.env.get(CFC_INVOCATION_CONTEXT_DIR_ENV) ?? "").length > 0;
 const TAINTED_SECRET = '{"secret":"tainted from policy"}\n';
+const INVOCATION_TAINT_SUBJECT = "did:key:argv-reader";
 const FABRIC_MOUNT = Deno.env.get("CF_HARNESS_INTEGRATION_FABRIC_MOUNT");
 const FABRIC_INTEGRATION = INTEGRATION &&
   FABRIC_MOUNT !== undefined &&
@@ -116,6 +124,24 @@ const assertConfidentialityTaint = (label: IFCLabel) => {
     `expected a non-empty confidentiality label, got ${JSON.stringify(label)}`,
   );
 };
+
+const assertLabelIncludesSubject = (label: IFCLabel, subject: string) => {
+  assertConfidentialityTaint(label);
+  assertStringIncludes(JSON.stringify(label.confidentiality), subject);
+};
+
+const invocationInputLabels = (): CfcLabelView => ({
+  version: 1,
+  entries: [{
+    path: ["argv"],
+    label: {
+      confidentiality: [{
+        type: "test.cfc/User",
+        subject: INVOCATION_TAINT_SUBJECT,
+      }],
+    },
+  }],
+});
 
 const writePolicyLabeledSecret = async (secretsHostPath: string) => {
   await Deno.mkdir(secretsHostPath, { recursive: true });
@@ -279,6 +305,119 @@ Deno.test({
           );
         },
         {
+          configureSandbox: () => ({
+            image: CFC_TAINT_IMAGE,
+            extraDockerArgs: [
+              "--mount",
+              `type=bind,src=${secretsHostPath},dst=/secrets,readonly`,
+            ],
+          }),
+        },
+      );
+    } finally {
+      await Deno.remove(secretsHostPath, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "cf-harness integration: invocation input labels taint host bind output",
+  ignore: !INTEGRATION || !CFC_RESULT_DIR_CONFIGURED ||
+    !CFC_INVOCATION_CONTEXT_DIR_CONFIGURED,
+  permissions: { env: true, read: true, run: true, write: true },
+  async fn() {
+    await withHarness(
+      "integration-input-label-host-bind",
+      async (engine, hostPath) => {
+        const writeResult = await engine.invokeBuiltinTool("bash", {
+          command:
+            "printf 'from invocation label\n' > /workspace/input-labeled.txt; printf 'wrote input-labeled file\n'",
+          cfcInputLabels: invocationInputLabels(),
+        });
+
+        assertEquals(
+          await Deno.readTextFile(`${hostPath}/input-labeled.txt`),
+          "from invocation label\n",
+        );
+        assert(writeResult.output.cfcResult !== undefined);
+        assertEquals(writeResult.output.cfcResult.stdout.policy, "opaque");
+        assertLabelIncludesSubject(
+          writeResult.output.cfcResult.stdout.label,
+          INVOCATION_TAINT_SUBJECT,
+        );
+
+        const readBack = await engine.invokeBuiltinTool("bash", {
+          command: "cat /workspace/input-labeled.txt",
+        });
+        assert(readBack.output.cfcResult !== undefined);
+        assertEquals(readBack.output.cfcResult.stdout.policy, "opaque");
+        assertLabelIncludesSubject(
+          readBack.output.cfcResult.stdout.label,
+          INVOCATION_TAINT_SUBJECT,
+        );
+      },
+      { cfcEnforcementMode: "enforce-strict" },
+    );
+  },
+});
+
+Deno.test({
+  name:
+    "cf-harness integration: invocation labels join policy reads before writes",
+  ignore: !INTEGRATION || !CFC_RESULT_DIR_CONFIGURED ||
+    !CFC_INVOCATION_CONTEXT_DIR_CONFIGURED,
+  permissions: { env: true, read: true, run: true, write: true },
+  async fn() {
+    await assertCfcPolicyLabelsAvailable();
+    const secretsHostPath = await makeIntegrationTempDir(
+      "cf-harness-secrets-",
+    );
+    try {
+      await writePolicyLabeledSecret(secretsHostPath);
+      await withHarness(
+        "integration-input-label-join-host-read",
+        async (engine, hostPath) => {
+          const joinedWrite = await engine.invokeBuiltinTool("bash", {
+            command: [
+              "cat /secrets/space.json >/dev/null",
+              "printf 'joined taint\n' > /workspace/joined.txt",
+              "printf 'joined result\n'",
+            ].join("; "),
+            cfcInputLabels: invocationInputLabels(),
+          });
+
+          assertEquals(
+            await Deno.readTextFile(`${hostPath}/joined.txt`),
+            "joined taint\n",
+          );
+          assert(joinedWrite.output.cfcResult !== undefined);
+          assertEquals(joinedWrite.output.cfcResult.stdout.policy, "opaque");
+          assertLabelIncludesSubject(
+            joinedWrite.output.cfcResult.stdout.label,
+            INVOCATION_TAINT_SUBJECT,
+          );
+          assertLabelIncludesSubject(
+            joinedWrite.output.cfcResult.stdout.label,
+            "did:key:alice",
+          );
+
+          const readBack = await engine.invokeBuiltinTool("bash", {
+            command: "cat /workspace/joined.txt",
+          });
+          assert(readBack.output.cfcResult !== undefined);
+          assertEquals(readBack.output.cfcResult.stdout.policy, "opaque");
+          assertLabelIncludesSubject(
+            readBack.output.cfcResult.stdout.label,
+            INVOCATION_TAINT_SUBJECT,
+          );
+          assertLabelIncludesSubject(
+            readBack.output.cfcResult.stdout.label,
+            "did:key:alice",
+          );
+        },
+        {
+          cfcEnforcementMode: "enforce-strict",
           configureSandbox: () => ({
             image: CFC_TAINT_IMAGE,
             extraDockerArgs: [

--- a/packages/cf-harness/integration/engine.integration.test.ts
+++ b/packages/cf-harness/integration/engine.integration.test.ts
@@ -36,6 +36,19 @@ const FABRIC_MOUNT = Deno.env.get("CF_HARNESS_INTEGRATION_FABRIC_MOUNT");
 const FABRIC_INTEGRATION = INTEGRATION &&
   FABRIC_MOUNT !== undefined &&
   FABRIC_MOUNT.trim() !== "";
+const FABRIC_CFC_FLOW_INTEGRATION = FABRIC_INTEGRATION &&
+  Deno.env.get("CF_HARNESS_INTEGRATION_FABRIC_CFC_FLOW") === "1";
+const FABRIC_CFC_DURABLE_HOST_LABEL_INTEGRATION = FABRIC_CFC_FLOW_INTEGRATION &&
+  Deno.env.get("CF_HARNESS_INTEGRATION_FABRIC_CFC_DURABLE_HOST_LABEL") === "1";
+const FABRIC_CFC_READ_PATH = Deno.env.get(
+  "CF_HARNESS_INTEGRATION_FABRIC_CFC_READ_PATH",
+);
+const FABRIC_CFC_WRITE_PATH = Deno.env.get(
+  "CF_HARNESS_INTEGRATION_FABRIC_CFC_WRITE_PATH",
+);
+const FABRIC_CFC_LABEL_SUBJECT =
+  Deno.env.get("CF_HARNESS_INTEGRATION_FABRIC_CFC_LABEL_SUBJECT")?.trim() ||
+  "did:key:fabric";
 const CF_CLI_INTEGRATION = INTEGRATION &&
   Deno.env.get("CF_HARNESS_INTEGRATION_CF_CLI") === "1";
 const LABS_ROOT_URL = new URL("../../..", import.meta.url);
@@ -129,6 +142,32 @@ const assertLabelIncludesSubject = (label: IFCLabel, subject: string) => {
   assertConfidentialityTaint(label);
   assertStringIncludes(JSON.stringify(label.confidentiality), subject);
 };
+
+const requireSandboxFabricPath = (
+  path: string | undefined,
+  envName: string,
+): string => {
+  const trimmed = path?.trim() ?? "";
+  if (trimmed === "") {
+    throw new Error(`${envName} is required for Fabric CFC flow tests`);
+  }
+  const segments = trimmed.slice(1).split("/");
+  if (
+    !trimmed.startsWith("/fabric/") ||
+    segments.some((segment) =>
+      segment === "" || segment === "." ||
+      segment === ".."
+    )
+  ) {
+    throw new Error(
+      `${envName} must be a concrete absolute sandbox path under /fabric without . or .. segments`,
+    );
+  }
+  return trimmed;
+};
+
+const singleQuoteShell = (value: string): string =>
+  `'${value.replaceAll("'", `'"'"'`)}'`;
 
 const invocationInputLabels = (): CfcLabelView => ({
   version: 1,
@@ -636,5 +675,213 @@ Deno.test({
       assertStringIncludes(statusResult.output.content, '"startedAt"');
       assertStringIncludes(statusResult.output.content, '"spaces"');
     });
+  },
+});
+
+Deno.test({
+  name: "cf-harness integration: Fabric FUSE read labels immediate return",
+  ignore: !FABRIC_CFC_FLOW_INTEGRATION || !CFC_RESULT_DIR_CONFIGURED,
+  permissions: { env: true, read: true, run: true, write: true },
+  async fn() {
+    const fabricReadPath = requireSandboxFabricPath(
+      FABRIC_CFC_READ_PATH,
+      "CF_HARNESS_INTEGRATION_FABRIC_CFC_READ_PATH",
+    );
+    await withFabricHarness(
+      "integration-fabric-read-host-bind",
+      async (engine, hostPath) => {
+        const hostPayload = "fuse read tainted host output\n";
+        const result = await engine.invokeBuiltinTool("bash", {
+          command: [
+            "set -eu",
+            `cat ${singleQuoteShell(fabricReadPath)} >/dev/null`,
+            `printf ${
+              singleQuoteShell(hostPayload)
+            } > /workspace/fuse-read-host.txt`,
+            "printf 'fuse read tainted return\\n'",
+          ].join("\n"),
+        });
+
+        assertEquals(result.output.exitCode, 0);
+        assertEquals(
+          await Deno.readTextFile(`${hostPath}/fuse-read-host.txt`),
+          hostPayload,
+        );
+        assert(result.output.cfcResult !== undefined);
+        assertEquals(result.output.cfcResult.stdout.policy, "opaque");
+        assertLabelIncludesSubject(
+          result.output.cfcResult.stdout.label,
+          FABRIC_CFC_LABEL_SUBJECT,
+        );
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "cf-harness integration: Fabric FUSE read labels host bind readback",
+  ignore: !FABRIC_CFC_DURABLE_HOST_LABEL_INTEGRATION ||
+    !CFC_RESULT_DIR_CONFIGURED,
+  permissions: { env: true, read: true, run: true, write: true },
+  async fn() {
+    const fabricReadPath = requireSandboxFabricPath(
+      FABRIC_CFC_READ_PATH,
+      "CF_HARNESS_INTEGRATION_FABRIC_CFC_READ_PATH",
+    );
+    await withFabricHarness(
+      "integration-fabric-read-host-bind-readback",
+      async (engine, hostPath) => {
+        const hostPayload = "fuse read durable host output\n";
+        const result = await engine.invokeBuiltinTool("bash", {
+          command: [
+            "set -eu",
+            `cat ${singleQuoteShell(fabricReadPath)} >/dev/null`,
+            `printf ${
+              singleQuoteShell(hostPayload)
+            } > /workspace/fuse-read-host.txt`,
+            "printf 'fuse read durable return\\n'",
+          ].join("\n"),
+        });
+
+        assertEquals(result.output.exitCode, 0);
+        assertEquals(
+          await Deno.readTextFile(`${hostPath}/fuse-read-host.txt`),
+          hostPayload,
+        );
+        assert(result.output.cfcResult !== undefined);
+        assertEquals(result.output.cfcResult.stdout.policy, "opaque");
+        assertLabelIncludesSubject(
+          result.output.cfcResult.stdout.label,
+          FABRIC_CFC_LABEL_SUBJECT,
+        );
+
+        const hostReadBack = await engine.invokeBuiltinTool("bash", {
+          command: "cat /workspace/fuse-read-host.txt",
+        });
+        assertEquals(hostReadBack.output.exitCode, 0);
+        assertStringIncludes(hostReadBack.output.stdout, hostPayload);
+        assert(hostReadBack.output.cfcResult !== undefined);
+        assertEquals(hostReadBack.output.cfcResult.stdout.policy, "opaque");
+        assertLabelIncludesSubject(
+          hostReadBack.output.cfcResult.stdout.label,
+          FABRIC_CFC_LABEL_SUBJECT,
+        );
+      },
+    );
+  },
+});
+
+Deno.test({
+  name:
+    "cf-harness integration: invocation labels taint Fabric FUSE write and return",
+  ignore: !FABRIC_CFC_FLOW_INTEGRATION || !CFC_RESULT_DIR_CONFIGURED ||
+    !CFC_INVOCATION_CONTEXT_DIR_CONFIGURED,
+  permissions: { env: true, read: true, run: true, write: true },
+  async fn() {
+    const fabricWritePath = requireSandboxFabricPath(
+      FABRIC_CFC_WRITE_PATH,
+      "CF_HARNESS_INTEGRATION_FABRIC_CFC_WRITE_PATH",
+    );
+    await withFabricHarness(
+      "integration-input-label-fabric-write",
+      async (engine) => {
+        const fabricPayload =
+          "from invocation label through FUSE: integration-input-label-fabric-write\n";
+        const writeResult = await engine.invokeBuiltinTool("bash", {
+          command: [
+            "set -eu",
+            `printf ${singleQuoteShell(fabricPayload)} > ${
+              singleQuoteShell(fabricWritePath)
+            }`,
+            "printf 'wrote fabric value\\n'",
+          ].join("\n"),
+          cfcInputLabels: invocationInputLabels(),
+        });
+
+        assertEquals(writeResult.output.exitCode, 0);
+        assert(writeResult.output.cfcResult !== undefined);
+        assertEquals(writeResult.output.cfcResult.stdout.policy, "opaque");
+        assertLabelIncludesSubject(
+          writeResult.output.cfcResult.stdout.label,
+          INVOCATION_TAINT_SUBJECT,
+        );
+
+        const readBack = await engine.invokeBuiltinTool("bash", {
+          command: `cat ${singleQuoteShell(fabricWritePath)}`,
+        });
+        assertEquals(readBack.output.exitCode, 0);
+        assertStringIncludes(readBack.output.stdout, fabricPayload);
+        assert(readBack.output.cfcResult !== undefined);
+        assertEquals(readBack.output.cfcResult.stdout.policy, "opaque");
+        assertLabelIncludesSubject(
+          readBack.output.cfcResult.stdout.label,
+          INVOCATION_TAINT_SUBJECT,
+        );
+      },
+    );
+  },
+});
+
+Deno.test({
+  name:
+    "cf-harness integration: invocation and Fabric labels join before Fabric write",
+  ignore: !FABRIC_CFC_FLOW_INTEGRATION || !CFC_RESULT_DIR_CONFIGURED ||
+    !CFC_INVOCATION_CONTEXT_DIR_CONFIGURED,
+  permissions: { env: true, read: true, run: true, write: true },
+  async fn() {
+    const fabricReadPath = requireSandboxFabricPath(
+      FABRIC_CFC_READ_PATH,
+      "CF_HARNESS_INTEGRATION_FABRIC_CFC_READ_PATH",
+    );
+    const fabricWritePath = requireSandboxFabricPath(
+      FABRIC_CFC_WRITE_PATH,
+      "CF_HARNESS_INTEGRATION_FABRIC_CFC_WRITE_PATH",
+    );
+    await withFabricHarness(
+      "integration-input-label-fabric-join-write",
+      async (engine) => {
+        const joinedPayload =
+          "joined invocation and fabric labels: integration-input-label-fabric-join-write\n";
+        const joinedWrite = await engine.invokeBuiltinTool("bash", {
+          command: [
+            "set -eu",
+            `cat ${singleQuoteShell(fabricReadPath)} >/dev/null`,
+            `printf ${singleQuoteShell(joinedPayload)} > ${
+              singleQuoteShell(fabricWritePath)
+            }`,
+            "printf 'joined fabric result\\n'",
+          ].join("\n"),
+          cfcInputLabels: invocationInputLabels(),
+        });
+
+        assertEquals(joinedWrite.output.exitCode, 0);
+        assert(joinedWrite.output.cfcResult !== undefined);
+        assertEquals(joinedWrite.output.cfcResult.stdout.policy, "opaque");
+        assertLabelIncludesSubject(
+          joinedWrite.output.cfcResult.stdout.label,
+          INVOCATION_TAINT_SUBJECT,
+        );
+        assertLabelIncludesSubject(
+          joinedWrite.output.cfcResult.stdout.label,
+          FABRIC_CFC_LABEL_SUBJECT,
+        );
+
+        const readBack = await engine.invokeBuiltinTool("bash", {
+          command: `cat ${singleQuoteShell(fabricWritePath)}`,
+        });
+        assertEquals(readBack.output.exitCode, 0);
+        assertStringIncludes(readBack.output.stdout, joinedPayload);
+        assert(readBack.output.cfcResult !== undefined);
+        assertEquals(readBack.output.cfcResult.stdout.policy, "opaque");
+        assertLabelIncludesSubject(
+          readBack.output.cfcResult.stdout.label,
+          INVOCATION_TAINT_SUBJECT,
+        );
+        assertLabelIncludesSubject(
+          readBack.output.cfcResult.stdout.label,
+          FABRIC_CFC_LABEL_SUBJECT,
+        );
+      },
+    );
   },
 });

--- a/packages/cf-harness/integration/engine.integration.test.ts
+++ b/packages/cf-harness/integration/engine.integration.test.ts
@@ -660,7 +660,6 @@ Deno.test({
         ].join("\n"),
       });
       assertEquals(navResult.output.exitCode, 0);
-      assertEquals(navResult.output.cwd, "/fabric");
       assertStringIncludes(navResult.output.stdout, "pwd=/fabric\n");
       assertStringIncludes(navResult.output.stdout, "status-bytes=");
 
@@ -694,7 +693,7 @@ Deno.test({
         const result = await engine.invokeBuiltinTool("bash", {
           command: [
             "set -eu",
-            `cat ${singleQuoteShell(fabricReadPath)} >/dev/null`,
+            `payload=$(cat ${singleQuoteShell(fabricReadPath)})`,
             `printf ${
               singleQuoteShell(hostPayload)
             } > /workspace/fuse-read-host.txt`,
@@ -735,11 +734,12 @@ Deno.test({
         const result = await engine.invokeBuiltinTool("bash", {
           command: [
             "set -eu",
-            `cat ${singleQuoteShell(fabricReadPath)} >/dev/null`,
+            `IFS= read -r payload < ${
+              singleQuoteShell(fabricReadPath)
+            } || [ -n "$payload" ]`,
             `printf ${
               singleQuoteShell(hostPayload)
             } > /workspace/fuse-read-host.txt`,
-            "printf 'fuse read durable return\\n'",
           ].join("\n"),
         });
 

--- a/packages/cf-harness/integration/engine.integration.test.ts
+++ b/packages/cf-harness/integration/engine.integration.test.ts
@@ -169,6 +169,24 @@ const requireSandboxFabricPath = (
 const singleQuoteShell = (value: string): string =>
   `'${value.replaceAll("'", `'"'"'`)}'`;
 
+const fabricParentDirectories = (path: string): string[] => {
+  const parts = path.slice(1).split("/");
+  const dirs: string[] = [];
+  for (let index = 0; index < parts.length - 1; index++) {
+    dirs.push(`/${parts.slice(0, index + 1).join("/")}`);
+  }
+  return dirs;
+};
+
+const warmFabricParentDirectories = (path: string): string[] =>
+  fabricParentDirectories(path).flatMap((dir) => {
+    const quoted = singleQuoteShell(dir);
+    return [
+      `for _ in 1 2 3 4 5; do ls -ld ${quoted} >/dev/null 2>&1 && break; sleep 0.1; done`,
+      `ls -ld ${quoted} >/dev/null`,
+    ];
+  });
+
 const invocationInputLabels = (): CfcLabelView => ({
   version: 1,
   entries: [{
@@ -693,6 +711,7 @@ Deno.test({
         const result = await engine.invokeBuiltinTool("bash", {
           command: [
             "set -eu",
+            ...warmFabricParentDirectories(fabricReadPath),
             `payload=$(cat ${singleQuoteShell(fabricReadPath)})`,
             `printf ${
               singleQuoteShell(hostPayload)
@@ -734,6 +753,7 @@ Deno.test({
         const result = await engine.invokeBuiltinTool("bash", {
           command: [
             "set -eu",
+            ...warmFabricParentDirectories(fabricReadPath),
             `IFS= read -r payload < ${
               singleQuoteShell(fabricReadPath)
             } || [ -n "$payload" ]`,
@@ -790,6 +810,7 @@ Deno.test({
         const writeResult = await engine.invokeBuiltinTool("bash", {
           command: [
             "set -eu",
+            ...warmFabricParentDirectories(fabricWritePath),
             `printf ${singleQuoteShell(fabricPayload)} > ${
               singleQuoteShell(fabricWritePath)
             }`,
@@ -807,7 +828,11 @@ Deno.test({
         );
 
         const readBack = await engine.invokeBuiltinTool("bash", {
-          command: `cat ${singleQuoteShell(fabricWritePath)}`,
+          command: [
+            "set -eu",
+            ...warmFabricParentDirectories(fabricWritePath),
+            `cat ${singleQuoteShell(fabricWritePath)}`,
+          ].join("\n"),
         });
         assertEquals(readBack.output.exitCode, 0);
         assertStringIncludes(readBack.output.stdout, fabricPayload);
@@ -845,7 +870,9 @@ Deno.test({
         const joinedWrite = await engine.invokeBuiltinTool("bash", {
           command: [
             "set -eu",
+            ...warmFabricParentDirectories(fabricReadPath),
             `cat ${singleQuoteShell(fabricReadPath)} >/dev/null`,
+            ...warmFabricParentDirectories(fabricWritePath),
             `printf ${singleQuoteShell(joinedPayload)} > ${
               singleQuoteShell(fabricWritePath)
             }`,
@@ -867,7 +894,11 @@ Deno.test({
         );
 
         const readBack = await engine.invokeBuiltinTool("bash", {
-          command: `cat ${singleQuoteShell(fabricWritePath)}`,
+          command: [
+            "set -eu",
+            ...warmFabricParentDirectories(fabricWritePath),
+            `cat ${singleQuoteShell(fabricWritePath)}`,
+          ].join("\n"),
         });
         assertEquals(readBack.output.exitCode, 0);
         assertStringIncludes(readBack.output.stdout, joinedPayload);

--- a/packages/cf-harness/integration/engine.integration.test.ts
+++ b/packages/cf-harness/integration/engine.integration.test.ts
@@ -187,6 +187,18 @@ const warmFabricParentDirectories = (path: string): string[] =>
     ];
   });
 
+const warmFabricParents = async (
+  engine: CfHarnessEngine,
+  path: string,
+): Promise<void> => {
+  const commands = warmFabricParentDirectories(path);
+  if (commands.length === 0) return;
+  const result = await engine.invokeBuiltinTool("bash", {
+    command: ["set -eu", ...commands].join("\n"),
+  });
+  assertEquals(result.output.exitCode, 0);
+};
+
 const invocationInputLabels = (): CfcLabelView => ({
   version: 1,
   entries: [{
@@ -708,10 +720,10 @@ Deno.test({
       "integration-fabric-read-host-bind",
       async (engine, hostPath) => {
         const hostPayload = "fuse read tainted host output\n";
+        await warmFabricParents(engine, fabricReadPath);
         const result = await engine.invokeBuiltinTool("bash", {
           command: [
             "set -eu",
-            ...warmFabricParentDirectories(fabricReadPath),
             `payload=$(cat ${singleQuoteShell(fabricReadPath)})`,
             `printf ${
               singleQuoteShell(hostPayload)
@@ -750,10 +762,10 @@ Deno.test({
       "integration-fabric-read-host-bind-readback",
       async (engine, hostPath) => {
         const hostPayload = "fuse read durable host output\n";
+        await warmFabricParents(engine, fabricReadPath);
         const result = await engine.invokeBuiltinTool("bash", {
           command: [
             "set -eu",
-            ...warmFabricParentDirectories(fabricReadPath),
             `IFS= read -r payload < ${
               singleQuoteShell(fabricReadPath)
             } || [ -n "$payload" ]`,
@@ -807,10 +819,10 @@ Deno.test({
       async (engine) => {
         const fabricPayload =
           "from invocation label through FUSE: integration-input-label-fabric-write\n";
+        await warmFabricParents(engine, fabricWritePath);
         const writeResult = await engine.invokeBuiltinTool("bash", {
           command: [
             "set -eu",
-            ...warmFabricParentDirectories(fabricWritePath),
             `printf ${singleQuoteShell(fabricPayload)} > ${
               singleQuoteShell(fabricWritePath)
             }`,
@@ -827,10 +839,10 @@ Deno.test({
           INVOCATION_TAINT_SUBJECT,
         );
 
+        await warmFabricParents(engine, fabricWritePath);
         const readBack = await engine.invokeBuiltinTool("bash", {
           command: [
             "set -eu",
-            ...warmFabricParentDirectories(fabricWritePath),
             `cat ${singleQuoteShell(fabricWritePath)}`,
           ].join("\n"),
         });
@@ -867,12 +879,12 @@ Deno.test({
       async (engine) => {
         const joinedPayload =
           "joined invocation and fabric labels: integration-input-label-fabric-join-write\n";
+        await warmFabricParents(engine, fabricReadPath);
+        await warmFabricParents(engine, fabricWritePath);
         const joinedWrite = await engine.invokeBuiltinTool("bash", {
           command: [
             "set -eu",
-            ...warmFabricParentDirectories(fabricReadPath),
             `cat ${singleQuoteShell(fabricReadPath)} >/dev/null`,
-            ...warmFabricParentDirectories(fabricWritePath),
             `printf ${singleQuoteShell(joinedPayload)} > ${
               singleQuoteShell(fabricWritePath)
             }`,
@@ -893,10 +905,10 @@ Deno.test({
           FABRIC_CFC_LABEL_SUBJECT,
         );
 
+        await warmFabricParents(engine, fabricWritePath);
         const readBack = await engine.invokeBuiltinTool("bash", {
           command: [
             "set -eu",
-            ...warmFabricParentDirectories(fabricWritePath),
             `cat ${singleQuoteShell(fabricWritePath)}`,
           ].join("\n"),
         });

--- a/packages/cf-harness/src/contracts/cfc-invocation-context.ts
+++ b/packages/cf-harness/src/contracts/cfc-invocation-context.ts
@@ -1,4 +1,7 @@
-import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import type {
+  CfcEnforcementMode,
+  CfcLabelView,
+} from "@commonfabric/runner/cfc";
 import type { PromptSlotBinding } from "./prompt-slot.ts";
 import type { HarnessRunManifest } from "./run-manifest.ts";
 import type { BuiltinToolId } from "./tool-descriptor.ts";
@@ -57,6 +60,7 @@ export interface HarnessCfcInvocationContext {
   promptSlot?: PromptSlotBinding;
   runManifest: HarnessCfcInvocationRunManifestSummary;
   inputs: HarnessCfcInvocationInputSummary;
+  cfcInputLabels?: CfcLabelView;
 }
 
 export interface CreateHarnessCfcInvocationContextOptions {
@@ -75,6 +79,7 @@ export interface CreateHarnessCfcInvocationContextOptions {
   args?: readonly string[];
   stdinText?: string;
   env?: Record<string, string>;
+  cfcInputLabels?: CfcLabelView;
 }
 
 const textEncoder = new TextEncoder();
@@ -195,5 +200,8 @@ export const createHarnessCfcInvocationContext = async (
       ...(stdin !== undefined ? { stdin } : {}),
       ...(env !== undefined ? { env } : {}),
     },
+    ...(options.cfcInputLabels !== undefined
+      ? { cfcInputLabels: options.cfcInputLabels }
+      : {}),
   };
 };

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -70,6 +70,7 @@ import {
 } from "./contracts/tool-result.ts";
 import type { HarnessTranscriptMessage } from "./contracts/transcript.ts";
 import type { BuiltinToolId } from "./contracts/tool-descriptor.ts";
+import type { CfcLabelView } from "@commonfabric/runner/cfc";
 import {
   DockerRunscSandboxRuntime,
   resolveDockerRunscSandboxConfig,
@@ -968,6 +969,7 @@ export class CfHarnessEngine {
     args?: readonly string[];
     stdinText?: string;
     env?: Record<string, string>;
+    cfcInputLabels?: CfcLabelView;
   }): Promise<HarnessCfcInvocationContext> {
     const now = this.#now();
     const invocation = await createHarnessCfcInvocationContext({
@@ -995,6 +997,9 @@ export class CfHarnessEngine {
         ? { stdinText: options.stdinText }
         : {}),
       ...(options.env !== undefined ? { env: options.env } : {}),
+      ...(options.cfcInputLabels !== undefined
+        ? { cfcInputLabels: options.cfcInputLabels }
+        : {}),
     });
     this.#runState = appendHarnessCfcInvocationContext(
       this.#runState,
@@ -1059,6 +1064,7 @@ export class CfHarnessEngine {
         args?: readonly string[];
         stdinText?: string;
         env?: Record<string, string>;
+        cfcInputLabels?: CfcLabelView;
       }) => this.#createCfcInvocationContext(options),
     };
   }

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -247,6 +247,21 @@ const tryParseToolArguments = (
   }
 };
 
+const TRUSTED_ONLY_TOOL_INPUT_FIELDS = ["cfcInputLabels"];
+
+const stripTrustedOnlyToolInputFields = (
+  input: Record<string, unknown>,
+): Record<string, unknown> => {
+  let sanitized: Record<string, unknown> | undefined;
+  for (const field of TRUSTED_ONLY_TOOL_INPUT_FIELDS) {
+    if (Object.hasOwn(input, field)) {
+      sanitized ??= { ...input };
+      delete sanitized[field];
+    }
+  }
+  return sanitized ?? input;
+};
+
 const textBytes = (input: string): Uint8Array =>
   new TextEncoder().encode(input);
 
@@ -1622,7 +1637,10 @@ export class CfHarnessPromptLoop {
         `unknown builtin tool requested: ${toolCall.function.name}`,
       );
     }
-    const parsedInputForDeniedTool = tryParseToolArguments(toolCall);
+    const parsedInput = tryParseToolArguments(toolCall);
+    const parsedInputForDeniedTool = parsedInput === undefined
+      ? undefined
+      : stripTrustedOnlyToolInputFields(parsedInput);
     const deniedToolInputSummary = parsedInputForDeniedTool === undefined
       ? undefined
       : await summarizeToolInput(
@@ -1709,7 +1727,8 @@ export class CfHarnessPromptLoop {
         },
       };
     }
-    const input = parsedInputForDeniedTool ?? parseToolArguments(toolCall);
+    const input = parsedInputForDeniedTool ??
+      stripTrustedOnlyToolInputFields(parseToolArguments(toolCall));
     const toolInputSummary = deniedToolInputSummary ??
       await summarizeToolInput(toolCall.function.name, input);
     const decision = evaluateToolPolicy(

--- a/packages/cf-harness/src/tools/bash.ts
+++ b/packages/cf-harness/src/tools/bash.ts
@@ -1,5 +1,5 @@
 import type { JSONSchema } from "@commonfabric/api";
-import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
+import type { CfcLabelView, CfcSandboxResult } from "@commonfabric/runner/cfc";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import {
   BASH_COMMAND_DENIED_EXIT_CODE,
@@ -17,6 +17,9 @@ export interface BashToolInput {
   command: string;
   cwd?: string;
   timeoutMs?: number;
+  // Trusted harness/test plumbing for invocation input labels. This is omitted
+  // from the public tool schema so model-authored tool calls do not mint labels.
+  cfcInputLabels?: CfcLabelView;
 }
 
 export interface BashToolOutput {
@@ -104,6 +107,9 @@ export const bashTool: HarnessToolDefinition<BashToolInput, BashToolOutput> = {
         operation: "shell",
         cwd: commandCwd,
         command,
+        ...(input.cfcInputLabels !== undefined
+          ? { cfcInputLabels: input.cfcInputLabels }
+          : {}),
       }),
     });
     const mayTrustCwdMarker = context.cfcEnforcementMode === "disabled" ||

--- a/packages/cf-harness/src/tools/shell-cwd.ts
+++ b/packages/cf-harness/src/tools/shell-cwd.ts
@@ -14,7 +14,7 @@ export const commandWithFinalWorkingDirectoryMarker = (
 ): string =>
   [
     `__cf_harness_cwd_marker=${JSON.stringify(cwdMarker)}`,
-    'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
+    'trap \'__cf_harness_status=$?; trap - EXIT; { printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)" || true; }; exit "$__cf_harness_status"\' EXIT',
     command,
   ].join("\n");
 

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -1,4 +1,7 @@
-import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
+import type {
+  CfcEnforcementMode,
+  CfcLabelView,
+} from "@commonfabric/runner/cfc";
 import type {
   HarnessCfcInvocationContext,
   HarnessCfcInvocationOperation,
@@ -49,6 +52,7 @@ export interface HarnessToolContext {
     args?: readonly string[];
     stdinText?: string;
     env?: Record<string, string>;
+    cfcInputLabels?: CfcLabelView;
   }): Promise<HarnessCfcInvocationContext>;
 }
 

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -149,9 +149,9 @@ Deno.test({
           inputs: {
             command: {
               type: "cf-harness.redacted-text-summary",
-              bytes: 205,
+              bytes: 218,
               digest:
-                "sha256:6bb6cd56e7da813533d74d7817e27d52c502178533187fe96132f5804f2a7d15",
+                "sha256:639e51198d6d74a7eaf2333cf7cb33819448ba30b4c8aa668809cda975728cfd",
             },
           },
         }],

--- a/packages/cf-harness/test/cfc-invocation-context.test.ts
+++ b/packages/cf-harness/test/cfc-invocation-context.test.ts
@@ -5,6 +5,7 @@ import {
   summarizeCfcInvocationText,
 } from "../src/contracts/cfc-invocation-context.ts";
 import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
+import type { CfcLabelView } from "@commonfabric/runner/cfc";
 
 Deno.test("createHarnessCfcInvocationContext summarizes measured invocation inputs without raw values", async () => {
   // Spec: specs/cfc/18-runtime-implementation-profiles.md §18.2.4.1
@@ -19,6 +20,35 @@ Deno.test("createHarnessCfcInvocationContext summarizes measured invocation inpu
   const env = {
     SECRET_TOKEN: "secret env payload",
     PUBLIC_MODE: "observe",
+  };
+  const cfcInputLabels: CfcLabelView = {
+    version: 1,
+    entries: [
+      {
+        path: ["argv"],
+        label: {
+          confidentiality: [
+            { type: "test.cfc/User", subject: "did:key:argv-reader" },
+          ],
+        },
+      },
+      {
+        path: ["env", "SECRET_TOKEN"],
+        label: {
+          confidentiality: [
+            { type: "test.cfc/User", subject: "did:key:env-reader" },
+          ],
+        },
+      },
+      {
+        path: ["cwd"],
+        label: {
+          confidentiality: [
+            { type: "test.cfc/Workspace", subject: "workspace-secret" },
+          ],
+        },
+      },
+    ],
   };
 
   const context = await createHarnessCfcInvocationContext({
@@ -48,6 +78,7 @@ Deno.test("createHarnessCfcInvocationContext summarizes measured invocation inpu
     args,
     stdinText,
     env,
+    cfcInputLabels,
   });
 
   assertEquals(
@@ -67,6 +98,7 @@ Deno.test("createHarnessCfcInvocationContext summarizes measured invocation inpu
   });
   assertEquals(context.cwd, "/workspace/project");
   assertEquals(context.promptSlot?.type, CFC_PROMPT_SLOT_BOUND_ATOM_TYPE);
+  assertEquals(context.cfcInputLabels, cfcInputLabels);
 
   const serialized = JSON.stringify(context);
   for (

--- a/packages/cf-harness/test/cfc-invocation-context.test.ts
+++ b/packages/cf-harness/test/cfc-invocation-context.test.ts
@@ -1,0 +1,86 @@
+import { assertEquals } from "@std/assert";
+import {
+  createHarnessCfcInvocationContext,
+  summarizeCfcInvocationSequence,
+  summarizeCfcInvocationText,
+} from "../src/contracts/cfc-invocation-context.ts";
+import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
+
+Deno.test("createHarnessCfcInvocationContext summarizes measured invocation inputs without raw values", async () => {
+  // Spec: specs/cfc/18-runtime-implementation-profiles.md §18.2.4.1
+  // requires measured execution bundles to bind argv/env/cwd facts. The
+  // cf-harness sidecar is provenance transport for those facts; it carries
+  // redacted summaries so raw command/input bytes are not copied into the
+  // sidecar itself.
+  const command = "printf '%s' \"$SECRET_TOKEN\"";
+  const argv = ["/bin/printf", "%s", "secret-argv"];
+  const args = ["/workspace/secret.txt", "append"];
+  const stdinText = "secret stdin payload";
+  const env = {
+    SECRET_TOKEN: "secret env payload",
+    PUBLIC_MODE: "observe",
+  };
+
+  const context = await createHarnessCfcInvocationContext({
+    sequence: 7,
+    runId: "run-1",
+    createdAt: "2026-05-11T16:00:00.000Z",
+    toolId: "bash",
+    operation: "shell",
+    cfcEnforcementMode: "enforce-explicit",
+    cwd: "/workspace/project",
+    promptSlot: {
+      type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+      source: { type: "cf-harness.test-input", surface: "cli" },
+      role: "direct-command",
+      kernelName: "cli",
+      surface: "cli",
+    },
+    runManifest: {
+      present: true,
+      source: "loom",
+      wishId: "W-519",
+      cfcEnforcementMode: "enforce-explicit",
+      promptSlotPresent: true,
+    },
+    command,
+    argv,
+    args,
+    stdinText,
+    env,
+  });
+
+  assertEquals(
+    context.inputs.command,
+    await summarizeCfcInvocationText(command),
+  );
+  assertEquals(context.inputs.argv, await summarizeCfcInvocationSequence(argv));
+  assertEquals(context.inputs.args, await summarizeCfcInvocationSequence(args));
+  assertEquals(
+    context.inputs.stdin,
+    await summarizeCfcInvocationText(stdinText),
+  );
+  assertEquals(context.inputs.env, {
+    type: "cf-harness.env-summary",
+    count: 2,
+    names: ["PUBLIC_MODE", "SECRET_TOKEN"],
+  });
+  assertEquals(context.cwd, "/workspace/project");
+  assertEquals(context.promptSlot?.type, CFC_PROMPT_SLOT_BOUND_ATOM_TYPE);
+
+  const serialized = JSON.stringify(context);
+  for (
+    const rawValue of [
+      command,
+      "secret-argv",
+      stdinText,
+      "secret env payload",
+    ]
+  ) {
+    assertEquals(
+      serialized.includes(rawValue),
+      false,
+      `sidecar leaked raw invocation input ${rawValue}`,
+    );
+  }
+});

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -300,6 +300,19 @@ Deno.test("DockerRunscSandboxRuntime writes invocation context sidecars before s
       },
       runManifest: { present: false },
       command: "echo hello",
+      cfcInputLabels: {
+        version: 1,
+        entries: [
+          {
+            path: ["argv"],
+            label: {
+              confidentiality: [
+                { type: "test.cfc/User", subject: "did:key:argv-reader" },
+              ],
+            },
+          },
+        ],
+      },
     });
     const runner = new FakeProcessRunner(dockerLifecycleResults());
     const runtime = new DockerRunscSandboxRuntime(

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -6,6 +6,7 @@ import {
   resolveDockerRunscSandboxConfig,
 } from "../src/sandbox/docker-runsc.ts";
 import { createHarnessCfcInvocationContext } from "../src/contracts/cfc-invocation-context.ts";
+import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
 import type {
   ProcessRunner,
@@ -290,6 +291,13 @@ Deno.test("DockerRunscSandboxRuntime writes invocation context sidecars before s
       operation: "shell",
       cfcEnforcementMode: "observe",
       cwd: "/workspace",
+      promptSlot: {
+        type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+        source: { type: "cf-harness.test-input", surface: "cli" },
+        role: "direct-command",
+        kernelName: "cli",
+        surface: "cli",
+      },
       runManifest: { present: false },
       command: "echo hello",
     });

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -380,6 +380,83 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
   );
 });
 
+Deno.test("CfHarnessPromptLoop strips trusted-only CFC input labels from model tool args", async () => {
+  const sandbox = new FakeSandboxRuntime([
+    { stdout: "ok\n", stderr: "", exitCode: 0 },
+  ]);
+  let fetchCount = 0;
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: sandbox,
+      runId: "run-strip-cfc-input-labels",
+      cfcEnforcementMode: "disabled",
+      model: "gpt-5.4",
+    }),
+    fetchFn: () => {
+      fetchCount++;
+      const payload = fetchCount === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-forged-labels",
+                type: "function",
+                function: {
+                  name: "bash",
+                  arguments: JSON.stringify({
+                    command: "printf ok",
+                    cfcInputLabels: {
+                      version: 1,
+                      entries: [{
+                        path: ["argv"],
+                        label: {
+                          confidentiality: [{
+                            type: "test.cfc/User",
+                            subject: "did:key:forged",
+                          }],
+                        },
+                      }],
+                    },
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "done",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Run a command.",
+  });
+
+  const toolRequest = sandbox.shellRequests.find((request) =>
+    !request.command.includes(CAPABILITY_PROBE_SENTINEL)
+  );
+  assert(toolRequest !== undefined);
+  assertEquals(toolRequest.cfcInvocationContext?.cfcInputLabels, undefined);
+  assertEquals(
+    result.runState.cfcInvocationContexts?.[0]?.cfcInputLabels,
+    undefined,
+  );
+});
+
 Deno.test("CfHarnessPromptLoop attaches images loaded by view_image on the next model turn", async () => {
   const workspace = await Deno.realPath(await Deno.makeTempDir());
   await Deno.writeFile(join(workspace, "capture.png"), ONE_PIXEL_PNG);

--- a/packages/cf-harness/test/shell-cwd.test.ts
+++ b/packages/cf-harness/test/shell-cwd.test.ts
@@ -17,7 +17,7 @@ Deno.test("commandWithFinalWorkingDirectoryMarker wraps commands with a cwd trap
     commandWithFinalWorkingDirectoryMarker("pwd", "__MARKER__"),
     [
       '__cf_harness_cwd_marker="__MARKER__"',
-      'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
+      'trap \'__cf_harness_status=$?; trap - EXIT; { printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)" || true; }; exit "$__cf_harness_status"\' EXIT',
       "pwd",
     ].join("\n"),
   );

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -276,7 +276,7 @@ Deno.test("bash tool executes the command through the sandbox shell runtime", as
     request: {
       command: [
         '__cf_harness_cwd_marker="__CF_HARNESS_CWD__run-1:bash:1__"',
-        'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
+        'trap \'__cf_harness_status=$?; trap - EXIT; { printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)" || true; }; exit "$__cf_harness_status"\' EXIT',
         "pwd",
       ].join("\n"),
       cwd: "/workspace/repo",
@@ -291,7 +291,7 @@ Deno.test("bash tool executes the command through the sandbox shell runtime", as
     sandbox.calls[0]?.request.cfcInvocationContext?.inputs.command?.bytes,
     [
       '__cf_harness_cwd_marker="__CF_HARNESS_CWD__run-1:bash:1__"',
-      'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
+      'trap \'__cf_harness_status=$?; trap - EXIT; { printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)" || true; }; exit "$__cf_harness_status"\' EXIT',
       "pwd",
     ].join("\n").length,
   );
@@ -330,7 +330,7 @@ Deno.test("bash tool allows curl to localhost through the sandbox shell runtime"
     request: {
       command: [
         '__cf_harness_cwd_marker="__CF_HARNESS_CWD__run-1:bash:1__"',
-        'trap \'__cf_harness_status=$?; trap - EXIT; printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)"; exit "$__cf_harness_status"\' EXIT',
+        'trap \'__cf_harness_status=$?; trap - EXIT; { printf "%s%s" "$__cf_harness_cwd_marker" "$(pwd)" || true; }; exit "$__cf_harness_status"\' EXIT',
         "curl -fsS http://localhost:8000/health",
       ].join("\n"),
       cwd: "/workspace",

--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -122,6 +122,26 @@ export const fuse = new Command()
     "Linux only: export the mount to other users such as Docker daemon. Requires user_allow_other in /etc/fuse.conf.",
   )
   .option(
+    "--cfc-mode <mode:string>",
+    "Enable FUSE-side CFC mode: disabled, observe, enforce-explicit, or enforce-strict.",
+  )
+  .option(
+    "--cfc-annotations",
+    "Publish CFC annotation xattrs even when CFC mode is disabled.",
+  )
+  .option(
+    "--cfc-xattr-namespace <namespace:string>",
+    "CFC xattr namespace to expose: trusted, compat, or both.",
+  )
+  .option(
+    "--cfc-writeback-xattrs",
+    "Enable temporary CFC writeback prepare/finalize xattrs for integration testing.",
+  )
+  .option(
+    "--cfc-writeback-state <path:string>",
+    "Path for persisted CFC writeback recovery state.",
+  )
+  .option(
     "-s, --space <name:string>",
     "Space(s) to connect (repeatable, default: home).",
     { collect: true },
@@ -185,6 +205,17 @@ export const fuse = new Command()
       if (apiUrl) spawnArgs.push("--api-url", apiUrl);
       if (identity) spawnArgs.push("--identity", identity);
       if (options.allowOther) spawnArgs.push("--allow-other");
+      if (options.cfcMode) spawnArgs.push("--cfc-mode", options.cfcMode);
+      if (options.cfcAnnotations) spawnArgs.push("--cfc-annotations");
+      if (options.cfcXattrNamespace) {
+        spawnArgs.push("--cfc-xattr-namespace", options.cfcXattrNamespace);
+      }
+      if (options.cfcWritebackXattrs) {
+        spawnArgs.push("--cfc-writeback-xattrs");
+      }
+      if (options.cfcWritebackState) {
+        spawnArgs.push("--cfc-writeback-state", options.cfcWritebackState);
+      }
       if (execCli) spawnArgs.push("--exec-cli", execCli);
       for (const s of options.space ?? []) spawnArgs.push("--space", s);
     } else {
@@ -197,6 +228,11 @@ export const fuse = new Command()
         identity,
         execCli,
         allowOther: options.allowOther,
+        cfcMode: options.cfcMode,
+        cfcAnnotations: options.cfcAnnotations,
+        cfcXattrNamespace: options.cfcXattrNamespace,
+        cfcWritebackXattrs: options.cfcWritebackXattrs,
+        cfcWritebackState: options.cfcWritebackState,
       });
       for (const s of options.space ?? []) spawnArgs.push("--space", s);
     }

--- a/packages/cli/lib/fuse.ts
+++ b/packages/cli/lib/fuse.ts
@@ -290,6 +290,11 @@ export function buildDenoArgs(opts: {
   execCli: string;
   logFile?: string;
   allowOther?: boolean;
+  cfcMode?: string;
+  cfcAnnotations?: boolean;
+  cfcXattrNamespace?: string;
+  cfcWritebackXattrs?: boolean;
+  cfcWritebackState?: string;
 }): string[] {
   const args = [
     "run",
@@ -308,6 +313,15 @@ export function buildDenoArgs(opts: {
   if (opts.execCli) args.push("--exec-cli", opts.execCli);
   if (opts.logFile) args.push("--log-file", opts.logFile);
   if (opts.allowOther) args.push("--allow-other");
+  if (opts.cfcMode) args.push("--cfc-mode", opts.cfcMode);
+  if (opts.cfcAnnotations) args.push("--cfc-annotations");
+  if (opts.cfcXattrNamespace) {
+    args.push("--cfc-xattr-namespace", opts.cfcXattrNamespace);
+  }
+  if (opts.cfcWritebackXattrs) args.push("--cfc-writeback-xattrs");
+  if (opts.cfcWritebackState) {
+    args.push("--cfc-writeback-state", opts.cfcWritebackState);
+  }
 
   return args;
 }

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -547,4 +547,29 @@ describe("buildDenoArgs", () => {
     expect(args).not.toContain("--identity");
     expect(args).not.toContain("--exec-cli");
   });
+
+  it("passes CFC mount options through to the daemon", () => {
+    const args = buildDenoArgs({
+      modPath: "/mod.ts",
+      mountpoint: "/mnt",
+      apiUrl: "",
+      identity: "",
+      execCli: "",
+      allowOther: true,
+      cfcMode: "enforce-explicit",
+      cfcAnnotations: true,
+      cfcXattrNamespace: "both",
+      cfcWritebackXattrs: true,
+      cfcWritebackState: "/tmp/cf-writeback.json",
+    });
+    expect(args).toContain("--allow-other");
+    expect(args).toContain("--cfc-mode");
+    expect(args).toContain("enforce-explicit");
+    expect(args).toContain("--cfc-annotations");
+    expect(args).toContain("--cfc-xattr-namespace");
+    expect(args).toContain("both");
+    expect(args).toContain("--cfc-writeback-xattrs");
+    expect(args).toContain("--cfc-writeback-state");
+    expect(args).toContain("/tmp/cf-writeback.json");
+  });
 });

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -208,6 +208,8 @@ type RebuildPieceProp = (args: {
   spaceName: string;
 }) => Promise<void>;
 
+type EnqueuePiecePropRebuild = RebuildPieceProp;
+
 type BuildSourceTree = (
   pieceIno: bigint,
   piece: unknown,
@@ -990,6 +992,63 @@ Deno.test("CellBridge.rebuildPieceProp keeps replaced callable inodes alive brie
   assertEquals(currentToolIno !== undefined, true);
   assertEquals(currentToolIno === initialToolIno, false);
   assertEquals(tree.getNode(initialToolIno!)?.kind, "callable");
+});
+
+Deno.test("CellBridge queues piece prop rebuilds for the same prop", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const cell = makeCell({}, undefined);
+
+  let releaseFirst: (() => void) | undefined;
+  const firstCanFinish = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  let active = 0;
+  let maxActive = 0;
+  const events: string[] = [];
+
+  (bridge as unknown as { rebuildPieceProp: RebuildPieceProp })
+    .rebuildPieceProp = async (args) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      events.push(`start-${String(args.newValue)}`);
+      if (args.newValue === "first") {
+        await firstCanFinish;
+      }
+      events.push(`end-${String(args.newValue)}`);
+      active--;
+    };
+
+  const enqueue = (bridge as unknown as {
+    enqueuePiecePropRebuild: EnqueuePiecePropRebuild;
+  }).enqueuePiecePropRebuild.bind(bridge);
+
+  const baseJob = {
+    cell,
+    pieceId: "of:queued-prop",
+    pieceIno: 42n,
+    pieceName: "Queued Prop",
+    propName: "result" as const,
+    resolveLink: () => null,
+    spaceName: "home",
+  };
+
+  const first = enqueue({ ...baseJob, newValue: "first" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const second = enqueue({ ...baseJob, newValue: "second" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assertEquals(events, ["start-first"]);
+  releaseFirst?.();
+  await Promise.all([first, second]);
+
+  assertEquals(maxActive, 1);
+  assertEquals(events, [
+    "start-first",
+    "end-first",
+    "start-second",
+    "end-second",
+  ]);
 });
 
 Deno.test("CellBridge.rebuildPieceProp clears stale result mounts when value becomes null", async () => {

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -297,6 +297,7 @@ export class CellBridge {
   private hydratedPieceProps = new Map<bigint, Set<"input" | "result">>();
   /** In-flight hydration promises keyed by `${pieceIno}-${propName}`. */
   private pendingHydrations = new Map<string, Promise<boolean>>();
+  private pendingFinalizations = new Map<string, Promise<void>>();
   private retainedSubtrees = new Map<bigint, number>();
   /** Monotonic invalidation epoch per hydration key. */
   private hydrationEpochs = new Map<string, number>();
@@ -1551,18 +1552,30 @@ export class CellBridge {
       this.invalidateWritePath(writePath);
       return;
     }
-    const cell = await writePath.piece[writePath.cell].getCell();
-    const newValue = await writePath.piece[writePath.cell].get();
-    await this.rebuildPieceProp({
-      cell,
-      newValue,
-      pieceId: writePath.piece.id,
-      pieceIno,
-      pieceName: writePath.pieceName,
-      propName: writePath.cell,
-      resolveLink: this.makeLinkResolver(writePath.spaceName),
-      spaceName: writePath.spaceName,
+    const key = this.propRebuildKey(pieceIno, writePath.cell);
+    const previous = this.pendingFinalizations.get(key) ?? Promise.resolve();
+    const current = previous.catch(() => {}).then(async () => {
+      const cell = await writePath.piece[writePath.cell].getCell();
+      const newValue = await writePath.piece[writePath.cell].get();
+      await this.rebuildPieceProp({
+        cell,
+        newValue,
+        pieceId: writePath.piece.id,
+        pieceIno,
+        pieceName: writePath.pieceName,
+        propName: writePath.cell,
+        resolveLink: this.makeLinkResolver(writePath.spaceName),
+        spaceName: writePath.spaceName,
+      });
     });
+    this.pendingFinalizations.set(key, current);
+    try {
+      await current;
+    } finally {
+      if (this.pendingFinalizations.get(key) === current) {
+        this.pendingFinalizations.delete(key);
+      }
+    }
   }
 
   async finalizeSourceWritePath(writePath: SourceWritePath): Promise<void> {

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -297,7 +297,7 @@ export class CellBridge {
   private hydratedPieceProps = new Map<bigint, Set<"input" | "result">>();
   /** In-flight hydration promises keyed by `${pieceIno}-${propName}`. */
   private pendingHydrations = new Map<string, Promise<boolean>>();
-  private pendingFinalizations = new Map<string, Promise<void>>();
+  private pendingPropRebuildQueues = new Map<string, Promise<void>>();
   private retainedSubtrees = new Map<bigint, number>();
   /** Monotonic invalidation epoch per hydration key. */
   private hydrationEpochs = new Map<string, number>();
@@ -1127,7 +1127,7 @@ export class CellBridge {
         this.pendingPropRebuilds.delete(key);
         this.activePropRebuilds.add(key);
         this.updateStatus();
-        void this.rebuildPieceProp({
+        void this.enqueuePiecePropRebuild({
           cell: entry.cell,
           newValue: entry.latestValue,
           pieceId: entry.pieceId,
@@ -1382,6 +1382,23 @@ export class CellBridge {
     this.debugLog(`[${spaceName}] Updated ${pieceName}/${propName}`);
   }
 
+  private async enqueuePiecePropRebuild(args: PropRebuildJob): Promise<void> {
+    const key = this.propRebuildKey(args.pieceIno, args.propName);
+    const previous = this.pendingPropRebuildQueues.get(key) ??
+      Promise.resolve();
+    const current = previous.catch(() => {}).then(() =>
+      this.rebuildPieceProp(args)
+    );
+    this.pendingPropRebuildQueues.set(key, current);
+    try {
+      await current;
+    } finally {
+      if (this.pendingPropRebuildQueues.get(key) === current) {
+        this.pendingPropRebuildQueues.delete(key);
+      }
+    }
+  }
+
   private static readonly MAX_HYDRATION_RETRIES = 3;
 
   private hydratePieceProp(
@@ -1410,7 +1427,7 @@ export class CellBridge {
         try {
           const cell = await info.piece[propName].getCell();
           const newValue = await info.piece[propName].get();
-          await this.rebuildPieceProp({
+          await this.enqueuePiecePropRebuild({
             cell,
             newValue,
             pieceId: info.piece.id,
@@ -1552,30 +1569,18 @@ export class CellBridge {
       this.invalidateWritePath(writePath);
       return;
     }
-    const key = this.propRebuildKey(pieceIno, writePath.cell);
-    const previous = this.pendingFinalizations.get(key) ?? Promise.resolve();
-    const current = previous.catch(() => {}).then(async () => {
-      const cell = await writePath.piece[writePath.cell].getCell();
-      const newValue = await writePath.piece[writePath.cell].get();
-      await this.rebuildPieceProp({
-        cell,
-        newValue,
-        pieceId: writePath.piece.id,
-        pieceIno,
-        pieceName: writePath.pieceName,
-        propName: writePath.cell,
-        resolveLink: this.makeLinkResolver(writePath.spaceName),
-        spaceName: writePath.spaceName,
-      });
+    const cell = await writePath.piece[writePath.cell].getCell();
+    const newValue = await writePath.piece[writePath.cell].get();
+    await this.enqueuePiecePropRebuild({
+      cell,
+      newValue,
+      pieceId: writePath.piece.id,
+      pieceIno,
+      pieceName: writePath.pieceName,
+      propName: writePath.cell,
+      resolveLink: this.makeLinkResolver(writePath.spaceName),
+      spaceName: writePath.spaceName,
     });
-    this.pendingFinalizations.set(key, current);
-    try {
-      await current;
-    } finally {
-      if (this.pendingFinalizations.get(key) === current) {
-        this.pendingFinalizations.delete(key);
-      }
-    }
   }
 
   async finalizeSourceWritePath(writePath: SourceWritePath): Promise<void> {
@@ -2785,7 +2790,7 @@ export class CellBridge {
               // undefined, keep the current mounted tree intact until a
               // concrete replacement arrives.
               this.invalidateRootPropCache(pieceIno, propName);
-              await this.rebuildPieceProp({
+              await this.enqueuePiecePropRebuild({
                 cell,
                 newValue: rebuildValue,
                 pieceId: piece.id,

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -350,6 +350,25 @@ export async function main(argv: string[] = Deno.args) {
     lastErrorAt: null as string | null,
   };
 
+  // Number of FUSE requests whose reply is intentionally delayed while async
+  // bridge work runs. Reverse invalidations are unsafe while these requests are
+  // outstanding because the kernel may still be waiting in request_wait_answer.
+  let pendingFuseReplies = 0;
+  let onPendingFuseRepliesDrained: (() => void) | undefined;
+
+  function trackPendingFuseReply(): () => void {
+    pendingFuseReplies++;
+    let done = false;
+    return () => {
+      if (done) return;
+      done = true;
+      pendingFuseReplies--;
+      if (pendingFuseReplies === 0) {
+        onPendingFuseRepliesDrained?.();
+      }
+    };
+  }
+
   // Populate tree
   const apiUrl = args["api-url"];
   if (apiUrl) {
@@ -791,12 +810,15 @@ export async function main(argv: string[] = Deno.args) {
         if (replyLookupFromTree(req, parent, lookup.directoryName)) {
           return;
         }
+        const finishPendingReply = trackPendingFuseReply();
         bridge.connectSpace(lookup.spaceName).then(() => {
           if (!replyLookupFromTree(req, parent, lookup.directoryName)) {
             fuse.symbols.fuse_reply_err(req, ENOENT);
           }
+          finishPendingReply();
         }).catch(() => {
           fuse.symbols.fuse_reply_err(req, ENOENT);
+          finishPendingReply();
         });
         return;
       }
@@ -808,16 +830,21 @@ export async function main(argv: string[] = Deno.args) {
         // previously hydrated data), reply immediately and trigger
         // hydration in the background for not-yet-populated entries.
         if (!mustSynchronize && replyLookupFromTree(req, parent, name)) {
-          bridge.prepareLookup(parent, name).catch(() => {});
+          setTimeout(() => {
+            bridge.prepareLookup(parent, name).catch(() => {});
+          }, 0);
           return;
         }
         // Slow path: entry not in tree, must hydrate before replying.
+        const finishPendingReply = trackPendingFuseReply();
         bridge.prepareLookup(parent, name).then(() => {
           if (!replyLookupFromTree(req, parent, name)) {
             fuse.symbols.fuse_reply_err(req, ENOENT);
           }
+          finishPendingReply();
         }).catch(() => {
           fuse.symbols.fuse_reply_err(req, ENOENT);
+          finishPendingReply();
         });
         return;
       }
@@ -1198,10 +1225,13 @@ export async function main(argv: string[] = Deno.args) {
       };
 
       if (bridge?.shouldPrepareDirectory(inode)) {
+        const finishPendingReply = trackPendingFuseReply();
         bridge.prepareDirectory(inode).then(() => {
           sendDirectoryReply();
+          finishPendingReply();
         }).catch(() => {
           fuse.symbols.fuse_reply_err(req, ENOENT);
+          finishPendingReply();
         });
         return;
       }
@@ -2978,41 +3008,121 @@ export async function main(argv: string[] = Deno.args) {
 
   let unmounting = false;
 
-  // Wire up kernel cache invalidation for subscriptions
+  // Wire up kernel cache invalidation for subscriptions.
+  //
+  // libfuse reverse invalidation can block while the kernel answers the notify
+  // request. Some bridge paths run while a FUSE request is still awaiting its
+  // reply (for example, lookup -> connectSpace -> syncPieceList). Calling
+  // notify inline from those paths can deadlock the daemon against the kernel's
+  // pending request. Queue notifications onto a timer and wait for all tracked
+  // async replies to drain before issuing reverse invalidations.
   if (bridge) {
-    let notifySupported = true;
-    bridge.onInvalidate = (parentIno: bigint, names: string[]) => {
-      if (!notifySupported || unmounting) return;
-      for (const name of names) {
-        const nameBuf = encoder.encode(name + "\0");
-        const rc = fuse.symbols.fuse_lowlevel_notify_inval_entry(
-          handle.notifyTarget,
-          parentIno,
-          nameBuf,
-          BigInt(name.length),
-        );
-        if (rc === -38) {
-          // ENOSYS — FUSE-T doesn't support notify_inval_entry
-          console.log(
-            "notify_inval_entry not supported (FUSE-T); relying on short timeouts",
-          );
-          notifySupported = false;
-          break;
+    let entryNotifySupported = true;
+    let inodeNotifySupported = true;
+    const pendingEntryInvalidations = new Map<
+      string,
+      { parentIno: bigint; names: Set<string> }
+    >();
+    const pendingInodeInvalidations = new Set<bigint>();
+    let invalidationTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const scheduleInvalidationFlush = () => {
+      if (invalidationTimer !== undefined) return;
+      invalidationTimer = setTimeout(() => {
+        invalidationTimer = undefined;
+        if (pendingFuseReplies > 0) return;
+        flushDeferredInvalidations();
+      }, 0);
+    };
+    onPendingFuseRepliesDrained = scheduleInvalidationFlush;
+
+    const flushDeferredInvalidations = () => {
+      if (unmounting) {
+        pendingEntryInvalidations.clear();
+        pendingInodeInvalidations.clear();
+        return;
+      }
+
+      if (entryNotifySupported) {
+        for (const { parentIno, names } of pendingEntryInvalidations.values()) {
+          for (const name of names) {
+            const nameBuf = encoder.encode(name + "\0");
+            try {
+              const rc = fuse.symbols.fuse_lowlevel_notify_inval_entry(
+                handle.notifyTarget,
+                parentIno,
+                nameBuf,
+                BigInt(nameBuf.length - 1),
+              );
+              if (rc === -38) {
+                // ENOSYS — FUSE-T doesn't support notify_inval_entry.
+                console.log(
+                  "notify_inval_entry not supported (FUSE-T); relying on short timeouts",
+                );
+                entryNotifySupported = false;
+                break;
+              }
+              if (debug && rc !== 0) {
+                console.log(
+                  `notify_inval_entry(parent=${parentIno}, name=${name}) => ${rc}`,
+                );
+              }
+            } catch (e) {
+              console.warn(`notify_inval_entry failed: ${e}`);
+              entryNotifySupported = false;
+              break;
+            }
+          }
+          if (!entryNotifySupported) break;
         }
       }
+      pendingEntryInvalidations.clear();
+
+      if (inodeNotifySupported) {
+        for (const ino of pendingInodeInvalidations) {
+          try {
+            // Invalidate all cached data for this inode (off=0, len=-1 means all)
+            const ret = fuse.symbols.fuse_lowlevel_notify_inval_inode(
+              handle.notifyTarget,
+              ino,
+              0n,
+              -1n,
+            );
+            if (ret === -38) {
+              // ENOSYS — FUSE-T doesn't support notify_inval_inode.
+              inodeNotifySupported = false;
+              break;
+            }
+            if (debug) {
+              console.log(`notify_inval_inode(ino=${ino}) => ${ret}`);
+            }
+          } catch (e) {
+            console.warn(`notify_inval_inode failed: ${e}`);
+            inodeNotifySupported = false;
+            break;
+          }
+        }
+      }
+      pendingInodeInvalidations.clear();
+    };
+
+    bridge.onInvalidate = (parentIno: bigint, names: string[]) => {
+      if (!entryNotifySupported || unmounting) return;
+      const key = parentIno.toString();
+      let pending = pendingEntryInvalidations.get(key);
+      if (!pending) {
+        pending = { parentIno, names: new Set<string>() };
+        pendingEntryInvalidations.set(key, pending);
+      }
+      for (const name of names) {
+        pending.names.add(name);
+      }
+      scheduleInvalidationFlush();
     };
     bridge.onInvalidateInode = (ino: bigint) => {
-      if (unmounting) return;
-      // Invalidate all cached data for this inode (off=0, len=-1 means all)
-      const ret = fuse.symbols.fuse_lowlevel_notify_inval_inode(
-        handle.notifyTarget,
-        ino,
-        0n,
-        -1n,
-      );
-      if (debug) {
-        console.log(`notify_inval_inode(ino=${ino}) => ${ret}`);
-      }
+      if (!inodeNotifySupported || unmounting) return;
+      pendingInodeInvalidations.add(ino);
+      scheduleInvalidationFlush();
     };
   }
 

--- a/packages/patterns/system/backlinks-index.tsx
+++ b/packages/patterns/system/backlinks-index.tsx
@@ -200,14 +200,13 @@ const BacklinksIndex = pattern<Input, Output>(({ allPieces }) => {
             {filteredCount} of {totalCount} pieces
           </span>
 
-          {filtered.map((entry) => {
-            const row = EntryRow({
-              piece: entry.piece,
-              name: entry.name,
-              backlinks: entry.backlinks,
-            });
-            return row[UI];
-          })}
+          {filtered.map((entry) => (
+            <EntryRow
+              piece={entry.piece}
+              name={entry.name}
+              backlinks={entry.backlinks}
+            />
+          ))}
         </cf-vstack>
       </cf-screen>
     ),


### PR DESCRIPTION
## Summary
- Adds focused tests for cf-harness invocation contexts: command, argv, args, and stdin are summarized with byte counts and digests, while env only exposes variable names.
- Adds explicit `cfcInputLabels` to invocation contexts so real labels can travel with those redacted summaries without leaking raw input values.
- Threads those input labels through the cf-harness tool/engine path into the Docker runsc sidecar.
- Adds gated integration coverage for `cfcInputLabels` through bash into runsc, host-bind file writes, runsc result-sidecar opacity, and joined taint after reading a differently labeled host secret.
- Adds live Fabric FUSE CFC probes for mount visibility, immediate FUSE-read result labeling, durable host-bind readback, invocation-label-to-FUSE writes, and joined invocation+FUSE labels.
- Forwards CFC options through `cf fuse mount` so integration runs can enable CFC xattrs/writeback state without invoking the daemon manually.
- Makes cf-harness bash cwd markers best-effort so CFC-blocked marker output does not change the command exit status.
- Fixes `BacklinksIndex` sub-pattern rendering so the Toolshed path no longer throws `EntryRow is not a function` when creating/stepping the writable FUSE fixture.
- Defers Labs FUSE reverse invalidations until pending async replies drain and serializes all piece-prop rebuild entry points through one queue to avoid daemon/kernel deadlocks and pending-subtree races.
- Warms Fabric FUSE parent directories in separate preflight invocations with bounded stat checks, keeping the labeled read/write/readback assertions focused on the operation under test.
- Documents the Fabric FUSE CFC env gates, including `CF_HARNESS_INTEGRATION_FABRIC_CFC_DURABLE_HOST_LABEL`.

## Why
This gives us a safer audit trail for how a tool was invoked, and it gives runsc a real label-bearing field to consume. The summaries are still just summaries; only `cfcInputLabels` is meant to drive CFC taint. The FUSE changes make live probes safer and less flaky without claiming that durable sandbox-to-FUSE writeback semantics are complete.

## Validation
- `deno test --filter "createHarnessCfcInvocationContext summarizes measured invocation inputs without raw values" packages/cf-harness/test/cfc-invocation-context.test.ts`
- `ENV=test deno test --allow-read --allow-write --allow-run --filter "DockerRunscSandboxRuntime writes invocation context sidecars before start" packages/cf-harness/test/docker-runsc-sandbox.test.ts`
- `ENV=test deno test --allow-env --allow-read --allow-run --allow-write --filter "invocation input labels taint host bind output" packages/cf-harness/integration/engine.integration.test.ts` (ignored unless CFC integration env is configured)
- `ENV=test deno test --allow-env --allow-read --allow-run --allow-write --filter "invocation labels join policy reads before writes" packages/cf-harness/integration/engine.integration.test.ts` (ignored unless CFC integration env is configured)
- `deno check packages/cf-harness/src/tools/bash.ts packages/cf-harness/integration/engine.integration.test.ts`
- `deno fmt --check packages/cf-harness/README.md packages/cf-harness/integration/engine.integration.test.ts packages/cli/commands/fuse.ts packages/cli/lib/fuse.ts packages/cli/test/fuse.test.ts`
- `deno check packages/cf-harness/integration/engine.integration.test.ts packages/cli/commands/fuse.ts packages/cli/lib/fuse.ts packages/cli/test/fuse.test.ts`
- `ENV=test deno test --allow-env --allow-read --allow-write --allow-run --filter "buildDenoArgs" packages/cli/test/fuse.test.ts`
- `deno fmt --check packages/patterns/system/backlinks-index.tsx`
- `deno check packages/patterns/system/backlinks-index.tsx`
- `ENV=test deno task test`
- `deno fmt --check packages/cf-harness/src/tools/shell-cwd.ts packages/cf-harness/test/shell-cwd.test.ts packages/cf-harness/integration/engine.integration.test.ts`
- `deno check packages/cf-harness/src/tools/shell-cwd.ts packages/cf-harness/test/shell-cwd.test.ts packages/cf-harness/integration/engine.integration.test.ts`
- `ENV=test deno test --filter "commandWithFinalWorkingDirectoryMarker wraps commands with a cwd trap" packages/cf-harness/test/shell-cwd.test.ts`
- `ENV=test deno test --allow-env --allow-read --allow-run --allow-write --filter "resolveDockerRunscSandboxConfig normalizes a Fabric FUSE mount" packages/cf-harness/test/docker-runsc-sandbox.test.ts`
- `deno fmt --check packages/fuse/mod.ts packages/fuse/cell-bridge.ts packages/cf-harness/integration/engine.integration.test.ts`
- `deno check packages/fuse/mod.ts packages/fuse/cell-bridge.ts packages/cf-harness/integration/engine.integration.test.ts`
- `deno test --allow-env packages/fuse/cell-bridge.test.ts packages/fuse/callable-path.test.ts packages/fuse/handles.test.ts`
- `deno fmt --check packages/fuse/cell-bridge.ts packages/fuse/cell-bridge.test.ts packages/cf-harness/integration/engine.integration.test.ts`
- `deno check packages/fuse/cell-bridge.ts packages/fuse/cell-bridge.test.ts packages/cf-harness/integration/engine.integration.test.ts`
- `deno test --allow-env packages/fuse/cell-bridge.test.ts packages/fuse/tree-builder.test.ts packages/fuse/callable-path.test.ts packages/fuse/handles.test.ts` (`112 passed | 0 failed`)
- LSP diagnostics clean for `packages/fuse/mod.ts`, `packages/fuse/cell-bridge.ts`, `packages/fuse/cell-bridge.test.ts`, and `packages/cf-harness/integration/engine.integration.test.ts`.
- Live Docker host-bind after gVisor rebuild/reinstall: derived host-bind output persisted `user.commonfabric.cfc.contentLabel`, fresh reader sidecar included `did:key:alice`, and tainted append to an existing public file failed without changing or labeling it.
- Live local FUSE against fresh mount `/tmp/cf-harness-home-fuse-fresh`:
  - `cf-harness integration: Fabric FUSE mount is visible through runsc-cfc` passed.
  - `cf-harness integration: Fabric FUSE read labels immediate return` passed.
  - `cf-harness integration: Fabric FUSE read labels host bind readback` passed.

## Remaining coverage gaps
- `cf-harness -> sandbox -> fuse` is still a live gap: invocation sidecars are consumed and host-only handler/scalar writes pass, but durable sandbox-to-FUSE cell readback is not proven.
- Labs FUSE expects trusted prepare/finalize writeback metadata for durable CFC writeback. Current docs require a trusted runner/runtime path for that metadata; they do **not** document automatic gVisor prepare/finalize emission as an accepted implementation.
- Atomicity semantics for create/write/rename/truncate/setattr need explicit design before implementing any automatic sandbox writeback protocol.
- The current `/fabric/home/...` target is not a writable fresh-file target; write-direction tests need a safe stable writable piece/cell fixture path such as a known `Fuse-Exec-Fixture` input/result path.
- Stale unsafe FUSE repro processes/mounts from earlier D-state hangs should be avoided; continue live probes only on fresh mounts with bounded single-path checks.