### PR TITLE
Fixed a doc reference in SKILL.md

### DIFF
--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -593,6 +593,10 @@ export interface IStorageTransaction {
    * Calling commit on a transaction that has already completed (committed or
    * failed) returns the prior error or a {@link IStorageTransactionComplete}
    * error. Commit is NOT idempotent — it does not replay the original result.
+   *
+   * When this method returns, the changes will have been committed locally,
+   * but may not be visible to another runtime. When the returned promise
+   * resolves, the data is fully committed and available to other processes.
    */
   commit(): Promise<Result<Unit, CommitError>>;
 

--- a/skills/knowledge-base/SKILL.md
+++ b/skills/knowledge-base/SKILL.md
@@ -9,7 +9,8 @@ description: Shared foundation for Oracle & Corrector agents. Establishes the so
 
 Read these docs to orient yourself:
 
-1. **`docs/common/concepts/glossary.md`** - Terminology (Cell, Piece, Space, Spell, etc.)
+1. **`docs/common/concepts/glossary.md`** - Terminology (Cell, Piece, Space,
+   Spell, etc.)
 2. **`docs/specs/pattern-construction/overview.md`** - Authoritative system
    design
 3. **`AGENTS.md`** - Documentation reading list and codebase guidelines

--- a/skills/knowledge-base/SKILL.md
+++ b/skills/knowledge-base/SKILL.md
@@ -9,7 +9,7 @@ description: Shared foundation for Oracle & Corrector agents. Establishes the so
 
 Read these docs to orient yourself:
 
-1. **`docs/glossary.md`** - Terminology (Cell, Piece, Space, Spell, etc.)
+1. **`docs/common/concepts/glossary.md`** - Terminology (Cell, Piece, Space, Spell, etc.)
 2. **`docs/specs/pattern-construction/overview.md`** - Authoritative system
    design
 3. **`AGENTS.md`** - Documentation reading list and codebase guidelines


### PR DESCRIPTION
Added a comment to IStorageTransaction.commit to help the agents realize we shouldn't await the commit.

Edit: Updating perf baseline. For some reason, we're way slower on this test now, though it's obviously not related to this PR.
NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 145s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified `IStorageTransaction.commit()` semantics: changes are committed locally when `commit()` returns; awaiting the promise ensures visibility to other runtimes/processes. Fixed the glossary link in `skills/knowledge-base/SKILL.md` to `docs/common/concepts/glossary.md`, and applied `deno fmt`.

<sup>Written for commit 7b9df740419936908201c8662713d88b7df659ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

