### PR TITLE
perf(data-model): more bigint twos-complement encode/decode wins

### DIFF
--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -246,10 +246,23 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
   // large positive numbers but _not_ large negative numbers. The cross-over
   // point of this code was measured to be at 32 bytes for negative numbers.
   if (!negative || (bytes.length <= 32)) {
-    let result = negative ? -1n : 0n;
+    let result;
 
-    for (let i = 0; i < partials; i++) {
-      result = (result << 8n) | BigInt(bytes[i]!);
+    if (partials === 0) {
+      result = negative ? -1n : 0n;
+    } else if (partials <= 4) {
+      const partial = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
+      result = partial >> BigInt(32 - (partials * 8));
+    } else {
+      const partial1 = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
+      const partial2 = BigInt(
+        (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
+      ) & 0xffff_ffffn;
+      result = ((partial1 << 32n) | partial2) >> BigInt(64 - (partials * 8));
     }
 
     // Note: Over ~1024 bytes, benchmarks indicate there is a win to be had by

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -221,9 +221,18 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
       result = (result << 8n) | BigInt(bytes[i]!);
     }
 
+    // Note: Over ~1024 bytes, benchmarks indicate there is a win to be had by
+    // using a `DataView` to extract `uint64`s from `bytes`.
     for (let i = partials; i < bytes.length; i += 8) {
-      dv64Bytes.set(bytes.subarray(i, i + 8));
-      result = (result << 64n) | dv64View.getBigUint64(0, false);
+      const subResult1 = BigInt(
+        (bytes[i] << 24) | (bytes[i + 1] << 16) | (bytes[i + 2] << 8) |
+          bytes[i + 3],
+      ) & 0xffff_ffffn;
+      const subResult2 = BigInt(
+        (bytes[i + 4] << 24) | (bytes[i + 5] << 16) | (bytes[i + 6] << 8) |
+          bytes[i + 7],
+      ) & 0xffff_ffffn;
+      result = (result << 64n) | (subResult1 << 32n) | subResult2;
     }
 
     return result;
@@ -240,9 +249,15 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
     }
 
     for (let i = partials; i < bytes.length; i += 8) {
-      dv64Bytes.set(bytes.subarray(i, i + 8));
-      result = (result << 64n) |
-        (0xffff_ffff_ffff_ffffn ^ dv64View.getBigUint64(0, false));
+      const subResult1 = BigInt(
+        ~((bytes[i] << 24) | (bytes[i + 1] << 16) | (bytes[i + 2] << 8) |
+          bytes[i + 3]),
+      ) & 0xffff_ffffn;
+      const subResult2 = BigInt(
+        ~((bytes[i + 4] << 24) | (bytes[i + 5] << 16) | (bytes[i + 6] << 8) |
+          bytes[i + 7]),
+      ) & 0xffff_ffffn;
+      result = (result << 64n) | (subResult1 << 32n) | subResult2;
     }
 
     return ~result;

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -241,30 +241,33 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
   // Count of partial-`int64` bytes.
   const partials = bytes.length & 7;
 
+  let result;
+
+  // This calculates the high-order "partial" `int64`, if any. We waste a little
+  // bit of work in cases where the partial count isn't a multiple of `4`, but
+  // it's worth it for the simplicity (and is at worst negligible in time cost).
+  if (partials === 0) {
+    result = negative ? -1n : 0n;
+  } else if (partials <= 4) {
+    const partial = BigInt(
+      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+    );
+    result = partial >> BigInt(32 - (partials * 8));
+  } else {
+    const partial1 = BigInt(
+      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+    );
+    const partial2 = BigInt(
+      (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
+    ) & 0xffff_ffffn;
+    result = ((partial1 << 32n) | partial2) >> BigInt(64 - (partials * 8));
+  }
+
   // Possibly surprising test here: Benchmarks indicate that V8 (and assumed to
   // be similar in other JS VMs) has internal optimizations for left-shift on
   // large positive numbers but _not_ large negative numbers. The cross-over
   // point of this code was measured to be at 32 bytes for negative numbers.
   if (!negative || (bytes.length <= 32)) {
-    let result;
-
-    if (partials === 0) {
-      result = negative ? -1n : 0n;
-    } else if (partials <= 4) {
-      const partial = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-      );
-      result = partial >> BigInt(32 - (partials * 8));
-    } else {
-      const partial1 = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-      );
-      const partial2 = BigInt(
-        (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
-      ) & 0xffff_ffffn;
-      result = ((partial1 << 32n) | partial2) >> BigInt(64 - (partials * 8));
-    }
-
     // Note: Over ~1024 bytes, benchmarks indicate there is a win to be had by
     // using a `DataView` to extract `uint64`s from `bytes`.
     for (let i = partials; i < bytes.length; i += 8) {
@@ -284,13 +287,9 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
     // Negative and large enough to feel the pain of an unoptimized `bigint`
     // left shift. This uses uses a similar ones-complement trick as is done in
     // the encoder function, above, so that we operate on positive `bigint`s
-    // within the loops.
+    // within the loop.
 
-    let result = 0n;
-
-    for (let i = 0; i < partials; i++) {
-      result = (result << 8n) | BigInt(0xff ^ bytes[i]!);
-    }
+    result = ~result; // Because the `partials` calc made it negative.
 
     for (let i = partials; i < bytes.length; i += 8) {
       const subResult1 = BigInt(

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -176,6 +176,9 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
     throw new Error("bigintFromMinimalTwosComplement: empty input");
   }
 
+  // Note: `false` second argument to the `DataView.get*()` methods means
+  // "big-endian."
+
   // Determine sign from the high bit of the first byte.
   const negative = (bytes[0]! & 0x80) !== 0;
 
@@ -198,13 +201,13 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
       // Fast path for `bytes.length` in `2..8`.
       dv64Bytes.fill(negative ? 0xff : 0);
       dv64Bytes.set(bytes, 8 - bytes.length);
-      return dv64View.getBigInt64(0, false); // `false` means big-endian.
+      return dv64View.getBigInt64(0, false);
     }
   }
 
   // Slow path.
 
-  // Count of partial-int65 bytes.
+  // Count of partial-`int64` bytes.
   const partials = bytes.length & 7;
 
   // Possibly surprising test here: Benchmarks indicate that V8 (and assumed to
@@ -220,7 +223,7 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
 
     for (let i = partials; i < bytes.length; i += 8) {
       dv64Bytes.set(bytes.subarray(i, i + 8));
-      result = (result << 64n) | dv64View.getBigUint64(0, false); // `false` means big-endian.
+      result = (result << 64n) | dv64View.getBigUint64(0, false);
     }
 
     return result;
@@ -239,7 +242,7 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
     for (let i = partials; i < bytes.length; i += 8) {
       dv64Bytes.set(bytes.subarray(i, i + 8));
       result = (result << 64n) |
-        (0xffff_ffff_ffff_ffffn ^ dv64View.getBigUint64(0, false)); // `false` means big-endian.
+        (0xffff_ffff_ffff_ffffn ^ dv64View.getBigUint64(0, false));
     }
 
     return ~result;

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -95,16 +95,6 @@ function convertSmallValue(value: bigint, negative: boolean) {
 }
 
 /**
- * Cached result of `0n` as a `Uint8Array`.
- */
-const ZERO_BYTES = new Uint8Array([0x00]);
-
-/**
- * Cached result of `-1n` as a `Uint8Array`.
- */
-const NEGATIVE_ONE_BYTES = new Uint8Array([0xFF]);
-
-/**
  * Converts a bigint to its minimal two's-complement big-endian byte
  * representation. The encoding is the same one used by the hash
  * byte-level spec (Section 3.7).
@@ -118,8 +108,10 @@ const NEGATIVE_ONE_BYTES = new Uint8Array([0xFF]);
  */
 export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
   if (value >= 0n) {
-    if (value === 0n) {
-      return ZERO_BYTES.slice();
+    if (value <= 127n) {
+      const result = new Uint8Array(1);
+      result[0] = Number(value);
+      return result;
     } else if (value <= 0x7fff_ffff_ffff_ffffn) {
       return convertSmallValue(value, false);
     }
@@ -139,8 +131,10 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
 
     return bytes;
   } else {
-    if (value === -1n) {
-      return NEGATIVE_ONE_BYTES.slice();
+    if (value >= -128n) {
+      const result = new Uint8Array(1);
+      result[0] = Number(value);
+      return result;
     } else if (value >= -0x8000_0000_0000_0000n) {
       return convertSmallValue(value, true);
     }

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -186,24 +186,19 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
     return dv64View.getBigInt64(0, false); // `false` means big-endian.
   }
 
-  // Slow path. For negative numbers, this uses a similar ones-complement trick
-  // as is done in the encoder function, above.
+  // Slow path.
 
-  const byteMask = negative ? 0xff : 0x00;
-  const bigMask = negative ? 0xffff_ffff_ffff_ffffn : 0n;
   const partials = bytes.length & 7;
-
-  let result = 0n;
+  let result = negative ? -1n : 0n;
 
   for (let i = 0; i < partials; i++) {
-    result = (result << 8n) | BigInt(byteMask ^ bytes[i]!);
+    result = (result << 8n) | BigInt(bytes[i]!);
   }
 
   for (let i = partials; i < bytes.length; i += 8) {
     dv64Bytes.set(bytes.subarray(i, i + 8));
-    result = (result << 64n) |
-      (bigMask ^ dv64View.getBigUint64(0, false)); // `false` means big-endian.
+    result = (result << 64n) | dv64View.getBigUint64(0, false); // `false` means big-endian.
   }
 
-  return negative ? ~result : result;
+  return result;
 }

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -179,11 +179,27 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
   // Determine sign from the high bit of the first byte.
   const negative = (bytes[0]! & 0x80) !== 0;
 
-  if (bytes.length <= 8) {
-    // Fast path for `bytes.length <= 8`.
-    dv64Bytes.fill(negative ? 0xff : 0);
-    dv64Bytes.set(bytes, 8 - bytes.length);
-    return dv64View.getBigInt64(0, false); // `false` means big-endian.
+  switch (bytes.length) {
+    case 1: {
+      if (negative) {
+        return BigInt((bytes[0] << 24) >> 24); // Sign-extend.
+      } else {
+        return BigInt(bytes[0]);
+      }
+    }
+
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+    case 6:
+    case 7:
+    case 8: {
+      // Fast path for `bytes.length` in `2..8`.
+      dv64Bytes.fill(negative ? 0xff : 0);
+      dv64Bytes.set(bytes, 8 - bytes.length);
+      return dv64View.getBigInt64(0, false); // `false` means big-endian.
+    }
   }
 
   // Slow path.

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -204,17 +204,44 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
 
   // Slow path.
 
+  // Count of partial-int65 bytes.
   const partials = bytes.length & 7;
-  let result = negative ? -1n : 0n;
 
-  for (let i = 0; i < partials; i++) {
-    result = (result << 8n) | BigInt(bytes[i]!);
+  // Possibly surprising test here: Benchmarks indicate that V8 (and assumed to
+  // be similar in other JS VMs) has internal optimizations for left-shift on
+  // large positive numbers but _not_ large negative numbers. The cross-over
+  // point of this code was measured to be at 32 bytes for negative numbers.
+  if (!negative || (bytes.length <= 32)) {
+    let result = negative ? -1n : 0n;
+
+    for (let i = 0; i < partials; i++) {
+      result = (result << 8n) | BigInt(bytes[i]!);
+    }
+
+    for (let i = partials; i < bytes.length; i += 8) {
+      dv64Bytes.set(bytes.subarray(i, i + 8));
+      result = (result << 64n) | dv64View.getBigUint64(0, false); // `false` means big-endian.
+    }
+
+    return result;
+  } else {
+    // Negative and large enough to feel the pain of an unoptimized `bigint`
+    // left shift. This uses uses a similar ones-complement trick as is done in
+    // the encoder function, above, so that we operate on positive `bigint`s
+    // within the loops.
+
+    let result = 0n;
+
+    for (let i = 0; i < partials; i++) {
+      result = (result << 8n) | BigInt(0xff ^ bytes[i]!);
+    }
+
+    for (let i = partials; i < bytes.length; i += 8) {
+      dv64Bytes.set(bytes.subarray(i, i + 8));
+      result = (result << 64n) |
+        (0xffff_ffff_ffff_ffffn ^ dv64View.getBigUint64(0, false)); // `false` means big-endian.
+    }
+
+    return ~result;
   }
-
-  for (let i = partials; i < bytes.length; i += 8) {
-    dv64Bytes.set(bytes.subarray(i, i + 8));
-    result = (result << 64n) | dv64View.getBigUint64(0, false); // `false` means big-endian.
-  }
-
-  return result;
 }

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -266,8 +266,8 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
   // Possibly surprising test here: Benchmarks indicate that V8 (and assumed to
   // be similar in other JS VMs) has internal optimizations for left-shift on
   // large positive numbers but _not_ large negative numbers. The cross-over
-  // point of this code was measured to be at 32 bytes for negative numbers.
-  if (!negative || (bytes.length <= 32)) {
+  // point of this code was measured to be at 128 bytes for negative numbers.
+  if (!negative || (bytes.length <= 128)) {
     // Note: Over ~1024 bytes, benchmarks indicate there is a win to be had by
     // using a `DataView` to extract `uint64`s from `bytes`.
     for (let i = partials; i < bytes.length; i += 8) {

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -172,11 +172,11 @@ export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
  * the corresponding bigint. Empty input throws.
  */
 export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
-  if (bytes.length === 0) {
-    throw new Error("bigintFromMinimalTwosComplement: empty input");
-  }
-
   switch (bytes.length) {
+    case 0: {
+      throw new Error("bigintFromMinimalTwosComplement: empty input");
+    }
+
     case 1: {
       // `(x << 24) >> 24` to sign extend. Similar below.
       return BigInt((bytes[0] << 24) >> 24);
@@ -187,34 +187,48 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
     }
 
     case 3: {
-      return BigInt(((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8)) >> 8);
+      return BigInt(
+        ((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8)) >> 8,
+      );
     }
 
     case 4: {
-      return BigInt((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]);
+      return BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
     }
 
     case 5: {
-      const subResult1 = BigInt((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]);
+      const subResult1 = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
       const subResult2 = BigInt(bytes[4]);
       return (subResult1 << 8n) | subResult2;
     }
 
     case 6: {
-      const subResult1 = BigInt((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]);
+      const subResult1 = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
       const subResult2 = BigInt((bytes[4] << 8) | bytes[5]);
       return (subResult1 << 16n) | subResult2;
     }
 
     case 7: {
-      const subResult1 = BigInt((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]);
+      const subResult1 = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
       const subResult2 = BigInt((bytes[4] << 16) | (bytes[5] << 8) | bytes[6]);
       return (subResult1 << 24n) | subResult2;
     }
 
     case 8: {
-      const subResult1 = BigInt((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]);
-      const subResult2 = BigInt((bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7]) & 0xffff_ffffn;
+      const subResult1 = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
+      const subResult2 = BigInt(
+        (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
+      ) & 0xffff_ffffn;
       return (subResult1 << 32n) | subResult2;
     }
   }

--- a/packages/data-model/bigint-encoding.ts
+++ b/packages/data-model/bigint-encoding.ts
@@ -176,36 +176,53 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
     throw new Error("bigintFromMinimalTwosComplement: empty input");
   }
 
-  // Note: `false` second argument to the `DataView.get*()` methods means
-  // "big-endian."
-
-  // Determine sign from the high bit of the first byte.
-  const negative = (bytes[0]! & 0x80) !== 0;
-
   switch (bytes.length) {
     case 1: {
-      if (negative) {
-        return BigInt((bytes[0] << 24) >> 24); // Sign-extend.
-      } else {
-        return BigInt(bytes[0]);
-      }
+      // `(x << 24) >> 24` to sign extend. Similar below.
+      return BigInt((bytes[0] << 24) >> 24);
     }
 
-    case 2:
-    case 3:
-    case 4:
-    case 5:
-    case 6:
-    case 7:
+    case 2: {
+      return BigInt(((bytes[0] << 24) | (bytes[1] << 16)) >> 16);
+    }
+
+    case 3: {
+      return BigInt(((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8)) >> 8);
+    }
+
+    case 4: {
+      return BigInt((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]);
+    }
+
+    case 5: {
+      const subResult1 = BigInt((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]);
+      const subResult2 = BigInt(bytes[4]);
+      return (subResult1 << 8n) | subResult2;
+    }
+
+    case 6: {
+      const subResult1 = BigInt((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]);
+      const subResult2 = BigInt((bytes[4] << 8) | bytes[5]);
+      return (subResult1 << 16n) | subResult2;
+    }
+
+    case 7: {
+      const subResult1 = BigInt((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]);
+      const subResult2 = BigInt((bytes[4] << 16) | (bytes[5] << 8) | bytes[6]);
+      return (subResult1 << 24n) | subResult2;
+    }
+
     case 8: {
-      // Fast path for `bytes.length` in `2..8`.
-      dv64Bytes.fill(negative ? 0xff : 0);
-      dv64Bytes.set(bytes, 8 - bytes.length);
-      return dv64View.getBigInt64(0, false);
+      const subResult1 = BigInt((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]);
+      const subResult2 = BigInt((bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7]) & 0xffff_ffffn;
+      return (subResult1 << 32n) | subResult2;
     }
   }
 
   // Slow path.
+
+  // Determine sign from the high bit of the first byte.
+  const negative = (bytes[0]! & 0x80) !== 0;
 
   // Count of partial-`int64` bytes.
   const partials = bytes.length & 7;

--- a/packages/data-model/test/bigint-encoding.bench.ts
+++ b/packages/data-model/test/bigint-encoding.bench.ts
@@ -3,10 +3,12 @@
  *
  * Measures `bigintToMinimalTwosComplement()` and
  * `bigintFromMinimalTwosComplement()` across the full byte-length spectrum,
- * with separate positive/negative tracks. Sizes 1-32 sweep in single-byte
- * steps so the discontinuity at the 8-byte boundary is visible (both
- * directions switch from a `DataView.{set,get}BigUint64()` fast path to a
- * per-byte fallback there). Sizes 64..1024 sample the deep-fallback regime.
+ * with separate positive/negative tracks. Sizes 1-127 sweep in single-byte
+ * steps so several discontinuities are visible: the 8-byte fast-path boundary
+ * (both directions switch from a `DataView.{set,get}BigUint64()` fast path to
+ * a per-byte fallback) and the 32-byte large-negative-decoder crossover.
+ * Sizes 128, 256, 512 sample the deep-fallback regime; 1008..1039 brackets
+ * 1024 to expose `partials` cost (`bytes.length & 7`) at very large sizes.
  *
  * Each iteration of a benchmark function processes a fixed BATCH of values
  * pre-generated with a deterministic xorshift RNG, so JIT specialization on
@@ -34,45 +36,15 @@ import {
 
 const BATCH = 64;
 
-const BYTE_SIZES: readonly number[] = [
-  1,
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  8,
-  9,
-  10,
-  11,
-  12,
-  13,
-  14,
-  15,
-  16,
-  17,
-  18,
-  19,
-  20,
-  21,
-  22,
-  23,
-  24,
-  25,
-  26,
-  27,
-  28,
-  29,
-  30,
-  31,
-  32,
-  64,
-  128,
-  256,
-  512,
-  1024,
-];
+const BYTE_SIZES: readonly number[] = (() => {
+  const set = new Set<number>();
+  for (let i = 1; i <= 127; i++) set.add(i);
+  set.add(128);
+  set.add(256);
+  set.add(512);
+  for (let i = 1008; i <= 1039; i++) set.add(i);
+  return [...set].sort((a, b) => a - b);
+})();
 
 function makeRng(seed: number): () => number {
   let s = seed >>> 0;


### PR DESCRIPTION
## Summary

Follow-up perf work on `bigint-encoding.ts` after #3551:

- **Decode fast path (lengths 1..8):** custom per-length expression using `Number`-side shifts plus one or two `BigInt()` boxings, replacing the `DataView.fill + set + getBigInt64` round-trip.
- **Decode slow path (lengths >8):** replace the inner `DataView.getBigUint64` chunk read with two 32-bit `Number`-side packs converted to `BigInt`. The complement on the large-negative branch moves to the `Number` side too (`~(...)` before `BigInt(...)`), avoiding a per-chunk `BigInt` allocation.
- **Decode partials:** byte-loop replaced with a direct `Number`-side calculation, three-way split by `partials` count (0 / 1..4 / 5..7). The same calc seeds both slow-path branches.
- **Crossover threshold:** the small-or-positive vs large-negative split moved from `<= 32` to `<= 128`. With the new `Number`-shift main loop, the V8 negative-bigint-shift quirk only dominates around ~1024-bit bigints; below that, the XOR-trick path's per-iteration complement work is net overhead.
- **Encode 1B special case:** widened from just `0n`/`-1n` (cached `.slice()`) to the full single-byte range (`-128..127`) via a pre-allocated `Uint8Array(1)` + index assignment. Positive and negative now share the same code path.
- **Benchmark coverage:** extended `BYTE_SIZES` to sweep 1..127 in single-byte steps and add a 1008..1039 window around 1024, so partials-byte effects and the `bytes.length & 7` cycle are visible at both medium and large scales.

A note in the source flags one remaining open item: at >1024B, the `DataView`-based main loop is still slightly faster than the `Number`-shift version on the small-or-positive branch (~6% at 1024B, ~14% at 1039B). Not addressed here.

## Perf

Headline sizes, times per 64-op batch (so divide by 64 for per-op). Both runs are on the same M5 Pro under Deno 2.7.8. "this PR" = the committed branch state.

| op | size | main | this PR | change |
|---|---|---:|---:|---:|
| decode positive | 1B | 1.50 µs | 229 ns | **6.54× faster** |
| decode positive | 2B | 919 ns | 232 ns | **3.96× faster** |
| decode positive | 4B | 954 ns | 249 ns | **3.84× faster** |
| decode positive | 8B | 936 ns | 614 ns | **1.53× faster** |
| decode positive | 16B | 3.60 µs | 2.10 µs | **1.71× faster** |
| decode positive | 32B | 7.60 µs | 4.50 µs | **1.69× faster** |
| decode positive | 64B | 15.90 µs | 10.00 µs | **1.59× faster** |
| decode positive | 128B | 34.60 µs | 22.80 µs | **1.52× faster** |
| decode positive | 256B | 76.10 µs | 54.30 µs | **1.40× faster** |
| decode positive | 512B | 154.70 µs | 122.50 µs | **1.26× faster** |
| decode positive | 1024B | 348.20 µs | 350.80 µs | 1.01× slower |
| decode negative | 1B | 914 ns | 230 ns | **3.98× faster** |
| decode negative | 2B | 908 ns | 232 ns | **3.92× faster** |
| decode negative | 4B | 941 ns | 250 ns | **3.77× faster** |
| decode negative | 8B | 925 ns | 591 ns | **1.56× faster** |
| decode negative | 16B | 4.50 µs | 2.60 µs | **1.73× faster** |
| decode negative | 32B | 8.80 µs | 5.10 µs | **1.73× faster** |
| decode negative | 64B | 18.10 µs | 10.60 µs | **1.71× faster** |
| decode negative | 128B | 38.20 µs | 24.50 µs | **1.56× faster** |
| decode negative | 256B | 81.80 µs | 55.50 µs | **1.47× faster** |
| decode negative | 512B | 167.80 µs | 124.00 µs | **1.35× faster** |
| decode negative | 1024B | 377.80 µs | 335.60 µs | **1.13× faster** |
| encode positive | 1B | 6.70 µs | 6.30 µs | **1.06× faster** |
| encode positive | 16B | 12.90 µs | 12.40 µs | **1.04× faster** |
| encode positive | 64B | 20.70 µs | 20.40 µs | 1.01× faster |
| encode positive | 256B | 54.50 µs | 54.90 µs | 1.01× slower |
| encode positive | 1024B | 267.00 µs | 290.90 µs | 1.09× slower (likely noise) |
| encode negative | 1B | 6.90 µs | 6.30 µs | **1.10× faster** |
| encode negative | 16B | 13.50 µs | 13.00 µs | **1.04× faster** |
| encode negative | 64B | 22.60 µs | 20.60 µs | **1.10× faster** |
| encode negative | 128B | 35.10 µs | 31.10 µs | **1.13× faster** |
| encode negative | 256B | 62.40 µs | 53.90 µs | **1.16× faster** |
| encode negative | 512B | 138.30 µs | 125.60 µs | **1.10× faster** |
| encode negative | 1024B | 322.20 µs | 334.40 µs | 1.04× slower (likely noise) |

Only the 1B encode path was changed in this PR; the consistent improvements visible in `encode negative` 16–512B (a steady ~10–16%) are most likely run-to-run drift rather than a real effect, since no code on those paths was touched — though the consistency across adjacent sizes is unusual. Worth a confirmation re-run before relying on those numbers. The two "slower" cells at 1024B are within the ~±5–7% run-to-run noise we've measured previously at that magnitude.

## Test plan

- [ ] CI green (existing `bigint-encoding.test.ts` covers both polarities and the boundary lengths around the fast/slow path).
- [ ] Re-run the bench locally and confirm the headline wins on a fresh machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves two’s‑complement bigint encode/decode performance in `data-model`, with number-side paths that make small decodes up to 6.5× faster and deliver steady wins up to 512B.

- **Performance**
  - Decode: added per-length (1–8B) number-shift fast paths and number-side 2×32‑bit chunking for >8B; reduces BigInt allocations and moves complement to number ops.
  - Results: decodes are ~3.8–6.5× faster at 1–4B, ~1.5× at 8B, and ~1.3–1.7× at 16–512B; 1024B is neutral for positives and ~1.13× faster for negatives.
  - Crossover: moved large-negative split to ≤128B to avoid V8 negative-shift costs.
  - Encode/bench: single-byte encode now covers −128..127 via a 1B buffer (removes `0n`/`-1n` special cases). Bench sweep expanded to 1–127 and 1008–1039 to expose partials and large-size effects.

<sup>Written for commit b4f0e60c658fdb0aa9e071434a76fc415cf8530e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

