### PR TITLE
fix(runner): propagate modern-data-model global default into runtime view

### DIFF
--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -15,6 +15,7 @@ import type {
 } from "./builder/types.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import {
+  getDataModelConfig,
   resetDataModelConfig,
   setDataModelConfig,
 } from "@commonfabric/data-model/fabric-value";
@@ -307,8 +308,14 @@ export class Runtime {
       );
     }
 
-    // Propagate experimental flags to their ambient control points.
+    // Propagate experimental flags to their ambient control points, then
+    // read back the effective state so `experimental.modernDataModel` reflects
+    // what is actually in effect (matters when the caller didn't pass an
+    // explicit value — without this, consumers like `createQueryResultProxy`
+    // see `undefined` and treat the runtime as legacy even when the global
+    // default is modern).
     setDataModelConfig(this.experimental.modernDataModel);
+    this.experimental.modernDataModel = getDataModelConfig();
 
     this.id = options.storageManager.id;
     this.apiUrl = new URL(options.apiUrl);


### PR DESCRIPTION
## Summary

A `Runtime` constructed without an explicit `experimental.modernDataModel`
value left `this.experimental.modernDataModel` as `undefined`. Downstream,
`createQueryResultProxy` reads `!runtime.experimental.modernDataModel`
to decide whether to wrap a frozen value in a proxy or short-circuit
and return the stored object directly (the legacy "frozen = terminal"
assumption). Under the modern global flag the storage layer deep-freezes
everything regardless of the per-runtime field, so the short-circuit
fired for runtimes that had simply *inherited* the modern global without
opting in explicitly — and handlers ended up with the raw stored
representation instead of an array/object proxy.

The piece test `default-pattern-persistence.test.ts` showed this most
clearly: `context.allPieces` came through as the literal legacy alias
object `{ "$alias": { path: [...], cell: {...} } }` instead of an array
proxy, and `allPieces.push` resolved to `undefined` (→ `TypeError:
allPieces.push is not a function`).

Fix: after `setDataModelConfig(...)`, read the effective value back
via `getDataModelConfig()` and store it on `this.experimental.modernDataModel`,
so the proxy machinery (and any future consumer of the runtime view)
sees the same flag value the storage layer is honouring. Tests that
set the flag explicitly are unchanged — the read-back returns the value
that was just set.

This is a no-op on `main` (where the global default is `false`,
`!undefined` and `!false` behave identically for the only consumer)
and unblocks the piece handler test on the flag-flip branch (PR #3569).
It also fixes 50+ other failures of the same root cause that were
showing up under modern; six pre-existing failures remain and are
genuine bugs left for follow-up.

## Test plan
- [x] `packages/piece` `deno task test` passes on `main` (default OFF)
- [x] `packages/piece` `deno task test` passes with `modernDataModelEnabled = true` locally
- [x] `packages/runner` `deno task test` passes on `main` (415 passed)
- [x] `packages/runner` `deno task test` under `modernDataModelEnabled = true`: 409 passed, 6 failed (down from 57 before this fix; remaining failures are unrelated real bugs)
- [x] Full workspace `deno task test` is green
- [x] Swept the codebase for similar runtime-view-vs-global-state inconsistencies (`runtime.experimental.modernDataModel` is the only consumer that compared against undefined; `richStorableValues` is unread outside the constructor; `schedulerHistoricalMightWrite` uses `=== true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates the modern data model global default into the runtime view so proxy logic uses the correct flag. Fixes cases where handlers got raw stored objects instead of array/object proxies when the runtime didn’t set the flag explicitly.

- **Bug Fixes**
  - After calling `setDataModelConfig`, read back the effective value with `getDataModelConfig` and store it in `runtime.experimental.modernDataModel`.
  - Prevents the legacy short-circuit in `createQueryResultProxy` when modern is the global default; e.g., `context.allPieces` is now an array proxy.
  - No behavior change on `main` when the global default is false.

<sup>Written for commit 5b020b90ee27c940c36e2125bfa53ff2f950941a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

