### PR TITLE
Clarify Pattern Factory Build input-state guidance

### DIFF
--- a/docs/common/ai/pattern-factory-build-guide.md
+++ b/docs/common/ai/pattern-factory-build-guide.md
@@ -56,6 +56,66 @@ piece. Sub-patterns often receive caller-owned writable inputs and must include
 top-level deliverable to require external writable inputs when the brief expects
 a standalone pattern.
 
+## Top-Level State Ownership
+
+Decide what owns state before creating cells. Pattern Factory Build usually
+produces a top-level pattern whose inputs and outputs are the pattern contract.
+Those input fields are already reactive at runtime.
+
+Do not mirror reactive pattern inputs into new local cells during pattern
+initialization. In particular, do not write `Writable.of(input.field)`,
+`Writable.of(input.field || fallback)`, `Cell.of(input.field)`, or helper calls
+around `input.field` inside `Writable.of(...)`. `Writable.of()` and `Cell.of()`
+are only for new pattern-owned cells initialized from static values.
+
+Wrong:
+
+```tsx
+export default pattern<DeviceInput>((input) => {
+  const name = Writable.of(input.name || ""); // input.name is reactive
+  const capabilities = Writable.of(input.capabilities || []);
+  // ...
+});
+```
+
+Prefer one of these designs instead:
+
+- If the field is the pattern's primary state, model it in the input/output
+  contract with `Default<>` and `Writable<>` as needed, then use that reactive
+  input cell directly.
+- If the field is independent local UI state, initialize it from a static value:
+  `Writable.of("")`, `Writable.of(false)`, or `Writable.of<Item[]>([])`.
+- If the field is draft/editing state seeded from input state, initialize the
+  draft from a static value and copy the current input value inside an `action()`
+  or another valid event/reactive context.
+
+Example:
+
+```tsx
+interface DeviceInput {
+  name: Writable<string | Default<"">>;
+}
+
+export default pattern<DeviceInput, DeviceOutput>(({ name }) => {
+  const draftName = Writable.of("");
+
+  const startEditing = action(() => {
+    draftName.set(name.get());
+  });
+
+  const saveDraft = action(() => {
+    name.set(draftName.get());
+  });
+
+  return {
+    name,
+    startEditing,
+    saveDraft,
+    [UI]: <cf-input $value={name} />,
+  };
+});
+```
+
 ## Build Verification
 
 Build is complete only when the generated pattern compiles and its pattern tests

--- a/docs/common/ai/pattern-factory-build-guide.md
+++ b/docs/common/ai/pattern-factory-build-guide.md
@@ -111,7 +111,7 @@ export default pattern<DeviceInput, DeviceOutput>(({ name }) => {
     name,
     startEditing,
     saveDraft,
-    [UI]: <cf-input $value={name} />,
+    [UI]: <cf-input $value={draftName} />,
   };
 });
 ```

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -892,6 +892,11 @@ type RecordHarnessPolicyEvent = (
   event: Parameters<CfHarnessEngine["recordPolicyEvent"]>[0],
 ) => Promise<void>;
 
+const MODEL_FACING_BASH_STREAM_HEAD_CHARS = 60_000;
+const MODEL_FACING_BASH_STREAM_TAIL_CHARS = 20_000;
+const MODEL_FACING_BASH_STREAM_MAX_CHARS = MODEL_FACING_BASH_STREAM_HEAD_CHARS +
+  MODEL_FACING_BASH_STREAM_TAIL_CHARS;
+
 interface InvokedToolCallMessages {
   toolMessage: HarnessToolTranscriptMessage;
   followupMessages?: readonly HarnessTranscriptMessage[];
@@ -981,6 +986,68 @@ const stripBashCwdMarker = (
     stdout,
     cwdMarkerForOutput(BASH_CWD_MARKER_PREFIX, outputId),
   ).stdout;
+};
+
+const truncateModelFacingBashStream = (
+  value: string | ObservationDenied,
+  channel: "stdout" | "stderr",
+  resultRef: ToolResultRef,
+): {
+  value: string | ObservationDenied;
+  truncated?: boolean;
+  originalLength?: number;
+} => {
+  if (
+    typeof value !== "string" ||
+    value.length <= MODEL_FACING_BASH_STREAM_MAX_CHARS
+  ) {
+    return { value };
+  }
+  const omitted = value.length - MODEL_FACING_BASH_STREAM_MAX_CHARS;
+  return {
+    value: `${value.slice(0, MODEL_FACING_BASH_STREAM_HEAD_CHARS)}\n\n` +
+      `[cf-harness: ${channel} truncated for model context; omitted ${omitted} characters. ` +
+      `Full ${channel} is preserved in tool output ${resultRef.outputId}.]\n\n` +
+      value.slice(-MODEL_FACING_BASH_STREAM_TAIL_CHARS),
+    truncated: true,
+    originalLength: value.length,
+  };
+};
+
+const truncateModelFacingBashOutput = (
+  output: unknown,
+  resultRef: ToolResultRef,
+): unknown => {
+  if (!isObjectRecord(output)) {
+    return output;
+  }
+  const stdout = truncateModelFacingBashStream(
+    typeof output.stdout === "string" ? output.stdout : "",
+    "stdout",
+    resultRef,
+  );
+  const stderr = truncateModelFacingBashStream(
+    typeof output.stderr === "string" ? output.stderr : "",
+    "stderr",
+    resultRef,
+  );
+  return {
+    ...output,
+    stdout: stdout.value,
+    stderr: stderr.value,
+    ...(stdout.truncated === true
+      ? {
+        stdoutTruncated: true,
+        stdoutOriginalLength: stdout.originalLength,
+      }
+      : {}),
+    ...(stderr.truncated === true
+      ? {
+        stderrTruncated: true,
+        stderrOriginalLength: stderr.originalLength,
+      }
+      : {}),
+  };
 };
 
 const renderExitCodeObservation = (
@@ -1074,17 +1141,41 @@ const renderMediatedBashOutput = (
   output: Record<string, unknown>,
   cfcResult: CfcSandboxResult,
   resultRef: ToolResultRef,
-): ModelFacingToolOutput => ({
-  outputId: output.outputId,
-  stdout: stripBashCwdMarker(
-    renderStreamObservation(cfcResult.stdout, resultRef),
-    output.outputId,
-  ),
-  stderr: renderStreamObservation(cfcResult.stderr, resultRef),
-  exitCode: renderExitCodeObservation(cfcResult.exitCode, resultRef),
-  cwd: output.cwd,
-  cfc: summarizeCfcSandboxResult(cfcResult),
-});
+): ModelFacingToolOutput => {
+  const stdout = truncateModelFacingBashStream(
+    stripBashCwdMarker(
+      renderStreamObservation(cfcResult.stdout, resultRef),
+      output.outputId,
+    ),
+    "stdout",
+    resultRef,
+  );
+  const stderr = truncateModelFacingBashStream(
+    renderStreamObservation(cfcResult.stderr, resultRef),
+    "stderr",
+    resultRef,
+  );
+  return {
+    outputId: output.outputId,
+    stdout: stdout.value,
+    stderr: stderr.value,
+    exitCode: renderExitCodeObservation(cfcResult.exitCode, resultRef),
+    cwd: output.cwd,
+    cfc: summarizeCfcSandboxResult(cfcResult),
+    ...(stdout.truncated === true
+      ? {
+        stdoutTruncated: true,
+        stdoutOriginalLength: stdout.originalLength,
+      }
+      : {}),
+    ...(stderr.truncated === true
+      ? {
+        stderrTruncated: true,
+        stderrOriginalLength: stderr.originalLength,
+      }
+      : {}),
+  };
+};
 
 const hasDirectCommandBinding = (
   promptSlotBinding?: PromptSlotBinding,
@@ -1898,7 +1989,12 @@ export class CfHarnessPromptLoop {
       const detail =
         `${toolId} output did not include trusted CFC mediation metadata`;
       if (mode === "disabled") {
-        return stripInternalCfcFields(output);
+        return toolId === "bash"
+          ? truncateModelFacingBashOutput(
+            stripInternalCfcFields(output),
+            resultRef,
+          )
+          : stripInternalCfcFields(output);
       }
       if (mode === "observe") {
         await writePolicyEvent({
@@ -1909,7 +2005,12 @@ export class CfHarnessPromptLoop {
           detail:
             `${detail}; raw output was exposed because CFC is in observe mode`,
         });
-        return stripInternalCfcFields(output);
+        return toolId === "bash"
+          ? truncateModelFacingBashOutput(
+            stripInternalCfcFields(output),
+            resultRef,
+          )
+          : stripInternalCfcFields(output);
       }
       const denial = makeObservationDenied("not-observable", {
         detail,

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -2989,6 +2989,80 @@ Deno.test("CfHarnessPromptLoop records observe-mode warnings and still executes 
   );
 });
 
+Deno.test("CfHarnessPromptLoop truncates large model-facing bash output in observe mode", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const hugeStdout = `${"a".repeat(90_000)}MIDDLE${"z".repeat(30_000)}`;
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        { stdout: hugeStdout, stderr: "", exitCode: 0 },
+      ]),
+      runId: "run-large-bash-output",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "observe",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-large-bash",
+                type: "function",
+                function: {
+                  name: "bash",
+                  arguments: JSON.stringify({ command: "grep big" }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Handled large output.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Run a noisy shell command.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  assertEquals(result.finalAssistantText, "Handled large output.");
+  const secondRequest = JSON.parse(String(fetchCalls[1]?.body)) as {
+    messages: Array<{ role: string; content: string }>;
+  };
+  const toolMessage = secondRequest.messages.at(-1);
+  assertEquals(toolMessage?.role, "tool");
+  const content = JSON.parse(toolMessage!.content);
+  assertEquals(
+    content.outputId,
+    createToolOutputId("run-large-bash-output", "bash", 1),
+  );
+  assertEquals(content.stdoutTruncated, true);
+  assertEquals(content.stdoutOriginalLength, hugeStdout.length);
+  assert(content.stdout.length < hugeStdout.length);
+  assert(content.stdout.startsWith("a".repeat(100)));
+  assert(content.stdout.includes("omitted 40006 characters"));
+  assert(content.stdout.endsWith("z".repeat(100)));
+  assertEquals(content.stderr, "");
+  assertEquals(content.exitCode, 0);
+});
+
 Deno.test("CfHarnessPromptLoop denies bash output without CFC metadata in enforce mode", async () => {
   const fetchCalls: RequestInit[] = [];
   const loop = new CfHarnessPromptLoop({

--- a/skills/pattern-implement/SKILL.md
+++ b/skills/pattern-implement/SKILL.md
@@ -65,6 +65,19 @@ reactive value into `Writable.of()`. If the pattern receives writable state, use
 that input cell directly; if a draft needs to copy from input state, copy in an
 action or another valid reactive/event context.
 
+For Pattern Factory Build, this rule applies to the top-level pattern input
+object too. Do not initialize local state with `Writable.of(input.name || "")`,
+`Writable.of(input.items || [])`, `Cell.of(input.field)`, or helper calls around
+`input.field`. First decide whether each field is primary pattern state, static
+local UI state, or draft/editing state:
+
+- Primary pattern state: expose it in the `Input`/`Output` contract with
+  `Default<>` and `Writable<>` as needed, then use the reactive input directly.
+- Static local UI state: create it with `Writable.of(...)` from static literals
+  only.
+- Draft/editing state: create it from a static value, then copy from input state
+  inside an `action()` or another valid event/reactive context.
+
 Use `safeDateNow()` and `nonPrivateRandom()` instead of ambient `Date.now()` and
 `Math.random()` when a pattern needs explicit time or randomness. If a control
 is already bound to a cell, usually via `$value` or `$checked`, let that binding


### PR DESCRIPTION
## Summary

- clarify Pattern Factory Build guidance around input state and writable locals
- add cf-harness model-facing bash output truncation for large observed outputs
- cover truncation behavior with prompt-loop tests
- update the pattern implementation skill with the same input-state guidance

## Tests

- `/Users/gideonwald/.deno/bin/deno fmt --check docs/common/ai/pattern-factory-build-guide.md skills/pattern-implement/SKILL.md packages/cf-harness/src/prompt-loop.ts packages/cf-harness/test/prompt-loop.test.ts`
- `/Users/gideonwald/.deno/bin/deno check packages/cf-harness/src/prompt-loop.ts packages/cf-harness/test/prompt-loop.test.ts`
- `/Users/gideonwald/.deno/bin/deno task test` from `packages/cf-harness` (`264 passed`)
- `env PATH=/Users/gideonwald/.deno/bin:$PATH /Users/gideonwald/.deno/bin/deno task check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Pattern Factory Build guidance on input state ownership and writable locals. Adds model-facing `bash` output truncation in `cf-harness` to reduce prompt size while keeping full tool output available.

- **New Features**
  - Truncate model-facing `bash` stdout/stderr to 60k head + 20k tail; add `stdoutTruncated`/`stderrTruncated` and `*OriginalLength`; full streams remain via tool output `outputId`.
  - Applies to mediated outputs and to `bash` without CFC metadata in observe/disabled modes; added prompt-loop tests.

- **Bug Fixes**
  - Fix draft editing example to bind the UI to the draft cell, aligning with the input-state guidance.

<sup>Written for commit 9176ed6da4a5c998a5f6b3b0c0addf6e5d1b87ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

