### PR TITLE
chore(claude-hooks): drop auto-fmt from post-edit; rely on pre-commit

### DIFF
--- a/.claude/scripts/post-edit-ts.ts
+++ b/.claude/scripts/post-edit-ts.ts
@@ -4,8 +4,13 @@
  *
  * Claude Code Post-Tool hook for Write|Edit.
  * - Runs `deno check <file>` on TypeScript files after editing.
- * - Runs `deno fmt <file>` to auto-format.
  * - Reports type errors via exit code 2.
+ *
+ * Formatting (`deno fmt`) is deliberately NOT run here — it ran on every
+ * Edit/Write and produced noisy "file was modified by a formatter"
+ * notifications that interrupt iteration. Formatting now lives in the
+ * git pre-commit hook (`.githooks/pre-commit`); install via
+ * `scripts/install-git-hooks.sh`.
  */
 
 const rawInput = await new Response(Deno.stdin.readable).text();
@@ -47,13 +52,5 @@ if (!checkResult.success) {
   // Exit 0 to allow incremental changes - errors are shown but don't block
   Deno.exit(0);
 }
-
-// Auto-format the file (non-blocking - we don't fail on format issues)
-const fmt = new Deno.Command("deno", {
-  args: ["fmt", filePath],
-  stdout: "piped",
-  stderr: "piped",
-});
-await fmt.output();
 
 Deno.exit(0);


### PR DESCRIPTION
## Summary

Removes the `deno fmt <file>` step from `.claude/scripts/post-edit-ts.ts` (the Claude Code Write|Edit PostTool hook). The repo already runs `deno fmt` (+ `deno lint`) on staged files via `.githooks/pre-commit`, so the per-edit pass was redundant.

## Why

The per-edit `deno fmt` produced a stream of "file was modified by a formatter" notifications during AI-assisted iteration. Each notification interrupted the flow and occasionally raced against the next edit, forcing a re-read of the file. Moving formatting to the pre-commit hook gives the same correctness guarantee on what lands in git history, without the noise mid-iteration.

## What stays the same

- `deno check <file>` still runs after every Write/Edit (fast, doesn't mutate files).
- `.githooks/pre-commit` continues to run `deno fmt` + `deno lint` on staged files.
- Anyone who hasn't run `scripts/install-git-hooks.sh` in their clone won't get pre-commit coverage — same as before.

## Test plan

- [x] `deno check .claude/scripts/post-edit-ts.ts` passes locally.
- [x] Pre-commit hook ran on this commit (visible in commit output).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the per-edit `deno fmt` step from `.claude/scripts/post-edit-ts.ts` to stop noisy formatter notifications during iterative edits. Formatting now runs in the pre-commit hook (`.githooks/pre-commit` via `scripts/install-git-hooks.sh`); `deno check` still runs after edits.

<sup>Written for commit 24ed47fe99477cc3aa93b0e6ffc3092414238099. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

