### PR TITLE
fix(memory): deep-freeze applyPatch return at function boundary

### DIFF
--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -8,6 +8,27 @@ type PatchObject = Record<string, FabricValue>;
 type PatchContainer = PatchObject | FabricValue[];
 const MAX_ARRAY_INDEX = 2 ** 32 - 2;
 
+/**
+ * Applies a sequence of RFC 6902 JSON Patch operations (`replace`, `add`,
+ * `remove`, `move`, `splice`) to a document tree, returning a new document
+ * tree with the patches applied in order. JSON Pointer paths in the ops are
+ * parsed via `parsePointer()` from `./path.ts`.
+ *
+ * Used during document materialization: `engine.ts` walks the stored patch
+ * sequence for a branch and rebuilds the current document by replaying each
+ * patch on top of the previous state (`applyPatchDocument` → `applyPatch`).
+ * The function is therefore on the hot path for any read that reconstructs
+ * a document from its stored patch list.
+ *
+ * Mutation discipline: each `applyOp` call uses `shallowCloneContainer` to
+ * produce a new top-level copy of the container being modified, then
+ * recurses into the path; containers off the modified path remain
+ * frozen-by-reference. The returned tree is then fully deep-frozen at the
+ * function boundary, completing the shallow-clone / mutate / deep-freeze
+ * pattern: shallow clones at the immediate containers on the modified
+ * path, deep-freeze of the assembled result before it leaves the function.
+ * Callers can rely on the return value being deeply frozen.
+ */
 export const applyPatch = (
   state: FabricValue,
   ops: PatchOp[],

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -1,4 +1,5 @@
 import type { FabricValue } from "../interface.ts";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { isInstance, isObject } from "@commonfabric/utils/types";
 import type { PatchOp } from "../v2.ts";
 import { encodePointer, parsePointer } from "./path.ts";
@@ -15,7 +16,7 @@ export const applyPatch = (
   for (const op of ops) {
     current = applyOp(current, op);
   }
-  return current;
+  return deepFreeze(current);
 };
 
 const applyOp = (state: FabricValue, op: PatchOp): FabricValue => {


### PR DESCRIPTION
## Summary

Wraps `applyPatch`'s return in `deepFreeze` so the post-patch
tree is fully-frozen at the function boundary, rather than the
worst-of-both-worlds partial thaw (top-level container unfrozen,
deep children frozen-by-reference) that the existing
`shallowCloneContainer`-only implementation produces. Operationalizes
the inner-narrowness clause at site S1 of the decode-boundary
clone arc: the `shallow-clone / mutate / refreeze` pattern at
`applyPatch` already had shallow-clone and mutate; this adds the
refreeze. Cedar's coder-time verify (memory 99/0, runner 415/0,
no new failures) confirms PR-A is atomic-landable — with the
broad clone at `decodeMemoryBoundary` still in place, this
change is a no-op relative to current behavior, and clears
~114 of the ~119 B1-shape ("Cannot assign to read only
property") test failures named in the decode-boundary-clone-
removal classification once the broad clone is later removed.

## Review

**APPROVE-no-NITs at `146d33031` by `reviewer-flux`.** Lens-8
at-source trace covered: `shallowCloneContainer` unfrozen-top-
level verified at `patch.ts:289-299`; deep-children-frozen-by-
reference under `Object.assign` shallow property-copy;
`deepFreeze` walk path verified at `data-model/deep-freeze.ts`
cache-short-circuit; clause-2 anchor verified at-source; atomic-
landable claim verified via chain-of-reasoning (broad clone
downstream re-thaws, so PR-A is no-op for behavior — see "Perf
cost + handoff" below for the perf-impact correction); ~114-
of-~119 number internally consistent; import path
`@commonfabric/data-model/deep-freeze` resolves via
`packages/data-model/deno.json` exports map. Test coverage
disposition: no new dedicated test required per
`rules/code-process.md` — existing 7 tests at `v2-patch-test.ts`
exercise `applyPatch` and pass under PR-A; the deep-freeze
property is observable downstream once PR-C lands.

## Research input

* `coordination/docs/2026-05-12-decode-boundary-clone-failures.md`
  (`597e77c`) — §3.1 contains the B1-cascade trace identifying
  `applyPatch`'s partial-thaw return as the root cause of the
  ~119-failure cascade visible under the proposed `return
  decoded as Value` change at `decodeMemoryBoundary`.
* `coordination/docs/2026-05-13-decode-clone-mutation-site-
  triage.md` (`847da6e`) — §3.1 contains the S1 (applyPatch)
  per-site verdict: refreeze-at-boundary, with the shallowest-
  clone analysis showing `shallowCloneContainer` is already
  shallow; only the missing refreeze needs to land.
* (Arc context, not PR-A-relevance): the same triage report
  was updated at `f0eb2a4` with a §8.6 S3-correction addendum
  surfacing from Remy's Q1 thin-trace; that's the authoritative
  anchor for PR-B's verdict (delete the legacy short-circuit
  at `query-result-proxy.ts:162-168`), included here as a
  discoverable pointer for readers landing on PR-A first.

## Architectural anchor

Dan's two-clause direction for the decode-boundary clone arc
(load-bearing-quote-locality preserved verbatim):

> **Clause 1 (outer narrowness):** frozen data through the
> system to the extent possible / narrowest-possible place to
> clone-as-mutable then mutate then deep-freeze.

> **Clause 2 (inner narrowness):** the "thaw" part of "thaw -
> mutate - freeze" should also be _narrow_ which is to say a
> _shallow_ clone wherever possible, or more generally the
> _shallowest possible clone in context_.

PR-A is the clause-2 application at site S1: `applyPatch`
already does the shallow-clone (via `shallowCloneContainer`
along the modified path, leaving sub-trees off the modified
path frozen-by-reference) and the mutate, and was missing the
refreeze. The `deepFreeze` walk at the return boundary is
**O(tree size)** today because the broad clone at
`decodeMemoryBoundary` (still on `main` until PR-C lands)
re-thaws the entire decoded tree on every memory-boundary
call, producing an identity-distinct mutable tree that defeats
the entry-point cache short-circuit. See **"Perf cost +
handoff to PR-C"** below for the cost-shape and the
structural resolution.

## Sequencing in the decode-boundary clone arc

This PR is the second of three coordinated changes:

* **PR-B (merged at `1001d7cd4`)** — removed the legacy
  frozen-as-terminal short-circuit at
  `query-result-proxy.ts:162-168` so frozen values flow
  through the proxy's existing shallow-clone-mutate-refreeze
  machinery rather than being returned raw. Cleared the B2
  (visible-`TypeError` array-mutation) prerequisite.
* **PR-A (this PR)** — adds `deepFreeze` at the `applyPatch`
  return boundary. Clears the B1 cascade prerequisite (the
  ~119 "Cannot assign to read only property" failures named
  at `597e77c` §3.1). Behavior is unchanged at runtime today
  because the broad clone at `decodeMemoryBoundary` still
  re-thaws downstream; the B1-cascade only becomes a real
  risk once PR-C removes that broad clone.
* **PR-C (follow-up after this PR merges)** — the change Dan
  originally named in the session-074 kickoff: remove the
  broad clone at `decodeMemoryBoundary` so frozen data flows
  through the system unchanged, plus flip the B3 contract
  self-test direction. Will ship after PR-A merges, using
  the content empirically validated against the combined-
  state perf check on draft PR #3576.

## Perf cost + handoff to PR-C

**Acknowledged, planned, handled by PR-C.** This PR introduces
a unit-test perf degradation, measured empirically via
Phase-1 investigation:

* `cfc-trusted-surfaces`: **+~20%** wall-clock vs pre-PR-A
  baseline (baseline n=20 median 13.5s ±0.9s).
* `core-piece-links`: **+~62%** wall-clock vs pre-PR-A
  baseline (baseline n=16 median 116s ±6.4s).

CI's **Performance Check** on this PR will surface as red;
the regression it flags is the one this section names.

**Mechanism** (corrects an earlier internal claim — the
`deepFreeze` walk's cost-scale was originally projected as
O(path depth), but the empirical trace refuted that): each
`applyPatch` call now does an **O(tree size)** `deepFreeze`
walk at the return boundary. The cost-scale is O(tree size)
rather than O(path depth) because the broad clone at
`decodeMemoryBoundary` — still on `main` until PR-C lands —
produces an identity-distinct mutable tree on every memory-
boundary call, defeating the entry-point cache short-circuit
at `data-model/deep-freeze.ts:130`
(`isNecessarilyOrKnownDeepFrozen`). Every `applyPatch` call
sees a fresh tree and walks the whole thing.

**Structurally resolved by PR-C.** Once the broad clone at
`decodeMemoryBoundary` is removed (PR-C, follow-up after this
PR merges), decoder output retains its deeply-frozen identity
across the memory boundary. The dominant first-order win is a
**count reduction in clone operations**: most decode-boundary
outputs are read by non-mutating consumers (shape-checks,
lookups, transactional reads), and the broad clone was
performing O(tree size) work for all of them, regardless of
whether the consumer actually mutated the result. Removing
the broad clone eliminates that work outright on the
non-mutation path. As a second-order effect on the mutation
path, the `applyPatch` deepFreeze walk sees frozen subtrees
that short-circuit via the entry-point cache — the deep walk
becomes O(path depth) amortized at last, matching the
original internal projection. Empirically validated against
draft PR #3576's combined-state CI run.

**Why this PR is the right shape to ship anyway**: the
sequencing rationale is deliberate. PR-A's deep-freeze
contract is the prerequisite that prevents the B1 cascade
once the broad clone is removed; PR-C is the structural
resolution that eliminates the perf cost. Shipping them in
this order keeps each change reviewable in isolation and
keeps `main` correct (cascade-free) at every step. The perf
cost is real but bounded by the time-to-PR-C, not durable.

## Test impact

Verified at coder-time (per the commit message + Cedar's
brief): `memory` 99 / 0 fail, `runner` 415 / 0 fail, no new
failures across the broader workspace. The atomic-landable
claim is concrete on correctness: this PR is a no-op
relative to current behavior with the broad clone in place,
so it can land independently and the B1-cascade clears only
when PR-C removes the broad clone. On perf, the cost-shape
is as described in **"Perf cost + handoff to PR-C"** above:
acknowledged, transient, structurally resolved by PR-C.

## Test plan

- [x] `deno task test` in `packages/memory` passes (99/0).
- [x] `deno task test` in `packages/runner` passes (415/0).
- [ ] CI green on the PR (pending; review APPROVE-no-NITs by
  `reviewer-flux`).

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: reviewer-flux (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>

## Performance Baseline

This PR _does_ make a number of unit tests measurably run more slowly, though not enough to show up as a performance check failure. That said, the very next planned PR is one enabled by _this_ PR, and will remove much more object churn (the source of slowness here) than this PR adds.

But also, this PR got hit with a spurious perf check failure, per the following override:

NEW_PERF_BASELINE: step: background worker integration = 19s

