### PR TITLE
test: make `modernDataModel` flag reset tests flag-default-agnostic

### DIFF
--- a/packages/data-model/test/fabric-value-dispatch.test.ts
+++ b/packages/data-model/test/fabric-value-dispatch.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   fabricFromNativeValue,
+  getDataModelConfig,
   nativeFromFabricValue,
   resetDataModelConfig,
   setDataModelConfig,
@@ -25,11 +26,12 @@ describe("fabric-value-dispatch", () => {
   });
 
   // --------------------------------------------------------------------------
-  // Default state (flag OFF)
+  // Flag OFF: legacy fabric value conversion
   // --------------------------------------------------------------------------
 
-  describe("default state (flag OFF)", () => {
+  describe("flag OFF: legacy fabric value conversion", () => {
     it("fabricFromNativeValue performs legacy deep conversion", () => {
+      setDataModelConfig(false);
       const value = { hello: "world" } as FabricValue;
       // fabricFromNativeValue returns a new frozen copy for objects.
       const stored = fabricFromNativeValue(value);
@@ -37,11 +39,13 @@ describe("fabric-value-dispatch", () => {
     });
 
     it("nativeFromFabricValue is identity passthrough", () => {
+      setDataModelConfig(false);
       const value = { hello: "world" } as FabricValue;
       expect(nativeFromFabricValue(value)).toBe(value);
     });
 
     it("fabricFromNativeValue converts Error via legacy path", () => {
+      setDataModelConfig(false);
       // `fabricFromNativeValue()` handles Error conversion directly.
       const error = new Error("legacy error");
       const stored = fabricFromNativeValue(error as unknown as FabricValue);
@@ -54,6 +58,7 @@ describe("fabric-value-dispatch", () => {
     });
 
     it("primitives pass through", () => {
+      setDataModelConfig(false);
       expect(fabricFromNativeValue(42 as FabricValue)).toBe(42);
       expect(fabricFromNativeValue("hello" as FabricValue)).toBe("hello");
       expect(fabricFromNativeValue(null)).toBe(null);
@@ -145,51 +150,24 @@ describe("fabric-value-dispatch", () => {
       expect(stored).toBeInstanceOf(FabricError);
     });
 
-    it("resetDataModelConfig() restores legacy conversion", () => {
-      setDataModelConfig(true);
+    it("resetDataModelConfig() restores the default state", () => {
+      const defaultState = getDataModelConfig();
+      setDataModelConfig(!defaultState);
+      expect(getDataModelConfig()).toBe(!defaultState);
       resetDataModelConfig();
-      const error = new Error("reset test");
-      const stored = fabricFromNativeValue(error as unknown as FabricValue);
-      // Back to legacy path: Error becomes @Error object, not FabricError.
-      expect(stored).not.toBeInstanceOf(FabricError);
-      const obj = stored as Record<string, unknown>;
-      expect(obj["@Error"]).toBeDefined();
+      expect(getDataModelConfig()).toBe(defaultState);
     });
 
     it("multiple set/reset cycles work correctly", () => {
-      // Cycle 1: ON — modern conversion
-      setDataModelConfig(true);
-      const error1 = new Error("test1");
-      expect(fabricFromNativeValue(error1 as unknown as FabricValue))
-        .toBeInstanceOf(
-          FabricError,
-        );
-
-      // Cycle 1: OFF — legacy conversion
-      resetDataModelConfig();
-      const error1b = new Error("test1b");
-      const stored1 = fabricFromNativeValue(
-        error1b as unknown as FabricValue,
-      );
-      expect(stored1).not.toBeInstanceOf(FabricError);
-      expect((stored1 as Record<string, unknown>)["@Error"]).toBeDefined();
-
-      // Cycle 2: ON — modern conversion
-      setDataModelConfig(true);
-      const error2 = new Error("test2");
-      expect(fabricFromNativeValue(error2 as unknown as FabricValue))
-        .toBeInstanceOf(
-          FabricError,
-        );
-
-      // Cycle 2: OFF — legacy conversion
-      resetDataModelConfig();
-      const error2b = new Error("test2b");
-      const stored2 = fabricFromNativeValue(
-        error2b as unknown as FabricValue,
-      );
-      expect(stored2).not.toBeInstanceOf(FabricError);
-      expect((stored2 as Record<string, unknown>)["@Error"]).toBeDefined();
+      const defaultState = getDataModelConfig();
+      for (let i = 0; i < 3; i++) {
+        setDataModelConfig(true);
+        expect(getDataModelConfig()).toBe(true);
+        setDataModelConfig(false);
+        expect(getDataModelConfig()).toBe(false);
+        resetDataModelConfig();
+        expect(getDataModelConfig()).toBe(defaultState);
+      }
     });
 
     it("setDataModelConfig(false) after true restores legacy conversion", () => {

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -157,12 +157,12 @@ describe("ExperimentalOptions", () => {
       expect((result as unknown[])[1]).toBe(undefined);
     });
 
-    it("returns to flag-OFF behavior after reset", () => {
-      setDataModelConfig(true);
+    it("reset restores the default behavior", () => {
+      const initial = getDataModelConfig();
+      // Toggle to the opposite of the default, then reset.
+      setDataModelConfig(!initial);
       resetDataModelConfig();
-      const err = new Error("test");
-      const result = shallowFabricFromNativeValue(err);
-      expect(result).toHaveProperty("@Error");
+      expect(getDataModelConfig()).toBe(initial);
     });
   });
 
@@ -232,11 +232,11 @@ describe("ExperimentalOptions", () => {
       expect(2 in result).toBe(true);
     });
 
-    it("returns to flag-OFF behavior after reset", () => {
-      setDataModelConfig(true);
+    it("reset restores the default behavior", () => {
+      const initial = getDataModelConfig();
+      setDataModelConfig(!initial);
       resetDataModelConfig();
-      const result = fabricFromNativeValue({ a: 1, b: undefined });
-      expect(result).toEqual({ a: 1 });
+      expect(getDataModelConfig()).toBe(initial);
     });
 
     it("caches correctly when toJSON() returns undefined (no false cache miss)", () => {
@@ -297,11 +297,11 @@ describe("ExperimentalOptions", () => {
       expect(isFabricValue(sparse)).toBe(true);
     });
 
-    it("returns to flag-OFF behavior after reset", () => {
-      setDataModelConfig(true);
+    it("reset restores the default behavior", () => {
+      const initial = getDataModelConfig();
+      setDataModelConfig(!initial);
       resetDataModelConfig();
-      expect(isFabricValue(new Error("test"))).toBe(false);
-      expect(isFabricValue([undefined])).toBe(false);
+      expect(getDataModelConfig()).toBe(initial);
     });
   });
 
@@ -350,22 +350,23 @@ describe("ExperimentalOptions", () => {
       await sm.close();
     });
 
-    it("disposing Runtime resets global config", async () => {
+    it("disposing Runtime resets global config to the default", async () => {
+      const initial = getDataModelConfig();
       const sm = StorageManager.emulate({ as: signer });
       const runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager: sm,
         experimental: {
-          modernDataModel: true,
+          modernDataModel: !initial,
         },
       });
 
-      expect(getDataModelConfig()).toBe(true);
+      expect(getDataModelConfig()).toBe(!initial);
 
       await runtime.dispose();
       await sm.close();
 
-      expect(getDataModelConfig()).toBe(false);
+      expect(getDataModelConfig()).toBe(initial);
     });
   });
 });


### PR DESCRIPTION
## Summary

Three reset/lifecycle tests for the `modernDataModel` flag asserted the legacy default by name (e.g. *"returns to flag-OFF behavior after reset"*). Restructure them — and the analogous `fabric-value-dispatch` tests in `data-model` — so they capture the current default via `getDataModelConfig()` and assert reset/dispose returns to *whatever the default is*, instead of asserting a hardcoded value.

Prep work for flipping `modernDataModelEnabled` to `true` in a follow-up PR (#3569). Both files now pass with either default state of the flag.

## Test plan
- [x] `packages/data-model` tests pass on `main` (default OFF)
- [x] `packages/data-model` tests pass with `modernDataModelEnabled = true` locally
- [x] `packages/runner/test/experimental-options.test.ts` passes on `main` (default OFF)
- [x] `packages/runner/test/experimental-options.test.ts` passes with `modernDataModelEnabled = true` locally
- [x] Full workspace `deno task test` is green
- [x] Full `packages/runner` `deno task test` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `modernDataModel`-related tests default-agnostic by capturing the current default with `getDataModelConfig()` and asserting reset/dispose restores it. This keeps the suite green whether the flag defaults to ON or OFF and prepares for enabling `modernDataModelEnabled` by default.

- **Refactors**
  - `packages/data-model/test/fabric-value-dispatch.test.ts`: Tests now set the flag explicitly; reset tests capture the default and verify `resetDataModelConfig()` returns to it; simplified multi-cycle checks to config toggles.
  - `packages/runner/test/experimental-options.test.ts`: Replaced “flag-OFF after reset” assertions with default-agnostic checks; `Runtime.dispose()` test captures the default, starts with the opposite, then verifies the default is restored.
  - Both suites pass with either default and are ready for flipping `modernDataModelEnabled` to `true`.

<sup>Written for commit e2c38c019b195587af87c6d4ea9784b96b8badb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Performance baseline

This PR just adjusts tests to work correctly with either default state of the modern data model flag. As such, the following accounts for spurious performance check failures.

NEW_PERF_BASELINE: job: Generated Patterns Integration Tests (3/4) = 80s
NEW_PERF_BASELINE: step: generated patterns integration = 68s
NEW_PERF_BASELINE: job: Generated Patterns Integration Tests = 80s
