### PR TITLE
Pin memory websocket streams by space

### DIFF
--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -20,6 +20,15 @@ export const toWebSocketAddress = (address: URL): URL => {
   return next;
 };
 
+export const toSpaceWebSocketAddress = (
+  address: URL,
+  space: MemorySpace,
+): URL => {
+  const next = toWebSocketAddress(address);
+  next.searchParams.set("space", space);
+  return next;
+};
+
 class WebSocketTransport implements MemoryClient.Transport {
   #receiver: (payload: string) => void = () => {};
   #closeReceiver: (error?: Error) => void = () => {};
@@ -128,7 +137,9 @@ export class RemoteSessionFactory implements SessionFactory {
 
   async create(space: MemorySpace, signer = this.defaultSigner) {
     const client = await MemoryClient.connect({
-      transport: new WebSocketTransport(this.address),
+      transport: new WebSocketTransport(
+        toSpaceWebSocketAddress(this.address, space),
+      ),
     });
     const session = await client.mount(
       space,

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { toWebSocketAddress } from "../src/storage/v2-remote-session.ts";
+import {
+  toSpaceWebSocketAddress,
+  toWebSocketAddress,
+} from "../src/storage/v2-remote-session.ts";
 
 describe("memory v2 remote session websocket address", () => {
   it("upgrades http and https urls to websocket protocols", () => {
@@ -19,5 +22,16 @@ describe("memory v2 remote session websocket address", () => {
     expect(
       toWebSocketAddress(new URL("wss://example.test/storage")).toString(),
     ).toBe("wss://example.test/storage");
+  });
+
+  it("adds the memory space to the websocket query", () => {
+    expect(
+      toSpaceWebSocketAddress(
+        new URL("https://example.test/api/storage/memory?trace=1"),
+        "did:key:z6Mk-storage-space",
+      ).toString(),
+    ).toBe(
+      "wss://example.test/api/storage/memory?trace=1&space=did%3Akey%3Az6Mk-storage-space",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- append the memory space DID as a `space` query parameter on v2 memory websocket stream URLs
- preserve existing stream URL query parameters while upgrading http/https to ws/wss
- add a regression test for the pinned websocket URL shape

## Validation

- red: `deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git packages/runner/test/memory-v2-remote-session.test.ts` failed before implementation because `toSpaceWebSocketAddress` was missing
- green: `deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git packages/runner/test/memory-v2-remote-session.test.ts`
- `deno fmt --check packages/runner/src/storage/v2-remote-session.ts packages/runner/test/memory-v2-remote-session.test.ts`
- `deno task check`
- `deno task --cwd packages/runner test`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins v2 memory websocket streams to the selected space by adding the space DID as a `space` query param, ensuring streams route to the correct memory space. Existing query params are preserved and URLs still upgrade from http/https to ws/wss.

- **New Features**
  - Added `toSpaceWebSocketAddress(address, space)` and used it in `RemoteSessionFactory`.
  - Added a regression test to verify the pinned websocket URL shape.

<sup>Written for commit 7c65e4ca45b1f5c23fc190ca7bf7c811b224655d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

