### PR TITLE
fix(memory): remove decodeMemoryBoundary broad clone + flip B3 contract test

### DIFF
--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
-import { assert, assertEquals, assertFalse } from "@std/assert";
+import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
 import {
   resetDataModelConfig,
   setDataModelConfig,
@@ -132,7 +132,7 @@ describe("memory v2 boundary decode", () => {
     resetDataModelConfig();
   });
 
-  it("returns mutable plain JSON trees", () => {
+  it("returns deeply-frozen plain JSON trees", () => {
     const decoded = decodeMemoryBoundary<{
       value: {
         nested: {
@@ -156,11 +156,13 @@ describe("memory v2 boundary decode", () => {
         },
       },
     });
-    assertFalse(Object.isFrozen(decoded));
-    assertFalse(Object.isFrozen(decoded.value));
-    assertFalse(Object.isFrozen(decoded.value.nested));
+    assert(Object.isFrozen(decoded));
+    assert(Object.isFrozen(decoded.value));
+    assert(Object.isFrozen(decoded.value.nested));
 
-    decoded.value.nested.count = 2;
-    assertEquals(decoded.value.nested.count, 2);
+    assertThrows(() => {
+      decoded.value.nested.count = 2;
+    }, TypeError);
+    assertEquals(decoded.value.nested.count, 1);
   });
 });

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1,7 +1,4 @@
-import {
-  cloneIfNecessary,
-  getDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
+import { getDataModelConfig } from "@commonfabric/data-model/fabric-value";
 import {
   jsonFromValue,
   valueFromJson,
@@ -371,13 +368,7 @@ export const decodeMemoryBoundary = <Value = FabricValue>(
     memoryReconstructionContext,
   ) as FabricValue;
 
-  // TODO(danfuzz): It shouldn't be necessary to thaw values coming out of the
-  // JSON decoder. See what happens when this gets replaced with just
-  // `return value`.
-  return cloneIfNecessary(
-    decoded,
-    { frozen: false, deep: true, force: true },
-  ) as Value;
+  return decoded as Value;
 };
 
 export const toDocumentPath = (path: readonly string[]): DocumentPath =>


### PR DESCRIPTION
## Summary

Removes the broad clone at `decodeMemoryBoundary`
(`packages/memory/v2.ts:374-380`) so frozen data flows
through the memory boundary unchanged, closing the
decode-boundary clone arc Dan kicked off the session with.
Also flips the B3 contract self-test
(`packages/memory/test/v2-test.ts:135-165`) from "the
decoder output is *not* frozen" to "the decoder output *is*
deeply-frozen," matching the corrected contract. The
TODO-comment Dan originally added at the broad-clone site
(which kicked off this session's investigation) is removed
alongside the body it annotated — premise-comment-removed-
with-conditional discriminator; historical rationale lives
durably in the commit message + `847da6e` §6.1.

Operationalizes the **outer-narrowness clause** of Dan's
architectural direction: with PR-A's deepFreeze at
`applyPatch`'s return boundary (merged) + PR-B's legacy
proxy short-circuit removal (merged) both in place, the
broad clone here was the last remaining unjustified thaw on
the read path. Decoder output is now deeply-frozen and
stays frozen through the system unless a downstream site
explicitly opts into a narrow clone-mutate-refreeze cycle.

**This PR is the third and final of three coordinated
landings, closing the decode-boundary clone arc**: PR-B
(merged at `1001d7cd4`) → PR-A (merged at `e496c9c44`) →
this PR.

## Empirical perf validation

This PR's content was validated against the combined-state
draft (this same PR while it was in draft form), which ran
the post-merge-of-main combined state under CI's
Performance Check. The hypothesis under test — that
removing the broad clone here would eliminate the perf
regression PR-A's Performance Check surfaced — held
empirically. **The Performance Check on this PR
(post-rebase on PR-A-merged `main`) is expected to go
green**, closing out PR-A's acknowledged-and-planned
perf-handoff. PR-A's body explicitly named this PR as the
forward-resolution of that handoff; this PR is that
resolution.

**Mechanism — count-reduction primary.** The dominant
first-order win is a **count reduction in clone
operations**: the broad clone here was firing on **every**
memory-boundary read, performing O(tree size)
mutable-clone work regardless of whether the consumer
actually mutated the result. Most decode-boundary outputs
are read by non-mutating consumers (shape-checks, lookups,
transactional reads); for those the clone was wasted work.
Removing the broad clone eliminates that work outright on
the non-mutation path.

As a second-order effect on the mutation path, the
`applyPatch` deepFreeze walk (from PR-A) now sees frozen
sub-trees that short-circuit via the `deepFrozenCache`
entry-point check at
`packages/data-model/deep-freeze.ts:130`
(`isNecessarilyOrKnownDeepFrozen`). The deep walk becomes
O(path depth) amortized — matching the original internal
projection that PR-A's perf-handoff section corrected as
O(tree size) under the pre-PR-C workload.

## Review

(To be filled in once `reviewer-flux` re-anchors at the
post-rebase tip `ca156d691`. Mechanical-rebase case-1
applies — content-unchanged-against-new-base — so Flux's
verdict at the pre-rebase tip is forward-stable in shape;
the re-anchor is a confirmation rather than a fresh trace.)

## Research input

* `coordination/docs/2026-05-12-decode-boundary-clone-
  failures.md` (`597e77c`) — §3.1 contains the B1 cascade
  classification, identifying `applyPatch`'s partial-thaw
  return as the root cause that PR-A's deepFreeze prevents;
  §3.2 contains the B2 (visible-`TypeError`) bucket that
  PR-B's short-circuit removal cleared. With both
  prerequisites merged, this PR removes the broad clone
  without re-introducing either bucket.
* `coordination/docs/2026-05-13-decode-clone-mutation-site-
  triage.md` (`847da6e`) — §6.1 contains the PR-C per-site
  verdict: remove the broad clone + flip the B3 contract
  self-test. The same triage report at `f0eb2a4` adds §8.6
  with Remy's Q1 thin-trace correction surface for PR-B
  (delete-not-extend the proxy short-circuit), which
  retroactively confirmed PR-B's prerequisite shape.
* Remy's Phase-1 perf-investigation finding — established
  empirically that PR-A's `deepFreeze(applyPatch)` call was
  the proximate cause of the +~20% `cfc-trusted-surfaces`
  and +~62% `core-piece-links` regressions, *under the
  pre-PR-C workload where the broad clone still fired
  per-call*. The fix-shape is structural: remove the
  upstream per-call work that defeats the cache.

## Architectural anchor

Dan's two-clause direction for the decode-boundary clone
arc (load-bearing-quote-locality preserved verbatim, n=3
of 3 PRs in the arc carrying both clauses verbatim):

> **Clause 1 (outer narrowness):** frozen data through the
> system to the extent possible / narrowest-possible place
> to clone-as-mutable then mutate then deep-freeze.

> **Clause 2 (inner narrowness):** the "thaw" part of "thaw
> - mutate - freeze" should also be _narrow_ which is to
> say a _shallow_ clone wherever possible, or more
> generally the _shallowest possible clone in context_.

PR-C is the **clause-1 application** at the system level:
removing the broad clone here lets decoder output retain
its frozen-by-default identity all the way through the
memory boundary into downstream callers. The system-level
invariant "frozen data through the system to the extent
possible" is now actually satisfied; the narrow clone-
mutate-refreeze cycles at `applyPatch` (PR-A, inner-
narrowness clause-2 at site S1) and the proxy's get-trap
machinery (PR-B's prerequisite via the unfrozen-stub trick)
are the only thaw sites that remain, each exactly where a
downstream consumer needs mutability.

## Sequencing in the decode-boundary clone arc

This PR is the third and final of three coordinated
changes:

* **PR-B (merged at `1001d7cd4`)** — removed the legacy
  frozen-as-terminal short-circuit at
  `query-result-proxy.ts:162-168`. Cleared the B2
  prerequisite.
* **PR-A (merged at `e496c9c44`)** — added `deepFreeze` at
  the `applyPatch` return boundary. Cleared the B1
  prerequisite. Acknowledged a perf cost (O(tree size)
  under the pre-PR-C workload), explicitly handed off
  resolution to PR-C.
* **PR-C (this PR)** — removes the broad clone at
  `decodeMemoryBoundary` + flips the B3 contract self-test
  direction. Closes the arc with the change Dan originally
  named in the session-074 kickoff.

## Perf-handoff completion

PR-A's body explicitly acknowledged the perf cost as
"acknowledged, planned, handled by PR-C." This PR is that
PR-C. The Performance Check that surfaced red on PR-A
(and that PR-A's body warned reviewers to expect) is
expected to **go green** on this PR — empirically
validated on the combined-state draft CI run before
rebase. The CI badge on this PR and the perf-handoff
narrative in PR-A's body should reconcile cleanly: red
there → green here, closing the loop.

## Test impact

Verified at coder-time on the combined state (and again
post-rebase):

* `packages/memory` `deno task test`: **99 passed / 0
  failed.** Flipped B3 contract test ("returns deeply-
  frozen plain JSON trees" + `assertThrows(...TypeError)`
  on mutation attempt) passes under the new contract.
* `packages/runner` `deno task test`: **416 passed / 2385
  steps / 0 failed / 0 ignored** — identical to PR-B-on-
  main baseline. Full B1/B2 cascade clearance under the
  combined state (zero "Cannot assign to read only
  property" failures, zero array-mutation TypeErrors).

The cascade-clearance prediction from `597e77c` §3.1 +
`847da6e` §6.1 held precisely.

## Test plan

- [x] `deno task test` in `packages/memory` passes (99/0).
- [x] `deno task test` in `packages/runner` passes (416/0).
- [x] `deno fmt --check` clean on both modified files.
- [ ] CI green on the PR post-rebase (Performance Check
  expected green, closing PR-A's perf-handoff).
- [ ] Review APPROVE-no-NITs by `reviewer-flux` at the
  post-rebase tip.

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: reviewer-flux (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
Co-Authored-By: upstream-liaison-bolt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
