### PR TITLE
Fix memory v2 pending replay after async commits

### DIFF
--- a/packages/runner/integration/pattern-and-data-persistence.test.ts
+++ b/packages/runner/integration/pattern-and-data-persistence.test.ts
@@ -203,8 +203,6 @@ async function phase2LoadAndVerify(
     resultCell,
   );
   await tx.commit();
-  // FIXME(@ubik2) - Why is the tx.commit insufficient?
-  await ctx.runtime.storageManager.synced();
   const pulled = await runResult.pull();
 
   const output = runResult.getAsQueryResult();

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -391,6 +391,16 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       writeResult.error &&
       (writeResult.error.name === "NotFoundError")
     ) {
+      if (this.tx.writeBatch) {
+        const batchRetry = this.tx.writeBatch([{ address, value }]);
+        if (!batchRetry.error) {
+          return;
+        }
+        if (batchRetry.error.name !== "NotFoundError") {
+          throw toThrowable(batchRetry.error);
+        }
+      }
+
       // Create parent entries if needed.
       // errorPath includes the missing key (consistent with read errors).
       // lastExistingPath is one level up - the actual last existing parent.

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1883,12 +1883,18 @@ export class V2StorageTransaction implements IStorageTransaction {
     type: MediaType,
     doc: WritableDocumentEntry,
   ): NativeStorageCommitOperation | null {
-    if (doc.initial.value === undefined || doc.current.value === undefined) {
+    if (doc.current.value === undefined) {
       return null;
     }
 
     const details = [...doc.patchDetails.values()];
     if (details.some((detail) => detail.address.path.length === 0)) {
+      return null;
+    }
+    if (
+      doc.initial.value === undefined &&
+      details.some((detail) => detail.address.path.length <= 1)
+    ) {
       return null;
     }
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -120,20 +120,22 @@ type MaterializedVersion = {
   transactionValue: CachedTransactionValue;
 };
 
+type PendingMetadata = {
+  localSeq: number;
+  appliedSeq?: number;
+};
+
 type PendingVersion =
-  | {
-    localSeq: number;
+  | PendingMetadata & {
     op: "set";
     value: EntityDocument;
   }
-  | {
-    localSeq: number;
+  | PendingMetadata & {
     op: "patch";
     patches: PatchOp[];
     value: EntityDocument;
   }
-  | {
-    localSeq: number;
+  | PendingMetadata & {
     op: "delete";
   };
 
@@ -329,6 +331,47 @@ const materializedVersionThroughPending = (
     });
   }
   return cache.prefixes[pendingCount - 1]!;
+};
+
+const promoteAppliedPendingPrefix = (record: DocumentRecord): void => {
+  const firstUnappliedIndex = record.pending.findIndex((entry) =>
+    entry.appliedSeq === undefined
+  );
+  const appliedCount = firstUnappliedIndex === -1
+    ? record.pending.length
+    : firstUnappliedIndex;
+  if (appliedCount === 0) {
+    return;
+  }
+
+  const appliedSeq = Math.max(
+    ...record.pending
+      .slice(0, appliedCount)
+      .map((entry) => entry.appliedSeq ?? record.confirmed.seq),
+  );
+  const previousConfirmed = record.confirmed;
+  const cache = ensurePendingMaterializationCache(record);
+  const prefix = materializedVersionThroughPending(record, appliedCount);
+
+  if (record.confirmed.seq < appliedSeq) {
+    const promoted = confirmedVersion(appliedSeq, prefix.value);
+    promoted.transactionValue = prefix.transactionValue;
+    record.confirmed = promoted;
+    record.pending = record.pending.slice(appliedCount);
+    record.materialized = cache.confirmed === previousConfirmed
+      ? {
+        confirmed: promoted,
+        prefixes: cache.prefixes.slice(appliedCount),
+      }
+      : undefined;
+    if (record.materialized?.prefixes.length === 0) {
+      record.materialized = undefined;
+    }
+    return;
+  }
+
+  record.pending = record.pending.slice(appliedCount);
+  dropMaterializedSuffix(record, 0);
 };
 
 const dropMaterializedSuffix = (
@@ -1405,6 +1448,11 @@ class SpaceReplica implements ISpaceReplica {
 
     for (const upsert of sync.upserts) {
       const record = this.record(upsert.id as URI);
+      // Watch refreshes can arrive after local confirmations. Never move the
+      // confirmed base backwards; pending replay depends on monotonic bases.
+      if (upsert.seq < record.confirmed.seq) {
+        continue;
+      }
       record.confirmed = confirmedVersion(
         upsert.seq,
         upsert.deleted === true ? undefined : upsert.doc,
@@ -1482,52 +1530,11 @@ class SpaceReplica implements ISpaceReplica {
         );
         continue;
       }
-      const firstPendingIndex = pendingIndexes[0]!;
-      const lastPendingIndex = pendingIndexes[pendingIndexes.length - 1]!;
-      const pending = record.pending[lastPendingIndex]!;
-      const previousConfirmed = record.confirmed;
-      let promoted: ConfirmedVersion | undefined;
-      let reusedSuffix: PendingMaterializedPrefix[] | undefined;
-
-      if (record.confirmed.seq < applied.seq) {
-        if (firstPendingIndex === 0) {
-          const prefix = materializedVersionThroughPending(
-            record,
-            lastPendingIndex + 1,
-          );
-          const cache = ensurePendingMaterializationCache(record);
-          promoted = confirmedVersion(
-            applied.seq,
-            prefix.value,
-          );
-          promoted.transactionValue = prefix.transactionValue;
-          if (cache.confirmed === previousConfirmed) {
-            reusedSuffix = cache.prefixes.slice(lastPendingIndex + 1);
-          }
-        } else {
-          promoted = confirmedVersion(
-            applied.seq,
-            applyPendingVersion(record.confirmed.value, pending),
-          );
-        }
+      for (const pendingIndex of pendingIndexes) {
+        record.pending[pendingIndex]!.appliedSeq = applied.seq;
       }
 
-      record.pending = record.pending.filter((entry) =>
-        entry.localSeq !== localSeq
-      );
-
-      if (promoted) {
-        record.confirmed = promoted;
-        record.materialized = reusedSuffix && reusedSuffix.length > 0
-          ? {
-            confirmed: promoted,
-            prefixes: reusedSuffix,
-          }
-          : undefined;
-        continue;
-      }
-
-      dropMaterializedSuffix(record, firstPendingIndex);
+      promoteAppliedPendingPrefix(record);
     }
   }
 
@@ -1543,6 +1550,7 @@ class SpaceReplica implements ISpaceReplica {
         entry.localSeq !== localSeq
       );
       dropMaterializedSuffix(record, firstPendingIndex);
+      promoteAppliedPendingPrefix(record);
     }
   }
 

--- a/packages/runner/test/memory-v2-native-commit.test.ts
+++ b/packages/runner/test/memory-v2-native-commit.test.ts
@@ -113,6 +113,36 @@ Deno.test("memory v2 native commits require explicit full-document roots", async
   }
 });
 
+Deno.test("memory v2 extended root writes into new documents emit set drafts", async () => {
+  const { storage, drafts } = captureNativeDrafts();
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: storage,
+  });
+
+  try {
+    const tx = runtime.edit();
+    tx.writeValueOrThrow(
+      { space, id: "of:memory-v2-native-root-create", path: [] },
+      { count: 1 },
+    );
+
+    const commitResult = await tx.commit();
+    assert(commitResult.ok);
+    assertEquals(drafts, [{
+      operations: [{
+        op: "set",
+        id: "of:memory-v2-native-root-create",
+        type,
+        value: { value: { count: 1 } },
+      }],
+    }]);
+  } finally {
+    await runtime.dispose();
+    await storage.close();
+  }
+});
+
 Deno.test("memory v2 transactions emit patch drafts for safe object-path writes", async () => {
   const { storage, drafts } = captureNativeDrafts();
 
@@ -159,7 +189,7 @@ Deno.test("memory v2 transactions emit patch drafts for safe object-path writes"
   }
 });
 
-Deno.test("memory v2 transactions emit set drafts for leaf writes into new documents", async () => {
+Deno.test("memory v2 transactions emit patch drafts for leaf writes into new documents", async () => {
   const { storage, drafts } = captureNativeDrafts();
 
   try {
@@ -181,13 +211,86 @@ Deno.test("memory v2 transactions emit set drafts for leaf writes into new docum
     assert(commitResult.ok);
     assertEquals(drafts, [{
       operations: [{
-        op: "set",
+        op: "patch",
         id: "of:memory-v2-native-create-via-patch",
         type,
+        patches: [{
+          op: "add",
+          path: "/value/profile/name",
+          value: "Ada",
+        }],
         value: { value: { profile: { name: "Ada" } } },
       }],
     }]);
   } finally {
+    await storage.close();
+  }
+});
+
+Deno.test("memory v2 concurrent leaf writes into new documents merge as path patches", async () => {
+  const { storage, drafts } = captureNativeDrafts();
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: storage,
+  });
+
+  try {
+    const id = "of:memory-v2-native-concurrent-leaf-writes";
+    const sumTx = runtime.edit();
+    const resultTx = runtime.edit();
+
+    sumTx.writeValueOrThrow({ space, id, path: ["sum"] }, 15);
+    resultTx.writeValueOrThrow(
+      { space, id, path: ["result"] },
+      "Numbers: 15",
+    );
+
+    const sumCommit = sumTx.commit();
+    const resultCommit = resultTx.commit();
+
+    assertEquals(runtime.readTx().readValueOrThrow({ space, id, path: [] }), {
+      sum: 15,
+      result: "Numbers: 15",
+    });
+
+    assert((await sumCommit).ok);
+    assert((await resultCommit).ok);
+    await storage.synced();
+
+    assertEquals(drafts, [
+      {
+        operations: [{
+          op: "patch",
+          id,
+          type,
+          patches: [{
+            op: "add",
+            path: "/value/sum",
+            value: 15,
+          }],
+          value: { value: { sum: 15 } },
+        }],
+      },
+      {
+        operations: [{
+          op: "patch",
+          id,
+          type,
+          patches: [{
+            op: "add",
+            path: "/value/result",
+            value: "Numbers: 15",
+          }],
+          value: { value: { result: "Numbers: 15" } },
+        }],
+      },
+    ]);
+    assertEquals(runtime.readTx().readValueOrThrow({ space, id, path: [] }), {
+      sum: 15,
+      result: "Numbers: 15",
+    });
+  } finally {
+    await runtime.dispose();
     await storage.close();
   }
 });

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -88,18 +88,20 @@ type RejectedRecord = {
   commit: ClientCommit;
   error: { name: string; message: string };
 };
+type ScriptedResponseOptions = {
+  remoteInterleave?: RemoteCommit;
+  responseDelayMs?: number;
+};
 type ScriptedOutcome =
-  | { kind: "accept"; remoteInterleave?: RemoteCommit }
-  | {
+  | ScriptedResponseOptions & { kind: "accept" }
+  | ScriptedResponseOptions & {
     kind: "rejectConflict";
     message?: string;
-    remoteInterleave?: RemoteCommit;
   }
-  | { kind: "dropThenReplayAccept"; remoteInterleave?: RemoteCommit }
-  | {
+  | ScriptedResponseOptions & { kind: "dropThenReplayAccept" }
+  | ScriptedResponseOptions & {
     kind: "dropThenReplayReject";
     message?: string;
-    remoteInterleave?: RemoteCommit;
   };
 type RemoteCommit = {
   label: string;
@@ -134,6 +136,7 @@ class ScriptedServerModel {
   readonly applied = new Map<number, AppliedRecord>();
   readonly rejected = new Map<number, RejectedRecord>();
   readonly scripted = new Map<number, ScriptedOutcome>();
+  readonly responseDelays = new Map<number, number>();
   readonly dropped = new Set<number>();
   serverSeq = 0;
   sessionId = "session:stacked";
@@ -146,6 +149,13 @@ class ScriptedServerModel {
 
   setOutcome(localSeq: number, outcome: ScriptedOutcome): void {
     this.scripted.set(localSeq, outcome);
+    if (outcome.responseDelayMs !== undefined) {
+      this.responseDelays.set(localSeq, outcome.responseDelayMs);
+    }
+  }
+
+  responseDelayMs(localSeq: number): number {
+    return this.responseDelays.get(localSeq) ?? 0;
   }
 
   seed(id: URI, value: RootValue): DocState {
@@ -387,9 +397,9 @@ class ScriptedModelTransport implements MemoryV2Client.Transport {
         });
         break;
       case "transact": {
+        const commit = message.commit!;
+        const response = this.model.transact(commit);
         setTimeout(() => {
-          const commit = message.commit!;
-          const response = this.model.transact(commit);
           if (response.type === "drop") {
             this.#closeReceiver(new Error("disconnect"));
             return;
@@ -401,7 +411,7 @@ class ScriptedModelTransport implements MemoryV2Client.Transport {
               ? { ok: response.applied }
               : { error: response.error }),
           });
-        }, 0);
+        }, this.model.responseDelayMs(commit.localSeq));
         break;
       }
       default:
@@ -970,6 +980,131 @@ Deno.test("memory v2 stacked commits: C1,C2,C3 all succeed on one doc", async ()
       changedIdsFor(harness.notifications.notifications, "revert"),
       [],
     );
+  } finally {
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: out-of-order confirmations preserve earlier pending patches", async () => {
+  const harness = await createHarness();
+  try {
+    await seedAccepted(harness, DOCS.A, {});
+
+    harness.model.setOutcome(2, {
+      kind: "accept",
+      responseDelayMs: 25,
+    });
+    harness.model.setOutcome(3, { kind: "accept" });
+
+    const sum = beginPatch(
+      harness,
+      DOCS.A,
+      [{
+        op: "add",
+        path: "/value/sum",
+        value: 15,
+      }],
+      { sum: 15 },
+    );
+
+    const result = beginPatch(
+      harness,
+      DOCS.A,
+      [{
+        op: "add",
+        path: "/value/result",
+        value: "Numbers: 15",
+      }],
+      {
+        sum: 15,
+        result: "Numbers: 15",
+      },
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+
+    await assertResultOk(result);
+    expectVisible(harness, {
+      A: {
+        sum: 15,
+        result: "Numbers: 15",
+      },
+    });
+
+    await assertResultOk(sum);
+    expectVisible(harness, {
+      A: {
+        sum: 15,
+        result: "Numbers: 15",
+      },
+    });
+  } finally {
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: out-of-order setup and derived patch confirmations preserve siblings", async () => {
+  const harness = await createHarness();
+  try {
+    const setup = beginSet(harness, DOCS.A, {});
+    harness.model.setOutcome(setup.localSeq, {
+      kind: "accept",
+      responseDelayMs: 20,
+    });
+
+    const sum = beginPatch(
+      harness,
+      DOCS.A,
+      [{
+        op: "add",
+        path: "/value/sum",
+        value: 15,
+      }],
+      { sum: 15 },
+    );
+    harness.model.setOutcome(2, {
+      kind: "accept",
+      responseDelayMs: 40,
+    });
+
+    const result = beginPatch(
+      harness,
+      DOCS.A,
+      [{
+        op: "add",
+        path: "/value/result",
+        value: "Numbers: 15",
+      }],
+      {
+        sum: 15,
+        result: "Numbers: 15",
+      },
+      sourceFromReads([{ id: DOCS.A }]),
+    );
+    harness.model.setOutcome(3, { kind: "accept" });
+
+    await assertResultOk(result);
+    expectVisible(harness, {
+      A: {
+        sum: 15,
+        result: "Numbers: 15",
+      },
+    });
+
+    await assertResultOk(setup.promise);
+    expectVisible(harness, {
+      A: {
+        sum: 15,
+        result: "Numbers: 15",
+      },
+    });
+
+    await assertResultOk(sum);
+    expectVisible(harness, {
+      A: {
+        sum: 15,
+        result: "Numbers: 15",
+      },
+    });
   } finally {
     await harness.close();
   }


### PR DESCRIPTION
This was generated by codex, and I don't think it's particularly valid, but I've created a PR for it in case it's useful when investigating the pull consistency issue.

Here's codex's conclusion after changing things:
```
• Resumed and finished the investigation.

  Root cause: the server did store both writes. The client lost sum because a stale watch/pull upsert for
  setup seq 3 arrived after local confirmation seq 4, rolled the confirmed base backward to { value: {} },
  then replayed pending patches over that stale base.

  I fixed this without waiting on tx.commit():

  - Leaf writes into newly created docs now stay as path patches when safe.
  - Pending confirmations only promote contiguous applied pending entries.
  - Stale session upserts no longer move the confirmed base backward.
  - Removed the masking ctx.runtime.storageManager.synced() from pattern-and-data-persistence.test.ts.

  The transact snapshot for the sum example:

  {
    "computeSum": {
      "op": "patch",
      "patches": [{ "op": "add", "path": "/value/sum", "value": 15 }]
    },
    "formatResult": {
      "op": "patch",
      "patches": [
        { "op": "add", "path": "/value/result", "value": "Numbers: 15" }
      ]
    }
  }

  Server final state for the internal doc had both fields:

  {
    "value": { "sum": 15, "result": "Numbers: 15" }
  }
```


Preserve fine-grained patch writes for safe leaf updates into newly created documents, and keep local pending state stable while commit confirmations and watch refreshes arrive out of order.

Only promote confirmed pending entries as a contiguous prefix, and ignore stale session upserts that would move the confirmed base backward. This prevents a later pull from replaying pending patches over an older base and dropping sibling writes.

Remove the synced() workaround from the persistence integration test and add coverage for concurrent leaf writes, patch drafts, and out-of-order confirmations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pending replay in memory v2 when commit confirmations and watch refreshes arrive out of order. Preserves sibling fields and keeps confirmed bases monotonic, especially for concurrent leaf writes into new docs.

- **Bug Fixes**
  - Promote pending entries only as a contiguous confirmed prefix; tag each with `appliedSeq` to avoid replaying over stale bases (`packages/runner/src/storage/v2.ts`).
  - Ignore stale session upserts that would move the confirmed base backward.
  - Emit path `patch` drafts for safe leaf writes into newly created docs; keep root writes as `set` (`packages/runner/src/storage/v2-transaction.ts`).
  - Retry `writeBatch` before creating parent entries on `NotFound` (`packages/runner/src/storage/extended-storage-transaction.ts`).
  - Tests: add cases for concurrent leaf writes and out-of-order confirmations; remove `synced()` workaround in integration test.

<sup>Written for commit b39c6d89407ab9363087ead7e341f57bc2c0d5fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

