### PR TITLE
Remove the unified JSON flag

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -10,7 +10,6 @@ affecting users who haven't opted in.
 | Flag | Env Var | Description |
 |------|---------|-------------|
 | `modernDataModel` | `EXPERIMENTAL_MODERN_DATA_MODEL` | Enables the new fabric value type system (`bigint`, `Map`, `Set`, `Uint8Array`, `Date`, `FabricInstance`). |
-| `unifiedJsonEncoding` | `EXPERIMENTAL_UNIFIED_JSON_ENCODING` | Enables a unified JSON encoding scheme for all fabric values. |
 
 All flags default to `undefined` which means they take on the default value
 defined for the flag. The default is generally `false` unless the flag is in the
@@ -26,11 +25,11 @@ and when **running the server** (for server-side flags):
 
 ```bash
 # Enable a single flag (build + run)
-EXPERIMENTAL_MODERN_DATA_MODEL=true deno task dev
+EXPERIMENTAL_SOME_FLAG=true deno task dev
 
 # Enable multiple flags
-EXPERIMENTAL_MODERN_DATA_MODEL=true \
-EXPERIMENTAL_UNIFIED_JSON_ENCODING=true \
+EXPERIMENTAL_SOME_FLAG=true \
+EXPERIMENTAL_SOME_OTHER_FLAG=true \
 deno task dev
 ```
 
@@ -97,9 +96,6 @@ Browser Web Worker
               +-- setDataModelConfig(true)
               |    +-- modernDataModelEnabled = true
               |         +-- fabricFromNativeValue() checks modernDataModelEnabled
-              +-- setUnifiedJsonEncoding(...)
-                   +-- unifiedJsonEncoding = true
-                        +-- jsonFromValue() (etc.) dispatches to modern path
 ```
 
 Key points:
@@ -138,7 +134,7 @@ When any experimental flags are enabled, the `Runtime` constructor logs them on
 startup. Look for a line like:
 
 ```
-Experimental flags enabled: modernDataModel, unifiedJsonEncoding
+Experimental flags enabled: someFlag, someOtherFlag
 ```
 
 - **Server-side (toolshed):** Check `packages/toolshed/local-dev-toolshed.log`.
@@ -170,9 +166,7 @@ with defaults (all `false`) and stores the resolved result as
 
 The memory layer uses module-level ambient config variables:
 `modernDataModelEnabled` in `packages/data-model/fabric-value.ts` (set by
-`setDataModelConfig()`), and
-`unifiedJsonEncoding` in `packages/data-model/json-encoding.ts` (set by
-`setJsonEncodingConfig()`). This means:
+`setDataModelConfig()`). This means:
 
 - Only one set of experimental flags is active per JavaScript context at a time.
 - In the browser, the Web Worker is a separate JS context, so its flags are

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -18,10 +18,8 @@ experimental behavior (if it happened to be on by default).
 ## Defining a new flag
 
 Unfortunately, there is no single unified "source of truth" for the set of
-flags. As a stop-gap there is a "dummy" flag called `pancakeTelephony` /
-`EXPERIMENTAL_PANCAKE_TELEPHONY`. If you search the codebase for these, then
-you'll find everywhere where code needs to change in order to accommodate a
-new flag.
+flags. You pretty much need to search the codebase for an existing flag, and
+tweak all the spots that turn up.
 
 ## Enabling Flags Locally
 

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -1,9 +1,7 @@
 # Experimental Options
 
 `ExperimentalOptions` are feature flags that gate incremental rollout of
-space-model data-layer changes. Each flag independently enables a piece of the
-new fabric-value pipeline so features can be activated one at a time without
-affecting users who haven't opted in.
+various major features.
 
 ## Available Flags
 
@@ -16,6 +14,14 @@ defined for the flag. The default is generally `false` unless the flag is in the
 process of being "graduated." Setting any flag to `true` activates the
 corresponding experimental behavior, and setting it to `false` suppresses the
 experimental behavior (if it happened to be on by default).
+
+## Defining a new flag
+
+Unfortunately, there is no single unified "source of truth" for the set of
+flags. As a stop-gap there is a "dummy" flag called `pancakeTelephony` /
+`EXPERIMENTAL_PANCAKE_TELEPHONY`. If you search the codebase for these, then
+you'll find everywhere where code needs to change in order to accommodate a
+new flag.
 
 ## Enabling Flags Locally
 

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -47,8 +47,7 @@ The client MUST declare its protocol version in the first WebSocket message:
   "type": "hello",
   "protocol": "memory/v2",
   "flags": {
-    "richStorableValues": true,
-    "unifiedJsonEncoding": true
+    "richStorableValues": true // a/k/a `modernDataModel`
   }
 }
 ```
@@ -60,8 +59,7 @@ If the server accepts the protocol, it returns:
   "type": "hello.ok",
   "protocol": "memory/v2",
   "flags": {
-    "richStorableValues": true,
-    "unifiedJsonEncoding": true
+    "richStorableValues": true // a/k/a `modernDataModel`
   }
 }
 ```
@@ -139,8 +137,7 @@ interface HelloMessage {
   type: "hello";
   protocol: "memory/v2";
   flags: {
-    richStorableValues: boolean;
-    unifiedJsonEncoding: boolean;
+    richStorableValues: boolean; // a/k/a `modernDataModel`
   };
 }
 

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -47,7 +47,7 @@ The client MUST declare its protocol version in the first WebSocket message:
   "type": "hello",
   "protocol": "memory/v2",
   "flags": {
-    "richStorableValues": true // a/k/a `modernDataModel`
+    "richStorableValues": true
   }
 }
 ```
@@ -59,7 +59,7 @@ If the server accepts the protocol, it returns:
   "type": "hello.ok",
   "protocol": "memory/v2",
   "flags": {
-    "richStorableValues": true // a/k/a `modernDataModel`
+    "richStorableValues": true
   }
 }
 ```

--- a/packages/background-charm-service/src/env.ts
+++ b/packages/background-charm-service/src/env.ts
@@ -38,13 +38,12 @@ const envSchema = z.object({
   // Toolshed configuration
   API_URL: z.string().default("http://localhost:8000"),
 
-  // Experimental space-model feature flags (see ExperimentalOptions in runner)
-  // Note: We intentionally avoid z.coerce.boolean() here. Zod's coerce uses
-  // Boolean(), which treats any non-empty string as truthy -- so setting an
-  // env var to "false" would incorrectly enable the flag. The other boolean
-  // env vars in this file have the same latent bug.
+  // Experimental feature flags. See `ExperimentalOptions` in `runner`.
+  // Note: We intentionally avoid `z.coerce.boolean()` here. Zod's coerce uses
+  // `Boolean()`, which treats any non-empty string as truthy -- so setting an
+  // env var to the string `"false"` would incorrectly enable the flag. The
+  // other boolean env vars in this file have the same latent bug.
   EXPERIMENTAL_MODERN_DATA_MODEL: flagValue(),
-  EXPERIMENTAL_UNIFIED_JSON_ENCODING: flagValue(),
   // Background Charm Service: default is public space "toolshed-system"
   //SERVICE_DID: z.string().default(
   //  "did:key:z6Mkfuw7h6jDwqVb6wimYGys14JFcyTem4Kqvdj9DjpFhY88",

--- a/packages/background-charm-service/src/main.ts
+++ b/packages/background-charm-service/src/main.ts
@@ -33,7 +33,6 @@ const runtime = new Runtime({
   }),
   experimental: {
     modernDataModel: env.EXPERIMENTAL_MODERN_DATA_MODEL,
-    unifiedJsonEncoding: env.EXPERIMENTAL_UNIFIED_JSON_ENCODING,
   },
 });
 const service = new BackgroundCharmService({

--- a/packages/background-charm-service/src/worker-controller.ts
+++ b/packages/background-charm-service/src/worker-controller.ts
@@ -26,7 +26,6 @@ export interface WorkerOptions {
   timeoutMs?: number;
   experimental?: {
     modernDataModel?: boolean;
-    unifiedJsonEncoding?: boolean;
   };
 }
 

--- a/packages/background-charm-service/src/worker-ipc.ts
+++ b/packages/background-charm-service/src/worker-ipc.ts
@@ -13,7 +13,6 @@ export type InitializationData = {
   rawIdentity: KeyPairRaw;
   experimental?: {
     modernDataModel?: boolean;
-    unifiedJsonEncoding?: boolean;
   };
 };
 

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -26,7 +26,6 @@ export function experimentalOptionsFromEnv(): ExperimentalOptions {
   };
   const opts: ExperimentalOptions = {
     modernDataModel: read("EXPERIMENTAL_MODERN_DATA_MODEL"),
-    unifiedJsonEncoding: read("EXPERIMENTAL_UNIFIED_JSON_ENCODING"),
   };
 
   // Log any overridden experimental flags.

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -1621,7 +1621,6 @@ Deno.test("memory v2 client rejects hello.ok when flags disagree", async () => {
           protocol: MEMORY_PROTOCOL,
           flags: {
             richStorableValues: !getMemoryProtocolFlags().richStorableValues,
-            unifiedJsonEncoding: getMemoryProtocolFlags().unifiedJsonEncoding,
           },
         }));
       }

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -559,7 +559,6 @@ Deno.test("memory v2 server rejects handshakes when flags disagree", async () =>
       protocol: MEMORY_PROTOCOL,
       flags: {
         richStorableValues: !HELLO_FLAGS.richStorableValues,
-        unifiedJsonEncoding: HELLO_FLAGS.unifiedJsonEncoding,
       },
     }));
 
@@ -571,7 +570,6 @@ Deno.test("memory v2 server rejects handshakes when flags disagree", async () =>
         message: `memory flag mismatch: client=${
           JSON.stringify({
             richStorableValues: !HELLO_FLAGS.richStorableValues,
-            unifiedJsonEncoding: HELLO_FLAGS.unifiedJsonEncoding,
           })
         } server=${JSON.stringify(HELLO_FLAGS)}`,
       },

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -1,13 +1,9 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { afterEach, describe, it } from "@std/testing/bdd";
 import { assert, assertEquals, assertFalse } from "@std/assert";
 import {
   resetDataModelConfig,
   setDataModelConfig,
 } from "@commonfabric/data-model/fabric-value";
-import {
-  resetJsonEncodingConfig,
-  setJsonEncodingConfig,
-} from "@commonfabric/data-model/json-encoding";
 import {
   decodeMemoryBoundary,
   DEFAULT_BRANCH,
@@ -111,24 +107,19 @@ describe("memory v2 source links", () => {
 describe("memory v2 flags", () => {
   it("reflects the active runtime storage flags", () => {
     resetDataModelConfig();
-    resetJsonEncodingConfig();
-
     setDataModelConfig(false);
-    setJsonEncodingConfig(false);
 
     assertEquals(getMemoryProtocolFlags(), {
       richStorableValues: false,
     });
 
     setDataModelConfig(true);
-    setJsonEncodingConfig(true);
 
     assertEquals(getMemoryProtocolFlags(), {
       richStorableValues: true,
     });
 
     resetDataModelConfig();
-    resetJsonEncodingConfig();
   });
 });
 
@@ -136,80 +127,40 @@ describe("memory v2 flags", () => {
 // Boundary encode/decode dispatch test (explicitly tests OFF and ON paths)
 // ---------------------------------------------------------------------------
 
-describe("memory v2 boundary encoding dispatch", () => {
-  it("follows unified JSON dispatch", () => {
-    const document = {
-      value: {
-        present: 1,
-        missing: undefined,
-      },
-    };
-
-    setJsonEncodingConfig(false);
-    const legacyEncoded = encodeMemoryBoundary(document);
-    assertEquals(legacyEncoded, JSON.stringify({ value: { present: 1 } }));
-    assertEquals(decodeMemoryBoundary(legacyEncoded), {
-      value: { present: 1 },
-    });
-
-    setJsonEncodingConfig(true);
-    const unifiedEncoded = encodeMemoryBoundary(document);
-    assertEquals(
-      decodeMemoryBoundary(unifiedEncoded),
-      document,
-    );
-
-    resetJsonEncodingConfig();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Per-flag-state tests — run for both flag=false and flag=true
-// ---------------------------------------------------------------------------
-
 describe("memory v2 boundary decode", () => {
   afterEach(() => {
     resetDataModelConfig();
-    resetJsonEncodingConfig();
   });
 
-  for (const unifiedJsonEncoding of [false, true]) {
-    describe(`with \`unifiedJsonEncoding = ${unifiedJsonEncoding}\``, () => {
-      beforeEach(() => {
-        setJsonEncodingConfig(unifiedJsonEncoding);
-      });
-
-      it("returns mutable plain JSON trees", () => {
-        const decoded = decodeMemoryBoundary<{
-          value: {
-            nested: {
-              count: number;
-            };
-          };
-        }>(
-          encodeMemoryBoundary({
-            value: {
-              nested: {
-                count: 1,
-              },
-            },
-          }),
-        );
-
-        assertEquals(decoded, {
-          value: {
-            nested: {
-              count: 1,
-            },
+  it("returns mutable plain JSON trees", () => {
+    const decoded = decodeMemoryBoundary<{
+      value: {
+        nested: {
+          count: number;
+        };
+      };
+    }>(
+      encodeMemoryBoundary({
+        value: {
+          nested: {
+            count: 1,
           },
-        });
-        assertFalse(Object.isFrozen(decoded));
-        assertFalse(Object.isFrozen(decoded.value));
-        assertFalse(Object.isFrozen(decoded.value.nested));
+        },
+      }),
+    );
 
-        decoded.value.nested.count = 2;
-        assertEquals(decoded.value.nested.count, 2);
-      });
+    assertEquals(decoded, {
+      value: {
+        nested: {
+          count: 1,
+        },
+      },
     });
-  }
+    assertFalse(Object.isFrozen(decoded));
+    assertFalse(Object.isFrozen(decoded.value));
+    assertFalse(Object.isFrozen(decoded.value.nested));
+
+    decoded.value.nested.count = 2;
+    assertEquals(decoded.value.nested.count, 2);
+  });
 });

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -118,7 +118,6 @@ describe("memory v2 flags", () => {
 
     assertEquals(getMemoryProtocolFlags(), {
       richStorableValues: false,
-      unifiedJsonEncoding: false,
     });
 
     setDataModelConfig(true);
@@ -126,7 +125,6 @@ describe("memory v2 flags", () => {
 
     assertEquals(getMemoryProtocolFlags(), {
       richStorableValues: true,
-      unifiedJsonEncoding: true,
     });
 
     resetDataModelConfig();

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -141,7 +141,6 @@ export interface SessionOpenResult {
 
 export interface MemoryProtocolFlags {
   richStorableValues: boolean;
-  unifiedJsonEncoding: boolean;
 }
 
 export interface HelloMessage {
@@ -345,15 +344,12 @@ const memoryReconstructionContext: ReconstructionContext = {
 
 export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   richStorableValues: getDataModelConfig(),
-  unifiedJsonEncoding: getJsonEncodingConfig(),
 });
 
 export const sameMemoryProtocolFlags = (
   left: MemoryProtocolFlags,
   right: MemoryProtocolFlags,
-): boolean =>
-  left.richStorableValues === right.richStorableValues &&
-  left.unifiedJsonEncoding === right.unifiedJsonEncoding;
+): boolean => left.richStorableValues === right.richStorableValues;
 
 export const isMemoryProtocolFlags = (
   value: unknown,
@@ -362,8 +358,7 @@ export const isMemoryProtocolFlags = (
     return false;
   }
 
-  return typeof value.richStorableValues === "boolean" &&
-    typeof value.unifiedJsonEncoding === "boolean";
+  return typeof value.richStorableValues === "boolean";
 };
 
 export const encodeMemoryBoundary = (value: unknown): string =>

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -18,10 +18,6 @@ import {
   resetDataModelConfig,
   setDataModelConfig,
 } from "@commonfabric/data-model/fabric-value";
-import {
-  resetJsonEncodingConfig,
-  setJsonEncodingConfig,
-} from "@commonfabric/data-model/json-encoding";
 import { PatternEnvironment, setPatternEnvironment } from "./builder/env.ts";
 import { AsyncSemaphoreQueue, type QueueConfig } from "./queue.ts";
 import type {
@@ -150,8 +146,6 @@ export interface ExperimentalOptions {
   modernDataModel?: boolean | undefined;
   /** Backward-compat alias for `modernDataModel`. */
   richStorableValues?: boolean | undefined;
-  /** Enable `/<Type>@<Version>` JSON encoding, replacing legacy sigil/`@`-prefix/`$`-prefix conventions. */
-  unifiedJsonEncoding?: boolean | undefined;
   /** Preserve cumulative scheduler write history instead of using current-known writes. */
   schedulerHistoricalMightWrite?: boolean | undefined;
 }
@@ -291,7 +285,6 @@ export class Runtime {
     this.experimental = {
       modernDataModel: undefined,
       richStorableValues: undefined,
-      unifiedJsonEncoding: undefined,
       schedulerHistoricalMightWrite: undefined,
       ...options.experimental,
     };
@@ -314,9 +307,9 @@ export class Runtime {
       );
     }
 
-    // Propagate experimental flags to the memory layer's ambient config.
+    // Propagate experimental flags to their ambient control points.
     setDataModelConfig(this.experimental.modernDataModel);
-    setJsonEncodingConfig(this.experimental.unifiedJsonEncoding);
+
     this.id = options.storageManager.id;
     this.apiUrl = new URL(options.apiUrl);
     this.staticCache = isDeno()
@@ -486,9 +479,8 @@ export class Runtime {
     // Dispose the Engine (clears compiler/runtime state and the console hook)
     this.harness.dispose();
 
-    // Reset experimental fabric config to defaults
+    // Reset experimental config to defaults.
     resetDataModelConfig();
-    resetJsonEncodingConfig();
 
     // Clear the current runtime reference
     // Removed setCurrentRuntime call - no longer using singleton pattern

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -1042,12 +1042,11 @@ describe("Cell raw methods: frozen-or-not (richStorableValues ON)", () => {
   });
 });
 
-// Source-cell round-trip across commit + fresh-tx reload, parameterized over
-// `unifiedJsonEncoding` flag state. These tests assert end-to-end correctness
-// of the standard `setSourceCell` → commit → `getSourceCell` round-trip:
-// the round-trip preserves the source-link object, and a raw `tx.read` of
-// `path: ["source"]` returns it as an object link record (with own-property
-// `"/"`), never as a string.
+// Source-cell round-trip across commit + fresh-tx reload. These tests assert
+// end-to-end correctness of the standard `setSourceCell` → commit →
+// `getSourceCell` round-trip: the round-trip preserves the source-link object,
+// and a raw `tx.read` of `path: ["source"]` returns it as an object link record
+// (with own-property `"/"`), never as a string.
 //
 // Historical context: these tests were authored alongside the deletion of
 // two defensive `JSON.parse` blocks that previously existed in
@@ -1066,122 +1065,114 @@ describe("Cell raw methods: frozen-or-not (richStorableValues ON)", () => {
 // deletion.
 //
 // The tests below pin the round-trip behavior that, post-deletion, is the
-// observable contract — and that, pre-deletion, was being maintained
-// gratuitously by the now-removed parses. They serve as a passive
-// regression net for any future change that might re-introduce a
-// non-object value at `path: ["source"]`.
+// observable contract. They serve as a passive regression net for any future
+// change that might re-introduce a non-object value at `path: ["source"]`.
 //
 // See `coordination/docs/2026-04-30-fvj1-parse-site-kickoff.md` (project
 // kickoff doc, session 2026-067) for the full liveness analysis.
-for (const unifiedJsonEncoding of [false, true]) {
-  describe(
-    `Cell source-cell round-trip with \`unifiedJsonEncoding = ${unifiedJsonEncoding}\``,
-    () => {
-      let runtime: Runtime;
-      let storageManager: ReturnType<typeof StorageManager.emulate>;
-      let tx: IExtendedStorageTransaction;
+describe(`Cell source-cell round-trip`, () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
 
-      beforeEach(() => {
-        storageManager = StorageManager.emulate({ as: signer });
-        runtime = new Runtime({
-          apiUrl: new URL(import.meta.url),
-          storageManager,
-          experimental: { unifiedJsonEncoding },
-        });
-        tx = runtime.edit();
-      });
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
 
-      afterEach(async () => {
-        await runtime?.dispose();
-        await storageManager?.close();
-      });
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
 
-      it(
-        "setSourceCell + commit + getSourceCell round-trips correctly across a fresh tx",
-        async () => {
-          // Set up a source/target pair via the standard API.
-          const sourceCell = runtime.getCell<{ foo: number }>(
-            space,
-            "fvj1 source-cell round-trip: source",
-            undefined,
-            tx,
-          );
-          sourceCell.set({ foo: 123 });
-
-          const targetCell = runtime.getCell<{ bar: string }>(
-            space,
-            "fvj1 source-cell round-trip: target",
-            undefined,
-            tx,
-          );
-          targetCell.set({ bar: "baz" });
-          targetCell.setSourceCell(sourceCell);
-
-          // Commit, then start a fresh tx. This forces the `path: ["source"]`
-          // read to go through the storage layer (rather than the in-tx
-          // novelty cache, which short-circuits serialization), so
-          // `valueFromJson` runs as the actual decode step.
-          await tx.commit();
-          tx = runtime.edit();
-
-          // Fresh-tx getSourceCell: reads `path: ["source"]` through the
-          // storage layer, where `valueFromJson` decodes the row to an
-          // object before it surfaces here. `getSourceCell` then takes its
-          // `isRecord` branch and converts the link record to a URI string.
-          const retrievedSource = targetCell.withTx(tx).getSourceCell();
-          expect(isCell(retrievedSource)).toBe(true);
-          expect(retrievedSource?.withTx(tx).get()).toEqual({ foo: 123 });
-        },
+  it(
+    "setSourceCell + commit + getSourceCell round-trips correctly across a fresh tx",
+    async () => {
+      // Set up a source/target pair via the standard API.
+      const sourceCell = runtime.getCell<{ foo: number }>(
+        space,
+        "fvj1 source-cell round-trip: source",
+        undefined,
+        tx,
       );
+      sourceCell.set({ foo: 123 });
 
-      it(
-        "raw read of path: ['source'] returns an object link record",
-        async () => {
-          // Set up a source/target pair and commit.
-          const sourceCell = runtime.getCell<{ foo: number }>(
-            space,
-            "fvj1 source-cell raw read: source",
-            undefined,
-            tx,
-          );
-          sourceCell.set({ foo: 123 });
-
-          const targetCell = runtime.getCell<{ bar: string }>(
-            space,
-            "fvj1 source-cell raw read: target",
-            undefined,
-            tx,
-          );
-          targetCell.set({ bar: "baz" });
-          targetCell.setSourceCell(sourceCell);
-
-          await tx.commit();
-          tx = runtime.edit();
-
-          // Raw read of `path: ["source"]` exercises the same storage-layer
-          // code path as `getSourceCell`'s underlying `readOrThrow`. The
-          // value the storage layer surfaces should be an object link
-          // record (with own-property `"/"`), never a JSON-stringified
-          // form, under both flag states.
-          const targetLink = targetCell.getAsNormalizedFullLink();
-          const sourceAddress = {
-            space,
-            id: targetLink.id,
-            path: ["source"],
-          } as IMemorySpaceAddress;
-          const readResult = tx.read(sourceAddress);
-          expect(readResult.ok).toBeDefined();
-
-          const value = readResult.ok!.value;
-          expect(typeof value).not.toBe("string");
-          expect(typeof value).toBe("object");
-          expect(value).not.toBeNull();
-          expect(Object.prototype.hasOwnProperty.call(value, "/")).toBe(true);
-        },
+      const targetCell = runtime.getCell<{ bar: string }>(
+        space,
+        "fvj1 source-cell round-trip: target",
+        undefined,
+        tx,
       );
+      targetCell.set({ bar: "baz" });
+      targetCell.setSourceCell(sourceCell);
+
+      // Commit, then start a fresh tx. This forces the `path: ["source"]`
+      // read to go through the storage layer (rather than the in-tx
+      // novelty cache, which short-circuits serialization), so
+      // `valueFromJson` runs as the actual decode step.
+      await tx.commit();
+      tx = runtime.edit();
+
+      // Fresh-tx getSourceCell: reads `path: ["source"]` through the
+      // storage layer, where `valueFromJson` decodes the row to an
+      // object before it surfaces here. `getSourceCell` then takes its
+      // `isRecord` branch and converts the link record to a URI string.
+      const retrievedSource = targetCell.withTx(tx).getSourceCell();
+      expect(isCell(retrievedSource)).toBe(true);
+      expect(retrievedSource?.withTx(tx).get()).toEqual({ foo: 123 });
     },
   );
-}
+
+  it(
+    "raw read of path: ['source'] returns an object link record",
+    async () => {
+      // Set up a source/target pair and commit.
+      const sourceCell = runtime.getCell<{ foo: number }>(
+        space,
+        "fvj1 source-cell raw read: source",
+        undefined,
+        tx,
+      );
+      sourceCell.set({ foo: 123 });
+
+      const targetCell = runtime.getCell<{ bar: string }>(
+        space,
+        "fvj1 source-cell raw read: target",
+        undefined,
+        tx,
+      );
+      targetCell.set({ bar: "baz" });
+      targetCell.setSourceCell(sourceCell);
+
+      await tx.commit();
+      tx = runtime.edit();
+
+      // Raw read of `path: ["source"]` exercises the same storage-layer
+      // code path as `getSourceCell`'s underlying `readOrThrow`. The
+      // value the storage layer surfaces should be an object link
+      // record (with own-property `"/"`), never a JSON-stringified
+      // form, under both flag states.
+      const targetLink = targetCell.getAsNormalizedFullLink();
+      const sourceAddress = {
+        space,
+        id: targetLink.id,
+        path: ["source"],
+      } as IMemorySpaceAddress;
+      const readResult = tx.read(sourceAddress);
+      expect(readResult.ok).toBeDefined();
+
+      const value = readResult.ok!.value;
+      expect(typeof value).not.toBe("string");
+      expect(typeof value).toBe("object");
+      expect(value).not.toBeNull();
+      expect(Object.prototype.hasOwnProperty.call(value, "/")).toBe(true);
+    },
+  );
+});
 
 // Cell-storage behavior for the four "weird" numeric values: `-0`, `NaN`,
 // `+Infinity`, `-Infinity`. The two data-model paths diverge sharply here:

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -34,13 +34,11 @@ describe("ExperimentalOptions", () => {
         storageManager: sm,
         experimental: {
           modernDataModel: false,
-          unifiedJsonEncoding: false,
         },
       });
       expect(runtime.experimental).toEqual({
         modernDataModel: false,
         richStorableValues: undefined,
-        unifiedJsonEncoding: false,
         schedulerHistoricalMightWrite: undefined,
       });
       await runtime.dispose();
@@ -54,13 +52,11 @@ describe("ExperimentalOptions", () => {
         storageManager: sm,
         experimental: {
           modernDataModel: true,
-          unifiedJsonEncoding: true,
         },
       });
       expect(runtime.experimental).toEqual({
         modernDataModel: true,
         richStorableValues: undefined,
-        unifiedJsonEncoding: true,
         schedulerHistoricalMightWrite: undefined,
       });
       await runtime.dispose();
@@ -79,7 +75,6 @@ describe("ExperimentalOptions", () => {
       expect(runtime.experimental).toEqual({
         modernDataModel: true,
         richStorableValues: undefined,
-        unifiedJsonEncoding: undefined,
         schedulerHistoricalMightWrite: undefined,
       });
       await runtime.dispose();

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -130,7 +130,6 @@ export interface InitializationData {
   // Experimental space-model feature flags.
   experimental?: {
     modernDataModel?: boolean;
-    unifiedJsonEncoding?: boolean;
   };
   // Commit-boundary CFC mode for the worker runtime.
   cfcEnforcementMode?:

--- a/packages/shell/felt.config.ts
+++ b/packages/shell/felt.config.ts
@@ -44,9 +44,6 @@ const config: Config = {
       "$EXPERIMENTAL_MODERN_DATA_MODEL": Deno.env.get(
         "EXPERIMENTAL_MODERN_DATA_MODEL",
       ),
-      "$EXPERIMENTAL_UNIFIED_JSON_ENCODING": Deno.env.get(
-        "EXPERIMENTAL_UNIFIED_JSON_ENCODING",
-      ),
       "$COMPILATION_CACHE_CLIENT": Deno.env.get(
         "COMPILATION_CACHE_CLIENT",
       ) ?? "true",

--- a/packages/shell/src/lib/env.ts
+++ b/packages/shell/src/lib/env.ts
@@ -3,7 +3,6 @@ declare global {
   var $API_URL: string | undefined;
   var $COMMIT_SHA: string | undefined;
   var $EXPERIMENTAL_MODERN_DATA_MODEL: string | undefined;
-  var $EXPERIMENTAL_UNIFIED_JSON_ENCODING: string | undefined;
   var $COMPILATION_CACHE_CLIENT: string | undefined;
 }
 
@@ -17,10 +16,6 @@ const COMMIT_SHA_DEFINE = typeof $COMMIT_SHA === "string"
 const EXPERIMENTAL_MODERN_DATA_MODEL_DEFINE =
   typeof $EXPERIMENTAL_MODERN_DATA_MODEL === "string"
     ? $EXPERIMENTAL_MODERN_DATA_MODEL
-    : undefined;
-const EXPERIMENTAL_UNIFIED_JSON_ENCODING_DEFINE =
-  typeof $EXPERIMENTAL_UNIFIED_JSON_ENCODING === "string"
-    ? $EXPERIMENTAL_UNIFIED_JSON_ENCODING
     : undefined;
 const COMPILATION_CACHE_CLIENT_DEFINE =
   typeof $COMPILATION_CACHE_CLIENT === "string"
@@ -47,7 +42,6 @@ function flagValue(flag: string | undefined): boolean | undefined {
 /** Build-time experimental flags, injected via felt.config.ts defines. */
 export const EXPERIMENTAL = {
   modernDataModel: flagValue(EXPERIMENTAL_MODERN_DATA_MODEL_DEFINE),
-  unifiedJsonEncoding: flagValue(EXPERIMENTAL_UNIFIED_JSON_ENCODING_DEFINE),
 };
 
 export const COMPILATION_CACHE_CLIENT =

--- a/packages/shell/test/env.test.ts
+++ b/packages/shell/test/env.test.ts
@@ -36,8 +36,6 @@ Deno.test({
       $EXPERIMENTAL_MODERN_DATA_MODEL: "true",
       $EXPERIMENTAL_UNIFIED_JSON_ENCODING: "false",
       $EXPERIMENTAL_RICH_STORABLE_VALUES: undefined,
-      $EXPERIMENTAL_STORABLE_PROTOCOL: undefined,
-      $EXPERIMENTAL_CANONICAL_HASHING: undefined,
     }, importFreshEnvModule);
 
     expect(mod.EXPERIMENTAL).toEqual({
@@ -56,8 +54,6 @@ Deno.test({
       $EXPERIMENTAL_MODERN_DATA_MODEL: undefined,
       $EXPERIMENTAL_UNIFIED_JSON_ENCODING: undefined,
       $EXPERIMENTAL_RICH_STORABLE_VALUES: "true",
-      $EXPERIMENTAL_STORABLE_PROTOCOL: "true",
-      $EXPERIMENTAL_CANONICAL_HASHING: "true",
     }, importFreshEnvModule);
 
     expect(mod.EXPERIMENTAL).toEqual({

--- a/packages/shell/test/env.test.ts
+++ b/packages/shell/test/env.test.ts
@@ -34,13 +34,11 @@ Deno.test({
     const mod = await withPatchedGlobals({
       $API_URL: "http://shell.test/",
       $EXPERIMENTAL_MODERN_DATA_MODEL: "true",
-      $EXPERIMENTAL_UNIFIED_JSON_ENCODING: "false",
       $EXPERIMENTAL_RICH_STORABLE_VALUES: undefined,
     }, importFreshEnvModule);
 
     expect(mod.EXPERIMENTAL).toEqual({
       modernDataModel: true,
-      unifiedJsonEncoding: false,
     });
   },
 });
@@ -52,13 +50,11 @@ Deno.test({
     const mod = await withPatchedGlobals({
       $API_URL: "http://shell.test/",
       $EXPERIMENTAL_MODERN_DATA_MODEL: undefined,
-      $EXPERIMENTAL_UNIFIED_JSON_ENCODING: undefined,
       $EXPERIMENTAL_RICH_STORABLE_VALUES: "true",
     }, importFreshEnvModule);
 
     expect(mod.EXPERIMENTAL).toEqual({
       modernDataModel: undefined,
-      unifiedJsonEncoding: undefined,
     });
   },
 });

--- a/packages/shell/test/runtime-navigation.test.ts
+++ b/packages/shell/test/runtime-navigation.test.ts
@@ -58,7 +58,6 @@ describe("RuntimeInternals navigation", () => {
       $COMMIT_SHA?: string;
       $MEMORY_VERSION?: string;
       $EXPERIMENTAL_MODERN_DATA_MODEL?: string;
-      $EXPERIMENTAL_UNIFIED_JSON_ENCODING?: string;
       $COMPILATION_CACHE_CLIENT?: string;
     };
     const originalEnv = {
@@ -67,8 +66,6 @@ describe("RuntimeInternals navigation", () => {
       $COMMIT_SHA: env.$COMMIT_SHA,
       $MEMORY_VERSION: env.$MEMORY_VERSION,
       $EXPERIMENTAL_MODERN_DATA_MODEL: env.$EXPERIMENTAL_MODERN_DATA_MODEL,
-      $EXPERIMENTAL_UNIFIED_JSON_ENCODING:
-        env.$EXPERIMENTAL_UNIFIED_JSON_ENCODING,
       $COMPILATION_CACHE_CLIENT: env.$COMPILATION_CACHE_CLIENT,
     };
     env.$API_URL = "http://shell.test/";
@@ -76,7 +73,6 @@ describe("RuntimeInternals navigation", () => {
     env.$COMMIT_SHA = undefined;
     env.$MEMORY_VERSION = undefined;
     env.$EXPERIMENTAL_MODERN_DATA_MODEL = undefined;
-    env.$EXPERIMENTAL_UNIFIED_JSON_ENCODING = undefined;
     env.$COMPILATION_CACHE_CLIENT = undefined;
 
     const { RuntimeInternals } = await import("../src/lib/runtime.ts");
@@ -138,8 +134,6 @@ describe("RuntimeInternals navigation", () => {
       env.$MEMORY_VERSION = originalEnv.$MEMORY_VERSION;
       env.$EXPERIMENTAL_MODERN_DATA_MODEL =
         originalEnv.$EXPERIMENTAL_MODERN_DATA_MODEL;
-      env.$EXPERIMENTAL_UNIFIED_JSON_ENCODING =
-        originalEnv.$EXPERIMENTAL_UNIFIED_JSON_ENCODING;
       env.$COMPILATION_CACHE_CLIENT = originalEnv.$COMPILATION_CACHE_CLIENT;
       await runtime.dispose();
     }
@@ -152,7 +146,6 @@ describe("RuntimeInternals navigation", () => {
       $COMMIT_SHA?: string;
       $MEMORY_VERSION?: string;
       $EXPERIMENTAL_MODERN_DATA_MODEL?: string;
-      $EXPERIMENTAL_UNIFIED_JSON_ENCODING?: string;
       $COMPILATION_CACHE_CLIENT?: string;
     };
     const originalEnv = {
@@ -161,8 +154,6 @@ describe("RuntimeInternals navigation", () => {
       $COMMIT_SHA: env.$COMMIT_SHA,
       $MEMORY_VERSION: env.$MEMORY_VERSION,
       $EXPERIMENTAL_MODERN_DATA_MODEL: env.$EXPERIMENTAL_MODERN_DATA_MODEL,
-      $EXPERIMENTAL_UNIFIED_JSON_ENCODING:
-        env.$EXPERIMENTAL_UNIFIED_JSON_ENCODING,
       $COMPILATION_CACHE_CLIENT: env.$COMPILATION_CACHE_CLIENT,
     };
     env.$API_URL = "http://shell.test/";
@@ -170,7 +161,6 @@ describe("RuntimeInternals navigation", () => {
     env.$COMMIT_SHA = undefined;
     env.$MEMORY_VERSION = undefined;
     env.$EXPERIMENTAL_MODERN_DATA_MODEL = undefined;
-    env.$EXPERIMENTAL_UNIFIED_JSON_ENCODING = undefined;
     env.$COMPILATION_CACHE_CLIENT = undefined;
 
     const { RuntimeInternals } = await import("../src/lib/runtime.ts");
@@ -217,8 +207,6 @@ describe("RuntimeInternals navigation", () => {
       env.$MEMORY_VERSION = originalEnv.$MEMORY_VERSION;
       env.$EXPERIMENTAL_MODERN_DATA_MODEL =
         originalEnv.$EXPERIMENTAL_MODERN_DATA_MODEL;
-      env.$EXPERIMENTAL_UNIFIED_JSON_ENCODING =
-        originalEnv.$EXPERIMENTAL_UNIFIED_JSON_ENCODING;
       env.$COMPILATION_CACHE_CLIENT = originalEnv.$COMPILATION_CACHE_CLIENT;
       await runtime.dispose();
     }

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -204,7 +204,6 @@ const EnvSchema = z.object({
   // env vars in this file have the same latent bug.
   // ===========================================================================
   EXPERIMENTAL_MODERN_DATA_MODEL: flagValue(),
-  EXPERIMENTAL_UNIFIED_JSON_ENCODING: flagValue(),
 
   // ===========================================================================
   // Compilation cache flags (see docs/specs/compilation-cache.md)

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -56,7 +56,6 @@ const initializeRuntime = async () => {
       }),
       experimental: {
         modernDataModel: env.EXPERIMENTAL_MODERN_DATA_MODEL,
-        unifiedJsonEncoding: env.EXPERIMENTAL_UNIFIED_JSON_ENCODING,
       },
       cachedCompiler,
     });

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -166,7 +166,6 @@ describe("Blob Routes", () => {
         }),
         experimental: {
           modernDataModel: true,
-          unifiedJsonEncoding: true,
         },
       });
 


### PR DESCRIPTION
This PR removes all the stuff having to do with detecting, setting up, and resetting the unified JSON flag. That is, this PR makes the flag defunct.

The one remaining spot that this PR doesn't touch is the code in `json-encoding.ts` itself, where the flag can be manipulated and is dispatched. That will be cleaned up in a follow-on PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `unifiedJsonEncoding` experimental flag across the codebase and docs. Env vars, runtime options, protocol flags, and tests are gone; only the encoding dispatch in `json-encoding.ts` remains and will be removed in a follow-up.

- **Refactors**
  - Removed the flag from `ExperimentalOptions`, env readers, and worker IPC across `runner`, `background-charm-service`, `toolshed`, `shell`, and CLI.
  - Updated memory v2 protocol: dropped the flag from types, handshake checks, and docs; simplified `getMemoryProtocolFlags` and equality checks; cleaned JSON examples to be valid (no comments).
  - Deleted `EXPERIMENTAL_UNIFIED_JSON_ENCODING` defines and tests; simplified tests that previously parameterized on the flag.
  - Updated `EXPERIMENTAL_OPTIONS.md`: removed the flag, adjusted examples, and added a short “Defining a new flag” note.

- **Migration**
  - Stop setting `EXPERIMENTAL_UNIFIED_JSON_ENCODING` in env or build defines.
  - Remove `experimental.unifiedJsonEncoding` from `Runtime` or service init options.
  - Update memory v2 clients and servers together; hello flags now only include `richStorableValues` (a.k.a. `modernDataModel`).

<sup>Written for commit 7cbcb370c30b683facec4859415bbbfac4dbcb75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

