### PR TITLE
fix(runner,memory): drop no-op JSON.parse/stringify round-trips

### DIFF
--- a/packages/memory/consumer.ts
+++ b/packages/memory/consumer.ts
@@ -894,12 +894,11 @@ class QuerySubscriptionInvocation<
       }
     }
     this.integrate(commit);
-    // This is a bit strange, but the revisions in here aren't proper
-    // They've lost their Reference methods, so recreate them
+    // The revisions in here aren't proper: they've lost their identity as
+    // `FabricHash`, so recreate them from the string form.
     commit.revisions.forEach((item) => {
-      item.cause = FabricHash.fromJson(
-        item.cause as unknown as { "/": string },
-      );
+      const stringValue = (item.cause as unknown as { "/": string })["/"];
+      item.cause = FabricHash.fromString(stringValue);
     });
 
     return { ok: {} };

--- a/packages/memory/consumer.ts
+++ b/packages/memory/consumer.ts
@@ -897,7 +897,9 @@ class QuerySubscriptionInvocation<
     // This is a bit strange, but the revisions in here aren't proper
     // They've lost their Reference methods, so recreate them
     commit.revisions.forEach((item) => {
-      item.cause = FabricHash.fromJson(JSON.parse(JSON.stringify(item.cause)));
+      item.cause = FabricHash.fromJson(
+        item.cause as unknown as { "/": string },
+      );
     });
 
     return { ok: {} };

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -119,8 +119,6 @@ export function getEntityId(value: any): { "/": string } | undefined {
   const entityId = { "/": fromURI(link.id) };
 
   if (link.path && link.path.length > 0) {
-    return JSON.parse(
-      JSON.stringify(createRef({ path: link.path }, entityId)),
-    );
+    return createRef({ path: link.path }, entityId).toJSON!();
   } else return entityId;
 }

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -5377,9 +5377,7 @@ function getPieceMetadataFromFrame(frame?: Frame): {
   result.spellId = spellCell?.getAsNormalizedFullLink().id;
   const resultCell = source.get()?.resultRef;
   result.space = source.space;
-  result.pieceId = JSON.parse(
-    JSON.stringify(resultCell?.entityId ?? {}),
-  )["/"];
+  result.pieceId = resultCell?.entityId?.["/"];
   return result;
 }
 

--- a/packages/runner/src/uri-utils.ts
+++ b/packages/runner/src/uri-utils.ts
@@ -8,10 +8,10 @@ import type { URI } from "./sigil-types.ts";
  * Convert an entity ID to URI format with "of:" prefix
  */
 export function toURI(value: unknown): URI {
-  if (value instanceof FabricHash) {
-    return `of:${value.toJSON()["/"]}`;
-  }
   if (isRecord(value)) {
+    if (value instanceof FabricHash) {
+      return `of:${value.toJSON()["/"]}`;
+    }
     if (typeof value["/"] === "string") {
       return `of:${value["/"]}`;
     }

--- a/packages/runner/src/uri-utils.ts
+++ b/packages/runner/src/uri-utils.ts
@@ -8,18 +8,11 @@ import type { URI } from "./sigil-types.ts";
  * Convert an entity ID to URI format with "of:" prefix
  */
 export function toURI(value: unknown): URI {
-  if (isRecord(value)) {
-    if (value instanceof FabricHash) {
-      return `of:${value.toJSON()["/"]}`;
-    }
-    if (typeof value["/"] === "string") {
-      return `of:${value["/"]}`;
-    }
-    throw new Error(
-      `Cannot convert value to URI: ${toCompactDebugString(value)}`,
-    );
-  }
-  if (typeof value === "string") {
+  if (value instanceof FabricHash) {
+    return `of:${value}`;
+  } else if (isRecord(value) && typeof value["/"] === "string") {
+    return `of:${value["/"]}`;
+  } else if (typeof value === "string") {
     // Already has prefix with colon
     if (value.includes(":")) {
       // TODO(seefeld): Remove this once we want to support any URI, ideally

--- a/packages/runner/src/uri-utils.ts
+++ b/packages/runner/src/uri-utils.ts
@@ -1,3 +1,4 @@
+import { FabricHash } from "@commonfabric/data-model/fabric-hash";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { isRecord } from "@commonfabric/utils/types";
@@ -7,18 +8,18 @@ import type { URI } from "./sigil-types.ts";
  * Convert an entity ID to URI format with "of:" prefix
  */
 export function toURI(value: unknown): URI {
+  if (value instanceof FabricHash) {
+    return `of:${value.toJSON()["/"]}`;
+  }
   if (isRecord(value)) {
-    // Normalize: prefer `toJSON()` result if present (e.g., `FabricHash`),
-    // else use `value` directly. Inputs whose `/` is not a string fall
-    // through to the error path.
-    const normalized = (typeof value.toJSON === "function")
-      ? value.toJSON()
-      : value;
-
-    if (isRecord(normalized) && typeof normalized["/"] === "string") {
-      return `of:${normalized["/"]}`;
+    if (typeof value["/"] === "string") {
+      return `of:${value["/"]}`;
     }
-  } else if (typeof value === "string") {
+    throw new Error(
+      `Cannot convert value to URI: ${toCompactDebugString(value)}`,
+    );
+  }
+  if (typeof value === "string") {
     // Already has prefix with colon
     if (value.includes(":")) {
       // TODO(seefeld): Remove this once we want to support any URI, ideally

--- a/packages/runner/src/uri-utils.ts
+++ b/packages/runner/src/uri-utils.ts
@@ -8,11 +8,16 @@ import type { URI } from "./sigil-types.ts";
  */
 export function toURI(value: unknown): URI {
   if (isRecord(value)) {
-    // Converts EntityId to JSON
-    const parsed = JSON.parse(JSON.stringify(value)) as { "/": string };
+    // Normalize: prefer `toJSON()` result if present (e.g., `FabricHash`),
+    // else use `value` directly. Inputs whose `/` is not a string fall
+    // through to the error path.
+    const normalized = (typeof value.toJSON === "function")
+      ? value.toJSON()
+      : value;
 
-    // Handle EntityId object
-    if (typeof parsed["/"] === "string") return `of:${parsed["/"]}`;
+    if (isRecord(normalized) && typeof normalized["/"] === "string") {
+      return `of:${normalized["/"]}`;
+    }
   } else if (typeof value === "string") {
     // Already has prefix with colon
     if (value.includes(":")) {


### PR DESCRIPTION
## Summary

Drop no-op `JSON.parse(JSON.stringify(x))` round-trips at 3 sites
(`scheduler.ts`, `create-ref.ts`, `consumer.ts`) where the input is
already plain-JSON-shaped at the call site, plus replace the
fourth-site round-trip in `uri-utils.ts` with a flat
`if/else if/else if/else` discriminator chain (matching `fromURI`'s
shape) that names the two reachable object shapes (`FabricHash` and
plain `{ "/": string }`) explicitly.

Per `researcher-remy`'s strip-methods classification report
in the danfuzz-land meta-project repo
([`coordination/docs/2026-05-11-strip-methods-classification.md`](https://github.com/commontoolsinc/danfuzz-land/blob/main/projects/space-model-implementation/coordination/docs/2026-05-11-strip-methods-classification.md)),
ratified by Dan as the in-scope fix shape, with six Dan-direct
line-level review revisions folded in across two waves of fixup
commits.

## Headline finding from the research

**3 of 4 sites are defensive no-op round-trips** (input is already
plain-JSON-shaped at the call site), not strip-methods idioms.
Only `uri-utils.ts` performs genuine multi-input-shape dispatch.
The original task-entry framing assumed all 4 were strip-methods;
Remy's per-site classification refined this to a three-sub-class
decomposition: defensive no-op round-trip (scheduler, consumer) /
`toJSON`-driven projection (create-ref) / multi-input-shape
discriminator-dispatch (uri-utils).

## Per-site changes

| Site | Intent | Fix | Coverage |
|---|---|---|---|
| `packages/runner/src/scheduler.ts:5380-5382` | Defensive no-op round-trip on `Cell.entityId` (plain object literal) | Direct property access via optional chain: `resultCell?.entityId?.["/"]` | Existing scheduler tests |
| `packages/runner/src/create-ref.ts:122-124` | `toJSON`-driven projection on `FabricHash` return | Direct `.toJSON!()` call (precedent: `memory/entity.ts:34`) | Existing create-ref tests |
| `packages/memory/consumer.ts:900` | Defensive no-op round-trip on wire-stripped `item.cause` (static type `FabricHash`, runtime shape plain `{ "/": string }`) | `const stringValue = (item.cause as unknown as { "/": string })["/"]; item.cause = FabricHash.fromString(stringValue);` (precedent: `fabric-hash.ts:111-113` — `fromJson({ "/": s })` literally delegates to `fromString(s)`, so the prior shape was constructing a one-key object just to read its only property) | **GAP — dead-code surface accepted per Dan-review** (see below) |
| `packages/runner/src/uri-utils.ts:9-32` | Multi-input-shape dispatch across 3 runtime input shapes (`FabricHash` instance, `{ "/": string }`, `{ "/": Uint8Array }`) | Flat `if/else if/else if/else` discriminator chain matching `fromURI`'s shape: `instanceof FabricHash` → `${value}` template; `isRecord && "/" is string` → return; other → fall through to end-of-function throw. The `{ "/": Uint8Array }` arm reaches the throw via fall-through (matching prior behavior on rejection) | `schema-examples.test.ts:340-405` (plain-object branch); `runtime.getCell()` transitively (`FabricHash` branch) |

### Site-3 gap-disposition

Site 3 (`memory/consumer.ts:900`) has no test coverage:
`consumer.ts` is on dead-code surface (re-exported via `lib.ts` but
zero callers in the codebase). The fix shape mirrors `fact.ts:174`
precedent; an in-place test would require ~40-50 lines of
`MemorySession` mocking which is anti-amortization for a 2-line
mechanical swap on dead-code-now surface. Gap accepted per
Dan-review.

## Mid-flight refinements from Dan-direct line-level review

Dan posted six line-level review threads on the PR across two
waves, all on shape-clarity rather than behavior. All six folded
into two fixup commits ([`ca8dbe68e`](https://github.com/commontoolsinc/labs/pull/3549/commits/ca8dbe68e) and [`778c022bb`](https://github.com/commontoolsinc/labs/pull/3549/commits/778c022bb)).

**Wave 1** (3 threads → `ca8dbe68e`):

1. **`consumer.ts:897`** (stale-comment refresh) — the prior
   comment referenced `Reference` methods, which were the methods
   on `merkle-reference`'s `Reference` class (no longer used in
   this codebase). New text names `FabricHash` as the identity
   that's been lost on the wire.
2. **`consumer.ts:900`** (`fromString` swap, captured in the table
   above) — `FabricHash.fromJson({ "/": s })` literally delegates
   to `FabricHash.fromString(s)`; the prior shape was constructing
   a one-key object just to read its only property.
3. **`uri-utils.ts:11`** (explicit named-arms dispatch) — replaces
   toJSON-feature-detection normalization with named-discriminator
   dispatch over the two reachable shapes. Adds named import of
   `FabricHash` from `@commonfabric/data-model/fabric-hash`
   (precedent: `runner/src/builder/factory.ts:59`).

**Wave 2** (3 threads → `778c022bb`):

4. **`uri-utils.ts` Thread B** (template-literal simplification) —
   replace `${value.toJSON()["/"]}` with `${value}`.
   `FabricHash.toString()` and `FabricHash.toJSON()["/"]` both
   return `#fullStringForm` (the same `<tag>:<base64urlHash>`
   string) per `fabric-hash.ts:94-104`, so this is byte-equivalent.
5. **`uri-utils.ts` Thread C** (flat dispatch structure) —
   restructured as flat `if/else if/else if/else` chain matching
   `fromURI`'s shape. The `FabricHash` arm hoisted to the
   top-level check rather than nested inside an `isRecord` wrapper.
6. **`uri-utils.ts` Thread D** (redundant-throw removal) — removed
   the inner throw; the outer throw at the end of the function
   handles the unhandled-object-shape case via fall-through.
   `{ "/": Uint8Array }` continues to throw per Remy §4.4-3
   carveout.

## What's NOT in this PR (banked for future task entries)

Three boundary observations from Remy's §4.4 explicitly left as-is
(out-of-scope per Remy's recommendation, ratified by Dan):

1. **`createRef`'s return-type widening** — declared `EntityId`,
   always returns `FabricHash`. Tightening would simplify the
   `create-ref.ts` fix to bare `.toJSON()` (no non-null assert),
   but is out-of-scope here.
2. **`consumer.ts:900` wire-typing layer fix** — the static/runtime
   mismatch (typed `FabricHash` but wire-deserialized as plain
   JSON) is preserved via the `as unknown as { "/": string }` cast.
3. **`toURI`'s `Uint8Array` `/` arm** — the new flat dispatch chain
   reaches this input via fall-through to the end-of-function
   throw (behavior unchanged: rejection). No caller passes that
   shape today.

## Disqualified substitute candidates

Per Remy's per-site analysis, all three task-entry-named substitute
shapes are disqualified for these 4 sites:

- **`toPlainJsonShape(x)` helper** — no site warrants the
  abstraction; the 3 no-op sites need *removal*, not a helper.
- **`structuredClone()` swap** — no clone is happening at any site;
  swapping in a clone would change behavior.
- **`cloneIfNecessary()` swap** — no class-identity-preservation
  goal at any site; at the one site (`uri-utils.ts`) that does
  perform a transformation, the goal is shape-discriminator
  dispatch rather than identity-preserving clone.

## Pre-push gates

- `deno fmt --check` on `packages/runner` + `packages/memory`:
  clean (re-run on each fix-tip through `778c022bb`).
- `deno lint` on `packages/runner` + `packages/memory`: clean.
- `deno task test` on `packages/runner`: 414 passed (2373 steps).
- `deno task test` on `packages/memory`: 100 passed (28 steps).

Behavior preserved on all currently-reachable inputs (each fix is
mechanical and either drops a no-op or replaces it with a shape
that produces identical output for the inputs callers actually
pass today).

## Test plan

- [x] `deno fmt --check` on `packages/runner`.
- [x] `deno fmt --check` on `packages/memory`.
- [x] `deno lint` on `packages/runner`.
- [x] `deno lint` on `packages/memory`.
- [x] `deno task test` on `packages/runner` (414/414 passed).
- [x] `deno task test` on `packages/memory` (100/100 passed).
- [ ] CI green on this PR.
