### PR TITLE
fix(runner): keep pull render sinks responsive

### DIFF
--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -576,93 +576,83 @@ describe("default-app flow test", () => {
     }
   });
 
-  it({
-    // Disabled while the push scheduler is still in use — this test
-    // exercises a race that's flaky under push semantics. Berni is
-    // investigating the underlying scheduler bug; the push scheduler is
-    // being removed in favor of pull soon, after which this can be
-    // re-enabled (and the body already calls setSchedulerPullMode(true)
-    // for that future state). Tracked alongside the move-to-pull work.
-    name: "should render every rapidly created notebook note",
-    ignore: true,
-    fn: async () => {
-      identity = await Identity.generate({ implementation: "noble" });
-      const notebookSpaceName = globalThis.crypto.randomUUID();
+  it("should render every rapidly created notebook note", async () => {
+    identity = await Identity.generate({ implementation: "noble" });
+    const notebookSpaceName = globalThis.crypto.randomUUID();
 
-      const page = shell.page();
-      await shell.goto({
-        frontendUrl: FRONTEND_URL,
-        view: { spaceName: notebookSpaceName },
-        identity,
-      });
+    const page = shell.page();
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: notebookSpaceName },
+      identity,
+    });
 
-      console.log("Set scheduler mode: pull for notebook regression...");
-      await waitFor(async () => {
-        return await setSchedulerPullMode(page, true);
-      });
+    console.log("Set scheduler mode: pull for notebook regression...");
+    await waitFor(async () => {
+      return await setSchedulerPullMode(page, true);
+    });
 
+    await waitFor(async () => {
+      return !!(await clickButtonWithText(page, "Notes"));
+    });
+    await waitFor(async () => {
+      return !!(await clickButtonWithText(page, "New Notebook"));
+    });
+    try {
       await waitFor(async () => {
-        return !!(await clickButtonWithText(page, "Notes"));
+        const state = await collectNotebookRenderState(page);
+        return state.isNotebook;
       });
-      await waitFor(async () => {
-        return !!(await clickButtonWithText(page, "New Notebook"));
-      });
-      try {
-        await waitFor(async () => {
-          const state = await collectNotebookRenderState(page);
-          return state.isNotebook;
-        });
-      } catch (error) {
-        console.log(
-          "Notebook navigation diagnostics:",
-          JSON.stringify(await collectNavigationDiagnostics(page), null, 2),
-        );
-        throw error;
-      }
-
-      await waitFor(async () => {
-        return !!(await clickButtonWithTitle(page, "New Note"));
-      });
-      await waitFor(async () => {
-        return !!(await findButtonWithText(page, "Create Another"));
-      });
-
-      const noteCreates = 7;
-      for (let i = 0; i < noteCreates - 1; i++) {
-        assert(
-          await clickButtonWithText(page, "Create Another"),
-          `Expected Create Another click ${i + 1} to succeed`,
-        );
-      }
-      assert(
-        await clickButtonWithExactText(page, "Create"),
-        "Expected final Create click to succeed",
+    } catch (error) {
+      console.log(
+        "Notebook navigation diagnostics:",
+        JSON.stringify(await collectNavigationDiagnostics(page), null, 2),
       );
+      throw error;
+    }
 
-      try {
-        await waitFor(async () => {
-          const state = await collectNotebookRenderState(page);
-          return state.noteCount === noteCreates &&
-            state.renderedNoteChips === noteCreates;
-        });
-      } catch (_) {
-        // Keep the final assertions below so failures include diagnostics.
-      }
+    await waitFor(async () => {
+      return !!(await clickButtonWithTitle(page, "New Note"));
+    });
+    await waitFor(async () => {
+      return !!(await findButtonWithText(page, "Create Another"));
+    });
 
-      const summary = await collectNotebookRenderState(page);
-      if (
-        summary.noteCount !== noteCreates ||
-        summary.renderedNoteChips !== noteCreates
-      ) {
-        console.log(
-          "Notebook rapid create diagnostics:",
-          JSON.stringify(await collectNotebookDiagnostics(page), null, 2),
-        );
-      }
+    const noteCreates = 7;
+    for (let i = 0; i < noteCreates - 1; i++) {
+      assert(
+        await clickButtonWithText(page, "Create Another"),
+        `Expected Create Another click ${i + 1} to succeed`,
+      );
+    }
+    assert(
+      await clickButtonWithExactText(page, "Create"),
+      "Expected final Create click to succeed",
+    );
 
-      assertEquals(summary.noteCount, noteCreates);
-      assertEquals(summary.renderedNoteChips, noteCreates);
-    },
+    try {
+      await waitFor(async () => {
+        const state = await collectNotebookRenderState(page);
+        return state.noteCount === noteCreates &&
+          state.renderedNoteChips === noteCreates;
+      });
+    } catch (_) {
+      // Keep the final assertions below so failures include diagnostics.
+    }
+
+    const summary = await collectNotebookRenderState(page);
+    if (
+      summary.noteCount !== noteCreates ||
+      summary.renderedNoteChips !== noteCreates
+    ) {
+      console.log(
+        "Notebook rapid create diagnostics:",
+        JSON.stringify(await collectNotebookDiagnostics(page), null, 2),
+      );
+    }
+
+    assertEquals(summary.noteCount, noteCreates);
+    assertEquals(summary.renderedNoteChips, noteCreates);
   });
 });
 

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -2698,11 +2698,29 @@ async function collectNotebookDiagnostics(
       id: string;
       preview?: string;
       isPending: boolean;
+      isDemanded?: boolean;
+      isDebouncedWaiting?: boolean;
+      isConditionallyScheduled?: boolean;
+      hasActiveDebounceTimer?: boolean;
+      nextDebounceRunInMs?: number;
+      nextEligibleRunInMs?: number;
       reads: string[];
       writes: string[];
       outgoing: Array<{ to: string; cells?: string[]; edgeType?: string }>;
     }>;
-    pendingEffects?: Array<{ id: string; preview?: string }>;
+    effectState?: Array<{
+      id: string;
+      preview?: string;
+      isPending: boolean;
+      isDirty: boolean;
+      isPullDemandRoot?: boolean;
+      isConditionallyScheduled?: boolean;
+      hasActiveDebounceTimer?: boolean;
+      debounceMs?: number;
+      nextEligibleRunInMs?: number;
+      reads: string[];
+      writes: string[];
+    }>;
     actionTraceTail?: Array<{ id: string; type: string; writes: string[] }>;
   }
 > {
@@ -2724,6 +2742,12 @@ async function collectNotebookDiagnostics(
         id: node.id,
         preview: node.preview,
         isPending: node.isPending,
+        isDemanded: node.isDemanded,
+        isDebouncedWaiting: node.isDebouncedWaiting,
+        isConditionallyScheduled: node.isConditionallyScheduled,
+        hasActiveDebounceTimer: node.hasActiveDebounceTimer,
+        nextDebounceRunInMs: node.nextDebounceRunInMs,
+        nextEligibleRunInMs: node.nextEligibleRunInMs,
         reads: (node.reads ?? []).slice(0, 12),
         writes: (node.writes ?? []).slice(0, 8),
         outgoing: (edgesByFrom.get(node.id) ?? [])
@@ -2734,10 +2758,29 @@ async function collectNotebookDiagnostics(
             edgeType: edge.edgeType,
           })),
       }));
-    const pendingEffects = (graph?.nodes ?? [])
-      .filter((node: any) => node.type === "effect" && node.isPending)
+    const effectState = (graph?.nodes ?? [])
+      .filter((node: any) =>
+        node.type === "effect" &&
+        (node.isPending ||
+          node.isDirty ||
+          node.isConditionallyScheduled ||
+          node.hasActiveDebounceTimer ||
+          node.debounceMs !== undefined)
+      )
       .slice(0, 20)
-      .map((node: any) => ({ id: node.id, preview: node.preview }));
+      .map((node: any) => ({
+        id: node.id,
+        preview: node.preview,
+        isPending: node.isPending,
+        isDirty: node.isDirty,
+        isPullDemandRoot: node.isPullDemandRoot,
+        isConditionallyScheduled: node.isConditionallyScheduled,
+        hasActiveDebounceTimer: node.hasActiveDebounceTimer,
+        debounceMs: node.debounceMs,
+        nextEligibleRunInMs: node.nextEligibleRunInMs,
+        reads: (node.reads ?? []).slice(0, 8),
+        writes: (node.writes ?? []).slice(0, 6),
+      }));
     const actionTraceTail = (actionTrace ?? []).slice(-20).map((
       entry: any,
     ) => ({
@@ -2750,7 +2793,7 @@ async function collectNotebookDiagnostics(
 
     return {
       dirtyComputations,
-      pendingEffects,
+      effectState,
       actionTraceTail,
     };
   });

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -431,7 +431,7 @@ export class Scheduler {
   private stale = new Set<Action>();
   private upstreamStaleWriters = new WeakMap<Action, Set<Action>>();
   private upstreamStaleCount = new WeakMap<Action, number>();
-  private pullMode = true;
+  private pullMode = false;
 
   // Debugger breakpoints: action IDs that should trigger `debugger` before execution
   private breakpoints = new Set<string>();

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -431,7 +431,7 @@ export class Scheduler {
   private stale = new Set<Action>();
   private upstreamStaleWriters = new WeakMap<Action, Set<Action>>();
   private upstreamStaleCount = new WeakMap<Action, number>();
-  private pullMode = false;
+  private pullMode = true;
 
   // Debugger breakpoints: action IDs that should trigger `debugger` before execution
   private breakpoints = new Set<string>();

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -2383,8 +2383,11 @@ export class Scheduler {
       );
 
       // Get timing controls
+      const now = performance.now();
       const debounceMs = this.actionDebounce.get(action);
       const throttleMs = this.actionThrottle.get(action);
+      const nextDebounceRunAt = this.getNextDebounceRunTime(action);
+      const nextEligibleRunAt = this.getNextEligibleRunTime(action);
 
       // Get pattern association
       const annotated = action as Partial<TelemetryAnnotations>;
@@ -2398,6 +2401,21 @@ export class Scheduler {
         stats: this.actionStats.get(id),
         isDirty: this.dirty.has(action),
         isPending: this.pending.has(action),
+        isDemanded: this.isDemandedPullComputation(action),
+        isLiveEffect: this.isLiveEffect(action),
+        isPullDemandRoot: this.isPullDemandRootEffect(action),
+        isConditionallyScheduled: this.conditionallyScheduledEffects.has(
+          action,
+        ),
+        isDebouncedWaiting: nextDebounceRunAt !== undefined &&
+          nextDebounceRunAt > now,
+        hasActiveDebounceTimer: this.debounceTimers.has(action),
+        nextDebounceRunInMs: nextDebounceRunAt !== undefined
+          ? Math.max(0, Math.round(nextDebounceRunAt - now))
+          : undefined,
+        nextEligibleRunInMs: nextEligibleRunAt !== undefined
+          ? Math.max(0, Math.round(nextEligibleRunAt - now))
+          : undefined,
         parentId,
         childCount: childCount && childCount > 0 ? childCount : undefined,
         preview: (action as Action & {
@@ -3047,6 +3065,18 @@ export class Scheduler {
       this.dependencies.has(action);
   }
 
+  private isPullDemandRootEffect(action: Action): boolean {
+    return this.pullMode &&
+      this.effects.has(action) &&
+      (this.getSchedulingWrites(action)?.length ?? 0) === 0;
+  }
+
+  private canAutomaticallyDebounce(action: Action): boolean {
+    if (this.noDebounce.get(action)) return false;
+    if (!this.effects.has(action)) return false;
+    return !this.isPullDemandRootEffect(action);
+  }
+
   private shouldRunFirstPullComputationInDemandContext(
     action: Action,
   ): boolean {
@@ -3570,12 +3600,10 @@ export class Scheduler {
    * Auto-debounce is enabled by default; use noDebounce to opt out.
    */
   private maybeAutoDebounce(action: Action): void {
-    // Check if action has opted out of auto-debounce
-    if (this.noDebounce.get(action)) return;
-
     // Auto-debouncing computations in push mode makes observable derived state
-    // lag behind writes. Keep auto-debounce for effects only.
-    if (!this.effects.has(action)) return;
+    // lag behind writes. Pull-mode demand roots are effects, but delaying them
+    // can leave a live renderer observing stale materialized data.
+    if (!this.canAutomaticallyDebounce(action)) return;
 
     // Check if already has a manual debounce set
     if (this.actionDebounce.has(action)) return;
@@ -4841,8 +4869,7 @@ export class Scheduler {
         } else {
           const activePullDemand = this.pullMode &&
             (this.computations.has(fn) ||
-              (this.effects.has(fn) &&
-                (this.getSchedulingWrites(fn)?.length ?? 0) === 0));
+              this.isPullDemandRootEffect(fn));
           if (activePullDemand) {
             this.activePullDemandActions.add(fn);
           }
@@ -4950,9 +4977,8 @@ export class Scheduler {
     if (this.pullMode && executeElapsed >= CYCLE_DEBOUNCE_THRESHOLD_MS) {
       for (const [action, runs] of this.runsThisExecute) {
         if (
-          this.effects.has(action) &&
-          runs >= CYCLE_DEBOUNCE_MIN_RUNS &&
-          !this.noDebounce.get(action)
+          this.canAutomaticallyDebounce(action) &&
+          runs >= CYCLE_DEBOUNCE_MIN_RUNS
         ) {
           // This action is cycling - apply adaptive debounce
           const adaptiveDelay = Math.round(

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -24,6 +24,14 @@ export interface SchedulerGraphNode {
   stats?: ActionStats;
   isDirty: boolean;
   isPending: boolean;
+  isDemanded?: boolean;
+  isLiveEffect?: boolean;
+  isPullDemandRoot?: boolean;
+  isConditionallyScheduled?: boolean;
+  isDebouncedWaiting?: boolean;
+  hasActiveDebounceTimer?: boolean;
+  nextDebounceRunInMs?: number;
+  nextEligibleRunInMs?: number;
   parentId?: string; // ID of parent action if this was created during parent's execution
   childCount?: number; // Number of child actions created during this action's execution
   preview?: string; // First ~200 chars of function body for hover tooltips

--- a/packages/runner/test/scheduler-pull.test.ts
+++ b/packages/runner/test/scheduler-pull.test.ts
@@ -80,8 +80,8 @@ describe("pull-based scheduling", () => {
     await storageManager?.close();
   });
 
-  it("should default to pull mode", () => {
-    expect(runtime.scheduler.isPullModeEnabled()).toBe(true);
+  it("should default to push mode", () => {
+    expect(runtime.scheduler.isPullModeEnabled()).toBe(false);
   });
 
   it("should dispatch schema-marked streams without a materialized stream marker", async () => {

--- a/packages/runner/test/scheduler-pull.test.ts
+++ b/packages/runner/test/scheduler-pull.test.ts
@@ -80,8 +80,8 @@ describe("pull-based scheduling", () => {
     await storageManager?.close();
   });
 
-  it("should default to push mode", () => {
-    expect(runtime.scheduler.isPullModeEnabled()).toBe(false);
+  it("should default to pull mode", () => {
+    expect(runtime.scheduler.isPullModeEnabled()).toBe(true);
   });
 
   it("should dispatch schema-marked streams without a materialized stream marker", async () => {

--- a/packages/runner/test/scheduler-timing.test.ts
+++ b/packages/runner/test/scheduler-timing.test.ts
@@ -348,7 +348,39 @@ describe("debounce and throttling", () => {
     expect(runtime.scheduler.getDebounce(computation)).toBeUndefined();
   });
 
-  it("should auto-debounce slow effects after threshold runs", () => {
+  it("should auto-debounce slow writeful effects after threshold runs", () => {
+    const output = runtime.getCell<number>(
+      space,
+      "auto-debounce-writeful-effect-output",
+      undefined,
+      tx,
+    );
+    const effect: Action = (actionTx) => {
+      output.withTx(actionTx).send(1);
+    };
+    runtime.scheduler.subscribe(effect, {
+      reads: [],
+      shallowReads: [],
+      writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
+    }, { isEffect: true });
+
+    const scheduler = runtime.scheduler as any;
+    scheduler.actionStats.set(scheduler.getActionId(effect), {
+      runCount: 3,
+      totalTime: 180,
+      averageTime: 60,
+      lastRunTime: 60,
+      lastRunTimestamp: performance.now(),
+    });
+
+    scheduler.maybeAutoDebounce(effect);
+
+    expect(runtime.scheduler.getDebounce(effect)).toBe(100);
+  });
+
+  it("should not auto-debounce write-less pull demand root effects", () => {
+    runtime.scheduler.enablePullMode();
+
     const effect: Action = () => {};
     runtime.scheduler.subscribe(effect, {
       reads: [],
@@ -367,7 +399,7 @@ describe("debounce and throttling", () => {
 
     scheduler.maybeAutoDebounce(effect);
 
-    expect(runtime.scheduler.getDebounce(effect)).toBe(100);
+    expect(runtime.scheduler.getDebounce(effect)).toBeUndefined();
   });
 
   it("should not auto-debounce fast actions", async () => {


### PR DESCRIPTION
## Summary

- Keep the pull scheduler opt-in; this PR no longer flips the runner default.
- Keep write-less pull demand-root effects out of automatic/cycle debounce so live render sinks can refresh stale pull-mode materialized state.
- Re-enable the rapid notebook regression that creates 7 notes through `Create Another` and asserts both the notebook counter and rendered chips reach 7.

## Bug

In pull mode, rapidly creating notes inside a notebook could leave rendered note chips behind the durable notebook count. The user-visible symptom was a notebook counter reaching 7 while only some of those notes rendered in the list.

The fix treats write-less live pull-demand effects as render demand roots. Those effects should pull stale data promptly, not be delayed by automatic debounce or cycle debounce. Pull mode remains disabled by default so the eventual flag flip can stay in its own PR.

## Validation

- `deno fmt --check packages/runner/src/scheduler.ts packages/runner/test/scheduler-pull.test.ts packages/runner/test/scheduler-timing.test.ts packages/patterns/integration/default-app.test.ts`
- `deno check packages/patterns/integration/default-app.test.ts packages/runner/src/scheduler.ts packages/runner/src/telemetry.ts packages/runner/test/scheduler-pull.test.ts packages/runner/test/scheduler-timing.test.ts`
- `deno test -A packages/runner/test/scheduler-pull.test.ts packages/runner/test/scheduler-timing.test.ts`
- `HEADLESS=1 PIPE_CONSOLE=1 deno task integration --port-offset=133 patterns default-app`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the runner’s pull scheduler opt-in and make live pull render sinks responsive by excluding write-less effects from auto and cycle debounce. Re-enables the rapid notebook regression to ensure all 7 notes render.

- **Bug Fixes**
  - Treat write-less pull demand-root effects as render demand roots; skip auto/cycle debounce so stale state refreshes promptly.
  - Expand scheduler telemetry with demand/debounce fields for better visibility and diagnostics.
  - Tests: re-enable the notebook rapid-create regression; add timing tests to ensure only writeful effects auto-debounce in pull mode.

<sup>Written for commit 36e6933397f178bd6bdbbbf53548cfaabb121688. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: step: patterns integration = 109s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-trusted-component-examples/process-examples.test.tsx = 13s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-spec-gallery/main.test.tsx = 20s

