### PR TITLE
perf(data-model): speed up bigint twos-complement encoding/decoding

### DIFF
--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -60,6 +60,7 @@ function hexStringFromPositiveValue(value: bigint): string {
  */
 function convertSmallValue(value: bigint, negative: boolean) {
   const skipByte = negative ? 0xff : 0x00;
+  const signBit = skipByte & 0x80;
 
   dv64View.setBigInt64(0, value, false); // `false` means big-endian.
 
@@ -71,10 +72,8 @@ function convertSmallValue(value: bigint, negative: boolean) {
     if (byte !== skipByte) {
       // Adjust starting index backwards if the non-skipped byte would flip
       // the sign of the result.
-      if (negative) {
-        if (byte <= 0x7f) i--;
-      } else {
-        if (byte >= 0x80) i--;
+      if ((byte & 0x80) !== signBit) {
+        i--;
       }
       return dv64Bytes.slice(i);
     }

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -163,12 +163,25 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
 // ---------------------------------------------------------------------------
 
 /**
- * Helper for `bigintFromMinimalTwosComplement()`, which decodes the given
- * array into a _positive_ `bigint`, with all bits complemented when told that
- * the ultimate result is negative (`negative = true`).
+ * Interprets a byte array as a two's-complement big-endian integer and returns
+ * the corresponding bigint. Empty input throws.
  */
-function decodeLargeValue(bytes: Uint8Array, negative: boolean): bigint {
-  // For negative numbers, this uses a similar ones-complement trick
+export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
+  if (bytes.length === 0) {
+    throw new Error("bigintFromMinimalTwosComplement: empty input");
+  }
+
+  // Determine sign from the high bit of the first byte.
+  const negative = (bytes[0]! & 0x80) !== 0;
+
+  if (bytes.length <= 8) {
+    // Fast path for `bytes.length <= 8`.
+    dv64Bytes.fill(negative ? 0xff : 0);
+    dv64Bytes.set(bytes, 8 - bytes.length);
+    return dv64View.getBigInt64(0, false); // `false` means big-endian.
+  }
+
+  // Slow path. For negative numbers, this uses a similar ones-complement trick
   // as is done in the encoder function, above.
 
   const byteMask = negative ? 0xff : 0x00;
@@ -188,29 +201,4 @@ function decodeLargeValue(bytes: Uint8Array, negative: boolean): bigint {
   }
 
   return negative ? ~result : result;
-}
-
-/**
- * Interprets a byte array as a two's-complement big-endian integer and returns
- * the corresponding bigint. Empty input throws.
- */
-export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
-  if (bytes.length === 0) {
-    throw new Error("bigintFromMinimalTwosComplement: empty input");
-  }
-
-  // Note: `false` in `getBig*(n, false)` means "big-endian."
-
-  // Determine sign from the high bit of the first byte.
-  const negative = (bytes[0]! & 0x80) !== 0;
-
-  if (bytes.length <= 8) {
-    // Fast path for `bytes.length <= 8`.
-    dv64Bytes.fill(negative ? 0xff : 0);
-    dv64Bytes.set(bytes, 8 - bytes.length);
-    return dv64View.getBigInt64(0, false); // `false` means big-endian.
-  } else {
-    // Slow path.
-    return decodeLargeValue(bytes, negative);
-  }
 }

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -77,7 +77,7 @@ function convertSmallValue(value: bigint, negative: boolean) {
         : dv64Bytes.slice(i - 1);
     }
   }
-};
+}
 
 /**
  * Shared 8-byte scratch buffer for the `DataView` fast path. A single
@@ -185,8 +185,14 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
     // Slow path for negative values. This uses a similar ones-complement trick
     // as is done in the encoder function, above.
     let result = 0n;
-    for (let i = 0; i < bytes.length; i++) {
+    const partials = bytes.length & 7;
+    for (let i = 0; i < partials; i++) {
       result = (result << 8n) | BigInt(0xff - bytes[i]!);
+    }
+    for (let i = partials; i < bytes.length; i += 8) {
+      dv64Bytes.set(bytes.subarray(i, i + 8));
+      result = (result << 64n) |
+        (0xffff_ffff_ffff_ffffn - dv64View.getBigUint64(0, false));
     }
     return ~result;
   } else {

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -163,6 +163,34 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
 // ---------------------------------------------------------------------------
 
 /**
+ * Helper for `bigintFromMinimalTwosComplement()`, which decodes the given
+ * array into a _positive_ `bigint`, with all bits complemented when told that
+ * the ultimate result is negative (`negative = true`).
+ */
+function decodeLargeValue(bytes: Uint8Array, negative: boolean): bigint {
+  // For negative numbers, this uses a similar ones-complement trick
+  // as is done in the encoder function, above.
+
+  const byteMask = negative ? 0xff : 0x00;
+  const bigMask = negative ? 0xffff_ffff_ffff_ffffn : 0n;
+  const partials = bytes.length & 7;
+
+  let result = 0n;
+
+  for (let i = 0; i < partials; i++) {
+    result = (result << 8n) | BigInt(byteMask ^ bytes[i]!);
+  }
+
+  for (let i = partials; i < bytes.length; i += 8) {
+    dv64Bytes.set(bytes.subarray(i, i + 8));
+    result = (result << 64n) |
+      (bigMask ^ dv64View.getBigUint64(0, false)); // `false` means big-endian.
+  }
+
+  return negative ? ~result : result;
+}
+
+/**
  * Interprets a byte array as a two's-complement big-endian integer and returns
  * the corresponding bigint. Empty input throws.
  */
@@ -180,32 +208,9 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
     // Fast path for `bytes.length <= 8`.
     dv64Bytes.fill(negative ? 0xff : 0);
     dv64Bytes.set(bytes, 8 - bytes.length);
-    return dv64View.getBigInt64(0, false);
-  } else if (negative) {
-    // Slow path for negative values. This uses a similar ones-complement trick
-    // as is done in the encoder function, above.
-    let result = 0n;
-    const partials = bytes.length & 7;
-    for (let i = 0; i < partials; i++) {
-      result = (result << 8n) | BigInt(0xff ^ bytes[i]!);
-    }
-    for (let i = partials; i < bytes.length; i += 8) {
-      dv64Bytes.set(bytes.subarray(i, i + 8));
-      result = (result << 64n) |
-        (0xffff_ffff_ffff_ffffn ^ dv64View.getBigUint64(0, false));
-    }
-    return ~result;
+    return dv64View.getBigInt64(0, false); // `false` means big-endian.
   } else {
-    // Slow path for positive values.
-    let result = 0n;
-    const partials = bytes.length & 7;
-    for (let i = 0; i < partials; i++) {
-      result = (result << 8n) | BigInt(bytes[i]!);
-    }
-    for (let i = partials; i < bytes.length; i += 8) {
-      dv64Bytes.set(bytes.subarray(i, i + 8));
-      result = (result << 64n) | dv64View.getBigUint64(0, false);
-    }
-    return result;
+    // Slow path.
+    return decodeLargeValue(bytes, negative);
   }
 }

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -171,6 +171,8 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
     throw new Error("bigintFromMinimalTwosComplement: empty input");
   }
 
+  // Note: `false` in `getBig*(n, false)` means "big-endian."
+
   // Determine sign from the high bit of the first byte.
   const negative = (bytes[0]! & 0x80) !== 0;
 
@@ -178,7 +180,7 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
     // Fast path for `bytes.length <= 8`.
     dv64Bytes.fill(negative ? 0xff : 0);
     dv64Bytes.set(bytes, 8 - bytes.length);
-    return dv64View.getBigInt64(0, false); // `false` means big-endian.
+    return dv64View.getBigInt64(0, false);
   } else if (negative) {
     // Slow path for negative values. This uses a similar ones-complement trick
     // as is done in the encoder function, above.
@@ -190,8 +192,13 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
   } else {
     // Slow path for positive values.
     let result = 0n;
-    for (let i = 0; i < bytes.length; i++) {
+    const partials = bytes.length & 7;
+    for (let i = 0; i < partials; i++) {
       result = (result << 8n) | BigInt(bytes[i]!);
+    }
+    for (let i = partials; i < bytes.length; i += 8) {
+      dv64Bytes.set(bytes.subarray(i, i + 8));
+      result = (result << 64n) | dv64View.getBigUint64(0, false);
     }
     return result;
   }

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -58,8 +58,7 @@ function hexStringFromPositiveValue(value: bigint): string {
  * Helper for `bigintToMinimalTwosComplement()`, which converts a non-zero and
  * non-`-1` value that fits into 64 bits.
  */
-function convertSmallValue(value: bigint) {
-  const negative = value < 0;
+function convertSmallValue(value: bigint, negative: boolean) {
   const skipByte = negative ? 0xff : 0x00;
 
   dv64View.setBigInt64(0, value, false); // `false` means big-endian.
@@ -119,7 +118,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     if (value === 0n) {
       return ZERO_BYTES.slice();
     } else if (value <= 0x7fff_ffff_ffff_ffffn) {
-      return convertSmallValue(value);
+      return convertSmallValue(value, false);
     }
 
     // Slow path for positive numbers: This stringifies and then parses back the
@@ -140,7 +139,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     if (value === -1n) {
       return NEGATIVE_ONE_BYTES.slice();
     } else if (value >= -0x8000_0000_0000_0000n) {
-      return convertSmallValue(value);
+      return convertSmallValue(value, true);
     }
 
     // Slow path for negative numbers. See above for details. The extra twist

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -8,21 +8,20 @@
  * except as needed for sign extension.
  */
 
- /**
-  * Shared 8-byte scratch buffer.
-  */
- const dv64Buf = new ArrayBuffer(8);
+/**
+ * Shared 8-byte scratch buffer.
+ */
+const dv64Buf = new ArrayBuffer(8);
 
- /**
-  * `DataView` of `dv64buf`.
-  */
- const dv64View = new DataView(dv64Buf);
+/**
+ * `DataView` of `dv64buf`.
+ */
+const dv64View = new DataView(dv64Buf);
 
- /**
-  * `Uint8Array` view of `dv64buf`.
-  */
- const dv64Bytes = new Uint8Array(dv64Buf);
-
+/**
+ * `Uint8Array` view of `dv64buf`.
+ */
+const dv64Bytes = new Uint8Array(dv64Buf);
 
 // ---------------------------------------------------------------------------
 // `bigint` -> minimal two's-complement big-endian bytes

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -8,6 +8,22 @@
  * except as needed for sign extension.
  */
 
+ /**
+  * Shared 8-byte scratch buffer.
+  */
+ const dv64Buf = new ArrayBuffer(8);
+
+ /**
+  * `DataView` of `dv64buf`.
+  */
+ const dv64View = new DataView(dv64Buf);
+
+ /**
+  * `Uint8Array` view of `dv64buf`.
+  */
+ const dv64Bytes = new Uint8Array(dv64Buf);
+
+
 // ---------------------------------------------------------------------------
 // `bigint` -> minimal two's-complement big-endian bytes
 // ---------------------------------------------------------------------------
@@ -78,16 +94,6 @@ function convertSmallValue(value: bigint, negative: boolean) {
     }
   }
 }
-
-/**
- * Shared 8-byte scratch buffer for the `DataView` fast path. A single
- * `setBigUint64()` call writes all 8 bytes at once, avoiding hex string
- * processing for values that fit in 64 bits. Same shared-buffer pattern as
- * `f64Buf`/`f64View`/`f64Bytes` in `value-hash.ts`.
- */
-const dv64Buf = new ArrayBuffer(8);
-const dv64View = new DataView(dv64Buf);
-const dv64Bytes = new Uint8Array(dv64Buf);
 
 /**
  * Cached result of `0n` as a `Uint8Array`.

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -55,7 +55,35 @@ function hexStringFromPositiveValue(value: bigint): string {
 }
 
 /**
- * Shared 8-byte scratch buffer for the DataView fast path. A single
+ * Helper for `bigintToMinimalTwosComplement()`, which converts a non-zero and
+ * non-`-1` value that fits into 64 bits.
+ */
+function convertSmallValue(value: bigint) {
+  const negative = value < 0;
+  const skipByte = negative ? 0xff : 0x00;
+
+  dv64View.setBigInt64(0, value, false); // `false` means big-endian.
+
+  // Note: Loop necessarily ends before running off the end of the array
+  // because by virtue of the caller's up-front check, there's definitely a
+  // non-skipped byte).
+  for (let i = 0; true; i++) {
+    const byte = dv64Bytes[i];
+    if (byte !== skipByte) {
+      // Adjust starting index backwards if the non-skipped byte would flip
+      // the sign of the result.
+      if (negative) {
+        if (byte <= 0x7f) i--;
+      } else {
+        if (byte >= 0x80) i--;
+      }
+      return dv64Bytes.slice(i);
+    }
+  }
+};
+
+/**
+ * Shared 8-byte scratch buffer for the `DataView` fast path. A single
  * `setBigUint64()` call writes all 8 bytes at once, avoiding hex string
  * processing for values that fit in 64 bits. Same shared-buffer pattern as
  * `f64Buf`/`f64View`/`f64Bytes` in `value-hash.ts`.
@@ -87,34 +115,11 @@ const NEGATIVE_ONE_BYTES = new Uint8Array([0xFF]);
  *   when the high bit would otherwise be clear (sign extension for negative).
  */
 export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
-  // Converts a value that fits into 64 bits.
-  const convertSmallValue = (negative: boolean) => {
-    dv64View.setBigInt64(0, value, false); // `false` means big-endian.
-
-    // Note: Loop necessarily ends before running off the end of the array
-    // because by virtue of the caller's up-front check, there's definitely a
-    // non-skipped byte).
-    const skipByte = negative ? 0xff : 0x00;
-    for (let i = 0; true; i++) {
-      const byte = dv64Bytes[i];
-      if (byte !== skipByte) {
-        // Adjust starting index backwards if the non-skipped byte would flip
-        // the sign of the result.
-        if (negative) {
-          if (byte <= 0x7f) i--;
-        } else {
-          if (byte >= 0x80) i--;
-        }
-        return dv64Bytes.slice(i);
-      }
-    }
-  };
-
   if (value >= 0n) {
     if (value === 0n) {
       return ZERO_BYTES.slice();
     } else if (value <= 0x7fff_ffff_ffff_ffffn) {
-      return convertSmallValue(false);
+      return convertSmallValue(value);
     }
 
     // Slow path for positive numbers: This stringifies and then parses back the
@@ -135,7 +140,7 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     if (value === -1n) {
       return NEGATIVE_ONE_BYTES.slice();
     } else if (value >= -0x8000_0000_0000_0000n) {
-      return convertSmallValue(true);
+      return convertSmallValue(value);
     }
 
     // Slow path for negative numbers. See above for details. The extra twist

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -150,8 +150,8 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
     const bytes = new Uint8Array(hex.length >> 1);
 
     for (let i = 0; i < bytes.length; i++) {
-      // `0xff - value` to undo the ones-complement in `~value` above.
-      bytes[i] = 0xff - byteValueAt(hex, i * 2);
+      // `0xff ^ value` to undo the ones-complement in `~value` above.
+      bytes[i] = 0xff ^ byteValueAt(hex, i * 2);
     }
 
     return bytes;
@@ -187,12 +187,12 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
     let result = 0n;
     const partials = bytes.length & 7;
     for (let i = 0; i < partials; i++) {
-      result = (result << 8n) | BigInt(0xff - bytes[i]!);
+      result = (result << 8n) | BigInt(0xff ^ bytes[i]!);
     }
     for (let i = partials; i < bytes.length; i += 8) {
       dv64Bytes.set(bytes.subarray(i, i + 8));
       result = (result << 64n) |
-        (0xffff_ffff_ffff_ffffn - dv64View.getBigUint64(0, false));
+        (0xffff_ffff_ffff_ffffn ^ dv64View.getBigUint64(0, false));
     }
     return ~result;
   } else {

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -72,10 +72,9 @@ function convertSmallValue(value: bigint, negative: boolean) {
     if (byte !== skipByte) {
       // Adjust starting index backwards if the non-skipped byte would flip
       // the sign of the result.
-      if ((byte & 0x80) !== signBit) {
-        i--;
-      }
-      return dv64Bytes.slice(i);
+      return ((byte & 0x80) === signBit)
+        ? dv64Bytes.slice(i)
+        : dv64Bytes.slice(i - 1);
     }
   }
 };


### PR DESCRIPTION
## Summary

Refactors `bigint-encoding.ts` for clarity and performance, with no semantic change. Both `bigintToMinimalTwosComplement()` and `bigintFromMinimalTwosComplement()` round-trip identical values to `main`; the exhaustive round-trip tests (random payloads up to 1659 bytes) continue to pass unchanged.

Two structural improvements drive the perf gains:

- **Encode small values (≤ 8 bytes):** Extracted the `DataView`-fast-path body as a top-level `convertSmallValue()` helper with `negative` passed explicitly so the function avoids re-deriving the sign.
- **Decode slow path (≥ 9 bytes, both signs):** Replaced the per-byte `BigInt` shift-OR loop with a head loop for the leading partial bytes followed by 8-byte chunks consumed via `DataView.getBigUint64()`. For negative values, the per-byte `0xff - byte` complement becomes per-chunk `0xffff_ffff_ffff_ffffn ^ chunk` XOR (cheaper on `BigInt`, no carry chain, and structurally symmetric with the positive branch). The two slow paths are unified via a single inlined sequence parameterized by `byteMask` / `bigMask`.

## Performance

All numbers are per `64`-op iteration on Apple M5 Pro / Deno 2.7.8. Lower is better.

### Encode (small values, `convertSmallValue()` path)

At parity with `main` across the 1B–8B band; deviations are within the bench's ~3% run-to-run noise floor.

### Decode (slow path, 9B and up)

Speedup grows with size toward the theoretical ~8× ceiling (one `BigInt` op per 8 bytes instead of per byte). The negative-side multiplier runs slightly below the positive side because each chunk pays for an extra XOR.

| size  | positive: main → branch | speedup | negative: main → branch | speedup |
|-------|-------------------------|---------|-------------------------|---------|
| 16B   | 8.5 µs → 3.8 µs         | 2.24×   | 8.6 µs → 4.7 µs         | 1.83×   |
| 32B   | 18.2 µs → 8.2 µs        | 2.22×   | 18.9 µs → 9.5 µs        | 1.99×   |
| 64B   | 40.6 µs → 16.2 µs       | 2.51×   | 42.7 µs → 18.0 µs       | 2.37×   |
| 128B  | 101.5 µs → 34.0 µs      | 2.99×   | 107.0 µs → 37.6 µs      | 2.85×   |
| 256B  | 266.8 µs → 74.7 µs      | 3.57×   | 272.2 µs → 81.1 µs      | 3.36×   |
| 512B  | 699.0 µs → 152.3 µs     | 4.59×   | 701.4 µs → 162.4 µs     | 4.32×   |
| 1024B | 2.3 ms → 339.6 µs       | ~6.77×  | 2.3 ms → 374.2 µs       | ~6.15×  |

Fast path (≤8B decode) is structurally unchanged, and measures within noise of `main`. Encode large values (≥9B) is similarly untouched.

## Test plan

- [x] `deno bench --no-check test/bigint-encoding.bench.ts` run on both `main` and this branch.
- [x] `deno task test` in `packages/data-model` — 45 passed (17,425 steps).
- [ ] CI green on the full workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up two’s‑complement bigint encode/decode in `packages/data-model/bigint-encoding.ts` with no behavior changes. Large-value decode is ~2–6.8× faster; small-value paths remain at parity.

- **Refactors**
  - Added `convertSmallValue(value, negative)` for ≤8B encodes using `DataView.setBigInt64()` and hoisted the shared 8‑byte `DataView` buffer for reuse in both functions.
  - Rewrote ≥9B decode to read 8‑byte chunks via `DataView.getBigUint64()` and XOR masks for negatives; unified slow paths with `byteMask`/`bigMask`.
  - Switched ones‑complement undo from `0xff - b` to `0xff ^ b` in the encoder.

<sup>Written for commit 474458e9187a9419452b5ed3187ccec5a5fa81b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

