### PR TITLE
ci: show Estuary deploy ref in run title

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,5 +1,7 @@
 name: Manual Production Deployment
 
+run-name: Deploy ${{ inputs.ref }} to Estuary
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- Add a `run-name` to the manual Estuary production deployment workflow so the requested deploy ref is visible in the Actions run/review title.
- This makes Loom-triggered deploys show the SHA/tag being deployed before the protected `estuary` job starts.

## Verification
- Parsed `.github/workflows/deploy-production.yml` with Ruby YAML.
- Confirmed the workflow currently requires `workflow_dispatch.inputs.ref`; dispatching without a ref is not valid for this workflow.

## Notes
- The existing checkout/resolve/deploy behavior is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the requested deploy ref in the GitHub Actions run title for manual Estuary production deploys. Adds `run-name: Deploy ${{ inputs.ref }} to Estuary` to `.github/workflows/deploy-production.yml`; behavior unchanged.

<sup>Written for commit 002a168269f000346a80c589993211986f78bc98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

