### PR TITLE
chore(runner): enable pull scheduler by default

### DIFF
--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -431,7 +431,7 @@ export class Scheduler {
   private stale = new Set<Action>();
   private upstreamStaleWriters = new WeakMap<Action, Set<Action>>();
   private upstreamStaleCount = new WeakMap<Action, number>();
-  private pullMode = false;
+  private pullMode = true;
 
   // Debugger breakpoints: action IDs that should trigger `debugger` before execution
   private breakpoints = new Set<string>();

--- a/packages/runner/test/scheduler-pull.test.ts
+++ b/packages/runner/test/scheduler-pull.test.ts
@@ -80,8 +80,8 @@ describe("pull-based scheduling", () => {
     await storageManager?.close();
   });
 
-  it("should default to push mode", () => {
-    expect(runtime.scheduler.isPullModeEnabled()).toBe(false);
+  it("should default to pull mode", () => {
+    expect(runtime.scheduler.isPullModeEnabled()).toBe(true);
   });
 
   it("should dispatch schema-marked streams without a materialized stream marker", async () => {


### PR DESCRIPTION
## Summary

- Enable pull scheduler mode by default in the runner.
- Update the scheduler default regression assertion to expect pull mode.

## Notes

This is intentionally scoped to the default flag flip. The pull-mode notebook render fix has already landed on `main`, so this PR only changes the runner's starting scheduler mode.

## Validation

- `deno fmt --check packages/runner/src/scheduler.ts packages/runner/test/scheduler-pull.test.ts`
- `deno check packages/runner/src/scheduler.ts packages/runner/test/scheduler-pull.test.ts`
- `deno test -A packages/runner/test/scheduler-pull.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable pull-based scheduling by default in the runner. Set `Scheduler` to pull mode by default and update the test to expect pull mode on startup.

<sup>Written for commit 2db5edb0635bb3d9bbaf4b5407d9bcf3ce783c67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: job: Package Integration Tests (shell) = 118s
