### PR TITLE
fix(runner): remove legacy frozen-as-terminal proxy short-circuit

### DIFF
--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -159,14 +159,6 @@ export function createQueryResultProxy<T>(
 
   if (!isRecord(value)) return value;
 
-  // When modernDataModel is OFF, frozen objects are terminal values that
-  // don't need proxy wrapping (the legacy assumption: "frozen = terminal").
-  // When modernDataModel is ON, frozen objects may contain link structures
-  // that need resolution, so we fall through to proxy-wrap them below.
-  if (Object.isFrozen(value) && !runtime.experimental.modernDataModel) {
-    return value as T;
-  }
-
   // When modernDataModel is enabled, stored objects are deep-frozen during
   // storage normalization (fabricFromNativeValueModern). A frozen proxy target
   // would force every property access through the invariant guard (ECMAScript

--- a/packages/runner/test/frozen-proxy-target.test.ts
+++ b/packages/runner/test/frozen-proxy-target.test.ts
@@ -566,3 +566,99 @@ describe("frozen proxy target: committed reads with richStorableValues OFF", () 
     expect(Number(result.b)).toBe(2);
   });
 });
+
+describe("frozen proxy target: wrap fires under modernDataModel=OFF", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({
+      as: signer,
+    });
+    // Construct the runtime under `modernDataModel: true` so the storage
+    // layer produces a deep-frozen committed value, then flip the flag to
+    // `false` post-write to simulate the post-PR-C state where a frozen
+    // value reaches `createQueryResultProxy` while `modernDataModel` is
+    // falsy. Prior to PR-B, this case hit a now-removed short-circuit at
+    // `query-result-proxy.ts:162-168` that returned the raw frozen value
+    // instead of wrapping it -- defeating link resolution and breaking
+    // user-code mutation through the proxy.
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: {
+        modernDataModel: true,
+      },
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("wraps a frozen object input even when modernDataModel is OFF", async () => {
+    const link = writeCell(runtime, tx, "pr-b-wrap-frozen-object", {
+      a: 1,
+      b: 2,
+    });
+
+    tx = await commitAndReopen(runtime, tx);
+
+    // Precondition: the committed read returns a deep-frozen object.
+    const rawValue = tx.readValueOrThrow(link);
+    expect(Object.isFrozen(rawValue)).toBe(true);
+
+    // Simulate the post-PR-C state: frozen value reaches the proxy with
+    // `modernDataModel` falsy.
+    runtime.experimental.modernDataModel = false;
+
+    const proxy = createQueryResultProxy<{ a: number; b: number }>(
+      runtime,
+      tx,
+      link,
+      0,
+      false,
+    );
+
+    // Post-PR-B, the proxy must wrap the frozen value (not return it raw),
+    // so property access goes through the get trap.
+    expect(proxy).not.toBe(rawValue);
+    expect(Number(proxy.a)).toBe(1);
+    expect(Number(proxy.b)).toBe(2);
+  });
+
+  it("wraps a frozen array input even when modernDataModel is OFF", async () => {
+    const link = writeCell(runtime, tx, "pr-b-wrap-frozen-array", [
+      10,
+      20,
+      30,
+    ]);
+
+    tx = await commitAndReopen(runtime, tx);
+
+    const rawValue = tx.readValueOrThrow(link);
+    expect(Object.isFrozen(rawValue)).toBe(true);
+    expect(Array.isArray(rawValue)).toBe(true);
+
+    runtime.experimental.modernDataModel = false;
+
+    const proxy = createQueryResultProxy<number[]>(
+      runtime,
+      tx,
+      link,
+      0,
+      false,
+    );
+
+    // The proxy must wrap so array-method dispatch at `:266-321` can fire
+    // for write-mutation methods. Spot-check via a read-only iterator that
+    // routes through the proxy's get-trap rather than the raw target.
+    expect(proxy).not.toBe(rawValue);
+    expect(Array.isArray(proxy)).toBe(true);
+    expect([...proxy].map(Number)).toEqual([10, 20, 30]);
+  });
+});


### PR DESCRIPTION
## Summary

Deletes the `modernDataModel`-conditional short-circuit at
`createQueryResultProxy` (`packages/runner/src/query-result-
proxy.ts:162-168`) so frozen values flow through the proxy's
existing shallow-clone / mutate / refreeze machinery rather
than being returned raw. The short-circuit encoded a legacy
"frozen = terminal" assumption that was structurally true
under the old modern/legacy split — frozen objects originated
only from legacy storage and were known to be link-free
terminal data — but no longer holds: with `modernDataModel`
graduated, frozen values may now reach the proxy from either
side of the split, carrying link structures that need
resolution + proxy-wrap handling. This change is *subtractive*:
it does not add any new clone-mutate-refreeze machinery; it
stops *bypassing* the existing machinery (the 9-method
`arrayMethods` table at `:77-113`, the get-trap shallow-clone-
mutate-refreeze cycle at `:266-321`, and the unfrozen-stub
trick at the original `:170-192` for ECMAScript proxy-
invariant compliance). A dedicated unit test
(`frozen-proxy-target.test.ts` / "wrap fires under
modernDataModel=OFF") documents the corrected contract
synthetically; the failure cases it guards against only
become naturally reachable once a separate downstream change
(see "Broader arc" below) removes the broad clone at
`decodeMemoryBoundary` that currently re-thaws decoder output
before it reaches the proxy.

## Review

**APPROVE-no-NITs at fix-tip `766dad6f4` (mechanical-rebase
forward-stable to `d2de45241`) by `reviewer-flux`.** Lens-8
at-source trace covered (substantive):

1. 9-method `arrayMethods` table at `:77-113` verified — each
   method present with file:line + ReadWrite/WriteOnly
   variant. This empirically substantiates the foundational
   claim that the proxy already implements the machinery this
   change stops bypassing.
2. Get-trap four-part cycle at `:266-321` verified (read →
   shallow `[...]` / `.map(createProxyForArrayValue)` →
   `method.apply(copy, args)` → `diffAndUpdate`).
3. Unfrozen-stub trick at the new `:162-184` preserved
   byte-identical — the load-bearing ECMAScript 10.5.8
   invariant handler is unchanged.
4. Pure subtractive on code side (-8) + pure additive on
   test side (+96); diff-minimality holds.
5. Upstream control-flow trace: the deleted `if`-block was
   *only* bypassing-shape; `isStreamValue` and `!isRecord`
   are distinct correctness-preserving short-circuits and
   remain.
6. Synthetic-test design verified at-source
   (`modernDataModel: true` write + flag-flip-to-`false`
   post-write exercises the post-broad-clone-removal-
   applicable domain).
7. `modernDataModel: true` test surface unchanged — control-
   flow confirms the removed branch is dead under `true`
   (the `&&` short-circuits before the `Object.isFrozen`
   check).
8. Comment-block disposition (remove-alongside-`if`)
   verified consistent with diff.

## Architectural anchor

Dan's two-clause direction for the broader frozen-data-
through-the-system arc (load-bearing-quote-locality preserved
verbatim):

> **Clause 1 (outer narrowness):** frozen data through the
> system to the extent possible / narrowest-possible place to
> clone-as-mutable then mutate then deep-freeze.

> **Clause 2 (inner narrowness):** the "thaw" part of "thaw -
> mutate - freeze" should also be _narrow_ which is to say a
> _shallow_ clone wherever possible, or more generally the
> _shallowest possible clone in context_.

**This change doesn't add any new clone-mutate-refreeze; it
stops *bypassing* the existing clone-mutate-refreeze
machinery for frozen inputs.** This preempts a natural
reading-confusion: a "thaw-related bug fix" might suggest
adding a thaw, but the proxy's get-trap dispatch at
`:266-321` already does the shallowest-possible thaw (a
per-method shallow `[...]` of the immediate container, not
the deep tree). The job here is to ensure that dispatch path
actually fires for frozen inputs.

## Research input

* `coordination/docs/2026-05-13-decode-clone-mutation-site-
  triage.md` (`847da6e`) — §3.3 contains the *original* site-3
  verdict ("extend the proxy for array methods"), preserved
  for the temporal record of triage error + trace-driven
  correction.
* The same triage report updated at `f0eb2a4` with the **§8.6
  site-3-correction addendum** — the authoritative anchor for
  this change's verdict. The corrected verdict is *delete the
  short-circuit*, not extend the proxy, because a follow-on
  thin-trace surfaced that the proxy already implements the
  required machinery (the 9 array methods are covered at
  `:77-113`; the get-trap cycle at `:266-321` already does
  the shallow-clone-mutate-refreeze). Triage entries §3.3 +
  §6.1 carry forward-pointing correction-bullets to §8.6 so
  the trail of triage-error-then-correction is durable in the
  artifact.
* `coordination/docs/2026-05-12-decode-boundary-clone-
  failures.md` (`597e77c`) — the visible-`TypeError` bucket
  trace named two representative tests
  (`patterns-handlers.test.ts:57-65` "`counter.value +=`" and
  `patterns-regressions.test.ts:154-160` "`notes.push`") that
  will become naturally reachable failures (and start passing
  under this change) once a downstream change removes the
  broad clone at `decodeMemoryBoundary`.

## What's removed

The `if`-block at the original `query-result-proxy.ts:162-168`,
including its 4-line "legacy assumption: frozen = terminal"
preamble comment. The historical rationale ("under the legacy
split, frozen originated only from legacy storage and was
known to be link-free terminal data") now lives durably at
`847da6e` §8.6 (the corrected verdict addendum) plus this
PR's history.

## What's preserved

* The unfrozen-stub trick at the original `:170-192` (now
  starting at the new `:162`) is **unchanged and
  load-bearing**: it constructs an unfrozen empty proxy
  target to satisfy the ECMAScript 10.5.8 proxy-invariant
  for non-configurable / non-writable properties when the
  underlying value is frozen. This is exactly the case the
  removed short-circuit was bypassing.
* The 9-method `arrayMethods` dispatch table at `:77-113`
  (covering `push`, `pop`, `splice`, `shift`, `unshift`,
  `sort`, `reverse`, `fill`, `copyWithin`) is unchanged.
* The get-trap shallow-clone-mutate-refreeze cycle at
  `:266-321` (fresh `readValueOrThrow` → shallow `[...]` →
  `method.apply(copy, args)` → `diffAndUpdate`) is unchanged.

## New test

`packages/runner/test/frozen-proxy-target.test.ts` gains a new
describe block — **"wrap fires under modernDataModel=OFF"** —
with two tests exercising the corrected contract:

* **frozen-object input**: `createQueryResultProxy` returns a
  proxy (not the raw frozen value) for a frozen object.
* **frozen-array input**: same for a frozen array, the more
  load-bearing case for the array-mutation dispatch path.

The setup is **synthetic by necessity** at this stage: the
runtime is constructed under `modernDataModel: true` (which
produces frozen committed reads), then the flag is flipped to
`false` before the proxy call so the post-broad-clone-removal-
applicable domain is exercised. The synthetic shape is
annotated in a `beforeEach` comment so future readers
understand why — today the broad clone at
`decodeMemoryBoundary` re-thaws decoder output before it
reaches the proxy under `modernDataModel=OFF`; a downstream
change removes that clone and the bug becomes naturally
reachable without the flag flip.

Per `rules/code-process.md` test-coverage discipline.

## Why this stands alone

This change is content-independent of the other work in the
broader arc:

* **Current runtime behavior is preserved.** Under
  `modernDataModel=OFF`, the broad clone at
  `decodeMemoryBoundary` currently re-thaws all decoder
  output before it reaches the proxy, so the
  `Object.isFrozen` short-circuit being removed never fires
  on production inputs at the present time. The change is
  dead-code-until-the-broad-clone-removes; merging it now
  pre-positions the corrected contract without changing
  observed behavior.
* **No dependency on other in-flight changes.** The proxy
  machinery this change relies on (the 9-method table, the
  get-trap cycle, the unfrozen-stub trick) all already exist
  on `main`; this is a pure subtraction from the existing
  bypass plus a synthetic-flag-flip test that exercises the
  corrected contract independently of any decoder-path
  state.
* **The corrected-verdict trail (§3.3 → §6.1 → §8.6) is the
  authoritative research-input artifact** and is durable
  regardless of the cadence of other arc work.

## Broader arc

Two related changes are in flight or planned in the same
frozen-data arc:

* A change that deep-freezes `applyPatch`'s return at the
  function boundary in `packages/memory/v2/patch.ts` —
  related but independent of this PR.
* A change that removes the broad clone at
  `decodeMemoryBoundary` in `packages/memory/v2.ts` (the
  change Dan originally named in the kickoff for this arc);
  that change is the one that makes the bug this PR guards
  against naturally reachable. Until then, this PR's
  contract is exercised only via the synthetic-flag-flip
  test.

Each PR in the arc is independently landable on its own
merits per the analysis above. The corrected-verdict trail
in `f0eb2a4` §8.6 + `847da6e` §3.3 / §6.1 documents the
shared architectural anchor.

## Test impact

Verified at coder-time: `memory` 99 / 0 fail, `runner`
416 / 0 fail. The visible-`TypeError` representative tests
at `patterns-handlers.test.ts:57-65` (`counter.value +=`)
and `patterns-regressions.test.ts:154-160` (`notes.push`)
remain in their current passing state at this stage — their
failure mode only becomes reachable after the broad clone at
`decodeMemoryBoundary` is removed in a separate change.

## Test plan

- [x] `deno task test` in `packages/runner` passes (416/0).
- [x] `deno task test` in `packages/memory` passes (99/0).
- [x] `deno fmt` clean across the PR-touched files.
- [ ] CI green on the PR (pending; review APPROVE-no-NITs by
  `reviewer-flux`, forward-stable through mechanical rebase).

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: reviewer-flux (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
